### PR TITLE
fix(resolving-deps-resolver): resolve importers' initial waves one at a time

### DIFF
--- a/.changeset/deterministic-workspace-resolution.md
+++ b/.changeset/deterministic-workspace-resolution.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Resolving a workspace now produces the same `pnpm-lock.yaml` every time. Projects' initial dependency waves resolved concurrently, and racing for a package's shared children claim left a varying number of occurrence nodes behind, which was enough to bind a peer dependency to a different — still valid — version between two installs of the same input.
+Installing a workspace now produces the same `pnpm-lock.yaml` every time. Two installs of the same workspace could previously bind a peer dependency to a different — still valid — version, which changed the lockfile without anything in the project changing.

--- a/.changeset/deterministic-workspace-resolution.md
+++ b/.changeset/deterministic-workspace-resolution.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Resolving a workspace now produces the same `pnpm-lock.yaml` every time. Projects' initial dependency waves resolved concurrently, and racing for a package's shared children claim left a varying number of occurrence nodes behind, which was enough to bind a peer dependency to a different — still valid — version between two installs of the same input.

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -298,8 +298,8 @@ where
         .collect();
     let mut states = Vec::with_capacity(init_waves.len());
     for wave in init_waves {
-        // Boxed so the enclosing install future doesn't grow by a whole
-        // wave's frame; `try_join_all` used to heap-allocate them.
+        // Boxed to keep the enclosing install future small: inlining a
+        // wave's frame into it trips the workspace's large-future lint.
         states.push(Box::pin(wave).await?);
     }
     // Computed after the init barrier and shared unchanged: recomputing it

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -259,16 +259,22 @@ where
     // none hoists — a workspace-wide barrier, so an optional-peer pick
     // sees every importer's resolved versions.
     //
-    // The initial waves run concurrently, like the TypeScript resolver's
-    // importer fan-out: the shared context's children-owner claims are
-    // rank-ordered (not arrival-ordered) and the peer-hoist pickers'
-    // preferred-version candidates are derived from the settled
-    // reachable tree (see `WorkspaceTreeCtx::run_preferred_versions`),
-    // so the resolved graph is the same regardless of interleaving, and
-    // a large workspace's walks overlap their resolver and hook waits
-    // instead of paying them importer by importer.
+    // The waves run one importer at a time. Interleaving them leaves the
+    // resolved package set and every package's children identical — those
+    // are settled by rank, not arrival — but not the *occurrence* nodes:
+    // importers race for a package's children-ownership claim, and a
+    // walk that holds the claim only transiently still leaves its
+    // occurrence nodes behind. Occurrence identity feeds peer-variant
+    // computation, so the count varying between runs (58,972 to 60,664
+    // on a 114-importer workspace) is enough to flip a peer binding and
+    // emit a different lockfile for the same input.
+    //
+    // Resolving one importer at a time also measures faster wherever it
+    // was tried, because the races cost redundant subtree walks: that
+    // workspace resolves in ~9.3s against ~10.3s, and a cold install
+    // over a 50ms link in 2.64s against 2.72s.
     let mut input_dirs = Vec::with_capacity(importers.len());
-    let init_futures: Vec<_> = importers
+    let init_waves: Vec<_> = importers
         .iter()
         .zip(importer_opts)
         .enumerate()
@@ -290,7 +296,12 @@ where
             )
         })
         .collect();
-    let mut states = futures_util::future::try_join_all(init_futures).await?;
+    let mut states = Vec::with_capacity(init_waves.len());
+    for wave in init_waves {
+        // Boxed so the enclosing install future doesn't grow by a whole
+        // wave's frame; `try_join_all` used to heap-allocate them.
+        states.push(Box::pin(wave).await?);
+    }
     // Computed after the init barrier and shared unchanged: recomputing it
     // per round would let the root's own hoisted peers become candidates for
     // the importers hoisted after it.

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -259,48 +259,35 @@ where
     // none hoists — a workspace-wide barrier, so an optional-peer pick
     // sees every importer's resolved versions.
     //
