### PR TITLE
ci(release): stage pnpm packages before publishing

### DIFF
--- a/.github/scripts/npm-package-publication-state.sh
+++ b/.github/scripts/npm-package-publication-state.sh
@@ -3,8 +3,9 @@
 set -u
 
 package_spec=$1
+registry=https://registry.npmjs.org/
 
-if output=$(cd "${RUNNER_TEMP:-/tmp}" && npm view "$package_spec" version 2>&1); then
+if output=$(cd "${RUNNER_TEMP:-/tmp}" && npm view "$package_spec" version --registry "$registry" 2>&1); then
   echo published
 elif grep -Eq '^npm (ERR!|error) code E404$' <<< "$output"; then
   echo missing

--- a/.github/scripts/npm-package-publication-state.test.sh
+++ b/.github/scripts/npm-package-publication-state.test.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# cspell:ignore ECONNRESET
+
 set -euo pipefail
 
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
@@ -10,6 +12,10 @@ mkdir "$fake_bin"
 
 cat > "$fake_bin/npm" <<'EOF'
 #!/usr/bin/env bash
+if [ "$4" != '--registry' ] || [ "$5" != 'https://registry.npmjs.org/' ]; then
+  echo "unexpected registry arguments: $*" >&2
+  exit 1
+fi
 case "$2" in
   published)
     echo 1.0.0

--- a/.github/scripts/npm-staged-publication.sh
+++ b/.github/scripts/npm-staged-publication.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+read_package_identity() {
+  local package_dir=$1
+  local manifest="$package_dir/package.json"
+  if [ ! -f "$manifest" ]; then
+    echo "::error::Missing package manifest: $manifest" >&2
+    return 1
+  fi
+  jq -er '
+    [(.publishConfig.name // .name), .version]
+    | select(all(.[]; type == "string" and length > 0))
+    | @tsv
+  ' "$manifest"
+}
+
+publication_state() {
+  "$script_dir/npm-package-publication-state.sh" "$1"
+}
+
+stage_packages() {
+  local layer=$1
+  local tag=$2
+  shift 2
+
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    {
+      printf '### npm staged publication: %s\n\n' "$layer"
+      printf '| Package | Stage ID |\n'
+      printf '| --- | --- |\n'
+    } >> "$GITHUB_STEP_SUMMARY"
+  fi
+
+  local package_dir name version package_spec state stage_output stage_id
+  local staged_count=0
+  for package_dir in "$@"; do
+    IFS=$'\t' read -r name version < <(read_package_identity "$package_dir")
+    package_spec="$name@$version"
+    state=$(publication_state "$package_spec")
+    case "$state" in
+      published)
+        echo "$package_spec is already published; skipping"
+        if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+          printf '| `%s` | already published |\n' "$package_spec" >> "$GITHUB_STEP_SUMMARY"
+        fi
+        ;;
+      missing)
+        stage_output=$(pnpm stage publish "${package_dir%/}/" \
+          --tag "$tag" \
+          --access public \
+          --provenance \
+          --no-git-checks \
+          --json)
+        if ! stage_id=$(jq -er --arg name "$name" \
+          '.[$name].stageId | strings | select(length > 0)' <<< "$stage_output"); then
+          echo "::error::pnpm stage publish returned no stage ID for $package_spec" >&2
+          while IFS= read -r line; do
+            printf 'stage output: %s\n' "$line" >&2
+          done <<< "$stage_output"
+          return 1
+        fi
+        echo "Staged $package_spec with ID $stage_id"
+        if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+          printf '| `%s` | `%s` |\n' "$package_spec" "$stage_id" >> "$GITHUB_STEP_SUMMARY"
+        fi
+        staged_count=$((staged_count + 1))
+        ;;
+      *)
+        echo "::error::Unexpected npm publication state for $package_spec" >&2
+        return 1
+        ;;
+    esac
+  done
+
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ] && [ "$staged_count" -gt 0 ]; then
+    {
+      printf '\nApprove every staged package above with interactive 2FA using '
+      printf '`pnpm stage approve <stage-id>`. '
+      printf 'The workflow will continue after this entire dependency layer is public.\n'
+    } >> "$GITHUB_STEP_SUMMARY"
+  fi
+}
+
+wait_for_packages() {
+  local layer=$1
+  shift
+
+  local poll_seconds=${NPM_PUBLICATION_POLL_SECONDS:-30}
+  local timeout_seconds=${NPM_PUBLICATION_TIMEOUT_SECONDS:-19800}
+  if [[ ! $poll_seconds =~ ^[0-9]+$ ]]; then
+    echo "::error::NPM_PUBLICATION_POLL_SECONDS must be a non-negative integer" >&2
+    return 1
+  fi
+  if [[ ! $timeout_seconds =~ ^[0-9]+$ ]]; then
+    echo "::error::NPM_PUBLICATION_TIMEOUT_SECONDS must be a non-negative integer" >&2
+    return 1
+  fi
+
+  local package_dir name version package_spec state
+  local -a package_specs=()
+  for package_dir in "$@"; do
+    IFS=$'\t' read -r name version < <(read_package_identity "$package_dir")
+    package_specs+=("$name@$version")
+  done
+
+  local deadline=$((SECONDS + timeout_seconds))
+  local -a pending=()
+  while true; do
+    pending=()
+    for package_spec in "${package_specs[@]}"; do
+      state=$(publication_state "$package_spec")
+      case "$state" in
+        published) ;;
+        missing) pending+=("$package_spec") ;;
+        *)
+          echo "::error::Unexpected npm publication state for $package_spec" >&2
+          return 1
+          ;;
+      esac
+    done
+
+    if [ "${#pending[@]}" -eq 0 ]; then
+      echo "Every package in $layer is published."
+      return
+    fi
+    if [ "$SECONDS" -ge "$deadline" ]; then
+      echo "::error::Timed out waiting for npm approval of the $layer packages:" >&2
+      printf '  %s\n' "${pending[@]}" >&2
+      return 1
+    fi
+
+    echo "Waiting for npm approval of the $layer packages:"
+    printf '  %s\n' "${pending[@]}"
+    sleep "$poll_seconds"
+  done
+}
+
+case "${1:-}" in
+  stage)
+    if [ "$#" -lt 4 ]; then
+      echo "Usage: $0 stage <layer> <tag> <package-dir>..." >&2
+      exit 1
+    fi
+    shift
+    stage_packages "$@"
+    ;;
+  wait)
+    if [ "$#" -lt 3 ]; then
+      echo "Usage: $0 wait <layer> <package-dir>..." >&2
+      exit 1
+    fi
+    shift
+    wait_for_packages "$@"
+    ;;
+  *)
+    echo "Usage: $0 <stage|wait> ..." >&2
+    exit 1
+    ;;
+esac

