### PR TITLE
test(resolving-deps-resolver): cover the required-peer picker under the adversarial interleaving

### DIFF
--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -1261,12 +1261,8 @@ async fn local_workspace_package_version_can_satisfy_another_importers_optional_
     );
 }
 
-/// The transiently-resolved `dep@1.0.0` must not be offered to the
-/// *optional*-peer hoist: no reachable version satisfies `host`'s
-/// optional `^1.0.0` peer, so nothing is installed and `host` stays
-/// unsuffixed. An arrival-ordered candidate set would install the pin
-/// (and suffix `host`) only in runs where the transient walk went
-/// first.
+/// An arrival-ordered candidate set would let the transient walk's pin
+/// satisfy `host`'s optional peer whenever that walk went first.
 #[tokio::test]
 async fn transiently_walked_subtree_versions_do_not_bias_optional_peer_hoists() {
     let host_manifest = serde_json::json!({
@@ -1292,12 +1288,10 @@ async fn transiently_walked_subtree_versions_do_not_bias_optional_peer_hoists() 
     assert_eq!(graph_versions_of(&result, "dep"), ["2.0.0"]);
 }
 
-/// The same interleaving through the *required*-peer picker: the
-/// transient walk resolves the locked `dep@1.9.0`, the owner's fresh
-/// walk lands on `1.5.0`, and both satisfy `host`'s required `^1.0.0`
-/// peer — so an arrival-ordered candidate set would hoist the higher
-/// but unreachable `1.9.0` whenever the transient walk went first. The
-/// hoist must install the reachable `1.5.0`.
+/// The required-peer picker dedupes onto the highest satisfying
+/// candidate, so here the transient pin — higher than, and equally
+/// satisfying as, the owner's pick — is exactly what an arrival-ordered
+/// candidate set would hoist.
 #[tokio::test]
 async fn transiently_walked_subtree_versions_do_not_bias_required_peer_hoists() {
     let host_manifest = serde_json::json!({

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -1261,93 +1261,26 @@ async fn local_workspace_package_version_can_satisfy_another_importers_optional_
     );
 }
 
-/// Regression test for
-/// <https://github.com/pnpm/pnpm/issues/13567>: forces the adversarial
-/// interleaving of the concurrent init waves.
-///
-/// Both importers depend on `shared@1.0.0`, whose children context is
-/// deterministically owned by the root importer (same depth, lower
-/// importer order). Delaying the root's `shared` resolution lets
-/// `pkg-b` reuse its locked `shared` subtree first — a transient walk
-/// that resolves the pinned `dep@1.0.0` before losing the children
-/// context to the root, whose fresh walk resolves `dep@^1.0.0` to
-/// `2.0.0` instead. `dep@1.0.0` is then unreachable, so it must not be
-/// offered to the optional-peer hoist: an arrival-ordered candidate set
-/// would install it (and suffix `host`) only in runs where the
-/// transient walk happened to go first.
+/// The transiently-resolved `dep@1.0.0` must not be offered to the
+/// *optional*-peer hoist: no reachable version satisfies `host`'s
+/// optional `^1.0.0` peer, so nothing is installed and `host` stays
+/// unsuffixed. An arrival-ordered candidate set would install the pin
+/// (and suffix `host`) only in runs where the transient walk went
+/// first.
 #[tokio::test]
 async fn transiently_walked_subtree_versions_do_not_bias_optional_peer_hoists() {
-    let (_tmp_root, root_manifest) =
-        fake_manifest(serde_json::json!({ "shared": "1.0.0", "host": "1.0.0" }));
-    let (_tmp_b, b_manifest) = fake_manifest(serde_json::json!({ "shared": "1.0.0" }));
-    let importers = [
-        WorkspaceImporter { id: ".".to_string(), manifest: &root_manifest },
-        WorkspaceImporter { id: "pkg-b".to_string(), manifest: &b_manifest },
-    ];
-    let resolver = SlowAliasResolver {
-        table: HashMap::from_iter([
-            (
-                ("shared".to_string(), "1.0.0".to_string()),
-                fake_result(
-                    "shared",
-                    "1.0.0",
-                    None,
-                    serde_json::json!({
-                        "name": "shared",
-                        "version": "1.0.0",
-                        "dependencies": { "dep": "^1.0.0" },
-                    }),
-                ),
-            ),
-            (
-                ("dep".to_string(), "^1.0.0".to_string()),
-                fake_result(
-                    "dep",
-                    "2.0.0",
-                    None,
-                    serde_json::json!({ "name": "dep", "version": "2.0.0" }),
-                ),
-            ),
-            (
-                ("dep".to_string(), "1.0.0".to_string()),
-                fake_result(
-                    "dep",
-                    "1.0.0",
-                    None,
-                    serde_json::json!({ "name": "dep", "version": "1.0.0" }),
-                ),
-            ),
-            (
-                ("host".to_string(), "1.0.0".to_string()),
-                fake_result(
-                    "host",
-                    "1.0.0",
-                    None,
-                    serde_json::json!({
-                        "name": "host",
-                        "version": "1.0.0",
-                        "peerDependencies": { "dep": "^1.0.0" },
-                        "peerDependenciesMeta": { "dep": { "optional": true } },
-                    }),
-                ),
-            ),
-        ]),
-        slow: ("shared".to_string(), "1.0.0".to_string()),
-    };
-    let mut opts = workspace_opts(false, false);
-    opts.auto_install_peers = true;
-    opts.wanted_lockfile = Some(Arc::new(reuse_graph_lockfile(
-        "pkg-b",
-        &[("shared", "1.0.0", "1.0.0")],
-        &[("shared@1.0.0", &[("dep", "1.0.0")]), ("dep@1.0.0", &[])],
-        &[],
-    )));
-    let result =
-        resolve_workspace(&resolver, &importers, &[DependencyGroup::Prod], opts, |importer| {
-            importer_opts(std::path::PathBuf::from("/repo").join(&importer.id), None)
-        })
-        .await
-        .expect("resolve workspace under the adversarial interleaving");
+    let host_manifest = serde_json::json!({
+        "name": "host",
+        "version": "1.0.0",
+        "peerDependencies": { "dep": "^1.0.0" },
+        "peerDependenciesMeta": { "dep": { "optional": true } },
+    });
+    let result = resolve_with_transient_shared_walk(
+        host_manifest,
+        "1.0.0",
+        &[("^1.0.0", "2.0.0"), ("1.0.0", "1.0.0")],
+    )
+    .await;
 
     let direct = result.peers.direct_dependencies_by_importer.get(".").expect("root importer");
     assert_eq!(
@@ -1357,6 +1290,111 @@ async fn transiently_walked_subtree_versions_do_not_bias_optional_peer_hoists() 
     );
     assert_eq!(direct.get("dep"), None, "no optional-peer hoist may install dep");
     assert_eq!(graph_versions_of(&result, "dep"), ["2.0.0"]);
+}
+
+/// The same interleaving through the *required*-peer picker: the
+/// transient walk resolves the locked `dep@1.9.0`, the owner's fresh
+/// walk lands on `1.5.0`, and both satisfy `host`'s required `^1.0.0`
+/// peer — so an arrival-ordered candidate set would hoist the higher
+/// but unreachable `1.9.0` whenever the transient walk went first. The
+/// hoist must install the reachable `1.5.0`.
+#[tokio::test]
+async fn transiently_walked_subtree_versions_do_not_bias_required_peer_hoists() {
+    let host_manifest = serde_json::json!({
+        "name": "host",
+        "version": "1.0.0",
+        "peerDependencies": { "dep": "^1.0.0" },
+    });
+    let result = resolve_with_transient_shared_walk(
+        host_manifest,
+        "1.9.0",
+        &[("^1.0.0", "1.5.0"), ("1.5.0", "1.5.0"), ("1.9.0", "1.9.0")],
+    )
+    .await;
+
+    let direct = result.peers.direct_dependencies_by_importer.get(".").expect("root importer");
+    assert_eq!(
+        direct.get("host").map(std::string::ToString::to_string),
+        Some("host@1.0.0(dep@1.5.0)".to_string()),
+        "the required-peer hoist must dedupe onto the reachable version",
+    );
+    assert_eq!(
+        direct.get("dep").map(std::string::ToString::to_string),
+        Some("dep@1.5.0".to_string()),
+    );
+    assert_eq!(graph_versions_of(&result, "dep"), ["1.5.0"]);
+}
+
+/// Drive [`fn@resolve_workspace`] through the adversarial interleaving
+/// of <https://github.com/pnpm/pnpm/issues/13567>.
+///
+/// Both importers depend on `shared@1.0.0`, whose children context is
+/// deterministically owned by the root importer (same depth, lower
+/// importer order). Delaying the root's `shared` resolution lets
+/// `pkg-b` reuse its locked `shared` subtree first — a transient walk
+/// that resolves the pinned `dep@<pinned_dep_version>` before losing
+/// the children context to the root, whose fresh walk resolves
+/// `dep@^1.0.0` to whatever `dep_results` maps it to. The pinned
+/// version is then unreachable, so the peer-hoist pickers deciding
+/// `host`'s missing `dep` peer must never see it; each caller asserts
+/// that for its peer shape.
+async fn resolve_with_transient_shared_walk(
+    host_manifest: serde_json::Value,
+    pinned_dep_version: &str,
+    dep_results: &[(&str, &str)],
+) -> super::ResolveWorkspaceResult {
+    let (_tmp_root, root_manifest) =
+        fake_manifest(serde_json::json!({ "shared": "1.0.0", "host": "1.0.0" }));
+    let (_tmp_b, b_manifest) = fake_manifest(serde_json::json!({ "shared": "1.0.0" }));
+    let importers = [
+        WorkspaceImporter { id: ".".to_string(), manifest: &root_manifest },
+        WorkspaceImporter { id: "pkg-b".to_string(), manifest: &b_manifest },
+    ];
+    let mut table = HashMap::from_iter([
+        (
+            ("shared".to_string(), "1.0.0".to_string()),
+            fake_result(
+                "shared",
+                "1.0.0",
+                None,
+                serde_json::json!({
+                    "name": "shared",
+                    "version": "1.0.0",
+                    "dependencies": { "dep": "^1.0.0" },
+                }),
+            ),
+        ),
+        (
+            ("host".to_string(), "1.0.0".to_string()),
+            fake_result("host", "1.0.0", None, host_manifest),
+        ),
+    ]);
+    for (wanted, version) in dep_results {
+        table.insert(
+            ("dep".to_string(), (*wanted).to_string()),
+            fake_result(
+                "dep",
+                version,
+                None,
+                serde_json::json!({ "name": "dep", "version": version }),
+            ),
+        );
+    }
+    let resolver = SlowAliasResolver { table, slow: ("shared".to_string(), "1.0.0".to_string()) };
+    let pinned_dep_key = format!("dep@{pinned_dep_version}");
+    let mut opts = workspace_opts(false, false);
+    opts.auto_install_peers = true;
+    opts.wanted_lockfile = Some(Arc::new(reuse_graph_lockfile(
+        "pkg-b",
+        &[("shared", "1.0.0", "1.0.0")],
+        &[("shared@1.0.0", &[("dep", pinned_dep_version)]), (&pinned_dep_key, &[])],
+        &[],
+    )));
+    resolve_workspace(&resolver, &importers, &[DependencyGroup::Prod], opts, |importer| {
+        importer_opts(std::path::PathBuf::from("/repo").join(&importer.id), None)
+    })
+    .await
+    .expect("resolve workspace under the adversarial interleaving")
 }
 
 /// [`RecordingResolver`] with one artificially slow entry: its resolve

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -1261,8 +1261,9 @@ async fn local_workspace_package_version_can_satisfy_another_importers_optional_
     );
 }
 
-/// An arrival-ordered candidate set would let the transient walk's pin
-/// satisfy `host`'s optional peer whenever that walk went first.
+/// The pin satisfies `host`'s optional peer range and the owner's
+/// pick does not, so this picker installs nothing only if unreachable
+/// candidates are filtered out.
 #[tokio::test]
 async fn transiently_walked_subtree_versions_do_not_bias_optional_peer_hoists() {
     let host_manifest = serde_json::json!({
@@ -1289,9 +1290,9 @@ async fn transiently_walked_subtree_versions_do_not_bias_optional_peer_hoists() 
 }
 
 /// The required-peer picker dedupes onto the highest satisfying
-/// candidate, so here the transient pin — higher than, and equally
-/// satisfying as, the owner's pick — is exactly what an arrival-ordered
-/// candidate set would hoist.
+/// candidate, so the pin is higher than (and as satisfying as) the
+/// owner's pick — the arrangement where unreachable-candidate
+/// filtering is observable through this picker.
 #[tokio::test]
 async fn transiently_walked_subtree_versions_do_not_bias_required_peer_hoists() {
     let host_manifest = serde_json::json!({


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Follow-up test coverage for pnpm/pnpm#13570 (Related to pnpm/pnpm#13567): the determinism fix's interleaving regression test only exercised the *optional*-peer picker (`get_hoistable_optional_peers`). The *required*-peer picker (`hoist_peers`) reads the same run-resolved candidate set but picks differently — it dedupes onto the highest satisfying candidate — so a transient unreachable version could flip its pick too, and that path was untested.

This adds `transiently_walked_subtree_versions_do_not_bias_required_peer_hoists`: the transient walk resolves a locked `dep@1.9.0`, the deterministic owner's fresh walk lands on `1.5.0`, and both satisfy the host's required `^1.0.0` peer — so pre-fix, an arrival-ordered candidate set hoisted the unreachable `1.9.0` whenever the transient walk went first. Verified by temporarily reverting the resolver to the pre-13570 implementation: the new test fails there with exactly that symptom (`host@1.0.0(dep@1.9.0)` vs `host@1.0.0(dep@1.5.0)`), and passes on current `main`.

The shared fixture (two importers, delayed `shared` resolution, lockfile-reuse transient walk) is extracted into a `resolve_with_transient_shared_walk` driver that both interleaving tests use, parameterized by the host's peer shape, the locked pin, and the `dep` resolution table.

Test-only change: no changeset (nothing published changes), no TypeScript counterpart (the interleaving being forced is specific to the Rust resolver's threading; the fix itself was Rust-only for the same reason).

## Squash Commit Body

```text
The optional- and required-peer hoists read the same run-resolved
candidate set but pick differently, so the transient-walk regression
scenario from pnpm/pnpm#13567 is now asserted through both pickers:
the required-peer variant pins that an unreachable transiently-walked
version must not win the dedupe-onto-highest-satisfying pick. Verified
to fail against the pre-pnpm/pnpm#13570 resolver with the exact
symptom (host suffixed with the unreachable pin). The shared fixture
is extracted into a resolve_with_transient_shared_walk driver.

Related to pnpm/pnpm#13567.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788207379&installation_model_id=426870&pr_number=13572&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13572&signature=10fee72baeff41d79c9eddb98012f6f28a2fe497ae1b2c79534ac29fc33348b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency resolution for optional and required peer dependencies.
  * Prevented unreachable dependency versions from affecting peer dependency hoisting.
  * Ensured reachable versions are selected consistently when deduplicating required peer dependencies.

* **Tests**
  * Expanded regression coverage for shared dependency trees, optional peer dependencies, and required peer dependency scenarios.
  * Added coverage for complex dependency resolution interleavings to verify consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->