### PR TITLE
perf: let pnpm remove skip resolution

### DIFF
--- a/.changeset/remove-command-fast-path.md
+++ b/.changeset/remove-command-fast-path.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.deps-installer": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+`pnpm remove` no longer re-resolves the dependency graph. The removed dependency's entries are dropped from `pnpm-lock.yaml` and anything they made unreachable is pruned, without registry access. The install still falls back to a full resolution when a surviving package resolves a peer dependency through the removed one.

--- a/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
@@ -1132,7 +1132,7 @@ fn remove_command_drops_the_dependency_without_resolving() {
                 "is-positive": "1.0.0"
             },
             "scripts": {
-                "postinstall": "node -e \"require('fs').writeFileSync('postinstall-ran','')\""
+                "postinstall": r#"node -e "require('fs').writeFileSync('postinstall-ran','')""#
             }
         })
         .to_string(),

--- a/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
@@ -1130,6 +1130,9 @@ fn remove_command_drops_the_dependency_without_resolving() {
             "dependencies": {
                 "@pnpm.e2e/pkg-with-1-dep": "100.0.0",
                 "is-positive": "1.0.0"
+            },
+            "scripts": {
+                "postinstall": "node -e \"require('fs').writeFileSync('postinstall-ran','')\""
             }
         })
         .to_string(),
@@ -1141,6 +1144,8 @@ fn remove_command_drops_the_dependency_without_resolving() {
     fs::write(&workspace_yaml_path, format!("{workspace_yaml}trustLockfile: true\n"))
         .expect("enable trusted lockfile");
     pacquet_at(&workspace).with_arg("install").assert().success();
+    fs::remove_file(workspace.join("postinstall-ran"))
+        .expect("the full install ran the project postinstall");
 
     let dead_registry = dead_registry_url();
     let live_npmrc = fs::read_to_string(&npmrc_path).expect("read .npmrc");
@@ -1192,6 +1197,10 @@ fn remove_command_drops_the_dependency_without_resolving() {
     assert!(
         workspace.join("node_modules").join("@pnpm.e2e").join("pkg-with-1-dep").exists(),
         "and its node_modules link",
+    );
+    assert!(
+        !workspace.join("postinstall-ran").exists(),
+        "a remove runs no project lifecycle script",
     );
 
     drop((root, mock_instance));

--- a/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
@@ -1118,3 +1118,67 @@ fn dropping_a_dependency_from_the_manifest_skips_resolution() {
 
     drop((root, mock_instance));
 }
+
+#[test]
+fn remove_command_drops_the_dependency_without_resolving() {
+    let CommandTempCwd { workspace, root, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, npmrc_path, .. } = npmrc_info;
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pkg-with-1-dep": "100.0.0",
+                "is-positive": "1.0.0"
+            }
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    fs::write(&workspace_yaml_path, format!("{workspace_yaml}trustLockfile: true\n"))
+        .expect("enable trusted lockfile");
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    let dead_registry = dead_registry_url();
+    let live_npmrc = fs::read_to_string(&npmrc_path).expect("read .npmrc");
+    let dead_npmrc = live_npmrc
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("registry="))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(&npmrc_path, format!("registry={dead_registry}\n{dead_npmrc}\n"))
+        .expect("rewrite .npmrc with a dead registry");
+
+    let assert = pacquet_at(&workspace).with_args(["remove", "is-positive"]).assert().success();
+    assert!(
+        String::from_utf8_lossy(&assert.get_output().stdout)
+            .contains("Lockfile is up to date, resolution step is skipped"),
+        "removing a dependency needs no resolution",
+    );
+    let manifest: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(workspace.join("package.json")).expect("read package.json"),
+    )
+    .expect("parse package.json");
+    assert!(manifest["dependencies"].get("is-positive").is_none(), "the manifest entry is gone");
+    let wanted = pacquet_lockfile::Lockfile::load_wanted_from_dir(&workspace)
+        .expect("load updated wanted lockfile")
+        .expect("updated wanted lockfile");
+    assert!(
+        !wanted
+            .packages
+            .as_ref()
+            .expect("packages")
+            .keys()
+            .any(|key| key.to_string().starts_with("is-positive@")),
+        "the removed package is pruned from the lockfile",
+    );
+    assert!(
+        !workspace.join("node_modules").join("is-positive").exists(),
+        "and unlinked from node_modules",
+    );
+
+    drop((root, mock_instance));
+}

