### PR TITLE
fix(deps-installer): satisfy semver ranges under strict catalog mode

### DIFF
--- a/.changeset/catalog-strict-range-satisfies.md
+++ b/.changeset/catalog-strict-range-satisfies.md
@@ -1,6 +1,7 @@
 ---
 "@pnpm/installing.deps-installer": patch
+"pacquet": patch
 "pnpm": patch
 ---
 
-`pnpm update <pkg>@<version>` under `catalogMode: strict` no longer rejects a version that satisfies a range-based catalog entry, only a version that actually disagrees with it.
+`pnpm add <pkg>@<version>` and `pnpm update <pkg>@<version>` under `catalogMode: strict` no longer fail with `ERR_PNPM_CATALOG_VERSION_MISMATCH` when the catalog entry is a range that the wanted version satisfies. The dependency keeps using the catalog; only a version that really falls outside the catalog's range is rejected [#13715](https://github.com/pnpm/pnpm/issues/13715).

--- a/.changeset/catalog-strict-range-satisfies.md
+++ b/.changeset/catalog-strict-range-satisfies.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-installer": patch
+"pnpm": patch
+---
+
+`pnpm update <pkg>@<version>` under `catalogMode: strict` no longer rejects a version that satisfies a range-based catalog entry, only a version that actually disagrees with it.

--- a/pnpm/crates/cli/tests/suite/update.rs
+++ b/pnpm/crates/cli/tests/suite/update.rs
@@ -1049,16 +1049,16 @@ fn update_latest_default_catalog_preserves_reference() {
 }
 
 /// `pacquet update --lockfile-only <pkg>@<version>` under
