### PR TITLE
fix(pacquet): add Corepack package entrypoints

### DIFF
--- a/.changeset/corepack-pacquet-shim.md
+++ b/.changeset/corepack-pacquet-shim.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+The pnpm v12 package now includes Corepack-compatible `bin/pnpm.mjs` and `bin/pnpx.mjs` entrypoints so Corepack can launch the pacquet wrapper without relying on the skipped `preinstall` relink step.

--- a/.changeset/corepack-pacquet-shim.md
+++ b/.changeset/corepack-pacquet-shim.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-The pnpm v12 package now includes Corepack-compatible `bin/pnpm.mjs` and `bin/pnpx.mjs` entrypoints so Corepack can launch the pacquet wrapper without relying on the skipped `preinstall` relink step.
+Corepack can now run the pnpm v12 package through the `bin/pnpm.mjs` and `bin/pnpx.mjs` entrypoints.

--- a/pnpm/npm/pnpm/bin/pnpm.mjs
+++ b/pnpm/npm/pnpm/bin/pnpm.mjs
@@ -47,7 +47,11 @@ export function resolveNativeBinary ({ candidates = getBinCandidates(), requireR
   for (const target of candidates) {
     try {
       return requireResolve(target)
-    } catch {}
+    } catch (err) {
+      if (err?.code !== 'MODULE_NOT_FOUND') {
+        throw err
+      }
+    }
   }
   return null
 }

--- a/pnpm/npm/pnpm/bin/pnpm.mjs
+++ b/pnpm/npm/pnpm/bin/pnpm.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process'
+import { createRequire } from 'node:module'
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+const require = createRequire(import.meta.url)
+
+const PLATFORMS = {
+  win32: {
+    x64: '@pnpm/exe.win32-x64/pnpm.exe',
+    arm64: '@pnpm/exe.win32-arm64/pnpm.exe',
+  },
+  darwin: {
+    x64: '@pnpm/exe.darwin-x64/pnpm',
+    arm64: '@pnpm/exe.darwin-arm64/pnpm',
+  },
+  linux: {
+    x64: {
+      glibc: '@pnpm/exe.linux-x64/pnpm',
+      musl: '@pnpm/exe.linux-x64-musl/pnpm',
+    },
+    arm64: {
+      glibc: '@pnpm/exe.linux-arm64/pnpm',
+      musl: '@pnpm/exe.linux-arm64-musl/pnpm',
+    },
+  },
+}
+
+export function getBinCandidates ({ platform = process.platform, arch = process.arch, libc = detectLinuxLibc() } = {}) {
+  const platformEntry = PLATFORMS?.[platform]?.[arch]
+
+  if (platformEntry == null) {
+    return []
+  }
+  if (typeof platformEntry === 'string') {
+    return [platformEntry]
+  }
+
+  const order = libc === 'musl' ? ['musl', 'glibc'] : ['glibc', 'musl']
+  return order.map((libc) => platformEntry[libc])
+}
+
+export function resolveNativeBinary ({ candidates = getBinCandidates(), requireResolve = require.resolve } = {}) {
+  for (const target of candidates) {
+    try {
+      return requireResolve(target)
+    } catch {}
+  }
+  return null
+}
+
+export function runPnpm ({ argv = process.argv.slice(2), spawn = spawnSync } = {}) {
+  const candidates = getBinCandidates()
+  if (candidates.length === 0) {
+    fail(`pnpm does not ship a prebuilt binary for ${process.platform}-${process.arch}.`)
+  }
+
+  const nativeBinary = resolveNativeBinary({ candidates })
+  if (nativeBinary == null) {
+    const pkgName = candidates[0].split('/').slice(0, 2).join('/')
+    fail(
+      `The "${pkgName}" package is not installed, so pnpm has no native binary to run.\n` +
+      'If your package manager skipped optional dependencies, enable them and reinstall.'
+    )
+  }
+
+  const result = spawn(nativeBinary, argv, { stdio: 'inherit' })
+  if (result.error != null) {
+    fail(`Could not run the pnpm binary at ${nativeBinary}: ${result.error.message}`)
+  }
+  if (result.signal != null) {
+    process.kill(process.pid, result.signal)
+    return
+  }
+  process.exit(result.status ?? 1)
+}
+
+function fail (message) {
+  console.error(message)
+  process.exit(1)
+}
+
+function detectLinuxLibc () {
+  if (process.platform !== 'linux') {
+    return null
+  }
+
+  try {
+    return process.report?.getReport().header.glibcVersionRuntime ? 'glibc' : 'musl'
+  } catch {
+    return null
+  }
+}
+
+function isMain () {
+  if (process.argv[1] == null) {
+    return false
+  }
+  return fs.realpathSync(fileURLToPath(import.meta.url)) === fs.realpathSync(path.resolve(process.argv[1]))
+}
+
+if (isMain()) {
+  runPnpm()
+}

