### PR TITLE
perf(lockfile): rewrite exact catalog version changes without resolving

### DIFF
--- a/.changeset/exact-catalog-version-rewrite.md
+++ b/.changeset/exact-catalog-version-rewrite.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.deps-installer": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+Changing a catalog entry to a different exact version no longer re-resolves the dependency graph. The package is replaced in `pnpm-lock.yaml` directly, reusing the same check the `pnpm.overrides` fast path applies: every locked dependency of the package must still satisfy the new version's manifest. Installs fall back to a full resolution when anything other than the catalog reaches the package — an importer that depends on it directly, or another package that depends on it — since the graph would then need both versions.

--- a/pnpm/crates/package-manager/src/fast_update_catalog_versions.rs
+++ b/pnpm/crates/package-manager/src/fast_update_catalog_versions.rs
@@ -1,7 +1,7 @@
 use crate::fast_update_overrides::{
     FastOverride, RewriteContext, apply_rewrite_plan, build_replacement_plan,
 };
-use node_semver::Version;
+use node_semver::{Range, Version};
 use pacquet_catalogs_types::Catalogs;
 use pacquet_lockfile::{Lockfile, PkgName, ResolvedCatalogEntry};
 use std::collections::BTreeMap;
@@ -9,21 +9,28 @@ use std::collections::BTreeMap;
 /// Move a catalog entry to a version the lockfile does not have, without
 /// resolving the whole graph.
 ///
-/// [`crate::fast_update_catalogs`] handles the range-only case, where the
-/// recorded version still satisfies the new specifier and nothing but the
-/// specifier moves. This handles the other half: the entry now names a
-/// version the locked one cannot satisfy, so the package itself has to be
-/// replaced. That is the same rewrite an exact `pnpm.overrides` entry
-/// performs, so it reuses that machinery — including the check that every
-/// locked child still satisfies the new version's manifest.
+/// Replacing the package is the rewrite an exact `pnpm.overrides` entry
+/// performs, so this drives that machinery rather than repeating it;
+/// [`crate::fast_update_catalogs`] keeps the range-only case, where the
+/// specifier moves and the package does not.
 ///