--- a/.github/scripts/npm-staged-publication.sh
+++ b/.github/scripts/npm-staged-publication.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+registry=https://registry.npmjs.org/
 
 read_package_identity() {
   local package_dir=$1
@@ -35,7 +36,7 @@ stage_packages() {
     } >> "$GITHUB_STEP_SUMMARY"
   fi
 
-  local package_dir name version package_spec state stage_output stage_id
+  local package_dir package_path name version package_spec state stage_output stage_id
   local staged_count=0
   for package_dir in "$@"; do
     IFS=$'\t' read -r name version < <(read_package_identity "$package_dir")
@@ -49,7 +50,10 @@ stage_packages() {
         fi
         ;;
       missing)
-        stage_output=$(pnpm stage publish "${package_dir%/}/" \
+        package_path=$(cd "$package_dir" && pwd -P)
+        stage_output=$(pnpm stage publish "$package_path/" \
+          --registry "$registry" \
+          --npmrc-auth-file /dev/null \
           --tag "$tag" \
           --access public \
           --provenance \
@@ -90,9 +94,9 @@ wait_for_packages() {
   shift
 
   local poll_seconds=${NPM_PUBLICATION_POLL_SECONDS:-30}
-  local timeout_seconds=${NPM_PUBLICATION_TIMEOUT_SECONDS:-19800}
-  if [[ ! $poll_seconds =~ ^[0-9]+$ ]]; then
-    echo "::error::NPM_PUBLICATION_POLL_SECONDS must be a non-negative integer" >&2
+  local timeout_seconds=${NPM_PUBLICATION_TIMEOUT_SECONDS:-5400}
+  if [[ ! $poll_seconds =~ ^[1-9][0-9]*$ ]]; then
+    echo "::error::NPM_PUBLICATION_POLL_SECONDS must be a positive integer" >&2
     return 1
   fi
   if [[ ! $timeout_seconds =~ ^[0-9]+$ ]]; then
@@ -100,7 +104,7 @@ wait_for_packages() {
     return 1
   fi
 
-  local package_dir name version package_spec state
+  local package_dir name version package_spec state lookup_output
   local -a package_specs=()
   for package_dir in "$@"; do
     IFS=$'\t' read -r name version < <(read_package_identity "$package_dir")
@@ -108,11 +112,22 @@ wait_for_packages() {
   done
 
   local deadline=$((SECONDS + timeout_seconds))
+  local consecutive_lookup_failures=0
+  local max_consecutive_lookup_failures=3
   local -a pending=()
   while true; do
     pending=()
+    local lookup_failed=false
     for package_spec in "${package_specs[@]}"; do
-      state=$(publication_state "$package_spec")
+      if ! lookup_output=$(publication_state "$package_spec" 2>&1); then
+        pending+=("$package_spec")
+        lookup_failed=true
+        while IFS= read -r line; do
+          printf 'publication state lookup: %s\n' "$line" >&2
+        done <<< "$lookup_output"
+        continue
+      fi
+      state=$lookup_output
       case "$state" in
         published) ;;
         missing) pending+=("$package_spec") ;;
@@ -122,6 +137,16 @@ wait_for_packages() {
           ;;
       esac
     done
+
+    if [ "$lookup_failed" = true ]; then
+      consecutive_lookup_failures=$((consecutive_lookup_failures + 1))
+      if [ "$consecutive_lookup_failures" -ge "$max_consecutive_lookup_failures" ]; then
+        echo "::error::npm publication state lookup failed $consecutive_lookup_failures consecutive times" >&2
+        return 1
+      fi
+    else
+      consecutive_lookup_failures=0
+    fi
 
     if [ "${#pending[@]}" -eq 0 ]; then
       echo "Every package in $layer is published."

--- a/.github/scripts/npm-staged-publication.sh
+++ b/.github/scripts/npm-staged-publication.sh
@@ -84,84 +84,9 @@ stage_packages() {
     {
       printf '\nApprove every staged package above with interactive 2FA using '
       printf '`pnpm stage approve <stage-id>`. '
-      printf 'The workflow will continue after this entire dependency layer is public.\n'
+      printf 'Wait until the workflow finishes, then approve the dependency layers in release order.\n'
     } >> "$GITHUB_STEP_SUMMARY"
   fi
-}
-
-wait_for_packages() {
-  local layer=$1
-  shift
-
-  local poll_seconds=${NPM_PUBLICATION_POLL_SECONDS:-30}
-  local timeout_seconds=${NPM_PUBLICATION_TIMEOUT_SECONDS:-5400}
-  if [[ ! $poll_seconds =~ ^[1-9][0-9]*$ ]]; then
-    echo "::error::NPM_PUBLICATION_POLL_SECONDS must be a positive integer" >&2
-    return 1
-  fi
-  if [[ ! $timeout_seconds =~ ^[0-9]+$ ]]; then
-    echo "::error::NPM_PUBLICATION_TIMEOUT_SECONDS must be a non-negative integer" >&2
-    return 1
-  fi
-
-  local package_dir name version package_spec state lookup_output
-  local -a package_specs=()
-  for package_dir in "$@"; do
-    IFS=$'\t' read -r name version < <(read_package_identity "$package_dir")
-    package_specs+=("$name@$version")
-  done
-
-  local deadline=$((SECONDS + timeout_seconds))
-  local consecutive_lookup_failures=0
-  local max_consecutive_lookup_failures=3
-  local -a pending=()
-  while true; do
-    pending=()
-    local lookup_failed=false
-    for package_spec in "${package_specs[@]}"; do
-      if ! lookup_output=$(publication_state "$package_spec" 2>&1); then
-        pending+=("$package_spec")
-        lookup_failed=true
-        while IFS= read -r line; do
-          printf 'publication state lookup: %s\n' "$line" >&2
-        done <<< "$lookup_output"
-        continue
-      fi
-      state=$lookup_output
-      case "$state" in
-        published) ;;
-        missing) pending+=("$package_spec") ;;
-        *)
-          echo "::error::Unexpected npm publication state for $package_spec" >&2
-          return 1
-          ;;
-      esac
-    done
-
-    if [ "$lookup_failed" = true ]; then
-      consecutive_lookup_failures=$((consecutive_lookup_failures + 1))
-      if [ "$consecutive_lookup_failures" -ge "$max_consecutive_lookup_failures" ]; then
-        echo "::error::npm publication state lookup failed $consecutive_lookup_failures consecutive times" >&2
-        return 1
-      fi
-    else
-      consecutive_lookup_failures=0
-    fi
-
-    if [ "${#pending[@]}" -eq 0 ]; then
-      echo "Every package in $layer is published."
-      return
-    fi
-    if [ "$SECONDS" -ge "$deadline" ]; then
-      echo "::error::Timed out waiting for npm approval of the $layer packages:" >&2
-      printf '  %s\n' "${pending[@]}" >&2
-      return 1
-    fi
-
-    echo "Waiting for npm approval of the $layer packages:"
-    printf '  %s\n' "${pending[@]}"
-    sleep "$poll_seconds"
-  done
 }
 
 case "${1:-}" in
@@ -173,16 +98,8 @@ case "${1:-}" in
     shift
     stage_packages "$@"
     ;;
-  wait)
-    if [ "$#" -lt 3 ]; then
-      echo "Usage: $0 wait <layer> <package-dir>..." >&2
-      exit 1
-    fi
-    shift
-    wait_for_packages "$@"
-    ;;
   *)
