### PR TITLE
fix(pacquet): keep workspace-internal links out of the excludeLinksFromLockfile remap

### DIFF
--- a/.changeset/exclude-links-keeps-workspace-internal-links.md
+++ b/.changeset/exclude-links-keeps-workspace-internal-links.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+With `excludeLinksFromLockfile` enabled, a `link:` dependency pointing inside the workspace is no longer treated as an external link when it resolves a peer dependency, so the peer suffixes it produces stay identical to an install with the setting off. Injected (`file:`) workspace dependencies are no longer affected by the setting either [#13556](https://github.com/pnpm/pnpm/issues/13556).

--- a/pnpm/crates/cli/tests/exclude_links_from_lockfile.rs
+++ b/pnpm/crates/cli/tests/exclude_links_from_lockfile.rs
@@ -1,0 +1,100 @@
+//! End-to-end coverage for the `excludeLinksFromLockfile` setting.
+
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
+use std::{fmt::Write as _, fs, path::Path};
+
+/// The setting only keeps the machine-dependent path of an *external*
+/// link out of the lockfile. A workspace-internal link resolving a peer
+/// dependency is already stable across machines, so its peer suffix and
+/// snapshot edge must come out exactly as they do with the setting off.
+#[test]
+fn workspace_internal_link_peer_is_unaffected_by_exclude_links_from_lockfile() {
+    let with_setting = install_workspace_with_linked_peer(true);
+    let without_setting = install_workspace_with_linked_peer(false);
+
+    let snapshot_key = concat!(
+        "@pnpm.e2e/abc@1.0.0",
+        "(@pnpm.e2e/peer-a@packages+peer-a)",
+        "(@pnpm.e2e/peer-b@1.0.0)",
+        "(@pnpm.e2e/peer-c@1.0.0)",
+    );
+    for (lockfile, exclude_links) in [(&with_setting, true), (&without_setting, false)] {
+        assert!(
+            lockfile.contains(snapshot_key),
+            "the workspace link must keep its own path in the peer suffix with \
+             excludeLinksFromLockfile: {exclude_links}\n{lockfile}",
+        );
+        assert!(
+            !lockfile.contains("node_modules+peer-a"),
+            "the workspace link must not be remapped to the importer's node_modules with \
+             excludeLinksFromLockfile: {exclude_links}\n{lockfile}",
+        );
+    }
+    assert_eq!(
+        with_setting.replace("excludeLinksFromLockfile: true", "excludeLinksFromLockfile: false"),
+        without_setting,
+        "only the recorded setting itself may differ",
+    );
+}
+
+/// Workspace whose `packages/app` depends on a registry package with
+/// peer dependencies, one of which is provided by the sibling workspace
+/// package `packages/peer-a`. Returns the resulting `pnpm-lock.yaml`.
+fn install_workspace_with_linked_peer(exclude_links_from_lockfile: bool) -> String {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "name": "ws-root", "version": "0.0.0", "private": true }).to_string(),
+    )
+    .expect("write root package.json");
+
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    if !workspace_yaml.ends_with('\n') {
+        workspace_yaml.push('\n');
+    }
+    workspace_yaml.push_str("packages:\n  - 'packages/*'\n");
+    writeln!(workspace_yaml, "excludeLinksFromLockfile: {exclude_links_from_lockfile}")
+        .expect("append the setting to pnpm-workspace.yaml");
+    fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
+
+    write_project(
+        &workspace,
+        "packages/app",
+        &serde_json::json!({
+            "name": "app",
+            "version": "1.0.0",
+            "dependencies": {
+                "@pnpm.e2e/abc": "1.0.0",
+                "@pnpm.e2e/peer-a": "workspace:*",
+                "@pnpm.e2e/peer-b": "1.0.0",
+                "@pnpm.e2e/peer-c": "1.0.0",
+            },
+        }),
+    );
+    write_project(
+        &workspace,
+        "packages/peer-a",
+        &serde_json::json!({ "name": "@pnpm.e2e/peer-a", "version": "1.0.0" }),
+    );
+
+    pacquet.with_arg("install").with_arg("--lockfile-only").assert().success();
+    let lockfile =
+        fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read pnpm-lock.yaml");
+
+    drop((root, mock_instance));
+    lockfile
+}
+
+fn write_project(workspace: &Path, relative_dir: &str, manifest: &serde_json::Value) {
+    let project_dir = workspace.join(relative_dir);
+    fs::create_dir_all(&project_dir).expect("create project directory");
+    fs::write(project_dir.join("package.json"), manifest.to_string())
+        .expect("write project manifest");
+}

