### PR TITLE
fix(security): contain the rebuild pkg root against a traversal depPath name

### DIFF
--- a/.changeset/rebuild-depath-name-traversal.md
+++ b/.changeset/rebuild-depath-name-traversal.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/building.after-install": patch
+"pnpm": patch
+---
+
+Security: `pnpm rebuild` now refuses a lockfile whose `packages` key carries a path traversal in the package name (e.g. `../../../escaped@1.0.0`), instead of running that package's lifecycle scripts and linking its bins in a directory outside the virtual store. Such a name is rejected with `ERR_PNPM_INVALID_DEPENDENCY_NAME`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1627,6 +1627,9 @@ importers:
       '@pnpm/exec.lifecycle':
         specifier: workspace:*
         version: link:../../exec/lifecycle
+      '@pnpm/fs.symlink-dependency':
+        specifier: workspace:*
+        version: link:../../fs/symlink-dependency
       '@pnpm/installing.context':
         specifier: workspace:*
         version: link:../../installing/context

--- a/pnpm11/building/after-install/package.json
+++ b/pnpm11/building/after-install/package.json
@@ -43,6 +43,7 @@
     "@pnpm/deps.path": "workspace:*",
     "@pnpm/error": "workspace:*",
     "@pnpm/exec.lifecycle": "workspace:*",
+    "@pnpm/fs.symlink-dependency": "workspace:*",
     "@pnpm/installing.context": "workspace:*",
     "@pnpm/installing.modules-yaml": "workspace:*",
     "@pnpm/lockfile.types": "workspace:*",

--- a/pnpm11/building/after-install/src/index.ts
+++ b/pnpm11/building/after-install/src/index.ts
@@ -19,6 +19,7 @@ import {
   runLifecycleHooksConcurrently,
   runPostinstallHooks,
 } from '@pnpm/exec.lifecycle'
+import { safeJoinModulesDir } from '@pnpm/fs.symlink-dependency'
 import { getContext, type PnpmContext } from '@pnpm/installing.context'
 import { writeModulesManifest } from '@pnpm/installing.modules-yaml'
 import type { TarballResolution } from '@pnpm/lockfile.types'
