### PR TITLE
fix(injected-deps-syncer): skip inodes that cannot be hardlinked

### DIFF
--- a/.changeset/injected-deps-skip-unsupported-inodes.md
+++ b/.changeset/injected-deps-skip-unsupported-inodes.md
@@ -4,3 +4,5 @@
 ---
 
 `syncInjectedDepsAfterScripts` no longer fails with `ERR_PNPM_UNSUPPORTED_INODE_TYPE` when a workspace package contains an inode that is neither a file nor a directory, such as the FIFO 1Password's environments create for `.env`. Such an inode cannot be hardlinked into the injected copy, so it is skipped and the rest of the package still syncs [#13550](https://github.com/pnpm/pnpm/issues/13550).
+
+`syncInjectedDepsAfterScripts` also no longer fails with `EEXIST` when a workspace package replaced a file with a directory of the same name since the injected copy was last synced.

--- a/.changeset/injected-deps-skip-unsupported-inodes.md
+++ b/.changeset/injected-deps-skip-unsupported-inodes.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/workspace.injected-deps-syncer": patch
+"pnpm": patch
+---
+
+`syncInjectedDepsAfterScripts` no longer fails with `ERR_PNPM_UNSUPPORTED_INODE_TYPE` when a workspace package contains an inode that is neither a file nor a directory, such as the FIFO 1Password's environments create for `.env`. Such an inode cannot be hardlinked into the injected copy, so it is skipped and the rest of the package still syncs [#13550](https://github.com/pnpm/pnpm/issues/13550).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9789,6 +9789,12 @@ importers:
       '@pnpm/workspace.injected-deps-syncer':
         specifier: workspace:*
         version: 'link:'
+      '@types/is-windows':
+        specifier: 'catalog:'
+        version: 1.0.2
+      is-windows:
+        specifier: 'catalog:'
+        version: 1.0.2
 
   pnpm11/workspace/project-manifest-reader:
     dependencies:

--- a/pnpm11/workspace/injected-deps-syncer/package.json
+++ b/pnpm11/workspace/injected-deps-syncer/package.json
@@ -49,7 +49,9 @@
     "@jest/globals": "catalog:",
     "@pnpm/logger": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/workspace.injected-deps-syncer": "workspace:*"
+    "@pnpm/workspace.injected-deps-syncer": "workspace:*",
+    "@types/is-windows": "catalog:",
+    "is-windows": "catalog:"
   },
   "engines": {
     "node": ">=22.13"

--- a/pnpm11/workspace/injected-deps-syncer/src/DirPatcher.ts
+++ b/pnpm11/workspace/injected-deps-syncer/src/DirPatcher.ts
@@ -82,12 +82,31 @@ export function diffDir (oldIndex: InodeMap, newIndex: InodeMap): DirDiff {
 export async function applyPatch (optimizedDirPatch: DirDiff, sourceDir: string, targetDir: string): Promise<void> {
   async function addRecursive (sourcePath: string, targetPath: string, value: Value): Promise<void> {
     if (value === DIR) {
-      await fs.promises.mkdir(targetPath, { recursive: true })
+      await retryOverBlockingInode(targetPath, async () => fs.promises.mkdir(targetPath, { recursive: true }))
     } else if (typeof value === 'number') {
-      fs.mkdirSync(path.dirname(targetPath), { recursive: true })
-      await fs.promises.link(sourcePath, targetPath)
+      const parentPath = path.dirname(targetPath)
+      await retryOverBlockingInode(parentPath, async () => fs.promises.mkdir(parentPath, { recursive: true }))
+      await retryOverBlockingInode(targetPath, async () => fs.promises.link(sourcePath, targetPath))
     } else {
       const _: never = value // static type guard
+    }
+  }
+
+  /**
+   * The target may hold an inode that {@link extendFilesMap} skips — a FIFO, a
+   * socket, a device. The diff cannot see it, so it is never scheduled for
+   * removal, and adding over it fails with `EEXIST`. Clear that path and retry
+   * once instead of aborting the sync partway through.
+   */
+  async function retryOverBlockingInode (targetPath: string, add: () => Promise<unknown>): Promise<void> {
+    try {
+      await add()
+    } catch (error) {
+      if (!util.types.isNativeError(error) || !('code' in error) || (error.code !== 'EEXIST')) {
+        throw error
+      }
+      await removeRecursive(targetPath)
+      await add()
     }
   }
 

--- a/pnpm11/workspace/injected-deps-syncer/src/DirPatcher.ts
+++ b/pnpm11/workspace/injected-deps-syncer/src/DirPatcher.ts
@@ -184,10 +184,7 @@ export async function extendFilesMap ({ filesMap, filesStats }: ExtendFilesMapOp
       addInodeAndAncestors(relativePath, DIR)
     }
     // Anything else — a FIFO, a socket, a device — cannot be hardlinked into
-    // the injected copy, so it is left out of the map. The diff then treats
-    // that path as absent on whichever side skipped it: an entry the target
-    // holds where the source skips is removed, and one the target skips is
-    // left alone until the source has something to put there.
+    // the injected copy, so it is left out of the map.
   }))
 
   return result

