### PR TITLE
fix(pnpr-fixtures): replace a storage tree that lost its completion marker

### DIFF
--- a/pnpr/crates/pnpr-fixtures/src/lib.rs
+++ b/pnpr/crates/pnpr-fixtures/src/lib.rs
@@ -81,23 +81,50 @@ fn ensure_storage_for_fingerprint(packages: &Path, generated: &Path, storage: &P
     }
     fs::create_dir_all(storage.parent().expect("registry fixture storage has parent"))
         .expect("create generated registry fixture storage dir");
-    let temp = generated.join(format!(
-        "storage.tmp.{}.{}",
-        std::process::id(),
-        TEMP_COUNTER.fetch_add(1, Ordering::Relaxed),
-    ));
+    let temp = generated.join(scratch_name("storage.tmp"));
     if temp.exists() {
         fs::remove_dir_all(&temp).expect("remove stale temp registry fixture storage");
     }
     build_storage(packages, &temp, &[]);
     fs::write(temp.join(COMPLETE_FILE), "").expect("write registry fixture completion marker");
-    match fs::rename(&temp, storage) {
-        Ok(()) => {}
-        Err(_) if storage.join(COMPLETE_FILE).exists() => {
-            fs::remove_dir_all(&temp).expect("remove redundant registry fixture storage");
-        }
-        Err(err) => panic!("publish generated registry fixture storage: {err}"),
+    publish_storage(generated, &temp, storage);
+}
+
+/// Move a freshly built `temp` tree into place at `storage`.
+///
+/// Publishers race: the loser's rename fails because the winner's tree is
+/// already there, which is harmless — the completion marker proves the
+/// content arrived. A tree *without* the marker is a different matter. It
+/// is a half-finished publish, or a build cache restored without the
+/// marker, and no reader may touch it; left alone it wedges every later
+/// run with `Directory not empty`. Move it aside — atomically, so only
+/// one publisher can claim it — and publish over the space it freed.
+fn publish_storage(generated: &Path, temp: &Path, storage: &Path) {
+    if try_publish_storage(temp, storage).is_ok() {
+        return;
     }
+    let discarded = generated.join(scratch_name("storage.stale"));
+    if fs::rename(storage, &discarded).is_ok() {
+        fs::remove_dir_all(&discarded).expect("remove unusable registry fixture storage");
+    }
+    try_publish_storage(temp, storage).expect("publish generated registry fixture storage");
+}
+
+fn try_publish_storage(temp: &Path, storage: &Path) -> io::Result<()> {
+    match fs::rename(temp, storage) {
+        Ok(()) => Ok(()),
+        Err(_) if storage.join(COMPLETE_FILE).exists() => {
+            fs::remove_dir_all(temp).expect("remove redundant registry fixture storage");
+            Ok(())
+        }
+        Err(err) => Err(err),
+    }
+}
+
+/// A scratch directory name no other publisher — in this process or any
+/// concurrent one — can collide with.
+fn scratch_name(prefix: &str) -> String {
+    format!("{prefix}.{}.{}", std::process::id(), TEMP_COUNTER.fetch_add(1, Ordering::Relaxed))
 }
 
 fn fixture_fingerprint(root: &Path) -> String {

--- a/pnpr/crates/pnpr-fixtures/src/lib.rs
+++ b/pnpr/crates/pnpr-fixtures/src/lib.rs
@@ -97,17 +97,37 @@ fn ensure_storage_for_fingerprint(packages: &Path, generated: &Path, storage: &P
 /// content arrived. A tree *without* the marker is a different matter. It
 /// is a half-finished publish, or a build cache restored without the
 /// marker, and no reader may touch it; left alone it wedges every later
-/// run with `Directory not empty`. Move it aside — atomically, so only
-/// one publisher can claim it — and publish over the space it freed.
+/// run with `Directory not empty`.
 fn publish_storage(generated: &Path, temp: &Path, storage: &Path) {
     if try_publish_storage(temp, storage).is_ok() {
         return;
     }
-    let discarded = generated.join(scratch_name("storage.stale"));
-    if fs::rename(storage, &discarded).is_ok() {
-        fs::remove_dir_all(&discarded).expect("remove unusable registry fixture storage");
-    }
+    discard_unusable_storage(generated, storage);
     try_publish_storage(temp, storage).expect("publish generated registry fixture storage");
+}
+
+/// Clear an unusable tree out of `storage` so a publish can land there.
+///
+/// Claiming the tree with a rename is what makes this safe against other
+/// publishers: exactly one of them can move a given directory, so the
+/// others find the path already free (or already republished) rather than
+/// deleting each other's work.
+///
+/// The claim is taken before the marker can be inspected, though, and a
+/// competing publisher may have completed the tree in between. Deleting it
+/// then would pull content out from under every reader holding the path,
+/// so the marker is re-checked *after* the claim and a completed tree is
+/// put straight back.
+fn discard_unusable_storage(generated: &Path, storage: &Path) {
+    let claimed = generated.join(scratch_name("storage.stale"));
+    if fs::rename(storage, &claimed).is_err() {
+        return;
+    }
+    if claimed.join(COMPLETE_FILE).exists() {
+        fs::rename(&claimed, storage).expect("restore completed registry fixture storage");
+        return;
+    }
+    fs::remove_dir_all(&claimed).expect("remove unusable registry fixture storage");
 }
 
 fn try_publish_storage(temp: &Path, storage: &Path) -> io::Result<()> {

--- a/pnpr/crates/pnpr-fixtures/src/lib.rs
+++ b/pnpr/crates/pnpr-fixtures/src/lib.rs
@@ -124,10 +124,22 @@ fn discard_unusable_storage(generated: &Path, storage: &Path) {
         return;
     }
     if claimed.join(COMPLETE_FILE).exists() {
-        fs::rename(&claimed, storage).expect("restore completed registry fixture storage");
+        restore_claimed_storage(&claimed, storage);
         return;
     }
     fs::remove_dir_all(&claimed).expect("remove unusable registry fixture storage");
+}
+
+/// Put a claimed tree back after it turned out to be complete.
+///
+/// The claim leaves `storage` free, so a publisher can land its own tree
+/// there before the restore runs. Its content is the same — the path is
+/// addressed by a fingerprint of the fixtures — so a claim that can no
+/// longer go back is redundant rather than lost, and gets dropped.
+fn restore_claimed_storage(claimed: &Path, storage: &Path) {
+    if fs::rename(claimed, storage).is_err() {
+        fs::remove_dir_all(claimed).expect("remove redundant registry fixture storage");
+    }
 }
 
 fn try_publish_storage(temp: &Path, storage: &Path) -> io::Result<()> {

--- a/pnpr/crates/pnpr-fixtures/src/tests.rs
+++ b/pnpr/crates/pnpr-fixtures/src/tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    COMPLETE_FILE, build_storage_at_with_substitutions, ensure_storage, latest_version,
-    packages_dir, publish_storage,
+    COMPLETE_FILE, build_storage_at_with_substitutions, discard_unusable_storage, ensure_storage,
+    latest_version, packages_dir, publish_storage,
 };
 use std::{collections::BTreeSet, fs, path::Path};
 use tempfile::TempDir;
@@ -119,10 +119,6 @@ fn root_license_is_injected_except_for_self_contained_workspaces() {
     assert!(!bundled.contains("package/LICENSE"), "{bundled:?}");
 }
 
-/// A storage tree left behind without its completion marker — a
-/// half-finished publish, or a build cache restored without it — is
-/// unusable, so the next publisher replaces it instead of failing every
-/// run that follows with `Directory not empty`.
 #[test]
 fn publish_replaces_a_storage_tree_that_lost_its_marker() {
     let root = TempDir::new().expect("create temp dir");
@@ -147,8 +143,6 @@ fn publish_replaces_a_storage_tree_that_lost_its_marker() {
     assert!(!temp.exists());
 }
 
-/// The publisher that loses the race keeps the winner's tree and drops
-/// its own — the marker is what proves the content arrived.
 #[test]
 fn publish_yields_to_a_tree_that_already_carries_the_marker() {
     let root = TempDir::new().expect("create temp dir");
@@ -170,4 +164,26 @@ fn publish_yields_to_a_tree_that_already_carries_the_marker() {
         "winner",
     );
     assert!(!temp.exists());
+}
+
+/// The interleaving the claim-then-check ordering exists for: a competing
+/// publisher completes the tree after this publisher's rename failed but
+/// before it claims the tree. Readers already hold that path, so the
+/// content has to survive.
+#[test]
+fn discarding_leaves_a_tree_that_completed_after_the_claim_was_decided() {
+    let root = TempDir::new().expect("create temp dir");
+    let generated = root.path();
+    let storage = generated.join("storage").join("fingerprint");
+    fs::create_dir_all(&storage).expect("create storage dir");
+    fs::write(storage.join("packument"), "winner").expect("write winner file");
+    fs::write(storage.join(COMPLETE_FILE), "").expect("write completion marker");
+
+    discard_unusable_storage(generated, &storage);
+
+    assert_eq!(
+        fs::read_to_string(storage.join("packument")).expect("read published file"),
+        "winner",
+    );
+    assert!(storage.join(COMPLETE_FILE).exists());
 }

--- a/pnpr/crates/pnpr-fixtures/src/tests.rs
+++ b/pnpr/crates/pnpr-fixtures/src/tests.rs
@@ -213,3 +213,17 @@ fn restoring_yields_to_a_publisher_that_took_the_freed_path() {
         "publisher",
     );
 }
+
+/// Another publisher claimed the tree first, so there is nothing at the
+/// path to claim and nothing to do.
+#[test]
+fn discarding_does_nothing_when_the_path_is_already_free() {
+    let root = TempDir::new().expect("create temp dir");
+    let generated = root.path();
+    let storage = generated.join("storage").join("fingerprint");
+
+    discard_unusable_storage(generated, &storage);
+
+    assert!(!storage.exists());
+    assert!(!generated.join("storage").exists());
+}

--- a/pnpr/crates/pnpr-fixtures/src/tests.rs
+++ b/pnpr/crates/pnpr-fixtures/src/tests.rs
@@ -1,6 +1,6 @@
 use super::{
     COMPLETE_FILE, build_storage_at_with_substitutions, discard_unusable_storage, ensure_storage,
-    latest_version, packages_dir, publish_storage,
+    latest_version, packages_dir, publish_storage, restore_claimed_storage,
 };
 use std::{collections::BTreeSet, fs, path::Path};
 use tempfile::TempDir;
@@ -186,4 +186,30 @@ fn discarding_leaves_a_tree_that_completed_after_the_claim_was_decided() {
         "winner",
     );
     assert!(storage.join(COMPLETE_FILE).exists());
+}
+
+/// The claim frees `storage`, so a publisher can take it before the
+/// restore runs. That tree is equivalent — the path is keyed by a
+/// fingerprint of the fixtures — so the claim is dropped, not forced back.
+#[test]
+fn restoring_yields_to_a_publisher_that_took_the_freed_path() {
+    let root = TempDir::new().expect("create temp dir");
+    let generated = root.path();
+    let storage = generated.join("storage").join("fingerprint");
+    fs::create_dir_all(&storage).expect("create storage dir");
+    fs::write(storage.join("packument"), "publisher").expect("write publisher file");
+    fs::write(storage.join(COMPLETE_FILE), "").expect("write completion marker");
+
+    let claimed = generated.join("storage.stale");
+    fs::create_dir_all(&claimed).expect("create claimed dir");
+    fs::write(claimed.join("packument"), "claimed").expect("write claimed file");
+    fs::write(claimed.join(COMPLETE_FILE), "").expect("write completion marker");
+
+    restore_claimed_storage(&claimed, &storage);
+
+    assert!(!claimed.exists());
+    assert_eq!(
+        fs::read_to_string(storage.join("packument")).expect("read published file"),
+        "publisher",
+    );
 }

--- a/pnpr/crates/pnpr-fixtures/src/tests.rs
+++ b/pnpr/crates/pnpr-fixtures/src/tests.rs
@@ -1,5 +1,9 @@
-use super::{build_storage_at_with_substitutions, ensure_storage, latest_version, packages_dir};
-use std::{collections::BTreeSet, path::Path};
+use super::{
+    COMPLETE_FILE, build_storage_at_with_substitutions, ensure_storage, latest_version,
+    packages_dir, publish_storage,
+};
+use std::{collections::BTreeSet, fs, path::Path};
+use tempfile::TempDir;
 
 fn tarball_entries(tarball: &Path) -> BTreeSet<String> {
     let bytes = std::fs::read(tarball).expect("read fixture tarball");
@@ -113,4 +117,57 @@ fn root_license_is_injected_except_for_self_contained_workspaces() {
             "@pnpm.e2e/pkg-with-bundled-dependencies/pkg-with-bundled-dependencies-1.0.0.tgz",
         ));
     assert!(!bundled.contains("package/LICENSE"), "{bundled:?}");
+}
+
+/// A storage tree left behind without its completion marker — a
+/// half-finished publish, or a build cache restored without it — is
+/// unusable, so the next publisher replaces it instead of failing every
+/// run that follows with `Directory not empty`.
+#[test]
+fn publish_replaces_a_storage_tree_that_lost_its_marker() {
+    let root = TempDir::new().expect("create temp dir");
+    let generated = root.path();
+    let storage = generated.join("storage").join("fingerprint");
+    fs::create_dir_all(&storage).expect("create storage dir");
+    fs::write(storage.join("leftover"), "stale").expect("write leftover file");
+
+    let temp = generated.join("storage.tmp");
+    fs::create_dir_all(&temp).expect("create temp dir");
+    fs::write(temp.join("packument"), "fresh").expect("write fresh file");
+    fs::write(temp.join(COMPLETE_FILE), "").expect("write completion marker");
+
+    publish_storage(generated, &temp, &storage);
+
+    assert!(storage.join(COMPLETE_FILE).exists());
+    assert_eq!(
+        fs::read_to_string(storage.join("packument")).expect("read published file"),
+        "fresh",
+    );
+    assert!(!storage.join("leftover").exists());
+    assert!(!temp.exists());
+}
+
+/// The publisher that loses the race keeps the winner's tree and drops
+/// its own — the marker is what proves the content arrived.
+#[test]
+fn publish_yields_to_a_tree_that_already_carries_the_marker() {
+    let root = TempDir::new().expect("create temp dir");
+    let generated = root.path();
+    let storage = generated.join("storage").join("fingerprint");
+    fs::create_dir_all(&storage).expect("create storage dir");
+    fs::write(storage.join("packument"), "winner").expect("write winner file");
+    fs::write(storage.join(COMPLETE_FILE), "").expect("write completion marker");
+
+    let temp = generated.join("storage.tmp");
+    fs::create_dir_all(&temp).expect("create temp dir");
+    fs::write(temp.join("packument"), "loser").expect("write loser file");
+    fs::write(temp.join(COMPLETE_FILE), "").expect("write completion marker");
+
+    publish_storage(generated, &temp, &storage);
+
+    assert_eq!(
+        fs::read_to_string(storage.join("packument")).expect("read published file"),
+        "winner",
+    );
+    assert!(!temp.exists());
 }


