### PR TITLE
perf(resolving-deps-resolver): answer the hoist scope's ancestor queries per shared suffix

### DIFF
--- a/.changeset/hoist-scope-suffix-memo.md
+++ b/.changeset/hoist-scope-suffix-memo.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Resolving a workspace whose dependency chains are deep is faster: deciding which missing peer dependencies another project's resolution already covers now answers once per shared chain segment instead of once per report.

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -43,7 +43,9 @@ use crate::{
     node_id::NodeId,
     resolved_tree::{DirectDep, ResolvedTree},
 };
-use context::{CurrentProviderSource, SharedChain, importer_relative_link_dep_path};
+use context::{
+    ChainSuffixMemo, CurrentProviderSource, SharedChain, importer_relative_link_dep_path,
+};
 use discovery::PeerDiscoveryCaches;
 pub(crate) use discovery::{PeerDiscoveryResult, PeerHoistDiscovery, apply_hoist_missing_scope};
 use pacquet_deps_path::DepPath;
@@ -199,22 +201,27 @@ pub struct HoistMissingScope {
 impl HoistMissingScope {
     /// `true` when a miss of `peer_name` declared under the given
     /// ancestor chain is covered by another importer's shared walk.
-    fn suppresses_iter<'a>(
+    fn suppresses_chain(
         &self,
-        ancestor_pkg_ids: impl Iterator<Item = &'a String>,
+        ancestor_pkg_ids: &SharedChain<String>,
         peer_name: &str,
+        memo: &mut ChainSuffixMemo,
     ) -> bool {
         if self.locked_peer_names.contains(peer_name) {
             return false;
         }
-        ancestor_pkg_ids.into_iter().any(|pkg_id| {
-            self.first_importer_by_pkg.get(pkg_id).is_some_and(|owner| {
-                *owner != self.importer_id
-                    && self
-                        .first_walk_missing_by_pkg
-                        .get(pkg_id)
-                        .is_some_and(|missing| !missing.contains(peer_name))
-            })
+        ancestor_pkg_ids.any_memoized(memo, |pkg_id| self.covers(pkg_id, peer_name))
+    }
+
+    /// Whether another importer's shared walk of `pkg_id` already
+    /// reported on `peer_name` — and found it satisfied.
+    fn covers(&self, pkg_id: &str, peer_name: &str) -> bool {
+        self.first_importer_by_pkg.get(pkg_id).is_some_and(|owner| {
+            *owner != self.importer_id
+                && self
+                    .first_walk_missing_by_pkg
+                    .get(pkg_id)
+                    .is_some_and(|missing| !missing.contains(peer_name))
         })
     }
 }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -205,12 +205,25 @@ impl HoistMissingScope {
         &self,
         ancestor_pkg_ids: &SharedChain<String>,
         peer_name: &str,
-        memo: &mut ChainSuffixMemo,
+        memo: &mut ChainSuffixMemo<String>,
     ) -> bool {
         if self.locked_peer_names.contains(peer_name) {
             return false;
         }
         ancestor_pkg_ids.any_memoized(memo, |pkg_id| self.covers(pkg_id, peer_name))
+    }
+
+    /// The unmemoized form, for callers that cannot keep every queried
+    /// chain alive (see [`SharedChain::any_memoized`]).
+    fn suppresses_iter<'a>(
+        &self,
+        ancestor_pkg_ids: impl Iterator<Item = &'a String>,
+        peer_name: &str,
+    ) -> bool {
+        if self.locked_peer_names.contains(peer_name) {
+            return false;
+        }
+        ancestor_pkg_ids.into_iter().any(|pkg_id| self.covers(pkg_id, peer_name))
     }
 
     /// Whether another importer's shared walk of `pkg_id` already

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/context.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/context.rs
@@ -92,11 +92,24 @@ impl<Element: PartialEq> SharedChain<Element> {
     }
 }
 
-/// Memo for [`SharedChain::any_memoized`], keyed by link identity: the
+/// Memo for [`SharedChain::any_memoized`], keyed by link address: the
 /// answer for a link covers that link and everything above it, so it
 /// holds for every chain that shares the suffix. One memo is valid for
 /// one predicate.
-pub(super) type ChainSuffixMemo = HashMap<usize, bool>;
+///
+/// Each entry keeps the link it is keyed on alive. Addresses are only
+/// unique among live allocations, so a dropped link could otherwise
+/// hand its address — and its answer — to whatever was allocated there
+/// next.
+pub(super) struct ChainSuffixMemo<Element> {
+    answers: HashMap<usize, (Arc<SharedChainLink<Element>>, bool)>,
+}
+
+impl<Element> Default for ChainSuffixMemo<Element> {
+    fn default() -> Self {
+        ChainSuffixMemo { answers: HashMap::default() }
+    }
+}
 
 impl<Element> SharedChain<Element> {
     /// Whether any element from here to the root satisfies `predicate`,
@@ -110,14 +123,14 @@ impl<Element> SharedChain<Element> {
     /// suffixes the memo already answers.
     pub(super) fn any_memoized(
         &self,
-        memo: &mut ChainSuffixMemo,
+        memo: &mut ChainSuffixMemo<Element>,
         mut predicate: impl FnMut(&Element) -> bool,
     ) -> bool {
         let mut unmemoized = Vec::new();
         let mut cursor = self.0.as_ref();
         let mut satisfied = false;
         while let Some(link) = cursor {
-            if let Some(&answer) = memo.get(&link_key(link)) {
+            if let Some(&(_, answer)) = memo.answers.get(&link_key(link)) {
                 satisfied = answer;
                 break;
             }
@@ -126,7 +139,7 @@ impl<Element> SharedChain<Element> {
         }
         for link in unmemoized.into_iter().rev() {
             satisfied = satisfied || predicate(&link.value);
-            memo.insert(link_key(link), satisfied);
+            memo.answers.insert(link_key(link), (Arc::clone(link), satisfied));
         }
         satisfied
     }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/context.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/context.rs
@@ -92,6 +92,50 @@ impl<Element: PartialEq> SharedChain<Element> {
     }
 }
 
+/// Memo for [`SharedChain::any_memoized`], keyed by link identity: the
+/// answer for a link covers that link and everything above it, so it
+/// holds for every chain that shares the suffix. One memo is valid for
+/// one predicate.
+pub(super) type ChainSuffixMemo = HashMap<usize, bool>;
+
+impl<Element> SharedChain<Element> {
+    /// Whether any element from here to the root satisfies `predicate`,
+    /// answering from `memo` for suffixes already evaluated. Chains built
+    /// by pushing onto a common ancestor share those suffixes, so a
+    /// repeated query over a family of chains costs each link once
+    /// instead of once per chain.
+    ///
+    /// `predicate` must be pure: it is called on the links this call is
+    /// first to reach, in root-to-tip order, and skipped entirely for
+    /// suffixes the memo already answers.
+    pub(super) fn any_memoized(
+        &self,
+        memo: &mut ChainSuffixMemo,
+        mut predicate: impl FnMut(&Element) -> bool,
+    ) -> bool {
+        let mut unmemoized = Vec::new();
+        let mut cursor = self.0.as_ref();
+        let mut satisfied = false;
+        while let Some(link) = cursor {
+            if let Some(&answer) = memo.get(&link_key(link)) {
+                satisfied = answer;
+                break;
+            }
+            unmemoized.push(link);
+            cursor = link.parent.as_ref();
+        }
+        for link in unmemoized.into_iter().rev() {
+            satisfied = satisfied || predicate(&link.value);
+            memo.insert(link_key(link), satisfied);
+        }
+        satisfied
+    }
+}
+
+fn link_key<Element>(link: &Arc<SharedChainLink<Element>>) -> usize {
+    Arc::as_ptr(link) as usize
+}
+
 impl<Element: Clone> SharedChain<Element> {
     fn to_root_vec(&self) -> Vec<Element> {
         let mut values: Vec<Element> = self.iter().cloned().collect();

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/context/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/context/tests.rs
@@ -1,8 +1,8 @@
 //! Unit tests for the peer-resolution context helpers.
 
 use super::{
-    ParentRef, importer_relative_link_dep_path, peer_segment_names, remap_link_node_id,
-    satisfies_with_prereleases, scoped_hoisted_optional_parent_refs,
+    ChainSuffixMemo, ParentRef, SharedChain, importer_relative_link_dep_path, peer_segment_names,
+    remap_link_node_id, satisfies_with_prereleases, scoped_hoisted_optional_parent_refs,
 };
 use crate::{
     node_id::NodeId,
@@ -154,4 +154,77 @@ fn satisfies_accepts_prerelease_against_non_prerelease_range() {
     assert!(satisfies_with_prereleases("18.0.0-rc.1", "^18.0.0"));
     assert!(satisfies_with_prereleases("1.2.3-beta.0", "^1.2.0"));
     assert!(!satisfies_with_prereleases("19.0.0-rc.1", "^18.0.0"));
+}
+
+/// Build `root -> ... -> tip` and return the chain at the tip.
+fn chain_of(values: &[&str]) -> SharedChain<String> {
+    values.iter().fold(SharedChain::default(), |chain, value| chain.pushed((*value).to_string()))
+}
+
+#[test]
+fn memoized_any_matches_the_unmemoized_answer() {
+    let shared = chain_of(&["root", "middle"]);
+    let with_match = shared.pushed("needle".to_string());
+    let without_match = shared.pushed("other".to_string());
+
+    let mut memo = ChainSuffixMemo::default();
+    assert!(with_match.any_memoized(&mut memo, |value| value == "needle"));
+    assert!(!without_match.any_memoized(&mut memo, |value| value == "needle"));
+
+    let mut fresh = ChainSuffixMemo::default();
+    assert_eq!(
+        with_match.any_memoized(&mut fresh, |value| value == "needle"),
+        with_match.iter().any(|value| value == "needle"),
+    );
+}
+
+#[test]
+fn a_match_in_a_shared_suffix_answers_every_chain_built_on_it() {
+    let shared = chain_of(&["root", "needle"]);
+    let branches: Vec<_> =
+        ["a", "b", "c"].iter().map(|tip| shared.pushed((*tip).to_string())).collect();
+
+    let mut memo = ChainSuffixMemo::default();
+    let mut visits = 0;
+    for branch in &branches {
+        assert!(branch.any_memoized(&mut memo, |value| {
+            visits += 1;
+            value == "needle"
+        }));
+    }
+
+    assert_eq!(
+        visits, 2,
+        "the two shared links answer once, and a suffix that already matched \
+         spares every branch's own tip",
+    );
+}
+
+#[test]
+fn an_unmatched_shared_suffix_is_still_evaluated_only_once() {
+    let shared = chain_of(&["root", "plain"]);
+    let branches: Vec<_> =
+        ["a", "b", "c"].iter().map(|tip| shared.pushed((*tip).to_string())).collect();
+
+    let mut memo = ChainSuffixMemo::default();
+    let mut visits = 0;
+    for branch in &branches {
+        assert!(!branch.any_memoized(&mut memo, |value| {
+            visits += 1;
+            value == "needle"
+        }));
+    }
+
+    assert_eq!(visits, 5, "two shared links once, plus each branch's own tip");
+}
+
+#[test]
+fn suffixes_evaluated_under_one_predicate_are_not_reused_for_another() {
+    let chain = chain_of(&["root", "needle"]);
+
+    let mut memo = ChainSuffixMemo::default();
+    assert!(chain.any_memoized(&mut memo, |value| value == "needle"));
+
+    let mut other = ChainSuffixMemo::default();
+    assert!(!chain.any_memoized(&mut other, |value| value == "absent"));
 }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/context/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/context/tests.rs
@@ -156,6 +156,11 @@ fn satisfies_accepts_prerelease_against_non_prerelease_range() {
     assert!(!satisfies_with_prereleases("19.0.0-rc.1", "^18.0.0"));
 }
 
+/// Strong count of a chain's tip link, for asserting who holds it.
+fn link_strong_count(chain: &SharedChain<String>) -> usize {
+    chain.0.as_ref().map_or(0, std::sync::Arc::strong_count)
+}
+
 /// Build `root -> ... -> tip` and return the chain at the tip.
 fn chain_of(values: &[&str]) -> SharedChain<String> {
     values.iter().fold(SharedChain::default(), |chain, value| chain.pushed((*value).to_string()))
@@ -227,4 +232,22 @@ fn suffixes_evaluated_under_one_predicate_are_not_reused_for_another() {
 
     let mut other = ChainSuffixMemo::default();
     assert!(!chain.any_memoized(&mut other, |value| value == "absent"));
+}
+
+#[test]
+fn a_memo_keeps_the_links_it_keyed_on_alive() {
+    let mut memo = ChainSuffixMemo::default();
+    let root = chain_of(&["root"]);
+
+    let held_by = {
+        let temporary = root.pushed("temporary".to_string());
+        assert!(temporary.any_memoized(&mut memo, |value| value == "temporary"));
+        link_strong_count(&temporary)
+    };
+
+    // The chain that produced the entry is gone, but the memo's own
+    // reference keeps its link — and therefore its address — reserved,
+    // so nothing else can be allocated there and inherit the answer.
+    assert_eq!(held_by, 2, "the memo holds a reference alongside the caller's");
+    assert!(!chain_of(&["root", "other"]).any_memoized(&mut memo, |value| value == "temporary"));
 }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/discovery.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/discovery.rs
@@ -238,9 +238,9 @@ pub(crate) fn apply_hoist_missing_scope(
         let mut memo = ChainSuffixMemo::default();
         *issues = std::mem::take(issues)
             .into_iter()
-            .zip(ancestor_chains)
+            .zip(ancestor_chains.iter())
             .filter_map(|(issue, ancestor_pkg_ids)| {
-                (!scope.suppresses_chain(&ancestor_pkg_ids, peer_name, &mut memo)).then_some(issue)
+                (!scope.suppresses_chain(ancestor_pkg_ids, peer_name, &mut memo)).then_some(issue)
             })
             .collect();
         !issues.is_empty()

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/discovery.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/discovery.rs
@@ -9,7 +9,7 @@ use crate::{
     resolve_peers::{
         HoistMissingScope, ResolvePeersOptions,
         cache::{PeerProviderChildren, PeersCacheItem},
-        context::{CurrentProviderSource, ParentPkgInfo, SharedChain},
+        context::{ChainSuffixMemo, CurrentProviderSource, ParentPkgInfo, SharedChain},
         walker::{MissingSummary, NodeOutput, Walker},
     },
     resolved_tree::{DirectDep, ResolvedTree},
@@ -233,11 +233,14 @@ pub(crate) fn apply_hoist_missing_scope(
 ) {
     result.peer_dependency_issues.missing.retain(|peer_name, issues| {
         let ancestor_chains = result.missing_ancestor_pkg_ids.remove(peer_name).unwrap_or_default();
+        // The issues reported for one peer come from occurrences spread
+        // through the tree, whose ancestor chains share long suffixes.
+        let mut memo = ChainSuffixMemo::default();
         *issues = std::mem::take(issues)
             .into_iter()
             .zip(ancestor_chains)
             .filter_map(|(issue, ancestor_pkg_ids)| {
-                (!scope.suppresses_iter(ancestor_pkg_ids.iter(), peer_name)).then_some(issue)
+                (!scope.suppresses_chain(&ancestor_pkg_ids, peer_name, &mut memo)).then_some(issue)
             })
             .collect();
         !issues.is_empty()

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
@@ -15,7 +15,8 @@ use crate::{
             merge_realize_undo,
         },
         context::{
-            CurrentProviderSource, ParentPkgInfo, ParentRef, ParentRefs, SharedChain,
+            ChainSuffixMemo, CurrentProviderSource, ParentPkgInfo, ParentRef, ParentRefs,
+            SharedChain,
             importer_relative_link_dep_path, insert_parent_ref, link_node_id_as_dep_path,
             parents_from_chain, pkg_name_version, remap_link_node_id, satisfies_with_prereleases,
             scoped_hoisted_optional_parent_refs,
@@ -130,6 +131,11 @@ pub(super) struct Walker<'tree> {
     peer_provider_index_peer_names: HashSet<String>,
     pub(super) empty_resolved_peers: Arc<HashMap<String, NodeId>>,
     pub(super) empty_missing_peers: Arc<HashMap<String, MissingPeerInfo>>,
+    /// Per peer name, the suffix verdicts
+    /// [`Self::missing_issue_suppressed`] has already computed against
+    /// this walk's [`ResolvePeersOptions::hoist_missing_scope`]. The
+    /// scope is fixed for the walk, so the answers stay valid for it.
+    missing_scope_memo: HashMap<String, ChainSuffixMemo>,
 }
 
 impl<'tree> Walker<'tree> {
@@ -209,6 +215,7 @@ impl<'tree> Walker<'tree> {
             peer_provider_index_peer_names,
             empty_resolved_peers: Arc::new(HashMap::default()),
             empty_missing_peers: Arc::new(HashMap::default()),
+            missing_scope_memo: HashMap::default(),
         }
     }
 
@@ -1175,12 +1182,13 @@ impl Walker<'_> {
     /// given ancestor chain must not be emitted for the hoist input.
     /// See [`ResolvePeersOptions::hoist_missing_scope`].
     pub(super) fn missing_issue_suppressed(
-        &self,
+        &mut self,
         ancestor_pkg_ids: &SharedChain<String>,
         peer_name: &str,
     ) -> bool {
-        let Some(scope) = self.opts.hoist_missing_scope.as_ref() else { return false };
-        scope.suppresses_iter(ancestor_pkg_ids.iter(), peer_name)
+        let Some(scope) = self.opts.hoist_missing_scope.clone() else { return false };
+        let memo = self.missing_scope_memo.entry(peer_name.to_string()).or_default();
+        scope.suppresses_chain(ancestor_pkg_ids, peer_name, memo)
     }
 
     pub(super) fn record_missing_issue(

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
@@ -16,10 +16,9 @@ use crate::{
         },
         context::{
             ChainSuffixMemo, CurrentProviderSource, ParentPkgInfo, ParentRef, ParentRefs,
-            SharedChain,
-            importer_relative_link_dep_path, insert_parent_ref, link_node_id_as_dep_path,
-            parents_from_chain, pkg_name_version, remap_link_node_id, satisfies_with_prereleases,
-            scoped_hoisted_optional_parent_refs,
+            SharedChain, importer_relative_link_dep_path, insert_parent_ref,
+            link_node_id_as_dep_path, parents_from_chain, pkg_name_version, remap_link_node_id,
+            satisfies_with_prereleases, scoped_hoisted_optional_parent_refs,
         },
         discovery::PeerDiscoveryCaches,
         finalize::{NodeRecord, PendingPeerEdge, WalkedNode},

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
@@ -15,10 +15,10 @@ use crate::{
             merge_realize_undo,
         },
         context::{
-            ChainSuffixMemo, CurrentProviderSource, ParentPkgInfo, ParentRef, ParentRefs,
-            SharedChain, importer_relative_link_dep_path, insert_parent_ref,
-            link_node_id_as_dep_path, parents_from_chain, pkg_name_version, remap_link_node_id,
-            satisfies_with_prereleases, scoped_hoisted_optional_parent_refs,
+            CurrentProviderSource, ParentPkgInfo, ParentRef, ParentRefs, SharedChain,
+            importer_relative_link_dep_path, insert_parent_ref, link_node_id_as_dep_path,
+            parents_from_chain, pkg_name_version, remap_link_node_id, satisfies_with_prereleases,
+            scoped_hoisted_optional_parent_refs,
         },
         discovery::PeerDiscoveryCaches,
         finalize::{NodeRecord, PendingPeerEdge, WalkedNode},
@@ -130,11 +130,6 @@ pub(super) struct Walker<'tree> {
     peer_provider_index_peer_names: HashSet<String>,
     pub(super) empty_resolved_peers: Arc<HashMap<String, NodeId>>,
     pub(super) empty_missing_peers: Arc<HashMap<String, MissingPeerInfo>>,
-    /// Per peer name, the suffix verdicts
-    /// [`Self::missing_issue_suppressed`] has already computed against
-    /// this walk's [`ResolvePeersOptions::hoist_missing_scope`]. The
-    /// scope is fixed for the walk, so the answers stay valid for it.
-    missing_scope_memo: HashMap<String, ChainSuffixMemo>,
 }
 
 impl<'tree> Walker<'tree> {
@@ -214,7 +209,6 @@ impl<'tree> Walker<'tree> {
             peer_provider_index_peer_names,
             empty_resolved_peers: Arc::new(HashMap::default()),
             empty_missing_peers: Arc::new(HashMap::default()),
-            missing_scope_memo: HashMap::default(),
         }
     }
 
@@ -1181,13 +1175,12 @@ impl Walker<'_> {
     /// given ancestor chain must not be emitted for the hoist input.
     /// See [`ResolvePeersOptions::hoist_missing_scope`].
     pub(super) fn missing_issue_suppressed(
-        &mut self,
+        &self,
         ancestor_pkg_ids: &SharedChain<String>,
         peer_name: &str,
     ) -> bool {
-        let Some(scope) = self.opts.hoist_missing_scope.clone() else { return false };
-        let memo = self.missing_scope_memo.entry(peer_name.to_string()).or_default();
-        scope.suppresses_chain(ancestor_pkg_ids, peer_name, memo)
+        let Some(scope) = self.opts.hoist_missing_scope.as_ref() else { return false };
+        scope.suppresses_iter(ancestor_pkg_ids.iter(), peer_name)
     }
 
     pub(super) fn record_missing_issue(


### PR DESCRIPTION
## Summary

Deciding whether a missing-peer issue is already covered by another
importer's walk scans the issue's ancestor chain for a package that
importer owns. That scan ran **per issue**, and the issues reported for
one peer come from occurrences spread through the tree whose ancestor
chains share long suffixes — so the same suffix was rescanned once per
issue.

`SharedChain` is a cons-list whose links are shared, which is exactly
what makes the rescan avoidable: the answer for a link covers that link
and everything above it, for *every* chain built on it. `any_memoized`
records the answer per link, so the total cost is the number of distinct
links rather than the sum over chains. A suffix that already matched
spares each branch's own tip as well, since the fold short-circuits.

Per importer this takes `O(issues × depth)` to `O(distinct links)`. The
issue count grows with the workspace, so the removed term is superlinear
in workspace size — multiplied by chain depth, which is what decides
whether it is visible.

Only the post-round scope filter memoizes, per peer name. I first
memoized the walk's own suppression check too; reviewers found that
unsound — a memo keyed on `Arc::as_ptr` outliving its links can answer
for whatever is allocated at that address next, and a walk allocates and
drops chain links throughout. That memo is gone, and measurement says
the walk never wanted it anyway (the fixture is faster without it). The
memo that remains holds an `Arc` to every link it keys on, so an entry
cannot outlive its link's address.

## Measurements

Output is unchanged; 7,565 workspace tests pass.

| workload | main | this PR |
|---|---:|---:|
| full-size resolution fixture (331 importers, chains 250 deep) | 1.55 / 1.56 / 1.57s | **1.18 / 1.20 / 1.20s** |
| CI-sized fixture (chains 60 deep), as CI measured it | 245.8 ± 0.64ms | 238.5 ± 0.69ms (3%) |
| 114-importer bit.cloud workspace (replay, interleaved ×3) | 10.31s median | 10.35s median (neutral) |

**I want to be straight about the last two rows.** The win needs chains
deeper than either realistic workload has — deeper even than the
pathological chain from pnpm/pnpm#13574, which was 15–26 packages. So
this is not a change users will time. What it buys is the removal of a
term that scales with the issue count, and the guarantee that a
deep-chain workspace cannot pay it quadratically. It measured
equal-or-better everywhere and slower nowhere.

The CI gate added in pnpm/pnpm#13581 does register it — 3%, at its own
0.3% variance — though my local runs of that size were too noisy to see
it. Deepening its fixture to 150 layers separates the builds much more
clearly (573ms vs 663ms) but triples that group's cost on every PR,
which I did not think this was worth.

## Squash Commit Body

```text
Deciding whether a missing-peer issue is covered by another importer's
walk scans the issue's ancestor chain for a package that importer owns.
The scan ran per issue, and issues of one peer come from occurrences
spread through the tree whose chains share long suffixes, so the same
suffix was rescanned once per issue: O(issues x depth) per importer,
with the issue count growing with the workspace.

SharedChain already shares those suffixes structurally, so the answer
for a link covers that link and everything above it, for every chain
built on it. `any_memoized` records that answer per link, taking the
total to the number of distinct links; a suffix that already matched
spares each branch's own tip as well.

The post-round scope filter memoizes, per peer name; the walk's own
suppression check does not, because a memo outliving its links cannot
be keyed on their addresses and the walk drops chains throughout. Each
entry holds an `Arc` to the link it is keyed on, so an address cannot
be recycled underneath it.

Output is unchanged. On the full-size workspace resolution fixture,
whose chains are 250 deep, resolution goes from ~1.56s to ~1.19s, and
the CI-sized fixture moves 3%. It is neutral on the 114-importer
bit.cloud workspace, whose chains are too shallow for the rescan to
dominate: the term this removes scales with the issue count, but only
in proportion to chain depth.

Related to https://github.com/pnpm/pnpm/issues/13505.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <!-- pacquet-only: the peer-hoist scope has no TypeScript counterpart. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package.
- [x] Added or updated tests.
  <!-- Four unit tests on the memo, break-tested: memoising only the tip,
  and never reading the memo, each fail them. The fourth asserts the memo
  keeps its keys' links alive after the caller's chain is dropped. -->

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved dependency resolution performance for projects with deeply chained workspaces.
  * Reused ancestor-chain checks to reduce repeated work during missing-peer dependency handling.

* **Bug Fixes**
  * Preserved correct handling of locked peer dependencies while applying optimized resolution checks.

* **Tests**
  * Added coverage confirming consistent results and safe reuse of cached dependency-chain evaluations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->