-    echo "Usage: $0 <stage|wait> ..." >&2
+    echo "Usage: $0 stage <layer> <tag> <package-dir>..." >&2
     exit 1
     ;;
 esac

--- a/.github/scripts/npm-staged-publication.sh
+++ b/.github/scripts/npm-staged-publication.sh
@@ -58,6 +58,7 @@ stage_packages() {
           --access public \
           --provenance \
           --no-git-checks \
+          --reporter=silent \
           --json)
         if ! stage_id=$(jq -er --arg name "$name" \
           '.[$name].stageId | strings | select(length > 0)' <<< "$stage_output"); then

--- a/.github/scripts/npm-staged-publication.test.sh
+++ b/.github/scripts/npm-staged-publication.test.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# cspell:ignore ECONNRESET
+
 set -euo pipefail
 
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
@@ -31,6 +33,10 @@ create_package "$test_tmp/wait" '@pnpm/wait'
 cat > "$fake_bin/npm" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+if [ "$4" != '--registry' ] || [ "$5" != 'https://registry.npmjs.org/' ]; then
+  echo "unexpected registry arguments: $*" >&2
+  exit 1
+fi
 package_spec=$2
 case "${NPM_STAGE_TEST_MODE:-stage}:$package_spec" in
   stage:@pnpm/already@1.0.0)
@@ -49,10 +55,18 @@ case "${NPM_STAGE_TEST_MODE:-stage}:$package_spec" in
     count=$((count + 1))
     echo "$count" > "$count_file"
     if [ "$count" -eq 1 ]; then
+      echo 'npm error code ECONNRESET' >&2
+      exit 1
+    fi
+    if [ "$count" -eq 2 ]; then
       echo 'npm error code E404' >&2
       exit 1
     fi
     echo 1.0.0
+    ;;
+  lookup-failure:@pnpm/wait@1.0.0)
+    echo 'npm error code ECONNRESET' >&2
+    exit 1
     ;;
   *)
     echo "unexpected npm view: $*" >&2
@@ -70,6 +84,7 @@ package_dir=${3%/}
 name=$(jq -r '.publishConfig.name // .name' "$package_dir/package.json")
 version=$(jq -r '.version' "$package_dir/package.json")
 if [ "${NPM_STAGE_OUTPUT_MODE:-valid}" = missing-id ]; then
+  echo '::warning::forged-stage-output'
   jq -n --arg name "$name" --arg version "$version" \
     '{($name): {name: $name, version: $version}}'
 else
@@ -78,6 +93,12 @@ else
 fi
 EOF
 chmod +x "$fake_bin/pnpm"
+
+cat > "$fake_bin/sleep" <<'EOF'
+#!/usr/bin/env bash
+test "$1" = 1
+EOF
+chmod +x "$fake_bin/sleep"
 
 summary="$test_tmp/summary.md"
 pnpm_log="$test_tmp/pnpm.log"
@@ -89,7 +110,7 @@ NPM_STAGE_TEST_PNPM_LOG="$pnpm_log" \
   "$script_dir/npm-staged-publication.sh" stage 'test layer' next-12 \
     "$test_tmp/staged" "$test_tmp/already"
 
-grep -q 'stage publish.*/staged/ --tag next-12 --access public --provenance --no-git-checks --json' "$pnpm_log"
+grep -q 'stage publish.*/staged/ --registry https://registry.npmjs.org/ --npmrc-auth-file /dev/null --tag next-12 --access public --provenance --no-git-checks --json' "$pnpm_log"
 test "$(wc -l < "$pnpm_log")" -eq 1
 grep -q '| `@pnpm/staged@1.0.0` | `11111111-2222-4333-8444-555555555555` |' "$summary"
 grep -q '| `@pnpm/already@1.0.0` | already published |' "$summary"
@@ -105,23 +126,59 @@ if PATH="$fake_bin:$PATH" \
   exit 1
 fi
 grep -q 'returned no stage ID for @pnpm/staged@1.0.0' "$test_tmp/missing-id.out"
+grep -q '^stage output: ::warning::forged-stage-output$' "$test_tmp/missing-id.out"
+if grep -q '^::warning::forged-stage-output$' "$test_tmp/missing-id.out"; then
+  echo 'stage output produced a workflow command' >&2
+  exit 1
+fi
+
+if PATH="$fake_bin:$PATH" \
+  RUNNER_TEMP="$test_tmp" \
+  NPM_STAGE_TEST_MODE=wait \
+  NPM_STAGE_TEST_STATE_DIR="$state_dir" \
+  NPM_PUBLICATION_POLL_SECONDS=0 \
+  NPM_PUBLICATION_TIMEOUT_SECONDS=5 \
+    "$script_dir/npm-staged-publication.sh" wait 'test layer' "$test_tmp/wait" \
+      > "$test_tmp/invalid-poll.out" 2>&1; then
+  echo 'expected a zero publication polling interval to fail' >&2
+  exit 1
+fi
+grep -q 'NPM_PUBLICATION_POLL_SECONDS must be a positive integer' "$test_tmp/invalid-poll.out"
 
 PATH="$fake_bin:$PATH" \
 RUNNER_TEMP="$test_tmp" \
 NPM_STAGE_TEST_MODE=wait \
 NPM_STAGE_TEST_STATE_DIR="$state_dir" \
-NPM_PUBLICATION_POLL_SECONDS=0 \
+NPM_PUBLICATION_POLL_SECONDS=1 \
 NPM_PUBLICATION_TIMEOUT_SECONDS=5 \
   "$script_dir/npm-staged-publication.sh" wait 'test layer' "$test_tmp/wait" \
-    > "$test_tmp/wait.out"
+    > "$test_tmp/wait.out" 2>&1
 grep -q 'Waiting for npm approval of the test layer packages' "$test_tmp/wait.out"
+grep -q '^publication state lookup: ::error::npm view failed$' "$test_tmp/wait.out"
+if grep -q '^::error::npm view failed$' "$test_tmp/wait.out"; then
+  echo 'publication lookup output produced a workflow command' >&2
+  exit 1
+fi
 grep -q 'Every package in test layer is published' "$test_tmp/wait.out"
