### PR TITLE
fix(lockfile): read a CRLF or BOM-prefixed multi-document lockfile

### DIFF
--- a/.changeset/read-crlf-multi-document-lockfile.md
+++ b/.changeset/read-crlf-multi-document-lockfile.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `pnpm install` ignoring a `pnpm-lock.yaml` that carries a leading env lockfile document when the file has CRLF line endings or a UTF-8 byte order mark, as a `core.autocrlf` checkout on Windows produces. The lockfile was reported as broken with `multiple YAML documents detected` and every dependency was re-resolved from the registry [#13606](https://github.com/pnpm/pnpm/issues/13606).

--- a/pnpm/crates/lockfile/src/env_lockfile.rs
+++ b/pnpm/crates/lockfile/src/env_lockfile.rs
@@ -116,7 +116,7 @@ impl EnvLockfile {
         let Some(env_doc) = extract_env_document(&content) else {
             return Ok(None);
         };
-        let mut env: EnvLockfile = serde_saphyr::from_str(env_doc)
+        let mut env: EnvLockfile = serde_saphyr::from_str(&env_doc)
             .map_err(|source| LoadLockfileError::parse_yaml(&path, &source))?;
         env.root_importer_mut();
         Ok(Some(env))

--- a/pnpm/crates/lockfile/src/env_lockfile/tests.rs
+++ b/pnpm/crates/lockfile/src/env_lockfile/tests.rs
@@ -70,6 +70,19 @@ fn reads_non_numeric_lockfile_version() {
 }
 
 #[test]
+fn reads_a_crlf_combined_lockfile() {
+    let dir = TempDir::new().unwrap();
+    let env = sample_env_lockfile();
+    env.write(dir.path()).unwrap();
+    let path = dir.path().join(Lockfile::FILE_NAME);
+    let crlf = std::fs::read_to_string(&path).unwrap().replace('\n', "\r\n");
+    std::fs::write(&path, crlf).unwrap();
+
+    let read_back = EnvLockfile::read(dir.path()).unwrap().expect("env document present");
+    assert_eq!(read_back, env);
+}
+
+#[test]
 fn write_preserves_existing_main_document() {
     let dir = TempDir::new().unwrap();
     let main = "lockfileVersion: '9.0'\n\nimporters:\n\n  .:\n    dependencies:\n      is-odd:\n        specifier: 1.0.0\n        version: 1.0.0\n";

--- a/pnpm/crates/lockfile/src/load_lockfile.rs
+++ b/pnpm/crates/lockfile/src/load_lockfile.rs
@@ -118,7 +118,7 @@ impl Lockfile {
             return Ok(None);
         }
         serde_saphyr::from_str_with_options::<Self>(
-            main,
+            &main,
             serde_saphyr::options! {
                 // Every size-proportional budget is raised to the document's
                 // byte length: none of these dimensions can exceed the size of

--- a/pnpm/crates/lockfile/src/load_lockfile/tests.rs
+++ b/pnpm/crates/lockfile/src/load_lockfile/tests.rs
@@ -87,6 +87,29 @@ fn parses_main_document_from_combined_yaml() {
     assert_eq!(combined_loaded, main_only_loaded);
 }
 
+/// Regression test for <https://github.com/pnpm/pnpm/issues/13606>: a
+/// combined lockfile checked out with CRLF line endings was handed to
+/// serde whole, failing as "multiple YAML documents detected" and
+/// making every install re-resolve from the registry.
+#[test]
+fn parses_main_document_from_crlf_combined_yaml() {
+    let combined = format!("---\n{ENV_DOC}\n---\n{MAIN_DOC}").replace('\n', "\r\n");
+    let tmp = write_lockfile(&combined);
+    let virtual_store_dir = tmp.path().join("node_modules").join(".pacquet");
+
+    let crlf_loaded = Lockfile::load_current_from_virtual_store_dir(&virtual_store_dir)
+        .expect("load CRLF combined lockfile")
+        .expect("CRLF combined lockfile should be present");
+
+    let tmp_main = write_lockfile(MAIN_DOC);
+    let main_only_dir = tmp_main.path().join("node_modules").join(".pacquet");
+    let main_only_loaded = Lockfile::load_current_from_virtual_store_dir(&main_only_dir)
+        .expect("load main-only lockfile")
+        .expect("main-only lockfile should be present");
+
+    assert_eq!(crlf_loaded, main_only_loaded);
+}
+
 #[test]
 fn env_only_lockfile_loads_as_none() {
     let env_only = format!("---\n{ENV_DOC}\n");

--- a/pnpm/crates/lockfile/src/save_lockfile.rs
+++ b/pnpm/crates/lockfile/src/save_lockfile.rs
@@ -1,6 +1,9 @@
 use crate::{
     Lockfile, serialize_yaml,
-    yaml_documents::{YAML_DOCUMENT_SEPARATOR, YAML_DOCUMENT_START, extract_env_document},
+    yaml_documents::{
+        YAML_DOCUMENT_SEPARATOR, YAML_DOCUMENT_START, extract_env_document,
+        normalize_lockfile_content,
+    },
 };
 use derive_more::{Display, Error};
 use pacquet_diagnostics::miette::{self, Diagnostic};
@@ -79,9 +82,7 @@ pub fn save_value_to_path<Document: serde::Serialize>(
 ) -> Result<(), SaveLockfileError> {
     let content = serialize_yaml::to_string(value).map_err(SaveLockfileError::SerializeYaml)?;
     let existing = match fs::read_to_string(path) {
-        Ok(existing) => {
-            Some(existing.strip_prefix('\u{feff}').unwrap_or(&existing).replace("\r\n", "\n"))
-        }
+        Ok(existing) => Some(normalize_lockfile_content(&existing).into_owned()),
         Err(error) if error.kind() == io::ErrorKind::NotFound => None,
         Err(error) => return Err(SaveLockfileError::WriteFile(error)),
     };

--- a/pnpm/crates/lockfile/src/yaml_documents.rs
+++ b/pnpm/crates/lockfile/src/yaml_documents.rs
@@ -6,6 +6,13 @@
 //! and the second document is the regular project lockfile. Pacquet
 //! only consumes the second document, so this module strips the
 //! leading env document before handing the content to serde.
+//!
+//! Every entry point here takes the *whole* file and normalizes it
+//! first: a lockfile pacquet did not write may carry a UTF-8 BOM or
+//! CRLF line endings (a `core.autocrlf` checkout on Windows), and the
+//! document markers below would then match nothing.
+
+use std::borrow::Cow;
 
 /// Document-stream marker that ends one YAML document and starts the
 /// next.
@@ -14,16 +21,25 @@ pub(crate) const YAML_DOCUMENT_SEPARATOR: &str = "\n---\n";
 /// Document-stream marker at the very start of a file.
 pub(crate) const YAML_DOCUMENT_START: &str = "---\n";
 
+/// Strip a leading UTF-8 BOM and rewrite CRLF as LF, so the rest of the
+/// lockfile machinery only ever sees the byte shape pacquet writes.
+#[must_use]
+pub fn normalize_lockfile_content(content: &str) -> Cow<'_, str> {
+    let content = content.strip_prefix('\u{feff}').unwrap_or(content);
+    if content.contains("\r\n") {
+        Cow::Owned(content.replace("\r\n", "\n"))
+    } else {
+        Cow::Borrowed(content)
+    }
+}
+
 /// Extract the main lockfile document (second YAML document) from a
 /// combined file.
 #[must_use]
-pub fn extract_main_document(content: &str) -> &str {
-    let Some(rest) = content.strip_prefix(YAML_DOCUMENT_START) else {
-        return content;
-    };
-    match rest.find(YAML_DOCUMENT_SEPARATOR) {
-        Some(idx) => &rest[idx + YAML_DOCUMENT_SEPARATOR.len()..],
-        None => "",
+pub fn extract_main_document(content: &str) -> Cow<'_, str> {
+    match normalize_lockfile_content(content) {
+        Cow::Borrowed(content) => Cow::Borrowed(main_document_of(content)),
+        Cow::Owned(content) => Cow::Owned(main_document_of(&content).to_string()),
     }
 }
 
@@ -35,12 +51,25 @@ pub fn extract_main_document(content: &str) -> &str {
 /// - Returns the slice between the leading `---\n` and the next
 ///   `\n---\n` separator. A leading `---\n` with no following separator
 ///   (an env-only file with no main document) also yields `None`.
-///
-/// pacquet reads the whole lockfile into memory rather than streaming,
-/// so this skips chunked BOM/CRLF handling — the only callers pass
-/// content pacquet itself wrote with LF line endings.
 #[must_use]
-pub fn extract_env_document(content: &str) -> Option<&str> {
+pub fn extract_env_document(content: &str) -> Option<Cow<'_, str>> {
+    match normalize_lockfile_content(content) {
+        Cow::Borrowed(content) => env_document_of(content).map(Cow::Borrowed),
+        Cow::Owned(content) => env_document_of(&content).map(|doc| Cow::Owned(doc.to_string())),
+    }
+}
+
+fn main_document_of(content: &str) -> &str {
+    let Some(rest) = content.strip_prefix(YAML_DOCUMENT_START) else {
+        return content;
+    };
+    match rest.find(YAML_DOCUMENT_SEPARATOR) {
+        Some(idx) => &rest[idx + YAML_DOCUMENT_SEPARATOR.len()..],
+        None => "",
+    }
+}
+
+fn env_document_of(content: &str) -> Option<&str> {
     let rest = content.strip_prefix(YAML_DOCUMENT_START)?;
     rest.find(YAML_DOCUMENT_SEPARATOR).map(|idx| &rest[..idx])
 }

--- a/pnpm/crates/lockfile/src/yaml_documents/tests.rs
+++ b/pnpm/crates/lockfile/src/yaml_documents/tests.rs
@@ -1,4 +1,4 @@
-use super::extract_main_document;
+use super::{extract_env_document, extract_main_document};
 
 #[test]
 fn returns_entire_content_when_it_does_not_start_with_separator() {
@@ -17,4 +17,25 @@ fn returns_the_second_document_from_a_combined_file() {
     let main = "lockfileVersion: 9.0\npackages: {}\n";
     let combined = format!("---\nfoo: bar\n---\n{main}");
     assert_eq!(extract_main_document(&combined), main);
+}
+
+#[test]
+fn splits_a_crlf_combined_file() {
+    let combined = "---\r\nfoo: bar\r\n---\r\nlockfileVersion: 9.0\r\npackages: {}\r\n";
+    assert_eq!(extract_main_document(combined), "lockfileVersion: 9.0\npackages: {}\n");
+    assert_eq!(extract_env_document(combined).as_deref(), Some("foo: bar"));
+}
+
+#[test]
+fn splits_a_combined_file_behind_a_byte_order_mark() {
+    let combined = "\u{feff}---\nfoo: bar\n---\nlockfileVersion: 9.0\n";
+    assert_eq!(extract_main_document(combined), "lockfileVersion: 9.0\n");
+    assert_eq!(extract_env_document(combined).as_deref(), Some("foo: bar"));
+}
+
+#[test]
+fn normalizes_a_single_document_file() {
+    let content = "\u{feff}lockfileVersion: 9.0\r\npackages: {}\r\n";
+    assert_eq!(extract_main_document(content), "lockfileVersion: 9.0\npackages: {}\n");
+    assert_eq!(extract_env_document(content), None);
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/pnpm/pnpm/issues/13606: pnpm 12 discarded a `pnpm-lock.yaml` that pnpm 11 wrote as two YAML documents, warned `multiple YAML documents detected; use from_multiple or from_multiple_with_options`, and re-resolved every dependency from the registry — so the lockfile stopped pinning anything.

`extract_main_document` / `extract_env_document` in `pnpm/crates/lockfile/src/yaml_documents.rs` split the combined lockfile by matching the literal markers `---\n` and `\n---\n`. A lockfile pacquet did not write may not use LF: a `core.autocrlf` checkout on Windows (the reporter's platform) gives CRLF, and an editor may add a UTF-8 BOM. Neither marker matches then, so `extract_main_document` fell through to `return content` — the whole two-document file — which `serde_saphyr::from_str_with_options` rejected with exactly the reported error, at the line where the second document starts.

The fix normalizes the whole file (strip a leading BOM, rewrite CRLF as LF) inside both extractors, so every caller is covered: `Lockfile::parse`, `Lockfile::wanted_exists_in_dir`, `EnvLockfile::read`, `EnvLockfile::write`, and `save_value_to_path`. `Cow` keeps the common LF path allocation-free. `save_value_to_path` already did this normalization inline and now shares the helper instead.

**No TypeScript counterpart is needed.** `pnpm11/lockfile/fs/src/yamlDocuments.ts` already normalizes CRLF inside `extractMainDocument` / `extractEnvDocument` and strips the BOM at every read site; this brings pacquet to the behavior the TypeScript CLI already has.

Tests added: CRLF and BOM document splits in `yaml_documents/tests.rs`, a loader-level regression asserting a CRLF combined lockfile loads identically to the equivalent main-only lockfile, and a CRLF env-document read.

Note on local verification: `just ready` is green except for `package_manager_check::a_command_outside_the_install_family_records_the_pinned_package_manager` and `a_package_manager_field_with_an_integrity_hash_matches_the_running_version`, which fail on `main` too — they bootstrap the pinned `pnpm@12.0.0-beta.4` from the real registry and that version is not published yet (npm's `next-12` is still `12.0.0-beta.3`). They fail before any lockfile is read.

## Squash Commit Body

```text
`extract_main_document` / `extract_env_document` split the combined
`pnpm-lock.yaml` on literal `---\n` and `\n---\n`. A lockfile pacquet
did not write may carry CRLF line endings — a `core.autocrlf` checkout
on Windows — or a UTF-8 BOM, and neither marker then matches. The main
extractor fell through to returning the whole file, which serde rejected
as `multiple YAML documents detected`, so the lockfile was discarded and
every dependency re-resolved from the registry.

Normalize the whole file (strip BOM, CRLF to LF) inside both extractors,
which covers every caller. `save_value_to_path` already normalized the
same way inline and now shares the helper.

The TypeScript stack needs no counterpart change:
`pnpm11/lockfile/fs/src/yamlDocuments.ts` already normalizes CRLF in
`extractMainDocument` / `extractEnvDocument` and strips the BOM at each
read site.

Closes pnpm/pnpm#13606
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788358044&installation_model_id=426870&pr_number=13609&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13609&signature=f9c10326b492f71f093e46b85d387245475f193402dd32786eef014cd48c11c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm install` handling of lockfiles with CRLF line endings, UTF-8 BOMs, or leading environment documents.
  * Prevented incorrect multiple-document errors and unnecessary dependency re-resolution.
  * Preserved correct lockfile behavior when reading and saving normalized content.

* **Tests**
  * Added regression coverage for combined, BOM-prefixed, and CRLF-formatted lockfiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->