--- a/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
@@ -1179,6 +1179,20 @@ fn remove_command_drops_the_dependency_without_resolving() {
         !workspace.join("node_modules").join("is-positive").exists(),
         "and unlinked from node_modules",
     );
+    assert!(
+        manifest["dependencies"].get("@pnpm.e2e/pkg-with-1-dep").is_some(),
+        "the surviving dependency keeps its manifest entry",
+    );
+    assert!(
+        wanted.importers["."].dependencies.as_ref().is_some_and(|dependencies| {
+            dependencies.contains_key(&"@pnpm.e2e/pkg-with-1-dep".parse().expect("alias"))
+        }),
+        "and its importer entry",
+    );
+    assert!(
+        workspace.join("node_modules").join("@pnpm.e2e").join("pkg-with-1-dep").exists(),
+        "and its node_modules link",
+    );
 
     drop((root, mock_instance));
 }

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -189,9 +189,12 @@ pub enum ProjectMutation {
     /// rewrite named dependencies rather than installing the project's
     /// whole manifest.
     InstallSome,
-    /// A run that installs no project's manifest: pnpm's
-    /// `mutation: 'uninstallSome'` (`pacquet remove`) and the commands
-    /// that only materialize what the lockfile already records
+    /// pnpm's `mutation: 'uninstallSome'`: `pacquet remove`, which
+    /// deletes named dependencies from the manifest before the install
+    /// runs.
+    UninstallSome,
+    /// A run that installs no project's manifest: the commands that
+    /// only materialize what the lockfile already records
     /// (`link`, `import`, `fetch`, `rebuild`).
     NoInstall,
 }
@@ -202,6 +205,16 @@ impl ProjectMutation {
     #[must_use]
     pub fn is_full_install(self) -> bool {
         matches!(self, ProjectMutation::InstallWorkspace | ProjectMutation::InstallSelected)
+    }
+
+    /// Whether the run may absorb manifest drift by rewriting the
+    /// loaded lockfile instead of resolving: full installs, and
+    /// `pacquet remove`, whose only drift is the importer edges it
+    /// deleted — exactly what the removal handler of
+    /// `try_fast_update_lockfile` expresses.
+    #[must_use]
+    pub fn may_fast_update_lockfile(self) -> bool {
+        self.is_full_install() || matches!(self, ProjectMutation::UninstallSome)
     }
 }
 

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -207,11 +207,9 @@ impl ProjectMutation {
         matches!(self, ProjectMutation::InstallWorkspace | ProjectMutation::InstallSelected)
     }
 
