### PR TITLE
fix: bound minimumReleaseAge fallbacks for custom dist-tags

### DIFF
--- a/.changeset/chilly-foxes-brush.md
+++ b/.changeset/chilly-foxes-brush.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/resolving.registry.pkg-metadata-filter": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+Fixed `minimumReleaseAge` fallback for custom dist-tags so the selected version does not exceed the registry’s original tag target.

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
@@ -410,9 +410,9 @@ pub(crate) fn apply_published_by_policy(
 /// Filter a packument to versions published at or before `cutoff`,
 /// then rewrite each `dist-tag` to the highest within-cutoff version
 /// that still belongs to the tag's original "family" (same major
-/// for non-`latest` tags, no newer than the original target for
-/// `latest`, matching prerelease/release status, and preferring
-/// non-deprecated versions when both are present).
+/// for non-`latest` tags, no newer than the original target, matching
+/// prerelease/release status, and preferring non-deprecated versions
+/// when both are present).
 ///
 /// The result is memoized on `meta` (see [`DerivedPackuments`]) and
 /// shared between callers, so it is handed back behind an [`Arc`]:
@@ -464,7 +464,7 @@ fn filter_pkg_metadata_by_publish_date_uncached(
          caller must check before invoking",
     );
 
-    filter_pkg_metadata_versions_with_latest_bound(
+    filter_pkg_metadata_versions_with_dist_tag_bound(
         meta,
         |version| {
             let mature = time
@@ -488,18 +488,18 @@ fn filter_pkg_metadata_by_publish_date_uncached(
 /// major/prerelease lane.
 #[must_use]
 pub fn filter_pkg_metadata_versions(meta: &Package, keep: impl FnMut(&str) -> bool) -> Package {
-    filter_pkg_metadata_versions_with_latest_bound(meta, keep, false)
+    filter_pkg_metadata_versions_with_dist_tag_bound(meta, keep, false)
 }
 
-fn filter_pkg_metadata_versions_with_latest_bound(
+fn filter_pkg_metadata_versions_with_dist_tag_bound(
     meta: &Package,
     mut keep: impl FnMut(&str) -> bool,
-    bound_latest: bool,
+    bound_dist_tags: bool,
 ) -> Package {
     // Decide on version strings alone; slots move as raw fragments, so
     // the filter never hydrates a manifest.
     let filtered_versions = meta.versions.filtered(|version| keep(version));
-    let dist_tags = repopulate_dist_tags(meta, &filtered_versions, bound_latest);
+    let dist_tags = repopulate_dist_tags(meta, &filtered_versions, bound_dist_tags);
 
     Package {
         name: meta.name.clone(),
@@ -518,7 +518,7 @@ fn filter_pkg_metadata_versions_with_latest_bound(
 fn repopulate_dist_tags(
     meta: &Package,
     filtered_versions: &PackageVersions,
-    bound_latest: bool,
+    bound_dist_tags: bool,
 ) -> std::collections::HashMap<String, String> {
     let mut dist_tags_within_date = std::collections::HashMap::new();
     // Candidate versions parsed once per filter call and shared by
@@ -550,7 +550,7 @@ fn repopulate_dist_tags(
         let mut best_index: Option<usize> = None;
         for (index, slot) in candidates.iter().enumerate() {
             let (candidate, _, _) = slot;
-            if bound_latest && tag == "latest" && candidate > &original {
+            if bound_dist_tags && candidate > &original {
                 continue;
             }
             if tag != "latest" && candidate.major != original.major {

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package_from_meta/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package_from_meta/tests.rs
@@ -518,6 +518,29 @@ fn filter_latest_fallback_does_not_exceed_original_tag_target() {
 }
 
 #[test]
+fn filter_custom_dist_tag_fallback_does_not_exceed_original_target() {
+    let mut pkg = make_package(
+        "nightly-fallback",
+        &[
+            ("0.0.29-nightly.20260724.896", None),
+            ("0.0.29-nightly.20260725.899", None),
+            ("0.1.0-alpha.1", None),
+        ],
+        &[("nightly", "0.0.29-nightly.20260725.899")],
+    );
+    pkg.time = Some(make_time_map(&[
+        ("0.0.29-nightly.20260724.896", "2026-07-24T20:37:59.752Z"),
+        ("0.0.29-nightly.20260725.899", "2026-07-25T04:18:17.590Z"),
+        ("0.1.0-alpha.1", "2026-02-28T23:12:56.014Z"),
+    ]));
+    let cutoff = parse_iso("2026-07-25T00:00:00.000Z");
+
+    let filtered = filter_pkg_metadata_by_publish_date(&pkg, cutoff, None);
+
+    assert_eq!(filtered.dist_tag("nightly"), Some("0.0.29-nightly.20260724.896"));
+}
+
+#[test]
 fn filter_is_memoized_per_packument_and_stays_bounded() {
     let mut pkg = make_package("acme", &[("1.0.0", None)], &[("latest", "1.0.0")]);
     pkg.time = Some(make_time_map(&[("1.0.0", "2020-01-01T00:00:00.000Z")]));

--- a/pnpm11/resolving/registry/pkg-metadata-filter/src/index.ts
+++ b/pnpm11/resolving/registry/pkg-metadata-filter/src/index.ts
@@ -103,7 +103,7 @@ function filterPkgMetadataByPublishDateUncached (
       const candidateParsed = tryParseSemver(candidate)
       if (
         !candidateParsed ||
-        (tag === 'latest' && candidateParsed.compare(originalSemVer) > 0) ||
+        candidateParsed.compare(originalSemVer) > 0 ||
         (tag !== 'latest' && candidateParsed.major !== originalSemVer.major) ||
         (candidateParsed.prerelease.length > 0) !== originalIsPrerelease
       ) continue

--- a/pnpm11/resolving/registry/pkg-metadata-filter/test/index.ts
+++ b/pnpm11/resolving/registry/pkg-metadata-filter/test/index.ts
@@ -105,6 +105,35 @@ test('latest fallback does not exceed the original dist-tag target', () => {
   expect(withoutSafeFallback['dist-tags'].latest).toBeUndefined()
 })
 
+test('custom dist-tag fallback does not exceed the original target', () => {
+  const cutoff = new Date('2026-07-25T00:00:00.000Z')
+  const name = 'nightly-fallback'
+  const packageVersion = (version: string) => ({
+    name,
+    version,
+    dist: { tarball: `https://registry.npmjs.org/${name}/-/${name}-${version}.tgz`, shasum: '' },
+  })
+
+  const filtered = filterPkgMetadataByPublishDate({
+    name,
+    versions: {
+      '0.0.29-nightly.20260724.896': packageVersion('0.0.29-nightly.20260724.896'),
+      '0.0.29-nightly.20260725.899': packageVersion('0.0.29-nightly.20260725.899'),
+      '0.1.0-alpha.1': packageVersion('0.1.0-alpha.1'),
+    },
+    'dist-tags': {
+      nightly: '0.0.29-nightly.20260725.899',
+    },
+    time: {
+      '0.0.29-nightly.20260724.896': '2026-07-24T20:37:59.752Z',
+      '0.0.29-nightly.20260725.899': '2026-07-25T04:18:17.590Z',
+      '0.1.0-alpha.1': '2026-02-28T23:12:56.014Z',
+    },
+  }, cutoff)
+
+  expect(filtered['dist-tags'].nightly).toBe('0.0.29-nightly.20260724.896')
+})
+
 test('filtering is memoized per packument and the per-packument policy cache stays bounded', () => {
   const name = 'memoized-pkg'
   const doc = {


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

pnpm now by default uses `minimumReleaseAge` of 24 hours, I use a package called `t3` which has nightly versions, so every newest nightly version doesn't qualify under that range, but instead of resolving to the latest version on that dist tag, in my case newest `nightly` that is more than 24 hour old

Fixes #13370

Assisted in root cause analysis and verification by an agent (Codex - GPT 5.6 Sol) 
<img width="1550" height="556" alt="Screenshot 2026-08-07 at 17-20-14" src="https://github.com/user-attachments/assets/71fe56dc-a103-47f7-b638-0936df5ab913" />


## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

pnpm's minimumReleaseAge combined with a custom dist-tag didn't resolve to the newest qualifying release on that dist-tag, because there was a hardcoded equals to `latest` check in the resolver. By removing that check now it functions properly and resolves to newest version on the specified dist tag that satisfies minimum release age. Fixes #13370

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788695396&installation_model_id=426870&pr_number=13706&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13706&signature=fa7d58b88c13caa8b1cd1f49d7b0a185e25e09861a239e194f2983da3c876b2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dist-tag version selection when publish-date restrictions exclude the original tag target.
  * Custom dist-tags now fall back to the highest eligible version without selecting a newer release than the original target.
  * Applied consistent safeguards across all dist-tags, including `latest`.

* **Tests**
  * Added regression coverage for custom `nightly` dist-tag fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->