### PR TITLE
fix(cli): accept npm's --prefix and --store spellings

### DIFF
--- a/.changeset/prefix-alias-of-dir.md
+++ b/.changeset/prefix-alias-of-dir.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+npm's `--prefix` is accepted as a spelling of `--dir`, and `--store` as a spelling of `--store-dir`, so `pnpm --prefix ../ run test` no longer fails with "unexpected argument '--prefix' found" [#13583](https://github.com/pnpm/pnpm/issues/13583).

--- a/pnpm/crates/cli/src/cli_args.rs
+++ b/pnpm/crates/cli/src/cli_args.rs
@@ -102,5 +102,14 @@ mod verify_deps;
 
 pub(crate) use cli_command::CliArgs;
 
+/// The CLI grammar, built once per process. Constructing it walks every
+/// subcommand, and the passes that run before the parse each need the same
+/// view of it — argument arity, aliases, and which positionals name a
+/// subcommand.
+pub(crate) fn grammar() -> &'static clap::Command {
+    static GRAMMAR: std::sync::OnceLock<clap::Command> = std::sync::OnceLock::new();
+    GRAMMAR.get_or_init(<CliArgs as clap::CommandFactory>::command)
+}
+
 #[cfg(test)]
 mod tests;

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -111,17 +111,12 @@ pub struct CliArgs {
 
     /// Set working directory. Accepted anywhere on the command line,
     /// before or after the subcommand, like every other rc-option.
-    // `--prefix` is npm's spelling of the same option; pnpm renames it to
-    // `--dir` before parsing (`RENAMED_OPTIONS` in `parseCliArgs.ts`) and
-    // keeps it out of the help output.
     #[clap(short = 'C', long, alias = "prefix", default_value = ".", global = true)]
     pub dir: PathBuf,
 
     /// Directory in which the package store is created. Relative paths
     /// are resolved from the workspace root, or from `--dir` outside a
     /// workspace.
-    // `--store` is npm's spelling, renamed to `--store-dir` by the same
-    // `RENAMED_OPTIONS` table that maps `--prefix` onto `--dir`.
     #[clap(
         long = "store-dir",
         alias = "store",

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -111,14 +111,20 @@ pub struct CliArgs {
 
     /// Set working directory. Accepted anywhere on the command line,
     /// before or after the subcommand, like every other rc-option.
-    #[clap(short = 'C', long, default_value = ".", global = true)]
+    // `--prefix` is npm's spelling of the same option; pnpm renames it to
+    // `--dir` before parsing (`RENAMED_OPTIONS` in `parseCliArgs.ts`) and
+    // keeps it out of the help output.
+    #[clap(short = 'C', long, alias = "prefix", default_value = ".", global = true)]
     pub dir: PathBuf,
 
     /// Directory in which the package store is created. Relative paths
     /// are resolved from the workspace root, or from `--dir` outside a
     /// workspace.
+    // `--store` is npm's spelling, renamed to `--store-dir` by the same
+    // `RENAMED_OPTIONS` table that maps `--prefix` onto `--dir`.
     #[clap(
         long = "store-dir",
+        alias = "store",
         value_name = "DIR",
         global = true,
         overrides_with = "store_dir",

--- a/pnpm/crates/cli/src/cli_args/pre_command.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command.rs
@@ -26,7 +26,8 @@ use super::{
         spawn_pnpm,
     },
 };
-use crate::{config_deps, config_overrides::ConfigOverrides};
+use crate::{config_deps, config_overrides::ConfigOverrides, flag_relocation::ArgTable};
+use clap::CommandFactory;
 use derive_more::{Display, Error};
 use miette::{Context, Diagnostic, IntoDiagnostic};
 use pacquet_config::{Config, Host, PNPM_VERSION, PmOnFail};
@@ -833,6 +834,7 @@ impl SwitchInput {
     }
 
     fn from_version_argv(argv: &[OsString]) -> Self {
+        let global_options = ArgTable::top_level(&CliArgs::command());
         let mut input = Self { dir: PathBuf::from("."), npmrc_auth_file: None, command: None };
         let mut index = 1;
         while index < argv.len() {
@@ -877,7 +879,7 @@ impl SwitchInput {
                 index += width;
                 continue;
             }
-            index += if value_taking_global_option(token) { 2 } else { 1 };
+            index += if consumes_next_token(token, &global_options) { 2 } else { 1 };
         }
         input
     }
@@ -994,20 +996,19 @@ fn long_value<'a>(
         .map(|value| (value, 1))
 }
 
