### PR TITLE
perf(resolving-deps-resolver): derive each package's name once for the peer-name cycle graph

### DIFF
--- a/.changeset/peer-cycle-graph-name-once.md
+++ b/.changeset/peer-cycle-graph-name-once.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Resolution spends less time in its final peer pass: the package-name cycle graph it consults is now derived once per package instead of once per occurrence of that package.

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/context.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/context.rs
@@ -499,11 +499,21 @@ pub(super) fn remap_link_node_id(
 /// peer propagation for non-npm packages without panicking on
 /// `name_ver = None`.
 pub(super) fn pkg_name_version(result: &ResolveResult) -> (String, String) {
+    let version = result
+        .name_ver
+        .as_ref()
+        .map_or_else(|| result.id.as_str().to_string(), |name_ver| name_ver.suffix.to_string());
+    (pkg_name(result), version)
+}
+
+/// The name half of [`fn@pkg_name_version`], for callers that would
+/// discard the version. `PkgName` holds scope and bare name separately,
+/// so rendering either half allocates.
+pub(super) fn pkg_name(result: &ResolveResult) -> String {
     if let Some(name_ver) = result.name_ver.as_ref() {
-        return (name_ver.name.to_string(), name_ver.suffix.to_string());
+        return name_ver.name.to_string();
     }
-    let fallback_name = result.alias.clone().unwrap_or_else(|| result.id.as_str().to_string());
-    (fallback_name, result.id.as_str().to_string())
+    result.alias.clone().unwrap_or_else(|| result.id.as_str().to_string())
 }
 
 /// The `name@version` identity a peer contributes to a depPath's peer suffix.

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/finalize.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/finalize.rs
@@ -381,42 +381,56 @@ impl Walker<'_> {
     }
 
     fn cyclic_peer_names(&self) -> HashSet<String> {
-        let mut graph: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+        // The graph is over package *names*, of which a workspace has
+        // orders of magnitude fewer than the occurrences contributing to
+        // it, so the name each occurrence's package renders to is derived
+        // once per package rather than once per occurrence.
+        let mut name_of_pkg: HashMap<&str, String> = HashMap::default();
         for (node_id, peers) in &self.node_external_peers {
             if peers.is_empty() {
                 continue;
             }
-            let tree_node = &self.tree.dependencies_tree[node_id];
-            let pkg = &self.tree.packages[&tree_node.resolved_package_id];
-            let (name, _) = pkg_name_version(&pkg.result);
-            let edges = graph.entry(name).or_default();
-            for peer_alias in peers.keys() {
-                edges.insert(peer_alias.clone());
+            let pkg_id = self.tree.dependencies_tree[node_id].resolved_package_id.as_str();
+            if !name_of_pkg.contains_key(pkg_id) {
+                let pkg = &self.tree.packages[pkg_id];
+                name_of_pkg.insert(pkg_id, pkg_name_version(&pkg.result).0);
             }
         }
-        let peer_names: Vec<String> =
-            graph.values().flat_map(|edges| edges.iter().cloned()).collect();
+
+        let mut graph: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
+        for (node_id, peers) in &self.node_external_peers {
+            if peers.is_empty() {
+                continue;
+            }
+            let pkg_id = self.tree.dependencies_tree[node_id].resolved_package_id.as_str();
+            let edges = graph.entry(name_of_pkg[pkg_id].as_str()).or_default();
+            for peer_alias in peers.keys() {
+                edges.insert(peer_alias.as_str());
+            }
+        }
+        let peer_names: Vec<&str> =
+            graph.values().flat_map(|edges| edges.iter().copied()).collect();
         for peer_name in peer_names {
             graph.entry(peer_name).or_default();
         }
 
         struct PeerNameTarjan<'a> {
-            graph: &'a BTreeMap<String, BTreeSet<String>>,
-            index_of: HashMap<String, u32>,
-            low_of: HashMap<String, u32>,
-            on_stack: HashSet<String>,
-            tarjan_stack: Vec<String>,
+            graph: &'a BTreeMap<&'a str, BTreeSet<&'a str>>,
+            index_of: HashMap<&'a str, u32>,
+            low_of: HashMap<&'a str, u32>,
+            on_stack: HashSet<&'a str>,
+            tarjan_stack: Vec<&'a str>,
             cyclic: HashSet<String>,
             next_index: u32,
         }
 
-        impl PeerNameTarjan<'_> {
-            fn strongconnect(&mut self, name: &str) {
-                self.index_of.insert(name.to_string(), self.next_index);
-                self.low_of.insert(name.to_string(), self.next_index);
+        impl<'a> PeerNameTarjan<'a> {
+            fn strongconnect(&mut self, name: &'a str) {
+                self.index_of.insert(name, self.next_index);
+                self.low_of.insert(name, self.next_index);
                 self.next_index += 1;
-                self.on_stack.insert(name.to_string());
-                self.tarjan_stack.push(name.to_string());
+                self.on_stack.insert(name);
+                self.tarjan_stack.push(name);
 
                 if let Some(neighbors) = self.graph.get(name) {
                     for child in neighbors {
@@ -424,11 +438,11 @@ impl Walker<'_> {
                             self.strongconnect(child);
                             let name_low = self.low_of[name];
                             let child_low = self.low_of[child];
-                            self.low_of.insert(name.to_string(), name_low.min(child_low));
+                            self.low_of.insert(name, name_low.min(child_low));
                         } else if self.on_stack.contains(child) {
                             let name_low = self.low_of[name];
                             let child_index = self.index_of[child];
-                            self.low_of.insert(name.to_string(), name_low.min(child_index));
+                            self.low_of.insert(name, name_low.min(child_index));
                         }
                     }
                 }
@@ -447,7 +461,7 @@ impl Walker<'_> {
                         self.graph.get(member).is_some_and(|edges| edges.contains(member))
                     });
                     if component.len() > 1 || self_loop {
-                        self.cyclic.extend(component);
+                        self.cyclic.extend(component.into_iter().map(str::to_owned));
                     }
                 }
             }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/finalize.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/finalize.rs
