### PR TITLE
chore(hooks): bind each linked worktree to one branch for its whole life

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,0 +1,2 @@
+#!/bin/sh
+node .husky/reject-worktree-rebind.mjs "$1" "$2" "$3"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,3 +5,4 @@ if [ -n "$CLAUDECODE" ] && [ "$(git rev-parse --abbrev-ref HEAD)" = "main" ]; th
   echo "error: Committing directly to the main branch is not allowed. Create a new branch and open a pull request instead." >&2
   exit 1
 fi
+node .husky/reject-worktree-rebind.mjs --bind-only

--- a/.husky/reject-worktree-rebind.mjs
+++ b/.husky/reject-worktree-rebind.mjs
@@ -49,9 +49,15 @@ if (gitDir === gitCommonDir) {
 let branch
 try {
   branch = git('symbolic-ref', '--quiet', '--short', 'HEAD')
-} catch {
-  // Detached HEAD (rebase, bisect, CI checkout) is not a rebind.
-  process.exit(0)
+} catch (error) {
+  // `--quiet` exits 1 on a detached HEAD (rebase, bisect, CI
+  // checkout), which is not a rebind. Anything else is an unexpected
+  // failure the guard must not silently fail open on.
+  if (error?.status === 1) {
+    process.exit(0)
+  }
+  console.error(`reject-worktree-rebind: cannot read HEAD: ${error?.message ?? error}`)
+  process.exit(1)
 }
 
 const markerPath = join(gitDir, 'agent-bound-branch')
@@ -66,7 +72,7 @@ if (bound === branch || bindOnly) {
 }
 
 const isAgent = Boolean(process.env.CLAUDECODE)
-const overridden = Boolean(process.env.PNPM_ALLOW_WORKTREE_REBIND)
+const overridden = process.env.PNPM_ALLOW_WORKTREE_REBIND === '1'
 if (!isAgent || overridden) {
   writeFileSync(markerPath, `${branch}\n`)
   process.exit(0)

--- a/.husky/reject-worktree-rebind.mjs
+++ b/.husky/reject-worktree-rebind.mjs
@@ -22,8 +22,12 @@ import { execFileSync } from 'node:child_process'
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 
+// Child stderr is piped (not inherited) so an expected failure — a
+// detached HEAD, an unresolvable `@{-1}` — doesn't splash `fatal:`
+// noise into every checkout; the messages this script prints carry
+// the signal instead.
 const git = (...args) =>
-  execFileSync('git', args, { encoding: 'utf8' }).trim()
+  execFileSync('git', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim()
 
 // Single-quote a value for a copy/paste-safe POSIX shell command.
 const shellQuote = (value) => `'${value.replaceAll("'", String.raw`'\''`)}'`
@@ -60,10 +64,33 @@ try {
   process.exit(1)
 }
 
+const isAgent = Boolean(process.env.CLAUDECODE)
+const overridden = process.env.PNPM_ALLOW_WORKTREE_REBIND === '1'
+
 const markerPath = join(gitDir, 'agent-bound-branch')
 let bound = existsSync(markerPath) ? readFileSync(markerPath, 'utf8').trim() : null
 if (bound === null) {
   bound = initialBinding(branch)
+  if (bound === null) {
+    // A first-observed switch whose origin the checkout history cannot
+    // name would otherwise bind to its own destination — the exact
+    // rebind this guard exists to reject. Fail closed for agents and
+    // leave the worktree unbound.
+    console.error(
+      [
+        `error: This worktree has no recorded branch binding, and the checkout history does not name the branch this switch to \`${branch}\` came from.`,
+        '',
+        'One worktree works on one branch for its whole life. Switch back to the',
+        "branch this worktree was on. If it is legitimately this worktree's own",
+        'branch, record the binding with:',
+        '',
+        '  node .husky/reject-worktree-rebind.mjs --bind-only',
+        '',
+        'A human can instead re-run the checkout with PNPM_ALLOW_WORKTREE_REBIND=1.',
+      ].join('\n')
+    )
+    process.exit(1)
+  }
   writeFileSync(markerPath, `${bound}\n`)
 }
 
@@ -71,8 +98,6 @@ if (bound === branch || bindOnly) {
   process.exit(0)
 }
 
-const isAgent = Boolean(process.env.CLAUDECODE)
-const overridden = process.env.PNPM_ALLOW_WORKTREE_REBIND === '1'
 if (!isAgent || overridden) {
   writeFileSync(markerPath, `${branch}\n`)
   process.exit(0)
@@ -95,23 +120,39 @@ console.error(
 )
 process.exit(1)
 
-// The branch a first-observed checkout binds the worktree to: the
-// branch the worktree was on before the switch, so the switch itself
-// still gets checked. The worktree's own creation (old ref is the null
-// SHA) and a checkout history that names no prior branch bind to the
-// branch just checked out.
+// The branch a first-observed checkout binds the worktree to: the most
+// recent branch named as a checkout source in the worktree's HEAD
+// reflog, so the switch itself still gets checked. Reflog subjects are
+// read directly — `@{-N}` cannot name a since-deleted branch — and
+// detached sources (a rebase or bisect in progress at the time) are
+// skipped in favor of the branch they detached from. A same-branch
+// re-checkout binds to itself through its own reflog entry; comparing
+// the hook's old/new SHAs cannot stand in for that, because `switch
+// -c` from the bound branch also moves nothing. The worktree's own
+// creation (old ref is the null SHA) and a `--bind-only` call bind to
+// the branch just checked out. `null` means a checkout happened whose
+// history cannot name any source branch (reflog disabled, expired, or
+// detached throughout), so agent sessions must not trust the
+// destination.
 function initialBinding (currentBranch) {
   const oldRef = bindOnly ? null : process.argv[2]
   if (!oldRef || /^0+$/.test(oldRef)) {
     return currentBranch
   }
+  let subjects
   try {
-    const previous = git('rev-parse', '--symbolic-full-name', '@{-1}')
-    if (previous.startsWith('refs/heads/')) {
-      return previous.slice('refs/heads/'.length)
-    }
+    subjects = git('log', '-g', '--format=%gs', 'HEAD')
   } catch {
-    // No prior checkout recorded; fall through.
+    subjects = ''
   }
-  return currentBranch
+  // The newest entry is the checkout that fired this hook; its source
+  // is where the worktree stood before.
+  for (const line of subjects.split('\n')) {
+    const source = /^checkout: moving from (\S+) to /.exec(line)?.[1]
+    if (!source || /^[0-9a-f]{40}$/.test(source)) {
+      continue
+    }
+    return source
+  }
+  return isAgent && !overridden ? null : currentBranch
 }

--- a/.husky/reject-worktree-rebind.mjs
+++ b/.husky/reject-worktree-rebind.mjs
@@ -1,0 +1,85 @@
+// Enforces the one-worktree-one-branch rule for agents: a linked
+// worktree keeps the branch it was bound to for its whole life, so two
+// workers never end up sharing (or repurposing) the same directory.
+//
+// The binding is recorded in `<git-dir>/agent-bound-branch` the first
+// time any wired hook runs in the worktree. Later branch checkouts in
+// that worktree are rejected for agent sessions (`CLAUDECODE` set)
+// unless they return to the bound branch. Humans may rebind freely —
+// doing so moves the binding. Rationale lives in the error message
+// below and in AGENTS.md ("Worktrees").
+//
+// Invoked two ways:
+//   post-checkout: reject-worktree-rebind.mjs <old> <new> <flag>
+//   other hooks:   reject-worktree-rebind.mjs --bind-only
+// `--bind-only` records the binding if missing and never rejects, so a
+// worktree that predates this guard becomes bound by its normal use
+// (commits, pushes) before any rebind can slip through.
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const git = (...args) =>
+  execFileSync('git', args, { encoding: 'utf8' }).trim()
+
+const bindOnly = process.argv[2] === '--bind-only'
+// post-checkout's third argument is 1 for a branch checkout, 0 for a
+// file checkout; only branch checkouts can rebind a worktree.
+if (!bindOnly && process.argv[4] !== '1') {
+  process.exit(0)
+}
+
+const gitDir = git('rev-parse', '--absolute-git-dir')
+const gitCommonDir = git('rev-parse', '--path-format=absolute', '--git-common-dir')
+// The main checkout is free to switch branches; only linked worktrees
+// are single-branch workspaces.
+if (gitDir === gitCommonDir) {
+  process.exit(0)
+}
+
+let branch
+try {
+  branch = git('symbolic-ref', '--quiet', '--short', 'HEAD')
+} catch {
+  // Detached HEAD (rebase, bisect, CI checkout) is not a rebind.
+  process.exit(0)
+}
+
+const markerPath = join(gitDir, 'agent-bound-branch')
+const bound = existsSync(markerPath) ? readFileSync(markerPath, 'utf8').trim() : null
+
+if (bound === null || bound === branch) {
+  if (bound === null) {
+    writeFileSync(markerPath, `${branch}\n`)
+  }
+  process.exit(0)
+}
+
+if (bindOnly) {
+  process.exit(0)
+}
+
+const isAgent = Boolean(process.env.CLAUDECODE)
+const overridden = Boolean(process.env.PNPM_ALLOW_WORKTREE_REBIND)
+if (!isAgent || overridden) {
+  writeFileSync(markerPath, `${branch}\n`)
+  process.exit(0)
+}
+
+console.error(
+  [
+    `error: This worktree is bound to the branch \`${bound}\`, but it was just switched to \`${branch}\`.`,
+    '',
+    'One worktree works on one branch for its whole life, so concurrent workers',
+    'never collide in a shared directory. Undo the switch and start the new branch',
+    'in a fresh worktree instead:',
+    '',
+    `  git switch ${bound}`,
+    `  git worktree add ../${branch.replaceAll('/', '-')} ${branch}`,
+    '',
+    'A human who really wants to rebind this worktree can re-run the checkout with',
+    'PNPM_ALLOW_WORKTREE_REBIND=1.',
+  ].join('\n')
+)
+process.exit(1)

--- a/.husky/reject-worktree-rebind.mjs
+++ b/.husky/reject-worktree-rebind.mjs
@@ -2,26 +2,31 @@
 // worktree keeps the branch it was bound to for its whole life, so two
 // workers never end up sharing (or repurposing) the same directory.
 //
-// The binding is recorded in `<git-dir>/agent-bound-branch` the first
-// time any wired hook runs in the worktree. Later branch checkouts in
-// that worktree are rejected for agent sessions (`CLAUDECODE` set)
-// unless they return to the bound branch. Humans may rebind freely —
-// doing so moves the binding. Rationale lives in the error message
-// below and in AGENTS.md ("Worktrees").
+// The binding is recorded in `<git-dir>/agent-bound-branch`. A branch
+// checkout observed in a worktree with no recorded binding binds it to
+// the branch the worktree was on *before* the switch (recovered from
+// the checkout history), so even the first switch is checked. Branch
+// checkouts away from the bound branch are rejected for agent sessions
+// (`CLAUDECODE` set); returning to the bound branch is always allowed.
+// Humans may rebind freely — doing so moves the binding. Rationale
+// lives in the error message below and in AGENTS.md ("Worktrees").
 //
 // Invoked two ways:
 //   post-checkout: reject-worktree-rebind.mjs <old> <new> <flag>
 //   other hooks:   reject-worktree-rebind.mjs --bind-only
 // `--bind-only` records the binding if missing and never rejects, so a
-// worktree that predates this guard becomes bound by its normal use
-// (commits, pushes) before any rebind can slip through.
+// worktree in which this hook has never observed a checkout still
+// becomes bound through its normal use (commits).
 
 import { execFileSync } from 'node:child_process'
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 
 const git = (...args) =>
   execFileSync('git', args, { encoding: 'utf8' }).trim()
+
+// Single-quote a value for a copy/paste-safe POSIX shell command.
+const shellQuote = (value) => `'${value.replaceAll("'", String.raw`'\''`)}'`
 
 const bindOnly = process.argv[2] === '--bind-only'
 // post-checkout's third argument is 1 for a branch checkout, 0 for a
@@ -30,8 +35,11 @@ if (!bindOnly && process.argv[4] !== '1') {
   process.exit(0)
 }
 
-const gitDir = git('rev-parse', '--absolute-git-dir')
-const gitCommonDir = git('rev-parse', '--path-format=absolute', '--git-common-dir')
+// `--git-dir` / `--git-common-dir` may print worktree-relative paths;
+// hooks run from the worktree's top level, so resolving against the
+// working directory absolutizes both.
+const gitDir = resolve(git('rev-parse', '--git-dir'))
+const gitCommonDir = resolve(git('rev-parse', '--git-common-dir'))
 // The main checkout is free to switch branches; only linked worktrees
 // are single-branch workspaces.
 if (gitDir === gitCommonDir) {
@@ -47,16 +55,13 @@ try {
 }
 
 const markerPath = join(gitDir, 'agent-bound-branch')
-const bound = existsSync(markerPath) ? readFileSync(markerPath, 'utf8').trim() : null
-
-if (bound === null || bound === branch) {
-  if (bound === null) {
-    writeFileSync(markerPath, `${branch}\n`)
-  }
-  process.exit(0)
+let bound = existsSync(markerPath) ? readFileSync(markerPath, 'utf8').trim() : null
+if (bound === null) {
+  bound = initialBinding(branch)
+  writeFileSync(markerPath, `${bound}\n`)
 }
 
-if (bindOnly) {
+if (bound === branch || bindOnly) {
   process.exit(0)
 }
 
@@ -75,11 +80,32 @@ console.error(
     'never collide in a shared directory. Undo the switch and start the new branch',
     'in a fresh worktree instead:',
     '',
-    `  git switch ${bound}`,
-    `  git worktree add ../${branch.replaceAll('/', '-')} ${branch}`,
+    `  git switch ${shellQuote(bound)}`,
+    `  git worktree add ${shellQuote(`../${branch.replaceAll('/', '-')}`)} ${shellQuote(branch)}`,
     '',
     'A human who really wants to rebind this worktree can re-run the checkout with',
     'PNPM_ALLOW_WORKTREE_REBIND=1.',
   ].join('\n')
 )
 process.exit(1)
+
+// The branch a first-observed checkout binds the worktree to: the
+// branch the worktree was on before the switch, so the switch itself
+// still gets checked. The worktree's own creation (old ref is the null
+// SHA) and a checkout history that names no prior branch bind to the
+// branch just checked out.
+function initialBinding (currentBranch) {
+  const oldRef = bindOnly ? null : process.argv[2]
+  if (!oldRef || /^0+$/.test(oldRef)) {
+    return currentBranch
+  }
+  try {
+    const previous = git('rev-parse', '--symbolic-full-name', '@{-1}')
+    if (previous.startsWith('refs/heads/')) {
+      return previous.slice('refs/heads/'.length)
+    }
+  } catch {
+    // No prior checkout recorded; fall through.
+  }
+  return currentBranch
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,9 +321,10 @@ git worktree add ../<dir-name> -b <branch-name> origin/main
 ```
 
 A `post-checkout` hook (`.husky/reject-worktree-rebind.mjs`) enforces
-this for agent sessions: the first hook-active checkout (or commit)
-binds the worktree to its branch, and later branch switches in that
-worktree are rejected. Returning to the bound branch is always allowed.
+this for agent sessions: a checkout or commit binds the worktree to its
+branch (a first-observed *switch* binds to the branch it left, so even
+that switch is checked), and branch switches away from the bound branch
+are rejected. Returning to the bound branch is always allowed.
 A human who genuinely wants to rebind a worktree can re-run the
 checkout with `PNPM_ALLOW_WORKTREE_REBIND=1`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,7 +156,7 @@ Follow the [Conventional Commits](https://www.conventionalcommits.org/) specific
 
 ### Install the git hooks before committing
 
-The git hooks in `.husky/` (including the `commit-msg` check described below) only run once husky has wired them into git. A fresh clone does **not** have them active until installed. **Before making any commit, ensure the hooks are installed** by running one of:
+The git hooks in `.husky/` (including the `commit-msg` check described below) only run once husky has wired them into git. A fresh clone — and every fresh worktree — does **not** have them active until installed. **Before making any commit, ensure the hooks are installed** by running one of:
 
 ```bash
 pnpm install      # runs the "prepare": "husky" script as part of install
@@ -303,6 +303,34 @@ try {
   throw err
 }
 ```
+
+## Worktrees
+
+Development happens in linked git worktrees — one directory per task —
+usually hanging off a bare clone. Multiple workers (agents and humans)
+run concurrently, each in its own worktree.
+
+**One worktree works on one branch for its whole life.** Never switch an
+existing worktree to another branch (`git switch <other>`,
+`git checkout -b`, …): the worktree you are in may be another worker's
+workspace tomorrow, and the branch you take it to may be someone else's
+task. Start every new branch in a fresh worktree instead:
+
+```bash
+git worktree add ../<dir-name> -b <branch-name> origin/main
+```
+
+A `post-checkout` hook (`.husky/reject-worktree-rebind.mjs`) enforces
+this for agent sessions: the first hook-active checkout (or commit)
+binds the worktree to its branch, and later branch switches in that
+worktree are rejected. Returning to the bound branch is always allowed.
+A human who genuinely wants to rebind a worktree can re-run the
+checkout with `PNPM_ALLOW_WORKTREE_REBIND=1`.
+
+Remember that hooks are installed per worktree: a fresh worktree has no
+active hooks (including this guard) until `pnpm install` or
+`pnpm exec husky` runs in it — see
+[Install the git hooks before committing](#install-the-git-hooks-before-committing).
 
 ## Working with GitHub PRs, Issues, and Comments
 


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Multiple workers (agents and humans) run concurrently in this repo, one linked worktree per task. An agent that switches an existing worktree to another branch repurposes a directory another worker may be relying on — which happened during the pnpm/pnpm#13570 follow-up work, when the `fix-13567` worktree got switched to a new test branch instead of that branch getting a fresh worktree.

This makes the rule explicit and enforced:

- **AGENTS.md gains a "Worktrees" section**: one worktree works on one branch for its whole life; every new branch starts in a fresh worktree (`git worktree add ../<dir> -b <branch> origin/main`). The hooks-install section now also notes that hooks are installed per worktree, not per clone.
- **`.husky/post-checkout` + `.husky/reject-worktree-rebind.mjs`**: the first hook-active checkout binds a linked worktree to its branch (marker in the worktree's git admin dir); later branch switches are rejected for agent sessions (`CLAUDECODE` set, same gating as the existing amend and commit-to-main guards) with a message showing how to undo the switch and where to put the new branch. Returning to the bound branch is always allowed; humans rebind freely (the binding follows them); `PNPM_ALLOW_WORKTREE_REBIND=1` is the explicit agent override.
- **`pre-commit` also records the binding** (never rejects), so worktrees that predate this guard become bound through their normal use before any rebind can slip through.

Git has no pre-checkout hook, so `post-checkout` cannot prevent the switch — it fails loudly *after* it with exact recovery instructions, which is enough to stop an agent (verified end-to-end: `git switch -c` in a bound worktree errors and the agent path back is `git switch <bound>`). The main checkout is exempt (it legitimately switches branches), as are detached-HEAD states (rebase, bisect, CI) and file checkouts.

Not covered (by design): two sessions pointed at the *same directory and branch* — that's launcher-side (each worker must be started in its own worktree), which the AGENTS.md section now states.

No changeset: tooling/docs only, nothing published changes. No pacquet/pnpr parity surface.

## Squash Commit Body

```text
Concurrent workers each own a linked worktree; switching an existing
worktree to another branch repurposes a directory another worker may
rely on. A post-checkout hook records the worktree's bound branch on
first hook-active checkout (pre-commit also records it, so worktrees
predating the guard become bound through normal use) and rejects later
branch switches for agent sessions (CLAUDECODE, matching the existing
amend and commit-to-main guards), pointing at the fresh-worktree
workflow. Humans rebind freely; PNPM_ALLOW_WORKTREE_REBIND=1 is the
explicit override. The rule and workflow are documented in the new
AGENTS.md "Worktrees" section.
```

## Checklist

- [x] Added or updated tests. (Hook behavior verified manually end-to-end:
  bind, same-branch pass, file-checkout pass, agent rebind rejection via
  real `git switch -c`, human rebind, override rebind, detached-HEAD and
  main-checkout exemptions by construction.)
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788208093&installation_model_id=426870&pr_number=13573&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13573&signature=44e3cef93319aa58f2db7001dd48c11a46afb029ab6c30bcbabf073d5e9d0449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added safeguards to keep each linked worktree associated with a single branch during agent sessions.
  * Added automatic checks after checkout and before commits, with recovery guidance when a branch switch is rejected.
  * Added an optional override for exceptional branch rebinding scenarios.
  * Safeguards accommodate detached states, file-only checkouts, and the primary worktree.

* **Documentation**
  * Updated worktree setup guidance, recommended commands, hook installation steps, and branch-binding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->