### PR TITLE
perf(lockfile): record inert setting changes without resolving

### DIFF
--- a/.changeset/ignored-optional-dependencies-order-preserved.md
+++ b/.changeset/ignored-optional-dependencies-order-preserved.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/lockfile.settings-checker": patch
+"pnpm": patch
+---
+
+Checking whether `ignoredOptionalDependencies` is up to date no longer reorders the configured patterns. The check sorted them in place, which could move an `!` exclusion ahead of the pattern it excludes from and flip which optional dependencies were ignored.

--- a/.changeset/inert-lockfile-setting-updates.md
+++ b/.changeset/inert-lockfile-setting-updates.md
@@ -1,0 +1,9 @@
+---
+"@pnpm/lockfile.settings-checker": minor
+"@pnpm/installing.deps-installer": patch
+"@pnpm/lockfile.fs": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+Changing `autoInstallPeers`, `dedupePeers`, `peersSuffixMaxLength`, `excludeLinksFromLockfile`, or `injectWorkspacePackages` no longer re-resolves the dependency graph when the lockfile proves the setting cannot affect it: no package or project declares a peer dependency for the peer settings, and no project depends on a directory or on another workspace project for the link and injection settings. The new setting is recorded in `pnpm-lock.yaml` and the install proceeds from the existing resolution. Every other case still falls back to a full resolution.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7015,6 +7015,9 @@ importers:
         specifier: 'catalog:'
         version: '@pnpm/ramda@0.28.1'
     devDependencies:
+      '@jest/globals':
+        specifier: 'catalog:'
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/lockfile.settings-checker':
         specifier: workspace:*
         version: 'link:'

