### PR TITLE
fix(package-manager): don't write the PnP loader for a virtual-store-only install

### DIFF
--- a/.changeset/pnp-loader-virtual-store-only.md
+++ b/.changeset/pnp-loader-virtual-store-only.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/installing.deps-installer": patch
+"@pnpm/installing.deps-restorer": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+`pnpm fetch`, and any install run with `virtualStoreOnly`, no longer writes a `.pnp.cjs` loader under `nodeLinker: pnp`. These installs populate the virtual store without linking the project, so the loader would have claimed the project resolves out of a store it was never linked into. The importer links and `node_modules/.package-map.json` were already skipped; the PnP loader now follows the same rule.

--- a/pnpm/crates/cli/tests/fetch.rs
+++ b/pnpm/crates/cli/tests/fetch.rs
@@ -175,3 +175,36 @@ fn fetch_populates_the_global_virtual_store_without_importer_links() {
 
     drop((root, mock_instance));
 }
+
+/// `.pnp.cjs` is how a `PnP` project resolves, which makes it a
+/// project-level artifact like the importer links `fetch` already skips.
+/// Writing it would leave the project claiming to resolve out of a store
+/// that `fetch` populated but never linked into.
+///
+/// `fetch` takes its linker from configuration rather than a flag, so
+/// the linker is set in `pnpm-workspace.yaml`.
+#[test]
+fn fetch_under_pnp_does_not_write_the_loader() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { store_dir, mock_instance, .. } = npmrc_info;
+
+    // Append rather than overwrite: the harness's own workspace manifest
+    // carries `storeDir` / `cacheDir` / `registry`, and losing those
+    // makes the store assertion below fail for an unrelated reason.
+    let workspace_manifest = workspace.join("pnpm-workspace.yaml");
+    let mut yaml = fs::read_to_string(&workspace_manifest).expect("read pnpm-workspace.yaml");
+    yaml.push_str("nodeLinker: pnp\n");
+    fs::write(&workspace_manifest, yaml).expect("write pnpm-workspace.yaml");
+
+    write_manifest_and_lockfile(&workspace);
+    pacquet_at(&workspace).with_arg("fetch").assert().success();
+
+    assert!(store_dir.join("v11").exists(), "fetch must still populate the store");
+    assert!(
+        !workspace.join(".pnp.cjs").exists(),
+        "fetch must not write the PnP loader: it never linked the project",
+    );
+
+    drop((root, mock_instance, store_dir));
+}

--- a/pnpm/crates/cli/tests/fetch.rs
+++ b/pnpm/crates/cli/tests/fetch.rs
@@ -1,5 +1,6 @@
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
+use pacquet_store_dir::STORE_VERSION;
 use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
 use std::{fs, path::Path, process::Command};
 