-fn value_taking_global_option(token: &str) -> bool {
-    if matches!(token, "-F") {
-        return true;
+/// Whether an option token takes the following argv token as its value, so
+/// the scan steps over it instead of mistaking it for the command name.
+/// Read from the clap grammar rather than a list of names, so an option (or
+/// alias) added to [`CliArgs`] is accounted for here without a second edit.
+fn consumes_next_token(token: &str, global_options: &ArgTable) -> bool {
+    if let Some(name) = token.strip_prefix("--") {
+        return !name.contains('=') && global_options.long_consumes_value(name).unwrap_or(false);
     }
-    if token.starts_with("-F") {
-        return false;
-    }
-    let Some(name) = token.strip_prefix("--") else {
+    let Some(rest) = token.strip_prefix('-').filter(|rest| !rest.is_empty()) else {
         return false;
     };
-    if name.contains('=') {
-        return false;
-    }
-    matches!(name, "filter" | "filter-prod" | "npmrc-auth-file" | "reporter" | "userconfig")
+    let short = rest.chars().next().expect("checked non-empty");
+    rest.chars().count() == 1 && global_options.short_consumes_value(short).unwrap_or(false)
 }
 
 #[cfg(test)]

--- a/pnpm/crates/cli/src/cli_args/pre_command.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command.rs
@@ -855,7 +855,9 @@ impl SwitchInput {
                 continue;
             }
             if let Some((value, width)) =
-                long_value(token, "dir", argv.get(index + 1).map(OsString::as_os_str))
+                long_value(token, "dir", argv.get(index + 1).map(OsString::as_os_str)).or_else(
+                    || long_value(token, "prefix", argv.get(index + 1).map(OsString::as_os_str)),
+                )
             {
                 input.dir = PathBuf::from(value);
                 index += width;

--- a/pnpm/crates/cli/src/cli_args/pre_command.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command.rs
@@ -27,7 +27,6 @@ use super::{
     },
 };
 use crate::{config_deps, config_overrides::ConfigOverrides, flag_relocation::ArgTable};
-use clap::CommandFactory;
 use derive_more::{Display, Error};
 use miette::{Context, Diagnostic, IntoDiagnostic};
 use pacquet_config::{Config, Host, PNPM_VERSION, PmOnFail};
@@ -834,7 +833,7 @@ impl SwitchInput {
     }
 
     fn from_version_argv(argv: &[OsString]) -> Self {
-        let global_options = ArgTable::top_level(&CliArgs::command());
+        let global_options = ArgTable::top_level(super::grammar());
         let mut input = Self { dir: PathBuf::from("."), npmrc_auth_file: None, command: None };
         let mut index = 1;
         while index < argv.len() {

--- a/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
@@ -72,6 +72,20 @@ fn version_argv_reads_dir_auth_file_and_command_forms() {
             npmrc_auth_file: None,
             command: Some("install"),
         },
+        Case {
+            name: "store directory value is not mistaken for the command",
+            argv: &["pnpm", "--store", "/tmp/store", "--prefix", "/tmp/scanned", "--version"],
+            dir: "/tmp/scanned",
+            npmrc_auth_file: None,
+            command: None,
+        },
+        Case {
+            name: "canonical store directory value is not mistaken for the command",
+            argv: &["pnpm", "--store-dir", "/tmp/store", "--dir", "/tmp/scanned", "--version"],
+            dir: "/tmp/scanned",
+            npmrc_auth_file: None,
+            command: None,
+        },
     ];
 
     for case in cases {

--- a/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
@@ -45,6 +45,20 @@ fn version_argv_reads_dir_auth_file_and_command_forms() {
             command: None,
         },
         Case {
+            name: "prefix alias of dir",
+            argv: &["pnpm", "--prefix", "/tmp/prefix-dir", "--version"],
+            dir: "/tmp/prefix-dir",
+            npmrc_auth_file: None,
+            command: None,
+        },
+        Case {
+            name: "equals prefix alias of dir",
+            argv: &["pnpm", "--prefix=/tmp/equals-prefix", "--version"],
+            dir: "/tmp/equals-prefix",
+            npmrc_auth_file: None,
+            command: None,
+        },
+        Case {
             name: "separator stops command detection",
             argv: &["pnpm", "--dir=/tmp/separator", "--", "run"],
             dir: "/tmp/separator",

--- a/pnpm/crates/cli/src/cli_args/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/tests.rs
@@ -46,6 +46,18 @@ fn dir_is_global_and_parses_on_either_side_of_the_subcommand() {
 }
 
 #[test]
+fn prefix_is_an_alias_of_dir() {
+    for argv in [
+        ["pacquet", "--prefix", "project", "run", "test"].as_slice(),
+        ["pacquet", "--prefix=project", "run", "test"].as_slice(),
+        ["pacquet", "install", "--prefix", "project"].as_slice(),
+    ] {
+        let parsed = CliArgs::try_parse_from(argv).expect("parses --prefix");
+        assert_eq!(parsed.dir, std::path::PathBuf::from("project"));
+    }
+}
+
+#[test]
 fn registry_is_a_universal_global_option() {
     for argv in [
         ["pacquet", "--registry=https://r.test/", "add", "foo"].as_slice(),
@@ -71,6 +83,17 @@ fn store_dir_is_global_and_parses_on_either_side_of_the_subcommand() {
         ["pacquet", "install", "--store-dir=custom-store"].as_slice(),
     ] {
         let parsed = CliArgs::try_parse_from(argv).expect("parses global --store-dir");
+        assert_eq!(parsed.store_dir.as_deref(), Some(Path::new("custom-store")));
+    }
+}
+
+#[test]
+fn store_is_an_alias_of_store_dir() {
+    for argv in [
+        ["pacquet", "--store", "custom-store", "install"].as_slice(),
+        ["pacquet", "install", "--store=custom-store"].as_slice(),
+    ] {
+        let parsed = CliArgs::try_parse_from(argv).expect("parses --store");
         assert_eq!(parsed.store_dir.as_deref(), Some(Path::new("custom-store")));
     }
 }

--- a/pnpm/crates/cli/src/lib.rs
+++ b/pnpm/crates/cli/src/lib.rs
@@ -7,6 +7,7 @@ mod github_actions;
 mod job_control;
 mod leading_separator;
 mod parse_boundary;
+mod renamed_options;
 mod shorthands;
 mod state;
 mod with_current;
@@ -75,6 +76,10 @@ fn run_cli() -> miette::Result<()> {
     // `--reporter=silent`) over argv before parsing; mirror that so they
     // work with every command. See `shorthands`.
     let argv = shorthands::expand_universal_shorthands(&command, argv);
+    // npm's spellings of two of pnpm's options (`--prefix`, `--store`) are
+    // hidden clap aliases; pnpm additionally lets the canonical spelling win
+    // when a command line uses both. See `renamed_options`.
+    let argv = renamed_options::drop_shadowed_aliases(&command, argv);
     // pnpm's option parser is position-independent; move subcommand
     // options written before the subcommand to after it so clap agrees.
     // See `flag_relocation`.

--- a/pnpm/crates/cli/src/parse_boundary.rs
+++ b/pnpm/crates/cli/src/parse_boundary.rs
@@ -8,8 +8,8 @@
 //! [`ConfigOverrides::extract`]: crate::config_overrides::ConfigOverrides::extract
 //! [`expand_universal_shorthands`]: crate::shorthands::expand_universal_shorthands
 
-use crate::{cli_args::CliArgs, flag_relocation::ArgTable};
-use clap::{Command, CommandFactory};
+use crate::{cli_args::grammar, flag_relocation::ArgTable};
+use clap::Command;
 use std::ffi::OsString;
 
 /// Commands whose own arguments are unconditionally a foreign command line.
@@ -64,11 +64,11 @@ pub(crate) struct CommandBoundary {
 
 /// The boundary implied by the command alone, ignoring any `--`.
 pub(crate) fn command_boundary(argv: &[OsString]) -> Option<CommandBoundary> {
-    let command = CliArgs::command();
+    let command = grammar();
     // Both halves of the union: a global lives on the top-level command,
     // a command's own options on its subcommand.
-    let mut arity = ArgTable::top_level(&command);
-    arity.absorb_subcommands(&command);
+    let mut arity = ArgTable::top_level(command);
+    arity.absorb_subcommands(command);
     let mut index = 1;
     let mut prefix_allowed = true;
     while index < argv.len() {
@@ -90,7 +90,7 @@ pub(crate) fn command_boundary(argv: &[OsString]) -> Option<CommandBoundary> {
             index += 1;
             continue;
         }
-        let Some(subcommand) = matching_subcommand(&command, arg) else {
+        let Some(subcommand) = matching_subcommand(command, arg) else {
             // Names no command: the `pnpm <script>` fallback.
             return Some(CommandBoundary { index: index + 1, is_script_shortcut: false });
         };

--- a/pnpm/crates/cli/src/renamed_options.rs
+++ b/pnpm/crates/cli/src/renamed_options.rs
@@ -69,11 +69,7 @@ pub fn drop_shadowed_aliases(cmd: &Command, argv: Vec<OsString>) -> Vec<OsString
         } else if let Some(rest) = token.strip_prefix('-').filter(|rest| !rest.is_empty()) {
             let short = rest.chars().next().expect("checked non-empty");
             let is_bare_short = rest.chars().count() == 1;
-            for (option_index, option) in RENAMED_OPTIONS.iter().enumerate() {
-                if option.canonical_short.is_some_and(|canonical| rest.contains(canonical)) {
-                    canonical_seen[option_index] = true;
-                }
-            }
+            mark_canonical_shorts(rest, &arity, &mut canonical_seen);
             index += token_width(
                 arity.short_consumes_value(short).unwrap_or(false) && is_bare_short,
                 false,
@@ -96,6 +92,26 @@ pub fn drop_shadowed_aliases(cmd: &Command, argv: Vec<OsString>) -> Vec<OsString
         argv.drain(index..(index + width).min(argv.len()));
     }
     argv
+}
+
+/// Record the canonical short options a `-abc` cluster names. The chars are
+/// read left to right and stop at the first option that takes a value,
+/// since everything past it is that value rather than more options.
+fn mark_canonical_shorts(
+    cluster: &str,
+    arity: &ArgTable,
+    canonical_seen: &mut [bool; RENAMED_OPTIONS.len()],
+) {
+    for short in cluster.chars() {
+        for (option_index, option) in RENAMED_OPTIONS.iter().enumerate() {
+            if option.canonical_short == Some(short) {
+                canonical_seen[option_index] = true;
+            }
+        }
+        if arity.short_consumes_value(short).unwrap_or(false) {
+            break;
+        }
+    }
 }
 
 #[cfg(test)]

--- a/pnpm/crates/cli/src/renamed_options.rs
+++ b/pnpm/crates/cli/src/renamed_options.rs
@@ -1,0 +1,102 @@
+//! npm's spellings of pnpm's own options.
+//!
+//! pnpm accepts `--prefix` for `--dir` and `--store` for `--store-dir`,
+//! renaming them over argv before parsing (the rename table in
+//! `pnpm11/pnpm/src/parseCliArgs.ts`). Clap accepts the alias spellings
+//! itself — they are hidden aliases on the two options, so the help output
+//! documents neither, exactly like pnpm's — which leaves only the
+//! precedence rule to reproduce: when a command line spells the same
+//! option both ways, pnpm keeps the canonical one and drops the alias,
+//! regardless of which came first. Clap alone would keep the last
+//! occurrence, so [`drop_shadowed_aliases`] removes the alias tokens up
+//! front.
+
+use crate::{
+    flag_relocation::{ArgTable, token_width},
+    parse_boundary,
+};
+use clap::Command;
+use std::ffi::OsString;
+
+/// An npm spelling and the option it names.
+struct RenamedOption {
+    alias: &'static str,
+    canonical_long: &'static str,
+    canonical_short: Option<char>,
+}
+
+const RENAMED_OPTIONS: &[RenamedOption] = &[
+    RenamedOption { alias: "prefix", canonical_long: "dir", canonical_short: Some('C') },
+    RenamedOption { alias: "store", canonical_long: "store-dir", canonical_short: None },
+];
+
+/// Drop every alias token whose option is also spelled canonically. See
+/// the module docs.
+///
+/// `cmd` must be the same [`Command`] the returned argv is parsed with, so
+/// option values are stepped over with the arity the parse will use and a
+/// value that happens to spell `--prefix` is never removed. Everything a
+/// command forwards to a child process is left untouched.
+pub fn drop_shadowed_aliases(cmd: &Command, argv: Vec<OsString>) -> Vec<OsString> {
+    let mut arity = ArgTable::top_level(cmd);
+    arity.absorb_subcommands(cmd);
+    let passthrough_from = parse_boundary::passthrough_from(&argv).unwrap_or(argv.len());
+
+    let mut canonical_seen = [false; RENAMED_OPTIONS.len()];
+    let mut alias_tokens: Vec<(usize, usize, usize)> = Vec::new();
+    let mut index = 1;
+    while index < passthrough_from.min(argv.len()) {
+        let Some(token) = argv[index].to_str() else {
+            index += 1;
+            continue;
+        };
+        if token == "--" {
+            break;
+        }
+        if let Some(rest) = token.strip_prefix("--") {
+            let (name, has_inline_value) =
+                rest.split_once('=').map_or((rest, false), |(name, _)| (name, true));
+            let width =
+                token_width(arity.long_consumes_value(name).unwrap_or(false), has_inline_value);
+            for (option_index, option) in RENAMED_OPTIONS.iter().enumerate() {
+                if name == option.alias {
+                    alias_tokens.push((option_index, index, width));
+                } else if name == option.canonical_long {
+                    canonical_seen[option_index] = true;
+                }
+            }
+            index += width;
+        } else if let Some(rest) = token.strip_prefix('-').filter(|rest| !rest.is_empty()) {
+            let short = rest.chars().next().expect("checked non-empty");
+            let is_bare_short = rest.chars().count() == 1;
+            for (option_index, option) in RENAMED_OPTIONS.iter().enumerate() {
+                if option.canonical_short.is_some_and(|canonical| rest.contains(canonical)) {
+                    canonical_seen[option_index] = true;
+                }
+            }
+            index += token_width(
+                arity.short_consumes_value(short).unwrap_or(false) && is_bare_short,
+                false,
+            );
+        } else {
+            index += 1;
+        }
+    }
+
+    let shadowed: Vec<(usize, usize)> = alias_tokens
+        .into_iter()
+        .filter(|&(option_index, ..)| canonical_seen[option_index])
+        .map(|(_, index, width)| (index, width))
+        .collect();
+    if shadowed.is_empty() {
+        return argv;
+    }
+    let mut argv = argv;
+    for (index, width) in shadowed.into_iter().rev() {
+        argv.drain(index..(index + width).min(argv.len()));
+    }
+    argv
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/renamed_options.rs
+++ b/pnpm/crates/cli/src/renamed_options.rs
@@ -67,13 +67,8 @@ pub fn drop_shadowed_aliases(cmd: &Command, argv: Vec<OsString>) -> Vec<OsString
             }
             index += width;
         } else if let Some(rest) = token.strip_prefix('-').filter(|rest| !rest.is_empty()) {
-            let short = rest.chars().next().expect("checked non-empty");
-            let is_bare_short = rest.chars().count() == 1;
-            mark_canonical_shorts(rest, &arity, &mut canonical_seen);
-            index += token_width(
-                arity.short_consumes_value(short).unwrap_or(false) && is_bare_short,
-                false,
-            );
+            let consumes_next = scan_short_cluster(rest, &arity, &mut canonical_seen);
+            index += token_width(consumes_next, false);
         } else {
             index += 1;
         }
@@ -94,24 +89,29 @@ pub fn drop_shadowed_aliases(cmd: &Command, argv: Vec<OsString>) -> Vec<OsString
     argv
 }
 
-/// Record the canonical short options a `-abc` cluster names. The chars are
-/// read left to right and stop at the first option that takes a value,
-/// since everything past it is that value rather than more options.
-fn mark_canonical_shorts(
+/// Record the canonical short options a `-abc` cluster names, and report
+/// whether the cluster takes the next argv token as its value.
+///
+/// The chars are read left to right up to the first option that takes a
+/// value, since everything past it is that value rather than more options —
+/// attached when the cluster continues, the next token when it ends there.
+fn scan_short_cluster(
     cluster: &str,
     arity: &ArgTable,
     canonical_seen: &mut [bool; RENAMED_OPTIONS.len()],
-) {
-    for short in cluster.chars() {
+) -> bool {
+    let mut chars = cluster.chars();
+    while let Some(short) = chars.next() {
         for (option_index, option) in RENAMED_OPTIONS.iter().enumerate() {
             if option.canonical_short == Some(short) {
                 canonical_seen[option_index] = true;
             }
         }
         if arity.short_consumes_value(short).unwrap_or(false) {
-            break;
+            return chars.next().is_none();
         }
     }
+    false
 }
 
 #[cfg(test)]

--- a/pnpm/crates/cli/src/renamed_options/tests.rs
+++ b/pnpm/crates/cli/src/renamed_options/tests.rs
@@ -1,0 +1,79 @@
+use super::drop_shadowed_aliases;
+use crate::{
+    boolean_negations::with_boolean_negations, cli_args::CliArgs,
+    flag_relocation::relocate_pre_subcommand_flags, shorthands::expand_universal_shorthands,
+};
+use clap::{CommandFactory, FromArgMatches};
+use pretty_assertions::assert_eq;
+use std::{ffi::OsString, path::Path};
+
+fn drop_aliases(tokens: &[&str]) -> Vec<String> {
+    let cmd = with_boolean_negations(CliArgs::command());
+    drop_shadowed_aliases(&cmd, tokens.iter().map(OsString::from).collect())
+        .into_iter()
+        .map(|token| token.into_string().expect("test tokens are UTF-8"))
+        .collect()
+}
+
+/// Run the full pre-parse pipeline and parse.
+fn parse(tokens: &[&str]) -> CliArgs {
+    let cmd = with_boolean_negations(CliArgs::command());
+    let argv = expand_universal_shorthands(&cmd, tokens.iter().map(OsString::from).collect());
+    let argv = drop_shadowed_aliases(&cmd, argv);
+    let argv = relocate_pre_subcommand_flags(&cmd, argv);
+    cmd.try_get_matches_from(argv)
+        .and_then(|matches| CliArgs::from_arg_matches(&matches))
+        .expect("parses after the pre-parse pipeline")
+}
+
+#[test]
+fn a_lone_alias_is_kept() {
+    assert_eq!(
+        drop_aliases(&["pnpm", "--prefix", "here", "install"]),
+        ["pnpm", "--prefix", "here", "install"],
+    );
+    assert_eq!(
+        drop_aliases(&["pnpm", "--store=here", "install"]),
+        ["pnpm", "--store=here", "install"],
+    );
+}
+
+#[test]
+fn the_canonical_spelling_wins_over_the_alias_in_either_order() {
+    for argv in [
+        ["pnpm", "--prefix", "aliased", "--dir", "canonical", "install"].as_slice(),
+        ["pnpm", "--dir", "canonical", "--prefix", "aliased", "install"].as_slice(),
+        ["pnpm", "--prefix=aliased", "-C", "canonical", "install"].as_slice(),
+    ] {
+        assert_eq!(parse(argv).dir, Path::new("canonical"), "argv: {argv:?}");
+    }
+
+    for argv in [
+        ["pnpm", "--store", "aliased", "--store-dir", "canonical", "install"].as_slice(),
+        ["pnpm", "--store-dir=canonical", "--store=aliased", "install"].as_slice(),
+    ] {
+        assert_eq!(
+            parse(argv).store_dir.as_deref(),
+            Some(Path::new("canonical")),
+            "argv: {argv:?}",
+        );
+    }
+}
+
+/// Only pnpm's own tokens are considered: a script's `--prefix` is the
+/// script's, and so is an option value that happens to spell one.
+#[test]
+fn forwarded_and_value_tokens_are_left_alone() {
+    assert_eq!(
+        drop_aliases(&["pnpm", "--dir", "here", "run", "build", "--prefix", "there"]),
+        ["pnpm", "--dir", "here", "run", "build", "--prefix", "there"],
+    );
+    assert_eq!(
+        drop_aliases(&["pnpm", "--dir", "here", "--", "--prefix", "there"]),
+        ["pnpm", "--dir", "here", "--", "--prefix", "there"],
+    );
+    assert_eq!(
+        drop_aliases(&["pnpm", "--dir", "here", "--filter", "--prefix", "install"]),
+        ["pnpm", "--dir", "here", "--filter", "--prefix", "install"],
+    );
+}

--- a/pnpm/crates/cli/src/renamed_options/tests.rs
+++ b/pnpm/crates/cli/src/renamed_options/tests.rs
@@ -82,6 +82,16 @@ fn a_canonical_short_inside_an_attached_value_is_not_the_option() {
     );
 }
 
+/// A cluster ending in a value-taking short takes the next token as its
+/// value, so a directory that spells an alias is not read as one.
+#[test]
+fn a_cluster_s_separate_value_is_not_read_as_an_option() {
+    assert_eq!(
+        drop_aliases(&["pnpm", "-rC", "--prefix", "install"]),
+        ["pnpm", "-rC", "--prefix", "install"],
+    );
+}
+
 /// Only pnpm's own tokens are considered: a script's `--prefix` is the
 /// script's, and so is an option value that happens to spell one.
 #[test]

--- a/pnpm/crates/cli/src/renamed_options/tests.rs
+++ b/pnpm/crates/cli/src/renamed_options/tests.rs
@@ -60,6 +60,28 @@ fn the_canonical_spelling_wins_over_the_alias_in_either_order() {
     }
 }
 
+/// A canonical short option counts only where a short option can appear:
+/// the `C` inside a `--filter` pattern attached to `-F` is part of that
+/// pattern, not a `--dir`.
+#[test]
+fn a_canonical_short_inside_an_attached_value_is_not_the_option() {
+    assert_eq!(
+        drop_aliases(&["pnpm", "-FpkgC", "--prefix", "here", "install"]),
+        ["pnpm", "-FpkgC", "--prefix", "here", "install"],
+    );
+    assert_eq!(parse(&["pnpm", "-FpkgC", "--prefix", "here", "install"]).dir, Path::new("here"));
+    // Up to that point the cluster's own options are read: `-r` takes no
+    // value, so the `-C` behind it is an option and shadows the alias.
+    assert_eq!(
+        drop_aliases(&["pnpm", "-rCcanonical", "--prefix", "here", "install"]),
+        ["pnpm", "-rCcanonical", "install"],
+    );
+    assert_eq!(
+        parse(&["pnpm", "-rCcanonical", "--prefix", "here", "install"]).dir,
+        Path::new("canonical"),
+    );
+}
+
 /// Only pnpm's own tokens are considered: a script's `--prefix` is the
 /// script's, and so is an option value that happens to spell one.
 #[test]

--- a/pnpm/crates/cli/tests/run.rs
+++ b/pnpm/crates/cli/tests/run.rs
@@ -562,6 +562,42 @@ scripts:
     drop(root);
 }
 
+/// npm's `--prefix` is accepted as a spelling of `--dir`
+/// (<https://github.com/pnpm/pnpm/issues/13583>). Only the pre-subcommand
+/// position is exercised: everything after the script name is the
+/// script's own command line.
+#[test]
+fn prefix_is_accepted_as_dir() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let project = workspace.join("project");
+    fs::create_dir_all(&project).expect("create project dir");
+    let marker = workspace.join("ran.txt");
+    fs::write(
+        project.join("package.json"),
+        json!({
+            "name": "project",
+            "version": "0.0.0",
+            "scripts": {
+                "test": r#"node -e "require('fs').writeFileSync(process.env.MARKER_PATH, 'ran')""#,
+            },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    pacquet
+        .with_env("MARKER_PATH", marker.to_string_lossy().as_ref())
+        .with_arg("--prefix")
+        .with_arg(&project)
+        .with_arg("run")
+        .with_arg("test")
+        .assert()
+        .success();
+    assert_eq!(fs::read_to_string(&marker).expect("read marker"), "ran");
+
+    drop(root);
+}
+
 #[cfg(unix)]
 #[test]
 fn top_level_fallback_runs_local_bin_when_script_is_missing() {

--- a/pnpm/crates/cli/tests/run.rs
+++ b/pnpm/crates/cli/tests/run.rs
@@ -563,11 +563,11 @@ scripts:
 }
 
 /// npm's `--prefix` is accepted as a spelling of `--dir`
-/// (<https://github.com/pnpm/pnpm/issues/13583>). Only the pre-subcommand
-/// position is exercised: everything after the script name is the
-/// script's own command line.
+/// (<https://github.com/pnpm/pnpm/issues/13583>) — ahead of the
+/// subcommand, where pnpm's own options live. Past the script name the
+/// same token is the script's, so the script records what it received.
 #[test]
-fn prefix_is_accepted_as_dir() {
+fn prefix_selects_the_dir_before_the_subcommand_and_is_the_script_s_after_it() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
     let project = workspace.join("project");
     fs::create_dir_all(&project).expect("create project dir");
@@ -577,8 +577,10 @@ fn prefix_is_accepted_as_dir() {
         json!({
             "name": "project",
             "version": "0.0.0",
+            // The `--` keeps node from claiming a forwarded `--prefix` as
+            // one of its own options.
             "scripts": {
-                "test": r#"node -e "require('fs').writeFileSync(process.env.MARKER_PATH, 'ran')""#,
+                "test": r#"node -e "require('fs').writeFileSync(process.env.MARKER_PATH, process.argv.slice(1).join(' '))" --"#,
             },
         })
         .to_string(),
@@ -591,9 +593,11 @@ fn prefix_is_accepted_as_dir() {
         .with_arg(&project)
         .with_arg("run")
         .with_arg("test")
+        .with_arg("--prefix")
+        .with_arg("forwarded")
         .assert()
         .success();
-    assert_eq!(fs::read_to_string(&marker).expect("read marker"), "ran");
+    assert_eq!(fs::read_to_string(&marker).expect("read marker"), "--prefix forwarded");
 
     drop(root);
 }


### PR DESCRIPTION
## Summary

`pnpm --prefix ../ run test` failed on pnpm 12 with `error: unexpected argument '--prefix' found`. pnpm 11 rewrites `--prefix` to `--dir` and `--store` to `--store-dir` before parsing (`RENAMED_OPTIONS` in `pnpm11/pnpm/src/parseCliArgs.ts`), so npm habits and existing CI scripts keep working; pacquet had no equivalent and clap rejected the unknown long flag outright.

Two pieces:

1. **The spellings are hidden clap aliases** on the two global options, rather than a full argv-rewriting pass. The pre-clap passes (`shorthands.rs`, `flag_relocation.rs`, `parse_boundary.rs`) derive their arity tables from the clap `Command` and already fold in every alias, so `--prefix` relocates and steps over its value exactly like `--dir`. Hidden rather than `visible_alias`, so `--help` stays identical to pnpm 11's, which documents neither spelling.
2. **The canonical spelling wins when a command line uses both.** pnpm's rename loop drops the alias whenever the canonical option is also present, in either order (`--prefix foo --dir bar` and `--dir bar --prefix foo` both resolve to `bar`), while clap alone would keep the last occurrence. The new `renamed_options` pass removes the shadowed alias tokens ahead of the parse, reusing the same clap-derived arity tables, so an alias value that spells a subcommand is never mistaken for one and a script's own `--prefix` stays the script's.

Two smaller fixes ride along. The `--version` pre-scan (`SwitchInput::from_version_argv`) now reads option arity from the clap grammar instead of a hand-maintained list of value-taking options. The list did not know about `--store-dir`, so `pnpm --store-dir /s --version` took `/s` for the command name and stopped scanning — a pre-existing bug that the `--store` alias would have extended. And the clap grammar is now built once per process (`cli_args::grammar()`) instead of per caller: constructing it walks every subcommand, and the pre-parse passes each need the same view of it, so this is a net reduction in startup work versus `main`.

TypeScript-side parity: none needed — the TS CLI already supports both spellings, this is pacquet catching up.

Closes pnpm/pnpm#13583

## Squash Commit Body

```text
pnpm 11 rewrites `--prefix` to `--dir` and `--store` to `--store-dir`
before parsing argv (`RENAMED_OPTIONS` in `parseCliArgs.ts`), so npm
habits and existing CI scripts keep working. pacquet had no equivalent
and clap rejected the unknown long flag outright, breaking invocations
like `pnpm --prefix ../ run test:ci`.

Both spellings are added as clap aliases on the global options rather
than as an argv-rewriting pass: the pre-clap passes derive their arity
tables from the clap `Command` and already fold in every alias, so
`--prefix` relocates and steps over its value like `--dir` does. The
aliases are hidden so the help output stays identical to pnpm 11's,
which does not document either spelling.

pnpm additionally drops the alias when a command line spells the same
option both ways, so `--prefix foo --dir bar` and `--dir bar --prefix
foo` both resolve to `bar`. Clap keeps the last occurrence instead, so
`renamed_options` removes the shadowed alias tokens ahead of the parse,
alongside the other pre-clap passes and using the same clap-derived
arity tables.

The `--version` pre-scan reads `--dir` directly to find the project
whose pin decides the delegated version. It now honors `--prefix` there
too, and takes option arity from the clap grammar instead of a
hand-maintained list of value-taking options: the list did not know
about `--store-dir`, so `pnpm --store-dir /s --version` took `/s` for
the command name and stopped scanning.

The clap grammar is built once per process rather than per caller.
Constructing it walks every subcommand, and every pass that runs before
the parse needs the same view of it, so the boundary scan no longer
rebuilds one on each call.

Closes pnpm/pnpm#13583
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5[1m]).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--prefix` as an alias for `--dir`, supporting separate values and `--prefix=<path>`.
  * Added `--store` as an alias for `--store-dir`, including `--store=<path>`.
  * Commands such as `pnpm --prefix <directory> run <script>` now work as expected.
  * Canonical options take precedence when both forms are provided.
  * Options intended for scripts continue to be forwarded correctly.

* **Tests**
  * Added coverage for aliases before and after subcommands, including end-to-end script execution and option forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->