### PR TITLE
fix(store.path): keep the store inside the project when nothing above it is linkable

### DIFF
--- a/.changeset/sandbox-store-path.md
+++ b/.changeset/sandbox-store-path.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/store.path": patch
+"pnpm": patch
+---
+
+Fix store path selection when only the project directory is writable, preventing pnpm from creating a project-local `.pnpm-store`.

--- a/.changeset/sandbox-store-path.md
+++ b/.changeset/sandbox-store-path.md
@@ -1,6 +1,5 @@
 ---
-"@pnpm/store.path": patch
-"pnpm": patch
+"pacquet": patch
 ---
 
-Fix store path selection when only the project directory is writable, preventing pnpm from creating a project-local `.pnpm-store`.
+When no directory above the project accepts a hard link — inside an AI agent sandbox that only grants write access to the project, or a container with just the project mounted writable — the default store is now created at `<project>/node_modules/.pnpm-store` instead of in the pnpm home directory. In those environments the home store is either read-only or on another volume, which forces every package to be copied instead of hard linked [#13525](https://github.com/pnpm/pnpm/issues/13525).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9471,18 +9471,12 @@ importers:
       '@pnpm/store.path':
         specifier: workspace:*
         version: 'link:'
-      '@types/is-windows':
-        specifier: 'catalog:'
-        version: 1.0.2
       '@types/node':
         specifier: 'catalog:'
         version: 22.20.1
       '@types/touch':
         specifier: 'catalog:'
         version: 3.1.5
-      is-windows:
-        specifier: 'catalog:'
-        version: 1.0.2
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3

--- a/pnpm/crates/config/src/store_path.rs
+++ b/pnpm/crates/config/src/store_path.rs
@@ -13,21 +13,11 @@
 //!    linkable, and return `<mount_point>/.pnpm-store`.
 //!
 //! The mount point can be the project directory itself, when nothing
-//! above it accepts a hard link — a sandbox that only grants write
-//! access to the project, or a container with just the project
-//! bind-mounted writable. The store still belongs there rather than in
-//! the home directory: it is the only location on the project's volume,
-//! so it can be hardlinked from, whereas the home store would either be
-//! unwritable too or force a full copy of every package.
-//!
-//! That case is the one place where pacquet deliberately parts from
-//! pnpm 11, which places the store at `<pkg_root>/.pnpm-store` and so
-//! leaves an untracked directory in the working tree. pacquet nests it
-//! under `node_modules` instead. Installing the same project with both
-//! CLIs therefore reports `ERR_PNPM_UNEXPECTED_STORE` once and
-//! reinstalls against the new location — acceptable, since reaching
-//! this branch at all requires an environment where every ancestor of
-//! the project rejects hard links.
+//! above it accepts a hard link. The store then goes to
+//! `<pkg_root>/node_modules/.pnpm-store`, where the project's VCS
+//! ignores it — deliberately not the `<pkg_root>/.pnpm-store` pnpm 11
+//! uses, so a project installed with both CLIs reports
+//! `ERR_PNPM_UNEXPECTED_STORE` once and reinstalls.
 //!
 //! Without this detection a developer with a separate
 //! case-sensitive workspace volume (for example
@@ -97,8 +87,6 @@ pub fn resolve_store_dir<Sys: LinkProbe>(
         _ => mountpoint,
     };
 
-    // A store under `node_modules` is invisible to the project's VCS
-    // status, which a `<pkg_root>/.pnpm-store` would not be.
     if mountpoint == pkg_root {
         return pkg_root.join("node_modules").join(".pnpm-store");
     }

--- a/pnpm/crates/config/src/store_path.rs
+++ b/pnpm/crates/config/src/store_path.rs
@@ -10,8 +10,24 @@
 //! 2. Otherwise walk from the filesystem root toward the project,
 //!    find the first directory that *does* accept the hardlink (the
 //!    mount point), prefer that mount point's parent if it is also
-//!    linkable, and return `<mount_point>/.pnpm-store`. If only the
-//!    project folder itself is linkable, fall back to the home store.
+//!    linkable, and return `<mount_point>/.pnpm-store`.
+//!
+//! The mount point can be the project directory itself, when nothing
+//! above it accepts a hard link — a sandbox that only grants write
+//! access to the project, or a container with just the project
+//! bind-mounted writable. The store still belongs there rather than in
+//! the home directory: it is the only location on the project's volume,
+//! so it can be hardlinked from, whereas the home store would either be
+//! unwritable too or force a full copy of every package.
+//!
+//! That case is the one place where pacquet deliberately parts from
+//! pnpm 11, which places the store at `<pkg_root>/.pnpm-store` and so
+//! leaves an untracked directory in the working tree. pacquet nests it
+//! under `node_modules` instead. Installing the same project with both
+//! CLIs therefore reports `ERR_PNPM_UNEXPECTED_STORE` once and
+//! reinstalls against the new location — acceptable, since reaching
+//! this branch at all requires an environment where every ancestor of
+//! the project rejects hard links.
 //!
 //! Without this detection a developer with a separate
 //! case-sensitive workspace volume (for example
@@ -81,11 +97,10 @@ pub fn resolve_store_dir<Sys: LinkProbe>(
         _ => mountpoint,
     };
 
-    // When linkability is confined to the project folder itself, the
-    // mount-point fallback would put the store *inside* the project
-    // — instead, defer to the home store.
+    // A store under `node_modules` is invisible to the project's VCS
+    // status, which a `<pkg_root>/.pnpm-store` would not be.
     if mountpoint == pkg_root {
-        return home_default;
+        return pkg_root.join("node_modules").join(".pnpm-store");
     }
 
     mountpoint.join(".pnpm-store")

--- a/pnpm/crates/config/src/store_path/tests.rs
+++ b/pnpm/crates/config/src/store_path/tests.rs
@@ -143,7 +143,7 @@ fn resolve_store_dir_prefers_parent_when_parent_is_also_linkable() {
 
 #[test]
 #[cfg(unix)]
-fn resolve_store_dir_falls_back_when_only_pkg_root_is_linkable() {
+fn resolve_store_dir_uses_node_modules_when_only_pkg_root_is_linkable() {
     prefix_probe!();
     let tmp = tempdir().expect("create tempdir");
     let pkg_root = tmp.path().join("project");
@@ -153,9 +153,8 @@ fn resolve_store_dir_falls_back_when_only_pkg_root_is_linkable() {
     let pnpm_home = PathBuf::from("/home/test-user/Library/pnpm");
 
     set_allow(&[&pkg_root_canon]);
-    let resolved =
-        resolve_store_dir::<PrefixProbe>(home_default.clone(), &pnpm_home, &pkg_root_canon);
-    assert_eq!(resolved, home_default);
+    let resolved = resolve_store_dir::<PrefixProbe>(home_default, &pnpm_home, &pkg_root_canon);
+    assert_eq!(resolved, pkg_root_canon.join("node_modules").join(".pnpm-store"));
 }
 
 #[test]

--- a/pnpm/crates/package-manager/src/install/tests.rs
+++ b/pnpm/crates/package-manager/src/install/tests.rs
@@ -9998,9 +9998,10 @@ async fn pre_resolution_hook_log_is_forwarded_to_pnpm_hook_channel() {
 #[tokio::test]
 async fn test_install_purges_node_modules_on_layout_mismatch() {
     let dir = tempdir().unwrap();
-    let store_dir = dir.path().join("pacquet-store");
     let project_root = dir.path().join("project");
     let modules_dir = project_root.join("node_modules");
+    // Where the default store lands — see [`pacquet_config::store_path`].
+    let store_dir = modules_dir.join(".pnpm-store");
     let virtual_store_dir = modules_dir.join(".pacquet");
 
     let manifest_path = project_root.join("package.json");
@@ -10076,9 +10077,9 @@ async fn test_install_purges_node_modules_on_layout_mismatch() {
     std::fs::write(&canary_path, "canary").unwrap();
     assert!(canary_path.exists());
 
-    // Where the default store lands — see [`pacquet_config::store_path`].
-    let store_in_modules = modules_dir.join(".pnpm-store");
-    std::fs::create_dir_all(&store_in_modules).unwrap();
+    let store_marker = store_dir.join("marker");
+    std::fs::create_dir_all(&store_dir).unwrap();
+    std::fs::write(&store_marker, "keep").unwrap();
 
     // 2nd install: Hoisted node linker
     Install {
@@ -10119,7 +10120,11 @@ async fn test_install_purges_node_modules_on_layout_mismatch() {
     .expect("2nd install success");
 
     assert!(!canary_path.exists(), "node_modules should be purged due to mismatch");
-    assert!(store_in_modules.exists(), "a store inside node_modules should survive the purge");
+    assert_eq!(
+        std::fs::read_to_string(&store_marker).ok().as_deref(),
+        Some("keep"),
+        "a store inside node_modules should survive the purge",
+    );
 }
 
 #[tokio::test]

--- a/pnpm/crates/package-manager/src/install/tests.rs
+++ b/pnpm/crates/package-manager/src/install/tests.rs
@@ -10076,6 +10076,12 @@ async fn test_install_purges_node_modules_on_layout_mismatch() {
     std::fs::write(&canary_path, "canary").unwrap();
     assert!(canary_path.exists());
 
+    // The default store lands here when nothing above the project
+    // accepts a hard link — see [`pacquet_config::store_path`] — so a
+    // purge that wiped it would throw away every fetched package.
+    let store_in_modules = modules_dir.join(".pnpm-store");
+    std::fs::create_dir_all(&store_in_modules).unwrap();
+
     // 2nd install: Hoisted node linker
     Install {
         tarball_mem_cache: Default::default(),
@@ -10115,6 +10121,7 @@ async fn test_install_purges_node_modules_on_layout_mismatch() {
     .expect("2nd install success");
 
     assert!(!canary_path.exists(), "node_modules should be purged due to mismatch");
+    assert!(store_in_modules.exists(), "a store inside node_modules should survive the purge");
 }
 
 #[tokio::test]

--- a/pnpm/crates/package-manager/src/install/tests.rs
+++ b/pnpm/crates/package-manager/src/install/tests.rs
@@ -10076,9 +10076,7 @@ async fn test_install_purges_node_modules_on_layout_mismatch() {
     std::fs::write(&canary_path, "canary").unwrap();
     assert!(canary_path.exists());
 
-    // The default store lands here when nothing above the project
-    // accepts a hard link — see [`pacquet_config::store_path`] — so a
-    // purge that wiped it would throw away every fetched package.
+    // Where the default store lands — see [`pacquet_config::store_path`].
     let store_in_modules = modules_dir.join(".pnpm-store");
     std::fs::create_dir_all(&store_in_modules).unwrap();
 

--- a/pnpm11/store/path/package.json
+++ b/pnpm11/store/path/package.json
@@ -43,10 +43,8 @@
   "devDependencies": {
     "@jest/globals": "catalog:",
     "@pnpm/store.path": "workspace:*",
-    "@types/is-windows": "catalog:",
     "@types/node": "catalog:",
     "@types/touch": "catalog:",
-    "is-windows": "catalog:",
     "rimraf": "catalog:"
   },
   "engines": {

--- a/pnpm11/store/path/src/index.ts
+++ b/pnpm11/store/path/src/index.ts
@@ -103,7 +103,7 @@ async function safeRmdir (dir: string): Promise<void> {
 }
 
 function dirsAreEqual (dir1: string, dir2: string): boolean {
-  return path.relative(dir1, dir2) === '.'
+  return path.relative(dir1, dir2) === ''
 }
 
 function getHomedir (): string {

--- a/pnpm11/store/path/src/index.ts
+++ b/pnpm11/store/path/src/index.ts
@@ -59,14 +59,12 @@ async function storePathRelativeToHome (pkgRoot: string, relStore: string, homed
     // So we create an empty directory and try to link there.
     // The store will be a directory anyway.
     const mountpointParent = path.join(mountpoint, '..')
-    if (!dirsAreEqual(mountpointParent, mountpoint) && await canLinkToSubdir(tempFile, mountpointParent)) {
+    if (mountpointParent !== mountpoint && await canLinkToSubdir(tempFile, mountpointParent)) {
       mountpoint = mountpointParent
     }
-    // If linking works only in the project folder
-    // then prefer to place the store inside the homedir
-    if (dirsAreEqual(pkgRoot, mountpoint)) {
-      return storeInHomeDir
-    }
+    // The mountpoint may be the project directory itself, when nothing above it
+    // accepts a hard link. A store there still links into node_modules, which
+    // beats a store in the home directory that would have to be copied from.
     return path.join(mountpoint, '.pnpm-store', STORE_VERSION)
   } catch {
     // this is an unlikely situation but if there is no way to find
@@ -100,10 +98,6 @@ async function safeRmdir (dir: string): Promise<void> {
   } catch {
     // ignore
   }
-}
-
-function dirsAreEqual (dir1: string, dir2: string): boolean {
-  return path.relative(dir1, dir2) === ''
 }
 
 function getHomedir (): string {

--- a/pnpm11/store/path/src/index.ts
+++ b/pnpm11/store/path/src/index.ts
@@ -62,9 +62,6 @@ async function storePathRelativeToHome (pkgRoot: string, relStore: string, homed
     if (mountpointParent !== mountpoint && await canLinkToSubdir(tempFile, mountpointParent)) {
       mountpoint = mountpointParent
     }
-    // The mountpoint may be the project directory itself, when nothing above it
-    // accepts a hard link. A store there still links into node_modules, which
-    // beats a store in the home directory that would have to be copied from.
     return path.join(mountpoint, '.pnpm-store', STORE_VERSION)
   } catch {
     // this is an unlikely situation but if there is no way to find

--- a/pnpm11/store/path/src/index.ts
+++ b/pnpm11/store/path/src/index.ts
@@ -59,7 +59,7 @@ async function storePathRelativeToHome (pkgRoot: string, relStore: string, homed
     // So we create an empty directory and try to link there.
     // The store will be a directory anyway.
     const mountpointParent = path.join(mountpoint, '..')
-    if (mountpointParent !== mountpoint && await canLinkToSubdir(tempFile, mountpointParent)) {
+    if (!dirsAreEqual(mountpointParent, mountpoint) && await canLinkToSubdir(tempFile, mountpointParent)) {
       mountpoint = mountpointParent
     }
     return path.join(mountpoint, '.pnpm-store', STORE_VERSION)
@@ -95,6 +95,10 @@ async function safeRmdir (dir: string): Promise<void> {
   } catch {
     // ignore
   }
+}
+
+function dirsAreEqual (dir1: string, dir2: string): boolean {
+  return path.relative(dir1, dir2) === ''
 }
 
 function getHomedir (): string {

--- a/pnpm11/store/path/test/index.ts
+++ b/pnpm11/store/path/test/index.ts
@@ -103,18 +103,18 @@ test('a link can be created to the root of the drive', async () => {
   )
 })
 
-test('a link can be created to the a subdir in the root of the drive', async () => {
+test('a link can be created to a subdir in the root of the drive', async () => {
   expect(await getStorePath({
     pkgRoot: MOUNT_PROJECT,
     pnpmHomeDir: PNPM_HOME_DIR,
   })).toBe(path.join(MOUNT_ROOT, '.pnpm-store', STORE_VERSION))
 })
 
-test('the home store is used when only the project directory is linkable', async () => {
+test('the store is created in the project when only the project directory is linkable', async () => {
   expect(await getStorePath({
     pkgRoot: SANDBOX_PROJECT,
     pnpmHomeDir: PNPM_HOME_DIR,
-  })).toBe(path.join(PNPM_HOME_DIR, 'store', STORE_VERSION))
+  })).toBe(path.join(SANDBOX_PROJECT, '.pnpm-store', STORE_VERSION))
   expect(canLinkMock).toHaveBeenCalledWith(
     path.join(SANDBOX_PROJECT, 'tmp'),
     path.join(SANDBOX_ROOT, 'tmp', 'tmp')

--- a/pnpm11/store/path/test/index.ts
+++ b/pnpm11/store/path/test/index.ts
@@ -1,8 +1,16 @@
 import path from 'node:path'
 
-import { expect, jest, test } from '@jest/globals'
+import { beforeEach, expect, jest, test } from '@jest/globals'
 import { STORE_VERSION } from '@pnpm/constants'
-import isWindows from 'is-windows'
+
+const DRIVE_ROOT = path.parse(process.cwd()).root
+const CAN_LINK_HOME_PROJECT = path.join(DRIVE_ROOT, 'can-link-to-homedir')
+const MOUNT_ROOT = path.join(DRIVE_ROOT, 'mnt')
+const MOUNT_PROJECT = path.join(MOUNT_ROOT, 'project')
+const PNPM_HOME_DIR = path.join(DRIVE_ROOT, 'local', 'share', 'pnpm')
+const ROOT_PROJECT = path.join(DRIVE_ROOT, 'src', 'workspace', 'project')
+const SANDBOX_ROOT = path.join(DRIVE_ROOT, 'sandbox')
+const SANDBOX_PROJECT = path.join(SANDBOX_ROOT, 'project')
 
 jest.unstable_mockModule('touch', () => {
   return {
@@ -11,8 +19,9 @@ jest.unstable_mockModule('touch', () => {
 })
 jest.unstable_mockModule('root-link-target', () => {
   const MAPPINGS: Record<string, string> = {
-    '/src/workspace/project/tmp': '/',
-    '/mnt/project/tmp': '/mnt/project',
+    [path.join(MOUNT_PROJECT, 'tmp')]: MOUNT_PROJECT,
+    [path.join(ROOT_PROJECT, 'tmp')]: DRIVE_ROOT,
+    [path.join(SANDBOX_PROJECT, 'tmp')]: SANDBOX_PROJECT,
   }
 
   return {
@@ -52,42 +61,64 @@ const fsMock = {
 }
 jest.unstable_mockModule('fs', () => fsMock)
 jest.unstable_mockModule('node:fs', () => fsMock)
-jest.unstable_mockModule('can-link', () => {
-  const CAN_LINK = new Set([
-    '/can-link-to-homedir/tmp=>/home/user/tmp',
-    '/mnt/project/tmp=>/mnt/tmp/tmp',
-  ])
+const CAN_LINK = new Set([
+  `${path.join(CAN_LINK_HOME_PROJECT, 'tmp')}=>${path.join(PNPM_HOME_DIR, 'tmp', 'tmp')}`,
+  `${path.join(MOUNT_PROJECT, 'tmp')}=>${path.join(MOUNT_ROOT, 'tmp', 'tmp')}`,
+])
+const canLinkMock = jest.fn(function (existingPath: string, newPath: string): boolean {
+  return CAN_LINK.has(`${existingPath}=>${newPath}`)
+})
 
+jest.unstable_mockModule('can-link', () => {
   return {
-    canLink: function (existingPath: string, newPath: string): boolean {
-      return CAN_LINK.has(`${existingPath}=>${newPath}`)
-    },
+    canLink: canLinkMock,
   }
 })
 
 const { getStorePath } = await import('@pnpm/store.path')
 
-const skipOnWindows = isWindows() ? test.skip : test
-
-skipOnWindows('when a link can be created to the homedir', async () => {
-  expect(await getStorePath({
-    pkgRoot: '/can-link-to-homedir',
-    pnpmHomeDir: '/local/share/pnpm',
-  })).toBe(`/local/share/pnpm/store/${STORE_VERSION}`)
+beforeEach(() => {
+  canLinkMock.mockClear()
 })
 
-skipOnWindows('a link can be created to the root of the drive', async () => {
+test('when a link can be created to the homedir', async () => {
   expect(await getStorePath({
-    pkgRoot: '/src/workspace/project',
-    pnpmHomeDir: '/local/share/pnpm',
-  })).toBe(`/.pnpm-store/${STORE_VERSION}`)
+    pkgRoot: CAN_LINK_HOME_PROJECT,
+    pnpmHomeDir: PNPM_HOME_DIR,
+  })).toBe(path.join(PNPM_HOME_DIR, 'store', STORE_VERSION))
+  expect(canLinkMock).toHaveBeenCalledWith(
+    path.join(CAN_LINK_HOME_PROJECT, 'tmp'),
+    path.join(PNPM_HOME_DIR, 'tmp', 'tmp')
+  )
 })
 
-skipOnWindows('a link can be created to the a subdir in the root of the drive', async () => {
+test('a link can be created to the root of the drive', async () => {
   expect(await getStorePath({
-    pkgRoot: '/mnt/project',
-    pnpmHomeDir: '/local/share/pnpm',
-  })).toBe(`/mnt/.pnpm-store/${STORE_VERSION}`)
+    pkgRoot: ROOT_PROJECT,
+    pnpmHomeDir: PNPM_HOME_DIR,
+  })).toBe(path.join(DRIVE_ROOT, '.pnpm-store', STORE_VERSION))
+  expect(canLinkMock).not.toHaveBeenCalledWith(
+    path.join(ROOT_PROJECT, 'tmp'),
+    path.join(DRIVE_ROOT, 'tmp', 'tmp')
+  )
+})
+
+test('a link can be created to the a subdir in the root of the drive', async () => {
+  expect(await getStorePath({
+    pkgRoot: MOUNT_PROJECT,
+    pnpmHomeDir: PNPM_HOME_DIR,
+  })).toBe(path.join(MOUNT_ROOT, '.pnpm-store', STORE_VERSION))
+})
+
+test('the home store is used when only the project directory is linkable', async () => {
+  expect(await getStorePath({
+    pkgRoot: SANDBOX_PROJECT,
+    pnpmHomeDir: PNPM_HOME_DIR,
+  })).toBe(path.join(PNPM_HOME_DIR, 'store', STORE_VERSION))
+  expect(canLinkMock).toHaveBeenCalledWith(
+    path.join(SANDBOX_PROJECT, 'tmp'),
+    path.join(SANDBOX_ROOT, 'tmp', 'tmp')
+  )
 })
 
 test('fail when pnpm home directory is not defined', async () => {


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#13525.

`dirsAreEqual` compared the result of `path.relative()` with `'.'`, but Node returns `''` for equal paths, so both equality checks in `storePathRelativeToHome` were always false. The dead branch would have placed the store in the home directory whenever the project folder was the only linkable location.

The original version of this PR repaired the comparison. Measuring the result showed that executing the branch is the wrong trade, so this PR now removes it instead.

The branch fires exactly when no ancestor of the project accepts a hard link — an agent sandbox that grants write access only to the project, or a container with just the project bind-mounted writable. In a read-only-root sandbox (`bwrap --ro-bind / /` with only the project writable):

| store location | result |
| --- | --- |
| `<project>/.pnpm-store` (what pnpm has always shipped) | install succeeds, hard linked |
| `~/.local/share/pnpm/store/v11` (repairing the comparison) | fails with `EROFS ... symlink .../store/v11/projects/38f7f...` |

When the home directory *is* writable, it is on another volume by construction — that is why the earlier `canLink` probe failed — so the home store forces a full copy of every package and reuses nothing, which is the worst outcome in CI. A store on the project's own volume is the better answer in both cases.

So: the dead branch is removed rather than repaired, and the surviving root guard drops the helper for a plain string comparison of two `path.join` results. **The TypeScript CLI's behavior does not change** — it is what pnpm has shipped since `@pnpm/store-path` moved into the monorepo.

### pacquet

pacquet implemented the intended-but-dead branch, so it inherited both failure modes. It now keeps the store in the project too, at `<project>/node_modules/.pnpm-store` rather than pnpm 11's `<project>/.pnpm-store`, which keeps it out of the working tree's VCS status — the complaint in pnpm/pnpm#13525. This is a deliberate divergence between the two stacks, documented in the `store_path` module docs.

The install purge skips hidden entries other than `.bin`, `.modules.yaml`, and the virtual store dir, so a layout change cannot wipe a store nested there; `test_install_purges_node_modules_on_layout_mismatch` now pins that.

## Squash Commit Body

```text
`dirsAreEqual` compared the result of `path.relative()` with `'.'`, but
Node returns `''` for equal paths, so both equality checks in
`storePathRelativeToHome` were always false. The dead branch would have
placed the store in the home directory whenever the project folder was
the only linkable location.

Executing that branch would be the wrong trade. It fires exactly when no
ancestor of the project accepts a hard link — an agent sandbox that
grants write access only to the project, or a container with just the
project bind-mounted writable. There the home store is either read-only,
so the install fails outright, or on another volume, so every package is
copied instead of hard linked and nothing is ever reused. A store on the
project's own volume is the better answer in both cases, so the branch is
removed rather than repaired, and the surviving root guard drops the
helper for a plain string comparison of two `path.join` results.

pacquet implemented the intended-but-dead branch, so it inherited both
failure modes; it now keeps the store in the project too. It places the
store at `<project>/node_modules/.pnpm-store` instead of pnpm 11's
`<project>/.pnpm-store`, which keeps it out of the working tree's VCS
status. The install purge already skips hidden entries other than `.bin`,
`.modules.yaml`, and the virtual store dir, so a layout change cannot
wipe the store; `test_install_purges_node_modules_on_layout_mismatch` now
pins that.

Closes pnpm/pnpm#13525
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

## Validation

- `pnpm --filter @pnpm/store.path test` — 5/5
- `cargo nextest run -p pacquet-config` — 453/453
- `cargo nextest run -p pacquet-package-manager test_install_purges_node_modules_on_layout_mismatch` — pass, and verified non-vacuous by disabling the purge's hidden-entry skip
- `cargo fmt --check`, `cargo clippy -D warnings` on the touched crates, `RUSTDOCFLAGS=-D warnings cargo doc -p pacquet-config`
- `pnpm run lint:meta`, cspell, `pnpm install --frozen-lockfile`
- Rebased onto current `main`; the unused `is-windows` devDependencies the test rewrite orphaned were removed along with their lockfile entries

---
Written by an agent (Claude Code, claude-opus-5[1m]).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed default store placement when only the project directory supports linking.
  * The store is now created at `<project>/node_modules/.pnpm-store` instead of falling back to the home directory.
  * Improved handling of mount points, drive roots, and project subdirectories.

* **Tests**
  * Expanded coverage for platform-specific paths and store placement scenarios.
  * Improved validation of cleanup behavior when store layouts change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->