### PR TITLE
test(pacquet): stop ambient pnpm configuration from reaching the suites

### DIFF
--- a/pnpm/crates/cli/tests/suite/_utils/mod.rs
+++ b/pnpm/crates/cli/tests/suite/_utils/mod.rs
@@ -5,6 +5,7 @@ use pacquet_modules_yaml::{Host as ModulesHost, Modules, read_modules_manifest};
 use pacquet_store_dir::{CafsFileInfo, StoreDir, StoreIndex};
 use pacquet_testing_utils::{
     bin::{AddMockedRegistry, CommandTempCwd},
+    command_env::CommandTestExt,
     fs::is_symlink_or_junction,
 };
 use pacquet_workspace_state::WorkspaceState;
@@ -24,7 +25,10 @@ use tempfile::TempDir;
 /// its first `.assert()`).
 #[must_use]
 pub fn pacquet_in(workspace: &Path) -> Command {
-    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm")
+        .expect("find the pnpm binary")
+        .with_current_dir(workspace)
+        .without_ambient_pnpm_config()
 }
 
 /// Strip whitespace and box-drawing glyphs out of a miette report so a

--- a/pnpm/crates/cli/tests/suite/global.rs
+++ b/pnpm/crates/cli/tests/suite/global.rs
@@ -7,6 +7,7 @@ use command_extra::CommandExtra;
 #[cfg(unix)]
 use pacquet_testing_utils::bin::AddMockedRegistry;
 use pacquet_testing_utils::bin::CommandTempCwd;
+use pacquet_testing_utils::command_env::CommandTestExt;
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -49,6 +50,7 @@ fn global_command(workspace: &Path, pnpm_home: &Path) -> Command {
         .with_current_dir(workspace)
         .with_env("PNPM_HOME", pnpm_home)
         .with_env("PATH", path)
+        .without_ambient_pnpm_config()
 }
 
 #[cfg(unix)]

--- a/pnpm/crates/cli/tests/suite/global.rs
+++ b/pnpm/crates/cli/tests/suite/global.rs
@@ -6,8 +6,7 @@ use assert_cmd::cargo::CommandCargoExt;
 use command_extra::CommandExtra;
 #[cfg(unix)]
 use pacquet_testing_utils::bin::AddMockedRegistry;
