### PR TITLE
fix(resolver): honor offline mode during lockfile verification

### DIFF
--- a/.changeset/offline-lockfile-verification-cache.md
+++ b/.changeset/offline-lockfile-verification-cache.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/resolving.default-resolver": patch
+"@pnpm/resolving.npm-resolver": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+Lockfile verification now honors offline mode by using cached registry metadata instead of reaching the registry. When the required metadata is not available locally, verification reports the same `ERR_PNPM_NO_OFFLINE_META` condition used by offline resolution.

--- a/.changeset/offline-lockfile-verification-cache.md
+++ b/.changeset/offline-lockfile-verification-cache.md
@@ -1,6 +1,6 @@
 ---
-"@pnpm/resolving.default-resolver": patch
-"@pnpm/resolving.npm-resolver": patch
+"@pnpm/resolving.default-resolver": minor
+"@pnpm/resolving.npm-resolver": minor
 "pacquet": patch
 "pnpm": patch
 ---

--- a/pnpm/crates/package-manager/src/build_resolution_verifiers.rs
+++ b/pnpm/crates/package-manager/src/build_resolution_verifiers.rs
@@ -129,6 +129,7 @@ pub fn build_resolution_verifiers(
         auth_headers: auth_override.unwrap_or_else(|| Arc::clone(&config.auth_headers)),
         cache_dir: Some(config.cache_dir.clone()),
         meta_cache,
+        offline: config.offline,
         retry_opts: retry_opts_from_config(config),
         now: None,
         observed_dist_stats,

--- a/pnpm/crates/package-manager/src/build_resolution_verifiers/tests.rs
+++ b/pnpm/crates/package-manager/src/build_resolution_verifiers/tests.rs
@@ -61,6 +61,6 @@ async fn offline_config_threads_to_resolution_verifier() {
     let ResolutionVerification::FetchFailed { message } = result else {
         panic!("expected offline metadata failure, got {result:?}");
     };
-    assert!(message.contains("ERR_PNPM_NO_OFFLINE_META") || message.contains("Failed to resolve"));
+    assert!(message.contains("ERR_PNPM_NO_OFFLINE_META"));
     no_network.assert_async().await;
 }

--- a/pnpm/crates/package-manager/src/build_resolution_verifiers/tests.rs
+++ b/pnpm/crates/package-manager/src/build_resolution_verifiers/tests.rs
@@ -1,9 +1,15 @@
 use std::sync::Arc;
 
 use pacquet_config::Config;
+use pacquet_lockfile::{LockfileResolution, PkgName, TarballResolution};
 use pacquet_network::ThrottledClient;
+use pacquet_resolving_resolver_base::{ResolutionVerification, VerifyCtx};
+use ssri::Integrity;
+use tempfile::TempDir;
 
 use super::{BuildVerifiersError, build_resolution_verifiers};
+
+const FAKE_INTEGRITY: &str = "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==";
 
 /// Verifiers are built before the resolver chain that also validates
 /// `namedRegistries`, and on the frozen path that chain never runs, so a
@@ -21,4 +27,40 @@ fn reserved_named_registry_is_an_error_not_a_panic() {
         "expected a diagnostic, got {:?}",
         result.map(|verifiers| verifiers.len()),
     );
+}
+
+#[tokio::test]
+async fn offline_config_threads_to_resolution_verifier() {
+    let mut server = mockito::Server::new_async().await;
+    let registry = format!("{}/", server.url());
+    let no_network = server.mock("GET", "/acme").with_status(500).expect(0).create_async().await;
+
+    let cache_dir = TempDir::new().expect("tempdir");
+    let config = Config {
+        registry: registry.clone(),
+        cache_dir: cache_dir.path().to_path_buf(),
+        offline: true,
+        ..Default::default()
+    };
+
+    let verifiers =
+        build_resolution_verifiers(&config, Arc::new(ThrottledClient::default()), None, None, None)
+            .expect("build verifiers");
+    let name: PkgName = "acme".parse().expect("parse name");
+    let resolution = LockfileResolution::Tarball(TarballResolution {
+        tarball: format!("{registry}acme/-/acme-1.0.0.tgz"),
+        integrity: Some(FAKE_INTEGRITY.parse::<Integrity>().expect("parse integrity")),
+        git_hosted: None,
+        path: None,
+    });
+
+    let result = verifiers[0]
+        .verify(&resolution, VerifyCtx { name: &name, version: "1.0.0", registry_name: None })
+        .await;
+
+    let ResolutionVerification::FetchFailed { message } = result else {
+        panic!("expected offline metadata failure, got {result:?}");
+    };
+    assert!(message.contains("ERR_PNPM_NO_OFFLINE_META") || message.contains("Failed to resolve"));
+    no_network.assert_async().await;
 }

