### PR TITLE
fix(resolving-deps-resolver): stop re-walking a recorded subtree

### DIFF
--- a/.changeset/bounded-peer-chain-resolution.md
+++ b/.changeset/bounded-peer-chain-resolution.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Installing a dependency chain whose packages carry peer dependencies no longer expands exponentially with the depth of the chain. A single project with a single such dependency could exhaust memory before finishing; it now resolves in tens of megabytes.

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/reuse.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/reuse.rs
@@ -650,9 +650,10 @@ where
                 });
                 realized.insert(dep.alias, dep.node_id);
             }
-            record_children(
+            let published = record_children(
                 ctx,
                 &id,
+                &children_owner.owner,
                 by_id,
                 RecordedChildrenContext {
                     peer_shadowed: Arc::clone(&children_owner.peer_shadowed),
@@ -660,7 +661,13 @@ where
                     update_active: !matches!(ctx.update_reuse_scope(), UpdateReuseScope::All),
                 },
             );
-            crate::resolved_tree::TreeChildren::Realized(realized)
+            if published {
+                crate::resolved_tree::TreeChildren::Realized(realized)
+            } else {
+                crate::resolved_tree::TreeChildren::Lazy {
+                    parent_ids: AncestorIds::from(Arc::clone(ancestor_ids)),
+                }
+            }
         } else {
             crate::resolved_tree::TreeChildren::Lazy {
                 parent_ids: AncestorIds::from(Arc::clone(ancestor_ids)),

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/reuse.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/reuse.rs
@@ -600,8 +600,7 @@ where
     let next_ancestors: Vec<String> =
         ancestor_ids.iter().cloned().chain(std::iter::once(id.clone())).collect();
     let next_ancestors = Arc::new(next_ancestors);
-    let children_owner =
-        claim_children_owner(ctx, &id, depth, ancestor_ids, HashSet::default(), Some(&key));
+    let children_owner = claim_children_owner(ctx, &id, depth, ancestor_ids, HashSet::default());
 
     let children = if children_owner.owns_children {
         let child_results = child_refs

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/reuse.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/reuse.rs
@@ -600,7 +600,8 @@ where
     let next_ancestors: Vec<String> =
         ancestor_ids.iter().cloned().chain(std::iter::once(id.clone())).collect();
     let next_ancestors = Arc::new(next_ancestors);
-    let children_owner = claim_children_owner(ctx, &id, depth, ancestor_ids, HashSet::default());
+    let children_owner =
+        claim_children_owner(ctx, &id, depth, ancestor_ids, HashSet::default(), Some(&key));
 
     let children = if children_owner.owns_children {
         let child_results = child_refs

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/reuse.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/reuse.rs
@@ -29,8 +29,9 @@ use super::{
     tree_ctx::TreeCtx,
     walk::{node_alias, parent_ids_contain_sequence, resolve_node},
     workspace_ctx::{
-        DirectDepVersions, claim_children_owner, insert_tree_node, is_current_children_owner,
-        make_non_owner_nodes_lazy, remember_node_parent_ids,
+        DirectDepVersions, RecordedChildrenContext, claim_children_owner, insert_tree_node,
+        is_current_children_owner, make_non_owner_nodes_lazy, record_children,
+        remember_node_parent_ids,
     },
 };
 
@@ -649,8 +650,16 @@ where
                 });
                 realized.insert(dep.alias, dep.node_id);
             }
-            lock_recoverable(&ctx.workspace.children_by_id).insert(id.clone(), Arc::new(by_id));
-            ctx.workspace.record_children_by_id_write(&id);
+            record_children(
+                ctx,
+                &id,
+                by_id,
+                RecordedChildrenContext {
+                    peer_shadowed: Arc::clone(&children_owner.peer_shadowed),
+                    prior_key: Some(key.clone()),
+                    update_active: !matches!(ctx.update_reuse_scope(), UpdateReuseScope::All),
+                },
+            );
             crate::resolved_tree::TreeChildren::Realized(realized)
         } else {
             crate::resolved_tree::TreeChildren::Lazy {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
@@ -42,9 +42,9 @@ use super::{
         project_relative_cache_scope,
     },
     workspace_ctx::{
-        ChildSpec, ChildrenOwnerClaim, WantedKey, claim_children_owner, insert_tree_node,
-        is_current_children_owner, make_non_owner_nodes_lazy, register_peer_dep_names,
-        remember_node_parent_ids,
+        ChildSpec, ChildrenOwnerClaim, WantedKey, claim_children_owner, has_recorded_children,
+        insert_tree_node, is_current_children_owner, make_non_owner_nodes_lazy,
+        register_peer_dep_names, remember_node_parent_ids,
     },
 };
 
@@ -439,6 +439,7 @@ where
             parent_pkg_aliases,
             ctx.workspace.auto_install_peers,
         ),
+        prior_key.as_ref(),
     );
     let peer_dependencies = if is_link {
         BTreeMap::new()
@@ -558,6 +559,22 @@ where
         // map: a linked node has no children of its own here.
         crate::resolved_tree::TreeChildren::Realized(BTreeMap::new())
     } else if !children_owner.owns_children {
+        crate::resolved_tree::TreeChildren::Lazy {
+            parent_ids: AncestorIds::from(Arc::clone(&parent_ancestors)),
+        }
+    } else if children_owner.recorded_children_reusable
+        && !resolves_children_through_catalogs(&result)
+        && has_recorded_children(ctx, &id)
+    {
+        // A winning claim only means this occurrence outranks the one
+        // that recorded the children — not that the children differ.
+        // Concurrent occurrences of the same package take turns
+        // outranking each other, and each turn used to re-walk the whole
+        // subtree and leave its occurrence nodes behind, which is what
+        // made a peer-carrying chain expand exponentially with depth
+        // (https://github.com/pnpm/pnpm/issues/13574). Expand from the
+        // recorded children instead, exactly as a losing occurrence
+        // does.
         crate::resolved_tree::TreeChildren::Lazy {
             parent_ids: AncestorIds::from(Arc::clone(&parent_ancestors)),
         }
@@ -1045,6 +1062,17 @@ pub(super) async fn warm_children_resolutions<Chain>(
         })
         .pipe(future::join_all)
         .await;
+}
+
+/// Whether this package's child specifiers pass through the importer's
+/// catalogs, which makes them a property of the resolving importer
+/// rather than of the package id — the one input a
+/// [`ChildrenOwnerClaim::recorded_children_reusable`] winner cannot
+/// assume it shares with the occurrence that recorded them.
+fn resolves_children_through_catalogs(
+    result: &pacquet_resolving_resolver_base::ResolveResult,
+) -> bool {
+    result.resolved_via == "workspace" && result.id.as_str().starts_with("file:")
 }
 
 /// The install aliases one resolved level contributes to its

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
@@ -552,7 +552,9 @@ where
         current_is_optional,
         prior_key,
     } = pending;
