### PR TITLE
perf(resolving-deps-resolver): amortize the per-importer workspace scans in the hoist loop

### DIFF
--- a/.changeset/amortize-hoist-round-workspace-scans.md
+++ b/.changeset/amortize-hoist-round-workspace-scans.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Installing a workspace whose projects auto-install peer dependencies is substantially faster. Each round of the peer-hoist loop no longer rescans the whole workspace once per project, so the cost of resolution grows with the workspace instead of with its square.

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
@@ -15,6 +15,7 @@ use std::{
 
 use crate::{
     node_id::NodeId,
+    resolve_peers::MissingNames,
     resolved_tree::{
         AncestorIds, DependenciesTreeNode, DirectDep, PeerDep, ResolvedPackage, ResolvedTree,
     },
@@ -631,10 +632,10 @@ impl WorkspaceTreeCtx {
     /// its own later hoist waves never refresh it — and replaces any
     /// provisional report a non-owner's earlier walk left behind. See
     /// the `first_walk_missing_by_pkg` field doc.
-    pub fn record_first_walk_missing(
+    pub(crate) fn record_first_walk_missing(
         &self,
         importer_id: &str,
-        missing_by_pkg: &HashMap<String, HashSet<String>>,
+        missing_by_pkg: &HashMap<&str, MissingNames<'_>>,
     ) {
         // Lock order: `children_owner_by_id` before
         // `first_walk_missing_by_pkg`, the only place both are held.
@@ -649,23 +650,27 @@ impl WorkspaceTreeCtx {
                 .get(pkg_id)
                 .is_some_and(|entry| entry.recorded_by.as_ref() == Some(owner));
             if !recorded_by_current_owner {
+                let names = missing_by_pkg
+                    .get(pkg_id.as_str())
+                    .map(|names| names.iter().map(str::to_owned).collect())
+                    .unwrap_or_default();
                 record.map_mut().insert(
                     pkg_id.clone(),
-                    OwnerMissingRecord {
-                        recorded_by: Some(owner.clone()),
-                        names: missing_by_pkg.get(pkg_id).cloned().unwrap_or_default(),
-                    },
+                    OwnerMissingRecord { recorded_by: Some(owner.clone()), names },
                 );
             }
         }
         for (pkg_id, names) in missing_by_pkg {
-            if record.map().contains_key(pkg_id) {
+            if record.map().contains_key(*pkg_id) {
                 continue;
             }
-            if owners.get(pkg_id).is_none_or(|entry| entry.owner.importer_id != importer_id) {
+            if owners.get(*pkg_id).is_none_or(|entry| entry.owner.importer_id != importer_id) {
                 record.map_mut().insert(
-                    pkg_id.clone(),
-                    OwnerMissingRecord { recorded_by: None, names: names.clone() },
+                    (*pkg_id).to_owned(),
+                    OwnerMissingRecord {
+                        recorded_by: None,
+                        names: names.iter().map(str::to_owned).collect(),
+                    },
                 );
             }
         }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
@@ -326,8 +326,7 @@ pub struct WorkspaceTreeCtx {
     /// so a peer the owner only satisfied by hoisting stays visible to
     /// every other importer's hoist. Consumed via
     /// [`crate::HoistMissingScope`].
-    first_walk_missing_by_pkg:
-        Mutex<SnapshotCell<HashMap<String, OwnerMissingRecord>, HashMap<String, HashSet<String>>>>,
+    first_walk_missing_by_pkg: Mutex<FirstWalkMissingCell>,
     /// Per importer: direct-dep aliases whose manifest specifier differs
     /// from the prior lockfile (new deps included). Gates the stale-pin
     /// refresh's reuse-decline; only a changed direct dep can re-resolve
@@ -349,6 +348,13 @@ pub struct WorkspaceTreeCtx {
     pub(super) direct_dep_versions: Mutex<HashMap<String, Arc<DirectDepVersions>>>,
 }
 
+/// The per-package missing-peer names
+/// [`WorkspaceTreeCtx::first_walk_missing_by_pkg`] projects out of its
+/// [`OwnerMissingRecord`] entries.
+type FirstWalkMissing = HashMap<String, HashSet<String>>;
+
+type FirstWalkMissingCell = SnapshotCell<HashMap<String, OwnerMissingRecord>, FirstWalkMissing>;
+
 /// One [`WorkspaceTreeCtx::first_walk_missing_by_pkg`] entry: the
 /// missing-peer names plus the owner generation that recorded them
 /// (`None` for a non-owner's provisional report).
@@ -366,23 +372,23 @@ struct OwnerMissingRecord {
 /// Writers reach the map through [`Self::map_mut`], which drops the
 /// snapshot; a writer that finds nothing to change must keep to
 /// [`Self::map`] so the cache survives.
-struct SnapshotCell<M, S> {
-    map: M,
-    snapshot: Option<Arc<S>>,
+struct SnapshotCell<Map, Snapshot> {
+    map: Map,
+    snapshot: Option<Arc<Snapshot>>,
 }
 
-impl<M: Default, S> Default for SnapshotCell<M, S> {
+impl<Map: Default, Snapshot> Default for SnapshotCell<Map, Snapshot> {
     fn default() -> Self {
-        SnapshotCell { map: M::default(), snapshot: None }
+        SnapshotCell { map: Map::default(), snapshot: None }
     }
 }
 
-impl<M, S> SnapshotCell<M, S> {
-    fn map(&self) -> &M {
+impl<Map, Snapshot> SnapshotCell<Map, Snapshot> {
+    fn map(&self) -> &Map {
         &self.map
     }
 
-    fn map_mut(&mut self) -> &mut M {
+    fn map_mut(&mut self) -> &mut Map {
         self.snapshot = None;
         &mut self.map
     }
@@ -390,7 +396,7 @@ impl<M, S> SnapshotCell<M, S> {
     /// The current snapshot, projected through `project` when a write
     /// invalidated the last one. Snapshots already handed out keep the
     /// contents they were built from.
-    fn snapshot(&mut self, project: impl FnOnce(&M) -> S) -> Arc<S> {
+    fn snapshot(&mut self, project: impl FnOnce(&Map) -> Snapshot) -> Arc<Snapshot> {
         Arc::clone(self.snapshot.get_or_insert_with(|| Arc::new(project(&self.map))))
     }
 }
@@ -679,7 +685,7 @@ impl WorkspaceTreeCtx {
     /// Snapshot of the per-package owner-context missing-peer names.
     /// See the `first_walk_missing_by_pkg` field doc.
     #[must_use]
-    pub fn first_walk_missing_by_pkg(&self) -> Arc<HashMap<String, HashSet<String>>> {
+    pub fn first_walk_missing_by_pkg(&self) -> Arc<FirstWalkMissing> {
         lock_recoverable(&self.first_walk_missing_by_pkg).snapshot(|record| {
             record.iter().map(|(pkg_id, entry)| (pkg_id.clone(), entry.names.clone())).collect()
         })

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
@@ -316,7 +316,7 @@ pub struct WorkspaceTreeCtx {
     /// a package's subtree is recorded once per id, and a non-owner occurrence
     /// reuses the owner occurrence's children and missing-peer report. Consumed via
     /// [`crate::HoistMissingScope`].
-    first_importer_by_pkg: Mutex<HashMap<String, String>>,
+    first_importer_by_pkg: Mutex<SnapshotCell<HashMap<String, String>, HashMap<String, String>>>,
     /// Per package: the missing-peer names reported by the *initial*
     /// peer walk of the current children-owner generation, plus the
     /// owner that recorded them (`None` while only a non-owner's
@@ -325,7 +325,8 @@ pub struct WorkspaceTreeCtx {
     /// so a peer the owner only satisfied by hoisting stays visible to
     /// every other importer's hoist. Consumed via
     /// [`crate::HoistMissingScope`].
-    first_walk_missing_by_pkg: Mutex<HashMap<String, OwnerMissingRecord>>,
+    first_walk_missing_by_pkg:
+        Mutex<SnapshotCell<HashMap<String, OwnerMissingRecord>, HashMap<String, HashSet<String>>>>,
     /// Per importer: direct-dep aliases whose manifest specifier differs
     /// from the prior lockfile (new deps included). Gates the stale-pin
     /// refresh's reuse-decline; only a changed direct dep can re-resolve
@@ -353,6 +354,44 @@ pub struct WorkspaceTreeCtx {
 struct OwnerMissingRecord {
     recorded_by: Option<ChildrenOwner>,
     names: HashSet<String>,
+}
+
+/// A map whose readers want a whole-map snapshot rather than a lookup,
+/// paired with the last snapshot handed out. Every hoist round of every
+/// importer takes one of these, so rebuilding per read is quadratic in
+/// workspace size — the cached `Arc` collapses a round of reads that
+/// changed nothing into one projection.
+///
+/// Writers reach the map through [`Self::map_mut`], which drops the
+/// snapshot; a writer that finds nothing to change must keep to
+/// [`Self::map`] so the cache survives.
+struct SnapshotCell<M, S> {
+    map: M,
+    snapshot: Option<Arc<S>>,
+}
+
+impl<M: Default, S> Default for SnapshotCell<M, S> {
+    fn default() -> Self {
+        SnapshotCell { map: M::default(), snapshot: None }
+    }
+}
+
+impl<M, S> SnapshotCell<M, S> {
+    fn map(&self) -> &M {
+        &self.map
+    }
+
+    fn map_mut(&mut self) -> &mut M {
+        self.snapshot = None;
+        &mut self.map
+    }
+
+    /// The current snapshot, projected through `project` when a write
+    /// invalidated the last one. Snapshots already handed out keep the
+    /// contents they were built from.
+    fn snapshot(&mut self, project: impl FnOnce(&M) -> S) -> Arc<S> {
+        Arc::clone(self.snapshot.get_or_insert_with(|| Arc::new(project(&self.map))))
+    }
 }
 
 /// State behind [`WorkspaceTreeCtx::run_preferred_versions`]: the
@@ -440,8 +479,8 @@ impl Default for WorkspaceTreeCtx {
             deprecation_log: None,
             auto_install_peers: false,
             registries: std::collections::HashMap::new(),
-            first_importer_by_pkg: Mutex::new(HashMap::default()),
-            first_walk_missing_by_pkg: Mutex::new(HashMap::default()),
+            first_importer_by_pkg: Mutex::new(SnapshotCell::default()),
+            first_walk_missing_by_pkg: Mutex::new(SnapshotCell::default()),
             changed_direct_deps: Mutex::new(HashMap::default()),
             direct_dep_versions: Mutex::new(HashMap::default()),
         }
@@ -583,8 +622,8 @@ impl WorkspaceTreeCtx {
 
     /// Snapshot of `pkg id → children-owner importer id`. See the field doc.
     #[must_use]
-    pub fn first_importer_by_pkg(&self) -> HashMap<String, String> {
-        lock_recoverable(&self.first_importer_by_pkg).clone()
+    pub fn first_importer_by_pkg(&self) -> Arc<HashMap<String, String>> {
+        lock_recoverable(&self.first_importer_by_pkg).snapshot(Clone::clone)
     }
 
     /// Record a walk's per-package missing-peer names. The owning
@@ -605,10 +644,12 @@ impl WorkspaceTreeCtx {
             if owner.importer_id != importer_id {
                 continue;
             }
-            let recorded_by_current_owner =
-                record.get(pkg_id).is_some_and(|entry| entry.recorded_by.as_ref() == Some(owner));
+            let recorded_by_current_owner = record
+                .map()
+                .get(pkg_id)
+                .is_some_and(|entry| entry.recorded_by.as_ref() == Some(owner));
             if !recorded_by_current_owner {
-                record.insert(
+                record.map_mut().insert(
                     pkg_id.clone(),
                     OwnerMissingRecord {
                         recorded_by: Some(owner.clone()),
@@ -618,11 +659,14 @@ impl WorkspaceTreeCtx {
             }
         }
         for (pkg_id, names) in missing_by_pkg {
+            if record.map().contains_key(pkg_id) {
+                continue;
+            }
             if owners.get(pkg_id).is_none_or(|entry| entry.owner.importer_id != importer_id) {
-                record.entry(pkg_id.clone()).or_insert_with(|| OwnerMissingRecord {
-                    recorded_by: None,
-                    names: names.clone(),
-                });
+                record.map_mut().insert(
+                    pkg_id.clone(),
+                    OwnerMissingRecord { recorded_by: None, names: names.clone() },
+                );
             }
         }
     }
@@ -630,11 +674,10 @@ impl WorkspaceTreeCtx {
     /// Snapshot of the per-package owner-context missing-peer names.
     /// See the `first_walk_missing_by_pkg` field doc.
     #[must_use]
-    pub fn first_walk_missing_by_pkg(&self) -> HashMap<String, HashSet<String>> {
-        lock_recoverable(&self.first_walk_missing_by_pkg)
-            .iter()
-            .map(|(pkg_id, entry)| (pkg_id.clone(), entry.names.clone()))
-            .collect()
+    pub fn first_walk_missing_by_pkg(&self) -> Arc<HashMap<String, HashSet<String>>> {
+        lock_recoverable(&self.first_walk_missing_by_pkg).snapshot(|record| {
+            record.iter().map(|(pkg_id, entry)| (pkg_id.clone(), entry.names.clone())).collect()
+        })
     }
 
     /// Record importer-level direct-dependency package ids as roots for
@@ -1195,8 +1238,10 @@ pub(super) fn claim_children_owner(
         }
     };
     if owns_children {
-        lock_recoverable(&ctx.workspace.first_importer_by_pkg)
-            .insert(pkg_id.to_string(), owner.importer_id.clone());
+        let mut first_importer = lock_recoverable(&ctx.workspace.first_importer_by_pkg);
+        if first_importer.map().get(pkg_id) != Some(&owner.importer_id) {
+            first_importer.map_mut().insert(pkg_id.to_string(), owner.importer_id.clone());
+        }
     }
     ChildrenOwnerClaim { owner, owns_children, peer_shadowed, children_context_unchanged }
 }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx/tests.rs
@@ -190,6 +190,43 @@ fn owner_missing_record_is_written_once_per_generation() {
 }
 
 #[test]
+fn owner_scope_snapshots_are_shared_until_a_write_changes_the_map() {
+    use super::super::lock_recoverable;
+    use super::{ChildrenOwner, ChildrenOwnerEntry, WorkspaceTreeCtx};
+    use crate::resolve_peers::MissingNames;
+    use std::sync::Arc;
+
+    let ctx = WorkspaceTreeCtx::default();
+    let owner = ChildrenOwner {
+        update_active: false,
+        depth: 0,
+        importer_order: 0,
+        parent_path: Vec::new(),
+        importer_id: ".".to_string(),
+    };
+    lock_recoverable(&ctx.children_owner_by_id).insert(
+        "pkg@1.0.0".to_string(),
+        ChildrenOwnerEntry { owner, peer_shadowed: Arc::new(HashSet::default()) },
+    );
+
+    let peers: HashSet<String> = HashSet::from_iter(["peer".to_string()]);
+    let missing = HashMap::from_iter([("pkg@1.0.0", MissingNames::One(&peers))]);
+
+    let before = ctx.first_walk_missing_by_pkg();
+    ctx.record_first_walk_missing(".", &missing);
+    let after_write = ctx.first_walk_missing_by_pkg();
+    assert!(!Arc::ptr_eq(&before, &after_write), "a write must invalidate the shared snapshot");
+    assert!(before.is_empty(), "an issued snapshot keeps what it was built from");
+    assert_eq!(after_write.get("pkg@1.0.0"), Some(&peers));
+
+    ctx.record_first_walk_missing(".", &missing);
+    assert!(
+        Arc::ptr_eq(&after_write, &ctx.first_walk_missing_by_pkg()),
+        "a re-record that changes nothing must reuse the snapshot",
+    );
+}
+
+#[test]
 fn importer_scoped_update_owner_wins_before_discovery_order() {
     use super::ChildrenOwner;
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx/tests.rs
@@ -136,6 +136,7 @@ fn ownership_rewrite_of_existing_nodes_bumps_children_rewrites() {
 fn owner_missing_record_is_written_once_per_generation() {
     use super::super::lock_recoverable;
     use super::{ChildrenOwner, ChildrenOwnerEntry, WorkspaceTreeCtx};
+    use crate::resolve_peers::MissingNames;
     use std::sync::Arc;
 
     let ctx = WorkspaceTreeCtx::default();
@@ -153,23 +154,25 @@ fn owner_missing_record_is_written_once_per_generation() {
     lock_recoverable(&ctx.children_owner_by_id)
         .insert("pkg@1.0.0".to_string(), entry(owner.clone()));
 
-    let miss = |names: &[&str]| {
-        let mut map: HashMap<String, HashSet<String>> = HashMap::default();
-        map.insert("pkg@1.0.0".to_string(), names.iter().map(|name| (*name).to_string()).collect());
-        map
+    let names = |names: &[&str]| -> HashSet<String> {
+        names.iter().map(|name| (*name).to_string()).collect()
     };
+    fn miss(names: &HashSet<String>) -> HashMap<&str, MissingNames<'_>> {
+        HashMap::from_iter([("pkg@1.0.0", MissingNames::One(names))])
+    }
 
-    ctx.record_first_walk_missing("pkg-a", &miss(&["peer"]));
-    assert_eq!(
-        ctx.first_walk_missing_by_pkg().get("pkg@1.0.0"),
-        Some(&miss(&["peer"]).remove("pkg@1.0.0").unwrap()),
-    );
+    let one_peer = names(&["peer"]);
+    let two_peers = names(&["peer", "other-peer"]);
+    let none = names(&[]);
 
-    ctx.record_first_walk_missing(".", &miss(&["peer", "other-peer"]));
+    ctx.record_first_walk_missing("pkg-a", &miss(&one_peer));
+    assert_eq!(ctx.first_walk_missing_by_pkg().get("pkg@1.0.0"), Some(&one_peer));
+
+    ctx.record_first_walk_missing(".", &miss(&two_peers));
     let recorded = ctx.first_walk_missing_by_pkg();
     assert_eq!(recorded.get("pkg@1.0.0").map(HashSet::len), Some(2));
 
-    ctx.record_first_walk_missing(".", &miss(&[]));
+    ctx.record_first_walk_missing(".", &miss(&none));
     let recorded = ctx.first_walk_missing_by_pkg();
     assert!(
         recorded.get("pkg@1.0.0").is_some_and(|names| names.contains("peer")),
@@ -178,7 +181,7 @@ fn owner_missing_record_is_written_once_per_generation() {
 
     let new_owner = ChildrenOwner { depth: 0, ..owner };
     lock_recoverable(&ctx.children_owner_by_id).insert("pkg@1.0.0".to_string(), entry(new_owner));
-    ctx.record_first_walk_missing(".", &miss(&[]));
+    ctx.record_first_walk_missing(".", &miss(&none));
     assert_eq!(
         ctx.first_walk_missing_by_pkg().get("pkg@1.0.0").map(HashSet::len),
         Some(0),

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -37,7 +37,7 @@ use crate::{
     },
     resolve_peers::{
         HoistMissingScope, PeerDiscoveryResult, PeerHoistDiscovery, ResolvePeersOptions,
-        ResolvePeersResult, apply_hoist_missing_scope, resolve_peers,
+        ResolvePeersResult, apply_hoist_missing_scope, index_missing_names, resolve_peers,
     },
     resolved_tree::ResolvedTree,
 };
@@ -674,9 +674,10 @@ impl ImporterHoistState {
             .ctx
             .workspace()
             .provider_pkg_ids(discovery.resolved_peer_providers_by_alias.values());
-        self.ctx
-            .workspace()
-            .record_first_walk_missing(&self.importer_id, &discovery.missing_names_by_pkg);
+        self.ctx.workspace().record_first_walk_missing(
+            &self.importer_id,
+            &index_missing_names(&discovery.missing_summaries),
+        );
         RequiredRound { provider_pkg_ids, discovery, walk_was_full }
     }
 
@@ -696,10 +697,7 @@ impl ImporterHoistState {
                     Some(Arc::new(HoistMissingScope {
                         importer_id: self.importer_id.clone(),
                         first_importer_by_pkg: self.ctx.workspace().first_importer_by_pkg(),
-                        first_walk_missing_by_pkg: self
-                            .ctx
-                            .workspace()
-                            .first_walk_missing_by_pkg(),
+                        first_walk_missing_by_pkg: self.ctx.workspace().first_walk_missing_by_pkg(),
                         locked_peer_names: Arc::clone(&self.locked_peer_names),
                     })),
                     peer_discovery,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -695,12 +695,11 @@ impl ImporterHoistState {
                 None => self.resolve_required_round(
                     Some(Arc::new(HoistMissingScope {
                         importer_id: self.importer_id.clone(),
-                        first_importer_by_pkg: Arc::new(
-                            self.ctx.workspace().first_importer_by_pkg(),
-                        ),
-                        first_walk_missing_by_pkg: Arc::new(
-                            self.ctx.workspace().first_walk_missing_by_pkg(),
-                        ),
+                        first_importer_by_pkg: self.ctx.workspace().first_importer_by_pkg(),
+                        first_walk_missing_by_pkg: self
+                            .ctx
+                            .workspace()
+                            .first_walk_missing_by_pkg(),
                         locked_peer_names: Arc::clone(&self.locked_peer_names),
                     })),
                     peer_discovery,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -54,6 +54,7 @@ use std::{
     sync::Arc,
 };
 use walker::Walker;
+pub(crate) use walker::{MissingNames, index_missing_names};
 
 /// Options threaded into [`fn@resolve_peers`].
 #[derive(Debug, Clone)]

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/discovery.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/discovery.rs
@@ -10,7 +10,7 @@ use crate::{
         HoistMissingScope, ResolvePeersOptions,
         cache::{PeerProviderChildren, PeersCacheItem},
         context::{CurrentProviderSource, ParentPkgInfo, SharedChain},
-        walker::{NodeOutput, Walker, merge_missing_summary},
+        walker::{MissingSummary, NodeOutput, Walker},
     },
     resolved_tree::{DirectDep, ResolvedTree},
 };
@@ -126,8 +126,13 @@ pub(crate) struct PeerDiscoveryResult {
     /// Ancestor `pkgIdWithPatchHash` chains recorded per missing-peer
     /// issue, consumed by [`fn@apply_hoist_missing_scope`].
     missing_ancestor_pkg_ids: HashMap<String, Vec<SharedChain<String>>>,
-    /// See [`ResolvePeersResult::missing_names_by_pkg`](super::ResolvePeersResult::missing_names_by_pkg).
-    pub(crate) missing_names_by_pkg: HashMap<String, HashSet<String>>,
+    /// The pass's subtree missing-peer summaries, one per walked direct
+    /// dep. Read through
+    /// [`index_missing_names`](fn@crate::resolve_peers::index_missing_names)
+    /// for the per-package view
+    /// [`ResolvePeersResult::missing_names_by_pkg`](super::ResolvePeersResult::missing_names_by_pkg)
+    /// materializes.
+    pub(crate) missing_summaries: Vec<Arc<MissingSummary>>,
 }
 
 /// Walk `direct` in discovery mode: peer matching, caches, and issue
@@ -173,16 +178,15 @@ fn discover_peers(
             &importer_parent_dep_paths,
         );
     }
-    let mut seen_missing_summaries = HashSet::default();
-    let mut fold_output = |result: &mut PeerDiscoveryResult, output: NodeOutput| {
+    let fold_output = |result: &mut PeerDiscoveryResult, output: NodeOutput| {
         for (peer_alias, peer_node_id) in output.auto_install_resolved_peers {
             result.resolved_peer_providers_by_alias.insert(peer_alias, peer_node_id);
         }
-        merge_missing_summary(
-            &mut result.missing_names_by_pkg,
-            &mut seen_missing_summaries,
-            output.subtree_missing_by_pkg,
-        );
+        if let Some(summary) = output.subtree_missing_by_pkg
+            && !result.missing_summaries.iter().any(|seen| Arc::ptr_eq(seen, &summary))
+        {
+            result.missing_summaries.push(summary);
+        }
     };
     for dep in &own_direct {
         let output = walker.resolve_node(

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
@@ -260,7 +260,7 @@ pub(super) struct MissingPeerInfo {
 /// are shared with their parents instead of repeatedly copying every
 /// descendant's package map into each ancestor and cache entry.
 #[derive(Debug)]
-pub(super) struct MissingSummary {
+pub(crate) struct MissingSummary {
     own: Option<(String, HashSet<String>)>,
     children: Vec<Arc<MissingSummary>>,
 }
@@ -1361,20 +1361,54 @@ impl Walker<'_> {
     }
 }
 
-pub(super) fn merge_missing_summary(
-    target: &mut HashMap<String, HashSet<String>>,
-    seen: &mut HashSet<usize>,
-    summary: SubtreeMissingByPkg,
-) {
-    let Some(summary) = summary else { return };
-    let mut pending = vec![summary];
+/// The missing-peer names reported for one package by a walk. A
+/// package's occurrences can appear in several subtree summaries, whose
+/// reports are read as their union.
+pub(crate) enum MissingNames<'a> {
+    One(&'a HashSet<String>),
+    Union(Vec<&'a HashSet<String>>),
+}
+
+impl<'a> MissingNames<'a> {
+    fn add(&mut self, names: &'a HashSet<String>) {
+        match self {
+            MissingNames::One(first) => *self = MissingNames::Union(vec![first, names]),
+            MissingNames::Union(all) => all.push(names),
+        }
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &str> {
+        let (one, union) = match self {
+            MissingNames::One(names) => (Some(*names), None),
+            MissingNames::Union(all) => (None, Some(all)),
+        };
+        one.into_iter()
+            .chain(union.into_iter().flatten().copied())
+            .flat_map(|names| names.iter().map(String::as_str))
+    }
+}
+
+/// Index the per-package missing-peer names `roots` reported, borrowing
+/// from the summaries rather than copying every descendant's names into
+/// an owned map: one of these is built per importer per hoist round, so
+/// a copy would make each round cost the whole workspace.
+pub(crate) fn index_missing_names<'a>(
+    roots: &'a [Arc<MissingSummary>],
+) -> HashMap<&'a str, MissingNames<'a>> {
+    let mut index: HashMap<&str, MissingNames<'_>> = HashMap::default();
+    let mut seen: HashSet<usize> = HashSet::default();
+    let mut pending: Vec<&Arc<MissingSummary>> = roots.iter().collect();
     while let Some(summary) = pending.pop() {
-        if !seen.insert(Arc::as_ptr(&summary) as usize) {
+        if !seen.insert(Arc::as_ptr(summary) as usize) {
             continue;
         }
         if let Some((pkg_id, names)) = &summary.own {
-            target.entry(pkg_id.clone()).or_default().extend(names.iter().cloned());
+            index
+                .entry(pkg_id.as_str())
+                .and_modify(|entry| entry.add(names))
+                .or_insert(MissingNames::One(names));
         }
-        pending.extend(summary.children.iter().cloned());
+        pending.extend(summary.children.iter());
     }
+    index
 }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
@@ -1392,9 +1392,9 @@ impl<'a> MissingNames<'a> {
 /// from the summaries rather than copying every descendant's names into
 /// an owned map: one of these is built per importer per hoist round, so
 /// a copy would make each round cost the whole workspace.
-pub(crate) fn index_missing_names<'a>(
-    roots: &'a [Arc<MissingSummary>],
-) -> HashMap<&'a str, MissingNames<'a>> {
+pub(crate) fn index_missing_names(
+    roots: &[Arc<MissingSummary>],
+) -> HashMap<&str, MissingNames<'_>> {
     let mut index: HashMap<&str, MissingNames<'_>> = HashMap::default();
     let mut seen: HashSet<usize> = HashSet::default();
     let mut pending: Vec<&Arc<MissingSummary>> = roots.iter().collect();
@@ -1412,3 +1412,6 @@ pub(crate) fn index_missing_names<'a>(
     }
     index
 }
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker/tests.rs
@@ -1,0 +1,53 @@
+//! Unit tests for reading a walk's subtree missing-peer summaries.
+
+use super::{MissingSummary, index_missing_names};
+use rustc_hash::FxHashSet as HashSet;
+use std::sync::Arc;
+
+fn summary(
+    own: Option<(&str, &[&str])>,
+    children: Vec<Arc<MissingSummary>>,
+) -> Arc<MissingSummary> {
+    Arc::new(MissingSummary {
+        own: own.map(|(pkg_id, names)| {
+            (pkg_id.to_string(), names.iter().map(|name| (*name).to_string()).collect())
+        }),
+        children,
+    })
+}
+
+fn names_of<'a>(
+    index: &'a rustc_hash::FxHashMap<&str, super::MissingNames<'_>>,
+    pkg_id: &str,
+) -> HashSet<&'a str> {
+    index.get(pkg_id).expect("package reported missing peers").iter().collect()
+}
+
+#[test]
+fn descendants_of_every_root_are_indexed() {
+    let shared = summary(Some(("deep@1.0.0", &["deep-peer"])), Vec::new());
+    let roots = vec![
+        summary(Some(("a@1.0.0", &["a-peer"])), vec![Arc::clone(&shared)]),
+        summary(Some(("b@1.0.0", &["b-peer"])), vec![shared]),
+    ];
+
+    let index = index_missing_names(&roots);
+
+    assert_eq!(index.len(), 3);
+    assert_eq!(names_of(&index, "a@1.0.0"), HashSet::from_iter(["a-peer"]));
+    assert_eq!(names_of(&index, "b@1.0.0"), HashSet::from_iter(["b-peer"]));
+    assert_eq!(names_of(&index, "deep@1.0.0"), HashSet::from_iter(["deep-peer"]));
+}
+
+#[test]
+fn occurrences_of_one_package_report_the_union_of_their_missing_peers() {
+    let roots = vec![
+        summary(Some(("pkg@1.0.0", &["first"])), Vec::new()),
+        summary(Some(("pkg@1.0.0", &["second"])), Vec::new()),
+        summary(Some(("pkg@1.0.0", &["third", "first"])), Vec::new()),
+    ];
+
+    let index = index_missing_names(&roots);
+
+    assert_eq!(names_of(&index, "pkg@1.0.0"), HashSet::from_iter(["first", "second", "third"]));
+}

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -313,8 +313,8 @@ where
     // The context is quiescent between the prepare barrier above and
     // the completes below, so one snapshot of the owner-scope maps
     // serves every importer.
-    let first_importer_by_pkg = Arc::new(workspace.first_importer_by_pkg());
-    let first_walk_missing_by_pkg = Arc::new(workspace.first_walk_missing_by_pkg());
+    let first_importer_by_pkg = workspace.first_importer_by_pkg();
+    let first_walk_missing_by_pkg = workspace.first_walk_missing_by_pkg();
     for (state, round) in states.iter().zip(&mut initial_required_rounds) {
         if let Some(round) = round {
             state.apply_owner_missing_scope(


### PR DESCRIPTION
## Summary

Two amortizations in the peer-hoist loop, for
https://github.com/pnpm/pnpm/issues/13505. Together they take the
hoist-heavy resolution benchmark (331 importers, 5,030 packages) from
**6.7s to 1.50s**.

I profiled `main` first, because the budget in the issue predates
pnpm/pnpm#13571 and pnpm/pnpm#13575 and no longer holds:

| item | time | share |
|---|---:|---:|
| discovery walks (662) | 2.95s | 44% |
| freeing each round's flattened missing-peer map | 1.27s | 19% |
| re-snapshotting two workspace maps per importer | 1.13s | 17% |
| owner-scope barrier snapshot | 0.37s | 6% |
| final peer pass | 0.40s | 6% |
| everything else | 0.53s | 8% |

The final peer pass — one of the two parallelization targets the issue
names — is 6% of the resolve today. The two items above it are both
per-importer rescans of the whole workspace, and both come out without
touching what resolves or adding a thread.

### Shared snapshots of the owner-scope maps

Every hoist round of every importer cloned `first_importer_by_pkg` and
`first_walk_missing_by_pkg` whole to build its `HoistMissingScope`, so a
round cost the workspace and a wave cost its square.

Each map now carries the `Arc` snapshot last projected from it, handed
out until a write invalidates it. The two writers that usually find
nothing to change — an ownership claim re-recording the importer that
already owns the package, and a later round re-recording a missing-peer
report the same owner generation already wrote — test before writing, so
a round that changes nothing reuses the projection. Snapshots already
issued keep what they were built from when a later write invalidates the
cache.

6.7s → 4.4s.

### No flattened missing-peer map per round

Each discovery pass folded its subtree summaries into an owned `pkg id →
missing peer names` map, cloning every descendant's package id and name
set into it. Its one consumer — the per-package owner-context record —
read that map and dropped it. On the benchmark the passes built 1.6M
entries and spent 1.1s freeing them again.

The summaries are already shared bottom-up by `Arc`, so a pass reports
its roots and the reader indexes them. The index borrows the names in
place, which makes it free to drop; the union that a package's several
occurrences require is materialized only when a second summary reports
the same package.

4.4s → 1.5s.

### Results

In-repo `workspace_full_resolution`, three runs each:

| scenario | main | this PR |
|---|---:|---:|
| hoist-heavy workspace resolution | 6.66 / 6.75 / 6.85s | **1.50 / 1.50 / 1.50s** |
| peer-heavy workspace resolution | 0.83 / 0.83 / 0.87s | 0.84 / 0.85 / 0.84s |
| full workspace resolution | 0.32 / 0.33 / 0.34s | 0.32 / 0.33 / 0.33s |

The two scenarios that never enter the hoist loop are unchanged, as
expected — see the note on pnpm/pnpm#13505 about which scenario
discriminates hoist-round work.

On the 114-importer bit.cloud workspace from the issue the gain is small,
because only ~0.2s of its resolve is the work this removes (its importers
mostly have their peers provided, so the per-round maps are small):

| phase | main | this PR |
|---|---:|---:|
| importer inits | 1.44s | 1.39s |
| prepare initial rounds | 0.94s | 0.90s |
| owner-scope barrier | 0.042s | 0.043s |
| complete initial rounds | 2.65s | **2.42s** |
| optional/required hoist loop | 0.82s | 0.87s |
| merged snapshot + collect | 0.16s | 0.16s |
| final peer pass | 2.48s | 2.52s |
| total replay | 10.48s | 10.19s |

Peak memory falls as well: one shared snapshot replaces the per-importer
copies, and the flattened maps are never built (6.24 GB → 6.33 GB peak
RSS on that workspace, i.e. unchanged within noise, since its maps were
small to begin with).

### On proving the output is unchanged

Both changes are meant to be output-preserving, and the 7,557 workspace
tests — which include the lockfile-shape and peer-resolution suites —
pass.

I could **not** gate that with lockfile byte-identity on the bit.cloud
workspace, because `main` itself is not run-to-run deterministic there:
two consecutive replays of the same `main` binary over the same restored
input differ by 10,390 lines, and *main-vs-this-branch* (5,336 lines) is
smaller than either build's own run-to-run noise. I have reopened
pnpm/pnpm#13567 with the measurement.

## Squash Commit Body

```text
Two per-importer rescans of the whole workspace came out of the
peer-hoist loop, which made a hoist wave cost the square of the
workspace rather than the workspace.

Every round of every importer cloned `first_importer_by_pkg` and
`first_walk_missing_by_pkg` whole to build its `HoistMissingScope`.
Each map now carries the `Arc` snapshot last projected from it and
hands that out until a write invalidates it; the two writers that
usually change nothing — an ownership claim re-recording the importer
that already owns the package, and a later round re-recording a
missing-peer report the same owner generation already wrote — test
before writing, so a round that changes nothing reuses the projection.
Snapshots already issued keep what they were built from.

Each discovery pass also folded its subtree summaries into an owned
`pkg id -> missing peer names` map, cloning every descendant's package
id and name set into it, for one consumer that read the map and
dropped it: on the benchmark below, 1.6M entries built and 1.1s spent
freeing them. The summaries are already shared bottom-up by `Arc`, so
a pass now reports its roots and the reader indexes them in place. The
index borrows the names, which makes it free to drop, and the union
several occurrences of one package require is materialized only when a
second summary reports that package.

The hoist-heavy `workspace_full_resolution` scenario (331 importers,
5,030 packages) drops from ~6.7s to ~1.50s; the two scenarios that
never enter the hoist loop are unchanged. On the 114-importer
bit.cloud workspace from the issue the gain is ~0.2s of a 10.4s
resolve, since its importers mostly have their peers provided and its
per-round maps are small.

Related to https://github.com/pnpm/pnpm/issues/13505.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <!-- pacquet-only: the peer-hoist loop and its discovery engine have no
  TypeScript counterpart. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788254488&installation_model_id=426870&pr_number=13579&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13579&signature=828ea50fb81cec6a1cb0690fac5ba717791aace473a76459f67d2b77a98266b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved workspace installation performance by avoiding repeated scans during peer dependency resolution.
  * Reduced resolution scaling from quadratic to linear as workspace size grows.
  * Reduced redundant copying when processing missing peer dependency information.

* **Bug Fixes**
  * Improved consistency when tracking missing peer names across shared dependency trees.
  * Preserved accurate dependency resolution results when package information is reused across workspace projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->