### PR TITLE
fix(building.during-install): resolve hoisted link destinations on the main thread

### DIFF
--- a/.changeset/absolute-hoisted-link-destinations.md
+++ b/.changeset/absolute-hoisted-link-destinations.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/building.during-install": patch
+"pnpm": patch
+---
+
+Fixed intermittent `ERR_PNPM_ENOENT` and `ERR_PNPM_ENOTEMPTY` errors while renaming `_tmp_*` directories during installation with `nodeLinker: hoisted`, in workspaces that also use `patchedDependencies`.

--- a/pnpm11/building/during-install/src/index.ts
+++ b/pnpm11/building/during-install/src/index.ts
@@ -325,7 +325,13 @@ async function buildDependency<T extends string> (
         // There is no need to build the same package in every location.
         // We just copy the built package to every location where it is present.
         const currentHoistedLocation = path.relative(opts.lockfileDir, depNode.dir)
+        // The destinations are resolved here, on the main thread, on purpose.
+        // hardLinkDir() runs on a worker thread and the cwd is process-wide:
+        // applyPatchToDir() switches the cwd to the package it patches, so a worker
+        // resolving a relative path inside that window would resolve it against
+        // the wrong directory.
         const nonBuiltHoistedDeps = hoistedLocationsOfDep?.filter((hoistedLocation) => hoistedLocation !== currentHoistedLocation)
+          .map((hoistedLocation) => path.join(opts.lockfileDir, hoistedLocation))
         await hardLinkDir(depNode.dir, nonBuiltHoistedDeps)
       }
     }

