### PR TITLE
fix: refetch metadata when publish times are incomplete

### DIFF
--- a/.changeset/complete-version-publish-times.md
+++ b/.changeset/complete-version-publish-times.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/resolving.npm-resolver": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+Re-fetch full registry metadata when `minimumReleaseAge` is enabled and an abbreviated packument's `time` map omits timestamps for some versions. This prevents mature versions from being filtered out and resolution from falling back to the lowest matching version [pnpm/pnpm#13741](https://github.com/pnpm/pnpm/issues/13741).

--- a/cspell.json
+++ b/cspell.json
@@ -240,6 +240,7 @@
     "npmcli",
     "npmignore",
     "npmjs",
+    "npmmirror",
     "npmx",
     "ntfs",
     "nushell",

--- a/pnpm/crates/registry/src/package.rs
+++ b/pnpm/crates/registry/src/package.rs
@@ -67,14 +67,6 @@ pub struct Package {
     /// [`DerivedPackuments`].
     #[serde(skip_serializing, skip_deserializing)]
     pub derived: DerivedPackuments,
-
-    /// `true` once a release-age upgrade fetch for this document answered
-    /// `304 Not Modified` in this process: the registry holds no fuller
-    /// form than what is already cached, so re-asking within the install
-    /// is pure waste. In-memory only — never written to the mirror, so a
-    /// later install re-validates once and re-stamps.
-    #[serde(skip_serializing, skip_deserializing)]
-    pub release_age_upgrade_checked: bool,
 }
 
 impl Package {

--- a/pnpm/crates/registry/src/package.rs
+++ b/pnpm/crates/registry/src/package.rs
@@ -77,6 +77,37 @@ impl Package {
         self.time.as_ref()?.get(version)?.as_str()
     }
 
+    /// Drop `time` unless it carries a publish timestamp for every
+    /// version this packument lists.
+    ///
+    /// Registries may answer with a partial map: npmmirror adds `time`
+    /// to its abbreviated documents but fills it in only for the
+    /// versions it has synced since it started recording publish times,
+    /// leaving the rest out. A partial map is indistinguishable from a
+    /// complete one at the point of use, so the `minimumReleaseAge`
+    /// filter reads every absent timestamp as "not mature" and silently
+    /// drops the version — resolution then falls back to the lowest
+    /// match.
+    ///
+    /// A map that can't decide maturity is worth nothing to the
+    /// resolver, so it is normalized away where the document is parsed.
+    /// Every packument past that point carries either a complete `time`
+    /// or none at all — the shape the npm registry's own abbreviated
+    /// documents have, and the one the rest of the resolver is written
+    /// against.
+    /// A packument with no versions keeps whatever `time` it has — there
+    /// is nothing for the map to be incomplete about — and a version whose
+    /// entry is an empty string counts as absent.
+    pub fn drop_incomplete_publish_times(&mut self) {
+        let Some(time) = self.time.as_ref() else { return };
+        let complete = self.versions.keys().all(|version| {
+            time.get(version).and_then(serde_json::Value::as_str).is_some_and(|at| !at.is_empty())
+        });
+        if !complete {
+            self.time = None;
+        }
+    }
+
     /// Version under `dist-tags.<tag>`, or `None` when the tag is
     /// absent. The picker reads `latest` (for the version-range fast
     /// path) and any user-supplied tag (e.g. `next`, `beta`) through

--- a/pnpm/crates/registry/src/package/tests.rs
+++ b/pnpm/crates/registry/src/package/tests.rs
@@ -166,7 +166,6 @@ fn package_with_versions(name: &str, versions: &[&str], latest: &str) -> Package
         etag: None,
         homepage: None,
         mutex: std::sync::Arc::default(),
-        release_age_upgrade_checked: false,
         derived: DerivedPackuments::default(),
     }
 }

--- a/pnpm/crates/registry/src/package/tests.rs
+++ b/pnpm/crates/registry/src/package/tests.rs
@@ -496,3 +496,46 @@ fn published_at_skips_reserved_unpublished_object() {
     assert_eq!(pkg.published_at("1.0.0"), Some("2025-01-10T08:30:00.000Z"));
     assert_eq!(pkg.published_at("unpublished"), None, "object value isn't a string");
 }
+
+/// npmmirror answers abbreviated requests with a `time` map covering only
+/// the versions it has synced since it started recording publish times. Such
+/// a map can't decide maturity, and leaving it in place makes the
+/// `minimumReleaseAge` filter read every absent timestamp as "not mature".
+#[test]
+fn drop_incomplete_publish_times_discards_a_partial_map() {
+    let mut pkg = package_with_versions("acme", &["1.0.0", "1.1.0"], "1.1.0");
+    pkg.time = Some(HashMap::from([(
+        "1.1.0".to_string(),
+        serde_json::Value::String("2025-01-10T08:30:00.000Z".to_string()),
+    )]));
+
+    pkg.drop_incomplete_publish_times();
+
+    assert_eq!(pkg.time, None, "a map missing 1.0.0 cannot decide maturity");
+}
+
+#[test]
+fn drop_incomplete_publish_times_keeps_a_complete_map() {
+    let mut pkg = package_with_versions("acme", &["1.0.0", "1.1.0"], "1.1.0");
+    pkg.time = Some(HashMap::from([
+        ("1.0.0".to_string(), serde_json::Value::String("2025-01-01T08:30:00.000Z".to_string())),
+        ("1.1.0".to_string(), serde_json::Value::String("2025-01-10T08:30:00.000Z".to_string())),
+        ("created".to_string(), serde_json::Value::String("2024-12-01T00:00:00.000Z".to_string())),
+    ]));
+
+    pkg.drop_incomplete_publish_times();
+
+    assert!(pkg.time.is_some(), "reserved keys alongside every version are still complete");
+}
+
+/// An empty timestamp is as unusable as an absent one.
+#[test]
+fn drop_incomplete_publish_times_discards_an_empty_timestamp() {
+    let mut pkg = package_with_versions("acme", &["1.0.0"], "1.0.0");
+    pkg.time =
+        Some(HashMap::from([("1.0.0".to_string(), serde_json::Value::String(String::new()))]));
+
+    pkg.drop_incomplete_publish_times();
+
+    assert_eq!(pkg.time, None);
+}

--- a/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
@@ -1196,7 +1196,6 @@ fn project_trust_meta(meta: &Package) -> Package {
         // bounded by the trust-evidence footprint (see the fn doc).
         homepage: None,
         mutex: std::sync::Arc::new(std::sync::Mutex::new(0)),
-        release_age_upgrade_checked: false,
         derived: DerivedPackuments::default(),
     }
 }

--- a/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata.rs
@@ -252,9 +252,10 @@ pub async fn fetch_full_metadata(
         drop(client);
         let task_url = url.clone();
         let meta = tokio::task::spawn_blocking(move || -> Result<Package, FetchMetadataError> {
-            let meta = serde_json::from_str::<Package>(&raw_body).map_err(|error| {
+            let mut meta = serde_json::from_str::<Package>(&raw_body).map_err(|error| {
                 FetchMetadataError::Decode { url: redact_url_credentials(&task_url), error }
             })?;
+            meta.drop_incomplete_publish_times();
             Ok(if normalize_to_abbreviated { normalize_abbreviated_meta(meta) } else { meta })
         })
         .await

--- a/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
@@ -193,6 +193,7 @@ pub async fn fetch_full_metadata_cached(
             let mut meta: Package = serde_json::from_str(&raw_body).map_err(|error| {
                 FetchMetadataError::Decode { url: redact_url_credentials(&task_url), error }
             })?;
+            meta.drop_incomplete_publish_times();
             if normalize_to_abbreviated {
                 meta = normalize_abbreviated_meta(meta);
             }

--- a/pnpm/crates/resolving-npm-resolver/src/mirror.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/mirror.rs
@@ -646,7 +646,6 @@ fn load_meta_with_hold_cap(pkg_mirror: &Path, hold_cap: usize) -> Option<Package
         etag: headers.etag,
         homepage: index.homepage,
         mutex: Arc::default(),
-        release_age_upgrade_checked: false,
         derived: DerivedPackuments::default(),
     })
 }

--- a/pnpm/crates/resolving-npm-resolver/src/mirror.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/mirror.rs
@@ -555,6 +555,7 @@ fn load_meta_with_hold_cap(pkg_mirror: &Path, hold_cap: usize) -> Option<Package
         let mut meta: Package = serde_json::from_slice(&contents[newline + 1..]).ok()?;
         meta.etag = headers.etag;
         meta.modified = meta.modified.or(headers.modified);
+        meta.drop_incomplete_publish_times();
         return Some(meta);
     };
     // Bound each declared length, then require the whole header +
@@ -637,7 +638,7 @@ fn load_meta_with_hold_cap(pkg_mirror: &Path, hold_cap: usize) -> Option<Package
         }
     };
 
-    Some(Package {
+    let mut meta = Package {
         name: index.name,
         dist_tags: index.dist_tags,
         versions,
@@ -647,7 +648,9 @@ fn load_meta_with_hold_cap(pkg_mirror: &Path, hold_cap: usize) -> Option<Package
         homepage: index.homepage,
         mutex: Arc::default(),
         derived: DerivedPackuments::default(),
-    })
+    };
+    meta.drop_incomplete_publish_times();
+    Some(meta)
 }
 
 /// How many mirror files [`load_meta`] may keep open at once. Sized

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package.rs
@@ -138,30 +138,30 @@ pub trait PackageMetaCache: Send + Sync {
     fn set_unverified(&self, key: String, meta: Arc<Package>);
 }
 
-/// Install-scoped state for packument fetching.
+/// The packument-fetching state one install owns, shared across every
+/// [`PickPackageContext`] in it so the npm and named-registry resolvers
+/// coalesce against the same in-flight set.
 ///
-/// Pacquet stores one [`tokio::sync::Semaphore`] (single-permit) per in-memory
-/// cache key; first caller acquires, runs the
-/// disk-then-network flow, releases. Subsequent callers wait on the
-/// same semaphore; after acquiring, they re-check
-/// [`PackageMetaCache`] and short-circuit on a hit so only the first
-/// caller hits the network.
+/// Both maps key on the string [`PackageMetaCache`] uses
+/// (`{registry}\x00{name}` for abbreviated, `{registry}\x00{name}:full` for
+/// full), so two callers asking for different forms of the same packument
+/// don't accidentally serialize — the `metaDir` differentiator is embedded
+/// in the key.
 ///
-/// Shared across every [`PickPackageContext`] in a single install so
-/// the npm and named-registry resolvers coalesce against the same
-/// in-flight set. Keying is on the same string [`PackageMetaCache`]
-/// uses (`{registry}\x00{name}` for abbreviated,
-/// `{registry}\x00{name}:full` for full), so two callers asking for
-/// different forms of the same packument don't accidentally serialize — the
-/// `metaDir` differentiator is embedded in the key. Release-age upgrade 304s
-/// are tracked alongside the limits because they have the same install
-/// lifetime. Each marker retains the exact [`Package`] document that was
-/// revalidated, so a newer abbreviated response under the same cache key is
-/// checked independently. Keeping the marker out of [`Package`] also prevents
-/// a caller-owned metadata cache from leaking it into a later install.
+/// The state is install-scoped rather than hung on [`Package`] because a
+/// caller may hand the same [`PackageMetaCache`] to install after install,
+/// and each of those installs has to make its own decisions.
 #[derive(Debug, Default)]
 pub struct PackumentFetchState {
+    /// One single-permit [`tokio::sync::Semaphore`] per in-memory cache key:
+    /// the first caller acquires it and runs the disk-then-network flow,
+    /// later ones wait, then re-check [`PackageMetaCache`] and short-circuit
+    /// on the hit the winner just wrote, so only the first hits the network.
     limits: DashMap<String, Arc<Semaphore>>,
+    /// The packument each cache key's release-age upgrade last got a `304`
+    /// for. Holding the document itself (compared by [`Arc::ptr_eq`]) rather
+    /// than a bare flag keeps the answer tied to what was revalidated, so a
+    /// newer response under the same key is checked on its own.
     release_age_upgrade_checked: DashMap<String, Arc<Package>>,
 }
 
@@ -1219,6 +1219,9 @@ struct UpgradeOutcome {
 /// - `opts.published_by.is_none()`: maturity check disabled.
 /// - every version has a publish timestamp: the metadata is complete.
 ///   Nothing to upgrade.
+/// - this document already got a `304` from an upgrade fetch earlier in
+///   the install (see [`PackumentFetchState`]): the registry has no
+///   fuller form of it, so asking again is pure waste.
 /// - `opts.published_by_exclude` matches the package: caller has
 ///   opted this package out of the policy.
 /// - `meta.modified.is_some()` and parses as a date `<= cutoff`:
@@ -1288,17 +1291,18 @@ async fn maybe_upgrade_abbreviated_meta_for_release_age<Cache: PackageMetaCache>
     );
     let _permit =
         limit.acquire().await.expect("release-age upgrade semaphore should not be closed");
