### PR TITLE
perf(resolving-deps-resolver): order node ids without rendering a sort key

### DIFF
--- a/.changeset/faster-peer-dep-path-finalization.md
+++ b/.changeset/faster-peer-dep-path-finalization.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Resolution on large peer-heavy workspaces got faster: a Bit workspace with 114 projects and ~21,000 lockfile entries resolves in ~13.4s instead of ~16.0s. The resolved dependency graph is unchanged.

--- a/pnpm/crates/resolving-deps-resolver/src/node_id.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/node_id.rs
@@ -13,8 +13,13 @@ use std::sync::{
 /// Leaves share a single tree node across every parent that references
 /// them.
 ///
+/// The derived ordering — counters before leaves, counters by their
+/// numeric value, leaves by package id — is what the peer-resolution
+/// passes sort by to keep their output independent of hash iteration
+/// order.
+///
 /// [`DependenciesTree`]: super::resolved_tree::DependenciesTree
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum NodeId {
     /// Fresh per-occurrence counter value. Allocated by [`NodeId::next`].
     Counter(u64),
@@ -47,3 +52,6 @@ impl std::fmt::Display for NodeId {
         }
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/resolving-deps-resolver/src/node_id/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/node_id/tests.rs
@@ -1,0 +1,26 @@
+use super::NodeId;
+
+/// The peer-resolution passes sort `NodeId`s to keep their output
+/// independent of hash iteration order, so the order itself is part of
+/// the resolved lockfile: counters first, in numeric (not textual)
+/// order, then leaves by package id.
+#[test]
+fn sorts_counters_numerically_before_leaves() {
+    let mut node_ids = vec![
+        NodeId::leaf("zod@3.25.76"),
+        NodeId::Counter(10),
+        NodeId::leaf("react@19.2.8"),
+        NodeId::Counter(2),
+    ];
+    node_ids.sort();
+    dbg!(&node_ids);
+    assert_eq!(
+        node_ids,
+        vec![
+            NodeId::Counter(2),
+            NodeId::Counter(10),
+            NodeId::leaf("react@19.2.8"),
+            NodeId::leaf("zod@3.25.76"),
+        ],
+    );
+}

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -43,9 +43,7 @@ use crate::{
     node_id::NodeId,
     resolved_tree::{DirectDep, ResolvedTree},
 };
-use context::{
-    CurrentProviderSource, SharedChain, importer_relative_link_dep_path, node_id_sort_key,
-};
+use context::{CurrentProviderSource, SharedChain, importer_relative_link_dep_path};
 use discovery::PeerDiscoveryCaches;
 pub(crate) use discovery::{PeerDiscoveryResult, PeerHoistDiscovery, apply_hoist_missing_scope};
 use pacquet_deps_path::DepPath;
@@ -510,7 +508,7 @@ fn build_node_ids_by_previous_dep_path(
         return map;
     }
     let mut node_ids: Vec<&NodeId> = tree.dependencies_tree.keys().collect();
-    node_ids.sort_by_key(|node_id| node_id_sort_key(node_id));
+    node_ids.sort();
     for node_id in node_ids {
         if let Some(previous) = tree.dependencies_tree[node_id].previous_dep_path.as_ref()
             && !map.contains_key(previous)

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/context.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/context.rs
@@ -427,13 +427,6 @@ pub(super) fn remap_link_node_id(
     Some(NodeId::leaf(&format!("link:{rel}")))
 }
 
-pub(super) fn node_id_sort_key(node_id: &NodeId) -> String {
-    match node_id {
-        NodeId::Counter(value) => format!("0:{value:020}"),
-        NodeId::Leaf(value) => format!("1:{value}"),
-    }
-}
-
 /// Pull `(name, version)` out of a `ResolveResult` the peer-resolution
 /// stage can hash and compare on.
 ///

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/finalize.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/finalize.rs
@@ -8,10 +8,7 @@ use crate::{
     dependencies_graph::{DependenciesGraph, DependenciesGraphNode},
     node_id::NodeId,
     resolve_peers::{
-        context::{
-            SharedChain, link_node_id_as_dep_path, node_id_sort_key, peer_segment_names,
-            pkg_name_version,
-        },
+        context::{SharedChain, link_node_id_as_dep_path, peer_segment_names, pkg_name_version},
         walker::{MissingPeerInfo, Walker},
     },
     resolved_tree::ResolvedPackage,
@@ -240,7 +237,7 @@ impl Walker<'_> {
         let mut final_dep_paths: HashMap<NodeId, DepPath> = HashMap::default();
         let mut visiting = HashSet::default();
         let mut node_ids: Vec<NodeId> = self.node_external_peers.keys().cloned().collect();
-        node_ids.sort_by_key(node_id_sort_key);
+        node_ids.sort();
         for node_id in node_ids {
             self.final_dep_path_for_node(
                 &node_id,
@@ -477,7 +474,7 @@ impl Walker<'_> {
             .filter(|(_, peers)| !peers.is_empty())
             .map(|(node_id, _)| node_id.clone())
             .collect();
-        participants.sort_by_key(node_id_sort_key);
+        participants.sort();
         participants.dedup();
         let participant_set: HashSet<NodeId> = participants.iter().cloned().collect();
         let neighbors = |node_id: &NodeId| -> Vec<NodeId> {
@@ -489,7 +486,7 @@ impl Walker<'_> {
                 .filter(|peer| participant_set.contains(*peer))
                 .cloned()
                 .collect();
-            out.sort_by_key(node_id_sort_key);
+            out.sort();
             out
         };
 


### PR DESCRIPTION
## Summary

Third installment on the peer-phase performance work in
https://github.com/pnpm/pnpm/issues/13505 (after pnpm/pnpm#13506 and
pnpm/pnpm#13545). Related to pnpm/pnpm#13505 — partial fix, the issue stays
open.

Profiling the reference Bit workspace (114 projects, ~21,000 lockfile entries;
resolution-only replay through `@pnpm/napi` with `lockfileOnly: true`) showed
that **2.50s of the 4.6s final peer pass was spent in `build_final_dep_paths`**
— not in peer matching, but in sorting. The peer-resolution passes sort
`NodeId`s so their output does not depend on hash iteration order, and the
comparison key was a freshly formatted `String` per element
(`"0:{value:020}"` for a counter, `"1:{id}"` for a leaf). `sort_by_key`
re-invokes the key function on **every comparison**, so each sort allocated
`O(n log n)` strings; the Tarjan pass under `build_final_dep_paths` also sorts
one successor list per participating node.

Deriving `Ord` on `NodeId` and sorting the values directly removes those
allocations. The derived order is the same total order the rendered keys
encoded, so the resolved graph is unchanged (see the commit body for why the
two orders coincide).

Measured on the reference workspace (resolution-only replay, warm cache,
offline):

| | main | this PR |
|---|---|---|
| whole resolution | ~16.0s | ~13.4s |
| `build_final_dep_paths` | 2.50s | 0.76s |
| — Tarjan SCC pass | 1.10s | 0.12s |
| — depPath recomputation | 1.27s | 0.45s |

The in-repo `workspace_full_resolution` benchmark's peer-heavy scenario goes
from ~1.01s to ~0.85s (3 runs each, ±0.01s).

### Side finding: resolution is not run-to-run deterministic on that workspace

While setting up the byte-comparison for this change I found that **`main`
already produces different lockfiles on consecutive runs** of the same binary,
with the same input lockfile and `offline: true` — peer-variant bindings flip
between still-valid providers (e.g. `typescript@3.9.10` ↔ `5.5.3` ↔ `5.9.3`,
several thousand lines). This predates this PR and is unrelated to it; it is
almost certainly the concurrent importer-init fan-out interacting with an
order-sensitive fold (the preferred-versions fold the hoist pickers read).
Filed separately as pnpm/pnpm#13567.

Because of that, byte-identity of the emitted lockfile could not be used as the
gate here. The change is instead argued to be output-preserving by
construction (equal orders) and covered by the full suite (7,547 tests pass)
plus a unit test pinning the ordering contract.

### Still open on pnpm/pnpm#13505

- Parallelize per-importer discovery and the final peer pass — the whole peer
  phase is still single-threaded (~4.6s discovery walks + ~2.3s final walk).
- Amortize the initial rounds.
- Emit a progress/stage event during the peer phase (pending a TS
  emission-parity check).

## Squash Commit Body

```text
The peer-resolution passes sort `NodeId`s so their output does not depend
on hash iteration order. The comparison key was a freshly formatted
`String` per element — `"0:{value:020}"` for a counter, `"1:{id}"` for a
leaf — and `sort_by_key` re-invokes the key function on every comparison,
so each sort allocated `O(n log n)` strings. `build_final_dep_paths` and
the Tarjan pass under it run those sorts over every node that resolved a
peer, plus one sorted successor list per node.

Derive `Ord` on `NodeId` instead and sort the values directly. The
derived order is the same total order the rendered keys encoded: the
variant order puts counters before leaves, a fixed-width zero-padded
u64 compares like the number it renders, and leaf ids compare as their
`str` either way. The resolved graph is unchanged.

On the 114-project Bit workspace from
https://github.com/pnpm/pnpm/issues/13505, resolution drops from ~16.0s
to ~13.4s, with the final depPath pass falling from 2.50s to 0.76s. The
peer-heavy `workspace_full_resolution` benchmark goes from ~1.01s to
~0.85s.

Related to https://github.com/pnpm/pnpm/issues/13505.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <!-- pacquet-internal resolver performance; no user-visible surface and no
  TypeScript counterpart. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13568"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788198185&installation_model_id=426870&pr_number=13568&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13568&signature=d02304dd083823f9aa3694182415810d76015f82c36266e8a426e30e790983aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved dependency resolution speed for large workspaces with many peer dependencies.
  - Preserved existing dependency graph results while streamlining internal ordering.

- **Bug Fixes**
  - Ensured consistent ordering of dependency nodes, including numeric counters and package identifiers.

- **Tests**
  - Added coverage verifying dependency node ordering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->