### PR TITLE
fix(deps-restorer): react to removed packages in the headless install

### DIFF
--- a/.changeset/headless-removal-bookkeeping.md
+++ b/.changeset/headless-removal-bookkeeping.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-restorer": patch
+"pnpm": patch
+---
+
+An install that skips resolution because `pnpm-lock.yaml` is already up to date now reacts fully to packages the lockfile removed — for example after pulling a lockfile in which a dependency was deleted. The hoist layer is recomputed, so a package that became hoistable when a direct dependency was removed is hoisted, and `pendingBuilds` entries for removed packages are dropped instead of staying pending forever.

--- a/pnpm/crates/cli/tests/hoist.rs
+++ b/pnpm/crates/cli/tests/hoist.rs
@@ -1544,10 +1544,8 @@ fn direct_dep_bin_wins_over_a_publicly_hoisted_workspace_package() {
     drop((root, mock_instance));
 }
 
-/// A lockfile-only resolve records the removal of the direct
-/// `@pnpm.e2e/dep-of-pkg-with-1-dep`, as pulling a teammate's lockfile
-/// would; the headless install after it has to notice that the removal
-/// made `@pnpm.e2e/pkg-with-1-dep`'s own copy hoistable.
+/// The lockfile-only resolve stands in for pulling a teammate's
+/// lockfile; the install after it takes the headless path.
 #[test]
 fn rehoists_when_an_up_to_date_lockfile_removes_a_direct_dependency() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =

--- a/pnpm/crates/cli/tests/hoist.rs
+++ b/pnpm/crates/cli/tests/hoist.rs
@@ -1543,3 +1543,49 @@ fn direct_dep_bin_wins_over_a_publicly_hoisted_workspace_package() {
 
     drop((root, mock_instance));
 }
+
+/// A lockfile-only resolve records the removal of the direct
+/// `@pnpm.e2e/dep-of-pkg-with-1-dep`, as pulling a teammate's lockfile
+/// would; the headless install after it has to notice that the removal
+/// made `@pnpm.e2e/pkg-with-1-dep`'s own copy hoistable.
+#[test]
+fn rehoists_when_an_up_to_date_lockfile_removes_a_direct_dependency() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_workspace_yaml(&workspace, "hoistPattern:\n  - '*'\n");
+    write_manifest(
+        &workspace,
+        serde_json::json!({
+            "@pnpm.e2e/pkg-with-1-dep": "100.0.0",
+            "@pnpm.e2e/dep-of-pkg-with-1-dep": "101.0.0",
+        }),
+    );
+    pacquet.with_arg("install").assert().success();
+    let hoisted = workspace.join("node_modules/.pnpm/node_modules/@pnpm.e2e/dep-of-pkg-with-1-dep");
+    assert!(
+        fs::symlink_metadata(&hoisted).is_err(),
+        "a direct dependency's name is not privately hoisted",
+    );
+
+    write_manifest(&workspace, serde_json::json!({ "@pnpm.e2e/pkg-with-1-dep": "100.0.0" }));
+    pacquet_at(&workspace).with_args(["install", "--lockfile-only"]).assert().success();
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    assert!(
+        is_symlink_or_junction(&hoisted).unwrap_or(false),
+        "the transitive copy is hoisted once the direct dependency is gone",
+    );
+    let manifest: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(hoisted.join("package.json")).expect("read hoisted package.json"),
+    )
+    .expect("parse hoisted package.json");
+    assert_eq!(manifest["version"], "100.1.0");
+
+    drop((root, mock_instance));
+}
+
+fn pacquet_at(workspace: &Path) -> Command {
+    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
+}

--- a/pnpm11/installing/deps-installer/test/install/hoist.ts
+++ b/pnpm11/installing/deps-installer/test/install/hoist.ts
@@ -198,6 +198,35 @@ test('should rehoist after running a general install', async () => {
   project.has('.pnpm/node_modules/debug') // debug hoisted because it is not a direct dep anymore
 })
 
