### PR TITLE
fix: make the Ecosystem E2E workflow pass

### DIFF
--- a/.changeset/gvs-compat-angular-nuxt-phantom-deps.md
+++ b/.changeset/gvs-compat-angular-nuxt-phantom-deps.md
@@ -4,4 +4,4 @@
 "pacquet": patch
 ---
 
-Added compatibility `packageExtensions` for `@angular/build` (undeclared `tslib`) and `@nuxt/vite-builder@>=4` (undeclared `unplugin`), so `ng build` and `nuxt build` work under the global virtual store, where undeclared dependencies are not resolvable by design.
+`ng build` and `nuxt build` now work under the global virtual store: pnpm's built-in compatibility extensions add the `tslib` dependency that `@angular/build` uses without declaring and the `unplugin` dependency that `@nuxt/vite-builder` v4 uses without declaring.

--- a/.changeset/gvs-compat-angular-nuxt-phantom-deps.md
+++ b/.changeset/gvs-compat-angular-nuxt-phantom-deps.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/hooks.read-package-hook": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+Added compatibility `packageExtensions` for `@angular/build` (undeclared `tslib`) and `@nuxt/vite-builder@>=4` (undeclared `unplugin`), so `ng build` and `nuxt build` work under the global virtual store, where undeclared dependencies are not resolvable by design.

--- a/.github/workflows/ecosystem-e2e.yml
+++ b/.github/workflows/ecosystem-e2e.yml
@@ -82,6 +82,14 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install Node
+        # The runner image's system Node is older than the bundle's floor
+        # (`node:sqlite` needs >= 22.13). Installs the `devEngines.runtime`
+        # pin, which the harness passes to every subprocess through PATH.
+        uses: pnpm/setup@6523ce966bcf7a1061ce6401e5c6e0b60466bd31
+        with:
+          install: false
+
       - name: Download build outputs
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/pnpm/crates/package-manager/src/compat_package_extensions.rs
+++ b/pnpm/crates/package-manager/src/compat_package_extensions.rs
@@ -3,11 +3,8 @@ use indexmap::IndexMap;
 use pacquet_config::{PackageExtension, PeerDependencyMeta};
 use std::{collections::BTreeMap, sync::LazyLock};
 