--- a/pnpm/npm/pnpm/bin/pnpx.mjs
+++ b/pnpm/npm/pnpm/bin/pnpx.mjs
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+import process from 'node:process'
+
+import { runPnpm } from './pnpm.mjs'
+
+runPnpm({ argv: ['dlx', ...process.argv.slice(2)] })

--- a/pnpm/npm/pnpm/package.json
+++ b/pnpm/npm/pnpm/package.json
@@ -41,6 +41,8 @@
     "node": ">=18.*"
   },
   "files": [
+    "bin/pnpm.mjs",
+    "bin/pnpx.mjs",
     "pnpm",
     "pn",
     "pnpx",

--- a/pnpm/npm/pnpm/scripts/generate-packages.mjs
+++ b/pnpm/npm/pnpm/scripts/generate-packages.mjs
@@ -8,7 +8,7 @@
 // meta-updater and pnpm's own name-keyed resolution key on); this script
 // rewrites it into the publishable `pnpm` manifest.
 
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import * as fs from "node:fs";
 
@@ -24,8 +24,18 @@ const PACKAGE_DIR_PREFIX = "pacquet";
 const NATIVE_BIN_FILE = "pnpm";
 const EXE_WRAPPER_NAME = "@pnpm/exe";
 const EXE_WRAPPER_DIR = "pnpm-exe";
-// Files shared verbatim by both wrappers: the root-level bins + preinstall + README.
-const WRAPPER_FILES = ["pnpm", "pn", "pnpx", "pnx", "install.js", "README.md"];
+// Files shared verbatim by both wrappers: Corepack shim, root-level bins,
+// preinstall, and README.
+const WRAPPER_FILES = [
+  "bin/pnpm.mjs",
+  "bin/pnpx.mjs",
+  "pnpm",
+  "pn",
+  "pnpx",
+  "pnx",
+  "install.js",
+  "README.md",
+];
 
 const PNPM_ROOT = resolve(fileURLToPath(import.meta.url), "../..");
 const PACKAGES_ROOT = resolve(PNPM_ROOT, "..");
@@ -120,8 +130,11 @@ function generateExeWrapper() {
 
   // Copy instead of symlinking so the tarball is self-contained for publish.
   for (const file of WRAPPER_FILES) {
-    fs.copyFileSync(resolve(PNPM_ROOT, file), resolve(exeRoot, file));
-    fs.chmodSync(resolve(exeRoot, file), fs.statSync(resolve(PNPM_ROOT, file)).mode);
+    const source = resolve(PNPM_ROOT, file);
+    const target = resolve(exeRoot, file);
+    fs.mkdirSync(dirname(target), { recursive: true });
+    fs.copyFileSync(source, target);
+    fs.chmodSync(target, fs.statSync(source).mode);
   }
 
   // Both wrappers place the native binary next to themselves, so both need

--- a/pnpm/npm/pnpm/scripts/generate-packages.mjs
+++ b/pnpm/npm/pnpm/scripts/generate-packages.mjs
@@ -24,8 +24,6 @@ const PACKAGE_DIR_PREFIX = "pacquet";
 const NATIVE_BIN_FILE = "pnpm";
 const EXE_WRAPPER_NAME = "@pnpm/exe";
 const EXE_WRAPPER_DIR = "pnpm-exe";
-// Files shared verbatim by both wrappers: Corepack shim, root-level bins,
-// preinstall, and README.
 const WRAPPER_FILES = [
   "bin/pnpm.mjs",
   "bin/pnpx.mjs",

--- a/pnpm/npm/pnpm/test/corepack-shim.test.mjs
+++ b/pnpm/npm/pnpm/test/corepack-shim.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import { spawnSync } from 'node:child_process'
 import test from 'node:test'
 import { fileURLToPath } from 'node:url'
 
@@ -9,6 +10,17 @@ import { getBinCandidates, resolveNativeBinary } from '../bin/pnpm.mjs'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const packageRoot = path.resolve(__dirname, '..')
+
+const generatedTargets = [
+  { codeTarget: 'win32-x64', ext: '.exe' },
+  { codeTarget: 'win32-arm64', ext: '.exe' },
+  { codeTarget: 'darwin-x64', ext: '' },
+  { codeTarget: 'darwin-arm64', ext: '' },
+  { codeTarget: 'linux-x64', ext: '' },
+  { codeTarget: 'linux-arm64', ext: '' },
+  { codeTarget: 'linux-x64-musl', ext: '' },
+  { codeTarget: 'linux-arm64-musl', ext: '' },
+]
 
 test('published pnpm wrapper includes the Corepack entrypoints', () => {
   const manifest = JSON.parse(fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf8'))
@@ -18,11 +30,37 @@ test('published pnpm wrapper includes the Corepack entrypoints', () => {
 })
 
 test('generated exe wrapper copies the Corepack entrypoints', () => {
-  const generatePackages = fs.readFileSync(path.join(packageRoot, 'scripts/generate-packages.mjs'), 'utf8')
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-generate-wrapper-'))
+  const fixturePackageRoot = path.join(tempRoot, 'pnpm/npm/pnpm')
+  const fixtureWrapperRoot = path.join(tempRoot, 'pnpm/npm/pnpm-exe')
 
-  assert.match(generatePackages, /"bin\/pnpm\.mjs"/)
-  assert.match(generatePackages, /"bin\/pnpx\.mjs"/)
-  assert.match(generatePackages, /fs\.mkdirSync\(dirname\(target\), \{ recursive: true \}\)/)
+  try {
+    fs.mkdirSync(path.dirname(fixturePackageRoot), { recursive: true })
+    fs.cpSync(packageRoot, fixturePackageRoot, {
+      recursive: true,
+      filter: (source) => !source.includes(`${path.sep}node_modules${path.sep}`),
+    })
+    for (const { codeTarget, ext } of generatedTargets) {
+      const binaryPath = path.join(tempRoot, `pnpm-${codeTarget}${ext}`)
+      fs.writeFileSync(binaryPath, 'native binary')
+      fs.chmodSync(binaryPath, 0o755)
+    }
+
+    const result = spawnSync(process.execPath, [path.join(fixturePackageRoot, 'scripts/generate-packages.mjs')], {
+      cwd: tempRoot,
+      stdio: 'pipe',
+    })
+    assert.equal(result.status, 0, result.stderr.toString())
+
+    for (const file of ['bin/pnpm.mjs', 'bin/pnpx.mjs']) {
+      const sourcePath = path.join(fixturePackageRoot, file)
+      const targetPath = path.join(fixtureWrapperRoot, file)
+      assert.equal(fs.existsSync(targetPath), true)
+      assert.equal(fs.statSync(targetPath).mode & 0o777, fs.statSync(sourcePath).mode & 0o777)
+    }
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
 })
 
 test('native binary candidates follow platform optional dependency packages', () => {
@@ -43,7 +81,7 @@ test('native binary resolution accepts the first installed candidate', () => {
     candidates: ['@pnpm/exe.linux-x64/pnpm', '@pnpm/exe.linux-x64-musl/pnpm'],
     requireResolve: (target) => {
       if (target === '@pnpm/exe.linux-x64/pnpm') {
-        throw new Error('not installed')
+        throw Object.assign(new Error('not installed'), { code: 'MODULE_NOT_FOUND' })
       }
       return '/node_modules/@pnpm/exe.linux-x64-musl/pnpm'
     },
@@ -52,9 +90,30 @@ test('native binary resolution accepts the first installed candidate', () => {
   assert.equal(resolved, '/node_modules/@pnpm/exe.linux-x64-musl/pnpm')
 })
 
-test('Corepack entrypoints can run an installed native binary on POSIX', async (t) => {
+test('native binary resolution does not mask invalid packages', () => {
+  assert.throws(
+    () => resolveNativeBinary({
+      candidates: ['@pnpm/exe.linux-x64/pnpm', '@pnpm/exe.linux-x64-musl/pnpm'],
+      requireResolve: (target) => {
+        if (target === '@pnpm/exe.linux-x64/pnpm') {
+          throw Object.assign(new Error('invalid package exports'), { code: 'ERR_PACKAGE_PATH_NOT_EXPORTED' })
+        }
+        return '/node_modules/@pnpm/exe.linux-x64-musl/pnpm'
+      },
+    }),
+    { code: 'ERR_PACKAGE_PATH_NOT_EXPORTED' }
+  )
+})
+
+test('Corepack entrypoints can run an installed native binary on POSIX', (t) => {
   if (process.platform === 'win32') {
     t.skip('Windows needs a real .exe fixture to execute the native binary path.')
+    return
+  }
+
+  const candidates = getBinCandidates()
+  if (candidates.length === 0) {
+    t.skip(`No native package fixture for ${process.platform}-${process.arch}.`)
     return
   }
 
@@ -63,7 +122,7 @@ test('Corepack entrypoints can run an installed native binary on POSIX', async (
 
   fs.cpSync(path.join(packageRoot, 'bin'), path.join(tempRoot, 'bin'), { recursive: true })
 
-  const [candidate] = getBinCandidates()
+  const [candidate] = candidates
   const [scope, name, ...binarySegments] = candidate.split('/')
   const packageDir = path.join(tempRoot, 'node_modules', scope, name)
   const binaryPath = path.join(packageDir, ...binarySegments)
@@ -73,23 +132,33 @@ test('Corepack entrypoints can run an installed native binary on POSIX', async (
     binaryPath,
     '#!/usr/bin/env node\n' +
     'const fs = require("node:fs");\n' +
+    'if (process.env.PNPM_SHIM_MODE === "status") process.exit(33);\n' +
+    'if (process.env.PNPM_SHIM_MODE === "signal") process.kill(process.pid, "SIGTERM");\n' +
     'fs.writeFileSync(process.env.PNPM_SHIM_CAPTURE, JSON.stringify(process.argv.slice(2)));\n'
   )
   fs.chmodSync(binaryPath, 0o755)
 
   const capturePath = path.join(tempRoot, 'argv.json')
-  const { spawnSync } = await import('node:child_process')
-  const pnpmResult = spawnSync(process.execPath, [path.join(tempRoot, 'bin/pnpm.mjs'), '--version'], {
-    env: { ...process.env, PNPM_SHIM_CAPTURE: capturePath },
-    stdio: 'pipe',
-  })
+  const runEntrypoint = (entrypoint, args, env = {}) => spawnSync(
+    process.execPath,
+    [path.join(tempRoot, `bin/${entrypoint}.mjs`), ...args],
+    {
+      env: { ...process.env, PNPM_SHIM_CAPTURE: capturePath, ...env },
+      stdio: 'pipe',
+    }
+  )
+
+  const pnpmResult = runEntrypoint('pnpm', ['--version'])
   assert.equal(pnpmResult.status, 0, pnpmResult.stderr.toString())
   assert.deepEqual(JSON.parse(fs.readFileSync(capturePath, 'utf8')), ['--version'])
 
-  const pnpxResult = spawnSync(process.execPath, [path.join(tempRoot, 'bin/pnpx.mjs'), 'is-sorted'], {
-    env: { ...process.env, PNPM_SHIM_CAPTURE: capturePath },
-    stdio: 'pipe',
-  })
+  const pnpxResult = runEntrypoint('pnpx', ['is-sorted'])
   assert.equal(pnpxResult.status, 0, pnpxResult.stderr.toString())
   assert.deepEqual(JSON.parse(fs.readFileSync(capturePath, 'utf8')), ['dlx', 'is-sorted'])
+
+  assert.equal(runEntrypoint('pnpm', [], { PNPM_SHIM_MODE: 'status' }).status, 33)
+  assert.equal(runEntrypoint('pnpx', [], { PNPM_SHIM_MODE: 'status' }).status, 33)
+
+  assert.equal(runEntrypoint('pnpm', [], { PNPM_SHIM_MODE: 'signal' }).signal, 'SIGTERM')
+  assert.equal(runEntrypoint('pnpx', [], { PNPM_SHIM_MODE: 'signal' }).signal, 'SIGTERM')
 })

--- a/pnpm/npm/pnpm/test/corepack-shim.test.mjs
+++ b/pnpm/npm/pnpm/test/corepack-shim.test.mjs
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+import { getBinCandidates, resolveNativeBinary } from '../bin/pnpm.mjs'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const packageRoot = path.resolve(__dirname, '..')
+
+test('published pnpm wrapper includes the Corepack entrypoints', () => {
+  const manifest = JSON.parse(fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf8'))
+
+  assert.equal(manifest.files.includes('bin/pnpm.mjs'), true)
+  assert.equal(manifest.files.includes('bin/pnpx.mjs'), true)
+})
+
+test('generated exe wrapper copies the Corepack entrypoints', () => {
+  const generatePackages = fs.readFileSync(path.join(packageRoot, 'scripts/generate-packages.mjs'), 'utf8')
+
+  assert.match(generatePackages, /"bin\/pnpm\.mjs"/)
+  assert.match(generatePackages, /"bin\/pnpx\.mjs"/)
+  assert.match(generatePackages, /fs\.mkdirSync\(dirname\(target\), \{ recursive: true \}\)/)
+})
+
+test('native binary candidates follow platform optional dependency packages', () => {
+  assert.deepEqual(getBinCandidates({ platform: 'darwin', arch: 'arm64' }), ['@pnpm/exe.darwin-arm64/pnpm'])
+  assert.deepEqual(getBinCandidates({ platform: 'linux', arch: 'x64', libc: 'glibc' }), [
+    '@pnpm/exe.linux-x64/pnpm',
+    '@pnpm/exe.linux-x64-musl/pnpm',
+  ])
+  assert.deepEqual(getBinCandidates({ platform: 'linux', arch: 'x64', libc: 'musl' }), [
+    '@pnpm/exe.linux-x64-musl/pnpm',
+    '@pnpm/exe.linux-x64/pnpm',
+  ])
+  assert.deepEqual(getBinCandidates({ platform: 'freebsd', arch: 'x64' }), [])
+})
+
+test('native binary resolution accepts the first installed candidate', () => {
+  const resolved = resolveNativeBinary({
+    candidates: ['@pnpm/exe.linux-x64/pnpm', '@pnpm/exe.linux-x64-musl/pnpm'],
+    requireResolve: (target) => {
+      if (target === '@pnpm/exe.linux-x64/pnpm') {
+        throw new Error('not installed')
+      }
+      return '/node_modules/@pnpm/exe.linux-x64-musl/pnpm'
+    },
+  })
+
+  assert.equal(resolved, '/node_modules/@pnpm/exe.linux-x64-musl/pnpm')
+})
+
+test('Corepack entrypoints can run an installed native binary on POSIX', async (t) => {
+  if (process.platform === 'win32') {
+    t.skip('Windows needs a real .exe fixture to execute the native binary path.')
+    return
+  }
+
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-corepack-shim-'))
+  t.after(() => fs.rmSync(tempRoot, { recursive: true, force: true }))
+
+  fs.cpSync(path.join(packageRoot, 'bin'), path.join(tempRoot, 'bin'), { recursive: true })
+
+  const [candidate] = getBinCandidates()
+  const [scope, name, ...binarySegments] = candidate.split('/')
+  const packageDir = path.join(tempRoot, 'node_modules', scope, name)
+  const binaryPath = path.join(packageDir, ...binarySegments)
+  fs.mkdirSync(packageDir, { recursive: true })
+  fs.writeFileSync(path.join(packageDir, 'package.json'), JSON.stringify({ name: `${scope}/${name}`, version: '0.0.0' }))
+  fs.writeFileSync(
+    binaryPath,
+    '#!/usr/bin/env node\n' +
+    'const fs = require("node:fs");\n' +
+    'fs.writeFileSync(process.env.PNPM_SHIM_CAPTURE, JSON.stringify(process.argv.slice(2)));\n'
+  )
+  fs.chmodSync(binaryPath, 0o755)
+
+  const capturePath = path.join(tempRoot, 'argv.json')
+  const { spawnSync } = await import('node:child_process')
+  const pnpmResult = spawnSync(process.execPath, [path.join(tempRoot, 'bin/pnpm.mjs'), '--version'], {
+    env: { ...process.env, PNPM_SHIM_CAPTURE: capturePath },
+    stdio: 'pipe',
+  })
+  assert.equal(pnpmResult.status, 0, pnpmResult.stderr.toString())
+  assert.deepEqual(JSON.parse(fs.readFileSync(capturePath, 'utf8')), ['--version'])
+
+  const pnpxResult = spawnSync(process.execPath, [path.join(tempRoot, 'bin/pnpx.mjs'), 'is-sorted'], {
+    env: { ...process.env, PNPM_SHIM_CAPTURE: capturePath },
+    stdio: 'pipe',
+  })
+  assert.equal(pnpxResult.status, 0, pnpxResult.stderr.toString())
+  assert.deepEqual(JSON.parse(fs.readFileSync(capturePath, 'utf8')), ['dlx', 'is-sorted'])
+})


### PR DESCRIPTION
## Summary
- add Corepack-compatible `bin/pnpm.mjs` and `bin/pnpx.mjs` entrypoints to the pnpm v12 package
- have the entrypoints resolve the installed native optional dependency package and delegate to the native binary without relying on `preinstall`
- include the entrypoints in the generated `@pnpm/exe` wrapper package and add package-level regression coverage

## Why
Corepack maps pnpm >=11 to `./bin/pnpm.mjs` and `./bin/pnpx.mjs`, but the pacquet-backed package currently relies on `preinstall` relinking the root wrapper files. Corepack does not run that install step, so `corepack use pnpm@next-12` can fail with `MODULE_NOT_FOUND` before pnpm has a chance to run.

## Validation
- `node --test pnpm/npm/pnpm/test/*.test.mjs`
- `node --check pnpm/npm/pnpm/bin/pnpm.mjs`
- `node --check pnpm/npm/pnpm/bin/pnpx.mjs`
- `node --check pnpm/npm/pnpm/scripts/generate-packages.mjs`
- `node --check pnpm/npm/pnpm/test/corepack-shim.test.mjs`
- `pnpm --config.manage-package-manager-versions=false lint:meta`
- `pnpm --config.manage-package-manager-versions=false spellcheck`
- `typos .changeset/corepack-pacquet-shim.md pnpm/npm/pnpm`
- `npm pack --dry-run --json`
- `pnpm --config.manage-package-manager-versions=false pack --dry-run --json`
- `just test-pacquet`
- `just ready`
- pre-push hook: compile, lint/build, spellcheck/meta/type lint, Rust fmt check, clippy, docs, dylint, typos, taplo

Fixes #13018.

Disclosure: I used Codex (GPT-5) to help prepare this PR under my review. I take responsibility for the code, tests, and validation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13722"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788744613&installation_model_id=426870&pr_number=13722&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13722&signature=8549c069be91c61d46ae09313a1a9109f1b627b619d22ed411caa860154dfb39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Corepack-compatible `pnpm` and `pnpx` launchers.
  - Launchers select the appropriate native binary for the current platform, architecture, and Linux environment.
  - Added fallback handling when the preferred native package is unavailable.
  - `pnpx` continues to support executing packages through the `dlx` command.
- **Bug Fixes**
  - Improved launcher reliability across supported environments.
- **Tests**
  - Added coverage for packaging, platform detection, fallback resolution, argument forwarding, and executable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
