### PR TITLE
fix(pacquet): exec the target from a shim so signal deaths survive

### DIFF
--- a/.changeset/shim-exec-preserves-signals.md
+++ b/.changeset/shim-exec-preserves-signals.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Command shims on POSIX again `exec` a target that has no interpreter — a runtime binary such as the managed Node.js, or any bin without a shebang — instead of waiting on it. A shim that waited reported a target killed by a signal as exit code `128+N` (for example `137` for `SIGKILL`), so callers that distinguish a signal death from an exit code, such as CI runners and process supervisors, saw the wrong outcome.

--- a/pnpm/crates/cmd-shim/src/shim.rs
+++ b/pnpm/crates/cmd-shim/src/shim.rs
@@ -338,11 +338,9 @@ pub fn generate_sh_shim(
                 sh.push_str(&exec_block(args));
             }
         }
-        // `exec` so the target replaces the shell: a shell that waits on
-        // the target instead reports a signal death as exit code 128+N,
-        // and the caller can no longer tell the two apart. The trailing
-        // `exit $?` is unreachable after it, and is emitted only because
-        // upstream emits it — the two stacks' shims stay byte-identical.
+        // The trailing `exit $?` is unreachable after the `exec`. It is
+        // emitted anyway because upstream emits it, which is what keeps
+        // the two stacks' shims byte-identical.
         runtime_opt => {
             let args = runtime_opt.map_or("", |runtime| runtime.args.as_str());
             writeln!(sh, "exec {quoted_target} {args} \"$@\"\nexit $?").unwrap();

--- a/pnpm/crates/cmd-shim/src/shim.rs
+++ b/pnpm/crates/cmd-shim/src/shim.rs
@@ -338,11 +338,14 @@ pub fn generate_sh_shim(
                 sh.push_str(&exec_block(args));
             }
         }
-        // Emit `exit $?` on this branch for parity with non-execve
-        // POSIX shells.
+        // `exec` so the target replaces the shell: a shell that waits on
+        // the target instead reports a signal death as exit code 128+N,
+        // and the caller can no longer tell the two apart. The trailing
+        // `exit $?` is unreachable after it, and is emitted only because
+        // upstream emits it — the two stacks' shims stay byte-identical.
         runtime_opt => {
             let args = runtime_opt.map_or("", |runtime| runtime.args.as_str());
-            writeln!(sh, "{quoted_target} {args} \"$@\"\nexit $?").unwrap();
+            writeln!(sh, "exec {quoted_target} {args} \"$@\"\nexit $?").unwrap();
         }
     }
 

