### PR TITLE
fix(pacquet): always record a tarball integrity in the lockfile

### DIFF
--- a/.changeset/lockfile-only-records-tarball-integrity.md
+++ b/.changeset/lockfile-only-records-tarball-integrity.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-The lockfile now always records an integrity for a registry dependency. A registry that publishes only the legacy `dist.shasum` — as `https://node-registry.bit.cloud/` does — had its packages recorded with a bare tarball URL and no hash, and `--lockfile-only` never computed one, so the very first `pnpm install --frozen-lockfile` failed with `ERR_PNPM_MISSING_TARBALL_INTEGRITY` [#13547](https://github.com/pnpm/pnpm/issues/13547). A `dist.shasum` is now promoted to its `sha1-` integrity as pnpm does, and a version that pins nothing at all has its tarball hashed even under `--lockfile-only`.
+A registry dependency is now always recorded in `pnpm-lock.yaml` with an integrity hash, including under `--lockfile-only`. Packages from a registry that publishes no subresource-integrity metadata — `https://node-registry.bit.cloud/`, for one — were recorded without one, so the next `pnpm install --frozen-lockfile` failed with `ERR_PNPM_MISSING_TARBALL_INTEGRITY` [#13547](https://github.com/pnpm/pnpm/issues/13547).

--- a/.changeset/lockfile-only-records-tarball-integrity.md
+++ b/.changeset/lockfile-only-records-tarball-integrity.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+The lockfile now always records an integrity for a registry dependency. A registry that publishes only the legacy `dist.shasum` — as `https://node-registry.bit.cloud/` does — had its packages recorded with a bare tarball URL and no hash, and `--lockfile-only` never computed one, so the very first `pnpm install --frozen-lockfile` failed with `ERR_PNPM_MISSING_TARBALL_INTEGRITY` [#13547](https://github.com/pnpm/pnpm/issues/13547). A `dist.shasum` is now promoted to its `sha1-` integrity as pnpm does, and a version that pins nothing at all has its tarball hashed even under `--lockfile-only`.

--- a/pnpm/crates/cli/tests/lockfile_only.rs
+++ b/pnpm/crates/cli/tests/lockfile_only.rs
@@ -13,6 +13,7 @@ use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pacquet_testing_utils::{
     bin::{AddMockedRegistry, CommandTempCwd},
+    fixtures::minimal_tarball,
     fs::get_all_files,
 };
 use std::{fs, path::Path, process::Command};
@@ -369,4 +370,80 @@ fn lockfile_only_updates_importers_when_a_project_is_added() {
     );
 
     drop((root, mock_instance));
+}
+
+/// A registry version that pins nothing — neither `dist.integrity` nor
+/// the legacy `dist.shasum` — leaves the lockfile no hash to record, so
+/// the resolver has to download that tarball and compute one even under
+/// `--lockfile-only` (<https://github.com/pnpm/pnpm/issues/13547>).
+#[test]
+fn computes_the_integrity_of_an_unpinned_tarball() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut registry = mockito::Server::new();
+    let tarball_path = "/unpinned/-/unpinned-1.0.0.tgz";
+    let packument = serde_json::json!({
+        "name": "unpinned",
+        "dist-tags": { "latest": "1.0.0" },
+        "modified": "2020-01-15T12:00:00.000Z",
+        "time": { "1.0.0": "2020-01-10T08:30:00.000Z" },
+        "versions": {
+            "1.0.0": {
+                "name": "unpinned",
+                "version": "1.0.0",
+                "dist": { "tarball": format!("{}{tarball_path}", registry.url()) },
+            },
+        },
+    });
+    let packument_mock =
+        registry.mock("GET", "/unpinned").with_body(packument.to_string()).create();
+    let tarball_mock = registry
+        .mock("GET", tarball_path)
+        .with_body(minimal_tarball("unpinned", "1.0.0"))
+        .expect_at_least(1)
+        .create();
+    write_registry_workspace(&workspace, &registry.url());
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "dependencies": { "unpinned": "1.0.0" } }).to_string(),
+    )
+    .expect("write package.json");
+
+    pacquet_at(&workspace).with_args(["install", "--lockfile-only"]).assert().success();
+
+    let lockfile = fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read lockfile");
+    assert!(
+        lockfile.contains("resolution: {integrity: sha512-"),
+        "the unpinned tarball's integrity must be computed and recorded:\n{lockfile}",
+    );
+    assert!(
+        !workspace.join("node_modules").exists(),
+        "node_modules must not be created by --lockfile-only",
+    );
+    packument_mock.assert();
+    tarball_mock.assert();
+
+    // The lockfile the resolve pass wrote is the whole point: it has to
+    // be installable as-is, which is what
+    // <https://github.com/pnpm/pnpm/issues/13547> reported it wasn't.
+    pacquet_at(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
+    assert!(
+        workspace.join("node_modules/unpinned/package.json").exists(),
+        "the frozen install must materialize the unpinned dependency",
+    );
+
+    drop(root);
+}
+
+/// `.npmrc` + `pnpm-workspace.yaml` pointing at `registry`, with the
+/// store and cache under the test's own temp root. The
+/// [`AddMockedRegistry`] helper writes the same pair, but only for the
+/// shared pnpr fixture registry — a hand-built packument needs its own
+/// server.
+fn write_registry_workspace(workspace: &Path, registry: &str) {
+    fs::write(workspace.join(".npmrc"), format!("registry={registry}/\n")).expect("write .npmrc");
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        "storeDir: ../pacquet-store\ncacheDir: ../pacquet-cache\nenableGlobalVirtualStore: false\n",
+    )
+    .expect("write pnpm-workspace.yaml");
 }

