### PR TITLE
fix(ci): resume partial pnpr npm publishes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1359,8 +1359,23 @@ jobs:
         env:
           TAG: ${{ needs.plan.outputs.pnpr_tag }}
         run: |
+          set -euo pipefail
           for package in pnpr/npm/pnpr-* pnpr/npm/pnpr; do
-            pnpm publish "$package/" --tag "$TAG" --access public --provenance --no-git-checks
+            name=$(jq -r '.publishConfig.name // .name' "$package/package.json")
+            version=$(jq -r '.version' "$package/package.json")
+            state=$(.github/scripts/npm-package-publication-state.sh "$name@$version")
+            case "$state" in
+              published)
+                echo "$name@$version is already published; skipping"
+                ;;
+              missing)
+                pnpm publish "$package/" --tag "$TAG" --access public --provenance --no-git-checks
+                ;;
+              *)
+                echo "::error::Unexpected npm publication state"
+                exit 1
+                ;;
+            esac
           done
 
   docker-pnpr:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1372,7 +1372,7 @@ jobs:
                 pnpm publish "$package/" --tag "$TAG" --access public --provenance --no-git-checks
                 ;;
               *)
-                echo "::error::Unexpected npm publication state"
+                echo "::error::Unexpected npm publication state for $name@$version"
                 exit 1
                 ;;
             esac


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

A rerun after a partial pnpr npm publication tried to publish every native package again. npm's immutable versions then caused the workflow to fail before it could publish the missing packages or wrapper.

- Reuse the workflow's publication-state helper for each native pnpr package.
- Skip versions that are already published and publish only missing versions.
- Abort on registry lookup errors and keep the wrapper publication last.

## Squash Commit Body

```text
Make pnpr npm publication resumable after a partially successful run. Check each native package's publication state, skip immutable versions that already exist, and publish only missing packages.

Treat lookup failures as fatal rather than as missing versions, and continue publishing the wrapper only after every native package is confirmed available.
```

## Checklist

- [x] Verified the workflow YAML, the publication-state helper tests, and mixed-state resume behavior.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788419711&installation_model_id=426870&pr_number=13635&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13635&signature=e74007979af5f77f9207030c59e73fb5b00dfbf9eb4bf11d610f651cc6e38149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package release handling by skipping packages that are already published.
  * Packages missing from the registry are now published automatically.
  * Releases now fail clearly when an unexpected registry state is detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->