### PR TITLE
fix: stabilize pacquet dependency traversal order

### DIFF
--- a/.changeset/amortize-hoist-round-workspace-scans.md
+++ b/.changeset/amortize-hoist-round-workspace-scans.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Installing a workspace whose projects auto-install peer dependencies is substantially faster. Each round of the peer-hoist loop no longer rescans the whole workspace once per project, so the cost of resolution grows with the workspace instead of with its square.
+Installing a workspace whose projects auto-install peer dependencies is substantially faster. Each round of the peer-hoist loop no longer scans the whole workspace once per project, so the cost of resolution grows with the workspace instead of with its square.

--- a/.changeset/friendly-spiders-smile.md
+++ b/.changeset/friendly-spiders-smile.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed nondeterministic peer bindings in large multi-project workspaces.

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/manifest.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/manifest.rs
@@ -142,6 +142,7 @@ pub(super) fn extract_children(
     for (name, specifier) in engines_runtime_dependencies(manifest, "engines", "dependencies") {
         out.push((name.to_string(), specifier, false));
     }
+    out.sort_unstable();
     Ok(out)
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/manifest/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/manifest/tests.rs
@@ -22,6 +22,35 @@ fn dependency_engines_runtime_is_walked_as_a_runtime_dependency() {
     );
 }
 
+#[test]
+fn child_order_does_not_depend_on_manifest_property_order() {
+    let forward = manifest_result(
+        serde_json::from_str(
+            r#"{
+            "name": "parent",
+            "version": "1.0.0",
+            "dependencies": { "alpha": "1.0.0", "zulu": "2.0.0" }
+        }"#,
+        )
+        .unwrap(),
+    );
+    let reverse = manifest_result(
+        serde_json::from_str(
+            r#"{
+            "name": "parent",
+            "version": "1.0.0",
+            "dependencies": { "zulu": "2.0.0", "alpha": "1.0.0" }
+        }"#,
+        )
+        .unwrap(),
+    );
+
+    let forward_children = extract_children(&forward).unwrap();
+    let reverse_children = extract_children(&reverse).unwrap();
+    dbg!(&forward_children, &reverse_children);
+    assert_eq!(forward_children, reverse_children);
+}
+
 // Regression test for pnpm/pnpm#13334: npm ships bundled dependencies
 // inside the package's own tarball, so they must not be resolved as
 // edges of their own.


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Closes pnpm/pnpm#13567.

Pacquet resolved child dependencies in manifest property order. Concurrent manifest fetches can return equivalent dependency maps in different orders, which changed the assignment of internal node IDs and made later peer resolution choose different bindings.

This sorts extracted child specs before the dependency walk, making traversal and node assignment deterministic. A regression test verifies that reversing manifest property order produces the same child sequence. Five consecutive installs against the reported 114-importer, 21,834-snapshot reproduction produced byte-identical 30 MB lockfiles; without the fix, identical inputs produced a 196,825-line diff.

This is specific to pacquet's concurrent Rust resolver and does not require a TypeScript CLI change. The PR also fixes a spelling-check failure in an existing changeset that blocked the required pre-push checks.

## Squash Commit Body

```text
Canonicalize the child specs extracted from resolved manifests before the
dependency walk. Manifest fetches run concurrently and equivalent JSON maps
can arrive with different insertion orders. Letting that order reach lazy
child discovery changes internal node-ID assignment, which can alter the peer
providers selected later in large workspaces.

Add a regression test proving that reversed dependency property order yields
the same child sequence. Also correct an existing changeset wording issue
found by the repository pre-push spellcheck.

Closes pnpm/pnpm#13567.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788264790&installation_model_id=426870&pr_number=13584&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13584&signature=672b18768724543b83b014f4159f7e219afaedb6ddf789775cc5774c1b549d5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed nondeterministic peer dependency bindings in large multi-project workspaces.
  * Dependency resolution now produces consistent results regardless of manifest dependency property order.
  * Improved workspace resolution performance by reducing scaling from quadratic to linear as workspace size grows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->