### PR TITLE
fix: allow exotic dependencies under workspace packages (pnpm/pnpm#13…

### DIFF
--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -567,6 +567,7 @@ where
                     base_overlay,
                     None,
                     parent_pkg_aliases,
+                    false,
                 )
                 .await?;
                 warm_children_resolutions(ctx, resolver, &seed).await;

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
@@ -92,6 +92,7 @@ where
         base_overlay.clone(),
         None,
         parent_pkg_aliases,
+        false,
     )
     .await?;
     let direct =
@@ -185,6 +186,7 @@ pub(super) async fn resolve_node_seed<Chain>(
     pick_overlay: Option<Arc<PreferredVersionsOverlay>>,
     parent_dir: Option<&Path>,
     parent_pkg_aliases: &Arc<ParentPkgAliases>,
+    parent_is_workspace: bool,
 ) -> Result<NodeSeed, ResolveDependencyTreeError>
 where
     Chain: Resolver + ?Sized,
@@ -369,6 +371,7 @@ where
 
     if ctx.base_opts.block_exotic_subdeps
         && depth > 0
+        && !parent_is_workspace
         && is_exotic_resolved_via(&result.resolved_via)
     {
         return Err(ResolveDependencyTreeError::ExoticSubdep {
@@ -890,6 +893,7 @@ where
     let direct_versions =
         lock_recoverable(&ctx.workspace.direct_dep_versions).get(&ctx.importer_id).map(Arc::clone);
     let declaring_dir = declaring_manifest_dir(ctx, &pending.result);
+    let parent_is_workspace = pending.result.resolved_via == "workspace";
     let child_depth = pending.depth + 1;
     let child_optional_parent = pending.current_is_optional;
     let next_ancestors = Arc::clone(&pending.next_ancestors);
@@ -939,6 +943,7 @@ where
                     pick_overlay,
                     declaring_dir.as_deref(),
                     parent_pkg_aliases,
+                    parent_is_workspace,
                 )
                 .await?;
                 warm_children_resolutions(ctx, resolver, &seed).await;

--- a/pnpm/crates/resolving-deps-resolver/src/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/tests.rs
@@ -1002,6 +1002,57 @@ mod block_exotic_subdeps {
         .expect("exotic subdep must pass when disabled");
         assert!(tree.packages.contains_key("say-hi@1.0.0"));
     }
+
+    #[tokio::test]
+    async fn allows_exotic_dep_under_workspace_dep() {
+        let mut table = HashMap::default();
+        let mut workspace_dep_res = fake_result(
+            "workspace-dep",
+            "1.0.0",
+            serde_json::json!({
+                "name": "workspace-dep",
+                "version": "1.0.0",
+                "dependencies": { "say-hi": "github:zkochan/hi" }
+            }),
+        );
+        workspace_dep_res.resolved_via = "workspace".to_string();
+        table.insert(
+            ("workspace-dep".to_string(), "workspace:^1.0.0".to_string()),
+            workspace_dep_res,
+        );
+        table.insert(
+            ("say-hi".to_string(), "github:zkochan/hi".to_string()),
+            git_result(
+                "say-hi",
+                "1.0.0",
+                serde_json::json!({ "name": "say-hi", "version": "1.0.0" }),
+            ),
+        );
+        let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+        let (_tmp, manifest) =
+            fake_manifest(serde_json::json!({ "workspace-dep": "workspace:^1.0.0" }));
+
+        let tree = resolve_dependency_tree(
+            &resolver,
+            &manifest,
+            [DependencyGroup::Prod],
+            ResolveDependencyTreeOptions {
+                base_opts: ResolveOptions {
+                    block_exotic_subdeps: true,
+                    ..ResolveOptions::default()
+                },
+                patched_dependencies: None,
+                manifest_hook: None,
+                overrides_hook: None,
+                pnpmfile_hook: None,
+                read_package_log: None,
+                auto_install_peers: false,
+            },
+        )
+        .await
+        .expect("exotic dep under workspace dep must pass");
+        assert!(tree.packages.contains_key("say-hi@1.0.0"));
+    }
 }
 
 mod peers {

--- a/pnpm11/installing/deps-installer/test/install/blockExoticSubdeps.ts
+++ b/pnpm11/installing/deps-installer/test/install/blockExoticSubdeps.ts
@@ -1,7 +1,10 @@
+import path from 'node:path'
+
 import { afterEach, beforeEach, expect, test } from '@jest/globals'
-import { addDependenciesToPackage } from '@pnpm/installing.deps-installer'
-import { prepareEmpty } from '@pnpm/prepare'
+import { addDependenciesToPackage, type MutatedProject, mutateModules } from '@pnpm/installing.deps-installer'
+import { prepareEmpty, preparePackages } from '@pnpm/prepare'
 import { getMockAgent, setupMockAgent, teardownMockAgent } from '@pnpm/testing.mock-agent'
+import type { ProjectRootDir } from '@pnpm/types'
 
 import { testDefaults } from '../utils/index.js'
 
@@ -73,4 +76,75 @@ test('blockExoticSubdeps: false (default) allows git dependencies in subdependen
 
   const m = project.requireModule('@pnpm.e2e/has-aliased-git-dependency')
   expect(m).toBe('Hi')
+})
+
+test('blockExoticSubdeps allows exotic dependencies in workspace packages', async () => {
+  preparePackages([
+    {
+      location: 'project-1',
+      package: { name: 'project-1' },
+    },
+    {
+      location: 'project-2',
+      package: { name: 'project-2' },
+    },
+  ])
+
+  const importers: MutatedProject[] = [
+    {
+      mutation: 'install',
+      rootDir: path.resolve('project-1') as ProjectRootDir,
+    },
+    {
+      mutation: 'install',
+      rootDir: path.resolve('project-2') as ProjectRootDir,
+    },
+  ]
+
+  const allProjects = [
+    {
+      buildIndex: 0,
+      manifest: {
+        name: 'project-1',
+        version: '1.0.0',
+        dependencies: {
+          'project-2': 'workspace:^',
+        },
+      },
+      rootDir: path.resolve('project-1') as ProjectRootDir,
+    },
+    {
+      buildIndex: 0,
+      manifest: {
+        name: 'project-2',
+        version: '1.0.0',
+        dependencies: {
+          // Direct git dependency in workspace project
+          'is-negative': 'github:kevva/is-negative#1.0.0',
+        },
+      },
+      rootDir: path.resolve('project-2') as ProjectRootDir,
+    },
+  ]
+
+  // Mock the HEAD request that isRepoPublic() makes to check if the repo is public.
+  getMockAgent().get('https://github.com')
+    .intercept({ path: '/kevva/is-negative', method: 'HEAD' })
+    .reply(200)
+
+  const workspacePackages = new Map([
+    ['project-2', new Map([
+      ['1.0.0', {
+        rootDir: path.resolve('project-2') as ProjectRootDir,
+        manifest: allProjects[1].manifest,
+      }],
+    ])],
+  ])
+
+  // This should not fail even when blockExoticSubdeps is true
+  await mutateModules(importers, testDefaults({
+    allProjects,
+    blockExoticSubdeps: true,
+    workspacePackages,
+  }))
 })

--- a/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
+++ b/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
@@ -2037,6 +2037,7 @@ async function resolveDependency (
     if (
       ctx.blockExoticSubdeps &&
       options.currentDepth > 0 &&
+      options.parentPkg.resolvedVia !== 'workspace' &&
       pkgResponse.body.resolvedVia != null && // This is already coming from the lockfile, we skip the check in this case for now. Should be fixed later.
       isExoticDep(pkgResponse.body.resolvedVia)
     ) {


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

When `blockExoticSubdeps` is enabled, pnpm prevents resolving transitive subdependencies via exotic protocols (like `git`, `url`, or `file`). However, direct dependencies of workspace packages are explicitly declared by the user in the repository. They should not be blocked as "subdependencies" even when they are resolved at a depth > 0 (e.g., when a workspace app depends on a workspace package, which in turn depends on an exotic catalog dependency).

This PR:
* Bypasses the `blockExoticSubdeps` check if the parent package was resolved via `'workspace'` (indicating it is a workspace package).
* Implements the fix in both the TypeScript and Rust (`pacquet`) dependency resolvers.
* Adds corresponding tests for both implementations.

Closes pnpm/pnpm#13682

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
Allow exotic dependencies (git/url/file) when they are direct dependencies of workspace packages under blockExoticSubdeps.

- TS: Skip blockExoticSubdeps check in resolveDependencies if options.parentPkg.resolvedVia === 'workspace'.
- Rust: Thread parent_resolved_via Option through resolve_node and resolve_node_seed, bypassing checks when Some("workspace").
- Added TS integration test in blockExoticSubdeps.ts and Rust unit test in tests.rs.

Closes pnpm/pnpm#13682
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port.
- [ ] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788737432&installation_model_id=426870&pr_number=13719&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13719&signature=1054816a492939c61412d0444031a376ba38d364d1ecec94d97cd553c672892d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace packages can now use Git and other exotic transitive dependencies when exotic subdependencies are blocked.
  * Existing restrictions remain in place for exotic dependencies under packages resolved through other methods.
  * Improved dependency resolution consistency across fresh, recursive, and lockfile-based installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->