### PR TITLE
fix(git-resolver): resolve ssh git URLs that carry no user info

### DIFF
--- a/.changeset/ssh-git-url-without-user-info.md
+++ b/.changeset/ssh-git-url-without-user-info.md
@@ -4,3 +4,5 @@
 ---
 
 An `ssh://` git dependency written without user info no longer fails with `TypeError: Cannot read properties of undefined (reading 'includes')`. Specifiers such as `ssh://git.example.com/team/repo.git` and `git+ssh://git.example.com:2222/team/repo.git` are resolved again; only the `user@host` form worked before.
+
+An `ssh://` git dependency pointing at a bracketed IPv6 host, such as `ssh://[::1]/repo.git`, is also resolved now. Its colons were read as an SCP-style path separator, which turned the address into `[:/1]` and left `TypeError: Invalid URL`.

--- a/.changeset/ssh-git-url-without-user-info.md
+++ b/.changeset/ssh-git-url-without-user-info.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/resolving.git-resolver": patch
+"pnpm": patch
+---
+
+An `ssh://` git dependency written without user info no longer fails with `TypeError: Cannot read properties of undefined (reading 'includes')`. Specifiers such as `ssh://git.example.com/team/repo.git` and `git+ssh://git.example.com:2222/team/repo.git` are resolved again; only the `user@host` form worked before.

--- a/.changeset/ssh-git-url-without-user-info.md
+++ b/.changeset/ssh-git-url-without-user-info.md
@@ -1,8 +1,9 @@
 ---
 "@pnpm/resolving.git-resolver": patch
 "pnpm": patch
+"pacquet": patch
 ---
 
-An `ssh://` git dependency written without user info no longer fails with `TypeError: Cannot read properties of undefined (reading 'includes')`. Specifiers such as `ssh://git.example.com/team/repo.git` and `git+ssh://git.example.com:2222/team/repo.git` are resolved again; only the `user@host` form worked before.
+An `ssh://` git dependency pointing at a bracketed IPv6 host, such as `ssh://[::1]/repo.git`, is resolved now. Its colons were read as an SCP-style path separator, which turned the address into `[:/1]` and left the specifier unresolvable. Applies to both the TypeScript CLI and pacquet.
 
-An `ssh://` git dependency pointing at a bracketed IPv6 host, such as `ssh://[::1]/repo.git`, is also resolved now. Its colons were read as an SCP-style path separator, which turned the address into `[:/1]` and left `TypeError: Invalid URL`.
+In the TypeScript CLI, an `ssh://` git dependency written without user info — `ssh://git.example.com/team/repo.git`, `git+ssh://git.example.com:2222/team/repo.git` — no longer fails with `TypeError: Cannot read properties of undefined (reading 'includes')`. Only the `user@host` form worked before.

