### PR TITLE
fix(self-update): anchor the engine and dlx cache installs to their install dirs

### DIFF
--- a/.changeset/self-update-ignores-ambient-workspace.md
+++ b/.changeset/self-update-ignores-ambient-workspace.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm self-update` no longer fails with `the installed pnpm wrapper is missing` when the global packages directory carries a `pnpm-workspace.yaml` of global settings (written there when a global install persists an `allowBuilds` decision). The engine install stays anchored to its own install directory instead of walking up and adopting that file as its workspace root. The `pnpm dlx` cache install gets the same anchoring, so a stray `pnpm-workspace.yaml` above the cache directory can no longer break it [#13697](https://github.com/pnpm/pnpm/issues/13697).

--- a/pnpm/crates/cli/src/cli_args/dlx.rs
+++ b/pnpm/crates/cli/src/cli_args/dlx.rs
@@ -296,8 +296,12 @@ async fn install_into_cache<Reporter: self::Reporter + 'static>(
     // The throwaway cache project is not part of the caller's
     // workspace. If a caller has a settings-only pnpm-workspace.yaml,
     // carrying its workspace root here makes the install enumerate that
-    // workspace and fail on the missing root package.json.
-    config.workspace_dir = None;
+    // workspace and fail on the missing root package.json. Anchor to the
+    // prepare dir itself (not `None`): unset, the install pipeline walks
+    // up from the cache dir and can adopt an unrelated
+    // `pnpm-workspace.yaml` above it — the walk-up that broke self-update
+    // in pnpm/pnpm#13697.
+    config.workspace_dir = Some(prepare_dir.to_path_buf());
     // Build a *fresh* allow-list for the throwaway install — the dlx
     // packages themselves plus the CLI `--allow-build` entries — rather
     // than inheriting the caller project's `allow_builds` /

--- a/pnpm/crates/cli/src/cli_args/dlx.rs
+++ b/pnpm/crates/cli/src/cli_args/dlx.rs
@@ -296,11 +296,9 @@ async fn install_into_cache<Reporter: self::Reporter + 'static>(
     // The throwaway cache project is not part of the caller's
     // workspace. If a caller has a settings-only pnpm-workspace.yaml,
     // carrying its workspace root here makes the install enumerate that
-    // workspace and fail on the missing root package.json. Anchor to the
-    // prepare dir itself (not `None`): unset, the install pipeline walks
-    // up from the cache dir and can adopt an unrelated
-    // `pnpm-workspace.yaml` above it — the walk-up that broke self-update
-    // in pnpm/pnpm#13697.
+    // workspace and fail on the missing root package.json. Anchored
+    // rather than `None`, which walks up from the cache dir and can
+    // adopt a stray `pnpm-workspace.yaml` above it (pnpm/pnpm#13697).
     config.workspace_dir = Some(prepare_dir.to_path_buf());
     // Build a *fresh* allow-list for the throwaway install — the dlx
     // packages themselves plus the CLI `--allow-build` entries — rather

--- a/pnpm/crates/cli/src/cli_args/self_update/install_pnpm.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/install_pnpm.rs
@@ -253,7 +253,16 @@ pub(crate) async fn run_install<Reporter: self::Reporter + 'static>(
     cfg.virtual_store_dir = install_dir.join("node_modules").join(".pnpm");
     cfg.enable_global_virtual_store = enable_global_virtual_store;
     cfg.lockfile = true;
-    cfg.workspace_dir = None;
+    // Anchor the engine project to its own install dir, exactly like the
+    // global-add group install (see `run_group_install` in
+    // `cli_args::global`). The self-update install dir sits under the
+    // global packages dir, which carries a `pnpm-workspace.yaml` of global
+    // settings once a global `allowBuilds` decision has been persisted;
+    // left unanchored, the install pipeline walks up, adopts that file as
+    // the workspace root, and lays the engine out as a workspace
+    // sub-importer — leaving `node_modules/` in the install dir without
+    // the wrapper package (pnpm/pnpm#13697).
+    cfg.workspace_dir = Some(install_dir.to_path_buf());
     cfg.supported_architectures = supported_architectures;
     // The engine is installed with scripts disabled — the wrapper's
     // preinstall (which links the platform binary) is replicated by

--- a/pnpm/crates/cli/src/cli_args/self_update/install_pnpm.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/install_pnpm.rs
@@ -253,15 +253,10 @@ pub(crate) async fn run_install<Reporter: self::Reporter + 'static>(
     cfg.virtual_store_dir = install_dir.join("node_modules").join(".pnpm");
     cfg.enable_global_virtual_store = enable_global_virtual_store;
     cfg.lockfile = true;
-    // Anchor the engine project to its own install dir, exactly like the
-    // global-add group install (see `run_group_install` in
-    // `cli_args::global`). The self-update install dir sits under the
-    // global packages dir, which carries a `pnpm-workspace.yaml` of global
-    // settings once a global `allowBuilds` decision has been persisted;
-    // left unanchored, the install pipeline walks up, adopts that file as
-    // the workspace root, and lays the engine out as a workspace
-    // sub-importer — leaving `node_modules/` in the install dir without
-    // the wrapper package (pnpm/pnpm#13697).
+    // Anchored (never `None`, which walks up and can adopt the global
+    // packages dir's own settings `pnpm-workspace.yaml` as the workspace
+    // root, pnpm/pnpm#13697) — the same guard as `run_group_install` in
+    // `cli_args::global`, where the full rationale lives.
     cfg.workspace_dir = Some(install_dir.to_path_buf());
     cfg.supported_architectures = supported_architectures;
     // The engine is installed with scripts disabled — the wrapper's

--- a/pnpm/crates/cli/src/cli_args/self_update/install_pnpm/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/install_pnpm/tests.rs
@@ -27,6 +27,16 @@ async fn run_install_ignores_an_ambient_workspace_manifest_above_the_install_dir
     fs::create_dir_all(&global_pkg_dir).expect("create global packages dir");
     fs::write(global_pkg_dir.join("pnpm-workspace.yaml"), "allowBuilds:\n  esbuild: true\n")
         .expect("write ambient workspace manifest");
+    // The leftovers an unanchored install strands in the global packages
+    // dir: a stray `node_modules` and a lockfile at the adopted workspace
+    // root. A later self-update must succeed with them in place (each
+    // update installs into a fresh slot) and must not touch that lockfile
+    // — it is the env lockfile's home.
+    fs::create_dir_all(global_pkg_dir.join("node_modules").join(".pnpm"))
+        .expect("create leftover node_modules");
+    let leftover_lockfile = "lockfileVersion: '9.0'\n";
+    fs::write(global_pkg_dir.join("pnpm-lock.yaml"), leftover_lockfile)
+        .expect("write leftover lockfile");
     let install_dir = global_pkg_dir.join("engine-slot");
     fs::create_dir_all(&install_dir).expect("create install dir");
 
@@ -53,6 +63,12 @@ async fn run_install_ignores_an_ambient_workspace_manifest_above_the_install_dir
     assert!(
         manifest.exists(),
         "the installed package must land in the install dir, not in an ambient workspace root",
+    );
+    let ambient_lockfile = fs::read_to_string(global_pkg_dir.join("pnpm-lock.yaml"))
+        .expect("read back the global-dir lockfile");
+    assert_eq!(
+        ambient_lockfile, leftover_lockfile,
+        "the install must write its lockfile into the install dir, not over the global dir's",
     );
 }
 

--- a/pnpm/crates/cli/src/cli_args/self_update/install_pnpm/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/install_pnpm/tests.rs
@@ -1,10 +1,60 @@
 use super::{
     PNPM_EXE_PACKAGE_NAME, PNPM_PACKAGE_NAME, assert_release_is_installable,
     exe_platform_pkg_dir_name, exe_platform_pkg_dir_name_next, link_exe_platform_binary,
-    package_dir, pnpm_package_to_install, reuse_cached_engine,
+    package_dir, pnpm_package_to_install, reuse_cached_engine, run_install,
 };
+use pacquet_config::Config;
 use pacquet_graph_hasher::{host_arch, host_libc, host_platform};
+use pacquet_reporter::SilentReporter;
+use pacquet_store_dir::StoreDir;
+use pacquet_testing_utils::registry::TestRegistry;
 use std::fs;
+
+/// The engine install must stay anchored to its install dir even when an
+/// ancestor carries a `pnpm-workspace.yaml` — the global packages dir
+/// legitimately holds one of global settings once a global `allowBuilds`
+/// decision has been persisted. Left unanchored, the install pipeline
+/// walked up, adopted that file as the workspace root, and the wrapper
+/// package never landed in `node_modules/` of the install dir
+/// (pnpm/pnpm#13697). Driven with a stand-in package from the mock
+/// registry: `run_install` lays out whatever package it is given, so the
+/// anchoring is observable without a real pnpm release.
+#[tokio::test]
+async fn run_install_ignores_an_ambient_workspace_manifest_above_the_install_dir() {
+    let registry = TestRegistry::start();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let global_pkg_dir = temp.path().join("global").join("v11");
+    fs::create_dir_all(&global_pkg_dir).expect("create global packages dir");
+    fs::write(global_pkg_dir.join("pnpm-workspace.yaml"), "allowBuilds:\n  esbuild: true\n")
+        .expect("write ambient workspace manifest");
+    let install_dir = global_pkg_dir.join("engine-slot");
+    fs::create_dir_all(&install_dir).expect("create install dir");
+
+    let mut cfg = Config {
+        store_dir: StoreDir::new(temp.path().join("store")),
+        cache_dir: temp.path().join("cache"),
+        ..Config::default()
+    };
+    cfg.package_manager_bootstrap.registry = registry.url();
+    let config = Config::leak(cfg);
+
+    run_install::<SilentReporter>(
+        config,
+        &install_dir,
+        "@pnpm.e2e/hello-world-js-bin",
+        "1.0.0",
+        None,
+        false,
+    )
+    .await
+    .expect("install the stand-in engine package");
+
+    let manifest = package_dir(&install_dir, "@pnpm.e2e/hello-world-js-bin").join("package.json");
+    assert!(
+        manifest.exists(),
+        "the installed package must land in the install dir, not in an ambient workspace root",
+    );
+}
 
 #[test]
 fn legacy_platform_dir_names() {

--- a/pnpm/crates/cli/tests/suite/dlx.rs
+++ b/pnpm/crates/cli/tests/suite/dlx.rs
@@ -108,7 +108,7 @@ fn dlx_resolves_caller_catalog_references_in_overrides() {
 #[cfg(unix)]
 #[test]
 fn dlx_ignores_an_ambient_workspace_manifest_above_the_cache_dir() {
-    let CommandTempCwd { pacquet, root, workspace, .. } =
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();
 
     // `root` is the parent of both the caller's workspace and the
@@ -121,6 +121,24 @@ fn dlx_ignores_an_ambient_workspace_manifest_above_the_cache_dir() {
     assert!(
         workspace.join("touch.txt").exists(),
         "the package's bin should run in the process cwd and write `touch.txt`",
+    );
+    let cached_manifests: Vec<_> = std::fs::read_dir(npmrc_info.cache_dir.join("dlx"))
+        .expect("read the dlx cache dir")
+        .filter_map(Result::ok)
+        .map(|entry| {
+            entry
+                .path()
+                .join("pkg")
+                .join("node_modules")
+                .join("@foo")
+                .join("touch-file-one-bin")
+                .join("package.json")
+        })
+        .filter(|manifest| manifest.exists())
+        .collect();
+    assert!(
+        !cached_manifests.is_empty(),
+        "the package must land in the dlx cache prepare dir, not in an ambient workspace root",
     );
 
     drop(root);

--- a/pnpm/crates/cli/tests/suite/dlx.rs
+++ b/pnpm/crates/cli/tests/suite/dlx.rs
@@ -98,3 +98,30 @@ fn dlx_resolves_caller_catalog_references_in_overrides() {
 
     drop(root);
 }
+
+/// The dlx cache install must stay anchored to its prepare dir even when a
+/// directory above the cache carries a `pnpm-workspace.yaml`. Left
+/// unanchored, the install pipeline walks up from the cache dir, adopts
+/// that file as the workspace root, and the dlx package never lands in the
+/// prepare dir — the same walk-up that broke self-update in
+/// pnpm/pnpm#13697.
+#[cfg(unix)]
+#[test]
+fn dlx_ignores_an_ambient_workspace_manifest_above_the_cache_dir() {
+    let CommandTempCwd { pacquet, root, workspace, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+
+    // `root` is the parent of both the caller's workspace and the
+    // `pacquet-cache` dir the dlx prepare dir is created under.
+    std::fs::write(root.path().join("pnpm-workspace.yaml"), "allowBuilds:\n  esbuild: true\n")
+        .expect("write ambient workspace manifest above the cache dir");
+
+    pacquet.with_arg("dlx").with_arg("@foo/touch-file-one-bin").assert().success();
+
+    assert!(
+        workspace.join("touch.txt").exists(),
+        "the package's bin should run in the process cwd and write `touch.txt`",
+    );
+
+    drop(root);
+}


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#13697.

`pnpm self-update latest` on v12 failed with `the installed pnpm wrapper is missing at …\node_modules\@pnpm\exe` on machines where the global packages directory (`…/pnpm/global/v11`) contains a `pnpm-workspace.yaml`. That file is written there by pacquet itself when a global install persists an `allowBuilds` decision, so any such machine had every subsequent `self-update` fresh install broken.

Root cause: `self_update::install_pnpm::run_install` set `cfg.workspace_dir = None`, and with `None` the install pipeline *discovers* a workspace by walking up from the manifest dir (`configured_or_discovered_workspace_dir`). The engine's fresh install dir sits directly under `global/v11`, so the walk-up adopted the global-settings `pnpm-workspace.yaml` as the workspace root and laid the engine out as a workspace sub-importer — the wrapper package never landed in the install dir's `node_modules/`, and the reporter's progress line carried the global dir as its prefix (exactly what the issue's garbled log shows). The global-add group install already guards against this very hazard by pinning `workspace_dir` to the install dir (`run_group_install` in `cli_args::global`); the engine install and the dlx cache install never got the same anchor.

The fix pins `workspace_dir = Some(install_dir)` in both places:

- `self_update::install_pnpm::run_install` (also used by `pnpm with` and `packageManager` delegation for the engine's global-virtual-store install);
- the `dlx` cache install, which had the same latent exposure — a stray `pnpm-workspace.yaml` above the cache directory broke every `pnpm dlx` invocation.

Verified that a machine already carrying the corrupted leftovers (stray `node_modules`/lockfile at `global/v11` from failed attempts) recovers with no manual cleanup: the next `self-update` succeeds and links the wrapper correctly.

This is a pacquet-only fix: the TypeScript CLI passes its lockfile dir into the install explicitly and does not re-discover a workspace from the install dir (the reporter's TS-driven self-updates on the same machine worked fine), so there is nothing to mirror.

## Squash Commit Body

```text
Closes pnpm/pnpm#13697.