--- a/pnpm/crates/cli/tests/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/lockfile_resolution_reuse.rs
@@ -778,7 +778,7 @@ fn peer_setting_change_on_a_peerless_lockfile_skips_resolution() {
 fn peer_setting_change_falls_back_when_the_lockfile_records_peers() {
     let CommandTempCwd { workspace, root, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();
-    let AddMockedRegistry { mock_instance, npmrc_path, .. } = npmrc_info;
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
     fs::write(
         workspace.join("package.json"),
         serde_json::json!({
@@ -802,16 +802,10 @@ fn peer_setting_change_falls_back_when_the_lockfile_records_peers() {
     let workspace_yaml = fs::read_to_string(&workspace_yaml_path).expect("read workspace yaml");
     fs::write(&workspace_yaml_path, format!("{workspace_yaml}dedupePeers: true\n"))
         .expect("turn dedupePeers on");
-    let dead_registry = dead_registry_url();
-    let npmrc = fs::read_to_string(&npmrc_path).expect("read .npmrc");
-    let npmrc = npmrc
-        .lines()
-        .filter(|line| !line.trim_start().starts_with("registry="))
-        .collect::<Vec<_>>()
-        .join("\n");
-    fs::write(&npmrc_path, format!("registry={dead_registry}\n{npmrc}\n"))
-        .expect("rewrite .npmrc with a dead registry");
 
+    // Unlike the peerless sibling above, this install has to resolve, so it
+    // keeps the mocked registry reachable: pointing it at a dead one would
+    // only assert that the resolve happened to be satisfiable offline.
     let assert = pacquet_at(&workspace).with_arg("install").assert().success();
     assert!(
         !String::from_utf8_lossy(&assert.get_output().stdout)

--- a/pnpm/crates/cli/tests/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/lockfile_resolution_reuse.rs
@@ -717,3 +717,107 @@ fn reinstalling_an_unchanged_manifest_keeps_the_lockfile_byte_identical() {
 
     drop(project);
 }
+
+#[test]
+fn peer_setting_change_on_a_peerless_lockfile_skips_resolution() {
+    let CommandTempCwd { workspace, root, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, npmrc_path, .. } = npmrc_info;
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pkg-with-1-dep": "100.0.0"
+            }
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    fs::write(
+        &workspace_yaml_path,
+        format!("{workspace_yaml}trustLockfile: true\nfetchRetries: 0\nfetchTimeout: 1000\n"),
+    )
+    .expect("enable trusted lockfile");
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    let workspace_yaml = fs::read_to_string(&workspace_yaml_path).expect("read workspace yaml");
+    fs::write(&workspace_yaml_path, format!("{workspace_yaml}dedupePeers: true\n"))
+        .expect("turn dedupePeers on");
+    let dead_registry = dead_registry_url();
+    let npmrc = fs::read_to_string(&npmrc_path).expect("read .npmrc");
+    let npmrc = npmrc
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("registry="))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(&npmrc_path, format!("registry={dead_registry}\n{npmrc}\n"))
+        .expect("rewrite .npmrc with a dead registry");
+
+    let assert = pacquet_at(&workspace).with_arg("install").assert().success();
+    assert!(
+        String::from_utf8_lossy(&assert.get_output().stdout)
+            .contains("Lockfile is up to date, resolution step is skipped"),
+    );
+
+    let wanted = pacquet_lockfile::Lockfile::load_wanted_from_dir(&workspace)
+        .expect("load wanted lockfile")
+        .expect("wanted lockfile");
+    assert_eq!(
+        wanted.settings.expect("recorded settings").dedupe_peers,
+        Some(true),
+        "the changed setting must be recorded without resolving",
+    );
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn peer_setting_change_falls_back_when_the_lockfile_records_peers() {
+    let CommandTempCwd { workspace, root, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, npmrc_path, .. } = npmrc_info;
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/has-optional-peer-with-peer": "^1.0.0"
+            }
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    fs::write(
+        &workspace_yaml_path,
+        format!("{workspace_yaml}trustLockfile: true\nfetchRetries: 0\nfetchTimeout: 1000\n"),
+    )
+    .expect("enable trusted lockfile");
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    let workspace_yaml = fs::read_to_string(&workspace_yaml_path).expect("read workspace yaml");
+    fs::write(&workspace_yaml_path, format!("{workspace_yaml}dedupePeers: true\n"))
+        .expect("turn dedupePeers on");
+    let dead_registry = dead_registry_url();
+    let npmrc = fs::read_to_string(&npmrc_path).expect("read .npmrc");
+    let npmrc = npmrc
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("registry="))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(&npmrc_path, format!("registry={dead_registry}\n{npmrc}\n"))
+        .expect("rewrite .npmrc with a dead registry");
+
+    let assert = pacquet_at(&workspace).with_arg("install").assert().success();
+    assert!(
+        !String::from_utf8_lossy(&assert.get_output().stdout)
+            .contains("Lockfile is up to date, resolution step is skipped"),
+        "a peer setting change over a peer-suffixed graph must go through resolution",
+    );
+
+    drop((root, mock_instance));
+}

--- a/pnpm/crates/lockfile/src/freshness.rs
+++ b/pnpm/crates/lockfile/src/freshness.rs
@@ -440,7 +440,7 @@ pub fn check_lockfile_settings(
     // setting it was written under, so there is nothing to compare —
     // pnpm's `lockfile.settings?.autoInstallPeers != null` guard.
     if let Some(settings) = lockfile.settings.as_ref()
-        && settings.auto_install_peers != auto_install_peers
+        && auto_install_peers_changed(Some(settings), auto_install_peers)
     {
         return Err(StalenessReason::AutoInstallPeersChanged {
             lockfile: settings.auto_install_peers,
@@ -448,8 +448,7 @@ pub fn check_lockfile_settings(
         });
     }
 
-    let lockfile_dedupe_peers =
-        lockfile.settings.as_ref().and_then(|settings| settings.dedupe_peers).unwrap_or(false);
+    let lockfile_dedupe_peers = recorded_dedupe_peers(lockfile.settings.as_ref());
     if lockfile_dedupe_peers != dedupe_peers {
         return Err(StalenessReason::DedupePeersChanged {
             lockfile: lockfile_dedupe_peers,
@@ -458,7 +457,7 @@ pub fn check_lockfile_settings(
     }
 
     if let Some(settings) = lockfile.settings.as_ref()
-        && settings.exclude_links_from_lockfile != exclude_links_from_lockfile
+        && exclude_links_from_lockfile_changed(Some(settings), exclude_links_from_lockfile)
     {
         return Err(StalenessReason::ExcludeLinksFromLockfileChanged {
             lockfile: settings.exclude_links_from_lockfile,
@@ -466,11 +465,8 @@ pub fn check_lockfile_settings(
         });
     }
 
-    let lockfile_peers_suffix_max_length = lockfile
-        .settings
-        .as_ref()
-        .and_then(|s| s.peers_suffix_max_length)
-        .unwrap_or(crate::DEFAULT_PEERS_SUFFIX_MAX_LENGTH);
+    let lockfile_peers_suffix_max_length =
+        recorded_peers_suffix_max_length(lockfile.settings.as_ref());
     if lockfile_peers_suffix_max_length != peers_suffix_max_length {
         return Err(StalenessReason::PeersSuffixMaxLengthChanged {
             lockfile: lockfile_peers_suffix_max_length,
@@ -487,8 +483,7 @@ pub fn check_lockfile_settings(
         });
     }
 
-    let lockfile_inject =
-        lockfile.settings.as_ref().is_some_and(|settings| settings.inject_workspace_packages);
+    let lockfile_inject = recorded_inject_workspace_packages(lockfile.settings.as_ref());
     if lockfile_inject != inject_workspace_packages {
         return Err(StalenessReason::InjectWorkspacePackagesChanged {
             lockfile: lockfile_inject,
@@ -497,6 +492,51 @@ pub fn check_lockfile_settings(
     }
 
     Ok(())
+}
+
+/// Whether `settings.autoInstallPeers` drifted from what the lockfile
+/// records. A lockfile with no `settings` block records nothing about
+/// the setting it was written under, so there is nothing to compare.
+///
+/// This and its four peers below are the single definition of "this
+/// lockfile setting changed", shared with the fast path that records a
+/// provably inert setting change without re-resolving.
+#[must_use]
+pub fn auto_install_peers_changed(
+    recorded: Option<&crate::LockfileSettings>,
+    auto_install_peers: bool,
+) -> bool {
+    recorded.is_some_and(|settings| settings.auto_install_peers != auto_install_peers)
+}
+
+/// See [`auto_install_peers_changed`].
+#[must_use]
+pub fn exclude_links_from_lockfile_changed(
+    recorded: Option<&crate::LockfileSettings>,
+    exclude_links_from_lockfile: bool,
+) -> bool {
+    recorded
+        .is_some_and(|settings| settings.exclude_links_from_lockfile != exclude_links_from_lockfile)
+}
+
+/// See [`auto_install_peers_changed`].
+#[must_use]
+pub fn recorded_dedupe_peers(recorded: Option<&crate::LockfileSettings>) -> bool {
+    recorded.and_then(|settings| settings.dedupe_peers).unwrap_or(false)
+}
+
+/// See [`auto_install_peers_changed`].
+#[must_use]
+pub fn recorded_peers_suffix_max_length(recorded: Option<&crate::LockfileSettings>) -> u64 {
+    recorded
+        .and_then(|settings| settings.peers_suffix_max_length)
+        .unwrap_or(crate::DEFAULT_PEERS_SUFFIX_MAX_LENGTH)
+}
+
+/// See [`auto_install_peers_changed`].
+#[must_use]
+pub fn recorded_inject_workspace_packages(recorded: Option<&crate::LockfileSettings>) -> bool {
+    recorded.is_some_and(|settings| settings.inject_workspace_packages)
 }
 
 fn all_catalogs_are_up_to_date(

--- a/pnpm/crates/package-manager/src/fast_update_settings.rs
+++ b/pnpm/crates/package-manager/src/fast_update_settings.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 /// The `settings` block an install under `config` records, matching
-/// what [`crate::dependencies_graph_to_lockfile`] writes after a full
+/// what [`fn@crate::dependencies_graph_to_lockfile`] writes after a full
 /// resolution.
 pub(crate) fn lockfile_settings_from_config(config: &Config) -> LockfileSettings {
     LockfileSettings {

--- a/pnpm/crates/package-manager/src/fast_update_settings.rs
+++ b/pnpm/crates/package-manager/src/fast_update_settings.rs
@@ -1,0 +1,224 @@
+use pacquet_config::Config;
+use pacquet_lockfile::{ImporterDepVersion, Lockfile, LockfileSettings, ProjectSnapshot};
+use pacquet_package_manifest::{DependencyGroup, PackageManifest};
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+};
+
+/// The `settings` block an install under `config` records, matching
+/// what [`crate::dependencies_graph_to_lockfile`] writes after a full
+/// resolution.
+pub(crate) fn lockfile_settings_from_config(config: &Config) -> LockfileSettings {
+    LockfileSettings {
+        auto_install_peers: config.auto_install_peers,
+        dedupe_peers: config.dedupe_peers.then_some(true),
+        exclude_links_from_lockfile: config.exclude_links_from_lockfile,
+        inject_workspace_packages: config.inject_workspace_packages,
+        peers_suffix_max_length: (config.peers_suffix_max_length
+            != pacquet_config::default_peers_suffix_max_length())
+        .then_some(config.peers_suffix_max_length),
+    }
+}
+
+/// A lockfile setting whose recorded value no longer matches the
+/// current configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ChangedSetting {
+    AutoInstallPeers,
+    DedupePeers,
+    ExcludeLinksFromLockfile,
+    PeersSuffixMaxLength,
+    InjectWorkspacePackages,
+}
+
+/// Record a changed lockfile setting without resolving the dependency
+/// graph, for the settings that the lockfile itself proves cannot
+/// affect its graph: the peer settings when nothing declares a peer
+/// dependency, and the link and injection settings when no project
+/// depends on a directory or on another workspace project.
+///
+/// `None` — nothing changed, or a changed setting could affect the
+/// graph — leaves the caller on the full-resolution path.
+pub(crate) fn try_fast_update_settings(
+    lockfile: &Lockfile,
+    settings: &LockfileSettings,
+    manifests: &[(PathBuf, &PackageManifest)],
+) -> Option<Lockfile> {
+    let changed = changed_settings(lockfile.settings.as_ref(), settings);
+    if changed.is_empty() {
+        return None;
+    }
+    let workspace_package_names = workspace_package_names(manifests);
+    if !changed.iter().all(|setting| {
+        setting_cannot_affect_lockfile(*setting, lockfile, manifests, &workspace_package_names)
+    }) {
+        return None;
+    }
+    let mut candidate = lockfile.clone();
+    candidate.settings = Some(settings.clone());
+    Some(candidate)
+}
+
+fn changed_settings(
+    recorded: Option<&LockfileSettings>,
+    settings: &LockfileSettings,
+) -> Vec<ChangedSetting> {
+    let mut changed = Vec::new();
+    if pacquet_lockfile::auto_install_peers_changed(recorded, settings.auto_install_peers) {
+        changed.push(ChangedSetting::AutoInstallPeers);
+    }
+    if pacquet_lockfile::recorded_dedupe_peers(recorded)
+        != pacquet_lockfile::recorded_dedupe_peers(Some(settings))
+    {
+        changed.push(ChangedSetting::DedupePeers);
+    }
+    if pacquet_lockfile::exclude_links_from_lockfile_changed(
+        recorded,
+        settings.exclude_links_from_lockfile,
+    ) {
+        changed.push(ChangedSetting::ExcludeLinksFromLockfile);
+    }
+    if pacquet_lockfile::recorded_peers_suffix_max_length(recorded)
+        != pacquet_lockfile::recorded_peers_suffix_max_length(Some(settings))
+    {
+        changed.push(ChangedSetting::PeersSuffixMaxLength);
+    }
+    if pacquet_lockfile::recorded_inject_workspace_packages(recorded)
+        != pacquet_lockfile::recorded_inject_workspace_packages(Some(settings))
+    {
+        changed.push(ChangedSetting::InjectWorkspacePackages);
+    }
+    changed
+}
+
+fn setting_cannot_affect_lockfile(
+    setting: ChangedSetting,
+    lockfile: &Lockfile,
+    manifests: &[(PathBuf, &PackageManifest)],
+    workspace_package_names: &HashSet<String>,
+) -> bool {
+    match setting {
+        ChangedSetting::AutoInstallPeers
+        | ChangedSetting::DedupePeers
+        | ChangedSetting::PeersSuffixMaxLength => has_no_peer_dependencies(lockfile, manifests),
+        ChangedSetting::ExcludeLinksFromLockfile => {
+            has_no_linked_dependencies(lockfile, manifests, workspace_package_names)
+        }
+        ChangedSetting::InjectWorkspacePackages => {
+            has_no_injectable_dependencies(lockfile, manifests, workspace_package_names)
+        }
+    }
+}
+
+/// All three peer settings only change how peer dependencies are
+/// resolved, deduplicated, and hashed into depPath suffixes. None of
+/// them has anything to act on when no package or project declares a
+/// peer dependency and no depPath carries a peers suffix.
+fn has_no_peer_dependencies(
+    lockfile: &Lockfile,
+    manifests: &[(PathBuf, &PackageManifest)],
+) -> bool {
+    let peerless_packages = lockfile.packages.iter().flatten().all(|(key, metadata)| {
+        key.suffix.peer().is_empty()
+            && metadata.peer_dependencies.as_ref().is_none_or(HashMap::is_empty)
+            && metadata.peer_dependencies_meta.as_ref().is_none_or(HashMap::is_empty)
+    });
+    let peerless_snapshots = lockfile.snapshots.iter().flatten().all(|(key, snapshot)| {
+        key.suffix.peer().is_empty()
+            && snapshot.transitive_peer_dependencies.as_ref().is_none_or(Vec::is_empty)
+    });
+    peerless_packages
+        && peerless_snapshots
+        && manifests
+            .iter()
+            .all(|(_, manifest)| manifest.dependencies([DependencyGroup::Peer]).next().is_none())
+}
+
+/// `excludeLinksFromLockfile` decides whether a dependency that
+/// resolves to a directory is recorded in the lockfile. Dependencies
+/// declared with the `workspace:` protocol are recorded either way, so
+/// only the other directory dependencies matter — including plain
+/// ranges that `linkWorkspacePackages` turns into links to a workspace
+/// project.
+fn has_no_linked_dependencies(
+    lockfile: &Lockfile,
+    manifests: &[(PathBuf, &PackageManifest)],
+    workspace_package_names: &HashSet<String>,
+) -> bool {
+    !lockfile.importers.values().any(has_directory_reference)
+        && manifests.iter().all(|(_, manifest)| {
+            manifest.dependencies(DEPENDENCY_GROUPS).all(|(alias, bare_specifier)| {
+                bare_specifier.starts_with("workspace:")
+                    || !is_directory_dependency(alias, bare_specifier, workspace_package_names)
+            })
+        })
+}
+
+/// `injectWorkspacePackages` replaces the symlinks to workspace
+/// projects with hard-linked copies, which the lockfile records as
+/// directory dependencies of the importer. An install with no
+/// dependency on any workspace project has nothing to inject.
+fn has_no_injectable_dependencies(
+    lockfile: &Lockfile,
+    manifests: &[(PathBuf, &PackageManifest)],
+    workspace_package_names: &HashSet<String>,
+) -> bool {
+    !lockfile.importers.values().any(has_directory_reference)
+        && manifests.iter().all(|(_, manifest)| {
+            !declares_injected_dependency(manifest)
+                && manifest.dependencies(DEPENDENCY_GROUPS).all(|(alias, bare_specifier)| {
+                    !is_directory_dependency(alias, bare_specifier, workspace_package_names)
+                })
+        })
+}
+
+fn is_directory_dependency(
+    alias: &str,
+    bare_specifier: &str,
+    workspace_package_names: &HashSet<String>,
+) -> bool {
+    bare_specifier.starts_with("workspace:")
+        || bare_specifier.starts_with("link:")
+        || bare_specifier.starts_with("file:")
+        || workspace_package_names.contains(alias)
+}
+
+fn has_directory_reference(importer: &ProjectSnapshot) -> bool {
+    [&importer.dependencies, &importer.dev_dependencies, &importer.optional_dependencies]
+        .into_iter()
+        .flatten()
+        .flatten()
+        .any(|(_, dependency)| {
+            matches!(dependency.version, ImporterDepVersion::Link(_) | ImporterDepVersion::File(_))
+        })
+}
+
+fn declares_injected_dependency(manifest: &PackageManifest) -> bool {
+    manifest.value().get("dependenciesMeta").and_then(serde_json::Value::as_object).is_some_and(
+        |entries| {
+            entries.values().any(|meta| {
+                meta.get("injected").and_then(serde_json::Value::as_bool).unwrap_or(false)
+            })
+        },
+    )
+}
+
+fn workspace_package_names(manifests: &[(PathBuf, &PackageManifest)]) -> HashSet<String> {
+    manifests
+        .iter()
+        .filter_map(|(_, manifest)| {
+            manifest
+                .value()
+                .get("name")
+                .and_then(serde_json::Value::as_str)
+                .map(ToString::to_string)
+        })
+        .collect()
+}
+
+const DEPENDENCY_GROUPS: [DependencyGroup; 3] =
+    [DependencyGroup::Dev, DependencyGroup::Prod, DependencyGroup::Optional];
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/package-manager/src/fast_update_settings/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_settings/tests.rs
@@ -1,0 +1,290 @@
+use super::try_fast_update_settings;
+use pacquet_lockfile::{Lockfile, LockfileSettings};
+use pacquet_package_manifest::PackageManifest;
+use serde_json::{Value, json};
+use std::path::PathBuf;
+
+const PEERLESS_LOCKFILE: &str = r"
+lockfileVersion: '9.0'
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+importers:
+  .:
+    dependencies:
+      foo:
+        specifier: ^1.0.0
+        version: 1.1.0
+packages:
+  foo@1.1.0:
+    resolution:
+      integrity: sha512-deadbeef
+snapshots:
+  foo@1.1.0: {}
+";
+
+fn lockfile(source: &str) -> Lockfile {
+    serde_saphyr::from_str(source).expect("parse lockfile")
+}
+
+fn manifest(value: Value) -> PackageManifest {
+    PackageManifest::from_value(PathBuf::from("/project/package.json"), value)
+}
+
+fn recorded_settings() -> LockfileSettings {
+    LockfileSettings {
+        auto_install_peers: true,
+        dedupe_peers: None,
+        exclude_links_from_lockfile: false,
+        inject_workspace_packages: false,
+        peers_suffix_max_length: None,
+    }
+}
+
+#[test]
+fn records_every_setting_the_locked_graph_cannot_notice() {
+    let manifest = manifest(json!({ "dependencies": { "foo": "^1.0.0" } }));
+    let settings = LockfileSettings {
+        auto_install_peers: false,
+        dedupe_peers: Some(true),
+        exclude_links_from_lockfile: true,
+        inject_workspace_packages: true,
+        peers_suffix_max_length: Some(10),
+    };
+
+    let updated = try_fast_update_settings(
+        &lockfile(PEERLESS_LOCKFILE),
+        &settings,
+        &[(PathBuf::from("/project"), &manifest)],
+    )
+    .expect("a peerless, linkless lockfile absorbs every setting change");
+    assert_eq!(updated.settings, Some(settings));
+}
+
+#[test]
+fn rejects_a_peer_setting_when_a_package_declares_peer_dependencies() {
+    let manifest = manifest(json!({ "dependencies": { "foo": "^1.0.0" } }));
+    let lockfile = lockfile(
+        r"
+lockfileVersion: '9.0'
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+importers:
+  .:
+    dependencies:
+      foo:
+        specifier: ^1.0.0
+        version: 1.1.0
+packages:
+  foo@1.1.0:
+    resolution:
+      integrity: sha512-deadbeef
+    peerDependencies:
+      bar: ^1.0.0
+snapshots:
+  foo@1.1.0: {}
+",
+    );
+    let settings = LockfileSettings { dedupe_peers: Some(true), ..recorded_settings() };
+
+    assert!(
+        try_fast_update_settings(&lockfile, &settings, &[(PathBuf::from("/project"), &manifest)])
+            .is_none()
+    );
+}
+
+#[test]
+fn rejects_a_peer_setting_when_a_snapshot_key_carries_a_peers_suffix() {
+    let manifest = manifest(json!({ "dependencies": { "foo": "^1.0.0" } }));
+    let lockfile = lockfile(
+        r"
+lockfileVersion: '9.0'
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+importers:
+  .:
+    dependencies:
+      foo:
+        specifier: ^1.0.0
+        version: 1.1.0(bar@1.0.0)
+packages:
+  foo@1.1.0:
+    resolution:
+      integrity: sha512-deadbeef
+snapshots:
+  foo@1.1.0(bar@1.0.0): {}
+",
+    );
+    let settings = LockfileSettings { peers_suffix_max_length: Some(10), ..recorded_settings() };
+
+    assert!(
+        try_fast_update_settings(&lockfile, &settings, &[(PathBuf::from("/project"), &manifest)])
+            .is_none()
+    );
+}
+
+#[test]
+fn rejects_a_peer_setting_when_a_project_declares_peer_dependencies() {
+    let manifest = manifest(json!({
+        "dependencies": { "foo": "^1.0.0" },
+        "peerDependencies": { "bar": "^1.0.0" },
+    }));
+    let settings = LockfileSettings { auto_install_peers: false, ..recorded_settings() };
+
+    assert!(
+        try_fast_update_settings(
+            &lockfile(PEERLESS_LOCKFILE),
+            &settings,
+            &[(PathBuf::from("/project"), &manifest)],
+        )
+        .is_none()
+    );
+}
+
+#[test]
+fn rejects_exclude_links_when_a_project_depends_on_a_directory() {
+    let manifest = manifest(json!({ "dependencies": { "bar": "link:../bar", "foo": "^1.0.0" } }));
+    let settings = LockfileSettings { exclude_links_from_lockfile: true, ..recorded_settings() };
+
+    assert!(
+        try_fast_update_settings(
+            &lockfile(PEERLESS_LOCKFILE),
+            &settings,
+            &[(PathBuf::from("/project"), &manifest)],
+        )
+        .is_none()
+    );
+}
+
+#[test]
+fn rejects_exclude_links_when_the_lockfile_records_a_link() {
+    let manifest = manifest(json!({ "dependencies": { "foo": "^1.0.0" } }));
+    let lockfile = lockfile(
+        r"
+lockfileVersion: '9.0'
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+importers:
+  .:
+    dependencies:
+      bar:
+        specifier: link:../bar
+        version: link:../bar
+",
+    );
+    let settings = LockfileSettings { exclude_links_from_lockfile: true, ..recorded_settings() };
+
+    assert!(
+        try_fast_update_settings(&lockfile, &settings, &[(PathBuf::from("/project"), &manifest)])
+            .is_none()
+    );
+}
+
+#[test]
+fn records_exclude_links_when_the_only_workspace_dependency_uses_the_workspace_protocol() {
+    let root = manifest(json!({
+        "name": "root",
+        "dependencies": { "bar": "workspace:*", "foo": "^1.0.0" },
+    }));
+    let sibling = manifest(json!({ "name": "bar" }));
+    let settings = LockfileSettings { exclude_links_from_lockfile: true, ..recorded_settings() };
+
+    assert!(
+        try_fast_update_settings(
+            &lockfile(PEERLESS_LOCKFILE),
+            &settings,
+            &[(PathBuf::from("/project"), &root), (PathBuf::from("/project/bar"), &sibling)],
+        )
+        .is_some()
+    );
+}
+
+#[test]
+fn rejects_exclude_links_when_a_workspace_project_is_depended_on_by_range() {
+    let root =
+        manifest(json!({ "name": "root", "dependencies": { "bar": "^1.0.0", "foo": "^1.0.0" } }));
+    let sibling = manifest(json!({ "name": "bar" }));
+    let settings = LockfileSettings { exclude_links_from_lockfile: true, ..recorded_settings() };
+
+    assert!(
+        try_fast_update_settings(
+            &lockfile(PEERLESS_LOCKFILE),
+            &settings,
+            &[(PathBuf::from("/project"), &root), (PathBuf::from("/project/bar"), &sibling)],
+        )
+        .is_none()
+    );
+}
+
+#[test]
+fn rejects_inject_workspace_packages_when_a_workspace_project_is_depended_on() {
+    let root = manifest(json!({
+        "name": "root",
+        "dependencies": { "bar": "workspace:*", "foo": "^1.0.0" },
+    }));
+    let sibling = manifest(json!({ "name": "bar" }));
+    let settings = LockfileSettings { inject_workspace_packages: true, ..recorded_settings() };
+
+    assert!(
+        try_fast_update_settings(
+            &lockfile(PEERLESS_LOCKFILE),
+            &settings,
+            &[(PathBuf::from("/project"), &root), (PathBuf::from("/project/bar"), &sibling)],
+        )
+        .is_none()
+    );
+}
+
+#[test]
+fn rejects_inject_workspace_packages_when_a_dependency_is_already_injected() {
+    let manifest = manifest(json!({
+        "dependencies": { "foo": "^1.0.0" },
+        "dependenciesMeta": { "foo": { "injected": true } },
+    }));
+    let settings = LockfileSettings { inject_workspace_packages: true, ..recorded_settings() };
+
+    assert!(
+        try_fast_update_settings(
+            &lockfile(PEERLESS_LOCKFILE),
+            &settings,
+            &[(PathBuf::from("/project"), &manifest)],
+        )
+        .is_none()
+    );
+}
+
+#[test]
+fn rejects_a_group_of_changed_settings_when_one_of_them_is_unsafe() {
+    let manifest = manifest(json!({ "dependencies": { "bar": "link:../bar", "foo": "^1.0.0" } }));
+    let settings = LockfileSettings {
+        dedupe_peers: Some(true),
+        inject_workspace_packages: true,
+        ..recorded_settings()
+    };
+
+    assert!(
+        try_fast_update_settings(
+            &lockfile(PEERLESS_LOCKFILE),
+            &settings,
+            &[(PathBuf::from("/project"), &manifest)],
+        )
+        .is_none()
+    );
+}
+
+#[test]
+fn reports_no_update_when_the_settings_match() {
+    let manifest = manifest(json!({ "dependencies": { "foo": "^1.0.0" } }));
+
+    assert!(
+        try_fast_update_settings(
+            &lockfile(PEERLESS_LOCKFILE),
+            &recorded_settings(),
+            &[(PathBuf::from("/project"), &manifest)],
+        )
+        .is_none()
+    );
+}

--- a/pnpm/crates/package-manager/src/fast_update_settings/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_settings/tests.rs
@@ -90,7 +90,7 @@ snapshots:
 
     assert!(
         try_fast_update_settings(&lockfile, &settings, &[(PathBuf::from("/project"), &manifest)])
-            .is_none()
+            .is_none(),
     );
 }
 
@@ -121,7 +121,7 @@ snapshots:
 
     assert!(
         try_fast_update_settings(&lockfile, &settings, &[(PathBuf::from("/project"), &manifest)])
-            .is_none()
+            .is_none(),
     );
 }
 
@@ -139,7 +139,7 @@ fn rejects_a_peer_setting_when_a_project_declares_peer_dependencies() {
             &settings,
             &[(PathBuf::from("/project"), &manifest)],
         )
-        .is_none()
+        .is_none(),
     );
 }
 
@@ -154,7 +154,7 @@ fn rejects_exclude_links_when_a_project_depends_on_a_directory() {
             &settings,
             &[(PathBuf::from("/project"), &manifest)],
         )
-        .is_none()
+        .is_none(),
     );
 }
 
@@ -179,7 +179,7 @@ importers:
 
     assert!(
         try_fast_update_settings(&lockfile, &settings, &[(PathBuf::from("/project"), &manifest)])
-            .is_none()
+            .is_none(),
     );
 }
 
@@ -198,7 +198,7 @@ fn records_exclude_links_when_the_only_workspace_dependency_uses_the_workspace_p
             &settings,
             &[(PathBuf::from("/project"), &root), (PathBuf::from("/project/bar"), &sibling)],
         )
-        .is_some()
+        .is_some(),
     );
 }
 
@@ -215,7 +215,7 @@ fn rejects_exclude_links_when_a_workspace_project_is_depended_on_by_range() {
             &settings,
             &[(PathBuf::from("/project"), &root), (PathBuf::from("/project/bar"), &sibling)],
         )
-        .is_none()
+        .is_none(),
     );
 }
 
@@ -234,7 +234,7 @@ fn rejects_inject_workspace_packages_when_a_workspace_project_is_depended_on() {
             &settings,
             &[(PathBuf::from("/project"), &root), (PathBuf::from("/project/bar"), &sibling)],
         )
-        .is_none()
+        .is_none(),
     );
 }
 
@@ -252,7 +252,7 @@ fn rejects_inject_workspace_packages_when_a_dependency_is_already_injected() {
             &settings,
             &[(PathBuf::from("/project"), &manifest)],
         )
-        .is_none()
+        .is_none(),
     );
 }
 
