### PR TITLE
fix(dlx): drop the caller project's patches from the cache install

### DIFF
--- a/.changeset/dlx-ignores-caller-patches.md
+++ b/.changeset/dlx-ignores-caller-patches.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm dlx` and `pnpm create` work again in a project that has `patchedDependencies`. The caller's patches were carried into the throwaway cache install, whose patch paths no longer resolve, so every invocation failed with "Failed to read patch file". The cache install now ignores them, as pnpm does.

--- a/.changeset/dlx-ignores-caller-patches.md
+++ b/.changeset/dlx-ignores-caller-patches.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm dlx` and `pnpm create` work again in a project that has `patchedDependencies`. The caller's patches were carried into the throwaway cache install, whose patch paths no longer resolve, so every invocation failed with "Failed to read patch file". The cache install now ignores them, as pnpm does.
+`pnpm dlx` and `pnpm create` no longer fail with "Failed to read patch file" in a project that has `patchedDependencies`. As in pnpm, the package dlx runs is installed unpatched.

--- a/pnpm/crates/cli/src/cli_args/dlx.rs
+++ b/pnpm/crates/cli/src/cli_args/dlx.rs
@@ -300,6 +300,13 @@ async fn install_into_cache<Reporter: self::Reporter + 'static>(
     // rather than `None`, which walks up from the cache dir and can
     // adopt a stray `pnpm-workspace.yaml` above it (pnpm/pnpm#13697).
     config.workspace_dir = Some(prepare_dir.to_path_buf());
+    // The caller's patches never apply to the throwaway install (pnpm's
+    // dlx installs the package unpatched too). Their paths are relative
+    // to the caller's workspace root, which the anchor above replaced, so
+    // keeping them would also make every dlx invocation from a project
+    // with `patchedDependencies` fail on a patch file missing under the
+    // cache dir.
+    config.patched_dependencies = None;
     // Build a *fresh* allow-list for the throwaway install — the dlx
     // packages themselves plus the CLI `--allow-build` entries — rather
     // than inheriting the caller project's `allow_builds` /

--- a/pnpm/crates/cli/tests/suite/dlx.rs
+++ b/pnpm/crates/cli/tests/suite/dlx.rs
@@ -102,6 +102,55 @@ fn dlx_resolves_caller_catalog_references_in_overrides() {
     drop(root);
 }
 
