### PR TITLE
test(pacquet): stabilize the peer-heavy benchmark and stop its gate dropping data

### DIFF
--- a/.github/workflows/pacquet-integrated-benchmark.yml
+++ b/.github/workflows/pacquet-integrated-benchmark.yml
@@ -357,19 +357,40 @@ jobs:
           cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESOLVE_HOT_CACHE_OFFLINE.json
 
       - name: 'Benchmark: Isolated linker: peer-heavy resolve, hot cache, offline'
+        id: peer_heavy
         shell: bash
         # Bit-style dependency DAG whose shared subgraphs expand into many
         # peer-resolution occurrences. The online lockfile-only pass primes
         # each target's metadata mirror; timed runs remove the generated
         # lockfile and resolve offline, isolating peer discovery and resolution.
-        # Three measured runs are enough because the pre-fix regression is
-        # multi-second and deterministic, while keeping the added CI cost
-        # bounded across current Rust, main Rust, and TypeScript pnpm.
-        timeout-minutes: 25
+        #
+        # This fixture's run-to-run spread is wide — a local 15-run pass
+        # measured a ~15% coefficient of variation on an idle machine, with the
+        # slow samples scattered through the sequence rather than clustered at
+        # the start, so the noise is contention rather than a cold cache and
+        # extra warmups would not help. What helps is more samples: the guard
+        # and the reported metric both read the *fastest* run, so nine runs
+        # give that minimum a good chance of landing on an uncontended one.
+        #
+        # The cross-engine ratio assertion inside the harness is a gate, not a
+        # measurement, and it must not cost us the measurement: a failure here
+        # would abort the job before the Bencher upload and drop *every*
+        # scenario's data point for the run (which is why this benchmark has
+        # almost no history — the two main pushes after it was added both
+        # failed on the since-recalibrated 10x floor). Record the verdict and
+        # re-raise it after the upload instead.
+        continue-on-error: true
+        timeout-minutes: 30
         run: |
-          just integrated-benchmark --reuse-prebuilt-binaries --scenario=isolated-linker.peer-heavy-resolve.hot-cache.offline --runs=3 --registry=verdaccio --pnpr-latency-ms=${PNPR_LATENCY_MS} --registry-latency-ms=${REGISTRY_LATENCY_MS} --registry-bandwidth-mbps=${REGISTRY_BANDWIDTH_MBPS} $PEER_HEAVY_BENCHMARK_TARGETS
-          cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_ISOLATED_PEER_HEAVY_RESOLVE_HOT_CACHE_OFFLINE.md
-          cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_ISOLATED_PEER_HEAVY_RESOLVE_HOT_CACHE_OFFLINE.json
+          status=0
+          just integrated-benchmark --reuse-prebuilt-binaries --scenario=isolated-linker.peer-heavy-resolve.hot-cache.offline --runs=9 --registry=verdaccio --pnpr-latency-ms=${PNPR_LATENCY_MS} --registry-latency-ms=${REGISTRY_LATENCY_MS} --registry-bandwidth-mbps=${REGISTRY_BANDWIDTH_MBPS} $PEER_HEAVY_BENCHMARK_TARGETS || status=$?
+          # hyperfine exports both reports before the harness asserts, so a
+          # failed gate still leaves a full measurement to publish. A failure
+          # before hyperfine leaves nothing, and the Bencher build step's jq
+          # then fails the job on the missing input — which is what we want.
+          cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_ISOLATED_PEER_HEAVY_RESOLVE_HOT_CACHE_OFFLINE.md || true
+          cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_ISOLATED_PEER_HEAVY_RESOLVE_HOT_CACHE_OFFLINE.json || true
+          exit $status
 
       - name: 'Benchmark: Isolated linker: fresh restore, cold cache + cold store + cold pnpr'
         shell: bash
@@ -687,3 +708,13 @@ jobs:
           }
           upload pacquet bench-work-env/bencher-results.json
           upload pnpr bench-work-env/bencher-results-pnpr.json
+
+      - name: Re-raise the peer-heavy gate
+        # Deferred from the peer-heavy step so its cross-engine assertion
+        # cannot abort the job before the run's data points are published.
+        # Runs even when an earlier step failed, so the gate is never skipped.
+        if: always() && steps.peer_heavy.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::error::The peer-heavy benchmark step failed; see its log for the assertion or build error."
+          exit 1

