### PR TITLE
test(resolving-npm-resolver): fix sparse-tail mirror tests on Windows

### DIFF
--- a/pnpm/crates/lockfile/src/env_lockfile.rs
+++ b/pnpm/crates/lockfile/src/env_lockfile.rs
@@ -15,7 +15,7 @@
 use crate::{
     LoadLockfileError, Lockfile, PackageKey, PackageMetadata, SaveLockfileError, SnapshotEntry,
     extract_env_document, extract_main_document,
-    save_lockfile::{ensure_lockfile_is_not_symlink, symlinked_lockfile_error},
+    save_lockfile::ensure_lockfile_is_not_symlink,
     serialize_yaml,
     yaml_documents::{YAML_DOCUMENT_SEPARATOR, YAML_DOCUMENT_START},
 };
@@ -28,6 +28,8 @@ use std::{
     path::Path,
 };
 
+#[cfg(unix)]
+use crate::save_lockfile::symlinked_lockfile_error;
 #[cfg(unix)]
 use std::os::unix::fs::OpenOptionsExt as _;
 

--- a/pnpm/crates/resolving-npm-resolver/src/mirror/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/mirror/tests.rs
@@ -210,8 +210,6 @@ fn load_meta_past_the_hold_cap_ignores_a_sparse_tail() {
     let mirror = dir.path().join("acme.jsonl");
     let pkg = fixture_package();
     save_meta_indexed(&mirror, &pkg, None).expect("save");
-    // `write(true)`, not `append(true)`: Windows denies `set_len` on an
-    // append-only handle (`FILE_APPEND_DATA` without `FILE_WRITE_DATA`).
     let file = std::fs::OpenOptions::new().write(true).open(&mirror).expect("open");
     let size = file.metadata().expect("metadata").len();
     file.set_len(size + 64 * 1024 * 1024).expect("extend sparsely");

--- a/pnpm/crates/resolving-npm-resolver/src/mirror/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/mirror/tests.rs
@@ -210,7 +210,9 @@ fn load_meta_past_the_hold_cap_ignores_a_sparse_tail() {
     let mirror = dir.path().join("acme.jsonl");
     let pkg = fixture_package();
     save_meta_indexed(&mirror, &pkg, None).expect("save");
-    let file = std::fs::OpenOptions::new().append(true).open(&mirror).expect("open");
+    // `write(true)`, not `append(true)`: Windows denies `set_len` on an
+    // append-only handle (`FILE_APPEND_DATA` without `FILE_WRITE_DATA`).
+    let file = std::fs::OpenOptions::new().write(true).open(&mirror).expect("open");
     let size = file.metadata().expect("metadata").len();
     file.set_len(size + 64 * 1024 * 1024).expect("extend sparsely");
     let loaded = load_meta_with_hold_cap(&mirror, 0).expect("read full back without a handle");
@@ -232,7 +234,7 @@ fn load_meta_past_the_hold_cap_skips_a_sparse_gap_between_spans() {
     let contents =
         format!("pacquet-meta-v1 {} {}\n{headers}{index}{fragment}", headers.len(), index.len());
     std::fs::write(&mirror, &contents).expect("write");
-    let file = std::fs::OpenOptions::new().append(true).open(&mirror).expect("open");
+    let file = std::fs::OpenOptions::new().write(true).open(&mirror).expect("open");
     file.set_len(contents.len() as u64 + far_offset + 16).expect("extend sparsely");
     let loaded = load_meta_with_hold_cap(&mirror, 0).expect("read full back without a handle");
     let manifest = loaded.versions.get("1.0.0").expect("hydrate the near fragment");
@@ -259,7 +261,7 @@ fn load_meta_treats_an_oversized_fragment_span_as_absent() {
     std::fs::write(&mirror, &contents).expect("write");
     // A sparse tail makes the file size cover the declared span
     // without paying for the bytes, like a corrupt mirror would.
-    let file = std::fs::OpenOptions::new().append(true).open(&mirror).expect("open");
+    let file = std::fs::OpenOptions::new().write(true).open(&mirror).expect("open");
     file.set_len(contents.len() as u64 + 64 * 1024 * 1024).expect("extend sparsely");
     let loaded = load_meta(&mirror).expect("read full back");
     assert!(loaded.versions.get("9.9.9").is_none(), "oversized span must read as absent");


### PR DESCRIPTION
## Summary

Fixes the Windows Rust CI failure on `main` introduced by the mirror-file packument cache ([example failing run](https://github.com/pnpm/pnpm/actions/runs/31160830557/job/92810600356)).

`mirror::tests::load_meta_past_the_hold_cap_ignores_a_sparse_tail` fails on Windows with `PermissionDenied: Access is denied` at the `set_len` call. The sparse-tail tests open the mirror with `append(true)` and then call `set_len` to extend it, but Windows opens append-only handles with `FILE_APPEND_DATA` and no `FILE_WRITE_DATA`, and `SetEndOfFile` (which backs `set_len`) requires write access. The two sibling tests using the same pattern would have failed next once fail-fast let them run. A plain `write(true)` handle satisfies `set_len` on every platform and does not truncate.

Also gates the `symlinked_lockfile_error` import in `env_lockfile.rs` to `#[cfg(unix)]` — it is only called from the unix-only `ELOOP` normalization path, so Windows builds emitted an unused-import warning (visible in the same CI log).

## Squash Commit Body

```text
The sparse-tail mirror tests opened the mirror file with append(true) and
then called set_len to extend it. Windows opens append-only handles with
FILE_APPEND_DATA but not FILE_WRITE_DATA, and SetEndOfFile (which backs
set_len) requires write access, so set_len failed with PermissionDenied
and the Windows CI test job failed. A plain write(true) handle satisfies
set_len on every platform and does not truncate the file.

Also gate the symlinked_lockfile_error import in env_lockfile.rs to
cfg(unix): it is only called from the unix-only ELOOP normalization
path, so the ungated import raised an unused-import warning on Windows
builds.
```

## Checklist

- [x] The change is Rust-test-only; the TypeScript CLI has no counterpart to port.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13691"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788683941&installation_model_id=426870&pr_number=13691&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13691&signature=8e5da7609d8d284609b4f754992bfa3f732c4d3b1e052c5a5031c8a0e701b69d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform lockfile handling.
  * Fixed sparse-file mirror tests to reliably preserve expected file behavior when extending files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->