### PR TITLE
fix(network): fall back to bundled CA roots when the system trust store is empty

### DIFF
--- a/.changeset/install-without-system-ca-certificates.md
+++ b/.changeset/install-without-system-ca-certificates.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm install` no longer crashes on a machine whose system certificate store is empty or absent — for example a nixpkgs sandbox with `SSL_CERT_FILE` unset [#13588](https://github.com/pnpm/pnpm/issues/13588). Such a system now falls back to the Mozilla root certificates bundled into the binary, the same set Node.js ships, so both offline and online installs work again. Certificates from the system store, `NODE_EXTRA_CA_CERTS`, and the `.npmrc` `ca` / `cafile` settings keep taking precedence whenever any of them is available.

--- a/.changeset/install-without-system-ca-certificates.md
+++ b/.changeset/install-without-system-ca-certificates.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm install` no longer crashes on a machine whose system certificate store is empty or absent — for example a nixpkgs sandbox with `SSL_CERT_FILE` unset [#13588](https://github.com/pnpm/pnpm/issues/13588). Such a system now falls back to the Mozilla root certificates bundled into the binary, the same set Node.js ships, so both offline and online installs work again. Certificates from the system store, `NODE_EXTRA_CA_CERTS`, and the `.npmrc` `ca` / `cafile` settings keep taking precedence whenever any of them is available.
+`pnpm install` no longer crashes on a machine whose system certificate store is empty or absent — for example a minimal container or build sandbox that ships no CA certificates [#13588](https://github.com/pnpm/pnpm/issues/13588). Such a system now falls back to the Mozilla root certificates bundled into the binary, the same set Node.js ships, so both offline and online installs work again. Certificates from the system store, `NODE_EXTRA_CA_CERTS`, and the `.npmrc` `ca` / `cafile` settings keep taking precedence whenever any of them is available.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4645,6 +4645,7 @@ dependencies = [
  "reqwest",
  "tokio",
  "tracing",
+ "webpki-root-certs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,6 +184,7 @@ tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 tokio              = { version = "1", features = ["rt", "rt-multi-thread", "macros", "fs", "io-util", "net", "signal", "sync"] }
 url                = { version = "2.5.8" }
 walkdir            = { version = "2.5.0" }
+webpki-root-certs  = { version = "1.0.7" }
 windows-sys        = { version = "0.61", features = ["Win32_Foundation", "Win32_System_JobObjects", "Win32_System_Threading"] }
 yaml_serde         = { version = "0.10.4" }
 yamlpatch          = { version = "1.25.2" }

--- a/pnpm/crates/network/Cargo.toml
+++ b/pnpm/crates/network/Cargo.toml
@@ -11,12 +11,13 @@ license.workspace    = true
 repository.workspace = true
 
 [dependencies]
-derive_more = { workspace = true }
-miette      = { workspace = true }
-pipe-trait  = { workspace = true }
-reqwest     = { workspace = true }
-tokio       = { workspace = true, features = ["time"] }
-tracing     = { workspace = true }
+derive_more       = { workspace = true }
+miette            = { workspace = true }
+pipe-trait        = { workspace = true }
+reqwest           = { workspace = true }
+tokio             = { workspace = true, features = ["time"] }
+tracing           = { workspace = true }
+webpki-root-certs = { workspace = true }
 
 [dev-dependencies]
 mockito               = { workspace = true }

--- a/pnpm/crates/network/src/lib.rs
+++ b/pnpm/crates/network/src/lib.rs
@@ -432,9 +432,9 @@ impl ThrottledClient {
         let build_client = |effective_tls: &TlsConfig| -> Result<Client, ForInstallsError> {
             match make_builder(effective_tls, TrustRoots::Platform)?.build() {
                 Ok(client) => Ok(client),
-                Err(platform_error) => make_builder(effective_tls, TrustRoots::Bundled)?
+                Err(platform) => make_builder(effective_tls, TrustRoots::Bundled)?
                     .build()
-                    .map_err(|_| ForInstallsError::ClientBuild(platform_error)),
+                    .map_err(|bundled| ForInstallsError::ClientBuild { platform, bundled }),
             }
         };
 
@@ -872,11 +872,16 @@ pub enum ForInstallsError {
     ZeroNetworkConcurrency,
 
     /// reqwest rejected the assembled client configuration, with both
-    /// the platform trust store and the bundled Mozilla roots.
-    /// Carries the platform-verifier attempt's error — the one that
-    /// describes the environment.
-    #[display("Failed to build the HTTP client")]
-    ClientBuild(#[error(source)] reqwest::Error),
+    /// the platform trust store and the bundled Mozilla roots. The
+    /// platform attempt is the source (it is the one that describes
+    /// the environment); the retry's own failure is spelled out too,
+    /// since the two can differ.
+    #[display("Failed to build the HTTP client (retry with bundled CA roots: {bundled})")]
+    ClientBuild {
+        #[error(source)]
+        platform: reqwest::Error,
+        bundled: reqwest::Error,
+    },
 }
 
 impl From<ProxyError> for ForInstallsError {

--- a/pnpm/crates/network/src/lib.rs
+++ b/pnpm/crates/network/src/lib.rs
@@ -36,7 +36,7 @@ use std::{
     collections::HashMap,
     num::NonZeroUsize,
     ops::Deref,
-    sync::{Arc, Mutex},
+    sync::{Arc, LazyLock, Mutex},
     time::Duration,
 };
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
@@ -329,6 +329,9 @@ impl ThrottledClient {
     ///   as Node's `rejectUnauthorized=false` short-circuit.
     /// * **`local_address`.** Pinned via
     ///   `reqwest::ClientBuilder::local_address`.
+    /// * **Trust store.** The platform's, falling back to the Mozilla
+    ///   roots bundled into the binary when the platform verifier
+    ///   cannot be constructed (a system with no trust store at all).
     ///
     /// Returns [`ProxyError::InvalidProxy`] when either configured
     /// proxy URL fails to parse even after the auto-`http://` prefix
@@ -401,7 +404,9 @@ impl ThrottledClient {
         // bundle per call would re-read and re-parse it N times.
         let extra_ca_certs = load_node_extra_ca_certs();
 
-        let build_client = |effective_tls: &TlsConfig| -> Result<Client, ForInstallsError> {
+        let make_builder = |effective_tls: &TlsConfig,
+                            trust_roots: TrustRoots|
+         -> Result<reqwest::ClientBuilder, ForInstallsError> {
             let mut builder = default_client_builder(settings);
             if let Some(url) = https.clone() {
                 builder = builder.proxy(build_scheme_proxy(url, "https", Arc::clone(&no_proxy)));
@@ -415,10 +420,22 @@ impl ThrottledClient {
                 builder = builder.add_root_certificate(cert.clone());
             }
             builder = apply_tls(builder, effective_tls)?;
+            if trust_roots == TrustRoots::Bundled {
+                builder = builder.tls_certs_only(bundled_root_certs().iter().cloned());
+            }
             if let Some(guard) = redirect_guard {
                 builder = builder.redirect(allowlist_redirect_policy(Arc::clone(guard)));
             }
-            Ok(builder.build().expect("build reqwest client with default timeouts and proxy"))
+            Ok(builder)
+        };
+
+        let build_client = |effective_tls: &TlsConfig| -> Result<Client, ForInstallsError> {
+            match make_builder(effective_tls, TrustRoots::Platform)?.build() {
+                Ok(client) => Ok(client),
+                Err(platform_error) => make_builder(effective_tls, TrustRoots::Bundled)?
+                    .build()
+                    .map_err(|_| ForInstallsError::ClientBuild(platform_error)),
+            }
         };
 
         let default_client = build_client(tls)?;
@@ -648,6 +665,42 @@ fn default_client_builder(settings: &NetworkSettings) -> reqwest::ClientBuilder 
     configure_dns(builder)
 }
 
+/// Which trust anchors a client built by
+/// [`ThrottledClient::for_installs`] verifies registry certificates
+/// against.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TrustRoots {
+    /// The OS trust store, via reqwest's `rustls-platform-verifier`
+    /// backend. Picks up corporate / MITM roots an administrator
+    /// installed system-wide, which the bundled set cannot.
+    Platform,
+
+    /// The Mozilla root set compiled into the binary. Used only when
+    /// the platform verifier cannot be constructed at all — on a
+    /// machine with no system trust store, `rustls-platform-verifier`
+    /// fails the client build outright rather than degrading, and
+    /// pnpm-on-Node keeps working there because Node ships the same
+    /// bundled roots. Falling back restores that parity; it is never
+    /// preferred over the platform store, so a user who deliberately
+    /// distrusts a Mozilla root system-wide keeps that decision as
+    /// long as their store loads at all.
+    Bundled,
+}
+
+/// The Mozilla CA root set compiled into the binary, in reqwest's
+/// [`Certificate`] form. Parsed once — `for_installs` builds one
+/// client per per-registry override, and the fallback path is taken
+/// by every one of them on a system without a trust store.
+fn bundled_root_certs() -> &'static [Certificate] {
+    static CERTS: LazyLock<Vec<Certificate>> = LazyLock::new(|| {
+        webpki_root_certs::TLS_SERVER_ROOT_CERTS
+            .iter()
+            .map(|der| Certificate::from_der(der).expect("bundled Mozilla root is valid DER"))
+            .collect()
+    });
+    &CERTS
+}
+
 /// Load the PEM bundle named by `NODE_EXTRA_CA_CERTS` as extra trust
 /// roots, to be added to every client `for_installs` builds.
 ///
@@ -671,7 +724,7 @@ fn default_client_builder(settings: &NetworkSettings) -> reqwest::ClientBuilder 
 ///
 /// The resulting certs are additive and lowest-priority: layered under
 /// the `.npmrc` `ca` / `cafile` roots that [`apply_tls`] adds afterward
-/// and under the built-in webpki roots (ordering is immaterial — the
+/// and under the platform trust store (ordering is immaterial — the
 /// rustls root store is a union). A missing, unreadable, or malformed
 /// file yields an empty list, matching pnpm's silent treatment of a
 /// missing `cafile` rather than failing the client build.
@@ -817,6 +870,13 @@ pub enum ForInstallsError {
     /// fails fast rather than deadlock.
     #[display("networkConcurrency must be at least 1")]
     ZeroNetworkConcurrency,
+
+    /// reqwest rejected the assembled client configuration, with both
+    /// the platform trust store and the bundled Mozilla roots.
+    /// Carries the platform-verifier attempt's error — the one that
+    /// describes the environment.
+    #[display("Failed to build the HTTP client")]
+    ClientBuild(#[error(source)] reqwest::Error),
 }
 
 impl From<ProxyError> for ForInstallsError {

--- a/pnpm/crates/network/src/tests.rs
+++ b/pnpm/crates/network/src/tests.rs
@@ -770,6 +770,29 @@ fn for_installs_falls_back_to_bundled_roots_without_a_system_trust_store() {
     )
     .expect("bundled Mozilla roots stand in for the missing system trust store");
 
+    // A configured `ca` is itself enough to keep the platform verifier
+    // constructible, so a user with custom roots never reaches the
+    // fallback — their roots cannot be displaced by it.
+    let ca =
+        std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/test-ca.pem"))
+            .expect("read test ca fixture");
+    assert!(
+        reqwest::Client::builder()
+            .add_root_certificate(
+                reqwest::Certificate::from_pem(ca.as_bytes()).expect("parse test ca fixture")
+            )
+            .build()
+            .is_ok(),
+        "a custom CA root keeps the platform verifier constructible",
+    );
+    ThrottledClient::for_installs(
+        &ProxyConfig::default(),
+        &TlsConfig { ca: vec![ca], ..TlsConfig::default() },
+        &PerRegistryTls::default(),
+        &NetworkSettings::default(),
+    )
+    .expect("a configured ca builds without a system trust store");
+
     let _ = std::fs::remove_file(&empty_bundle);
 }
 

--- a/pnpm/crates/network/src/tests.rs
+++ b/pnpm/crates/network/src/tests.rs
@@ -739,6 +739,40 @@ fn node_extra_ca_certs_is_loaded_and_failures_are_non_fatal() {
     // `env` restores NODE_EXTRA_CA_CERTS on drop.
 }
 
+// `SSL_CERT_FILE` alone switches `rustls-native-certs` to env-only
+// loading, so pointing it at an empty file is a portable stand-in for a
+// machine whose system trust store holds nothing — the nixpkgs sandbox
+// of pnpm/pnpm#13588. Only the Linux/BSD platform verifier reads that
+// variable; the Apple and Windows ones go to the OS keychain.
+#[cfg(all(unix, not(target_vendor = "apple")))]
+#[test]
+fn for_installs_falls_back_to_bundled_roots_without_a_system_trust_store() {
+    let env = EnvGuard::snapshot(["SSL_CERT_FILE", "SSL_CERT_DIR", "NODE_EXTRA_CA_CERTS"]);
+    let empty_bundle =
+        std::env::temp_dir().join(format!("pacquet-empty-ca-{}.pem", std::process::id()));
+    std::fs::write(&empty_bundle, b"").expect("write empty ca bundle");
+    env.set("SSL_CERT_FILE", &empty_bundle);
+    env.set("SSL_CERT_DIR", &empty_bundle);
+    // An extra root of any kind keeps the platform verifier alive, so
+    // the fallback would go untested with the developer's own value.
+    env.set("NODE_EXTRA_CA_CERTS", "");
+
+    assert!(
+        reqwest::Client::builder().build().is_err(),
+        "precondition: the platform verifier must fail without a system trust store",
+    );
+
+    ThrottledClient::for_installs(
+        &ProxyConfig::default(),
+        &TlsConfig::default(),
+        &PerRegistryTls::default(),
+        &NetworkSettings::default(),
+    )
+    .expect("bundled Mozilla roots stand in for the missing system trust store");
+
+    let _ = std::fs::remove_file(&empty_bundle);
+}
+
 #[test]
 fn for_installs_local_address_pinned() {
     use std::net::Ipv4Addr;

--- a/pnpm/crates/network/src/tls.rs
+++ b/pnpm/crates/network/src/tls.rs
@@ -15,13 +15,21 @@
 //! material, silently ignores a missing `cafile`, and consults no
 //! environment variables. Pacquet mirrors each of those choices.
 //!
-//! One deliberate exception sits *outside* this struct: pacquet honors
-//! the `NODE_EXTRA_CA_CERTS` environment variable as an additional
-//! trust root (see `load_node_extra_ca_certs` in `lib.rs`). pnpm-on-
-//! Node already trusts that bundle implicitly via Node's TLS runtime,
-//! so a native port must read it explicitly to preserve real-world
-//! parity. It is applied at the client-builder layer, never folded
-//! into this `.npmrc`-only [`TlsConfig`].
+//! Two deliberate exceptions sit *outside* this struct, both applied
+//! at the client-builder layer and never folded into this
+//! `.npmrc`-only [`TlsConfig`]:
+//!
+//! * pacquet honors the `NODE_EXTRA_CA_CERTS` environment variable as
+//!   an additional trust root (see `load_node_extra_ca_certs` in
+//!   `lib.rs`). pnpm-on-Node already trusts that bundle implicitly via
+//!   Node's TLS runtime, so a native port must read it explicitly to
+//!   preserve real-world parity.
+//! * The default trust store is the platform's, but pacquet falls back
+//!   to the Mozilla roots bundled into the binary when the platform
+//!   verifier cannot be built at all (see `TrustRoots` in `lib.rs`).
+//!   Node ships those same roots, so the fallback keeps installs
+//!   working on a machine with no system trust store, exactly as
+//!   pnpm-on-Node does.
 
 use crate::auth::nerf_dart;
 use std::{collections::HashMap, net::IpAddr};


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#13588.

On a machine whose system trust store is empty or absent (a nixpkgs sandbox, a scratch container, `SSL_CERT_FILE=`), `pnpm install` died with a panic before doing any work:

```
Error:   × Main thread panicked.
  ├─▶ at pnpm/crates/network/src/lib.rs:421:32
  ╰─▶ build reqwest client with default timeouts and proxy: reqwest::Error { kind: Builder, source: General("No CA certificates were loaded from the system") }
```

reqwest's `rustls-platform-verifier` backend fails `ClientBuilder::build()` outright when the platform store yields nothing, and the install client turned that into a panic through `.expect(...)`. Every install on such a machine failed — `--offline` included, even though nothing is fetched — whereas pnpm 11 works there because Node ships its own bundled Mozilla root store.

The fix keeps the platform verifier as the primary trust source and falls back to the Mozilla roots bundled via `webpki-root-certs` **only** when a client cannot be built with the platform verifier at all. That restores pnpm-11/Node parity for both offline and online installs on a certless system, and changes nothing for anyone whose system store loads: a root deliberately distrusted system-wide stays distrusted, and system / `NODE_EXTRA_CA_CERTS` / `.npmrc` `ca`+`cafile` roots keep taking precedence. A build failure for any other reason now surfaces as `ForInstallsError::ClientBuild` instead of a panic, carrying both the platform attempt's error (as the diagnostic source, since it describes the environment) and the bundled-roots retry's own error.

`webpki-root-certs` was already in `Cargo.lock` as a transitive dependency of `rustls-platform-verifier`, and its `CDLA-Permissive-2.0` license is already allowed in `deny.toml`; the dependency was approved for promotion to `[workspace.dependencies]`.

**Parity:** pacquet-only. The TypeScript CLI is unaffected — Node's bundled root store is exactly why pnpm 11 works on these systems — so this change *restores* parity rather than diverging, and needs no TypeScript counterpart.

Verified end-to-end with the issue's repro (a debug `pnpm` binary, `SSL_CERT_FILE= SSL_CERT_DIR=`): the offline install now completes, and so does a fresh online install against `registry.npmjs.org` over HTTPS. A regression test points `SSL_CERT_FILE` at an empty bundle (which switches `rustls-native-certs` to env-only loading), asserts a plain reqwest client build fails in that environment, and asserts `for_installs` still succeeds. It also pins that a configured `ca` keeps the platform verifier constructible — a user with custom roots never reaches the fallback.

Not addressed here: `PnprClient::new` (the opt-in `pnprServer` path) uses `reqwest::Client::new()`, which panics the same way. It is a separate, non-default code path and its constructor is infallible today, so converting it is left as a follow-up.

## Squash Commit Body

```text
reqwest's `rustls-platform-verifier` backend hard-errors with
"No CA certificates were loaded from the system" when the platform
store yields nothing, and the install client turned that into a
`Main thread panicked` through an `.expect` on `ClientBuilder::build`.
Any install on such a machine — a nixpkgs sandbox, a scratch
container — died, offline installs included, even though pnpm 11 works
there because Node ships its own Mozilla root store.

Keep the platform verifier as the primary trust source and fall back to
the Mozilla roots bundled via `webpki-root-certs` only when the client
cannot be built with it at all. A user who deliberately distrusts a root
system-wide keeps that decision as long as their store loads, and a
build failure for any other reason now surfaces as
`ForInstallsError::ClientBuild` — carrying both that error and the
retry's own — instead of a panic.

pacquet-only: the TypeScript CLI is unaffected, since Node's bundled
root store is what makes pnpm 11 work on these systems.

Closes pnpm/pnpm#13588
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `pnpm install` now succeeds when the system certificate store is unavailable by using bundled Mozilla root certificates.
  * Existing system certificates, `NODE_EXTRA_CA_CERTS`, and npm certificate settings retain priority.
  * Improved error reporting when secure network connections cannot be established.

* **Documentation**
  * Updated TLS documentation to explain certificate fallback and additional certificate authority handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->