### PR TITLE
fix(fs): junction fallback and link removal without symlink privilege on Windows

### DIFF
--- a/.changeset/windows-symlink-privilege-fallback.md
+++ b/.changeset/windows-symlink-privilege-fallback.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+On Windows, installation no longer fails with "A required privilege is not held by the client. (os error 1314)" when symlink creation requires elevation (e.g. Developer Mode is off) — pnpm now falls back to NTFS junctions in that case. Additionally, `pnpm clean` and `pnpm deploy --force` no longer fail with "Access is denied. (os error 5)" when removing the package links inside `node_modules` [#13694](https://github.com/pnpm/pnpm/issues/13694).

--- a/pnpm/crates/cli/src/cli_args/clean.rs
+++ b/pnpm/crates/cli/src/cli_args/clean.rs
@@ -4,7 +4,7 @@ use super::{
 use derive_more::{Display, Error};
 use miette::{Context, Diagnostic, IntoDiagnostic};
 use pacquet_config::Config;
-use pacquet_fs::{is_subdir, lexical_normalize, relative_path};
+use pacquet_fs::{is_subdir, lexical_normalize, relative_path, remove_dirent};
 use pacquet_workspace::read_project_manifest_only;
 use serde_json::Value;
 use std::path::{Path, PathBuf};
@@ -177,9 +177,7 @@ fn remove_modules_dir_contents(modules_dir: &Path) -> miette::Result<()> {
 }
 
 fn remove_path(path: &Path) -> miette::Result<()> {
-    let result =
-        if path.is_dir() { std::fs::remove_dir_all(path) } else { std::fs::remove_file(path) };
-    result
+    remove_dirent(path)
         .or_else(
             |error| {
                 if error.kind() == std::io::ErrorKind::NotFound { Ok(()) } else { Err(error) }

--- a/pnpm/crates/cli/src/cli_args/deploy.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy.rs
@@ -8,7 +8,7 @@ use indexmap::IndexMap;
 use miette::{Context, Diagnostic, IntoDiagnostic};
 use pacquet_config::{Config, LinkWorkspacePackages, NodeLinker, PackageImportMethod};
 use pacquet_directory_fetcher::DirectoryFetcher;
-use pacquet_fs::{lexical_normalize, remove_symlink_dir};
+use pacquet_fs::{lexical_normalize, remove_dirent};
 use pacquet_lockfile::{
     DirectoryResolution, ImporterDepVersion, LazyLockfile, Lockfile, LockfileResolution,
     MaybeLazyLockfile, PackageKey, PackageMetadata, PkgName, PkgNameVerPeer, ProjectSnapshot,
@@ -693,20 +693,13 @@ fn is_empty_dir_or_absent(path: &Path) -> miette::Result<bool> {
 }
 
 fn remove_path_if_exists(path: &Path) -> miette::Result<()> {
-    let metadata = match fs::symlink_metadata(path) {
-        Ok(metadata) => metadata,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
-        Err(error) => return Err(error).into_diagnostic(),
-    };
-    let unsafe_link = is_unsafe_deploy_link(&metadata);
-    if metadata.is_dir() && !unsafe_link {
-        fs::remove_dir_all(path).into_diagnostic()
-    } else if metadata.is_dir() {
-        remove_symlink_dir(path).into_diagnostic()
-    } else {
-        fs::remove_file(path).into_diagnostic()
+    match remove_dirent(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("remove deploy path {}", path.display())),
     }
-    .wrap_err_with(|| format!("remove deploy path {}", path.display()))
 }
 
 fn is_unsafe_deploy_link(metadata: &fs::Metadata) -> bool {

--- a/pnpm/crates/cli/tests/suite/clean.rs
+++ b/pnpm/crates/cli/tests/suite/clean.rs
@@ -60,7 +60,14 @@ fn clean_removes_package_links_into_the_virtual_store() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(output.status.success(), "pacquet clean should succeed: {stderr}");
 
-    assert!(!node_modules.join(".pnpm").exists(), ".pnpm should be removed");
+    let virtual_store_metadata = fs::symlink_metadata(node_modules.join(".pnpm"));
+    assert!(
+        matches!(
+            &virtual_store_metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound
+        ),
+        ".pnpm should be removed, got {virtual_store_metadata:?}",
+    );
     let link_metadata = fs::symlink_metadata(node_modules.join("greenly"));
     assert!(
         matches!(&link_metadata, Err(error) if error.kind() == std::io::ErrorKind::NotFound),

--- a/pnpm/crates/cli/tests/suite/clean.rs
+++ b/pnpm/crates/cli/tests/suite/clean.rs
@@ -41,6 +41,34 @@ fn clean_removes_packages_and_pnpm_entries_but_preserves_non_pnpm_dotfiles() {
     drop(root);
 }
 
+/// The real isolated-linker layout: `node_modules/<name>` is a link
+/// (symlink or junction) into `.pnpm`. `.pnpm` sorts before the package
+/// names, so by the time `clean` reaches the link it dangles — removal
+/// must unlink it rather than follow it
+/// ([pnpm/pnpm#13694](https://github.com/pnpm/pnpm/issues/13694)).
+#[test]
+fn clean_removes_package_links_into_the_virtual_store() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+
+    let node_modules = workspace.join("node_modules");
+    let store_pkg_dir = node_modules.join(".pnpm").join("greenly@1.0.0").join("node_modules");
+    seed_package(&store_pkg_dir, "greenly");
+    pacquet_fs::symlink_dir(&store_pkg_dir.join("greenly"), &node_modules.join("greenly"))
+        .expect("link the package into node_modules");
+
+    let output = pacquet.with_args(["clean"]).output().expect("run pacquet clean");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "pacquet clean should succeed: {stderr}");
+
+    assert!(!node_modules.join(".pnpm").exists(), ".pnpm should be removed");
+    assert!(
+        fs::symlink_metadata(node_modules.join("greenly")).is_err(),
+        "the package link should be removed",
+    );
+
+    drop(root);
+}
+
 #[test]
 fn clean_handles_missing_node_modules_gracefully() {
     let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init();

--- a/pnpm/crates/cli/tests/suite/clean.rs
+++ b/pnpm/crates/cli/tests/suite/clean.rs
@@ -61,9 +61,10 @@ fn clean_removes_package_links_into_the_virtual_store() {
     assert!(output.status.success(), "pacquet clean should succeed: {stderr}");
 
     assert!(!node_modules.join(".pnpm").exists(), ".pnpm should be removed");
+    let link_metadata = fs::symlink_metadata(node_modules.join("greenly"));
     assert!(
-        fs::symlink_metadata(node_modules.join("greenly")).is_err(),
-        "the package link should be removed",
+        matches!(&link_metadata, Err(error) if error.kind() == std::io::ErrorKind::NotFound),
+        "the package link should be removed, got {link_metadata:?}",
     );
 
     drop(root);

--- a/pnpm/crates/fs/src/lib.rs
+++ b/pnpm/crates/fs/src/lib.rs
@@ -3,6 +3,7 @@ mod ensure_file;
 mod is_subdir;
 mod lexical_normalize;
 mod relative_path;
+mod remove_dirent;
 mod symlink_dir;
 mod write_atomic;
 
@@ -11,6 +12,7 @@ pub use ensure_file::*;
 pub use is_subdir::is_subdir;
 pub use lexical_normalize::lexical_normalize;
 pub use relative_path::relative_path;
+pub use remove_dirent::remove_dirent;
 pub use symlink_dir::*;
 pub use write_atomic::write_atomic;
 

--- a/pnpm/crates/fs/src/remove_dirent.rs
+++ b/pnpm/crates/fs/src/remove_dirent.rs
@@ -1,0 +1,33 @@
+use std::{fs, io, path::Path};
+
+/// Remove whatever occupies `path` without following links: a regular
+/// file (or file-shaped symlink) is unlinked, a real directory is
+/// removed recursively, and a directory-shaped link — a symlink to a
+/// directory, or a junction on Windows — is unlinked without touching
+/// its target. Dangling links are removed too.
+///
+/// The naive `is_dir()` dispatch to `remove_dir_all` / `remove_file`
+/// is wrong on Windows twice over: following the link makes a dangling
+/// link report as a non-directory, and even [`fs::symlink_metadata`]'s
+/// [`fs::FileType::is_dir`] is `false` for a name-surrogate reparse
+/// point. Either way the link is routed to `DeleteFileW`, which fails
+/// on directory-shaped entries with `ERROR_ACCESS_DENIED` (os error 5);
+/// they need `RemoveDirectoryW` instead.
+pub fn remove_dirent(path: &Path) -> io::Result<()> {
+    let metadata = fs::symlink_metadata(path)?;
+    if metadata.is_dir() {
+        return fs::remove_dir_all(path);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        const FILE_ATTRIBUTE_DIRECTORY: u32 = 0x10;
+        if metadata.file_attributes() & FILE_ATTRIBUTE_DIRECTORY != 0 {
+            return fs::remove_dir(path);
+        }
+    }
+    fs::remove_file(path)
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/fs/src/remove_dirent/tests.rs
+++ b/pnpm/crates/fs/src/remove_dirent/tests.rs
@@ -1,0 +1,108 @@
+//! Tests for the [`crate::remove_dirent`] module.
+
+use super::remove_dirent;
+use crate::symlink_dir;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn removes_a_regular_file() {
+    let root = tempdir().expect("create temp dir");
+    let file = root.path().join("file.txt");
+    fs::write(&file, "contents").expect("write file");
+
+    remove_dirent(&file).expect("remove the file");
+
+    assert!(!file.exists());
+}
+
+#[test]
+fn removes_a_directory_tree() {
+    let root = tempdir().expect("create temp dir");
+    let dir = root.path().join("dir");
+    fs::create_dir_all(dir.join("nested")).expect("create nested dirs");
+    fs::write(dir.join("nested").join("file.txt"), "contents").expect("write file");
+
+    remove_dirent(&dir).expect("remove the directory tree");
+
+    assert!(!dir.exists());
+}
+
+#[test]
+fn removes_a_directory_link_without_touching_its_target() {
+    let root = tempdir().expect("create temp dir");
+    let target = root.path().join("target");
+    let link = root.path().join("link");
+    fs::create_dir(&target).expect("create target dir");
+    fs::write(target.join("file.txt"), "contents").expect("write file in target");
+    symlink_dir(&target, &link).expect("create link");
+
+    remove_dirent(&link).expect("remove the link");
+
+    assert!(fs::symlink_metadata(&link).is_err(), "the link itself must be gone");
+    assert!(target.join("file.txt").exists(), "the target must be untouched");
+}
+
+/// The shape `pnpm clean` hits after removing `node_modules/.pnpm`
+/// before the top-level package links
+/// ([pnpm/pnpm#13694](https://github.com/pnpm/pnpm/issues/13694)): the
+/// link dangles, so any dispatch that follows it sees a non-directory.
+#[test]
+fn removes_a_dangling_directory_link() {
+    let root = tempdir().expect("create temp dir");
+    let target = root.path().join("target");
+    let link = root.path().join("link");
+    fs::create_dir(&target).expect("create target dir");
+    symlink_dir(&target, &link).expect("create link");
+    fs::remove_dir(&target).expect("remove target to dangle the link");
+
+    remove_dirent(&link).expect("remove the dangling link");
+
+    assert!(fs::symlink_metadata(&link).is_err(), "the dangling link must be gone");
+}
+
+#[cfg(unix)]
+#[test]
+fn removes_a_file_symlink() {
+    let root = tempdir().expect("create temp dir");
+    let target = root.path().join("file.txt");
+    let link = root.path().join("link");
+    fs::write(&target, "contents").expect("write target file");
+    std::os::unix::fs::symlink(&target, &link).expect("create file symlink");
+
+    remove_dirent(&link).expect("remove the file symlink");
+
+    assert!(fs::symlink_metadata(&link).is_err(), "the link must be gone");
+    assert!(target.exists(), "the target must be untouched");
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_removes_a_junction_without_touching_its_target() {
+    let root = tempdir().expect("create temp dir");
+    let target = root.path().join("target");
+    let link = root.path().join("link");
+    fs::create_dir(&target).expect("create target dir");
+    fs::write(target.join("file.txt"), "contents").expect("write file in target");
+    junction::create(&target, &link).expect("create junction");
+
+    remove_dirent(&link).expect("remove the junction");
+
+    assert!(fs::symlink_metadata(&link).is_err(), "the junction itself must be gone");
+    assert!(target.join("file.txt").exists(), "the target must be untouched");
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_removes_a_dangling_junction() {
+    let root = tempdir().expect("create temp dir");
+    let target = root.path().join("target");
+    let link = root.path().join("link");
+    fs::create_dir(&target).expect("create target dir");
+    junction::create(&target, &link).expect("create junction");
+    fs::remove_dir(&target).expect("remove target to dangle the junction");
+
+    remove_dirent(&link).expect("remove the dangling junction");
+
+    assert!(fs::symlink_metadata(&link).is_err(), "the dangling junction must be gone");
+}

--- a/pnpm/crates/fs/src/remove_dirent/tests.rs
+++ b/pnpm/crates/fs/src/remove_dirent/tests.rs
@@ -2,8 +2,19 @@
 
 use super::remove_dirent;
 use crate::symlink_dir;
-use std::fs;
+use std::{fs, io, path::Path};
 use tempfile::tempdir;
+
+/// Assert `path` no longer exists, distinguishing "gone" (`NotFound`)
+/// from an inspection failure that would leave the entry in place.
+#[track_caller]
+fn assert_gone(path: &Path, what: &str) {
+    let metadata = fs::symlink_metadata(path);
+    assert!(
+        matches!(&metadata, Err(error) if error.kind() == io::ErrorKind::NotFound),
+        "{what} must be gone, got {metadata:?}",
+    );
+}
 
 #[test]
 fn removes_a_regular_file() {
@@ -39,7 +50,7 @@ fn removes_a_directory_link_without_touching_its_target() {
 
     remove_dirent(&link).expect("remove the link");
 
-    assert!(fs::symlink_metadata(&link).is_err(), "the link itself must be gone");
+    assert_gone(&link, "the link itself");
     assert!(target.join("file.txt").exists(), "the target must be untouched");
 }
 
@@ -58,7 +69,7 @@ fn removes_a_dangling_directory_link() {
 
     remove_dirent(&link).expect("remove the dangling link");
 
-    assert!(fs::symlink_metadata(&link).is_err(), "the dangling link must be gone");
+    assert_gone(&link, "the dangling link");
 }
 
 #[cfg(unix)]
@@ -72,7 +83,7 @@ fn removes_a_file_symlink() {
 
     remove_dirent(&link).expect("remove the file symlink");
 
-    assert!(fs::symlink_metadata(&link).is_err(), "the link must be gone");
+    assert_gone(&link, "the link");
     assert!(target.exists(), "the target must be untouched");
 }
 
@@ -88,7 +99,7 @@ fn windows_removes_a_junction_without_touching_its_target() {
 
     remove_dirent(&link).expect("remove the junction");
 
-    assert!(fs::symlink_metadata(&link).is_err(), "the junction itself must be gone");
+    assert_gone(&link, "the junction itself");
     assert!(target.join("file.txt").exists(), "the target must be untouched");
 }
 
@@ -104,5 +115,5 @@ fn windows_removes_a_dangling_junction() {
 
     remove_dirent(&link).expect("remove the dangling junction");
 
-    assert!(fs::symlink_metadata(&link).is_err(), "the dangling junction must be gone");
+    assert_gone(&link, "the dangling junction");
 }

--- a/pnpm/crates/fs/src/symlink_dir.rs
+++ b/pnpm/crates/fs/src/symlink_dir.rs
@@ -17,9 +17,9 @@ use std::{
 ///
 /// On Windows the writer tries a true directory symlink first
 /// (`std::os::windows::fs::symlink_dir`) and falls back to a junction
-/// on `PermissionDenied` (symbolic links may require elevated
+/// on a privilege error (symbolic links may require elevated
 /// privileges; junctions don't). The first successful branch is cached
-/// process-wide so subsequent calls skip the EPERM probe.
+/// process-wide so subsequent calls skip the privilege probe.
 pub fn symlink_dir(original: &Path, link: &Path) -> io::Result<()> {
     #[cfg(unix)]
     {
@@ -424,9 +424,9 @@ mod windows {
         // running in Developer Mode (or as Administrator) get, and
         // true symlinks are preferred over junctions when allowed.
         // `CreateSymbolicLinkW` returns
-        // `ERROR_PRIVILEGE_NOT_HELD` (`PermissionDenied`) when the
-        // process can't create symlinks; junctions don't carry that
-        // constraint, so fall back to those.
+        // `ERROR_PRIVILEGE_NOT_HELD` when the process can't create
+        // symlinks; junctions don't carry that constraint, so fall
+        // back to those.
         match create_true_symlink(original, link) {
             Ok(()) => {
                 MODE.store(USE_SYMLINK, Ordering::Relaxed);
@@ -441,8 +441,13 @@ mod windows {
 
     pub(super) fn should_fallback_to_junction(error: &io::Error) -> bool {
         const ERROR_DIRECTORY: i32 = 267;
+        // `CreateSymbolicLinkW` without symlink privilege (no Developer
+        // Mode, not elevated) fails with `ERROR_PRIVILEGE_NOT_HELD`,
+        // which std maps to `Uncategorized` — not `PermissionDenied` —
+        // so it must be matched by raw os error.
+        const ERROR_PRIVILEGE_NOT_HELD: i32 = 1314;
         error.kind() == io::ErrorKind::PermissionDenied
-            || error.raw_os_error() == Some(ERROR_DIRECTORY)
+            || matches!(error.raw_os_error(), Some(ERROR_DIRECTORY | ERROR_PRIVILEGE_NOT_HELD))
     }
 
     fn create_and_cache_junction(original: &Path, link: &Path) -> io::Result<()> {

--- a/pnpm/crates/fs/src/symlink_dir/tests.rs
+++ b/pnpm/crates/fs/src/symlink_dir/tests.rs
@@ -325,6 +325,18 @@ fn windows_error_directory_falls_back_to_junctions() {
     assert!(!super::windows::should_fallback_to_junction(&std::io::Error::from_raw_os_error(123)));
 }
 
+/// `ERROR_PRIVILEGE_NOT_HELD` (1314) — symlink creation without
+/// Developer Mode or elevation — maps to `Uncategorized`, not
+/// `PermissionDenied`, so the fallback must match the raw os error
+/// ([pnpm/pnpm#13694](https://github.com/pnpm/pnpm/issues/13694)).
+#[cfg(windows)]
+#[test]
+fn windows_privilege_not_held_falls_back_to_junctions() {
+    let error = std::io::Error::from_raw_os_error(1314);
+    assert_ne!(error.kind(), std::io::ErrorKind::PermissionDenied);
+    assert!(super::windows::should_fallback_to_junction(&error));
+}
+
 #[test]
 fn force_symlink_dir_links_a_scoped_alias() {
     let root = tempdir().expect("create temp dir");

--- a/pnpm/crates/package-manager/src/prune_virtual_store.rs
+++ b/pnpm/crates/package-manager/src/prune_virtual_store.rs
@@ -216,15 +216,9 @@ fn read_virtual_store_dir(virtual_store_dir: &Path) -> Option<Vec<String>> {
 /// accurate (it must not count an entry a swallowed error left behind).
 ///
 /// Surplus entries are normally package directories, but a stray file or
-/// symlink could appear; any of them is removed. `symlink_metadata` keeps
-/// the file/symlink branch from following a link into a real directory.
+/// symlink could appear; any of them is removed.
 fn try_remove_pkg(path: &Path) -> bool {
-    let result = match fs::symlink_metadata(path) {
-        Ok(metadata) if metadata.is_dir() => fs::remove_dir_all(path),
-        Ok(_) => fs::remove_file(path),
-        Err(error) => Err(error),
-    };
-    match result {
+    match pacquet_fs::remove_dirent(path) {
         Ok(()) => true,
         Err(error) if error.kind() == io::ErrorKind::NotFound => true,
         Err(error) => {


### PR DESCRIPTION
## Summary

Fixes two Windows failures in the Rust CLI reported in pnpm/pnpm#13694 (Closes pnpm/pnpm#13694):

1. **`os error 1314` during install.** The junction fallback in `pacquet_fs::symlink_dir` only matched `io::ErrorKind::PermissionDenied`, but Rust std maps `ERROR_PRIVILEGE_NOT_HELD` (1314) to `Uncategorized`. On a machine without Developer Mode or elevation, `CreateSymbolicLinkW` fails with 1314, so the fallback never fired and the install aborted. The fallback now also matches the raw os error. (pnpm v11 worked because the `symlink-dir` npm package falls back to junctions.)

2. **`os error 5` from `pnpm clean` (and `pnpm deploy --force`).** Removal sites dispatched on `is_dir()`, which on Windows is `false` for junctions, directory symlinks (name-surrogate reparse points), and dangling links, so directory-shaped links were routed to `DeleteFileW`, which fails on them with `ERROR_ACCESS_DENIED`. `clean` always hits this: `.pnpm` sorts before the package names, so every top-level package link dangles by the time it is removed. Added `pacquet_fs::remove_dirent`, which removes any dirent without following links (dir-shaped links are unlinked via `RemoveDirectoryW`), and switched `clean`, `deploy`, and the virtual-store pruner to it.

The TypeScript CLI is unaffected — it links via the `symlink-dir` package and removes with rimraf, both junction-safe — so this is a Rust-only fix with a `pacquet`-only changeset.

Behavioral note on `deploy`: a deploy target that is a non-name-surrogate reparse *directory* (e.g. a dedup-enabled folder) was previously removed with a bare `RemoveDirectoryW`, which fails on a non-empty directory; it now goes through `remove_dir_all`, whose traversal is already link-safe.

## Squash Commit Body

```text
Two Windows failures from pnpm/pnpm#13694:

1. The junction fallback in symlink_dir only matched PermissionDenied,
   but Rust std maps ERROR_PRIVILEGE_NOT_HELD (os error 1314) to
   Uncategorized, so installs failed outright for users without
   Developer Mode or elevation instead of falling back to junctions.
   Match the raw os error too.

2. Removal sites dispatched on is_dir(), which is false on Windows for
   junctions, directory symlinks (name-surrogate reparse points), and
   dangling links, routing them to DeleteFileW, which fails on
   directory-shaped entries with ERROR_ACCESS_DENIED (os error 5).
   Add pacquet_fs::remove_dirent, which unlinks directory-shaped links
   with RemoveDirectoryW without following them, and use it in clean,
   deploy, and the virtual-store pruner.

The TypeScript CLI is unaffected: it removes with rimraf and links via
the symlink-dir package, both of which already handle junctions.

Closes pnpm/pnpm#13694
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13707"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788698768&installation_model_id=426870&pr_number=13707&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13707&signature=20ae27b438dd0937d29d3e2eff69c5ce54c65e6e47f818e8ad77db3d859a326d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed package-link removal failures during `pnpm clean` and `pnpm deploy --force`.
  - Improved handling of regular files, directories, symlinks, dangling links, and Windows junctions during cleanup.
  - Windows now falls back to NTFS junctions when symlink creation lacks required privileges.
  - Added coverage for cleanup and Windows privilege-fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->