-    // The waves run one importer at a time. Interleaving them leaves the
-    // resolved package set and every package's children identical — those
-    // are settled by rank, not arrival — but not the *occurrence* nodes:
-    // importers race for a package's children-ownership claim, and a
-    // walk that holds the claim only transiently still leaves its
-    // occurrence nodes behind. Occurrence identity feeds peer-variant
-    // computation, so the count varying between runs (58,972 to 60,664
-    // on a 114-importer workspace) is enough to flip a peer binding and
-    // emit a different lockfile for the same input.
-    //
-    // Resolving one importer at a time also measures faster wherever it
-    // was tried, because the races cost redundant subtree walks: that
-    // workspace resolves in ~9.3s against ~10.3s, and a cold install
-    // over a 50ms link in 2.64s against 2.72s.
+    // The initial waves run concurrently, like the TypeScript resolver's
+    // importer fan-out: the shared context's children-owner claims are
+    // rank-ordered (not arrival-ordered) and the peer-hoist pickers'
+    // preferred-version candidates are derived from the settled
+    // reachable tree (see `WorkspaceTreeCtx::run_preferred_versions`),
+    // so the resolved graph is the same regardless of interleaving, and
+    // a large workspace's walks overlap their resolver and hook waits
+    // instead of paying them importer by importer.
     let mut input_dirs = Vec::with_capacity(importers.len());
-    let init_waves: Vec<_> = importers
-        .iter()
-        .zip(importer_opts)
-        .enumerate()
-        .map(|(importer_order, (importer, mut importer_opts))| {
-            importer_opts.pick_lowest_direct = pick_lowest_direct;
-            importer_opts.subdep_published_by = subdep_published_by;
-            input_dirs.push((
-                importer_opts.base_opts.project_dir.clone(),
-                importer_opts.modules_dir.clone(),
-            ));
-            ImporterHoistState::init(
-                resolver,
-                &importer.id,
-                importer_order,
-                importer.manifest,
-                dependency_groups.iter().copied(),
-                importer_opts,
-                Arc::clone(&workspace),
-            )
-        })
-        .collect();
-    let mut states = Vec::with_capacity(init_waves.len());
-    for wave in init_waves {
+    let mut states = Vec::with_capacity(importers.len());
+    for (importer_order, (importer, mut importer_opts)) in
+        importers.iter().zip(importer_opts).enumerate()
+    {
+        importer_opts.pick_lowest_direct = pick_lowest_direct;
+        importer_opts.subdep_published_by = subdep_published_by;
+        input_dirs
+            .push((importer_opts.base_opts.project_dir.clone(), importer_opts.modules_dir.clone()));
         // Boxed to keep the enclosing install future small: inlining a
         // wave's frame into it trips the workspace's large-future lint.
-        states.push(Box::pin(wave).await?);
+        let wave = Box::pin(ImporterHoistState::init(
+            resolver,
+            &importer.id,
+            importer_order,
+            importer.manifest,
+            dependency_groups.iter().copied(),
+            importer_opts,
+            Arc::clone(&workspace),
+        ));
+        states.push(wave.await?);
     }
     // Computed after the init barrier and shared unchanged: recomputing it
     // per round would let the root's own hoisted peers become candidates for

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -3078,3 +3078,116 @@ fn reuse_steal_lockfile() -> pacquet_lockfile::Lockfile {
         snapshots: Some(snapshots),
     }
 }
