### PR TITLE
Fix/13556 exclude links lockfile relative

### DIFF
--- a/.changeset/fix-exclude-links-lockfile-relative-path.md
+++ b/.changeset/fix-exclude-links-lockfile-relative-path.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed an issue where `excludeLinksFromLockfile` incorrectly remaps workspace-internal `link:` dependencies by resolving relative link targets against the importer's `project_dir` before performing the subdirectory containment check.

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -3867,7 +3867,14 @@ fn remap_link_node_id(
         _ => return None,
     };
     let link_target = std::path::Path::new(directory);
-    if pacquet_fs::is_subdir(lockfile_dir, link_target) {
+    let absolute_target = if link_target.is_absolute() {
+        std::borrow::Cow::Borrowed(link_target)
+    } else if let Some(project_dir) = &opts.project_dir {
+        std::borrow::Cow::Owned(project_dir.join(link_target))
+    } else {
+        std::borrow::Cow::Borrowed(link_target)
+    };
+    if pacquet_fs::is_subdir(lockfile_dir, &absolute_target) {
         return None;
     }
     let target = modules_dir.join(alias);

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -1,6 +1,6 @@
 use super::{
     ImporterPeerInput, NodeOutput, NodeRecord, ParentRef, PeerDiscoveryCaches, ResolvePeersOptions,
-    Walker, importer_relative_link_dep_path, peer_segment_names, resolve_peers,
+    Walker, importer_relative_link_dep_path, peer_segment_names, remap_link_node_id, resolve_peers,
     resolve_peers_workspace, satisfies_with_prereleases, scoped_hoisted_optional_parent_refs,
     should_retain_materialized_node,
 };
@@ -2261,6 +2261,112 @@ fn resolve_result(name: &str, version: &str) -> ResolveResult {
         alias: Some(name.to_string()),
         policy_violation: None,
     }
+}
+
+#[test]
+fn test_remap_link_node_id_containment() {
+    use std::path::PathBuf;
+
+    let lockfile_dir = PathBuf::from("/ws");
+    let modules_dir = lockfile_dir.join("packages/app/node_modules");
+    let project_dir = lockfile_dir.join("packages/app");
+
+    let mut opts = ResolvePeersOptions {
+        peers_suffix_max_length: 1000,
+        dedupe_peers: false,
+        exclude_links_from_lockfile: true,
+        lockfile_dir: Some(lockfile_dir),
+        project_dir: Some(project_dir),
+        modules_dir: Some(modules_dir),
+        ..ResolvePeersOptions::default()
+    };
+
+    // Case 1: Relative link target inside workspace (lockfile_dir)
+    // e.g. from /ws/packages/app, "../lib" resolves to /ws/packages/lib
+    // Since it is inside /ws, it must return None.
+    let result_internal_rel = ResolveResult {
+        id: PkgResolutionId::from("link:../lib"),
+        name_ver: None,
+        latest: None,
+        published_at: None,
+        manifest: None,
+        resolution: LockfileResolution::Directory(DirectoryResolution {
+            directory: "../lib".to_string(),
+        }),
+        resolved_via: "workspace".to_string(),
+        normalized_bare_specifier: None,
+        alias: Some("lib".to_string()),
+        policy_violation: None,
+    };
+    assert_eq!(remap_link_node_id(&opts, "lib", &result_internal_rel), None,);
+
+    // Case 2: Relative link target outside workspace (lockfile_dir)
+    // e.g. from /ws/packages/app, "../../../external" resolves to /external
+    // Since it is outside /ws, it must return Some(NodeId::leaf("link:..."))
+    let result_external_rel = ResolveResult {
+        id: PkgResolutionId::from("link:../../../external"),
+        name_ver: None,
+        latest: None,
+        published_at: None,
+        manifest: None,
+        resolution: LockfileResolution::Directory(DirectoryResolution {
+            directory: "../../../external".to_string(),
+        }),
+        resolved_via: "workspace".to_string(),
+        normalized_bare_specifier: None,
+        alias: Some("external".to_string()),
+        policy_violation: None,
+    };
+    assert_eq!(
+        remap_link_node_id(&opts, "external", &result_external_rel),
+        Some(NodeId::leaf("link:packages/app/node_modules/external")),
+    );
+
+    // Case 3: Absolute link target inside workspace (lockfile_dir)
+    // e.g. "/ws/packages/lib" is inside /ws
+    // It must return None.
+    let result_internal_abs = ResolveResult {
+        id: PkgResolutionId::from("link:/ws/packages/lib"),
+        name_ver: None,
+        latest: None,
+        published_at: None,
+        manifest: None,
+        resolution: LockfileResolution::Directory(DirectoryResolution {
+            directory: "/ws/packages/lib".to_string(),
+        }),
+        resolved_via: "workspace".to_string(),
+        normalized_bare_specifier: None,
+        alias: Some("lib".to_string()),
+        policy_violation: None,
+    };
+    assert_eq!(remap_link_node_id(&opts, "lib", &result_internal_abs), None,);
+
+    // Case 4: Absolute link target outside workspace (lockfile_dir)
+    // e.g. "/external" is outside /ws
+    // It must return Some(NodeId::leaf("link:..."))
+    let result_external_abs = ResolveResult {
+        id: PkgResolutionId::from("link:/external"),
+        name_ver: None,
+        latest: None,
+        published_at: None,
+        manifest: None,
+        resolution: LockfileResolution::Directory(DirectoryResolution {
+            directory: "/external".to_string(),
+        }),
+        resolved_via: "workspace".to_string(),
+        normalized_bare_specifier: None,
+        alias: Some("external".to_string()),
+        policy_violation: None,
+    };
+    assert_eq!(
+        remap_link_node_id(&opts, "external", &result_external_abs),
+        Some(NodeId::leaf("link:packages/app/node_modules/external")),
+    );
+
+    // Case 5: exclude_links_from_lockfile is false
+    // It must return None regardless of where it is.
+    opts.exclude_links_from_lockfile = false;
+    assert_eq!(remap_link_node_id(&opts, "external", &result_external_abs), None,);
 }
 
 /// Ported from upstream `resolvePeers.ts`'s `locked peer provider

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -2298,7 +2298,7 @@ fn test_remap_link_node_id_containment() {
         alias: Some("lib".to_string()),
         policy_violation: None,
     };
