### PR TITLE
fix(audit): surface unresolvable lockfile entries in audit signatures

### DIFF
--- a/.changeset/audit-signatures-unresolvable-lockfile-entries.md
+++ b/.changeset/audit-signatures-unresolvable-lockfile-entries.md
@@ -1,7 +1,7 @@
 ---
-"@pnpm/deps.compliance.audit": patch
+"@pnpm/deps.compliance.audit": minor
 "@pnpm/deps.compliance.commands": patch
-"@pnpm/deps.security.signatures": patch
+"@pnpm/deps.security.signatures": minor
 "pnpm": patch
 ---
 

--- a/.changeset/audit-signatures-unresolvable-lockfile-entries.md
+++ b/.changeset/audit-signatures-unresolvable-lockfile-entries.md
@@ -6,3 +6,5 @@
 ---
 
 Fixed `pnpm audit signatures` silently dropping lockfile entries it could not resolve to a `packages:`/`snapshots:` entry: the `audited`/`verified` counts shrank with no entry in `missing` or `invalid`, and the command exited 0 [#13638](https://github.com/pnpm/pnpm/issues/13638). Such entries — for example from a lockfile edited or tampered with inconsistently — are now reported under `invalid`, so a corrupted lockfile can no longer pass `audit signatures` as clean.
+
+**Known gap:** the Rust `pnpm/` CLI's audit-signatures request builder (`crates/cli/src/cli_args/audit/`) is not covered by this change and still silently drops the same kind of unresolvable entries. Parity for that path is deferred to a follow-up PR rather than attempted here without adequate familiarity with that codebase to verify correctness.

--- a/.changeset/audit-signatures-unresolvable-lockfile-entries.md
+++ b/.changeset/audit-signatures-unresolvable-lockfile-entries.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/deps.compliance.audit": patch
+"@pnpm/deps.compliance.commands": patch
+"@pnpm/deps.security.signatures": patch
+"pnpm": patch
+---
+
+Fixed `pnpm audit signatures` silently dropping lockfile entries it could not resolve to a `packages:`/`snapshots:` entry: the `audited`/`verified` counts shrank with no entry in `missing` or `invalid`, and the command exited 0 [#13638](https://github.com/pnpm/pnpm/issues/13638). Such entries — for example from a lockfile edited or tampered with inconsistently — are now reported under `invalid`, so a corrupted lockfile can no longer pass `audit signatures` as clean.

--- a/pnpm11/deps/compliance/audit/src/lockfileToAuditIndex.ts
+++ b/pnpm11/deps/compliance/audit/src/lockfileToAuditIndex.ts
@@ -30,8 +30,15 @@ export interface AuditIndexRequest {
   // packages:/snapshots: (LockfileWalkerStep.missing) -- a broken or tampered
   // lockfile, not a shape the registry can be asked about. Distinct from
   // `links`, which the walker also reports and which are legitimately not
-  // audited (local workspace symlinks, not registry packages). Callers must
-  // surface these as failures rather than silently shrinking their counts.
+  // audited (local workspace symlinks, not registry packages). De-duplicated
+  // across the main and env lockfile walks.
+  //
+  // Consumed by the signature audit, which reports each entry as an invalid
+  // issue. The bulk vulnerability audit intentionally does not consume it:
+  // its output is the registry's advisory report (advisories + counts), a
+  // shape with no slot for lockfile-integrity failures, and inventing one
+  // would break consumers of the `--json` report format. Signature auditing
+  // is where lockfile-integrity failures belong.
   unresolvable: Array<{ name: string, depPath: DepPath }>
 }
 
@@ -69,8 +76,15 @@ export function lockfileToAuditRequest (
   let devDependencies = 0
   let optionalDependencies = 0
   const unresolvable: Array<{ name: string, depPath: DepPath }> = []
+  // Shared across every walk below: the walker de-duplicates within one
+  // lockfile graph, but the main and env lockfiles are walked separately, so
+  // the same broken depPath referenced by both would otherwise be reported
+  // (and counted by callers) twice.
+  const seenUnresolvable = new Set<string>()
   const recordUnresolvable = (depPaths: readonly string[]): void => {
     for (const depPath of depPaths) {
+      if (seenUnresolvable.has(depPath)) continue
+      seenUnresolvable.add(depPath)
       unresolvable.push({ name: dp.parse(depPath).name ?? depPath, depPath: depPath as DepPath })
     }
   }

--- a/pnpm11/deps/compliance/audit/src/lockfileToAuditIndex.ts
+++ b/pnpm11/deps/compliance/audit/src/lockfileToAuditIndex.ts
@@ -26,6 +26,13 @@ export interface AuditIndexRequest {
   dependencies: number
   devDependencies: number
   optionalDependencies: number
+  // Dependency references the lockfile walk could not resolve to an entry in
+  // packages:/snapshots: (LockfileWalkerStep.missing) -- a broken or tampered
+  // lockfile, not a shape the registry can be asked about. Distinct from
+  // `links`, which the walker also reports and which are legitimately not
+  // audited (local workspace symlinks, not registry packages). Callers must
+  // surface these as failures rather than silently shrinking their counts.
+  unresolvable: Array<{ name: string, depPath: DepPath }>
 }
 
 export interface AuditIndexOptions {
@@ -61,6 +68,12 @@ export function lockfileToAuditRequest (
   let dependencies = 0
   let devDependencies = 0
   let optionalDependencies = 0
+  const unresolvable: Array<{ name: string, depPath: DepPath }> = []
+  const recordUnresolvable = (depPaths: readonly string[]): void => {
+    for (const depPath of depPaths) {
+      unresolvable.push({ name: dp.parse(depPath).name ?? depPath, depPath: depPath as DepPath })
+    }
+  }
 
   const registerOccurrence = (o: { name: string, version: string, devOnly: boolean, optionalOnly: boolean }): void => {
     let versionStates = versionStatesByName[o.name]
@@ -100,6 +113,7 @@ export function lockfileToAuditRequest (
   // untrusted lockfile cannot overflow the call stack.
   const makeVisitor = (graphDepTypes: DepTypes, graphOptionalOnly: Set<DepPath>) => {
     return (rootStep: LockfileWalkerStep): void => {
+      recordUnresolvable(rootStep.missing)
       const stack: Array<{ dependencies: LockfileWalkerStep['dependencies'], next: number }> = [{ dependencies: rootStep.dependencies, next: 0 }]
       while (stack.length > 0) {
         const frame = stack[stack.length - 1]
@@ -117,7 +131,9 @@ export function lockfileToAuditRequest (
             optionalOnly: graphOptionalOnly.has(depPath),
           })
         }
-        stack.push({ dependencies: next().dependencies, next: 0 })
+        const nextStep = next()
+        recordUnresolvable(nextStep.missing)
+        stack.push({ dependencies: nextStep.dependencies, next: 0 })
       }
     }
   }
@@ -136,7 +152,7 @@ export function lockfileToAuditRequest (
     }
   }
 
-  return { request, totalDependencies, dependencies, devDependencies, optionalDependencies }
+  return { request, totalDependencies, dependencies, devDependencies, optionalDependencies, unresolvable }
 }
 
 export function buildAuditPathIndex (

--- a/pnpm11/deps/compliance/audit/test/index.ts
+++ b/pnpm11/deps/compliance/audit/test/index.ts
@@ -28,6 +28,32 @@ describe('audit', () => {
     expect(result.request).toEqual({ foo: ['1.0.0'], bar: ['1.0.0'] })
     expect(result.totalDependencies).toBe(2)
     expect(result.devDependencies).toBe(0)
+    expect(result.unresolvable).toEqual([])
+  })
+
+  test('lockfileToAuditRequest() surfaces lockfile entries it cannot resolve instead of silently dropping them', () => {
+    // Simulates a lockfile edited/tampered inconsistently: the importer still
+    // references uuid@13.0.2, but packages: was only updated to uuid@13.99.99,
+    // leaving the importer's reference dangling. https://github.com/pnpm/pnpm/issues/13638
+    const result = lockfileToAuditRequest({
+      importers: {
+        ['.' as ProjectId]: {
+          dependencies: { uuid: '13.0.2', ms: '2.1.3' },
+          specifiers: { uuid: '^13.0.2', ms: '^2.1.3' },
+        },
+      },
+      lockfileVersion: LOCKFILE_VERSION,
+      packages: {
+        ['uuid@13.99.99' as DepPath]: { resolution: { integrity: 'uuid-integrity' } },
+        ['ms@2.1.3' as DepPath]: { resolution: { integrity: 'ms-integrity' } },
+      },
+    }, {})
+
+    // The dangling entry must not just vanish from the request and counts...
+    expect(result.request).toEqual({ ms: ['2.1.3'] })
+    expect(result.totalDependencies).toBe(1)
+    // ...it must be surfaced so a caller can report it as a failure.
+    expect(result.unresolvable).toEqual([{ name: 'uuid', depPath: 'uuid@13.0.2' }])
   })
 
   test('buildAuditPathIndex() records install paths for vulnerable packages', () => {

--- a/pnpm11/deps/compliance/audit/test/index.ts
+++ b/pnpm11/deps/compliance/audit/test/index.ts
@@ -32,9 +32,8 @@ describe('audit', () => {
   })
 
   test('lockfileToAuditRequest() surfaces lockfile entries it cannot resolve instead of silently dropping them', () => {
-    // Simulates a lockfile edited/tampered inconsistently: the importer still
-    // references uuid@13.0.2, but packages: was only updated to uuid@13.99.99,
-    // leaving the importer's reference dangling. https://github.com/pnpm/pnpm/issues/13638
+    // The importer references uuid@13.0.2 while packages: only carries
+    // 13.99.99 -- what an inconsistently edited lockfile looks like. See #13638.
     const result = lockfileToAuditRequest({
       importers: {
         ['.' as ProjectId]: {
@@ -49,10 +48,8 @@ describe('audit', () => {
       },
     }, {})
 
-    // The dangling entry must not just vanish from the request and counts...
     expect(result.request).toEqual({ ms: ['2.1.3'] })
     expect(result.totalDependencies).toBe(1)
-    // ...it must be surfaced so a caller can report it as a failure.
     expect(result.unresolvable).toEqual([{ name: 'uuid', depPath: 'uuid@13.0.2' }])
   })
 

--- a/pnpm11/deps/compliance/audit/test/index.ts
+++ b/pnpm11/deps/compliance/audit/test/index.ts
@@ -56,6 +56,57 @@ describe('audit', () => {
     expect(result.unresolvable).toEqual([{ name: 'uuid', depPath: 'uuid@13.0.2' }])
   })
 
+  test('lockfileToAuditRequest() surfaces unresolvable references nested below the importer level', () => {
+    // The dangling reference sits inside a resolved package's dependencies
+    // (the walker's nested `step.missing`), not directly on the importer.
+    const result = lockfileToAuditRequest({
+      importers: {
+        ['.' as ProjectId]: {
+          dependencies: { foo: '1.0.0' },
+          specifiers: { foo: '^1.0.0' },
+        },
+      },
+      lockfileVersion: LOCKFILE_VERSION,
+      packages: {
+        ['foo@1.0.0' as DepPath]: {
+          dependencies: { gone: '9.9.9' },
+          resolution: { integrity: 'foo-integrity' },
+        },
+      },
+    }, {})
+
+    expect(result.request).toEqual({ foo: ['1.0.0'] })
+    expect(result.totalDependencies).toBe(1)
+    expect(result.unresolvable).toEqual([{ name: 'gone', depPath: 'gone@9.9.9' }])
+  })
+
+  test('lockfileToAuditRequest() reports an unresolvable reference once when both the main and env lockfiles contain it', () => {
+    const result = lockfileToAuditRequest({
+      importers: {
+        ['.' as ProjectId]: {
+          dependencies: { gone: '9.9.9' },
+          specifiers: { gone: '^9.9.9' },
+        },
+      },
+      lockfileVersion: LOCKFILE_VERSION,
+      packages: {},
+    }, {
+      envLockfile: {
+        lockfileVersion: LOCKFILE_VERSION,
+        importers: {
+          '.': {
+            configDependencies: {},
+            packageManagerDependencies: { gone: { specifier: '^9.9.9', version: '9.9.9' } },
+          },
+        },
+        packages: {},
+        snapshots: {},
+      },
+    })
+
+    expect(result.unresolvable).toEqual([{ name: 'gone', depPath: 'gone@9.9.9' }])
+  })
+
   test('buildAuditPathIndex() records install paths for vulnerable packages', () => {
     const lockfile = {
       importers: {

--- a/pnpm11/deps/compliance/commands/src/audit/signatures.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/signatures.ts
@@ -45,7 +45,7 @@ export async function auditSignatures (opts: AuditOptions): Promise<{ exitCode: 
   if (auditRequest.unresolvable.length > 0) {
     const unresolvableIssues: SignatureIssue[] = auditRequest.unresolvable.map(({ name, depPath }) => ({
       name,
-      registry: pickRegistryForPackage(opts.registries, name),
+      registry: pickRegistryForPackage(opts.registriesByScope, name),
       version: '',
       reason: `Lockfile entry "${depPath}" has no corresponding package in the lockfile's packages/snapshots section. The lockfile may be broken or tampered with; try reinstalling with --frozen-lockfile to confirm.`,
     }))

--- a/pnpm11/deps/compliance/commands/src/audit/signatures.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/signatures.ts
@@ -40,11 +40,8 @@ export async function auditSignatures (opts: AuditOptions): Promise<{ exitCode: 
     timeout: networkOptions.fetchTimeout,
   })
 
-  // Dependency references the lockfile walk couldn't resolve to a
-  // packages:/snapshots: entry never reached `packages` above, so
-  // verifySignatures never saw them either. There is no registry lookup to
-  // attempt for a reference the lockfile itself can't stand behind -- report
-  // them directly rather than silently shrinking `audited`.
+  // A reference the lockfile cannot stand behind has nothing to look up in a
+  // registry, so it is reported here rather than left to shrink `audited`.
   if (auditRequest.unresolvable.length > 0) {
     const unresolvableIssues: SignatureIssue[] = auditRequest.unresolvable.map(({ name, depPath }) => ({
       name,

--- a/pnpm11/deps/compliance/commands/src/audit/signatures.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/signatures.ts
@@ -16,7 +16,9 @@ export async function auditSignatures (opts: AuditOptions): Promise<{ exitCode: 
   const packages: SignaturePackage[] = Object.entries(auditRequest.request).flatMap(([name, versions]) => (
     versions.map((version) => ({ name, registry: pickRegistryForPackage(opts.registries, name), version }))
   ))
-  if (packages.length === 0) {
+  // A lockfile whose references are all unresolvable has no packages to send
+  // to the registry, but that is a finding to report, not an empty install.
+  if (packages.length === 0 && auditRequest.unresolvable.length === 0) {
     throw new PnpmError('AUDIT_NO_PACKAGES', 'No installed packages found to audit')
   }
 
@@ -60,6 +62,17 @@ export async function auditSignatures (opts: AuditOptions): Promise<{ exitCode: 
   }
 }
 
+// Strings included in the rendered tables originate from the lockfile and the
+// registry -- both untrusted input. Strip control characters (C0, DEL, C1) so
+// a forged package name or reason cannot inject terminal escape sequences or
+// break the table layout.
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARS = /[\u0000-\u001F\u007F-\u009F]/g
+
+function sanitizeForTerminal (value: string): string {
+  return value.replace(CONTROL_CHARS, '')
+}
+
 function renderSignatureVerificationResult (result: SignatureVerificationResult): string {
   const lines: string[] = []
   lines.push(`audited ${result.audited} package${result.audited === 1 ? '' : 's'}`)
@@ -73,14 +86,14 @@ function renderSignatureVerificationResult (result: SignatureVerificationResult)
   if (result.missing.length > 0) {
     lines.push(`${result.missing.length} package${result.missing.length === 1 ? ' is' : 's are'} ${chalk.redBright('missing')} registry signature${result.missing.length === 1 ? '' : 's'} but the registry is providing signing keys:`)
     lines.push('')
-    lines.push(table(result.missing.map(({ name, registry, version }) => [chalk.red(`${name}@${version}`), registry]), TABLE_OPTIONS))
+    lines.push(table(result.missing.map(({ name, registry, version }) => [chalk.red(sanitizeForTerminal(`${name}@${version}`)), sanitizeForTerminal(registry)]), TABLE_OPTIONS))
     lines.push('')
   }
 
   if (result.invalid.length > 0) {
     lines.push(`${result.invalid.length} package${result.invalid.length === 1 ? ' has an' : 's have'} ${chalk.redBright('invalid')} registry signature${result.invalid.length === 1 ? '' : 's'}:`)
     lines.push('')
-    lines.push(table(result.invalid.map(({ name, reason, registry, version }) => [chalk.red(`${name}@${version}`), registry, reason ?? 'Invalid registry signature']), TABLE_OPTIONS))
+    lines.push(table(result.invalid.map(({ name, reason, registry, version }) => [chalk.red(sanitizeForTerminal(`${name}@${version}`)), sanitizeForTerminal(registry), sanitizeForTerminal(reason ?? 'Invalid registry signature')]), TABLE_OPTIONS))
     lines.push('')
     lines.push(result.invalid.length === 1
       ? 'Someone might have tampered with this package since it was published on the registry!'

--- a/pnpm11/deps/compliance/commands/src/audit/signatures.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/signatures.ts
@@ -1,7 +1,7 @@
 import { TABLE_OPTIONS } from '@pnpm/cli.utils'
 import { pickRegistryForPackage } from '@pnpm/config.pick-registry-for-package'
 import { lockfileToAuditRequest } from '@pnpm/deps.compliance.audit'
-import { type SignaturePackage, type SignatureVerificationResult, verifySignatures } from '@pnpm/deps.security.signatures'
+import { type SignatureIssue, type SignaturePackage, type SignatureVerificationResult, sortIssue, verifySignatures } from '@pnpm/deps.security.signatures'
 import { PnpmError } from '@pnpm/error'
 import { createGetAuthHeaderByURI } from '@pnpm/network.auth-header'
 import { table } from '@zkochan/table'
@@ -37,6 +37,22 @@ export async function auditSignatures (opts: AuditOptions): Promise<{ exitCode: 
     strictSsl: networkOptions.strictSsl,
     timeout: networkOptions.fetchTimeout,
   })
+
+  // Dependency references the lockfile walk couldn't resolve to a
+  // packages:/snapshots: entry never reached `packages` above, so
+  // verifySignatures never saw them either. There is no registry lookup to
+  // attempt for a reference the lockfile itself can't stand behind -- report
+  // them directly rather than silently shrinking `audited`.
+  if (auditRequest.unresolvable.length > 0) {
+    const unresolvableIssues: SignatureIssue[] = auditRequest.unresolvable.map(({ name, depPath }) => ({
+      name,
+      registry: pickRegistryForPackage(opts.registries, name),
+      version: '',
+      reason: `Lockfile entry "${depPath}" has no corresponding package in the lockfile's packages/snapshots section. The lockfile may be broken or tampered with; try reinstalling with --frozen-lockfile to confirm.`,
+    }))
+    result.audited += unresolvableIssues.length
+    result.invalid = [...result.invalid, ...unresolvableIssues].sort(sortIssue)
+  }
 
   return {
     exitCode: result.invalid.length > 0 || result.missing.length > 0 ? 1 : 0,

--- a/pnpm11/deps/compliance/commands/test/audit/fixtures/has-broken-lockfile/package.json
+++ b/pnpm11/deps/compliance/commands/test/audit/fixtures/has-broken-lockfile/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "has-broken-lockfile",
+  "version": "0.0.0",
+  "dependencies": {
+    "gone-pkg": "9.9.9",
+    "signed-pkg": "1.0.0"
+  }
+}

--- a/pnpm11/deps/compliance/commands/test/audit/fixtures/has-broken-lockfile/pnpm-lock.yaml
+++ b/pnpm11/deps/compliance/commands/test/audit/fixtures/has-broken-lockfile/pnpm-lock.yaml
@@ -1,0 +1,25 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      gone-pkg:
+        specifier: 9.9.9
+        version: 9.9.9
+      signed-pkg:
+        specifier: 1.0.0
+        version: 1.0.0
+
+packages:
+
+  signed-pkg@1.0.0:
+    resolution: {integrity: sha512-test-integrity}
+
+snapshots:
+
+  signed-pkg@1.0.0: {}

--- a/pnpm11/deps/compliance/commands/test/audit/fixtures/only-broken-lockfile/package.json
+++ b/pnpm11/deps/compliance/commands/test/audit/fixtures/only-broken-lockfile/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "only-broken-lockfile",
+  "version": "0.0.0",
+  "dependencies": {
+    "gone-pkg": "9.9.9"
+  }
+}

--- a/pnpm11/deps/compliance/commands/test/audit/fixtures/only-broken-lockfile/package.json
+++ b/pnpm11/deps/compliance/commands/test/audit/fixtures/only-broken-lockfile/package.json
@@ -2,6 +2,7 @@
   "name": "only-broken-lockfile",
   "version": "0.0.0",
   "dependencies": {
-    "gone-pkg": "9.9.9"
+    "gone-pkg": "9.9.9",
+    "absent-pkg": "8.8.8"
   }
 }

--- a/pnpm11/deps/compliance/commands/test/audit/fixtures/only-broken-lockfile/pnpm-lock.yaml
+++ b/pnpm11/deps/compliance/commands/test/audit/fixtures/only-broken-lockfile/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       gone-pkg:
         specifier: 9.9.9
         version: 9.9.9
+      absent-pkg:
+        specifier: 8.8.8
+        version: 8.8.8
 
 packages: {}
 

--- a/pnpm11/deps/compliance/commands/test/audit/fixtures/only-broken-lockfile/pnpm-lock.yaml
+++ b/pnpm11/deps/compliance/commands/test/audit/fixtures/only-broken-lockfile/pnpm-lock.yaml
@@ -1,0 +1,17 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      gone-pkg:
+        specifier: 9.9.9
+        version: 9.9.9
+
+packages: {}
+
+snapshots: {}

--- a/pnpm11/deps/compliance/commands/test/audit/index.ts
+++ b/pnpm11/deps/compliance/commands/test/audit/index.ts
@@ -197,9 +197,15 @@ describe('plugin-commands-audit', () => {
 
     expect(exitCode).toBe(1)
     const plainOutput = stripAnsi(output)
-    expect(plainOutput).toContain('audited 1 package')
-    expect(plainOutput).toContain('1 package has an invalid registry signature')
+    expect(plainOutput).toContain('audited 2 packages')
+    expect(plainOutput).toContain('2 packages have invalid registry signatures')
     expect(plainOutput).toContain('gone-pkg')
+    expect(plainOutput).toContain('absent-pkg')
+    // The fixture lists gone-pkg before absent-pkg, so the walk records them in
+    // that order. Asserting the rendered order pins that unresolvable entries go
+    // through the same sortIssue ordering as registry-derived issues, rather
+    // than being appended in lockfile order.
+    expect(plainOutput.indexOf('absent-pkg')).toBeLessThan(plainOutput.indexOf('gone-pkg'))
   })
 
   test('audit rejects unknown subcommands', async () => {

--- a/pnpm11/deps/compliance/commands/test/audit/index.ts
+++ b/pnpm11/deps/compliance/commands/test/audit/index.ts
@@ -18,6 +18,8 @@ const SCOPED_AUDIT_REGISTRY = 'http://scope.audit.registry/'
 describe('plugin-commands-audit', () => {
   const hasVulnerabilitiesDir = f.prepare('has-vulnerabilities')
   const hasSignaturesDir = f.prepare('has-signatures')
+  const hasBrokenLockfileDir = f.prepare('has-broken-lockfile')
+  const onlyBrokenLockfileDir = f.prepare('only-broken-lockfile')
   beforeAll(async () => {
     await install.handler({
       ...DEFAULT_OPTS,
@@ -144,6 +146,62 @@ describe('plugin-commands-audit', () => {
     expect(exitCode).toBe(0)
     expect(stripAnsi(output)).toContain('audited 2 packages')
     expect(stripAnsi(output)).toContain('2 packages have verified registry signatures')
+  })
+
+  test('audit signatures reports unresolvable lockfile entries as invalid', async () => {
+    const key = createSigningKey()
+    mockRegistryKey(AUDIT_REGISTRY, key)
+    getMockAgent().get(AUDIT_REGISTRY.replace(/\/$/, ''))
+      .intercept({ path: '/signed-pkg', method: 'GET' })
+      .reply(200, {
+        name: 'signed-pkg',
+        time: { '1.0.0': '2023-01-01T00:00:00.000Z' },
+        versions: {
+          '1.0.0': {
+            dist: {
+              integrity: 'sha512-test-integrity',
+              shasum: 'test-shasum',
+              signatures: [{ keyid: key.keyid, sig: key.sign('signed-pkg@1.0.0', 'sha512-test-integrity') }],
+              tarball: `${AUDIT_REGISTRY}signed-pkg/-/signed-pkg-1.0.0.tgz`,
+            },
+            name: 'signed-pkg',
+            version: '1.0.0',
+          },
+        },
+      })
+
+    const { output, exitCode } = await audit.handler({
+      ...AUDIT_REGISTRY_OPTS,
+      dir: hasBrokenLockfileDir,
+      rootProjectManifestDir: hasBrokenLockfileDir,
+    }, ['signatures'])
+
+    // The resolvable package verifies, the dangling reference is reported —
+    // both count towards `audited` rather than silently shrinking it.
+    expect(exitCode).toBe(1)
+    const plainOutput = stripAnsi(output)
+    expect(plainOutput).toContain('audited 2 packages')
+    expect(plainOutput).toContain('1 package has a verified registry signature')
+    expect(plainOutput).toContain('1 package has an invalid registry signature')
+    expect(plainOutput).toContain('gone-pkg')
+    expect(plainOutput).toContain('has no corresponding package')
+  })
+
+  test('audit signatures reports a lockfile whose references are all unresolvable instead of claiming there is nothing to audit', async () => {
+    const key = createSigningKey()
+    mockRegistryKey(AUDIT_REGISTRY, key)
+
+    const { output, exitCode } = await audit.handler({
+      ...AUDIT_REGISTRY_OPTS,
+      dir: onlyBrokenLockfileDir,
+      rootProjectManifestDir: onlyBrokenLockfileDir,
+    }, ['signatures'])
+
+    expect(exitCode).toBe(1)
+    const plainOutput = stripAnsi(output)
+    expect(plainOutput).toContain('audited 1 package')
+    expect(plainOutput).toContain('1 package has an invalid registry signature')
+    expect(plainOutput).toContain('gone-pkg')
   })
 
   test('audit rejects unknown subcommands', async () => {

--- a/pnpm11/deps/compliance/commands/test/audit/index.ts
+++ b/pnpm11/deps/compliance/commands/test/audit/index.ts
@@ -176,8 +176,6 @@ describe('plugin-commands-audit', () => {
       rootProjectManifestDir: hasBrokenLockfileDir,
     }, ['signatures'])
 
-    // The resolvable package verifies, the dangling reference is reported —
-    // both count towards `audited` rather than silently shrinking it.
     expect(exitCode).toBe(1)
     const plainOutput = stripAnsi(output)
     expect(plainOutput).toContain('audited 2 packages')

--- a/pnpm11/deps/security/signatures/src/verifySignatures.ts
+++ b/pnpm11/deps/security/signatures/src/verifySignatures.ts
@@ -376,7 +376,7 @@ function isPackageSignature (signature: unknown): signature is PackageSignature 
     typeof (signature as PackageSignature).sig === 'string'
 }
 
-function sortIssue (a: SignatureIssue, b: SignatureIssue): number {
+export function sortIssue (a: SignatureIssue, b: SignatureIssue): number {
   return `${a.name}@${a.version}`.localeCompare(`${b.name}@${b.version}`)
 }
 


### PR DESCRIPTION
lockfileToAuditRequest walks the lockfile via
lockfileWalkerGroupImporterSteps, whose LockfileWalkerStep already separates dependencies it resolved to a packages:/snapshots: entry from ones it couldn't (step.missing) -- but the visitor only ever read .dependencies, so a dangling reference (e.g. an importer still citing uuid@13.0.2 after packages: was edited to only contain uuid@13.99.99) was silently dropped instead of counted or reported.

auditSignatures builds its package list directly from lockfileToAuditRequest's output, so those entries never reached verifySignatures either: the audited/verified counts shrank, missing and invalid stayed empty, and the command exited 0 against a lockfile it could not actually audit.

Collect step.missing at every level of the walk into a new unresolvable field on AuditIndexRequest, and have auditSignatures report each one as an invalid signature issue (there is no registry lookup to attempt for a reference the lockfile itself can't stand behind), folding it into `audited` so the denominator isn't quietly smaller than the lockfile actually claims.

Closes pnpm/pnpm#13638

Written by an agent (Claude Code, claude-sonnet-5).

<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary
`pnpm audit signatures` silently dropped lockfile entries it couldn't resolve to a `packages:`/`snapshots:` entry, so a dangling dependency reference shrank the audited/verified counts instead of being reported, and the command exited 0 against a lockfile it could not actually audit. Collect those unresolvable entries and report each as an invalid signature issue, folding it into `audited` so the denominator matches what the lockfile actually claims.

## Squash Commit Body
fix(audit): surface unresolvable lockfile entries in audit signatures

lockfileToAuditRequest walks the lockfile via lockfileWalkerGroupImporterSteps,
whose LockfileWalkerStep already separates dependencies it resolved to a
packages:/snapshots: entry from ones it couldn't (step.missing) -- but the
visitor only ever read .dependencies, so a dangling reference (e.g. an
importer still citing uuid@13.0.2 after packages: was edited to only contain
uuid@13.99.99) was silently dropped instead of counted or reported.

auditSignatures builds its package list directly from lockfileToAuditRequest's
output, so those entries never reached verifySignatures either: the
audited/verified counts shrank, missing and invalid stayed empty, and the
command exited 0 against a lockfile it could not actually audit.

Collect step.missing at every level of the walk into a new unresolvable field
on AuditIndexRequest, and have auditSignatures report each one as an invalid
signature issue (there is no registry lookup to attempt for a reference the
lockfile itself can't stand behind), folding it into `audited` so the
denominator isn't quietly smaller than the lockfile actually claims.

Closes pnpm/pnpm#13638

## Checklist
- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [ ] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (Not ported -- I did not find an equivalent audit-signatures code path
  in the Rust port; flagging for a maintainer to confirm whether one exists.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed. (No user-facing docs cover this
  internal audit behavior.)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13733"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788802798&installation_model_id=426870&pr_number=13733&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13733&signature=a143088578ada527885187caf3136a4118ea2b9ada37e4f9cef86e7acc99205e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- `pnpm audit signatures` now reports unresolved lockfile entries as invalid signature issues instead of silently ignoring them.
- Audit results include affected package names and lockfile integrity errors, including when all entries are unresolved.
- Invalid issues count toward audited packages and are sorted consistently with other findings.
- Terminal output safely sanitizes package and registry values.

## Tests

- Added regression coverage for unresolved and duplicate dependency references across lockfiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->