--- a/.github/workflows/pacquet-integrated-benchmark.yml
+++ b/.github/workflows/pacquet-integrated-benchmark.yml
@@ -373,12 +373,10 @@ jobs:
         # give that minimum a good chance of landing on an uncontended one.
         #
         # The cross-engine ratio assertion inside the harness is a gate, not a
-        # measurement, and it must not cost us the measurement: a failure here
-        # would abort the job before the Bencher upload and drop *every*
-        # scenario's data point for the run (which is why this benchmark has
-        # almost no history — the two main pushes after it was added both
-        # failed on the since-recalibrated 10x floor). Record the verdict and
-        # re-raise it after the upload instead.
+        # measurement, and it must not cost us the measurement: failing inside
+        # the job aborts it before the Bencher upload, which drops *every*
+        # scenario's data point for the run, not just this one's. Record the
+        # verdict here and re-raise it after the upload instead.
         continue-on-error: true
         timeout-minutes: 30
         run: |
@@ -415,7 +413,10 @@ jobs:
       # per-revision pnpr server logs so the real install error reaches the CI
       # log for diagnosis.
       - name: Dump benchmark install output on failure
-        if: failure()
+        # `steps.peer_heavy` swallows its own failure so the upload can run, so
+        # `failure()` alone would skip these logs for the one scenario whose
+        # gate is deferred.
+        if: failure() || steps.peer_heavy.outcome == 'failure'
         shell: bash
         run: |
           shopt -s nullglob
@@ -577,8 +578,8 @@ jobs:
         # and swung ~30% between runs, tripping a spurious alert on a control
         # run whose HEAD and main binaries were byte-identical). Because the
         # minimum only needs one uncontended run, hyperfine's default sampling
-        # suffices for regular scenarios. The peer-heavy case uses three runs
-        # to keep its cross-engine comparison bounded. The human-readable
+        # suffices for regular scenarios. The peer-heavy case is noisier and
+        # fixes its own count instead. The human-readable
         # comment still reports mean ± σ; only the alerting signal moves to the
         # min.
         #

--- a/pnpm/tasks/integrated-benchmark/src/work_env.rs
+++ b/pnpm/tasks/integrated-benchmark/src/work_env.rs
@@ -1197,16 +1197,29 @@ impl WorkEnv {
         {
             return;
         }
-        let pacquet = benchmark_target_min(diagnostics, "pacquet@HEAD");
-        let pnpm = benchmark_target_min(diagnostics, "pnpm@HEAD");
-        let speedup = pnpm / pacquet;
-        assert!(
-            speedup >= PACQUET_PNPM_SPEEDUP_MIN,
+        if let Err(message) = check_peer_heavy_speedup(diagnostics) {
+            panic!("{message}");
+        }
+    }
+}
+
+/// How much faster pacquet resolved the peer-heavy DAG than the TypeScript CLI,
+/// or the gate's failure message when that is under
+/// [`PACQUET_PNPM_SPEEDUP_MIN`].
+///
+/// Both sides are each target's fastest run: see [`benchmark_target_min`].
+fn check_peer_heavy_speedup(diagnostics: &BenchmarkDiagnostics) -> Result<f64, String> {
+    let pacquet = benchmark_target_min(diagnostics, "pacquet@HEAD");
+    let pnpm = benchmark_target_min(diagnostics, "pnpm@HEAD");
+    let speedup = pnpm / pacquet;
+    if speedup < PACQUET_PNPM_SPEEDUP_MIN {
+        return Err(format!(
             "pacquet@HEAD was only {speedup:.2}x faster than pnpm@HEAD on the peer-heavy DAG; \
              required at least {PACQUET_PNPM_SPEEDUP_MIN:.2}x \
              (pacquet {pacquet:.3}s, pnpm {pnpm:.3}s)",
-        );
+        ));
     }
+    Ok(speedup)
 }
 
 #[derive(Debug, Deserialize)]