-    assert_eq!(remap_link_node_id(&opts, "lib", &result_internal_rel), None,);
+    assert_eq!(remap_link_node_id(&opts, "lib", &result_internal_rel), None);
 
     // Case 2: Relative link target outside workspace (lockfile_dir)
     // e.g. from /ws/packages/app, "../../../external" resolves to /external
@@ -2339,7 +2339,7 @@ fn test_remap_link_node_id_containment() {
         alias: Some("lib".to_string()),
         policy_violation: None,
     };
-    assert_eq!(remap_link_node_id(&opts, "lib", &result_internal_abs), None,);
+    assert_eq!(remap_link_node_id(&opts, "lib", &result_internal_abs), None);
 
     // Case 4: Absolute link target outside workspace (lockfile_dir)
     // e.g. "/external" is outside /ws
@@ -2366,7 +2366,7 @@ fn test_remap_link_node_id_containment() {
     // Case 5: exclude_links_from_lockfile is false
     // It must return None regardless of where it is.
     opts.exclude_links_from_lockfile = false;
-    assert_eq!(remap_link_node_id(&opts, "external", &result_external_abs), None,);
+    assert_eq!(remap_link_node_id(&opts, "external", &result_external_abs), None);
 }
 
 /// Ported from upstream `resolvePeers.ts`'s `locked peer provider


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

This PR fixes a bug in `pacquet` (the Rust CLI) where workspace-internal `link:` dependencies were incorrectly remapped when `excludeLinksFromLockfile` was enabled. 

The issue occurred because the resolver checked whether a link target was inside the workspace by calling `pacquet_fs::is_subdir` using a relative target directory (e.g. `../lib`), which failed to match the absolute `lockfile_dir` coordinate system. We now resolve relative target directories against the importer's `project_dir` prior to checking containment.

Closes pnpm/pnpm#13556.

## Squash Commit Body

The function `remap_link_node_id` in `pacquet-resolving-deps-resolver` checks if a link target directory is inside `lockfile_dir` using `pacquet_fs::is_subdir`. However, `is_subdir` is purely lexical and does not resolve relative paths against a base. For workspace `link:` dependencies, targets are emitted relative to the importer's `project_dir` rather than `lockfile_dir` (e.g., `../lib` instead of `/ws/packages/lib`). Because of this difference in coordinate systems, the check would fail and the internal link was incorrectly remapped.

To fix this, we resolve the relative link target path against `project_dir` before passing it to `is_subdir`. If `project_dir` is missing (e.g., in unit tests) or the target path is absolute, it falls back to the original target.

Closes pnpm/pnpm#13556.

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [ ] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  *(Note: This fix is Rust-only; `excludeLinksFromLockfile` has no counterpart in the TypeScript CLI.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13561"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788190203&installation_model_id=426870&pr_number=13561&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13561&signature=7102e5e20383feb250e5c06d0ca0fb19ef76ab9eb7d7631b46e0548309fbe49b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed workspace-internal relative link dependencies being incorrectly remapped in lockfiles.
  - Improved handling of relative and absolute link targets, ensuring only links outside the workspace are remapped.
  - Preserved expected behavior when link exclusion is disabled.

- **Tests**
  - Added coverage for internal, external, relative, and absolute link targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->