### PR TITLE
fix(tarball): size extraction fan-out by CPU quota, not host core count

### DIFF
--- a/.changeset/tarball-extraction-respects-cpu-quota.md
+++ b/.changeset/tarball-extraction-respects-cpu-quota.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Tarball extraction concurrency now respects the container's CPU quota instead of the host's core count. In a CPU-limited container — a CI runner, a Docker `--cpus` limit — pnpm sized the concurrent-decompression cap and the CAS-write thread pool for every core on the machine, not the few it was allowed to use. Each concurrent decompression holds the tarball and its inflate output in memory, so on a small-memory runner installs could be killed by the OOM killer.

--- a/.changeset/tarball-extraction-respects-cpu-quota.md
+++ b/.changeset/tarball-extraction-respects-cpu-quota.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Tarball extraction concurrency now respects the container's CPU quota instead of the host's core count. In a CPU-limited container — a CI runner, a Docker `--cpus` limit — pnpm sized the concurrent-decompression cap and the CAS-write thread pool for every core on the machine, not the few it was allowed to use. Each concurrent decompression holds the tarball and its inflate output in memory, so on a small-memory runner installs could be killed by the OOM killer.
+Tarball extraction concurrency now respects the container's CPU quota instead of the host's core count. In a CPU-limited container — a CI runner, a Docker `--cpus` limit — pnpm sized the concurrent-decompression cap and the CAS-write thread pool for every core on the machine rather than the few it was allowed to use, adding scheduler contention and holding more decompression buffers in memory than the container had cores to work through.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3672,16 +3672,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "num_enum"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5161,7 +5151,6 @@ dependencies = [
  "futures-util",
  "miette 7.6.0",
  "mockito",
- "num_cpus",
  "pacquet-diagnostics",
  "pacquet-fs",
  "pacquet-network",

--- a/pnpm/crates/tarball/Cargo.toml
+++ b/pnpm/crates/tarball/Cargo.toml
@@ -22,7 +22,6 @@ dashmap      = { workspace = true }
 derive_more  = { workspace = true }
 futures-util = { workspace = true }
 miette       = { workspace = true }
-num_cpus     = { workspace = true }
 pipe-trait   = { workspace = true }
 rayon        = { workspace = true }
 reqwest      = { workspace = true }

--- a/pnpm/crates/tarball/src/lib.rs
+++ b/pnpm/crates/tarball/src/lib.rs
@@ -51,15 +51,31 @@ const MAX_UNTRUSTED_PREALLOC_BYTES: usize = 64 * 1024 * 1024;
 /// fires hundreds of these at once on a 1352-snapshot install, which
 /// thrashes small CI runners. Past "Download completed" a 2-CPU GitHub
 /// Actions runner wedged between decompress-close and `Checksum verified`
-/// on [#269] until the step timeout. `num_cpus * 2` (floor 4) keeps enough
-/// work in flight to overlap per-file FS writes with SHA on another task
-/// without oversubscribing the cores.
+/// on [#269] until the step timeout. `parallelism * 2` (floor 4) keeps
+/// enough work in flight to overlap per-file FS writes with SHA on another
+/// task without oversubscribing the cores.
+///
+/// Each permit holds the buffered tarball plus its inflate output in RAM
+/// (the eager reservation alone reaches [`MAX_UNTRUSTED_PREALLOC_BYTES`]),
+/// so this cap is a memory bound as much as a CPU one. That is why it is
+/// derived from [`std::thread::available_parallelism`] rather than
+/// `num_cpus::get()`: `num_cpus` reports the host's logical CPU count and
+/// ignores cgroup CPU quotas, so a 2-CPU container on a 36-core host would
+/// size the fan-out — and the peak RSS — for 36 cores it will never get
+/// scheduled onto, and get OOM-killed for it. Matches the convention
+/// `crates/cli` and `crates/network` already use.
 ///
 /// [#269]: https://github.com/pnpm/pacquet/pull/269
 fn post_download_semaphore() -> &'static Semaphore {
     static SEM: LazyLock<Semaphore> =
-        LazyLock::new(|| Semaphore::new(num_cpus::get().saturating_mul(2).max(4)));
+        LazyLock::new(|| Semaphore::new(cpu_parallelism().saturating_mul(2).max(4)));
     &SEM
+}
+
+/// Logical CPUs this process may actually be scheduled onto, honouring
+/// cgroup / CPU-quota limits in containers and CI runners.
+fn cpu_parallelism() -> usize {
+    std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get)
 }
 
 /// Dedicated rayon pool for the per-file CAS-write phase of extraction
@@ -77,12 +93,15 @@ fn post_download_semaphore() -> &'static Semaphore {
 ///
 /// Sized to the core count: the work is CPU-bound (SHA-512 + CAFS
 /// write), so more threads than cores only adds scheduling contention.