### PR DESCRIPTION
## Summary

`Rust CI / Test` is red on every platform for every PR opened since the last `main` run — see pnpm/pnpm#13748 and pnpm/pnpm#13743, both of which die identically on ubuntu, macOS, and windows before running a single test of their own:

```
thread '…' panicked at pnpr/crates/pnpr-fixtures/src/lib.rs:99:21:
publish generated registry fixture storage: Directory not empty (os error 39)
```

The generated registry-fixture storage is published by building a temp tree and renaming it onto `target/pnpr-fixtures/storage/<fingerprint>`. Renaming onto a *non-empty* directory fails with ENOTEMPTY, and the publisher forgave that only when the directory carried the `.complete` marker — the signal that a concurrent publisher already put good content there. Any other ENOTEMPTY aborted the process.

But a marker-less tree at that path is not a lost race, and it happens: a half-finished publish, or — what CI hit here — a build cache that restores `target/` without the marker. Nothing is allowed to read such a tree (readers gate on the marker), and nothing could ever repair it, so it wedges every subsequent run until the cache rolls over. `main` stays green only because it has not run since the cache was written.

This makes the publisher replace an unusable tree instead of dying on it: move it aside with a rename — atomic, so exactly one publisher claims it — and publish over the space that frees. A publisher that loses to a *complete* tree still yields to it and drops its own copy, unchanged from before.