+test('hoists again when an up-to-date lockfile removes a direct dependency', async () => {
+  const project = prepareEmpty()
+
+  await install({
+    dependencies: {
+      debug: '3.1.0',
+      express: '4.16.0',
+    },
+  }, testDefaults({ fastUnpack: false, hoistPattern: '*' }))
+  project.hasNot('.pnpm/node_modules/debug')
+
+  // The removal is resolved into the lockfile without touching node_modules,
+  // as pulling a teammate's lockfile would. The install after it takes the
+  // headless path and has to notice that removing the direct dependency made
+  // express's own `debug` hoistable.
+  await install({
+    dependencies: {
+      express: '4.16.0',
+    },
+  }, testDefaults({ fastUnpack: false, hoistPattern: '*', lockfileOnly: true }))
+  await install({
+    dependencies: {
+      express: '4.16.0',
+    },
+  }, testDefaults({ fastUnpack: false, hoistPattern: '*' }))
+
+  project.has('.pnpm/node_modules/debug')
+})
+
 test('should not override aliased dependencies', async () => {
   const project = prepareEmpty()
   // now I install is-negative, but aliased as "debug". I do not want the "debug" dependency of express to override my alias

--- a/pnpm11/installing/deps-installer/test/install/hoist.ts
+++ b/pnpm11/installing/deps-installer/test/install/hoist.ts
@@ -209,10 +209,8 @@ test('hoists again when an up-to-date lockfile removes a direct dependency', asy
   }, testDefaults({ fastUnpack: false, hoistPattern: '*' }))
   project.hasNot('.pnpm/node_modules/debug')
 
-  // The removal is resolved into the lockfile without touching node_modules,
-  // as pulling a teammate's lockfile would. The install after it takes the
-  // headless path and has to notice that removing the direct dependency made
-  // express's own `debug` hoistable.
+  // The lockfile-only resolve stands in for pulling a teammate's lockfile;
+  // the install after it takes the headless path.
   await install({
     dependencies: {
       express: '4.16.0',
@@ -225,6 +223,51 @@ test('hoists again when an up-to-date lockfile removes a direct dependency', asy
   }, testDefaults({ fastUnpack: false, hoistPattern: '*' }))
 
   project.has('.pnpm/node_modules/debug')
+})
+
+test('a filtered install after a removal keeps the other importers hoisted entries', async () => {
+  const rootManifestBefore = {
+    name: 'root',
+    dependencies: {
+      debug: '3.1.0',
+      express: '4.16.0',
+    },
+  }
+  const rootManifestAfter = {
+    name: 'root',
+    dependencies: {
+      express: '4.16.0',
+    },
+  }
+  const packageManifest = {
+    name: 'package',
+    dependencies: {
+      '@pnpm.e2e/pkg-with-1-dep': '100.0.0',
+    },
+  }
+  const projects = preparePackages([
+    { location: '.', package: rootManifestBefore },
+    { location: 'package', package: packageManifest },
+  ])
+  const mutatedProjects: MutatedProject[] = [
+    { mutation: 'install', rootDir: process.cwd() as ProjectRootDir },
+    { mutation: 'install', rootDir: path.resolve('package') as ProjectRootDir },
+  ]
+  const allProjects = (rootManifest: typeof rootManifestBefore) => [
+    { buildIndex: 0, manifest: rootManifest, rootDir: process.cwd() as ProjectRootDir },
+    { buildIndex: 0, manifest: packageManifest, rootDir: path.resolve('package') as ProjectRootDir },
+  ]
+  await mutateModules(mutatedProjects, testDefaults({ allProjects: allProjects(rootManifestBefore), fastUnpack: false, hoistPattern: '*' }))
+  const hoistedDepOfPkg = (): boolean => Object.keys(projects['root'].readModulesManifest()!.hoistedDependencies)
+    .some((depPath) => depPath.startsWith('@pnpm.e2e/dep-of-pkg-with-1-dep@'))
+  expect(hoistedDepOfPkg()).toBeTruthy()
+
+  // The lockfile-only resolve stands in for pulling a teammate's lockfile;
+  // the filtered install after it takes the headless path.
+  await mutateModules(mutatedProjects, testDefaults({ allProjects: allProjects(rootManifestAfter), fastUnpack: false, hoistPattern: '*', lockfileOnly: true }))
+  await mutateModules([mutatedProjects[0]], testDefaults({ allProjects: allProjects(rootManifestAfter), fastUnpack: false, hoistPattern: '*' }))
+
+  expect(hoistedDepOfPkg()).toBeTruthy()
 })
 
 test('should not override aliased dependencies', async () => {

--- a/pnpm11/installing/deps-installer/test/install/hoist.ts
+++ b/pnpm11/installing/deps-installer/test/install/hoist.ts
@@ -253,7 +253,7 @@ test('a filtered install after a removal keeps the other importers hoisted entri
     { mutation: 'install', rootDir: process.cwd() as ProjectRootDir },
     { mutation: 'install', rootDir: path.resolve('package') as ProjectRootDir },
   ]
-  const allProjects = (rootManifest: typeof rootManifestBefore) => [
+  const allProjects = (rootManifest: { name: string, dependencies: Record<string, string> }) => [
     { buildIndex: 0, manifest: rootManifest, rootDir: process.cwd() as ProjectRootDir },
     { buildIndex: 0, manifest: packageManifest, rootDir: path.resolve('package') as ProjectRootDir },
   ]

--- a/pnpm11/installing/deps-installer/test/lockfile.ts
+++ b/pnpm11/installing/deps-installer/test/lockfile.ts
@@ -645,9 +645,9 @@ test('pendingBuilds gets updated if a headless install removes packages', async 
   }, testDefaults({ fastUnpack: false, ignoreScripts: true }))
   const modules1 = project.readModulesManifest()
 
-  // The removal is resolved into the lockfile without touching node_modules,
-  // as pulling a teammate's lockfile would; the install after it takes the
-  // headless path.
+  // The lockfile-only resolve stands in for pulling a teammate's lockfile;
+  // the install after it takes the headless path. It runs without
+  // ignoreScripts to pin that the reconciliation is not tied to that flag.
   await install({
     dependencies: {
       '@pnpm.e2e/pre-and-postinstall-scripts-example': '*',
@@ -657,12 +657,16 @@ test('pendingBuilds gets updated if a headless install removes packages', async 
     dependencies: {
       '@pnpm.e2e/pre-and-postinstall-scripts-example': '*',
     },
-  }, testDefaults({ fastUnpack: false, ignoreScripts: true }))
+  }, testDefaults({ fastUnpack: false }))
   const modules2 = project.readModulesManifest()
+  const lockfile = project.readLockfile()
 
   expect(modules1).toBeTruthy()
   expect(modules2).toBeTruthy()
   expect(modules1!.pendingBuilds.length > modules2!.pendingBuilds.length).toBeTruthy()
+  for (const entry of modules2!.pendingBuilds) {
+    expect(lockfile.packages[entry] ?? lockfile.importers[entry]).toBeTruthy()
+  }
 })
 
 test('optional properties are correctly updated on named install', async () => {

--- a/pnpm11/installing/deps-installer/test/lockfile.ts
+++ b/pnpm11/installing/deps-installer/test/lockfile.ts
@@ -634,6 +634,37 @@ test('pendingBuilds gets updated if install removes packages', async () => {
   expect(modules1!.pendingBuilds.length > modules2!.pendingBuilds.length).toBeTruthy()
 })
 
+test('pendingBuilds gets updated if a headless install removes packages', async () => {
+  const project = prepareEmpty()
+
+  await install({
+    dependencies: {
+      '@pnpm.e2e/pre-and-postinstall-scripts-example': '*',
+      '@pnpm.e2e/with-postinstall-b': '*',
+    },
+  }, testDefaults({ fastUnpack: false, ignoreScripts: true }))
+  const modules1 = project.readModulesManifest()
+
+  // The removal is resolved into the lockfile without touching node_modules,
+  // as pulling a teammate's lockfile would; the install after it takes the
+  // headless path.
+  await install({
+    dependencies: {
+      '@pnpm.e2e/pre-and-postinstall-scripts-example': '*',
+    },
+  }, testDefaults({ fastUnpack: false, ignoreScripts: true, lockfileOnly: true }))
+  await install({
+    dependencies: {
+      '@pnpm.e2e/pre-and-postinstall-scripts-example': '*',
+    },
+  }, testDefaults({ fastUnpack: false, ignoreScripts: true }))
+  const modules2 = project.readModulesManifest()
+
+  expect(modules1).toBeTruthy()
+  expect(modules2).toBeTruthy()
+  expect(modules1!.pendingBuilds.length > modules2!.pendingBuilds.length).toBeTruthy()
+})
+
 test('optional properties are correctly updated on named install', async () => {
   const project = prepareEmpty()
 

--- a/pnpm11/installing/deps-restorer/src/index.ts
+++ b/pnpm11/installing/deps-restorer/src/index.ts
@@ -369,7 +369,8 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
     supportedArchitectures: opts.supportedArchitectures,
     includeUnchangedDeps: (!equals(opts.currentHoistPattern ?? [], opts.hoistPattern ?? [])) ||
       (!equals(opts.currentPublicHoistPattern ?? [], opts.publicHoistPattern ?? [])) ||
-      (opts.enableGlobalVirtualStore === true && !equals(opts.modulesFile?.allowBuilds ?? {}, opts.allowBuilds ?? {})),
+      (opts.enableGlobalVirtualStore === true && !equals(opts.modulesFile?.allowBuilds ?? {}, opts.allowBuilds ?? {})) ||
+      lockfileRemovesPackages(currentLockfile, wantedLockfile),
   } as LockfileToDepGraphOptions
   const {
     directDependenciesByImporterId,
@@ -407,6 +408,12 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
     })
   }
   const depNodes = Object.values(graph)
+  // A node the graph carries without a fetch was already materialized by an
+  // earlier install. It is in the graph so hoisting can see it; the build
+  // step must not run its scripts or re-apply its patch.
+  for (const depNode of depNodes) {
+    if (depNode.fetching == null) depNode.isBuilt = true
+  }
 
   const added = depNodes.filter(({ fetching }) => fetching).length
   const skipGvsInternalLinking = opts.enableGlobalVirtualStore === true && added === 0
@@ -487,37 +494,41 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
     })
 
     if (opts.ignorePackageManifest !== true && !skipPostImportLinking && (opts.hoistPattern != null || opts.publicHoistPattern != null)) {
-      newHoistedDependencies = {
-        ...opts.hoistedDependencies,
-        ...await hoist({
-          extraNodePath: opts.extraNodePaths,
-          graph,
-          directDepsByImporterId: Object.fromEntries(Object.entries(directDependenciesByImporterId).map(([projectId, deps]) => [
-            projectId,
-            new Map(Object.entries(deps)),
-          ])),
-          importerIds,
-          preferSymlinkedExecutables: opts.preferSymlinkedExecutables,
-          privateHoistedModulesDir: hoistedModulesDir,
-          privateHoistPattern: opts.hoistPattern ?? [],
-          publicHoistedModulesDir,
-          publicHoistPattern: opts.publicHoistPattern ?? [],
-          virtualStoreDir,
-          virtualStoreDirMaxLength: opts.virtualStoreDirMaxLength,
-          hoistedWorkspacePackages: opts.hoistWorkspacePackages
-            ? Object.values(opts.allProjects).reduce((hoistedWorkspacePackages, project) => {
-              if (project.manifest.name && project.id !== '.') {
-                hoistedWorkspacePackages[project.id] = {
-                  dir: project.rootDir,
-                  name: project.manifest.name,
-                }
+      // With the full graph the recomputed hoist map is complete, so it
+      // replaces the recorded one and drops the entries this install made
+      // ineligible. The incremental graph only knows the packages it
+      // imported, so there the recorded map fills in the rest.
+      const hoisted = await hoist({
+        extraNodePath: opts.extraNodePaths,
+        graph,
+        directDepsByImporterId: Object.fromEntries(Object.entries(directDependenciesByImporterId).map(([projectId, deps]) => [
+          projectId,
+          new Map(Object.entries(deps)),
+        ])),
+        importerIds,
+        preferSymlinkedExecutables: opts.preferSymlinkedExecutables,
+        privateHoistedModulesDir: hoistedModulesDir,
+        privateHoistPattern: opts.hoistPattern ?? [],
+        publicHoistedModulesDir,
+        publicHoistPattern: opts.publicHoistPattern ?? [],
+        virtualStoreDir,
+        virtualStoreDirMaxLength: opts.virtualStoreDirMaxLength,
+        hoistedWorkspacePackages: opts.hoistWorkspacePackages
+          ? Object.values(opts.allProjects).reduce((hoistedWorkspacePackages, project) => {
+            if (project.manifest.name && project.id !== '.') {
+              hoistedWorkspacePackages[project.id] = {
+                dir: project.rootDir,
+                name: project.manifest.name,
               }
-              return hoistedWorkspacePackages
-            }, {} as Record<string, HoistedWorkspaceProject>)
-            : undefined,
-          skipped: opts.skipped,
-        }),
-      }
+            }
+            return hoistedWorkspacePackages
+          }, {} as Record<string, HoistedWorkspaceProject>)
+          : undefined,
+        skipped: opts.skipped,
+      }) ?? {}
+      newHoistedDependencies = lockfileToDepGraphOpts.includeUnchangedDeps
+        ? hoisted
+        : { ...opts.hoistedDependencies, ...hoisted }
     } else {
       newHoistedDependencies = {}
     }
@@ -594,13 +605,17 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
         opts.pendingBuilds.push(id)
       }
     }