pacquet's install pipeline treats config.workspace_dir = None as "discover
the workspace by walking up from the manifest dir". The self-update engine
install creates its fresh install dir directly under the global packages
dir, and that dir legitimately carries a pnpm-workspace.yaml of global
settings once a global allowBuilds decision has been persisted. The walk-up
adopted it as the workspace root, the engine was laid out as a workspace
sub-importer, and the wrapper package never landed in the install dir —
self-update then failed with "the installed pnpm wrapper is missing" (and
left a stray node_modules in the global packages dir).

Anchor the engine install to its own install dir, the same guard the
global-add group install already applies (run_group_install in
cli_args::global). The dlx cache install had the identical latent exposure
from a pnpm-workspace.yaml above the cache dir and gets the same anchor.

Regression tests: run_install is exercised directly against the mock
registry with a stand-in package (engine signature verification happens in
the caller, so no real pnpm release is needed), and a dlx e2e test plants a
settings-only pnpm-workspace.yaml above the cache dir. Both fail without
the fix.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13709"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788700786&installation_model_id=426870&pr_number=13709&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13709&signature=e4394f4255df8bd86bcd1c2ac190071f7fb1d45f1a256a3e7365b3988ec68847"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm self-update` and `pnpm dlx` installations being affected by unrelated workspace configuration in parent directories.
  * Ensured temporary and self-update packages install in their intended directories, preventing missing-wrapper and execution failures.

* **Tests**
  * Added regression coverage for self-update and `dlx` behavior when an ancestor workspace configuration is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->