--- a/pnpm/crates/resolving-git-resolver/src/parse_bare_specifier.rs
+++ b/pnpm/crates/resolving-git-resolver/src/parse_bare_specifier.rs
@@ -141,9 +141,7 @@ fn correct_url(input: &str) -> String {
     // that the URL parser cannot consume. Convert the last colon in
     // the host into a `/`, unless it's followed by a numeric port.
     let host = auth.rsplit_once('@').map_or(auth, |(_, host)| host);
-    // A bracketed IPv6 literal carries colons of its own, so only what
-    // comes after the closing bracket can hold the SCP-style separator
-    // or a port.
+    // The colons of a bracketed IPv6 literal belong to the address.
     let after_host = if host.starts_with('[') {
         host.find(']').map_or(host, |idx| &host[idx + 1..])
     } else {

--- a/pnpm/crates/resolving-git-resolver/src/parse_bare_specifier.rs
+++ b/pnpm/crates/resolving-git-resolver/src/parse_bare_specifier.rs
@@ -155,13 +155,9 @@ fn correct_url(input: &str) -> String {
     });
     let host_has_colon = after_host.contains(':');
     if host_has_colon && !port_pattern_present {
-        let auth_parts: Vec<&str> = auth.split(':').collect();
         let protocol = "ssh";
-        // `auth_parts[..-1] join ':' + '/' + auth_parts[-1]`
-        let new_auth = if auth_parts.len() >= 2 {
-            let last = auth_parts[auth_parts.len() - 1];
-            let rest = auth_parts[..auth_parts.len() - 1].join(":");
-            format!("{rest}/{last}")
+        let new_auth = if let Some(separator) = auth.rfind(':') {
+            format!("{}/{}", &auth[..separator], &auth[separator + 1..])
         } else {
             auth.to_string()
         };

--- a/pnpm/crates/resolving-git-resolver/src/parse_bare_specifier.rs
+++ b/pnpm/crates/resolving-git-resolver/src/parse_bare_specifier.rs
@@ -141,10 +141,19 @@ fn correct_url(input: &str) -> String {
     // that the URL parser cannot consume. Convert the last colon in
     // the host into a `/`, unless it's followed by a numeric port.
     let host = auth.rsplit_once('@').map_or(auth, |(_, host)| host);
-    let port_pattern_present = host.rfind(':').is_some_and(|idx| {
-        host[idx + 1..].chars().all(|byte| byte.is_ascii_digit()) && !host[idx + 1..].is_empty()
+    // A bracketed IPv6 literal carries colons of its own, so only what
+    // comes after the closing bracket can hold the SCP-style separator
+    // or a port.
+    let after_host = if host.starts_with('[') {
+        host.find(']').map_or(host, |idx| &host[idx + 1..])
+    } else {
+        host
+    };
+    let port_pattern_present = after_host.rfind(':').is_some_and(|idx| {
+        after_host[idx + 1..].chars().all(|byte| byte.is_ascii_digit())
+            && !after_host[idx + 1..].is_empty()
     });
-    let host_has_colon = host.contains(':');
+    let host_has_colon = after_host.contains(':');
     if host_has_colon && !port_pattern_present {
         let auth_parts: Vec<&str> = auth.split(':').collect();
         let protocol = "ssh";

--- a/pnpm/crates/resolving-git-resolver/src/parse_bare_specifier/tests.rs
+++ b/pnpm/crates/resolving-git-resolver/src/parse_bare_specifier/tests.rs
@@ -62,16 +62,14 @@ fn correct_url_keeps_numeric_port() {
 
 #[test]
 fn correct_url_keeps_bracketed_ipv6_host() {
-    // The colons inside the brackets belong to the address, so the
-    // authority has no SCP-style separator to rewrite.
     assert_eq!(correct_url("ssh://[::1]/repo.git"), "ssh://[::1]/repo.git");
     assert_eq!(
         correct_url("ssh://[2001:db8::1]/team/repo.git"),
         "ssh://[2001:db8::1]/team/repo.git",
     );
     assert_eq!(correct_url("ssh://[::1]:2222/repo.git"), "ssh://[::1]:2222/repo.git");
+    assert_eq!(correct_url("ssh://[::1]:team/repo.git"), "ssh://[::1]/team/repo.git");
     assert_eq!(correct_url("ssh://git@[::1]/repo.git"), "ssh://git@[::1]/repo.git");
-    // A colon *after* the closing bracket is still the separator.
     assert_eq!(correct_url("ssh://git@[::1]:team/repo.git"), "ssh://git@[::1]/team/repo.git");
 }
 
@@ -213,6 +211,7 @@ fn fetch_spec_for_bracketed_ipv6_hosts() {
         ("ssh://[::1]/repo.git", "ssh://[::1]/repo.git"),
         ("ssh://[2001:db8::1]/team/repo.git", "ssh://[2001:db8::1]/team/repo.git"),
         ("ssh://[::1]:2222/repo.git", "ssh://[::1]:2222/repo.git"),
+        ("ssh://[::1]:team/repo.git", "ssh://[::1]/team/repo.git"),
         ("ssh://git@[::1]/repo.git", "ssh://git@[::1]/repo.git"),
         ("ssh://git@[::1]:team/repo.git", "ssh://git@[::1]/team/repo.git"),
     ];

--- a/pnpm/crates/resolving-git-resolver/src/parse_bare_specifier/tests.rs
+++ b/pnpm/crates/resolving-git-resolver/src/parse_bare_specifier/tests.rs
@@ -61,6 +61,21 @@ fn correct_url_keeps_numeric_port() {
 }
 
 #[test]
+fn correct_url_keeps_bracketed_ipv6_host() {
+    // The colons inside the brackets belong to the address, so the
+    // authority has no SCP-style separator to rewrite.
+    assert_eq!(correct_url("ssh://[::1]/repo.git"), "ssh://[::1]/repo.git");
+    assert_eq!(
+        correct_url("ssh://[2001:db8::1]/team/repo.git"),
+        "ssh://[2001:db8::1]/team/repo.git",
+    );
+    assert_eq!(correct_url("ssh://[::1]:2222/repo.git"), "ssh://[::1]:2222/repo.git");
+    assert_eq!(correct_url("ssh://git@[::1]/repo.git"), "ssh://git@[::1]/repo.git");
+    // A colon *after* the closing bracket is still the separator.
+    assert_eq!(correct_url("ssh://git@[::1]:team/repo.git"), "ssh://git@[::1]/team/repo.git");
+}
+
+#[test]
 fn finalize_direct_returns_spec_unchanged() {
     let kind = parse_bare_specifier("git+https://example.com/repo.git#abc").expect("direct");
     let spec = kind.finalize();
@@ -172,6 +187,43 @@ fn fetch_spec_for_scp_style_inputs() {
             "input {input}: expected fetch_spec {expected}, got {got}",
             got = spec.fetch_spec,
         );
+    }
+}
+
+// Ported `parsePref.test.ts` no-user-info cases. `correct_url` reads
+// the host from the last `@` and falls back to the whole authority, so
+// these hold here; the TypeScript side was catching up to this file.
+#[test]
+fn fetch_spec_for_inputs_without_user_info() {
+    let cases: &[(&str, &str)] = &[
+        ("ssh://git.example.com/team/repo.git", "ssh://git.example.com/team/repo.git"),
+        ("ssh://git.example.com:2222/team/repo.git", "ssh://git.example.com:2222/team/repo.git"),
+        ("ssh://git.example.com:team/repo.git", "ssh://git.example.com/team/repo.git"),
+        ("ssh://git.example.com:repo.git", "ssh://git.example.com/repo.git"),
+        ("git+ssh://git.example.com/team/repo.git", "ssh://git.example.com/team/repo.git"),
+        ("git+ssh://git.example.com:team/repo.git", "ssh://git.example.com/team/repo.git"),
+    ];
+    for (input, expected) in cases {
+        let kind = parse_bare_specifier(input).expect("parse claims input");
+        let spec = kind.finalize();
+        assert_eq!(spec.fetch_spec, *expected, "input {input}");
+    }
+}
+
+// Ported `parsePref.test.ts` bracketed-IPv6 cases.
+#[test]
+fn fetch_spec_for_bracketed_ipv6_hosts() {
+    let cases: &[(&str, &str)] = &[
+        ("ssh://[::1]/repo.git", "ssh://[::1]/repo.git"),
+        ("ssh://[2001:db8::1]/team/repo.git", "ssh://[2001:db8::1]/team/repo.git"),
+        ("ssh://[::1]:2222/repo.git", "ssh://[::1]:2222/repo.git"),
+        ("ssh://git@[::1]/repo.git", "ssh://git@[::1]/repo.git"),
+        ("ssh://git@[::1]:team/repo.git", "ssh://git@[::1]/team/repo.git"),
+    ];
+    for (input, expected) in cases {
+        let kind = parse_bare_specifier(input).expect("parse claims input");
+        let spec = kind.finalize();
+        assert_eq!(spec.fetch_spec, *expected, "input {input}");
     }
 }
 

--- a/pnpm/crates/resolving-git-resolver/src/parse_bare_specifier/tests.rs
+++ b/pnpm/crates/resolving-git-resolver/src/parse_bare_specifier/tests.rs
@@ -190,9 +190,6 @@ fn fetch_spec_for_scp_style_inputs() {
     }
 }
 
-// Ported `parsePref.test.ts` no-user-info cases. `correct_url` reads
-// the host from the last `@` and falls back to the whole authority, so
-// these hold here; the TypeScript side was catching up to this file.
 #[test]
 fn fetch_spec_for_inputs_without_user_info() {
     let cases: &[(&str, &str)] = &[
@@ -210,7 +207,6 @@ fn fetch_spec_for_inputs_without_user_info() {
     }
 }
 
-// Ported `parsePref.test.ts` bracketed-IPv6 cases.
 #[test]
 fn fetch_spec_for_bracketed_ipv6_hosts() {
     let cases: &[(&str, &str)] = &[
@@ -227,7 +223,6 @@ fn fetch_spec_for_bracketed_ipv6_hosts() {
     }
 }
 
-// Ported `parsePref.test.ts` path-extraction cases.
 #[test]
 fn path_extracted_from_scp_style_inputs() {
     let cases: &[(&str, Option<&str>)] = &[

--- a/pnpm11/resolving/git-resolver/src/parseBareSpecifier.ts
+++ b/pnpm11/resolving/git-resolver/src/parseBareSpecifier.ts
@@ -206,7 +206,8 @@ function correctUrl (gitUrl: string): string {
       _gitUrl = _gitUrl.slice(0, hashIndex)
     }
     const [auth, ...pathname] = _gitUrl.slice(6).split('/')
-    const [, host] = auth.split('@')
+    const userInfoEnd = auth.lastIndexOf('@')
+    const host = userInfoEnd === -1 ? auth : auth.slice(userInfoEnd + 1)
     if (host.includes(':') && !/:\d+$/.test(host)) {
       const authArr = auth.split(':')
       const protocol = gitUrl.split('://')[0]

--- a/pnpm11/resolving/git-resolver/src/parseBareSpecifier.ts
+++ b/pnpm11/resolving/git-resolver/src/parseBareSpecifier.ts
@@ -208,8 +208,7 @@ function correctUrl (gitUrl: string): string {
     const [auth, ...pathname] = _gitUrl.slice(6).split('/')
     const userInfoEnd = auth.lastIndexOf('@')
     const host = userInfoEnd === -1 ? auth : auth.slice(userInfoEnd + 1)
-    // A bracketed IPv6 literal carries colons of its own, so only what comes
-    // after the closing bracket can hold the SCP-style separator or a port.
+    // The colons of a bracketed IPv6 literal belong to the address.
     const bracketEnd = host.startsWith('[') ? host.indexOf(']') : -1
     const afterHost = bracketEnd === -1 ? host : host.slice(bracketEnd + 1)
     if (afterHost.includes(':') && !/:\d+$/.test(afterHost)) {

--- a/pnpm11/resolving/git-resolver/src/parseBareSpecifier.ts
+++ b/pnpm11/resolving/git-resolver/src/parseBareSpecifier.ts
@@ -208,7 +208,11 @@ function correctUrl (gitUrl: string): string {
     const [auth, ...pathname] = _gitUrl.slice(6).split('/')
     const userInfoEnd = auth.lastIndexOf('@')
     const host = userInfoEnd === -1 ? auth : auth.slice(userInfoEnd + 1)
-    if (host.includes(':') && !/:\d+$/.test(host)) {
+    // A bracketed IPv6 literal carries colons of its own, so only what comes
+    // after the closing bracket can hold the SCP-style separator or a port.
+    const bracketEnd = host.startsWith('[') ? host.indexOf(']') : -1
+    const afterHost = bracketEnd === -1 ? host : host.slice(bracketEnd + 1)
+    if (afterHost.includes(':') && !/:\d+$/.test(afterHost)) {
       const authArr = auth.split(':')
       const protocol = gitUrl.split('://')[0]
       gitUrl = `${protocol}://${authArr.slice(0, -1).join(':') + '/' + authArr[authArr.length - 1]}${pathname.length ? '/' + pathname.join('/') : ''}${hash}`

--- a/pnpm11/resolving/git-resolver/test/parsePref.test.ts
+++ b/pnpm11/resolving/git-resolver/test/parsePref.test.ts
@@ -76,6 +76,17 @@ test.each([
   expect(parsed?.fetchSpec).toBe(output)
 })
 
+// The host is read from the last `@`, so an authority holding more than one
+// still splits at the separator rather than inside the user info.
+test.each([
+  ['ssh://user@a@b.example.com/repo.git', 'ssh://user%40a@b.example.com/repo.git'],
+  ['ssh://user:p@ss@example.com:repo.git', 'ssh://user:p%40ss@example.com/repo.git'],
+  ['ssh://user:p@ss@example.com:22/repo.git', 'ssh://user:p%40ss@example.com:22/repo.git'],
+])('the fetchSpec of %s, whose authority holds more than one @, should be %s', async (input, output) => {
+  const parsed = await parseBareSpecifier(input, {})?.()
+  expect(parsed?.fetchSpec).toBe(output)
+})
+
 // Test for https:// URLs ending in .git (issue #10468)
 test.each([
   ['https://gitea.osmocom.org/ttcn3/highlightjs-ttcn3.git', 'https://gitea.osmocom.org/ttcn3/highlightjs-ttcn3.git'],

--- a/pnpm11/resolving/git-resolver/test/parsePref.test.ts
+++ b/pnpm11/resolving/git-resolver/test/parsePref.test.ts
@@ -61,7 +61,6 @@ test.each([
   expect(parsed?.fetchSpec).toBe(output)
 })
 
-// Every case above writes user info, so the shape without it went unexercised.
 test.each([
   ['ssh://git.example.com/team/repo.git', 'ssh://git.example.com/team/repo.git'],
   ['ssh://git.example.com:2222/team/repo.git', 'ssh://git.example.com:2222/team/repo.git'],
@@ -75,8 +74,6 @@ test.each([
   expect(parsed?.fetchSpec).toBe(output)
 })
 
-// The host is read from the last `@`, so an authority holding more than one
-// still splits at the separator rather than inside the user info.
 test.each([
   ['ssh://user@a@b.example.com/repo.git', 'ssh://user%40a@b.example.com/repo.git'],
   ['ssh://user:p@ss@example.com:repo.git', 'ssh://user:p%40ss@example.com/repo.git'],
@@ -86,12 +83,11 @@ test.each([
   expect(parsed?.fetchSpec).toBe(output)
 })
 
-// The colons of a bracketed IPv6 host belong to the address, not to a port or
-// to an SCP-style separator.
 test.each([
   ['ssh://[::1]/repo.git', 'ssh://[::1]/repo.git'],
   ['ssh://[2001:db8::1]/team/repo.git', 'ssh://[2001:db8::1]/team/repo.git'],
   ['ssh://[::1]:2222/repo.git', 'ssh://[::1]:2222/repo.git'],
+  ['ssh://[::1]:team/repo.git', 'ssh://[::1]/team/repo.git'],
   ['ssh://git@[::1]/repo.git', 'ssh://git@[::1]/repo.git'],
   ['ssh://git@[::1]:team/repo.git', 'ssh://git@[::1]/team/repo.git'],
 ])('the fetchSpec of %s, which holds a bracketed IPv6 host, should be %s', async (input, output) => {

--- a/pnpm11/resolving/git-resolver/test/parsePref.test.ts
+++ b/pnpm11/resolving/git-resolver/test/parsePref.test.ts
@@ -61,6 +61,21 @@ test.each([
   expect(parsed?.fetchSpec).toBe(output)
 })
 
+// An ssh:// URL does not have to carry user info. Every case above writes one,
+// so the no-userinfo shape went unexercised.
+test.each([
+  ['ssh://git.example.com/team/repo.git', 'ssh://git.example.com/team/repo.git'],
+  ['ssh://git.example.com:2222/team/repo.git', 'ssh://git.example.com:2222/team/repo.git'],
+  ['ssh://git.example.com:team/repo.git', 'ssh://git.example.com/team/repo.git'],
+  ['ssh://git.example.com:repo.git', 'ssh://git.example.com/repo.git'],
+  ['git+ssh://git.example.com/team/repo.git', 'ssh://git.example.com/team/repo.git'],
+  ['git+ssh://git.example.com:team/repo.git', 'ssh://git.example.com/team/repo.git'],
+  ['ssh://git.example.com:2222/team/repo.git#v1.0.0', 'ssh://git.example.com:2222/team/repo.git'],
+])('the fetchSpec of %s, which carries no user info, should be %s', async (input, output) => {
+  const parsed = await parseBareSpecifier(input, {})?.()
+  expect(parsed?.fetchSpec).toBe(output)
+})
+
 // Test for https:// URLs ending in .git (issue #10468)
 test.each([
   ['https://gitea.osmocom.org/ttcn3/highlightjs-ttcn3.git', 'https://gitea.osmocom.org/ttcn3/highlightjs-ttcn3.git'],

--- a/pnpm11/resolving/git-resolver/test/parsePref.test.ts
+++ b/pnpm11/resolving/git-resolver/test/parsePref.test.ts
@@ -61,8 +61,7 @@ test.each([
   expect(parsed?.fetchSpec).toBe(output)
 })
 
-// An ssh:// URL does not have to carry user info. Every case above writes one,
-// so the no-userinfo shape went unexercised.
+// Every case above writes user info, so the shape without it went unexercised.
 test.each([
   ['ssh://git.example.com/team/repo.git', 'ssh://git.example.com/team/repo.git'],
   ['ssh://git.example.com:2222/team/repo.git', 'ssh://git.example.com:2222/team/repo.git'],
@@ -83,6 +82,19 @@ test.each([
   ['ssh://user:p@ss@example.com:repo.git', 'ssh://user:p%40ss@example.com/repo.git'],
   ['ssh://user:p@ss@example.com:22/repo.git', 'ssh://user:p%40ss@example.com:22/repo.git'],
 ])('the fetchSpec of %s, whose authority holds more than one @, should be %s', async (input, output) => {
+  const parsed = await parseBareSpecifier(input, {})?.()
+  expect(parsed?.fetchSpec).toBe(output)
+})
+
+// The colons of a bracketed IPv6 host belong to the address, not to a port or
+// to an SCP-style separator.
+test.each([
+  ['ssh://[::1]/repo.git', 'ssh://[::1]/repo.git'],
+  ['ssh://[2001:db8::1]/team/repo.git', 'ssh://[2001:db8::1]/team/repo.git'],
+  ['ssh://[::1]:2222/repo.git', 'ssh://[::1]:2222/repo.git'],
+  ['ssh://git@[::1]/repo.git', 'ssh://git@[::1]/repo.git'],
+  ['ssh://git@[::1]:team/repo.git', 'ssh://git@[::1]/team/repo.git'],
+])('the fetchSpec of %s, which holds a bracketed IPv6 host, should be %s', async (input, output) => {
   const parsed = await parseBareSpecifier(input, {})?.()
   expect(parsed?.fetchSpec).toBe(output)
 })


### PR DESCRIPTION
## Summary

SSH Git dependencies without user information could crash during parsing because the TypeScript resolver expected every authority to contain `user@host`. Bracketed IPv6 addresses exposed a second issue: colons inside the address were mistaken for an SCP-style separator.

This change keeps the TypeScript and Rust implementations aligned:

- the host lookup falls back to the full authority when no user information is present;
- only the part after a bracketed host is inspected for an SCP separator or port;
- the Rust rewrite finds the final separator directly with `rfind(':')`, which expresses the intended operation without allocating a temporary vector;
- regression coverage includes no-user-info URLs, bracketed IPv6 hosts, ports, SCP-style paths, and path extraction.

## Validation

Validated in Linux containers with the repository's declared runtimes.

- Rust 1.95.0: all 68 tests in `pacquet-resolving-git-resolver` passed.
- `cargo fmt --all -- --check` passed.
- Clippy passed for the affected crate and for the full Rust workspace with all targets and warnings denied.
- `cargo doc --no-deps --workspace --all-features` passed with warnings denied.
- The full pre-push JavaScript checks passed: supply-chain policy verification, compilation, spellcheck across 2,904 files, metadata validation, and ESLint with no errors.
- Husky commit hooks and commitlint passed.

## Checklist

- [x] TypeScript and Rust implementations remain in sync.
- [x] Tests cover the reported cases.
- [x] The published package change includes a changeset.
- [x] No documentation update is needed because this restores expected URL handling.

---
Written by an agent (Codex, GPT-5.6 Sol Pro).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788766171&installation_model_id=426870&pr_number=13726&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13726&signature=dba2426bf0790aba7b6309c838045b27d3006661f91c1f4f34e66b6d97f0ea58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Restored resolution of SSH Git dependencies without user information.
- Added support for standard and port-specific SSH URLs, including colon-separated paths.
- Improved handling of authentication details containing multiple `@` characters.
- Added support for bracketed IPv6 SSH hosts and ports.
- Preserved and correctly encoded authentication details during URL processing.
- Ensured URL fragments are removed and supported SSH URL formats are normalized consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->