+
+if PATH="$fake_bin:$PATH" \
+  RUNNER_TEMP="$test_tmp" \
+  NPM_STAGE_TEST_MODE=lookup-failure \
+  NPM_STAGE_TEST_STATE_DIR="$state_dir" \
+  NPM_PUBLICATION_POLL_SECONDS=1 \
+  NPM_PUBLICATION_TIMEOUT_SECONDS=5 \
+    "$script_dir/npm-staged-publication.sh" wait 'test layer' "$test_tmp/wait" \
+      > "$test_tmp/lookup-failure.out" 2>&1; then
+  echo 'expected repeated publication lookup failures to fail' >&2
+  exit 1
+fi
+grep -q 'npm publication state lookup failed 3 consecutive times' "$test_tmp/lookup-failure.out"
 
 if PATH="$fake_bin:$PATH" \
   RUNNER_TEMP="$test_tmp" \
   NPM_STAGE_TEST_MODE=timeout \
   NPM_STAGE_TEST_STATE_DIR="$state_dir" \
-  NPM_PUBLICATION_POLL_SECONDS=0 \
+  NPM_PUBLICATION_POLL_SECONDS=1 \
   NPM_PUBLICATION_TIMEOUT_SECONDS=0 \
     "$script_dir/npm-staged-publication.sh" wait 'test layer' "$test_tmp/wait" \
       > "$test_tmp/timeout.out" 2>&1; then

--- a/.github/scripts/npm-staged-publication.test.sh
+++ b/.github/scripts/npm-staged-publication.test.sh
@@ -78,7 +78,7 @@ NPM_STAGE_TEST_PNPM_LOG="$pnpm_log" \
   "$script_dir/npm-staged-publication.sh" stage 'test layer' next-12 \
     "$test_tmp/staged" "$test_tmp/already"
 
-grep -q 'stage publish.*/staged/ --registry https://registry.npmjs.org/ --npmrc-auth-file /dev/null --tag next-12 --access public --provenance --no-git-checks --json' "$pnpm_log"
+grep -q 'stage publish.*/staged/ --registry https://registry.npmjs.org/ --npmrc-auth-file /dev/null --tag next-12 --access public --provenance --no-git-checks --reporter=silent --json' "$pnpm_log"
 test "$(wc -l < "$pnpm_log")" -eq 1
 grep -q '| `@pnpm/staged@1.0.0` | `11111111-2222-4333-8444-555555555555` |' "$summary"
 grep -q '| `@pnpm/already@1.0.0` | already published |' "$summary"

--- a/.github/scripts/npm-staged-publication.test.sh
+++ b/.github/scripts/npm-staged-publication.test.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+fake_bin="$test_tmp/bin"
+state_dir="$test_tmp/state"
+mkdir "$fake_bin" "$state_dir"
+
+create_package() {
+  local dir=$1
+  local name=$2
+  mkdir "$dir"
+  cat > "$dir/package.json" <<EOF
+{
+  "name": "private-workspace-name",
+  "version": "1.0.0",
+  "publishConfig": {
+    "name": "$name"
+  }
+}
+EOF
+}
+
+create_package "$test_tmp/staged" '@pnpm/staged'
+create_package "$test_tmp/already" '@pnpm/already'
+create_package "$test_tmp/wait" '@pnpm/wait'
+
+cat > "$fake_bin/npm" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+package_spec=$2
+case "${NPM_STAGE_TEST_MODE:-stage}:$package_spec" in
+  stage:@pnpm/already@1.0.0)
+    echo 1.0.0
+    ;;
+  stage:@pnpm/staged@1.0.0|timeout:@pnpm/wait@1.0.0)
+    echo 'npm error code E404' >&2
+    exit 1
+    ;;
+  wait:@pnpm/wait@1.0.0)
+    count_file="$NPM_STAGE_TEST_STATE_DIR/wait-count"
+    count=0
+    if [ -f "$count_file" ]; then
+      count=$(<"$count_file")
+    fi
+    count=$((count + 1))
+    echo "$count" > "$count_file"
+    if [ "$count" -eq 1 ]; then
+      echo 'npm error code E404' >&2
+      exit 1
+    fi
+    echo 1.0.0
+    ;;
+  *)
+    echo "unexpected npm view: $*" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "$fake_bin/npm"
+
+cat > "$fake_bin/pnpm" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$NPM_STAGE_TEST_PNPM_LOG"
+package_dir=${3%/}
+name=$(jq -r '.publishConfig.name // .name' "$package_dir/package.json")
+version=$(jq -r '.version' "$package_dir/package.json")
+if [ "${NPM_STAGE_OUTPUT_MODE:-valid}" = missing-id ]; then
+  jq -n --arg name "$name" --arg version "$version" \
+    '{($name): {name: $name, version: $version}}'
+else
+  jq -n --arg name "$name" --arg version "$version" \
+    '{($name): {name: $name, version: $version, stageId: "11111111-2222-4333-8444-555555555555"}}'
+fi
+EOF
+chmod +x "$fake_bin/pnpm"
+
+summary="$test_tmp/summary.md"
+pnpm_log="$test_tmp/pnpm.log"
+PATH="$fake_bin:$PATH" \
+RUNNER_TEMP="$test_tmp" \
+GITHUB_STEP_SUMMARY="$summary" \
+NPM_STAGE_TEST_MODE=stage \
+NPM_STAGE_TEST_PNPM_LOG="$pnpm_log" \
+  "$script_dir/npm-staged-publication.sh" stage 'test layer' next-12 \
+    "$test_tmp/staged" "$test_tmp/already"
+
+grep -q 'stage publish.*/staged/ --tag next-12 --access public --provenance --no-git-checks --json' "$pnpm_log"
+test "$(wc -l < "$pnpm_log")" -eq 1
+grep -q '| `@pnpm/staged@1.0.0` | `11111111-2222-4333-8444-555555555555` |' "$summary"
+grep -q '| `@pnpm/already@1.0.0` | already published |' "$summary"
+
+if PATH="$fake_bin:$PATH" \
+  RUNNER_TEMP="$test_tmp" \
+  NPM_STAGE_TEST_MODE=stage \
+  NPM_STAGE_OUTPUT_MODE=missing-id \
+  NPM_STAGE_TEST_PNPM_LOG="$pnpm_log" \
+    "$script_dir/npm-staged-publication.sh" stage 'test layer' next-12 \
+      "$test_tmp/staged" > "$test_tmp/missing-id.out" 2>&1; then
+  echo 'expected staging without a stage ID to fail' >&2
+  exit 1
+fi
+grep -q 'returned no stage ID for @pnpm/staged@1.0.0' "$test_tmp/missing-id.out"
+
+PATH="$fake_bin:$PATH" \
+RUNNER_TEMP="$test_tmp" \
+NPM_STAGE_TEST_MODE=wait \
+NPM_STAGE_TEST_STATE_DIR="$state_dir" \
+NPM_PUBLICATION_POLL_SECONDS=0 \
+NPM_PUBLICATION_TIMEOUT_SECONDS=5 \
+  "$script_dir/npm-staged-publication.sh" wait 'test layer' "$test_tmp/wait" \
+    > "$test_tmp/wait.out"
+grep -q 'Waiting for npm approval of the test layer packages' "$test_tmp/wait.out"
+grep -q 'Every package in test layer is published' "$test_tmp/wait.out"
+
+if PATH="$fake_bin:$PATH" \
+  RUNNER_TEMP="$test_tmp" \
+  NPM_STAGE_TEST_MODE=timeout \
+  NPM_STAGE_TEST_STATE_DIR="$state_dir" \
+  NPM_PUBLICATION_POLL_SECONDS=0 \
+  NPM_PUBLICATION_TIMEOUT_SECONDS=0 \
+    "$script_dir/npm-staged-publication.sh" wait 'test layer' "$test_tmp/wait" \
+      > "$test_tmp/timeout.out" 2>&1; then
+  echo 'expected publication wait to time out' >&2
+  exit 1
+fi
+grep -q 'Timed out waiting for npm approval of the test layer packages' "$test_tmp/timeout.out"

