### PR TITLE
fix(audit): only exclude patched versions actually blocked by `minimumReleaseAge`

### DIFF
--- a/.changeset/audit-fix-age-excludes-only-when-needed.md
+++ b/.changeset/audit-fix-age-excludes-only-when-needed.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/deps.compliance.commands": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+`pnpm audit --fix` and `pnpm audit --fix update` no longer add `minimumReleaseAgeExclude` entries for patched versions that were published before the `minimumReleaseAge` cutoff. The publish time of each minimum patched version is now checked against the registry metadata, and only versions young enough to be blocked by the age gate get an exclusion entry [#11563](https://github.com/pnpm/pnpm/issues/11563).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2903,6 +2903,12 @@ importers:
       '@pnpm/network.auth-header':
         specifier: workspace:*
         version: link:../../../network/auth-header
+      '@pnpm/network.fetch':
+        specifier: workspace:*
+        version: link:../../../network/fetch
+      '@pnpm/npm-package-arg':
+        specifier: 'catalog:'
+        version: 2.0.0
       '@pnpm/object.key-sorting':
         specifier: workspace:*
         version: link:../../../object/key-sorting

--- a/pnpm/crates/cli/src/cli_args/audit.rs
+++ b/pnpm/crates/cli/src/cli_args/audit.rs
@@ -1,4 +1,5 @@
 use crate::State;
+use chrono::{DateTime, Utc};
 use clap::{Args, ValueEnum};
 use derive_more::{Display, Error};
 use dialoguer::MultiSelect;
@@ -10,12 +11,13 @@ use pacquet_lockfile::{
     EnvLockfile, ImporterDepVersion, Lockfile, PackageKey, PkgName, ResolvedDependencyMap,
     SnapshotDepRef, SnapshotEntry, SpecifierAndResolution, pick_registry_for_package,
 };
