### PR TITLE
fix: preserve percent-encoded slashes in registry tarball URLs

### DIFF
--- a/.changeset/fix-dist-tarball-encoded-slashes.md
+++ b/.changeset/fix-dist-tarball-encoded-slashes.md
@@ -1,7 +1,7 @@
 ---
 "@pnpm/resolving.tarball-url": patch
-"pnpm": patch
 "pacquet": patch
+"pnpm": patch
 ---
 
-Fix an issue where scoped packages using percent-encoded slashes (`%2f` or `%2F`) in their registry tarball URLs could have their URLs incorrectly omitted from the lockfile, subsequently causing 404 errors during installation on registries that require percent-encoding (e.g. GitHub Enterprise Server).
+Fixed `404` errors when installing from a registry that serves scoped packages only from a percent-encoded path, such as GitHub Enterprise Server. Outside `registry.npmjs.org`, a tarball URL that encodes the scope separator as `%2f` or `%2F` is no longer mistaken for one that pnpm can rebuild from the package name, version, and registry, so it is kept in `pnpm-lock.yaml` and requested verbatim on the next install [#13534](https://github.com/pnpm/pnpm/issues/13534).

--- a/.changeset/fix-dist-tarball-encoded-slashes.md
+++ b/.changeset/fix-dist-tarball-encoded-slashes.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/resolving.tarball-url": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+Fix an issue where scoped packages using percent-encoded slashes (`%2f` or `%2F`) in their registry tarball URLs could have their URLs incorrectly omitted from the lockfile, subsequently causing 404 errors during installation on registries that require percent-encoding (e.g. GitHub Enterprise Server).

--- a/pnpm/crates/lockfile/src/resolution.rs
+++ b/pnpm/crates/lockfile/src/resolution.rs
@@ -414,8 +414,7 @@ pub fn npm_tarball_url(name: &str, version: &str, registry: &str) -> String {
 
 /// Whether `tarball` is the canonical npm registry URL derived from `name`,
 /// `version`, and `registry` — i.e. it can be dropped from the lockfile and
-/// rebuilt on demand. Percent-encoding is case-insensitive, so the unescape
-/// matches both `%2f` and `%2F` in the URLs npm produces for scoped packages.
+/// rebuilt on demand.
 fn is_canonical_registry_tarball_url(
     tarball: &str,
     name: &str,
@@ -423,8 +422,21 @@ fn is_canonical_registry_tarball_url(
     registry: &str,
 ) -> bool {
     let expected = npm_tarball_url(name, version, registry);
-    let actual = tarball;
-    remove_protocol(&expected) == remove_protocol(actual)
+    let expected = remove_protocol(&expected);
+    let actual = remove_protocol(tarball);
+    // registry.npmjs.org serves a scoped package from both the encoded and the
+    // unencoded path; elsewhere only the encoded one may work.
+    // See <https://github.com/pnpm/pnpm/issues/13534>.
+    expected == actual
+        || (is_public_npm_registry(registry)
+            && expected == actual.replace("%2f", "/").replace("%2F", "/"))
+}
+
+const PUBLIC_NPM_REGISTRY_HOST: &str = "registry.npmjs.org";
+
+fn is_public_npm_registry(registry: &str) -> bool {
+    let registry = remove_protocol(registry);
+    registry.strip_suffix('/').unwrap_or(registry) == PUBLIC_NPM_REGISTRY_HOST
 }
 
 /// Default-vs-scope routing for an npm package.

--- a/pnpm/crates/lockfile/src/resolution.rs
+++ b/pnpm/crates/lockfile/src/resolution.rs
@@ -423,8 +423,8 @@ fn is_canonical_registry_tarball_url(
     registry: &str,
 ) -> bool {
     let expected = npm_tarball_url(name, version, registry);
-    let actual = tarball.replace("%2f", "/").replace("%2F", "/");
-    remove_protocol(&expected) == remove_protocol(&actual)
+    let actual = tarball;
+    remove_protocol(&expected) == remove_protocol(actual)
 }
 
 /// Default-vs-scope routing for an npm package.

--- a/pnpm/crates/lockfile/src/resolution.rs
+++ b/pnpm/crates/lockfile/src/resolution.rs
@@ -408,8 +408,8 @@ fn is_canonical_registry_tarball_url(
     registry: &str,
 ) -> bool {
     let expected = npm_tarball_url(name, version, registry);
-    let actual = tarball.replace("%2f", "/").replace("%2F", "/");
-    remove_protocol(&expected) == remove_protocol(&actual)
+    let actual = tarball;
+    remove_protocol(&expected) == remove_protocol(actual)
 }
 
 /// Default-vs-scope routing for an npm package.

--- a/pnpm/crates/lockfile/src/resolution/tests.rs
+++ b/pnpm/crates/lockfile/src/resolution/tests.rs
@@ -791,11 +791,26 @@ fn to_lockfile_form_keeps_git_hosted_subdirectory_path_when_including_tarball_ur
     assert_eq!(actual, resolution);
 }
 
-/// Percent-encoded scoped package tarball URLs are not considered canonical,
-/// and must be kept verbatim in the lockfile to prevent 404s on registries (like GHES)
-/// that require percent-encoding.
 #[test]
-fn to_lockfile_form_keeps_scoped_tarball_with_percent_encoding() {
+fn to_lockfile_form_keeps_scoped_tarball_with_percent_encoded_scope_separator() {
+    for tarball_url in [
+        "https://npm.example.com/@babel%2Fcore/-/core-7.0.0.tgz",
+        "https://npm.example.com/@babel%2fcore/-/core-7.0.0.tgz",
+    ] {
+        let resolution = LockfileResolution::Tarball(TarballResolution {
+            tarball: tarball_url.to_string(),
+            integrity: Some(integrity(SHA512)),
+            git_hosted: None,
+            path: None,
+        });
+        let actual =
+            resolution.to_lockfile_form("@babel/core", "7.0.0", "https://npm.example.com/", false);
+        assert_eq!(actual, resolution, "{tarball_url} must survive verbatim");
+    }
+}
+
+#[test]
+fn to_lockfile_form_drops_scoped_tarball_with_percent_encoding_on_the_public_registry() {
     for tarball_url in [
         "https://registry.npmjs.org/@babel%2Fcore/-/core-7.0.0.tgz",
         "https://registry.npmjs.org/@babel%2fcore/-/core-7.0.0.tgz",
@@ -812,7 +827,11 @@ fn to_lockfile_form_keeps_scoped_tarball_with_percent_encoding() {
             "https://registry.npmjs.org/",
             false,
         );
-        assert_eq!(actual, resolution);
+        assert_eq!(
+            actual,
+            LockfileResolution::Registry(RegistryResolution { integrity: integrity(SHA512) }),
+            "{tarball_url} must be dropped",
+        );
     }
 }
 

--- a/pnpm/crates/lockfile/src/resolution/tests.rs
+++ b/pnpm/crates/lockfile/src/resolution/tests.rs
@@ -732,22 +732,29 @@ fn to_lockfile_form_keeps_git_hosted_subdirectory_path_when_including_tarball_ur
     assert_eq!(actual, resolution);
 }
 
-/// Percent-encoding is case-insensitive, so a scoped tarball using uppercase
-/// `%2F` is still the canonical URL and must be dropped just like `%2f`.
+/// Percent-encoded scoped package tarball URLs are not considered canonical,
+/// and must be kept verbatim in the lockfile to prevent 404s on registries (like GHES)
+/// that require percent-encoding.
 #[test]
-fn to_lockfile_form_drops_scoped_tarball_with_uppercase_percent_encoding() {
-    let resolution = LockfileResolution::Tarball(TarballResolution {
-        tarball: "https://registry.npmjs.org/@babel%2Fcore/-/core-7.0.0.tgz".to_string(),
-        integrity: Some(integrity(SHA512)),
-        git_hosted: None,
-        path: None,
-    });
-    let actual =
-        resolution.to_lockfile_form("@babel/core", "7.0.0", "https://registry.npmjs.org/", false);
-    assert_eq!(
-        actual,
-        LockfileResolution::Registry(RegistryResolution { integrity: integrity(SHA512) }),
-    );
+fn to_lockfile_form_keeps_scoped_tarball_with_percent_encoding() {
+    for tarball_url in [
+        "https://registry.npmjs.org/@babel%2Fcore/-/core-7.0.0.tgz",
+        "https://registry.npmjs.org/@babel%2fcore/-/core-7.0.0.tgz",
+    ] {
+        let resolution = LockfileResolution::Tarball(TarballResolution {
+            tarball: tarball_url.to_string(),
+            integrity: Some(integrity(SHA512)),
+            git_hosted: None,
+            path: None,
+        });
+        let actual = resolution.to_lockfile_form(
+            "@babel/core",
+            "7.0.0",
+            "https://registry.npmjs.org/",
+            false,
+        );
+        assert_eq!(actual, resolution);
+    }
 }
 
 /// A URL that merely starts with the canonical URL but carries a trailing

--- a/pnpm/crates/lockfile/src/resolution/tests.rs
+++ b/pnpm/crates/lockfile/src/resolution/tests.rs
@@ -791,22 +791,29 @@ fn to_lockfile_form_keeps_git_hosted_subdirectory_path_when_including_tarball_ur
     assert_eq!(actual, resolution);
 }
 
-/// Percent-encoding is case-insensitive, so a scoped tarball using uppercase
-/// `%2F` is still the canonical URL and must be dropped just like `%2f`.
+/// Percent-encoded scoped package tarball URLs are not considered canonical,
+/// and must be kept verbatim in the lockfile to prevent 404s on registries (like GHES)
+/// that require percent-encoding.
 #[test]
-fn to_lockfile_form_drops_scoped_tarball_with_uppercase_percent_encoding() {
-    let resolution = LockfileResolution::Tarball(TarballResolution {
-        tarball: "https://registry.npmjs.org/@babel%2Fcore/-/core-7.0.0.tgz".to_string(),
-        integrity: Some(integrity(SHA512)),
-        git_hosted: None,
-        path: None,
-    });
-    let actual =
-        resolution.to_lockfile_form("@babel/core", "7.0.0", "https://registry.npmjs.org/", false);
-    assert_eq!(
-        actual,
-        LockfileResolution::Registry(RegistryResolution { integrity: integrity(SHA512) }),
-    );
+fn to_lockfile_form_keeps_scoped_tarball_with_percent_encoding() {
+    for tarball_url in [
+        "https://registry.npmjs.org/@babel%2Fcore/-/core-7.0.0.tgz",
+        "https://registry.npmjs.org/@babel%2fcore/-/core-7.0.0.tgz",
+    ] {
+        let resolution = LockfileResolution::Tarball(TarballResolution {
+            tarball: tarball_url.to_string(),
+            integrity: Some(integrity(SHA512)),
+            git_hosted: None,
+            path: None,
+        });
+        let actual = resolution.to_lockfile_form(
+            "@babel/core",
+            "7.0.0",
+            "https://registry.npmjs.org/",
+            false,
+        );
+        assert_eq!(actual, resolution);
+    }
 }
 
 /// A URL that merely starts with the canonical URL but carries a trailing

--- a/pnpm11/lockfile/utils/test/toLockfileResolution.ts
+++ b/pnpm11/lockfile/utils/test/toLockfileResolution.ts
@@ -53,6 +53,35 @@ test('keeps the tarball for non-standard registry URLs when lockfileIncludeTarba
   })
 })
 
