### PR TITLE
perf(resolver): serve cached packument fragments from the mirror file

### DIFF
--- a/.changeset/mirror-file-span-metadata.md
+++ b/.changeset/mirror-file-span-metadata.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Reduced peak install memory: cached registry metadata is now read on demand from the on-disk metadata cache instead of being held in memory for the whole resolution. Resolving a large peer-heavy graph (`@teambit/bit`) peaks at about 1.3 GB instead of 3.2 GB, and a full cold install of it stays under 2 GB [#13681](https://github.com/pnpm/pnpm/issues/13681).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5123,6 +5123,7 @@ dependencies = [
  "futures-util",
  "httpdate",
  "indexmap 2.14.0",
+ "libc",
  "miette 7.6.0",
  "mockito",
  "node-semver",

--- a/pnpm/crates/registry/src/lib.rs
+++ b/pnpm/crates/registry/src/lib.rs
@@ -9,7 +9,7 @@ pub use package::{DerivedPackuments, Package};
 pub use package_distribution::{AttestationsDist, PackageDistribution, ProvenanceMeta};
 pub use package_tag::PackageTag;
 pub use package_version::{Approver, NpmUser, PackageVersion, TrustedPublisher};
-pub use package_versions::PackageVersions;
+pub use package_versions::{MirrorFile, PackageVersions};
 pub use range_spec_style::{RangeSpecGranularity, RangeSpecStyle};
 
 use derive_more::{Display, Error, From};

--- a/pnpm/crates/registry/src/lib.rs
+++ b/pnpm/crates/registry/src/lib.rs
@@ -9,7 +9,7 @@ pub use package::{DerivedPackuments, Package};
 pub use package_distribution::{AttestationsDist, PackageDistribution, ProvenanceMeta};
 pub use package_tag::PackageTag;
 pub use package_version::{Approver, NpmUser, PackageVersion, TrustedPublisher};
-pub use package_versions::{MirrorFile, PackageVersions};
+pub use package_versions::{MirrorFile, PackageVersions, read_exact_at};
 pub use range_spec_style::{RangeSpecGranularity, RangeSpecStyle};
 
 use derive_more::{Display, Error, From};

--- a/pnpm/crates/registry/src/package_versions.rs
+++ b/pnpm/crates/registry/src/package_versions.rs
@@ -57,13 +57,11 @@ enum FragmentSource {
     /// of a packument body captures these).
     Raw(Arc<RawValue>),
     /// Byte span inside an indexed on-disk metadata mirror, read on
-    /// demand from the *held-open* file. Holding the handle (instead
-    /// of re-opening by path) pins the inode: mirror rewrites go
-    /// through temp-file + `rename`, so the bytes behind an open
-    /// handle can never shift under the recorded spans. Reading per
-    /// hydration instead of retaining the mirror body is what keeps a
-    /// workspace-scale packument cache out of resident memory — the
-    /// bytes stay in the (reclaimable) page cache.
+    /// demand from the *held-open* file — reading per hydration
+    /// instead of retaining the mirror body keeps a workspace-scale
+    /// packument cache out of resident memory. See
+    /// [`PackageVersions::from_file_spans`] for the inode-pinning
+    /// contract the held handle provides.
     FileSpan { file: Arc<File>, offset: u64, len: u32 },
     /// No fragment — the slot was constructed from an already-typed
     /// manifest (tests, the publish-date filter's slot moves).
@@ -258,8 +256,11 @@ impl PackageVersions {
 impl PackageVersions {
     /// Build a map whose fragments are byte spans read on demand from
     /// the held-open `file` (the indexed mirror). Nothing parses until
-    /// a version hydrates, and no fragment bytes stay resident. See
-    /// [`FragmentSource::FileSpan`] for the inode-pinning contract.
+    /// a version hydrates, and no fragment bytes stay resident.
+    ///
+    /// The handle pins the inode: mirror rewrites go through temp-file
+    /// + `rename`, so the bytes behind this open handle can never
+    /// shift under the recorded spans.
     #[must_use]
     pub fn from_file_spans(
         file: &Arc<File>,

--- a/pnpm/crates/registry/src/package_versions.rs
+++ b/pnpm/crates/registry/src/package_versions.rs
@@ -145,16 +145,16 @@ impl FragmentSource {
     }
 }
 
-/// Fill `buf` from `file` at the absolute `offset`, without using or
-/// disturbing the handle's read cursor (safe for concurrent readers of
-/// one shared handle).
+/// Fill `buf` from `file` at the absolute `offset`. The handle's read
+/// cursor is never consulted, and callers must not rely on where it
+/// ends up: the unix implementation leaves it untouched, while the
+/// Windows one moves it as a `seek_read` side effect.
 #[cfg(unix)]
 pub fn read_exact_at(file: &File, buf: &mut [u8], offset: u64) -> std::io::Result<()> {
     std::os::unix::fs::FileExt::read_exact_at(file, buf, offset)
 }
 
-/// See the unix sibling; Windows' `seek_read` moves the cursor, but no
-/// caller relies on it.
+/// See the unix sibling for the shared contract.
 #[cfg(windows)]
 pub fn read_exact_at(file: &File, mut buf: &mut [u8], mut offset: u64) -> std::io::Result<()> {
     while !buf.is_empty() {

--- a/pnpm/crates/registry/src/package_versions.rs
+++ b/pnpm/crates/registry/src/package_versions.rs
@@ -258,9 +258,9 @@ impl PackageVersions {
     /// the held-open `file` (the indexed mirror). Nothing parses until
     /// a version hydrates, and no fragment bytes stay resident.
     ///
-    /// The handle pins the inode: mirror rewrites go through temp-file
-    /// + `rename`, so the bytes behind this open handle can never
-    /// shift under the recorded spans.
+    /// The handle pins the inode: mirror rewrites go through a temp
+    /// file followed by `rename`, so the bytes behind this open handle
+    /// can never shift under the recorded spans.
     #[must_use]
     pub fn from_file_spans(
         file: &Arc<File>,

--- a/pnpm/crates/registry/src/package_versions.rs
+++ b/pnpm/crates/registry/src/package_versions.rs
@@ -50,6 +50,48 @@ struct VersionSlot {
     parsed: OnceLock<Option<Arc<PackageVersion>>>,
 }
 
+/// A mirror file held open for on-demand fragment reads, counted
+/// against a caller-supplied cap so a fleet of held handles can never
+/// exhaust the process's descriptor budget — a load that would exceed
+/// the cap falls back to buffering its fragments instead (see
+/// [`MirrorFile::try_hold`]).
+#[derive(Debug)]
+pub struct MirrorFile {
+    file: File,
+}
+
+/// Descriptors currently held by live [`MirrorFile`]s.
+static HELD_MIRROR_FILES: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+impl MirrorFile {
+    /// Wrap `file` for span reads when fewer than `cap` mirror files
+    /// are currently held; hand the file back otherwise so the caller
+    /// can buffer its contents and close it.
+    pub fn try_hold(file: File, cap: usize) -> Result<Arc<MirrorFile>, File> {
+        let mut held = HELD_MIRROR_FILES.load(std::sync::atomic::Ordering::Relaxed);
+        loop {
+            if held >= cap {
+                return Err(file);
+            }
+            match HELD_MIRROR_FILES.compare_exchange_weak(
+                held,
+                held + 1,
+                std::sync::atomic::Ordering::Relaxed,
+                std::sync::atomic::Ordering::Relaxed,
+            ) {
+                Ok(_) => return Ok(Arc::new(MirrorFile { file })),
+                Err(current) => held = current,
+            }
+        }
+    }
+}
+
+impl Drop for MirrorFile {
+    fn drop(&mut self) {
+        HELD_MIRROR_FILES.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
 /// Where a version's JSON fragment lives until it is hydrated.
 #[derive(Debug, Clone)]
 enum FragmentSource {
@@ -62,7 +104,7 @@ enum FragmentSource {
     /// packument cache out of resident memory. See
     /// [`PackageVersions::from_file_spans`] for the inode-pinning
     /// contract the held handle provides.
-    FileSpan { file: Arc<File>, offset: u64, len: u32 },
+    FileSpan { file: Arc<MirrorFile>, offset: u64, len: u32 },
     /// No fragment — the slot was constructed from an already-typed
     /// manifest (tests, the publish-date filter's slot moves).
     None,
@@ -77,7 +119,7 @@ impl FragmentSource {
             FragmentSource::Raw(raw) => Some(Cow::Borrowed(raw.get())),
             FragmentSource::FileSpan { file, offset, len } => {
                 let mut bytes = vec![0u8; *len as usize];
-                if let Err(error) = read_exact_at(file, &mut bytes, *offset) {
+                if let Err(error) = read_exact_at(&file.file, &mut bytes, *offset) {
                     tracing::warn!(
                         target: "pacquet_registry",
                         %error,
@@ -263,7 +305,7 @@ impl PackageVersions {
     /// can never shift under the recorded spans.
     #[must_use]
     pub fn from_file_spans(
-        file: &Arc<File>,
+        file: &Arc<MirrorFile>,
         spans: impl IntoIterator<Item = (String, u64, u32)>,
     ) -> Self {
         PackageVersions {
@@ -278,6 +320,31 @@ impl PackageVersions {
                                 offset,
                                 len,
                             },
+                            parsed: OnceLock::new(),
+                        },
+                    )
+                })
+                .collect(),
+        }
+    }
+
+    /// Build a map from already-extracted raw JSON fragments. The
+    /// fallback for a mirror the loader could not keep open (the
+    /// held-handle cap in [`MirrorFile::try_hold`] was reached): the
+    /// fragments stay buffered in memory like a freshly-fetched
+    /// packument's, trading residency for a descriptor.
+    #[must_use]
+    pub fn from_raw_fragments(
+        fragments: impl IntoIterator<Item = (String, Box<RawValue>)>,
+    ) -> Self {
+        PackageVersions {
+            slots: fragments
+                .into_iter()
+                .map(|(version, raw)| {
+                    (
+                        version,
+                        VersionSlot {
+                            source: FragmentSource::Raw(Arc::from(raw)),
                             parsed: OnceLock::new(),
                         },
                     )

--- a/pnpm/crates/registry/src/package_versions.rs
+++ b/pnpm/crates/registry/src/package_versions.rs
@@ -145,13 +145,18 @@ impl FragmentSource {
     }
 }
 
+/// Fill `buf` from `file` at the absolute `offset`, without using or
+/// disturbing the handle's read cursor (safe for concurrent readers of
+/// one shared handle).
 #[cfg(unix)]
-fn read_exact_at(file: &File, buf: &mut [u8], offset: u64) -> std::io::Result<()> {
+pub fn read_exact_at(file: &File, buf: &mut [u8], offset: u64) -> std::io::Result<()> {
     std::os::unix::fs::FileExt::read_exact_at(file, buf, offset)
 }
 
+/// See the unix sibling; Windows' `seek_read` moves the cursor, but no
+/// caller relies on it.
 #[cfg(windows)]
-fn read_exact_at(file: &File, mut buf: &mut [u8], mut offset: u64) -> std::io::Result<()> {
+pub fn read_exact_at(file: &File, mut buf: &mut [u8], mut offset: u64) -> std::io::Result<()> {
     while !buf.is_empty() {
         match std::os::windows::fs::FileExt::seek_read(file, buf, offset) {
             Ok(0) => {

--- a/pnpm/crates/registry/src/package_versions.rs
+++ b/pnpm/crates/registry/src/package_versions.rs
@@ -60,7 +60,6 @@ pub struct MirrorFile {
     file: File,
 }
 
-/// Descriptors currently held by live [`MirrorFile`]s.
 static HELD_MIRROR_FILES: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 
 impl MirrorFile {

--- a/pnpm/crates/registry/src/package_versions.rs
+++ b/pnpm/crates/registry/src/package_versions.rs
@@ -5,10 +5,11 @@
 //! and `serde_json::Value` trees behind each version are built, hashed,
 //! and dropped even though a pick consults only the version *strings*
 //! plus the handful of manifests it actually considers. Each version
-//! therefore stays as the raw JSON fragment serde captured — an
-//! [`Arc<RawValue>`], shared rather than copied — until someone asks
-//! for the typed form, and the hydrated manifest is cached per slot so
-//! repeated lookups parse once.
+//! therefore stays as an unhydrated fragment — the raw JSON serde
+//! captured ([`Arc<RawValue>`], shared rather than copied) or a byte
+//! span read on demand from the held-open mirror file — until someone
+//! asks for the typed form, and the hydrated manifest is cached per
+//! slot so repeated lookups parse once.
 //!
 //! A fragment that fails to decode behaves as if the version were
 //! absent from the packument (with a `tracing::warn`), mirroring the
@@ -18,6 +19,7 @@
 use std::{
     borrow::Cow,
     collections::HashMap,
+    fs::File,
     sync::{Arc, OnceLock},
 };
 
@@ -54,12 +56,15 @@ enum FragmentSource {
     /// Raw JSON fragment as served by the registry (the serde parse
     /// of a packument body captures these).
     Raw(Arc<RawValue>),
-    /// Byte span inside an indexed on-disk metadata mirror, whose
-    /// contents the loader read into one shared buffer. Hydration
-    /// parses the span in place — no per-fragment file I/O (the pick
-    /// paths can probe many candidate fragments per package, so
-    /// open-per-hydration measured slower than one sequential read).
-    BufferSpan { buffer: Arc<Vec<u8>>, offset: u64, len: u32 },
+    /// Byte span inside an indexed on-disk metadata mirror, read on
+    /// demand from the *held-open* file. Holding the handle (instead
+    /// of re-opening by path) pins the inode: mirror rewrites go
+    /// through temp-file + `rename`, so the bytes behind an open
+    /// handle can never shift under the recorded spans. Reading per
+    /// hydration instead of retaining the mirror body is what keeps a
+    /// workspace-scale packument cache out of resident memory — the
+    /// bytes stay in the (reclaimable) page cache.
+    FileSpan { file: Arc<File>, offset: u64, len: u32 },
     /// No fragment — the slot was constructed from an already-typed
     /// manifest (tests, the publish-date filter's slot moves).
     None,
@@ -67,17 +72,24 @@ enum FragmentSource {
 
 impl FragmentSource {
     /// The fragment's JSON text: borrowed for [`FragmentSource::Raw`],
-    /// read from the shared buffer for [`FragmentSource::BufferSpan`],
-    /// absent for [`FragmentSource::None`] or invalid spans.
+    /// read from the mirror file for [`FragmentSource::FileSpan`],
+    /// absent for [`FragmentSource::None`] or unreadable spans.
     fn json(&self) -> Option<Cow<'_, str>> {
         match self {
             FragmentSource::Raw(raw) => Some(Cow::Borrowed(raw.get())),
-            FragmentSource::BufferSpan { buffer, offset, len } => {
-                let start = usize::try_from(*offset).ok()?;
-                let end = start.checked_add(*len as usize)?;
-                let bytes = buffer.get(start..end)?;
-                match std::str::from_utf8(bytes) {
-                    Ok(json) => Some(Cow::Borrowed(json)),
+            FragmentSource::FileSpan { file, offset, len } => {
+                let mut bytes = vec![0u8; *len as usize];
+                if let Err(error) = read_exact_at(file, &mut bytes, *offset) {
+                    tracing::warn!(
+                        target: "pacquet_registry",
+                        %error,
+                        offset,
+                        "could not read a metadata mirror fragment",
+                    );
+                    return None;
+                }
+                match String::from_utf8(bytes) {
+                    Ok(json) => Some(Cow::Owned(json)),
                     Err(error) => {
                         tracing::warn!(
                             target: "pacquet_registry",
@@ -92,6 +104,32 @@ impl FragmentSource {
             FragmentSource::None => None,
         }
     }
+}
+
+#[cfg(unix)]
+fn read_exact_at(file: &File, buf: &mut [u8], offset: u64) -> std::io::Result<()> {
+    std::os::unix::fs::FileExt::read_exact_at(file, buf, offset)
+}
+
+#[cfg(windows)]
+fn read_exact_at(file: &File, mut buf: &mut [u8], mut offset: u64) -> std::io::Result<()> {
+    while !buf.is_empty() {
+        match std::os::windows::fs::FileExt::seek_read(file, buf, offset) {
+            Ok(0) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "mirror fragment span reaches past the end of the file",
+                ));
+            }
+            Ok(read) => {
+                buf = &mut buf[read..];
+                offset += read as u64;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
 }
 
 impl Clone for VersionSlot {
@@ -218,12 +256,13 @@ impl PackageVersions {
 /// (see `pacquet-resolving-npm-resolver`'s `mirror` module, which owns
 /// the file layout).
 impl PackageVersions {
-    /// Build a map whose fragments are byte spans inside `buffer`
-    /// (the indexed mirror file's contents). Nothing parses until a
-    /// version hydrates.
+    /// Build a map whose fragments are byte spans read on demand from
+    /// the held-open `file` (the indexed mirror). Nothing parses until
+    /// a version hydrates, and no fragment bytes stay resident. See
+    /// [`FragmentSource::FileSpan`] for the inode-pinning contract.
     #[must_use]
-    pub fn from_buffer_spans(
-        buffer: &Arc<Vec<u8>>,
+    pub fn from_file_spans(
+        file: &Arc<File>,
         spans: impl IntoIterator<Item = (String, u64, u32)>,
     ) -> Self {
         PackageVersions {
@@ -233,8 +272,8 @@ impl PackageVersions {
                     (
                         version,
                         VersionSlot {
-                            source: FragmentSource::BufferSpan {
-                                buffer: Arc::clone(buffer),
+                            source: FragmentSource::FileSpan {
+                                file: Arc::clone(file),
                                 offset,
                                 len,
                             },

--- a/pnpm/crates/resolving-npm-resolver/Cargo.toml
+++ b/pnpm/crates/resolving-npm-resolver/Cargo.toml
@@ -27,6 +27,7 @@ dashmap     = { workspace = true }
 derive_more = { workspace = true }
 httpdate    = { workspace = true }
 indexmap    = { workspace = true }
+libc        = { workspace = true }
 miette      = { workspace = true }
 node-semver = { workspace = true }
 pipe-trait  = { workspace = true }

--- a/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
@@ -34,8 +34,8 @@ use crate::{
     },
     mirror::{
         ABBREVIATED_META_DIR, FULL_FILTERED_META_DIR, FULL_META_DIR, clear_meta,
-        get_pkg_mirror_path, load_meta_async, load_meta_headers_async, save_meta_indexed,
-        save_meta_ndjson, scoped_meta_dir,
+        get_pkg_mirror_path, load_meta, load_meta_async, load_meta_headers_async,
+        save_meta_indexed, save_meta_ndjson, scoped_meta_dir,
     },
     registry_url::to_registry_url,
 };
@@ -187,18 +187,36 @@ pub async fn fetch_full_metadata_cached(
                 // A filtered full response is written in pnpm's NDJSON
                 // shape. Other responses keep pacquet's indexed mirror
                 // layout for lazy version hydration.
-                let save_result = if should_filter_metadata {
-                    save_meta_ndjson(path, &meta, etag.as_deref())
+                if should_filter_metadata {
+                    if let Err(error) = save_meta_ndjson(path, &meta, etag.as_deref()) {
+                        tracing::debug!(
+                            target: "pacquet_resolving_npm_resolver::cache",
+                            ?error,
+                            path = %path.display(),
+                            "could not persist mirror; bypassing cache write",
+                        );
+                    }
                 } else {
-                    save_meta_indexed(path, &meta, etag.as_deref())
-                };
-                if let Err(error) = save_result {
-                    tracing::debug!(
-                        target: "pacquet_resolving_npm_resolver::cache",
-                        ?error,
-                        path = %path.display(),
-                        "could not persist mirror; bypassing cache write",
-                    );
+                    match save_meta_indexed(path, &meta, etag.as_deref()) {
+                        // Serve the just-persisted mirror instead of the
+                        // response body: its version fragments read from
+                        // the file on demand, so the multi-megabyte body
+                        // drops here instead of living in the packument
+                        // cache for the rest of the install.
+                        Ok(()) => {
+                            if let Some(saved) = load_meta(path) {
+                                return Ok(saved);
+                            }
+                        }
+                        Err(error) => {
+                            tracing::debug!(
+                                target: "pacquet_resolving_npm_resolver::cache",
+                                ?error,
+                                path = %path.display(),
+                                "could not persist mirror; bypassing cache write",
+                            );
+                        }
+                    }
                 }
             }
             Ok(meta)

--- a/pnpm/crates/resolving-npm-resolver/src/mirror.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/mirror.rs
@@ -128,6 +128,13 @@ pub enum SaveMetaError {
 const MAX_HEADERS_LEN: usize = 64 * 1024;
 const MAX_INDEX_LEN: usize = 64 * 1024 * 1024;
 
+/// Ceiling for a single version fragment's declared span. The span
+/// end is validated against the file size, but a sparse file makes
+/// the file size itself untrustworthy — without a per-fragment bound
+/// a corrupt mirror could declare a multi-gigabyte span and drive an
+/// equally large hydration allocation.
+const MAX_FRAGMENT_LEN: u32 = 16 * 1024 * 1024;
+
 /// Mirror root for descriptor-scoped private metadata. A
 /// [`MetadataCacheScope::Private`] route stores its packuments under
 /// `<cache_dir>/v11/metadata-private/<descriptor-id>/<meta-suffix>/...`
@@ -581,7 +588,7 @@ fn load_meta_with_hold_cap(pkg_mirror: &Path, hold_cap: usize) -> Option<Package
     let mut spans = Vec::with_capacity(index.versions.len());
     for (version, offset, len) in index.versions {
         let absolute = (fragment_base as u64).checked_add(offset)?;
-        if absolute.checked_add(u64::from(len))? > file_size {
+        if len > MAX_FRAGMENT_LEN || absolute.checked_add(u64::from(len))? > file_size {
             return None;
         }
         spans.push((version, absolute, len));
@@ -638,7 +645,7 @@ fn held_mirror_file_cap() -> usize {
     static CAP: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
     *CAP.get_or_init(|| {
         raise_open_file_limit_once();
-        soft_open_file_limit().map_or(1 << 19, |soft| (soft / 2).clamp(128, 1 << 19))
+        soft_open_file_limit().map_or(1 << 19, |soft| (soft / 2).min(1 << 19))
     })
 }
 

--- a/pnpm/crates/resolving-npm-resolver/src/mirror.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/mirror.rs
@@ -611,31 +611,28 @@ fn load_meta_with_hold_cap(pkg_mirror: &Path, hold_cap: usize) -> Option<Package
         // a full cache can never make `File::open` fail elsewhere and
         // turn present mirrors into cache misses.
         Err(file) => {
-            // The prefix probe may have read past `fragment_base`; the
-            // buffer must start there, with the rest read from the
-            // file's current position (`fs::read` would re-open by
-            // path and lose the already-consumed prefix). The read
-            // stops at the highest validated span end — bytes past it
-            // (a sparse or garbage tail) belong to no fragment.
-            let fragment_end = spans
-                .iter()
-                .map(|(_, absolute, len)| absolute + u64::from(*len))
-                .max()
-                .unwrap_or(fragment_base as u64);
-            let mut fragments = Vec::new();
-            if fragment_base < filled {
-                fragments.extend_from_slice(&prefix[fragment_base..filled]);
+            // Each validated span is read with its own positioned read
+            // and the file closed afterwards: reading the contiguous
+            // fragment region would let a corrupt index's sparse gaps
+            // inflate the buffer far past the real fragment bytes. The
+            // budget bounds the total even against an index whose spans
+            // overlap or repeat.
+            const MAX_EAGER_FRAGMENT_TOTAL: u64 = 1 << 30;
+            let mut budget = MAX_EAGER_FRAGMENT_TOTAL;
+            let mut raw_fragments = Vec::with_capacity(spans.len());
+            for (version, absolute, len) in spans {
+                budget = budget.checked_sub(u64::from(len))?;
+                let mut bytes = vec![0u8; len as usize];
+                if pacquet_registry::read_exact_at(&file, &mut bytes, absolute).is_err() {
+                    continue;
+                }
+                let Ok(json) = String::from_utf8(bytes) else { continue };
+                let Ok(raw) = serde_json::from_str::<Box<serde_json::value::RawValue>>(&json)
+                else {
+                    continue;
+                };
+                raw_fragments.push((version, raw));
             }
-            let remaining =
-                (fragment_end - fragment_base as u64).saturating_sub(fragments.len() as u64);
-            io::BufReader::new(file).take(remaining).read_to_end(&mut fragments).ok()?;
-            let raw_fragments = spans.into_iter().filter_map(|(version, absolute, len)| {
-                let start = usize::try_from(absolute.checked_sub(fragment_base as u64)?).ok()?;
-                let end = start.checked_add(len as usize)?;
-                let json = std::str::from_utf8(fragments.get(start..end)?).ok()?;
-                let raw = serde_json::from_str::<Box<serde_json::value::RawValue>>(json).ok()?;
-                Some((version, raw))
-            });
             PackageVersions::from_raw_fragments(raw_fragments)
         }
     };

--- a/pnpm/crates/resolving-npm-resolver/src/mirror.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/mirror.rs
@@ -605,12 +605,21 @@ fn load_meta_with_hold_cap(pkg_mirror: &Path, hold_cap: usize) -> Option<Package
             // The prefix probe may have read past `fragment_base`; the
             // buffer must start there, with the rest read from the
             // file's current position (`fs::read` would re-open by
-            // path and lose the already-consumed prefix).
+            // path and lose the already-consumed prefix). The read
+            // stops at the highest validated span end — bytes past it
+            // (a sparse or garbage tail) belong to no fragment.
+            let fragment_end = spans
+                .iter()
+                .map(|(_, absolute, len)| absolute + u64::from(*len))
+                .max()
+                .unwrap_or(fragment_base as u64);
             let mut fragments = Vec::new();
             if fragment_base < filled {
                 fragments.extend_from_slice(&prefix[fragment_base..filled]);
             }
-            io::BufReader::new(file).read_to_end(&mut fragments).ok()?;
+            let remaining =
+                (fragment_end - fragment_base as u64).saturating_sub(fragments.len() as u64);
+            io::BufReader::new(file).take(remaining).read_to_end(&mut fragments).ok()?;
             let raw_fragments = spans.into_iter().filter_map(|(version, absolute, len)| {
                 let start = usize::try_from(absolute.checked_sub(fragment_base as u64)?).ok()?;
                 let end = start.checked_add(len as usize)?;

--- a/pnpm/crates/resolving-npm-resolver/src/mirror.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/mirror.rs
@@ -283,9 +283,10 @@ pub fn save_meta_indexed(
     for (version, json) in meta.versions.fragments() {
         let offset = fragment_bytes.len() as u64;
         let len = u32::try_from(json.len()).unwrap_or(u32::MAX);
-        if len as usize != json.len() {
-            // A single >4 GiB version manifest is not a thing the npm
-            // registry produces; skip it rather than corrupt the index.
+        if len as usize != json.len() || len > MAX_FRAGMENT_LEN {
+            // A version manifest past the loader's fragment bound
+            // would be persisted only to be skipped on every read;
+            // omit it so the saved and served views agree.
             continue;
         }
         fragment_bytes.extend_from_slice(json.as_bytes());
@@ -587,8 +588,16 @@ fn load_meta_with_hold_cap(pkg_mirror: &Path, hold_cap: usize) -> Option<Package
     // than handing out garbage fragments later.
     let mut spans = Vec::with_capacity(index.versions.len());
     for (version, offset, len) in index.versions {
+        // A span past the fragment bound reads as an absent version
+        // (the same contract as an undecodable fragment) rather than
+        // rejecting the whole document: the bound exists to stop a
+        // corrupt index from driving huge hydration allocations, and
+        // the writer never persists such fragments.
+        if len > MAX_FRAGMENT_LEN {
+            continue;
+        }
         let absolute = (fragment_base as u64).checked_add(offset)?;
-        if len > MAX_FRAGMENT_LEN || absolute.checked_add(u64::from(len))? > file_size {
+        if absolute.checked_add(u64::from(len))? > file_size {
             return None;
         }
         spans.push((version, absolute, len));

--- a/pnpm/crates/resolving-npm-resolver/src/mirror.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/mirror.rs
@@ -594,15 +594,16 @@ fn load_meta_with_hold_cap(pkg_mirror: &Path, hold_cap: usize) -> Option<Package
         // cap): buffer this mirror's fragments and close the file, so
         // a full cache can never make `File::open` fail elsewhere and
         // turn present mirrors into cache misses.
-        Err(mut file) => {
+        Err(file) => {
             // The prefix probe may have read past `fragment_base`; the
             // buffer must start there, with the rest read from the
-            // file's current position.
+            // file's current position (`fs::read` would re-open by
+            // path and lose the already-consumed prefix).
             let mut fragments = Vec::new();
             if fragment_base < filled {
                 fragments.extend_from_slice(&prefix[fragment_base..filled]);
             }
-            file.read_to_end(&mut fragments).ok()?;
+            io::BufReader::new(file).read_to_end(&mut fragments).ok()?;
             let raw_fragments = spans.into_iter().filter_map(|(version, absolute, len)| {
                 let start = usize::try_from(absolute.checked_sub(fragment_base as u64)?).ok()?;
                 let end = start.checked_add(len as usize)?;

--- a/pnpm/crates/resolving-npm-resolver/src/mirror.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/mirror.rs
@@ -388,6 +388,54 @@ fn meta_modified(meta: &Package) -> Option<String> {
     })
 }
 
+/// One-time, best-effort raise of the process's soft `RLIMIT_NOFILE`
+/// toward the hard limit. Loaded mirrors keep their file handle open
+/// so version fragments can be read on demand without buffering the
+/// body (see [`load_meta`]), which holds one descriptor per packument
+/// — beyond the conservative soft defaults some platforms ship (256
+/// on macOS, 1024 on several Linux distros) once a workspace consults
+/// thousands of packuments. Raising the soft limit to the hard limit
+/// needs no privileges; it is the same startup adjustment the Go
+/// runtime performs.
+#[cfg(unix)]
+fn raise_open_file_limit_once() {
+    static RAISE: std::sync::Once = std::sync::Once::new();
+    RAISE.call_once(|| {
+        // SAFETY: plain libc calls; `limit` is a properly initialised
+        // out-parameter and no pointer outlives its call.
+        unsafe {
+            let mut limit = libc::rlimit { rlim_cur: 0, rlim_max: 0 };
+            if libc::getrlimit(libc::RLIMIT_NOFILE, &raw mut limit) != 0 {
+                return;
+            }
+            let ceiling: libc::rlim_t = 1 << 20;
+            let target = limit.rlim_max.min(ceiling);
+            if target <= limit.rlim_cur {
+                return;
+            }
+            let request = libc::rlimit { rlim_cur: target, rlim_max: limit.rlim_max };
+            if libc::setrlimit(libc::RLIMIT_NOFILE, &raw const request) != 0 {
+                // macOS rejects soft limits above `kern.maxfilesperproc`
+                // even when the hard limit reads unlimited; 10240 is
+                // the historically safe `OPEN_MAX` ceiling there.
+                #[cfg(target_os = "macos")]
+                {
+                    let fallback = limit.rlim_max.min(10240);
+                    if fallback > limit.rlim_cur {
+                        let request = libc::rlimit { rlim_cur: fallback, rlim_max: limit.rlim_max };
+                        let _ = libc::setrlimit(libc::RLIMIT_NOFILE, &raw const request);
+                    }
+                }
+            }
+        }
+    });
+}
+
+/// Windows has no `RLIMIT_NOFILE`; per-process handle capacity is far
+/// above any realistic packument count.
+#[cfg(not(unix))]
+fn raise_open_file_limit_once() {}
+
 /// Parse the `pacquet-meta-v1 <headers_len> <index_len>` line.
 /// `None` for anything else, including pnpm's NDJSON format.
 fn parse_mirror_magic(line: &str) -> Option<(usize, usize)> {
@@ -451,17 +499,39 @@ pub fn load_meta_headers(pkg_mirror: &Path) -> Option<MetaHeaders> {
     read_mirror_headers(&mut file)
 }
 
-/// Read the full mirror file and reconstruct a [`Package`] with its
-/// etag back-filled from the headers line.
+/// Read a mirror file's headers + index and reconstruct a [`Package`]
+/// with its etag back-filled from the headers line.
+///
+/// For the indexed format only the header and index records are read
+/// into memory; version fragments stay on disk behind the held-open
+/// file handle ([`PackageVersions::from_file_spans`]), so a cache full
+/// of multi-megabyte packuments costs their index size in resident
+/// memory, not their body size. The legacy NDJSON format still parses
+/// the whole body.
 ///
 /// Returns `None` on missing file / malformed contents: the caller's
 /// response to "couldn't read" is the same as "no cache".
 #[must_use]
 pub fn load_meta(pkg_mirror: &Path) -> Option<Package> {
-    let contents = fs::read(pkg_mirror).ok()?;
-    let newline = contents.iter().position(|&byte| byte == b'\n')?;
-    let line = std::str::from_utf8(&contents[..newline]).ok()?;
+    raise_open_file_limit_once();
+    let mut file = File::open(pkg_mirror).ok()?;
+    // The magic line plus the two length fields fit well inside this.
+    let mut prefix = [0u8; 256];
+    let mut filled = 0usize;
+    while filled < prefix.len() {
+        let read = file.read(&mut prefix[filled..]).ok()?;
+        if read == 0 {
+            break;
+        }
+        filled += read;
+    }
+    let prefix = &prefix[..filled];
+    let newline = prefix.iter().position(|&byte| byte == b'\n')?;
+    let line = std::str::from_utf8(&prefix[..newline]).ok()?;
     let Some((headers_len, index_len)) = parse_mirror_magic(line) else {
+        // Legacy NDJSON mirror — the whole body is the packument.
+        let contents = fs::read(pkg_mirror).ok()?;
+        let newline = contents.iter().position(|&byte| byte == b'\n')?;
         let headers: MetaHeaders = serde_json::from_slice(&contents[..newline]).ok()?;
         let mut meta: Package = serde_json::from_slice(&contents[newline + 1..]).ok()?;
         meta.etag = headers.etag;
@@ -471,18 +541,23 @@ pub fn load_meta(pkg_mirror: &Path) -> Option<Package> {
     let headers_start = newline + 1;
     let index_start = headers_start.checked_add(headers_len)?;
     let fragment_base = index_start.checked_add(index_len)?;
-    if fragment_base > contents.len() {
-        return None;
-    }
+    // Read the rest of the headers + index records; the file's
+    // fragment section is never buffered.
+    let mut records = vec![0u8; fragment_base.checked_sub(filled.min(fragment_base))?];
+    file.read_exact(&mut records).ok()?;
+    let mut prefixed = Vec::with_capacity(fragment_base);
+    prefixed.extend_from_slice(&prefix[..filled.min(fragment_base)]);
+    prefixed.extend_from_slice(&records);
     let headers: MetaHeaders =
-        serde_json::from_slice(&contents[headers_start..index_start]).ok()?;
-    let index: MirrorIndex = serde_json::from_slice(&contents[index_start..fragment_base]).ok()?;
+        serde_json::from_slice(prefixed.get(headers_start..index_start)?).ok()?;
+    let index: MirrorIndex =
+        serde_json::from_slice(prefixed.get(index_start..fragment_base)?).ok()?;
 
     // Rebase the relative spans and reject any that fall outside the
     // file — a truncated or hand-edited mirror reads as a miss rather
     // than handing out garbage fragments later.
-    let file_size = contents.len() as u64;
-    let buffer = Arc::new(contents);
+    let file_size = file.metadata().ok()?.len();
+    let file = Arc::new(file);
     let mut spans = Vec::with_capacity(index.versions.len());
     for (version, offset, len) in index.versions {
         let absolute = (fragment_base as u64).checked_add(offset)?;
@@ -495,7 +570,7 @@ pub fn load_meta(pkg_mirror: &Path) -> Option<Package> {
     Some(Package {
         name: index.name,
         dist_tags: index.dist_tags,
-        versions: PackageVersions::from_buffer_spans(&buffer, spans),
+        versions: PackageVersions::from_file_spans(&file, spans),
         time: index.time,
         modified: headers.modified,
         etag: headers.etag,

--- a/pnpm/crates/resolving-npm-resolver/src/mirror.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/mirror.rs
@@ -58,7 +58,7 @@ use std::{
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_network::MetadataCacheScope;
-use pacquet_registry::{DerivedPackuments, Package, PackageVersions};
+use pacquet_registry::{DerivedPackuments, MirrorFile, Package, PackageVersions};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
@@ -118,6 +118,15 @@ pub enum SaveMetaError {
         error: io::Error,
     },
 }
+
+/// The declared record lengths in a mirror's magic line come from the
+/// file itself, so a corrupted or hostile mirror must never drive an
+/// arbitrarily large allocation. The headers record is ~100 bytes of
+/// etag + timestamp; the index scales with the version count (~100
+/// bytes per version), so its bound leaves six-figure version counts
+/// of headroom.
+const MAX_HEADERS_LEN: usize = 64 * 1024;
+const MAX_INDEX_LEN: usize = 64 * 1024 * 1024;
 
 /// Mirror root for descriptor-scoped private metadata. A
 /// [`MetadataCacheScope::Private`] route stores its packuments under
@@ -464,10 +473,6 @@ fn read_mirror_headers(file: &mut File) -> Option<MetaHeaders> {
     let Some((headers_len, _)) = parse_mirror_magic(line) else {
         return serde_json::from_str(line).ok();
     };
-    // The headers record is ~100 bytes of etag + timestamp. Bound the
-    // declared length before allocating from it so a corrupted or
-    // hostile mirror can't trigger an arbitrarily large allocation.
-    const MAX_HEADERS_LEN: usize = 64 * 1024;
     if headers_len > MAX_HEADERS_LEN {
         return None;
     }
@@ -506,13 +511,19 @@ pub fn load_meta_headers(pkg_mirror: &Path) -> Option<MetaHeaders> {
 /// into memory; version fragments stay on disk behind the held-open
 /// file handle ([`PackageVersions::from_file_spans`]), so a cache full
 /// of multi-megabyte packuments costs their index size in resident
-/// memory, not their body size. The legacy NDJSON format still parses
-/// the whole body.
+/// memory, not their body size. Past the held-handle budget (sized
+/// from the descriptor limit) a load buffers its fragments instead of
+/// keeping the file open. The legacy NDJSON format still parses the
+/// whole body.
 ///
 /// Returns `None` on missing file / malformed contents: the caller's
 /// response to "couldn't read" is the same as "no cache".
 #[must_use]
 pub fn load_meta(pkg_mirror: &Path) -> Option<Package> {
+    load_meta_with_hold_cap(pkg_mirror, held_mirror_file_cap())
+}
+
+fn load_meta_with_hold_cap(pkg_mirror: &Path, hold_cap: usize) -> Option<Package> {
     raise_open_file_limit_once();
     let mut file = File::open(pkg_mirror).ok()?;
     // The magic line plus the two length fields fit well inside this.
@@ -538,11 +549,22 @@ pub fn load_meta(pkg_mirror: &Path) -> Option<Package> {
         meta.modified = meta.modified.or(headers.modified);
         return Some(meta);
     };
+    // Bound each declared length, then require the whole header +
+    // index region to fit inside the actual file before allocating a
+    // buffer for it.
+    if headers_len > MAX_HEADERS_LEN || index_len > MAX_INDEX_LEN {
+        return None;
+    }
     let headers_start = newline + 1;
     let index_start = headers_start.checked_add(headers_len)?;
     let fragment_base = index_start.checked_add(index_len)?;
+    let file_size = file.metadata().ok()?.len();
+    if u64::try_from(fragment_base).ok()? > file_size {
+        return None;
+    }
     // Read the rest of the headers + index records; the file's
-    // fragment section is never buffered.
+    // fragment section is only buffered on the held-handle fallback
+    // below.
     let mut records = vec![0u8; fragment_base.checked_sub(filled.min(fragment_base))?];
     file.read_exact(&mut records).ok()?;
     let mut prefixed = Vec::with_capacity(fragment_base);
@@ -556,8 +578,6 @@ pub fn load_meta(pkg_mirror: &Path) -> Option<Package> {
     // Rebase the relative spans and reject any that fall outside the
     // file — a truncated or hand-edited mirror reads as a miss rather
     // than handing out garbage fragments later.
-    let file_size = file.metadata().ok()?.len();
-    let file = Arc::new(file);
     let mut spans = Vec::with_capacity(index.versions.len());
     for (version, offset, len) in index.versions {
         let absolute = (fragment_base as u64).checked_add(offset)?;
@@ -567,10 +587,37 @@ pub fn load_meta(pkg_mirror: &Path) -> Option<Package> {
         spans.push((version, absolute, len));
     }
 
+    let versions = match MirrorFile::try_hold(file, hold_cap) {
+        Ok(held) => PackageVersions::from_file_spans(&held, spans),
+        // Held-handle budget exhausted (an unusually low descriptor
+        // limit, or an install consulting more packuments than the
+        // cap): buffer this mirror's fragments and close the file, so
+        // a full cache can never make `File::open` fail elsewhere and
+        // turn present mirrors into cache misses.
+        Err(mut file) => {
+            // The prefix probe may have read past `fragment_base`; the
+            // buffer must start there, with the rest read from the
+            // file's current position.
+            let mut fragments = Vec::new();
+            if fragment_base < filled {
+                fragments.extend_from_slice(&prefix[fragment_base..filled]);
+            }
+            file.read_to_end(&mut fragments).ok()?;
+            let raw_fragments = spans.into_iter().filter_map(|(version, absolute, len)| {
+                let start = usize::try_from(absolute.checked_sub(fragment_base as u64)?).ok()?;
+                let end = start.checked_add(len as usize)?;
+                let json = std::str::from_utf8(fragments.get(start..end)?).ok()?;
+                let raw = serde_json::from_str::<Box<serde_json::value::RawValue>>(json).ok()?;
+                Some((version, raw))
+            });
+            PackageVersions::from_raw_fragments(raw_fragments)
+        }
+    };
+
     Some(Package {
         name: index.name,
         dist_tags: index.dist_tags,
-        versions: PackageVersions::from_file_spans(&file, spans),
+        versions,
         time: index.time,
         modified: headers.modified,
         etag: headers.etag,
@@ -579,6 +626,37 @@ pub fn load_meta(pkg_mirror: &Path) -> Option<Package> {
         release_age_upgrade_checked: false,
         derived: DerivedPackuments::default(),
     })
+}
+
+/// How many mirror files [`load_meta`] may keep open at once. Sized
+/// from the post-raise soft descriptor limit with headroom for the
+/// rest of the install (sockets, tarball extraction, store writes);
+/// loads beyond the cap buffer their fragments instead of holding a
+/// handle.
+fn held_mirror_file_cap() -> usize {
+    static CAP: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *CAP.get_or_init(|| {
+        raise_open_file_limit_once();
+        soft_open_file_limit().map_or(1 << 19, |soft| (soft / 2).clamp(128, 1 << 19))
+    })
+}
+
+#[cfg(unix)]
+fn soft_open_file_limit() -> Option<usize> {
+    let mut limit = libc::rlimit { rlim_cur: 0, rlim_max: 0 };
+    // SAFETY: plain libc call; `limit` is a properly initialised
+    // out-parameter and the pointer does not outlive the call.
+    if unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &raw mut limit) } != 0 {
+        return None;
+    }
+    usize::try_from(limit.rlim_cur).ok()
+}
+
+/// Windows has no `RLIMIT_NOFILE`; the per-process handle capacity is
+/// far above the cap's upper clamp.
+#[cfg(not(unix))]
+fn soft_open_file_limit() -> Option<usize> {
+    None
 }
 
 /// Async sibling of [`load_meta`]. The body is a blocking

--- a/pnpm/crates/resolving-npm-resolver/src/mirror/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/mirror/tests.rs
@@ -144,6 +144,51 @@ fn load_meta_round_trip_hydrates_versions_from_spans() {
     assert_eq!(manifest.dist.tarball, "https://registry/acme-1.0.0.tgz");
 }
 
+/// A loaded mirror pins its inode: fragments hydrate from the
+/// held-open handle, so a rewrite of the same path (another install
+/// racing, a release-age upgrade persist) can never shift the bytes
+/// under the recorded spans.
+#[test]
+fn load_meta_survives_mirror_rewrite() {
+    let dir = TempDir::new().expect("tmp dir");
+    let mirror = dir.path().join("acme.jsonl");
+    let pkg = fixture_package();
+    save_meta_indexed(&mirror, &pkg, None).expect("save");
+    let loaded = load_meta(&mirror).expect("read full back");
+    // The rewritten packument's `1.0.0` fragment sits at a different
+    // offset (a fatter `0.9.0` fragment precedes it), so a loader that
+    // re-read the path instead of the pinned inode would parse garbage.
+    let newer: Package = serde_json::from_value(serde_json::json!({
+        "name": "acme",
+        "dist-tags": { "latest": "1.0.0" },
+        "versions": {
+            "0.9.0": {
+                "name": "acme",
+                "version": "0.9.0",
+                "deprecated": "superseded by 1.0.0; padding padding padding padding",
+                "dist": {
+                    "integrity": "sha512-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB==",
+                    "shasum": "1111111111111111111111111111111111111111",
+                    "tarball": "https://registry/acme-0.9.0.tgz"
+                }
+            },
+            "1.0.0": {
+                "name": "acme",
+                "version": "1.0.0",
+                "dist": {
+                    "integrity": "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+                    "shasum": "0000000000000000000000000000000000000000",
+                    "tarball": "https://registry/acme-1.0.0-rebuilt.tgz"
+                }
+            }
+        }
+    }))
+    .expect("deserialize rewritten Package");
+    save_meta_indexed(&mirror, &newer, None).expect("overwrite");
+    let manifest = loaded.versions.get("1.0.0").expect("hydrate after rewrite");
+    assert_eq!(manifest.dist.tarball, "https://registry/acme-1.0.0.tgz");
+}
+
 #[test]
 fn load_meta_rejects_truncated_fragments() {
     let dir = TempDir::new().expect("tmp dir");

--- a/pnpm/crates/resolving-npm-resolver/src/mirror/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/mirror/tests.rs
@@ -219,21 +219,28 @@ fn load_meta_past_the_hold_cap_ignores_a_sparse_tail() {
 }
 
 #[test]
-fn load_meta_rejects_an_oversized_fragment_span() {
+fn load_meta_treats_an_oversized_fragment_span_as_absent() {
     let dir = TempDir::new().expect("tmp dir");
     let mirror = dir.path().join("acme.jsonl");
     let headers = "{}";
+    let fragment = r#"{"name":"acme","version":"1.0.0","dist":{"integrity":"sha512-A","shasum":"0","tarball":"https://registry/acme-1.0.0.tgz"}}"#;
     let index = format!(
-        r#"{{"name":"acme","distTags":{{}},"versions":[["1.0.0",0,{}]]}}"#,
+        r#"{{"name":"acme","distTags":{{}},"versions":[["1.0.0",0,{}],["9.9.9",{},{}]]}}"#,
+        fragment.len(),
+        fragment.len(),
         32 * 1024 * 1024,
     );
-    let contents = format!("pacquet-meta-v1 {} {}\n{headers}{index}", headers.len(), index.len());
+    let contents =
+        format!("pacquet-meta-v1 {} {}\n{headers}{index}{fragment}", headers.len(), index.len(),);
     std::fs::write(&mirror, &contents).expect("write");
     // A sparse tail makes the file size cover the declared span
     // without paying for the bytes, like a corrupt mirror would.
     let file = std::fs::OpenOptions::new().append(true).open(&mirror).expect("open");
     file.set_len(contents.len() as u64 + 64 * 1024 * 1024).expect("extend sparsely");
-    assert!(load_meta(&mirror).is_none());
+    let loaded = load_meta(&mirror).expect("read full back");
+    assert!(loaded.versions.get("9.9.9").is_none(), "oversized span must read as absent");
+    let manifest = loaded.versions.get("1.0.0").expect("hydrate the in-bounds fragment");
+    assert_eq!(manifest.dist.tarball, "https://registry/acme-1.0.0.tgz");
 }
 
 #[test]

--- a/pnpm/crates/resolving-npm-resolver/src/mirror/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/mirror/tests.rs
@@ -231,7 +231,7 @@ fn load_meta_treats_an_oversized_fragment_span_as_absent() {
         32 * 1024 * 1024,
     );
     let contents =
-        format!("pacquet-meta-v1 {} {}\n{headers}{index}{fragment}", headers.len(), index.len(),);
+        format!("pacquet-meta-v1 {} {}\n{headers}{index}{fragment}", headers.len(), index.len());
     std::fs::write(&mirror, &contents).expect("write");
     // A sparse tail makes the file size cover the declared span
     // without paying for the bytes, like a corrupt mirror would.

--- a/pnpm/crates/resolving-npm-resolver/src/mirror/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/mirror/tests.rs
@@ -8,8 +8,8 @@ use pacquet_network::MetadataCacheScope;
 
 use super::{
     ABBREVIATED_META_DIR, FULL_FILTERED_META_DIR, FULL_META_DIR, encode_pkg_name,
-    get_pkg_mirror_path, get_registry_name, load_meta, load_meta_headers, save_meta_indexed,
-    scoped_meta_dir,
+    get_pkg_mirror_path, get_registry_name, load_meta, load_meta_headers, load_meta_with_hold_cap,
+    save_meta_indexed, scoped_meta_dir,
 };
 
 #[test]
@@ -144,10 +144,6 @@ fn load_meta_round_trip_hydrates_versions_from_spans() {
     assert_eq!(manifest.dist.tarball, "https://registry/acme-1.0.0.tgz");
 }
 
-/// A loaded mirror pins its inode: fragments hydrate from the
-/// held-open handle, so a rewrite of the same path (another install
-/// racing, a release-age upgrade persist) can never shift the bytes
-/// under the recorded spans.
 #[test]
 fn load_meta_survives_mirror_rewrite() {
     let dir = TempDir::new().expect("tmp dir");
@@ -155,9 +151,8 @@ fn load_meta_survives_mirror_rewrite() {
     let pkg = fixture_package();
     save_meta_indexed(&mirror, &pkg, None).expect("save");
     let loaded = load_meta(&mirror).expect("read full back");
-    // The rewritten packument's `1.0.0` fragment sits at a different
-    // offset (a fatter `0.9.0` fragment precedes it), so a loader that
-    // re-read the path instead of the pinned inode would parse garbage.
+    // The fatter `0.9.0` fragment shifts `1.0.0`'s offset, so a loader
+    // that re-read the path instead of the pinned inode parses garbage.
     let newer: Package = serde_json::from_value(serde_json::json!({
         "name": "acme",
         "dist-tags": { "latest": "1.0.0" },
@@ -187,6 +182,26 @@ fn load_meta_survives_mirror_rewrite() {
     save_meta_indexed(&mirror, &newer, None).expect("overwrite");
     let manifest = loaded.versions.get("1.0.0").expect("hydrate after rewrite");
     assert_eq!(manifest.dist.tarball, "https://registry/acme-1.0.0.tgz");
+}
+
+#[test]
+fn load_meta_past_the_hold_cap_buffers_fragments_instead_of_missing() {
+    let dir = TempDir::new().expect("tmp dir");
+    let mirror = dir.path().join("acme.jsonl");
+    let pkg = fixture_package();
+    save_meta_indexed(&mirror, &pkg, Some(r#"W/"abc""#)).expect("save");
+    let loaded = load_meta_with_hold_cap(&mirror, 0).expect("read full back without a handle");
+    let manifest = loaded.versions.get("1.0.0").expect("hydrate from buffered fragment");
+    assert_eq!(manifest.dist.tarball, "https://registry/acme-1.0.0.tgz");
+    assert_eq!(loaded.etag.as_deref(), Some(r#"W/"abc""#));
+}
+
+#[test]
+fn load_meta_rejects_oversized_declared_record_lengths() {
+    let dir = TempDir::new().expect("tmp dir");
+    let mirror = dir.path().join("acme.jsonl");
+    std::fs::write(&mirror, "pacquet-meta-v1 128 999999999999\n{}{}").expect("write");
+    assert!(load_meta(&mirror).is_none());
 }
 
 #[test]

--- a/pnpm/crates/resolving-npm-resolver/src/mirror/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/mirror/tests.rs
@@ -205,6 +205,20 @@ fn load_meta_rejects_oversized_declared_record_lengths() {
 }
 
 #[test]
+fn load_meta_past_the_hold_cap_ignores_a_sparse_tail() {
+    let dir = TempDir::new().expect("tmp dir");
+    let mirror = dir.path().join("acme.jsonl");
+    let pkg = fixture_package();
+    save_meta_indexed(&mirror, &pkg, None).expect("save");
+    let file = std::fs::OpenOptions::new().append(true).open(&mirror).expect("open");
+    let size = file.metadata().expect("metadata").len();
+    file.set_len(size + 64 * 1024 * 1024).expect("extend sparsely");
+    let loaded = load_meta_with_hold_cap(&mirror, 0).expect("read full back without a handle");
+    let manifest = loaded.versions.get("1.0.0").expect("hydrate from buffered fragment");
+    assert_eq!(manifest.dist.tarball, "https://registry/acme-1.0.0.tgz");
+}
+
+#[test]
 fn load_meta_rejects_an_oversized_fragment_span() {
     let dir = TempDir::new().expect("tmp dir");
     let mirror = dir.path().join("acme.jsonl");

--- a/pnpm/crates/resolving-npm-resolver/src/mirror/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/mirror/tests.rs
@@ -205,6 +205,24 @@ fn load_meta_rejects_oversized_declared_record_lengths() {
 }
 
 #[test]
+fn load_meta_rejects_an_oversized_fragment_span() {
+    let dir = TempDir::new().expect("tmp dir");
+    let mirror = dir.path().join("acme.jsonl");
+    let headers = "{}";
+    let index = format!(
+        r#"{{"name":"acme","distTags":{{}},"versions":[["1.0.0",0,{}]]}}"#,
+        32 * 1024 * 1024,
+    );
+    let contents = format!("pacquet-meta-v1 {} {}\n{headers}{index}", headers.len(), index.len());
+    std::fs::write(&mirror, &contents).expect("write");
+    // A sparse tail makes the file size cover the declared span
+    // without paying for the bytes, like a corrupt mirror would.
+    let file = std::fs::OpenOptions::new().append(true).open(&mirror).expect("open");
+    file.set_len(contents.len() as u64 + 64 * 1024 * 1024).expect("extend sparsely");
+    assert!(load_meta(&mirror).is_none());
+}
+
+#[test]
 fn load_meta_rejects_truncated_fragments() {
     let dir = TempDir::new().expect("tmp dir");
     let mirror = dir.path().join("acme.jsonl");

--- a/pnpm/crates/resolving-npm-resolver/src/mirror/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/mirror/tests.rs
@@ -219,6 +219,30 @@ fn load_meta_past_the_hold_cap_ignores_a_sparse_tail() {
 }
 
 #[test]
+fn load_meta_past_the_hold_cap_skips_a_sparse_gap_between_spans() {
+    let dir = TempDir::new().expect("tmp dir");
+    let mirror = dir.path().join("acme.jsonl");
+    let headers = "{}";
+    let fragment = r#"{"name":"acme","version":"1.0.0","dist":{"integrity":"sha512-A","shasum":"0","tarball":"https://registry/acme-1.0.0.tgz"}}"#;
+    let far_offset: u64 = 512 * 1024 * 1024;
+    let index = format!(
+        r#"{{"name":"acme","distTags":{{}},"versions":[["1.0.0",0,{}],["2.0.0",{far_offset},16]]}}"#,
+        fragment.len(),
+    );
+    let contents =
+        format!("pacquet-meta-v1 {} {}\n{headers}{index}{fragment}", headers.len(), index.len());
+    std::fs::write(&mirror, &contents).expect("write");
+    let file = std::fs::OpenOptions::new().append(true).open(&mirror).expect("open");
+    file.set_len(contents.len() as u64 + far_offset + 16).expect("extend sparsely");
+    let loaded = load_meta_with_hold_cap(&mirror, 0).expect("read full back without a handle");
+    let manifest = loaded.versions.get("1.0.0").expect("hydrate the near fragment");
+    assert_eq!(manifest.dist.tarball, "https://registry/acme-1.0.0.tgz");
+    // The far span reads zeroes out of the sparse hole — not JSON, so
+    // the version is absent; the gap itself must never be buffered.
+    assert!(loaded.versions.get("2.0.0").is_none());
+}
+
+#[test]
 fn load_meta_treats_an_oversized_fragment_span_as_absent() {
     let dir = TempDir::new().expect("tmp dir");
     let mirror = dir.path().join("acme.jsonl");

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package.rs
@@ -65,7 +65,8 @@ use crate::{
     FetchMetadataError, fetch_full_metadata, fetch_full_metadata_cached,
     mirror::{
         ABBREVIATED_META_DIR, FULL_FILTERED_META_DIR, FULL_META_DIR, clear_meta,
-        get_pkg_mirror_path, load_meta_async, save_meta_indexed, save_meta_ndjson, scoped_meta_dir,
+        get_pkg_mirror_path, load_meta, load_meta_async, save_meta_indexed, save_meta_ndjson,
+        scoped_meta_dir,
     },
     pick_package_from_meta::{
         PickPackageFromMetaError, PickPackageFromMetaOptions, RegistryPackageSpec,
@@ -631,10 +632,12 @@ pub async fn pick_package<Cache: PackageMetaCache>(
                 meta,
             )
             .await?;
-            let meta = upgrade.meta;
+            let mut meta = upgrade.meta;
             if upgrade.upgraded && !opts.dry_run {
-                if let Some(path) = pkg_mirror.as_deref() {
-                    persist_upgraded_to_mirror(path, &meta, use_filtered_full_metadata);
+                if let Some(reloaded) = pkg_mirror.as_deref().and_then(|path| {
+                    persist_upgraded_to_mirror(path, &meta, use_filtered_full_metadata)
+                }) {
+                    meta = Arc::new(reloaded);
                 }
                 ctx.meta_cache.set(cache_key.clone(), Arc::clone(&meta));
             }
@@ -725,12 +728,14 @@ pub async fn pick_package<Cache: PackageMetaCache>(
         meta,
     )
     .await?;
-    let meta = upgrade.meta;
+    let mut meta = upgrade.meta;
     if upgrade.upgraded
         && !opts.dry_run
-        && let Some(path) = pkg_mirror.as_deref()
+        && let Some(reloaded) = pkg_mirror
+            .as_deref()
+            .and_then(|path| persist_upgraded_to_mirror(path, &meta, use_filtered_full_metadata))
     {
-        persist_upgraded_to_mirror(path, &meta, use_filtered_full_metadata);
+        meta = Arc::new(reloaded);
     }
 
     // Worth flagging: a dry-run is meant to gate the on-disk save, but
@@ -789,12 +794,14 @@ async fn handle_cache_hit<Cache: PackageMetaCache>(
         cached.meta,
     )
     .await?;
-    let meta = upgrade.meta;
+    let mut meta = upgrade.meta;
     // The upgrade fetch (re)validated the packument against the registry.
     let registry_verified = cached.registry_verified || upgrade.upgraded;
     if upgrade.upgraded && !opts.dry_run {
-        if let Some(path) = pkg_mirror {
-            persist_upgraded_to_mirror(path, &meta, use_filtered_full_metadata);
+        if let Some(reloaded) = pkg_mirror
+            .and_then(|path| persist_upgraded_to_mirror(path, &meta, use_filtered_full_metadata))
+        {
+            meta = Arc::new(reloaded);
         }
         ctx.meta_cache.set(cache_key.to_string(), Arc::clone(&meta));
     }
@@ -1284,10 +1291,20 @@ async fn maybe_upgrade_abbreviated_meta_for_release_age<Cache: PackageMetaCache>
 
 /// Write the upgraded full metadata back to `pkg_mirror` (which
 /// points at the abbreviated cache because the picker is in
-/// abbreviated mode). Fire-and-forget: a write failure logs at debug
-/// and the install proceeds — the next install simply re-triggers
-/// the upgrade fetch.
-fn persist_upgraded_to_mirror(pkg_mirror: &Path, meta: &Package, filter_metadata: bool) {
+/// abbreviated mode). A write failure logs at debug and the install
+/// proceeds — the next install simply re-triggers the upgrade fetch.
+///
+/// On a successful indexed save, returns the just-persisted mirror
+/// reloaded in its file-backed form so the caller can cache *it*
+/// instead of the response-body-backed document — upgraded packuments
+/// are the largest documents an install handles, and caching the
+/// in-memory form kept every full body resident for the rest of the
+/// resolution.
+fn persist_upgraded_to_mirror(
+    pkg_mirror: &Path,
+    meta: &Package,
+    filter_metadata: bool,
+) -> Option<Package> {
     let save_result = if filter_metadata {
         let meta_for_cache = match clear_meta(meta) {
             Ok(meta_for_cache) => meta_for_cache,
@@ -1298,20 +1315,25 @@ fn persist_upgraded_to_mirror(pkg_mirror: &Path, meta: &Package, filter_metadata
                     path = %pkg_mirror.display(),
                     "could not filter upgraded mirror metadata",
                 );
-                return;
+                return None;
             }
         };
         save_meta_ndjson(pkg_mirror, &meta_for_cache, meta.etag.as_deref())
     } else {
         save_meta_indexed(pkg_mirror, meta, meta.etag.as_deref())
     };
-    if let Err(error) = save_result {
-        tracing::debug!(
-            target: "pacquet_resolving_npm_resolver::pick_package",
-            ?error,
-            path = %pkg_mirror.display(),
-            "could not write upgraded meta to mirror; skipping persist",
-        );
+    match save_result {
+        Ok(()) if !filter_metadata => load_meta(pkg_mirror),
+        Ok(()) => None,
+        Err(error) => {
+            tracing::debug!(
+                target: "pacquet_resolving_npm_resolver::pick_package",
+                ?error,
+                path = %pkg_mirror.display(),
+                "could not write upgraded meta to mirror; skipping persist",
+            );
+            None
+        }
     }
 }
 


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Related to pnpm/pnpm#13681 (the single-importer resolution peak; the multi-importer link-phase burst is discussed below).

Profiling the issue's `@teambit/bit@2.0.67` repro attributed the resolution-phase peak to the in-memory packument cache: every consulted packument kept its **entire JSON body** resident for the whole install — as raw response fragments after a network fetch, or as the whole mirror-file buffer after a warm disk load. The repro's mirror holds 1.7 GB of packument JSON (mostly a few hundred multi-megabyte bit.cloud documents), and a phase-boundary RSS probe showed ~2.4 GB live right after the importer init waves, against a 3.18 GB total peak.

This change stops retaining packument bodies:

- `FragmentSource::FileSpan` (replacing `BufferSpan`): a loaded mirror keeps its **file handle open** and reads each version fragment on demand with a positioned read. Holding the handle pins the inode — mirror rewrites go through temp-file + `rename`, so recorded spans can never shift under a reader. Fragment bytes now live in the (reclaimable) page cache instead of anonymous memory.
- Warm loads (`load_meta`) parse only the header + index records; the fragment section is never buffered.
- Cold fetches (`fetch_full_metadata_cached`) and release-age upgrade persists (`persist_upgraded_to_mirror`) return/cache the just-persisted mirror in its file-backed form, so the multi-megabyte response body drops as soon as it is written instead of living in the packument cache for the rest of the install.
- Because the cache now holds one open descriptor per consulted packument, the soft `RLIMIT_NOFILE` is raised once toward the hard limit (the same startup adjustment the Go runtime performs; macOS falls back to the historic 10240 ceiling). Windows needs no adjustment.

### Measurements

Linux x64, 32 cores, same fixture as the issue (single importer, `@teambit/bit@2.0.67`, ~3850 packages, hoisted + autoInstallPeers config), peak RSS via `/usr/bin/time -v`:

| Scenario | Before | After |
| --- | ---: | ---: |
| `--lockfile-only` resolve, warm metadata mirror (offline) | 3.18 GB | **1.31 GB** |
| `--lockfile-only` resolve, cold metadata (online) | 3.33 GB | **1.86 GB** |
| Full install, no lockfile, cold store | — | **1.99 GB** |

The issue's expectation ("peak in the same ballpark as pnpm v10, ≤ ~2 GB for the single-importer repro"; v10's full install measures 2.13 GB there) is met. Wall time is unchanged: 6-run A/B of the warm offline resolve is ~5.2 s for both binaries.

Phase probes after the change put the packument cache at ~0.2 GB; the largest remaining block is the peer-discovery walk state (~0.65 GB at this scale), which is the follow-up lever if more is needed.

### Lockfile stability

The emitted lockfile is unchanged **modulo a pre-existing race**: on this fixture, unmodified `main` already produces different lockfiles across identical runs (6 runs → 4 distinct hashes; `classnames: 2.2.6 ↔ 2.5.1` edge flips). The race is arrival-ordered children recording for overlay-affected picks — filed separately with the mechanism and a bounded-fix sketch as pnpm/pnpm#13685. This PR does not change the distribution of outcomes (verified by running both binaries 6×; the hash sets overlap), and byte-compares on race-free fixtures are unaffected — the crate and workspace test suites pass unchanged.

### On the multi-importer link-phase burst

The issue's second observation (a ~1300-importer workspace bursting 12 GB → 31 GB after downloads complete) could not be reproduced at that scale locally. Two data points from this investigation:

- The hoisted-graph builder itself measures small at real workspace scale: `lockfile_to_hoisted_dep_graph` over a 343-importer / 6349-snapshot workspace lockfile allocates ~47 MB (10.6k graph nodes).
- The fetch-phase plateau the burst sits on includes the retained metadata this PR removes (a bit-scale workspace consults strictly more bit.cloud packuments than the single-importer repro), so the whole curve should shift down by several GB.

A re-test of the CI workspace against this change would tell how much of the burst remains; the `hoisted_dep_graph` re-expansion path deserves its own profiling pass if it still spikes.

This is Rust-only: the change is an internal memory representation of the metadata cache (the on-disk mirror format is unchanged), so there is no TypeScript-side behavior to port.

## Squash Commit Body

```text
Stop retaining packument bodies in the install-scoped metadata cache
(Related to pnpm/pnpm#13681).

Every consulted packument kept its entire JSON body resident for the
whole install: raw response fragments after a network fetch, or the
whole mirror-file buffer after a warm disk load. On the issue's
@teambit/bit repro that is 1.7 GB of JSON and the dominant share of the
3.18 GB resolution peak.

Version fragments now stay on disk behind the loaded mirror's held-open
file handle (FragmentSource::FileSpan) and are read on demand with a
positioned read; holding the handle pins the inode, so rename-based
mirror rewrites can never shift bytes under the recorded spans. Warm
loads parse only the header and index records. Cold fetches and
release-age upgrade persists return the just-persisted mirror in its
file-backed form so the response body drops at write time. The soft
RLIMIT_NOFILE is raised once toward the hard limit to cover the held
descriptors (one per consulted packument).

Every declared length in a mirror is treated as untrusted: the header,
index, and per-fragment spans are bounded and validated against the
real file size before any allocation. Held handles are counted against
a descriptor-budget cap sized from the post-raise soft limit; a load
past the cap buffers its fragments span by span (bounded by a
cumulative budget) and closes the file, so a full cache can never turn
File::open failures into cache misses elsewhere. An over-limit
fragment reads as an absent version on both the save and load sides,
keeping the persisted and served views agreeing.

Peak RSS on the repro: 3.18 GB -> 1.31 GB (warm offline resolve),
3.33 GB -> 1.86 GB (cold online resolve); a full cold install stays
under 2 GB, below the pnpm v10 baseline from the issue. Wall time is
unchanged (6-run A/B). The fixture's lockfile flips predate this change
(pre-existing arrival-order race, filed as pnpm/pnpm#13685).
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).