--- a/.github/scripts/npm-staged-publication.test.sh
+++ b/.github/scripts/npm-staged-publication.test.sh
@@ -1,15 +1,12 @@
 #!/usr/bin/env bash
 
-# cspell:ignore ECONNRESET
-
 set -euo pipefail
 
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 test_tmp=$(mktemp -d)
 trap 'rm -rf "$test_tmp"' EXIT
 fake_bin="$test_tmp/bin"
-state_dir="$test_tmp/state"
-mkdir "$fake_bin" "$state_dir"
+mkdir "$fake_bin"
 
 create_package() {
   local dir=$1
@@ -28,7 +25,6 @@ EOF
 
 create_package "$test_tmp/staged" '@pnpm/staged'
 create_package "$test_tmp/already" '@pnpm/already'
-create_package "$test_tmp/wait" '@pnpm/wait'
 
 cat > "$fake_bin/npm" <<'EOF'
 #!/usr/bin/env bash
@@ -42,30 +38,8 @@ case "${NPM_STAGE_TEST_MODE:-stage}:$package_spec" in
   stage:@pnpm/already@1.0.0)
     echo 1.0.0
     ;;
-  stage:@pnpm/staged@1.0.0|timeout:@pnpm/wait@1.0.0)
+  stage:@pnpm/staged@1.0.0)
     echo 'npm error code E404' >&2
-    exit 1
-    ;;
-  wait:@pnpm/wait@1.0.0)
-    count_file="$NPM_STAGE_TEST_STATE_DIR/wait-count"
-    count=0
-    if [ -f "$count_file" ]; then
-      count=$(<"$count_file")
-    fi
-    count=$((count + 1))
-    echo "$count" > "$count_file"
-    if [ "$count" -eq 1 ]; then
-      echo 'npm error code ECONNRESET' >&2
-      exit 1
-    fi
-    if [ "$count" -eq 2 ]; then
-      echo 'npm error code E404' >&2
-      exit 1
-    fi
-    echo 1.0.0
-    ;;
-  lookup-failure:@pnpm/wait@1.0.0)
-    echo 'npm error code ECONNRESET' >&2
     exit 1
     ;;
   *)
@@ -93,12 +67,6 @@ else
 fi
 EOF
 chmod +x "$fake_bin/pnpm"
-
-cat > "$fake_bin/sleep" <<'EOF'
-#!/usr/bin/env bash
-test "$1" = 1
-EOF
-chmod +x "$fake_bin/sleep"
 
 summary="$test_tmp/summary.md"
 pnpm_log="$test_tmp/pnpm.log"
@@ -131,58 +99,3 @@ if grep -q '^::warning::forged-stage-output$' "$test_tmp/missing-id.out"; then
   echo 'stage output produced a workflow command' >&2
   exit 1
 fi
-
-if PATH="$fake_bin:$PATH" \
-  RUNNER_TEMP="$test_tmp" \
-  NPM_STAGE_TEST_MODE=wait \
-  NPM_STAGE_TEST_STATE_DIR="$state_dir" \
-  NPM_PUBLICATION_POLL_SECONDS=0 \
-  NPM_PUBLICATION_TIMEOUT_SECONDS=5 \
-    "$script_dir/npm-staged-publication.sh" wait 'test layer' "$test_tmp/wait" \
-      > "$test_tmp/invalid-poll.out" 2>&1; then
-  echo 'expected a zero publication polling interval to fail' >&2
-  exit 1
-fi
-grep -q 'NPM_PUBLICATION_POLL_SECONDS must be a positive integer' "$test_tmp/invalid-poll.out"
-
-PATH="$fake_bin:$PATH" \
-RUNNER_TEMP="$test_tmp" \
-NPM_STAGE_TEST_MODE=wait \
-NPM_STAGE_TEST_STATE_DIR="$state_dir" \
-NPM_PUBLICATION_POLL_SECONDS=1 \
-NPM_PUBLICATION_TIMEOUT_SECONDS=5 \
-  "$script_dir/npm-staged-publication.sh" wait 'test layer' "$test_tmp/wait" \
-    > "$test_tmp/wait.out" 2>&1
-grep -q 'Waiting for npm approval of the test layer packages' "$test_tmp/wait.out"
-grep -q '^publication state lookup: ::error::npm view failed$' "$test_tmp/wait.out"
-if grep -q '^::error::npm view failed$' "$test_tmp/wait.out"; then
-  echo 'publication lookup output produced a workflow command' >&2
-  exit 1
-fi
-grep -q 'Every package in test layer is published' "$test_tmp/wait.out"
-
-if PATH="$fake_bin:$PATH" \
-  RUNNER_TEMP="$test_tmp" \
-  NPM_STAGE_TEST_MODE=lookup-failure \
-  NPM_STAGE_TEST_STATE_DIR="$state_dir" \
-  NPM_PUBLICATION_POLL_SECONDS=1 \
-  NPM_PUBLICATION_TIMEOUT_SECONDS=5 \
-    "$script_dir/npm-staged-publication.sh" wait 'test layer' "$test_tmp/wait" \
-      > "$test_tmp/lookup-failure.out" 2>&1; then
-  echo 'expected repeated publication lookup failures to fail' >&2
-  exit 1
-fi
-grep -q 'npm publication state lookup failed 3 consecutive times' "$test_tmp/lookup-failure.out"
-
-if PATH="$fake_bin:$PATH" \
-  RUNNER_TEMP="$test_tmp" \
-  NPM_STAGE_TEST_MODE=timeout \
-  NPM_STAGE_TEST_STATE_DIR="$state_dir" \
-  NPM_PUBLICATION_POLL_SECONDS=1 \
-  NPM_PUBLICATION_TIMEOUT_SECONDS=0 \
-    "$script_dir/npm-staged-publication.sh" wait 'test layer' "$test_tmp/wait" \
-      > "$test_tmp/timeout.out" 2>&1; then
-  echo 'expected publication wait to time out' >&2
-  exit 1
-fi
-grep -q 'Timed out waiting for npm approval of the test layer packages' "$test_tmp/timeout.out"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,8 +82,10 @@ jobs:
         persist-credentials: false
     - name: Install pnpm
       uses: pnpm/setup@6523ce966bcf7a1061ce6401e5c6e0b60466bd31