@@ -271,7 +271,7 @@ fn rejects_a_group_of_changed_settings_when_one_of_them_is_unsafe() {
             &settings,
             &[(PathBuf::from("/project"), &manifest)],
         )
-        .is_none()
+        .is_none(),
     );
 }
 
@@ -285,6 +285,6 @@ fn reports_no_update_when_the_settings_match() {
             &recorded_settings(),
             &[(PathBuf::from("/project"), &manifest)],
         )
-        .is_none()
+        .is_none(),
     );
 }

--- a/pnpm/crates/package-manager/src/install/lockfile_freshness.rs
+++ b/pnpm/crates/package-manager/src/install/lockfile_freshness.rs
@@ -1,32 +1,49 @@
 use super::{
     Arc, Catalogs, Config, DependencyGroup, Diagnostic, Display, Error, InstallError,
-    InstallWithFreshLockfileError, Lockfile, PackageManifest, Path, PnpmfileChecksumCheck,
+    InstallWithFreshLockfileError, Lockfile, PackageManifest, Path, PathBuf, PnpmfileChecksumCheck,
     StalenessReason, satisfies_package_manifest,
 };
 
 pub(super) struct FastUpdateLockfileOptions<'a, 'manifest> {
     pub(super) lockfile: Option<&'a Lockfile>,
     pub(super) manifests: &'a [(String, &'manifest PackageManifest)],