--- a/pnpm11/workspace/injected-deps-syncer/src/DirPatcher.ts
+++ b/pnpm11/workspace/injected-deps-syncer/src/DirPatcher.ts
@@ -177,9 +177,9 @@ export async function extendFilesMap ({ filesMap, filesStats }: ExtendFilesMapOp
     }
     // Anything else — a FIFO, a socket, a device — cannot be hardlinked into
     // the injected copy, so it is left out of the map. The diff then treats
-    // that path as absent: whatever the target holds there is removed, and a
-    // skipped inode in the target, being absent from its own map too, is
-    // left alone.
+    // that path as absent on whichever side skipped it: an entry the target
+    // holds where the source skips is removed, and one the target skips is
+    // left alone until the source has something to put there.
   }))
 
   return result

--- a/pnpm11/workspace/injected-deps-syncer/src/DirPatcher.ts
+++ b/pnpm11/workspace/injected-deps-syncer/src/DirPatcher.ts
@@ -157,9 +157,10 @@ export async function extendFilesMap ({ filesMap, filesStats }: ExtendFilesMapOp
       addInodeAndAncestors(relativePath, DIR)
     }
     // Anything else — a FIFO, a socket, a device — cannot be hardlinked into
-    // the injected copy. Leaving it out of the map also keeps it out of the
-    // diff, so such an inode is neither copied into the target nor removed
-    // from it.
+    // the injected copy, so it is left out of the map. The diff then treats
+    // that path as absent: whatever the target holds there is removed, and a
+    // skipped inode in the target, being absent from its own map too, is
+    // left alone.
   }))
 
   return result

