### PR TITLE
perf(lockfile): drop removed dependencies without resolving

### DIFF
--- a/.changeset/drop-removed-dependencies-without-resolving.md
+++ b/.changeset/drop-removed-dependencies-without-resolving.md
@@ -4,4 +4,4 @@
 "pnpm": patch
 ---
 
-Removing a dependency from `package.json` and reinstalling no longer re-resolves the dependency graph. The importer's entry is dropped from `pnpm-lock.yaml` and anything it made unreachable is pruned, which needs no registry access. Installs still fall back to a full resolution when another package resolves a peer dependency through the removed one, since that would change the dependent's entry rather than only prune.
+Removing a dependency from `package.json` and reinstalling no longer re-resolves the dependency graph. The importer's entry is dropped from `pnpm-lock.yaml`, anything it made unreachable is pruned, and a catalog entry that loses its last referent is removed — all without registry access. Installs still fall back to a full resolution when a package that stays resolves a peer dependency through the removed one, since that would change the surviving package's entry rather than only prune.

--- a/.changeset/drop-removed-dependencies-without-resolving.md
+++ b/.changeset/drop-removed-dependencies-without-resolving.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.deps-installer": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+Removing a dependency from `package.json` and reinstalling no longer re-resolves the dependency graph. The importer's entry is dropped from `pnpm-lock.yaml` and anything it made unreachable is pruned, which needs no registry access. Installs still fall back to a full resolution when another package resolves a peer dependency through the removed one, since that would change the dependent's entry rather than only prune.

--- a/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
@@ -1048,3 +1048,73 @@ fn generated_by_install(workspace: &Path) -> String {
     )
     .expect("read the file the install script generates")
 }
+
+#[test]
+fn dropping_a_dependency_from_the_manifest_skips_resolution() {
+    let CommandTempCwd { workspace, root, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, npmrc_path, .. } = npmrc_info;
+    let manifest_path = workspace.join("package.json");
+    fs::write(
+        &manifest_path,
+        serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pkg-with-1-dep": "100.0.0",
+                "is-positive": "1.0.0"
+            }
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    fs::write(&workspace_yaml_path, format!("{workspace_yaml}trustLockfile: true\n"))
+        .expect("enable trusted lockfile");
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    fs::write(
+        &manifest_path,
+        serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pkg-with-1-dep": "100.0.0"
+            }
+        })
+        .to_string(),
+    )
+    .expect("drop is-positive from package.json");
+    let dead_registry = dead_registry_url();
+    let live_npmrc = fs::read_to_string(&npmrc_path).expect("read .npmrc");
+    let dead_npmrc = live_npmrc
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("registry="))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(&npmrc_path, format!("registry={dead_registry}\n{dead_npmrc}\n"))
+        .expect("rewrite .npmrc with a dead registry");
+
+    let assert = pacquet_at(&workspace).with_arg("install").assert().success();
+    assert!(
+        String::from_utf8_lossy(&assert.get_output().stdout)
+            .contains("Lockfile is up to date, resolution step is skipped"),
+        "dropping an importer edge needs no resolution",
+    );
+    let wanted = pacquet_lockfile::Lockfile::load_wanted_from_dir(&workspace)
+        .expect("load updated wanted lockfile")
+        .expect("updated wanted lockfile");
+    assert!(
+        !wanted
+            .packages
+            .as_ref()
+            .expect("packages")
+            .keys()
+            .any(|key| key.to_string().starts_with("is-positive@")),
+        "the dropped package is pruned from the lockfile",
+    );
+    assert!(
+        !workspace.join("node_modules").join("is-positive").exists(),
+        "and unlinked from node_modules",
+    );
+
+    drop((root, mock_instance));
+}