Reproduced locally by deleting the marker from an existing `target/pnpr-fixtures/storage/<fingerprint>/`, which turns every pacquet test into the CI panic; with this change the same setup self-heals on the next run and leaves no scratch directories behind.

No changeset: `pnpr-fixtures` is test infrastructure and is not published.

## Squash Commit Body

```text
The generated registry-fixture storage is published by renaming a freshly
built temp tree onto `target/pnpr-fixtures/storage/<fingerprint>`. A rename
onto a non-empty directory fails with ENOTEMPTY, which the publisher treated
as a lost race and forgave only when the target carried the `.complete`
marker; anything else aborted the process.

A marker-less tree at that path is not a lost race, and it does happen: a
half-finished publish, or a CI build cache that restores `target/` without
the marker. Nothing may read such a tree, and nothing could ever repair it,
so every test process that touched the fixtures died with "publish generated
registry fixture storage: Directory not empty" until the cache rolled over.

Move the unusable tree aside instead — atomically, so exactly one publisher
claims it — and publish over the space it frees.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (Test infrastructure for the Rust stack only — no TypeScript counterpart exists.)
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788912123&installation_model_id=426870&pr_number=13749&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13749&signature=d8a4ca2d655f1cbe07cf69bb374850d0ec20e9dc895052359e8b4de928b2ecfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when storage is published concurrently.
  - Safely replaces incomplete or stale storage and retries publication.
  - Preserves completed storage during competing publication and cleanup operations.
  - Cleans up temporary publishing data, including after a lost publication race.
  - Prevents completed storage from being incorrectly discarded.
  - Handles cleanup safely when storage is already absent.

- **Tests**
  - Added coverage for incomplete storage replacement, concurrent publishing, temporary directory cleanup, and race-condition safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->