### PR TITLE
fix: honor updateNotifier=false inside checkForUpdates

### DIFF
--- a/pnpm11/pnpm/src/checkForUpdates.test.ts
+++ b/pnpm11/pnpm/src/checkForUpdates.test.ts
@@ -98,3 +98,23 @@ test('check for updates when last update check happened two days ago', async () 
   expect(state.lastUpdateCheck).toBeDefined()
   expect(state.lastUpdateCheck).not.toEqual(initialLastUpdateCheck)
 })
+
+test('does not check for updates when updateNotifier is false', async () => {
+  prepareEmpty()
+
+  const { config } = await getConfig({
+    cliOptions: {},
+    packageManager: {
+      name: 'pnpm',
+      version: '1.0.0',
+    },
+  })
+  await checkForUpdates({
+    ...config,
+    stateDir: process.cwd(),
+    updateNotifier: false,
+  })
+
+  expect(updateCheckLogger.debug).not.toHaveBeenCalled()
+  expect(() => loadJsonFileSync('pnpm-state.json')).toThrow()
+})

--- a/pnpm11/pnpm/src/checkForUpdates.ts
+++ b/pnpm11/pnpm/src/checkForUpdates.ts
@@ -14,6 +14,13 @@ interface State {
 const UPDATE_CHECK_FREQUENCY = 24 * 60 * 60 * 1000 // 1 day
 
 export async function checkForUpdates (config: Config): Promise<void> {
+  // Defense in depth: callers should skip when disabled, but honor the setting
+  // here too so a forgotten call site cannot ignore `updateNotifier: false`
+  // (https://github.com/pnpm/pnpm/issues/12731).
+  if (config.updateNotifier === false) {
+    return
+  }
+
   const stateFile = path.join(config.stateDir, 'pnpm-state.json')
   let state: State | undefined
   try {


### PR DESCRIPTION
## Summary

Fixes #12731.

`main.ts` skips scheduling an update check when `updateNotifier === false`, but `checkForUpdates` itself did not re-check the flag. If the state file was missing and any path called the helper anyway, the notifier still ran.

### Change

Return immediately from `checkForUpdates` when `config.updateNotifier === false`, and cover that with a unit test (no logger call, no `pnpm-state.json` write).

### Test plan

- [x] Unit: `updateNotifier: false` → no update check / no state file
- [ ] Manual: set `update-notifier: false` in global `config.yaml` or `pnpm-workspace.yaml`, remove `pnpm-state.json`, run `pnpm install`, confirm no update notifier