### PR TITLE
chore(release): move the Rust CLI to the rc lane

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,7 +220,7 @@ The Rust products are released through the same native flow. Their npm wrapper p
 - `@pnpm/napi` — the Node.js addon bindings for the Rust engine.
 - `@pnpm/pnpr` — the pnpr registry server (published as `@pnpm/pnpr` and its platform packages, plus the `ghcr.io/pnpm/pnpr` Docker image).
 
-The Rust products release on `alpha` lanes (`versioning.lanes` in `pnpm-workspace.yaml`): each run of `pnpm version -r` that consumes an intent for one of them cuts an `X.Y.Z-alpha.N` prerelease, while the TypeScript CLI keeps releasing stable versions on the main lane. `pnpm lane main --filter …` graduates a product to a stable version.
+The Rust products release on prerelease lanes (`versioning.lanes` in `pnpm-workspace.yaml`): each run of `pnpm version -r` that consumes an intent for one of them cuts an `X.Y.Z-<lane>.N` prerelease — `rc` for the Rust CLI and its NAPI addon, `alpha` for pnpr — while the TypeScript CLI keeps releasing stable versions on the main lane. `pnpm lane main --filter …` graduates a product to a stable version.
 
 Do not add `"pnpm"` to a Rust-only changeset: in changesets, `pnpm` always means the TypeScript CLI package. A changeset whose implementation is Rust-only and targets `pacquet` must omit `"pnpm"`. A parity change that lands in both stacks carries one changeset naming both the affected TypeScript packages (plus `"pnpm"`) and the Rust wrapper(s).
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -73,13 +73,13 @@ versioning:
   # shared version.
   fixed:
     - ['pacquet', '@pnpm/napi']
-  # The Rust CLI and its NAPI addon release as `X.Y.Z-beta.N` prereleases, while
+  # The Rust CLI and its NAPI addon release as `X.Y.Z-rc.N` prereleases, while
   # pnpr remains on `X.Y.Z-alpha.N`. Both are published under the `next` dist-tag
   # while the TypeScript CLI keeps releasing stable versions on the main lane.
   # `pnpm lane main --filter …` graduates a product to stable.
   lanes:
-    pacquet: beta
-    '@pnpm/napi': beta
+    pacquet: rc
+    '@pnpm/napi': rc
     '@pnpm/pnpr': alpha
 
 allowBuilds:


### PR DESCRIPTION
## Summary

Moves the Rust CLI off the beta lane and onto an `rc` lane. `versioning.lanes` in
`pnpm-workspace.yaml` now maps `pacquet` and `` `@pnpm/napi` `` (its `versioning.fixed`
partner, which has to share the lane) to `rc`; `` `@pnpm/pnpr` `` stays on `alpha`.

The wrapper packages are still at `12.0.0-beta.4`; the next `pnpm version -r` run that
consumes a Rust intent will cut the first `12.0.0-rc.N` prerelease instead of continuing
the beta series. Both keep publishing under the `next` dist-tag, and the TypeScript CLI
keeps releasing stable versions on the main lane.

`AGENTS.md` (and its `CLAUDE.md` symlink) described both Rust products as releasing from
`alpha` lanes — already stale before this PR, since the Rust CLI was on `beta`. It now names
the lane per product, so the sentence survives the next lane move.

Edited by hand rather than through `pnpm lane`: the command refuses a direct beta -> rc
move (`ERR_PNPM_VERSIONING_ALREADY_ON_LANE`, pointing at `pnpm lane main` first), and the
`main` -> `rc` round-trip rewrites the whole file — stripping every comment in the
`versioning` block and relocating the block to the end of the file. That rewrite is a
separate bug, not addressed here.

## Squash Commit Body

```text
Switch pacquet and its fixed-group partner `@pnpm/napi` from the beta lane
to rc, so the next "pnpm version -r" cuts 12.0.0-rc.N prereleases instead
of continuing the 12.0.0-beta.N series. pnpr stays on alpha.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (Release configuration only — nothing to port.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
  (No published package changes; this only selects the prerelease lane.)

---
Written by an agent (Claude Code, claude-opus-5[1m]).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release channels for `pacquet` and `@pnpm/napi` from beta to release candidate.
  * Preserved the existing alpha channel and fixed release grouping.
  * Updated Rust release guidance to reflect the release candidate channel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->