### PR TITLE
fix(link-bins): reapply executable bit to restored bins

### DIFF
--- a/.changeset/reapply-executable-bit-to-restored-bins.md
+++ b/.changeset/reapply-executable-bit-to-restored-bins.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/bins.linker": patch
+"pnpm": patch
+---
+
+When a failed install re-copies a bin script from the store, rerunning `pnpm install` now reapplies the executable bit to the bin instead of leaving it non-executable [#12742](https://github.com/pnpm/pnpm/issues/12742).

--- a/pnpm11/bins/linker/src/index.ts
+++ b/pnpm11/bins/linker/src/index.ts
@@ -264,20 +264,26 @@ async function linkBin (cmd: CommandInfo, binsDir: string, opts?: LinkBinOptions
   // This avoids redundant I/O on warm installs and EACCES on read-only stores.
   // We verify the target path — not just existence — so that conflict resolution
   // changes or provider swaps still get the bin rewritten.
+  let isCorrectlyLinked = false
   try {
     const stat = await fs.lstat(externalBinPath)
     if (stat.isSymbolicLink()) {
       const target = await fs.readlink(externalBinPath)
-      if (target === cmd.path || path.resolve(binsDir, target) === path.resolve(cmd.path)) {
-        return
-      }
+      isCorrectlyLinked = target === cmd.path || path.resolve(binsDir, target) === path.resolve(cmd.path)
     } else if (stat.isFile() && stat.size < CMD_SHIM_MAX_SIZE) {
       const content = await fs.readFile(externalBinPath, 'utf8')
-      if (isShimPointingAt(content, cmd.path)) {
-        return
-      }
+      isCorrectlyLinked = isShimPointingAt(content, cmd.path)
     }
   } catch {}
+  if (isCorrectlyLinked) {
+    // If a previous install failed, we may have re-copied the bin script from
+    // the store, but we won't necessarily have reapplied the executable bit -
+    // so apply it here.
+    if (EXECUTABLE_SHEBANG_SUPPORTED) {
+      await ensureExecutableIfNeeded(cmd.path, 0o755)
+    }
+    return
+  }
   if (IS_WINDOWS) {
     const exePath = path.join(binsDir, `${cmd.name}${getExeExtension()}`)
     // node.exe is the only bin pnpm links directly as a real executable rather
@@ -451,6 +457,13 @@ async function ensureExecutable (file: string, mode: number): Promise<void> {
       if (stat != null && (stat.mode & 0o111) !== 0 && !(await hasWindowsShebang(file))) return
     }
     throw err
+  }
+}
+
+async function ensureExecutableIfNeeded (file: string, mode: number): Promise<void> {
+  const stat = await fs.stat(file)
+  if ((stat.mode & 0o111) === 0 || await hasWindowsShebang(file)) {
+    await ensureExecutable(file, mode)
   }
 }
 

--- a/pnpm11/bins/linker/src/index.ts
+++ b/pnpm11/bins/linker/src/index.ts
@@ -460,8 +460,12 @@ async function ensureExecutable (file: string, mode: number): Promise<void> {
   }
 }
 
+// A missing or unreadable source is skipped rather than failing the install:
+// the existing bin was accepted as correctly linked, and before this repair
+// step the skip path returned without touching the source at all.
 async function ensureExecutableIfNeeded (file: string, mode: number): Promise<void> {
-  const stat = await fs.stat(file)
+  const stat = await fs.stat(file).catch(() => undefined)
+  if (stat == null) return
   if ((stat.mode & 0o111) === 0 || await hasWindowsShebang(file)) {
     await ensureExecutable(file, mode)
   }

--- a/pnpm11/bins/linker/test/index.ts
+++ b/pnpm11/bins/linker/test/index.ts
@@ -114,6 +114,18 @@ testOnPosix('linkBins() repairs a non-executable source when the existing bin re
   expect(fs.statSync(binSource).mode & 0o777).toBe(0o755)
 })
 
+testOnPosix('linkBins() keeps a correctly linked bin whose source file is missing', async () => {
+  const binTarget = temporaryDirectory()
+  const warn = jest.fn()
+  const simpleFixture = f.prepare('simple-fixture')
+  const binSource = path.join(simpleFixture, 'node_modules', 'simple', 'index.js')
+
+  await linkBins(path.join(simpleFixture, 'node_modules'), binTarget, { warn })
+  fs.rmSync(binSource)
+
+  await expect(linkBins(path.join(simpleFixture, 'node_modules'), binTarget, { warn })).resolves.not.toThrow()
+})
+
 test('linkBins() rewrites bins that lack a target marker', async () => {
   const binTarget = temporaryDirectory()
   const warn = jest.fn()

--- a/pnpm11/bins/linker/test/index.ts
+++ b/pnpm11/bins/linker/test/index.ts
@@ -100,6 +100,20 @@ test('linkBins() skips bins that already reference the correct target', async ()
   expect(fs.readFileSync(binLocation, 'utf8')).toBe(sentinel)
 })
 
+testOnPosix('linkBins() repairs a non-executable source when the existing bin references it', async () => {
+  const binTarget = temporaryDirectory()
+  const warn = jest.fn()
+  const simpleFixture = f.prepare('simple-fixture')
+  const binSource = path.join(simpleFixture, 'node_modules', 'simple', 'index.js')
+
+  await linkBins(path.join(simpleFixture, 'node_modules'), binTarget, { warn })
+  fs.chmodSync(binSource, 0o644)
+
+  await linkBins(path.join(simpleFixture, 'node_modules'), binTarget, { warn })
+
+  expect(fs.statSync(binSource).mode & 0o777).toBe(0o755)
+})
+
 test('linkBins() rewrites bins that lack a target marker', async () => {
   const binTarget = temporaryDirectory()
   const warn = jest.fn()


### PR DESCRIPTION
## Summary

When a `pnpm install` fails we may re-copy a bin script from the store when `pnpm install` is rerun. After pnpm/pnpm#11069 though, we don't reapply the executable bit to the bin script that we did on the first install attempt. This change fixes that by reapplying the executable bit when necessary. This should fix pnpm/pnpm#12742.

## Squash Commit Body

```text
When a `pnpm install` fails we may re-copy a bin script from the store when `pnpm install` is rerun.
After pnpm/pnpm#11069 though, we don't reapply the executable bit to the bin script that we did on
the first install attempt. This change fixes that by reapplying the executable bit when necessary.
This should fix pnpm/pnpm#12742.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [ ] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13630"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788415304&installation_model_id=426870&pr_number=13630&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13630&signature=e21dad998374251881ad17266b11895241f79e416c3aa1bb184bd62728c9e411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where executable permissions could be lost when an existing link or shim already pointed to a binary.
  - Improved handling of binaries with Windows-style shebangs to ensure they remain executable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->