### PR TITLE
fix(deps-resolver): reduce peer walker memory on large graphs

### DIFF
--- a/.changeset/peer-walker-realize-memory.md
+++ b/.changeset/peer-walker-realize-memory.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Reduced the peer-resolution walker's memory usage on large dependency graphs. Children realized for a visit that is then served from the `peersCache` are removed from the tree again instead of being retained (previously ~4M never-walked tree nodes on a ~3.5k-package graph), and all children of a node now share one ancestor-chain `Arc` instead of each child cloning the full chain (previously 6.5M clones / ~20 GB of cumulative allocation on the same graph).

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -2289,7 +2289,9 @@ where
         // map: a linked node has no children of its own here.
         crate::resolved_tree::TreeChildren::Realized(BTreeMap::new())
     } else if !children_owner.owns_children {
-        crate::resolved_tree::TreeChildren::Lazy { parent_ids: ancestors_without_self(&next_ancestors) }
+        crate::resolved_tree::TreeChildren::Lazy {
+            parent_ids: ancestors_without_self(&next_ancestors),
+        }
     } else {
         // Look up cached children specs first; only walk the manifest on
         // a miss. The cache value is held by `Arc` so revisits clone the
@@ -2459,7 +2461,9 @@ where
             lock_recoverable(&ctx.workspace.children_by_id).insert(id.clone(), Arc::new(by_id));
             crate::resolved_tree::TreeChildren::Realized(realized)
         } else {
-            crate::resolved_tree::TreeChildren::Lazy { parent_ids: ancestors_without_self(&next_ancestors) }
+            crate::resolved_tree::TreeChildren::Lazy {
+                parent_ids: ancestors_without_self(&next_ancestors),
+            }
         }
     };
 
@@ -2498,8 +2502,10 @@ where
 /// chain clones dominated the peer walker's memory on large graphs.
 ///
 /// [`TreeChildren::Lazy`]: crate::resolved_tree::TreeChildren::Lazy
-/// [`realize_children`]: crate::resolve_peers
-pub(crate) fn ancestors_without_self(chain: &std::sync::Arc<Vec<String>>) -> std::sync::Arc<Vec<String>> {
+/// [`realize_children`]: mod@crate::resolve_peers
+pub(crate) fn ancestors_without_self(
+    chain: &std::sync::Arc<Vec<String>>,
+) -> std::sync::Arc<Vec<String>> {
     std::sync::Arc::new(chain[..chain.len().saturating_sub(1)].to_vec())
 }
 
@@ -3547,10 +3553,14 @@ where
             lock_recoverable(&ctx.workspace.children_by_id).insert(id.clone(), Arc::new(by_id));
             crate::resolved_tree::TreeChildren::Realized(realized)
         } else {
-            crate::resolved_tree::TreeChildren::Lazy { parent_ids: ancestors_without_self(&next_ancestors) }
+            crate::resolved_tree::TreeChildren::Lazy {
+                parent_ids: ancestors_without_self(&next_ancestors),
+            }
         }
     } else {
-        crate::resolved_tree::TreeChildren::Lazy { parent_ids: ancestors_without_self(&next_ancestors) }
+        crate::resolved_tree::TreeChildren::Lazy {
+            parent_ids: ancestors_without_self(&next_ancestors),
+        }
     };
 
     remember_node_parent_ids(ctx, &node_id, ancestors_without_self(&next_ancestors));

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -2289,7 +2289,7 @@ where
         // map: a linked node has no children of its own here.
         crate::resolved_tree::TreeChildren::Realized(BTreeMap::new())
     } else if !children_owner.owns_children {
-        crate::resolved_tree::TreeChildren::Lazy { parent_ids: Arc::clone(&next_ancestors) }
+        crate::resolved_tree::TreeChildren::Lazy { parent_ids: ancestors_without_self(&next_ancestors) }
     } else {
         // Look up cached children specs first; only walk the manifest on
         // a miss. The cache value is held by `Arc` so revisits clone the
@@ -2459,7 +2459,7 @@ where
             lock_recoverable(&ctx.workspace.children_by_id).insert(id.clone(), Arc::new(by_id));
             crate::resolved_tree::TreeChildren::Realized(realized)
         } else {
-            crate::resolved_tree::TreeChildren::Lazy { parent_ids: Arc::clone(&next_ancestors) }
+            crate::resolved_tree::TreeChildren::Lazy { parent_ids: ancestors_without_self(&next_ancestors) }
         }
     };
 
