### PR TITLE
perf(pacquet): bound memory in peer-heavy hoisted installs

### DIFF
--- a/.changeset/quick-plums-hoist.md
+++ b/.changeset/quick-plums-hoist.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Reduced memory use when resolving peer-heavy dependency graphs and prevented nested hoisted graphs from expanding into excessive dependency paths.

--- a/.github/workflows/pacquet-integrated-benchmark.yml
+++ b/.github/workflows/pacquet-integrated-benchmark.yml
@@ -72,7 +72,7 @@ jobs:
       # workflow_dispatch from a non-main branch), compare HEAD against
       # main so the report shows the relative shift.
       #
-      # Every scenario runs both tools: `pacquet@<rev>` (direct install)
+      # Every regular scenario runs both tools: `pacquet@<rev>` (direct install)
       # and `pnpr@<rev>` (the same client through the pnpr install
       # accelerator, against a warm long-running server). The cold-store
       # scenarios wipe the *client* store between iterations while the
@@ -80,6 +80,15 @@ jobs:
       # the realistic CI case. Running both tools in one hyperfine
       # invocation also yields the pnpr-vs-direct ratio per scenario.
       BENCHMARK_TARGETS: ${{ github.ref_name == 'main' && 'pacquet@HEAD pnpr@HEAD' || 'pacquet@HEAD pacquet@main pnpr@HEAD pnpr@main' }}
+      # The peer-heavy resolver case compares the PR against both main and the
+      # TypeScript CLI. It does not include pnpr because the timed offline
+      # command exercises client-side peer resolution rather than server or
+      # tarball performance.
+      PEER_HEAVY_BENCHMARK_TARGETS: ${{ github.ref_name == 'main' && 'pacquet@HEAD pnpm@HEAD' || 'pacquet@HEAD pacquet@main pnpm@HEAD' }}
+      # Precompile the union once. The regular and peer-heavy target lists
+      # overlap on pacquet, so spelling out the distinct targets avoids
+      # cloning/building the same revision twice.
+      BENCHMARK_BUILD_TARGETS: ${{ github.ref_name == 'main' && 'pacquet@HEAD pnpr@HEAD pnpm@HEAD' || 'pacquet@HEAD pacquet@main pnpr@HEAD pnpr@main pnpm@HEAD' }}
       # Network emulation so both install strategies cross the link they
       # would in production instead of free loopback (~GB/s, ~0 RTT), which
       # would hide every download cost.
@@ -256,13 +265,14 @@ jobs:
 
       - name: Precompile benchmark revisions
         shell: bash
-        # Builds the superset of targets (pacquet + pnpr revisions). A
-        # `pnpr@<rev>` target builds both the `pacquet` client and the
+        # Builds the superset of targets (pacquet + pnpr revisions and the
+        # TypeScript pnpm bundle). A pnpr target builds both the `pacquet`
+        # client and the
         # `pnpr` server from its clone, so this also produces the server
         # binaries the boot step needs. More builds than the pacquet-only
         # bench, hence the larger timeout.
         timeout-minutes: 50
-        run: just integrated-benchmark --reuse-prebuilt-binaries --build-only $BENCHMARK_TARGETS
+        run: just integrated-benchmark --reuse-prebuilt-binaries --build-only $BENCHMARK_BUILD_TARGETS
 
       - name: 'Benchmark: Isolated linker: fresh restore, cold cache + cold store'
         shell: bash
@@ -346,6 +356,21 @@ jobs:
           cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESOLVE_HOT_CACHE_OFFLINE.md
           cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESOLVE_HOT_CACHE_OFFLINE.json
 
+      - name: 'Benchmark: Isolated linker: peer-heavy resolve, hot cache, offline'
+        shell: bash
+        # Bit-style dependency DAG whose shared subgraphs expand into many
+        # peer-resolution occurrences. The online lockfile-only pass primes
+        # each target's metadata mirror; timed runs remove the generated
+        # lockfile and resolve offline, isolating peer discovery and resolution.
+        # Three measured runs are enough because the pre-fix regression is
+        # multi-second and deterministic, while keeping the added CI cost
+        # bounded across current Rust, main Rust, and TypeScript pnpm.
+        timeout-minutes: 25
+        run: |
+          just integrated-benchmark --reuse-prebuilt-binaries --scenario=isolated-linker.peer-heavy-resolve.hot-cache.offline --runs=3 --registry=verdaccio --pnpr-latency-ms=${PNPR_LATENCY_MS} --registry-latency-ms=${REGISTRY_LATENCY_MS} --registry-bandwidth-mbps=${REGISTRY_BANDWIDTH_MBPS} $PEER_HEAVY_BENCHMARK_TARGETS
+          cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_ISOLATED_PEER_HEAVY_RESOLVE_HOT_CACHE_OFFLINE.md
+          cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_ISOLATED_PEER_HEAVY_RESOLVE_HOT_CACHE_OFFLINE.json
+
       - name: 'Benchmark: Isolated linker: fresh restore, cold cache + cold store + cold pnpr'
         shell: bash
         # The only scenario with a cold pnpr-side cache: the per-revision mock
@@ -414,7 +439,7 @@ jobs:
             echo
             echo "**Commit:** [\`${SHA:0:12}\`](${{ github.server_url }}/${{ github.repository }}/commit/$SHA)"
             echo
-            echo 'Each scenario reports direct installs and pnpr installs. Bencher consumes pacquet@HEAD and pnpr@HEAD.'
+            echo 'Regular scenarios report direct and pnpr installs. The peer-heavy resolver scenario compares current Rust, main Rust, and TypeScript pnpm. Bencher consumes pacquet@HEAD and pnpr@HEAD.'
             echo
             echo 'The tables below show mean ± σ; Bencher thresholds on the **minimum** latency, which is far less perturbed by shared-runner contention (noise only adds time).'
             echo
@@ -490,6 +515,18 @@ jobs:
             echo
             echo '</details>'
             echo
+            echo '### Scenario: Isolated linker: peer-heavy resolve, hot cache, offline'
+            echo
+            cat bench-work-env/BENCHMARK_REPORT_ISOLATED_PEER_HEAVY_RESOLVE_HOT_CACHE_OFFLINE.md
+            echo
+            echo '<details><summary>BENCHMARK_REPORT.json</summary>'
+            echo
+            echo '```json'
+            jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_ISOLATED_PEER_HEAVY_RESOLVE_HOT_CACHE_OFFLINE.json
+            echo '```'
+            echo
+            echo '</details>'
+            echo
             echo '### Scenario: Isolated linker: fresh restore, cold cache + cold store + cold pnpr'
             echo
             cat bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE_COLD_PNPR.md
@@ -506,9 +543,9 @@ jobs:
       - name: Build Bencher-shaped report
         # Convert the scenario JSONs into a Bencher Metric Format (BMF) file
         # per testbed, keeping only the chosen target's result from each
-        # scenario and naming each benchmark after the scenario. Both tools run
-        # every scenario, so the `pacquet` testbed gets `pacquet@HEAD` and the
-        # `pnpr` testbed gets `pnpr@HEAD`, each across the same scenario set.
+        # scenario and naming each benchmark after the scenario. Regular
+        # scenarios contribute both testbeds; the client-only peer-heavy case
+        # contributes only `pacquet@HEAD`.
         #
         # We report each scenario's *minimum* latency as the metric value, so
         # Bencher's threshold tracks the min rather than the mean. On a shared
@@ -519,8 +556,10 @@ jobs:
         # and swung ~30% between runs, tripping a spurious alert on a control
         # run whose HEAD and main binaries were byte-identical). Because the
         # minimum only needs one uncontended run, hyperfine's default sampling
-        # suffices — no extra warmup or runs. The human-readable comment still
-        # reports mean ± σ; only the alerting signal moves to the min.
+        # suffices for regular scenarios. The peer-heavy case uses three runs
+        # to keep its cross-engine comparison bounded. The human-readable
+        # comment still reports mean ± σ; only the alerting signal moves to the
+        # min.
         #
         # BMF rather than the `shell_hyperfine` adapter with a doctored `mean`:
         # this reports the min honestly as the value instead of relabelling it.
@@ -560,6 +599,7 @@ jobs:
             'ISOLATED_FRESH_INSTALL_HOT_CACHE_HOT_STORE:isolated-linker.fresh-install.hot-cache.hot-store' \
             'ISOLATED_FRESH_INSTALL_COLD_CACHE_HOT_STORE:isolated-linker.fresh-install.cold-cache.hot-store' \
             'ISOLATED_FRESH_RESOLVE_HOT_CACHE_OFFLINE:isolated-linker.fresh-resolve.hot-cache.offline' \
+            'ISOLATED_PEER_HEAVY_RESOLVE_HOT_CACHE_OFFLINE:isolated-linker.peer-heavy-resolve.hot-cache.offline' \
             'ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE_COLD_PNPR:isolated-linker.fresh-restore.cold-cache.cold-store.cold-pnpr'
 
           build_bencher_file bench-work-env/bencher-results-pnpr.json pnpr@HEAD \

--- a/pnpm/crates/deps-path/src/dep_path.rs
+++ b/pnpm/crates/deps-path/src/dep_path.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 /// Branded depPath string.
 ///
 /// A depPath is a `string` brand — it's never validated at the
@@ -11,7 +13,7 @@
 /// suffix scanning, filename escaping) can speak in depPath terms
 /// without forcing a back-dependency from `deps-path` to the resolver.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DepPath(String);