-use pacquet_testing_utils::bin::CommandTempCwd;
-use pacquet_testing_utils::command_env::CommandTestExt;
+use pacquet_testing_utils::{bin::CommandTempCwd, command_env::CommandTestExt};
 use std::{
     fs,
     path::{Path, PathBuf},

--- a/pnpm/crates/cli/tests/suite/global_shims.rs
+++ b/pnpm/crates/cli/tests/suite/global_shims.rs
@@ -3,6 +3,7 @@
 
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
+use pacquet_testing_utils::command_env::CommandTestExt;
 use std::{fs, path::Path, process::Command};
 use tempfile::TempDir;
 
@@ -14,6 +15,7 @@ const AUTO_TRUST_ENV: &str = "PNPM_AUTO_APPROVE_PROJECT_BINS_FOR_TESTS";
 fn shim_command(root: &TempDir, cwd: &Path, shim_args: &[&str]) -> Command {
     let mut command = Command::cargo_bin("pnpm")
         .unwrap()
+        .without_ambient_pnpm_config()
         .with_current_dir(cwd)
         .with_env("PNPM_HOME", root.path().join("pnpm-home"))
         .with_env("XDG_STATE_HOME", root.path().join("state"))

--- a/pnpm/crates/cli/tests/suite/package_manager_check.rs
+++ b/pnpm/crates/cli/tests/suite/package_manager_check.rs
@@ -556,26 +556,20 @@ fn run(command: Command, root: &Path, args: &[&str]) -> Output {
     command.env("PNPM_HOME", root.join("pnpm-home"));
     command.env("HOME", root);
     command.env("XDG_CONFIG_HOME", root.join("xdg-config"));
-    // Clear the inherited settings the checks read, without disturbing the
-    // ones a test set on purpose. Windows matches environment names
-    // case-insensitively, so an explicit `pnpm_config_pm_on_fail` must also
-    // suppress the removal of `PNPM_CONFIG_PM_ON_FAIL`.
+    // These checks run `exec node`, which resolves `node` from `PATH`. A
+    // context-aware global shim there would honour the deliberately
+    // unsatisfiable `devEngines.runtime` pin these fixtures declare and
+    // fail to fetch it, instead of running the node the test expects.
+    command.env("PNPM_SHIM_BYPASS", "1");
+    // The pnpm and npm settings these checks read are already gone:
+    // `CommandTempCwd::init` strips the inherited ones, and an explicit
+    // `env` on the command overrides that removal. `COREPACK_ROOT` is not
+    // one of them, so clear it here — unless a test set it on purpose.
+    // Windows matches environment names case-insensitively, so does this.
     let explicitly_set =
         command.get_envs().map(|(name, _)| name.to_string_lossy().into_owned()).collect::<Vec<_>>();
-    for name in [
-        "pnpm_config_pm_on_fail",
-        "PNPM_CONFIG_PM_ON_FAIL",
-        "pnpm_config_runtime_on_fail",
-        "PNPM_CONFIG_RUNTIME_ON_FAIL",
-        "npm_config_manage_package_manager_versions",
-        "NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS",
-        "pnpm_config_manage_package_manager_versions",
-        "PNPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS",
-        "COREPACK_ROOT",
-    ] {
-        if !explicitly_set.iter().any(|set_name| set_name.eq_ignore_ascii_case(name)) {
-            command.env_remove(name);
-        }
+    if !explicitly_set.iter().any(|name| name.eq_ignore_ascii_case("COREPACK_ROOT")) {
+        command.env_remove("COREPACK_ROOT");
     }
     let output = command.args(args).output().expect("run pacquet");
     dbg!(&output);

--- a/pnpm/crates/cli/tests/suite/with.rs
+++ b/pnpm/crates/cli/tests/suite/with.rs
@@ -2,8 +2,10 @@
 
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
-use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
-use pacquet_testing_utils::command_env::CommandTestExt;
+use pacquet_testing_utils::{
+    bin::{AddMockedRegistry, CommandTempCwd},
+    command_env::CommandTestExt,
+};
 use std::{
     fs,
     path::Path,

--- a/pnpm/crates/cli/tests/suite/with.rs
+++ b/pnpm/crates/cli/tests/suite/with.rs
@@ -3,6 +3,7 @@
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
+use pacquet_testing_utils::command_env::CommandTestExt;
 use std::{
     fs,
     path::Path,
@@ -188,13 +189,12 @@ fn with_current_requires_a_command() {
     drop(root);
 }
 
-fn test_command(mut command: Command, root: &Path) -> Command {
+fn test_command(command: Command, root: &Path) -> Command {
+    let mut command = command.without_ambient_pnpm_config();
     command.env("PNPM_HOME", root.join("pnpm-home"));
     command.env("HOME", root);
     command.env("XDG_CONFIG_HOME", root.join("xdg-config"));
     command.env_remove("COREPACK_ROOT");
-    command.env_remove("pnpm_config_pm_on_fail");
-    command.env_remove("PNPM_CONFIG_PM_ON_FAIL");
     command
 }
 

--- a/pnpm/crates/testing-utils/src/bin.rs
+++ b/pnpm/crates/testing-utils/src/bin.rs
@@ -1,4 +1,4 @@
-use crate::registry::TestRegistry;
+use crate::{command_env::CommandTestExt, registry::TestRegistry};
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use std::{fs, path::PathBuf, process::Command};
@@ -35,9 +35,11 @@ impl CommandTempCwd<()> {
             .expect("create temporary directory");
         let workspace = root.path().join("workspace");
         fs::create_dir(&workspace).expect("create temporary workspace for the commands");
-        let pacquet =
-            Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(&workspace);
-        let pnpm = Command::new("pnpm").with_current_dir(&workspace);
+        let pacquet = Command::cargo_bin("pnpm")
+            .expect("find the pnpm binary")
+            .with_current_dir(&workspace)
+            .without_ambient_pnpm_config();
+        let pnpm = Command::new("pnpm").with_current_dir(&workspace).without_ambient_pnpm_config();
         CommandTempCwd { pacquet, pnpm, root, workspace, npmrc_info: () }
     }
 }

--- a/pnpm/crates/testing-utils/src/command_env.rs
+++ b/pnpm/crates/testing-utils/src/command_env.rs
@@ -1,0 +1,58 @@
+//! Keep the pnpm processes a test spawns free of the ambient pnpm
+//! configuration.
+
+use std::{ffi::OsString, process::Command};
+
+/// Test-only additions to [`Command`].
+pub trait CommandTestExt {
+    /// Strip the pnpm and npm configuration variables out of the inherited
+    /// environment, so the spawned process is configured only by the
+    /// test's own `.npmrc` / workspace YAML and whatever the caller sets
+    /// afterwards.
+    ///
+    /// A spawned command inherits this process's environment, and pnpm
+    /// reads settings from `PNPM_CONFIG_*` / `pnpm_config_*` as well as
+    /// the npm spellings. One such variable in CI or in a contributor's
+    /// shell therefore reconfigures the pnpm under test: `pnpm/setup`
+    /// exports `PNPM_CONFIG_GLOBAL_SHIMS` to pin the runtime it installed,
+    /// which flipped the shim style the global-shims suites assert on.
+    ///
+    /// Call this at construction time so a later `env` still wins for
+    /// tests that exercise one of these settings deliberately.
+    #[must_use]
+    fn without_ambient_pnpm_config(self) -> Self;
+}
+
+impl CommandTestExt for Command {
+    fn without_ambient_pnpm_config(mut self) -> Self {
+        for name in ambient_pnpm_config_vars() {
+            self.env_remove(name);
+        }
+        self
+    }
+}
+
+/// The names in the current environment that [`is_pnpm_config_var`]
+/// matches.
+fn ambient_pnpm_config_vars() -> impl Iterator<Item = OsString> {
+    std::env::vars_os()
+        .map(|(name, _)| name)
+        .filter(|name| name.to_str().is_some_and(is_pnpm_config_var))
+}
+
+/// Whether `name` configures pnpm: either spelling of the `pnpm_config_`
+/// / `npm_config_` prefixes, or the context-aware shim kill switch.
+/// `PNPM_HOME` is deliberately not one of them — the suites spawn the
+/// ambient pnpm for their compatibility checks.
+fn is_pnpm_config_var(name: &str) -> bool {
+    const PREFIXES: [&str; 2] = ["pnpm_config_", "npm_config_"];
+    const SHIM_BYPASS: &str = "PNPM_SHIM_BYPASS";
+
+    name.eq_ignore_ascii_case(SHIM_BYPASS)
+        || PREFIXES.iter().any(|prefix| {
+            name.len() > prefix.len() && name[..prefix.len()].eq_ignore_ascii_case(prefix)
+        })
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/testing-utils/src/command_env.rs
+++ b/pnpm/crates/testing-utils/src/command_env.rs
@@ -50,7 +50,11 @@ fn is_pnpm_config_var(name: &str) -> bool {
 
     name.eq_ignore_ascii_case(SHIM_BYPASS)
         || PREFIXES.iter().any(|prefix| {
-            name.len() > prefix.len() && name[..prefix.len()].eq_ignore_ascii_case(prefix)
+            // `get`, not a slice: the environment is outside this process's
+            // control, and a name whose prefix-length byte falls inside a
+            // multi-byte character would panic every command construction.
+            name.len() > prefix.len()
+                && name.get(..prefix.len()).is_some_and(|head| head.eq_ignore_ascii_case(prefix))
         })
 }
 

--- a/pnpm/crates/testing-utils/src/command_env/tests.rs
+++ b/pnpm/crates/testing-utils/src/command_env/tests.rs
@@ -1,9 +1,14 @@
-use super::is_pnpm_config_var;
+use super::{CommandTestExt, is_pnpm_config_var};
+use crate::env_guard::EnvGuard;
+use command_extra::CommandExtra;
+use std::{ffi::OsStr, process::Command};
+
+const SETTING: &str = "PNPM_CONFIG_GLOBAL_SHIMS";
 
 #[test]
 fn pnpm_and_npm_settings_match_in_either_spelling() {
     for name in [
-        "PNPM_CONFIG_GLOBAL_SHIMS",
+        SETTING,
         "pnpm_config_global_shims",
         "PnPm_CoNfIg_GlObAl_ShImS",
         "NPM_CONFIG_REGISTRY",
@@ -16,10 +21,50 @@ fn pnpm_and_npm_settings_match_in_either_spelling() {
 }
 
 /// The suites locate the ambient pnpm they spawn for compatibility checks
-/// through the environment, and a bare prefix names no setting at all.
+/// through the environment, and a bare prefix names no setting at all. The
+/// last name puts a multi-byte character across the prefix boundary, which
+/// a slice would panic on rather than reject.
 #[test]
 fn the_environment_the_suites_rely_on_is_left_alone() {
-    for name in ["PNPM_HOME", "PATH", "HOME", "PNPM_CONFIG_", "npm_config_", "PNPM_SHIM_BYPASS_X"] {
+    for name in [
+        "PNPM_HOME",
+        "PATH",
+        "HOME",
+        "PNPM_CONFIG_",
+        "npm_config_",
+        "PNPM_SHIM_BYPASS_X",
+        "aaaaaaaaaaaéz",
+    ] {
         assert!(!is_pnpm_config_var(name), "{name} should be kept");
     }
+}
+
+/// The removal happens at construction precisely so that a test wanting one
+/// of these settings can still set it — the documented contract callers
+/// depend on.
+#[test]
+fn an_explicit_value_set_afterwards_survives_the_removal() {
+    let guard = EnvGuard::snapshot([SETTING]);
+    guard.set(SETTING, r#"{"node":false}"#);
+
+    let stripped = Command::new("pnpm").without_ambient_pnpm_config();
+    assert_eq!(env_value(&stripped, SETTING), None, "the inherited value should be removed");
+
+    let overridden =
+        Command::new("pnpm").without_ambient_pnpm_config().with_env(SETTING, r#"{"node":"auto"}"#);
+    assert_eq!(
+        env_value(&overridden, SETTING).as_deref(),
+        Some(OsStr::new(r#"{"node":"auto"}"#)),
+        "a later `env` should win over the removal",
+    );
+}
+
+/// What `command` will pass for `name`: `None` once it is removed, `Some`
+/// once it is set again.
+fn env_value(command: &Command, name: &str) -> Option<std::ffi::OsString> {
+    command
+        .get_envs()
+        .find(|(key, _)| *key == OsStr::new(name))
+        .and_then(|(_, value)| value)
+        .map(OsStr::to_os_string)
 }

--- a/pnpm/crates/testing-utils/src/command_env/tests.rs
+++ b/pnpm/crates/testing-utils/src/command_env/tests.rs
@@ -1,0 +1,25 @@
+use super::is_pnpm_config_var;
+
+#[test]
+fn pnpm_and_npm_settings_match_in_either_spelling() {
+    for name in [
+        "PNPM_CONFIG_GLOBAL_SHIMS",
+        "pnpm_config_global_shims",
+        "PnPm_CoNfIg_GlObAl_ShImS",
+        "NPM_CONFIG_REGISTRY",
+        "npm_config_registry",
+        "PNPM_SHIM_BYPASS",
+        "pnpm_shim_bypass",
+    ] {
+        assert!(is_pnpm_config_var(name), "{name} should be stripped");
+    }
+}
+
+/// The suites locate the ambient pnpm they spawn for compatibility checks
+/// through the environment, and a bare prefix names no setting at all.
+#[test]
+fn the_environment_the_suites_rely_on_is_left_alone() {
+    for name in ["PNPM_HOME", "PATH", "HOME", "PNPM_CONFIG_", "npm_config_", "PNPM_SHIM_BYPASS_X"] {
+        assert!(!is_pnpm_config_var(name), "{name} should be kept");
+    }
+}

--- a/pnpm/crates/testing-utils/src/lib.rs
+++ b/pnpm/crates/testing-utils/src/lib.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(dylint_lib = "perfectionist", register_tool(perfectionist))]
 
 pub mod bin;
+pub mod command_env;
 pub mod env_guard;
 pub mod fixtures;
 pub mod fs;


### PR DESCRIPTION
## Summary

The pacquet suites spawn `pnpm` as a sub-process, and a spawned command inherits the test process's environment. pnpm reads its settings from `PNPM_CONFIG_*` / `pnpm_config_*` (and the npm spellings) via the `pacquet_config` env overlay, so a single such variable in the environment reconfigures thousands of tests at once.

That is not hypothetical. `pnpm/setup` now exports `PNPM_CONFIG_GLOBAL_SHIMS={"node":false}` to `$GITHUB_ENV` to keep the runtime it installed authoritative (pnpm/setup#25). `$GITHUB_ENV` applies to every later step in the job, including `Test pacquet`, so `config.global_shims` resolved `node` to `Off`, `link_global_bins` wrote a direct shim, and `global_shims_auto_writes_context_aware_shims_for_node_runtime` failed on ubuntu and macos. A contributor with any pnpm setting exported in their shell hits the same class of failure locally. Two suites had already run into it and hand-listed the variables they knew to strip.

This adds `CommandTestExt::without_ambient_pnpm_config` in a new `pacquet-testing-utils::command_env` module and applies it where the suites construct their commands — `CommandTempCwd::init`, `_utils::pacquet_in`, `global.rs::global_command`, `global_shims.rs::shim_command`. The removal happens at construction, so a test that exercises one of these settings deliberately still wins with a later `env`. The two hand-rolled lists now share the helper.

It also fixes 4 `package_manager_check` tests that **already fail on main**, for a related reason: they run `exec node`, which resolves `node` from `PATH`. Where the global `node` is a context-aware shim, it honours the deliberately unsatisfiable `devEngines.runtime` pin those fixtures declare (`99999.0.0`) and dies trying to fetch it. CI has not seen this only because the pnpm it installs still writes direct shims — it would have started failing as soon as CI moved to a pnpm that writes context-aware ones, independently of this PR. Those checks are about `packageManager` behaviour, not shim dispatch, so their helper bypasses the dispatcher.

Related to pnpm/pnpm#13675.

## Squash Commit Body

```text
Every command the suites spawn inherits the test process's environment, and
pnpm reads its settings from `PNPM_CONFIG_*` / `pnpm_config_*` and the npm
spellings. One such variable therefore reconfigures the pnpm under test:
`pnpm/setup` exports `PNPM_CONFIG_GLOBAL_SHIMS` to keep the runtime it
installed authoritative, which made `link_global_bins` write direct shims and
failed the global-shims assertions in CI. A contributor with a setting
exported in their shell hits the same class of failure locally.

Add `CommandTestExt::without_ambient_pnpm_config` and apply it where the
suites construct their commands, so a test is configured only by its own
`.npmrc` / workspace YAML plus whatever it sets on the command — an explicit
`env` still wins, because the removal happens at construction. Two suites
already hand-listed the variables they knew to strip; they now share the
helper.

The `packageManager` checks additionally run `exec node`, resolving `node`
from `PATH`. A context-aware global shim there honours the deliberately
unsatisfiable `devEngines.runtime` pin those fixtures declare and fails to
fetch it, so bypass the dispatcher for them. That failure already reproduces
on main for anyone whose global pnpm writes context-aware shims; CI has not
seen it because the pnpm it installs still writes direct ones.

The scrub covers the shared command constructors. The ad-hoc
`Command::cargo_bin("pnpm")` sites scattered through the suites still inherit
the ambient environment; closing those needs either a sweep of every call
site or a process-wide scrub, which would mean a new dependency and `unsafe`.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <sub>Rust test harness only — no TypeScript counterpart exists.</sub>
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
  <sub>Not needed: test-harness only, no published behaviour changes.</sub>
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

## Verification

- Reproduced the CI failure locally by exporting `PNPM_CONFIG_GLOBAL_SHIMS={"node":false}`; with the fix, `global`, `with` and `package_manager_check` are 323/323 (including the 4 that fail on main).
- Full `pacquet-cli` suite: 1413/1413 passed.
- Confirmed the 4 `package_manager_check` failures are pre-existing by stashing this change and re-running them against main.
- `cargo fmt --check`, `cargo clippy --all-targets --workspace -- -D warnings`, rustdoc, `cargo dylint`, `typos`, and `taplo` all clean (the full pre-push gate).

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788894634&installation_model_id=426870&pr_number=13744&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13744&signature=ca84edb9b8bc5a2e708863444b025ce6e9509463ddb969c5914a38b338418112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line test reliability by preventing inherited pnpm and npm configuration from affecting test execution.
  * Ensured global commands and package manager checks run in isolated environments.
  * Preserved required environment settings while bypassing unintended shim and configuration behavior.

* **Tests**
  * Added coverage for configuration-variable detection, including case-insensitive names and unrelated environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->