### PR TITLE
perf(npm-resolver): skip the registry when a preferred workspace package must win

### DIFF
--- a/.changeset/skip-registry-for-preferred-workspace-packages.md
+++ b/.changeset/skip-registry-for-preferred-workspace-packages.md
@@ -1,5 +1,7 @@
 ---
 "@pnpm/resolving.npm-resolver": patch
+"pacquet": patch
+"pnpm": patch
 ---
 
-`preferWorkspacePackages` no longer pays a registry round-trip per workspace package name. When that setting is on and exactly one workspace copy carries the wanted name and satisfies the range, the registry response cannot change which package is chosen, so the request is now skipped entirely. Workspaces that declare inter-workspace dependencies with plain ranges (`"*"`, `"^1.2.3"`) rather than the `workspace:` protocol paid this on every install, and workspace packages that were never published paid a 404 each time because negative results are not cached. The request is still made for injected dependencies, when several workspace copies share a name, under `trustPolicy=no-downgrade`, and when `updateChecksums` is set.
+Installs are faster in workspaces that declare inter-workspace dependencies with plain ranges (`"*"`, `"^1.2.3"`) rather than the `workspace:` protocol. With `preferWorkspacePackages` enabled, the registry request made before linking such a dependency could not change the outcome, and workspace packages that were never published returned an uncached 404 on every install. That request is now skipped when exactly one workspace copy carries the name and satisfies the range. The registry is still consulted for injected dependencies, when several workspace copies share a name, under `trustPolicy=no-downgrade`, and when `updateChecksums` is set.

--- a/.changeset/skip-registry-for-preferred-workspace-packages.md
+++ b/.changeset/skip-registry-for-preferred-workspace-packages.md
@@ -4,4 +4,4 @@
 "pnpm": patch
 ---
 
-Installs are faster in workspaces that declare inter-workspace dependencies with plain ranges (`"*"`, `"^1.2.3"`) rather than the `workspace:` protocol. With `preferWorkspacePackages` enabled, the registry request made before linking such a dependency could not change the outcome, and workspace packages that were never published returned an uncached 404 on every install. That request is now skipped when exactly one workspace copy carries the name and satisfies the range. The registry is still consulted for injected dependencies, when several workspace copies share a name, under `trustPolicy=no-downgrade`, and when `updateChecksums` is set.
+Installs are faster in workspaces that declare inter-workspace dependencies with plain ranges (`"*"`, `"^1.2.3"`) rather than the `workspace:` protocol. With `preferWorkspacePackages` enabled, linking such a dependency no longer makes a registry request that cannot change the outcome — and workspace packages that were never published no longer cost a 404 on every install.

--- a/.changeset/skip-registry-for-preferred-workspace-packages.md
+++ b/.changeset/skip-registry-for-preferred-workspace-packages.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/resolving.npm-resolver": patch
+---
+
+`preferWorkspacePackages` no longer pays a registry round-trip per workspace package name. When that setting is on and exactly one workspace copy carries the wanted name and satisfies the range, the registry response cannot change which package is chosen, so the request is now skipped entirely. Workspaces that declare inter-workspace dependencies with plain ranges (`"*"`, `"^1.2.3"`) rather than the `workspace:` protocol paid this on every install, and workspace packages that were never published paid a 404 each time because negative results are not cached. The request is still made for injected dependencies, when several workspace copies share a name, under `trustPolicy=no-downgrade`, and when `updateChecksums` is set.

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -217,6 +217,39 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
             .then_some(opts.workspace_packages.as_ref())
             .flatten();
 
