### PR TITLE
chore(release): 11.19.0

### DIFF
--- a/.changeset/changelogs/@pnpm!assert-project@1100.0.24.md
+++ b/.changeset/changelogs/@pnpm!assert-project@1100.0.24.md
@@ -1,0 +1,9 @@
+## 1100.0.24
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/assert-store@1100.0.24
+  - @pnpm/installing.modules-yaml@1100.0.14
+  - @pnpm/lockfile.types@1100.0.18
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!assert-store@1100.0.24.md
+++ b/.changeset/changelogs/@pnpm!assert-store@1100.0.24.md
@@ -1,0 +1,6 @@
+## 1100.0.24
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/store.cafs@1100.1.17

--- a/.changeset/changelogs/@pnpm!auth.commands@1100.3.0.md
+++ b/.changeset/changelogs/@pnpm!auth.commands@1100.3.0.md
@@ -1,0 +1,14 @@
+## 1100.3.0
+
+### Minor Changes
+
+- `pnpm login` no longer requires an interactive terminal when the registry supports web-based login: without a TTY it prints the authentication URL (skipping the QR code and the "Press ENTER to open the URL in your browser" prompt) and polls the registry until the browser approval completes. Only the classic username/password login still fails with `ERR_PNPM_LOGIN_NON_INTERACTIVE` in a non-interactive terminal.
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/cli.utils@1101.0.21
+  - @pnpm/config.reader@1101.15.1
+  - @pnpm/network.fetch@1100.1.10
+  - @pnpm/network.web-auth@1101.4.0
+  - @pnpm/registry-access.client@1100.1.12

--- a/.changeset/changelogs/@pnpm!bins.linker@1100.0.24.md
+++ b/.changeset/changelogs/@pnpm!bins.linker@1100.0.24.md
@@ -1,0 +1,10 @@
+## 1100.0.24
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/bins.resolver@1100.0.13
+  - @pnpm/pkg-manifest.reader@1100.0.14
+  - @pnpm/pkg-manifest.utils@1100.3.0
+  - @pnpm/types@1101.8.0
+  - @pnpm/workspace.project-manifest-reader@1100.0.22

--- a/.changeset/changelogs/@pnpm!bins.remover@1100.0.18.md
+++ b/.changeset/changelogs/@pnpm!bins.remover@1100.0.18.md
@@ -1,0 +1,9 @@
+## 1100.0.18
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/bins.resolver@1100.0.13
+  - @pnpm/core-loggers@1100.3.1
+  - @pnpm/pkg-manifest.reader@1100.0.14
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!bins.resolver@1100.0.13.md
+++ b/.changeset/changelogs/@pnpm!bins.resolver@1100.0.13.md
@@ -1,0 +1,6 @@
+## 1100.0.13
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!building.after-install@1102.0.14.md
+++ b/.changeset/changelogs/@pnpm!building.after-install@1102.0.14.md
@@ -1,0 +1,24 @@
+## 1102.0.14
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/bins.linker@1100.0.24
+  - @pnpm/building.pkg-requires-build@1100.0.13
+  - @pnpm/building.policy@1100.0.17
+  - @pnpm/config.normalize-registries@1100.0.13
+  - @pnpm/config.reader@1101.15.1
+  - @pnpm/core-loggers@1100.3.1
+  - @pnpm/deps.graph-hasher@1100.2.14
+  - @pnpm/deps.path@1100.0.13
+  - @pnpm/exec.lifecycle@1100.1.10
+  - @pnpm/installing.context@1100.0.30
+  - @pnpm/installing.modules-yaml@1100.0.14
+  - @pnpm/lockfile.types@1100.0.18
+  - @pnpm/lockfile.utils@1100.1.7
+  - @pnpm/lockfile.walker@1100.0.18
+  - @pnpm/pkg-manifest.reader@1100.0.14
+  - @pnpm/store.cafs@1100.1.17
+  - @pnpm/store.connection-manager@1100.3.14
+  - @pnpm/store.controller-types@1101.0.0
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!building.commands@1100.1.19.md
+++ b/.changeset/changelogs/@pnpm!building.commands@1100.1.19.md
@@ -1,0 +1,16 @@
+## 1100.1.19
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/building.after-install@1102.0.14
+  - @pnpm/building.policy@1100.0.17
+  - @pnpm/cli.utils@1101.0.21
+  - @pnpm/config.reader@1101.15.1
+  - @pnpm/config.writer@1100.0.20
+  - @pnpm/deps.path@1100.0.13
+  - @pnpm/installing.commands@1100.12.2
+  - @pnpm/installing.modules-yaml@1100.0.14
+  - @pnpm/store.connection-manager@1100.3.14
+  - @pnpm/types@1101.8.0
+  - @pnpm/workspace.projects-sorter@1100.0.13

--- a/.changeset/changelogs/@pnpm!building.during-install@1102.0.13.md
+++ b/.changeset/changelogs/@pnpm!building.during-install@1102.0.13.md
@@ -1,0 +1,14 @@
+## 1102.0.13
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/bins.linker@1100.0.24
+  - @pnpm/config.reader@1101.15.1
+  - @pnpm/core-loggers@1100.3.1
+  - @pnpm/deps.graph-hasher@1100.2.14
+  - @pnpm/deps.path@1100.0.13
+  - @pnpm/exec.lifecycle@1100.1.10
+  - @pnpm/pkg-manifest.reader@1100.0.14
+  - @pnpm/store.controller-types@1101.0.0
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!building.pkg-requires-build@1100.0.13.md
+++ b/.changeset/changelogs/@pnpm!building.pkg-requires-build@1100.0.13.md
@@ -1,0 +1,6 @@
+## 1100.0.13
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!building.policy@1100.0.17.md
+++ b/.changeset/changelogs/@pnpm!building.policy@1100.0.17.md
@@ -1,0 +1,17 @@
+## 1100.0.17
+
+### Patch Changes
+
+- `allowBuilds` entries can now approve git-hosted packages that pnpm downloads as a tarball, such as `github:` dependencies (which are fetched from `codeload.github.com` rather than cloned), by their repository URL without the resolved commit hash. This matches the hashless `git+` matching already supported for cloned git dependencies. For example:
+
+  ```yaml
+  allowBuilds:
+    "foo@git+https://github.com/org/foo.git": true
+  ```
+
+  This approves the package whether pnpm clones it or downloads a tarball, so the entry no longer has to be updated every time the pinned commit changes. GitLab and Bitbucket tarball downloads are matched the same way. Approving or denying a specific resolved commit by its full tarball dep path continues to work.
+
+- Updated dependencies:
+  - @pnpm/config.version-policy@1100.1.11
+  - @pnpm/deps.path@1100.0.13
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!cache.api@1100.0.35.md
+++ b/.changeset/changelogs/@pnpm!cache.api@1100.0.35.md
@@ -1,0 +1,8 @@
+## 1100.0.35
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/config.reader@1101.15.1
+  - @pnpm/resolving.npm-resolver@1103.0.0
+  - @pnpm/store.cafs@1100.1.17

--- a/.changeset/changelogs/@pnpm!cache.commands@1100.0.36.md
+++ b/.changeset/changelogs/@pnpm!cache.commands@1100.0.36.md
@@ -1,0 +1,8 @@
+## 1100.0.36
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/cache.api@1100.0.35
+  - @pnpm/cli.utils@1101.0.21
+  - @pnpm/config.reader@1101.15.1

--- a/.changeset/changelogs/@pnpm!cli.commands@1100.0.34.md
+++ b/.changeset/changelogs/@pnpm!cli.commands@1100.0.34.md
@@ -1,0 +1,6 @@
+## 1100.0.34
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/config.reader@1101.15.1

--- a/.changeset/changelogs/@pnpm!cli.default-reporter@1100.3.14.md
+++ b/.changeset/changelogs/@pnpm!cli.default-reporter@1100.3.14.md
@@ -1,0 +1,11 @@
+## 1100.3.14
+
+### Patch Changes
+
+- The default reporter no longer depends on `@pnpm/config.reader` at runtime: it declares its own minimal `ReporterPnpmConfig` type for the config fields it reads. Hosts that embed the reporter no longer pull in the config-reader dependency tree.
+
+- Updated dependencies:
+  - @pnpm/cli.meta@1100.0.13
+  - @pnpm/core-loggers@1100.3.1
+  - @pnpm/deps.inspection.peers-issues-renderer@1100.0.11
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!cli.meta@1100.0.13.md
+++ b/.changeset/changelogs/@pnpm!cli.meta@1100.0.13.md
@@ -1,0 +1,6 @@
+## 1100.0.13
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!cli.utils@1101.0.21.md
+++ b/.changeset/changelogs/@pnpm!cli.utils@1101.0.21.md
@@ -1,0 +1,10 @@
+## 1101.0.21
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/cli.meta@1100.0.13
+  - @pnpm/config.package-is-installable@1100.1.1
+  - @pnpm/pkg-manifest.utils@1100.3.0
+  - @pnpm/types@1101.8.0
+  - @pnpm/workspace.project-manifest-reader@1100.0.22

--- a/.changeset/changelogs/@pnpm!config.commands@1100.0.35.md
+++ b/.changeset/changelogs/@pnpm!config.commands@1100.0.35.md
@@ -1,0 +1,8 @@
+## 1100.0.35
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/cli.utils@1101.0.21
+  - @pnpm/config.reader@1101.15.1
+  - @pnpm/workspace.workspace-manifest-writer@1100.0.20

--- a/.changeset/changelogs/@pnpm!config.normalize-registries@1100.0.13.md
+++ b/.changeset/changelogs/@pnpm!config.normalize-registries@1100.0.13.md
@@ -1,0 +1,6 @@
+## 1100.0.13
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!config.package-is-installable@1100.1.1.md
+++ b/.changeset/changelogs/@pnpm!config.package-is-installable@1100.1.1.md
@@ -1,0 +1,9 @@
+## 1100.1.1
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/cli.meta@1100.0.13
+  - @pnpm/core-loggers@1100.3.1
+  - @pnpm/engine.runtime.system-version@1100.0.8
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!config.pick-registry-for-package@1100.0.14.md
+++ b/.changeset/changelogs/@pnpm!config.pick-registry-for-package@1100.0.14.md
@@ -1,0 +1,6 @@
+## 1100.0.14
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!config.reader@1101.15.1.md
+++ b/.changeset/changelogs/@pnpm!config.reader@1101.15.1.md
@@ -1,0 +1,10 @@
+## 1101.15.1
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/hooks.pnpmfile@1100.0.24
+  - @pnpm/pkg-manifest.utils@1100.3.0
+  - @pnpm/types@1101.8.0
+  - @pnpm/workspace.project-manifest-reader@1100.0.22
+  - @pnpm/workspace.workspace-manifest-reader@1100.1.4

--- a/.changeset/changelogs/@pnpm!config.version-policy@1100.1.11.md
+++ b/.changeset/changelogs/@pnpm!config.version-policy@1100.1.11.md
@@ -1,0 +1,6 @@
+## 1100.1.11
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!config.writer@1100.0.20.md
+++ b/.changeset/changelogs/@pnpm!config.writer@1100.0.20.md
@@ -1,0 +1,7 @@
+## 1100.0.20
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/types@1101.8.0
+  - @pnpm/workspace.workspace-manifest-writer@1100.0.20

--- a/.changeset/changelogs/@pnpm!core-loggers@1100.3.1.md
+++ b/.changeset/changelogs/@pnpm!core-loggers@1100.3.1.md
@@ -1,0 +1,6 @@
+## 1100.3.1
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!deps.compliance.audit@1101.0.28.md
+++ b/.changeset/changelogs/@pnpm!deps.compliance.audit@1101.0.28.md
@@ -1,0 +1,13 @@
+## 1101.0.28
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/deps.path@1100.0.13
+  - @pnpm/lockfile.detect-dep-types@1100.0.18
+  - @pnpm/lockfile.fs@1100.1.16
+  - @pnpm/lockfile.types@1100.0.18
+  - @pnpm/lockfile.utils@1100.1.7
+  - @pnpm/lockfile.walker@1100.0.18
+  - @pnpm/network.fetch@1100.1.10
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!deps.compliance.commands@1101.5.12.md
+++ b/.changeset/changelogs/@pnpm!deps.compliance.commands@1101.5.12.md
@@ -1,0 +1,23 @@
+## 1101.5.12
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/cli.meta@1100.0.13
+  - @pnpm/cli.utils@1101.0.21
+  - @pnpm/config.pick-registry-for-package@1100.0.14
+  - @pnpm/config.reader@1101.15.1
+  - @pnpm/config.version-policy@1100.1.11
+  - @pnpm/config.writer@1100.0.20
+  - @pnpm/deps.compliance.audit@1101.0.28
+  - @pnpm/deps.compliance.license-scanner@1100.0.32
+  - @pnpm/deps.compliance.sbom@1100.3.10
+  - @pnpm/deps.security.signatures@1101.2.9
+  - @pnpm/installing.commands@1100.12.2
+  - @pnpm/lockfile.fs@1100.1.16
+  - @pnpm/lockfile.types@1100.0.18
+  - @pnpm/lockfile.utils@1100.1.7
+  - @pnpm/lockfile.walker@1100.0.18
+  - @pnpm/network.auth-header@1101.1.8
+  - @pnpm/types@1101.8.0
+  - @pnpm/workspace.project-manifest-reader@1100.0.22

--- a/.changeset/changelogs/@pnpm!deps.compliance.license-scanner@1100.0.32.md
+++ b/.changeset/changelogs/@pnpm!deps.compliance.license-scanner@1100.0.32.md
@@ -1,0 +1,15 @@
+## 1100.0.32
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/config.package-is-installable@1100.1.1
+  - @pnpm/deps.path@1100.0.13
+  - @pnpm/lockfile.detect-dep-types@1100.0.18
+  - @pnpm/lockfile.fs@1100.1.16
+  - @pnpm/lockfile.types@1100.0.18
+  - @pnpm/lockfile.utils@1100.1.7
+  - @pnpm/lockfile.walker@1100.0.18
+  - @pnpm/pkg-manifest.reader@1100.0.14
+  - @pnpm/store.pkg-finder@1100.0.27
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!deps.compliance.sbom@1100.3.10.md
+++ b/.changeset/changelogs/@pnpm!deps.compliance.sbom@1100.3.10.md
@@ -1,0 +1,13 @@
+## 1100.3.10
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/lockfile.detect-dep-types@1100.0.18
+  - @pnpm/lockfile.types@1100.0.18
+  - @pnpm/lockfile.utils@1100.1.7
+  - @pnpm/lockfile.walker@1100.0.18
+  - @pnpm/pkg-manifest.reader@1100.0.14
+  - @pnpm/resolving.resolver-base@1101.0.0
+  - @pnpm/store.pkg-finder@1100.0.27
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!deps.github-actions@1100.1.2.md
+++ b/.changeset/changelogs/@pnpm!deps.github-actions@1100.1.2.md
@@ -1,0 +1,6 @@
+## 1100.1.2
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/resolving.git-resolver@1100.1.14

--- a/.changeset/changelogs/@pnpm!deps.graph-builder@1100.1.1.md
+++ b/.changeset/changelogs/@pnpm!deps.graph-builder@1100.1.1.md
@@ -1,0 +1,17 @@
+## 1100.1.1
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/config.package-is-installable@1100.1.1
+  - @pnpm/core-loggers@1100.3.1
+  - @pnpm/deps.graph-hasher@1100.2.14
+  - @pnpm/deps.path@1100.0.13
+  - @pnpm/fs.symlink-dependency@1100.0.16
+  - @pnpm/hooks.types@1100.2.5
+  - @pnpm/installing.modules-yaml@1100.0.14
+  - @pnpm/lockfile.fs@1100.1.16
+  - @pnpm/lockfile.utils@1100.1.7
+  - @pnpm/patching.config@1100.0.14
+  - @pnpm/store.controller-types@1101.0.0
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!deps.graph-hasher@1100.2.14.md
+++ b/.changeset/changelogs/@pnpm!deps.graph-hasher@1100.2.14.md
@@ -1,0 +1,11 @@
+## 1100.2.14
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/deps.path@1100.0.13
+  - @pnpm/engine.runtime.system-version@1100.0.8
+  - @pnpm/lockfile.types@1100.0.18
+  - @pnpm/lockfile.utils@1100.1.7
+  - @pnpm/resolving.resolver-base@1101.0.0
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!deps.inspection.commands@1100.7.2.md
+++ b/.changeset/changelogs/@pnpm!deps.inspection.commands@1100.7.2.md
@@ -1,0 +1,24 @@
+## 1100.7.2
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/cli.utils@1101.0.21
+  - @pnpm/config.pick-registry-for-package@1100.0.14
+  - @pnpm/config.reader@1101.15.1
+  - @pnpm/deps.github-actions@1100.1.2
+  - @pnpm/deps.inspection.list@1100.0.31
+  - @pnpm/deps.inspection.outdated@1100.1.22
+  - @pnpm/deps.inspection.peers-checker@1100.0.25
+  - @pnpm/deps.inspection.peers-issues-renderer@1100.0.11
+  - @pnpm/global.commands@1100.0.42
+  - @pnpm/global.packages@1100.0.15
+  - @pnpm/installing.modules-yaml@1100.0.14
+  - @pnpm/lockfile.fs@1100.1.16
+  - @pnpm/network.auth-header@1101.1.8
+  - @pnpm/network.fetch@1100.1.10
+  - @pnpm/resolving.default-resolver@1100.3.22
+  - @pnpm/resolving.npm-resolver@1103.0.0
+  - @pnpm/resolving.registry.types@1100.1.8
+  - @pnpm/types@1101.8.0
+  - @pnpm/workspace.project-manifest-reader@1100.0.22