+/// The count comes from [`cpu_parallelism`], so a CPU-quota-limited
+/// container gets threads for the cores it can actually use rather than
+/// for the host's full core count.
 /// Returns `None` if the pool can't be built, in which case the caller
 /// falls back to the global pool.
 fn cas_write_pool() -> Option<&'static rayon::ThreadPool> {
     static POOL: LazyLock<Option<rayon::ThreadPool>> = LazyLock::new(|| {
         rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get().max(1))
+            .num_threads(cpu_parallelism())
             .thread_name(|index| format!("cas-write-{index}"))
             .build()
             .map_err(|error| {
@@ -2004,7 +2023,7 @@ async fn fetch_and_extract_once<Reporter: self::Reporter>(
     // flate2 decompresses faster than the network delivers, so
     // buffered-but-not-yet-decompressing tarballs stay close to zero.
     // Gating body buffering with `post_download_semaphore` (the
-    // smaller `num_cpus * 2` cap) instead would pin `network_concurrency`
+    // smaller `parallelism * 2` cap) instead would pin `network_concurrency`
     // permits waiting for it and collapse fetch concurrency down to
     // `post_download` — that's the regression `perf(tarball)` (a43ca32)
     // fixed; don't reintroduce it.


### PR DESCRIPTION
## Summary

`pnpm/crates/tarball` is the last place in the Rust port still deriving concurrency from `num_cpus::get()`. `crates/cli` (rayon global pool) and `crates/network` (`default_network_concurrency`) both moved to `std::thread::available_parallelism()` because `num_cpus` ignores cgroup CPU quotas and reports the host's logical CPU count; their doc comments spell out the reasoning. This brings the last holdout in line.

Measured under a cgroup with `CPUQuota=200%` on a 32-core host — i.e. what a 2-vCPU CI container looks like:

| | `num_cpus::get()` | `available_parallelism()` |
|---|---|---|
| reported CPUs | 32 | 2 |
| `post_download_semaphore` permits | 64 | 4 |
| `cas_write_pool` threads | 32 | 2 |

So a 2-CPU container sized its decompression fan-out and CAS-write pool for 32 cores it will never be scheduled onto. Each `post_download_semaphore` permit also holds a buffered tarball plus its inflate output, with an eager reservation up to `MAX_UNTRUSTED_PREALLOC_BYTES` (64 MiB), so the over-sizing costs memory as well as scheduler contention.

Also drops the now-unused `num_cpus` dependency from the crate.

### Scope — what this does NOT fix

I originally wrote this PR believing it explained OOM kills in a downstream project's CI (Bit, 2-CPU / 4 GB CircleCI containers). **I measured it, and it does not.** Correcting that here so nobody inherits the wrong claim:

A/B of this patch against its exact parent commit, same engine build otherwise, 5 alternating pairs of a real install-heavy e2e under `CPUQuota=200% MemoryMax=4G MemorySwapMax=0`:

| | runs | OOM kills | mean peak anon RSS |
|---|---|---|---|
| control (`num_cpus`) | 5 | 0 | 3458 MB |
| patched (`available_parallelism`) | 5 | 0 | 3466 MB |

No effect — the patched arm is 8 MB higher, i.e. noise. Per-process profiling showed that workload's peak was its own toolchain (a 2.2 GB Node process plus an 843 MB `tsc` child), with no tarball fan-out at the peak at all.

So this is a **latent-consistency fix**, not a fix for any observed OOM. It matters where extraction genuinely is the peak — a large cold install in a small CPU-quota-limited container — and it removes a real inconsistency with the convention the other two crates already follow. Judge it on that, not on a memory-bug story.

Related, and deliberately left alone: `default_network_concurrency()` clamps to a floor of 64 that a CPU quota does not lower, and each of those permits also buffers a full tarball body in RAM. That floor is intentional (downloads are I/O-bound), but it means extraction memory still is not proportional to a small container's budget. Separate call, separate PR if wanted.

## Squash Commit Body

```text
`crates/tarball` was the last place still deriving concurrency from
`num_cpus::get()`; `crates/cli` and `crates/network` had already moved to
`std::thread::available_parallelism()` because `num_cpus` ignores cgroup
CPU quotas and reports the host's logical CPU count.

On a 2-CPU container scheduled on a 32-core host, `num_cpus::get()`
returns 32, so `post_download_semaphore` admitted 64 concurrent
decompressions and the CAS-write rayon pool spawned 32 threads. With the
quota respected the same container admits 4 and 2. Each semaphore permit
also holds a buffered tarball plus its inflate output (eager reservation
up to MAX_UNTRUSTED_PREALLOC_BYTES, 64 MiB), so the over-sizing cost
memory as well as scheduler contention.

This is a consistency fix, not a fix for a measured OOM: an A/B against
the parent commit on a 4 GB / 2-CPU install-heavy workload showed no
difference in peak anon RSS (3458 MB vs 3466 MB over 5 pairs, no OOM
kills in either arm).

Also drops the now-unused `num_cpus` dependency from the crate.
```

## Checklist

- [x] The change is implemented in the Rust `pnpm/` port. The TypeScript CLI has no equivalent code path — its extraction concurrency is governed by `networkConcurrency`, not a core-count-derived semaphore.
- [x] Added a changeset.
- [ ] Added or updated tests. No test added: both values are process-global `LazyLock` statics read once per process, so asserting on them from the crate's test binary would pin whatever the test host reports rather than exercise the quota path. The behaviour is a thread/semaphore sizing decision with no observable output to assert on.
- [x] `cargo fmt`, `cargo clippy -p pacquet-tarball --all-targets` clean; 83/83 `pacquet-tarball` tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tarball extraction now respects container and CI CPU limits when managing concurrent decompression and storage operations.
  * Reduced memory usage and risk of out-of-memory failures on CPU-limited runners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->