-    - name: Test release publication guard
-      run: .github/scripts/npm-package-publication-state.test.sh
+    - name: Test release publication scripts
+      run: |
+        .github/scripts/npm-package-publication-state.test.sh
+        .github/scripts/npm-staged-publication.test.sh
     - name: Compile TypeScript
       run: pn compile-only
     - name: Lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -399,7 +399,6 @@ jobs:
       attestations: write  # for actions/attest-build-provenance
     runs-on: macos-latest
     environment: release
-    timeout-minutes: 360
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -428,11 +427,10 @@ jobs:
         with:
           runtime: node@26.7.0
       # Internal workspace packages still publish with the static token. `@pnpm/exe`
-      # and `pnpm` use stage-only OIDC and wait for an interactive 2FA approval, in
-      # that order, so the `pnpm` gate cannot become public while the executable
-      # wrapper is pending. Keeping each stage operation in a token-free step also
-      # prevents an accidental fallback to token authentication. Each wait has a
-      # 90-minute deadline, leaving room for both layers within the job deadline.
+      # and `pnpm` use stage-only OIDC. CI stages both packages but cannot approve
+      # or publish them; a maintainer does that later with interactive 2FA. Keeping
+      # each stage operation in a token-free step also prevents an accidental
+      # fallback to token authentication.
       - name: Build TypeScript executable artifacts
         run: pn --filter=@pnpm/exe run build-artifacts
       - name: Publish internal workspace packages (static token)
@@ -455,20 +453,10 @@ jobs:
           .github/scripts/npm-staged-publication.sh stage
           'TypeScript @pnpm/exe wrapper' next-11
           pnpm11/pnpm/artifacts/exe
-      - name: Wait for @pnpm/exe approval
-        run: >-
-          .github/scripts/npm-staged-publication.sh wait
-          'TypeScript @pnpm/exe wrapper'
-          pnpm11/pnpm/artifacts/exe
       - name: Stage pnpm CLI (OIDC)
         run: >-
           .github/scripts/npm-staged-publication.sh stage
           'TypeScript pnpm CLI' next-11
-          pnpm11/pnpm
-      - name: Wait for pnpm CLI approval
-        run: >-
-          .github/scripts/npm-staged-publication.sh wait
-          'TypeScript pnpm CLI'
           pnpm11/pnpm
       - name: Copy Artifacts
         run: pn copy-artifacts
@@ -900,7 +888,6 @@ jobs:
     name: Publish pnpm (Rust) and @pnpm/napi to npm
     runs-on: ubuntu-latest
     environment: release
-    timeout-minutes: 360
     permissions:
       # Required by pnpm/setup to resolve the pnpm 11 GitHub release asset.
       contents: read
@@ -954,24 +941,18 @@ jobs:
           node pnpm/npm/pnpm/scripts/generate-packages.mjs
           node pnpm/npm/napi/scripts/generate-packages.mjs
 
-      # Every generated package uses stage-only OIDC. Each dependency layer
-      # must be approved with interactive 2FA before its wrappers are staged:
-      # native packages first, `@pnpm/napi` / `@pnpm/exe` second, and `pnpm`
-      # last. This keeps exact-version optionalDependencies installable and
-      # preserves `pnpm` as the plan job's "release completed" gate. The build
-      # dirs `pacquet-*` are published as `@pnpm/exe.<target>`. Each wait has a
-      # 90-minute deadline, leaving room for all three layers within the job deadline.
+      # Every generated package uses stage-only OIDC. CI stages the native
+      # packages, `@pnpm/napi` / `@pnpm/exe` wrappers, and `pnpm`, then finishes
+      # without publishing any of them. A maintainer approves those layers later
+      # with interactive 2FA in the same dependency order. The `pnpm` wrapper is
+      # approved last because the plan job uses it as the "release completed"
+      # gate. The build dirs `pacquet-*` publish as `@pnpm/exe.<target>`.
       - name: Stage Rust native packages (OIDC)
         env:
           TAG: ${{ needs.plan.outputs.rust_tag }}
         run: >-
           .github/scripts/npm-staged-publication.sh stage
           'Rust native packages' "$TAG"
-          pnpm/npm/pacquet-* pnpm/npm/napi.*
-      - name: Wait for Rust native package approvals
-        run: >-
-          .github/scripts/npm-staged-publication.sh wait
-          'Rust native packages'
           pnpm/npm/pacquet-* pnpm/npm/napi.*
       - name: Stage Rust wrapper packages (OIDC)
         env:
@@ -980,22 +961,12 @@ jobs:
           .github/scripts/npm-staged-publication.sh stage
           'Rust wrapper packages' "$TAG"
           pnpm/npm/napi pnpm/npm/pnpm-exe
-      - name: Wait for Rust wrapper package approvals
-        run: >-
-          .github/scripts/npm-staged-publication.sh wait
-          'Rust wrapper packages'
-          pnpm/npm/napi pnpm/npm/pnpm-exe
       - name: Stage Rust pnpm package (OIDC)
         env:
           TAG: ${{ needs.plan.outputs.rust_tag }}
         run: >-
           .github/scripts/npm-staged-publication.sh stage
           'Rust pnpm package' "$TAG"
-          pnpm/npm/pnpm
-      - name: Wait for Rust pnpm package approval
-        run: >-
-          .github/scripts/npm-staged-publication.sh wait
-          'Rust pnpm package'
           pnpm/npm/pnpm
 
   github-release-rust:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -399,6 +399,7 @@ jobs:
       attestations: write  # for actions/attest-build-provenance
     runs-on: macos-latest
     environment: release
+    timeout-minutes: 360
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -426,19 +427,13 @@ jobs:
         uses: pnpm/setup@6523ce966bcf7a1061ce6401e5c6e0b60466bd31
         with:
           runtime: node@26.7.0
