### PR TITLE
fix(self-update): support registries without canonical tarball URLs or signature metadata

### DIFF
--- a/.changeset/pm-bootstrap-nonderivable-tarball-registries.md
+++ b/.changeset/pm-bootstrap-nonderivable-tarball-registries.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.env-installer": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+The automatic `packageManager` version switch works again on registries whose tarball URLs point at a different host than the registry itself (load-balanced feed proxies, Artifactory-style mirrors). Package-manager entries are now always recorded with integrity-only resolutions — the download URL is derived from the trusted bootstrap registry instead — and entries persisted in an invalid shape by an earlier pnpm are discarded and re-resolved instead of failing every command [#13619](https://github.com/pnpm/pnpm/issues/13619).

--- a/.changeset/pm-signature-fallback-registry.md
+++ b/.changeset/pm-signature-fallback-registry.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/deps.security.signatures": minor
+"@pnpm/engine.pm.commands": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+Registries that serve no npm signature metadata (private mirrors and feed proxies commonly strip `dist.signatures`) no longer break the automatic `packageManager` version switch and `pnpm self-update` [#13147](https://github.com/pnpm/pnpm/issues/13147). When the configured registry cannot provide a verifiable signature, pnpm now fetches the signature from `registry.npmjs.org` and verifies it against the same embedded npm keys over the installed integrity — which proves exactly the same thing. If no signature can be obtained from either source (for example, both are unreachable, or the registry publishes only a `shasum`), pnpm proceeds with a warning instead of failing, but only when the packages resolve through a registry configured in the user's own (non-project) configuration; the download stays pinned by the lockfile integrity, and a signature that exists but does not validate still fails the switch.

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -215,6 +215,7 @@ impl InstallPipeline {
                 &pm.specifier,
                 &pm.version,
                 frozen_lockfile,
+                false,
             )
             .await?;
         }
@@ -299,6 +300,7 @@ impl AddPipeline {
                 &config_root,
                 &pm.specifier,
                 &pm.version,
+                false,
                 false,
             )
             .await?;
@@ -389,6 +391,7 @@ impl UpdatePipeline {
                 &config_root,
                 &pm.specifier,
                 &pm.version,
+                false,
                 false,
             )
             .await?;
@@ -492,6 +495,7 @@ impl RemovePipeline {
                 &pm.specifier,
                 &pm.version,
                 false,
+                false,
             )
             .await?;
         }
@@ -563,6 +567,7 @@ impl DeployPipeline {
                 &config_root,
                 &pm.specifier,
                 &pm.version,
+                false,
                 false,
             )
             .await?;
@@ -718,6 +723,7 @@ impl DedupePipeline {
                 &pm.specifier,
                 &pm.version,
                 false,
+                false,
             )
             .await?;
         }
@@ -755,6 +761,7 @@ impl PrunePipeline {
                 &config_root,
                 &pm.specifier,
                 &pm.version,
+                false,
                 false,
             )
             .await?;

--- a/pnpm/crates/cli/src/cli_args/pre_command.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command.rs
@@ -105,6 +105,7 @@ pub(crate) async fn execute_plan(
                 &package_manager.specifier,
                 &package_manager.version,
                 false,
+                false,
             )
             .await?;
             Ok(false)
@@ -127,11 +128,25 @@ async fn execute_switch(plan: SwitchPlan, child_argv: &[OsString]) -> miette::Re
                 Box::pin(install_pnpm_from_env::<SilentReporter>(config, &env, &version)).await?;
             (version, bin_dir)
         }
-        SwitchSource::Resolve { env_root } => {
+        SwitchSource::Resolve { env_root, force_resync } => {
             let resolved = config_deps::resolve_pnpm_version(config, &spec)
                 .await?
                 .ok_or_else(|| miette::miette!(r#"Cannot resolve pnpm version for "{}""#, spec))?;
             if resolved.version == PNPM_VERSION {
+                if force_resync {
+                    // No switch to perform, but the recorded entries are
+                    // invalid — heal them now or every later invocation
+                    // re-resolves over the network.
+                    config_deps::sync_package_manager_dependencies(
+                        config,
+                        &env_root,
+                        &spec,
+                        &resolved.version,
+                        false,
+                        true,
+                    )
+                    .await?;
+                }
                 return Ok(false);
             }
             assert_release_is_installable(&resolved.version)?;
@@ -140,6 +155,7 @@ async fn execute_switch(plan: SwitchPlan, child_argv: &[OsString]) -> miette::Re
                 &env_root,
                 &spec,
                 &resolved.version,
+                force_resync,
             ))
             .await?;
             (resolved.version, bin_dir)
@@ -560,7 +576,21 @@ fn switch_target(config: &Config, root_dir: &Path) -> miette::Result<Option<Swit
         && let Some(env) = read_env_lockfile(root_dir)?
         && let Some(version) = locked_package_manager_version(&env, &spec)?
     {
-        return Ok(Some(SwitchTarget { spec, source: SwitchSource::LockedEnv { env, version } }));
+        if assert_package_manager_lockfile_uses_registry_resolutions(&env).is_ok() {
+            return Ok(Some(SwitchTarget {
+                spec,
+                source: SwitchSource::LockedEnv { env, version },
+            }));
+        }
+        // Entries that don't satisfy the bootstrap rules — e.g. resolutions
+        // carrying tarball URLs written by an earlier pnpm — are not an
+        // error: they are discarded and re-resolved afresh through the
+        // trusted bootstrap registries, which yields entries in the accepted
+        // shape.
+        return Ok(Some(SwitchTarget {
+            spec,
+            source: SwitchSource::Resolve { env_root: root_dir.to_path_buf(), force_resync: true },
+        }));
     }
 
     let env_root = if persist_lockfile {
@@ -572,7 +602,7 @@ fn switch_target(config: &Config, root_dir: &Path) -> miette::Result<Option<Swit
             )
         })?
     };