@@ -381,40 +381,39 @@ impl Walker<'_> {
     }
 
     fn cyclic_peer_names(&self) -> HashSet<String> {
-        // The graph is over package *names*, of which a workspace has
-        // orders of magnitude fewer than the occurrences contributing to
-        // it, so the name each occurrence's package renders to is derived
-        // once per package rather than once per occurrence.
-        let mut name_of_pkg: HashMap<&str, String> = HashMap::default();
+        // Collect by package id, which every occurrence already carries,
+        // and render names when folding the result: the graph is over
+        // package *names*, of which a workspace has far fewer than the
+        // occurrences contributing to them, and rendering one costs an
+        // allocation (`PkgName` holds scope and bare name separately).
+        // Two package ids can share a name — different versions of one
+        // package — so the fold unions their edges.
+        let mut edges_of_pkg: HashMap<&str, BTreeSet<&str>> = HashMap::default();
         for (node_id, peers) in &self.node_external_peers {
             if peers.is_empty() {
                 continue;
             }
             let pkg_id = self.tree.dependencies_tree[node_id].resolved_package_id.as_str();
-            name_of_pkg
-                .entry(pkg_id)
-                .or_insert_with(|| pkg_name(&self.tree.packages[pkg_id].result));
-        }
-
-        let mut graph: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
-        for (node_id, peers) in &self.node_external_peers {
-            if peers.is_empty() {
-                continue;
-            }
-            let pkg_id = self.tree.dependencies_tree[node_id].resolved_package_id.as_str();
-            let edges = graph.entry(name_of_pkg[pkg_id].as_str()).or_default();
+            let edges = edges_of_pkg.entry(pkg_id).or_default();
             for peer_alias in peers.keys() {
                 edges.insert(peer_alias.as_str());
             }
         }
+
+        let mut graph: BTreeMap<String, BTreeSet<&str>> = BTreeMap::new();
+        for (pkg_id, edges) in edges_of_pkg {
+            graph.entry(pkg_name(&self.tree.packages[pkg_id].result)).or_default().extend(edges);
+        }
         let peer_names: Vec<&str> =
             graph.values().flat_map(|edges| edges.iter().copied()).collect();
         for peer_name in peer_names {
-            graph.entry(peer_name).or_default();
+            if !graph.contains_key(peer_name) {
+                graph.insert(peer_name.to_string(), BTreeSet::default());
+            }
         }
 
         struct PeerNameTarjan<'a> {
-            graph: &'a BTreeMap<&'a str, BTreeSet<&'a str>>,
+            graph: &'a BTreeMap<String, BTreeSet<&'a str>>,
             index_of: HashMap<&'a str, u32>,
             low_of: HashMap<&'a str, u32>,
             on_stack: HashSet<&'a str>,
@@ -457,7 +456,7 @@ impl Walker<'_> {
                         }
                     }
                     let self_loop = component.first().is_some_and(|member| {
-                        self.graph.get(member).is_some_and(|edges| edges.contains(member))
+                        self.graph.get(*member).is_some_and(|edges| edges.contains(member))
                     });
                     if component.len() > 1 || self_loop {
                         self.cyclic.extend(component.into_iter().map(str::to_owned));
@@ -476,7 +475,7 @@ impl Walker<'_> {
             next_index: 0,
         };
         for name in graph.keys() {
-            if !tarjan.index_of.contains_key(name) {
+            if !tarjan.index_of.contains_key(name.as_str()) {
                 tarjan.strongconnect(name);
             }
         }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/finalize.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/finalize.rs
@@ -9,7 +9,7 @@ use crate::{
     node_id::NodeId,
     resolve_peers::{
         context::{
-            SharedChain, link_node_id_as_dep_path, peer_id_pair, peer_segment_names,
+            SharedChain, link_node_id_as_dep_path, peer_id_pair, peer_segment_names, pkg_name,
             pkg_name_version,
         },
         walker::{MissingPeerInfo, Walker},
@@ -391,10 +391,9 @@ impl Walker<'_> {
                 continue;
             }
             let pkg_id = self.tree.dependencies_tree[node_id].resolved_package_id.as_str();
-            if !name_of_pkg.contains_key(pkg_id) {
-                let pkg = &self.tree.packages[pkg_id];
-                name_of_pkg.insert(pkg_id, pkg_name_version(&pkg.result).0);
-            }
+            name_of_pkg
+                .entry(pkg_id)
+                .or_insert_with(|| pkg_name(&self.tree.packages[pkg_id].result));
         }
 
         let mut graph: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();


### PR DESCRIPTION
## Summary

The final depPath pass consults a cycle graph over **package names**, to
decide which peer names must collapse to `name@version`. A workspace has
orders of magnitude fewer package names than occurrences: on the
114-importer bit.cloud workspace, ~5,000 packages against **224,946
occurrences with external peers**.

That graph was built by deriving the name from every one of those
occurrences. `pkg_name_version` reassembles `@scope/bare` into a fresh
`String` — `PkgName` stores the halves separately, so there is no
borrow to hand back — and also builds a version string this caller
discards. Each occurrence then cloned its name for the graph key and its
peer aliases for the edges.

Now edges are collected keyed by package id — which every occurrence
already carries and which needs no rendering — and one name is rendered
per distinct package when folding that into the graph. Two package ids
can share a name (different versions of one package), so the fold unions
their edges, as grouping by name did. One pass over occurrences, one
over packages.

The first version of this deduplicated by filling a name cache in one
pass and reading it in a second. That only pays where packages repeat,
and on the peer-heavy fixture — where they barely do — the extra pass
cost more than it saved, showing up as a real ~0.8% regression on the
integrated benchmark's peer-heavy scenario. Keying by package id needs
no such cache.

## Measurements

Same graph, same cycles; 7,572 workspace tests pass.

Four runs each, same build session:

| workload | main | this PR |
|---|---:|---:|
| hoist-heavy resolution fixture | 1.21–1.23s | **1.18–1.19s** |
| peer-heavy resolution fixture | 842–865ms | **828–839ms** |
| CI-sized fixture, as CI measured the first version | 247.1 ± 0.57ms | 233.8 ± 0.88ms (5.4%) |
| `cyclic_peer_names` itself, reference workspace | 132ms of a 10.2s replay | |
| reference workspace, end to end | | below its run-to-run noise |

CI measured the first version of this at 5.4% and 1.8% on two runs of
the gate, the second with four times the variance of the first; treat
that as a range, not a single figure. What CI *also* showed was the
peer-heavy regression described above, which is why the implementation
changed.

The end-to-end effect on a real workspace is still smaller than that
workspace's own noise. What the change removes is a per-occurrence term
from a pass whose result depends only on the package set, so the gap
widens with the ratio of occurrences to packages — 45:1 on the
reference workspace.

Found while profiling the final peer pass for
https://github.com/pnpm/pnpm/issues/13505. The rest of that pass is
peer-walk work (62%) and `build_final_dep_paths` (23%), neither of which
has waste of this kind.

## Squash Commit Body

```text
The cycle graph the final depPath pass consults is over package names,
of which a workspace has orders of magnitude fewer than the occurrences
contributing to it — on the reference workspace, ~5,000 packages against
224,946 occurrences with external peers. It was built by deriving the
name from every one of those occurrences, and `pkg_name_version`
allocates both the name and a version this caller discards, so the graph
cost two allocations per occurrence and its keys and edges cost another
`String` clone each.

Derive the name once per package id and borrow throughout: the graph,
the peer-name list that seeds its isolated nodes, and the Tarjan pass
over it all hold `&str` now. Only the returned cyclic set owns its
names, because it outlives the graph.

Same graph, same cycles. The effect is ~1-2% on the full-size
resolution fixture and below this workspace's run-to-run noise on the
reference workspace; what it removes is a per-occurrence term in a pass
whose result depends only on the package set.

Related to https://github.com/pnpm/pnpm/issues/13505.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <!-- pacquet-only: this pass has no TypeScript counterpart. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package.
- [x] Added or updated tests.
  <!-- No new test: the change is a refactor of how an existing result is
  computed, and the existing peer-cycle tests cover the result. -->

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved dependency resolution efficiency by deriving package-name cycle graphs once per package.
  * Reduced redundant processing during peer dependency cycle detection.

* **Bug Fixes**
  * Improved package-name resolution by consistently using available package names, aliases, or resolver identifiers as fallbacks.
  * Preserved existing cycle detection behavior while making results more reliable across package aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->