### PR TITLE
perf(lockfile): apply patchedDependencies changes without resolving

### DIFF
--- a/.changeset/inert-patched-dependencies-updates.md
+++ b/.changeset/inert-patched-dependencies-updates.md
@@ -1,8 +1,8 @@
 ---
-"@pnpm/installing.deps-installer": minor
+"@pnpm/installing.deps-installer": patch
 "@pnpm/patching.config": minor
 "pacquet": patch
-"pnpm": minor
+"pnpm": patch
 ---
 
 Changing `patchedDependencies` no longer re-resolves the dependency graph when the change targets no package the lockfile records. A patch that matches a locked package still goes through a full resolution, because applying it rekeys that package's entry. The install falls back to a full resolution whenever the new configuration would leave a patch unused and `allowUnusedPatches` is off, so `ERR_PNPM_UNUSED_PATCH` is still reported.

--- a/.changeset/inert-patched-dependencies-updates.md
+++ b/.changeset/inert-patched-dependencies-updates.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/installing.deps-installer": minor
+"@pnpm/patching.config": minor
+"pacquet": patch
+"pnpm": minor
+---
+
+Changing `patchedDependencies` no longer re-resolves the dependency graph when the change targets no package the lockfile records. A patch that matches a locked package still goes through a full resolution, because applying it rekeys that package's entry. The install falls back to a full resolution whenever the new configuration would leave a patch unused and `allowUnusedPatches` is off, so `ERR_PNPM_UNUSED_PATCH` is still reported.

--- a/.changeset/inert-patched-dependencies-updates.md
+++ b/.changeset/inert-patched-dependencies-updates.md
@@ -5,4 +5,4 @@
 "pnpm": patch
 ---
 
-Changing `patchedDependencies` no longer re-resolves the dependency graph when the change targets no package the lockfile records. A patch that matches a locked package still goes through a full resolution, because applying it rekeys that package's entry. The install falls back to a full resolution whenever the new configuration would leave a patch unused and `allowUnusedPatches` is off, so `ERR_PNPM_UNUSED_PATCH` is still reported.
+Adding, editing, or removing an entry in `patchedDependencies` no longer re-resolves the dependency graph. Resolution never reads a patch — it only records the patch file's hash against the package it matches — so the install now rewrites the affected entries in `pnpm-lock.yaml` and materializes the patched package from the store instead. Installs still fall back to a full resolution when the patched package is reachable as a peer dependency, and when the new configuration would leave a patch unused while `allowUnusedPatches` is off, so `ERR_PNPM_UNUSED_PATCH` is still reported.

--- a/pnpm/crates/cli/tests/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/lockfile_resolution_reuse.rs
@@ -815,3 +815,91 @@ fn peer_setting_change_falls_back_when_the_lockfile_records_peers() {
 
     drop((root, mock_instance));
 }
+
+#[test]
+fn an_unused_patch_is_recorded_without_resolution_and_a_used_one_is_not() {
+    let CommandTempCwd { workspace, root, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, npmrc_path, .. } = npmrc_info;
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pkg-with-1-dep": "100.0.0"
+            }
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    fs::create_dir_all(workspace.join("patches")).expect("create patches dir");
+    fs::write(workspace.join("patches").join("absent.patch"), "--- a\n+++ b\n")
+        .expect("write patch for a package nobody depends on");
+    let workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    fs::write(
+        &workspace_yaml_path,
+        format!("{workspace_yaml}trustLockfile: true\nallowUnusedPatches: true\n"),
+    )
+    .expect("enable trusted lockfile");
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    let workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    fs::write(
+        &workspace_yaml_path,
+        format!(
+            "{workspace_yaml}patchedDependencies:\n  absent-package@1.0.0: patches/absent.patch\n"
+        ),
+    )
+    .expect("patch a package the lockfile does not record");
+    let dead_registry = dead_registry_url();
+    let live_npmrc = fs::read_to_string(&npmrc_path).expect("read .npmrc");
+    let dead_npmrc = live_npmrc
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("registry="))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(&npmrc_path, format!("registry={dead_registry}\n{dead_npmrc}\n"))
+        .expect("rewrite .npmrc with a dead registry");
+
+    let assert = pacquet_at(&workspace).with_arg("install").assert().success();
+    assert!(
+        String::from_utf8_lossy(&assert.get_output().stdout)
+            .contains("Lockfile is up to date, resolution step is skipped"),
+        "a patch matching no locked package must not trigger resolution",
+    );
+    let wanted = pacquet_lockfile::Lockfile::load_wanted_from_dir(&workspace)
+        .expect("load updated wanted lockfile")
+        .expect("updated wanted lockfile");
+    assert_eq!(
+        wanted.patched_dependencies.as_ref().map(|map| map.keys().collect::<Vec<_>>()),
+        Some(vec![&"absent-package@1.0.0".to_string()]),
+        "the new patchedDependencies entry is still recorded",
+    );
+
+    // Patching a package the lockfile does record has to rekey its
+    // snapshot, so the live registry goes back before this install.
+    fs::write(&npmrc_path, live_npmrc).expect("restore the live registry");
+    fs::write(workspace.join("patches").join("dep.patch"), "--- a/index.js\n+++ b/index.js\n")
+        .expect("write patch for a locked package");
+    let workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    fs::write(
+        &workspace_yaml_path,
+        workspace_yaml.replace(
+            "  absent-package@1.0.0: patches/absent.patch\n",
+            "  absent-package@1.0.0: patches/absent.patch\n  '@pnpm.e2e/pkg-with-1-dep@100.0.0': patches/dep.patch\n",
+        ),
+    )
+    .expect("patch a locked package");
+
+    let assert = pacquet_at(&workspace).with_arg("install").assert();
+    assert!(
+        !String::from_utf8_lossy(&assert.get_output().stdout)
+            .contains("Lockfile is up to date, resolution step is skipped"),
+        "patching a locked package must go through resolution",
+    );
+
+    drop((root, mock_instance));
+}

--- a/pnpm/crates/cli/tests/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/lockfile_resolution_reuse.rs
@@ -12,6 +12,10 @@ use command_extra::CommandExtra;
 use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
 use std::{fs, net::TcpListener, path::Path, process::Command};
 
+const IS_POSITIVE_PATCH: &str = include_str!(
+    "../../../../pnpm11/installing/deps-installer/test/fixtures/patch-pkg/is-positive@1.0.0.patch"
+);
+
 fn pacquet_at(workspace: &Path) -> Command {
     Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
 }
@@ -826,15 +830,15 @@ fn an_unused_patch_is_recorded_without_resolution_and_a_used_one_is_not() {
         workspace.join("package.json"),
         serde_json::json!({
             "dependencies": {
-                "@pnpm.e2e/pkg-with-1-dep": "100.0.0"
+                "is-positive": "1.0.0"
             }
         })
         .to_string(),
     )
     .expect("write package.json");
     fs::create_dir_all(workspace.join("patches")).expect("create patches dir");
