### PR TITLE
docs(security): state the untrusted-repository trust boundary

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,16 +49,27 @@ In particular:
   CI jobs, restrict write access to trusted identities via filesystem
   permissions.
 
-- **Running a repository's code means trusting that repository.** `pnpm run`,
-  `pnpm exec`, and `pnpm dlx` execute code the repository chooses, so
-  configuration that only influences those commands — `nodeOptions`, script
-  bodies, `.bin` entries — is not a boundary we can defend. What we do defend is
-  the weaker act of *installing* from an untrusted repository: a `pnpm install`
-  must not send your credentials to a host the repository picked, and must not
-  run dependency build scripts you did not allow. This is why environment
-  variable expansion in repository-controlled configuration is restricted for
-  request destinations (`registry`, `proxy`, `pnprServer`) and auth values, and
-  not for settings that merely shape a command you asked pnpm to run.
+- **Running pnpm inside a repository means trusting that repository.** This is
+  not limited to `pnpm run`, `pnpm exec`, and `pnpm dlx`, which execute whatever
+  the repository specifies. A plain `pnpm install` also runs the project's own
+  `preinstall`, `install`, `postinstall`, and `prepare` scripts by default;
+  `--ignore-scripts` is what suppresses them. The build approval prompt
+  (`onlyBuiltDependencies` / `allowBuilds`) gates **dependencies'** build
+  scripts, not the scripts of the project you are installing.
+
+  A report therefore does not describe a privilege escalation merely because an
+  untrusted repository can influence what pnpm executes — in that starting
+  position, code execution is already available to the attacker by design.
+
+- **Some restrictions are hardening, not boundaries.** Environment variable
+  expansion in repository-controlled configuration is suppressed for request
+  destinations (`registry`, `proxy`, `pnprServer`) and for auth values. That
+  narrows silent credential exfiltration — the case that survives
+  `--ignore-scripts`, and the case where a one-line config diff draws less
+  review than a new `postinstall` script would. It is deliberately not a
+  general-purpose sandbox, and a setting outside its coverage is not a
+  vulnerability on that basis alone. What matters is what the gap grants an
+  attacker beyond what the repository could already do without it.
 
 The following are examples of reports we consider **out of scope**:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,6 +49,17 @@ In particular:
   CI jobs, restrict write access to trusted identities via filesystem
   permissions.
 
+- **Running a repository's code means trusting that repository.** `pnpm run`,
+  `pnpm exec`, and `pnpm dlx` execute code the repository chooses, so
+  configuration that only influences those commands — `nodeOptions`, script
+  bodies, `.bin` entries — is not a boundary we can defend. What we do defend is
+  the weaker act of *installing* from an untrusted repository: a `pnpm install`
+  must not send your credentials to a host the repository picked, and must not
+  run dependency build scripts you did not allow. This is why environment
+  variable expansion in repository-controlled configuration is restricted for
+  request destinations (`registry`, `proxy`, `pnprServer`) and auth values, and
+  not for settings that merely shape a command you asked pnpm to run.
+
 The following are examples of reports we consider **out of scope**:
 
 - Tampering with store, lockfile, `node_modules`, or config files that the
@@ -56,7 +67,15 @@ The following are examples of reports we consider **out of scope**:
 - Bypassing store integrity checks given pre-existing write access to the store.
 - Attacks that require the user to run pnpm with a maliciously crafted local
   project or environment that they did not obtain from a trusted source.
+- Repository-controlled configuration that changes what `pnpm run`, `pnpm exec`,
+  or `pnpm dlx` executes, since those commands run repository-controlled code by
+  definition.
+- Behavior that matches npm and Yarn and that we would have to diverge from the
+  ecosystem to change. Report it upstream first; if they treat it as a
+  vulnerability, we will follow.
 
 If you believe a report falls outside these assumptions — for example, a way to
 bypass a trust boundary that pnpm *does* enforce — please include the exact
-privilege the attacker starts with and how pnpm escalates it.
+privilege the attacker starts with and how pnpm escalates it. When the report is
+about a hardening measure that does not cover some setting, state what the
+attacker gains from that gap beyond what they could already do without it.