+    pub(super) project_manifests: &'a [(PathBuf, &'manifest PackageManifest)],
     pub(super) config: &'a Config,
     pub(super) catalogs: &'a Catalogs,
     pub(super) pnpmfile_hook: Option<&'a Arc<dyn pacquet_hooks::PnpmfileHooks>>,
     pub(super) ignore_manifest_check: bool,
 }
 
+/// Rewrite the loaded lockfile in place of a full resolution for the
+/// drift the lockfile itself proves is safe to absorb: a compatible
+/// direct-dependency range change, an addition to
+/// `ignoredOptionalDependencies`, or a setting change that cannot
+/// affect the recorded graph. The candidate only replaces the loaded
+/// lockfile once it passes every freshness gate, so a handler that
+/// rewrites too much falls back to the resolver instead of committing.
+///
+/// Each handler rewrites the same loaded lockfile, so their candidates
+/// cannot be composed: when more than one fires, the resolver takes
+/// over rather than committing a candidate that drops another's rewrite.
 pub(super) async fn try_fast_update_lockfile(
     opts: FastUpdateLockfileOptions<'_, '_>,
 ) -> Option<Lockfile> {
     let lockfile = opts.lockfile?;
-    let importer_candidate =
-        crate::fast_update_importers::try_fast_update_importers(lockfile, opts.manifests);
-    let ignored_optional_candidate =
+    let mut candidates = [
+        crate::fast_update_importers::try_fast_update_importers(lockfile, opts.manifests),
         crate::fast_update_ignored_optional_dependencies::try_fast_update_ignored_optional_dependencies(
             lockfile,
             opts.config.ignored_optional_dependencies.as_deref().unwrap_or_default(),
-        );
-    let ((Some(candidate), None) | (None, Some(candidate))) =
-        (importer_candidate, ignored_optional_candidate)
-    else {
+        ),
+        crate::fast_update_settings::try_fast_update_settings(
+            lockfile,
+            &crate::fast_update_settings::lockfile_settings_from_config(opts.config),
+            opts.project_manifests,
+        ),
+    ]
+    .into_iter()
+    .flatten();
+    let (Some(candidate), None) = (candidates.next(), candidates.next()) else {
         return None;
     };
     check_lockfile_freshness(

--- a/pnpm/crates/package-manager/src/install/run.rs
+++ b/pnpm/crates/package-manager/src/install/run.rs
@@ -502,6 +502,7 @@ where
             try_fast_update_lockfile(FastUpdateLockfileOptions {
                 lockfile,
                 manifests: &manifest_freshness_inputs,
+                project_manifests: &project_manifests,
                 config,
                 catalogs: &catalogs,
                 pnpmfile_hook: pnpmfile_hook.as_ref(),

--- a/pnpm/crates/package-manager/src/lib.rs
+++ b/pnpm/crates/package-manager/src/lib.rs
@@ -11,6 +11,7 @@ mod fast_update_ignored_optional_dependencies;
 mod fast_update_importers;
 mod fast_update_lockfile;
 mod fast_update_overrides;
+mod fast_update_settings;
 mod install;
 mod install_with_fresh_lockfile;
 mod link_manifest_link_deps;

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -63,8 +63,10 @@ import {
 import { getPreferredVersionsFromLockfileAndManifests } from '@pnpm/lockfile.preferred-versions'
 import {
   calcPatchHashes,
+  type ChangedField,
+  type ChangedSettingsField,
   createOverridesMapFromParsed,
-  getOutdatedLockfileSetting,
+  getOutdatedLockfileSettings,
   resolvePatchedDependencies,
 } from '@pnpm/lockfile.settings-checker'
 import { PACKAGE_MAP_FILENAME, writePackageMap, writePnpFile } from '@pnpm/lockfile.to-pnp'
@@ -112,6 +114,7 @@ import { tryFastUpdateIgnoredOptionalDependencies } from './tryFastUpdateIgnored
 import { hasChangedProjectSpecifiers, tryFastUpdateImporters } from './tryFastUpdateImporters.js'
 import { tryFastUpdateLockfile } from './tryFastUpdateLockfile.js'
 import { tryFastUpdateOverrides } from './tryFastUpdateOverrides.js'
+import { tryFastUpdateSettings } from './tryFastUpdateSettings.js'
 import { validateModules } from './validateModules.js'
 import { verifyLockfileResolutions } from './verifyLockfileResolutions.js'
 import { warnOnStaleConvergenceOverrides } from './warnOnStaleConvergenceOverrides.js'
@@ -668,39 +671,47 @@ export async function mutateModules (
     const patchGroups = patchGroupInput ? groupPatchedDependencies(patchGroupInput) : undefined
     const frozenLockfile = opts.frozenLockfile ||
       opts.frozenLockfileIfExists && ctx.existsNonEmptyWantedLockfile
-    let outdatedLockfileSettingName = null as ReturnType<typeof getOutdatedLockfileSetting>
+    let changedLockfileSettings: ChangedField[] = []
     const overridesMap = createOverridesMapFromParsed(opts.parsedOverrides)
-    const lockfileSettings = {
+    const wantedLockfileSettings = {
       autoInstallPeers: opts.autoInstallPeers,
-      catalogs: opts.catalogs,
       dedupePeers: opts.dedupePeers || undefined,
-      injectWorkspacePackages: opts.injectWorkspacePackages,
       excludeLinksFromLockfile: opts.excludeLinksFromLockfile,
       peersSuffixMaxLength: opts.peersSuffixMaxLength,
+      injectWorkspacePackages: opts.injectWorkspacePackages,
+    }
+    const lockfileSettings = {
+      ...wantedLockfileSettings,
+      catalogs: opts.catalogs,
       ignoredOptionalDependencies: opts.ignoredOptionalDependencies?.sort(),
       packageExtensionsChecksum,
       patchedDependencies,
       pnpmfileChecksum,
     }
     if (!opts.ignorePackageManifest) {
-      outdatedLockfileSettingName = getOutdatedLockfileSetting(ctx.wantedLockfile, {
+      changedLockfileSettings = getOutdatedLockfileSettings(ctx.wantedLockfile, {
         ...lockfileSettings,
         overrides: overridesMap,
       })
-      if (frozenLockfile && outdatedLockfileSettingName != null) {
-        throw new LockfileConfigMismatchError(outdatedLockfileSettingName!)
+      if (frozenLockfile && changedLockfileSettings.length > 0) {
+        throw new LockfileConfigMismatchError(changedLockfileSettings[0])
       }
     }
+    let outdatedLockfileSettingName: ChangedField | null = changedLockfileSettings[0] ?? null
     const _isWantedDepBareSpecifierSame = isWantedDepBareSpecifierSame.bind(null, ctx.wantedLockfile.catalogs, opts.catalogs)
     const upToDateLockfileMajorVersion = ctx.wantedLockfile.lockfileVersion.toString().startsWith(`${LOCKFILE_MAJOR_VERSION}.`)
     let didFastUpdateOverrides = false
     const contextProjects = Object.values(ctx.projects)
     const hasChangedSpecifiers = outdatedLockfileSettingName == null &&
       hasChangedProjectSpecifiers(ctx.wantedLockfile, contextProjects)
+    const changedSettingsFields = changedLockfileSettings.filter(isSettingsField)
+    const onlyLockfileSettingsChanged = changedLockfileSettings.length > 0 &&
+      changedLockfileSettings.length === changedSettingsFields.length
     const canTryFastUpdateLockfile =
       (outdatedLockfileSettingName === 'catalogs' ||
         outdatedLockfileSettingName === 'ignoredOptionalDependencies' ||
         outdatedLockfileSettingName === 'overrides' ||
+        onlyLockfileSettingsChanged ||
         hasChangedSpecifiers) &&
       !frozenLockfile &&
       installsOnly &&
@@ -729,20 +740,7 @@ export async function mutateModules (
       await verifyLockfilePromise
       const overridesUseCatalogs = Object.values(opts.overrides)
         .some((specifier) => parseCatalogProtocol(specifier) != null)
-      const lockfileCatalogs = ctx.wantedLockfile.catalogs == null
-        ? {}
-        : Object.fromEntries(Object.entries(ctx.wantedLockfile.catalogs).map(([catalogName, catalog]) => [
-          catalogName,
-          Object.fromEntries(Object.entries(catalog).map(([alias, entry]) => [alias, entry.specifier])),
-        ]))
-      const onlyChangedSetting = getOutdatedLockfileSetting(ctx.wantedLockfile, {
-        ...lockfileSettings,
-        catalogs: changedSetting === 'catalogs' ? lockfileCatalogs : opts.catalogs,
-        ignoredOptionalDependencies: changedSetting === 'ignoredOptionalDependencies'
-          ? ctx.wantedLockfile.ignoredOptionalDependencies
-          : lockfileSettings.ignoredOptionalDependencies,
-        overrides: changedSetting === 'overrides' ? ctx.wantedLockfile.overrides : overridesMap,
-      }) == null
+      const onlyChangedSetting = onlyLockfileSettingsChanged || changedLockfileSettings.length <= 1
       const isLockfileUpToDate = (lockfile: LockfileObject) => allProjectsAreUpToDate(Object.values(ctx.projects), {
         catalogs: opts.catalogs,
         autoInstallPeers: opts.autoInstallPeers,
@@ -758,6 +756,14 @@ export async function mutateModules (
         (changedSetting === 'catalogs' || !overridesUseCatalogs) &&
         await tryFastUpdateLockfile(ctx.wantedLockfile, {
           update: async (candidate) => {
+            if (onlyLockfileSettingsChanged) {
+              return tryFastUpdateSettings(candidate, {
+                changedSettings: changedSettingsFields,
+                projects: contextProjects,
+                settings: wantedLockfileSettings,
+                workspacePackages: ctx.workspacePackages,
+              })
+            }
             if (changedSetting === 'catalogs') {
               return tryFastUpdateCatalogs(candidate, {
                 catalogs: opts.catalogs,
@@ -806,26 +812,14 @@ export async function mutateModules (
       opts.forceFullResolution ||
       forceResolutionFromHook
     if (needsFullResolution) {
-      ctx.wantedLockfile.settings = {
-        autoInstallPeers: opts.autoInstallPeers,
-        dedupePeers: opts.dedupePeers || undefined,
-        excludeLinksFromLockfile: opts.excludeLinksFromLockfile,
-        peersSuffixMaxLength: opts.peersSuffixMaxLength,
-        injectWorkspacePackages: opts.injectWorkspacePackages,
-      }
+      ctx.wantedLockfile.settings = { ...wantedLockfileSettings }
       ctx.wantedLockfile.overrides = overridesMap
       ctx.wantedLockfile.packageExtensionsChecksum = packageExtensionsChecksum
       ctx.wantedLockfile.ignoredOptionalDependencies = opts.ignoredOptionalDependencies
       ctx.wantedLockfile.pnpmfileChecksum = pnpmfileChecksum
       ctx.wantedLockfile.patchedDependencies = patchedDependencies
     } else if (!frozenLockfile) {
-      ctx.wantedLockfile.settings = {
-        autoInstallPeers: opts.autoInstallPeers,
-        dedupePeers: opts.dedupePeers || undefined,
-        excludeLinksFromLockfile: opts.excludeLinksFromLockfile,
-        peersSuffixMaxLength: opts.peersSuffixMaxLength,
-        injectWorkspacePackages: opts.injectWorkspacePackages,
-      }
+      ctx.wantedLockfile.settings = { ...wantedLockfileSettings }
     }
 
     const frozenInstallResult = await tryFrozenInstall({
@@ -2667,6 +2661,10 @@ function mergeInstallSelectors (manifest: ProjectManifest, mutation: InstallSome
     }
   }
   return manifest
+}
+
+function isSettingsField (changedField: ChangedField): changedField is ChangedSettingsField {
+  return changedField.startsWith('settings.')
 }
 
 function guessDepField (alias: string, manifest: ProjectManifest): DependenciesField | undefined {

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateSettings.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateSettings.ts
@@ -130,11 +130,11 @@ function hasDirectoryReference (importer: ProjectSnapshot): boolean {
 }
 
 function manifestDependencies (manifest: ProjectManifest): Array<[string, string]> {
-  return Object.entries({
-    ...manifest.devDependencies,
-    ...manifest.dependencies,
-    ...manifest.optionalDependencies,
-  })
+  return [
+    ...Object.entries(manifest.devDependencies ?? {}),
+    ...Object.entries(manifest.dependencies ?? {}),
+    ...Object.entries(manifest.optionalDependencies ?? {}),
+  ]
 }
 
 function isEmpty (record: Record<string, unknown> | undefined): boolean {

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateSettings.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateSettings.ts
@@ -1,0 +1,142 @@
+import * as dp from '@pnpm/deps.path'
+import type { ChangedSettingsField } from '@pnpm/lockfile.settings-checker'
+import type { LockfileObject, LockfileSettings, ProjectSnapshot } from '@pnpm/lockfile.types'
+import type { WorkspacePackages } from '@pnpm/resolving.resolver-base'
+import type { DepPath, ProjectId, ProjectManifest } from '@pnpm/types'
+
+interface Project {
+  id: ProjectId
+  manifest: ProjectManifest
+}
+
+export interface FastSettingsUpdateOptions {
+  changedSettings: ChangedSettingsField[]
+  projects: Project[]
+  settings: LockfileSettings
+  workspacePackages: WorkspacePackages
+}
+
+/**
+ * Record a changed lockfile setting without resolving the dependency graph,
+ * for the settings that the lockfile itself proves cannot affect its graph:
+ * peer settings when nothing declares a peer dependency, and the link and
+ * injection settings when no project depends on a directory or on another
+ * workspace project.
+ *
+ * Returns `false` for everything else, which keeps the full-resolution path
+ * as the fallback.
+ */
+export function tryFastUpdateSettings (
+  lockfile: LockfileObject,
+  opts: FastSettingsUpdateOptions
+): boolean {
+  if (opts.changedSettings.length === 0) return false
+  if (!opts.changedSettings.every((setting) => settingCannotAffectLockfile(setting, lockfile, opts))) {
+    return false
+  }
+  lockfile.settings = { ...opts.settings }
+  return true
+}
+
+function settingCannotAffectLockfile (
+  setting: ChangedSettingsField,
+  lockfile: LockfileObject,
+  opts: FastSettingsUpdateOptions
+): boolean {
+  switch (setting) {
+    case 'settings.autoInstallPeers':
+    case 'settings.dedupePeers':
+    case 'settings.peersSuffixMaxLength':
+      return hasNoPeerDependencies(lockfile, opts.projects)
+    case 'settings.excludeLinksFromLockfile':
+      return hasNoLinkedDependencies(lockfile, opts.projects, opts.workspacePackages)
+    case 'settings.injectWorkspacePackages':
+      return hasNoInjectableDependencies(lockfile, opts.projects, opts.workspacePackages)
+  }
+}
+
+/**
+ * All three peer settings only change how peer dependencies are resolved,
+ * deduplicated, and hashed into dep path suffixes. None of them has anything
+ * to act on when no package or project declares a peer dependency and no dep
+ * path carries a peers suffix.
+ */
+function hasNoPeerDependencies (lockfile: LockfileObject, projects: Project[]): boolean {
+  for (const [depPath, pkg] of Object.entries(lockfile.packages ?? {})) {
+    if (dp.parseDepPath(depPath as DepPath).peerDepGraphHash !== '') return false
+    if (!isEmpty(pkg.peerDependencies) || !isEmpty(pkg.peerDependenciesMeta)) return false
+    if (pkg.transitivePeerDependencies?.length) return false
+  }
+  return projects.every((project) => isEmpty(project.manifest.peerDependencies))
+}
+
+/**
+ * `excludeLinksFromLockfile` decides whether a dependency that resolves to a
+ * directory is recorded in the lockfile. Dependencies declared with the
+ * `workspace:` protocol are recorded either way, so only the other directory
+ * dependencies matter — including plain ranges that `linkWorkspacePackages`
+ * turns into links to a workspace project.
+ */
+function hasNoLinkedDependencies (
+  lockfile: LockfileObject,
+  projects: Project[],
+  workspacePackages: WorkspacePackages
+): boolean {
+  if (Object.values(lockfile.importers).some(hasDirectoryReference)) return false
+  return projects.every((project) =>
+    manifestDependencies(project.manifest).every(([alias, bareSpecifier]) =>
+      bareSpecifier.startsWith('workspace:') ||
+      !isDirectoryDependency(alias, bareSpecifier, workspacePackages)
+    )
+  )
+}
+
+/**
+ * `injectWorkspacePackages` replaces the symlinks to workspace projects with
+ * hard-linked copies, which the lockfile records as directory dependencies of
+ * the importer. An install with no dependency on any workspace project has
+ * nothing to inject.
+ */
+function hasNoInjectableDependencies (
+  lockfile: LockfileObject,
+  projects: Project[],
+  workspacePackages: WorkspacePackages
+): boolean {
+  if (Object.values(lockfile.importers).some(hasDirectoryReference)) return false
+  return projects.every((project) =>
+    Object.values(project.manifest.dependenciesMeta ?? {}).every((meta) => !meta.injected) &&
+    manifestDependencies(project.manifest).every(([alias, bareSpecifier]) =>
+      !isDirectoryDependency(alias, bareSpecifier, workspacePackages)
+    )
+  )
+}
+
+function isDirectoryDependency (
+  alias: string,
+  bareSpecifier: string,
+  workspacePackages: WorkspacePackages
+): boolean {
+  return bareSpecifier.startsWith('workspace:') ||
+    bareSpecifier.startsWith('link:') ||
+    bareSpecifier.startsWith('file:') ||
+    workspacePackages.has(alias)
+}
+
+function hasDirectoryReference (importer: ProjectSnapshot): boolean {
+  return [importer.dependencies, importer.devDependencies, importer.optionalDependencies]
+    .some((deps) => Object.values(deps ?? {}).some((ref) =>
+      ref.startsWith('link:') || ref.startsWith('file:')
+    ))
+}
+
+function manifestDependencies (manifest: ProjectManifest): Array<[string, string]> {
+  return Object.entries({
+    ...manifest.devDependencies,
+    ...manifest.dependencies,
+    ...manifest.optionalDependencies,
+  })
+}
+
+function isEmpty (record: Record<string, unknown> | undefined): boolean {
+  return record == null || Object.keys(record).length === 0
+}

--- a/pnpm11/installing/deps-installer/test/install/settingsFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/settingsFastUpdate.ts
@@ -1,0 +1,292 @@
+import { expect, test } from '@jest/globals'
+import { mutateModulesInSingleProject } from '@pnpm/installing.deps-installer'
+import type { LockfileObject } from '@pnpm/lockfile.types'
+import { prepareEmpty } from '@pnpm/prepare'
+import type { WorkspacePackages } from '@pnpm/resolving.resolver-base'
+import type { StoreController } from '@pnpm/store.controller-types'
+import type { ProjectId, ProjectManifest, ProjectRootDir } from '@pnpm/types'
+
+import {
+  type FastSettingsUpdateOptions,
+  tryFastUpdateSettings,
+} from '../../src/install/tryFastUpdateSettings.js'
+import { testDefaults } from '../utils/index.js'
+
+const NEW_SETTINGS = {
+  autoInstallPeers: false,
+  dedupePeers: true,
+  excludeLinksFromLockfile: true,
+  peersSuffixMaxLength: 10,
+  injectWorkspacePackages: true,
+}
+
+test.each([
+  'settings.autoInstallPeers',
+  'settings.dedupePeers',
+  'settings.excludeLinksFromLockfile',
+  'settings.peersSuffixMaxLength',
+  'settings.injectWorkspacePackages',
+] as const)('%s is recorded without resolution when the lockfile has no dependency it could affect', (changedSetting) => {
+  const lockfile = lockfileWithRegistryDependency()
+
+  expect(tryFastUpdateSettings(lockfile, updateOptions({
+    changedSettings: [changedSetting],
+  }))).toBe(true)
+  expect(lockfile.settings).toStrictEqual(NEW_SETTINGS)
+})
+
+test.each([
+  'settings.autoInstallPeers',
+  'settings.dedupePeers',
+  'settings.peersSuffixMaxLength',
+] as const)('%s falls back when a package declares peer dependencies', (changedSetting) => {
+  const lockfile = lockfileWithRegistryDependency()
+  lockfile.packages!['foo@1.0.0' as keyof typeof lockfile.packages] = {
+    peerDependencies: { bar: '^1.0.0' },
+  } as never
+
+  expect(tryFastUpdateSettings(lockfile, updateOptions({
+    changedSettings: [changedSetting],
+  }))).toBe(false)
+  expect(lockfile.settings).toBeUndefined()
+})
+
+test('a peer setting falls back when a dep path carries a peers suffix', () => {
+  const lockfile = lockfileWithRegistryDependency()
+  lockfile.packages!['foo@1.0.0(bar@1.0.0)' as keyof typeof lockfile.packages] = {} as never
+
+  expect(tryFastUpdateSettings(lockfile, updateOptions({
+    changedSettings: ['settings.dedupePeers'],
+  }))).toBe(false)
+})
+
+test('a peer setting falls back when a project declares peer dependencies', () => {
+  const lockfile = lockfileWithRegistryDependency()
+
+  expect(tryFastUpdateSettings(lockfile, updateOptions({
+    changedSettings: ['settings.autoInstallPeers'],
+    projects: [{
+      id: '.' as ProjectId,
+      manifest: {
+        dependencies: { foo: '^1.0.0' },
+        peerDependencies: { bar: '^1.0.0' },
+      },
+    }],
+  }))).toBe(false)
+})
+
+test('excludeLinksFromLockfile falls back when a project depends on a directory', () => {
+  const lockfile = lockfileWithRegistryDependency()
+
+  expect(tryFastUpdateSettings(lockfile, updateOptions({
+    changedSettings: ['settings.excludeLinksFromLockfile'],
+    projects: [{
+      id: '.' as ProjectId,
+      manifest: {
+        dependencies: {
+          bar: 'link:../bar',
+          foo: '^1.0.0',
+        },
+      },
+    }],
+  }))).toBe(false)
+})
+
+test('excludeLinksFromLockfile falls back when the lockfile records a link', () => {
+  const lockfile = lockfileWithRegistryDependency()
+  lockfile.importers['.' as ProjectId].dependencies!.bar = 'link:../bar'
+
+  expect(tryFastUpdateSettings(lockfile, updateOptions({
+    changedSettings: ['settings.excludeLinksFromLockfile'],
+  }))).toBe(false)
+})
+
+test('excludeLinksFromLockfile is recorded when the only workspace dependency uses the workspace protocol', () => {
+  const lockfile = lockfileWithRegistryDependency()
+
+  expect(tryFastUpdateSettings(lockfile, updateOptions({
+    changedSettings: ['settings.excludeLinksFromLockfile'],
+    projects: [{
+      id: '.' as ProjectId,
+      manifest: {
+        dependencies: {
+          bar: 'workspace:*',
+          foo: '^1.0.0',
+        },
+      },
+    }],
+    workspacePackages: new Map([['bar', new Map()]]) as WorkspacePackages,
+  }))).toBe(true)
+})
+
+test('excludeLinksFromLockfile falls back when a workspace project is depended on by range', () => {
+  const lockfile = lockfileWithRegistryDependency()
+
+  expect(tryFastUpdateSettings(lockfile, updateOptions({
+    changedSettings: ['settings.excludeLinksFromLockfile'],
+    projects: [{
+      id: '.' as ProjectId,
+      manifest: {
+        dependencies: {
+          bar: '^1.0.0',
+          foo: '^1.0.0',
+        },
+      },
+    }],
+    workspacePackages: new Map([['bar', new Map()]]) as WorkspacePackages,
+  }))).toBe(false)
+})
+
+test.each([
+  ['workspace:*', new Map([['bar', new Map()]]) as WorkspacePackages],
+  ['^1.0.0', new Map([['bar', new Map()]]) as WorkspacePackages],
+  ['link:../bar', new Map() as WorkspacePackages],
+])('injectWorkspacePackages falls back when a workspace project is depended on as %s', (bareSpecifier, workspacePackages) => {
+  const lockfile = lockfileWithRegistryDependency()
+
+  expect(tryFastUpdateSettings(lockfile, updateOptions({
+    changedSettings: ['settings.injectWorkspacePackages'],
+    projects: [{
+      id: '.' as ProjectId,
+      manifest: {
+        dependencies: {
+          bar: bareSpecifier,
+          foo: '^1.0.0',
+        },
+      },
+    }],
+    workspacePackages,
+  }))).toBe(false)
+})
+
+test('injectWorkspacePackages falls back when a dependency is already injected', () => {
+  const lockfile = lockfileWithRegistryDependency()
+
+  expect(tryFastUpdateSettings(lockfile, updateOptions({
+    changedSettings: ['settings.injectWorkspacePackages'],
+    projects: [{
+      id: '.' as ProjectId,
+      manifest: {
+        dependencies: { foo: '^1.0.0' },
+        dependenciesMeta: { foo: { injected: true } },
+      },
+    }],
+  }))).toBe(false)
+})
+
+test('a group of changed settings is recorded only when every one of them is safe', () => {
+  const lockfile = lockfileWithRegistryDependency()
+
+  expect(tryFastUpdateSettings(lockfile, updateOptions({
+    changedSettings: ['settings.dedupePeers', 'settings.injectWorkspacePackages'],
+    projects: [{
+      id: '.' as ProjectId,
+      manifest: {
+        dependencies: {
+          bar: 'link:../bar',
+          foo: '^1.0.0',
+        },
+      },
+    }],
+  }))).toBe(false)
+  expect(lockfile.settings).toBeUndefined()
+})
+
+test('toggling dedupePeers on a peerless lockfile skips resolution', async () => {
+  const project = prepareEmpty()
+  const manifest: ProjectManifest = {
+    dependencies: {
+      '@pnpm.e2e/foo': '^100.0.0',
+    },
+  }
+  const options = testDefaults()
+
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, options)
+
+  const requestedPackages = trackRequestedPackages(options.storeController)
+  options.dedupePeers = true
+
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, options)
+
+  expect(requestedPackages).toStrictEqual([])
+  expect(project.readLockfile().settings.dedupePeers).toBe(true)
+})
+
+test('toggling dedupePeers falls back to resolution when peer dependencies are locked', async () => {
+  prepareEmpty()
+  const manifest: ProjectManifest = {
+    dependencies: {
+      '@pnpm.e2e/has-optional-peer-with-peer': '^1.0.0',
+    },
+  }
+  const options = testDefaults()
+
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, options)
+
+  const requestedPackages = trackRequestedPackages(options.storeController)
+  options.dedupePeers = true
+
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, options)
+
+  expect(requestedPackages.length).toBeGreaterThan(0)
+})
+
+function updateOptions (opts: Partial<FastSettingsUpdateOptions>): FastSettingsUpdateOptions {
+  return {
+    changedSettings: [],
+    projects: [{
+      id: '.' as ProjectId,
+      manifest: {
+        dependencies: { foo: '^1.0.0' },
+      },
+    }],
+    settings: NEW_SETTINGS,
+    workspacePackages: new Map() as WorkspacePackages,
+    ...opts,
+  }
+}
+
+function lockfileWithRegistryDependency (): LockfileObject {
+  return {
+    importers: {
+      '.': {
+        dependencies: {
+          foo: '1.0.0',
+        },
+        specifiers: {
+          foo: '^1.0.0',
+        },
+      },
+    },
+    lockfileVersion: '9.0',
+    packages: {
+      'foo@1.0.0': {},
+    },
+  } as unknown as LockfileObject
+}
+
+function trackRequestedPackages (storeController: StoreController): string[] {
+  const requestedPackages: string[] = []
+  const requestPackage = storeController.requestPackage
+  storeController.requestPackage = async (wantedDependency, requestOptions) => {
+    requestedPackages.push(wantedDependency.alias!)
+    return requestPackage(wantedDependency, requestOptions)
+  }
+  return requestedPackages
+}

--- a/pnpm11/installing/deps-installer/test/install/settingsFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/settingsFastUpdate.ts
@@ -92,6 +92,26 @@ test('excludeLinksFromLockfile falls back when a project depends on a directory'
   }))).toBe(false)
 })
 
+test('excludeLinksFromLockfile falls back when a link is shadowed by the same alias in another group', () => {
+  const lockfile = lockfileWithRegistryDependency()
+
+  expect(tryFastUpdateSettings(lockfile, updateOptions({
+    changedSettings: ['settings.excludeLinksFromLockfile'],
+    projects: [{
+      id: '.' as ProjectId,
+      manifest: {
+        dependencies: {
+          bar: '^1.0.0',
+          foo: '^1.0.0',
+        },
+        devDependencies: {
+          bar: 'link:../bar',
+        },
+      },
+    }],
+  }))).toBe(false)
+})
+
 test('excludeLinksFromLockfile falls back when the lockfile records a link', () => {
   const lockfile = lockfileWithRegistryDependency()
   lockfile.importers['.' as ProjectId].dependencies!.bar = 'link:../bar'

--- a/pnpm11/lockfile/fs/src/lockfileFormatConverters.ts
+++ b/pnpm11/lockfile/fs/src/lockfileFormatConverters.ts
@@ -56,7 +56,7 @@ export function convertToLockfileFile (lockfile: LockfileObject): LockfileFile {
     newLockfile.settings = omit(['peersSuffixMaxLength'], newLockfile.settings)
   }
   if (newLockfile.settings?.injectWorkspacePackages === false) {
-    delete newLockfile.settings.injectWorkspacePackages
+    newLockfile.settings = omit(['injectWorkspacePackages'], newLockfile.settings)
   }
   return normalizeLockfile(newLockfile)
 }

--- a/pnpm11/lockfile/settings-checker/package.json
+++ b/pnpm11/lockfile/settings-checker/package.json
@@ -27,10 +27,11 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\"",
-    "test": "pn compile",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "test": "pn compile && pn .test",
     "prepublishOnly": "tsgo --build",
-    "compile": "tsgo --build && pn lint --fix"
+    "compile": "tsgo --build && pn lint --fix",
+    ".test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169\" jest"
   },
   "dependencies": {
     "@pnpm/catalogs.types": "workspace:*",
@@ -42,6 +43,7 @@
     "ramda": "catalog:"
   },
   "devDependencies": {
+    "@jest/globals": "catalog:",
     "@pnpm/lockfile.settings-checker": "workspace:*",
     "@pnpm/prepare": "workspace:*",
     "@types/ramda": "catalog:"

--- a/pnpm11/lockfile/settings-checker/src/getOutdatedLockfileSetting.ts
+++ b/pnpm11/lockfile/settings-checker/src/getOutdatedLockfileSetting.ts
@@ -83,7 +83,11 @@ function * outdatedLockfileSettings (
   if (lockfile.packageExtensionsChecksum !== packageExtensionsChecksum) {
     yield 'packageExtensionsChecksum'
   }
-  if (!equals(lockfile.ignoredOptionalDependencies?.sort() ?? [], ignoredOptionalDependencies?.sort() ?? [])) {
+  // Compare copies: the recorded and configured arrays belong to the caller,
+  // and `ignoredOptionalDependencies` is order-sensitive downstream — sorting
+  // it in place can move an `!` exclusion ahead of the pattern it excludes
+  // from and flip which dependencies `createMatcher` ignores.
+  if (!equals([...lockfile.ignoredOptionalDependencies ?? []].sort(), [...ignoredOptionalDependencies ?? []].sort())) {
     yield 'ignoredOptionalDependencies'
   }
   if (!equals(lockfile.patchedDependencies ?? {}, patchedDependencies ?? {})) {

--- a/pnpm11/lockfile/settings-checker/src/getOutdatedLockfileSetting.ts
+++ b/pnpm11/lockfile/settings-checker/src/getOutdatedLockfileSetting.ts
@@ -9,14 +9,56 @@ export type ChangedField =
   | 'overrides'
   | 'packageExtensionsChecksum'
   | 'ignoredOptionalDependencies'
+  | ChangedSettingsField
+  | 'pnpmfileChecksum'
+
+export type ChangedSettingsField =
   | 'settings.autoInstallPeers'
   | 'settings.dedupePeers'
   | 'settings.excludeLinksFromLockfile'
   | 'settings.peersSuffixMaxLength'
   | 'settings.injectWorkspacePackages'
-  | 'pnpmfileChecksum'
+
+export const DEFAULT_PEERS_SUFFIX_MAX_LENGTH = 1000
+
+export interface LockfileSettingsInput {
+  catalogs?: Catalogs
+  overrides?: Record<string, string>
+  packageExtensionsChecksum?: string
+  patchedDependencies?: Record<string, string>
+  ignoredOptionalDependencies?: string[]
+  autoInstallPeers?: boolean
+  dedupePeers?: boolean
+  excludeLinksFromLockfile?: boolean
+  peersSuffixMaxLength?: number
+  pnpmfileChecksum?: string
+  injectWorkspacePackages?: boolean
+}
 
 export function getOutdatedLockfileSetting (
+  lockfile: LockfileObject,
+  settings: LockfileSettingsInput
+): ChangedField | null {
+  for (const changedField of outdatedLockfileSettings(lockfile, settings)) {
+    return changedField
+  }
+  return null
+}
+
+/**
+ * Every setting recorded in the lockfile that the current configuration
+ * no longer matches. Use it when a caller has to know that a given setting
+ * is the *only* thing that changed; {@link getOutdatedLockfileSetting} is
+ * the cheaper choice when just the first mismatch is needed.
+ */
+export function getOutdatedLockfileSettings (
+  lockfile: LockfileObject,
+  settings: LockfileSettingsInput
+): ChangedField[] {
+  return Array.from(outdatedLockfileSettings(lockfile, settings))
+}
+
+function * outdatedLockfileSettings (
   lockfile: LockfileObject,
   {
     catalogs,
@@ -30,55 +72,42 @@ export function getOutdatedLockfileSetting (
     peersSuffixMaxLength,
     pnpmfileChecksum,
     injectWorkspacePackages,
-  }: {
-    catalogs?: Catalogs
-    overrides?: Record<string, string>
-    packageExtensionsChecksum?: string
-    patchedDependencies?: Record<string, string>
-    ignoredOptionalDependencies?: string[]
-    autoInstallPeers?: boolean
-    dedupePeers?: boolean
-    excludeLinksFromLockfile?: boolean
-    peersSuffixMaxLength?: number
-    pnpmfileChecksum?: string
-    injectWorkspacePackages?: boolean
-  }
-): ChangedField | null {
+  }: LockfileSettingsInput
+): Generator<ChangedField> {
   if (!allCatalogsAreUpToDate(catalogs ?? {}, lockfile.catalogs)) {
-    return 'catalogs'
+    yield 'catalogs'
   }
   if (!equals(lockfile.overrides ?? {}, overrides ?? {})) {
-    return 'overrides'
+    yield 'overrides'
   }
   if (lockfile.packageExtensionsChecksum !== packageExtensionsChecksum) {
-    return 'packageExtensionsChecksum'
+    yield 'packageExtensionsChecksum'
   }
   if (!equals(lockfile.ignoredOptionalDependencies?.sort() ?? [], ignoredOptionalDependencies?.sort() ?? [])) {
-    return 'ignoredOptionalDependencies'
+    yield 'ignoredOptionalDependencies'
   }
   if (!equals(lockfile.patchedDependencies ?? {}, patchedDependencies ?? {})) {
-    return 'patchedDependencies'
+    yield 'patchedDependencies'
   }
   if ((lockfile.settings?.autoInstallPeers != null && lockfile.settings.autoInstallPeers !== autoInstallPeers)) {
-    return 'settings.autoInstallPeers'
+    yield 'settings.autoInstallPeers'
   }
   if (Boolean(lockfile.settings?.dedupePeers) !== Boolean(dedupePeers)) {
-    return 'settings.dedupePeers'
+    yield 'settings.dedupePeers'
   }
   if (lockfile.settings?.excludeLinksFromLockfile != null && lockfile.settings.excludeLinksFromLockfile !== excludeLinksFromLockfile) {
-    return 'settings.excludeLinksFromLockfile'
+    yield 'settings.excludeLinksFromLockfile'
   }
   if (
     lockfile.settings?.peersSuffixMaxLength != null && lockfile.settings.peersSuffixMaxLength !== peersSuffixMaxLength ||
-    lockfile.settings?.peersSuffixMaxLength == null && peersSuffixMaxLength !== 1000
+    lockfile.settings?.peersSuffixMaxLength == null && peersSuffixMaxLength !== DEFAULT_PEERS_SUFFIX_MAX_LENGTH
   ) {
-    return 'settings.peersSuffixMaxLength'
+    yield 'settings.peersSuffixMaxLength'
   }
   if (lockfile.pnpmfileChecksum !== pnpmfileChecksum) {
-    return 'pnpmfileChecksum'
+    yield 'pnpmfileChecksum'
   }
   if (Boolean(lockfile.settings?.injectWorkspacePackages) !== Boolean(injectWorkspacePackages)) {
-    return 'settings.injectWorkspacePackages'
+    yield 'settings.injectWorkspacePackages'
   }
-  return null
 }

--- a/pnpm11/lockfile/settings-checker/src/index.ts
+++ b/pnpm11/lockfile/settings-checker/src/index.ts
@@ -1,4 +1,10 @@
 export { calcPatchHashes } from './calcPatchHashes.js'
 export { createOverridesMapFromParsed } from './createOverridesMapFromParsed.js'
-export { type ChangedField, getOutdatedLockfileSetting } from './getOutdatedLockfileSetting.js'
+export {
+  type ChangedField,
+  type ChangedSettingsField,
+  DEFAULT_PEERS_SUFFIX_MAX_LENGTH,
+  getOutdatedLockfileSetting,
+  getOutdatedLockfileSettings,
+} from './getOutdatedLockfileSetting.js'
 export { resolvePatchedDependencies } from './resolvePatchedDependencies.js'

--- a/pnpm11/lockfile/settings-checker/test/getOutdatedLockfileSettings.test.ts
+++ b/pnpm11/lockfile/settings-checker/test/getOutdatedLockfileSettings.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@jest/globals'
+import type { LockfileObject } from '@pnpm/lockfile.types'
+
+import { getOutdatedLockfileSettings } from '../src/getOutdatedLockfileSetting.js'
+
+test('ignoredOptionalDependencies is reported when the sets differ', () => {
+  const lockfile = emptyLockfile({ ignoredOptionalDependencies: ['foo'] })
+
+  expect(getOutdatedLockfileSettings(lockfile, { ignoredOptionalDependencies: ['bar'] }))
+    .toContain('ignoredOptionalDependencies')
+})
+
+test('ignoredOptionalDependencies is not reported when the sets match in a different order', () => {
+  const lockfile = emptyLockfile({ ignoredOptionalDependencies: ['foo', 'bar'] })
+
+  expect(getOutdatedLockfileSettings(lockfile, { ignoredOptionalDependencies: ['bar', 'foo'] }))
+    .not.toContain('ignoredOptionalDependencies')
+})
+
+test('the compared ignoredOptionalDependencies arrays are left in their original order', () => {
+  // `createMatcher` is order-sensitive: an `!` exclusion only excludes from the
+  // patterns before it, so reordering these arrays would flip which optional
+  // dependencies get ignored.
+  const recorded = ['*', '!foo']
+  const configured = ['*', '!bar']
+  const lockfile = emptyLockfile({ ignoredOptionalDependencies: recorded })
+
+  getOutdatedLockfileSettings(lockfile, { ignoredOptionalDependencies: configured })
+
+  expect(recorded).toStrictEqual(['*', '!foo'])
+  expect(configured).toStrictEqual(['*', '!bar'])
+})
+
+function emptyLockfile (settings: Partial<LockfileObject>): LockfileObject {
+  return {
+    importers: {},
+    lockfileVersion: '9.0',
+    ...settings,
+  }
+}

--- a/pnpm11/lockfile/settings-checker/test/tsconfig.json
+++ b/pnpm11/lockfile/settings-checker/test/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "../node_modules/.test.lib",
+    "rootDir": "..",
+    "isolatedModules": true
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Next bounded slice of the fast-path roadmap in
[pnpm/pnpm#13474](https://github.com/pnpm/pnpm/issues/13474): the
**setting-only updates** stage.

Changing `autoInstallPeers`, `dedupePeers`, `peersSuffixMaxLength`,
`excludeLinksFromLockfile`, or `injectWorkspacePackages` forced a full
dependency resolution even when the lockfile already proved the setting had
nothing to act on. Each setting now has its own predicate, and the changed
setting is recorded on a staged lockfile that is committed only when the
predicate holds *and* the existing freshness / resolution validation passes:

- the three peer settings — no package or project declares a peer dependency,
  no depPath carries a peers suffix, and no snapshot lists transitive peers;
- `excludeLinksFromLockfile` — no importer entry records a `link:` / `file:`
  reference and no project depends on a directory (`workspace:`-protocol deps
  are recorded either way, so they don't disqualify it, while a plain range
  onto a workspace project does);
- `injectWorkspacePackages` — no project depends on another workspace project
  at all, and nothing is already marked `injected`.

Everything else falls back to the resolver with the input lockfile untouched.
Implemented in both stacks: `tryFastUpdateSettings` behind the existing
coordinator in the TypeScript CLI, and `fast_update_settings` chained after the
importer fast path in pacquet (its candidate is validated by
`check_lockfile_freshness` before it replaces the loaded lockfile).

Related to [pnpm/pnpm#13474](https://github.com/pnpm/pnpm/issues/13474).

## Squash Commit Body

```text
Changing `autoInstallPeers`, `dedupePeers`, `peersSuffixMaxLength`,
`excludeLinksFromLockfile`, or `injectWorkspacePackages` forced a full
dependency resolution even when the lockfile already proved the setting had
nothing to act on: an install with no peer dependencies anywhere, or one where
no project depends on a directory or on another workspace project.

Both stacks now stage the new `settings` block on a candidate lockfile and
commit it only when every changed setting passes its own predicate and the
candidate still satisfies the existing freshness and resolution validation.
Anything else — a peer-suffixed depPath, a package or project declaring peers,
a `link:` / `file:` / workspace dependency, an already-injected dependency —
falls back to the resolver untouched.

The predicates that decide "this setting changed" now live in one place per
stack, so the fast path and the staleness check cannot drift:
`getOutdatedLockfileSettings` (which also reports every changed field, letting
the coordinator drop its neutralize-and-recompare dance) and the comparison
helpers in pacquet's `freshness` module. As a side effect the lockfile
serializer no longer deletes `injectWorkspacePackages` out of the in-memory
lockfile's shared `settings` object while writing it.

Related to pnpm/pnpm#13474.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788309133&installation_model_id=426870&pr_number=13600&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13600&signature=4d2c0e02cfbae07ab1e78b49d48fcec6ce57112a2b5f8935563e9a1fce44e6db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Lockfile-only setting changes can now be applied without re-resolving dependencies when the existing dependency graph is unaffected.
  * Changes involving peers, links, workspace packages, or injected dependencies continue to use full resolution when necessary.

* **Bug Fixes**
  * Lockfile checks preserve the configured order of ignored optional dependency patterns.
  * Frozen installs report setting mismatches more accurately.

* **Tests**
  * Added coverage for safe updates and fallback scenarios across supported lockfile settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->