-    // we can use concat here because we always only append new packages, which are guaranteed to not be there by definition
-    opts.pendingBuilds = opts.pendingBuilds
-      .concat(
-        depNodes
-          .filter(({ requiresBuild }) => requiresBuild)
-          .map(({ depPath }) => depPath)
-      )
+    // Reconcile rather than append: an entry whose package the wanted
+    // lockfile no longer records would otherwise stay pending forever.
+    opts.pendingBuilds = Array.from(new Set(
+      opts.pendingBuilds
+        .filter((id) => wantedLockfile.packages?.[id as DepPath] != null || wantedLockfile.importers[id as ProjectId] != null)
+        .concat(
+          depNodes
+            .filter(({ requiresBuild }) => requiresBuild)
+            .map(({ depPath }) => depPath)
+        )
+    ))
   }
   let ignoredBuilds: IgnoredBuilds | undefined
   if ((!opts.ignoreScripts || Object.keys(opts.patchedDependencies ?? {}).length > 0) && opts.enableModulesDir !== false) {
@@ -956,6 +971,21 @@ async function getRootPackagesToLink (
 
 const limitLinking = pLimit(16)
 const limitModulesDirReads = pLimit(16)
+
+/**
+ * Whether moving from the installed state to the wanted lockfile removes any
+ * package. A removal changes the hoist eligibility of packages that stay, and
+ * the incremental graph of an install that only removes packages is empty, so
+ * the graph must include the unchanged packages for the hoist layer to be
+ * recomputed. Compared against the full wanted lockfile, not the filtered
+ * one, so a filtered install is not mistaken for a removal.
+ */
+function lockfileRemovesPackages (currentLockfile: LockfileObject | null, wantedLockfile: LockfileObject): boolean {
+  if (currentLockfile?.packages == null) return false
+  const wantedPackages = wantedLockfile.packages
+  if (wantedPackages == null) return Object.keys(currentLockfile.packages).length > 0
+  return Object.keys(currentLockfile.packages).some((depPath) => wantedPackages[depPath as DepPath] == null)
+}
 
 async function linkAllPkgs (
   storeController: StoreController,

--- a/pnpm11/installing/deps-restorer/src/index.ts
+++ b/pnpm11/installing/deps-restorer/src/index.ts
@@ -526,7 +526,14 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
           : undefined,
         skipped: opts.skipped,
       }) ?? {}
-      newHoistedDependencies = lockfileToDepGraphOpts.includeUnchangedDeps
+      // The recomputed map only replaces the recorded one when the graph is
+      // the whole workspace: a filtered install hoists from the filtered
+      // lockfile, so replacing there would forget the unselected importers'
+      // entries. Everywhere else the recorded map fills in what the graph
+      // does not know.
+      const hoistMapIsComplete = lockfileToDepGraphOpts.includeUnchangedDeps &&
+        equals([...importerIds].sort(), Object.keys(wantedLockfile.importers).sort())
+      newHoistedDependencies = hoistMapIsComplete
         ? hoisted
         : { ...opts.hoistedDependencies, ...hoisted }
     } else {
@@ -594,9 +601,14 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
     }
   }
 
