### PR TITLE
test(cli): pass the restart log path through `process.argv`

### DIFF
--- a/pnpm/crates/cli/src/cli_args/restart/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/restart/tests.rs
@@ -62,11 +62,14 @@ fn restart_passes_args_to_each_script() {
     let tmp = TempDir::new().expect("tmp dir");
     let dir = tmp.path();
     let log_file = dir.join("log.txt");
+    // The log path travels as a script argument, not inside the JS source:
+    // interpolated there, a Windows path's backslashes would be swallowed as
+    // string escapes. The forwarded restart argument lands after it.
     let append_arg_node = |name: &str| {
         format!(
-            r#"node -e "require('fs').appendFileSync('{}', '{} ' + process.argv[1] + '\n')""#,
-            log_file.display(),
+            r#"node -e "require('fs').appendFileSync(process.argv[1], '{} ' + process.argv[2] + '\n')" "{}""#,
             name,
+            log_file.display(),
         )
     };
     let manifest = json!({

--- a/pnpm/crates/cli/tests/restart.rs
+++ b/pnpm/crates/cli/tests/restart.rs
@@ -113,11 +113,14 @@ fn restart_with_if_present_skips_missing_scripts() {
 fn restart_passes_args_to_scripts() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
     let log_file = workspace.join("log.txt");
+    // The log path travels as a script argument, not inside the JS source:
+    // interpolated there, a Windows path's backslashes would be swallowed as
+    // string escapes. The forwarded restart argument lands after it.
     let append_arg_node = |name: &str| {
         format!(
-            r#"node -e "require('fs').appendFileSync('{}', '{} ' + process.argv[1] + '\n')""#,
-            log_file.display(),
+            r#"node -e "require('fs').appendFileSync(process.argv[1], '{} ' + process.argv[2] + '\n')" "{}""#,
             name,
+            log_file.display(),
         )
     };
     let manifest = json!({


### PR DESCRIPTION
## Summary

Resolves <https://github.com/pnpm/pnpm/issues/12720>.

The `node -e` helper in the restart tests interpolated the log file's path into a single-quoted JavaScript string literal, so a Windows path such as `C:\Users\...\log.txt` has `\U` and `\n` parsed as escape sequences and the script appends to a mangled path instead of the log the test reads back. The helper now passes the path as a script argument and reads it from `process.argv[1]`, never letting it reach the JavaScript parser; the argument that `pnpm restart` forwards to each script follows at `process.argv[2]`.

Both copies of the helper are updated: the unit tests in `pnpm/crates/cli/src/cli_args/restart/tests.rs` and the integration tests in `pnpm/crates/cli/tests/restart.rs`. The sibling shell helpers need no equivalent change — they interpolate into a double-quoted POSIX shell word, which does not eat backslashes.

Both tests remain `#[cfg(unix)]`, so this fixes a latent defect rather than an observed failure; lifting the gates needs a Windows machine to verify and is not part of this change. There is nothing to port to the TypeScript CLI, whose test helpers already pass paths as shell-quoted arguments rather than embedding them in JavaScript source.

## Squash Commit Body

```text
The `node -e` helper in the restart tests interpolated the log file's
path straight into a single-quoted JavaScript string literal. A Windows
temp path such as `C:\Users\...\log.txt` is then parsed as JS text, so
`\U` and `\n` become escape sequences and the script appends to a
mangled path instead of the log the test reads back.

Pass the path as a script argument and read it from `process.argv[1]`
instead, so it never reaches the JavaScript parser. The argument that
`pnpm restart` forwards to each script follows it at `process.argv[2]`.

Both copies of the helper are updated: the unit tests in
`cli_args/restart/tests.rs` and the integration tests in
`tests/restart.rs`.

The sibling shell helpers in the same files interpolate the path into a
double-quoted POSIX shell word, which does not eat backslashes, and
those tests are gated to Unix; they need no equivalent change.

Resolves https://github.com/pnpm/pnpm/issues/12720.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added or updated tests.

---
Written by an agent (Claude Code).

_Generated by [Claude Code](https://claude.ai/code)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved restart argument-forwarding test coverage to handle log paths and forwarded script arguments more reliably.
  * Reduced test fragility by passing values through process arguments instead of embedding them in generated script code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->