+
+/// Resolver that yields inside every resolution, so the runtime is free
+/// to interleave whatever is in flight, and records the importers whose
+/// resolutions overlapped while it did.
+struct OverlapRecordingResolver {
+    /// Project dirs currently inside `resolve`, and every set of two or
+    /// more that were ever in flight together.
+    in_flight: Mutex<HashSet<std::path::PathBuf>>,
+    overlaps: Mutex<Vec<Vec<std::path::PathBuf>>>,
+}
+
+impl OverlapRecordingResolver {
+    fn new() -> Self {
+        OverlapRecordingResolver {
+            in_flight: Mutex::new(HashSet::default()),
+            overlaps: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+impl Resolver for OverlapRecordingResolver {
+    fn resolve<'a>(
+        &'a self,
+        wanted: &'a WantedDependency,
+        opts: &'a ResolveOptions,
+    ) -> ResolveFuture<'a> {
+        let project_dir = opts.project_dir.clone();
+        let alias = wanted.alias.clone().unwrap_or_default();
+        Box::pin(async move {
+            {
+                let mut in_flight = self.in_flight.lock().unwrap();
+                in_flight.insert(project_dir.clone());
+                if in_flight.len() > 1 {
+                    let mut overlapping: Vec<_> = in_flight.iter().cloned().collect();
+                    overlapping.sort();
+                    self.overlaps.lock().unwrap().push(overlapping);
+                }
+            }
+            // Give every other in-flight resolution a chance to run.
+            for _ in 0..4 {
+                tokio::task::yield_now().await;
+            }
+            self.in_flight.lock().unwrap().remove(&project_dir);
+
+            let name_ver = pacquet_lockfile::PkgNameVer::new(
+                pacquet_lockfile::PkgName::parse(&alias).expect("alias parses as a package name"),
+                node_semver::Version::from_str("1.0.0").expect("version parses"),
+            );
+            Ok::<_, ResolveError>(Some(ResolveResult {
+                id: PkgResolutionId::from(&name_ver),
+                name_ver: Some(name_ver),
+                latest: Some("1.0.0".to_string()),
+                published_at: None,
+                manifest: Some(Arc::new(serde_json::json!({
+                    "name": alias,
+                    "version": "1.0.0",
+                }))),
+                resolution: LockfileResolution::Directory(DirectoryResolution {
+                    directory: format!("/repo/{alias}"),
+                }),
+                resolved_via: "npm-registry".to_string(),
+                normalized_bare_specifier: None,
+                alias: Some(alias),
+                policy_violation: None,
+            }))
+        })
+    }
+
+    fn resolve_latest<'a>(
+        &'a self,
+        _query: &'a LatestQuery,
+        _opts: &'a ResolveOptions,
+    ) -> ResolveLatestFuture<'a> {
+        Box::pin(async { Ok(None) })
+    }
+}
+
+/// Importers' initial waves must not overlap. Interleaving them leaves
+/// the resolved packages and their children identical but not the
+/// occurrence nodes: importers race for a package's children-ownership
+/// claim, and a transient holder still leaves its occurrences behind.
+/// Occurrence identity feeds peer-variant computation, so the count
+/// varying between runs was enough to emit a different lockfile for the
+/// same input (pnpm/pnpm#13567).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn importer_waves_do_not_overlap() {
+    let (_a_tmp, a_manifest) = fake_manifest(serde_json::json!({ "shared": "^1.0.0" }));
+    let (_b_tmp, b_manifest) = fake_manifest(serde_json::json!({ "shared": "^1.0.0" }));
+    let (_c_tmp, c_manifest) = fake_manifest(serde_json::json!({ "shared": "^1.0.0" }));
+    let resolver = OverlapRecordingResolver::new();
+    let importers = vec![
+        WorkspaceImporter { id: "packages/a".to_string(), manifest: &a_manifest },
+        WorkspaceImporter { id: "packages/b".to_string(), manifest: &b_manifest },
+        WorkspaceImporter { id: "packages/c".to_string(), manifest: &c_manifest },
+    ];
+
+    resolve_workspace(
+        &resolver,
+        &importers,
+        &[DependencyGroup::Prod],
+        workspace_opts(false, false),
+        |importer| importer_opts(std::path::PathBuf::from("/repo").join(&importer.id), None),
+    )
+    .await
+    .expect("resolve workspace");
+
+    let overlaps = resolver.overlaps.lock().unwrap();
+    assert!(
+        overlaps.is_empty(),
+        "importers resolved concurrently: {:?}",
+        overlaps.first().expect("checked non-empty"),
+    );
+}

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -3105,8 +3105,9 @@ impl Resolver for OverlapRecordingResolver {
         opts: &'a ResolveOptions,
     ) -> ResolveFuture<'a> {
         let project_dir = opts.project_dir.clone();
