### PR TITLE
fix(env-installer): stop pinning the exe package from pnpm v12

### DIFF
--- a/.changeset/env-lockfile-skips-pnpm-exe-from-v12.md
+++ b/.changeset/env-lockfile-skips-pnpm-exe-from-v12.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/installing.env-installer": patch
+"@pnpm/engine.pm.commands": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+The env lockfile no longer pins `@pnpm/exe` alongside `pnpm` when the wanted pnpm version is 12 or newer. From v12 the unscoped `pnpm` package is itself the native executable, so `@pnpm/exe` is not published for it and resolving it would fail. The engine identity check now verifies the native binary through whichever package ships it.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6268,6 +6268,9 @@ importers:
       '@pnpm/deps.graph-hasher':
         specifier: workspace:*
         version: link:../../deps/graph-hasher
+      '@pnpm/deps.path':
+        specifier: workspace:*
+        version: link:../../deps/path
       '@pnpm/error':
         specifier: workspace:*
         version: link:../../core/error

--- a/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
@@ -552,24 +552,16 @@ importers:
   .:
     configDependencies: {{}}
     packageManagerDependencies:
-      '@pnpm/exe':
-        specifier: '{specifier}'
-        version: {version}
       pnpm:
         specifier: '{specifier}'
         version: {version}
 
 packages:
 
-  '@pnpm/exe@{version}':
-    resolution: {{integrity: sha512-di6YvqPO/2jvih6kCJ8r0ySzQNjQWrBXPEfqEHtrmwOamuNALnfASwhFBwEtMjWmaA8QG7TqAg2qEvAe+8cBkQ==}}
-
   pnpm@{version}:
     resolution: {{integrity: sha512-QVocwll0cx51RVwUaDcb50xapft2IbUNQFbSIkUWCfEUEvI/1gLmFp8eBgRmZB95hZfhvpYaEGiINqZ7FlaUmQ==}}
 
 snapshots:
-
-  '@pnpm/exe@{version}': {{}}
 
   pnpm@{version}: {{}}
 ---

--- a/pnpm/crates/cli/src/cli_args/self_update/verify_engine.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/verify_engine.rs
@@ -21,13 +21,13 @@ use p256::{
 };
 use pacquet_config::Config;
 use pacquet_graph_hasher::{host_arch, host_libc, host_platform};
-use pacquet_lockfile::{EnvLockfile, PackageKey, SnapshotDepRef};
+use pacquet_lockfile::{EnvLockfile, PackageKey, SnapshotDepRef, SpecifierAndResolution};
 use pacquet_network::{
     NetworkSettings, RetryOpts, ThrottledClient, encode_package_name, redact_url_credentials,
     send_with_retry,
 };
 use serde::Deserialize;