--- a/pnpm/crates/package-manager/src/fast_update_catalog_versions.rs
+++ b/pnpm/crates/package-manager/src/fast_update_catalog_versions.rs
@@ -90,11 +90,6 @@ fn catalog_entry_is_sole_reference(
     catalog_name: &str,
     name: &PkgName,
 ) -> bool {
-    let protocol = if catalog_name == "default" {
-        "catalog:".to_string()
-    } else {
-        format!("catalog:{catalog_name}")
-    };
     let importers_agree = lockfile.importers.values().all(|importer| {
         [
             importer.dependencies.as_ref(),
@@ -104,7 +99,10 @@ fn catalog_entry_is_sole_reference(
         .into_iter()
         .flatten()
         .all(|dependencies| {
-            dependencies.get(name).is_none_or(|dependency| dependency.specifier == protocol)
+            dependencies.get(name).is_none_or(|dependency| {
+                pacquet_catalogs_protocol_parser::parse_catalog_protocol(&dependency.specifier)
+                    == Some(catalog_name)
+            })
         })
     });
     let no_package_depends_on_it = lockfile.snapshots.as_ref().is_none_or(|snapshots| {

--- a/pnpm/crates/package-manager/src/fast_update_catalogs.rs
+++ b/pnpm/crates/package-manager/src/fast_update_catalogs.rs
@@ -102,7 +102,11 @@ pub(crate) fn catalog_references_have_snapshots(lockfile: &Lockfile, catalogs: &
     })
 }
 
-fn catalog_entry_is_referenced(lockfile: &Lockfile, catalog_name: &str, alias: &str) -> bool {
+pub(crate) fn catalog_entry_is_referenced(
+    lockfile: &Lockfile,
+    catalog_name: &str,
+    alias: &str,
+) -> bool {
     let Ok(alias) = PkgName::parse(alias) else { return true };
     let protocol = if catalog_name == "default" {
         "catalog:".to_string()

--- a/pnpm/crates/package-manager/src/fast_update_catalogs.rs
+++ b/pnpm/crates/package-manager/src/fast_update_catalogs.rs
@@ -108,11 +108,8 @@ pub(crate) fn catalog_entry_is_referenced(
     alias: &str,
 ) -> bool {
     let Ok(alias) = PkgName::parse(alias) else { return true };
-    let protocol = if catalog_name == "default" {
-        "catalog:".to_string()
-    } else {
-        format!("catalog:{catalog_name}")
-    };
+    // Parsed rather than compared to a rebuilt protocol string, so the
+    // `catalog:default` spelling of the default catalog counts too.
     lockfile.importers.values().any(|importer| {
         [
             importer.dependencies.as_ref(),
@@ -122,7 +119,10 @@ pub(crate) fn catalog_entry_is_referenced(
         .into_iter()
         .flatten()
         .any(|dependencies| {
-            dependencies.get(&alias).is_some_and(|dependency| dependency.specifier == protocol)
+            dependencies.get(&alias).is_some_and(|dependency| {
+                pacquet_catalogs_protocol_parser::parse_catalog_protocol(&dependency.specifier)
+                    == Some(catalog_name)
+            })
         })
     })
 }

--- a/pnpm/crates/package-manager/src/fast_update_ignored_optional_dependencies.rs
+++ b/pnpm/crates/package-manager/src/fast_update_ignored_optional_dependencies.rs
@@ -50,6 +50,7 @@ pub(crate) fn try_fast_update_ignored_optional_dependencies(
     }
     candidate.ignored_optional_dependencies = Some(current.into_iter().collect());
     crate::fast_update_lockfile::prune_unreachable_packages(&mut candidate);
+    crate::fast_update_lockfile::prune_unreferenced_catalog_entries(&mut candidate);
     Some(candidate)
 }
 

--- a/pnpm/crates/package-manager/src/fast_update_ignored_optional_dependencies/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_ignored_optional_dependencies/tests.rs
@@ -141,3 +141,40 @@ importers: {}
         Some(["unused".to_string()].as_slice()),
     );
 }
+
+/// The ignored optional dependency is the only referent of its catalog
+/// entry, so the entry goes with it.
+#[test]
+fn prunes_a_catalog_entry_its_last_referent_was_ignored() {
+    let lockfile: Lockfile = serde_saphyr::from_str(
+        r"
+lockfileVersion: '9.0'
+catalogs:
+  default:
+    is-positive:
+      specifier: ^1.0.0
+      version: 1.0.0
+importers:
+  .:
+    specifiers:
+      is-positive: 'catalog:'
+    optionalDependencies:
+      is-positive:
+        specifier: 'catalog:'
+        version: 1.0.0
+packages:
+  is-positive@1.0.0:
+    resolution:
+      integrity: sha512-pos
+snapshots:
+  is-positive@1.0.0: {}
+",
+    )
+    .expect("parse lockfile");
+
+    let updated =
+        try_fast_update_ignored_optional_dependencies(&lockfile, &["is-positive".to_string()])
+            .expect("ignoring the sole referent needs no resolution");
+
+    assert!(updated.catalogs.is_none(), "the orphaned catalog entry goes with its referent");
+}

--- a/pnpm/crates/package-manager/src/fast_update_importers.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers.rs
@@ -1,7 +1,7 @@
 use node_semver::Range;
 use pacquet_lockfile::{Lockfile, PkgName, ProjectSnapshot, ResolvedDependencySpec};
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 pub(crate) fn try_fast_update_importers(
     lockfile: &Lockfile,
@@ -9,15 +9,16 @@ pub(crate) fn try_fast_update_importers(
 ) -> Option<Lockfile> {
     let mut candidate = lockfile.clone();
     let mut changed = false;
+    let mut dropped = HashSet::new();
     for (importer_id, manifest) in manifests {
         let importer = candidate.importers.get_mut(importer_id)?;
         let manifest_specifiers = manifest
             .dependencies([DependencyGroup::Dev, DependencyGroup::Prod, DependencyGroup::Optional])
             .collect::<HashMap<_, _>>();
-        for (alias, specifier) in manifest_specifiers {
-            let alias = PkgName::parse(alias).ok()?;
+        for (alias, specifier) in &manifest_specifiers {
+            let alias = PkgName::parse(*alias).ok()?;
             let dependency = importer_dependency_mut(importer, &alias)?;
-            if dependency.specifier == specifier {
+            if dependency.specifier == *specifier {
                 continue;
             }
             let range = Range::parse(specifier).ok()?;
@@ -25,11 +26,81 @@ pub(crate) fn try_fast_update_importers(
             if !version.satisfies(&range) {
                 return None;
             }
-            dependency.specifier = specifier.to_string();
+            dependency.specifier = (*specifier).to_string();
             changed = true;
         }
+        let removed = remove_dependencies_absent_from(importer, &manifest_specifiers);
+        changed |= !removed.is_empty();
+        dropped.extend(removed);
+    }
+    if !dropped.is_empty() {
+        if !peer_suffixes_are_independent_of(&candidate, &dropped) {
+            return None;
+        }
+        crate::fast_update_lockfile::prune_unreachable_packages(&mut candidate);
     }
     changed.then_some(candidate)
+}
+
+/// Drop every dependency the importer records that the manifest no longer
+/// declares, returning their names.
+fn remove_dependencies_absent_from(
+    importer: &mut ProjectSnapshot,
+    manifest_specifiers: &HashMap<&str, &str>,
+) -> HashSet<PkgName> {
+    let declared = |alias: &PkgName| manifest_specifiers.contains_key(alias.to_string().as_str());
+    let mut removed = HashSet::new();
+    for group in [
+        importer.dependencies.as_mut(),
+        importer.dev_dependencies.as_mut(),
+        importer.optional_dependencies.as_mut(),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        group.retain(|alias, _| {
+            if declared(alias) {
+                return true;
+            }
+            removed.insert(alias.clone());
+            false
+        });
+    }
+    for group in [
+        &mut importer.dependencies,
+        &mut importer.dev_dependencies,
+        &mut importer.optional_dependencies,
+    ] {
+        if group.as_ref().is_some_and(HashMap::is_empty) {
+            *group = None;
+        }
+    }
+    if let Some(specifiers) = importer.specifiers.as_mut() {
+        specifiers.retain(|alias, _| !removed.iter().any(|name| name.to_string() == *alias));
+    }
+    removed
+}
+
+/// Whether no surviving snapshot resolves a peer through one of `dropped`.
+///
+/// A dropped package that some snapshot reaches as a peer is embedded in
+/// that snapshot's key, so removing it would rekey the dependent rather
+/// than only prune. A peer suffix pnpm shortened into a hash cannot be
+/// read to rule that out.
+fn peer_suffixes_are_independent_of(lockfile: &Lockfile, dropped: &HashSet<PkgName>) -> bool {
+    let Some(snapshots) = lockfile.snapshots.as_ref() else {
+        return true;
+    };
+    snapshots.keys().all(|key| {
+        let peers = key.suffix.peer();
+        peers.is_empty()
+            || (peers
+                .trim_start_matches('(')
+                .trim_end_matches(')')
+                .split(")(")
+                .all(|segment| segment.contains('@'))
+                && !dropped.iter().any(|name| peers.contains(&format!("{name}@"))))
+    })
 }
 
 fn importer_dependency_mut<'a>(

--- a/pnpm/crates/package-manager/src/fast_update_importers.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers.rs
@@ -34,10 +34,14 @@ pub(crate) fn try_fast_update_importers(
         dropped.extend(removed);
     }
     if !dropped.is_empty() {
+        // Prune first: a peer-dependent snapshot that the removal itself
+        // makes unreachable needs no rekeying, so only the survivors are
+        // checked.
+        crate::fast_update_lockfile::prune_unreachable_packages(&mut candidate);
         if !peer_suffixes_are_independent_of(&candidate, &dropped) {
             return None;
         }
-        crate::fast_update_lockfile::prune_unreachable_packages(&mut candidate);
+        crate::fast_update_lockfile::prune_unreferenced_catalog_entries(&mut candidate);
     }
     changed.then_some(candidate)
 }

--- a/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
@@ -330,3 +330,27 @@ fn rejects_dropping_a_dependency_when_a_surviving_suffix_is_hashed() {
         "a shortened suffix cannot be checked for the dropped package",
     );
 }
+
+#[test]
+fn keeps_a_catalog_entry_referenced_with_the_catalog_default_spelling() {
+    let mut lockfile = parsed_lockfile(WITH_CATALOG_DEP);
+    let mut importer = lockfile.importers["."].clone();
+    let alias: PkgName = "foo".parse().expect("alias");
+    importer.dependencies.as_mut().expect("dependencies").get_mut(&alias).expect("foo").specifier =
+        "catalog:default".to_string();
+    lockfile.importers.insert("pkg-a".to_string(), importer);
+    let manifest = manifest_from(json!({ "dependencies": { "bar": "^2.0.0" } }));
+    let other =
+        manifest_from(json!({ "dependencies": { "foo": "catalog:default", "bar": "^2.0.0" } }));
+
+    let updated = try_fast_update_importers(
+        &lockfile,
+        &[(".".to_string(), &manifest), ("pkg-a".to_string(), &other)],
+    )
+    .expect("the other importer still references the catalog entry");
+
+    assert!(
+        updated.catalogs.as_ref().is_some_and(|catalogs| catalogs["default"].contains_key("foo")),
+        "the catalog:default spelling counts as a reference to the default catalog",
+    );
+}

--- a/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
@@ -168,3 +168,165 @@ fn rejects_dropping_a_dependency_another_package_resolves_as_a_peer() {
         "baz's key embeds foo, so dropping foo rekeys baz rather than only pruning",
     );
 }
+
+/// `foo` is referenced through the default catalog by the sole importer;
+/// `bar` is a plain dependency.
+const WITH_CATALOG_DEP: &str = r"
+lockfileVersion: '9.0'
+catalogs:
+  default:
+    foo:
+      specifier: ^1.0.0
+      version: 1.1.0
+importers:
+  .:
+    specifiers:
+      foo: 'catalog:'
+      bar: ^2.0.0
+    dependencies:
+      foo:
+        specifier: 'catalog:'
+        version: 1.1.0
+      bar:
+        specifier: ^2.0.0
+        version: 2.0.0
+packages:
+  foo@1.1.0:
+    resolution:
+      integrity: sha512-foo
+  bar@2.0.0:
+    resolution:
+      integrity: sha512-bar
+snapshots:
+  foo@1.1.0: {}
+  bar@2.0.0: {}
+";
+
+/// `baz` resolves `foo` as a peer, and nothing else depends on `baz`,
+/// so dropping both from the manifest leaves no snapshot that embeds
+/// `foo`.
+const WITH_REMOVABLE_PEER_PAIR: &str = r"
+lockfileVersion: '9.0'
+importers:
+  .:
+    specifiers:
+      foo: ^1.0.0
+      baz: ^4.0.0
+      bar: ^2.0.0
+    dependencies:
+      foo:
+        specifier: ^1.0.0
+        version: 1.1.0
+      baz:
+        specifier: ^4.0.0
+        version: 4.0.0(foo@1.1.0)
+      bar:
+        specifier: ^2.0.0
+        version: 2.0.0
+packages:
+  foo@1.1.0:
+    resolution:
+      integrity: sha512-foo
+  baz@4.0.0:
+    resolution:
+      integrity: sha512-baz
+  bar@2.0.0:
+    resolution:
+      integrity: sha512-bar
+snapshots:
+  foo@1.1.0: {}
+  baz@4.0.0(foo@1.1.0):
+    dependencies:
+      foo: 1.1.0
+  bar@2.0.0: {}
+";
+
+/// A surviving snapshot whose peer suffix pnpm shortened into a hash.
+const WITH_HASHED_PEER_SUFFIX: &str = r"
+lockfileVersion: '9.0'
+importers:
+  .:
+    specifiers:
+      foo: ^1.0.0
+      baz: ^4.0.0
+    dependencies:
+      foo:
+        specifier: ^1.0.0
+        version: 1.1.0
+      baz:
+        specifier: ^4.0.0
+        version: 4.0.0(sha256-abcdef)
+packages:
+  foo@1.1.0:
+    resolution:
+      integrity: sha512-foo
+  baz@4.0.0:
+    resolution:
+      integrity: sha512-baz
+snapshots:
+  foo@1.1.0: {}
+  baz@4.0.0(sha256-abcdef): {}
+";
+
+#[test]
+fn prunes_a_catalog_entry_its_last_referent_dropped() {
+    let manifest = manifest_from(json!({ "dependencies": { "bar": "^2.0.0" } }));
+
+    let updated = try_fast_update_importers(
+        &parsed_lockfile(WITH_CATALOG_DEP),
+        &[(".".to_string(), &manifest)],
+    )
+    .expect("dropping the catalog referent needs no resolution");
+
+    assert!(updated.catalogs.is_none(), "the orphaned catalog entry goes with its referent");
+}
+
+#[test]
+fn keeps_a_catalog_entry_another_importer_references() {
+    let mut lockfile = parsed_lockfile(WITH_CATALOG_DEP);
+    let importer = lockfile.importers["."].clone();
+    lockfile.importers.insert("pkg-a".to_string(), importer);
+    let manifest = manifest_from(json!({ "dependencies": { "bar": "^2.0.0" } }));
+    let other = manifest_from(json!({ "dependencies": { "foo": "catalog:", "bar": "^2.0.0" } }));
+
+    let updated = try_fast_update_importers(
+        &lockfile,
+        &[(".".to_string(), &manifest), ("pkg-a".to_string(), &other)],
+    )
+    .expect("the other importer still references the catalog entry");
+
+    assert!(
+        updated.catalogs.as_ref().is_some_and(|catalogs| catalogs["default"].contains_key("foo")),
+        "the still-referenced catalog entry stays",
+    );
+}
+
+#[test]
+fn drops_a_peer_pair_removed_together() {
+    let manifest = manifest_from(json!({ "dependencies": { "bar": "^2.0.0" } }));
+
+    let updated = try_fast_update_importers(
+        &parsed_lockfile(WITH_REMOVABLE_PEER_PAIR),
+        &[(".".to_string(), &manifest)],
+    )
+    .expect("the peer-dependent snapshot is unreachable after the removal, so nothing rekeys");
+
+    let mut packages: Vec<_> =
+        updated.packages.as_ref().expect("packages").keys().map(ToString::to_string).collect();
+    packages.sort();
+    assert_eq!(packages, vec!["bar@2.0.0".to_string()]);
+}
+
+#[test]
+fn rejects_dropping_a_dependency_when_a_surviving_suffix_is_hashed() {
+    let manifest = manifest_from(json!({ "dependencies": { "baz": "^4.0.0" } }));
+
+    assert!(
+        try_fast_update_importers(
+            &parsed_lockfile(WITH_HASHED_PEER_SUFFIX),
+            &[(".".to_string(), &manifest)],
+        )
+        .is_none(),
+        "a shortened suffix cannot be checked for the dropped package",
+    );
+}

--- a/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
@@ -1,5 +1,5 @@
 use super::try_fast_update_importers;
-use pacquet_lockfile::Lockfile;
+use pacquet_lockfile::{Lockfile, PkgName};
 use pacquet_package_manifest::PackageManifest;
 use serde_json::json;
 use std::path::PathBuf;
@@ -23,6 +23,14 @@ snapshots:
 ",
     )
     .expect("parse lockfile")
+}
+
+fn parsed_lockfile(source: &str) -> Lockfile {
+    serde_saphyr::from_str(source).expect("parse lockfile")
+}
+
+fn manifest_from(value: serde_json::Value) -> PackageManifest {
+    PackageManifest::from_value(PathBuf::from("/project/package.json"), value)
 }
 
 fn manifest(specifier: &str) -> PackageManifest {
@@ -55,4 +63,108 @@ fn rejects_an_incompatible_dependency_range() {
 fn rejects_a_non_semver_dependency_specifier() {
     let manifest = manifest("latest");
     assert!(try_fast_update_importers(&lockfile(), &[(".".to_string(), &manifest)]).is_none());
+}
+
+const WITH_REMOVABLE_DEP: &str = r"
+lockfileVersion: '9.0'
+importers:
+  .:
+    specifiers:
+      foo: ^1.0.0
+      bar: ^2.0.0
+    dependencies:
+      foo:
+        specifier: ^1.0.0
+        version: 1.1.0
+      bar:
+        specifier: ^2.0.0
+        version: 2.0.0
+packages:
+  foo@1.1.0:
+    resolution:
+      integrity: sha512-foo
+  bar@2.0.0:
+    resolution:
+      integrity: sha512-bar
+  child@3.0.0:
+    resolution:
+      integrity: sha512-child
+snapshots:
+  foo@1.1.0: {}
+  bar@2.0.0:
+    dependencies:
+      child: 3.0.0
+  child@3.0.0: {}
+";
+
+/// The same graph where `baz` resolves `foo` as a peer, so `foo`'s id is
+/// embedded in `baz`'s key.
+const WITH_PEER_ON_REMOVABLE_DEP: &str = r"
+lockfileVersion: '9.0'
+importers:
+  .:
+    specifiers:
+      foo: ^1.0.0
+      baz: ^4.0.0
+    dependencies:
+      foo:
+        specifier: ^1.0.0
+        version: 1.1.0
+      baz:
+        specifier: ^4.0.0
+        version: 4.0.0(foo@1.1.0)
+packages:
+  foo@1.1.0:
+    resolution:
+      integrity: sha512-foo
+  baz@4.0.0:
+    resolution:
+      integrity: sha512-baz
+snapshots:
+  foo@1.1.0: {}
+  baz@4.0.0(foo@1.1.0):
+    dependencies:
+      foo: 1.1.0
+";
+
+#[test]
+fn drops_a_dependency_the_manifest_no_longer_declares() {
+    let manifest = manifest_from(json!({ "dependencies": { "bar": "^2.0.0" } }));
+
+    let updated = try_fast_update_importers(
+        &parsed_lockfile(WITH_REMOVABLE_DEP),
+        &[(".".to_string(), &manifest)],
+    )
+    .expect("dropping an importer edge needs no resolution");
+
+    let importer = &updated.importers["."];
+    let dependencies = importer.dependencies.as_ref().expect("dependencies");
+    assert!(!dependencies.contains_key(&"foo".parse::<PkgName>().expect("alias")));
+    assert!(dependencies.contains_key(&"bar".parse::<PkgName>().expect("alias")));
+    assert_eq!(
+        importer.specifiers.as_ref().expect("specifiers").keys().collect::<Vec<_>>(),
+        vec!["bar"],
+    );
+    let mut packages: Vec<_> =
+        updated.packages.as_ref().expect("packages").keys().map(ToString::to_string).collect();
+    packages.sort();
+    assert_eq!(
+        packages,
+        vec!["bar@2.0.0".to_string(), "child@3.0.0".to_string()],
+        "the dropped package goes with its subtree, and shared entries stay",
+    );
+}
+
+#[test]
+fn rejects_dropping_a_dependency_another_package_resolves_as_a_peer() {
+    let manifest = manifest_from(json!({ "dependencies": { "baz": "^4.0.0" } }));
+
+    assert!(
+        try_fast_update_importers(
+            &parsed_lockfile(WITH_PEER_ON_REMOVABLE_DEP),
+            &[(".".to_string(), &manifest)],
+        )
+        .is_none(),
+        "baz's key embeds foo, so dropping foo rekeys baz rather than only pruning",
+    );
 }

--- a/pnpm/crates/package-manager/src/fast_update_lockfile.rs
+++ b/pnpm/crates/package-manager/src/fast_update_lockfile.rs
@@ -56,3 +56,35 @@ pub(crate) fn prune_unreachable_packages(lockfile: &mut Lockfile) {
         }
     }
 }
+
+/// Drop every catalog snapshot entry that no importer references any
+/// more, matching what a full resolution records after the same removal.
+pub(crate) fn prune_unreferenced_catalog_entries(lockfile: &mut Lockfile) {
+    let Some(catalogs) = lockfile.catalogs.as_ref() else {
+        return;
+    };
+    let stale: Vec<(String, String)> = catalogs
+        .iter()
+        .flat_map(|(catalog_name, entries)| {
+            entries.keys().map(move |alias| (catalog_name.clone(), alias.clone()))
+        })
+        .filter(|(catalog_name, alias)| {
+            !crate::fast_update_catalogs::catalog_entry_is_referenced(lockfile, catalog_name, alias)
+        })
+        .collect();
+    if stale.is_empty() {
+        return;
+    }
+    let catalogs = lockfile.catalogs.as_mut().expect("checked above");
+    for (catalog_name, alias) in stale {
+        if let Some(entries) = catalogs.get_mut(&catalog_name) {
+            entries.remove(&alias);
+            if entries.is_empty() {
+                catalogs.remove(&catalog_name);
+            }
+        }
+    }
+    if catalogs.is_empty() {
+        lockfile.catalogs = None;
+    }
+}

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -717,6 +717,9 @@ export async function mutateModules (
         onlyLockfileSettingsChanged ||
         hasChangedSpecifiers) &&
       !frozenLockfile &&
+      // `pnpm fetch` installs from the lockfile alone; with its empty
+      // manifests every recorded dependency would read as removed.
+      !opts.ignorePackageManifest &&
       installsOnly &&
       !isCheckOnlyInstall(opts) &&
       opts.preferFrozenLockfile &&

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateCatalogs.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateCatalogs.ts
@@ -50,8 +50,11 @@ function catalogEntryIsReferenced (
   catalogName: string,
   alias: string
 ): boolean {
-  const protocol = catalogName === 'default' ? 'catalog:' : `catalog:${catalogName}`
-  return Object.values(importers).some((importer) => importer.specifiers[alias] === protocol)
+  // Parsed rather than compared to a rebuilt protocol string, so the
+  // `catalog:default` spelling of the default catalog counts too.
+  return Object.values(importers).some(
+    (importer) => parseCatalogProtocol(importer.specifiers[alias] ?? '') === catalogName
+  )
 }
 
 /**

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateCatalogs.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateCatalogs.ts
@@ -73,3 +73,24 @@ export function catalogReferencesHaveSnapshots (
     })
   )
 }
+
+/**
+ * Drop every catalog snapshot entry that no importer references any more,
+ * matching what a full resolution records after the same removal.
+ */
+export function pruneUnreferencedCatalogEntries (lockfile: LockfileObject): void {
+  if (lockfile.catalogs == null) return
+  for (const [catalogName, catalog] of Object.entries(lockfile.catalogs)) {
+    for (const alias of Object.keys(catalog)) {
+      if (!catalogEntryIsReferenced(lockfile.importers, catalogName, alias)) {
+        delete catalog[alias]
+      }
+    }
+    if (Object.keys(catalog).length === 0) {
+      delete lockfile.catalogs[catalogName]
+    }
+  }
+  if (Object.keys(lockfile.catalogs).length === 0) {
+    delete lockfile.catalogs
+  }
+}

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateIgnoredOptionalDependencies.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateIgnoredOptionalDependencies.ts
@@ -6,6 +6,8 @@ import type {
   ResolvedDependencies,
 } from '@pnpm/lockfile.types'
 
+import { pruneUnreferencedCatalogEntries } from './tryFastUpdateCatalogs.js'
+
 export function tryFastUpdateIgnoredOptionalDependencies (
   lockfile: LockfileObject,
   ignoredOptionalDependencies: string[]
@@ -38,6 +40,7 @@ export function tryFastUpdateIgnoredOptionalDependencies (
   } else {
     lockfile.packages = pruned.packages
   }
+  pruneUnreferencedCatalogEntries(lockfile)
   return true
 }
 

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
@@ -1,4 +1,5 @@
 import * as dp from '@pnpm/deps.path'
+import { pruneSharedLockfile } from '@pnpm/lockfile.pruner'
 import type { LockfileObject } from '@pnpm/lockfile.types'
 import type { ProjectId, ProjectManifest } from '@pnpm/types'
 import semver from 'semver'
@@ -15,8 +16,11 @@ export function hasChangedProjectSpecifiers (
   return projects.some((project) => {
     const importer = lockfile.importers[project.id]
     if (importer == null) return false
-    return Object.entries(getManifestSpecifiers(project.manifest))
-      .some(([alias, specifier]) => importer.specifiers[alias] !== specifier)
+    const manifestSpecifiers = getManifestSpecifiers(project.manifest)
+    return Object.entries(manifestSpecifiers)
+      .some(([alias, specifier]) => importer.specifiers[alias] !== specifier) ||
+      // A dependency the importer records that the manifest dropped.
+      Object.keys(importer.specifiers).some((alias) => manifestSpecifiers[alias] == null)
   })
 }
 
@@ -54,10 +58,56 @@ export function tryFastUpdateImporters (
       })
     }
   }
+  const dropped = new Set<string>()
+  for (const project of projects) {
+    const importer = lockfile.importers[project.id]
+    const manifestSpecifiers = getManifestSpecifiers(project.manifest)
+    for (const alias of Object.keys(importer.specifiers)) {
+      if (manifestSpecifiers[alias] != null) continue
+      dropped.add(alias)
+      delete importer.specifiers[alias]
+      delete importer.dependencies?.[alias]
+      delete importer.devDependencies?.[alias]
+      delete importer.optionalDependencies?.[alias]
+    }
+  }
+
+  if (dropped.size > 0 && !peerSuffixesAreIndependentOf(lockfile, dropped)) return false
+
   for (const update of updates) {
     update.specifiers[update.alias] = update.specifier
   }
-  return updates.length > 0
+  if (dropped.size > 0) {
+    const pruned = pruneSharedLockfile(lockfile)
+    if (pruned.packages == null) {
+      delete lockfile.packages
+    } else {
+      lockfile.packages = pruned.packages
+    }
+  }
+  return updates.length > 0 || dropped.size > 0
+}
+
+/**
+ * Whether no surviving package resolves a peer through one of `dropped`.
+ *
+ * A dropped package that some package reaches as a peer is embedded in that
+ * package's key, so removing it would rekey the dependent rather than only
+ * prune. A peer suffix pnpm shortened into a hash cannot be read to rule that
+ * out.
+ */
+function peerSuffixesAreIndependentOf (lockfile: LockfileObject, dropped: Set<string>): boolean {
+  return Object.keys(lockfile.packages ?? {}).every((depPath) => {
+    const { peersIndex } = dp.indexOfDepPathSuffix(depPath)
+    if (peersIndex === -1) return true
+    const peers = depPath.substring(peersIndex)
+    return peers
+      .replace(/^\(/, '')
+      .replace(/\)$/, '')
+      .split(')(')
+      .every((segment) => segment.includes('@')) &&
+      ![...dropped].some((alias) => peers.includes(`${alias}@`))
+  })
 }
 
 function getManifestSpecifiers (manifest: ProjectManifest): Record<string, string> {

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
@@ -2,7 +2,10 @@ import * as dp from '@pnpm/deps.path'
 import { pruneSharedLockfile } from '@pnpm/lockfile.pruner'
 import type { LockfileObject } from '@pnpm/lockfile.types'
 import type { ProjectId, ProjectManifest } from '@pnpm/types'
+import { clone } from 'ramda'
 import semver from 'semver'
+
+import { pruneUnreferencedCatalogEntries } from './tryFastUpdateCatalogs.js'
 
 interface Project {
   id: ProjectId
@@ -19,7 +22,6 @@ export function hasChangedProjectSpecifiers (
     const manifestSpecifiers = getManifestSpecifiers(project.manifest)
     return Object.entries(manifestSpecifiers)
       .some(([alias, specifier]) => importer.specifiers[alias] !== specifier) ||
-      // A dependency the importer records that the manifest dropped.
       Object.keys(importer.specifiers).some((alias) => manifestSpecifiers[alias] == null)
   })
 }
