### PR TITLE
refactor(store-dir): share the store-index open and drain helpers

### DIFF
--- a/pnpm/crates/cli/src/cli_args/dedupe.rs
+++ b/pnpm/crates/cli/src/cli_args/dedupe.rs
@@ -115,11 +115,7 @@ impl DedupeArgs {
                     .unwrap_or_else(|| Path::new("."))
                     .display()
                     .to_string(),
-                store_index: if config.frozen_store {
-                    StoreIndex::shared_immutable_in(&config.store_dir)
-                } else {
-                    StoreIndex::shared_readonly_in(&config.store_dir)
-                },
+                store_index: StoreIndex::shared_for(&config.store_dir, config.frozen_store),
                 reusable_skipped_package_ids,
                 reporter: PhantomData,
             })),

--- a/pnpm/crates/deps-restorer/src/create_virtual_store.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store.rs
@@ -306,23 +306,7 @@ impl CreateVirtualStore<'_> {
                 None
             };
 
-        let open_store_index = if config.frozen_store {
-            StoreIndex::shared_immutable_in
-        } else {
-            StoreIndex::shared_readonly_in
-        };
-        let store_index =
-            match tokio::task::spawn_blocking(move || open_store_index(store_dir)).await {
-                Ok(store_index) => store_index,
-                Err(error) => {
-                    tracing::warn!(
-                        target: "pacquet::install",
-                        ?error,
-                        "store-index open task failed; continuing without a shared cache index",
-                    );
-                    None
-                }
-            };
+        let store_index = StoreIndex::open_shared(store_dir, config.frozen_store).await;
         let store_index_ref = store_index.as_ref();
 
         // The batched store-index writer is owned by the caller

--- a/pnpm/crates/deps-restorer/src/install_frozen_lockfile.rs
+++ b/pnpm/crates/deps-restorer/src/install_frozen_lockfile.rs
@@ -659,11 +659,8 @@ where
         // Under `frozenStore` the store is opened read-only, so the
         // writer is replaced with a drain-and-drop stub that never opens
         // `index.db` (no WAL / SHM sidecar under the read-only root).
-        let (store_index_writer, writer_task) = if config.frozen_store {
-            StoreIndexWriter::spawn_disabled()
-        } else {
-            StoreIndexWriter::spawn(&config.store_dir)
-        };
+        let (store_index_writer, writer_task) =
+            StoreIndexWriter::spawn_for(&config.store_dir, config.frozen_store);
 
         // Seed the skip set from the previous install's
         // `.modules.yaml.skipped`. Each entry there is a depPath
@@ -1077,19 +1074,7 @@ where
         // complete and a missed cache write just forces a re-fetch
         // on the next install.
         drop(store_index_writer);
-        match writer_task.await {
-            Ok(Ok(())) => {}
-            Ok(Err(error)) => tracing::warn!(
-                target: "pacquet::install",
-                ?error,
-                "store-index writer task returned an error; some rows may not be persisted",
-            ),
-            Err(error) => tracing::warn!(
-                target: "pacquet::install",
-                ?error,
-                "store-index writer task panicked; some rows may not be persisted",
-            ),
-        }
+        StoreIndexWriter::drain(writer_task, "; some rows may not be persisted").await;
 
         // The injectedDeps payload for `.modules.yaml`: every `file:`
         // snapshot is a materialized copy of an injected workspace

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1558,7 +1558,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         // install is complete and a missed cache write just forces a
         // re-fetch on the next install.
         drop(store_index_writer);