-use std::time::Duration;
+use std::{collections::BTreeMap, time::Duration};
 
 use super::{
     SelfUpdateError,
@@ -117,9 +117,9 @@ pub(crate) async fn verify_pnpm_engine_identity(
 }
 
 /// Collect the engine components to verify from the env lockfile: `pnpm`,
-/// `@pnpm/exe`, and the host's `@pnpm/exe` platform binary (an optional
-/// dependency of `@pnpm/exe`). Errors if a present component carries no
-/// integrity.
+/// `@pnpm/exe`, and the host's platform binary (an optional dependency of
+/// the native wrapper, see [`native_engine_wrapper`]). Errors if a present
+/// component carries no integrity.
 fn collect_engine_components(
     env: &EnvLockfile,
     config: &Config,
@@ -139,14 +139,13 @@ fn collect_engine_components(
         }
     }
 
-    // The bytes actually executed are the host's `@pnpm/exe` platform
-    // binary, listed as an optional dependency of `@pnpm/exe`. Since this
-    // is the native code self-update will run, a missing snapshot, missing
-    // optional deps, or no host candidate fails closed rather than letting
-    // verification pass on `pnpm`/`@pnpm/exe` alone.
-    if let Some(exe) = pm_deps.get("@pnpm/exe") {
-        let exe_version = &exe.version;
-        let snapshot_label = format!("@pnpm/exe@{exe_version}");
+    // The bytes actually executed are the host's platform binary, listed as
+    // an optional dependency of the native wrapper. Since this is the native
+    // code self-update will run, a missing snapshot, missing optional deps,
+    // or no host candidate fails closed rather than letting verification pass
+    // on the wrappers alone.
+    if let Some((wrapper_name, wrapper_version)) = native_engine_wrapper(pm_deps) {
+        let snapshot_label = format!("{wrapper_name}@{wrapper_version}");
         let snapshot_key = snapshot_label.parse::<PackageKey>().map_err(|_| {
             SelfUpdateError::EngineIdentityUnverifiable {
                 message: format!(
@@ -188,6 +187,21 @@ fn collect_engine_components(
     }
 
     Ok(to_verify)
+}
+
+/// The engine package whose optional dependencies carry the host's native
+/// binary: `@pnpm/exe` for the majors that publish it, and the unscoped
+/// `pnpm` from v12, which is itself the native executable. `None` for the
+/// JS-only `pnpm` of the majors that predate `@pnpm/exe`.
+fn native_engine_wrapper(
+    pm_deps: &BTreeMap<String, SpecifierAndResolution>,
+) -> Option<(&str, &str)> {
+    if let Some(exe) = pm_deps.get("@pnpm/exe") {
+        return Some(("@pnpm/exe", &exe.version));
+    }
+    let pnpm = pm_deps.get("pnpm")?;
+    let version = node_semver::Version::parse(&pnpm.version).ok()?;
+    (version.major >= 12).then_some(("pnpm", pnpm.version.as_str()))
 }
 
 /// Build the [`EngineComponent`] for `name@version`, reading its integrity

--- a/pnpm/crates/cli/src/cli_args/self_update/verify_engine.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/verify_engine.rs
@@ -190,9 +190,10 @@ fn collect_engine_components(
 }
 
 /// The engine package whose optional dependencies carry the host's native
-/// binary: `@pnpm/exe` for the majors that publish it, and the unscoped
-/// `pnpm` from v12, which is itself the native executable. `None` for the
-/// JS-only `pnpm` of the majors that predate `@pnpm/exe`.
+/// binary: `@pnpm/exe` when the lockfile pins it, otherwise `pnpm` itself
+/// for `>=12`, where the unscoped package is the native executable. `None`
+/// when the lockfile pins only a JS-only `pnpm` (`<6.17.1`), which has no
+/// platform binaries.
 fn native_engine_wrapper(
     pm_deps: &BTreeMap<String, SpecifierAndResolution>,
 ) -> Option<(&str, &str)> {

--- a/pnpm/crates/cli/src/cli_args/self_update/verify_engine/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/verify_engine/tests.rs
@@ -1,10 +1,11 @@
 use super::{
-    EngineComponent, NpmSigningKey, PackageSignature, plain_version, signature_validates_against,
-    verify_one,
+    EngineComponent, NpmSigningKey, PackageSignature, native_engine_wrapper, plain_version,
+    signature_validates_against, verify_one,
 };
 use base64::Engine as _;
 use p256::ecdsa::SigningKey;
-use pacquet_lockfile::SnapshotDepRef;
+use pacquet_lockfile::{SnapshotDepRef, SpecifierAndResolution};
+use std::collections::BTreeMap;
 
 fn signing_key() -> SigningKey {
     SigningKey::from_slice(&[0x42; 32]).expect("valid P-256 scalar")
@@ -111,4 +112,30 @@ fn plain_version_reads_only_plain_references() {
 
     let link = SnapshotDepRef::Link("packages/x".to_string());
     assert_eq!(plain_version(&link), None);
+}
+
+fn pm_deps(entries: &[(&str, &str)]) -> BTreeMap<String, SpecifierAndResolution> {
+    entries
+        .iter()
+        .map(|(name, version)| {
+            (
+                (*name).to_string(),
+                SpecifierAndResolution {
+                    specifier: (*version).to_string(),
+                    version: (*version).to_string(),
+                },
+            )
+        })
+        .collect()
+}
+
+#[test]
+fn native_engine_wrapper_follows_the_package_that_ships_the_binary() {
+    assert_eq!(
+        native_engine_wrapper(&pm_deps(&[("pnpm", "11.0.0"), ("@pnpm/exe", "11.0.0")])),
+        Some(("@pnpm/exe", "11.0.0")),
+    );
+    assert_eq!(native_engine_wrapper(&pm_deps(&[("pnpm", "12.0.0")])), Some(("pnpm", "12.0.0")));
+    assert_eq!(native_engine_wrapper(&pm_deps(&[("pnpm", "6.16.0")])), None);
+    assert_eq!(native_engine_wrapper(&pm_deps(&[])), None);
 }

--- a/pnpm/crates/env-installer/src/resolve_package_manager_integrities.rs
+++ b/pnpm/crates/env-installer/src/resolve_package_manager_integrities.rs
@@ -14,7 +14,7 @@ use pacquet_resolving_resolver_base::{ResolveOptions, ResolveResult, Resolver, W
 use std::{collections::HashMap, path::PathBuf};
 
 const PACKAGE_MANAGER_DEPS_WITH_EXE: [&str; 2] = ["pnpm", "@pnpm/exe"];
-const PACKAGE_MANAGER_DEPS_JS_ONLY: [&str; 1] = ["pnpm"];
+const PACKAGE_MANAGER_DEPS_PNPM_ONLY: [&str; 1] = ["pnpm"];
 const PNPM_EXE_INTRODUCED: (u64, u64, u64) = (6, 17, 1);
 
 pub async fn resolve_package_manager_integrities(
@@ -142,19 +142,25 @@ fn is_package_manager_resolved_with_deps(
         })
 }
 
+/// The packages the env lockfile pins for `pnpm_version`.
+///
+/// Both the JS `pnpm` and the native `@pnpm/exe` are pinned for the majors
+/// that publish the two separately, because the pin is shared and teammates
+/// may run either one. Outside that range only `pnpm` exists: before 6.17.1
+/// `@pnpm/exe` was not published yet, and from v12 the unscoped `pnpm` is
+/// itself the native executable.
 fn package_manager_deps(pnpm_version: &str) -> &'static [&'static str] {
-    if pnpm_exe_package_exists(pnpm_version) {
+    let Some(version) = node_semver::Version::parse(pnpm_version).ok() else {
+        return &PACKAGE_MANAGER_DEPS_WITH_EXE;
+    };
+    if version.major >= 12 {
+        return &PACKAGE_MANAGER_DEPS_PNPM_ONLY;
+    }
+    if (version.major, version.minor, version.patch) >= PNPM_EXE_INTRODUCED {
         &PACKAGE_MANAGER_DEPS_WITH_EXE
     } else {
-        &PACKAGE_MANAGER_DEPS_JS_ONLY
+        &PACKAGE_MANAGER_DEPS_PNPM_ONLY
     }
-}
-
-fn pnpm_exe_package_exists(pnpm_version: &str) -> bool {
-    let Some(version) = node_semver::Version::parse(pnpm_version).ok() else {
-        return true;
-    };
-    (version.major, version.minor, version.patch) >= PNPM_EXE_INTRODUCED
 }
 
 fn package_manager_entry_exists(env_lockfile: &EnvLockfile, name: &str, version: &str) -> bool {

--- a/pnpm/crates/env-installer/src/resolve_package_manager_integrities.rs
+++ b/pnpm/crates/env-installer/src/resolve_package_manager_integrities.rs
@@ -144,11 +144,10 @@ fn is_package_manager_resolved_with_deps(
 
 /// The packages the env lockfile pins for `pnpm_version`.
 ///
-/// Both the JS `pnpm` and the native `@pnpm/exe` are pinned for the majors
-/// that publish the two separately, because the pin is shared and teammates
-/// may run either one. Outside that range only `pnpm` exists: before 6.17.1
-/// `@pnpm/exe` was not published yet, and from v12 the unscoped `pnpm` is
-/// itself the native executable.
+/// `>=6.17.1 <12` publishes the JS `pnpm` and the native `@pnpm/exe` as two
+/// packages, and both are pinned, because the pin is shared and teammates
+/// may run either one. Every other version publishes `pnpm` alone: as the JS
+/// CLI below 6.17.1, and as the native executable itself from 12.
 fn package_manager_deps(pnpm_version: &str) -> &'static [&'static str] {
     let Some(version) = node_semver::Version::parse(pnpm_version).ok() else {
         return &PACKAGE_MANAGER_DEPS_WITH_EXE;

--- a/pnpm/crates/env-installer/src/tests.rs
+++ b/pnpm/crates/env-installer/src/tests.rs
@@ -268,16 +268,16 @@ async fn resolves_package_manager_dependencies_graph() {
     let resolver = FixtureResolver::new()
         .package(serde_json::json!({
             "name": "pnpm",
-            "version": "100.0.0",
+            "version": "11.0.0",
             "bin": "bin/pnpm.cjs",
             "engines": { "node": ">=22.0.0" },
         }))
         .package(serde_json::json!({
             "name": "@pnpm/exe",
-            "version": "100.0.0",
+            "version": "11.0.0",
             "bin": { "pnpm": "bin/pnpm.cjs" },
             "dependencies": { "detect-libc": "2.0.0" },
-            "optionalDependencies": { "@pnpm/linuxstatic-x64": "100.0.0" },
+            "optionalDependencies": { "@pnpm/linuxstatic-x64": "11.0.0" },
         }))
         .package(serde_json::json!({
             "name": "detect-libc",
@@ -286,15 +286,15 @@ async fn resolves_package_manager_dependencies_graph() {
         }))
         .package(serde_json::json!({
             "name": "@pnpm/linuxstatic-x64",
-            "version": "100.0.0",
+            "version": "11.0.0",
             "cpu": ["x64"],
             "os": ["linux"],
             "libc": "musl",
         }));
 
     resolve_package_manager_integrities(
-        "^100.0.0",
-        "100.0.0",
+        "^11.0.0",
+        "11.0.0",
         &resolver,
         &options(&harness, root.path(), false),
     )
@@ -306,15 +306,15 @@ async fn resolves_package_manager_dependencies_graph() {
         .package_manager_dependencies
         .as_ref()
         .expect("package manager deps recorded");
-    assert_eq!(pm_deps["pnpm"].specifier, "^100.0.0");
-    assert_eq!(pm_deps["pnpm"].version, "100.0.0");
-    assert_eq!(pm_deps["@pnpm/exe"].specifier, "^100.0.0");
-    assert_eq!(pm_deps["@pnpm/exe"].version, "100.0.0");
+    assert_eq!(pm_deps["pnpm"].specifier, "^11.0.0");
+    assert_eq!(pm_deps["pnpm"].version, "11.0.0");
+    assert_eq!(pm_deps["@pnpm/exe"].specifier, "^11.0.0");
+    assert_eq!(pm_deps["@pnpm/exe"].version, "11.0.0");
 
-    let pnpm_key: PackageKey = "pnpm@100.0.0".parse().unwrap();
-    let exe_key: PackageKey = "@pnpm/exe@100.0.0".parse().unwrap();
+    let pnpm_key: PackageKey = "pnpm@11.0.0".parse().unwrap();
+    let exe_key: PackageKey = "@pnpm/exe@11.0.0".parse().unwrap();
     let libc_key: PackageKey = "detect-libc@2.0.0".parse().unwrap();
-    let platform_key: PackageKey = "@pnpm/linuxstatic-x64@100.0.0".parse().unwrap();
+    let platform_key: PackageKey = "@pnpm/linuxstatic-x64@11.0.0".parse().unwrap();
 
     assert_eq!(env.packages[&pnpm_key].has_bin, Some(true));
     assert_eq!(env.packages[&pnpm_key].engines.as_ref().unwrap()["node"], ">=22.0.0");
@@ -329,12 +329,12 @@ async fn resolves_package_manager_dependencies_graph() {
     assert_eq!(detect_libc_ref, "2.0.0");
     assert_eq!(
         exe_snapshot.optional_dependencies.as_ref().unwrap()[&platform_name].to_string(),
-        "100.0.0",
+        "11.0.0",
     );
     assert!(env.snapshots[&platform_key].optional);
     assert!(!env.snapshots[&libc_key].optional);
-    assert!(is_package_manager_resolved(&env, "^100.0.0", "100.0.0"));
-    assert!(!is_package_manager_resolved(&env, "~100.0.0", "100.0.0"));
+    assert!(is_package_manager_resolved(&env, "^11.0.0", "11.0.0"));
+    assert!(!is_package_manager_resolved(&env, "~11.0.0", "11.0.0"));
 
     let mut env_with_extra_pm_dep = env.clone();
     env_with_extra_pm_dep
@@ -348,7 +348,57 @@ async fn resolves_package_manager_dependencies_graph() {
             "yarn".to_string(),
             SpecifierAndResolution { specifier: "1.0.0".to_string(), version: "1.0.0".to_string() },
         );
-    assert!(!is_package_manager_resolved(&env_with_extra_pm_dep, "^100.0.0", "100.0.0",));
+    assert!(!is_package_manager_resolved(&env_with_extra_pm_dep, "^11.0.0", "11.0.0",));
+}
+
+#[tokio::test]
+async fn resolves_package_manager_dependencies_without_exe_from_v12() {
+    let harness = harness();
+    let root = TempDir::new().unwrap();
+    let resolver = FixtureResolver::new()
+        .package(serde_json::json!({
+            "name": "pnpm",
+            "version": "12.0.0",
+            "bin": { "pnpm": "pnpm" },
+            "optionalDependencies": { "@pnpm/exe.linux-x64": "12.0.0" },
+        }))
+        .package(serde_json::json!({
+            "name": "@pnpm/exe.linux-x64",
+            "version": "12.0.0",
+            "cpu": ["x64"],
+            "os": ["linux"],
+        }));
+
+    resolve_package_manager_integrities(
+        "^12.0.0",
+        "12.0.0",
+        &resolver,
+        &options(&harness, root.path(), false),
+    )
+    .await
+    .unwrap();
+
+    let env = EnvLockfile::read(root.path()).unwrap().expect("env lockfile written");
+    let pm_deps = env.importers[EnvLockfile::ROOT_IMPORTER_KEY]
+        .package_manager_dependencies
+        .as_ref()
+        .expect("package manager deps recorded");
+    assert_eq!(pm_deps.len(), 1);
+    assert_eq!(pm_deps["pnpm"].specifier, "^12.0.0");
+    assert_eq!(pm_deps["pnpm"].version, "12.0.0");
+    assert!(!pm_deps.contains_key("@pnpm/exe"));
+
+    let pnpm_key: PackageKey = "pnpm@12.0.0".parse().unwrap();
+    let platform_key: PackageKey = "@pnpm/exe.linux-x64@12.0.0".parse().unwrap();
+    assert!(env.packages.contains_key(&pnpm_key));
+    assert!(env.packages.contains_key(&platform_key));
+    let platform_name = "@pnpm/exe.linux-x64".parse().unwrap();
+    assert_eq!(
+        env.snapshots[&pnpm_key].optional_dependencies.as_ref().unwrap()[&platform_name]
+            .to_string(),
+        "12.0.0",
+    );
+    assert!(is_package_manager_resolved(&env, "^12.0.0", "12.0.0"));
 }
 
 #[tokio::test]

--- a/pnpm11/engine/pm/commands/src/self-updater/verifyPnpmEngineIdentity.ts
+++ b/pnpm11/engine/pm/commands/src/self-updater/verifyPnpmEngineIdentity.ts
@@ -12,6 +12,7 @@ import type { EnvLockfile } from '@pnpm/lockfile.types'
 import { createGetAuthHeaderByURI } from '@pnpm/network.auth-header'
 import type { Registries, RegistryConfig } from '@pnpm/types'
 import { familySync } from 'detect-libc'
+import semver from 'semver'
 
 import { exePlatformPkgDirName, exePlatformPkgDirNameNext } from './installPnpm.js'
 
@@ -103,11 +104,11 @@ function collectEnginePackagesToVerify (envLockfile: EnvLockfile, registries: Re
     toVerify.push(engineComponentToVerify(envLockfile, registries, { name, version }))
   }
 
-  // The bytes actually executed are the host's `@pnpm/exe` platform binary,
-  // listed as an optional dependency of `@pnpm/exe`.
-  const exeVersion = pmDeps['@pnpm/exe']?.version
-  if (exeVersion != null) {
-    const optionalDeps = envLockfile.snapshots[`@pnpm/exe@${exeVersion}`]?.optionalDependencies ?? {}
+  // The bytes actually executed are the host's platform binary, listed as an
+  // optional dependency of the native wrapper.
+  const wrapper = nativeEngineWrapper(pmDeps)
+  if (wrapper != null) {
+    const optionalDeps = envLockfile.snapshots[`${wrapper.name}@${wrapper.version}`]?.optionalDependencies ?? {}
     const libcFamily = familySync()
     const candidateNames = [
       `@pnpm/${exePlatformPkgDirName(process.platform, process.arch, libcFamily)}`,
@@ -124,6 +125,21 @@ function collectEnginePackagesToVerify (envLockfile: EnvLockfile, registries: Re
   }
 
   return toVerify
+}
+
+/**
+ * The engine package whose optional dependencies carry the host's native
+ * binary: `@pnpm/exe` for the majors that publish it, and the unscoped `pnpm`
+ * from v12, which is itself the native executable. Returns `undefined` for the
+ * JS-only `pnpm` of the majors that predate `@pnpm/exe`.
+ */
+function nativeEngineWrapper (pmDeps: Record<string, { version: string }>): { name: string, version: string } | undefined {
+  const exeVersion = pmDeps['@pnpm/exe']?.version
+  if (exeVersion != null) return { name: '@pnpm/exe', version: exeVersion }
+  const pnpmVersion = pmDeps['pnpm']?.version
+  if (pnpmVersion == null) return undefined
+  const parsed = semver.parse(pnpmVersion, { loose: true })
+  return parsed != null && parsed.major >= 12 ? { name: 'pnpm', version: pnpmVersion } : undefined
 }
 
 function engineComponentToVerify (

--- a/pnpm11/engine/pm/commands/src/self-updater/verifyPnpmEngineIdentity.ts
+++ b/pnpm11/engine/pm/commands/src/self-updater/verifyPnpmEngineIdentity.ts
@@ -105,23 +105,35 @@ function collectEnginePackagesToVerify (envLockfile: EnvLockfile, registries: Re
   }
 
   // The bytes actually executed are the host's platform binary, listed as an
-  // optional dependency of the native wrapper.
+  // optional dependency of the native wrapper. Since this is the native code
+  // that will run, a missing snapshot, missing optional deps, or no host
+  // candidate fails closed rather than letting verification pass on the
+  // wrappers alone.
   const wrapper = nativeEngineWrapper(pmDeps)
   if (wrapper != null) {
-    const optionalDeps = envLockfile.snapshots[`${wrapper.name}@${wrapper.version}`]?.optionalDependencies ?? {}
+    const label = `${wrapper.name}@${wrapper.version}`
+    const optionalDeps = envLockfile.snapshots[label]?.optionalDependencies
+    if (optionalDeps == null) {
+      throw new PnpmError(
+        'PNPM_ENGINE_IDENTITY_UNVERIFIABLE',
+        `Cannot verify the identity of ${label}: its platform binaries are missing from pnpm-lock.yaml.`
+      )
+    }
     const libcFamily = familySync()
     const candidateNames = [
       `@pnpm/${exePlatformPkgDirName(process.platform, process.arch, libcFamily)}`,
       `@pnpm/${exePlatformPkgDirNameNext(process.platform, process.arch, libcFamily)}`,
     ]
-    for (const platformName of candidateNames) {
-      const platformVersion = optionalDeps[platformName]
-      if (platformVersion == null) continue
-      // The first candidate present in the lockfile is the binary the install
-      // will link and execute, so it is the one that must be verifiable.
-      toVerify.push(engineComponentToVerify(envLockfile, registries, { name: platformName, version: platformVersion }))
-      break
+    // The first candidate present in the lockfile is the binary the install
+    // will link and execute, so it is the one that must be verifiable.
+    const platformName = candidateNames.find((name) => optionalDeps[name] != null)
+    if (platformName == null) {
+      throw new PnpmError(
+        'PNPM_ENGINE_IDENTITY_UNVERIFIABLE',
+        `Cannot verify the identity of the @pnpm/exe.${process.platform}-${process.arch} native binary: it is missing from pnpm-lock.yaml.`
+      )
     }
+    toVerify.push(engineComponentToVerify(envLockfile, registries, { name: platformName, version: optionalDeps[platformName] }))
   }
 
   return toVerify
@@ -129,9 +141,10 @@ function collectEnginePackagesToVerify (envLockfile: EnvLockfile, registries: Re
 
 /**
  * The engine package whose optional dependencies carry the host's native
- * binary: `@pnpm/exe` for the majors that publish it, and the unscoped `pnpm`
- * from v12, which is itself the native executable. Returns `undefined` for the
- * JS-only `pnpm` of the majors that predate `@pnpm/exe`.
+ * binary: `@pnpm/exe` when the lockfile pins it, otherwise `pnpm` itself for
+ * `>=12`, where the unscoped package is the native executable. `undefined`
+ * when the lockfile pins only a JS-only `pnpm` (`<6.17.1`), which has no
+ * platform binaries.
  */
 function nativeEngineWrapper (pmDeps: Record<string, { version: string }>): { name: string, version: string } | undefined {
   const exeVersion = pmDeps['@pnpm/exe']?.version

--- a/pnpm11/engine/pm/commands/test/self-updater/verifyPnpmEngineIdentity.test.ts
+++ b/pnpm11/engine/pm/commands/test/self-updater/verifyPnpmEngineIdentity.test.ts
@@ -114,7 +114,7 @@ describe('verifyPnpmEngineIdentity', () => {
   test('throws when no platform binary in the lockfile matches the host', async () => {
     const key = createSigningKey()
     const lockfile = envLockfile()
-    ;(lockfile.snapshots as Record<string, unknown>)['@pnpm/exe@9.1.0'] = { optionalDependencies: { '@pnpm/exe.someos-somearch': '9.1.0' } }
+    ;(lockfile.snapshots as Record<string, unknown>)['@pnpm/exe@9.1.0'] = { optionalDependencies: { '@pnpm/exe.aix-mips': '9.1.0' } }
 
     await expect(verifyPnpmEngineIdentity(lockfile, '9.1.0', optsTrusting(key))).rejects.toThrow(/native binary: it is missing/)
   })

--- a/pnpm11/engine/pm/commands/test/self-updater/verifyPnpmEngineIdentity.test.ts
+++ b/pnpm11/engine/pm/commands/test/self-updater/verifyPnpmEngineIdentity.test.ts
@@ -25,8 +25,9 @@ afterEach(async () => {
 describe('verifyPnpmEngineIdentity', () => {
   test('resolves when both pnpm and @pnpm/exe carry a valid registry signature over the installed bytes', async () => {
     const key = createSigningKey()
-    mockPackument('pnpm', PNPM_INTEGRITY, [{ keyid: key.keyid, sig: key.sign('pnpm@9.1.0', PNPM_INTEGRITY) }])
-    mockPackument('@pnpm/exe', EXE_INTEGRITY, [{ keyid: key.keyid, sig: key.sign('@pnpm/exe@9.1.0', EXE_INTEGRITY) }])
+    mockPackument({ name: 'pnpm', integrity: PNPM_INTEGRITY, signatures: [{ keyid: key.keyid, sig: key.sign('pnpm@9.1.0', PNPM_INTEGRITY) }] })
+    mockPackument({ name: '@pnpm/exe', integrity: EXE_INTEGRITY, signatures: [{ keyid: key.keyid, sig: key.sign('@pnpm/exe@9.1.0', EXE_INTEGRITY) }] })
+    mockPackument({ name: PLATFORM_PKG_NAME, integrity: PLATFORM_INTEGRITY, signatures: [{ keyid: key.keyid, sig: key.sign(`${PLATFORM_PKG_NAME}@9.1.0`, PLATFORM_INTEGRITY) }] })
 
     await expect(verifyPnpmEngineIdentity(envLockfile(), '9.1.0', optsTrusting(key))).resolves.toBeUndefined()
   })
@@ -34,16 +35,16 @@ describe('verifyPnpmEngineIdentity', () => {
   test('throws when the installed bytes do not match what the registry signed (tamper)', async () => {
     const key = createSigningKey()
     // The registry signed the genuine integrity, but the lockfile pins a different one.
-    mockPackument('pnpm', PNPM_INTEGRITY, [{ keyid: key.keyid, sig: key.sign('pnpm@9.1.0', 'sha512-genuine-pnpm') }])
-    mockPackument('@pnpm/exe', EXE_INTEGRITY, [{ keyid: key.keyid, sig: key.sign('@pnpm/exe@9.1.0', 'sha512-genuine-exe') }])
+    mockPackument({ name: 'pnpm', integrity: PNPM_INTEGRITY, signatures: [{ keyid: key.keyid, sig: key.sign('pnpm@9.1.0', 'sha512-genuine-pnpm') }] })
+    mockPackument({ name: '@pnpm/exe', integrity: EXE_INTEGRITY, signatures: [{ keyid: key.keyid, sig: key.sign('@pnpm/exe@9.1.0', 'sha512-genuine-exe') }] })
 
     await expect(verifyPnpmEngineIdentity(envLockfile(), '9.1.0', optsTrusting(key))).rejects.toThrow(/Refusing to run pnpm/)
   })
 
   test('throws when the engine is signed by a key pnpm does not trust', async () => {
     const signingKey = createSigningKey()
-    mockPackument('pnpm', PNPM_INTEGRITY, [{ keyid: signingKey.keyid, sig: signingKey.sign('pnpm@9.1.0', PNPM_INTEGRITY) }])
-    mockPackument('@pnpm/exe', EXE_INTEGRITY, [{ keyid: signingKey.keyid, sig: signingKey.sign('@pnpm/exe@9.1.0', EXE_INTEGRITY) }])
+    mockPackument({ name: 'pnpm', integrity: PNPM_INTEGRITY, signatures: [{ keyid: signingKey.keyid, sig: signingKey.sign('pnpm@9.1.0', PNPM_INTEGRITY) }] })
+    mockPackument({ name: '@pnpm/exe', integrity: EXE_INTEGRITY, signatures: [{ keyid: signingKey.keyid, sig: signingKey.sign('@pnpm/exe@9.1.0', EXE_INTEGRITY) }] })
 
     // Trust a different key than the one that signed.
     await expect(verifyPnpmEngineIdentity(envLockfile(), '9.1.0', optsTrusting(createSigningKey()))).rejects.toThrow(/Refusing to run pnpm/)
@@ -69,7 +70,7 @@ describe('verifyPnpmEngineIdentity', () => {
 
   test('throws when an engine component in the lockfile has no integrity metadata', async () => {
     const key = createSigningKey()
-    mockPackument('pnpm', PNPM_INTEGRITY, [{ keyid: key.keyid, sig: key.sign('pnpm@9.1.0', PNPM_INTEGRITY) }])
+    mockPackument({ name: 'pnpm', integrity: PNPM_INTEGRITY, signatures: [{ keyid: key.keyid, sig: key.sign('pnpm@9.1.0', PNPM_INTEGRITY) }] })
 
     const lockfile = envLockfile()
     ;(lockfile.packages as Record<string, unknown>)['@pnpm/exe@9.1.0'] = { resolution: { tarball: `${REGISTRY}@pnpm/exe/-/exe-9.1.0.tgz` } }
@@ -79,8 +80,8 @@ describe('verifyPnpmEngineIdentity', () => {
 
   test('throws when the platform binary in the lockfile has no integrity metadata', async () => {
     const key = createSigningKey()
-    mockPackument('pnpm', PNPM_INTEGRITY, [{ keyid: key.keyid, sig: key.sign('pnpm@9.1.0', PNPM_INTEGRITY) }])
-    mockPackument('@pnpm/exe', EXE_INTEGRITY, [{ keyid: key.keyid, sig: key.sign('@pnpm/exe@9.1.0', EXE_INTEGRITY) }])
+    mockPackument({ name: 'pnpm', integrity: PNPM_INTEGRITY, signatures: [{ keyid: key.keyid, sig: key.sign('pnpm@9.1.0', PNPM_INTEGRITY) }] })
+    mockPackument({ name: '@pnpm/exe', integrity: EXE_INTEGRITY, signatures: [{ keyid: key.keyid, sig: key.sign('@pnpm/exe@9.1.0', EXE_INTEGRITY) }] })
 
     const lockfile = envLockfile()
     ;(lockfile.snapshots as Record<string, unknown>)['@pnpm/exe@9.1.0'] = { optionalDependencies: { [PLATFORM_PKG_NAME]: '9.1.0' } }
@@ -91,9 +92,9 @@ describe('verifyPnpmEngineIdentity', () => {
 
   test('resolves when the platform binary carries a valid registry signature', async () => {
     const key = createSigningKey()
-    mockPackument('pnpm', PNPM_INTEGRITY, [{ keyid: key.keyid, sig: key.sign('pnpm@9.1.0', PNPM_INTEGRITY) }])
-    mockPackument('@pnpm/exe', EXE_INTEGRITY, [{ keyid: key.keyid, sig: key.sign('@pnpm/exe@9.1.0', EXE_INTEGRITY) }])
-    mockPackument(PLATFORM_PKG_NAME, PLATFORM_INTEGRITY, [{ keyid: key.keyid, sig: key.sign(`${PLATFORM_PKG_NAME}@9.1.0`, PLATFORM_INTEGRITY) }])
+    mockPackument({ name: 'pnpm', integrity: PNPM_INTEGRITY, signatures: [{ keyid: key.keyid, sig: key.sign('pnpm@9.1.0', PNPM_INTEGRITY) }] })
+    mockPackument({ name: '@pnpm/exe', integrity: EXE_INTEGRITY, signatures: [{ keyid: key.keyid, sig: key.sign('@pnpm/exe@9.1.0', EXE_INTEGRITY) }] })
+    mockPackument({ name: PLATFORM_PKG_NAME, integrity: PLATFORM_INTEGRITY, signatures: [{ keyid: key.keyid, sig: key.sign(`${PLATFORM_PKG_NAME}@9.1.0`, PLATFORM_INTEGRITY) }] })
 
     const lockfile = envLockfile()
     ;(lockfile.snapshots as Record<string, unknown>)['@pnpm/exe@9.1.0'] = { optionalDependencies: { [PLATFORM_PKG_NAME]: '9.1.0' } }
@@ -102,10 +103,26 @@ describe('verifyPnpmEngineIdentity', () => {
     await expect(verifyPnpmEngineIdentity(lockfile, '9.1.0', optsTrusting(key))).resolves.toBeUndefined()
   })
 
+  test('throws when the wrapper snapshot lists no platform binaries', async () => {
+    const key = createSigningKey()
+    const lockfile = envLockfile()
+    ;(lockfile.snapshots as Record<string, unknown>)['@pnpm/exe@9.1.0'] = {}
+
+    await expect(verifyPnpmEngineIdentity(lockfile, '9.1.0', optsTrusting(key))).rejects.toThrow(/platform binaries are missing/)
+  })
+
+  test('throws when no platform binary in the lockfile matches the host', async () => {
+    const key = createSigningKey()
+    const lockfile = envLockfile()
+    ;(lockfile.snapshots as Record<string, unknown>)['@pnpm/exe@9.1.0'] = { optionalDependencies: { '@pnpm/exe.someos-somearch': '9.1.0' } }
+
+    await expect(verifyPnpmEngineIdentity(lockfile, '9.1.0', optsTrusting(key))).rejects.toThrow(/native binary: it is missing/)
+  })
+
   test('verifies the platform binary of the unscoped pnpm, which is the native wrapper from v12', async () => {
     const key = createSigningKey()
-    mockPackument('pnpm', PNPM_INTEGRITY, [{ keyid: key.keyid, sig: key.sign('pnpm@12.0.0', PNPM_INTEGRITY) }], '12.0.0')
-    mockPackument(PLATFORM_PKG_NAME_NEXT, PLATFORM_INTEGRITY, [{ keyid: key.keyid, sig: key.sign(`${PLATFORM_PKG_NAME_NEXT}@12.0.0`, 'sha512-genuine-platform') }], '12.0.0')
+    mockPackument({ name: 'pnpm', integrity: PNPM_INTEGRITY, signatures: [{ keyid: key.keyid, sig: key.sign('pnpm@12.0.0', PNPM_INTEGRITY) }], version: '12.0.0' })
+    mockPackument({ name: PLATFORM_PKG_NAME_NEXT, integrity: PLATFORM_INTEGRITY, signatures: [{ keyid: key.keyid, sig: key.sign(`${PLATFORM_PKG_NAME_NEXT}@12.0.0`, 'sha512-genuine-platform') }], version: '12.0.0' })
 
     await expect(verifyPnpmEngineIdentity(envLockfileV12(), '12.0.0', optsTrusting(key))).rejects.toThrow(/Refusing to run pnpm/)
   })
@@ -155,15 +172,16 @@ function envLockfile (): EnvLockfile {
     packages: {
       'pnpm@9.1.0': { resolution: { integrity: PNPM_INTEGRITY } },
       '@pnpm/exe@9.1.0': { resolution: { integrity: EXE_INTEGRITY } },
+      [`${PLATFORM_PKG_NAME}@9.1.0`]: { resolution: { integrity: PLATFORM_INTEGRITY } },
     },
     snapshots: {
       'pnpm@9.1.0': {},
-      '@pnpm/exe@9.1.0': {},
+      '@pnpm/exe@9.1.0': { optionalDependencies: { [PLATFORM_PKG_NAME]: '9.1.0' } },
     },
   } as unknown as EnvLockfile
 }
 
-function mockPackument (name: string, integrity: string, signatures: unknown, version: string = '9.1.0'): void {
+function mockPackument ({ name, integrity, signatures, version = '9.1.0' }: { name: string, integrity: string, signatures: unknown, version?: string }): void {
   const encodedPath = name[0] === '@' ? `/${name.replace(/\//g, '%2F')}` : `/${name}`
   getMockAgent().get(REGISTRY.replace(/\/$/, ''))
     .intercept({ path: encodedPath, method: 'GET' })

--- a/pnpm11/engine/pm/commands/test/self-updater/verifyPnpmEngineIdentity.test.ts
+++ b/pnpm11/engine/pm/commands/test/self-updater/verifyPnpmEngineIdentity.test.ts
@@ -5,13 +5,14 @@ import type { EnvLockfile } from '@pnpm/lockfile.types'
 import { getMockAgent, setupMockAgent, teardownMockAgent } from '@pnpm/testing.mock-agent'
 import { familySync } from 'detect-libc'
 
-const { exePlatformPkgDirName, verifyPnpmEngineIdentity } = await import('@pnpm/engine.pm.commands')
+const { exePlatformPkgDirName, exePlatformPkgDirNameNext, verifyPnpmEngineIdentity } = await import('@pnpm/engine.pm.commands')
 
 const REGISTRY = 'https://registry.example.test/'
 const PNPM_INTEGRITY = 'sha512-pnpm-integrity'
 const EXE_INTEGRITY = 'sha512-exe-integrity'
 const PLATFORM_INTEGRITY = 'sha512-platform-integrity'
 const PLATFORM_PKG_NAME = `@pnpm/${exePlatformPkgDirName(process.platform, process.arch, familySync())}`
+const PLATFORM_PKG_NAME_NEXT = `@pnpm/${exePlatformPkgDirNameNext(process.platform, process.arch, familySync())}`
 
 beforeEach(async () => {
   await setupMockAgent()
@@ -100,7 +101,37 @@ describe('verifyPnpmEngineIdentity', () => {
 
     await expect(verifyPnpmEngineIdentity(lockfile, '9.1.0', optsTrusting(key))).resolves.toBeUndefined()
   })
+
+  test('verifies the platform binary of the unscoped pnpm, which is the native wrapper from v12', async () => {
+    const key = createSigningKey()
+    mockPackument('pnpm', PNPM_INTEGRITY, [{ keyid: key.keyid, sig: key.sign('pnpm@12.0.0', PNPM_INTEGRITY) }], '12.0.0')
+    mockPackument(PLATFORM_PKG_NAME_NEXT, PLATFORM_INTEGRITY, [{ keyid: key.keyid, sig: key.sign(`${PLATFORM_PKG_NAME_NEXT}@12.0.0`, 'sha512-genuine-platform') }], '12.0.0')
+
+    await expect(verifyPnpmEngineIdentity(envLockfileV12(), '12.0.0', optsTrusting(key))).rejects.toThrow(/Refusing to run pnpm/)
+  })
 })
+
+/** An env lockfile of a v12 engine, whose only package-manager dependency is the native `pnpm`. */
+function envLockfileV12 (): EnvLockfile {
+  return {
+    lockfileVersion: '9.0',
+    importers: {
+      '.': {
+        configDependencies: {},
+        packageManagerDependencies: {
+          pnpm: { specifier: '12.0.0', version: '12.0.0' },
+        },
+      },
+    },
+    packages: {
+      'pnpm@12.0.0': { resolution: { integrity: PNPM_INTEGRITY } },
+      [`${PLATFORM_PKG_NAME_NEXT}@12.0.0`]: { resolution: { integrity: PLATFORM_INTEGRITY } },
+    },
+    snapshots: {
+      'pnpm@12.0.0': { optionalDependencies: { [PLATFORM_PKG_NAME_NEXT]: '12.0.0' } },
+    },
+  } as unknown as EnvLockfile
+}
 
 function optsTrusting (key: ReturnType<typeof createSigningKey>) {
   return {
@@ -132,15 +163,15 @@ function envLockfile (): EnvLockfile {
   } as unknown as EnvLockfile
 }
 
-function mockPackument (name: string, integrity: string, signatures: unknown): void {
+function mockPackument (name: string, integrity: string, signatures: unknown, version: string = '9.1.0'): void {
   const encodedPath = name[0] === '@' ? `/${name.replace(/\//g, '%2F')}` : `/${name}`
   getMockAgent().get(REGISTRY.replace(/\/$/, ''))
     .intercept({ path: encodedPath, method: 'GET' })
     .reply(200, {
       name,
-      time: { '9.1.0': '2024-01-01T00:00:00.000Z' },
+      time: { [version]: '2024-01-01T00:00:00.000Z' },
       versions: {
-        '9.1.0': { name, version: '9.1.0', dist: { integrity, signatures, tarball: `${REGISTRY}${name}/-/x-9.1.0.tgz` } },
+        [version]: { name, version, dist: { integrity, signatures, tarball: `${REGISTRY}${name}/-/x-${version}.tgz` } },
       },
     }).persist()
 }

--- a/pnpm11/installing/env-installer/package.json
+++ b/pnpm11/installing/env-installer/package.json
@@ -39,6 +39,7 @@
     "@pnpm/constants": "workspace:*",
     "@pnpm/core-loggers": "workspace:*",
     "@pnpm/deps.graph-hasher": "workspace:*",
+    "@pnpm/deps.path": "workspace:*",
     "@pnpm/error": "workspace:*",
     "@pnpm/fs.read-modules-dir": "workspace:*",
     "@pnpm/fs.symlink-dependency": "workspace:*",

--- a/pnpm11/installing/env-installer/src/resolvePackageManagerIntegrities.ts
+++ b/pnpm11/installing/env-installer/src/resolvePackageManagerIntegrities.ts
@@ -1,3 +1,4 @@
+import { parseRegistryQualifiedVersion } from '@pnpm/deps.path'
 import { convertToLockfileFile, createEnvLockfile, readEnvLockfile } from '@pnpm/lockfile.fs'
 import { pruneSharedLockfile } from '@pnpm/lockfile.pruner'
 import type { EnvLockfile, LockfileObject } from '@pnpm/lockfile.types'
@@ -47,11 +48,10 @@ export function isPackageManagerResolved (
 /**
  * The packages the env lockfile pins for `pnpmVersion`.
  *
- * Both the JS `pnpm` and the native `@pnpm/exe` are pinned for the majors that
- * publish the two separately, because the pin is shared and teammates may run
- * either one. Outside that range only `pnpm` exists: before 6.17.1 `@pnpm/exe`
- * was not published yet, and from v12 the unscoped `pnpm` is itself the native
- * executable.
+ * `>=6.17.1 <12` publishes the JS `pnpm` and the native `@pnpm/exe` as two
+ * packages, and both are pinned, because the pin is shared and teammates may
+ * run either one. Every other version publishes `pnpm` alone: as the JS CLI
+ * below 6.17.1, and as the native executable itself from 12.
  */
 function packageManagerDeps (pnpmVersion: string): readonly string[] {
   const parsed = semver.parse(pnpmVersion, { loose: true })
@@ -115,10 +115,10 @@ export async function resolvePackageManagerIntegrities (
 }
 
 /**
- * Resolves the pnpm packages wanted by `spec`, which may be a range or a
- * dist-tag. `pnpm` alone is resolved first because which packages are wanted
- * (see {@link packageManagerDeps}) is only known once the spec has been
- * resolved to an exact version.
+ * Resolves the pnpm packages wanted by `spec`, which may also be a range or a
+ * dist-tag. A spec that is not an exact version is resolved through `pnpm`
+ * alone first, because which packages are wanted (see
+ * {@link packageManagerDeps}) is only known once the version is known.
  */
 async function resolveWantedPnpmPackages (
   spec: string,
@@ -130,18 +130,20 @@ async function resolveWantedPnpmPackages (
     storeController: opts.storeController,
     storeDir: opts.storeDir,
   }
+  if (semver.valid(spec) != null) {
+    return resolveManifestDependencies({ dependencies: wantedDependencies(spec, spec) }, resolveOpts)
+  }
   const lockfile = await resolveManifestDependencies({ dependencies: { pnpm: spec } }, resolveOpts)
-  const resolvedVersion = lockfile.importers['.' as ProjectId]?.dependencies?.['pnpm']
+  const ref = lockfile.importers['.' as ProjectId]?.dependencies?.['pnpm']
+  // A pnpm resolved from a named registry is referenced as `<registry>:<version>`.
+  const resolvedVersion = ref == null ? undefined : parseRegistryQualifiedVersion(ref)?.version ?? ref
   if (resolvedVersion == null || !packageManagerDeps(resolvedVersion).includes('@pnpm/exe')) {
     return lockfile
   }
-  return resolveManifestDependencies(
-    {
-      dependencies: {
-        'pnpm': spec,
-        '@pnpm/exe': spec,
-      },
-    },
-    resolveOpts
-  )
+  return resolveManifestDependencies({ dependencies: wantedDependencies(resolvedVersion, spec) }, resolveOpts)
+}
+
+/** The dependency map to resolve `spec` through, for a pnpm of `pnpmVersion`. */
+function wantedDependencies (pnpmVersion: string, spec: string): Record<string, string> {
+  return Object.fromEntries(packageManagerDeps(pnpmVersion).map((name) => [name, spec]))
 }

--- a/pnpm11/installing/env-installer/src/resolvePackageManagerIntegrities.ts
+++ b/pnpm11/installing/env-installer/src/resolvePackageManagerIntegrities.ts
@@ -1,12 +1,17 @@
 import { convertToLockfileFile, createEnvLockfile, readEnvLockfile } from '@pnpm/lockfile.fs'
 import { pruneSharedLockfile } from '@pnpm/lockfile.pruner'
-import type { EnvLockfile } from '@pnpm/lockfile.types'
+import type { EnvLockfile, LockfileObject } from '@pnpm/lockfile.types'
 import type { StoreController } from '@pnpm/store.controller'
 import type { DepPath, ProjectId, Registries } from '@pnpm/types'
+import semver from 'semver'
 
 import { convertToLockfileEnvObject } from './pruneEnvLockfile.js'
 import { resolveManifestDependencies } from './resolveManifestDependencies.js'
 import { writeVerifiedEnvLockfile } from './writeVerifiedEnvLockfile.js'
+
+const PACKAGE_MANAGER_DEPS_WITH_EXE = ['pnpm', '@pnpm/exe'] as const
+const PACKAGE_MANAGER_DEPS_PNPM_ONLY = ['pnpm'] as const
+const PNPM_EXE_INTRODUCED = '6.17.1'
 
 export interface ResolvePackageManagerIntegritiesOpts {
   envLockfile?: EnvLockfile
@@ -33,17 +38,39 @@ export function isPackageManagerResolved (
   if (!envLockfile) return false
 
   const pmDeps = envLockfile.importers['.'].packageManagerDependencies
-  return pmDeps != null &&
-    pmDeps['pnpm']?.version === pnpmVersion &&
-    pmDeps['@pnpm/exe']?.version === pnpmVersion
+  if (pmDeps == null) return false
+  const wantedDeps = packageManagerDeps(pnpmVersion)
+  return Object.keys(pmDeps).length === wantedDeps.length &&
+    wantedDeps.every((name) => pmDeps[name]?.version === pnpmVersion)
 }
 
 /**
- * Resolves integrity checksums for `pnpm`, `@pnpm/exe`, and their dependencies
- * by calling resolveManifestDependencies. When `opts.save` is true (the
- * default) the results are written to the `packageManagerDependencies`
- * section of `pnpm-lock.yaml`; when false, resolution happens purely in
- * memory and the returned `EnvLockfile` is never persisted to disk.
+ * The packages the env lockfile pins for `pnpmVersion`.
+ *
+ * Both the JS `pnpm` and the native `@pnpm/exe` are pinned for the majors that
+ * publish the two separately, because the pin is shared and teammates may run
+ * either one. Outside that range only `pnpm` exists: before 6.17.1 `@pnpm/exe`
+ * was not published yet, and from v12 the unscoped `pnpm` is itself the native
+ * executable.
+ */
+function packageManagerDeps (pnpmVersion: string): readonly string[] {
+  const parsed = semver.parse(pnpmVersion, { loose: true })
+  if (parsed == null) return PACKAGE_MANAGER_DEPS_WITH_EXE
+  if (parsed.major >= 12) return PACKAGE_MANAGER_DEPS_PNPM_ONLY
+  // Prereleases of a version that has `@pnpm/exe` ship it too, so compare on
+  // the release triple alone.
+  return semver.gte(`${parsed.major}.${parsed.minor}.${parsed.patch}`, PNPM_EXE_INTRODUCED)
+    ? PACKAGE_MANAGER_DEPS_WITH_EXE
+    : PACKAGE_MANAGER_DEPS_PNPM_ONLY
+}
+
+/**
+ * Resolves integrity checksums for the pnpm packages of the wanted version
+ * (see {@link packageManagerDeps}) and their dependencies by calling
+ * resolveManifestDependencies. When `opts.save` is true (the default) the
+ * results are written to the `packageManagerDependencies` section of
+ * `pnpm-lock.yaml`; when false, resolution happens purely in memory and the
+ * returned `EnvLockfile` is never persisted to disk.
  */
 export async function resolvePackageManagerIntegrities (
   pnpmVersion: string,
@@ -56,20 +83,7 @@ export async function resolvePackageManagerIntegrities (
     return envLockfile
   }
 
-  const lockfile = await resolveManifestDependencies(
-    {
-      dependencies: {
-        'pnpm': pnpmVersion,
-        '@pnpm/exe': pnpmVersion,
-      },
-    },
-    {
-      dir: opts.rootDir,
-      registries: opts.registries,
-      storeController: opts.storeController,
-      storeDir: opts.storeDir,
-    }
-  )
+  const lockfile = await resolveWantedPnpmPackages(pnpmVersion, opts)
 
   if (lockfile.packages) {
     // Build packageManagerDependencies from the resolved lockfile importers
@@ -98,4 +112,36 @@ export async function resolvePackageManagerIntegrities (
     }
   }
   return envLockfile
+}
+
+/**
+ * Resolves the pnpm packages wanted by `spec`, which may be a range or a
+ * dist-tag. `pnpm` alone is resolved first because which packages are wanted
+ * (see {@link packageManagerDeps}) is only known once the spec has been
+ * resolved to an exact version.
+ */
+async function resolveWantedPnpmPackages (
+  spec: string,
+  opts: ResolvePackageManagerIntegritiesOpts
+): Promise<LockfileObject> {
+  const resolveOpts = {
+    dir: opts.rootDir,
+    registries: opts.registries,
+    storeController: opts.storeController,
+    storeDir: opts.storeDir,
+  }
+  const lockfile = await resolveManifestDependencies({ dependencies: { pnpm: spec } }, resolveOpts)
+  const resolvedVersion = lockfile.importers['.' as ProjectId]?.dependencies?.['pnpm']
+  if (resolvedVersion == null || !packageManagerDeps(resolvedVersion).includes('@pnpm/exe')) {
+    return lockfile
+  }
+  return resolveManifestDependencies(
+    {
+      dependencies: {
+        'pnpm': spec,
+        '@pnpm/exe': spec,
+      },
+    },
+    resolveOpts
+  )
 }

--- a/pnpm11/installing/env-installer/test/resolvePackageManagerIntegrities.test.ts
+++ b/pnpm11/installing/env-installer/test/resolvePackageManagerIntegrities.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@jest/globals'
+import { isPackageManagerResolved } from '@pnpm/installing.env-installer'
+import type { EnvLockfile } from '@pnpm/lockfile.types'
+
+test('the JS pnpm and @pnpm/exe are both pinned for the majors that publish them separately', () => {
+  expect(isPackageManagerResolved(envLockfile({ 'pnpm': '11.0.0', '@pnpm/exe': '11.0.0' }), '11.0.0')).toBe(true)
+  expect(isPackageManagerResolved(envLockfile({ pnpm: '11.0.0' }), '11.0.0')).toBe(false)
+  expect(isPackageManagerResolved(envLockfile({ 'pnpm': '6.17.1', '@pnpm/exe': '6.17.1' }), '6.17.1')).toBe(true)
+})
+
+test('only pnpm is pinned from v12, where the unscoped pnpm is itself the executable', () => {
+  expect(isPackageManagerResolved(envLockfile({ pnpm: '12.0.0' }), '12.0.0')).toBe(true)
+  expect(isPackageManagerResolved(envLockfile({ 'pnpm': '12.0.0', '@pnpm/exe': '12.0.0' }), '12.0.0')).toBe(false)
+})
+
+test('only pnpm is pinned before @pnpm/exe was published', () => {
+  expect(isPackageManagerResolved(envLockfile({ pnpm: '6.16.0' }), '6.16.0')).toBe(true)
+})
+
+test('an env lockfile pinning another pnpm version is not resolved', () => {
+  expect(isPackageManagerResolved(envLockfile({ pnpm: '12.0.0' }), '12.1.0')).toBe(false)
+  expect(isPackageManagerResolved(undefined, '12.0.0')).toBe(false)
+})
+
+function envLockfile (packageManagerDependencies: Record<string, string>): EnvLockfile {
+  return {
+    lockfileVersion: '9.0',
+    importers: {
+      '.': {
+        configDependencies: {},
+        packageManagerDependencies: Object.fromEntries(
+          Object.entries(packageManagerDependencies).map(([name, version]) => [name, { specifier: version, version }])
+        ),
+      },
+    },
+    packages: {},
+    snapshots: {},
+  } as unknown as EnvLockfile
+}

--- a/pnpm11/installing/env-installer/tsconfig.json
+++ b/pnpm11/installing/env-installer/tsconfig.json
@@ -37,6 +37,9 @@
       "path": "../../deps/graph-hasher"
     },
     {
+      "path": "../../deps/path"
+    },
+    {
       "path": "../../fs/read-modules-dir"
     },
     {


### PR DESCRIPTION
## Summary

From pnpm v12 the unscoped `pnpm` package is itself the native executable — the CLI no longer ships a separate `@pnpm/exe` wrapper. The env lockfile, however, always pinned both `pnpm` and `@pnpm/exe` under `packageManagerDependencies`, so a v12 pin would try to resolve a package that is not published for that version.

Both stacks now pick the package set from the wanted version: `pnpm` alone from v12 (and before 6.17.1, where `@pnpm/exe` did not exist yet), both packages in between.

One consequence needed fixing along with it: the native-binary leg of the engine identity check looked up the host's platform package under `@pnpm/exe` by name. With `@pnpm/exe` absent from a v12 lockfile that leg silently verified nothing, leaving the bytes that actually execute unchecked. It now follows whichever package carries the platform binary as an optional dependency — `@pnpm/exe` for the majors that publish it, the unscoped `pnpm` from v12.

On the TypeScript side `resolvePackageManagerIntegrities` is also called with a range or dist-tag (`pnpm with latest`), where the package set is not known up front. It now resolves `pnpm` first and only runs the second resolution for versions that do ship `@pnpm/exe`. The Rust entry point already receives an exact version, so it needs no such step.

Noticed while working here, left alone as out of scope: when the platform binary is missing from the lockfile, pacquet fails closed but the TypeScript CLI skips it silently.

## Squash Commit Body

```text
From v12 the unscoped `pnpm` package is itself the native executable, so
`@pnpm/exe` is no longer published alongside it. The env lockfile now pins
only `pnpm` for those versions, in both stacks, instead of resolving a
package that does not exist.

The native-binary leg of the engine identity check followed `@pnpm/exe`
by name, so it silently verified nothing once that package is absent. It
now follows whichever package carries the host's platform binary as an
optional dependency: `@pnpm/exe` for the majors that publish it, the
unscoped `pnpm` from v12.

On the TypeScript side the wanted version can arrive as a range or a
dist-tag (`pnpm with latest`), so `pnpm` is resolved first and the second
resolution only happens for the versions that do ship `@pnpm/exe`.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788308289&installation_model_id=426870&pr_number=13599&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13599&signature=bd5b1da625142c8d3da60cc51618d95d0bc8768550da97d34cf29cbf3a405c60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved self-update verification for pnpm 12 and later by correctly identifying and validating the platform-specific native executable.
  * Updated environment installation and lockfile handling to support pnpm’s version-dependent executable packaging.
  * Preserved compatibility with older pnpm releases, including versions that use a separate executable package.
  * Added safeguards for missing, incomplete, or outdated lockfile metadata during installation and updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->