-    let children_context = RecordedChildrenContext {
+    // Built on demand: a linked node and a losing occurrence never
+    // reach either the reuse test or the recording.
+    let children_context = || RecordedChildrenContext {
         peer_shadowed: Arc::clone(&children_owner.peer_shadowed),
         prior_key: prior_key.clone(),
         update_active: !matches!(ctx.update_reuse_scope(), super::UpdateReuseScope::All),
@@ -567,7 +569,7 @@ where
             parent_ids: AncestorIds::from(Arc::clone(&parent_ancestors)),
         }
     } else if !resolves_children_through_catalogs(&result)
-        && recorded_children_match(ctx, &id, &children_context)
+        && recorded_children_match(ctx, &id, &children_context())
     {
         // A winning claim means this occurrence outranks the one that
         // recorded the children, not that the children differ.
@@ -745,8 +747,13 @@ where
                 });
                 realized.insert(dep.alias, dep.node_id);
             }
-            record_children(ctx, &id, by_id, children_context.clone());
-            crate::resolved_tree::TreeChildren::Realized(realized)
+            if record_children(ctx, &id, &children_owner.owner, by_id, children_context()) {
+                crate::resolved_tree::TreeChildren::Realized(realized)
+            } else {
+                crate::resolved_tree::TreeChildren::Lazy {
+                    parent_ids: AncestorIds::from(Arc::clone(&parent_ancestors)),
+                }
+            }
         } else {
             crate::resolved_tree::TreeChildren::Lazy {
                 parent_ids: AncestorIds::from(Arc::clone(&parent_ancestors)),

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
@@ -42,9 +42,10 @@ use super::{
         project_relative_cache_scope,
     },
     workspace_ctx::{
-        ChildSpec, ChildrenOwnerClaim, WantedKey, claim_children_owner, has_recorded_children,
+        ChildSpec, ChildrenOwnerClaim, RecordedChildrenContext, WantedKey, claim_children_owner,
         insert_tree_node, is_current_children_owner, make_non_owner_nodes_lazy,
-        register_peer_dep_names, remember_node_parent_ids,
+        record_children_context, recorded_children_match, register_peer_dep_names,
+        remember_node_parent_ids,
     },
 };
 
@@ -553,6 +554,11 @@ where
         current_is_optional,
         prior_key,
     } = pending;
+    let children_context = RecordedChildrenContext {
+        peer_shadowed: Arc::clone(&children_owner.peer_shadowed),
+        prior_key: prior_key.clone(),
+        update_active: !matches!(ctx.update_reuse_scope(), super::UpdateReuseScope::All),
+    };
     let children = if is_link {
         // Linked nodes don't walk their manifest's deps — see the
         // `is_link` comment block above. They get an empty `Realized`
@@ -562,9 +568,8 @@ where
         crate::resolved_tree::TreeChildren::Lazy {
             parent_ids: AncestorIds::from(Arc::clone(&parent_ancestors)),
         }
-    } else if children_owner.recorded_children_reusable
-        && !resolves_children_through_catalogs(&result)
-        && has_recorded_children(ctx, &id)
+    } else if !resolves_children_through_catalogs(&result)
+        && recorded_children_match(ctx, &id, &children_context)
     {
         // A winning claim only means this occurrence outranks the one
         // that recorded the children — not that the children differ.
@@ -745,6 +750,7 @@ where
                 realized.insert(dep.alias, dep.node_id);
             }
             lock_recoverable(&ctx.workspace.children_by_id).insert(id.clone(), Arc::new(by_id));
+            record_children_context(ctx, &id, children_context.clone());
             ctx.workspace.record_children_by_id_write(&id);
             crate::resolved_tree::TreeChildren::Realized(realized)
         } else {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
@@ -43,9 +43,8 @@ use super::{
     },
     workspace_ctx::{
         ChildSpec, ChildrenOwnerClaim, RecordedChildrenContext, WantedKey, claim_children_owner,
-        insert_tree_node, is_current_children_owner, make_non_owner_nodes_lazy,
-        record_children_context, recorded_children_match, register_peer_dep_names,
-        remember_node_parent_ids,
+        insert_tree_node, is_current_children_owner, make_non_owner_nodes_lazy, record_children,
+        recorded_children_match, register_peer_dep_names, remember_node_parent_ids,
     },
 };
 
@@ -570,15 +569,13 @@ where
     } else if !resolves_children_through_catalogs(&result)
         && recorded_children_match(ctx, &id, &children_context)
     {
-        // A winning claim only means this occurrence outranks the one
-        // that recorded the children — not that the children differ.
-        // Concurrent occurrences of the same package take turns
-        // outranking each other, and each turn used to re-walk the whole
-        // subtree and leave its occurrence nodes behind, which is what
-        // made a peer-carrying chain expand exponentially with depth
-        // (https://github.com/pnpm/pnpm/issues/13574). Expand from the
-        // recorded children instead, exactly as a losing occurrence
-        // does.
+        // A winning claim means this occurrence outranks the one that
+        // recorded the children, not that the children differ.
+        // Occurrences of one package race for the claim, so walking on
+        // every win costs a redundant subtree walk and a second set of
+        // occurrence nodes per race — enough, down a peer-carrying
+        // chain, to expand exponentially with its depth
+        // (https://github.com/pnpm/pnpm/issues/13574).
         crate::resolved_tree::TreeChildren::Lazy {
             parent_ids: AncestorIds::from(Arc::clone(&parent_ancestors)),
         }
@@ -748,9 +745,7 @@ where
                 });
                 realized.insert(dep.alias, dep.node_id);
             }