--- a/.changeset/changelogs/@pnpm!deps.inspection.list@1100.0.31.md
+++ b/.changeset/changelogs/@pnpm!deps.inspection.list@1100.0.31.md
@@ -1,0 +1,10 @@
+## 1100.0.31
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/deps.inspection.tree-builder@1100.0.26
+  - @pnpm/lockfile.fs@1100.1.16
+  - @pnpm/pkg-manifest.reader@1100.0.14
+  - @pnpm/types@1101.8.0
+  - @pnpm/workspace.project-manifest-reader@1100.0.22

--- a/.changeset/changelogs/@pnpm!deps.inspection.outdated@1100.1.22.md
+++ b/.changeset/changelogs/@pnpm!deps.inspection.outdated@1100.1.22.md
@@ -1,0 +1,14 @@
+## 1100.1.22
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/config.version-policy@1100.1.11
+  - @pnpm/deps.path@1100.0.13
+  - @pnpm/hooks.read-package-hook@1100.2.1
+  - @pnpm/installing.client@1100.3.1
+  - @pnpm/lockfile.fs@1100.1.16
+  - @pnpm/lockfile.utils@1100.1.7
+  - @pnpm/pkg-manifest.utils@1100.3.0
+  - @pnpm/resolving.npm-resolver@1103.0.0
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!deps.inspection.peers-checker@1100.0.25.md
+++ b/.changeset/changelogs/@pnpm!deps.inspection.peers-checker@1100.0.25.md
@@ -1,0 +1,9 @@
+## 1100.0.25
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/deps.path@1100.0.13
+  - @pnpm/lockfile.fs@1100.1.16
+  - @pnpm/lockfile.walker@1100.0.18
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!deps.inspection.peers-issues-renderer@1100.0.11.md
+++ b/.changeset/changelogs/@pnpm!deps.inspection.peers-issues-renderer@1100.0.11.md
@@ -1,0 +1,6 @@
+## 1100.0.11
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!deps.inspection.tree-builder@1100.0.26.md
+++ b/.changeset/changelogs/@pnpm!deps.inspection.tree-builder@1100.0.26.md
@@ -1,0 +1,14 @@
+## 1100.0.26
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/config.normalize-registries@1100.0.13
+  - @pnpm/deps.path@1100.0.13
+  - @pnpm/installing.modules-yaml@1100.0.14
+  - @pnpm/lockfile.detect-dep-types@1100.0.18
+  - @pnpm/lockfile.fs@1100.1.16
+  - @pnpm/lockfile.utils@1100.1.7
+  - @pnpm/pkg-manifest.reader@1100.0.14
+  - @pnpm/store.cafs@1100.1.17
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!deps.path@1100.0.13.md
+++ b/.changeset/changelogs/@pnpm!deps.path@1100.0.13.md
@@ -1,0 +1,6 @@
+## 1100.0.13
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!deps.security.signatures@1101.2.9.md
+++ b/.changeset/changelogs/@pnpm!deps.security.signatures@1101.2.9.md
@@ -1,0 +1,6 @@
+## 1101.2.9
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/network.fetch@1100.1.10

--- a/.changeset/changelogs/@pnpm!deps.status@1100.1.14.md
+++ b/.changeset/changelogs/@pnpm!deps.status@1100.1.14.md
@@ -1,0 +1,15 @@
+## 1100.1.14
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/config.reader@1101.15.1
+  - @pnpm/installing.context@1100.0.30
+  - @pnpm/lockfile.fs@1100.1.16
+  - @pnpm/lockfile.settings-checker@1100.1.9
+  - @pnpm/lockfile.verification@1100.0.30
+  - @pnpm/resolving.resolver-base@1101.0.0
+  - @pnpm/types@1101.8.0
+  - @pnpm/workspace.projects-reader@1101.0.21
+  - @pnpm/workspace.state@1100.0.35
+  - @pnpm/workspace.workspace-manifest-reader@1100.1.4

--- a/.changeset/changelogs/@pnpm!engine.pm.commands@1101.3.1.md
+++ b/.changeset/changelogs/@pnpm!engine.pm.commands@1101.3.1.md
@@ -1,0 +1,32 @@
+## 1101.3.1
+
+### Patch Changes
+
+- `pnpm update` keeps the explicit `=` operator of an exact version pin: a dependency saved as `=3.5.1` now updates to `=3.5.2` instead of the bare `3.5.2`. See pnpm/pnpm#13168.
+
+- Renamed the `PinnedVersion` type to `RangeSpecStyle` and the `pinnedVersion` option fields to `rangeSpecStyle`: the value selects the operator a specifier is saved with, not a pin. `whichVersionIsPinned` is now `inferRangeSpecStyle`, and the new `rangeSpecGranularity` helper collapses the `exact` spelling to its `patch` range width. `@pnpm/types` keeps `PinnedVersion` as a deprecated alias of `RangeSpecStyle`. The rename itself changes no CLI behavior; the `=`-pin handling is described in its own changesets.
+
+- Updated dependencies:
+  - @pnpm/bins.linker@1100.0.24
+  - @pnpm/building.policy@1100.0.17
+  - @pnpm/cli.meta@1100.0.13
+  - @pnpm/cli.utils@1101.0.21
+  - @pnpm/config.pick-registry-for-package@1100.0.14
+  - @pnpm/config.reader@1101.15.1
+  - @pnpm/config.version-policy@1100.1.11
+  - @pnpm/deps.graph-hasher@1100.2.14
+  - @pnpm/deps.security.signatures@1101.2.9
+  - @pnpm/global.commands@1100.0.42
+  - @pnpm/global.packages@1100.0.15
+  - @pnpm/installing.client@1100.3.1
+  - @pnpm/installing.deps-restorer@1102.2.1
+  - @pnpm/installing.env-installer@1102.0.14
+  - @pnpm/lockfile.fs@1100.1.16
+  - @pnpm/lockfile.types@1100.0.18
+  - @pnpm/network.auth-header@1101.1.8
+  - @pnpm/pkg-manifest.utils@1100.3.0
+  - @pnpm/resolving.npm-resolver@1103.0.0
+  - @pnpm/store.connection-manager@1100.3.14
+  - @pnpm/store.controller@1102.0.10
+  - @pnpm/types@1101.8.0
+  - @pnpm/workspace.project-manifest-reader@1100.0.22

--- a/.changeset/changelogs/@pnpm!engine.runtime.bun-resolver@1102.0.13.md
+++ b/.changeset/changelogs/@pnpm!engine.runtime.bun-resolver@1102.0.13.md
@@ -1,0 +1,10 @@
+## 1102.0.13
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/fetching.binary-fetcher@1102.0.8
+  - @pnpm/fetching.fetcher-base@1100.2.6
+  - @pnpm/resolving.npm-resolver@1103.0.0
+  - @pnpm/resolving.resolver-base@1101.0.0
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!engine.runtime.commands@1100.1.18.md
+++ b/.changeset/changelogs/@pnpm!engine.runtime.commands@1100.1.18.md
@@ -1,0 +1,10 @@
+## 1100.1.18
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/cli.utils@1101.0.21
+  - @pnpm/config.reader@1101.15.1
+  - @pnpm/engine.runtime.node-resolver@1101.1.20
+  - @pnpm/network.fetch@1100.1.10
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!engine.runtime.deno-resolver@1102.0.13.md
+++ b/.changeset/changelogs/@pnpm!engine.runtime.deno-resolver@1102.0.13.md
@@ -1,0 +1,10 @@
+## 1102.0.13
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/fetching.binary-fetcher@1102.0.8
+  - @pnpm/fetching.fetcher-base@1100.2.6
+  - @pnpm/resolving.npm-resolver@1103.0.0
+  - @pnpm/resolving.resolver-base@1101.0.0
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!engine.runtime.node-resolver@1101.1.20.md
+++ b/.changeset/changelogs/@pnpm!engine.runtime.node-resolver@1101.1.20.md
@@ -1,0 +1,8 @@
+## 1101.1.20
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/config.reader@1101.15.1
+  - @pnpm/resolving.resolver-base@1101.0.0
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!engine.runtime.system-version@1100.0.8.md
+++ b/.changeset/changelogs/@pnpm!engine.runtime.system-version@1100.0.8.md
@@ -1,0 +1,7 @@
+## 1100.0.8
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/cli.meta@1100.0.13
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!exec.commands@1100.4.6.md
+++ b/.changeset/changelogs/@pnpm!exec.commands@1100.4.6.md
@@ -1,0 +1,21 @@
+## 1100.4.6
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/bins.resolver@1100.0.13
+  - @pnpm/building.commands@1100.1.19
+  - @pnpm/cli.utils@1101.0.21
+  - @pnpm/config.reader@1101.15.1
+  - @pnpm/config.version-policy@1100.1.11
+  - @pnpm/core-loggers@1100.3.1
+  - @pnpm/deps.status@1100.1.14
+  - @pnpm/engine.runtime.commands@1100.1.18
+  - @pnpm/exec.lifecycle@1100.1.10
+  - @pnpm/installing.client@1100.3.1
+  - @pnpm/installing.commands@1100.12.2
+  - @pnpm/pkg-manifest.reader@1100.0.14
+  - @pnpm/types@1101.8.0
+  - @pnpm/workspace.injected-deps-syncer@1100.0.30
+  - @pnpm/workspace.project-manifest-reader@1100.0.22
+  - @pnpm/workspace.projects-sorter@1100.0.13

--- a/.changeset/changelogs/@pnpm!exec.lifecycle@1100.1.10.md
+++ b/.changeset/changelogs/@pnpm!exec.lifecycle@1100.1.10.md
@@ -1,0 +1,11 @@
+## 1100.1.10
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/bins.linker@1100.0.24
+  - @pnpm/core-loggers@1100.3.1
+  - @pnpm/fetching.directory-fetcher@1100.0.27
+  - @pnpm/pkg-manifest.reader@1100.0.14
+  - @pnpm/store.controller-types@1101.0.0
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!exec.prepare-package@1100.0.29.md
+++ b/.changeset/changelogs/@pnpm!exec.prepare-package@1100.0.29.md
@@ -1,0 +1,8 @@
+## 1100.0.29
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/exec.lifecycle@1100.1.10
+  - @pnpm/pkg-manifest.reader@1100.0.14
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!fetching.binary-fetcher@1102.0.8.md
+++ b/.changeset/changelogs/@pnpm!fetching.binary-fetcher@1102.0.8.md
@@ -1,0 +1,6 @@
+## 1102.0.8
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/fetching.fetcher-base@1100.2.6

--- a/.changeset/changelogs/@pnpm!fetching.directory-fetcher@1100.0.27.md
+++ b/.changeset/changelogs/@pnpm!fetching.directory-fetcher@1100.0.27.md
@@ -1,0 +1,10 @@
+## 1100.0.27
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/building.pkg-requires-build@1100.0.13
+  - @pnpm/fetching.fetcher-base@1100.2.6
+  - @pnpm/resolving.resolver-base@1101.0.0
+  - @pnpm/types@1101.8.0
+  - @pnpm/workspace.project-manifest-reader@1100.0.22

--- a/.changeset/changelogs/@pnpm!fetching.fetcher-base@1100.2.6.md
+++ b/.changeset/changelogs/@pnpm!fetching.fetcher-base@1100.2.6.md
@@ -1,0 +1,7 @@
+## 1100.2.6
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/resolving.resolver-base@1101.0.0
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!fetching.git-fetcher@1102.0.11.md
+++ b/.changeset/changelogs/@pnpm!fetching.git-fetcher@1102.0.11.md
@@ -1,0 +1,8 @@
+## 1102.0.11
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/exec.prepare-package@1100.0.29
+  - @pnpm/fetching.fetcher-base@1100.2.6
+  - @pnpm/resolving.git-resolver@1100.1.14

--- a/.changeset/changelogs/@pnpm!fetching.pick-fetcher@1100.1.5.md
+++ b/.changeset/changelogs/@pnpm!fetching.pick-fetcher@1100.1.5.md
@@ -1,0 +1,8 @@
+## 1100.1.5
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/fetching.fetcher-base@1100.2.6
+  - @pnpm/hooks.types@1100.2.5
+  - @pnpm/resolving.resolver-base@1101.0.0

--- a/.changeset/changelogs/@pnpm!fetching.tarball-fetcher@1102.0.11.md
+++ b/.changeset/changelogs/@pnpm!fetching.tarball-fetcher@1102.0.11.md
@@ -1,0 +1,9 @@
+## 1102.0.11
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/core-loggers@1100.3.1
+  - @pnpm/exec.prepare-package@1100.0.29
+  - @pnpm/fetching.fetcher-base@1100.2.6
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!fs.indexed-pkg-importer@1100.0.23.md
+++ b/.changeset/changelogs/@pnpm!fs.indexed-pkg-importer@1100.0.23.md
@@ -1,0 +1,7 @@
+## 1100.0.23
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/core-loggers@1100.3.1
+  - @pnpm/store.controller-types@1101.0.0

--- a/.changeset/changelogs/@pnpm!fs.symlink-dependency@1100.0.16.md
+++ b/.changeset/changelogs/@pnpm!fs.symlink-dependency@1100.0.16.md
@@ -1,0 +1,7 @@
+## 1100.0.16
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/core-loggers@1100.3.1
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!get-release-text@1100.0.4.md
+++ b/.changeset/changelogs/@pnpm!get-release-text@1100.0.4.md
@@ -3,4 +3,4 @@
 ### Patch Changes
 
 - Updated dependencies:
-  - @pnpm/releasing.versioning@1100.2.2
+  - @pnpm/releasing.versioning@1100.2.3

--- a/.changeset/changelogs/@pnpm!global.commands@1100.0.42.md
+++ b/.changeset/changelogs/@pnpm!global.commands@1100.0.42.md
@@ -1,0 +1,22 @@
+## 1100.0.42
+
+### Patch Changes
+
+- Renamed the `PinnedVersion` type to `RangeSpecStyle` and the `pinnedVersion` option fields to `rangeSpecStyle`: the value selects the operator a specifier is saved with, not a pin. `whichVersionIsPinned` is now `inferRangeSpecStyle`, and the new `rangeSpecGranularity` helper collapses the `exact` spelling to its `patch` range width. `@pnpm/types` keeps `PinnedVersion` as a deprecated alias of `RangeSpecStyle`. The rename itself changes no CLI behavior; the `=`-pin handling is described in its own changesets.
+
+- The `save-prefix` setting now accepts `=`: newly added dependencies are saved with an explicit `=` operator (`=1.2.3`) instead of the setting being silently treated as the default `^`.
+
+- Updated dependencies:
+  - @pnpm/bins.linker@1100.0.24
+  - @pnpm/bins.remover@1100.0.18
+  - @pnpm/bins.resolver@1100.0.13
+  - @pnpm/cli.utils@1101.0.21
+  - @pnpm/config.reader@1101.15.1
+  - @pnpm/core-loggers@1100.3.1
+  - @pnpm/deps.inspection.list@1100.0.31
+  - @pnpm/global.packages@1100.0.15
+  - @pnpm/installing.deps-installer@1103.0.0
+  - @pnpm/pkg-manifest.reader@1100.0.14
+  - @pnpm/pkg-manifest.utils@1100.3.0
+  - @pnpm/store.connection-manager@1100.3.14
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!global.packages@1100.0.15.md
+++ b/.changeset/changelogs/@pnpm!global.packages@1100.0.15.md
@@ -1,0 +1,8 @@
+## 1100.0.15
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/bins.resolver@1100.0.13
+  - @pnpm/pkg-manifest.reader@1100.0.14
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!hooks.pnpmfile@1100.0.24.md
+++ b/.changeset/changelogs/@pnpm!hooks.pnpmfile@1100.0.24.md
@@ -1,0 +1,10 @@
+## 1100.0.24
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/core-loggers@1100.3.1
+  - @pnpm/hooks.types@1100.2.5
+  - @pnpm/lockfile.types@1100.0.18
+  - @pnpm/store.controller-types@1101.0.0
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!hooks.read-package-hook@1100.2.1.md
+++ b/.changeset/changelogs/@pnpm!hooks.read-package-hook@1100.2.1.md
@@ -1,0 +1,6 @@
+## 1100.2.1
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!hooks.types@1100.2.5.md
+++ b/.changeset/changelogs/@pnpm!hooks.types@1100.2.5.md
@@ -1,0 +1,9 @@
+## 1100.2.5
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/fetching.fetcher-base@1100.2.6
+  - @pnpm/lockfile.types@1100.0.18
+  - @pnpm/resolving.resolver-base@1101.0.0
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!installing.client@1100.3.1.md
+++ b/.changeset/changelogs/@pnpm!installing.client@1100.3.1.md
@@ -1,0 +1,17 @@
+## 1100.3.1
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/engine.runtime.node-resolver@1101.1.20
+  - @pnpm/fetching.binary-fetcher@1102.0.8
+  - @pnpm/fetching.directory-fetcher@1100.0.27
+  - @pnpm/fetching.git-fetcher@1102.0.11
+  - @pnpm/fetching.tarball-fetcher@1102.0.11
+  - @pnpm/hooks.types@1100.2.5
+  - @pnpm/network.auth-header@1101.1.8
+  - @pnpm/network.fetch@1100.1.10
+  - @pnpm/resolving.default-resolver@1100.3.22
+  - @pnpm/resolving.npm-resolver@1103.0.0
+  - @pnpm/resolving.resolver-base@1101.0.0
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!installing.commands@1100.12.2.md
+++ b/.changeset/changelogs/@pnpm!installing.commands@1100.12.2.md
@@ -1,0 +1,48 @@
+## 1100.12.2
+
+### Patch Changes
+
+- Renamed the `PinnedVersion` type to `RangeSpecStyle` and the `pinnedVersion` option fields to `rangeSpecStyle`: the value selects the operator a specifier is saved with, not a pin. `whichVersionIsPinned` is now `inferRangeSpecStyle`, and the new `rangeSpecGranularity` helper collapses the `exact` spelling to its `patch` range width. `@pnpm/types` keeps `PinnedVersion` as a deprecated alias of `RangeSpecStyle`. The rename itself changes no CLI behavior; the `=`-pin handling is described in its own changesets.
+
+- The `save-prefix` setting now accepts `=`: newly added dependencies are saved with an explicit `=` operator (`=1.2.3`) instead of the setting being silently treated as the default `^`.
+
+- Updated dependencies:
+  - @pnpm/building.after-install@1102.0.14
+  - @pnpm/building.policy@1100.0.17
+  - @pnpm/cli.utils@1101.0.21
+  - @pnpm/config.pick-registry-for-package@1100.0.14
+  - @pnpm/config.reader@1101.15.1
+  - @pnpm/config.version-policy@1100.1.11
+  - @pnpm/config.writer@1100.0.20
+  - @pnpm/core-loggers@1100.3.1
+  - @pnpm/deps.github-actions@1100.1.2
+  - @pnpm/deps.inspection.outdated@1100.1.22
+  - @pnpm/deps.path@1100.0.13
+  - @pnpm/deps.security.signatures@1101.2.9
+  - @pnpm/deps.status@1100.1.14
+  - @pnpm/global.commands@1100.0.42
+  - @pnpm/hooks.pnpmfile@1100.0.24
+  - @pnpm/installing.context@1100.0.30
+  - @pnpm/installing.dedupe.check@1100.1.7
+  - @pnpm/installing.deps-installer@1103.0.0
+  - @pnpm/installing.env-installer@1102.0.14
+  - @pnpm/lockfile.fs@1100.1.16
+  - @pnpm/lockfile.types@1100.0.18
+  - @pnpm/network.auth-header@1101.1.8
+  - @pnpm/network.fetch@1100.1.10
+  - @pnpm/pkg-manifest.reader@1100.0.14
+  - @pnpm/pkg-manifest.utils@1100.3.0
+  - @pnpm/resolving.npm-resolver@1103.0.0
+  - @pnpm/resolving.resolver-base@1101.0.0
+  - @pnpm/store.connection-manager@1100.3.14
+  - @pnpm/store.controller@1102.0.10
+  - @pnpm/types@1101.8.0
+  - @pnpm/workspace.project-manifest-reader@1100.0.22
+  - @pnpm/workspace.project-manifest-writer@1100.0.13
+  - @pnpm/workspace.projects-filter@1100.0.34
+  - @pnpm/workspace.projects-graph@1100.0.30
+  - @pnpm/workspace.projects-reader@1101.0.21
+  - @pnpm/workspace.projects-sorter@1100.0.13
+  - @pnpm/workspace.state@1100.0.35
+  - @pnpm/workspace.workspace-manifest-reader@1100.1.4
+  - @pnpm/workspace.workspace-manifest-writer@1100.0.20