-      # The publish phase is split into three sequential steps to control which packages
-      # use trusted publishing (OIDC) vs. a static token. `pnpm publish` currently bails
-      # out of OIDC as soon as a static `_authToken` is configured, so the only way to
-      # force trusted publishing for a given package today is to run its publish in a
-      # step that doesn't have NPM_TOKEN set. See https://github.com/pnpm/pnpm/pull/11495
-      # for the longer-term fix that lets OIDC override a configured token.
+      # Internal workspace packages still publish with the static token. `@pnpm/exe`
+      # and `pnpm` use stage-only OIDC and wait for an interactive 2FA approval, in
+      # that order, so the `pnpm` gate cannot become public while the executable
+      # wrapper is pending. Keeping each stage operation in a token-free step also
+      # prevents an accidental fallback to token authentication.
       - name: Build TypeScript executable artifacts
         run: pn --filter=@pnpm/exe run build-artifacts
-      - name: Publish @pnpm/exe (trusted publishing)
-        # No NPM_TOKEN: pnpm has no static token to short-circuit on, so it will perform
-        # the OIDC token exchange against npm's trusted-publishing config for `@pnpm/exe`.
-        run: |
-          pn --filter=@pnpm/exe publish --tag=next-11 --access=public --provenance
       - name: Publish internal workspace packages (static token)
         # The other workspace packages don't have trusted publishing configured on npm,
         # so we still need a static token here. The token is removed from pnpm's config
@@ -454,10 +449,26 @@ jobs:
           trap 'pn config delete "//registry.npmjs.org/:_authToken" || true' EXIT
           pn config set "//registry.npmjs.org/:_authToken" "${NPM_TOKEN}"
           pn publish --filter=!pnpm --filter=!@pnpm/exe --access=public --provenance
-      - name: Publish pnpm CLI (trusted publishing)
-        # No NPM_TOKEN — same rationale as the @pnpm/exe step above. This must come after
-        # the previous step has cleared its NPM_TOKEN from pnpm's config.
-        run: pn publish --filter=pnpm --tag=next-11 --access=public --provenance
+      - name: Stage @pnpm/exe (OIDC)
+        run: >-
+          .github/scripts/npm-staged-publication.sh stage
+          'TypeScript @pnpm/exe wrapper' next-11
+          pnpm11/pnpm/artifacts/exe
+      - name: Wait for @pnpm/exe approval
+        run: >-
+          .github/scripts/npm-staged-publication.sh wait
+          'TypeScript @pnpm/exe wrapper'
+          pnpm11/pnpm/artifacts/exe
+      - name: Stage pnpm CLI (OIDC)
+        run: >-
+          .github/scripts/npm-staged-publication.sh stage
+          'TypeScript pnpm CLI' next-11
+          pnpm11/pnpm
+      - name: Wait for pnpm CLI approval
+        run: >-
+          .github/scripts/npm-staged-publication.sh wait
+          'TypeScript pnpm CLI'
+          pnpm11/pnpm
       - name: Copy Artifacts
         run: pn copy-artifacts
       - name: Attest build provenance
@@ -888,6 +899,7 @@ jobs:
     name: Publish pnpm (Rust) and @pnpm/napi to npm
     runs-on: ubuntu-latest
     environment: release
+    timeout-minutes: 360
     permissions:
       # Required by pnpm/setup to resolve the pnpm 11 GitHub release asset.
       contents: read
@@ -941,37 +953,48 @@ jobs:
           node pnpm/npm/pnpm/scripts/generate-packages.mjs
           node pnpm/npm/napi/scripts/generate-packages.mjs
 
-      # Everything publishes via trusted publishing: the `pnpm` / `@pnpm/exe`
-      # trusted publishers are bound to this workflow file (they are shared
-      # with the TypeScript release job above), and the natives' and
-      # `@pnpm/napi`'s publishers are bound here too. Publishing the natives
-      # first keeps the wrappers' exact-version optionalDependencies
-      # installable the moment each wrapper goes live, and the `pnpm` wrapper
-      # goes last because the plan job uses it as the "release completed"
-      # gate. The trailing slash publishes the directory; the build dirs
-      # `pacquet-*` are published as `@pnpm/exe.<target>`.
-      - name: Publish (trusted publishing)
+      # Every generated package uses stage-only OIDC. Each dependency layer
+      # must be approved with interactive 2FA before its wrappers are staged:
+      # native packages first, `@pnpm/napi` / `@pnpm/exe` second, and `pnpm`
+      # last. This keeps exact-version optionalDependencies installable and
+      # preserves `pnpm` as the plan job's "release completed" gate. The build
+      # dirs `pacquet-*` are published as `@pnpm/exe.<target>`.
+      - name: Stage Rust native packages (OIDC)
         env:
           TAG: ${{ needs.plan.outputs.rust_tag }}
-        run: |
-          set -euo pipefail
-          for package in pnpm/npm/pacquet-* pnpm/npm/napi.* pnpm/npm/napi pnpm/npm/pnpm-exe pnpm/npm/pnpm; do
-            name=$(jq -r '.publishConfig.name // .name' "$package/package.json")
-            version=$(jq -r '.version' "$package/package.json")
-            state=$(.github/scripts/npm-package-publication-state.sh "$name@$version")
-            case "$state" in
-              published)
-                echo "$name@$version is already published; skipping"
-                ;;
-              missing)
-                pnpm publish "$package/" --tag "$TAG" --access public --provenance --no-git-checks
-                ;;
-              *)
-                echo "::error::Unexpected npm publication state"
-                exit 1
-                ;;
-            esac
-          done
+        run: >-
+          .github/scripts/npm-staged-publication.sh stage
+          'Rust native packages' "$TAG"
+          pnpm/npm/pacquet-* pnpm/npm/napi.*
+      - name: Wait for Rust native package approvals
+        run: >-
+          .github/scripts/npm-staged-publication.sh wait
+          'Rust native packages'
+          pnpm/npm/pacquet-* pnpm/npm/napi.*
+      - name: Stage Rust wrapper packages (OIDC)
+        env:
+          TAG: ${{ needs.plan.outputs.rust_tag }}
+        run: >-
+          .github/scripts/npm-staged-publication.sh stage
+          'Rust wrapper packages' "$TAG"
+          pnpm/npm/napi pnpm/npm/pnpm-exe
+      - name: Wait for Rust wrapper package approvals
+        run: >-
+          .github/scripts/npm-staged-publication.sh wait
+          'Rust wrapper packages'
+          pnpm/npm/napi pnpm/npm/pnpm-exe
+      - name: Stage Rust pnpm package (OIDC)
+        env:
+          TAG: ${{ needs.plan.outputs.rust_tag }}
+        run: >-
+          .github/scripts/npm-staged-publication.sh stage
+          'Rust pnpm package' "$TAG"
+          pnpm/npm/pnpm
+      - name: Wait for Rust pnpm package approval
+        run: >-
+          .github/scripts/npm-staged-publication.sh wait
+          'Rust pnpm package'
+          pnpm/npm/pnpm
 
   github-release-rust:
     name: Draft GitHub release for pnpm (Rust)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -431,7 +431,8 @@ jobs:
       # and `pnpm` use stage-only OIDC and wait for an interactive 2FA approval, in
       # that order, so the `pnpm` gate cannot become public while the executable
       # wrapper is pending. Keeping each stage operation in a token-free step also