--- a/pnpm/crates/cli/tests/exclude_links_from_lockfile.rs
+++ b/pnpm/crates/cli/tests/exclude_links_from_lockfile.rs
@@ -5,8 +5,9 @@ pub mod _utils;
 use _utils::append_workspace_yaml_key;
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
+use pacquet_lockfile::{Lockfile, PackageKey, PkgName, SnapshotDepRef};
 use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
-use std::{fs, path::Path};
+use std::{fs, path::Path, str::FromStr};
 
 /// The setting only keeps the machine-dependent path of an *external*
 /// link out of the lockfile. A workspace-internal link resolving a peer
@@ -14,41 +15,46 @@ use std::{fs, path::Path};
 /// snapshot edge must come out exactly as they do with the setting off.
 #[test]
 fn workspace_internal_link_peer_is_unaffected_by_exclude_links_from_lockfile() {
-    let with_setting = install_workspace_with_linked_peer(true);
+    let mut with_setting = install_workspace_with_linked_peer(true);
     let without_setting = install_workspace_with_linked_peer(false);
 
-    let snapshot_key = concat!(
+    let snapshot_key = PackageKey::from_str(concat!(
         "@pnpm.e2e/abc@1.0.0",
         "(@pnpm.e2e/peer-a@packages+peer-a)",
         "(@pnpm.e2e/peer-b@1.0.0)",
         "(@pnpm.e2e/peer-c@1.0.0)",
-    );
+    ))
+    .expect("parse the expected snapshot key");
+    let peer_name = PkgName::parse("@pnpm.e2e/peer-a").expect("parse the peer name");
     for (lockfile, exclude_links) in [(&with_setting, true), (&without_setting, false)] {
-        assert!(
-            lockfile.contains(snapshot_key),
-            "the workspace link must keep its own path in the peer suffix with \
-             excludeLinksFromLockfile: {exclude_links}\n{lockfile}",
-        );
-        assert!(
-            !lockfile.contains("node_modules+peer-a"),
+        let snapshots = lockfile.snapshots.as_ref().expect("the lockfile has snapshots");
+        dbg!(snapshots.keys().collect::<Vec<_>>());
+        let snapshot = snapshots.get(&snapshot_key).unwrap_or_else(|| {
+            panic!(
+                "the workspace link must keep its own path in the peer suffix with \
+                 excludeLinksFromLockfile: {exclude_links}",
+            )
+        });
+        assert_eq!(
+            snapshot.dependencies.as_ref().and_then(|deps| deps.get(&peer_name)),
+            Some(&SnapshotDepRef::Link("packages/peer-a".to_string())),
             "the workspace link must not be remapped to the importer's node_modules with \
-             excludeLinksFromLockfile: {exclude_links}\n{lockfile}",
+             excludeLinksFromLockfile: {exclude_links}",
         );
     }
-    let with_setting_normalized =
-        with_setting.replace("excludeLinksFromLockfile: true", "excludeLinksFromLockfile: false");
-    eprintln!("WITH SETTING:\n{with_setting_normalized}\n");
-    eprintln!("WITHOUT SETTING:\n{without_setting}\n");
-    assert_eq!(
-        with_setting_normalized, without_setting,
-        "only the recorded setting itself may differ",
-    );
+
+    // Structural rather than textual: the invariant is that the setting
+    // changes nothing else, not that the two files serialize identically.
+    let settings = with_setting.settings.as_mut().expect("the lockfile records its settings");
+    settings.exclude_links_from_lockfile = false;
+    dbg!(&with_setting, &without_setting);
+    assert_eq!(with_setting, without_setting, "only the recorded setting itself may differ");
 }
 
 /// Workspace whose `packages/app` depends on a registry package with
 /// peer dependencies, one of which is provided by the sibling workspace
 /// package `packages/peer-a`. Returns the resulting `pnpm-lock.yaml`.
-fn install_workspace_with_linked_peer(exclude_links_from_lockfile: bool) -> String {
+fn install_workspace_with_linked_peer(exclude_links_from_lockfile: bool) -> Lockfile {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();
     let AddMockedRegistry { mock_instance, .. } = npmrc_info;
@@ -83,8 +89,8 @@ fn install_workspace_with_linked_peer(exclude_links_from_lockfile: bool) -> Stri
     );
 
     pacquet.with_arg("install").with_arg("--lockfile-only").assert().success();
-    let lockfile =
-        fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read pnpm-lock.yaml");
+    let text = fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read pnpm-lock.yaml");
+    let lockfile = serde_saphyr::from_str(&text).expect("parse pnpm-lock.yaml");
 
     drop((root, mock_instance));
     lockfile

--- a/pnpm/crates/cli/tests/exclude_links_from_lockfile.rs
+++ b/pnpm/crates/cli/tests/exclude_links_from_lockfile.rs
@@ -35,9 +35,12 @@ fn workspace_internal_link_peer_is_unaffected_by_exclude_links_from_lockfile() {
              excludeLinksFromLockfile: {exclude_links}\n{lockfile}",
         );
     }
+    let with_setting_normalized =
+        with_setting.replace("excludeLinksFromLockfile: true", "excludeLinksFromLockfile: false");
+    eprintln!("WITH SETTING:\n{with_setting_normalized}\n");
+    eprintln!("WITHOUT SETTING:\n{without_setting}\n");
     assert_eq!(
-        with_setting.replace("excludeLinksFromLockfile: true", "excludeLinksFromLockfile: false"),
-        without_setting,
+        with_setting_normalized, without_setting,
         "only the recorded setting itself may differ",
     );
 }