-    /// Whether the run may absorb manifest drift by rewriting the
-    /// loaded lockfile instead of resolving: full installs, and
-    /// `pacquet remove`, whose only drift is the importer edges it
-    /// deleted — exactly what the removal handler of
-    /// `try_fast_update_lockfile` expresses.
+    /// Whether the run may absorb its manifest drift by rewriting the
+    /// loaded lockfile instead of resolving. `pacquet remove` qualifies
+    /// because its only drift is the importer edges it deleted.
     #[must_use]
     pub fn may_fast_update_lockfile(self) -> bool {
         self.is_full_install() || matches!(self, ProjectMutation::UninstallSome)

--- a/pnpm/crates/package-manager/src/install/run.rs
+++ b/pnpm/crates/package-manager/src/install/run.rs
@@ -497,8 +497,10 @@ where
         // would hide the change of a real install creating `pnpm-lock.yaml`.
         let existing_wanted_lockfile = lockfile;
         let lockfile = lockfile.or(synthesized_lockfile.as_ref());
-        let can_fast_update_lockfile =
-            !frozen_lockfile && !dry_run && prefer_frozen_lockfile && mutation.is_full_install();
+        let can_fast_update_lockfile = !frozen_lockfile
+            && !dry_run
+            && prefer_frozen_lockfile
+            && mutation.may_fast_update_lockfile();
         let fast_updated_lockfile = if can_fast_update_lockfile {
             try_fast_update_lockfile(FastUpdateLockfileOptions {
                 lockfile,

--- a/pnpm/crates/package-manager/src/install/workspace_state.rs
+++ b/pnpm/crates/package-manager/src/install/workspace_state.rs
@@ -375,7 +375,7 @@ pub(super) fn projects_running_own_scripts<'manifest>(
         materialized_project_manifests,
     } = *inputs;
     let full_install = match mutation {
-        ProjectMutation::NoInstall => return Vec::new(),
+        ProjectMutation::NoInstall | ProjectMutation::UninstallSome => return Vec::new(),
         ProjectMutation::InstallWorkspace => return materialized_project_manifests.to_vec(),
         ProjectMutation::InstallSelected => true,
         ProjectMutation::InstallSome => false,

--- a/pnpm/crates/package-manager/src/remove.rs
+++ b/pnpm/crates/package-manager/src/remove.rs
@@ -115,11 +115,12 @@ impl Remove<'_> {
             // re-resolve walks all three.
             dependency_groups: DIRECT_GROUPS,
             frozen_lockfile: false,
-            // `pacquet remove` mutates the manifest, so the lockfile is
-            // necessarily stale — short-circuit the prefer-frozen fast
-            // path so the install always re-resolves. See the parallel
-            // comment in `add.rs`.
-            prefer_frozen_lockfile: Some(false),
+            // The manifest was just edited, but the drift is exactly the
+            // deleted importer edges, which the removal handler of the
+            // lockfile fast path absorbs without resolving. When it
+            // declines, the freshness check fails and the install
+            // re-resolves as it always did.
+            prefer_frozen_lockfile: None,
             ignore_manifest_check: false,
             skip_runtimes: config.skip_runtimes,
             trust_lockfile: config.trust_lockfile,
@@ -128,7 +129,7 @@ impl Remove<'_> {
             // `uninstallSome` mutation), so the root project's own
             // lifecycle scripts must not run — they fire only on a full
             // install.
-            mutation: ProjectMutation::NoInstall,
+            mutation: ProjectMutation::UninstallSome,
             installs_only: false,
             resolved_packages,
             supported_architectures,
@@ -210,12 +211,12 @@ impl Remove<'_> {
             lockfile_path,
             dependency_groups: DIRECT_GROUPS,
             frozen_lockfile: false,
-            prefer_frozen_lockfile: Some(false),
+            prefer_frozen_lockfile: None,
             ignore_manifest_check: false,
             skip_runtimes: config.skip_runtimes,
             trust_lockfile: config.trust_lockfile,
             update_checksums: false,
-            mutation: ProjectMutation::NoInstall,
+            mutation: ProjectMutation::UninstallSome,
             installs_only: false,
             resolved_packages,
             supported_architectures,

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -2428,9 +2428,9 @@ const installInContext: InstallFunction = async (projects, ctx, opts) => {
         },
         currentHoistedLocations: ctx.modulesFile?.hoistedLocations,
         selectedProjectDirs: projects.map((project) => project.rootDir),
-          projectDirsRunningScripts: projects
-            .filter((project) => project.mutation !== 'uninstallSome')
-            .map((project) => project.rootDir),
+        projectDirsRunningScripts: projects
+          .filter((project) => project.mutation !== 'uninstallSome')
+          .map((project) => project.rootDir),
         allProjects: ctx.projects,
         prunedAt: ctx.modulesFile?.prunedAt,
         wantedLockfile: result.newLockfile,

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -2398,6 +2398,9 @@ const installInContext: InstallFunction = async (projects, ctx, opts) => {
           },
           currentHoistedLocations: ctx.modulesFile?.hoistedLocations,
           selectedProjectDirs: projects.map((project) => project.rootDir),
+          projectDirsRunningScripts: projects
+            .filter((project) => project.mutation !== 'uninstallSome')
+            .map((project) => project.rootDir),
           allProjects: ctx.projects,
           prunedAt: ctx.modulesFile?.prunedAt,
           wantedLockfile: result.newLockfile,
@@ -2425,6 +2428,9 @@ const installInContext: InstallFunction = async (projects, ctx, opts) => {
         },
         currentHoistedLocations: ctx.modulesFile?.hoistedLocations,
         selectedProjectDirs: projects.map((project) => project.rootDir),
+          projectDirsRunningScripts: projects
+            .filter((project) => project.mutation !== 'uninstallSome')
+            .map((project) => project.rootDir),
         allProjects: ctx.projects,
         prunedAt: ctx.modulesFile?.prunedAt,
         wantedLockfile: result.newLockfile,

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -1338,6 +1338,9 @@ Note that in CI environments, this setting is enabled by default.`,
         currentHoistedLocations: ctx.modulesFile?.hoistedLocations,
         patchedDependencies: patchGroups,
         selectedProjectDirs: projects.map((project) => project.rootDir),
+        projectDirsRunningScripts: projects
+          .filter((project) => project.mutation !== 'uninstallSome')
+          .map((project) => project.rootDir),
         allProjects: ctx.projects,
         prunedAt: ctx.modulesFile?.prunedAt,
         pruneVirtualStore,

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -352,6 +352,12 @@ export async function mutateModules (
   }
 
   const installsOnly = allMutationsAreInstalls(projects)
+  // Removals may take the fast lockfile update and the frozen-like
+  // install; an explicitly frozen run keeps its stricter behavior.
+  const installsAndUninstallsOnly = installsOnly ||
+    projects.every((project) => (
+      project.mutation === 'install' && !project.update && !project.updateMatching
+    ) || project.mutation === 'uninstallSome')
   if (!installsOnly) opts.strictPeerDependencies = false
   const rootProjectManifest = opts.allProjects.find(({ rootDir }) => rootDir === opts.lockfileDir)?.manifest ??
     // When running install/update on a subset of projects, the root project might not be included,
@@ -673,6 +679,21 @@ export async function mutateModules (
     const patchGroups = patchGroupInput ? groupPatchedDependencies(patchGroupInput) : undefined
     const frozenLockfile = opts.frozenLockfile ||
       opts.frozenLockfileIfExists && ctx.existsNonEmptyWantedLockfile
+    // `uninstallSome` edits the manifests here, ahead of the fast-path
+    // dispatch, so a removal is visible to it the same way a hand-edited
+    // manifest is. The resolution path is unaffected: it drops the same
+    // names through `removePackages`, and `removeDeps` re-applied there
+    // is a no-op.
+    await Promise.all(projects.map(async (project) => {
+      if (project.mutation !== 'uninstallSome') return
+      const ctxProject = ctx.projects[project.rootDir]
+      if (ctxProject == null) return
+      const _removeDeps = async (manifest: ProjectManifest) => removeDeps(manifest, project.dependencyNames, { prefix: project.rootDir, saveType: project.targetDependenciesField })
+      ctxProject.manifest = await _removeDeps(ctxProject.manifest)
+      if (ctxProject.originalManifest != null) {
+        ctxProject.originalManifest = await _removeDeps(ctxProject.originalManifest)
+      }
+    }))
     let changedLockfileSettings: ChangedField[] = []
     const overridesMap = createOverridesMapFromParsed(opts.parsedOverrides)
     const wantedLockfileSettings = {
@@ -720,7 +741,7 @@ export async function mutateModules (
       // `pnpm fetch` installs from the lockfile alone; with its empty
       // manifests every recorded dependency would read as removed.
       !opts.ignorePackageManifest &&
-      installsOnly &&
+      installsAndUninstallsOnly &&
       !isCheckOnlyInstall(opts) &&
       opts.preferFrozenLockfile &&
       opts.useLockfile &&
@@ -1185,7 +1206,7 @@ export async function mutateModules (
       // frozen path would skip resolution and/or perform a real install.
       !isCheckOnlyInstall(opts) &&
 
-      installsOnly &&
+      (installsOnly || (installsAndUninstallsOnly && !frozenLockfile)) &&
       (
         // If the user explicitly requested a frozen lockfile install, attempt
         // to perform one. An error will be thrown if updates are required.

--- a/pnpm11/installing/deps-installer/test/install/importerRemovalFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/importerRemovalFastUpdate.ts
@@ -1,5 +1,8 @@
 import { expect, test } from '@jest/globals'
+import { mutateModulesInSingleProject } from '@pnpm/installing.deps-installer'
 import type { LockfileObject } from '@pnpm/lockfile.types'
+import { prepareEmpty } from '@pnpm/prepare'
+import type { StoreController } from '@pnpm/store.controller-types'
 import type { DepPath, ProjectId, ProjectManifest } from '@pnpm/types'
 import { clone } from 'ramda'
 
@@ -7,6 +10,7 @@ import {
   hasChangedProjectSpecifiers,
   tryFastUpdateImporters,
 } from '../../src/install/tryFastUpdateImporters.js'
+import { testDefaults } from '../utils/index.js'
 
 test('a dependency the manifest dropped is noticed as a change', () => {
   expect(hasChangedProjectSpecifiers(lockfile(), [project({ bar: '^2.0.0' })])).toBe(true)
@@ -110,6 +114,52 @@ test('a catalog entry another importer references is kept', () => {
   ])).toBe(true)
   expect(subject.catalogs).toStrictEqual({ default: { foo: { specifier: '^1.0.0', version: '1.1.0' } } })
 })
+
+test('pnpm remove drops the dependency without requesting packages', async () => {
+  const project = prepareEmpty()
+  const manifest: ProjectManifest = {
+    dependencies: {
+      '@pnpm.e2e/pkg-with-1-dep': '100.0.0',
+      'is-positive': '1.0.0',
+    },
+  }
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, testDefaults())
+
+  const options = testDefaults()
+  const requestedPackages = trackRequestedPackages(options.storeController)
+  const { updatedProject } = await mutateModulesInSingleProject({
+    dependencyNames: ['is-positive'],
+    manifest,
+    mutation: 'uninstallSome',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, options)
+
+  expect(requestedPackages).toStrictEqual([])
+  expect(updatedProject.manifest.dependencies).toStrictEqual({
+    '@pnpm.e2e/pkg-with-1-dep': '100.0.0',
+  })
+  const lockfile = project.readLockfile()
+  expect(Object.keys(lockfile.packages).some((depPath) => depPath.startsWith('is-positive@'))).toBe(false)
+  expect(lockfile.importers['.']).toStrictEqual({
+    dependencies: {
+      '@pnpm.e2e/pkg-with-1-dep': { specifier: '100.0.0', version: '100.0.0' },
+    },
+  })
+})
+
+function trackRequestedPackages (storeController: StoreController): string[] {
+  const requestedPackages: string[] = []
+  const requestPackage = storeController.requestPackage
+  storeController.requestPackage = async (wantedDependency, requestOptions) => {
+    requestedPackages.push(wantedDependency.alias!)
+    return requestPackage(wantedDependency, requestOptions)
+  }
+  return requestedPackages
+}
 
 function project (dependencies: Record<string, string>) {
   return {

--- a/pnpm11/installing/deps-installer/test/install/importerRemovalFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/importerRemovalFastUpdate.ts
@@ -149,6 +149,8 @@ test('pnpm remove drops the dependency without requesting packages', async () =>
       '@pnpm.e2e/pkg-with-1-dep': { specifier: '100.0.0', version: '100.0.0' },
     },
   })
+  project.hasNot('is-positive')
+  project.has('@pnpm.e2e/pkg-with-1-dep')
 })
 
 function trackRequestedPackages (storeController: StoreController): string[] {

--- a/pnpm11/installing/deps-installer/test/install/importerRemovalFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/importerRemovalFastUpdate.ts
@@ -3,7 +3,7 @@ import { mutateModulesInSingleProject } from '@pnpm/installing.deps-installer'
 import type { LockfileObject } from '@pnpm/lockfile.types'
 import { prepareEmpty } from '@pnpm/prepare'
 import type { StoreController } from '@pnpm/store.controller-types'
-import type { DepPath, ProjectId, ProjectManifest } from '@pnpm/types'
+import type { DepPath, ProjectId, ProjectManifest, ProjectRootDir } from '@pnpm/types'
 import { clone } from 'ramda'
 
 import {

--- a/pnpm11/installing/deps-restorer/src/index.ts
+++ b/pnpm11/installing/deps-restorer/src/index.ts
@@ -136,6 +136,12 @@ export interface HeadlessOptions {
   ignoreLocalPackages?: boolean
   include: IncludedDependencies
   selectedProjectDirs: string[]
+  /**
+   * The selected projects whose own lifecycle scripts may run. Defaults to
+   * every selected project; an `uninstallSome` mutation materializes for its
+   * project without running its scripts, matching the resolution path.
+   */
+  projectDirsRunningScripts?: string[]
   allProjects: Record<string, Project>
   prunedAt?: string
   hoistedDependencies: HoistedDependencies
@@ -244,6 +250,9 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
   )
   const publicHoistedModulesDir = rootModulesDir
   const selectedProjects = Object.values(pick(opts.selectedProjectDirs, opts.allProjects))
+  const projectsRunningScripts = opts.projectDirsRunningScripts == null
+    ? selectedProjects
+    : Object.values(pick(opts.projectDirsRunningScripts, opts.allProjects))
 
   const scriptsOpts = {
     optional: false,
@@ -607,7 +616,7 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
   opts.pendingBuilds = opts.pendingBuilds
     .filter((id) => wantedLockfile.packages?.[id as DepPath] != null || wantedLockfile.importers[id as ProjectId] != null)
   if (opts.ignoreScripts) {
-    for (const { id, manifest } of selectedProjects) {
+    for (const { id, manifest } of projectsRunningScripts) {
       if (((manifest?.scripts) != null) &&
         (manifest.scripts.preinstall ?? manifest.scripts.prepublish ??
           manifest.scripts.install ??
@@ -802,7 +811,7 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
     await opts.verifyLockfile?.()
     await runLifecycleHooksConcurrently(
       ['preinstall', 'install', 'postinstall', 'preprepare', 'prepare', 'postprepare'],
-      projectsToBeBuilt,
+      projectsToBeBuilt.filter((project) => projectsRunningScripts.some(({ rootDir }) => rootDir === project.rootDir)),
       opts.childConcurrency ?? 5,
       scriptsOpts
     )

--- a/pnpm11/pnpm/test/install/lifecycleScripts.ts
+++ b/pnpm11/pnpm/test/install/lifecycleScripts.ts
@@ -562,6 +562,17 @@ test('a remove in a workspace member runs no project postinstall', () => {
   expect(projectsThatRanPostinstall(['a', 'b'])).toStrictEqual([])
 })
 
+test('a remove that falls back to resolution runs no project postinstall', () => {
+  prepareInstalledWorkspace(['a', 'b'])
+  // A pnpmfile keeps the remove off the fast lockfile update, so the
+  // removal takes the resolve-then-materialize path.
+  fs.writeFileSync('.pnpmfile.cjs', 'module.exports = { hooks: { readPackage: (pkg) => pkg } }')
+
+  execPnpmSync(['remove', DEP], { cwd: path.resolve('packages/a'), expectSuccess: true })
+
+  expect(projectsThatRanPostinstall(['a', 'b'])).toStrictEqual([])
+})
+
 test('an argumentless update at the workspace root runs the postinstall of the root alone', () => {
   prepareInstalledWorkspace(['a', 'b'])
 


### PR DESCRIPTION
## Summary

Related to pnpm/pnpm#13696 — the second half of the `pnpm remove` item. pnpm/pnpm#13698 built the lockfile transformation; this wires the `remove` command itself to it, in both stacks. `pnpm remove` now drops the dependency's entries and prunes without resolving; the resolver only runs when the removal handler declines (a dropped dependency that a surviving package resolves as a peer, a hashed peer suffix).

### pacquet

`pacquet remove` already edits the manifest before its install runs, but forced `prefer_frozen_lockfile` off on the grounds that "the lockfile is necessarily stale — always re-resolve". The removal handler now absorbs exactly that staleness, so the override only cost a full resolution.

Remove gets its own `ProjectMutation::UninstallSome` instead of the `NoInstall` it shared with `link`, `import`, `fetch`, and `rebuild` — commands that must never rewrite the lockfile. The new variant behaves like `NoInstall` everywhere except the fast-update gate, expressed as `may_fast_update_lockfile()` so the gate names the semantics rather than enumerating variants.

### TypeScript

`uninstallSome` fed its removals into resolution through `removePackages`, while the fast-path dispatch compared manifests that still contained the removed dependencies — the manifest edit happened later, inside the resolution path. The edit is now applied to the context projects before the dispatch, so a removal is visible to it the same way a hand-edited manifest is, and install+`uninstallSome` mutation sets are admitted to the fast update and the frozen-like install. An explicitly frozen run keeps its stricter behavior, and the resolution path is unchanged: it drops the same names through `removePackages`, and re-applying `removeDeps` there is a no-op.

### Tests

- pacquet e2e: `pacquet remove` against a dead registry — resolution skipped, manifest persisted, lockfile pruned, `node_modules` unlinked. Fails with the mutation gate reverted.
- TypeScript: `pnpm remove` requests no packages from the store controller and lands the pruned lockfile; fails with the admission reverted. (For removals this assertion is discriminating: a real resolution of the surviving graph requests every remaining package.)
- The full `uninstall` suites in both stacks pass with removals now routed through the fast path, covering bins cleanup and the rest of the removal behaviors.

## Squash Commit Body

```text
pnpm remove edits the manifest and then re-resolved the whole graph,
although its only lockfile drift is the importer edges it deleted —
exactly what the removal fast path absorbs.

pacquet: give remove its own ProjectMutation::UninstallSome instead of
the NoInstall it shared with link, import, fetch, and rebuild, and stop
forcing prefer_frozen_lockfile off; the gate admits the new variant via
may_fast_update_lockfile.

TypeScript: apply the uninstallSome manifest edit to the context projects
before the fast-path dispatch, and admit install+uninstallSome mutation
sets to the fast update and the frozen-like install. Explicitly frozen
runs keep their stricter behavior; the resolution path is unchanged.

When the removal handler declines, the freshness check fails and the
install re-resolves as before.

Related to pnpm/pnpm#13696.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788705690&installation_model_id=426870&pr_number=13712&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13712&signature=ffc5ab16c28d3106034c1f875e3bbc570c20260ca24a907866c0044ed23fbf20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `pnpm remove` now updates project manifests, lockfiles, and installed dependencies without contacting the registry when resolution is unnecessary.
  - Full dependency resolution is retained when peer dependencies require the removed package.

- **Bug Fixes**
  - Improved dependency removal when the registry is unavailable.
  - Prevented unnecessary project lifecycle scripts from running during removal.
  - Ensured removed packages are consistently pruned from lockfiles and `node_modules`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->