### PR TITLE
test(resolving-deps-resolver): improve final graph diagnostics and min-depth coverage

### DIFF
--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/finalize/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/finalize/tests.rs
@@ -10,7 +10,10 @@ use crate::{
 };
 use pacquet_deps_path::DepPath;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
-use std::{collections::BTreeMap, sync::Arc};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
 
 #[test]
 fn final_graph_keeps_first_equal_depth_payload_and_unions_transitive_peers() {
@@ -150,6 +153,9 @@ fn final_graph_peer_edge_keeps_the_providers_own_peer_suffix() {
     let provider_analyzer = NodeId::next();
     let provider_bare = NodeId::next();
     let consumer = NodeId::next();
+    // A shallower `find_hit` revisit: short-circuited before a `NodeRecord`
+    // was created, so only `node_dep_paths` carries its depth.
+    let consumer_revisit = NodeId::next();
 
     let provider_analyzer_dep_path = DepPath::from(
         "webpack-cli@6.0.1(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.2)(webpack@5.107.2)",
@@ -191,6 +197,7 @@ fn final_graph_peer_edge_keeps_the_providers_own_peer_suffix() {
             (provider_analyzer.clone(), tree_node("webpack-cli@6.0.1", BTreeMap::new(), 0)),
             (provider_bare.clone(), tree_node("webpack-cli@6.0.1", BTreeMap::new(), 0)),
             (consumer.clone(), tree_node("@webpack-cli/serve@3.0.1", BTreeMap::new(), 1)),
+            (consumer_revisit.clone(), tree_node("@webpack-cli/serve@3.0.1", BTreeMap::new(), 0)),
         ]),
         all_peer_dep_names: HashSet::from_iter([
             "webpack".to_string(),
@@ -203,6 +210,10 @@ fn final_graph_peer_edge_keeps_the_providers_own_peer_suffix() {
         children_by_id: HashMap::default(),
     };
     let mut walker = walker_for_tests(&mut tree);
+    walker.node_dep_paths.insert(provider_analyzer.clone(), provider_analyzer_dep_path.clone());
+    walker.node_dep_paths.insert(provider_bare.clone(), provider_bare_dep_path.clone());
+    walker.node_dep_paths.insert(consumer.clone(), consumer_dep_path.clone());
+    walker.node_dep_paths.insert(consumer_revisit.clone(), consumer_dep_path.clone());
     walker.node_records.insert(
         provider_analyzer.clone(),
         NodeRecord {
@@ -265,19 +276,28 @@ fn final_graph_peer_edge_keeps_the_providers_own_peer_suffix() {
         (provider_analyzer, provider_analyzer_dep_path.clone()),
         (provider_bare, provider_bare_dep_path),
         (consumer, consumer_dep_path.clone()),
+        (consumer_revisit, consumer_dep_path.clone()),
     ]));
 
     assert_eq!(
         graph[&consumer_dep_path].children.get("webpack-cli"),
         Some(&provider_analyzer_dep_path),
     );
-    assert!(!graph.contains_key(&trimmed_dep_path), "no variant is fabricated for the edge");
+    assert_eq!(graph[&consumer_dep_path].depth, 0);
+    assert!(
+        !graph.contains_key(&trimmed_dep_path),
+        "no variant is fabricated for the edge; final graph keys: {:#?}",
+        graph.keys().collect::<BTreeSet<_>>(),
+    );
 }
 
 #[test]
 fn final_graph_peer_edge_keeps_provider_transitive_peer_suffixes() {
     let provider = NodeId::next();
     let consumer = NodeId::next();
+    // A shallower `find_hit` revisit: short-circuited before a `NodeRecord`
+    // was created, so only `node_dep_paths` carries its depth.
+    let provider_revisit = NodeId::next();
 
     let provider_dep_path = DepPath::from(
         "webpack-dev-server@5.2.2(bufferutil@4.1.0)(tslib@2.8.1)(utf-8-validate@5.0.10)(webpack-cli@6.0.1)(webpack@5.107.2)",
@@ -316,6 +336,7 @@ fn final_graph_peer_edge_keeps_provider_transitive_peer_suffixes() {
         ]),
         dependencies_tree: HashMap::from_iter([
             (provider.clone(), tree_node("webpack-dev-server@5.2.2", BTreeMap::new(), 1)),
+            (provider_revisit.clone(), tree_node("webpack-dev-server@5.2.2", BTreeMap::new(), 0)),
             (consumer.clone(), tree_node("webpack-cli@6.0.1", BTreeMap::new(), 0)),
         ]),
         all_peer_dep_names: HashSet::from_iter([
@@ -332,6 +353,9 @@ fn final_graph_peer_edge_keeps_provider_transitive_peer_suffixes() {
         children_by_id: HashMap::default(),
     };
     let mut walker = walker_for_tests(&mut tree);
+    walker.node_dep_paths.insert(provider.clone(), provider_dep_path.clone());
+    walker.node_dep_paths.insert(provider_revisit.clone(), provider_dep_path.clone());
+    walker.node_dep_paths.insert(consumer.clone(), consumer_dep_path.clone());
     walker.node_records.insert(
         provider.clone(),
         NodeRecord {
@@ -381,6 +405,7 @@ fn final_graph_peer_edge_keeps_provider_transitive_peer_suffixes() {
 
     let graph = walker.build_final_graph(&HashMap::from_iter([
         (provider, provider_dep_path.clone()),
+        (provider_revisit, provider_dep_path.clone()),
         (consumer, consumer_dep_path.clone()),
     ]));
 
@@ -388,5 +413,10 @@ fn final_graph_peer_edge_keeps_provider_transitive_peer_suffixes() {
         graph[&consumer_dep_path].children.get("webpack-dev-server"),
         Some(&provider_dep_path),
     );
-    assert!(!graph.contains_key(&trimmed_provider_dep_path));
+    assert_eq!(graph[&provider_dep_path].depth, 0);
+    assert!(
+        !graph.contains_key(&trimmed_provider_dep_path),
+        "no trimmed provider variant is fabricated; final graph keys: {:#?}",
+        graph.keys().collect::<BTreeSet<_>>(),
+    );
 }


### PR DESCRIPTION
## Summary

Two test-only follow-ups deferred from the peer-resolver modularization
(pnpm/pnpm#13551), which preserved moved test bodies byte-for-byte.

`final_graph_peer_edge_keeps_the_providers_own_peer_suffix` and
`final_graph_peer_edge_keeps_provider_transitive_peer_suffixes` left
`walker.node_dep_paths` empty, so `Walker::build_final_graph` skipped its
`min_depth` pass entirely and every node's depth fell back to `record.depth`.
Each test now registers a shallower `find_hit` revisit — walked, so it has a
`node_dep_paths` entry, but short-circuited before a `NodeRecord` was created —
and asserts the merged graph node takes that shallower depth. Both new
assertions were verified to fail when the `min_depth` lookup is replaced by
`record.depth`.

The bare `assert!` flagged in the review comment now prints the final graph
keys on failure (collected into a `BTreeSet`, so the output is deterministic);
its sibling assertion in the neighbouring test gets the same context so the
pair stays consistent.

No resolver behavior changes; the resolver-structure follow-ups in
pnpm/pnpm#13553 and pnpm/pnpm#13554 are untouched.

Closes pnpm/pnpm#13555

## Squash Commit Body

```text
The two final-graph tests that exercise peer-edge suffixes left
`node_dep_paths` empty, so `build_final_graph` skipped its `min_depth` pass
entirely and every node's depth came from the fallback `record.depth`. Each
test now registers a shallower `find_hit` revisit — walked, so it has a
`node_dep_paths` entry, but short-circuited before a `NodeRecord` was created —
and asserts the merged node takes that shallower depth. Both new assertions
fail when the `min_depth` lookup is replaced by `record.depth`.

The bare `assert!` that no trimmed provider variant is fabricated now prints
the final graph keys, as does its sibling in the neighbouring test, so a
failure shows which variants were built.

Closes pnpm/pnpm#13555
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (Rust-only test change — nothing to mirror.)
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5[1m]).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13560"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788189827&installation_model_id=426870&pr_number=13560&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13560&signature=0c5a5b12fdbeaad656a3b1cca3b222776b91cb1529306613c07ca019126d9f00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for dependency resolution when revisiting shallower nodes.
  * Verified that dependency graph depth and provider paths remain correct.
  * Confirmed that unnecessary dependency-path variants are not generated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->