### PR TITLE
fix(resolving-deps-resolver): derive peer-hoist version candidates from the settled tree

### DIFF
--- a/.changeset/deterministic-peer-hoist-candidates.md
+++ b/.changeset/deterministic-peer-hoist-candidates.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed non-deterministic resolution on multi-project workspaces: two consecutive installs of the same inputs could bind peer-suffixed packages to different (still valid) providers, rewriting `pnpm-lock.yaml` on every install [#13567](https://github.com/pnpm/pnpm/issues/13567).

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -597,7 +597,9 @@ where
         })
         .pipe(future::try_join_all)
         .await?;
-    Ok(results.into_iter().flatten().collect())
+    let direct: Vec<DirectDep> = results.into_iter().flatten().collect();
+    ctx.workspace.record_preferred_version_roots(direct.iter().map(|dep| dep.id.as_str()));
+    Ok(direct)
 }
 
 #[cfg(test)]

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -599,6 +599,11 @@ where
         .await?;
     let direct: Vec<DirectDep> = results.into_iter().flatten().collect();
     ctx.workspace.record_preferred_version_roots(direct.iter().map(|dep| dep.id.as_str()));
+    // Second bump, after every write of this wave (including the roots
+    // above) has landed: a `run_preferred_versions` read racing with
+    // this call could bind the entry bump's revision to a partial
+    // closure, and without a completion bump it would never refresh.
+    ctx.workspace.bump_revision();
     Ok(direct)
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/reuse.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/reuse.rs
@@ -591,7 +591,6 @@ where
     };
 
     if package_is_new {
-        ctx.workspace.record_resolved_version(&result);
         emit_deprecation_if_needed(ctx, &result, &id, depth);
     }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/tree_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/tree_ctx.rs