--- a/.changeset/changelogs/@pnpm!installing.context@1100.0.30.md
+++ b/.changeset/changelogs/@pnpm!installing.context@1100.0.30.md
@@ -1,0 +1,12 @@
+## 1100.0.30
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/core-loggers@1100.3.1
+  - @pnpm/installing.modules-yaml@1100.0.14
+  - @pnpm/installing.read-projects-context@1100.0.26
+  - @pnpm/lockfile.fs@1100.1.16
+  - @pnpm/resolving.resolver-base@1101.0.0
+  - @pnpm/store.controller@1102.0.10
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!installing.dedupe.check@1100.1.7.md
+++ b/.changeset/changelogs/@pnpm!installing.dedupe.check@1100.1.7.md
@@ -1,0 +1,7 @@
+## 1100.1.7
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/lockfile.types@1100.0.18
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!installing.deps-installer@1103.0.0.md
+++ b/.changeset/changelogs/@pnpm!installing.deps-installer@1103.0.0.md
@@ -1,0 +1,48 @@
+## 1103.0.0
+
+### Major Changes
+
+- Renamed the `PinnedVersion` type to `RangeSpecStyle` and the `pinnedVersion` option fields to `rangeSpecStyle`: the value selects the operator a specifier is saved with, not a pin. `whichVersionIsPinned` is now `inferRangeSpecStyle`, and the new `rangeSpecGranularity` helper collapses the `exact` spelling to its `patch` range width. `@pnpm/types` keeps `PinnedVersion` as a deprecated alias of `RangeSpecStyle`. The rename itself changes no CLI behavior; the `=`-pin handling is described in its own changesets.
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/bins.linker@1100.0.24
+  - @pnpm/bins.remover@1100.0.18
+  - @pnpm/building.after-install@1102.0.14
+  - @pnpm/building.during-install@1102.0.13
+  - @pnpm/building.policy@1100.0.17
+  - @pnpm/config.normalize-registries@1100.0.13
+  - @pnpm/config.version-policy@1100.1.11
+  - @pnpm/core-loggers@1100.3.1
+  - @pnpm/deps.graph-hasher@1100.2.14
+  - @pnpm/deps.path@1100.0.13
+  - @pnpm/exec.lifecycle@1100.1.10
+  - @pnpm/fs.symlink-dependency@1100.0.16
+  - @pnpm/hooks.read-package-hook@1100.2.1
+  - @pnpm/hooks.types@1100.2.5
+  - @pnpm/installing.context@1100.0.30
+  - @pnpm/installing.deps-resolver@1101.0.0
+  - @pnpm/installing.deps-restorer@1102.2.1
+  - @pnpm/installing.linking.direct-dep-linker@1100.0.16
+  - @pnpm/installing.linking.hoist@1100.0.24
+  - @pnpm/installing.linking.modules-cleaner@1100.1.17
+  - @pnpm/installing.modules-yaml@1100.0.14
+  - @pnpm/installing.package-requester@1102.1.8
+  - @pnpm/lockfile.filtering@1100.2.1
+  - @pnpm/lockfile.fs@1100.1.16
+  - @pnpm/lockfile.preferred-versions@1100.0.27
+  - @pnpm/lockfile.pruner@1100.0.18
+  - @pnpm/lockfile.settings-checker@1100.1.9
+  - @pnpm/lockfile.to-pnp@1100.1.11
+  - @pnpm/lockfile.utils@1100.1.7
+  - @pnpm/lockfile.verification@1100.0.30
+  - @pnpm/lockfile.walker@1100.0.18
+  - @pnpm/network.auth-header@1101.1.8
+  - @pnpm/patching.config@1100.0.14
+  - @pnpm/pkg-manifest.utils@1100.3.0
+  - @pnpm/pnpr.client@1.3.9
+  - @pnpm/resolving.resolver-base@1101.0.0
+  - @pnpm/store.controller-types@1101.0.0
+  - @pnpm/types@1101.8.0
+  - @pnpm/workspace.project-manifest-reader@1100.0.22

--- a/.changeset/changelogs/@pnpm!installing.deps-resolver@1101.0.0.md
+++ b/.changeset/changelogs/@pnpm!installing.deps-resolver@1101.0.0.md
@@ -1,0 +1,31 @@
+## 1101.0.0
+
+### Major Changes
+
+- Renamed the `PinnedVersion` type to `RangeSpecStyle` and the `pinnedVersion` option fields to `rangeSpecStyle`: the value selects the operator a specifier is saved with, not a pin. `whichVersionIsPinned` is now `inferRangeSpecStyle`, and the new `rangeSpecGranularity` helper collapses the `exact` spelling to its `patch` range width. `@pnpm/types` keeps `PinnedVersion` as a deprecated alias of `RangeSpecStyle`. The rename itself changes no CLI behavior; the `=`-pin handling is described in its own changesets.
+
+### Patch Changes
+
+- Fixed empty `bundledDependencies` and `bundleDependencies` arrays causing nondeterministic lockfile changes. See pnpm/pnpm#13123.
+
+- Preserve a workspace dependency's `link:` entry when a run does not target it — e.g. `pnpm update <other-pkg>` (with or without `--recursive`), or a plain install after a root/catalog dependency change — with `injectWorkspacePackages`, instead of spuriously rewriting it to a peer-suffixed `file:` protocol. See pnpm/pnpm#10433.
+
+- Updated dependencies:
+  - @pnpm/config.version-policy@1100.1.11
+  - @pnpm/core-loggers@1100.3.1
+  - @pnpm/deps.graph-hasher@1100.2.14
+  - @pnpm/deps.path@1100.0.13
+  - @pnpm/fetching.pick-fetcher@1100.1.5
+  - @pnpm/fs.symlink-dependency@1100.0.16
+  - @pnpm/hooks.types@1100.2.5
+  - @pnpm/lockfile.preferred-versions@1100.0.27
+  - @pnpm/lockfile.pruner@1100.0.18
+  - @pnpm/lockfile.types@1100.0.18
+  - @pnpm/lockfile.utils@1100.1.7
+  - @pnpm/patching.config@1100.0.14
+  - @pnpm/pkg-manifest.reader@1100.0.14
+  - @pnpm/pkg-manifest.utils@1100.3.0
+  - @pnpm/resolving.npm-resolver@1103.0.0
+  - @pnpm/resolving.resolver-base@1101.0.0
+  - @pnpm/store.controller-types@1101.0.0
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!installing.deps-restorer@1102.2.1.md
+++ b/.changeset/changelogs/@pnpm!installing.deps-restorer@1102.2.1.md
@@ -1,0 +1,30 @@
+## 1102.2.1
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/bins.linker@1100.0.24
+  - @pnpm/building.during-install@1102.0.13
+  - @pnpm/building.policy@1100.0.17
+  - @pnpm/config.package-is-installable@1100.1.1
+  - @pnpm/core-loggers@1100.3.1
+  - @pnpm/deps.graph-builder@1100.1.1
+  - @pnpm/deps.graph-hasher@1100.2.14
+  - @pnpm/deps.path@1100.0.13
+  - @pnpm/exec.lifecycle@1100.1.10
+  - @pnpm/fs.symlink-dependency@1100.0.16
+  - @pnpm/installing.linking.direct-dep-linker@1100.0.16
+  - @pnpm/installing.linking.hoist@1100.0.24
+  - @pnpm/installing.linking.modules-cleaner@1100.1.17
+  - @pnpm/installing.linking.real-hoist@1100.1.11
+  - @pnpm/installing.modules-yaml@1100.0.14
+  - @pnpm/installing.package-requester@1102.1.8
+  - @pnpm/lockfile.filtering@1100.2.1
+  - @pnpm/lockfile.fs@1100.1.16
+  - @pnpm/lockfile.to-pnp@1100.1.11
+  - @pnpm/lockfile.utils@1100.1.7
+  - @pnpm/patching.config@1100.0.14
+  - @pnpm/pkg-manifest.reader@1100.0.14
+  - @pnpm/store.controller-types@1101.0.0
+  - @pnpm/types@1101.8.0
+  - @pnpm/workspace.project-manifest-reader@1100.0.22

--- a/.changeset/changelogs/@pnpm!installing.env-installer@1102.0.14.md
+++ b/.changeset/changelogs/@pnpm!installing.env-installer@1102.0.14.md
@@ -1,0 +1,23 @@
+## 1102.0.14
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/config.package-is-installable@1100.1.1
+  - @pnpm/config.pick-registry-for-package@1100.0.14
+  - @pnpm/config.writer@1100.0.20
+  - @pnpm/core-loggers@1100.3.1
+  - @pnpm/deps.graph-hasher@1100.2.14
+  - @pnpm/fs.symlink-dependency@1100.0.16
+  - @pnpm/installing.deps-resolver@1101.0.0
+  - @pnpm/lockfile.fs@1100.1.16
+  - @pnpm/lockfile.pruner@1100.0.18
+  - @pnpm/lockfile.types@1100.0.18
+  - @pnpm/lockfile.utils@1100.1.7
+  - @pnpm/network.auth-header@1101.1.8
+  - @pnpm/network.fetch@1100.1.10
+  - @pnpm/pkg-manifest.reader@1100.0.14
+  - @pnpm/resolving.npm-resolver@1103.0.0
+  - @pnpm/store.controller@1102.0.10
+  - @pnpm/store.controller-types@1101.0.0
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!installing.linking.direct-dep-linker@1100.0.16.md
+++ b/.changeset/changelogs/@pnpm!installing.linking.direct-dep-linker@1100.0.16.md
@@ -1,0 +1,7 @@
+## 1100.0.16
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/core-loggers@1100.3.1
+  - @pnpm/fs.symlink-dependency@1100.0.16

--- a/.changeset/changelogs/@pnpm!installing.linking.hoist@1100.0.24.md
+++ b/.changeset/changelogs/@pnpm!installing.linking.hoist@1100.0.24.md
@@ -1,0 +1,8 @@
+## 1100.0.24
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/bins.linker@1100.0.24
+  - @pnpm/core-loggers@1100.3.1
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!installing.linking.modules-cleaner@1100.1.17.md
+++ b/.changeset/changelogs/@pnpm!installing.linking.modules-cleaner@1100.1.17.md
@@ -1,0 +1,13 @@
+## 1100.1.17
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/bins.remover@1100.0.18
+  - @pnpm/core-loggers@1100.3.1
+  - @pnpm/deps.path@1100.0.13
+  - @pnpm/lockfile.filtering@1100.2.1
+  - @pnpm/lockfile.types@1100.0.18
+  - @pnpm/lockfile.utils@1100.1.7
+  - @pnpm/store.controller-types@1101.0.0
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!installing.linking.real-hoist@1100.1.11.md
+++ b/.changeset/changelogs/@pnpm!installing.linking.real-hoist@1100.1.11.md
@@ -1,0 +1,7 @@
+## 1100.1.11
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/deps.path@1100.0.13
+  - @pnpm/lockfile.utils@1100.1.7

--- a/.changeset/changelogs/@pnpm!installing.modules-yaml@1100.0.14.md
+++ b/.changeset/changelogs/@pnpm!installing.modules-yaml@1100.0.14.md
@@ -1,0 +1,6 @@
+## 1100.0.14
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!installing.package-requester@1102.1.8.md
+++ b/.changeset/changelogs/@pnpm!installing.package-requester@1102.1.8.md
@@ -1,0 +1,15 @@
+## 1102.1.8
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/config.package-is-installable@1100.1.1
+  - @pnpm/core-loggers@1100.3.1
+  - @pnpm/deps.path@1100.0.13
+  - @pnpm/fetching.fetcher-base@1100.2.6
+  - @pnpm/fetching.pick-fetcher@1100.1.5
+  - @pnpm/hooks.types@1100.2.5
+  - @pnpm/resolving.resolver-base@1101.0.0
+  - @pnpm/store.cafs@1100.1.17
+  - @pnpm/store.controller-types@1101.0.0
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!installing.read-projects-context@1100.0.26.md
+++ b/.changeset/changelogs/@pnpm!installing.read-projects-context@1100.0.26.md
@@ -1,0 +1,9 @@
+## 1100.0.26
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/config.normalize-registries@1100.0.13
+  - @pnpm/installing.modules-yaml@1100.0.14
+  - @pnpm/lockfile.fs@1100.1.16
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!jest-config@1100.0.22.md
+++ b/.changeset/changelogs/@pnpm!jest-config@1100.0.22.md
@@ -3,4 +3,4 @@
 ### Patch Changes
 
 - Updated dependencies:
-  - @pnpm/worker@1100.2.8
+  - @pnpm/worker@1100.2.9

--- a/.changeset/changelogs/@pnpm!lockfile.detect-dep-types@1100.0.18.md
+++ b/.changeset/changelogs/@pnpm!lockfile.detect-dep-types@1100.0.18.md
@@ -1,0 +1,8 @@
+## 1100.0.18
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/deps.path@1100.0.13
+  - @pnpm/lockfile.types@1100.0.18
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!lockfile.filtering@1100.2.1.md
+++ b/.changeset/changelogs/@pnpm!lockfile.filtering@1100.2.1.md
@@ -1,0 +1,11 @@
+## 1100.2.1
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/config.package-is-installable@1100.1.1
+  - @pnpm/deps.path@1100.0.13
+  - @pnpm/lockfile.types@1100.0.18
+  - @pnpm/lockfile.utils@1100.1.7
+  - @pnpm/lockfile.walker@1100.0.18
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!lockfile.fs@1100.1.16.md
+++ b/.changeset/changelogs/@pnpm!lockfile.fs@1100.1.16.md
@@ -1,0 +1,10 @@
+## 1100.1.16
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/deps.path@1100.0.13
+  - @pnpm/lockfile.merger@1100.0.18
+  - @pnpm/lockfile.types@1100.0.18
+  - @pnpm/lockfile.utils@1100.1.7
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!lockfile.make-dedicated-lockfile@1100.0.32.md
+++ b/.changeset/changelogs/@pnpm!lockfile.make-dedicated-lockfile@1100.0.32.md
@@ -1,0 +1,10 @@
+## 1100.0.32
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/lockfile.fs@1100.1.16
+  - @pnpm/lockfile.pruner@1100.0.18
+  - @pnpm/releasing.exportable-manifest@1100.2.1
+  - @pnpm/types@1101.8.0
+  - @pnpm/workspace.project-manifest-reader@1100.0.22

