### PR TITLE
feat(resolving-git-resolver)!: treat hosted git specs as identities, not transport choices

### DIFF
--- a/.changeset/git-specs-are-identities.md
+++ b/.changeset/git-specs-are-identities.md
@@ -6,7 +6,7 @@
 
 To reach a private hosted repository over SSH, configure the machine (not the project) with git's own URL rewriting, for example:
 
-```
+```sh
 git config --global url."git@github.com:".insteadOf https://github.com/
 ```
 

--- a/.changeset/git-specs-are-identities.md
+++ b/.changeset/git-specs-are-identities.md
@@ -1,0 +1,15 @@
+---
+"pacquet": minor
+---
+
+**Breaking change.** Git dependencies on known hosts (GitHub, GitLab, Bitbucket) are now treated as identities rather than transport choices. Every representation of the same repository — `github:owner/repo`, `owner/repo`, `git+https://…`, `git+ssh://git@…` — resolves through the host's canonical HTTPS URL, and the lockfile never records an SSH URL for them. Repositories whose archive endpoint is anonymously reachable resolve to the host's archive (fast tarball download); all others resolve to a `git` clone of the canonical HTTPS URL, which every machine with access to the repository can fetch.
+
+To reach a private hosted repository over SSH, configure the machine (not the project) with git's own URL rewriting, for example:
+
+```
+git config --global url."git@github.com:".insteadOf https://github.com/
+```
+
+pnpm shells out to `git`, so the rewrite applies to all of pnpm's git operations automatically. URLs of unknown hosts (self-hosted servers) are unaffected and keep their exact URL, including SSH. URLs with embedded credentials are also kept verbatim and never resolve to a host archive.
+
+This removes the network probing that previously decided between HTTPS and SSH at resolution time, which could record a transport that only worked on the machine that happened to run the resolution (e.g. an SSH URL that broke CI runners without SSH keys).

--- a/.changeset/git-specs-are-identities.md
+++ b/.changeset/git-specs-are-identities.md
@@ -1,8 +1,8 @@
 ---
-"pacquet": minor
+"pacquet": major
 ---
 
-**Breaking change.** Git dependencies on known hosts (GitHub, GitLab, Bitbucket) are now treated as identities rather than transport choices. Every representation of the same repository — `github:owner/repo`, `owner/repo`, `git+https://…`, `git+ssh://git@…` — resolves through the host's canonical HTTPS URL, and the lockfile never records an SSH URL for them. Repositories whose archive endpoint is anonymously reachable resolve to the host's archive (fast tarball download); all others resolve to a `git` clone of the canonical HTTPS URL, which every machine with access to the repository can fetch.
+Git dependencies on known hosts (GitHub, GitLab, Bitbucket) are now treated as identities rather than transport choices. Every representation of the same repository — `github:owner/repo`, `owner/repo`, `git+https://…`, `git+ssh://git@…` — resolves through the host's canonical HTTPS URL, and the lockfile never records an SSH URL for them. Repositories whose archive endpoint is anonymously reachable resolve to the host's archive (fast tarball download); all others resolve to a `git` clone of the canonical HTTPS URL, which every machine with access to the repository can fetch.
 
 To reach a private hosted repository over SSH, configure the machine (not the project) with git's own URL rewriting, for example:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5067,6 +5067,7 @@ version = "0.0.1"
 dependencies = [
  "derive_more",
  "miette 7.6.0",
+ "mockito",
  "node-semver",
  "pacquet-git-fetcher",
  "pacquet-lockfile",

--- a/pnpm/crates/resolving-git-resolver/Cargo.toml
+++ b/pnpm/crates/resolving-git-resolver/Cargo.toml
@@ -28,6 +28,7 @@ tokio       = { workspace = true }
 tracing     = { workspace = true }
 
 [dev-dependencies]
+mockito           = { workspace = true }
 pretty_assertions = { workspace = true }
 tokio             = { workspace = true, features = ["macros", "rt"] }
 

--- a/pnpm/crates/resolving-git-resolver/src/git_resolver.rs
+++ b/pnpm/crates/resolving-git-resolver/src/git_resolver.rs
@@ -2,7 +2,7 @@
 //! ls-remote runner into a single [`Resolver`] the dispatcher can
 //! compose into the default-resolver chain.
 
-use std::sync::Arc;
+use std::{future::Future, pin::Pin, sync::Arc};
 
 use pacquet_git_fetcher::{GitManifestQuery, read_git_manifest};
 use pacquet_lockfile::{GitResolution, LockfileResolution, TarballResolution};
@@ -18,9 +18,31 @@ use pacquet_tarball::{FetchTarballForResolution, RetryOpts};
 use crate::{
     create_git_hosted_pkg_id::create_git_hosted_pkg_id,
     hosted_git::HostedOpts,
-    parse_bare_specifier::{GitProbe, HostedPackageSpec, parse_bare_specifier},
+    parse_bare_specifier::{HostedPackageSpec, parse_bare_specifier},
     resolve_ref::{GitCommandRunner, resolve_ref},
 };
+
+/// Boxed-future return type used by [`GitProbe`]. Same shape as the
+/// rest of pacquet's async traits (see `ResolveFuture`).
+pub type ProbeFuture<'a> = Pin<Box<dyn Future<Output = bool> + Send + 'a>>;
+
+/// Capability seam for the one network check resolution performs: an
+/// anonymous HTTP HEAD of a host's archive URL.
+///
+/// The host-archive (tarball) shape is recorded only when this probe
+/// proves the exact URL to be recorded anonymously fetchable, so a
+/// recorded archive URL is valid by construction. On probe failure the
+/// resolution falls back to `type: git` over the canonical HTTPS URL,
+/// which every machine with access to the repo can fetch — a false
+/// negative (private repo, host throttling past the retries) costs
+/// archive speed on one dependency, never correctness.
+pub trait GitProbe: Send + Sync {
+    /// `true` when an anonymous HTTP HEAD of `url` returned 2xx.
+    /// Implementations retry transient failures (429/5xx/network
+    /// errors) so host throttling is not mistaken for a private
+    /// repository.
+    fn anonymous_head_ok<'a>(&'a self, url: &'a str) -> ProbeFuture<'a>;
+}
 
 /// Store/network handles [`GitResolver`] needs to read a git dep's
 /// identity out of the package itself during resolution.
@@ -34,10 +56,11 @@ use crate::{
 ///
 /// Two shapes, by resolution:
 ///
-/// - a git *host* (`github:` / `gitlab:` / `bitbucket:`) serves an
-///   archive, which is downloaded and hashed;
-/// - any other repo (ssh, self-hosted, `file:`) has no archive
-///   endpoint, so a throwaway checkout is the cheapest read.
+/// - a git *host*'s anonymously fetchable archive (see [`GitProbe`])
+///   is downloaded and hashed;
+/// - any other repo (unknown host, private hosted repo, `file:`) has
+///   no usable archive endpoint, so a throwaway checkout is the
+///   cheapest read.
 ///
 /// Either way this stops at the manifest: `prepare` / `prepublish` and
 /// packlist filtering stay in the install pass, so no package script
@@ -117,10 +140,14 @@ impl<Probe: GitProbe + 'static, Runner: GitCommandRunner + 'static> GitResolver<
     ) -> Result<Option<ResolveResult>, ResolveError> {
         let Some(bare) = wanted_dependency.bare_specifier.as_deref() else { return Ok(None) };
         let Some(partial) = parse_bare_specifier(bare) else { return Ok(None) };
-        let spec = partial.finalize(self.probe.as_ref()).await;
-        let mut result =
-            build_resolve_result(spec, self.runner.as_ref(), wanted_dependency.alias.as_deref())
-                .await?;
+        let spec = partial.finalize();
+        let mut result = build_resolve_result(
+            spec,
+            self.probe.as_ref(),
+            self.runner.as_ref(),
+            wanted_dependency.alias.as_deref(),
+        )
+        .await?;
         self.read_package_metadata(&mut result).await?;
         Ok(Some(result))
     }
@@ -210,8 +237,9 @@ impl<Probe: GitProbe + 'static, Runner: GitCommandRunner + 'static> GitResolver<
     }
 }
 