+/// The caller project's `patchedDependencies` must not reach the dlx cache
+/// install: pnpm's dlx installs the package unpatched, and the configured
+/// paths are relative to the caller's workspace root, which the dlx install
+/// does not have. Inheriting them failed every dlx invocation from a project
+/// with patches, on a patch file missing under the cache dir.
+#[cfg(unix)]
+#[test]
+fn dlx_ignores_the_caller_projects_patched_dependencies() {
+    let CommandTempCwd { pacquet, root, workspace, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+
+    std::fs::create_dir(workspace.join("patches")).expect("create the caller's patches dir");
+    std::fs::write(
+        workspace.join("patches").join("touch-file-one-bin.patch"),
+        concat!(
+            "diff --git a/cli.js b/cli.js\n",
+            "--- a/cli.js\n",
+            "+++ b/cli.js\n",
+            "@@ -1,4 +1,4 @@\n",
+            " 'use strict'\n",
+            " const fs = require('fs')\n",
+            " \n",
+            "-fs.writeFileSync('touch.txt', 'hello world', 'utf8')\n",
+            "+fs.writeFileSync('patched.txt', 'hello world', 'utf8')\n",
+        ),
+    )
+    .expect("write the caller's patch");
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut workspace_yaml =
+        std::fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    workspace_yaml.push_str(
+        "patchedDependencies:\n  '@foo/touch-file-one-bin@1.0.0': patches/touch-file-one-bin.patch\n",
+    );
+    std::fs::write(&workspace_yaml_path, workspace_yaml).expect("add the caller's patch entry");
+
+    pacquet.with_arg("dlx").with_arg("@foo/touch-file-one-bin").assert().success();
+
+    assert!(
+        workspace.join("touch.txt").exists(),
+        "dlx must run the unpatched package, which writes `touch.txt`",
+    );
+    assert!(
+        !workspace.join("patched.txt").exists(),
+        "the caller's patch must not be applied to the dlx install",
+    );
+
+    drop(root);
+}
+
 /// The dlx cache install must stay anchored to its prepare dir even when a
 /// directory above the cache carries a `pnpm-workspace.yaml`. Left
 /// unanchored, the install pipeline walks up from the cache dir, adopts

--- a/pnpm/crates/cli/tests/suite/dlx.rs
+++ b/pnpm/crates/cli/tests/suite/dlx.rs
@@ -1,7 +1,3 @@
-// `assert_cmd::prelude::*` (for `.assert()`) is only used by the Unix-
-// gated dlx happy-path test below; gating the import avoids an
-// `unused_imports` error on Windows under clippy's `-D warnings`.
-#[cfg(unix)]
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pacquet_testing_utils::bin::CommandTempCwd;
@@ -102,13 +98,10 @@ fn dlx_resolves_caller_catalog_references_in_overrides() {
     drop(root);
 }
 
-/// The caller project's `patchedDependencies` must not reach the dlx cache
-/// install: pnpm's dlx installs the package unpatched, and the configured
-/// paths are relative to the caller's workspace root, which the dlx install
-/// does not have. Inheriting them failed every dlx invocation from a project
-/// with patches, on a patch file missing under the cache dir.
-#[cfg(unix)]
+/// pnpm's dlx installs the package unpatched, and the caller's patch paths
+/// are relative to a workspace root the cache install does not have.
 #[test]
+#[cfg_attr(not(unix), ignore = "dlx bin execution is only exercised on Unix")]
 fn dlx_ignores_the_caller_projects_patched_dependencies() {
     let CommandTempCwd { pacquet, root, workspace, .. } =
         CommandTempCwd::init().add_mocked_registry();


### PR DESCRIPTION
## Summary

`pnpm dlx` (and `pnpm create`, which routes through it) fails in any project that
uses `patchedDependencies`:

```
$ pnpm dlx cowsay hi
Error:   × adding a new package
  ╰─▶ Failed to read patch file /home/zoltan/.cache/pnpm/dlx/f35ea02…/mskn61f7-23wx0/__patches__/graceful-fs@4.2.11.patch: No such file or directory (os error 2)
```

The dlx cache install runs with the invoking project's already-loaded config,
which carries `patchedDependencies`, while its workspace root is anchored to the
throwaway prepare dir. Patch paths are resolved against the workspace root
(`Config::resolved_patched_dependencies`), so they end up pointing inside the dlx
cache dir, where nothing exists.

pnpm installs the dlx package unpatched — I verified this against the TypeScript
CLI: a `pnpm dlx --package=fs-extra …` run from this repo (which patches
`graceful-fs@4.2.11`) produces a dlx cache lockfile with no `patchedDependencies`
and an unpatched `graceful-fs`. So the cache install now drops the caller's
patches instead of rebasing the paths onto the caller's workspace — the same
treatment `overrides`, `catalogs`, and `packageExtensions` already get in the
global (`cli_args::global`) and self-update (`self_update::install_pnpm`)
installs. `patchedDependencies` is the only remaining `workspace_dir`-relative
config field, so no other setting needs the same handling.

This is also why CI is red on pnpm/pnpm#13675: this repo patches `graceful-fs`,
and `pn compile-only` shells out to `pnx`, so both `TS CI / Compile & Lint` and
the integrated benchmark fail there as soon as an affected release is pinned as
`packageManager`.

TypeScript CLI: no change needed — it already installs dlx packages unpatched
(verified by running the bundle, as described above).

## Squash Commit Body

```text
The dlx cache install inherits the invoking project's config, including
`patchedDependencies`, but its workspace root is anchored to the throwaway
prepare dir. Patch paths resolve against that root, so a caller with patches
sent the install looking for them under the dlx cache dir and every
`pnpm dlx` / `pnpm create` from such a project died with "Failed to read
patch file <cache dir>/... (os error 2)". This repo is one such project:
`pn compile-only` runs `pnx`, so TS CI and the integrated benchmark both go
red as soon as an affected release is pinned.

pnpm installs the dlx package unpatched (verified against the TypeScript
CLI: the dlx cache lockfile records no `patchedDependencies`), so the
throwaway install drops them rather than rebasing the paths onto the
caller's workspace — the same treatment `overrides`, `catalogs`, and
`packageExtensions` already get in the global and self-update installs.

Regression test: a dlx run from a project that patches the dlx package
itself must run the unpatched bin. It fails without the fix, on the exact
missing-patch-file error.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5[1m]).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788802864&installation_model_id=426870&pr_number=13734&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13734&signature=ff8ad73aa888e755a6435bfbade44946d8f036abe1a39a7da46d865c8536e457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `pnpm dlx` and `pnpm create` so temporary installations are not affected by `patchedDependencies` configured in the calling project.
  - Ensured packages run with their original contents when executed through these commands, preventing unexpected patched output.

- **Tests**
  - Added regression coverage confirming patched caller projects do not alter `dlx` execution results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->