@@ -84,7 +85,7 @@ fn fetch_populates_every_group_by_default() {
 
     pacquet_at(&workspace).with_arg("fetch").assert().success();
 
-    assert!(store_dir.join("v11").exists(), "fetch must populate the store");
+    assert!(store_dir.join(STORE_VERSION).exists(), "fetch must populate the store");
     assert!(virtual_dep(&workspace, PROD_DEP).exists(), "production dep must be fetched");
     assert!(virtual_dep(&workspace, DEV_DEP).exists(), "dev dep must be fetched");
     assert!(virtual_dep(&workspace, OPTIONAL_DEP).exists(), "optional dep must be fetched");
@@ -165,7 +166,7 @@ fn fetch_populates_the_global_virtual_store_without_importer_links() {
 
     pacquet_at(&workspace).with_arg("fetch").assert().success();
 
-    let gvs_root = store_dir.join(pacquet_store_dir::STORE_VERSION).join("links");
+    let gvs_root = store_dir.join(STORE_VERSION).join("links");
     assert!(gvs_root.is_dir(), "fetch must populate the global virtual store");
     assert!(
         gvs_root.join(PROD_DEP).join("100.0.0").is_dir(),
@@ -200,7 +201,7 @@ fn fetch_under_pnp_does_not_write_the_loader() {
     write_manifest_and_lockfile(&workspace);
     pacquet_at(&workspace).with_arg("fetch").assert().success();
 
-    assert!(store_dir.join("v11").exists(), "fetch must still populate the store");
+    assert!(store_dir.join(STORE_VERSION).exists(), "fetch must still populate the store");
     assert!(
         !workspace.join(".pnp.cjs").exists(),
         "fetch must not write the PnP loader: it never linked the project",

--- a/pnpm/crates/cli/tests/install.rs
+++ b/pnpm/crates/cli/tests/install.rs
@@ -1916,3 +1916,40 @@ fn an_unmigrated_package_json_pnpm_field_is_not_reported() {
 
     drop(root);
 }
+
+/// `virtualStoreOnly` populates the virtual store and creates no
+/// importer links. `.pnp.cjs` is how a `PnP` project resolves, so it is a
+/// project-level artifact of the same kind and must not be written
+/// either — otherwise the project claims to resolve out of a store it
+/// was never linked into.
+///
+/// Covers the fresh-resolution path: `pnpm fetch` pins
+/// `frozenLockfile`, so only a plain install reaches this one.
+#[test]
+fn virtual_store_only_install_under_pnp_does_not_write_the_loader() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { store_dir, mock_instance, .. } = npmrc_info;
+
+    // Append: the harness's own workspace manifest carries `storeDir` /
+    // `cacheDir` / `registry`.
+    let workspace_manifest = workspace.join("pnpm-workspace.yaml");
+    let mut yaml = std::fs::read_to_string(&workspace_manifest).expect("read pnpm-workspace.yaml");
+    yaml.push_str("nodeLinker: pnp\nvirtualStoreOnly: true\n");
+    std::fs::write(&workspace_manifest, yaml).expect("write pnpm-workspace.yaml");
+
+    std::fs::write(
+        workspace.join("package.json"),
+        r#"{"dependencies":{"@pnpm.e2e/foo":"100.0.0"}}"#,
+    )
+    .expect("write package.json");
+
+    pacquet.with_arg("install").assert().success();
+
+    assert!(
+        !workspace.join(".pnp.cjs").exists(),
+        "virtualStoreOnly must not write the PnP loader: it links no importers",
+    );
+
+    drop((root, mock_instance, store_dir));
+}

--- a/pnpm/crates/cli/tests/install.rs
+++ b/pnpm/crates/cli/tests/install.rs
@@ -1947,6 +1947,10 @@ fn virtual_store_only_install_under_pnp_does_not_write_the_loader() {
     pacquet.with_arg("install").assert().success();
 
     assert!(
+        store_dir.join(STORE_VERSION).exists(),
+        "the install must still populate the store, or the assertion below is vacuous",
+    );
+    assert!(
         !workspace.join(".pnp.cjs").exists(),
         "virtualStoreOnly must not write the PnP loader: it links no importers",
     );

--- a/pnpm/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_frozen_lockfile.rs
@@ -1346,7 +1346,9 @@ where
             )
             .map_err(InstallFrozenLockfileError::WritePackageMap)?;
         }
-        if matches!(node_linker, NodeLinker::Pnp) {
+        // See `install_with_fresh_lockfile::linking` for why
+        // `virtual_store_only` suppresses the loader.
+        if matches!(node_linker, NodeLinker::Pnp) && !config.virtual_store_only {
             let filtered_lockfile =
                 crate::filter_lockfile_for_current(lockfile, included, &skipped);
             crate::write_pnp_file(

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile/linking.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile/linking.rs
@@ -426,7 +426,12 @@ pub(super) fn write_module_resolution_sidecars(
     lockfile_dir: &Path,
 ) -> Result<(), InstallWithFreshLockfileError> {
     let write_package_map = crate::should_write_package_map(config, node_linker);
-    let write_pnp = matches!(node_linker, pacquet_config::NodeLinker::Pnp);
+    // `.pnp.cjs` is how a PnP project resolves, which makes it a
+    // project-level artifact like the importer links and the package
+    // map. `virtual_store_only` — how `pnpm fetch` warms a store without
+    // touching the project — must not write it.
+    let write_pnp =
+        matches!(node_linker, pacquet_config::NodeLinker::Pnp) && !config.virtual_store_only;
     if !write_package_map && !write_pnp {
         return Ok(());
     }

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -1881,7 +1881,11 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
         virtualStoreDirMaxLength: ctx.virtualStoreDirMaxLength,
       })
     }
-    if (opts.enablePnp) {
+    // `.pnp.cjs` is how a PnP project resolves, which makes it a
+    // project-level artifact like the importer symlinks and the package
+    // map. `virtualStoreOnly` — how `pnpm fetch` warms a store without
+    // touching the project — must not write it.
+    if (opts.enablePnp && !opts.virtualStoreOnly) {
       const importerNames = Object.fromEntries(
         projects.map(({ manifest, id }) => [id, manifest.name ?? id])
       )

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -1915,7 +1915,9 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
         const rootNodes = depPaths.filter((depPath) => dependenciesGraph[depPath].depth === 0)
 
         let extraEnv: Record<string, string> | undefined = opts.scriptsOpts.extraEnv
-        if (opts.enablePnp) {
+        // Only point Node at the loader when it was actually written —
+        // `--require` on a missing file fails the script before it runs.
+        if (opts.enablePnp && !opts.virtualStoreOnly) {
           extraEnv = {
             ...extraEnv,
             ...makeNodeRequireOption(path.join(opts.lockfileDir, '.pnp.cjs'), extraEnv),

--- a/pnpm11/installing/deps-installer/test/install/misc.ts
+++ b/pnpm11/installing/deps-installer/test/install/misc.ts
@@ -191,6 +191,32 @@ test('does not inject a package map into lifecycle scripts when virtualStoreOnly
   expect(fs.existsSync(marker)).toBeTruthy()
 })
 
+test('does not write or inject the PnP loader when virtualStoreOnly skips linking', async () => {
+  prepareEmpty()
+  fs.mkdirSync('pkg')
+  const marker = path.resolve('pnp-env-ok')
+  fs.writeFileSync('pkg/package.json', JSON.stringify({
+    name: 'pkg',
+    version: '1.0.0',
+    scripts: {
+      install: makeAssertNoPnpNodeOptionsScript(marker),
+    },
+  }), 'utf8')
+
+  await addDependenciesToPackage({}, ['file:./pkg'], testDefaults({
+    allowBuilds: { 'pkg@file:pkg': true },
+    enablePnp: true,
+    virtualStoreOnly: true,
+  }))
+
+  // virtualStoreOnly links no importers, so the loader would describe a
+  // resolution the project cannot perform.
+  expect(fs.existsSync(path.resolve('.pnp.cjs'))).toBeFalsy()
+  // ...and `--require`-ing the absent loader would fail the script
+  // before it could write its marker.
+  expect(fs.existsSync(marker)).toBeTruthy()
+})
+
 test('does not write or inject a package map when modules directory creation is disabled', async () => {
   prepareEmpty()
   const marker = path.resolve('package-map-env-ok')
@@ -1553,6 +1579,19 @@ test('install should not hang on circular peer dependencies', async () => {
   // cspell:disable-next-line
   await addDependenciesToPackage({}, ['@medusajs/medusa-js@6.1.7'], testDefaults())
 })
+
+function makeAssertNoPnpNodeOptionsScript (marker: string): string {
+  const scriptPath = path.resolve('assert-no-pnp-node-options.cjs')
+  fs.writeFileSync(scriptPath, `
+const fs = require('node:fs')
+
+if ((process.env.NODE_OPTIONS || '').includes('.pnp.cjs')) {
+  throw new Error('unexpected PnP NODE_OPTIONS')
+}
+fs.writeFileSync(process.argv[2], 'ok')
+`, 'utf8')
+  return `node ${JSON.stringify(scriptPath)} ${JSON.stringify(marker)}`
+}
 
 function makeAssertNoPackageMapNodeOptionsScript (marker: string): string {
   const scriptPath = path.resolve('assert-no-package-map-node-options.cjs')

--- a/pnpm11/installing/deps-installer/test/install/misc.ts
+++ b/pnpm11/installing/deps-installer/test/install/misc.ts
@@ -209,6 +209,10 @@ test('does not write or inject the PnP loader when virtualStoreOnly skips linkin
     virtualStoreOnly: true,
   }))
 
+  // The dependency really reached the virtual store, so the assertions
+  // below are about a install that did the work, not one that bailed.
+  expect(fs.readdirSync(path.resolve('node_modules/.pnpm')).some((entry) => entry.startsWith('pkg@')))
+    .toBeTruthy()
   // virtualStoreOnly links no importers, so the loader would describe a
   // resolution the project cannot perform.
   expect(fs.existsSync(path.resolve('.pnp.cjs'))).toBeFalsy()

--- a/pnpm11/installing/deps-installer/test/install/misc.ts
+++ b/pnpm11/installing/deps-installer/test/install/misc.ts
@@ -177,7 +177,7 @@ test('does not inject a package map into lifecycle scripts when virtualStoreOnly
     name: 'pkg',
     version: '1.0.0',
     scripts: {
-      install: makeAssertNoPackageMapNodeOptionsScript(marker),
+      install: makeAssertNoNodeOptionsScript('package-map', '--experimental-package-map', marker),
     },
   }), 'utf8')
 
@@ -199,7 +199,7 @@ test('does not write or inject the PnP loader when virtualStoreOnly skips linkin
     name: 'pkg',
     version: '1.0.0',
     scripts: {
-      install: makeAssertNoPnpNodeOptionsScript(marker),
+      install: makeAssertNoNodeOptionsScript('pnp', '.pnp.cjs', marker),
     },
   }), 'utf8')
 
@@ -228,7 +228,7 @@ test('does not write or inject a package map when modules directory creation is 
     name: 'project',
     version: '1.0.0',
     scripts: {
-      install: makeAssertNoPackageMapNodeOptionsScript(marker),
+      install: makeAssertNoNodeOptionsScript('package-map', '--experimental-package-map', marker),
     },
     dependencies: {
       'is-positive': '1.0.0',
@@ -1584,26 +1584,17 @@ test('install should not hang on circular peer dependencies', async () => {
   await addDependenciesToPackage({}, ['@medusajs/medusa-js@6.1.7'], testDefaults())
 })
 
-function makeAssertNoPnpNodeOptionsScript (marker: string): string {
-  const scriptPath = path.resolve('assert-no-pnp-node-options.cjs')
+/// Build a lifecycle script that fails if `NODE_OPTIONS` carries
+/// `forbidden`, and otherwise writes `marker`. The marker is what proves
+/// the script ran at all, so a clean environment cannot be confused with
+/// a script that never executed.
+function makeAssertNoNodeOptionsScript (name: string, forbidden: string, marker: string): string {
+  const scriptPath = path.resolve(`assert-no-${name}-node-options.cjs`)
   fs.writeFileSync(scriptPath, `
 const fs = require('node:fs')
 
-if ((process.env.NODE_OPTIONS || '').includes('.pnp.cjs')) {
-  throw new Error('unexpected PnP NODE_OPTIONS')
-}
-fs.writeFileSync(process.argv[2], 'ok')
-`, 'utf8')
-  return `node ${JSON.stringify(scriptPath)} ${JSON.stringify(marker)}`
-}
-
-function makeAssertNoPackageMapNodeOptionsScript (marker: string): string {
-  const scriptPath = path.resolve('assert-no-package-map-node-options.cjs')
-  fs.writeFileSync(scriptPath, `
-const fs = require('node:fs')
-
-if ((process.env.NODE_OPTIONS || '').includes('--experimental-package-map')) {
-  throw new Error('unexpected package map NODE_OPTIONS')
+if ((process.env.NODE_OPTIONS || '').includes(${JSON.stringify(forbidden)})) {
+  throw new Error(${JSON.stringify(`unexpected ${name} NODE_OPTIONS`)})
 }
 fs.writeFileSync(process.argv[2], 'ok')
 `, 'utf8')

--- a/pnpm11/installing/deps-restorer/src/index.ts
+++ b/pnpm11/installing/deps-restorer/src/index.ts
@@ -392,7 +392,9 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
         lockfileToDepGraphOpts
       )
   )
-  if (opts.enablePnp) {
+  // `.pnp.cjs` is a project-level resolution artifact, so it follows the
+  // same rule as the importer links and the package map above.
+  if (opts.enablePnp && !skipPostImportLinking) {
     const importerNames = Object.fromEntries(
       selectedProjects.map(({ manifest, id }) => [id, manifest.name ?? id])
     )

--- a/pnpm11/installing/deps-restorer/src/index.ts
+++ b/pnpm11/installing/deps-restorer/src/index.ts
@@ -618,7 +618,9 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
       extraBinPaths.unshift(path.join(hoistedModulesDir, '.bin'))
     }
     let extraEnv: Record<string, string> | undefined = opts.extraEnv
-    if (opts.enablePnp) {
+    // Only point Node at the loader when it was actually written —
+    // `--require` on a missing file fails the script before it runs.
+    if (opts.enablePnp && !skipPostImportLinking) {
       extraEnv = {
         ...extraEnv,
         ...makeNodeRequireOption(path.join(opts.lockfileDir, '.pnp.cjs'), extraEnv),

--- a/pnpm11/installing/deps-restorer/test/index.ts
+++ b/pnpm11/installing/deps-restorer/test/index.ts
@@ -816,6 +816,21 @@ test('installing in a workspace', async () => {
   ])
 })
 
+test('does not write the PnP loader when virtualStoreOnly skips linking', async () => {
+  const prefix = f.prepare('simple')
+
+  await headlessInstall(await testDefaults({
+    enablePnp: true,
+    lockfileDir: prefix,
+    virtualStoreOnly: true,
+  }))
+
+  // The virtual store is still populated; only the project-level
+  // artifacts are withheld, and the loader is one of them.
+  expect(fs.existsSync(path.join(prefix, 'node_modules/.pnpm'))).toBeTruthy()
+  expect(fs.existsSync(path.join(prefix, '.pnp.cjs'))).toBeFalsy()
+})
+
 test('installing with no symlinks but with PnP', async () => {
   const prefix = f.prepare('simple')
 

--- a/pnpm11/installing/deps-restorer/test/index.ts
+++ b/pnpm11/installing/deps-restorer/test/index.ts
@@ -825,9 +825,11 @@ test('does not write the PnP loader when virtualStoreOnly skips linking', async 
     virtualStoreOnly: true,
   }))
 
-  // The virtual store is still populated; only the project-level
-  // artifacts are withheld, and the loader is one of them.
-  expect(fs.existsSync(path.join(prefix, 'node_modules/.pnpm'))).toBeTruthy()
+  // The virtual store is still populated — assert an extracted file, so
+  // the check cannot pass on a directory that was merely created.
+  expect(fs.existsSync(path.join(prefix, 'node_modules/.pnpm/rimraf@2.7.1/node_modules/rimraf/package.json')))
+    .toBeTruthy()
+  // Only the project-level artifacts are withheld, and the loader is one.
   expect(fs.existsSync(path.join(prefix, '.pnp.cjs'))).toBeFalsy()
 })
 


### PR DESCRIPTION
## Summary

`virtualStoreOnly` populates the virtual store and creates no importer links — it is how `pnpm fetch` warms a store in a Docker layer without touching the project. The importer symlinks and `node_modules/.package-map.json` were already skipped on that path, but `.pnp.cjs` was not.

`.pnp.cjs` is how a PnP project resolves, which makes it a project-level artifact of exactly the same kind. Writing it leaves the project claiming to resolve out of a store it was never linked into. This gates it on `virtualStoreOnly` like the other two.

All four implementations carried the gap, so all four are fixed:

| Stack | Path | Site |
|---|---|---|
| TypeScript | fresh | `deps-installer/src/install/index.ts` |
| TypeScript | headless | `deps-restorer/src/index.ts` (reuses the `skipPostImportLinking` flag it already derives) |
| Rust | fresh | `install_with_fresh_lockfile/linking.rs` |
| Rust | frozen | `install_frozen_lockfile.rs` |

### Why fix rather than forbid

Rejecting `virtualStoreOnly` + `nodeLinker: pnp` as a config conflict was considered — there is precedent next door (`CONFIG_CONFLICT_VIRTUAL_STORE_ONLY_WITH_NO_MODULES_DIR`). It was rejected because `pnpm fetch` sets `virtualStoreOnly` itself, so erroring would stop PnP users warming a store at all, which is a legitimate thing to want.

### Tests

Two regression tests, each verified to fail when its own guard is removed:

- `fetch_under_pnp_does_not_write_the_loader` — the frozen path. `fetch` pins `frozenLockfile`, so it always goes headless.
- `virtual_store_only_install_under_pnp_does_not_write_the_loader` — the fresh path, reachable because `virtualStoreOnly` is a `pnpm-workspace.yaml` setting a plain install can carry.

The second exists because the first does not exercise the fresh path at all; without it that guard would ship unexercised.

Both tests set the linker by **appending** to the harness's `pnpm-workspace.yaml`. Overwriting it drops the `storeDir` / `cacheDir` / `registry` the harness put there, and `node-linker` in `.npmrc` does not enable PnP at all (pnpm 11 reads it from the workspace manifest) — either mistake yields a test that passes whatever the code does.

### Verification

- `cargo nextest run -p pacquet-package-manager` — 857 passed.
- `cargo nextest run -p pacquet-cli --test fetch --test install` — 57 passed.
- clippy `-D warnings`, and `cargo doc` with `RUSTDOCFLAGS=-D warnings --document-private-items`.

**The TypeScript half is not verified locally** — the worktree has no `node_modules`, so `deps-installer` / `deps-restorer` were neither typechecked nor tested. The edits are one-line conditionals, but CI is their first check. Flagging it rather than implying otherwise. The same missing bootstrap means the pre-push hook was inactive, so nothing was gated on push either.

## Squash Commit Body

```text
`virtualStoreOnly` populates the virtual store and creates no importer
links — it is how `pnpm fetch` warms a store in a Docker layer without
touching the project. The importer symlinks and
`node_modules/.package-map.json` were already skipped on that path, but
`.pnp.cjs` was not.

`.pnp.cjs` is how a PnP project resolves, which makes it a project-level
artifact of exactly the same kind: writing it leaves the project
claiming to resolve out of a store it was never linked into. Gate it on
`virtualStoreOnly` like the other two.

Fixed in all four implementations, since every one carried the gap:
`deps-installer` and `deps-restorer` on the TypeScript side, and the
fresh and frozen paths in pacquet. The headless path reuses the
`skipPostImportLinking` flag it already derives.

Forbidding the combination instead was considered and rejected: `pnpm
fetch` sets `virtualStoreOnly`, so erroring would stop PnP users warming
a store at all, which is a legitimate thing to want.

Two regression tests, each verified to fail when its own guard is
removed:

- `fetch_under_pnp_does_not_write_the_loader` covers the frozen path
  (`fetch` pins `frozenLockfile`, so it always goes headless).
- `virtual_store_only_install_under_pnp_does_not_write_the_loader`
  covers the fresh path, reachable because `virtualStoreOnly` is a
  `pnpm-workspace.yaml` setting a plain install can carry.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.
  <!-- No documented behaviour changes: `virtualStoreOnly` is already
  described as populating the store without linking, which is what this
  makes true for the PnP loader. -->

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788430019&installation_model_id=426870&pr_number=13636&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13636&signature=0b1b882fca2d9065c4bf3cdb301be779d448aadde7f66bd03302a5887b25e417"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `pnpm fetch` and virtual store-only installations with PnP enabled no longer generate `.pnp.cjs` loader files.
  * Lifecycle scripts in virtual store-only PnP installations no longer receive unnecessary PnP loader settings.
  * Standard PnP installations continue to generate and use the loader as expected.

* **Tests**
  * Added coverage confirming successful installation, virtual store population, and absence of project-level PnP loaders in affected scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->