-async fn build_resolve_result<Runner: GitCommandRunner + ?Sized>(
+async fn build_resolve_result<Probe: GitProbe + ?Sized, Runner: GitCommandRunner + ?Sized>(
     spec: HostedPackageSpec,
+    probe: &Probe,
     runner: &Runner,
     alias: Option<&str>,
 ) -> Result<ResolveResult, ResolveError> {
@@ -224,7 +252,7 @@ async fn build_resolve_result<Runner: GitCommandRunner + ?Sized>(
             .await
             .map_err(|err| Box::new(err) as ResolveError)?;
 
-    let resolution = pick_resolution(&spec, &commit);
+    let resolution = pick_resolution(&spec, probe, &commit).await;
 
     let id_string = match &resolution {
         LockfileResolution::Tarball(t) => {
@@ -255,14 +283,19 @@ async fn build_resolve_result<Runner: GitCommandRunner + ?Sized>(
     })
 }
 
-/// Pick between a tarball and a git resolution.
-fn pick_resolution(spec: &HostedPackageSpec, commit: &str) -> LockfileResolution {
-    if let Some(hosted) = spec.hosted.as_ref()
-        && !is_ssh(&spec.fetch_spec)
-    {
+/// Pick between a tarball and a git resolution — see [`GitProbe`] for
+/// the rule and its fail-safe direction.
+async fn pick_resolution<Probe: GitProbe + ?Sized>(
+    spec: &HostedPackageSpec,
+    probe: &Probe,
+    commit: &str,
+) -> LockfileResolution {
+    if let Some(hosted) = spec.hosted.as_ref() {
         let mut hosted = hosted.clone();
         hosted.committish = Some(commit.to_string());
-        if let Some(tarball) = hosted.tarball(HostedOpts::default()) {
+        if let Some(tarball) = hosted.tarball(HostedOpts::default())
+            && probe.anonymous_head_ok(&tarball).await
+        {
             return LockfileResolution::Tarball(TarballResolution {
                 tarball,
                 integrity: None,
@@ -276,10 +309,6 @@ fn pick_resolution(spec: &HostedPackageSpec, commit: &str) -> LockfileResolution
         commit: commit.to_string(),
         path: spec.path.clone(),
     })
-}
-
-fn is_ssh(spec: &str) -> bool {
-    spec.starts_with("git+ssh://") || spec.starts_with("git@")
 }
 
 #[cfg(test)]

--- a/pnpm/crates/resolving-git-resolver/src/git_resolver/tests.rs
+++ b/pnpm/crates/resolving-git-resolver/src/git_resolver/tests.rs
@@ -114,10 +114,6 @@ async fn github_shortcut_full_commit_returns_tarball() {
     );
 }
 
-/// The archive probe failing (private repo, or throttling past the
-/// retries) downgrades the resolution to `type: git` over the same
-/// canonical HTTPS URL — never to SSH, and never to an archive URL
-/// that just proved unfetchable.
 #[tokio::test]
 async fn archive_probe_failure_records_git_over_https() {
     const COMMIT: &str = "0000000000000000000000000000000000000000";
@@ -144,10 +140,6 @@ async fn archive_probe_failure_records_git_over_https() {
     );
 }
 
-/// An SSH representation of a known host is the same identity as the
-/// shortcut: resolution goes through the canonical HTTPS URL, and the
-/// machine-level git configuration (`url.<base>.insteadOf`) — not the
-/// spec — decides how each machine reaches the host.
 #[tokio::test]
 async fn hosted_ssh_input_resolves_through_the_https_identity() {
     const COMMIT: &str = "1234567890123456789012345678901234567890";
@@ -169,8 +161,6 @@ async fn hosted_ssh_input_resolves_through_the_https_identity() {
     );
 }
 
-/// A URL of an unknown host is kept verbatim — for it, the URL *is*
-/// the identity, transport included — and no archive probe runs.
 #[tokio::test]
 async fn unknown_host_ssh_url_stays_a_git_resolution() {
     let stdout = "abcdef1234567890123456789012345678901234\tHEAD\n";
@@ -258,10 +248,6 @@ async fn sub_folder_and_branch_resolve_to_a_tarball_carrying_the_path() {
     );
 }
 
-/// The credentials in the URL are what make the repo reachable, and a
-/// host's archive endpoint does not carry them — so this must stay a
-/// `type: git` resolution against the authenticated remote, without
-/// even probing the archive.
 #[tokio::test]
 async fn credentialed_https_url_keeps_the_authenticated_url() {
     const COMMIT: &str = "0000000000000000000000000000000000000000";

--- a/pnpm/crates/resolving-git-resolver/src/git_resolver/tests.rs
+++ b/pnpm/crates/resolving-git-resolver/src/git_resolver/tests.rs
@@ -49,10 +49,9 @@ fn runner(stdout: &str) -> FakeRunner {
     FakeRunner { stdout: stdout.to_string(), calls: Mutex::new(Vec::new()) }
 }
 
-/// Resolve `bare_specifier`, returning the result alongside the fakes
-/// so a test can assert which remote `ls-remote` was pointed at and
-/// which archive URL was probed — for this resolver those choices
-/// *are* the behavior under test.
+/// The fakes ride back with the result because which remote
+/// `ls-remote` hits and which archive URL gets probed *are* the
+/// behavior under test.
 async fn resolve_with(
     archive_ok: bool,
     stdout: &str,

--- a/pnpm/crates/resolving-git-resolver/src/git_resolver/tests.rs
+++ b/pnpm/crates/resolving-git-resolver/src/git_resolver/tests.rs
@@ -1,8 +1,5 @@
-use super::{GitProbe, GitResolver};
-use crate::{
-    parse_bare_specifier::ProbeFuture,
-    resolve_ref::{GitCommandRunner, GitRunError},
-};
+use super::{GitProbe, GitResolver, ProbeFuture};
+use crate::resolve_ref::{GitCommandRunner, GitRunError};
 use pacquet_lockfile::LockfileResolution;
 use pacquet_resolving_resolver_base::{ResolveOptions, ResolveResult, Resolver, WantedDependency};
 use std::{
@@ -12,42 +9,23 @@ use std::{
 };
 
 struct FakeProbe {
-    head_ok: bool,
-    ls_ok: bool,
-    /// When non-empty, `ls-remote --exit-code` succeeds only for these
-    /// URLs and `ls_ok` is ignored. Models a repo that is reachable
-    /// over exactly one of the candidate transports — which is what
-    /// decides the fetch spec for a private repo.
-    ls_ok_only_for: Vec<String>,
+    /// Whether the anonymous HEAD of the archive URL succeeds — the
+    /// public/private axis of the repo under test.
+    archive_ok: bool,
+    calls: Mutex<Vec<String>>,
 }
 
 impl FakeProbe {
-    /// A public repo: both probes succeed for every URL.
-    fn public() -> Self {
-        Self { head_ok: true, ls_ok: true, ls_ok_only_for: Vec::new() }
-    }
-
-    /// A private repo — the HTTPS HEAD that detects a public repo comes
-    /// back non-2xx — reachable only over `url`. Upstream's
-    /// `mockFetchAsPrivate` plus a `git` mock that throws for every
-    /// other remote.
-    fn private_reachable_over(url: &str) -> Self {
-        Self { head_ok: false, ls_ok: false, ls_ok_only_for: vec![url.to_string()] }
+    fn new(archive_ok: bool) -> Self {
+        Self { archive_ok, calls: Mutex::new(Vec::new()) }
     }
 }
 
 impl GitProbe for FakeProbe {
-    fn https_head_ok<'a>(&'a self, _url: &'a str) -> ProbeFuture<'a> {
-        let enabled = self.head_ok;
-        Box::pin(async move { enabled })
-    }
-    fn ls_remote_exit_code<'a>(&'a self, repo: &'a str) -> ProbeFuture<'a> {
-        let enabled = if self.ls_ok_only_for.is_empty() {
-            self.ls_ok
-        } else {
-            self.ls_ok_only_for.iter().any(|allowed| allowed == repo)
-        };
-        Box::pin(async move { enabled })
+    fn anonymous_head_ok<'a>(&'a self, url: &'a str) -> ProbeFuture<'a> {
+        self.calls.lock().unwrap().push(url.to_string());
+        let ok = self.archive_ok;
+        Box::pin(async move { ok })
     }
 }
 
@@ -67,27 +45,22 @@ impl GitCommandRunner for FakeRunner {
     }
 }
 
-fn resolver(head_ok: bool, ls_ok: bool, stdout: &str) -> GitResolver<FakeProbe, FakeRunner> {
-    GitResolver::new(
-        Arc::new(FakeProbe { head_ok, ls_ok, ls_ok_only_for: Vec::new() }),
-        Arc::new(runner(stdout)),
-    )
-}
-
 fn runner(stdout: &str) -> FakeRunner {
     FakeRunner { stdout: stdout.to_string(), calls: Mutex::new(Vec::new()) }
 }
 
-/// Resolve `bare_specifier`, returning the result alongside the runner
-/// so a test can assert which remote `ls-remote` was pointed at — for a
-/// private repo that choice *is* the behavior under test.
+/// Resolve `bare_specifier`, returning the result alongside the fakes
+/// so a test can assert which remote `ls-remote` was pointed at and
+/// which archive URL was probed — for this resolver those choices
+/// *are* the behavior under test.
 async fn resolve_with(
-    probe: FakeProbe,
+    archive_ok: bool,
     stdout: &str,
     bare_specifier: &str,
-) -> (ResolveResult, Arc<FakeRunner>) {
+) -> (ResolveResult, Arc<FakeRunner>, Arc<FakeProbe>) {
     let runner = Arc::new(runner(stdout));
-    let resolver = GitResolver::new(Arc::new(probe), Arc::clone(&runner));
+    let probe = Arc::new(FakeProbe::new(archive_ok));
+    let resolver = GitResolver::new(Arc::clone(&probe), Arc::clone(&runner));
     let wanted = WantedDependency {
         alias: None,
         bare_specifier: Some(bare_specifier.to_string()),
@@ -95,12 +68,12 @@ async fn resolve_with(
     };
     let result =
         resolver.resolve(&wanted, &ResolveOptions::default()).await.unwrap().expect("claimed");
-    (result, runner)
+    (result, runner, probe)
 }
 
 #[tokio::test]
 async fn declines_non_git_specifier() {
-    let resolver = resolver(true, true, "");
+    let resolver = GitResolver::new(Arc::new(FakeProbe::new(true)), Arc::new(runner("")));
     let wanted = WantedDependency {
         alias: Some("foo".to_string()),
         bare_specifier: Some("1.2.3".to_string()),
@@ -111,22 +84,15 @@ async fn declines_non_git_specifier() {
 
 #[tokio::test]
 async fn github_shortcut_full_commit_returns_tarball() {
-    let resolver = resolver(true, true, "");
-    let wanted = WantedDependency {
-        alias: None,
-        bare_specifier: Some(
-            "zkochan/is-negative#163360a8d3ae6bee9524541043197ff356f8ed99".to_string(),
-        ),
-        ..WantedDependency::default()
-    };
-    let result =
-        resolver.resolve(&wanted, &ResolveOptions::default()).await.unwrap().expect("claimed");
+    const COMMIT: &str = "163360a8d3ae6bee9524541043197ff356f8ed99";
+    let (result, runner, probe) =
+        resolve_with(true, "", &format!("zkochan/is-negative#{COMMIT}")).await;
     assert_eq!(result.resolved_via, "git-repository");
     match result.resolution {
         LockfileResolution::Tarball(t) => {
             assert_eq!(
                 t.tarball,
-                "https://codeload.github.com/zkochan/is-negative/tar.gz/163360a8d3ae6bee9524541043197ff356f8ed99",
+                format!("https://codeload.github.com/zkochan/is-negative/tar.gz/{COMMIT}"),
             );
             assert_eq!(t.git_hosted, Some(true));
             assert!(t.path.is_none());
@@ -135,25 +101,82 @@ async fn github_shortcut_full_commit_returns_tarball() {
     }
     assert_eq!(
         result.id.as_str(),
-        "https://codeload.github.com/zkochan/is-negative/tar.gz/163360a8d3ae6bee9524541043197ff356f8ed99",
+        format!("https://codeload.github.com/zkochan/is-negative/tar.gz/{COMMIT}"),
     );
     assert_eq!(
         result.normalized_bare_specifier.as_deref(),
-        Some("github:zkochan/is-negative#163360a8d3ae6bee9524541043197ff356f8ed99"),
+        Some(format!("github:zkochan/is-negative#{COMMIT}").as_str()),
+    );
+    assert!(runner.calls.lock().unwrap().is_empty(), "a full sha needs no ls-remote");
+    assert_eq!(
+        probe.calls.lock().unwrap().as_slice(),
+        [format!("https://codeload.github.com/zkochan/is-negative/tar.gz/{COMMIT}")],
+        "the probe must test the exact URL that gets recorded",
     );
 }
 
+/// The archive probe failing (private repo, or throttling past the
+/// retries) downgrades the resolution to `type: git` over the same
+/// canonical HTTPS URL — never to SSH, and never to an archive URL
+/// that just proved unfetchable.
 #[tokio::test]
-async fn ssh_url_falls_back_to_git_resolution() {
+async fn archive_probe_failure_records_git_over_https() {
+    const COMMIT: &str = "0000000000000000000000000000000000000000";
+    let (result, runner, probe) =
+        resolve_with(false, &format!("{COMMIT}\tHEAD\n"), "github:foo/bar").await;
+
+    assert_eq!(result.normalized_bare_specifier.as_deref(), Some("github:foo/bar"));
+    match &result.resolution {
+        LockfileResolution::Git(git) => {
+            assert_eq!(git.repo, "https://github.com/foo/bar.git");
+            assert_eq!(git.commit, COMMIT);
+            assert_eq!(git.path, None);
+        }
+        other => panic!("expected Git, got {other:?}"),
+    }
+    assert_eq!(result.id.as_str(), format!("git+https://github.com/foo/bar.git#{COMMIT}"));
+    assert_eq!(
+        runner.calls.lock().unwrap().as_slice(),
+        [("https://github.com/foo/bar.git".to_string(), Some("HEAD".to_string()))],
+    );
+    assert_eq!(
+        probe.calls.lock().unwrap().as_slice(),
+        [format!("https://codeload.github.com/foo/bar/tar.gz/{COMMIT}")],
+    );
+}
+
+/// An SSH representation of a known host is the same identity as the
+/// shortcut: resolution goes through the canonical HTTPS URL, and the
+/// machine-level git configuration (`url.<base>.insteadOf`) — not the
+/// spec — decides how each machine reaches the host.
+#[tokio::test]
+async fn hosted_ssh_input_resolves_through_the_https_identity() {
+    const COMMIT: &str = "1234567890123456789012345678901234567890";
+    let (result, runner, _probe) =
+        resolve_with(true, &format!("{COMMIT}\tHEAD\n"), "git+ssh://git@github.com/foo/bar.git")
+            .await;
+
+    assert_eq!(result.normalized_bare_specifier.as_deref(), Some("github:foo/bar"));
+    match &result.resolution {
+        LockfileResolution::Tarball(t) => {
+            assert_eq!(t.tarball, format!("https://codeload.github.com/foo/bar/tar.gz/{COMMIT}"));
+        }
+        other => panic!("expected Tarball, got {other:?}"),
+    }
+    assert_eq!(
+        runner.calls.lock().unwrap().as_slice(),
+        [("https://github.com/foo/bar.git".to_string(), Some("HEAD".to_string()))],
+        "ls-remote must run against the canonical HTTPS URL, not the SSH form",
+    );
+}
+
+/// A URL of an unknown host is kept verbatim — for it, the URL *is*
+/// the identity, transport included — and no archive probe runs.
+#[tokio::test]
+async fn unknown_host_ssh_url_stays_a_git_resolution() {
     let stdout = "abcdef1234567890123456789012345678901234\tHEAD\n";
-    let resolver = resolver(false, true, stdout);
-    let wanted = WantedDependency {
-        alias: None,
-        bare_specifier: Some("git+ssh://git@example.com/org/repo.git#abcdef12".to_string()),
-        ..WantedDependency::default()
-    };
-    let result =
-        resolver.resolve(&wanted, &ResolveOptions::default()).await.unwrap().expect("claimed");
+    let (result, _runner, probe) =
+        resolve_with(true, stdout, "git+ssh://git@example.com/org/repo.git#abcdef12").await;
     match result.resolution {
         LockfileResolution::Git(g) => {
             assert_eq!(g.repo, "ssh://git@example.com/org/repo.git");
@@ -163,21 +186,18 @@ async fn ssh_url_falls_back_to_git_resolution() {
         other => panic!("expected Git, got {other:?}"),
     }
     assert!(result.id.as_str().starts_with("git+ssh://git@example.com/org/repo.git#"));
+    assert!(probe.calls.lock().unwrap().is_empty());
 }
 
 #[tokio::test]
 async fn path_suffix_appended_to_id_and_resolution() {
     let stdout = "1111111111111111111111111111111111111111\tHEAD\n";
-    let resolver = resolver(true, true, stdout);
-    let wanted = WantedDependency {
-        alias: None,
-        bare_specifier: Some(
-            "github:RexSkz/test-git-subfolder-fetch#path:/packages/simple-react-app".to_string(),
-        ),
-        ..WantedDependency::default()
-    };
-    let result =
-        resolver.resolve(&wanted, &ResolveOptions::default()).await.unwrap().expect("claimed");
+    let (result, _runner, _probe) = resolve_with(
+        true,
+        stdout,
+        "github:RexSkz/test-git-subfolder-fetch#path:/packages/simple-react-app",
+    )
+    .await;
     match result.resolution {
         LockfileResolution::Tarball(t) => {
             assert_eq!(t.path.as_deref(), Some("/packages/simple-react-app"));
@@ -198,8 +218,8 @@ async fn path_suffix_appended_to_id_and_resolution() {
 #[tokio::test]
 async fn sub_folder_and_branch_resolve_to_a_tarball_carrying_the_path() {
     const BETA_COMMIT: &str = "777e8a3e78cc89bbf41fb3fd9f6cf922d5463313";
-    let (result, runner) = resolve_with(
-        FakeProbe::public(),
+    let (result, runner, _probe) = resolve_with(
+        true,
         &format!("{BETA_COMMIT}\trefs/heads/beta\n"),
         "github:RexSkz/test-git-subfolder-fetch.git#beta&path:/packages/simple-react-app",
     )
@@ -239,55 +259,17 @@ async fn sub_folder_and_branch_resolve_to_a_tarball_carrying_the_path() {
     );
 }
 
-/// TS: `resolve a private repository using the HTTPS protocol without
-/// auth token` (`resolving/git-resolver/test/index.ts:482`).
-///
-/// The HTTPS HEAD that detects a public repo fails and the anonymous
-/// HTTPS remote is unreachable, so the only transport left is SSH —
-/// and an SSH fetch spec must not resolve to the host's public archive
-/// URL.
-#[tokio::test]
-async fn private_https_repo_without_auth_falls_back_to_the_ssh_url() {
-    const SSH_URL: &str = "git+ssh://git@github.com/foo/bar.git";
-    const COMMIT: &str = "0000000000000000000000000000000000000000";
-    let (result, runner) = resolve_with(
-        FakeProbe::private_reachable_over(SSH_URL),
-        &format!("{COMMIT}\tHEAD\n"),
-        "git+https://github.com/foo/bar.git",
-    )
-    .await;
-
-    assert_eq!(result.resolved_via, "git-repository");
-    assert_eq!(result.normalized_bare_specifier.as_deref(), Some("github:foo/bar"));
-    match &result.resolution {
-        LockfileResolution::Git(git) => {
-            assert_eq!(git.repo, SSH_URL);
-            assert_eq!(git.commit, COMMIT);
-            assert_eq!(git.path, None);
-        }
-        other => panic!("expected Git, got {other:?}"),
-    }
-    assert_eq!(result.id.as_str(), format!("{SSH_URL}#{COMMIT}"));
-    assert_eq!(
-        runner.calls.lock().unwrap().as_slice(),
-        [(SSH_URL.to_string(), Some("HEAD".to_string()))],
-    );
-}
-
-/// TS: `resolve a private repository using the HTTPS protocol and an
-/// auth token` (`resolving/git-resolver/test/index.ts:526`).
-///
 /// The credentials in the URL are what make the repo reachable, and a
 /// host's archive endpoint does not carry them — so this must stay a
-/// `type: git` resolution against the authenticated remote rather than
-/// collapsing to a `codeload` URL nothing could fetch.
+/// `type: git` resolution against the authenticated remote, without
+/// even probing the archive.
 #[tokio::test]
-async fn private_https_repo_with_an_auth_token_keeps_the_authenticated_url() {
+async fn credentialed_https_url_keeps_the_authenticated_url() {
     const COMMIT: &str = "0000000000000000000000000000000000000000";
     const AUTH_URL: &str =
         "https://0000000000000000000000000000000000000000:x-oauth-basic@github.com/foo/bar.git";
-    let (result, runner) = resolve_with(
-        FakeProbe::private_reachable_over(AUTH_URL),
+    let (result, runner, probe) = resolve_with(
+        true,
         &format!("{COMMIT}\tHEAD\n"),
         "git+https://0000000000000000000000000000000000000000:x-oauth-basic@github.com/foo/bar.git",
     )
@@ -311,4 +293,5 @@ async fn private_https_repo_with_an_auth_token_keeps_the_authenticated_url() {
         runner.calls.lock().unwrap().as_slice(),
         [(AUTH_URL.to_string(), Some("HEAD".to_string()))],
     );
+    assert!(probe.calls.lock().unwrap().is_empty());
 }

--- a/pnpm/crates/resolving-git-resolver/src/lib.rs
+++ b/pnpm/crates/resolving-git-resolver/src/lib.rs
@@ -5,20 +5,27 @@
 //! plain `https://host/repo.git[#ref]` shape some hosts (Gitea, ...)
 //! serve.
 //!
+//! Specs of known hosts are identities, not transport choices: they
+//! finalise to the host's canonical HTTPS URL no matter which
+//! representation the user wrote, and each machine's own git
+//! configuration (credential helpers, `url.<base>.insteadOf`
+//! rewrites) decides how that machine reaches the host. Nothing
+//! transport-shaped is ever probed for or recorded — see
+//! `parse_bare_specifier`'s module doc.
+//!
 //! Three pieces:
 //!
 //! - [`create_git_hosted_pkg_id()`] — pure ID builder for git resolutions.
-//! - [`parse_bare_specifier()`] — recognise + normalise the input string,
-//!   resolve hosted-vs-private (HTTP HEAD probe + `git ls-remote --exit-code`
-//!   reachability check), pick a `fetchSpec`.
+//! - [`parse_bare_specifier()`] — recognise + normalise the input
+//!   string, pick a `fetchSpec`. Pure — no network.
 //! - [`GitResolver`] — the [`Resolver`](pacquet_resolving_resolver_base::Resolver)
-//!   impl that drives the two above, runs `git ls-remote` to pin a
-//!   commit, and emits either a `Tarball{gitHosted: true}` or `Git`
-//!   resolution. Given a [`GitFetchContext`], it also reads the
-//!   package's name from its `package.json` — out of the host archive,
-//!   or out of a checkout for a repo that serves no archive — plus the
-//!   archive's integrity. See that type for why resolution is where
-//!   that has to happen.
+//!   impl that runs `git ls-remote` to pin a commit and emits either a
+//!   `Tarball{gitHosted: true}` or `Git` resolution, decided by the
+//!   [`GitProbe`] archive check. Given a [`GitFetchContext`], it also
+//!   reads the package's name from its `package.json` — out of the
+//!   host archive, or out of a checkout for a repo that serves no
+//!   archive — plus the archive's integrity. See that type for why
+//!   resolution is where that has to happen.
 //!
 //! Out of scope:
 //!
@@ -38,11 +45,9 @@ mod resolve_ref;
 mod runners;
 
 pub use create_git_hosted_pkg_id::create_git_hosted_pkg_id;
-pub use git_resolver::{GitFetchContext, GitResolver};
+pub use git_resolver::{GitFetchContext, GitProbe, GitResolver, ProbeFuture};
 pub use hosted_git::{HostedGit, HostedGitType, HostedOpts};
-pub use parse_bare_specifier::{
-    GitProbe, HostedPackageSpec, PartialSpec, ProbeFuture, parse_bare_specifier,
-};
+pub use parse_bare_specifier::{HostedPackageSpec, PartialSpec, parse_bare_specifier};
 pub use resolve_ref::{
     GitCommandRunner, GitResolveRefError, GitRunError, get_repo_refs, resolve_ref,
 };

--- a/pnpm/crates/resolving-git-resolver/src/lib.rs
+++ b/pnpm/crates/resolving-git-resolver/src/lib.rs
@@ -5,13 +5,8 @@
 //! plain `https://host/repo.git[#ref]` shape some hosts (Gitea, ...)
 //! serve.
 //!
-//! Specs of known hosts are identities, not transport choices: they
-//! finalise to the host's canonical HTTPS URL no matter which
-//! representation the user wrote, and each machine's own git
-//! configuration (credential helpers, `url.<base>.insteadOf`
-//! rewrites) decides how that machine reaches the host. Nothing
-//! transport-shaped is ever probed for or recorded — see
-//! `parse_bare_specifier`'s module doc.
+//! Specs of known hosts are identities, not transport choices —
+//! `parse_bare_specifier`'s module doc states the rule.
 //!
 //! Three pieces:
 //!

--- a/pnpm/crates/resolving-git-resolver/src/parse_bare_specifier.rs
+++ b/pnpm/crates/resolving-git-resolver/src/parse_bare_specifier.rs
@@ -203,10 +203,8 @@ fn from_hosted_git(hosted: HostedGit) -> HostedPackageSpec {
     let params = parse_git_params(hosted.committish.as_deref());
     let https_url = hosted.https(HostedGit::no_committish_no_git_plus());
     // URL-embedded credentials are explicit user content, not
-    // transport: keep the exact URL, echo it back to the manifest,
-    // and withhold `hosted` so the resolution can never become a
-    // host-archive URL (the archive endpoint would not carry the
-    // credentials).
+    // transport — and the host's archive endpoint would not carry
+    // them, so the spec stays archive-ineligible.
     if hosted.auth.is_some()
         && let Some(https_url) = &https_url
     {

--- a/pnpm/crates/resolving-git-resolver/src/parse_bare_specifier.rs
+++ b/pnpm/crates/resolving-git-resolver/src/parse_bare_specifier.rs
@@ -1,18 +1,20 @@
 //! Recognise and normalise a git-shaped `bareSpecifier`.
 //!
-//! Two-phase API splits the sync protocol-prefix dispatch from the
-//! async hosted-repo probe:
+//! Parsing is pure: no network, no probing. A hosted spec (`github:`,
+//! `gitlab:`, `bitbucket:`, `owner/repo`, or any URL of a known host —
+//! HTTPS *and* SSH alike) is treated as an *identity*, not a transport
+//! choice, and always finalises to the host's canonical HTTPS URL.
+//! Which transport a given machine actually uses to reach the host is
+//! that machine's git configuration (credential helpers,
+//! `url.<base>.insteadOf` rewrites) — never something recorded in the
+//! manifest or lockfile, because it would be wrong on the next machine.
 //!
-//! * [`parse_bare_specifier`] runs the synchronous part. Returns
-//!   `None` when the input isn't a git-shaped specifier (so the
-//!   resolver chain falls through to the next resolver).
-//! * [`PartialSpec::finalize`] runs the async part. For hosted
-//!   specs it picks between https / ssh based on the
-//!   [`GitProbe`] callbacks (HTTP HEAD + `git ls-remote --exit-code`);
-//!   for protocol-prefix specs the spec is already complete and the
-//!   probe is unused.
-
-use std::{future::Future, pin::Pin};
+//! * [`parse_bare_specifier`] returns `None` when the input isn't a
+//!   git-shaped specifier (so the resolver chain falls through to the
+//!   next resolver).
+//! * [`PartialSpec::finalize`] completes the hosted branch. URLs of
+//!   unknown hosts pass through verbatim — for them the URL *is* the
+//!   identity, transport included.
 
 use crate::hosted_git::{HostedGit, HostedOpts};
 
@@ -21,11 +23,12 @@ use crate::hosted_git::{HostedGit, HostedOpts};
 pub struct HostedPackageSpec {
     /// URL passed to `git ls-remote`. Always carries no committish —
     /// the committish lives in [`Self::git_committish`] /
-    /// [`Self::git_range`].
+    /// [`Self::git_range`]. For hosted inputs this is the canonical
+    /// HTTPS URL regardless of the representation the user wrote.
     pub fetch_spec: String,
     /// Original `HostedGit` parse, when the input matched a known
-    /// host. Drives [`crate::GitResolver`]'s tarball vs git-resolution
-    /// decision.
+    /// host and carried no URL-embedded credentials. Makes the repo
+    /// eligible for [`crate::GitResolver`]'s host-archive resolution.
     pub hosted: Option<HostedGit>,
     /// What the resolver echoes back to the manifest as
     /// `normalizedBareSpecifier`. For hosted inputs this is the
@@ -39,46 +42,21 @@ pub struct HostedPackageSpec {
 
 /// Output of the sync prefilter [`parse_bare_specifier`].
 pub enum PartialSpec {
-    /// Hosted input: needs an async probe to decide https/ssh routing.
+    /// Input matched a known host: identity parsed, canonical URL
+    /// still to be derived.
     Hosted(HostedGit),
-    /// Protocol-prefix input: already finalised, no probe needed.
+    /// URL of an unknown host: already final, kept verbatim.
     Direct(HostedPackageSpec),
 }
 
 impl PartialSpec {
-    /// Drive the async leg. For [`PartialSpec::Direct`] the probe is
-    /// ignored.
-    pub async fn finalize<Probe: GitProbe + ?Sized>(self, probe: &Probe) -> HostedPackageSpec {
+    #[must_use]
+    pub fn finalize(self) -> HostedPackageSpec {
         match self {
             PartialSpec::Direct(spec) => spec,
-            PartialSpec::Hosted(hosted) => from_hosted_git(hosted, probe).await,
+            PartialSpec::Hosted(hosted) => from_hosted_git(hosted),
         }
     }
-}
-
-/// Boxed-future return type used by [`GitProbe`]. Same shape as the
-/// rest of pacquet's async traits (see `ResolveFuture`).
-pub type ProbeFuture<'a> = Pin<Box<dyn Future<Output = bool> + Send + 'a>>;
-
-/// Capability seam for the network and git invocations the hosted
-/// branch needs.
-///
-/// Real installs supply an implementation that issues an HTTP HEAD via
-/// the install-wide [`pacquet_network::ThrottledClient`] and shells
-/// out to `git ls-remote --exit-code`. Tests supply a fake that
-/// records calls and yields canned values without touching the
-/// network or the system git binary.
-pub trait GitProbe: Send + Sync {
-    /// `true` when an HTTP HEAD to the given URL returned a 2xx /
-    /// 3xx. Used to detect public repos before running `git ls-remote`
-    /// (which would otherwise prompt for credentials on a private
-    /// repo).
-    fn https_head_ok<'a>(&'a self, url: &'a str) -> ProbeFuture<'a>;
-
-    /// `true` when `git ls-remote --exit-code <url> HEAD` exited zero.
-    /// Used as a reachability test on both the https and ssh
-    /// candidates.
-    fn ls_remote_exit_code<'a>(&'a self, repo: &'a str) -> ProbeFuture<'a>;
 }
 
 const GIT_PROTOCOLS: &[&str] =
@@ -218,83 +196,31 @@ fn parse_git_params(committish: Option<&str>) -> GitParsedParams {
     out
 }
 
-/// Async leg: probe the hosted host for public-vs-private + ssh
-/// reachability, pick a `fetchSpec`.
-async fn from_hosted_git<Probe: GitProbe + ?Sized>(
-    hosted: HostedGit,
-    probe: &Probe,
-) -> HostedPackageSpec {
-    let mut fetch_spec: Option<String> = None;
-
-    let git_https_url = hosted.https(HostedGit::no_committish_no_git_plus());
-    if let Some(ref https_url) = git_https_url
-        && probe.https_head_ok(https_url).await
-        && probe.ls_remote_exit_code(https_url).await
-    {
-        fetch_spec = Some(https_url.clone());
-    }
-
-    if fetch_spec.is_none() {
-        let ssh_url = hosted.ssh(HostedGit::no_committish());
-        if let Some(ref url) = ssh_url
-            && probe.ls_remote_exit_code(url).await
-        {
-            fetch_spec = Some(url.clone());
-        }
-    }
-
-    if fetch_spec.is_none()
-        && let Some(https_url) = hosted.https(HostedGit::no_committish_no_git_plus())
-    {
-        // Private repo or HEAD probe failed: try `https` (with auth if
-        // present) directly, gated on ls-remote reachability.
-        let has_auth = hosted.auth.is_some();
-        let probe_succeeded = if has_auth || !probe.https_head_ok(&https_url).await {
-            probe.ls_remote_exit_code(&https_url).await
-        } else {
-            false
-        };
-        if probe_succeeded {
-            let params = parse_git_params(hosted.committish.as_deref());
-            return HostedPackageSpec {
-                fetch_spec: https_url.clone(),
-                // `hosted: None` drops the host-archive option, so the
-                // resolution stays `type: git` against the URL that
-                // just probed reachable. A host's archive endpoint
-                // carries none of this URL's credentials, so a private
-                // repo resolved to its `codeload`-style archive would
-                // record a URL nothing can fetch. Mirrors upstream
-                // returning `hosted: { ...hosted, tarball: undefined }`
-                // here.
-                hosted: None,
-                normalized_bare_specifier: format!("git+{https_url}"),
-                git_committish: params.git_committish,
-                git_range: params.git_range,
-                path: params.path,
-            };
-        }
-        // Try an additional HEAD probe on the bare URL (no `.git`
-        // suffix) to confirm the path resolves at all before falling
-        // through to ssh. Done only when there's no `auth`: with auth,
-        // the path is the auth-gated private URL above. Without auth,
-        // retest as below.
-        if !has_auth {
-            let stripped = https_url.strip_suffix(".git").unwrap_or(&https_url);
-            if probe.https_head_ok(stripped).await {
-                fetch_spec = Some(https_url.clone());
-            }
-        }
-    }
-
-    // Final fallback: `git+ssh` URL form (the committish-less
-    // ssh URL).
-    let fetch_spec = fetch_spec
-        .or_else(|| hosted.sshurl(HostedGit::no_committish()))
-        .unwrap_or_else(|| hosted.shortcut(HostedOpts::default()));
-
+/// Finalise a hosted spec to its canonical HTTPS URL. See the module
+/// doc for why no other representation (notably SSH) is ever derived
+/// here.
+fn from_hosted_git(hosted: HostedGit) -> HostedPackageSpec {
     let params = parse_git_params(hosted.committish.as_deref());
+    let https_url = hosted.https(HostedGit::no_committish_no_git_plus());
+    // URL-embedded credentials are explicit user content, not
+    // transport: keep the exact URL, echo it back to the manifest,
+    // and withhold `hosted` so the resolution can never become a
+    // host-archive URL (the archive endpoint would not carry the
+    // credentials).
+    if hosted.auth.is_some()
+        && let Some(https_url) = &https_url
+    {
+        return HostedPackageSpec {
+            fetch_spec: https_url.clone(),
+            hosted: None,
+            normalized_bare_specifier: format!("git+{https_url}"),
+            git_committish: params.git_committish,
+            git_range: params.git_range,
+            path: params.path,
+        };
+    }
     HostedPackageSpec {
-        fetch_spec,
+        fetch_spec: https_url.unwrap_or_else(|| hosted.shortcut(HostedOpts::default())),
         normalized_bare_specifier: hosted.shortcut(HostedOpts::default()),
         hosted: Some(hosted),
         git_committish: params.git_committish,

--- a/pnpm/crates/resolving-git-resolver/src/parse_bare_specifier/tests.rs
+++ b/pnpm/crates/resolving-git-resolver/src/parse_bare_specifier/tests.rs
@@ -1,33 +1,4 @@
-use std::sync::Mutex;
-
-use super::{
-    GitProbe, PartialSpec, ProbeFuture, correct_url, parse_bare_specifier, parse_git_params,
-};
-
-struct Fake {
-    head_ok: bool,
-    ls_ok: bool,
-    calls: Mutex<Vec<String>>,
-}
-
-impl GitProbe for Fake {
-    fn https_head_ok<'a>(&'a self, url: &'a str) -> ProbeFuture<'a> {
-        Box::pin(async move {
-            self.calls.lock().unwrap().push(format!("head {url}"));
-            self.head_ok
-        })
-    }
-    fn ls_remote_exit_code<'a>(&'a self, repo: &'a str) -> ProbeFuture<'a> {
-        Box::pin(async move {
-            self.calls.lock().unwrap().push(format!("ls {repo}"));
-            self.ls_ok
-        })
-    }
-}
-
-fn fake() -> Fake {
-    Fake { head_ok: true, ls_ok: true, calls: Mutex::new(Vec::new()) }
-}
+use super::{PartialSpec, correct_url, parse_bare_specifier, parse_git_params};
 
 #[test]
 fn rejects_non_git_url() {
@@ -89,38 +60,58 @@ fn correct_url_keeps_numeric_port() {
     );
 }
 
-#[tokio::test]
-async fn finalize_direct_returns_spec_unchanged() {
+#[test]
+fn finalize_direct_returns_spec_unchanged() {
     let kind = parse_bare_specifier("git+https://example.com/repo.git#abc").expect("direct");
-    let probe = fake();
-    let spec = kind.finalize(&probe).await;
+    let spec = kind.finalize();
     assert_eq!(spec.fetch_spec, "https://example.com/repo.git");
     assert_eq!(spec.git_committish.as_deref(), Some("abc"));
-    assert!(probe.calls.lock().unwrap().is_empty());
 }
 
-#[tokio::test]
-async fn finalize_hosted_prefers_https_when_public() {
+#[test]
+fn finalize_hosted_uses_canonical_https() {
     let kind = parse_bare_specifier("zkochan/is-negative").expect("hosted");
-    let probe = fake();
-    let spec = kind.finalize(&probe).await;
+    let spec = kind.finalize();
     assert_eq!(spec.fetch_spec, "https://github.com/zkochan/is-negative.git");
+    assert_eq!(spec.normalized_bare_specifier, "github:zkochan/is-negative");
     assert!(spec.hosted.is_some());
 }
 
-#[tokio::test]
-async fn finalize_hosted_falls_back_to_ssh_when_private() {
-    let kind = parse_bare_specifier("foo/private-repo").expect("hosted");
-    let probe = Fake { head_ok: false, ls_ok: false, calls: Mutex::new(Vec::new()) };
-    let spec = kind.finalize(&probe).await;
-    assert_eq!(spec.fetch_spec, "git+ssh://git@github.com/foo/private-repo.git");
+#[test]
+fn finalize_hosted_ssh_input_becomes_the_same_https_identity() {
+    let kind = parse_bare_specifier("git+ssh://git@github.com/foo/bar.git").expect("hosted");
+    let spec = kind.finalize();
+    assert_eq!(spec.fetch_spec, "https://github.com/foo/bar.git");
+    assert_eq!(spec.normalized_bare_specifier, "github:foo/bar");
+    assert!(spec.hosted.is_some());
+}
+
+#[test]
+fn finalize_hosted_scp_style_input_becomes_the_same_https_identity() {
+    let kind = parse_bare_specifier("git@github.com:foo/bar.git#v1.0.0").expect("hosted");
+    let spec = kind.finalize();
+    assert_eq!(spec.fetch_spec, "https://github.com/foo/bar.git");
+    assert_eq!(spec.normalized_bare_specifier, "github:foo/bar#v1.0.0");
+    assert_eq!(spec.git_committish.as_deref(), Some("v1.0.0"));
+}
+
+#[test]
+fn finalize_hosted_auth_url_kept_verbatim_without_archive_eligibility() {
+    let kind = parse_bare_specifier("git+https://token:x-oauth-basic@github.com/foo/bar.git")
+        .expect("hosted");
+    let spec = kind.finalize();
+    assert_eq!(spec.fetch_spec, "https://token:x-oauth-basic@github.com/foo/bar.git");
+    assert_eq!(
+        spec.normalized_bare_specifier,
+        "git+https://token:x-oauth-basic@github.com/foo/bar.git",
+    );
+    assert!(spec.hosted.is_none(), "credentialed URL must never resolve to a host archive");
 }
 
 // Ported `parsePref.test.ts` SCP-style URL repair cases. Each row
 // is `(input, expected_fetch_spec)`.
-#[tokio::test]
-async fn fetch_spec_for_scp_style_inputs() {
-    let probe = fake();
+#[test]
+fn fetch_spec_for_scp_style_inputs() {
     let cases: &[(&str, &str)] = &[
         (
             "ssh://username:password@example.com:repo.git",
@@ -174,7 +165,7 @@ async fn fetch_spec_for_scp_style_inputs() {
     ];
     for (input, expected) in cases {
         let kind = parse_bare_specifier(input).expect("parse claims input");
-        let spec = kind.finalize(&probe).await;
+        let spec = kind.finalize();
         assert_eq!(
             spec.fetch_spec,
             *expected,
@@ -185,9 +176,8 @@ async fn fetch_spec_for_scp_style_inputs() {
 }
 
 // Ported `parsePref.test.ts` path-extraction cases.
-#[tokio::test]
-async fn path_extracted_from_scp_style_inputs() {
-    let probe = fake();
+#[test]
+fn path_extracted_from_scp_style_inputs() {
     let cases: &[(&str, Option<&str>)] = &[
         ("ssh://username:password@example.com:repo.git#path:/a/@b", Some("/a/@b")),
         ("ssh://username:password@example.com:repo/@foo.git#path:/a/@b", Some("/a/@b")),
@@ -205,15 +195,14 @@ async fn path_extracted_from_scp_style_inputs() {
     ];
     for (input, expected_path) in cases {
         let kind = parse_bare_specifier(input).expect("parse claims input");
-        let spec = kind.finalize(&probe).await;
+        let spec = kind.finalize();
         assert_eq!(spec.path.as_deref(), *expected_path, "input {input}: path mismatch");
     }
 }
 
 // Ported "plain http/https URLs ending in .git should be recognized" suite.
-#[tokio::test]
-async fn plain_http_dot_git_recognized() {
-    let probe = fake();
+#[test]
+fn plain_http_dot_git_recognized() {
     let cases: &[(&str, &str)] = &[
         (
             "https://gitea.osmocom.org/ttcn3/highlightjs-ttcn3.git",
@@ -228,7 +217,7 @@ async fn plain_http_dot_git_recognized() {
     ];
     for (input, expected) in cases {
         let kind = parse_bare_specifier(input).expect("claim");
-        let spec = kind.finalize(&probe).await;
+        let spec = kind.finalize();
         assert_eq!(spec.fetch_spec, *expected, "input {input}");
     }
 }

--- a/pnpm/crates/resolving-git-resolver/src/runners.rs
+++ b/pnpm/crates/resolving-git-resolver/src/runners.rs
@@ -19,12 +19,19 @@ use crate::{
 /// per-registry config all apply).
 pub struct RealGitProbe {
     pub http_client: Arc<ThrottledClient>,
+    /// Per-attempt deadline, overriding the client's much larger
+    /// `fetchTimeout`. The probe only gates an optimization — failure
+    /// falls back to a `type: git` resolution that always works — so
+    /// an archive endpoint a firewall blackholes (reachable
+    /// `github.com`, blocked `codeload.github.com`) must cost seconds,
+    /// not attempts × `fetchTimeout`.
+    pub head_timeout: Duration,
 }
 
 impl RealGitProbe {
     #[must_use]
     pub fn new(http_client: Arc<ThrottledClient>) -> Self {
-        Self { http_client }
+        Self { http_client, head_timeout: Duration::from_secs(10) }
     }
 }
 
@@ -37,7 +44,13 @@ impl GitProbe for RealGitProbe {
                 // backoff sleep.
                 let status = {
                     let guard = self.http_client.acquire_for_url(url).await;
-                    guard.head(url).send().await.map(|response| response.status()).ok()
+                    guard
+                        .head(url)
+                        .timeout(self.head_timeout)
+                        .send()
+                        .await
+                        .map(|response| response.status())
+                        .ok()
                 };
                 if let Some(status) = status {
                     if status.is_success() {

--- a/pnpm/crates/resolving-git-resolver/src/runners.rs
+++ b/pnpm/crates/resolving-git-resolver/src/runners.rs
@@ -5,70 +5,54 @@
 //! pair (real network + real `git` binary) or supply their own
 //! ports of the traits in tests.
 
-use std::{
-    future::Future,
-    path::PathBuf,
-    pin::Pin,
-    process::{Command, Stdio},
-    sync::Arc,
-};
+use std::{future::Future, path::PathBuf, pin::Pin, process::Command, sync::Arc, time::Duration};
 
 use pacquet_network::ThrottledClient;
 
 use crate::{
-    parse_bare_specifier::{GitProbe, ProbeFuture},
+    git_resolver::{GitProbe, ProbeFuture},
     resolve_ref::{GitCommandRunner, GitRunError},
 };
 
-/// Production [`GitProbe`].
-///
-/// `https_head_ok` issues an HTTP HEAD via the install-wide
+/// Production [`GitProbe`]: issues the HEAD via the install-wide
 /// [`ThrottledClient`] (so concurrency-throttling, proxy, TLS, and
-/// per-registry config all apply). `ls_remote_exit_code` shells out
-/// to the system `git` binary.
-///
-/// `git_bin` overrides the binary path; production callers leave it
-/// `None` and the runner resolves `git` through `PATH`.
+/// per-registry config all apply).
 pub struct RealGitProbe {
     pub http_client: Arc<ThrottledClient>,
-    pub git_bin: Option<PathBuf>,
 }
 
 impl RealGitProbe {
     #[must_use]
     pub fn new(http_client: Arc<ThrottledClient>) -> Self {
-        Self { http_client, git_bin: None }
+        Self { http_client }
     }
 }
 
 impl GitProbe for RealGitProbe {
-    fn https_head_ok<'a>(&'a self, url: &'a str) -> ProbeFuture<'a> {
+    fn anonymous_head_ok<'a>(&'a self, url: &'a str) -> ProbeFuture<'a> {
         Box::pin(async move {
-            // Match upstream's `replace(/\.git$/, '')` strip before
-            // issuing HEAD — host endpoints serve the human page on
-            // the path without `.git`, but reject HEAD on the `.git`
-            // alias on some configurations.
-            let stripped: &str = url.strip_suffix(".git").unwrap_or(url);
-            let guard = self.http_client.acquire().await;
-            let response = guard.head(stripped).send().await;
-            match response {
-                Ok(resp) => resp.status().is_success(),
-                Err(_) => false,
+            let mut delay = Duration::from_millis(500);
+            for attempt in 0..3 {
+                let guard = self.http_client.acquire().await;
+                let response = guard.head(url).send().await;
+                drop(guard);
+                if let Ok(resp) = response {
+                    let status = resp.status();
+                    if status.is_success() {
+                        return true;
+                    }
+                    let transient = status.is_server_error()
+                        || matches!(status.as_u16(), 408 | 409 | 420 | 429);
+                    if !transient {
+                        return false;
+                    }
+                }
+                if attempt < 2 {
+                    tokio::time::sleep(delay).await;
+                    delay *= 2;
+                }
             }
-        })
-    }
-
-    fn ls_remote_exit_code<'a>(&'a self, repo: &'a str) -> ProbeFuture<'a> {
-        Box::pin(async move {
-            let bin = self.git_bin.as_deref().map(std::path::Path::to_path_buf);
-            let repo_owned = repo.to_string();
-            tokio::task::spawn_blocking(move || {
-                let mut cmd = ls_remote_command(bin.as_ref(), &repo_owned, LsRemoteMode::Probe);
-                cmd.stdout(Stdio::null()).stderr(Stdio::null()).stdin(Stdio::null());
-                cmd.status().is_ok_and(|s| s.success())
-            })
-            .await
-            .unwrap_or(false)
+            false
         })
     }
 }
@@ -126,7 +110,7 @@ fn run_ls_remote_blocking(
     let attempts = 2; // matches upstream `graceful-git` retries: 1
     let mut last_err: Option<String> = None;
     for _ in 0..attempts {
-        let mut cmd = ls_remote_command(bin, repo, LsRemoteMode::Resolve(ref_.map(String::as_str)));
+        let mut cmd = ls_remote_command(bin, repo, ref_.map(String::as_str));
         let output = cmd.output();
         match output {
             Ok(out) if out.status.success() => {
@@ -145,31 +129,15 @@ fn run_ls_remote_blocking(
     })
 }
 
-#[derive(Clone, Copy)]
-enum LsRemoteMode<'a> {
-    Probe,
-    Resolve(Option<&'a str>),
-}
-
-fn ls_remote_command(bin: Option<&PathBuf>, repo: &str, mode: LsRemoteMode<'_>) -> Command {
+fn ls_remote_command(bin: Option<&PathBuf>, repo: &str, ref_: Option<&str>) -> Command {
     let mut cmd = match bin {
         Some(bin) => Command::new(bin),
         None => Command::new("git"),
     };
     cmd.env("GIT_TERMINAL_PROMPT", "0");
-    cmd.arg("ls-remote");
-    if matches!(mode, LsRemoteMode::Probe) {
-        cmd.arg("--exit-code");
-    }
-    cmd.arg("--").arg(repo);
-    match mode {
-        LsRemoteMode::Probe => {
-            cmd.arg("HEAD");
-        }
-        LsRemoteMode::Resolve(Some(ref_)) => {
-            cmd.arg(ref_).arg(format!("{ref_}^{{}}"));
-        }
-        LsRemoteMode::Resolve(None) => {}
+    cmd.arg("ls-remote").arg("--").arg(repo);
+    if let Some(ref_) = ref_ {
+        cmd.arg(ref_).arg(format!("{ref_}^{{}}"));
     }
     cmd
 }

--- a/pnpm/crates/resolving-git-resolver/src/runners.rs
+++ b/pnpm/crates/resolving-git-resolver/src/runners.rs
@@ -33,11 +33,13 @@ impl GitProbe for RealGitProbe {
         Box::pin(async move {
             let mut delay = Duration::from_millis(500);
             for attempt in 0..3 {
-                let guard = self.http_client.acquire().await;
-                let response = guard.head(url).send().await;
-                drop(guard);
-                if let Ok(resp) = response {
-                    let status = resp.status();
+                // Scoped so the throttle permit is released before any
+                // backoff sleep.
+                let status = {
+                    let guard = self.http_client.acquire_for_url(url).await;
+                    guard.head(url).send().await.map(|response| response.status()).ok()
+                };
+                if let Some(status) = status {
                     if status.is_success() {
                         return true;
                     }

--- a/pnpm/crates/resolving-git-resolver/src/runners/tests.rs
+++ b/pnpm/crates/resolving-git-resolver/src/runners/tests.rs
@@ -1,31 +1,28 @@
-use super::{LsRemoteMode, ls_remote_command};
+use std::sync::Arc;
 
-fn args(mode: LsRemoteMode<'_>) -> Vec<String> {
-    ls_remote_command(None, "--upload-pack=malicious", mode)
+use pacquet_network::ThrottledClient;
+
+use super::{RealGitProbe, ls_remote_command};
+use crate::git_resolver::GitProbe;
+
+fn args(ref_: Option<&str>) -> Vec<String> {
+    ls_remote_command(None, "--upload-pack=malicious", ref_)
         .get_args()
         .map(|arg| arg.to_string_lossy().into_owned())
         .collect()
 }
 
 #[test]
-fn probe_separates_options_from_the_repository() {
-    assert_eq!(
-        args(LsRemoteMode::Probe),
-        ["ls-remote", "--exit-code", "--", "--upload-pack=malicious", "HEAD"],
-    );
-}
-
-#[test]
 fn resolve_separates_options_from_the_repository_and_ref() {
     assert_eq!(
-        args(LsRemoteMode::Resolve(Some("--help"))),
+        args(Some("--help")),
         ["ls-remote", "--", "--upload-pack=malicious", "--help", "--help^{}",],
     );
 }
 
 #[test]
 fn passes_git_terminal_prompt_zero() {
-    let cmd = ls_remote_command(None, "some-repo", LsRemoteMode::Probe);
+    let cmd = ls_remote_command(None, "some-repo", None);
     let mut has_env = false;
     for (k, v) in cmd.get_envs() {
         if k == "GIT_TERMINAL_PROMPT" {
@@ -34,4 +31,35 @@ fn passes_git_terminal_prompt_zero() {
         }
     }
     assert!(has_env);
+}
+
+fn real_probe() -> RealGitProbe {
+    RealGitProbe::new(Arc::new(ThrottledClient::default()))
+}
+
+#[tokio::test]
+async fn head_probe_accepts_success_without_retrying() {
+    let mut server = mockito::Server::new_async().await;
+    let mock =
+        server.mock("HEAD", "/foo/bar/tar.gz/abc").with_status(200).expect(1).create_async().await;
+    assert!(real_probe().anonymous_head_ok(&format!("{}/foo/bar/tar.gz/abc", server.url())).await);
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn head_probe_does_not_retry_definitive_statuses() {
+    let mut server = mockito::Server::new_async().await;
+    let mock =
+        server.mock("HEAD", "/foo/bar/tar.gz/abc").with_status(404).expect(1).create_async().await;
+    assert!(!real_probe().anonymous_head_ok(&format!("{}/foo/bar/tar.gz/abc", server.url())).await);
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn head_probe_retries_transient_statuses_to_exhaustion() {
+    let mut server = mockito::Server::new_async().await;
+    let mock =
+        server.mock("HEAD", "/foo/bar/tar.gz/abc").with_status(429).expect(3).create_async().await;
+    assert!(!real_probe().anonymous_head_ok(&format!("{}/foo/bar/tar.gz/abc", server.url())).await);
+    mock.assert_async().await;
 }

--- a/pnpm/crates/resolving-git-resolver/src/runners/tests.rs
+++ b/pnpm/crates/resolving-git-resolver/src/runners/tests.rs
@@ -56,6 +56,29 @@ async fn head_probe_does_not_retry_definitive_statuses() {
 }
 
 #[tokio::test]
+async fn head_probe_bounds_attempts_on_an_unresponsive_endpoint() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let hold_connections_open = tokio::spawn(async move {
+        let mut held = Vec::new();
+        while let Ok((socket, _)) = listener.accept().await {
+            held.push(socket);
+        }
+    });
+    let probe = RealGitProbe {
+        http_client: Arc::new(ThrottledClient::default()),
+        head_timeout: std::time::Duration::from_millis(100),
+    };
+    let started = std::time::Instant::now();
+    assert!(!probe.anonymous_head_ok(&format!("http://{addr}/foo/tar.gz/abc")).await);
+    // 3 timed-out attempts plus 1.5s of backoff; generous slack for CI
+    // load. Without the per-attempt deadline this hangs for the
+    // client-wide timeout per attempt instead.
+    assert!(started.elapsed() < std::time::Duration::from_secs(15), "{:?}", started.elapsed());
+    hold_connections_open.abort();
+}
+
+#[tokio::test]
 async fn head_probe_retries_transient_statuses_to_exhaustion() {
     let mut server = mockito::Server::new_async().await;
     let mock =


### PR DESCRIPTION
## Summary

**Breaking change, Rust CLI (v12 lane) only.** Git dependency specs of known hosts (GitHub, GitLab, Bitbucket) are now treated as *identities*, not transport choices. Every representation of the same repository — `github:owner/repo`, `owner/repo`, `git+https://…`, `git+ssh://git@…` — resolves through the host's canonical HTTPS URL, and nothing transport-shaped is ever probed for or recorded in the lockfile.

The resolution shape is decided by a single fail-safe check: after `ls-remote` pins the commit, the resolver issues one anonymous HTTP HEAD of the **exact archive URL it would record** (with transient-failure retries). Success records the host-archive tarball — fetchable by construction. Anything else records `type: git` over the canonical HTTPS URL, which is always valid for any machine that can access the repo. A false negative (throttling past retries) therefore costs archive speed on one dependency, never correctness.

Reaching a private hosted repo over SSH becomes per-machine configuration, which git already provides: `git config --global url."git@github.com:".insteadOf https://github.com/`. pnpm shells out to `git` for `ls-remote` and clones, so the rewrite applies everywhere automatically. Unknown-host URLs keep their exact URL (SSH included); credential-embedded URLs are kept verbatim and never resolve to a host archive.

This deletes the resolve-time transport-probing ladder (publicness HEAD heuristic, HTTPS/SSH `ls-remote --exit-code` reachability probes, SSH fallback) that could freeze one machine's working transport into the lockfile and break every environment configured differently. Ecosystem precedent: Go modules and Cargo record identity only and delegate transport to gitconfig; no other package manager probes the network to choose a transport at resolve time.

Related to pnpm/pnpm#13276 (the v12 resolution of that bug class; pnpm/pnpm#13290 fixes the acute v11 regression within the probing design, which the TypeScript CLI keeps).

## Squash Commit Body

```text
Hosted specs (github:/gitlab:/bitbucket: shortcuts and HTTPS/SSH URLs
of those hosts) now all resolve through the host's canonical HTTPS
URL. The lockfile records either the host archive tarball - only when
an anonymous HEAD of the exact archive URL succeeds, so a recorded
archive URL is fetchable by construction - or a git resolution over
the canonical HTTPS URL, which any machine with access to the repo can
fetch. SSH is never inferred: reaching a host over SSH is per-machine
git configuration (url.insteadOf), which pnpm honors by shelling out
to git.

This deletes the resolve-time transport probing (HTTP HEAD publicness
check plus https/ssh ls-remote reachability ladder) that could freeze
one machine's working transport into the lockfile and break every
environment configured differently - the pnpm/pnpm#13276 bug class.
URLs of unknown hosts and URLs with embedded credentials keep their
exact URL and never resolve to a host archive.

parse_bare_specifier becomes fully synchronous and network-free; the
GitProbe seam shrinks to one method (anonymous_head_ok, with
transient-status retries) consumed by pick_resolution. Existing
lockfile entries are untouched - the new rules apply to fresh and
re-resolutions only, and both recorded shapes already exist in the
lockfile format.

Rust-only breaking change for the v12 lane; the TypeScript CLI stays
on the v11 probing behavior (fixed separately in pnpm/pnpm#13290).

Related to pnpm/pnpm#13276.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. *(Deliberately Rust-only: this is a v12 breaking change and the Rust CLI is the v12 version; the TypeScript CLI will not have a v12.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed. *(pnpm.io docs for v12 git specs / the `insteadOf` recipe should follow before v12 stable.)*

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788618735&installation_model_id=426870&pr_number=13684&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13684&signature=b2ddbedb0e6790ade9b485d6a37f3f21d388513d5be38a65b783b38a82a91f85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Git dependencies from supported hosts now use canonical HTTPS repository identities.
  * Public repositories may resolve through downloadable archives for faster installation.
  * Private repositories continue using Git access configured on the machine.

* **Bug Fixes**
  * Improved handling of hosted SSH, SCP-style, unknown-host, and authenticated Git URLs.
  * Failed or unavailable archive checks now fall back to Git access.
  * Added retries for temporary archive-server responses.
  * Authenticated repository URLs are preserved and not treated as public archives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->