### PR TITLE
ci(docker): verify the release assets before trusting their checksums

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -71,18 +71,31 @@ jobs:
           fi
           echo "tags=$tags" >> "$GITHUB_OUTPUT"
 
+      # The digests handed to the image build have to mean more than "this is
+      # what we just downloaded" — the Dockerfile checks the asset against them,
+      # so a digest taken from an unverified download only proves the same bytes
+      # arrived twice. Each asset is verified against its build attestation
+      # first: sigstore-signed, recorded in a public transparency log, and tied
+      # to the release workflow running at the signed tag.
       - name: Compute pnpm tarball checksums
         id: checksums
         env:
           VERSION: ${{ steps.meta.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -eu
           base="https://github.com/pnpm/pnpm/releases/download/v${VERSION}"
+          workdir="$(mktemp -d)"
+          trap 'rm -rf "$workdir"' EXIT
           for pair in amd64:x64 arm64:arm64; do
             key="${pair%:*}"
             name="${pair#*:}"
-            sha="$(curl -fsSL --retry 3 --retry-delay 2 "${base}/pnpm-linux-${name}.tar.gz" \
-                   | sha256sum | awk '{print $1}')"
+            asset="$workdir/pnpm-linux-${name}.tar.gz"
+            curl -fsSL --retry 3 --retry-delay 2 -o "$asset" "${base}/pnpm-linux-${name}.tar.gz"
+            gh attestation verify "$asset" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/release.yml"
+            sha="$(sha256sum "$asset" | awk '{print $1}')"
             echo "sha_${key}=${sha}" >> "$GITHUB_OUTPUT"
           done
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,6 +22,8 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      # `gh attestation verify` reads the release attestations through the API.
+      attestations: read
     env:
       IMAGE: ghcr.io/${{ github.repository_owner }}/pnpm
     steps:
@@ -92,9 +94,14 @@ jobs:
             name="${pair#*:}"
             asset="$workdir/pnpm-linux-${name}.tar.gz"
             curl -fsSL --retry 3 --retry-delay 2 -o "$asset" "${base}/pnpm-linux-${name}.tar.gz"
+            # Pins the signing identity down to the tag, so an asset from a
+            # different release cannot pass on its own valid attestation.
+            # `--cert-identity` is an exact match on the certificate subject;
+            # `--signer-workflow` documents a path only, and a ref appended to
+            # it would be silently dropped if that ever stopped matching.
             gh attestation verify "$asset" \
               --repo "${GITHUB_REPOSITORY}" \
-              --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/release.yml"
+              --cert-identity "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/.github/workflows/release.yml@refs/tags/v${VERSION}"
             sha="$(sha256sum "$asset" | awk '{print $1}')"
             echo "sha_${key}=${sha}" >> "$GITHUB_OUTPUT"
           done


### PR DESCRIPTION
## Summary

`docker/Dockerfile` checks the tarball it downloads against a SHA-256 handed in as a build arg. That is the right shape — the expected digest comes from outside the artifact it describes — but the workflow produced that digest like this:

```sh
sha="$(curl -fsSL ".../pnpm-linux-${name}.tar.gz" | sha256sum | awk '{print $1}')"
```

It downloads the same asset and hashes it. So the check proves the bytes that reached the image build match the bytes that reached the workflow moments earlier: it catches a corrupted or truncated download, not a replaced release. A poisoned asset would have been hashed, passed to the build, and matched itself.

Each asset is now verified against its build attestation before being hashed. pnpm already publishes these — sigstore-signed, recorded in Rekor's public transparency log, with an in-toto release attestation binding the assets to the signed release tag — they simply weren't being checked anywhere.

`--cert-identity` pins the signing identity exactly — the release workflow **at the release's own tag** — so neither an attestation from another workflow in this repository nor one from a different release is enough.

## Testing

Ran the exact commands against v11.20.0:

| case | result |
|---|---|
| `pnpm-linux-x64.tar.gz`, identity pinned to its own tag | verified → `sha b4ad6ad2b21db2f8…` |
| `pnpm-linux-arm64.tar.gz`, identity pinned to its own tag | verified → `sha f00fc2041bb41742…` |
| v11.20.0 asset, identity pinned to `v11.19.0` | rejected |
| identity pinned to `docker.yml` instead of `release.yml` | rejected |
| one byte appended | rejected — no attestation exists for those bytes |

## Trade-off

Releases predating GitHub's asset attestations cannot be rebuilt with this in place. The oldest attested release is well below the versions this image ships, and an asset that cannot be verified should stop a publish rather than be waved through — so this fails closed rather than skipping the check when no attestation is found.

The Dockerfile itself is unchanged: it already had the right structure, and the fix belongs where the digest is produced.

The job declares `attestations: read`, which is what `gh attestation verify` reads through the API.

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Package downloads are now verified for authenticity using release attestations before their checksums are calculated.
  * Verification is tied to the expected release workflow and version tag.
  * Temporary files used during verification are automatically cleaned up after processing.
  * Secure authentication is used during attestation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->