### PR TITLE
feat(napi): add allowUnusedPatches install option

### DIFF
--- a/.changeset/napi-allow-unused-patches.md
+++ b/.changeset/napi-allow-unused-patches.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/napi": minor
+---
+
+Added an `allowUnusedPatches` install option. When `true`, a `patchedDependencies` entry that matches no installed package warns instead of failing the install with `ERR_PNPM_UNUSED_PATCH`.

--- a/pnpm/crates/napi/src/config.rs
+++ b/pnpm/crates/napi/src/config.rs
@@ -63,6 +63,10 @@ pub struct ConfigOverlay {
     pub global_virtual_store_dir: Option<PathBuf>,
     pub package_extensions: Option<IndexMap<String, PackageExtension>>,
     pub patched_dependencies: Option<IndexMap<String, String>>,
+    /// `allowUnusedPatches` — when `true`, a configured patch that matches no
+    /// installed package warns instead of failing with
+    /// `ERR_PNPM_UNUSED_PATCH`.
+    pub allow_unused_patches: Option<bool>,
     pub hoist_pattern: Option<Vec<String>>,
     pub public_hoist_pattern: Option<Vec<String>>,
     pub external_dependencies: Option<BTreeSet<String>>,
@@ -301,6 +305,9 @@ fn build_config(dir: &Path, overlay: &ConfigOverlay) -> Result<Config, LoadWorks
         if config.workspace_dir.is_none() {
             config.workspace_dir = Some(dir.to_path_buf());
         }
+    }
+    if let Some(value) = overlay.allow_unused_patches {
+        config.allow_unused_patches = value;
     }
     if let Some(hoist_pattern) = &overlay.hoist_pattern {
         config.hoist_pattern = Some(hoist_pattern.clone());

--- a/pnpm/crates/napi/src/install.rs
+++ b/pnpm/crates/napi/src/install.rs
@@ -98,6 +98,11 @@ pub struct InstallOptions {
     pub package_extensions: Option<IndexMap<String, PackageExtensionInput>>,
     /// Patch paths keyed by package selector. Relative paths resolve from `dir`.
     pub patched_dependencies: Option<IndexMap<String, String>>,
+    /// Warn instead of failing with `ERR_PNPM_UNUSED_PATCH` when a
+    /// `patchedDependencies` entry matches no installed package. Lets an
+    /// embedder ship a patch keyed to a version range that only some
+    /// workspaces resolve.
+    pub allow_unused_patches: Option<bool>,
     pub peers_suffix_max_length: Option<u32>,
     pub dedupe_peer_dependents: Option<bool>,
     pub dedupe_peers: Option<bool>,
@@ -607,6 +612,7 @@ fn build_overlay(options: &InstallOptions) -> napi::Result<ConfigOverlay> {
                 .collect()
         }),
         patched_dependencies: options.patched_dependencies.clone(),
+        allow_unused_patches: options.allow_unused_patches,
         hoist_pattern: options.hoist_pattern.clone(),
         public_hoist_pattern: options.public_hoist_pattern.clone(),
         external_dependencies: options

--- a/pnpm/crates/napi/src/install/tests.rs
+++ b/pnpm/crates/napi/src/install/tests.rs
@@ -122,6 +122,23 @@ fn resolved_config_applies_trust_lockfile() {
 }
 
 #[test]
+fn resolved_config_applies_allow_unused_patches() {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    for (allow_unused_patches, expected) in
+        [(Some(false), false), (Some(true), true), (None, false)]
+    {
+        let mut options = install_options();
+        options.allow_unused_patches = allow_unused_patches;
+        let overlay = build_overlay(&options).expect("overlay");
+        assert_eq!(
+            resolve_config(dir.path(), &overlay).expect("config").allow_unused_patches,
+            expected,
+        );
+    }
+}
+
+#[test]
 fn build_overlay_parses_link_workspace_packages() {
     use pacquet_config::LinkWorkspacePackages;
 

--- a/pnpm/crates/napi/src/install/tests.rs
+++ b/pnpm/crates/napi/src/install/tests.rs
@@ -17,9 +17,7 @@ use crate::{
     reporter_bridge::{begin_stats, take_stats},
 };
 
-/// Adds a marker file, so a patch's content is valid without depending on
-/// any particular package's sources.
-const MARKER_PATCH: &str = concat!(
+const WELL_FORMED_PATCH: &str = concat!(
     "diff --git a/patched-marker.txt b/patched-marker.txt\n",
     "new file mode 100644\n",
     "index 0000000..3f2e1d4\n",
@@ -514,10 +512,6 @@ fn lockfile_records_overrides_in_declaration_order() {
     assert!(zzz < aaa, "overrides must keep declaration order (zzz before aaa), got:\n{lockfile}");
 }
 
-/// A patch whose key matches no installed package fails the install, and
-/// `allowUnusedPatches` is the only way an embedder can downgrade that to a
-/// warning — needed to ship a patch keyed to a version range that only some
-/// of the embedder's workspaces resolve.
 #[test]
 fn allow_unused_patches_downgrades_an_unmatched_patch_to_a_warning() {
     let registry = TestRegistry::start();
@@ -526,7 +520,7 @@ fn allow_unused_patches_downgrades_an_unmatched_patch_to_a_warning() {
     std::fs::create_dir(&project_dir).expect("create project dir");
     std::fs::write(project_dir.join("package.json"), "{}\n").expect("write package.json");
     std::fs::create_dir(project_dir.join("patches")).expect("create patches dir");
-    std::fs::write(project_dir.join("patches/unmatched.patch"), MARKER_PATCH)
+    std::fs::write(project_dir.join("patches/unmatched.patch"), WELL_FORMED_PATCH)
         .expect("write patch file");
 
     let project_dir_string = project_dir.to_string_lossy().into_owned();

--- a/pnpm/crates/napi/src/install/tests.rs
+++ b/pnpm/crates/napi/src/install/tests.rs
@@ -17,6 +17,18 @@ use crate::{
     reporter_bridge::{begin_stats, take_stats},
 };
 
+/// Adds a marker file, so a patch's content is valid without depending on
+/// any particular package's sources.
+const MARKER_PATCH: &str = concat!(
+    "diff --git a/patched-marker.txt b/patched-marker.txt\n",
+    "new file mode 100644\n",
+    "index 0000000..3f2e1d4\n",
+    "--- /dev/null\n",
+    "+++ b/patched-marker.txt\n",
+    "@@ -0,0 +1 @@\n",
+    "+patched\n",
+);
+
 #[test]
 fn resolve_config_reloads_changed_workspace_yaml() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -502,6 +514,49 @@ fn lockfile_records_overrides_in_declaration_order() {
     assert!(zzz < aaa, "overrides must keep declaration order (zzz before aaa), got:\n{lockfile}");
 }
 
+/// A patch whose key matches no installed package fails the install, and
+/// `allowUnusedPatches` is the only way an embedder can downgrade that to a
+/// warning — needed to ship a patch keyed to a version range that only some
+/// of the embedder's workspaces resolve.
+#[test]
+fn allow_unused_patches_downgrades_an_unmatched_patch_to_a_warning() {
+    let registry = TestRegistry::start();
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let project_dir = temp_dir.path().join("project");
+    std::fs::create_dir(&project_dir).expect("create project dir");
+    std::fs::write(project_dir.join("package.json"), "{}\n").expect("write package.json");
+    std::fs::create_dir(project_dir.join("patches")).expect("create patches dir");
+    std::fs::write(project_dir.join("patches/unmatched.patch"), MARKER_PATCH)
+        .expect("write patch file");
+
+    let project_dir_string = project_dir.to_string_lossy().into_owned();
+    let mut options = install_options();
+    options.dir = project_dir_string.clone();
+    options.projects = vec![NodeApiProject {
+        root_dir: project_dir_string,
+        manifest: serde_json::json!({ "dependencies": { "@pnpm.e2e/foo": "100.0.0" } }),
+        dependency_manifest: None,
+    }];
+    options.store_dir = Some(temp_dir.path().join("store").to_string_lossy().into_owned());
+    options.registries = Some(HashMap::from([("default".to_string(), registry.url())]));
+    options.patched_dependencies = Some(indexmap::IndexMap::from_iter([(
+        "is-negative@1.0.0".to_string(),
+        "patches/unmatched.patch".to_string(),
+    )]));
+
+    let error = run_install_inner(&options, None, EngineMode::Install(None))
+        .expect_err("an unmatched patch must fail the install");
+    assert!(
+        error.reason.contains("ERR_PNPM_UNUSED_PATCH"),
+        "expected ERR_PNPM_UNUSED_PATCH, got: {reason}",
+        reason = error.reason,
+    );
+
+    options.allow_unused_patches = Some(true);
+    run_install_inner(&options, None, EngineMode::Install(None))
+        .expect("allowUnusedPatches must let the install through");
+}
+
 fn install_options() -> InstallOptions {
     InstallOptions {
         dir: String::new(),
@@ -535,6 +590,7 @@ fn install_options() -> InstallOptions {
         global_virtual_store_dir: None,
         package_extensions: None,
         patched_dependencies: None,
+        allow_unused_patches: None,
         peers_suffix_max_length: None,
         dedupe_peer_dependents: None,
         dedupe_peers: None,

--- a/pnpm/npm/napi/index.d.ts
+++ b/pnpm/npm/napi/index.d.ts
@@ -148,6 +148,12 @@ export interface InstallOptions extends SharedEngineOptions {
   packageExtensions?: Record<string, PackageExtension>
   /** Patch paths keyed by package selector. Relative paths resolve from `dir`. */
   patchedDependencies?: Record<string, string>
+  /**
+   * Warn instead of failing with `ERR_PNPM_UNUSED_PATCH` when a
+   * `patchedDependencies` entry matches no installed package. Lets an embedder
+   * ship a patch keyed to a version range that only some workspaces resolve.
+   */
+  allowUnusedPatches?: boolean
   peersSuffixMaxLength?: number
   dedupePeerDependents?: boolean
   /**


### PR DESCRIPTION
## Summary

Exposes `allowUnusedPatches` as an install option on `@pnpm/napi`.

pnpm fails an install when a configured patch matches no installed package
(`ERR_PNPM_UNUSED_PATCH`). The CLI lets a workspace opt out with
`allowUnusedPatches` in `pnpm-workspace.yaml`, but the Node API accepted
`patchedDependencies` only — an embedder that ships its own patches had no way
to reach the setting.

This blocks [teambit/bit#10572](https://github.com/teambit/bit/pull/10572),
which ships a Bit-owned patch for `` `@teambit/react.react-env` ``'s phantom
`tsconfig` dependency under the global virtual store. The phantom dependency
only exists on the package's 1.x line (2.x already inlines the config), so the
patch has to be keyed `` `@teambit/react.react-env@1` `` — and every workspace
that resolves 2.x then matches no key and fails the install. `allowUnusedPatches`
is what makes a version-ranged, embedder-supplied patch safe to ship.

Related to [teambit/bit#10572](https://github.com/teambit/bit/pull/10572).

## Squash Commit Body

```text
pnpm fails an install when a configured patch matches no installed
package (ERR_PNPM_UNUSED_PATCH). The CLI lets a workspace opt out via
allowUnusedPatches in pnpm-workspace.yaml, but the binding accepted
patchedDependencies only, so an embedder that ships its own patches had
no way to reach the setting.

Threads the flag through InstallOptions -> ConfigOverlay ->
Config::allow_unused_patches, which the fresh-lockfile path already reads
when it calls verify_patches. No engine-side change is needed; this is
purely the missing binding surface.

Bit needs it to ship a patch keyed to a version range
(`@teambit/react.react-env@1`) from its own config: workspaces that
resolve 2.x match no key and would otherwise fail the install. See
teambit/bit#10572.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <br>N/A — `@pnpm/napi` is the Rust engine's Node binding; it has no
  TypeScript counterpart. The setting itself already exists in both stacks.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
  <br>`allow_unused_patches_downgrades_an_unmatched_patch_to_a_warning` runs a
  real install with an unmatched patch key: it asserts `ERR_PNPM_UNUSED_PATCH`
  without the option and success with it.
- [x] Updated the documentation if needed.
  <br>`pnpm/npm/napi/index.d.ts` documents the new option.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788596119&installation_model_id=426870&pr_number=13677&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13677&signature=8137bed57af918e8aa09505c1e447c4cd2a08084fc74c6382871dcaa6d870c27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `allowUnusedPatches` install option.
  * Unmatched patched dependencies can now generate a warning instead of causing installation to fail when enabled.

* **Bug Fixes**
  * Preserved the default error behavior for unused patches when the option is not enabled.

* **Tests**
  * Added coverage for failing and warning-based handling of unmatched patches.
  * Verified the new option is correctly applied during installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->