-        resolver_setup::drain_store_index_writer(writer_task, "; some rows may not be persisted")
+        pacquet_store_dir::StoreIndexWriter::drain(writer_task, "; some rows may not be persisted")
             .await;
 
         let injected_deps = crate::collect_injected_deps(
@@ -1823,7 +1823,8 @@ async fn finish_lockfile_only<Reporter: self::Reporter>(
     // Close the writer cleanly even though no rows were written,
     // mirroring the drain at the tail of the materializing path.
     drop(store_index_writer);
-    resolver_setup::drain_store_index_writer(writer_task, " during a lockfile-only install").await;
+    pacquet_store_dir::StoreIndexWriter::drain(writer_task, " during a lockfile-only install")
+        .await;
 
     Reporter::emit(&LogEvent::Stage(StageLog {
         level: LogLevel::Debug,

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolver_setup.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolver_setup.rs
@@ -55,53 +55,9 @@ pub(super) async fn open_store_index_handles(
     config: &Config,
     store_dir: &'static StoreDir,
 ) -> StoreIndexHandles {
-    let open_store_index = if config.frozen_store {
-        StoreIndex::shared_immutable_in
-    } else {
-        StoreIndex::shared_readonly_in
-    };
-    let index = match tokio::task::spawn_blocking(move || open_store_index(store_dir)).await {
-        Ok(index) => index,
-        Err(error) => {
-            tracing::warn!(
-                target: "pacquet::install",
-                ?error,
-                "store-index open task failed; continuing without a shared cache index",
-            );
-            None
-        }
-    };
-    let (writer, writer_task) = if config.frozen_store {
-        StoreIndexWriter::spawn_disabled()
-    } else {
-        StoreIndexWriter::spawn(store_dir)
-    };
+    let index = StoreIndex::open_shared(store_dir, config.frozen_store).await;
+    let (writer, writer_task) = StoreIndexWriter::spawn_for(store_dir, config.frozen_store);
     StoreIndexHandles { index, writer, writer_task }
-}
-
-/// Wait for the writer's final batch flush after the last handle has
-/// been dropped. Errors are downgraded to `warn!` (see
-/// `create_virtual_store.rs`): the install is complete and a missed
-/// cache write just forces a re-fetch on the next install.
-///
-/// `outcome` is appended to the log line to name the path that drained.
-pub(super) async fn drain_store_index_writer(
-    writer_task: tokio::task::JoinHandle<Result<(), pacquet_store_dir::StoreIndexError>>,
-    outcome: &str,
-) {
-    match writer_task.await {
-        Ok(Ok(())) => {}
-        Ok(Err(error)) => tracing::warn!(
-            target: "pacquet::install",
-            ?error,
-            "store-index writer task returned an error{}", outcome,
-        ),
-        Err(error) => tracing::warn!(
-            target: "pacquet::install",
-            ?error,
-            "store-index writer task panicked{}", outcome,
-        ),
-    }
 }
 
 pub(super) struct Registries {

--- a/pnpm/crates/package-manager/src/patch.rs
+++ b/pnpm/crates/package-manager/src/patch.rs
@@ -13,8 +13,8 @@ use pacquet_network::ThrottledClient;
 use pacquet_reporter::Reporter;
 use pacquet_resolving_parse_wanted_dependency::parse_wanted_dependency;
 use pacquet_store_dir::{
-    SharedReadonlyStoreIndex, SharedVerifiedFilesCache, StoreIndex, StoreIndexError,
-    StoreIndexWriter, git_hosted_store_index_key,
+    SharedVerifiedFilesCache, StoreIndex, StoreIndexError, StoreIndexWriter,
+    git_hosted_store_index_key,
 };
 use pacquet_tarball::{DownloadTarballToStore, MemCache, TarballError};
 use std::{
@@ -213,12 +213,9 @@ impl WritePackageForPatch<'_> {
 
         validate_patch_destination(dest)?;
 
-        let store_index = open_store_index_for_patch(config).await;
-        let (store_index_writer, writer_task) = if config.frozen_store {
-            StoreIndexWriter::spawn_disabled()
-        } else {
-            StoreIndexWriter::spawn(&config.store_dir)
-        };
+        let store_index = StoreIndex::open_shared(&config.store_dir, config.frozen_store).await;
+        let (store_index_writer, writer_task) =
+            StoreIndexWriter::spawn_for(&config.store_dir, config.frozen_store);
         let verified_files_cache = SharedVerifiedFilesCache::default();
 
         let result = async {
@@ -313,44 +310,12 @@ fn validate_patch_destination(dest: &Path) -> Result<(), WritePackageForPatchErr
     }
 }
 
-async fn open_store_index_for_patch(config: &'static Config) -> Option<SharedReadonlyStoreIndex> {
-    let open_store_index = if config.frozen_store {
-        StoreIndex::shared_immutable_in
-    } else {
-        StoreIndex::shared_readonly_in
-    };
-    let store_dir: &'static _ = &config.store_dir;
-    match tokio::task::spawn_blocking(move || open_store_index(store_dir)).await {
-        Ok(store_index) => store_index,
-        Err(error) => {
-            tracing::warn!(
-                target: "pacquet::patch",
-                ?error,
-                "store-index open task failed; continuing without a shared cache index",
-            );
-            None
-        }
-    }
-}
-
 async fn shutdown_store_index_writer_for_patch(
     store_index_writer: Arc<StoreIndexWriter>,
     writer_task: tokio::task::JoinHandle<Result<(), StoreIndexError>>,
 ) {
     drop(store_index_writer);
-    match writer_task.await {
-        Ok(Ok(())) => {}
-        Ok(Err(error)) => tracing::warn!(
-            target: "pacquet::patch",
-            ?error,
-            "store-index writer task returned an error; some rows may not be persisted",
-        ),
-        Err(error) => tracing::warn!(
-            target: "pacquet::patch",
-            ?error,
-            "store-index writer task panicked; some rows may not be persisted",
-        ),
-    }
+    StoreIndexWriter::drain(writer_task, "; some rows may not be persisted").await;
 }
 
 fn git_tarball_url(resolution: &LockfileResolution) -> Option<String> {

--- a/pnpm/crates/package-manager/src/tarball_prefetch.rs
+++ b/pnpm/crates/package-manager/src/tarball_prefetch.rs
@@ -328,19 +328,7 @@ impl TarballPrefetcher {
     /// missing index row only costs the next install a re-download.
     pub async fn shutdown(self) {
         drop(self.store_index_writer);
-        match self.writer_task.await {
-            Ok(Ok(())) => {}
-            Ok(Err(error)) => tracing::warn!(
-                target: "pacquet::pnpr",
-                ?error,
-                "store-index writer task returned an error; some rows may not be persisted",
-            ),
-            Err(error) => tracing::warn!(
-                target: "pacquet::pnpr",
-                ?error,
-                "store-index writer task panicked; some rows may not be persisted",
-            ),
-        }
+        StoreIndexWriter::drain(self.writer_task, "; some rows may not be persisted").await;
     }
 }
 

--- a/pnpm/crates/store-dir/src/store_index.rs
+++ b/pnpm/crates/store-dir/src/store_index.rs
@@ -172,6 +172,47 @@ impl StoreIndexWriter {
         (Arc::new(StoreIndexWriter { tx, warn_on_send_failure: AtomicBool::new(true) }), handle)
     }
 
+    /// [`StoreIndexWriter::spawn`], or [`StoreIndexWriter::spawn_disabled`]
+    /// under `frozenStore` where the store is read-only and there is
+    /// nothing to write back.
+    #[must_use]
+    pub fn spawn_for(
+        store_dir: &StoreDir,
+        frozen_store: bool,
+    ) -> (Arc<StoreIndexWriter>, tokio::task::JoinHandle<Result<(), StoreIndexError>>) {
+        if frozen_store {
+            StoreIndexWriter::spawn_disabled()
+        } else {
+            StoreIndexWriter::spawn(store_dir)
+        }
+    }
+
+    /// Wait for the final batch flush after the last handle has been
+    /// dropped.
+    ///
+    /// Errors are warned rather than propagated: by this point the work
+    /// the rows describe is already on disk, so a missed index write
+    /// only costs a re-fetch on the next install. `outcome` is appended
+    /// to the log line to name the path that drained.
+    pub async fn drain(
+        writer_task: tokio::task::JoinHandle<Result<(), StoreIndexError>>,
+        outcome: &str,
+    ) {
+        match writer_task.await {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => tracing::warn!(
+                target: "pacquet::store_index",
+                ?error,
+                "store-index writer task returned an error{}", outcome,
+            ),
+            Err(error) => tracing::warn!(
+                target: "pacquet::store_index",
+                ?error,
+                "store-index writer task panicked{}", outcome,
+            ),
+        }
+    }
+
     /// Spawn a writer that never opens `index.db` — it drains every
     /// queued message and drops it.
     ///
@@ -507,6 +548,55 @@ impl StoreIndex {
     /// contract.
     pub fn shared_immutable_in(store_dir: &StoreDir) -> Option<SharedReadonlyStoreIndex> {
         StoreIndex::shared_in(store_dir, StoreIndex::open_immutable)
+    }
+
+    /// Open the shared read-only index the way `frozenStore` requires:
+    /// [`StoreIndex::open_immutable`] when frozen, so no WAL or SHM
+    /// sidecar is created under a read-only store root, and
+    /// [`StoreIndex::open_readonly`] otherwise.
+    ///
+    /// `None` means the store has no `index.db` yet — a first install
+    /// against an empty store — and every lookup simply misses.
+    #[must_use]
+    pub fn shared_for(
+        store_dir: &StoreDir,
+        frozen_store: bool,
+    ) -> Option<SharedReadonlyStoreIndex> {
+        if frozen_store {
+            StoreIndex::shared_immutable_in(store_dir)
+        } else {
+            StoreIndex::shared_readonly_in(store_dir)
+        }
+    }
+
+    /// [`StoreIndex::shared_for`] off the reactor thread.
+    ///
+    /// Opening is synchronous `SQLite` I/O (`Connection::open_with_flags`
+    /// plus a `PRAGMA busy_timeout`), so it is parked on the blocking
+    /// pool even for the sub-millisecond it usually takes.
+    ///
+    /// A join failure — a panic in the blocking task, or cancellation
+    /// during runtime shutdown — degrades to `None` rather than failing
+    /// the caller: every lookup then misses, which callers already
+    /// handle for the empty-store case. It is surfaced at `warn!` so a
+    /// silent panic stays diagnosable.
+    pub async fn open_shared(
+        store_dir: &'static StoreDir,
+        frozen_store: bool,
+    ) -> Option<SharedReadonlyStoreIndex> {
+        match tokio::task::spawn_blocking(move || StoreIndex::shared_for(store_dir, frozen_store))
+            .await
+        {
+            Ok(index) => index,
+            Err(error) => {
+                tracing::warn!(
+                    target: "pacquet::store_index",
+                    ?error,
+                    "store-index open task failed; continuing without a shared cache index",
+                );
+                None
+            }
+        }
     }
 
     fn shared_in(


### PR DESCRIPTION
## Summary

Ten call sites repeated the same store-index setup and teardown. None of it is install logic — it is how any caller opens the store index and closes its writer — so it moves to `pacquet-store-dir`, which already owns those types.

| Duplicated block | Sites | Now |
|---|---|---|
| `frozenStore` branch → `shared_immutable_in` / `shared_readonly_in` | 4 | `StoreIndex::shared_for` |
| …wrapped in `spawn_blocking` + warn on join failure | 3 | `StoreIndex::open_shared` |
| `frozenStore` branch → `spawn` / `spawn_disabled` | 2 | `StoreIndexWriter::spawn_for` |
| Writer drain (`match writer_task.await`, warn both arms) | 4 | `StoreIndexWriter::drain` |

Callers: `create_virtual_store`, `install_frozen_lockfile`, `install_with_fresh_lockfile`, `patch`, `tarball_prefetch`, `dedupe`. Two local wrappers that existed only to hold a copy — `open_store_index_for_patch` and `resolver_setup::drain_store_index_writer` — are gone.

Net **−132 / +103**, and the duplicated blocks drop to zero outside `store-dir`.

## Design notes

**`frozen_store: bool`, not `&Config`.** `store-dir` sits below the config crate, and taking a bool keeps it that way rather than inverting the dependency for one field.

**Degradation policy is now stated once.** `open_shared` returns `None` on a join failure because every lookup then simply misses — which callers already handle for the empty-store case — and `drain` warns rather than propagating because by that point the rows describe work already on disk, so a missed index write only costs a re-fetch next install. Both rationales previously existed as comments in several copies, with the risk of one copy drifting.

## One observable change

The `warn!` target moves from whichever caller copied the block — `pacquet::install`, `pacquet::patch`, `pacquet::pnpr` — to `pacquet::store_index`, which names the subsystem the event is about rather than whoever happened to trigger it. A `RUST_LOG` filter aimed at the old targets will no longer match these two lines.

These are `tracing` diagnostics, not reporter events, so nothing parses them and no changeset is needed. Flagging it because it is the only thing in this PR a user could notice.

## Verification

- `pacquet-store-dir` + `pacquet-deps-restorer` + `pacquet-package-manager` — 960 passed.
- Full `pacquet-cli` suite — 2418 passed.
- `cargo clippy --workspace --all-targets -- -D warnings`; `cargo doc` with `RUSTDOCFLAGS=-D warnings --document-private-items`; `cargo dylint --all` — all clean.

## Squash Commit Body

```text
Ten call sites repeated the same store-index setup and teardown: the
`frozenStore` branch for opening the shared index, the `spawn_blocking`
wrapper around it, the `spawn` / `spawn_disabled` branch for the writer,
and the writer drain. None of it is install logic.

`pacquet-store-dir` owns those types, so it now owns the helpers:
`StoreIndex::shared_for`, `StoreIndex::open_shared`,
`StoreIndexWriter::spawn_for` and `StoreIndexWriter::drain`. They take
`frozen_store: bool` rather than `&Config`, keeping `store-dir` free of
a dependency on the config crate above it.

Two local wrappers that existed only to hold a copy are removed.

The `warn!` target moves from whichever caller copied the block to
`pacquet::store_index`, naming the subsystem the event is about.

No behaviour change otherwise.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <!-- Rust-only internal refactor; no user-visible surface. -->
- [x] Added a changeset if this PR changes any published package.
  <!-- Not applicable: no behaviour change. The tracing-target move is a
  debug-log detail, not a released contract. -->
- [x] Added or updated tests.
  <!-- Not applicable: behaviour is unchanged; the existing 960 unit and
  2418 CLI tests are the regression gate and all pass. -->

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13647"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788463225&installation_model_id=426870&pr_number=13647&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13647&signature=8a90f57ad222d3cb2d54cb7c725e37e32c2b2bdb2efc91ea03df07db18865e67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when installing dependencies with frozen lockfiles and stores.
  * Improved handling of dependency store access and shutdown errors, reducing the chance of interrupted or incomplete installation operations.

* **Refactor**
  * Standardized dependency store management across installations, patching, and tarball prefetching.
  * Simplified background processing and error handling for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->