### PR TITLE
fix(store): resolve store path calculation when project root is mount…

### DIFF
--- a/.changeset/fix-dirs-are-equal-store-path.md
+++ b/.changeset/fix-dirs-are-equal-store-path.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/store.path": patch
+"pnpm": patch
+---
+
+Fix `dirsAreEqual` to correctly check for empty relative path, ensuring that the store is placed in the home directory when the project root itself is a mountpoint and the parent directory is not linkable pnpm/pnpm#13602.

--- a/pnpm11/store/path/src/index.ts
+++ b/pnpm11/store/path/src/index.ts
@@ -103,7 +103,7 @@ async function safeRmdir (dir: string): Promise<void> {
 }
 
 function dirsAreEqual (dir1: string, dir2: string): boolean {
-  return path.relative(dir1, dir2) === '.'
+  return path.relative(dir1, dir2) === ''
 }
 
 function getHomedir (): string {

--- a/pnpm11/store/path/test/index.ts
+++ b/pnpm11/store/path/test/index.ts
@@ -13,6 +13,7 @@ jest.unstable_mockModule('root-link-target', () => {
   const MAPPINGS: Record<string, string> = {
     '/src/workspace/project/tmp': '/',
     '/mnt/project/tmp': '/mnt/project',
+    '/mnt/project-only/tmp': '/mnt/project-only',
   }
 
   return {
@@ -56,6 +57,7 @@ jest.unstable_mockModule('can-link', () => {
   const CAN_LINK = new Set([
     '/can-link-to-homedir/tmp=>/home/user/tmp',
     '/mnt/project/tmp=>/mnt/tmp/tmp',
+    '/mnt/project-only/tmp=>/mnt/project-only/tmp/tmp',
   ])
 
   return {
@@ -88,6 +90,13 @@ skipOnWindows('a link can be created to the a subdir in the root of the drive', 
     pkgRoot: '/mnt/project',
     pnpmHomeDir: '/local/share/pnpm',
   })).toBe(`/mnt/.pnpm-store/${STORE_VERSION}`)
+})
+
+skipOnWindows('store is placed in the home directory if project root is the mountpoint and parent directory is not linkable', async () => {
+  expect(await getStorePath({
+    pkgRoot: '/mnt/project-only',
+    pnpmHomeDir: '/local/share/pnpm',
+  })).toBe(`/local/share/pnpm/store/${STORE_VERSION}`)
 })
 
 test('fail when pnpm home directory is not defined', async () => {


### PR DESCRIPTION
fix(store): resolve store path calculation when project root is mountpoint (pnpm/pnpm#13602)

<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

This PR fixes `dirsAreEqual` in `pnpm11/store/path` which compared the output of `path.relative` to `.` instead of `''`. Under Node.js, `path.relative(x, x)` returns `''`, causing `dirsAreEqual` to evaluate to `false` for identical paths. 

Consequently, when a project root is mounted directly as a filesystem mountpoint (e.g. in VS Code devcontainers or custom mounts) and the parent directory is not linkable, the safety guard to fallback to the home directory is bypassed, and the store is placed inside the project folder at `<project-root>/.pnpm-store/v11`. This PR corrects the check.

Closes pnpm/pnpm#13602

## Squash Commit Body

```text
Fix `dirsAreEqual` in `@pnpm/store.path` to check for `""` (empty string) instead of `"."`. Node's `path.relative` returns an empty string when the two directory paths are equal. 

This fixes a bug where, if the project root itself is a mountpoint (and the parent directory is not linkable), `dirsAreEqual(pkgRoot, mountpoint)` incorrectly evaluates to `false`, causing the store to be placed inside the project directory under `<project-root>/.pnpm-store/v11` rather than falling back to the user's home directory.

The Rust pacquet port config (`pnpm/crates/config/src/store_path.rs`) is not affected as it uses direct path comparison (`mountpoint == pkg_root`).

Closes pnpm/pnpm#13602
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting. (The Rust port was not affected since it uses direct path equality).
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788343266&installation_model_id=426870&pr_number=13603&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13603&signature=d3380b219afe9f18c6e3da47bffab5735324fe2e2e0fe8f589669d87612578b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed store path comparison for project roots that are mountpoints.
  * Ensured the store is placed under the pnpm home directory when the mountpoint’s parent cannot be linked.
* **Tests**
  * Added coverage for mountpoint and empty relative path scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->