+        // Fast path: skip the registry when the workspace copy is guaranteed
+        // to win. Under `prefer_workspace_packages`, `try_workspace_shadow`
+        // below returns the local package whatever the registry says, so the
+        // request only adds latency — and a workspace package that was never
+        // published costs a 404 on every install, uncached. Mirrors the
+        // TypeScript CLI (`pnpm11/resolving/npm-resolver/src/index.ts`).
+        //
+        // Restricted to a single local copy: with several, the exact-match arm
+        // of `try_workspace_shadow` picks by the registry's version. Injected
+        // deps keep the request because they resolve to `file:`, which is not
+        // treated as a local package downstream, so `latest` stays observable.
+        // `no-downgrade` and `update_checksums` both need registry metadata.
+        if opts.prefer_workspace_packages
+            && opts.trust_policy != Some(TrustPolicy::NoDowngrade)
+            && !opts.update_checksums
+            && !opts.inject_workspace_packages
+            && !wanted_dependency.injected.unwrap_or(false)
+            && let Some(workspace_packages) = workspace_packages_active
+            && let Some(matching_name) = workspace_packages.get(spec.name.as_str())
+            && matching_name.len() == 1
+            && let Some(local_version) = pick_matching_local_version_or_null(matching_name, &spec)
+            && let Some(local_package) = matching_name.get(&local_version)
+        {
+            return Ok(Some(resolve_from_local_package(
+                local_package,
+                wanted_dependency,
+                false,
+                opts.project_dir.as_path(),
+                opts.lockfile_dir.as_path(),
+                saved_specifier_options(opts),
+            )));
+        }
+
         let pick_result = self.pick_from_registry(&registry, &spec, opts, optional).await;
         let picked = match pick_result {
             Ok(RegistryPick::Picked(picked)) => picked,

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -217,18 +217,9 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
             .then_some(opts.workspace_packages.as_ref())
             .flatten();
 
-        // Fast path: skip the registry when the workspace copy is guaranteed
-        // to win. Under `prefer_workspace_packages`, `try_workspace_shadow`
-        // below returns the local package whatever the registry says, so the
-        // request only adds latency — and a workspace package that was never
-        // published costs a 404 on every install, uncached. Mirrors the
-        // TypeScript CLI (`pnpm11/resolving/npm-resolver/src/index.ts`).
-        //
-        // Restricted to a single local copy: with several, the exact-match arm
-        // of `try_workspace_shadow` picks by the registry's version. Injected
-        // deps keep the request because they resolve to `file:`, which is not
-        // treated as a local package downstream, so `latest` stays observable.
-        // `no-downgrade` and `update_checksums` both need registry metadata.
+        // A store-manifest peek, once pacquet grows one, has to run before
+        // this fast path — the TypeScript counterpart
+        // (`pnpm11/resolving/npm-resolver/src/index.ts`) documents why.
         if opts.prefer_workspace_packages
             && opts.trust_policy != Some(TrustPolicy::NoDowngrade)
             && !opts.update_checksums

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -1001,6 +1001,129 @@ async fn prefer_workspace_packages_keeps_workspace_over_newer_registry() {
 }
 
 #[tokio::test]
+async fn prefer_workspace_packages_skips_the_registry_entirely() {
+    let mut server = mockito::Server::new_async().await;
+    // The workspace copy wins whatever the registry says, so the request must
+    // not be made at all.
+    let mock = server.mock("GET", "/acme").expect(0).create_async().await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    let packages = build_workspace_packages("acme", &["1.0.0"]);
+    let mut opts = workspace_resolve_options(packages);
+    opts.prefer_workspace_packages = true;
+
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("^1.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, &opts).await.unwrap().expect("workspace pick");
+    assert_eq!(result.resolved_via, "workspace");
+    assert_eq!(result.id.as_str(), "link:../acme");
+    // `latest` comes from registry metadata, so the fast path cannot report it.
+    assert_eq!(result.latest, None);
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn prefer_workspace_packages_still_consults_registry_for_several_local_copies() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_body(single_version_body(
+            "1.1.0",
+            "sha512-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB==",
+        ))
+        .create_async()
+        .await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    // Two local copies: the registry's picked version decides which one wins,
+    // so the request is still required.
+    let packages = build_workspace_packages_at(
+        "acme",
+        &[("1.0.0", "/repo/packages/acme-1"), ("1.1.0", "/repo/packages/acme-11")],
+    );
+    let mut opts = workspace_resolve_options(packages);
+    opts.prefer_workspace_packages = true;
+
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("^1.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, &opts).await.unwrap().expect("workspace pick");
+    assert_eq!(result.resolved_via, "workspace");
+    assert_eq!(result.id.as_str(), "link:../acme-11");
+    assert_eq!(result.latest.as_deref(), Some("1.1.0"));
+}
+
+#[tokio::test]
+async fn prefer_workspace_packages_still_consults_registry_for_injected_deps() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_body(single_version_body(
+            "1.1.0",
+            "sha512-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB==",
+        ))
+        .create_async()
+        .await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    let packages = build_workspace_packages("acme", &["1.0.0"]);
+    let mut opts = workspace_resolve_options(packages);
+    opts.prefer_workspace_packages = true;
+
+    // Injected deps resolve to `file:`, which is not treated as a local package
+    // downstream, so `latest` stays observable and the request is still needed.
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("^1.0.0".to_string()),
+        injected: Some(true),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, &opts).await.unwrap().expect("workspace pick");
+    assert_eq!(result.resolved_via, "workspace");
+    assert_eq!(result.latest.as_deref(), Some("1.1.0"));
+}
+
+#[tokio::test]
+async fn prefer_workspace_packages_does_not_engage_without_a_matching_local_version() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_body(single_version_body(
+            "2.0.0",
+            "sha512-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB==",
+        ))
+        .create_async()
+        .await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    // The only local copy is outside the wanted range, so the registry decides.
+    let packages = build_workspace_packages("acme", &["1.0.0"]);
+    let mut opts = workspace_resolve_options(packages);
+    opts.prefer_workspace_packages = true;
+
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("^2.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, &opts).await.unwrap().expect("registry pick");
+    assert_eq!(result.resolved_via, "npm-registry");
+    assert_eq!(result.id.as_str(), "acme@2.0.0");
+}
+
+#[tokio::test]
 async fn workspace_higher_version_shadows_registry_pick() {
     let mut server = mockito::Server::new_async().await;
     let _mock = server

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -1029,7 +1029,7 @@ async fn prefer_workspace_packages_skips_the_registry_entirely() {
 #[tokio::test]
 async fn prefer_workspace_packages_still_consults_registry_for_several_local_copies() {
     let mut server = mockito::Server::new_async().await;
-    let _mock = server
+    let mock = server
         .mock("GET", "/acme")
         .with_status(200)
         .with_body(single_version_body(
@@ -1056,6 +1056,8 @@ async fn prefer_workspace_packages_still_consults_registry_for_several_local_cop
         ..WantedDependency::default()
     };
     let result = resolver.resolve(&wanted, &opts).await.unwrap().expect("workspace pick");
+    // The fallback must have gone to the registry.
+    mock.assert_async().await;
     assert_eq!(result.resolved_via, "workspace");
     assert_eq!(result.id.as_str(), "link:../acme-11");
     assert_eq!(result.latest.as_deref(), Some("1.1.0"));
@@ -1064,7 +1066,7 @@ async fn prefer_workspace_packages_still_consults_registry_for_several_local_cop
 #[tokio::test]
 async fn prefer_workspace_packages_still_consults_registry_for_injected_deps() {
     let mut server = mockito::Server::new_async().await;
-    let _mock = server
+    let mock = server
         .mock("GET", "/acme")
         .with_status(200)
         .with_body(single_version_body(
@@ -1089,6 +1091,8 @@ async fn prefer_workspace_packages_still_consults_registry_for_injected_deps() {
         ..WantedDependency::default()
     };
     let result = resolver.resolve(&wanted, &opts).await.unwrap().expect("workspace pick");
+    // The fallback must have gone to the registry.
+    mock.assert_async().await;
     assert_eq!(result.resolved_via, "workspace");
     assert_eq!(result.latest.as_deref(), Some("1.1.0"));
 }
@@ -1096,7 +1100,7 @@ async fn prefer_workspace_packages_still_consults_registry_for_injected_deps() {
 #[tokio::test]
 async fn prefer_workspace_packages_does_not_engage_without_a_matching_local_version() {
     let mut server = mockito::Server::new_async().await;
-    let _mock = server
+    let mock = server
         .mock("GET", "/acme")
         .with_status(200)
         .with_body(single_version_body(
@@ -1119,10 +1123,114 @@ async fn prefer_workspace_packages_does_not_engage_without_a_matching_local_vers
         ..WantedDependency::default()
     };
     let result = resolver.resolve(&wanted, &opts).await.unwrap().expect("registry pick");
+    // The fallback must have gone to the registry.
+    mock.assert_async().await;
     assert_eq!(result.resolved_via, "npm-registry");
     assert_eq!(result.id.as_str(), "acme@2.0.0");
 }
 
+#[tokio::test]
+async fn prefer_workspace_packages_still_consults_registry_under_no_downgrade() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_body(single_version_body(
+            "1.1.0",
+            "sha512-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB==",
+        ))
+        .create_async()
+        .await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    // `no-downgrade` validates registry metadata even when a workspace package wins, so the
+    // fast path must stay out of the way.
+    let packages = build_workspace_packages("acme", &["1.0.0"]);
+    let mut opts = workspace_resolve_options(packages);
+    opts.prefer_workspace_packages = true;
+    opts.trust_policy = Some(TrustPolicy::NoDowngrade);
+
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("^1.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, &opts).await.unwrap().expect("workspace pick");
+    assert_eq!(result.resolved_via, "workspace");
+    assert_eq!(result.id.as_str(), "link:../acme");
+    assert_eq!(result.latest.as_deref(), Some("1.1.0"));
+    // The fallback must have gone to the registry.
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn prefer_workspace_packages_still_consults_registry_when_updating_checksums() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_body(single_version_body(
+            "1.1.0",
+            "sha512-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB==",
+        ))
+        .create_async()
+        .await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    // `update_checksums` asks the resolver to rewrite cached metadata, which needs the fetch.
+    let packages = build_workspace_packages("acme", &["1.0.0"]);
+    let mut opts = workspace_resolve_options(packages);
+    opts.prefer_workspace_packages = true;
+    opts.update_checksums = true;
+
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("^1.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, &opts).await.unwrap().expect("workspace pick");
+    assert_eq!(result.resolved_via, "workspace");
+    assert_eq!(result.id.as_str(), "link:../acme");
+    assert_eq!(result.latest.as_deref(), Some("1.1.0"));
+    // The fallback must have gone to the registry.
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn prefer_workspace_packages_still_consults_registry_when_injecting_workspace_packages() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_body(single_version_body(
+            "1.1.0",
+            "sha512-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB==",
+        ))
+        .create_async()
+        .await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    // The install-wide `inject_workspace_packages` has the same effect as the per-dependency
+    // `injected` flag: a `file:` id, which is not treated as a local package downstream.
+    let packages = build_workspace_packages("acme", &["1.0.0"]);
+    let mut opts = workspace_resolve_options(packages);
+    opts.prefer_workspace_packages = true;
+    opts.inject_workspace_packages = true;
+
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("^1.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, &opts).await.unwrap().expect("workspace pick");
+    assert_eq!(result.resolved_via, "workspace");
+    assert_eq!(result.latest.as_deref(), Some("1.1.0"));
+    // The fallback must have gone to the registry.
+    mock.assert_async().await;
+}
 #[tokio::test]
 async fn workspace_higher_version_shadows_registry_pick() {
     let mut server = mockito::Server::new_async().await;

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -1003,8 +1003,6 @@ async fn prefer_workspace_packages_keeps_workspace_over_newer_registry() {
 #[tokio::test]
 async fn prefer_workspace_packages_skips_the_registry_entirely() {
     let mut server = mockito::Server::new_async().await;
-    // The workspace copy wins whatever the registry says, so the request must
-    // not be made at all.
     let mock = server.mock("GET", "/acme").expect(0).create_async().await;
     let registry = format!("{}/", server.url());
     let (resolver, _tempdir) = build_resolver(&registry);
@@ -1021,7 +1019,6 @@ async fn prefer_workspace_packages_skips_the_registry_entirely() {
     let result = resolver.resolve(&wanted, &opts).await.unwrap().expect("workspace pick");
     assert_eq!(result.resolved_via, "workspace");
     assert_eq!(result.id.as_str(), "link:../acme");
-    // `latest` comes from registry metadata, so the fast path cannot report it.
     assert_eq!(result.latest, None);
     mock.assert_async().await;
 }
@@ -1041,8 +1038,6 @@ async fn prefer_workspace_packages_still_consults_registry_for_several_local_cop
     let registry = format!("{}/", server.url());
     let (resolver, _tempdir) = build_resolver(&registry);
 
-    // Two local copies: the registry's picked version decides which one wins,
-    // so the request is still required.
     let packages = build_workspace_packages_at(
         "acme",
         &[("1.0.0", "/repo/packages/acme-1"), ("1.1.0", "/repo/packages/acme-11")],
@@ -1056,7 +1051,6 @@ async fn prefer_workspace_packages_still_consults_registry_for_several_local_cop
         ..WantedDependency::default()
     };
     let result = resolver.resolve(&wanted, &opts).await.unwrap().expect("workspace pick");
-    // The fallback must have gone to the registry.
     mock.assert_async().await;
     assert_eq!(result.resolved_via, "workspace");
     assert_eq!(result.id.as_str(), "link:../acme-11");
@@ -1082,8 +1076,6 @@ async fn prefer_workspace_packages_still_consults_registry_for_injected_deps() {
     let mut opts = workspace_resolve_options(packages);
     opts.prefer_workspace_packages = true;
 
-    // Injected deps resolve to `file:`, which is not treated as a local package
-    // downstream, so `latest` stays observable and the request is still needed.
     let wanted = WantedDependency {
         alias: Some("acme".to_string()),
         bare_specifier: Some("^1.0.0".to_string()),
@@ -1091,7 +1083,6 @@ async fn prefer_workspace_packages_still_consults_registry_for_injected_deps() {
         ..WantedDependency::default()
     };
     let result = resolver.resolve(&wanted, &opts).await.unwrap().expect("workspace pick");
-    // The fallback must have gone to the registry.
     mock.assert_async().await;
     assert_eq!(result.resolved_via, "workspace");
     assert_eq!(result.latest.as_deref(), Some("1.1.0"));
@@ -1112,7 +1103,6 @@ async fn prefer_workspace_packages_does_not_engage_without_a_matching_local_vers
     let registry = format!("{}/", server.url());
     let (resolver, _tempdir) = build_resolver(&registry);
 
-    // The only local copy is outside the wanted range, so the registry decides.
     let packages = build_workspace_packages("acme", &["1.0.0"]);
     let mut opts = workspace_resolve_options(packages);
     opts.prefer_workspace_packages = true;
@@ -1123,7 +1113,6 @@ async fn prefer_workspace_packages_does_not_engage_without_a_matching_local_vers
         ..WantedDependency::default()
     };
     let result = resolver.resolve(&wanted, &opts).await.unwrap().expect("registry pick");
-    // The fallback must have gone to the registry.
     mock.assert_async().await;
     assert_eq!(result.resolved_via, "npm-registry");
     assert_eq!(result.id.as_str(), "acme@2.0.0");
@@ -1144,8 +1133,6 @@ async fn prefer_workspace_packages_still_consults_registry_under_no_downgrade() 
     let registry = format!("{}/", server.url());
     let (resolver, _tempdir) = build_resolver(&registry);
 
-    // `no-downgrade` validates registry metadata even when a workspace package wins, so the
-    // fast path must stay out of the way.
     let packages = build_workspace_packages("acme", &["1.0.0"]);
     let mut opts = workspace_resolve_options(packages);
     opts.prefer_workspace_packages = true;
@@ -1160,7 +1147,6 @@ async fn prefer_workspace_packages_still_consults_registry_under_no_downgrade() 
     assert_eq!(result.resolved_via, "workspace");
     assert_eq!(result.id.as_str(), "link:../acme");
     assert_eq!(result.latest.as_deref(), Some("1.1.0"));
-    // The fallback must have gone to the registry.
     mock.assert_async().await;
 }
 
@@ -1179,7 +1165,6 @@ async fn prefer_workspace_packages_still_consults_registry_when_updating_checksu
     let registry = format!("{}/", server.url());
     let (resolver, _tempdir) = build_resolver(&registry);
 
-    // `update_checksums` asks the resolver to rewrite cached metadata, which needs the fetch.
     let packages = build_workspace_packages("acme", &["1.0.0"]);
     let mut opts = workspace_resolve_options(packages);
     opts.prefer_workspace_packages = true;
@@ -1194,7 +1179,6 @@ async fn prefer_workspace_packages_still_consults_registry_when_updating_checksu
     assert_eq!(result.resolved_via, "workspace");
     assert_eq!(result.id.as_str(), "link:../acme");
     assert_eq!(result.latest.as_deref(), Some("1.1.0"));
-    // The fallback must have gone to the registry.
     mock.assert_async().await;
 }
 
@@ -1213,8 +1197,6 @@ async fn prefer_workspace_packages_still_consults_registry_when_injecting_worksp
     let registry = format!("{}/", server.url());
     let (resolver, _tempdir) = build_resolver(&registry);
 
-    // The install-wide `inject_workspace_packages` has the same effect as the per-dependency
-    // `injected` flag: a `file:` id, which is not treated as a local package downstream.
     let packages = build_workspace_packages("acme", &["1.0.0"]);
     let mut opts = workspace_resolve_options(packages);
     opts.prefer_workspace_packages = true;
@@ -1228,9 +1210,9 @@ async fn prefer_workspace_packages_still_consults_registry_when_injecting_worksp
     let result = resolver.resolve(&wanted, &opts).await.unwrap().expect("workspace pick");
     assert_eq!(result.resolved_via, "workspace");
     assert_eq!(result.latest.as_deref(), Some("1.1.0"));
-    // The fallback must have gone to the registry.
     mock.assert_async().await;
 }
+
 #[tokio::test]
 async fn workspace_higher_version_shadows_registry_pick() {
     let mut server = mockito::Server::new_async().await;

--- a/pnpm11/resolving/npm-resolver/src/index.ts
+++ b/pnpm11/resolving/npm-resolver/src/index.ts
@@ -607,41 +607,18 @@ async function resolveNpm (
 
   // Fast path: skip the registry when the workspace copy is guaranteed to win.
   //
-  // With `preferWorkspacePackages`, the prefer-workspace gate below fires whenever a local
-  // version satisfies the spec, no matter what the registry returns, so the request is pure
-  // latency: its result is discarded. Repos that declare workspace deps with plain ranges
-  // (`"*"`, `"^1.2.3"`) rather than the `workspace:` protocol pay one round-trip per workspace
-  // package name on every install, and workspace packages that were never published pay a 404
-  // every time, since there is no negative caching.
+  // Under `preferWorkspacePackages`, the prefer-workspace gate below returns the local
+  // package whatever the registry says, so the request only adds latency — and a workspace
+  // package that was never published costs a 404 on every install, uncached.
   //
-  // Deliberately placed AFTER the store peek above: when the peek is eligible it returns the
-  // package recorded in the lockfile, and that must keep taking precedence. `update` is not
-  // enough to rule the peek out, because `wantedDepIsLocallyAvailable` in the deps resolver
-  // matches tags without `includePrerelease` while `pickMatchingLocalVersionOrNull` below
-  // includes them, so a prerelease-only workspace package can reach here with `update: false`.
+  // Two conditions are non-obvious. It runs *after* the store peek because a tag-specified
+  // dep whose only local copy is a prerelease reaches here with `update: false`
+  // (`wantedDepIsLocallyAvailable` ignores prereleases for tags, `pickMatchingLocalVersionOrNull`
+  // does not), and the peek must keep winning there. And `update` is deliberately not excluded:
+  // that same helper forces it on for these deps, so excluding it would make this unreachable.
   //
-  // Only taken when the outcome matches the slow path:
-  //   - `preferWorkspacePackages` is set, so the gate below ignores the registry's version.
-  //   - Exactly one workspace copy carries this name. With several copies the exact-match gate
-  //     below can select a different one via `pickedPackage.version`, which needs the registry.
-  //   - The dependency is not injected. Injected packages resolve to a `file:` id, which
-  //     `packageRequester` does not mark `isLocal`, so they keep flowing through the registry
-  //     bookkeeping in `resolveDependency` where the `latest` field below is still read.
-  //   - `trustPolicy` is not 'no-downgrade', which validates registry metadata even when a
-  //     workspace package ultimately wins.
-  //   - `updateChecksums` is off, since that asks the resolver to rewrite cached metadata.
-  //
-  // `update` is otherwise not excluded: it does not change which local version is chosen (this
-  // path and the gate below both match against `spec`), and `wantedDepIsLocallyAvailable` forces
-  // `update` on for precisely the workspace deps this targets, so excluding it would leave the
-  // fast path almost never reachable.
-  //
-  // The `latest` field the gates below attach is not observable through the install pipeline for
-  // the packages this path returns: they are linked rather than injected, so `resolveDependency`
-  // returns them early on `isLocal` before `ctx.outdatedDependencies` is populated. It does
-  // remain absent for direct consumers of this resolver's exported API. Metadata cache warming
-  // is skipped as a side effect, which can leave a later resolution of the same name without a
-  // warm mirror.
+  // `latest` is not carried over. It comes from registry metadata, and is only read for
+  // non-local packages — which is why injected deps, resolving to `file:`, keep the request.
   if (
     opts.preferWorkspacePackages === true &&
     workspacePackages != null &&

--- a/pnpm11/resolving/npm-resolver/src/index.ts
+++ b/pnpm11/resolving/npm-resolver/src/index.ts
@@ -605,6 +605,69 @@ async function resolveNpm (
     }
   }
 
+  // Fast path: skip the registry when the workspace copy is guaranteed to win.
+  //
+  // With `preferWorkspacePackages`, the prefer-workspace gate below fires whenever a local
+  // version satisfies the spec, no matter what the registry returns, so the request is pure
+  // latency: its result is discarded. Repos that declare workspace deps with plain ranges
+  // (`"*"`, `"^1.2.3"`) rather than the `workspace:` protocol pay one round-trip per workspace
+  // package name on every install, and workspace packages that were never published pay a 404
+  // every time, since there is no negative caching.
+  //
+  // Deliberately placed AFTER the store peek above: when the peek is eligible it returns the
+  // package recorded in the lockfile, and that must keep taking precedence. `update` is not
+  // enough to rule the peek out, because `wantedDepIsLocallyAvailable` in the deps resolver
+  // matches tags without `includePrerelease` while `pickMatchingLocalVersionOrNull` below
+  // includes them, so a prerelease-only workspace package can reach here with `update: false`.
+  //
+  // Only taken when the outcome matches the slow path:
+  //   - `preferWorkspacePackages` is set, so the gate below ignores the registry's version.
+  //   - Exactly one workspace copy carries this name. With several copies the exact-match gate
+  //     below can select a different one via `pickedPackage.version`, which needs the registry.
+  //   - The dependency is not injected. Injected packages resolve to a `file:` id, which
+  //     `packageRequester` does not mark `isLocal`, so they keep flowing through the registry
+  //     bookkeeping in `resolveDependency` where the `latest` field below is still read.
+  //   - `trustPolicy` is not 'no-downgrade', which validates registry metadata even when a
+  //     workspace package ultimately wins.
+  //   - `updateChecksums` is off, since that asks the resolver to rewrite cached metadata.
+  //
+  // `update` is otherwise not excluded: it does not change which local version is chosen (this
+  // path and the gate below both match against `spec`), and `wantedDepIsLocallyAvailable` forces
+  // `update` on for precisely the workspace deps this targets, so excluding it would leave the
+  // fast path almost never reachable.
+  //
+  // The `latest` field the gates below attach is not observable through the install pipeline for
+  // the packages this path returns: they are linked rather than injected, so `resolveDependency`
+  // returns them early on `isLocal` before `ctx.outdatedDependencies` is populated. It does
+  // remain absent for direct consumers of this resolver's exported API. Metadata cache warming
+  // is skipped as a side effect, which can leave a later resolution of the same name without a
+  // warm mirror.
+  if (
+    opts.preferWorkspacePackages === true &&
+    workspacePackages != null &&
+    opts.projectDir != null &&
+    opts.trustPolicy !== 'no-downgrade' &&
+    !opts.updateChecksums &&
+    opts.injectWorkspacePackages !== true &&
+    !wantedDependency.injected
+  ) {
+    const workspacePkgsMatchingName = workspacePackages.get(spec.name)
+    if (workspacePkgsMatchingName?.size === 1) {
+      const localVersion = pickMatchingLocalVersionOrNull(workspacePkgsMatchingName, spec)
+      if (localVersion != null) {
+        return resolveFromLocalPackage(workspacePkgsMatchingName.get(localVersion)!, spec, {
+          wantedDependency,
+          projectDir: opts.projectDir,
+          lockfileDir: opts.lockfileDir,
+          hardLinkLocalPackages: false,
+          saveWorkspaceProtocol: ctx.saveWorkspaceProtocol,
+          calcSpecifier: opts.calcSpecifier,
+          rangeSpecStyle: opts.rangeSpecStyle,
+        })
+      }
+    }
+  }
+
   const authHeaderValue = ctx.getAuthHeaderValueByURI(registry, { pkgName: spec.name })
   let pickResult!: { meta: PackageMeta, pickedPackage: PackageInRegistry | null }
   try {

--- a/pnpm11/resolving/npm-resolver/src/index.ts
+++ b/pnpm11/resolving/npm-resolver/src/index.ts
@@ -605,24 +605,15 @@ async function resolveNpm (
     }
   }
 
-  // Fast path: skip the registry when the workspace copy is guaranteed to win.
-  //
-  // Under `preferWorkspacePackages`, the prefer-workspace gate below returns the local
-  // package whatever the registry says, so the request only adds latency — and a workspace
-  // package that was never published costs a 404 on every install, uncached.
-  //
-  // Two conditions are non-obvious. It runs *after* the store peek because a tag-specified
-  // dep whose only local copy is a prerelease reaches here with `update: false`
-  // (`wantedDepIsLocallyAvailable` ignores prereleases for tags, `pickMatchingLocalVersionOrNull`
-  // does not), and the peek must keep winning there. And `update` is deliberately not excluded:
-  // that same helper forces it on for these deps, so excluding it would make this unreachable.
-  //
-  // `latest` is not carried over. It comes from registry metadata, and is only read for
-  // non-local packages — which is why injected deps, resolving to `file:`, keep the request.
+  // This runs *after* the store peek because a tag-specified dep whose only local copy is a
+  // prerelease reaches here with `update: false` (`wantedDepIsLocallyAvailable` ignores
+  // prereleases for tags, `pickMatchingLocalVersionOrNull` does not), and the peek must keep
+  // winning there. `update` is deliberately absent from the guard: that same helper forces it
+  // on for exactly these deps, so excluding it would make this block unreachable.
   if (
     opts.preferWorkspacePackages === true &&
     workspacePackages != null &&
-    opts.projectDir != null &&
+    opts.projectDir &&
     opts.trustPolicy !== 'no-downgrade' &&
     !opts.updateChecksums &&
     opts.injectWorkspacePackages !== true &&

--- a/pnpm11/resolving/npm-resolver/src/index.ts
+++ b/pnpm11/resolving/npm-resolver/src/index.ts
@@ -607,6 +607,69 @@ async function resolveNpm (
     }
   }
 
+  // Fast path: skip the registry when the workspace copy is guaranteed to win.
+  //
+  // With `preferWorkspacePackages`, the prefer-workspace gate below fires whenever a local
+  // version satisfies the spec, no matter what the registry returns, so the request is pure
+  // latency: its result is discarded. Repos that declare workspace deps with plain ranges
+  // (`"*"`, `"^1.2.3"`) rather than the `workspace:` protocol pay one round-trip per workspace
+  // package name on every install, and workspace packages that were never published pay a 404
+  // every time, since there is no negative caching.
+  //
+  // Deliberately placed AFTER the store peek above: when the peek is eligible it returns the
+  // package recorded in the lockfile, and that must keep taking precedence. `update` is not
+  // enough to rule the peek out, because `wantedDepIsLocallyAvailable` in the deps resolver
+  // matches tags without `includePrerelease` while `pickMatchingLocalVersionOrNull` below
+  // includes them, so a prerelease-only workspace package can reach here with `update: false`.
+  //
+  // Only taken when the outcome matches the slow path:
+  //   - `preferWorkspacePackages` is set, so the gate below ignores the registry's version.
+  //   - Exactly one workspace copy carries this name. With several copies the exact-match gate
+  //     below can select a different one via `pickedPackage.version`, which needs the registry.
+  //   - The dependency is not injected. Injected packages resolve to a `file:` id, which
+  //     `packageRequester` does not mark `isLocal`, so they keep flowing through the registry
+  //     bookkeeping in `resolveDependency` where the `latest` field below is still read.
+  //   - `trustPolicy` is not 'no-downgrade', which validates registry metadata even when a
+  //     workspace package ultimately wins.
+  //   - `updateChecksums` is off, since that asks the resolver to rewrite cached metadata.
+  //
+  // `update` is otherwise not excluded: it does not change which local version is chosen (this
+  // path and the gate below both match against `spec`), and `wantedDepIsLocallyAvailable` forces
+  // `update` on for precisely the workspace deps this targets, so excluding it would leave the
+  // fast path almost never reachable.
+  //
+  // The `latest` field the gates below attach is not observable through the install pipeline for
+  // the packages this path returns: they are linked rather than injected, so `resolveDependency`
+  // returns them early on `isLocal` before `ctx.outdatedDependencies` is populated. It does
+  // remain absent for direct consumers of this resolver's exported API. Metadata cache warming
+  // is skipped as a side effect, which can leave a later resolution of the same name without a
+  // warm mirror.
+  if (
+    opts.preferWorkspacePackages === true &&
+    workspacePackages != null &&
+    opts.projectDir != null &&
+    opts.trustPolicy !== 'no-downgrade' &&
+    !opts.updateChecksums &&
+    opts.injectWorkspacePackages !== true &&
+    !wantedDependency.injected
+  ) {
+    const workspacePkgsMatchingName = workspacePackages.get(spec.name)
+    if (workspacePkgsMatchingName?.size === 1) {
+      const localVersion = pickMatchingLocalVersionOrNull(workspacePkgsMatchingName, spec)
+      if (localVersion != null) {
+        return resolveFromLocalPackage(workspacePkgsMatchingName.get(localVersion)!, spec, {
+          wantedDependency,
+          projectDir: opts.projectDir,
+          lockfileDir: opts.lockfileDir,
+          hardLinkLocalPackages: false,
+          saveWorkspaceProtocol: ctx.saveWorkspaceProtocol,
+          calcSpecifier: opts.calcSpecifier,
+          rangeSpecStyle: opts.rangeSpecStyle,
+        })
+      }
+    }
+  }
+
   const authHeaderValue = ctx.getAuthHeaderValueByURI(registry, { pkgName: spec.name })
   let pickResult!: { meta: PackageMeta, pickedPackage: PackageInRegistry | null }
   try {

--- a/pnpm11/resolving/npm-resolver/test/index.ts
+++ b/pnpm11/resolving/npm-resolver/test/index.ts
@@ -1544,18 +1544,14 @@ test('use version from the registry if it is newer than the local one', async ()
 })
 
 test('preferWorkspacePackages: use version from the workspace even if there is newer version in the registry', async () => {
-  getMockAgent().get(registries.default.replace(/\/$/, ''))
-    .intercept({ path: '/is-positive', method: 'GET' })
-    .reply(200, {
-      ...isPositiveMeta,
-      'dist-tags': { latest: '3.1.0' },
-    })
-
   const { resolveFromNpm } = createResolveFromNpm({
     storeDir: temporaryDirectory(),
     cacheDir: temporaryDirectory(),
     registries,
   })
+  // No registry interceptor is registered on purpose: with preferWorkspacePackages the
+  // workspace copy wins regardless of what the registry says, so the resolver must not
+  // make the request at all. Any request would fail the test via the mock agent.
   const resolveResult = await resolveFromNpm({
     alias: 'is-positive',
     bareSpecifier: '^3.0.0',
@@ -1579,9 +1575,178 @@ test('preferWorkspacePackages: use version from the workspace even if there is n
     expect.objectContaining({
       resolvedVia: 'workspace',
       id: 'link:is-positive',
+    })
+  )
+  // `latest` comes from the registry metadata, so the fast path cannot report it. It is only
+  // consumed for registry packages: local packages return from resolveDependency before
+  // outdatedDependencies is populated.
+  expect(resolveResult!.latest).toBeUndefined()
+})
+
+test('preferWorkspacePackages: still consults the registry when several workspace copies share a name', async () => {
+  getMockAgent().get(registries.default.replace(/\/$/, ''))
+    .intercept({ path: '/is-positive', method: 'GET' })
+    .reply(200, {
+      ...isPositiveMeta,
+      'dist-tags': { latest: '3.1.0' },
+    })
+
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir: temporaryDirectory(),
+    registries,
+  })
+  const resolveResult = await resolveFromNpm({
+    alias: 'is-positive',
+    bareSpecifier: '^3.0.0',
+  }, {
+    preferWorkspacePackages: true,
+    projectDir: '/home/istvan/src',
+    workspacePackages: new Map([
+      ['is-positive', new Map([
+        ['3.0.0', {
+          rootDir: '/home/istvan/src/is-positive-3' as ProjectRootDir,
+          manifest: { name: 'is-positive', version: '3.0.0' },
+        }],
+        ['3.1.0', {
+          rootDir: '/home/istvan/src/is-positive-3.1' as ProjectRootDir,
+          manifest: { name: 'is-positive', version: '3.1.0' },
+        }],
+      ])],
+    ]),
+  })
+
+  // With more than one local copy the registry's picked version decides which one is used,
+  // so the fast path must not engage and `latest` is still reported.
+  expect(resolveResult).toStrictEqual(
+    expect.objectContaining({
+      resolvedVia: 'workspace',
+      id: 'link:is-positive-3.1',
       latest: '3.1.0',
     })
   )
+})
+
+test('preferWorkspacePackages: still consults the registry under trustPolicy=no-downgrade', async () => {
+  getMockAgent().get(registries.default.replace(/\/$/, ''))
+    .intercept({ path: '/is-positive', method: 'GET' })
+    .reply(200, {
+      ...isPositiveMeta,
+      'dist-tags': { latest: '3.1.0' },
+      // trustPolicy=no-downgrade validates publish times, so the fast path engaging here
+      // would skip that check entirely. Reaching it at all is the point of this test.
+      time: {
+        '1.0.0': '2016-01-01T00:00:00.000Z',
+        '3.0.0': '2017-01-01T00:00:00.000Z',
+        '3.1.0': '2018-01-01T00:00:00.000Z',
+      },
+    })
+
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir: temporaryDirectory(),
+    registries,
+  })
+  const resolveResult = await resolveFromNpm({
+    alias: 'is-positive',
+    bareSpecifier: '^3.0.0',
+  }, {
+    preferWorkspacePackages: true,
+    trustPolicy: 'no-downgrade',
+    projectDir: '/home/istvan/src',
+    workspacePackages: new Map([
+      ['is-positive', new Map([
+        ['3.0.0', {
+          rootDir: '/home/istvan/src/is-positive' as ProjectRootDir,
+          manifest: { name: 'is-positive', version: '3.0.0' },
+        }],
+      ])],
+    ]),
+  })
+
+  expect(resolveResult).toStrictEqual(
+    expect.objectContaining({
+      resolvedVia: 'workspace',
+      id: 'link:is-positive',
+      latest: '3.1.0',
+    })
+  )
+})
+
+test('preferWorkspacePackages: does not engage for injected workspace packages', async () => {
+  getMockAgent().get(registries.default.replace(/\/$/, ''))
+    .intercept({ path: '/is-positive', method: 'GET' })
+    .reply(200, {
+      ...isPositiveMeta,
+      'dist-tags': { latest: '3.1.0' },
+    })
+
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir: temporaryDirectory(),
+    registries,
+  })
+  const resolveResult = await resolveFromNpm({
+    alias: 'is-positive',
+    bareSpecifier: '^3.0.0',
+    injected: true,
+  }, {
+    preferWorkspacePackages: true,
+    projectDir: '/home/istvan/src',
+    lockfileDir: '/home/istvan/src',
+    workspacePackages: new Map([
+      ['is-positive', new Map([
+        ['3.0.0', {
+          rootDir: '/home/istvan/src/is-positive' as ProjectRootDir,
+          manifest: { name: 'is-positive', version: '3.0.0' },
+        }],
+      ])],
+    ]),
+  })
+
+  // Injected packages resolve to a `file:` id, which packageRequester does not mark `isLocal`,
+  // so they still flow through the registry bookkeeping that reads `latest`. The fast path must
+  // stay out of the way and let the registry supply it.
+  expect(resolveResult).toStrictEqual(
+    expect.objectContaining({
+      resolvedVia: 'workspace',
+      latest: '3.1.0',
+    })
+  )
+})
+
+test('preferWorkspacePackages: does not engage when no local version satisfies the range', async () => {
+  getMockAgent().get(registries.default.replace(/\/$/, ''))
+    .intercept({ path: '/is-positive', method: 'GET' })
+    .reply(200, {
+      ...isPositiveMeta,
+      'dist-tags': { latest: '3.1.0' },
+    })
+
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir: temporaryDirectory(),
+    registries,
+  })
+  const resolveResult = await resolveFromNpm({
+    alias: 'is-positive',
+    bareSpecifier: '^3.0.0',
+  }, {
+    preferWorkspacePackages: true,
+    projectDir: '/home/istvan/src',
+    workspacePackages: new Map([
+      ['is-positive', new Map([
+        ['1.0.0', {
+          rootDir: '/home/istvan/src/is-positive' as ProjectRootDir,
+          manifest: { name: 'is-positive', version: '1.0.0' },
+        }],
+      ])],
+    ]),
+  })
+
+  // The only local copy is outside the wanted range, so the registry decides.
+  expect(resolveResult!.resolvedVia).toBe('npm-registry')
+  expect(resolveResult!.id).toBe('is-positive@3.1.0')
 })
 
 test('use local version if it is newer than the latest in the registry', async () => {

--- a/pnpm11/resolving/npm-resolver/test/index.ts
+++ b/pnpm11/resolving/npm-resolver/test/index.ts
@@ -1544,18 +1544,14 @@ test('use version from the registry if it is newer than the local one', async ()
 })
 
 test('preferWorkspacePackages: use version from the workspace even if there is newer version in the registry', async () => {
-  getMockAgent().get(registriesByScope.default.replace(/\/$/, ''))
-    .intercept({ path: '/is-positive', method: 'GET' })
-    .reply(200, {
-      ...isPositiveMeta,
-      'dist-tags': { latest: '3.1.0' },
-    })
-
   const { resolveFromNpm } = createResolveFromNpm({
     storeDir: temporaryDirectory(),
     cacheDir: temporaryDirectory(),
     registriesByScope,
   })
+  // No registry interceptor is registered on purpose: with preferWorkspacePackages the
+  // workspace copy wins regardless of what the registry says, so the resolver must not
+  // make the request at all. Any request would fail the test via the mock agent.
   const resolveResult = await resolveFromNpm({
     alias: 'is-positive',
     bareSpecifier: '^3.0.0',
@@ -1579,9 +1575,178 @@ test('preferWorkspacePackages: use version from the workspace even if there is n
     expect.objectContaining({
       resolvedVia: 'workspace',
       id: 'link:is-positive',
+    })
+  )
+  // `latest` comes from the registry metadata, so the fast path cannot report it. It is only
+  // consumed for registry packages: local packages return from resolveDependency before
+  // outdatedDependencies is populated.
+  expect(resolveResult!.latest).toBeUndefined()
+})
+
+test('preferWorkspacePackages: still consults the registry when several workspace copies share a name', async () => {
+  getMockAgent().get(registriesByScope.default.replace(/\/$/, ''))
+    .intercept({ path: '/is-positive', method: 'GET' })
+    .reply(200, {
+      ...isPositiveMeta,
+      'dist-tags': { latest: '3.1.0' },
+    })
+
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir: temporaryDirectory(),
+    registriesByScope,
+  })
+  const resolveResult = await resolveFromNpm({
+    alias: 'is-positive',
+    bareSpecifier: '^3.0.0',
+  }, {
+    preferWorkspacePackages: true,
+    projectDir: '/home/istvan/src',
+    workspacePackages: new Map([
+      ['is-positive', new Map([
+        ['3.0.0', {
+          rootDir: '/home/istvan/src/is-positive-3' as ProjectRootDir,
+          manifest: { name: 'is-positive', version: '3.0.0' },
+        }],
+        ['3.1.0', {
+          rootDir: '/home/istvan/src/is-positive-3.1' as ProjectRootDir,
+          manifest: { name: 'is-positive', version: '3.1.0' },
+        }],
+      ])],
+    ]),
+  })
+
+  // With more than one local copy the registry's picked version decides which one is used,
+  // so the fast path must not engage and `latest` is still reported.
+  expect(resolveResult).toStrictEqual(
+    expect.objectContaining({
+      resolvedVia: 'workspace',
+      id: 'link:is-positive-3.1',
       latest: '3.1.0',
     })
   )
+})
+
+test('preferWorkspacePackages: still consults the registry under trustPolicy=no-downgrade', async () => {
+  getMockAgent().get(registriesByScope.default.replace(/\/$/, ''))
+    .intercept({ path: '/is-positive', method: 'GET' })
+    .reply(200, {
+      ...isPositiveMeta,
+      'dist-tags': { latest: '3.1.0' },
+      // trustPolicy=no-downgrade validates publish times, so the fast path engaging here
+      // would skip that check entirely. Reaching it at all is the point of this test.
+      time: {
+        '1.0.0': '2016-01-01T00:00:00.000Z',
+        '3.0.0': '2017-01-01T00:00:00.000Z',
+        '3.1.0': '2018-01-01T00:00:00.000Z',
+      },
+    })
+
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir: temporaryDirectory(),
+    registriesByScope,
+  })
+  const resolveResult = await resolveFromNpm({
+    alias: 'is-positive',
+    bareSpecifier: '^3.0.0',
+  }, {
+    preferWorkspacePackages: true,
+    trustPolicy: 'no-downgrade',
+    projectDir: '/home/istvan/src',
+    workspacePackages: new Map([
+      ['is-positive', new Map([
+        ['3.0.0', {
+          rootDir: '/home/istvan/src/is-positive' as ProjectRootDir,
+          manifest: { name: 'is-positive', version: '3.0.0' },
+        }],
+      ])],
+    ]),
+  })
+
+  expect(resolveResult).toStrictEqual(
+    expect.objectContaining({
+      resolvedVia: 'workspace',
+      id: 'link:is-positive',
+      latest: '3.1.0',
+    })
+  )
+})
+
+test('preferWorkspacePackages: does not engage for injected workspace packages', async () => {
+  getMockAgent().get(registriesByScope.default.replace(/\/$/, ''))
+    .intercept({ path: '/is-positive', method: 'GET' })
+    .reply(200, {
+      ...isPositiveMeta,
+      'dist-tags': { latest: '3.1.0' },
+    })
+
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir: temporaryDirectory(),
+    registriesByScope,
+  })
+  const resolveResult = await resolveFromNpm({
+    alias: 'is-positive',
+    bareSpecifier: '^3.0.0',
+    injected: true,
+  }, {
+    preferWorkspacePackages: true,
+    projectDir: '/home/istvan/src',
+    lockfileDir: '/home/istvan/src',
+    workspacePackages: new Map([
+      ['is-positive', new Map([
+        ['3.0.0', {
+          rootDir: '/home/istvan/src/is-positive' as ProjectRootDir,
+          manifest: { name: 'is-positive', version: '3.0.0' },
+        }],
+      ])],
+    ]),
+  })
+
+  // Injected packages resolve to a `file:` id, which packageRequester does not mark `isLocal`,
+  // so they still flow through the registry bookkeeping that reads `latest`. The fast path must
+  // stay out of the way and let the registry supply it.
+  expect(resolveResult).toStrictEqual(
+    expect.objectContaining({
+      resolvedVia: 'workspace',
+      latest: '3.1.0',
+    })
+  )
+})
+
+test('preferWorkspacePackages: does not engage when no local version satisfies the range', async () => {
+  getMockAgent().get(registriesByScope.default.replace(/\/$/, ''))
+    .intercept({ path: '/is-positive', method: 'GET' })
+    .reply(200, {
+      ...isPositiveMeta,
+      'dist-tags': { latest: '3.1.0' },
+    })
+
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir: temporaryDirectory(),
+    registriesByScope,
+  })
+  const resolveResult = await resolveFromNpm({
+    alias: 'is-positive',
+    bareSpecifier: '^3.0.0',
+  }, {
+    preferWorkspacePackages: true,
+    projectDir: '/home/istvan/src',
+    workspacePackages: new Map([
+      ['is-positive', new Map([
+        ['1.0.0', {
+          rootDir: '/home/istvan/src/is-positive' as ProjectRootDir,
+          manifest: { name: 'is-positive', version: '1.0.0' },
+        }],
+      ])],
+    ]),
+  })
+
+  // The only local copy is outside the wanted range, so the registry decides.
+  expect(resolveResult!.resolvedVia).toBe('npm-registry')
+  expect(resolveResult!.id).toBe('is-positive@3.1.0')
 })
 
 test('use local version if it is newer than the latest in the registry', async () => {

--- a/pnpm11/resolving/npm-resolver/test/index.ts
+++ b/pnpm11/resolving/npm-resolver/test/index.ts
@@ -1544,14 +1544,23 @@ test('use version from the registry if it is newer than the local one', async ()
 })
 
 test('preferWorkspacePackages: use version from the workspace even if there is newer version in the registry', async () => {
+  // The interceptor is registered deliberately. Omitting it does NOT prove the request was
+  // skipped: an unmocked request throws, resolveNpm catches request errors and falls back to
+  // tryResolveFromWorkspacePackages, and that path also returns no `latest` — so the test
+  // would pass either way. With a live interceptor, any request would populate `latest` from
+  // `dist-tags`, so asserting `latest === undefined` is what proves the registry was skipped.
+  getMockAgent().get(registries.default.replace(/\/$/, ''))
+    .intercept({ path: '/is-positive', method: 'GET' })
+    .reply(200, {
+      ...isPositiveMeta,
+      'dist-tags': { latest: '3.1.0' },
+    })
+
   const { resolveFromNpm } = createResolveFromNpm({
     storeDir: temporaryDirectory(),
     cacheDir: temporaryDirectory(),
     registriesByScope,
   })
-  // No registry interceptor is registered on purpose: with preferWorkspacePackages the
-  // workspace copy wins regardless of what the registry says, so the resolver must not
-  // make the request at all. Any request would fail the test via the mock agent.
   const resolveResult = await resolveFromNpm({
     alias: 'is-positive',
     bareSpecifier: '^3.0.0',
@@ -1577,9 +1586,6 @@ test('preferWorkspacePackages: use version from the workspace even if there is n
       id: 'link:is-positive',
     })
   )
-  // `latest` comes from the registry metadata, so the fast path cannot report it. It is only
-  // consumed for registry packages: local packages return from resolveDependency before
-  // outdatedDependencies is populated.
   expect(resolveResult!.latest).toBeUndefined()
 })
 

--- a/pnpm11/resolving/npm-resolver/test/index.ts
+++ b/pnpm11/resolving/npm-resolver/test/index.ts
@@ -1544,12 +1544,9 @@ test('use version from the registry if it is newer than the local one', async ()
 })
 
 test('preferWorkspacePackages: use version from the workspace even if there is newer version in the registry', async () => {
-  // The interceptor is registered deliberately. Omitting it does NOT prove the request was
-  // skipped: an unmocked request throws, resolveNpm catches request errors and falls back to
-  // tryResolveFromWorkspacePackages, and that path also returns no `latest` — so the test
-  // would pass either way. With a live interceptor, any request would populate `latest` from
-  // `dist-tags`, so asserting `latest === undefined` is what proves the registry was skipped.
-  getMockAgent().get(registries.default.replace(/\/$/, ''))
+  // Omitting the interceptor would not prove the request was skipped: an unmocked request
+  // throws, and the error fallback returns the same workspace package with no `latest` either.
+  getMockAgent().get(registriesByScope.default.replace(/\/$/, ''))
     .intercept({ path: '/is-positive', method: 'GET' })
     .reply(200, {
       ...isPositiveMeta,
@@ -1622,8 +1619,6 @@ test('preferWorkspacePackages: still consults the registry when several workspac
     ]),
   })
 
-  // With more than one local copy the registry's picked version decides which one is used,
-  // so the fast path must not engage and `latest` is still reported.
   expect(resolveResult).toStrictEqual(
     expect.objectContaining({
       resolvedVia: 'workspace',
@@ -1639,8 +1634,6 @@ test('preferWorkspacePackages: still consults the registry under trustPolicy=no-
     .reply(200, {
       ...isPositiveMeta,
       'dist-tags': { latest: '3.1.0' },
-      // trustPolicy=no-downgrade validates publish times, so the fast path engaging here
-      // would skip that check entirely. Reaching it at all is the point of this test.
       time: {
         '1.0.0': '2016-01-01T00:00:00.000Z',
         '3.0.0': '2017-01-01T00:00:00.000Z',
@@ -1710,12 +1703,88 @@ test('preferWorkspacePackages: does not engage for injected workspace packages',
     ]),
   })
 
-  // Injected packages resolve to a `file:` id, which packageRequester does not mark `isLocal`,
-  // so they still flow through the registry bookkeeping that reads `latest`. The fast path must
-  // stay out of the way and let the registry supply it.
   expect(resolveResult).toStrictEqual(
     expect.objectContaining({
       resolvedVia: 'workspace',
+      latest: '3.1.0',
+    })
+  )
+})
+
+test('preferWorkspacePackages: does not engage when the whole install injects workspace packages', async () => {
+  getMockAgent().get(registriesByScope.default.replace(/\/$/, ''))
+    .intercept({ path: '/is-positive', method: 'GET' })
+    .reply(200, {
+      ...isPositiveMeta,
+      'dist-tags': { latest: '3.1.0' },
+    })
+
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir: temporaryDirectory(),
+    registriesByScope,
+  })
+  const resolveResult = await resolveFromNpm({
+    alias: 'is-positive',
+    bareSpecifier: '^3.0.0',
+  }, {
+    preferWorkspacePackages: true,
+    injectWorkspacePackages: true,
+    projectDir: '/home/istvan/src',
+    lockfileDir: '/home/istvan/src',
+    workspacePackages: new Map([
+      ['is-positive', new Map([
+        ['3.0.0', {
+          rootDir: '/home/istvan/src/is-positive' as ProjectRootDir,
+          manifest: { name: 'is-positive', version: '3.0.0' },
+        }],
+      ])],
+    ]),
+  })
+
+  expect(resolveResult).toStrictEqual(
+    expect.objectContaining({
+      resolvedVia: 'workspace',
+      id: 'file:is-positive',
+      latest: '3.1.0',
+    })
+  )
+})
+
+test('preferWorkspacePackages: still consults the registry when updateChecksums is set', async () => {
+  getMockAgent().get(registriesByScope.default.replace(/\/$/, ''))
+    .intercept({ path: '/is-positive', method: 'GET' })
+    .reply(200, {
+      ...isPositiveMeta,
+      'dist-tags': { latest: '3.1.0' },
+    })
+
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir: temporaryDirectory(),
+    registriesByScope,
+  })
+  const resolveResult = await resolveFromNpm({
+    alias: 'is-positive',
+    bareSpecifier: '^3.0.0',
+  }, {
+    preferWorkspacePackages: true,
+    updateChecksums: true,
+    projectDir: '/home/istvan/src',
+    workspacePackages: new Map([
+      ['is-positive', new Map([
+        ['3.0.0', {
+          rootDir: '/home/istvan/src/is-positive' as ProjectRootDir,
+          manifest: { name: 'is-positive', version: '3.0.0' },
+        }],
+      ])],
+    ]),
+  })
+
+  expect(resolveResult).toStrictEqual(
+    expect.objectContaining({
+      resolvedVia: 'workspace',
+      id: 'link:is-positive',
       latest: '3.1.0',
     })
   )
@@ -1750,7 +1819,6 @@ test('preferWorkspacePackages: does not engage when no local version satisfies t
     ]),
   })
 
-  // The only local copy is outside the wanted range, so the registry decides.
   expect(resolveResult!.resolvedVia).toBe('npm-registry')
   expect(resolveResult!.id).toBe('is-positive@3.1.0')
 })