@@ -2472,7 +2472,7 @@ where
     // Linked nodes carry `depth = -1` so the peer-resolution pass
     // short-circuits them in `resolve_node`.
     let node_depth = if is_link { -1 } else { depth };
-    remember_node_parent_ids(ctx, &node_id, Arc::clone(&next_ancestors));
+    remember_node_parent_ids(ctx, &node_id, ancestors_without_self(&next_ancestors));
     insert_tree_node(ctx, node_id.clone(), &id, children, node_depth);
     if children_owner.owns_children
         && !children_owner.children_context_unchanged
@@ -2491,6 +2491,18 @@ where
 /// previously-resolved-children merge restoring the pruned edge on the
 /// repeated node); only the repeat of the full `parent … child`
 /// sequence is dropped.
+/// A node's ancestor chain without the node itself. [`TreeChildren::Lazy`]
+/// stores this shape (rather than the chain including the node) so
+/// [`realize_children`] can rebuild the full chain once per realize call
+/// and share one `Arc` across every child it inserts — the per-child
+/// chain clones dominated the peer walker's memory on large graphs.
+///
+/// [`TreeChildren::Lazy`]: crate::resolved_tree::TreeChildren::Lazy
+/// [`realize_children`]: crate::resolve_peers
+pub(crate) fn ancestors_without_self(chain: &std::sync::Arc<Vec<String>>) -> std::sync::Arc<Vec<String>> {
+    std::sync::Arc::new(chain[..chain.len().saturating_sub(1)].to_vec())
+}
+
 pub(crate) fn parent_ids_contain_sequence(
     pkg_ids: &[String],
     pkg_id1: &str,
@@ -3535,13 +3547,13 @@ where
             lock_recoverable(&ctx.workspace.children_by_id).insert(id.clone(), Arc::new(by_id));
             crate::resolved_tree::TreeChildren::Realized(realized)
         } else {
-            crate::resolved_tree::TreeChildren::Lazy { parent_ids: Arc::clone(&next_ancestors) }
+            crate::resolved_tree::TreeChildren::Lazy { parent_ids: ancestors_without_self(&next_ancestors) }
         }
     } else {
-        crate::resolved_tree::TreeChildren::Lazy { parent_ids: Arc::clone(&next_ancestors) }
+        crate::resolved_tree::TreeChildren::Lazy { parent_ids: ancestors_without_self(&next_ancestors) }
     };
 
-    remember_node_parent_ids(ctx, &node_id, Arc::clone(&next_ancestors));
+    remember_node_parent_ids(ctx, &node_id, ancestors_without_self(&next_ancestors));
     insert_tree_node(ctx, node_id.clone(), &id, children, depth);
     if children_owner.owns_children
         && !children_owner.children_context_unchanged

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -2573,7 +2573,10 @@ impl Walker<'_> {
     ///    [self_pkg_id]` for cycle break on its own descendants.
     /// 4. Flip this node's `children` field to `Realized` so a
     ///    later visitor reuses the map.
