### PR TITLE
fix(deps-installer): prevent dedupe --check from moving hoisted dependencies

### DIFF
--- a/.changeset/dedupe-check-hoisted-node-linker.md
+++ b/.changeset/dedupe-check-hoisted-node-linker.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-installer": patch
+"pnpm": patch
+---
+
+Fixed an issue where running `pnpm dedupe --check` in projects with `nodeLinker: hoisted` would cause dependencies to be moved out of `node_modules` into `node_modules/.ignored`.

--- a/pnpm11/installing/commands/test/dedupe.ts
+++ b/pnpm11/installing/commands/test/dedupe.ts
@@ -133,6 +133,39 @@ describe('pnpm dedupe', () => {
     expect(server.getLines()).toStrictEqual([])
   })
 
+  test('dedupe --check does not move node_modules files in hoisted mode', async () => {
+    const project = prepare({
+      name: 'test-dedupe-check-hoisted',
+      version: '0.0.0',
+      dependencies: {
+        'is-positive': '3.1.0',
+      },
+    })
+
+    const opts = {
+      ...DEFAULT_OPTS,
+      dir: project.dir(),
+      lockfileDir: project.dir(),
+      workspaceDir: project.dir(),
+      nodeLinker: 'hoisted' as const,
+    }
+
+    await install.handler(opts)
+
+    const isPositivePath = path.join(project.dir(), 'node_modules/is-positive')
+    expect(fs.existsSync(isPositivePath)).toBeTruthy()
+    expect(fs.lstatSync(isPositivePath).isDirectory()).toBeTruthy()
+
+    await dedupe.handler({
+      ...opts,
+      check: true,
+    })
+
+    expect(fs.existsSync(isPositivePath)).toBeTruthy()
+    const ignoredPath = path.join(project.dir(), 'node_modules/.ignored/is-positive')
+    expect(fs.existsSync(ignoredPath)).toBeFalsy()
+  })
+
   describe('cliOptionsTypes', () => {
     test('trivially contains command line arguments from install command', () => {
       // Using --store-dir and --registry as a gut check to ensure the "pnpm

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -1679,7 +1679,7 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
       dedupeInjectedDeps: opts.dedupeInjectedDeps,
       dedupePeerDependents: opts.dedupePeerDependents,
       dedupePeers: opts.dedupePeers,
-      dryRun: opts.lockfileOnly,
+      dryRun: opts.lockfileOnly || isCheckOnlyInstall(opts),
       enableGlobalVirtualStore: opts.enableGlobalVirtualStore,
       engineStrict: opts.engineStrict,
       excludeLinksFromLockfile: opts.excludeLinksFromLockfile,


### PR DESCRIPTION
Ensure resolver dryRun is true for check-only installs to avoid modifying node_modules.

Resolves pnpm/pnpm#13503

<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

When `pnpm dedupe --check` runs, it calls `installDeps` with `lockfileCheck` set, but `dryRun` is set to `false`. In `mutateModules`, this goes down the `isCheckOnlyInstall(opts)` path, which suppresses writing packages to disk and skips final installations. However, during the initial resolution phase, the resolver runs `resolveDependencies`. The resolver was configured with `dryRun: opts.lockfileOnly`. Because `opts.lockfileOnly` is `false`, the resolver ran with `dryRun: false`, meaning it treated the run as a mutating installation.

Under `nodeLinker: hoisted`, the dependency directory isn't a symlink (an inner link), so the resolver's `partitionLinkedPackages` -> `safeIsInnerLink` treated it as an "alien module" and physically moved the dependency directory to `node_modules/.ignored`—causing a filesystem mutation during a check-only run.

This PR changes `resolveDependencies`'s `dryRun` parameter to `opts.lockfileOnly || isCheckOnlyInstall(opts)`. This ensures that any check-only runs (like `dedupe --check` or `install --dry-run`) treat resolution as a dry-run, which disables moving alien modules and avoids executing remote fetches.

## Squash Commit Body

During a check-only run (`pnpm dedupe --check` or `pnpm install --dry-run`), the resolver should perform its resolution phase as a dry-run. Previously, it received `dryRun: opts.lockfileOnly`, which was `false` during check-only runs. This caused `safeIsInnerLink` to physically move hoisted directories to `node_modules/.ignored` (thinking they were alien modules from another package manager), modifying `node_modules` during a check-only run.

Closes pnpm/pnpm#13503

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting. (Note: No cross-stack parity work implied — this is a v11-side regression; `dedupe` is not one of the install/add/update/remove parity commands, and the Rust `pacquet` `dedupe` uses an independent code path).
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788344373&installation_model_id=426870&pr_number=13604&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13604&signature=57d7a8253510ff1f3d0e9b51008b5085a3a40d16908aa46798ab3aa187cdc18a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `pnpm dedupe --check` with the hoisted linker so existing dependencies remain in place and are not incorrectly moved to `.ignored`.
  - Improved lockfile-check operations to avoid modifying the installed dependency layout.

- **Chores**
  - Added patch release notes for the affected packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->