### PR TITLE
fix(tarball): treat `\` as a separator in archive entry paths

### DIFF
--- a/.changeset/backslash-entry-paths.md
+++ b/.changeset/backslash-entry-paths.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Archive entries whose paths use `\` as a separator are now read the same way pnpm reads them. A nested path spelled `bin\tool.js` by Windows publishing tooling resolves to `bin/tool.js`, and a path traversal spelled with backslashes is rejected instead of being stored verbatim.

--- a/pnpm/crates/tarball/src/extract.rs
+++ b/pnpm/crates/tarball/src/extract.rs
@@ -1,9 +1,8 @@
 //! Tarball decompression and entry extraction into the CAS.
 
 use super::{
-    Component, Cursor, HashMap, IgnoreEntryFilter, IntoParallelRefIterator,
-    MAX_UNTRUSTED_PREALLOC_BYTES, ParallelIterator, PathBuf, TarballError, UNIX_EPOCH,
-    cas_write_pool,
+    Cursor, HashMap, IgnoreEntryFilter, IntoParallelRefIterator, MAX_UNTRUSTED_PREALLOC_BYTES,
+    ParallelIterator, PathBuf, TarballError, UNIX_EPOCH, cas_write_pool,
 };
 use pacquet_fs::file_mode;
 use pacquet_package_manifest::{
@@ -336,18 +335,16 @@ pub(crate) fn extract_tarball_entries(
         // always-forward-slashed path layer and the `index.db` both
         // implementations share. `to_string_lossy` coerces non-UTF-8
         // bytes to U+FFFD per component.
-        let mut parts: Vec<String> = Vec::new();
-        for component in entry_path.components().skip(1) {
-            let Component::Normal(part) = component else {
-                return Err(TarballError::ReadTarballEntries(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!(
-                        "tar entry path rejected (non-normal component, possible directory traversal): {entry_path:?}",
-                    ),
-                )));
-            };
-            parts.push(part.to_string_lossy().into_owned());
-        }
+        let Some(mut parts) = archive_entry_segments(&entry_path.to_string_lossy()) else {
+            return Err(TarballError::ReadTarballEntries(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "tar entry path rejected (non-normal component, possible directory traversal): {entry_path:?}",
+                ),
+            )));
+        };
+        // Drop the top-level package directory (`package/`).
+        parts.remove(0);
         if parts.is_empty() {
             return Err(TarballError::ReadTarballEntries(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
@@ -496,4 +493,31 @@ pub(crate) fn tar_entry_payload<'a, Reader: std::io::Read>(
             "tar entry payload extends beyond archive",
         ))
     })
+}
+
+/// Split a published archive entry's path into its segments, rejecting
+/// anything that escapes the archive root.
+///
+/// `\` is treated as a separator, as pnpm does before it validates
+/// (`parseTarball.ts`). Without that, a Windows-built entry keeps its
+/// backslashes verbatim on Unix — where they are ordinary filename
+/// characters — and the resulting key travels through the `index.db`
+/// both implementations share to a reader that *does* treat them as
+/// separators.
+///
+/// `None` for an absolute path or one climbing past the root.
+pub(crate) fn archive_entry_segments(raw: &str) -> Option<Vec<String>> {
+    let normalized = raw.replace('\\', "/");
+    if normalized.starts_with('/') {
+        return None;
+    }
+    let mut segments = Vec::new();
+    for segment in normalized.split('/') {
+        match segment {
+            "" | "." => {}
+            ".." => return None,
+            other => segments.push(other.to_string()),
+        }
+    }
+    (!segments.is_empty()).then_some(segments)
 }

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -3904,3 +3904,67 @@ fn extract_keeps_only_regular_file_entries() {
 
     drop(tempdir);
 }
+
+/// Build a tar carrying one entry whose raw header name is `name`,
+/// bypassing `set_path`'s own validation so hostile names can be tested.
+fn tar_with_raw_entry_name(name: &[u8]) -> Vec<u8> {
+    let mut tar_bytes = Vec::new();
+    let mut builder = tar::Builder::new(&mut tar_bytes);
+    let mut header = tar::Header::new_gnu();
+    header.set_size(5);
+    header.set_mode(0o644);
+    header.set_entry_type(tar::EntryType::Regular);
+    let raw = header.as_mut_bytes();
+    raw[..name.len()].copy_from_slice(name);
+    for byte in &mut raw[name.len()..100] {
+        *byte = 0;
+    }
+    header.set_cksum();
+    builder.append(&header, &b"bytes"[..]).expect("append entry");
+    builder.finish().expect("finalize tar");
+    drop(builder);
+    tar_bytes
+}
+
+/// A backslash is an ordinary filename character on Unix but a
+/// separator on Windows, and these keys travel between the two through
+/// the shared `index.db`. pnpm folds `\` to `/` before validating
+/// (`parseTarball.ts`), so a traversal spelled with backslashes has to
+/// be caught here too rather than stored verbatim.
+#[test]
+fn extract_rejects_backslash_traversal_in_entry_path() {
+    let (tempdir, store_path) = tempdir_with_leaked_path();
+
+    let tar_bytes = tar_with_raw_entry_name(br"package/..\..\evil.txt");
+    let err = extract_tarball_entries(&tar_bytes, store_path, None)
+        .expect_err("a backslash-spelled traversal must be rejected");
+
+    match err {
+        TarballError::ReadTarballEntries(io_err) => {
+            assert_eq!(io_err.kind(), std::io::ErrorKind::InvalidData);
+        }
+        other => panic!("expected a rejected tar entry, got {other:?}"),
+    }
+
+    drop(tempdir);
+}
+
+/// Folding `\` to `/` must not reject the benign case: an archive built
+/// by Windows tooling that spells a nested path with backslashes
+/// installs under pnpm, so it installs here, under the same key.
+#[test]
+fn extract_reads_a_windows_separator_entry_as_a_nested_path() {
+    let (tempdir, store_path) = tempdir_with_leaked_path();
+
+    let tar_bytes = tar_with_raw_entry_name(br"package/bin\tool.js");
+    let (cas_paths, _) =
+        extract_tarball_entries(&tar_bytes, store_path, None).expect("extract the tarball");
+
+    assert!(
+        cas_paths.contains_key("bin/tool.js"),
+        "a backslash separator must resolve to the same key as `/`, got {:?}",
+        cas_paths.keys().collect::<Vec<_>>(),
+    );
+
+    drop(tempdir);
+}

--- a/pnpm/crates/tarball/src/zip_archive.rs
+++ b/pnpm/crates/tarball/src/zip_archive.rs
@@ -93,26 +93,16 @@ pub(crate) fn extract_zip_entries(
             continue;
         }
 
-        // Rebuild the path into a forward-slash string from the
-        // sanitized `enclosed_name()` components. Three reasons over
-        // using the raw `entry.name()`:
+        // Rebuild the path as a forward-slash string from the sanitized
+        // components, so `.` segments collapse to one canonical key and
+        // the ignore filter matches against exactly that key.
         //
-        // 1. `.` segments are already collapsed by `enclosed_name`,
-        //    so `pkg/./foo.txt` and `pkg/foo.txt` produce the same
-        //    `cas_paths` key — no accidental duplicates from
-        //    publisher tooling quirks.
-        // 2. The ignore filter sees the same canonical strings the
-        //    map is keyed by, so the regex / hand-coded matchers
-        //    can't be tripped up by `.` segments either.
-        // 3. Zip entries are spec'd to use `/` separators; this also
-        //    rejects any `\` an in-the-wild Windows-built archive
-        //    might have smuggled in (those would be `Normal`
-        //    components on Unix but interpreted as separators on
-        //    Windows).
-        //
-        // `enclosed_name` only yields `Normal` components, so the
-        // path-component walk below covers every case.
-        let normalized: String = enclosed
+        // `enclosed_name` yields only `Normal` components, but a `\`
+        // inside one is an ordinary filename character on Unix, so the
+        // segments are re-checked by
+        // [`crate::extract::archive_entry_segments`], which treats it as
+        // a separator the way pnpm does.
+        let joined: String = enclosed
             .components()
             .map(|component| match component {
                 Component::Normal(name) => name.to_string_lossy().into_owned(),
@@ -120,6 +110,14 @@ pub(crate) fn extract_zip_entries(
             })
             .collect::<Vec<_>>()
             .join("/");
+        let Some(segments) = crate::extract::archive_entry_segments(&joined) else {
+            return Err(TarballError::PathTraversal {
+                url: package_url.to_string(),
+                entry_path: raw_name,
+                reason: "zip entry path is absolute or escapes the archive root",
+            });
+        };
+        let normalized = segments.join("/");
 
         // Strip the archive's top-level basename (`prefix` on
         // `pacquet_lockfile::BinaryResolution`) so the ignore filter


### PR DESCRIPTION
## Summary

A published archive can spell an entry path with backslashes. On Unix those are ordinary filename characters, so pacquet's traversal check — which walks `Path` components — saw `..\..\evil.txt` as a single `Normal` component and stored it verbatim as a CAFS key.

Verified against `main` before fixing:

```
PROBE ACCEPTED keys=["..\\..\\evil.txt"]
```

That key is then written into the `index.db` that pacquet shares with the TypeScript CLI, and read back by implementations that *do* treat `\` as a separator.

The TypeScript CLI already handles this, in `store/cafs/src/parseTarball.ts`:

```js
// Normalize path traversal attempts (including Windows backslash traversal)
fileName = path.posix.join('/', fileName.replaceAll('\\', '/')).slice(1)
```

So the fix is the same fold rather than an outright rejection — that matters for the benign case. An archive built by Windows tooling that spells a nested path `bin\tool.js` installs under pnpm today; rejecting backslashes outright would have made pacquet hard-fail a package pnpm accepts. It now installs here too, under the same `bin/tool.js` key.

`archive_entry_segments` performs the fold and the escape check for both container formats. Worth noting the zip path carried a comment claiming it already rejected smuggled backslashes — `enclosed_name` only guarantees `Normal` components, which says nothing about what is *inside* one, so it did not.

### Remaining divergence, deliberately not changed here

pnpm normalizes `..` away (`package/../../evil.txt` → `evil.txt`, installed); pacquet rejects the entry outright. That is pre-existing, stricter, and unrelated to the separator handling — worth settling separately rather than inside a security fix.

## Squash Commit Body

Treat `\` as a separator when validating archive entry paths, matching pnpm's `parseTarball.ts`. A traversal spelled with backslashes was previously stored verbatim as a CAFS key and shared through `index.db` with readers that treat backslashes as separators.

## Checklist

- [x] Tests added — rejection of a backslash-spelled traversal, and the benign Windows-separator path resolving to the same key as `/`; both verified to fail with the fold removed
- [x] Changeset added (`pacquet`, patch — Rust-only)
- [x] Behavior checked against the TypeScript CLI's `parseTarball.ts`
- [x] `cargo clippy -D warnings`, `cargo doc --document-private-items`, `cargo dylint --all` clean; 934 tests pass

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13655"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788508198&installation_model_id=426870&pr_number=13655&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13655&signature=b0ff37b44b2780731e76731e7c2d3594de46eeaf01d9786831a5061f34fd395f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved archive extraction by normalizing Windows-style backslash paths consistently.
  * Rejected archive entries that use absolute paths or path traversal to escape the extraction directory.
  * Applied consistent path validation and normalization across tar and zip archives.
* **Tests**
  * Added coverage for safe backslash-based paths and traversal attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->