-    fn realize_children(&mut self, node_id: &NodeId) -> (BTreeMap<String, NodeId>, Option<UndoRealize>) {
+    fn realize_children(
+        &mut self,
+        node_id: &NodeId,
+    ) -> (BTreeMap<String, NodeId>, Option<UndoRealize>) {
         // Snapshot the bits we need; we'll mutate `self.tree` below
         // and can't hold a borrow on the entry across the mutation.
         let (parent_ids, pkg_id, depth) = {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -50,6 +50,7 @@ use pacquet_deps_path::{
 };
 use pacquet_resolving_resolver_base::{ResolveResult, get_peer_version_range};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+
 use std::{
     collections::{BTreeMap, BTreeSet},
     path::{Path, PathBuf},
@@ -843,6 +844,18 @@ struct FinalPeerContext<'a> {
     cyclic_peer_names: &'a HashSet<String>,
 }
 
+/// State needed to revert a [`Walker::realize_children`] call whose
+/// visit was then served from the peers cache: the freshly inserted
+/// child tree nodes and the `Lazy` parent-ids the node's `children`
+/// field held before the call. Realizing ~20 children per visit for
+/// the ~97% of visits that short-circuit through `purePkgs` /
+/// `peersCache` dominated the walker's memory (millions of
+/// never-walked tree nodes, each carrying an owned ancestor-id chain).
+struct UndoRealize {
+    newly_inserted: Vec<NodeId>,
+    prev_parent_ids: Arc<Vec<String>>,
+}
+
 struct Walker<'tree> {
     tree: &'tree mut ResolvedTree,
     opts: ResolvePeersOptions,
@@ -1396,7 +1409,7 @@ impl Walker<'_> {
         // over it doesn't hold a borrow on `self.tree`, so the
         // recursion below can mutate the tree (realising
         // grandchildren) freely.
-        let children_map = self.realize_children(&node_id);
+        let (children_map, realize_undo) = self.realize_children(&node_id);
         let tree_node = self.tree.dependencies_tree[&node_id].clone();
         let pkg = self.tree.packages[&tree_node.resolved_package_id].clone();
         let mut refs_changed = tree_node.locked_peer_names.is_some();
@@ -1511,6 +1524,20 @@ impl Walker<'_> {
         if let Some(cached) = self.find_hit(&child_parent_refs, &pkg.id) {
             let output = cached.to_node_output();
             let missing_of_children = cached.missing_peers_of_children.clone();
+            // This visit is served from the cache, so the children
+            // realized above will never be walked. Drop the fresh
+            // tree nodes and restore the `Lazy` state so cache-served
+            // occurrences don't retain their (never-visited) subtree
+            // expansion — see [`UndoRealize`].
+            if let Some(undo) = realize_undo {
+                for child_id in &undo.newly_inserted {
+                    self.tree.dependencies_tree.remove(child_id);
+                    self.parent_pkgs_of_node.remove(child_id);
+                }
+                if let Some(node) = self.tree.dependencies_tree.get_mut(&node_id) {
+                    node.children = TreeChildren::Lazy { parent_ids: undo.prev_parent_ids };
+                }
+            }
             // Re-emit the missing-peer issues against the current
             // parent chain so each occurrence of the package shows up
             // in the diagnostic. Without this, the first walk's parent
@@ -2546,13 +2573,13 @@ impl Walker<'_> {
     ///    [self_pkg_id]` for cycle break on its own descendants.
     /// 4. Flip this node's `children` field to `Realized` so a
     ///    later visitor reuses the map.
-    fn realize_children(&mut self, node_id: &NodeId) -> BTreeMap<String, NodeId> {
+    fn realize_children(&mut self, node_id: &NodeId) -> (BTreeMap<String, NodeId>, Option<UndoRealize>) {
         // Snapshot the bits we need; we'll mutate `self.tree` below
         // and can't hold a borrow on the entry across the mutation.
         let (parent_ids, pkg_id, depth) = {
             let node = &self.tree.dependencies_tree[node_id];
             match &node.children {
-                TreeChildren::Realized(map) => return map.clone(),
+                TreeChildren::Realized(map) => return (map.clone(), None),
                 TreeChildren::Lazy { parent_ids } => {
                     (Arc::clone(parent_ids), node.resolved_package_id.clone(), node.depth)
                 }
@@ -2566,12 +2593,22 @@ impl Walker<'_> {
         };
         let child_depth = depth + 1;
         let mut realized: BTreeMap<String, NodeId> = BTreeMap::new();
+        let mut newly_inserted: Vec<NodeId> = Vec::new();
+        // `parent_ids` excludes this node itself; rebuild the full
+        // chain once and share the `Arc` across every child inserted
+        // below — see `ancestors_without_self`.
+        let full_chain = {
+            let mut chain = Vec::with_capacity(parent_ids.len() + 1);
+            chain.extend(parent_ids.iter().cloned());
+            chain.push(pkg_id.clone());
+            Arc::new(chain)
+        };
         for edge in children_spec.iter() {
             // Same cycle gate as the eager walk: keep the first
             // re-entry, drop a direct self-edge or a second lap.
             if pkg_id == edge.pkg_id
                 || crate::resolve_dependency_tree::parent_ids_contain_sequence(
-                    &parent_ids,
+                    &full_chain,
                     &pkg_id,
                     &edge.pkg_id,
                 )
@@ -2586,27 +2623,23 @@ impl Walker<'_> {
             // later visit can still observe per-call-site state.
             let is_leaf = self.tree.packages.get(&edge.pkg_id).is_some_and(|pkg| pkg.is_leaf);
             let child_node_id = if is_leaf { NodeId::leaf(&edge.pkg_id) } else { NodeId::next() };
-            let child_parent_ids = {
-                let mut next_ids = (*parent_ids).clone();
-                next_ids.push(edge.pkg_id.clone());
-                Arc::new(next_ids)
-            };
-            self.tree
-                .dependencies_tree
-                .entry(child_node_id.clone())
-                .and_modify(|n| {
-                    if n.depth > child_depth {
-                        n.depth = child_depth;
-                    }
-                })
-                .or_insert_with(|| {
+            let child_parent_ids = Arc::clone(&full_chain);
+            if let Some(n) = self.tree.dependencies_tree.get_mut(&child_node_id) {
+                if n.depth > child_depth {
+                    n.depth = child_depth;
+                }
+            } else {
+                self.tree.dependencies_tree.insert(
+                    child_node_id.clone(),
                     DependenciesTreeNode::new(
                         edge.pkg_id.clone(),
                         TreeChildren::Lazy { parent_ids: child_parent_ids },
                         child_depth,
                         true,
-                    )
-                });
+                    ),
+                );
+                newly_inserted.push(child_node_id.clone());
+            }
             realized.insert(edge.alias.clone(), child_node_id);
         }
         // Replace this node's `Lazy` with `Realized` so future
@@ -2614,7 +2647,7 @@ impl Walker<'_> {
         if let Some(node) = self.tree.dependencies_tree.get_mut(node_id) {
             node.children = TreeChildren::Realized(realized.clone());
         }
-        realized
+        (realized, Some(UndoRealize { newly_inserted, prev_parent_ids: parent_ids }))
     }
 
     fn previously_resolved_children(
@@ -2634,7 +2667,7 @@ impl Walker<'_> {
                 .get(parent_node_id)
                 .is_some_and(|node| node.resolved_package_id == current_pkg_id);
             if same_pkg {
-                for (alias, child_node_id) in self.realize_children(parent_node_id) {
+                for (alias, child_node_id) in self.realize_children(parent_node_id).0 {
                     children.entry(alias).or_insert(child_node_id);
                 }
             }

--- a/pnpm/crates/resolving-deps-resolver/src/resolved_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolved_tree.rs
@@ -225,7 +225,10 @@ pub enum TreeChildren {
     Realized(BTreeMap<String, NodeId>),
     /// Children are known by spec only. `parent_ids` is the chain of
     /// `pkgIdWithPatchHash` ancestors this occurrence reached the
-    /// node through, threaded so the peer resolver's tree builder can
+    /// node through — excluding the node itself, which the reader
+    /// appends from `resolved_package_id` (so one chain `Arc` is
+    /// shared across every sibling instead of cloned per child) —
+    /// threaded so the peer resolver's tree builder can
     /// apply the parent-ids-contain-sequence cycle-break
     /// per-occurrence. Without it, a revisit's subtree would
     /// silently include cycle edges that the first walk correctly


### PR DESCRIPTION
Two allocation hot spots in the peer-resolution `Walker`, found while investigating installs of a large single-importer graph (~3.5k packages) that peak at >30 GB RSS through `@pnpm/napi` (repro and full investigation: https://github.com/pnpm/pnpm/issues/13540).

1. **Children were realized before the peers-cache check.** ~97% of `resolve_node` visits short-circuit through `purePkgs`/`peersCache`, but every visit had already materialized all of its children into the persistent tree — ~5M occurrence nodes on the graph above, ~4M of them belonging to visits that were then served from the cache and never walked. `realize_children` now reports which tree nodes it freshly inserted, and a cache-served visit removes them again and restores the node's `Lazy` state.

2. **Each realized child cloned the full ancestor chain.** `TreeChildren::Lazy { parent_ids }` stored the chain *including the node itself*, so siblings could never share it and every child got its own `Vec<String>` copy of the whole chain — 6.5M clones / ~20.5 GB cumulative allocation on the same graph. The chain now excludes the node itself (readers append it from `resolved_package_id`), so one `Arc` per `realize_children` call is shared by all siblings: 6.5M → 618k chain allocations, ~20.5 GB → ~2 GB.

Measured on the repro graph: retained tree nodes after the first discovery pass drop 4.95M → 966k, and peak RSS of a `lockfileOnly` install drops 32.8 GB → 27.5 GB. The resulting `pnpm-lock.yaml` is byte-identical to the one the unpatched engine produces. This intentionally does not address the two larger remaining costs (per-visit retained walk state, and the hoisted linker's `walk_deps` graph) — those need design decisions and are described in #13540.

`cargo test -p pacquet-resolving-deps-resolver`: 278 passed.
