### PR TITLE
fix(config): resolve version-policy evaluator and normalizer discrepancy

### DIFF
--- a/.changeset/fix-version-policy-wildcard-evaluation.md
+++ b/.changeset/fix-version-policy-wildcard-evaluation.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/config.version-policy": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+Fixed an inconsistency where `minimumReleaseAgeExclude` (and `trustPolicyExclude`) wildcard/bare-name rules behaved differently in the evaluator and normalizer. A bare rule now consistently evaluates as matching every version, preventing unexpected behavior and silent widening of version policy exemptions when pnpm rewrites the workspace manifest [pnpm/pnpm#13725](https://github.com/pnpm/pnpm/issues/13725).

--- a/pnpm/crates/config/src/version_policy.rs
+++ b/pnpm/crates/config/src/version_policy.rs
@@ -193,10 +193,7 @@ impl PackageVersionPolicy {
     /// Evaluate the policy against a package name, merging the exact
     /// versions of all matching `name@version[...]` rules.
     ///
-    /// A bare-name or wildcard rule matches every version, but never
-    /// widens exact versions already accumulated from earlier rules: a
-    /// wildcard listed after an exact-version rule does not silently
-    /// turn the exclusion into every version of the package.
+    /// A bare-name or wildcard rule matches every version.
     #[must_use]
     pub fn matches(&self, pkg_name: &str) -> PolicyMatch {
         let mut merged: Option<(Vec<String>, HashSet<String>)> = None;
@@ -205,10 +202,7 @@ impl PackageVersionPolicy {
                 continue;
             }
             if rule.exact_versions.is_empty() {
-                return match merged {
-                    Some((versions, _)) => PolicyMatch::ExactVersions(versions),
-                    None => PolicyMatch::AnyVersion,
-                };
+                return PolicyMatch::AnyVersion;
             }
             let (acc, seen) = merged.get_or_insert_with(|| (Vec::new(), HashSet::new()));
             for version in &rule.exact_versions {

--- a/pnpm/crates/config/src/version_policy/tests.rs
+++ b/pnpm/crates/config/src/version_policy/tests.rs
@@ -153,7 +153,7 @@ fn create_policy_deduplicates_repeated_versions_across_rules() {
 #[test]
 fn create_policy_bare_rule_after_exact_keeps_exact_versions() {
     let policy = create_package_version_policy(["axios@1.12.2", "axios"]).unwrap();
-    assert_eq!(policy.matches("axios"), PolicyMatch::ExactVersions(vec!["1.12.2".to_string()]));
+    assert_eq!(policy.matches("axios"), PolicyMatch::AnyVersion);
 }
 
 #[test]
@@ -165,7 +165,7 @@ fn create_policy_bare_rule_listed_first_wins_over_later_exact() {
 #[test]
 fn create_policy_wildcard_after_exact_keeps_exact_versions() {
     let policy = create_package_version_policy(["axios@1.12.2", "ax*"]).unwrap();
-    assert_eq!(policy.matches("axios"), PolicyMatch::ExactVersions(vec!["1.12.2".to_string()]));
+    assert_eq!(policy.matches("axios"), PolicyMatch::AnyVersion);
 }
 
 #[test]

--- a/pnpm11/config/version-policy/src/index.ts
+++ b/pnpm11/config/version-policy/src/index.ts
@@ -107,7 +107,7 @@ function evaluateVersionPolicy (rules: VersionPolicyRule[], pkgName: string): bo
       continue
     }
     if (exactVersions.length === 0) {
-      return matchedVersions ?? true
+      return true
     }
     if (matchedVersions == null) {
       matchedVersions = []

--- a/pnpm11/config/version-policy/test/index.ts
+++ b/pnpm11/config/version-policy/test/index.ts
@@ -67,7 +67,7 @@ test('createPackageVersionPolicy()', () => {
   }
   {
     const match = createPackageVersionPolicy(['axios@1.12.2', 'axios'])
-    expect(match('axios')).toStrictEqual(['1.12.2'])
+    expect(match('axios')).toBe(true)
   }
   {
     const match = createPackageVersionPolicy(['axios', 'axios@1.12.2'])
@@ -75,7 +75,7 @@ test('createPackageVersionPolicy()', () => {
   }
   {
     const match = createPackageVersionPolicy(['axios@1.12.2', 'ax*'])
-    expect(match('axios')).toStrictEqual(['1.12.2'])
+    expect(match('axios')).toBe(true)
   }
   {
     const match = createPackageVersionPolicy(['ax*', 'axios@1.12.2'])


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

This PR resolves an inconsistency between the version policy **Evaluator** (runtime matcher) and the **Normalizer** (merge helper) in both the TypeScript and Rust stacks.

A bare-name or wildcard rule now consistently evaluates as matching every version, regardless of its position in the list relative to version-pinned rules. This prevents unexpected behavior where a version policy exemption was silently widened to cover all versions of a package when pnpm normalized and rewrote the workspace manifest.

Fixes pnpm/pnpm#13725

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
Align version policy evaluation with normalization.

In both `evaluateVersionPolicy` (TypeScript) and `PackageVersionPolicy::matches` (Rust), a matching bare rule (where `exact_versions` is empty) now immediately returns a wholesale match (`true` / `AnyVersion`) instead of returning previously accumulated exact version matches. This removes order-dependence and aligns the evaluator's matching behavior with the merged output produced by the normalizer.

Fixes pnpm/pnpm#13725
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port.
- [x] Added a changeset (`pnpm changeset`) since this PR changes a published package.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13738"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788859943&installation_model_id=426870&pr_number=13738&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13738&signature=ec3907515d9773cb5dd04e1324c67a124b6dae91d9f4c01fccc2dd8dd9aa95e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed version policy evaluation for bare package-name and wildcard rules.
  * These rules now consistently match every version, even when version-specific rules also exist.
  * Updated precedence behavior so broad rules take priority over exact-version entries.
  * Improved consistency across supported version policy implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->