### PR DESCRIPTION
## Summary

Documents the trust boundary that security reports keep landing on, and that `SECURITY.md` did not describe.

The existing threat model covers the filesystem-permissions tier: an attacker who can already write to the store, the lockfile, `node_modules`, or config files is out of scope. It says nothing about the tier reporters actually probe — a repository the user clones and then runs pnpm inside.

`pnpm install` in an untrusted repository is already arbitrary code execution: the project's own `preinstall`/`install`/`postinstall`/`prepare` scripts run by default (`installing/deps-installer/src/install/index.ts:2076`), gated only by `ignoreScripts`, whose default is `false`. The build approval mechanism does not cover them — `allowBuild` is passed to `buildModules` and `_rebuild` only, so `onlyBuiltDependencies`/`allowBuilds` gates *dependencies'* build scripts, not the scripts of the project being installed.

What pnpm does restrict is narrower: environment variable expansion in repository-controlled configuration is suppressed for request destinations (`registry`, `proxy`, `pnprServer`) and auth values. That is hardening, aimed at silent credential exfiltration — the case that survives `--ignore-scripts`, and the case where a one-line config diff draws less review than a new `postinstall` script would. Because that restriction is real but deliberately partial, any setting absent from it reads as an oversight rather than as a setting that was never in scope.

A recent advisory reported exactly that about `nodeOptions`: it is not in `REQUEST_DESTINATION_SCALAR_KEYS`, so `${VAR}` placeholders in it expand. But `nodeOptions` is read only by `pnpm run` and `pnpm exec`, and it is honored verbatim — `nodeOptions: --require=./evil.js` needs no placeholder and no gate. Blocking expansion there would prevent nothing.

This PR names the boundary so the next such report is answered before it is filed:

- A threat-model bullet stating that running pnpm inside a repository means trusting it, spelling out that a plain `pnpm install` runs the project's own lifecycle scripts and that the build approval prompt does not cover them.
- A second bullet separating hardening from boundaries, so the scope of the env-expansion restrictions is not mistaken for a sandbox.
- Two out-of-scope entries: repository-controlled configuration that changes what `run`/`exec`/`dlx` executes, and behavior matching npm and Yarn that we would have to diverge from the ecosystem to change.
- A counterfactual request in the closing paragraph: when reporting that a hardening measure misses a setting, state what the gap buys an attacker beyond what they could already do without it.

The second commit corrects the first, which claimed installing from an untrusted repository is a defended act distinct from running its code. The lifecycle-script behavior above shows it is not, and the text now says so rather than promising a boundary pnpm does not enforce.

## Squash Commit Body

```text
The threat model section only described the filesystem-permissions tier,
so it was silent on the tier that reports actually target: a repository
the user clones and then runs pnpm inside.

That tier is thinner than it looks. A plain `pnpm install` already runs
the installed project's own preinstall/install/postinstall/prepare
scripts, gated only by `ignoreScripts` (default false); the build
approval mechanism covers dependencies' build scripts, not the project's
own. Code execution is therefore available to an untrusted repository
before any `pnpm run` is involved.

What pnpm restricts is narrower: environment variable expansion in
repository-controlled configuration is suppressed for request
destinations and auth values, as hardening against silent credential
exfiltration. Because that restriction is real but partial, a setting
missing from it reads as an oversight rather than as a setting that was
never in scope. A recent advisory reported exactly that about
`nodeOptions`, which only takes effect for `pnpm run` and `pnpm exec`
and is honored verbatim with no placeholder at all.

Name the boundary, separate hardening from it, list the two out-of-scope
classes it implies, and ask reporters of coverage gaps for the
counterfactual: what the gap buys an attacker beyond what they could
already do without it.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (Repo-wide policy document; no code in either stack.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
  (No published package changes — `SECURITY.md` only.)
- [x] Added or updated tests. (Not applicable — documentation only.)
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5[1m]).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded security guidance for commands, dependency installation, environment variables, and request destinations.
  * Clarified out-of-scope scenarios and added expectations for reporting attacker privileges and potential impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->