+test.each([
+  'https://npm.example.com/@babel%2Fcore/-/core-7.0.0.tgz',
+  'https://npm.example.com/@babel%2fcore/-/core-7.0.0.tgz',
+])('keeps a scoped tarball URL that percent-encodes the scope separator: %s', (tarball) => {
+  expect(toLockfileResolution(
+    { name: '@babel/core', version: '7.0.0' },
+    { integrity: 'sha512-AAAA', tarball },
+    'https://npm.example.com/',
+    false
+  )).toEqual({
+    integrity: 'sha512-AAAA',
+    tarball,
+  })
+})
+
+test.each([
+  'https://registry.npmjs.org/@babel%2Fcore/-/core-7.0.0.tgz',
+  'https://registry.npmjs.org/@babel%2fcore/-/core-7.0.0.tgz',
+])('drops a percent-encoded scoped tarball URL on the public registry: %s', (tarball) => {
+  expect(toLockfileResolution(
+    { name: '@babel/core', version: '7.0.0' },
+    { integrity: 'sha512-AAAA', tarball },
+    REGISTRY,
+    false
+  )).toEqual({
+    integrity: 'sha512-AAAA',
+  })
+})
+
 test('keeps GitHub Packages /download/ tarball URLs when lockfileIncludeTarballUrl is false', () => {
   // GitHub Packages serves tarballs at /download/<scope>/<name>/<version>/<hash>,
   // which cannot be derived from name+version+registry. See

--- a/pnpm11/resolving/npm-resolver/src/createNpmResolutionVerifier.ts
+++ b/pnpm11/resolving/npm-resolver/src/createNpmResolutionVerifier.ts
@@ -437,10 +437,9 @@ function sameTarballUrl (a: string, b: string): boolean {
   return canonicalTarballUrl(a) === canonicalTarballUrl(b)
 }
 
-// Mirror the tolerance toLockfileResolution applies when it decides whether
-// a tarball URL is "the expected one": ignore the protocol and `%2f` scope
-// encoding so a benign http/https or encoding difference isn't read as
-// tampering. The `%2f` match is case-insensitive because `normalizeRegistryUrl`
+// Both URLs come from the registry, so ignore the protocol and `%2f` scope
+// encoding: a benign http/https or encoding difference isn't tampering. The
+// `%2f` match is case-insensitive because `normalizeRegistryUrl`
 // (`new URL().toString()`) can upper-case percent-escapes to `%2F`.
 function canonicalTarballUrl (url: string): string {
   const normalized = normalizeRegistryUrl(url).replace(/%2f/gi, '/')

--- a/pnpm11/resolving/tarball-url/src/index.ts
+++ b/pnpm11/resolving/tarball-url/src/index.ts
@@ -1,3 +1,5 @@
+const PUBLIC_NPM_REGISTRY = 'https://registry.npmjs.org/'
+
 /**
  * Build the canonical tarball URL of an npm package — i.e. the URL pnpm derives
  * from a package's name, version, and registry. Vendored from the
@@ -28,22 +30,27 @@ export function getNpmTarballUrl (
  * path (e.g. an ephemeral `localhost:<port>`) can rewrite the resolved tarball
  * to `getNpmTarballUrl(name, version, { registry })` so nothing host-specific
  * is persisted to `pnpm-lock.yaml`.
- *
- * Percent-encoding is case-insensitive, so the `%2f` unescape matches both
- * `%2f` and `%2F` in the URLs npm produces for scoped packages.
  */
 export function isCanonicalRegistryTarballUrl (
   tarball: string,
   pkg: { name: string, version: string },
   registry: string
 ): boolean {
-  const expectedTarball = getNpmTarballUrl(pkg.name, pkg.version, { registry })
-  const actualTarball = tarball
-  return removeProtocol(expectedTarball) === removeProtocol(actualTarball)
+  const expectedTarball = removeProtocol(getNpmTarballUrl(pkg.name, pkg.version, { registry }))
+  const actualTarball = removeProtocol(tarball)
+  if (expectedTarball === actualTarball) return true
+  // registry.npmjs.org serves a scoped package from both the encoded and the
+  // unencoded path; elsewhere only the encoded one may work.
+  // See https://github.com/pnpm/pnpm/issues/13534.
+  return isPublicNpmRegistry(registry) && expectedTarball === actualTarball.replace(/%2f/gi, '/')
+}
+
+function isPublicNpmRegistry (registry: string): boolean {
+  return removeProtocol(normalizeRegistry(registry)) === removeProtocol(PUBLIC_NPM_REGISTRY)
 }
 
 function normalizeRegistry (registry?: string): string {
-  if (!registry) return 'https://registry.npmjs.org/'
+  if (!registry) return PUBLIC_NPM_REGISTRY
   return registry.endsWith('/') ? registry : `${registry}/`
 }
 

--- a/pnpm11/resolving/tarball-url/src/index.ts
+++ b/pnpm11/resolving/tarball-url/src/index.ts
@@ -38,7 +38,7 @@ export function isCanonicalRegistryTarballUrl (
   registry: string
 ): boolean {
   const expectedTarball = getNpmTarballUrl(pkg.name, pkg.version, { registry })
-  const actualTarball = tarball.replace(/%2f/gi, '/')
+  const actualTarball = tarball
   return removeProtocol(expectedTarball) === removeProtocol(actualTarball)
 }
 

--- a/pnpm11/resolving/tarball-url/test/index.test.ts
+++ b/pnpm11/resolving/tarball-url/test/index.test.ts
@@ -41,14 +41,18 @@ describe('isCanonicalRegistryTarballUrl', () => {
     expect(isCanonicalRegistryTarballUrl(tarball, { name: '@babel/core', version: '7.0.0' }, registry)).toBe(true)
   })
 
-  test('is false for a scoped package using lowercase %2f escaping', () => {
-    const tarball = 'https://registry.npmjs.org/@babel%2fcore/-/core-7.0.0.tgz'
-    expect(isCanonicalRegistryTarballUrl(tarball, { name: '@babel/core', version: '7.0.0' }, registry)).toBe(false)
+  test.each([
+    'https://registry.npmjs.org/@babel%2fcore/-/core-7.0.0.tgz',
+    'https://registry.npmjs.org/@babel%2Fcore/-/core-7.0.0.tgz',
+  ])('is true on the public registry, which also serves the encoded path: %s', (tarball) => {
+    expect(isCanonicalRegistryTarballUrl(tarball, { name: '@babel/core', version: '7.0.0' }, registry)).toBe(true)
   })
 
-  test('is false for a scoped package using uppercase %2F escaping', () => {
-    const tarball = 'https://registry.npmjs.org/@babel%2Fcore/-/core-7.0.0.tgz'
-    expect(isCanonicalRegistryTarballUrl(tarball, { name: '@babel/core', version: '7.0.0' }, registry)).toBe(false)
+  test.each([
+    'https://npm.example.com/@babel%2fcore/-/core-7.0.0.tgz',
+    'https://npm.example.com/@babel%2Fcore/-/core-7.0.0.tgz',
+  ])('is false on any other registry, which may serve only the encoded path: %s', (tarball) => {
+    expect(isCanonicalRegistryTarballUrl(tarball, { name: '@babel/core', version: '7.0.0' }, 'https://npm.example.com/')).toBe(false)
   })
 
   test('ignores the protocol', () => {

--- a/pnpm11/resolving/tarball-url/test/index.test.ts
+++ b/pnpm11/resolving/tarball-url/test/index.test.ts
@@ -36,14 +36,19 @@ describe('isCanonicalRegistryTarballUrl', () => {
     expect(isCanonicalRegistryTarballUrl(tarball, { name: 'lodash', version: '4.17.21' }, registry)).toBe(true)
   })
 
-  test('is true for a scoped package, matching the npm %2f escaping', () => {
+  test('is true for a scoped package using unencoded slash', () => {
     const tarball = getNpmTarballUrl('@babel/core', '7.0.0', { registry })
     expect(isCanonicalRegistryTarballUrl(tarball, { name: '@babel/core', version: '7.0.0' }, registry)).toBe(true)
   })
 
-  test('is true for a scoped package using uppercase %2F escaping', () => {
+  test('is false for a scoped package using lowercase %2f escaping', () => {
+    const tarball = 'https://registry.npmjs.org/@babel%2fcore/-/core-7.0.0.tgz'
+    expect(isCanonicalRegistryTarballUrl(tarball, { name: '@babel/core', version: '7.0.0' }, registry)).toBe(false)
+  })
+
+  test('is false for a scoped package using uppercase %2F escaping', () => {
     const tarball = 'https://registry.npmjs.org/@babel%2Fcore/-/core-7.0.0.tgz'
-    expect(isCanonicalRegistryTarballUrl(tarball, { name: '@babel/core', version: '7.0.0' }, registry)).toBe(true)
+    expect(isCanonicalRegistryTarballUrl(tarball, { name: '@babel/core', version: '7.0.0' }, registry)).toBe(false)
   })
 
   test('ignores the protocol', () => {


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Scoped packages whose registry tarball URL percent-encodes the scope separator (`@scope%2fname`) had that URL stripped from the lockfile, because the canonical-URL check unescaped `%2f`/`%2F` before comparing it against the URL pnpm derives from the package name, version, and registry. On a registry that serves the package only from the encoded path — GitHub Enterprise Server — the next install rebuilt the unencoded URL and failed with `404 Not Found`.

The unescape is now scoped to `registry.npmjs.org`, which answers the encoded and the unencoded path with the same tarball (verified against the live registry: the two forms return identical bytes). Against every other registry the match is exact apart from the protocol, so an encoded URL is kept verbatim in `pnpm-lock.yaml` and requested unchanged on the next install.

Closes pnpm/pnpm#13534

### Behavior notes

- **npmjs users see no change.** Encoded npmjs URLs — from an existing lockfile or a pnpmfile `resolvers` hook — still collapse to `{ integrity }`, so there is no lockfile churn.
- **On other registries those entries now carry an absolute tarball URL**, so they stop following a later change to the `registry` setting, exactly as GitHub Packages `/download/` URLs already behave. The lockfile-verification pass compares the pinned URL against the packument from the *configured* registry, so a registry switch fails the install loudly instead of fetching cross-host.
- **Nothing widens on the read path.** `isCanonicalRegistryTarballUrl` / `is_canonical_registry_tarball_url` are used only when writing the lockfile; installs already honored any `tarball` field verbatim.

## Squash Commit Body

```text
Scope the tarball URL percent-decoding to the public registry

The canonical registry tarball URL check unescaped `%2f`/`%2F` before
comparing, so a scoped package served only from the encoded path (GitHub
Enterprise Server) had its URL classified as canonical and dropped from the
lockfile; the next install rebuilt the unencoded URL and got a 404.

registry.npmjs.org serves a scoped package from both the encoded and the
unencoded path, so the unescape is kept there and encoded npmjs URLs already
recorded in a lockfile keep resolving to `{ integrity }` rather than churning.
Everywhere else the match is now exact apart from the protocol, so the encoded
URL stays in `pnpm-lock.yaml` and is requested verbatim.

Closes pnpm/pnpm#13534
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13541"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788122255&installation_model_id=426870&pr_number=13541&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13541&signature=1c83944fd64f58a42ea987d4082cf9ca55ef4c4c3e8cd2b16aa323198f2df1a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved percent-encoded slashes in scoped-package registry tarball URLs.
  * Prevented valid URLs from being omitted from lockfiles or causing installation 404 errors.
  * Improved handling of uppercase and lowercase encoded slash formats across public and private registries.
  * Ensured equivalent public registry URLs are recognized consistently.

* **Tests**
  * Expanded coverage for scoped-package tarball URLs and lockfile resolution behavior.

* **Documentation**
  * Added release notes for the affected packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