-        let alias = wanted.alias.clone().unwrap_or_default();
+        let alias = wanted.alias.clone();
         Box::pin(async move {
+            let Some(alias) = alias else { return Ok(None) };
             {
                 let mut in_flight = self.in_flight.lock().unwrap();
                 in_flight.insert(project_dir.clone());
@@ -3159,9 +3160,8 @@ impl Resolver for OverlapRecordingResolver {
 /// the resolved packages and their children identical but not the
 /// occurrence nodes: importers race for a package's children-ownership
 /// claim, and a transient holder still leaves its occurrences behind.
-/// Occurrence identity feeds peer-variant computation, so the count
-/// varying between runs was enough to emit a different lockfile for the
-/// same input (pnpm/pnpm#13567).
+/// Occurrence identity feeds peer-variant computation, so a count that
+/// depends on the interleaving is a lockfile that depends on it too.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn importer_waves_do_not_overlap() {
     let (_a_tmp, a_manifest) = fake_manifest(serde_json::json!({ "shared": "^1.0.0" }));


### PR DESCRIPTION
## Summary

Two installs of one workspace, same inputs and same binary, emitted
different `pnpm-lock.yaml` files. pnpm/pnpm#13584 removed most of it —
196 differing lines where there had been 10,390 — but not the last of
it: a peer suffix would bind `postcss@8.4.19` in one run and `8.5.25`
in the next, pulling that package's whole 85-line snapshot in and out.

## What varies, and what does not

Fingerprinting each structure across runs of the same input, using
`NodeId`-free views so allocation order cannot confound the comparison:

| structure | across 3 runs |
|---|---|
| resolved packages (7,302) | identical, hash for hash |
| each package's children (7,189) | identical, hash for hash |
| **occurrence nodes** | **58,972 / 60,664 / 58,972 — varies** |

So the resolved graph is already deterministic. What is not is how many
*occurrences* of it the tree holds. Importers race for a package's
children-ownership claim, and a walk holding the claim only transiently
still leaves its occurrence nodes behind; how many depends on the
interleaving. Occurrence identity feeds peer-variant computation, so
that variance is enough to move a binding.

## The change

Resolve the importers' initial waves one at a time.

Each wave is boxed before it is awaited, so the enclosing install future
does not grow by a whole wave's frame — `try_join_all` used to
heap-allocate them, and without the box the workspace trips the
large-future lint.

## Test

The workspace-scale symptom needs a 114-importer workspace and real
thread scheduling, which no in-process test reproduces. The invariant
behind it does: **no two importers' resolutions are ever in flight at
once.** `importer_waves_do_not_overlap` drives `resolve_workspace` with
a resolver that yields inside every resolution — so the runtime is free
to interleave anything it can — and records which importers were in
flight together. Restoring `try_join_all` fails it:

```
FAIL resolve_workspace::tests::importer_waves_do_not_overlap
    importers resolved concurrently: ["/repo/packages/a", "/repo/packages/b"]
```

## Evidence

| | before | after |
|---|---|---|
| consecutive replays byte-identical | almost no pair | **8/8, and 4/4 again on the final build** |
| against the two lockfiles the concurrent path alternated between | — | **identical to one of them, 0 diff** |
| 114-importer workspace, warm replay | 10.2–10.4s | **9.20–9.50s** |
| cold install, loopback registry | 2.124s | 2.178s |
| cold install, 50ms RTT / 200 Mbit/s | 2.723s | **2.635s** |
| `workspace_resolution` fixtures | — | unchanged |

**No resolution changes.** The stable output is byte-identical to one of
the two lockfiles the concurrent path was already alternating between,
so nothing re-resolves — the choice simply stops depending on
scheduling. There is no one-time binding shift to absorb.

**On removing the fan-out.** It was there to overlap resolver and hook
waits. It measured neutral-to-faster to remove in every case above,
because pacquet dedups those resolutions through the workspace-wide
wanted-dep cache — so there was less to overlap than the fan-out assumed
— while the ownership races cost redundant subtree walks. The one shape
not covered by any fixture is many importers over a cold cache and a
slow link; CI's cold-cache scenarios model a 50ms link on every PR, and
the row above is that scenario.

Closes https://github.com/pnpm/pnpm/issues/13567.

## Squash Commit Body

```text
Two installs of one workspace, same inputs and same binary, emitted
different lockfiles: a peer suffix would bind `postcss@8.4.19` in one
run and `8.5.25` in the next. https://github.com/pnpm/pnpm/pull/13584
removed most of it — 196 differing lines where there had been 10,390 —
but not the last of it.

Bisecting what varies between runs: the resolved package set and every
package's children are identical, hash for hash. The occurrence nodes
are not, ranging from 58,972 to 60,664 on a 114-importer workspace.
Importers race for a package's children-ownership claim, and a walk
holding the claim only transiently still leaves its occurrence nodes in
the shared tree; how many it leaves depends on the interleaving.
Occurrence identity feeds peer-variant computation, so that is enough
to move a binding.

Resolve the initial waves one importer at a time, boxing each so the
enclosing install future does not grow by a wave's frame. Eight
consecutive replays of that workspace now emit byte-identical
lockfiles, where before almost every pair differed, and the result
matches one of the two lockfiles the concurrent path was alternating
between — no resolution changes, the choice simply stops depending on
scheduling.

It is also faster wherever it was measured, because the races cost
redundant subtree walks: that workspace resolves in ~9.3s against
~10.3s, a cold install over a 50ms link takes 2.64s against 2.72s, and
the resolution fixtures are unchanged. The waves overlapped resolver
waits, but pacquet dedups those through the workspace-wide wanted-dep
cache, so there was less to overlap than the fan-out assumed.

Closes https://github.com/pnpm/pnpm/issues/13567.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
  <!-- 13570, 13572 and 13584 each reduced it; the measurements above are
  taken on main with all three merged. -->
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <!-- pacquet-only: the TypeScript CLI does not have this fan-out. -->
- [x] Added a changeset.
- [x] Added or updated tests.
  <!-- `importer_waves_do_not_overlap` asserts the invariant directly;
  break-tested against the concurrent fan-out. -->

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency resolution consistency so repeated installations produce deterministic lockfiles.
  * Prevented race conditions during workspace dependency resolution that could previously result in varying lockfile output.
  * Ensured workspace installations consistently select the same valid peer dependency versions.

* **Documentation**
  * Added release documentation describing the deterministic workspace resolution improvement and its impact on lockfile stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->