### PR TITLE
fix(napi): keep registry-custom fields in a fullMetadata resolve

### DIFF
--- a/.changeset/napi-resolve-full-metadata.md
+++ b/.changeset/napi-resolve-full-metadata.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/napi": patch
+---
+
+Fixed `resolveDependency({ fullMetadata: true })` returning a manifest stripped down to the abbreviated npm field set. Registry-custom fields on the version object (such as Bit's `componentId`) are now preserved.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4654,6 +4654,7 @@ dependencies = [
  "dashmap",
  "indexmap 2.14.0",
  "miette 7.6.0",
+ "mockito",
  "napi",
  "napi-build",
  "napi-derive",

--- a/pnpm/crates/napi/Cargo.toml
+++ b/pnpm/crates/napi/Cargo.toml
@@ -54,6 +54,7 @@ tokio       = { workspace = true }
 napi-build = { workspace = true }
 
 [dev-dependencies]
+mockito               = { workspace = true }
 pretty_assertions     = { workspace = true }
 pacquet-testing-utils = { workspace = true }
 tempfile              = { workspace = true }

--- a/pnpm/crates/napi/src/resolve.rs
+++ b/pnpm/crates/napi/src/resolve.rs
@@ -134,6 +134,13 @@ fn run_resolve_blocking(
     );
 
     let full_metadata = options.full_metadata.unwrap_or(false);
+    // `filter_metadata` stays off even under `full_metadata`, unlike the
+    // install path: a caller asking this API for full metadata wants the
+    // version object's non-abbreviated fields (Bit reads `componentId`),
+    // and `clear_meta` would drop exactly those. Matches pnpm's
+    // `createClient({ fullMetadata: true })` with no `filterMetadata`,
+    // which is what this API replaces.
+    let filter_metadata = false;
     let retry_opts = RetryOpts {
         retries: config.fetch_retries,
         factor: config.fetch_retry_factor,
@@ -161,7 +168,7 @@ fn run_resolve_blocking(
         prefer_offline: config.prefer_offline,
         ignore_missing_time_field: config.minimum_release_age_ignore_missing_time,
         full_metadata,
-        filter_metadata: full_metadata,
+        filter_metadata,
         retry_opts,
     });
 
@@ -214,7 +221,7 @@ fn run_resolve_blocking(
         prefer_offline: config.prefer_offline,
         ignore_missing_time_field: config.minimum_release_age_ignore_missing_time,
         full_metadata,
-        filter_metadata: full_metadata,
+        filter_metadata,
         retry_opts,
     };
 

--- a/pnpm/crates/napi/src/resolve/tests.rs
+++ b/pnpm/crates/napi/src/resolve/tests.rs
@@ -1,8 +1,9 @@
-//! Offline coverage for the [`resolveDependency`](super::resolve_dependency)
-//! resolver chain. Every case here resolves through the local-filesystem
-//! branch of the chain (or exhausts it), so no registry / git / network
-//! access is required — the runtime resolvers never run for a `file:` /
-//! `link:` spec because the local-scheme resolver claims it first.
+//! Coverage for the [`resolveDependency`](super::resolve_dependency)
+//! resolver chain that needs no outside network. Most cases resolve
+//! through the local-filesystem branch of the chain (or exhaust it) — the
+//! runtime resolvers never run for a `file:` / `link:` spec because the
+//! local-scheme resolver claims it first; the registry cases point the
+//! default registry at a `mockito` server on localhost.
 
 use std::collections::HashMap;
 
@@ -93,4 +94,59 @@ fn errors_when_no_resolver_in_the_chain_claims_the_spec() {
         "unexpected error message: {}",
         error.reason,
     );
+}
+
+/// A packument whose version object carries a registry-custom field
+/// (`componentId` is Bit's) outside the abbreviated field set.
+const CUSTOM_FIELD_PACKAGE_BODY: &str = r#"{
+    "name": "custom-field-pkg",
+    "dist-tags": { "latest": "1.0.0" },
+    "modified": "2024-01-15T12:00:00.000Z",
+    "time": { "1.0.0": "2024-01-10T08:30:00.000Z" },
+    "versions": {
+        "1.0.0": {
+            "name": "custom-field-pkg",
+            "version": "1.0.0",
+            "componentId": { "scope": "acme.ui", "name": "button", "version": "1.0.0" },
+            "dist": {
+                "integrity": "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+                "shasum": "0000000000000000000000000000000000000000",
+                "tarball": "https://registry/custom-field-pkg-1.0.0.tgz"
+            }
+        }
+    }
+}"#;
+
+#[test]
+fn full_metadata_keeps_registry_custom_version_fields() {
+    let mut server = mockito::Server::new();
+    let mock = server
+        .mock("GET", "/custom-field-pkg")
+        .with_status(200)
+        .with_body(CUSTOM_FIELD_PACKAGE_BODY)
+        .create();
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cache_dir = tempfile::tempdir().expect("cache tempdir");
+    let options = ResolveDependencyOptions {
+        dir: dir.path().display().to_string(),
+        store_dir: None,
+        cache_dir: Some(cache_dir.path().display().to_string()),
+        registries: Some(HashMap::from([("default".to_string(), format!("{}/", server.url()))])),
+        full_metadata: Some(true),
+        offline: None,
+        prefer_offline: None,
+        auth_header_by_uri: None,
+    };
+    let wanted = WantedDependencyInput {
+        alias: Some("custom-field-pkg".to_string()),
+        bare_specifier: Some("1.0.0".to_string()),
+    };
+
+    let result = run_resolve_blocking(wanted, &options).expect("resolve registry dep");
+
+    let manifest = result.manifest.expect("registry resolution carries a manifest");
+    dbg!(&manifest);
+    assert_eq!(manifest["componentId"]["name"], "button");
+    mock.assert();
 }