--- a/.changeset/changelogs/@pnpm!lockfile.merger@1100.0.18.md
+++ b/.changeset/changelogs/@pnpm!lockfile.merger@1100.0.18.md
@@ -1,0 +1,7 @@
+## 1100.0.18
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/lockfile.types@1100.0.18
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!lockfile.preferred-versions@1100.0.27.md
+++ b/.changeset/changelogs/@pnpm!lockfile.preferred-versions@1100.0.27.md
@@ -1,0 +1,9 @@
+## 1100.0.27
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/lockfile.utils@1100.1.7
+  - @pnpm/pkg-manifest.utils@1100.3.0
+  - @pnpm/resolving.resolver-base@1101.0.0
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!lockfile.pruner@1100.0.18.md
+++ b/.changeset/changelogs/@pnpm!lockfile.pruner@1100.0.18.md
@@ -1,0 +1,8 @@
+## 1100.0.18
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/deps.path@1100.0.13
+  - @pnpm/lockfile.types@1100.0.18
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!lockfile.settings-checker@1100.1.9.md
+++ b/.changeset/changelogs/@pnpm!lockfile.settings-checker@1100.1.9.md
@@ -1,0 +1,7 @@
+## 1100.1.9
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/lockfile.types@1100.0.18
+  - @pnpm/lockfile.verification@1100.0.30

--- a/.changeset/changelogs/@pnpm!lockfile.to-pnp@1100.1.11.md
+++ b/.changeset/changelogs/@pnpm!lockfile.to-pnp@1100.1.11.md
@@ -1,0 +1,10 @@
+## 1100.1.11
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/deps.path@1100.0.13
+  - @pnpm/fs.symlink-dependency@1100.0.16
+  - @pnpm/lockfile.fs@1100.1.16
+  - @pnpm/lockfile.utils@1100.1.7
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!lockfile.types@1100.0.18.md
+++ b/.changeset/changelogs/@pnpm!lockfile.types@1100.0.18.md
@@ -1,0 +1,7 @@
+## 1100.0.18
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/resolving.resolver-base@1101.0.0
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!lockfile.utils@1100.1.7.md
+++ b/.changeset/changelogs/@pnpm!lockfile.utils@1100.1.7.md
@@ -1,0 +1,10 @@
+## 1100.1.7
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/deps.path@1100.0.13
+  - @pnpm/hooks.types@1100.2.5
+  - @pnpm/lockfile.types@1100.0.18
+  - @pnpm/resolving.resolver-base@1101.0.0
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!lockfile.verification@1100.0.30.md
+++ b/.changeset/changelogs/@pnpm!lockfile.verification@1100.0.30.md
@@ -1,0 +1,12 @@
+## 1100.0.30
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/deps.path@1100.0.13
+  - @pnpm/installing.context@1100.0.30
+  - @pnpm/lockfile.types@1100.0.18
+  - @pnpm/lockfile.utils@1100.1.7
+  - @pnpm/pkg-manifest.reader@1100.0.14
+  - @pnpm/resolving.resolver-base@1101.0.0
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!lockfile.walker@1100.0.18.md
+++ b/.changeset/changelogs/@pnpm!lockfile.walker@1100.0.18.md
@@ -1,0 +1,8 @@
+## 1100.0.18
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/deps.path@1100.0.13
+  - @pnpm/lockfile.types@1100.0.18
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!modules-mounter.daemon@1100.0.35.md
+++ b/.changeset/changelogs/@pnpm!modules-mounter.daemon@1100.0.35.md
@@ -1,0 +1,11 @@
+## 1100.0.35
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/config.reader@1101.15.1
+  - @pnpm/deps.path@1100.0.13
+  - @pnpm/lockfile.fs@1100.1.16
+  - @pnpm/lockfile.utils@1100.1.7
+  - @pnpm/store.cafs@1100.1.17
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!napi@12.0.0-beta.2.md
+++ b/.changeset/changelogs/@pnpm!napi@12.0.0-beta.2.md
@@ -1,5 +1,0 @@
-## 12.0.0-beta.2
-
-### Minor Changes
-
-- Added `readConfig(options)`: resolves the configuration the engine's own installs use — registries with their resolved `Authorization` headers, `authHeaderByUri`, proxy, TLS, network limits, store/cache directories, and install behavior settings from the `.npmrc` / `pnpm-workspace.yaml` cascade — so hosts that embed the engine no longer need a JavaScript config reader.

--- a/.changeset/changelogs/@pnpm!network.auth-header@1101.1.8.md
+++ b/.changeset/changelogs/@pnpm!network.auth-header@1101.1.8.md
@@ -1,0 +1,6 @@
+## 1101.1.8
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!network.fetch@1100.1.10.md
+++ b/.changeset/changelogs/@pnpm!network.fetch@1100.1.10.md
@@ -1,0 +1,7 @@
+## 1100.1.10
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/core-loggers@1100.3.1
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!network.web-auth@1101.4.0.md
+++ b/.changeset/changelogs/@pnpm!network.web-auth@1101.4.0.md
@@ -1,0 +1,5 @@
+## 1101.4.0
+
+### Minor Changes
+
+- `pnpm login` no longer requires an interactive terminal when the registry supports web-based login: without a TTY it prints the authentication URL (skipping the QR code and the "Press ENTER to open the URL in your browser" prompt) and polls the registry until the browser approval completes. Only the classic username/password login still fails with `ERR_PNPM_LOGIN_NON_INTERACTIVE` in a non-interactive terminal.

--- a/.changeset/changelogs/@pnpm!patching.commands@1100.1.19.md
+++ b/.changeset/changelogs/@pnpm!patching.commands@1100.1.19.md
@@ -1,0 +1,17 @@
+## 1100.1.19
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/cli.utils@1101.0.21
+  - @pnpm/config.reader@1101.15.1
+  - @pnpm/config.writer@1100.0.20
+  - @pnpm/installing.commands@1100.12.2
+  - @pnpm/installing.modules-yaml@1100.0.14
+  - @pnpm/lockfile.fs@1100.1.16
+  - @pnpm/lockfile.utils@1100.1.7
+  - @pnpm/pkg-manifest.reader@1100.0.14
+  - @pnpm/store.connection-manager@1100.3.14
+  - @pnpm/types@1101.8.0
+  - @pnpm/workspace.project-manifest-reader@1100.0.22
+  - @pnpm/workspace.workspace-manifest-reader@1100.1.4

--- a/.changeset/changelogs/@pnpm!patching.config@1100.0.14.md
+++ b/.changeset/changelogs/@pnpm!patching.config@1100.0.14.md
@@ -1,0 +1,6 @@
+## 1100.0.14
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/deps.path@1100.0.13

--- a/.changeset/changelogs/@pnpm!pkg-manifest.commands@1100.1.19.md
+++ b/.changeset/changelogs/@pnpm!pkg-manifest.commands@1100.1.19.md
@@ -1,0 +1,8 @@
+## 1100.1.19
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/cli.utils@1101.0.21
+  - @pnpm/config.reader@1101.15.1
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!pkg-manifest.reader@1100.0.14.md
+++ b/.changeset/changelogs/@pnpm!pkg-manifest.reader@1100.0.14.md
@@ -1,0 +1,6 @@
+## 1100.0.14
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!pkg-manifest.utils@1100.3.0.md
+++ b/.changeset/changelogs/@pnpm!pkg-manifest.utils@1100.3.0.md
@@ -1,0 +1,15 @@
+## 1100.3.0
+
+### Minor Changes
+
+- Renamed the `PinnedVersion` type to `RangeSpecStyle` and the `pinnedVersion` option fields to `rangeSpecStyle`: the value selects the operator a specifier is saved with, not a pin. `whichVersionIsPinned` is now `inferRangeSpecStyle`, and the new `rangeSpecGranularity` helper collapses the `exact` spelling to its `patch` range width. `@pnpm/types` keeps `PinnedVersion` as a deprecated alias of `RangeSpecStyle`. The rename itself changes no CLI behavior; the `=`-pin handling is described in its own changesets.
+
+- The `save-prefix` setting now accepts `=`: newly added dependencies are saved with an explicit `=` operator (`=1.2.3`) instead of the setting being silently treated as the default `^`.
+
+### Patch Changes
+
+- `pnpm update` keeps the explicit `=` operator of an exact version pin: a dependency saved as `=3.5.1` now updates to `=3.5.2` instead of the bare `3.5.2`. See pnpm/pnpm#13168.
+
+- Updated dependencies:
+  - @pnpm/core-loggers@1100.3.1
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!pnpr.client@1.3.9.md
+++ b/.changeset/changelogs/@pnpm!pnpr.client@1.3.9.md
@@ -1,0 +1,8 @@
+## 1.3.9
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/lockfile.fs@1100.1.16
+  - @pnpm/lockfile.types@1100.0.18
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!prepare@1100.0.24.md
+++ b/.changeset/changelogs/@pnpm!prepare@1100.0.24.md
@@ -1,0 +1,7 @@
+## 1100.0.24
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/assert-project@1100.0.24
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!registry-access.client@1100.1.12.md
+++ b/.changeset/changelogs/@pnpm!registry-access.client@1100.1.12.md
@@ -1,0 +1,7 @@
+## 1100.1.12
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/network.fetch@1100.1.10
+  - @pnpm/network.web-auth@1101.4.0

--- a/.changeset/changelogs/@pnpm!registry-access.commands@1100.5.7.md
+++ b/.changeset/changelogs/@pnpm!registry-access.commands@1100.5.7.md
@@ -1,0 +1,14 @@
+## 1100.5.7
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/cli.utils@1101.0.21
+  - @pnpm/config.pick-registry-for-package@1100.0.14
+  - @pnpm/config.reader@1101.15.1
+  - @pnpm/network.auth-header@1101.1.8
+  - @pnpm/network.fetch@1100.1.10
+  - @pnpm/network.web-auth@1101.4.0
+  - @pnpm/registry-access.client@1100.1.12
+  - @pnpm/resolving.registry.types@1100.1.8
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!releasing.commands@1100.8.1.md
+++ b/.changeset/changelogs/@pnpm!releasing.commands@1100.8.1.md
@@ -1,0 +1,31 @@
+## 1100.8.1
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/bins.resolver@1100.0.13
+  - @pnpm/cli.utils@1101.0.21
+  - @pnpm/config.pick-registry-for-package@1100.0.14
+  - @pnpm/config.reader@1101.15.1
+  - @pnpm/deps.path@1100.0.13
+  - @pnpm/engine.runtime.commands@1100.1.18
+  - @pnpm/engine.runtime.node-resolver@1101.1.20
+  - @pnpm/exec.lifecycle@1100.1.10
+  - @pnpm/fetching.directory-fetcher@1100.0.27
+  - @pnpm/fs.indexed-pkg-importer@1100.0.23
+  - @pnpm/installing.client@1100.3.1
+  - @pnpm/installing.commands@1100.12.2
+  - @pnpm/lockfile.fs@1100.1.16
+  - @pnpm/lockfile.types@1100.0.18
+  - @pnpm/network.auth-header@1101.1.8
+  - @pnpm/network.fetch@1100.1.10
+  - @pnpm/network.web-auth@1101.4.0
+  - @pnpm/releasing.exportable-manifest@1100.2.1
+  - @pnpm/releasing.versioning@1100.2.3
+  - @pnpm/resolving.npm-resolver@1103.0.0
+  - @pnpm/resolving.registry.types@1100.1.8
+  - @pnpm/resolving.resolver-base@1101.0.0
+  - @pnpm/types@1101.8.0
+  - @pnpm/workspace.projects-filter@1100.0.34
+  - @pnpm/workspace.projects-sorter@1100.0.13
+  - @pnpm/workspace.workspace-manifest-writer@1100.0.20

--- a/.changeset/changelogs/@pnpm!releasing.exportable-manifest@1100.2.1.md
+++ b/.changeset/changelogs/@pnpm!releasing.exportable-manifest@1100.2.1.md
@@ -1,0 +1,8 @@
+## 1100.2.1
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/bins.resolver@1100.0.13
+  - @pnpm/types@1101.8.0
+  - @pnpm/workspace.project-manifest-reader@1100.0.22

--- a/.changeset/changelogs/@pnpm!releasing.versioning@1100.2.3.md
+++ b/.changeset/changelogs/@pnpm!releasing.versioning@1100.2.3.md
@@ -1,0 +1,7 @@
+## 1100.2.3
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/types@1101.8.0
+  - @pnpm/workspace.project-manifest-reader@1100.0.22

--- a/.changeset/changelogs/@pnpm!resolving.default-resolver@1100.3.22.md
+++ b/.changeset/changelogs/@pnpm!resolving.default-resolver@1100.3.22.md
@@ -1,0 +1,16 @@
+## 1100.3.22
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/engine.runtime.bun-resolver@1102.0.13
+  - @pnpm/engine.runtime.deno-resolver@1102.0.13
+  - @pnpm/engine.runtime.node-resolver@1101.1.20
+  - @pnpm/hooks.types@1100.2.5
+  - @pnpm/network.auth-header@1101.1.8
+  - @pnpm/resolving.git-resolver@1100.1.14
+  - @pnpm/resolving.local-resolver@1101.1.16
+  - @pnpm/resolving.npm-resolver@1103.0.0
+  - @pnpm/resolving.resolver-base@1101.0.0
+  - @pnpm/resolving.tarball-resolver@1100.1.11
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!resolving.git-resolver@1100.1.14.md
+++ b/.changeset/changelogs/@pnpm!resolving.git-resolver@1100.1.14.md
@@ -1,0 +1,9 @@
+## 1100.1.14
+
+### Patch Changes
+
+- `pnpm outdated --include-github-actions` no longer blocks on an interactive git credential prompt when a workflow uses a private action repo.
+
+- Updated dependencies:
+  - @pnpm/network.fetch@1100.1.10
+  - @pnpm/resolving.resolver-base@1101.0.0

--- a/.changeset/changelogs/@pnpm!resolving.local-resolver@1101.1.16.md
+++ b/.changeset/changelogs/@pnpm!resolving.local-resolver@1101.1.16.md
@@ -1,0 +1,8 @@
+## 1101.1.16
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/resolving.resolver-base@1101.0.0
+  - @pnpm/types@1101.8.0
+  - @pnpm/workspace.project-manifest-reader@1100.0.22