### PR DESCRIPTION
I found that our large (~250-project) monorepo at Microsoft was spending surprising amount of install time re-resolving dependencies that are already on disk. 

I traced the issue to the fact that we were declaring our inter-workspace dependencies with plain ranges (`"*"`) rather than the `workspace:` protocol (we use `preferWorkspacePackages` and `linkWorkspacePackages`). This (currently) casuses re-resolution to make unnecessary registry requests for intra-worksapce packages -- many of which would fail anyways because the package isn't even published.

This PR skips those requests, just like it would if we declared intra-workspace dependencies with `workspace:`. Against pnpm 11.21.0 on our repo, this results in **~490 fewer requests (60%) and ~20s off a 66s install (30%)**.

(We can work around this by always using `workspace:*`, but I thought it would be a nice thing to contribute the optimization upstream, because it's not obvious that using `"*"` would cause any issues)

## Problem

When `preferWorkspacePackages` is enabled, `resolveNpm` still makes a registry request whose result it then discards.

The gate that prefers a workspace package fires whenever a local version satisfies the spec, **regardless of what the registry returned**:

```ts
const localVersion = pickMatchingLocalVersionOrNull(workspacePkgsMatchingName, spec)
if (localVersion && (semver.gt(localVersion, pickedPackage.version) || opts.preferWorkspacePackages)) {
  return { ...resolveFromLocalPackage(...), latest }
}
```

The `await ctx.pickPackage(...)` that precedes it is therefore pure latency.

This hits any workspace that declares inter-workspace dependencies with **plain ranges** (`"*"`, `"^1.2.3"`) instead of the `workspace:` protocol — a very common shape in repos migrated from Yarn or npm, and the reason `linkWorkspacePackages` / `preferWorkspacePackages` exist at all. Such a repo pays one round-trip per workspace package name on every install. Worse, workspace packages that were **never published** return 404 every single time, because negative results are not cached.

## Measurement

A private ~250-project monorepo whose inter-workspace deps are all `"*"`, with `linkWorkspacePackages: deep` and `preferWorkspacePackages: true`, against a private Azure DevOps registry. Scenario: add one workspace dependency to one project, restore the committed lockfile, `pnpm install`. Warm store and metadata cache, 3 runs per arm, interleaved on one machine.

| | registry requests | of those, workspace packages | median install |
|---|---|---|---|
| pnpm 11.21.0 | 817 | 483 | 65.8s |
| this PR | **326** | **0** | **45.8s** |

**~490 fewer requests (60%), ~20s faster (30%).**

The request count is deterministic — every patched run issued exactly 326, with zero workspace-package lookups. What disappears is roughly 155 `200`s for published workspace packages plus roughly 330 `404`s for workspace packages that were never published.

Two notes on rigor:

- The patched build runs through pnpm's `pd` dev harness (esbuild, unbundled). Running the **unpatched** source through that same harness gives 833 requests / 68.6s, so the harness itself costs ~3s versus released pnpm. Isolating the patch alone, with the harness on both sides, it is 833 → 326 requests and 68.6s → 45.8s (**33%**) — the 30% above is the conservative figure.
- Wall-clock time varies with registry latency; the request count does not.

## The change

A fast path in `resolveNpm` that returns `resolveFromLocalPackage(...)` without contacting the registry, taken only when the outcome is already determined:

- `preferWorkspacePackages` is on — so the gate ignores the registry's version anyway.
- **Exactly one** workspace copy carries this name. With several copies, the exact-match gate can select a different one via `pickedPackage.version`, which genuinely needs the registry.
- The dependency is **not injected**. Injected packages get a `file:` id, which `packageRequester` does *not* mark `isLocal`, so they keep flowing through the registry bookkeeping that reads `latest`.
- `trustPolicy !== 'no-downgrade'` — that validates registry metadata even when a workspace package wins.
- `updateChecksums` is off — that asks the resolver to rewrite cached metadata.

Placed **after** the `peekManifestFromStore` block, so a resolution already recorded in the lockfile keeps precedence.

That ordering matters in one narrow case. A dependency requested by tag (`foo`, `foo@latest`) whose only workspace copy is a prerelease is treated as *not* locally available by `wantedDepIsLocallyAvailable` in the deps resolver, because it ignores prereleases when matching a tag. `update` therefore stays `false` and the store peek is eligible, so today the lockfile's registry resolution wins. `pickMatchingLocalVersionOrNull` in this package *does* match prereleases, so a fast path placed before the peek would newly link the workspace prerelease instead. Running after the peek preserves the current outcome.

### Why `update` is not excluded

I originally gated on `!opts.update` and the fast path almost never fired. `wantedDepIsLocallyAvailable` in the deps resolver forces `update: true` for precisely the workspace deps this targets. Excluding it defeats the optimization.

It is safe: neither this path nor the gate it replaces applies update semantics to the local pick — both match against `spec`. (`tryResolveFromWorkspacePackages` *does* substitute `{fetchSpec:'*'}` under update, but it's only reached on the error / empty-pick paths.)

## Why the result is the same

Every registry outcome already converges on the same package:

- successful pick → the exact-match or prefer-workspace gate returns the workspace package
- 404 or any request error → `catch` → `tryResolveFromWorkspacePackages` → same package
- `pickedPackage == null` → same

The one exception is `latest`. Since `ResolveResult.latest` is the registry's `dist-tags.latest`, it can only be populated by a registry call, so this optimization leaves it `undefined` in cases where it is populated today.

That is fine for an install, because nothing reads it for the packages this path returns. The only consumer is `resolveDependencies.ts`, which records `latest` into `ctx.outdatedDependencies` to produce the "(X is available)" hint — and it never gets that far for these packages: they resolve to a `link:`, which `packageRequester` marks `isLocal`, and `resolveDependency` returns early on `isLocal` before that line runs. Injected dependencies are the exception, since they resolve to a `file:` id that is *not* marked `isLocal`, which is why they are excluded from the fast path.

## Known behavior changes

These are slight (known) deviations from existing behavior introduced by this optimization that seem acceptable.

1. **`latest` is absent** for direct consumers of the exported resolver API on this path, even though it is not observable through a normal install.
2. **Metadata cache warming is skipped.** A later resolution of the same name no longer benefits from a mirror this request would have warmed.
3. **`spec.name` vs `pickedPackage.name`.** The fast path keys `workspacePackages` by `spec.name`; the existing post-registry gate uses `pickedPackage.name`, which `pickPackageFromMeta` can rewrite to `meta.name` (GitHub-registry scope normalization). `tryResolveFromWorkspacePackages` already keys by `spec.name`, so this matches existing behavior on the fallback paths, but it is an assumption.
4. **Malformed registry metadata.** A manifest with an invalid `version` can make `semver.gt` throw today, where the fast path now succeeds locally.

## Tests

`resolving/npm-resolver` — 91/91 passing. Added:

- fast path engages, makes no registry request, reports no `latest`
- falls back when several workspace copies share a name
- falls back under `trustPolicy: 'no-downgrade'`
- falls back when `updateChecksums` is set
- falls back when the whole install sets `injectWorkspacePackages`
- falls back when no local version satisfies the range
- does not engage for injected workspace packages

One existing test (`preferWorkspacePackages: use version from the workspace even if there is newer version in the registry`) was updated: it previously asserted `latest: '3.1.0'`, and now asserts that `latest` is absent. It keeps its registry interceptor on purpose — dropping it would not prove anything, because an unmocked request throws, the resolver catches request errors and falls back to `tryResolveFromWorkspacePackages`, and that path reports no `latest` either. With the interceptor live, any request would populate `latest` from `dist-tags`, so asserting its absence is what proves the registry was skipped.

The pacquet suite asserts the same seven scenarios against a `mockito` mock — `.expect(0)` for the fast path, `assert_async()` for each fallback.

Downstream suites pass unchanged: `resolving/default-resolver` 21/21, `installing/deps-resolver` 178/178.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13717"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788732417&installation_model_id=426870&pr_number=13717&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13717&signature=da207f2bb7b1524055d1322e0c6d7a0d45a16f4d660b384f860a54c98b9bf005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Performance

* Workspace dependencies with one matching local package now resolve faster without contacting the package registry.

## Bug Fixes

* Registry resolution remains available when multiple local matches exist, requirements are unmet, packages are injected, policy requires verification, or checksums need updating.
* Existing fallback behavior is preserved when local resolution is unavailable.

## Tests

* Expanded coverage for workspace resolution, registry bypass, and fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