### PR DESCRIPTION
## Summary

`@pnpm/napi`'s `resolveDependency` derived `filter_metadata` from `full_metadata`, so a caller asking for full metadata got a manifest that had been run through `clear_meta` — reduced to npm's abbreviated version fields. Any registry-custom field on the version object was dropped.

Bit is the consumer that hit this: it reads `componentId` off the resolved manifest, and every resolve through the engine failed with

```
unable to resolve a component-id from the package-name @bitdev/node.node-server,
the package.json of version "3.0.17" has no componentId field, it's probably not a component
```

The API this replaces — `createClient({ fullMetadata: true })` from `@pnpm/installing.client` — leaves `filterMetadata` unset, and `retainsFullMeta()` keeps the document whole in exactly that combination. Only the install path (`createNewStoreController`) pairs the two flags, where nothing outside the abbreviated set is ever read. This PR untangles them on the napi resolve path.

No cache invalidation is needed after upgrading: filtered documents were mirrored under `FULL_FILTERED_META_DIR`, a different slot from the unfiltered `FULL_META_DIR` the fixed code reads, so a poisoned mirror can't be served.

No TypeScript-side change is needed — the TS resolver path was already correct; only the napi binding mis-paired the flags.

Related to teambit/bit#10558, which added a fallback on the Bit side.

## Squash Commit Body

```text
`resolveDependency` derived `filter_metadata` from `full_metadata`, so a
caller asking for full metadata got a manifest run through `clear_meta` —
reduced to npm's abbreviated version fields. Registry-custom fields were
dropped, which broke Bit's `componentId` lookups ("the package.json of
version X has no componentId field").

The API this replaces, `createClient({ fullMetadata: true })`, leaves
`filterMetadata` unset and keeps the document whole; only the install
path pairs the two flags, where nothing outside the abbreviated set is
read. Untangle them here.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5[1m]).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788532525&installation_model_id=426870&pr_number=13664&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13664&signature=9e61f803521fbc3728485d04c2409e2ddc359d0a8ca4e8184448b940a72f17b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Full-metadata dependency resolution now preserves registry-specific fields, such as Bit’s `componentId`, on version manifests.
  * Custom metadata is retained consistently for dependencies resolved from npm and named registries.

* **Tests**
  * Added coverage validating preservation of custom registry metadata during full-metadata resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->