-      # prevents an accidental fallback to token authentication.
+      # prevents an accidental fallback to token authentication. Each wait has a
+      # 90-minute deadline, leaving room for both layers within the job deadline.
       - name: Build TypeScript executable artifacts
         run: pn --filter=@pnpm/exe run build-artifacts
       - name: Publish internal workspace packages (static token)
@@ -958,7 +959,8 @@ jobs:
       # native packages first, `@pnpm/napi` / `@pnpm/exe` second, and `pnpm`
       # last. This keeps exact-version optionalDependencies installable and
       # preserves `pnpm` as the plan job's "release completed" gate. The build
-      # dirs `pacquet-*` are published as `@pnpm/exe.<target>`.
+      # dirs `pacquet-*` are published as `@pnpm/exe.<target>`. Each wait has a
+      # 90-minute deadline, leaving room for all three layers within the job deadline.
       - name: Stage Rust native packages (OIDC)
         env:
           TAG: ${{ needs.plan.outputs.rust_tag }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -66,13 +66,12 @@ See [#13578](https://github.com/pnpm/pnpm/issues/13578).
    git push origin "${tags[@]}"
    ```
 
-6. Approve the staged npm packages. The TypeScript pnpm release stages
-   `@pnpm/exe` and then `pnpm`. The Rust pnpm release stages its native
-   packages, then its `@pnpm/napi` and `@pnpm/exe` wrappers, and finally
-   `pnpm`. Each stage pauses the workflow until every package in that dependency
-   layer has been approved and is public. Copy the stage IDs from the job
-   summary and approve each one from a maintainer's machine within the layer's
-   90-minute approval window:
+6. After the workflow finishes, approve the staged npm packages. The TypeScript
+   pnpm release stages `@pnpm/exe` and then `pnpm`. The Rust pnpm release
+   stages its native packages, then its `@pnpm/napi` and `@pnpm/exe` wrappers, and finally
+   `pnpm`. Copy the stage IDs from the completed job's summary and approve each
+   one from a maintainer's machine. Approve all packages in each dependency
+   layer before moving to the next layer, leaving `pnpm` until last:
 
    ```bash
    pnpm stage approve <stage-id>

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -66,6 +66,22 @@ See [#13578](https://github.com/pnpm/pnpm/issues/13578).
    git push origin "${tags[@]}"
    ```
 
+6. Approve the staged npm packages. The TypeScript pnpm release stages
+   `@pnpm/exe` and then `pnpm`. The Rust pnpm release stages its native
+   packages, then its `@pnpm/napi` and `@pnpm/exe` wrappers, and finally
+   `pnpm`. Each stage pauses the workflow until every package in that dependency
+   layer has been approved and is public. Copy the stage IDs from the job
+   summary and approve each one from a maintainer's machine:
+
+   ```bash
+   pnpm stage approve <stage-id>
+   ```
+
+   Approval requires interactive 2FA. The npm trusted publishers for `pnpm`,
+   `@pnpm/exe`, `@pnpm/napi`, and their platform packages must allow staged
+   publishing only, so CI can stage a release but cannot approve or publish it
+   directly.
+
 ## Reruns and partial releases
 
 `release.yml`'s plan job asks npm whether each product's *gate* package is
@@ -110,6 +126,12 @@ npm and cannot be republished at the same version — read the failed run's logs
 to see how far it got. If the fix has to change something already published,
 the release needs a new version rather than a retry.
 
+If a run stopped after staging a package but before it became public, first
+approve or reject that pending stage from a maintainer's machine. CI cannot
+inspect or remove it with its stage-only OIDC permission, and trying to stage
+the same package version again will fail. The stage ID remains available in
+the stopped run's log and job summary.
+
 Moving a tag is only safe while the release is still failing. Once a release
 has completed and been announced, the tag is what downstream packagers verify
 and pin, so it must never be moved.
@@ -135,6 +157,8 @@ root: anyone whose key lands there can cut a release.
 
 A maintainer cutting releases needs a PGP key configured for git and registered
 with GitHub:
+
+<!-- cspell:ignore signingkey -->
 
 ```bash
 git config --global user.signingkey <fingerprint>

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -71,7 +71,8 @@ See [#13578](https://github.com/pnpm/pnpm/issues/13578).
    packages, then its `@pnpm/napi` and `@pnpm/exe` wrappers, and finally
    `pnpm`. Each stage pauses the workflow until every package in that dependency
    layer has been approved and is public. Copy the stage IDs from the job
-   summary and approve each one from a maintainer's machine:
+   summary and approve each one from a maintainer's machine within the layer's
+   90-minute approval window:
 
    ```bash
    pnpm stage approve <stage-id>


### PR DESCRIPTION
## Summary

- Stage the TypeScript `@pnpm/exe` and `pnpm` packages through OIDC without giving CI approval or direct-publish permission.
- Stage the Rust native packages, `@pnpm/napi` and `@pnpm/exe` wrappers, and `pnpm` gate in one workflow run.
- Record stage IDs in the completed job summary and safely skip versions that are already public on a rerun. A maintainer approves the stages later with interactive 2FA, following dependency order and leaving `pnpm` until last.
- Pin all publication traffic to the npm registry, ignore ambient auth configuration while staging, and prevent forged workflow commands from passing through stage output.
- Keep staged publishing ranked above direct OIDC publishing for `trustPolicy=no-downgrade`, fixing pnpm/pnpm#13693 without weakening the policy.

Before this workflow is used, the npm trusted publishers for `pnpm`, `@pnpm/exe`, `@pnpm/napi`, and their platform packages need to be configured for staged publishing only. That lets CI create stages but reserves approval and publication for a maintainer using interactive 2FA.

## Squash Commit Body

```text
Keep staged publishing above direct OIDC publishing in the trust-policy ranking.
Use the stronger release path instead of lowering the rank.

Stage the TypeScript `@pnpm/exe` and `pnpm` packages in dependency order.
Stage Rust native packages, wrappers, and the `pnpm` gate as separate layers.
Let CI finish after creating every stage without polling for approval.
Maintainers approve the completed stages later with interactive 2FA.

Pin publication traffic to the npm registry and ignore ambient auth configuration.
Sanitize stage output before logging registry-provided content.

Closes pnpm/pnpm#13693.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Process**
  * Added staged npm publication with approval checkpoints, public access, provenance, and explicit registry verification.
  * Updated TypeScript and Rust releases to use ordered staging for published packages.
  * Improved handling of already-published packages, failures, and pending stages.

* **Documentation**
  * Added guidance for approving staged releases, completing 2FA, and recovering pending stages.

* **Tests**
  * Added end-to-end coverage for staging, publication status checks, registry validation, failures, and diagnostic output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->