### PR TITLE
test(pacquet): recalibrate the peer-heavy pacquet-vs-pnpm floor

### DIFF
--- a/pnpm/tasks/integrated-benchmark/src/work_env.rs
+++ b/pnpm/tasks/integrated-benchmark/src/work_env.rs
@@ -32,7 +32,12 @@ const PREWARM_SCRIPT: &str = "prewarm.bash";
 const BENCHMARK_DIAGNOSTICS_JSON: &str = "BENCHMARK_DIAGNOSTICS.json";
 const BENCHMARK_DIAGNOSTICS_MD: &str = "BENCHMARK_DIAGNOSTICS.md";
 const PNPR_DIRECT_RATIO_MAX: f64 = 1.05;
-const PACQUET_PNPM_SPEEDUP_MIN: f64 = 10.0;
+// A pacquet peer-resolution blowup lands *below* 1x on this DAG, so the floor
+// only has to clear measurement noise, not encode how far ahead pacquet is.
+// The TypeScript resolver's own hot-cache cost moves independently — offline
+// resolution of this fixture dropped from ~34s to ~3s in pnpm/pnpm#13504 — and
+// a floor tracking that headroom would fail on every TypeScript perf win.
+const PACQUET_PNPM_SPEEDUP_MIN: f64 = 1.25;
 const PNPR_SERVER_REGISTRY_ENV: &str = "PACQUET_BENCHMARK_PNPR_SERVER_REGISTRY";
 const PNPR_TARBALL_REWRITE_FROM_ENV: &str = "PACQUET_BENCHMARK_PNPR_TARBALL_REWRITE_FROM";
 const PNPR_BENCHMARK_USERNAME: &str = "pnpr-benchmark";


### PR DESCRIPTION
## Summary

The peer-heavy integrated benchmark has failed on every `main` push since it
landed, e.g.
[run 30699800078](https://github.com/pnpm/pnpm/actions/runs/30699800078/job/91368694286):

```
pacquet@HEAD was only 1.78x faster than pnpm@HEAD on the peer-heavy DAG;
required at least 10.00x (pacquet 1.651s, pnpm 2.943s)
```

The 10x floor was calibrated on
[the benchmark's own PR run](https://github.com/pnpm/pnpm/actions/runs/30698809461),
whose base predated pnpm/pnpm#13504 — that PR merged nine minutes after the
benchmark run started, and landed on `main` twenty minutes before
pnpm/pnpm#13545 did. pnpm/pnpm#13504 removed exactly the per-edge work this
scenario stresses (`filterPkgMetadataByPublishDate` and semver re-parsing on
every dependency edge, offline hot cache), so the TypeScript arm collapsed:

| target | PR run (pre-13504) | `main` run (post-13504) |
| --- | --- | --- |
| `pacquet@HEAD` | 1.467 s | 1.651 s |
| `pnpm@HEAD` | 34.663 s | 2.943 s |
| ratio | 23.6x | 1.78x |

pacquet did not move; TypeScript pnpm got ~12x faster on this workload. Both
failing `main` runs agree (1.78x and 1.72x), so this is not measurement noise.

This lowers the floor to 1.25x and documents what it is actually guarding.

Related to pnpm/pnpm#13540.

## Squash Commit Body

```text
The peer-heavy scenario asserted that pacquet resolves the fixture at least
10x faster than the TypeScript CLI. That headroom was measured against a base
that still re-filtered the packument and re-parsed semver ranges once per
dependency edge on the offline hot-cache path. pnpm/pnpm#13504 removed that
per-edge work, so the same 401-package DAG now resolves in ~2.9s instead of
~34.4s and the ratio fell to ~1.7x, failing the benchmark on main.

Tie the floor to what the assertion is actually for: a peer-resolution blowup
of the kind pnpm/pnpm#13540 tracked runs slower than the TypeScript CLI (7.0s
versus 2.9s, ~0.4x), so 1.25x clears the run-to-run noise while still catching
it, and no longer breaks whenever the TypeScript resolver gets faster.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.

<!-- The remaining items do not apply: this recalibrates the benchmark's own
regression gate, so there is no separate test to add, no TypeScript
counterpart to mirror, no published package to bump, and no user-facing
documentation to update. -->

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13552"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788181836&installation_model_id=426870&pr_number=13552&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13552&signature=b42a5befebc6923194dc97bf7a355b0e19f7101ad947bb5d612234e14723e1ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance explaining the benchmark speedup threshold.

* **Bug Fixes**
  * Adjusted the minimum expected speedup threshold to better reflect observed benchmark performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->