--- a/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
@@ -133,6 +133,9 @@ pub struct CreateNpmResolutionVerifierOptions {
     /// unit tests don't have a resolver running alongside, in which
     /// case the verifier falls back to its own fetch chain.
     pub meta_cache: Option<Arc<dyn PackageMetaCache>>,
+    /// When true, verifier metadata lookups must use the local mirror
+    /// only and never reach the registry or attestation endpoint.
+    pub offline: bool,
     /// Retry budget for the verifier's metadata and attestation
     /// fetches. Sourced from the same `fetch-retries` config the
     /// resolver and tarball paths use.
@@ -174,6 +177,7 @@ pub struct NpmResolutionVerifier {
     auth_headers: Arc<AuthHeaders>,
     cache_dir: Option<PathBuf>,
     meta_cache: Option<Arc<dyn PackageMetaCache>>,
+    offline: bool,
     retry_opts: RetryOpts,
     now: Option<DateTime<Utc>>,
     policy_snapshot: serde_json::Map<String, JsonValue>,
@@ -189,6 +193,7 @@ impl std::fmt::Debug for NpmResolutionVerifier {
             .field("ignore_missing_time_field", &self.ignore_missing_time_field)
             .field("trust_policy", &self.trust_policy)
             .field("trust_policy_ignore_after", &self.trust_policy_ignore_after)
+            .field("offline", &self.offline)
             .field("sorted_min_age_excludes", &self.sorted_min_age_excludes)
             .field("sorted_trust_excludes", &self.sorted_trust_excludes)
             .field("policy_snapshot", &self.policy_snapshot)
@@ -256,6 +261,7 @@ pub fn create_npm_resolution_verifier(
         auth_headers: opts.auth_headers,
         cache_dir: opts.cache_dir,
         meta_cache: opts.meta_cache,
+        offline: opts.offline,
         retry_opts: opts.retry_opts,
         now: opts.now,
         policy_snapshot,
@@ -739,6 +745,7 @@ impl NpmResolutionVerifier {
                     cache_dir: self.cache_dir.as_deref(),
                     full_metadata: false,
                     filter_metadata: false,
+                    offline: self.offline,
                     retry_opts: self.retry_opts,
                 };
                 // Carry a fetch failure (auth/network/5xx) as the `Err` value
@@ -826,6 +833,9 @@ impl NpmResolutionVerifier {
         name: &PkgName,
         version: &str,
     ) -> Result<Option<String>, String> {
+        if self.offline {
+            return Ok(None);
+        }
         let opts = FetchAttestationOptions {
             registry,
             http_client: &self.http_client,
@@ -917,6 +927,7 @@ impl NpmResolutionVerifier {
             // both of which the abbreviated form drops. Always full.
             full_metadata: true,
             filter_metadata: false,
+            offline: self.offline,
             retry_opts: self.retry_opts,
         };
         fetch_full_metadata_cached(&name.to_string(), &opts)

--- a/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
@@ -26,6 +26,7 @@ use std::{
 
 use chrono::{DateTime, Utc};
 use dashmap::DashMap;
+use miette::Diagnostic as _;
 use pacquet_config::{TrustPolicy, version_policy::PackageVersionPolicy};
 use pacquet_lockfile::{LockfileResolution, PkgName, is_git_hosted_tarball_url};
 use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient, redact_url_credentials};
@@ -755,7 +756,7 @@ impl NpmResolutionVerifier {
                 // it reports a 403 as a tampering-style mismatch.
                 match fetch_full_metadata_cached(&name.to_string(), &opts).await {
                     Ok(meta) => Ok(project_abbreviated_meta(&meta)),
-                    Err(error) => Err(redact_url_credentials(&error.to_string())),
+                    Err(error) => Err(render_fetch_metadata_error(&error)),
                 }
             })
             .await;
@@ -932,7 +933,16 @@ impl NpmResolutionVerifier {
         };
         fetch_full_metadata_cached(&name.to_string(), &opts)
             .await
-            .map_err(|err| redact_url_credentials(&err.to_string()))
+            .map_err(|error| render_fetch_metadata_error(&error))
+    }
+}
+
+fn render_fetch_metadata_error(error: &crate::FetchMetadataError) -> String {
+    let code = error.code().map(|code| code.to_string());
+    let message = redact_url_credentials(&error.to_string());
+    match code {
+        Some(code) => format!("{code}: {message}"),
+        None => message,
     }
 }
 

--- a/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/tests.rs
@@ -67,6 +67,7 @@ fn default_opts(registry_url: &str) -> CreateNpmResolutionVerifierOptions {
         auth_headers: Arc::new(AuthHeaders::default()),
         cache_dir: None,
         meta_cache: None,
+        offline: false,
         // No retries: tests that point an endpoint at an unmocked /
         // erroring upstream would otherwise wait out the full pnpm
         // backoff (10 s + 60 s) on every run.

--- a/pnpm/crates/resolving-npm-resolver/src/errors.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/errors.rs
@@ -21,7 +21,7 @@ use pacquet_network::redact_and_sanitize;
 #[derive(Debug, Display, Error, Diagnostic)]
 #[non_exhaustive]
 pub enum FetchMetadataError {
-    #[display("Failed to resolve {pkg_name} in package mirror {pkg_mirror:?}")]
+    #[display("Failed to resolve {pkg_name} in package mirror {}", pkg_mirror.display())]
     #[diagnostic(code(ERR_PNPM_NO_OFFLINE_META))]
     NoOfflineMeta {
         #[error(not(source))]

--- a/pnpm/crates/resolving-npm-resolver/src/errors.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/errors.rs
@@ -21,6 +21,15 @@ use pacquet_network::redact_and_sanitize;
 #[derive(Debug, Display, Error, Diagnostic)]
 #[non_exhaustive]
 pub enum FetchMetadataError {
+    #[display("Failed to resolve {pkg_name} in package mirror {pkg_mirror:?}")]
+    #[diagnostic(code(ERR_PNPM_NO_OFFLINE_META))]
+    NoOfflineMeta {
+        #[error(not(source))]
+        pkg_name: String,
+        #[error(not(source))]
+        pkg_mirror: std::path::PathBuf,
+    },
+
     #[display("Failed to fetch metadata from {url}: {error}")]
     #[diagnostic(code(ERR_PNPM_RESOLVING_NPM_RESOLVER_NETWORK_ERROR))]
     Network {

--- a/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
@@ -14,7 +14,7 @@
 //! only the version fragments a pick consults.
 
 use std::{
-    path::Path,
+    path::{Path, PathBuf},
     sync::atomic::{AtomicBool, Ordering},
 };
 
@@ -60,6 +60,9 @@ pub struct FetchFullMetadataCachedOptions<'a> {
     /// When full metadata is requested, use pnpm's filtered metadata
     /// mirror and persist the filtered packument shape.
     pub filter_metadata: bool,
+    /// When true, use only the on-disk metadata mirror and never reach
+    /// the registry.
+    pub offline: bool,
     pub(crate) retry_opts: RetryOpts,
 }
 
@@ -104,6 +107,17 @@ pub async fn fetch_full_metadata_cached(
         // No cache dir — fetch fresh without reading or writing a mirror.
         None => None,
     };
+
+    if opts.offline {
+        if let Some(meta) = load_meta_async(mirror_path.as_deref()).await {
+            return Ok(meta);
+        }
+        return Err(FetchMetadataError::NoOfflineMeta {
+            pkg_name: pkg_name.to_string(),
+            pkg_mirror: mirror_path.unwrap_or_else(PathBuf::new),
+        });
+    }
+
     let cache_headers = load_meta_headers_async(mirror_path.as_deref()).await;
     let accept = if opts.full_metadata { ACCEPT_FULL_DOC } else { ACCEPT_ABBREVIATED_DOC };
     let should_filter_metadata = opts.full_metadata && opts.filter_metadata;

--- a/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached/tests.rs
@@ -81,6 +81,7 @@ async fn cold_cache_writes_mirror_on_200() {
         cache_dir: Some(cache.path()),
         full_metadata: true,
         filter_metadata: false,
+        offline: false,
         retry_opts: no_retry_opts(),
     };
 
@@ -93,6 +94,61 @@ async fn cold_cache_writes_mirror_on_200() {
     assert!(mirror_path.exists(), "mirror file written");
     let headers = load_meta_headers(&mirror_path).expect("headers readable");
     assert_eq!(headers.etag.as_deref(), Some(r#"W/"fresh""#));
+}
+
+#[tokio::test]
+async fn offline_with_mirror_reads_cache_without_registry() {
+    let mut server = mockito::Server::new_async().await;
+    let no_network = server.mock("GET", "/acme").with_status(500).expect(0).create_async().await;
+
+    let cache = TempDir::new().expect("tempdir");
+    let registry = format!("{}/", server.url());
+    write_stale_mirror(cache.path(), FULL_META_DIR, &registry);
+
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let opts = FetchFullMetadataCachedOptions {
+        registry: &registry,
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        cache_dir: Some(cache.path()),
+        full_metadata: true,
+        filter_metadata: false,
+        offline: true,
+        retry_opts: no_retry_opts(),
+    };
+
+    let pkg = fetch_full_metadata_cached("acme", &opts).await.expect("offline cache hit");
+    assert_eq!(pkg.name, "acme");
+    no_network.assert_async().await;
+}
+
+#[tokio::test]
+async fn offline_without_mirror_errors_without_registry() {
+    let mut server = mockito::Server::new_async().await;
+    let no_network = server.mock("GET", "/acme").with_status(500).expect(0).create_async().await;
+
+    let cache = TempDir::new().expect("tempdir");
+    let registry = format!("{}/", server.url());
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let opts = FetchFullMetadataCachedOptions {
+        registry: &registry,
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        cache_dir: Some(cache.path()),
+        full_metadata: true,
+        filter_metadata: false,
+        offline: true,
+        retry_opts: no_retry_opts(),
+    };
+
+    let error = fetch_full_metadata_cached("acme", &opts).await.expect_err("offline miss");
+    assert!(matches!(
+        error,
+        FetchMetadataError::NoOfflineMeta { ref pkg_name, .. } if pkg_name == "acme"
+    ));
+    no_network.assert_async().await;
 }
 
 #[tokio::test]
@@ -129,6 +185,7 @@ async fn unsolicited_304_retries_without_cache() {
         cache_dir: Some(cache.path()),
         full_metadata: true,
         filter_metadata: false,
+        offline: false,
         retry_opts: no_retry_opts(),
     };
 
@@ -167,6 +224,7 @@ async fn repeated_unsolicited_304_reports_missing_cache() {
         cache_dir: Some(cache.path()),
         full_metadata: true,
         filter_metadata: false,
+        offline: false,
         retry_opts: no_retry_opts(),
     };
 
@@ -227,6 +285,7 @@ async fn cache_loss_after_304_stops_after_one_fallback() {
         cache_dir: Some(cache.path()),
         full_metadata: true,
         filter_metadata: false,
+        offline: false,
         retry_opts: no_retry_opts(),
     };
 
@@ -289,6 +348,7 @@ async fn cache_loss_after_304_body_retry_remains_bypassed() {
         cache_dir: Some(cache.path()),
         full_metadata: true,
         filter_metadata: false,
+        offline: false,
         retry_opts: fast_retry_opts(),
     };
 
@@ -340,6 +400,7 @@ async fn cache_loss_after_304_registry_error_propagates() {
         cache_dir: Some(cache.path()),
         full_metadata: true,
         filter_metadata: false,
+        offline: false,
         retry_opts: no_retry_opts(),
     };
 
@@ -400,6 +461,7 @@ async fn assert_cache_loss_after_304_recovers(
         cache_dir: Some(cache.path()),
         full_metadata,
         filter_metadata: false,
+        offline: false,
         retry_opts: no_retry_opts(),
     };
 
@@ -473,6 +535,7 @@ async fn filtered_full_cache_writes_filtered_mirror_on_200() {
         cache_dir: Some(cache.path()),
         full_metadata: true,
         filter_metadata: true,
+        offline: false,
         retry_opts: no_retry_opts(),
     };
 
@@ -529,6 +592,7 @@ async fn a_full_doc_served_for_an_abbreviated_request_is_normalized_before_cachi
         cache_dir: Some(cache.path()),
         full_metadata: false,
         filter_metadata: false,
+        offline: false,
         retry_opts: no_retry_opts(),
     };
 
@@ -581,6 +645,7 @@ async fn a_doc_served_with_the_abbreviated_content_type_is_cached_verbatim() {
         cache_dir: Some(cache.path()),
         full_metadata: false,
         filter_metadata: false,
+        offline: false,
         retry_opts: no_retry_opts(),
     };
 
@@ -626,6 +691,7 @@ async fn warm_cache_serves_from_mirror_on_304() {
         cache_dir: Some(cache.path()),
         full_metadata: true,
         filter_metadata: false,
+        offline: false,
         retry_opts: no_retry_opts(),
     };
 
@@ -669,6 +735,7 @@ async fn a_304_renews_the_mirror_mtime() {
         cache_dir: Some(cache.path()),
         full_metadata: true,
         filter_metadata: false,
+        offline: false,
         retry_opts: no_retry_opts(),
     };
 
@@ -728,6 +795,7 @@ async fn stale_cache_refreshes_mirror_on_200() {
         cache_dir: Some(cache.path()),
         full_metadata: true,
         filter_metadata: false,
+        offline: false,
         retry_opts: no_retry_opts(),
     };
 
@@ -764,6 +832,7 @@ async fn no_cache_dir_skips_mirror_io() {
         cache_dir: None,
         full_metadata: true,
         filter_metadata: false,
+        offline: false,
         retry_opts: no_retry_opts(),
     };
 
@@ -800,6 +869,7 @@ async fn read_only_cache_dir_does_not_fail_the_call() {
         cache_dir: Some(cache.path()),
         full_metadata: true,
         filter_metadata: false,
+        offline: false,
         retry_opts: no_retry_opts(),
     };
 
@@ -835,6 +905,7 @@ async fn body_read_failure_retries_and_writes_mirror() {
         cache_dir: Some(cache.path()),
         full_metadata: true,
         filter_metadata: false,
+        offline: false,
         retry_opts: fast_retry_opts(),
     };
 

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package.rs
@@ -671,6 +671,7 @@ pub async fn pick_package<Cache: PackageMetaCache>(
         cache_dir: ctx.cache_dir,
         full_metadata,
         filter_metadata: use_filtered_full_metadata,
+        offline: ctx.offline,
         retry_opts: ctx.retry_opts,
     };
 

--- a/pnpm11/resolving/default-resolver/src/index.ts
+++ b/pnpm11/resolving/default-resolver/src/index.ts
@@ -178,7 +178,7 @@ export function createResolver (
 }
 
 export type ResolutionVerifierFactoryOptions =
-  & Pick<ResolverFactoryOptions, 'cacheDir' | 'registries' | 'namedRegistries' | 'retry' | 'timeout' | 'fetchWarnTimeoutMs'>
+  & Pick<ResolverFactoryOptions, 'cacheDir' | 'registries' | 'namedRegistries' | 'offline' | 'retry' | 'timeout' | 'fetchWarnTimeoutMs'>
   & Pick<CreateNpmResolutionVerifierOptions,
   | 'minimumReleaseAge'
   | 'minimumReleaseAgeStrict'
@@ -230,6 +230,7 @@ export function createResolutionVerifiers (
     fetchOpts,
     getAuthHeaderValueByURI,
     cacheDir: opts.cacheDir,
+    offline: opts.offline,
     metaCache: opts.metaCache,
     now: opts.now,
   })

--- a/pnpm11/resolving/npm-resolver/src/createNpmResolutionVerifier.ts
+++ b/pnpm11/resolving/npm-resolver/src/createNpmResolutionVerifier.ts
@@ -89,6 +89,11 @@ export interface CreateNpmResolutionVerifierOptions {
   getAuthHeaderValueByURI: GetAuthHeader
   cacheDir?: FetchFullMetadataCachedOptions['cacheDir']
   /**
+   * When true, verifier metadata lookups must use the local mirror
+   * only and never reach the registry or attestation endpoint.
+   */
+  offline?: boolean
+  /**
    * Per-install LRU shared with the npm resolver's `pickPackage`
    * (`{ get, set }` over `PackageMeta`). When provided, the verifier
    * consults it before fetching: a name the resolver already pulled
@@ -148,6 +153,7 @@ export function createNpmResolutionVerifier (
     fetchOpts: opts.fetchOpts,
     getAuthHeaderValueByURI: opts.getAuthHeaderValueByURI,
     cacheDir: opts.cacheDir,
+    offline: opts.offline === true,
     cutoffMs: cutoff,
     sharedMetaCache: opts.metaCache,
     abbreviatedMetaCache: new Map(),
@@ -522,6 +528,7 @@ function fetchFullMetaForTrust (
         registry,
         authHeaderValue: context.getAuthHeaderValueByURI(registry, { pkgName: name }),
         cacheDir: context.cacheDir,
+        offline: context.offline,
       }).then(projectTrustMeta)
     }
     context.fullMetaForTrustCache.set(cacheKey, cachedPromise)
@@ -588,6 +595,7 @@ interface PublishedAtLookupContext {
   fetchOpts: FetchMetadataFromFromRegistryOptions
   getAuthHeaderValueByURI: GetAuthHeader
   cacheDir?: string
+  offline: boolean
   /**
    * The `minimumReleaseAge` cutoff converted to a unix-ms epoch. A
    * version with a publish time strictly less than this passes the
@@ -697,11 +705,13 @@ async function resolvePublishedAt (
   const localTime = await readLocalMetaTime(context, registry, name)
   if (localTime?.[version]) return localTime[version]
 
-  const attestationTime = await fetchAttestationPublishedAt(context.fetchOpts, name, version, {
-    registry,
-    authHeaderValue: context.getAuthHeaderValueByURI(registry, { pkgName: name }),
-  })
-  if (attestationTime != null) return attestationTime
+  if (!context.offline) {
+    const attestationTime = await fetchAttestationPublishedAt(context.fetchOpts, name, version, {
+      registry,
+      authHeaderValue: context.getAuthHeaderValueByURI(registry, { pkgName: name }),
+    })
+    if (attestationTime != null) return attestationTime
+  }
 
   const fullMetaTime = await fetchFullMetaTime(context, registry, name)
   return fullMetaTime?.[version]
@@ -773,6 +783,7 @@ function fetchAbbreviatedMeta (
         registry,
         authHeaderValue: context.getAuthHeaderValueByURI(registry, { pkgName: name }),
         cacheDir: context.cacheDir,
+        offline: context.offline,
       }).then(
         (meta) => ({ meta: projectAbbreviatedMeta(meta) }),
         (error: unknown) => ({ error })
@@ -915,6 +926,7 @@ function fetchFullMetaTime (
       registry,
       authHeaderValue: context.getAuthHeaderValueByURI(registry, { pkgName: name }),
       cacheDir: context.cacheDir,
+      offline: context.offline,
     }).then((meta) => meta.time)
     context.fullMetaCache.set(cacheKey, cachedPromise)
   }

--- a/pnpm11/resolving/npm-resolver/src/fetchFullMetadataCached.ts
+++ b/pnpm11/resolving/npm-resolver/src/fetchFullMetadataCached.ts
@@ -1,4 +1,5 @@
 import { ABBREVIATED_META_DIR, FULL_META_DIR } from '@pnpm/constants'
+import { PnpmError } from '@pnpm/error'
 import type { PackageMeta } from '@pnpm/resolving.registry.types'
 
 import {
@@ -18,6 +19,10 @@ export interface FetchMetadataCachedOptions {
    * back. Omit to disable caching — every call re-fetches.
    */
   cacheDir?: string
+  /**
+   * Use only pnpm's on-disk metadata mirror and never reach the registry.
+   */
+  offline?: boolean
 }
 
 export type FetchFullMetadataCachedOptions = FetchMetadataCachedOptions
@@ -63,6 +68,14 @@ async function fetchMetadataCached (
   const pkgMirror = opts.cacheDir != null
     ? getPkgMirrorPath(opts.cacheDir, opts.metaDir, opts.registry, pkgName)
     : null
+
+  if (opts.offline === true) {
+    if (pkgMirror != null) {
+      const cached = await loadMeta(pkgMirror)
+      if (cached != null) return cached
+    }
+    throw new PnpmError('NO_OFFLINE_META', `Failed to resolve ${pkgName} in package mirror ${pkgMirror ?? ''}`)
+  }
 
   const cacheHeaders = pkgMirror != null ? await loadMetaHeaders(pkgMirror) : null
   const conditional = await fetchMetadataFromFromRegistry(fetchOpts, pkgName, {

--- a/pnpm11/resolving/npm-resolver/test/createNpmResolutionVerifier.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/createNpmResolutionVerifier.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, beforeEach, expect, test } from '@jest/globals'
 import { normalizeNamedRegistries } from '@pnpm/config.normalize-registries'
+import { ABBREVIATED_META_DIR } from '@pnpm/constants'
 import { createFetchFromRegistry } from '@pnpm/network.fetch'
 import { createNpmResolutionVerifier } from '@pnpm/resolving.npm-resolver'
 import type { Resolution } from '@pnpm/resolving.resolver-base'
 import type { Registries } from '@pnpm/types'
 import { temporaryDirectory } from 'tempy'
 
+import { getPkgMirrorPath, prepareJsonForDisk, saveMeta } from '../src/pickPackage.js'
 import { getMockAgent, setupMockAgent, teardownMockAgent } from './utils/index.js'
 
 const registries: Registries = {
@@ -74,6 +76,38 @@ test('createNpmResolutionVerifier() still verifies tarball URLs when no age/trus
     { name: 'aged-pkg', version: '1.0.0' }
   )
   expect(result).toMatchObject({ ok: false, code: 'TARBALL_URL_MISMATCH' })
+})
+
+test('createNpmResolutionVerifier() verifies tarball URLs from cached metadata in offline mode', async () => {
+  const cacheDir = temporaryDirectory()
+  const meta = {
+    name: 'offline-pkg',
+    'dist-tags': { latest: '1.0.0' },
+    versions: {
+      '1.0.0': {
+        name: 'offline-pkg',
+        version: '1.0.0',
+        dist: {
+          tarball: 'https://registry.npmjs.org/offline-pkg/-/offline-pkg-1.0.0.tgz',
+          shasum: 'aa',
+        },
+      },
+    },
+    modified: '2020-01-01T00:00:00.000Z',
+  }
+  await saveMeta(
+    getPkgMirrorPath(cacheDir, ABBREVIATED_META_DIR, registries.default, 'offline-pkg'),
+    prepareJsonForDisk(meta, '"cached"')
+  )
+
+  const verifier = createNpmResolutionVerifier(makeVerifierOpts({ cacheDir, offline: true }))
+  const result = await verifier.verify(
+    makeTarballResolution('offline-pkg', '1.0.0'),
+    { name: 'offline-pkg', version: '1.0.0' }
+  )
+
+  expect(result).toStrictEqual({ ok: true })
+  getMockAgent().assertNoPendingInterceptors()
 })
 
 test('createNpmResolutionVerifier() passes package name to auth header lookup', async () => {

--- a/pnpm11/resolving/npm-resolver/test/ifModifiedSince.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/ifModifiedSince.test.ts
@@ -62,6 +62,44 @@ beforeEach(async () => {
   await setupMockAgent()
 })
 
+test.each(cachedMetadataCases)('cached $kind metadata uses the mirror without registry access in offline mode', async ({ fetchMetadata, metaDir }) => {
+  const cacheDir = temporaryDirectory()
+  const pkgMirror = getPkgMirrorPath(cacheDir, metaDir, registries.default, 'is-positive')
+  await saveMeta(pkgMirror, prepareJsonForDisk(isPositiveMeta, '"cached"'))
+
+  const result = await fetchMetadata({
+    fetch,
+    retry: { retries: 0 },
+    timeout: 30_000,
+    fetchWarnTimeoutMs: 30_000,
+  }, 'is-positive', {
+    cacheDir,
+    registry: registries.default,
+    offline: true,
+  })
+
+  expect(result.name).toBe('is-positive')
+  getMockAgent().assertNoPendingInterceptors()
+})
+
+test('cached metadata reports NO_OFFLINE_META without registry access when offline cache is empty', async () => {
+  const cacheDir = temporaryDirectory()
+
+  await expect(fetchFullMetadataCached({
+    fetch,
+    retry: { retries: 0 },
+    timeout: 30_000,
+    fetchWarnTimeoutMs: 30_000,
+  }, 'is-positive', {
+    cacheDir,
+    registry: registries.default,
+    offline: true,
+  })).rejects.toMatchObject({
+    code: 'ERR_PNPM_NO_OFFLINE_META',
+  })
+  getMockAgent().assertNoPendingInterceptors()
+})
+
 test('use local cache when registry returns 304 Not Modified', async () => {
   const cacheDir = temporaryDirectory()
   // Write cached metadata with etag to disk in NDJSON format:


### PR DESCRIPTION
## Summary

- Thread `offline` into lockfile resolution verification in both the TypeScript and Rust resolver stacks.
- Make verifier metadata fetches use the local metadata mirror in offline mode, returning `ERR_PNPM_NO_OFFLINE_META` when required metadata is not cached.
- Skip the attestation fallback while offline so `--offline` does not reach the registry during verification.

Fixes pnpm/pnpm#11801.

## Validation

- `cargo test -p pacquet-resolving-npm-resolver --lib`
- `cargo test -p pacquet-package-manager build_resolution_verifiers --lib`
- `pn --filter @pnpm/resolving.npm-resolver run test`
- `pn --filter @pnpm/resolving.default-resolver run test`
- `pn run compile-only`
- `pn run lint --quiet`
- `bash pnpm/scripts/pre-push-rust.sh`

## Disclosure

This PR was prepared with AI assistance under human direction and review. Agent/model: OpenAI Codex (GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788581569&installation_model_id=426870&pr_number=13671&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13671&signature=45fe1eb63ded8aa8df88bd645246f877cee684a1068a4ba404d9d9fdda3f8f5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lockfile and tarball verification now support offline mode using cached registry metadata.
  * Offline resolution uses local package metadata and skips registry and attestation requests.
  * Cached full and abbreviated metadata can be used without network access.
* **Bug Fixes**
  * Added a clear `ERR_PNPM_NO_OFFLINE_META` error when required metadata is unavailable locally.
  * Improved cached metadata recovery, retries, and handling of incomplete cache data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->