-/// `catalogMode: strict`, where the catalog entry for `<pkg>` is a
-/// *range*, rejects with `ERR_PNPM_CATALOG_VERSION_MISMATCH` instead of
-/// crashing. This is the exact `Renovate` scenario ported from
-/// [pnpm#11706](https://github.com/pnpm/pnpm/pull/11706): before the fix,
-/// passing a range to the exact-version comparison threw `Invalid
-/// Version`.
+/// `catalogMode: strict`, where the wanted version falls outside the
+/// catalog entry's range, rejects with
+/// `ERR_PNPM_CATALOG_VERSION_MISMATCH` instead of crashing
+/// ([pnpm#11706](https://github.com/pnpm/pnpm/pull/11706): before that
+/// fix, passing a range to the exact-version comparison threw `Invalid
+/// Version`).
 #[test]
 fn update_strict_catalog_range_mismatch_errors() {
     let (root, workspace, anchor) = setup();
-    set_strict_catalog(&workspace, &[(DEP, "^100.0.0")]);
+    set_strict_catalog(&workspace, &[(DEP, "^101.0.0")]);
     write_manifest(&workspace, &format!(r#"{{ "{DEP}": "catalog:" }}"#));
 
     let output = pacquet(&workspace, ["update", "--lockfile-only", &format!("{DEP}@100.0.0")])
@@ -1073,6 +1073,31 @@ fn update_strict_catalog_range_mismatch_errors() {
     assert!(
         stderr.contains("ERR_PNPM_CATALOG_VERSION_MISMATCH"),
         "stderr did not carry the error code: {stderr}",
+    );
+
+    drop((root, anchor));
+}
+
+/// A wanted version the catalog range already covers is taken from the
+/// catalog instead of being rejected, so the dependency keeps its
+/// `catalog:` reference. This is the `Renovate` scenario from
+/// [pnpm#13715](https://github.com/pnpm/pnpm/issues/13715).
+#[test]
+fn update_strict_catalog_range_covering_the_wanted_version_succeeds() {
+    let (root, workspace, anchor) = setup();
+    set_strict_catalog(&workspace, &[(DEP, "^100.0.0")]);
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "catalog:" }}"#));
+    pacquet(&workspace, ["install", "--lockfile-only"]).assert().success();
+
+    pacquet(&workspace, ["update", "--lockfile-only", &format!("{DEP}@100.1.0")])
+        .assert()
+        .success();
+
+    assert_eq!(dep_spec(&workspace, DEP).as_deref(), Some("catalog:"));
+    let lockfile = fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read lockfile");
+    assert!(
+        lockfile.contains(&format!("{DEP}@100.1.0")),
+        "the update should have moved the catalog resolution to 100.1.0:\n{lockfile}",
     );
 
     drop((root, anchor));

--- a/pnpm/crates/package-manager/src/catalog_mode.rs
+++ b/pnpm/crates/package-manager/src/catalog_mode.rs
@@ -12,7 +12,7 @@
 
 use derive_more::{Display, Error};
 use miette::Diagnostic;
-use node_semver::Version;
+use node_semver::{Range, Version};
 use pacquet_catalogs_protocol_parser::parse_catalog_protocol;
 use pacquet_catalogs_resolver::{CatalogResolutionResult, WantedDependency, resolve_from_catalog};
 use pacquet_catalogs_types::{Catalogs, DEFAULT_CATALOG_NAME};
@@ -155,7 +155,7 @@ pub(crate) fn decide_catalog_outcome(
         }
     };
 
-    if versions_equal(dep.bare_specifier, &entry) {
+    if catalog_covers(&entry, dep.bare_specifier) {
         return Ok(CatalogDecisionOutcome {
             decision: CatalogDecision::Catalog {
                 manifest_specifier: catalog_specifier,
@@ -187,14 +187,15 @@ pub(crate) fn decide_catalog_outcome(
     }
 }
 
-/// Equal only when **both** specifiers are concrete semver versions that
-/// compare equal. A range (e.g. `^2.0.0`) fails [`Version::parse`], so it
-/// never reaches the comparison — the Rust analogue of pnpm guarding
-/// `semver.eq` with `semver.valid`
-/// ([pnpm#11706](https://github.com/pnpm/pnpm/pull/11706)). Passing a
-/// range to an exact-version comparison is the bug that fix prevents.
-fn versions_equal(lhs: &str, rhs: &str) -> bool {
-    matches!((Version::parse(lhs), Version::parse(rhs)), (Ok(left), Ok(right)) if left == right)
+/// Whether the catalog entry already covers the wanted specifier, so the
+/// dependency can keep resolving through the catalog: the entry names the
+/// same concrete version, or it is a range the wanted version satisfies.
+///
+/// The wanted specifier has to be a concrete version. A wanted range is
+/// never covered, because the catalog — not the dependency — decides which
+/// version a `catalog:` reference resolves to.
+fn catalog_covers(entry: &str, wanted: &str) -> bool {
+    matches!((Range::parse(entry), Version::parse(wanted)), (Ok(entry), Ok(wanted)) if entry.satisfies(&wanted))
 }
 
 /// The catalog group a dependency belongs to: a previous `catalog:<name>`

--- a/pnpm/crates/package-manager/src/catalog_mode/tests.rs
+++ b/pnpm/crates/package-manager/src/catalog_mode/tests.rs
@@ -58,15 +58,42 @@ fn strict_errors_on_a_concrete_version_mismatch() {
 }
 
 #[test]
-fn strict_errors_when_the_catalog_entry_is_a_range() {
+fn strict_errors_when_the_catalog_range_excludes_the_wanted_version() {
     let catalogs = catalogs(&[("default", &[("is-positive", "^2.0.0")])]);
     let err = decide(CatalogMode::Strict, &catalogs, &dep("is-positive", "1.0.0"))
-        .expect_err("a range catalog entry must error, not panic, under strict mode");
+        .expect_err("a version outside the catalog range must error, not panic, under strict mode");
     assert_eq!(
         err,
         CatalogVersionMismatchError {
             catalog_dep: "is-positive@^2.0.0".to_string(),
             wanted_dep: "is-positive@1.0.0".to_string(),
+        },
+    );
+}
+
+#[test]
+fn strict_uses_the_catalog_when_its_range_covers_the_wanted_version() {
+    let catalogs = catalogs(&[("default", &[("is-positive", "^2.0.0")])]);
+    let decision = decide(CatalogMode::Strict, &catalogs, &dep("is-positive", "2.1.0")).unwrap();
+    assert_eq!(
+        decision,
+        CatalogDecision::Catalog {
+            manifest_specifier: "catalog:".to_string(),
+            updated_entry: None
+        },
+        "a version inside the catalog range reuses the existing catalog entry",
+    );
+}
+
+#[test]
+fn prefer_uses_the_catalog_when_its_range_covers_the_wanted_version() {
+    let catalogs = catalogs(&[("default", &[("is-positive", "^2.0.0")])]);
+    let decision = decide(CatalogMode::Prefer, &catalogs, &dep("is-positive", "2.1.0")).unwrap();
+    assert_eq!(
+        decision,
+        CatalogDecision::Catalog {
+            manifest_specifier: "catalog:".to_string(),
+            updated_entry: None
         },
     );
 }

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -1164,14 +1164,21 @@ export async function mutateModules (
           const catalog = resolveFromCatalog(opts.catalogs, { ...wantedDep, bareSpecifier: catalogBareSpecifier })
           const catalogDepSpecifier = matchCatalogResolveResult(catalog, pickCatalogSpecifier)
 
+          const wantedVersion = semver.valid(wantedDep.bareSpecifier)
           if (
             !catalogDepSpecifier ||
             wantedDep.bareSpecifier === catalogBareSpecifier ||
-            semver.valid(wantedDep.bareSpecifier) && (
-              semver.valid(catalogDepSpecifier) && semver.eq(wantedDep.bareSpecifier, catalogDepSpecifier) ||
-              semver.validRange(catalogDepSpecifier) && semver.satisfies(wantedDep.bareSpecifier, catalogDepSpecifier)
-            )
+            wantedVersion != null && semver.valid(catalogDepSpecifier) != null && semver.eq(wantedVersion, catalogDepSpecifier)
           ) {
+            wantedDep.saveCatalogName = perDepCatalogName
+            continue
+          }
+
+          if (wantedVersion != null && semver.validRange(catalogDepSpecifier) != null && semver.satisfies(wantedVersion, catalogDepSpecifier)) {
+            // The catalog range covers the wanted version, so the dependency resolves through
+            // the catalog. Keeping the wanted version as the specifier would pin it in the
+            // manifest instead, dropping the project out of the catalog.
+            wantedDep.bareSpecifier = catalogBareSpecifier
             wantedDep.saveCatalogName = perDepCatalogName
             continue
           }

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -1167,9 +1167,10 @@ export async function mutateModules (
           if (
             !catalogDepSpecifier ||
             wantedDep.bareSpecifier === catalogBareSpecifier ||
-            semver.valid(wantedDep.bareSpecifier) &&
-            semver.valid(catalogDepSpecifier) &&
-            semver.eq(wantedDep.bareSpecifier, catalogDepSpecifier)
+            semver.valid(wantedDep.bareSpecifier) && (
+              semver.valid(catalogDepSpecifier) && semver.eq(wantedDep.bareSpecifier, catalogDepSpecifier) ||
+              semver.validRange(catalogDepSpecifier) && semver.satisfies(wantedDep.bareSpecifier, catalogDepSpecifier)
+            )
           ) {
             wantedDep.saveCatalogName = perDepCatalogName
             continue

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -1164,19 +1164,15 @@ export async function mutateModules (
           const catalog = resolveFromCatalog(opts.catalogs, { ...wantedDep, bareSpecifier: catalogBareSpecifier })
           const catalogDepSpecifier = matchCatalogResolveResult(catalog, pickCatalogSpecifier)
 
-          const wantedVersion = semver.valid(wantedDep.bareSpecifier)
-          if (
-            !catalogDepSpecifier ||
-            wantedDep.bareSpecifier === catalogBareSpecifier ||
-            wantedVersion != null && semver.valid(catalogDepSpecifier) != null && semver.eq(wantedVersion, catalogDepSpecifier)
-          ) {
+          if (!catalogDepSpecifier || wantedDep.bareSpecifier === catalogBareSpecifier) {
             wantedDep.saveCatalogName = perDepCatalogName
             continue
           }
 
-          if (wantedVersion != null && semver.validRange(catalogDepSpecifier) != null && semver.satisfies(wantedVersion, catalogDepSpecifier)) {
-            // The catalog range covers the wanted version, so the dependency resolves through
-            // the catalog. Keeping the wanted version as the specifier would pin it in the
+          if (catalogCovers(catalogDepSpecifier, wantedDep.bareSpecifier)) {
+            // The catalog covers the wanted version, so the dependency resolves through the
+            // catalog: every project referencing the entry stays on the one version the entry
+            // resolves to. Keeping the wanted version as the specifier would pin it in the
             // manifest instead, dropping the project out of the catalog.
             wantedDep.bareSpecifier = catalogBareSpecifier
             wantedDep.saveCatalogName = perDepCatalogName
@@ -1600,6 +1596,21 @@ function isWantedDepBareSpecifierSame (
   const nextCatalogEntrySpec = catalogsConfig?.[catalogName]?.[alias]
 
   return prevCatalogEntrySpec === nextCatalogEntrySpec
+}
+
+/**
+ * Whether the catalog entry already covers the wanted specifier, so the dependency can keep
+ * resolving through the catalog: the entry names the same concrete version, or it is a range the
+ * wanted version satisfies.
+ *
+ * The wanted specifier has to be a concrete version. A wanted range is never covered, because the
+ * catalog — not the dependency — decides which version a `catalog:` reference resolves to.
+ */
+function catalogCovers (catalogSpecifier: string, bareSpecifier: string | undefined): boolean {
+  return bareSpecifier != null &&
+    semver.valid(bareSpecifier) != null &&
+    semver.validRange(catalogSpecifier) != null &&
+    semver.satisfies(bareSpecifier, catalogSpecifier)
 }
 
 /**

--- a/pnpm11/installing/deps-installer/test/catalogs.ts
+++ b/pnpm11/installing/deps-installer/test/catalogs.ts
@@ -1535,6 +1535,40 @@ describe('add', () => {
   })
 
   // Regression test for https://github.com/pnpm/pnpm/issues/13715
+  test('adding the version a named catalog pins exactly keeps the named catalog with catalogMode: strict', async () => {
+    const { options, projects, readLockfile } = preparePackagesAndReturnObjects([{
+      name: 'project1',
+      dependencies: {
+        '@pnpm.e2e/foo': 'catalog:foo',
+      },
+    }])
+
+    const { updatedManifest } = await addDependenciesToPackage(
+      projects['project1' as ProjectId],
+      ['@pnpm.e2e/foo@1.0.0'],
+      {
+        ...options,
+        dir: path.join(options.lockfileDir, 'project1'),
+        lockfileOnly: true,
+        allowNew: true,
+        catalogs: {
+          foo: { '@pnpm.e2e/foo': '1.0.0' },
+        },
+        catalogMode: 'strict',
+      })
+
+    expect(updatedManifest).toEqual({
+      name: 'project1',
+      dependencies: {
+        '@pnpm.e2e/foo': 'catalog:foo',
+      },
+    })
+    expect(readLockfile()).toMatchObject({
+      catalogs: { foo: { '@pnpm.e2e/foo': { specifier: '1.0.0', version: '1.0.0' } } },
+      importers: { project1: { dependencies: { '@pnpm.e2e/foo': { specifier: 'catalog:foo', version: '1.0.0' } } } },
+    })
+  })
+
   test('adding a version within the catalog range uses the catalog with catalogMode: strict', async () => {
     const { options, projects, readLockfile } = preparePackagesAndReturnObjects([{
       name: 'project1',

--- a/pnpm11/installing/deps-installer/test/catalogs.ts
+++ b/pnpm11/installing/deps-installer/test/catalogs.ts
@@ -1534,6 +1534,42 @@ describe('add', () => {
     ).rejects.toThrow(expect.objectContaining({ code: 'ERR_PNPM_CATALOG_VERSION_MISMATCH' }))
   })
 
+  test('wanted version satisfying catalog range does not error with catalogMode: strict', async () => {
+    const { options, projects, readLockfile } = preparePackagesAndReturnObjects([{
+      name: 'project1',
+      dependencies: {
+        'is-positive': 'catalog:',
+      },
+    }])
+
+    const { updatedManifest } = await addDependenciesToPackage(
+      projects['project1' as ProjectId],
+      ['is-positive@2.0.0'],
+      {
+        ...options,
+        dir: path.join(options.lockfileDir, 'project1'),
+        lockfileOnly: true,
+        allowNew: true,
+        catalogs: {
+          default: {
+            'is-positive': '^2.0.0',
+          },
+        },
+        catalogMode: 'strict',
+      })
+
+    expect(updatedManifest).toEqual({
+      name: 'project1',
+      dependencies: {
+        'is-positive': '2.0.0',
+      },
+    })
+    expect(readLockfile()).toMatchObject({
+      importers: { project1: { dependencies: { 'is-positive': { specifier: '2.0.0', version: '2.0.0' } } } },
+      packages: { 'is-positive@2.0.0': expect.any(Object) },
+    })
+  })
+
   test('adding mismatched version with catalogMode: prefer will warn and use direct', async () => {
     const { options, projects, readLockfile } = preparePackagesAndReturnObjects([{
       name: 'project1',

--- a/pnpm11/installing/deps-installer/test/catalogs.ts
+++ b/pnpm11/installing/deps-installer/test/catalogs.ts
@@ -1534,39 +1534,57 @@ describe('add', () => {
     ).rejects.toThrow(expect.objectContaining({ code: 'ERR_PNPM_CATALOG_VERSION_MISMATCH' }))
   })
 
-  test('wanted version satisfying catalog range does not error with catalogMode: strict', async () => {
+  // Regression test for https://github.com/pnpm/pnpm/issues/13715
+  test('adding a version within the catalog range uses the catalog with catalogMode: strict', async () => {
     const { options, projects, readLockfile } = preparePackagesAndReturnObjects([{
       name: 'project1',
       dependencies: {
-        'is-positive': 'catalog:',
+        '@pnpm.e2e/foo': 'catalog:',
+      },
+    }, {
+      name: 'project2',
+      dependencies: {
+        '@pnpm.e2e/foo': 'catalog:',
       },
     }])
 
-    const { updatedManifest } = await addDependenciesToPackage(
+    const mutateOpts = {
+      ...options,
+      lockfileOnly: true,
+      catalogs: {
+        default: { '@pnpm.e2e/foo': '^1.0.0' },
+      },
+      catalogMode: 'strict' as const,
+    }
+
+    await mutateModules(installProjects(projects), mutateOpts)
+
+    const { updatedManifest, updatedCatalogs } = await addDependenciesToPackage(
       projects['project1' as ProjectId],
-      ['is-positive@2.0.0'],
+      ['@pnpm.e2e/foo@1.3.0'],
       {
-        ...options,
+        ...mutateOpts,
         dir: path.join(options.lockfileDir, 'project1'),
-        lockfileOnly: true,
         allowNew: true,
-        catalogs: {
-          default: {
-            'is-positive': '^2.0.0',
-          },
-        },
-        catalogMode: 'strict',
       })
 
+    // The catalog covers the wanted version, so the dependency keeps using the
+    // catalog instead of pinning the version directly in the manifest.
     expect(updatedManifest).toEqual({
       name: 'project1',
       dependencies: {
-        'is-positive': '2.0.0',
+        '@pnpm.e2e/foo': 'catalog:',
       },
     })
+    expect(updatedCatalogs).toEqual({
+      default: { '@pnpm.e2e/foo': '^1.3.0' },
+    })
     expect(readLockfile()).toMatchObject({
-      importers: { project1: { dependencies: { 'is-positive': { specifier: '2.0.0', version: '2.0.0' } } } },
-      packages: { 'is-positive@2.0.0': expect.any(Object) },
+      catalogs: { default: { '@pnpm.e2e/foo': { specifier: '^1.3.0', version: '1.3.0' } } },
+      importers: {
+        project1: { dependencies: { '@pnpm.e2e/foo': { specifier: 'catalog:', version: '1.3.0' } } },
+        project2: { dependencies: { '@pnpm.e2e/foo': { specifier: 'catalog:', version: '1.3.0' } } },
+      },
     })
   })
 
@@ -1740,6 +1758,69 @@ describe('update', () => {
     })
 
     // Ensure the old 1.0.0 version is no longer used.
+    expect(Object.keys(lockfile.snapshots)).toEqual(['@pnpm.e2e/foo@1.3.0'])
+  })
+
+  // Simulates `pnpm update <pkg>@<version> --recursive --lockfile-only` against a
+  // catalog entry that is a range, the command Renovate runs.
+  // Regression test for https://github.com/pnpm/pnpm/issues/13715
+  test('updating to a version within the catalog range works with catalogMode: strict', async () => {
+    const { options, projects, readLockfile } = preparePackagesAndReturnObjects([{
+      name: 'project1',
+      dependencies: {
+        '@pnpm.e2e/foo': 'catalog:',
+      },
+    }, {
+      name: 'project2',
+      dependencies: {
+        '@pnpm.e2e/foo': 'catalog:',
+      },
+    }])
+
+    const catalogs = {
+      default: { '@pnpm.e2e/foo': '1.0.0' },
+    }
+    const mutateOpts = {
+      ...options,
+      lockfileOnly: true,
+      catalogs,
+      catalogMode: 'strict' as const,
+    }
+
+    await mutateModules(installProjects(projects), mutateOpts)
+
+    // Widen the catalog to a range while 1.0.0 stays locked, so the targeted
+    // update below is the only thing that can move the resolution.
+    catalogs.default['@pnpm.e2e/foo'] = '^1.0.0'
+    await mutateModules(installProjects(projects), mutateOpts)
+
+    expect(readLockfile().catalogs.default).toEqual({
+      '@pnpm.e2e/foo': { specifier: '^1.0.0', version: '1.0.0' },
+    })
+
+    const { updatedCatalogs, updatedProjects } = await mutateModules(
+      Object.entries(projects).map(([id, manifest]) => ({
+        ...manifest,
+        rootDir: path.resolve(id) as ProjectRootDir,
+        mutation: 'installSome' as const,
+        dependencySelectors: ['@pnpm.e2e/foo@1.3.0'],
+        allowNew: false,
+        update: true,
+        updatePackageManifest: true,
+      })),
+      mutateOpts
+    )
+
+    expect(updatedProjects[0]?.manifest?.dependencies?.['@pnpm.e2e/foo']).toBe('catalog:')
+    expect(updatedProjects[1]?.manifest?.dependencies?.['@pnpm.e2e/foo']).toBe('catalog:')
+    expect(updatedCatalogs).toEqual({
+      default: { '@pnpm.e2e/foo': '^1.3.0' },
+    })
+
+    const lockfile = readLockfile()
+    expect(lockfile.catalogs).toEqual({
+      default: { '@pnpm.e2e/foo': { specifier: '^1.3.0', version: '1.3.0' } },
+    })
     expect(Object.keys(lockfile.snapshots)).toEqual(['@pnpm.e2e/foo@1.3.0'])
   })
 

--- a/pnpm11/installing/deps-installer/test/catalogs.ts
+++ b/pnpm11/installing/deps-installer/test/catalogs.ts
@@ -1534,7 +1534,6 @@ describe('add', () => {
     ).rejects.toThrow(expect.objectContaining({ code: 'ERR_PNPM_CATALOG_VERSION_MISMATCH' }))
   })
 
-  // Regression test for https://github.com/pnpm/pnpm/issues/13715
   test('adding the version a named catalog pins exactly keeps the named catalog with catalogMode: strict', async () => {
     const { options, projects, readLockfile } = preparePackagesAndReturnObjects([{
       name: 'project1',
@@ -1569,6 +1568,7 @@ describe('add', () => {
     })
   })
 
+  // Regression test for https://github.com/pnpm/pnpm/issues/13715
   test('adding a version within the catalog range uses the catalog with catalogMode: strict', async () => {
     const { options, projects, readLockfile } = preparePackagesAndReturnObjects([{
       name: 'project1',


### PR DESCRIPTION
### The bug

`catalogMode: strict` rejects a wanted version whenever the catalog entry for that
dependency is a semver range, even when the requested version falls squarely inside
that range.

The comparison in `mutateModules` (in `pnpm11/installing/deps-installer/src/install/index.ts`)
accepts a wanted dependency only when both the wanted specifier and the catalog specifier
are individually "valid" exact versions and equal to each other:

```ts
semver.valid(wantedDep.bareSpecifier) &&
semver.valid(catalogDepSpecifier) &&
semver.eq(wantedDep.bareSpecifier, catalogDepSpecifier)
```

`semver.valid()` returns false for a range such as `^7.22.17`, which is the common,
documented, recommended way to declare a catalog entry. So whenever the catalog entry
is a range, this condition can never succeed, regardless of whether the wanted version
actually satisfies that range. Every such comparison falls through to
`CatalogVersionMismatchError`.

### Minimal repro

Workspace with `catalogMode: strict` and:

```yaml
catalog:
  is-positive: ^2.0.0
```

```json
{ "dependencies": { "is-positive": "catalog:" } }
```

Running:

```
pnpm update is-positive@2.5.0 --recursive --lockfile-only
```

throws `ERR_PNPM_CATALOG_VERSION_MISMATCH`, even though `2.5.0` satisfies `^2.0.0`.
This blocks Renovate's pnpm artifact-update flow, which runs exactly this kind of
targeted update command, on every workspace using `catalogMode: strict` with
range-based catalog entries.

### The fix

Add a second acceptance branch: when the catalog specifier is a valid range and the
wanted version satisfies it, accept the dependency instead of throwing.

```ts
semver.valid(wantedDep.bareSpecifier) && (
  semver.valid(catalogDepSpecifier) && semver.eq(wantedDep.bareSpecifier, catalogDepSpecifier) ||
  semver.validRange(catalogDepSpecifier) && semver.satisfies(wantedDep.bareSpecifier, catalogDepSpecifier)
)
```

This preserves all existing behavior for concrete-vs-concrete comparisons and for a
wanted specifier that is itself a range (both still correctly fall through to rejection,
since `semver.valid()` on a range is still false). It only adds the missing "wanted
version satisfies the catalog range" case.

This behavior was introduced by #11706, which fixed a crash in this same comparison
(passing a range to `semver.eq()` threw `Invalid Version`) but deliberately preserved
the reject-on-range behavior without addressing whether range satisfaction should
succeed. That question was raised in #11570's own "Expected Behavior" section and never
addressed. This PR closes that gap.

### Tests

Added a test in `test/catalogs.ts` right after the existing
`catalog specifier as a range does not crash with catalogMode: strict` test (which is
left unchanged and still passes, since `1.0.0` correctly does not satisfy `^2.0.0`).
The new test uses a wanted version that does satisfy the range (`2.0.0` against
`^2.0.0`) under `catalogMode: strict` and asserts the update resolves without throwing,
with the correct version recorded in the lockfile.

### Verification

```
cd pnpm11/installing/deps-installer
npx tsgo --build
PNPM_REGISTRY_MOCK_PORT=7769 NODE_OPTIONS="--experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" npx jest test/catalogs.ts
```

```
Test Suites: 1 passed, 1 total
Tests:       50 passed, 50 total
Snapshots:   0 total
Time:        3.913 s
```

Also ran the package's full test suite (excluding the network-dependent
`test/install/deepRecursive.ts`, which needs a real npm registry and fails offline on
both this branch and unmodified main) with `--runInBand`, all 964 tests passing with no
regressions.

### Scope note

This only touches the TypeScript pnpm implementation. Per this project's own
`pnpm/CONTRIBUTING.md`, a corresponding `pacquet` (Rust) parity port should only be made
after the TypeScript fix has landed and shipped, so that port is intentionally deferred
to a follow-up PR.

---

Written by an agent (Claude Code, claude-sonnet-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788722123&installation_model_id=426870&pr_number=13716&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13716&signature=2edd17c6c5055419a456538de940338d1af18bfa7dc94d4524e173321b24f3cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Strict catalog mode now accepts package versions that satisfy configured semver ranges during additions and updates.
  - Compatible catalog references are preserved in manifests and lockfiles.
  - Versions outside configured ranges continue to be rejected.
  - Non-semver catalog specifications retain their existing behavior.

- **Tests**
  - Added coverage for compatible and incompatible catalog ranges across installations, updates, workspaces, and lockfile resolutions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->