+pub struct DepPath(Arc<str>);
 
 impl DepPath {
     /// Borrow the underlying depPath string.
@@ -29,12 +31,12 @@ impl std::fmt::Display for DepPath {
 
 impl From<String> for DepPath {
     fn from(value: String) -> DepPath {
-        DepPath(value)
+        DepPath(Arc::from(value))
     }
 }
 
 impl From<&str> for DepPath {
     fn from(value: &str) -> DepPath {
-        DepPath(value.to_string())
+        DepPath(Arc::from(value))
     }
 }

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -1222,7 +1222,7 @@ fn snapshot_preserves_optional_child_edges_from_resolved_tree() {
             outer_node_id,
             DependenciesTreeNode::new(
                 outer_id.clone(),
-                TreeChildren::Lazy { parent_ids: Arc::new(Vec::new()) },
+                TreeChildren::Lazy { parent_ids: Arc::new(Vec::new()).into() },
                 0,
                 true,
             ),

--- a/pnpm/crates/real-hoist/src/lib.rs
+++ b/pnpm/crates/real-hoist/src/lib.rs
@@ -572,11 +572,6 @@ pub fn percent_encode_path(text: &str) -> String {
 ///
 /// What this does *not* model yet:
 ///
-/// * Per-importer roots in the multi-level output shape upstream
-///   produces for workspaces. [`hoist`] does attach every non-root
-///   importer as a `Workspace`-kind child of the virtual `.` root,
-///   and package conflict roots are hoisted recursively, but workspace
-///   importers still don't get independent hoisting contexts.
 /// * `ExternalSoftLink` descendants — pacquet creates soft-links
 ///   only as zero-children placeholders, so upstream's
 ///   "only-hoist-when-all-descendants-hoist" rule has nothing to
@@ -587,18 +582,14 @@ pub fn percent_encode_path(text: &str) -> String {
 ///
 /// [upstream]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L329
 fn nm_hoist(tree: &HoisterTree, opts: &HoistOpts) -> HoisterResult {
-    // Compute the root locator from the input tree, where each
-    // node carries a single unambiguous `reference`. The result
-    // graph collects references into a `BTreeSet` (one
-    // `HoisterResult` can absorb several `HoisterTree` nodes with
-    // the same ident), so deriving the locator from a result
-    // node would mean picking an arbitrary entry from the set;
-    // doing it here keeps the lookup well-defined.
-    let root_locator = format!("{}@{}", tree.ident_name, tree.reference);
-    let mut memo: HashMap<*const HoisterTree, Rc<HoisterResult>> = HashMap::new();
-    let root = convert(tree, &mut memo);
-    hoist_into_root(&root, &root_locator, opts);
-    hoist_nested_roots(&root, opts);
+    let mut context = ConvertContext::default();
+    let root = convert(tree, &mut context);
+    let root_locator = context
+        .locator_by_result
+        .get(&Rc::as_ptr(&root))
+        .expect("every converted result has its input locator");
+    hoist_into_root(&root, root_locator, opts);
+    hoist_nested_roots(&root, opts, &context.locator_by_result);
     // Returning an owned `HoisterResult` (rather than
     // `Rc<HoisterResult>`) keeps the wrapper's post-hoist
     // `external_dependencies` filter from mutating the shared graph.
@@ -608,7 +599,11 @@ fn nm_hoist(tree: &HoisterTree, opts: &HoistOpts) -> HoisterResult {
     (*root).clone()
 }
 
-fn hoist_nested_roots(root: &Rc<HoisterResult>, opts: &HoistOpts) {
+fn hoist_nested_roots(
+    root: &Rc<HoisterResult>,
+    opts: &HoistOpts,
+    locator_by_result: &HashMap<*const HoisterResult, String>,
+) {
     let mut visited = HashSet::from([Rc::as_ptr(root)]);
     let mut pending: Vec<Rc<HoisterResult>> =
         root.dependencies.borrow().iter().map(|child| Rc::clone(&child.0)).collect();
@@ -616,9 +611,10 @@ fn hoist_nested_roots(root: &Rc<HoisterResult>, opts: &HoistOpts) {
         if !visited.insert(Rc::as_ptr(&node)) {
             continue;
         }
-        let reference = node.references.borrow().iter().next().cloned().unwrap_or_default();
-        let locator = format!("{}@{reference}", node.ident_name);
-        hoist_into_root(&node, &locator, opts);
+        let locator = locator_by_result
+            .get(&Rc::as_ptr(&node))
+            .expect("every converted result has its input locator");
+        hoist_into_root(&node, locator, opts);
         pending.extend(node.dependencies.borrow().iter().map(|child| Rc::clone(&child.0)));
     }
 }
@@ -1139,12 +1135,15 @@ fn would_shadow_peer(
     false
 }
 
-fn convert(
-    tree: &HoisterTree,
-    memo: &mut HashMap<*const HoisterTree, Rc<HoisterResult>>,
-) -> Rc<HoisterResult> {
+#[derive(Default)]
+struct ConvertContext {
+    result_by_tree: HashMap<*const HoisterTree, Rc<HoisterResult>>,
+    locator_by_result: HashMap<*const HoisterResult, String>,
+}
+
+fn convert(tree: &HoisterTree, context: &mut ConvertContext) -> Rc<HoisterResult> {
     let ptr = std::ptr::from_ref::<HoisterTree>(tree);
-    if let Some(existing) = memo.get(&ptr) {
+    if let Some(existing) = context.result_by_tree.get(&ptr) {
         return Rc::clone(existing);
     }
     // Stash a node with empty `dependencies`, then recurse and
@@ -1161,7 +1160,10 @@ fn convert(
         peer_names: tree.peer_names.clone(),
         dependencies: RefCell::new(IndexSet::new()),
     });
-    memo.insert(ptr, Rc::clone(&node));
+    context.result_by_tree.insert(ptr, Rc::clone(&node));
+    context
+        .locator_by_result
+        .insert(Rc::as_ptr(&node), format!("{}@{}", tree.ident_name, tree.reference));
 
     // Collect the children before recursing so we can drop the
     // `Ref<'_, IndexSet<...>>` borrow on `tree.dependencies`. The
@@ -1173,7 +1175,7 @@ fn convert(
         tree.dependencies.borrow().iter().cloned().collect();
     let mut children: IndexSet<RcByPtr<HoisterResult>> = IndexSet::new();
     for child in to_convert {
-        children.insert(RcByPtr(convert(&child.0, memo)));
+        children.insert(RcByPtr(convert(&child.0, context)));
     }
     *node.dependencies.borrow_mut() = children;
     node

--- a/pnpm/crates/real-hoist/src/lib.rs
+++ b/pnpm/crates/real-hoist/src/lib.rs
@@ -572,12 +572,11 @@ pub fn percent_encode_path(text: &str) -> String {
 ///
 /// What this does *not* model yet:
 ///
-/// * Per-importer roots and the multi-level output shape upstream
+/// * Per-importer roots in the multi-level output shape upstream
 ///   produces for workspaces. [`hoist`] does attach every non-root
-///   importer as a `Workspace`-kind child of the virtual `.` root
-///   when [`HoistOpts::hoist_workspace_packages`] is enabled, but the
-///   algorithm still hoists into that single `.` root rather than
-///   giving each importer its own hoisting root.
+///   importer as a `Workspace`-kind child of the virtual `.` root,
+///   and package conflict roots are hoisted recursively, but workspace
+///   importers still don't get independent hoisting contexts.
 /// * `ExternalSoftLink` descendants — pacquet creates soft-links
 ///   only as zero-children placeholders, so upstream's
 ///   "only-hoist-when-all-descendants-hoist" rule has nothing to
@@ -599,6 +598,7 @@ fn nm_hoist(tree: &HoisterTree, opts: &HoistOpts) -> HoisterResult {
     let mut memo: HashMap<*const HoisterTree, Rc<HoisterResult>> = HashMap::new();
     let root = convert(tree, &mut memo);
     hoist_into_root(&root, &root_locator, opts);
+    hoist_nested_roots(&root, opts);
     // Returning an owned `HoisterResult` (rather than
     // `Rc<HoisterResult>`) keeps the wrapper's post-hoist
     // `external_dependencies` filter from mutating the shared graph.
@@ -606,6 +606,21 @@ fn nm_hoist(tree: &HoisterTree, opts: &HoistOpts) -> HoisterResult {
     // the subtree children remain shared via the cloned `RcByPtr`
     // values, so deep deps stay deduplicated.
     (*root).clone()
+}
+
+fn hoist_nested_roots(root: &Rc<HoisterResult>, opts: &HoistOpts) {
+    let mut visited = HashSet::from([Rc::as_ptr(root)]);
+    let mut pending: Vec<Rc<HoisterResult>> =
+        root.dependencies.borrow().iter().map(|child| Rc::clone(&child.0)).collect();
+    while let Some(node) = pending.pop() {
+        if !visited.insert(Rc::as_ptr(&node)) {
+            continue;
+        }
+        let reference = node.references.borrow().iter().next().cloned().unwrap_or_default();
+        let locator = format!("{}@{reference}", node.ident_name);
+        hoist_into_root(&node, &locator, opts);
+        pending.extend(node.dependencies.borrow().iter().map(|child| Rc::clone(&child.0)));
+    }
 }
 
 /// Outcome of the per-child hoist decision at the root.

--- a/pnpm/crates/real-hoist/src/tests.rs
+++ b/pnpm/crates/real-hoist/src/tests.rs
@@ -904,6 +904,82 @@ fn hoisting_limits_keyed_on_unrelated_importer_is_inert() {
 }
 
 #[test]
+fn nested_hoist_uses_the_nested_root_locator() {
+    let mut importers = HashMap::new();
+    importers.insert(Lockfile::ROOT_IMPORTER_KEY.to_string(), ProjectSnapshot::default());
+    let mut workspace_deps = ResolvedDependencyMap::new();
+    workspace_deps.insert(pkg_name("a"), resolved_dep("1.0.0"));
+    importers.insert(
+        "packages/foo".to_string(),
+        ProjectSnapshot { dependencies: Some(workspace_deps), ..ProjectSnapshot::default() },
+    );
+
+    let mut snapshots = HashMap::new();
+    let mut a_deps = HashMap::new();
+    a_deps.insert(pkg_name("b"), SnapshotDepRef::Plain(ver_peer("1.0.0")));
+    let mut b_deps = HashMap::new();
+    b_deps.insert(pkg_name("c"), SnapshotDepRef::Plain(ver_peer("1.0.0")));
+    snapshots.insert(
+        dep_key("a", "1.0.0"),
+        SnapshotEntry { dependencies: Some(a_deps), ..SnapshotEntry::default() },
+    );
+    snapshots.insert(
+        dep_key("b", "1.0.0"),
+        SnapshotEntry { dependencies: Some(b_deps), ..SnapshotEntry::default() },
+    );
+    snapshots.insert(dep_key("c", "1.0.0"), SnapshotEntry::default());
+
+    let mut opts = HoistOpts::default();
+    opts.hoisting_limits.insert(".@".to_string(), BTreeSet::from(["packages%2Ffoo".to_string()]));
+    opts.hoisting_limits.insert(
+        "packages%2Ffoo@workspace:packages/foo".to_string(),
+        BTreeSet::from(["b".to_string()]),
+    );
+
+    let result = hoist(
+        &Lockfile {
+            lockfile_version: lockfile_version(),
+            settings: None,
+            catalogs: None,
+            overrides: None,
+            package_extensions_checksum: None,
+            pnpmfile_checksum: None,
+            ignored_optional_dependencies: None,
+            patched_dependencies: None,
+            importers,
+            packages: None,
+            snapshots: Some(snapshots),
+        },
+        &opts,
+    )
+    .expect("nested hoist with importer limits should succeed");
+
+    let root_children = result.dependencies.borrow();
+    let workspace = Rc::clone(
+        &root_children
+            .iter()
+            .find(|dep| dep.0.name == "packages%2Ffoo")
+            .expect("workspace stays at the virtual root")
+            .0,
+    );
+    let workspace_deps = workspace.dependencies.borrow();
+    let mut workspace_names: Vec<&str> =
+        workspace_deps.iter().map(|dep| dep.0.name.as_str()).collect();
+    workspace_names.sort_unstable();
+    assert_eq!(
+        workspace_names,
+        ["a", "b"],
+        "the root border no longer applies inside the workspace, while its own b border does",
+    );
+    let dep_b = Rc::clone(
+        &workspace_deps.iter().find(|dep| dep.0.name == "b").expect("b hoists within workspace").0,
+    );
+    let b_deps = dep_b.dependencies.borrow();
+    let b_names: Vec<&str> = b_deps.iter().map(|dep| dep.0.name.as_str()).collect();
+    assert_eq!(b_names, ["c"], "the workspace's b border keeps c below b");
+}
+
+#[test]
 fn self_dependency_does_not_loop() {
     let mut importers = HashMap::new();
     let mut root_deps = ResolvedDependencyMap::new();

--- a/pnpm/crates/real-hoist/src/tests.rs
+++ b/pnpm/crates/real-hoist/src/tests.rs
@@ -206,6 +206,7 @@ fn version_conflict_keeps_loser_at_parent() {
     let mut root_deps = ResolvedDependencyMap::new();
     root_deps.insert(pkg_name("a"), resolved_dep("1.0.0"));
     root_deps.insert(pkg_name("c"), resolved_dep("1.0.0"));
+    root_deps.insert(pkg_name("d"), resolved_dep("1.0.0"));
     importers.insert(
         Lockfile::ROOT_IMPORTER_KEY.to_string(),
         ProjectSnapshot { dependencies: Some(root_deps), ..ProjectSnapshot::default() },
@@ -225,7 +226,14 @@ fn version_conflict_keeps_loser_at_parent() {
         SnapshotEntry { dependencies: Some(c_deps), ..SnapshotEntry::default() },
     );
     snapshots.insert(dep_key("b", "1.0.0"), SnapshotEntry::default());
-    snapshots.insert(dep_key("b", "2.0.0"), SnapshotEntry::default());
+    let mut b_two_deps = HashMap::new();
+    b_two_deps.insert(pkg_name("d"), SnapshotDepRef::Plain(ver_peer("2.0.0")));
+    snapshots.insert(
+        dep_key("b", "2.0.0"),
+        SnapshotEntry { dependencies: Some(b_two_deps), ..SnapshotEntry::default() },
+    );
+    snapshots.insert(dep_key("d", "1.0.0"), SnapshotEntry::default());
+    snapshots.insert(dep_key("d", "2.0.0"), SnapshotEntry::default());
 
     let lockfile = Lockfile {
         lockfile_version: lockfile_version(),
@@ -245,17 +253,21 @@ fn version_conflict_keeps_loser_at_parent() {
     let root_children = result.dependencies.borrow();
     let mut names: Vec<&str> = root_children.iter().map(|dep| dep.0.name.as_str()).collect();
     names.sort_unstable();
-    assert_eq!(names, ["a", "b", "c"], "root has a, c, and one b");
+    assert_eq!(names, ["a", "b", "c", "d"], "root keeps its direct d and one b");
     let b_at_root = Rc::clone(&root_children.iter().find(|dep| dep.0.name == "b").unwrap().0);
     let b_refs = b_at_root.references.borrow();
     assert!(b_refs.contains("b@1.0.0"), "first DFS visitor wins root slot: {b_refs:?}");
     assert_eq!(b_refs.len(), 1, "no other reference accumulated yet: {b_refs:?}");
     let dep_c = Rc::clone(&root_children.iter().find(|dep| dep.0.name == "c").unwrap().0);
     let c_kids = dep_c.dependencies.borrow();
-    assert_eq!(c_kids.len(), 1, "c kept its conflicting b@2");
-    let b_under_c_refs = c_kids[0].0.references.borrow();
+    assert_eq!(c_kids.len(), 2, "c kept b@2 and hoisted its conflicting d@2");
+    let b_under_c = Rc::clone(&c_kids.iter().find(|dep| dep.0.name == "b").unwrap().0);
+    let b_under_c_refs = b_under_c.references.borrow();
     assert!(b_under_c_refs.contains("b@2.0.0"), "loser stays under c: {b_under_c_refs:?}");
     assert_eq!(b_under_c_refs.len(), 1);
+    assert!(b_under_c.dependencies.borrow().is_empty(), "b's descendants hoist to nested root c");
+    let d_under_c_refs = c_kids.iter().find(|dep| dep.0.name == "d").unwrap().0.references.borrow();
+    assert!(d_under_c_refs.contains("d@2.0.0"), "d@2 stays below the root's d@1 conflict");
 }
 
 /// The most-depended-on version of a shared name wins the root

--- a/pnpm/crates/resolving-deps-resolver/src/lib.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/lib.rs
@@ -109,8 +109,8 @@ pub use resolve_workspace::{
     ResolveWorkspaceResult, WorkspaceImporter, WorkspaceResolveOptions, resolve_workspace,
 };
 pub use resolved_tree::{
-    ChildEdge, DependenciesTree, DependenciesTreeNode, DirectDep, PeerDep, ResolvedPackage,
-    ResolvedTree, TreeChildren,
+    AncestorIds, ChildEdge, DependenciesTree, DependenciesTreeNode, DirectDep, PeerDep,
+    ResolvedPackage, ResolvedTree, TreeChildren,
 };
 pub use validate_dependency_alias::is_valid_dependency_alias;
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -42,7 +42,9 @@ use crate::{
     },
     node_id::NodeId,
     parent_pkg_aliases::{ParentPkgAliases, peer_shadowed_dependencies},
-    resolved_tree::{DependenciesTreeNode, DirectDep, PeerDep, ResolvedPackage, ResolvedTree},
+    resolved_tree::{
+        AncestorIds, DependenciesTreeNode, DirectDep, PeerDep, ResolvedPackage, ResolvedTree,
+    },
 };
 use pacquet_lockfile::{
     PkgName, PkgNameVerPeer, ProjectSnapshot, ResolvedDependencyMap, SnapshotDepRef, SnapshotEntry,
@@ -1711,10 +1713,12 @@ where
     // preferred-versions overlay (a per-level fold; the direct deps
     // themselves resolve against the importer's static preferred map
     // only).
+    let root_ancestors = Arc::new(Vec::new());
     let seeds = wanted
         .into_iter()
         .map(|(name, range, optional, injected)| {
             let reuse = reuse.clone();
+            let root_ancestors = Arc::clone(&root_ancestors);
             async move {
                 // `injected: Some(true)` only when the importer manifest's
                 // `dependenciesMeta[name].injected = true` opted this dep
@@ -1737,7 +1741,7 @@ where
                     ctx,
                     resolver,
                     wanted,
-                    &[],
+                    &root_ancestors,
                     0,
                     false,
                     reuse,
@@ -1804,7 +1808,7 @@ async fn resolve_node<Chain>(
     ctx: &TreeCtx,
     resolver: &Chain,
     wanted: WantedDependency,
-    ancestor_ids: &[String],
+    ancestor_ids: &Arc<Vec<String>>,
     depth: i32,
     parent_optional: bool,
     reuse: ReuseSource,
@@ -1861,6 +1865,7 @@ struct PendingNode {
     alias: String,
     node_id: NodeId,
     is_link: bool,
+    parent_ancestors: Arc<Vec<String>>,
     next_ancestors: Arc<Vec<String>>,
     /// The deterministic children-ownership claim taken at seed time;
     /// the walk phase re-checks it before recording the children, so
@@ -1911,7 +1916,7 @@ async fn resolve_node_seed<Chain>(
     ctx: &TreeCtx,
     resolver: &Chain,
     wanted: WantedDependency,
-    ancestor_ids: &[String],
+    ancestor_ids: &Arc<Vec<String>>,
     depth: i32,
     parent_optional: bool,
     reuse: ReuseSource,
@@ -2220,6 +2225,7 @@ where
         alias,
         node_id,
         is_link,
+        parent_ancestors: Arc::clone(ancestor_ids),
         next_ancestors,
         children_owner,
         depth,
@@ -2277,6 +2283,7 @@ where
         alias,
         node_id,
         is_link,
+        parent_ancestors,
         next_ancestors,
         children_owner,
         depth,
@@ -2289,7 +2296,9 @@ where
         // map: a linked node has no children of its own here.
         crate::resolved_tree::TreeChildren::Realized(BTreeMap::new())
     } else if !children_owner.owns_children {
-        crate::resolved_tree::TreeChildren::Lazy { parent_ids: Arc::clone(&next_ancestors) }
+        crate::resolved_tree::TreeChildren::Lazy {
+            parent_ids: AncestorIds::from(Arc::clone(&parent_ancestors)),
+        }
     } else {
         // Look up cached children specs first; only walk the manifest on
         // a miss. The cache value is held by `Arc` so revisits clone the
@@ -2459,7 +2468,9 @@ where
             lock_recoverable(&ctx.workspace.children_by_id).insert(id.clone(), Arc::new(by_id));
             crate::resolved_tree::TreeChildren::Realized(realized)
         } else {
-            crate::resolved_tree::TreeChildren::Lazy { parent_ids: Arc::clone(&next_ancestors) }
+            crate::resolved_tree::TreeChildren::Lazy {
+                parent_ids: AncestorIds::from(Arc::clone(&parent_ancestors)),
+            }
         }
     };
 
@@ -2472,7 +2483,7 @@ where
     // Linked nodes carry `depth = -1` so the peer-resolution pass
     // short-circuits them in `resolve_node`.
     let node_depth = if is_link { -1 } else { depth };
-    remember_node_parent_ids(ctx, &node_id, Arc::clone(&next_ancestors));
+    remember_node_parent_ids(ctx, &node_id, parent_ancestors);
     insert_tree_node(ctx, node_id.clone(), &id, children, node_depth);
     if children_owner.owns_children
         && !children_owner.children_context_unchanged
@@ -2487,10 +2498,8 @@ where
 /// Whether the `parent → child` edge closes a dependency cycle's
 /// *second* lap. The first re-entry of a cycle is kept (so the
 /// cycle-closing dependency edge appears in the tree and the lockfile
-/// snapshot, with [`fn@crate::resolve_peers`]'s
-/// previously-resolved-children merge restoring the pruned edge on the
-/// repeated node); only the repeat of the full `parent … child`
-/// sequence is dropped.
+/// snapshot); only the repeat of the full `parent … child` sequence is
+/// dropped.
 pub(crate) fn parent_ids_contain_sequence(
     pkg_ids: &[String],
     pkg_id1: &str,
@@ -3089,7 +3098,9 @@ fn make_non_owner_nodes_lazy(ctx: &TreeCtx, pkg_id: &str, owner_node_id: &NodeId
     let mut rewrote_any = false;
     for (node_id, parent_ids) in parent_ids_by_node {
         if let Some(node) = tree.get_mut(&node_id) {
-            node.children = crate::resolved_tree::TreeChildren::Lazy { parent_ids };
+            node.children = crate::resolved_tree::TreeChildren::Lazy {
+                parent_ids: AncestorIds::from(parent_ids),
+            };
             rewrote_any = true;
         }
     }
@@ -3399,7 +3410,7 @@ async fn resolve_reused_node<Chain>(
     ctx: &TreeCtx,
     resolver: &Chain,
     wanted: WantedDependency,
-    ancestor_ids: &[String],
+    ancestor_ids: &Arc<Vec<String>>,
     depth: i32,
     current_is_optional: bool,
     reused: ReusedNode,
@@ -3535,13 +3546,17 @@ where
             lock_recoverable(&ctx.workspace.children_by_id).insert(id.clone(), Arc::new(by_id));
             crate::resolved_tree::TreeChildren::Realized(realized)
         } else {
-            crate::resolved_tree::TreeChildren::Lazy { parent_ids: Arc::clone(&next_ancestors) }
+            crate::resolved_tree::TreeChildren::Lazy {
+                parent_ids: AncestorIds::from(Arc::clone(ancestor_ids)),
+            }
         }
     } else {
-        crate::resolved_tree::TreeChildren::Lazy { parent_ids: Arc::clone(&next_ancestors) }
+        crate::resolved_tree::TreeChildren::Lazy {
+            parent_ids: AncestorIds::from(Arc::clone(ancestor_ids)),
+        }
     };
 
-    remember_node_parent_ids(ctx, &node_id, Arc::clone(&next_ancestors));
+    remember_node_parent_ids(ctx, &node_id, Arc::clone(ancestor_ids));
     insert_tree_node(ctx, node_id.clone(), &id, children, depth);
     if children_owner.owns_children
         && !children_owner.children_context_unchanged

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/tests.rs
@@ -103,7 +103,7 @@ fn importer_snapshot_follows_lazy_edges_for_the_package_closure() {
         root.clone(),
         DependenciesTreeNode::new(
             "root@1.0.0".to_string(),
-            TreeChildren::Lazy { parent_ids: Arc::new(Vec::new()) },
+            TreeChildren::Lazy { parent_ids: Arc::new(Vec::new()).into() },
             0,
             true,
         ),

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -127,25 +127,6 @@ fn pkg_name_version(result: &ResolveResult) -> (String, String) {
     (fallback_name, result.id.as_str().to_string())
 }
 
-/// Compares the package-name component returned by [`pkg_name_version`]
-/// without allocating its owned fallback tuple.
-///
-/// Must remain equivalent to `pkg_name_version(result).0 == expected`.
-fn package_name_matches(result: &ResolveResult, expected: &str) -> bool {
-    let Some(name_ver) = result.name_ver.as_ref() else {
-        return result.alias.as_deref().unwrap_or(result.id.as_str()) == expected;
-    };
-    match name_ver.name.scope.as_deref() {
-        None => name_ver.name.bare == expected,
-        Some(scope) => expected
-            .strip_prefix('@')
-            .and_then(|name| name.split_once('/'))
-            .is_some_and(|(expected_scope, expected_bare)| {
-                expected_scope == scope && expected_bare == name_ver.name.bare
-            }),
-    }
-}
-
 /// Options threaded into [`fn@resolve_peers`].
 #[derive(Debug, Clone)]
 pub struct ResolvePeersOptions {
@@ -362,6 +343,8 @@ pub(crate) struct PeerDiscoveryCaches {
     peers_cache: HashMap<String, Vec<PeersCacheItem>>,
     parent_pkgs_of_node: HashMap<NodeId, Arc<HashMap<String, ParentPkgInfo>>>,
     retained_peer_node_ids: HashSet<NodeId>,
+    peer_provider_children_by_pkg_id: HashMap<String, PeerProviderChildren>,
+    peer_provider_index_peer_names: HashSet<String>,
 }
 
 /// Peer-hoist discovery engine: one persistent tree view + walker
@@ -934,6 +917,12 @@ struct CurrentProviderSource {
     explicitly_requested_direct_dependencies: HashSet<String>,
 }
 
+#[derive(Debug, Default)]
+struct PeerProviderChildren {
+    relevant_edge_indices: Vec<usize>,
+    edge_indices_by_name: HashMap<String, Vec<usize>>,
+}
+
 #[derive(Clone, Copy)]
 struct FinalPeerContext<'a> {
     scc_of: &'a HashMap<NodeId, usize>,
@@ -1053,6 +1042,8 @@ struct Walker<'tree> {
     /// fallback keeps its per-call meaning.
     visited_this_call: HashSet<NodeId>,
     packages_by_id: HashMap<String, Arc<ResolvedPackage>>,
+    peer_provider_children_by_pkg_id: HashMap<String, PeerProviderChildren>,
+    peer_provider_index_peer_names: HashSet<String>,
     empty_resolved_peers: Arc<HashMap<String, NodeId>>,
     empty_missing_peers: Arc<HashMap<String, MissingPeerInfo>>,
 }
@@ -1072,7 +1063,40 @@ impl<'tree> Walker<'tree> {
             peers_cache,
             parent_pkgs_of_node,
             retained_peer_node_ids,
+            mut peer_provider_children_by_pkg_id,
+            mut peer_provider_index_peer_names,
         } = caches;
+        if peer_provider_index_peer_names != tree.all_peer_dep_names {
+            peer_provider_children_by_pkg_id.clear();
+            peer_provider_index_peer_names.clone_from(&tree.all_peer_dep_names);
+        }
+        for (pkg_id, children) in &tree.children_by_id {
+            if peer_provider_children_by_pkg_id.contains_key(pkg_id) {
+                continue;
+            }
+            let mut providers = PeerProviderChildren::default();
+            for (edge_index, edge) in children.iter().enumerate() {
+                let Some(pkg) = tree.packages.get(&edge.pkg_id) else { continue };
+                let real_name = pkg_name_version(&pkg.result).0;
+                let alias_is_peer = tree.all_peer_dep_names.contains(&edge.alias);
+                let real_name_is_peer = tree.all_peer_dep_names.contains(&real_name);
+                if !alias_is_peer && !real_name_is_peer {
+                    continue;
+                }
+                providers.relevant_edge_indices.push(edge_index);
+                if alias_is_peer {
+                    providers
+                        .edge_indices_by_name
+                        .entry(edge.alias.clone())
+                        .or_default()
+                        .push(edge_index);
+                }
+                if real_name_is_peer && real_name != edge.alias {
+                    providers.edge_indices_by_name.entry(real_name).or_default().push(edge_index);
+                }
+            }
+            peer_provider_children_by_pkg_id.insert(pkg_id.clone(), providers);
+        }
         Walker {
             tree,
             opts,
@@ -1097,6 +1121,8 @@ impl<'tree> Walker<'tree> {
             discovery,
             visited_this_call: HashSet::default(),
             packages_by_id: HashMap::default(),
+            peer_provider_children_by_pkg_id,
+            peer_provider_index_peer_names,
             empty_resolved_peers: Arc::new(HashMap::default()),
             empty_missing_peers: Arc::new(HashMap::default()),
         }
@@ -1109,6 +1135,8 @@ impl<'tree> Walker<'tree> {
             peers_cache: self.peers_cache,
             parent_pkgs_of_node: self.parent_pkgs_of_node,
             retained_peer_node_ids: self.retained_peer_node_ids,
+            peer_provider_children_by_pkg_id: self.peer_provider_children_by_pkg_id,
+            peer_provider_index_peer_names: self.peer_provider_index_peer_names,
         }
     }
 }
@@ -1657,9 +1685,6 @@ impl Walker<'_> {
             let Some(child_pkg) = self.tree.packages.get(&child_tree.resolved_package_id) else {
                 continue;
             };
-            if !self.is_peer_relevant(alias, child_pkg) {
-                continue;
-            }
             insert_parent_ref(
                 &mut new_parent_refs,
                 alias,
@@ -2896,15 +2921,17 @@ impl Walker<'_> {
             }
         };
         let children = self.tree.children_by_id.get(&pkg_id).cloned().unwrap_or_default();
+        let provider_edge_indices = self
+            .peer_provider_children_by_pkg_id
+            .get(&pkg_id)
+            .map_or(&[][..], |providers| providers.relevant_edge_indices.as_slice());
         let full_chain = parent_ids.pushed(pkg_id.clone());
         let mut providers = BTreeMap::new();
         let mut newly_inserted = Vec::new();
-        for edge in children.iter() {
+        for &edge_index in provider_edge_indices {
+            let edge = &children[edge_index];
             let Some(pkg) = self.tree.packages.get(&edge.pkg_id) else { continue };
-            if !self.is_peer_relevant(&edge.alias, pkg)
-                || pkg_id == edge.pkg_id
-                || full_chain.forms_cycle(&pkg_id, &edge.pkg_id)
-            {
+            if pkg_id == edge.pkg_id || full_chain.forms_cycle(&pkg_id, &edge.pkg_id) {
                 continue;
             }
             let child_node_id =
@@ -3436,14 +3463,18 @@ impl Walker<'_> {
         let Some(children) = self.tree.children_by_id.get(pkg_id) else {
             return inherited.map_or(FastProvider::Missing, FastProvider::Inherited);
         };
+        let Some(edge_indices) = self
+            .peer_provider_children_by_pkg_id
+            .get(pkg_id)
+            .and_then(|providers| providers.edge_indices_by_name.get(name))
+        else {
+            return inherited.map_or(FastProvider::Missing, FastProvider::Inherited);
+        };
 
         let mut child_pkg_id = None;
-        for edge in children.iter() {
+        for &edge_index in edge_indices {
+            let edge = &children[edge_index];
             if parent_ids.forms_cycle(pkg_id, &edge.pkg_id) {
-                continue;
-            }
-            let Some(pkg) = self.tree.packages.get(&edge.pkg_id) else { continue };
-            if edge.alias != name && !package_name_matches(&pkg.result, name) {
                 continue;
             }
             if child_pkg_id.is_some() {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -129,6 +129,8 @@ fn pkg_name_version(result: &ResolveResult) -> (String, String) {
 
 /// Compares the package-name component returned by [`pkg_name_version`]
 /// without allocating its owned fallback tuple.
+///
+/// Must remain equivalent to `pkg_name_version(result).0 == expected`.
 fn package_name_matches(result: &ResolveResult, expected: &str) -> bool {
     let Some(name_ver) = result.name_ver.as_ref() else {
         return result.alias.as_deref().unwrap_or(result.id.as_str()) == expected;

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -127,6 +127,8 @@ fn pkg_name_version(result: &ResolveResult) -> (String, String) {
     (fallback_name, result.id.as_str().to_string())
 }
 
+/// Compares the package-name component returned by [`pkg_name_version`]
+/// without allocating its owned fallback tuple.
 fn package_name_matches(result: &ResolveResult, expected: &str) -> bool {
     let Some(name_ver) = result.name_ver.as_ref() else {
         return result.alias.as_deref().unwrap_or(result.id.as_str()) == expected;
@@ -941,6 +943,9 @@ struct UndoRealize {
     prev_parent_ids: AncestorIds,
 }
 
+/// Combines preview and final-materialization undo logs for the same node.
+/// Both logs restore the same pre-realization ancestor chain; previewing
+/// does not change the node's lazy parent state.
 fn merge_realize_undo(
     first: Option<UndoRealize>,
     second: Option<UndoRealize>,
@@ -3252,14 +3257,7 @@ impl Walker<'_> {
     ) {
         let Some(undo) = undo else { return };
         for child_id in &undo.newly_inserted {
-            let output_references_child = output.is_some_and(|output| {
-                output.external_resolved_peers.values().any(|node_id| node_id == child_id)
-                    || output
-                        .auto_install_resolved_peers
-                        .values()
-                        .any(|node_id| node_id == child_id)
-            });
-            if self.retained_peer_node_ids.contains(child_id) || output_references_child {
+            if should_retain_materialized_node(&self.retained_peer_node_ids, output, child_id) {
                 continue;
             }
             self.tree.dependencies_tree.remove(child_id);
@@ -3361,7 +3359,13 @@ impl Walker<'_> {
                     parent_node_ids,
                     parent_pkg_ids,
                 );
-                if !self.parent_pkgs_of_node.contains_key(&node_id) {
+                if !self.parent_pkgs_of_node.contains_key(&node_id)
+                    && !should_retain_materialized_node(
+                        &self.retained_peer_node_ids,
+                        Some(&output),
+                        &node_id,
+                    )
+                {
                     self.tree.dependencies_tree.remove(&node_id);
                     self.node_dep_paths.remove(&node_id);
                     self.visited_this_call.remove(&node_id);
@@ -3567,6 +3571,21 @@ impl Walker<'_> {
         }
         true
     }
+}
+
+fn should_retain_materialized_node(
+    retained_peer_node_ids: &HashSet<NodeId>,
+    output: Option<&NodeOutput>,
+    node_id: &NodeId,
+) -> bool {
+    retained_peer_node_ids.contains(node_id)
+        || output.is_some_and(|output| {
+            output.external_resolved_peers.values().any(|resolved_id| resolved_id == node_id)
+                || output
+                    .auto_install_resolved_peers
+                    .values()
+                    .any(|resolved_id| resolved_id == node_id)
+        })
 }
 
 /// Whether every entry in `parents` has `occurrence == 0`.

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -22,7 +22,7 @@
 //!   `pkgIdWithPatchHash` without recursing. Stored on
 //!   [`Walker::pure_pkgs`] and consulted at the top of
 //!   [`Walker::resolve_node`].
-//!   The set is populated bottom-up: a node lands in `purePkgs` only
+//!   The cache is populated bottom-up: a node lands in `purePkgs` only
 //!   when both its own walked subtree and (transitively) every cached
 //!   subtree it relies on report no resolved or missing peers.
 //!
@@ -39,7 +39,8 @@ use crate::{
     },
     node_id::NodeId,
     resolved_tree::{
-        DependenciesTreeNode, DirectDep, PeerDep, ResolvedPackage, ResolvedTree, TreeChildren,
+        AncestorIds, ChildEdge, DependenciesTreeNode, DirectDep, PeerDep, ResolvedPackage,
+        ResolvedTree, TreeChildren,
     },
 };
 use node_semver::{Range, Version};
@@ -124,6 +125,21 @@ fn pkg_name_version(result: &ResolveResult) -> (String, String) {
     }
     let fallback_name = result.alias.clone().unwrap_or_else(|| result.id.as_str().to_string());
     (fallback_name, result.id.as_str().to_string())
+}
+
+fn package_name_matches(result: &ResolveResult, expected: &str) -> bool {
+    let Some(name_ver) = result.name_ver.as_ref() else {
+        return result.alias.as_deref().unwrap_or(result.id.as_str()) == expected;
+    };
+    match name_ver.name.scope.as_deref() {
+        None => name_ver.name.bare == expected,
+        Some(scope) => expected
+            .strip_prefix('@')
+            .and_then(|name| name.split_once('/'))
+            .is_some_and(|(expected_scope, expected_bare)| {
+                expected_scope == scope && expected_bare == name_ver.name.bare
+            }),
+    }
 }
 
 /// Options threaded into [`fn@resolve_peers`].
@@ -246,11 +262,15 @@ pub struct HoistMissingScope {
 impl HoistMissingScope {
     /// `true` when a miss of `peer_name` declared under the given
     /// ancestor chain is covered by another importer's shared walk.
-    fn suppresses(&self, ancestor_pkg_ids: &[String], peer_name: &str) -> bool {
+    fn suppresses_iter<'a>(
+        &self,
+        ancestor_pkg_ids: impl Iterator<Item = &'a String>,
+        peer_name: &str,
+    ) -> bool {
         if self.locked_peer_names.contains(peer_name) {
             return false;
         }
-        ancestor_pkg_ids.iter().any(|pkg_id| {
+        ancestor_pkg_ids.into_iter().any(|pkg_id| {
             self.first_importer_by_pkg.get(pkg_id).is_some_and(|owner| {
                 *owner != self.importer_id
                     && self
@@ -315,7 +335,7 @@ pub(crate) struct PeerDiscoveryResult {
     pub(crate) peer_dependency_issues: PeerDependencyIssues,
     /// Ancestor `pkgIdWithPatchHash` chains recorded per missing-peer
     /// issue, consumed by [`fn@apply_hoist_missing_scope`].
-    pub(crate) missing_ancestor_pkg_ids: HashMap<String, Vec<Vec<String>>>,
+    missing_ancestor_pkg_ids: HashMap<String, Vec<SharedChain<String>>>,
     /// See [`ResolvePeersResult::missing_names_by_pkg`].
     pub(crate) missing_names_by_pkg: HashMap<String, HashSet<String>>,
 }
@@ -334,9 +354,10 @@ pub(crate) struct PeerDiscoveryResult {
 #[derive(Debug, Default)]
 pub(crate) struct PeerDiscoveryCaches {
     node_dep_paths: HashMap<NodeId, DepPath>,
-    pure_pkgs: HashSet<String>,
+    pure_pkgs: HashMap<String, DepPath>,
     peers_cache: HashMap<String, Vec<PeersCacheItem>>,
     parent_pkgs_of_node: HashMap<NodeId, Arc<HashMap<String, ParentPkgInfo>>>,
+    retained_peer_node_ids: HashSet<NodeId>,
 }
 
 /// Peer-hoist discovery engine: one persistent tree view + walker
@@ -434,35 +455,35 @@ fn discover_peers(
         Walker::new(tree, opts, HashMap::default(), current_provider_sources, caches, true);
 
     let importer_parents = Arc::new(walker.build_importer_parents_from(parents_direct));
-    let parent_chain_names: Vec<String> = Vec::new();
-    let parent_node_ids: Vec<NodeId> = Vec::new();
-    let parent_pkg_ids_chain: Vec<String> = Vec::new();
+    let parent_chain_names = SharedChain::default();
+    let parent_node_ids = SharedChain::default();
+    let parent_pkg_ids_chain = SharedChain::default();
     let importer_parent_dep_paths = walker.parent_dep_paths_from_refs(&importer_parents);
     let (own_direct, provider_direct): (Vec<&DirectDep>, Vec<&DirectDep>) = walk_direct
         .iter()
         .partition(|dep| !walker.opts.hoisted_peer_provider_node_ids.contains(&dep.node_id));
     let mut result = PeerDiscoveryResult::default();
     for dep in &own_direct {
-        walker
-            .parent_pkgs_of_node
-            .insert(dep.node_id.clone(), Arc::clone(&importer_parent_dep_paths));
+        walker.remember_parent_context_if_peer_provider(
+            &dep.alias,
+            &dep.node_id,
+            &importer_parent_dep_paths,
+        );
     }
-    let fold_output = |result: &mut PeerDiscoveryResult, output: NodeOutput| {
+    let mut seen_missing_summaries = HashSet::default();
+    let mut fold_output = |result: &mut PeerDiscoveryResult, output: NodeOutput| {
         for (peer_alias, peer_node_id) in output.auto_install_resolved_peers {
             result.resolved_peer_providers_by_alias.insert(peer_alias, peer_node_id);
         }
-        let Some(subtree_missing) = output.subtree_missing_by_pkg else { return };
-        for (pkg_id, names) in subtree_missing.iter() {
-            result
-                .missing_names_by_pkg
-                .entry(pkg_id.clone())
-                .or_default()
-                .extend(names.iter().cloned());
-        }
+        merge_missing_summary(
+            &mut result.missing_names_by_pkg,
+            &mut seen_missing_summaries,
+            output.subtree_missing_by_pkg,
+        );
     };
     for dep in &own_direct {
         let output = walker.resolve_node(
-            dep.node_id.clone(),
+            &dep.node_id,
             &importer_parents,
             &importer_parent_dep_paths,
             &parent_chain_names,
@@ -479,11 +500,13 @@ fn discover_peers(
         if walker.visited_this_call.contains(&dep.node_id) {
             continue;
         }
-        walker
-            .parent_pkgs_of_node
-            .insert(dep.node_id.clone(), Arc::clone(&importer_parent_dep_paths));
+        walker.remember_parent_context_if_peer_provider(
+            &dep.alias,
+            &dep.node_id,
+            &importer_parent_dep_paths,
+        );
         let output = walker.resolve_node(
-            dep.node_id.clone(),
+            &dep.node_id,
             &importer_parents,
             &importer_parent_dep_paths,
             &parent_chain_names,
@@ -534,7 +557,7 @@ pub struct WorkspaceResolvePeersResult {
 /// NodeId)` children map is allocated on first descent and the
 /// parent's `TreeChildren::Lazy` flips to `Realized` so a second
 /// visitor reuses the map without redoing the work. Pure subtrees
-/// that the resolver short-circuits via its `purePkgs` set never get
+/// that the resolver short-circuits via its `purePkgs` cache never get
 /// realised.
 pub fn resolve_peers(tree: &mut ResolvedTree, opts: ResolvePeersOptions) -> ResolvePeersResult {
     let node_ids_by_previous_dep_path = build_node_ids_by_previous_dep_path(tree, &opts);
@@ -570,7 +593,7 @@ pub(crate) fn apply_hoist_missing_scope(
             .into_iter()
             .zip(ancestor_chains)
             .filter_map(|(issue, ancestor_pkg_ids)| {
-                (!scope.suppresses(&ancestor_pkg_ids, peer_name)).then_some(issue)
+                (!scope.suppresses_iter(ancestor_pkg_ids.iter(), peer_name)).then_some(issue)
             })
             .collect();
         !issues.is_empty()
@@ -688,22 +711,24 @@ pub fn resolve_peers_workspace(
             } else {
                 walker.build_importer_parents_from(&importer.direct)
             });
-        let parent_chain_names: Vec<String> = Vec::new();
-        let parent_node_ids: Vec<NodeId> = Vec::new();
-        let parent_pkg_ids_chain: Vec<String> = Vec::new();
+        let parent_chain_names = SharedChain::default();
+        let parent_node_ids = SharedChain::default();
+        let parent_pkg_ids_chain = SharedChain::default();
         let importer_parent_dep_paths = walker.parent_dep_paths_from_refs(&importer_parents);
         let (own_direct, provider_direct): (Vec<&DirectDep>, Vec<&DirectDep>) = importer
             .direct
             .iter()
             .partition(|dep| !walker.opts.hoisted_peer_provider_node_ids.contains(&dep.node_id));
         for dep in &own_direct {
-            walker
-                .parent_pkgs_of_node
-                .insert(dep.node_id.clone(), Arc::clone(&importer_parent_dep_paths));
+            walker.remember_parent_context_if_peer_provider(
+                &dep.alias,
+                &dep.node_id,
+                &importer_parent_dep_paths,
+            );
         }
         for dep in &own_direct {
             walker.resolve_node(
-                dep.node_id.clone(),
+                &dep.node_id,
                 &importer_parents,
                 &importer_parent_dep_paths,
                 &parent_chain_names,
@@ -719,11 +744,13 @@ pub fn resolve_peers_workspace(
             if walker.visited_this_call.contains(&dep.node_id) {
                 continue;
             }
-            walker
-                .parent_pkgs_of_node
-                .insert(dep.node_id.clone(), Arc::clone(&importer_parent_dep_paths));
+            walker.remember_parent_context_if_peer_provider(
+                &dep.alias,
+                &dep.node_id,
+                &importer_parent_dep_paths,
+            );
             walker.resolve_node(
-                dep.node_id.clone(),
+                &dep.node_id,
                 &importer_parents,
                 &importer_parent_dep_paths,
                 &parent_chain_names,
@@ -812,6 +839,72 @@ struct ParentRef {
 /// the real name.
 type ParentRefs = HashMap<String, ParentRef>;
 
+enum FastProvider<'a> {
+    Missing,
+    Inherited(&'a ParentRef),
+    Child(&'a str),
+    Ambiguous,
+}
+
+enum FastCacheMatch {
+    Match,
+    NoMatch,
+    Ambiguous,
+}
+
+#[derive(Debug, Clone)]
+struct SharedChain<Element>(Option<Arc<SharedChainLink<Element>>>);
+
+#[derive(Debug)]
+struct SharedChainLink<Element> {
+    value: Element,
+    parent: Option<Arc<SharedChainLink<Element>>>,
+}
+
+impl<Element> Default for SharedChain<Element> {
+    fn default() -> Self {
+        SharedChain(None)
+    }
+}
+
+impl<Element> SharedChain<Element> {
+    fn pushed(&self, value: Element) -> Self {
+        SharedChain(Some(Arc::new(SharedChainLink { value, parent: self.0.clone() })))
+    }
+
+    fn iter(&self) -> SharedChainIter<'_, Element> {
+        SharedChainIter { next: self.0.as_deref() }
+    }
+}
+
+impl<Element: PartialEq> SharedChain<Element> {
+    fn contains(&self, value: &Element) -> bool {
+        self.iter().any(|item| item == value)
+    }
+}
+
+impl<Element: Clone> SharedChain<Element> {
+    fn to_root_vec(&self) -> Vec<Element> {
+        let mut values: Vec<Element> = self.iter().cloned().collect();
+        values.reverse();
+        values
+    }
+}
+
+struct SharedChainIter<'a, Element> {
+    next: Option<&'a SharedChainLink<Element>>,
+}
+
+impl<'a, Element> Iterator for SharedChainIter<'a, Element> {
+    type Item = &'a Element;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let link = self.next?;
+        self.next = link.parent.as_deref();
+        Some(&link.value)
+    }
+}
+
 fn scoped_hoisted_optional_parent_refs(
     parent_refs: &ParentRefs,
     locked_peer_names: &HashSet<String>,
@@ -843,12 +936,30 @@ struct FinalPeerContext<'a> {
     cyclic_peer_names: &'a HashSet<String>,
 }
 
+struct UndoRealize {
+    newly_inserted: Vec<NodeId>,
+    prev_parent_ids: AncestorIds,
+}
+
+fn merge_realize_undo(
+    first: Option<UndoRealize>,
+    second: Option<UndoRealize>,
+) -> Option<UndoRealize> {
+    match (first, second) {
+        (None, undo) | (undo, None) => undo,
+        (Some(mut first), Some(second)) => {
+            first.newly_inserted.extend(second.newly_inserted);
+            Some(first)
+        }
+    }
+}
+
 struct Walker<'tree> {
     tree: &'tree mut ResolvedTree,
     opts: ResolvePeersOptions,
     graph: DependenciesGraph,
     issues: PeerDependencyIssues,
-    missing_ancestor_pkg_ids: HashMap<String, Vec<Vec<String>>>,
+    missing_ancestor_pkg_ids: HashMap<String, Vec<SharedChain<String>>>,
     /// `NodeId → DepPath` once a node has been walked. Lets repeated
     /// visits (an importer-direct dep that's also reached transitively)
     /// reuse the already-computed depPath.
@@ -857,13 +968,13 @@ struct Walker<'tree> {
     /// the "unknown resolved peers" propagated up so a parent can fold
     /// its descendants' peer dependencies into its own peer suffix.
     /// Indexed by `NodeId`; value's keys are peer aliases.
-    node_external_peers: HashMap<NodeId, HashMap<String, NodeId>>,
+    node_external_peers: HashMap<NodeId, Arc<HashMap<String, NodeId>>>,
     /// Peers each node and its subtree declared but couldn't find.
     /// Indexed by `NodeId`; value's keys are peer aliases.
-    node_missing_peers: HashMap<NodeId, HashMap<String, MissingPeerInfo>>,
+    node_missing_peers: HashMap<NodeId, Arc<HashMap<String, MissingPeerInfo>>>,
     /// Peers each node's children declared but couldn't find.
     /// Indexed by `NodeId`; value's keys are peer aliases.
-    node_missing_peers_of_children: HashMap<NodeId, HashMap<String, MissingPeerInfo>>,
+    node_missing_peers_of_children: HashMap<NodeId, Arc<HashMap<String, MissingPeerInfo>>>,
     /// Resolver-stage real peer providers seen while walking the tree.
     /// This intentionally excludes `peerDependenciesMeta`-only entries:
     /// the auto-install pass reads real `peerDependencies` entries only.
@@ -888,7 +999,7 @@ struct Walker<'tree> {
     /// recursion, no peersCache lookup.
     /// Populated bottom-up: a node is added when its local `is_pure`
     /// flag is true after its own walk completes.
-    pure_pkgs: HashSet<String>,
+    pure_pkgs: HashMap<String, DepPath>,
     /// Per-`pkgIdWithPatchHash` cached results from earlier walks of
     /// non-pure subtrees. Each cache item records the `depPath`, the
     /// external `(peer_name → NodeId)` map, and the `(peer_name →
@@ -910,6 +1021,7 @@ struct Walker<'tree> {
     /// current walk's `parent_refs` (or, for `purePkgs` peers, the
     /// presence-and-pkg-id match short-circuit).
     parent_pkgs_of_node: HashMap<NodeId, Arc<HashMap<String, ParentPkgInfo>>>,
+    retained_peer_node_ids: HashSet<NodeId>,
     /// Per-`NodeId` snapshot captured at graph-insert time, consumed by
     /// the post-walk [`Walker::build_final_dep_paths`] /
     /// [`Walker::build_final_graph`] pass. See [`NodeRecord`].
@@ -933,6 +1045,9 @@ struct Walker<'tree> {
     /// persistent [`PeerDiscoveryCaches`], so the pruned-provider
     /// fallback keeps its per-call meaning.
     visited_this_call: HashSet<NodeId>,
+    packages_by_id: HashMap<String, Arc<ResolvedPackage>>,
+    empty_resolved_peers: Arc<HashMap<String, NodeId>>,
+    empty_missing_peers: Arc<HashMap<String, MissingPeerInfo>>,
 }
 
 impl<'tree> Walker<'tree> {
@@ -944,8 +1059,13 @@ impl<'tree> Walker<'tree> {
         caches: PeerDiscoveryCaches,
         discovery: bool,
     ) -> Self {
-        let PeerDiscoveryCaches { node_dep_paths, pure_pkgs, peers_cache, parent_pkgs_of_node } =
-            caches;
+        let PeerDiscoveryCaches {
+            node_dep_paths,
+            pure_pkgs,
+            peers_cache,
+            parent_pkgs_of_node,
+            retained_peer_node_ids,
+        } = caches;
         Walker {
             tree,
             opts,
@@ -962,12 +1082,16 @@ impl<'tree> Walker<'tree> {
             pure_pkgs,
             peers_cache,
             parent_pkgs_of_node,
+            retained_peer_node_ids,
             node_records: HashMap::default(),
             next_record_order: 0,
             node_ids_by_previous_dep_path,
             current_provider_sources,
             discovery,
             visited_this_call: HashSet::default(),
+            packages_by_id: HashMap::default(),
+            empty_resolved_peers: Arc::new(HashMap::default()),
+            empty_missing_peers: Arc::new(HashMap::default()),
         }
     }
 
@@ -977,6 +1101,7 @@ impl<'tree> Walker<'tree> {
             pure_pkgs: self.pure_pkgs,
             peers_cache: self.peers_cache,
             parent_pkgs_of_node: self.parent_pkgs_of_node,
+            retained_peer_node_ids: self.retained_peer_node_ids,
         }
     }
 }
@@ -1016,14 +1141,45 @@ struct ParentPkgInfo {
 #[derive(Debug)]
 struct PeersCacheItem {
     dep_path: DepPath,
-    resolved_peers: HashMap<String, NodeId>,
-    missing_peers: HashMap<String, MissingPeerInfo>,
-    missing_peers_of_children: HashMap<String, MissingPeerInfo>,
+    resolved_peers: Arc<HashMap<String, NodeId>>,
+    missing_peers: Arc<HashMap<String, MissingPeerInfo>>,
+    missing_peers_of_children: Arc<HashMap<String, MissingPeerInfo>>,
     /// See [`NodeOutput::subtree_missing_by_pkg`]. Replayed on a cache
     /// hit so a discovery pass that never descends into the cached
     /// subtree still reports the same per-package missing breakdown a
     /// full walk of it would.
     subtree_missing_by_pkg: SubtreeMissingByPkg,
+}
+
+struct CachedNodeOutput {
+    output: NodeOutput,
+    missing_peers_of_children: Arc<HashMap<String, MissingPeerInfo>>,
+}
+
+enum DeferredChildResolution {
+    Pure(DepPath),
+    Cached(CachedNodeOutput),
+    Materialize(String),
+}
+
+struct CacheHitContext<'a> {
+    node_id: &'a NodeId,
+    tree_node_depth: i32,
+    parent_chain_names: &'a SharedChain<String>,
+    parent_pkg_ids_chain: &'a SharedChain<String>,
+    preview_undo: Option<UndoRealize>,
+}
+
+struct DeferredChildContext<'a> {
+    edge: &'a ChildEdge,
+    node_id: NodeId,
+    parent_ids: &'a AncestorIds,
+    parent_refs: &'a Arc<ParentRefs>,
+    parent_dep_paths: &'a Arc<HashMap<String, ParentPkgInfo>>,
+    chain_names: &'a SharedChain<String>,
+    parent_node_ids: &'a SharedChain<NodeId>,
+    parent_pkg_ids: &'a SharedChain<String>,
+    depth: i32,
 }
 
 impl PeersCacheItem {
@@ -1032,10 +1188,17 @@ impl PeersCacheItem {
     fn to_node_output(&self) -> NodeOutput {
         NodeOutput {
             dep_path: self.dep_path.clone(),
-            external_resolved_peers: self.resolved_peers.clone(),
+            external_resolved_peers: Arc::clone(&self.resolved_peers),
             auto_install_resolved_peers: HashMap::default(),
-            missing_peers: self.missing_peers.clone(),
+            missing_peers: Arc::clone(&self.missing_peers),
             subtree_missing_by_pkg: self.subtree_missing_by_pkg.clone(),
+        }
+    }
+
+    fn to_cached_node_output(&self) -> CachedNodeOutput {
+        CachedNodeOutput {
+            output: self.to_node_output(),
+            missing_peers_of_children: Arc::clone(&self.missing_peers_of_children),
         }
     }
 }
@@ -1086,11 +1249,16 @@ struct MissingPeerInfo {
     optional: bool,
 }
 
-/// Per-package missing-peer breakdown of a node's whole subtree:
-/// `pkgIdWithPatchHash → missing-peer names its occurrences' children
-/// reported`. `None` when the subtree misses nothing (the common
-/// case), so pure trees never allocate.
-type SubtreeMissingByPkg = Option<Arc<HashMap<String, HashSet<String>>>>;
+/// Persistent summary of missing peers in a subtree. Child summaries
+/// are shared with their parents instead of repeatedly copying every
+/// descendant's package map into each ancestor and cache entry.
+#[derive(Debug)]
+struct MissingSummary {
+    own: Option<(String, HashSet<String>)>,
+    children: Vec<Arc<MissingSummary>>,
+}
+
+type SubtreeMissingByPkg = Option<Arc<MissingSummary>>;
 
 /// Output of [`Walker::resolve_node`] — the per-node result the parent
 /// folds into its own state.
@@ -1099,23 +1267,80 @@ struct NodeOutput {
     /// Peers that this node + its subtree resolved against ancestors.
     /// Excludes peers resolved against this node's own children (those
     /// are absorbed into the children's depPaths).
-    external_resolved_peers: HashMap<String, NodeId>,
+    external_resolved_peers: Arc<HashMap<String, NodeId>>,
     /// Real `peerDependencies` resolved anywhere in this node's
     /// subtree. This feeds the auto-install-peers loop.
     auto_install_resolved_peers: HashMap<String, NodeId>,
-    missing_peers: HashMap<String, MissingPeerInfo>,
+    missing_peers: Arc<HashMap<String, MissingPeerInfo>>,
     /// [`ResolvePeersResult::missing_names_by_pkg`]'s per-subtree
     /// slice, propagated bottom-up so discovery can aggregate it from
     /// the importer's direct deps alone.
     subtree_missing_by_pkg: SubtreeMissingByPkg,
 }
 
+enum ChildAliases<'a> {
+    Realized(&'a BTreeMap<String, NodeId>),
+    Deferred(&'a [ChildEdge]),
+}
+
+impl ChildAliases<'_> {
+    fn contains(&self, alias: &str) -> bool {
+        match self {
+            ChildAliases::Realized(children) => children.contains_key(alias),
+            ChildAliases::Deferred(children) => children.iter().any(|edge| edge.alias == alias),
+        }
+    }
+}
+
+#[derive(Default)]
+struct ChildOutputs {
+    external_peers: HashMap<String, NodeId>,
+    auto_install_resolved_peers: HashMap<String, NodeId>,
+    missing_peers: HashMap<String, MissingPeerInfo>,
+    dep_paths: BTreeMap<String, DepPath>,
+    missing_summaries: Vec<Arc<MissingSummary>>,
+}
+
+impl ChildOutputs {
+    fn push(
+        &mut self,
+        alias: &str,
+        output: NodeOutput,
+        child_aliases: &ChildAliases<'_>,
+        collect_dep_paths: bool,
+    ) {
+        let NodeOutput {
+            dep_path,
+            external_resolved_peers,
+            auto_install_resolved_peers,
+            missing_peers,
+            subtree_missing_by_pkg,
+        } = output;
+        if let Some(summary) = subtree_missing_by_pkg
+            && !self.missing_summaries.iter().any(|existing| Arc::ptr_eq(existing, &summary))
+        {
+            self.missing_summaries.push(summary);
+        }
+        if collect_dep_paths {
+            self.dep_paths.insert(alias.to_string(), dep_path);
+        }
+        self.auto_install_resolved_peers.extend(auto_install_resolved_peers);
+        for (peer_alias, peer_node_id) in external_resolved_peers.iter() {
+            if !child_aliases.contains(peer_alias) {
+                self.external_peers.insert(peer_alias.clone(), peer_node_id.clone());
+            }
+        }
+        self.missing_peers
+            .extend(missing_peers.iter().map(|(name, info)| (name.clone(), info.clone())));
+    }
+}
+
 impl Walker<'_> {
     fn walk(mut self) -> ResolvePeersResult {
         let importer_parents = Arc::new(self.build_importer_parents());
-        let parent_chain_names: Vec<String> = Vec::new();
-        let parent_node_ids: Vec<NodeId> = Vec::new();
-        let parent_pkg_ids_chain: Vec<String> = Vec::new();
+        let parent_chain_names = SharedChain::default();
+        let parent_node_ids = SharedChain::default();
+        let parent_pkg_ids_chain = SharedChain::default();
         let mut direct_by_alias = BTreeMap::new();
         // Clone direct deps into an owned `Vec` so the recursion
         // below can mutate `self.tree` (realising lazy children)
@@ -1127,12 +1352,15 @@ impl Walker<'_> {
             .iter()
             .partition(|dep| !self.opts.hoisted_peer_provider_node_ids.contains(&dep.node_id));
         for dep in &own_direct {
-            self.parent_pkgs_of_node
-                .insert(dep.node_id.clone(), Arc::clone(&importer_parent_dep_paths));
+            self.remember_parent_context_if_peer_provider(
+                &dep.alias,
+                &dep.node_id,
+                &importer_parent_dep_paths,
+            );
         }
         for dep in &own_direct {
             let output = self.resolve_node(
-                dep.node_id.clone(),
+                &dep.node_id,
                 &importer_parents,
                 &importer_parent_dep_paths,
                 &parent_chain_names,
@@ -1151,10 +1379,13 @@ impl Walker<'_> {
             if self.visited_this_call.contains(&dep.node_id) {
                 continue;
             }
-            self.parent_pkgs_of_node
-                .insert(dep.node_id.clone(), Arc::clone(&importer_parent_dep_paths));
+            self.remember_parent_context_if_peer_provider(
+                &dep.alias,
+                &dep.node_id,
+                &importer_parent_dep_paths,
+            );
             let output = self.resolve_node(
-                dep.node_id.clone(),
+                &dep.node_id,
                 &importer_parents,
                 &importer_parent_dep_paths,
                 &parent_chain_names,
@@ -1291,12 +1522,12 @@ impl Walker<'_> {
 
     fn resolve_node(
         &mut self,
-        node_id: NodeId,
+        node_id: &NodeId,
         parent_parent_refs: &Arc<ParentRefs>,
         parent_dep_paths: &Arc<HashMap<String, ParentPkgInfo>>,
-        parent_chain_names: &[String],
-        parent_node_ids: &[NodeId],
-        parent_pkg_ids_chain: &[String],
+        parent_chain_names: &SharedChain<String>,
+        parent_node_ids: &SharedChain<NodeId>,
+        parent_pkg_ids_chain: &SharedChain<String>,
     ) -> NodeOutput {
         // `purePkgs` fast-path. When the subtree below this
         // `pkgIdWithPatchHash` resolved with zero external peers and
@@ -1305,73 +1536,43 @@ impl Walker<'_> {
         // bare `pkgIdWithPatchHash` regardless of parent context.
         // Skip recursion entirely.
         //
-        // The pkg lookup happens before the existing in-progress
-        // gate because: a re-entry on this same `NodeId` while it's
-        // still on the call stack is a cycle (handled below); a
-        // re-entry on a `NodeId` that's done and pure is exactly what
-        // this fast-path should catch. The unconditional clone
-        // mirrors the post-`in_progress` clone the rest of the
-        // function already does — peer resolution is single-threaded
-        // and the clones are cheap.
-        if let Some(tree_node) = self.tree.dependencies_tree.get(&node_id) {
-            let tree_node_depth = tree_node.depth;
-            let pkg_id = tree_node.resolved_package_id.clone();
-            // Workspace-link short-circuit: a node at depth -1 is a
-            // workspace link. The linked package's depPath is its
-            // `link:<rel-path>` id verbatim — no peer-graph suffix,
-            // no graph entry. Peer matching for the linked package is
-            // the linked importer's responsibility, not the parent's.
-            if tree_node_depth == -1 {
-                let dep_path = DepPath::from(pkg_id);
-                self.node_dep_paths.insert(node_id.clone(), dep_path.clone());
-                self.visited_this_call.insert(node_id);
-                return NodeOutput {
-                    dep_path,
-                    external_resolved_peers: HashMap::default(),
-                    auto_install_resolved_peers: HashMap::default(),
-                    missing_peers: HashMap::default(),
-                    subtree_missing_by_pkg: None,
-                };
-            }
-            let pkg_peer_dependencies_empty =
-                self.tree.packages[&pkg_id].peer_dependencies.is_empty();
-            let bare_dep_path = DepPath::from(pkg_id.clone());
-            // Discovery builds no graph, so the graph-entry half of the
-            // gate (an output-completeness requirement) doesn't apply.
-            if self.pure_pkgs.contains(&pkg_id)
-                && pkg_peer_dependencies_empty
-                && (self.discovery
-                    || self
-                        .graph
-                        .get(&bare_dep_path)
-                        .is_some_and(|node| node.depth <= tree_node_depth))
-            {
-                let dep_path = bare_dep_path;
-                self.node_dep_paths.insert(node_id.clone(), dep_path.clone());
-                self.visited_this_call.insert(node_id.clone());
-                // Lower the existing graph entry's `depth` if this
-                // occurrence reached the package shallower than the
-                // previous walk(s). The same minimum-depth tie-break
-                // the non-fast path runs via
-                // `self.graph.entry(...).and_modify(...)`; without it
-                // a shallow revisit through `pure_pkgs` would leave
-                // the entry's depth stuck at the first walk's value.
-                if let Some(node) = self.graph.get_mut(&dep_path)
-                    && node.depth > tree_node_depth
-                {
-                    node.depth = tree_node_depth;
+        let context_free_dep_path =
+            self.tree.dependencies_tree.get(node_id).and_then(|tree_node| {
+                if tree_node.depth == -1 {
+                    return Some((
+                        tree_node.depth,
+                        DepPath::from(tree_node.resolved_package_id.clone()),
+                    ));
                 }
-                return NodeOutput {
-                    dep_path,
-                    external_resolved_peers: HashMap::default(),
-                    auto_install_resolved_peers: HashMap::default(),
-                    missing_peers: HashMap::default(),
-                    subtree_missing_by_pkg: None,
-                };
+                let dep_path = self.pure_pkgs.get(&tree_node.resolved_package_id)?;
+                if !self.tree.packages[&tree_node.resolved_package_id].peer_dependencies.is_empty()
+                    || (!self.discovery
+                        && self
+                            .graph
+                            .get(dep_path)
+                            .is_none_or(|graph_node| graph_node.depth > tree_node.depth))
+                {
+                    return None;
+                }
+                Some((tree_node.depth, dep_path.clone()))
+            });
+        if let Some((tree_node_depth, dep_path)) = context_free_dep_path {
+            self.remember_resolved_node(node_id, &dep_path);
+            if let Some(node) = self.graph.get_mut(&dep_path)
+                && node.depth > tree_node_depth
+            {
+                node.depth = tree_node_depth;
             }
+            return NodeOutput {
+                dep_path,
+                external_resolved_peers: Arc::clone(&self.empty_resolved_peers),
+                auto_install_resolved_peers: HashMap::default(),
+                missing_peers: Arc::clone(&self.empty_missing_peers),
+                subtree_missing_by_pkg: None,
+            };
         }
 
-        if self.in_progress.contains(&node_id) {
+        if self.in_progress.contains(node_id) {
             // Cycle: bottom out with the bare `pkgIdWithPatchHash` as
             // the depPath. The original visit (still on the stack) will
             // compute the real depPath and insert it into
@@ -1379,28 +1580,53 @@ impl Walker<'_> {
             // current ancestor's peer-suffix construction can use a
             // `name@version` PeerId — see [`build_peer_id`] for the
             // cycle handling.
-            let tree_node = &self.tree.dependencies_tree[&node_id];
+            let tree_node = &self.tree.dependencies_tree[node_id];
             let pkg = &self.tree.packages[&tree_node.resolved_package_id];
             return NodeOutput {
                 dep_path: DepPath::from(pkg.id.clone()),
-                external_resolved_peers: HashMap::default(),
+                external_resolved_peers: Arc::clone(&self.empty_resolved_peers),
                 auto_install_resolved_peers: HashMap::default(),
-                missing_peers: HashMap::default(),
+                missing_peers: Arc::clone(&self.empty_missing_peers),
                 subtree_missing_by_pkg: None,
             };
         }
         self.in_progress.insert(node_id.clone());
 
-        // Realize children for this node if they're still Lazy. The
-        // returned `children_map` is an owned clone; later iteration
-        // over it doesn't hold a borrow on `self.tree`, so the
-        // recursion below can mutate the tree (realising
-        // grandchildren) freely.
-        let children_map = self.realize_children(&node_id);
-        let tree_node = self.tree.dependencies_tree[&node_id].clone();
-        let pkg = self.tree.packages[&tree_node.resolved_package_id].clone();
-        let mut refs_changed = tree_node.locked_peer_names.is_some();
-        let parent_parent_refs = if let Some(locked_peer_names) = &tree_node.locked_peer_names {
+        let fast_cached = {
+            let tree_node = &self.tree.dependencies_tree[node_id];
+            (tree_node.locked_peer_names.is_none() && tree_node.locked_peer_context.is_none())
+                .then(|| {
+                    self.find_fast_hit(node_id, parent_parent_refs, &tree_node.resolved_package_id)
+                })
+                .flatten()
+                .map(PeersCacheItem::to_cached_node_output)
+        };
+        if let Some(cached) = fast_cached {
+            let tree_node_depth = self.tree.dependencies_tree[node_id].depth;
+            return self.finish_cache_hit(
+                cached,
+                CacheHitContext {
+                    node_id,
+                    tree_node_depth,
+                    parent_chain_names,
+                    parent_pkg_ids_chain,
+                    preview_undo: None,
+                },
+            );
+        }
+        let (pkg_id, tree_node_depth, tree_node_installable, locked_peer_names) = {
+            let tree_node = &self.tree.dependencies_tree[node_id];
+            (
+                tree_node.resolved_package_id.clone(),
+                tree_node.depth,
+                tree_node.installable,
+                tree_node.locked_peer_names.clone(),
+            )
+        };
+        let pkg = self.owned_package(&pkg_id);
+        let (provider_children, preview_undo) = self.preview_peer_provider_children(node_id);
+        let mut refs_changed = locked_peer_names.is_some();
+        let parent_parent_refs = if let Some(locked_peer_names) = &locked_peer_names {
             Arc::new(scoped_hoisted_optional_parent_refs(
                 parent_parent_refs,
                 locked_peer_names,
@@ -1411,13 +1637,6 @@ impl Walker<'_> {
         };
         let (pkg_name, _pkg_version) = pkg_name_version(&pkg.result);
 
-        let mut current_parent_node_ids = parent_node_ids.to_vec();
-        current_parent_node_ids.push(node_id.clone());
-        let mut child_parent_pkg_ids_chain = parent_pkg_ids_chain.to_vec();
-        if !child_parent_pkg_ids_chain.contains(&pkg.id) {
-            child_parent_pkg_ids_chain.push(pkg.id.clone());
-        }
-
         // Build the ParentRefs map that descendants of this node see:
         // parent's view + this node's own peer-relevant children. Kept
         // behind `Arc` copy-on-write: most nodes contribute nothing, so
@@ -1426,7 +1645,7 @@ impl Walker<'_> {
         // peer-heavy workspaces.
         let mut child_parent_refs = parent_parent_refs;
         let mut new_parent_refs = ParentRefs::default();
-        for (alias, child_node_id) in &children_map {
+        for (alias, child_node_id) in &provider_children {
             let Some(child_tree) = self.tree.dependencies_tree.get(child_node_id) else { continue };
             let Some(child_pkg) = self.tree.packages.get(&child_tree.resolved_package_id) else {
                 continue;
@@ -1460,7 +1679,7 @@ impl Walker<'_> {
                             with_new,
                             existing,
                             &new_parent_ref,
-                            &children_map,
+                            node_id,
                         )
                     {
                         new_parent_ref.occurrence = existing.occurrence + 1;
@@ -1473,7 +1692,7 @@ impl Walker<'_> {
         }
 
         let locked_pins =
-            self.locked_peer_context_pins(&tree_node, &pkg, &child_parent_refs, parent_node_ids);
+            self.locked_peer_context_pins(node_id, &pkg, &child_parent_refs, parent_node_ids);
         if !locked_pins.is_empty() {
             refs_changed = true;
             let refs = Arc::make_mut(&mut child_parent_refs);
@@ -1492,12 +1711,11 @@ impl Walker<'_> {
         } else {
             Arc::clone(parent_dep_paths)
         };
-        for child_node_id in children_map.values() {
+        for child_node_id in
+            new_parent_refs.values().filter_map(|parent_ref| parent_ref.node_id.as_ref())
+        {
             self.parent_pkgs_of_node.insert(child_node_id.clone(), Arc::clone(&parent_dep_paths));
         }
-
-        let mut child_chain_names: Vec<String> = parent_chain_names.to_vec();
-        child_chain_names.push(pkg_name.clone());
 
         // `peersCache` lookup. When an earlier walk of this same
         // `pkgIdWithPatchHash` produced a result whose resolved-peer
@@ -1508,89 +1726,118 @@ impl Walker<'_> {
         // The cache lookup uses `child_parent_refs` (the augmented
         // view) because a node's own children count as parents for
         // its own descendants' peer resolution.
-        if let Some(cached) = self.find_hit(&child_parent_refs, &pkg.id) {
-            let output = cached.to_node_output();
-            let missing_of_children = cached.missing_peers_of_children.clone();
-            // Re-emit the missing-peer issues against the current
-            // parent chain so each occurrence of the package shows up
-            // in the diagnostic. Without this, the first walk's parent
-            // chain would be the only one ever reported. The cached
-            // summary blends the node's own peers with its subtree's,
-            // so under a hoist scope the foreignness of the node
-            // itself counts too.
-            {
-                let mut chain_with_self = parent_pkg_ids_chain.to_vec();
-                chain_with_self.push(pkg.id.clone());
-                for (peer_name, info) in &output.missing_peers {
-                    if self.missing_issue_suppressed(&chain_with_self, peer_name) {
+        let cached =
+            self.find_hit(&child_parent_refs, &pkg.id).map(PeersCacheItem::to_cached_node_output);
+        if let Some(cached) = cached {
+            return self.finish_cache_hit(
+                cached,
+                CacheHitContext {
+                    node_id,
+                    tree_node_depth,
+                    parent_chain_names,
+                    parent_pkg_ids_chain,
+                    preview_undo,
+                },
+            );
+        }
+        let discovery_children = if self.discovery {
+            let node = &self.tree.dependencies_tree[node_id];
+            if let TreeChildren::Lazy { parent_ids } = &node.children {
+                Some((
+                    self.tree.children_by_id.get(&pkg.id).cloned().unwrap_or_default(),
+                    parent_ids.pushed(pkg.id.clone()),
+                ))
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        let (children_map, realize_undo) = if discovery_children.is_some() {
+            (BTreeMap::new(), None)
+        } else {
+            self.realize_children_with(node_id, Some(&provider_children))
+        };
+        let realize_undo = merge_realize_undo(preview_undo, realize_undo);
+        let current_parent_node_ids = parent_node_ids.pushed(node_id.clone());
+        let child_parent_pkg_ids_chain = if parent_pkg_ids_chain.contains(&pkg.id) {
+            parent_pkg_ids_chain.clone()
+        } else {
+            parent_pkg_ids_chain.pushed(pkg.id.clone())
+        };
+        let child_chain_names = parent_chain_names.pushed(pkg_name.clone());
+
+        // Recurse into children first (post-order). Discovery walks lazy
+        // children directly so cache hits never need occurrence-tree nodes.
+        let mut child_outputs = ChildOutputs::default();
+        if let Some((children, parent_ids)) = &discovery_children {
+            let child_aliases = ChildAliases::Deferred(children);
+            for repeated in [true, false] {
+                for edge in children.iter() {
+                    if child_parent_refs.contains_key(&edge.alias) != repeated
+                        || parent_ids.forms_cycle(&pkg.id, &edge.pkg_id)
+                    {
                         continue;
                     }
-                    self.record_missing_issue(
-                        peer_name,
-                        MissingPeer {
-                            wanted_range: get_peer_version_range(&info.range),
-                            raw_range: info.range.clone(),
-                            optional: info.optional,
-                            parents: parents_from_chain(parent_chain_names, &pkg_name),
-                        },
-                        &chain_with_self,
+                    let child_node_id =
+                        provider_children.get(&edge.alias).cloned().unwrap_or_else(|| {
+                            if self.tree.packages.get(&edge.pkg_id).is_some_and(|pkg| pkg.is_leaf) {
+                                NodeId::leaf(&edge.pkg_id)
+                            } else {
+                                NodeId::next()
+                            }
+                        });
+                    let child_output = if self.tree.dependencies_tree.contains_key(&child_node_id) {
+                        self.resolve_node(
+                            &child_node_id,
+                            &child_parent_refs,
+                            &parent_dep_paths,
+                            &child_chain_names,
+                            &current_parent_node_ids,
+                            &child_parent_pkg_ids_chain,
+                        )
+                    } else {
+                        self.resolve_deferred_child(DeferredChildContext {
+                            edge,
+                            node_id: child_node_id,
+                            parent_ids,
+                            parent_refs: &child_parent_refs,
+                            parent_dep_paths: &parent_dep_paths,
+                            chain_names: &child_chain_names,
+                            parent_node_ids: &current_parent_node_ids,
+                            parent_pkg_ids: &child_parent_pkg_ids_chain,
+                            depth: tree_node_depth + 1,
+                        })
+                    };
+                    child_outputs.push(&edge.alias, child_output, &child_aliases, false);
+                }
+            }
+        } else {
+            let child_aliases = ChildAliases::Realized(&children_map);
+            for repeated in [true, false] {
+                for (alias, child_node_id) in &children_map {
+                    if child_parent_refs.contains_key(alias) != repeated {
+                        continue;
+                    }
+                    let child_output = self.resolve_node(
+                        child_node_id,
+                        &child_parent_refs,
+                        &parent_dep_paths,
+                        &child_chain_names,
+                        &current_parent_node_ids,
+                        &child_parent_pkg_ids_chain,
                     );
+                    child_outputs.push(alias, child_output, &child_aliases, !self.discovery);
                 }
             }
-            self.node_dep_paths.insert(node_id.clone(), output.dep_path.clone());
-            self.node_external_peers
-                .insert(node_id.clone(), output.external_resolved_peers.clone());
-            self.node_missing_peers.insert(node_id.clone(), output.missing_peers.clone());
-            self.node_missing_peers_of_children.insert(node_id.clone(), missing_of_children);
-            // Same depth tie-break as the `purePkgs` fast path and the
-            // non-fast `entry(...).and_modify(...)` write below — a
-            // shallower revisit through the cache must still lower the
-            // existing graph entry's `depth`.
-            if let Some(node) = self.graph.get_mut(&output.dep_path)
-                && node.depth > tree_node.depth
-            {
-                node.depth = tree_node.depth;
-            }
-            self.in_progress.remove(&node_id);
-            self.visited_this_call.insert(node_id);
-            return output;
         }
-        // Recurse into children first (post-order). Collect each child's
-        // depPath and the external peers / missing peers they propagate
-        // up. Children's external peers may overlap with this node's
-        // own children (e.g. a child resolved a peer to a sibling of
-        // its parent — i.e., this node's child). Those are not external
-        // *to this node* — they're internal here — so filter them out.
-        let mut external_from_children: HashMap<String, NodeId> = HashMap::default();
-        let mut auto_install_resolved_peers: HashMap<String, NodeId> = HashMap::default();
-        let mut missing_from_children: HashMap<String, MissingPeerInfo> = HashMap::default();
-        let mut child_dep_paths: BTreeMap<String, DepPath> = BTreeMap::new();
-        let mut subtree_missing_by_pkg: SubtreeMissingByPkg = None;
-        let child_entries = ordered_child_entries(&children_map, &child_parent_refs);
-        for (alias, child_node_id) in &child_entries {
-            let child_output = self.resolve_node(
-                child_node_id.clone(),
-                &child_parent_refs,
-                &parent_dep_paths,
-                &child_chain_names,
-                &current_parent_node_ids,
-                &child_parent_pkg_ids_chain,
-            );
-            merge_subtree_missing(&mut subtree_missing_by_pkg, child_output.subtree_missing_by_pkg);
-            child_dep_paths.insert(alias.clone(), child_output.dep_path);
-            for (peer_alias, peer_node_id) in child_output.auto_install_resolved_peers {
-                auto_install_resolved_peers.insert(peer_alias, peer_node_id);
-            }
-            for (peer_alias, peer_node_id) in child_output.external_resolved_peers {
-                if children_map.contains_key(&peer_alias) {
-                    continue;
-                }
-                external_from_children.insert(peer_alias, peer_node_id);
-            }
-            for (peer_alias, info) in child_output.missing_peers {
-                missing_from_children.insert(peer_alias, info);
-            }
-        }
+        let ChildOutputs {
+            external_peers: external_from_children,
+            mut auto_install_resolved_peers,
+            missing_peers: missing_from_children,
+            dep_paths: child_dep_paths,
+            mut missing_summaries,
+        } = child_outputs;
 
         // Resolve this node's own peer requirements against the augmented
         // ParentRefs visible at this node, including peer-relevant children.
@@ -1644,20 +1891,27 @@ impl Walker<'_> {
         // propagated state before inserting into the graph (so any
         // cycle the graph insert hits via `child_dep_paths` can find
         // this node's depPath).
-        self.node_dep_paths.insert(node_id.clone(), dep_path.clone());
-        self.visited_this_call.insert(node_id.clone());
-        self.node_external_peers.insert(node_id.clone(), all_resolved_peers.clone());
-        self.node_missing_peers.insert(node_id.clone(), all_missing_peers.clone());
-        self.node_missing_peers_of_children.insert(node_id.clone(), missing_from_children.clone());
+        self.remember_resolved_node(node_id, &dep_path);
 
-        if !missing_from_children.is_empty() {
-            let mut merged =
-                subtree_missing_by_pkg.take().map(Arc::unwrap_or_clone).unwrap_or_default();
-            merged.entry(pkg.id.clone()).or_default().extend(missing_from_children.keys().cloned());
-            subtree_missing_by_pkg = Some(Arc::new(merged));
-        }
+        let own_missing = (!missing_from_children.is_empty())
+            .then(|| (pkg.id.clone(), missing_from_children.keys().cloned().collect()));
+        let subtree_missing_by_pkg = match (own_missing, missing_summaries.len()) {
+            (None, 0) => None,
+            (None, 1) => missing_summaries.pop(),
+            (own, _) => Some(Arc::new(MissingSummary { own, children: missing_summaries })),
+        };
 
         let is_pure = all_resolved_peers.is_empty() && all_missing_peers.is_empty();
+        let all_resolved_peers = Arc::new(all_resolved_peers);
+        let all_missing_peers = Arc::new(all_missing_peers);
+        let missing_from_children = Arc::new(missing_from_children);
+
+        if !self.discovery {
+            self.node_external_peers.insert(node_id.clone(), Arc::clone(&all_resolved_peers));
+            self.node_missing_peers.insert(node_id.clone(), Arc::clone(&all_missing_peers));
+            self.node_missing_peers_of_children
+                .insert(node_id.clone(), Arc::clone(&missing_from_children));
+        }
 
         // Record this walk's outcome in the per-`pkgIdWithPatchHash`
         // caches. Pure subtrees go in [`Self::pure_pkgs`] for the
@@ -1679,13 +1933,14 @@ impl Walker<'_> {
             // hit the authoritative entry of the same package) instead of
             // reusing this partial one.
         } else if is_pure {
-            self.pure_pkgs.insert(pkg.id.clone());
+            self.pure_pkgs.insert(pkg.id.clone(), dep_path.clone());
         } else {
+            self.retained_peer_node_ids.extend(all_resolved_peers.values().cloned());
             self.peers_cache.entry(pkg.id.clone()).or_default().push(PeersCacheItem {
                 dep_path: dep_path.clone(),
-                resolved_peers: all_resolved_peers.clone(),
-                missing_peers: all_missing_peers.clone(),
-                missing_peers_of_children: missing_from_children,
+                resolved_peers: Arc::clone(&all_resolved_peers),
+                missing_peers: Arc::clone(&all_missing_peers),
+                missing_peers_of_children: Arc::clone(&missing_from_children),
                 subtree_missing_by_pkg: subtree_missing_by_pkg.clone(),
             });
         }
@@ -1712,7 +1967,7 @@ impl Walker<'_> {
             for (alias, child_dep_path) in child_dep_paths {
                 graph_children.insert(alias, child_dep_path);
             }
-            for (peer_alias, peer_node_id) in &all_resolved_peers {
+            for (peer_alias, peer_node_id) in all_resolved_peers.iter() {
                 self.add_graph_child_or_pending(
                     &mut graph_children,
                     &dep_path,
@@ -1759,8 +2014,8 @@ impl Walker<'_> {
                     edges: record_edges,
                     optional_child_aliases: optional_child_aliases.clone(),
                     transitive_peer_dependencies: transitive_peer_dependencies.clone(),
-                    depth: tree_node.depth,
-                    installable: tree_node.installable,
+                    depth: tree_node_depth,
+                    installable: tree_node_installable,
                     is_pure,
                     order: record_order,
                 },
@@ -1772,8 +2027,8 @@ impl Walker<'_> {
             self.graph
                 .entry(dep_path.clone())
                 .and_modify(|node| {
-                    if node.depth > tree_node.depth {
-                        node.depth = tree_node.depth;
+                    if node.depth > tree_node_depth {
+                        node.depth = tree_node_depth;
                     }
                 })
                 .or_insert(DependenciesGraphNode {
@@ -1785,27 +2040,89 @@ impl Walker<'_> {
                     peer_dependencies: pkg.peer_dependencies.clone(),
                     transitive_peer_dependencies,
                     resolved_peer_names: all_resolved_peers.keys().cloned().collect(),
-                    depth: tree_node.depth,
-                    installable: tree_node.installable,
+                    depth: tree_node_depth,
+                    installable: tree_node_installable,
                     is_pure,
                     optional: pkg.optional,
                 });
         }
 
-        self.in_progress.remove(&node_id);
+        self.in_progress.remove(node_id);
 
         let external_to_report: HashMap<String, NodeId> = all_resolved_peers
-            .into_iter()
-            .filter(|(peer_alias, _)| !children_map.contains_key(peer_alias))
+            .iter()
+            .filter(|(peer_alias, _)| {
+                !children_map.contains_key(peer_alias.as_str())
+                    && discovery_children.as_ref().is_none_or(|(children, _)| {
+                        !children.iter().any(|edge| edge.alias == **peer_alias)
+                    })
+            })
+            .map(|(peer_alias, peer_node_id)| (peer_alias.clone(), peer_node_id.clone()))
             .collect();
 
-        NodeOutput {
+        let output = NodeOutput {
             dep_path,
-            external_resolved_peers: external_to_report,
+            external_resolved_peers: Arc::new(external_to_report),
             auto_install_resolved_peers,
             missing_peers: all_missing_peers,
             subtree_missing_by_pkg,
+        };
+        if self.discovery {
+            self.undo_realize(node_id, realize_undo, Some(&output));
         }
+        output
+    }
+
+    fn finish_cache_hit(
+        &mut self,
+        cached: CachedNodeOutput,
+        context: CacheHitContext<'_>,
+    ) -> NodeOutput {
+        let CacheHitContext {
+            node_id,
+            tree_node_depth,
+            parent_chain_names,
+            parent_pkg_ids_chain,
+            preview_undo,
+        } = context;
+        let output = cached.output;
+        self.undo_realize(node_id, preview_undo, None);
+
+        if !output.missing_peers.is_empty() {
+            let pkg_id = self.tree.dependencies_tree[node_id].resolved_package_id.clone();
+            let chain_with_self = parent_pkg_ids_chain.pushed(pkg_id.clone());
+            let pkg_name = pkg_name_version(&self.tree.packages[&pkg_id].result).0;
+            for (peer_name, info) in output.missing_peers.iter() {
+                if self.missing_issue_suppressed(&chain_with_self, peer_name) {
+                    continue;
+                }
+                self.record_missing_issue(
+                    peer_name,
+                    MissingPeer {
+                        wanted_range: get_peer_version_range(&info.range),
+                        raw_range: info.range.clone(),
+                        optional: info.optional,
+                        parents: self.issue_parents(parent_chain_names, &pkg_name),
+                    },
+                    &chain_with_self,
+                );
+            }
+        }
+        self.remember_resolved_node(node_id, &output.dep_path);
+        if !self.discovery {
+            self.node_external_peers
+                .insert(node_id.clone(), Arc::clone(&output.external_resolved_peers));
+            self.node_missing_peers.insert(node_id.clone(), Arc::clone(&output.missing_peers));
+            self.node_missing_peers_of_children
+                .insert(node_id.clone(), cached.missing_peers_of_children);
+        }
+        if let Some(node) = self.graph.get_mut(&output.dep_path)
+            && node.depth > tree_node_depth
+        {
+            node.depth = tree_node_depth;
+        }
+        self.in_progress.remove(node_id);
+        output
     }
 
     /// `true` when a missing-peer issue for `peer_name` under the
@@ -1826,14 +2143,17 @@ impl Walker<'_> {
     /// equivalent to inserting while iterating.
     fn locked_peer_context_pins(
         &self,
-        tree_node: &DependenciesTreeNode,
+        node_id: &NodeId,
         pkg: &ResolvedPackage,
         parent_refs: &ParentRefs,
-        parent_node_ids: &[NodeId],
+        parent_node_ids: &SharedChain<NodeId>,
     ) -> Vec<(String, ParentRef)> {
         let mut pins = Vec::new();
         let (Some(locked_peer_context), Some(provider_paths)) = (
-            tree_node.locked_peer_context.as_ref(),
+            self.tree
+                .dependencies_tree
+                .get(node_id)
+                .and_then(|tree_node| tree_node.locked_peer_context.as_ref()),
             self.opts.resolved_peer_provider_paths.as_ref(),
         ) else {
             return pins;
@@ -1906,7 +2226,7 @@ impl Walker<'_> {
         &self,
         peer_name: &str,
         parent_refs: &ParentRefs,
-        parent_node_ids: &[NodeId],
+        parent_node_ids: &SharedChain<NodeId>,
     ) -> bool {
         let Some(peer_node_id) =
             parent_refs.get(peer_name).and_then(|parent| parent.node_id.as_ref())
@@ -1929,7 +2249,7 @@ impl Walker<'_> {
                 }
             }
         }
-        for parent_node_id in parent_node_ids {
+        for parent_node_id in parent_node_ids.iter() {
             let Some(parent_node) = self.tree.dependencies_tree.get(parent_node_id) else {
                 continue;
             };
@@ -1947,22 +2267,32 @@ impl Walker<'_> {
         false
     }
 
-    fn missing_issue_suppressed(&self, ancestor_pkg_ids: &[String], peer_name: &str) -> bool {
+    fn missing_issue_suppressed(
+        &self,
+        ancestor_pkg_ids: &SharedChain<String>,
+        peer_name: &str,
+    ) -> bool {
         let Some(scope) = self.opts.hoist_missing_scope.as_ref() else { return false };
-        scope.suppresses(ancestor_pkg_ids, peer_name)
+        scope.suppresses_iter(ancestor_pkg_ids.iter(), peer_name)
     }
 
     fn record_missing_issue(
         &mut self,
         peer_name: &str,
         issue: MissingPeer,
-        ancestor_pkg_ids: &[String],
+        ancestor_pkg_ids: &SharedChain<String>,
     ) {
         self.issues.missing.entry(peer_name.to_string()).or_default().push(issue);
-        self.missing_ancestor_pkg_ids
-            .entry(peer_name.to_string())
-            .or_default()
-            .push(ancestor_pkg_ids.to_vec());
+        if self.discovery {
+            self.missing_ancestor_pkg_ids
+                .entry(peer_name.to_string())
+                .or_default()
+                .push(ancestor_pkg_ids.clone());
+        }
+    }
+
+    fn issue_parents(&self, chain: &SharedChain<String>, pkg_name: &str) -> Vec<ParentPackageRef> {
+        if self.discovery { Vec::new() } else { parents_from_chain(chain, pkg_name) }
     }
 
     #[expect(
@@ -1975,8 +2305,8 @@ impl Walker<'_> {
         peer_name: &str,
         peer_dep: &PeerDep,
         parent_refs: &ParentRefs,
-        chain: &[String],
-        ancestor_pkg_ids: &[String],
+        chain: &SharedChain<String>,
+        ancestor_pkg_ids: &SharedChain<String>,
         resolved: &mut HashMap<String, NodeId>,
         missing: &mut HashMap<String, MissingPeerInfo>,
     ) {
@@ -2003,7 +2333,7 @@ impl Walker<'_> {
                             wanted_range: range_for_satisfies,
                             raw_range: range_for_match.to_string(),
                             optional,
-                            parents: parents_from_chain(chain, pkg_name),
+                            parents: self.issue_parents(chain, pkg_name),
                         },
                         ancestor_pkg_ids,
                     );
@@ -2011,12 +2341,13 @@ impl Walker<'_> {
             }
             Some(parent) => {
                 if !satisfies_with_prereleases(&parent.version, &range_for_satisfies) {
+                    let parents = self.issue_parents(chain, pkg_name);
                     self.issues.bad.entry(peer_name.to_string()).or_default().push(
                         PeerDependencyIssue {
                             wanted_range: range_for_satisfies,
                             found_version: parent.version.clone(),
                             optional,
-                            parents: parents_from_chain(chain, pkg_name),
+                            parents,
                             resolved_from: Vec::new(),
                         },
                     );
@@ -2529,6 +2860,65 @@ impl Walker<'_> {
             .collect()
     }
 
+    fn preview_peer_provider_children(
+        &mut self,
+        node_id: &NodeId,
+    ) -> (BTreeMap<String, NodeId>, Option<UndoRealize>) {
+        let (parent_ids, pkg_id, depth) = {
+            let node = &self.tree.dependencies_tree[node_id];
+            match &node.children {
+                TreeChildren::Realized(children) => {
+                    let providers = children
+                        .iter()
+                        .filter(|(alias, child_node_id)| {
+                            self.tree
+                                .dependencies_tree
+                                .get(*child_node_id)
+                                .and_then(|child| {
+                                    self.tree.packages.get(&child.resolved_package_id)
+                                })
+                                .is_some_and(|pkg| self.is_peer_relevant(alias, pkg))
+                        })
+                        .map(|(alias, child_node_id)| (alias.clone(), child_node_id.clone()))
+                        .collect();
+                    return (providers, None);
+                }
+                TreeChildren::Lazy { parent_ids } => {
+                    (parent_ids.clone(), node.resolved_package_id.clone(), node.depth)
+                }
+            }
+        };
+        let children = self.tree.children_by_id.get(&pkg_id).cloned().unwrap_or_default();
+        let full_chain = parent_ids.pushed(pkg_id.clone());
+        let mut providers = BTreeMap::new();
+        let mut newly_inserted = Vec::new();
+        for edge in children.iter() {
+            let Some(pkg) = self.tree.packages.get(&edge.pkg_id) else { continue };
+            if !self.is_peer_relevant(&edge.alias, pkg)
+                || pkg_id == edge.pkg_id
+                || full_chain.forms_cycle(&pkg_id, &edge.pkg_id)
+            {
+                continue;
+            }
+            let child_node_id =
+                if pkg.is_leaf { NodeId::leaf(&edge.pkg_id) } else { NodeId::next() };
+            if !self.tree.dependencies_tree.contains_key(&child_node_id) {
+                self.tree.dependencies_tree.insert(
+                    child_node_id.clone(),
+                    DependenciesTreeNode::new(
+                        edge.pkg_id.clone(),
+                        TreeChildren::Lazy { parent_ids: full_chain.clone() },
+                        depth + 1,
+                        true,
+                    ),
+                );
+                newly_inserted.push(child_node_id.clone());
+            }
+            providers.insert(edge.alias.clone(), child_node_id);
+        }
+        (providers, Some(UndoRealize { newly_inserted, prev_parent_ids: parent_ids }))
+    }
+
     /// Realize the `(alias → NodeId)` children of `node_id` if it's
     /// currently a [`TreeChildren::Lazy`] entry; return the realized
     /// map (cloned for the caller). On a [`TreeChildren::Realized`]
@@ -2546,15 +2936,26 @@ impl Walker<'_> {
     ///    [self_pkg_id]` for cycle break on its own descendants.
     /// 4. Flip this node's `children` field to `Realized` so a
     ///    later visitor reuses the map.
-    fn realize_children(&mut self, node_id: &NodeId) -> BTreeMap<String, NodeId> {
+    fn realize_children(
+        &mut self,
+        node_id: &NodeId,
+    ) -> (BTreeMap<String, NodeId>, Option<UndoRealize>) {
+        self.realize_children_with(node_id, None)
+    }
+
+    fn realize_children_with(
+        &mut self,
+        node_id: &NodeId,
+        previewed: Option<&BTreeMap<String, NodeId>>,
+    ) -> (BTreeMap<String, NodeId>, Option<UndoRealize>) {
         // Snapshot the bits we need; we'll mutate `self.tree` below
         // and can't hold a borrow on the entry across the mutation.
         let (parent_ids, pkg_id, depth) = {
             let node = &self.tree.dependencies_tree[node_id];
             match &node.children {
-                TreeChildren::Realized(map) => return map.clone(),
+                TreeChildren::Realized(map) => return (map.clone(), None),
                 TreeChildren::Lazy { parent_ids } => {
-                    (Arc::clone(parent_ids), node.resolved_package_id.clone(), node.depth)
+                    (parent_ids.clone(), node.resolved_package_id.clone(), node.depth)
                 }
             }
         };
@@ -2566,16 +2967,12 @@ impl Walker<'_> {
         };
         let child_depth = depth + 1;
         let mut realized: BTreeMap<String, NodeId> = BTreeMap::new();
+        let mut newly_inserted: Vec<NodeId> = Vec::new();
+        let full_chain = parent_ids.pushed(pkg_id.clone());
         for edge in children_spec.iter() {
             // Same cycle gate as the eager walk: keep the first
             // re-entry, drop a direct self-edge or a second lap.
-            if pkg_id == edge.pkg_id
-                || crate::resolve_dependency_tree::parent_ids_contain_sequence(
-                    &parent_ids,
-                    &pkg_id,
-                    &edge.pkg_id,
-                )
-            {
+            if full_chain.forms_cycle(&pkg_id, &edge.pkg_id) {
                 continue;
             }
             // Reuse the first walk's classification (persisted on
@@ -2584,29 +2981,30 @@ impl Walker<'_> {
             // shape as the eager walker's `manifest == None` arm,
             // and `NodeId::next()` keeps occurrences distinct so a
             // later visit can still observe per-call-site state.
-            let is_leaf = self.tree.packages.get(&edge.pkg_id).is_some_and(|pkg| pkg.is_leaf);
-            let child_node_id = if is_leaf { NodeId::leaf(&edge.pkg_id) } else { NodeId::next() };
-            let child_parent_ids = {
-                let mut next_ids = (*parent_ids).clone();
-                next_ids.push(edge.pkg_id.clone());
-                Arc::new(next_ids)
+            let previewed_node_id = previewed.and_then(|previewed| previewed.get(&edge.alias));
+            let child_node_id = if let Some(previewed_node_id) = previewed_node_id {
+                previewed_node_id.clone()
+            } else {
+                let is_leaf = self.tree.packages.get(&edge.pkg_id).is_some_and(|pkg| pkg.is_leaf);
+                if is_leaf { NodeId::leaf(&edge.pkg_id) } else { NodeId::next() }
             };
-            self.tree
-                .dependencies_tree
-                .entry(child_node_id.clone())
-                .and_modify(|n| {
-                    if n.depth > child_depth {
-                        n.depth = child_depth;
-                    }
-                })
-                .or_insert_with(|| {
+            let child_parent_ids = full_chain.clone();
+            if let Some(node) = self.tree.dependencies_tree.get_mut(&child_node_id) {
+                if node.depth > child_depth {
+                    node.depth = child_depth;
+                }
+            } else {
+                self.tree.dependencies_tree.insert(
+                    child_node_id.clone(),
                     DependenciesTreeNode::new(
                         edge.pkg_id.clone(),
                         TreeChildren::Lazy { parent_ids: child_parent_ids },
                         child_depth,
                         true,
-                    )
-                });
+                    ),
+                );
+                newly_inserted.push(child_node_id.clone());
+            }
             realized.insert(edge.alias.clone(), child_node_id);
         }
         // Replace this node's `Lazy` with `Realized` so future
@@ -2614,27 +3012,27 @@ impl Walker<'_> {
         if let Some(node) = self.tree.dependencies_tree.get_mut(node_id) {
             node.children = TreeChildren::Realized(realized.clone());
         }
-        realized
+        (realized, Some(UndoRealize { newly_inserted, prev_parent_ids: parent_ids }))
     }
 
     fn previously_resolved_children(
         &mut self,
-        parent_node_ids: &[NodeId],
-        parent_pkg_ids_chain: &[String],
+        parent_node_ids: &SharedChain<NodeId>,
+        parent_pkg_ids_chain: &SharedChain<String>,
         current_pkg_id: &str,
     ) -> BTreeMap<String, NodeId> {
         let mut children = BTreeMap::new();
         if !parent_pkg_ids_chain.iter().any(|pkg_id| pkg_id == current_pkg_id) {
             return children;
         }
-        for parent_node_id in parent_node_ids.iter().rev() {
+        for parent_node_id in parent_node_ids.iter() {
             let same_pkg = self
                 .tree
                 .dependencies_tree
                 .get(parent_node_id)
                 .is_some_and(|node| node.resolved_package_id == current_pkg_id);
             if same_pkg {
-                for (alias, child_node_id) in self.realize_children(parent_node_id) {
+                for (alias, child_node_id) in self.realize_children(parent_node_id).0 {
                     children.entry(alias).or_insert(child_node_id);
                 }
             }
@@ -2691,7 +3089,7 @@ impl Walker<'_> {
         parent_refs: &ParentRefs,
         inherited_parent_pkg: &ParentRef,
         own_child_parent_pkg: &ParentRef,
-        children: &BTreeMap<String, NodeId>,
+        node_id: &NodeId,
     ) -> bool {
         let (Some(inherited_node_id), Some(own_child_node_id)) =
             (inherited_parent_pkg.node_id.as_ref(), own_child_parent_pkg.node_id.as_ref())
@@ -2729,15 +3127,24 @@ impl Walker<'_> {
             return false;
         }
 
-        for child_node_id in children.values() {
-            let Some(child_pkg) = self
+        let Some(node) = self.tree.dependencies_tree.get(node_id) else { return false };
+        let child_pkg_ids: Vec<&str> = match &node.children {
+            TreeChildren::Realized(children) => children
+                .values()
+                .filter_map(|child_node_id| self.tree.dependencies_tree.get(child_node_id))
+                .map(|child| child.resolved_package_id.as_str())
+                .collect(),
+            TreeChildren::Lazy { .. } => self
                 .tree
-                .dependencies_tree
-                .get(child_node_id)
-                .and_then(|node| self.tree.packages.get(&node.resolved_package_id))
-            else {
-                continue;
-            };
+                .children_by_id
+                .get(&node.resolved_package_id)
+                .into_iter()
+                .flat_map(|children| children.iter())
+                .map(|child| child.pkg_id.as_str())
+                .collect(),
+        };
+        for child_pkg_id in child_pkg_ids {
+            let Some(child_pkg) = self.tree.packages.get(child_pkg_id) else { continue };
             if !child_pkg.peer_dependencies.contains_key(&parent_pkg_name) {
                 continue;
             }
@@ -2804,6 +3211,276 @@ impl Walker<'_> {
         Arc::new(out)
     }
 
+    fn remember_parent_context_if_peer_provider(
+        &mut self,
+        alias: &str,
+        node_id: &NodeId,
+        parent_context: &Arc<HashMap<String, ParentPkgInfo>>,
+    ) {
+        let Some(tree_node) = self.tree.dependencies_tree.get(node_id) else { return };
+        let Some(pkg) = self.tree.packages.get(&tree_node.resolved_package_id) else { return };
+        if self.is_peer_relevant(alias, pkg) {
+            self.parent_pkgs_of_node.insert(node_id.clone(), Arc::clone(parent_context));
+        }
+    }
+
+    fn owned_package(&mut self, pkg_id: &str) -> Arc<ResolvedPackage> {
+        if let Some(pkg) = self.packages_by_id.get(pkg_id) {
+            return Arc::clone(pkg);
+        }
+        let pkg = Arc::new(self.tree.packages[pkg_id].clone());
+        self.packages_by_id.insert(pkg_id.to_string(), Arc::clone(&pkg));
+        pkg
+    }
+
+    fn remember_resolved_node(&mut self, node_id: &NodeId, dep_path: &DepPath) {
+        let retain = !self.discovery
+            || self.parent_pkgs_of_node.contains_key(node_id)
+            || self.opts.hoisted_peer_provider_node_ids.contains(node_id);
+        if !retain {
+            return;
+        }
+        self.node_dep_paths.insert(node_id.clone(), dep_path.clone());
+        self.visited_this_call.insert(node_id.clone());
+    }
+
+    fn undo_realize(
+        &mut self,
+        node_id: &NodeId,
+        undo: Option<UndoRealize>,
+        output: Option<&NodeOutput>,
+    ) {
+        let Some(undo) = undo else { return };
+        for child_id in &undo.newly_inserted {
+            let output_references_child = output.is_some_and(|output| {
+                output.external_resolved_peers.values().any(|node_id| node_id == child_id)
+                    || output
+                        .auto_install_resolved_peers
+                        .values()
+                        .any(|node_id| node_id == child_id)
+            });
+            if self.retained_peer_node_ids.contains(child_id) || output_references_child {
+                continue;
+            }
+            self.tree.dependencies_tree.remove(child_id);
+            self.parent_pkgs_of_node.remove(child_id);
+            self.node_dep_paths.remove(child_id);
+            self.visited_this_call.remove(child_id);
+        }
+        if let Some(node) = self.tree.dependencies_tree.get_mut(node_id) {
+            node.children = TreeChildren::Lazy { parent_ids: undo.prev_parent_ids };
+        }
+    }
+
+    fn find_fast_hit(
+        &self,
+        node_id: &NodeId,
+        parent_refs: &ParentRefs,
+        pkg_id: &str,
+    ) -> Option<&PeersCacheItem> {
+        let TreeChildren::Lazy { parent_ids } = &self.tree.dependencies_tree.get(node_id)?.children
+        else {
+            return None;
+        };
+        self.find_fast_hit_for_lazy(parent_ids, parent_refs, pkg_id)
+    }
+
+    fn find_fast_hit_for_lazy(
+        &self,
+        parent_ids: &AncestorIds,
+        parent_refs: &ParentRefs,
+        pkg_id: &str,
+    ) -> Option<&PeersCacheItem> {
+        self.peers_cache.get(pkg_id)?.iter().find(|item| {
+            matches!(
+                self.fast_cache_item_matches(parent_ids, parent_refs, pkg_id, item),
+                FastCacheMatch::Match,
+            )
+        })
+    }
+
+    fn deferred_child_resolution(
+        &self,
+        parent_ids: &AncestorIds,
+        parent_refs: &ParentRefs,
+        pkg_id: &str,
+    ) -> DeferredChildResolution {
+        if self
+            .pure_pkgs
+            .get(pkg_id)
+            .is_some_and(|_| self.tree.packages[pkg_id].peer_dependencies.is_empty())
+        {
+            return DeferredChildResolution::Pure(self.pure_pkgs[pkg_id].clone());
+        }
+        if let Some(cached) = self
+            .find_fast_hit_for_lazy(parent_ids, parent_refs, pkg_id)
+            .map(PeersCacheItem::to_cached_node_output)
+            && cached.output.missing_peers.is_empty()
+        {
+            return DeferredChildResolution::Cached(cached);
+        }
+        DeferredChildResolution::Materialize(pkg_id.to_string())
+    }
+
+    fn resolve_deferred_child(&mut self, context: DeferredChildContext<'_>) -> NodeOutput {
+        let DeferredChildContext {
+            edge,
+            node_id,
+            parent_ids,
+            parent_refs,
+            parent_dep_paths,
+            chain_names,
+            parent_node_ids,
+            parent_pkg_ids,
+            depth,
+        } = context;
+        match self.deferred_child_resolution(parent_ids, parent_refs, &edge.pkg_id) {
+            DeferredChildResolution::Pure(dep_path) => NodeOutput {
+                dep_path,
+                external_resolved_peers: Arc::clone(&self.empty_resolved_peers),
+                auto_install_resolved_peers: HashMap::default(),
+                missing_peers: Arc::clone(&self.empty_missing_peers),
+                subtree_missing_by_pkg: None,
+            },
+            DeferredChildResolution::Cached(cached) => cached.output,
+            DeferredChildResolution::Materialize(pkg_id) => {
+                self.tree.dependencies_tree.insert(
+                    node_id.clone(),
+                    DependenciesTreeNode::new(
+                        pkg_id,
+                        TreeChildren::Lazy { parent_ids: parent_ids.clone() },
+                        depth,
+                        true,
+                    ),
+                );
+                let output = self.resolve_node(
+                    &node_id,
+                    parent_refs,
+                    parent_dep_paths,
+                    chain_names,
+                    parent_node_ids,
+                    parent_pkg_ids,
+                );
+                if !self.parent_pkgs_of_node.contains_key(&node_id) {
+                    self.tree.dependencies_tree.remove(&node_id);
+                    self.node_dep_paths.remove(&node_id);
+                    self.visited_this_call.remove(&node_id);
+                }
+                output
+            }
+        }
+    }
+
+    fn fast_cache_item_matches(
+        &self,
+        parent_ids: &AncestorIds,
+        parent_refs: &ParentRefs,
+        pkg_id: &str,
+        item: &PeersCacheItem,
+    ) -> FastCacheMatch {
+        let mut ambiguous = false;
+        for (name, cached_node_id) in item.resolved_peers.iter() {
+            match self.fast_provider_for_name(parent_ids, parent_refs, pkg_id, name) {
+                FastProvider::Missing => return FastCacheMatch::NoMatch,
+                FastProvider::Inherited(current_ref) => {
+                    if !self.parent_ref_matches_cached(current_ref, cached_node_id) {
+                        return FastCacheMatch::NoMatch;
+                    }
+                }
+                FastProvider::Child(child_pkg_id) => {
+                    let Some(cached_tree_node) = self.tree.dependencies_tree.get(cached_node_id)
+                    else {
+                        return FastCacheMatch::NoMatch;
+                    };
+                    if cached_tree_node.resolved_package_id != child_pkg_id {
+                        return FastCacheMatch::NoMatch;
+                    }
+                    let child_is_stable = self.pure_pkgs.contains_key(child_pkg_id)
+                        || matches!(
+                            cached_node_id,
+                            NodeId::Leaf(cached_pkg_id) if cached_pkg_id.as_ref() == child_pkg_id,
+                        );
+                    if !child_is_stable {
+                        ambiguous = true;
+                    }
+                }
+                FastProvider::Ambiguous => ambiguous = true,
+            }
+        }
+        for name in item.missing_peers.keys() {
+            match self.fast_provider_for_name(parent_ids, parent_refs, pkg_id, name) {
+                FastProvider::Missing => {}
+                FastProvider::Inherited(_) | FastProvider::Child(_) => {
+                    return FastCacheMatch::NoMatch;
+                }
+                FastProvider::Ambiguous => ambiguous = true,
+            }
+        }
+        if ambiguous { FastCacheMatch::Ambiguous } else { FastCacheMatch::Match }
+    }
+
+    fn fast_provider_for_name<'a>(
+        &'a self,
+        parent_ids: &AncestorIds,
+        parent_refs: &'a ParentRefs,
+        pkg_id: &str,
+        name: &str,
+    ) -> FastProvider<'a> {
+        let inherited = parent_refs.get(name);
+        let Some(children) = self.tree.children_by_id.get(pkg_id) else {
+            return inherited.map_or(FastProvider::Missing, FastProvider::Inherited);
+        };
+
+        let mut child_pkg_id = None;
+        for edge in children.iter() {
+            if parent_ids.forms_cycle(pkg_id, &edge.pkg_id) {
+                continue;
+            }
+            let Some(pkg) = self.tree.packages.get(&edge.pkg_id) else { continue };
+            if edge.alias != name && !package_name_matches(&pkg.result, name) {
+                continue;
+            }
+            if child_pkg_id.is_some() {
+                return FastProvider::Ambiguous;
+            }
+            child_pkg_id = Some(edge.pkg_id.as_str());
+        }
+
+        match (inherited, child_pkg_id) {
+            (Some(_), Some(_)) => FastProvider::Ambiguous,
+            (Some(parent_ref), None) => FastProvider::Inherited(parent_ref),
+            (None, Some(pkg_id)) => FastProvider::Child(pkg_id),
+            (None, None) => FastProvider::Missing,
+        }
+    }
+
+    fn parent_ref_matches_cached(&self, current_ref: &ParentRef, cached_node_id: &NodeId) -> bool {
+        let Some(current_node_id) = current_ref.node_id.as_ref() else {
+            return false;
+        };
+        if current_node_id == cached_node_id {
+            return true;
+        }
+        if let (Some(cached_dp), Some(current_dp)) =
+            (self.node_dep_paths.get(cached_node_id), self.node_dep_paths.get(current_node_id))
+            && cached_dp == current_dp
+        {
+            return true;
+        }
+        let (Some(cached_tree_node), Some(current_tree_node)) = (
+            self.tree.dependencies_tree.get(cached_node_id),
+            self.tree.dependencies_tree.get(current_node_id),
+        ) else {
+            return false;
+        };
+        let parent_pkg_id = &current_tree_node.resolved_package_id;
+        if parent_pkg_id != &cached_tree_node.resolved_package_id {
+            return false;
+        }
+        self.pure_pkgs.contains_key(parent_pkg_id)
+            || self.parent_packages_match(cached_node_id, current_node_id)
+    }
+
     /// Look up [`Self::peers_cache`] for a cached resolution of
     /// `pkg_id` whose parent peer context is compatible with the
     /// current `parent_refs`.
@@ -2826,43 +3503,11 @@ impl Walker<'_> {
     fn find_hit(&self, parent_refs: &ParentRefs, pkg_id: &str) -> Option<&PeersCacheItem> {
         let cache_items = self.peers_cache.get(pkg_id)?;
         cache_items.iter().find(|item| {
-            for (name, cached_node_id) in &item.resolved_peers {
+            for (name, cached_node_id) in item.resolved_peers.iter() {
                 let Some(current_ref) = parent_refs.get(name) else {
                     return false;
                 };
-                let Some(current_node_id) = current_ref.node_id.as_ref() else {
-                    return false;
-                };
-                if current_node_id == cached_node_id {
-                    continue;
-                }
-                // Same `DepPath` reached via a different `NodeId` — that's a
-                // legitimate match (e.g. via the leaf-NodeId collapse).
-                if let (Some(cached_dp), Some(current_dp)) = (
-                    self.node_dep_paths.get(cached_node_id),
-                    self.node_dep_paths.get(current_node_id),
-                ) && cached_dp == current_dp
-                {
-                    continue;
-                }
-                // Different `NodeId`s — both must at least point to
-                // packages with the same `pkgIdWithPatchHash`, and the
-                // deep `parent_packages_match` check (or the
-                // `purePkgs` shortcut) has to agree.
-                let Some(cached_tree_node) = self.tree.dependencies_tree.get(cached_node_id) else {
-                    return false;
-                };
-                let Some(current_tree_node) = self.tree.dependencies_tree.get(current_node_id)
-                else {
-                    return false;
-                };
-                let parent_pkg_id = &current_tree_node.resolved_package_id;
-                if parent_pkg_id != &cached_tree_node.resolved_package_id {
-                    return false;
-                }
-                if !self.pure_pkgs.contains(parent_pkg_id)
-                    && !self.parent_packages_match(cached_node_id, current_node_id)
-                {
+                if !self.parent_ref_matches_cached(current_ref, cached_node_id) {
                     return false;
                 }
             }
@@ -2915,7 +3560,7 @@ impl Walker<'_> {
             }
             if !(peer_deps_not_shadowed
                 || current_info.depth == max_depth
-                || self.pure_pkgs.contains(cached_pkg_id))
+                || self.pure_pkgs.contains_key(cached_pkg_id))
             {
                 return false;
             }
@@ -2929,21 +3574,21 @@ fn parent_pkgs_have_single_occurrence(parents: &HashMap<String, ParentPkgInfo>) 
     parents.values().all(|info| info.occurrence == 0)
 }
 
-/// Union `addition` into `target`, keeping the no-miss case
-/// allocation-free and sharing a lone child's map by refcount.
-fn merge_subtree_missing(target: &mut SubtreeMissingByPkg, addition: SubtreeMissingByPkg) {
-    let Some(addition) = addition else { return };
-    match target {
-        None => *target = Some(addition),
-        Some(existing) => {
-            if Arc::ptr_eq(existing, &addition) {
-                return;
-            }
-            let merged = Arc::make_mut(existing);
-            for (pkg_id, names) in addition.iter() {
-                merged.entry(pkg_id.clone()).or_default().extend(names.iter().cloned());
-            }
+fn merge_missing_summary(
+    target: &mut HashMap<String, HashSet<String>>,
+    seen: &mut HashSet<usize>,
+    summary: SubtreeMissingByPkg,
+) {
+    let Some(summary) = summary else { return };
+    let mut pending = vec![summary];
+    while let Some(summary) = pending.pop() {
+        if !seen.insert(Arc::as_ptr(&summary) as usize) {
+            continue;
         }
+        if let Some((pkg_id, names)) = &summary.own {
+            target.entry(pkg_id.clone()).or_default().extend(names.iter().cloned());
+        }
+        pending.extend(summary.children.iter().cloned());
     }
 }
 
@@ -3135,22 +3780,6 @@ fn update_parent_refs(refs: &mut ParentRefs, new_alias: &str, parent_ref: &Paren
     refs.insert(new_alias.to_string(), parent_ref.clone());
 }
 
-fn ordered_child_entries(
-    children: &BTreeMap<String, NodeId>,
-    parent_refs: &ParentRefs,
-) -> Vec<(String, NodeId)> {
-    let mut out = Vec::with_capacity(children.len());
-    for repeated in [true, false] {
-        for (alias, node_id) in children {
-            if parent_refs.contains_key(alias) != repeated {
-                continue;
-            }
-            out.push((alias.clone(), node_id.clone()));
-        }
-    }
-    out
-}
-
 fn version_gte(left: &str, right: &str) -> bool {
     match (Version::parse(left), Version::parse(right)) {
         (Ok(left), Ok(right)) => left >= right,
@@ -3198,14 +3827,15 @@ fn remap_link_node_id(
 /// Build the `parents` chain attached to a peer issue. Records just
 /// `name` and `version` per parent, which is what the renderer
 /// downstream consumes.
-fn parents_from_chain(chain_names: &[String], _pkg_name: &str) -> Vec<ParentPackageRef> {
+fn parents_from_chain(chain_names: &SharedChain<String>, _pkg_name: &str) -> Vec<ParentPackageRef> {
     // The chain pacquet tracks today is name-only — populating
     // `version` would need a parallel `Vec<String>` of versions or a
     // re-lookup against the tree. The issue-renderer consumes the
     // names primarily; expanding to versions is a follow-up.
     chain_names
-        .iter()
-        .map(|name| ParentPackageRef { name: name.clone(), version: String::new() })
+        .to_root_vec()
+        .into_iter()
+        .map(|name| ParentPackageRef { name, version: String::new() })
         .collect()
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -961,11 +961,10 @@ fn previously_resolved_children_prefers_closest_same_package_ancestor() {
     };
     let mut walker = walker_for_tests(&mut tree);
 
-    let children = walker.previously_resolved_children(
-        &[far_parent, close_parent],
-        &["loop@1.0.0".to_string()],
-        "loop@1.0.0",
-    );
+    let parent_node_ids = super::SharedChain::default().pushed(far_parent).pushed(close_parent);
+    let parent_pkg_ids = super::SharedChain::default().pushed("loop@1.0.0".to_string());
+    let children =
+        walker.previously_resolved_children(&parent_node_ids, &parent_pkg_ids, "loop@1.0.0");
 
     assert_eq!(children.get("shared"), Some(&close_child));
 }
@@ -1199,24 +1198,24 @@ fn final_graph_peer_edge_keeps_the_providers_own_peer_suffix() {
     );
     walker.node_external_peers.insert(
         provider_analyzer.clone(),
-        HashMap::from_iter([
+        Arc::new(HashMap::from_iter([
             ("webpack-bundle-analyzer".to_string(), NodeId::leaf("webpack-bundle-analyzer@4.10.2")),
             ("webpack-dev-server".to_string(), NodeId::leaf("webpack-dev-server@5.2.2")),
             ("webpack".to_string(), NodeId::leaf("webpack@5.107.2")),
-        ]),
+        ])),
     );
     walker.node_external_peers.insert(
         provider_bare.clone(),
-        HashMap::from_iter([("webpack".to_string(), NodeId::leaf("webpack@5.107.2"))]),
+        Arc::new(HashMap::from_iter([("webpack".to_string(), NodeId::leaf("webpack@5.107.2"))])),
     );
     walker.node_external_peers.insert(
         consumer.clone(),
-        HashMap::from_iter([
+        Arc::new(HashMap::from_iter([
             ("webpack-bundle-analyzer".to_string(), NodeId::leaf("webpack-bundle-analyzer@4.10.2")),
             ("webpack-cli".to_string(), provider_analyzer.clone()),
             ("webpack-dev-server".to_string(), NodeId::leaf("webpack-dev-server@5.2.2")),
             ("webpack".to_string(), NodeId::leaf("webpack@5.107.2")),
-        ]),
+        ])),
     );
 
     let graph = walker.build_final_graph(&HashMap::from_iter([
@@ -1320,21 +1319,21 @@ fn final_graph_peer_edge_keeps_provider_transitive_peer_suffixes() {
     );
     walker.node_external_peers.insert(
         provider.clone(),
-        HashMap::from_iter([
+        Arc::new(HashMap::from_iter([
             ("bufferutil".to_string(), NodeId::leaf("bufferutil@4.1.0")),
             ("tslib".to_string(), NodeId::leaf("tslib@2.8.1")),
             ("utf-8-validate".to_string(), NodeId::leaf("utf-8-validate@5.0.10")),
             ("webpack-cli".to_string(), consumer.clone()),
             ("webpack".to_string(), NodeId::leaf("webpack@5.107.2")),
-        ]),
+        ])),
     );
     walker.node_external_peers.insert(
         consumer.clone(),
-        HashMap::from_iter([
+        Arc::new(HashMap::from_iter([
             ("webpack-bundle-analyzer".to_string(), NodeId::leaf("webpack-bundle-analyzer@4.10.2")),
             ("webpack-dev-server".to_string(), provider.clone()),
             ("webpack".to_string(), NodeId::leaf("webpack@5.107.2")),
-        ]),
+        ])),
     );
 
     let graph = walker.build_final_graph(&HashMap::from_iter([
@@ -2129,7 +2128,7 @@ fn discovery_engine_rebuilds_after_a_children_ownership_rewrite() {
     engine.discover(&workspace, &[], &[], ResolvePeersOptions::default());
 
     // A marker in the persistent caches makes reset-vs-merge observable.
-    engine.caches.pure_pkgs.insert("marker@1.0.0".to_string());
+    engine.caches.pure_pkgs.insert("marker@1.0.0".to_string(), DepPath::from("marker@1.0.0"));
     // Production rewrites happen inside `extend_tree`, which always
     // bumps the revision; mirror that pairing.
     workspace.record_children_rewrite();
@@ -2140,11 +2139,11 @@ fn discovery_engine_rebuilds_after_a_children_ownership_rewrite() {
         "an ownership rewrite must discard walk state derived before it",
     );
 
-    engine.caches.pure_pkgs.insert("marker@1.0.0".to_string());
+    engine.caches.pure_pkgs.insert("marker@1.0.0".to_string(), DepPath::from("marker@1.0.0"));
     workspace.bump_revision();
     engine.discover(&workspace, &[], &[], ResolvePeersOptions::default());
     assert!(
-        engine.caches.pure_pkgs.contains("marker@1.0.0"),
+        engine.caches.pure_pkgs.contains_key("marker@1.0.0"),
         "a rewrite-free revision bump merges instead of rebuilding",
     );
 }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -1,7 +1,8 @@
 use super::{
-    ImporterPeerInput, NodeRecord, ParentRef, PeerDiscoveryCaches, ResolvePeersOptions, Walker,
-    importer_relative_link_dep_path, peer_segment_names, resolve_peers, resolve_peers_workspace,
-    satisfies_with_prereleases, scoped_hoisted_optional_parent_refs,
+    ImporterPeerInput, NodeOutput, NodeRecord, ParentRef, PeerDiscoveryCaches, ResolvePeersOptions,
+    Walker, importer_relative_link_dep_path, peer_segment_names, resolve_peers,
+    resolve_peers_workspace, satisfies_with_prereleases, scoped_hoisted_optional_parent_refs,
+    should_retain_materialized_node,
 };
 use crate::{
     node_id::NodeId,
@@ -24,6 +25,30 @@ const PATCHED_WORKFLOWS_SDK: &str = concat!(
     "(better-sqlite3@12.8.0)",
     "(express@4.21.2)",
 );
+
+#[test]
+fn materialized_nodes_referenced_by_peer_outputs_are_retained() {
+    let referenced = NodeId::next();
+    let unreferenced = NodeId::next();
+    let output = NodeOutput {
+        dep_path: DepPath::from("consumer@1.0.0"),
+        external_resolved_peers: Arc::new(HashMap::from_iter([(
+            "peer".to_string(),
+            referenced.clone(),
+        )])),
+        auto_install_resolved_peers: HashMap::default(),
+        missing_peers: Arc::new(HashMap::default()),
+        subtree_missing_by_pkg: None,
+    };
+
+    assert!(should_retain_materialized_node(&HashSet::default(), Some(&output), &referenced));
+    assert!(!should_retain_materialized_node(&HashSet::default(), Some(&output), &unreferenced,));
+    assert!(should_retain_materialized_node(
+        &HashSet::from_iter([unreferenced.clone()]),
+        None,
+        &unreferenced,
+    ));
+}
 
 #[test]
 fn locked_direct_dep_only_sees_its_locked_hoisted_optional_peers() {

--- a/pnpm/crates/resolving-deps-resolver/src/resolved_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolved_tree.rs
@@ -61,6 +61,60 @@ pub struct ChildEdge {
     pub optional: bool,
 }
 
+/// Ancestor package ids for a lazy occurrence. The dependency walk keeps its
+/// already-built contiguous vector as the base, while peer discovery appends
+/// shallow vectors of shared string storage instead of copying every package
+/// id for each context-sensitive revisit.
+#[derive(Debug, Default, Clone)]
+pub struct AncestorIds {
+    base: Arc<Vec<String>>,
+    appended: Arc<Vec<Arc<str>>>,
+}
+
+impl AncestorIds {
+    #[must_use]
+    pub fn pushed(&self, id: String) -> Self {
+        let mut appended = Vec::with_capacity(self.appended.len() + 1);
+        appended.extend(self.appended.iter().cloned());
+        appended.push(Arc::from(id));
+        Self { base: Arc::clone(&self.base), appended: Arc::new(appended) }
+    }
+
+    #[must_use]
+    pub fn forms_cycle(&self, pkg_id: &str, child_pkg_id: &str) -> bool {
+        if pkg_id == child_pkg_id {
+            return true;
+        }
+
+        if let Some(pkg_index) = self.base.iter().position(|ancestor| ancestor == pkg_id) {
+            if self
+                .base
+                .iter()
+                .rposition(|ancestor| ancestor == child_pkg_id)
+                .is_some_and(|child_index| pkg_index < child_index)
+            {
+                return true;
+            }
+            return self.appended.iter().any(|ancestor| ancestor.as_ref() == child_pkg_id);
+        }
+
+        let oldest_pkg_index =
+            self.appended.iter().position(|ancestor| ancestor.as_ref() == pkg_id);
+        let newest_child_index =
+            self.appended.iter().rposition(|ancestor| ancestor.as_ref() == child_pkg_id);
+        matches!(
+            (oldest_pkg_index, newest_child_index),
+            (Some(pkg_index), Some(child_index)) if pkg_index < child_index,
+        )
+    }
+}
+
+impl From<Arc<Vec<String>>> for AncestorIds {
+    fn from(base: Arc<Vec<String>>) -> Self {
+        Self { base, appended: Arc::new(Vec::new()) }
+    }
+}
+
 /// One edge in the resolved tree: the local install name (`alias`) and
 /// the resolved node's [`NodeId`], plus the resolved `pkgId`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -225,13 +279,15 @@ pub enum TreeChildren {
     Realized(BTreeMap<String, NodeId>),
     /// Children are known by spec only. `parent_ids` is the chain of
     /// `pkgIdWithPatchHash` ancestors this occurrence reached the
-    /// node through, threaded so the peer resolver's tree builder can
+    /// node through, excluding the node itself. The reader appends the
+    /// node from `resolved_package_id`, which lets all siblings share one
+    /// chain allocation. The chain is threaded so the peer resolver can
     /// apply the parent-ids-contain-sequence cycle-break
     /// per-occurrence. Without it, a revisit's subtree would
     /// silently include cycle edges that the first walk correctly
     /// rejected, or omit valid edges the first walk's ancestor
     /// chain happened to exclude.
-    Lazy { parent_ids: Arc<Vec<String>> },
+    Lazy { parent_ids: AncestorIds },
 }
 
 impl TreeChildren {
@@ -259,3 +315,6 @@ impl TreeChildren {
         }
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/resolving-deps-resolver/src/resolved_tree/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolved_tree/tests.rs
@@ -1,0 +1,22 @@
+use super::AncestorIds;
+use std::sync::Arc;
+
+fn ancestors(base: &[&str], appended: &[&str]) -> AncestorIds {
+    appended.iter().fold(
+        AncestorIds::from(Arc::new(base.iter().map(ToString::to_string).collect())),
+        |ids, id| ids.pushed((*id).to_string()),
+    )
+}
+
+#[test]
+fn detects_cycle_sequences_across_base_and_appended_ids() {
+    let ids = ancestors(&["a", "b", "c"], &["d", "b", "e"]);
+
+    assert!(ids.forms_cycle("a", "c"));
+    assert!(ids.forms_cycle("c", "d"));
+    assert!(ids.forms_cycle("d", "e"));
+    assert!(ids.forms_cycle("b", "b"));
+    assert!(!ids.forms_cycle("d", "c"));
+    assert!(!ids.forms_cycle("e", "a"));
+    assert!(!ids.forms_cycle("missing", "e"));
+}

--- a/pnpm/tasks/integrated-benchmark/src/cli_args.rs
+++ b/pnpm/tasks/integrated-benchmark/src/cli_args.rs
@@ -230,6 +230,12 @@ pub enum BenchmarkScenario {
     /// runs first.
     #[value(name = "isolated-linker.fresh-resolve.hot-cache.offline")]
     IsolatedFreshResolveHotCacheOffline,
+    /// Bit-style peer-heavy dependency DAG whose shared subgraphs expand into
+    /// many peer-resolution occurrences. Like the regular fresh-resolve
+    /// scenario, the timed command resolves offline from a hot metadata mirror
+    /// with no lockfile or linking, isolating peer discovery and resolution.
+    #[value(name = "isolated-linker.peer-heavy-resolve.hot-cache.offline")]
+    IsolatedPeerHeavyResolveHotCacheOffline,
     /// Frozen lockfile, hot cache + hot store, `enableGlobalVirtualStore: true` with a pre-warmed GVS.
     #[value(name = "gvs-linker.fresh-restore.hot-cache.hot-store")]
     GvsFreshRestoreHotCacheHotStore,
@@ -259,7 +265,8 @@ impl BenchmarkScenario {
                 &["install", "--frozen-lockfile"]
             }
             BenchmarkScenario::IsolatedFreshAddDepHotCacheHotStore => &["add", "is-odd"],
-            BenchmarkScenario::IsolatedFreshResolveHotCacheOffline => {
+            BenchmarkScenario::IsolatedFreshResolveHotCacheOffline
+            | BenchmarkScenario::IsolatedPeerHeavyResolveHotCacheOffline => {
                 &["install", "--offline", "--lockfile-only"]
             }
         }
@@ -274,6 +281,9 @@ impl BenchmarkScenario {
     pub fn prewarm_install_args(self) -> Option<&'static [&'static str]> {
         match self {
             BenchmarkScenario::IsolatedFreshResolveHotCacheOffline => Some(&["install"]),
+            BenchmarkScenario::IsolatedPeerHeavyResolveHotCacheOffline => {
+                Some(&["install", "--lockfile-only"])
+            }
             _ => None,
         }
     }
@@ -296,6 +306,7 @@ impl BenchmarkScenario {
             | BenchmarkScenario::IsolatedFreshRestoreHotCacheHotStore
             | BenchmarkScenario::IsolatedFreshAddDepHotCacheHotStore
             | BenchmarkScenario::IsolatedFreshResolveHotCacheOffline
+            | BenchmarkScenario::IsolatedPeerHeavyResolveHotCacheOffline
             | BenchmarkScenario::GvsFreshRestoreHotCacheHotStore => true,
         }
     }
@@ -307,8 +318,7 @@ impl BenchmarkScenario {
     /// the online pre-warm pass skip resolution, leaving the metadata
     /// mirror cold for the measured offline runs.
     pub fn seeds_lockfile(self) -> bool {
-        self.lockfile_enabled()
-            && !matches!(self, BenchmarkScenario::IsolatedFreshResolveHotCacheOffline)
+        self.lockfile_enabled() && !self.is_offline_fresh_resolve()
     }
 
     /// The `pnpm-lock.yaml` contents to seed during init, when
@@ -378,7 +388,8 @@ impl BenchmarkScenario {
             // date"), and the timed runs would measure a no-op. The warm
             // `cache-dir` / `store-dir` the pre-warm populated are the
             // scenario's contract and survive.
-            BenchmarkScenario::IsolatedFreshResolveHotCacheOffline => {
+            BenchmarkScenario::IsolatedFreshResolveHotCacheOffline
+            | BenchmarkScenario::IsolatedPeerHeavyResolveHotCacheOffline => {
                 Cleanup { remove: &["node_modules", "pnpm-lock.yaml"], restore: &[] }
             }
         }
@@ -407,6 +418,22 @@ impl BenchmarkScenario {
     /// `…cold-store.cold-pnpr` variant); selects the cold-mock spawn.
     pub fn cold_pnpr_cache(self) -> bool {
         matches!(self, BenchmarkScenario::IsolatedFreshRestoreColdCacheColdStoreColdPnpr)
+    }
+
+    /// Whether to use the generated shared-subgraph fixture that guards
+    /// peer-heavy resolution.
+    pub fn uses_peer_heavy_fixture(self) -> bool {
+        matches!(self, BenchmarkScenario::IsolatedPeerHeavyResolveHotCacheOffline)
+    }
+
+    /// Whether the measured command needs an online pre-warm followed by an
+    /// offline, lockfile-only fresh resolve.
+    fn is_offline_fresh_resolve(self) -> bool {
+        matches!(
+            self,
+            BenchmarkScenario::IsolatedFreshResolveHotCacheOffline
+                | BenchmarkScenario::IsolatedPeerHeavyResolveHotCacheOffline,
+        )
     }
 }
 

--- a/pnpm/tasks/integrated-benchmark/src/cli_args.rs
+++ b/pnpm/tasks/integrated-benchmark/src/cli_args.rs
@@ -281,6 +281,8 @@ impl BenchmarkScenario {
     pub fn prewarm_install_args(self) -> Option<&'static [&'static str]> {
         match self {
             BenchmarkScenario::IsolatedFreshResolveHotCacheOffline => Some(&["install"]),
+            // This resolution-only fixture has no fetchable tarballs, so its
+            // metadata prewarm must not proceed to fetching or linking.
             BenchmarkScenario::IsolatedPeerHeavyResolveHotCacheOffline => {
                 Some(&["install", "--lockfile-only"])
             }

--- a/pnpm/tasks/integrated-benchmark/src/main.rs
+++ b/pnpm/tasks/integrated-benchmark/src/main.rs
@@ -71,6 +71,14 @@ async fn main() {
     };
     let registry_public_url = registry.trim_end_matches('/').to_string();
 
+    if !build_only && scenario.is_some_and(cli_args::BenchmarkScenario::uses_peer_heavy_fixture) {
+        assert!(
+            matches!(registry_mode, RegistryMode::Verdaccio),
+            "the peer-heavy benchmark requires --registry=verdaccio",
+        );
+        work_env::seed_peer_heavy_registry(pacquet_registry_mock::runtime_storage());
+    }
+
     let verdaccio = if build_only {
         None
     } else {

--- a/pnpm/tasks/integrated-benchmark/src/work_env.rs
+++ b/pnpm/tasks/integrated-benchmark/src/work_env.rs
@@ -32,12 +32,24 @@ const PREWARM_SCRIPT: &str = "prewarm.bash";
 const BENCHMARK_DIAGNOSTICS_JSON: &str = "BENCHMARK_DIAGNOSTICS.json";
 const BENCHMARK_DIAGNOSTICS_MD: &str = "BENCHMARK_DIAGNOSTICS.md";
 const PNPR_DIRECT_RATIO_MAX: f64 = 1.05;
+const PACQUET_PNPM_SPEEDUP_MIN: f64 = 10.0;
 const PNPR_SERVER_REGISTRY_ENV: &str = "PACQUET_BENCHMARK_PNPR_SERVER_REGISTRY";
 const PNPR_TARBALL_REWRITE_FROM_ENV: &str = "PACQUET_BENCHMARK_PNPR_TARBALL_REWRITE_FROM";
 const PNPR_BENCHMARK_USERNAME: &str = "pnpr-benchmark";
 const PNPR_BENCHMARK_PASSWORD: &str = "password123";
 const PNPR_BENCHMARK_HTPASSWD: &str =
     "pnpr-benchmark:$2y$04$MpoezfOJSlhn9S4iiOJihue1IMZTZfYclKbajdz.Dt2pvAoBLNAay\n";
+const PEER_HEAVY_DEPTH: usize = 5;
+const PEER_HEAVY_WIDTH: usize = 80;
+const PEER_HEAVY_PROVIDER: &str = "@pnpmtest/peer-benchmark-provider";
+const PEER_HEAVY_VERSION: &str = "1.0.0";
+const PEER_HEAVY_INTEGRITY: &str = "sha512-z6pI0F3yfz8Zl3R0+g1pwMbdY12h7Osj5UYSTh6Rcpd7UtO7nxeIzf+7gPDOAH4mgxi7BXaTyBDS0hBFgZVssQ==";
+const PNPM_BUNDLE_PATHS: [&str; 4] = [
+    "pnpm11/pnpm/dist/pnpm.mjs",
+    "pnpm11/pnpm/dist/pnpm.cjs",
+    "pnpm/dist/pnpm.mjs",
+    "pnpm/dist/pnpm.cjs",
+];
 
 #[derive(Debug)]
 pub struct WorkEnv {
@@ -236,13 +248,8 @@ impl WorkEnv {
                 // so the existence check sees the bundle produced by
                 // `pnpm run compile-only`, not the empty tree visible
                 // during `init()`.
-                let candidates = [
-                    "./pnpm-source/pnpm11/pnpm/dist/pnpm.mjs",
-                    "./pnpm-source/pnpm11/pnpm/dist/pnpm.cjs",
-                    "./pnpm-source/pnpm/dist/pnpm.mjs",
-                    "./pnpm-source/pnpm/dist/pnpm.cjs",
-                ]
-                .join(" ");
+                let candidates =
+                    PNPM_BUNDLE_PATHS.map(|path| format!("./pnpm-source/{path}")).join(" ");
                 format!(
                     r#"node "$(for f in {candidates}; do if [ -f "$f" ]; then echo "$f"; break; fi; done)""#,
                 )
@@ -256,12 +263,12 @@ impl WorkEnv {
         eprintln!("Initializing...");
         // The proxy-cache populator only runs against a local
         // verdaccio/virtual registry to warm its on-disk cache. With
-        // `--registry=npm`, no proxy exists, so skip writing the
-        // INIT_PROXY_CACHE bench dir entirely — its files (npmrc,
-        // workspace, install script, saved-pristine copies) would be
-        // unreferenced overhead.
+        // `--registry=npm`, no proxy exists. The peer-heavy fixture is
+        // already seeded into hosted storage, so it needs no population
+        // pass either.
         let populate_proxy_cache =
-            matches!(self.registry_mode, RegistryMode::Verdaccio | RegistryMode::Virtual);
+            matches!(self.registry_mode, RegistryMode::Verdaccio | RegistryMode::Virtual)
+                && !scenario.uses_peer_heavy_fixture();
         let id_list = self
             .target_ids()
             .chain(populate_proxy_cache.then_some(WorkEnv::INIT_PROXY_CACHE))
@@ -271,7 +278,7 @@ impl WorkEnv {
             let dir = self.bench_dir(id);
             let registry = self.registry_for(id, direct_registry, revision_mocks);
             fs::create_dir_all(&dir).expect("create directory for the revision");
-            create_package_json(&dir, self.fixture_dir.as_deref());
+            create_package_json(&dir, self.fixture_dir.as_deref(), scenario);
             create_pnpm_workspace(&dir, self.fixture_dir.as_deref(), registry, scenario);
             create_install_script(&dir, scenario, &WorkEnv::install_command(id), id);
             create_npmrc(&dir, registry, scenario);
@@ -477,11 +484,17 @@ impl WorkEnv {
     }
 
     fn build_pnpm(&self, revision: &str) {
+        let revision_repo = self.pnpm_source_dir(revision);
+        if self.reuse_prebuilt_binaries
+            && PNPM_BUNDLE_PATHS.iter().any(|path| revision_repo.join(path).is_file())
+        {
+            eprintln!("Revision: {revision:?} (pnpm) — reusing prebuilt bundle");
+            return;
+        }
+
         eprintln!("Revision: {revision:?} (pnpm)");
 
         let repository = self.pnpm_repository();
-        let revision_repo = self.pnpm_source_dir(revision);
-
         let commit = WorkEnv::resolve_revision(repository, revision);
         eprintln!("Resolved {revision:?} to {commit}");
 
@@ -634,6 +647,19 @@ impl WorkEnv {
             .arg(self.root().join("BENCHMARK_REPORT.md"));
 
         executor("hyperfine")(&mut command);
+        if scenario.uses_peer_heavy_fixture() {
+            eprintln!("Verifying peer-heavy lockfile parity...");
+            Command::new("bash")
+                .current_dir(self.root())
+                .arg("-c")
+                .arg(&cleanup_command)
+                .pipe_mut(executor("lockfile comparison cleanup"));
+            for id in self.target_ids() {
+                Command::new("bash")
+                    .arg(self.script_path(id))
+                    .pipe_mut(executor("lockfile comparison install"));
+            }
+        }
         self.write_benchmark_diagnostics();
     }
 
@@ -1075,8 +1101,30 @@ impl WorkEnv {
 
     fn verify_benchmark_diagnostics(&self) {
         let diagnostics = read_benchmark_diagnostics(&self.root().join(BENCHMARK_DIAGNOSTICS_JSON));
+        self.verify_peer_heavy_lockfiles();
         self.verify_fresh_pnpr_cold_batch(&diagnostics);
         self.verify_pnpr_direct_ratios(&diagnostics);
+        self.verify_peer_heavy_pacquet_pnpm_ratio(&diagnostics);
+    }
+
+    fn verify_peer_heavy_lockfiles(&self) {
+        if self.scenario != Some(BenchmarkScenario::IsolatedPeerHeavyResolveHotCacheOffline) {
+            return;
+        }
+        let mut lockfiles = self.target_ids().map(|id| {
+            let path = self.bench_dir(id).join("pnpm-lock.yaml");
+            let contents =
+                fs::read(&path).unwrap_or_else(|error| panic!("read {path:?} for {id}: {error}"));
+            (id.to_string(), contents)
+        });
+        let (reference_id, reference) =
+            lockfiles.next().expect("peer-heavy benchmark has at least one target");
+        for (target_id, lockfile) in lockfiles {
+            assert!(
+                lockfile == reference,
+                "peer-heavy lockfile from {target_id} differs from {reference_id}",
+            );
+        }
     }
 
     fn verify_fresh_pnpr_cold_batch(&self, diagnostics: &BenchmarkDiagnostics) {
@@ -1127,6 +1175,30 @@ impl WorkEnv {
                 ratio.pacquet_mean_seconds,
             );
         }
+    }
+
+    fn verify_peer_heavy_pacquet_pnpm_ratio(&self, diagnostics: &BenchmarkDiagnostics) {
+        if self.scenario != Some(BenchmarkScenario::IsolatedPeerHeavyResolveHotCacheOffline)
+            || !self
+                .targets
+                .iter()
+                .any(|target| target.kind == TargetKind::Pnpm && target.rev == "HEAD")
+            || !self
+                .targets
+                .iter()
+                .any(|target| target.kind == TargetKind::Pacquet && target.rev == "HEAD")
+        {
+            return;
+        }
+        let pacquet = benchmark_target_mean(diagnostics, "pacquet@HEAD");
+        let pnpm = benchmark_target_mean(diagnostics, "pnpm@HEAD");
+        let speedup = pnpm / pacquet;
+        assert!(
+            speedup >= PACQUET_PNPM_SPEEDUP_MIN,
+            "pacquet@HEAD was only {speedup:.2}x faster than pnpm@HEAD on the peer-heavy DAG; \
+             required at least {PACQUET_PNPM_SPEEDUP_MIN:.2}x \
+             (pacquet {pacquet:.3}s, pnpm {pnpm:.3}s)",
+        );
     }
 }
 
@@ -1331,6 +1403,15 @@ fn non_trivial_cold_batch(cold: u64, total: u64) -> bool {
 
 fn requires_fresh_pnpr_cold_batch_metrics(target_id: &str) -> bool {
     target_id == "pnpr@HEAD"
+}
+
+fn benchmark_target_mean(diagnostics: &BenchmarkDiagnostics, target_id: &str) -> f64 {
+    diagnostics
+        .targets
+        .iter()
+        .find(|target| target.id == target_id)
+        .and_then(|target| target.hyperfine_mean_seconds)
+        .unwrap_or_else(|| panic!("benchmark report has no mean for required target {target_id}"))
 }
 
 fn render_diagnostics_markdown(
@@ -1603,8 +1684,12 @@ where
     parts.join(" && ")
 }
 
-fn create_package_json(dst_dir: &Path, src_dir: Option<&Path>) {
+fn create_package_json(dst_dir: &Path, src_dir: Option<&Path>, scenario: BenchmarkScenario) {
     let dst = dst_dir.join("package.json");
+    if scenario.uses_peer_heavy_fixture() {
+        fs::write(dst, peer_heavy_root_manifest()).expect("write peer-heavy package.json");
+        return;
+    }
     if let Some(src_dir) = src_dir {
         let src = src_dir.join("package.json");
         assert!(src.is_file(), "{src:?} must be a file");
@@ -1613,6 +1698,104 @@ fn create_package_json(dst_dir: &Path, src_dir: Option<&Path>) {
     } else {
         fs::write(dst, PACKAGE_JSON).expect("write package.json for the revision");
     }
+}
+
+fn peer_heavy_root_manifest() -> String {
+    let mut dependencies = serde_json::Map::new();
+    dependencies
+        .insert(PEER_HEAVY_PROVIDER.to_string(), Value::String(PEER_HEAVY_VERSION.to_string()));
+    for index in 0..PEER_HEAVY_WIDTH {
+        dependencies.insert(
+            peer_heavy_package_name(0, index),
+            Value::String(PEER_HEAVY_VERSION.to_string()),
+        );
+    }
+    serde_json::to_string_pretty(&serde_json::json!({
+        "name": "peer-heavy-benchmark-root",
+        "version": "0.0.0",
+        "private": true,
+        "dependencies": dependencies,
+    }))
+    .expect("serialize peer-heavy root manifest")
+}
+
+pub(crate) fn seed_peer_heavy_registry(storage_root: &Path) {
+    write_peer_heavy_packument(storage_root, PEER_HEAVY_PROVIDER, &serde_json::Map::new(), false);
+    for level in 0..PEER_HEAVY_DEPTH {
+        let dependencies = if level + 1 == PEER_HEAVY_DEPTH {
+            serde_json::Map::new()
+        } else {
+            (0..PEER_HEAVY_WIDTH)
+                .map(|index| {
+                    (
+                        peer_heavy_package_name(level + 1, index),
+                        Value::String(PEER_HEAVY_VERSION.to_string()),
+                    )
+                })
+                .collect()
+        };
+        for index in 0..PEER_HEAVY_WIDTH {
+            write_peer_heavy_packument(
+                storage_root,
+                &peer_heavy_package_name(level, index),
+                &dependencies,
+                true,
+            );
+        }
+    }
+}
+
+fn write_peer_heavy_packument(
+    storage_root: &Path,
+    name: &str,
+    dependencies: &serde_json::Map<String, Value>,
+    has_peer: bool,
+) {
+    let mut manifest = serde_json::json!({
+        "name": name,
+        "version": PEER_HEAVY_VERSION,
+        "dependencies": dependencies,
+        "dist": {
+            "tarball": format!(
+                "http://example.test/{name}/-/{}-{PEER_HEAVY_VERSION}.tgz",
+                name.rsplit('/').next().expect("package name has a final segment"),
+            ),
+            "integrity": PEER_HEAVY_INTEGRITY,
+        },
+    });
+    if has_peer {
+        let peer_dependencies = serde_json::Map::from_iter([(
+            PEER_HEAVY_PROVIDER.to_string(),
+            Value::String(PEER_HEAVY_VERSION.to_string()),
+        )]);
+        manifest
+            .as_object_mut()
+            .expect("package manifest is an object")
+            .insert("peerDependencies".to_string(), Value::Object(peer_dependencies));
+    }
+    let versions = serde_json::Map::from_iter([(PEER_HEAVY_VERSION.to_string(), manifest)]);
+    let time = serde_json::Map::from_iter([
+        ("created".to_string(), Value::String("2020-01-01T00:00:00.000Z".to_string())),
+        ("modified".to_string(), Value::String("2020-01-01T00:00:00.000Z".to_string())),
+        (PEER_HEAVY_VERSION.to_string(), Value::String("2020-01-01T00:00:00.000Z".to_string())),
+    ]);
+    let packument = serde_json::json!({
+        "name": name,
+        "dist-tags": { "latest": PEER_HEAVY_VERSION },
+        "versions": versions,
+        "time": time,
+    });
+    let package_dir = storage_root.join(name);
+    fs::create_dir_all(&package_dir).expect("create peer-heavy registry package directory");
+    fs::write(
+        package_dir.join("package.json"),
+        serde_json::to_vec(&packument).expect("serialize peer-heavy packument"),
+    )
+    .expect("write peer-heavy packument");
+}
+
+fn peer_heavy_package_name(level: usize, index: usize) -> String {
+    format!("@pnpmtest/peer-benchmark-level-{level}-{index:02}")
 }
 
 /// Save pristine copies of `package.json` and (when present)
@@ -1675,6 +1858,7 @@ fn create_pnpm_workspace(
     scenario: BenchmarkScenario,
 ) {
     let dst = dst_dir.join("pnpm-workspace.yaml");
+    let src_dir = if scenario.uses_peer_heavy_fixture() { None } else { src_dir };
     let mut manifest = if let Some(src_dir) = src_dir {
         let src = src_dir.join("pnpm-workspace.yaml");
         if src.is_file() {
@@ -1707,14 +1891,12 @@ fn create_pnpm_workspace(
     if manifest.cache_dir.is_none() {
         manifest.cache_dir = Some("./cache-dir".to_string());
     }
-    // Pin `packages: ['.']` when the fixture didn't set it. Without this
-    // the fresh-resolve install path's project walker
+    // Pin `packages: ['.']` when the fixture didn't set one.
+    // Without this the fresh-resolve install path's project walker
     // (`find_workspace_projects`) defaults to `[".", "**"]` and recurses
     // into the per-revision `<bench_dir>/pacquet/` clone of pnpm/pnpm,
     // tripping on the intentionally malformed test fixture at
     // `workspace/project-manifest-reader/__fixtures__/invalid-package-json/package.json`.
-    // The benchmark's installs are always single-project, so restricting
-    // to the root is the right scope regardless of fixture.
     if manifest.packages.is_none() {
         manifest.packages = Some(vec![".".to_string()]);
     }

--- a/pnpm/tasks/integrated-benchmark/src/work_env/tests.rs
+++ b/pnpm/tasks/integrated-benchmark/src/work_env/tests.rs
@@ -1,8 +1,10 @@
 use super::{
-    BenchId, BenchmarkScenario, HyperfineCommand, PhaseEvent, WorkEnv, collect_pnpr_direct_ratios,
-    create_install_script, non_trivial_cold_batch, pnpr_auth_config_key,
-    pnpr_benchmark_config_yaml, read_phase_events, render_diagnostics_markdown,
-    requires_fresh_pnpr_cold_batch_metrics, summarize_phase_events,
+    BenchId, BenchmarkScenario, HyperfineCommand, PEER_HEAVY_DEPTH, PEER_HEAVY_PROVIDER,
+    PEER_HEAVY_WIDTH, PhaseEvent, WorkEnv, collect_pnpr_direct_ratios, create_install_script,
+    create_package_json, create_pnpm_workspace, non_trivial_cold_batch, peer_heavy_package_name,
+    pnpr_auth_config_key, pnpr_benchmark_config_yaml, read_phase_events,
+    render_diagnostics_markdown, requires_fresh_pnpr_cold_batch_metrics, seed_peer_heavy_registry,
+    summarize_phase_events,
 };
 use std::{collections::HashMap, fs};
 
@@ -43,6 +45,76 @@ fn online_scenario_writes_no_prewarm_script() {
     let _ = fs::remove_dir_all(&dir);
 
     assert!(!has_prewarm);
+}
+
+#[test]
+fn peer_heavy_scenario_generates_shared_subgraph_root() {
+    let dir = std::env::temp_dir()
+        .join(format!("pacquet-integrated-benchmark-peer-heavy-workspace-{}", std::process::id()));
+    fs::create_dir_all(&dir).expect("create peer-heavy workspace test dir");
+
+    create_package_json(&dir, None, BenchmarkScenario::IsolatedPeerHeavyResolveHotCacheOffline);
+    create_pnpm_workspace(
+        &dir,
+        None,
+        "http://localhost:4873/",
+        BenchmarkScenario::IsolatedPeerHeavyResolveHotCacheOffline,
+    );
+    create_install_script(
+        &dir,
+        BenchmarkScenario::IsolatedPeerHeavyResolveHotCacheOffline,
+        "pnpm",
+        BenchId::PnpmRevision("HEAD"),
+    );
+
+    let manifest: serde_json::Value = serde_json::from_slice(
+        &fs::read(dir.join("package.json")).expect("read generated package manifest"),
+    )
+    .expect("parse generated package manifest");
+    let workspace =
+        fs::read_to_string(dir.join("pnpm-workspace.yaml")).expect("read generated workspace");
+    let prewarm = fs::read_to_string(dir.join("prewarm.bash")).expect("read prewarm script");
+    let registry = dir.join("registry");
+    seed_peer_heavy_registry(&registry);
+    let first_packument: serde_json::Value = serde_json::from_slice(
+        &fs::read(registry.join(peer_heavy_package_name(0, 0)).join("package.json"))
+            .expect("read first peer-heavy packument"),
+    )
+    .expect("parse first peer-heavy packument");
+    let leaf_packument: serde_json::Value = serde_json::from_slice(
+        &fs::read(
+            registry.join(peer_heavy_package_name(PEER_HEAVY_DEPTH - 1, 0)).join("package.json"),
+        )
+        .expect("read leaf peer-heavy packument"),
+    )
+    .expect("parse leaf peer-heavy packument");
+    let registry_package_count =
+        fs::read_dir(registry.join("@pnpmtest")).expect("read peer-heavy registry scope").count();
+    let _ = fs::remove_dir_all(&dir);
+
+    let dependencies = manifest["dependencies"].as_object().expect("generated dependencies");
+    assert_eq!(dependencies.len(), PEER_HEAVY_WIDTH + 1);
+    assert_eq!(dependencies[PEER_HEAVY_PROVIDER], "1.0.0");
+    assert!(workspace.contains("packages:") && workspace.contains("- '.'"));
+    assert!(prewarm.ends_with("exec pnpm install --lockfile-only\n"), "prewarm = {prewarm}");
+    assert_eq!(registry_package_count, PEER_HEAVY_DEPTH * PEER_HEAVY_WIDTH + 1);
+    assert_eq!(
+        first_packument["versions"]["1.0.0"]["dependencies"]
+            .as_object()
+            .expect("first-layer dependencies")
+            .len(),
+        PEER_HEAVY_WIDTH,
+    );
+    assert_eq!(
+        first_packument["versions"]["1.0.0"]["peerDependencies"][PEER_HEAVY_PROVIDER],
+        "1.0.0",
+    );
+    assert!(
+        leaf_packument["versions"]["1.0.0"]["dependencies"]
+            .as_object()
+            .expect("leaf dependencies")
+            .is_empty(),
+    );
 }
 
 #[test]

--- a/pnpm/tasks/integrated-benchmark/src/workspace_manifest.rs
+++ b/pnpm/tasks/integrated-benchmark/src/workspace_manifest.rs
@@ -35,9 +35,9 @@ pub struct MinimalWorkspaceManifest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lockfile: Option<bool>,
     /// Workspace project globs. The benchmark forces this to `['.']`
-    /// (workspace root only) whenever the fixture doesn't set it, so
-    /// the fresh-resolve install path's
-    /// `find_workspace_projects` walk doesn't recurse into the
+    /// (workspace root only) whenever the fixture doesn't set it. The
+    /// root-only default keeps the fresh-resolve install path's
+    /// `find_workspace_projects` walk from recursing into the
     /// per-revision `<bench_dir>/pacquet/` clone of `pnpm/pnpm` and
     /// trip over the repo's intentionally malformed test fixtures
     /// (e.g. an `invalid-package-json` fixture). Both pnpm and pacquet


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Closes pnpm/pnpm#13540.

Large peer-heavy installs through the Rust engine expanded a few thousand packages into millions
of temporary dependency-tree occurrences. Cache hits happened only after their lazy children had
been materialized, and discovery retained occurrence-keyed state that was not needed by the final
graph. Hoisted linking then expanded nested conflict roots into very deep `node_modules` paths.

This change:

- checks pure-package and peers-cache entries before materializing lazy children, streams deferred
  children on true cache misses, and retains only nodes needed as peer providers;
- indexes peer-relevant child providers once per evolving workspace graph instead of rescanning every
  child for each cached peer lookup;
- structurally shares ancestor chains, missing-peer summaries, package data, peer maps, and
  dependency-path strings across repeated contexts;
- recursively hoists nested package-conflict roots so the linker receives a bounded graph instead
  of hundreds of thousands of deeply nested paths; and
- adds a deterministic integrated benchmark for the shared-subgraph peer-resolution failure mode,
  comparing Rust HEAD with main and TypeScript pnpm and requiring Rust to remain at least 10x faster.

The linked draft pnpm/pnpm#13538 implements two bounded allocation reductions but explicitly leaves
the occurrence-keyed discovery state and hoisted-linker expansion unresolved. This PR includes those
reductions and addresses both remaining costs.

This is Rust-only. The TypeScript engine remains the behavioral reference, the emitted lockfile
contract is unchanged, and there is no TypeScript-side behavior to port.

The issue reproduction was run with `@bitdev` and `@teambit` scoped to
`https://node-registry.bit.cloud/`. To isolate resolver CPU from registry latency, the comparison
used fresh output directories with no lockfile, offline `lockfileOnly` installs, and the same
prewarmed metadata cache generated from that registry:

| Engine | Wall time | Peak RSS |
| --- | ---: | ---: |
| TypeScript pnpm 11.19 | 17.30–17.49 s | 3.92–3.98 GiB |
| Rust before the provider index | 19.60 s | 2.88 GiB |
| Rust after the provider index | 5.82–8.40 s | 2.71–2.98 GiB |

The final Rust implementation is 2.1–3.0x faster than TypeScript on this controlled reproduction.
The Rust lockfile before and after the optimization is byte-identical: 2,781,634 bytes with SHA-256
`4a02feb99f5d1af834803a9bf3ba57a445f72488af1cb89a068355d63e019d45`.

The permanent integrated case is self-contained so registry metadata cannot drift. It generates a
five-layer, 80-package-wide DAG: 400 peer-dependent packages, 25,600 shared dependency edges, and
more than 3.3 billion possible root-to-leaf occurrence paths. An online lockfile-only pass warms
metadata, then the timed pass removes the lockfile and resolves offline without linking. Three runs
produced:

| Engine | Mean wall time | Relative to fixed Rust |
| --- | ---: | ---: |
| Rust at PR HEAD | 1.453 ± 0.133 s | 1.00x |
| Rust at PR base | 5.231 ± 0.626 s | 3.60x slower |
| TypeScript pnpm 11.19 | 25.127 ± 0.107 s | 17.29x slower |

The earlier 24% example compared HEAD with intermediate commit `6ebf80d432`, which already contained
most of the fix. Comparing with the actual PR base exposes the intended 3.60x reduction. The
benchmark also performs an untimed correctness pass and fails if target lockfiles differ. All three
lockfiles are byte-identical: 2,526,383 bytes with SHA-256
`241575b87b2202d92c05fd313191afd0531162abe188a939c49e83deb0bb7b8c`.

Resolver benchmarks also improved:

| Benchmark | Before | After |
| --- | ---: | ---: |
| Full workspace resolution | 389–410 ms | 336.72 ms |
| Peer-heavy workspace resolution | 2.10–2.14 s | 981.60 ms |

The corrected nested hoister graph has 4,755 occurrences at maximum depth 5; before recursively
hoisting conflict roots, the same graph expanded to roughly 222,000 deeply nested paths.

Validation:

- Controlled Bit-registry reproduction against TypeScript pnpm 11.19: Rust is 2.1–3.0x faster;
  pre-index and post-index Rust lockfiles are byte-identical.
- Deterministic integrated peer-heavy benchmark: fixed Rust is 3.60x faster than the PR base and
  17.29x faster than TypeScript; all target lockfiles are byte-identical.
- `just ready`: 7,529 tests passed, 4 skipped; formatting, checks, and clippy passed.
- `just dylint`: passed.
- Pre-push TypeScript compile/lint/spellcheck and Rust fmt/clippy/rustdoc/dylint/typos/TOML checks:
  passed.
- `pnpm change status`: passed.

## Squash Commit Body

```text
Stream lazy child resolution through caches and share ancestry, missing-peer summaries, package
data, and dependency paths across repeated peer contexts. Retain only discovery nodes needed as
peer providers instead of occurrence state for every cache-served visit.

Index peer-provider children once per evolving workspace graph so cached peer lookup and lazy
provider previews avoid repeatedly scanning every dependency edge.

Recursively hoist nested conflict roots so the hoisted linker does not expand a small dependency
graph into deeply repeated node_modules paths.

Add a deterministic integrated benchmark that compares the peer-heavy resolver against main and
TypeScript pnpm while enforcing byte-identical lockfiles.

Closes pnpm/pnpm#13540.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced memory usage when resolving peer-heavy dependency graphs.
  * Limited unnecessary dependency-path expansion in deeply nested hoisted graphs.
  * Improved caching and deferred resolution for faster dependency processing.

* **Bug Fixes**
  * Improved peer resolution for aliases, provider reuse, optional providers, and importer-specific contexts.
  * Improved handling of version conflicts, missing peers, cycles, and nested hoisting.
  * Preserved relevant dependency nodes for more accurate results.
  * Improved workspace hoisting and locator handling across nested projects.
  * Improved consistency when resolving dependencies across complex workspace layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->