--- a/pnpm/crates/cmd-shim/src/shim/tests.rs
+++ b/pnpm/crates/cmd-shim/src/shim/tests.rs
@@ -151,7 +151,7 @@ fn generate_sh_shim_emits_direct_exec_when_no_runtime() {
     let shim = Path::new("/proj/node_modules/.bin/cli");
     let body = generate_sh_shim(target, shim, None, &[], ShimStyle::Direct);
     assert!(
-        body.contains("\"$basedir/../foo/bin/cli\"  \"$@\"\nexit $?\n"),
+        body.contains("exec \"$basedir/../foo/bin/cli\"  \"$@\"\nexit $?\n"),
         "no-runtime arm must exec the target directly, body:\n{body}",
     );
     assert!(body.ends_with("# cmd-shim-target=/proj/node_modules/foo/bin/cli\n"));
@@ -164,7 +164,7 @@ fn generate_sh_shim_threads_args_when_prog_is_none() {
     let runtime = ScriptRuntime { prog: None, args: "--flag".to_string() };
     let body = generate_sh_shim(target, shim, Some(&runtime), &[], ShimStyle::Direct);
     assert!(
-        body.contains("\"$basedir/../cli\" --flag \"$@\"\nexit $?\n"),
+        body.contains("exec \"$basedir/../cli\" --flag \"$@\"\nexit $?\n"),
         "args must be threaded into the no-prog arm, body:\n{body}",
     );
 }
@@ -738,4 +738,37 @@ fn context_aware_windows_shims_preserve_bin_name_extensions() {
     );
     assert!(cmd.contains(r#"--shim "tool.cmd""#), "body was:\n{cmd}");
     assert!(pwsh.contains(r"'--shim' 'tool.ps1'"), "body was:\n{pwsh}");
+}
+
+/// A caller must be able to tell "the target died on a signal" from "the
+/// target exited with a code". Only holds if the shim `exec`s the target:
+/// a shell that waits on it converts a signal death into exit code 128+N.
+#[cfg(unix)]
+#[test]
+fn a_shim_lets_the_targets_signal_death_reach_the_caller() {
+    use std::{
+        os::unix::{fs::PermissionsExt, process::ExitStatusExt},
+        process::Command,
+    };
+
+    // A real executable, so the shim takes the no-interpreter arm the way
+    // a managed runtime binary does. A script would carry a shebang and be
+    // launched through its interpreter instead.
+    let dir = tempfile::tempdir().expect("create a temporary directory");
+    let target = dir.path().join("target");
+    std::fs::copy("/bin/sh", &target).expect("copy /bin/sh");
+
+    let shim = dir.path().join("shim");
+    let body = generate_sh_shim(&target, &shim, None, &[], ShimStyle::Direct);
+    std::fs::write(&shim, body).expect("write the shim");
+    std::fs::set_permissions(&shim, std::fs::Permissions::from_mode(0o755))
+        .expect("make the shim executable");
+
+    let status = Command::new(&shim)
+        .args(["-c", "kill -9 $$"])
+        .status()
+        .expect("run the target through the shim");
+
+    assert_eq!(status.signal(), Some(9), "the shim swallowed the signal, reporting {status:?}");
+    assert_eq!(status.code(), None);
 }

--- a/pnpm/crates/cmd-shim/src/shim/tests.rs
+++ b/pnpm/crates/cmd-shim/src/shim/tests.rs
@@ -740,9 +740,8 @@ fn context_aware_windows_shims_preserve_bin_name_extensions() {
     assert!(pwsh.contains(r"'--shim' 'tool.ps1'"), "body was:\n{pwsh}");
 }
 
-/// A caller must be able to tell "the target died on a signal" from "the
-/// target exited with a code". Only holds if the shim `exec`s the target:
-/// a shell that waits on it converts a signal death into exit code 128+N.
+/// A waiting shell would surface the death as exit code 128+N, which the
+/// caller cannot tell from an ordinary exit.
 #[cfg(unix)]
 #[test]
 fn a_shim_lets_the_targets_signal_death_reach_the_caller() {


### PR DESCRIPTION
## Summary

A shim generated for a target with no interpreter — a managed runtime binary, or any bin without a shebang — ran the target as a child of the shell and then `exit $?`. A child killed by a signal makes the shell exit `128+N`, so a target that died on `SIGKILL` was reported to the caller as exit code `137`, and a signal death became indistinguishable from an ordinary exit.

`@zkochan/cmd-shim` `exec`s on this arm and emits an unreachable `exit $?` after it. The port kept only the trailing line and a comment read that as deliberate ("upstream still emits `exit $?` … for parity with non-execve POSIX shells"). It is not deliberate — this restores parity rather than diverging from it, which is also why there is no TypeScript-side change.

The context-aware global shims widened the blast radius: their fallback re-enters the shim body with dispatch disabled, and that is exactly this arm. So any global runtime bin invoked while `globalShims` is off (the setting, `PNPM_SHIM_BYPASS`, or the `PNPM_CONFIG_GLOBAL_SHIMS` that `pnpm/setup` now exports) converted signal deaths into exit codes. It surfaced as a TS CI failure on pnpm/pnpm#13675, where `assertPnpmRuns › describes a signal rather than a null exit code` received `it exited with code 137: Killed` instead of a signal.

Related to pnpm/pnpm#13675.

## Squash Commit Body

```text
A shim for a target with no interpreter — a managed runtime binary, or any
bin without a shebang — ran the target as a child of the shell and exited
with `$?`. A child killed by a signal makes the shell exit 128+N, so the
caller saw exit code 137 where the target had died on SIGKILL, and could no
longer tell a signal from an exit code.

`@zkochan/cmd-shim` execs on this arm and emits an unreachable `exit $?`
after it; the port kept only the trailing line and read it as deliberate.
Restore the `exec`, and keep the vestigial `exit $?` so the two stacks'
shims stay byte-identical.

The context-aware global shims made this reachable in more places: their
fallback re-enters the shim body with dispatch disabled, which is exactly
this arm, so any global runtime bin run with `globalShims` off converted
signal deaths into exit codes.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <sub>The TypeScript stack (`@zkochan/cmd-shim`) already `exec`s; this closes the gap.</sub>
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

## Verification

`a_shim_lets_the_targets_signal_death_reach_the_caller` pins the behaviour rather than the template text: it copies a real binary, generates a shim for it, runs `kill -9 $$` through the shim, and asserts `status.signal() == Some(9)`. Reverting the one-word change makes it fail (`right: Some(9)`), so it is a real regression test.

`pacquet-cmd-shim` is 104/104, and the `shim` / `global` / `bin` CLI suites are 120/120. The two existing template assertions were updated — note both already carried the message "no-runtime arm must exec the target directly", so the intent was `exec` all along; only the assertion had been pinned to the wrong body.

## Release note

The shim body is written at link time, so this reaches a machine only once a pnpm carrying the fix rewrites the shim. Existing installs keep the old body until `pnpm self-update`, `pnpm runtime set -g`, or a global install re-links it. pnpm/pnpm#13675 cannot go green until a release with this fix exists for its `packageManager` pin to resolve to.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13745"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788896885&installation_model_id=426870&pr_number=13745&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13745&signature=53576607d146c36d9776c545d0871b7d35fef47b8584c237e74f2aa173206bb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * POSIX command shims now preserve signal-based termination behavior when launching interpreterless targets.
  * Commands terminated by signals, such as `SIGKILL`, now report the correct termination status instead of a transformed exit code.

* **Tests**
  * Added coverage for signal handling and `exec` behavior in shell shims.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->