-            lock_recoverable(&ctx.workspace.children_by_id).insert(id.clone(), Arc::new(by_id));
-            record_children_context(ctx, &id, children_context.clone());
-            ctx.workspace.record_children_by_id_write(&id);
+            record_children(ctx, &id, by_id, children_context.clone());
             crate::resolved_tree::TreeChildren::Realized(realized)
         } else {
             crate::resolved_tree::TreeChildren::Lazy {
@@ -1071,9 +1066,9 @@ pub(super) async fn warm_children_resolutions<Chain>(
 
 /// Whether this package's child specifiers pass through the importer's
 /// catalogs, which makes them a property of the resolving importer
-/// rather than of the package id — the one input a
-/// [`ChildrenOwnerClaim::recorded_children_reusable`] winner cannot
-/// assume it shares with the occurrence that recorded them.
+/// rather than of the package id — the one input
+/// [`fn@recorded_children_match`] cannot compare, since the recorded
+/// context does not carry the catalogs the recording importer used.
 fn resolves_children_through_catalogs(
     result: &pacquet_resolving_resolver_base::ResolveResult,
 ) -> bool {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
@@ -440,7 +440,6 @@ where
             parent_pkg_aliases,
             ctx.workspace.auto_install_peers,
         ),
-        prior_key.as_ref(),
     );
     let peer_dependencies = if is_link {
         BTreeMap::new()

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
@@ -152,6 +152,41 @@ struct ChildrenOwnerEntry {
     pub(super) peer_shadowed: Arc<HashSet<String>>,
 }
 
+/// What a recorded `children_by_id` entry was resolved under. A later
+/// occurrence may expand from that entry instead of walking the
+/// package's manifest again only when its own context equals this one:
+/// each field can change which children the walk produces.
+#[derive(Debug, Clone)]
+pub(super) struct RecordedChildrenContext {
+    /// Dependencies the package's own `peerDependencies` shadow, which
+    /// the walk drops from its children.
+    pub(super) peer_shadowed: Arc<HashSet<String>>,
+    /// The prior-lockfile key whose snapshot pinned the children, if the
+    /// walk reused one.
+    pub(super) prior_key: Option<PkgNameVerPeer>,
+    /// Whether the resolving importer had an active update policy, which
+    /// re-resolves what a keep-all importer reuses.
+    pub(super) update_active: bool,
+}
+
+impl RecordedChildrenContext {
+    /// Two contexts produce the same children.
+    ///
+    /// The preferred-versions overlay is deliberately not part of the
+    /// test. `children_by_id` records one child list per package id,
+    /// and every occurrence that does not own the children already
+    /// expands from it whatever its own overlay says — the overlay
+    /// only ever decides which occurrence's versions get *recorded*.
+    /// Requiring identical overlays here would mean requiring identical
+    /// parents, which never holds for the occurrences that race, and
+    /// measurably reinstates the expansion this test exists to prevent.
+    pub(super) fn produces_same_children_as(&self, other: &Self) -> bool {
+        self.peer_shadowed == other.peer_shadowed
+            && self.prior_key == other.prior_key
+            && self.update_active == other.update_active
+    }
+}
+
 /// Workspace-shared maps. Every per-importer [`TreeCtx`] in a
 /// multi-importer install holds an `Arc<WorkspaceTreeCtx>` so the
 /// resolver's per-`pkgIdWithPatchHash` dedup (`packages`,
@@ -203,6 +238,9 @@ pub struct WorkspaceTreeCtx {
         Mutex<HashMap<WantedKey, Arc<pacquet_resolving_resolver_base::ResolveResult>>>,
     pub(super) children_specs_by_id: Mutex<HashMap<String, Arc<Vec<ChildSpec>>>>,
     pub(super) children_by_id: Mutex<HashMap<String, Arc<Vec<crate::resolved_tree::ChildEdge>>>>,
+    /// The context each `children_by_id` entry was recorded under. See
+    /// [`RecordedChildrenContext`].
+    children_context_by_id: Mutex<HashMap<String, RecordedChildrenContext>>,
     children_owner_by_id: Mutex<HashMap<String, ChildrenOwnerEntry>>,
     node_parent_ids_by_id: Mutex<HashMap<NodeId, Arc<Vec<String>>>>,
     /// Reverse index over `dependencies_tree`: every occurrence node
@@ -385,6 +423,7 @@ impl Default for WorkspaceTreeCtx {
             resolved_by_wanted: Mutex::new(HashMap::default()),
             children_specs_by_id: Mutex::new(HashMap::default()),
             children_by_id: Mutex::new(HashMap::default()),
+            children_context_by_id: Mutex::new(HashMap::default()),
             children_owner_by_id: Mutex::new(HashMap::default()),
             node_parent_ids_by_id: Mutex::new(HashMap::default()),
             nodes_by_pkg_id: Mutex::new(HashMap::default()),
@@ -1097,24 +1136,16 @@ pub(super) struct ChildrenOwnerClaim {
     /// lost. See [`ChildrenOwnerEntry::peer_shadowed`].
     pub(super) peer_shadowed: Arc<HashSet<String>>,
     /// A winning claim displaced an owner whose shadowed-dependency set
-    /// equals this occurrence's. Children resolve identically under
-    /// both, so the other occurrences' realized children stay valid and
-    /// the winner skips the lazy-flip (and the engine-invalidating
-    /// rewrite signal) it would otherwise broadcast.
-    pub(super) children_context_unchanged: bool,
-    /// The displaced owner resolved this package's children under
-    /// conditions this occurrence would reproduce exactly: the same
-    /// shadowed-dependency set *and* the same update policy. Walking
-    /// them again would rebuild identical edges and leave a second
-    /// occurrence subtree behind, so the winner can reuse the recorded
-    /// children instead — see [`fn@super::walk::walk_node_children`].
+    /// equals this occurrence's, so the other occurrences' realized
+    /// children — including a subtree reused from the prior lockfile —
+    /// stay valid and the winner skips the lazy-flip (and the
+    /// engine-invalidating rewrite signal) it would otherwise broadcast.
     ///
-    /// The update policy and the prior-lockfile key are part of the
-    /// test alongside the shadowed set: an update-active occurrence
-    /// re-resolves what a keep-all one reused, and an occurrence
-    /// pinned by a different snapshot key resolves different children
-    /// — inheriting either would change the resolved graph.
-    pub(super) recorded_children_reusable: bool,
+    /// This is a narrower question than whether the *recorded* children
+    /// can be reused instead of walked; that one is
+    /// [`fn@recorded_children_match`], which compares the full
+    /// resolution context.
+    pub(super) children_context_unchanged: bool,
 }
 
 /// `peer_shadowed` is this occurrence's own set; it is installed as the
@@ -1135,19 +1166,15 @@ pub(super) fn claim_children_owner(
         parent_path: ancestor_ids.to_vec(),
         importer_id: ctx.importer_id.clone(),
     };
-    let (owns_children, peer_shadowed, children_context_unchanged, same_resolution_context) = {
+    let (owns_children, peer_shadowed, children_context_unchanged) = {
         let mut owners = lock_recoverable(&ctx.workspace.children_owner_by_id);
         match owners.get(pkg_id) {
             Some(existing) if !owner.wins_over(&existing.owner) => {
-                (false, Arc::clone(&existing.peer_shadowed), false, false)
+                (false, Arc::clone(&existing.peer_shadowed), false)
             }
             existing => {
                 let children_context_unchanged =
                     existing.is_some_and(|entry| *entry.peer_shadowed == peer_shadowed);
-                let same_resolution_context = existing.is_some_and(|entry| {
-                    entry.owner.update_active == owner.update_active
-                        && entry.prior_key.as_ref() == prior_key
-                });
                 let peer_shadowed = Arc::new(peer_shadowed);
                 owners.insert(
                     pkg_id.to_string(),
@@ -1157,7 +1184,7 @@ pub(super) fn claim_children_owner(
                         peer_shadowed: Arc::clone(&peer_shadowed),
                     },
                 );
-                (true, peer_shadowed, children_context_unchanged, same_resolution_context)
+                (true, peer_shadowed, children_context_unchanged)
             }
         }
     };
@@ -1165,21 +1192,32 @@ pub(super) fn claim_children_owner(
         lock_recoverable(&ctx.workspace.first_importer_by_pkg)
             .insert(pkg_id.to_string(), owner.importer_id.clone());
     }
-    ChildrenOwnerClaim {
-        owner,
-        owns_children,
-        peer_shadowed,
-        children_context_unchanged,
-        recorded_children_reusable: children_context_unchanged && same_resolution_context,
-    }
+    ChildrenOwnerClaim { owner, owns_children, peer_shadowed, children_context_unchanged }
 }
 
-/// Whether the walk already recorded this package's children, i.e.
-/// whether a [`ChildrenOwnerClaim::recorded_children_reusable`] winner
-/// has something to reuse. `false` while the previous owner is still
-/// walking them.
-pub(super) fn has_recorded_children(ctx: &TreeCtx, pkg_id: &str) -> bool {
-    lock_recoverable(&ctx.workspace.children_by_id).contains_key(pkg_id)
+/// Whether this package's recorded children were resolved under
+/// `context`, and can therefore be expanded from instead of walked
+/// again. `false` while no walk has recorded them yet, and `false`
+/// when the recording walk ran under a different context — the owner
+/// that recorded them need not be the owner standing now.
+pub(super) fn recorded_children_match(
+    ctx: &TreeCtx,
+    pkg_id: &str,
+    context: &RecordedChildrenContext,
+) -> bool {
+    lock_recoverable(&ctx.workspace.children_context_by_id)
+        .get(pkg_id)
+        .is_some_and(|recorded| recorded.produces_same_children_as(context))
+}
+
+/// Record the context a `children_by_id` entry was produced under.
+/// Called with every write to that map, so the two never disagree.
+pub(super) fn record_children_context(
+    ctx: &TreeCtx,
+    pkg_id: &str,
+    context: RecordedChildrenContext,
+) {
+    lock_recoverable(&ctx.workspace.children_context_by_id).insert(pkg_id.to_string(), context);
 }
 
 /// Seed the peer-walker's `parentPkgs` filter with the names a

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
@@ -135,6 +135,12 @@ impl ChildrenOwner {
 #[derive(Debug, Clone)]
 struct ChildrenOwnerEntry {
     pub(super) owner: ChildrenOwner,
+    /// The owner occurrence's prior-lockfile key, which decides whether
+    /// its children came from the recorded snapshot or from a fresh
+    /// resolve. Two occurrences with different keys can resolve the same
+    /// package's children to different versions, so a later winner can
+    /// only reuse recorded children when its own key matches.
+    pub(super) prior_key: Option<PkgNameVerPeer>,
     /// The owner occurrence's peer-shadowed `dependencies` (see
     /// [`peer_shadowed_dependencies`]). Which names are shadowed
     /// depends on the parent scope, which differs per occurrence;
@@ -1096,6 +1102,19 @@ pub(super) struct ChildrenOwnerClaim {
     /// the winner skips the lazy-flip (and the engine-invalidating
     /// rewrite signal) it would otherwise broadcast.
     pub(super) children_context_unchanged: bool,
+    /// The displaced owner resolved this package's children under
+    /// conditions this occurrence would reproduce exactly: the same
+    /// shadowed-dependency set *and* the same update policy. Walking
+    /// them again would rebuild identical edges and leave a second
+    /// occurrence subtree behind, so the winner can reuse the recorded
+    /// children instead — see [`fn@super::walk::walk_node_children`].
+    ///
+    /// The update policy and the prior-lockfile key are part of the
+    /// test alongside the shadowed set: an update-active occurrence
+    /// re-resolves what a keep-all one reused, and an occurrence
+    /// pinned by a different snapshot key resolves different children
+    /// — inheriting either would change the resolved graph.
+    pub(super) recorded_children_reusable: bool,
 }
 
 /// `peer_shadowed` is this occurrence's own set; it is installed as the
@@ -1107,6 +1126,7 @@ pub(super) fn claim_children_owner(
     depth: i32,
     ancestor_ids: &[String],
     peer_shadowed: HashSet<String>,
+    prior_key: Option<&PkgNameVerPeer>,
 ) -> ChildrenOwnerClaim {
     let owner = ChildrenOwner {
         update_active: !matches!(ctx.update_reuse_scope(), UpdateReuseScope::All),
@@ -1115,24 +1135,29 @@ pub(super) fn claim_children_owner(
         parent_path: ancestor_ids.to_vec(),
         importer_id: ctx.importer_id.clone(),
     };
-    let (owns_children, peer_shadowed, children_context_unchanged) = {
+    let (owns_children, peer_shadowed, children_context_unchanged, same_resolution_context) = {
         let mut owners = lock_recoverable(&ctx.workspace.children_owner_by_id);
         match owners.get(pkg_id) {
             Some(existing) if !owner.wins_over(&existing.owner) => {
-                (false, Arc::clone(&existing.peer_shadowed), false)
+                (false, Arc::clone(&existing.peer_shadowed), false, false)
             }
             existing => {
                 let children_context_unchanged =
                     existing.is_some_and(|entry| *entry.peer_shadowed == peer_shadowed);
+                let same_resolution_context = existing.is_some_and(|entry| {
+                    entry.owner.update_active == owner.update_active
+                        && entry.prior_key.as_ref() == prior_key
+                });
                 let peer_shadowed = Arc::new(peer_shadowed);
                 owners.insert(
                     pkg_id.to_string(),
                     ChildrenOwnerEntry {
                         owner: owner.clone(),
+                        prior_key: prior_key.cloned(),
                         peer_shadowed: Arc::clone(&peer_shadowed),
                     },
                 );
-                (true, peer_shadowed, children_context_unchanged)
+                (true, peer_shadowed, children_context_unchanged, same_resolution_context)
             }
         }
     };
@@ -1140,7 +1165,21 @@ pub(super) fn claim_children_owner(
         lock_recoverable(&ctx.workspace.first_importer_by_pkg)
             .insert(pkg_id.to_string(), owner.importer_id.clone());
     }
-    ChildrenOwnerClaim { owner, owns_children, peer_shadowed, children_context_unchanged }
+    ChildrenOwnerClaim {
+        owner,
+        owns_children,
+        peer_shadowed,
+        children_context_unchanged,
+        recorded_children_reusable: children_context_unchanged && same_resolution_context,
+    }
+}
+
+/// Whether the walk already recorded this package's children, i.e.
+/// whether a [`ChildrenOwnerClaim::recorded_children_reusable`] winner
+/// has something to reuse. `false` while the previous owner is still
+/// walking them.
+pub(super) fn has_recorded_children(ctx: &TreeCtx, pkg_id: &str) -> bool {
+    lock_recoverable(&ctx.workspace.children_by_id).contains_key(pkg_id)
 }
 
 /// Seed the peer-walker's `parentPkgs` filter with the names a

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
@@ -1216,17 +1216,31 @@ pub(super) fn recorded_children_match(
         .is_some_and(|recorded| recorded.context.produces_same_children_as(context))
 }
 
-/// Record a package's children together with the context that
-/// produced them.
+/// Publish a package's children together with the context that
+/// produced them, and report whether they were published.
+///
+/// The ownership check happens under the same lock as the write: a
+/// claim that landed while this walk ran has its own children to
+/// publish, and an older walk finishing afterwards would otherwise
+/// overwrite them. A walk whose ownership lapsed keeps its node lazy
+/// and expands from whatever the standing owner recorded.
 pub(super) fn record_children(
     ctx: &TreeCtx,
     pkg_id: &str,
+    owner: &ChildrenOwner,
     edges: Vec<crate::resolved_tree::ChildEdge>,
     context: RecordedChildrenContext,
-) {
-    lock_recoverable(&ctx.workspace.children_by_id)
-        .insert(pkg_id.to_string(), RecordedChildren { edges: Arc::new(edges), context });
+) -> bool {
+    {
+        let owners = lock_recoverable(&ctx.workspace.children_owner_by_id);
+        if owners.get(pkg_id).is_none_or(|entry| entry.owner != *owner) {
+            return false;
+        }
+        lock_recoverable(&ctx.workspace.children_by_id)
+            .insert(pkg_id.to_string(), RecordedChildren { edges: Arc::new(edges), context });
+    }
     ctx.workspace.record_children_by_id_write(pkg_id);
+    true
 }
 
 /// Seed the peer-walker's `parentPkgs` filter with the names a

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
@@ -135,12 +135,6 @@ impl ChildrenOwner {
 #[derive(Debug, Clone)]
 struct ChildrenOwnerEntry {
     pub(super) owner: ChildrenOwner,
-    /// The owner occurrence's prior-lockfile key, which decides whether
-    /// its children came from the recorded snapshot or from a fresh
-    /// resolve. Two occurrences with different keys can resolve the same
-    /// package's children to different versions, so a later winner can
-    /// only reuse recorded children when its own key matches.
-    pub(super) prior_key: Option<PkgNameVerPeer>,
     /// The owner occurrence's peer-shadowed `dependencies` (see
     /// [`peer_shadowed_dependencies`]). Which names are shadowed
     /// depends on the parent scope, which differs per occurrence;
@@ -1157,7 +1151,6 @@ pub(super) fn claim_children_owner(
     depth: i32,
     ancestor_ids: &[String],
     peer_shadowed: HashSet<String>,
-    prior_key: Option<&PkgNameVerPeer>,
 ) -> ChildrenOwnerClaim {
     let owner = ChildrenOwner {
         update_active: !matches!(ctx.update_reuse_scope(), UpdateReuseScope::All),
@@ -1180,7 +1173,6 @@ pub(super) fn claim_children_owner(
                     pkg_id.to_string(),
                     ChildrenOwnerEntry {
                         owner: owner.clone(),
-                        prior_key: prior_key.cloned(),
                         peer_shadowed: Arc::clone(&peer_shadowed),
                     },
                 );

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
@@ -155,21 +155,6 @@ pub(super) struct RecordedChildren {
     context: RecordedChildrenContext,
 }
 
-#[cfg(test)]
-impl RecordedChildren {
-    /// A recording whose context these tests do not vary.
-    pub(super) fn for_tests(edges: Vec<crate::resolved_tree::ChildEdge>) -> Self {
-        RecordedChildren {
-            edges: Arc::new(edges),
-            context: RecordedChildrenContext {
-                peer_shadowed: Arc::default(),
-                prior_key: None,
-                update_active: false,
-            },
-        }
-    }
-}
-
 /// What a recorded `children_by_id` entry was resolved under. A later
 /// occurrence may expand from that entry instead of walking the
 /// package's manifest again only when its own context equals this one:

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
@@ -146,6 +146,30 @@ struct ChildrenOwnerEntry {
     pub(super) peer_shadowed: Arc<HashSet<String>>,
 }
 
+/// A package's recorded children together with what they were resolved
+/// under. The two travel in one entry so a reader that accepts the
+/// context cannot then expand edges another walk recorded.
+#[derive(Debug, Clone)]
+pub(super) struct RecordedChildren {
+    pub(super) edges: Arc<Vec<crate::resolved_tree::ChildEdge>>,
+    context: RecordedChildrenContext,
+}
+
+#[cfg(test)]
+impl RecordedChildren {
+    /// A recording whose context these tests do not vary.
+    pub(super) fn for_tests(edges: Vec<crate::resolved_tree::ChildEdge>) -> Self {
+        RecordedChildren {
+            edges: Arc::new(edges),
+            context: RecordedChildrenContext {
+                peer_shadowed: Arc::default(),
+                prior_key: None,
+                update_active: false,
+            },
+        }
+    }
+}
+
 /// What a recorded `children_by_id` entry was resolved under. A later
 /// occurrence may expand from that entry instead of walking the
 /// package's manifest again only when its own context equals this one:
@@ -172,8 +196,7 @@ impl RecordedChildrenContext {
     /// expands from it whatever its own overlay says — the overlay
     /// only ever decides which occurrence's versions get *recorded*.
     /// Requiring identical overlays here would mean requiring identical
-    /// parents, which never holds for the occurrences that race, and
-    /// measurably reinstates the expansion this test exists to prevent.
+    /// parents, which the occurrences that race never have.
     pub(super) fn produces_same_children_as(&self, other: &Self) -> bool {
         self.peer_shadowed == other.peer_shadowed
             && self.prior_key == other.prior_key
@@ -231,10 +254,7 @@ pub struct WorkspaceTreeCtx {
     pub(super) resolved_by_wanted:
         Mutex<HashMap<WantedKey, Arc<pacquet_resolving_resolver_base::ResolveResult>>>,
     pub(super) children_specs_by_id: Mutex<HashMap<String, Arc<Vec<ChildSpec>>>>,
-    pub(super) children_by_id: Mutex<HashMap<String, Arc<Vec<crate::resolved_tree::ChildEdge>>>>,
-    /// The context each `children_by_id` entry was recorded under. See
-    /// [`RecordedChildrenContext`].
-    children_context_by_id: Mutex<HashMap<String, RecordedChildrenContext>>,
+    pub(super) children_by_id: Mutex<HashMap<String, RecordedChildren>>,
     children_owner_by_id: Mutex<HashMap<String, ChildrenOwnerEntry>>,
     node_parent_ids_by_id: Mutex<HashMap<NodeId, Arc<Vec<String>>>>,
     /// Reverse index over `dependencies_tree`: every occurrence node
@@ -417,7 +437,6 @@ impl Default for WorkspaceTreeCtx {
             resolved_by_wanted: Mutex::new(HashMap::default()),
             children_specs_by_id: Mutex::new(HashMap::default()),
             children_by_id: Mutex::new(HashMap::default()),
-            children_context_by_id: Mutex::new(HashMap::default()),
             children_owner_by_id: Mutex::new(HashMap::default()),
             node_parent_ids_by_id: Mutex::new(HashMap::default()),
             nodes_by_pkg_id: Mutex::new(HashMap::default()),
@@ -458,7 +477,10 @@ impl WorkspaceTreeCtx {
             all_peer_dep_names: lock_recoverable(&self.all_peer_dep_names).clone(),
             policy_violations: lock_recoverable(&self.policy_violations).clone(),
             applied_patches: lock_recoverable(&self.applied_patches).clone(),
-            children_by_id: lock_recoverable(&self.children_by_id).clone(),
+            children_by_id: lock_recoverable(&self.children_by_id)
+                .iter()
+                .map(|(pkg_id, recorded)| (pkg_id.clone(), Arc::clone(&recorded.edges)))
+                .collect(),
         }
     }
 
@@ -514,8 +536,8 @@ impl WorkspaceTreeCtx {
             let Some(children) = all_children.get(&pkg_id) else {
                 continue;
             };
-            children_by_id.insert(pkg_id, Arc::clone(children));
-            for child in children.iter() {
+            children_by_id.insert(pkg_id, Arc::clone(&children.edges));
+            for child in children.edges.iter() {
                 if reachable_pkg_ids.insert(child.pkg_id.clone()) {
                     pending_pkg_ids.push(child.pkg_id.clone());
                 }
@@ -700,7 +722,7 @@ impl WorkspaceTreeCtx {
                     continue;
                 }
                 if let Some(children) = children_by_id.get(&pkg_id) {
-                    for child in children.iter() {
+                    for child in children.edges.iter() {
                         if !cache.visited.contains(&child.pkg_id) {
                             queue.push(child.pkg_id.clone());
                         }
@@ -837,7 +859,9 @@ impl WorkspaceTreeCtx {
             });
             let children_by_id = lock_recoverable(&self.children_by_id);
             for pkg_id in &written {
-                let Some(spec) = children_by_id.get(pkg_id) else { continue };
+                let Some(spec) = children_by_id.get(pkg_id).map(|recorded| &recorded.edges) else {
+                    continue;
+                };
                 match tree.children_by_id.entry(pkg_id.clone()) {
                     Entry::Vacant(entry) => {
                         entry.insert(Arc::clone(spec));
@@ -918,8 +942,10 @@ impl WorkspaceTreeCtx {
                 peer_dep_names: log.peer_dep_names.len(),
             }
         };
-        for (pkg_id, spec) in lock_recoverable(&self.children_by_id).iter() {
-            tree.children_by_id.entry(pkg_id.clone()).or_insert_with(|| Arc::clone(spec));
+        for (pkg_id, recorded) in lock_recoverable(&self.children_by_id).iter() {
+            tree.children_by_id
+                .entry(pkg_id.clone())
+                .or_insert_with(|| Arc::clone(&recorded.edges));
         }
         for (pkg_id, pkg) in lock_recoverable(&self.packages).iter() {
             tree.packages.entry(pkg_id.clone()).or_insert_with(|| pkg.clone());
@@ -1103,7 +1129,10 @@ impl WorkspaceTreeCtx {
             children_by_id: self
                 .children_by_id
                 .into_inner()
-                .unwrap_or_else(std::sync::PoisonError::into_inner),
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .into_iter()
+                .map(|(pkg_id, recorded)| (pkg_id, recorded.edges))
+                .collect(),
         }
     }
 }
@@ -1189,27 +1218,30 @@ pub(super) fn claim_children_owner(
 
 /// Whether this package's recorded children were resolved under
 /// `context`, and can therefore be expanded from instead of walked
-/// again. `false` while no walk has recorded them yet, and `false`
-/// when the recording walk ran under a different context — the owner
-/// that recorded them need not be the owner standing now.
+/// again. The walk that recorded them need not be the one owning the
+/// children now, which is why the comparison is against the recorded
+/// context rather than against the standing claim.
 pub(super) fn recorded_children_match(
     ctx: &TreeCtx,
     pkg_id: &str,
     context: &RecordedChildrenContext,
 ) -> bool {
-    lock_recoverable(&ctx.workspace.children_context_by_id)
+    lock_recoverable(&ctx.workspace.children_by_id)
         .get(pkg_id)
-        .is_some_and(|recorded| recorded.produces_same_children_as(context))
+        .is_some_and(|recorded| recorded.context.produces_same_children_as(context))
 }
 
-/// Record the context a `children_by_id` entry was produced under.
-/// Called with every write to that map, so the two never disagree.
-pub(super) fn record_children_context(
+/// Record a package's children together with the context that
+/// produced them.
+pub(super) fn record_children(
     ctx: &TreeCtx,
     pkg_id: &str,
+    edges: Vec<crate::resolved_tree::ChildEdge>,
     context: RecordedChildrenContext,
 ) {
-    lock_recoverable(&ctx.workspace.children_context_by_id).insert(pkg_id.to_string(), context);
+    lock_recoverable(&ctx.workspace.children_by_id)
+        .insert(pkg_id.to_string(), RecordedChildren { edges: Arc::new(edges), context });
+    ctx.workspace.record_children_by_id_write(pkg_id);
 }
 
 /// Seed the peer-walker's `parentPkgs` filter with the names a

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx/tests.rs
@@ -147,6 +147,7 @@ fn owner_missing_record_is_written_once_per_generation() {
         importer_id: ".".to_string(),
     };
     let entry = |owner: ChildrenOwner| ChildrenOwnerEntry {
+        prior_key: None,
         owner,
         peer_shadowed: Arc::new(HashSet::default()),
     };

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx/tests.rs
@@ -1,6 +1,9 @@
 use pacquet_resolving_resolver_base::ResolveOptions;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
-use std::collections::{BTreeMap, BTreeSet};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
 
 use super::{
     super::{lock_recoverable, test_support::manifest_result},
@@ -443,5 +446,12 @@ fn record_tree_node(workspace: &WorkspaceTreeCtx, node_id: &NodeId, pkg_id: &str
 
 /// Children recorded by a walk whose context these tests do not vary.
 fn recorded(edges: Vec<crate::resolved_tree::ChildEdge>) -> super::RecordedChildren {
-    super::RecordedChildren::for_tests(edges)
+    super::RecordedChildren {
+        edges: Arc::new(edges),
+        context: super::RecordedChildrenContext {
+            peer_shadowed: Arc::default(),
+            prior_key: None,
+            update_active: false,
+        },
+    }
 }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx/tests.rs
@@ -1,9 +1,6 @@
 use pacquet_resolving_resolver_base::ResolveOptions;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    sync::Arc,
-};
+use std::collections::{BTreeMap, BTreeSet};
 
 use super::{
     super::{lock_recoverable, test_support::manifest_result},
@@ -79,14 +76,14 @@ fn importer_snapshot_follows_lazy_edges_for_the_package_closure() {
     }
     lock_recoverable(&workspace.children_by_id).insert(
         "root@1.0.0".to_string(),
-        Arc::new(vec![ChildEdge {
+        recorded(vec![ChildEdge {
             alias: "lazy-child".to_string(),
             pkg_id: "lazy-child@1.0.0".to_string(),
             optional: false,
         }]),
     );
     lock_recoverable(&workspace.children_by_id)
-        .insert("foreign@1.0.0".to_string(), Arc::new(Vec::new()));
+        .insert("foreign@1.0.0".to_string(), recorded(Vec::new()));
 
     let snapshot = workspace.snapshot_reachable_from(vec![DirectDep {
         alias: "root".to_string(),
@@ -255,7 +252,7 @@ fn run_preferred_versions_grow_with_new_roots_and_rebuild_on_children_rewrites()
 
     // A children-ownership rewrite can drop edges, so the closure is
     // rebuilt rather than grown.
-    lock_recoverable(&workspace.children_by_id).insert("root@1.0.0".to_string(), Arc::new(vec![]));
+    lock_recoverable(&workspace.children_by_id).insert("root@1.0.0".to_string(), recorded(vec![]));
     workspace.record_children_rewrite();
     workspace.bump_revision();
     let cache = workspace.run_preferred_versions();
@@ -322,7 +319,7 @@ fn insert_named_package(workspace: &WorkspaceTreeCtx, name: &str, version: &str)
 fn insert_child_edge(workspace: &WorkspaceTreeCtx, parent_id: &str, alias: &str, child_id: &str) {
     lock_recoverable(&workspace.children_by_id).insert(
         parent_id.to_string(),
-        Arc::new(vec![crate::resolved_tree::ChildEdge {
+        recorded(vec![crate::resolved_tree::ChildEdge {
             alias: alias.to_string(),
             pkg_id: child_id.to_string(),
             optional: false,
@@ -442,4 +439,9 @@ fn record_tree_node(workspace: &WorkspaceTreeCtx, node_id: &NodeId, pkg_id: &str
     }
     drop(tree);
     workspace.record_tree_node_write(node_id);
+}
+
+/// Children recorded by a walk whose context these tests do not vary.
+fn recorded(edges: Vec<crate::resolved_tree::ChildEdge>) -> super::RecordedChildren {
+    super::RecordedChildren::for_tests(edges)
 }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx/tests.rs
@@ -147,7 +147,6 @@ fn owner_missing_record_is_written_once_per_generation() {
         importer_id: ".".to_string(),
     };
     let entry = |owner: ChildrenOwner| ChildrenOwnerEntry {
-        prior_key: None,
         owner,
         peer_shadowed: Arc::new(HashSet::default()),
     };

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx/tests.rs
@@ -455,3 +455,66 @@ fn recorded(edges: Vec<crate::resolved_tree::ChildEdge>) -> super::RecordedChild
         },
     }
 }
+
+/// Reuse is offered against what the recording walk resolved under, so
+/// each field of the recorded context has to be able to withhold it.
+#[test]
+fn recorded_children_match_only_under_the_recording_context() {
+    use super::super::{UpdateReuseScope, tree_ctx::TreeCtx};
+    use super::{
+        RecordedChildrenContext, claim_children_owner, record_children, recorded_children_match,
+    };
+    use std::sync::Arc;
+
+    let workspace = Arc::new(WorkspaceTreeCtx::default());
+    let ctx = TreeCtx::with_workspace(Arc::clone(&workspace), ResolveOptions::default());
+    let claim = claim_children_owner(&ctx, "pkg@1.0.0", 1, &[], HashSet::default());
+    let context = || RecordedChildrenContext {
+        peer_shadowed: Arc::default(),
+        prior_key: None,
+        update_active: false,
+    };
+    assert!(!recorded_children_match(&ctx, "pkg@1.0.0", &context()), "nothing recorded yet");
+    assert!(record_children(&ctx, "pkg@1.0.0", &claim.owner, Vec::new(), context()));
+
+    assert!(recorded_children_match(&ctx, "pkg@1.0.0", &context()));
+    let shadowed = RecordedChildrenContext {
+        peer_shadowed: Arc::new(HashSet::from_iter(["peer".to_string()])),
+        ..context()
+    };
+    assert!(!recorded_children_match(&ctx, "pkg@1.0.0", &shadowed), "a different shadow set");
+    let updating = RecordedChildrenContext { update_active: true, ..context() };
+    assert!(!recorded_children_match(&ctx, "pkg@1.0.0", &updating), "a different update policy");
+    let pinned = RecordedChildrenContext {
+        prior_key: Some("pkg@1.0.0".parse().expect("parse snapshot key")),
+        ..context()
+    };
+    assert!(!recorded_children_match(&ctx, "pkg@1.0.0", &pinned), "a different snapshot key");
+    assert!(matches!(ctx.update_reuse_scope(), UpdateReuseScope::All));
+}
+
+/// A walk that lost the claim while it ran must not overwrite the
+/// children the occurrence that outranked it published.
+#[test]
+fn children_are_published_only_by_the_standing_owner() {
+    use super::super::tree_ctx::TreeCtx;
+    use super::{RecordedChildrenContext, claim_children_owner, record_children};
+    use std::sync::Arc;
+
+    let workspace = Arc::new(WorkspaceTreeCtx::default());
+    let ctx = TreeCtx::with_workspace(Arc::clone(&workspace), ResolveOptions::default());
+    let context = || RecordedChildrenContext {
+        peer_shadowed: Arc::default(),
+        prior_key: None,
+        update_active: false,
+    };
+    let deep = claim_children_owner(&ctx, "pkg@1.0.0", 5, &[], HashSet::default());
+    let shallow = claim_children_owner(&ctx, "pkg@1.0.0", 0, &[], HashSet::default());
+    assert!(deep.owns_children && shallow.owns_children, "each claim won when it was taken");
+
+    assert!(
+        !record_children(&ctx, "pkg@1.0.0", &deep.owner, Vec::new(), context()),
+        "the deeper walk lost the claim before it published",
+    );
+    assert!(record_children(&ctx, "pkg@1.0.0", &shallow.owner, Vec::new(), context()));
+}


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#13574: a dependency chain whose packages carry peer dependencies
made resolution cost grow exponentially with the depth of the chain. One project
with **one** dependency, over a graph of ~500 packages, could not finish inside
6 GB. The TypeScript CLI resolves the same input in 1.06s / 263 MB.

### The mechanism

Winning the children-ownership claim is what licenses an occurrence to walk a
package's manifest children — a loser stays lazy and expands from the recorded
`children_by_id`. Concurrent occurrences of the same package take turns winning
that claim, and **each turn re-walked the entire subtree**, leaving its
occurrence nodes in the shared tree forever. Those nodes then issue claims of
their own, which is the multiplication.

Counters on the fixture, single importer, single dependency — note that the
number of claims *won* dwarfs the package count, while at most one occurrence
per package can be the final owner:

| chain depth | packages | occurrence nodes | claims won | of which context-changing |
|---|---|---|---|---|
| 12 | 200 | 14,955 | 7,304 | 200 |
| 14 | 240 | 111,295 | 49,899 | 240 |
| 15 | 260 | 114,607 | 56,298 | 260 |

Every winning claim beyond the package count re-walked a subtree that resolves
identically. The memory is all in `dependencies_tree`: every peer-walker
structure stays under 1,000 entries, and the tree is fully populated *before*
the peer pass starts.

### The change

Winning the claim only means this occurrence outranks the one that recorded the
children, not that the children differ. When the displaced owner resolved them
under conditions this occurrence would reproduce, expand from the recorded
children instead — exactly what a losing occurrence does.

"Conditions this occurrence would reproduce" is a three-part test, and each part
is load-bearing:

- **the same peer-shadowed set** — a different shadow set drops different
  dependencies (this part already existed as `children_context_unchanged`);
- **the same update policy** — an update-active occurrence re-resolves what a
  keep-all one reused, so inheriting a keep-all walk's children would silently
  defeat `pacquet update`;
- **the same prior-lockfile key** — an occurrence pinned by a different snapshot
  key resolves different children. This is the part the adversarial-interleaving
  tests from pnpm/pnpm#13570 and pnpm/pnpm#13572 caught when I first wrote the
  guard without it; they fail without this term and pass with it.

Packages whose child specifiers pass through the importer's catalogs are
excluded too, being a property of the resolving importer rather than of the
package id.

### Result

| chain depth | before | after |
|---|---|---|
| 15 | 198,023 occurrence nodes, 278 MB, 1.00s | 3,211 nodes, 62 MB, 0.10s |
| 20 | 4,463 MB, 17.5s | 71 MB, 0.17s |
| 24 | did not finish in 180s under 6 GB | 78 MB, 0.20s |
| 26 | did not finish | 78 MB, 0.19s |

Output is unchanged: the emitted lockfile is byte-identical before and after,
and byte-identical to the one the TypeScript CLI writes for the same input.

On the 114-project Bit workspace from pnpm/pnpm#13505 the change is **neutral**
(12.30–13.03s / 7.5–7.9 GB on main; 11.97–13.18s / 7.5–8.0 GB here) — that
workspace is wide rather than deep, so it barely takes the re-walk path. Its
~7.5 GB peak is a separate problem, and its run-to-run lockfile instability is
too: two consecutive runs of *main* on it still differ by 9,194 lines, so
pnpm/pnpm#13567 is not fully closed. I will report that separately.

### On the missing regression test

I could not build one that fails without this fix, and I would rather say so
than add a test that passes either way. The blowup needs occurrences of one
package to race for the claim; an in-process `resolve_workspace` test does not
produce that, at any shape I tried — a yielding resolver, a multi-threaded
runtime, and the CLI fixture's exact dimensions (12 layers x 20 packages, 4
children, 30 providers, 8 peers each) all give the same 631 occurrence nodes
with and without the fix, while the CLI on that same shape gives 23,479 without
and ~2,600 with.

The guard that would work drives the real CLI: the multi-importer hoist-heavy
scenario I have prototyped for the integrated benchmark, sized below this
blowup. I will propose it separately, with the A/B that shows it discriminates.

## Squash Commit Body

```text
Winning the children-ownership claim is what licenses an occurrence to
walk a package's manifest children. Concurrent occurrences of one
package take turns winning it — each turn re-walked the whole subtree
and left its occurrence nodes in the shared tree — so a chain of
peer-carrying packages expanded exponentially with its depth. One
project with one such dependency, over a graph of ~500 packages, could
not finish inside 6 GB; at depth 22 it peaked at 4.1 GB. The TypeScript
CLI resolves the same input in 1.06s and 263 MB.

Winning the claim only means this occurrence outranks the one that
recorded the children, not that the children differ. When the displaced
owner resolved them under conditions this occurrence would reproduce —
the same peer-shadowed set, the same update policy, the same
prior-lockfile key — expand from the recorded children instead, exactly
as a losing occurrence does. Each term of that test is load-bearing: an
update-active occurrence re-resolves what a keep-all one reused, and an
occurrence pinned by a different snapshot key resolves different
children. Packages whose child specifiers pass through the importer's
catalogs are excluded as well, being a property of the resolving
importer rather than of the package id.

On the generated chain from the issue, one project and one dependency,
depth 15 falls from 198,023 occurrence nodes / 278 MB / 1.00s to 3,211
nodes / 62 MB / 0.10s, and depths 24 and 26 — which previously did not
finish inside 6 GB — complete in 78 MB and 0.2s. The emitted lockfile is
byte-identical before and after, and byte-identical to the TypeScript
CLI's for the same input.

Closes https://github.com/pnpm/pnpm/issues/13574.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <!-- pacquet-only defect: the TypeScript CLI does not have this expansion,
  and is the reference the fix is measured against. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [ ] Added or updated tests.
  <!-- Not added: see "On the missing regression test" above. The existing
  adversarial-interleaving tests from #13570/#13572 do gate the soundness of
  the reuse condition — they fail against a version of this change that omits
  the prior-lockfile-key term. -->

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788217502&installation_model_id=426870&pr_number=13575&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13575&signature=21e3884dc7f245cf2556113602e5a781d2be3ac20db04847b9c941c18f058b43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced memory growth when resolving deep dependency chains.
  * Avoided unnecessary reprocessing by reusing compatible dependency results.
  * Improved dependency resolution efficiency for complex workspaces.

* **Reliability Improvements**
  * Preserved correct handling of peer dependencies, lockfile state, updates, and catalog-based resolutions.
  * Maintained consistent dependency trees across snapshots and preferred-version resolution.
  * Improved fallback behavior when previously resolved results cannot be reused.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->