@@ -402,7 +403,9 @@ async function _rebuild (
       const pkgInfo = nameVerFromPkgSnapshot(depPath, pkgSnapshot)
       const pkgRoots = opts.nodeLinker === 'hoisted'
         ? (ctx.modulesFile?.hoistedLocations?.[depPath] ?? []).map((hoistedLocation) => path.join(opts.lockfileDir, hoistedLocation))
-        : [path.join(pkgModulesDir(depPath), pkgInfo.name)]
+        // `pkgInfo.name` comes from the depPath key of the lockfile in
+        // `node_modules` via `dp.parse`, which validates nothing (GHSA-c59q-g84q-2gj5).
+        : [safeJoinModulesDir(pkgModulesDir(depPath), pkgInfo.name)]
       if (pkgRoots.length === 0) {
         if (pkgSnapshot.optional) return
         throw new PnpmError('MISSING_HOISTED_LOCATIONS', `${depPath} is not found in hoistedLocations inside node_modules/.modules.yaml`, {
@@ -545,7 +548,7 @@ async function _rebuild (
           const pkgSnapshot = pkgSnapshots[depPath]
           const pkgInfo = nameVerFromPkgSnapshot(depPath, pkgSnapshot)
           const modules = pkgModulesDir(depPath)
-          const binPath = path.join(modules, pkgInfo.name, 'node_modules', '.bin')
+          const binPath = path.join(safeJoinModulesDir(modules, pkgInfo.name), 'node_modules', '.bin')
           return linkBins(modules, binPath, { warn })
         }))
     )

--- a/pnpm11/building/after-install/tsconfig.json
+++ b/pnpm11/building/after-install/tsconfig.json
@@ -43,6 +43,9 @@
       "path": "../../exec/lifecycle"
     },
     {
+      "path": "../../fs/symlink-dependency"
+    },
+    {
       "path": "../../installing/context"
     },
     {

--- a/pnpm11/building/commands/test/build/index.ts
+++ b/pnpm11/building/commands/test/build/index.ts
@@ -609,6 +609,21 @@ test('rebuild refuses a lockfile depPath name that escapes the virtual store', a
   fs.writeFileSync(currentLockfilePath, fs.readFileSync(currentLockfilePath, 'utf8')
     .replaceAll('@pnpm.e2e/pre-and-postinstall-scripts-example', '../../../escaped'))
 
+  // The traversal resolves out of `node_modules/.pnpm/<slot>/node_modules` to
+  // `node_modules/escaped`. Plant a package there whose postinstall writes a
+  // marker, so the test fails loudly if the build ever runs outside the
+  // virtual store rather than only if a directory happens to be created.
+  const escapedPkgDir = path.resolve('node_modules/escaped')
+  const marker = path.resolve('pwned.txt')
+  fs.mkdirSync(escapedPkgDir, { recursive: true })
+  fs.writeFileSync(path.join(escapedPkgDir, 'package.json'), JSON.stringify({
+    name: 'escaped',
+    version: '1.0.0',
+    scripts: { postinstall: 'node write-marker.cjs' },
+  }))
+  fs.writeFileSync(path.join(escapedPkgDir, 'write-marker.cjs'),
+    `require('fs').writeFileSync(${JSON.stringify(marker)}, 'pwned')`)
+
   const modulesManifest = project.readModulesManifest()
   await expect(rebuild.handler({
     ...DEFAULT_OPTS,
@@ -617,8 +632,11 @@ test('rebuild refuses a lockfile depPath name that escapes the virtual store', a
     pending: false,
     registries: modulesManifest!.registries!,
     storeDir,
-    allowBuilds: { '../../../escaped': true },
+    // The advisory's stated escalation to code execution. Without it the
+    // build policy would block the script anyway and the test could not
+    // tell a contained join from a merely unapproved one.
+    dangerouslyAllowAllBuilds: true,
   }, [])).rejects.toThrow(expect.objectContaining({ code: 'ERR_PNPM_INVALID_DEPENDENCY_NAME' }))
 
-  expect(fs.existsSync(path.resolve('../../../escaped'))).toBeFalsy()
+  expect(fs.existsSync(marker)).toBeFalsy()
 })

--- a/pnpm11/building/commands/test/build/index.ts
+++ b/pnpm11/building/commands/test/build/index.ts
@@ -632,10 +632,11 @@ test('rebuild refuses a lockfile depPath name that escapes the virtual store', a
     pending: false,
     registries: modulesManifest!.registries!,
     storeDir,
-    // The advisory's stated escalation to code execution. Without it the
-    // build policy would block the script anyway and the test could not
-    // tell a contained join from a merely unapproved one.
-    dangerouslyAllowAllBuilds: true,
+    // Approve the build, so that what stops the script is the contained
+    // join and not the build policy. The key has to carry the version:
+    // a bare `../../../escaped` is read as a depPath allow-build key and
+    // then never matches the depPath it came from.
+    allowBuilds: { '../../../escaped@1.0.0': true },
   }, [])).rejects.toThrow(expect.objectContaining({ code: 'ERR_PNPM_INVALID_DEPENDENCY_NAME' }))
 
   expect(fs.existsSync(marker)).toBeFalsy()

--- a/pnpm11/building/commands/test/build/index.ts
+++ b/pnpm11/building/commands/test/build/index.ts
@@ -585,3 +585,40 @@ test('rebuilds in the global virtual store when the approval was granted after t
 
   expect(fs.existsSync(path.join(pkgInGvs, 'generated-by-postinstall.js'))).toBeTruthy()
 })
+
+// GHSA-c59q-g84q-2gj5: a traversal depPath key must not point the build
+// at a directory outside the virtual store.
+test('rebuild refuses a lockfile depPath name that escapes the virtual store', async () => {
+  const project = prepare()
+  const cacheDir = path.resolve('cache')
+  const storeDir = path.resolve('store')
+
+  await execa('node', [
+    pnpmBin,
+    'add',
+    '--save-dev',
+    '@pnpm.e2e/pre-and-postinstall-scripts-example@1.0.0',
+    '--config.enableGlobalVirtualStore=false',
+    `--registry=${REGISTRY}`,
+    `--store-dir=${storeDir}`,
+    '--ignore-scripts',
+    `--cache-dir=${cacheDir}`,
+  ])
+
+  const currentLockfilePath = path.resolve('node_modules/.pnpm/lock.yaml')
+  fs.writeFileSync(currentLockfilePath, fs.readFileSync(currentLockfilePath, 'utf8')
+    .replaceAll('@pnpm.e2e/pre-and-postinstall-scripts-example', '../../../escaped'))
+
+  const modulesManifest = project.readModulesManifest()
+  await expect(rebuild.handler({
+    ...DEFAULT_OPTS,
+    cacheDir,
+    dir: process.cwd(),
+    pending: false,
+    registries: modulesManifest!.registries!,
+    storeDir,
+    allowBuilds: { '../../../escaped': true },
+  }, [])).rejects.toThrow(expect.objectContaining({ code: 'ERR_PNPM_INVALID_DEPENDENCY_NAME' }))
+
+  expect(fs.existsSync(path.resolve('../../../escaped'))).toBeFalsy()
+})


