### PR TITLE
fix(config): expand ${ENV} in trusted _auth authToken values

### DIFF
--- a/pnpm11/config/reader/src/loadNpmrcFiles.ts
+++ b/pnpm11/config/reader/src/loadNpmrcFiles.ts
@@ -130,8 +130,8 @@ export function loadNpmrcConfig (opts: LoadNpmrcConfigOpts): NpmrcConfigResult {
   // runners that silently drop env vars whose names contain `/`, `:`, or
   // `.` — GitHub Actions, bash, zsh; see pnpm/pnpm#12314) and the `_auth`
   // key of the global pnpm config yaml. The env var wins on conflict.
-  const envJsonAuth = readJsonAuthEnv(env)
-  const globalConfigJsonAuth = readGlobalConfigAuth(opts.globalConfigAuth)
+  const envJsonAuth = readJsonAuthEnv(env, warnings)
+  const globalConfigJsonAuth = readGlobalConfigAuth(opts.globalConfigAuth, env, warnings)
   const jsonAuth: JsonAuthResult = {
     auth: { ...globalConfigJsonAuth.auth, ...envJsonAuth.auth },
     registries: { ...globalConfigJsonAuth.registries, ...envJsonAuth.registries },
@@ -239,7 +239,7 @@ function readUrlScopedEnvConfig (env: Record<string, string | undefined>): Recor
   return { ...npmScoped, ...pnpmScoped }
 }
 
-function readJsonAuthEnv (env: Record<string, string | undefined>): JsonAuthResult {
+function readJsonAuthEnv (env: Record<string, string | undefined>, warnings: string[]): JsonAuthResult {
   const value = readJsonAuthEnvValue(env)
   if (value == null) return { auth: {}, registries: {} }
 
@@ -249,7 +249,7 @@ function readJsonAuthEnv (env: Record<string, string | undefined>): JsonAuthResu
   } catch (err: unknown) {
     throw new PnpmError('INVALID_AUTH_SETTING', `Failed to parse pnpm_config__auth as JSON: ${err instanceof Error ? err.message : String(err)}`)
   }
-  return parseJsonAuth(parsed, 'pnpm_config__auth')
+  return parseJsonAuth(parsed, 'pnpm_config__auth', env, warnings)
 }
 
 /**
@@ -261,7 +261,12 @@ function readJsonAuthEnv (env: Record<string, string | undefined>): JsonAuthResu
  * typo should fail fast rather than silently drop auth. `source` names the
  * origin in errors; raw URL keys are never echoed — they can embed secrets.
  */
-function parseJsonAuth (parsed: unknown, source: string): JsonAuthResult {
+function parseJsonAuth (
+  parsed: unknown,
+  source: string,
+  env: Record<string, string | undefined>,
+  warnings: string[]
+): JsonAuthResult {
   if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
     throw new PnpmError('INVALID_AUTH_SETTING', `${source} must be a JSON object`)
   }
@@ -280,7 +285,7 @@ function parseJsonAuth (parsed: unknown, source: string): JsonAuthResult {
       if (rawCreds === null || typeof rawCreds !== 'object' || Array.isArray(rawCreds)) {
         throw new PnpmError('INVALID_AUTH_SETTING', `${source}[${registry.label}][${JSON.stringify(scope)}] must be an auth object`)
       }
-      const token = jsonAuthToken(rawCreds as Record<string, unknown>, registry, scope, source)
+      const token = jsonAuthToken(rawCreds as Record<string, unknown>, registry, scope, source, env, warnings)
       auth[`${registry.nerfed}:${scope === '@' ? '' : `${scope}:`}_authToken`] = token
       // Infer a registry route from the same entry (see JsonAuthResult.registries).
       // Last write wins on a duplicate scope, matching yaml/CLI.
@@ -291,9 +296,13 @@ function parseJsonAuth (parsed: unknown, source: string): JsonAuthResult {
 }
 
 /** Parse `_auth` from the global pnpm config yaml (already a parsed object). */
-function readGlobalConfigAuth (globalConfigAuth: unknown): JsonAuthResult {
+function readGlobalConfigAuth (
+  globalConfigAuth: unknown,
+  env: Record<string, string | undefined>,
+  warnings: string[]
+): JsonAuthResult {
   if (globalConfigAuth == null) return { auth: {}, registries: {} }
-  return parseJsonAuth(globalConfigAuth, '_auth')
+  return parseJsonAuth(globalConfigAuth, '_auth', env, warnings)
 }
 
 interface JsonAuthRegistry {
@@ -356,7 +365,9 @@ function jsonAuthToken (
   creds: Record<string, unknown>,
   registry: JsonAuthRegistry,
   scope: string,
-  source: string
+  source: string,
+  env: Record<string, string | undefined>,
+  warnings: string[]
 ): string {
   for (const field of Object.keys(creds)) {
     if (field !== 'authToken') {
@@ -367,7 +378,9 @@ function jsonAuthToken (
   if (typeof token !== 'string') {
     throw new PnpmError('INVALID_AUTH_SETTING', `${source}[${registry.label}][${JSON.stringify(scope)}]: "authToken" must be a string`)
   }
-  return token
+  // Trusted sources only (global config.yaml / pnpm_config__auth). Expand
+  // `${ENV}` the same way .npmrc auth values do — see #12828.
+  return substituteEnv(token, env, warnings)
 }
 
 // Per-registry rc keys that, when written without a `//host/` prefix, fall

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -1454,6 +1454,52 @@ test('reads a host-keyed default auth token from pnpm_config__auth', async () =>
   expect(config.authConfig['//json-test.example/:_authToken']).toBe('json-token')
 })
 
+test('expands ${ENV} placeholders inside pnpm_config__auth authToken values', async () => {
+  prepareEmpty()
+
+  const { config } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      MY_REGISTRY_TOKEN: 'resolved-secret',
+      pnpm_config__auth: JSON.stringify({
+        'https://json-test.example': {
+          '@': { authToken: '${MY_REGISTRY_TOKEN}' },
+        },
+      }),
+    },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+  })
+
+  expect(config.authConfig['//json-test.example/:_authToken']).toBe('resolved-secret')
+})
+
+test('expands ${ENV} placeholders inside global config.yaml _auth authToken values', async () => {
+  prepareEmpty()
+
+  fs.mkdirSync('.config/pnpm', { recursive: true })
+  writeYamlFileSync('.config/pnpm/config.yaml', {
+    _auth: {
+      'https://yaml-auth.example/': {
+        '@': { authToken: '${YAML_AUTH_TOKEN}' },
+      },
+    },
+  })
+  process.env.XDG_CONFIG_HOME = path.resolve('.config')
+  process.env.YAML_AUTH_TOKEN = 'yaml-resolved'
+
+  const { config } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      YAML_AUTH_TOKEN: 'yaml-resolved',
+    },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+  })
+
+  expect(config.authConfig['//yaml-auth.example/:_authToken']).toBe('yaml-resolved')
+})
+
 test('pnpm_config__auth normalizes registry URL keys before keying auth', async () => {
   prepareEmpty()
 

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -1487,8 +1487,10 @@ test('expands ${ENV} placeholders inside global config.yaml _auth authToken valu
   })
   const originalXdg = process.env.XDG_CONFIG_HOME
   const originalYamlToken = process.env.YAML_AUTH_TOKEN
-  process.env.XDG_CONFIG_HOME = path.resolve('.config')
-  process.env.YAML_AUTH_TOKEN = 'yaml-resolved'
+  const configHome = path.resolve('.config')
+  process.env.XDG_CONFIG_HOME = configHome
+  // Ensure expansion comes from getConfig's env, not process.env.
+  delete process.env.YAML_AUTH_TOKEN
 
   try {
     const { config } = await getConfig({
@@ -1496,7 +1498,7 @@ test('expands ${ENV} placeholders inside global config.yaml _auth authToken valu
       env: {
         ...env,
         YAML_AUTH_TOKEN: 'yaml-resolved',
-        XDG_CONFIG_HOME: path.resolve('.config'),
+        XDG_CONFIG_HOME: configHome,
       },
       packageManager: { name: 'pnpm', version: '1.0.0' },
     })

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -1485,19 +1485,35 @@ test('expands ${ENV} placeholders inside global config.yaml _auth authToken valu
       },
     },
   })
+  const originalXdg = process.env.XDG_CONFIG_HOME
+  const originalYamlToken = process.env.YAML_AUTH_TOKEN
   process.env.XDG_CONFIG_HOME = path.resolve('.config')
   process.env.YAML_AUTH_TOKEN = 'yaml-resolved'
 
-  const { config } = await getConfig({
-    cliOptions: {},
-    env: {
-      ...env,
-      YAML_AUTH_TOKEN: 'yaml-resolved',
-    },
-    packageManager: { name: 'pnpm', version: '1.0.0' },
-  })
+  try {
+    const { config } = await getConfig({
+      cliOptions: {},
+      env: {
+        ...env,
+        YAML_AUTH_TOKEN: 'yaml-resolved',
+        XDG_CONFIG_HOME: path.resolve('.config'),
+      },
+      packageManager: { name: 'pnpm', version: '1.0.0' },
+    })
 
-  expect(config.authConfig['//yaml-auth.example/:_authToken']).toBe('yaml-resolved')
+    expect(config.authConfig['//yaml-auth.example/:_authToken']).toBe('yaml-resolved')
+  } finally {
+    if (originalXdg === undefined) {
+      delete process.env.XDG_CONFIG_HOME
+    } else {
+      process.env.XDG_CONFIG_HOME = originalXdg
+    }
+    if (originalYamlToken === undefined) {
+      delete process.env.YAML_AUTH_TOKEN
+    } else {
+      process.env.YAML_AUTH_TOKEN = originalYamlToken
+    }
+  }
 })
 
 test('pnpm_config__auth normalizes registry URL keys before keying auth', async () => {


### PR DESCRIPTION
## Summary

Fixes #12828.

Structured `_auth` (global `config.yaml` and `pnpm_config__auth`) did not expand `${ENV}` / `${ENV-default}` in `authToken` values, unlike `.npmrc` auth settings. Installs then sent the literal placeholder as the bearer token and failed with 401.

### Change

Run `authToken` through the existing `substituteEnv` helper when parsing trusted `_auth` JSON/YAML. Project `.npmrc` env rules are unchanged.

### Test plan

- [x] `pnpm_config__auth` with `authToken: '${MY_REGISTRY_TOKEN}'` resolves from the environment
- [x] Global `config.yaml` `_auth` authToken expands the same way


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication tokens from supported configuration sources now expand environment variables correctly.
  * Unresolved environment-variable placeholders are reported as warnings instead of failing silently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->