### PR TITLE
fix(update): skip compatibility database for project manifests

### DIFF
--- a/.changeset/skip-importer-compatibility-db.md
+++ b/.changeset/skip-importer-compatibility-db.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/hooks.read-package-hook": patch
+"@pnpm/installing.context": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+Do not apply the built-in package compatibility database to project manifests, so `pnpm update` no longer adds dependencies when a project's name and version match a registry package [#11700](https://github.com/pnpm/pnpm/issues/11700). User-configured package extensions still apply to projects.

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile/manifest_transforms.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile/manifest_transforms.rs
@@ -67,15 +67,11 @@ pub(super) fn build_manifest_transforms(
         .map(|parsed| Arc::new(VersionsOverrider::new(parsed, lockfile_dir)));
 
     let mut effective_importer_manifests = BTreeMap::new();
-    if compat_package_extender.is_some()
-        || package_extender.is_some()
+    if package_extender.is_some()
         || versions_overrider.as_ref().is_some_and(|overrider| !overrider.is_empty())
     {
         for (id, manifest) in importer_manifests {
             let mut cloned = (*manifest).clone();
-            if let Some(extender) = compat_package_extender {
-                extender.apply(cloned.value_mut());
-            }
             if let Some(extender) = package_extender.as_ref() {
                 extender.apply(cloned.value_mut());
             }

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile/tests.rs
@@ -1,10 +1,12 @@
 use super::{
     ImporterUpdateSeedPolicy, UpdateSeedPolicy, compute_package_extensions_checksum,
     full_resolution_required, include_transitive_optional_dependencies,
-    is_partial_workspace_selection, update_reuse_scopes,
+    is_partial_workspace_selection, manifest_transforms::build_manifest_transforms,
+    update_reuse_scopes,
 };
+use pacquet_catalogs_types::Catalogs;
 use pacquet_config::{Config, PackageExtension};
-use pacquet_package_manifest::DependencyGroup;
+use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pretty_assertions::assert_eq;
 
 fn config_with_extensions(entries: &[(&str, &[(&str, &str)])]) -> Box<Config> {
@@ -43,6 +45,30 @@ fn partial_installs_keep_transitive_optional_dependencies() {
     assert!(include_transitive_optional_dependencies(false, &prod_only));
     assert!(!include_transitive_optional_dependencies(true, &prod_only));
     assert!(include_transitive_optional_dependencies(true, &with_optional));
+}
+
+#[test]
+fn builtin_compatibility_extensions_do_not_apply_to_importer_manifests() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest = PackageManifest::from_value(
+        dir.path().join("package.json"),
+        serde_json::json!({
+            "name": "vue-loader",
+            "version": "0.0.0",
+        }),
+    );
+    let importer_manifests = std::collections::BTreeMap::from([(".".to_string(), &manifest)]);
+
+    let transforms = build_manifest_transforms(
+        &Config::new(),
+        &Catalogs::default(),
+        dir.path(),
+        &importer_manifests,
+    )
+    .unwrap();
+    let effective_manifest = transforms.effective_importer_manifests.get(".").unwrap_or(&manifest);
+
+    assert_eq!(effective_manifest.value().get("peerDependencies"), None);
 }
 
 /// Ports `installing/.../packageExtensions.ts:103-153`

--- a/pnpm11/hooks/read-package-hook/src/createReadPackageHook.ts
+++ b/pnpm11/hooks/read-package-hook/src/createReadPackageHook.ts
@@ -68,12 +68,8 @@ export function createReadPackageHook (
   }
 ): ReadPackageHook | undefined {
   const hooks: ReadPackageHook[] = []
-  const effectivePackageExtensions = getEffectivePackageExtensions({
-    ignoreCompatibilityDb,
-    packageExtensions,
-  })
-  if (effectivePackageExtensions != null) {
-    hooks.push(createPackageExtender(effectivePackageExtensions))
+  if (!isEmpty(packageExtensions ?? {})) {
+    hooks.push(createPackageExtender(packageExtensions!))
   }
   if (Array.isArray(readPackageHook)) {
     hooks.push(...readPackageHook)
@@ -87,12 +83,23 @@ export function createReadPackageHook (
     hooks.push(createOptionalDependenciesRemover(ignoredOptionalDependencies))
   }
 
-  if (hooks.length === 0) {
+  const dependencyHooks = [...hooks]
+  const compatibilityPackageExtensions = getEffectivePackageExtensions({
+    ignoreCompatibilityDb,
+  })
+  if (compatibilityPackageExtensions != null) {
+    dependencyHooks.unshift(createPackageExtender(compatibilityPackageExtensions))
+  }
+
+  if (dependencyHooks.length === 0) {
     return undefined
   }
-  const readPackageAndExtend = hooks.length === 1
-    ? hooks[0]
-    : ((pkg: PackageManifest | ProjectManifest, dir: string) => pipeWith(async (f, res) => f(await res, dir), hooks as any)(pkg, dir)) as ReadPackageHook // eslint-disable-line @typescript-eslint/no-explicit-any
+  const readPackageAndExtend = ((pkg: PackageManifest | ProjectManifest, dir?: string) => {
+    const hooksForManifest = dir == null ? dependencyHooks : hooks
+    if (hooksForManifest.length === 0) return pkg
+    if (hooksForManifest.length === 1) return hooksForManifest[0](pkg, dir)
+    return pipeWith(async (f, res) => f(await res, dir), hooksForManifest as any)(pkg, dir) // eslint-disable-line @typescript-eslint/no-explicit-any
+  }) as ReadPackageHook
   return readPackageAndExtend
 }
 

--- a/pnpm11/hooks/read-package-hook/test/createReadPackageHook.ts
+++ b/pnpm11/hooks/read-package-hook/test/createReadPackageHook.ts
@@ -1,5 +1,5 @@
 import { expect, jest, test } from '@jest/globals'
-import type { ReadPackageHook } from '@pnpm/types'
+import type { PackageManifest, ReadPackageHook } from '@pnpm/types'
 
 import { createReadPackageHook, getEffectivePackageExtensions } from '../lib/createReadPackageHook.js'
 
@@ -68,6 +68,49 @@ test('getEffectivePackageExtensions() includes the pnpm-specific compatibility e
     },
   })
   expect(getEffectivePackageExtensions({ ignoreCompatibilityDb: true })).toBeUndefined()
+})
+
+test('createReadPackageHook() does not apply compatibility extensions to project manifests', async () => {
+  const readPackageHook = createReadPackageHook({
+    lockfileDir: '/project',
+    packageExtensions: {
+      'vue-loader': {
+        dependencies: {
+          custom: '1.0.0',
+        },
+      },
+    },
+  })
+
+  const updatedManifest = await readPackageHook!({
+    name: 'vue-loader',
+    version: '0.0.0',
+  }, '/project')
+
+  expect(updatedManifest).toStrictEqual({
+    dependencies: {
+      custom: '1.0.0',
+    },
+    name: 'vue-loader',
+    version: '0.0.0',
+  })
+})
+
+test('createReadPackageHook() applies compatibility extensions to dependency manifests', async () => {
+  const readPackageHook = createReadPackageHook({
+    lockfileDir: '/project',
+  })
+
+  const manifest: PackageManifest = {
+    name: 'vue-loader',
+    version: '0.0.0',
+  }
+  const updatedManifest = await readPackageHook!(manifest)
+
+  expect(updatedManifest.peerDependencies).toStrictEqual({
+    '@vue/compiler-sfc': '^3.0.8',
+    webpack: '^4.1.0 || ^5.0.0-0',
+  })
 })
 
 test('getEffectivePackageExtensions() merges duplicate compatibility selectors', () => {

--- a/pnpm11/installing/context/src/index.ts
+++ b/pnpm11/installing/context/src/index.ts
@@ -328,7 +328,7 @@ export async function getContextForSingleImporter (
     importerId,
     include: opts.include ?? include,
     lockfileDir: opts.lockfileDir,
-    manifest: await opts.readPackageHook?.(manifest) ?? manifest,
+    manifest: await opts.readPackageHook?.(manifest, opts.dir) ?? manifest,
     modulesDir,
     modulesFile: modules,
     pendingBuilds,

--- a/pnpm11/pnpm/test/update.ts
+++ b/pnpm11/pnpm/test/update.ts
@@ -71,6 +71,23 @@ test('update', async () => {
   expect(pkg.dependencies?.['@pnpm.e2e/foo']).toBe('^100.1.0')
 })
 
+test('update does not add compatibility peers to a dependency-free project', async () => {
+  const project = prepare({
+    name: 'vue-loader',
+    version: '0.0.0',
+  })
+
+  await execPnpm(['update'])
+
+  const pkg = await readPackageJsonFromDir(process.cwd())
+  expect(pkg).toMatchObject({
+    name: 'vue-loader',
+    version: '0.0.0',
+  })
+  expect(pkg.dependencies).toBeUndefined()
+  expect(project.readLockfile().importers['.']).toStrictEqual({})
+})
+
 test('recursive update --no-save', async () => {
   await addDistTag('@pnpm.e2e/foo', '100.1.0', 'latest')
   preparePackages([

--- a/pnpr/.fixtures/packages/@vue/compiler-sfc/3.5.34/package.json
+++ b/pnpr/.fixtures/packages/@vue/compiler-sfc/3.5.34/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@vue/compiler-sfc",
+  "version": "3.5.34"
+}

--- a/pnpr/.fixtures/packages/webpack/5.106.2/package.json
+++ b/pnpr/.fixtures/packages/webpack/5.106.2/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "webpack",
+  "version": "5.106.2"
+}


### PR DESCRIPTION
## Summary

When a project's name and version matched a registry package, `pnpm update` could apply entries from the built-in compatibility database to the project manifest itself. This caused otherwise dependency-free projects to gain dependencies unexpectedly.

This change keeps built-in compatibility extensions limited to dependency manifests in both the TypeScript and Rust implementations. Project manifests continue to receive user-configured `packageExtensions`.

Regression coverage has been added for the read-package hook, the `pnpm update` flow, and the Rust manifest transform.

Fixes pnpm/pnpm#11700.

## Squash Commit Body

```text
Keep the built-in package compatibility database scoped to dependency manifests. A project manifest should not inherit registry compatibility entries simply because its name and version match a published package, while user-configured packageExtensions should continue to apply.

Apply the same boundary in the TypeScript and Rust implementations, and cover it through the read-package hook, update flow, and Rust manifest-transform tests.

Fixes pnpm/pnpm#11700.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13670"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788573325&installation_model_id=426870&pr_number=13670&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13670&signature=5cc78ebe3adfc57df252bd34bbfcbc2e9da5b25fb7a763acae5b8335f638f63b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project manifests are no longer modified by pnpm’s built-in package compatibility database.
  * User-configured package extensions and version overrides continue to work as expected.
  * Compatibility adjustments remain available for dependency manifests.
  * `pnpm update` now leaves dependency-free project manifests unchanged and creates an empty lockfile importer where appropriate.

* **Tests**
  * Added coverage for manifest handling, compatibility extensions, and update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->