-    Ok(Some(SwitchTarget { spec, source: SwitchSource::Resolve { env_root } }))
+    Ok(Some(SwitchTarget { spec, source: SwitchSource::Resolve { env_root, force_resync: false } }))
 }
 
 fn locked_package_manager_version(
@@ -594,7 +624,6 @@ fn locked_package_manager_version(
     if !package_manager_dependencies_are_resolved(env, &version) {
         return Ok(None);
     }
-    assert_package_manager_lockfile_uses_registry_resolutions(env)?;
     Ok(Some(version))
 }
 
@@ -813,8 +842,18 @@ pub(crate) struct EnvLockfileSync {
 
 #[derive(Debug)]
 enum SwitchSource {
-    LockedEnv { env: EnvLockfile, version: String },
-    Resolve { env_root: PathBuf },
+    LockedEnv {
+        env: EnvLockfile,
+        version: String,
+    },
+    Resolve {
+        env_root: PathBuf,
+        /// Discard the recorded `packageManagerDependencies` and re-resolve
+        /// them even when they look up to date — set when the recorded
+        /// entries failed the bootstrap validation, so the resync heals the
+        /// env lockfile instead of no-op'ing on the invalid entries.
+        force_resync: bool,
+    },
 }
 
 struct SwitchInput {

--- a/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
@@ -436,25 +436,31 @@ fn switch_target_accepts_v12_lockfile_without_legacy_wrapper_entry() {
 }
 
 #[test]
-fn switch_target_rejects_package_manager_lockfile_resolution_with_non_integrity_fields() {
+fn switch_target_discards_package_manager_lockfile_resolution_with_non_integrity_fields() {
     let root = TempDir::new().expect("tmp dir");
     write_dev_engine_manifest(root.path(), "9.3.0");
     write_lockfile(root.path(), LOCKED_9_3_0_WITH_TARBALL_RESOLUTION);
 
-    let error = switch_target_error(root.path());
+    let target = switch_target(&Config::default(), root.path()).expect("target").expect("switch");
 
-    assert!(error.to_string().contains("integrity-only resolution"), "unexpected error: {error:?}");
+    let SwitchSource::Resolve { env_root, force_resync: true } = target.source else {
+        panic!("expected a forced re-resolve, got {:?}", target.source);
+    };
+    assert_eq!(env_root, root.path());
 }
 
 #[test]
-fn switch_target_rejects_package_manager_lockfile_dependency_with_non_registry_dep_path() {
+fn switch_target_discards_package_manager_lockfile_dependency_with_non_registry_dep_path() {
     let root = TempDir::new().expect("tmp dir");
     write_dev_engine_manifest(root.path(), "9.3.0");
     write_lockfile(root.path(), LOCKED_9_3_0_WITH_FILE_DEP_PATH);
 
-    let error = switch_target_error(root.path());
+    let target = switch_target(&Config::default(), root.path()).expect("target").expect("switch");
 
-    assert!(error.to_string().contains("registry package path"), "unexpected error: {error:?}");
+    let SwitchSource::Resolve { env_root, force_resync: true } = target.source else {
+        panic!("expected a forced re-resolve, got {:?}", target.source);
+    };
+    assert_eq!(env_root, root.path());
 }
 
 #[test]
@@ -466,7 +472,7 @@ fn switch_target_reresolves_when_locked_version_no_longer_satisfies_range() {
     let target = switch_target(&Config::default(), root.path()).expect("target").expect("switch");
 
     assert_eq!(target.spec, ">=9.1.2 <9.1.4");
-    let SwitchSource::Resolve { env_root } = target.source else {
+    let SwitchSource::Resolve { env_root, force_resync: false } = target.source else {
         panic!("expected resolve target");
     };
     assert_eq!(env_root, root.path());
@@ -485,7 +491,7 @@ fn switch_target_uses_global_env_for_legacy_package_manager_field() {
     .expect("target")
     .expect("switch");
 
-    let SwitchSource::Resolve { env_root } = target.source else {
+    let SwitchSource::Resolve { env_root, force_resync: false } = target.source else {
         panic!("expected resolve target");
     };
     assert_eq!(target.spec, "9.3.0");
@@ -567,13 +573,6 @@ snapshots:
 ---
 ",
     )
-}
-
-fn switch_target_error(root: &Path) -> miette::Report {
-    match switch_target(&Config::default(), root) {
-        Ok(_) => panic!("expected poisoned lockfile to fail"),
-        Err(error) => error,
-    }
 }
 
 const LOCKED_9_3_0_WITH_PEER_SUFFIX: &str = r"---

--- a/pnpm/crates/cli/src/cli_args/self_update.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update.rs
@@ -284,6 +284,7 @@ async fn handler<Reporter: self::Reporter + 'static>(
         &target_version,
         &target_version,
         false,
+        false,
     ))
     .await?;
     let env = EnvLockfile::read(&env_root)
@@ -294,7 +295,11 @@ async fn handler<Reporter: self::Reporter + 'static>(
                 "Cannot verify the identity of pnpm@{target_version}: its integrity metadata is missing from pnpm-lock.yaml.",
             ),
         })?;
-    Box::pin(verify_engine::verify_pnpm_engine_identity(&env, &target_version, config)).await?;
+    if let Some(warning) =
+        Box::pin(verify_engine::verify_pnpm_engine_identity(&env, &target_version, config)).await?
+    {
+        warn::<Reporter>(&prefix, &warning);
+    }
 
     let result = Box::pin(install_pnpm::install_pnpm::<Reporter>(
         config,
@@ -395,6 +400,7 @@ async fn update_project_pin(
                 &root_dir,
                 &pin_specifier,
                 target_version,
+                false,
                 false,
             ))
             .await?;

--- a/pnpm/crates/cli/src/cli_args/self_update/verify_engine.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/verify_engine.rs
@@ -354,7 +354,7 @@ async fn find_signature_failure(
     if !component.integrity.starts_with("sha512-") {
         return failure(
             format!(
-                "{label} is pinned by a non-sha512 integrity, which npm registry signatures cannot cover"
+                "{label} is pinned by a non-sha512 integrity, which npm registry signatures cannot cover",
             ),
             FailureCategory::Uncovered,
         );

--- a/pnpm/crates/cli/src/cli_args/self_update/verify_engine.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/verify_engine.rs
@@ -56,6 +56,14 @@ struct NpmSigningKey<'a> {
     expires: Option<&'a str>,
 }
 
+/// The canonical npm registry, consulted for signature metadata when a
+/// user-configured registry cannot provide a verifiable signature. Where the
+/// signature bytes come from does not affect what they prove: they are
+/// verified against the embedded keys over the lockfile integrity, so a
+/// component passes only when a genuine signature validates over the bytes
+/// actually installed. See <https://github.com/pnpm/pnpm/issues/13147>.
+const CANONICAL_NPM_REGISTRY: &str = "https://registry.npmjs.org/";
+
 /// A pnpm-engine component whose registry signature must validate over the
 /// bytes the lockfile pins.
 struct EngineComponent {
@@ -67,16 +75,33 @@ struct EngineComponent {
 
 /// Verify the pnpm engine recorded in `env` against npm's embedded keys.
 ///
-/// Returns an error when verification detects tampering (an invalid
-/// signature), when a component is absent from the registry, when a
-/// component carries no integrity metadata, or when the registry is
-/// unreachable — failing closed in every case, since the lockfile
-/// integrity is project-controlled and not a safe fallback.
+/// Registries that serve no `dist.signatures` (private mirrors and feed
+/// proxies commonly strip them) do not fail the check outright: the
+/// signature is fetched from [`CANONICAL_NPM_REGISTRY`] instead, which
+/// proves exactly the same thing. When no signature can be obtained from
+/// either source (both unreachable, or the integrity is a non-sha512 pin no
+/// npm signature can cover), the check returns a warning for the caller to
+/// emit and lets the install proceed — but only when every engine component
+/// resolves through a non-canonical registry. Such a registry can only come
+/// from the user's own trusted (non-project) configuration, the download URL
+/// is derived from it rather than read from the lockfile, and the bytes stay
+/// pinned by the lockfile integrity — so a cloned repository still cannot
+/// steer pnpm to attacker-controlled bytes; the residual trust is the same
+/// the user already places in that registry for every package installed
+/// from it.
+///
+/// Returns `Ok(None)` when a signature validated, `Ok(Some(warning))` when
+/// the install may proceed unverified, and an error when verification
+/// detects tampering (an invalid signature), when a component is absent from
+/// a reachable canonical registry, when a component carries no integrity
+/// metadata, or when the canonical registry is the configured registry and
+/// is unreachable — the lockfile integrity is project-controlled and not a
+/// safe fallback there.
 pub(crate) async fn verify_pnpm_engine_identity(
     env: &EnvLockfile,
     pnpm_version: &str,
     config: &Config,
-) -> Result<(), SelfUpdateError> {
+) -> Result<Option<String>, SelfUpdateError> {
     let to_verify = collect_engine_components(env, config)?;
     if to_verify.is_empty() {
         return Err(SelfUpdateError::EngineIdentityUnverifiable {
@@ -91,19 +116,36 @@ pub(crate) async fn verify_pnpm_engine_identity(
 
     let mut failures: Vec<SignatureFailure> = Vec::new();
     for component in &to_verify {
-        if let Some(failure) = find_signature_failure(component, &client, retry_opts, config).await
+        if let Some(failure) = find_signature_failure(
+            component,
+            CANONICAL_NPM_REGISTRY,
+            NPM_SIGNING_KEYS,
+            &client,
+            retry_opts,
+            config,
+        )
+        .await
         {
             failures.push(failure);
         }
     }
     if failures.is_empty() {
-        return Ok(());
+        return Ok(None);
     }
     failures.sort_by(|left, right| left.label.cmp(&right.label));
+    let described = failures.iter().map(SignatureFailure::describe).collect::<Vec<_>>().join("; ");
+
+    if failures.iter().all(SignatureFailure::tolerable_without_signature) {
+        return Ok(Some(format!(
+            "The authenticity of pnpm@{pnpm_version} could not be verified against npm's registry \
+             signatures: {described}. Proceeding anyway, because the release was resolved through \
+             the registry configured in your own (non-project) configuration and stays pinned by \
+             its integrity checksum.",
+        )));
+    }
 
     let only_unreachable =
         failures.iter().all(|failure| failure.category == FailureCategory::Unreachable);
-    let described = failures.iter().map(SignatureFailure::describe).collect::<Vec<_>>().join("; ");
     let message = format!(
         "Refusing to run pnpm@{pnpm_version}: its npm registry signature could not be verified \
          ({described}). The bytes selected by this project's lockfile/registry do not match a \
@@ -252,10 +294,16 @@ enum FailureCategory {
     Invalid,
     Absent,
     Unreachable,
+    /// The lockfile integrity is not a sha512 hash (e.g. a sha1 pin from a
+    /// registry that publishes only `shasum`), so no npm registry signature
+    /// can ever validate over it — verification is impossible by
+    /// construction, not evidence of tampering.
+    Uncovered,
 }
 
 struct SignatureFailure {
     label: String,
+    registry: String,
     reason: String,
     category: FailureCategory,
 }
@@ -264,41 +312,126 @@ impl SignatureFailure {
     fn describe(&self) -> String {
         format!("{}: {}", self.label, self.reason)
     }
+
+    /// Whether the engine may run despite this failure: no signature was
+    /// obtainable (nothing suspicious was observed — as opposed to a
+    /// signature that exists but does not validate, or the canonical
+    /// registry answering that no signed release exists), and the component
+    /// resolves through a registry the user configured themselves.
+    fn tolerable_without_signature(&self) -> bool {
+        matches!(self.category, FailureCategory::Unreachable | FailureCategory::Uncovered)
+            && !equal_registries(&self.registry, CANONICAL_NPM_REGISTRY)
+    }
 }
 
 /// Per-component verification. Returns `None` when a registry signature
-/// validates over the lockfile bytes.
+/// validates over the lockfile bytes — from the component's own registry,
+/// or from `fallback_registry` when its own registry cannot provide a
+/// verifiable one. `fallback_registry` is [`CANONICAL_NPM_REGISTRY`] in
+/// production and a mock registry in unit tests.
 async fn find_signature_failure(
     component: &EngineComponent,
+    fallback_registry: &str,
+    keys: &[NpmSigningKey<'_>],
     client: &ThrottledClient,
     retry_opts: RetryOpts,
     config: &Config,
 ) -> Option<SignatureFailure> {
     let label = format!("{}@{}", component.name, component.version);
-    let packument = match fetch_packument(component, client, retry_opts, config).await {
+    let failure = |reason: String, category: FailureCategory| {
+        Some(SignatureFailure {
+            reason,
+            category,
+            label: label.clone(),
+            registry: component.registry.clone(),
+        })
+    };
+
+    // npm registry signatures sign `name@version:integrity` with the sha512
+    // integrity the registry published; any other installed form can never
+    // validate, and verifying it would misreport an authentic release as
+    // tampered with.
+    if !component.integrity.starts_with("sha512-") {
+        return failure(
+            format!(
+                "{label} is pinned by a non-sha512 integrity, which npm registry signatures cannot cover"
+            ),
+            FailureCategory::Uncovered,
+        );
+    }
+
+    let primary = attempt_signature_verification(
+        component,
+        &component.registry,
+        keys,
+        client,
+        retry_opts,
+        config,
+    )
+    .await?;
+    if equal_registries(&component.registry, fallback_registry) {
+        return failure(primary.0, primary.1);
+    }
+
+    // A genuine signature validating over the installed integrity proves the
+    // installed bytes regardless of which registry the primary attempt hit
+    // or what it answered (e.g. a mirror serving stale signatures from a
+    // rotated key), so a fallback pass is a pass.
+    let secondary = attempt_signature_verification(
+        component,
+        fallback_registry,
+        keys,
+        client,
+        retry_opts,
+        config,
+    )
+    .await?;
+
+    // A well-formed signature that fails to validate is a tamper signal from
+    // either source; surface it over the softer categories.
+    if primary.1 == FailureCategory::Invalid {
+        return failure(primary.0, primary.1);
+    }
+    if secondary.1 != FailureCategory::Unreachable {
+        return failure(secondary.0, secondary.1);
+    }
+    // The primary registry had no usable signature (a mirror commonly serves
+    // none) and the fallback could not be consulted — nothing suspicious was
+    // observed, the signature was simply unobtainable.
+    failure(
+        format!(
+            "{}; the fallback registry ({fallback_registry}) could not be consulted either: {}",
+            primary.0, secondary.0,
+        ),
+        FailureCategory::Unreachable,
+    )
+}
+
+/// Verify `component`'s lockfile integrity against the signatures the
+/// packument on `registry` carries. Returns `None` on success, otherwise
+/// the failure reason and category.
+async fn attempt_signature_verification(
+    component: &EngineComponent,
+    registry: &str,
+    keys: &[NpmSigningKey<'_>],
+    client: &ThrottledClient,
+    retry_opts: RetryOpts,
+    config: &Config,
+) -> Option<(String, FailureCategory)> {
+    let label = format!("{}@{}", component.name, component.version);
+    let packument = match fetch_packument(component, registry, client, retry_opts, config).await {
         Ok(Some(packument)) => packument,
         Ok(None) => {
-            return Some(SignatureFailure {
-                reason: format!("{} is not published on {}", component.name, component.registry),
-                category: FailureCategory::Absent,
-                label,
-            });
+            return Some((
+                format!("{} is not published on {registry}", component.name),
+                FailureCategory::Absent,
+            ));
         }
-        Err(reason) => {
-            return Some(SignatureFailure {
-                reason,
-                category: FailureCategory::Unreachable,
-                label,
-            });
-        }
+        Err(reason) => return Some((reason, FailureCategory::Unreachable)),
     };
 
     let Some(version) = packument.versions.get(&component.version) else {
-        return Some(SignatureFailure {
-            reason: format!("{label} was not found on {}", component.registry),
-            category: FailureCategory::Absent,
-            label,
-        });
+        return Some((format!("{label} was not found on {registry}"), FailureCategory::Absent));
     };
     let raw_signatures = version.dist.as_ref().and_then(|dist| dist.signatures.as_ref());
     let parsed_signatures = match raw_signatures {
@@ -308,59 +441,47 @@ async fn find_signature_failure(
             for element in elements {
                 let Ok(signature) = serde_json::from_value::<PackageSignature>(element.clone())
                 else {
-                    return Some(SignatureFailure {
-                        reason: format!("malformed registry signatures metadata for {label}"),
-                        category: FailureCategory::Absent,
-                        label,
-                    });
+                    return Some((
+                        format!("malformed registry signatures metadata for {label}"),
+                        FailureCategory::Absent,
+                    ));
                 };
                 parsed.push(signature);
             }
             parsed
         }
         Some(_) => {
-            return Some(SignatureFailure {
-                reason: format!("malformed registry signatures metadata for {label}"),
-                category: FailureCategory::Absent,
-                label,
-            });
+            return Some((
+                format!("malformed registry signatures metadata for {label}"),
+                FailureCategory::Absent,
+            ));
         }
     };
     if parsed_signatures.is_empty() {
-        return Some(SignatureFailure {
-            reason: format!("{label} has no registry signature"),
-            category: FailureCategory::Absent,
-            label,
-        });
+        return Some((
+            format!("{label} has no registry signature on {registry}"),
+            FailureCategory::Absent,
+        ));
     }
 
     let published_at = packument.time.get(&component.version).and_then(serde_json::Value::as_str);
     // The message is built from the *lockfile* integrity, so a signature
     // only validates when the installed bytes match what the registry
     // signed.
-    if signature_validates(component, &parsed_signatures, published_at) {
+    if signature_validates_against(component, &parsed_signatures, published_at, keys) {
         None
     } else {
-        Some(SignatureFailure {
-            reason: "invalid registry signature".to_string(),
-            category: FailureCategory::Invalid,
-            label,
-        })
+        Some(("invalid registry signature".to_string(), FailureCategory::Invalid))
     }
 }
 
-/// `true` as soon as one signature validates against a trusted, unexpired
-/// npm key over `name@version:integrity`.
-fn signature_validates(
-    component: &EngineComponent,
-    signatures: &[PackageSignature],
-    published_at: Option<&str>,
-) -> bool {
-    signature_validates_against(component, signatures, published_at, NPM_SIGNING_KEYS)
+fn equal_registries(left: &str, right: &str) -> bool {
+    with_trailing_slash(left).eq_ignore_ascii_case(&with_trailing_slash(right))
 }
 
-/// [`signature_validates`] against an explicit key set — the trusted
-/// [`NPM_SIGNING_KEYS`] in production, a test key in unit tests.
+/// `true` as soon as one signature validates against a trusted, unexpired
+/// key over `name@version:integrity` — the trusted [`NPM_SIGNING_KEYS`] in
+/// production, a test key in unit tests.
 fn signature_validates_against(
     component: &EngineComponent,
     signatures: &[PackageSignature],
@@ -437,16 +558,18 @@ struct Packument {
     versions: std::collections::HashMap<String, PackumentVersion>,
 }
 
-/// Fetch a component's packument from its (trusted) registry. `Ok(None)`
-/// for a 404 (package absent); `Err` for any other failure (treated as
-/// `unreachable` by the caller, so verification fails closed).
+/// Fetch a component's packument from `registry` — its own (trusted)
+/// registry, or the canonical fallback. `Ok(None)` for a 404 (package
+/// absent); `Err` for any other failure (treated as `unreachable` by the
+/// caller).
 async fn fetch_packument(
     component: &EngineComponent,
+    registry: &str,
     client: &ThrottledClient,
     retry_opts: RetryOpts,
     config: &Config,
 ) -> Result<Option<Packument>, String> {
-    let registry_url = with_trailing_slash(&component.registry);
+    let registry_url = with_trailing_slash(registry);
     let packument_url = format!("{registry_url}{}", encode_package_name(&component.name));
     let display_url = redact_url_credentials(&packument_url);
     // Resolve auth against the request URL *and* the package name so a

--- a/pnpm/crates/cli/src/cli_args/self_update/verify_engine.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/verify_engine.rs
@@ -23,7 +23,7 @@ use pacquet_config::Config;
 use pacquet_graph_hasher::{host_arch, host_libc, host_platform};
 use pacquet_lockfile::{EnvLockfile, PackageKey, SnapshotDepRef, SpecifierAndResolution};
 use pacquet_network::{
-    NetworkSettings, RetryOpts, ThrottledClient, encode_package_name, redact_url_credentials,
+    NetworkSettings, RetryOpts, ThrottledClient, encode_package_name, redact_and_sanitize,
     send_with_retry,
 };
 use serde::Deserialize;
@@ -343,7 +343,7 @@ async fn find_signature_failure(
             reason,
             category,
             label: label.clone(),
-            registry: redact_url_credentials(&component.registry),
+            registry: redact_and_sanitize(&component.registry),
         })
     };
 
@@ -402,7 +402,7 @@ async fn find_signature_failure(
         format!(
             "{}; the fallback registry ({}) could not be consulted either: {}",
             primary.0,
-            redact_url_credentials(fallback_registry),
+            redact_and_sanitize(fallback_registry),
             secondary.0,
         ),
         FailureCategory::Unreachable,
@@ -423,7 +423,7 @@ async fn attempt_signature_verification(
     let label = format!("{}@{}", component.name, component.version);
     // Registry URLs may carry inline `user:pass@` credentials, and the
     // reasons built here end up in error messages and warnings.
-    let display_registry = redact_url_credentials(registry);
+    let display_registry = redact_and_sanitize(registry);
     let packument = match fetch_packument(component, registry, client, retry_opts, config).await {
         Ok(Some(packument)) => packument,
         Ok(None) => {
@@ -496,7 +496,7 @@ fn equal_registries(left: &str, right: &str) -> bool {
 }
 
 fn normalize_registry_url(registry: &str) -> String {
-    let with_slash = redact_url_credentials(&with_trailing_slash(registry));
+    let with_slash = redact_and_sanitize(&with_trailing_slash(registry));
     // URL normalization lowercases the host and drops a default port.
     url::Url::parse(&with_slash).map(String::from).unwrap_or(with_slash)
 }
@@ -593,7 +593,7 @@ async fn fetch_packument(
 ) -> Result<Option<Packument>, String> {
     let registry_url = with_trailing_slash(registry);
     let packument_url = format!("{registry_url}{}", encode_package_name(&component.name));
-    let display_url = redact_url_credentials(&packument_url);
+    let display_url = redact_and_sanitize(&packument_url);
     // Resolve auth against the request URL *and* the package name so a
     // `@scope:registry`-scoped token applies (plain `for_url` skips the
     // scope lookup, breaking bootstrap registries that require it).
@@ -610,7 +610,7 @@ async fn fetch_packument(
         request
     })
     .await
-    .map_err(|source| format!("{display_url}: {}", redact_url_credentials(&source.to_string())))?;
+    .map_err(|source| format!("{display_url}: {}", redact_and_sanitize(&source.to_string())))?;
 
     let status = response.status().as_u16();
     if status == 404 {
@@ -632,7 +632,7 @@ async fn fetch_packument(
     let mut body_bytes = Vec::new();
     while let Some(chunk) = stream.next().await {
         let chunk = chunk.map_err(|source| {
-            format!("{display_url}: {}", redact_url_credentials(&source.to_string()))
+            format!("{display_url}: {}", redact_and_sanitize(&source.to_string()))
         })?;
         if (body_bytes.len() + chunk.len()) as u64 > MAX_PACKUMENT_BYTES {
             return Err(format!("{display_url} returned an oversized packument"));

--- a/pnpm/crates/cli/src/cli_args/self_update/verify_engine.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/verify_engine.rs
@@ -479,7 +479,8 @@ async fn attempt_signature_verification(
 /// forms must compare equal — hosts are case-insensitive and default ports
 /// are implied — or a canonical registry written as e.g.
 /// `https://Registry.NPMJS.org:443/` would be misclassified as a different,
-/// non-canonical one, weakening fail-closed decisions keyed on canonicality.
+/// non-canonical one, weakening fail-closed decisions keyed on whether the
+/// registry is the canonical one.
 fn equal_registries(left: &str, right: &str) -> bool {
     normalize_registry_url(left).eq_ignore_ascii_case(&normalize_registry_url(right))
 }

--- a/pnpm/crates/cli/src/cli_args/self_update/verify_engine.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/verify_engine.rs
@@ -343,7 +343,7 @@ async fn find_signature_failure(
             reason,
             category,
             label: label.clone(),
-            registry: component.registry.clone(),
+            registry: redact_url_credentials(&component.registry),
         })
     };
 
@@ -400,8 +400,10 @@ async fn find_signature_failure(
     // observed, the signature was simply unobtainable.
     failure(
         format!(
-            "{}; the fallback registry ({fallback_registry}) could not be consulted either: {}",
-            primary.0, secondary.0,
+            "{}; the fallback registry ({}) could not be consulted either: {}",
+            primary.0,
+            redact_url_credentials(fallback_registry),
+            secondary.0,
         ),
         FailureCategory::Unreachable,
     )
@@ -419,11 +421,14 @@ async fn attempt_signature_verification(
     config: &Config,
 ) -> Option<(String, FailureCategory)> {
     let label = format!("{}@{}", component.name, component.version);
+    // Registry URLs may carry inline `user:pass@` credentials, and the
+    // reasons built here end up in error messages and warnings.
+    let display_registry = redact_url_credentials(registry);
     let packument = match fetch_packument(component, registry, client, retry_opts, config).await {
         Ok(Some(packument)) => packument,
         Ok(None) => {
             return Some((
-                format!("{} is not published on {registry}", component.name),
+                format!("{} is not published on {display_registry}", component.name),
                 FailureCategory::Absent,
             ));
         }
@@ -431,7 +436,10 @@ async fn attempt_signature_verification(
     };
 
     let Some(version) = packument.versions.get(&component.version) else {
-        return Some((format!("{label} was not found on {registry}"), FailureCategory::Absent));
+        return Some((
+            format!("{label} was not found on {display_registry}"),
+            FailureCategory::Absent,
+        ));
     };
     let raw_signatures = version.dist.as_ref().and_then(|dist| dist.signatures.as_ref());
     let parsed_signatures = match raw_signatures {
@@ -459,7 +467,7 @@ async fn attempt_signature_verification(
     };
     if parsed_signatures.is_empty() {
         return Some((
-            format!("{label} has no registry signature on {registry}"),
+            format!("{label} has no registry signature on {display_registry}"),
             FailureCategory::Absent,
         ));
     }
@@ -480,13 +488,15 @@ async fn attempt_signature_verification(
 /// are implied — or a canonical registry written as e.g.
 /// `https://Registry.NPMJS.org:443/` would be misclassified as a different,
 /// non-canonical one, weakening fail-closed decisions keyed on whether the
-/// registry is the canonical one.
+/// registry is the canonical one. Inline `user:pass@` credentials are auth
+/// material, not identity, so they are stripped before comparing for the
+/// same reason.
 fn equal_registries(left: &str, right: &str) -> bool {
     normalize_registry_url(left).eq_ignore_ascii_case(&normalize_registry_url(right))
 }
 
 fn normalize_registry_url(registry: &str) -> String {
-    let with_slash = with_trailing_slash(registry);
+    let with_slash = redact_url_credentials(&with_trailing_slash(registry));
     // URL normalization lowercases the host and drops a default port.
     url::Url::parse(&with_slash).map(String::from).unwrap_or(with_slash)
 }

--- a/pnpm/crates/cli/src/cli_args/self_update/verify_engine.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/verify_engine.rs
@@ -475,8 +475,19 @@ async fn attempt_signature_verification(
     }
 }
 
+/// Whether two registry URLs address the same registry. URL-equivalent
+/// forms must compare equal — hosts are case-insensitive and default ports
+/// are implied — or a canonical registry written as e.g.
+/// `https://Registry.NPMJS.org:443/` would be misclassified as a different,
+/// non-canonical one, weakening fail-closed decisions keyed on canonicality.
 fn equal_registries(left: &str, right: &str) -> bool {
-    with_trailing_slash(left).eq_ignore_ascii_case(&with_trailing_slash(right))
+    normalize_registry_url(left).eq_ignore_ascii_case(&normalize_registry_url(right))
+}
+
+fn normalize_registry_url(registry: &str) -> String {
+    let with_slash = with_trailing_slash(registry);
+    // URL normalization lowercases the host and drops a default port.
+    url::Url::parse(&with_slash).map(String::from).unwrap_or(with_slash)
 }
 
 /// `true` as soon as one signature validates against a trusted, unexpired

--- a/pnpm/crates/cli/src/cli_args/self_update/verify_engine/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/verify_engine/tests.rs
@@ -1,11 +1,14 @@
 use super::{
-    EngineComponent, NpmSigningKey, PackageSignature, native_engine_wrapper, plain_version,
+    EngineComponent, FailureCategory, NpmSigningKey, PackageSignature, SignatureFailure,
+    build_client, find_signature_failure, native_engine_wrapper, plain_version,
     signature_validates_against, verify_one,
 };
 use base64::Engine as _;
 use p256::ecdsa::SigningKey;
+use pacquet_config::Config;
 use pacquet_lockfile::{SnapshotDepRef, SpecifierAndResolution};
-use std::collections::BTreeMap;
+use pacquet_network::RetryOpts;
+use std::{collections::BTreeMap, time::Duration};
 
 fn signing_key() -> SigningKey {
     SigningKey::from_slice(&[0x42; 32]).expect("valid P-256 scalar")
@@ -138,4 +141,158 @@ fn native_engine_wrapper_follows_the_package_that_ships_the_binary() {
     assert_eq!(native_engine_wrapper(&pm_deps(&[("pnpm", "12.0.0")])), Some(("pnpm", "12.0.0")));
     assert_eq!(native_engine_wrapper(&pm_deps(&[("pnpm", "6.16.0")])), None);
     assert_eq!(native_engine_wrapper(&pm_deps(&[])), None);
+}
+
+#[test]
+fn tolerable_without_signature_requires_a_soft_category_and_a_non_canonical_registry() {
+    let failure = |category: FailureCategory, registry: &str| SignatureFailure {
+        label: "pnpm@12.0.0".to_string(),
+        registry: registry.to_string(),
+        reason: "reason".to_string(),
+        category,
+    };
+    let mirror = "https://mirror.example.com/";
+    assert!(failure(FailureCategory::Unreachable, mirror).tolerable_without_signature());
+    assert!(failure(FailureCategory::Uncovered, mirror).tolerable_without_signature());
+    assert!(!failure(FailureCategory::Absent, mirror).tolerable_without_signature());
+    assert!(!failure(FailureCategory::Invalid, mirror).tolerable_without_signature());
+    // The canonical registry always provides signatures for genuine
+    // releases, so nothing is tolerated there.
+    let canonical = "https://registry.npmjs.org";
+    assert!(!failure(FailureCategory::Unreachable, canonical).tolerable_without_signature());
+    assert!(!failure(FailureCategory::Uncovered, canonical).tolerable_without_signature());
+}
+
+fn no_retry() -> RetryOpts {
+    RetryOpts {
+        retries: 0,
+        factor: 2,
+        min_timeout: Duration::from_millis(1),
+        max_timeout: Duration::from_millis(1),
+    }
+}
+
+fn packument_body(name: &str, version: &str, signatures_json: &str) -> String {
+    format!(
+        r#"{{"name":"{name}","time":{{"{version}":"2024-01-01T00:00:00.000Z"}},"versions":{{"{version}":{{"dist":{{"signatures":{signatures_json}}}}}}}}}"#,
+    )
+}
+
+async fn mock_packument(server: &mut mockito::ServerGuard, signatures_json: &str) -> mockito::Mock {
+    server
+        .mock("GET", "/pnpm")
+        .with_status(200)
+        .with_body(packument_body("pnpm", "12.0.0", signatures_json))
+        .create_async()
+        .await
+}
+
+fn signatures_json(key: &SigningKey, message: &str) -> String {
+    format!(r#"[{{"keyid":"SHA256:test","sig":"{}"}}]"#, sign_b64(key, message))
+}
+
+/// `find_signature_failure` against a mirror at `server` and a fallback at
+/// `fallback_registry`, trusting only the test key.
+async fn find_failure_with_fallback(
+    component: &EngineComponent,
+    fallback_registry: &str,
+) -> Option<SignatureFailure> {
+    let key = signing_key();
+    let pub_b64 = public_key_b64(&key);
+    let keys = [NpmSigningKey { keyid: "SHA256:test", key: &pub_b64, expires: None }];
+    let config = Config::default();
+    let client = build_client(&config).expect("build client");
+    find_signature_failure(component, fallback_registry, &keys, &client, no_retry(), &config).await
+}
+
+#[tokio::test]
+async fn falls_back_to_the_canonical_registry_when_the_mirror_serves_no_signatures() {
+    let mut mirror = mockito::Server::new_async().await;
+    let mut fallback = mockito::Server::new_async().await;
+    let component = EngineComponent { registry: format!("{}/", mirror.url()), ..component() };
+    let _mirror = mock_packument(&mut mirror, "[]").await;
+    let _fallback = mock_packument(
+        &mut fallback,
+        &signatures_json(&signing_key(), &signed_message(&component)),
+    )
+    .await;
+
+    let failure = find_failure_with_fallback(&component, &fallback.url()).await;
+    assert!(failure.is_none(), "expected a fallback pass, got {:?}", failure.map(|f| f.reason));
+}
+
+#[tokio::test]
+async fn a_fallback_signature_still_fails_over_a_tampered_integrity() {
+    let mut mirror = mockito::Server::new_async().await;
+    let mut fallback = mockito::Server::new_async().await;
+    let component = EngineComponent { registry: format!("{}/", mirror.url()), ..component() };
+    let _mirror = mock_packument(&mut mirror, "[]").await;
+    // The fallback signed different bytes than the lockfile pins.
+    let _fallback = mock_packument(
+        &mut fallback,
+        &signatures_json(&signing_key(), "pnpm@12.0.0:sha512-genuine"),
+    )
+    .await;
+
+    let failure =
+        find_failure_with_fallback(&component, &fallback.url()).await.expect("failure expected");
+    assert!(matches!(failure.category, FailureCategory::Invalid));
+}
+
+#[tokio::test]
+async fn reports_unreachable_when_neither_registry_can_provide_a_signature() {
+    let mut mirror = mockito::Server::new_async().await;
+    let component = EngineComponent { registry: format!("{}/", mirror.url()), ..component() };
+    let _mirror = mock_packument(&mut mirror, "[]").await;
+
+    // Nothing listens on the fallback address, so consulting it fails.
+    let failure = find_failure_with_fallback(&component, "http://127.0.0.1:9/")
+        .await
+        .expect("failure expected");
+    assert!(matches!(failure.category, FailureCategory::Unreachable));
+    assert!(failure.reason.contains("127.0.0.1:9"), "unexpected reason: {}", failure.reason);
+}
+
+#[tokio::test]
+async fn reports_absent_when_a_reachable_fallback_has_no_signed_release() {
+    let mut mirror = mockito::Server::new_async().await;
+    let mut fallback = mockito::Server::new_async().await;
+    let component = EngineComponent { registry: format!("{}/", mirror.url()), ..component() };
+    let _mirror = mock_packument(&mut mirror, "[]").await;
+    let _fallback = fallback.mock("GET", "/pnpm").with_status(404).create_async().await;
+
+    let failure =
+        find_failure_with_fallback(&component, &fallback.url()).await.expect("failure expected");
+    assert!(matches!(failure.category, FailureCategory::Absent));
+}
+
+#[tokio::test]
+async fn verifies_via_the_fallback_when_the_mirror_serves_an_unusable_signature() {
+    let mut mirror = mockito::Server::new_async().await;
+    let mut fallback = mockito::Server::new_async().await;
+    let component = EngineComponent { registry: format!("{}/", mirror.url()), ..component() };
+    // e.g. a mirror caching a stale signature from a rotated-out key
+    let _mirror =
+        mock_packument(&mut mirror, r#"[{"keyid":"SHA256:rotated-out","sig":"c3RhbGU="}]"#).await;
+    let _fallback = mock_packument(
+        &mut fallback,
+        &signatures_json(&signing_key(), &signed_message(&component)),
+    )
+    .await;
+
+    let failure = find_failure_with_fallback(&component, &fallback.url()).await;
+    assert!(failure.is_none(), "expected a fallback pass, got {:?}", failure.map(|f| f.reason));
+}
+
+#[tokio::test]
+async fn reports_a_non_sha512_integrity_as_uncovered_without_consulting_any_registry() {
+    // No servers are mocked: the category is decided before any fetch.
+    let component = EngineComponent {
+        integrity: "sha1-i+4AKGoXwAoTx+bm3ZqbOJIg7n8=".to_string(),
+        ..component()
+    };
+    let failure = find_failure_with_fallback(&component, "http://127.0.0.1:9/")
+        .await
+        .expect("failure expected");
+    assert!(matches!(failure.category, FailureCategory::Uncovered));
 }

--- a/pnpm/crates/cli/src/cli_args/self_update/verify_engine/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/verify_engine/tests.rs
@@ -163,6 +163,7 @@ fn tolerable_without_signature_requires_a_soft_category_and_a_non_canonical_regi
         "https://registry.npmjs.org",
         "https://Registry.NPMJS.org:443/",
         "https://registry.npmjs.org:443",
+        "https://user:pass@registry.npmjs.org/",
     ] {
         assert!(
             !failure(FailureCategory::Unreachable, canonical).tolerable_without_signature(),

--- a/pnpm/crates/cli/src/cli_args/self_update/verify_engine/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/verify_engine/tests.rs
@@ -164,6 +164,7 @@ fn tolerable_without_signature_requires_a_soft_category_and_a_non_canonical_regi
         "https://Registry.NPMJS.org:443/",
         "https://registry.npmjs.org:443",
         "https://user:pass@registry.npmjs.org/",
+        "https://user:p\rass@registry.npmjs.org/",
     ] {
         assert!(
             !failure(FailureCategory::Unreachable, canonical).tolerable_without_signature(),

--- a/pnpm/crates/cli/src/cli_args/self_update/verify_engine/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/verify_engine/tests.rs
@@ -157,10 +157,19 @@ fn tolerable_without_signature_requires_a_soft_category_and_a_non_canonical_regi
     assert!(!failure(FailureCategory::Absent, mirror).tolerable_without_signature());
     assert!(!failure(FailureCategory::Invalid, mirror).tolerable_without_signature());
     // The canonical registry always provides signatures for genuine
-    // releases, so nothing is tolerated there.
-    let canonical = "https://registry.npmjs.org";
-    assert!(!failure(FailureCategory::Unreachable, canonical).tolerable_without_signature());
-    assert!(!failure(FailureCategory::Uncovered, canonical).tolerable_without_signature());
+    // releases, so nothing is tolerated there — under any URL-equivalent
+    // spelling of it.
+    for canonical in [
+        "https://registry.npmjs.org",
+        "https://Registry.NPMJS.org:443/",
+        "https://registry.npmjs.org:443",
+    ] {
+        assert!(
+            !failure(FailureCategory::Unreachable, canonical).tolerable_without_signature(),
+            "{canonical} must count as canonical",
+        );
+        assert!(!failure(FailureCategory::Uncovered, canonical).tolerable_without_signature());
+    }
 }
 
 fn no_retry() -> RetryOpts {

--- a/pnpm/crates/cli/src/cli_args/with.rs
+++ b/pnpm/crates/cli/src/cli_args/with.rs
@@ -87,6 +87,7 @@ impl WithArgs {
             &env_root,
             spec,
             &resolved.version,
+            false,
         ))
         .await?;
 

--- a/pnpm/crates/cli/src/cli_args/with/install_pnpm_to_store.rs
+++ b/pnpm/crates/cli/src/cli_args/with/install_pnpm_to_store.rs
@@ -44,11 +44,14 @@ use crate::{
 /// `pnpm` + `@pnpm/exe` closure) is written, under the pnpm home
 /// directory. `spec` is the user's bare specifier (a version, range,
 /// or dist-tag) and `version` the exact version it resolved to.
+/// `force_resync` discards recorded `packageManagerDependencies` and
+/// re-resolves them even when they look up to date.
 pub(crate) async fn install_pnpm_to_store<Reporter: self::Reporter + 'static>(
     config: &'static Config,
     env_root: &Path,
     spec: &str,
     version: &str,
+    force_resync: bool,
 ) -> miette::Result<PathBuf> {
     let config = package_manager_engine_config(config)?.leak();
     fs::create_dir_all(env_root).into_diagnostic().wrap_err_with(|| {
@@ -57,9 +60,17 @@ pub(crate) async fn install_pnpm_to_store<Reporter: self::Reporter + 'static>(
     let env = {
         let _lock = package_manager_env_lock::<Reporter>(config).await?;
         // Resolve the package-manager closure into the env lockfile (a no-op
-        // when this spec+version is already recorded there).
-        config_deps::sync_package_manager_dependencies(config, env_root, spec, version, false)
-            .await?;
+        // when this spec+version is already recorded there and a resync is
+        // not forced).
+        config_deps::sync_package_manager_dependencies(
+            config,
+            env_root,
+            spec,
+            version,
+            false,
+            force_resync,
+        )
+        .await?;
         EnvLockfile::read(env_root)
             .map_err(miette::Report::new)
             .wrap_err("read the package-manager env lockfile")?
@@ -124,10 +135,17 @@ async fn install_pnpm_from_env_with_config<Reporter: self::Reporter + 'static>(
 
     // Genuine download: verify the engine's registry signature before
     // installing or executing it.
-    verify_pnpm_engine_identity(env, version, config)
+    if let Some(warning) = verify_pnpm_engine_identity(env, version, config)
         .await
         .map_err(miette::Report::new)
-        .wrap_err("verify the pnpm engine identity")?;
+        .wrap_err("verify the pnpm engine identity")?
+    {
+        Reporter::emit(&LogEvent::Pnpm(PnpmLog {
+            level: LogLevel::Warn,
+            message: warning,
+            prefix: String::new(),
+        }));
+    }
 
     // Install into a throwaway directory with the global virtual store
     // enabled, so the engine itself materializes in `<store>/links/...`

--- a/pnpm/crates/cli/src/config_deps.rs
+++ b/pnpm/crates/cli/src/config_deps.rs
@@ -53,20 +53,28 @@ pub async fn install_config_deps<Reporter: self::Reporter>(
 
 /// Resolve the package-manager engine dependencies into the env lockfile's
 /// `packageManagerDependencies` block before the wanted lockfile is
-/// loaded.
+/// loaded. `force_resync` discards recorded entries and re-resolves them
+/// even when they look up to date.
 pub async fn sync_package_manager_dependencies(
     config: &Config,
     root_dir: &Path,
     wanted_specifier: &str,
     pnpm_version: &str,
     frozen_lockfile: bool,
+    force_resync: bool,
 ) -> Result<()> {
     let context = EnvInstallerContext::for_package_manager(config)?;
     let options = context.options(root_dir, frozen_lockfile);
-    resolve_package_manager_integrities(wanted_specifier, pnpm_version, &context.resolver, &options)
-        .await
-        .map_err(miette::Report::new)
-        .wrap_err("resolve package manager dependencies")
+    resolve_package_manager_integrities(
+        wanted_specifier,
+        pnpm_version,
+        &context.resolver,
+        &options,
+        force_resync,
+    )
+    .await
+    .map_err(miette::Report::new)
+    .wrap_err("resolve package manager dependencies")
 }
 
 /// The version `pnpm self-update` resolved a specifier to, plus whether

--- a/pnpm/crates/env-installer/src/resolve_package_manager_integrities.rs
+++ b/pnpm/crates/env-installer/src/resolve_package_manager_integrities.rs
@@ -7,8 +7,8 @@ use crate::{
     verify_env_lockfile::write_verified_env_lockfile,
 };
 use pacquet_lockfile::{
-    EnvLockfile, PackageKey, PkgName, PkgVerPeer, SnapshotDepRef, SnapshotEntry,
-    SpecifierAndResolution,
+    EnvLockfile, LockfileResolution, PackageKey, PkgName, PkgVerPeer, RegistryResolution,
+    SnapshotDepRef, SnapshotEntry, SpecifierAndResolution, TarballResolution,
 };
 use pacquet_resolving_resolver_base::{ResolveOptions, ResolveResult, Resolver, WantedDependency};
 use std::{collections::HashMap, path::PathBuf};
@@ -17,22 +17,28 @@ const PACKAGE_MANAGER_DEPS_WITH_EXE: [&str; 2] = ["pnpm", "@pnpm/exe"];
 const PACKAGE_MANAGER_DEPS_PNPM_ONLY: [&str; 1] = ["pnpm"];
 const PNPM_EXE_INTRODUCED: (u64, u64, u64) = (6, 17, 1);
 
+/// `force_resync` skips the recorded-entries fast path, so entries that look
+/// up to date but are invalid (e.g. resolutions carrying tarball URLs
+/// written by an earlier pnpm) are discarded and re-resolved.
 pub async fn resolve_package_manager_integrities(
     wanted_specifier: &str,
     pnpm_version: &str,
     resolver: &dyn Resolver,
     opts: &ConfigDepsInstallOptions<'_>,
+    force_resync: bool,
 ) -> Result<(), ConfigDepError> {
     let mut env_lockfile = EnvLockfile::read(opts.root_dir)
         .map_err(ConfigDepError::ReadLockfile)?
         .unwrap_or_else(EnvLockfile::create);
     let package_manager_deps = package_manager_deps(pnpm_version);
-    if is_package_manager_resolved_with_deps(
-        &env_lockfile,
-        wanted_specifier,
-        pnpm_version,
-        package_manager_deps,
-    ) {
+    if !force_resync
+        && is_package_manager_resolved_with_deps(
+            &env_lockfile,
+            wanted_specifier,
+            pnpm_version,
+            package_manager_deps,
+        )
+    {
         return Ok(());
     }
     if opts.frozen_lockfile {
@@ -69,10 +75,10 @@ pub async fn resolve_package_manager_integrities(
             continue;
         }
         let registry = opts.pick_registry(&package.name);
-        env_lockfile.packages.insert(
-            package.key.clone(),
-            package_metadata(&package.name, &package.version, &package.result, registry, false),
-        );
+        let mut metadata =
+            package_metadata(&package.name, &package.version, &package.result, registry, false);
+        metadata.resolution = strip_registry_tarball_url(metadata.resolution);
+        env_lockfile.packages.insert(package.key.clone(), metadata);
 
         let manifest = package.result.manifest.as_deref();
         let mut dependencies = HashMap::new();
@@ -103,6 +109,29 @@ pub async fn resolve_package_manager_integrities(
 
     prune_env_lockfile(&mut env_lockfile);
     write_verified_env_lockfile(&env_lockfile, opts.root_dir)
+}
+
+/// Rewrite a registry tarball resolution to integrity-only form, dropping
+/// tarball URLs a registry advertises on a host other than its own —
+/// load-balanced proxies and Artifactory-style mirrors do this, see
+/// <https://github.com/pnpm/pnpm/issues/13619>. The package-manager
+/// bootstrap never fetches a URL recorded in the lockfile: the download URL
+/// is always derived from the trusted bootstrap registries at install time,
+/// so a repository-provided entry cannot steer the download. Dropping the
+/// URL here keeps freshly resolved entries in exactly the integrity-only
+/// shape the bootstrap validation accepts.
+fn strip_registry_tarball_url(resolution: LockfileResolution) -> LockfileResolution {
+    match resolution {
+        LockfileResolution::Tarball(TarballResolution {
+            tarball,
+            integrity: Some(integrity),
+            git_hosted: None | Some(false),
+            path: None,
+        }) if !tarball.starts_with("file:") => {
+            LockfileResolution::Registry(RegistryResolution { integrity })
+        }
+        other => other,
+    }
 }
 
 #[must_use]

--- a/pnpm/crates/env-installer/src/tests.rs
+++ b/pnpm/crates/env-installer/src/tests.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use pacquet_lockfile::{
     EnvLockfile, LockfileResolution, PackageKey, PackageMetadata, RegistryResolution,
-    SnapshotDepRef, SnapshotEntry, SpecifierAndResolution,
+    SnapshotDepRef, SnapshotEntry, SpecifierAndResolution, TarballResolution,
 };
 use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient};
 use pacquet_reporter::{InstallingConfigDepsStatus, LogEvent, Reporter, SilentReporter};
@@ -132,6 +132,10 @@ fn clean_spec(version: &str) -> ConfigDependency {
 #[derive(Default)]
 struct FixtureResolver {
     packages: HashMap<(String, String), serde_json::Value>,
+    /// Resolve to tarball resolutions whose URL is not derivable from the
+    /// registry — the shape a load-balanced proxy or Artifactory-style
+    /// mirror produces.
+    non_derivable_tarball_urls: bool,
 }
 
 impl FixtureResolver {
@@ -143,6 +147,11 @@ impl FixtureResolver {
         let name = manifest["name"].as_str().expect("fixture package name").to_string();
         let version = manifest["version"].as_str().expect("fixture package version").to_string();
         self.packages.insert((name, version), manifest);
+        self
+    }
+
+    fn with_non_derivable_tarball_urls(mut self) -> Self {
+        self.non_derivable_tarball_urls = true;
         self
     }
 }
@@ -172,12 +181,23 @@ impl Resolver for FixtureResolver {
             Ok(Some(ResolveResult {
                 id: PkgResolutionId::from(id.as_str()),
                 name_ver: Some(id.parse().expect("fixture name/version parses")),
-                latest: Some(version),
+                latest: Some(version.clone()),
                 published_at: None,
                 manifest: Some(Arc::new(manifest)),
-                resolution: LockfileResolution::Registry(RegistryResolution {
-                    integrity: ssri::Integrity::from(id.as_bytes()),
-                }),
+                resolution: if self.non_derivable_tarball_urls {
+                    LockfileResolution::Tarball(TarballResolution {
+                        tarball: format!(
+                            "https://mirror-pool-7.example.com/registry/{name}/-/{name}-{version}.tgz",
+                        ),
+                        integrity: Some(ssri::Integrity::from(id.as_bytes())),
+                        git_hosted: None,
+                        path: None,
+                    })
+                } else {
+                    LockfileResolution::Registry(RegistryResolution {
+                        integrity: ssri::Integrity::from(id.as_bytes()),
+                    })
+                },
                 resolved_via: "npm-registry".to_string(),
                 normalized_bare_specifier: Some(specifier.to_string()),
                 alias: Some(alias.to_string()),
@@ -297,6 +317,7 @@ async fn resolves_package_manager_dependencies_graph() {
         "11.0.0",
         &resolver,
         &options(&harness, root.path(), false),
+        false,
     )
     .await
     .unwrap();
@@ -351,6 +372,95 @@ async fn resolves_package_manager_dependencies_graph() {
     assert!(!is_package_manager_resolved(&env_with_extra_pm_dep, "^11.0.0", "11.0.0",));
 }
 
+/// A registry that advertises tarballs on another host (a load-balanced
+/// proxy or Artifactory-style mirror) must still yield integrity-only
+/// package-manager entries, or the bootstrap validation rejects them.
+/// See <https://github.com/pnpm/pnpm/issues/13619>.
+#[tokio::test]
+async fn records_integrity_only_resolutions_for_non_derivable_tarball_urls() {
+    let harness = harness();
+    let root = TempDir::new().unwrap();
+    let resolver = FixtureResolver::new()
+        .with_non_derivable_tarball_urls()
+        .package(serde_json::json!({
+            "name": "pnpm",
+            "version": "11.0.0",
+            "bin": "bin/pnpm.cjs",
+        }))
+        .package(serde_json::json!({
+            "name": "@pnpm/exe",
+            "version": "11.0.0",
+            "bin": { "pnpm": "bin/pnpm.cjs" },
+            "optionalDependencies": { "@pnpm/linuxstatic-x64": "11.0.0" },
+        }))
+        .package(serde_json::json!({
+            "name": "@pnpm/linuxstatic-x64",
+            "version": "11.0.0",
+        }));
+
+    resolve_package_manager_integrities(
+        "^11.0.0",
+        "11.0.0",
+        &resolver,
+        &options(&harness, root.path(), false),
+        false,
+    )
+    .await
+    .unwrap();
+
+    let env = EnvLockfile::read(root.path()).unwrap().expect("env lockfile written");
+    for (key, metadata) in &env.packages {
+        assert!(
+            matches!(&metadata.resolution, LockfileResolution::Registry(resolution) if !resolution.integrity.to_string().is_empty()),
+            "expected an integrity-only resolution for {key}, got {:?}",
+            metadata.resolution,
+        );
+    }
+}
+
+/// `force_resync` discards recorded entries that look up to date, so
+/// invalid resolutions written by an earlier pnpm are healed instead of
+/// surviving the fast path.
+#[tokio::test]
+async fn force_resync_overwrites_recorded_package_manager_entries() {
+    let harness = harness();
+    let root = TempDir::new().unwrap();
+    let fixtures = || {
+        FixtureResolver::new().package(serde_json::json!({
+            "name": "pnpm",
+            "version": "12.0.0",
+            "bin": "bin/pnpm.cjs",
+        }))
+    };
+
+    resolve_package_manager_integrities(
+        "^12.0.0",
+        "12.0.0",
+        &fixtures().with_non_derivable_tarball_urls(),
+        &options(&harness, root.path(), false),
+        false,
+    )
+    .await
+    .unwrap();
+    let env = EnvLockfile::read(root.path()).unwrap().expect("env lockfile written");
+    assert!(is_package_manager_resolved(&env, "^12.0.0", "12.0.0"));
+
+    // Without force, the recorded entries short-circuit resolution; with
+    // force, they are re-resolved and rewritten.
+    resolve_package_manager_integrities(
+        "^12.0.0",
+        "12.0.0",
+        &fixtures(),
+        &options(&harness, root.path(), false),
+        true,
+    )
+    .await
+    .unwrap();
+    let env = EnvLockfile::read(root.path()).unwrap().expect("env lockfile written");
+    let key: PackageKey = "pnpm@12.0.0".parse().unwrap();
+    assert!(matches!(&env.packages[&key].resolution, LockfileResolution::Registry(_)));
+}
+
 #[tokio::test]
 async fn resolves_package_manager_dependencies_without_exe_from_v12() {
     let harness = harness();
@@ -374,6 +484,7 @@ async fn resolves_package_manager_dependencies_without_exe_from_v12() {
         "12.0.0",
         &resolver,
         &options(&harness, root.path(), false),
+        false,
     )
     .await
     .unwrap();
@@ -416,6 +527,7 @@ async fn resolves_package_manager_dependencies_without_exe_before_it_was_publish
         "6.16.0",
         &resolver,
         &options(&harness, root.path(), false),
+        false,
     )
     .await
     .unwrap();
@@ -465,6 +577,7 @@ async fn resolves_package_manager_dependencies_with_exe_at_first_published_versi
         "6.17.1",
         &resolver,
         &options(&harness, root.path(), false),
+        false,
     )
     .await
     .unwrap();

--- a/pnpm11/deps/security/signatures/src/verifySignatures.ts
+++ b/pnpm11/deps/security/signatures/src/verifySignatures.ts
@@ -574,10 +574,23 @@ async function attemptSignatureVerification (
   return issue == null ? undefined : { reason: issue.reason ?? 'invalid registry signature', category: 'invalid' }
 }
 
-function equalRegistries (a: string, b: string): boolean {
+/**
+ * Whether two registry URLs address the same registry. URL-equivalent forms
+ * must compare equal — hosts are case-insensitive and default ports are
+ * implied — or a canonical registry written as e.g.
+ * `https://Registry.NPMJS.org:443/` would be misclassified as a different,
+ * non-canonical one, weakening fail-closed decisions keyed on canonicality.
+ */
+export function equalRegistries (a: string, b: string): boolean {
   return normalizeRegistryUrl(a) === normalizeRegistryUrl(b)
 }
 
 function normalizeRegistryUrl (registry: string): string {
-  return (registry.endsWith('/') ? registry : `${registry}/`).toLowerCase()
+  const withSlash = registry.endsWith('/') ? registry : `${registry}/`
+  try {
+    // URL normalization lowercases the host and drops a default port.
+    return new url.URL(withSlash).toString().toLowerCase()
+  } catch {
+    return withSlash.toLowerCase()
+  }
 }

--- a/pnpm11/deps/security/signatures/src/verifySignatures.ts
+++ b/pnpm11/deps/security/signatures/src/verifySignatures.ts
@@ -470,12 +470,17 @@ export async function verifyInstalledPackageSignatures (
   getAuthHeader: GetAuthHeader,
   opts: VerifyInstalledSignaturesOptions
 ): Promise<InstalledSignatureVerificationResult> {
-  const packumentCache = new Map<string, Promise<Packument | undefined>>()
+  const ctx: SignatureVerificationContext = {
+    trustedKeys,
+    getAuthHeader,
+    opts,
+    packumentCache: new Map(),
+  }
   const limit = pLimit(opts.networkConcurrency ?? 16)
 
   const failures: InstalledSignatureFailure[] = []
   await Promise.all(packages.map((pkg) => limit(async () => {
-    const failure = await findSignatureFailure(pkg, trustedKeys, getAuthHeader, opts, packumentCache)
+    const failure = await findSignatureFailure(pkg, ctx)
     if (failure != null) {
       failures.push({ name: pkg.name, version: pkg.version, registry: pkg.registry, ...failure })
     }
@@ -485,12 +490,17 @@ export async function verifyInstalledPackageSignatures (
   return { verified: failures.length === 0, failures }
 }
 
+/** State shared by every verification of one installed-package batch. */
+interface SignatureVerificationContext {
+  trustedKeys: RegistryKey[]
+  getAuthHeader: GetAuthHeader
+  opts: VerifyInstalledSignaturesOptions
+  packumentCache: Map<string, Promise<Packument | undefined>>
+}
+
 async function findSignatureFailure (
   pkg: InstalledPackageToVerify,
-  trustedKeys: RegistryKey[],
-  getAuthHeader: GetAuthHeader,
-  opts: VerifyInstalledSignaturesOptions,
-  packumentCache: Map<string, Promise<Packument | undefined>>
+  ctx: SignatureVerificationContext
 ): Promise<{ reason: string, category: SignatureFailureCategory } | undefined> {
   // npm registry signatures sign `name@version:integrity` with the sha512
   // integrity the registry published. An installed integrity in any other form
@@ -504,13 +514,13 @@ async function findSignatureFailure (
     }
   }
 
-  const primary = await attemptSignatureVerification(pkg, pkg.registry, trustedKeys, getAuthHeader, opts, packumentCache)
+  const primary = await attemptSignatureVerification(pkg, pkg.registry, ctx)
   if (primary == null) return undefined
 
-  const { fallbackRegistry } = opts
+  const { fallbackRegistry } = ctx.opts
   if (fallbackRegistry == null || equalRegistries(pkg.registry, fallbackRegistry)) return primary
 
-  const secondary = await attemptSignatureVerification(pkg, fallbackRegistry, trustedKeys, getAuthHeader, opts, packumentCache)
+  const secondary = await attemptSignatureVerification(pkg, fallbackRegistry, ctx)
   // A genuine signature validating over the installed integrity proves the
   // installed bytes regardless of which registry the primary attempt hit or
   // what it answered (e.g. a mirror serving stale signatures from a rotated
@@ -537,14 +547,11 @@ async function findSignatureFailure (
 async function attemptSignatureVerification (
   pkg: InstalledPackageToVerify,
   registry: string,
-  trustedKeys: RegistryKey[],
-  getAuthHeader: GetAuthHeader,
-  opts: VerifySignaturesOptions,
-  packumentCache: Map<string, Promise<Packument | undefined>>
+  ctx: SignatureVerificationContext
 ): Promise<{ reason: string, category: SignatureFailureCategory } | undefined> {
   let packument: Packument | undefined
   try {
-    packument = await getPackument({ ...pkg, registry }, getAuthHeader, opts, packumentCache)
+    packument = await getPackument({ ...pkg, registry }, ctx.getAuthHeader, ctx.opts, ctx.packumentCache)
   } catch (err: unknown) {
     return { reason: util.types.isNativeError(err) ? err.message : String(err), category: 'unreachable' }
   }
@@ -569,7 +576,7 @@ async function attemptSignatureVerification (
   // validates when the installed bytes match what the registry signed.
   const issue = verifyPackageSignatures(
     { ...pkg, integrity: pkg.integrity, publishedAt: packument.time?.[pkg.version], signatures },
-    trustedKeys
+    ctx.trustedKeys
   )
   return issue == null ? undefined : { reason: issue.reason ?? 'invalid registry signature', category: 'invalid' }
 }

--- a/pnpm11/deps/security/signatures/src/verifySignatures.ts
+++ b/pnpm11/deps/security/signatures/src/verifySignatures.ts
@@ -579,7 +579,8 @@ async function attemptSignatureVerification (
  * must compare equal — hosts are case-insensitive and default ports are
  * implied — or a canonical registry written as e.g.
  * `https://Registry.NPMJS.org:443/` would be misclassified as a different,
- * non-canonical one, weakening fail-closed decisions keyed on canonicality.
+ * non-canonical one, weakening fail-closed decisions keyed on whether the
+ * registry is the canonical one.
  */
 export function equalRegistries (a: string, b: string): boolean {
   return normalizeRegistryUrl(a) === normalizeRegistryUrl(b)

--- a/pnpm11/deps/security/signatures/src/verifySignatures.ts
+++ b/pnpm11/deps/security/signatures/src/verifySignatures.ts
@@ -412,12 +412,18 @@ export interface InstalledPackageToVerify {
  * - `unreachable`: the trust root could not be consulted (registry advertised no
  *   signing keys, or the network request failed) — typically transient/offline,
  *   not evidence of tampering.
+ * - `uncovered`: the installed integrity is not a sha512 hash (e.g. a sha1 pin
+ *   from a registry that only publishes `shasum`), so no npm registry signature
+ *   can ever validate over it — verification is impossible by construction,
+ *   not evidence of tampering.
  */
-export type SignatureFailureCategory = 'invalid' | 'absent' | 'unreachable'
+export type SignatureFailureCategory = 'invalid' | 'absent' | 'unreachable' | 'uncovered'
 
 export interface InstalledSignatureFailure {
   name: string
   version: string
+  /** The registry the package was installed from (see {@link InstalledPackageToVerify.registry}). */
+  registry: string
   reason: string
   category: SignatureFailureCategory
 }
@@ -445,11 +451,24 @@ export interface InstalledSignatureVerificationResult {
  * A package counts as a failure when the package is unsigned/unpublished, or
  * when a signature is present but does not validate over the installed bytes.
  */
+export interface VerifyInstalledSignaturesOptions extends VerifySignaturesOptions {
+  /**
+   * A registry to consult for signature metadata when a package's own registry
+   * cannot provide a verifiable signature (its packument omits `dist.signatures`,
+   * as private mirrors commonly do, or carries only a stale/broken one).
+   * Signatures are verified against the caller's trusted keys over the installed
+   * integrity, so where the signature bytes come from does not affect what they
+   * prove — a package passes only when some genuine signature validates over the
+   * bytes actually installed. See https://github.com/pnpm/pnpm/issues/13147.
+   */
+  fallbackRegistry?: string
+}
+
 export async function verifyInstalledPackageSignatures (
   packages: InstalledPackageToVerify[],
   trustedKeys: RegistryKey[],
   getAuthHeader: GetAuthHeader,
-  opts: VerifySignaturesOptions
+  opts: VerifyInstalledSignaturesOptions
 ): Promise<InstalledSignatureVerificationResult> {
   const packumentCache = new Map<string, Promise<Packument | undefined>>()
   const limit = pLimit(opts.networkConcurrency ?? 16)
@@ -458,7 +477,7 @@ export async function verifyInstalledPackageSignatures (
   await Promise.all(packages.map((pkg) => limit(async () => {
     const failure = await findSignatureFailure(pkg, trustedKeys, getAuthHeader, opts, packumentCache)
     if (failure != null) {
-      failures.push({ name: pkg.name, version: pkg.version, ...failure })
+      failures.push({ name: pkg.name, version: pkg.version, registry: pkg.registry, ...failure })
     }
   })))
 
@@ -470,19 +489,69 @@ async function findSignatureFailure (
   pkg: InstalledPackageToVerify,
   trustedKeys: RegistryKey[],
   getAuthHeader: GetAuthHeader,
+  opts: VerifyInstalledSignaturesOptions,
+  packumentCache: Map<string, Promise<Packument | undefined>>
+): Promise<{ reason: string, category: SignatureFailureCategory } | undefined> {
+  // npm registry signatures sign `name@version:integrity` with the sha512
+  // integrity the registry published. An installed integrity in any other form
+  // (a sha1 pin converted from `shasum` by a registry that publishes no
+  // `integrity`) can never validate against a genuine signature, so verifying
+  // it would misreport an authentic release as tampered with.
+  if (!pkg.integrity.startsWith('sha512-')) {
+    return {
+      reason: `${pkg.name}@${pkg.version} is pinned by a non-sha512 integrity, which npm registry signatures cannot cover`,
+      category: 'uncovered',
+    }
+  }
+
+  const primary = await attemptSignatureVerification(pkg, pkg.registry, trustedKeys, getAuthHeader, opts, packumentCache)
+  if (primary == null) return undefined
+
+  const { fallbackRegistry } = opts
+  if (fallbackRegistry == null || equalRegistries(pkg.registry, fallbackRegistry)) return primary
+
+  const secondary = await attemptSignatureVerification(pkg, fallbackRegistry, trustedKeys, getAuthHeader, opts, packumentCache)
+  // A genuine signature validating over the installed integrity proves the
+  // installed bytes regardless of which registry the primary attempt hit or
+  // what it answered (e.g. a mirror serving stale signatures from a rotated
+  // key), so a fallback pass is a pass.
+  if (secondary == null) return undefined
+
+  // A well-formed signature that fails to validate is a tamper signal from
+  // either source; surface it over the softer categories.
+  if (primary.category === 'invalid') return primary
+  if (secondary.category !== 'unreachable') return secondary
+  // The primary registry had no usable signature (a mirror commonly serves
+  // none) and the fallback could not be consulted — nothing suspicious was
+  // observed, the signature was simply unobtainable.
+  return {
+    reason: `${primary.reason}; the fallback registry (${fallbackRegistry}) could not be consulted either: ${secondary.reason}`,
+    category: 'unreachable',
+  }
+}
+
+/**
+ * Verifies `pkg`'s installed integrity against the signatures the packument on
+ * `registry` carries. Returns `undefined` on success, otherwise the failure.
+ */
+async function attemptSignatureVerification (
+  pkg: InstalledPackageToVerify,
+  registry: string,
+  trustedKeys: RegistryKey[],
+  getAuthHeader: GetAuthHeader,
   opts: VerifySignaturesOptions,
   packumentCache: Map<string, Promise<Packument | undefined>>
 ): Promise<{ reason: string, category: SignatureFailureCategory } | undefined> {
   let packument: Packument | undefined
   try {
-    packument = await getPackument(pkg, getAuthHeader, opts, packumentCache)
+    packument = await getPackument({ ...pkg, registry }, getAuthHeader, opts, packumentCache)
   } catch (err: unknown) {
     return { reason: util.types.isNativeError(err) ? err.message : String(err), category: 'unreachable' }
   }
-  if (!packument) return { reason: `${pkg.name} is not published on ${pkg.registry}`, category: 'absent' }
+  if (!packument) return { reason: `${pkg.name} is not published on ${registry}`, category: 'absent' }
 
   const version = packument.versions?.[pkg.version]
-  if (!version) return { reason: `${pkg.name}@${pkg.version} was not found on ${pkg.registry}`, category: 'absent' }
+  if (!version) return { reason: `${pkg.name}@${pkg.version} was not found on ${registry}`, category: 'absent' }
 
   const rawSignatures = version.dist?.signatures
   if (rawSignatures != null && !Array.isArray(rawSignatures)) {
@@ -493,7 +562,7 @@ async function findSignatureFailure (
     return { reason: `malformed registry signatures metadata for ${pkg.name}@${pkg.version}`, category: 'absent' }
   }
   if (signatures.length === 0) {
-    return { reason: `${pkg.name}@${pkg.version} has no registry signature`, category: 'absent' }
+    return { reason: `${pkg.name}@${pkg.version} has no registry signature on ${registry}`, category: 'absent' }
   }
 
   // The message is built from the installed integrity, so a signature only
@@ -503,4 +572,12 @@ async function findSignatureFailure (
     trustedKeys
   )
   return issue == null ? undefined : { reason: issue.reason ?? 'invalid registry signature', category: 'invalid' }
+}
+
+function equalRegistries (a: string, b: string): boolean {
+  return normalizeRegistryUrl(a) === normalizeRegistryUrl(b)
+}
+
+function normalizeRegistryUrl (registry: string): string {
+  return (registry.endsWith('/') ? registry : `${registry}/`).toLowerCase()
 }

--- a/pnpm11/deps/security/signatures/src/verifySignatures.ts
+++ b/pnpm11/deps/security/signatures/src/verifySignatures.ts
@@ -2,7 +2,7 @@ import crypto from 'node:crypto'
 import url from 'node:url'
 import util from 'node:util'
 
-import { PnpmError } from '@pnpm/error'
+import { PnpmError, redactUrlCredentials } from '@pnpm/error'
 import type { GetAuthHeader } from '@pnpm/fetching.types'
 import { createFetchFromRegistry, type CreateFetchFromRegistryOptions, type RetryTimeoutOptions } from '@pnpm/network.fetch'
 import pLimit from 'p-limit'
@@ -422,7 +422,11 @@ export type SignatureFailureCategory = 'invalid' | 'absent' | 'unreachable' | 'u
 export interface InstalledSignatureFailure {
   name: string
   version: string
-  /** The registry the package was installed from (see {@link InstalledPackageToVerify.registry}). */
+  /**
+   * The registry the package was installed from (see
+   * {@link InstalledPackageToVerify.registry}), with inline `user:pass@`
+   * credentials stripped so the failure is safe to print or log.
+   */
   registry: string
   reason: string
   category: SignatureFailureCategory
@@ -482,7 +486,7 @@ export async function verifyInstalledPackageSignatures (
   await Promise.all(packages.map((pkg) => limit(async () => {
     const failure = await findSignatureFailure(pkg, ctx)
     if (failure != null) {
-      failures.push({ name: pkg.name, version: pkg.version, registry: pkg.registry, ...failure })
+      failures.push({ name: pkg.name, version: pkg.version, registry: redactUrlCredentials(pkg.registry), ...failure })
     }
   })))
 
@@ -535,7 +539,7 @@ async function findSignatureFailure (
   // none) and the fallback could not be consulted — nothing suspicious was
   // observed, the signature was simply unobtainable.
   return {
-    reason: `${primary.reason}; the fallback registry (${fallbackRegistry}) could not be consulted either: ${secondary.reason}`,
+    reason: `${primary.reason}; the fallback registry (${redactUrlCredentials(fallbackRegistry)}) could not be consulted either: ${secondary.reason}`,
     category: 'unreachable',
   }
 }
@@ -549,16 +553,20 @@ async function attemptSignatureVerification (
   registry: string,
   ctx: SignatureVerificationContext
 ): Promise<{ reason: string, category: SignatureFailureCategory } | undefined> {
+  // Registry URLs may carry inline `user:pass@` credentials, and the reasons
+  // built here end up in error messages and warnings.
+  const displayRegistry = redactUrlCredentials(registry)
   let packument: Packument | undefined
   try {
     packument = await getPackument({ ...pkg, registry }, ctx.getAuthHeader, ctx.opts, ctx.packumentCache)
   } catch (err: unknown) {
-    return { reason: util.types.isNativeError(err) ? err.message : String(err), category: 'unreachable' }
+    // The fetch error may echo the request URL, credentials included.
+    return { reason: redactUrlCredentials(util.types.isNativeError(err) ? err.message : String(err)), category: 'unreachable' }
   }
-  if (!packument) return { reason: `${pkg.name} is not published on ${registry}`, category: 'absent' }
+  if (!packument) return { reason: `${pkg.name} is not published on ${displayRegistry}`, category: 'absent' }
 
   const version = packument.versions?.[pkg.version]
-  if (!version) return { reason: `${pkg.name}@${pkg.version} was not found on ${registry}`, category: 'absent' }
+  if (!version) return { reason: `${pkg.name}@${pkg.version} was not found on ${displayRegistry}`, category: 'absent' }
 
   const rawSignatures = version.dist?.signatures
   if (rawSignatures != null && !Array.isArray(rawSignatures)) {
@@ -569,7 +577,7 @@ async function attemptSignatureVerification (
     return { reason: `malformed registry signatures metadata for ${pkg.name}@${pkg.version}`, category: 'absent' }
   }
   if (signatures.length === 0) {
-    return { reason: `${pkg.name}@${pkg.version} has no registry signature on ${registry}`, category: 'absent' }
+    return { reason: `${pkg.name}@${pkg.version} has no registry signature on ${displayRegistry}`, category: 'absent' }
   }
 
   // The message is built from the installed integrity, so a signature only
@@ -587,14 +595,16 @@ async function attemptSignatureVerification (
  * implied — or a canonical registry written as e.g.
  * `https://Registry.NPMJS.org:443/` would be misclassified as a different,
  * non-canonical one, weakening fail-closed decisions keyed on whether the
- * registry is the canonical one.
+ * registry is the canonical one. Inline `user:pass@` credentials are auth
+ * material, not identity, so they are stripped before comparing for the same
+ * reason.
  */
 export function equalRegistries (a: string, b: string): boolean {
   return normalizeRegistryUrl(a) === normalizeRegistryUrl(b)
 }
 
 function normalizeRegistryUrl (registry: string): string {
-  const withSlash = registry.endsWith('/') ? registry : `${registry}/`
+  const withSlash = redactUrlCredentials(registry.endsWith('/') ? registry : `${registry}/`)
   try {
     // URL normalization lowercases the host and drops a default port.
     return new url.URL(withSlash).toString().toLowerCase()

--- a/pnpm11/deps/security/signatures/src/verifySignatures.ts
+++ b/pnpm11/deps/security/signatures/src/verifySignatures.ts
@@ -2,7 +2,7 @@ import crypto from 'node:crypto'
 import url from 'node:url'
 import util from 'node:util'
 
-import { PnpmError, redactUrlCredentials } from '@pnpm/error'
+import { PnpmError, redactAndSanitize } from '@pnpm/error'
 import type { GetAuthHeader } from '@pnpm/fetching.types'
 import { createFetchFromRegistry, type CreateFetchFromRegistryOptions, type RetryTimeoutOptions } from '@pnpm/network.fetch'
 import pLimit from 'p-limit'
@@ -425,7 +425,7 @@ export interface InstalledSignatureFailure {
   /**
    * The registry the package was installed from (see
    * {@link InstalledPackageToVerify.registry}), with inline `user:pass@`
-   * credentials stripped so the failure is safe to print or log.
+   * credentials and control characters stripped so the failure is safe to print or log.
    */
   registry: string
   reason: string
@@ -486,7 +486,7 @@ export async function verifyInstalledPackageSignatures (
   await Promise.all(packages.map((pkg) => limit(async () => {
     const failure = await findSignatureFailure(pkg, ctx)
     if (failure != null) {
-      failures.push({ name: pkg.name, version: pkg.version, registry: redactUrlCredentials(pkg.registry), ...failure })
+      failures.push({ name: pkg.name, version: pkg.version, registry: redactAndSanitize(pkg.registry), ...failure })
     }
   })))
 
@@ -539,7 +539,7 @@ async function findSignatureFailure (
   // none) and the fallback could not be consulted — nothing suspicious was
   // observed, the signature was simply unobtainable.
   return {
-    reason: `${primary.reason}; the fallback registry (${redactUrlCredentials(fallbackRegistry)}) could not be consulted either: ${secondary.reason}`,
+    reason: `${primary.reason}; the fallback registry (${redactAndSanitize(fallbackRegistry)}) could not be consulted either: ${secondary.reason}`,
     category: 'unreachable',
   }
 }
@@ -555,13 +555,13 @@ async function attemptSignatureVerification (
 ): Promise<{ reason: string, category: SignatureFailureCategory } | undefined> {
   // Registry URLs may carry inline `user:pass@` credentials, and the reasons
   // built here end up in error messages and warnings.
-  const displayRegistry = redactUrlCredentials(registry)
+  const displayRegistry = redactAndSanitize(registry)
   let packument: Packument | undefined
   try {
     packument = await getPackument({ ...pkg, registry }, ctx.getAuthHeader, ctx.opts, ctx.packumentCache)
   } catch (err: unknown) {
     // The fetch error may echo the request URL, credentials included.
-    return { reason: redactUrlCredentials(util.types.isNativeError(err) ? err.message : String(err)), category: 'unreachable' }
+    return { reason: redactAndSanitize(util.types.isNativeError(err) ? err.message : String(err)), category: 'unreachable' }
   }
   if (!packument) return { reason: `${pkg.name} is not published on ${displayRegistry}`, category: 'absent' }
 
@@ -604,7 +604,7 @@ export function equalRegistries (a: string, b: string): boolean {
 }
 
 function normalizeRegistryUrl (registry: string): string {
-  const withSlash = redactUrlCredentials(registry.endsWith('/') ? registry : `${registry}/`)
+  const withSlash = redactAndSanitize(registry.endsWith('/') ? registry : `${registry}/`)
   try {
     // URL normalization lowercases the host and drops a default port.
     return new url.URL(withSlash).toString().toLowerCase()

--- a/pnpm11/deps/security/signatures/test/verifySignatures.ts
+++ b/pnpm11/deps/security/signatures/test/verifySignatures.ts
@@ -420,11 +420,14 @@ describe('verifyInstalledPackageSignatures', () => {
     // the registries involved.
     const result = await verifyInstalledPackageSignatures([
       { name: 'signed-pkg', registry: 'https://user:pass@registry.example.test/', version: '1.0.0', integrity: INTEGRITY },
+      // A control character inside the password must not split the
+      // authority and leak either half of the credentials.
+      { name: 'other-pkg', registry: 'https://user:p\rass@registry.example.test/', version: '1.0.0', integrity: INTEGRITY },
     ], [toRegistryKey(key)], () => undefined, { fallbackRegistry: 'https://user:pass@second-registry.example.test/' })
 
     expect(result.verified).toBe(false)
     expect(result.failures[0].registry).toBe(REGISTRY)
-    expect(JSON.stringify(result.failures)).not.toContain('user:pass')
+    expect(JSON.stringify(result.failures)).not.toContain('user:p')
   })
 
   test('reports a non-sha512 integrity pin as uncovered without consulting any registry', async () => {

--- a/pnpm11/deps/security/signatures/test/verifySignatures.ts
+++ b/pnpm11/deps/security/signatures/test/verifySignatures.ts
@@ -414,6 +414,19 @@ describe('verifyInstalledPackageSignatures', () => {
     expect(result.failures[0]).toMatchObject({ category: 'absent' })
   })
 
+  test('failures never echo inline registry credentials', async () => {
+    const key = createSigningKey()
+    // Neither registry is mocked, so both lookups fail and the failure quotes
+    // the registries involved.
+    const result = await verifyInstalledPackageSignatures([
+      { name: 'signed-pkg', registry: 'https://user:pass@registry.example.test/', version: '1.0.0', integrity: INTEGRITY },
+    ], [toRegistryKey(key)], () => undefined, { fallbackRegistry: 'https://user:pass@second-registry.example.test/' })
+
+    expect(result.verified).toBe(false)
+    expect(result.failures[0].registry).toBe(REGISTRY)
+    expect(JSON.stringify(result.failures)).not.toContain('user:pass')
+  })
+
   test('reports a non-sha512 integrity pin as uncovered without consulting any registry', async () => {
     const key = createSigningKey()
     // No packuments are mocked: the category is decided before any fetch.

--- a/pnpm11/deps/security/signatures/test/verifySignatures.ts
+++ b/pnpm11/deps/security/signatures/test/verifySignatures.ts
@@ -334,6 +334,96 @@ describe('verifyInstalledPackageSignatures', () => {
     expect(result.failures[0]).toMatchObject({ category: 'absent' })
     expect(result.failures[0].reason).toContain('not published')
   })
+
+  test('verifies via the fallback registry when the package registry serves no signatures', async () => {
+    const key = createSigningKey()
+    mockPackument({ signatures: [] })
+    mockPackument({ signatures: [{ keyid: key.keyid, sig: key.sign('signed-pkg@1.0.0', INTEGRITY) }], registry: SECOND_REGISTRY })
+
+    const result = await verifyInstalledPackageSignatures([
+      { name: 'signed-pkg', registry: REGISTRY, version: '1.0.0', integrity: INTEGRITY },
+    ], [toRegistryKey(key)], () => undefined, { fallbackRegistry: SECOND_REGISTRY })
+
+    expect(result).toEqual({ verified: true, failures: [] })
+  })
+
+  test('a fallback signature still fails over a tampered installed integrity', async () => {
+    const key = createSigningKey()
+    mockPackument({ signatures: [] })
+    mockPackument({ signatures: [{ keyid: key.keyid, sig: key.sign('signed-pkg@1.0.0', INTEGRITY) }], registry: SECOND_REGISTRY })
+
+    const result = await verifyInstalledPackageSignatures([
+      { name: 'signed-pkg', registry: REGISTRY, version: '1.0.0', integrity: 'sha512-tampered-bytes' },
+    ], [toRegistryKey(key)], () => undefined, { fallbackRegistry: SECOND_REGISTRY })
+
+    expect(result.verified).toBe(false)
+    expect(result.failures[0]).toMatchObject({ category: 'invalid', registry: REGISTRY })
+  })
+
+  test('verifies via the fallback registry when the package registry serves an unusable signature', async () => {
+    const key = createSigningKey()
+    // e.g. a mirror caching a stale signature from a rotated-out key
+    mockPackument({ signatures: [{ keyid: 'SHA256:rotated-out-key', sig: 'stale-signature' }] })
+    mockPackument({ signatures: [{ keyid: key.keyid, sig: key.sign('signed-pkg@1.0.0', INTEGRITY) }], registry: SECOND_REGISTRY })
+
+    const result = await verifyInstalledPackageSignatures([
+      { name: 'signed-pkg', registry: REGISTRY, version: '1.0.0', integrity: INTEGRITY },
+    ], [toRegistryKey(key)], () => undefined, { fallbackRegistry: SECOND_REGISTRY })
+
+    expect(result).toEqual({ verified: true, failures: [] })
+  })
+
+  test('reports unreachable when neither the package registry nor the fallback can provide a signature', async () => {
+    const key = createSigningKey()
+    mockPackument({ signatures: [] })
+    // The fallback registry is not mocked, so consulting it fails.
+
+    const result = await verifyInstalledPackageSignatures([
+      { name: 'signed-pkg', registry: REGISTRY, version: '1.0.0', integrity: INTEGRITY },
+    ], [toRegistryKey(key)], () => undefined, { fallbackRegistry: SECOND_REGISTRY })
+
+    expect(result.verified).toBe(false)
+    expect(result.failures[0]).toMatchObject({ category: 'unreachable', registry: REGISTRY })
+    expect(result.failures[0].reason).toContain(SECOND_REGISTRY)
+  })
+
+  test('reports absent when a reachable fallback registry has no signature either', async () => {
+    const key = createSigningKey()
+    mockPackument({ signatures: [] })
+    getMockAgent().get(SECOND_REGISTRY.replace(/\/$/, ''))
+      .intercept({ path: '/signed-pkg', method: 'GET' })
+      .reply(404, {})
+
+    const result = await verifyInstalledPackageSignatures([
+      { name: 'signed-pkg', registry: REGISTRY, version: '1.0.0', integrity: INTEGRITY },
+    ], [toRegistryKey(key)], () => undefined, { fallbackRegistry: SECOND_REGISTRY })
+
+    expect(result.verified).toBe(false)
+    expect(result.failures[0]).toMatchObject({ category: 'absent' })
+  })
+
+  test('does not consult the fallback when it is the package registry itself', async () => {
+    const key = createSigningKey()
+    mockPackument({ signatures: [] })
+
+    const result = await verifyInstalledPackageSignatures([
+      { name: 'signed-pkg', registry: REGISTRY, version: '1.0.0', integrity: INTEGRITY },
+    ], [toRegistryKey(key)], () => undefined, { fallbackRegistry: REGISTRY.replace(/\/$/, '') })
+
+    expect(result.verified).toBe(false)
+    expect(result.failures[0]).toMatchObject({ category: 'absent' })
+  })
+
+  test('reports a non-sha512 integrity pin as uncovered without consulting any registry', async () => {
+    const key = createSigningKey()
+    // No packuments are mocked: the category is decided before any fetch.
+    const result = await verifyInstalledPackageSignatures([
+      { name: 'signed-pkg', registry: REGISTRY, version: '1.0.0', integrity: 'sha1-8bee00286a17c00a13c7e6e6dd9a9b389220ee7f' },
+    ], [toRegistryKey(key)], () => undefined, { fallbackRegistry: SECOND_REGISTRY })
+
+    expect(result.verified).toBe(false)
+    expect(result.failures[0]).toMatchObject({ category: 'uncovered', registry: REGISTRY })
+  })
 })
 
 function toRegistryKey (key: ReturnType<typeof createSigningKey>) {
@@ -362,11 +452,11 @@ function mockRegistryKey (key: ReturnType<typeof createSigningKey>): void {
     })
 }
 
-function mockPackument (opts: { signatures: unknown, time?: string | null }): void {
+function mockPackument (opts: { signatures: unknown, time?: string | null, registry?: string }): void {
   const time = Object.hasOwn(opts, 'time')
     ? (opts.time == null ? {} : { '1.0.0': opts.time })
     : { '1.0.0': '2023-01-01T00:00:00.000Z' }
-  getMockAgent().get(REGISTRY.replace(/\/$/, ''))
+  getMockAgent().get((opts.registry ?? REGISTRY).replace(/\/$/, ''))
     .intercept({ path: '/signed-pkg', method: 'GET' })
     .reply(200, {
       name: 'signed-pkg',

--- a/pnpm11/engine/pm/commands/src/self-updater/verifyPnpmEngineIdentity.ts
+++ b/pnpm11/engine/pm/commands/src/self-updater/verifyPnpmEngineIdentity.ts
@@ -2,6 +2,7 @@ import { pickRegistryForPackage } from '@pnpm/config.pick-registry-for-package'
 import {
   getNpmSigningKeys,
   type InstalledPackageToVerify,
+  type InstalledSignatureFailure,
   type RegistryKey,
   type SignatureFailureCategory,
   verifyInstalledPackageSignatures,
@@ -9,12 +10,15 @@ import {
 } from '@pnpm/deps.security.signatures'
 import { PnpmError } from '@pnpm/error'
 import type { EnvLockfile } from '@pnpm/lockfile.types'
+import { globalWarn } from '@pnpm/logger'
 import { createGetAuthHeaderByURI } from '@pnpm/network.auth-header'
 import type { Registries, RegistryConfig } from '@pnpm/types'
 import { familySync } from 'detect-libc'
 import semver from 'semver'
 
 import { exePlatformPkgDirName, exePlatformPkgDirNameNext } from './installPnpm.js'
+
+const CANONICAL_NPM_REGISTRY = 'https://registry.npmjs.org/'
 
 export type VerifyPnpmEngineIdentityOptions = VerifySignaturesOptions & {
   registries: Registries
@@ -43,13 +47,29 @@ export type VerifyPnpmEngineIdentityOptions = VerifySignaturesOptions & {
  * its own key pair; the signed packument is fetched from the configured registry,
  * which an npm mirror proxies transparently.
  *
+ * Registries that serve no `dist.signatures` at all (private mirrors and feed
+ * proxies commonly strip them — https://github.com/pnpm/pnpm/issues/13147) do
+ * not fail the check outright: the signature is then fetched from the canonical
+ * npm registry instead, which proves exactly the same thing, since it is
+ * verified against the embedded keys over the installed integrity. When no
+ * signature can be obtained from either source (both unreachable, or the
+ * integrity is a non-sha512 pin no npm signature can cover), the check warns
+ * and proceeds — but only when every engine package resolves through a
+ * non-canonical registry. Such a registry can only come from the user's own
+ * trusted (non-project) configuration, the download URL is derived from it
+ * rather than read from the lockfile, and the bytes stay pinned by the
+ * lockfile integrity — so a cloned repository still cannot steer pnpm to
+ * attacker-controlled bytes; the residual trust is the same the user already
+ * places in that registry for every package they install from it.
+ *
  * Throws when verification detects tampering (an invalid signature), when a
- * package/version is absent from the registry, or when an engine component
- * present in the lockfile carries no integrity metadata — pnpm can install a
- * tarball without integrity, so a missing integrity must fail closed rather
- * than silently exempt that component from verification. Even an unreachable
- * registry fails closed (with `PNPM_ENGINE_IDENTITY_UNVERIFIABLE`): the
- * lockfile integrity is project-controlled, so it is not a safe fallback.
+ * package/version is absent from a reachable canonical registry, or when an
+ * engine component present in the lockfile carries no integrity metadata —
+ * pnpm can install a tarball without integrity, so a missing integrity must
+ * fail closed rather than silently exempt that component from verification.
+ * For engine packages resolved from the canonical npm registry itself, even an
+ * unreachable registry fails closed (with `PNPM_ENGINE_IDENTITY_UNVERIFIABLE`):
+ * the lockfile integrity is project-controlled, so it is not a safe fallback.
  * This runs only when the engine is actually being installed (a store cache
  * miss), so it does not add a network round trip to every command.
  */
@@ -72,7 +92,10 @@ export async function verifyPnpmEngineIdentity (
   const getAuthHeader = createGetAuthHeaderByURI(opts.configByUri ?? {})
   let result
   try {
-    result = await verifyInstalledPackageSignatures(toVerify, trustedKeys, getAuthHeader, opts)
+    result = await verifyInstalledPackageSignatures(toVerify, trustedKeys, getAuthHeader, {
+      ...opts,
+      fallbackRegistry: CANONICAL_NPM_REGISTRY,
+    })
   } catch (err: unknown) {
     // Fail closed: we will not run a downloaded pnpm we could not verify, even
     // when the failure is "could not reach the registry". The lockfile integrity
@@ -85,6 +108,14 @@ export async function verifyPnpmEngineIdentity (
   }
   if (result.verified) return
 
+  if (result.failures.every(isTolerableWithoutSignature)) {
+    globalWarn(
+      `The authenticity of pnpm@${pnpmVersion} could not be verified against npm's registry signatures: ${describe(result.failures)}. ` +
+      'Proceeding anyway, because the release was resolved through the registry configured in your own (non-project) configuration and stays pinned by its integrity checksum.'
+    )
+    return
+  }
+
   const onlyUnreachable = result.failures.every((f) => f.category === 'unreachable')
   throw new PnpmError(
     onlyUnreachable ? 'PNPM_ENGINE_IDENTITY_UNVERIFIABLE' : 'PNPM_ENGINE_IDENTITY_MISMATCH',
@@ -92,6 +123,18 @@ export async function verifyPnpmEngineIdentity (
     `(${describe(result.failures)}). The bytes selected by this project's lockfile/registry do not match a published, signed pnpm release.`,
     { hint: 'This can indicate a tampered lockfile or a malicious/unreachable registry. Set `pmOnFail` to `ignore` to skip the version switch if this is unexpected.' }
   )
+}
+
+/**
+ * Whether the engine may run despite `failure`: no signature was obtainable
+ * (nothing suspicious was observed — as opposed to a signature that exists but
+ * does not validate, or a canonical registry answering that no signed release
+ * exists), and the package resolves through a registry the user configured
+ * themselves. See the trust rationale on {@link verifyPnpmEngineIdentity}.
+ */
+function isTolerableWithoutSignature (failure: InstalledSignatureFailure): boolean {
+  return (failure.category === 'unreachable' || failure.category === 'uncovered') &&
+    failure.registry.replace(/\/$/, '') !== CANONICAL_NPM_REGISTRY.replace(/\/$/, '')
 }
 
 function collectEnginePackagesToVerify (envLockfile: EnvLockfile, registries: Registries): InstalledPackageToVerify[] {

--- a/pnpm11/engine/pm/commands/src/self-updater/verifyPnpmEngineIdentity.ts
+++ b/pnpm11/engine/pm/commands/src/self-updater/verifyPnpmEngineIdentity.ts
@@ -1,5 +1,6 @@
 import { pickRegistryForPackage } from '@pnpm/config.pick-registry-for-package'
 import {
+  equalRegistries,
   getNpmSigningKeys,
   type InstalledPackageToVerify,
   type InstalledSignatureFailure,
@@ -134,7 +135,7 @@ export async function verifyPnpmEngineIdentity (
  */
 function isTolerableWithoutSignature (failure: InstalledSignatureFailure): boolean {
   return (failure.category === 'unreachable' || failure.category === 'uncovered') &&
-    failure.registry.replace(/\/$/, '') !== CANONICAL_NPM_REGISTRY.replace(/\/$/, '')
+    !equalRegistries(failure.registry, CANONICAL_NPM_REGISTRY)
 }
 
 function collectEnginePackagesToVerify (envLockfile: EnvLockfile, registries: Registries): InstalledPackageToVerify[] {

--- a/pnpm11/engine/pm/commands/test/self-updater/verifyPnpmEngineIdentity.test.ts
+++ b/pnpm11/engine/pm/commands/test/self-updater/verifyPnpmEngineIdentity.test.ts
@@ -8,6 +8,7 @@ import { familySync } from 'detect-libc'
 const { exePlatformPkgDirName, exePlatformPkgDirNameNext, verifyPnpmEngineIdentity } = await import('@pnpm/engine.pm.commands')
 
 const REGISTRY = 'https://registry.example.test/'
+const CANONICAL_REGISTRY = 'https://registry.npmjs.org/'
 const PNPM_INTEGRITY = 'sha512-pnpm-integrity'
 const EXE_INTEGRITY = 'sha512-exe-integrity'
 const PLATFORM_INTEGRITY = 'sha512-platform-integrity'
@@ -50,18 +51,73 @@ describe('verifyPnpmEngineIdentity', () => {
     await expect(verifyPnpmEngineIdentity(envLockfile(), '9.1.0', optsTrusting(createSigningKey()))).rejects.toThrow(/Refusing to run pnpm/)
   })
 
-  test('throws when the engine version is absent from the registry', async () => {
-    getMockAgent().get(REGISTRY.replace(/\/$/, ''))
-      .intercept({ path: '/pnpm', method: 'GET' }).reply(404, {})
-    getMockAgent().get(REGISTRY.replace(/\/$/, ''))
-      .intercept({ path: '/@pnpm%2Fexe', method: 'GET' }).reply(404, {}) // cspell:disable-line
+  test('throws when the engine version is absent from both the registry and the canonical registry', async () => {
+    for (const registry of [REGISTRY, CANONICAL_REGISTRY]) {
+      getMockAgent().get(registry.replace(/\/$/, ''))
+        .intercept({ path: '/pnpm', method: 'GET' }).reply(404, {})
+      getMockAgent().get(registry.replace(/\/$/, ''))
+        .intercept({ path: '/@pnpm%2Fexe', method: 'GET' }).reply(404, {}) // cspell:disable-line
+    }
 
     await expect(verifyPnpmEngineIdentity(envLockfile(), '9.1.0', optsTrusting(createSigningKey()))).rejects.toThrow(/Refusing to run pnpm/)
   })
 
-  test('throws (fails closed) when the registry is unreachable', async () => {
+  test('throws (fails closed) when the canonical registry is the configured registry and is unreachable', async () => {
     // No intercept registered and net connect disabled, so the packument fetch fails.
-    await expect(verifyPnpmEngineIdentity(envLockfile(), '9.1.0', optsTrusting(createSigningKey()))).rejects.toThrow(/Refusing to run pnpm/)
+    const opts = { ...optsTrusting(createSigningKey()), registries: { default: CANONICAL_REGISTRY } }
+    await expect(verifyPnpmEngineIdentity(envLockfile(), '9.1.0', opts)).rejects.toThrow(/Refusing to run pnpm/)
+  })
+
+  test('warns and proceeds when a user-configured registry is unreachable and no signature is obtainable', async () => {
+    // No intercept registered and net connect disabled: neither the configured
+    // registry nor the canonical fallback can provide a signature. The
+    // configured registry comes from trusted (non-project) configuration, so
+    // the switch proceeds on the lockfile integrity pin alone.
+    await expect(verifyPnpmEngineIdentity(envLockfile(), '9.1.0', optsTrusting(createSigningKey()))).resolves.toBeUndefined()
+  })
+
+  test('verifies via the canonical registry when the configured registry serves no signatures', async () => {
+    const key = createSigningKey()
+    mockPackument({ name: 'pnpm', integrity: PNPM_INTEGRITY, signatures: [] })
+    mockPackument({ name: '@pnpm/exe', integrity: EXE_INTEGRITY, signatures: [] })
+    mockPackument({ name: PLATFORM_PKG_NAME, integrity: PLATFORM_INTEGRITY, signatures: [] })
+    mockPackument({ name: 'pnpm', integrity: PNPM_INTEGRITY, signatures: [{ keyid: key.keyid, sig: key.sign('pnpm@9.1.0', PNPM_INTEGRITY) }], registry: CANONICAL_REGISTRY })
+    mockPackument({ name: '@pnpm/exe', integrity: EXE_INTEGRITY, signatures: [{ keyid: key.keyid, sig: key.sign('@pnpm/exe@9.1.0', EXE_INTEGRITY) }], registry: CANONICAL_REGISTRY })
+    mockPackument({ name: PLATFORM_PKG_NAME, integrity: PLATFORM_INTEGRITY, signatures: [{ keyid: key.keyid, sig: key.sign(`${PLATFORM_PKG_NAME}@9.1.0`, PLATFORM_INTEGRITY) }], registry: CANONICAL_REGISTRY })
+
+    await expect(verifyPnpmEngineIdentity(envLockfile(), '9.1.0', optsTrusting(key))).resolves.toBeUndefined()
+  })
+
+  test('a canonical-registry signature still catches a tampered integrity when the configured registry serves no signatures', async () => {
+    const key = createSigningKey()
+    mockPackument({ name: 'pnpm', integrity: PNPM_INTEGRITY, signatures: [] })
+    mockPackument({ name: '@pnpm/exe', integrity: EXE_INTEGRITY, signatures: [] })
+    mockPackument({ name: PLATFORM_PKG_NAME, integrity: PLATFORM_INTEGRITY, signatures: [] })
+    // The canonical registry signed different bytes than the lockfile pins.
+    mockPackument({ name: 'pnpm', integrity: PNPM_INTEGRITY, signatures: [{ keyid: key.keyid, sig: key.sign('pnpm@9.1.0', 'sha512-genuine-pnpm') }], registry: CANONICAL_REGISTRY })
+    mockPackument({ name: '@pnpm/exe', integrity: EXE_INTEGRITY, signatures: [{ keyid: key.keyid, sig: key.sign('@pnpm/exe@9.1.0', 'sha512-genuine-exe') }], registry: CANONICAL_REGISTRY })
+    mockPackument({ name: PLATFORM_PKG_NAME, integrity: PLATFORM_INTEGRITY, signatures: [{ keyid: key.keyid, sig: key.sign(`${PLATFORM_PKG_NAME}@9.1.0`, 'sha512-genuine-platform') }], registry: CANONICAL_REGISTRY })
+
+    await expect(verifyPnpmEngineIdentity(envLockfile(), '9.1.0', optsTrusting(key))).rejects.toThrow(/Refusing to run pnpm/)
+  })
+
+  test('warns and proceeds when a user-configured registry pins a non-sha512 integrity no signature can cover', async () => {
+    // A registry that publishes only `shasum` yields sha1 pins; no npm
+    // signature can ever validate over them, so no packument is even fetched.
+    const lockfile = envLockfile()
+    ;(lockfile.packages as Record<string, { resolution: { integrity: string } }>)['pnpm@9.1.0'] = { resolution: { integrity: 'sha1-8bee00286a17c00a13c7e6e6dd9a9b389220ee7f' } }
+    ;(lockfile.packages as Record<string, { resolution: { integrity: string } }>)['@pnpm/exe@9.1.0'] = { resolution: { integrity: 'sha1-9bee00286a17c00a13c7e6e6dd9a9b389220ee7f' } }
+    ;(lockfile.packages as Record<string, { resolution: { integrity: string } }>)[`${PLATFORM_PKG_NAME}@9.1.0`] = { resolution: { integrity: 'sha1-abee00286a17c00a13c7e6e6dd9a9b389220ee7f' } }
+
+    await expect(verifyPnpmEngineIdentity(lockfile, '9.1.0', optsTrusting(createSigningKey()))).resolves.toBeUndefined()
+  })
+
+  test('throws for a non-sha512 integrity pin when the engine resolves from the canonical registry', async () => {
+    const lockfile = envLockfile()
+    ;(lockfile.packages as Record<string, { resolution: { integrity: string } }>)['pnpm@9.1.0'] = { resolution: { integrity: 'sha1-8bee00286a17c00a13c7e6e6dd9a9b389220ee7f' } }
+
+    const opts = { ...optsTrusting(createSigningKey()), registries: { default: CANONICAL_REGISTRY } }
+    await expect(verifyPnpmEngineIdentity(lockfile, '9.1.0', opts)).rejects.toThrow(/Refusing to run pnpm/)
   })
 
   test('skips (no throw) when no trusted keys are provided', async () => {
@@ -181,9 +237,9 @@ function envLockfile (): EnvLockfile {
   } as unknown as EnvLockfile
 }
 
-function mockPackument ({ name, integrity, signatures, version = '9.1.0' }: { name: string, integrity: string, signatures: unknown, version?: string }): void {
+function mockPackument ({ name, integrity, signatures, version = '9.1.0', registry = REGISTRY }: { name: string, integrity: string, signatures: unknown, version?: string, registry?: string }): void {
   const encodedPath = name[0] === '@' ? `/${name.replace(/\//g, '%2F')}` : `/${name}`
-  getMockAgent().get(REGISTRY.replace(/\/$/, ''))
+  getMockAgent().get(registry.replace(/\/$/, ''))
     .intercept({ path: encodedPath, method: 'GET' })
     .reply(200, {
       name,

--- a/pnpm11/engine/pm/commands/test/self-updater/verifyPnpmEngineIdentity.test.ts
+++ b/pnpm11/engine/pm/commands/test/self-updater/verifyPnpmEngineIdentity.test.ts
@@ -68,6 +68,11 @@ describe('verifyPnpmEngineIdentity', () => {
     await expect(verifyPnpmEngineIdentity(envLockfile(), '9.1.0', opts)).rejects.toThrow(/Refusing to run pnpm/)
   })
 
+  test('recognizes URL-equivalent spellings of the canonical registry and still fails closed', async () => {
+    const opts = { ...optsTrusting(createSigningKey()), registries: { default: 'https://Registry.NPMJS.org:443/' } }
+    await expect(verifyPnpmEngineIdentity(envLockfile(), '9.1.0', opts)).rejects.toThrow(/Refusing to run pnpm/)
+  })
+
   test('warns and proceeds when a user-configured registry is unreachable and no signature is obtainable', async () => {
     // No intercept registered and net connect disabled: neither the configured
     // registry nor the canonical fallback can provide a signature. The

--- a/pnpm11/engine/pm/commands/test/self-updater/verifyPnpmEngineIdentity.test.ts
+++ b/pnpm11/engine/pm/commands/test/self-updater/verifyPnpmEngineIdentity.test.ts
@@ -69,8 +69,13 @@ describe('verifyPnpmEngineIdentity', () => {
   })
 
   test('recognizes URL-equivalent spellings of the canonical registry and still fails closed', async () => {
-    const opts = { ...optsTrusting(createSigningKey()), registries: { default: 'https://Registry.NPMJS.org:443/' } }
-    await expect(verifyPnpmEngineIdentity(envLockfile(), '9.1.0', opts)).rejects.toThrow(/Refusing to run pnpm/)
+    // Case, an explicit default port, and inline credentials are all
+    // URL-equivalent to the canonical registry and must not unlock the
+    // warn-and-proceed path.
+    await Promise.all(['https://Registry.NPMJS.org:443/', 'https://user:pass@registry.npmjs.org/'].map(async (canonical) => {
+      const opts = { ...optsTrusting(createSigningKey()), registries: { default: canonical } }
+      await expect(verifyPnpmEngineIdentity(envLockfile(), '9.1.0', opts)).rejects.toThrow(/Refusing to run pnpm/)
+    }))
   })
 
   test('warns and proceeds when a user-configured registry is unreachable and no signature is obtainable', async () => {

--- a/pnpm11/installing/env-installer/src/resolvePackageManagerIntegrities.ts
+++ b/pnpm11/installing/env-installer/src/resolvePackageManagerIntegrities.ts
@@ -84,6 +84,7 @@ export async function resolvePackageManagerIntegrities (
   }
 
   const lockfile = await resolveWantedPnpmPackages(pnpmVersion, opts)
+  stripRegistryTarballUrls(lockfile)
 
   if (lockfile.packages) {
     // Build packageManagerDependencies from the resolved lockfile importers
@@ -112,6 +113,34 @@ export async function resolvePackageManagerIntegrities (
     }
   }
   return envLockfile
+}
+
+/**
+ * Rewrites registry tarball resolutions to integrity-only form, dropping
+ * tarball URLs that a registry advertises on a host other than its own —
+ * load-balanced proxies and Artifactory-style mirrors do this, see
+ * https://github.com/pnpm/pnpm/issues/13619. The package-manager bootstrap
+ * never fetches a URL recorded in the lockfile: the download URL is always
+ * derived from the trusted bootstrap registries at install time, so a
+ * repository-provided entry cannot steer the download. Dropping the URL here
+ * keeps freshly resolved entries in exactly the integrity-only shape the
+ * bootstrap validation accepts.
+ */
+function stripRegistryTarballUrls (lockfile: LockfileObject): void {
+  for (const pkg of Object.values(lockfile.packages ?? {})) {
+    const resolution = pkg.resolution
+    if (
+      resolution == null ||
+      !('integrity' in resolution) || !resolution.integrity ||
+      !('tarball' in resolution) || typeof resolution.tarball !== 'string' ||
+      resolution.tarball.startsWith('file:') ||
+      ('gitHosted' in resolution && resolution.gitHosted === true) ||
+      ('path' in resolution && resolution.path != null)
+    ) {
+      continue
+    }
+    pkg.resolution = { integrity: resolution.integrity }
+  }
 }
 
 /**

--- a/pnpm11/installing/env-installer/test/resolvePackageManagerIntegrities.test.ts
+++ b/pnpm11/installing/env-installer/test/resolvePackageManagerIntegrities.test.ts
@@ -1,6 +1,12 @@
-import { expect, test } from '@jest/globals'
+import { expect, jest, test } from '@jest/globals'
 import { isPackageManagerResolved } from '@pnpm/installing.env-installer'
-import type { EnvLockfile } from '@pnpm/lockfile.types'
+import type { EnvLockfile, LockfileObject } from '@pnpm/lockfile.types'
+
+const resolveManifestDependencies = jest.fn<() => Promise<LockfileObject>>()
+jest.unstable_mockModule('../src/resolveManifestDependencies.js', () => ({
+  resolveManifestDependencies,
+}))
+const { resolvePackageManagerIntegrities } = await import('../src/resolvePackageManagerIntegrities.js')
 
 test('the JS pnpm and @pnpm/exe are both pinned for the majors that publish them separately', () => {
   expect(isPackageManagerResolved(envLockfile({ 'pnpm': '11.0.0', '@pnpm/exe': '11.0.0' }), '11.0.0')).toBe(true)
@@ -20,6 +26,70 @@ test('only pnpm is pinned before @pnpm/exe was published', () => {
 test('an env lockfile pinning another pnpm version is not resolved', () => {
   expect(isPackageManagerResolved(envLockfile({ pnpm: '12.0.0' }), '12.1.0')).toBe(false)
   expect(isPackageManagerResolved(undefined, '12.0.0')).toBe(false)
+})
+
+// A registry that advertises tarballs on another host (a load-balanced proxy
+// or Artifactory-style mirror) must still yield integrity-only
+// package-manager entries, or the bootstrap validation rejects them.
+// See https://github.com/pnpm/pnpm/issues/13619.
+test('registry tarball URLs are dropped from package-manager resolutions; file:, git-hosted, and subdir tarballs are kept', async () => {
+  resolveManifestDependencies.mockResolvedValueOnce({
+    lockfileVersion: '9.0',
+    importers: {
+      '.': {
+        specifiers: { pnpm: '12.0.0' },
+        dependencies: { pnpm: '12.0.0' },
+      },
+    },
+    packages: {
+      'pnpm@12.0.0': {
+        resolution: {
+          integrity: 'sha512-pnpm',
+          tarball: 'https://mirror-pool-7.example.com/registry/pnpm/-/pnpm-12.0.0.tgz',
+        },
+        dependencies: {
+          'git-hosted-dep': '1.0.0',
+          'local-dep': '1.0.0',
+          'subdir-dep': '1.0.0',
+        },
+      },
+      'git-hosted-dep@1.0.0': {
+        resolution: {
+          integrity: 'sha512-git',
+          tarball: 'https://codeload.github.com/org/repo/tar.gz/abc',
+          gitHosted: true,
+        },
+      },
+      'local-dep@1.0.0': {
+        resolution: {
+          integrity: 'sha512-local',
+          tarball: 'file:../local-dep.tgz',
+        },
+      },
+      'subdir-dep@1.0.0': {
+        resolution: {
+          integrity: 'sha512-subdir',
+          tarball: 'https://codeload.github.com/org/mono/tar.gz/def',
+          path: '/packages/a',
+        },
+      },
+    },
+  } as unknown as LockfileObject)
+
+  const result = await resolvePackageManagerIntegrities('12.0.0', {
+    registries: { default: 'https://mirror.example.com/' },
+    rootDir: '/repo',
+    storeController: {} as never,
+    storeDir: '/store',
+    save: false,
+  })
+
+  const resolutionOf = (depPath: string) =>
+    (result.packages as Record<string, { resolution: unknown }>)[depPath].resolution
+  expect(resolutionOf('pnpm@12.0.0')).toEqual({ integrity: 'sha512-pnpm' })
+  expect(resolutionOf('git-hosted-dep@1.0.0')).toMatchObject({ tarball: expect.any(String), gitHosted: true })
+  expect(resolutionOf('local-dep@1.0.0')).toMatchObject({ tarball: 'file:../local-dep.tgz' })
+  expect(resolutionOf('subdir-dep@1.0.0')).toMatchObject({ tarball: expect.any(String), path: '/packages/a' })
 })
 
 function envLockfile (packageManagerDependencies: Record<string, string>): EnvLockfile {

--- a/pnpm11/installing/env-installer/test/resolvePackageManagerIntegrities.test.ts
+++ b/pnpm11/installing/env-installer/test/resolvePackageManagerIntegrities.test.ts
@@ -87,9 +87,20 @@ test('registry tarball URLs are dropped from package-manager resolutions; file:,
   const resolutionOf = (depPath: string) =>
     (result.packages as Record<string, { resolution: unknown }>)[depPath].resolution
   expect(resolutionOf('pnpm@12.0.0')).toEqual({ integrity: 'sha512-pnpm' })
-  expect(resolutionOf('git-hosted-dep@1.0.0')).toMatchObject({ tarball: expect.any(String), gitHosted: true })
-  expect(resolutionOf('local-dep@1.0.0')).toMatchObject({ tarball: 'file:../local-dep.tgz' })
-  expect(resolutionOf('subdir-dep@1.0.0')).toMatchObject({ tarball: expect.any(String), path: '/packages/a' })
+  expect(resolutionOf('git-hosted-dep@1.0.0')).toEqual({
+    integrity: 'sha512-git',
+    tarball: 'https://codeload.github.com/org/repo/tar.gz/abc',
+    gitHosted: true,
+  })
+  expect(resolutionOf('local-dep@1.0.0')).toEqual({
+    integrity: 'sha512-local',
+    tarball: 'file:../local-dep.tgz',
+  })
+  expect(resolutionOf('subdir-dep@1.0.0')).toEqual({
+    integrity: 'sha512-subdir',
+    tarball: 'https://codeload.github.com/org/mono/tar.gz/def',
+    path: '/packages/a',
+  })
 })
 
 function envLockfile (packageManagerDependencies: Record<string, string>): EnvLockfile {

--- a/pnpm11/pnpm/src/switchCliVersion.test.ts
+++ b/pnpm11/pnpm/src/switchCliVersion.test.ts
@@ -303,21 +303,109 @@ test('switchCliVersion accepts registry-only package-manager lockfiles with peer
   exit.mockRestore()
 })
 
-test('switchCliVersion rejects package-manager lockfile resolutions with non-integrity fields', async () => {
-  const poisonedLockfile: EnvLockfile = {
-    ...envLockfile,
-    packages: {
-      ...envLockfile.packages,
-      '@pnpm/linux-x64@9.3.0': {
-        resolution: {
-          integrity: 'sha512-poisoned',
-          tarball: 'https://evil.example.com/pnpm-linux-x64.tgz',
-        },
-      },
+test('switchCliVersion discards package-manager lockfile resolutions with non-integrity fields and re-resolves them', async () => {
+  // Deep clone: the discard mutates the lockfile it heals, and the shared
+  // fixture must stay intact for the other tests.
+  const poisonedLockfile = envLockfileFor('9.3.0')
+  poisonedLockfile.packages['@pnpm/linux-x64@9.3.0' as keyof typeof poisonedLockfile.packages] = {
+    resolution: {
+      integrity: 'sha512-poisoned',
+      tarball: 'https://evil.example.com/pnpm-linux-x64.tgz',
     },
   }
 
   readEnvLockfile.mockResolvedValueOnce(poisonedLockfile)
+
+  const exit = jest.spyOn(process, 'exit').mockImplementation(((code?: string | number | null | undefined) => {
+    throw new Error(`exit ${code ?? 0}`)
+  }) as typeof process.exit)
+  try {
+    await expect(switchCliVersion({
+      registries: { default: 'https://registry.npmjs.org/' },
+      virtualStoreDirMaxLength: 120,
+    } as unknown as Config, {
+      rootProjectManifestDir: '/repo',
+      wantedPackageManager: {
+        fromDevEngines: true,
+        name: 'pnpm',
+        onFail: 'download',
+        version: '9.3.0',
+      },
+    } as unknown as ConfigContext)).rejects.toThrow('exit 0')
+  } finally {
+    exit.mockRestore()
+  }
+
+  // The discarded entries must not survive into the re-resolution input.
+  expect(poisonedLockfile.importers['.'].packageManagerDependencies).toBeUndefined()
+  expect(resolvePackageManagerIntegrities).toHaveBeenCalledWith('9.3.0', expect.objectContaining({
+    envLockfile: poisonedLockfile,
+  }))
+  // The install runs from the freshly resolved lockfile, not the poisoned one.
+  expect(installPnpmToStore).toHaveBeenCalledWith('9.3.0', expect.objectContaining({
+    envLockfile,
+  }))
+})
+
+test('switchCliVersion discards package-manager lockfile dependencies with non-registry dep paths and re-resolves them', async () => {
+  const poisonedLockfile = envLockfileFor('9.3.0')
+  Object.assign(poisonedLockfile.packages, {
+    'payload@file:../payload.tgz': {
+      resolution: {
+        integrity: 'sha512-payload',
+      },
+    },
+  })
+  Object.assign(poisonedLockfile.snapshots, {
+    'pnpm@9.3.0': {
+      dependencies: {
+        payload: 'file:../payload.tgz',
+      },
+    },
+    'payload@file:../payload.tgz': {},
+  })
+
+  readEnvLockfile.mockResolvedValueOnce(poisonedLockfile)
+
+  const exit = jest.spyOn(process, 'exit').mockImplementation(((code?: string | number | null | undefined) => {
+    throw new Error(`exit ${code ?? 0}`)
+  }) as typeof process.exit)
+  try {
+    await expect(switchCliVersion({
+      registries: { default: 'https://registry.npmjs.org/' },
+      virtualStoreDirMaxLength: 120,
+    } as unknown as Config, {
+      rootProjectManifestDir: '/repo',
+      wantedPackageManager: {
+        fromDevEngines: true,
+        name: 'pnpm',
+        onFail: 'download',
+        version: '9.3.0',
+      },
+    } as unknown as ConfigContext)).rejects.toThrow('exit 0')
+  } finally {
+    exit.mockRestore()
+  }
+
+  expect(resolvePackageManagerIntegrities).toHaveBeenCalledWith('9.3.0', expect.anything())
+  expect(installPnpmToStore).toHaveBeenCalledWith('9.3.0', expect.objectContaining({
+    envLockfile,
+  }))
+})
+
+test('switchCliVersion rejects a package-manager lockfile that is still invalid after re-resolving', async () => {
+  const poisonLinuxX64 = (lockfile: EnvLockfile) => {
+    lockfile.packages['@pnpm/linux-x64@9.3.0' as keyof typeof lockfile.packages] = {
+      resolution: {
+        integrity: 'sha512-poisoned',
+        tarball: 'https://evil.example.com/pnpm-linux-x64.tgz',
+      },
+    }
+    return lockfile
+  }
+
+  readEnvLockfile.mockResolvedValueOnce(poisonLinuxX64(envLockfileFor('9.3.0')))
+  resolvePackageManagerIntegrities.mockResolvedValueOnce(poisonLinuxX64(envLockfileFor('9.3.0')))
 
   await expect(switchCliVersion({
     registries: { default: 'https://registry.npmjs.org/' },
@@ -332,51 +420,6 @@ test('switchCliVersion rejects package-manager lockfile resolutions with non-int
     },
   } as unknown as ConfigContext)).rejects.toThrow('integrity-only resolution')
 
-  expect(resolvePackageManagerIntegrities).not.toHaveBeenCalled()
-  expect(createStoreController).not.toHaveBeenCalled()
-  expect(installPnpmToStore).not.toHaveBeenCalled()
-  expect(spawnSync).not.toHaveBeenCalled()
-})
-
-test('switchCliVersion rejects package-manager lockfile dependencies with non-registry dep paths', async () => {
-  const poisonedLockfile: EnvLockfile = {
-    ...envLockfile,
-    packages: {
-      ...envLockfile.packages,
-      'payload@file:../payload.tgz': {
-        resolution: {
-          integrity: 'sha512-payload',
-        },
-      },
-    },
-    snapshots: {
-      ...envLockfile.snapshots,
-      'pnpm@9.3.0': {
-        dependencies: {
-          payload: 'file:../payload.tgz',
-        },
-      },
-      'payload@file:../payload.tgz': {},
-    },
-  }
-
-  readEnvLockfile.mockResolvedValueOnce(poisonedLockfile)
-
-  await expect(switchCliVersion({
-    registries: { default: 'https://registry.npmjs.org/' },
-    virtualStoreDirMaxLength: 120,
-  } as unknown as Config, {
-    rootProjectManifestDir: '/repo',
-    wantedPackageManager: {
-      fromDevEngines: true,
-      name: 'pnpm',
-      onFail: 'download',
-      version: '9.3.0',
-    },
-  } as unknown as ConfigContext)).rejects.toThrow('registry package path')
-
-  expect(resolvePackageManagerIntegrities).not.toHaveBeenCalled()
-  expect(createStoreController).not.toHaveBeenCalled()
   expect(installPnpmToStore).not.toHaveBeenCalled()
   expect(spawnSync).not.toHaveBeenCalled()
 })

--- a/pnpm11/pnpm/src/switchCliVersion.ts
+++ b/pnpm11/pnpm/src/switchCliVersion.ts
@@ -1,4 +1,5 @@
 import path from 'node:path'
+import util from 'node:util'
 
 import { packageManager } from '@pnpm/cli.meta'
 import { type Config, type ConfigContext, getPackageManagerBootstrapConfig, shouldPersistLockfile } from '@pnpm/config.reader'
@@ -35,6 +36,7 @@ export async function switchCliVersion (config: Config, context: ConfigContext):
 
   // Check if the env lockfile already has a resolved version that satisfies the wanted version/range.
   let pmVersion = envLockfile?.importers['.'].packageManagerDependencies?.['pnpm']?.version
+  let freshlyResolved = false
   if (!pmVersion || !semver.satisfies(pmVersion, pm.version, { includePrerelease: true })) {
     // Resolve to an exact version from the registry.
     storeToUse = await createStoreController({ ...config, ...context, ...packageManagerConfig })
@@ -46,6 +48,7 @@ export async function switchCliVersion (config: Config, context: ConfigContext):
       storeDir: storeToUse.dir,
       save: persistLockfile,
     })
+    freshlyResolved = true
     pmVersion = envLockfile.importers['.'].packageManagerDependencies?.['pnpm']?.version
     if (!pmVersion) {
       globalWarn(`Cannot resolve pnpm version for "${pm.version}"`)
@@ -62,6 +65,7 @@ export async function switchCliVersion (config: Config, context: ConfigContext):
       storeDir: storeToUse.dir,
       save: persistLockfile,
     })
+    freshlyResolved = true
   }
 
   // If the wanted version matches the current version, no switch needed.
@@ -87,7 +91,44 @@ export async function switchCliVersion (config: Config, context: ConfigContext):
   }
 
   try {
-    assertPackageManagerLockfileUsesRegistryResolutions(envLockfile)
+    try {
+      assertPackageManagerLockfileUsesRegistryResolutions(envLockfile)
+    } catch (err: unknown) {
+      if (
+        freshlyResolved ||
+        !util.types.isNativeError(err) ||
+        !('code' in err) ||
+        err.code !== 'ERR_PNPM_INVALID_PACKAGE_MANAGER_LOCKFILE'
+      ) {
+        throw err
+      }
+      // The persisted entries don't satisfy the current bootstrap rules — e.g.
+      // an earlier pnpm recorded resolutions carrying tarball URLs. Rather than
+      // refusing to run, discard them and resolve afresh through the trusted
+      // bootstrap registries, which yields entries in the accepted shape.
+      delete envLockfile.importers['.'].packageManagerDependencies
+      storeToUse ??= await createStoreController({ ...config, ...context, ...packageManagerConfig })
+      envLockfile = await resolvePackageManagerIntegrities(pm.version, {
+        envLockfile,
+        registries: packageManagerConfig.registries,
+        rootDir: context.rootProjectManifestDir,
+        storeController: storeToUse.ctrl,
+        storeDir: storeToUse.dir,
+        save: persistLockfile,
+      })
+      pmVersion = envLockfile.importers['.'].packageManagerDependencies?.['pnpm']?.version
+      if (!pmVersion) {
+        globalWarn(`Cannot resolve pnpm version for "${pm.version}"`)
+        await storeToUse.ctrl.close()
+        return
+      }
+      if (pmVersion === packageManager.version) {
+        await storeToUse.ctrl.close()
+        return
+      }
+      assertReleaseIsInstallable(pmVersion)
+      assertPackageManagerLockfileUsesRegistryResolutions(envLockfile)
+    }
   } catch (err: unknown) {
     await storeToUse?.ctrl.close()
     throw err


### PR DESCRIPTION
## Summary

Unblocks the automatic `packageManager` version switch (and `pnpm self-update`) behind private mirrors and feed proxies, while keeping the bootstrap-hardening guarantees of pnpm/pnpm#12296 and pnpm/pnpm#12292 intact. This is the pair of regressions reported by Microsoft in [discussion 3787](https://github.com/orgs/pnpm/discussions/3787#discussioncomment-17884891), which currently blocks >200 monorepos / >4k engineers there.

Closes pnpm/pnpm#13619. Closes pnpm/pnpm#13147.

**What changes (both stacks):**

1. **Integrity-only package-manager entries** — registries that advertise tarballs on another host (load-balanced proxies, Artifactory-style mirrors) always retained a `tarball` URL in the resolution, which the strict env-lockfile validation then rejected. The advertised URL is now dropped at resolution time: the bootstrap never fetches a lockfile-recorded URL anyway (the URL is always derived from the trusted bootstrap registries), so the entries land in exactly the integrity-only shape the validation accepts. The validation itself is unchanged — still maximally strict.
2. **Self-healing** — entries persisted in an invalid shape by an earlier pnpm (including 11.5.3+, which wrote tarball-carrying entries *before* rejecting them) are discarded and re-resolved through the trusted registries instead of failing every command.
3. **Canonical-registry signature fallback** — when the configured registry serves no `dist.signatures` (or only a stale/broken one), the signature is fetched from registry.npmjs.org and verified against the same embedded npm keys over the *installed* integrity. Where the signature bytes come from does not change what they prove, so this is exactly as strong as today's check, and it also rides out mirrors caching signatures from rotated-out keys.
4. **Warn-and-proceed only when no signature is obtainable** — if both sources are unreachable, or the registry publishes only a `shasum` (a sha1 pin no npm signature can ever cover — Microsoft's proxy does both), the switch proceeds with a warning **only when the engine resolves through a non-canonical registry**, which can only come from the user's own trusted (non-project) configuration. The canonical-registry comparison normalizes through URL parsing, so URL-equivalent spellings (`https://Registry.NPMJS.org:443/`) cannot sidestep the fail-closed policy.

**Why this stays secure** (the properties pnpm/pnpm#12296 / pnpm/pnpm#12292 established):

- A cloned repository still cannot steer the bootstrap download: URLs never come from the lockfile, registries and network config never come from project config.
- Repo-controlled lockfile integrity can only *pin* bytes — a mismatch fails the download; it can never select attacker bytes.
- Tamper evidence always fails closed: a signature that exists but does not validate over the installed integrity hard-fails, as does a reachable canonical registry answering that no signed release exists.
- The residual trust in the warn path equals the trust the user already places in their own configured registry for every package they install from it — the same posture corepack takes for custom registries (its integrity check applies to the default registry).

**Verified end to end** against the registry from the report (`packagefeedproxy.microsoft.io`, publicly readable): both the legacy `packageManager` path and the persisting `devEngines` path now switch successfully, and the persisted entries are integrity-only.

**Notes / known gaps:**

- On the automatic-switch path the "proceeding unverified" warning is currently emitted before the reporter subscribes (TS) / through `SilentReporter` (pacquet), so it is not visible there; it *is* visible on `pnpm self-update` and `pnpm with`. This mirrors the pre-existing handling of other bootstrap-time warnings in both stacks and could be improved in a follow-up.
- pacquet's engine GVS slot cache is unaffected by the resolution-shape change (the slot hash is derived from the integrity alone when one is present).

## Squash Commit Body

```text
The package-manager bootstrap hardening broke version switching on
private mirrors and feed proxies:

1. Registries that advertise tarballs on a different host than the one
   serving the packument always retain a tarball URL in the resolution,
   which the integrity-only env-lockfile validation then rejects
   (Closes pnpm/pnpm#13619).
2. Registries that serve no dist.signatures fail the engine identity
   check outright (Closes pnpm/pnpm#13147).

Fixes, in both stacks:

- Package-manager dependency resolutions are recorded integrity-only:
  the advertised tarball URL is dropped at resolution time, because the
  bootstrap never fetches a lockfile-recorded URL - the download URL is
  always derived from the trusted bootstrap registries. Dropping the URL
  does not perturb the global-virtual-store slot hash, which is derived
  from the integrity alone whenever one is present.
- Persisted entries that fail the bootstrap validation (e.g. written by
  an earlier pnpm) are discarded and re-resolved through the trusted
  registries instead of failing every command.
- Engine identity verification falls back to fetching the signature from
  the canonical npm registry when the configured registry cannot provide
  a verifiable one; it is verified against the same embedded npm keys
  over the installed integrity, so the source of the signature bytes
  does not change what they prove.
- When no signature is obtainable at all (both sources unreachable, or a
  shasum-only registry yields a sha1 pin no npm signature can cover),
  the switch proceeds with a warning - only when the engine resolves
  through a non-canonical registry, which can only come from the user's
  own trusted (non-project) configuration. The canonical-registry
  comparison normalizes through URL parsing, so URL-equivalent spellings
  cannot sidestep the fail-closed policy. Tamper evidence still fails
  closed.

Verified end to end against packagefeedproxy.microsoft.io, the registry
from the report in discussion 3787.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788776295&installation_model_id=426870&pr_number=13728&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13728&signature=b2b6aa4d81bd6544632aabf9f288064bce9be1222ad0c82b4411fbbbbd9ddb4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved automatic package-manager version switching across registries with different download hosts.
  * Registry tarball references can now be stored as integrity-only resolutions.
  * Added fallback signature verification through the canonical npm registry when configured registries lack signature metadata.

* **Bug Fixes**
  * Invalid or outdated package-manager lockfile entries are automatically re-resolved and repaired.
  * Invalid signatures still fail verification, while unavailable or unsigned mirror metadata produces a warning.
  * Improved handling of unsupported integrity formats and registry URL differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
