### PR TITLE
fix(git-fetcher): retry a failed SSH clone over HTTPS

### DIFF
--- a/.changeset/git-ssh-https-fetch-fallback.md
+++ b/.changeset/git-ssh-https-fetch-fallback.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/resolving.git-resolver": patch
+"@pnpm/fetching.git-fetcher": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+A git dependency whose lockfile entry records an SSH URL (`git@github.com:user/repo.git`) is now retried over HTTPS when the SSH clone fails, so an existing lockfile no longer breaks installs on machines without an SSH key, such as CI runners [#13743](https://github.com/pnpm/pnpm/issues/13743).

--- a/pnpm/crates/git-fetcher/src/fetcher.rs
+++ b/pnpm/crates/git-fetcher/src/fetcher.rs
@@ -275,7 +275,7 @@ fn download_repo<Reporter: self::Reporter>(
     Reporter::emit(&LogEvent::Pnpm(PnpmLog {
         level: LogLevel::Warn,
         message: format!(
-            "Failed to fetch \"{}\" over SSH, so it was fetched from \"{https_repo}\" instead. Re-resolve this dependency to record the HTTPS URL in the lockfile.",
+            r#"Failed to fetch "{}" over SSH, so it was fetched from "{https_repo}" instead. Re-resolve this dependency to record the HTTPS URL in the lockfile."#,
             opts.repo,
         ),
         prefix: String::new(),

--- a/pnpm/crates/git-fetcher/src/fetcher.rs
+++ b/pnpm/crates/git-fetcher/src/fetcher.rs
@@ -19,7 +19,7 @@ use crate::{
 use pacquet_executor::ScriptsPrependNodePath;
 use pacquet_fs_packlist::packlist;
 use pacquet_package_manifest::safe_read_package_json_from_dir;
-use pacquet_reporter::Reporter;
+use pacquet_reporter::{LogEvent, LogLevel, PnpmLog, Reporter};
 use pacquet_store_dir::{PackageFilesIndex, StoreDir, StoreIndexWriter};
 use serde_json::Value;
 use std::{
@@ -104,7 +104,7 @@ impl GitFetcher<'_> {
     fn run_sync<Reporter: self::Reporter>(self) -> Result<GitFetchOutput, GitFetcherError> {
         let temp = tempfile::tempdir().map_err(GitFetcherError::Io)?;
         let temp_location = temp.path();
-        checkout_commit(&CheckoutOptions {
+        checkout_commit::<Reporter>(&CheckoutOptions {
             repo: self.repo,
             commit: self.commit,
             git_shallow_hosts: self.git_shallow_hosts,
@@ -205,6 +205,7 @@ fn wrap_prepare_error(_repo: &str, err: PreparePackageError) -> GitFetcherError 
 /// True iff `commit` is exactly a 40-character hexadecimal git SHA,
 /// validated before the value reaches `git`.
 /// Inputs for [`checkout_commit`].
+#[derive(Clone, Copy)]
 pub struct CheckoutOptions<'a> {
     pub repo: &'a str,
     pub commit: &'a str,
@@ -222,8 +223,10 @@ pub struct CheckoutOptions<'a> {
 /// Shared by the install pass's [`GitFetcher`] and the resolve pass's
 /// [`read_git_manifest`], which need the same working tree for
 /// different reasons.
-pub fn checkout_commit(opts: &CheckoutOptions<'_>) -> Result<(), GitFetcherError> {
-    let &CheckoutOptions { repo, commit, git_shallow_hosts, git_bin, dest } = opts;
+pub fn checkout_commit<Reporter: self::Reporter>(
+    opts: &CheckoutOptions<'_>,
+) -> Result<(), GitFetcherError> {
+    let &CheckoutOptions { repo, commit, git_bin, dest, .. } = opts;
     if !is_valid_commit_hash(commit) {
         return Err(GitFetcherError::InvalidCommit {
             commit: commit.to_string(),
@@ -235,15 +238,7 @@ pub fn checkout_commit(opts: &CheckoutOptions<'_>) -> Result<(), GitFetcherError
     }
 
     let git_bin = git_bin.unwrap_or_else(|| Path::new("git"));
-    // `--` keeps the repository positional out of git's option parser,
-    // belt and braces with the `is_safe_repo_arg` check above.
-    if should_use_shallow(repo, git_shallow_hosts) {
-        exec_git_with(git_bin, &["init"], Some(dest))?;
-        exec_git_with(git_bin, &["remote", "add", "origin", "--", repo], Some(dest))?;
-        exec_git_with(git_bin, &["fetch", "--depth", "1", "origin", commit], Some(dest))?;
-    } else {
-        exec_git_with(git_bin, &["clone", "--", repo, &dest.to_string_lossy()], None)?;
-    }
+    download_repo::<Reporter>(git_bin, opts)?;
 
     exec_git_with(git_bin, &["checkout", commit], Some(dest))?;
     let received = exec_git_with(git_bin, &["rev-parse", "HEAD"], Some(dest))?;
@@ -255,6 +250,86 @@ pub fn checkout_commit(opts: &CheckoutOptions<'_>) -> Result<(), GitFetcherError
         });
     }
     Ok(())
+}
+
+/// Materialize `opts.repo` into `opts.dest`, retrying over HTTPS when an SSH
+/// transport fails.
+///
+/// A lockfile may record an SSH URL for a dependency whose specifier never
+/// asked for SSH, which makes the lockfile unusable wherever no SSH key is
+/// configured — CI runners, most commonly. The commit is pinned and verified
+/// by [`checkout_commit`] either way, so the same repository is retried over
+/// HTTPS before the install is failed. The SSH failure is the one reported
+/// when HTTPS cannot reach the repository either.
+fn download_repo<Reporter: self::Reporter>(
+    git_bin: &Path,
+    opts: &CheckoutOptions<'_>,
+) -> Result<(), GitFetcherError> {
+    let Err(ssh_error) = clone_or_fetch(git_bin, opts) else { return Ok(()) };
+    let Some(https_repo) = ssh_repo_url_to_https(opts.repo) else { return Err(ssh_error) };
+    fs::remove_dir_all(opts.dest).map_err(GitFetcherError::Io)?;
+    fs::create_dir_all(opts.dest).map_err(GitFetcherError::Io)?;
+    if clone_or_fetch(git_bin, &CheckoutOptions { repo: &https_repo, ..*opts }).is_err() {
+        return Err(ssh_error);
+    }
+    Reporter::emit(&LogEvent::Pnpm(PnpmLog {
+        level: LogLevel::Warn,
+        message: format!(
+            "Failed to fetch \"{}\" over SSH, so it was fetched from \"{https_repo}\" instead. Re-resolve this dependency to record the HTTPS URL in the lockfile.",
+            opts.repo,
+        ),
+        prefix: String::new(),
+    }));
+    Ok(())
+}
+
+fn clone_or_fetch(git_bin: &Path, opts: &CheckoutOptions<'_>) -> Result<(), GitFetcherError> {
+    let &CheckoutOptions { repo, commit, git_shallow_hosts, dest, .. } = opts;
+    // `--` keeps the repository positional out of git's option parser,
+    // belt and braces with the `is_safe_repo_arg` check in `checkout_commit`.
+    if should_use_shallow(repo, git_shallow_hosts) {
+        exec_git_with(git_bin, &["init"], Some(dest))?;
+        exec_git_with(git_bin, &["remote", "add", "origin", "--", repo], Some(dest))?;
+        exec_git_with(git_bin, &["fetch", "--depth", "1", "origin", commit], Some(dest))?;
+    } else {
+        exec_git_with(git_bin, &["clone", "--", repo, &dest.to_string_lossy()], None)?;
+    }
+    Ok(())
+}
+
+/// The HTTPS equivalent of an SSH git repository reference, or `None` when
+/// `repo` is not one.
+///
+/// The SSH user and port are dropped: neither carries over to HTTPS, where the
+/// host serves git over 443 and credentials come from git's credential helpers.
+fn ssh_repo_url_to_https(repo: &str) -> Option<String> {
+    let (host, path) = split_ssh_repo_url(repo)?;
+    let path = path.trim_start_matches('/');
+    if host.is_empty() || path.is_empty() {
+        return None;
+    }
+    Some(format!("https://{host}/{path}"))
+}
+
+/// Split an SSH git repository reference into its host and repo-rooted path.
+///
+/// Covers the URL form (`[git+]ssh://[user@]host[:port]/path`) and the
+/// scp-style shorthand (`[user@]host:path`) that carries no scheme. The `user@`
+/// is mandatory in the shorthand, which is also what keeps a Windows drive path
+/// (`C:\repo`) from being read as a host.
+fn split_ssh_repo_url(repo: &str) -> Option<(&str, &str)> {
+    if let Some(rest) = repo.strip_prefix("ssh://").or_else(|| repo.strip_prefix("git+ssh://")) {
+        let (authority, path) = rest.split_once('/')?;
+        let host = authority.rsplit_once('@').map_or(authority, |(_user, host)| host);
+        let host = host.split_once(':').map_or(host, |(host, _port)| host);
+        return Some((host, path));
+    }
+    if repo.contains("://") {
+        return None;
+    }
+    let (authority, path) = repo.split_once(':')?;
+    let (_user, host) = authority.rsplit_once('@')?;
+    Some((host, path))
 }
 
 /// Inputs for [`read_git_manifest`].
@@ -283,12 +358,12 @@ pub struct GitManifestQuery<'a> {
 ///
 /// Only the manifest is read: `prepare` / `prepublish` and the packlist
 /// stay in the install pass, so no package script runs here.
-pub async fn read_git_manifest(
+pub async fn read_git_manifest<Reporter: self::Reporter>(
     query: GitManifestQuery<'_>,
 ) -> Result<Option<Value>, GitFetcherError> {
     tokio::task::block_in_place(|| {
         let temp = tempfile::tempdir().map_err(GitFetcherError::Io)?;
-        checkout_commit(&CheckoutOptions {
+        checkout_commit::<Reporter>(&CheckoutOptions {
             repo: query.repo,
             commit: query.commit,
             git_shallow_hosts: query.git_shallow_hosts,

--- a/pnpm/crates/git-fetcher/src/fetcher/tests.rs
+++ b/pnpm/crates/git-fetcher/src/fetcher/tests.rs
@@ -1273,24 +1273,24 @@ fn is_safe_repo_arg_rejects_option_shaped_values() {
 #[test]
 fn ssh_repo_url_to_https_rewrites_only_ssh_references() {
     assert_eq!(
-        ssh_repo_url_to_https("git@github.com:logux/client.git").as_deref(),
-        Some("https://github.com/logux/client.git"),
+        ssh_repo_url_to_https("git@github.com:acme/widget.git").as_deref(),
+        Some("https://github.com/acme/widget.git"),
     );
     assert_eq!(
-        ssh_repo_url_to_https("ssh://git@github.com/logux/client.git").as_deref(),
-        Some("https://github.com/logux/client.git"),
+        ssh_repo_url_to_https("ssh://git@github.com/acme/widget.git").as_deref(),
+        Some("https://github.com/acme/widget.git"),
     );
     assert_eq!(
-        ssh_repo_url_to_https("git+ssh://git@github.com/logux/client.git").as_deref(),
-        Some("https://github.com/logux/client.git"),
+        ssh_repo_url_to_https("git+ssh://git@github.com/acme/widget.git").as_deref(),
+        Some("https://github.com/acme/widget.git"),
     );
     assert_eq!(
         ssh_repo_url_to_https("ssh://git@gitlab.example.com:2222/org/repo.git").as_deref(),
         Some("https://gitlab.example.com/org/repo.git"),
     );
 
-    assert_eq!(ssh_repo_url_to_https("https://github.com/logux/client.git"), None);
-    assert_eq!(ssh_repo_url_to_https("git://github.com/logux/client.git"), None);
+    assert_eq!(ssh_repo_url_to_https("https://github.com/acme/widget.git"), None);
+    assert_eq!(ssh_repo_url_to_https("git://github.com/acme/widget.git"), None);
     assert_eq!(ssh_repo_url_to_https("file:///home/zoltan/src/repo"), None);
     assert_eq!(ssh_repo_url_to_https("ssh://git@github.com"), None);
     assert_eq!(ssh_repo_url_to_https(r"C:\src\repo"), None);

--- a/pnpm/crates/git-fetcher/src/fetcher/tests.rs
+++ b/pnpm/crates/git-fetcher/src/fetcher/tests.rs
@@ -1,6 +1,6 @@
 use super::{
     GitFetcher, GitManifestQuery, exec_git_with, extract_host, is_safe_repo_arg,
-    is_valid_commit_hash, read_git_manifest, should_use_shallow,
+    is_valid_commit_hash, read_git_manifest, should_use_shallow, ssh_repo_url_to_https,
 };
 use crate::{
     error::{GitFetcherError, PreparePackageError},
@@ -8,10 +8,14 @@ use crate::{
 };
 use pacquet_executor::ScriptsPrependNodePath;
 use pacquet_reporter::SilentReporter;
+#[cfg(unix)]
+use pacquet_reporter::{LogEvent, LogLevel, PnpmLog, Reporter};
 use pacquet_store_dir::StoreDir;
 #[cfg(unix)]
 use pacquet_testing_utils::env_guard::EnvGuard;
 use serde_json::Value;
+#[cfg(unix)]
+use std::sync::Mutex;
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -849,6 +853,13 @@ async fn fetcher_allows_untrusted_manifest_identity_by_dep_path() {
 /// --depth 1 origin`, `checkout`, `rev-parse HEAD`) and the
 /// non-shallow `clone`. Each is logged before exit-zero, so both
 /// branches of `should_use_shallow` exercise the same shim.
+///
+/// The invocations the shim fails are a transport over SSH — standing in
+/// for the keyless machine that [`ssh_fallback_refetches_over_https`] is
+/// about — and any reference to `unreachable.invalid`, which
+/// [`ssh_failure_is_reported_when_https_fallback_fails_too`] uses to fail
+/// the HTTPS retry as well. No other test passes either, so the rules
+/// cost them nothing.
 #[cfg(unix)]
 fn write_git_shim(dir: &Path) -> PathBuf {
     use std::os::unix::fs::PermissionsExt;
@@ -865,6 +876,22 @@ set -eu
 # field. Quoting `"$@"` and `"$PACQUET_GIT_SHIM_LOG"` keeps
 # whitespace/metachars in arg values from being re-tokenized.
 { printf '%s\t' "$@"; printf '\n'; } >> "$PACQUET_GIT_SHIM_LOG"
+# An absolute path is the checkout destination, never a remote, and is
+# skipped before the remote patterns so a temp dir holding `@` and `:`
+# can't be mistaken for an scp-style reference.
+for arg in "$@"; do
+    case "$arg" in
+        /*) ;;
+        ssh://*|git+ssh://*|*@*:*)
+            printf 'ssh: connect to host port 22: Connection refused\n' >&2
+            exit 128
+            ;;
+        *unreachable.invalid*)
+            printf 'fatal: repository not found\n' >&2
+            exit 128
+            ;;
+    esac
+done
 # `rev-parse HEAD` is the only invocation whose stdout the fetcher
 # actually inspects (to compare against the resolution commit).
 if [ "$1" = rev-parse ] && [ "$2" = HEAD ]; then
@@ -1100,7 +1127,7 @@ async fn read_git_manifest_reads_the_name_from_the_checkout() {
     let (bare, commit) = make_bare_repo(tmp.path());
     let repo = format!("file://{}", bare.to_string_lossy());
 
-    let manifest = read_git_manifest(GitManifestQuery {
+    let manifest = read_git_manifest::<SilentReporter>(GitManifestQuery {
         repo: &repo,
         commit: &commit,
         path: None,
@@ -1123,7 +1150,7 @@ async fn read_git_manifest_reads_a_repo_rooted_sub_directory() {
     let (bare, commit) = make_bare_repo_with_sub_package(tmp.path());
     let repo = format!("file://{}", bare.to_string_lossy());
 
-    let manifest = read_git_manifest(GitManifestQuery {
+    let manifest = read_git_manifest::<SilentReporter>(GitManifestQuery {
         repo: &repo,
         commit: &commit,
         path: Some("/packages/foo"),
@@ -1145,7 +1172,7 @@ async fn read_git_manifest_returns_none_for_a_directory_without_a_manifest() {
     let (bare, commit) = make_bare_repo_with_sub_package(tmp.path());
     let repo = format!("file://{}", bare.to_string_lossy());
 
-    let manifest = read_git_manifest(GitManifestQuery {
+    let manifest = read_git_manifest::<SilentReporter>(GitManifestQuery {
         repo: &repo,
         commit: &commit,
         path: Some("/packages/no-manifest"),
@@ -1166,7 +1193,7 @@ async fn read_git_manifest_rejects_a_non_sha_commit() {
     let (bare, _) = make_bare_repo(tmp.path());
     let repo = format!("file://{}", bare.to_string_lossy());
 
-    let err = read_git_manifest(GitManifestQuery {
+    let err = read_git_manifest::<SilentReporter>(GitManifestQuery {
         repo: &repo,
         commit: "--upload-pack=touch /tmp/pwned",
         path: None,
@@ -1192,7 +1219,7 @@ async fn read_git_manifest_rejects_a_sub_directory_escape() {
     fs::write(tmp.path().join("package.json"), r#"{"name":"outside","version":"9.9.9"}"#).unwrap();
 
     for escape in ["/../..", "../..", "/../"] {
-        let err = read_git_manifest(GitManifestQuery {
+        let err = read_git_manifest::<SilentReporter>(GitManifestQuery {
             repo: &repo,
             commit: &commit,
             path: Some(escape),
@@ -1217,7 +1244,7 @@ async fn read_git_manifest_rejects_an_option_shaped_repo() {
     let marker = tmp.path().join("pwned.txt");
     let payload = format!("--upload-pack=touch {}", marker.to_string_lossy());
 
-    let err = read_git_manifest(GitManifestQuery {
+    let err = read_git_manifest::<SilentReporter>(GitManifestQuery {
         repo: &payload,
         commit: "0123456789abcdef0123456789abcdef01234567",
         path: None,
@@ -1241,4 +1268,141 @@ fn is_safe_repo_arg_rejects_option_shaped_values() {
     assert!(!is_safe_repo_arg("-oProxyCommand=curl evil.example"));
     assert!(!is_safe_repo_arg(""));
     assert!(!is_safe_repo_arg("https://example.com/\0/x"));
+}
+
+#[test]
+fn ssh_repo_url_to_https_rewrites_only_ssh_references() {
+    assert_eq!(
+        ssh_repo_url_to_https("git@github.com:logux/client.git").as_deref(),
+        Some("https://github.com/logux/client.git"),
+    );
+    assert_eq!(
+        ssh_repo_url_to_https("ssh://git@github.com/logux/client.git").as_deref(),
+        Some("https://github.com/logux/client.git"),
+    );
+    assert_eq!(
+        ssh_repo_url_to_https("git+ssh://git@github.com/logux/client.git").as_deref(),
+        Some("https://github.com/logux/client.git"),
+    );
+    assert_eq!(
+        ssh_repo_url_to_https("ssh://git@gitlab.example.com:2222/org/repo.git").as_deref(),
+        Some("https://gitlab.example.com/org/repo.git"),
+    );
+
+    assert_eq!(ssh_repo_url_to_https("https://github.com/logux/client.git"), None);
+    assert_eq!(ssh_repo_url_to_https("git://github.com/logux/client.git"), None);
+    assert_eq!(ssh_repo_url_to_https("file:///home/zoltan/src/repo"), None);
+    assert_eq!(ssh_repo_url_to_https("ssh://git@github.com"), None);
+    assert_eq!(ssh_repo_url_to_https(r"C:\src\repo"), None);
+}
+
+/// A lockfile that records an SSH URL for a public repository is unusable
+/// on a machine without SSH keys. Covers
+/// <https://github.com/pnpm/pnpm/issues/13743>.
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread")]
+async fn ssh_fallback_refetches_over_https() {
+    static WARNINGS: Mutex<Vec<String>> = Mutex::new(Vec::new());
+    WARNINGS.lock().unwrap().clear();
+    struct WarningRecorder;
+    impl Reporter for WarningRecorder {
+        fn emit(event: &LogEvent) {
+            if let LogEvent::Pnpm(PnpmLog { level: LogLevel::Warn, message, .. }) = event {
+                WARNINGS.lock().unwrap().push(message.clone());
+            }
+        }
+    }
+
+    let tmp = tempdir().unwrap();
+    let log_path = tmp.path().join("git-invocations.log");
+    let fake_commit = "c9b30e71d704cd30fa71f2edd1ecc7dcc4985493";
+    let shim_path = write_git_shim(&tmp.path().join("shim"));
+
+    let store_root = tempdir().unwrap();
+    let store_dir = StoreDir::from(store_root.path().to_path_buf());
+
+    let env = EnvGuard::snapshot(["PACQUET_GIT_SHIM_LOG", "PACQUET_GIT_SHIM_FAKE_COMMIT"]);
+    env.set("PACQUET_GIT_SHIM_LOG", &log_path);
+    env.set("PACQUET_GIT_SHIM_FAKE_COMMIT", fake_commit);
+
+    ssh_repo_fetcher("git@test.invalid:x/y.git", fake_commit, &store_dir, &shim_path)
+        .run::<WarningRecorder>()
+        .await
+        .expect("the HTTPS retry must carry the fetch");
+
+    let cloned_from: Vec<String> = parse_shim_log(&log_path)
+        .iter()
+        .filter(|args| args.first().map(String::as_str) == Some("clone"))
+        .map(|args| args[2].clone())
+        .collect();
+    assert_eq!(
+        cloned_from,
+        ["git@test.invalid:x/y.git", "https://test.invalid/x/y.git"],
+        "SSH must be tried first, and only then the HTTPS rewrite",
+    );
+
+    let warnings = WARNINGS.lock().unwrap();
+    assert_eq!(warnings.len(), 1, "{warnings:?}");
+    assert!(warnings[0].contains("git@test.invalid:x/y.git"), "{warnings:?}");
+    assert!(warnings[0].contains("https://test.invalid/x/y.git"), "{warnings:?}");
+}
+
+/// The SSH failure is the actionable one, so it is what surfaces when the
+/// HTTPS retry cannot reach the repository either.
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread")]
+async fn ssh_failure_is_reported_when_https_fallback_fails_too() {
+    let tmp = tempdir().unwrap();
+    let log_path = tmp.path().join("git-invocations.log");
+    let fake_commit = "c9b30e71d704cd30fa71f2edd1ecc7dcc4985493";
+    let shim_path = write_git_shim(&tmp.path().join("shim"));
+
+    let store_root = tempdir().unwrap();
+    let store_dir = StoreDir::from(store_root.path().to_path_buf());
+
+    let env = EnvGuard::snapshot(["PACQUET_GIT_SHIM_LOG", "PACQUET_GIT_SHIM_FAKE_COMMIT"]);
+    env.set("PACQUET_GIT_SHIM_LOG", &log_path);
+    env.set("PACQUET_GIT_SHIM_FAKE_COMMIT", fake_commit);
+
+    let err =
+        ssh_repo_fetcher("git@unreachable.invalid:x/y.git", fake_commit, &store_dir, &shim_path)
+            .run::<SilentReporter>()
+            .await
+            .expect_err("neither transport can reach the repository");
+
+    let GitFetcherError::GitExec { stderr, .. } = &err else {
+        panic!("expected a git failure; got {err:?}");
+    };
+    assert!(stderr.contains("Connection refused"), "{stderr:?}");
+}
+
+/// A fetcher over `repo` with no shallow hosts configured, so it takes the
+/// `git clone` branch the SSH fallback tests spy on.
+#[cfg(unix)]
+fn ssh_repo_fetcher<'a>(
+    repo: &'a str,
+    commit: &'a str,
+    store_dir: &'a StoreDir,
+    git_bin: &'a Path,
+) -> GitFetcher<'a> {
+    GitFetcher {
+        repo,
+        commit,
+        path: None,
+        git_shallow_hosts: &[],
+        allow_build: deny_all_builds(),
+        ignore_scripts: false,
+        unsafe_perm: true,
+        user_agent: None,
+        scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+        script_shell: None,
+        node_execpath: None,
+        npm_execpath: None,
+        store_dir,
+        package_id: "x@1.0.0",
+        requester: "/test",
+        store_index_writer: None,
+        files_index_file: "x@1.0.0\tbuilt",
+        git_bin: Some(git_bin),
+    }
 }

--- a/pnpm/crates/resolving-git-resolver/src/git_resolver.rs
+++ b/pnpm/crates/resolving-git-resolver/src/git_resolver.rs
@@ -201,7 +201,7 @@ impl<Probe: GitProbe + 'static, Runner: GitCommandRunner + 'static> GitResolver<
                 // the only source of the name. A `Git` resolution
                 // carries no integrity — it is anchored by its commit —
                 // so the manifest is all there is to read.
-                let manifest = read_git_manifest(GitManifestQuery {
+                let manifest = read_git_manifest::<SilentReporter>(GitManifestQuery {
                     repo: &git.repo,
                     commit: &git.commit,
                     path: git.path.as_deref(),

--- a/pnpm11/fetching/git-fetcher/src/index.ts
+++ b/pnpm11/fetching/git-fetcher/src/index.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert'
+import fs from 'node:fs/promises'
 import path from 'node:path'
 import { URL } from 'node:url'
 import util from 'node:util'
@@ -8,7 +9,7 @@ import { preparePackage } from '@pnpm/exec.prepare-package'
 import type { GitFetcher } from '@pnpm/fetching.fetcher-base'
 import { packlist } from '@pnpm/fs.packlist'
 import { globalWarn } from '@pnpm/logger'
-import { createGitHostedPkgId } from '@pnpm/resolving.git-resolver'
+import { createGitHostedPkgId, sshRepoUrlToHttps } from '@pnpm/resolving.git-resolver'
 import type { StoreIndex } from '@pnpm/store.index'
 import { addFilesFromDir } from '@pnpm/worker'
 import { rimraf } from '@zkochan/rimraf'
@@ -31,13 +32,7 @@ export function createGitFetcher (createOpts: CreateGitFetcherOptions): { git: G
       throw new PnpmError('INVALID_GIT_COMMIT', `Invalid git commit hash "${resolution.commit}" for repository "${resolution.repo}". Expected a 40-character hexadecimal SHA.`)
     }
     const tempLocation = await cafs.tempDir()
-    if (allowedHosts.size > 0 && shouldUseShallow(resolution.repo, allowedHosts)) {
-      await execGit(['init'], { cwd: tempLocation })
-      await execGit(['remote', 'add', 'origin', resolution.repo], { cwd: tempLocation })
-      await execGit(['fetch', '--depth', '1', 'origin', resolution.commit], { cwd: tempLocation })
-    } else {
-      await execGit(['clone', resolution.repo, tempLocation])
-    }
+    await downloadRepo(resolution.repo, resolution.commit, tempLocation)
     await execGit(['checkout', resolution.commit], { cwd: tempLocation })
     const receivedCommit = await execGit(['rev-parse', 'HEAD'], { cwd: tempLocation })
     if (receivedCommit.trim() !== resolution.commit) {
@@ -76,6 +71,39 @@ export function createGitFetcher (createOpts: CreateGitFetcherOptions): { git: G
       readManifest: opts.readManifest,
       pkg: opts.pkg,
     })
+  }
+
+  async function downloadRepo (repo: string, commit: string, dest: string): Promise<void> {
+    try {
+      await cloneOrFetch(repo, commit, dest)
+      return
+    } catch (err: unknown) {
+      const httpsRepo = sshRepoUrlToHttps(repo)
+      if (httpsRepo == null) throw err
+      // A lockfile may record an SSH URL for a dependency whose specifier never
+      // asked for SSH, which makes the lockfile unusable wherever no SSH key is
+      // configured (CI runners, most commonly). The commit is pinned and
+      // verified after checkout either way, so the same repository is retried
+      // over HTTPS before the install is failed.
+      await rimraf(dest)
+      await fs.mkdir(dest, { recursive: true })
+      try {
+        await cloneOrFetch(httpsRepo, commit, dest)
+      } catch {
+        throw err
+      }
+      globalWarn(`Failed to fetch "${repo}" over SSH, so it was fetched from "${httpsRepo}" instead. Re-resolve this dependency to record the HTTPS URL in the lockfile.`)
+    }
+  }
+
+  async function cloneOrFetch (repo: string, commit: string, dest: string): Promise<void> {
+    if (allowedHosts.size > 0 && shouldUseShallow(repo, allowedHosts)) {
+      await execGit(['init'], { cwd: dest })
+      await execGit(['remote', 'add', 'origin', repo], { cwd: dest })
+      await execGit(['fetch', '--depth', '1', 'origin', commit], { cwd: dest })
+    } else {
+      await execGit(['clone', repo, dest])
+    }
   }
 
   return {

--- a/pnpm11/fetching/git-fetcher/test/index.ts
+++ b/pnpm11/fetching/git-fetcher/test/index.ts
@@ -347,3 +347,62 @@ test('fetch only the included files', async () => {
     'package.json',
   ])
 })
+
+// Covers https://github.com/pnpm/pnpm/issues/13743: a lockfile that records an
+// SSH URL is unusable on a machine without SSH keys, even when the repository
+// is public. `GIT_SSH_COMMAND=false` makes every SSH transport fail the way a
+// keyless CI runner does.
+test('falls back to HTTPS when the SSH transport of a git dependency fails', async () => {
+  const storeDir = temporaryDirectory()
+  const fetch = createGitFetcher({ storeIndex: createStoreIndex(storeDir) }).git
+  const { filesMap, manifest } = await withoutSsh(async () => fetch(
+    createCafsStore(storeDir),
+    {
+      commit: 'c9b30e71d704cd30fa71f2edd1ecc7dcc4985493',
+      repo: 'git@github.com:kevva/is-positive.git',
+      type: 'git',
+    },
+    {
+      readManifest: true,
+      filesIndexFile: path.join(storeDir, 'index.json'),
+    }
+  ))
+  expect(manifest?.name).toBe('is-positive')
+  expect(filesMap.has('package.json')).toBeTruthy()
+  const clonedFrom = jest.mocked(execa).mock.calls
+    .filter(([, args]) => (args as string[])?.includes('clone'))
+    .map(([, args]) => (args as string[])[(args as string[]).indexOf('clone') + 1])
+  expect(clonedFrom).toStrictEqual(['git@github.com:kevva/is-positive.git', 'https://github.com/kevva/is-positive.git'])
+  expect(jest.mocked(globalWarn).mock.calls[0][0]).toContain('Failed to fetch "git@github.com:kevva/is-positive.git" over SSH')
+})
+
+test('reports the SSH failure when the HTTPS fallback fails too', async () => {
+  const storeDir = temporaryDirectory()
+  const fetch = createGitFetcher({ storeIndex: createStoreIndex(storeDir) }).git
+  await expect(withoutSsh(async () => fetch(
+    createCafsStore(storeDir),
+    {
+      commit: 'c9b30e71d704cd30fa71f2edd1ecc7dcc4985493',
+      repo: 'git@github.com:pnpm-e2e/this-repository-does-not-exist.git',
+      type: 'git',
+    },
+    {
+      filesIndexFile: path.join(storeDir, 'index.json'),
+    }
+  ))).rejects.toThrow('git@github.com:pnpm-e2e/this-repository-does-not-exist.git')
+  expect(jest.mocked(globalWarn)).not.toHaveBeenCalled()
+})
+
+async function withoutSsh<T> (fn: () => Promise<T>): Promise<T> {
+  const original = process.env.GIT_SSH_COMMAND
+  process.env.GIT_SSH_COMMAND = 'false'
+  try {
+    return await fn()
+  } finally {
+    if (original == null) {
+      delete process.env.GIT_SSH_COMMAND
+    } else {
+      process.env.GIT_SSH_COMMAND = original
+    }
+  }
+}

--- a/pnpm11/resolving/git-resolver/src/createGitHostedPkgId.ts
+++ b/pnpm11/resolving/git-resolver/src/createGitHostedPkgId.ts
@@ -1,21 +1,13 @@
 import type { PkgResolutionId } from '@pnpm/resolving.resolver-base'
 
+import { normalizeGitRepoUrl } from './gitRepoUrl.js'
+
 export function createGitHostedPkgId ({ repo, commit, path }: { repo: string, commit: string, path?: string }): PkgResolutionId {
-  const normalizedRepo = normalizeGitRepoForPkgResolutionId(repo)
+  const normalizedRepo = normalizeGitRepoUrl(repo)
   let id = `${normalizedRepo.includes('://') ? '' : 'https://'}${normalizedRepo}#${commit}`
   if (!id.startsWith('git+')) id = `git+${id}`
   if (path) {
     id += `&path:${path}`
   }
   return id as PkgResolutionId
-}
-
-function normalizeGitRepoForPkgResolutionId (repo: string): string {
-  // Only scp-style shorthand (`user@host:path`) needs rewriting. A repo that
-  // already carries a URL scheme (e.g. `ssh://user@host:2222/path`) is left
-  // alone — its `@host:port` would otherwise match the scp pattern and get
-  // mangled into `ssh://ssh://…`.
-  if (repo.includes('://')) return repo
-  const scp = /^([^@\s]+@[^:\s]+):(.+)$/.exec(repo)
-  return scp == null ? repo : `ssh://${scp[1]}/${scp[2]}`
 }

--- a/pnpm11/resolving/git-resolver/src/gitRepoUrl.ts
+++ b/pnpm11/resolving/git-resolver/src/gitRepoUrl.ts
@@ -1,0 +1,35 @@
+import { URL } from 'node:url'
+
+/**
+ * The URL form of a git repository reference, giving scp-style shorthand
+ * (`user@host:path`) the `ssh://` scheme it implies.
+ *
+ * A reference that already carries a scheme (e.g. `ssh://user@host:2222/path`)
+ * is left alone — its `@host:port` would otherwise match the scp pattern and
+ * get mangled into `ssh://ssh://…`.
+ */
+export function normalizeGitRepoUrl (repo: string): string {
+  if (repo.includes('://')) return repo
+  const scp = /^([^@\s]+@[^:\s]+):(.+)$/.exec(repo)
+  return scp == null ? repo : `ssh://${scp[1]}/${scp[2]}`
+}
+
+/**
+ * The HTTPS equivalent of an SSH git repository reference, or `undefined` if
+ * `repo` is not one.
+ *
+ * The SSH user and port are dropped: neither carries over to HTTPS, where the
+ * host serves git over 443 and credentials come from git's credential helpers.
+ */
+export function sshRepoUrlToHttps (repo: string): string | undefined {
+  const sshUrl = normalizeGitRepoUrl(repo).replace(/^git\+/, '')
+  if (!sshUrl.startsWith('ssh://')) return undefined
+  let parsed: URL
+  try {
+    parsed = new URL(sshUrl)
+  } catch {
+    return undefined
+  }
+  if (!parsed.hostname || parsed.pathname.length <= 1) return undefined
+  return `https://${parsed.hostname}${parsed.pathname}`
+}

--- a/pnpm11/resolving/git-resolver/src/index.ts
+++ b/pnpm11/resolving/git-resolver/src/index.ts
@@ -4,10 +4,11 @@ import type { GitResolution, LatestInfo, LatestQuery, PkgResolutionId, ResolveOp
 import semver from 'semver'
 
 import { createGitHostedPkgId } from './createGitHostedPkgId.js'
+import { normalizeGitRepoUrl, sshRepoUrlToHttps } from './gitRepoUrl.js'
 import { lsRemote } from './lsRemote.js'
 import { type HostedPackageSpec, parseBareSpecifier } from './parseBareSpecifier.js'
 
-export { createGitHostedPkgId }
+export { createGitHostedPkgId, normalizeGitRepoUrl, sshRepoUrlToHttps }
 
 export type { HostedPackageSpec }
 

--- a/pnpm11/resolving/git-resolver/test/gitRepoUrl.test.ts
+++ b/pnpm11/resolving/git-resolver/test/gitRepoUrl.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from '@jest/globals'
+import { sshRepoUrlToHttps } from '@pnpm/resolving.git-resolver'
+
+test.each([
+  ['git@github.com:logux/client.git', 'https://github.com/logux/client.git'],
+  ['ssh://git@github.com/logux/client.git', 'https://github.com/logux/client.git'],
+  ['git+ssh://git@github.com/logux/client.git', 'https://github.com/logux/client.git'],
+  // The SSH port has no meaning over HTTPS, where the host serves git on 443.
+  ['ssh://git@gitlab.example.com:2222/org/repo.git', 'https://gitlab.example.com/org/repo.git'],
+  ['https://github.com/logux/client.git', undefined],
+  ['git://github.com/logux/client.git', undefined],
+  ['file:///home/zoltan/src/repo', undefined],
+  ['ssh://git@github.com', undefined],
+])('sshRepoUrlToHttps(%s)', (repo, expected) => {
+  expect(sshRepoUrlToHttps(repo)).toBe(expected)
+})

--- a/pnpm11/resolving/git-resolver/test/gitRepoUrl.test.ts
+++ b/pnpm11/resolving/git-resolver/test/gitRepoUrl.test.ts
@@ -2,13 +2,13 @@ import { expect, test } from '@jest/globals'
 import { sshRepoUrlToHttps } from '@pnpm/resolving.git-resolver'
 
 test.each([
-  ['git@github.com:logux/client.git', 'https://github.com/logux/client.git'],
-  ['ssh://git@github.com/logux/client.git', 'https://github.com/logux/client.git'],
-  ['git+ssh://git@github.com/logux/client.git', 'https://github.com/logux/client.git'],
+  ['git@github.com:acme/widget.git', 'https://github.com/acme/widget.git'],
+  ['ssh://git@github.com/acme/widget.git', 'https://github.com/acme/widget.git'],
+  ['git+ssh://git@github.com/acme/widget.git', 'https://github.com/acme/widget.git'],
   // The SSH port has no meaning over HTTPS, where the host serves git on 443.
   ['ssh://git@gitlab.example.com:2222/org/repo.git', 'https://gitlab.example.com/org/repo.git'],
-  ['https://github.com/logux/client.git', undefined],
-  ['git://github.com/logux/client.git', undefined],
+  ['https://github.com/acme/widget.git', undefined],
+  ['git://github.com/acme/widget.git', undefined],
   ['file:///home/zoltan/src/repo', undefined],
   ['ssh://git@github.com', undefined],
 ])('sshRepoUrlToHttps(%s)', (repo, expected) => {


### PR DESCRIPTION
## Summary

[pnpm/pnpm#13290](https://github.com/pnpm/pnpm/pull/13290) stopped the resolver from *writing* SSH URLs for git dependencies that never asked for SSH, but it cannot help a lockfile that already has them. When the lockfile is up to date, resolution is skipped entirely and the fetcher clones straight from the recorded `repo` — so [hplush/slowreader](https://github.com/hplush/slowreader/tree/logux-db), whose specifiers are all `github:owner/repo` but whose lockfile records `repo: git@github.com:logux/client.git`, still fails on every keyless CI runner with `Permission denied (publickey)`. There is also no user-facing way out: the lockfile still matches the specifiers, so nothing re-resolves those entries.

The git fetcher now rewrites an SSH reference to its HTTPS equivalent and retries the clone before failing, warning on the line that carried the fetch:

```
[WARN] Failed to fetch "git@github.com:kevva/is-positive.git" over SSH, so it was fetched
       from "https://github.com/kevva/is-positive.git" instead. Re-resolve this dependency
       to record the HTTPS URL in the lockfile.
```

SSH stays the first transport tried, so a private repo reachable only over SSH is unaffected. The pinned commit is verified against the checkout either way, so the fallback cannot change which tree is installed — only which transport carries the same bytes. When HTTPS cannot reach the repository either, the SSH failure is the one reported, since that is the actionable one.

Both the URL-form (`[git+]ssh://[user@]host[:port]/path`) and the scp-style shorthand (`user@host:path`) are recognised; the SSH user and port are dropped, since neither carries over to HTTPS.

Verified end-to-end in both stacks with a hand-written lockfile carrying `repo: git@github.com:kevva/is-positive.git` and `GIT_SSH_COMMAND=false` standing in for a keyless runner: `pnpm install --frozen-lockfile` fails before this change and succeeds after, with byte-identical warning text from the TypeScript CLI and pacquet.

Closes [pnpm/pnpm#13743](https://github.com/pnpm/pnpm/issues/13743).

## Squash Commit Body

```text
A lockfile written before pnpm/pnpm#13290 can record an SSH URL for a
git dependency whose specifier never asked for SSH (github:owner/repo).
Resolution is skipped when the lockfile is up to date, so the fetcher
clones from the recorded SSH URL and every install on a machine without
an SSH key fails with Permission denied (publickey) - and re-resolving
is not something the user can trigger while the lockfile still matches
the specifiers.

The fetcher now rewrites the SSH reference to its HTTPS equivalent and
retries the clone before failing, warning when the retry carries the
fetch. SSH stays the first transport tried, so a repository reachable
only over SSH is unaffected. The pinned commit is verified after
checkout either way, so the fallback cannot change which tree is
installed. When HTTPS cannot reach the repository either, the SSH
failure is the one reported.

Landed in both stacks: pnpm11/fetching/git-fetcher plus a shared
sshRepoUrlToHttps in pnpm11/resolving/git-resolver, and
pnpm/crates/git-fetcher's checkout_commit, which now threads a Reporter
so the warning reaches the default reporter the same way.

Closes pnpm/pnpm#13743.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5[1m]).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13747"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788910168&installation_model_id=426870&pr_number=13747&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13747&signature=01674a4ed40e2fecd55ef4c458f9a8654e815d50470b82cec7267215d07fc64d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Git dependencies using SSH now automatically retry over HTTPS when SSH cloning or fetching fails.
  * Improved support for common SSH repository URL formats.
  * Preserved the original SSH error when the HTTPS fallback also fails.
  * Added a warning when HTTPS fallback succeeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->