-use pacquet_network::{RetryOpts, send_with_retry};
+use pacquet_network::{RetryOpts, encode_package_name, send_with_retry};
 use pacquet_package_manager::{ResolutionObserver, ResolvedPackageHint, Update};
 use pacquet_package_manifest::DependencyGroup;
 use pacquet_reporter::Reporter;
 use pacquet_resolving_resolver_base::{
     PackageVersionGuard, PackageVersionGuardDecision, PackageVersionGuardFuture,
+    parse_packument_timestamp,
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -258,7 +260,13 @@ impl AuditArgs {
             };
             return match fix_method {
                 FixMethod::Override => {
-                    let output = fix_override(&filtered, &settings_dir, state.config)?;
+                    let output = fix_override(
+                        &filtered,
+                        &settings_dir,
+                        state.config,
+                        state.http_client.as_ref(),
+                    )
+                    .await?;
                     print!("{output}");
                     let _ = std::io::stdout().flush();
                     Ok(AuditOutcome::Clean)

--- a/pnpm/crates/cli/src/cli_args/audit/fix.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/fix.rs
@@ -6,8 +6,8 @@ use super::{
     PackageVersionGuard, Range, Reporter, ResolutionObserver, State, Update, Utc, Version, blue,
     caret_range_for_patched, color_severity, encode_package_name, green, normalize_ghsa_id,
     normalize_registry, parse_packument_timestamp, pick_registry_for_package, red,
-    retry_opts_from_config, satisfies_including_prerelease, send_with_retry, severity_name,
-    severity_number,
+    redact_url_userinfo, retry_opts_from_config, satisfies_including_prerelease, send_with_retry,
+    severity_name, severity_number,
 };
 
 /// Filter `report`'s advisories down to the set both fix methods and the
@@ -115,13 +115,15 @@ async fn fetch_publish_times(
 
     let registry = normalize_registry(registry);
     let url = format!("{registry}{}", encode_package_name(name));
-    let authorization = config.auth_headers.for_url(&registry);
+    // The URL is user-configured and may embed credentials; keep only the
+    // redacted form, like the audit request does, so retry diagnostics never
+    // print them (auth travels in the header instead).
+    let url = redact_url_userinfo(&url);
+    let authorization = config.auth_headers.for_url_with_package(&registry, Some(name));
     let retry_opts = retry_opts_from_config(config);
-    let (_, response) = send_with_retry(http_client, &url, retry_opts, |client| {
-        let mut request = client.get(&url).header(
-            "accept",
-            "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*",
-        );
+    let (_guard, response) = send_with_retry(http_client, &url, retry_opts, |client| {
+        // Full metadata: the abbreviated packument has no `time` field.
+        let mut request = client.get(&url).header("accept", "application/json; q=1.0, */*");
         if let Some(value) = &authorization {
             request = request.header("authorization", value);
         }
@@ -154,11 +156,13 @@ async fn resolve_minimum_release_age_excludes(
     else {
         return Ok(Vec::new());
     };
-    // One fetch per package name, however many advisories it carries.
+    // One fetch per package name, however many advisories it carries. The
+    // name comes from the registry's advisory feed, so normalize it like
+    // `classify_for_update` does before using it in requests and config.
     let names: HashSet<&str> = advisories
         .values()
         .filter(|advisory| advisory.patched_versions.is_some())
-        .map(|advisory| advisory.module_name.as_str())
+        .map(|advisory| advisory.module_name.trim())
         .collect();
     let registries: HashMap<String, String> = config.resolved_registries().into_iter().collect();
     let mut publish_times = HashMap::new();
@@ -188,14 +192,15 @@ pub(crate) fn minimum_release_age_excludes(
             let min = patched
                 .strip_prefix(">=")
                 .and_then(|version| version.trim().parse::<Version>().ok())?;
+            let name = advisory.module_name.trim();
             let published_at = publish_times
-                .get(&advisory.module_name)
+                .get(name)
                 .and_then(Option::as_ref)
                 .and_then(|times| times.get(min.to_string().as_str()))
                 .and_then(|raw| parse_packument_timestamp(raw));
             match published_at {
                 Some(published_at) if published_at <= cutoff => None,
-                _ => Some(format!("{}@{min}", advisory.module_name)),
+                _ => Some(format!("{name}@{min}")),
             }
         })
         .collect();

--- a/pnpm/crates/cli/src/cli_args/audit/fix.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/fix.rs
@@ -1,10 +1,12 @@
 //! Applying fixes: overrides, ignores, and dependency updates.
 
 use super::{
-    Arc, AuditAdvisory, AuditError, AuditReport, BTreeMap, Config, ConfigAuditLevel,
-    DependencyGroup, HashMap, HashSet, IntoDiagnostic, Lockfile, MultiSelect, PackageVersionGuard,
-    Range, Reporter, ResolutionObserver, State, Update, Version, blue, caret_range_for_patched,
-    color_severity, green, normalize_ghsa_id, red, satisfies_including_prerelease, severity_name,
+    Arc, AuditAdvisory, AuditError, AuditReport, BTreeMap, Config, ConfigAuditLevel, DateTime,
+    DependencyGroup, Deserialize, HashMap, HashSet, IntoDiagnostic, Lockfile, MultiSelect,
+    PackageVersionGuard, Range, Reporter, ResolutionObserver, State, Update, Utc, Version, blue,
+    caret_range_for_patched, color_severity, encode_package_name, green, normalize_ghsa_id,
+    normalize_registry, parse_packument_timestamp, pick_registry_for_package, red,
+    retry_opts_from_config, satisfies_including_prerelease, send_with_retry, severity_name,
     severity_number,
 };
 
@@ -55,10 +57,11 @@ pub(crate) fn create_overrides(
 
 /// Write the override-method fixes to `pnpm-workspace.yaml` and return the
 /// user-facing summary. Mirrors the override branch of pnpm's audit handler.
-pub(crate) fn fix_override(
+pub(crate) async fn fix_override(
     advisories: &BTreeMap<String, AuditAdvisory>,
     settings_dir: &std::path::Path,
     config: &Config,
+    http_client: &pacquet_network::ThrottledClient,
 ) -> miette::Result<String> {
     let overrides = create_overrides(advisories);
     if overrides.is_empty() {
@@ -73,8 +76,14 @@ pub(crate) fn fix_override(
         "{} overrides were added to pnpm-workspace.yaml to fix vulnerabilities.\nRun \"pnpm install\" to apply the fixes.\n\nThe added overrides:\n{json}",
         overrides.len(),
     );
-    if config.resolved_minimum_release_age().is_some() {
-        let added = minimum_release_age_excludes(advisories)?;
+    if let Some(minimum_release_age) = config.resolved_minimum_release_age() {
+        let added = resolve_minimum_release_age_excludes(
+            advisories,
+            config,
+            http_client,
+            minimum_release_age,
+        )
+        .await?;
         if !added.is_empty() {
             write_age_excludes(settings_dir, config, &added)?;
             let note = format!(
@@ -88,13 +97,89 @@ pub(crate) fn fix_override(
     Ok(output)
 }
 
-/// Patched minimum versions of the fixable advisories, as
-/// `name@minVersion` specs merged per package. Ports pnpm's
-/// `createMinimumReleaseAgeExcludes`: these are appended to
-/// `minimumReleaseAgeExclude` so a `minimumReleaseAge` cutoff doesn't block
-/// installing a freshly-published patched version.
+/// The packument `time` map of one package: version to raw publish timestamp,
+/// or `None` when the publish times are unknown — the request failed, the
+/// registry answered non-200, or the packument carries no usable `time` field.
+/// Ports pnpm's `createPublishTimesFetcher`; `None` must read as "no
+/// information", not "old", so a genuinely fresh fix keeps its exclusion.
+async fn fetch_publish_times(
+    name: &str,
+    registry: &str,
+    config: &Config,
+    http_client: &pacquet_network::ThrottledClient,
+) -> Option<HashMap<String, String>> {
+    #[derive(Deserialize)]
+    struct PackumentTimes {
+        time: Option<HashMap<String, String>>,
+    }
+
+    let registry = normalize_registry(registry);
+    let url = format!("{registry}{}", encode_package_name(name));
+    let authorization = config.auth_headers.for_url(&registry);
+    let retry_opts = retry_opts_from_config(config);
+    let (_, response) = send_with_retry(http_client, &url, retry_opts, |client| {
+        let mut request = client.get(&url).header(
+            "accept",
+            "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*",
+        );
+        if let Some(value) = &authorization {
+            request = request.header("authorization", value);
+        }
+        request
+    })
+    .await
+    .ok()?;
+    if response.status().as_u16() != 200 {
+        return None;
+    }
+    response.json::<PackumentTimes>().await.ok()?.time
+}
+
+/// Compute the age-gate exclusions for `advisories`, consulting the
+/// packuments of the affected packages so a patched version published long
+/// before the cutoff gets no pointless `minimumReleaseAgeExclude` entry.
+/// Ports the publish-time lookup of pnpm's `createMinimumReleaseAgeExcludes`.
+async fn resolve_minimum_release_age_excludes(
+    advisories: &BTreeMap<String, AuditAdvisory>,
+    config: &Config,
+    http_client: &pacquet_network::ThrottledClient,
+    minimum_release_age: u64,
+) -> miette::Result<Vec<String>> {
+    // On overflow leave the cutoff uncomputable, as `PickPolicy::from_config`
+    // does; with no effective gate no bypass entries are needed.
+    let Some(cutoff) = i64::try_from(minimum_release_age)
+        .ok()
+        .and_then(chrono::Duration::try_minutes)
+        .and_then(|age| Utc::now().checked_sub_signed(age))
+    else {
+        return Ok(Vec::new());
+    };
+    // One fetch per package name, however many advisories it carries.
+    let names: HashSet<&str> = advisories
+        .values()
+        .filter(|advisory| advisory.patched_versions.is_some())
+        .map(|advisory| advisory.module_name.as_str())
+        .collect();
+    let registries: HashMap<String, String> = config.resolved_registries().into_iter().collect();
+    let mut publish_times = HashMap::new();
+    for name in names {
+        let registry = pick_registry_for_package(&registries, name, None);
+        let times = fetch_publish_times(name, &registry, config, http_client).await;
+        publish_times.insert(name.to_string(), times);
+    }
+    minimum_release_age_excludes(advisories, &publish_times, cutoff)
+}
+
+/// The `minimumReleaseAgeExclude` entries needed to keep the age gate from
+/// blocking the patched versions: one `name@minVersion` spec per fixable
+/// advisory whose minimum patched version is younger than `cutoff`. A version
+/// published at or before the cutoff doesn't need a bypass, and a version
+/// whose publish time is unknown keeps its entry so a genuinely fresh fix
+/// stays installable. Ports pnpm's `createMinimumReleaseAgeExcludes`.
 pub(crate) fn minimum_release_age_excludes(
     advisories: &BTreeMap<String, AuditAdvisory>,
+    publish_times: &HashMap<String, Option<HashMap<String, String>>>,
+    cutoff: DateTime<Utc>,
 ) -> miette::Result<Vec<String>> {
     let specs: Vec<String> = advisories
         .values()
@@ -103,7 +188,15 @@ pub(crate) fn minimum_release_age_excludes(
             let min = patched
                 .strip_prefix(">=")
                 .and_then(|version| version.trim().parse::<Version>().ok())?;
-            Some(format!("{}@{min}", advisory.module_name))
+            let published_at = publish_times
+                .get(&advisory.module_name)
+                .and_then(Option::as_ref)
+                .and_then(|times| times.get(min.to_string().as_str()))
+                .and_then(|raw| parse_packument_timestamp(raw));
+            match published_at {
+                Some(published_at) if published_at <= cutoff => None,
+                _ => Some(format!("{}@{min}", advisory.module_name)),
+            }
         })
         .collect();
     pacquet_config::version_policy::merge_package_version_specs(&specs).map_err(miette::Report::new)
@@ -319,17 +412,25 @@ pub(crate) async fn fix_with_update<Reporter: self::Reporter + 'static>(
         classify_for_update(advisories);
 
     // When `minimumReleaseAge` is set, the patched versions are likely
-    // fresher than the cutoff; record them as exclusions (persisted to config
-    // and injected into this resolve) so the picker may install them.
-    let age_excludes = if state.config.resolved_minimum_release_age().is_some() {
-        let added = minimum_release_age_excludes(advisories)?;
-        if !added.is_empty() {
-            write_age_excludes(settings_dir, state.config, &added)?;
-        }
-        added
-    } else {
-        Vec::new()
-    };
+    // fresher than the cutoff; record the ones that actually are as
+    // exclusions (persisted to config and injected into this resolve) so the
+    // picker may install them.
+    let age_excludes =
+        if let Some(minimum_release_age) = state.config.resolved_minimum_release_age() {
+            let added = resolve_minimum_release_age_excludes(
+                advisories,
+                state.config,
+                state.http_client.as_ref(),
+                minimum_release_age,
+            )
+            .await?;
+            if !added.is_empty() {
+                write_age_excludes(settings_dir, state.config, &added)?;
+            }
+            added
+        } else {
+            Vec::new()
+        };
 
     let guard_ranges: HashMap<String, Vec<Range>> = vulnerabilities
         .iter()

--- a/pnpm/crates/cli/src/cli_args/audit/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/tests.rs
@@ -16,6 +16,7 @@ use super::{
     request::{Include, lockfile_to_audit_request},
     version_ranges::{caret_range_for_patched, satisfies_safe},
 };
+use chrono::{DateTime, Utc};
 use pacquet_lockfile::{EnvLockfile, Lockfile, SnapshotEntry, SpecifierAndResolution};
 use std::{collections::HashSet, fmt::Write as _};
 
@@ -1170,6 +1171,22 @@ fn format_fix_with_update_output_lists_fixed_and_remaining() {
     assert!(output.contains("stuck-pkg"));
 }
 
+fn age_cutoff() -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z").expect("valid cutoff").with_timezone(&Utc)
+}
+
+fn publish_times(
+    package: &str,
+    entries: &[(&str, &str)],
+) -> HashMap<String, Option<HashMap<String, String>>> {
+    HashMap::from([(
+        package.to_string(),
+        Some(
+            entries.iter().map(|(version, time)| (version.to_string(), time.to_string())).collect(),
+        ),
+    )])
+}
+
 #[test]
 fn minimum_release_age_excludes_uses_patched_minimums_and_skips_unfixable() {
     let advisories = report_of(vec![
@@ -1179,9 +1196,91 @@ fn minimum_release_age_excludes_uses_patched_minimums_and_skips_unfixable() {
     ])
     .advisories;
 
-    let excludes = minimum_release_age_excludes(&advisories).expect("compute excludes");
+    // No publish-time information at all: fail open, keep the entry.
+    let excludes = minimum_release_age_excludes(&advisories, &HashMap::new(), age_cutoff())
+        .expect("compute excludes");
 
     assert_eq!(excludes, vec!["foo@2.0.0".to_string()]);
+}
+
+#[test]
+fn minimum_release_age_excludes_drops_versions_older_than_the_cutoff() {
+    let advisories = report_of(vec![
+        fix_advisory(1, "old", "<2.0.0", Some(">=2.0.0"), ConfigAuditLevel::High, "GHSA-a"),
+        fix_advisory(2, "fresh", "<3.0.0", Some(">=3.0.0"), ConfigAuditLevel::High, "GHSA-b"),
+    ])
+    .advisories;
+    let times = HashMap::from([
+        (
+            "old".to_string(),
+            Some(HashMap::from([("2.0.0".to_string(), "2020-01-01T00:00:00Z".to_string())])),
+        ),
+        (
+            "fresh".to_string(),
+            Some(HashMap::from([("3.0.0".to_string(), "2026-06-01T00:00:00Z".to_string())])),
+        ),
+    ]);
+
+    let excludes =
+        minimum_release_age_excludes(&advisories, &times, age_cutoff()).expect("compute excludes");
+
+    assert_eq!(excludes, vec!["fresh@3.0.0".to_string()], "the old fix needs no bypass");
+}
+
+#[test]
+fn minimum_release_age_excludes_drops_versions_published_exactly_at_the_cutoff() {
+    let advisories = report_of(vec![fix_advisory(
+        1,
+        "foo",
+        "<2.0.0",
+        Some(">=2.0.0"),
+        ConfigAuditLevel::High,
+        "GHSA-a",
+    )])
+    .advisories;
+    let times = publish_times("foo", &[("2.0.0", "2026-01-01T00:00:00Z")]);
+
+    let excludes =
+        minimum_release_age_excludes(&advisories, &times, age_cutoff()).expect("compute excludes");
+
+    assert!(excludes.is_empty(), "a version at the cutoff is mature: {excludes:?}");
+}
+
+#[test]
+fn minimum_release_age_excludes_keeps_versions_with_unknown_publish_times() {
+    let advisories = report_of(vec![
+        fix_advisory(1, "absent", "<2.0.0", Some(">=2.0.0"), ConfigAuditLevel::High, "GHSA-a"),
+        fix_advisory(2, "garbled", "<3.0.0", Some(">=3.0.0"), ConfigAuditLevel::High, "GHSA-b"),
+        fix_advisory(3, "unfetchable", "<4.0.0", Some(">=4.0.0"), ConfigAuditLevel::High, "GHSA-c"),
+    ])
+    .advisories;
+    let times = HashMap::from([
+        // The version is absent from the packument's `time` map.
+        (
+            "absent".to_string(),
+            Some(HashMap::from([("1.0.0".to_string(), "2020-01-01T00:00:00Z".to_string())])),
+        ),
+        // The timestamp does not parse.
+        (
+            "garbled".to_string(),
+            Some(HashMap::from([("3.0.0".to_string(), "not-a-date".to_string())])),
+        ),
+        // The fetch failed outright.
+        ("unfetchable".to_string(), None),
+    ]);
+
+    let excludes =
+        minimum_release_age_excludes(&advisories, &times, age_cutoff()).expect("compute excludes");
+
+    assert_eq!(
+        excludes,
+        vec![
+            "absent@2.0.0".to_string(),
+            "garbled@3.0.0".to_string(),
+            "unfetchable@4.0.0".to_string()
+        ],
+        "unknown publish times fail open so a fresh fix stays installable",
+    );
 }
 
 #[test]

--- a/pnpm/crates/cli/tests/suite/audit.rs
+++ b/pnpm/crates/cli/tests/suite/audit.rs
@@ -1,6 +1,4 @@
-pub mod _utils;
-
-use _utils::set_minimum_release_age;
+use crate::_utils::set_minimum_release_age;
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use mockito::Matcher;

--- a/pnpm/crates/cli/tests/suite/audit.rs
+++ b/pnpm/crates/cli/tests/suite/audit.rs
@@ -751,6 +751,10 @@ fn audit_fix_override_skips_age_exclude_when_patched_version_is_old() {
         fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("read workspace manifest");
     assert!(manifest.contains("overrides:"), "manifest should hold the override:\n{manifest}");
     assert!(
+        manifest.contains("vulnerable@<2.0.0: ^2.0.0"),
+        "manifest should hold the patched override:\n{manifest}",
+    );
+    assert!(
         !manifest.contains("minimumReleaseAgeExclude:"),
         "manifest should hold no exclusion:\n{manifest}",
     );
@@ -813,6 +817,10 @@ fn audit_fix_override_writes_age_exclude_when_patched_version_is_within_the_wind
     assert!(
         manifest.contains("minimumReleaseAgeExclude:"),
         "manifest should hold the exclusions:\n{manifest}",
+    );
+    assert!(
+        manifest.contains("vulnerable@1.5.0 || 2.0.0"),
+        "manifest should hold both patched-version exclusions:\n{manifest}",
     );
     mock.assert();
     packument_mock.assert();

--- a/pnpm/crates/cli/tests/suite/audit.rs
+++ b/pnpm/crates/cli/tests/suite/audit.rs
@@ -1,3 +1,6 @@
+pub mod _utils;
+
+use _utils::set_minimum_release_age;
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use mockito::Matcher;
@@ -719,6 +722,105 @@ fn audit_fix_override_writes_minimum_release_age_excludes_when_configured() {
 }
 
 #[test]
+fn audit_fix_override_skips_age_exclude_when_patched_version_is_old() {
+    let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
+    let mut registry = mockito::Server::new();
+    let mock = audit_mock(
+        &mut registry,
+        &advisory_response("vulnerable", 123, "high", "<2.0.0", "test", "GHSA-test-1111-2222"),
+    )
+    .create();
+    // The patched version predates the cutoff, so the age gate would not
+    // block it and no exclusion entry is needed.
+    let packument_mock = registry
+        .mock("GET", "/vulnerable")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"time":{"2.0.0":"2020-01-01T00:00:00.000Z"}}"#)
+        .create();
+    write_audit_workspace(&workspace, &registry.url(), "minimumReleaseAge: 1440\n");
+
+    let output = pacquet.arg("audit").arg("--fix").output().expect("run pacquet audit --fix");
+
+    assert_success(&output);
+    assert!(stdout(&output).contains("overrides were added to pnpm-workspace.yaml"));
+    assert!(
+        !stdout(&output).contains("entries were added to minimumReleaseAgeExclude"),
+        "no exclusions should be reported:\n{}",
+        stdout(&output),
+    );
+    let manifest =
+        fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("read workspace manifest");
+    assert!(manifest.contains("overrides:"), "manifest should hold the override:\n{manifest}");
+    assert!(
+        !manifest.contains("minimumReleaseAgeExclude:"),
+        "manifest should hold no exclusion:\n{manifest}",
+    );
+    mock.assert();
+    packument_mock.assert();
+}
+
+#[test]
+fn audit_fix_override_writes_age_exclude_when_patched_version_is_within_the_window() {
+    let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
+    let mut registry = mockito::Server::new();
+    // Two advisories on one package: the packument is fetched once.
+    let mock = audit_mock(
+        &mut registry,
+        r#"{
+  "vulnerable": [
+    {
+      "id": 123,
+      "url": "https://github.com/advisories/GHSA-test-1111-2222",
+      "title": "test",
+      "severity": "high",
+      "vulnerable_versions": "<2.0.0",
+      "cwe": []
+    },
+    {
+      "id": 124,
+      "url": "https://github.com/advisories/GHSA-test-3333-4444",
+      "title": "test",
+      "severity": "high",
+      "vulnerable_versions": "<1.5.0",
+      "cwe": []
+    }
+  ]
+}"#,
+    )
+    .create();
+    let packument_mock = registry
+        .mock("GET", "/vulnerable")
+        .expect(1)
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"time":{"1.5.0":"2020-01-01T00:00:00.000Z","2.0.0":"2020-01-01T00:00:00.000Z"}}"#,
+        )
+        .create();
+    // A ~19-year window puts the 2020 publish times after the cutoff, so the
+    // age gate would block the patched versions and the exclusions stay.
+    write_audit_workspace(&workspace, &registry.url(), "minimumReleaseAge: 10000000\n");
+
+    let output = pacquet.arg("audit").arg("--fix").output().expect("run pacquet audit --fix");
+
+    assert_success(&output);
+    assert!(
+        stdout(&output).contains("entries were added to minimumReleaseAgeExclude"),
+        "exclusions should be reported:\n{}",
+        stdout(&output),
+    );
+    let manifest =
+        fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("read workspace manifest");
+    assert!(
+        manifest.contains("minimumReleaseAgeExclude:"),
+        "manifest should hold the exclusions:\n{manifest}",
+    );
+    mock.assert();
+    packument_mock.assert();
+}
+
+#[test]
 fn audit_fix_override_with_no_fixable_vulnerabilities_makes_no_changes() {
     let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
     let mut registry = mockito::Server::new();
@@ -899,6 +1001,76 @@ fn audit_fix_update_moves_to_a_non_vulnerable_version() {
     assert!(
         !lockfile.contains("audit-multi-version@2.0."),
         "no vulnerable 2.x version should remain:\n{lockfile}",
+    );
+    mock.assert();
+    drop((root, npmrc_info));
+}
+
+/// `--fix update` with `minimumReleaseAge`: the inferred patched version
+/// (3.0.0) has no entry in the packument's `time` map, so its publish time is
+/// unknown and the exclusion fails open — it must be written and reported.
+#[test]
+fn audit_fix_update_writes_age_exclude_when_patched_publish_time_is_unknown() {
+    const PKG: &str = "@pnpm.e2e/audit-multi-version";
+    let CommandTempCwd { workspace, root, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let pnpr_url = npmrc_info.mock_instance.url();
+
+    fs::write(
+        workspace.join("package.json"),
+        format!(
+            r#"{{"name":"audit-fix-update","version":"1.0.0","dependencies":{{"{PKG}":">=1.0.0"}}}}"#,
+        ),
+    )
+    .expect("write package.json");
+    pacquet_cmd(&workspace, ["install"]).assert().success();
+    set_minimum_release_age(&workspace, 1440);
+
+    let mut audit_registry = mockito::Server::new();
+    let mock = audit_registry
+        .mock("POST", "/-/npm/v1/security/advisories/bulk")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(advisory_response(
+            PKG,
+            9001,
+            "high",
+            ">=2.0.0 <3.0.0",
+            "vulnerable 2.x",
+            "GHSA-mult-1111-2222",
+        ))
+        .create();
+    fs::write(
+        workspace.join(".npmrc"),
+        format!(
+            "registry={audit}\n@pnpm.e2e:registry={pnpr}\nstore-dir=../pacquet-store\ncache-dir=../pacquet-cache\nfetchRetries=0\n",
+            audit = audit_registry.url(),
+            pnpr = pnpr_url,
+        ),
+    )
+    .expect("rewrite .npmrc");
+
+    let output = pacquet_cmd(&workspace, ["audit", "--fix", "update"])
+        .output()
+        .expect("run audit --fix update");
+
+    assert!(
+        output.status.success(),
+        "audit --fix update should succeed; stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("vulnerability was fixed"), "stdout should report the fix:\n{stdout}");
+    assert!(
+        stdout.contains("entries were added to minimumReleaseAgeExclude"),
+        "stdout should report the exclusion:\n{stdout}",
+    );
+    let manifest =
+        fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("read workspace manifest");
+    assert!(
+        manifest.contains("minimumReleaseAgeExclude:")
+            && manifest.contains("@pnpm.e2e/audit-multi-version@3.0.0"),
+        "manifest should hold the patched-version exclusion:\n{manifest}",
     );
     mock.assert();
     drop((root, npmrc_info));

--- a/pnpm11/deps/compliance/commands/package.json
+++ b/pnpm11/deps/compliance/commands/package.json
@@ -57,6 +57,8 @@
     "@pnpm/lockfile.utils": "workspace:*",
     "@pnpm/lockfile.walker": "workspace:*",
     "@pnpm/network.auth-header": "workspace:*",
+    "@pnpm/network.fetch": "workspace:*",
+    "@pnpm/npm-package-arg": "catalog:",
     "@pnpm/object.key-sorting": "workspace:*",
     "@pnpm/store.path": "workspace:*",
     "@pnpm/types": "workspace:*",

--- a/pnpm11/deps/compliance/commands/src/audit/fix.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/fix.ts
@@ -5,6 +5,7 @@ import { sortDirectKeys } from '@pnpm/object.key-sorting'
 import semver from 'semver'
 
 import type { AuditOptions } from './audit.js'
+import { createPublishTimesFetcher } from './publishTimes.js'
 
 export interface FixResult {
   vulnOverrides: Record<string, string>
@@ -15,7 +16,12 @@ export async function fix (auditReport: AuditReport, opts: AuditOptions): Promis
   const fixableAdvisories = getFixableAdvisories(Object.values(auditReport.advisories), opts.auditConfig?.ignoreGhsas)
   const vulnOverrides = createOverrides(fixableAdvisories)
   if (Object.values(vulnOverrides).length === 0) return { vulnOverrides, addedAgeExcludes: [] }
-  const addedAgeExcludes = opts.minimumReleaseAge ? createMinimumReleaseAgeExcludes(fixableAdvisories) : []
+  const addedAgeExcludes = opts.minimumReleaseAge
+    ? await createMinimumReleaseAgeExcludes(fixableAdvisories, {
+      getPublishTimes: createPublishTimesFetcher(opts),
+      minimumReleaseAge: opts.minimumReleaseAge,
+    })
+    : []
   await writeSettings({
     updatedOverrides: vulnOverrides,
     addedMinimumReleaseAgeExcludes: addedAgeExcludes.length > 0 ? addedAgeExcludes : undefined,
@@ -56,14 +62,41 @@ export function caretRangeForPatched (patchedRange: string): string {
   return min ? `^${min.version}` : patchedRange
 }
 
-export function createMinimumReleaseAgeExcludes (advisories: AuditAdvisory[]): string[] {
-  const specs: string[] = []
-  for (const advisory of advisories) {
+export interface CreateMinimumReleaseAgeExcludesOptions {
+  /**
+   * Publish-time lookup (the packument's `time` map) per package name.
+   * `undefined` means the publish times are unknown.
+   */
+  getPublishTimes: (pkgName: string) => Promise<Record<string, string> | undefined>
+  /**
+   * In minutes, same unit as the `minimumReleaseAge` setting.
+   */
+  minimumReleaseAge: number
+  now?: number
+}
+
+/**
+ * The `minimumReleaseAgeExclude` entries needed to keep the age gate from
+ * blocking the patched versions: one entry per fixable advisory whose minimum
+ * patched version is younger than the cutoff. A version published at or
+ * before the cutoff doesn't need a bypass, and a version whose publish time
+ * is unknown keeps its entry so a genuinely fresh fix stays installable.
+ */
+export async function createMinimumReleaseAgeExcludes (
+  advisories: AuditAdvisory[],
+  opts: CreateMinimumReleaseAgeExcludesOptions
+): Promise<string[]> {
+  const cutoff = (opts.now ?? Date.now()) - opts.minimumReleaseAge * 60 * 1000
+  const specs = await Promise.all(advisories.map(async (advisory): Promise<string | undefined> => {
     const patchedVersions = advisory.patched_versions
-    if (!patchedVersions) continue
+    if (!patchedVersions) return undefined
     const minVersion = semver.minVersion(patchedVersions)
-    if (!minVersion) continue
-    specs.push(`${advisory.module_name}@${minVersion.version}`)
-  }
-  return mergePackageVersionSpecs(specs)
+    if (!minVersion) return undefined
+    const spec = `${advisory.module_name}@${minVersion.version}`
+    const publishTime = (await opts.getPublishTimes(advisory.module_name))?.[minVersion.version]
+    if (publishTime == null) return spec
+    const publishedAt = new Date(publishTime).getTime()
+    return Number.isNaN(publishedAt) || publishedAt > cutoff ? spec : undefined
+  }))
+  return mergePackageVersionSpecs(specs.filter((spec): spec is string => spec != null))
 }

--- a/pnpm11/deps/compliance/commands/src/audit/fix.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/fix.ts
@@ -93,8 +93,10 @@ export async function createMinimumReleaseAgeExcludes (
     const minVersion = semver.minVersion(patchedVersions)
     if (!minVersion) return undefined
     const spec = `${advisory.module_name}@${minVersion.version}`
-    const publishTime = (await opts.getPublishTimes(advisory.module_name))?.[minVersion.version]
-    if (publishTime == null) return spec
+    const publishTime: unknown = (await opts.getPublishTimes(advisory.module_name))?.[minVersion.version]
+    // The time map comes from an untrusted registry response: only a string
+    // can carry a real timestamp; anything else is treated as unknown.
+    if (typeof publishTime !== 'string') return spec
     const publishedAt = new Date(publishTime).getTime()
     return Number.isNaN(publishedAt) || publishedAt > cutoff ? spec : undefined
   }))

--- a/pnpm11/deps/compliance/commands/src/audit/fixWithUpdate.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/fixWithUpdate.ts
@@ -93,7 +93,6 @@ export async function fixWithUpdate (auditReport: AuditReport, opts: FixWithUpda
 
   // Add minimum patched versions to minimumReleaseAgeExclude so the resolver
   // can install them even when minimumReleaseAge would otherwise block them.
-  // Versions already older than the cutoff don't need the bypass.
   const addedAgeExcludes = opts.minimumReleaseAge
     ? await createMinimumReleaseAgeExcludes(Object.values(auditReport.advisories), {
       getPublishTimes: createPublishTimesFetcher(opts),

--- a/pnpm11/deps/compliance/commands/src/audit/fixWithUpdate.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/fixWithUpdate.ts
@@ -15,6 +15,7 @@ import semver from 'semver'
 import type { AuditOptions } from './audit.js'
 import { createMinimumReleaseAgeExcludes } from './fix.js'
 import { lockfileToPackages } from './lockfileToPackages.js'
+import { createPublishTimesFetcher } from './publishTimes.js'
 
 interface ExtendedPackageVulnerability {
   vulnerability: PackageVulnerability
@@ -92,7 +93,13 @@ export async function fixWithUpdate (auditReport: AuditReport, opts: FixWithUpda
 
   // Add minimum patched versions to minimumReleaseAgeExclude so the resolver
   // can install them even when minimumReleaseAge would otherwise block them.
-  const addedAgeExcludes = opts.minimumReleaseAge ? createMinimumReleaseAgeExcludes(Object.values(auditReport.advisories)) : []
+  // Versions already older than the cutoff don't need the bypass.
+  const addedAgeExcludes = opts.minimumReleaseAge
+    ? await createMinimumReleaseAgeExcludes(Object.values(auditReport.advisories), {
+      getPublishTimes: createPublishTimesFetcher(opts),
+      minimumReleaseAge: opts.minimumReleaseAge,
+    })
+    : []
   const updateOpts = { ...opts } as Record<string, unknown>
   if (addedAgeExcludes.length > 0) {
     const existing = (updateOpts.minimumReleaseAgeExclude as string[] | undefined) ?? []

--- a/pnpm11/deps/compliance/commands/src/audit/publishTimes.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/publishTimes.ts
@@ -1,0 +1,59 @@
+import { pickRegistryForPackage } from '@pnpm/config.pick-registry-for-package'
+import { createGetAuthHeaderByURI } from '@pnpm/network.auth-header'
+import { createFetchFromRegistry } from '@pnpm/network.fetch'
+import npa from '@pnpm/npm-package-arg'
+
+import type { AuditOptions } from './audit.js'
+import { createAuditNetworkOptions } from './auditContext.js'
+
+/**
+ * Returns a memoized lookup of each package's publish-time map (the `time`
+ * field of its packument), so callers can tell whether a version is young
+ * enough that `minimumReleaseAge` would block it. `undefined` means the
+ * publish times are unknown — the request failed or the packument carries no
+ * `time` field; callers must treat that as "no information", not as "old".
+ */
+export function createPublishTimesFetcher (opts: AuditOptions): (pkgName: string) => Promise<Record<string, string> | undefined> {
+  const networkOptions = createAuditNetworkOptions(opts)
+  const getAuthHeader = createGetAuthHeaderByURI(opts.configByUri)
+  const fetchFromRegistry = createFetchFromRegistry({
+    ca: networkOptions.ca,
+    cert: networkOptions.cert,
+    httpProxy: networkOptions.httpProxy,
+    httpsProxy: networkOptions.httpsProxy,
+    key: networkOptions.key,
+    localAddress: networkOptions.localAddress,
+    maxSockets: networkOptions.maxSockets,
+    noProxy: networkOptions.noProxy,
+    strictSsl: networkOptions.strictSsl,
+    configByUri: opts.configByUri,
+  })
+  const timesByPkg = new Map<string, Promise<Record<string, string> | undefined>>()
+  return (pkgName) => {
+    let times = timesByPkg.get(pkgName)
+    if (times == null) {
+      times = fetchTimes(pkgName)
+      timesByPkg.set(pkgName, times)
+    }
+    return times
+  }
+
+  async function fetchTimes (pkgName: string): Promise<Record<string, string> | undefined> {
+    const registry = pickRegistryForPackage(opts.registries, pkgName)
+    const packageUrl = new URL(npa(pkgName).escapedName, registry.endsWith('/') ? registry : `${registry}/`).href
+    try {
+      const res = await fetchFromRegistry(packageUrl, {
+        authHeaderValue: getAuthHeader(registry),
+        retry: networkOptions.retry,
+        timeout: networkOptions.fetchTimeout,
+      })
+      if (!res.ok) return undefined
+      const body = await res.json() as { time?: Record<string, string> }
+      return body.time != null && typeof body.time === 'object' ? body.time : undefined
+    } catch {
+      // A failed lookup must not break the fix flow: the caller keeps its
+      // current behavior (the exclude entry) when the age is unknown.
+      return undefined
+    }
+  }
+}

--- a/pnpm11/deps/compliance/commands/src/audit/publishTimes.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/publishTimes.ts
@@ -39,11 +39,13 @@ export function createPublishTimesFetcher (opts: AuditOptions): (pkgName: string
   }
 
   async function fetchTimes (pkgName: string): Promise<Record<string, string> | undefined> {
-    const registry = pickRegistryForPackage(opts.registries, pkgName)
-    const packageUrl = new URL(npa(pkgName).escapedName, registry.endsWith('/') ? registry : `${registry}/`).href
     try {
+      const registry = pickRegistryForPackage(opts.registries, pkgName)
+      const packageUrl = new URL(npa(pkgName).escapedName, registry.endsWith('/') ? registry : `${registry}/`).href
+      // Full metadata: the abbreviated packument has no `time` field.
       const res = await fetchFromRegistry(packageUrl, {
-        authHeaderValue: getAuthHeader(registry),
+        authHeaderValue: getAuthHeader(registry, { pkgName }),
+        fullMetadata: true,
         retry: networkOptions.retry,
         timeout: networkOptions.fetchTimeout,
       })

--- a/pnpm11/deps/compliance/commands/src/audit/publishTimes.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/publishTimes.ts
@@ -51,7 +51,7 @@ export function createPublishTimesFetcher (opts: AuditOptions): (pkgName: string
       })
       if (!res.ok) return undefined
       const body = await res.json() as { time?: Record<string, string> }
-      return body.time != null && typeof body.time === 'object' ? body.time : undefined
+      return body.time != null && typeof body.time === 'object' && !Array.isArray(body.time) ? body.time as Record<string, string> : undefined
     } catch {
       // A failed lookup must not break the fix flow: the caller keeps its
       // current behavior (the exclude entry) when the age is unknown.

--- a/pnpm11/deps/compliance/commands/test/audit/fix.ts
+++ b/pnpm11/deps/compliance/commands/test/audit/fix.ts
@@ -53,6 +53,86 @@ test('overrides are added for vulnerable dependencies', async () => {
   expect(axiosExclude).toContain('0.21.2')
 })
 
+test('no minimumReleaseAgeExclude entries are added for patched versions published before the cutoff', async () => {
+  const tmp = f.prepare('has-vulnerabilities')
+
+  getMockAgent().get(AUDIT_REGISTRY.replace(/\/$/, ''))
+    .intercept({ path: '/-/npm/v1/security/advisories/bulk', method: 'POST' })
+    .reply(200, {
+      axios: [
+        {
+          id: 1,
+          title: 'vulnerability in axios',
+          severity: 'high',
+          vulnerable_versions: '<=0.18.0',
+          url: 'https://github.com/advisories/GHSA-mock-mock-mock',
+        },
+      ],
+    })
+  getMockAgent().get(AUDIT_REGISTRY.replace(/\/$/, ''))
+    .intercept({ path: '/axios', method: 'GET' })
+    .reply(200, {
+      name: 'axios',
+      time: { '0.18.1': '2020-01-01T00:00:00.000Z' },
+    })
+
+  const { exitCode, output } = await audit.handler({
+    ...AUDIT_REGISTRY_OPTS,
+    auditLevel: 'moderate',
+    minimumReleaseAge: 1440,
+    dir: tmp,
+    rootProjectManifestDir: tmp,
+    fix: true,
+  })
+
+  expect(exitCode).toBe(0)
+  expect(output).not.toContain('minimumReleaseAgeExclude')
+
+  const manifest = readYamlFileSync<{ overrides?: Record<string, string>, minimumReleaseAgeExclude?: string[] }>(path.join(tmp, 'pnpm-workspace.yaml'))
+  expect(manifest.overrides?.['axios@<=0.18.0']).toBe('^0.18.1')
+  expect(manifest.minimumReleaseAgeExclude).toBeUndefined()
+})
+
+test('minimumReleaseAgeExclude entries are added for patched versions published after the cutoff', async () => {
+  const tmp = f.prepare('has-vulnerabilities')
+
+  getMockAgent().get(AUDIT_REGISTRY.replace(/\/$/, ''))
+    .intercept({ path: '/-/npm/v1/security/advisories/bulk', method: 'POST' })
+    .reply(200, {
+      axios: [
+        {
+          id: 1,
+          title: 'vulnerability in axios',
+          severity: 'high',
+          vulnerable_versions: '<=0.18.0',
+          url: 'https://github.com/advisories/GHSA-mock-mock-mock',
+        },
+      ],
+    })
+  getMockAgent().get(AUDIT_REGISTRY.replace(/\/$/, ''))
+    .intercept({ path: '/axios', method: 'GET' })
+    .reply(200, {
+      name: 'axios',
+      time: { '0.18.1': new Date().toISOString() },
+    })
+
+  const { exitCode, output } = await audit.handler({
+    ...AUDIT_REGISTRY_OPTS,
+    auditLevel: 'moderate',
+    minimumReleaseAge: 1440,
+    dir: tmp,
+    rootProjectManifestDir: tmp,
+    fix: true,
+  })
+
+  expect(exitCode).toBe(0)
+  expect(output).toContain('entries were added to minimumReleaseAgeExclude')
+
+  const manifest = readYamlFileSync<{ overrides?: Record<string, string>, minimumReleaseAgeExclude?: string[] }>(path.join(tmp, 'pnpm-workspace.yaml'))
+  expect(manifest.overrides?.['axios@<=0.18.0']).toBe('^0.18.1')
+  expect(manifest.minimumReleaseAgeExclude).toEqual(['axios@0.18.1'])
+})
+
 test('no overrides are added if no vulnerabilities are found', async () => {
   const tmp = f.prepare('fixture')
 
@@ -146,52 +226,104 @@ function advisory (moduleName: string, vulnerableVersions: string, patchedVersio
 }
 
 describe('createMinimumReleaseAgeExcludes', () => {
-  test('combines multiple advisories for the same module into a single sorted entry', () => {
+  // The publish times are unknown: every entry is kept.
+  const unknownPublishTimes = async (): Promise<undefined> => undefined
+
+  test('combines multiple advisories for the same module into a single sorted entry', async () => {
     const advisories = [
       advisory('axios', '<0.21.2', '>=0.21.2'),
       advisory('axios', '<=0.18.0', '>=0.18.1'),
       advisory('axios', '<0.21.1', '>=0.21.1'),
     ]
-    const excludes = createMinimumReleaseAgeExcludes(advisories)
+    const excludes = await createMinimumReleaseAgeExcludes(advisories, {
+      getPublishTimes: unknownPublishTimes,
+      minimumReleaseAge: 1440,
+    })
     expect(excludes).toEqual(['axios@0.18.1 || 0.21.1 || 0.21.2'])
   })
 
-  test('keeps different modules as separate entries', () => {
+  test('keeps different modules as separate entries', async () => {
     const advisories = [
       advisory('axios', '<=0.18.0', '>=0.18.1'),
       advisory('lodash', '<4.17.21', '>=4.17.21'),
     ]
-    const excludes = createMinimumReleaseAgeExcludes(advisories)
+    const excludes = await createMinimumReleaseAgeExcludes(advisories, {
+      getPublishTimes: unknownPublishTimes,
+      minimumReleaseAge: 1440,
+    })
     expect(excludes).toEqual([
       'axios@0.18.1',
       'lodash@4.17.21',
     ])
   })
 
-  test('skips advisories without patched_versions', () => {
+  test('skips advisories without patched_versions', async () => {
     const advisories = [
       advisory('axios', '<=0.18.0', '>=0.18.1'),
       advisory('sync-exec', '>=0.0.0'),
     ]
-    const excludes = createMinimumReleaseAgeExcludes(advisories)
+    const excludes = await createMinimumReleaseAgeExcludes(advisories, {
+      getPublishTimes: unknownPublishTimes,
+      minimumReleaseAge: 1440,
+    })
     expect(excludes).toEqual(['axios@0.18.1'])
   })
 
-  test('returns empty array when no advisories are fixable', () => {
+  test('returns empty array when no advisories are fixable', async () => {
     const advisories = [
       advisory('sync-exec', '>=0.0.0'),
     ]
-    const excludes = createMinimumReleaseAgeExcludes(advisories)
+    const excludes = await createMinimumReleaseAgeExcludes(advisories, {
+      getPublishTimes: unknownPublishTimes,
+      minimumReleaseAge: 1440,
+    })
     expect(excludes).toEqual([])
   })
 
-  test('deduplicates the same minimum patched version for a module', () => {
+  test('deduplicates the same minimum patched version for a module', async () => {
     const advisories = [
       advisory('axios', '<=0.18.0', '>=0.18.1'),
       advisory('axios', '<=0.17.0', '>=0.18.1'),
     ]
-    const excludes = createMinimumReleaseAgeExcludes(advisories)
+    const excludes = await createMinimumReleaseAgeExcludes(advisories, {
+      getPublishTimes: unknownPublishTimes,
+      minimumReleaseAge: 1440,
+    })
     expect(excludes).toEqual(['axios@0.18.1'])
+  })
+
+  test('omits entries for patched versions published at or before the cutoff', async () => {
+    const advisories = [
+      advisory('axios', '<=0.18.0', '>=0.18.1'),
+      advisory('lodash', '<4.17.21', '>=4.17.21'),
+    ]
+    const publishTimes: Record<string, Record<string, string>> = {
+      axios: { '0.18.1': '2026-01-01T00:00:00.000Z' },
+      lodash: { '4.17.21': '2026-01-07T23:30:00.000Z' },
+    }
+    const excludes = await createMinimumReleaseAgeExcludes(advisories, {
+      getPublishTimes: async (pkgName) => publishTimes[pkgName],
+      minimumReleaseAge: 60,
+      now: new Date('2026-01-08T00:00:00.000Z').getTime(),
+    })
+    expect(excludes).toEqual(['lodash@4.17.21'])
+  })
+
+  test('keeps entries whose publish time is missing from the packument', async () => {
+    const advisories = [
+      advisory('axios', '<=0.18.0', '>=0.18.1'),
+      advisory('lodash', '<4.17.21', '>=4.17.21'),
+    ]
+    const publishTimes: Record<string, Record<string, string>> = {
+      axios: { '0.18.1': '2026-01-01T00:00:00.000Z' },
+      lodash: {},
+    }
+    const excludes = await createMinimumReleaseAgeExcludes(advisories, {
+      getPublishTimes: async (pkgName) => publishTimes[pkgName],
+      minimumReleaseAge: 60,
+      now: new Date('2026-01-08T00:00:00.000Z').getTime(),
+    })
+    expect(excludes).toEqual(['lodash@4.17.21'])
   })
 })
 

--- a/pnpm11/deps/compliance/commands/test/audit/fix.ts
+++ b/pnpm11/deps/compliance/commands/test/audit/fix.ts
@@ -325,6 +325,36 @@ describe('createMinimumReleaseAgeExcludes', () => {
     })
     expect(excludes).toEqual(['lodash@4.17.21'])
   })
+
+  test('omits entries for patched versions published exactly at the cutoff', async () => {
+    const advisories = [
+      advisory('axios', '<=0.18.0', '>=0.18.1'),
+    ]
+    const excludes = await createMinimumReleaseAgeExcludes(advisories, {
+      getPublishTimes: async () => ({ '0.18.1': '2026-01-07T23:00:00.000Z' }),
+      minimumReleaseAge: 60,
+      now: new Date('2026-01-08T00:00:00.000Z').getTime(),
+    })
+    expect(excludes).toEqual([])
+  })
+
+  test('keeps entries whose publish time is not a valid date string', async () => {
+    const advisories = [
+      advisory('axios', '<=0.18.0', '>=0.18.1'),
+      advisory('lodash', '<4.17.21', '>=4.17.21'),
+    ]
+    const publishTimes: Record<string, Record<string, string>> = {
+      axios: { '0.18.1': 'not-a-date' },
+      // A non-string value smuggled past the registry response type.
+      lodash: { '4.17.21': 0 as unknown as string },
+    }
+    const excludes = await createMinimumReleaseAgeExcludes(advisories, {
+      getPublishTimes: async (pkgName) => publishTimes[pkgName],
+      minimumReleaseAge: 60,
+      now: new Date('2026-01-08T00:00:00.000Z').getTime(),
+    })
+    expect(excludes).toEqual(['axios@0.18.1', 'lodash@4.17.21'])
+  })
 })
 
 describe('caretRangeForPatched', () => {

--- a/pnpm11/deps/compliance/commands/test/audit/fixWithUpdate.ts
+++ b/pnpm11/deps/compliance/commands/test/audit/fixWithUpdate.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs'
 import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, test } from '@jest/globals'
@@ -84,6 +85,41 @@ The fixed vulnerabilities are:
       if (pkgId === originalPkgId) continue
       expect(packagesArray).toContain(pkgId)
     }
+  })
+
+  test('patched versions older than the minimumReleaseAge cutoff are fixed without minimumReleaseAgeExclude entries', async () => {
+    const tmp = f.prepare('update-single-depth-2')
+
+    const expectedPkgId = '@pnpm.e2e/pkg-with-1-dep@100.1.0' as DepPath
+
+    const mockResponse = await loadJsonFile<Record<string, unknown[]>>(join(tmp, 'responses', 'top-level-vulnerability.json'))
+
+    getMockAgent().get(MOCK_REGISTRY)
+      .intercept({ path: '/-/npm/v1/security/advisories/bulk', method: 'POST' })
+      .reply(200, mockResponse)
+
+    const { exitCode, output } = await audit.handler({
+      ...MOCK_REGISTRY_OPTS,
+      dir: tmp,
+      rootProjectManifestDir: tmp,
+      auditLevel: 'moderate',
+      fix: 'update',
+      lockfileOnly: true,
+      // Every version on the mock registry was published in 2022, so the
+      // patched version is way older than the cutoff and needs no bypass.
+      minimumReleaseAge: 60 * 24,
+    })
+
+    expect(exitCode).toBe(0)
+    expect(output).toContain(`${chalk.green(1)} vulnerability was fixed`)
+    expect(output).not.toContain('minimumReleaseAgeExclude')
+
+    // No entries were needed, so no settings file is created.
+    expect(fs.existsSync(join(tmp, 'pnpm-workspace.yaml'))).toBe(false)
+
+    const lockfile = await readWantedLockfile(tmp, { ignoreIncompatible: true })
+    expect(lockfile).toBeTruthy()
+    expect(Object.keys(lockfile!.packages!)).toContain(expectedPkgId)
   })
 
   test('top-level pinned vulnerability is fixed by updating the vulnerable package', async () => {

--- a/pnpm11/deps/compliance/commands/tsconfig.json
+++ b/pnpm11/deps/compliance/commands/tsconfig.json
@@ -71,6 +71,9 @@
       "path": "../../../network/auth-header"
     },
     {
+      "path": "../../../network/fetch"
+    },
+    {
       "path": "../../../object/key-sorting"
     },
     {


### PR DESCRIPTION


<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary
fix #11563
<!-- Describe what this PR changes and why, for reviewers. Link any related
issues here (Closes pnpm/pnpm#123, Fixes pnpm/pnpm#456, or Related to
pnpm/pnpm#123 for a partial fix). -->

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
`pnpm audit --fix` and `pnpm audit --fix update` no longer add `minimumReleaseAgeExclude` entries for patched versions that were published before the `minimumReleaseAge` cutoff. The publish time of each minimum patched version is now checked against the registry metadata, and only versions young enough to be blocked by the age gate get an exclusion entry
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [ ] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [ ] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [ ] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [ ] Added or updated tests.
- [ ] Updated the documentation if needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788602938&installation_model_id=426870&pr_number=13678&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13678&signature=77d13d4fd835b99e15409bee7a37557e8ad6773679b9650942a64febe052ad77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Audit fixes now add `minimumReleaseAgeExclude` entries only when patched versions were published within the configured age window.
  * Older patched versions can be selected normally without unnecessary exclusions.
  * Missing, invalid, or unavailable publication data continues to receive safe exclusions.
  * Override and update-based audit fixes now apply this behavior consistently.
  * Duplicate package metadata requests are avoided when processing multiple advisories.
* **Documentation**
  * Added release notes describing the corrected audit-fix behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->