--- a/.changeset/changelogs/@pnpm!resolving.npm-resolver@1103.0.0.md
+++ b/.changeset/changelogs/@pnpm!resolving.npm-resolver@1103.0.0.md
@@ -1,0 +1,22 @@
+## 1103.0.0
+
+### Major Changes
+
+- Renamed the `PinnedVersion` type to `RangeSpecStyle` and the `pinnedVersion` option fields to `rangeSpecStyle`: the value selects the operator a specifier is saved with, not a pin. `whichVersionIsPinned` is now `inferRangeSpecStyle`, and the new `rangeSpecGranularity` helper collapses the `exact` spelling to its `patch` range width. `@pnpm/types` keeps `PinnedVersion` as a deprecated alias of `RangeSpecStyle`. The rename itself changes no CLI behavior; the `=`-pin handling is described in its own changesets.
+
+### Patch Changes
+
+- The install summary no longer prints `(X is available)` when the registry's `dist-tags.latest` is still held back by the active `minimumReleaseAge` policy. The hint only ever names the actual latest tag, so an immature latest suppresses the hint instead of advertising the version pnpm just refused to install [#11698](https://github.com/pnpm/pnpm/issues/11698).
+
+- `pnpm update` keeps the explicit `=` operator of an exact version pin: a dependency saved as `=3.5.1` now updates to `=3.5.2` instead of the bare `3.5.2`. See pnpm/pnpm#13168.
+
+- Updated dependencies:
+  - @pnpm/config.pick-registry-for-package@1100.0.14
+  - @pnpm/config.version-policy@1100.1.11
+  - @pnpm/core-loggers@1100.3.1
+  - @pnpm/pkg-manifest.utils@1100.3.0
+  - @pnpm/resolving.registry.pkg-metadata-filter@1100.0.14
+  - @pnpm/resolving.registry.types@1100.1.8
+  - @pnpm/resolving.resolver-base@1101.0.0
+  - @pnpm/store.cafs@1100.1.17
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!resolving.registry.pkg-metadata-filter@1100.0.14.md
+++ b/.changeset/changelogs/@pnpm!resolving.registry.pkg-metadata-filter@1100.0.14.md
@@ -1,0 +1,8 @@
+## 1100.0.14
+
+### Patch Changes
+
+- Prevented `minimumReleaseAge` from replacing `latest` with a SemVer-greater version than the registry tag target [#13034](https://github.com/pnpm/pnpm/issues/13034).
+
+- Updated dependencies:
+  - @pnpm/resolving.registry.types@1100.1.8

--- a/.changeset/changelogs/@pnpm!resolving.registry.types@1100.1.8.md
+++ b/.changeset/changelogs/@pnpm!resolving.registry.types@1100.1.8.md
@@ -1,0 +1,6 @@
+## 1100.1.8
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!resolving.resolver-base@1101.0.0.md
+++ b/.changeset/changelogs/@pnpm!resolving.resolver-base@1101.0.0.md
@@ -1,0 +1,10 @@
+## 1101.0.0
+
+### Major Changes
+
+- Renamed the `PinnedVersion` type to `RangeSpecStyle` and the `pinnedVersion` option fields to `rangeSpecStyle`: the value selects the operator a specifier is saved with, not a pin. `whichVersionIsPinned` is now `inferRangeSpecStyle`, and the new `rangeSpecGranularity` helper collapses the `exact` spelling to its `patch` range width. `@pnpm/types` keeps `PinnedVersion` as a deprecated alias of `RangeSpecStyle`. The rename itself changes no CLI behavior; the `=`-pin handling is described in its own changesets.
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!resolving.tarball-resolver@1100.1.11.md
+++ b/.changeset/changelogs/@pnpm!resolving.tarball-resolver@1100.1.11.md
@@ -1,0 +1,6 @@
+## 1100.1.11
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/resolving.resolver-base@1101.0.0

--- a/.changeset/changelogs/@pnpm!scripts@1100.0.21.md
+++ b/.changeset/changelogs/@pnpm!scripts@1100.0.21.md
@@ -3,5 +3,5 @@
 ### Patch Changes
 
 - Updated dependencies:
-  - @pnpm/workspace.projects-reader@1101.0.20
-  - @pnpm/workspace.workspace-manifest-reader@1100.1.3
+  - @pnpm/workspace.projects-reader@1101.0.21
+  - @pnpm/workspace.workspace-manifest-reader@1100.1.4

--- a/.changeset/changelogs/@pnpm!store.cafs@1100.1.17.md
+++ b/.changeset/changelogs/@pnpm!store.cafs@1100.1.17.md
@@ -1,0 +1,8 @@
+## 1100.1.17
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/fetching.fetcher-base@1100.2.6
+  - @pnpm/store.controller-types@1101.0.0
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!store.commands@1100.0.40.md
+++ b/.changeset/changelogs/@pnpm!store.commands@1100.0.40.md
@@ -1,0 +1,18 @@
+## 1100.0.40
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/cli.utils@1101.0.21
+  - @pnpm/config.normalize-registries@1100.0.13
+  - @pnpm/config.reader@1101.15.1
+  - @pnpm/deps.path@1100.0.13
+  - @pnpm/global.packages@1100.0.15
+  - @pnpm/installing.client@1100.3.1
+  - @pnpm/installing.context@1100.0.30
+  - @pnpm/lockfile.types@1100.0.18
+  - @pnpm/lockfile.utils@1100.1.7
+  - @pnpm/store.cafs@1100.1.17
+  - @pnpm/store.connection-manager@1100.3.14
+  - @pnpm/store.controller-types@1101.0.0
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!store.connection-manager@1100.3.14.md
+++ b/.changeset/changelogs/@pnpm!store.connection-manager@1100.3.14.md
@@ -1,0 +1,10 @@
+## 1100.3.14
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/cli.meta@1100.0.13
+  - @pnpm/config.reader@1101.15.1
+  - @pnpm/installing.client@1100.3.1
+  - @pnpm/resolving.resolver-base@1101.0.0
+  - @pnpm/store.controller@1102.0.10

--- a/.changeset/changelogs/@pnpm!store.controller-types@1101.0.0.md
+++ b/.changeset/changelogs/@pnpm!store.controller-types@1101.0.0.md
@@ -1,0 +1,12 @@
+## 1101.0.0
+
+### Major Changes
+
+- Renamed the `PinnedVersion` type to `RangeSpecStyle` and the `pinnedVersion` option fields to `rangeSpecStyle`: the value selects the operator a specifier is saved with, not a pin. `whichVersionIsPinned` is now `inferRangeSpecStyle`, and the new `rangeSpecGranularity` helper collapses the `exact` spelling to its `patch` range width. `@pnpm/types` keeps `PinnedVersion` as a deprecated alias of `RangeSpecStyle`. The rename itself changes no CLI behavior; the `=`-pin handling is described in its own changesets.
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/fetching.fetcher-base@1100.2.6
+  - @pnpm/resolving.resolver-base@1101.0.0
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!store.controller@1102.0.10.md
+++ b/.changeset/changelogs/@pnpm!store.controller@1102.0.10.md
@@ -1,0 +1,13 @@
+## 1102.0.10
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/fetching.fetcher-base@1100.2.6
+  - @pnpm/hooks.types@1100.2.5
+  - @pnpm/installing.package-requester@1102.1.8
+  - @pnpm/resolving.resolver-base@1101.0.0
+  - @pnpm/store.cafs@1100.1.17
+  - @pnpm/store.controller-types@1101.0.0
+  - @pnpm/store.create-cafs-store@1100.0.23
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!store.create-cafs-store@1100.0.23.md
+++ b/.changeset/changelogs/@pnpm!store.create-cafs-store@1100.0.23.md
@@ -1,0 +1,10 @@
+## 1100.0.23
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/building.pkg-requires-build@1100.0.13
+  - @pnpm/fetching.fetcher-base@1100.2.6
+  - @pnpm/fs.indexed-pkg-importer@1100.0.23
+  - @pnpm/store.cafs@1100.1.17
+  - @pnpm/store.controller-types@1101.0.0

--- a/.changeset/changelogs/@pnpm!store.pkg-finder@1100.0.27.md
+++ b/.changeset/changelogs/@pnpm!store.pkg-finder@1100.0.27.md
@@ -1,0 +1,8 @@
+## 1100.0.27
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/fetching.directory-fetcher@1100.0.27
+  - @pnpm/resolving.resolver-base@1101.0.0
+  - @pnpm/store.cafs@1100.1.17

--- a/.changeset/changelogs/@pnpm!testing.mock-agent@1101.0.7.md
+++ b/.changeset/changelogs/@pnpm!testing.mock-agent@1101.0.7.md
@@ -3,4 +3,4 @@
 ### Patch Changes
 
 - Updated dependencies:
-  - @pnpm/network.fetch@1100.1.9
+  - @pnpm/network.fetch@1100.1.10

--- a/.changeset/changelogs/@pnpm!testing.registry-mock@1100.0.11.md
+++ b/.changeset/changelogs/@pnpm!testing.registry-mock@1100.0.11.md
@@ -3,5 +3,5 @@
 ### Patch Changes
 
 - Updated dependencies:
-  - @pnpm/network.fetch@1100.1.9
-  - @pnpm/registry-access.client@1100.1.11
+  - @pnpm/network.fetch@1100.1.10
+  - @pnpm/registry-access.client@1100.1.12

--- a/.changeset/changelogs/@pnpm!testing.temp-store@1100.1.23.md
+++ b/.changeset/changelogs/@pnpm!testing.temp-store@1100.1.23.md
@@ -1,0 +1,9 @@
+## 1100.1.23
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/installing.client@1100.3.1
+  - @pnpm/resolving.resolver-base@1101.0.0
+  - @pnpm/store.controller@1102.0.10
+  - @pnpm/store.controller-types@1101.0.0

--- a/.changeset/changelogs/@pnpm!types@1101.8.0.md
+++ b/.changeset/changelogs/@pnpm!types@1101.8.0.md
@@ -1,0 +1,9 @@
+## 1101.8.0
+
+### Minor Changes
+
+- Renamed the `PinnedVersion` type to `RangeSpecStyle` and the `pinnedVersion` option fields to `rangeSpecStyle`: the value selects the operator a specifier is saved with, not a pin. `whichVersionIsPinned` is now `inferRangeSpecStyle`, and the new `rangeSpecGranularity` helper collapses the `exact` spelling to its `patch` range width. `@pnpm/types` keeps `PinnedVersion` as a deprecated alias of `RangeSpecStyle`. The rename itself changes no CLI behavior; the `=`-pin handling is described in its own changesets.
+
+### Patch Changes
+
+- `pnpm update` keeps the explicit `=` operator of an exact version pin: a dependency saved as `=3.5.1` now updates to `=3.5.2` instead of the bare `3.5.2`. See pnpm/pnpm#13168.

--- a/.changeset/changelogs/@pnpm!worker@1100.2.9.md
+++ b/.changeset/changelogs/@pnpm!worker@1100.2.9.md
@@ -1,0 +1,9 @@
+## 1100.2.9
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/building.pkg-requires-build@1100.0.13
+  - @pnpm/fs.symlink-dependency@1100.0.16
+  - @pnpm/store.cafs@1100.1.17
+  - @pnpm/store.create-cafs-store@1100.0.23

--- a/.changeset/changelogs/@pnpm!workspace.commands@1100.1.33.md
+++ b/.changeset/changelogs/@pnpm!workspace.commands@1100.1.33.md
@@ -1,0 +1,10 @@
+## 1100.1.33
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/cli.meta@1100.0.13
+  - @pnpm/cli.utils@1101.0.21
+  - @pnpm/config.reader@1101.15.1
+  - @pnpm/types@1101.8.0
+  - @pnpm/workspace.project-manifest-writer@1100.0.13

--- a/.changeset/changelogs/@pnpm!workspace.injected-deps-syncer@1100.0.30.md
+++ b/.changeset/changelogs/@pnpm!workspace.injected-deps-syncer@1100.0.30.md
@@ -1,0 +1,11 @@
+## 1100.0.30
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/bins.linker@1100.0.24
+  - @pnpm/fetching.directory-fetcher@1100.0.27
+  - @pnpm/installing.modules-yaml@1100.0.14
+  - @pnpm/pkg-manifest.reader@1100.0.14
+  - @pnpm/types@1101.8.0
+  - @pnpm/workspace.projects-reader@1101.0.21

--- a/.changeset/changelogs/@pnpm!workspace.project-manifest-reader@1100.0.22.md
+++ b/.changeset/changelogs/@pnpm!workspace.project-manifest-reader@1100.0.22.md
@@ -1,0 +1,8 @@
+## 1100.0.22
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/pkg-manifest.utils@1100.3.0
+  - @pnpm/types@1101.8.0
+  - @pnpm/workspace.project-manifest-writer@1100.0.13

--- a/.changeset/changelogs/@pnpm!workspace.project-manifest-writer@1100.0.13.md
+++ b/.changeset/changelogs/@pnpm!workspace.project-manifest-writer@1100.0.13.md
@@ -1,0 +1,6 @@
+## 1100.0.13
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!workspace.projects-filter@1100.0.34.md
+++ b/.changeset/changelogs/@pnpm!workspace.projects-filter@1100.0.34.md
@@ -1,0 +1,8 @@
+## 1100.0.34
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/workspace.projects-graph@1100.0.30
+  - @pnpm/workspace.projects-reader@1101.0.21
+  - @pnpm/workspace.workspace-manifest-reader@1100.1.4

--- a/.changeset/changelogs/@pnpm!workspace.projects-graph@1100.0.30.md
+++ b/.changeset/changelogs/@pnpm!workspace.projects-graph@1100.0.30.md
@@ -1,0 +1,9 @@
+## 1100.0.30
+
+### Patch Changes
+
+- Workspace dependencies declared with a relative path (e.g. `"foo": "workspace:../foo"`) are no longer silently dropped from the workspace projects graph, so `--filter` selection and the topological order of recursive commands take them into account.
+
+- Updated dependencies:
+  - @pnpm/resolving.npm-resolver@1103.0.0
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!workspace.projects-reader@1101.0.21.md
+++ b/.changeset/changelogs/@pnpm!workspace.projects-reader@1101.0.21.md
@@ -1,0 +1,8 @@
+## 1101.0.21
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/cli.utils@1101.0.21
+  - @pnpm/types@1101.8.0
+  - @pnpm/workspace.project-manifest-reader@1100.0.22

--- a/.changeset/changelogs/@pnpm!workspace.projects-sorter@1100.0.13.md
+++ b/.changeset/changelogs/@pnpm!workspace.projects-sorter@1100.0.13.md
@@ -1,0 +1,6 @@
+## 1100.0.13
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!workspace.state@1100.0.35.md
+++ b/.changeset/changelogs/@pnpm!workspace.state@1100.0.35.md
@@ -1,0 +1,7 @@
+## 1100.0.35
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/config.reader@1101.15.1
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!workspace.workspace-manifest-reader@1100.1.4.md
+++ b/.changeset/changelogs/@pnpm!workspace.workspace-manifest-reader@1100.1.4.md
@@ -1,0 +1,6 @@
+## 1100.1.4
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/types@1101.8.0

--- a/.changeset/changelogs/@pnpm!workspace.workspace-manifest-writer@1100.0.20.md
+++ b/.changeset/changelogs/@pnpm!workspace.workspace-manifest-writer@1100.0.20.md
@@ -1,0 +1,9 @@
+## 1100.0.20
+
+### Patch Changes
+
+- Updated dependencies:
+  - @pnpm/config.version-policy@1100.1.11
+  - @pnpm/lockfile.types@1100.0.18
+  - @pnpm/types@1101.8.0
+  - @pnpm/workspace.workspace-manifest-reader@1100.1.4

--- a/.changeset/changelogs/@pnpm-private!updater@1100.0.29.md
+++ b/.changeset/changelogs/@pnpm-private!updater@1100.0.29.md
@@ -3,7 +3,7 @@
 ### Patch Changes
 
 - Updated dependencies:
-  - @pnpm/lockfile.fs@1100.1.15
-  - @pnpm/types@1101.7.0
-  - @pnpm/workspace.projects-reader@1101.0.20
-  - @pnpm/workspace.workspace-manifest-reader@1100.1.3
+  - @pnpm/lockfile.fs@1100.1.16
+  - @pnpm/types@1101.8.0
+  - @pnpm/workspace.projects-reader@1101.0.21
+  - @pnpm/workspace.workspace-manifest-reader@1100.1.4

--- a/.changeset/changelogs/pacquet@12.0.0-beta.2.md
+++ b/.changeset/changelogs/pacquet@12.0.0-beta.2.md
@@ -1,7 +1,0 @@
-## 12.0.0-beta.2
-
-### Patch Changes
-
-- `pnpm install` no longer fails when `pnpm-lock.yaml` exists but cannot be parsed. Matching the TypeScript CLI, the install now prints an "Ignoring broken lockfile" warning, resolves dependencies from the manifests, and rewrites the lockfile. `--frozen-lockfile` still fails on a broken lockfile.
-
-- Fresh installs no longer download the tarballs of platform-specific optional dependencies that don't match the current platform.

--- a/.changeset/changelogs/pd@1100.0.22.md
+++ b/.changeset/changelogs/pd@1100.0.22.md
@@ -3,5 +3,5 @@
 ### Patch Changes
 
 - Updated dependencies:
-  - @pnpm/workspace.projects-reader@1101.0.20
-  - @pnpm/workspace.workspace-manifest-reader@1100.1.3
+  - @pnpm/workspace.projects-reader@1101.0.21
+  - @pnpm/workspace.workspace-manifest-reader@1100.1.4

--- a/.changeset/changelogs/pnpm@11.19.0.md
+++ b/.changeset/changelogs/pnpm@11.19.0.md
@@ -1,0 +1,36 @@
+## 11.19.0
+
+### Minor Changes
+
+- `pnpm login` no longer requires an interactive terminal when the registry supports web-based login: without a TTY it prints the authentication URL (skipping the QR code and the "Press ENTER to open the URL in your browser" prompt) and polls the registry until the browser approval completes. Only the classic username/password login still fails with `ERR_PNPM_LOGIN_NON_INTERACTIVE` in a non-interactive terminal.
+
+- The `save-prefix` setting now accepts `=`: newly added dependencies are saved with an explicit `=` operator (`=1.2.3`) instead of the setting being silently treated as the default `^`.
+
+### Patch Changes
+
+- `allowBuilds` entries can now approve git-hosted packages that pnpm downloads as a tarball, such as `github:` dependencies (which are fetched from `codeload.github.com` rather than cloned), by their repository URL without the resolved commit hash. This matches the hashless `git+` matching already supported for cloned git dependencies. For example:
+
+  ```yaml
+  allowBuilds:
+    "foo@git+https://github.com/org/foo.git": true
+  ```
+
+  This approves the package whether pnpm clones it or downloads a tarball, so the entry no longer has to be updated every time the pinned commit changes. GitLab and Bitbucket tarball downloads are matched the same way. Approving or denying a specific resolved commit by its full tarball dep path continues to work.
+
+- `pnpm outdated --include-github-actions` no longer blocks on an interactive git credential prompt when a workflow uses a private action repo.
+
+- Prevented `minimumReleaseAge` from replacing `latest` with a SemVer-greater version than the registry tag target [#13034](https://github.com/pnpm/pnpm/issues/13034).
+
+- Fixed empty `bundledDependencies` and `bundleDependencies` arrays causing nondeterministic lockfile changes. See pnpm/pnpm#13123.
+
+- The install summary no longer prints `(X is available)` when the registry's `dist-tags.latest` is still held back by the active `minimumReleaseAge` policy. The hint only ever names the actual latest tag, so an immature latest suppresses the hint instead of advertising the version pnpm just refused to install [#11698](https://github.com/pnpm/pnpm/issues/11698).
+
+- `pnpm update` keeps the explicit `=` operator of an exact version pin: a dependency saved as `=3.5.1` now updates to `=3.5.2` instead of the bare `3.5.2`. See pnpm/pnpm#13168.
+
+- Preserve a workspace dependency's `link:` entry when a run does not target it — e.g. `pnpm update <other-pkg>` (with or without `--recursive`), or a plain install after a root/catalog dependency change — with `injectWorkspacePackages`, instead of spuriously rewriting it to a peer-suffixed `file:` protocol. See pnpm/pnpm#10433.
+
+- Renamed the `PinnedVersion` type to `RangeSpecStyle` and the `pinnedVersion` option fields to `rangeSpecStyle`: the value selects the operator a specifier is saved with, not a pin. `whichVersionIsPinned` is now `inferRangeSpecStyle`, and the new `rangeSpecGranularity` helper collapses the `exact` spelling to its `patch` range width. `@pnpm/types` keeps `PinnedVersion` as a deprecated alias of `RangeSpecStyle`. The rename itself changes no CLI behavior; the `=`-pin handling is described in its own changesets.
+
+- The default reporter no longer depends on `@pnpm/config.reader` at runtime: it declares its own minimal `ReporterPnpmConfig` type for the config fields it reads. Hosts that embed the reporter no longer pull in the config-reader dependency tree.
+
+- Workspace dependencies declared with a relative path (e.g. `"foo": "workspace:../foo"`) are no longer silently dropped from the workspace projects graph, so `--filter` selection and the topological order of recursive commands take them into account.

--- a/.changeset/changelogs/pnpm@11.19.0.md
+++ b/.changeset/changelogs/pnpm@11.19.0.md
@@ -29,8 +29,4 @@
 
 - Preserve a workspace dependency's `link:` entry when a run does not target it — e.g. `pnpm update <other-pkg>` (with or without `--recursive`), or a plain install after a root/catalog dependency change — with `injectWorkspacePackages`, instead of spuriously rewriting it to a peer-suffixed `file:` protocol. See pnpm/pnpm#10433.
 
-- Renamed the `PinnedVersion` type to `RangeSpecStyle` and the `pinnedVersion` option fields to `rangeSpecStyle`: the value selects the operator a specifier is saved with, not a pin. `whichVersionIsPinned` is now `inferRangeSpecStyle`, and the new `rangeSpecGranularity` helper collapses the `exact` spelling to its `patch` range width. `@pnpm/types` keeps `PinnedVersion` as a deprecated alias of `RangeSpecStyle`. The rename itself changes no CLI behavior; the `=`-pin handling is described in its own changesets.
-
-- The default reporter no longer depends on `@pnpm/config.reader` at runtime: it declares its own minimal `ReporterPnpmConfig` type for the config fields it reads. Hosts that embed the reporter no longer pull in the config-reader dependency tree.
-
 - Workspace dependencies declared with a relative path (e.g. `"foo": "workspace:../foo"`) are no longer silently dropped from the workspace projects graph, so `--filter` selection and the topological order of recursive commands take them into account.

--- a/.changeset/ledger.yaml
+++ b/.changeset/ledger.yaml
@@ -11,6 +11,10 @@
   intents:
     - republish-all-lib-packages
     - web-auth-qr-code-fallback
+"@pnpm/auth.commands@1100.3.0":
+  dir: pnpm11/auth/commands
+  intents:
+    - login-non-interactive-web-auth
 "@pnpm/bins.linker@1100.0.22":
   dir: pnpm11/bins/linker
   intents:
@@ -51,6 +55,10 @@
   dir: pnpm11/building/policy
   intents:
     - republish-all-lib-packages
+"@pnpm/building.policy@1100.0.17":
+  dir: pnpm11/building/policy
+  intents:
+    - allow-git-tarball-builds-by-repo-url
 "@pnpm/cache.api@1100.0.33":
   dir: pnpm11/cache/api
   intents:
@@ -95,6 +103,10 @@
   dir: pnpm11/cli/default-reporter
   intents:
     - republish-all-lib-packages
+"@pnpm/cli.default-reporter@1100.3.14":
+  dir: pnpm11/cli/default-reporter
+  intents:
+    - reporter-own-config-type
 "@pnpm/cli.default-reporter@1100.3.8":
   dir: pnpm11/cli/default-reporter
   intents:
@@ -352,6 +364,11 @@
     - gvs-local-directory-deps
     - pnpm-setup-github-actions
     - self-update-release-age
+"@pnpm/engine.pm.commands@1101.3.1":
+  dir: pnpm11/engine/pm/commands
+  intents:
+    - preserve-equals-pin-operator
+    - rename-pinned-version-to-range-spec-style
 "@pnpm/engine.runtime.bun-resolver@1102.0.11":
   dir: pnpm11/engine/runtime/bun-resolver
   intents:
@@ -494,6 +511,11 @@
   dir: pnpm11/global/commands
   intents:
     - republish-all-lib-packages
+"@pnpm/global.commands@1100.0.42":
+  dir: pnpm11/global/commands
+  intents:
+    - rename-pinned-version-to-range-spec-style
+    - save-prefix-equals
 "@pnpm/global.packages@1100.0.13":
   dir: pnpm11/global/packages
   intents:
@@ -553,6 +575,11 @@
     - interactive-update-workspace-labels
     - run-the-dev-preinstall-hook
     - update-workspace-only-links-named-deps
+"@pnpm/installing.commands@1100.12.2":
+  dir: pnpm11/installing/commands
+  intents:
+    - rename-pinned-version-to-range-spec-style
+    - save-prefix-equals
 "@pnpm/installing.context@1100.0.28":
   dir: pnpm11/installing/context
   intents:
@@ -601,6 +628,10 @@
     - quiet-catalogs-dedupe
     - restore-package-import-method-log
     - tidy-donkeys-check
+"@pnpm/installing.deps-installer@1103.0.0":
+  dir: pnpm11/installing/deps-installer
+  intents:
+    - rename-pinned-version-to-range-spec-style
 "@pnpm/installing.deps-resolver@1100.2.11":
   dir: pnpm11/installing/deps-resolver
   intents:
@@ -625,6 +656,12 @@
     - optional-peer-hoist-respects-workspace-root
     - overrides-reach-auto-installed-peers
     - peer-hoist-skips-project-relative-root-deps
+"@pnpm/installing.deps-resolver@1101.0.0":
+  dir: pnpm11/installing/deps-resolver
+  intents:
+    - normalize-empty-bundled-dependencies
+    - preserve-workspace-link-on-partial-update
+    - rename-pinned-version-to-range-spec-style
 "@pnpm/installing.deps-restorer@1102.1.10":
   dir: pnpm11/installing/deps-restorer
   intents:
@@ -776,6 +813,10 @@
     - harden-web-auth-poll-body
     - republish-all-lib-packages
     - web-auth-qr-code-fallback
+"@pnpm/network.web-auth@1101.4.0":
+  dir: pnpm11/network/web-auth
+  intents:
+    - login-non-interactive-web-auth
 "@pnpm/object.key-sorting@1100.0.2":
   dir: pnpm11/object/key-sorting
   intents:
@@ -820,6 +861,12 @@
   dir: pnpm11/pkg-manifest/utils
   intents:
     - republish-all-lib-packages
+"@pnpm/pkg-manifest.utils@1100.3.0":
+  dir: pnpm11/pkg-manifest/utils
+  intents:
+    - preserve-equals-pin-operator
+    - rename-pinned-version-to-range-spec-style
+    - save-prefix-equals
 "@pnpm/pnpr.client@1.3.5":
   dir: pnpr/client
   intents:
@@ -947,6 +994,10 @@
   intents:
     - github-actions-server-setting
     - republish-all-lib-packages
+"@pnpm/resolving.git-resolver@1100.1.14":
+  dir: pnpm11/resolving/git-resolver
+  intents:
+    - fix-git-resolver-prompt
 "@pnpm/resolving.jsr-specifier-parser@1100.0.3":
   dir: pnpm11/resolving/jsr-specifier-parser
   intents:
@@ -973,6 +1024,12 @@
   dir: pnpm11/resolving/npm-resolver
   intents:
     - republish-all-lib-packages
+"@pnpm/resolving.npm-resolver@1103.0.0":
+  dir: pnpm11/resolving/npm-resolver
+  intents:
+    - policy-aware-install-summary-latest
+    - preserve-equals-pin-operator
+    - rename-pinned-version-to-range-spec-style
 "@pnpm/resolving.parse-wanted-dependency@1100.0.2":
   dir: pnpm11/resolving/parse-wanted-dependency
   intents:
@@ -981,6 +1038,10 @@
   dir: pnpm11/resolving/registry/pkg-metadata-filter
   intents:
     - republish-all-lib-packages
+"@pnpm/resolving.registry.pkg-metadata-filter@1100.0.14":
+  dir: pnpm11/resolving/registry/pkg-metadata-filter
+  intents:
+    - minimum-release-age-latest-bound
 "@pnpm/resolving.registry.types@1100.1.6":
   dir: pnpm11/resolving/registry/types
   intents:
@@ -989,6 +1050,10 @@
   dir: pnpm11/resolving/resolver-base
   intents:
     - republish-all-lib-packages
+"@pnpm/resolving.resolver-base@1101.0.0":
+  dir: pnpm11/resolving/resolver-base
+  intents:
+    - rename-pinned-version-to-range-spec-style
 "@pnpm/resolving.tarball-resolver@1100.1.9":
   dir: pnpm11/resolving/tarball-resolver
   intents:
@@ -1025,6 +1090,10 @@
   dir: pnpm11/store/controller-types
   intents:
     - republish-all-lib-packages
+"@pnpm/store.controller-types@1101.0.0":
+  dir: pnpm11/store/controller-types
+  intents:
+    - rename-pinned-version-to-range-spec-style
 "@pnpm/store.controller@1102.0.8":
   dir: pnpm11/store/controller
   intents:
@@ -1085,6 +1154,11 @@
   intents:
     - interactive-update-github-actions-opt-in
     - publish-config-name
+"@pnpm/types@1101.8.0":
+  dir: pnpm11/core/types
+  intents:
+    - preserve-equals-pin-operator
+    - rename-pinned-version-to-range-spec-style
 "@pnpm/worker@1100.2.7":
   dir: pnpm11/worker
   intents:
@@ -1113,6 +1187,10 @@
   dir: pnpm11/workspace/projects-graph
   intents:
     - republish-all-lib-packages
+"@pnpm/workspace.projects-graph@1100.0.30":
+  dir: pnpm11/workspace/projects-graph
+  intents:
+    - workspace-relative-path-deps-resolved
 "@pnpm/workspace.projects-reader@1101.0.19":
   dir: pnpm11/workspace/projects-reader
   intents:
@@ -1564,3 +1642,18 @@ pnpm@11.18.0:
     - self-update-release-age
     - tidy-donkeys-check
     - update-workspace-only-links-named-deps
+pnpm@11.19.0:
+  dir: pnpm11/pnpm
+  intents:
+    - allow-git-tarball-builds-by-repo-url
+    - fix-git-resolver-prompt
+    - login-non-interactive-web-auth
+    - minimum-release-age-latest-bound
+    - normalize-empty-bundled-dependencies
+    - policy-aware-install-summary-latest
+    - preserve-equals-pin-operator
+    - preserve-workspace-link-on-partial-update
+    - rename-pinned-version-to-range-spec-style
+    - reporter-own-config-type
+    - save-prefix-equals
+    - workspace-relative-path-deps-resolved

--- a/pnpm11/__utils__/assert-project/package.json
+++ b/pnpm11/__utils__/assert-project/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pnpm/assert-project",
   "description": "Utils for testing projects that use pnpm",
-  "version": "1100.0.23",
+  "version": "1100.0.24",
   "author": {
     "name": "Zoltan Kochan",
     "email": "z@kochan.io",

--- a/pnpm11/__utils__/assert-store/package.json
+++ b/pnpm11/__utils__/assert-store/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pnpm/assert-store",
   "description": "Utils for testing pnpm store",
-  "version": "1100.0.23",
+  "version": "1100.0.24",
   "bugs": {
     "url": "https://github.com/pnpm/pnpm/issues"
   },

--- a/pnpm11/__utils__/prepare/package.json
+++ b/pnpm11/__utils__/prepare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/prepare",
-  "version": "1100.0.23",
+  "version": "1100.0.24",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "type": "module",

--- a/pnpm11/auth/commands/package.json
+++ b/pnpm11/auth/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/auth.commands",
-  "version": "1100.2.16",
+  "version": "1100.3.0",
   "description": "Commands for authentication with npm registries",
   "keywords": [
     "pnpm",

--- a/pnpm11/bins/linker/package.json
+++ b/pnpm11/bins/linker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/bins.linker",
-  "version": "1100.0.23",
+  "version": "1100.0.24",
   "description": "Link bins to node_modules/.bin",
   "keywords": [
     "pnpm",

--- a/pnpm11/bins/remover/package.json
+++ b/pnpm11/bins/remover/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/bins.remover",
-  "version": "1100.0.17",
+  "version": "1100.0.18",
   "description": "Remove bins from .bin",
   "keywords": [
     "pnpm",

--- a/pnpm11/bins/resolver/package.json
+++ b/pnpm11/bins/resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/bins.resolver",
-  "version": "1100.0.12",
+  "version": "1100.0.13",
   "description": "Returns bins of a package",
   "keywords": [
     "pnpm",

--- a/pnpm11/building/after-install/package.json
+++ b/pnpm11/building/after-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/building.after-install",
-  "version": "1102.0.13",
+  "version": "1102.0.14",
   "description": "Rebuild packages that are already installed by running their lifecycle scripts",
   "keywords": [
     "pnpm",

--- a/pnpm11/building/commands/package.json
+++ b/pnpm11/building/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/building.commands",
-  "version": "1100.1.18",
+  "version": "1100.1.19",
   "description": "Commands for rebuilding and managing dependency builds",
   "keywords": [
     "pnpm",

--- a/pnpm11/building/during-install/package.json
+++ b/pnpm11/building/during-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/building.during-install",
-  "version": "1102.0.12",
+  "version": "1102.0.13",
   "description": "Build packages in node_modules",
   "keywords": [
     "pnpm",

--- a/pnpm11/building/pkg-requires-build/package.json
+++ b/pnpm11/building/pkg-requires-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/building.pkg-requires-build",
-  "version": "1100.0.12",
+  "version": "1100.0.13",
   "description": "Checks if a package requires to be built",
   "keywords": [
     "pnpm",

--- a/pnpm11/building/policy/package.json
+++ b/pnpm11/building/policy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/building.policy",
-  "version": "1100.0.16",
+  "version": "1100.0.17",
   "description": "Create a function for filtering out dependencies that are not allowed to be built",
   "keywords": [
     "pnpm",

--- a/pnpm11/cache/api/package.json
+++ b/pnpm11/cache/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/cache.api",
-  "version": "1100.0.34",
+  "version": "1100.0.35",
   "description": "API for controlling the cache",
   "keywords": [
     "pnpm",

--- a/pnpm11/cache/commands/package.json
+++ b/pnpm11/cache/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/cache.commands",
-  "version": "1100.0.35",
+  "version": "1100.0.36",
   "description": "Commands for controlling the cache",
   "keywords": [
     "pnpm",

--- a/pnpm11/cli/commands/package.json
+++ b/pnpm11/cli/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/cli.commands",
-  "version": "1100.0.33",
+  "version": "1100.0.34",
   "description": "Commands for pnpm CLI",
   "keywords": [
     "pnpm",

--- a/pnpm11/cli/default-reporter/package.json
+++ b/pnpm11/cli/default-reporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/cli.default-reporter",
-  "version": "1100.3.13",
+  "version": "1100.3.14",
   "description": "The default reporter of pnpm",
   "keywords": [
     "pnpm",

--- a/pnpm11/cli/meta/package.json
+++ b/pnpm11/cli/meta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/cli.meta",
-  "version": "1100.0.12",
+  "version": "1100.0.13",
   "description": "Reads the metainfo of the currently running pnpm instance",
   "keywords": [
     "pnpm",

--- a/pnpm11/cli/utils/package.json
+++ b/pnpm11/cli/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/cli.utils",
-  "version": "1101.0.20",
+  "version": "1101.0.21",
   "description": "Utils for pnpm commands",
   "keywords": [
     "pnpm",

--- a/pnpm11/config/commands/package.json
+++ b/pnpm11/config/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/config.commands",
-  "version": "1100.0.34",
+  "version": "1100.0.35",
   "description": "Commands for reading and writing settings to/from config files",
   "keywords": [
     "pnpm",

--- a/pnpm11/config/normalize-registries/package.json
+++ b/pnpm11/config/normalize-registries/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/config.normalize-registries",
-  "version": "1100.0.12",
+  "version": "1100.0.13",
   "description": "Accepts a mapping of registry URLs and returns a mapping with the same URLs but normalized",
   "keywords": [
     "pnpm",

--- a/pnpm11/config/package-is-installable/package.json
+++ b/pnpm11/config/package-is-installable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/config.package-is-installable",
-  "version": "1100.1.0",
+  "version": "1100.1.1",
   "description": "Checks if a package is installable on the current system",
   "keywords": [
     "pnpm",

--- a/pnpm11/config/pick-registry-for-package/package.json
+++ b/pnpm11/config/pick-registry-for-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/config.pick-registry-for-package",
-  "version": "1100.0.13",
+  "version": "1100.0.14",
   "description": "Picks the right registry for the package from a registries config",
   "keywords": [
     "pnpm",

--- a/pnpm11/config/reader/package.json
+++ b/pnpm11/config/reader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/config.reader",
-  "version": "1101.15.0",
+  "version": "1101.15.1",
   "description": "Gets configuration options for pnpm",
   "keywords": [
     "pnpm",

--- a/pnpm11/config/version-policy/package.json
+++ b/pnpm11/config/version-policy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/config.version-policy",
-  "version": "1100.1.10",
+  "version": "1100.1.11",
   "description": "Parses and evaluates package version policy specs and produces package-version matchers",
   "keywords": [
     "pnpm",

--- a/pnpm11/config/writer/package.json
+++ b/pnpm11/config/writer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/config.writer",
-  "version": "1100.0.19",
+  "version": "1100.0.20",
   "description": "Functions for updating the configuration settings",
   "keywords": [
     "pnpm",

--- a/pnpm11/core/core-loggers/package.json
+++ b/pnpm11/core/core-loggers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/core-loggers",
-  "version": "1100.3.0",
+  "version": "1100.3.1",
   "description": "Core loggers of pnpm",
   "keywords": [
     "pnpm",

--- a/pnpm11/core/types/package.json
+++ b/pnpm11/core/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/types",
-  "version": "1101.7.0",
+  "version": "1101.8.0",
   "description": "Basic types used by pnpm",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/compliance/audit/package.json
+++ b/pnpm11/deps/compliance/audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.compliance.audit",
-  "version": "1101.0.27",
+  "version": "1101.0.28",
   "description": "Audit a lockfile",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/compliance/commands/package.json
+++ b/pnpm11/deps/compliance/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.compliance.commands",
-  "version": "1101.5.11",
+  "version": "1101.5.12",
   "description": "pnpm commands for audit, licenses, and sbom",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/compliance/license-scanner/package.json
+++ b/pnpm11/deps/compliance/license-scanner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.compliance.license-scanner",
-  "version": "1100.0.31",
+  "version": "1100.0.32",
   "description": "Check for licenses packages",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/compliance/sbom/package.json
+++ b/pnpm11/deps/compliance/sbom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.compliance.sbom",
-  "version": "1100.3.9",
+  "version": "1100.3.10",
   "description": "Generate SBOM from pnpm lockfile",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/github-actions/package.json
+++ b/pnpm11/deps/github-actions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.github-actions",
-  "version": "1100.1.1",
+  "version": "1100.1.2",
   "description": "Discover and update GitHub Actions dependencies",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/graph-builder/package.json
+++ b/pnpm11/deps/graph-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.graph-builder",
-  "version": "1100.1.0",
+  "version": "1100.1.1",
   "description": "A package for building a dependency graph from a lockfile",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/graph-hasher/package.json
+++ b/pnpm11/deps/graph-hasher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.graph-hasher",
-  "version": "1100.2.13",
+  "version": "1100.2.14",
   "description": "Calculates the state of a dependency",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/inspection/commands/package.json
+++ b/pnpm11/deps/inspection/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.inspection.commands",
-  "version": "1100.7.1",
+  "version": "1100.7.2",
   "description": "The list, ll, why, and outdated commands of pnpm",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/inspection/list/package.json
+++ b/pnpm11/deps/inspection/list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.inspection.list",
-  "version": "1100.0.30",
+  "version": "1100.0.31",
   "description": "List installed packages in a symlinked `node_modules`",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/inspection/outdated/package.json
+++ b/pnpm11/deps/inspection/outdated/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.inspection.outdated",
-  "version": "1100.1.21",
+  "version": "1100.1.22",
   "description": "Check for outdated packages",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/inspection/peers-checker/package.json
+++ b/pnpm11/deps/inspection/peers-checker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.inspection.peers-checker",
-  "version": "1100.0.24",
+  "version": "1100.0.25",
   "description": "Check for unmet and missing peer dependency issues from the lockfile",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/inspection/peers-issues-renderer/package.json
+++ b/pnpm11/deps/inspection/peers-issues-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.inspection.peers-issues-renderer",
-  "version": "1100.0.10",
+  "version": "1100.0.11",
   "description": "Visualizes peer dependency issues",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/inspection/tree-builder/package.json
+++ b/pnpm11/deps/inspection/tree-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.inspection.tree-builder",
-  "version": "1100.0.25",
+  "version": "1100.0.26",
   "description": "Creates a dependencies hierarchy for a symlinked `node_modules`",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/path/package.json
+++ b/pnpm11/deps/path/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.path",
-  "version": "1100.0.12",
+  "version": "1100.0.13",
   "description": "Utilities for working with symlinked node_modules",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/security/signatures/package.json
+++ b/pnpm11/deps/security/signatures/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.security.signatures",
-  "version": "1101.2.8",
+  "version": "1101.2.9",
   "description": "Verify package signatures from npm registries",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/status/package.json
+++ b/pnpm11/deps/status/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.status",
-  "version": "1100.1.13",
+  "version": "1100.1.14",
   "description": "Check dependencies status",
   "keywords": [
     "pnpm",

--- a/pnpm11/engine/pm/commands/package.json
+++ b/pnpm11/engine/pm/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/engine.pm.commands",
-  "version": "1101.3.0",
+  "version": "1101.3.1",
   "description": "pnpm commands for self-updating and setting up pnpm",
   "keywords": [
     "pnpm",

--- a/pnpm11/engine/runtime/bun-resolver/package.json
+++ b/pnpm11/engine/runtime/bun-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/engine.runtime.bun-resolver",
-  "version": "1102.0.12",
+  "version": "1102.0.13",
   "description": "Resolves the Bun runtime",
   "keywords": [
     "pnpm",

--- a/pnpm11/engine/runtime/commands/package.json
+++ b/pnpm11/engine/runtime/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/engine.runtime.commands",
-  "version": "1100.1.17",
+  "version": "1100.1.18",
   "description": "pnpm commands for managing runtimes",
   "keywords": [
     "pnpm",

--- a/pnpm11/engine/runtime/deno-resolver/package.json
+++ b/pnpm11/engine/runtime/deno-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/engine.runtime.deno-resolver",
-  "version": "1102.0.12",
+  "version": "1102.0.13",
   "description": "Resolves the Deno runtime",
   "keywords": [
     "pnpm",

--- a/pnpm11/engine/runtime/node-resolver/package.json
+++ b/pnpm11/engine/runtime/node-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/engine.runtime.node-resolver",
-  "version": "1101.1.19",
+  "version": "1101.1.20",
   "description": "Resolves a Node.js version specifier to an exact Node.js version",
   "keywords": [
     "pnpm",

--- a/pnpm11/engine/runtime/system-version/package.json
+++ b/pnpm11/engine/runtime/system-version/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/engine.runtime.system-version",
-  "version": "1100.0.7",
+  "version": "1100.0.8",
   "description": "Detects the current system version of supported runtimes (Node.js, Deno, Bun)",
   "keywords": [
     "pnpm",

--- a/pnpm11/exec/commands/package.json
+++ b/pnpm11/exec/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/exec.commands",
-  "version": "1100.4.5",
+  "version": "1100.4.6",
   "description": "Commands for running scripts",
   "keywords": [
     "pnpm",

--- a/pnpm11/exec/lifecycle/package.json
+++ b/pnpm11/exec/lifecycle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/exec.lifecycle",
-  "version": "1100.1.9",
+  "version": "1100.1.10",
   "description": "Package lifecycle hook runner",
   "keywords": [
     "pnpm",

--- a/pnpm11/exec/prepare-package/package.json
+++ b/pnpm11/exec/prepare-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/exec.prepare-package",
-  "version": "1100.0.28",
+  "version": "1100.0.29",
   "description": "Prepares a Git-hosted package",
   "keywords": [
     "pnpm",

--- a/pnpm11/fetching/binary-fetcher/package.json
+++ b/pnpm11/fetching/binary-fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/fetching.binary-fetcher",
-  "version": "1102.0.7",
+  "version": "1102.0.8",
   "description": "A fetcher for binary archives",
   "keywords": [
     "pnpm",

--- a/pnpm11/fetching/directory-fetcher/package.json
+++ b/pnpm11/fetching/directory-fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/fetching.directory-fetcher",
-  "version": "1100.0.26",
+  "version": "1100.0.27",
   "description": "A fetcher for local directory packages",
   "keywords": [
     "pnpm",

--- a/pnpm11/fetching/fetcher-base/package.json
+++ b/pnpm11/fetching/fetcher-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/fetching.fetcher-base",
-  "version": "1100.2.5",
+  "version": "1100.2.6",
   "description": "Types for pnpm-compatible fetchers",
   "keywords": [
     "pnpm",

--- a/pnpm11/fetching/git-fetcher/package.json
+++ b/pnpm11/fetching/git-fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/fetching.git-fetcher",
-  "version": "1102.0.10",
+  "version": "1102.0.11",
   "description": "A fetcher for git-hosted packages",
   "keywords": [
     "pnpm",

--- a/pnpm11/fetching/pick-fetcher/package.json
+++ b/pnpm11/fetching/pick-fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/fetching.pick-fetcher",
-  "version": "1100.1.4",
+  "version": "1100.1.5",
   "description": "Pick a package fetcher by type",
   "keywords": [
     "pnpm",

--- a/pnpm11/fetching/tarball-fetcher/package.json
+++ b/pnpm11/fetching/tarball-fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/fetching.tarball-fetcher",
-  "version": "1102.0.10",
+  "version": "1102.0.11",
   "description": "Fetcher for packages hosted as tarballs",
   "keywords": [
     "pnpm",

--- a/pnpm11/fs/indexed-pkg-importer/package.json
+++ b/pnpm11/fs/indexed-pkg-importer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/fs.indexed-pkg-importer",
-  "version": "1100.0.22",
+  "version": "1100.0.23",
   "description": "Replicates indexed directories using hard links, copies, or cloning",
   "keywords": [
     "pnpm",

--- a/pnpm11/fs/symlink-dependency/package.json
+++ b/pnpm11/fs/symlink-dependency/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/fs.symlink-dependency",
-  "version": "1100.0.15",
+  "version": "1100.0.16",
   "description": "Symlink a dependency to node_modules",
   "keywords": [
     "pnpm",

--- a/pnpm11/global/commands/package.json
+++ b/pnpm11/global/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/global.commands",
-  "version": "1100.0.41",
+  "version": "1100.0.42",
   "description": "Global package command handlers for pnpm",
   "keywords": [
     "pnpm",

--- a/pnpm11/global/packages/package.json
+++ b/pnpm11/global/packages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/global.packages",
-  "version": "1100.0.14",
+  "version": "1100.0.15",
   "description": "Utilities for managing isolated global packages",
   "keywords": [
     "pnpm",

--- a/pnpm11/hooks/pnpmfile/package.json
+++ b/pnpm11/hooks/pnpmfile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/hooks.pnpmfile",
-  "version": "1100.0.23",
+  "version": "1100.0.24",
   "description": "Reading a .pnpmfile.cjs",
   "keywords": [
     "pnpm",

--- a/pnpm11/hooks/read-package-hook/package.json
+++ b/pnpm11/hooks/read-package-hook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/hooks.read-package-hook",
-  "version": "1100.2.0",
+  "version": "1100.2.1",
   "description": "Creates the default package reader hook used by pnpm",
   "keywords": [
     "pnpm",

--- a/pnpm11/hooks/types/package.json
+++ b/pnpm11/hooks/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/hooks.types",
-  "version": "1100.2.4",
+  "version": "1100.2.5",
   "description": "Types for hooks",
   "keywords": [
     "pnpm",

--- a/pnpm11/installing/client/package.json
+++ b/pnpm11/installing/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.client",
-  "version": "1100.3.0",
+  "version": "1100.3.1",
   "description": "Creates the package resolve and fetch functions",
   "keywords": [
     "pnpm",

--- a/pnpm11/installing/commands/package.json
+++ b/pnpm11/installing/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.commands",
-  "version": "1100.12.1",
+  "version": "1100.12.2",
   "description": "Commands for installation",
   "keywords": [
     "pnpm",

--- a/pnpm11/installing/context/package.json
+++ b/pnpm11/installing/context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.context",
-  "version": "1100.0.29",
+  "version": "1100.0.30",
   "description": "Gets context information about a project",
   "keywords": [
     "pnpm",

--- a/pnpm11/installing/dedupe/check/package.json
+++ b/pnpm11/installing/dedupe/check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.dedupe.check",
-  "version": "1100.1.6",
+  "version": "1100.1.7",
   "description": "Visualize pnpm dedupe --check issues.",
   "keywords": [
     "pnpm",

--- a/pnpm11/installing/deps-installer/package.json
+++ b/pnpm11/installing/deps-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.deps-installer",
-  "version": "1102.3.7",
+  "version": "1103.0.0",
   "description": "Fast, disk space efficient installation engine",
   "keywords": [
     "pnpm",

--- a/pnpm11/installing/deps-resolver/package.json
+++ b/pnpm11/installing/deps-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.deps-resolver",
-  "version": "1100.4.0",
+  "version": "1101.0.0",
   "description": "Resolves dependency graph of a package",
   "keywords": [
     "pnpm",

--- a/pnpm11/installing/deps-restorer/package.json
+++ b/pnpm11/installing/deps-restorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.deps-restorer",
-  "version": "1102.2.0",
+  "version": "1102.2.1",
   "description": "Fast installation using only pnpm-lock.yaml",
   "keywords": [
     "pnpm",

--- a/pnpm11/installing/env-installer/package.json
+++ b/pnpm11/installing/env-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.env-installer",
-  "version": "1102.0.13",
+  "version": "1102.0.14",
   "description": "Installer for configurational dependencies",
   "keywords": [
     "pnpm",

--- a/pnpm11/installing/linking/direct-dep-linker/package.json
+++ b/pnpm11/installing/linking/direct-dep-linker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.linking.direct-dep-linker",
-  "version": "1100.0.15",
+  "version": "1100.0.16",
   "description": "Fast installation using only pnpm-lock.yaml",
   "keywords": [
     "pnpm",

--- a/pnpm11/installing/linking/hoist/package.json
+++ b/pnpm11/installing/linking/hoist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.linking.hoist",
-  "version": "1100.0.23",
+  "version": "1100.0.24",
   "description": "Hoists dependencies in a node_modules created by pnpm",
   "keywords": [
     "pnpm",

--- a/pnpm11/installing/linking/modules-cleaner/package.json
+++ b/pnpm11/installing/linking/modules-cleaner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.linking.modules-cleaner",
-  "version": "1100.1.16",
+  "version": "1100.1.17",
   "description": "Exports util functions to clean up node_modules",
   "keywords": [
     "pnpm",

--- a/pnpm11/installing/linking/real-hoist/package.json
+++ b/pnpm11/installing/linking/real-hoist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.linking.real-hoist",
-  "version": "1100.1.10",
+  "version": "1100.1.11",
   "description": "Hoists dependencies in a node_modules created by pnpm",
   "keywords": [
     "pnpm",

--- a/pnpm11/installing/modules-yaml/package.json
+++ b/pnpm11/installing/modules-yaml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.modules-yaml",
-  "version": "1100.0.13",
+  "version": "1100.0.14",
   "description": "Reads/writes `node_modules/.modules.yaml`",
   "keywords": [
     "pnpm",

--- a/pnpm11/installing/package-requester/package.json
+++ b/pnpm11/installing/package-requester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.package-requester",
-  "version": "1102.1.7",
+  "version": "1102.1.8",
   "description": "Concurrent downloader of npm-compatible packages",
   "keywords": [
     "pnpm",

--- a/pnpm11/installing/read-projects-context/package.json
+++ b/pnpm11/installing/read-projects-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.read-projects-context",
-  "version": "1100.0.25",
+  "version": "1100.0.26",
   "description": "Reads the current state of projects from modules manifest",
   "keywords": [
     "pnpm",

--- a/pnpm11/lockfile/detect-dep-types/package.json
+++ b/pnpm11/lockfile/detect-dep-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/lockfile.detect-dep-types",
-  "version": "1100.0.17",
+  "version": "1100.0.18",
   "description": "Detect the types of dependencies",
   "keywords": [
     "pnpm",

--- a/pnpm11/lockfile/filtering/package.json
+++ b/pnpm11/lockfile/filtering/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/lockfile.filtering",
-  "version": "1100.2.0",
+  "version": "1100.2.1",
   "description": "Filters a lockfile",
   "keywords": [
     "pnpm",

--- a/pnpm11/lockfile/fs/package.json
+++ b/pnpm11/lockfile/fs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/lockfile.fs",
-  "version": "1100.1.15",
+  "version": "1100.1.16",
   "description": "Read/write pnpm-lock.yaml files",
   "keywords": [
     "pnpm",

--- a/pnpm11/lockfile/make-dedicated-lockfile/package.json
+++ b/pnpm11/lockfile/make-dedicated-lockfile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/lockfile.make-dedicated-lockfile",
-  "version": "1100.0.31",
+  "version": "1100.0.32",
   "description": "Creates a dedicated lockfile for a subset of workspace projects",
   "keywords": [
     "pnpm",

--- a/pnpm11/lockfile/merger/package.json
+++ b/pnpm11/lockfile/merger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/lockfile.merger",
-  "version": "1100.0.17",
+  "version": "1100.0.18",
   "description": "Merges lockfiles. Can automatically fix merge conflicts",
   "keywords": [
     "pnpm",

--- a/pnpm11/lockfile/preferred-versions/package.json
+++ b/pnpm11/lockfile/preferred-versions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/lockfile.preferred-versions",
-  "version": "1100.0.26",
+  "version": "1100.0.27",
   "description": "Get preferred version from lockfile",
   "keywords": [
     "pnpm",

--- a/pnpm11/lockfile/pruner/package.json
+++ b/pnpm11/lockfile/pruner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/lockfile.pruner",
-  "version": "1100.0.17",
+  "version": "1100.0.18",
   "description": "Prune a pnpm-lock.yaml",
   "keywords": [
     "pnpm",

--- a/pnpm11/lockfile/settings-checker/package.json
+++ b/pnpm11/lockfile/settings-checker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/lockfile.settings-checker",
-  "version": "1100.1.8",
+  "version": "1100.1.9",
   "description": "Utilities to check if lockfile settings are out-of-date",
   "keywords": [
     "pnpm",

--- a/pnpm11/lockfile/to-pnp/package.json
+++ b/pnpm11/lockfile/to-pnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/lockfile.to-pnp",
-  "version": "1100.1.10",
+  "version": "1100.1.11",
   "description": "Creates a Plug'n'Play file from a pnpm-lock.yaml",
   "keywords": [
     "pnpm",

--- a/pnpm11/lockfile/types/package.json
+++ b/pnpm11/lockfile/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/lockfile.types",
-  "version": "1100.0.17",
+  "version": "1100.0.18",
   "description": "Types for the pnpm-lock.yaml lockfile",
   "keywords": [
     "pnpm",

--- a/pnpm11/lockfile/utils/package.json
+++ b/pnpm11/lockfile/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/lockfile.utils",
-  "version": "1100.1.6",
+  "version": "1100.1.7",
   "description": "Utils for dealing with pnpm-lock.yaml",
   "keywords": [
     "pnpm",

--- a/pnpm11/lockfile/verification/package.json
+++ b/pnpm11/lockfile/verification/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/lockfile.verification",
-  "version": "1100.0.29",
+  "version": "1100.0.30",
   "description": "Checks a lockfile",
   "keywords": [
     "pnpm",

--- a/pnpm11/lockfile/walker/package.json
+++ b/pnpm11/lockfile/walker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/lockfile.walker",
-  "version": "1100.0.17",
+  "version": "1100.0.18",
   "description": "Walk over all the dependencies in a lockfile",
   "keywords": [
     "pnpm",

--- a/pnpm11/modules-mounter/daemon/package.json
+++ b/pnpm11/modules-mounter/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/modules-mounter.daemon",
-  "version": "1100.0.34",
+  "version": "1100.0.35",
   "description": "Mounts a node_modules directory with FUSE",
   "keywords": [
     "pnpm",

--- a/pnpm11/network/auth-header/package.json
+++ b/pnpm11/network/auth-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/network.auth-header",
-  "version": "1101.1.7",
+  "version": "1101.1.8",
   "description": "Gets the authorization header for the given URI",
   "keywords": [
     "pnpm",

--- a/pnpm11/network/fetch/package.json
+++ b/pnpm11/network/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/network.fetch",
-  "version": "1100.1.9",
+  "version": "1100.1.10",
   "description": "Native fetch with retries",
   "keywords": [
     "pnpm",

--- a/pnpm11/network/web-auth/package.json
+++ b/pnpm11/network/web-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/network.web-auth",
-  "version": "1101.3.0",
+  "version": "1101.4.0",
   "description": "Web-based authentication flow with QR code display and token polling",
   "keywords": [
     "pnpm",

--- a/pnpm11/patching/commands/package.json
+++ b/pnpm11/patching/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/patching.commands",
-  "version": "1100.1.18",
+  "version": "1100.1.19",
   "description": "Commands for creating patches",
   "keywords": [
     "pnpm",

--- a/pnpm11/patching/config/package.json
+++ b/pnpm11/patching/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/patching.config",
-  "version": "1100.0.13",
+  "version": "1100.0.14",
   "description": "Functions related to patching configurations",
   "keywords": [
     "pnpm",

--- a/pnpm11/pkg-manifest/commands/package.json
+++ b/pnpm11/pkg-manifest/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/pkg-manifest.commands",
-  "version": "1100.1.18",
+  "version": "1100.1.19",
   "description": "Commands for managing package.json",
   "keywords": [
     "pnpm",

--- a/pnpm11/pkg-manifest/reader/package.json
+++ b/pnpm11/pkg-manifest/reader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/pkg-manifest.reader",
-  "version": "1100.0.13",
+  "version": "1100.0.14",
   "description": "Read a package.json",
   "keywords": [
     "pnpm",

--- a/pnpm11/pkg-manifest/utils/package.json
+++ b/pnpm11/pkg-manifest/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/pkg-manifest.utils",
-  "version": "1100.2.13",
+  "version": "1100.3.0",
   "description": "Utils for dealing with package manifest",
   "keywords": [
     "pnpm",

--- a/pnpm11/pnpm/artifacts/darwin-arm64/package.json
+++ b/pnpm11/pnpm/artifacts/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/macos-arm64",
-  "version": "11.18.0",
+  "version": "11.19.0",
   "keywords": [
     "pnpm",
     "pnpm11",

--- a/pnpm11/pnpm/artifacts/exe/package.json
+++ b/pnpm11/pnpm/artifacts/exe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/exe",
-  "version": "11.18.0",
+  "version": "11.19.0",
   "description": "Fast, disk space efficient package manager",
   "keywords": [
     "pnpm",

--- a/pnpm11/pnpm/artifacts/linux-arm64-musl/package.json
+++ b/pnpm11/pnpm/artifacts/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/linuxstatic-arm64",
-  "version": "11.18.0",
+  "version": "11.19.0",
   "keywords": [
     "pnpm",
     "pnpm11",

--- a/pnpm11/pnpm/artifacts/linux-arm64/package.json
+++ b/pnpm11/pnpm/artifacts/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/linux-arm64",
-  "version": "11.18.0",
+  "version": "11.19.0",
   "keywords": [
     "pnpm",
     "pnpm11",

--- a/pnpm11/pnpm/artifacts/linux-x64-musl/package.json
+++ b/pnpm11/pnpm/artifacts/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/linuxstatic-x64",
-  "version": "11.18.0",
+  "version": "11.19.0",
   "keywords": [
     "pnpm",
     "pnpm11",

--- a/pnpm11/pnpm/artifacts/linux-x64/package.json
+++ b/pnpm11/pnpm/artifacts/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/linux-x64",
-  "version": "11.18.0",
+  "version": "11.19.0",
   "keywords": [
     "pnpm",
     "pnpm11",

--- a/pnpm11/pnpm/artifacts/win32-arm64/package.json
+++ b/pnpm11/pnpm/artifacts/win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/win-arm64",
-  "version": "11.18.0",
+  "version": "11.19.0",
   "keywords": [
     "pnpm",
     "pnpm11",

--- a/pnpm11/pnpm/artifacts/win32-x64/package.json
+++ b/pnpm11/pnpm/artifacts/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/win-x64",
-  "version": "11.18.0",
+  "version": "11.19.0",
   "keywords": [
     "pnpm",
     "pnpm11",

--- a/pnpm11/pnpm/package.json
+++ b/pnpm11/pnpm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnpm",
-  "version": "11.18.0",
+  "version": "11.19.0",
   "description": "Fast, disk space efficient package manager",
   "keywords": [
     "pnpm",

--- a/pnpm11/registry-access/client/package.json
+++ b/pnpm11/registry-access/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/registry-access.client",
-  "version": "1100.1.11",
+  "version": "1100.1.12",
   "description": "Low-level helpers for npm-registry HTTP endpoints (PUT dist-tag, PUT user, etc.)",
   "keywords": [
     "pnpm",

--- a/pnpm11/registry-access/commands/package.json
+++ b/pnpm11/registry-access/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/registry-access.commands",
-  "version": "1100.5.6",
+  "version": "1100.5.7",
   "description": "Commands for managing packages on the registry",
   "keywords": [
     "pnpm",

--- a/pnpm11/releasing/commands/package.json
+++ b/pnpm11/releasing/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/releasing.commands",
-  "version": "1100.8.0",
+  "version": "1100.8.1",
   "description": "Commands for deploy, pack, and publish",
   "keywords": [
     "pnpm",

--- a/pnpm11/releasing/exportable-manifest/package.json
+++ b/pnpm11/releasing/exportable-manifest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/releasing.exportable-manifest",
-  "version": "1100.2.0",
+  "version": "1100.2.1",
   "description": "Creates an exportable manifest",
   "keywords": [
     "pnpm",

--- a/pnpm11/releasing/versioning/package.json
+++ b/pnpm11/releasing/versioning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/releasing.versioning",
-  "version": "1100.2.2",
+  "version": "1100.2.3",
   "description": "Native workspace release management: change intents, release-plan assembly, and changelog writing",
   "keywords": [
     "pnpm",

--- a/pnpm11/resolving/default-resolver/package.json
+++ b/pnpm11/resolving/default-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/resolving.default-resolver",
-  "version": "1100.3.21",
+  "version": "1100.3.22",
   "description": "pnpm's default package resolver",
   "keywords": [
     "pnpm",

--- a/pnpm11/resolving/git-resolver/package.json
+++ b/pnpm11/resolving/git-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/resolving.git-resolver",
-  "version": "1100.1.13",
+  "version": "1100.1.14",
   "description": "Resolver for git-hosted packages",
   "keywords": [
     "pnpm",

--- a/pnpm11/resolving/local-resolver/package.json
+++ b/pnpm11/resolving/local-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/resolving.local-resolver",
-  "version": "1101.1.15",
+  "version": "1101.1.16",
   "description": "Resolver for local packages",
   "keywords": [
     "pnpm",

--- a/pnpm11/resolving/npm-resolver/package.json
+++ b/pnpm11/resolving/npm-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/resolving.npm-resolver",
-  "version": "1102.1.9",
+  "version": "1103.0.0",
   "description": "Resolver for npm-hosted packages",
   "keywords": [
     "pnpm",

--- a/pnpm11/resolving/registry/pkg-metadata-filter/package.json
+++ b/pnpm11/resolving/registry/pkg-metadata-filter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/resolving.registry.pkg-metadata-filter",
-  "version": "1100.0.13",
+  "version": "1100.0.14",
   "description": "Filters the package metadata from the registry",
   "keywords": [
     "pnpm",

--- a/pnpm11/resolving/registry/types/package.json
+++ b/pnpm11/resolving/registry/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/resolving.registry.types",
-  "version": "1100.1.7",
+  "version": "1100.1.8",
   "description": "Types related to the npm registry",
   "keywords": [
     "pnpm",

--- a/pnpm11/resolving/resolver-base/package.json
+++ b/pnpm11/resolving/resolver-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/resolving.resolver-base",
-  "version": "1100.5.5",
+  "version": "1101.0.0",
   "description": "Types for pnpm-compatible resolvers",
   "keywords": [
     "pnpm",

--- a/pnpm11/resolving/tarball-resolver/package.json
+++ b/pnpm11/resolving/tarball-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/resolving.tarball-resolver",
-  "version": "1100.1.10",
+  "version": "1100.1.11",
   "description": "Resolver for tarball dependencies",
   "keywords": [
     "pnpm",

--- a/pnpm11/store/cafs/package.json
+++ b/pnpm11/store/cafs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/store.cafs",
-  "version": "1100.1.16",
+  "version": "1100.1.17",
   "description": "A content-addressable filesystem for the packages storage",
   "keywords": [
     "pnpm",

--- a/pnpm11/store/commands/package.json
+++ b/pnpm11/store/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/store.commands",
-  "version": "1100.0.39",
+  "version": "1100.0.40",
   "description": "Commands for controlling and inspecting the store",
   "keywords": [
     "pnpm",

--- a/pnpm11/store/connection-manager/package.json
+++ b/pnpm11/store/connection-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/store.connection-manager",
-  "version": "1100.3.13",
+  "version": "1100.3.14",
   "description": "Create a pnpm store controller",
   "keywords": [
     "pnpm",

--- a/pnpm11/store/controller-types/package.json
+++ b/pnpm11/store/controller-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/store.controller-types",
-  "version": "1100.1.11",
+  "version": "1101.0.0",
   "description": "Types for the store controller",
   "keywords": [
     "pnpm",

--- a/pnpm11/store/controller/package.json
+++ b/pnpm11/store/controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/store.controller",
-  "version": "1102.0.9",
+  "version": "1102.0.10",
   "description": "A storage for packages",
   "keywords": [
     "pnpm",

--- a/pnpm11/store/create-cafs-store/package.json
+++ b/pnpm11/store/create-cafs-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/store.create-cafs-store",
-  "version": "1100.0.22",
+  "version": "1100.0.23",
   "description": "Create a CAFS store controller",
   "keywords": [
     "pnpm",

--- a/pnpm11/store/pkg-finder/package.json
+++ b/pnpm11/store/pkg-finder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/store.pkg-finder",
-  "version": "1100.0.26",
+  "version": "1100.0.27",
   "description": "Read a package's file map from the content-addressable store",
   "keywords": [
     "pnpm",

--- a/pnpm11/testing/temp-store/package.json
+++ b/pnpm11/testing/temp-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/testing.temp-store",
-  "version": "1100.1.22",
+  "version": "1100.1.23",
   "description": "A temporary store for testing purposes",
   "keywords": [
     "pnpm",

--- a/pnpm11/worker/package.json
+++ b/pnpm11/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/worker",
-  "version": "1100.2.8",
+  "version": "1100.2.9",
   "description": "A worker for extracting package tarballs to the store",
   "keywords": [
     "pnpm",

--- a/pnpm11/workspace/commands/package.json
+++ b/pnpm11/workspace/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/workspace.commands",
-  "version": "1100.1.32",
+  "version": "1100.1.33",
   "description": "Create a package.json file",
   "keywords": [
     "pnpm",

--- a/pnpm11/workspace/injected-deps-syncer/package.json
+++ b/pnpm11/workspace/injected-deps-syncer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/workspace.injected-deps-syncer",
-  "version": "1100.0.29",
+  "version": "1100.0.30",
   "description": "Update all injected replica of a workspace package",
   "keywords": [
     "pnpm",

--- a/pnpm11/workspace/project-manifest-reader/package.json
+++ b/pnpm11/workspace/project-manifest-reader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/workspace.project-manifest-reader",
-  "version": "1100.0.21",
+  "version": "1100.0.22",
   "description": "Read a project manifest (called package.json in most cases)",
   "keywords": [
     "pnpm",

--- a/pnpm11/workspace/project-manifest-writer/package.json
+++ b/pnpm11/workspace/project-manifest-writer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/workspace.project-manifest-writer",
-  "version": "1100.0.12",
+  "version": "1100.0.13",
   "description": "Write a project manifest (called package.json in most cases)",
   "keywords": [
     "pnpm",

--- a/pnpm11/workspace/projects-filter/package.json
+++ b/pnpm11/workspace/projects-filter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/workspace.projects-filter",
-  "version": "1100.0.33",
+  "version": "1100.0.34",
   "description": "Filters packages in a workspace",
   "keywords": [
     "pnpm",

--- a/pnpm11/workspace/projects-graph/package.json
+++ b/pnpm11/workspace/projects-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/workspace.projects-graph",
-  "version": "1100.0.29",
+  "version": "1100.0.30",
   "description": "Create a graph from an array of packages",
   "keywords": [
     "pnpm",

--- a/pnpm11/workspace/projects-reader/package.json
+++ b/pnpm11/workspace/projects-reader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/workspace.projects-reader",
-  "version": "1101.0.20",
+  "version": "1101.0.21",
   "description": "Finds packages inside a workspace",
   "keywords": [
     "pnpm",

--- a/pnpm11/workspace/projects-sorter/package.json
+++ b/pnpm11/workspace/projects-sorter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/workspace.projects-sorter",
-  "version": "1100.0.12",
+  "version": "1100.0.13",
   "description": "Sort packages",
   "keywords": [
     "pnpm",

--- a/pnpm11/workspace/state/package.json
+++ b/pnpm11/workspace/state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/workspace.state",
-  "version": "1100.0.34",
+  "version": "1100.0.35",
   "description": "Track the list of actual paths of workspace packages in a cache",
   "keywords": [
     "pnpm",

--- a/pnpm11/workspace/workspace-manifest-reader/package.json
+++ b/pnpm11/workspace/workspace-manifest-reader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/workspace.workspace-manifest-reader",
-  "version": "1100.1.3",
+  "version": "1100.1.4",
   "description": "Reads a workspace manifest file",
   "keywords": [
     "pnpm",

--- a/pnpm11/workspace/workspace-manifest-writer/package.json
+++ b/pnpm11/workspace/workspace-manifest-writer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/workspace.workspace-manifest-writer",
-  "version": "1100.0.19",
+  "version": "1100.0.20",
   "description": "Updates the workspace manifest file",
   "keywords": [
     "pnpm",

--- a/pnpr/client/package.json
+++ b/pnpr/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/pnpr.client",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "Client for the pnpr server — resolves a project server-side and receives the resolved lockfile",
   "keywords": [
     "pnpm",


### PR DESCRIPTION
Automated release PR created by the create-release-pr workflow.

Releasing `main`: 11.19.0. Merging this PR consumes the pending changesets and records them in the committed `.changeset/ledger.yaml`, then auto-tags each released product (tag-release.yml) to run the release workflow.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788079422&installation_model_id=426870&pr_number=13524&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13524&signature=bf5eb7c2ef72eeab402aeae4d2bc16ca2e11f94c95a73755568b76f432b035ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `pnpm login` now supports browser-based authentication in non-interactive environments by displaying an approval URL and waiting for confirmation.
  * Git-hosted tarball dependencies are matched more reliably by build approvals.
  * `pnpm update` preserves exact-version specifications and explicit `=` prefixes.
  * Workspace commands better retain relative and `link:` dependency relationships.
* **Bug Fixes**
  * Improved handling of release-age restrictions, bundled dependencies, install hints, and private GitHub Action repositories.
* **Release**
  * Updated pnpm to version 11.19.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->