### PR TITLE
perf(resolver): defer peer-issue parent-chain materialization

### DIFF
--- a/.changeset/tidy-hoops-shine.md
+++ b/.changeset/tidy-hoops-shine.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Reduced peak memory usage and allocation churn during peer dependency resolution: peer-dependency issues now keep a cheap shared handle to their parent chain instead of a materialized copy per occurrence [#13681](https://github.com/pnpm/pnpm/issues/13681).
+Reduced peak memory usage and allocation churn during peer dependency resolution on workspaces with many peer-dependency issue occurrences [#13681](https://github.com/pnpm/pnpm/issues/13681).

--- a/.changeset/tidy-hoops-shine.md
+++ b/.changeset/tidy-hoops-shine.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Reduced peak memory usage and allocation churn during peer dependency resolution: peer-dependency issues now keep a cheap shared handle to their parent chain instead of a materialized copy per occurrence [#13681](https://github.com/pnpm/pnpm/issues/13681).

--- a/pnpm/crates/napi/src/install.rs
+++ b/pnpm/crates/napi/src/install.rs
@@ -991,7 +991,7 @@ fn peer_issues_to_json(
     let parents_json = |parents: &pacquet_resolving_deps_resolver::ParentChain| {
         parents
             .to_refs()
-            .iter()
+            .into_iter()
             .map(|parent| serde_json::json!({ "name": parent.name, "version": parent.version }))
             .collect::<Vec<_>>()
     };

--- a/pnpm/crates/napi/src/install.rs
+++ b/pnpm/crates/napi/src/install.rs
@@ -988,8 +988,9 @@ fn run_peer_issues_blocking(options: &serde_json::Value) -> napi::Result<serde_j
 fn peer_issues_to_json(
     issues: &pacquet_resolving_deps_resolver::PeerDependencyIssues,
 ) -> serde_json::Value {
-    let parents_json = |parents: &[pacquet_resolving_deps_resolver::ParentPackageRef]| {
+    let parents_json = |parents: &pacquet_resolving_deps_resolver::ParentChain| {
         parents
+            .to_refs()
             .iter()
             .map(|parent| serde_json::json!({ "name": parent.name, "version": parent.version }))
             .collect::<Vec<_>>()

--- a/pnpm/crates/napi/src/install/tests.rs
+++ b/pnpm/crates/napi/src/install/tests.rs
@@ -681,7 +681,9 @@ fn safe_intersect_matches_merge_peers_semantics() {
 /// missing ranges, and disjoint ranges surfacing under `conflicts`.
 #[test]
 fn peer_issues_to_json_derives_conflicts_and_intersections() {
-    use pacquet_resolving_deps_resolver::{MissingPeer, ParentChain, PeerDependencyIssues};
+    use pacquet_resolving_deps_resolver::{
+        MissingPeer, ParentChain, PeerDependencyIssue, PeerDependencyIssues,
+    };
 
     let missing_entry = |range: &str, optional: bool| MissingPeer {
         wanted_range: range.to_string(),
@@ -696,6 +698,20 @@ fn peer_issues_to_json_derives_conflicts_and_intersections() {
         vec![missing_entry("^1.0.0", false), missing_entry("^2.0.0", false)],
     );
     issues.missing.insert("optional-only".to_string(), vec![missing_entry("*", true)]);
+    issues.bad.insert(
+        "styled".to_string(),
+        vec![PeerDependencyIssue {
+            wanted_range: "^5.0.0".to_string(),
+            found_version: "4.1.0".to_string(),
+            optional: false,
+            parents: ParentChain::from_names([
+                "root".to_string(),
+                "mid".to_string(),
+                "leaf".to_string(),
+            ]),
+            resolved_from: ParentChain::from_names(["provider".to_string()]),
+        }],
+    );
 
     let json = super::peer_issues_to_json(&issues);
     assert_eq!(json["intersections"]["react"], "^16.8.0");
@@ -703,5 +719,17 @@ fn peer_issues_to_json_derives_conflicts_and_intersections() {
     assert!(json["intersections"].get("optional-only").is_none());
     assert_eq!(json["missing"]["react"][0]["wantedRange"], "^16.8.0");
     assert_eq!(json["missing"]["react"][0]["parents"][0]["name"], "comp1");
-    assert_eq!(json["bad"], serde_json::json!({}));
+    assert_eq!(
+        json["bad"]["styled"][0]["parents"],
+        serde_json::json!([
+            { "name": "root", "version": "" },
+            { "name": "mid", "version": "" },
+            { "name": "leaf", "version": "" },
+        ]),
+    );
+    assert_eq!(
+        json["bad"]["styled"][0]["resolvedFrom"],
+        serde_json::json!([{ "name": "provider", "version": "" }]),
+    );
+    assert_eq!(json["bad"]["styled"][0]["foundVersion"], "4.1.0");
 }

--- a/pnpm/crates/napi/src/install/tests.rs
+++ b/pnpm/crates/napi/src/install/tests.rs
@@ -681,14 +681,13 @@ fn safe_intersect_matches_merge_peers_semantics() {
 /// missing ranges, and disjoint ranges surfacing under `conflicts`.
 #[test]
 fn peer_issues_to_json_derives_conflicts_and_intersections() {
-    use pacquet_resolving_deps_resolver::{MissingPeer, ParentPackageRef, PeerDependencyIssues};
+    use pacquet_resolving_deps_resolver::{MissingPeer, ParentChain, PeerDependencyIssues};
 
-    let parent = ParentPackageRef { name: "comp1".to_string(), version: "1.0.0".to_string() };
     let missing_entry = |range: &str, optional: bool| MissingPeer {
         wanted_range: range.to_string(),
         raw_range: range.to_string(),
         optional,
-        parents: vec![parent.clone()],
+        parents: ParentChain::from_names(["comp1".to_string()]),
     };
     let mut issues = PeerDependencyIssues::default();
     issues.missing.insert("react".to_string(), vec![missing_entry("^16.8.0", false)]);

--- a/pnpm/crates/resolving-deps-resolver/src/dependencies_graph.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/dependencies_graph.rs
@@ -4,7 +4,7 @@ use pacquet_deps_path::DepPath;
 use pacquet_resolving_resolver_base::ResolveResult;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
-use crate::resolved_tree::PeerDep;
+use crate::{resolve_peers::SharedChain, resolved_tree::PeerDep};
 
 /// Post-peer-resolution graph keyed by depPath.
 ///
@@ -84,9 +84,9 @@ pub struct MissingPeer {
     /// source.
     pub raw_range: String,
     pub optional: bool,
-    /// Chain of `(name, version)` from the root importer down to the
-    /// parent that declared the peer requirement.
-    pub parents: Vec<ParentPackageRef>,
+    /// Chain from the root importer down to the parent that declared
+    /// the peer requirement.
+    pub parents: ParentChain,
 }
 
 /// One bad-peer entry, keyed by peer name in
@@ -96,11 +96,59 @@ pub struct PeerDependencyIssue {
     pub wanted_range: String,
     pub found_version: String,
     pub optional: bool,
-    pub parents: Vec<ParentPackageRef>,
+    pub parents: ParentChain,
     /// Chain that brought the bad candidate into scope — `parents`
     /// describes who requires the peer; this describes where the bad
     /// version was found.
-    pub resolved_from: Vec<ParentPackageRef>,
+    pub resolved_from: ParentChain,
+}
+
+/// Ancestor chain attached to a peer issue. Holds a handle to the
+/// walker's shared parent chain — an O(1) clone of an `Arc` linked
+/// list — instead of a materialized vector: issues are recorded per
+/// occurrence (tens of thousands on large auto-install-peers graphs)
+/// and most are never rendered, so the names are cloned out only when
+/// a consumer calls [`Self::to_refs`].
+#[derive(Clone, Default)]
+pub struct ParentChain(pub(crate) SharedChain<String>);
+
+impl ParentChain {
+    /// Build a chain from names given root importer first.
+    #[must_use]
+    pub fn from_names(names: impl IntoIterator<Item = String>) -> Self {
+        let mut chain = SharedChain::default();
+        for name in names {
+            chain = chain.pushed(name);
+        }
+        ParentChain(chain)
+    }
+
+    /// Materialize the chain, root importer first. `version` is empty
+    /// today: the chain pacquet tracks is name-only — populating it
+    /// would need a parallel version chain or a re-lookup against the
+    /// tree, and the issue renderer consumes the names primarily.
+    #[must_use]
+    pub fn to_refs(&self) -> Vec<ParentPackageRef> {
+        self.0
+            .to_root_vec()
+            .into_iter()
+            .map(|name| ParentPackageRef { name, version: String::new() })
+            .collect()
+    }
+}
+
+impl PartialEq for ParentChain {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.iter().eq(other.0.iter())
+    }
+}
+
+impl Eq for ParentChain {}
+
+impl std::fmt::Debug for ParentChain {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_list().entries(self.0.to_root_vec()).finish()
+    }
 }
 
 /// One `(name, version)` link in the chain returned with each peer

--- a/pnpm/crates/resolving-deps-resolver/src/dependencies_graph.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/dependencies_graph.rs
@@ -103,12 +103,9 @@ pub struct PeerDependencyIssue {
     pub resolved_from: ParentChain,
 }
 
-/// Ancestor chain attached to a peer issue. Holds a handle to the
-/// walker's shared parent chain — an O(1) clone of an `Arc` linked
-/// list — instead of a materialized vector: issues are recorded per
-/// occurrence (tens of thousands on large auto-install-peers graphs)
-/// and most are never rendered, so the names are cloned out only when
-/// a consumer calls [`Self::to_refs`].
+/// Ancestor chain attached to a peer issue. Cheap to clone and to
+/// record per occurrence; the names are cloned out only when a
+/// consumer materializes the chain via [`Self::to_refs`].
 #[derive(Default, Clone)]
 pub struct ParentChain(pub(crate) SharedChain<String>);
 

--- a/pnpm/crates/resolving-deps-resolver/src/dependencies_graph.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/dependencies_graph.rs
@@ -109,7 +109,7 @@ pub struct PeerDependencyIssue {
 /// occurrence (tens of thousands on large auto-install-peers graphs)
 /// and most are never rendered, so the names are cloned out only when
 /// a consumer calls [`Self::to_refs`].
-#[derive(Clone, Default)]
+#[derive(Default, Clone)]
 pub struct ParentChain(pub(crate) SharedChain<String>);
 
 impl ParentChain {

--- a/pnpm/crates/resolving-deps-resolver/src/lib.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/lib.rs
@@ -81,8 +81,8 @@ mod resolved_tree;
 mod validate_dependency_alias;
 
 pub use dependencies_graph::{
-    DependenciesGraph, DependenciesGraphNode, MissingPeer, ParentPackageRef, PeerDependencyIssue,
-    PeerDependencyIssues,
+    DependenciesGraph, DependenciesGraphNode, MissingPeer, ParentChain, ParentPackageRef,
+    PeerDependencyIssue, PeerDependencyIssues,
 };
 pub use hoist_peers::{
     DependencyOverrider, HoistPeersOptions, MissingPeerInfo, WorkspaceRootDep,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -43,9 +43,8 @@ use crate::{
     node_id::NodeId,
     resolved_tree::{DirectDep, ResolvedTree},
 };
-use context::{
-    ChainSuffixMemo, CurrentProviderSource, SharedChain, importer_relative_link_dep_path,
-};
+pub(crate) use context::SharedChain;
+use context::{ChainSuffixMemo, CurrentProviderSource, importer_relative_link_dep_path};
 use discovery::PeerDiscoveryCaches;
 pub(crate) use discovery::{PeerDiscoveryResult, PeerHoistDiscovery, apply_hoist_missing_scope};
 use pacquet_deps_path::DepPath;

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/cache.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/cache.rs
@@ -7,7 +7,7 @@ use crate::{
     dependencies_graph::MissingPeer,
     node_id::NodeId,
     resolve_peers::{
-        context::{ParentPkgInfo, ParentRef, ParentRefs, SharedChain, pkg_name_version},
+        context::{ParentPkgInfo, ParentRef, ParentRefs, SharedChain},
         walker::{MissingPeerInfo, NodeOutput, SubtreeMissingByPkg, Walker},
     },
     resolved_tree::{AncestorIds, ChildEdge, DependenciesTreeNode, TreeChildren},
@@ -375,8 +375,7 @@ impl Walker<'_> {
 
         if !output.missing_peers.is_empty() {
             let pkg_id = self.tree.dependencies_tree[node_id].resolved_package_id.clone();
-            let chain_with_self = parent_pkg_ids_chain.pushed(pkg_id.clone());
-            let pkg_name = pkg_name_version(&self.tree.packages[&pkg_id].result).0;
+            let chain_with_self = parent_pkg_ids_chain.pushed(pkg_id);
             for (peer_name, info) in output.missing_peers.iter() {
                 if self.missing_issue_suppressed(&chain_with_self, peer_name) {
                     continue;
@@ -387,7 +386,7 @@ impl Walker<'_> {
                         wanted_range: get_peer_version_range(&info.range),
                         raw_range: info.range.clone(),
                         optional: info.optional,
-                        parents: self.issue_parents(parent_chain_names, &pkg_name),
+                        parents: self.issue_parents(parent_chain_names),
                     },
                     &chain_with_self,
                 );

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/context.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/context.rs
@@ -3,7 +3,6 @@
 //! node-id remapping, peer-suffix parsing, and range matching.
 
 use crate::{
-    dependencies_graph::ParentPackageRef,
     node_id::NodeId,
     resolve_peers::{ResolvePeersOptions, walker::Walker},
     resolved_tree::{ResolvedPackage, TreeChildren},
@@ -62,7 +61,7 @@ pub(super) struct ParentPkgInfo {
 }
 
 #[derive(Debug, Clone)]
-pub(super) struct SharedChain<Element>(Option<Arc<SharedChainLink<Element>>>);
+pub(crate) struct SharedChain<Element>(Option<Arc<SharedChainLink<Element>>>);
 
 #[derive(Debug)]
 struct SharedChainLink<Element> {
@@ -77,11 +76,11 @@ impl<Element> Default for SharedChain<Element> {
 }
 
 impl<Element> SharedChain<Element> {
-    pub(super) fn pushed(&self, value: Element) -> Self {
+    pub(crate) fn pushed(&self, value: Element) -> Self {
         SharedChain(Some(Arc::new(SharedChainLink { value, parent: self.0.clone() })))
     }
 
-    pub(super) fn iter(&self) -> SharedChainIter<'_, Element> {
+    pub(crate) fn iter(&self) -> SharedChainIter<'_, Element> {
         SharedChainIter { next: self.0.as_deref() }
     }
 }
@@ -150,14 +149,14 @@ fn link_key<Element>(link: &Arc<SharedChainLink<Element>>) -> usize {
 }
 
 impl<Element: Clone> SharedChain<Element> {
-    fn to_root_vec(&self) -> Vec<Element> {
+    pub(crate) fn to_root_vec(&self) -> Vec<Element> {
         let mut values: Vec<Element> = self.iter().cloned().collect();
         values.reverse();
         values
     }
 }
 
-pub(super) struct SharedChainIter<'a, Element> {
+pub(crate) struct SharedChainIter<'a, Element> {
     next: Option<&'a SharedChainLink<Element>>,
 }
 
@@ -541,24 +540,6 @@ fn named_registry_of(result: &ResolveResult) -> Option<&str> {
     let (registry_name, _) =
         pacquet_deps_path::parse_registry_qualified_version(id.get(at + 1..)?)?;
     Some(registry_name)
-}
-
-/// Build the `parents` chain attached to a peer issue. Records just
-/// `name` and `version` per parent, which is what the renderer
-/// downstream consumes.
-pub(super) fn parents_from_chain(
-    chain_names: &SharedChain<String>,
-    _pkg_name: &str,
-) -> Vec<ParentPackageRef> {
-    // The chain pacquet tracks today is name-only — populating
-    // `version` would need a parallel `Vec<String>` of versions or a
-    // re-lookup against the tree. The issue-renderer consumes the
-    // names primarily; expanding to versions is a follow-up.
-    chain_names
-        .to_root_vec()
-        .into_iter()
-        .map(|name| ParentPackageRef { name, version: String::new() })
-        .collect()
 }
 
 pub(super) fn peer_segment_names(dep_path: &DepPath) -> Option<Vec<String>> {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     dependencies_graph::{
-        DependenciesGraph, MissingPeer, ParentPackageRef, PeerDependencyIssue, PeerDependencyIssues,
+        DependenciesGraph, MissingPeer, ParentChain, PeerDependencyIssue, PeerDependencyIssues,
     },
     node_id::NodeId,
     resolve_peers::{
@@ -17,8 +17,8 @@ use crate::{
         context::{
             CurrentProviderSource, ParentPkgInfo, ParentRef, ParentRefs, SharedChain,
             importer_relative_link_dep_path, insert_parent_ref, link_node_id_as_dep_path,
-            parents_from_chain, peer_id_pair, pkg_name_version, remap_link_node_id,
-            satisfies_with_prereleases, scoped_hoisted_optional_parent_refs,
+            peer_id_pair, pkg_name_version, remap_link_node_id, satisfies_with_prereleases,
+            scoped_hoisted_optional_parent_refs,
         },
         discovery::PeerDiscoveryCaches,
         finalize::{NodeRecord, PendingPeerEdge, WalkedNode},
@@ -994,7 +994,6 @@ impl Walker<'_> {
         let mut own_missing: HashMap<String, MissingPeerInfo> = HashMap::default();
         for (peer_name, peer_dep) in &pkg.peer_dependencies {
             self.resolve_one_peer(
-                pkg_name,
                 peer_name,
                 peer_dep,
                 parent_refs,
@@ -1198,12 +1197,8 @@ impl Walker<'_> {
         }
     }
 
-    pub(super) fn issue_parents(
-        &self,
-        chain: &SharedChain<String>,
-        pkg_name: &str,
-    ) -> Vec<ParentPackageRef> {
-        if self.discovery { Vec::new() } else { parents_from_chain(chain, pkg_name) }
+    pub(super) fn issue_parents(&self, chain: &SharedChain<String>) -> ParentChain {
+        if self.discovery { ParentChain::default() } else { ParentChain(chain.clone()) }
     }
 
     #[expect(
@@ -1212,7 +1207,6 @@ impl Walker<'_> {
     )]
     fn resolve_one_peer(
         &mut self,
-        pkg_name: &str,
         peer_name: &str,
         peer_dep: &PeerDep,
         parent_refs: &ParentRefs,
@@ -1244,7 +1238,7 @@ impl Walker<'_> {
                             wanted_range: range_for_satisfies,
                             raw_range: range_for_match.to_string(),
                             optional,
-                            parents: self.issue_parents(chain, pkg_name),
+                            parents: self.issue_parents(chain),
                         },
                         ancestor_pkg_ids,
                     );
@@ -1252,14 +1246,14 @@ impl Walker<'_> {
             }
             Some(parent) => {
                 if !satisfies_with_prereleases(&parent.version, &range_for_satisfies) {
-                    let parents = self.issue_parents(chain, pkg_name);
+                    let parents = self.issue_parents(chain);
                     self.issues.bad.entry(peer_name.to_string()).or_default().push(
                         PeerDependencyIssue {
                             wanted_range: range_for_satisfies,
                             found_version: parent.version.clone(),
                             optional,
                             parents,
-                            resolved_from: Vec::new(),
+                            resolved_from: ParentChain::default(),
                         },
                     );
                 }


### PR DESCRIPTION
## Summary

Related to pnpm/pnpm#13681 (the peer-discovery share of the remaining resolution-phase memory).

The peer walker recorded a materialized `Vec<ParentPackageRef>` — the full ancestor chain, with every name string cloned — on every peer-dependency issue occurrence. On large `autoInstallPeers` graphs that is tens of thousands of vectors and millions of cloned strings (dhat: 155 MB of vectors + 54 MB of strings + 19 MB on the non-cache path, all still live at the heap peak), and almost none of it is ever read: the CLI issue renderer reads counts only today, and the napi issues API is a separate call.

This PR introduces `ParentChain`, an O(1)-clone handle to the walker's shared ancestor chain (`Arc` linked list), and stores that on `MissingPeer` / `PeerDependencyIssue` instead. Names are cloned out only when a consumer calls `ParentChain::to_refs()` — today that's the napi `get_peer_dependency_issues` JSON serialization, after the walk state has been dropped. A normal install never materializes at all.

Measured on the pnpm/pnpm#13681 single-importer repro (`@teambit/bit@2.0.67`, 3.8k packages, warm offline `--lockfile-only` resolve):

- peak live heap (dhat t-gmax): 933 MB → 808 MB
- max RSS: 1.28 GB → 1.22 GB
- wall: ~4.8 s → ~4.4 s (~8%, from ~3.4M fewer allocations)
- lockfile output byte-identical; JSON shape of the napi issues API unchanged

## Squash Commit Body

```text
Peer-dependency issues recorded a materialized Vec<ParentPackageRef> of
the full ancestor chain per occurrence — tens of thousands of vectors
and millions of cloned name strings on large autoInstallPeers graphs,
all alive for the rest of the resolve and almost never rendered (the
CLI issue renderer reads counts only, and the napi issues API is a
separate call).

Issues now hold ParentChain, an O(1)-clone handle to the walker's
shared ancestor chain, and clone the names out only when a consumer
materializes them via ParentChain::to_refs.

On the pnpm/pnpm#13681 single-importer repro (warm offline
lockfile-only resolve, 3.8k packages): peak live heap 933 MB -> 808 MB
(dhat), max RSS 1.28 GB -> 1.22 GB, wall 4.8 s -> 4.4 s, ~3.4M fewer
allocations. Lockfile output is byte-identical.

Related to pnpm/pnpm#13681.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. *(Rust-only:
  this changes pacquet's internal issue representation; the TypeScript CLI's
  issue objects are plain JS references with no equivalent per-occurrence
  clone cost, and the observable surface — lockfile and issues JSON — is
  unchanged.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests. *(Existing coverage: 308 resolver + 39 napi
  tests pass unchanged; the napi wire-shape test now builds the chain via the
  new `ParentChain::from_names`.)*

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13695"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788688813&installation_model_id=426870&pr_number=13695&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13695&signature=7f2dbdd7bf2e49388536a944d4de46c4fe93d4b258e3cb8dacdb804babe92a88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced peak memory usage and allocation overhead during peer dependency resolution in large workspaces.
  * Improved efficiency when tracking dependency ancestry for peer dependency issues.

* **Bug Fixes**
  * Improved serialization and reporting of missing and conflicting peer dependency paths.
  * Preserved accurate parent package and resolution-source information in peer dependency diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->