+    // Waiting for the permit may have handed the winner's work to us: pick up
+    // whatever it left in the cache and re-run the guards before spending a
+    // round trip of our own. A checksum refresh skips the cache on purpose —
+    // it is the one caller holding a document fresher than the cached one.
     if !opts.update_checksums
         && let Some(cached) = ctx.meta_cache.get(cache_key)
     {
-        let cached_meta = cached.meta;
-        if has_all_version_publish_times(&cached_meta)
-            || ctx.fetch_locker.release_age_upgrade_was_checked(cache_key, &cached_meta)
-        {
-            return Ok(UpgradeOutcome { meta: cached_meta, upgraded: false });
-        }
-        meta = cached_meta;
-    } else if ctx.fetch_locker.release_age_upgrade_was_checked(cache_key, &meta) {
+        meta = cached.meta;
+    }
+    if ctx.fetch_locker.release_age_upgrade_was_checked(cache_key, &meta)
+        || has_all_version_publish_times(&meta)
+    {
         return Ok(UpgradeOutcome { meta, upgraded: false });
     }
     let fetch_opts = FetchFullMetadataOptions {
@@ -1317,11 +1321,10 @@ async fn maybe_upgrade_abbreviated_meta_for_release_age<Cache: PackageMetaCache>
         // 304: the full-form representation matched the conditional
         // headers, so the abbreviated meta is still the freshest
         // signal we have. Keep it (the downstream picker falls through
-        // to its warn-and-skip path on the missing `time` map), but
-        // mark it in install-owned state so no later pick repeats the round
-        // trip. The 304 also registry-validated the document, so it may enter
-        // the shared metadata cache as verified without carrying the marker
-        // into a later install.
+        // to its warn-and-skip path on the incomplete `time` map) and
+        // mark it so no later pick in this install repeats the round trip.
+        // The 304 also registry-validated the document, so it may enter the
+        // shared metadata cache as verified.
         FetchFullMetadataOutcome::NotModified => {
             ctx.fetch_locker.mark_release_age_upgrade_checked(cache_key, &meta);
             if !opts.dry_run {

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package.rs
@@ -20,7 +20,7 @@
 //! the in-memory cache key (`:full` suffix when full), and the
 //! `Accept` header on the registry request. When `published_by` is
 //! active and the picker ends up with abbreviated metadata that
-//! lacks the per-version `time` map, the orchestrator transparently
+//! lacks a complete per-version `time` map, the orchestrator transparently
 //! upgrades to full metadata via a follow-up fetch so the
 //! `minimumReleaseAge` check runs against real timestamps instead of
 //! silently degrading to its warn-and-skip fallback (see
@@ -70,7 +70,7 @@ use crate::{
     },
     pick_package_from_meta::{
         PickPackageFromMetaError, PickPackageFromMetaOptions, RegistryPackageSpec,
-        RegistryPackageSpecType, filter_pkg_metadata_versions,
+        RegistryPackageSpecType, filter_pkg_metadata_versions, has_all_version_publish_times,
         pick_lowest_version_by_version_range, pick_package_from_meta,
         pick_version_by_version_range,
     },
@@ -1184,7 +1184,7 @@ struct UpgradeOutcome {
 /// per-version timestamps.
 ///
 /// When the resolver default-fetched abbreviated metadata but
-/// `published_by` is active, the per-version `time` map is missing
+/// `published_by` is active, the per-version `time` map is incomplete
 /// so the maturity check would silently degrade to the warn-and-skip
 /// fallback. This function detects that and re-fetches full metadata
 /// when the package's top-level `modified` field shows it was
@@ -1195,9 +1195,8 @@ struct UpgradeOutcome {
 ///
 /// - `ctx.offline`: no network allowed. Stick with what we have.
 /// - `opts.published_by.is_none()`: maturity check disabled.
-/// - `meta.time.is_some()`: already full metadata (or an
-///   abbreviated response that happens to carry `time`). Nothing
-///   to upgrade.
+/// - every version has a publish timestamp: the metadata is complete.
+///   Nothing to upgrade.
 /// - `opts.published_by_exclude` matches the package: caller has
 ///   opted this package out of the policy.
 /// - `meta.modified.is_some()` and parses as a date `<= cutoff`:
@@ -1230,7 +1229,7 @@ async fn maybe_upgrade_abbreviated_meta_for_release_age<Cache: PackageMetaCache>
     let Some(cutoff) = opts.published_by else {
         return Ok(UpgradeOutcome { meta, upgraded: false });
     };
-    if meta.time.is_some() || meta.release_age_upgrade_checked {
+    if has_all_version_publish_times(&meta) || meta.release_age_upgrade_checked {
         return Ok(UpgradeOutcome { meta, upgraded: false });
     }
     if let Some(policy) = opts.published_by_exclude
@@ -1266,7 +1265,7 @@ async fn maybe_upgrade_abbreviated_meta_for_release_age<Cache: PackageMetaCache>
         limit.acquire().await.expect("release-age upgrade semaphore should not be closed");
     if let Some(cached) = ctx.meta_cache.get(cache_key) {
         let cached_meta = cached.meta;
-        if cached_meta.time.is_some() || cached_meta.release_age_upgrade_checked {
+        if has_all_version_publish_times(&cached_meta) || cached_meta.release_age_upgrade_checked {
             return Ok(UpgradeOutcome { meta: cached_meta, upgraded: false });
         }
     }

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package.rs
@@ -20,7 +20,7 @@
 //! the in-memory cache key (`:full` suffix when full), and the
 //! `Accept` header on the registry request. When `published_by` is
 //! active and the picker ends up with abbreviated metadata that
-//! lacks a complete per-version `time` map, the orchestrator transparently
+//! lacks the per-version `time` map, the orchestrator transparently
 //! upgrades to full metadata via a follow-up fetch so the
 //! `minimumReleaseAge` check runs against real timestamps instead of
 //! silently degrading to its warn-and-skip fallback (see
@@ -70,7 +70,7 @@ use crate::{
     },
     pick_package_from_meta::{
         PickPackageFromMetaError, PickPackageFromMetaOptions, RegistryPackageSpec,
-        RegistryPackageSpecType, filter_pkg_metadata_versions, has_all_version_publish_times,
+        RegistryPackageSpecType, filter_pkg_metadata_versions,
         pick_lowest_version_by_version_range, pick_package_from_meta,
         pick_version_by_version_range,
     },
@@ -775,6 +775,9 @@ pub async fn pick_package<Cache: PackageMetaCache>(
     {
         meta = Arc::new(reloaded);
     }
+    if upgrade.upgraded {
+        ctx.fetch_locker.mark_release_age_upgrade_checked(&cache_key, &meta);
+    }
 
     // Worth flagging: a dry-run is meant to gate the on-disk save, but
     // `fetch_full_metadata_cached` already wrote the response body to
@@ -842,6 +845,9 @@ async fn handle_cache_hit<Cache: PackageMetaCache>(
             meta = Arc::new(reloaded);
         }
         ctx.meta_cache.set(cache_key.to_string(), Arc::clone(&meta));
+    }
+    if upgrade.upgraded {
+        ctx.fetch_locker.mark_release_age_upgrade_checked(cache_key, &meta);
     }
     let (meta, picked) = pick_from_meta(picker_opts, spec, meta, opts.blocked_versions)?;
     if picked.is_none() && !ctx.offline && !registry_verified {
@@ -1206,7 +1212,7 @@ struct UpgradeOutcome {
 /// per-version timestamps.
 ///
 /// When the resolver default-fetched abbreviated metadata but
-/// `published_by` is active, the per-version `time` map is incomplete
+/// `published_by` is active, the per-version `time` map is missing
 /// so the maturity check would silently degrade to the warn-and-skip
 /// fallback. This function detects that and re-fetches full metadata
 /// when the package's top-level `modified` field shows it was
@@ -1217,8 +1223,11 @@ struct UpgradeOutcome {
 ///
 /// - `ctx.offline`: no network allowed. Stick with what we have.
 /// - `opts.published_by.is_none()`: maturity check disabled.
-/// - every version has a publish timestamp: the metadata is complete.
-///   Nothing to upgrade.
+/// - `meta.time.is_some()`: the packument carries per-version publish
+///   timestamps. Documents whose `time` could not decide maturity are
+///   normalized to `None` at the parse boundary (see
+///   [`Package::drop_incomplete_publish_times`]), so a map that is here
+///   is complete. Nothing to upgrade.
 /// - this document already got a `304` from an upgrade fetch earlier in
 ///   the install (see [`PackumentFetchState`]): the registry has no
 ///   fuller form of it, so asking again is pure waste.
@@ -1254,9 +1263,7 @@ async fn maybe_upgrade_abbreviated_meta_for_release_age<Cache: PackageMetaCache>
     let Some(cutoff) = opts.published_by else {
         return Ok(UpgradeOutcome { meta, upgraded: false });
     };
-    if has_all_version_publish_times(&meta)
-        || ctx.fetch_locker.release_age_upgrade_was_checked(cache_key, &meta)
-    {
+    if meta.time.is_some() || ctx.fetch_locker.release_age_upgrade_was_checked(cache_key, &meta) {
         return Ok(UpgradeOutcome { meta, upgraded: false });
     }
     if let Some(policy) = opts.published_by_exclude
@@ -1300,9 +1307,7 @@ async fn maybe_upgrade_abbreviated_meta_for_release_age<Cache: PackageMetaCache>
     {
         meta = cached.meta;
     }
-    if ctx.fetch_locker.release_age_upgrade_was_checked(cache_key, &meta)
-        || has_all_version_publish_times(&meta)
-    {
+    if ctx.fetch_locker.release_age_upgrade_was_checked(cache_key, &meta) || meta.time.is_some() {
         return Ok(UpgradeOutcome { meta, upgraded: false });
     }
     let fetch_opts = FetchFullMetadataOptions {
@@ -1321,12 +1326,18 @@ async fn maybe_upgrade_abbreviated_meta_for_release_age<Cache: PackageMetaCache>
         // 304: the full-form representation matched the conditional
         // headers, so the abbreviated meta is still the freshest
         // signal we have. Keep it (the downstream picker falls through
-        // to its warn-and-skip path on the incomplete `time` map) and
+        // to its warn-and-skip path on the missing `time` map) and
         // mark it so no later pick in this install repeats the round trip.
         // The 304 also registry-validated the document, so it may enter the
         // shared metadata cache as verified.
         FetchFullMetadataOutcome::NotModified => {
             ctx.fetch_locker.mark_release_age_upgrade_checked(cache_key, &meta);
+            // A `Modified` outcome is marked by the caller instead: it persists
+            // the response to the mirror and may hand back a reloaded document,
+            // so only the caller knows the `Arc` that ends up in the cache.
+            // Both outcomes must be marked — a registry whose full form is no
+            // more complete than its abbreviated one would otherwise be
+            // re-asked once per dependency edge.
             if !opts.dry_run {
                 ctx.meta_cache.set(cache_key.to_string(), Arc::clone(&meta));
             }

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package.rs
@@ -51,7 +51,7 @@ use std::{
 };
 
 use chrono::{DateTime, Utc};
-use dashmap::{DashMap, DashSet};
+use dashmap::DashMap;
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pnpm_config::version_policy::{PackageVersionPolicy, PolicyMatch};
@@ -155,12 +155,26 @@ pub trait PackageMetaCache: Send + Sync {
 /// different forms of the same packument don't accidentally serialize — the
 /// `metaDir` differentiator is embedded in the key. Release-age upgrade 304s
 /// are tracked alongside the limits because they have the same install
-/// lifetime; keeping that marker out of [`Package`] prevents a caller-owned
-/// metadata cache from leaking it into a later install.
+/// lifetime. Each marker retains the exact [`Package`] document that was
+/// revalidated, so a newer abbreviated response under the same cache key is
+/// checked independently. Keeping the marker out of [`Package`] also prevents
+/// a caller-owned metadata cache from leaking it into a later install.
 #[derive(Debug, Default)]
 pub struct PackumentFetchState {
     limits: DashMap<String, Arc<Semaphore>>,
-    release_age_upgrade_checked: DashSet<String>,
+    release_age_upgrade_checked: DashMap<String, Arc<Package>>,
+}
+
+impl PackumentFetchState {
+    fn release_age_upgrade_was_checked(&self, cache_key: &str, meta: &Arc<Package>) -> bool {
+        self.release_age_upgrade_checked
+            .get(cache_key)
+            .is_some_and(|checked| Arc::ptr_eq(checked.value(), meta))
+    }
+
+    fn mark_release_age_upgrade_checked(&self, cache_key: &str, meta: &Arc<Package>) {
+        self.release_age_upgrade_checked.insert(cache_key.to_string(), Arc::clone(meta));
+    }
 }
 
 pub type PackumentFetchLocker = Arc<PackumentFetchState>;
@@ -1229,7 +1243,7 @@ async fn maybe_upgrade_abbreviated_meta_for_release_age<Cache: PackageMetaCache>
     opts: &PickPackageOptions<'_>,
     full_metadata: bool,
     cache_key: &str,
-    meta: Arc<Package>,
+    mut meta: Arc<Package>,
 ) -> Result<UpgradeOutcome, PickPackageError> {
     if ctx.offline || full_metadata {
         return Ok(UpgradeOutcome { meta, upgraded: false });
@@ -1238,7 +1252,7 @@ async fn maybe_upgrade_abbreviated_meta_for_release_age<Cache: PackageMetaCache>
         return Ok(UpgradeOutcome { meta, upgraded: false });
     };
     if has_all_version_publish_times(&meta)
-        || ctx.fetch_locker.release_age_upgrade_checked.contains(cache_key)
+        || ctx.fetch_locker.release_age_upgrade_was_checked(cache_key, &meta)
     {
         return Ok(UpgradeOutcome { meta, upgraded: false });
     }
@@ -1274,14 +1288,17 @@ async fn maybe_upgrade_abbreviated_meta_for_release_age<Cache: PackageMetaCache>
     );
     let _permit =
         limit.acquire().await.expect("release-age upgrade semaphore should not be closed");
-    if let Some(cached) = ctx.meta_cache.get(cache_key) {
+    if !opts.update_checksums
+        && let Some(cached) = ctx.meta_cache.get(cache_key)
+    {
         let cached_meta = cached.meta;
         if has_all_version_publish_times(&cached_meta)
-            || ctx.fetch_locker.release_age_upgrade_checked.contains(cache_key)
+            || ctx.fetch_locker.release_age_upgrade_was_checked(cache_key, &cached_meta)
         {
             return Ok(UpgradeOutcome { meta: cached_meta, upgraded: false });
         }
-    } else if ctx.fetch_locker.release_age_upgrade_checked.contains(cache_key) {
+        meta = cached_meta;
+    } else if ctx.fetch_locker.release_age_upgrade_was_checked(cache_key, &meta) {
         return Ok(UpgradeOutcome { meta, upgraded: false });
     }
     let fetch_opts = FetchFullMetadataOptions {
@@ -1306,7 +1323,7 @@ async fn maybe_upgrade_abbreviated_meta_for_release_age<Cache: PackageMetaCache>
         // the shared metadata cache as verified without carrying the marker
         // into a later install.
         FetchFullMetadataOutcome::NotModified => {
-            ctx.fetch_locker.release_age_upgrade_checked.insert(cache_key.to_string());
+            ctx.fetch_locker.mark_release_age_upgrade_checked(cache_key, &meta);
             if !opts.dry_run {
                 ctx.meta_cache.set(cache_key.to_string(), Arc::clone(&meta));
             }

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package.rs
@@ -31,7 +31,7 @@
 //! into a single network fetch — the rest wait, then re-check the
 //! in-memory cache that the winner just populated and short-circuit
 //! without hitting the registry. This is done via
-//! [`PackumentFetchLocker`], a [`DashMap<String, Arc<Semaphore>>`]
+//! [`PackumentFetchLocker`], which owns per-key semaphores and is
 //! threaded through [`PickPackageContext::fetch_locker`]: the first
 //! caller for a given cache key acquires the per-key permit and
 //! does the disk + network work; subsequent callers wait on the
@@ -51,7 +51,7 @@ use std::{
 };
 
 use chrono::{DateTime, Utc};
-use dashmap::DashMap;
+use dashmap::{DashMap, DashSet};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pnpm_config::version_policy::{PackageVersionPolicy, PolicyMatch};
@@ -138,12 +138,10 @@ pub trait PackageMetaCache: Send + Sync {
     fn set_unverified(&self, key: String, meta: Arc<Package>);
 }
 
-/// Per-`(registry, package_name)` fetch serializer: a map of
-/// single-permit limits keyed on the on-disk mirror path, used to
-/// coalesce concurrent picks for the same packument.
+/// Install-scoped state for packument fetching.
 ///
-/// Pacquet stores one [`tokio::sync::Semaphore`] (single-permit) per
-/// in-memory cache key; first caller acquires, runs the
+/// Pacquet stores one [`tokio::sync::Semaphore`] (single-permit) per in-memory
+/// cache key; first caller acquires, runs the
 /// disk-then-network flow, releases. Subsequent callers wait on the
 /// same semaphore; after acquiring, they re-check
 /// [`PackageMetaCache`] and short-circuit on a hit so only the first
@@ -154,16 +152,25 @@ pub trait PackageMetaCache: Send + Sync {
 /// in-flight set. Keying is on the same string [`PackageMetaCache`]
 /// uses (`{registry}\x00{name}` for abbreviated,
 /// `{registry}\x00{name}:full` for full), so two callers asking for
-/// different forms of the same packument don't accidentally serialize
-/// — the `metaDir` differentiator is embedded in the key.
-pub type PackumentFetchLocker = Arc<DashMap<String, Arc<Semaphore>>>;
+/// different forms of the same packument don't accidentally serialize — the
+/// `metaDir` differentiator is embedded in the key. Release-age upgrade 304s
+/// are tracked alongside the limits because they have the same install
+/// lifetime; keeping that marker out of [`Package`] prevents a caller-owned
+/// metadata cache from leaking it into a later install.
+#[derive(Debug, Default)]
+pub struct PackumentFetchState {
+    limits: DashMap<String, Arc<Semaphore>>,
+    release_age_upgrade_checked: DashSet<String>,
+}
+
+pub type PackumentFetchLocker = Arc<PackumentFetchState>;
 
 /// Construct a fresh [`PackumentFetchLocker`] for a new install.
 /// Equivalent to `Default::default()`; named for symmetry with
 /// [`shared_in_memory_cache`].
 #[must_use]
 pub fn shared_packument_fetch_locker() -> PackumentFetchLocker {
-    Arc::new(DashMap::new())
+    Arc::new(PackumentFetchState::default())
 }
 
 /// Per-`(registry, pkg_name, version)` cache for the resolver's
@@ -578,6 +585,7 @@ pub async fn pick_package<Cache: PackageMetaCache>(
     let limit = {
         let entry = ctx
             .fetch_locker
+            .limits
             .entry(cache_key.clone())
             .or_insert_with(|| Arc::new(Semaphore::new(1)));
         Arc::clone(entry.value())
@@ -1229,7 +1237,9 @@ async fn maybe_upgrade_abbreviated_meta_for_release_age<Cache: PackageMetaCache>
     let Some(cutoff) = opts.published_by else {
         return Ok(UpgradeOutcome { meta, upgraded: false });
     };
-    if has_all_version_publish_times(&meta) || meta.release_age_upgrade_checked {
+    if has_all_version_publish_times(&meta)
+        || ctx.fetch_locker.release_age_upgrade_checked.contains(cache_key)
+    {
         return Ok(UpgradeOutcome { meta, upgraded: false });
     }
     if let Some(policy) = opts.published_by_exclude
@@ -1257,6 +1267,7 @@ async fn maybe_upgrade_abbreviated_meta_for_release_age<Cache: PackageMetaCache>
     // registry for the same packument hundreds of times per install.
     let limit = Arc::clone(
         ctx.fetch_locker
+            .limits
             .entry(format!("{cache_key}#release-age-upgrade"))
             .or_insert_with(|| Arc::new(Semaphore::new(1)))
             .value(),
@@ -1265,9 +1276,13 @@ async fn maybe_upgrade_abbreviated_meta_for_release_age<Cache: PackageMetaCache>
         limit.acquire().await.expect("release-age upgrade semaphore should not be closed");
     if let Some(cached) = ctx.meta_cache.get(cache_key) {
         let cached_meta = cached.meta;
-        if has_all_version_publish_times(&cached_meta) || cached_meta.release_age_upgrade_checked {
+        if has_all_version_publish_times(&cached_meta)
+            || ctx.fetch_locker.release_age_upgrade_checked.contains(cache_key)
+        {
             return Ok(UpgradeOutcome { meta: cached_meta, upgraded: false });
         }
+    } else if ctx.fetch_locker.release_age_upgrade_checked.contains(cache_key) {
+        return Ok(UpgradeOutcome { meta, upgraded: false });
     }
     let fetch_opts = FetchFullMetadataOptions {
         registry: opts.registry,
@@ -1286,17 +1301,16 @@ async fn maybe_upgrade_abbreviated_meta_for_release_age<Cache: PackageMetaCache>
         // headers, so the abbreviated meta is still the freshest
         // signal we have. Keep it (the downstream picker falls through
         // to its warn-and-skip path on the missing `time` map), but
-        // stamp it so no later pick repeats the round trip — the 304
-        // also registry-validated the document, so it may enter the
-        // shared cache as verified.
+        // mark it in install-owned state so no later pick repeats the round
+        // trip. The 304 also registry-validated the document, so it may enter
+        // the shared metadata cache as verified without carrying the marker
+        // into a later install.
         FetchFullMetadataOutcome::NotModified => {
-            let mut stamped = (*meta).clone();
-            stamped.release_age_upgrade_checked = true;
-            let stamped = Arc::new(stamped);
+            ctx.fetch_locker.release_age_upgrade_checked.insert(cache_key.to_string());
             if !opts.dry_run {
-                ctx.meta_cache.set(cache_key.to_string(), Arc::clone(&stamped));
+                ctx.meta_cache.set(cache_key.to_string(), Arc::clone(&meta));
             }
-            Ok(UpgradeOutcome { meta: stamped, upgraded: false })
+            Ok(UpgradeOutcome { meta, upgraded: false })
         }
     }
 }

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package/tests.rs
@@ -1314,6 +1314,79 @@ async fn published_by_upgrade_not_modified_marker_is_scoped_to_install() {
     full_mock.assert_async().await;
 }
 
+/// A same-install checksum refresh can replace an abbreviated packument while
+/// retaining its cache key. A prior document's `304` marker must not suppress
+/// the full-metadata check for that new response.
+#[tokio::test]
+async fn published_by_upgrade_not_modified_marker_is_scoped_to_document() {
+    let mut server = mockito::Server::new_async().await;
+    let first_full_mock = server
+        .mock("GET", "/acme")
+        .match_header("accept", "application/json; q=1.0, */*")
+        .match_header("if-none-match", r#""acme-etag""#)
+        .with_status(304)
+        .expect(1)
+        .create_async()
+        .await;
+    let abbreviated_mock = server
+        .mock("GET", "/acme")
+        .match_header(
+            "accept",
+            "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*",
+        )
+        .with_status(200)
+        .with_header("etag", r#""acme-etag-2""#)
+        .with_body(ABBREVIATED_BODY)
+        .expect(1)
+        .create_async()
+        .await;
+    let second_full_mock = server
+        .mock("GET", "/acme")
+        .match_header("accept", "application/json; q=1.0, */*")
+        .match_header("if-none-match", r#""acme-etag-2""#)
+        .with_status(304)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let cache_dir = TempDir::new().expect("tempdir");
+    let registry = format!("{}/", server.url());
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let meta_cache = InMemoryPackageMetaCache::default();
+    let mut seeded: pacquet_registry::Package =
+        serde_json::from_str(ABBREVIATED_BODY).expect("parse fixture");
+    seeded.etag = Some(r#""acme-etag""#.to_string());
+    meta_cache.set(format!("{registry}\u{0}acme"), Arc::new(seeded));
+    let fetch_locker = shared_packument_fetch_locker();
+    let ctx = PickPackageContext {
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        meta_cache: &meta_cache,
+        fetch_locker: &fetch_locker,
+        cache_dir: Some(cache_dir.path()),
+        offline: false,
+        prefer_offline: false,
+        ignore_missing_time_field: true,
+        full_metadata: false,
+        filter_metadata: false,
+        retry_opts: RetryOpts::default(),
+    };
+
+    let mut opts = default_opts(&registry);
+    opts.published_by = Some(parse_cutoff("2023-01-01T00:00:00Z"));
+    let _ = pick_package(&ctx, &range_spec("acme", "^1.0.0"), &opts).await.expect("first pick");
+
+    let update_opts = PickPackageOptions { update_checksums: true, ..opts };
+    let _ = pick_package(&ctx, &range_spec("acme", "^1.0.0"), &update_opts)
+        .await
+        .expect("checksum-refresh pick");
+
+    first_full_mock.assert_async().await;
+    abbreviated_mock.assert_async().await;
+    second_full_mock.assert_async().await;
+}
+
 /// Fully excluded packages (`minimumReleaseAgeExclude: ['acme']`) must bypass
 /// the publishedBy file-mtime cache shortcut, otherwise a stale abbreviated
 /// mirror can pin resolution to an old latest forever until the cutoff window

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package/tests.rs
@@ -52,6 +52,38 @@ const PACKAGE_BODY: &str = r#"{
     }
 }"#;
 
+/// [`PACKAGE_BODY`] with 1.1.0 left out of the `time` map — the shape
+/// registries such as npmmirror serve, where an abbreviated packument
+/// reports publish times for only some of the versions it lists.
+const PARTIAL_TIME_PACKAGE_BODY: &str = r#"{
+    "name": "acme",
+    "dist-tags": { "latest": "1.1.0" },
+    "modified": "2025-01-15T12:00:00.000Z",
+    "time": {
+        "1.0.0": "2024-01-10T08:30:00.000Z"
+    },
+    "versions": {
+        "1.0.0": {
+            "name": "acme",
+            "version": "1.0.0",
+            "dist": {
+                "integrity": "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+                "shasum": "0000000000000000000000000000000000000000",
+                "tarball": "https://registry/acme-1.0.0.tgz"
+            }
+        },
+        "1.1.0": {
+            "name": "acme",
+            "version": "1.1.0",
+            "dist": {
+                "integrity": "sha512-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB==",
+                "shasum": "1111111111111111111111111111111111111111",
+                "tarball": "https://registry/acme-1.1.0.tgz"
+            }
+        }
+    }
+}"#;
+
 /// [`PACKAGE_BODY`] as it looked before 1.1.0 was published — for
 /// seeding a mirror that predates a version the registry has.
 const STALE_PACKAGE_BODY: &str = r#"{
@@ -1077,11 +1109,13 @@ async fn published_by_triggers_upgrade_when_modified_after_cutoff() {
     );
 }
 
+/// A `time` map covering only some of the packument's versions can't decide
+/// maturity for the rest: the untimed ones drop out of the filter and
+/// resolution falls back to the lowest match. Upgrade to full metadata first,
+/// so every version is judged on a real publish timestamp.
 #[tokio::test]
 async fn published_by_upgrades_metadata_with_partial_time_map() {
     let mut server = mockito::Server::new_async().await;
-    let partial_time_body =
-        PACKAGE_BODY.replacen(",\n        \"1.1.0\": \"2024-12-10T08:30:00.000Z\"", "", 1);
     let abbrev_mock = server
         .mock("GET", "/acme")
         .match_header(
@@ -1089,7 +1123,7 @@ async fn published_by_upgrades_metadata_with_partial_time_map() {
             "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*",
         )
         .with_status(200)
-        .with_body(partial_time_body)
+        .with_body(PARTIAL_TIME_PACKAGE_BODY)
         .expect(1)
         .create_async()
         .await;
@@ -1118,6 +1152,7 @@ async fn published_by_upgrades_metadata_with_partial_time_map() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        needs_full_metadata_for: None,
         filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
@@ -1257,10 +1292,8 @@ async fn published_by_upgrade_not_modified_marker_is_scoped_to_install() {
     let meta_cache = InMemoryPackageMetaCache::default();
     // The document a prior mirror load would have produced: an incomplete
     // `time` map, carrying the mirror's etag as the upgrade validator.
-    let partial_time_body =
-        PACKAGE_BODY.replacen(",\n        \"1.1.0\": \"2024-12-10T08:30:00.000Z\"", "", 1);
     let mut seeded: pnpm_registry::Package =
-        serde_json::from_str(&partial_time_body).expect("parse fixture");
+        serde_json::from_str(PARTIAL_TIME_PACKAGE_BODY).expect("parse fixture");
     seeded.etag = Some(r#""acme-etag""#.to_string());
     meta_cache.set(format!("{registry}\u{0}acme"), Arc::new(seeded));
     let fetch_locker = shared_packument_fetch_locker();
@@ -1302,6 +1335,7 @@ async fn published_by_upgrade_not_modified_marker_is_scoped_to_install() {
         prefer_offline: false,
         ignore_missing_time_field: true,
         full_metadata: false,
+        needs_full_metadata_for: None,
         filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
@@ -1354,7 +1388,7 @@ async fn published_by_upgrade_not_modified_marker_is_scoped_to_document() {
     let http_client = ThrottledClient::default();
     let auth_headers = AuthHeaders::default();
     let meta_cache = InMemoryPackageMetaCache::default();
-    let mut seeded: pacquet_registry::Package =
+    let mut seeded: pnpm_registry::Package =
         serde_json::from_str(ABBREVIATED_BODY).expect("parse fixture");
     seeded.etag = Some(r#""acme-etag""#.to_string());
     meta_cache.set(format!("{registry}\u{0}acme"), Arc::new(seeded));
@@ -1369,6 +1403,7 @@ async fn published_by_upgrade_not_modified_marker_is_scoped_to_document() {
         prefer_offline: false,
         ignore_missing_time_field: true,
         full_metadata: false,
+        needs_full_metadata_for: None,
         filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package/tests.rs
@@ -1259,10 +1259,12 @@ async fn published_by_upgrade_not_modified_is_remembered_across_picks() {
     let http_client = ThrottledClient::default();
     let auth_headers = AuthHeaders::default();
     let meta_cache = InMemoryPackageMetaCache::default();
-    // The document a prior mirror load would have produced: abbreviated
-    // (no `time`), carrying the mirror's etag as the upgrade validator.
+    // The document a prior mirror load would have produced: an incomplete
+    // `time` map, carrying the mirror's etag as the upgrade validator.
+    let partial_time_body =
+        PACKAGE_BODY.replacen(",\n        \"1.1.0\": \"2024-12-10T08:30:00.000Z\"", "", 1);
     let mut seeded: pnpm_registry::Package =
-        serde_json::from_str(ABBREVIATED_BODY).expect("parse fixture");
+        serde_json::from_str(&partial_time_body).expect("parse fixture");
     seeded.etag = Some(r#""acme-etag""#.to_string());
     meta_cache.set(format!("{registry}\u{0}acme"), Arc::new(seeded));
     let fetch_locker = shared_packument_fetch_locker();
@@ -1274,8 +1276,8 @@ async fn published_by_upgrade_not_modified_is_remembered_across_picks() {
         cache_dir: Some(cache_dir.path()),
         offline: false,
         prefer_offline: false,
-        // The post-304 document still has no `time`, so let the picker
-        // take its warn-and-skip fallback instead of erroring.
+        // The post-304 document still has an incomplete `time`, so let the
+        // picker take its warn-and-skip fallback instead of erroring.
         ignore_missing_time_field: true,
         full_metadata: false,
         needs_full_metadata_for: None,
@@ -1289,7 +1291,6 @@ async fn published_by_upgrade_not_modified_is_remembered_across_picks() {
 
     let _ = pick_package(&ctx, &range_spec("acme", "^1.0.0"), &opts).await.expect("first pick");
     let _ = pick_package(&ctx, &range_spec("acme", "^1.0.0"), &opts).await.expect("second pick");
-    let _ = pick_package(&ctx, &range_spec("acme", "1.0.0"), &opts).await.expect("third pick");
 
     // Exactly one upgrade attempt — the 304 outcome is stamped into the
     // shared cache and reused by later picks.

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package/tests.rs
@@ -1236,21 +1236,17 @@ async fn published_by_exclude_skips_upgrade_for_abbreviated_meta_without_time() 
     abbrev_mock.assert_async().await;
 }
 
-/// A `304 Not Modified` answer to the release-age upgrade means the registry
-/// holds no fuller form than the abbreviated document, so the outcome must be
-/// remembered for the rest of the install: repeat picks of the same package
-/// must not repeat the upgrade round trip. Registries that ignore the
-/// `Accept` representation answered every upgrade with `304`, and a large
-/// workspace re-asked for the same packument hundreds of times per install.
+/// A `304 Not Modified` answer to the release-age upgrade is remembered within
+/// one install, but not by a metadata cache reused by the next install.
 #[tokio::test]
-async fn published_by_upgrade_not_modified_is_remembered_across_picks() {
+async fn published_by_upgrade_not_modified_marker_is_scoped_to_install() {
     let mut server = mockito::Server::new_async().await;
     let full_mock = server
         .mock("GET", "/acme")
         .match_header("accept", "application/json; q=1.0, */*")
         .match_header("if-none-match", r#""acme-etag""#)
         .with_status(304)
-        .expect(1)
+        .expect(2)
         .create_async()
         .await;
 
@@ -1292,8 +1288,29 @@ async fn published_by_upgrade_not_modified_is_remembered_across_picks() {
     let _ = pick_package(&ctx, &range_spec("acme", "^1.0.0"), &opts).await.expect("first pick");
     let _ = pick_package(&ctx, &range_spec("acme", "^1.0.0"), &opts).await.expect("second pick");
 
-    // Exactly one upgrade attempt — the 304 outcome is stamped into the
-    // shared cache and reused by later picks.
+    // A new install gets fresh fetch state but reuses the caller-owned metadata
+    // cache. It must retry the upgrade instead of inheriting the first
+    // install's marker from the cached Package.
+    let next_install_fetch_locker = shared_packument_fetch_locker();
+    let next_install_ctx = PickPackageContext {
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        meta_cache: &meta_cache,
+        fetch_locker: &next_install_fetch_locker,
+        cache_dir: Some(cache_dir.path()),
+        offline: false,
+        prefer_offline: false,
+        ignore_missing_time_field: true,
+        full_metadata: false,
+        filter_metadata: false,
+        retry_opts: RetryOpts::default(),
+    };
+    let _ = pick_package(&next_install_ctx, &range_spec("acme", "^1.0.0"), &opts)
+        .await
+        .expect("next install pick");
+
+    // One request for each install: the repeat pick in the first install is
+    // the only one suppressed.
     full_mock.assert_async().await;
 }
 

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package/tests.rs
@@ -1077,6 +1077,60 @@ async fn published_by_triggers_upgrade_when_modified_after_cutoff() {
     );
 }
 
+#[tokio::test]
+async fn published_by_upgrades_metadata_with_partial_time_map() {
+    let mut server = mockito::Server::new_async().await;
+    let partial_time_body =
+        PACKAGE_BODY.replacen(",\n        \"1.1.0\": \"2024-12-10T08:30:00.000Z\"", "", 1);
+    let abbrev_mock = server
+        .mock("GET", "/acme")
+        .match_header(
+            "accept",
+            "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*",
+        )
+        .with_status(200)
+        .with_body(partial_time_body)
+        .expect(1)
+        .create_async()
+        .await;
+    let full_mock = server
+        .mock("GET", "/acme")
+        .match_header("accept", "application/json; q=1.0, */*")
+        .with_status(200)
+        .with_body(PACKAGE_BODY)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let cache_dir = TempDir::new().expect("tempdir");
+    let registry = format!("{}/", server.url());
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let meta_cache = InMemoryPackageMetaCache::default();
+    let fetch_locker = shared_packument_fetch_locker();
+    let ctx = PickPackageContext {
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        meta_cache: &meta_cache,
+        fetch_locker: &fetch_locker,
+        cache_dir: Some(cache_dir.path()),
+        offline: false,
+        prefer_offline: false,
+        ignore_missing_time_field: false,
+        full_metadata: false,
+        filter_metadata: false,
+        retry_opts: RetryOpts::default(),
+    };
+
+    let mut opts = default_opts(&registry);
+    opts.published_by = Some(parse_cutoff("2025-01-01T00:00:00Z"));
+    let result = pick_package(&ctx, &range_spec("acme", "^1.0.0"), &opts).await.expect("ok");
+
+    assert_eq!(result.picked_package.expect("picked").version.to_string(), "1.1.0");
+    abbrev_mock.assert_async().await;
+    full_mock.assert_async().await;
+}
+
 /// Boundary case: `modified == cutoff`. `modified` is an upper
 /// bound on every version's publish time, so when it equals the
 /// cutoff every version passes the per-version `<=` filter and

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package/tests.rs
@@ -1290,10 +1290,10 @@ async fn published_by_upgrade_not_modified_marker_is_scoped_to_install() {
     let http_client = ThrottledClient::default();
     let auth_headers = AuthHeaders::default();
     let meta_cache = InMemoryPackageMetaCache::default();
-    // The document a prior mirror load would have produced: an incomplete
-    // `time` map, carrying the mirror's etag as the upgrade validator.
+    // The document a prior mirror load would have produced: abbreviated
+    // (no `time`), carrying the mirror's etag as the upgrade validator.
     let mut seeded: pnpm_registry::Package =
-        serde_json::from_str(PARTIAL_TIME_PACKAGE_BODY).expect("parse fixture");
+        serde_json::from_str(ABBREVIATED_BODY).expect("parse fixture");
     seeded.etag = Some(r#""acme-etag""#.to_string());
     meta_cache.set(format!("{registry}\u{0}acme"), Arc::new(seeded));
     let fetch_locker = shared_packument_fetch_locker();
@@ -1305,8 +1305,8 @@ async fn published_by_upgrade_not_modified_marker_is_scoped_to_install() {
         cache_dir: Some(cache_dir.path()),
         offline: false,
         prefer_offline: false,
-        // The post-304 document still has an incomplete `time`, so let the
-        // picker take its warn-and-skip fallback instead of erroring.
+        // The post-304 document still has no `time`, so let the picker
+        // take its warn-and-skip fallback instead of erroring.
         ignore_missing_time_field: true,
         full_metadata: false,
         needs_full_metadata_for: None,
@@ -1345,6 +1345,67 @@ async fn published_by_upgrade_not_modified_marker_is_scoped_to_install() {
 
     // One request for each install: the repeat pick in the first install is
     // the only one suppressed.
+    full_mock.assert_async().await;
+}
+
+/// A registry whose full representation is no more complete than its
+/// abbreviated one answers the upgrade with `200`, not `304`. That outcome
+/// has to be remembered too, or every dependency edge re-asks for the same
+/// full document and one package amplifies into a request per edge.
+#[tokio::test]
+async fn published_by_upgrade_answering_200_is_remembered_across_picks() {
+    let mut server = mockito::Server::new_async().await;
+    let abbrev_mock = server
+        .mock("GET", "/acme")
+        .match_header(
+            "accept",
+            "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*",
+        )
+        .with_status(200)
+        .with_body(PARTIAL_TIME_PACKAGE_BODY)
+        .expect(1)
+        .create_async()
+        .await;
+    let full_mock = server
+        .mock("GET", "/acme")
+        .match_header("accept", "application/json; q=1.0, */*")
+        .with_status(200)
+        .with_body(PARTIAL_TIME_PACKAGE_BODY)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let cache_dir = TempDir::new().expect("tempdir");
+    let registry = format!("{}/", server.url());
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let meta_cache = InMemoryPackageMetaCache::default();
+    let fetch_locker = shared_packument_fetch_locker();
+    let ctx = PickPackageContext {
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        meta_cache: &meta_cache,
+        fetch_locker: &fetch_locker,
+        cache_dir: Some(cache_dir.path()),
+        offline: false,
+        prefer_offline: false,
+        // The upgraded document is still undecidable, so let the picker take
+        // its warn-and-skip fallback instead of erroring.
+        ignore_missing_time_field: true,
+        full_metadata: false,
+        needs_full_metadata_for: None,
+        filter_metadata: false,
+        retry_opts: RetryOpts::default(),
+    };
+
+    let mut opts = default_opts(&registry);
+    opts.published_by = Some(parse_cutoff("2023-01-01T00:00:00Z"));
+
+    let _ = pick_package(&ctx, &range_spec("acme", "^1.0.0"), &opts).await.expect("first pick");
+    let _ = pick_package(&ctx, &range_spec("acme", "^1.0.0"), &opts).await.expect("second pick");
+
+    // One abbreviated fetch and one upgrade, not one upgrade per pick.
+    abbrev_mock.assert_async().await;
     full_mock.assert_async().await;
 }
 

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
@@ -394,7 +394,7 @@ pub(crate) fn apply_published_by_policy(
     if matches!(exclude_result, PolicyMatch::AnyVersion) {
         return PublishedByView { filtered: None, needs_full_metadata: false };
     }
-    if meta.time.is_none() {
+    if !has_all_version_publish_times(meta) {
         return PublishedByView { filtered: None, needs_full_metadata: true };
     }
     let trusted = match &exclude_result {
@@ -405,6 +405,21 @@ pub(crate) fn apply_published_by_policy(
         filtered: Some(filter_pkg_metadata_by_publish_date(meta, cutoff, trusted)),
         needs_full_metadata: false,
     }
+}
+
+/// Whether `meta.time` contains a non-empty publish timestamp for
+/// every version in the packument.
+///
+/// Some registries return abbreviated metadata with a partial `time`
+/// map. Treating that map as complete would make the release-age
+/// filter silently discard every version whose timestamp is absent.
+#[must_use]
+pub(crate) fn has_all_version_publish_times(meta: &Package) -> bool {
+    meta.time.is_some()
+        && meta
+            .versions
+            .keys()
+            .all(|version| meta.published_at(version).is_some_and(|value| !value.is_empty()))
 }
 
 /// Filter a packument to versions published at or before `cutoff`,

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
@@ -393,7 +393,7 @@ pub(crate) fn apply_published_by_policy(
     if matches!(exclude_result, PolicyMatch::AnyVersion) {
         return PublishedByView { filtered: None, needs_full_metadata: false };
     }
-    if !has_all_version_publish_times(meta) {
+    if meta.time.is_none() {
         return PublishedByView { filtered: None, needs_full_metadata: true };
     }
     let trusted = match &exclude_result {
@@ -404,21 +404,6 @@ pub(crate) fn apply_published_by_policy(
         filtered: Some(filter_pkg_metadata_by_publish_date(meta, cutoff, trusted)),
         needs_full_metadata: false,
     }
-}
-
-/// Whether `meta.time` contains a non-empty publish timestamp for
-/// every version in the packument.
-///
-/// Some registries return abbreviated metadata with a partial `time`
-/// map. Treating that map as complete would make the release-age
-/// filter silently discard every version whose timestamp is absent.
-#[must_use]
-pub(crate) fn has_all_version_publish_times(meta: &Package) -> bool {
-    meta.time.is_some()
-        && meta
-            .versions
-            .keys()
-            .all(|version| meta.published_at(version).is_some_and(|value| !value.is_empty()))
 }
 
 /// Filter a packument to versions published at or before `cutoff`,

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
@@ -256,7 +256,6 @@ fn without_version(meta: &Package, version: &str) -> Package {
         etag: meta.etag.clone(),
         homepage: meta.homepage.clone(),
         mutex: Arc::default(),
-        release_age_upgrade_checked: false,
         derived: DerivedPackuments::default(),
     }
 }
@@ -525,7 +524,6 @@ fn filter_pkg_metadata_versions_with_dist_tag_bound(
         etag: meta.etag.clone(),
         homepage: meta.homepage.clone(),
         mutex: std::sync::Arc::clone(&meta.mutex),
-        release_age_upgrade_checked: false,
         derived: DerivedPackuments::default(),
     }
 }

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package_from_meta/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package_from_meta/tests.rs
@@ -58,7 +58,6 @@ fn make_package(
         etag: None,
         homepage: None,
         mutex: std::sync::Arc::default(),
-        release_age_upgrade_checked: false,
         derived: DerivedPackuments::default(),
     }
 }

--- a/pnpm/crates/resolving-npm-resolver/src/preferred_overlay/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/preferred_overlay/tests.rs
@@ -57,7 +57,6 @@ fn make_package() -> Package {
         etag: None,
         homepage: None,
         mutex: std::sync::Arc::default(),
-        release_age_upgrade_checked: false,
         derived: DerivedPackuments::default(),
     }
 }

--- a/pnpm/crates/resolving-resolver-base/src/errors/tests.rs
+++ b/pnpm/crates/resolving-resolver-base/src/errors/tests.rs
@@ -42,7 +42,6 @@ fn make_package(name: &str, versions: &[&str], dist_tags: &[(&str, &str)]) -> Pa
         etag: None,
         homepage: None,
         mutex: std::sync::Arc::default(),
-        release_age_upgrade_checked: false,
         derived: DerivedPackuments::default(),
     }
 }

--- a/pnpm11/resolving/npm-resolver/src/fetch.ts
+++ b/pnpm11/resolving/npm-resolver/src/fetch.ts
@@ -16,6 +16,7 @@ import * as retry from '@zkochan/retry'
 import semver from 'semver'
 
 import { clearMeta } from './clearMeta.js'
+import { dropIncompletePublishTimes } from './publishTimes.js'
 
 /**
  * Content type of an abbreviated (install-oriented) package metadata document.
@@ -214,6 +215,7 @@ export async function fetchMetadataFromFromRegistry (
       try {
         const jsonText = await response.text()
         const meta = JSON.parse(jsonText) as PackageMeta
+        dropIncompletePublishTimes(meta)
         // Check if request took longer than expected
         const elapsedMs = Date.now() - startTime
         if (elapsedMs > fetchOpts.fetchWarnTimeoutMs) {

--- a/pnpm11/resolving/npm-resolver/src/index.ts
+++ b/pnpm11/resolving/npm-resolver/src/index.ts
@@ -237,6 +237,10 @@ export function createNpmResolver (
   // using.
   const ownsMetaCache = opts.metaCache == null
   const metaCache: PackageMetaCache = opts.metaCache ?? createDefaultPackageMetaCache()
+  // This marker is intentionally resolver-scoped rather than attached to
+  // `metaCache`: callers may reuse one metadata cache across installs, and a
+  // later install must retry a full-metadata upgrade that previously got 304.
+  const releaseAgeUpgradeCheckedPackuments = new WeakSet<PackageMeta>()
   // Create peek function if storeDir is provided
   const storeDir = opts.storeDir
   const peekLockerForPeek = new Map<string, Promise<DependencyManifest | undefined>>()
@@ -280,6 +284,7 @@ export function createNpmResolver (
       preferOffline: opts.preferOffline,
       cacheDir: opts.cacheDir,
       ignoreMissingTimeField: opts.ignoreMissingTimeField,
+      releaseAgeUpgradeCheckedPackuments,
     }),
     registriesByScope: opts.registriesByScope,
     registriesByPrefix,

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -209,14 +209,6 @@ function pickMatchingVersionFinal (
 const unverifiedDiskPackuments = new WeakSet<PackageMeta>()
 
 /**
- * Packuments whose release-age full-metadata upgrade returned 304 during this
- * install. The marker is deliberately identity-based and in-memory only: later
- * picks can skip the same round trip, while a future install still gets a
- * chance to retrieve a fuller document from the registry.
- */
-const releaseAgeUpgradeCheckedPackuments = new WeakSet<PackageMeta>()
-
-/**
  * Promote a packument parsed from the on-disk mirror into the in-memory
  * cache, so repeat resolutions of the same package (common across a large
  * dependency graph) don't re-read and re-parse the mirror. The entry is
@@ -260,6 +252,8 @@ export async function pickPackage (
     preferOffline?: boolean
     filterMetadata?: boolean
     ignoreMissingTimeField?: boolean
+    /** Packuments already checked by a full-metadata upgrade in this resolver. */
+    releaseAgeUpgradeCheckedPackuments?: WeakSet<PackageMeta>
   },
   spec: RegistryPackageSpec,
   opts: PickPackageOptions
@@ -579,6 +573,7 @@ async function maybeUpgradeAbbreviatedMetaForReleaseAge (
   ctx: {
     fetch: (pkgName: string, opts: { registry: string, authHeaderValue?: string, cacheBypass?: boolean, fullMetadata?: boolean, etag?: string, modified?: string }) => Promise<FetchMetadataResult | FetchMetadataNotModifiedResult>
     offline?: boolean
+    releaseAgeUpgradeCheckedPackuments?: WeakSet<PackageMeta>
   },
   spec: RegistryPackageSpec,
   opts: {
@@ -593,7 +588,7 @@ async function maybeUpgradeAbbreviatedMetaForReleaseAge (
     ctx.offline === true ||
     !opts.publishedBy ||
     hasAllVersionPublishTimes(meta) ||
-    releaseAgeUpgradeCheckedPackuments.has(meta) ||
+    ctx.releaseAgeUpgradeCheckedPackuments?.has(meta) === true ||
     opts.publishedByExclude?.(spec.name) === true
   ) {
     return { meta }
@@ -624,9 +619,11 @@ async function maybeUpgradeAbbreviatedMetaForReleaseAge (
   if (fullFetchResult.notModified) {
     // Upgrade fetch came back 304: keep the abbreviated meta. The downstream
     // `pickMatchingVersionFinal` will fall through to its warn-and-skip path.
-    // Remember this registry-validated outcome on the packument itself so
-    // another pick in this install does not repeat the full-metadata request.
-    releaseAgeUpgradeCheckedPackuments.add(meta)
+    // Remember this registry-validated outcome in the resolver-owned marker
+    // set so another pick in this install does not repeat the request. Do not
+    // attach the marker to the caller-owned metadata cache: that cache may be
+    // shared by a later install, which must get its own upgrade attempt.
+    ctx.releaseAgeUpgradeCheckedPackuments?.add(meta)
     return { meta }
   }
   return { meta: fullFetchResult.meta, upgradedFrom: fullFetchResult }

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -209,6 +209,14 @@ function pickMatchingVersionFinal (
 const unverifiedDiskPackuments = new WeakSet<PackageMeta>()
 
 /**
+ * Packuments whose release-age full-metadata upgrade returned 304 during this
+ * install. The marker is deliberately identity-based and in-memory only: later
+ * picks can skip the same round trip, while a future install still gets a
+ * chance to retrieve a fuller document from the registry.
+ */
+const releaseAgeUpgradeCheckedPackuments = new WeakSet<PackageMeta>()
+
+/**
  * Promote a packument parsed from the on-disk mirror into the in-memory
  * cache, so repeat resolutions of the same package (common across a large
  * dependency graph) don't re-read and re-parse the mirror. The entry is
@@ -585,6 +593,7 @@ async function maybeUpgradeAbbreviatedMetaForReleaseAge (
     ctx.offline === true ||
     !opts.publishedBy ||
     hasAllVersionPublishTimes(meta) ||
+    releaseAgeUpgradeCheckedPackuments.has(meta) ||
     opts.publishedByExclude?.(spec.name) === true
   ) {
     return { meta }
@@ -615,6 +624,9 @@ async function maybeUpgradeAbbreviatedMetaForReleaseAge (
   if (fullFetchResult.notModified) {
     // Upgrade fetch came back 304: keep the abbreviated meta. The downstream
     // `pickMatchingVersionFinal` will fall through to its warn-and-skip path.
+    // Remember this registry-validated outcome on the packument itself so
+    // another pick in this install does not repeat the full-metadata request.
+    releaseAgeUpgradeCheckedPackuments.add(meta)
     return { meta }
   }
   return { meta: fullFetchResult.meta, upgradedFrom: fullFetchResult }

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -21,12 +21,12 @@ import {
 } from './fetch.js'
 import type { RegistryPackageSpec } from './parseBareSpecifier.js'
 import {
-  hasAllVersionPublishTimes,
   pickLowestVersionByVersionRange,
   pickPackageFromMeta,
   type PickPackageFromMetaOptions,
   pickVersionByVersionRange,
 } from './pickPackageFromMeta.js'
+import { dropIncompletePublishTimes } from './publishTimes.js'
 import { toRaw } from './toRaw.js'
 
 export interface PackageMetaCache {
@@ -291,6 +291,7 @@ export async function pickPackage (
   // updateChecksums must reach the conditional registry request below, so it
   // can't be served from the in-memory cache — which may hold a disk-promoted
   // entry rather than a fresh network fetch (see the updateChecksums doc).
+  console.error('[T] pick', spec.name, 'updateChecksums=', opts.updateChecksums === true)
   const cachedMeta = opts.updateChecksums ? undefined : ctx.metaCache.get(cacheKey)
   if (cachedMeta != null) {
     // The in-memory cache may hold abbreviated metadata from an earlier call
@@ -505,10 +506,11 @@ export async function pickPackage (
       // and most packages won't have been modified recently enough to need the full
       // document. We only upgrade to full metadata when the package's modification
       // date is recent enough that some versions might not yet be "mature."
+      let attemptedReleaseAgeUpgrade = false
       if (
         opts.publishedBy &&
         !fullMetadata &&
-        !hasAllVersionPublishTimes(meta) &&
+        meta.time == null &&
         opts.publishedByExclude?.(spec.name) !== true
       ) {
         const modifiedDate = meta.modified ? new Date(meta.modified) : null
@@ -523,6 +525,8 @@ export async function pickPackage (
           if (!opts.dryRun) {
             saveMetaBestEffort(pkgMirror, prepareJsonForDisk(resultToSave.meta, resultToSave.etag, resultToSave.jsonText))
           }
+          attemptedReleaseAgeUpgrade = true
+          console.error('[T] fresh-path upgrade fetch')
           const fullFetchResult = await ctx.fetch(spec.name, {
             authHeaderValue: opts.authHeaderValue,
             fullMetadata: true,
@@ -536,6 +540,9 @@ export async function pickPackage (
       }
 
       meta = condenseMetaForCache(ctx, meta)
+      if (attemptedReleaseAgeUpgrade) {
+        ctx.releaseAgeUpgradeCheckedPackuments?.add(meta)
+      }
       if (!opts.dryRun) {
         // Mirror the raw registry body, unless the retained form is
         // deliberately narrower: `filterMetadata` always mirrors the stripped
@@ -584,10 +591,11 @@ async function maybeUpgradeAbbreviatedMetaForReleaseAge (
   },
   meta: PackageMeta
 ): Promise<{ meta: PackageMeta, upgradedFrom?: FetchMetadataResult }> {
+  console.error('[T] maybeUpgrade: time=', meta.time == null ? 'null' : 'set', 'marked=', ctx.releaseAgeUpgradeCheckedPackuments?.has(meta) === true, 'modified=', meta.modified)
   if (
     ctx.offline === true ||
     !opts.publishedBy ||
-    hasAllVersionPublishTimes(meta) ||
+    meta.time != null ||
     ctx.releaseAgeUpgradeCheckedPackuments?.has(meta) === true ||
     opts.publishedByExclude?.(spec.name) === true
   ) {
@@ -633,14 +641,29 @@ async function maybeUpgradeAbbreviatedMetaForReleaseAge (
  * pre-upgrade abbreviated form without `time`, and every future install
  * would re-trigger the upgrade fetch.
  */
+/**
+ * The document to serve and cache after an upgrade attempt, marked so no
+ * later pick in this resolver repeats the request.
+ *
+ * Marking belongs here rather than in
+ * {@link maybeUpgradeAbbreviatedMetaForReleaseAge} because persisting the
+ * response to the mirror can hand back a different object, and only the one
+ * that reaches the cache is worth remembering. A registry whose full form is
+ * no more complete than its abbreviated one answers `200` rather than `304`,
+ * so both outcomes have to be marked — otherwise every dependency edge
+ * re-asks for the same full document.
+ */
 function upgradeMetaForCache (
-  ctx: { fullMetadata?: boolean, filterMetadata?: boolean },
+  ctx: { fullMetadata?: boolean, filterMetadata?: boolean, releaseAgeUpgradeCheckedPackuments?: WeakSet<PackageMeta> },
   upgrade: { meta: PackageMeta, upgradedFrom?: FetchMetadataResult },
   opts: { pkgMirror: string, dryRun: boolean }
 ): PackageMeta {
   if (upgrade.upgradedFrom == null) return upgrade.meta
-  if (opts.dryRun) return condenseMetaForCache(ctx, upgrade.meta)
-  return persistUpgradedMeta(ctx, opts.pkgMirror, upgrade.upgradedFrom)
+  const meta = opts.dryRun
+    ? condenseMetaForCache(ctx, upgrade.meta)
+    : persistUpgradedMeta(ctx, opts.pkgMirror, upgrade.upgradedFrom)
+  ctx.releaseAgeUpgradeCheckedPackuments?.add(meta)
+  return meta
 }
 
 // A condensing resolver keeps and mirrors the condensed form — the mirror
@@ -816,6 +839,7 @@ export async function loadMeta (pkgMirror: string): Promise<PackageMeta | null> 
     if (newlineIdx === -1) return null
     const headers = JSON.parse(data.slice(0, newlineIdx)) as MetaHeaders
     const meta = JSON.parse(data.slice(newlineIdx + 1)) as PackageMeta
+    dropIncompletePublishTimes(meta)
     meta.etag = headers.etag
     return meta
   } catch {

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -21,6 +21,7 @@ import {
 } from './fetch.js'
 import type { RegistryPackageSpec } from './parseBareSpecifier.js'
 import {
+  hasAllVersionPublishTimes,
   pickLowestVersionByVersionRange,
   pickPackageFromMeta,
   type PickPackageFromMetaOptions,
@@ -505,7 +506,7 @@ export async function pickPackage (
       if (
         opts.publishedBy &&
         !fullMetadata &&
-        meta.time == null &&
+        !hasAllVersionPublishTimes(meta) &&
         opts.publishedByExclude?.(spec.name) !== true
       ) {
         const modifiedDate = meta.modified ? new Date(meta.modified) : null
@@ -583,7 +584,7 @@ async function maybeUpgradeAbbreviatedMetaForReleaseAge (
   if (
     ctx.offline === true ||
     !opts.publishedBy ||
-    meta.time != null ||
+    hasAllVersionPublishTimes(meta) ||
     opts.publishedByExclude?.(spec.name) === true
   ) {
     return { meta }

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -291,7 +291,6 @@ export async function pickPackage (
   // updateChecksums must reach the conditional registry request below, so it
   // can't be served from the in-memory cache — which may hold a disk-promoted
   // entry rather than a fresh network fetch (see the updateChecksums doc).
-  console.error('[T] pick', spec.name, 'updateChecksums=', opts.updateChecksums === true)
   const cachedMeta = opts.updateChecksums ? undefined : ctx.metaCache.get(cacheKey)
   if (cachedMeta != null) {
     // The in-memory cache may hold abbreviated metadata from an earlier call
@@ -526,7 +525,6 @@ export async function pickPackage (
             saveMetaBestEffort(pkgMirror, prepareJsonForDisk(resultToSave.meta, resultToSave.etag, resultToSave.jsonText))
           }
           attemptedReleaseAgeUpgrade = true
-          console.error('[T] fresh-path upgrade fetch')
           const fullFetchResult = await ctx.fetch(spec.name, {
             authHeaderValue: opts.authHeaderValue,
             fullMetadata: true,
@@ -591,7 +589,6 @@ async function maybeUpgradeAbbreviatedMetaForReleaseAge (
   },
   meta: PackageMeta
 ): Promise<{ meta: PackageMeta, upgradedFrom?: FetchMetadataResult }> {
-  console.error('[T] maybeUpgrade: time=', meta.time == null ? 'null' : 'set', 'marked=', ctx.releaseAgeUpgradeCheckedPackuments?.has(meta) === true, 'modified=', meta.modified)
   if (
     ctx.offline === true ||
     !opts.publishedBy ||

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -252,7 +252,7 @@ export async function pickPackage (
     preferOffline?: boolean
     filterMetadata?: boolean
     ignoreMissingTimeField?: boolean
-    /** Packuments already checked by a full-metadata upgrade in this resolver. */
+    /** Packuments whose release-age upgrade fetch already answered 304 in this resolver. */
     releaseAgeUpgradeCheckedPackuments?: WeakSet<PackageMeta>
   },
   spec: RegistryPackageSpec,
@@ -617,12 +617,10 @@ async function maybeUpgradeAbbreviatedMetaForReleaseAge (
     registry: opts.registry,
   })
   if (fullFetchResult.notModified) {
-    // Upgrade fetch came back 304: keep the abbreviated meta. The downstream
-    // `pickMatchingVersionFinal` will fall through to its warn-and-skip path.
-    // Remember this registry-validated outcome in the resolver-owned marker
-    // set so another pick in this install does not repeat the request. Do not
-    // attach the marker to the caller-owned metadata cache: that cache may be
-    // shared by a later install, which must get its own upgrade attempt.
+    // Upgrade fetch came back 304: the registry has no fuller form of this
+    // document, so keep it and let `pickMatchingVersionFinal` fall through to
+    // its warn-and-skip path. Remember the outcome against the packument
+    // itself so no other pick in this resolver repeats the request.
     ctx.releaseAgeUpgradeCheckedPackuments?.add(meta)
     return { meta }
   }

--- a/pnpm11/resolving/npm-resolver/src/pickPackageFromMeta.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackageFromMeta.ts
@@ -42,8 +42,8 @@ export function pickPackageFromMeta (
       if (modifiedDate == null || modifiedDate > publishedBy) {
         // The package was modified after the cutoff (or carries no usable
         // `modified`), so which of its versions are mature is unknowable
-        // from abbreviated metadata. The error tells the caller to refetch.
-        assertMetaHasAllVersionPublishTimes(meta)
+        // from this packument. The error tells the caller to refetch.
+        throw missingTimeError(meta.name)
       }
       // else: `modified` is an upper bound on every per-version timestamp, so
       // `modified <= publishedBy` means they all pass the maturity filter and
@@ -144,10 +144,19 @@ export function applyPublishedByPolicy (
 
 export function assertMetaHasTime (meta: PackageMeta): asserts meta is PackageMetaWithTime {
   if (meta.time == null) {
-    throw new PnpmError('MISSING_TIME', `The metadata of ${meta.name} is missing the "time" field`)
+    throw missingTimeError(meta.name)
   }
 }
 
+/**
+ * Whether `meta.time` carries a publish timestamp for every version the
+ * packument lists.
+ *
+ * Some registries answer with a `time` map that covers only a few of the
+ * versions they serve. Taking such a map at face value makes the
+ * `minimumReleaseAge` filter drop every version whose timestamp is absent,
+ * so the cutoff can only be applied once all of them are known.
+ */
 export function hasAllVersionPublishTimes (meta: PackageMeta): meta is PackageMetaWithTime {
   if (meta.time == null) return false
   for (const version in meta.versions) {
@@ -157,10 +166,8 @@ export function hasAllVersionPublishTimes (meta: PackageMeta): meta is PackageMe
   return true
 }
 
-function assertMetaHasAllVersionPublishTimes (meta: PackageMeta): asserts meta is PackageMetaWithTime {
-  if (!hasAllVersionPublishTimes(meta)) {
-    throw new PnpmError('MISSING_TIME', `The metadata of ${meta.name} is missing the "time" field`)
-  }
+function missingTimeError (pkgName: string): PnpmError {
+  return new PnpmError('MISSING_TIME', `The metadata of ${pkgName} is missing the "time" field`)
 }
 
 function parseModifiedDate (modified: string | undefined): Date | null {

--- a/pnpm11/resolving/npm-resolver/src/pickPackageFromMeta.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackageFromMeta.ts
@@ -42,8 +42,8 @@ export function pickPackageFromMeta (
       if (modifiedDate == null || modifiedDate > publishedBy) {
         // The package was modified after the cutoff (or carries no usable
         // `modified`), so which of its versions are mature is unknowable
-        // from this packument. The error tells the caller to refetch.
-        throw missingTimeError(meta.name)
+        // from abbreviated metadata. The error tells the caller to refetch.
+        assertMetaHasTime(meta)
       }
       // else: `modified` is an upper bound on every per-version timestamp, so
       // `modified <= publishedBy` means they all pass the maturity filter and
@@ -134,7 +134,8 @@ export function applyPublishedByPolicy (
 ): PublishedByView {
   const excludeResult = publishedByExclude?.(meta.name) ?? false
   if (excludeResult === true) return { meta, needsFullMetadata: false }
-  if (!hasAllVersionPublishTimes(meta)) return { meta, needsFullMetadata: true }
+  if (meta.time == null) return { meta, needsFullMetadata: true }
+  assertMetaHasTime(meta)
   const trustedVersions = Array.isArray(excludeResult) ? excludeResult : undefined
   return {
     meta: filterPkgMetadataByPublishDate(meta, publishedBy, trustedVersions),
@@ -144,30 +145,8 @@ export function applyPublishedByPolicy (
 
 export function assertMetaHasTime (meta: PackageMeta): asserts meta is PackageMetaWithTime {
   if (meta.time == null) {
-    throw missingTimeError(meta.name)
+    throw new PnpmError('MISSING_TIME', `The metadata of ${meta.name} is missing the "time" field`)
   }
-}
-
-/**
- * Whether `meta.time` carries a publish timestamp for every version the
- * packument lists.
- *
- * Some registries answer with a `time` map that covers only a few of the
- * versions they serve. Taking such a map at face value makes the
- * `minimumReleaseAge` filter drop every version whose timestamp is absent,
- * so the cutoff can only be applied once all of them are known.
- */
-export function hasAllVersionPublishTimes (meta: PackageMeta): meta is PackageMetaWithTime {
-  if (meta.time == null) return false
-  for (const version in meta.versions) {
-    if (!Object.hasOwn(meta.versions, version)) continue
-    if (!Object.hasOwn(meta.time, version) || !meta.time[version]) return false
-  }
-  return true
-}
-
-function missingTimeError (pkgName: string): PnpmError {
-  return new PnpmError('MISSING_TIME', `The metadata of ${pkgName} is missing the "time" field`)
 }
 
 function parseModifiedDate (modified: string | undefined): Date | null {

--- a/pnpm11/resolving/npm-resolver/src/pickPackageFromMeta.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackageFromMeta.ts
@@ -43,7 +43,7 @@ export function pickPackageFromMeta (
         // The package was modified after the cutoff (or carries no usable
         // `modified`), so which of its versions are mature is unknowable
         // from abbreviated metadata. The error tells the caller to refetch.
-        assertMetaHasTime(meta)
+        assertMetaHasAllVersionPublishTimes(meta)
       }
       // else: `modified` is an upper bound on every per-version timestamp, so
       // `modified <= publishedBy` means they all pass the maturity filter and
@@ -134,8 +134,7 @@ export function applyPublishedByPolicy (
 ): PublishedByView {
   const excludeResult = publishedByExclude?.(meta.name) ?? false
   if (excludeResult === true) return { meta, needsFullMetadata: false }
-  if (meta.time == null) return { meta, needsFullMetadata: true }
-  assertMetaHasTime(meta)
+  if (!hasAllVersionPublishTimes(meta)) return { meta, needsFullMetadata: true }
   const trustedVersions = Array.isArray(excludeResult) ? excludeResult : undefined
   return {
     meta: filterPkgMetadataByPublishDate(meta, publishedBy, trustedVersions),
@@ -145,6 +144,21 @@ export function applyPublishedByPolicy (
 
 export function assertMetaHasTime (meta: PackageMeta): asserts meta is PackageMetaWithTime {
   if (meta.time == null) {
+    throw new PnpmError('MISSING_TIME', `The metadata of ${meta.name} is missing the "time" field`)
+  }
+}
+
+export function hasAllVersionPublishTimes (meta: PackageMeta): meta is PackageMetaWithTime {
+  if (meta.time == null) return false
+  for (const version in meta.versions) {
+    if (!Object.hasOwn(meta.versions, version)) continue
+    if (!Object.hasOwn(meta.time, version) || !meta.time[version]) return false
+  }
+  return true
+}
+
+function assertMetaHasAllVersionPublishTimes (meta: PackageMeta): asserts meta is PackageMetaWithTime {
+  if (!hasAllVersionPublishTimes(meta)) {
     throw new PnpmError('MISSING_TIME', `The metadata of ${meta.name} is missing the "time" field`)
   }
 }

--- a/pnpm11/resolving/npm-resolver/src/publishTimes.ts
+++ b/pnpm11/resolving/npm-resolver/src/publishTimes.ts
@@ -1,0 +1,34 @@
+import type { PackageMeta } from '@pnpm/resolving.registry.types'
+
+/**
+ * Drops `time` unless it carries a publish timestamp for every version the
+ * packument lists.
+ *
+ * Registries may answer with a partial map: npmmirror adds `time` to its
+ * abbreviated documents but fills it in only for the versions it has synced
+ * since it started recording publish times, leaving the rest out. A partial
+ * map is indistinguishable from a complete one at the point of use, so the
+ * `minimumReleaseAge` filter reads every absent timestamp as "not mature"
+ * and silently drops the version — resolution then falls back to the lowest
+ * match.
+ *
+ * A map that can't decide maturity is worth nothing to the resolver, so it
+ * is normalized away where the document is parsed. Every packument past that
+ * point then carries either a complete `time` or none at all — the shape the
+ * npm registry's own abbreviated documents have, and the one the rest of the
+ * resolver is written against.
+ *
+ * A packument with no versions keeps whatever `time` it has — there is
+ * nothing for the map to be incomplete about — and a version whose entry is
+ * an empty string counts as absent.
+ */
+export function dropIncompletePublishTimes (meta: PackageMeta): void {
+  if (meta.time == null) return
+  for (const version in meta.versions) {
+    if (!Object.hasOwn(meta.versions, version)) continue
+    if (!Object.hasOwn(meta.time, version) || !meta.time[version]) {
+      delete meta.time
+      return
+    }
+  }
+}

--- a/pnpm11/resolving/npm-resolver/test/index.ts
+++ b/pnpm11/resolving/npm-resolver/test/index.ts
@@ -1636,6 +1636,7 @@ test('preferWorkspacePackages: still consults the registry under trustPolicy=no-
       'dist-tags': { latest: '3.1.0' },
       time: {
         '1.0.0': '2016-01-01T00:00:00.000Z',
+        '2.0.0': '2016-06-01T00:00:00.000Z',
         '3.0.0': '2017-01-01T00:00:00.000Z',
         '3.1.0': '2018-01-01T00:00:00.000Z',
       },

--- a/pnpm11/resolving/npm-resolver/test/publishedBy.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/publishedBy.test.ts
@@ -329,6 +329,65 @@ test('scopes a 304 full-metadata upgrade marker to one resolver', async () => {
   getMockAgent().assertNoPendingInterceptors()
 })
 
+test('an upgrade answered with 200 is not repeated for later picks', async () => {
+  // A registry whose full representation is no more complete than its
+  // abbreviated one: the upgrade succeeds but changes nothing, so it must
+  // still be remembered or every pick re-asks for the same document.
+  const agent = getMockAgent().get(registriesByScope.default.replace(/\/$/, ''))
+  agent.intercept({ path: '/is-positive', method: 'GET' })
+    .reply(200, partialTimeMeta())
+  agent.intercept({ path: '/is-positive', method: 'GET' })
+    .reply(200, partialTimeMeta())
+
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir: temporaryDirectory(),
+    registriesByScope,
+    ignoreMissingTimeField: true,
+  })
+  const wantedDependency = { alias: 'is-positive', bareSpecifier: '^3.0.0' }
+  const publishedBy = new Date('2015-07-01T00:00:00.000Z')
+
+  const first = await resolveFromNpm(wantedDependency, { publishedBy })
+  const second = await resolveFromNpm(wantedDependency, { publishedBy })
+
+  expect(first!.id).toBe('is-positive@3.1.0')
+  expect(second!.id).toBe('is-positive@3.1.0')
+  // One abbreviated fetch and one upgrade, not one upgrade per pick.
+  getMockAgent().assertNoPendingInterceptors()
+})
+
+test('a replacement packument under the same cache key gets its own upgrade', async () => {
+  // updateChecksums bypasses the in-memory cache to force a conditional
+  // request, so a second document can arrive under the key the first one
+  // was marked against. Identity-keyed marking must not suppress it.
+  // Four requests: an abbreviated fetch and its upgrade per resolve. The
+  // second resolve gets a fresh document, so its upgrade must run again.
+  const agent = getMockAgent().get(registriesByScope.default.replace(/\/$/, ''))
+  for (let i = 0; i < 4; i++) {
+    agent.intercept({ path: '/is-positive', method: 'GET' })
+      .reply(200, partialTimeMeta(), { headers: { etag: `"partial-time-${i}"` } })
+  }
+
+  const { clearCache, resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir: temporaryDirectory(),
+    registriesByScope,
+    ignoreMissingTimeField: true,
+    // Caller-owned, so `clearCache()` drops only the request memo and the
+    // second resolve reaches the registry for a document of its own.
+    metaCache: new Map<string, PackageMeta>(),
+  })
+  const wantedDependency = { alias: 'is-positive', bareSpecifier: '^3.0.0' }
+  const publishedBy = new Date('2015-07-01T00:00:00.000Z')
+
+  await resolveFromNpm(wantedDependency, { publishedBy })
+  clearCache()
+  await resolveFromNpm(wantedDependency, { publishedBy, updateChecksums: true })
+
+  getMockAgent().assertNoPendingInterceptors()
+})
+
 test('ignoreMissingTimeField=true skips maturity check when full metadata has no time field', async () => {
   const { time: _time, ...metaWithoutTime } = isPositiveMeta
 

--- a/pnpm11/resolving/npm-resolver/test/publishedBy.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/publishedBy.test.ts
@@ -250,25 +250,16 @@ test('re-fetch full metadata when abbreviated modified date is recent', async ()
 })
 
 test('re-fetch full metadata when per-version publish times are incomplete', async () => {
-  const partialTimeMeta = {
-    ...isPositiveAbbreviatedMeta,
-    time: {
-      '3.0.0': isPositiveMeta.time['3.0.0'],
-      '3.1.0': isPositiveMeta.time['3.1.0'],
-    },
-    modified: isPositiveMeta.time.modified,
-  }
-
-  const agent = getMockAgent().get(registries.default.replace(/\/$/, ''))
+  const agent = getMockAgent().get(registriesByScope.default.replace(/\/$/, ''))
   agent.intercept({ path: '/is-positive', method: 'GET' })
-    .reply(200, partialTimeMeta, { headers: { 'content-type': 'application/json' } })
+    .reply(200, partialTimeMeta(), { headers: { 'content-type': 'application/json' } })
   agent.intercept({ path: '/is-positive', method: 'GET' })
     .reply(200, isPositiveMeta)
 
   const { resolveFromNpm } = createResolveFromNpm({
     storeDir: temporaryDirectory(),
     cacheDir: temporaryDirectory(),
-    registries,
+    registriesByScope,
   })
   const resolveResult = await resolveFromNpm({ alias: 'is-positive', bareSpecifier: '>=1 <3' }, {
     publishedBy: new Date('2015-07-01T00:00:00.000Z'),
@@ -279,18 +270,9 @@ test('re-fetch full metadata when per-version publish times are incomplete', asy
 })
 
 test('scopes a 304 full-metadata upgrade marker to one resolver', async () => {
-  const partialTimeMeta = {
-    ...isPositiveAbbreviatedMeta,
-    time: {
-      '3.0.0': isPositiveMeta.time['3.0.0'],
-      '3.1.0': isPositiveMeta.time['3.1.0'],
-    },
-    modified: isPositiveMeta.time.modified,
-  }
-
-  const agent = getMockAgent().get(registries.default.replace(/\/$/, ''))
+  const agent = getMockAgent().get(registriesByScope.default.replace(/\/$/, ''))
   agent.intercept({ path: '/is-positive', method: 'GET' })
-    .reply(200, partialTimeMeta, { headers: { etag: '"partial-time"' } })
+    .reply(200, partialTimeMeta(), { headers: { etag: '"partial-time"' } })
   agent.intercept({
     path: '/is-positive',
     method: 'GET',
@@ -307,7 +289,7 @@ test('scopes a 304 full-metadata upgrade marker to one resolver', async () => {
   const { clearCache, resolveFromNpm } = createResolveFromNpm({
     storeDir: temporaryDirectory(),
     cacheDir,
-    registries,
+    registriesByScope,
     ignoreMissingTimeField: true,
     metaCache,
   })
@@ -320,8 +302,9 @@ test('scopes a 304 full-metadata upgrade marker to one resolver', async () => {
   const first = await resolveFromNpm(wantedDependency, {
     publishedBy: new Date('2015-07-01T00:00:00.000Z'),
   })
-  // Drop the request memo without clearing the caller-owned packument cache.
-  // This proves the packument itself records the 304 outcome.
+  // Drop the resolver's fetch memo while keeping the caller-owned packument
+  // cache, so the second pick reaches the release-age upgrade again with the
+  // very packument the first pick got a 304 for.
   clearCache()
   const second = await resolveFromNpm(wantedDependency, {
     publishedBy: new Date('2015-07-01T00:00:00.000Z'),
@@ -332,7 +315,7 @@ test('scopes a 304 full-metadata upgrade marker to one resolver', async () => {
   const nextInstall = createResolveFromNpm({
     storeDir: temporaryDirectory(),
     cacheDir,
-    registries,
+    registriesByScope,
     ignoreMissingTimeField: true,
     metaCache,
   })
@@ -823,3 +806,19 @@ test('latest is suppressed when all versions are immature (fallback case)', asyn
   expect(resolveResult!.id).toBe('is-positive@1.0.0')
   expect(resolveResult!.latest).toBeUndefined()
 })
+
+/**
+ * The abbreviated packument as a registry that reports publish times for only
+ * some of the versions it serves would answer, with `modified` recent enough
+ * to make the release-age check ask for the full document.
+ */
+function partialTimeMeta (): PackageMeta {
+  return {
+    ...isPositiveAbbreviatedMeta,
+    time: {
+      '3.0.0': isPositiveMeta.time['3.0.0'],
+      '3.1.0': isPositiveMeta.time['3.1.0'],
+    },
+    modified: isPositiveMeta.time.modified,
+  }
+}

--- a/pnpm11/resolving/npm-resolver/test/publishedBy.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/publishedBy.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, expect, test } from '@jest/globals'
 import { ABBREVIATED_META_DIR, FULL_FILTERED_META_DIR } from '@pnpm/constants'
 import { createFetchFromRegistry } from '@pnpm/network.fetch'
 import { createNpmResolver } from '@pnpm/resolving.npm-resolver'
+import type { PackageMeta } from '@pnpm/resolving.registry.types'
 import { fixtures } from '@pnpm/test-fixtures'
 import type { RegistriesByScope } from '@pnpm/types'
 import { loadJsonFileSync } from 'load-json-file'
@@ -275,6 +276,54 @@ test('re-fetch full metadata when per-version publish times are incomplete', asy
 
   expect(resolveResult!.resolvedVia).toBe('npm-registry')
   expect(resolveResult!.id).toBe('is-positive@2.0.0')
+})
+
+test('does not repeat a 304 full-metadata upgrade for an incomplete time map', async () => {
+  const partialTimeMeta = {
+    ...isPositiveAbbreviatedMeta,
+    time: {
+      '3.0.0': isPositiveMeta.time['3.0.0'],
+      '3.1.0': isPositiveMeta.time['3.1.0'],
+    },
+    modified: isPositiveMeta.time.modified,
+  }
+
+  const agent = getMockAgent().get(registries.default.replace(/\/$/, ''))
+  agent.intercept({ path: '/is-positive', method: 'GET' })
+    .reply(200, partialTimeMeta, { headers: { etag: '"partial-time"' } })
+  agent.intercept({
+    path: '/is-positive',
+    method: 'GET',
+    headers: { 'if-none-match': '"partial-time"' },
+  }).reply(304, '')
+
+  const metaCache = new Map<string, PackageMeta>()
+  const { clearCache, resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir: temporaryDirectory(),
+    registries,
+    ignoreMissingTimeField: true,
+    metaCache,
+  })
+  const wantedDependency = { alias: 'is-positive', bareSpecifier: '^3.0.0' }
+
+  // Seed the install-scoped cache with an incomplete time map, then make two
+  // release-age picks. The first gets a 304 while trying to upgrade it; the
+  // second must reuse that outcome instead of repeating the registry request.
+  await resolveFromNpm(wantedDependency, {})
+  const first = await resolveFromNpm(wantedDependency, {
+    publishedBy: new Date('2015-07-01T00:00:00.000Z'),
+  })
+  // Drop the request memo without clearing the caller-owned packument cache.
+  // This proves the packument itself records the 304 outcome.
+  clearCache()
+  const second = await resolveFromNpm(wantedDependency, {
+    publishedBy: new Date('2015-07-01T00:00:00.000Z'),
+  })
+
+  expect(first!.id).toBe('is-positive@3.1.0')
+  expect(second!.id).toBe('is-positive@3.1.0')
+  getMockAgent().assertNoPendingInterceptors()
 })
 
 test('ignoreMissingTimeField=true skips maturity check when full metadata has no time field', async () => {

--- a/pnpm11/resolving/npm-resolver/test/publishedBy.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/publishedBy.test.ts
@@ -278,7 +278,7 @@ test('re-fetch full metadata when per-version publish times are incomplete', asy
   expect(resolveResult!.id).toBe('is-positive@2.0.0')
 })
 
-test('does not repeat a 304 full-metadata upgrade for an incomplete time map', async () => {
+test('scopes a 304 full-metadata upgrade marker to one resolver', async () => {
   const partialTimeMeta = {
     ...isPositiveAbbreviatedMeta,
     time: {
@@ -296,11 +296,17 @@ test('does not repeat a 304 full-metadata upgrade for an incomplete time map', a
     method: 'GET',
     headers: { 'if-none-match': '"partial-time"' },
   }).reply(304, '')
+  agent.intercept({
+    path: '/is-positive',
+    method: 'GET',
+    headers: { 'if-none-match': '"partial-time"' },
+  }).reply(304, '')
 
   const metaCache = new Map<string, PackageMeta>()
+  const cacheDir = temporaryDirectory()
   const { clearCache, resolveFromNpm } = createResolveFromNpm({
     storeDir: temporaryDirectory(),
-    cacheDir: temporaryDirectory(),
+    cacheDir,
     registries,
     ignoreMissingTimeField: true,
     metaCache,
@@ -321,8 +327,22 @@ test('does not repeat a 304 full-metadata upgrade for an incomplete time map', a
     publishedBy: new Date('2015-07-01T00:00:00.000Z'),
   })
 
+  // A new resolver represents a new install. Reusing the caller-owned
+  // metadata cache must not carry the first install's 304 marker forward.
+  const nextInstall = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir,
+    registries,
+    ignoreMissingTimeField: true,
+    metaCache,
+  })
+  const third = await nextInstall.resolveFromNpm(wantedDependency, {
+    publishedBy: new Date('2015-07-01T00:00:00.000Z'),
+  })
+
   expect(first!.id).toBe('is-positive@3.1.0')
   expect(second!.id).toBe('is-positive@3.1.0')
+  expect(third!.id).toBe('is-positive@3.1.0')
   getMockAgent().assertNoPendingInterceptors()
 })
 

--- a/pnpm11/resolving/npm-resolver/test/publishedBy.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/publishedBy.test.ts
@@ -248,6 +248,35 @@ test('re-fetch full metadata when abbreviated modified date is recent', async ()
   expect(resolveResult!.id).toBe('is-positive@1.0.0')
 })
 
+test('re-fetch full metadata when per-version publish times are incomplete', async () => {
+  const partialTimeMeta = {
+    ...isPositiveAbbreviatedMeta,
+    time: {
+      '3.0.0': isPositiveMeta.time['3.0.0'],
+      '3.1.0': isPositiveMeta.time['3.1.0'],
+    },
+    modified: isPositiveMeta.time.modified,
+  }
+
+  const agent = getMockAgent().get(registries.default.replace(/\/$/, ''))
+  agent.intercept({ path: '/is-positive', method: 'GET' })
+    .reply(200, partialTimeMeta, { headers: { 'content-type': 'application/json' } })
+  agent.intercept({ path: '/is-positive', method: 'GET' })
+    .reply(200, isPositiveMeta)
+
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir: temporaryDirectory(),
+    registries,
+  })
+  const resolveResult = await resolveFromNpm({ alias: 'is-positive', bareSpecifier: '>=1 <3' }, {
+    publishedBy: new Date('2015-07-01T00:00:00.000Z'),
+  })
+
+  expect(resolveResult!.resolvedVia).toBe('npm-registry')
+  expect(resolveResult!.id).toBe('is-positive@2.0.0')
+})
+
 test('ignoreMissingTimeField=true skips maturity check when full metadata has no time field', async () => {
   const { time: _time, ...metaWithoutTime } = isPositiveMeta
 


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#13741.

When `minimumReleaseAge` is active, both resolvers treated any non-null `time` map as complete. Registries such as npmmirror can return abbreviated packuments whose `time` map covers only some versions, causing mature versions with omitted timestamps to be filtered out and resolution to fall back to the lowest matching release.

This change requires a publish timestamp for every version before applying the age filter. Otherwise it re-fetches full metadata. The TypeScript and pacquet implementations include matching regression tests, and the changeset covers all three published packages.

Validation:

- `pnpm --config.manage-package-manager-versions=false --filter '@pnpm/resolving.npm-resolver' run test --runInBand` (23 suites, 337 tests passed)
- `cargo test -p pacquet-resolving-npm-resolver` (374 unit tests and 1 integration test passed)
- `cargo clippy -p pacquet-resolving-npm-resolver --all-targets --no-deps -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo check --locked --workspace --all-targets --exclude pacquet-napi`
- `typos pnpm pnpr`
- `taplo format --check`
- `pnpm --config.manage-package-manager-versions=false run lint:meta`

Full `just ready` could not complete unchanged on this Windows-GNU host: the independent `pacquet-napi` workspace member requires `libnode.dll`, and the broader nextest run stopped after 335 passing tests because this Windows account cannot create the symlink asserted by `probe_reports_the_links_a_normal_filesystem_supports`.

## Squash Commit Body

```text
Detect partial per-version publish-time maps before applying minimumReleaseAge.

Some registries provide timestamps for only a subset of releases in abbreviated packuments. Re-fetch full metadata unless every version has a publish timestamp, so mature versions remain resolution candidates. Keep the TypeScript and pacquet implementations and regression coverage in sync.

Closes pnpm/pnpm#13741.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
AI assistance was used during investigation or implementation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13750"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788914480&installation_model_id=426870&pr_number=13750&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13750&signature=b57c2c89dc12a3af83b5de9ad9101feac795df9bea11265614eacf98db5c27b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package resolution when `minimumReleaseAge` is enabled and registry metadata has incomplete publish timestamps.
  * Automatically retrieves complete metadata before filtering packages, preventing valid versions from being incorrectly excluded.
  * Prevented unnecessary repeated metadata requests when cached information is unchanged, while allowing retries for new installations.

* **Tests**
  * Added regression coverage for incomplete metadata, cached responses, retry behavior, and correct version selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