+  // Reconcile in every mode, not only when scripts are ignored: an entry
+  // whose package the wanted lockfile no longer records would otherwise
+  // stay pending forever.
+  opts.pendingBuilds = opts.pendingBuilds
+    .filter((id) => wantedLockfile.packages?.[id as DepPath] != null || wantedLockfile.importers[id as ProjectId] != null)
   if (opts.ignoreScripts) {
     for (const { id, manifest } of selectedProjects) {
-      if (opts.ignoreScripts && ((manifest?.scripts) != null) &&
+      if (((manifest?.scripts) != null) &&
         (manifest.scripts.preinstall ?? manifest.scripts.prepublish ??
           manifest.scripts.install ??
           manifest.scripts.postinstall ??
@@ -605,16 +617,12 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
         opts.pendingBuilds.push(id)
       }
     }
-    // Reconcile rather than append: an entry whose package the wanted
-    // lockfile no longer records would otherwise stay pending forever.
     opts.pendingBuilds = Array.from(new Set(
-      opts.pendingBuilds
-        .filter((id) => wantedLockfile.packages?.[id as DepPath] != null || wantedLockfile.importers[id as ProjectId] != null)
-        .concat(
-          depNodes
-            .filter(({ requiresBuild }) => requiresBuild)
-            .map(({ depPath }) => depPath)
-        )
+      opts.pendingBuilds.concat(
+        depNodes
+          .filter(({ requiresBuild }) => requiresBuild)
+          .map(({ depPath }) => depPath)
+      )
     ))
   }
   let ignoredBuilds: IgnoredBuilds | undefined


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#13699.

The headless installer derives its work from the incremental dependency graph — the packages the wanted lockfile records that are not materialized yet. An install whose lockfile only **removes** packages has an empty graph, so every graph-driven stage silently did nothing:

- the hoist layer was never recomputed, so a package that became hoistable when a direct dependency was removed stayed unhoisted;
- `pendingBuilds` only ever appended, so entries for removed packages stayed pending forever.

Reachable with no unusual flags: pull a lockfile in which a teammate removed a dependency and run `pnpm install` — `allProjectsAreUpToDate` sends it down the headless path. Both symptoms reproduce on `main`; the regression tests in this PR fail without the fix.

### The fix

Desired state is computed from the wanted lockfile; incrementality stays at the I/O layer.

- The graph includes the unchanged packages whenever the transition from the installed state removes a package — the same `includeUnchangedDeps` mechanism a hoist-pattern change already uses. Unchanged nodes carry no fetch, so they are not re-imported (`linkAllPkgs` skips them) and are marked `isBuilt` so the build step does not re-run their scripts or re-apply their patches.
- With the graph complete, the recomputed hoist map **replaces** the recorded one instead of merging over it, so entries this install made ineligible are dropped from `.modules.yaml`.
- `pendingBuilds` is reconciled against the wanted lockfile rather than appended: entries whose package the lockfile no longer records are dropped.

The removal check compares the current lockfile against the **full** wanted lockfile, not the importer-filtered one, so a `--filter` install is not mistaken for a removal.

### pacquet

pacquet already behaves this way — `real_hoist::hoist` reads the lockfile, and `merge_pending_builds` retains only entries the current lockfile still records (covered by existing unit tests). The Rust side gains a pinning test for the rehoist scenario, which passes unchanged.

pacquet's own `pending_builds` test module already pins the removal scenario (`removing_a_package_shrinks_the_list`), so no Rust test was added either. An earlier revision of this description claimed a pendingBuilds population divergence; that was my misreading of a probe (pnpm/pnpm#13701, closed as incorrect).

### Why this PR exists

Surfaced by pnpm/pnpm#13698, whose removal fast path routed three existing tests into the headless path and made them fail. Those failures were symptoms of this pre-existing bug — any fast lockfile update that removes packages (the merged `ignoredOptionalDependencies` handler included) inherits it. Fixing headless fixes them all at once; 13698 will be rebased on top of this.

## Squash Commit Body

```text
The headless installer derives its work from the incremental graph — the
packages the wanted lockfile records that are not materialized yet. An
install whose lockfile only removes packages has an empty graph, so every
graph-driven stage silently did nothing: the hoist layer was never
recomputed (a package that became hoistable when a direct dependency was
removed stayed unhoisted), and pendingBuilds only ever appended, so
entries for removed packages stayed pending forever.

Reachable with no unusual flags: pull a lockfile in which a dependency
was removed and run `pnpm install` — allProjectsAreUpToDate sends it down
the headless path.

Include the unchanged packages in the graph whenever the transition from
the installed state removes a package, the same mechanism a hoist-pattern
change already uses. Unfetched nodes are marked built so the build step
does not re-run their scripts or re-apply their patches, and with the
graph complete the recomputed hoist map replaces the recorded one instead
of merging over it. pendingBuilds is reconciled against the wanted
lockfile rather than appended.

pacquet already behaves this way — its hoist pass reads the lockfile and
its pending-builds merge retains only entries the current lockfile still
records — so the Rust side only gains a pinning test.

Fixes pnpm/pnpm#13699.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13700"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788693264&installation_model_id=426870&pr_number=13700&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13700&signature=cae508bd2985170d43722f50e57768b3ea549c3986886631edb3e32a89823609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Lockfile-only installs now correctly recalculate dependency hoisting after packages are removed.
  * Removed packages no longer leave stale pending build entries.
  * Headless installs better reconcile dependencies and workspace packages with the updated lockfile.

* **Tests**
  * Added regression coverage for dependency removal, rehoisting, and pending build cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
