### PR TITLE
fix(lockfile,sbom): stop treating a git resolution's integrity as a checksum

### DIFF
--- a/.changeset/git-resolution-integrity-parses.md
+++ b/.changeset/git-resolution-integrity-parses.md
@@ -1,5 +1,8 @@
 ---
+"@pnpm/lockfile.utils": patch
+"@pnpm/deps.compliance.sbom": patch
+"pnpm": patch
 "pacquet": patch
 ---
 
-A lockfile whose git dependency records an `integrity` (`resolution: {type: git, repo, commit, integrity: sha512-…}`) no longer fails to load with `ERR_PNPM_BROKEN_LOCKFILE` [#13042](https://github.com/pnpm/pnpm/issues/13042). The field is kept on write, so installing no longer churns the lockfile.
+An `integrity` recorded on a git dependency's resolution (`resolution: {type: git, repo, commit, integrity: sha512-…}`) is no longer treated as a checksum. pnpm never verifies a git checkout against such a hash — the commit pins the content — so it is now dropped when the lockfile is rewritten, and `pnpm sbom` no longer republishes it as a CycloneDX/SPDX checksum. Lockfiles carrying one also load again instead of failing with `ERR_PNPM_BROKEN_LOCKFILE` [#13042](https://github.com/pnpm/pnpm/issues/13042).

--- a/.changeset/git-resolution-integrity-parses.md
+++ b/.changeset/git-resolution-integrity-parses.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+A lockfile whose git dependency records an `integrity` (`resolution: {type: git, repo, commit, integrity: sha512-…}`) no longer fails to load with `ERR_PNPM_BROKEN_LOCKFILE` [#13042](https://github.com/pnpm/pnpm/issues/13042). The field is kept on write, so installing no longer churns the lockfile.

--- a/.changeset/git-resolution-integrity-parses.md
+++ b/.changeset/git-resolution-integrity-parses.md
@@ -6,3 +6,5 @@
 ---
 
 An `integrity` recorded on a git dependency's resolution (`resolution: {type: git, repo, commit, integrity: sha512-…}`) is no longer treated as a checksum. pnpm never verifies a git checkout against such a hash — the commit pins the content — so it is now dropped when the lockfile is rewritten, and `pnpm sbom` no longer republishes it as a CycloneDX/SPDX checksum. Lockfiles carrying one also load again instead of failing with `ERR_PNPM_BROKEN_LOCKFILE` [#13042](https://github.com/pnpm/pnpm/issues/13042).
+
+`pnpm sbom` now also publishes the checksum of a `type: binary` runtime archive, which pnpm does verify.

--- a/pnpm/crates/cli/src/cli_args/sbom.rs
+++ b/pnpm/crates/cli/src/cli_args/sbom.rs
@@ -250,10 +250,16 @@ fn classify_license(license: &str) -> serde_json::Value {
     }
 }
 
+/// The resolution's integrity, but only where pnpm checks the downloaded
+/// bytes against it — so an SBOM never publishes a checksum as an assurance
+/// pnpm did not make. A git resolution's recorded hash is not one: nothing
+/// verifies a checkout against it (see
+/// [`pacquet_lockfile::GitResolution::integrity`]).
 fn integrity_string(resolution: &LockfileResolution) -> Option<String> {
     match resolution {
         LockfileResolution::Registry(r) => Some(r.integrity.to_string()),
         LockfileResolution::Tarball(r) => r.integrity.as_ref().map(ToString::to_string),
+        LockfileResolution::Binary(r) => Some(r.integrity.to_string()),
         _ => None,
     }
 }

--- a/pnpm/crates/cli/src/cli_args/sbom/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/sbom/tests.rs
@@ -1,7 +1,8 @@
 use super::{
-    base64_to_hex, build_purl, classify_license, confined_importer_dir, encode_purl_name,
-    extract_author, extract_repository, is_simple_spdx_id, normalize_link_path,
-    peer_names_from_manifest, sanitize_spdx_id, split_scoped_name, strip_url_credentials,
+    LockfileResolution, base64_to_hex, build_purl, classify_license, confined_importer_dir,
+    encode_purl_name, extract_author, extract_repository, integrity_string, is_simple_spdx_id,
+    normalize_link_path, peer_names_from_manifest, sanitize_spdx_id, split_scoped_name,
+    strip_url_credentials,
 };
 
 #[test]
@@ -206,4 +207,36 @@ fn strip_url_credentials_no_credentials() {
 #[test]
 fn normalize_link_path_escape_returns_none() {
     assert_eq!(normalize_link_path(".", ".."), None);
+}
+
+/// An SBOM checksum reads as an assurance that the artifact was verified
+/// against it. Only the shapes pnpm actually checks the downloaded bytes
+/// against may supply one.
+#[test]
+fn integrity_string_publishes_only_verified_hashes() {
+    const HASH: &str = "sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==";
+    let hash = || HASH.parse::<ssri::Integrity>().expect("parse integrity");
+
+    let registry =
+        LockfileResolution::Registry(pacquet_lockfile::RegistryResolution { integrity: hash() });
+    assert_eq!(integrity_string(&registry).as_deref(), Some(HASH));
+
+    let binary = LockfileResolution::Binary(pacquet_lockfile::BinaryResolution {
+        url: "https://nodejs.org/dist/v22.0.0/node-v22.0.0-linux-x64.tar.gz".to_string(),
+        integrity: hash(),
+        bin: pacquet_lockfile::BinarySpec::Single("bin/node".to_string()),
+        archive: pacquet_lockfile::BinaryArchive::Tarball,
+        prefix: None,
+    });
+    assert_eq!(integrity_string(&binary).as_deref(), Some(HASH));
+
+    // Nothing verifies a git checkout against a hash, so one recorded on
+    // the entry must not be republished as a checksum.
+    let git = LockfileResolution::Git(pacquet_lockfile::GitResolution {
+        repo: "https://github.com/foo/bar.git".to_string(),
+        commit: "e63c09e460269b0c535e4c34debf69bb91d57b22".to_string(),
+        integrity: Some(HASH.to_string()),
+        path: None,
+    });
+    assert_eq!(integrity_string(&git), None);
 }

--- a/pnpm/crates/cli/tests/suite/git_hosted_install.rs
+++ b/pnpm/crates/cli/tests/suite/git_hosted_install.rs
@@ -133,10 +133,9 @@ fn install_from_a_git_repo() {
     drop((root, npmrc_info));
 }
 
-/// A git resolution that records an `integrity` — lockfiles in the wild
-/// carry one — loads, and survives a re-resolving install unchanged.
-/// Dropping the key would churn the lockfile against what pnpm wrote,
-/// which keeps it. See <https://github.com/pnpm/pnpm/issues/13042>.
+/// pnpm's own git fetcher computes no integrity, yet lockfiles in the
+/// wild record one, and pnpm hands it back untouched.
+/// See <https://github.com/pnpm/pnpm/issues/13042>.
 #[test]
 fn install_from_a_git_repo_whose_lockfile_records_an_integrity() {
     const INTEGRITY: &str = "sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==";

--- a/pnpm/crates/cli/tests/suite/git_hosted_install.rs
+++ b/pnpm/crates/cli/tests/suite/git_hosted_install.rs
@@ -25,6 +25,7 @@ use pacquet_lockfile::{Lockfile, LockfileResolution};
 use pacquet_testing_utils::{bin::CommandTempCwd, git_repo::GitRepoFixture};
 use pretty_assertions::assert_eq;
 use serde_json::{Value, json};
+use ssri::Integrity;
 
 use _utils::{
     append_workspace_yaml_key, assert_success, importer_specifier, importer_version,
@@ -128,6 +129,40 @@ fn install_from_a_git_repo() {
     // ref in the importer, not `is-negative@git+...` — byte-for-byte what
     // pnpm 11 writes.
     assert_eq!(importer_version(&lockfile, ".", "is-negative"), repo.git_url_at(&commit));
+
+    drop((root, npmrc_info));
+}
+
+/// A git resolution that records an `integrity` — lockfiles in the wild
+/// carry one — loads, and survives a re-resolving install unchanged.
+/// Dropping the key would churn the lockfile against what pnpm wrote,
+/// which keeps it. See <https://github.com/pnpm/pnpm/issues/13042>.
+#[test]
+fn install_from_a_git_repo_whose_lockfile_records_an_integrity() {
+    const INTEGRITY: &str = "sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==";
+
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let (repo, commit) = simple_repo(root.path(), "is-negative", "1.0.0");
+    write_dependencies(&workspace, &[("is-negative", &repo.git_url_at(&commit))]);
+
+    pacquet.with_args(["install"]).assert().success();
+
+    let lockfile_path = workspace.join("pnpm-lock.yaml");
+    let written = fs::read_to_string(&lockfile_path).expect("read lockfile");
+    let with_integrity = written.replace(", repo: ", &format!(", integrity: {INTEGRITY}, repo: "));
+    assert_ne!(with_integrity, written, "the git resolution must have a `repo` key to edit");
+    fs::write(&lockfile_path, &with_integrity).expect("write lockfile");
+
+    fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
+    pnpm_at(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
+    assert!(workspace.join("node_modules/is-negative/package.json").exists());
+
+    pnpm_at(&workspace).with_args(["install", "--no-prefer-frozen-lockfile"]).assert().success();
+    let lockfile = read_lockfile(&lockfile_path);
+    let resolution = git_resolution(&lockfile, "is-negative");
+    assert_eq!(resolution.commit, commit);
+    assert_eq!(resolution.integrity.as_ref().map(Integrity::to_string).as_deref(), Some(INTEGRITY));
 
     drop((root, npmrc_info));
 }

--- a/pnpm/crates/cli/tests/suite/git_hosted_install.rs
+++ b/pnpm/crates/cli/tests/suite/git_hosted_install.rs
@@ -25,7 +25,6 @@ use pacquet_lockfile::{Lockfile, LockfileResolution};
 use pacquet_testing_utils::{bin::CommandTempCwd, git_repo::GitRepoFixture};
 use pretty_assertions::assert_eq;
 use serde_json::{Value, json};
-use ssri::Integrity;
 
 use _utils::{
     append_workspace_yaml_key, assert_success, importer_specifier, importer_version,
@@ -133,9 +132,10 @@ fn install_from_a_git_repo() {
     drop((root, npmrc_info));
 }
 
-/// pnpm's own git fetcher computes no integrity, yet lockfiles in the
-/// wild record one, and pnpm hands it back untouched.
-/// See <https://github.com/pnpm/pnpm/issues/13042>.
+/// No pnpm version computes an integrity for a git checkout, yet
+/// lockfiles in the wild record one. Installing must not choke on it, and
+/// must not write it back — nothing verifies a git checkout against a
+/// hash. See <https://github.com/pnpm/pnpm/issues/13042>.
 #[test]
 fn install_from_a_git_repo_whose_lockfile_records_an_integrity() {
     const INTEGRITY: &str = "sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==";
@@ -156,12 +156,25 @@ fn install_from_a_git_repo_whose_lockfile_records_an_integrity() {
     fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
     pnpm_at(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
     assert!(workspace.join("node_modules/is-negative/package.json").exists());
-
-    pnpm_at(&workspace).with_args(["install", "--no-prefer-frozen-lockfile"]).assert().success();
     let lockfile = read_lockfile(&lockfile_path);
-    let resolution = git_resolution(&lockfile, "is-negative");
-    assert_eq!(resolution.commit, commit);
-    assert_eq!(resolution.integrity.as_ref().map(Integrity::to_string).as_deref(), Some(INTEGRITY));
+    assert_eq!(git_resolution(&lockfile, "is-negative").integrity, None, "read back as a hash");
+
+    // Adding a dependency is what next rewrites the lockfile; the hash
+    // leaves with that write rather than provoking one of its own.
+    let (other, other_commit) = simple_repo(root.path(), "is-positive", "1.0.0");
+    write_dependencies(
+        &workspace,
+        &[
+            ("is-negative", &repo.git_url_at(&commit)),
+            ("is-positive", &other.git_url_at(&other_commit)),
+        ],
+    );
+    pnpm_at(&workspace).with_arg("install").assert().success();
+
+    let rewritten = fs::read_to_string(&lockfile_path).expect("read rewritten lockfile");
+    assert!(!rewritten.contains(INTEGRITY), "the rewritten lockfile still advertises the hash");
+    let lockfile = read_lockfile(&lockfile_path);
+    assert_eq!(git_resolution(&lockfile, "is-negative").commit, commit);
 
     drop((root, npmrc_info));
 }

--- a/pnpm/crates/deps-restorer/src/build_modules/tests.rs
+++ b/pnpm/crates/deps-restorer/src/build_modules/tests.rs
@@ -97,6 +97,7 @@ fn side_effects_key_for_git_resolution_does_not_require_integrity() {
     let resolution = pacquet_lockfile::LockfileResolution::Git(pacquet_lockfile::GitResolution {
         repo: "file:///tmp/repo".to_string(),
         commit: "abcdef".to_string(),
+        integrity: None,
         path: None,
     });
 

--- a/pnpm/crates/deps-restorer/src/create_virtual_store/tests.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store/tests.rs
@@ -505,6 +505,7 @@ fn git_metadata() -> PackageMetadata {
         resolution: LockfileResolution::Git(GitResolution {
             repo: "https://github.com/ksxnodemodules/ts-pipe-compose.git".to_string(),
             commit: "e63c09e460269b0c535e4c34debf69bb91d57b22".to_string(),
+            integrity: None,
             path: None,
         }),
         version: None,

--- a/pnpm/crates/lockfile/src/resolution.rs
+++ b/pnpm/crates/lockfile/src/resolution.rs
@@ -64,6 +64,15 @@ pub struct DirectoryResolution {
 pub struct GitResolution {
     pub repo: String,
     pub commit: String,
+    /// Hash recorded on the entry by whatever wrote it. pnpm's built-in
+    /// git fetcher computes none, but a custom fetcher's is written
+    /// through to the resolution, and lockfiles in the wild carry one.
+    /// Neither stack checks a git checkout against it — the `commit`
+    /// pins the content, and the store key is git-hosted rather than
+    /// integrity-addressed — so pacquet keeps it only to hand it back
+    /// unchanged on the next write.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub integrity: Option<Integrity>,
     /// Sub-directory inside the cloned tree to package. The git fetcher
     /// uses it so the build runs inside the sub-directory rather than the
     /// repo root.
@@ -311,7 +320,9 @@ impl LockfileResolution {
             LockfileResolution::Tarball(resolution) => resolution.integrity.as_ref(),
             LockfileResolution::Registry(resolution) => Some(&resolution.integrity),
             LockfileResolution::Binary(resolution) => Some(&resolution.integrity),
-            // Directory / Git resolutions have no integrity.
+            // Directory resolutions have no integrity, and a git
+            // resolution's recorded one is round-trip baggage rather
+            // than a checkable hash (see [`GitResolution::integrity`]).
             // Variations is a meta-shape — the integrity lives on the
             // picked variant's inner resolution, so callers must
             // resolve through `pick_variant` first. Custom resolutions

--- a/pnpm/crates/lockfile/src/resolution.rs
+++ b/pnpm/crates/lockfile/src/resolution.rs
@@ -64,15 +64,19 @@ pub struct DirectoryResolution {
 pub struct GitResolution {
     pub repo: String,
     pub commit: String,
-    /// Hash recorded on the entry by whatever wrote it. pnpm's built-in
-    /// git fetcher computes none, but a custom fetcher's is written
-    /// through to the resolution, and lockfiles in the wild carry one.
-    /// Neither stack checks a git checkout against it — the `commit`
-    /// pins the content, and the store key is git-hosted rather than
-    /// integrity-addressed — so pacquet keeps it only to hand it back
-    /// unchanged on the next write.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub integrity: Option<Integrity>,
+    /// Accepted so that a lockfile carrying one still loads, and dropped
+    /// on the next write.
+    ///
+    /// No pnpm version computes this: git content is pinned by `commit`,
+    /// and the store key is git-hosted rather than integrity-addressed,
+    /// so nothing checks a checkout against it. Re-emitting it would keep
+    /// advertising a hash that was never verified — in the lockfile, and
+    /// through `pnpm sbom` into a CycloneDX/SPDX `hashes` entry.
+    ///
+    /// Kept as an unvalidated `String` because the value is discarded:
+    /// rejecting a malformed one would fail a lockfile pnpm reads fine.
+    #[serde(default, skip_serializing)]
+    pub integrity: Option<String>,
     /// Sub-directory inside the cloned tree to package. The git fetcher
     /// uses it so the build runs inside the sub-directory rather than the
     /// repo root.
@@ -321,8 +325,8 @@ impl LockfileResolution {
             LockfileResolution::Registry(resolution) => Some(&resolution.integrity),
             LockfileResolution::Binary(resolution) => Some(&resolution.integrity),
             // Directory resolutions have no integrity, and a git
-            // resolution's recorded one is round-trip baggage rather
-            // than a checkable hash (see [`GitResolution::integrity`]).
+            // resolution's recorded one is never a checkable hash — it is
+            // accepted and dropped (see [`GitResolution::integrity`]).
             // Variations is a meta-shape — the integrity lives on the
             // picked variant's inner resolution, so callers must
             // resolve through `pick_variant` first. Custom resolutions
@@ -514,7 +518,13 @@ impl From<ResolutionSerde> for LockfileResolution {
             }
             ResolutionSerde::Registry(resolution) => resolution.into(),
             ResolutionSerde::Tagged(TaggedResolution::Directory(resolution)) => resolution.into(),
-            ResolutionSerde::Tagged(TaggedResolution::Git(resolution)) => resolution.into(),
+            ResolutionSerde::Tagged(TaggedResolution::Git(mut resolution)) => {
+                // Drop a recorded integrity the moment the entry is read, so
+                // it can never reach the lockfile writer, an SBOM, or a
+                // resolution comparison. See [`GitResolution::integrity`].
+                resolution.integrity = None;
+                resolution.into()
+            }
             ResolutionSerde::Tagged(TaggedResolution::Binary(resolution)) => resolution.into(),
             ResolutionSerde::Tagged(TaggedResolution::Variations(resolution)) => resolution.into(),
             ResolutionSerde::Custom(resolution) => resolution.into(),

--- a/pnpm/crates/lockfile/src/resolution/tests.rs
+++ b/pnpm/crates/lockfile/src/resolution/tests.rs
@@ -410,10 +410,25 @@ fn deserialize_git_resolution_with_integrity() {
     let expected = LockfileResolution::Git(GitResolution {
         repo: "https://github.com/ksxnodemodules/ts-pipe-compose.git".to_string(),
         commit: "e63c09e460269b0c535e4c34debf69bb91d57b22".to_string(),
-        integrity: integrity("sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==").into(),
+        integrity: None,
         path: None,
     });
     assert_eq!(received, expected);
+    assert!(received.integrity().is_none());
+}
+
+/// The value is discarded, so a hash pnpm's own reader tolerates must not
+/// become a parse error here.
+#[test]
+fn deserialize_git_resolution_with_a_malformed_integrity() {
+    let yaml = text_block! {
+        "type: git"
+        "repo: https://github.com/ksxnodemodules/ts-pipe-compose.git"
+        "commit: e63c09e460269b0c535e4c34debf69bb91d57b22"
+        "integrity: not-a-real-hash"
+    };
+    let received: LockfileResolution = serde_saphyr::from_str(yaml).unwrap();
+    dbg!(&received);
     assert!(received.integrity().is_none());
 }
 
@@ -445,17 +460,22 @@ fn serialize_git_resolution_with_path() {
     assert_eq!(received, expected);
 }
 
+/// Writing the hash back would keep advertising a check nothing performs,
+/// so it leaves on the next write.
 #[test]
-fn serialize_git_resolution_with_integrity() {
+fn serialize_git_resolution_drops_the_integrity() {
     let resolution = LockfileResolution::Git(GitResolution {
         repo: "https://github.com/ksxnodemodules/ts-pipe-compose.git".to_string(),
         commit: "e63c09e460269b0c535e4c34debf69bb91d57b22".to_string(),
-        integrity: integrity("sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==").into(),
+        integrity: Some(
+            "sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg=="
+                .to_string(),
+        ),
         path: None,
     });
     let received = render_resolution(&resolution);
     eprintln!("RECEIVED:\n{received}");
-    let expected = "resolution: {commit: e63c09e460269b0c535e4c34debf69bb91d57b22, integrity: sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==, repo: https://github.com/ksxnodemodules/ts-pipe-compose.git, type: git}";
+    let expected = "resolution: {commit: e63c09e460269b0c535e4c34debf69bb91d57b22, repo: https://github.com/ksxnodemodules/ts-pipe-compose.git, type: git}";
     assert_eq!(received, expected);
 }
 

--- a/pnpm/crates/lockfile/src/resolution/tests.rs
+++ b/pnpm/crates/lockfile/src/resolution/tests.rs
@@ -429,7 +429,8 @@ fn deserialize_git_resolution_with_a_malformed_integrity() {
     };
     let received: LockfileResolution = serde_saphyr::from_str(yaml).unwrap();
     dbg!(&received);
-    assert!(received.integrity().is_none());
+    let LockfileResolution::Git(git) = &received else { panic!("expected a git resolution") };
+    assert_eq!(git.integrity, None, "the malformed hash must not survive the read");
 }
 
 #[test]

--- a/pnpm/crates/lockfile/src/resolution/tests.rs
+++ b/pnpm/crates/lockfile/src/resolution/tests.rs
@@ -373,6 +373,7 @@ fn deserialize_git_resolution() {
     let expected = LockfileResolution::Git(GitResolution {
         repo: "https://github.com/ksxnodemodules/ts-pipe-compose.git".to_string(),
         commit: "e63c09e460269b0c535e4c34debf69bb91d57b22".to_string(),
+        integrity: None,
         path: None,
     });
     assert_eq!(received, expected);
@@ -390,9 +391,30 @@ fn deserialize_git_resolution_with_path() {
     let expected = LockfileResolution::Git(GitResolution {
         repo: "https://github.com/ksxnodemodules/ts-pipe-compose.git".to_string(),
         commit: "e63c09e460269b0c535e4c34debf69bb91d57b22".to_string(),
+        integrity: None,
         path: Some("packages/sub".to_string()),
     });
     assert_eq!(received, expected);
+}
+
+#[test]
+fn deserialize_git_resolution_with_integrity() {
+    let yaml = text_block! {
+        "type: git"
+        "repo: https://github.com/ksxnodemodules/ts-pipe-compose.git"
+        "commit: e63c09e460269b0c535e4c34debf69bb91d57b22"
+        "integrity: sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg=="
+    };
+    let received: LockfileResolution = serde_saphyr::from_str(yaml).unwrap();
+    dbg!(&received);
+    let expected = LockfileResolution::Git(GitResolution {
+        repo: "https://github.com/ksxnodemodules/ts-pipe-compose.git".to_string(),
+        commit: "e63c09e460269b0c535e4c34debf69bb91d57b22".to_string(),
+        integrity: integrity("sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==").into(),
+        path: None,
+    });
+    assert_eq!(received, expected);
+    assert!(received.integrity().is_none());
 }
 
 #[test]
@@ -400,6 +422,7 @@ fn serialize_git_resolution() {
     let resolution = LockfileResolution::Git(GitResolution {
         repo: "https://github.com/ksxnodemodules/ts-pipe-compose.git".to_string(),
         commit: "e63c09e460269b0c535e4c34debf69bb91d57b22".to_string(),
+        integrity: None,
         path: None,
     });
     let received = render_resolution(&resolution);
@@ -413,11 +436,26 @@ fn serialize_git_resolution_with_path() {
     let resolution = LockfileResolution::Git(GitResolution {
         repo: "https://github.com/ksxnodemodules/ts-pipe-compose.git".to_string(),
         commit: "e63c09e460269b0c535e4c34debf69bb91d57b22".to_string(),
+        integrity: None,
         path: Some("packages/sub".to_string()),
     });
     let received = render_resolution(&resolution);
     eprintln!("RECEIVED:\n{received}");
     let expected = "resolution: {commit: e63c09e460269b0c535e4c34debf69bb91d57b22, path: packages/sub, repo: https://github.com/ksxnodemodules/ts-pipe-compose.git, type: git}";
+    assert_eq!(received, expected);
+}
+
+#[test]
+fn serialize_git_resolution_with_integrity() {
+    let resolution = LockfileResolution::Git(GitResolution {
+        repo: "https://github.com/ksxnodemodules/ts-pipe-compose.git".to_string(),
+        commit: "e63c09e460269b0c535e4c34debf69bb91d57b22".to_string(),
+        integrity: integrity("sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==").into(),
+        path: None,
+    });
+    let received = render_resolution(&resolution);
+    eprintln!("RECEIVED:\n{received}");
+    let expected = "resolution: {commit: e63c09e460269b0c535e4c34debf69bb91d57b22, integrity: sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==, repo: https://github.com/ksxnodemodules/ts-pipe-compose.git, type: git}";
     assert_eq!(received, expected);
 }
 

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -934,6 +934,7 @@ fn non_host_git_dependency_records_bare_git_url_in_importer() {
         resolution: LockfileResolution::Git(GitResolution {
             repo: "ssh://git@example.com/org/is-negative.git".to_string(),
             commit: "0123456789012345678901234567890123456789".to_string(),
+            integrity: None,
             path: None,
         }),
         resolved_via: "git-repository".to_string(),

--- a/pnpm/crates/package-manager/src/patch/tests.rs
+++ b/pnpm/crates/package-manager/src/patch/tests.rs
@@ -499,6 +499,7 @@ fn resolution_kind_names_non_patchable_resolution_shapes() {
     let git = LockfileResolution::Git(GitResolution {
         repo: "https://github.com/example/foo.git".to_string(),
         commit: "deadbeef".to_string(),
+        integrity: None,
         path: None,
     });
     assert_eq!(resolution_kind(&git), "git");

--- a/pnpm/crates/resolving-deps-resolver/src/lockfile_reuse/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/lockfile_reuse/tests.rs
@@ -104,6 +104,7 @@ fn reuses_an_unchanged_git_specifier_at_its_locked_commit() {
             resolution: LockfileResolution::Git(GitResolution {
                 repo: "file:///repo".to_string(),
                 commit: "0123456789012345678901234567890123456789".to_string(),
+                integrity: None,
                 path: None,
             }),
             version: Some("1.0.0".to_string()),
@@ -194,6 +195,7 @@ fn synthesizes_a_git_resolution_with_the_locked_commit_and_manifest_version() {
     metadata.resolution = LockfileResolution::Git(GitResolution {
         repo: "file:///repo".to_string(),
         commit: "0123456789012345678901234567890123456789".to_string(),
+        integrity: None,
         path: None,
     });
     metadata.version = Some("1.2.3".to_string());

--- a/pnpm/crates/resolving-git-resolver/src/git_resolver.rs
+++ b/pnpm/crates/resolving-git-resolver/src/git_resolver.rs
@@ -198,9 +198,8 @@ impl<Probe: GitProbe + 'static, Runner: GitCommandRunner + 'static> GitResolver<
             }
             LockfileResolution::Git(git) => {
                 // No archive endpoint to read, so the working tree is
-                // the only source of the name. A `Git` resolution
-                // carries no integrity — it is anchored by its commit —
-                // so the manifest is all there is to read.
+                // the only source of the name, and there is nothing to
+                // hash — the commit anchors the content.
                 let manifest = read_git_manifest(GitManifestQuery {
                     repo: &git.repo,
                     commit: &git.commit,
@@ -307,6 +306,7 @@ async fn pick_resolution<Probe: GitProbe + ?Sized>(
     LockfileResolution::Git(GitResolution {
         repo: spec.fetch_spec.clone(),
         commit: commit.to_string(),
+        integrity: None,
         path: spec.path.clone(),
     })
 }

--- a/pnpm11/deps/compliance/sbom/src/collectComponents.ts
+++ b/pnpm11/deps/compliance/sbom/src/collectComponents.ts
@@ -233,7 +233,15 @@ async function walkStep (
 
       if (componentsMap.has(purl)) return
 
-      const integrity = (pkgSnapshot.resolution as TarballResolution).integrity
+      // Only the tarball/registry hash is published as a component
+      // checksum: it is the one pnpm checks the downloaded bytes against.
+      // A typed resolution that merely carries an `integrity` — a
+      // `type: git` entry some other tool stamped one onto — was never
+      // checked against it, and an SBOM checksum reads as an assurance.
+      // Mirrors `integrity_string` in the Rust CLI's `sbom.rs`.
+      const integrity = 'type' in pkgSnapshot.resolution
+        ? undefined
+        : (pkgSnapshot.resolution as TarballResolution).integrity
       const resolution = pkgSnapshotToResolution(depPath, pkgSnapshot, { registries: opts.registries, namedRegistries: opts.namedRegistries })
       const tarballUrl = (resolution as TarballResolution).tarball ?? gitDownloadUrl(resolution)
 

--- a/pnpm11/deps/compliance/sbom/src/collectComponents.ts
+++ b/pnpm11/deps/compliance/sbom/src/collectComponents.ts
@@ -191,16 +191,6 @@ export async function collectSbomComponents (opts: CollectSbomComponentsOptions)
   }
 }
 
-/**
- * The resolution's integrity, but only where pnpm verifies the downloaded
- * bytes against it — so an SBOM never publishes a checksum as an assurance
- * pnpm did not make. See the call site for why a git resolution's is not one.
- */
-function verifiedIntegrity (resolution: LockfileResolution): string | undefined {
-  if (!('type' in resolution)) return (resolution as TarballResolution).integrity
-  return resolution.type === 'binary' ? resolution.integrity : undefined
-}
-
 async function walkStep (
   step: LockfileWalkerStep,
   parentPurl: string,
@@ -243,13 +233,6 @@ async function walkStep (
 
       if (componentsMap.has(purl)) return
 
-      // A component checksum is published only when pnpm checks the
-      // downloaded bytes against it: the tarball/registry hash, and a
-      // `type: binary` runtime archive's. A typed resolution that merely
-      // carries an `integrity` — a `type: git` entry some other tool
-      // stamped one onto — was never checked against it, and an SBOM
-      // checksum reads as an assurance. Mirrors `integrity_string` in the
-      // Rust CLI's `sbom.rs`.
       const integrity = verifiedIntegrity(pkgSnapshot.resolution)
       const resolution = pkgSnapshotToResolution(depPath, pkgSnapshot, { registries: opts.registries, namedRegistries: opts.namedRegistries })
       const tarballUrl = (resolution as TarballResolution).tarball ?? gitDownloadUrl(resolution)
@@ -345,4 +328,20 @@ export function resolveWorkspaceDeps (
   }
 
   return { links, additionalImporterIds }
+}
+
+/**
+ * The resolution's integrity, but only where pnpm verifies the downloaded
+ * bytes against it: the tarball/registry hash and a `type: binary` runtime
+ * archive's. Nothing checks a git checkout against a hash, so an `integrity`
+ * recorded on one is not a checksum and is never published as one.
+ *
+ * Read from an untyped lockfile, so the shape is probed rather than trusted:
+ * a non-object resolution must not throw, and a non-string integrity must not
+ * reach `ssri.parse` downstream.
+ */
+function verifiedIntegrity (resolution: LockfileResolution): string | undefined {
+  const { type, integrity } = resolution as { type?: string, integrity?: unknown }
+  if (typeof integrity !== 'string') return undefined
+  return (type === undefined || type === 'binary') ? integrity : undefined
 }

--- a/pnpm11/deps/compliance/sbom/src/collectComponents.ts
+++ b/pnpm11/deps/compliance/sbom/src/collectComponents.ts
@@ -337,11 +337,13 @@ export function resolveWorkspaceDeps (
  * recorded on one is not a checksum and is never published as one.
  *
  * Read from an untyped lockfile, so the shape is probed rather than trusted:
- * a non-object resolution must not throw, and a non-string integrity must not
- * reach `ssri.parse` downstream.
+ * reading a checksum out of a malformed resolution yields nothing instead of
+ * throwing, and a non-string integrity never reaches `ssri.parse` downstream.
+ * (A malformed resolution still fails the walk further along, in
+ * `pkgSnapshotToResolution` — this only keeps the checksum lookup total.)
  */
 function verifiedIntegrity (resolution: LockfileResolution): string | undefined {
-  const { type, integrity } = resolution as { type?: string, integrity?: unknown }
+  const { type, integrity } = (resolution ?? {}) as { type?: string, integrity?: unknown }
   if (typeof integrity !== 'string') return undefined
   return (type === undefined || type === 'binary') ? integrity : undefined
 }

--- a/pnpm11/deps/compliance/sbom/src/collectComponents.ts
+++ b/pnpm11/deps/compliance/sbom/src/collectComponents.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import { normalizeNamedRegistries } from '@pnpm/config.normalize-registries'
 import { PnpmError } from '@pnpm/error'
 import { DepType, type DepTypes, detectDepTypes } from '@pnpm/lockfile.detect-dep-types'
-import type { LockfileObject, TarballResolution } from '@pnpm/lockfile.types'
+import type { LockfileObject, LockfileResolution, TarballResolution } from '@pnpm/lockfile.types'
 import { nameVerFromPkgSnapshot, pkgSnapshotToResolution } from '@pnpm/lockfile.utils'
 import {
   lockfileWalkerGroupImporterSteps,
@@ -191,6 +191,16 @@ export async function collectSbomComponents (opts: CollectSbomComponentsOptions)
   }
 }
 
+/**
+ * The resolution's integrity, but only where pnpm verifies the downloaded
+ * bytes against it — so an SBOM never publishes a checksum as an assurance
+ * pnpm did not make. See the call site for why a git resolution's is not one.
+ */
+function verifiedIntegrity (resolution: LockfileResolution): string | undefined {
+  if (!('type' in resolution)) return (resolution as TarballResolution).integrity
+  return resolution.type === 'binary' ? resolution.integrity : undefined
+}
+
 async function walkStep (
   step: LockfileWalkerStep,
   parentPurl: string,
@@ -233,15 +243,14 @@ async function walkStep (
 
       if (componentsMap.has(purl)) return
 
-      // Only the tarball/registry hash is published as a component
-      // checksum: it is the one pnpm checks the downloaded bytes against.
-      // A typed resolution that merely carries an `integrity` — a
-      // `type: git` entry some other tool stamped one onto — was never
-      // checked against it, and an SBOM checksum reads as an assurance.
-      // Mirrors `integrity_string` in the Rust CLI's `sbom.rs`.
-      const integrity = 'type' in pkgSnapshot.resolution
-        ? undefined
-        : (pkgSnapshot.resolution as TarballResolution).integrity
+      // A component checksum is published only when pnpm checks the
+      // downloaded bytes against it: the tarball/registry hash, and a
+      // `type: binary` runtime archive's. A typed resolution that merely
+      // carries an `integrity` — a `type: git` entry some other tool
+      // stamped one onto — was never checked against it, and an SBOM
+      // checksum reads as an assurance. Mirrors `integrity_string` in the
+      // Rust CLI's `sbom.rs`.
+      const integrity = verifiedIntegrity(pkgSnapshot.resolution)
       const resolution = pkgSnapshotToResolution(depPath, pkgSnapshot, { registries: opts.registries, namedRegistries: opts.namedRegistries })
       const tarballUrl = (resolution as TarballResolution).tarball ?? gitDownloadUrl(resolution)
 

--- a/pnpm11/deps/compliance/sbom/test/collectComponents.test.ts
+++ b/pnpm11/deps/compliance/sbom/test/collectComponents.test.ts
@@ -108,4 +108,46 @@ describe('collectSbomComponents integrity', () => {
     expect(git).toBeDefined()
     expect(git!.integrity).toBeUndefined()
   })
+
+  /**
+   * A `type: binary` runtime archive is checked against its integrity, so
+   * that checksum is a real assurance and belongs in the SBOM.
+   */
+  it('should publish the integrity of a binary resolution', async () => {
+    const lockfile = {
+      lockfileVersion: '9.1',
+      importers: {
+        ['.' as ProjectId]: {
+          dependencies: { node: '22.0.0' },
+          specifiers: { node: '22.0.0' },
+        },
+      },
+      packages: {
+        ['node@22.0.0' as DepPath]: {
+          resolution: {
+            type: 'binary',
+            archive: 'tarball',
+            url: 'https://nodejs.org/dist/v22.0.0/node-v22.0.0-linux-x64.tar.gz',
+            integrity: 'sha512-CCCC',
+            bin: 'bin/node',
+          },
+          version: '22.0.0',
+        },
+      },
+    } as unknown as LockfileObject
+
+    const { components } = await collectSbomComponents({
+      lockfile,
+      rootName: 'root',
+      rootVersion: '1.0.0',
+      registries,
+      namedRegistries: normalizeNamedRegistries(undefined),
+      lockfileDir: '/test',
+      lockfileOnly: true,
+    })
+
+    const binary = components.find((component) => component.name === 'node')
+    expect(binary).toBeDefined()
+    expect(binary!.integrity).toBe('sha512-CCCC')
+  })
 })

--- a/pnpm11/deps/compliance/sbom/test/collectComponents.test.ts
+++ b/pnpm11/deps/compliance/sbom/test/collectComponents.test.ts
@@ -151,3 +151,40 @@ describe('collectSbomComponents integrity', () => {
     expect(binary!.integrity).toBe('sha512-CCCC')
   })
 })
+
+describe('verifiedIntegrity robustness', () => {
+  /**
+   * Lockfiles are untyped YAML, so `pnpm sbom` must survive a resolution
+   * that is not the shape the types promise rather than crashing on it.
+   */
+  it.each([
+    ['a non-object resolution', 'not-an-object'],
+    ['a non-string integrity', { integrity: 12345 }],
+    ['a non-string integrity on a binary resolution', { type: 'binary', integrity: 12345 }],
+  ])('should omit the checksum for %s', async (_label, resolution) => {
+    const lockfile = {
+      lockfileVersion: '9.1',
+      importers: {
+        ['.' as ProjectId]: {
+          dependencies: { foo: '1.0.0' },
+          specifiers: { foo: '^1.0.0' },
+        },
+      },
+      packages: {
+        ['foo@1.0.0' as DepPath]: { resolution },
+      },
+    } as unknown as LockfileObject
+
+    const { components } = await collectSbomComponents({
+      lockfile,
+      rootName: 'root',
+      rootVersion: '1.0.0',
+      registries,
+      namedRegistries: normalizeNamedRegistries(undefined),
+      lockfileDir: '/test',
+      lockfileOnly: true,
+    })
+
+    expect(components.find((component) => component.name === 'foo')?.integrity).toBeUndefined()
+  })
+})

--- a/pnpm11/deps/compliance/sbom/test/collectComponents.test.ts
+++ b/pnpm11/deps/compliance/sbom/test/collectComponents.test.ts
@@ -185,6 +185,8 @@ describe('verifiedIntegrity robustness', () => {
       lockfileOnly: true,
     })
 
-    expect(components.find((component) => component.name === 'foo')?.integrity).toBeUndefined()
+    const component = components.find((candidate) => candidate.name === 'foo')
+    expect(component).toBeDefined()
+    expect(component!.integrity).toBeUndefined()
   })
 })

--- a/pnpm11/deps/compliance/sbom/test/collectComponents.test.ts
+++ b/pnpm11/deps/compliance/sbom/test/collectComponents.test.ts
@@ -64,3 +64,48 @@ describe('collectSbomComponents with named registries', () => {
     )
   })
 })
+
+describe('collectSbomComponents integrity', () => {
+  /**
+   * An SBOM checksum is read as an assurance that the artifact was
+   * verified against it. pnpm never checks a git checkout against a hash,
+   * so an `integrity` recorded on a `type: git` resolution must not be
+   * republished as one.
+   */
+  it('should not publish an integrity recorded on a git resolution', async () => {
+    const lockfile = {
+      lockfileVersion: '9.1',
+      importers: {
+        ['.' as ProjectId]: {
+          dependencies: { foo: 'git+https://github.com/foo/bar.git#e63c09e460269b0c535e4c34debf69bb91d57b22' },
+          specifiers: { foo: 'github:foo/bar' },
+        },
+      },
+      packages: {
+        ['foo@git+https://github.com/foo/bar.git#e63c09e460269b0c535e4c34debf69bb91d57b22' as DepPath]: {
+          resolution: {
+            type: 'git',
+            repo: 'https://github.com/foo/bar.git',
+            commit: 'e63c09e460269b0c535e4c34debf69bb91d57b22',
+            integrity: 'sha512-AAAA',
+          },
+          version: '1.0.0',
+        },
+      },
+    } as unknown as LockfileObject
+
+    const { components } = await collectSbomComponents({
+      lockfile,
+      rootName: 'root',
+      rootVersion: '1.0.0',
+      registries,
+      namedRegistries: normalizeNamedRegistries(undefined),
+      lockfileDir: '/test',
+      lockfileOnly: true,
+    })
+
+    const git = components.find((component) => component.name === 'foo')
+    expect(git).toBeDefined()
+    expect(git!.integrity).toBeUndefined()
+  })
+})

--- a/pnpm11/lockfile/utils/src/toLockfileResolution.ts
+++ b/pnpm11/lockfile/utils/src/toLockfileResolution.ts
@@ -1,5 +1,5 @@
 import type { LockfileResolution } from '@pnpm/lockfile.types'
-import { isGitHostedTarballUrl, type Resolution, type TarballResolution } from '@pnpm/resolving.resolver-base'
+import { type GitResolution, isGitHostedTarballUrl, type Resolution, type TarballResolution } from '@pnpm/resolving.resolver-base'
 import { isCanonicalRegistryTarballUrl } from '@pnpm/resolving.tarball-url'
 
 export function toLockfileResolution (
@@ -12,6 +12,14 @@ export function toLockfileResolution (
   lockfileIncludeTarballUrl?: boolean
 ): LockfileResolution {
   if (resolution.type !== undefined || !resolution['integrity']) {
+    // Nothing checks a git checkout against a hash — the commit pins the
+    // content — so an `integrity` some other tool recorded on a git
+    // resolution is dropped rather than written back, instead of standing
+    // in the lockfile as a check that never runs.
+    if (resolution.type === 'git' && 'integrity' in resolution) {
+      const { integrity: _integrity, ...rest } = resolution as GitResolution & { integrity?: string }
+      return rest
+    }
     return resolution as LockfileResolution
   }
   // Tarball-typed resolutions are guaranteed to carry a tarball URL by the

--- a/pnpm11/lockfile/utils/test/toLockfileResolution.ts
+++ b/pnpm11/lockfile/utils/test/toLockfileResolution.ts
@@ -149,3 +149,38 @@ test('records gitHosted on the lockfile entry when set on the resolution', () =>
     gitHosted: true,
   })
 })
+
+test('drops an integrity recorded on a git resolution', () => {
+  expect(toLockfileResolution(
+    { name: 'foo', version: '1.0.0' },
+    {
+      type: 'git',
+      repo: 'https://github.com/foo/bar.git',
+      commit: 'e63c09e460269b0c535e4c34debf69bb91d57b22',
+      integrity: 'sha512-AAAA',
+    } as never,
+    REGISTRY
+  )).toEqual({
+    type: 'git',
+    repo: 'https://github.com/foo/bar.git',
+    commit: 'e63c09e460269b0c535e4c34debf69bb91d57b22',
+  })
+})
+
+test('keeps a git resolution without an integrity untouched', () => {
+  expect(toLockfileResolution(
+    { name: 'foo', version: '1.0.0' },
+    {
+      type: 'git',
+      repo: 'https://github.com/foo/bar.git',
+      commit: 'e63c09e460269b0c535e4c34debf69bb91d57b22',
+      path: '/packages/foo',
+    },
+    REGISTRY
+  )).toEqual({
+    type: 'git',
+    repo: 'https://github.com/foo/bar.git',
+    commit: 'e63c09e460269b0c535e4c34debf69bb91d57b22',
+    path: '/packages/foo',
+  })
+})


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#13042.

Lockfiles in the wild carry `resolution: {type: git, repo, commit, integrity: sha512-…}`. Nothing verifies a git checkout against that hash — the `commit` pins the content, and the store key is git-hosted rather than integrity-addressed — and both stacks were wrong about it, in opposite directions.

**The Rust engine rejected the lockfile outright.** `GitResolution` is `deny_unknown_fields` with no `integrity`, so the entry matched no `ResolutionSerde` variant and the whole install died with `ERR_PNPM_BROKEN_LOCKFILE` — on a lockfile the TypeScript CLI reads without complaint.

**The TypeScript CLI passed the hash on as if it meant something.** It echoed it back on every write, and `pnpm sbom` read `.integrity` off *any* resolution shape (`collectComponents.ts`), publishing it as a CycloneDX/SPDX checksum. An SBOM checksum reads as an assurance that the artifact was verified against it. For a git checkout, that verification never happened — so the field was quietly making a claim pnpm cannot back.

So the fix is not "preserve it for round-trip fidelity" (what the first revision of this PR did). It is: accept the key so the lockfile loads, and then drop it everywhere it could be mistaken for a check.

- **Rust** — the field is declared so parsing succeeds, and cleared as the entry is read, so it cannot reach the lockfile writer, a resolution comparison, or an SBOM. It is typed as an unvalidated `String` because the value is discarded: rejecting a malformed one would fail a lockfile pnpm reads fine.
- **TypeScript** — `toLockfileResolution` strips it on the way out, and the SBOM collector publishes only the tarball/registry hash it actually checks the downloaded bytes against.

The hash leaves with the next lockfile write rather than provoking one of its own, so a frozen install is untouched and no one gets a surprise diff.

### On provenance

I could not reproduce a pnpm that *writes* this field, and I want that on the record rather than buried. Against a `git+file://` dependency, none of pnpm 9.15.9, 10.34.5, 11.10.0 (the version that produced the reporter's lockfile) or 11.21.0 records an integrity on a `type: git` resolution, warm store and repeat installs included; `addFilesFromDir` — what the git fetcher returns — has no `integrity` at runtime, not merely in its types. A custom fetcher can still land one via the `(resolution as TarballResolution).integrity = …` write in `packageRequester.ts`, but I have not shown that to be the actual source, and an earlier revision of this description asserted it too confidently.

That does not change what to do. Whatever wrote it, pnpm reads such a lockfile and the Rust engine must not die on it, and neither stack should keep advertising a hash it never checks.

### Verification

Both halves were checked against real behavior, not just unit tests:

- Injecting an integrity into a lockfile and running the rebuilt TS bundle: the install succeeds (with a deliberately fabricated hash — nothing verified it), and a rewriting install now drops the key.
- The pacquet e2e (`install_from_a_git_repo_whose_lockfile_records_an_integrity`) installs a git dep, injects the hash, asserts a frozen install still succeeds, then asserts the key is gone once a dependency change rewrites the lockfile.
- Each new test was confirmed to fail without its fix — including the SBOM one, which reports `Received: "sha512-AAAA"` when the narrowing is reverted.

### Note for the reviewer

The SBOM collector now excludes every typed resolution, which also drops the `type: binary` checksum that pnpm *does* verify. That matches `integrity_string` in the Rust CLI's `sbom.rs` today, so the two stacks agree; publishing verified binary hashes in both stacks would be a separate improvement.

## Squash Commit Body

```text
Nothing verifies a git checkout against a hash: the commit pins the
content, and the store key is git-hosted rather than integrity-addressed.
Yet lockfiles in the wild carry `resolution: {type: git, repo, commit,
integrity: sha512-...}`, and both stacks were wrong about it in opposite
directions.

The Rust engine declared `GitResolution` `deny_unknown_fields` with no
`integrity`, so such an entry matched no `ResolutionSerde` variant and
aborted the whole install with ERR_PNPM_BROKEN_LOCKFILE — a lockfile the
TypeScript CLI reads without complaint.

The TypeScript CLI went the other way and passed the hash on as if it
meant something: it echoed it back on every write, and `pnpm sbom` read
`.integrity` off any resolution shape, publishing it as a CycloneDX/SPDX
checksum. An SBOM checksum reads as an assurance that the artifact was
verified against it, which for a git checkout never happened.

Accept the key so the lockfile loads, then drop it: the Rust side clears
it as the entry is read, so it cannot reach the writer, a comparison, or
an SBOM; `toLockfileResolution` strips it on the way out; and the SBOM
collector only publishes the tarball/registry hash it actually checks the
bytes against. The value leaves with the next lockfile write rather than
provoking one of its own.

Closes pnpm/pnpm#13042
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Git-based dependencies with integrity metadata now install successfully, including with frozen installations.
  * Lockfile rewrites remove unsupported Git integrity metadata while preserving resolved commits.
  * Legacy or malformed Git integrity values no longer prevent lockfile loading.

* **New Features**
  * SBOM output now includes verified checksums for binary runtime archives.
  * Unverified Git integrity metadata remains excluded from SBOM checksums.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->