--- a/pnpm/crates/cli/tests/exclude_links_from_lockfile.rs
+++ b/pnpm/crates/cli/tests/exclude_links_from_lockfile.rs
@@ -1,9 +1,12 @@
 //! End-to-end coverage for the `excludeLinksFromLockfile` setting.
 
+pub mod _utils;
+
+use _utils::append_workspace_yaml_key;
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
-use std::{fmt::Write as _, fs, path::Path};
+use std::{fs, path::Path};
 
 /// The setting only keeps the machine-dependent path of an *external*
 /// link out of the lockfile. A workspace-internal link resolving a peer
@@ -53,16 +56,8 @@ fn install_workspace_with_linked_peer(exclude_links_from_lockfile: bool) -> Stri
     )
     .expect("write root package.json");
 
-    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
-    let mut workspace_yaml =
-        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
-    if !workspace_yaml.ends_with('\n') {
-        workspace_yaml.push('\n');
-    }
-    workspace_yaml.push_str("packages:\n  - 'packages/*'\n");
-    writeln!(workspace_yaml, "excludeLinksFromLockfile: {exclude_links_from_lockfile}")
-        .expect("append the setting to pnpm-workspace.yaml");
-    fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
+    append_workspace_yaml_key(&workspace, "packages", "['packages/*']");
+    append_workspace_yaml_key(&workspace, "excludeLinksFromLockfile", exclude_links_from_lockfile);
 
     write_project(
         &workspace,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -85,6 +85,9 @@ pub struct ResolvePeersOptions {
 
     /// Absolute root of the importer whose direct dependency map is
     /// being rendered. Snapshot graph edges remain lockfile-root-relative.
+    /// Also the base a `link:` dependency's importer-relative target is
+    /// resolved against before the `excludeLinksFromLockfile` remap
+    /// tests it for containment in [`lockfile_dir`](Self::lockfile_dir).
     pub project_dir: Option<std::path::PathBuf>,
 
     /// Absolute path of the importer's `node_modules` directory. Used
@@ -249,6 +252,10 @@ pub struct ImporterPeerInput {
     pub id: String,
     pub direct: Vec<DirectDep>,
     pub hoisted_optional_peer_node_ids: HashSet<NodeId>,
+    /// Absolute root of this importer. Threaded into
+    /// [`ResolvePeersOptions::project_dir`] while this importer is being
+    /// walked, and used to render its direct `link:` deps relative to
+    /// itself.
     pub root_dir: PathBuf,
     /// Absolute path of this importer's `node_modules` directory.
     /// Threaded into [`ResolvePeersOptions::modules_dir`] while this
@@ -339,17 +346,20 @@ pub fn resolve_peers_workspace(
         .then(|| importers.iter().find(|importer| importer.id == "."))
         .flatten();
     let root_parents = root_importer.map(|importer| {
-        let previous_modules_dir = walker.opts.modules_dir.clone();
+        let previous_dirs = (walker.opts.project_dir.clone(), walker.opts.modules_dir.clone());
+        walker.opts.project_dir = Some(importer.root_dir.clone());
         walker.opts.modules_dir.clone_from(&importer.modules_dir);
         let parents = walker.build_importer_parents_from(&importer.direct);
-        walker.opts.modules_dir = previous_modules_dir;
+        (walker.opts.project_dir, walker.opts.modules_dir) = previous_dirs;
         parents
     });
     for importer in importers {
         importer_root_dirs.insert(importer.id.clone(), importer.root_dir.clone());
-        // Swap the per-importer `modules_dir` in before the walk so
-        // the `excludeLinksFromLockfile` link-remap inside
-        // `resolve_node` uses the correct importer-scoped target.
+        // Swap the per-importer `project_dir` / `modules_dir` in before
+        // the walk so the `excludeLinksFromLockfile` link-remap inside
+        // `resolve_node` resolves link targets against the right
+        // importer and encodes the correct importer-scoped target.
+        walker.opts.project_dir = Some(importer.root_dir.clone());
         walker.opts.modules_dir.clone_from(&importer.modules_dir);
         walker
             .opts

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/context.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/context.rs
@@ -12,7 +12,10 @@ use node_semver::{Range, Version};
 use pacquet_deps_path::{DepPath, index_of_dep_path_suffix};
 use pacquet_resolving_resolver_base::ResolveResult;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
-use std::{path::Path, sync::Arc};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 /// Per-name entry in the propagating [`ParentRefs`] map.
 #[derive(Debug, Clone)]
@@ -382,7 +385,9 @@ pub(super) fn importer_relative_link_dep_path(
 ///
 /// Returns `None` when:
 ///
-/// - the dep isn't a `link:` directory resolution;
+/// - the dep isn't a `link:` directory resolution — an injected
+///   (`file:`) one is a real package in the graph and keeps its own
+///   node id;
 /// - the setting is off or the lockfile / modules dirs are missing;
 /// - the link target lives under `lockfile_dir` (workspace-internal
 ///   link — already stable across machines, no remap needed).
@@ -403,8 +408,17 @@ pub(super) fn remap_link_node_id(
         pacquet_lockfile::LockfileResolution::Directory(dir) => &dir.directory,
         _ => return None,
     };
-    let link_target = std::path::Path::new(directory);
-    if pacquet_fs::is_subdir(lockfile_dir, link_target) {
+    if !result.id.as_str().starts_with("link:") {
+        return None;
+    }
+    // A workspace link records its directory relative to the importer
+    // (the local resolver's is absolute), so it has to be resolved
+    // against `project_dir` before the lexical containment check.
+    let link_target = match opts.project_dir.as_deref() {
+        Some(project_dir) => project_dir.join(directory),
+        None => PathBuf::from(directory),
+    };
+    if pacquet_fs::is_subdir(lockfile_dir, &link_target) {
         return None;
     }
     let target = modules_dir.join(alias);

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/context/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/context/tests.rs
@@ -1,13 +1,16 @@
 //! Unit tests for the peer-resolution context helpers.
 
 use super::{
-    ParentRef, importer_relative_link_dep_path, peer_segment_names, satisfies_with_prereleases,
-    scoped_hoisted_optional_parent_refs,
+    ParentRef, importer_relative_link_dep_path, peer_segment_names, remap_link_node_id,
+    satisfies_with_prereleases, scoped_hoisted_optional_parent_refs,
 };
-use crate::node_id::NodeId;
+use crate::{
+    node_id::NodeId,
+    resolve_peers::{ResolvePeersOptions, test_support::linked_package},
+};
 use pacquet_deps_path::DepPath;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 const PATCHED_WORKFLOWS_SDK: &str = concat!(
     "@medusajs/workflows-sdk@2.13.3",
@@ -74,6 +77,53 @@ fn importer_relative_link_normalizes_the_project_dir() {
             expected,
             "unexpected link target for project dir {project_dir:?}",
         );
+    }
+}
+
+/// A workspace link records its `directory` relative to the importer,
+/// so the containment check has to resolve it against `project_dir`
+/// first — comparing the relative form with `lockfile_dir` never
+/// matches and remaps links that are already stable across machines.
+#[test]
+fn workspace_internal_link_is_not_remapped() {
+    for directory in ["../lib", "/ws/packages/lib"] {
+        let dep = linked_package("lib", "link:packages/lib", directory);
+        assert_eq!(
+            remap_link_node_id(&exclude_links_opts(), "lib", &dep.result),
+            None,
+            "unexpected remap of internal link target {directory:?}",
+        );
+    }
+}
+
+#[test]
+fn external_link_is_remapped_to_the_importers_modules_dir() {
+    for directory in ["../../../outside/lib", "/outside/lib"] {
+        let dep = linked_package("lib", "link:../../../outside/lib", directory);
+        assert_eq!(
+            remap_link_node_id(&exclude_links_opts(), "lib", &dep.result),
+            Some(NodeId::leaf("link:packages/app/node_modules/lib")),
+            "unexpected remap of external link target {directory:?}",
+        );
+    }
+}
+
+/// An injected workspace dependency is a real package in the graph
+/// rather than a link, and records its `directory` relative to
+/// `lockfile_dir`.
+#[test]
+fn injected_workspace_dep_is_not_remapped() {
+    let dep = linked_package("lib", "file:../outside/lib", "../outside/lib");
+    assert_eq!(remap_link_node_id(&exclude_links_opts(), "lib", &dep.result), None);
+}
+
+fn exclude_links_opts() -> ResolvePeersOptions {
+    ResolvePeersOptions {
+        exclude_links_from_lockfile: true,
+        lockfile_dir: Some(PathBuf::from("/ws")),
+        project_dir: Some(PathBuf::from("/ws/packages/app")),
+        modules_dir: Some(PathBuf::from("/ws/packages/app/node_modules")),
+        ..ResolvePeersOptions::default()
     }
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -1276,6 +1276,73 @@ fn linked_peer_provider_uses_root_relative_snapshot_ref_in_workspace_fallback() 
     assert_eq!(consumer.children.get("peer"), Some(&DepPath::from("link:packages/peer")));
 }
 
+/// `excludeLinksFromLockfile` only remaps links that point outside the
+/// workspace. Each importer's own root has to reach the remap for that
+/// to hold in the multi-importer walk, since a workspace link's target
+/// is recorded relative to the importer that declares it.
+#[test]
+fn workspace_internal_link_peer_keeps_its_node_id_when_exclude_links_on() {
+    let peer = NodeId::leaf("link:packages/peer");
+    let consumer = NodeId::next();
+    let importer = ImporterPeerInput {
+        id: "apps/app".to_string(),
+        hoisted_optional_peer_node_ids: HashSet::default(),
+        direct: vec![
+            DirectDep {
+                alias: "consumer".to_string(),
+                node_id: consumer.clone(),
+                id: "consumer@1.0.0".to_string(),
+            },
+            DirectDep {
+                alias: "peer".to_string(),
+                node_id: peer.clone(),
+                id: "link:packages/peer".to_string(),
+            },
+        ],
+        root_dir: std::path::PathBuf::from("/repo/apps/app"),
+        modules_dir: Some(std::path::PathBuf::from("/repo/apps/app/node_modules")),
+    };
+    let mut tree = ResolvedTree {
+        direct: Vec::new(),
+        packages: HashMap::from_iter([
+            (
+                "link:packages/peer".to_string(),
+                linked_package("peer", "link:packages/peer", "../../packages/peer"),
+            ),
+            ("consumer@1.0.0".to_string(), package("consumer", "1.0.0", &[("peer", "*")], false)),
+        ]),
+        dependencies_tree: HashMap::from_iter([
+            (peer, tree_node("link:packages/peer", BTreeMap::new(), -1)),
+            (consumer, tree_node("consumer@1.0.0", BTreeMap::new(), 0)),
+        ]),
+        all_peer_dep_names: HashSet::from_iter(["peer".to_string()]),
+        policy_violations: Vec::new(),
+        applied_patches: HashSet::default(),
+        children_by_id: HashMap::default(),
+    };
+
+    let result = resolve_peers_workspace(
+        &mut tree,
+        &[importer],
+        std::path::Path::new("/repo"),
+        false,
+        false,
+        false,
+        ResolvePeersOptions {
+            exclude_links_from_lockfile: true,
+            lockfile_dir: Some(std::path::PathBuf::from("/repo")),
+            ..ResolvePeersOptions::default()
+        },
+    );
+
+    let consumer_dep_path = &result.direct_dependencies_by_importer["apps/app"]["consumer"];
+    assert_eq!(consumer_dep_path.as_str(), "consumer@1.0.0(peer@packages+peer)");
+    assert_eq!(
+        result.graph[consumer_dep_path].children.get("peer"),
+        Some(&DepPath::from("link:packages/peer")),
+    );
+}
+
 #[test]
 fn single_importer_link_is_rendered_relative_to_project_root() {
     let shared = NodeId::leaf("link:packages/shared");

--- a/pnpm11/installing/deps-installer/test/install/excludeLinksFromLockfile.ts
+++ b/pnpm11/installing/deps-installer/test/install/excludeLinksFromLockfile.ts
@@ -242,6 +242,57 @@ test('path to external link is not added to the lockfile, when it resolves a pee
   expect(lockfile.snapshots[key].dependencies?.['@pnpm.e2e/peer-a']).toBe('link:node_modules/@pnpm.e2e/peer-a')
 })
 
+test('path to a workspace-internal link is kept, when it resolves a peer dependency', async () => {
+  await addDistTag({ package: '@pnpm.e2e/peer-b', version: '1.0.0', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/peer-c', version: '1.0.0', distTag: 'latest' })
+  const pkg1 = {
+    name: 'project-1',
+    version: '1.0.0',
+
+    dependencies: {
+      '@pnpm.e2e/abc': '1.0.0',
+      '@pnpm.e2e/peer-a': 'workspace:*',
+    },
+  }
+  const pkg2 = {
+    name: '@pnpm.e2e/peer-a',
+    version: '1.0.0',
+  }
+  preparePackages([
+    { location: 'project-1', package: pkg1 },
+    { location: 'peer-a', package: pkg2 },
+  ])
+
+  const importers: MutatedProject[] = [
+    {
+      mutation: 'install',
+      rootDir: path.resolve('project-1') as ProjectRootDir,
+    },
+    {
+      mutation: 'install',
+      rootDir: path.resolve('peer-a') as ProjectRootDir,
+    },
+  ]
+  const allProjects: ProjectOptions[] = [
+    {
+      buildIndex: 0,
+      manifest: pkg1,
+      rootDir: path.resolve('project-1') as ProjectRootDir,
+    },
+    {
+      buildIndex: 0,
+      manifest: pkg2,
+      rootDir: path.resolve('peer-a') as ProjectRootDir,
+    },
+  ]
+  await mutateModules(importers, testDefaults({ allProjects, excludeLinksFromLockfile: true }))
+
+  const lockfile: LockfileFile = readYamlFileSync(WANTED_LOCKFILE)
+  const key = '@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-a@peer-a)(@pnpm.e2e/peer-b@1.0.0)(@pnpm.e2e/peer-c@1.0.0)'
+  expect(lockfile.snapshots?.[key]).toBeTruthy()
+  expect(lockfile.snapshots?.[key].dependencies?.['@pnpm.e2e/peer-a']).toBe('link:peer-a')
+})
+
 test('links resolved from workspace protocol dependencies are not removed', async () => {
   const pkg1 = {
     name: 'project-1',


### PR DESCRIPTION
## Summary

With `excludeLinksFromLockfile` enabled, pacquet remapped **workspace-internal** `link:` dependencies, even though the setting exists only to keep the machine-dependent path of an *external* link out of the lockfile. Closes pnpm/pnpm#13556.

`remap_link_node_id` compared `lockfile_dir` with the link's `directory` verbatim, but a workspace link records that directory relative to the importer that declares it (`resolve_from_workspace.rs`), and `pacquet_fs::is_subdir` is purely lexical. `is_subdir("/ws", "../lib")` is `false`, so the guard never fired and the internal link was remapped to `link:<modules_dir>/<alias>`.

The user-visible effect is confirmed end-to-end (new `pnpm/crates/cli/tests/exclude_links_from_lockfile.rs`): an internal link resolving a peer dependency was written as

```yaml
'@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-a@node_modules+@pnpm.e2e+peer-a)(...)':
  dependencies:
    '@pnpm.e2e/peer-a': link:node_modules/@pnpm.e2e/peer-a
```

instead of `(@pnpm.e2e/peer-a@packages+peer-a)` / `link:packages/peer-a`. The remapped ref is relative to the lockfile root while the symlink lives under the importer, so the recorded target does not exist.

**Parity.** The TypeScript CLI has the same remap (`installing/deps-resolver/src/index.ts`), and it is correct there because its directory resolutions for links are absolute (`resolveFromLocalPackage` keeps `localPackageDir`; the local resolver resolves the target). So this is a pacquet-only fix, and I added the matching TS test so the shared expectation is pinned on both sides.

**Second bug from the same check.** Injected (`file:`) workspace deps were remapped too — their directory is relative to the lockfile dir, so the containment check missed them as well. Upstream only remaps linked dependencies (`isLocal`, i.e. a non-`file:` directory resolution), so the remap is now gated on a `link:` id.

## Squash Commit Body

```text
`remap_link_node_id` compared `lockfile_dir` against the link's
`directory` verbatim, but a workspace link records that directory
relative to the importer that declares it, so the lexical containment
check never matched and every internal link was remapped to
`link:<modules_dir>/<alias>` — feeding peer resolution a node id that
should only stand in for links living outside the workspace. The
lockfile then recorded the peer as `link:node_modules/<alias>`, a path
relative to the lockfile root rather than to the importer that holds
the symlink.

Resolve the target against `project_dir` before the containment check,
and thread each importer's root into `ResolvePeersOptions::project_dir`
in the multi-importer walk (it already threads `modules_dir`).

The same check also caught injected (`file:`) workspace dependencies,
whose directory is relative to the lockfile dir. Upstream only remaps
linked dependencies (`isLocal`, i.e. a non-`file:` directory
resolution), so gate the remap on a `link:` id.

The TypeScript CLI is unaffected — its directory resolutions for links
are absolute — so it only gains the mirror test.

Closes pnpm/pnpm#13556
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5[1m]).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13563"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788190294&installation_model_id=426870&pr_number=13563&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13563&signature=ca0451d920cd054226558ca469434dd6048972f302fdafa12eb4dbe6bb9dab89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed lockfile handling so workspace-internal `link:` dependencies retain their original paths and peer suffixes when link entries are excluded.
  - Preserved injected workspace `file:` dependencies instead of remapping them.
  - Continued remapping external links appropriately relative to the importing project.
  - Ensured lockfiles remain consistent regardless of whether link exclusion is enabled.

- **Tests**
  - Added regression and end-to-end coverage for workspace links, peer dependencies, and injected file dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->