--- a/pnpm11/building/during-install/src/index.ts
+++ b/pnpm11/building/during-install/src/index.ts
@@ -325,11 +325,10 @@ async function buildDependency<T extends string> (
         // There is no need to build the same package in every location.
         // We just copy the built package to every location where it is present.
         const currentHoistedLocation = path.relative(opts.lockfileDir, depNode.dir)
-        // The destinations are resolved here, on the main thread, on purpose.
-        // hardLinkDir() runs on a worker thread and the cwd is process-wide:
-        // applyPatchToDir() switches the cwd to the package it patches, so a worker
-        // resolving a relative path inside that window would resolve it against
-        // the wrong directory.
+        // The destinations must be resolved here, on the main thread: hardLinkDir()
+        // runs on a worker thread, and applyPatchToDir() switches the process-wide
+        // cwd, so a worker resolving a relative path inside that window would
+        // resolve it against the wrong directory.
         const nonBuiltHoistedDeps = hoistedLocationsOfDep?.filter((hoistedLocation) => hoistedLocation !== currentHoistedLocation)
           .map((hoistedLocation) => path.join(opts.lockfileDir, hoistedLocation))
         await hardLinkDir(depNode.dir, nonBuiltHoistedDeps)

--- a/pnpm11/building/during-install/test/hoistedLocations.test.ts
+++ b/pnpm11/building/during-install/test/hoistedLocations.test.ts
@@ -29,11 +29,15 @@ test('the hoisted locations passed to hardLinkDir are absolute', async () => {
 })
 
 async function runInstall (lockfileDir: string): Promise<void> {
-  const pkgDir = path.join(lockfileDir, 'node_modules/foo')
+  // Real hoisted locations come from path.relative(), so they use the platform's
+  // separator. Build the fixture's the same way, otherwise on Windows the install code
+  // cannot match the current location against them and filters nothing out.
+  const currentHoistedLocation = path.join('node_modules', 'foo')
+  const otherHoistedLocation = path.join('node_modules', 'bar', 'node_modules', 'foo')
+  const pkgDir = path.join(lockfileDir, currentHoistedLocation)
   fs.mkdirSync(pkgDir, { recursive: true })
   fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({ name: 'foo', version: '1.0.0' }))
 
-  const otherHoistedLocation = 'node_modules/bar/node_modules/foo'
   const depGraph = {
     'foo@1.0.0': {
       children: {},
@@ -54,7 +58,7 @@ async function runInstall (lockfileDir: string): Promise<void> {
   await buildModules(depGraph, ['foo@1.0.0'], {
     depsStateCache: {},
     hoistedLocations: {
-      'foo@1.0.0': ['node_modules/foo', otherHoistedLocation],
+      'foo@1.0.0': [currentHoistedLocation, otherHoistedLocation],
     },
     ignoreScripts: true,
     lockfileDir,

--- a/pnpm11/building/during-install/test/hoistedLocations.test.ts
+++ b/pnpm11/building/during-install/test/hoistedLocations.test.ts
@@ -15,16 +15,14 @@ jest.unstable_mockModule('@pnpm/worker', () => ({
 
 const { buildModules } = await import('../lib/index.js')
 
-// hardLinkDir() runs on a worker thread, and the cwd is process-wide: applyPatchToDir()
-// switches the cwd to the package it patches, so a worker resolving a relative
-// destination during that window resolves it against the wrong directory. That surfaced as
-// intermittent ERR_PNPM_ENOENT/ENOTEMPTY renames of `_tmp_*` under nodeLinker=hoisted.
+// A relative destination would race with applyPatchToDir()'s process-wide cwd switch —
+// see the comment in buildDependency().
 test('the hoisted locations passed to hardLinkDir are absolute', async () => {
-  const lockfileDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-hoisted-'))
+  const lockfileDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'pnpm-hoisted-'))
   try {
     await runInstall(lockfileDir)
   } finally {
-    fs.rmSync(lockfileDir, { recursive: true, force: true })
+    await fs.promises.rm(lockfileDir, { recursive: true, force: true })
   }
 })
 
@@ -35,8 +33,8 @@ async function runInstall (lockfileDir: string): Promise<void> {
   const currentHoistedLocation = path.join('node_modules', 'foo')
   const otherHoistedLocation = path.join('node_modules', 'bar', 'node_modules', 'foo')
   const pkgDir = path.join(lockfileDir, currentHoistedLocation)
-  fs.mkdirSync(pkgDir, { recursive: true })
-  fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({ name: 'foo', version: '1.0.0' }))
+  await fs.promises.mkdir(pkgDir, { recursive: true })
+  await fs.promises.writeFile(path.join(pkgDir, 'package.json'), JSON.stringify({ name: 'foo', version: '1.0.0' }))
 
   const depGraph = {
     'foo@1.0.0': {

--- a/pnpm11/building/during-install/test/hoistedLocations.test.ts
+++ b/pnpm11/building/during-install/test/hoistedLocations.test.ts
@@ -6,7 +6,7 @@ import { expect, jest, test } from '@jest/globals'
 
 import type { DependenciesGraph } from '../lib/buildSequence.js'
 
-const hardLinkDir = jest.fn(async () => {})
+const hardLinkDir = jest.fn<(src: string, destDirs: string[]) => Promise<void>>(async () => {})
 const originalWorker = await import('@pnpm/worker')
 jest.unstable_mockModule('@pnpm/worker', () => ({
   ...originalWorker,
@@ -21,6 +21,14 @@ const { buildModules } = await import('../lib/index.js')
 // intermittent ERR_PNPM_ENOENT/ENOTEMPTY renames of `_tmp_*` under nodeLinker=hoisted.
 test('the hoisted locations passed to hardLinkDir are absolute', async () => {
   const lockfileDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-hoisted-'))
+  try {
+    await runInstall(lockfileDir)
+  } finally {
+    fs.rmSync(lockfileDir, { recursive: true, force: true })
+  }
+})
+
+async function runInstall (lockfileDir: string): Promise<void> {
   const pkgDir = path.join(lockfileDir, 'node_modules/foo')
   fs.mkdirSync(pkgDir, { recursive: true })
   fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({ name: 'foo', version: '1.0.0' }))
@@ -59,9 +67,9 @@ test('the hoisted locations passed to hardLinkDir are absolute', async () => {
   })
 
   expect(hardLinkDir).toHaveBeenCalledTimes(1)
-  const destDirs = hardLinkDir.mock.calls[0][1] as unknown as string[]
+  const destDirs = hardLinkDir.mock.calls[0][1]
   expect(destDirs).toStrictEqual([path.join(lockfileDir, otherHoistedLocation)])
   for (const destDir of destDirs) {
     expect(path.isAbsolute(destDir)).toBe(true)
   }
-})
+}

--- a/pnpm11/building/during-install/test/hoistedLocations.test.ts
+++ b/pnpm11/building/during-install/test/hoistedLocations.test.ts
@@ -1,0 +1,67 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { expect, jest, test } from '@jest/globals'
+
+import type { DependenciesGraph } from '../lib/buildSequence.js'
+
+const hardLinkDir = jest.fn(async () => {})
+const originalWorker = await import('@pnpm/worker')
+jest.unstable_mockModule('@pnpm/worker', () => ({
+  ...originalWorker,
+  hardLinkDir,
+}))
+
+const { buildModules } = await import('../lib/index.js')
+
+// hardLinkDir() runs on a worker thread, and the cwd is process-wide: applyPatchToDir()
+// switches the cwd to the package it patches, so a worker resolving a relative
+// destination during that window resolves it against the wrong directory. That surfaced as
+// intermittent ERR_PNPM_ENOENT/ENOTEMPTY renames of `_tmp_*` under nodeLinker=hoisted.
+test('the hoisted locations passed to hardLinkDir are absolute', async () => {
+  const lockfileDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-hoisted-'))
+  const pkgDir = path.join(lockfileDir, 'node_modules/foo')
+  fs.mkdirSync(pkgDir, { recursive: true })
+  fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({ name: 'foo', version: '1.0.0' }))
+
+  const otherHoistedLocation = 'node_modules/bar/node_modules/foo'
+  const depGraph = {
+    'foo@1.0.0': {
+      children: {},
+      depPath: 'foo@1.0.0',
+      name: 'foo',
+      version: '1.0.0',
+      dir: pkgDir,
+      filesIndexFile: path.join(lockfileDir, 'index.json'),
+      hasBin: false,
+      hasBundledDependencies: false,
+      optional: false,
+      optionalDependencies: new Set<string>(),
+      requiresBuild: true,
+      isBuilt: false,
+    },
+  } as unknown as DependenciesGraph<string>
+
+  await buildModules(depGraph, ['foo@1.0.0'], {
+    depsStateCache: {},
+    hoistedLocations: {
+      'foo@1.0.0': ['node_modules/foo', otherHoistedLocation],
+    },
+    ignoreScripts: true,
+    lockfileDir,
+    optional: true,
+    rootModulesDir: path.join(lockfileDir, 'node_modules'),
+    sideEffectsCacheWrite: false,
+    storeController: {} as never,
+    unsafePerm: false,
+    userAgent: 'pnpm',
+  })
+
+  expect(hardLinkDir).toHaveBeenCalledTimes(1)
+  const destDirs = hardLinkDir.mock.calls[0][1] as unknown as string[]
+  expect(destDirs).toStrictEqual([path.join(lockfileDir, otherHoistedLocation)])
+  for (const destDir of destDirs) {
+    expect(path.isAbsolute(destDir)).toBe(true)
+  }
+})


### PR DESCRIPTION
Closes #13627.

`hardLinkDir()` runs on a worker thread but is handed destinations relative to lockfileDir ([during-install#L327-L329](https://github.com/pnpm/pnpm/blob/main/pnpm11/building/during-install/src/index.ts#L327-L329)). `applyPatchToDir()` — called for every `patchedDependencies` entry — wraps patch application in a synchronous `process.chdir()` ([apply-patch#L18-L32](https://github.com/pnpm/pnpm/blob/main/pnpm11/patching/apply-patch/src/index.ts#L18-L32)). The cwd is process-wide and shared with worker threads, so a worker resolving a relative destination inside that window resolves it against the patched package instead of the project root, and the rename fails with `ERR_PNPM_ENOENT` — or `ERR_PNPM_ENOTEMPTY`, depending on what happens to be at the wrong path.

Resolving the destinations on the main thread is safe because the cwd is only switched inside a synchronous block, so no other main-thread code can observe it, and `hoistedLocations` values are always relative (they come from `path.relative`).

The rebuild path ([after-install#L405](https://github.com/pnpm/pnpm/blob/main/pnpm11/building/after-install/src/index.ts#L405)) already maps hoisted locations through `path.join(opts.lockfileDir, hoistedLocation)` before calling `hardLinkDir()`, so this makes install consistent with rebuild rather than introducing a new convention.

## Verification

Measured on a ~2150-package workspace with two `patchedDependencies` entries and esbuild in three hoisted locations (macOS/APFS, pnpm 10.34.4 — same code shape as `main`):

| pnpm  | patch cwd window | installs | failures                        |
| ----- | ---------------- | -------- | ------------------------------- |
| stock | unmodified       | 40       | **23** (19 ENOENT, 4 ENOTEMPTY) |
| fixed | unmodified       | 40       | **0**                           |
| stock | +800ms           | 8        | **7**                           |
| fixed | +800ms           | 8        | **0**                           |

The `+800ms` rows add a synchronous sleep inside the cwd window that `applyPatchToDir` already opens — no other change — which makes the failure reproduce almost every time.

With the fix applied, tracing shows worker renames **still happening inside open cwd windows** and simply succeeding, so this is not a timing change. Checking every path field in all six worker message types (`extract`, `link`, `add-dir`, `symlinkAllModules`, `hardLinkDir`, `init-store`) across a full install, `hardLinkDir`'s `destDirs` is the only relative path any worker receives.

## Test

Per the triage note, the race itself isn't directly testable, so the added test asserts the invariant instead: the destinations reaching `hardLinkDir()` from the install path are absolute. It fails on `main` (receives `node_modules/bar/node_modules/foo`) and passes with this change.

`jest` (13 tests), `eslint`, and `cspell` pass for `pnpm11/building/during-install`, and `tsgo --build` typechecks clean. I could not run the repo-wide `compile-only` / `lint` locally — pnpm's self-managed 12.0.0-beta.4 fails to install on this machine — so those are left to CI.

## Note on #12880

#12880 shares the error text but is a different race, and should not be closed by this. That workspace has no `patchedDependencies` at all; with this fix applied its error paths are absolute, so cwd plays no part, and its repro still fails. Tracing it shows a parent/child destination overlap inside `hardLinkDir` itself — two hoist-copies running concurrently where one's destination is nested inside the other's, and `renameOverwriteSync` swap-renames the parent directory aside, carrying the other worker's staged temp with it:

```
0.00ms tid1   stage-begin  dest=y0/node_modules/p0/node_modules/q0
                           temp=y0/node_modules/p0/node_modules/_tmp_639b…
0.09ms tid14  stage-begin  dest=y0/node_modules/p0          <- the parent package
1.09ms tid1   stage-done   temp exists
1.53ms tid1   RENAME-FAIL  ENOENT  temp gone, temp's parent gone
3.26ms tid14  rename-ok    -> y0/node_modules/p0
```

That is presumably why a retry around the rename clears that repro; it would not fix the cwd race here, because the temp directory never existed at the resolved path to begin with.

Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed intermittent installation rename errors in hoisted workspaces when using patched dependencies.
  - Improved installation reliability by resolving hoisted dependency destinations correctly before linking.
  - Prevented failures caused by relative destinations during hoisted dependency installation.
  - Added safeguards to help workspace installations complete consistently when linking hoisted dependencies.
  - Improved compatibility for installations that use patched dependencies alongside hoisted workspace layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->