-// `pnpm_compat_package_extensions.json` holds undeclared dependencies that
-// break popular packages under the global virtual store (which, by design,
-// exposes only declared dependencies). Its entries are not in
-// `@yarnpkg/extensions` yet; drop an entry once the upstream DB or the
-// package itself declares the dependency. Mirrored in the TypeScript CLI's
+// `pnpm_compat_package_extensions.json` holds pnpm-specific entries not in
+// `@yarnpkg/extensions` yet; keep it identical to the TypeScript CLI's
 // `pnpmCompatPackageExtensions`.
 static COMPAT_PACKAGE_EXTENSIONS: LazyLock<IndexMap<String, PackageExtension>> =
     LazyLock::new(|| {
@@ -17,7 +14,9 @@ static COMPAT_PACKAGE_EXTENSIONS: LazyLock<IndexMap<String, PackageExtension>> =
             (include_str!("pnpm_compat_package_extensions.json"), "pnpm"),
         ] {
             let entries: Vec<(String, PackageExtension)> = serde_json::from_str(source)
-                .unwrap_or_else(|error| panic!("{name} compatibility DB JSON is valid: {error}"));
+                .unwrap_or_else(|error| {
+                    panic!("failed to parse {name} compatibility DB JSON: {error}")
+                });
             for (selector, extension) in entries {
                 merge_package_extension_entry(&mut extensions, selector, extension);
             }

--- a/pnpm/crates/package-manager/src/compat_package_extensions.rs
+++ b/pnpm/crates/package-manager/src/compat_package_extensions.rs
@@ -3,14 +3,24 @@ use indexmap::IndexMap;
 use pacquet_config::{PackageExtension, PeerDependencyMeta};
 use std::{collections::BTreeMap, sync::LazyLock};
 
+// `pnpm_compat_package_extensions.json` holds undeclared dependencies that
+// break popular packages under the global virtual store (which, by design,
+// exposes only declared dependencies). Its entries are not in
+// `@yarnpkg/extensions` yet; drop an entry once the upstream DB or the
+// package itself declares the dependency. Mirrored in the TypeScript CLI's
+// `pnpmCompatPackageExtensions`.
 static COMPAT_PACKAGE_EXTENSIONS: LazyLock<IndexMap<String, PackageExtension>> =
     LazyLock::new(|| {
-        let entries: Vec<(String, PackageExtension)> =
-            serde_json::from_str(include_str!("compat_package_extensions.json"))
-                .expect("@yarnpkg/extensions compatibility DB JSON is valid");
         let mut extensions = IndexMap::new();
-        for (selector, extension) in entries {
-            merge_package_extension_entry(&mut extensions, selector, extension);
+        for (source, name) in [
+            (include_str!("compat_package_extensions.json"), "@yarnpkg/extensions"),
+            (include_str!("pnpm_compat_package_extensions.json"), "pnpm"),
+        ] {
+            let entries: Vec<(String, PackageExtension)> = serde_json::from_str(source)
+                .unwrap_or_else(|error| panic!("{name} compatibility DB JSON is valid: {error}"));
+            for (selector, extension) in entries {
+                merge_package_extension_entry(&mut extensions, selector, extension);
+            }
         }
         extensions
     });
@@ -67,3 +77,6 @@ fn merge_peer_meta_map(
     }
     *previous = Some(merged);
 }
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/package-manager/src/compat_package_extensions/tests.rs
+++ b/pnpm/crates/package-manager/src/compat_package_extensions/tests.rs
@@ -1,0 +1,19 @@
+use super::COMPAT_PACKAGE_EXTENSIONS;
+
+#[test]
+fn includes_pnpm_specific_compat_entries() {
+    let angular_build = COMPAT_PACKAGE_EXTENSIONS
+        .get("@angular/build@*")
+        .expect("@angular/build compat entry present");
+    assert_eq!(
+        angular_build.dependencies.as_ref().and_then(|deps| deps.get("tslib")),
+        Some(&"^2.3.0".to_string()),
+    );
+    let nuxt_vite_builder = COMPAT_PACKAGE_EXTENSIONS
+        .get("@nuxt/vite-builder@>=4.5.0")
+        .expect("@nuxt/vite-builder compat entry present");
+    assert_eq!(
+        nuxt_vite_builder.dependencies.as_ref().and_then(|deps| deps.get("unplugin")),
+        Some(&"^3.3.0".to_string()),
+    );
+}

--- a/pnpm/crates/package-manager/src/compat_package_extensions/tests.rs
+++ b/pnpm/crates/package-manager/src/compat_package_extensions/tests.rs
@@ -9,6 +9,13 @@ fn includes_pnpm_specific_compat_entries() {
         angular_build.dependencies.as_ref().and_then(|deps| deps.get("tslib")),
         Some(&"^2.3.0".to_string()),
     );
+    let legacy_nuxt_vite_builder = COMPAT_PACKAGE_EXTENSIONS
+        .get("@nuxt/vite-builder@>=4.0.0 <4.5.0")
+        .expect("legacy @nuxt/vite-builder compat entry present");
+    assert_eq!(
+        legacy_nuxt_vite_builder.dependencies.as_ref().and_then(|deps| deps.get("unplugin")),
+        Some(&"^2.3.5".to_string()),
+    );
     let nuxt_vite_builder = COMPAT_PACKAGE_EXTENSIONS
         .get("@nuxt/vite-builder@>=4.5.0")
         .expect("@nuxt/vite-builder compat entry present");

--- a/pnpm/crates/package-manager/src/pnpm_compat_package_extensions.json
+++ b/pnpm/crates/package-manager/src/pnpm_compat_package_extensions.json
@@ -1,0 +1,26 @@
+[
+  [
+    "@angular/build@*",
+    {
+      "dependencies": {
+        "tslib": "^2.3.0"
+      }
+    }
+  ],
+  [
+    "@nuxt/vite-builder@>=4.0.0 <4.5.0",
+    {
+      "dependencies": {
+        "unplugin": "^2.3.5"
+      }
+    }
+  ],
+  [
+    "@nuxt/vite-builder@>=4.5.0",
+    {
+      "dependencies": {
+        "unplugin": "^3.3.0"
+      }
+    }
+  ]
+]

--- a/pnpm11/hooks/read-package-hook/src/createReadPackageHook.ts
+++ b/pnpm11/hooks/read-package-hook/src/createReadPackageHook.ts
@@ -20,11 +20,8 @@ const PACKAGE_EXTENSION_FIELDS: PackageExtensionField[] = [
   'peerDependenciesMeta',
 ]
 
-// Undeclared dependencies that break popular packages under the global
-// virtual store (which, by design, exposes only declared dependencies).
-// These entries are not in `@yarnpkg/extensions` yet; drop an entry once
-// the upstream DB or the package itself declares the dependency.
-// Mirrored in pacquet's `pnpm_compat_package_extensions.json`.
+// pnpm-specific entries not in `@yarnpkg/extensions` yet; keep identical
+// to pacquet's `pnpm_compat_package_extensions.json`.
 const pnpmCompatPackageExtensions: Array<[string, PackageExtension]> = [
   ['@angular/build@*', { dependencies: { tslib: '^2.3.0' } }],
   ['@nuxt/vite-builder@>=4.0.0 <4.5.0', { dependencies: { unplugin: '^2.3.5' } }],

--- a/pnpm11/hooks/read-package-hook/src/createReadPackageHook.ts
+++ b/pnpm11/hooks/read-package-hook/src/createReadPackageHook.ts
@@ -20,6 +20,17 @@ const PACKAGE_EXTENSION_FIELDS: PackageExtensionField[] = [
   'peerDependenciesMeta',
 ]
 
+// Undeclared dependencies that break popular packages under the global
+// virtual store (which, by design, exposes only declared dependencies).
+// These entries are not in `@yarnpkg/extensions` yet; drop an entry once
+// the upstream DB or the package itself declares the dependency.
+// Mirrored in pacquet's `pnpm_compat_package_extensions.json`.
+const pnpmCompatPackageExtensions: Array<[string, PackageExtension]> = [
+  ['@angular/build@*', { dependencies: { tslib: '^2.3.0' } }],
+  ['@nuxt/vite-builder@>=4.0.0 <4.5.0', { dependencies: { unplugin: '^2.3.5' } }],
+  ['@nuxt/vite-builder@>=4.5.0', { dependencies: { unplugin: '^3.3.0' } }],
+]
+
 export function getEffectivePackageExtensions (
   {
     ignoreCompatibilityDb,
@@ -32,6 +43,7 @@ export function getEffectivePackageExtensions (
   const effectivePackageExtensions: Record<string, PackageExtension> = {}
   if (!ignoreCompatibilityDb) {
     mergePackageExtensions(effectivePackageExtensions, compatPackageExtensions)
+    mergePackageExtensions(effectivePackageExtensions, pnpmCompatPackageExtensions)
   }
   if (!isEmpty(packageExtensions ?? {})) {
     mergePackageExtensions(effectivePackageExtensions, Object.entries(packageExtensions!))

--- a/pnpm11/hooks/read-package-hook/test/createReadPackageHook.ts
+++ b/pnpm11/hooks/read-package-hook/test/createReadPackageHook.ts
@@ -57,6 +57,11 @@ test('getEffectivePackageExtensions() includes the pnpm-specific compatibility e
       tslib: '^2.3.0',
     },
   })
+  expect(extensions?.['@nuxt/vite-builder@>=4.0.0 <4.5.0']).toStrictEqual({
+    dependencies: {
+      unplugin: '^2.3.5',
+    },
+  })
   expect(extensions?.['@nuxt/vite-builder@>=4.5.0']).toStrictEqual({
     dependencies: {
       unplugin: '^3.3.0',

--- a/pnpm11/hooks/read-package-hook/test/createReadPackageHook.ts
+++ b/pnpm11/hooks/read-package-hook/test/createReadPackageHook.ts
@@ -50,6 +50,21 @@ test('createReadPackageHook() runs the custom hook before the version overrider'
   })
 })
 
+test('getEffectivePackageExtensions() includes the pnpm-specific compatibility entries', () => {
+  const extensions = getEffectivePackageExtensions({})
+  expect(extensions?.['@angular/build@*']).toStrictEqual({
+    dependencies: {
+      tslib: '^2.3.0',
+    },
+  })
+  expect(extensions?.['@nuxt/vite-builder@>=4.5.0']).toStrictEqual({
+    dependencies: {
+      unplugin: '^3.3.0',
+    },
+  })
+  expect(getEffectivePackageExtensions({ ignoreCompatibilityDb: true })).toBeUndefined()
+})
+
 test('getEffectivePackageExtensions() merges duplicate compatibility selectors', () => {
   expect(getEffectivePackageExtensions({})?.['gatsby-core-utils@<2.14.0-next.1']).toStrictEqual({
     dependencies: {


### PR DESCRIPTION
## Summary

Makes the Ecosystem E2E workflow pass. It has failed on every recorded run, for two independent reasons:

1. **The matrix jobs never installed Node.** They ran the built bundle with the runner image's system Node v20, while `pnpm.mjs` needs at least 22.13 (`node:sqlite`), so every `pnpm dlx` scaffold crashed with `ERR_UNKNOWN_BUILTIN_MODULE` before any cell ran. The jobs now run `pnpm/setup` (with `install: false`), which puts the `devEngines.runtime` Node pin on `PATH`, same as the build job.
2. **Two real global-virtual-store failures the suite was built to catch**, reproduced identically in both binaries: `@angular/build` requires `tslib` and `@nuxt/vite-builder` (since v4) imports `unplugin` without declaring them, so `ng build` and `nuxt build` fail under the GVS layout, where only declared dependencies resolve. Fixed with pnpm-specific compatibility `packageExtensions` in both stacks, merged after the `@yarnpkg/extensions` DB and gated by the same `ignoreCompatibilityDb` setting.

Verified locally with the full 28-cell grid (7 stacks × pnpm/pacquet × isolated/GVS): all cells pass. Branch dispatch of the workflow: https://github.com/pnpm/pnpm/actions/runs/31250822001

## Squash Commit Body

```text
The Ecosystem E2E workflow failed on every run since it was added, for
two stacked reasons.

The matrix jobs relied on the runner image's system Node (v20), while
the built pnpm bundle needs at least v22.13 for node:sqlite, so every
scaffold died with ERR_UNKNOWN_BUILTIN_MODULE before any cell ran. The
jobs now install the devEngines.runtime pin via pnpm/setup, the same
way the workflow's build job already did.

With scaffolding unblocked, the angular and nuxt global-virtual-store
cells failed in both binaries: "@angular/build" requires tslib and
"@nuxt/vite-builder" (since v4) imports unplugin without declaring
them, and the global virtual store only exposes declared dependencies.
Since neither entry is in the "@yarnpkg/extensions" compatibility DB
yet, carry them as pnpm-specific compatibility packageExtensions in
both stacks, merged after the upstream DB and gated by the same
ignoreCompatibilityDb setting. Drop an entry once the upstream DB or
the package itself declares the dependency.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788773614&installation_model_id=426870&pr_number=13727&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13727&signature=6e0c260c88d4339a61085f5ddf8ed64a6c70ca2e2c64ff2ca5f6fcb6bb1bd981"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility for Angular builds by supplying the required `tslib` dependency.
  - Improved Nuxt projects by supplying the appropriate `unplugin` version for different Nuxt releases.
  - Applied these compatibility adjustments when the compatibility database is enabled.

- **Tests**
  - Added coverage confirming compatibility entries are applied correctly and omitted when disabled.
  - Updated ecosystem testing to use the configured Node.js runtime for improved compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->