### PR TITLE
fix(deploy): drop excluded optional edges from the deployed lockfile

### DIFF
--- a/.changeset/deploy-no-optional-symlinks.md
+++ b/.changeset/deploy-no-optional-symlinks.md
@@ -1,5 +1,7 @@
 ---
+"@pnpm/releasing.commands": patch
 "pacquet": patch
+"pnpm": patch
 ---
 
 Fix `pnpm deploy --no-optional` creating dangling symlinks for transitive optional dependencies.

--- a/.changeset/deploy-no-optional-symlinks.md
+++ b/.changeset/deploy-no-optional-symlinks.md
@@ -4,4 +4,4 @@
 "pnpm": patch
 ---
 
-Fix `pnpm deploy --no-optional` creating dangling symlinks for transitive optional dependencies.
+`pnpm deploy --no-optional` no longer writes a lockfile whose snapshots reference optional dependencies that the deploy excluded.

--- a/.changeset/deploy-no-optional-symlinks.md
+++ b/.changeset/deploy-no-optional-symlinks.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fix `pnpm deploy --no-optional` creating dangling symlinks for transitive optional dependencies.

--- a/pnpm/crates/cli/src/cli_args/deploy.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy.rs
@@ -947,15 +947,13 @@ fn prune_deploy_lockfile_graph(lockfile: &mut Lockfile, dependency_groups: &[Dep
 
     let reachable_metadata = reachable.iter().map(PackageKey::without_peer).collect::<HashSet<_>>();
     if let Some(snapshots) = lockfile.snapshots.as_mut() {
+        snapshots.retain(|key, _| reachable.contains(key));
         if !include_optional {
-            // Retained snapshots can still point at optional-only packages that
-            // were pruned from the deploy graph; clear those edges so the
-            // deployed lockfile cannot ask the linker to create dangling links.
+            // A retained snapshot's optional edges point at packages this prune just dropped.
             for snapshot in snapshots.values_mut() {
                 snapshot.optional_dependencies = None;
             }
         }
-        snapshots.retain(|key, _| reachable.contains(key));
         if snapshots.is_empty() {
             lockfile.snapshots = None;
         }

--- a/pnpm/crates/cli/src/cli_args/deploy.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy.rs
@@ -947,6 +947,11 @@ fn prune_deploy_lockfile_graph(lockfile: &mut Lockfile, dependency_groups: &[Dep
 
     let reachable_metadata = reachable.iter().map(PackageKey::without_peer).collect::<HashSet<_>>();
     if let Some(snapshots) = lockfile.snapshots.as_mut() {
+        if !include_optional {
+            for snapshot in snapshots.values_mut() {
+                snapshot.optional_dependencies = None;
+            }
+        }
         snapshots.retain(|key, _| reachable.contains(key));
         if snapshots.is_empty() {
             lockfile.snapshots = None;

--- a/pnpm/crates/cli/src/cli_args/deploy.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy.rs
@@ -948,6 +948,9 @@ fn prune_deploy_lockfile_graph(lockfile: &mut Lockfile, dependency_groups: &[Dep
     let reachable_metadata = reachable.iter().map(PackageKey::without_peer).collect::<HashSet<_>>();
     if let Some(snapshots) = lockfile.snapshots.as_mut() {
         if !include_optional {
+            // Retained snapshots can still point at optional-only packages that
+            // were pruned from the deploy graph; clear those edges so the
+            // deployed lockfile cannot ask the linker to create dangling links.
             for snapshot in snapshots.values_mut() {
                 snapshot.optional_dependencies = None;
             }

--- a/pnpm/crates/cli/tests/suite/deploy.rs
+++ b/pnpm/crates/cli/tests/suite/deploy.rs
@@ -156,12 +156,13 @@ fn shared_lockfile_deploy_honors_no_optional_in_graph_and_virtual_store() {
         .success();
     let with_optional = workspace.join("deploy-with-optional");
     assert!(with_optional.join("node_modules/optional-only").exists());
-    assert!(
-        deploy_graph_keys(&with_optional).iter().any(|key| key.contains("@pnpm.e2e/qar@100.0.0")),
-    );
-    assert!(
-        deploy_graph_keys(&with_optional).iter().any(|key| key.contains("@pnpm.e2e/foo@100.0.0")),
-    );
+    let graph_keys = deploy_graph_keys(&with_optional);
+    for included in ["@pnpm.e2e/qar@100.0.0", "@pnpm.e2e/foo@100.0.0"] {
+        assert!(
+            graph_keys.iter().any(|key| key.contains(included)),
+            "default deploy lock graph should include {included}: {graph_keys:#?}",
+        );
+    }
 
     pacquet_cmd(&workspace)
         .with_args([
@@ -175,18 +176,25 @@ fn shared_lockfile_deploy_honors_no_optional_in_graph_and_virtual_store() {
         .assert()
         .success();
     let without_optional = workspace.join("deploy-without-optional");
-    assert!(without_optional.join("node_modules/lib").exists());
+    assert!(
+        without_optional.join("node_modules/lib").exists(),
+        "the production dependency carrying the optional edges should still be deployed",
+    );
     assert!(!without_optional.join("node_modules/optional-only").exists());
-    assert!(!deploy_graph_keys(&without_optional).iter().any(|key| {
-        key.contains("optional-only@file:")
-            || key.contains("@pnpm.e2e/qar@")
-            || key.contains("@pnpm.e2e/foo@")
-    }),);
-    assert!(!virtual_store_entries(&without_optional).iter().any(|entry| {
-        entry.contains("optional-only@file+")
-            || entry.contains("@pnpm.e2e+qar@")
-            || entry.contains("@pnpm.e2e+foo@")
-    }),);
+    let graph_keys = deploy_graph_keys(&without_optional);
+    for excluded in ["optional-only@file:", "@pnpm.e2e/qar@", "@pnpm.e2e/foo@"] {
+        assert!(
+            !graph_keys.iter().any(|key| key.contains(excluded)),
+            "no-optional deploy lock graph should exclude {excluded}: {graph_keys:#?}",
+        );
+    }
+    let virtual_store_entries = virtual_store_entries(&without_optional);
+    for excluded in ["optional-only@file+", "@pnpm.e2e+qar@", "@pnpm.e2e+foo@"] {
+        assert!(
+            !virtual_store_entries.iter().any(|entry| entry.contains(excluded)),
+            "no-optional deploy virtual store should exclude {excluded}: {virtual_store_entries:#?}",
+        );
+    }
 
     let deploy_lockfile = Lockfile::load_wanted_from_dir(&without_optional).unwrap().unwrap();
     let retained_optional_edges = deploy_lockfile

--- a/pnpm/crates/cli/tests/suite/deploy.rs
+++ b/pnpm/crates/cli/tests/suite/deploy.rs
@@ -175,6 +175,7 @@ fn shared_lockfile_deploy_honors_no_optional_in_graph_and_virtual_store() {
         .assert()
         .success();
     let without_optional = workspace.join("deploy-without-optional");
+    assert!(without_optional.join("node_modules/lib").exists());
     assert!(!without_optional.join("node_modules/optional-only").exists());
     assert!(!deploy_graph_keys(&without_optional).iter().any(|key| {
         key.contains("optional-only@file:")
@@ -186,10 +187,19 @@ fn shared_lockfile_deploy_honors_no_optional_in_graph_and_virtual_store() {
             || entry.contains("@pnpm.e2e+qar@")
             || entry.contains("@pnpm.e2e+foo@")
     }),);
-    let lockfile = fs::read_to_string(without_optional.join("pnpm-lock.yaml")).unwrap();
+
+    let deploy_lockfile = Lockfile::load_wanted_from_dir(&without_optional).unwrap().unwrap();
+    let retained_optional_edges = deploy_lockfile
+        .snapshots
+        .iter()
+        .flatten()
+        .filter_map(|(key, snapshot)| {
+            snapshot.optional_dependencies.as_ref().map(|deps| (key.to_string(), deps))
+        })
+        .collect::<Vec<_>>();
     assert!(
-        !lockfile.contains("optionalDependencies:\n      '@pnpm.e2e/qar'"),
-        "retained production snapshots must not keep pruned optional edges:\n{lockfile}",
+        retained_optional_edges.is_empty(),
+        "retained production snapshots must not keep pruned optional edges: {retained_optional_edges:?}",
     );
 
     drop((root, mock_instance));

--- a/pnpm/crates/cli/tests/suite/deploy.rs
+++ b/pnpm/crates/cli/tests/suite/deploy.rs
@@ -130,12 +130,22 @@ fn shared_lockfile_deploy_honors_no_optional_in_graph_and_virtual_store() {
     );
     write_project(
         &workspace,
+        "lib",
+        &serde_json::json!({
+            "name": "lib",
+            "version": "1.0.0",
+            "files": ["index.js"],
+            "optionalDependencies": { "@pnpm.e2e/qar": "100.0.0" },
+        }),
+    );
+    write_project(
+        &workspace,
         "optional-only",
         &serde_json::json!({
             "name": "optional-only",
             "version": "1.0.0",
             "files": ["index.js"],
-            "dependencies": { "@pnpm.e2e/qar": "100.0.0" },
+            "dependencies": { "@pnpm.e2e/foo": "100.0.0" },
         }),
     );
 
@@ -148,6 +158,9 @@ fn shared_lockfile_deploy_honors_no_optional_in_graph_and_virtual_store() {
     assert!(with_optional.join("node_modules/optional-only").exists());
     assert!(
         deploy_graph_keys(&with_optional).iter().any(|key| key.contains("@pnpm.e2e/qar@100.0.0")),
+    );
+    assert!(
+        deploy_graph_keys(&with_optional).iter().any(|key| key.contains("@pnpm.e2e/foo@100.0.0")),
     );
 
     pacquet_cmd(&workspace)
@@ -163,15 +176,20 @@ fn shared_lockfile_deploy_honors_no_optional_in_graph_and_virtual_store() {
         .success();
     let without_optional = workspace.join("deploy-without-optional");
     assert!(!without_optional.join("node_modules/optional-only").exists());
+    assert!(!deploy_graph_keys(&without_optional).iter().any(|key| {
+        key.contains("optional-only@file:")
+            || key.contains("@pnpm.e2e/qar@")
+            || key.contains("@pnpm.e2e/foo@")
+    }),);
+    assert!(!virtual_store_entries(&without_optional).iter().any(|entry| {
+        entry.contains("optional-only@file+")
+            || entry.contains("@pnpm.e2e+qar@")
+            || entry.contains("@pnpm.e2e+foo@")
+    }),);
+    let lockfile = fs::read_to_string(without_optional.join("pnpm-lock.yaml")).unwrap();
     assert!(
-        !deploy_graph_keys(&without_optional)
-            .iter()
-            .any(|key| key.contains("optional-only@file:") || key.contains("@pnpm.e2e/qar@")),
-    );
-    assert!(
-        !virtual_store_entries(&without_optional)
-            .iter()
-            .any(|entry| entry.contains("optional-only@file+") || entry.contains("@pnpm.e2e+qar@")),
+        !lockfile.contains("optionalDependencies:\n      '@pnpm.e2e/qar'"),
+        "retained production snapshots must not keep pruned optional edges:\n{lockfile}",
     );
 
     drop((root, mock_instance));

--- a/pnpm/crates/cli/tests/suite/deploy.rs
+++ b/pnpm/crates/cli/tests/suite/deploy.rs
@@ -123,7 +123,10 @@ fn shared_lockfile_deploy_honors_no_optional_in_graph_and_virtual_store() {
             "name": "app",
             "version": "1.0.0",
             "files": ["index.js"],
-            "dependencies": { "lib": "workspace:*" },
+            "dependencies": {
+                "lib": "workspace:*",
+                "@pnpm.e2e/support-different-architectures": "1.0.0",
+            },
             "devDependencies": { "dev-only": "workspace:*" },
             "optionalDependencies": { "optional-only": "workspace:*" },
         }),
@@ -163,6 +166,12 @@ fn shared_lockfile_deploy_honors_no_optional_in_graph_and_virtual_store() {
             "default deploy lock graph should include {included}: {graph_keys:#?}",
         );
     }
+    let optional_edges = deploy_optional_edges(&with_optional);
+    assert!(
+        optional_edges.iter().any(|(key, names)| key.contains("lib@file:")
+            && names.iter().any(|name| name == "@pnpm.e2e/qar")),
+        "default deploy should keep the optional edge on the retained production dependency: {optional_edges:#?}",
+    );
 
     pacquet_cmd(&workspace)
         .with_args([
@@ -196,18 +205,10 @@ fn shared_lockfile_deploy_honors_no_optional_in_graph_and_virtual_store() {
         );
     }
 
-    let deploy_lockfile = Lockfile::load_wanted_from_dir(&without_optional).unwrap().unwrap();
-    let retained_optional_edges = deploy_lockfile
-        .snapshots
-        .iter()
-        .flatten()
-        .filter_map(|(key, snapshot)| {
-            snapshot.optional_dependencies.as_ref().map(|deps| (key.to_string(), deps))
-        })
-        .collect::<Vec<_>>();
+    let retained_optional_edges = deploy_optional_edges(&without_optional);
     assert!(
         retained_optional_edges.is_empty(),
-        "retained production snapshots must not keep pruned optional edges: {retained_optional_edges:?}",
+        "retained production snapshots must not keep pruned optional edges: {retained_optional_edges:#?}",
     );
 
     drop((root, mock_instance));
@@ -643,6 +644,22 @@ fn deploy_graph_keys(deploy_dir: &Path) -> Vec<String> {
         .flatten()
         .map(|(key, _)| key.to_string())
         .chain(deploy_lockfile.snapshots.iter().flatten().map(|(key, _)| key.to_string()))
+        .collect()
+}
+
+/// Every snapshot of the deployed lockfile that still carries optional edges,
+/// as `(snapshot key, optional dependency names)`.
+fn deploy_optional_edges(deploy_dir: &Path) -> Vec<(String, Vec<String>)> {
+    let deploy_lockfile = Lockfile::load_wanted_from_dir(deploy_dir).unwrap().unwrap();
+    deploy_lockfile
+        .snapshots
+        .iter()
+        .flatten()
+        .filter_map(|(key, snapshot)| {
+            let names =
+                snapshot.optional_dependencies.as_ref()?.keys().map(ToString::to_string).collect();
+            Some((key.to_string(), names))
+        })
         .collect()
 }
 

--- a/pnpm11/pnpm/test/deploy.ts
+++ b/pnpm11/pnpm/test/deploy.ts
@@ -2,8 +2,10 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 import { expect, test } from '@jest/globals'
+import type { LockfileFile } from '@pnpm/lockfile.types'
 import { preparePackages } from '@pnpm/prepare'
 import { loadJsonFileSync } from 'load-json-file'
+import { readYamlFileSync } from 'read-yaml-file'
 import { writeYamlFileSync } from 'write-yaml-file'
 
 import { execPnpm } from './utils/index.js'
@@ -86,6 +88,63 @@ test.skip('legacy deploy creates only necessary directories when the root manife
   })
   expect(fs.readdirSync('services/foo/pnpm.out').sort()).toStrictEqual(['node_modules', 'package.json'])
   expect(loadJsonFileSync('services/foo/pnpm.out/package.json')).toStrictEqual(loadJsonFileSync('services/foo/package.json'))
+})
+
+test('deploy with a shared lockfile honors --no-optional in the graph and virtual store', async () => {
+  preparePackages([
+    { location: '.', package: { name: 'root', version: '0.0.0', private: true } },
+    {
+      location: 'packages/app',
+      package: {
+        name: 'app',
+        version: '1.0.0',
+        dependencies: {
+          lib: 'workspace:*',
+          '@pnpm.e2e/support-different-architectures': '1.0.0',
+        },
+        optionalDependencies: { 'optional-only': 'workspace:*' },
+      },
+    },
+    {
+      location: 'packages/lib',
+      package: {
+        name: 'lib',
+        version: '1.0.0',
+        optionalDependencies: { '@pnpm.e2e/qar': '100.0.0' },
+      },
+    },
+    {
+      location: 'packages/optional-only',
+      package: {
+        name: 'optional-only',
+        version: '1.0.0',
+        dependencies: { '@pnpm.e2e/foo': '100.0.0' },
+      },
+    },
+  ])
+
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    packages: ['packages/*'],
+    injectWorkspacePackages: true,
+  })
+
+  await execPnpm(['install'])
+
+  const deployDir = path.resolve('deploy-without-optional')
+  await execPnpm(['--filter=app', 'deploy', '--prod', '--no-optional', deployDir])
+
+  expect(fs.existsSync(path.join(deployDir, 'node_modules/lib'))).toBe(true)
+  expect(fs.existsSync(path.join(deployDir, 'node_modules/optional-only'))).toBe(false)
+
+  const virtualStoreEntries = fs.readdirSync(path.join(deployDir, 'node_modules/.pnpm'))
+  for (const excluded of ['optional-only@file+', '@pnpm.e2e+qar@', '@pnpm.e2e+foo@']) {
+    expect(virtualStoreEntries.filter(entry => entry.includes(excluded))).toStrictEqual([])
+  }
+
+  const deployLockfile = readYamlFileSync<LockfileFile>(path.join(deployDir, 'pnpm-lock.yaml'))
+  const retainedOptionalEdges = Object.entries(deployLockfile.snapshots ?? {})
+    .filter(([, snapshot]) => snapshot.optionalDependencies != null)
+  expect(retainedOptionalEdges).toStrictEqual([])
 })
 
 // `pacquet` is fetched from the real npm registry — registry-mock doesn't

--- a/pnpm11/releasing/commands/src/deploy/createDeployFiles.ts
+++ b/pnpm11/releasing/commands/src/deploy/createDeployFiles.ts
@@ -183,6 +183,7 @@ export function createDeployFiles ({
   return result
 }
 
+/** Takes ownership of `packages`: the retained snapshots are edited in place. */
 function filterDeployPackageSnapshots (
   importer: ProjectSnapshot,
   packages: PackageSnapshots,
@@ -217,8 +218,8 @@ function filterDeployPackageSnapshots (
     Array.from(reachable, (depPath) => {
       const snapshot = packages[depPath]
       // A retained snapshot's optional edges point at packages this filter just dropped.
-      if (include.optionalDependencies) return [depPath, snapshot]
-      return [depPath, { ...snapshot, optionalDependencies: undefined }]
+      if (!include.optionalDependencies) snapshot.optionalDependencies = undefined
+      return [depPath, snapshot]
     })
   ) as PackageSnapshots
 }

--- a/pnpm11/releasing/commands/src/deploy/createDeployFiles.ts
+++ b/pnpm11/releasing/commands/src/deploy/createDeployFiles.ts
@@ -214,7 +214,12 @@ function filterDeployPackageSnapshots (
   }
 
   return Object.fromEntries(
-    Array.from(reachable, (depPath) => [depPath, packages[depPath]])
+    Array.from(reachable, (depPath) => {
+      const snapshot = packages[depPath]
+      // A retained snapshot's optional edges point at packages this filter just dropped.
+      if (include.optionalDependencies) return [depPath, snapshot]
+      return [depPath, { ...snapshot, optionalDependencies: undefined }]
+    })
   ) as PackageSnapshots
 }
 

--- a/pnpm11/releasing/commands/test/deploy/createDeployFiles.test.ts
+++ b/pnpm11/releasing/commands/test/deploy/createDeployFiles.test.ts
@@ -74,3 +74,61 @@ test('createDeployFiles keeps local tarball package names when rewriting file UR
   expect(deployLockfile.packages?.[outputDepPath]).toBeDefined()
   expect(deployLockfile.packages?.[outputDepPathWithTarballFilename]).toBeUndefined()
 })
+
+test('createDeployFiles drops optional edges of retained packages when optional dependencies are excluded', () => {
+  const lockfileDir = path.resolve('workspace')
+  const deployDir = path.join(lockfileDir, 'out')
+  const projectId = '.' as ProjectId
+  const keptDepPath = 'kept@1.0.0' as DepPath
+  const optionalDepPath = 'opt@1.0.0' as DepPath
+  const lockfile: LockfileObject = {
+    lockfileVersion: '9.0',
+    settings: {
+      autoInstallPeers: true,
+      excludeLinksFromLockfile: false,
+    },
+    importers: {
+      [projectId]: {
+        specifiers: { kept: '1.0.0' },
+        dependencies: { kept: '1.0.0' },
+      },
+    },
+    packages: {
+      [keptDepPath]: {
+        resolution: { integrity: 'sha512-kept' },
+        version: '1.0.0',
+        optionalDependencies: { opt: '1.0.0' },
+      },
+      [optionalDepPath]: {
+        resolution: { integrity: 'sha512-opt' },
+        version: '1.0.0',
+      },
+    },
+  }
+  const commonOpts = {
+    allProjects: [{
+      rootDirRealPath: lockfileDir as ProjectRootDirRealPath,
+      manifest: { name: 'app', version: '1.0.0' },
+    }],
+    deployDir,
+    lockfile,
+    lockfileDir,
+    selectedProjectManifest: { name: 'app', version: '1.0.0' },
+    projectId,
+    rootProjectManifestDir: lockfileDir,
+  }
+
+  const withOptional = createDeployFiles({
+    ...commonOpts,
+    include: { dependencies: true, devDependencies: true, optionalDependencies: true },
+  }).lockfile
+  expect(withOptional.packages?.[keptDepPath].optionalDependencies).toStrictEqual({ opt: '1.0.0' })
+  expect(withOptional.packages?.[optionalDepPath]).toBeDefined()
+
+  const withoutOptional = createDeployFiles({
+    ...commonOpts,
+    include: { dependencies: true, devDependencies: true, optionalDependencies: false },
+  }).lockfile
+  expect(withoutOptional.packages?.[optionalDepPath]).toBeUndefined()
+  expect(withoutOptional.packages?.[keptDepPath].optionalDependencies).toBeUndefined()
+})


### PR DESCRIPTION
## Summary

`pnpm deploy --prod --no-optional` prunes the excluded optional packages from the deploy graph, but leaves the `optionalDependencies` map on every snapshot it keeps. The deployed `pnpm-lock.yaml` then lists optional dependencies that the same lockfile never defines.

On the `sharp@0.35.3` repro from https://github.com/pnpm/pnpm/issues/13623 the deployed lockfile ends up with `sharp@0.35.3` declaring 25 `@img/sharp-*` optional dependencies while `packages:` and `snapshots:` contain only four entries. This PR clears those edges in both stacks, so the deployed lockfile is self-consistent.

Both implementations had the bug in the same place — `prune_deploy_lockfile_graph` in pacquet and `filterDeployPackageSnapshots` in the TypeScript CLI — and both are fixed here.

### On the linked issue

This PR was opened as a fix for https://github.com/pnpm/pnpm/issues/13623, which reports dangling symlinks under the deployed virtual store. That symptom **no longer reproduces on `main`**, with or without this change: running the issue's `sharp@0.35.3` repro against a locally built binary, `pnpm deploy --prod --no-optional` yields zero dangling links in both builds. The issue was filed against `12.0.0-beta.4`; the linking half appears to have been fixed elsewhere between then and `12.0.0-rc.3`.

So this is deliberately linked as **Related to** rather than *Fixes* — it repairs the corrupt deployed lockfile, which is the part that is still reproducible. Someone should re-check https://github.com/pnpm/pnpm/issues/13623 against `main` and close it separately if it is already resolved.

Related to https://github.com/pnpm/pnpm/issues/13623

## Squash Commit Body

```text
Deploy prunes the optional packages that --no-optional excludes, but kept the
optionalDependencies map on each snapshot it retained. The deployed lockfile
then referenced packages it did not define: deploying a project that depends on
sharp@0.35.3 produced a lockfile whose sharp snapshot listed 25 @img/sharp-*
optional dependencies against four defined entries.

Clear those edges after the reachability prune, in pacquet's
prune_deploy_lockfile_graph and in the TypeScript CLI's
filterDeployPackageSnapshots. The snapshots handed to the latter are built
fresh by convertPackageSnapshot / convertProjectSnapshotToPackageSnapshot and
shared with nothing, so they are edited in place rather than cloned.

Tests in both stacks assert that the default deploy keeps the optional edges
and that --no-optional drops them; without the first half, clearing the edges
in both modes would have passed.

Related to https://github.com/pnpm/pnpm/issues/13623 — that issue also reports
dangling symlinks in the deploy directory, which no longer reproduce on main
either way.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

## Tests

```sh
cargo nextest run -p pacquet-cli -E 'test(/^deploy::/)'
pnpm --filter @pnpm/releasing.commands test test/deploy
pnpm --filter pnpm run compile && pnpm --filter pnpm test test/deploy.ts
```

Each new assertion was checked against a deliberately broken implementation to confirm it fails without the fix.

---
Written by an agent (Jeeves / Hermes Agent, gpt-5.5); reviewed, extended to the TypeScript CLI, and corrected by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788439683&installation_model_id=426870&pr_number=13641&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13641&signature=4ec278a3e4f2f46a676086e466ada3aa697f633ccac0b9845c0491758e91cb2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed production deployments with optional dependencies disabled to prevent dangling symlinks.
  - Ensured excluded optional packages and dependency links are fully removed from deployment lockfiles and virtual stores.
  - Preserved optional dependencies correctly when deployments include them.

- **Tests**
  - Added coverage for deployments with and without optional dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