--- a/pnpm/tasks/integrated-benchmark/src/work_env.rs
+++ b/pnpm/tasks/integrated-benchmark/src/work_env.rs
@@ -37,6 +37,7 @@ const PNPR_DIRECT_RATIO_MAX: f64 = 1.05;
 // The TypeScript resolver's own hot-cache cost moves independently — offline
 // resolution of this fixture dropped from ~34s to ~3s in pnpm/pnpm#13504 — and
 // a floor tracking that headroom would fail on every TypeScript perf win.
+// Compared on each target's fastest run: see [`benchmark_target_min`].
 const PACQUET_PNPM_SPEEDUP_MIN: f64 = 1.25;
 const PNPR_SERVER_REGISTRY_ENV: &str = "PACQUET_BENCHMARK_PNPR_SERVER_REGISTRY";
 const PNPR_TARBALL_REWRITE_FROM_ENV: &str = "PACQUET_BENCHMARK_PNPR_TARBALL_REWRITE_FROM";
@@ -1092,6 +1093,7 @@ impl WorkEnv {
                 BenchmarkTargetDiagnostics {
                     id,
                     hyperfine_mean_seconds: command.map(|command| command.mean),
+                    hyperfine_min_seconds: command.map(|command| command.min),
                     phase_summary: summarize_phase_events(&phase_events),
                     phase_events,
                 }
@@ -1195,8 +1197,8 @@ impl WorkEnv {
         {
             return;
         }
-        let pacquet = benchmark_target_mean(diagnostics, "pacquet@HEAD");
-        let pnpm = benchmark_target_mean(diagnostics, "pnpm@HEAD");
+        let pacquet = benchmark_target_min(diagnostics, "pacquet@HEAD");
+        let pnpm = benchmark_target_min(diagnostics, "pnpm@HEAD");
         let speedup = pnpm / pacquet;
         assert!(
             speedup >= PACQUET_PNPM_SPEEDUP_MIN,
@@ -1218,6 +1220,7 @@ struct HyperfineCommand {
     #[serde(default)]
     command_name: Option<String>,
     mean: f64,
+    min: f64,
 }
 
 impl HyperfineCommand {
@@ -1236,6 +1239,7 @@ struct BenchmarkDiagnostics {
 struct BenchmarkTargetDiagnostics {
     id: String,
     hyperfine_mean_seconds: Option<f64>,
+    hyperfine_min_seconds: Option<f64>,
     phase_summary: PhaseSummary,
     phase_events: Vec<PhaseEvent>,
 }
@@ -1410,13 +1414,19 @@ fn requires_fresh_pnpr_cold_batch_metrics(target_id: &str) -> bool {
     target_id == "pnpr@HEAD"
 }
 
-fn benchmark_target_mean(diagnostics: &BenchmarkDiagnostics, target_id: &str) -> f64 {
+/// The fastest of a target's timed runs.
+///
+/// Contention on a shared runner only ever *adds* time, so the minimum is the
+/// sample least perturbed by a noisy neighbour and the most stable basis for a
+/// cross-engine comparison. This is the same statistic the workflow reports to
+/// Bencher, for the same reason.
+fn benchmark_target_min(diagnostics: &BenchmarkDiagnostics, target_id: &str) -> f64 {
     diagnostics
         .targets
         .iter()
         .find(|target| target.id == target_id)
-        .and_then(|target| target.hyperfine_mean_seconds)
-        .unwrap_or_else(|| panic!("benchmark report has no mean for required target {target_id}"))
+        .and_then(|target| target.hyperfine_min_seconds)
+        .unwrap_or_else(|| panic!("benchmark report has no min for required target {target_id}"))
 }
 
 fn render_diagnostics_markdown(
@@ -1432,16 +1442,17 @@ fn render_diagnostics_markdown(
         );
     }
     out.push_str(
-        "| Target | hyperfine mean | warm | cold | skipped | CreateVirtualStore mean | link warm mean | link cold mean |\n",
+        "| Target | hyperfine mean | hyperfine min | warm | cold | skipped | CreateVirtualStore mean | link warm mean | link cold mean |\n",
     );
-    out.push_str("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n");
+    out.push_str("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n");
     for target in &diagnostics.targets {
         let partition = target.phase_summary.partition.as_ref();
         let _ = writeln!(
             out,
-            "| {} | {} | {} | {} | {} | {} | {} | {} |",
+            "| {} | {} | {} | {} | {} | {} | {} | {} | {} |",
             target.id,
             format_seconds(target.hyperfine_mean_seconds),
+            format_seconds(target.hyperfine_min_seconds),
             format_u64(partition.map(|metric| metric.warm)),
             format_u64(partition.map(|metric| metric.cold)),
             format_u64(partition.map(|metric| metric.skipped)),

--- a/pnpm/tasks/integrated-benchmark/src/work_env.rs
+++ b/pnpm/tasks/integrated-benchmark/src/work_env.rs
@@ -37,7 +37,7 @@ const PNPR_DIRECT_RATIO_MAX: f64 = 1.05;
 // The TypeScript resolver's own hot-cache cost moves independently — offline
 // resolution of this fixture dropped from ~34s to ~3s in pnpm/pnpm#13504 — and
 // a floor tracking that headroom would fail on every TypeScript perf win.
-// Compared on each target's fastest run: see [`benchmark_target_min`].
+// Compared on each target's fastest run: see `benchmark_target_min`.
 const PACQUET_PNPM_SPEEDUP_MIN: f64 = 1.25;
 const PNPR_SERVER_REGISTRY_ENV: &str = "PACQUET_BENCHMARK_PNPR_SERVER_REGISTRY";
 const PNPR_TARBALL_REWRITE_FROM_ENV: &str = "PACQUET_BENCHMARK_PNPR_TARBALL_REWRITE_FROM";

--- a/pnpm/tasks/integrated-benchmark/src/work_env/tests.rs
+++ b/pnpm/tasks/integrated-benchmark/src/work_env/tests.rs
@@ -202,6 +202,40 @@ fn phase_summary_reports_partition_and_means() {
     }
 }
 
+/// The peer-heavy guard compares each engine's fastest run, not its mean. On a
+/// shared runner one contended sample can drag the mean under the floor while
+/// every uncontended sample clears it comfortably — pnpm/pnpm#13551's CI saw a
+/// 2.83s outlier lift the pacquet mean to 2.15s against a 1.54s fastest run.
+#[test]
+fn peer_heavy_ratio_reads_the_fastest_run_not_the_mean() {
+    let diagnostics = super::BenchmarkDiagnostics {
+        targets: vec![
+            super::BenchmarkTargetDiagnostics {
+                id: "pacquet@HEAD".to_string(),
+                hyperfine_mean_seconds: Some(2.5),
+                hyperfine_min_seconds: Some(1.5),
+                phase_summary: super::PhaseSummary::default(),
+                phase_events: vec![],
+            },
+            super::BenchmarkTargetDiagnostics {
+                id: "pnpm@HEAD".to_string(),
+                hyperfine_mean_seconds: Some(2.9),
+                hyperfine_min_seconds: Some(2.8),
+                phase_summary: super::PhaseSummary::default(),
+                phase_events: vec![],
+            },
+        ],
+        pnpr_direct_ratios: vec![],
+    };
+
+    let speedup = super::benchmark_target_min(&diagnostics, "pnpm@HEAD")
+        / super::benchmark_target_min(&diagnostics, "pacquet@HEAD");
+    let mean_speedup = 2.9 / 2.5;
+    dbg!(speedup, mean_speedup, super::PACQUET_PNPM_SPEEDUP_MIN);
+    assert!(speedup >= super::PACQUET_PNPM_SPEEDUP_MIN);
+    assert!(mean_speedup < super::PACQUET_PNPM_SPEEDUP_MIN);
+}
+
 #[test]
 fn pnpr_direct_ratios_pair_matching_revisions() {
     let commands = HashMap::from([
@@ -211,15 +245,26 @@ fn pnpr_direct_ratios_pair_matching_revisions() {
                 command: "pacquet@HEAD".to_string(),
                 command_name: None,
                 mean: 10.0,
+                min: 10.0,
             },
         ),
         (
             "pnpr@HEAD".to_string(),
-            HyperfineCommand { command: "pnpr@HEAD".to_string(), command_name: None, mean: 8.0 },
+            HyperfineCommand {
+                command: "pnpr@HEAD".to_string(),
+                command_name: None,
+                mean: 8.0,
+                min: 8.0,
+            },
         ),
         (
             "pnpr@main".to_string(),
-            HyperfineCommand { command: "pnpr@main".to_string(), command_name: None, mean: 9.0 },
+            HyperfineCommand {
+                command: "pnpr@main".to_string(),
+                command_name: None,
+                mean: 9.0,
+                min: 9.0,
+            },
         ),
     ]);
 
@@ -288,6 +333,7 @@ fn diagnostics_markdown_includes_create_virtual_store_line_item() {
             targets: vec![super::BenchmarkTargetDiagnostics {
                 id: "pnpr@HEAD".to_string(),
                 hyperfine_mean_seconds: Some(7.5),
+                hyperfine_min_seconds: Some(7.5),
                 phase_summary: super::PhaseSummary {
                     partition: Some(super::PartitionMetric {
                         warm: 12,
@@ -317,6 +363,7 @@ fn diagnostics_markdown_notes_fresh_install_cold_store_tarball_baseline_shift() 
             targets: vec![super::BenchmarkTargetDiagnostics {
                 id: "pnpr@main".to_string(),
                 hyperfine_mean_seconds: Some(1.0),
+                hyperfine_min_seconds: Some(1.0),
                 phase_summary: super::PhaseSummary::default(),
                 phase_events: vec![],
             }],
@@ -337,6 +384,7 @@ fn diagnostics_markdown_omits_baseline_note_after_pnpr_main_is_instrumented() {
             targets: vec![super::BenchmarkTargetDiagnostics {
                 id: "pnpr@main".to_string(),
                 hyperfine_mean_seconds: Some(1.0),
+                hyperfine_min_seconds: Some(1.0),
                 phase_summary: super::PhaseSummary {
                     partition: Some(super::PartitionMetric {
                         warm: 0,

--- a/pnpm/tasks/integrated-benchmark/src/work_env/tests.rs
+++ b/pnpm/tasks/integrated-benchmark/src/work_env/tests.rs
@@ -224,8 +224,11 @@ fn peer_heavy_gate_reads_the_fastest_run_not_the_mean() {
     let diagnostics = peer_heavy_diagnostics((2.5, 1.5), (2.9, 2.8));
 
     let mean_speedup = 2.9 / 2.5;
-    dbg!(mean_speedup, super::PACQUET_PNPM_SPEEDUP_MIN);
-    assert!(mean_speedup < super::PACQUET_PNPM_SPEEDUP_MIN, "fixture must fail on the mean");
+    assert!(
+        mean_speedup < super::PACQUET_PNPM_SPEEDUP_MIN,
+        "fixture must fail on the mean: {mean_speedup} >= {}",
+        super::PACQUET_PNPM_SPEEDUP_MIN,
+    );
 
     let verdict = super::check_peer_heavy_speedup(&diagnostics);
     dbg!(&verdict);
@@ -238,9 +241,8 @@ fn peer_heavy_gate_reads_the_fastest_run_not_the_mean() {
 fn peer_heavy_gate_rejects_a_regression_on_every_sample() {
     let diagnostics = peer_heavy_diagnostics((3.1, 3.0), (2.9, 2.8));
 
-    let verdict = super::check_peer_heavy_speedup(&diagnostics);
-    dbg!(&verdict);
-    let message = verdict.expect_err("a sub-floor speedup must fail the gate");
+    let message = super::check_peer_heavy_speedup(&diagnostics)
+        .expect_err("a sub-floor speedup must fail the gate");
     assert!(message.contains("faster than pnpm@HEAD"), "{message}");
 }
 

--- a/pnpm/tasks/integrated-benchmark/src/work_env/tests.rs
+++ b/pnpm/tasks/integrated-benchmark/src/work_env/tests.rs
@@ -202,38 +202,46 @@ fn phase_summary_reports_partition_and_means() {
     }
 }
 
-/// The peer-heavy guard compares each engine's fastest run, not its mean. On a
-/// shared runner one contended sample can drag the mean under the floor while
-/// every uncontended sample clears it comfortably — pnpm/pnpm#13551's CI saw a
-/// 2.83s outlier lift the pacquet mean to 2.15s against a 1.54s fastest run.
-#[test]
-fn peer_heavy_ratio_reads_the_fastest_run_not_the_mean() {
-    let diagnostics = super::BenchmarkDiagnostics {
-        targets: vec![
-            super::BenchmarkTargetDiagnostics {
-                id: "pacquet@HEAD".to_string(),
-                hyperfine_mean_seconds: Some(2.5),
-                hyperfine_min_seconds: Some(1.5),
-                phase_summary: super::PhaseSummary::default(),
-                phase_events: vec![],
-            },
-            super::BenchmarkTargetDiagnostics {
-                id: "pnpm@HEAD".to_string(),
-                hyperfine_mean_seconds: Some(2.9),
-                hyperfine_min_seconds: Some(2.8),
-                phase_summary: super::PhaseSummary::default(),
-                phase_events: vec![],
-            },
-        ],
-        pnpr_direct_ratios: vec![],
+fn peer_heavy_diagnostics(pacquet: (f64, f64), pnpm: (f64, f64)) -> super::BenchmarkDiagnostics {
+    let target = |id: &str, (mean, min): (f64, f64)| super::BenchmarkTargetDiagnostics {
+        id: id.to_string(),
+        hyperfine_mean_seconds: Some(mean),
+        hyperfine_min_seconds: Some(min),
+        phase_summary: super::PhaseSummary::default(),
+        phase_events: vec![],
     };
+    super::BenchmarkDiagnostics {
+        targets: vec![target("pacquet@HEAD", pacquet), target("pnpm@HEAD", pnpm)],
+        pnpr_direct_ratios: vec![],
+    }
+}
 
-    let speedup = super::benchmark_target_min(&diagnostics, "pnpm@HEAD")
-        / super::benchmark_target_min(&diagnostics, "pacquet@HEAD");
+/// On a shared runner one contended sample drags a target's mean well past its
+/// uncontended runs, so the gate reads each engine's fastest run instead. These
+/// timings clear the floor on the minimum and fall under it on the mean.
+#[test]
+fn peer_heavy_gate_reads_the_fastest_run_not_the_mean() {
+    let diagnostics = peer_heavy_diagnostics((2.5, 1.5), (2.9, 2.8));
+
     let mean_speedup = 2.9 / 2.5;
-    dbg!(speedup, mean_speedup, super::PACQUET_PNPM_SPEEDUP_MIN);
-    assert!(speedup >= super::PACQUET_PNPM_SPEEDUP_MIN);
-    assert!(mean_speedup < super::PACQUET_PNPM_SPEEDUP_MIN);
+    dbg!(mean_speedup, super::PACQUET_PNPM_SPEEDUP_MIN);
+    assert!(mean_speedup < super::PACQUET_PNPM_SPEEDUP_MIN, "fixture must fail on the mean");
+
+    let verdict = super::check_peer_heavy_speedup(&diagnostics);
+    dbg!(&verdict);
+    assert!(verdict.is_ok(), "gate must clear the floor on the fastest runs");
+}
+
+/// A genuine blowup lands below the floor on every sample, so the gate must
+/// still reject it.
+#[test]
+fn peer_heavy_gate_rejects_a_regression_on_every_sample() {
+    let diagnostics = peer_heavy_diagnostics((3.1, 3.0), (2.9, 2.8));
+
+    let verdict = super::check_peer_heavy_speedup(&diagnostics);
+    dbg!(&verdict);
+    let message = verdict.expect_err("a sub-floor speedup must fail the gate");
+    assert!(message.contains("faster than pnpm@HEAD"), "{message}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Two related problems with `isolated-linker.peer-heavy-resolve.hot-cache.offline`: it flakes, and its gate has been silently destroying the run's benchmark data.

**It flakes.** A local 15-run pass on an idle machine measured a ~15% coefficient of variation, with the slow samples scattered through the sequence rather than clustered at the start — so the noise is runner contention, not a cold cache, and more warmups would not help. CI runs the scenario at `--runs=3` and gates on the *mean*, which is exactly the statistic that spread destroys. On pnpm/pnpm#13551 a single 2.83s outlier lifted the pacquet mean to 2.15s against a 1.54s fastest run, and the gate passed at 1.34x against its 1.25x floor — a 7% margin on a branch that was a provably pure code move.

Local, same fixture, 15 runs per target, that PR's head vs. its merge base:

| target | mean | median | min | sd |
|---|---|---|---|---|
| PR head | 1.399s | 1.338s | 1.076s | ±0.264 |
| merge base | 1.486s | 1.394s | 1.176s | ±0.211 |

Welch t = −1.00, 95% CI of the difference −0.261s … +0.088s. Indistinguishable, as a pure move under `lto = "fat"` / `codegen-units = 1` must be.

**Its gate drops the data.** `verify_peer_heavy_pacquet_pnpm_ratio` asserts in the middle of the job. A failure there aborts before the Bencher upload, so *every* scenario in that run loses its data point. That is why this benchmark has almost no history: the two `main` pushes after it was added (e2f439ba4e, 3f900cd042) both failed on the since-recalibrated 10x floor, so nothing uploaded at all. Only one point has ever been published — 1,247 ms from 5cf3a9698e — against 395 for `isolated-linker.fresh-resolve.hot-cache.offline`.

## Changes

- **Gate on each target's fastest run, not its mean.** Contention only ever adds time, so the minimum is the sample least perturbed by a noisy neighbour. This is already the statistic the workflow reports to Bencher, and the [existing comment there](https://github.com/pnpm/pnpm/blob/main/.github/workflows/pacquet-integrated-benchmark.yml) gives the same reasoning; the gate just wasn't following it. `HyperfineCommand` now deserializes `min`, and the diagnostics table shows both mean and min.
- **`--runs=3` → `--runs=9`** for this scenario, so that minimum has a good chance of landing on an uncontended run. No warmup change: the data says warmups are not the problem.
- **Defer the gate past the upload.** The step records its verdict and a final `Re-raise the peer-heavy gate` step fails the job afterwards, so a genuine regression still fails CI but the run's measurements are published either way. Report files are copied unconditionally — hyperfine exports them before the harness asserts. A failure *before* hyperfine still leaves nothing, and the Bencher build step's `jq` then fails the job on the missing input, which is the behavior we want.

## Not changed

The 1.25x floor itself, set in pnpm/pnpm#13552. With the gate reading the min it has much more headroom (that PR's CI data gives 2.85/1.54 = 1.85x), so recalibrating on top of a statistic change would confound the two.

## Squash Commit Body

```text
The peer-heavy resolver fixture has a wide run-to-run spread — a local 15-run
pass measured a ~15% coefficient of variation on an idle machine, with the slow
samples scattered through the sequence rather than clustered at the start, so
the noise is runner contention rather than a cold cache. Three CI runs against
that spread produced a 2.83s outlier on pnpm/pnpm#13551 that lifted the pacquet
mean to 2.15s while its fastest run sat at 1.54s, inside main's range.

Compare the cross-engine gate on each target's fastest run instead of its mean.
Contention only ever adds time, so the minimum is the sample least perturbed by
a noisy neighbour; this is already the statistic the workflow reports to
Bencher, for the same reason. Raise the scenario to nine runs so that minimum
has a good chance of landing on an uncontended run, and surface both mean and
min in the diagnostics table.

The gate is a correctness check, not a measurement, and it was costing us the
measurement: asserting mid-job aborted before the Bencher upload and dropped
every scenario's data point for the whole run. That is why this benchmark has
almost no history on bencher.dev — the two main pushes after it was added both
failed on the since-recalibrated 10x floor, so only one point was ever
published. Record the verdict, let the upload proceed, and re-raise the failure
afterwards.

Pacquet-only benchmark-harness and CI change; no user-visible surface, no
TypeScript counterpart, and no changeset.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] Pacquet-only benchmark-harness and CI change; no user-visible surface, so no TypeScript counterpart.
- [x] No changeset: no published package changes.
- [x] Added a regression test pinning the gate to the fastest run (`peer_heavy_ratio_reads_the_fastest_run_not_the_mean`) with a fixture whose mean fails the floor and whose min clears it.

---
Written by an agent (Claude Code, claude-opus-5[1m]).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788186968&installation_model_id=426870&pr_number=13559&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13559&signature=68d848a5ae0cccda021426d71c4e17be4f6b1a94e75d1ab4d375aa0a88e89d1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved benchmark comparisons by using the fastest recorded runtime instead of average runtime.
  * Added clearer benchmark diagnostics, including minimum runtime data.
  * Benchmark workflows now run consistently, preserve and publish reports after failures, and accurately report final status.

* **Tests**
  * Added regression coverage for fastest-run benchmark comparisons.
  * Updated benchmark validation to run nine iterations and capture reliable failure results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->