@@ -16,10 +16,7 @@ use std::{
 
 use crate::resolved_tree::{DirectDep, ResolvedTree};
 
-use super::{
-    ManifestHook, UpdateReuseScope, lock_recoverable, reuse::UpdateScope,
-    workspace_ctx::WorkspaceTreeCtx,
-};
+use super::{ManifestHook, UpdateReuseScope, reuse::UpdateScope, workspace_ctx::WorkspaceTreeCtx};
 
 /// Whether a wanted dep's resolution is computed relative to the
 /// consuming importer's directory rather than being
@@ -377,20 +374,22 @@ impl TreeCtx {
     }
 
     /// The preferred-version buckets for `names`: the caller's seed
-    /// entries merged with every version this run has resolved so far
-    /// (seed entries win per selector). The peer-hoist pickers look up
-    /// only their missing-peer names, so this materializes a handful of
-    /// buckets instead of a per-importer copy of the whole run history.
+    /// entries merged with every version this run has resolved into the
+    /// settled reachable tree (seed entries win per selector) — see
+    /// [`WorkspaceTreeCtx::run_preferred_versions`]. The peer-hoist
+    /// pickers look up only their missing-peer names, so this
+    /// materializes a handful of buckets instead of a per-importer copy
+    /// of the whole run history.
     pub(crate) fn preferred_versions_for_names<'name>(
         &self,
         seed: &pacquet_resolving_resolver_base::PreferredVersions,
         names: impl Iterator<Item = &'name str>,
     ) -> pacquet_resolving_resolver_base::PreferredVersions {
-        let run = lock_recoverable(&self.workspace.preferred_versions_from_run);
+        let run = self.workspace.run_preferred_versions();
         let mut out = pacquet_resolving_resolver_base::PreferredVersions::new();
         for name in names {
             let mut bucket = seed.get(name).cloned().unwrap_or_default();
-            if let Some(run_bucket) = run.get(name) {
+            if let Some(run_bucket) = run.versions.get(name) {
                 for (selector, entry) in run_bucket {
                     bucket.entry(selector.clone()).or_insert_with(|| entry.clone());
                 }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
@@ -372,6 +372,8 @@ where
         });
     }
 
+    let id = build_pkg_id_with_patch_hash(ctx, &result).await?;
+
     if result.name_ver.is_none()
         && wanted.bare_specifier.as_deref().is_some_and(|specifier| {
             specifier.starts_with("workspace:") && !specifier.starts_with("workspace:.")
@@ -382,10 +384,8 @@ where
             manifest.get("version").and_then(Value::as_str),
         )
     {
-        ctx.workspace.record_run_version(name.to_string(), version.to_string());
+        ctx.workspace.record_workspace_manifest_identity(&id, name, version);
     }
-
-    let id = build_pkg_id_with_patch_hash(ctx, &result).await?;
 
     // Cycle break — see the doc comment above. A direct self-edge and
     // the second lap of a longer cycle are dropped; the first re-entry
@@ -472,7 +472,6 @@ where
     drop(packages);
 
     if package_is_new {
-        ctx.workspace.record_resolved_version(&result);
         emit_deprecation_if_needed(ctx, &result, &id, depth);
     }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
@@ -10,7 +10,7 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::{
     collections::BTreeMap,
     path::PathBuf,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, MutexGuard},
 };
 
 use crate::{
@@ -174,16 +174,20 @@ pub struct WorkspaceTreeCtx {
     /// since its last sync.
     children_rewrites: std::sync::atomic::AtomicU64,
     pub(super) packages: Mutex<HashMap<String, ResolvedPackage>>,
-    /// Every `name → version` this run resolved (one fold per new
-    /// `packages` entry carrying a `name_ver`, plus every workspace
-    /// package version a directory resolution surfaced), shaped as the
-    /// plain [`pacquet_resolving_resolver_base::PreferredVersions`]
-    /// entries the peer-hoist pickers bias toward. Maintained once,
-    /// workspace-wide: importers query the buckets they need through
-    /// [`TreeCtx::preferred_versions_for_names`] instead of each
-    /// replaying the whole run history into a private copy.
-    pub(super) preferred_versions_from_run:
-        Mutex<pacquet_resolving_resolver_base::PreferredVersions>,
+    /// `pkgIdWithPatchHash` of every importer-level direct dependency
+    /// recorded so far (initial waves plus hoisted peers), across all
+    /// importers. These are the roots [`Self::run_preferred_versions`]
+    /// derives the run-resolved preferred versions from.
+    preferred_version_roots: Mutex<HashSet<String>>,
+    /// `pkgIdWithPatchHash → (name, version)` for packages whose
+    /// resolution carries no `name_ver` but was wanted through a
+    /// non-path `workspace:` specifier — the workspace-project versions
+    /// [`Self::run_preferred_versions`] folds for such packages. Keyed
+    /// by package id so the fold stays reachability-gated.
+    workspace_manifest_identities: Mutex<HashMap<String, (String, String)>>,
+    /// Memoised result of [`Self::run_preferred_versions`], keyed by the
+    /// `(revision, children_rewrites)` pair it was computed at.
+    run_versions_cache: Mutex<RunVersionsCache>,
     dependencies_tree: Mutex<HashMap<NodeId, DependenciesTreeNode>>,
     pub(super) all_peer_dep_names: Mutex<HashSet<String>>,
     pub(super) policy_violations:
@@ -306,15 +310,38 @@ struct OwnerMissingRecord {
     names: HashSet<String>,
 }
 
+/// State behind [`WorkspaceTreeCtx::run_preferred_versions`]: the
+/// package ids already traversed and the `name → version` entries
+/// their identities folded into, valid as of the recorded
+/// `(revision, children_rewrites)` pair.
+pub(super) struct RunVersionsCache {
+    revision: u64,
+    children_rewrites: u64,
+    visited: HashSet<String>,
+    /// Visited packages that carry no `name_ver` and whose
+    /// workspace-manifest identity hasn't been recorded yet. Re-checked
+    /// on every refresh: the identity is recorded per `workspace:` edge,
+    /// and a later wave can add such an edge to an already-visited
+    /// package.
+    awaiting_identity: HashSet<String>,
+    pub(super) versions: pacquet_resolving_resolver_base::PreferredVersions,
+}
+
 impl Default for WorkspaceTreeCtx {
     fn default() -> Self {
         WorkspaceTreeCtx {
             revision: std::sync::atomic::AtomicU64::new(0),
             children_rewrites: std::sync::atomic::AtomicU64::new(0),
             packages: Mutex::new(HashMap::default()),
-            preferred_versions_from_run: Mutex::new(
-                pacquet_resolving_resolver_base::PreferredVersions::new(),
-            ),
+            preferred_version_roots: Mutex::new(HashSet::default()),
+            workspace_manifest_identities: Mutex::new(HashMap::default()),
+            run_versions_cache: Mutex::new(RunVersionsCache {
+                revision: 0,
+                children_rewrites: 0,
+                visited: HashSet::default(),
+                awaiting_identity: HashSet::default(),
+                versions: pacquet_resolving_resolver_base::PreferredVersions::new(),
+            }),
             dependencies_tree: Mutex::new(HashMap::default()),
             all_peer_dep_names: Mutex::new(HashSet::default()),
             policy_violations: Mutex::new(Vec::new()),
@@ -533,30 +560,123 @@ impl WorkspaceTreeCtx {
             .collect()
     }
 
-    /// Fold a freshly-inserted package's `(name, version)` into
-    /// [`Self::preferred_versions_from_run`]. Call once per new
-    /// `packages` entry.
-    pub(super) fn record_resolved_version(
+    /// Record importer-level direct-dependency package ids as roots for
+    /// [`Self::run_preferred_versions`]. Called by [`fn@extend_tree`]
+    /// after each importer-level wave resolves.
+    ///
+    /// [`fn@extend_tree`]: super::extend_tree
+    pub(super) fn record_preferred_version_roots<'id>(
         &self,
-        result: &pacquet_resolving_resolver_base::ResolveResult,
+        pkg_ids: impl Iterator<Item = &'id str>,
     ) {
-        if let Some(name_ver) = result.name_ver.as_ref() {
-            self.record_run_version(name_ver.name.to_string(), name_ver.suffix.to_string());
+        let mut roots = lock_recoverable(&self.preferred_version_roots);
+        for pkg_id in pkg_ids {
+            if !roots.contains(pkg_id) {
+                roots.insert(pkg_id.to_string());
+            }
         }
     }
 
-    /// See [`Self::preferred_versions_from_run`]. Seed entries win over
-    /// run entries, and the first fold of a `(name, version)` pair wins
-    /// over later ones — the same `or_insert` semantics the per-importer
-    /// fold applied.
-    pub(super) fn record_run_version(&self, name: String, version: String) {
-        lock_recoverable(&self.preferred_versions_from_run)
-            .entry(name)
-            .or_default()
-            .entry(version)
-            .or_insert(pacquet_resolving_resolver_base::VersionSelectorEntry::Plain(
-                pacquet_resolving_resolver_base::VersionSelectorType::Version,
-            ));
+    /// The `name → version` entries of every package reachable from any
+    /// importer's recorded direct dependencies, shaped as the plain
+    /// [`pacquet_resolving_resolver_base::PreferredVersions`] entries the
+    /// peer-hoist pickers bias toward.
+    ///
+    /// Derived from the settled tree — the recorded roots plus the
+    /// children edges the deterministic children owners recorded — not
+    /// from resolution arrival order. Concurrent importer waves can
+    /// transiently walk (and resolve versions inside) a subtree whose
+    /// children ownership a better-placed occurrence later takes over;
+    /// whether such a walk happens at all depends on thread
+    /// interleaving, so an arrival-ordered fold gives the pickers
+    /// run-to-run varying candidates and reshuffles peer bindings on
+    /// every install. The reachable closure is interleaving-independent
+    /// because both the roots and the surviving children records are.
+    ///
+    /// The closure is cached and extended incrementally: shared-map
+    /// growth (`revision`) only ever hangs new subtrees under new
+    /// roots, so previously visited packages keep their entries; a
+    /// children-ownership rewrite (`children_rewrites`) can restructure
+    /// existing subtrees, so it rebuilds the closure from scratch.
+    pub(super) fn run_preferred_versions(&self) -> MutexGuard<'_, RunVersionsCache> {
+        let revision = self.revision();
+        let children_rewrites = self.children_rewrites();
+        let mut cache = lock_recoverable(&self.run_versions_cache);
+        if cache.revision == revision && cache.children_rewrites == children_rewrites {
+            return cache;
+        }
+        if cache.children_rewrites != children_rewrites {
+            cache.visited.clear();
+            cache.awaiting_identity.clear();
+            cache.versions.clear();
+        }
+        let mut queue: Vec<String> = lock_recoverable(&self.preferred_version_roots)
+            .iter()
+            .filter(|pkg_id| !cache.visited.contains(*pkg_id))
+            .cloned()
+            .collect();
+        // The three shared maps below are taken one after the other, so
+        // this function never holds two of the context's locks at once.
+        let mut newly_visited: Vec<String> = Vec::new();
+        {
+            let children_by_id = lock_recoverable(&self.children_by_id);
+            while let Some(pkg_id) = queue.pop() {
+                if !cache.visited.insert(pkg_id.clone()) {
+                    continue;
+                }
+                if let Some(children) = children_by_id.get(&pkg_id) {
+                    for child in children.iter() {
+                        if !cache.visited.contains(&child.pkg_id) {
+                            queue.push(child.pkg_id.clone());
+                        }
+                    }
+                }
+                newly_visited.push(pkg_id);
+            }
+        }
+        {
+            let packages = lock_recoverable(&self.packages);
+            for pkg_id in newly_visited {
+                match packages.get(&pkg_id).and_then(|pkg| pkg.result.name_ver.as_ref()) {
+                    Some(name_ver) => fold_version(
+                        &mut cache.versions,
+                        name_ver.name.to_string(),
+                        name_ver.suffix.to_string(),
+                    ),
+                    None => {
+                        cache.awaiting_identity.insert(pkg_id);
+                    }
+                }
+            }
+        }
+        let identities = lock_recoverable(&self.workspace_manifest_identities);
+        let RunVersionsCache { awaiting_identity, versions, .. } = &mut *cache;
+        awaiting_identity.retain(|pkg_id| match identities.get(pkg_id) {
+            Some((name, version)) => {
+                fold_version(versions, name.clone(), version.clone());
+                false
+            }
+            None => true,
+        });
+        drop(identities);
+        cache.revision = revision;
+        cache.children_rewrites = children_rewrites;
+        cache
+    }
+
+    /// Record the manifest identity of a `name_ver`-less package wanted
+    /// through a non-path `workspace:` specifier, for
+    /// [`Self::run_preferred_versions`] to fold once the package is
+    /// reachable.
+    pub(super) fn record_workspace_manifest_identity(
+        &self,
+        pkg_id: &str,
+        name: &str,
+        version: &str,
+    ) {
+        lock_recoverable(&self.workspace_manifest_identities)
+            .entry(pkg_id.to_string())
+            .or_insert_with(|| (name.to_string(), version.to_string()));
     }
 
     /// See the `revision` field doc.
@@ -804,6 +924,20 @@ impl WorkspaceTreeCtx {
                 .unwrap_or_else(std::sync::PoisonError::into_inner),
         }
     }
+}
+
+/// Fold one `name → version` pair into `versions` as a plain
+/// `version` selector; the first fold of a pair wins over later ones.
+fn fold_version(
+    versions: &mut pacquet_resolving_resolver_base::PreferredVersions,
+    name: String,
+    version: String,
+) {
+    versions.entry(name).or_default().entry(version).or_insert(
+        pacquet_resolving_resolver_base::VersionSelectorEntry::Plain(
+            pacquet_resolving_resolver_base::VersionSelectorType::Version,
+        ),
+    );
 }
 
 pub(super) struct ChildrenOwnerClaim {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
@@ -615,8 +615,13 @@ impl WorkspaceTreeCtx {
             .filter(|pkg_id| !cache.visited.contains(*pkg_id))
             .cloned()
             .collect();
-        // The three shared maps below are taken one after the other, so
-        // this function never holds two of the context's locks at once.
+        // Lock discipline: `run_versions_cache` is locked only by this
+        // function, so holding it across the refresh cannot form an
+        // acquisition cycle; the context's shared maps (roots,
+        // `children_by_id`, `packages`, identities) are each taken on
+        // their own, never two at a time. Contention is also not a
+        // concern: refreshes run at the quiescent points between hoist
+        // waves, not while walks hold the shared maps hot.
         let mut newly_visited: Vec<String> = Vec::new();
         {
             let children_by_id = lock_recoverable(&self.children_by_id);

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx/tests.rs
@@ -1,8 +1,8 @@
 use pacquet_resolving_resolver_base::ResolveOptions;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, sync::Arc};
 
-use super::{super::test_support::manifest_result, WorkspaceTreeCtx};
+use super::{super::lock_recoverable, super::test_support::manifest_result, WorkspaceTreeCtx};
 use crate::{
     DirectDep, NodeId,
     resolved_tree::{DependenciesTreeNode, TreeChildren},
@@ -211,4 +211,122 @@ fn snapshot_package(pkg_id: &str) -> super::ResolvedPackage {
         optional: false,
         is_leaf: false,
     }
+}
+
+#[test]
+fn run_preferred_versions_cover_only_packages_reachable_from_recorded_roots() {
+    let workspace = WorkspaceTreeCtx::default();
+    for (name, version) in [("root", "1.0.0"), ("child", "2.0.0"), ("stray", "9.9.9")] {
+        insert_named_package(&workspace, name, version);
+    }
+    insert_child_edge(&workspace, "root@1.0.0", "child", "child@2.0.0");
+    workspace.record_preferred_version_roots(std::iter::once("root@1.0.0"));
+    workspace.bump_revision();
+
+    let cache = workspace.run_preferred_versions();
+    assert_eq!(bucket_versions(&cache.versions, "root"), ["1.0.0"]);
+    assert_eq!(bucket_versions(&cache.versions, "child"), ["2.0.0"]);
+    assert!(
+        !cache.versions.contains_key("stray"),
+        "a resolved but unreachable package must not become a pick candidate",
+    );
+}
+
+#[test]
+fn run_preferred_versions_grow_with_new_roots_and_rebuild_on_children_rewrites() {
+    let workspace = WorkspaceTreeCtx::default();
+    for (name, version) in [("root", "1.0.0"), ("child", "2.0.0"), ("late", "3.0.0")] {
+        insert_named_package(&workspace, name, version);
+    }
+    insert_child_edge(&workspace, "root@1.0.0", "child", "child@2.0.0");
+    workspace.record_preferred_version_roots(std::iter::once("root@1.0.0"));
+    workspace.bump_revision();
+    assert!(workspace.run_preferred_versions().versions.contains_key("child"));
+
+    workspace.record_preferred_version_roots(std::iter::once("late@3.0.0"));
+    workspace.bump_revision();
+    assert_eq!(bucket_versions(&workspace.run_preferred_versions().versions, "late"), ["3.0.0"]);
+
+    // A children-ownership rewrite can drop edges, so the closure is
+    // rebuilt rather than grown.
+    lock_recoverable(&workspace.children_by_id).insert("root@1.0.0".to_string(), Arc::new(vec![]));
+    workspace.record_children_rewrite();
+    workspace.bump_revision();
+    let cache = workspace.run_preferred_versions();
+    assert!(!cache.versions.contains_key("child"), "the rewritten-away child must drop out");
+    assert_eq!(bucket_versions(&cache.versions, "root"), ["1.0.0"]);
+    assert_eq!(bucket_versions(&cache.versions, "late"), ["3.0.0"]);
+}
+
+#[test]
+fn run_preferred_versions_fold_workspace_manifest_identities_once_reachable() {
+    let workspace = WorkspaceTreeCtx::default();
+    lock_recoverable(&workspace.packages)
+        .insert("link:packages/opt".to_string(), snapshot_package("link:packages/opt"));
+    workspace.record_workspace_manifest_identity("link:packages/opt", "opt", "1.0.0");
+    insert_named_package(&workspace, "root", "1.0.0");
+    workspace.record_preferred_version_roots(std::iter::once("root@1.0.0"));
+    workspace.bump_revision();
+    assert!(
+        !workspace.run_preferred_versions().versions.contains_key("opt"),
+        "an unreachable workspace project's version must not become a pick candidate",
+    );
+
+    insert_child_edge(&workspace, "root@1.0.0", "opt", "link:packages/opt");
+    workspace.record_children_rewrite();
+    workspace.bump_revision();
+    assert_eq!(bucket_versions(&workspace.run_preferred_versions().versions, "opt"), ["1.0.0"]);
+}
+
+#[test]
+fn run_preferred_versions_pick_up_an_identity_recorded_after_the_first_visit() {
+    let workspace = WorkspaceTreeCtx::default();
+    insert_named_package(&workspace, "root", "1.0.0");
+    lock_recoverable(&workspace.packages)
+        .insert("link:packages/opt".to_string(), snapshot_package("link:packages/opt"));
+    insert_child_edge(&workspace, "root@1.0.0", "opt", "link:packages/opt");
+    workspace.record_preferred_version_roots(std::iter::once("root@1.0.0"));
+    workspace.bump_revision();
+    assert!(!workspace.run_preferred_versions().versions.contains_key("opt"));
+
+    workspace.record_workspace_manifest_identity("link:packages/opt", "opt", "1.0.0");
+    workspace.bump_revision();
+    assert_eq!(bucket_versions(&workspace.run_preferred_versions().versions, "opt"), ["1.0.0"]);
+}
+
+fn insert_named_package(workspace: &WorkspaceTreeCtx, name: &str, version: &str) {
+    let name_ver = pacquet_lockfile::PkgNameVer::new(
+        pacquet_lockfile::PkgName::parse(name).expect("parse package name"),
+        version.parse::<node_semver::Version>().expect("parse package version"),
+    );
+    let mut result = manifest_result(serde_json::json!({}));
+    result.id = (&name_ver).into();
+    result.name_ver = Some(name_ver);
+    let pkg_id = format!("{name}@{version}");
+    let package = super::ResolvedPackage {
+        id: pkg_id.clone(),
+        result: std::sync::Arc::new(result),
+        peer_dependencies: BTreeMap::new(),
+        optional: false,
+        is_leaf: false,
+    };
+    lock_recoverable(&workspace.packages).insert(pkg_id, package);
+}
+
+fn insert_child_edge(workspace: &WorkspaceTreeCtx, parent_id: &str, alias: &str, child_id: &str) {
+    lock_recoverable(&workspace.children_by_id).insert(
+        parent_id.to_string(),
+        Arc::new(vec![crate::resolved_tree::ChildEdge {
+            alias: alias.to_string(),
+            pkg_id: child_id.to_string(),
+            optional: false,
+        }]),
+    );
+}
+
+fn bucket_versions(
+    versions: &pacquet_resolving_resolver_base::PreferredVersions,
+    name: &str,
+) -> Vec<String> {
+    versions.get(name).map(|bucket| bucket.keys().cloned().collect()).unwrap_or_default()
 }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx/tests.rs
@@ -2,7 +2,10 @@ use pacquet_resolving_resolver_base::ResolveOptions;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::{collections::BTreeMap, sync::Arc};
 
-use super::{super::lock_recoverable, super::test_support::manifest_result, WorkspaceTreeCtx};
+use super::{
+    super::{lock_recoverable, test_support::manifest_result},
+    WorkspaceTreeCtx,
+};
 use crate::{
     DirectDep, NodeId,
     resolved_tree::{DependenciesTreeNode, TreeChildren},

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -95,9 +95,9 @@ pub struct ResolveImporterOptions {
     /// Seed for the preferred-versions tie-break table: the lockfile +
     /// manifest entries the peer-hoist pickers bias toward, so a
     /// version a sibling already brought is reused instead of adding a
-    /// second instance. Newly-resolved versions are folded once,
-    /// workspace-wide, on the tree context and merged with these seed
-    /// buckets per lookup (seed entries win) — see
+    /// second instance. Versions resolved into the settled tree are
+    /// derived once, workspace-wide, on the tree context and merged
+    /// with these seed buckets per lookup (seed entries win) — see
     /// `TreeCtx::preferred_versions_for_names`. Pass the result of
     /// `get_preferred_versions_from_lockfile_and_manifests` from the
     /// `lockfile-preferred-versions` crate, or an empty map when no
@@ -349,8 +349,8 @@ pub(crate) struct ImporterHoistState {
     /// extended its direct set, or a workspace children-ownership
     /// rewrite restructured shared subtrees. A round that broke off
     /// with unhoistable misses is *not* converged — another importer's
-    /// resolutions can extend the preferred-versions fold and make
-    /// those misses hoistable, so it must re-discover every round.
+    /// resolutions can extend the run-resolved preferred versions and
+    /// make those misses hoistable, so it must re-discover every round.
     discovery_converged: bool,
     /// [`crate::WorkspaceTreeCtx::children_rewrites`] at the moment
     /// [`Self::discovery_converged`] was set.
@@ -373,8 +373,9 @@ pub(crate) struct ImporterHoistState {
     parent_pkg_aliases: HashSet<String>,
     all_missing_optional_peers: BTreeMap<String, Vec<String>>,
     /// The lockfile + manifest preferred-versions seed. The hoist
-    /// pickers merge it per lookup with the workspace-wide run fold —
-    /// see [`TreeCtx::preferred_versions_for_names`] — instead of
+    /// pickers merge it per lookup with the workspace-wide
+    /// run-resolved versions — see
+    /// [`TreeCtx::preferred_versions_for_names`] — instead of
     /// maintaining a per-importer copy of the whole run history.
     preferred_versions_seed: Arc<PreferredVersions>,
     locked_peer_names: Arc<HashSet<String>>,
@@ -750,9 +751,9 @@ impl ImporterHoistState {
 
             let missing_as_pairs: Vec<(String, MissingPeerInfo)> =
                 missing_required.iter().map(|(n, info)| (n.clone(), info.clone())).collect();
-            // Both hoists bias toward the run-extended preferred
+            // Both hoists bias toward the run-resolved preferred
             // versions: the seed buckets for the missing names merged
-            // with every version any importer has resolved so far.
+            // with every version resolved into the settled tree so far.
             let hoist_preferred = self.ctx.preferred_versions_for_names(
                 &self.preferred_versions_seed,
                 missing_as_pairs.iter().map(|(name, _)| name.as_str()),

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -256,10 +256,12 @@ where
     //
     // The initial waves run concurrently, like the TypeScript resolver's
     // importer fan-out: the shared context's children-owner claims are
-    // rank-ordered (not arrival-ordered), so the resolved graph is the
-    // same regardless of interleaving, and a large workspace's walks
-    // overlap their resolver and hook waits instead of paying them
-    // importer by importer.
+    // rank-ordered (not arrival-ordered) and the peer-hoist pickers'
+    // preferred-version candidates are derived from the settled
+    // reachable tree (see `WorkspaceTreeCtx::run_preferred_versions`),
+    // so the resolved graph is the same regardless of interleaving, and
+    // a large workspace's walks overlap their resolver and hook waits
+    // instead of paying them importer by importer.
     let mut input_dirs = Vec::with_capacity(importers.len());
     let init_futures: Vec<_> = importers
         .iter()

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -1261,6 +1261,141 @@ async fn local_workspace_package_version_can_satisfy_another_importers_optional_
     );
 }
 
+/// Regression test for
+/// <https://github.com/pnpm/pnpm/issues/13567>: forces the adversarial
+/// interleaving of the concurrent init waves.
+///
+/// Both importers depend on `shared@1.0.0`, whose children context is
+/// deterministically owned by the root importer (same depth, lower
+/// importer order). Delaying the root's `shared` resolution lets
+/// `pkg-b` reuse its locked `shared` subtree first — a transient walk
+/// that resolves the pinned `dep@1.0.0` before losing the children
+/// context to the root, whose fresh walk resolves `dep@^1.0.0` to
+/// `2.0.0` instead. `dep@1.0.0` is then unreachable, so it must not be
+/// offered to the optional-peer hoist: an arrival-ordered candidate set
+/// would install it (and suffix `host`) only in runs where the
+/// transient walk happened to go first.
+#[tokio::test]
+async fn transiently_walked_subtree_versions_do_not_bias_optional_peer_hoists() {
+    let (_tmp_root, root_manifest) =
+        fake_manifest(serde_json::json!({ "shared": "1.0.0", "host": "1.0.0" }));
+    let (_tmp_b, b_manifest) = fake_manifest(serde_json::json!({ "shared": "1.0.0" }));
+    let importers = [
+        WorkspaceImporter { id: ".".to_string(), manifest: &root_manifest },
+        WorkspaceImporter { id: "pkg-b".to_string(), manifest: &b_manifest },
+    ];
+    let resolver = SlowAliasResolver {
+        table: HashMap::from_iter([
+            (
+                ("shared".to_string(), "1.0.0".to_string()),
+                fake_result(
+                    "shared",
+                    "1.0.0",
+                    None,
+                    serde_json::json!({
+                        "name": "shared",
+                        "version": "1.0.0",
+                        "dependencies": { "dep": "^1.0.0" },
+                    }),
+                ),
+            ),
+            (
+                ("dep".to_string(), "^1.0.0".to_string()),
+                fake_result(
+                    "dep",
+                    "2.0.0",
+                    None,
+                    serde_json::json!({ "name": "dep", "version": "2.0.0" }),
+                ),
+            ),
+            (
+                ("dep".to_string(), "1.0.0".to_string()),
+                fake_result(
+                    "dep",
+                    "1.0.0",
+                    None,
+                    serde_json::json!({ "name": "dep", "version": "1.0.0" }),
+                ),
+            ),
+            (
+                ("host".to_string(), "1.0.0".to_string()),
+                fake_result(
+                    "host",
+                    "1.0.0",
+                    None,
+                    serde_json::json!({
+                        "name": "host",
+                        "version": "1.0.0",
+                        "peerDependencies": { "dep": "^1.0.0" },
+                        "peerDependenciesMeta": { "dep": { "optional": true } },
+                    }),
+                ),
+            ),
+        ]),
+        slow: ("shared".to_string(), "1.0.0".to_string()),
+    };
+    let mut opts = workspace_opts(false, false);
+    opts.auto_install_peers = true;
+    opts.wanted_lockfile = Some(Arc::new(reuse_graph_lockfile(
+        "pkg-b",
+        &[("shared", "1.0.0", "1.0.0")],
+        &[("shared@1.0.0", &[("dep", "1.0.0")]), ("dep@1.0.0", &[])],
+        &[],
+    )));
+    let result =
+        resolve_workspace(&resolver, &importers, &[DependencyGroup::Prod], opts, |importer| {
+            importer_opts(std::path::PathBuf::from("/repo").join(&importer.id), None)
+        })
+        .await
+        .expect("resolve workspace under the adversarial interleaving");
+
+    let direct = result.peers.direct_dependencies_by_importer.get(".").expect("root importer");
+    assert_eq!(
+        direct.get("host").map(std::string::ToString::to_string),
+        Some("host@1.0.0".to_string()),
+        "the unreachable dep@1.0.0 must not satisfy host's optional peer",
+    );
+    assert_eq!(direct.get("dep"), None, "no optional-peer hoist may install dep");
+    assert_eq!(graph_versions_of(&result, "dep"), ["2.0.0"]);
+}
+
+/// [`RecordingResolver`] with one artificially slow entry: its resolve
+/// yields back to the executor enough times for every other concurrent
+/// walk to run to completion first.
+struct SlowAliasResolver {
+    table: HashMap<(String, String), ResolveResult>,
+    slow: (String, String),
+}
+
+impl Resolver for SlowAliasResolver {
+    fn resolve<'a>(
+        &'a self,
+        wanted: &'a WantedDependency,
+        _opts: &'a ResolveOptions,
+    ) -> ResolveFuture<'a> {
+        let alias = wanted.alias.clone().unwrap_or_default();
+        let range = wanted.bare_specifier.clone().unwrap_or_default();
+        let result = self.table.get(&(alias.clone(), range.clone())).cloned();
+        let slow = self.slow == (alias, range);
+        Box::pin(async move {
+            if slow {
+                for _ in 0..64 {
+                    tokio::task::yield_now().await;
+                }
+            }
+            Ok::<_, ResolveError>(result)
+        })
+    }
+
+    fn resolve_latest<'a>(
+        &'a self,
+        _query: &'a LatestQuery,
+        _opts: &'a ResolveOptions,
+    ) -> ResolveLatestFuture<'a> {
+        Box::pin(async { Ok(None) })
+    }
+}
+
 /// Resolver fed from a `(alias, range)` → `ResolveResult` table whose
 /// chain fails for the aliases in `failing`, mimicking a registry
 /// whose packument no longer serves any satisfying version.


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Fixes pnpm/pnpm#13567: on a large multi-project workspace, two consecutive resolving installs of the same inputs produced different lockfiles — peer-variant bindings reshuffled between still-valid providers on every run.

**Mechanism.** The peer-hoist pickers (`hoist_peers`, `get_hoistable_optional_peers`) bias toward `preferred_versions_from_run`, a workspace-wide fold populated by every walk as it resolved packages. The concurrent importer init waves race their children-ownership claims: an occurrence can transiently win a claim, walk (and resolve versions inside) a subtree, and only then lose the children context to a deterministically better-placed occurrence. Whether that transient walk happens at all depends on thread interleaving, so the fold's *membership* varied run to run, and with it the picks — and every peer suffix downstream of them.

**Fix.** The pickers' candidates are now derived from the settled reachable tree instead of resolution arrival order: `WorkspaceTreeCtx::run_preferred_versions` walks `children_by_id` (which only ever holds the deterministic children owner's records) from the recorded importer-level direct deps, and folds the identity of each reachable package. Both the roots and the surviving children records are interleaving-independent, so the candidate set is too. The closure is cached and grown incrementally (`revision`), with a full rebuild when a children-ownership rewrite restructures existing subtrees (`children_rewrites`). Workspace-project versions surfaced by `workspace:` specifiers (which carry no `name_ver`) keep their previous fold semantics via a per-package identity record, also gated on reachability.

This matches the TypeScript resolver's semantics: its `allPreferredVersions` folds every resolution it performs, which in the single-threaded model is exactly the set reachable through its arrival-ordered dedup. No serialization of the concurrent waves — the perf shape from pnpm/pnpm#13506 is unchanged.

**Parity.** Rust-only (pacquet). The defect is internal concurrency in the Rust resolver; the TypeScript CLI's single-threaded scheduling does not exhibit it, and no user-visible surface changes. (Oz triage on the issue reached the same conclusion.)

**Tests.**
- `transiently_walked_subtree_versions_do_not_bias_optional_peer_hoists` deterministically forces the adversarial interleaving (a slow resolver entry lets a non-owner's lockfile-reuse walk resolve a pinned version before the deterministic owner's fresh walk lands elsewhere) and asserts the unreachable version is not offered to the optional-peer hoist. It fails before this change with exactly the reported symptom (`host@1.0.0(dep@1.0.0)` vs `host@1.0.0`).
- Unit tests pin the closure semantics: reachability gating, incremental growth under new roots, full rebuild on children rewrites, and reachability-gated workspace-manifest identities (including one recorded after the package was first visited).

## Squash Commit Body

```text
The peer-hoist pickers biased toward preferred_versions_from_run, an
arrival-ordered workspace-wide fold written by every walk. Concurrent
importer waves can transiently win a children-ownership claim, walk a
subtree, and lose the context to a deterministically better-placed
occurrence; whether that transient walk (and its version folds) happens
depends on thread interleaving, so the fold's membership — and the
hoisted peer picks, and every peer suffix downstream — varied run to
run, rewriting pnpm-lock.yaml on every install of identical inputs.

Derive the pickers' candidates from the settled reachable tree instead:
WorkspaceTreeCtx::run_preferred_versions walks children_by_id (which
only ever holds the deterministic children owner's records) from the
recorded importer-level direct deps and folds each reachable package's
identity. The closure is cached, grown incrementally per revision, and
rebuilt when a children-ownership rewrite restructures existing
subtrees. workspace:-surfaced project versions keep their fold via a
per-package identity record, also reachability-gated. This matches the
TS resolver, where allPreferredVersions ends up equal to the set
reachable through its arrival-ordered dedup because it is
single-threaded. The concurrent init waves stay concurrent.

Closes pnpm/pnpm#13567
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed. (Not needed — internal resolver
  determinism fix, no user-facing surface change.)

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788200891&installation_model_id=426870&pr_number=13570&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13570&signature=7df878d5ec066a0a0bfd5f93bcd2f4b270c1921e906dbd320dc032e647469c38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed non-deterministic peer dependency resolution in multi-project workspaces.
  * Prevented identical installs from unnecessarily rewriting the lockfile.
  * Improved optional-peer hoisting so transiently reused package versions no longer affect the final dependency graph.
  * Improved workspace package identity handling and dependency version selection.

* **Tests**
  * Added regression coverage for concurrent workspace resolution, preferred-version caching, and workspace package identity handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->