### PR TITLE
perf(resolving-deps-resolver): compute previously_resolved_children once per node

### DIFF
--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/finalize.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/finalize.rs
@@ -109,6 +109,12 @@ impl Walker<'_> {
             is_pure,
         } = node;
 
+        // Seeds both the node's record edges and its graph children, so
+        // it is computed once: a second call would rescan the ancestor
+        // chain and re-realize every matching occurrence's children.
+        let mut record_edges =
+            self.previously_resolved_children(parent_node_ids, parent_pkg_ids_chain, &pkg.id);
+
         // The children's depPath edges become this node's graph children.
         // Resolved peers become extra edges, aliased by peer name. If a
         // peer's depPath isn't known yet — typically a later sibling
@@ -117,10 +123,13 @@ impl Walker<'_> {
         // edge entirely would leave the peer un-symlinked in the
         // parent's slot.
         let mut graph_children = BTreeMap::new();
-        for (alias, child_node_id) in
-            self.previously_resolved_children(parent_node_ids, parent_pkg_ids_chain, &pkg.id)
-        {
-            self.add_graph_child_or_pending(&mut graph_children, dep_path, alias, child_node_id);
+        for (alias, child_node_id) in &record_edges {
+            self.add_graph_child_or_pending(
+                &mut graph_children,
+                dep_path,
+                alias.clone(),
+                child_node_id.clone(),
+            );
         }
         for (alias, child_dep_path) in child_dep_paths {
             graph_children.insert(alias, child_dep_path);
@@ -148,17 +157,13 @@ impl Walker<'_> {
             }
         }
 
-        // Capture this node's NodeId-level edges + metadata for the
-        // post-walk [`Walker::build_final_dep_paths`] rebuild. Edges are
-        // the node's regular children overlaid with its *own* resolved
-        // peers — this node's own peer resolution, not the descendants'
-        // peers bubbled up for the suffix. A peer a descendant resolved
-        // (e.g. `debug`'s optional `supports-color`) is symlinked at the
-        // descendant that declares it, so it must not appear in this
-        // node's dependencies. Carries NodeIds so the rebuild can
-        // resolve each to its corrected final depPath.
-        let mut record_edges =
-            self.previously_resolved_children(parent_node_ids, parent_pkg_ids_chain, &pkg.id);
+        // Finish this node's NodeId-level edges for the post-walk
+        // [`Walker::build_final_dep_paths`] rebuild: its regular children
+        // overlaid with its *own* resolved peers — this node's own peer
+        // resolution, not the descendants' peers bubbled up for the
+        // suffix. A peer a descendant resolved (e.g. `debug`'s optional
+        // `supports-color`) is symlinked at the descendant that declares
+        // it, so it must not appear in this node's dependencies.
         record_edges.extend(children.clone());
         for (peer_alias, peer_node_id) in own_resolved_peers {
             record_edges.insert(peer_alias.clone(), peer_node_id.clone());


### PR DESCRIPTION
## Summary

Follow-up to pnpm/pnpm#13564, which merged before this could be pushed to it.

`Walker::record_walked_node` calls `previously_resolved_children` twice with
identical arguments — once to seed the node's graph children, once to seed its
record edges. Each call rescans the ancestor pkg-id chain and, on a match,
re-realizes every matching occurrence's children, so the second one is pure
repeat work in the peer-resolution hot path. The duplication predates
pnpm/pnpm#13564; extracting the phase into one function is what made it visible.

Build the record edges first and iterate them by reference for the graph
children. Cost accounting:

- **Common case** (the node's package is not in its own ancestor chain, so the
  helper early-returns an empty map): one chain scan instead of two, no clones
  either way — strictly less work.
- **Cycle case**: the per-entry clones in the loop replace the ones the second
  call made while rebuilding the map, so the clone count is unchanged, and one
  chain scan plus one `realize_children` pass go away.

CodeRabbit raised this on pnpm/pnpm#13564 and suggested cloning the map into the
first loop instead; that trades one cost for another and adds a clone to the hot
path, which pnpm/pnpm#13553 explicitly ruled out. Building the record edges first
removes the call without adding one.

`just ready` green — 7541 tests passed, 0 failures.

## Squash Commit Body

```text
record_walked_node called previously_resolved_children twice with identical
arguments — once to seed the graph children, once to seed the record edges.
Each call rescans the ancestor pkg-id chain and, on a match, re-realizes every
matching occurrence's children, so the second one was pure repeat work in the
peer-resolution hot path.

Build the record edges first and iterate them by reference for the graph
children. The clone count is unchanged — the per-entry clones in the loop
replace the ones the second call made while rebuilding the map — while one
chain scan and one realize_children pass go away, and the common case (the
node's package is not in its own ancestor chain, so the map is empty) now does
strictly less work.

Raised by CodeRabbit on pnpm/pnpm#13564. Its suggested fix cloned the map into
the first loop instead, which trades one cost for another; building the record
edges first removes the call without adding a clone.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <!-- pacquet-internal: no user-visible surface and no TypeScript counterpart. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
  <!-- Not applicable: internal hot-path cleanup, no behavior change. -->
- [x] Added or updated tests.
  <!-- Not applicable: no behavior change; covered by the existing resolver tests. -->
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5[1m]).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13565"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788193036&installation_model_id=426870&pr_number=13565&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13565&signature=aa6bf9800a745314cd90094f49941c2d818f2bc56d5d1c3865160a9a8759b61f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->