### PR TITLE
fix(resolver): treat an empty version range as "*"

### DIFF
--- a/.changeset/empty-version-range-resolves.md
+++ b/.changeset/empty-version-range-resolves.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Dependencies declared with an empty version range (`"adler-32": ""`) install again instead of failing with `ERR_PNPM_NO_MATCHING_VERSION` [#13673](https://github.com/pnpm/pnpm/issues/13673). An omitted range means "any version", as it does in npm and pnpm v11, so packages that publish one — such as `js-xlsx`, `codepage`, and `ssf` — no longer need an `overrides` entry to install.

--- a/pnpm/crates/lockfile-preferred-versions/src/version_selector_type.rs
+++ b/pnpm/crates/lockfile-preferred-versions/src/version_selector_type.rs
@@ -11,11 +11,10 @@ use pacquet_resolving_resolver_base::{VersionSelectorType, is_any_version_range}
 /// then a dist-tag.
 #[must_use]
 pub fn get_version_selector_type(spec: &str) -> Option<VersionSelectorType> {
-    // `node-semver` (Rust) cannot parse the any-version spellings JS
-    // accepts (`""`, whitespace, `"^1 || "`), so they are classified up
-    // front. Otherwise a dependency published without a range drops out
-    // of the preferred-versions table entirely and silently loses its
-    // tie-break weight.
+    // Must precede both parses: neither reads an empty comparator set
+    // the way `version-selector-type` does, and `is_uri_component_safe`
+    // rejects the blank spellings, so a dependency published without a
+    // range would otherwise drop out of the tie-break table entirely.
     if is_any_version_range(spec) {
         return Some(VersionSelectorType::Range);
     }

--- a/pnpm/crates/lockfile-preferred-versions/src/version_selector_type.rs
+++ b/pnpm/crates/lockfile-preferred-versions/src/version_selector_type.rs
@@ -11,10 +11,6 @@ use pacquet_resolving_resolver_base::{VersionSelectorType, is_any_version_range}
 /// then a dist-tag.
 #[must_use]
 pub fn get_version_selector_type(spec: &str) -> Option<VersionSelectorType> {
-    // Must precede both parses: neither reads an empty comparator set
-    // the way `version-selector-type` does, and `is_uri_component_safe`
-    // rejects the blank spellings, so a dependency published without a
-    // range would otherwise drop out of the tie-break table entirely.
     if is_any_version_range(spec) {
         return Some(VersionSelectorType::Range);
     }

--- a/pnpm/crates/lockfile-preferred-versions/src/version_selector_type.rs
+++ b/pnpm/crates/lockfile-preferred-versions/src/version_selector_type.rs
@@ -4,13 +4,21 @@
 //! tie-break table the preferred-versions map feeds.
 
 use node_semver::{Range, Version};
-use pacquet_resolving_resolver_base::VersionSelectorType;
+use pacquet_resolving_resolver_base::{VersionSelectorType, is_any_version_range};
 
 /// Classify a manifest spec as `Version`, `Range`, or `Tag`, using the
 /// loose precedence that tries an exact version first, then a range,
 /// then a dist-tag.
 #[must_use]
 pub fn get_version_selector_type(spec: &str) -> Option<VersionSelectorType> {
+    // `node-semver` (Rust) cannot parse the any-version spellings JS
+    // accepts (`""`, whitespace, `"^1 || "`), so they are classified up
+    // front. Otherwise a dependency published without a range drops out
+    // of the preferred-versions table entirely and silently loses its
+    // tie-break weight.
+    if is_any_version_range(spec) {
+        return Some(VersionSelectorType::Range);
+    }
     if spec.parse::<Version>().is_ok() {
         return Some(VersionSelectorType::Version);
     }

--- a/pnpm/crates/lockfile-preferred-versions/src/version_selector_type/tests.rs
+++ b/pnpm/crates/lockfile-preferred-versions/src/version_selector_type/tests.rs
@@ -25,9 +25,6 @@ fn classifies_url_safe_string_as_tag() {
 
 #[test]
 fn classifies_any_version_range_as_range() {
-    // `version-selector-type` reads an empty comparator set as `*`, so a
-    // dependency published without a range still carries tie-break
-    // weight.
     for spec in ["", " ", "||", "^1.0.0 || ", "latest || "] {
         assert_eq!(
             get_version_selector_type(spec),

--- a/pnpm/crates/lockfile-preferred-versions/src/version_selector_type/tests.rs
+++ b/pnpm/crates/lockfile-preferred-versions/src/version_selector_type/tests.rs
@@ -24,10 +24,20 @@ fn classifies_url_safe_string_as_tag() {
 }
 
 #[test]
+fn classifies_any_version_range_as_range() {
+    // JS `semver.validRange` normalizes every empty comparator set to
+    // `*`, so a dependency published without a range still carries
+    // tie-break weight.
+    assert_eq!(get_version_selector_type(""), Some(VersionSelectorType::Range));
+    assert_eq!(get_version_selector_type(" "), Some(VersionSelectorType::Range));
+    assert_eq!(get_version_selector_type("||"), Some(VersionSelectorType::Range));
+    assert_eq!(get_version_selector_type("^1.0.0 || "), Some(VersionSelectorType::Range));
+}
+
+#[test]
 fn rejects_unknown_specs() {
     assert_eq!(get_version_selector_type("git+ssh://example.com/repo.git"), None);
     assert_eq!(get_version_selector_type("file:./local-path"), None);
     assert_eq!(get_version_selector_type("workspace:*"), None);
     assert_eq!(get_version_selector_type("npm:other@^1"), None);
-    assert_eq!(get_version_selector_type(""), None);
 }

--- a/pnpm/crates/lockfile-preferred-versions/src/version_selector_type/tests.rs
+++ b/pnpm/crates/lockfile-preferred-versions/src/version_selector_type/tests.rs
@@ -25,13 +25,16 @@ fn classifies_url_safe_string_as_tag() {
 
 #[test]
 fn classifies_any_version_range_as_range() {
-    // JS `semver.validRange` normalizes every empty comparator set to
-    // `*`, so a dependency published without a range still carries
-    // tie-break weight.
-    assert_eq!(get_version_selector_type(""), Some(VersionSelectorType::Range));
-    assert_eq!(get_version_selector_type(" "), Some(VersionSelectorType::Range));
-    assert_eq!(get_version_selector_type("||"), Some(VersionSelectorType::Range));
-    assert_eq!(get_version_selector_type("^1.0.0 || "), Some(VersionSelectorType::Range));
+    // `version-selector-type` reads an empty comparator set as `*`, so a
+    // dependency published without a range still carries tie-break
+    // weight.
+    for spec in ["", " ", "||", "^1.0.0 || ", "latest || "] {
+        assert_eq!(
+            get_version_selector_type(spec),
+            Some(VersionSelectorType::Range),
+            "for {spec:?}",
+        );
+    }
 }
 
 #[test]

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -209,6 +209,28 @@ async fn range_specifier_picks_max_in_range() {
 }
 
 #[tokio::test]
+async fn empty_specifier_resolves_to_the_max_published_version() {
+    // Regression test for pnpm/pnpm#13673: an omitted range is "any
+    // version" in JS semver, so packages published that way (`js-xlsx`
+    // declares `"adler-32": ""`) must resolve instead of being treated
+    // as a request for a dist-tag named "".
+    let mut server = mockito::Server::new_async().await;
+    let _mock =
+        server.mock("GET", "/acme").with_status(200).with_body(PACKAGE_BODY).create_async().await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some(String::new()),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, &ResolveOptions::default()).await.unwrap().unwrap();
+    assert_eq!(result.id.as_str(), "acme@1.1.0");
+    assert_eq!(result.resolved_via, "npm-registry");
+}
+
+#[tokio::test]
 async fn package_version_guard_excludes_rejected_versions_and_repicks() {
     let mut server = mockito::Server::new_async().await;
     let _mock =

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -210,9 +210,8 @@ async fn range_specifier_picks_max_in_range() {
 
 #[tokio::test]
 async fn empty_specifier_resolves_to_the_max_published_version() {
-    // Regression test for pnpm/pnpm#13673: registries carry manifests
-    // that declare a dependency as `""`, and pnpm through v11 resolved
-    // those as "any version".
+    // Regression test for pnpm/pnpm#13673: an omitted range means "any
+    // version", and registries carry manifests that rely on it.
     let mut server = mockito::Server::new_async().await;
     let _mock =
         server.mock("GET", "/acme").with_status(200).with_body(PACKAGE_BODY).create_async().await;

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -210,8 +210,7 @@ async fn range_specifier_picks_max_in_range() {
 
 #[tokio::test]
 async fn empty_specifier_resolves_to_the_max_published_version() {
-    // Regression test for pnpm/pnpm#13673: an omitted range means "any
-    // version", and registries carry manifests that rely on it.
+    // Regression test for pnpm/pnpm#13673.
     let mut server = mockito::Server::new_async().await;
     let _mock =
         server.mock("GET", "/acme").with_status(200).with_body(PACKAGE_BODY).create_async().await;

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -210,10 +210,9 @@ async fn range_specifier_picks_max_in_range() {
 
 #[tokio::test]
 async fn empty_specifier_resolves_to_the_max_published_version() {
-    // Regression test for pnpm/pnpm#13673: an omitted range is "any
-    // version" in JS semver, so packages published that way (`js-xlsx`
-    // declares `"adler-32": ""`) must resolve instead of being treated
-    // as a request for a dist-tag named "".
+    // Regression test for pnpm/pnpm#13673: registries carry manifests
+    // that declare a dependency as `""`, and pnpm through v11 resolved
+    // those as "any version".
     let mut server = mockito::Server::new_async().await;
     let _mock =
         server.mock("GET", "/acme").with_status(200).with_body(PACKAGE_BODY).create_async().await;

--- a/pnpm/crates/resolving-npm-resolver/src/parse_bare_specifier.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/parse_bare_specifier.rs
@@ -274,14 +274,10 @@ pub fn parse_named_registry_specifier_to_registry_package_spec(
 
 /// Discriminate between an exact version, a semver range, and a
 /// dist-tag, returning the normalized form alongside the discriminator:
-/// version first, range second, dist-tag last. Returns `None` only when
-/// the selector contains characters that `encodeURIComponent` would
-/// escape (i.e. not a valid npm tag).
+/// version first, range second, tag last. Returns `None` only when the
+/// selector contains characters that `encodeURIComponent` would escape
+/// (i.e. not a valid npm tag).
 pub(crate) fn get_version_selector_type(selector: &str) -> Option<VersionSelectorMatch> {
-    // Must precede both parses: `Range::parse` reads `"^1.0.0 || "` as
-    // the narrower `^1.0.0`, and a blank selector would otherwise reach
-    // the dist-tag branch. No exact version is blank or contains `||`,
-    // so the `Version` branch loses nothing by going second.
     if is_any_version_range(selector) {
         return Some(VersionSelectorMatch {
             spec_type: RegistryPackageSpecType::Range,
@@ -314,9 +310,6 @@ pub(crate) fn get_version_selector_type(selector: &str) -> Option<VersionSelecto
 /// set is `A-Z a-z 0-9 - _ . ! ~ * ' ( )` — anything else (including
 /// `/`, `:`, spaces) bumps the candidate out of the tag bucket so
 /// protocol-prefixed specifiers fall through to the next resolver.
-///
-/// An empty selector satisfies the character check vacuously, so callers
-/// must classify any-version ranges before reaching this.
 fn is_valid_dist_tag(selector: &str) -> bool {
     selector.bytes().all(|byte| {
         matches!(byte,

--- a/pnpm/crates/resolving-npm-resolver/src/parse_bare_specifier.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/parse_bare_specifier.rs
@@ -18,6 +18,9 @@ use miette::Diagnostic;
 use node_semver::{Range, Version};
 use pacquet_resolving_jsr_specifier_parser::{ParseJsrSpecifierError, parse_jsr_specifier};
 use pacquet_resolving_parse_wanted_dependency::is_valid_old_npm_package_name;
+use pacquet_resolving_resolver_base::{
+    ANY_VERSION_RANGE, is_any_version_range, is_valid_semver_range,
+};
 use reqwest::Url;
 
 use crate::pick_package_from_meta::{RegistryPackageSpec, RegistryPackageSpecType};
@@ -49,7 +52,7 @@ pub fn parse_bare_specifier(
         let alias_str = alias;
         if let Some(a) = alias_str
             && !a.is_empty()
-            && Range::parse(&bare).is_ok()
+            && is_valid_semver_range(&bare)
         {
             name = Some(a.to_string());
         } else {
@@ -207,7 +210,7 @@ pub fn parse_named_registry_specifier_to_registry_package_spec(
     let pkg_name: String;
     let version_selector: Option<String>;
 
-    if Range::parse(body).is_ok() {
+    if is_valid_semver_range(body) {
         let Some(alias) = package_alias.filter(|alias| !alias.is_empty()) else {
             return Ok(None);
         };
@@ -271,10 +274,23 @@ pub fn parse_named_registry_specifier_to_registry_package_spec(
 
 /// Discriminate between an exact version, a semver range, and a
 /// dist-tag, returning the normalized form alongside the discriminator:
-/// version first, range second, tag last. Returns `None` only when the
-/// selector contains characters that `encodeURIComponent` would escape
-/// (i.e. not a valid npm tag).
+/// version first, range second, dist-tag last. Returns `None` only when
+/// the selector contains characters that `encodeURIComponent` would
+/// escape (i.e. not a valid npm tag).
 pub(crate) fn get_version_selector_type(selector: &str) -> Option<VersionSelectorMatch> {
+    // Ahead of both parses because `node-semver` (Rust) rejects every
+    // any-version spelling JS accepts. Without this, an omitted range
+    // (`"adler-32": ""`, as published by `js-xlsx` and friends) falls
+    // through to the dist-tag branch — which matches the empty string
+    // vacuously — and the picker then asks the registry for a tag that
+    // cannot exist. No exact version is blank or contains `||`, so
+    // running first costs the `Version` branch nothing.
+    if is_any_version_range(selector) {
+        return Some(VersionSelectorMatch {
+            spec_type: RegistryPackageSpecType::Range,
+            normalized: ANY_VERSION_RANGE.to_string(),
+        });
+    }
     if let Ok(version) = Version::parse(selector) {
         return Some(VersionSelectorMatch {
             spec_type: RegistryPackageSpecType::Version,
@@ -301,6 +317,9 @@ pub(crate) fn get_version_selector_type(selector: &str) -> Option<VersionSelecto
 /// set is `A-Z a-z 0-9 - _ . ! ~ * ' ( )` — anything else (including
 /// `/`, `:`, spaces) bumps the candidate out of the tag bucket so
 /// protocol-prefixed specifiers fall through to the next resolver.
+///
+/// An empty selector satisfies the character check vacuously, so callers
+/// must classify any-version ranges before reaching this.
 fn is_valid_dist_tag(selector: &str) -> bool {
     selector.bytes().all(|byte| {
         matches!(byte,

--- a/pnpm/crates/resolving-npm-resolver/src/parse_bare_specifier.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/parse_bare_specifier.rs
@@ -278,13 +278,10 @@ pub fn parse_named_registry_specifier_to_registry_package_spec(
 /// the selector contains characters that `encodeURIComponent` would
 /// escape (i.e. not a valid npm tag).
 pub(crate) fn get_version_selector_type(selector: &str) -> Option<VersionSelectorMatch> {
-    // Ahead of both parses because `node-semver` (Rust) rejects every
-    // any-version spelling JS accepts. Without this, an omitted range
-    // (`"adler-32": ""`, as published by `js-xlsx` and friends) falls
-    // through to the dist-tag branch — which matches the empty string
-    // vacuously — and the picker then asks the registry for a tag that
-    // cannot exist. No exact version is blank or contains `||`, so
-    // running first costs the `Version` branch nothing.
+    // Must precede both parses: `Range::parse` reads `"^1.0.0 || "` as
+    // the narrower `^1.0.0`, and a blank selector would otherwise reach
+    // the dist-tag branch. No exact version is blank or contains `||`,
+    // so the `Version` branch loses nothing by going second.
     if is_any_version_range(selector) {
         return Some(VersionSelectorMatch {
             spec_type: RegistryPackageSpecType::Range,

--- a/pnpm/crates/resolving-npm-resolver/src/parse_bare_specifier/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/parse_bare_specifier/tests.rs
@@ -44,6 +44,43 @@ fn no_alias_no_npm_prefix_declines() {
 }
 
 #[test]
+fn empty_selector_classified_as_any_version_range() {
+    // Registries carry manifests published against JS semver, where an
+    // omitted range means "any version" — `js-xlsx@0.8.22` declares
+    // `"adler-32": ""`. Classifying it as a dist-tag instead sends the
+    // picker looking for a tag that cannot exist.
+    let spec = parse_bare_specifier("", Some("adler-32"), DEFAULT_TAG, REGISTRY).unwrap();
+    assert_eq!(spec.name, "adler-32");
+    assert_eq!(spec.fetch_spec, "*");
+    assert_eq!(spec.spec_type, RegistryPackageSpecType::Range);
+}
+
+#[test]
+fn blank_selector_classified_as_any_version_range() {
+    let spec = parse_bare_specifier("   ", Some("foo"), DEFAULT_TAG, REGISTRY).unwrap();
+    assert_eq!(spec.fetch_spec, "*");
+    assert_eq!(spec.spec_type, RegistryPackageSpecType::Range);
+}
+
+#[test]
+fn union_with_empty_member_classified_as_any_version_range() {
+    // An empty comparator set imposes no bound, so it widens the whole
+    // union — `Range::parse` would otherwise silently drop it and
+    // resolve as if only `^1.0.0` had been declared.
+    let spec = parse_bare_specifier("^1.0.0 || ", Some("foo"), DEFAULT_TAG, REGISTRY).unwrap();
+    assert_eq!(spec.fetch_spec, "*");
+    assert_eq!(spec.spec_type, RegistryPackageSpecType::Range);
+}
+
+#[test]
+fn npm_alias_with_empty_selector_uses_outer_alias_as_name() {
+    let spec = parse_bare_specifier("npm:", Some("is-positive"), DEFAULT_TAG, REGISTRY).unwrap();
+    assert_eq!(spec.name, "is-positive");
+    assert_eq!(spec.fetch_spec, "*");
+    assert_eq!(spec.spec_type, RegistryPackageSpecType::Range);
+}
+
+#[test]
 fn npm_alias_with_range_uses_outer_alias_as_name() {
     let spec =
         parse_bare_specifier("npm:^1.0.0", Some("is-positive"), DEFAULT_TAG, REGISTRY).unwrap();

--- a/pnpm/crates/resolving-npm-resolver/src/parse_bare_specifier/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/parse_bare_specifier/tests.rs
@@ -45,8 +45,7 @@ fn no_alias_no_npm_prefix_declines() {
 
 #[test]
 fn empty_selector_classified_as_any_version_range() {
-    // `js-xlsx@0.8.22` really does declare `"adler-32": ""`
-    // (pnpm/pnpm#13673).
+    // pnpm/pnpm#13673: `js-xlsx@0.8.22` declares `"adler-32": ""`.
     let spec = parse_bare_specifier("", Some("adler-32"), DEFAULT_TAG, REGISTRY).unwrap();
     assert_eq!(spec.name, "adler-32");
     assert_eq!(spec.fetch_spec, "*");
@@ -62,8 +61,6 @@ fn blank_selector_classified_as_any_version_range() {
 
 #[test]
 fn union_with_empty_member_classified_as_any_version_range() {
-    // `Range::parse` would otherwise drop the empty half and resolve as
-    // if only `^1.0.0` had been declared.
     let spec = parse_bare_specifier("^1.0.0 || ", Some("foo"), DEFAULT_TAG, REGISTRY).unwrap();
     assert_eq!(spec.fetch_spec, "*");
     assert_eq!(spec.spec_type, RegistryPackageSpecType::Range);
@@ -71,8 +68,6 @@ fn union_with_empty_member_classified_as_any_version_range() {
 
 #[test]
 fn union_with_unparsable_member_still_classifies_as_any_version_range() {
-    // `version-selector-type` runs `validRange` loose, which drops the
-    // sets it cannot parse and leaves the empty one matching everything.
     for selector in ["latest || ", "|| latest", "garbage ||"] {
         let spec = parse_bare_specifier(selector, Some("foo"), DEFAULT_TAG, REGISTRY)
             .unwrap_or_else(|| panic!("expected a spec for {selector:?}"));
@@ -83,9 +78,6 @@ fn union_with_unparsable_member_still_classifies_as_any_version_range() {
 
 #[test]
 fn npm_alias_keeps_its_inner_name_when_the_union_does_not_parse_strictly() {
-    // The `npm:` disambiguation runs `validRange` strict, so
-    // `bar@^5 || ` is a name-plus-selector, not a bare range — reading
-    // it loosely would drop the `bar` alias and keep the outer `foo`.
     let spec = parse_bare_specifier("npm:bar@^5 || ", Some("foo"), DEFAULT_TAG, REGISTRY).unwrap();
     assert_eq!(spec.name, "bar");
     assert_eq!(spec.fetch_spec, "*");
@@ -373,9 +365,6 @@ fn named_registry_with_any_version_body_uses_the_alias_as_name() {
 
 #[test]
 fn named_registry_reads_a_strictly_invalid_union_as_a_package_name() {
-    // The body disambiguation runs `validRange` strict, so `latest || `
-    // is not a version selector — with an unscoped alias the body is
-    // read as the package name, which is then rejected as malformed.
     let gh = gh_aliases();
     for input in ["gh:latest || ", "gh:garbage ||"] {
         let err = parse_named_registry_specifier_to_registry_package_spec(

--- a/pnpm/crates/resolving-npm-resolver/src/parse_bare_specifier/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/parse_bare_specifier/tests.rs
@@ -45,10 +45,8 @@ fn no_alias_no_npm_prefix_declines() {
 
 #[test]
 fn empty_selector_classified_as_any_version_range() {
-    // Registries carry manifests published against JS semver, where an
-    // omitted range means "any version" — `js-xlsx@0.8.22` declares
-    // `"adler-32": ""`. Classifying it as a dist-tag instead sends the
-    // picker looking for a tag that cannot exist.
+    // `js-xlsx@0.8.22` really does declare `"adler-32": ""`
+    // (pnpm/pnpm#13673).
     let spec = parse_bare_specifier("", Some("adler-32"), DEFAULT_TAG, REGISTRY).unwrap();
     assert_eq!(spec.name, "adler-32");
     assert_eq!(spec.fetch_spec, "*");
@@ -64,10 +62,32 @@ fn blank_selector_classified_as_any_version_range() {
 
 #[test]
 fn union_with_empty_member_classified_as_any_version_range() {
-    // An empty comparator set imposes no bound, so it widens the whole
-    // union — `Range::parse` would otherwise silently drop it and
-    // resolve as if only `^1.0.0` had been declared.
+    // `Range::parse` would otherwise drop the empty half and resolve as
+    // if only `^1.0.0` had been declared.
     let spec = parse_bare_specifier("^1.0.0 || ", Some("foo"), DEFAULT_TAG, REGISTRY).unwrap();
+    assert_eq!(spec.fetch_spec, "*");
+    assert_eq!(spec.spec_type, RegistryPackageSpecType::Range);
+}
+
+#[test]
+fn union_with_unparsable_member_still_classifies_as_any_version_range() {
+    // `version-selector-type` runs `validRange` loose, which drops the
+    // sets it cannot parse and leaves the empty one matching everything.
+    for selector in ["latest || ", "|| latest", "garbage ||"] {
+        let spec = parse_bare_specifier(selector, Some("foo"), DEFAULT_TAG, REGISTRY)
+            .unwrap_or_else(|| panic!("expected a spec for {selector:?}"));
+        assert_eq!(spec.fetch_spec, "*", "for {selector:?}");
+        assert_eq!(spec.spec_type, RegistryPackageSpecType::Range, "for {selector:?}");
+    }
+}
+
+#[test]
+fn npm_alias_keeps_its_inner_name_when_the_union_does_not_parse_strictly() {
+    // The `npm:` disambiguation runs `validRange` strict, so
+    // `bar@^5 || ` is a name-plus-selector, not a bare range — reading
+    // it loosely would drop the `bar` alias and keep the outer `foo`.
+    let spec = parse_bare_specifier("npm:bar@^5 || ", Some("foo"), DEFAULT_TAG, REGISTRY).unwrap();
+    assert_eq!(spec.name, "bar");
     assert_eq!(spec.fetch_spec, "*");
     assert_eq!(spec.spec_type, RegistryPackageSpecType::Range);
 }
@@ -329,6 +349,47 @@ fn named_registry_with_scoped_alias_parses_version_selectors() {
     assert_eq!(spec.spec.name, "@acme/foo");
     assert_eq!(spec.spec.fetch_spec, "latest");
     assert_eq!(spec.spec.spec_type, RegistryPackageSpecType::Tag);
+}
+
+#[test]
+fn named_registry_with_any_version_body_uses_the_alias_as_name() {
+    let gh = gh_aliases();
+    for body in ["", "   ", "^1.0.0 || "] {
+        let input = format!("gh:{body}");
+        let spec = parse_named_registry_specifier_to_registry_package_spec(
+            &input,
+            &gh,
+            Some("@acme/foo"),
+            "latest",
+        )
+        .unwrap()
+        .unwrap_or_else(|| panic!("expected a spec for {input:?}"));
+        assert_eq!(spec.spec.name, "@acme/foo", "for {input:?}");
+        assert_eq!(spec.spec.fetch_spec, "*", "for {input:?}");
+        assert_eq!(spec.spec.spec_type, RegistryPackageSpecType::Range, "for {input:?}");
+        assert_eq!(spec.registry_name, "gh", "for {input:?}");
+    }
+}
+
+#[test]
+fn named_registry_reads_a_strictly_invalid_union_as_a_package_name() {
+    // The body disambiguation runs `validRange` strict, so `latest || `
+    // is not a version selector — with an unscoped alias the body is
+    // read as the package name, which is then rejected as malformed.
+    let gh = gh_aliases();
+    for input in ["gh:latest || ", "gh:garbage ||"] {
+        let err = parse_named_registry_specifier_to_registry_package_spec(
+            input,
+            &gh,
+            Some("foo"),
+            "latest",
+        )
+        .expect_err("a strictly invalid union is a malformed package name");
+        assert!(
+            matches!(err, ParseNamedRegistrySpecifierError::InvalidPackageName { .. }),
+            "got {err:?} for {input:?}",
+        );
+    }
 }
 
 #[test]

--- a/pnpm/crates/resolving-resolver-base/src/lib.rs
+++ b/pnpm/crates/resolving-resolver-base/src/lib.rs
@@ -21,6 +21,7 @@ mod errors;
 mod peer_range;
 mod publish_time;
 mod resolve;
+mod semver_range;
 mod verifier;
 
 pub use errors::{NoMatchingVersionError, RegistryResponseError, RegistryResponseErrorOptions};
@@ -35,6 +36,7 @@ pub use resolve::{
     VersionSelectorType, VersionSelectorWithWeight, VersionSelectors, WantedDependency,
     WorkspacePackage, WorkspacePackages, WorkspacePackagesByVersion,
 };
+pub use semver_range::{ANY_VERSION_RANGE, is_any_version_range, is_valid_semver_range};
 pub use verifier::{
     ResolutionPolicyViolation, ResolutionVerification, ResolutionVerifier, VerifyCtx, VerifyFuture,
 };

--- a/pnpm/crates/resolving-resolver-base/src/semver_range.rs
+++ b/pnpm/crates/resolving-resolver-base/src/semver_range.rs
@@ -1,41 +1,59 @@
 //! Compatibility shims that make `node-semver` (Rust) range checks agree
-//! with JavaScript's `semver.validRange`, which every pnpm version up to
-//! v11 resolved manifests with.
+//! with JavaScript's `semver.validRange`, which the TypeScript pnpm CLI
+//! resolves manifests with.
 //!
-//! The dialects diverge on the *empty comparator set*. JS treats it as
-//! "any version", so `""`, whitespace, `"||"`, and `"^1.0.0 || "` all
+//! The dialects diverge on the *empty comparator set*. A range is a union
+//! of comparator sets separated by `||`, and JS reads an empty set as
+//! "any version" — so `""`, whitespace, `"||"`, and `"^1.0.0 || "` all
 //! normalize to `"*"`. The Rust parser rejects the first three outright
 //! and silently drops the empty half of the last one. Registries are full
 //! of published manifests that rely on the JS reading (`js-xlsx`,
 //! `codepage`, and `ssf` all declare dependencies as `""`), so range
 //! checks on manifest input must go through here rather than calling
 //! [`Range::parse`] directly.
+//!
+//! JS has two readings of a union whose *non-empty* members do not parse,
+//! and pnpm uses both: loose mode drops the members it cannot parse,
+//! while strict mode rejects the whole range. The TypeScript CLI reaches
+//! loose mode through `version-selector-type` (whose default export
+//! passes `loose: true`) and strict mode through its own bare
+//! `semver.validRange(..)` calls, so the two are not interchangeable —
+//! see each function for which call sites it belongs to.
 
 use node_semver::Range;
 
 /// The range every any-version spelling normalizes to.
 pub const ANY_VERSION_RANGE: &str = "*";
 
-/// Whether `range` is one of the spellings JS `semver.validRange`
-/// normalizes to `"*"`.
+/// Whether `range` resolves to the unbounded range, matching JS
+/// `semver.validRange(range, /* loose */ true) === "*"`.
 ///
-/// A range is a union of comparator sets separated by `||`, and an empty
-/// comparator set imposes no bound — so a single empty member makes the
-/// whole union unbounded, however many other members it has.
+/// An empty comparator set imposes no bound and loose mode discards the
+/// sets it cannot parse, so a single empty member makes the whole union
+/// unbounded however its siblings are spelled.
+///
+/// This is the reading a version-selector classifier wants, because that
+/// is the mode `version-selector-type` runs in.
 #[must_use]
 pub fn is_any_version_range(range: &str) -> bool {
     range.split("||").any(|comparator_set| comparator_set.trim().is_empty())
 }
 
-/// The Rust equivalent of JS `semver.validRange(range) != null`.
+/// The Rust equivalent of JS `semver.validRange(range) != null` — the
+/// strict reading, under which one unparsable comparator set invalidates
+/// the whole union rather than being dropped from it.
 ///
-/// Use this instead of `Range::parse(range).is_ok()` whenever the input
-/// comes from a package manifest or a user-written specifier, so an
-/// omitted range is read as "any version" instead of falling through to
-/// the dist-tag branch of a specifier classifier.
+/// Use this instead of `Range::parse(range).is_ok()` wherever the
+/// TypeScript CLI calls `semver.validRange` without `loose`: the
+/// specifier-shape disambiguations that decide whether a body is a
+/// version range or a package name. Reading those loosely would hand
+/// `npm:bar@^5 || ` to the range branch and lose the `bar` alias.
 #[must_use]
 pub fn is_valid_semver_range(range: &str) -> bool {
-    is_any_version_range(range) || Range::parse(range).is_ok()
+    range
+        .split("||")
+        .map(str::trim)
+        .all(|comparator_set| comparator_set.is_empty() || Range::parse(comparator_set).is_ok())
 }
 
 #[cfg(test)]

--- a/pnpm/crates/resolving-resolver-base/src/semver_range.rs
+++ b/pnpm/crates/resolving-resolver-base/src/semver_range.rs
@@ -2,23 +2,17 @@
 //! with JavaScript's `semver.validRange`, which the TypeScript pnpm CLI
 //! resolves manifests with.
 //!
-//! The dialects diverge on the *empty comparator set*. A range is a union
+//! The dialects diverge on the *empty comparator set*: a range is a union
 //! of comparator sets separated by `||`, and JS reads an empty set as
-//! "any version" — so `""`, whitespace, `"||"`, and `"^1.0.0 || "` all
-//! normalize to `"*"`. The Rust parser rejects the first three outright
-//! and silently drops the empty half of the last one. Registries are full
-//! of published manifests that rely on the JS reading (`js-xlsx`,
-//! `codepage`, and `ssf` all declare dependencies as `""`), so range
+//! "any version" where the Rust parser rejects it. Registries are full of
+//! published manifests that rely on the JS reading — `js-xlsx`,
+//! `codepage`, and `ssf` all declare dependencies as `""` — so range
 //! checks on manifest input must go through here rather than calling
 //! [`Range::parse`] directly.
 //!
-//! JS has two readings of a union whose *non-empty* members do not parse,
-//! and pnpm uses both: loose mode drops the members it cannot parse,
-//! while strict mode rejects the whole range. The TypeScript CLI reaches
-//! loose mode through `version-selector-type` (whose default export
-//! passes `loose: true`) and strict mode through its own bare
-//! `semver.validRange(..)` calls, so the two are not interchangeable —
-//! see each function for which call sites it belongs to.
+//! JS has a loose and a strict reading of a union whose non-empty members
+//! do not parse, and pnpm uses both. The two functions below model one
+//! each and are not interchangeable.
 
 use node_semver::Range;
 
@@ -28,12 +22,10 @@ pub const ANY_VERSION_RANGE: &str = "*";
 /// Whether `range` resolves to the unbounded range, matching JS
 /// `semver.validRange(range, /* loose */ true) === "*"`.
 ///
-/// An empty comparator set imposes no bound and loose mode discards the
-/// sets it cannot parse, so a single empty member makes the whole union
-/// unbounded however its siblings are spelled.
-///
-/// This is the reading a version-selector classifier wants, because that
-/// is the mode `version-selector-type` runs in.
+/// Loose mode discards the comparator sets it cannot parse, so a single
+/// empty member makes the whole union unbounded however its siblings are
+/// spelled. This is the mode `version-selector-type` runs in, and so the
+/// reading a version-selector classifier wants.
 #[must_use]
 pub fn is_any_version_range(range: &str) -> bool {
     range.split("||").any(|comparator_set| comparator_set.trim().is_empty())
@@ -43,11 +35,9 @@ pub fn is_any_version_range(range: &str) -> bool {
 /// strict reading, under which one unparsable comparator set invalidates
 /// the whole union rather than being dropped from it.
 ///
-/// Use this instead of `Range::parse(range).is_ok()` wherever the
-/// TypeScript CLI calls `semver.validRange` without `loose`: the
-/// specifier-shape disambiguations that decide whether a body is a
-/// version range or a package name. Reading those loosely would hand
-/// `npm:bar@^5 || ` to the range branch and lose the `bar` alias.
+/// Belongs wherever the TypeScript CLI calls `semver.validRange` without
+/// `loose`: the specifier-shape disambiguations that decide whether a
+/// body is a version range or a package name.
 #[must_use]
 pub fn is_valid_semver_range(range: &str) -> bool {
     range

--- a/pnpm/crates/resolving-resolver-base/src/semver_range.rs
+++ b/pnpm/crates/resolving-resolver-base/src/semver_range.rs
@@ -1,0 +1,42 @@
+//! Compatibility shims that make `node-semver` (Rust) range checks agree
+//! with JavaScript's `semver.validRange`, which every pnpm version up to
+//! v11 resolved manifests with.
+//!
+//! The dialects diverge on the *empty comparator set*. JS treats it as
+//! "any version", so `""`, whitespace, `"||"`, and `"^1.0.0 || "` all
+//! normalize to `"*"`. The Rust parser rejects the first three outright
+//! and silently drops the empty half of the last one. Registries are full
+//! of published manifests that rely on the JS reading (`js-xlsx`,
+//! `codepage`, and `ssf` all declare dependencies as `""`), so range
+//! checks on manifest input must go through here rather than calling
+//! [`Range::parse`] directly.
+
+use node_semver::Range;
+
+/// The range every any-version spelling normalizes to.
+pub const ANY_VERSION_RANGE: &str = "*";
+
+/// Whether `range` is one of the spellings JS `semver.validRange`
+/// normalizes to `"*"`.
+///
+/// A range is a union of comparator sets separated by `||`, and an empty
+/// comparator set imposes no bound — so a single empty member makes the
+/// whole union unbounded, however many other members it has.
+#[must_use]
+pub fn is_any_version_range(range: &str) -> bool {
+    range.split("||").any(|comparator_set| comparator_set.trim().is_empty())
+}
+
+/// The Rust equivalent of JS `semver.validRange(range) != null`.
+///
+/// Use this instead of `Range::parse(range).is_ok()` whenever the input
+/// comes from a package manifest or a user-written specifier, so an
+/// omitted range is read as "any version" instead of falling through to
+/// the dist-tag branch of a specifier classifier.
+#[must_use]
+pub fn is_valid_semver_range(range: &str) -> bool {
+    is_any_version_range(range) || Range::parse(range).is_ok()
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/resolving-resolver-base/src/semver_range/tests.rs
+++ b/pnpm/crates/resolving-resolver-base/src/semver_range/tests.rs
@@ -1,0 +1,44 @@
+use super::{is_any_version_range, is_valid_semver_range};
+
+#[test]
+fn empty_and_blank_ranges_are_any_version() {
+    assert!(is_any_version_range(""));
+    assert!(is_any_version_range(" "));
+    assert!(is_any_version_range("   "));
+    assert!(is_any_version_range("\t"));
+}
+
+#[test]
+fn a_union_with_an_empty_member_is_any_version() {
+    assert!(is_any_version_range("||"));
+    assert!(is_any_version_range("^1.0.0 || "));
+    assert!(is_any_version_range("|| ^1.0.0"));
+    assert!(is_any_version_range("^1.0.0||"));
+}
+
+#[test]
+fn bounded_ranges_are_not_any_version() {
+    assert!(!is_any_version_range("^1.0.0"));
+    assert!(!is_any_version_range("1.0.0"));
+    assert!(!is_any_version_range(">=1.0.0 <2.0.0"));
+    assert!(!is_any_version_range("^1.0.0 || ^2.0.0"));
+    assert!(!is_any_version_range("latest"));
+}
+
+#[test]
+fn any_version_spellings_are_valid_ranges() {
+    assert!(is_valid_semver_range(""));
+    assert!(is_valid_semver_range(" "));
+    assert!(is_valid_semver_range("||"));
+    assert!(is_valid_semver_range("^1.0.0 || "));
+}
+
+#[test]
+fn ordinary_ranges_stay_valid_and_tags_stay_invalid() {
+    assert!(is_valid_semver_range("*"));
+    assert!(is_valid_semver_range("^1.0.0"));
+    assert!(is_valid_semver_range("1.x"));
+    assert!(is_valid_semver_range(">=1.0.0 <2.0.0"));
+    assert!(!is_valid_semver_range("latest"));
+    assert!(!is_valid_semver_range("npm:bar@^5"));
+}

--- a/pnpm/crates/resolving-resolver-base/src/semver_range/tests.rs
+++ b/pnpm/crates/resolving-resolver-base/src/semver_range/tests.rs
@@ -17,6 +17,15 @@ fn a_union_with_an_empty_member_is_any_version() {
 }
 
 #[test]
+fn an_empty_member_widens_a_union_whose_siblings_do_not_parse() {
+    // Loose mode drops the unparsable sets, leaving the empty one to
+    // match everything: `semver.validRange("latest || ", true)` is `"*"`.
+    assert!(is_any_version_range("latest || "));
+    assert!(is_any_version_range("|| latest"));
+    assert!(is_any_version_range("garbage ||"));
+}
+
+#[test]
 fn bounded_ranges_are_not_any_version() {
     assert!(!is_any_version_range("^1.0.0"));
     assert!(!is_any_version_range("1.0.0"));
@@ -39,6 +48,17 @@ fn ordinary_ranges_stay_valid_and_tags_stay_invalid() {
     assert!(is_valid_semver_range("^1.0.0"));
     assert!(is_valid_semver_range("1.x"));
     assert!(is_valid_semver_range(">=1.0.0 <2.0.0"));
+    assert!(is_valid_semver_range("^1.0.0 || ^2.0.0"));
     assert!(!is_valid_semver_range("latest"));
     assert!(!is_valid_semver_range("npm:bar@^5"));
+}
+
+#[test]
+fn a_union_with_an_unparsable_member_is_not_a_valid_range() {
+    // Strict mode builds every comparator set, so an empty member does
+    // not excuse an unparsable sibling — these are `null` in JS.
+    assert!(!is_valid_semver_range("latest || "));
+    assert!(!is_valid_semver_range("|| latest"));
+    assert!(!is_valid_semver_range("garbage ||"));
+    assert!(!is_valid_semver_range("npm:bar@^5 || "));
 }

--- a/pnpm/crates/resolving-resolver-base/src/semver_range/tests.rs
+++ b/pnpm/crates/resolving-resolver-base/src/semver_range/tests.rs
@@ -18,8 +18,6 @@ fn a_union_with_an_empty_member_is_any_version() {
 
 #[test]
 fn an_empty_member_widens_a_union_whose_siblings_do_not_parse() {
-    // Loose mode drops the unparsable sets, leaving the empty one to
-    // match everything: `semver.validRange("latest || ", true)` is `"*"`.
     assert!(is_any_version_range("latest || "));
     assert!(is_any_version_range("|| latest"));
     assert!(is_any_version_range("garbage ||"));
@@ -55,8 +53,6 @@ fn ordinary_ranges_stay_valid_and_tags_stay_invalid() {
 
 #[test]
 fn a_union_with_an_unparsable_member_is_not_a_valid_range() {
-    // Strict mode builds every comparator set, so an empty member does
-    // not excuse an unparsable sibling — these are `null` in JS.
     assert!(!is_valid_semver_range("latest || "));
     assert!(!is_valid_semver_range("|| latest"));
     assert!(!is_valid_semver_range("garbage ||"));


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#13673.

`pnpm@12.0.0-rc.0` fails to install any dependency declared with an empty version range:

```
 × installing dependencies
 ╰─▶ Failed to resolve dependency tree: No matching version found for adler-32@
     while fetching it from https://registry.npmjs.org/
     help: The latest release of adler-32 is "1.3.1".
```

An omitted range means "any version" — npm, Yarn and pnpm ≤ 11 all resolve it to the latest match. Bisect: `10.20.0` ✅, `11.20.0` ✅, `12.0.0-rc.0` ❌. Not a niche edge case: `js-xlsx@0.8.22`, `codepage@1.3.8` and `ssf@0.8.2` publish `"adler-32": ""`, `"crc-32": ""`, `"commander": ""`, `"concat-stream": ""` and `"voc": ""`, so any workspace transitively depending on them cannot install without an `overrides` workaround.

**Root cause.** `get_version_selector_type` classifies version → range → dist-tag. For `""`, `Version::parse` and `Range::parse` both fail, and `is_valid_dist_tag("")` is *vacuously true* — so `""` is misclassified as a dist-tag and the picker asks the registry for a tag that cannot exist.

The JS this ports leans on `semver.validRange`, which maps an empty comparator set to `*`. `validRange` has two modes, and pnpm uses **both** — loose drops the `||` members it cannot parse, strict rejects the whole range:

| input | `validRange(x)` (strict) | `validRange(x, true)` (loose) | Rust `Range::parse` |
|---|---|---|---|
| `""` / `" "` / `"\|\|"` | `"*"` | `"*"` | `Err` |
| `"^1.0.0 \|\| "` | `"*"` | `"*"` | parses as `^1.0.0` — silently narrower |
| `"latest \|\| "` | `null` | `"*"` | `Err` |
| `"npm:bar@^5 \|\| "` | `null` | `"*"` | `Err` |

Which mode a call site wants is deliberate in the TypeScript CLI: **loose** via `version-selector-type` (whose default export passes `loose: true`) for the selector *classifiers*, and **strict** via its own bare `semver.validRange(..)` calls for the specifier-*shape* disambiguations that decide whether a body is a version range or a package name.

**Fix.** `resolving-resolver-base` gains a `semver_range` shim with one function per mode, and each call site routes to the one its TypeScript counterpart uses:

- `is_any_version_range` (**loose**) — any `||` member is blank. `get_version_selector_type` consults it *before* both parses, returning `Range` + normalized `"*"`; that ordering also fixes the `"^1.0.0 || "` case `Range::parse` mis-parses. `lockfile-preferred-versions`, a second port of the same JS classifier, had the same gap — `""` returned `None`, silently dropping the spec from the preferred-versions tie-break table — and takes the loose helper too.
- `is_valid_semver_range` (**strict**) — every non-empty `||` member must parse. Replaces the two `Range::parse(..).is_ok()` disambiguations (`npm:` alias, named-registry body).

The split is load-bearing. Reading the disambiguations loosely sends the body to the range branch, which drops the inner package name and promotes the **outer alias** to be the package name:

```yaml
# dependency: { "aliased": "npm:is-negative@^2 || " }
pnpm 11.20.0   ->  version: is-negative@2.1.0
loose reading  ->  version: aliased@1.0.0   # a real, unrelated package fetched from the registry
```

**Verification.** Unit tests for `""`, whitespace, `"||"`, `"^1.0.0 || "`, the `npm:` alias path and the named-registry body, with the loose and strict helpers pinned on the *same* inputs (`latest || `, `|| latest`, `garbage ||`, `npm:bar@^5 || `) so the two can't be conflated again. A resolver-level `mockito` test asserts a bare `""` resolves to the max published version. Every new negative test was checked to fail when its helper is reverted. End-to-end against a live registry, both the original repro and the union case produce lockfiles **byte-identical** to `pnpm@11.20.0`'s.

**Out of scope.** ~50 other `Range::parse` call sites across the workspace (audit, update, patching, engines, peers) share the same JS/Rust divergence but are unrelated to this regression. Left alone to keep the diff reviewable — happy to follow up if you'd like them migrated.

## Squash Commit Body

```text
An omitted version range means "any version" in JS semver, but the Rust
port classified it as a dist-tag: Version::parse and Range::parse both
reject "", and is_valid_dist_tag("") is vacuously true. The picker then
asked the registry for a tag that cannot exist, so any manifest
publishing an empty range -- js-xlsx, codepage and ssf all do -- failed
to install.

Add a semver_range shim to resolving-resolver-base modelling the two
readings of semver.validRange that pnpm relies on, and route each call
site to the one its TypeScript counterpart uses.

is_any_version_range models the loose reading, validRange(x, true) ===
"*", which is the mode version-selector-type runs in. It answers before
Version::parse and Range::parse in both selector classifiers, so an
omitted range normalizes to "*" instead of falling through to the
dist-tag branch. Running first also fixes "^1.0.0 || ", which
Range::parse otherwise accepts and silently narrows to "^1.0.0". The
same gap had been dropping empty specs out of the preferred-versions
tie-break table.

is_valid_semver_range models the strict reading, validRange(x) != null,
under which one unparsable comparator set invalidates the whole union.
It replaces the two Range::parse(..).is_ok() checks that disambiguate a
version range from a package name. These cannot use the loose reading:
"npm:is-negative@^2 || " would take the range branch, dropping the inner
name so the outer alias becomes the package name, and pnpm would install
whatever is published under it.

Verified against pnpm 11.20.0 rather than by reading source: the
empty-range repro and the union case both produce byte-identical
lockfiles.

Fixes pnpm/pnpm#13673.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  **Rust-only, and nothing needs porting:** the TypeScript CLI never had the
  bug, because `version-selector-type` already maps an empty comparator set
  to `*` — which is why `pnpm@11.20.0` installs the repro fine.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
  Targets `pacquet` only; per `AGENTS.md`, a Rust-only changeset must omit
  `"pnpm"`, which always means the TypeScript CLI package.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788583564&installation_model_id=426870&pr_number=13674&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13674&signature=47f88ee813a797fbde3ec7eb249ddf45d1ec2c11846513323a60f9385344d9af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Empty, whitespace-only, and partially empty version ranges now resolve as unrestricted ranges.
  * Packages with empty version selectors install successfully without overrides.
  * Empty selectors resolve to the highest available published version instead of being treated as distribution tags.
  * Alias selectors preserve package and registry information while applying unrestricted version matching.
  * Invalid version unions are handled more consistently.

* **Tests**
  * Added coverage for empty, partial, whitespace-only, union, and alias version selectors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

