### PR TITLE
feat: add calculateFingerprint pnpmfile hook

### DIFF
--- a/.changeset/fingerprint-hook.md
+++ b/.changeset/fingerprint-hook.md
@@ -1,0 +1,13 @@
+---
+"@pnpm/hooks.pnpmfile": minor
+"@pnpm/workspace.state": minor
+"@pnpm/deps.status": minor
+"@pnpm/installing.commands": minor
+"pnpm": minor
+---
+
+Added a new pnpmfile hook: `calculateFingerprint`. The hook returns a fingerprint of any external state that the pnpmfile's behavior depends on (for example, the state of a custom package source used by a custom resolver). The fingerprint is recorded in the workspace state file — never the lockfile, so it may be machine-specific — and compared by the up-to-date checks behind `verify-deps-before-run` and `optimistic-repeat-install`. When it changes, `node_modules` is considered outdated even though the lockfile and manifests are unchanged, so a full install (including `shouldRefreshResolution` hooks) runs.
+
+This closes the gap where `shouldRefreshResolution` hooks were skipped by the fast paths ([#10995](https://github.com/pnpm/pnpm/pull/10995)): a pnpmfile can now cheaply signal "my resolution inputs changed" without disabling `optimistic-repeat-install`.
+
+This hook is not available in pacquet, which does not run pnpmfiles.

--- a/pnpm11/deps/status/src/checkDepsStatus.ts
+++ b/pnpm11/deps/status/src/checkDepsStatus.ts
@@ -256,7 +256,18 @@ async function _checkDepsStatus (opts: CheckDepsStatusOptions, workspaceState: W
 
   let fingerprint: string | undefined
   if (opts.hooks?.calculateFingerprint != null || workspaceState.fingerprint != null) {
-    fingerprint = await opts.hooks?.calculateFingerprint?.()
+    try {
+      fingerprint = await opts.hooks?.calculateFingerprint?.()
+    } catch (error) {
+      // A broken hook must invalidate deterministically (upToDate: false)
+      // rather than fall into the outer catch's upToDate: undefined, which
+      // callers may treat as "unknown" rather than "outdated".
+      return {
+        upToDate: false,
+        issue: `The pnpmfile calculateFingerprint hook failed: ${util.types.isNativeError(error) ? error.message : String(error)}`,
+        workspaceState,
+      }
+    }
     if (fingerprint !== workspaceState.fingerprint) {
       return {
         upToDate: false,

--- a/pnpm11/deps/status/src/checkDepsStatus.ts
+++ b/pnpm11/deps/status/src/checkDepsStatus.ts
@@ -254,6 +254,18 @@ async function _checkDepsStatus (opts: CheckDepsStatusOptions, workspaceState: W
     }
   }
 
+  let fingerprint: string | undefined
+  if (opts.hooks?.calculateFingerprint != null || workspaceState.fingerprint != null) {
+    fingerprint = await opts.hooks?.calculateFingerprint?.()
+    if (fingerprint !== workspaceState.fingerprint) {
+      return {
+        upToDate: false,
+        issue: 'The fingerprint returned by a pnpmfile has changed',
+        workspaceState,
+      }
+    }
+  }
+
   const lockfileDirs = getWantedLockfileDirs({
     allProjects,
     lockfileDir,
@@ -491,6 +503,7 @@ async function _checkDepsStatus (opts: CheckDepsStatusOptions, workspaceState: W
       allProjects,
       workspaceDir,
       pnpmfiles: workspaceState.pnpmfiles,
+      fingerprint,
       settings: opts,
       filteredInstall: workspaceState.filteredInstall,
     })

--- a/pnpm11/deps/status/test/checkDepsStatus.test.ts
+++ b/pnpm11/deps/status/test/checkDepsStatus.test.ts
@@ -513,6 +513,157 @@ describe('checkDepsStatus - pnpmfile modification', () => {
   })
 })
 
+describe('checkDepsStatus - fingerprint', () => {
+  beforeEach(() => {
+    jest.resetModules()
+    jest.clearAllMocks()
+  })
+
+  const makeWorkspaceState = (fingerprint?: string): WorkspaceState => ({
+    lastValidatedTimestamp: Date.now() - 10_000,
+    pnpmfiles: [],
+    settings: {
+      excludeLinksFromLockfile: false,
+      linkWorkspacePackages: true,
+      preferWorkspacePackages: true,
+    },
+    projects: {},
+    filteredInstall: false,
+    fingerprint,
+  })
+
+  it('returns upToDate: false when the fingerprint has changed', async () => {
+    const mockWorkspaceState = makeWorkspaceState('fingerprint-before')
+    jest.mocked(loadWorkspaceState).mockReturnValue(mockWorkspaceState)
+
+    const opts: CheckDepsStatusOptions = {
+      rootProjectManifest: {},
+      rootProjectManifestDir: '/project',
+      pnpmfile: [],
+      hooks: {
+        calculateFingerprint: async () => 'fingerprint-after',
+      },
+      ...mockWorkspaceState.settings,
+    }
+    const result = await checkDepsStatus(opts)
+
+    expect(result.upToDate).toBe(false)
+    expect(result.issue).toBe('The fingerprint returned by a pnpmfile has changed')
+  })
+
+  it('returns upToDate: false when a fingerprint appears for the first time', async () => {
+    const mockWorkspaceState = makeWorkspaceState(undefined)
+    jest.mocked(loadWorkspaceState).mockReturnValue(mockWorkspaceState)
+
+    const opts: CheckDepsStatusOptions = {
+      rootProjectManifest: {},
+      rootProjectManifestDir: '/project',
+      pnpmfile: [],
+      hooks: {
+        calculateFingerprint: async () => 'fingerprint-new',
+      },
+      ...mockWorkspaceState.settings,
+    }
+    const result = await checkDepsStatus(opts)
+
+    expect(result.upToDate).toBe(false)
+    expect(result.issue).toBe('The fingerprint returned by a pnpmfile has changed')
+  })
+
+  it('returns upToDate: false when a previously recorded fingerprint is gone', async () => {
+    const mockWorkspaceState = makeWorkspaceState('fingerprint-before')
+    jest.mocked(loadWorkspaceState).mockReturnValue(mockWorkspaceState)
+
+    const opts: CheckDepsStatusOptions = {
+      rootProjectManifest: {},
+      rootProjectManifestDir: '/project',
+      pnpmfile: [],
+      ...mockWorkspaceState.settings,
+    }
+    const result = await checkDepsStatus(opts)
+
+    expect(result.upToDate).toBe(false)
+    expect(result.issue).toBe('The fingerprint returned by a pnpmfile has changed')
+  })
+
+  it('continues past the fingerprint check when the fingerprint is unchanged', async () => {
+    const lastValidatedTimestamp = Date.now() - 10_000
+    const beforeLastValidation = lastValidatedTimestamp - 10_000
+    const afterLastValidation = lastValidatedTimestamp + 1_000
+    const projectRootDir = '/project' as ProjectRootDir
+    const projectRootDirRealPath = '/project' as ProjectRootDirRealPath
+    const mockWorkspaceState: WorkspaceState = {
+      ...makeWorkspaceState('fingerprint-same'),
+      lastValidatedTimestamp,
+      settings: {
+        excludeLinksFromLockfile: false,
+        linkWorkspacePackages: true,
+        preferWorkspacePackages: true,
+        patchedDependencies: {
+          foo: '/project/patches/foo.patch',
+        },
+      },
+      projects: {
+        [projectRootDir]: {
+          name: 'root',
+          version: '1.0.0',
+        },
+      },
+    }
+
+    jest.mocked(loadWorkspaceState).mockReturnValue(mockWorkspaceState)
+
+    jest.mocked(fsUtils.safeStat).mockImplementation(async (filePath: string) => {
+      if (filePath === '/project/patches/foo.patch') {
+        return {
+          mtime: new Date(afterLastValidation),
+          mtimeMs: afterLastValidation,
+        } as Stats
+      }
+      return {
+        mtime: new Date(beforeLastValidation),
+        mtimeMs: beforeLastValidation,
+      } as Stats
+    })
+    jest.mocked(statManifestFileUtils.statManifestFile).mockImplementation(async () => ({
+      mtime: new Date(beforeLastValidation),
+      mtimeMs: beforeLastValidation,
+    } as Stats))
+
+    const opts: CheckDepsStatusOptions = {
+      allProjects: [{
+        rootDir: projectRootDir,
+        rootDirRealPath: projectRootDirRealPath,
+        manifest: {
+          name: 'root',
+          version: '1.0.0',
+          dependencies: {
+            foo: '1.0.0',
+          },
+        },
+        writeProjectManifest: async () => {},
+      }],
+      workspaceDir: '/project',
+      rootProjectManifest: {},
+      rootProjectManifestDir: '/project',
+      pnpmfile: [],
+      patchedDependencies: {
+        foo: '/project/patches/foo.patch',
+      },
+      hooks: {
+        calculateFingerprint: async () => 'fingerprint-same',
+      },
+      ...mockWorkspaceState.settings,
+    }
+    const result = await checkDepsStatus(opts)
+
+    // The matching fingerprint must not trip the check; the modified patch
+    // (a later check) is what makes the state outdated.
+    expect(result.upToDate).toBe(false)
+    expect(result.issue).toBe('Patches were modified')
+  })
+})
+
 describe('checkDepsStatus - lockfile conflicts', () => {
   beforeEach(() => {
     jest.resetModules()

--- a/pnpm11/deps/status/test/checkDepsStatus.test.ts
+++ b/pnpm11/deps/status/test/checkDepsStatus.test.ts
@@ -586,6 +586,27 @@ describe('checkDepsStatus - fingerprint', () => {
     expect(result.issue).toBe('The fingerprint returned by a pnpmfile has changed')
   })
 
+  it('returns upToDate: false when the fingerprint hook throws', async () => {
+    const mockWorkspaceState = makeWorkspaceState('fingerprint-before')
+    jest.mocked(loadWorkspaceState).mockReturnValue(mockWorkspaceState)
+
+    const opts: CheckDepsStatusOptions = {
+      rootProjectManifest: {},
+      rootProjectManifestDir: '/project',
+      pnpmfile: [],
+      hooks: {
+        calculateFingerprint: async () => {
+          throw new Error('fingerprint source unavailable')
+        },
+      },
+      ...mockWorkspaceState.settings,
+    }
+    const result = await checkDepsStatus(opts)
+
+    expect(result.upToDate).toBe(false)
+    expect(result.issue).toBe('The pnpmfile calculateFingerprint hook failed: fingerprint source unavailable')
+  })
+
   it('continues past the fingerprint check when the fingerprint is unchanged', async () => {
     const lastValidatedTimestamp = Date.now() - 10_000
     const beforeLastValidation = lastValidatedTimestamp - 10_000

--- a/pnpm11/hooks/pnpmfile/src/Hooks.ts
+++ b/pnpm11/hooks/pnpmfile/src/Hooks.ts
@@ -18,4 +18,19 @@ export interface Hooks {
   importPackage?: ImportIndexedPackageAsync
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Flexible hook signature for any config object
   updateConfig?: (config: any) => any
+  /**
+   * Returns a fingerprint of any external state that the pnpmfile's behavior
+   * depends on (for example, the state of a custom package source used by a
+   * custom resolver). The value is recorded in the workspace state file and
+   * compared by the up-to-date checks used by `verify-deps-before-run` and
+   * `optimistic-repeat-install`; when it changes, `node_modules` is
+   * considered outdated even if the lockfile and manifests are unchanged.
+   *
+   * The fingerprint is never written to the lockfile, so it may be
+   * machine-specific. The hook runs on every up-to-date check (before
+   * `pnpm run`/`pnpm exec` under `verify-deps-before-run`, and on repeat
+   * installs under `optimistic-repeat-install`) as well as after every
+   * install to record the value, so it should be cheap to compute.
+   */
+  calculateFingerprint?: () => string | Promise<string>
 }

--- a/pnpm11/hooks/pnpmfile/src/requireHooks.ts
+++ b/pnpm11/hooks/pnpmfile/src/requireHooks.ts
@@ -43,6 +43,7 @@ export interface CookedHooks {
   customResolvers?: CustomResolver[]
   customFetchers?: CustomFetcher[]
   calculatePnpmfileChecksum?: () => Promise<string>
+  calculateFingerprint?: () => Promise<string>
 }
 
 export interface RequireHooksResult {
@@ -144,6 +145,7 @@ export async function requireHooks (
 
   let importProvider: string | undefined
   const finderProviders: Record<string, string> = {}
+  const fingerprintHooks: Array<{ file: string, hook: Required<Hooks>['calculateFingerprint'] }> = []
 
   // process hooks in order
   for (const { hooks, file, finders } of entries) {
@@ -216,6 +218,23 @@ export async function requireHooks (
       }
       importProvider = file
       cookedHooks.importPackage = fileHooks.importPackage
+    }
+
+    // calculateFingerprint
+    if (fileHooks.calculateFingerprint) {
+      fingerprintHooks.push({ file, hook: fileHooks.calculateFingerprint })
+    }
+  }
+
+  if (fingerprintHooks.length > 0) {
+    // pnpmfiles are loaded concurrently, so the order of `entries` is not
+    // stable; sorting keeps the combined fingerprint deterministic.
+    fingerprintHooks.sort((a, b) => (a.file < b.file ? -1 : a.file > b.file ? 1 : 0))
+    cookedHooks.calculateFingerprint = async () => {
+      const fingerprints = await Promise.all(fingerprintHooks.map(({ hook }) => hook()))
+      // JSON keeps component boundaries unambiguous regardless of what
+      // characters the hook values contain.
+      return JSON.stringify(fingerprints)
     }
   }
 

--- a/pnpm11/hooks/pnpmfile/test/__fixtures__/fingerprintA.js
+++ b/pnpm11/hooks/pnpmfile/test/__fixtures__/fingerprintA.js
@@ -1,0 +1,5 @@
+module.exports = {
+  hooks: {
+    calculateFingerprint: () => 'fingerprint-a',
+  },
+}

--- a/pnpm11/hooks/pnpmfile/test/__fixtures__/fingerprintB.js
+++ b/pnpm11/hooks/pnpmfile/test/__fixtures__/fingerprintB.js
@@ -1,0 +1,5 @@
+module.exports = {
+  hooks: {
+    calculateFingerprint: async () => 'fingerprint-b',
+  },
+}

--- a/pnpm11/hooks/pnpmfile/test/index.ts
+++ b/pnpm11/hooks/pnpmfile/test/index.ts
@@ -125,6 +125,27 @@ test('ignores a missing default pnpmfile when asynchronous module hooks are regi
   })
 })
 
+test('calculateFingerprint is undefined when no pnpmfile provides it', async () => {
+  const pnpmfile = path.join(import.meta.dirname, '__fixtures__/readPackageNoObject.js')
+  const { hooks } = await requireHooks(import.meta.dirname, { pnpmfiles: [pnpmfile] })
+  expect(hooks.calculateFingerprint).toBeUndefined()
+})
+
+test('calculateFingerprint returns the fingerprint provided by a pnpmfile', async () => {
+  const pnpmfile = path.join(import.meta.dirname, '__fixtures__/fingerprintA.js')
+  const { hooks } = await requireHooks(import.meta.dirname, { pnpmfiles: [pnpmfile] })
+  expect(await hooks.calculateFingerprint?.()).toBe(JSON.stringify(['fingerprint-a']))
+})
+
+test('calculateFingerprint combines the fingerprints of all pnpmfiles that provide it', async () => {
+  const pnpmfileA = path.join(import.meta.dirname, '__fixtures__/fingerprintA.js')
+  const pnpmfileB = path.join(import.meta.dirname, '__fixtures__/fingerprintB.js')
+  // Passed in reverse order to verify the combined fingerprint is sorted by
+  // file path, not by load order.
+  const { hooks } = await requireHooks(import.meta.dirname, { pnpmfiles: [pnpmfileB, pnpmfileA] })
+  expect(await hooks.calculateFingerprint?.()).toBe(JSON.stringify(['fingerprint-a', 'fingerprint-b']))
+})
+
 test('calculatePnpmfileChecksum resolves to hash string for existing pnpmfile', async () => {
   const pnpmfile = path.join(import.meta.dirname, '__fixtures__/readPackageNoObject.js')
   const { hooks } = await requireHooks(import.meta.dirname, { pnpmfiles: [pnpmfile] })

--- a/pnpm11/installing/commands/src/installDeps.ts
+++ b/pnpm11/installing/commands/src/installDeps.ts
@@ -439,6 +439,7 @@ export async function installDeps (
         settings: withUpdatedCatalogs(opts, updatedCatalogs),
         workspaceDir: opts.workspaceDir ?? opts.lockfileDir ?? opts.dir,
         pnpmfiles: opts.pnpmfile,
+        fingerprint: await opts.hooks?.calculateFingerprint?.(),
         filteredInstall: allProjects.length !== Object.keys(opts.selectedProjectsGraph ?? {}).length,
         configDependencies: opts.configDependencies,
       })
@@ -521,6 +522,7 @@ export async function installDeps (
         settings: withUpdatedCatalogs(opts, updatedCatalogs),
         workspaceDir: opts.workspaceDir ?? opts.lockfileDir ?? opts.dir,
         pnpmfiles: opts.pnpmfile,
+        fingerprint: await opts.hooks?.calculateFingerprint?.(),
         filteredInstall: allProjects.length !== Object.keys(opts.selectedProjectsGraph ?? {}).length,
         configDependencies: opts.configDependencies,
       })
@@ -549,6 +551,7 @@ async function recursiveInstallThenUpdateWorkspaceState (
       settings: withUpdatedCatalogs(opts, updatedCatalogs, recursiveResult.updatedCatalogs),
       workspaceDir: opts.workspaceDir,
       pnpmfiles: opts.pnpmfile,
+      fingerprint: await opts.hooks?.calculateFingerprint?.(),
       filteredInstall: allProjects.length !== Object.keys(opts.selectedProjectsGraph ?? {}).length,
       configDependencies: opts.configDependencies,
     })

--- a/pnpm11/workspace/state/src/createWorkspaceState.ts
+++ b/pnpm11/workspace/state/src/createWorkspaceState.ts
@@ -6,6 +6,7 @@ import { type ProjectsList, WORKSPACE_STATE_SETTING_KEYS, type WorkspaceState, t
 export interface CreateWorkspaceStateOptions {
   allProjects: ProjectsList
   pnpmfiles: string[]
+  fingerprint?: string
   filteredInstall: boolean
   settings: WorkspaceStateSettings
   configDependencies?: ConfigDependencies
@@ -21,6 +22,7 @@ export const createWorkspaceState = (opts: CreateWorkspaceStateOptions): Workspa
     },
   ])),
   pnpmfiles: opts.pnpmfiles,
+  fingerprint: opts.fingerprint,
   settings: pick(WORKSPACE_STATE_SETTING_KEYS, opts.settings),
   filteredInstall: opts.filteredInstall,
   configDependencies: opts.configDependencies,

--- a/pnpm11/workspace/state/src/types.ts
+++ b/pnpm11/workspace/state/src/types.ts
@@ -10,6 +10,12 @@ export interface WorkspaceState {
     version?: string
   }>
   pnpmfiles: string[]
+  /**
+   * Fingerprint returned by the pnpmfiles' `calculateFingerprint` hooks at the
+   * time of the last install. May be machine-specific, which is why it lives
+   * here and not in the lockfile.
+   */
+  fingerprint?: string
   filteredInstall: boolean
   configDependencies?: ConfigDependencies
   settings: WorkspaceStateSettings

--- a/pnpm11/workspace/state/src/updateWorkspaceState.ts
+++ b/pnpm11/workspace/state/src/updateWorkspaceState.ts
@@ -14,6 +14,7 @@ export interface UpdateWorkspaceStateOptions {
   settings: WorkspaceStateSettings
   workspaceDir: string
   pnpmfiles: string[]
+  fingerprint?: string
   filteredInstall: boolean
   configDependencies?: ConfigDependencies
 }


### PR DESCRIPTION
## What

Adds a new pnpmfile hook, `calculateFingerprint`, that returns a fingerprint of any external state the pnpmfile's behavior depends on — for example, the state of a custom package source used by a custom resolver. The value is recorded in the workspace state file after installs and compared by `checkDepsStatus`, so the `verify-deps-before-run` and `optimistic-repeat-install` fast paths invalidate when it changes and a full install (including `shouldRefreshResolution` hooks) runs.

## Why

Follow-up to #9516 / #10995. The custom resolver API's `shouldRefreshResolution` hook exists for package sources where content can change behind an unchanged name@version, but both fast paths use `checkDepsStatus`, which only examines local files (manifests, lockfile, patches, pnpmfile mtimes). A pnpmfile whose hooks read external state can be *logically* changed while every local file is unchanged — so under the pnpm 11 defaults (`optimisticRepeatInstall: true`, `verifyDepsBeforeRun: install`), resolver-refresh users silently go stale, which #10995 could only warn about. Running `shouldRefreshResolution` per lockfile entry inside the fast path was rejected there as too expensive; this hook is the cheap alternative — one author-controlled value, one comparison.

## Design notes

- **Fingerprint, not a boolean "changed?":** only pnpm knows when an install actually succeeds, and the record must advance only then. A self-comparing hook would have to commit its own "last seen" state at check time — corrupting it when the triggered install fails, when `verifyDepsBeforeRun` is `warn`/`error`/declined `prompt`, or when two processes race. The recorded value advances only inside `updateWorkspaceState` after a successful install, like every other staleness input. The cost is that hooks must be deterministic for unchanged state.
- **Workspace state file, not the lockfile:** the value may be machine-specific (absolute paths, local mtimes), so it must never enter a committed file. This is also why the existing `pnpmfileChecksum` (lockfile-recorded content hash) can't carry it.
- Multiple pnpmfiles may define the hook; the cooked hook combines their values sorted by file path, since pnpmfiles load concurrently.
- The comparison sits early in `_checkDepsStatus` (after the settings/configDependencies checks, before any filesystem work) and only runs when a hook exists or a value was recorded, so projects without the hook pay nothing.

## Pacquet parity

Deliberately not ported. Pacquet does not run pnpmfiles, and its optimistic-repeat-install fast path is uniformly unaware of hook effects today (the `patchesOrHooksAreModified` port does not exist yet); guarding only this field would be an inconsistent slice of that pre-existing gap. The schema change is tolerated as-is: serde ignores the unknown `fingerprint` field on read, and if a pacquet install rewrites the state without it, pnpm sees the missing fingerprint on its next run, invalidates, and re-records — fail-safe in the extra-install direction, never toward staleness. Fast-path hook awareness for pacquet (this field plus pnpmfiles mtime checks) is proposed as follow-up.

## Testing

- `@pnpm/hooks.pnpmfile`: hook cooking — absent, single, and multiple pnpmfiles (passed in reverse order to prove the deterministic sort).
- `@pnpm/deps.status`: all four comparison edge cases (changed, newly appeared, removed, unchanged-continues-past).
- End-to-end against the rebuilt bundle: install records the fingerprint in the workspace state; repeat install short-circuits; a changed value forces a full install and re-records; `pnpm run` triggers the verify-deps install; `pnpm-lock.yaml` stays untouched throughout.

Docs PR: pnpm/pnpm.io#860.

---
Written by an agent (Kiro, claude-fable-5), directed and reviewed by @everett1992.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for calculating fingerprints from pnpm hooks to track external dependency resolution changes.
  - Fingerprints are saved with workspace state and evaluated during dependency freshness checks.
  - Supports multiple fingerprint sources with deterministic results and asynchronous calculation.

- **Bug Fixes**
  - Dependency checks now trigger a full install when the recorded fingerprint changes, is added, or removed.
  - Fingerprint calculation failures now clearly mark dependencies as outdated.

- **Documentation**
  - Documented the new fingerprint hook and its availability limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->