### PR DESCRIPTION
## Summary

Follow-up to `51300fd41c` (GHSA-c59q-g84q-2gj5, GHSA-vq4v-j7r6-jq4m, GHSA-2rx9-3g3h-c2jv).

The GHSA-c59q-g84q-2gj5 report listed three sinks that join a lockfile-derived package name onto a directory. `51300fd41c` contained two of them — the isolated linker (`lockfileToDepGraph`) and the PnP `packageLocation` — and both are covered by regression tests. The third, the rebuild phase, was missed.

`_rebuild` in `@pnpm/building.after-install` reads the current lockfile from `node_modules` and builds the package root as `path.join(pkgModulesDir(depPath), pkgInfo.name)`, where `pkgInfo.name` comes from `dp.parse()` of the `packages` key. `dp.parse()` is a raw substring with no validation, so a key like `../../../escaped@1.0.0` pointed the lifecycle-script runner (and the post-build `.bin` linking a few lines down) at a directory outside the virtual store. The dep graph that phase walks is built by `@pnpm/deps.graph-hasher`, which deliberately defers the package-name check to its sink — and this sink had none.

Both joins now go through `safeJoinModulesDir`, so a crafted name fails with `ERR_PNPM_INVALID_DEPENDENCY_NAME` before any script runs.

Reachability is narrower than the install path the advisory described: the poisoned lockfile has to already be inside `node_modules/.pnpm/lock.yaml`, which means a shipped or CI-restored `node_modules`, not a committed `pnpm-lock.yaml`. It is a defence-in-depth gap rather than a live repeat of the original bug, but it is the exact sink the report asked to close.

## Squash Commit Body

```text
GHSA-c59q-g84q-2gj5 reported that the isolated linker joined the
lockfile-derived package name onto the virtual store without validation.
That site, and the PnP `packageLocation`, were already contained by
51300fd41c; the one recommended site that commit missed is the rebuild
phase, which resolves its package root the same way.

`_rebuild` reads the current lockfile from `node_modules` and rebuilds
`pkgRoot` as `path.join(pkgModulesDir(depPath), pkgInfo.name)`, where
`pkgInfo.name` comes from `dp.parse` of the depPath key. `dp.parse` is a
raw substring and validates nothing, so a `../../../escaped@1.0.0` key
pointed the lifecycle-script runner and the post-build bin linking at a
directory outside the virtual store. The dep graph that phase walks comes
from `@pnpm/deps.graph-hasher`, which deliberately defers the name check
to its sink -- and this sink had none.

Route both joins through `safeJoinModulesDir`, so a crafted name fails
with ERR_PNPM_INVALID_DEPENDENCY_NAME before any script runs.

Reachability is narrower than the reported install path: the poisoned
lockfile has to already be in `node_modules`, which means a shipped or
restored `node_modules` rather than a committed `pnpm-lock.yaml`.

No pacquet change: its `rebuild` drives the frozen-install pipeline, which
runs `verify_lockfile_dependency_names` unconditionally over snapshot
package names, and it reads the project lockfile rather than a copy in
`node_modules`, so it has no equivalent unguarded sink.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <!-- No pacquet change needed: `pacquet rebuild` drives the frozen-install
  pipeline, which runs `verify_lockfile_dependency_names` unconditionally over
  snapshot package names (covered by
  `trust_lockfile_still_rejects_traversal_dependency_name`), and it reads the
  project lockfile rather than a copy in `node_modules`, so it has no equivalent
  unguarded sink. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788305170&installation_model_id=426870&pr_number=13596&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13596&signature=40fbb9376b2a099d56d2efa36f6f104bb96319a89c0424a08f2c67019c5dbc35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `pnpm rebuild` now rejects lockfiles containing package names with path traversal segments.
  * Prevents lifecycle scripts from running and binaries from being linked outside the virtual store.
  * Reports the `ERR_PNPM_INVALID_DEPENDENCY_NAME` error for invalid dependency names.
  * Added regression coverage to verify unsafe directories are not created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->