@@ -28,15 +30,14 @@ export function tryFastUpdateImporters (
   lockfile: LockfileObject,
   projects: Project[]
 ): boolean {
-  const updates: Array<{
-    alias: string
-    specifier: string
-    specifiers: Record<string, string>
-  }> = []
+  const candidate = clone(lockfile)
+  const dropped = new Set<string>()
+  let changed = false
   for (const project of projects) {
-    const importer = lockfile.importers[project.id]
+    const importer = candidate.importers[project.id]
     if (importer == null) return false
-    for (const [alias, specifier] of Object.entries(getManifestSpecifiers(project.manifest))) {
+    const manifestSpecifiers = getManifestSpecifiers(project.manifest)
+    for (const [alias, specifier] of Object.entries(manifestSpecifiers)) {
       if (importer.specifiers[alias] === specifier) continue
       const reference =
         importer.optionalDependencies?.[alias] ??
@@ -51,41 +52,49 @@ export function tryFastUpdateImporters (
       ) {
         return false
       }
-      updates.push({
-        alias,
-        specifier,
-        specifiers: importer.specifiers,
-      })
+      importer.specifiers[alias] = specifier
+      changed = true
     }
-  }
-  const dropped = new Set<string>()
-  for (const project of projects) {
-    const importer = lockfile.importers[project.id]
-    const manifestSpecifiers = getManifestSpecifiers(project.manifest)
     for (const alias of Object.keys(importer.specifiers)) {
       if (manifestSpecifiers[alias] != null) continue
       dropped.add(alias)
       delete importer.specifiers[alias]
-      delete importer.dependencies?.[alias]
-      delete importer.devDependencies?.[alias]
-      delete importer.optionalDependencies?.[alias]
+      for (const group of ['dependencies', 'devDependencies', 'optionalDependencies'] as const) {
+        delete importer[group]?.[alias]
+        if (importer[group] != null && Object.keys(importer[group]).length === 0) {
+          delete importer[group]
+        }
+      }
+      changed = true
     }
   }
+  if (!changed) return false
 
-  if (dropped.size > 0 && !peerSuffixesAreIndependentOf(lockfile, dropped)) return false
-
-  for (const update of updates) {
-    update.specifiers[update.alias] = update.specifier
-  }
   if (dropped.size > 0) {
-    const pruned = pruneSharedLockfile(lockfile)
+    const pruned = pruneSharedLockfile(candidate)
     if (pruned.packages == null) {
-      delete lockfile.packages
+      delete candidate.packages
     } else {
-      lockfile.packages = pruned.packages
+      candidate.packages = pruned.packages
     }
+    // Pruned first: a peer-dependent package that the removal itself makes
+    // unreachable needs no rekeying, so only the survivors are checked.
+    if (!peerSuffixesAreIndependentOf(candidate, dropped)) return false
+    pruneUnreferencedCatalogEntries(candidate)
   }
-  return updates.length > 0 || dropped.size > 0
+
+  lockfile.importers = candidate.importers
+  if (candidate.packages == null) {
+    delete lockfile.packages
+  } else {
+    lockfile.packages = candidate.packages
+  }
+  if (candidate.catalogs == null) {
+    delete lockfile.catalogs
+  } else {
+    lockfile.catalogs = candidate.catalogs
+  }
+  return true
 }
 
 /**

--- a/pnpm11/installing/deps-installer/test/install/ignoredOptionalDependencies.ts
+++ b/pnpm11/installing/deps-installer/test/install/ignoredOptionalDependencies.ts
@@ -164,6 +164,33 @@ test('fast update prunes only optional packages that become unreachable', () => 
   expect(lockfile.packages).not.toHaveProperty(['unique@1.0.0'])
 })
 
+test('fast update prunes a catalog entry its last referent was ignored', () => {
+  const lockfile = {
+    catalogs: {
+      default: {
+        'is-positive': { specifier: '^1.0.0', version: '1.0.0' },
+      },
+    },
+    importers: {
+      '.': {
+        optionalDependencies: {
+          'is-positive': '1.0.0',
+        },
+        specifiers: {
+          'is-positive': 'catalog:',
+        },
+      },
+    },
+    lockfileVersion: '9.0',
+    packages: {
+      'is-positive@1.0.0': { resolution: { integrity: 'sha512-pos' } },
+    },
+  } as unknown as LockfileObject
+
+  expect(tryFastUpdateIgnoredOptionalDependencies(lockfile, ['is-positive'])).toBe(true)
+  expect(lockfile.catalogs).toBeUndefined()
+})
+
 test('fast update rejects a new exclusion pattern', () => {
   const lockfile = {
     ignoredOptionalDependencies: ['*'],

--- a/pnpm11/installing/deps-installer/test/install/importerRemovalFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/importerRemovalFastUpdate.ts
@@ -1,0 +1,61 @@
+import { expect, test } from '@jest/globals'
+import type { LockfileObject } from '@pnpm/lockfile.types'
+import type { DepPath, ProjectId, ProjectManifest } from '@pnpm/types'
+
+import {
+  hasChangedProjectSpecifiers,
+  tryFastUpdateImporters,
+} from '../../src/install/tryFastUpdateImporters.js'
+
+test('a dependency the manifest dropped is noticed as a change', () => {
+  expect(hasChangedProjectSpecifiers(lockfile(), [project({ bar: '^2.0.0' })])).toBe(true)
+})
+
+test('a dropped dependency is removed and its subtree pruned', () => {
+  const subject = lockfile()
+
+  expect(tryFastUpdateImporters(subject, [project({ bar: '^2.0.0' })])).toBe(true)
+  const importer = subject.importers['.' as ProjectId]
+  expect(importer.specifiers).toStrictEqual({ bar: '^2.0.0' })
+  expect(importer.dependencies).toStrictEqual({ bar: '2.0.0' })
+  expect(Object.keys(subject.packages!).sort()).toStrictEqual(['bar@2.0.0', 'child@3.0.0'])
+})
+
+test('dropping a dependency another package resolves as a peer falls back', () => {
+  const subject = lockfile()
+  subject.importers['.' as ProjectId].dependencies!.baz = '4.0.0(foo@1.1.0)'
+  subject.importers['.' as ProjectId].specifiers.baz = '^4.0.0'
+  subject.packages!['baz@4.0.0(foo@1.1.0)' as DepPath] = {
+    resolution: { integrity: 'sha512-baz' },
+    dependencies: { foo: '1.1.0' },
+  }
+
+  expect(tryFastUpdateImporters(subject, [project({ bar: '^2.0.0', baz: '^4.0.0' })])).toBe(false)
+})
+
+function project (dependencies: Record<string, string>) {
+  return {
+    id: '.' as ProjectId,
+    manifest: { dependencies } as ProjectManifest,
+  }
+}
+
+function lockfile (): LockfileObject {
+  return {
+    lockfileVersion: '9.0',
+    importers: {
+      ['.' as ProjectId]: {
+        specifiers: { foo: '^1.0.0', bar: '^2.0.0' },
+        dependencies: { foo: '1.1.0', bar: '2.0.0' },
+      },
+    },
+    packages: {
+      ['foo@1.1.0' as DepPath]: { resolution: { integrity: 'sha512-foo' } },
+      ['bar@2.0.0' as DepPath]: {
+        resolution: { integrity: 'sha512-bar' },
+        dependencies: { child: '3.0.0' },
+      },
+      ['child@3.0.0' as DepPath]: { resolution: { integrity: 'sha512-child' } },
+    },
+  }
+}

--- a/pnpm11/installing/deps-installer/test/install/importerRemovalFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/importerRemovalFastUpdate.ts
@@ -79,6 +79,22 @@ test('a catalog entry whose last referent is dropped is pruned', () => {
   expect(subject.catalogs).toBeUndefined()
 })
 
+test('a catalog entry referenced with the catalog:default spelling is kept', () => {
+  const subject = lockfile()
+  subject.catalogs = { default: { foo: { specifier: '^1.0.0', version: '1.1.0' } } }
+  subject.importers['.' as ProjectId].specifiers.foo = 'catalog:default'
+  subject.importers['pkg-a' as ProjectId] = {
+    specifiers: { foo: 'catalog:default', bar: '^2.0.0' },
+    dependencies: { foo: '1.1.0', bar: '2.0.0' },
+  }
+
+  expect(tryFastUpdateImporters(subject, [
+    project({ bar: '^2.0.0' }),
+    { id: 'pkg-a' as ProjectId, manifest: { dependencies: { foo: 'catalog:default', bar: '^2.0.0' } } as ProjectManifest },
+  ])).toBe(true)
+  expect(subject.catalogs).toStrictEqual({ default: { foo: { specifier: '^1.0.0', version: '1.1.0' } } })
+})
+
 test('a catalog entry another importer references is kept', () => {
   const subject = lockfile()
   subject.catalogs = { default: { foo: { specifier: '^1.0.0', version: '1.1.0' } } }

--- a/pnpm11/installing/deps-installer/test/install/importerRemovalFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/importerRemovalFastUpdate.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@jest/globals'
 import type { LockfileObject } from '@pnpm/lockfile.types'
 import type { DepPath, ProjectId, ProjectManifest } from '@pnpm/types'
+import { clone } from 'ramda'
 
 import {
   hasChangedProjectSpecifiers,
@@ -21,7 +22,21 @@ test('a dropped dependency is removed and its subtree pruned', () => {
   expect(Object.keys(subject.packages!).sort()).toStrictEqual(['bar@2.0.0', 'child@3.0.0'])
 })
 
-test('dropping a dependency another package resolves as a peer falls back', () => {
+test('dropping a dependency another package resolves as a peer falls back without mutating the lockfile', () => {
+  const subject = lockfile()
+  subject.importers['.' as ProjectId].dependencies!.baz = '4.0.0(foo@1.1.0)'
+  subject.importers['.' as ProjectId].specifiers.baz = '^4.0.0'
+  subject.packages!['baz@4.0.0(foo@1.1.0)' as DepPath] = {
+    resolution: { integrity: 'sha512-baz' },
+    dependencies: { foo: '1.1.0' },
+  }
+  const before = clone(subject)
+
+  expect(tryFastUpdateImporters(subject, [project({ bar: '^2.0.0', baz: '^4.0.0' })])).toBe(false)
+  expect(subject).toStrictEqual(before)
+})
+
+test('dropping a dependency together with its peer-dependent succeeds', () => {
   const subject = lockfile()
   subject.importers['.' as ProjectId].dependencies!.baz = '4.0.0(foo@1.1.0)'
   subject.importers['.' as ProjectId].specifiers.baz = '^4.0.0'
@@ -30,7 +45,54 @@ test('dropping a dependency another package resolves as a peer falls back', () =
     dependencies: { foo: '1.1.0' },
   }
 
+  expect(tryFastUpdateImporters(subject, [project({ bar: '^2.0.0' })])).toBe(true)
+  expect(Object.keys(subject.packages!)).toStrictEqual(['bar@2.0.0', 'child@3.0.0'])
+})
+
+test('dropping a dependency when a surviving peer suffix is hashed falls back', () => {
+  const subject = lockfile()
+  subject.importers['.' as ProjectId].dependencies!.baz = '4.0.0(sha256-abcdef)'
+  subject.importers['.' as ProjectId].specifiers.baz = '^4.0.0'
+  subject.packages!['baz@4.0.0(sha256-abcdef)' as DepPath] = {
+    resolution: { integrity: 'sha512-baz' },
+  }
+
   expect(tryFastUpdateImporters(subject, [project({ bar: '^2.0.0', baz: '^4.0.0' })])).toBe(false)
+})
+
+test('a dependency group emptied by the removal is deleted', () => {
+  const subject = lockfile()
+  subject.importers['.' as ProjectId].devDependencies = { qux: '5.0.0' }
+  subject.importers['.' as ProjectId].specifiers.qux = '^5.0.0'
+  subject.packages!['qux@5.0.0' as DepPath] = { resolution: { integrity: 'sha512-qux' } }
+
+  expect(tryFastUpdateImporters(subject, [project({ foo: '^1.0.0', bar: '^2.0.0' })])).toBe(true)
+  expect(subject.importers['.' as ProjectId].devDependencies).toBeUndefined()
+})
+
+test('a catalog entry whose last referent is dropped is pruned', () => {
+  const subject = lockfile()
+  subject.catalogs = { default: { foo: { specifier: '^1.0.0', version: '1.1.0' } } }
+  subject.importers['.' as ProjectId].specifiers.foo = 'catalog:'
+
+  expect(tryFastUpdateImporters(subject, [project({ bar: '^2.0.0' })])).toBe(true)
+  expect(subject.catalogs).toBeUndefined()
+})
+
+test('a catalog entry another importer references is kept', () => {
+  const subject = lockfile()
+  subject.catalogs = { default: { foo: { specifier: '^1.0.0', version: '1.1.0' } } }
+  subject.importers['.' as ProjectId].specifiers.foo = 'catalog:'
+  subject.importers['pkg-a' as ProjectId] = {
+    specifiers: { foo: 'catalog:' },
+    dependencies: { foo: '1.1.0' },
+  }
+
+  expect(tryFastUpdateImporters(subject, [
+    project({ bar: '^2.0.0' }),
+    { id: 'pkg-a' as ProjectId, manifest: { dependencies: { foo: 'catalog:' } } as ProjectManifest },
+  ])).toBe(true)
+  expect(subject.catalogs).toStrictEqual({ default: { foo: { specifier: '^1.0.0', version: '1.1.0' } } })
 })
 
 function project (dependencies: Record<string, string>) {


### PR DESCRIPTION
## Summary

Related to pnpm/pnpm#13696, the first of the cases that still re-resolve even though the lockfile already answers them.

A dependency the lockfile records but the manifest no longer declares forced a full resolution. Answering it needs no registry access at all: drop the importer's entry and prune whatever that leaves unreachable. Both stacks already had the pruning, from the `ignoredOptionalDependencies` handler.

- Extend the importer fast path in both stacks to drop entries the manifest dropped.
- Fix `hasChangedProjectSpecifiers`, which only compared the manifest against the lockfile in one direction, so a removed dependency was never noticed as a change and the fast path was never offered the case.

### Scope, and what this does not do yet

This is the lockfile transformation `pnpm remove` performs, and it applies today to an install over a hand-edited `package.json` — which is the same operation a user reaches for when they delete a dependency by hand.

Wiring the remove command itself still needs the mutation gate opened, and that is deliberately not in this PR. The gates differ between the stacks: the TypeScript CLI gates on `installsOnly` (`allMutationsAreInstalls`) and feeds removals into resolution via `removePackages`, while pacquet's `pacquet remove` is `ProjectMutation::NoInstall`, a variant it shares with `link`, `import`, `fetch`, and `rebuild`. Opening either gate is its own change with its own risks, and it is easier to review once the transformation underneath it is settled.

### When it falls back

A **surviving** package that resolves a peer through the removed one has its id embedded in its own key, so the removal would rekey the dependent rather than only prune it. Peer suffixes are checked after pruning, so a peer-dependent package that the removal itself makes unreachable does not force a fallback. A peer suffix pnpm shortened into a hash cannot be read to rule the above out, so that falls back too.

### What review and CI added

- A catalog entry that loses its last referent is pruned, matching a full resolution — in this handler and in the merged `ignoredOptionalDependencies` handler, which had the same gap.
- The TypeScript handler stages its work on a cloned candidate, so a rejected fast update leaves the caller's lockfile untouched.
- Two of the three original CI failures (rehoist, `pendingBuilds`) were symptoms of a pre-existing headless bug, fixed separately in pnpm/pnpm#13700; this PR's tests now pass on top of it.

## Squash Commit Body

```text
A dependency the lockfile records but the manifest no longer declares
needed a full resolution, even though answering it takes no registry
access: drop the importer entry and prune what that leaves unreachable.

`hasChangedProjectSpecifiers` compared the manifest against the lockfile
in one direction only, so a dropped dependency was not noticed as a
change and the fast path was never offered the case.

Fall back when a surviving package resolves a peer through a dropped one:
its id is embedded in that package's key, so the removal would rekey the
dependent rather than only prune it. A peer suffix pnpm shortened into a
hash cannot be read to rule that out, so it falls back too.

This is the lockfile transformation `pnpm remove` performs, and applies
today to an install over a hand-edited manifest. Wiring the remove
mutation itself needs the mutation gate opened, which differs between the
stacks and is left to its own change.

Related to pnpm/pnpm#13696.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788689877&installation_model_id=426870&pr_number=13698&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13698&signature=6a9a8c3fb7d8b4e67b1c71d85269b8f673ce03594bc4cec12a226f2d768aff9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Removing dependencies updates the lockfile and installed packages without registry access.
  - Unused dependency entries, package subtrees, and catalog entries are automatically pruned while referenced data is preserved.
  - Peer dependency relationships are validated before pruning to prevent unsafe updates.

- **Bug Fixes**
  - Removed dependencies are no longer retained in importer metadata or linked in `node_modules`.
  - Updates safely fall back when removal could affect peer resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
