### PR TITLE
fix: allow updating cataloged deps to versions satisfying catalog ran…

### DIFF
--- a/.changeset/strict-catalog-range-satisfy.md
+++ b/.changeset/strict-catalog-range-satisfy.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.deps-installer": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+When `catalogMode: strict` is enabled, permit installing or updating to concrete versions that satisfy a range catalog specifier rather than rejecting them with a mismatch error [pnpm/pnpm#13715](https://github.com/pnpm/pnpm/issues/13715).

--- a/pnpm/crates/cli/tests/suite/update.rs
+++ b/pnpm/crates/cli/tests/suite/update.rs
@@ -1058,7 +1058,7 @@ fn update_latest_default_catalog_preserves_reference() {
 #[test]
 fn update_strict_catalog_range_mismatch_errors() {
     let (root, workspace, anchor) = setup();
-    set_strict_catalog(&workspace, &[(DEP, "^100.0.0")]);
+    set_strict_catalog(&workspace, &[(DEP, "^100.1.0")]);
     write_manifest(&workspace, &format!(r#"{{ "{DEP}": "catalog:" }}"#));
 
     let output = pacquet(&workspace, ["update", "--lockfile-only", &format!("{DEP}@100.0.0")])

--- a/pnpm/crates/package-manager/src/catalog_mode.rs
+++ b/pnpm/crates/package-manager/src/catalog_mode.rs
@@ -12,7 +12,7 @@
 
 use derive_more::{Display, Error};
 use miette::Diagnostic;
-use node_semver::Version;
+use node_semver::{Range, Version};
 use pacquet_catalogs_protocol_parser::parse_catalog_protocol;
 use pacquet_catalogs_resolver::{CatalogResolutionResult, WantedDependency, resolve_from_catalog};
 use pacquet_catalogs_types::{Catalogs, DEFAULT_CATALOG_NAME};
@@ -187,14 +187,23 @@ pub(crate) fn decide_catalog_outcome(
     }
 }
 
-/// Equal only when **both** specifiers are concrete semver versions that
-/// compare equal. A range (e.g. `^2.0.0`) fails [`Version::parse`], so it
-/// never reaches the comparison — the Rust analogue of pnpm guarding
-/// `semver.eq` with `semver.valid`
-/// ([pnpm#11706](https://github.com/pnpm/pnpm/pull/11706)). Passing a
-/// range to an exact-version comparison is the bug that fix prevents.
+/// Returns true if the version `lhs` matches the specifier `rhs`.
+///
+/// Matches when either:
+/// - Both are valid semver versions and are equal.
+/// - `lhs` is a valid semver version that satisfies `rhs` as a semver range.
 fn versions_equal(lhs: &str, rhs: &str) -> bool {
-    matches!((Version::parse(lhs), Version::parse(rhs)), (Ok(left), Ok(right)) if left == right)
+    if let Ok(lhs_version) = Version::parse(lhs) {
+        if let Ok(rhs_version) = Version::parse(rhs) {
+            lhs_version == rhs_version
+        } else if let Ok(rhs_range) = Range::parse(rhs) {
+            rhs_range.satisfies(&lhs_version)
+        } else {
+            false
+        }
+    } else {
+        false
+    }
 }
 
 /// The catalog group a dependency belongs to: a previous `catalog:<name>`

--- a/pnpm/crates/package-manager/src/catalog_mode.rs
+++ b/pnpm/crates/package-manager/src/catalog_mode.rs
@@ -187,11 +187,6 @@ pub(crate) fn decide_catalog_outcome(
     }
 }
 
-/// Returns true if the version `lhs` matches the specifier `rhs`.
-///
-/// Matches when either:
-/// - Both are valid semver versions and are equal.
-/// - `lhs` is a valid semver version that satisfies `rhs` as a semver range.
 fn versions_equal(lhs: &str, rhs: &str) -> bool {
     if let Ok(lhs_version) = Version::parse(lhs) {
         if let Ok(rhs_version) = Version::parse(rhs) {

--- a/pnpm/crates/package-manager/src/catalog_mode/tests.rs
+++ b/pnpm/crates/package-manager/src/catalog_mode/tests.rs
@@ -72,6 +72,20 @@ fn strict_errors_when_the_catalog_entry_is_a_range() {
 }
 
 #[test]
+fn strict_allows_a_version_satisfying_a_range_catalog_entry() {
+    let catalogs = catalogs(&[("default", &[("is-positive", "^2.0.0")])]);
+    let decision = decide(CatalogMode::Strict, &catalogs, &dep("is-positive", "2.1.0")).unwrap();
+    assert_eq!(
+        decision,
+        CatalogDecision::Catalog {
+            manifest_specifier: "catalog:".to_string(),
+            updated_entry: None
+        },
+        "a version satisfying the range catalog entry is allowed",
+    );
+}
+
+#[test]
 fn strict_errors_when_the_wanted_specifier_is_a_range() {
     let catalogs = catalogs(&[("default", &[("is-positive", "1.0.0")])]);
     let err = decide(CatalogMode::Strict, &catalogs, &dep("is-positive", "^2.0.0"))

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -1076,9 +1076,12 @@ export async function mutateModules (
           if (
             !catalogDepSpecifier ||
             wantedDep.bareSpecifier === catalogBareSpecifier ||
-            semver.valid(wantedDep.bareSpecifier) &&
-            semver.valid(catalogDepSpecifier) &&
-            semver.eq(wantedDep.bareSpecifier, catalogDepSpecifier)
+            (
+              semver.valid(wantedDep.bareSpecifier) && (
+                (semver.valid(catalogDepSpecifier) && semver.eq(wantedDep.bareSpecifier, catalogDepSpecifier)) ||
+                (semver.validRange(catalogDepSpecifier) && semver.satisfies(wantedDep.bareSpecifier, catalogDepSpecifier))
+              )
+            )
           ) {
             wantedDep.saveCatalogName = perDepCatalogName
             continue

--- a/pnpm11/installing/deps-installer/test/catalogs.ts
+++ b/pnpm11/installing/deps-installer/test/catalogs.ts
@@ -1534,6 +1534,42 @@ describe('add', () => {
     ).rejects.toThrow(expect.objectContaining({ code: 'ERR_PNPM_CATALOG_VERSION_MISMATCH' }))
   })
 
+  test('adding satisfying version of a range catalog entry with catalogMode: strict succeeds', async () => {
+    const { options, projects, readLockfile } = preparePackagesAndReturnObjects([{
+      name: 'project1',
+      dependencies: {
+        'is-positive': 'catalog:',
+      },
+    }])
+
+    await addDependenciesToPackage(
+      projects['project1' as ProjectId],
+      ['is-positive@1.0.0'],
+      {
+        ...options,
+        dir: path.join(options.lockfileDir, 'project1'),
+        lockfileOnly: true,
+        allowNew: true,
+        catalogs: {
+          default: {
+            'is-positive': '^1.0.0',
+          },
+        },
+        catalogMode: 'strict',
+      }
+    )
+
+    const lockfile = readLockfile()
+    expect(lockfile.importers['project1' as ProjectId]).toEqual({
+      dependencies: {
+        'is-positive': {
+          specifier: '1.0.0',
+          version: '1.0.0',
+        },
+      },
+    })
+  })
+
   test('adding mismatched version with catalogMode: prefer will warn and use direct', async () => {
     const { options, projects, readLockfile } = preparePackagesAndReturnObjects([{
       name: 'project1',


### PR DESCRIPTION
## Summary

This PR fixes a bug in strict catalog mode (`catalogMode: strict`) where targeted package installations or updates (`pnpm update <pkg>@<version>` / `pnpm add <pkg>@<version>`) to a concrete version satisfying a range defined in the catalog were rejected with a `ERR_PNPM_CATALOG_VERSION_MISMATCH` error.

Instead of requiring exact string/version equality, strict mode now resolves the check using `semver.satisfies` when the catalog specifier is a valid range. This enables automated workflows (such as Renovate or lockfile-only updates) to bump lockfile resolutions within catalog-defined ranges.

Fixes pnpm/pnpm#13715

## Squash Commit Body

This PR resolves a strict catalog mode verification issue where updating a cataloged dependency to a concrete version satisfying a range specifier defined in the catalog was rejected.

### Problem
Previously, targeted updates or installations (e.g. `pnpm update pkg@version`) in strict catalog mode were verified by ensuring the wanted version (`wantedDep.bareSpecifier`) is string-equal or exact-value equal to the catalog specifier (`catalogDepSpecifier`). Since `semver.valid()` rejects range strings, range-pinned catalog entries could never pass this check when adding or updating to a concrete version, causing strict mode validation to incorrectly fail.

### Solution
- **TypeScript CLI:** In `@pnpm/installing.deps-installer`, added a range satisfaction check: if the catalog specifier is a valid range, we check if the wanted version satisfies the range via `semver.satisfies`.
- **Rust `pacquet` Port:** In `package-manager/src/catalog_mode.rs`, updated the `versions_equal` logic to parse the right-hand specifier as a `Range` if it is not an exact `Version`, and perform `Range::satisfies`.
- **Tests:** Added tests to both the TypeScript and Rust test suites to verify that strict mode permits adding/updating concrete versions satisfying a range catalog specifier.

Closes pnpm/pnpm#13715

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13723"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788750789&installation_model_id=426870&pr_number=13723&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13723&signature=b973749f1ec32a17482d7cc62a619e48c8008a6258fb5e6b0334377a6d31b627"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strict catalog mode now accepts exact package versions that satisfy an existing catalog range.
  * Catalog entries remain unchanged when the requested version falls within the configured range.
  * Genuine version mismatches continue to produce the appropriate strict-mode errors or prefer-mode warnings.

* **Tests**
  * Added coverage for compatible version ranges and confirmed mismatched ranges remain rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->