### PR TITLE
fix(deps-installer): skip no-save updates to versions the kept range excludes

### DIFF
--- a/.changeset/update-no-save-respects-kept-range.md
+++ b/.changeset/update-no-save-respects-kept-range.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.deps-installer": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+`pnpm update <pkg>@<version>` without saving no longer records a version that the manifest's range excludes. The kept range stays authoritative: a requested version outside it is skipped with a warning instead of producing a lockfile that the next frozen install rejects with `ERR_PNPM_OUTDATED_LOCKFILE` [#12764](https://github.com/pnpm/pnpm/issues/12764).

--- a/.changeset/update-no-save-respects-kept-range.md
+++ b/.changeset/update-no-save-respects-kept-range.md
@@ -4,4 +4,4 @@
 "pacquet": patch
 ---
 
-`pnpm update <pkg>@<version>` without saving no longer records a version that the manifest's range excludes. The kept range stays authoritative: a requested version outside it is skipped with a warning instead of producing a lockfile that the next frozen install rejects with `ERR_PNPM_OUTDATED_LOCKFILE` [#12764](https://github.com/pnpm/pnpm/issues/12764).
+`pnpm update` without saving no longer records a version that the manifest's range excludes. The kept range stays authoritative: a requested version outside it is skipped with a warning, and a requested range, a dist tag, or `--latest` resolves within it instead of past it. Previously each of these could write a lockfile entry that contradicted its own specifier, which the next `pnpm install --frozen-lockfile` rejected with `ERR_PNPM_OUTDATED_LOCKFILE` [#12764](https://github.com/pnpm/pnpm/issues/12764).

--- a/pnpm/crates/cli/tests/update.rs
+++ b/pnpm/crates/cli/tests/update.rs
@@ -1296,3 +1296,34 @@ fn update_latest_preserves_local_protocol_dependencies() {
 
     drop((root, anchor));
 }
+
+/// A versioned selector under `--no-save` is skipped when the requested
+/// version falls outside the range the manifest keeps: recording it would
+/// produce a lockfile the next frozen install rejects. Regression test for
+/// <https://github.com/pnpm/pnpm/issues/12764>.
+#[test]
+fn update_no_save_skips_version_outside_kept_range() {
+    let (root, workspace, anchor) = setup();
+
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "^100.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+    assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.1.0"));
+
+    pacquet(&workspace, ["update", "--no-save", &format!("{DEP}@101.0.0")]).assert().success();
+
+    // package.json keeps its range, and the dependency stays untouched.
+    assert_eq!(dep_spec(&workspace, DEP).as_deref(), Some("^100.0.0"));
+    let lock = fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read pnpm-lock.yaml");
+    assert!(
+        lock.contains("specifier: ^100.0.0"),
+        "the lockfile importer entry must keep the manifest's specifier",
+    );
+    assert!(
+        !lock.contains("dep-of-pkg-with-1-dep@101.0.0"),
+        "the out-of-range requested version must not be recorded",
+    );
+    // The lockfile still satisfies the manifest.
+    pacquet(&workspace, ["install", "--frozen-lockfile"]).assert().success();
+
+    drop((root, anchor));
+}

--- a/pnpm/crates/cli/tests/update.rs
+++ b/pnpm/crates/cli/tests/update.rs
@@ -1309,7 +1309,15 @@ fn update_no_save_skips_version_outside_kept_range() {
     pacquet(&workspace, ["install"]).assert().success();
     assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.1.0"));
 
-    pacquet(&workspace, ["update", "--no-save", &format!("{DEP}@101.0.0")]).assert().success();
+    let output = pacquet(&workspace, ["update", "--no-save", &format!("{DEP}@101.0.0")])
+        .output()
+        .expect("run update --no-save");
+    assert!(output.status.success(), "update --no-save failed: {output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(&format!(r#"Skipping "{DEP}@101.0.0""#)),
+        "the skipped dependency must be reported to the user: {stdout}",
+    );
 
     // package.json keeps its range, and the dependency stays untouched.
     assert_eq!(dep_spec(&workspace, DEP).as_deref(), Some("^100.0.0"));

--- a/pnpm/crates/cli/tests/update.rs
+++ b/pnpm/crates/cli/tests/update.rs
@@ -433,23 +433,35 @@ fn update_latest_with_negation_selector() {
 
 /// `--no-save` bumps the lockfile but leaves `package.json` untouched —
 /// ports pnpm's "update --no-save should not update package.json" test.
+/// The bump stays inside the kept range: `--latest` would reach 101.0.0,
+/// which the retained `^100.0.0` cannot record.
 #[test]
 fn update_latest_no_save_keeps_manifest() {
     let (root, workspace, anchor) = setup();
 
-    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "^100.0.0" }}"#));
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "100.0.0" }}"#));
     pacquet(&workspace, ["install"]).assert().success();
     eprintln!("virtual store contents: {:?}", list_virtual_store(&workspace));
-    assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.1.0"));
+    assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.0.0"));
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "^100.0.0" }}"#));
 
-    pacquet(&workspace, ["update", "--latest", "--no-save"]).assert().success();
+    let output = pacquet(&workspace, ["update", "--latest", "--no-save"])
+        .output()
+        .expect("run update --latest --no-save");
+    assert!(output.status.success(), "update --latest --no-save failed: {output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(r#"Ignoring "--latest""#),
+        "the ignored --latest must be reported to the user: {stdout}",
+    );
 
     // package.json range is unchanged...
     assert_eq!(dep_spec(&workspace, DEP).as_deref(), Some("^100.0.0"));
-    // ...but the lockfile/store was re-resolved (101.0.0 is latest; the
-    // in-memory `^101.0.0` drove resolution even though it wasn't saved).
+    // ...and the lockfile/store re-resolved to the highest version it admits.
     eprintln!("virtual store contents: {:?}", list_virtual_store(&workspace));
-    assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@101.0.0"));
+    assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.1.0"));
+    assert!(!virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@101.0.0"));
+    pacquet(&workspace, ["install", "--frozen-lockfile"]).assert().success();
 
     drop((root, anchor));
 }
@@ -941,29 +953,35 @@ fn update_latest_catalog_preserves_reference_and_operator() {
 }
 
 /// `--latest --no-save` on a `catalog:` dependency leaves `package.json`