-/// Unlike an override, a catalog entry only governs the importers that
-/// reference it. `None` when anything else reaches the package, since the
-/// graph would then have to hold both versions.
+/// An override moves a package everywhere it appears. A catalog entry
+/// governs only the importers that reference it, so anything else
+/// reaching the package would have to keep the old version while those
+/// importers move — a graph holding both, which this cannot express.
 pub(crate) async fn try_fast_update_catalog_versions(
     context: &RewriteContext<'_>,
     catalogs: &Catalogs,
 ) -> Option<Lockfile> {
+    // The same gate the range-only path opens with: an importer pointing at
+    // a catalog entry with nothing recorded for it needs the resolver, and
+    // this path would otherwise never look at that entry.
+    // The same gate the range-only path opens with: an importer pointing at
+    // a catalog entry with nothing recorded for it needs the resolver, and
+    // this path would otherwise never look at that entry.
+    if !crate::fast_update_catalogs::catalog_references_have_snapshots(context.lockfile, catalogs) {
+        return None;
+    }
     let recorded = context.lockfile.catalogs.as_ref()?;
     let mut entries = Vec::new();
     let mut updated_catalogs = BTreeMap::new();
@@ -36,12 +43,19 @@ pub(crate) async fn try_fast_update_catalog_versions(
                 updated_entries.insert(alias.clone(), entry.clone());
                 continue;
             }
-            // A specifier the locked version still satisfies belongs to
-            // the range-only path, which rewrites nothing.
-            let wanted = Version::parse(specifier).ok()?;
-            if wanted == locked {
-                return None;
+            // A specifier the locked version still satisfies moves nothing
+            // but the specifier, exactly as the range-only path would.
+            if Range::parse(specifier).is_ok_and(|range| locked.satisfies(&range)) {
+                updated_entries.insert(
+                    alias.clone(),
+                    ResolvedCatalogEntry {
+                        specifier: specifier.clone(),
+                        version: entry.version.clone(),
+                    },
+                );
+                continue;
             }
+            let wanted = Version::parse(specifier).ok()?;
             let name = PkgName::parse(alias).ok()?;
             if !catalog_entry_is_sole_reference(context.lockfile, catalog_name, &name) {
                 return None;
@@ -70,13 +84,7 @@ pub(crate) async fn try_fast_update_catalog_versions(
 }
 
 /// Whether the catalog entry is the only thing in the lockfile that
-/// reaches `name`: every importer that depends on it does so through this
-/// catalog, and no package depends on it at all.
-///
-/// An override moves a package everywhere it appears. A catalog entry
-/// cannot, so anything else pointing at the package would have to keep the
-/// old version while the catalog's importers move to the new one, leaving
-/// the graph holding both.
+/// reaches `name`.
 fn catalog_entry_is_sole_reference(
     lockfile: &Lockfile,
     catalog_name: &str,

--- a/pnpm/crates/package-manager/src/fast_update_catalog_versions.rs
+++ b/pnpm/crates/package-manager/src/fast_update_catalog_versions.rs
@@ -1,0 +1,114 @@
+use crate::fast_update_overrides::{
+    FastOverride, RewriteContext, apply_rewrite_plan, build_replacement_plan,
+};
+use node_semver::Version;
+use pacquet_catalogs_types::Catalogs;
+use pacquet_lockfile::{Lockfile, PkgName, ResolvedCatalogEntry};
+use std::collections::BTreeMap;
+
+/// Move a catalog entry to a version the lockfile does not have, without
+/// resolving the whole graph.
+///
+/// [`crate::fast_update_catalogs`] handles the range-only case, where the
+/// recorded version still satisfies the new specifier and nothing but the
+/// specifier moves. This handles the other half: the entry now names a
+/// version the locked one cannot satisfy, so the package itself has to be
+/// replaced. That is the same rewrite an exact `pnpm.overrides` entry
+/// performs, so it reuses that machinery — including the check that every
+/// locked child still satisfies the new version's manifest.
+///
+/// Unlike an override, a catalog entry only governs the importers that
+/// reference it. `None` when anything else reaches the package, since the
+/// graph would then have to hold both versions.
+pub(crate) async fn try_fast_update_catalog_versions(
+    context: &RewriteContext<'_>,
+    catalogs: &Catalogs,
+) -> Option<Lockfile> {
+    let recorded = context.lockfile.catalogs.as_ref()?;
+    let mut entries = Vec::new();
+    let mut updated_catalogs = BTreeMap::new();
+    for (catalog_name, recorded_entries) in recorded {
+        let mut updated_entries = BTreeMap::new();
+        for (alias, entry) in recorded_entries {
+            let specifier = catalogs.get(catalog_name)?.get(alias)?;
+            let locked = Version::parse(&entry.version).ok()?;
+            if specifier == &entry.specifier {
+                updated_entries.insert(alias.clone(), entry.clone());
+                continue;
+            }
+            // A specifier the locked version still satisfies belongs to
+            // the range-only path, which rewrites nothing.
+            let wanted = Version::parse(specifier).ok()?;
+            if wanted == locked {
+                return None;
+            }
+            let name = PkgName::parse(alias).ok()?;
+            if !catalog_entry_is_sole_reference(context.lockfile, catalog_name, &name) {
+                return None;
+            }
+            entries.push(FastOverride {
+                name,
+                new_version: Some(wanted.clone()),
+                old_version: Some(locked),
+                parent: None,
+            });
+            updated_entries.insert(
+                alias.clone(),
+                ResolvedCatalogEntry { specifier: specifier.clone(), version: wanted.to_string() },
+            );
+        }
+        updated_catalogs.insert(catalog_name.clone(), updated_entries);
+    }
+    if entries.is_empty() {
+        return None;
+    }
+
+    let plan = build_replacement_plan(context.lockfile, entries)?;
+    let mut updated = apply_rewrite_plan(context, &plan).await?;
+    updated.catalogs = Some(updated_catalogs);
+    Some(updated)
+}
+
+/// Whether the catalog entry is the only thing in the lockfile that
+/// reaches `name`: every importer that depends on it does so through this
+/// catalog, and no package depends on it at all.
+///
+/// An override moves a package everywhere it appears. A catalog entry
+/// cannot, so anything else pointing at the package would have to keep the
+/// old version while the catalog's importers move to the new one, leaving
+/// the graph holding both.
+fn catalog_entry_is_sole_reference(
+    lockfile: &Lockfile,
+    catalog_name: &str,
+    name: &PkgName,
+) -> bool {
+    let protocol = if catalog_name == "default" {
+        "catalog:".to_string()
+    } else {
+        format!("catalog:{catalog_name}")
+    };
+    let importers_agree = lockfile.importers.values().all(|importer| {
+        [
+            importer.dependencies.as_ref(),
+            importer.dev_dependencies.as_ref(),
+            importer.optional_dependencies.as_ref(),
+        ]
+        .into_iter()
+        .flatten()
+        .all(|dependencies| {
+            dependencies.get(name).is_none_or(|dependency| dependency.specifier == protocol)
+        })
+    });
+    let no_package_depends_on_it = lockfile.snapshots.as_ref().is_none_or(|snapshots| {
+        snapshots.values().all(|snapshot| {
+            [snapshot.dependencies.as_ref(), snapshot.optional_dependencies.as_ref()]
+                .into_iter()
+                .flatten()
+                .all(|dependencies| !dependencies.contains_key(name))
+        })
+    });
+    importers_agree && no_package_depends_on_it
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/package-manager/src/fast_update_catalog_versions/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_catalog_versions/tests.rs
@@ -188,6 +188,75 @@ async fn falls_back_when_a_package_depends_on_the_catalog_package() {
 }
 
 #[tokio::test]
+async fn falls_back_when_a_catalog_reference_has_no_recorded_entry() {
+    let mut subject = lockfile();
+    subject.importers.insert(
+        "pkg-a".to_string(),
+        serde_json::from_value(json!({
+            "specifiers": { "other": "catalog:" },
+            "dependencies": { "other": { "specifier": "catalog:", "version": "1.0.0" } }
+        }))
+        .expect("importer"),
+    );
+
+    assert!(
+        try_update(&subject, &catalogs("2.0.0"), manifest_requiring_child("^1.0.0"))
+            .await
+            .is_none(),
+        "that importer's catalog entry was never recorded, so the graph is incomplete",
+    );
+}
+
+#[tokio::test]
+async fn falls_back_when_two_catalogs_move_the_same_alias() {
+    let mut subject = lockfile();
+    subject.catalogs.as_mut().expect("catalogs").insert(
+        "other".to_string(),
+        serde_json::from_value(json!({
+            "target": { "specifier": "1.0.0", "version": "1.0.0" }
+        }))
+        .expect("catalog"),
+    );
+    let catalogs = Catalogs::from([
+        ("default".to_string(), BTreeMap::from([("target".to_string(), "2.0.0".to_string())])),
+        ("other".to_string(), BTreeMap::from([("target".to_string(), "3.0.0".to_string())])),
+    ]);
+
+    assert!(
+        try_update(&subject, &catalogs, manifest_requiring_child("^1.0.0")).await.is_none(),
+        "no single catalog is the sole reference once both name it",
+    );
+}
+
+#[tokio::test]
+async fn absorbs_a_range_only_entry_alongside_an_exact_move() {
+    let mut subject = lockfile();
+    subject.catalogs.as_mut().expect("catalogs").get_mut("default").expect("default").insert(
+        "child".to_string(),
+        serde_json::from_value(json!({ "specifier": "1.1.0", "version": "1.1.0" }))
+            .expect("catalog entry"),
+    );
+    let catalogs = Catalogs::from([(
+        "default".to_string(),
+        BTreeMap::from([
+            ("target".to_string(), "2.0.0".to_string()),
+            ("child".to_string(), "^1.1.0".to_string()),
+        ]),
+    )]);
+
+    let updated = try_update(&subject, &catalogs, manifest_requiring_child("^1.0.0"))
+        .await
+        .expect("the range-only entry rides along with the exact move");
+
+    let recorded = &updated.catalogs.as_ref().expect("catalogs")["default"];
+    assert_eq!(
+        (recorded["child"].specifier.as_str(), recorded["child"].version.as_str()),
+        ("^1.1.0", "1.1.0"),
+    );
+    assert_eq!(recorded["target"].version.as_str(), "2.0.0");
+}
+
+#[tokio::test]
 async fn declines_a_range_the_locked_version_still_satisfies() {
     assert!(
         try_update(&lockfile(), &catalogs("^1.0.0"), manifest_requiring_child("^1.0.0"))

--- a/pnpm/crates/package-manager/src/fast_update_catalog_versions/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_catalog_versions/tests.rs
@@ -1,0 +1,198 @@
+use super::try_fast_update_catalog_versions;
+use pacquet_catalogs_types::Catalogs;
+use pacquet_lockfile::{Lockfile, LockfileResolution, TarballResolution};
+use pacquet_resolving_resolver_base::{
+    LatestInfo, LatestQuery, PkgResolutionId, ResolveFuture, ResolveLatestFuture, ResolveOptions,
+    ResolveResult, Resolver, WantedDependency,
+};
+use serde_json::{Value, json};
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::Arc,
+};
+
+struct StubResolver {
+    manifest: Value,
+}
+
+impl Resolver for StubResolver {
+    fn resolve<'a>(
+        &'a self,
+        wanted_dependency: &'a WantedDependency,
+        _opts: &'a ResolveOptions,
+    ) -> ResolveFuture<'a> {
+        let name = wanted_dependency.alias.clone().expect("alias");
+        let version = wanted_dependency.bare_specifier.clone().expect("version");
+        let manifest = Arc::new(self.manifest.clone());
+        Box::pin(async move {
+            Ok(Some(ResolveResult {
+                id: PkgResolutionId::from(format!("{name}@{version}")),
+                name_ver: Some(format!("{name}@{version}").parse().expect("name and version")),
+                latest: Some(version),
+                published_at: None,
+                manifest: Some(manifest),
+                resolution: LockfileResolution::Tarball(TarballResolution {
+                    tarball: "https://registry.npmjs.org/target/-/target-2.0.0.tgz".to_string(),
+                    integrity: Some("sha512-dGFyZ2V0LTI=".parse().expect("integrity")),
+                    git_hosted: None,
+                    path: None,
+                }),
+                resolved_via: "npm-registry".to_string(),
+                normalized_bare_specifier: None,
+                alias: Some(name),
+                policy_violation: None,
+            }))
+        })
+    }
+
+    fn resolve_latest<'a>(
+        &'a self,
+        _query: &'a LatestQuery,
+        _opts: &'a ResolveOptions,
+    ) -> ResolveLatestFuture<'a> {
+        Box::pin(async { Ok(Some(LatestInfo { latest_manifest: None })) })
+    }
+}
+
+/// `target` is a direct dependency of the importer, reached only through
+/// the default catalog.
+fn lockfile() -> Lockfile {
+    serde_json::from_value(json!({
+        "lockfileVersion": "9.0",
+        "catalogs": {
+            "default": {
+                "target": { "specifier": "1.0.0", "version": "1.0.0" }
+            }
+        },
+        "importers": {
+            ".": {
+                "dependencies": {
+                    "target": { "specifier": "catalog:", "version": "1.0.0" }
+                }
+            }
+        },
+        "packages": {
+            "target@1.0.0": { "resolution": { "integrity": "sha512-target-1" } },
+            "child@1.1.0": { "resolution": { "integrity": "sha512-child" } }
+        },
+        "snapshots": {
+            "target@1.0.0": { "dependencies": { "child": "1.1.0" } },
+            "child@1.1.0": {}
+        }
+    }))
+    .expect("lockfile")
+}
+
+fn catalogs(specifier: &str) -> Catalogs {
+    Catalogs::from([(
+        "default".to_string(),
+        BTreeMap::from([("target".to_string(), specifier.to_string())]),
+    )])
+}
+
+fn manifest_requiring_child(range: &str) -> Value {
+    json!({ "name": "target", "version": "2.0.0", "dependencies": { "child": range } })
+}
+
+async fn try_update(lockfile: &Lockfile, catalogs: &Catalogs, manifest: Value) -> Option<Lockfile> {
+    let resolve_options = ResolveOptions::default();
+    let registries =
+        HashMap::from([("default".to_string(), "https://registry.npmjs.org/".to_string())]);
+    let resolver = StubResolver { manifest };
+    try_fast_update_catalog_versions(
+        &crate::fast_update_overrides::RewriteContext {
+            lockfile,
+            resolver: &resolver,
+            resolve_options: &resolve_options,
+            manifest_hook: None,
+            registries: &registries,
+            lockfile_include_tarball_url: false,
+        },
+        catalogs,
+    )
+    .await
+}
+
+fn snapshot_keys(lockfile: &Lockfile) -> Vec<String> {
+    let mut keys: Vec<_> =
+        lockfile.snapshots.as_ref().expect("snapshots").keys().map(ToString::to_string).collect();
+    keys.sort();
+    keys
+}
+
+#[tokio::test]
+async fn replaces_the_catalog_version_when_the_locked_child_still_fits() {
+    let updated = try_update(&lockfile(), &catalogs("2.0.0"), manifest_requiring_child("^1.0.0"))
+        .await
+        .expect("the locked child satisfies the new manifest");
+
+    assert_eq!(
+        snapshot_keys(&updated),
+        vec!["child@1.1.0".to_string(), "target@2.0.0".to_string()],
+    );
+    let entry = &updated.catalogs.as_ref().expect("catalogs")["default"]["target"];
+    assert_eq!((entry.specifier.as_str(), entry.version.as_str()), ("2.0.0", "2.0.0"));
+    assert_eq!(
+        updated.importers["."].dependencies.as_ref().expect("dependencies")
+            [&"target".parse().expect("alias")]
+            .version
+            .to_string(),
+        "2.0.0",
+        "the importer follows the catalog to the new version",
+    );
+}
+
+#[tokio::test]
+async fn falls_back_when_the_locked_child_does_not_satisfy_the_new_version() {
+    assert!(
+        try_update(&lockfile(), &catalogs("2.0.0"), manifest_requiring_child("^2.0.0"))
+            .await
+            .is_none(),
+        "resolving the new child is the resolver's job",
+    );
+}
+
+#[tokio::test]
+async fn falls_back_when_an_importer_depends_on_the_package_directly() {
+    let mut lockfile = lockfile();
+    lockfile.importers.insert(
+        "pkg-a".to_string(),
+        serde_json::from_value(json!({
+            "dependencies": { "target": { "specifier": "1.0.0", "version": "1.0.0" } }
+        }))
+        .expect("importer"),
+    );
+
+    assert!(
+        try_update(&lockfile, &catalogs("2.0.0"), manifest_requiring_child("^1.0.0"))
+            .await
+            .is_none(),
+        "that importer pinned the old version, so the graph would need both",
+    );
+}
+
+#[tokio::test]
+async fn falls_back_when_a_package_depends_on_the_catalog_package() {
+    let mut lockfile = lockfile();
+    lockfile.snapshots.as_mut().expect("snapshots").insert(
+        "parent@1.0.0".parse().expect("snapshot key"),
+        serde_json::from_value(json!({ "dependencies": { "target": "1.0.0" } })).expect("snapshot"),
+    );
+
+    assert!(
+        try_update(&lockfile, &catalogs("2.0.0"), manifest_requiring_child("^1.0.0"))
+            .await
+            .is_none(),
+        "the transitive dependent keeps the old version, so both would be needed",
+    );
+}
+
+#[tokio::test]
+async fn declines_a_range_the_locked_version_still_satisfies() {
+    assert!(
+        try_update(&lockfile(), &catalogs("^1.0.0"), manifest_requiring_child("^1.0.0"))
+            .await
+            .is_none(),
+        "that change rewrites nothing and belongs to the range-only path",
+    );
+}

--- a/pnpm/crates/package-manager/src/fast_update_catalogs.rs
+++ b/pnpm/crates/package-manager/src/fast_update_catalogs.rs
@@ -75,7 +75,7 @@ pub(crate) fn try_fast_update_catalogs(
     FastCatalogUpdate::Updated(Box::new(candidate))
 }
 
-fn catalog_references_have_snapshots(lockfile: &Lockfile, catalogs: &Catalogs) -> bool {
+pub(crate) fn catalog_references_have_snapshots(lockfile: &Lockfile, catalogs: &Catalogs) -> bool {
     lockfile.importers.values().all(|importer| {
         [
             importer.dependencies.as_ref(),

--- a/pnpm/crates/package-manager/src/fast_update_overrides.rs
+++ b/pnpm/crates/package-manager/src/fast_update_overrides.rs
@@ -148,9 +148,6 @@ fn build_rewrite_plan(
             return None;
         }
         let name = PkgName::parse(&parsed.target_pkg.name).ok()?;
-        if overrides.iter().any(|entry: &FastOverride| entry.name == name) {
-            return None;
-        }
         let new_version =
             if removes_dependency { None } else { Some(Version::parse(new_value).ok()?) };
         overrides.push(FastOverride {
@@ -180,6 +177,18 @@ pub(crate) fn build_replacement_plan(
     lockfile: &Lockfile,
     overrides: Vec<FastOverride>,
 ) -> Option<RewritePlan> {
+    // Two entries naming one package would each claim its key, and only
+    // one of them could win.
+    // Two entries naming one package would each claim its key, and only one
+    // of them could win. Both callers reject that earlier for their own
+    // reasons; this keeps the plan itself from expressing it.
+    if overrides
+        .iter()
+        .enumerate()
+        .any(|(index, entry)| overrides[..index].iter().any(|other| other.name == entry.name))
+    {
+        return None;
+    }
     let peer_names = get_peer_names(lockfile);
     if overrides
         .iter()

--- a/pnpm/crates/package-manager/src/fast_update_overrides.rs
+++ b/pnpm/crates/package-manager/src/fast_update_overrides.rs
@@ -61,7 +61,7 @@ pub(crate) async fn try_fast_update_overrides(opts: FastOverrideOptions<'_>) -> 
 
 /// Move every package named by `plan` to its new version, rebuilding the
 /// affected `packages:` and `snapshots:` entries from the new version's
-/// manifest and repointing everything that referenced the old key.
+/// manifest and redirecting everything that referenced the old key.
 ///
 /// `None` whenever the move cannot be proven safe from the lockfile plus
 /// the resolved manifests — a locked child that the new version's

--- a/pnpm/crates/package-manager/src/fast_update_overrides.rs
+++ b/pnpm/crates/package-manager/src/fast_update_overrides.rs
@@ -15,17 +15,17 @@ use std::{
     sync::Arc,
 };
 
-struct FastOverride {
-    name: PkgName,
-    new_version: Option<Version>,
-    old_version: Option<Version>,
-    parent: Option<PackageSelector>,
+pub(crate) struct FastOverride {
+    pub name: PkgName,
+    pub new_version: Option<Version>,
+    pub old_version: Option<Version>,
+    pub parent: Option<PackageSelector>,
 }
 
-struct RewritePlan {
-    overrides: Vec<FastOverride>,
-    peer_names: HashSet<PkgName>,
-    replacements: HashMap<PackageKey, PackageKey>,
+pub(crate) struct RewritePlan {
+    pub overrides: Vec<FastOverride>,
+    pub peer_names: HashSet<PkgName>,
+    pub replacements: HashMap<PackageKey, PackageKey>,
 }
 
 struct ResolvedOverride {
@@ -34,9 +34,16 @@ struct ResolvedOverride {
 }
 
 pub(crate) struct FastOverrideOptions<'a> {
-    pub lockfile: &'a Lockfile,
+    pub context: RewriteContext<'a>,
     pub parsed_overrides: &'a [VersionOverride],
     pub resolved_overrides: &'a IndexMap<String, String>,
+}
+
+/// What a rewrite needs regardless of which setting drove it: the
+/// lockfile being rewritten, and the resolver that fetches the manifest
+/// of every version the rewrite introduces.
+pub(crate) struct RewriteContext<'a> {
+    pub lockfile: &'a Lockfile,
     pub resolver: &'a dyn Resolver,
     pub resolve_options: &'a ResolveOptions,
     pub manifest_hook: Option<&'a ManifestHook>,
@@ -45,7 +52,26 @@ pub(crate) struct FastOverrideOptions<'a> {
 }
 
 pub(crate) async fn try_fast_update_overrides(opts: FastOverrideOptions<'_>) -> Option<Lockfile> {
-    let plan = build_rewrite_plan(opts.lockfile, opts.parsed_overrides, opts.resolved_overrides)?;
+    let plan =
+        build_rewrite_plan(opts.context.lockfile, opts.parsed_overrides, opts.resolved_overrides)?;
+    let mut updated = apply_rewrite_plan(&opts.context, &plan).await?;
+    updated.overrides = Some(opts.resolved_overrides.clone());
+    Some(updated)
+}
+
+/// Move every package named by `plan` to its new version, rebuilding the
+/// affected `packages:` and `snapshots:` entries from the new version's
+/// manifest and repointing everything that referenced the old key.
+///
+/// `None` whenever the move cannot be proven safe from the lockfile plus
+/// the resolved manifests — a locked child that the new version's
+/// manifest no longer admits, a registry result that does not match what
+/// was asked for, or an entry the rewrite would have to overwrite with
+/// something different.
+pub(crate) async fn apply_rewrite_plan(
+    context: &RewriteContext<'_>,
+    plan: &RewritePlan,
+) -> Option<Lockfile> {
     let resolutions = join_all(
         plan.overrides
             .iter()
@@ -56,16 +82,16 @@ pub(crate) async fn try_fast_update_overrides(opts: FastOverrideOptions<'_>) -> 
                         .iter()
                         .any(|(old, new)| old != new && old.name == override_entry.name)
             })
-            .map(|override_entry| resolve_override(&opts, override_entry)),
+            .map(|override_entry| resolve_override(context, override_entry)),
     )
     .await;
     let resolved: HashMap<_, _> =
         resolutions.into_iter().collect::<Option<Vec<_>>>()?.into_iter().collect();
-    rewrite_lockfile(&opts, &plan, &resolved)
+    rewrite_lockfile(context, plan, &resolved)
 }
 
 async fn resolve_override(
-    opts: &FastOverrideOptions<'_>,
+    context: &RewriteContext<'_>,
     override_entry: &FastOverride,
 ) -> Option<(PkgName, ResolvedOverride)> {
     let name = override_entry.name.to_string();
@@ -75,9 +101,9 @@ async fn resolve_override(
         bare_specifier: Some(version.clone()),
         ..WantedDependency::default()
     };
-    let result = opts.resolver.resolve(&wanted, opts.resolve_options).await.ok()??;
+    let result = context.resolver.resolve(&wanted, context.resolve_options).await.ok()??;
     let manifest = result.manifest.as_ref().map(Arc::clone)?;
-    let manifest = match opts.manifest_hook {
+    let manifest = match context.manifest_hook {
         Some(hook) => hook(manifest),
         None => manifest,
     };
@@ -142,6 +168,18 @@ fn build_rewrite_plan(
         return None;
     }
 
+    build_replacement_plan(lockfile, overrides)
+}
+
+/// Work out which locked packages each entry of `overrides` moves, and
+/// refuse the ones a rewrite cannot express: a package carrying a peer
+/// suffix or a registry qualifier, one that is patched, optional, or has
+/// its own peer dependencies, and any key that something outside
+/// `overrides` also reaches.
+pub(crate) fn build_replacement_plan(
+    lockfile: &Lockfile,
+    overrides: Vec<FastOverride>,
+) -> Option<RewritePlan> {
     let peer_names = get_peer_names(lockfile);
     if overrides
         .iter()
@@ -291,19 +329,19 @@ fn is_safe_registry_result(
 }
 
 fn rewrite_lockfile(
-    opts: &FastOverrideOptions<'_>,
+    context: &RewriteContext<'_>,
     plan: &RewritePlan,
     resolved: &HashMap<PkgName, ResolvedOverride>,
 ) -> Option<Lockfile> {
-    let mut updated = opts.lockfile.clone();
+    let mut updated = context.lockfile.clone();
     for importer in updated.importers.values_mut() {
         rewrite_importer_dependencies(&mut importer.dependencies, plan);
         rewrite_importer_dependencies(&mut importer.dev_dependencies, plan);
         rewrite_importer_dependencies(&mut importer.optional_dependencies, plan);
     }
-    let original_snapshots = opts.lockfile.snapshots.as_ref()?;
+    let original_snapshots = context.lockfile.snapshots.as_ref()?;
     let mut snapshots = original_snapshots.clone();
-    let mut packages = opts.lockfile.packages.clone()?;
+    let mut packages = context.lockfile.packages.clone()?;
     for (key, snapshot) in &mut snapshots {
         rewrite_snapshot_dependencies(&mut snapshot.dependencies, plan, Some(key));
         rewrite_snapshot_dependencies(&mut snapshot.optional_dependencies, plan, Some(key));
@@ -318,7 +356,7 @@ fn rewrite_lockfile(
             effective_dependencies(&replacement.manifest)?,
             old_snapshot.dependencies.as_ref(),
             original_snapshots,
-            opts.lockfile.packages.as_ref()?,
+            context.lockfile.packages.as_ref()?,
             plan,
             new_key,
         )?;
@@ -326,7 +364,7 @@ fn rewrite_lockfile(
             manifest_dependency_map(&replacement.manifest, "optionalDependencies")?,
             old_snapshot.optional_dependencies.as_ref(),
             original_snapshots,
-            opts.lockfile.packages.as_ref()?,
+            context.lockfile.packages.as_ref()?,
             plan,
             new_key,
         )?;
@@ -344,8 +382,8 @@ fn rewrite_lockfile(
             replacement.resolution.to_lockfile_form(
                 &old_key.name.to_string(),
                 &new_key.suffix.version().to_string(),
-                &pick_registry_for_package(opts.registries, &old_key.name.to_string(), None),
-                opts.lockfile_include_tarball_url,
+                &pick_registry_for_package(context.registries, &old_key.name.to_string(), None),
+                context.lockfile_include_tarball_url,
             ),
         );
         if let Some(existing) = packages.get(&metadata_key)
@@ -357,7 +395,6 @@ fn rewrite_lockfile(
     }
     updated.snapshots = Some(snapshots);
     updated.packages = Some(packages);
-    updated.overrides = Some(opts.resolved_overrides.clone());
     crate::fast_update_lockfile::prune_unreachable_packages(&mut updated);
     Some(updated)
 }

--- a/pnpm/crates/package-manager/src/fast_update_overrides/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_overrides/tests.rs
@@ -130,14 +130,16 @@ async fn try_update(
     let registries =
         HashMap::from([("default".to_string(), "https://registry.npmjs.org/".to_string())]);
     try_fast_update_overrides(FastOverrideOptions {
-        lockfile,
+        context: super::RewriteContext {
+            lockfile,
+            resolver,
+            resolve_options: &resolve_options,
+            manifest_hook: None,
+            registries: &registries,
+            lockfile_include_tarball_url: false,
+        },
         parsed_overrides,
         resolved_overrides,
-        resolver,
-        resolve_options: &resolve_options,
-        manifest_hook: None,
-        registries: &registries,
-        lockfile_include_tarball_url: false,
     })
     .await
 }

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolve.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolve.rs
@@ -224,8 +224,9 @@ pub(super) struct ReuseSeedInputs<'a> {
 /// back to withholding.
 pub(super) async fn lockfile_reuse_seed(inputs: ReuseSeedInputs<'_>) -> Option<Arc<Lockfile>> {
     use crate::{
+        fast_update_catalog_versions::try_fast_update_catalog_versions,
         fast_update_catalogs::{FastCatalogUpdate, try_fast_update_catalogs},
-        fast_update_overrides::{FastOverrideOptions, try_fast_update_overrides},
+        fast_update_overrides::{FastOverrideOptions, RewriteContext, try_fast_update_overrides},
     };
 
     let ReuseSeedInputs {
@@ -267,6 +268,7 @@ pub(super) async fn lockfile_reuse_seed(inputs: ReuseSeedInputs<'_>) -> Option<A
         super::overrides_match(lockfile.overrides.as_ref(), resolved_overrides)
     });
 
+    let rewrite_manifest_hook = super::compose_manifest_hooks(manifest_hook, overrides_hook);
     if let (Some(lockfile), Some(parsed), Some(resolved)) =
         (reusable_settings_lockfile, parsed_overrides, resolved_overrides)
         && catalogs_match
@@ -274,14 +276,16 @@ pub(super) async fn lockfile_reuse_seed(inputs: ReuseSeedInputs<'_>) -> Option<A
         && !override_settings_match
         && fast_override_eligible
         && let Some(seed) = try_fast_update_overrides(FastOverrideOptions {
-            lockfile,
+            context: RewriteContext {
+                lockfile,
+                resolver: npm_resolver,
+                resolve_options,
+                manifest_hook: rewrite_manifest_hook.as_ref(),
+                registries,
+                lockfile_include_tarball_url: config.lockfile_include_tarball_url,
+            },
             parsed_overrides: parsed,
             resolved_overrides: resolved,
-            resolver: npm_resolver,
-            resolve_options,
-            manifest_hook: super::compose_manifest_hooks(manifest_hook, overrides_hook).as_ref(),
-            registries,
-            lockfile_include_tarball_url: config.lockfile_include_tarball_url,
         })
         .await
     {
@@ -291,6 +295,29 @@ pub(super) async fn lockfile_reuse_seed(inputs: ReuseSeedInputs<'_>) -> Option<A
     // `override_settings_match` is computed with `is_some_and`, so it
     // already implies `reusable_settings_lockfile` is `Some`.
     if override_settings_match && let Some(seed) = fast_catalog_seed {
+        return Some(Arc::new(seed));
+    }
+
+    // A catalog entry that now names a version the locked one cannot
+    // satisfy left `catalogs_match` false with no seed above. Replacing the
+    // package is the same rewrite an exact override performs.
+    if let Some(lockfile) = reusable_settings_lockfile
+        && override_settings_match
+        && !overrides_use_catalogs
+        && fast_override_eligible
+        && let Some(seed) = try_fast_update_catalog_versions(
+            &RewriteContext {
+                lockfile,
+                resolver: npm_resolver,
+                resolve_options,
+                manifest_hook: rewrite_manifest_hook.as_ref(),
+                registries,
+                lockfile_include_tarball_url: config.lockfile_include_tarball_url,
+            },
+            catalogs,
+        )
+        .await
+    {
         return Some(Arc::new(seed));
     }
 

--- a/pnpm/crates/package-manager/src/lib.rs
+++ b/pnpm/crates/package-manager/src/lib.rs
@@ -6,6 +6,7 @@ mod catalog_mode;
 mod check_custom_resolver_force_resolve;
 mod compat_package_extensions;
 mod dependencies_graph_to_lockfile;
+mod fast_update_catalog_versions;
 mod fast_update_catalogs;
 mod fast_update_ignored_optional_dependencies;
 mod fast_update_importers;

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -768,15 +768,15 @@ export async function mutateModules (
               })
             }
             if (changedSetting === 'catalogs') {
-              if (tryFastUpdateCatalogs(candidate, {
+              // The range-only rewrite keeps the entries it cannot handle, so a
+              // mixed update still leaves an exact move for the rewrite below.
+              const rewroteRanges = tryFastUpdateCatalogs(candidate, {
                 catalogs: opts.catalogs,
                 overrides: opts.overrides,
-              })) return true
-              // The range-only rewrite declined, so the entry names a version
-              // the locked one cannot satisfy and the package itself moves.
-              if (overridesUseCatalogs) return false
+              })
+              if (overridesUseCatalogs) return rewroteRanges
               const catalogPolicy = getPublishedByPolicy(opts)
-              return tryFastUpdateCatalogVersions(candidate, {
+              return await tryFastUpdateCatalogVersions(candidate, {
                 catalogs: opts.catalogs,
                 lockfileDir: opts.lockfileDir,
                 lockfileIncludeTarballUrl: opts.lockfileIncludeTarballUrl,
@@ -791,7 +791,7 @@ export async function mutateModules (
                   : undefined,
                 trustPolicyIgnoreAfter: opts.trustPolicyIgnoreAfter,
                 isLockfileUpToDate,
-              })
+              }) || rewroteRanges
             }
             if (changedSetting === 'ignoredOptionalDependencies') {
               return tryFastUpdateIgnoredOptionalDependencies(candidate, opts.ignoredOptionalDependencies)

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -776,7 +776,7 @@ export async function mutateModules (
               })
               if (overridesUseCatalogs) return rewroteRanges
               const catalogPolicy = getPublishedByPolicy(opts)
-              return await tryFastUpdateCatalogVersions(candidate, {
+              const rewrite = await tryFastUpdateCatalogVersions(candidate, {
                 catalogs: opts.catalogs,
                 lockfileDir: opts.lockfileDir,
                 lockfileIncludeTarballUrl: opts.lockfileIncludeTarballUrl,
@@ -791,7 +791,12 @@ export async function mutateModules (
                   : undefined,
                 trustPolicyIgnoreAfter: opts.trustPolicyIgnoreAfter,
                 isLockfileUpToDate,
-              }) || rewroteRanges
+              })
+              // Only the "nothing moved" outcome may fall back on the
+              // range-only result. A move this cannot express has to reach the
+              // resolver, even though the range-only rewrite succeeded.
+              if (rewrite === 'applied') return true
+              return rewrite === 'nothing-to-move' && rewroteRanges
             }
             if (changedSetting === 'ignoredOptionalDependencies') {
               return tryFastUpdateIgnoredOptionalDependencies(candidate, opts.ignoredOptionalDependencies)

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -110,6 +110,7 @@ import {
 import { linkPackages } from './link.js'
 import { reportPeerDependencyIssues } from './reportPeerDependencyIssues.js'
 import { tryFastUpdateCatalogs } from './tryFastUpdateCatalogs.js'
+import { tryFastUpdateCatalogVersions } from './tryFastUpdateCatalogVersions.js'
 import { tryFastUpdateIgnoredOptionalDependencies } from './tryFastUpdateIgnoredOptionalDependencies.js'
 import { hasChangedProjectSpecifiers, tryFastUpdateImporters } from './tryFastUpdateImporters.js'
 import { tryFastUpdateLockfile } from './tryFastUpdateLockfile.js'
@@ -767,9 +768,29 @@ export async function mutateModules (
               })
             }
             if (changedSetting === 'catalogs') {
-              return tryFastUpdateCatalogs(candidate, {
+              if (tryFastUpdateCatalogs(candidate, {
                 catalogs: opts.catalogs,
                 overrides: opts.overrides,
+              })) return true
+              // The range-only rewrite declined, so the entry names a version
+              // the locked one cannot satisfy and the package itself moves.
+              if (overridesUseCatalogs) return false
+              const catalogPolicy = getPublishedByPolicy(opts)
+              return tryFastUpdateCatalogVersions(candidate, {
+                catalogs: opts.catalogs,
+                lockfileDir: opts.lockfileDir,
+                lockfileIncludeTarballUrl: opts.lockfileIncludeTarballUrl,
+                readPackageHook: opts.readPackageHook,
+                registries: ctx.registries,
+                requestPackage: opts.storeController.requestPackage,
+                publishedBy: catalogPolicy.publishedBy,
+                publishedByExclude: catalogPolicy.publishedByExclude,
+                trustPolicy: opts.trustPolicy,
+                trustPolicyExclude: opts.trustPolicyExclude
+                  ? createPackageVersionPolicyOrThrow(opts.trustPolicyExclude, 'trustPolicyExclude')
+                  : undefined,
+                trustPolicyIgnoreAfter: opts.trustPolicyIgnoreAfter,
+                isLockfileUpToDate,
               })
             }
             if (changedSetting === 'ignoredOptionalDependencies') {

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateCatalogVersions.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateCatalogVersions.ts
@@ -3,6 +3,7 @@ import type { Catalogs } from '@pnpm/catalogs.types'
 import type { LockfileObject, ProjectSnapshot, ResolvedDependencies } from '@pnpm/lockfile.types'
 import semver from 'semver'
 
+import { catalogReferencesHaveSnapshots } from './tryFastUpdateCatalogs.js'
 import {
   applyFastRewrite,
   type FastOverride,
@@ -13,22 +14,24 @@ import {
  * Move a catalog entry to a version the lockfile does not have, without
  * resolving the whole graph.
  *
- * `tryFastUpdateCatalogs` handles the range-only case, where the recorded
- * version still satisfies the new specifier and nothing but the specifier
- * moves. This handles the other half: the entry now names a version the
- * locked one cannot satisfy, so the package itself has to be replaced. That
- * is the same rewrite an exact `pnpm.overrides` entry performs, so it reuses
- * that machinery — including the check that every locked child still
- * satisfies the new version's manifest.
+ * Replacing the package is the rewrite an exact `pnpm.overrides` entry
+ * performs, so this drives that machinery rather than repeating it;
+ * `tryFastUpdateCatalogs` keeps the range-only case, where the specifier moves
+ * and the package does not.
  *
- * Unlike an override, a catalog entry only governs the importers that
- * reference it. Returns `false` when anything else reaches the package, since
- * the graph would then have to hold both versions.
+ * An override moves a package everywhere it appears. A catalog entry governs
+ * only the importers that reference it, so anything else reaching the package
+ * would have to keep the old version while those importers move — a graph
+ * holding both, which this cannot express.
  */
 export async function tryFastUpdateCatalogVersions (
   lockfile: LockfileObject,
   opts: FastRewriteOptions & { catalogs: Catalogs }
 ): Promise<boolean> {
+  // The same gate the range-only path opens with: an importer pointing at a
+  // catalog entry with nothing recorded for it needs the resolver, and this
+  // path would otherwise never look at that entry.
+  if (!catalogReferencesHaveSnapshots(lockfile, opts.catalogs)) return false
   if (lockfile.catalogs == null) return false
   const fastOverrides: FastOverride[] = []
   const catalogs: LockfileObject['catalogs'] = {}
@@ -57,16 +60,7 @@ export async function tryFastUpdateCatalogVersions (
   return applyFastRewrite(lockfile, fastOverrides, opts, { catalogs })
 }
 
-/**
- * Whether the catalog entry is the only thing in the lockfile that reaches
- * `alias`: every importer that depends on it does so through this catalog,
- * and no package depends on it at all.
- *
- * An override moves a package everywhere it appears. A catalog entry cannot,
- * so anything else pointing at the package would have to keep the old version
- * while the catalog's importers move to the new one, leaving the graph holding
- * both.
- */
+/** Whether the catalog entry is the only thing in the lockfile that reaches `alias`. */
 function catalogEntryIsSoleReference (
   lockfile: LockfileObject,
   catalogName: string,

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateCatalogVersions.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateCatalogVersions.ts
@@ -52,12 +52,17 @@ export async function tryFastUpdateCatalogVersions (
         catalogs[catalogName][alias] = entry
         continue
       }
-      // A specifier the locked version still satisfies belongs to the
-      // range-only path, which rewrites nothing.
-      const wanted = semver.valid(specifier)
-      if (wanted == null || semver.valid(entry.version) == null || wanted === entry.version) {
-        return 'unsupported'
+      if (semver.valid(entry.version) == null) return 'unsupported'
+      // A specifier the locked version still satisfies moves nothing but the
+      // specifier, exactly as the range-only path would.
+      // A specifier the locked version still satisfies moves nothing but the
+      // specifier, exactly as the range-only path would.
+      if (semver.validRange(specifier) != null && semver.satisfies(entry.version, specifier)) {
+        catalogs[catalogName][alias] = { specifier, version: entry.version }
+        continue
       }
+      const wanted = semver.valid(specifier)
+      if (wanted == null) return 'unsupported'
       if (!catalogEntryIsSoleReference(lockfile, catalogName, alias)) return 'unsupported'
       fastOverrides.push({ name: alias, newVersion: wanted, oldVersion: entry.version })
       catalogs[catalogName][alias] = { specifier, version: wanted }

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateCatalogVersions.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateCatalogVersions.ts
@@ -1,0 +1,93 @@
+import { parseCatalogProtocol } from '@pnpm/catalogs.protocol-parser'
+import type { Catalogs } from '@pnpm/catalogs.types'
+import type { LockfileObject, ProjectSnapshot, ResolvedDependencies } from '@pnpm/lockfile.types'
+import semver from 'semver'
+
+import {
+  applyFastRewrite,
+  type FastOverride,
+  type FastRewriteOptions,
+} from './tryFastUpdateOverrides.js'
+
+/**
+ * Move a catalog entry to a version the lockfile does not have, without
+ * resolving the whole graph.
+ *
+ * `tryFastUpdateCatalogs` handles the range-only case, where the recorded
+ * version still satisfies the new specifier and nothing but the specifier
+ * moves. This handles the other half: the entry now names a version the
+ * locked one cannot satisfy, so the package itself has to be replaced. That
+ * is the same rewrite an exact `pnpm.overrides` entry performs, so it reuses
+ * that machinery — including the check that every locked child still
+ * satisfies the new version's manifest.
+ *
+ * Unlike an override, a catalog entry only governs the importers that
+ * reference it. Returns `false` when anything else reaches the package, since
+ * the graph would then have to hold both versions.
+ */
+export async function tryFastUpdateCatalogVersions (
+  lockfile: LockfileObject,
+  opts: FastRewriteOptions & { catalogs: Catalogs }
+): Promise<boolean> {
+  if (lockfile.catalogs == null) return false
+  const fastOverrides: FastOverride[] = []
+  const catalogs: LockfileObject['catalogs'] = {}
+  for (const [catalogName, catalog] of Object.entries(lockfile.catalogs)) {
+    catalogs[catalogName] = {}
+    for (const [alias, entry] of Object.entries(catalog)) {
+      const specifier = opts.catalogs[catalogName]?.[alias]
+      if (specifier == null) return false
+      if (specifier === entry.specifier) {
+        catalogs[catalogName][alias] = entry
+        continue
+      }
+      // A specifier the locked version still satisfies belongs to the
+      // range-only path, which rewrites nothing.
+      const wanted = semver.valid(specifier)
+      if (wanted == null || semver.valid(entry.version) == null || wanted === entry.version) {
+        return false
+      }
+      if (!catalogEntryIsSoleReference(lockfile, catalogName, alias)) return false
+      fastOverrides.push({ name: alias, newVersion: wanted, oldVersion: entry.version })
+      catalogs[catalogName][alias] = { specifier, version: wanted }
+    }
+  }
+  if (fastOverrides.length === 0) return false
+
+  return applyFastRewrite(lockfile, fastOverrides, opts, { catalogs })
+}
+
+/**
+ * Whether the catalog entry is the only thing in the lockfile that reaches
+ * `alias`: every importer that depends on it does so through this catalog,
+ * and no package depends on it at all.
+ *
+ * An override moves a package everywhere it appears. A catalog entry cannot,
+ * so anything else pointing at the package would have to keep the old version
+ * while the catalog's importers move to the new one, leaving the graph holding
+ * both.
+ */
+function catalogEntryIsSoleReference (
+  lockfile: LockfileObject,
+  catalogName: string,
+  alias: string
+): boolean {
+  const importersAgree = Object.values(lockfile.importers).every((importer: ProjectSnapshot) =>
+    dependencyGroups(importer).every((dependencies) =>
+      dependencies[alias] == null ||
+      parseCatalogProtocol(importer.specifiers[alias] ?? '') === catalogName
+    )
+  )
+  const noPackageDependsOnIt = Object.values(lockfile.packages ?? {}).every((snapshot) =>
+    snapshot.dependencies?.[alias] == null && snapshot.optionalDependencies?.[alias] == null
+  )
+  return importersAgree && noPackageDependsOnIt
+}
+
+function dependencyGroups (importer: ProjectSnapshot): ResolvedDependencies[] {
+  return [
+    importer.dependencies,
+    importer.devDependencies,
+    importer.optionalDependencies,
+  ].filter((group) => group != null)
+}

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateCatalogVersions.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateCatalogVersions.ts
@@ -24,22 +24,30 @@ import {
  * would have to keep the old version while those importers move — a graph
  * holding both, which this cannot express.
  */
+export type CatalogVersionRewrite =
+  /** Every entry that moved was rewritten. */
+  | 'applied'
+  /** No entry moved to a version the locked one cannot satisfy. */
+  | 'nothing-to-move'
+  /** An entry moved but the rewrite cannot express it; the resolver must run. */
+  | 'unsupported'
+
 export async function tryFastUpdateCatalogVersions (
   lockfile: LockfileObject,
   opts: FastRewriteOptions & { catalogs: Catalogs }
-): Promise<boolean> {
+): Promise<CatalogVersionRewrite> {
   // The same gate the range-only path opens with: an importer pointing at a
   // catalog entry with nothing recorded for it needs the resolver, and this
   // path would otherwise never look at that entry.
-  if (!catalogReferencesHaveSnapshots(lockfile, opts.catalogs)) return false
-  if (lockfile.catalogs == null) return false
+  if (!catalogReferencesHaveSnapshots(lockfile, opts.catalogs)) return 'unsupported'
+  if (lockfile.catalogs == null) return 'nothing-to-move'
   const fastOverrides: FastOverride[] = []
   const catalogs: LockfileObject['catalogs'] = {}
   for (const [catalogName, catalog] of Object.entries(lockfile.catalogs)) {
     catalogs[catalogName] = {}
     for (const [alias, entry] of Object.entries(catalog)) {
       const specifier = opts.catalogs[catalogName]?.[alias]
-      if (specifier == null) return false
+      if (specifier == null) return 'unsupported'
       if (specifier === entry.specifier) {
         catalogs[catalogName][alias] = entry
         continue
@@ -48,16 +56,18 @@ export async function tryFastUpdateCatalogVersions (
       // range-only path, which rewrites nothing.
       const wanted = semver.valid(specifier)
       if (wanted == null || semver.valid(entry.version) == null || wanted === entry.version) {
-        return false
+        return 'unsupported'
       }
-      if (!catalogEntryIsSoleReference(lockfile, catalogName, alias)) return false
+      if (!catalogEntryIsSoleReference(lockfile, catalogName, alias)) return 'unsupported'
       fastOverrides.push({ name: alias, newVersion: wanted, oldVersion: entry.version })
       catalogs[catalogName][alias] = { specifier, version: wanted }
     }
   }
-  if (fastOverrides.length === 0) return false
+  if (fastOverrides.length === 0) return 'nothing-to-move'
 
-  return applyFastRewrite(lockfile, fastOverrides, opts, { catalogs })
+  return await applyFastRewrite(lockfile, fastOverrides, opts, { catalogs })
+    ? 'applied'
+    : 'unsupported'
 }
 
 /** Whether the catalog entry is the only thing in the lockfile that reaches `alias`. */

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateCatalogs.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateCatalogs.ts
@@ -13,17 +13,7 @@ export function tryFastUpdateCatalogs (
   if (Object.values(opts.overrides).some((specifier) => parseCatalogProtocol(specifier) != null)) {
     return false
   }
-  if (Object.values(lockfile.importers).some((importer) =>
-    Object.entries(importer.specifiers).some(([alias, specifier]) => {
-      const catalogName = parseCatalogProtocol(specifier)
-      return catalogName != null && (
-        opts.catalogs[catalogName]?.[alias] == null ||
-        lockfile.catalogs?.[catalogName]?.[alias] == null
-      )
-    })
-  )) {
-    return false
-  }
+  if (!catalogReferencesHaveSnapshots(lockfile, opts.catalogs)) return false
 
   let changed = false
   const catalogs = Object.fromEntries(
@@ -62,4 +52,24 @@ function catalogEntryIsReferenced (
 ): boolean {
   const protocol = catalogName === 'default' ? 'catalog:' : `catalog:${catalogName}`
   return Object.values(importers).some((importer) => importer.specifiers[alias] === protocol)
+}
+
+/**
+ * Whether every catalog an importer references has an entry in both the
+ * configuration and the lockfile. Without one there is nothing to rewrite the
+ * reference from, so the resolver has to run.
+ */
+export function catalogReferencesHaveSnapshots (
+  lockfile: LockfileObject,
+  catalogs: Catalogs
+): boolean {
+  return Object.values(lockfile.importers).every((importer) =>
+    Object.entries(importer.specifiers).every(([alias, specifier]) => {
+      const catalogName = parseCatalogProtocol(specifier)
+      return catalogName == null || (
+        catalogs[catalogName]?.[alias] != null &&
+        lockfile.catalogs?.[catalogName]?.[alias] != null
+      )
+    })
+  )
 }

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateOverrides.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateOverrides.ts
@@ -320,7 +320,18 @@ async function resolveNewManifests (
     const manifest = opts.readPackageHook == null
       ? rawManifest
       : await opts.readPackageHook(clone(rawManifest))
-    if (hasPeerDependencies(manifest)) return undefined
+    // pacquet validates after its manifest hook, so a hook that introduces
+    // any of these must send both stacks down the same fallback.
+    if (
+      manifest.name !== name ||
+      manifest.version !== newVersion ||
+      manifest.deprecated != null ||
+      hasInvalidManifestMaps(manifest) ||
+      hasPeerDependencies(manifest) ||
+      manifest.engines?.runtime != null ||
+      manifest.bundledDependencies != null ||
+      manifest.bundleDependencies != null
+    ) return undefined
     return {
       name,
       manifest,

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateOverrides.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateOverrides.ts
@@ -18,7 +18,7 @@ import type {
 import { clone, equals } from 'ramda'
 import semver from 'semver'
 
-interface FastOverride {
+export interface FastOverride {
   name: string
   newVersion?: string
   oldVersion?: string
@@ -43,23 +43,44 @@ interface ResolverPolicyOptions {
   trustPolicyIgnoreAfter?: number
 }
 
+export type FastRewriteOptions = ResolverPolicyOptions & {
+  lockfileDir: string
+  lockfileIncludeTarballUrl?: boolean
+  isLockfileUpToDate: (lockfile: LockfileObject) => Promise<boolean>
+  readPackageHook?: ReadPackageHook
+  registries: Registries
+  requestPackage: RequestPackageFunction
+  verifyLockfile?: (lockfile: LockfileObject) => Promise<void>
+}
+
 export async function tryFastUpdateOverrides (
   lockfile: LockfileObject,
-  opts: ResolverPolicyOptions & {
-    lockfileDir: string
-    lockfileIncludeTarballUrl?: boolean
+  opts: FastRewriteOptions & {
     overrides: Record<string, string>
     parsedOverrides: VersionOverride[]
-    isLockfileUpToDate: (lockfile: LockfileObject) => Promise<boolean>
-    readPackageHook?: ReadPackageHook
-    registries: Registries
-    requestPackage: RequestPackageFunction
-    verifyLockfile?: (lockfile: LockfileObject) => Promise<void>
   }
 ): Promise<boolean> {
   const fastOverrides = getFastOverrides(lockfile.overrides ?? {}, opts.overrides, opts.parsedOverrides)
   if (fastOverrides == null) return false
+  return applyFastRewrite(lockfile, fastOverrides, opts, { overrides: opts.overrides })
+}
 
+/**
+ * Move every package named by `fastOverrides` to its new version, rebuilding
+ * the affected package entries from the new version's manifest and redirecting
+ * everything that referenced the old key. `settings` is the setting block that
+ * drove the rewrite, recorded alongside it.
+ *
+ * Returns `false` whenever the move cannot be proven safe from the lockfile
+ * plus the resolved manifests — a locked child the new manifest no longer
+ * admits, or a candidate the freshness check rejects.
+ */
+export async function applyFastRewrite (
+  lockfile: LockfileObject,
+  fastOverrides: FastOverride[],
+  opts: FastRewriteOptions,
+  settings: Partial<LockfileObject>
+): Promise<boolean> {
   const removals = fastOverrides.filter(({ newVersion }) => newVersion == null)
   const peerNames = getPeerNames(lockfile)
   if (removals.some(({ name }) => peerNames.has(name))) return false
@@ -100,13 +121,13 @@ export async function tryFastUpdateOverrides (
     ...lockfile,
     importers,
     packages: pruneUnreachablePackages(importers, packages),
-    overrides: opts.overrides,
+    ...settings,
   }
   if (!await opts.isLockfileUpToDate(updatedLockfile)) return false
   await opts.verifyLockfile?.(updatedLockfile)
   lockfile.importers = updatedLockfile.importers
   lockfile.packages = updatedLockfile.packages
-  lockfile.overrides = updatedLockfile.overrides
+  Object.assign(lockfile, settings)
   return true
 }
 
@@ -240,7 +261,6 @@ async function resolveNewManifests (
   replacements: Map<DepPath, DepPath>,
   opts: ResolverPolicyOptions & {
     lockfileDir: string
-    parsedOverrides: VersionOverride[]
     readPackageHook?: ReadPackageHook
     requestPackage: RequestPackageFunction
   }

--- a/pnpm11/installing/deps-installer/test/install/catalogVersionFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/catalogVersionFastUpdate.ts
@@ -1,0 +1,85 @@
+import { expect, test } from '@jest/globals'
+import type { LockfileObject } from '@pnpm/lockfile.types'
+import type { DepPath, ProjectId } from '@pnpm/types'
+
+import { tryFastUpdateCatalogVersions } from '../../src/install/tryFastUpdateCatalogVersions.js'
+
+/** `target` is a direct dependency of the importer, reached only through the default catalog. */
+function lockfile (): LockfileObject {
+  return {
+    lockfileVersion: '9.0',
+    catalogs: {
+      default: { target: { specifier: '1.0.0', version: '1.0.0' } },
+    },
+    importers: {
+      ['.' as ProjectId]: {
+        specifiers: { target: 'catalog:' },
+        dependencies: { target: '1.0.0' },
+      },
+    },
+    packages: {
+      ['target@1.0.0' as DepPath]: {
+        resolution: { integrity: 'sha512-target-1' },
+        dependencies: { child: '1.1.0' },
+      },
+      ['child@1.1.0' as DepPath]: { resolution: { integrity: 'sha512-child' } },
+    },
+  }
+}
+
+function updateOptions (childRange: string, catalogSpecifier = '2.0.0') {
+  return {
+    catalogs: { default: { target: catalogSpecifier } },
+    lockfileDir: '/project',
+    registries: { default: 'https://registry.npmjs.org/' },
+    requestPackage: async () => ({
+      body: {
+        id: 'target@2.0.0',
+        resolvedVia: 'npm-registry',
+        resolution: {
+          integrity: 'sha512-target-2',
+          tarball: 'https://registry.npmjs.org/target/-/target-2.0.0.tgz',
+        },
+        manifest: { name: 'target', version: '2.0.0', dependencies: { child: childRange } },
+      },
+    }),
+    isLockfileUpToDate: async () => true,
+  } as unknown as Parameters<typeof tryFastUpdateCatalogVersions>[1]
+}
+
+test('a catalog entry moved to a new exact version replaces the package', async () => {
+  const subject = lockfile()
+
+  expect(await tryFastUpdateCatalogVersions(subject, updateOptions('^1.0.0'))).toBe(true)
+  expect(Object.keys(subject.packages!).sort()).toStrictEqual(['child@1.1.0', 'target@2.0.0'])
+  expect(subject.catalogs!.default.target).toStrictEqual({ specifier: '2.0.0', version: '2.0.0' })
+  expect(subject.importers['.' as ProjectId].dependencies).toStrictEqual({ target: '2.0.0' })
+})
+
+test('a locked child the new version no longer admits falls back', async () => {
+  expect(await tryFastUpdateCatalogVersions(lockfile(), updateOptions('^2.0.0'))).toBe(false)
+})
+
+test('an importer depending on the package directly falls back', async () => {
+  const subject = lockfile()
+  subject.importers['pkg-a' as ProjectId] = {
+    specifiers: { target: '1.0.0' },
+    dependencies: { target: '1.0.0' },
+  }
+
+  expect(await tryFastUpdateCatalogVersions(subject, updateOptions('^1.0.0'))).toBe(false)
+})
+
+test('a package depending on the catalog package falls back', async () => {
+  const subject = lockfile()
+  subject.packages!['parent@1.0.0' as DepPath] = {
+    resolution: { integrity: 'sha512-parent' },
+    dependencies: { target: '1.0.0' },
+  }
+
+  expect(await tryFastUpdateCatalogVersions(subject, updateOptions('^1.0.0'))).toBe(false)
+})
+
+test('a range the locked version still satisfies is declined', async () => {
+  expect(await tryFastUpdateCatalogVersions(lockfile(), updateOptions('^1.0.0', '^1.0.0'))).toBe(false)
+})

--- a/pnpm11/installing/deps-installer/test/install/catalogVersionFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/catalogVersionFastUpdate.ts
@@ -50,14 +50,14 @@ function updateOptions (childRange: string, catalogSpecifier = '2.0.0') {
 test('a catalog entry moved to a new exact version replaces the package', async () => {
   const subject = lockfile()
 
-  expect(await tryFastUpdateCatalogVersions(subject, updateOptions('^1.0.0'))).toBe(true)
+  expect(await tryFastUpdateCatalogVersions(subject, updateOptions('^1.0.0'))).toBe('applied')
   expect(Object.keys(subject.packages!).sort()).toStrictEqual(['child@1.1.0', 'target@2.0.0'])
   expect(subject.catalogs!.default.target).toStrictEqual({ specifier: '2.0.0', version: '2.0.0' })
   expect(subject.importers['.' as ProjectId].dependencies).toStrictEqual({ target: '2.0.0' })
 })
 
 test('a locked child the new version no longer admits falls back', async () => {
-  expect(await tryFastUpdateCatalogVersions(lockfile(), updateOptions('^2.0.0'))).toBe(false)
+  expect(await tryFastUpdateCatalogVersions(lockfile(), updateOptions('^2.0.0'))).toBe('unsupported')
 })
 
 test('an importer depending on the package directly falls back', async () => {
@@ -67,7 +67,7 @@ test('an importer depending on the package directly falls back', async () => {
     dependencies: { target: '1.0.0' },
   }
 
-  expect(await tryFastUpdateCatalogVersions(subject, updateOptions('^1.0.0'))).toBe(false)
+  expect(await tryFastUpdateCatalogVersions(subject, updateOptions('^1.0.0'))).toBe('unsupported')
 })
 
 test('a package depending on the catalog package falls back', async () => {
@@ -77,7 +77,7 @@ test('a package depending on the catalog package falls back', async () => {
     dependencies: { target: '1.0.0' },
   }
 
-  expect(await tryFastUpdateCatalogVersions(subject, updateOptions('^1.0.0'))).toBe(false)
+  expect(await tryFastUpdateCatalogVersions(subject, updateOptions('^1.0.0'))).toBe('unsupported')
 })
 
 test('a catalog reference with no recorded entry falls back', async () => {
@@ -87,7 +87,7 @@ test('a catalog reference with no recorded entry falls back', async () => {
     dependencies: { other: '1.0.0' },
   }
 
-  expect(await tryFastUpdateCatalogVersions(subject, updateOptions('^1.0.0'))).toBe(false)
+  expect(await tryFastUpdateCatalogVersions(subject, updateOptions('^1.0.0'))).toBe('unsupported')
 })
 
 test('a manifest hook that renames the package falls back', async () => {
@@ -97,9 +97,15 @@ test('a manifest hook that renames the package falls back', async () => {
   expect(await tryFastUpdateCatalogVersions(
     lockfile(),
     opts as unknown as Parameters<typeof tryFastUpdateCatalogVersions>[1]
-  )).toBe(false)
+  )).toBe('unsupported')
 })
 
-test('a range the locked version still satisfies is declined', async () => {
-  expect(await tryFastUpdateCatalogVersions(lockfile(), updateOptions('^1.0.0', '^1.0.0'))).toBe(false)
+test('a range the locked version still satisfies moves nothing', async () => {
+  expect(await tryFastUpdateCatalogVersions(lockfile(), updateOptions('^1.0.0', '^1.0.0')))
+    .toBe('unsupported')
+})
+
+test('an unchanged catalog reports that nothing moved', async () => {
+  expect(await tryFastUpdateCatalogVersions(lockfile(), updateOptions('^1.0.0', '1.0.0')))
+    .toBe('nothing-to-move')
 })

--- a/pnpm11/installing/deps-installer/test/install/catalogVersionFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/catalogVersionFastUpdate.ts
@@ -100,9 +100,28 @@ test('a manifest hook that renames the package falls back', async () => {
   )).toBe('unsupported')
 })
 
-test('a range the locked version still satisfies moves nothing', async () => {
-  expect(await tryFastUpdateCatalogVersions(lockfile(), updateOptions('^1.0.0', '^1.0.0')))
-    .toBe('unsupported')
+test('a satisfied range rides along with an exact move in one pass', async () => {
+  const subject = lockfile()
+  subject.catalogs!.default.child = { specifier: '1.1.0', version: '1.1.0' }
+  const opts = updateOptions('^1.0.0') as unknown as Record<string, unknown>
+  opts.catalogs = { default: { target: '2.0.0', child: '^1.1.0' } }
+
+  expect(await tryFastUpdateCatalogVersions(
+    subject,
+    opts as unknown as Parameters<typeof tryFastUpdateCatalogVersions>[1]
+  )).toBe('applied')
+  expect(subject.catalogs!.default.child).toStrictEqual({ specifier: '^1.1.0', version: '1.1.0' })
+  expect(subject.catalogs!.default.target).toStrictEqual({ specifier: '2.0.0', version: '2.0.0' })
+})
+
+test('a range the locked version still satisfies moves no package', async () => {
+  const subject = lockfile()
+
+  expect(await tryFastUpdateCatalogVersions(subject, updateOptions('^1.0.0', '^1.0.0')))
+    .toBe('nothing-to-move')
+  // Nothing was written: with no package to move, the range-only rewrite owns
+  // the specifier and this leaves the lockfile for it.
+  expect(subject.catalogs!.default.target).toStrictEqual({ specifier: '1.0.0', version: '1.0.0' })
 })
 
 test('an unchanged catalog reports that nothing moved', async () => {

--- a/pnpm11/installing/deps-installer/test/install/catalogVersionFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/catalogVersionFastUpdate.ts
@@ -80,6 +80,26 @@ test('a package depending on the catalog package falls back', async () => {
   expect(await tryFastUpdateCatalogVersions(subject, updateOptions('^1.0.0'))).toBe(false)
 })
 
+test('a catalog reference with no recorded entry falls back', async () => {
+  const subject = lockfile()
+  subject.importers['pkg-a' as ProjectId] = {
+    specifiers: { other: 'catalog:' },
+    dependencies: { other: '1.0.0' },
+  }
+
+  expect(await tryFastUpdateCatalogVersions(subject, updateOptions('^1.0.0'))).toBe(false)
+})
+
+test('a manifest hook that renames the package falls back', async () => {
+  const opts = updateOptions('^1.0.0') as unknown as Record<string, unknown>
+  opts.readPackageHook = (manifest: { name: string }) => ({ ...manifest, name: 'renamed' })
+
+  expect(await tryFastUpdateCatalogVersions(
+    lockfile(),
+    opts as unknown as Parameters<typeof tryFastUpdateCatalogVersions>[1]
+  )).toBe(false)
+})
+
 test('a range the locked version still satisfies is declined', async () => {
   expect(await tryFastUpdateCatalogVersions(lockfile(), updateOptions('^1.0.0', '^1.0.0'))).toBe(false)
 })


### PR DESCRIPTION
## Summary

Closes the last stage of pnpm/pnpm#13474, after pnpm/pnpm#13477 (catalogs), pnpm/pnpm#13482 (ignored optional dependencies), pnpm/pnpm#13600 (setting-only updates), and pnpm/pnpm#13680 (patched dependencies).

The existing catalog fast path only handles a specifier the locked version still satisfies: it updates the specifier and keeps the version. A catalog entry moved to a *different exact version* left it with nothing to do, so the install fell back to a full resolution.

Replacing the package is the same rewrite an exact `pnpm.overrides` entry performs, so this reuses that machinery rather than growing a second rewriter — including the check that every locked child still satisfies the new version's manifest, and the existing refusals for peer-suffixed keys, registry-qualified keys, patched or optional snapshots, and packages declaring peer dependencies.

- Split the override path into its plan building and a shared apply step, so the catalog caller can drive the rewrite and record the updated catalog snapshot instead of writing synthetic overrides into the lockfile.
- Build the same plan from the catalog entries whose version moved, chained after the range-only rewrite, which declines exactly the changes this handles.
- Implemented in both the TypeScript CLI (`tryFastUpdateCatalogVersions`) and pacquet (`fast_update_catalog_versions`).

### The guard that makes this different from an override

An override moves a package everywhere it appears. A catalog entry only governs the importers that reference it, so if anything else reaches the package — an importer depending on it directly, or any package depending on it — the graph would have to hold both the old and the new version, which this rewrite cannot express. Both stacks fall back in that case, with a test for each direction.

## Squash Commit Body

```text
A catalog entry that moves to a version the locked one cannot satisfy left
the range-only fast path with nothing to do, so the install fell back to a
full resolution. Replacing the package is the same rewrite an exact
`pnpm.overrides` entry performs, so reuse that machinery rather than
growing a second rewriter: the same dependency-shape validation decides
whether every locked child still fits the new version.

Split the override path into its plan building and a shared apply step so
the catalog caller can drive the rewrite without writing synthetic
overrides into the lockfile, and record the updated catalog snapshot
instead.

An override moves a package everywhere it appears; a catalog entry only
governs the importers that reference it. Fall back when anything else
reaches the package -- an importer pinning it directly, or any package
depending on it -- since the graph would then have to hold both versions.

Implemented in both the TypeScript CLI and pacquet.

Closes pnpm/pnpm#13474.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13689"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788642279&installation_model_id=426870&pr_number=13689&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13689&signature=f2685119c828afac7f029cd3ffaa3133dc67909f4e1b4bae5647db789e3cc927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Compatible exact-version catalog changes can update lockfiles without full dependency resolution.
  * Unchanged and range-only catalog updates preserve existing locked versions where possible.
  * Unsupported, ambiguous, or incompatible changes automatically fall back to full resolution.

* **Bug Fixes**
  * Improved validation prevents updates when dependencies or catalog references conflict.
  * Lockfile and catalog metadata are validated before changes are applied.

* **Tests**
  * Added coverage for successful updates, compatibility checks, unchanged entries, snapshot validation, and fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->