-    fs::write(workspace.join("patches").join("absent.patch"), "--- a\n+++ b\n")
-        .expect("write patch for a package nobody depends on");
+    fs::write(workspace.join("patches").join("is-positive@1.0.0.patch"), IS_POSITIVE_PATCH)
+        .expect("write the patch fixture");
     let workspace_yaml =
         fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
     fs::write(
@@ -844,12 +848,13 @@ fn an_unused_patch_is_recorded_without_resolution_and_a_used_one_is_not() {
     .expect("enable trusted lockfile");
     pacquet_at(&workspace).with_arg("install").assert().success();
 
+    // A key naming a package no importer depends on cannot rekey anything.
     let workspace_yaml =
         fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
     fs::write(
         &workspace_yaml_path,
         format!(
-            "{workspace_yaml}patchedDependencies:\n  absent-package@1.0.0: patches/absent.patch\n",
+            "{workspace_yaml}patchedDependencies:\n  absent-package@1.0.0: patches/is-positive@1.0.0.patch\n",
         ),
     )
     .expect("patch a package the lockfile does not record");
@@ -881,24 +886,31 @@ fn an_unused_patch_is_recorded_without_resolution_and_a_used_one_is_not() {
     // Patching a package the lockfile does record has to rekey its
     // snapshot, so the live registry goes back before this install.
     fs::write(&npmrc_path, live_npmrc).expect("restore the live registry");
-    fs::write(workspace.join("patches").join("dep.patch"), "--- a/index.js\n+++ b/index.js\n")
-        .expect("write patch for a locked package");
     let workspace_yaml =
         fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
     fs::write(
         &workspace_yaml_path,
         workspace_yaml.replace(
-            "  absent-package@1.0.0: patches/absent.patch\n",
-            "  absent-package@1.0.0: patches/absent.patch\n  '@pnpm.e2e/pkg-with-1-dep@100.0.0': patches/dep.patch\n",
+            "  absent-package@1.0.0: patches/is-positive@1.0.0.patch\n",
+            "  is-positive@1.0.0: patches/is-positive@1.0.0.patch\n",
         ),
     )
     .expect("patch a locked package");
 
-    let assert = pacquet_at(&workspace).with_arg("install").assert();
+    let assert = pacquet_at(&workspace).with_arg("install").assert().success();
     assert!(
         !String::from_utf8_lossy(&assert.get_output().stdout)
             .contains("Lockfile is up to date, resolution step is skipped"),
         "patching a locked package must go through resolution",
+    );
+    let wanted = pacquet_lockfile::Lockfile::load_wanted_from_dir(&workspace)
+        .expect("load updated wanted lockfile")
+        .expect("updated wanted lockfile");
+    assert!(
+        wanted.snapshots.is_some_and(|snapshots| {
+            snapshots.keys().any(|key| key.to_string().contains("patch_hash="))
+        }),
+        "the resolve rekeys the patched package",
     );
 
     drop((root, mock_instance));

--- a/pnpm/crates/cli/tests/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/lockfile_resolution_reuse.rs
@@ -847,6 +847,17 @@ fn an_unused_patch_is_recorded_without_resolution_and_a_used_one_is_not() {
     )
     .expect("enable trusted lockfile");
     pacquet_at(&workspace).with_arg("install").assert().success();
+    assert!(!installed_is_positive(&workspace).contains("// patched"));
+
+    let dead_registry = dead_registry_url();
+    let live_npmrc = fs::read_to_string(&npmrc_path).expect("read .npmrc");
+    let dead_npmrc = live_npmrc
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("registry="))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(&npmrc_path, format!("registry={dead_registry}\n{dead_npmrc}\n"))
+        .expect("rewrite .npmrc with a dead registry");
 
     // A key naming a package no importer depends on cannot rekey anything.
     let workspace_yaml =
@@ -858,15 +869,6 @@ fn an_unused_patch_is_recorded_without_resolution_and_a_used_one_is_not() {
         ),
     )
     .expect("patch a package the lockfile does not record");
-    let dead_registry = dead_registry_url();
-    let live_npmrc = fs::read_to_string(&npmrc_path).expect("read .npmrc");
-    let dead_npmrc = live_npmrc
-        .lines()
-        .filter(|line| !line.trim_start().starts_with("registry="))
-        .collect::<Vec<_>>()
-        .join("\n");
-    fs::write(&npmrc_path, format!("registry={dead_registry}\n{dead_npmrc}\n"))
-        .expect("rewrite .npmrc with a dead registry");
 
     let assert = pacquet_at(&workspace).with_arg("install").assert().success();
     assert!(
@@ -874,18 +876,15 @@ fn an_unused_patch_is_recorded_without_resolution_and_a_used_one_is_not() {
             .contains("Lockfile is up to date, resolution step is skipped"),
         "a patch matching no locked package must not trigger resolution",
     );
-    let wanted = pacquet_lockfile::Lockfile::load_wanted_from_dir(&workspace)
-        .expect("load updated wanted lockfile")
-        .expect("updated wanted lockfile");
     assert_eq!(
-        wanted.patched_dependencies.as_ref().map(|map| map.keys().collect::<Vec<_>>()),
-        Some(vec![&"absent-package@1.0.0".to_string()]),
+        patched_dependency_keys(&workspace),
+        vec!["absent-package@1.0.0".to_string()],
         "the new patchedDependencies entry is still recorded",
     );
 
-    // Patching a package the lockfile does record has to rekey its
-    // snapshot, so the live registry goes back before this install.
-    fs::write(&npmrc_path, live_npmrc).expect("restore the live registry");
+    // Patching a locked package renames its snapshot, which the rewrite
+    // does without asking the registry anything — the tarball it patches
+    // is already in the store.
     let workspace_yaml =
         fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
     fs::write(
@@ -899,19 +898,64 @@ fn an_unused_patch_is_recorded_without_resolution_and_a_used_one_is_not() {
 
     let assert = pacquet_at(&workspace).with_arg("install").assert().success();
     assert!(
-        !String::from_utf8_lossy(&assert.get_output().stdout)
+        String::from_utf8_lossy(&assert.get_output().stdout)
             .contains("Lockfile is up to date, resolution step is skipped"),
-        "patching a locked package must go through resolution",
+        "patching a locked package only renames its snapshot, so no resolution is needed",
     );
     let wanted = pacquet_lockfile::Lockfile::load_wanted_from_dir(&workspace)
         .expect("load updated wanted lockfile")
         .expect("updated wanted lockfile");
     assert!(
-        wanted.snapshots.is_some_and(|snapshots| {
-            snapshots.keys().any(|key| key.to_string().contains("patch_hash="))
-        }),
-        "the resolve rekeys the patched package",
+        wanted
+            .snapshots
+            .as_ref()
+            .expect("snapshots")
+            .keys()
+            .any(|key| key.to_string().starts_with("is-positive@1.0.0(patch_hash=")),
+        "the patched package's snapshot key carries the patch hash",
+    );
+    assert!(
+        installed_is_positive(&workspace).contains("// patched"),
+        "the rewrite still materializes the patched package",
+    );
+
+    // Dropping the patch renames the snapshot back and restores the
+    // unpatched package, again without resolving.
+    let workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    fs::write(
+        &workspace_yaml_path,
+        workspace_yaml.replace(
+            "patchedDependencies:\n  is-positive@1.0.0: patches/is-positive@1.0.0.patch\n",
+            "",
+        ),
+    )
+    .expect("drop the patch");
+
+    let assert = pacquet_at(&workspace).with_arg("install").assert().success();
+    assert!(
+        String::from_utf8_lossy(&assert.get_output().stdout)
+            .contains("Lockfile is up to date, resolution step is skipped"),
+        "dropping a patch renames the snapshot back without resolving",
+    );
+    assert!(
+        !installed_is_positive(&workspace).contains("// patched"),
+        "the unpatched package is materialized again",
     );
 
     drop((root, mock_instance));
+}
+
+fn installed_is_positive(workspace: &Path) -> String {
+    fs::read_to_string(workspace.join("node_modules").join("is-positive").join("index.js"))
+        .expect("read the installed is-positive")
+}
+
+fn patched_dependency_keys(workspace: &Path) -> Vec<String> {
+    pacquet_lockfile::Lockfile::load_wanted_from_dir(workspace)
+        .expect("load updated wanted lockfile")
+        .expect("updated wanted lockfile")
+        .patched_dependencies
+        .map(|map| map.keys().cloned().collect())
+        .unwrap_or_default()
 }

--- a/pnpm/crates/cli/tests/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/lockfile_resolution_reuse.rs
@@ -959,3 +959,92 @@ fn patched_dependency_keys(workspace: &Path) -> Vec<String> {
         .map(|map| map.keys().cloned().collect())
         .unwrap_or_default()
 }
+
+#[test]
+fn patching_a_package_with_an_install_script_rebuilds_it() {
+    let CommandTempCwd { workspace, root, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, npmrc_path, .. } = npmrc_info;
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/install-script-example": "1.0.0"
+            }
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    fs::create_dir_all(workspace.join("patches")).expect("create patches dir");
+    let workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    fs::write(
+        &workspace_yaml_path,
+        format!(
+            "{workspace_yaml}trustLockfile: true\nstrictDepBuilds: false\nallowBuilds:\n  '@pnpm.e2e/install-script-example': true\n",
+        ),
+    )
+    .expect("allow the install script");
+    pacquet_at(&workspace).with_arg("install").assert().success();
+    assert_eq!(generated_by_install(&workspace), "module.exports = function () {}\n");
+
+    fs::write(
+        workspace.join("patches").join("install-script-example.patch"),
+        concat!(
+            "diff --git a/create.js b/create.js\n",
+            "--- a/create.js\n",
+            "+++ b/create.js\n",
+            "@@ -1,4 +1,4 @@\n",
+            " 'use strict'\n",
+            " const fs = require('fs')\n",
+            " \n",
+            "-fs.writeFileSync(process.argv[2] + '.js', 'module.exports = function () {}\\n', 'utf8')\n",
+            "+fs.writeFileSync(process.argv[2] + '.js', 'patched\\n', 'utf8')\n",
+        ),
+    )
+    .expect("write the patch");
+    let dead_registry = dead_registry_url();
+    let live_npmrc = fs::read_to_string(&npmrc_path).expect("read .npmrc");
+    let dead_npmrc = live_npmrc
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("registry="))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(&npmrc_path, format!("registry={dead_registry}\n{dead_npmrc}\n"))
+        .expect("rewrite .npmrc with a dead registry");
+    let workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    fs::write(
+        &workspace_yaml_path,
+        format!(
+            "{workspace_yaml}patchedDependencies:\n  '@pnpm.e2e/install-script-example@1.0.0': patches/install-script-example.patch\n",
+        ),
+    )
+    .expect("patch the package");
+
+    let assert = pacquet_at(&workspace).with_arg("install").assert().success();
+    assert!(
+        String::from_utf8_lossy(&assert.get_output().stdout)
+            .contains("Lockfile is up to date, resolution step is skipped"),
+        "the rekey needs no resolution",
+    );
+    assert_eq!(
+        generated_by_install(&workspace),
+        "patched\n",
+        "the install script reran against the patched sources",
+    );
+
+    drop((root, mock_instance));
+}
+
+fn generated_by_install(workspace: &Path) -> String {
+    fs::read_to_string(
+        workspace
+            .join("node_modules")
+            .join("@pnpm.e2e")
+            .join("install-script-example")
+            .join("generated-by-install.js"),
+    )
+    .expect("read the file the install script generates")
+}

--- a/pnpm/crates/cli/tests/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/lockfile_resolution_reuse.rs
@@ -849,7 +849,7 @@ fn an_unused_patch_is_recorded_without_resolution_and_a_used_one_is_not() {
     fs::write(
         &workspace_yaml_path,
         format!(
-            "{workspace_yaml}patchedDependencies:\n  absent-package@1.0.0: patches/absent.patch\n"
+            "{workspace_yaml}patchedDependencies:\n  absent-package@1.0.0: patches/absent.patch\n",
         ),
     )
     .expect("patch a package the lockfile does not record");

--- a/pnpm/crates/package-manager/src/fast_update_patched_dependencies.rs
+++ b/pnpm/crates/package-manager/src/fast_update_patched_dependencies.rs
@@ -1,0 +1,93 @@
+use pacquet_config::Config;
+use pacquet_lockfile::Lockfile;
+use pacquet_patching::{PatchGroupRecord, all_patch_keys, get_patch_info};
+use std::collections::{BTreeMap, BTreeSet};
+
+/// Record a changed `patchedDependencies` without resolving the
+/// dependency graph, for the changes that touch no package the lockfile
+/// records.
+///
+/// A patch that matches a locked package contributes a
+/// `(patch_hash=...)` segment to that package's key, so adding,
+/// removing, or editing such a patch rekeys the graph and has to go
+/// through the resolver. A patch key that matches nothing contributes
+/// nothing, which makes the recorded map the only thing that changes.
+///
+/// `None` — nothing changed, a changed key matches a locked package, or
+/// the new configuration leaves a patch unused while
+/// `allowUnusedPatches` is off — leaves the caller on the
+/// full-resolution path, which is where `ERR_PNPM_UNUSED_PATCH` is
+/// raised.
+///
+/// A patch file that cannot be read or hashed also falls back, so the
+/// resolver reports it rather than this path swallowing the error.
+pub(crate) fn try_fast_update_patched_dependencies(
+    lockfile: &Lockfile,
+    config: &Config,
+) -> Option<Lockfile> {
+    let empty = BTreeMap::new();
+    let hashes = config.patched_dependency_hashes().ok()?;
+    let recorded = lockfile.patched_dependencies.as_ref().unwrap_or(&empty);
+    let current = hashes.as_ref().unwrap_or(&empty);
+    if recorded == current {
+        return None;
+    }
+
+    // Grouping re-reads the patch files, so it waits until the cheap
+    // map comparison above has proven there is drift to absorb.
+    let patch_groups = config.resolved_patched_dependencies().ok()?;
+    let applied = applied_patch_keys(lockfile, patch_groups.as_ref())?;
+    let mut affected = recorded
+        .iter()
+        .filter(|(key, hash)| current.get(*key) != Some(hash))
+        .chain(current.iter().filter(|(key, hash)| recorded.get(*key) != Some(hash)))
+        .map(|(key, _)| key.as_str());
+    if affected.any(|key| applied.contains(key)) {
+        return None;
+    }
+    if !config.allow_unused_patches
+        && patch_groups
+            .as_ref()
+            .into_iter()
+            .flat_map(all_patch_keys)
+            .any(|key| !applied.contains(key))
+    {
+        return None;
+    }
+
+    let mut candidate = lockfile.clone();
+    candidate.patched_dependencies = (!current.is_empty()).then(|| current.clone());
+    Some(candidate)
+}
+
+/// The configured patch keys that match a package the lockfile records,
+/// matched the way the resolver matches them.
+///
+/// `None` when a locked package matches more than one configured range,
+/// so the caller falls back and lets the resolver raise
+/// `ERR_PNPM_PATCH_KEY_CONFLICT` instead of quietly picking a winner.
+fn applied_patch_keys<'a>(
+    lockfile: &Lockfile,
+    patch_groups: Option<&'a PatchGroupRecord>,
+) -> Option<BTreeSet<&'a str>> {
+    let (Some(groups), Some(snapshots)) = (patch_groups, lockfile.snapshots.as_ref()) else {
+        return Some(BTreeSet::new());
+    };
+    let mut applied = BTreeSet::new();
+    for key in snapshots.keys() {
+        // Keyed exactly as `resolve_snapshot_patches` keys the patches it
+        // applies from a loaded lockfile, so this agrees with what the
+        // materializer would do. The peer suffix carries any
+        // `(patch_hash=...)` segment too, so stripping it leaves the
+        // `name@version` the patch keys match on.
+        let metadata_key = key.without_peer().to_string();
+        let (name, version) = pacquet_deps_restorer::parse_name_version_from_key(&metadata_key);
+        if let Some(info) = get_patch_info(Some(groups), &name, &version).ok()? {
+            applied.insert(info.key.as_str());
+        }
+    }
+    Some(applied)
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/package-manager/src/fast_update_patched_dependencies.rs
+++ b/pnpm/crates/package-manager/src/fast_update_patched_dependencies.rs
@@ -1,6 +1,8 @@
 use pacquet_config::Config;
 use pacquet_lockfile::Lockfile;
-use pacquet_patching::{PatchGroupRecord, all_patch_keys, get_patch_info};
+use pacquet_patching::{
+    PatchGroupRecord, PatchInput, all_patch_keys, get_patch_info, group_patched_dependencies,
+};
 use std::collections::{BTreeMap, BTreeSet};
 
 /// Record a changed `patchedDependencies` without resolving the
@@ -33,26 +35,25 @@ pub(crate) fn try_fast_update_patched_dependencies(
         return None;
     }
 
-    // Grouping re-reads the patch files, so it waits until the cheap
-    // map comparison above has proven there is drift to absorb.
-    let patch_groups = config.resolved_patched_dependencies().ok()?;
-    let applied = applied_patch_keys(lockfile, patch_groups.as_ref())?;
-    let mut affected = recorded
-        .iter()
-        .filter(|(key, hash)| current.get(*key) != Some(hash))
-        .chain(current.iter().filter(|(key, hash)| recorded.get(*key) != Some(hash)))
-        .map(|(key, _)| key.as_str());
-    if affected.any(|key| applied.contains(key)) {
+    // Every key whose presence or hash differs, taken from the recorded
+    // map as well as the current one. A key the previous install applied
+    // still owns a `(patch_hash=...)` segment in the recorded graph, so
+    // dropping it rekeys that package just as adding it did.
+    let affected = recorded
+        .keys()
+        .chain(current.keys())
+        .filter(|key| recorded.get(*key) != current.get(*key))
+        .cloned();
+    if !applied_patch_keys(lockfile, &groups_from_keys(affected)?)?.is_empty() {
         return None;
     }
-    if !config.allow_unused_patches
-        && patch_groups
-            .as_ref()
-            .into_iter()
-            .flat_map(all_patch_keys)
-            .any(|key| !applied.contains(key))
-    {
-        return None;
+
+    if !config.allow_unused_patches {
+        let current_groups = groups_from_keys(current.keys().cloned())?;
+        let applied = applied_patch_keys(lockfile, &current_groups)?;
+        if all_patch_keys(&current_groups).any(|key| !applied.contains(key)) {
+            return None;
+        }
     }
 
     let mut candidate = lockfile.clone();
@@ -60,17 +61,33 @@ pub(crate) fn try_fast_update_patched_dependencies(
     Some(candidate)
 }
 
-/// The configured patch keys that match a package the lockfile records,
-/// matched the way the resolver matches them.
+/// Bucket `keys` the way the resolver buckets configured patches.
+///
+/// Only the key decides what a patch matches, so this deliberately
+/// leaves the payload empty rather than re-reading the patch files that
+/// [`Config::patched_dependency_hashes`] has already hashed.
+///
+/// `None` for a key whose version segment is neither a version nor a
+/// range, leaving `ERR_PNPM_PATCH_NON_SEMVER_RANGE` to the resolver.
+fn groups_from_keys(keys: impl IntoIterator<Item = String>) -> Option<PatchGroupRecord> {
+    group_patched_dependencies(
+        keys.into_iter()
+            .map(|key| (key, PatchInput { hash: String::new(), patch_file_path: None })),
+    )
+    .ok()
+}
+
+/// The patch keys in `patch_groups` that match a package the lockfile
+/// records, matched the way the resolver matches them.
 ///
 /// `None` when a locked package matches more than one configured range,
 /// so the caller falls back and lets the resolver raise
 /// `ERR_PNPM_PATCH_KEY_CONFLICT` instead of quietly picking a winner.
 fn applied_patch_keys<'a>(
     lockfile: &Lockfile,
-    patch_groups: Option<&'a PatchGroupRecord>,
+    patch_groups: &'a PatchGroupRecord,
 ) -> Option<BTreeSet<&'a str>> {
-    let (Some(groups), Some(snapshots)) = (patch_groups, lockfile.snapshots.as_ref()) else {
+    let Some(snapshots) = lockfile.snapshots.as_ref() else {
         return Some(BTreeSet::new());
     };
     let mut applied = BTreeSet::new();
@@ -82,7 +99,7 @@ fn applied_patch_keys<'a>(
         // `name@version` the patch keys match on.
         let metadata_key = key.without_peer().to_string();
         let (name, version) = pacquet_deps_restorer::parse_name_version_from_key(&metadata_key);
-        if let Some(info) = get_patch_info(Some(groups), &name, &version).ok()? {
+        if let Some(info) = get_patch_info(Some(patch_groups), &name, &version).ok()? {
             applied.insert(info.key.as_str());
         }
     }

--- a/pnpm/crates/package-manager/src/fast_update_patched_dependencies.rs
+++ b/pnpm/crates/package-manager/src/fast_update_patched_dependencies.rs
@@ -73,11 +73,28 @@ fn plan_rekeys(lockfile: &Lockfile, groups: &PatchGroupRecord) -> Option<Rekeys>
     let mut rekeys = Rekeys::new();
     for key in snapshots.keys() {
         let rendered = key.to_string();
+        let suffix = index_of_dep_path_suffix(&rendered);
         let base = remove_suffix(&rendered);
-        let peers =
-            index_of_dep_path_suffix(&rendered).peers_index.map_or("", |index| &rendered[index..]);
+        let peers = suffix.peers_index.map_or("", |index| &rendered[index..]);
         let (name, version) = pacquet_deps_restorer::parse_name_version_from_key(base);
-        let segment = match get_patch_info(Some(groups), &name, &version).ok()? {
+        let patch = get_patch_info(Some(groups), &name, &version).ok()?;
+        // The resolver matches patches against a package's plain semver
+        // version, while this reads the version out of the key, where a
+        // named registry (`name@registry:version`) or a git / tarball
+        // reference occupies the same slot. The two only agree on plain
+        // semver, so anything else is left to the resolver rather than
+        // guessed at — as long as it needs no rekey at all.
+        if key.suffix.version_semver().is_none() {
+            // Matching cannot be reproduced here, so the question is only
+            // whether it could matter: any configured patch naming this
+            // package, or a patch hash already on the key, hands the
+            // decision back to the resolver.
+            if groups.contains_key(name.as_str()) || suffix.patch_hash_index.is_some() {
+                return None;
+            }
+            continue;
+        }
+        let segment = match patch {
             Some(patch) => format!("(patch_hash={})", patch.hash),
             None => String::new(),
         };

--- a/pnpm/crates/package-manager/src/fast_update_patched_dependencies.rs
+++ b/pnpm/crates/package-manager/src/fast_update_patched_dependencies.rs
@@ -1,22 +1,29 @@
 use pacquet_config::Config;
-use pacquet_lockfile::Lockfile;
+use pacquet_deps_path::{index_of_dep_path_suffix, remove_suffix};
+use pacquet_lockfile::{
+    ImporterDepVersion, Lockfile, PackageKey, ProjectSnapshot, ResolvedDependencyMap,
+    SnapshotDepRef,
+};
 use pacquet_patching::{
     PatchGroupRecord, PatchInput, all_patch_keys, get_patch_info, group_patched_dependencies,
 };
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
-/// Record a changed `patchedDependencies` without resolving the
-/// dependency graph, for the changes that touch no package the lockfile
-/// records.
+/// Where a package's snapshot key moves to when its patch changes.
+type Rekeys = HashMap<PackageKey, PackageKey>;
+
+/// Absorb a changed `patchedDependencies` without resolving the
+/// dependency graph.
 ///
-/// A patch that matches a locked package contributes a
-/// `(patch_hash=...)` segment to that package's key, so adding,
-/// removing, or editing such a patch rekeys the graph and has to go
-/// through the resolver. A patch key that matches nothing contributes
-/// nothing, which makes the recorded map the only thing that changes.
+/// Resolution never reads a patch: it appends the patch file's hash to
+/// an already-resolved package id, so the set of packages and versions
+/// is the same either way. Only the affected packages' `snapshots:`
+/// keys and the references pointing at them move, which is a rewrite of
+/// the loaded lockfile rather than a re-resolve. `packages:` is keyed
+/// without the patch hash, so it stays as it is.
 ///
-/// `None` — nothing changed, a changed key matches a locked package, or
-/// the new configuration leaves a patch unused while
+/// `None` — nothing changed, a patched package is reachable as a peer,
+/// or the new configuration leaves a patch unused while
 /// `allowUnusedPatches` is off — leaves the caller on the
 /// full-resolution path, which is where `ERR_PNPM_UNUSED_PATCH` is
 /// raised.
@@ -35,44 +42,173 @@ pub(crate) fn try_fast_update_patched_dependencies(
         return None;
     }
 
-    // Every key whose presence or hash differs, taken from the recorded
-    // map as well as the current one. A key the previous install applied
-    // still owns a `(patch_hash=...)` segment in the recorded graph, so
-    // dropping it rekeys that package just as adding it did.
-    let affected = recorded
-        .keys()
-        .chain(current.keys())
-        .filter(|key| recorded.get(*key) != current.get(*key))
-        .cloned();
-    if !applied_patch_keys(lockfile, &groups_from_keys(affected)?)?.is_empty() {
-        return None;
-    }
-
+    let groups = groups_from_hashes(current)?;
     if !config.allow_unused_patches {
-        let current_groups = groups_from_keys(current.keys().cloned())?;
-        let applied = applied_patch_keys(lockfile, &current_groups)?;
-        if all_patch_keys(&current_groups).any(|key| !applied.contains(key)) {
+        let applied = applied_patch_keys(lockfile, &groups)?;
+        if all_patch_keys(&groups).any(|key| !applied.contains(key)) {
             return None;
         }
     }
 
+    let rekeys = plan_rekeys(lockfile, &groups)?;
     let mut candidate = lockfile.clone();
+    apply_rekeys(&mut candidate, &rekeys);
     candidate.patched_dependencies = (!current.is_empty()).then(|| current.clone());
     Some(candidate)
 }
 
-/// Bucket `keys` the way the resolver buckets configured patches.
+/// Where every snapshot key moves to once `groups` is the configured
+/// set of patches: the same `name@version` and peer suffix, carrying the
+/// `(patch_hash=...)` segment the new configuration gives it.
 ///
-/// Only the key decides what a patch matches, so this deliberately
-/// leaves the payload empty rather than re-reading the patch files that
-/// [`Config::patched_dependency_hashes`] has already hashed.
+/// `None` when the move cannot be made from lockfile data alone: a
+/// rekeyed package that some snapshot reaches as a peer would rekey its
+/// dependents too (their peer suffix embeds its depPath), and a peer
+/// suffix that pnpm shortened into a hash cannot be inspected for that
+/// at all.
+fn plan_rekeys(lockfile: &Lockfile, groups: &PatchGroupRecord) -> Option<Rekeys> {
+    let Some(snapshots) = lockfile.snapshots.as_ref() else {
+        return Some(Rekeys::new());
+    };
+    let mut rekeys = Rekeys::new();
+    for key in snapshots.keys() {
+        let rendered = key.to_string();
+        let base = remove_suffix(&rendered);
+        let peers =
+            index_of_dep_path_suffix(&rendered).peers_index.map_or("", |index| &rendered[index..]);
+        let (name, version) = pacquet_deps_restorer::parse_name_version_from_key(base);
+        let segment = match get_patch_info(Some(groups), &name, &version).ok()? {
+            Some(patch) => format!("(patch_hash={})", patch.hash),
+            None => String::new(),
+        };
+        let moved = format!("{base}{segment}{peers}");
+        if moved != rendered {
+            rekeys.insert(key.clone(), moved.parse().ok()?);
+        }
+    }
+    if rekeys.is_empty() {
+        return Some(rekeys);
+    }
+
+    let moved_bases: Vec<String> =
+        rekeys.keys().map(|key| remove_suffix(&key.to_string()).to_string()).collect();
+    for key in snapshots.keys() {
+        let rendered = key.to_string();
+        let Some(index) = index_of_dep_path_suffix(&rendered).peers_index else {
+            continue;
+        };
+        let peers = &rendered[index..];
+        if peer_suffix_is_opaque(peers)
+            || moved_bases.iter().any(|base| peers.contains(base.as_str()))
+        {
+            return None;
+        }
+    }
+    Some(rekeys)
+}
+
+/// Whether `peers` is the short hash pnpm substitutes once the joined
+/// peer segments exceed `peersSuffixMaxLength`, which hides the peers
+/// this rewrite has to check for.
+fn peer_suffix_is_opaque(peers: &str) -> bool {
+    peers
+        .trim_start_matches('(')
+        .trim_end_matches(')')
+        .split(")(")
+        .any(|segment| !segment.contains('@'))
+}
+
+fn apply_rekeys(lockfile: &mut Lockfile, rekeys: &Rekeys) {
+    if rekeys.is_empty() {
+        return;
+    }
+    if let Some(snapshots) = lockfile.snapshots.take() {
+        lockfile.snapshots = Some(
+            snapshots
+                .into_iter()
+                .map(|(key, mut snapshot)| {
+                    rewrite_snapshot_dependencies(&mut snapshot.dependencies, rekeys);
+                    rewrite_snapshot_dependencies(&mut snapshot.optional_dependencies, rekeys);
+                    (rekeys.get(&key).cloned().unwrap_or(key), snapshot)
+                })
+                .collect(),
+        );
+    }
+    for importer in lockfile.importers.values_mut() {
+        rewrite_importer_dependencies(importer, rekeys);
+    }
+}
+
+fn rewrite_snapshot_dependencies(
+    dependencies: &mut Option<HashMap<pacquet_lockfile::PkgName, SnapshotDepRef>>,
+    rekeys: &Rekeys,
+) {
+    let Some(dependencies) = dependencies.as_mut() else {
+        return;
+    };
+    for (alias, reference) in dependencies.iter_mut() {
+        let Some(moved) = reference.resolve(alias).and_then(|target| rekeys.get(&target)).cloned()
+        else {
+            continue;
+        };
+        match reference {
+            SnapshotDepRef::Plain(ver_peer) => *ver_peer = moved.suffix,
+            SnapshotDepRef::Alias(key) => *key = moved,
+            // `resolve` yields no key for a link, so it never matches a
+            // rekeyed package.
+            SnapshotDepRef::Link(_) => {}
+        }
+    }
+}
+
+fn rewrite_importer_dependencies(importer: &mut ProjectSnapshot, rekeys: &Rekeys) {
+    for group in [
+        importer.dependencies.as_mut(),
+        importer.dev_dependencies.as_mut(),
+        importer.optional_dependencies.as_mut(),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        rewrite_importer_group(group, rekeys);
+    }
+}
+
+fn rewrite_importer_group(group: &mut ResolvedDependencyMap, rekeys: &Rekeys) {
+    for (alias, spec) in group.iter_mut() {
+        let target = match &spec.version {
+            ImporterDepVersion::Regular(ver_peer) => {
+                PackageKey::new(alias.clone(), ver_peer.clone())
+            }
+            ImporterDepVersion::Alias(key) => key.clone(),
+            // The remaining shapes point outside `snapshots:`, so they
+            // never name a rekeyed package.
+            _ => continue,
+        };
+        let Some(moved) = rekeys.get(&target).cloned() else {
+            continue;
+        };
+        match &mut spec.version {
+            ImporterDepVersion::Regular(ver_peer) => *ver_peer = moved.suffix,
+            ImporterDepVersion::Alias(key) => *key = moved,
+            _ => {}
+        }
+    }
+}
+
+/// Bucket `hashes` the way the resolver buckets configured patches.
+///
+/// The patch file path is left out: nothing here applies a patch, and
+/// the hashes [`Config::patched_dependency_hashes`] already computed are
+/// the only payload the rewrite needs, so no patch file is read twice.
 ///
 /// `None` for a key whose version segment is neither a version nor a
 /// range, leaving `ERR_PNPM_PATCH_NON_SEMVER_RANGE` to the resolver.
-fn groups_from_keys(keys: impl IntoIterator<Item = String>) -> Option<PatchGroupRecord> {
+fn groups_from_hashes(hashes: &BTreeMap<String, String>) -> Option<PatchGroupRecord> {
     group_patched_dependencies(
-        keys.into_iter()
-            .map(|key| (key, PatchInput { hash: String::new(), patch_file_path: None })),
+        hashes.iter().map(|(key, hash)| {
+            (key.clone(), PatchInput { hash: hash.clone(), patch_file_path: None })
+        }),
     )
     .ok()
 }

--- a/pnpm/crates/package-manager/src/fast_update_patched_dependencies/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_patched_dependencies/tests.rs
@@ -21,6 +21,24 @@ snapshots:
   foo@1.1.0: {}
 ";
 
+/// The same graph after a patch for `foo` was applied: the snapshot key
+/// carries the `(patch_hash=...)` segment the patch contributed.
+const PATCHED_LOCKFILE: &str = r"
+lockfileVersion: '9.0'
+importers:
+  .:
+    dependencies:
+      foo:
+        specifier: ^1.0.0
+        version: 1.1.0(patch_hash=deadbeef)
+packages:
+  foo@1.1.0:
+    resolution:
+      integrity: sha512-deadbeef
+snapshots:
+  foo@1.1.0(patch_hash=deadbeef): {}
+";
+
 fn lockfile(source: &str) -> Lockfile {
     serde_saphyr::from_str(source).expect("parse lockfile")
 }
@@ -128,6 +146,19 @@ fn removes_an_unused_patch_without_allowing_unused_patches() {
         .expect("dropping a key that matched nothing leaves no unused patch behind");
 
     assert!(updated.patched_dependencies.is_none());
+}
+
+#[test]
+fn rejects_removing_a_patch_that_was_applied_to_a_locked_package() {
+    let dir = workspace(&[]);
+    let mut lockfile = lockfile(PATCHED_LOCKFILE);
+    lockfile.patched_dependencies =
+        Some(BTreeMap::from([("foo@1.1.0".to_string(), "deadbeef".to_string())]));
+
+    assert!(
+        try_fast_update_patched_dependencies(&lockfile, &config(dir.path(), &[], true)).is_none(),
+        "the locked snapshot still carries the patch hash, so dropping the patch rekeys it",
+    );
 }
 
 #[test]

--- a/pnpm/crates/package-manager/src/fast_update_patched_dependencies/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_patched_dependencies/tests.rs
@@ -39,6 +39,30 @@ snapshots:
   foo@1.1.0(patch_hash=deadbeef): {}
 ";
 
+/// `bar` depends on `foo` as a plain transitive dependency, so patching
+/// `foo` has to move the reference inside `bar`'s snapshot too.
+const TRANSITIVE_LOCKFILE: &str = r"
+lockfileVersion: '9.0'
+importers:
+  .:
+    dependencies:
+      bar:
+        specifier: ^2.0.0
+        version: 2.0.0
+packages:
+  bar@2.0.0:
+    resolution:
+      integrity: sha512-deadbeef
+  foo@1.1.0:
+    resolution:
+      integrity: sha512-deadbeef
+snapshots:
+  bar@2.0.0:
+    dependencies:
+      foo: 1.1.0
+  foo@1.1.0: {}
+";
+
 /// `bar` reaches `foo` as a peer, so `foo`'s depPath is embedded in
 /// `bar`'s own key.
 const PEER_LOCKFILE: &str = r"
@@ -103,6 +127,14 @@ fn package_keys(lockfile: &Lockfile) -> Vec<String> {
         lockfile.packages.as_ref().expect("packages").keys().map(ToString::to_string).collect();
     keys.sort();
     keys
+}
+
+fn snapshot_dependency(lockfile: &Lockfile, key: &str, alias: &str) -> String {
+    lockfile.snapshots.as_ref().expect("snapshots")[&key.parse().expect("parse snapshot key")]
+        .dependencies
+        .as_ref()
+        .expect("snapshot dependencies")[&alias.parse().expect("parse alias")]
+        .to_string()
 }
 
 fn importer_version(lockfile: &Lockfile, alias: &str) -> String {
@@ -214,6 +246,27 @@ fn unpatches_a_locked_package_when_its_patch_is_removed() {
     assert_eq!(snapshot_keys(&updated), vec!["foo@1.1.0".to_string()]);
     assert_eq!(importer_version(&updated, "foo"), "1.1.0");
     assert!(updated.patched_dependencies.is_none());
+}
+
+#[test]
+fn moves_a_dependents_reference_to_the_rekeyed_package() {
+    let dir = workspace(&["foo@1.1.0"]);
+    let config = config(dir.path(), &["foo@1.1.0"], true);
+    let hash = config
+        .patched_dependency_hashes()
+        .expect("hash the patch files")
+        .expect("a configured patch")["foo@1.1.0"]
+        .clone();
+
+    let updated = try_fast_update_patched_dependencies(&lockfile(TRANSITIVE_LOCKFILE), &config)
+        .expect("patching a transitive dependency only renames it");
+
+    assert_eq!(
+        snapshot_dependency(&updated, "bar@2.0.0", "foo"),
+        format!("1.1.0(patch_hash={hash})"),
+        "the dependent points at the renamed snapshot",
+    );
+    assert_eq!(importer_version(&updated, "bar"), "2.0.0", "the dependent itself does not move");
 }
 
 #[test]

--- a/pnpm/crates/package-manager/src/fast_update_patched_dependencies/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_patched_dependencies/tests.rs
@@ -39,6 +39,48 @@ snapshots:
   foo@1.1.0(patch_hash=deadbeef): {}
 ";
 
+/// `foo` comes from a named registry, so the key's version slot holds
+/// `work:1.1.0` rather than a plain semver the patch keys can match.
+const REGISTRY_QUALIFIED_LOCKFILE: &str = r"
+lockfileVersion: '9.0'
+importers:
+  .:
+    dependencies:
+      foo:
+        specifier: ^1.0.0
+        version: work:1.1.0
+packages:
+  foo@work:1.1.0:
+    resolution:
+      integrity: sha512-deadbeef
+snapshots:
+  foo@work:1.1.0: {}
+";
+
+/// A tarball resolution, whose key carries a URL where a version would be.
+const TARBALL_LOCKFILE: &str = r"
+lockfileVersion: '9.0'
+importers:
+  .:
+    dependencies:
+      bar:
+        specifier: ^2.0.0
+        version: 2.0.0
+      foo:
+        specifier: https://example.test/foo.tgz
+        version: https://example.test/foo.tgz
+packages:
+  bar@2.0.0:
+    resolution:
+      integrity: sha512-deadbeef
+  foo@https://example.test/foo.tgz:
+    resolution:
+      integrity: sha512-deadbeef
+snapshots:
+  bar@2.0.0: {}
+  foo@https://example.test/foo.tgz: {}
+";
+
 /// `bar` depends on `foo` as a plain transitive dependency, so patching
 /// `foo` has to move the reference inside `bar`'s snapshot too.
 const TRANSITIVE_LOCKFILE: &str = r"
@@ -267,6 +309,48 @@ fn moves_a_dependents_reference_to_the_rekeyed_package() {
         "the dependent points at the renamed snapshot",
     );
     assert_eq!(importer_version(&updated, "bar"), "2.0.0", "the dependent itself does not move");
+}
+
+#[test]
+fn rejects_a_patch_for_a_registry_qualified_package() {
+    let dir = workspace(&["foo@1.1.0"]);
+
+    assert!(
+        try_fast_update_patched_dependencies(
+            &lockfile(REGISTRY_QUALIFIED_LOCKFILE),
+            &config(dir.path(), &["foo@1.1.0"], true),
+        )
+        .is_none(),
+        "the resolver matches this patch on plain semver, so it decides this one",
+    );
+}
+
+#[test]
+fn rejects_a_bare_name_patch_that_would_reach_a_tarball_resolution() {
+    let dir = workspace(&["foo"]);
+
+    assert!(
+        try_fast_update_patched_dependencies(
+            &lockfile(TARBALL_LOCKFILE),
+            &config(dir.path(), &["foo"], true),
+        )
+        .is_none(),
+        "a URL in the version slot is not a version the resolver would match on",
+    );
+}
+
+#[test]
+fn rekeys_around_a_tarball_resolution_no_patch_reaches() {
+    let dir = workspace(&["bar@2.0.0"]);
+
+    let updated = try_fast_update_patched_dependencies(
+        &lockfile(TARBALL_LOCKFILE),
+        &config(dir.path(), &["bar@2.0.0"], true),
+    )
+    .expect("an untouched tarball resolution does not block the rest");
+
+    assert!(snapshot_keys(&updated).iter().any(|key| key.starts_with("bar@2.0.0(patch_hash=")));
+    assert!(snapshot_keys(&updated).contains(&"foo@https://example.test/foo.tgz".to_string()));
 }
 
 #[test]

--- a/pnpm/crates/package-manager/src/fast_update_patched_dependencies/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_patched_dependencies/tests.rs
@@ -1,0 +1,173 @@
+use super::try_fast_update_patched_dependencies;
+use indexmap::IndexMap;
+use pacquet_config::Config;
+use pacquet_lockfile::Lockfile;
+use std::{collections::BTreeMap, fs, path::Path};
+use tempfile::TempDir;
+
+const LOCKFILE: &str = r"
+lockfileVersion: '9.0'
+importers:
+  .:
+    dependencies:
+      foo:
+        specifier: ^1.0.0
+        version: 1.1.0
+packages:
+  foo@1.1.0:
+    resolution:
+      integrity: sha512-deadbeef
+snapshots:
+  foo@1.1.0: {}
+";
+
+fn lockfile(source: &str) -> Lockfile {
+    serde_saphyr::from_str(source).expect("parse lockfile")
+}
+
+/// A workspace whose patch files exist on disk, since both the hash map
+/// and the grouped record are read from them.
+fn workspace(patches: &[&str]) -> TempDir {
+    let dir = tempfile::tempdir().expect("create workspace dir");
+    fs::create_dir_all(dir.path().join("patches")).expect("create patches dir");
+    for patch in patches {
+        write_patch(dir.path(), patch, "--- a\n+++ b\n");
+    }
+    dir
+}
+
+fn write_patch(workspace_dir: &Path, key: &str, contents: &str) {
+    let path = workspace_dir.join("patches").join(patch_file_name(key));
+    fs::write(path, contents).expect("write patch file");
+}
+
+fn patch_file_name(key: &str) -> String {
+    format!("{}.patch", key.replace('/', "+"))
+}
+
+fn config(workspace_dir: &Path, keys: &[&str], allow_unused_patches: bool) -> Config {
+    Config {
+        workspace_dir: Some(workspace_dir.to_path_buf()),
+        allow_unused_patches,
+        patched_dependencies: (!keys.is_empty()).then(|| {
+            keys.iter()
+                .map(|key| (key.to_string(), format!("patches/{}", patch_file_name(key))))
+                .collect::<IndexMap<_, _>>()
+        }),
+        ..Config::default()
+    }
+}
+
+fn recorded(lockfile: &Lockfile) -> &BTreeMap<String, String> {
+    lockfile.patched_dependencies.as_ref().expect("the candidate records patchedDependencies")
+}
+
+#[test]
+fn records_a_patch_that_matches_no_locked_package() {
+    let dir = workspace(&["bar@2.0.0"]);
+
+    let updated = try_fast_update_patched_dependencies(
+        &lockfile(LOCKFILE),
+        &config(dir.path(), &["bar@2.0.0"], true),
+    )
+    .expect("a patch matching nothing in the lockfile cannot change the graph");
+
+    assert_eq!(recorded(&updated).keys().collect::<Vec<_>>(), vec!["bar@2.0.0"]);
+}
+
+#[test]
+fn rejects_a_patch_that_matches_a_locked_package() {
+    let dir = workspace(&["foo@1.1.0"]);
+
+    assert!(
+        try_fast_update_patched_dependencies(
+            &lockfile(LOCKFILE),
+            &config(dir.path(), &["foo@1.1.0"], true),
+        )
+        .is_none(),
+        "patching a locked package rekeys its snapshot, so it needs the resolver",
+    );
+}
+
+#[test]
+fn rejects_a_bare_name_patch_that_matches_a_locked_package() {
+    let dir = workspace(&["foo"]);
+
+    assert!(
+        try_fast_update_patched_dependencies(
+            &lockfile(LOCKFILE),
+            &config(dir.path(), &["foo"], true),
+        )
+        .is_none(),
+        "a bare-name key matches every version of the package",
+    );
+}
+
+#[test]
+fn rejects_an_unused_patch_when_unused_patches_are_not_allowed() {
+    let dir = workspace(&["bar@2.0.0"]);
+
+    assert!(
+        try_fast_update_patched_dependencies(
+            &lockfile(LOCKFILE),
+            &config(dir.path(), &["bar@2.0.0"], false),
+        )
+        .is_none(),
+        "the resolver has to run so it can raise ERR_PNPM_UNUSED_PATCH",
+    );
+}
+
+#[test]
+fn removes_an_unused_patch_without_allowing_unused_patches() {
+    let dir = workspace(&[]);
+    let mut lockfile = lockfile(LOCKFILE);
+    lockfile.patched_dependencies =
+        Some(BTreeMap::from([("bar@2.0.0".to_string(), "deadbeef".to_string())]));
+
+    let updated = try_fast_update_patched_dependencies(&lockfile, &config(dir.path(), &[], false))
+        .expect("dropping a key that matched nothing leaves no unused patch behind");
+
+    assert!(updated.patched_dependencies.is_none());
+}
+
+#[test]
+fn rejects_an_edited_patch_file_for_a_locked_package() {
+    let dir = workspace(&["foo@1.1.0"]);
+    let mut lockfile = lockfile(LOCKFILE);
+    lockfile.patched_dependencies =
+        Some(BTreeMap::from([("foo@1.1.0".to_string(), "stale-hash".to_string())]));
+
+    assert!(
+        try_fast_update_patched_dependencies(&lockfile, &config(dir.path(), &["foo@1.1.0"], true),)
+            .is_none(),
+        "a new hash changes the (patch_hash=...) suffix of a locked package",
+    );
+}
+
+#[test]
+fn rejects_an_unchanged_configuration() {
+    let dir = workspace(&["bar@2.0.0"]);
+    let config = config(dir.path(), &["bar@2.0.0"], true);
+    let mut lockfile = lockfile(LOCKFILE);
+    lockfile.patched_dependencies =
+        config.patched_dependency_hashes().expect("hash the patch files");
+
+    assert!(
+        try_fast_update_patched_dependencies(&lockfile, &config).is_none(),
+        "with nothing to absorb this handler must not claim the install",
+    );
+}
+
+#[test]
+fn rejects_a_missing_patch_file() {
+    let dir = workspace(&[]);
+
+    assert!(
+        try_fast_update_patched_dependencies(
+            &lockfile(LOCKFILE),
+            &config(dir.path(), &["bar@2.0.0"], true),
+        )
+        .is_none(),
+        "the resolver reports the unreadable patch file instead",
+    );
+}

--- a/pnpm/crates/package-manager/src/fast_update_patched_dependencies/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_patched_dependencies/tests.rs
@@ -39,8 +39,77 @@ snapshots:
   foo@1.1.0(patch_hash=deadbeef): {}
 ";
 
+/// `bar` reaches `foo` as a peer, so `foo`'s depPath is embedded in
+/// `bar`'s own key.
+const PEER_LOCKFILE: &str = r"
+lockfileVersion: '9.0'
+importers:
+  .:
+    dependencies:
+      bar:
+        specifier: ^2.0.0
+        version: 2.0.0(foo@1.1.0)
+packages:
+  bar@2.0.0:
+    resolution:
+      integrity: sha512-deadbeef
+  foo@1.1.0:
+    resolution:
+      integrity: sha512-deadbeef
+snapshots:
+  bar@2.0.0(foo@1.1.0):
+    dependencies:
+      foo: 1.1.0
+  foo@1.1.0: {}
+";
+
+/// The same shape once the joined peer segments exceeded
+/// `peersSuffixMaxLength` and pnpm replaced them with a short hash.
+const HASHED_PEER_LOCKFILE: &str = r"
+lockfileVersion: '9.0'
+importers:
+  .:
+    dependencies:
+      bar:
+        specifier: ^2.0.0
+        version: 2.0.0(sha256-abcdef)
+packages:
+  bar@2.0.0:
+    resolution:
+      integrity: sha512-deadbeef
+  foo@1.1.0:
+    resolution:
+      integrity: sha512-deadbeef
+snapshots:
+  bar@2.0.0(sha256-abcdef):
+    dependencies:
+      foo: 1.1.0
+  foo@1.1.0: {}
+";
+
 fn lockfile(source: &str) -> Lockfile {
     serde_saphyr::from_str(source).expect("parse lockfile")
+}
+
+fn snapshot_keys(lockfile: &Lockfile) -> Vec<String> {
+    let mut keys: Vec<_> =
+        lockfile.snapshots.as_ref().expect("snapshots").keys().map(ToString::to_string).collect();
+    keys.sort();
+    keys
+}
+
+fn package_keys(lockfile: &Lockfile) -> Vec<String> {
+    let mut keys: Vec<_> =
+        lockfile.packages.as_ref().expect("packages").keys().map(ToString::to_string).collect();
+    keys.sort();
+    keys
+}
+
+fn importer_version(lockfile: &Lockfile, alias: &str) -> String {
+    lockfile.importers["."].dependencies.as_ref().expect("importer dependencies")
+        [&alias.parse().expect("parse alias")]
+        .version
+        .to_string()
 }
 
 /// A workspace whose patch files exist on disk, since both the hash map
@@ -94,30 +163,84 @@ fn records_a_patch_that_matches_no_locked_package() {
 }
 
 #[test]
-fn rejects_a_patch_that_matches_a_locked_package() {
+fn rekeys_a_locked_package_the_patch_matches() {
     let dir = workspace(&["foo@1.1.0"]);
+    let config = config(dir.path(), &["foo@1.1.0"], true);
+    let hash = config
+        .patched_dependency_hashes()
+        .expect("hash the patch files")
+        .expect("a configured patch")["foo@1.1.0"]
+        .clone();
 
-    assert!(
-        try_fast_update_patched_dependencies(
-            &lockfile(LOCKFILE),
-            &config(dir.path(), &["foo@1.1.0"], true),
-        )
-        .is_none(),
-        "patching a locked package rekeys its snapshot, so it needs the resolver",
+    let updated = try_fast_update_patched_dependencies(&lockfile(LOCKFILE), &config)
+        .expect("the patch only renames the snapshot, it does not change the graph");
+
+    assert_eq!(snapshot_keys(&updated), vec![format!("foo@1.1.0(patch_hash={hash})")]);
+    assert_eq!(
+        importer_version(&updated, "foo"),
+        format!("1.1.0(patch_hash={hash})"),
+        "the importer points at the renamed snapshot",
+    );
+    assert_eq!(
+        package_keys(&updated),
+        vec!["foo@1.1.0".to_string()],
+        "`packages:` is keyed without the patch hash, so it does not move",
     );
 }
 
 #[test]
-fn rejects_a_bare_name_patch_that_matches_a_locked_package() {
+fn rekeys_a_locked_package_a_bare_name_patch_matches() {
     let dir = workspace(&["foo"]);
+
+    let updated = try_fast_update_patched_dependencies(
+        &lockfile(LOCKFILE),
+        &config(dir.path(), &["foo"], true),
+    )
+    .expect("a bare-name key matches every version of the package");
+
+    assert!(snapshot_keys(&updated)[0].contains("(patch_hash="));
+}
+
+#[test]
+fn unpatches_a_locked_package_when_its_patch_is_removed() {
+    let dir = workspace(&[]);
+    let mut lockfile = lockfile(PATCHED_LOCKFILE);
+    lockfile.patched_dependencies =
+        Some(BTreeMap::from([("foo@1.1.0".to_string(), "deadbeef".to_string())]));
+
+    let updated = try_fast_update_patched_dependencies(&lockfile, &config(dir.path(), &[], true))
+        .expect("dropping the patch renames the snapshot back");
+
+    assert_eq!(snapshot_keys(&updated), vec!["foo@1.1.0".to_string()]);
+    assert_eq!(importer_version(&updated, "foo"), "1.1.0");
+    assert!(updated.patched_dependencies.is_none());
+}
+
+#[test]
+fn rejects_rekeying_a_package_another_snapshot_reaches_as_a_peer() {
+    let dir = workspace(&["foo@1.1.0"]);
 
     assert!(
         try_fast_update_patched_dependencies(
-            &lockfile(LOCKFILE),
-            &config(dir.path(), &["foo"], true),
+            &lockfile(PEER_LOCKFILE),
+            &config(dir.path(), &["foo@1.1.0"], true),
         )
         .is_none(),
-        "a bare-name key matches every version of the package",
+        "the dependent's peer suffix embeds foo's depPath, so it would rekey too",
+    );
+}
+
+#[test]
+fn rejects_rekeying_when_a_peer_suffix_is_hashed() {
+    let dir = workspace(&["foo@1.1.0"]);
+
+    assert!(
+        try_fast_update_patched_dependencies(
+            &lockfile(HASHED_PEER_LOCKFILE),
+            &config(dir.path(), &["foo@1.1.0"], true),
+        )
+        .is_none(),
+        "a shortened peer suffix cannot be checked for the patched package",
     );
 }
 
@@ -149,30 +272,18 @@ fn removes_an_unused_patch_without_allowing_unused_patches() {
 }
 
 #[test]
-fn rejects_removing_a_patch_that_was_applied_to_a_locked_package() {
-    let dir = workspace(&[]);
+fn rekeys_a_locked_package_whose_patch_file_was_edited() {
+    let dir = workspace(&["foo@1.1.0"]);
     let mut lockfile = lockfile(PATCHED_LOCKFILE);
     lockfile.patched_dependencies =
         Some(BTreeMap::from([("foo@1.1.0".to_string(), "deadbeef".to_string())]));
 
-    assert!(
-        try_fast_update_patched_dependencies(&lockfile, &config(dir.path(), &[], true)).is_none(),
-        "the locked snapshot still carries the patch hash, so dropping the patch rekeys it",
-    );
-}
+    let updated =
+        try_fast_update_patched_dependencies(&lockfile, &config(dir.path(), &["foo@1.1.0"], true))
+            .expect("a new hash renames the snapshot");
 
-#[test]
-fn rejects_an_edited_patch_file_for_a_locked_package() {
-    let dir = workspace(&["foo@1.1.0"]);
-    let mut lockfile = lockfile(LOCKFILE);
-    lockfile.patched_dependencies =
-        Some(BTreeMap::from([("foo@1.1.0".to_string(), "stale-hash".to_string())]));
-
-    assert!(
-        try_fast_update_patched_dependencies(&lockfile, &config(dir.path(), &["foo@1.1.0"], true),)
-            .is_none(),
-        "a new hash changes the (patch_hash=...) suffix of a locked package",
-    );
+    assert!(!snapshot_keys(&updated).contains(&"foo@1.1.0(patch_hash=deadbeef)".to_string()));
+    assert!(snapshot_keys(&updated)[0].contains("(patch_hash="));
 }
 
 #[test]

--- a/pnpm/crates/package-manager/src/install/lockfile_freshness.rs
+++ b/pnpm/crates/package-manager/src/install/lockfile_freshness.rs
@@ -17,8 +17,9 @@ pub(super) struct FastUpdateLockfileOptions<'a, 'manifest> {
 /// Rewrite the loaded lockfile in place of a full resolution for the
 /// drift the lockfile itself proves is safe to absorb: a compatible
 /// direct-dependency range change, an addition to
-/// `ignoredOptionalDependencies`, or a setting change that cannot
-/// affect the recorded graph. The candidate only replaces the loaded
+/// `ignoredOptionalDependencies`, a `patchedDependencies` change that
+/// matches no locked package, or a setting change that cannot affect
+/// the recorded graph. The candidate only replaces the loaded
 /// lockfile once it passes every freshness gate, so a handler that
 /// rewrites too much falls back to the resolver instead of committing.
 ///
@@ -39,6 +40,10 @@ pub(super) async fn try_fast_update_lockfile(
             lockfile,
             &crate::fast_update_settings::lockfile_settings_from_config(opts.config),
             opts.project_manifests,
+        ),
+        crate::fast_update_patched_dependencies::try_fast_update_patched_dependencies(
+            lockfile,
+            opts.config,
         ),
     ]
     .into_iter()

--- a/pnpm/crates/package-manager/src/lib.rs
+++ b/pnpm/crates/package-manager/src/lib.rs
@@ -11,6 +11,7 @@ mod fast_update_ignored_optional_dependencies;
 mod fast_update_importers;
 mod fast_update_lockfile;
 mod fast_update_overrides;
+mod fast_update_patched_dependencies;
 mod fast_update_settings;
 mod install;
 mod install_with_fresh_lockfile;

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -777,7 +777,6 @@ export async function mutateModules (
             }
             if (changedSetting === 'patchedDependencies') {
               return tryFastUpdatePatchedDependencies(candidate, {
-                patchGroups,
                 patchedDependencies,
                 allowUnusedPatches: opts.allowUnusedPatches,
               })

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -114,6 +114,7 @@ import { tryFastUpdateIgnoredOptionalDependencies } from './tryFastUpdateIgnored
 import { hasChangedProjectSpecifiers, tryFastUpdateImporters } from './tryFastUpdateImporters.js'
 import { tryFastUpdateLockfile } from './tryFastUpdateLockfile.js'
 import { tryFastUpdateOverrides } from './tryFastUpdateOverrides.js'
+import { tryFastUpdatePatchedDependencies } from './tryFastUpdatePatchedDependencies.js'
 import { tryFastUpdateSettings } from './tryFastUpdateSettings.js'
 import { validateModules } from './validateModules.js'
 import { verifyLockfileResolutions } from './verifyLockfileResolutions.js'
@@ -711,6 +712,7 @@ export async function mutateModules (
       (outdatedLockfileSettingName === 'catalogs' ||
         outdatedLockfileSettingName === 'ignoredOptionalDependencies' ||
         outdatedLockfileSettingName === 'overrides' ||
+        outdatedLockfileSettingName === 'patchedDependencies' ||
         onlyLockfileSettingsChanged ||
         hasChangedSpecifiers) &&
       !frozenLockfile &&
@@ -772,6 +774,13 @@ export async function mutateModules (
             }
             if (changedSetting === 'ignoredOptionalDependencies') {
               return tryFastUpdateIgnoredOptionalDependencies(candidate, opts.ignoredOptionalDependencies)
+            }
+            if (changedSetting === 'patchedDependencies') {
+              return tryFastUpdatePatchedDependencies(candidate, {
+                patchGroups,
+                patchedDependencies,
+                allowUnusedPatches: opts.allowUnusedPatches,
+              })
             }
             if (changedSetting == null) {
               return tryFastUpdateImporters(candidate, contextProjects)

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdatePatchedDependencies.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdatePatchedDependencies.ts
@@ -75,8 +75,18 @@ export function tryFastUpdatePatchedDependencies (
 function planRekeys (lockfile: LockfileObject, groups: PatchGroupRecord): Rekeys | undefined {
   const rekeys: Rekeys = new Map()
   for (const [depPath, snapshot] of Object.entries(lockfile.packages ?? {}) as Array<[DepPath, PackageSnapshot]>) {
-    const { name, version } = nameVerFromPkgSnapshot(depPath, snapshot)
-    if (version == null) continue
+    const { name, version, nonSemverVersion, registryName } = nameVerFromPkgSnapshot(depPath, snapshot)
+    const { patchHashIndex } = dp.indexOfDepPathSuffix(depPath)
+    // The resolver matches patches against a package's plain semver version.
+    // A named registry or a git / tarball reference occupies the same slot
+    // here, and matching those cannot be reproduced from the key, so the
+    // question is only whether it could matter: any configured patch naming
+    // this package, or a patch hash already on the key, hands the decision
+    // back to the resolver.
+    if (version == null || nonSemverVersion != null || registryName != null) {
+      if (groups[name] != null || patchHashIndex !== -1) return undefined
+      continue
+    }
     let patch
     try {
       patch = getPatchInfo(groups, name, version)

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdatePatchedDependencies.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdatePatchedDependencies.ts
@@ -1,4 +1,5 @@
-import type { LockfileObject } from '@pnpm/lockfile.types'
+import * as dp from '@pnpm/deps.path'
+import type { LockfileObject, PackageSnapshot, ResolvedDependencies } from '@pnpm/lockfile.types'
 import { nameVerFromPkgSnapshot } from '@pnpm/lockfile.utils'
 import {
   allPatchKeys,
@@ -6,23 +7,27 @@ import {
   groupPatchedDependencies,
   type PatchGroupRecord,
 } from '@pnpm/patching.config'
+import type { DepPath } from '@pnpm/types'
 
 export interface FastPatchedDependenciesUpdateOptions {
   patchedDependencies: Record<string, string> | undefined
   allowUnusedPatches: boolean
 }
 
+/** Where a package's key moves to when its patch changes. */
+type Rekeys = Map<DepPath, DepPath>
+
 /**
- * Record a changed `patchedDependencies` without resolving the dependency
- * graph, for the changes that touch no package the lockfile records.
+ * Absorb a changed `patchedDependencies` without resolving the dependency
+ * graph.
  *
- * A patch that matches a locked package contributes a `(patch_hash=...)`
- * segment to that package's key, so adding, removing, or editing such a patch
- * rekeys the graph and has to go through the resolver. A patch key that
- * matches nothing contributes nothing, which makes the recorded map the only
- * thing that changes.
+ * Resolution never reads a patch: it appends the patch file's hash to an
+ * already-resolved package id, so the set of packages and versions is the same
+ * either way. Only the affected packages' keys and the references pointing at
+ * them move, which is a rewrite of the loaded lockfile rather than a
+ * re-resolve.
  *
- * Returns `false` — nothing changed, a changed key matches a locked package,
+ * Returns `false` — nothing changed, a patched package is reachable as a peer,
  * or the new configuration leaves a patch unused while `allowUnusedPatches` is
  * off — which keeps the full-resolution path, where `ERR_PNPM_UNUSED_PATCH` is
  * raised.
@@ -33,27 +38,21 @@ export function tryFastUpdatePatchedDependencies (
 ): boolean {
   const recorded = lockfile.patchedDependencies ?? {}
   const current = opts.patchedDependencies ?? {}
-  // Every key whose presence or hash differs, taken from the recorded map as
-  // well as the current one. A key the previous install applied still owns a
-  // `(patch_hash=...)` segment in the recorded graph, so dropping it rekeys
-  // that package just as adding it did.
-  const affected = changedKeys(recorded, current)
-  if (affected.length === 0) return false
+  if (changedKeys(recorded, current).length === 0) return false
 
-  const affectedGroups = groupsFromKeys(affected)
-  if (affectedGroups == null) return false
-  const affectedApplied = appliedPatchKeys(lockfile, affectedGroups)
-  if (affectedApplied == null || affectedApplied.size > 0) return false
-
+  const groups = groupsFromHashes(current)
+  if (groups == null) return false
   if (!opts.allowUnusedPatches) {
-    const currentGroups = groupsFromKeys(Object.keys(current))
-    if (currentGroups == null) return false
-    const applied = appliedPatchKeys(lockfile, currentGroups)
+    const applied = appliedPatchKeys(lockfile, groups)
     if (applied == null) return false
-    for (const key of allPatchKeys(currentGroups)) {
+    for (const key of allPatchKeys(groups)) {
       if (!applied.has(key)) return false
     }
   }
+
+  const rekeys = planRekeys(lockfile, groups)
+  if (rekeys == null) return false
+  applyRekeys(lockfile, rekeys)
 
   if (Object.keys(current).length === 0) {
     delete lockfile.patchedDependencies
@@ -61,6 +60,92 @@ export function tryFastUpdatePatchedDependencies (
     lockfile.patchedDependencies = current
   }
   return true
+}
+
+/**
+ * Where every package key moves to once `groups` is the configured set of
+ * patches: the same `name@version` and peer suffix, carrying the
+ * `(patch_hash=...)` segment the new configuration gives it.
+ *
+ * `undefined` when the move cannot be made from lockfile data alone: a rekeyed
+ * package that some snapshot reaches as a peer would rekey its dependents too
+ * (their peer suffix embeds its depPath), and a peer suffix that pnpm
+ * shortened into a hash cannot be inspected for that at all.
+ */
+function planRekeys (lockfile: LockfileObject, groups: PatchGroupRecord): Rekeys | undefined {
+  const rekeys: Rekeys = new Map()
+  for (const [depPath, snapshot] of Object.entries(lockfile.packages ?? {}) as Array<[DepPath, PackageSnapshot]>) {
+    const { name, version } = nameVerFromPkgSnapshot(depPath, snapshot)
+    if (version == null) continue
+    let patch
+    try {
+      patch = getPatchInfo(groups, name, version)
+    } catch {
+      return undefined
+    }
+    const base = dp.removeSuffix(depPath)
+    const { peersIndex } = dp.indexOfDepPathSuffix(depPath)
+    const peers = peersIndex === -1 ? '' : depPath.substring(peersIndex)
+    const segment = patch ? `(patch_hash=${patch.hash})` : ''
+    const moved = `${base}${segment}${peers}` as DepPath
+    if (moved !== depPath) rekeys.set(depPath, moved)
+  }
+  if (rekeys.size === 0) return rekeys
+
+  const movedBases = [...rekeys.keys()].map((depPath) => dp.removeSuffix(depPath))
+  for (const depPath of Object.keys(lockfile.packages ?? {})) {
+    const { peersIndex } = dp.indexOfDepPathSuffix(depPath)
+    if (peersIndex === -1) continue
+    const peers = depPath.substring(peersIndex)
+    if (peerSuffixIsOpaque(peers) || movedBases.some((base) => peers.includes(base))) {
+      return undefined
+    }
+  }
+  return rekeys
+}
+
+/**
+ * Whether `peers` is the short hash pnpm substitutes once the joined peer
+ * segments exceed `peersSuffixMaxLength`, which hides the peers this rewrite
+ * has to check for.
+ */
+function peerSuffixIsOpaque (peers: string): boolean {
+  return peers
+    .replace(/^\(/, '')
+    .replace(/\)$/, '')
+    .split(')(')
+    .some((segment) => !segment.includes('@'))
+}
+
+function applyRekeys (lockfile: LockfileObject, rekeys: Rekeys): void {
+  if (rekeys.size === 0) return
+  const packages = lockfile.packages ?? {}
+  for (const snapshot of Object.values(packages)) {
+    rewriteReferences(snapshot.dependencies, rekeys)
+    rewriteReferences(snapshot.optionalDependencies, rekeys)
+  }
+  lockfile.packages = Object.fromEntries(
+    Object.entries(packages).map(([depPath, snapshot]) =>
+      [rekeys.get(depPath as DepPath) ?? depPath, snapshot]
+    )
+  ) as typeof lockfile.packages
+  for (const importer of Object.values(lockfile.importers)) {
+    rewriteReferences(importer.dependencies, rekeys)
+    rewriteReferences(importer.devDependencies, rekeys)
+    rewriteReferences(importer.optionalDependencies, rekeys)
+  }
+}
+
+function rewriteReferences (references: ResolvedDependencies | undefined, rekeys: Rekeys): void {
+  if (references == null) return
+  for (const [alias, reference] of Object.entries(references)) {
+    const depPath = dp.refToRelative(reference, alias)
+    const moved = depPath == null ? undefined : rekeys.get(depPath)
+    if (moved == null) continue
+    // A reference that already spelled out the whole depPath keeps doing so;
+    // the bare-version shape keeps dropping the `<alias>@` prefix.
+    references[alias] = depPath === reference ? moved : moved.substring(`${alias}@`.length)
+  }
 }
 
 function changedKeys (
@@ -72,18 +157,19 @@ function changedKeys (
 }
 
 /**
- * Bucket `keys` the way the resolver buckets configured patches.
+ * Bucket `hashes` the way the resolver buckets configured patches.
  *
- * Only the key decides what a patch matches, so this deliberately leaves the
- * payload empty rather than carrying hashes and paths it would never read.
+ * The patch file path is left out: nothing here applies a patch, and the
+ * hashes `calcPatchHashes` already computed are the only payload the rewrite
+ * needs.
  *
  * `undefined` for a key whose version segment is neither a version nor a
  * range, leaving `ERR_PNPM_PATCH_NON_SEMVER_RANGE` to the resolver.
  */
-function groupsFromKeys (keys: string[]): PatchGroupRecord | undefined {
+function groupsFromHashes (hashes: Record<string, string>): PatchGroupRecord | undefined {
   try {
     return groupPatchedDependencies(
-      Object.fromEntries(keys.map((key) => [key, { hash: '' }]))
+      Object.fromEntries(Object.entries(hashes).map(([key, hash]) => [key, { hash }]))
     )
   } catch {
     return undefined

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdatePatchedDependencies.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdatePatchedDependencies.ts
@@ -1,9 +1,13 @@
 import type { LockfileObject } from '@pnpm/lockfile.types'
 import { nameVerFromPkgSnapshot } from '@pnpm/lockfile.utils'
-import { allPatchKeys, getPatchInfo, type PatchGroupRecord } from '@pnpm/patching.config'
+import {
+  allPatchKeys,
+  getPatchInfo,
+  groupPatchedDependencies,
+  type PatchGroupRecord,
+} from '@pnpm/patching.config'
 
 export interface FastPatchedDependenciesUpdateOptions {
-  patchGroups: PatchGroupRecord | undefined
   patchedDependencies: Record<string, string> | undefined
   allowUnusedPatches: boolean
 }
@@ -29,14 +33,24 @@ export function tryFastUpdatePatchedDependencies (
 ): boolean {
   const recorded = lockfile.patchedDependencies ?? {}
   const current = opts.patchedDependencies ?? {}
+  // Every key whose presence or hash differs, taken from the recorded map as
+  // well as the current one. A key the previous install applied still owns a
+  // `(patch_hash=...)` segment in the recorded graph, so dropping it rekeys
+  // that package just as adding it did.
   const affected = changedKeys(recorded, current)
   if (affected.length === 0) return false
 
-  const applied = appliedPatchKeys(lockfile, opts.patchGroups)
-  if (applied == null) return false
-  if (affected.some((key) => applied.has(key))) return false
-  if (!opts.allowUnusedPatches && opts.patchGroups != null) {
-    for (const key of allPatchKeys(opts.patchGroups)) {
+  const affectedGroups = groupsFromKeys(affected)
+  if (affectedGroups == null) return false
+  const affectedApplied = appliedPatchKeys(lockfile, affectedGroups)
+  if (affectedApplied == null || affectedApplied.size > 0) return false
+
+  if (!opts.allowUnusedPatches) {
+    const currentGroups = groupsFromKeys(Object.keys(current))
+    if (currentGroups == null) return false
+    const applied = appliedPatchKeys(lockfile, currentGroups)
+    if (applied == null) return false
+    for (const key of allPatchKeys(currentGroups)) {
       if (!applied.has(key)) return false
     }
   }
@@ -58,7 +72,26 @@ function changedKeys (
 }
 
 /**
- * The configured patch keys that match a package the lockfile records, matched
+ * Bucket `keys` the way the resolver buckets configured patches.
+ *
+ * Only the key decides what a patch matches, so this deliberately leaves the
+ * payload empty rather than carrying hashes and paths it would never read.
+ *
+ * `undefined` for a key whose version segment is neither a version nor a
+ * range, leaving `ERR_PNPM_PATCH_NON_SEMVER_RANGE` to the resolver.
+ */
+function groupsFromKeys (keys: string[]): PatchGroupRecord | undefined {
+  try {
+    return groupPatchedDependencies(
+      Object.fromEntries(keys.map((key) => [key, { hash: '' }]))
+    )
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * The patch keys in `patchGroups` that match a package the lockfile records, matched
  * the way the resolver matches them.
  *
  * `undefined` when a locked package matches more than one configured range, so
@@ -67,10 +100,9 @@ function changedKeys (
  */
 function appliedPatchKeys (
   lockfile: LockfileObject,
-  patchGroups: PatchGroupRecord | undefined
+  patchGroups: PatchGroupRecord
 ): Set<string> | undefined {
   const applied = new Set<string>()
-  if (patchGroups == null) return applied
   for (const [depPath, snapshot] of Object.entries(lockfile.packages ?? {})) {
     const { name, version } = nameVerFromPkgSnapshot(depPath, snapshot)
     if (version == null) continue

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdatePatchedDependencies.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdatePatchedDependencies.ts
@@ -1,0 +1,86 @@
+import type { LockfileObject } from '@pnpm/lockfile.types'
+import { nameVerFromPkgSnapshot } from '@pnpm/lockfile.utils'
+import { allPatchKeys, getPatchInfo, type PatchGroupRecord } from '@pnpm/patching.config'
+
+export interface FastPatchedDependenciesUpdateOptions {
+  patchGroups: PatchGroupRecord | undefined
+  patchedDependencies: Record<string, string> | undefined
+  allowUnusedPatches: boolean
+}
+
+/**
+ * Record a changed `patchedDependencies` without resolving the dependency
+ * graph, for the changes that touch no package the lockfile records.
+ *
+ * A patch that matches a locked package contributes a `(patch_hash=...)`
+ * segment to that package's key, so adding, removing, or editing such a patch
+ * rekeys the graph and has to go through the resolver. A patch key that
+ * matches nothing contributes nothing, which makes the recorded map the only
+ * thing that changes.
+ *
+ * Returns `false` — nothing changed, a changed key matches a locked package,
+ * or the new configuration leaves a patch unused while `allowUnusedPatches` is
+ * off — which keeps the full-resolution path, where `ERR_PNPM_UNUSED_PATCH` is
+ * raised.
+ */
+export function tryFastUpdatePatchedDependencies (
+  lockfile: LockfileObject,
+  opts: FastPatchedDependenciesUpdateOptions
+): boolean {
+  const recorded = lockfile.patchedDependencies ?? {}
+  const current = opts.patchedDependencies ?? {}
+  const affected = changedKeys(recorded, current)
+  if (affected.length === 0) return false
+
+  const applied = appliedPatchKeys(lockfile, opts.patchGroups)
+  if (applied == null) return false
+  if (affected.some((key) => applied.has(key))) return false
+  if (!opts.allowUnusedPatches && opts.patchGroups != null) {
+    for (const key of allPatchKeys(opts.patchGroups)) {
+      if (!applied.has(key)) return false
+    }
+  }
+
+  if (Object.keys(current).length === 0) {
+    delete lockfile.patchedDependencies
+  } else {
+    lockfile.patchedDependencies = current
+  }
+  return true
+}
+
+function changedKeys (
+  recorded: Record<string, string>,
+  current: Record<string, string>
+): string[] {
+  const keys = new Set([...Object.keys(recorded), ...Object.keys(current)])
+  return [...keys].filter((key) => recorded[key] !== current[key])
+}
+
+/**
+ * The configured patch keys that match a package the lockfile records, matched
+ * the way the resolver matches them.
+ *
+ * `undefined` when a locked package matches more than one configured range, so
+ * the caller falls back and lets the resolver raise
+ * `ERR_PNPM_PATCH_KEY_CONFLICT` instead of quietly picking a winner.
+ */
+function appliedPatchKeys (
+  lockfile: LockfileObject,
+  patchGroups: PatchGroupRecord | undefined
+): Set<string> | undefined {
+  const applied = new Set<string>()
+  if (patchGroups == null) return applied
+  for (const [depPath, snapshot] of Object.entries(lockfile.packages ?? {})) {
+    const { name, version } = nameVerFromPkgSnapshot(depPath, snapshot)
+    if (version == null) continue
+    let patch
+    try {
+      patch = getPatchInfo(patchGroups, name, version)
+    } catch {
+      return undefined
+    }
+    if (patch != null) applied.add(patch.key)
+  }
+  return applied
+}

--- a/pnpm11/installing/deps-installer/test/install/patchedDependenciesFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/patchedDependenciesFastUpdate.ts
@@ -1,11 +1,32 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
 import { expect, test } from '@jest/globals'
+import { createHexHashFromFile } from '@pnpm/crypto.hash'
+import { mutateModulesInSingleProject } from '@pnpm/installing.deps-installer'
 import type { LockfileObject } from '@pnpm/lockfile.types'
-import type { DepPath, ProjectId } from '@pnpm/types'
+import { prepareEmpty } from '@pnpm/prepare'
+import type { StoreController } from '@pnpm/store.controller-types'
+import { fixtures } from '@pnpm/test-fixtures'
+import type { DepPath, ProjectId, ProjectManifest, ProjectRootDir } from '@pnpm/types'
 
 import {
   type FastPatchedDependenciesUpdateOptions,
   tryFastUpdatePatchedDependencies,
 } from '../../src/install/tryFastUpdatePatchedDependencies.js'
+import { testDefaults } from '../utils/index.js'
+
+const f = fixtures(import.meta.dirname)
+
+function trackRequestedPackages (storeController: StoreController): string[] {
+  const requestedPackages: string[] = []
+  const requestPackage = storeController.requestPackage
+  storeController.requestPackage = async (wantedDependency, requestOptions) => {
+    requestedPackages.push(wantedDependency.alias!)
+    return requestPackage(wantedDependency, requestOptions)
+  }
+  return requestedPackages
+}
 
 test('a patch that matches no locked package is recorded without resolution', () => {
   const lockfile = lockfileWithRegistryDependency()
@@ -56,6 +77,18 @@ test('editing a patch for a locked package rekeys it to the new hash', () => {
     patchedDependencies: { 'foo@1.1.0': 'edited-hash' },
   }))).toBe(true)
   expect(Object.keys(lockfile.packages!)).toStrictEqual(['foo@1.1.0(patch_hash=edited-hash)'])
+})
+
+test('a dependent reference to a rekeyed package is moved too', () => {
+  const lockfile = lockfileWithTransitiveDependency()
+
+  expect(tryFastUpdatePatchedDependencies(lockfile, updateOptions({
+    patchedDependencies: { 'foo@1.1.0': 'foo-hash' },
+  }))).toBe(true)
+  expect(lockfile.packages!['bar@2.0.0' as DepPath].dependencies)
+    .toStrictEqual({ foo: '1.1.0(patch_hash=foo-hash)' })
+  expect(lockfile.importers['.' as ProjectId].dependencies)
+    .toStrictEqual({ bar: '2.0.0' })
 })
 
 test('a package another snapshot reaches as a peer falls back to resolution', () => {
@@ -110,12 +143,100 @@ test('an unchanged configuration does not claim the install', () => {
   }))).toBe(false)
 })
 
+test('adding a patch for a locked package rekeys it without resolution', async () => {
+  const project = prepareEmpty()
+  const patchPath = path.join(f.find('patch-pkg'), 'is-positive@1.0.0.patch')
+  const manifest: ProjectManifest = { dependencies: { 'is-positive': '1.0.0' } }
+  const options = testDefaults()
+
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, options)
+  expect(fs.readFileSync('node_modules/is-positive/index.js', 'utf8')).not.toContain('// patched')
+
+  const patchFileHash = await createHexHashFromFile(patchPath)
+  const patchedOptions = testDefaults({
+    patchedDependencies: { 'is-positive@1.0.0': patchPath },
+  })
+  const requestedPackages = trackRequestedPackages(patchedOptions.storeController)
+
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, patchedOptions)
+
+  // Necessary but not sufficient on its own: a full resolution over an
+  // unchanged graph also requests nothing. What this pins is the end state —
+  // that the rewrite lands the same lockfile and node_modules a resolve would.
+  // `an_unused_patch_is_recorded_without_resolution_and_a_used_one_is_not` in
+  // pacquet's `lockfile_resolution_reuse` is what proves resolution is skipped.
+  expect(requestedPackages).toStrictEqual([])
+  const lockfile = project.readLockfile()
+  expect(lockfile.patchedDependencies).toStrictEqual({ 'is-positive@1.0.0': patchFileHash })
+  expect(lockfile.snapshots[`is-positive@1.0.0(patch_hash=${patchFileHash})`]).toBeTruthy()
+  expect(lockfile.importers['.' as ProjectId].dependencies!['is-positive']).toStrictEqual({
+    specifier: '1.0.0',
+    version: `1.0.0(patch_hash=${patchFileHash})`,
+  })
+  expect(fs.readFileSync('node_modules/is-positive/index.js', 'utf8')).toContain('// patched')
+})
+
+test('the rekeyed lockfile matches what a full resolution writes', async () => {
+  const patchPath = path.join(f.find('patch-pkg'), 'is-positive@1.0.0.patch')
+  const manifest: ProjectManifest = { dependencies: { 'is-positive': '1.0.0' } }
+
+  const rekeyed = prepareEmpty()
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, testDefaults())
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, testDefaults({ patchedDependencies: { 'is-positive@1.0.0': patchPath } }))
+  const rekeyedLockfile = rekeyed.readLockfile()
+
+  const resolved = prepareEmpty()
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, testDefaults({ patchedDependencies: { 'is-positive@1.0.0': patchPath } }))
+
+  expect(rekeyedLockfile).toStrictEqual(resolved.readLockfile())
+})
+
 function updateOptions (
   opts: Partial<FastPatchedDependenciesUpdateOptions> & {
     patchedDependencies: Record<string, string>
   }
 ): FastPatchedDependenciesUpdateOptions {
   return { allowUnusedPatches: true, ...opts }
+}
+
+/** `bar` depends on `foo`, so patching `foo` moves the reference inside `bar`. */
+function lockfileWithTransitiveDependency (): LockfileObject {
+  return {
+    lockfileVersion: '9.0',
+    importers: {
+      ['.' as ProjectId]: {
+        specifiers: { bar: '^2.0.0' },
+        dependencies: { bar: '2.0.0' },
+      },
+    },
+    packages: {
+      ['bar@2.0.0' as DepPath]: {
+        resolution: { integrity: 'sha512-deadbeef' },
+        dependencies: { foo: '1.1.0' },
+      },
+      ['foo@1.1.0' as DepPath]: { resolution: { integrity: 'sha512-deadbeef' } },
+    },
+  }
 }
 
 /** `bar` reaches `foo` as a peer, so `foo`'s depPath is embedded in `bar`'s key. */

--- a/pnpm11/installing/deps-installer/test/install/patchedDependenciesFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/patchedDependenciesFastUpdate.ts
@@ -16,49 +16,69 @@ test('a patch that matches no locked package is recorded without resolution', ()
   expect(lockfile.patchedDependencies).toStrictEqual({ 'bar@2.0.0': 'bar-hash' })
 })
 
-test('a patch that matches a locked package falls back to resolution', () => {
+test('a patch that matches a locked package is rekeyed without resolution', () => {
   const lockfile = lockfileWithRegistryDependency()
 
   expect(tryFastUpdatePatchedDependencies(lockfile, updateOptions({
     patchedDependencies: { 'foo@1.1.0': 'foo-hash' },
-  }))).toBe(false)
-  expect(lockfile.patchedDependencies).toBeUndefined()
+  }))).toBe(true)
+  expect(Object.keys(lockfile.packages!)).toStrictEqual(['foo@1.1.0(patch_hash=foo-hash)'])
+  expect(lockfile.importers['.' as ProjectId].dependencies)
+    .toStrictEqual({ foo: '1.1.0(patch_hash=foo-hash)' })
 })
 
-test('a bare-name patch key that matches a locked package falls back to resolution', () => {
+test('a bare-name patch key rekeys every version it matches', () => {
   const lockfile = lockfileWithRegistryDependency()
 
   expect(tryFastUpdatePatchedDependencies(lockfile, updateOptions({
     patchedDependencies: { foo: 'foo-hash' },
-  }))).toBe(false)
+  }))).toBe(true)
+  expect(Object.keys(lockfile.packages!)).toStrictEqual(['foo@1.1.0(patch_hash=foo-hash)'])
 })
 
-test('a range patch key that matches a locked package falls back to resolution', () => {
-  const lockfile = lockfileWithRegistryDependency()
-
-  expect(tryFastUpdatePatchedDependencies(lockfile, updateOptions({
-    patchedDependencies: { 'foo@^1.0.0': 'foo-hash' },
-  }))).toBe(false)
-})
-
-test('removing a patch that was applied to a locked package falls back to resolution', () => {
+test('removing a patch that was applied renames the package back', () => {
   const lockfile = lockfileWithPatchedDependency()
   lockfile.patchedDependencies = { 'foo@1.1.0': 'foo-hash' }
 
   expect(tryFastUpdatePatchedDependencies(lockfile, updateOptions({
     patchedDependencies: {},
-  }))).toBe(false)
-  expect(lockfile.patchedDependencies).toStrictEqual({ 'foo@1.1.0': 'foo-hash' })
+  }))).toBe(true)
+  expect(Object.keys(lockfile.packages!)).toStrictEqual(['foo@1.1.0'])
+  expect(lockfile.importers['.' as ProjectId].dependencies).toStrictEqual({ foo: '1.1.0' })
+  expect(lockfile.patchedDependencies).toBeUndefined()
 })
 
-test('an editing of a patch for a locked package falls back to resolution', () => {
-  const lockfile = lockfileWithRegistryDependency()
-  lockfile.patchedDependencies = { 'foo@1.1.0': 'stale-hash' }
+test('editing a patch for a locked package rekeys it to the new hash', () => {
+  const lockfile = lockfileWithPatchedDependency()
+  lockfile.patchedDependencies = { 'foo@1.1.0': 'foo-hash' }
+
+  expect(tryFastUpdatePatchedDependencies(lockfile, updateOptions({
+    patchedDependencies: { 'foo@1.1.0': 'edited-hash' },
+  }))).toBe(true)
+  expect(Object.keys(lockfile.packages!)).toStrictEqual(['foo@1.1.0(patch_hash=edited-hash)'])
+})
+
+test('a package another snapshot reaches as a peer falls back to resolution', () => {
+  const lockfile = lockfileWithPeerDependency()
 
   expect(tryFastUpdatePatchedDependencies(lockfile, updateOptions({
     patchedDependencies: { 'foo@1.1.0': 'foo-hash' },
   }))).toBe(false)
-  expect(lockfile.patchedDependencies).toStrictEqual({ 'foo@1.1.0': 'stale-hash' })
+})
+
+test('a hashed peer suffix falls back to resolution', () => {
+  const lockfile = lockfileWithPeerDependency()
+  lockfile.packages = {
+    ['bar@2.0.0(sha256-abcdef)' as DepPath]: {
+      resolution: { integrity: 'sha512-deadbeef' },
+      dependencies: { foo: '1.1.0' },
+    },
+    ['foo@1.1.0' as DepPath]: { resolution: { integrity: 'sha512-deadbeef' } },
+  }
+
+  expect(tryFastUpdatePatchedDependencies(lockfile, updateOptions({
+    patchedDependencies: { 'foo@1.1.0': 'foo-hash' },
+  }))).toBe(false)
 })
 
 test('an unused patch falls back to resolution when unused patches are not allowed', () => {
@@ -96,6 +116,26 @@ function updateOptions (
   }
 ): FastPatchedDependenciesUpdateOptions {
   return { allowUnusedPatches: true, ...opts }
+}
+
+/** `bar` reaches `foo` as a peer, so `foo`'s depPath is embedded in `bar`'s key. */
+function lockfileWithPeerDependency (): LockfileObject {
+  return {
+    lockfileVersion: '9.0',
+    importers: {
+      ['.' as ProjectId]: {
+        specifiers: { bar: '^2.0.0' },
+        dependencies: { bar: '2.0.0(foo@1.1.0)' },
+      },
+    },
+    packages: {
+      ['bar@2.0.0(foo@1.1.0)' as DepPath]: {
+        resolution: { integrity: 'sha512-deadbeef' },
+        dependencies: { foo: '1.1.0' },
+      },
+      ['foo@1.1.0' as DepPath]: { resolution: { integrity: 'sha512-deadbeef' } },
+    },
+  }
 }
 
 /** The same graph after a patch for `foo` was applied. */

--- a/pnpm11/installing/deps-installer/test/install/patchedDependenciesFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/patchedDependenciesFastUpdate.ts
@@ -1,0 +1,116 @@
+import { expect, test } from '@jest/globals'
+import type { LockfileObject } from '@pnpm/lockfile.types'
+import { groupPatchedDependencies } from '@pnpm/patching.config'
+import type { DepPath, ProjectId } from '@pnpm/types'
+
+import {
+  type FastPatchedDependenciesUpdateOptions,
+  tryFastUpdatePatchedDependencies,
+} from '../../src/install/tryFastUpdatePatchedDependencies.js'
+
+test('a patch that matches no locked package is recorded without resolution', () => {
+  const lockfile = lockfileWithRegistryDependency()
+
+  expect(tryFastUpdatePatchedDependencies(lockfile, updateOptions({
+    patchedDependencies: { 'bar@2.0.0': 'bar-hash' },
+  }))).toBe(true)
+  expect(lockfile.patchedDependencies).toStrictEqual({ 'bar@2.0.0': 'bar-hash' })
+})
+
+test('a patch that matches a locked package falls back to resolution', () => {
+  const lockfile = lockfileWithRegistryDependency()
+
+  expect(tryFastUpdatePatchedDependencies(lockfile, updateOptions({
+    patchedDependencies: { 'foo@1.1.0': 'foo-hash' },
+  }))).toBe(false)
+  expect(lockfile.patchedDependencies).toBeUndefined()
+})
+
+test('a bare-name patch key that matches a locked package falls back to resolution', () => {
+  const lockfile = lockfileWithRegistryDependency()
+
+  expect(tryFastUpdatePatchedDependencies(lockfile, updateOptions({
+    patchedDependencies: { foo: 'foo-hash' },
+  }))).toBe(false)
+})
+
+test('a range patch key that matches a locked package falls back to resolution', () => {
+  const lockfile = lockfileWithRegistryDependency()
+
+  expect(tryFastUpdatePatchedDependencies(lockfile, updateOptions({
+    patchedDependencies: { 'foo@^1.0.0': 'foo-hash' },
+  }))).toBe(false)
+})
+
+test('an editing of a patch for a locked package falls back to resolution', () => {
+  const lockfile = lockfileWithRegistryDependency()
+  lockfile.patchedDependencies = { 'foo@1.1.0': 'stale-hash' }
+
+  expect(tryFastUpdatePatchedDependencies(lockfile, updateOptions({
+    patchedDependencies: { 'foo@1.1.0': 'foo-hash' },
+  }))).toBe(false)
+  expect(lockfile.patchedDependencies).toStrictEqual({ 'foo@1.1.0': 'stale-hash' })
+})
+
+test('an unused patch falls back to resolution when unused patches are not allowed', () => {
+  const lockfile = lockfileWithRegistryDependency()
+
+  expect(tryFastUpdatePatchedDependencies(lockfile, updateOptions({
+    patchedDependencies: { 'bar@2.0.0': 'bar-hash' },
+    allowUnusedPatches: false,
+  }))).toBe(false)
+})
+
+test('removing a patch that matched nothing does not need allowUnusedPatches', () => {
+  const lockfile = lockfileWithRegistryDependency()
+  lockfile.patchedDependencies = { 'bar@2.0.0': 'bar-hash' }
+
+  expect(tryFastUpdatePatchedDependencies(lockfile, updateOptions({
+    patchedDependencies: {},
+    allowUnusedPatches: false,
+  }))).toBe(true)
+  expect(lockfile.patchedDependencies).toBeUndefined()
+})
+
+test('an unchanged configuration does not claim the install', () => {
+  const lockfile = lockfileWithRegistryDependency()
+  lockfile.patchedDependencies = { 'bar@2.0.0': 'bar-hash' }
+
+  expect(tryFastUpdatePatchedDependencies(lockfile, updateOptions({
+    patchedDependencies: { 'bar@2.0.0': 'bar-hash' },
+  }))).toBe(false)
+})
+
+function updateOptions (
+  opts: Partial<FastPatchedDependenciesUpdateOptions> & {
+    patchedDependencies: Record<string, string>
+  }
+): FastPatchedDependenciesUpdateOptions {
+  return {
+    allowUnusedPatches: true,
+    patchGroups: groupPatchedDependencies(
+      Object.fromEntries(Object.entries(opts.patchedDependencies).map(([key, hash]) => [
+        key,
+        { hash, patchFilePath: `/patches/${key}.patch` },
+      ]))
+    ),
+    ...opts,
+  }
+}
+
+function lockfileWithRegistryDependency (): LockfileObject {
+  return {
+    lockfileVersion: '9.0',
+    importers: {
+      ['.' as ProjectId]: {
+        specifiers: { foo: '^1.0.0' },
+        dependencies: { foo: '1.1.0' },
+      },
+    },
+    packages: {
+      ['foo@1.1.0' as DepPath]: {
+        resolution: { integrity: 'sha512-deadbeef' },
+      },
+    },
+  }
+}

--- a/pnpm11/installing/deps-installer/test/install/patchedDependenciesFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/patchedDependenciesFastUpdate.ts
@@ -91,6 +91,32 @@ test('a dependent reference to a rekeyed package is moved too', () => {
     .toStrictEqual({ bar: '2.0.0' })
 })
 
+test('a patch for a registry-qualified package falls back to resolution', () => {
+  const lockfile = lockfileWithRegistryDependency()
+  lockfile.importers['.' as ProjectId].dependencies = { foo: 'work:1.1.0' }
+  lockfile.packages = {
+    ['foo@work:1.1.0' as DepPath]: { resolution: { integrity: 'sha512-deadbeef' } },
+  }
+
+  expect(tryFastUpdatePatchedDependencies(lockfile, updateOptions({
+    patchedDependencies: { 'foo@1.1.0': 'foo-hash' },
+  }))).toBe(false)
+})
+
+test('a bare-name patch that would reach a tarball resolution falls back', () => {
+  const lockfile = lockfileWithRegistryDependency()
+  lockfile.importers['.' as ProjectId].dependencies = { foo: 'https://example.test/foo.tgz' }
+  lockfile.packages = {
+    ['foo@https://example.test/foo.tgz' as DepPath]: {
+      resolution: { tarball: 'https://example.test/foo.tgz' },
+    },
+  }
+
+  expect(tryFastUpdatePatchedDependencies(lockfile, updateOptions({
+    patchedDependencies: { foo: 'foo-hash' },
+  }))).toBe(false)
+})
+
 test('a package another snapshot reaches as a peer falls back to resolution', () => {
   const lockfile = lockfileWithPeerDependency()
 
@@ -168,11 +194,11 @@ test('adding a patch for a locked package rekeys it without resolution', async (
     rootDir: process.cwd() as ProjectRootDir,
   }, patchedOptions)
 
-  // Necessary but not sufficient on its own: a full resolution over an
-  // unchanged graph also requests nothing. What this pins is the end state —
-  // that the rewrite lands the same lockfile and node_modules a resolve would.
-  // `an_unused_patch_is_recorded_without_resolution_and_a_used_one_is_not` in
-  // pacquet's `lockfile_resolution_reuse` is what proves resolution is skipped.
+  // No registry work, matching the check the catalog and importer fast paths
+  // use. It is necessary rather than sufficient — a resolution pass seeded
+  // from this unchanged graph would request nothing either — so the proof
+  // that resolution is skipped lives in pacquet's `lockfile_resolution_reuse`,
+  // where the reporter says so outright.
   expect(requestedPackages).toStrictEqual([])
   const lockfile = project.readLockfile()
   expect(lockfile.patchedDependencies).toStrictEqual({ 'is-positive@1.0.0': patchFileHash })

--- a/pnpm11/installing/deps-installer/test/install/patchedDependenciesFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/patchedDependenciesFastUpdate.ts
@@ -1,6 +1,5 @@
 import { expect, test } from '@jest/globals'
 import type { LockfileObject } from '@pnpm/lockfile.types'
-import { groupPatchedDependencies } from '@pnpm/patching.config'
 import type { DepPath, ProjectId } from '@pnpm/types'
 
 import {
@@ -40,6 +39,16 @@ test('a range patch key that matches a locked package falls back to resolution',
   expect(tryFastUpdatePatchedDependencies(lockfile, updateOptions({
     patchedDependencies: { 'foo@^1.0.0': 'foo-hash' },
   }))).toBe(false)
+})
+
+test('removing a patch that was applied to a locked package falls back to resolution', () => {
+  const lockfile = lockfileWithPatchedDependency()
+  lockfile.patchedDependencies = { 'foo@1.1.0': 'foo-hash' }
+
+  expect(tryFastUpdatePatchedDependencies(lockfile, updateOptions({
+    patchedDependencies: {},
+  }))).toBe(false)
+  expect(lockfile.patchedDependencies).toStrictEqual({ 'foo@1.1.0': 'foo-hash' })
 })
 
 test('an editing of a patch for a locked package falls back to resolution', () => {
@@ -86,16 +95,20 @@ function updateOptions (
     patchedDependencies: Record<string, string>
   }
 ): FastPatchedDependenciesUpdateOptions {
-  return {
-    allowUnusedPatches: true,
-    patchGroups: groupPatchedDependencies(
-      Object.fromEntries(Object.entries(opts.patchedDependencies).map(([key, hash]) => [
-        key,
-        { hash, patchFilePath: `/patches/${key}.patch` },
-      ]))
-    ),
-    ...opts,
+  return { allowUnusedPatches: true, ...opts }
+}
+
+/** The same graph after a patch for `foo` was applied. */
+function lockfileWithPatchedDependency (): LockfileObject {
+  const lockfile = lockfileWithRegistryDependency()
+  lockfile.importers['.' as ProjectId].dependencies!.foo = '1.1.0(patch_hash=foo-hash)'
+  lockfile.packages = {
+    ['foo@1.1.0(patch_hash=foo-hash)' as DepPath]: {
+      patched: true,
+      resolution: { integrity: 'sha512-deadbeef' },
+    },
   }
+  return lockfile
 }
 
 function lockfileWithRegistryDependency (): LockfileObject {

--- a/pnpm11/patching/config/src/index.ts
+++ b/pnpm11/patching/config/src/index.ts
@@ -1,3 +1,4 @@
+export { allPatchKeys } from './allPatchKeys.js'
 export { getPatchInfo } from './getPatchInfo.js'
 export { groupPatchedDependencies } from './groupPatchedDependencies.js'
 export { verifyPatches, type VerifyPatchesOptions } from './verifyPatches.js'


### PR DESCRIPTION
## Summary

Related to pnpm/pnpm#13474 — the patched-dependencies stage of the lockfile fast-path roadmap, following pnpm/pnpm#13477 (catalogs), pnpm/pnpm#13482 (ignored optional dependencies), and pnpm/pnpm#13600 (setting-only updates).

Resolution never reads a patch. It appends the patch file's hash to an already-resolved package id, so a `patchedDependencies` change leaves the set of packages and versions untouched and moves only the affected keys. Adding, editing, or removing an entry is therefore a rewrite of the loaded lockfile, not a re-resolve.

- Rewrite the affected `snapshots:` keys and every reference pointing at them — the importers' resolved versions and dependents' dependency references. `packages:` is keyed without the patch hash, so it does not move.
- A patch key that matches no locked package is recorded with no rewrite at all.
- Implemented in both the TypeScript CLI (`tryFastUpdatePatchedDependencies`) and pacquet (`fast_update_patched_dependencies`).
- Export `allPatchKeys` from `@pnpm/patching.config`, which the unused-patch predicate needs and `verifyPatches` already used internally.

The patched tarball is already in the store, so materialization applies the patch with no network access. Because the rekey gives the package a new depPath, it lands in a fresh virtual-store slot — a patched package with an install script is rebuilt against the patched sources rather than reusing the previous build. There is an integration test for exactly that.

### When it still resolves

- **The patched package is reachable as a peer.** `resolve_peers` can emit a peer provider as its full depPath, so a patched provider is embedded in its dependents' peer suffixes and rekeying it would rekey them too.
- **A peer suffix was shortened into a hash.** Once the joined segments exceed `peersSuffixMaxLength` pnpm replaces them with a short hash, which cannot be inspected to rule the above out.
- **The new configuration leaves a patch unused while `allowUnusedPatches` is off**, so `ERR_PNPM_UNUSED_PATCH` is still raised. The two stacks disagree today about *when* they run that check — the TypeScript CLI only verifies on a forced or from-empty resolution, pacquet on every non-filtered fresh resolution — so rather than encode that divergence, both fall back under the same condition.
- **A locked package matches more than one configured range**, leaving `ERR_PNPM_PATCH_KEY_CONFLICT` to the resolver, and **a patch file that cannot be read or hashed**.

## Squash Commit Body

```text
Resolution never reads a patch. It appends the patch file's hash to an
already-resolved package id, so a `patchedDependencies` change leaves the
set of packages and versions untouched and moves only the affected keys.
Rewrite those keys and the references pointing at them instead of
re-resolving.

`packages:` is keyed without the patch hash, so only `snapshots:`, the
importers' resolved versions, and dependents' dependency references move.
The patched tarball is already in the store, so materialization applies
the patch with no network access, and the new depPath puts the package in
a fresh virtual-store slot so an install script reruns against the
patched sources.

Fall back to the resolver when the patched package is reachable as a peer
(its depPath is embedded in dependents' peer suffixes), when a peer suffix
was shortened into a hash and cannot be inspected, when the new
configuration would leave a patch unused while `allowUnusedPatches` is
off, and when a patch file cannot be read.

Implemented in both the TypeScript CLI and pacquet.

Related to pnpm/pnpm#13474.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Install and lockfile updates are faster when adding, changing, or removing patches, without unnecessary dependency resolution.
  * Safe patch changes update lockfile references and patched packages directly.

* **Bug Fixes**
  * Improved handling of unused patches, including clear errors when unused patches are disallowed.
  * Correctly handles edited, removed, range-based, and bare-name patches.
  * Re-runs install scripts when patched package contents change.
  * Uses full resolution for unsupported or unsafe dependency relationships.

* **Tests**
  * Expanded coverage for patched dependency updates, lockfile behavior, peer dependencies, and resolution fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->