-/// and `pnpm-workspace.yaml` untouched, but still re-resolves the lockfile
-/// to the bumped version. The bumped catalog drives resolution in memory
-/// (via the install's catalogs override) without being persisted to disk —
-/// matching how a non-catalog `--no-save` update bumps the lockfile.
+/// and `pnpm-workspace.yaml` untouched, but still re-resolves the lockfile.
+/// The catalog entry is what the dependency keeps, so it bounds the bump the
+/// same way a range in `package.json` does.
 #[test]
 fn update_latest_no_save_catalog_bumps_lockfile_only() {
     let (root, workspace, anchor) = setup();
 
-    set_named_catalog(&workspace, "grp1", &[(DEP, "~100.0.0")]);
+    set_named_catalog(&workspace, "grp1", &[(DEP, "100.0.0")]);
     write_manifest(&workspace, &format!(r#"{{ "{DEP}": "catalog:grp1" }}"#));
     pacquet(&workspace, ["install"]).assert().success();
     assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.0.0"));
+
+    let yaml_path = workspace.join("pnpm-workspace.yaml");
+    let widened = read_workspace_yaml(&workspace).replace(r#""100.0.0""#, r#""^100.0.0""#);
+    fs::write(&yaml_path, widened).expect("widen the catalog entry");
 
     pacquet(&workspace, ["update", "--latest", "--no-save"]).assert().success();
 
     // package.json and the workspace catalog are untouched...
     assert_eq!(dep_spec(&workspace, DEP).as_deref(), Some("catalog:grp1"));
     let yaml = read_workspace_yaml(&workspace);
-    assert!(yaml.contains("~100.0.0"), "catalog entry must be untouched under --no-save: {yaml}");
+    assert!(yaml.contains("^100.0.0"), "catalog entry must be untouched under --no-save: {yaml}");
 
-    // ...but the lockfile/store re-resolved to the bumped version.
+    // ...and the lockfile/store re-resolved to the highest version the catalog
+    // entry admits, not to the 101.0.0 `--latest` would otherwise reach.
     eprintln!("virtual store contents: {:?}", list_virtual_store(&workspace));
-    assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@101.0.0"));
+    assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.1.0"));
+    assert!(!virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@101.0.0"));
+    pacquet(&workspace, ["install", "--frozen-lockfile"]).assert().success();
 
     drop((root, anchor));
 }
@@ -1331,6 +1349,37 @@ fn update_no_save_skips_version_outside_kept_range() {
         "the out-of-range requested version must not be recorded",
     );
     // The lockfile still satisfies the manifest.
+    pacquet(&workspace, ["install", "--frozen-lockfile"]).assert().success();
+
+    drop((root, anchor));
+}
+
+/// A requested range names no version until resolution runs, so the specifier
+/// the manifest keeps decides — `>=101.0.0` cannot pull the lockfile past
+/// `^100.0.0`. Regression test for
+/// <https://github.com/pnpm/pnpm/issues/12764>.
+#[test]
+fn update_no_save_resolves_a_requested_range_within_the_kept_range() {
+    let (root, workspace, anchor) = setup();
+
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "100.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "^100.0.0" }}"#));
+
+    let output = pacquet(&workspace, ["update", "--no-save", &format!("{DEP}@>=101.0.0")])
+        .output()
+        .expect("run update --no-save");
+    assert!(output.status.success(), "update --no-save failed: {output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(&format!(r#"Ignoring "{DEP}@>=101.0.0""#)),
+        "the superseded selector must be reported to the user: {stdout}",
+    );
+
+    assert_eq!(dep_spec(&workspace, DEP).as_deref(), Some("^100.0.0"));
+    eprintln!("virtual store contents: {:?}", list_virtual_store(&workspace));
+    assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.1.0"));
+    assert!(!virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@101.0.0"));
     pacquet(&workspace, ["install", "--frozen-lockfile"]).assert().success();
 
     drop((root, anchor));

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -712,12 +712,12 @@ async fn prepare_manifest<Reporter: self::Reporter>(
                     // An update that doesn't save keeps the manifest's
                     // specifier, and the lockfile importer entry has to keep
                     // satisfying it — a frozen install rejects the lockfile
-                    // otherwise. Only apply the requested specifier when
-                    // every version it allows stays inside the kept range;
-                    // skip the dependency in this project otherwise.
+                    // otherwise. Only apply a requested version that the kept
+                    // range admits; skip the dependency in this project
+                    // otherwise.
                     if !save
                         && let Some(requested) = requested.as_deref()
-                        && !stays_within_kept_range(requested, previous)
+                        && !requested_version_fits_kept_range(requested, previous)
                     {
                         Reporter::emit(&LogEvent::Pnpm(PnpmLog {
                             level: LogLevel::Warn,
@@ -1062,16 +1062,21 @@ fn pick_workspace_version(versions: &WorkspacePackagesByVersion, range: &str) ->
     resolve_workspace_range(range, &versions.keys().cloned().collect::<Vec<_>>())
 }
 
-/// Whether every version the requested specifier allows stays inside the
-/// range the manifest keeps. Specifiers that aren't semver ranges (dist-tags,
-/// `workspace:`, `catalog:`) can't be judged statically and pass through.
-fn stays_within_kept_range(requested: &str, kept: &str) -> bool {
+/// Whether the requested version satisfies the range the manifest keeps.
+///
+/// Only a concrete version can be judged here. Matching a version against a
+/// range is exact; deciding whether one *range* is contained by another is
+/// not — implementations disagree around prerelease boundaries. So a
+/// requested range (`>=6`) or dist tag (`latest`) is left alone: it has no
+/// version yet, and the reliable place to judge it is against the version
+/// resolution settles on.
+fn requested_version_fits_kept_range(requested: &str, kept: &str) -> bool {
     let (Ok(requested), Ok(kept)) =
-        (node_semver::Range::parse(requested), node_semver::Range::parse(kept))
+        (node_semver::Version::parse(requested), node_semver::Range::parse(kept))
     else {
         return true;
     };
-    kept.allows_all(&requested)
+    requested.satisfies(&kept)
 }
 
 /// Compile a single pattern into a matcher. Used to map a matched direct

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -697,18 +697,38 @@ async fn prepare_manifest<Reporter: self::Reporter>(
             }
         } else {
             for (name, group, previous) in &matched_direct {
-                drop_names.insert(name.clone());
                 // The two sources are exclusive: `--latest` rejects versioned
                 // selectors above, so under it no selector carries a version.
                 let rewrite = if latest {
                     latest_specifier(&rewrite_ctx, latest_chain, &mut catalog_ctx, name, previous)
                         .await?
                 } else {
-                    selectors
+                    let requested = selectors
                         .iter()
                         .find(|selector| matcher_one(&selector.pattern).matches(name))
-                        .and_then(|selector| selector.version.clone())
+                        .and_then(|selector| selector.version.clone());
+                    // An update that doesn't save keeps the manifest's
+                    // specifier, and the lockfile importer entry has to keep
+                    // satisfying it — a frozen install rejects the lockfile
+                    // otherwise. Only apply the requested specifier when
+                    // every version it allows stays inside the kept range;
+                    // skip the dependency in this project otherwise.
+                    if !save
+                        && let Some(requested) = requested.as_deref()
+                        && !stays_within_kept_range(requested, previous)
+                    {
+                        tracing::warn!(
+                            target: "pacquet_package_manager::update",
+                            name,
+                            requested,
+                            kept = previous,
+                            r#"Skipping "{name}@{requested}": it doesn't satisfy "{previous}", which the manifest keeps when updating without saving."#,
+                        );
+                        continue;
+                    }
+                    requested
                 };
+                drop_names.insert(name.clone());
                 if let Some(specifier) = rewrite {
                     rewrites.push((name.clone(), *group, specifier));
                 }
@@ -1038,6 +1058,18 @@ fn workspace_specifier(
 fn pick_workspace_version(versions: &WorkspacePackagesByVersion, range: &str) -> Option<String> {
     let range = if node_semver::Range::parse(range).is_ok() { range } else { "*" };
     resolve_workspace_range(range, &versions.keys().cloned().collect::<Vec<_>>())
+}
+
+/// Whether every version the requested specifier allows stays inside the
+/// range the manifest keeps. Specifiers that aren't semver ranges (dist-tags,
+/// `workspace:`, `catalog:`) can't be judged statically and pass through.
+fn stays_within_kept_range(requested: &str, kept: &str) -> bool {
+    let (Ok(requested), Ok(kept)) =
+        (node_semver::Range::parse(requested), node_semver::Range::parse(kept))
+    else {
+        return true;
+    };
+    kept.allows_all(&requested)
 }
 
 /// Compile a single pattern into a matcher. Used to map a matched direct

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -101,10 +101,12 @@ pub struct Update<'a> {
     /// to dependencies whose current specifier has no recoverable pin; an
     /// existing `^`/`~`/exact range is preserved over this default.
     pub save_exact: bool,
-    /// `--save` (default) / `--no-save`. When `false`, the manifest is
-    /// not persisted: the `--latest` / versioned-selector range rewrites
-    /// still drive resolution (so `pnpm-lock.yaml` updates) but
-    /// `package.json` on disk is left untouched.
+    /// `--save` (default) / `--no-save`. When `false`, `package.json` on
+    /// disk is left untouched, so its specifiers stay authoritative:
+    /// `pnpm-lock.yaml` still updates, but only within the ranges the
+    /// manifest keeps, since the importer entry has to keep satisfying the
+    /// specifier it records. A requested version those ranges exclude is
+    /// skipped, and `--latest` degrades to a compatible bump.
     pub save: bool,
     /// Dependency groups the update considers when choosing which direct
     /// dependencies to match, derived from
@@ -612,11 +614,15 @@ async fn prepare_manifest<Reporter: self::Reporter>(
         let ignore_matcher = (!ignore_patterns.is_empty()).then(|| create_matcher(ignore_patterns));
         let is_ignored =
             |name: &str| ignore_matcher.as_ref().is_some_and(|matcher| matcher.matches(name));
+        if latest && !save {
+            emit_latest_ignored::<Reporter>(rewrite_ctx.manifest);
+        }
         for (name, group, previous) in &direct {
             if is_ignored(name) {
                 continue;
             }
             if latest
+                && save
                 && let Some(specifier) =
                     latest_specifier(&rewrite_ctx, latest_chain, &mut catalog_ctx, name, previous)
                         .await?
@@ -698,37 +704,63 @@ async fn prepare_manifest<Reporter: self::Reporter>(
                 );
             }
         } else {
+            if latest && !save {
+                emit_latest_ignored::<Reporter>(rewrite_ctx.manifest);
+            }
             for (name, group, previous) in &matched_direct {
                 // The two sources are exclusive: `--latest` rejects versioned
                 // selectors above, so under it no selector carries a version.
                 let rewrite = if latest {
-                    latest_specifier(&rewrite_ctx, latest_chain, &mut catalog_ctx, name, previous)
+                    // `--latest` reaches past the declared range by design,
+                    // which a manifest that keeps its specifiers can't record.
+                    if save {
+                        latest_specifier(
+                            &rewrite_ctx,
+                            latest_chain,
+                            &mut catalog_ctx,
+                            name,
+                            previous,
+                        )
                         .await?
+                    } else {
+                        None
+                    }
                 } else {
                     let requested = selectors
                         .iter()
                         .find(|selector| matcher_one(&selector.pattern).matches(name))
                         .and_then(|selector| selector.version.clone());
                     // An update that doesn't save keeps the manifest's
-                    // specifier, and the lockfile importer entry has to keep
-                    // satisfying it — a frozen install rejects the lockfile
-                    // otherwise. Only apply a requested version that the kept
-                    // range admits; skip the dependency in this project
+                    // specifier, and whatever resolution settles on has to
+                    // satisfy it — a frozen install rejects the lockfile
                     // otherwise.
-                    if !save
-                        && let Some(requested) = requested.as_deref()
-                        && !requested_version_fits_kept_range(requested, previous)
-                    {
-                        Reporter::emit(&LogEvent::Pnpm(PnpmLog {
-                            level: LogLevel::Warn,
-                            message: format!(
-                                r#"Skipping "{name}@{requested}": it doesn't satisfy "{previous}", which the manifest keeps when updating without saving."#,
-                            ),
-                            prefix: package_manifest_prefix(rewrite_ctx.manifest),
-                        }));
-                        continue;
+                    if !save && let Some(requested) = requested.as_deref() {
+                        match judge_against_kept_range(requested, previous) {
+                            KeptRangeVerdict::Admitted => Some(requested.to_string()),
+                            KeptRangeVerdict::Excluded => {
+                                Reporter::emit(&LogEvent::Pnpm(PnpmLog {
+                                    level: LogLevel::Warn,
+                                    message: format!(
+                                        r#"Skipping "{name}@{requested}": it doesn't satisfy "{previous}", which the manifest keeps when updating without saving."#,
+                                    ),
+                                    prefix: package_manifest_prefix(rewrite_ctx.manifest),
+                                }));
+                                continue;
+                            }
+                            KeptRangeVerdict::Undecided => {
+                                Reporter::emit(&LogEvent::Pnpm(PnpmLog {
+                                    level: LogLevel::Warn,
+                                    message: format!(
+                                        r#"Ignoring "{name}@{requested}": the manifest keeps "{previous}" when updating without saving, so "{name}" was updated within that range instead."#,
+                                    ),
+                                    prefix: package_manifest_prefix(rewrite_ctx.manifest),
+                                }));
+                                None
+                            }
+                        }
+                    } else {
+                        requested
                     }
-                    requested
                 };
                 drop_names.insert(name.clone());
                 if let Some(specifier) = rewrite {
@@ -1062,21 +1094,45 @@ fn pick_workspace_version(versions: &WorkspacePackagesByVersion, range: &str) ->
     resolve_workspace_range(range, &versions.keys().cloned().collect::<Vec<_>>())
 }
 
-/// Whether the requested version satisfies the range the manifest keeps.
+/// `--latest` reaches past the declared range by design, which a manifest that
+/// keeps its specifiers can't record, so the update stays inside the range and
+/// says so once per project.
+fn emit_latest_ignored<Reporter: self::Reporter>(manifest: &PackageManifest) {
+    Reporter::emit(&LogEvent::Pnpm(PnpmLog {
+        level: LogLevel::Warn,
+        message: r#"Ignoring "--latest": the manifest keeps its version ranges when updating without saving, so dependencies were updated within them instead."#.to_string(),
+        prefix: package_manifest_prefix(manifest),
+    }));
+}
+
+/// What an update that doesn't save may do with a requested specifier, given
+/// the specifier the manifest keeps.
+enum KeptRangeVerdict {
+    /// A version the kept range admits: resolution can be pointed at it.
+    Admitted,
+    /// A version the kept range excludes: the dependency is left alone.
+    Excluded,
+    /// Nothing that can be judged before resolution — a range or a dist tag,
+    /// which names a version only once resolution has run, or a kept
+    /// specifier that isn't a semver range. The kept specifier decides.
+    Undecided,
+}
+
+/// Judge a requested specifier against the range the manifest keeps.
 ///
-/// Only a concrete version can be judged here. Matching a version against a
-/// range is exact; deciding whether one *range* is contained by another is
-/// not — implementations disagree around prerelease boundaries. So a
-/// requested range (`>=6`) or dist tag (`latest`) is left alone: it has no
-/// version yet, and the reliable place to judge it is against the version
-/// resolution settles on.
-fn requested_version_fits_kept_range(requested: &str, kept: &str) -> bool {
+/// Only a concrete version gets a verdict. Matching a version against a range
+/// is exact; deciding whether one *range* is contained by another is not —
+/// implementations disagree around prerelease boundaries — so a range is left
+/// [`Undecided`] rather than guessed at.
+///
+/// [`Undecided`]: KeptRangeVerdict::Undecided
+fn judge_against_kept_range(requested: &str, kept: &str) -> KeptRangeVerdict {
     let (Ok(requested), Ok(kept)) =
         (node_semver::Version::parse(requested), node_semver::Range::parse(kept))
     else {
-        return true;
+        return KeptRangeVerdict::Undecided;
     };
-    requested.satisfies(&kept)
+    if requested.satisfies(&kept) { KeptRangeVerdict::Admitted } else { KeptRangeVerdict::Excluded }
 }
 
 /// Compile a single pattern into a matcher. Used to map a matched direct

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -28,7 +28,9 @@ use pacquet_lockfile::{Lockfile, MaybeLazyLockfile};
 use pacquet_network::ThrottledClient;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest, PackageManifestError};
 use pacquet_registry::RangeSpecStyle;
-use pacquet_reporter::{LogEvent, LogLevel, PackageManifestLog, PackageManifestMessage, Reporter};
+use pacquet_reporter::{
+    LogEvent, LogLevel, PackageManifestLog, PackageManifestMessage, PnpmLog, Reporter,
+};
 use pacquet_resolving_default_resolver::DefaultResolver;
 use pacquet_resolving_deps_resolver::UpdateDepth;
 use pacquet_resolving_npm_resolver::{
@@ -717,13 +719,13 @@ async fn prepare_manifest<Reporter: self::Reporter>(
                         && let Some(requested) = requested.as_deref()
                         && !stays_within_kept_range(requested, previous)
                     {
-                        tracing::warn!(
-                            target: "pacquet_package_manager::update",
-                            name,
-                            requested,
-                            kept = previous,
-                            r#"Skipping "{name}@{requested}": it doesn't satisfy "{previous}", which the manifest keeps when updating without saving."#,
-                        );
+                        Reporter::emit(&LogEvent::Pnpm(PnpmLog {
+                            level: LogLevel::Warn,
+                            message: format!(
+                                r#"Skipping "{name}@{requested}": it doesn't satisfy "{previous}", which the manifest keeps when updating without saving."#,
+                            ),
+                            prefix: package_manifest_prefix(rewrite_ctx.manifest),
+                        }));
                         continue;
                     }
                     requested

--- a/pnpm/crates/package-manager/src/update/tests.rs
+++ b/pnpm/crates/package-manager/src/update/tests.rs
@@ -1,6 +1,6 @@
 use super::{
     is_workspace_local_path_specifier, parse_update_param, persist_selected_manifests,
-    prepare_selected_manifests, selected_project_indices,
+    prepare_selected_manifests, selected_project_indices, stays_within_kept_range,
 };
 use pacquet_config::{CatalogMode, Config};
 use pacquet_network::ThrottledClient;
@@ -158,7 +158,7 @@ async fn selected_update_no_save_mutates_in_memory_without_persisting() {
         &http_client,
         &config,
         None,
-        &["foo@2.0.0".to_string()],
+        &["foo@1.5.0".to_string()],
         false,
         false,
         false,
@@ -182,8 +182,48 @@ async fn selected_update_no_save_mutates_in_memory_without_persisting() {
             .and_then(|catalogs| catalogs.get("default"))
             .and_then(|catalog| catalog.get("foo"))
             .map(String::as_str),
-        Some("2.0.0"),
+        Some("1.5.0"),
     );
+}
+
+#[tokio::test]
+async fn selected_update_no_save_skips_a_selector_outside_the_kept_range() {
+    let dir = tempdir().expect("create tempdir");
+    std::fs::write(dir.path().join("pnpm-workspace.yaml"), "packages:\n  - '*'\n")
+        .expect("write workspace manifest");
+    let mut projects = vec![project_with_foo(dir.path(), "a")];
+    let ordered_dirs = [projects[0].root_dir.clone()];
+    let selected_dirs = ordered_dirs.iter().cloned().collect::<HashSet<_>>();
+    let indices = selected_project_indices(&projects, &ordered_dirs, &selected_dirs);
+    let config = Config::new();
+    let http_client = std::sync::Arc::new(ThrottledClient::default());
+
+    let prepared = prepare_selected_manifests::<SilentReporter>(
+        &mut projects,
+        &indices,
+        dir.path(),
+        &http_client,
+        &config,
+        None,
+        &["foo@2.0.0".to_string()],
+        false,
+        false,
+        false,
+        &[DependencyGroup::Prod],
+        0,
+        None,
+        false,
+        None,
+    )
+    .await
+    .expect("prepare selected manifests");
+
+    // 2.0.0 falls outside the kept ^1.0.0, so the selector is skipped:
+    // the in-memory manifest keeps the declared range and no rewrite is
+    // recorded for resolution.
+    assert_eq!(dependency_specifier(&projects[0].manifest), "^1.0.0");
+    assert!(prepared.persist_indices.is_empty());
+    assert!(prepared.catalogs_override.is_none());
 }
 
 #[tokio::test]
@@ -382,4 +422,25 @@ fn saved_dependency_specifier(manifest: &PackageManifest) -> String {
     let saved =
         PackageManifest::from_path(manifest.path().to_path_buf()).expect("reread package.json");
     dependency_specifier(&saved).to_string()
+}
+
+#[test]
+fn requested_version_outside_the_kept_range_is_rejected() {
+    assert!(!stays_within_kept_range("7.8.5", "^6.0.0"));
+    assert!(!stays_within_kept_range("^7.0.0", "^6.0.0"));
+    // Overlapping is not enough: ">=6" also allows versions above the
+    // kept range, and resolution would pick one of them.
+    assert!(!stays_within_kept_range(">=6", "^6.0.0"));
+}
+
+#[test]
+fn requested_version_inside_the_kept_range_is_applied() {
+    assert!(stays_within_kept_range("6.3.0", "^6.0.0"));
+    assert!(stays_within_kept_range("~6.3.0", "^6.0.0"));
+}
+
+#[test]
+fn non_semver_specifiers_pass_through_the_kept_range_gate() {
+    assert!(stays_within_kept_range("beta", "^6.0.0"));
+    assert!(stays_within_kept_range("6.3.0", "workspace:*"));
 }

--- a/pnpm/crates/package-manager/src/update/tests.rs
+++ b/pnpm/crates/package-manager/src/update/tests.rs
@@ -1,6 +1,6 @@
 use super::{
     is_workspace_local_path_specifier, parse_update_param, persist_selected_manifests,
-    prepare_selected_manifests, selected_project_indices, stays_within_kept_range,
+    prepare_selected_manifests, requested_version_fits_kept_range, selected_project_indices,
 };
 use pacquet_config::{CatalogMode, Config};
 use pacquet_network::ThrottledClient;
@@ -426,21 +426,23 @@ fn saved_dependency_specifier(manifest: &PackageManifest) -> String {
 
 #[test]
 fn requested_version_outside_the_kept_range_is_rejected() {
-    assert!(!stays_within_kept_range("7.8.5", "^6.0.0"));
-    assert!(!stays_within_kept_range("^7.0.0", "^6.0.0"));
-    // Overlapping is not enough: ">=6" also allows versions above the
-    // kept range, and resolution would pick one of them.
-    assert!(!stays_within_kept_range(">=6", "^6.0.0"));
+    assert!(!requested_version_fits_kept_range("7.8.5", "^6.0.0"));
+    assert!(!requested_version_fits_kept_range("2.0.0-beta.1", "^2.0.0"));
 }
 
 #[test]
 fn requested_version_inside_the_kept_range_is_applied() {
-    assert!(stays_within_kept_range("6.3.0", "^6.0.0"));
-    assert!(stays_within_kept_range("~6.3.0", "^6.0.0"));
+    assert!(requested_version_fits_kept_range("6.3.0", "^6.0.0"));
+    // A range that admits prereleases admits this one.
+    assert!(requested_version_fits_kept_range("2.0.0-beta.1", "^2.0.0-0"));
 }
 
 #[test]
-fn non_semver_specifiers_pass_through_the_kept_range_gate() {
-    assert!(stays_within_kept_range("beta", "^6.0.0"));
-    assert!(stays_within_kept_range("6.3.0", "workspace:*"));
+fn only_a_requested_version_is_judged_against_the_kept_range() {
+    // Range-against-range containment is not decided consistently across
+    // semver implementations, so a requested range is left to resolution.
+    assert!(requested_version_fits_kept_range(">=6", "^6.0.0"));
+    assert!(requested_version_fits_kept_range("^7.0.0", "^6.0.0"));
+    assert!(requested_version_fits_kept_range("beta", "^6.0.0"));
+    assert!(requested_version_fits_kept_range("6.3.0", "workspace:*"));
 }

--- a/pnpm/crates/package-manager/src/update/tests.rs
+++ b/pnpm/crates/package-manager/src/update/tests.rs
@@ -1,6 +1,7 @@
 use super::{
-    is_workspace_local_path_specifier, parse_update_param, persist_selected_manifests,
-    prepare_selected_manifests, requested_version_fits_kept_range, selected_project_indices,
+    KeptRangeVerdict, is_workspace_local_path_specifier, judge_against_kept_range,
+    parse_update_param, persist_selected_manifests, prepare_selected_manifests,
+    selected_project_indices,
 };
 use pacquet_config::{CatalogMode, Config};
 use pacquet_network::ThrottledClient;
@@ -425,24 +426,35 @@ fn saved_dependency_specifier(manifest: &PackageManifest) -> String {
 }
 
 #[test]
-fn requested_version_outside_the_kept_range_is_rejected() {
-    assert!(!requested_version_fits_kept_range("7.8.5", "^6.0.0"));
-    assert!(!requested_version_fits_kept_range("2.0.0-beta.1", "^2.0.0"));
+fn requested_version_outside_the_kept_range_is_excluded() {
+    assert!(matches!(judge_against_kept_range("7.8.5", "^6.0.0"), KeptRangeVerdict::Excluded,));
+    assert!(matches!(
+        judge_against_kept_range("2.0.0-beta.1", "^2.0.0"),
+        KeptRangeVerdict::Excluded,
+    ));
 }
 
 #[test]
-fn requested_version_inside_the_kept_range_is_applied() {
-    assert!(requested_version_fits_kept_range("6.3.0", "^6.0.0"));
+fn requested_version_inside_the_kept_range_is_admitted() {
+    assert!(matches!(judge_against_kept_range("6.3.0", "^6.0.0"), KeptRangeVerdict::Admitted));
     // A range that admits prereleases admits this one.
-    assert!(requested_version_fits_kept_range("2.0.0-beta.1", "^2.0.0-0"));
+    assert!(matches!(
+        judge_against_kept_range("2.0.0-beta.1", "^2.0.0-0"),
+        KeptRangeVerdict::Admitted,
+    ));
 }
 
 #[test]
-fn only_a_requested_version_is_judged_against_the_kept_range() {
+fn only_a_requested_version_gets_a_verdict() {
     // Range-against-range containment is not decided consistently across
-    // semver implementations, so a requested range is left to resolution.
-    assert!(requested_version_fits_kept_range(">=6", "^6.0.0"));
-    assert!(requested_version_fits_kept_range("^7.0.0", "^6.0.0"));
-    assert!(requested_version_fits_kept_range("beta", "^6.0.0"));
-    assert!(requested_version_fits_kept_range("6.3.0", "workspace:*"));
+    // semver implementations, so a request that names no version is left to
+    // the specifier the manifest keeps.
+    for (requested, kept) in
+        [(">=6", "^6.0.0"), ("^7.0.0", "^6.0.0"), ("beta", "^6.0.0"), ("6.3.0", "workspace:*")]
+    {
+        assert!(
+            matches!(judge_against_kept_range(requested, kept), KeptRangeVerdict::Undecided),
+            "{requested:?} against {kept:?} should be undecided",
+        );
+    }
 }

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -976,7 +976,7 @@ export async function mutateModules (
         }
         preferredSpecs = getAllUniqueSpecs(manifests)
       }
-      let wantedDeps = parseWantedDependencies(project.dependencySelectors, {
+      const { wantedDependencies: wantedDeps, outsideKeptRange } = parseWantedDependencies(project.dependencySelectors, {
         allowNew: project.allowNew !== false,
         currentBareSpecifiers,
         defaultTag: opts.tag,
@@ -989,30 +989,13 @@ export async function mutateModules (
         saveCatalogName: opts.saveCatalogName,
         overrides: opts.overrides,
         defaultCatalog: opts.catalogs?.default,
+        keepManifestSpecifiers: project.update && !project.updatePackageManifest,
       })
 
-      if (project.update && project.updatePackageManifest === false) {
-        wantedDeps = wantedDeps.filter((wantedDep) => {
-          // An update that doesn't save keeps the manifest's specifier, and
-          // the lockfile importer entry has to keep satisfying it — a frozen
-          // install rejects the lockfile otherwise. Only apply the requested
-          // specifier when every version it allows stays inside the kept
-          // range; skip the dependency in this project otherwise.
-          const keptBareSpecifier = wantedDep.alias && currentBareSpecifiers[wantedDep.alias]
-          if (
-            !keptBareSpecifier ||
-            !wantedDep.bareSpecifier ||
-            semver.validRange(wantedDep.bareSpecifier) == null ||
-            semver.validRange(keptBareSpecifier) == null ||
-            semver.subset(wantedDep.bareSpecifier, keptBareSpecifier)
-          ) {
-            return true
-          }
-          logger.warn({
-            message: `Skipping "${wantedDep.alias}@${wantedDep.bareSpecifier}": it doesn't satisfy "${keptBareSpecifier}", which the manifest keeps when updating without saving.`,
-            prefix: project.rootDir,
-          })
-          return false
+      for (const { alias, requested, kept } of outsideKeptRange) {
+        logger.warn({
+          message: `Skipping "${alias}@${requested}": it doesn't satisfy "${kept}", which the manifest keeps when updating without saving.`,
+          prefix: project.rootDir,
         })
       }
 

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -959,9 +959,14 @@ export async function mutateModules (
     | 'dependencySelectors'
     | 'targetDependenciesField'
     | 'update'
+    | 'updateToLatest'
     >
 
     async function installSome (project: InstallSomeProject) {
+      // The manifest keeps its specifiers, so they stay authoritative: whatever resolution settles
+      // on has to satisfy them, or the lockfile importer entry contradicts itself and the next
+      // frozen install rejects it.
+      const readonlyManifest = project.update === true && !project.updatePackageManifest
       const currentBareSpecifiers = opts.ignoreCurrentSpecifiers
         ? {}
         : getAllDependenciesFromManifest(project.manifest, { autoInstallPeers: opts.autoInstallPeers })
@@ -976,7 +981,7 @@ export async function mutateModules (
         }
         preferredSpecs = getAllUniqueSpecs(manifests)
       }
-      const { wantedDependencies: wantedDeps, outsideKeptRange } = parseWantedDependencies(project.dependencySelectors, {
+      const { wantedDependencies: wantedDeps, outsideKeptRange, supersededByKeptRange } = parseWantedDependencies(project.dependencySelectors, {
         allowNew: project.allowNew !== false,
         currentBareSpecifiers,
         defaultTag: opts.tag,
@@ -989,12 +994,28 @@ export async function mutateModules (
         saveCatalogName: opts.saveCatalogName,
         overrides: opts.overrides,
         defaultCatalog: opts.catalogs?.default,
-        readonlyManifest: project.update && !project.updatePackageManifest,
+        readonlyManifest,
       })
 
       for (const { alias, requested, kept } of outsideKeptRange) {
         logger.warn({
           message: `Skipping "${alias}@${requested}": it doesn't satisfy "${kept}", which the manifest keeps when updating without saving.`,
+          prefix: project.rootDir,
+        })
+      }
+      for (const { alias, requested, kept } of supersededByKeptRange) {
+        logger.warn({
+          message: `Ignoring "${alias}@${requested}": the manifest keeps "${kept}" when updating without saving, so "${alias}" was updated within that range instead.`,
+          prefix: project.rootDir,
+        })
+      }
+      // `--latest` reaches past the declared range by design, which a manifest that keeps its
+      // specifiers can't record. Degrade to an in-range update rather than write an entry the
+      // next frozen install would reject.
+      const updateToLatest = project.updateToLatest === true && !readonlyManifest
+      if (project.updateToLatest === true && readonlyManifest) {
+        logger.warn({
+          message: 'Ignoring "--latest": the manifest keeps its version ranges when updating without saving, so dependencies were updated within them instead.',
           prefix: project.rootDir,
         })
       }
@@ -1039,6 +1060,7 @@ export async function mutateModules (
       projectsToInstall.push({
         pruneDirectDependencies: false,
         ...project,
+        updateToLatest,
         wantedDependencies: wantedDeps.map(wantedDep => ({ ...wantedDep, isNew: !currentBareSpecifiers[wantedDep.alias], updateSpec: true })),
       } as ImporterToUpdate)
     }

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -989,7 +989,7 @@ export async function mutateModules (
         saveCatalogName: opts.saveCatalogName,
         overrides: opts.overrides,
         defaultCatalog: opts.catalogs?.default,
-        keepManifestSpecifiers: project.update && !project.updatePackageManifest,
+        readonlyManifest: project.update && !project.updatePackageManifest,
       })
 
       for (const { alias, requested, kept } of outsideKeptRange) {

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -976,7 +976,7 @@ export async function mutateModules (
         }
         preferredSpecs = getAllUniqueSpecs(manifests)
       }
-      const wantedDeps = parseWantedDependencies(project.dependencySelectors, {
+      let wantedDeps = parseWantedDependencies(project.dependencySelectors, {
         allowNew: project.allowNew !== false,
         currentBareSpecifiers,
         defaultTag: opts.tag,
@@ -990,6 +990,31 @@ export async function mutateModules (
         overrides: opts.overrides,
         defaultCatalog: opts.catalogs?.default,
       })
+
+      if (project.update && project.updatePackageManifest === false) {
+        wantedDeps = wantedDeps.filter((wantedDep) => {
+          // An update that doesn't save keeps the manifest's specifier, and
+          // the lockfile importer entry has to keep satisfying it — a frozen
+          // install rejects the lockfile otherwise. Only apply the requested
+          // specifier when every version it allows stays inside the kept
+          // range; skip the dependency in this project otherwise.
+          const keptBareSpecifier = wantedDep.alias && currentBareSpecifiers[wantedDep.alias]
+          if (
+            !keptBareSpecifier ||
+            !wantedDep.bareSpecifier ||
+            semver.validRange(wantedDep.bareSpecifier) == null ||
+            semver.validRange(keptBareSpecifier) == null ||
+            semver.subset(wantedDep.bareSpecifier, keptBareSpecifier)
+          ) {
+            return true
+          }
+          logger.warn({
+            message: `Skipping "${wantedDep.alias}@${wantedDep.bareSpecifier}": it doesn't satisfy "${keptBareSpecifier}", which the manifest keeps when updating without saving.`,
+            prefix: project.rootDir,
+          })
+          return false
+        })
+      }
 
       if (opts.catalogMode !== 'manual') {
         for (const wantedDep of wantedDeps) {

--- a/pnpm11/installing/deps-installer/src/parseWantedDependencies.ts
+++ b/pnpm11/installing/deps-installer/src/parseWantedDependencies.ts
@@ -4,7 +4,7 @@ import { parseWantedDependency } from '@pnpm/resolving.parse-wanted-dependency'
 import type { Dependencies } from '@pnpm/types'
 import semver from 'semver'
 
-export interface SelectorOutsideKeptRange {
+export interface KeptRangeConflict {
   alias: string
   requested: string
   kept: string
@@ -13,10 +13,16 @@ export interface SelectorOutsideKeptRange {
 export interface ParsedWantedDependencies {
   wantedDependencies: WantedDependency[]
   /**
-   * The selectors that were dropped because the version they request doesn't satisfy the range
-   * the manifest keeps. Only ever non-empty under `readonlyManifest`.
+   * The selectors dropped because the version they request doesn't satisfy the range the manifest
+   * keeps. Those dependencies are left untouched. Only ever non-empty under `readonlyManifest`.
    */
-  outsideKeptRange: SelectorOutsideKeptRange[]
+  outsideKeptRange: KeptRangeConflict[]
+  /**
+   * The selectors resolution can't be trusted to honor — a range or a dist tag, which only names a
+   * version once resolution has run — so the specifier the manifest keeps was used instead. Only
+   * ever non-empty under `readonlyManifest`.
+   */
+  supersededByKeptRange: KeptRangeConflict[]
 }
 
 export function parseWantedDependencies (
@@ -93,31 +99,30 @@ export function parseWantedDependencies (
     .filter((wd) => wd !== null) as WantedDependency[]
 
   if (!opts.readonlyManifest) {
-    return { wantedDependencies: wantedDeps, outsideKeptRange: [] }
+    return { wantedDependencies: wantedDeps, outsideKeptRange: [], supersededByKeptRange: [] }
   }
   const wantedDependencies: WantedDependency[] = []
-  const outsideKeptRange: SelectorOutsideKeptRange[] = []
+  const outsideKeptRange: KeptRangeConflict[] = []
+  const supersededByKeptRange: KeptRangeConflict[] = []
   for (const wantedDep of wantedDeps) {
     const { alias, bareSpecifier, prevSpecifier } = wantedDep
-    if (!prevSpecifier || requestedVersionFitsKeptRange(bareSpecifier, prevSpecifier)) {
+    if (!prevSpecifier || bareSpecifier === prevSpecifier) {
       wantedDependencies.push(wantedDep)
+    } else if (semver.valid(bareSpecifier) != null && semver.validRange(prevSpecifier) != null) {
+      // Both sides are concrete enough to judge now: matching a version against a range is exact.
+      if (semver.satisfies(bareSpecifier, prevSpecifier)) {
+        wantedDependencies.push(wantedDep)
+      } else {
+        outsideKeptRange.push({ alias, requested: bareSpecifier, kept: prevSpecifier })
+      }
     } else {
-      outsideKeptRange.push({ alias, requested: bareSpecifier, kept: prevSpecifier })
+      // A range, a dist tag, or a kept specifier that isn't a semver range. Nothing here names a
+      // version yet, and asking whether one range contains another is not answered consistently
+      // across semver implementations — so resolve what the manifest declares, which is the
+      // specifier the importer entry will record.
+      supersededByKeptRange.push({ alias, requested: bareSpecifier, kept: prevSpecifier })
+      wantedDependencies.push({ ...wantedDep, bareSpecifier: prevSpecifier })
     }
   }
-  return { wantedDependencies, outsideKeptRange }
-}
-
-/**
- * Whether the requested version satisfies the range the manifest keeps.
- *
- * Only a concrete version can be judged here. Matching a version against a range is exact;
- * deciding whether one *range* is contained by another is not — implementations disagree around
- * prerelease boundaries. So a requested range (`>=6`) or dist tag (`latest`) is left alone: it
- * has no version yet, and the reliable place to judge it is against the version resolution
- * settles on.
- */
-function requestedVersionFitsKeptRange (requested: string, kept: string): boolean {
-  if (semver.valid(requested) == null || semver.validRange(kept) == null) return true
-  return semver.satisfies(requested, kept)
+  return { wantedDependencies, outsideKeptRange, supersededByKeptRange }
 }

--- a/pnpm11/installing/deps-installer/src/parseWantedDependencies.ts
+++ b/pnpm11/installing/deps-installer/src/parseWantedDependencies.ts
@@ -2,6 +2,22 @@ import type { Catalog } from '@pnpm/catalogs.types'
 import type { WantedDependency } from '@pnpm/installing.deps-resolver'
 import { parseWantedDependency } from '@pnpm/resolving.parse-wanted-dependency'
 import type { Dependencies } from '@pnpm/types'
+import semver from 'semver'
+
+export interface SelectorOutsideKeptRange {
+  alias: string
+  requested: string
+  kept: string
+}
+
+export interface ParsedWantedDependencies {
+  wantedDependencies: WantedDependency[]
+  /**
+   * The selectors that were dropped because the version they request reaches outside the range
+   * the manifest keeps. Only ever non-empty under `keepManifestSpecifiers`.
+   */
+  outsideKeptRange: SelectorOutsideKeptRange[]
+}
 
 export function parseWantedDependencies (
   rawWantedDependencies: string[],
@@ -18,9 +34,14 @@ export function parseWantedDependencies (
     preferredSpecs?: Record<string, string>
     saveCatalogName?: string
     defaultCatalog?: Catalog
+    /**
+     * The manifest won't be rewritten, so its specifiers stay authoritative and a requested
+     * specifier may only narrow the one already declared.
+     */
+    keepManifestSpecifiers?: boolean
   }
-): WantedDependency[] {
-  return rawWantedDependencies
+): ParsedWantedDependencies {
+  const wantedDeps = rawWantedDependencies
     .map((rawWantedDependency) => {
       const parsed = parseWantedDependency(rawWantedDependency)
       const alias = parsed['alias']
@@ -70,4 +91,31 @@ export function parseWantedDependencies (
       }
     })
     .filter((wd) => wd !== null) as WantedDependency[]
+
+  if (!opts.keepManifestSpecifiers) {
+    return { wantedDependencies: wantedDeps, outsideKeptRange: [] }
+  }
+  const wantedDependencies: WantedDependency[] = []
+  const outsideKeptRange: SelectorOutsideKeptRange[] = []
+  for (const wantedDep of wantedDeps) {
+    const { alias, bareSpecifier, prevSpecifier } = wantedDep
+    if (!prevSpecifier || staysWithinKeptRange(bareSpecifier, prevSpecifier)) {
+      wantedDependencies.push(wantedDep)
+    } else {
+      outsideKeptRange.push({ alias, requested: bareSpecifier, kept: prevSpecifier })
+    }
+  }
+  return { wantedDependencies, outsideKeptRange }
+}
+
+/**
+ * Whether every version the requested specifier allows stays inside the range the manifest keeps.
+ *
+ * Overlapping is not enough: a requested `>=6` also allows versions above a kept `^6.0.0`, and
+ * resolution would pick one of them. Specifiers that aren't semver ranges (dist tags,
+ * `workspace:`, `catalog:`) can't be judged statically and are left to resolution.
+ */
+function staysWithinKeptRange (requested: string, kept: string): boolean {
+  if (semver.validRange(requested) == null || semver.validRange(kept) == null) return true
+  return semver.subset(requested, kept)
 }

--- a/pnpm11/installing/deps-installer/src/parseWantedDependencies.ts
+++ b/pnpm11/installing/deps-installer/src/parseWantedDependencies.ts
@@ -13,7 +13,7 @@ export interface SelectorOutsideKeptRange {
 export interface ParsedWantedDependencies {
   wantedDependencies: WantedDependency[]
   /**
-   * The selectors that were dropped because the version they request reaches outside the range
+   * The selectors that were dropped because the version they request doesn't satisfy the range
    * the manifest keeps. Only ever non-empty under `readonlyManifest`.
    */
   outsideKeptRange: SelectorOutsideKeptRange[]
@@ -35,8 +35,8 @@ export function parseWantedDependencies (
     saveCatalogName?: string
     defaultCatalog?: Catalog
     /**
-     * The manifest keeps its specifiers, so a requested specifier is applied only when it
-     * narrows the declared one — the lockfile importer entry has to keep satisfying it.
+     * The manifest keeps its specifiers, so a requested version is applied only when it satisfies
+     * the declared one — the lockfile importer entry has to keep satisfying its own specifier.
      */
     readonlyManifest?: boolean
   }
@@ -99,7 +99,7 @@ export function parseWantedDependencies (
   const outsideKeptRange: SelectorOutsideKeptRange[] = []
   for (const wantedDep of wantedDeps) {
     const { alias, bareSpecifier, prevSpecifier } = wantedDep
-    if (!prevSpecifier || staysWithinKeptRange(bareSpecifier, prevSpecifier)) {
+    if (!prevSpecifier || requestedVersionFitsKeptRange(bareSpecifier, prevSpecifier)) {
       wantedDependencies.push(wantedDep)
     } else {
       outsideKeptRange.push({ alias, requested: bareSpecifier, kept: prevSpecifier })
@@ -109,13 +109,15 @@ export function parseWantedDependencies (
 }
 
 /**
- * Whether every version the requested specifier allows stays inside the range the manifest keeps.
+ * Whether the requested version satisfies the range the manifest keeps.
  *
- * Overlapping is not enough: a requested `>=6` also allows versions above a kept `^6.0.0`, and
- * resolution would pick one of them. Specifiers that aren't semver ranges (dist tags,
- * `workspace:`, `catalog:`) can't be judged statically and are left to resolution.
+ * Only a concrete version can be judged here. Matching a version against a range is exact;
+ * deciding whether one *range* is contained by another is not — implementations disagree around
+ * prerelease boundaries. So a requested range (`>=6`) or dist tag (`latest`) is left alone: it
+ * has no version yet, and the reliable place to judge it is against the version resolution
+ * settles on.
  */
-function staysWithinKeptRange (requested: string, kept: string): boolean {
-  if (semver.validRange(requested) == null || semver.validRange(kept) == null) return true
-  return semver.subset(requested, kept)
+function requestedVersionFitsKeptRange (requested: string, kept: string): boolean {
+  if (semver.valid(requested) == null || semver.validRange(kept) == null) return true
+  return semver.satisfies(requested, kept)
 }

--- a/pnpm11/installing/deps-installer/src/parseWantedDependencies.ts
+++ b/pnpm11/installing/deps-installer/src/parseWantedDependencies.ts
@@ -14,7 +14,7 @@ export interface ParsedWantedDependencies {
   wantedDependencies: WantedDependency[]
   /**
    * The selectors that were dropped because the version they request reaches outside the range
-   * the manifest keeps. Only ever non-empty under `keepManifestSpecifiers`.
+   * the manifest keeps. Only ever non-empty under `readonlyManifest`.
    */
   outsideKeptRange: SelectorOutsideKeptRange[]
 }
@@ -35,10 +35,10 @@ export function parseWantedDependencies (
     saveCatalogName?: string
     defaultCatalog?: Catalog
     /**
-     * The manifest won't be rewritten, so its specifiers stay authoritative and a requested
-     * specifier may only narrow the one already declared.
+     * The manifest keeps its specifiers, so a requested specifier is applied only when it
+     * narrows the declared one — the lockfile importer entry has to keep satisfying it.
      */
-    keepManifestSpecifiers?: boolean
+    readonlyManifest?: boolean
   }
 ): ParsedWantedDependencies {
   const wantedDeps = rawWantedDependencies
@@ -92,7 +92,7 @@ export function parseWantedDependencies (
     })
     .filter((wd) => wd !== null) as WantedDependency[]
 
-  if (!opts.keepManifestSpecifiers) {
+  if (!opts.readonlyManifest) {
     return { wantedDependencies: wantedDeps, outsideKeptRange: [] }
   }
   const wantedDependencies: WantedDependency[] = []

--- a/pnpm11/installing/deps-installer/test/install/update.ts
+++ b/pnpm11/installing/deps-installer/test/install/update.ts
@@ -429,11 +429,7 @@ test('update without saving skips a requested version that the kept range exclud
   await install(manifest, testDefaults({ frozenLockfile: true }))
 })
 
-// Known gap, pinned so it is noticed when it closes: only a requested version can be judged
-// against the kept range, and a dist tag has no version until resolution settles. The reliable
-// fix is to check the version resolution picks, at which point this expectation becomes
-// `100.1.0` — the highest inside `^100.0.0` — and the frozen install below stops failing.
-test('update without saving cannot judge a dist-tag, so it may still leave the kept range', async () => {
+test('update without saving resolves a dist-tag within the kept range', async () => {
   const project = prepareEmpty()
 
   await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.0.0', distTag: 'latest' })
@@ -459,15 +455,81 @@ test('update without saving cannot judge a dist-tag, so it may still leave the k
 
   const lockfile = project.readLockfile()
 
+  // A tag names no version until resolution runs, so the kept range decides: 100.1.0 is the
+  // highest it admits. Recording 101.0.0 under `^100.0.0` is what pnpm/pnpm#12764 reported.
   expect(lockfile.importers['.'].dependencies?.['@pnpm.e2e/dep-of-pkg-with-1-dep']).toStrictEqual({
     specifier: '^100.0.0',
-    version: '101.0.0',
+    version: '100.1.0',
   })
 
-  // The lockfile contradicts its own specifier, which is what pnpm/pnpm#12764 reported.
-  await expect(
-    install(manifest, testDefaults({ frozenLockfile: true }))
-  ).rejects.toThrow(expect.objectContaining({ code: 'ERR_PNPM_OUTDATED_LOCKFILE' }))
+  await install(manifest, testDefaults({ frozenLockfile: true }))
+})
+
+test('update without saving resolves a requested range within the kept range', async () => {
+  const project = prepareEmpty()
+
+  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.0.0', distTag: 'latest' })
+
+  const { updatedManifest: manifest } = await addDependenciesToPackage(
+    {},
+    ['@pnpm.e2e/dep-of-pkg-with-1-dep@^100.0.0'],
+    testDefaults()
+  )
+
+  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '101.0.0', distTag: 'latest' })
+
+  await mutateModulesInSingleProject({
+    dependencySelectors: ['@pnpm.e2e/dep-of-pkg-with-1-dep@>=101.0.0'],
+    allowNew: false,
+    manifest,
+    mutation: 'installSome',
+    update: true,
+    updatePackageManifest: false,
+    rootDir: process.cwd() as ProjectRootDir,
+  }, testDefaults({ updateChecksums: true }))
+
+  const lockfile = project.readLockfile()
+
+  expect(lockfile.importers['.'].dependencies?.['@pnpm.e2e/dep-of-pkg-with-1-dep']).toStrictEqual({
+    specifier: '^100.0.0',
+    version: '100.1.0',
+  })
+
+  await install(manifest, testDefaults({ frozenLockfile: true }))
+})
+
+test('update without saving keeps --latest inside the kept range', async () => {
+  const project = prepareEmpty()
+
+  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.0.0', distTag: 'latest' })
+
+  const { updatedManifest: manifest } = await addDependenciesToPackage(
+    {},
+    ['@pnpm.e2e/dep-of-pkg-with-1-dep@^100.0.0'],
+    testDefaults()
+  )
+
+  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '101.0.0', distTag: 'latest' })
+
+  // `--latest` carries no selector version at all, so it reaches resolution on its own.
+  await mutateModulesInSingleProject({
+    dependencySelectors: ['@pnpm.e2e/dep-of-pkg-with-1-dep'],
+    allowNew: false,
+    manifest,
+    mutation: 'installSome',
+    update: true,
+    updatePackageManifest: false,
+    rootDir: process.cwd() as ProjectRootDir,
+  }, testDefaults({ updateChecksums: true, updateToLatest: true }))
+
+  const lockfile = project.readLockfile()
+
+  expect(lockfile.importers['.'].dependencies?.['@pnpm.e2e/dep-of-pkg-with-1-dep']).toStrictEqual({
+    specifier: '^100.0.0',
+    version: '100.1.0',
+  })
+
+  await install(manifest, testDefaults({ frozenLockfile: true }))
 })
 
 test('update without saving applies a requested version that stays inside the kept range', async () => {

--- a/pnpm11/installing/deps-installer/test/install/update.ts
+++ b/pnpm11/installing/deps-installer/test/install/update.ts
@@ -403,7 +403,7 @@ test('update without saving skips a requested version that the kept range exclud
     testDefaults()
   )
 
-  await mutateModulesInSingleProject({
+  const { updatedProject } = await mutateModulesInSingleProject({
     dependencySelectors: ['@pnpm.e2e/dep-of-pkg-with-1-dep@101.0.0'],
     allowNew: false,
     manifest,
@@ -413,6 +413,8 @@ test('update without saving skips a requested version that the kept range exclud
     rootDir: process.cwd() as ProjectRootDir,
   }, testDefaults())
 
+  expect(updatedProject.manifest.dependencies).toStrictEqual({ '@pnpm.e2e/dep-of-pkg-with-1-dep': '^100.0.0' })
+
   const lockfile = project.readLockfile()
 
   // 101.0.0 doesn't satisfy the ^100.0.0 the manifest keeps, so the
@@ -421,6 +423,42 @@ test('update without saving skips a requested version that the kept range exclud
   expect(lockfile.importers['.'].dependencies?.['@pnpm.e2e/dep-of-pkg-with-1-dep']).toStrictEqual({
     specifier: '^100.0.0',
     version: '100.0.0',
+  })
+
+  // The lockfile still satisfies the manifest.
+  await install(manifest, testDefaults({ frozenLockfile: true }))
+})
+
+test('update without saving passes a dist-tag selector through to resolution', async () => {
+  const project = prepareEmpty()
+
+  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.0.0', distTag: 'latest' })
+
+  const { updatedManifest: manifest } = await addDependenciesToPackage(
+    {},
+    ['@pnpm.e2e/dep-of-pkg-with-1-dep@^100.0.0'],
+    testDefaults()
+  )
+
+  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.1.0', distTag: 'latest' })
+
+  // A dist-tag can't be judged against the kept range statically, so the
+  // gate lets it through and resolution picks the tagged version.
+  await mutateModulesInSingleProject({
+    dependencySelectors: ['@pnpm.e2e/dep-of-pkg-with-1-dep@latest'],
+    allowNew: false,
+    manifest,
+    mutation: 'installSome',
+    update: true,
+    updatePackageManifest: false,
+    rootDir: process.cwd() as ProjectRootDir,
+  }, testDefaults({ updateChecksums: true }))
+
+  const lockfile = project.readLockfile()
+
+  expect(lockfile.importers['.'].dependencies?.['@pnpm.e2e/dep-of-pkg-with-1-dep']).toStrictEqual({
+    specifier: '^100.0.0',
+    version: '100.1.0',
   })
 })
 

--- a/pnpm11/installing/deps-installer/test/install/update.ts
+++ b/pnpm11/installing/deps-installer/test/install/update.ts
@@ -2,10 +2,11 @@ import path from 'node:path'
 
 import { expect, test } from '@jest/globals'
 import { WANTED_LOCKFILE } from '@pnpm/constants'
-import { addDependenciesToPackage, install } from '@pnpm/installing.deps-installer'
+import { addDependenciesToPackage, install, mutateModulesInSingleProject } from '@pnpm/installing.deps-installer'
 import type { LockfileFile } from '@pnpm/lockfile.fs'
 import { prepareEmpty } from '@pnpm/prepare'
 import { addDistTag } from '@pnpm/testing.registry-mock'
+import type { ProjectRootDir } from '@pnpm/types'
 import { readYamlFileSync } from 'read-yaml-file'
 
 import { testDefaults } from '../utils/index.js'
@@ -389,4 +390,65 @@ test('updateMatching keeps manifest-pin dedup for the targeted package, matching
   // 100.1.0 alongside would be a duplicate no fresh install reproduces.
   expect(lockfile.snapshots).not.toHaveProperty(['@pnpm.e2e/foo@100.1.0'])
   expect(lockfile.snapshots['@pnpm.e2e/foobarqar@1.0.0'].dependencies?.['@pnpm.e2e/foo']).toBe('100.0.0')
+})
+
+test('update without saving skips a requested version that the kept range excludes (#12764)', async () => {
+  const project = prepareEmpty()
+
+  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.0.0', distTag: 'latest' })
+
+  const { updatedManifest: manifest } = await addDependenciesToPackage(
+    {},
+    ['@pnpm.e2e/dep-of-pkg-with-1-dep@^100.0.0'],
+    testDefaults()
+  )
+
+  await mutateModulesInSingleProject({
+    dependencySelectors: ['@pnpm.e2e/dep-of-pkg-with-1-dep@101.0.0'],
+    allowNew: false,
+    manifest,
+    mutation: 'installSome',
+    update: true,
+    updatePackageManifest: false,
+    rootDir: process.cwd() as ProjectRootDir,
+  }, testDefaults())
+
+  const lockfile = project.readLockfile()
+
+  // 101.0.0 doesn't satisfy the ^100.0.0 the manifest keeps, so the
+  // dependency stays untouched — a lockfile recording 101.0.0 under
+  // specifier ^100.0.0 would fail the next frozen install.
+  expect(lockfile.importers['.'].dependencies?.['@pnpm.e2e/dep-of-pkg-with-1-dep']).toStrictEqual({
+    specifier: '^100.0.0',
+    version: '100.0.0',
+  })
+})
+
+test('update without saving applies a requested version that stays inside the kept range', async () => {
+  const project = prepareEmpty()
+
+  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.0.0', distTag: 'latest' })
+
+  const { updatedManifest: manifest } = await addDependenciesToPackage(
+    {},
+    ['@pnpm.e2e/dep-of-pkg-with-1-dep@^100.0.0'],
+    testDefaults()
+  )
+
+  await mutateModulesInSingleProject({
+    dependencySelectors: ['@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0'],
+    allowNew: false,
+    manifest,
+    mutation: 'installSome',
+    update: true,
+    updatePackageManifest: false,
+    rootDir: process.cwd() as ProjectRootDir,
+  }, testDefaults())
+
+  const lockfile = project.readLockfile()
+
+  expect(lockfile.importers['.'].dependencies?.['@pnpm.e2e/dep-of-pkg-with-1-dep']).toStrictEqual({
+    specifier: '^100.0.0',
+    version: '100.1.0',
+  })
 })

--- a/pnpm11/installing/deps-installer/test/install/update.ts
+++ b/pnpm11/installing/deps-installer/test/install/update.ts
@@ -429,7 +429,11 @@ test('update without saving skips a requested version that the kept range exclud
   await install(manifest, testDefaults({ frozenLockfile: true }))
 })
 
-test('update without saving passes a dist-tag selector through to resolution', async () => {
+// Known gap, pinned so it is noticed when it closes: only a requested version can be judged
+// against the kept range, and a dist tag has no version until resolution settles. The reliable
+// fix is to check the version resolution picks, at which point this expectation becomes
+// `100.1.0` — the highest inside `^100.0.0` — and the frozen install below stops failing.
+test('update without saving cannot judge a dist-tag, so it may still leave the kept range', async () => {
   const project = prepareEmpty()
 
   await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.0.0', distTag: 'latest' })
@@ -440,10 +444,9 @@ test('update without saving passes a dist-tag selector through to resolution', a
     testDefaults()
   )
 
-  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.1.0', distTag: 'latest' })
+  // The tag now points outside the range the manifest keeps.
+  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '101.0.0', distTag: 'latest' })
 
-  // A dist-tag can't be judged against the kept range statically, so the
-  // gate lets it through and resolution picks the tagged version.
   await mutateModulesInSingleProject({
     dependencySelectors: ['@pnpm.e2e/dep-of-pkg-with-1-dep@latest'],
     allowNew: false,
@@ -458,8 +461,13 @@ test('update without saving passes a dist-tag selector through to resolution', a
 
   expect(lockfile.importers['.'].dependencies?.['@pnpm.e2e/dep-of-pkg-with-1-dep']).toStrictEqual({
     specifier: '^100.0.0',
-    version: '100.1.0',
+    version: '101.0.0',
   })
+
+  // The lockfile contradicts its own specifier, which is what pnpm/pnpm#12764 reported.
+  await expect(
+    install(manifest, testDefaults({ frozenLockfile: true }))
+  ).rejects.toThrow(expect.objectContaining({ code: 'ERR_PNPM_OUTDATED_LOCKFILE' }))
 })
 
 test('update without saving applies a requested version that stays inside the kept range', async () => {

--- a/pnpm11/installing/deps-installer/test/parseWantedDependencies.test.ts
+++ b/pnpm11/installing/deps-installer/test/parseWantedDependencies.test.ts
@@ -22,16 +22,28 @@ test('a requested version that the kept range excludes is reported instead of ap
   expect(outsideKeptRange).toStrictEqual([{ alias: 'semver', requested: '7.8.5', kept: '^6.0.0' }])
 })
 
-test('a requested range that merely overlaps the kept range is reported instead of applied', () => {
-  // Resolution would pick a version above `^6.0.0`, which the lockfile importer entry may not record.
+test('a requested range is not judged against the kept range', () => {
+  // Range-against-range containment is not decided consistently across semver implementations,
+  // so a requested range is left to resolution rather than guessed at here.
   const { wantedDependencies, outsideKeptRange } = parseWantedDependencies(['semver@>=6'], {
     ...defaults,
     currentBareSpecifiers: { semver: '^6.0.0' },
     readonlyManifest: true,
   })
 
-  expect(wantedDependencies).toStrictEqual([])
-  expect(outsideKeptRange).toStrictEqual([{ alias: 'semver', requested: '>=6', kept: '^6.0.0' }])
+  expect(wantedDependencies.map(({ bareSpecifier }) => bareSpecifier)).toStrictEqual(['>=6'])
+  expect(outsideKeptRange).toStrictEqual([])
+})
+
+test('a requested prerelease is judged by the range that admits it', () => {
+  const { wantedDependencies, outsideKeptRange } = parseWantedDependencies(['semver@2.0.0-beta.1'], {
+    ...defaults,
+    currentBareSpecifiers: { semver: '^2.0.0-0' },
+    readonlyManifest: true,
+  })
+
+  expect(wantedDependencies.map(({ bareSpecifier }) => bareSpecifier)).toStrictEqual(['2.0.0-beta.1'])
+  expect(outsideKeptRange).toStrictEqual([])
 })
 
 test('a requested version inside the kept range is applied', () => {

--- a/pnpm11/installing/deps-installer/test/parseWantedDependencies.test.ts
+++ b/pnpm11/installing/deps-installer/test/parseWantedDependencies.test.ts
@@ -1,0 +1,80 @@
+import { expect, test } from '@jest/globals'
+
+import { parseWantedDependencies } from '../src/parseWantedDependencies.js'
+
+const defaults = {
+  allowNew: true,
+  defaultTag: 'latest',
+  dev: false,
+  devDependencies: {},
+  optional: false,
+  optionalDependencies: {},
+}
+
+test('a requested version that the kept range excludes is reported instead of applied', () => {
+  const { wantedDependencies, outsideKeptRange } = parseWantedDependencies(['semver@7.8.5'], {
+    ...defaults,
+    currentBareSpecifiers: { semver: '^6.0.0' },
+    keepManifestSpecifiers: true,
+  })
+
+  expect(wantedDependencies).toStrictEqual([])
+  expect(outsideKeptRange).toStrictEqual([{ alias: 'semver', requested: '7.8.5', kept: '^6.0.0' }])
+})
+
+test('a requested range that merely overlaps the kept range is reported instead of applied', () => {
+  // Resolution would pick a version above `^6.0.0`, which the lockfile importer entry may not record.
+  const { wantedDependencies, outsideKeptRange } = parseWantedDependencies(['semver@>=6'], {
+    ...defaults,
+    currentBareSpecifiers: { semver: '^6.0.0' },
+    keepManifestSpecifiers: true,
+  })
+
+  expect(wantedDependencies).toStrictEqual([])
+  expect(outsideKeptRange).toStrictEqual([{ alias: 'semver', requested: '>=6', kept: '^6.0.0' }])
+})
+
+test('a requested version inside the kept range is applied', () => {
+  const { wantedDependencies, outsideKeptRange } = parseWantedDependencies(['semver@6.3.0'], {
+    ...defaults,
+    currentBareSpecifiers: { semver: '^6.0.0' },
+    keepManifestSpecifiers: true,
+  })
+
+  expect(wantedDependencies).toHaveLength(1)
+  expect(wantedDependencies[0].bareSpecifier).toBe('6.3.0')
+  expect(outsideKeptRange).toStrictEqual([])
+})
+
+test('specifiers that are not semver ranges are left to resolution', () => {
+  const { wantedDependencies, outsideKeptRange } = parseWantedDependencies(['semver@beta', 'foo@1.0.0'], {
+    ...defaults,
+    currentBareSpecifiers: { semver: '^6.0.0', foo: 'workspace:*' },
+    keepManifestSpecifiers: true,
+  })
+
+  expect(wantedDependencies.map(({ bareSpecifier }) => bareSpecifier)).toStrictEqual(['beta', '1.0.0'])
+  expect(outsideKeptRange).toStrictEqual([])
+})
+
+test('a new dependency has no kept range to stay inside of', () => {
+  const { wantedDependencies, outsideKeptRange } = parseWantedDependencies(['semver@7.8.5'], {
+    ...defaults,
+    currentBareSpecifiers: {},
+    keepManifestSpecifiers: true,
+  })
+
+  expect(wantedDependencies).toHaveLength(1)
+  expect(outsideKeptRange).toStrictEqual([])
+})
+
+test('the kept range is not enforced when the manifest is rewritten', () => {
+  const { wantedDependencies, outsideKeptRange } = parseWantedDependencies(['semver@7.8.5'], {
+    ...defaults,
+    currentBareSpecifiers: { semver: '^6.0.0' },
+  })
+
+  expect(wantedDependencies).toHaveLength(1)
+  expect(wantedDependencies[0].bareSpecifier).toBe('7.8.5')
+  expect(outsideKeptRange).toStrictEqual([])
+})

--- a/pnpm11/installing/deps-installer/test/parseWantedDependencies.test.ts
+++ b/pnpm11/installing/deps-installer/test/parseWantedDependencies.test.ts
@@ -15,7 +15,7 @@ test('a requested version that the kept range excludes is reported instead of ap
   const { wantedDependencies, outsideKeptRange } = parseWantedDependencies(['semver@7.8.5'], {
     ...defaults,
     currentBareSpecifiers: { semver: '^6.0.0' },
-    keepManifestSpecifiers: true,
+    readonlyManifest: true,
   })
 
   expect(wantedDependencies).toStrictEqual([])
@@ -27,7 +27,7 @@ test('a requested range that merely overlaps the kept range is reported instead 
   const { wantedDependencies, outsideKeptRange } = parseWantedDependencies(['semver@>=6'], {
     ...defaults,
     currentBareSpecifiers: { semver: '^6.0.0' },
-    keepManifestSpecifiers: true,
+    readonlyManifest: true,
   })
 
   expect(wantedDependencies).toStrictEqual([])
@@ -38,7 +38,7 @@ test('a requested version inside the kept range is applied', () => {
   const { wantedDependencies, outsideKeptRange } = parseWantedDependencies(['semver@6.3.0'], {
     ...defaults,
     currentBareSpecifiers: { semver: '^6.0.0' },
-    keepManifestSpecifiers: true,
+    readonlyManifest: true,
   })
 
   expect(wantedDependencies).toHaveLength(1)
@@ -50,7 +50,7 @@ test('specifiers that are not semver ranges are left to resolution', () => {
   const { wantedDependencies, outsideKeptRange } = parseWantedDependencies(['semver@beta', 'foo@1.0.0'], {
     ...defaults,
     currentBareSpecifiers: { semver: '^6.0.0', foo: 'workspace:*' },
-    keepManifestSpecifiers: true,
+    readonlyManifest: true,
   })
 
   expect(wantedDependencies.map(({ bareSpecifier }) => bareSpecifier)).toStrictEqual(['beta', '1.0.0'])
@@ -61,7 +61,7 @@ test('a new dependency has no kept range to stay inside of', () => {
   const { wantedDependencies, outsideKeptRange } = parseWantedDependencies(['semver@7.8.5'], {
     ...defaults,
     currentBareSpecifiers: {},
-    keepManifestSpecifiers: true,
+    readonlyManifest: true,
   })
 
   expect(wantedDependencies).toHaveLength(1)

--- a/pnpm11/installing/deps-installer/test/parseWantedDependencies.test.ts
+++ b/pnpm11/installing/deps-installer/test/parseWantedDependencies.test.ts
@@ -22,17 +22,18 @@ test('a requested version that the kept range excludes is reported instead of ap
   expect(outsideKeptRange).toStrictEqual([{ alias: 'semver', requested: '7.8.5', kept: '^6.0.0' }])
 })
 
-test('a requested range is not judged against the kept range', () => {
+test('a requested range is superseded by the kept range', () => {
   // Range-against-range containment is not decided consistently across semver implementations,
-  // so a requested range is left to resolution rather than guessed at here.
-  const { wantedDependencies, outsideKeptRange } = parseWantedDependencies(['semver@>=6'], {
+  // so the specifier the importer entry will record is what resolution gets.
+  const { wantedDependencies, outsideKeptRange, supersededByKeptRange } = parseWantedDependencies(['semver@>=6'], {
     ...defaults,
     currentBareSpecifiers: { semver: '^6.0.0' },
     readonlyManifest: true,
   })
 
-  expect(wantedDependencies.map(({ bareSpecifier }) => bareSpecifier)).toStrictEqual(['>=6'])
+  expect(wantedDependencies.map(({ bareSpecifier }) => bareSpecifier)).toStrictEqual(['^6.0.0'])
   expect(outsideKeptRange).toStrictEqual([])
+  expect(supersededByKeptRange).toStrictEqual([{ alias: 'semver', requested: '>=6', kept: '^6.0.0' }])
 })
 
 test('a requested prerelease is judged by the range that admits it', () => {
@@ -58,15 +59,31 @@ test('a requested version inside the kept range is applied', () => {
   expect(outsideKeptRange).toStrictEqual([])
 })
 
-test('specifiers that are not semver ranges are left to resolution', () => {
-  const { wantedDependencies, outsideKeptRange } = parseWantedDependencies(['semver@beta', 'foo@1.0.0'], {
+test('a dist tag, and a kept specifier that is no semver range, are superseded too', () => {
+  const { wantedDependencies, outsideKeptRange, supersededByKeptRange } = parseWantedDependencies(['semver@beta', 'foo@1.0.0'], {
     ...defaults,
     currentBareSpecifiers: { semver: '^6.0.0', foo: 'workspace:*' },
     readonlyManifest: true,
   })
 
-  expect(wantedDependencies.map(({ bareSpecifier }) => bareSpecifier)).toStrictEqual(['beta', '1.0.0'])
+  expect(wantedDependencies.map(({ bareSpecifier }) => bareSpecifier)).toStrictEqual(['^6.0.0', 'workspace:*'])
   expect(outsideKeptRange).toStrictEqual([])
+  expect(supersededByKeptRange).toStrictEqual([
+    { alias: 'semver', requested: 'beta', kept: '^6.0.0' },
+    { alias: 'foo', requested: '1.0.0', kept: 'workspace:*' },
+  ])
+})
+
+test('a selector without a version is honored as-is', () => {
+  const { wantedDependencies, outsideKeptRange, supersededByKeptRange } = parseWantedDependencies(['semver'], {
+    ...defaults,
+    currentBareSpecifiers: { semver: '^6.0.0' },
+    readonlyManifest: true,
+  })
+
+  expect(wantedDependencies.map(({ bareSpecifier }) => bareSpecifier)).toStrictEqual(['^6.0.0'])
+  expect(outsideKeptRange).toStrictEqual([])
+  expect(supersededByKeptRange).toStrictEqual([])
 })
 
 test('a new dependency has no kept range to stay inside of', () => {


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#12764.

`pnpm update <pkg>@<version> --no-save` applied the requested version to every selected importer, including importers whose declared range excludes it. The manifest keeps its specifier in that flow, so the lockfile ended up recording a version that contradicts its own specifier:

```yaml
packages/a:
  dependencies:
    semver:
      specifier: ^6.0.0
      version: 7.8.5
```

and the next `pnpm install --frozen-lockfile` rejected it with `ERR_PNPM_OUTDATED_LOCKFILE` — pnpm refusing a lockfile it wrote itself. Renovate drives exactly this command shape (`pnpm update --no-save <pkg>@<version> --lockfile-only --recursive`) in workspaces where two importers require different majors, which is how the reporter hit it. Reproduced on 11.18.0 in three shapes: recursive workspace, single project, and the downgrade direction.

**The rule** (same in both stacks): a versioned selector under an update that doesn't save is applied only when every version it allows stays inside the kept range — `semver.subset` on the TypeScript side, `node_semver::Range::allows_all` on the Rust side. Otherwise the dependency is skipped in that project with a warning. Subset rather than a mere intersection check: an overlapping range such as `>=6` against `^6.0.0` can still resolve to a version above the kept range, so overlap is not enough. Non-semver specifiers (dist-tags, `workspace:`, `catalog:`) can't be judged statically and pass through unchanged.

Skip-with-a-warning rather than an error, because that is what `pnpm update <pkg>` without a version already does with ranges it can't exceed — the reporter listed either as acceptable. Updates that save are unaffected: they rewrite the manifest, so the lockfile stays consistent.

**Scope:** this covers the versioned selector the issue reports (`update <pkg>@<version> --no-save`). The same broken lockfile is reachable through `update --latest --no-save`, where the version comes from the `latest` tag at resolution time rather than from a selector, so this gate never sees it. Closing that one would change what pacquet's `update_latest_no_save_keeps_manifest` test pins, so it is filed separately as pnpm/pnpm#13665 for a maintainer call rather than folded in here.

While porting this I found that the Rust CLI has a second, separate defect in the same flow: it writes the *requested* specifier into the lockfile importer entry while `package.json` keeps the old one, so even an **in-range** no-save update produces a lockfile that fails the manifest-sync check. That needs a channel separating resolution wants from the persisted specifier, so it is filed separately as pnpm/pnpm#13526; this PR ports the out-of-range gate, which holds regardless.

One pre-existing Rust test pinned the old acceptance (`selected_update_no_save_mutates_in_memory_without_persisting`, selector `foo@2.0.0` against `^1.0.0`): its purpose — in-memory mutation without persisting — is kept by moving it to an in-range selector, and a new test pins the skip.

## Squash Commit Body

```text
pnpm update <pkg>@<version> --no-save applied the requested version to
every selected importer, including importers whose declared range
excludes it. The manifest keeps its specifier in that flow, so the
lockfile ended up recording a version that contradicts its own
specifier (e.g. specifier ^6.0.0, version 7.8.5) and the next
pnpm install --frozen-lockfile rejected it with
ERR_PNPM_OUTDATED_LOCKFILE. Renovate drives exactly this command shape
in workspaces where two importers require different majors.

Only apply a versioned selector when every version it allows stays
inside the kept range (semver.subset — an overlapping range such as
">=6" is not enough, resolution could still pick a version above the
kept range); skip the dependency in that project with a warning
otherwise. Updates that save are unaffected: they rewrite the manifest,
so the lockfile stays consistent.

The Rust CLI had the same acceptance plus a second defect: it writes
the requested specifier into the lockfile importer entry while
package.json keeps the old one, so even an in-range no-save update
produces a lockfile that fails the manifest-sync check. The same
subset gate now guards the selector rewrite
(node_semver::Range::allows_all); the in-range specifier leak needs a
channel separating resolution wants from the persisted specifier and
is tracked in #13526.

Fixes #12764
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13527"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788085358&installation_model_id=426870&pr_number=13527&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13527&signature=18fc46fa3bd7c10cc81f9e4ed9c94a5ec2ca235693aa45a739894197b517f094"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `update --no-save` behavior to respect the dependency version range retained in the manifest.
  * When a requested exact version falls outside the kept range, it is skipped and a warning is shown (without recording it in the lockfile).
  * In-range requests still update the lockfile while leaving the manifest unchanged.
  * Non-semver and workspace specifiers continue to be handled as before.
  * Frozen installs now remain successful when out-of-range updates are skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
