### PR TITLE
fix(cli): keep root/bin/prefix -g stdout a clean path; support root -g and prefix -g in pnpm 12

### DIFF
--- a/.changeset/root-bin-stderr-clean-path.md
+++ b/.changeset/root-bin-stderr-clean-path.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+`pnpm root -g` and `pnpm bin -g` now print warnings to stderr instead of stdout, so their stdout stays a clean, machine-readable path. Previously, running either command with `--global` in a project that pins a package manager (e.g. via the `packageManager` field) printed a warning like `[WARN] Using --global skips the package manager check for this project` ahead of the path, breaking programs that capture the output as a path [#13672](https://github.com/pnpm/pnpm/issues/13672).

--- a/.changeset/root-bin-stderr-clean-path.md
+++ b/.changeset/root-bin-stderr-clean-path.md
@@ -2,4 +2,4 @@
 "pnpm": patch
 ---
 
-`pnpm root -g` and `pnpm bin -g` now print warnings to stderr instead of stdout, so their stdout stays a clean, machine-readable path. Previously, running either command with `--global` in a project that pins a package manager (e.g. via the `packageManager` field) printed a warning like `[WARN] Using --global skips the package manager check for this project` ahead of the path, breaking programs that capture the output as a path [#13672](https://github.com/pnpm/pnpm/issues/13672).
+`pnpm root -g` and `pnpm bin -g` now print warnings to stderr instead of stdout, so their stdout stays a clean, machine-readable path. Previously, running either command with `--global` in a project that pins a package manager (e.g. via the `packageManager` field) printed a warning like `[WARN] Using --global skips the package manager check for this project` ahead of the path, breaking programs that capture the output as a path [#13672](https://github.com/pnpm/pnpm/issues/13672). The Rust pnpm port (pnpm 12) does not support `root -g` yet, and its `bin -g` still prints this warning to stdout — stderr routing for it will follow in a separate change.

--- a/.changeset/root-bin-stderr-clean-path.md
+++ b/.changeset/root-bin-stderr-clean-path.md
@@ -1,5 +1,8 @@
 ---
 "pnpm": patch
+"pacquet": minor
 ---
 
-`pnpm root -g` and `pnpm bin -g` now print warnings to stderr instead of stdout, so their stdout stays a clean, machine-readable path. Previously, running either command with `--global` in a project that pins a package manager (e.g. via the `packageManager` field) printed a warning like `[WARN] Using --global skips the package manager check for this project` ahead of the path, breaking programs that capture the output as a path [#13672](https://github.com/pnpm/pnpm/issues/13672). The Rust pnpm port (pnpm 12) does not support `root -g` yet, and its `bin -g` still prints this warning to stdout — stderr routing for it will follow in a separate change.
+`pnpm root -g` and `pnpm bin -g` now print warnings to stderr instead of stdout, so their stdout stays a clean, machine-readable path. Previously, running either command with `--global` in a project that pins a package manager (e.g. via the `packageManager` field) printed a warning like `[WARN] Using --global skips the package manager check for this project` ahead of the path, breaking programs that capture the output as a path [#13672](https://github.com/pnpm/pnpm/issues/13672).
+
+In pnpm 12, `pnpm root -g` and `pnpm prefix -g` are now supported (they previously failed with `ERR_PNPM_CLI_ROOT_GLOBAL_UNSUPPORTED` / `ERR_PNPM_CLI_PREFIX_GLOBAL_UNSUPPORTED`), and the reporter output of `dlx`, `create`, `config`, `sbom`, `with`, `store`, `prefix`, `root`, and `bin` goes to stderr, matching pnpm 11.

--- a/pnpm/crates/cli/src/cli_args/bin.rs
+++ b/pnpm/crates/cli/src/cli_args/bin.rs
@@ -18,7 +18,7 @@ impl BinArgs {
             let bin = config.global_bin.clone().ok_or(GlobalError::NoGlobalBinDir)?;
             // Mirror pnpm's config reader: create then validate the global bin
             // dir for every `--global` command. `should_allow_write` is true for
-            // all but `root`, so `bin` checks writability too.
+            // all but `root` and `prefix`, so `bin` checks writability too.
             std::fs::create_dir_all(&bin).map_err(|error| {
                 let bin_dir = bin.display();
                 miette::miette!("failed to create the global bin directory {bin_dir}: {error}")

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -665,6 +665,25 @@ impl CliCommand {
         reports_scope && (recursive || matches!(self, CliCommand::Install(_)))
     }
 
+    /// Whether reporter output (warnings, progress) goes to stderr so this
+    /// command's stdout stays a clean, machine-readable value — pnpm's
+    /// `COMMANDS_WITH_STDERR_REPORTER`. pnpm's set also lists the top-level
+    /// `set` / `get` commands, which pacquet does not have.
+    pub(crate) fn uses_stderr_reporter(&self) -> bool {
+        matches!(
+            self,
+            CliCommand::Dlx(_)
+                | CliCommand::Create(_)
+                | CliCommand::Config(_)
+                | CliCommand::Sbom(_)
+                | CliCommand::With(_)
+                | CliCommand::Store(_)
+                | CliCommand::Prefix(_)
+                | CliCommand::Root(_)
+                | CliCommand::Bin(_),
+        )
+    }
+
     pub(crate) fn default_reporter_summary_scope(&self) -> SummaryScope {
         match self {
             CliCommand::Access(_) => SummaryScope::CurrentPrefix,

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -73,6 +73,7 @@ impl CliArgs {
             self.command.reports_scope(self.recursive),
             false,
             self.recursive,
+            self.command.uses_stderr_reporter(),
         );
     }
 

--- a/pnpm/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_query.rs
@@ -517,12 +517,12 @@ pub(super) fn clean<'a>(
 }
 
 pub(super) fn root<'a>(ctx: &RunCtx<'a>, args: RootArgs) -> miette::Result<CommandFuture<'a>> {
-    args.run(ctx.dir)?;
+    args.run(ctx.dir, (ctx.config)()?)?;
     Ok(Box::pin(std::future::ready(Ok(()))))
 }
 
 pub(super) fn prefix<'a>(ctx: &RunCtx<'a>, args: PrefixArgs) -> miette::Result<CommandFuture<'a>> {
-    args.run(ctx.dir)?;
+    args.run(ctx.dir, (ctx.config)()?)?;
     Ok(Box::pin(std::future::ready(Ok(()))))
 }
 

--- a/pnpm/crates/cli/src/cli_args/global.rs
+++ b/pnpm/crates/cli/src/cli_args/global.rs
@@ -55,6 +55,12 @@ pub enum GlobalError {
     )]
     NoGlobalBinDir,
 
+    /// The global packages directory could not be resolved (no `PNPM_HOME`
+    /// and no determinable data dir), matching pnpm's `prefix` handler.
+    #[display("The global package directory could not be resolved.")]
+    #[diagnostic(code(ERR_PNPM_MISSING_GLOBAL_PACKAGE_DIR))]
+    MissingGlobalPackageDir,
+
     #[display(r#"Use the "pnpm self-update" command to install or update pnpm"#)]
     #[diagnostic(code(ERR_PNPM_GLOBAL_PNPM_INSTALL))]
     GlobalPnpmInstall,

--- a/pnpm/crates/cli/src/cli_args/prefix.rs
+++ b/pnpm/crates/cli/src/cli_args/prefix.rs
@@ -1,7 +1,10 @@
 use clap::Args;
 use derive_more::{Display, Error};
 use miette::Diagnostic;
+use pacquet_config::{Config, check_global_bin_dir};
 use std::path::{Path, PathBuf};
+
+use super::global::GlobalError;
 
 /// Print the current package prefix — the nearest directory containing a
 /// `package.json`, `node_modules`, or `pnpm-workspace.yaml`.
@@ -16,12 +19,11 @@ pub struct PrefixArgs {
 #[derive(Debug, Display, Error, Diagnostic)]
 #[non_exhaustive]
 pub enum PrefixError {
-    /// `--global` is rejected because the global-dir machinery (pnpm's
-    /// `@pnpm/global.commands`) is not ported to pacquet yet; refuse rather
-    /// than print a wrong path.
-    #[display("`pnpm prefix --global` is not supported yet.")]
-    #[diagnostic(code(ERR_PNPM_CLI_PREFIX_GLOBAL_UNSUPPORTED))]
-    GlobalUnsupported,
+    /// The global packages directory could not be resolved (no `PNPM_HOME`
+    /// and no determinable data dir), matching pnpm's `prefix` handler.
+    #[display("The global package directory could not be resolved.")]
+    #[diagnostic(code(ERR_PNPM_MISSING_GLOBAL_PACKAGE_DIR))]
+    MissingGlobalPackageDir,
 
     /// IO error while looking up the prefix.
     #[display("failed to access {}: {source}", path.display())]
@@ -75,9 +77,26 @@ fn find_prefix_up(name: &Path, original: &Path) -> miette::Result<PathBuf> {
 }
 
 impl PrefixArgs {
-    pub fn run(self, dir: &Path) -> miette::Result<()> {
+    pub fn run(self, dir: &Path, config: &Config) -> miette::Result<()> {
         if self.global {
-            return Err(PrefixError::GlobalUnsupported.into());
+            // Mirror pnpm's config reader: create then validate the global bin
+            // dir for every `--global` command, without the writability check
+            // (`globalDirShouldAllowWrite` is false for `root` and `prefix`;
+            // see pnpm issue 2700).
+            let bin = config.global_bin.clone().ok_or(GlobalError::NoGlobalBinDir)?;
+            std::fs::create_dir_all(&bin).map_err(|error| {
+                let bin_dir = bin.display();
+                miette::miette!("failed to create the global bin directory {bin_dir}: {error}")
+            })?;
+            check_global_bin_dir(&bin, std::env::var("PATH").ok().as_deref(), false)
+                .map_err(miette::Report::new)?;
+            // pnpm's `prefix` handler prints the parent of the global packages
+            // dir — the global dir root, without the layout-version leaf.
+            let pkg_dir =
+                config.global_pkg_dir.clone().ok_or(PrefixError::MissingGlobalPackageDir)?;
+            let prefix_dir = pkg_dir.parent().ok_or(PrefixError::MissingGlobalPackageDir)?;
+            println!("{}", prefix_dir.display());
+            return Ok(());
         }
         let prefix_dir = find_local_prefix(dir)?;
         println!("{}", prefix_dir.display());

--- a/pnpm/crates/cli/src/cli_args/prefix.rs
+++ b/pnpm/crates/cli/src/cli_args/prefix.rs
@@ -19,12 +19,6 @@ pub struct PrefixArgs {
 #[derive(Debug, Display, Error, Diagnostic)]
 #[non_exhaustive]
 pub enum PrefixError {
-    /// The global packages directory could not be resolved (no `PNPM_HOME`
-    /// and no determinable data dir), matching pnpm's `prefix` handler.
-    #[display("The global package directory could not be resolved.")]
-    #[diagnostic(code(ERR_PNPM_MISSING_GLOBAL_PACKAGE_DIR))]
-    MissingGlobalPackageDir,
-
     /// IO error while looking up the prefix.
     #[display("failed to access {}: {source}", path.display())]
     #[diagnostic(code(ERR_PNPM_CLI_PREFIX_IO_ERROR))]
@@ -93,8 +87,8 @@ impl PrefixArgs {
             // pnpm's `prefix` handler prints the parent of the global packages
             // dir — the global dir root, without the layout-version leaf.
             let pkg_dir =
-                config.global_pkg_dir.clone().ok_or(PrefixError::MissingGlobalPackageDir)?;
-            let prefix_dir = pkg_dir.parent().ok_or(PrefixError::MissingGlobalPackageDir)?;
+                config.global_pkg_dir.clone().ok_or(GlobalError::MissingGlobalPackageDir)?;
+            let prefix_dir = pkg_dir.parent().ok_or(GlobalError::MissingGlobalPackageDir)?;
             println!("{}", prefix_dir.display());
             return Ok(());
         }

--- a/pnpm/crates/cli/src/cli_args/reporter.rs
+++ b/pnpm/crates/cli/src/cli_args/reporter.rs
@@ -40,8 +40,12 @@ pub(crate) fn configure_default_reporter(
     reports_scope: bool,
     hide_added_pkgs_progress: bool,
     is_recursive: bool,
+    use_stderr: bool,
 ) {
     pacquet_default_reporter::set_cwd(dir.to_string_lossy().into_owned());
+    if use_stderr {
+        pacquet_default_reporter::use_stderr();
+    }
     pacquet_default_reporter::set_summary_scope(summary_scope);
     pacquet_default_reporter::set_reports_scope(reports_scope);
     pacquet_default_reporter::set_hide_added_pkgs_progress(hide_added_pkgs_progress);

--- a/pnpm/crates/cli/src/cli_args/root.rs
+++ b/pnpm/crates/cli/src/cli_args/root.rs
@@ -1,7 +1,8 @@
 use clap::Args;
-use derive_more::{Display, Error};
-use miette::Diagnostic;
+use pacquet_config::{Config, check_global_bin_dir};
 use std::path::Path;
+
+use super::global::GlobalError;
 
 /// Print the path to the `node_modules` directory.
 #[derive(Debug, Args)]
@@ -11,23 +12,25 @@ pub struct RootArgs {
     pub global: bool,
 }
 
-/// Errors specific to `pacquet root`.
-#[derive(Debug, Display, Error, Diagnostic, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum RootError {
-    /// `--global` is rejected because the global-dir machinery is not
-    /// ported to pacquet yet; refuse rather than print a wrong path.
-    #[display("`pnpm root --global` is not supported yet.")]
-    #[diagnostic(code(ERR_PNPM_CLI_ROOT_GLOBAL_UNSUPPORTED))]
-    GlobalUnsupported,
-}
-
 impl RootArgs {
-    pub fn run(self, dir: &Path) -> miette::Result<()> {
+    pub fn run(self, dir: &Path, config: &Config) -> miette::Result<()> {
         if self.global {
-            return Err(RootError::GlobalUnsupported.into());
+            let pkg_dir = config.global_pkg_dir.clone().ok_or(GlobalError::NoGlobalBinDir)?;
+            let bin = config.global_bin.clone().ok_or(GlobalError::NoGlobalBinDir)?;
+            // Mirror pnpm's config reader: create then validate the global bin
+            // dir for every `--global` command. `root` only prints a path, so
+            // it skips the writability check (`globalDirShouldAllowWrite` is
+            // false for `root` and `prefix`; see pnpm issue 2700).
+            std::fs::create_dir_all(&bin).map_err(|error| {
+                let bin_dir = bin.display();
+                miette::miette!("failed to create the global bin directory {bin_dir}: {error}")
+            })?;
+            check_global_bin_dir(&bin, std::env::var("PATH").ok().as_deref(), false)
+                .map_err(miette::Report::new)?;
+            println!("{}", pkg_dir.display());
+        } else {
+            println!("{}", dir.join("node_modules").display());
         }
-        println!("{}", dir.join("node_modules").display());
         Ok(())
     }
 }

--- a/pnpm/crates/cli/src/cli_args/root.rs
+++ b/pnpm/crates/cli/src/cli_args/root.rs
@@ -15,18 +15,19 @@ pub struct RootArgs {
 impl RootArgs {
     pub fn run(self, dir: &Path, config: &Config) -> miette::Result<()> {
         if self.global {
-            let pkg_dir = config.global_pkg_dir.clone().ok_or(GlobalError::NoGlobalBinDir)?;
-            let bin = config.global_bin.clone().ok_or(GlobalError::NoGlobalBinDir)?;
             // Mirror pnpm's config reader: create then validate the global bin
             // dir for every `--global` command. `root` only prints a path, so
             // it skips the writability check (`globalDirShouldAllowWrite` is
             // false for `root` and `prefix`; see pnpm issue 2700).
+            let bin = config.global_bin.clone().ok_or(GlobalError::NoGlobalBinDir)?;
             std::fs::create_dir_all(&bin).map_err(|error| {
                 let bin_dir = bin.display();
                 miette::miette!("failed to create the global bin directory {bin_dir}: {error}")
             })?;
             check_global_bin_dir(&bin, std::env::var("PATH").ok().as_deref(), false)
                 .map_err(miette::Report::new)?;
+            let pkg_dir =
+                config.global_pkg_dir.clone().ok_or(GlobalError::MissingGlobalPackageDir)?;
             println!("{}", pkg_dir.display());
         } else {
             println!("{}", dir.join("node_modules").display());

--- a/pnpm/crates/cli/tests/suite/bin.rs
+++ b/pnpm/crates/cli/tests/suite/bin.rs
@@ -112,6 +112,48 @@ fn bin_global_errors_when_not_in_path() {
     drop(root);
 }
 
+/// The pm-check warning (`Using --global skips the package manager check for
+/// this project`) goes to stderr so `bin -g` keeps stdout a clean,
+/// machine-readable path. Ports `pnpm bin -g writes warnings to stderr so
+/// stdout stays a clean path` from `pnpm11/pnpm/test/bin.ts`: the impossible
+/// pin `pnpm@0.0.0` plus `--pm-on-fail=warn` triggers the warning without any
+/// version resolution. Unix-gated for the same `PATH`-format reason as the
+/// other `-g` cases.
+#[cfg(unix)]
+#[test]
+fn bin_global_writes_warnings_to_stderr_so_stdout_stays_a_clean_path() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("package.json"), r#"{ "packageManager": "pnpm@0.0.0" }"#)
+        .expect("write package.json");
+    let pnpm_home = root.path().join("pnpm-home");
+    let global_bin = pnpm_home.join("bin");
+    let existing_path = std::env::var("PATH").unwrap_or_default();
+    let path = format!("{}:{existing_path}", global_bin.display());
+
+    let output = pacquet
+        .with_env("PNPM_HOME", &pnpm_home)
+        .with_env("HOME", root.path())
+        .with_env("XDG_CONFIG_HOME", root.path().join("xdg-config"))
+        .with_env("PNPM_CONFIG_GLOBAL_BIN_DIR", "")
+        .with_env("pnpm_config_global_bin_dir", "")
+        .with_env("PATH", path)
+        .with_args(["--pm-on-fail=warn", "bin", "-g"])
+        .output()
+        .expect("run pacquet bin -g");
+    dbg!(&output);
+    assert!(output.status.success(), "pacquet bin -g should succeed");
+
+    let expected = format!("{}\n", global_bin.display());
+    assert_eq!(String::from_utf8_lossy(&output.stdout), expected);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Using --global skips the package manager check for this project"),
+        "stderr should carry the pm-check warning: {stderr}",
+    );
+
+    drop(root);
+}
+
 /// Differential parity: from a workspace subdirectory pnpm's `bin` prints the
 /// cwd's `node_modules/.bin` (its `config.dir` is the cwd, not the workspace
 /// root). pacquet must match byte-for-byte. Windows-skipped because it spawns

--- a/pnpm/crates/cli/tests/suite/create.rs
+++ b/pnpm/crates/cli/tests/suite/create.rs
@@ -48,9 +48,12 @@ fn create_converts_name_and_runs_via_dlx() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(output.status.success(), "create failed\nstdout:\n{stdout}\nstderr:\n{stderr}");
+    // The reporter writes to stderr for create (pnpm's
+    // `COMMANDS_WITH_STDERR_REPORTER`), keeping stdout for the executed
+    // command.
     assert!(
-        stdout.contains("dependencies:\n+ create-touch-file-one-bin"),
-        "create should print the installed package summary\nstdout:\n{stdout}",
+        stderr.contains("dependencies:\n+ create-touch-file-one-bin"),
+        "create should print the installed package summary on stderr\nstderr:\n{stderr}",
     );
 
     let touch_txt = workspace.join("touch.txt");

--- a/pnpm/crates/cli/tests/suite/dlx.rs
+++ b/pnpm/crates/cli/tests/suite/dlx.rs
@@ -57,9 +57,12 @@ fn dlx_installs_and_runs_packages_bin() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(output.status.success(), "dlx failed\nstdout:\n{stdout}\nstderr:\n{stderr}");
+    // The reporter writes to stderr for dlx (pnpm's
+    // `COMMANDS_WITH_STDERR_REPORTER`), keeping stdout for the executed
+    // command.
     assert!(
-        stdout.contains("dependencies:\n+ @foo/touch-file-one-bin"),
-        "dlx should print the installed package summary\nstdout:\n{stdout}",
+        stderr.contains("dependencies:\n+ @foo/touch-file-one-bin"),
+        "dlx should print the installed package summary on stderr\nstderr:\n{stderr}",
     );
 
     assert!(

--- a/pnpm/crates/cli/tests/suite/prefix.rs
+++ b/pnpm/crates/cli/tests/suite/prefix.rs
@@ -74,16 +74,40 @@ fn prefix_walks_up_from_node_modules() {
     drop(root);
 }
 
+/// `pacquet prefix -g` prints the global dir root (the parent of the
+/// global packages dir, without the layout-version leaf), matching pnpm's
+/// `prefix` handler. Like pnpm's config reader it creates and validates
+/// the global bin dir first, without the writability requirement
+/// (`globalDirShouldAllowWrite` is false for `root` and `prefix`; pnpm
+/// issue 2700). Unix-gated like `bin.rs`: the `PATH` validation is
+/// platform-specific.
+#[cfg(unix)]
 #[test]
-fn prefix_global_is_not_supported_yet() {
+fn prefix_global_prints_the_global_dir_root() {
     let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init();
+    let pnpm_home = root.path().join("pnpm-home");
+    let global_bin = pnpm_home.join("bin");
+    let existing_path = std::env::var("PATH").unwrap_or_default();
+    let path = format!("{}:{existing_path}", global_bin.display());
 
-    let output = pacquet.with_args(["prefix", "-g"]).output().expect("run pacquet prefix -g");
+    let output = pacquet
+        .with_env("PNPM_HOME", &pnpm_home)
+        .with_env("HOME", root.path())
+        .with_env("XDG_CONFIG_HOME", root.path().join("xdg-config"))
+        .with_env("PNPM_CONFIG_GLOBAL_DIR", "")
+        .with_env("pnpm_config_global_dir", "")
+        .with_env("PNPM_CONFIG_GLOBAL_BIN_DIR", "")
+        .with_env("pnpm_config_global_bin_dir", "")
+        .with_env("PATH", path)
+        .with_args(["prefix", "-g"])
+        .output()
+        .expect("run pacquet prefix -g");
     dbg!(&output);
-    assert!(!output.status.success(), "pacquet prefix -g should fail until global support lands");
+    assert!(output.status.success(), "pacquet prefix -g should succeed");
 
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("not supported yet"), "stderr should explain the gap: {stderr}");
+    let expected = format!("{}\n", pnpm_home.join("global").display());
+    assert_eq!(String::from_utf8_lossy(&output.stdout), expected);
+    assert!(global_bin.is_dir(), "pacquet prefix -g should create the global bin dir");
 
     drop(root);
 }

--- a/pnpm/crates/cli/tests/suite/root.rs
+++ b/pnpm/crates/cli/tests/suite/root.rs
@@ -51,17 +51,89 @@ fn root_ignores_a_custom_modules_dir() {
     drop(root);
 }
 
-/// `--global` / `-g` is rejected until global package management is ported.
+/// `pacquet root -g` prints the global packages directory
+/// (`<pnpm-home>/global/<layout-version>`). Like pnpm's config reader it
+/// creates and validates the global bin dir first, but without the
+/// writability requirement (`globalDirShouldAllowWrite` is false for
+/// `root`; pnpm issue 2700). Unix-gated like `bin.rs`: the `PATH`
+/// validation is platform-specific.
+#[cfg(unix)]
 #[test]
-fn root_global_is_not_supported_yet() {
+fn root_global_prints_the_global_packages_dir() {
     let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init();
+    let pnpm_home = root.path().join("pnpm-home");
+    let global_bin = pnpm_home.join("bin");
+    let existing_path = std::env::var("PATH").unwrap_or_default();
+    let path = format!("{}:{existing_path}", global_bin.display());
 
-    let output = pacquet.with_args(["root", "-g"]).output().expect("run pacquet root -g");
+    let output = pacquet
+        .with_env("PNPM_HOME", &pnpm_home)
+        .with_env("HOME", root.path())
+        .with_env("XDG_CONFIG_HOME", root.path().join("xdg-config"))
+        .with_env("PNPM_CONFIG_GLOBAL_DIR", "")
+        .with_env("pnpm_config_global_dir", "")
+        .with_env("PNPM_CONFIG_GLOBAL_BIN_DIR", "")
+        .with_env("pnpm_config_global_bin_dir", "")
+        .with_env("PATH", path)
+        .with_args(["root", "-g"])
+        .output()
+        .expect("run pacquet root -g");
     dbg!(&output);
-    assert!(!output.status.success(), "pacquet root -g should fail until global support lands");
+    assert!(output.status.success(), "pacquet root -g should succeed");
 
+    let expected = format!(
+        "{}\n",
+        pnpm_home.join("global").join(pacquet_config::GLOBAL_LAYOUT_VERSION).display()
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout), expected);
+    assert!(global_bin.is_dir(), "pacquet root -g should create the global bin dir");
+
+    drop(root);
+}
+
+/// The pm-check warning (`Using --global skips the package manager check for
+/// this project`) goes to stderr so `root -g` keeps stdout a clean,
+/// machine-readable path. Ports `pnpm root -g writes warnings to stderr so
+/// stdout stays a clean path` from `pnpm11/pnpm/test/root.ts`: the impossible
+/// pin `pnpm@0.0.0` plus `COREPACK_ROOT` triggers the warning without any
+/// version resolution.
+#[cfg(unix)]
+#[test]
+fn root_global_writes_warnings_to_stderr_so_stdout_stays_a_clean_path() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("package.json"), r#"{ "packageManager": "pnpm@0.0.0" }"#)
+        .expect("write package.json");
+    let pnpm_home = root.path().join("pnpm-home");
+    let global_bin = pnpm_home.join("bin");
+    let existing_path = std::env::var("PATH").unwrap_or_default();
+    let path = format!("{}:{existing_path}", global_bin.display());
+
+    let output = pacquet
+        .with_env("PNPM_HOME", &pnpm_home)
+        .with_env("HOME", root.path())
+        .with_env("XDG_CONFIG_HOME", root.path().join("xdg-config"))
+        .with_env("PNPM_CONFIG_GLOBAL_DIR", "")
+        .with_env("pnpm_config_global_dir", "")
+        .with_env("PNPM_CONFIG_GLOBAL_BIN_DIR", "")
+        .with_env("pnpm_config_global_bin_dir", "")
+        .with_env("PATH", path)
+        .with_env("COREPACK_ROOT", "/fake/corepack")
+        .with_args(["root", "-g"])
+        .output()
+        .expect("run pacquet root -g");
+    dbg!(&output);
+    assert!(output.status.success(), "pacquet root -g should succeed");
+
+    let expected = format!(
+        "{}\n",
+        pnpm_home.join("global").join(pacquet_config::GLOBAL_LAYOUT_VERSION).display()
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout), expected);
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("not supported yet"), "stderr should explain the gap: {stderr}");
+    assert!(
+        stderr.contains("Using --global skips the package manager check for this project"),
+        "stderr should carry the pm-check warning: {stderr}",
+    );
 
     drop(root);
 }

--- a/pnpm/crates/cli/tests/suite/root.rs
+++ b/pnpm/crates/cli/tests/suite/root.rs
@@ -83,7 +83,7 @@ fn root_global_prints_the_global_packages_dir() {
 
     let expected = format!(
         "{}\n",
-        pnpm_home.join("global").join(pacquet_config::GLOBAL_LAYOUT_VERSION).display()
+        pnpm_home.join("global").join(pacquet_config::GLOBAL_LAYOUT_VERSION).display(),
     );
     assert_eq!(String::from_utf8_lossy(&output.stdout), expected);
     assert!(global_bin.is_dir(), "pacquet root -g should create the global bin dir");
@@ -126,7 +126,7 @@ fn root_global_writes_warnings_to_stderr_so_stdout_stays_a_clean_path() {
 
     let expected = format!(
         "{}\n",
-        pnpm_home.join("global").join(pacquet_config::GLOBAL_LAYOUT_VERSION).display()
+        pnpm_home.join("global").join(pacquet_config::GLOBAL_LAYOUT_VERSION).display(),
     );
     assert_eq!(String::from_utf8_lossy(&output.stdout), expected);
     let stderr = String::from_utf8_lossy(&output.stderr);

--- a/pnpm/crates/config/src/global_bin_check.rs
+++ b/pnpm/crates/config/src/global_bin_check.rs
@@ -48,7 +48,7 @@ pub enum CheckGlobalBinDirError {
 /// `path_env` is the value of `PATH` (the caller reads it so this stays
 /// testable). When `should_allow_write` is set, the directory must also
 /// exist and be writable — pnpm enforces this for every command except
-/// `root`.
+/// `root` and `prefix`, which only print a path.
 pub fn check_global_bin_dir(
     global_bin_dir: &Path,
     path_env: Option<&str>,

--- a/pnpm/crates/default-reporter/src/lib.rs
+++ b/pnpm/crates/default-reporter/src/lib.rs
@@ -33,6 +33,7 @@ use crate::{
 };
 
 static CWD: OnceLock<String> = OnceLock::new();
+static USE_STDERR: OnceLock<bool> = OnceLock::new();
 static PACKAGE_VERSION: OnceLock<String> = OnceLock::new();
 static FORCE_APPEND_ONLY: OnceLock<bool> = OnceLock::new();
 static SUMMARY_SCOPE: OnceLock<SummaryScope> = OnceLock::new();
@@ -71,6 +72,19 @@ pub fn force_append_only() {
     let _ = FORCE_APPEND_ONLY.set(true);
 }
 
+/// Route all reporter output (warnings, progress, the summary) to stderr
+/// instead of stdout — pnpm's `useStderr`, set for the commands in its
+/// `COMMANDS_WITH_STDERR_REPORTER` whose stdout is a machine-readable
+/// value. TTY detection and terminal width follow the selected stream.
+/// Call once before the first event.
+pub fn use_stderr() {
+    let _ = USE_STDERR.set(true);
+}
+
+fn is_stderr_output() -> bool {
+    USE_STDERR.get().copied().unwrap_or(false)
+}
+
 /// Configure which prefixes contribute to the packages-diff summary.
 pub fn set_summary_scope(scope: SummaryScope) {
     let _ = SUMMARY_SCOPE.set(scope);
@@ -105,7 +119,8 @@ fn cwd() -> String {
     })
 }
 
-/// `--reporter=default`: renders pnpm-style visual output to stdout.
+/// `--reporter=default`: renders pnpm-style visual output to stdout, or to
+/// stderr when [`use_stderr`] was configured.
 pub struct DefaultReporter;
 
 impl Reporter for DefaultReporter {
@@ -151,7 +166,11 @@ struct Sink {
 
 impl Sink {
     fn new() -> Self {
-        let is_tty = std::io::stdout().is_terminal();
+        let is_tty = if is_stderr_output() {
+            std::io::stderr().is_terminal()
+        } else {
+            std::io::stdout().is_terminal()
+        };
         let append_only = !is_tty || FORCE_APPEND_ONLY.get().copied().unwrap_or(false);
         let columns = if is_tty { terminal_columns().unwrap_or(80) } else { 80 };
         // pnpm's `outputMaxWidth`: `columns - 2` on a TTY, else 80.
@@ -186,8 +205,13 @@ impl Sink {
     }
 
     fn on_prompt(&mut self, action: PromptAction) {
-        let mut out = std::io::stdout().lock();
-        self.on_prompt_to(action, &mut out);
+        if is_stderr_output() {
+            let mut out = std::io::stderr().lock();
+            self.on_prompt_to(action, &mut out);
+        } else {
+            let mut out = std::io::stdout().lock();
+            self.on_prompt_to(action, &mut out);
+        }
     }
 
     fn on_prompt_to(&mut self, action: PromptAction, out: &mut impl Write) {
@@ -217,8 +241,13 @@ impl Sink {
     }
 
     fn write(&mut self, output: Output, coalesceable: bool) {
-        let mut out = std::io::stdout().lock();
-        self.write_to(output, coalesceable, &mut out);
+        if is_stderr_output() {
+            let mut out = std::io::stderr().lock();
+            self.write_to(output, coalesceable, &mut out);
+        } else {
+            let mut out = std::io::stdout().lock();
+            self.write_to(output, coalesceable, &mut out);
+        }
     }
 
     fn write_to(&mut self, output: Output, coalesceable: bool, out: &mut impl Write) {
@@ -279,11 +308,12 @@ impl Sink {
 
 #[cfg(unix)]
 fn terminal_columns() -> Option<usize> {
+    let fd = if is_stderr_output() { libc::STDERR_FILENO } else { libc::STDOUT_FILENO };
     // SAFETY: `winsize` is plain-old-data; `ioctl` only writes into it and we
     // check the return code before reading.
     unsafe {
         let mut ws: libc::winsize = std::mem::zeroed();
-        (libc::ioctl(libc::STDOUT_FILENO, libc::TIOCGWINSZ, &mut ws) == 0 && ws.ws_col > 0)
+        (libc::ioctl(fd, libc::TIOCGWINSZ, &mut ws) == 0 && ws.ws_col > 0)
             .then_some(ws.ws_col as usize)
     }
 }

--- a/pnpm11/pnpm/src/main.ts
+++ b/pnpm11/pnpm/src/main.ts
@@ -42,7 +42,7 @@ export const REPORTER_INITIALIZED = Symbol('reporterInitialized')
 // path` is meant to be captured with `STORE=$(pnpm store path)` and `pnpm config
 // list --json` to be piped into `jq`; a warning mixed into stdout would corrupt
 // both.
-const COMMANDS_WITH_STDERR_REPORTER = new Set(['dlx', 'create', 'config', 'set', 'get', 'sbom', 'with', 'store', 'prefix'])
+const COMMANDS_WITH_STDERR_REPORTER = new Set(['dlx', 'create', 'config', 'set', 'get', 'sbom', 'with', 'store', 'prefix', 'root', 'bin'])
 
 loudRejection()
 

--- a/pnpm11/pnpm/test/bin.ts
+++ b/pnpm11/pnpm/test/bin.ts
@@ -31,3 +31,20 @@ test('pnpm bin -g', async () => {
   expect(result.status).toBe(0)
   expect(result.stdout.toString().trim()).toEqual(binDir)
 })
+
+test('pnpm bin -g writes warnings to stderr so stdout stays a clean path', async () => {
+  tempDir()
+  fs.writeFileSync('package.json', JSON.stringify({ packageManager: 'pnpm@0.0.0' }), 'utf8')
+
+  const binDir = path.join(process.cwd(), 'bin')
+  const env = {
+    PNPM_HOME: process.cwd(),
+    [PATH_NAME]: binDir,
+  }
+
+  const result = execPnpmSync(['--pm-on-fail=warn', 'bin', '-g'], { env })
+
+  expect(result.status).toBe(0)
+  expect(result.stdout.toString().trim()).toEqual(binDir)
+  expect(result.stderr.toString()).toContain('Using --global skips the package manager check for this project')
+})

--- a/pnpm11/pnpm/test/root.ts
+++ b/pnpm11/pnpm/test/root.ts
@@ -33,3 +33,25 @@ test('pnpm root -g', async () => {
   expect(result.status).toBe(0)
   expect(result.stdout.toString()).toBe(path.join(global, `pnpm/global/${GLOBAL_LAYOUT_VERSION}`) + '\n')
 })
+
+test('pnpm root -g writes warnings to stderr so stdout stays a clean path', async () => {
+  tempDir()
+  fs.writeFileSync('package.json', JSON.stringify({ packageManager: 'pnpm@0.0.0' }), 'utf8')
+
+  const global = path.resolve('global')
+  const pnpmHome = path.join(global, 'pnpm')
+  fs.mkdirSync(global)
+
+  const env = {
+    [PATH_NAME]: path.join(pnpmHome, 'bin'),
+    PNPM_HOME: pnpmHome,
+    XDG_DATA_HOME: global,
+    COREPACK_ROOT: '/fake/corepack',
+  }
+
+  const result = execPnpmSync(['root', '-g'], { env })
+
+  expect(result.status).toBe(0)
+  expect(result.stdout.toString()).toBe(path.join(global, `pnpm/global/${GLOBAL_LAYOUT_VERSION}`) + '\n')
+  expect(result.stderr.toString()).toContain('Using --global skips the package manager check for this project')
+})


### PR DESCRIPTION
## Summary

`pnpm root -g` and `pnpm bin -g` print a filesystem path on stdout, and programs capture it as a machine-readable value. When run with `--global` in a project that pins a package manager, pnpm emits `[WARN] Using --global skips the package manager check for this project` through the default reporter, which writes to stdout for any command not in `COMMANDS_WITH_STDERR_REPORTER` — so the warning landed ahead of the path, breaking consumers that parse stdout as a path.

**TypeScript CLI:** both commands are now in `COMMANDS_WITH_STDERR_REPORTER` (the same mechanism that keeps `pnpm store path` and `pnpm prefix -g` stdout clean), so the warning goes to stderr and stdout stays a clean path.

**Rust CLI (pacquet):** full parity now lands in this PR too:

- The default reporter gained per-command stderr routing: it writes to stderr (TTY detection and terminal width follow the selected stream) for the same command set as the TypeScript CLI — `dlx`, `create`, `config`, `sbom`, `with`, `store`, `prefix`, `root`, `bin` (pnpm's set also lists the top-level `set`/`get` commands, which pacquet does not have). The dlx/create tests that pinned the old install-summary-on-stdout divergence now assert stderr.
- `pnpm root -g` and `pnpm prefix -g` are now supported (previously rejected with `ERR_PNPM_CLI_ROOT_GLOBAL_UNSUPPORTED` / `ERR_PNPM_CLI_PREFIX_GLOBAL_UNSUPPORTED`): `root -g` prints the global packages directory and `prefix -g` its parent, mirroring pnpm's config reader (create + validate the global bin dir, without the writability requirement — `globalDirShouldAllowWrite` is false for `root`/`prefix`, pnpm/pnpm#2700). Output verified byte-identical against the pnpm 11 bundle (stdout and stderr) for `root -g`, `prefix -g`, and `bin -g`.

Fixes pnpm/pnpm#13672.

Notes:

- The warning only fires when the pm-check switch path is bypassed: under corepack (`COREPACK_ROOT` set) or with a non-download `pm-on-fail`. The issue's literal repro steps (version-matching direct install) do not warn, because `switchCliVersion` early-returns on an exact version match. The regression tests in both stacks trigger it via `COREPACK_ROOT` (`root -g`) and `--pm-on-fail=warn` (`bin -g`), pinning the impossible version `pnpm@0.0.0`; neither trigger performs version resolution, so the tests never touch the registry.

## Squash Commit Body

```text
`pnpm root -g` and `pnpm bin -g` print a path on stdout, and programs capture it as a machine-readable value. The default reporter writes warnings to stdout for any command not in COMMANDS_WITH_STDERR_REPORTER, so "[WARN] Using --global skips the package manager check for this project" fired ahead of the path when running either command with --global in a project that pins a package manager. store/config were routed to stderr in pnpm/pnpm#12434, and prefix when it landed in pnpm/pnpm#12728; root and bin were never added.

TypeScript CLI: both commands are now in COMMANDS_WITH_STDERR_REPORTER, so the warning goes to stderr and stdout stays a clean path.

Rust CLI: the default reporter gained per-command stderr routing mirroring the same command set (dlx, create, config, sbom, with, store, prefix, root, bin), and root -g / prefix -g are now supported instead of rejected as unsupported — root -g prints the global packages directory and prefix -g its parent, mirroring pnpm's config reader (create + validate the global bin dir without the writability requirement, pnpm/pnpm#2700). Output verified byte-identical between the two stacks for root -g, prefix -g, and bin -g.

Fixes pnpm/pnpm#13672.

The warning fires only when the pm-check switch path is bypassed — under corepack (COREPACK_ROOT set) or with a non-download pm-on-fail. The regression tests in both stacks trigger it via COREPACK_ROOT and --pm-on-fail=warn respectively, pinning the impossible version pnpm@0.0.0 so the mismatch cannot rot as the CLI version bumps. Neither trigger performs version resolution, so the tests never touch the registry.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (pi, deepseek-v4-flash); Rust parity by Claude Code (claude-fable-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for `root -g` and `prefix -g`, including configured global package and binary directories.
  - Global directories are created and validated when needed.
  - Added support for pnpm 12 global `root` and `prefix` configuration.

- **Bug Fixes**
  - Reporter messages for applicable commands now go to stderr, keeping paths and command output clean on stdout.
  - Improved handling of package-manager warnings for global path commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->