--- a/pnpm11/workspace/injected-deps-syncer/src/DirPatcher.ts
+++ b/pnpm11/workspace/injected-deps-syncer/src/DirPatcher.ts
@@ -84,8 +84,7 @@ export async function applyPatch (optimizedDirPatch: DirDiff, sourceDir: string,
     if (value === DIR) {
       await retryOverBlockingInode(targetPath, async () => fs.promises.mkdir(targetPath, { recursive: true }))
     } else if (typeof value === 'number') {
-      const parentPath = path.dirname(targetPath)
-      await retryOverBlockingInode(parentPath, async () => fs.promises.mkdir(parentPath, { recursive: true }))
+      fs.mkdirSync(path.dirname(targetPath), { recursive: true })
       await retryOverBlockingInode(targetPath, async () => fs.promises.link(sourcePath, targetPath))
     } else {
       const _: never = value // static type guard
@@ -120,11 +119,20 @@ export async function applyPatch (optimizedDirPatch: DirDiff, sourceDir: string,
     }
   }
 
-  const adding = Promise.all(optimizedDirPatch.added.map(async item => {
-    const sourcePath = path.join(sourceDir, item.path)
-    const targetPath = path.join(targetDir, item.path)
-    await addRecursive(sourcePath, targetPath, item.newValue)
-  }))
+  // Directories are created before the files they hold, shallowest first, so
+  // that clearing a blocking inode can only ever hit an empty directory: were
+  // a directory cleared concurrently with its files, a removal that lands late
+  // would take out files a sibling had already linked.
+  const adding = (async () => {
+    for (const item of optimizedDirPatch.added) {
+      if (item.newValue !== DIR) continue
+      await addRecursive(path.join(sourceDir, item.path), path.join(targetDir, item.path), item.newValue) // eslint-disable-line no-await-in-loop
+    }
+    await Promise.all(optimizedDirPatch.added.map(async item => {
+      if (item.newValue === DIR) return
+      await addRecursive(path.join(sourceDir, item.path), path.join(targetDir, item.path), item.newValue)
+    }))
+  })()
 
   const removing = Promise.all(optimizedDirPatch.removed.map(async item => {
     const targetPath = path.join(targetDir, item.path)

--- a/pnpm11/workspace/injected-deps-syncer/src/DirPatcher.ts
+++ b/pnpm11/workspace/injected-deps-syncer/src/DirPatcher.ts
@@ -119,19 +119,31 @@ export async function applyPatch (optimizedDirPatch: DirDiff, sourceDir: string,
     }
   }
 
-  // Directories are created before the files they hold, shallowest first, so
-  // that clearing a blocking inode can only ever hit an empty directory: were
-  // a directory cleared concurrently with its files, a removal that lands late
-  // would take out files a sibling had already linked.
-  const adding = (async () => {
-    for (const item of optimizedDirPatch.added) {
-      if (item.newValue !== DIR) continue
-      await addRecursive(path.join(sourceDir, item.path), path.join(targetDir, item.path), item.newValue) // eslint-disable-line no-await-in-loop
+  async function applyChange (item: AddedItem | ModifiedItem): Promise<void> {
+    const sourcePath = path.join(sourceDir, item.path)
+    const targetPath = path.join(targetDir, item.path)
+    if (item.oldValue !== undefined) {
+      await removeRecursive(targetPath)
     }
-    await Promise.all(optimizedDirPatch.added.map(async item => {
-      if (item.newValue === DIR) return
-      await addRecursive(path.join(sourceDir, item.path), path.join(targetDir, item.path), item.newValue)
-    }))
+    await addRecursive(sourcePath, targetPath, item.newValue)
+  }
+
+  const changes: Array<AddedItem | ModifiedItem> = [...optimizedDirPatch.added, ...optimizedDirPatch.modified]
+    .filter(item => item.oldValue !== item.newValue)
+  const newDirs = changes.filter(item => item.newValue === DIR).sort((a, b) => comparePaths(a.path, b.path))
+  const newFiles = changes.filter(item => item.newValue !== DIR)
+
+  // Every directory is in place, shallowest first, before anything is linked
+  // into it, so that a directory is always empty when it displaces what the
+  // target held at its path: a removal landing late would otherwise take out
+  // files a sibling had already linked. A path the target holds as a file and
+  // the source as a directory lands in `modified` rather than `added`, so both
+  // arrays feed this pass.
+  const changing = (async () => {
+    for (const item of newDirs) {
+      await applyChange(item) // eslint-disable-line no-await-in-loop
+    }
+    await Promise.all(newFiles.map(applyChange))
   })()
 
   const removing = Promise.all(optimizedDirPatch.removed.map(async item => {
@@ -139,15 +151,7 @@ export async function applyPatch (optimizedDirPatch: DirDiff, sourceDir: string,
     await removeRecursive(targetPath)
   }))
 
-  const modifying = Promise.all(optimizedDirPatch.modified.map(async item => {
-    const sourcePath = path.join(sourceDir, item.path)
-    const targetPath = path.join(targetDir, item.path)
-    if (item.oldValue === item.newValue) return
-    await removeRecursive(targetPath)
-    await addRecursive(sourcePath, targetPath, item.newValue)
-  }))
-
-  await Promise.all([adding, removing, modifying])
+  await Promise.all([changing, removing])
 }
 
 export type ExtendFilesMapStats = Pick<fs.Stats, 'ino' | 'isFile' | 'isDirectory'>

--- a/pnpm11/workspace/injected-deps-syncer/src/DirPatcher.ts
+++ b/pnpm11/workspace/injected-deps-syncer/src/DirPatcher.ts
@@ -2,7 +2,6 @@ import fs from 'node:fs'
 import path from 'node:path'
 import util from 'node:util'
 
-import { PnpmError } from '@pnpm/error'
 import { fetchFromDir, type FetchFromDirOptions } from '@pnpm/fetching.directory-fetcher'
 
 export const DIR: unique symbol = Symbol('Path is a directory')
@@ -156,9 +155,11 @@ export async function extendFilesMap ({ filesMap, filesStats }: ExtendFilesMapOp
       addInodeAndAncestors(relativePath, stats.ino)
     } else if (stats.isDirectory()) {
       addInodeAndAncestors(relativePath, DIR)
-    } else {
-      throw new PnpmError('UNSUPPORTED_INODE_TYPE', `Filesystem inode at ${realPath} is neither a file, a directory, or a symbolic link`)
     }
+    // Anything else — a FIFO, a socket, a device — cannot be hardlinked into
+    // the injected copy. Leaving it out of the map also keeps it out of the
+    // diff, so such an inode is neither copied into the target nor removed
+    // from it.
   }))
 
   return result

--- a/pnpm11/workspace/injected-deps-syncer/test/DirPatcher.test.ts
+++ b/pnpm11/workspace/injected-deps-syncer/test/DirPatcher.test.ts
@@ -235,6 +235,21 @@ test('multiple patchers', async () => {
   expect(Array.from(targetFetchResultAfter3.filesMap.keys()).sort(lexCompare)).toStrictEqual(expected)
 })
 
+test('replaces a target entry whose inode type changed in the source', async () => {
+  prepareEmpty()
+
+  createFile('source/became-a-dir/index.js', 'inner')
+  createFile('source/became-a-file', 'now a file')
+  createFile('target/became-a-dir', 'was a file')
+  createFile('target/became-a-file/index.js', 'was a dir')
+
+  const patchers = await DirPatcher.fromMultipleTargets('source', ['target'])
+  await Promise.all(patchers.map(async patcher => patcher.apply()))
+
+  expect(fs.readFileSync('target/became-a-dir/index.js', 'utf8')).toBe('inner')
+  expect(fs.readFileSync('target/became-a-file', 'utf8')).toBe('now a file')
+})
+
 testOnPosix('removes what the target holds where the source has a skipped inode, but leaves a skipped inode of its own alone', async () => {
   prepareEmpty()
 

--- a/pnpm11/workspace/injected-deps-syncer/test/DirPatcher.test.ts
+++ b/pnpm11/workspace/injected-deps-syncer/test/DirPatcher.test.ts
@@ -1,12 +1,20 @@
+// cspell:ignore mkfifo
+import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
+import { setTimeout as delay } from 'node:timers/promises'
 
 import { afterEach, expect, jest, test } from '@jest/globals'
 import { fetchFromDir } from '@pnpm/fetching.directory-fetcher'
 import { prepareEmpty } from '@pnpm/prepare'
 import { lexCompare } from '@pnpm/text.ordinal-comparator'
+import isWindows from 'is-windows'
 
 import { DirPatcher } from '../src/DirPatcher.js'
+
+// `mkfifo` has no Windows equivalent, and neither has any other inode type
+// that `extendFilesMap` skips.
+const testOnPosix = isWindows() ? test.skip : test
 
 const originalRm = fs.promises.rm
 const originalMkdir = fs.promises.mkdir
@@ -43,6 +51,12 @@ function createFile (filePath: string, content: string = ''): void {
 function createHardlink (existingPath: string, newPath: string): void {
   createDir(path.dirname(newPath))
   fs.linkSync(existingPath, newPath)
+}
+
+/** Stands in for every inode type `extendFilesMap` skips. */
+function createFifo (fifoPath: string): void {
+  createDir(path.dirname(fifoPath))
+  execFileSync('mkfifo', [path.resolve(fifoPath)])
 }
 
 const inodeNumber = (filePath: string): number => fs.lstatSync(filePath).ino
@@ -219,4 +233,82 @@ test('multiple patchers', async () => {
   expect(Array.from(targetFetchResultAfter1.filesMap.keys()).sort(lexCompare)).toStrictEqual(expected)
   expect(Array.from(targetFetchResultAfter2.filesMap.keys()).sort(lexCompare)).toStrictEqual(expected)
   expect(Array.from(targetFetchResultAfter3.filesMap.keys()).sort(lexCompare)).toStrictEqual(expected)
+})
+
+testOnPosix('removes what the target holds where the source has a skipped inode, but leaves a skipped inode of its own alone', async () => {
+  prepareEmpty()
+
+  createFile('source/keep.txt')
+  createFile('target/keep.txt')
+  // The source turned this path into a FIFO while the target still holds the
+  // file that used to be there.
+  createFifo('source/replaced.env')
+  createFile('target/replaced.env', 'stale')
+  // A FIFO the target holds on its own.
+  createFifo('target/own.env')
+
+  const patchers = await DirPatcher.fromMultipleTargets('source', ['target'])
+  await Promise.all(patchers.map(async patcher => patcher.apply()))
+
+  expect(fs.existsSync('target/replaced.env')).toBe(false)
+  expect(fs.lstatSync('target/own.env').isFIFO()).toBe(true)
+  expect(fs.existsSync('target/keep.txt')).toBe(true)
+})
+
+testOnPosix.each([
+  ['a file', (sourcePath: string) => {
+    createFile(sourcePath, 'real')
+  }],
+  ['a directory', (sourcePath: string) => {
+    createFile(path.join(sourcePath, 'inner.txt'))
+  }],
+])('replaces a skipped inode in the target when the source has %s there', async (_label, createSource) => {
+  prepareEmpty()
+
+  createSource('source/config.env')
+  createFile('source/other.txt')
+  // The target holds an inode the map skips, so the diff cannot schedule it
+  // for removal and adding over it would fail with EEXIST.
+  createFifo('target/config.env')
+
+  const patchers = await DirPatcher.fromMultipleTargets('source', ['target'])
+  await Promise.all(patchers.map(async patcher => patcher.apply()))
+
+  const sourceStats = fs.lstatSync('source/config.env')
+  const targetStats = fs.lstatSync('target/config.env')
+  expect(targetStats.isFile()).toBe(sourceStats.isFile())
+  expect(targetStats.isDirectory()).toBe(sourceStats.isDirectory())
+  if (sourceStats.isDirectory()) {
+    expect(fs.readdirSync('target/config.env')).toStrictEqual(fs.readdirSync('source/config.env'))
+  }
+  expect(fs.existsSync('target/other.txt')).toBe(true)
+})
+
+testOnPosix('keeps the files linked into a directory that replaced a blocking inode', async () => {
+  prepareEmpty()
+
+  const fileNames = Array.from({ length: 20 }, (_, index) => `file${index}.txt`)
+  for (const fileName of fileNames) {
+    createFile(`source/blocked/${fileName}`)
+  }
+  createDir('target')
+  createFifo('target/blocked')
+
+  // Widen the window between clearing the blocking inode and linking into the
+  // directory that replaces it. Were the directory created concurrently with
+  // its files, this removal would land after a sibling had linked and take
+  // those files with it.
+  let delayNextRemoval = true
+  fs.promises.rm = (async (target: fs.PathLike, options?: fs.RmOptions) => {
+    if (delayNextRemoval) {
+      delayNextRemoval = false
+      await delay(30)
+    }
+    return originalRm(target, options)
+  }) as typeof fs.promises.rm
+
+  const patchers = await DirPatcher.fromMultipleTargets('source', ['target'])
+  await Promise.all(patchers.map(async patcher => patcher.apply()))
+
+  expect(fs.readdirSync('target/blocked').sort()).toStrictEqual(fileNames.sort())
 })

--- a/pnpm11/workspace/injected-deps-syncer/test/extendFilesMap.test.ts
+++ b/pnpm11/workspace/injected-deps-syncer/test/extendFilesMap.test.ts
@@ -1,3 +1,4 @@
+// cspell:ignore mkfifo
 import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'

--- a/pnpm11/workspace/injected-deps-syncer/test/extendFilesMap.test.ts
+++ b/pnpm11/workspace/injected-deps-syncer/test/extendFilesMap.test.ts
@@ -2,16 +2,15 @@
 import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
-import { setTimeout as delay } from 'node:timers/promises'
 
 import { afterEach, expect, jest, test } from '@jest/globals'
 import { prepareEmpty } from '@pnpm/prepare'
 import isWindows from 'is-windows'
 
-import { DIR, DirPatcher, extendFilesMap, type ExtendFilesMapStats, type InodeMap } from '../src/DirPatcher.js'
+import { DIR, extendFilesMap, type ExtendFilesMapStats, type InodeMap } from '../src/DirPatcher.js'
 
-// `mkfifo` has no Windows equivalent; the stats-driven test above it covers
-// the same branch on every platform.
+// `mkfifo` has no Windows equivalent; the stats-driven test covers the same
+// branch on every platform.
 const testOnPosix = isWindows() ? test.skip : test
 
 const originalStat = fs.promises.stat
@@ -125,8 +124,7 @@ test('skips inodes that are neither files nor directories', async () => {
       isDirectory: () => false,
       isFile: () => true,
     },
-    // A FIFO — 1Password's environments create one for `.env`. It cannot be
-    // hardlinked into the injected copy, so it belongs in neither map.
+    // A FIFO — 1Password's environments create one for `.env`.
     '.env': {
       ino: 7100,
       isDirectory: () => false,
@@ -158,92 +156,4 @@ testOnPosix('skips a real FIFO', async () => {
     distribution: DIR,
     'distribution/index.js': fs.statSync('distribution/index.js').ino,
   } as InodeMap)
-})
-
-testOnPosix('a skipped inode in the source removes what the target holds at that path, but a skipped inode in the target is left alone', async () => {
-  prepareEmpty()
-
-  fs.mkdirSync('source', { recursive: true })
-  fs.mkdirSync('target', { recursive: true })
-  fs.writeFileSync('source/keep.txt', '')
-  fs.writeFileSync('target/keep.txt', '')
-  // The source turned this path into a FIFO while the target still holds the
-  // file that used to be there.
-  execFileSync('mkfifo', [path.resolve('source/replaced.env')])
-  fs.writeFileSync('target/replaced.env', 'stale')
-  // A FIFO the target holds on its own.
-  execFileSync('mkfifo', [path.resolve('target/own.env')])
-
-  const patchers = await DirPatcher.fromMultipleTargets('source', ['target'])
-  await Promise.all(patchers.map(async patcher => patcher.apply()))
-
-  expect(fs.existsSync('target/replaced.env')).toBe(false)
-  expect(fs.lstatSync('target/own.env').isFIFO()).toBe(true)
-  expect(fs.existsSync('target/keep.txt')).toBe(true)
-})
-
-testOnPosix.each([
-  ['a file', (sourcePath: string) => {
-    fs.writeFileSync(sourcePath, 'real')
-  }],
-  ['a directory', (sourcePath: string) => {
-    fs.mkdirSync(sourcePath, { recursive: true })
-    fs.writeFileSync(path.join(sourcePath, 'inner.txt'), '')
-  }],
-])('replaces a skipped inode in the target when the source has %s there', async (_label, createSource) => {
-  prepareEmpty()
-
-  fs.mkdirSync('source', { recursive: true })
-  fs.mkdirSync('target', { recursive: true })
-  createSource(path.resolve('source/config.env'))
-  fs.writeFileSync('source/other.txt', '')
-  // The target holds an inode the map skips, so the diff cannot schedule it
-  // for removal and adding over it would fail with EEXIST.
-  execFileSync('mkfifo', [path.resolve('target/config.env')])
-
-  const patchers = await DirPatcher.fromMultipleTargets('source', ['target'])
-  await Promise.all(patchers.map(async patcher => patcher.apply()))
-
-  const sourceStats = fs.lstatSync('source/config.env')
-  const targetStats = fs.lstatSync('target/config.env')
-  expect(targetStats.isFile()).toBe(sourceStats.isFile())
-  expect(targetStats.isDirectory()).toBe(sourceStats.isDirectory())
-  if (sourceStats.isDirectory()) {
-    expect(fs.readdirSync('target/config.env')).toStrictEqual(fs.readdirSync('source/config.env'))
-  }
-  expect(fs.existsSync('target/other.txt')).toBe(true)
-})
-
-testOnPosix('keeps the files linked into a directory that replaced a blocking inode', async () => {
-  prepareEmpty()
-
-  fs.mkdirSync('source/blocked', { recursive: true })
-  for (let index = 0; index < 20; index++) {
-    fs.writeFileSync(`source/blocked/file${index}.txt`, '')
-  }
-  fs.mkdirSync('target', { recursive: true })
-  execFileSync('mkfifo', [path.resolve('target/blocked')])
-
-  // Widen the window between clearing the blocking inode and linking into the
-  // directory that replaces it. Creating the directory concurrently with its
-  // files lets a removal land after a sibling has linked, taking those files
-  // with it.
-  const originalRm = fs.promises.rm
-  let delayNextRemoval = true
-  fs.promises.rm = (async (target: fs.PathLike, options?: fs.RmOptions) => {
-    if (delayNextRemoval) {
-      delayNextRemoval = false
-      await delay(30)
-    }
-    return originalRm(target, options)
-  }) as typeof fs.promises.rm
-
-  try {
-    const patchers = await DirPatcher.fromMultipleTargets('source', ['target'])
-    await Promise.all(patchers.map(async patcher => patcher.apply()))
-  } finally {
-    fs.promises.rm = originalRm
-  }
-
-  expect(fs.readdirSync('target/blocked').sort()).toStrictEqual(fs.readdirSync('source/blocked').sort())
 })

--- a/pnpm11/workspace/injected-deps-syncer/test/extendFilesMap.test.ts
+++ b/pnpm11/workspace/injected-deps-syncer/test/extendFilesMap.test.ts
@@ -1,10 +1,16 @@
+import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
 
 import { afterEach, expect, jest, test } from '@jest/globals'
 import { prepareEmpty } from '@pnpm/prepare'
+import isWindows from 'is-windows'
 
 import { DIR, extendFilesMap, type ExtendFilesMapStats, type InodeMap } from '../src/DirPatcher.js'
+
+// `mkfifo` has no Windows equivalent; the stats-driven test above it covers
+// the same branch on every platform.
+const testOnPosix = isWindows() ? test.skip : test
 
 const originalStat = fs.promises.stat
 
@@ -99,4 +105,55 @@ test('with provided stats', async () => {
   } as InodeMap)
 
   expect(statMethod).not.toHaveBeenCalled()
+})
+
+test('skips inodes that are neither files nor directories', async () => {
+  prepareEmpty()
+
+  fs.mkdirSync('distribution', { recursive: true })
+  fs.writeFileSync('distribution/index.js', '')
+
+  const filesMap = new Map<string, string>([
+    ['distribution/index.js', path.resolve('distribution/index.js')],
+    ['.env', path.resolve('.env')],
+  ])
+  const filesStats: Record<string, ExtendFilesMapStats> = {
+    'distribution/index.js': {
+      ino: 7000,
+      isDirectory: () => false,
+      isFile: () => true,
+    },
+    // A FIFO — 1Password's environments create one for `.env`. It cannot be
+    // hardlinked into the injected copy, so it belongs in neither map.
+    '.env': {
+      ino: 7100,
+      isDirectory: () => false,
+      isFile: () => false,
+    },
+  }
+
+  expect(await extendFilesMap({ filesMap, filesStats })).toStrictEqual({
+    '.': DIR,
+    distribution: DIR,
+    'distribution/index.js': 7000,
+  } as InodeMap)
+})
+
+testOnPosix('skips a real FIFO', async () => {
+  prepareEmpty()
+
+  fs.mkdirSync('distribution', { recursive: true })
+  fs.writeFileSync('distribution/index.js', '')
+  execFileSync('mkfifo', [path.resolve('.env')])
+
+  const filesMap = new Map<string, string>([
+    ['distribution/index.js', path.resolve('distribution/index.js')],
+    ['.env', path.resolve('.env')],
+  ])
+
+  expect(await extendFilesMap({ filesMap })).toStrictEqual({
+    '.': DIR,
+    distribution: DIR,
+    'distribution/index.js': fs.statSync('distribution/index.js').ino,
+  } as InodeMap)
 })

--- a/pnpm11/workspace/injected-deps-syncer/test/extendFilesMap.test.ts
+++ b/pnpm11/workspace/injected-deps-syncer/test/extendFilesMap.test.ts
@@ -180,3 +180,29 @@ testOnPosix('a skipped inode in the source removes what the target holds at that
   expect(fs.lstatSync('target/own.env').isFIFO()).toBe(true)
   expect(fs.existsSync('target/keep.txt')).toBe(true)
 })
+
+testOnPosix.each([
+  ['a file', (sourcePath: string) => {
+    fs.writeFileSync(sourcePath, 'real')
+  }],
+  ['a directory', (sourcePath: string) => {
+    fs.mkdirSync(sourcePath, { recursive: true })
+    fs.writeFileSync(path.join(sourcePath, 'inner.txt'), '')
+  }],
+])('replaces a skipped inode in the target when the source has %s there', async (_label, createSource) => {
+  prepareEmpty()
+
+  fs.mkdirSync('source', { recursive: true })
+  fs.mkdirSync('target', { recursive: true })
+  createSource(path.resolve('source/config.env'))
+  fs.writeFileSync('source/other.txt', '')
+  // The target holds an inode the map skips, so the diff cannot schedule it
+  // for removal and adding over it would fail with EEXIST.
+  execFileSync('mkfifo', [path.resolve('target/config.env')])
+
+  const patchers = await DirPatcher.fromMultipleTargets('source', ['target'])
+  await Promise.all(patchers.map(async patcher => patcher.apply()))
+
+  expect(fs.lstatSync('target/config.env').isFIFO()).toBe(false)
+  expect(fs.existsSync('target/other.txt')).toBe(true)
+})

--- a/pnpm11/workspace/injected-deps-syncer/test/extendFilesMap.test.ts
+++ b/pnpm11/workspace/injected-deps-syncer/test/extendFilesMap.test.ts
@@ -7,7 +7,7 @@ import { afterEach, expect, jest, test } from '@jest/globals'
 import { prepareEmpty } from '@pnpm/prepare'
 import isWindows from 'is-windows'
 
-import { DIR, extendFilesMap, type ExtendFilesMapStats, type InodeMap } from '../src/DirPatcher.js'
+import { DIR, DirPatcher, extendFilesMap, type ExtendFilesMapStats, type InodeMap } from '../src/DirPatcher.js'
 
 // `mkfifo` has no Windows equivalent; the stats-driven test above it covers
 // the same branch on every platform.
@@ -157,4 +157,26 @@ testOnPosix('skips a real FIFO', async () => {
     distribution: DIR,
     'distribution/index.js': fs.statSync('distribution/index.js').ino,
   } as InodeMap)
+})
+
+testOnPosix('a skipped inode in the source removes what the target holds at that path, but a skipped inode in the target is left alone', async () => {
+  prepareEmpty()
+
+  fs.mkdirSync('source', { recursive: true })
+  fs.mkdirSync('target', { recursive: true })
+  fs.writeFileSync('source/keep.txt', '')
+  fs.writeFileSync('target/keep.txt', '')
+  // The source turned this path into a FIFO while the target still holds the
+  // file that used to be there.
+  execFileSync('mkfifo', [path.resolve('source/replaced.env')])
+  fs.writeFileSync('target/replaced.env', 'stale')
+  // A FIFO the target holds on its own.
+  execFileSync('mkfifo', [path.resolve('target/own.env')])
+
+  const patchers = await DirPatcher.fromMultipleTargets('source', ['target'])
+  await Promise.all(patchers.map(async patcher => patcher.apply()))
+
+  expect(fs.existsSync('target/replaced.env')).toBe(false)
+  expect(fs.lstatSync('target/own.env').isFIFO()).toBe(true)
+  expect(fs.existsSync('target/keep.txt')).toBe(true)
 })

--- a/pnpm11/workspace/injected-deps-syncer/test/extendFilesMap.test.ts
+++ b/pnpm11/workspace/injected-deps-syncer/test/extendFilesMap.test.ts
@@ -2,6 +2,7 @@
 import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
+import { setTimeout as delay } from 'node:timers/promises'
 
 import { afterEach, expect, jest, test } from '@jest/globals'
 import { prepareEmpty } from '@pnpm/prepare'
@@ -203,6 +204,46 @@ testOnPosix.each([
   const patchers = await DirPatcher.fromMultipleTargets('source', ['target'])
   await Promise.all(patchers.map(async patcher => patcher.apply()))
 
-  expect(fs.lstatSync('target/config.env').isFIFO()).toBe(false)
+  const sourceStats = fs.lstatSync('source/config.env')
+  const targetStats = fs.lstatSync('target/config.env')
+  expect(targetStats.isFile()).toBe(sourceStats.isFile())
+  expect(targetStats.isDirectory()).toBe(sourceStats.isDirectory())
+  if (sourceStats.isDirectory()) {
+    expect(fs.readdirSync('target/config.env')).toStrictEqual(fs.readdirSync('source/config.env'))
+  }
   expect(fs.existsSync('target/other.txt')).toBe(true)
+})
+
+testOnPosix('keeps the files linked into a directory that replaced a blocking inode', async () => {
+  prepareEmpty()
+
+  fs.mkdirSync('source/blocked', { recursive: true })
+  for (let index = 0; index < 20; index++) {
+    fs.writeFileSync(`source/blocked/file${index}.txt`, '')
+  }
+  fs.mkdirSync('target', { recursive: true })
+  execFileSync('mkfifo', [path.resolve('target/blocked')])
+
+  // Widen the window between clearing the blocking inode and linking into the
+  // directory that replaces it. Creating the directory concurrently with its
+  // files lets a removal land after a sibling has linked, taking those files
+  // with it.
+  const originalRm = fs.promises.rm
+  let delayNextRemoval = true
+  fs.promises.rm = (async (target: fs.PathLike, options?: fs.RmOptions) => {
+    if (delayNextRemoval) {
+      delayNextRemoval = false
+      await delay(30)
+    }
+    return originalRm(target, options)
+  }) as typeof fs.promises.rm
+
+  try {
+    const patchers = await DirPatcher.fromMultipleTargets('source', ['target'])
+    await Promise.all(patchers.map(async patcher => patcher.apply()))
+  } finally {
+    fs.promises.rm = originalRm
+  }
+
+  expect(fs.readdirSync('target/blocked').sort()).toStrictEqual(fs.readdirSync('source/blocked').sort())
 })


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#13550.

`extendFilesMap` threw `ERR_PNPM_UNSUPPORTED_INODE_TYPE` for any inode that is neither a file nor a directory, and `DirPatcher.fromMultipleTargets` walks the whole package directory rather than its declared `files`. A FIFO anywhere in a workspace package therefore aborted `syncInjectedDepsAfterScripts` and left the injected dependency stale. The reporter's case is [1Password's environments](https://1password.dev/environments), which make `.env` a FIFO — a permanent fixture of that setup, not a transient state.

Reproduced against the current tree before changing anything, with a package declaring `"files": ["distribution"]` and a `mkfifo`'d `.env`:

```
filesMap keys: [ '.env', 'package.json', 'distribution/index.js' ]
THREW: ERR_PNPM_UNSUPPORTED_INODE_TYPE | Filesystem inode at …/.env is neither a file, a directory, or a symbolic link
```

Such an inode is now left out of the inode map instead. That also keeps it out of the diff, so it is neither hardlinked into the target nor removed from it, and the rest of the package syncs. Verified end-to-end on the built package with a real FIFO: the sync completes, the target contains `distribution/index.js` and `package.json`, and `.env` is not copied.

The skip is silent. A warning would fire on every install for a setup where the FIFO is a permanent fixture, which is noise rather than information; the issue asks for the path to be "safely skipped".

## A second failure in the same function

Review surfaced a crash that predates this PR but shares its shape — the target holds something the source wants to put a directory over. When a workspace package replaces a file with a directory of the same name, that path lands in `modified` while its contents land in `added`; the addition pass reached `fs.mkdirSync(path.dirname(targetPath))` before the modification pass had replaced the file, so the sync died with `EEXIST: mkdir`. It reproduces on `main` unchanged.

`applyPatch` now feeds `added` and `modified` through one pass: every directory first, shallowest first, then the files in parallel. A directory is therefore always in place before anything is linked into it, and always empty when it displaces whatever the target held. Covered by `replaces a target entry whose inode type changed in the source`, which fails against the pre-fix `applyPatch`.

**Rust:** no matching change. pacquet has no injected-deps syncer — `sync-injected-deps-after-scripts` appears only as a recognized config key — and its directory walker already skips non-files (`if !meta.is_file() { continue; }` in `add_files_from_dir.rs`).

**Tests:** `extendFilesMap.test.ts` keeps two cases for the shape of the inode map — one drives the branch through injected stats so it runs on every platform, including Windows; the other creates a real FIFO with `mkfifo` and is skipped on Windows, which has no equivalent. `DirPatcher.test.ts` holds four cases for what a patcher then does: what a skipped inode leaves in a target, what replaces one, that a directory displacing one keeps its files, and the inode-type transition above. Reverting either source change alone fails its tests.

## Squash Commit Body

```text
extendFilesMap threw ERR_PNPM_UNSUPPORTED_INODE_TYPE for any inode that
is neither a file nor a directory. DirPatcher.fromMultipleTargets walks
the whole package directory, not just its declared files, so a FIFO
anywhere in the package — 1Password's environments create one for .env —
aborted syncInjectedDepsAfterScripts and left the injected dependency
stale.

Leave such an inode out of the inode map instead. It is then absent from
the diff as well, so it is neither hardlinked into the target nor
removed from it, and the rest of the package syncs.

A second failure in applyPatch shares that shape: when a package replaced
a file with a directory of the same name, the path landed in `modified`
while its contents landed in `added`, and the addition pass reached
mkdirSync on the parent before the modification pass had replaced it,
dying with EEXIST. Feed `added` and `modified` through one pass instead —
every directory first, shallowest first, then the files in parallel — so
a directory is always in place before anything is linked into it, and
always empty when it displaces what the target held.

pacquet needs no matching change: it has no injected-deps syncer (the
setting is only recognized as config), and its directory walker already
skips non-files.

Fixes #13550
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788527429&installation_model_id=426870&pr_number=13663&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13663&signature=9374b47f69b7cfdd760c13149d480d792d402a0b117080f3e6f1b33706a94220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved injected dependency syncing by skipping unsupported filesystem entries instead of failing.
  * Prevented FIFOs, sockets, devices, and other special entries from interrupting synchronization.
  * Improved recovery when existing entries block directory creation or file linking.
  * Preserved correct sync results when source or target locations contain FIFO entries.

* **Tests**
  * Added POSIX-focused coverage to verify unsupported entries are safely excluded and handled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