--- a/pnpm/crates/cli/tests/lockfile_only.rs
+++ b/pnpm/crates/cli/tests/lockfile_only.rs
@@ -373,9 +373,9 @@ fn lockfile_only_updates_importers_when_a_project_is_added() {
 }
 
 /// A registry version that pins nothing — neither `dist.integrity` nor
-/// the legacy `dist.shasum` — leaves the lockfile no hash to record, so
-/// the resolver has to download that tarball and compute one even under
-/// `--lockfile-only` (<https://github.com/pnpm/pnpm/issues/13547>).
+/// `dist.shasum` — must be hashed even under `--lockfile-only`, or the
+/// lockfile it writes cannot be installed
+/// (<https://github.com/pnpm/pnpm/issues/13547>).
 #[test]
 fn computes_the_integrity_of_an_unpinned_tarball() {
     let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
@@ -422,9 +422,6 @@ fn computes_the_integrity_of_an_unpinned_tarball() {
     packument_mock.assert();
     tarball_mock.assert();
 
-    // The lockfile the resolve pass wrote is the whole point: it has to
-    // be installable as-is, which is what
-    // <https://github.com/pnpm/pnpm/issues/13547> reported it wasn't.
     pacquet_at(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
     assert!(
         workspace.join("node_modules/unpinned/package.json").exists(),
@@ -434,11 +431,9 @@ fn computes_the_integrity_of_an_unpinned_tarball() {
     drop(root);
 }
 
-/// `.npmrc` + `pnpm-workspace.yaml` pointing at `registry`, with the
-/// store and cache under the test's own temp root. The
-/// [`AddMockedRegistry`] helper writes the same pair, but only for the
-/// shared pnpr fixture registry — a hand-built packument needs its own
-/// server.
+/// `.npmrc` + `pnpm-workspace.yaml` for a registry the test hosts
+/// itself. [`AddMockedRegistry`] writes the same pair, but only ever for
+/// the shared pnpr fixture registry.
 fn write_registry_workspace(workspace: &Path, registry: &str) {
     fs::write(workspace.join(".npmrc"), format!("registry={registry}/\n")).expect("write .npmrc");
     fs::write(

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1049,36 +1049,37 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         // reporter the install pass uses. See
         // `prefetching_resolver.rs` for the full design rationale.
         //
-        // Skipped entirely under `--lockfile-only`: that path writes only
-        // `pnpm-lock.yaml` and must not touch the store, so resolution
-        // runs through the bare chain with no background download. This is
-        // the `dryRun: opts.lockfileOnly` path.
-        let resolver: Box<dyn Resolver> = if lockfile_only || filtered_isolated {
-            inner_resolver
-        } else {
-            Box::new(PrefetchingResolver::<Reporter>::new(
-                inner_resolver,
-                PrefetchContext {
-                    http_client: &http_client_arc,
-                    mem_cache: &tarball_mem_cache,
-                    store_index: store_index_ref,
-                    store_index_writer: Some(&store_index_writer),
-                    verified_files_cache: &verified_files_cache,
-                    config,
-                    requester,
-                    supported_architectures,
-                    progress_reported: &progress_reported,
-                },
-            ))
-        };
+        // The wrapper stays in the chain even when the background
+        // download is off, because it also completes the integrity of a
+        // registry version whose metadata carries none — the lockfile
+        // records that hash, so `--lockfile-only` needs it as much as a
+        // materializing install does. Matches pnpm, which fetches a
+        // resolution needing fetch-derived data even under
+        // `dryRun: opts.lockfileOnly`.
+        let resolver: Box<dyn Resolver> = Box::new(PrefetchingResolver::<Reporter>::new(
+            inner_resolver,
+            PrefetchContext {
+                http_client: &http_client_arc,
+                mem_cache: &tarball_mem_cache,
+                store_index: store_index_ref,
+                store_index_writer: Some(&store_index_writer),
+                verified_files_cache: &verified_files_cache,
+                config,
+                requester,
+                supported_architectures,
+                progress_reported: &progress_reported,
+                prefetch_downloads: !lockfile_only && !filtered_isolated,
+            },
+        ));
 
         // The pnpr server resolves `--lockfile-only` and reports each
         // resolved tarball to the client as it lands, so the client can
         // fetch in parallel with the server's resolution. Wrap the chain
-        // last so the observer sees every resolve regardless of whether
-        // the prefetcher above is in play (it isn't under
-        // `--lockfile-only`, which is the pnpr resolve path). A no-op for
-        // every local install (`resolution_observer` is `None`).
+        // last so the observer sees every resolve after the wrapper above
+        // has completed a missing integrity, whether or not that wrapper
+        // is also prefetching (it isn't under `--lockfile-only`, which is
+        // the pnpr resolve path). A no-op for every local install
+        // (`resolution_observer` is `None`).
         let resolver: Box<dyn Resolver> = match resolution_observer {
             Some(observer) => Box::new(crate::ObservingResolver::new(resolver, observer)),
             None => resolver,
@@ -1741,11 +1742,13 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         };
 
         // `--lockfile-only`: the graph is resolved, so build and write
-        // `pnpm-lock.yaml` and return before any materialization. No
-        // tarball was prefetched (the resolver ran without the
-        // `PrefetchingResolver` wrapper), so the store is untouched and
-        // there is no `node_modules`, `.modules.yaml`, or current
-        // lockfile — a lockfile-only resolve pass.
+        // `pnpm-lock.yaml` and return before any materialization. Nothing
+        // was prefetched (the `PrefetchingResolver` ran with
+        // `prefetch_downloads: false`), so the only tarballs that reached
+        // the store are the ones whose integrity the lockfile could not
+        // be written without, and there is no `node_modules`,
+        // `.modules.yaml`, or current lockfile — a lockfile-only resolve
+        // pass.
         if lockfile_only {
             let freshly_resolved = build_fresh_lockfile(FreshLockfileBuildOptions {
                 config,

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1048,14 +1048,6 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         // download's `pnpm:progress` emits route through the same
         // reporter the install pass uses. See
         // `prefetching_resolver.rs` for the full design rationale.
-        //
-        // The wrapper stays in the chain even when the background
-        // download is off, because it also completes the integrity of a
-        // registry version whose metadata carries none — the lockfile
-        // records that hash, so `--lockfile-only` needs it as much as a
-        // materializing install does. Matches pnpm, which fetches a
-        // resolution needing fetch-derived data even under
-        // `dryRun: opts.lockfileOnly`.
         let resolver: Box<dyn Resolver> = Box::new(PrefetchingResolver::<Reporter>::new(
             inner_resolver,
             PrefetchContext {
@@ -1075,10 +1067,8 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         // The pnpr server resolves `--lockfile-only` and reports each
         // resolved tarball to the client as it lands, so the client can
         // fetch in parallel with the server's resolution. Wrap the chain
-        // last so the observer sees every resolve after the wrapper above
-        // has completed a missing integrity, whether or not that wrapper
-        // is also prefetching (it isn't under `--lockfile-only`, which is
-        // the pnpr resolve path). A no-op for every local install
+        // last so the observer sees each resolve as the wrapper above
+        // leaves it, integrity included. A no-op for every local install
         // (`resolution_observer` is `None`).
         let resolver: Box<dyn Resolver> = match resolution_observer {
             Some(observer) => Box::new(crate::ObservingResolver::new(resolver, observer)),
@@ -1743,10 +1733,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
 
         // `--lockfile-only`: the graph is resolved, so build and write
         // `pnpm-lock.yaml` and return before any materialization. Nothing
-        // was prefetched (the `PrefetchingResolver` ran with
-        // `prefetch_downloads: false`), so the only tarballs that reached
-        // the store are the ones whose integrity the lockfile could not
-        // be written without, and there is no `node_modules`,
+        // was prefetched, and there is no `node_modules`,
         // `.modules.yaml`, or current lockfile — a lockfile-only resolve
         // pass.
         if lockfile_only {

--- a/pnpm/crates/package-manager/src/prefetching_resolver.rs
+++ b/pnpm/crates/package-manager/src/prefetching_resolver.rs
@@ -21,6 +21,13 @@
 //! prefetch is already done) or briefly blocks on the `Notify` (the
 //! prefetch is still in flight). Errors are surfaced to the install
 //! path as `TarballError::SiblingFetchFailed`.
+//!
+//! The wrapper carries a second, non-optional job: completing the
+//! integrity of a resolution that has none
+//! ([`PrefetchingResolver::populate_missing_integrity`]). Background
+//! prefetching is a pure optimization a run may switch off
+//! ([`PrefetchContext::prefetch_downloads`]); integrity completion is
+//! not, because the lockfile the run writes is invalid without it.
 
 use crate::{
     install_package_from_registry::{extract_tarball, manifest_file_count, manifest_unpacked_size},
@@ -70,6 +77,14 @@ pub struct PrefetchContext<'a> {
     /// consults the set so prefetch progress is visible immediately
     /// without being counted again.
     pub progress_reported: &'a SharedReportedProgressKeys,
+    /// Whether a resolved tarball is downloaded in the background.
+    /// `false` for a run whose install pass will never ask for those
+    /// bytes — `--lockfile-only`, or a filtered workspace selection
+    /// that materializes only part of the graph — so the store isn't
+    /// filled with tarballs nobody installs. Integrity completion is
+    /// unaffected: an integrity-less tarball is still downloaded, since
+    /// its hash is what the lockfile records.
+    pub prefetch_downloads: bool,
 }
 
 /// Owned, `'static`-friendly clones of [`PrefetchContext`] stored on
@@ -109,6 +124,7 @@ struct OwnedFetchCtx {
     /// edge downloads and computes the integrity; later edges await the
     /// same cell instead of fetching the URL again.
     integrity_cache: Arc<DashMap<String, Arc<OnceCell<Integrity>>>>,
+    prefetch_downloads: bool,
 }
 
 /// Wraps an inner [`Resolver`] and, after each successful resolve that
@@ -149,6 +165,7 @@ impl<Reporter: self::Reporter + 'static> PrefetchingResolver<Reporter> {
             requester,
             supported_architectures,
             progress_reported,
+            prefetch_downloads,
         } = prefetch_ctx;
         let ctx = OwnedFetchCtx {
             http_client: Arc::clone(http_client),
@@ -169,6 +186,7 @@ impl<Reporter: self::Reporter + 'static> PrefetchingResolver<Reporter> {
             progress_reported: SharedReportedProgressKeys::clone(progress_reported),
             spawned_urls: Arc::new(DashSet::new()),
             integrity_cache: Arc::new(DashMap::new()),
+            prefetch_downloads,
         };
         PrefetchingResolver { inner, ctx, _phantom: PhantomData }
     }
@@ -380,7 +398,9 @@ impl<Reporter: self::Reporter + 'static> Resolver for PrefetchingResolver<Report
             let mut result = self.inner.resolve(wanted_dependency, opts).await?;
             if let Some(result_mut) = result.as_mut() {
                 self.populate_missing_integrity(result_mut).await?;
-                if !self.should_skip_prefetch(wanted_dependency, result_mut) {
+                if self.ctx.prefetch_downloads
+                    && !self.should_skip_prefetch(wanted_dependency, result_mut)
+                {
                     self.maybe_kickoff_download(result_mut);
                 }
             }

--- a/pnpm/crates/package-manager/src/prefetching_resolver.rs
+++ b/pnpm/crates/package-manager/src/prefetching_resolver.rs
@@ -22,12 +22,10 @@
 //! prefetch is still in flight). Errors are surfaced to the install
 //! path as `TarballError::SiblingFetchFailed`.
 //!
-//! The wrapper carries a second, non-optional job: completing the
-//! integrity of a resolution that has none
-//! ([`PrefetchingResolver::populate_missing_integrity`]). Background
-//! prefetching is a pure optimization a run may switch off
-//! ([`PrefetchContext::prefetch_downloads`]); integrity completion is
-//! not, because the lockfile the run writes is invalid without it.
+//! That prefetch is speculative, and a run may switch it off
+//! ([`PrefetchContext::prefetch_downloads`]). Hashing a resolution
+//! that carries no integrity is not speculative — the lockfile records
+//! that hash — so it runs either way.
 
 use crate::{
     install_package_from_registry::{extract_tarball, manifest_file_count, manifest_unpacked_size},
@@ -77,13 +75,9 @@ pub struct PrefetchContext<'a> {
     /// consults the set so prefetch progress is visible immediately
     /// without being counted again.
     pub progress_reported: &'a SharedReportedProgressKeys,
-    /// Whether a resolved tarball is downloaded in the background.
-    /// `false` for a run whose install pass will never ask for those
-    /// bytes — `--lockfile-only`, or a filtered workspace selection
-    /// that materializes only part of the graph — so the store isn't
-    /// filled with tarballs nobody installs. Integrity completion is
-    /// unaffected: an integrity-less tarball is still downloaded, since
-    /// its hash is what the lockfile records.
+    /// Whether a resolved tarball is prefetched. `false` for a run
+    /// whose install pass will never ask for those bytes, so the store
+    /// isn't filled with tarballs nobody installs.
     pub prefetch_downloads: bool,
 }
 

--- a/pnpm/crates/package-manager/src/prefetching_resolver/tests.rs
+++ b/pnpm/crates/package-manager/src/prefetching_resolver/tests.rs
@@ -110,6 +110,14 @@ fn resolver_with_inner(
     dir: &Path,
     inner: Box<dyn Resolver>,
 ) -> PrefetchingResolver<SilentReporter> {
+    resolver_with_prefetch(dir, inner, true)
+}
+
+fn resolver_with_prefetch(
+    dir: &Path,
+    inner: Box<dyn Resolver>,
+    prefetch_downloads: bool,
+) -> PrefetchingResolver<SilentReporter> {
     let mut config = Config::new();
     config.store_dir = dir.join("store").into();
     config.cache_dir = dir.join("cache");
@@ -129,6 +137,7 @@ fn resolver_with_inner(
             requester: "/project",
             supported_architectures: None,
             progress_reported: &SharedReportedProgressKeys::default(),
+            prefetch_downloads,
         },
     )
 }
@@ -297,4 +306,96 @@ async fn keeps_prefetch_for_required_manifest() {
     );
 
     assert!(!resolver.should_skip_prefetch(&wanted, &result));
+}
+
+/// A resolution the registry pinned itself: the wrapper has no hash to
+/// compute, so only the background download is left to (not) do.
+fn integrity_pinned_result(tarball_url: &str) -> ResolveResult {
+    let mut result =
+        result_with_manifest("pinned", json!({ "name": "pinned", "version": "1.0.0" }));
+    result.resolution = LockfileResolution::Tarball(TarballResolution {
+        integrity: Some("sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==".parse().unwrap()),
+        tarball: tarball_url.to_string(),
+        git_hosted: None,
+        path: None,
+    });
+    result
+}
+
+/// <https://github.com/pnpm/pnpm/issues/13547>: a resolution the
+/// registry left unpinned still gets its integrity computed when
+/// background prefetching is off, because the lockfile records that
+/// hash.
+#[tokio::test]
+async fn populates_integrity_with_prefetching_off() {
+    let dir = tempdir().unwrap();
+    let mut server = mockito::Server::new_async().await;
+    let tarball_path = "/unpinned-1.0.0.tgz";
+    let get_mock = server
+        .mock("GET", tarball_path)
+        .with_status(200)
+        .with_body(minimal_tarball("unpinned", "1.0.0"))
+        .expect(1)
+        .create_async()
+        .await;
+    let mut result = result_with_manifest("unpinned", json!({}));
+    result.resolution = LockfileResolution::Tarball(TarballResolution {
+        integrity: None,
+        tarball: format!("{}{tarball_path}", server.url()),
+        git_hosted: None,
+        path: None,
+    });
+    let resolver = resolver_with_prefetch(dir.path(), Box::new(FixedResolver { result }), false);
+
+    let resolved = resolver
+        .resolve(&WantedDependency::default(), &ResolveOptions::default())
+        .await
+        .expect("resolve succeeds")
+        .expect("resolver returns a result");
+
+    let LockfileResolution::Tarball(tarball) = resolved.resolution else {
+        panic!("expected tarball resolution");
+    };
+    assert!(tarball.integrity.is_some(), "an unpinned tarball still needs its integrity");
+    get_mock.assert_async().await;
+}
+
+/// The other half of the split: with prefetching off, a resolution that
+/// already carries an integrity is never downloaded — `--lockfile-only`
+/// must not pull the whole graph into the store.
+#[tokio::test]
+async fn skips_the_background_download_with_prefetching_off() {
+    let dir = tempdir().unwrap();
+    let tarball_url = "https://registry.example/pinned-1.0.0.tgz";
+    let resolver = resolver_with_prefetch(
+        dir.path(),
+        Box::new(FixedResolver { result: integrity_pinned_result(tarball_url) }),
+        false,
+    );
+
+    resolver
+        .resolve(&WantedDependency::default(), &ResolveOptions::default())
+        .await
+        .expect("resolve succeeds")
+        .expect("resolver returns a result");
+
+    assert!(resolver.ctx.spawned_urls.is_empty(), "no download may be claimed");
+}
+
+#[tokio::test]
+async fn claims_the_background_download_with_prefetching_on() {
+    let dir = tempdir().unwrap();
+    let tarball_url = "https://registry.example/pinned-1.0.0.tgz";
+    let resolver = resolver_with_inner(
+        dir.path(),
+        Box::new(FixedResolver { result: integrity_pinned_result(tarball_url) }),
+    );
+
+    resolver
+        .resolve(&WantedDependency::default(), &ResolveOptions::default())
+        .await
+        .expect("resolve succeeds")
+        .expect("resolver returns a result");
+
+    assert!(resolver.ctx.spawned_urls.contains(tarball_url), "the download must be claimed");
 }

--- a/pnpm/crates/package-manager/src/prefetching_resolver/tests.rs
+++ b/pnpm/crates/package-manager/src/prefetching_resolver/tests.rs
@@ -308,8 +308,6 @@ async fn keeps_prefetch_for_required_manifest() {
     assert!(!resolver.should_skip_prefetch(&wanted, &result));
 }
 
-/// A resolution the registry pinned itself: the wrapper has no hash to
-/// compute, so only the background download is left to (not) do.
 fn integrity_pinned_result(tarball_url: &str) -> ResolveResult {
     let mut result =
         result_with_manifest("pinned", json!({ "name": "pinned", "version": "1.0.0" }));
@@ -322,10 +320,7 @@ fn integrity_pinned_result(tarball_url: &str) -> ResolveResult {
     result
 }
 
-/// <https://github.com/pnpm/pnpm/issues/13547>: a resolution the
-/// registry left unpinned still gets its integrity computed when
-/// background prefetching is off, because the lockfile records that
-/// hash.
+/// <https://github.com/pnpm/pnpm/issues/13547>
 #[tokio::test]
 async fn populates_integrity_with_prefetching_off() {
     let dir = tempdir().unwrap();
@@ -360,9 +355,6 @@ async fn populates_integrity_with_prefetching_off() {
     get_mock.assert_async().await;
 }
 
-/// The other half of the split: with prefetching off, a resolution that
-/// already carries an integrity is never downloaded — `--lockfile-only`
-/// must not pull the whole graph into the store.
 #[tokio::test]
 async fn skips_the_background_download_with_prefetching_off() {
     let dir = tempdir().unwrap();

--- a/pnpm/crates/resolving-npm-resolver/Cargo.toml
+++ b/pnpm/crates/resolving-npm-resolver/Cargo.toml
@@ -33,6 +33,7 @@ reqwest     = { workspace = true }
 serde       = { workspace = true }
 serde_json  = { workspace = true }
 sha2        = { workspace = true }
+ssri        = { workspace = true }
 tokio       = { workspace = true }
 tracing     = { workspace = true }
 
@@ -43,7 +44,6 @@ pacquet-resolving-local-resolver   = { workspace = true }
 futures-util      = { workspace = true }
 mockito           = { workspace = true }
 pretty_assertions = { workspace = true }
-ssri              = { workspace = true }
 tempfile          = { workspace = true }
 tokio             = { workspace = true, features = ["macros", "rt"] }
 

--- a/pnpm/crates/resolving-npm-resolver/src/errors.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/errors.rs
@@ -173,8 +173,7 @@ pub struct GuardRepickLimitError {
 /// from it.
 ///
 /// Both fields are quoted registry metadata, so [`Self::new`] redacts
-/// and sanitizes them for the same reason [`FetchMetadataError`] does:
-/// the message reaches the terminal, CI logs, and reporters.
+/// and sanitizes them — see [`FetchMetadataError`] for why.
 #[derive(Debug, Display, Error, Diagnostic)]
 #[display(r#"Tarball "{tarball}" has invalid shasum specified in its metadata: {shasum}"#)]
 #[diagnostic(code(ERR_PNPM_INVALID_TARBALL_INTEGRITY))]

--- a/pnpm/crates/resolving-npm-resolver/src/errors.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/errors.rs
@@ -2,6 +2,7 @@
 
 use derive_more::{Display, Error};
 use miette::Diagnostic;
+use pacquet_network::redact_and_sanitize;
 
 /// Failure to fetch a registry metadata document. Used by
 /// [`crate::fetch_full_metadata()`] and
@@ -170,6 +171,10 @@ pub struct GuardRepickLimitError {
 /// Raised when a registry version carries no `dist.integrity` and its
 /// `dist.shasum` is not a hex digest, so no SRI string can be derived
 /// from it.
+///
+/// Both fields are quoted registry metadata, so [`Self::new`] redacts
+/// and sanitizes them for the same reason [`FetchMetadataError`] does:
+/// the message reaches the terminal, CI logs, and reporters.
 #[derive(Debug, Display, Error, Diagnostic)]
 #[display(r#"Tarball "{tarball}" has invalid shasum specified in its metadata: {shasum}"#)]
 #[diagnostic(code(ERR_PNPM_INVALID_TARBALL_INTEGRITY))]
@@ -177,6 +182,16 @@ pub struct InvalidTarballIntegrityError {
     #[error(not(source))]
     pub tarball: String,
     pub shasum: String,
+}
+
+impl InvalidTarballIntegrityError {
+    #[must_use]
+    pub fn new(tarball: &str, shasum: &str) -> Self {
+        InvalidTarballIntegrityError {
+            tarball: redact_and_sanitize(tarball),
+            shasum: redact_and_sanitize(shasum),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/pnpm/crates/resolving-npm-resolver/src/errors.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/errors.rs
@@ -167,5 +167,17 @@ pub struct GuardRepickLimitError {
     pub reason: String,
 }
 
+/// Raised when a registry version carries no `dist.integrity` and its
+/// `dist.shasum` is not a hex digest, so no SRI string can be derived
+/// from it.
+#[derive(Debug, Display, Error, Diagnostic)]
+#[display(r#"Tarball "{tarball}" has invalid shasum specified in its metadata: {shasum}"#)]
+#[diagnostic(code(ERR_PNPM_INVALID_TARBALL_INTEGRITY))]
+pub struct InvalidTarballIntegrityError {
+    #[error(not(source))]
+    pub tarball: String,
+    pub shasum: String,
+}
+
 #[cfg(test)]
 mod tests;

--- a/pnpm/crates/resolving-npm-resolver/src/lib.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/lib.rs
@@ -44,7 +44,7 @@ pub use create_npm_resolution_verifier::{
     CreateNpmResolutionVerifierOptions, DistStats, NpmResolutionVerifier, ObservedDistStats,
     create_npm_resolution_verifier, observed_dist_stats_sink,
 };
-pub use errors::FetchMetadataError;
+pub use errors::{FetchMetadataError, InvalidTarballIntegrityError};
 pub use fetch_attestation_published_at::{FetchAttestationOptions, fetch_attestation_published_at};
 pub use fetch_full_metadata::{
     FetchFullMetadataOptions, FetchFullMetadataOutcome, fetch_full_metadata,

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -30,16 +30,17 @@ use node_semver::Version;
 use pacquet_config::{TrustPolicy, version_policy::PackageVersionPolicy};
 use pacquet_lockfile::{LockfileResolution, PkgName, PkgNameVer, TarballResolution};
 use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient, redact_and_sanitize};
-use pacquet_registry::{Package, PackageVersion, RangeSpecStyle};
+use pacquet_registry::{Package, PackageDistribution, PackageVersion, RangeSpecStyle};
 use pacquet_resolving_resolver_base::{
     LatestInfo, LatestQuery, NoMatchingVersionError, PackageVersionGuardDecision,
     RegistryResponseError, RegistryResponseErrorOptions, ResolutionPolicyViolation, ResolveError,
     ResolveFuture, ResolveLatestFuture, ResolveOptions, ResolveResult, Resolver, UpdateBehavior,
     WantedDependency, WorkspacePackages, parse_packument_timestamp,
 };
+use ssri::{Algorithm, Integrity};
 
 use crate::{
-    errors::{AllVersionsBlockedError, GuardRepickLimitError},
+    errors::{AllVersionsBlockedError, GuardRepickLimitError, InvalidTarballIntegrityError},
     named_registry::pick_registry_for_package,
     parse_bare_specifier::{parse_bare_specifier, parse_jsr_specifier_to_registry_package_spec},
     pick_package::{
@@ -814,7 +815,7 @@ pub(crate) fn build_resolve_result(
     // the URL the install path needs.
     let resolution = LockfileResolution::Tarball(TarballResolution {
         tarball: picked.dist.tarball.clone(),
-        integrity: picked.dist.integrity.clone(),
+        integrity: dist_integrity(&picked.dist)?,
         git_hosted: None,
         path: None,
     });
@@ -858,6 +859,29 @@ pub(crate) fn build_resolve_result(
         normalized_bare_specifier: spec.normalized_bare_specifier.clone().or(calculated_specifier),
         alias: alias.map(str::to_string),
         policy_violation,
+    })
+}
+
+/// The integrity a registry version's `dist` pins its tarball with.
+///
+/// A registry that predates subresource integrity publishes only the
+/// legacy `dist.shasum` hex digest; it still pins the bytes, so it is
+/// promoted to the equivalent `sha1-` SRI string rather than dropped.
+/// `None` when the version pins nothing at all — the tarball's hash is
+/// then learned by downloading it (see
+/// `PrefetchingResolver::populate_missing_integrity`).
+fn dist_integrity(dist: &PackageDistribution) -> Result<Option<Integrity>, ResolveError> {
+    if let Some(integrity) = &dist.integrity {
+        return Ok(Some(integrity.clone()));
+    }
+    let Some(shasum) = dist.shasum.as_deref().filter(|shasum| !shasum.is_empty()) else {
+        return Ok(None);
+    };
+    Integrity::from_hex(shasum, Algorithm::Sha1).map(Some).map_err(|_| {
+        Box::new(InvalidTarballIntegrityError {
+            tarball: dist.tarball.clone(),
+            shasum: shasum.to_string(),
+        }) as ResolveError
     })
 }
 

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -864,12 +864,10 @@ pub(crate) fn build_resolve_result(
 
 /// The integrity a registry version's `dist` pins its tarball with.
 ///
-/// A registry that predates subresource integrity publishes only the
-/// legacy `dist.shasum` hex digest; it still pins the bytes, so it is
-/// promoted to the equivalent `sha1-` SRI string rather than dropped.
-/// `None` when the version pins nothing at all — the tarball's hash is
-/// then learned by downloading it (see
-/// `PrefetchingResolver::populate_missing_integrity`).
+/// A registry predating subresource integrity publishes only the legacy
+/// `dist.shasum` hex digest, which pins the bytes just as well, so it is
+/// promoted to its `sha1-` SRI form. `None` when the version pins
+/// nothing at all.
 fn dist_integrity(dist: &PackageDistribution) -> Result<Option<Integrity>, ResolveError> {
     if let Some(integrity) = &dist.integrity {
         return Ok(Some(integrity.clone()));

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -878,10 +878,7 @@ fn dist_integrity(dist: &PackageDistribution) -> Result<Option<Integrity>, Resol
         return Ok(None);
     };
     Integrity::from_hex(shasum, Algorithm::Sha1).map(Some).map_err(|_| {
-        Box::new(InvalidTarballIntegrityError {
-            tarball: dist.tarball.clone(),
-            shasum: shasum.to_string(),
-        }) as ResolveError
+        Box::new(InvalidTarballIntegrityError::new(&dist.tarball, shasum)) as ResolveError
     })
 }
 

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -18,6 +18,7 @@ use serde_json::json;
 use tempfile::TempDir;
 
 use crate::{
+    errors::InvalidTarballIntegrityError,
     npm_resolver::NpmResolver,
     pick_package::{
         InMemoryPackageMetaCache, shared_packument_fetch_locker, shared_picked_manifest_cache,
@@ -1538,4 +1539,75 @@ async fn jsr_specifier_suppresses_latest_when_published_by_holds_back_raw_latest
     let result = resolver.resolve(&wanted, &opts).await.unwrap().unwrap();
     assert_eq!(result.name_ver.as_ref().expect("name_ver").suffix.to_string(), "1.0.0");
     assert!(result.latest.is_none(), "immature dist-tags.latest suppresses the hint");
+}
+
+/// A packument whose `dist` carries only the legacy `shasum`, as
+/// registries predating subresource integrity serve — the shape behind
+/// <https://github.com/pnpm/pnpm/issues/13547>.
+fn shasum_only_package_body(shasum: &str) -> String {
+    json!({
+        "name": "acme",
+        "dist-tags": { "latest": "1.0.0" },
+        "modified": "2025-01-15T12:00:00.000Z",
+        "versions": {
+            "1.0.0": {
+                "name": "acme",
+                "version": "1.0.0",
+                "dist": {
+                    "shasum": shasum,
+                    "tarball": "https://registry/acme-1.0.0.tgz",
+                },
+            },
+        },
+    })
+    .to_string()
+}
+
+#[tokio::test]
+async fn shasum_only_metadata_resolves_to_a_sha1_integrity() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_body(shasum_only_package_body("e21bf1d18b7ce29d1cd45f6d8e0e8bcd0a4ca8ba"))
+        .create_async()
+        .await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    let wanted =
+        WantedDependency { alias: Some("acme".to_string()), ..WantedDependency::default() };
+    let result = resolver.resolve(&wanted, &ResolveOptions::default()).await.unwrap().unwrap();
+
+    let LockfileResolution::Tarball(tarball) = &result.resolution else {
+        panic!("expected a tarball resolution, got {:?}", result.resolution);
+    };
+    assert_eq!(
+        tarball.integrity.as_ref().map(ToString::to_string).as_deref(),
+        Some("sha1-4hvx0Yt84p0c1F9tjg6LzQpMqLo="),
+    );
+}
+
+#[tokio::test]
+async fn unparsable_shasum_fails_the_resolve() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_body(shasum_only_package_body("not-a-hex-digest"))
+        .create_async()
+        .await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    let wanted =
+        WantedDependency { alias: Some("acme".to_string()), ..WantedDependency::default() };
+    let error = resolver
+        .resolve(&wanted, &ResolveOptions::default())
+        .await
+        .expect_err("an unusable shasum must fail the resolve");
+
+    let error = error.downcast_ref::<InvalidTarballIntegrityError>().expect("integrity error");
+    assert_eq!(error.shasum, "not-a-hex-digest");
+    assert_eq!(error.tarball, "https://registry/acme-1.0.0.tgz");
 }

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -1541,9 +1541,8 @@ async fn jsr_specifier_suppresses_latest_when_published_by_holds_back_raw_latest
     assert!(result.latest.is_none(), "immature dist-tags.latest suppresses the hint");
 }
 
-/// A packument whose `dist` carries only the legacy `shasum`, as
-/// registries predating subresource integrity serve — the shape behind
-/// <https://github.com/pnpm/pnpm/issues/13547>.
+/// A packument whose `dist` carries only the legacy `shasum`, the shape
+/// behind <https://github.com/pnpm/pnpm/issues/13547>.
 fn shasum_only_package_body(shasum: &str) -> String {
     json!({
         "name": "acme",

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -1611,3 +1611,41 @@ async fn unparsable_shasum_fails_the_resolve() {
     assert_eq!(error.shasum, "not-a-hex-digest");
     assert_eq!(error.tarball, "https://registry/acme-1.0.0.tgz");
 }
+
+#[tokio::test]
+async fn invalid_shasum_error_redacts_registry_metadata() {
+    let mut server = mockito::Server::new_async().await;
+    let body = json!({
+        "name": "acme",
+        "dist-tags": { "latest": "1.0.0" },
+        "modified": "2025-01-15T12:00:00.000Z",
+        "versions": {
+            "1.0.0": {
+                "name": "acme",
+                "version": "1.0.0",
+                "dist": {
+                    "shasum": "not\u{7}-a-hex-digest",
+                    "tarball": "https://user:hunter2@registry/acme-1.0.0.tgz",
+                },
+            },
+        },
+    })
+    .to_string();
+    let _mock = server.mock("GET", "/acme").with_status(200).with_body(body).create_async().await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    let wanted =
+        WantedDependency { alias: Some("acme".to_string()), ..WantedDependency::default() };
+    let error = resolver
+        .resolve(&wanted, &ResolveOptions::default())
+        .await
+        .expect_err("an unusable shasum must fail the resolve")
+        .to_string();
+
+    assert!(!error.contains("hunter2"), "inline credentials must not reach the message: {error}");
+    assert!(
+        !error.chars().any(char::is_control),
+        "control characters must not reach the message: {error:?}",
+    );
+}


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#13547.

`pnpm add <pkg> --lockfile-only` against a registry whose versions carry no `dist.integrity` wrote a lockfile with a bare tarball URL and no hash, and the first `pnpm install --frozen-lockfile` over it failed with `ERR_PNPM_MISSING_TARBALL_INTEGRITY`.

Reproducing the issue turned up **two** independent gaps, both fixed here. Only fixing the reported one would have left pacquet downloading every tarball of such a registry during `--lockfile-only` and writing sha512 hashes where the TypeScript CLI writes sha1 — a lockfile divergence.

**1. `dist.shasum` was ignored (`resolving-npm-resolver`).** pnpm's `getIntegrity` falls back to `ssri.fromHex(dist.shasum, 'sha1')` when `dist.integrity` is absent; that fallback is what pins every version published before subresource integrity, including all of `https://node-registry.bit.cloud/`. pacquet parsed `dist.shasum` into `PackageDistribution` and then dropped it. The new `dist_integrity` mirrors `getIntegrity`, including the `ERR_PNPM_INVALID_TARBALL_INTEGRITY` failure for a shasum that is not a hex digest. `pnpr` already assumed this fallback exists — its packument trimmer deliberately keeps `shasum` when `integrity` is missing "so pnpm's sha1 fallback still has a hash (pre-2017 publishes)".

This is also the more secure of the two behaviours: a registry-published hash pins the bytes, whereas hashing whatever the network returned pins nothing.

**2. `--lockfile-only` skipped `populate_missing_integrity` (`package-manager`).** The reported bug: the whole `PrefetchingResolver` was skipped under `lockfileOnly` (and under a filtered workspace selection), and that wrapper owns the only path that hashes a tarball no registry hash covers. The two jobs are now separated — the wrapper always sits in the resolver chain, and the new `prefetch_downloads` flag turns off only the speculative background download. So `--lockfile-only` still fetches nothing speculatively, but does fetch the few tarballs whose hash the lockfile cannot be written without. This is what pnpm does: `packageRequester` fetches when `resolutionNeedsFetch` is true even with `skipFetch` / `dryRun` set.

### Verification

The issue's reproduction, before and after, against the real registry:

```
# before
'@teambit/design.ui.icon-button@1.0.16':
  resolution: {tarball: https://node-registry.bit.cloud/@teambit/design.ui.icon-button/-/design.ui.icon-button-1.0.16.tgz}
# after
'@teambit/design.ui.icon-button@1.0.16':
  resolution: {integrity: sha1-4guwxtPII430l1WuK5krEgo4PUY=}
```

The lockfile pacquet writes for that graph is now **byte-identical** to the one `pnpm@11.18.0` writes (`diff` of the two `pnpm-lock.yaml` files is empty), and `pnpm install --frozen-lockfile` over it succeeds.

### Parity

TypeScript side needs no change — it already has both behaviours (`getIntegrity`, and the `resolutionNeedsFetch` fetch under `dryRun` from pnpm/pnpm#12491). This PR brings pacquet up to them.

## Squash Commit Body

```text
A registry version that carried no `dist.integrity` was recorded in the
lockfile with a bare tarball URL and no hash, and `--lockfile-only` never
computed one — so the very first `pnpm install --frozen-lockfile` over
that lockfile failed with `ERR_PNPM_MISSING_TARBALL_INTEGRITY`. Two
independent gaps produced it, and both are closed here.

First, `dist.shasum` was ignored. pnpm's `getIntegrity` promotes the
legacy hex digest to a `sha1-` SRI string when `dist.integrity` is
absent, which is what pins every version published before subresource
integrity — the whole of `https://node-registry.bit.cloud/`, for one.
pacquet parsed the field and dropped it, leaving those versions unpinned
and diverging from the lockfile the TypeScript CLI writes for the same
graph. `dist_integrity` now mirrors `getIntegrity`, including the
`ERR_PNPM_INVALID_TARBALL_INTEGRITY` failure for a shasum that is not a
hex digest. It also restores the stronger of the two behaviours: a
registry-published hash pins the bytes, where hashing whatever arrived
pins nothing.

Second, `--lockfile-only` skipped the `PrefetchingResolver` wholesale,
and that wrapper owns `populate_missing_integrity` — the only path that
hashes a tarball no registry hash covers. Background prefetching and
integrity completion are now separate concerns: the wrapper always sits
in the resolver chain, and `prefetch_downloads` turns off only the
speculative download. A run that materializes nothing (`--lockfile-only`)
or only part of the graph (a filtered workspace selection) still fetches
the few tarballs whose hash the lockfile cannot be written without, which
is what pnpm does with `resolutionNeedsFetch` under `dryRun`.

Closes pnpm/pnpm#13547
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (Rust-only: the TypeScript CLI already has both behaviours — see Parity above.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

Tests added: `computes_the_integrity_of_an_unpinned_tarball` (CLI, end to end over a hand-built packument that pins nothing — verified to fail without the fix), `shasum_only_metadata_resolves_to_a_sha1_integrity` + `unparsable_shasum_fails_the_resolve` (npm resolver), and `populates_integrity_with_prefetching_off` / `skips_the_background_download_with_prefetching_off` / `claims_the_background_download_with_prefetching_on` (prefetching resolver). Full Rust suite green (7531 tests).

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788169705&installation_model_id=426870&pr_number=13549&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13549&signature=dd5f1ebecbf896d8ca955ff211c2adddcd388feffb69c21956c545cb62b17420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lockfile-only installs now record tarball integrity for registry dependencies.
  * Legacy SHA-1 checksums are converted to standard integrity values.
  * Tarballs without integrity metadata are hashed automatically when needed.
* **Bug Fixes**
  * Invalid checksum metadata now produces a clear, sanitized resolution error.
  * Lockfile-only resolution avoids creating `node_modules` while still supporting later frozen installs.
* **Tests**
  * Added coverage for integrity generation, checksum conversion, invalid metadata, and download behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->