### PR TITLE
fix(pack): preserve workspace dependency order

### DIFF
--- a/.changeset/stable-packed-workspace-deps.md
+++ b/.changeset/stable-packed-workspace-deps.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/releasing.exportable-manifest": patch
+"pnpm": patch
+---
+
+Packed workspace package manifests now preserve dependency order, making repeated `pnpm pack` output deterministic [#10167](https://github.com/pnpm/pnpm/issues/10167).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8593,9 +8593,6 @@ importers:
       '@pnpm/workspace.project-manifest-reader':
         specifier: workspace:*
         version: link:../../workspace/project-manifest-reader
-      p-map-values:
-        specifier: 'catalog:'
-        version: 0.1.0
       ramda:
         specifier: 'catalog:'
         version: '@pnpm/ramda@0.28.1'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -617,9 +617,6 @@ catalogs:
     p-limit:
       specifier: ^7.3.1
       version: 7.3.1
-    p-map-values:
-      specifier: ^0.1.0
-      version: 0.1.0
     p-queue:
       specifier: ^9.3.3
       version: 9.3.3
@@ -7054,9 +7051,6 @@ importers:
       '@pnpm/lockfile.verification':
         specifier: workspace:*
         version: link:../verification
-      p-map-values:
-        specifier: 'catalog:'
-        version: 0.1.0
       ramda:
         specifier: 'catalog:'
         version: '@pnpm/ramda@0.28.1'
@@ -15782,10 +15776,6 @@ packages:
     resolution: {integrity: sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  p-map-values@0.1.0:
-    resolution: {integrity: sha512-IMr3wlbvIFnAIkUiJEZ4gUtMMte1tzDm+mehuFXJT7nXgluGsv6HbHaxuVgTc2D/LmKWOjdZN5IxnjVuudlt1w==}
-    engines: {node: '>=22.13'}
-
   p-map-values@1.0.0:
     resolution: {integrity: sha512-/n8QJM4Os3HLRMSuQWwAocsMExENSQwWTgRi8m3JVEOWQ/4gud14igBcnYvSGQTbiyZbuizxEmwf0w3ITn67gg==}
     engines: {node: '>=14'}
@@ -23907,8 +23897,6 @@ snapshots:
   p-locate@6.0.0:
     dependencies:
       p-limit: 4.0.0
-
-  p-map-values@0.1.0: {}
 
   p-map-values@1.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4735,9 +4735,6 @@ importers:
       lodash.throttle:
         specifier: 'catalog:'
         version: 4.1.1
-      p-map-values:
-        specifier: 'catalog:'
-        version: 0.1.0
       ramda:
         specifier: 'catalog:'
         version: '@pnpm/ramda@0.28.1'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -300,7 +300,6 @@ catalog:
   p-every: ^2.0.0
   p-filter: ^4.1.0
   p-limit: ^7.3.1
-  p-map-values: ^0.1.0
   p-queue: ^9.3.3
   parse-json: ^8.3.0
   parse-npm-tarball-url: ^5.0.0
@@ -427,7 +426,6 @@ minimumReleaseAgeExclude:
   - lodash@4.17.23
   - make-empty-dir
   - normalize-registry-url
-  - p-map-values
   - parse-npm-tarball-url@5.0.0
   - path-absolute
   - path-temp

--- a/pnpm/crates/exportable-manifest/src/tests.rs
+++ b/pnpm/crates/exportable-manifest/src/tests.rs
@@ -6,10 +6,13 @@
 
 use std::{fs, path::Path};
 
+use pnpm_catalogs_types::Catalogs;
+use serde_json::Value;
 use tempfile::TempDir;
 
 use super::{
-    CannotResolveWorkspaceProtocolError, ReplaceWorkspaceProtocolError, replace_workspace_protocol,
+    CannotResolveWorkspaceProtocolError, CreateExportableManifestOptions,
+    ReplaceWorkspaceProtocolError, create_exportable_manifest, replace_workspace_protocol,
     replace_workspace_protocol_peer_dependency,
 };
 
@@ -152,4 +155,47 @@ fn dep_name_mismatch_routes_to_npm_alias() {
     write_dep(&modules.join("local-name"), "actual-name", "1.2.3");
 
     assert_eq!(rewrite("local-name", "workspace:*", dir), "npm:actual-name@1.2.3");
+}
+
+/// The packed manifest is the input to the tarball hash, so a
+/// dependency map that reorders between runs makes an unchanged
+/// package pack to different bytes.
+#[test]
+fn published_dependencies_keep_declaration_order() {
+    let (_fixture, project) = workspace_fixture();
+    let catalogs = Catalogs::default();
+    let manifest = serde_json::json!({
+        "name": "workspace-protocol-package",
+        "version": "1.0.0",
+        "dependencies": {
+            "waldo": "workspace:*",
+            "baz": "workspace:*",
+            "quux": "workspace:*",
+            "foo": "workspace:*",
+        },
+    });
+
+    let published = create_exportable_manifest(
+        &project,
+        &manifest,
+        &CreateExportableManifestOptions {
+            catalogs: &catalogs,
+            modules_dir: None,
+            skip_manifest_obfuscation: false,
+            embed_readme: false,
+        },
+    )
+    .expect("manifest is exportable");
+
+    let dependencies =
+        published.get("dependencies").and_then(Value::as_object).expect("dependencies survive");
+    assert_eq!(
+        dependencies.iter().collect::<Vec<_>>(),
+        vec![
+            (&"waldo".to_string(), &Value::from("1.9.0")),
+            (&"baz".to_string(), &Value::from("1.2.3")),
+            (&"quux".to_string(), &Value::from("7.8.9")),
+            (&"foo".to_string(), &Value::from("4.5.6")),
+        ],
+    );
 }

--- a/pnpm11/fetching/tarball-fetcher/package.json
+++ b/pnpm11/fetching/tarball-fetcher/package.json
@@ -44,7 +44,6 @@
     "@pnpm/types": "workspace:*",
     "@zkochan/retry": "catalog:",
     "lodash.throttle": "catalog:",
-    "p-map-values": "catalog:",
     "ramda": "catalog:"
   },
   "peerDependencies": {

--- a/pnpm11/lockfile/settings-checker/package.json
+++ b/pnpm11/lockfile/settings-checker/package.json
@@ -39,7 +39,6 @@
     "@pnpm/crypto.hash": "workspace:*",
     "@pnpm/lockfile.types": "workspace:*",
     "@pnpm/lockfile.verification": "workspace:*",
-    "p-map-values": "catalog:",
     "ramda": "catalog:"
   },
   "devDependencies": {

--- a/pnpm11/lockfile/settings-checker/src/calcPatchHashes.ts
+++ b/pnpm11/lockfile/settings-checker/src/calcPatchHashes.ts
@@ -1,8 +1,10 @@
 import { createHexHashFromFile } from '@pnpm/crypto.hash'
-import { pMapValues } from 'p-map-values'
 
 export async function calcPatchHashes (patches: Record<string, string>): Promise<Record<string, string>> {
-  return pMapValues(async (patchFilePath: string) => {
-    return createHexHashFromFile(patchFilePath)
-  }, patches)
+  const hashes = await Promise.all(
+    Object.entries(patches).map(async ([patchKey, patchFilePath]): Promise<[string, string]> =>
+      [patchKey, await createHexHashFromFile(patchFilePath)]
+    )
+  )
+  return Object.fromEntries(hashes)
 }

--- a/pnpm11/releasing/exportable-manifest/package.json
+++ b/pnpm11/releasing/exportable-manifest/package.json
@@ -38,7 +38,6 @@
     "@pnpm/resolving.jsr-specifier-parser": "workspace:*",
     "@pnpm/types": "workspace:*",
     "@pnpm/workspace.project-manifest-reader": "workspace:*",
-    "p-map-values": "catalog:",
     "ramda": "catalog:"
   },
   "devDependencies": {

--- a/pnpm11/releasing/exportable-manifest/src/index.ts
+++ b/pnpm11/releasing/exportable-manifest/src/index.ts
@@ -9,7 +9,6 @@ import type { Hooks } from '@pnpm/hooks.pnpmfile'
 import { parseJsrSpecifier } from '@pnpm/resolving.jsr-specifier-parser'
 import type { Dependencies, ProjectManifest } from '@pnpm/types'
 import { tryReadProjectManifest } from '@pnpm/workspace.project-manifest-reader'
-import { pMapValues } from 'p-map-values'
 import { clone, omit } from 'ramda'
 
 import { overridePublishConfig } from './overridePublishConfig.js'
@@ -143,11 +142,12 @@ async function makePublishDependencies (
   { modulesDir, convertDependencyForPublish }: MakePublishDependenciesOpts
 ): Promise<Dependencies | undefined> {
   if (dependencies == null) return dependencies
-  const publishDependencies = await pMapValues(
-    async (depSpec: string, depName: string) => convertDependencyForPublish(depName, depSpec, dir, modulesDir),
-    dependencies
+  const publishDependencies = await Promise.all(
+    Object.entries(dependencies).map(async ([depName, depSpec]): Promise<[string, string]> =>
+      [depName, await convertDependencyForPublish(depName, depSpec, dir, modulesDir)]
+    )
   )
-  return Object.fromEntries(Object.keys(dependencies).map((depName) => [depName, publishDependencies[depName]]))
+  return Object.fromEntries(publishDependencies)
 }
 
 async function readAndCheckManifest (depName: string, dependencyDir: string): Promise<ProjectManifest> {

--- a/pnpm11/releasing/exportable-manifest/src/index.ts
+++ b/pnpm11/releasing/exportable-manifest/src/index.ts
@@ -147,7 +147,7 @@ async function makePublishDependencies (
     async (depSpec: string, depName: string) => convertDependencyForPublish(depName, depSpec, dir, modulesDir),
     dependencies
   )
-  return publishDependencies
+  return Object.fromEntries(Object.keys(dependencies).map((depName) => [depName, publishDependencies[depName]]))
 }
 
 async function readAndCheckManifest (depName: string, dependencyDir: string): Promise<ProjectManifest> {

--- a/pnpm11/releasing/exportable-manifest/test/dependencyOrder.test.ts
+++ b/pnpm11/releasing/exportable-manifest/test/dependencyOrder.test.ts
@@ -1,0 +1,70 @@
+import path from 'node:path'
+
+import { expect, jest, test } from '@jest/globals'
+import type { ProjectManifest } from '@pnpm/types'
+
+interface Deferred<T> {
+  promise: Promise<T>
+  resolve: (value: T) => void
+}
+
+type ManifestRead = { manifest: ProjectManifest }
+
+const reads = new Map<string, Deferred<ManifestRead>>()
+const completionOrder: string[] = []
+
+const tryReadProjectManifest = jest.fn(async (dependencyDir: string): Promise<ManifestRead> => {
+  const name = path.basename(dependencyDir)
+  const read = reads.get(name)
+  if (read == null) throw new Error(`Unexpected dependency: ${name}`)
+  const result = await read.promise
+  completionOrder.push(name)
+  return result
+})
+
+jest.unstable_mockModule('@pnpm/workspace.project-manifest-reader', () => ({
+  tryReadProjectManifest,
+}))
+
+const { createExportableManifest } = await import('@pnpm/releasing.exportable-manifest')
+
+test('workspace dependencies preserve declaration order when manifest reads resolve out of order', async () => {
+  const first = deferred<ManifestRead>()
+  const second = deferred<ManifestRead>()
+  reads.set('first', first)
+  reads.set('second', second)
+
+  const resultPromise = createExportableManifest(path.resolve('project'), {
+    name: 'project',
+    version: '1.0.0',
+    dependencies: {
+      first: 'workspace:*',
+      second: 'workspace:*',
+    },
+  }, {
+    catalogs: {},
+    modulesDir: path.resolve('node_modules'),
+  })
+
+  second.resolve({ manifest: { name: 'second', version: '2.0.0' } })
+  await new Promise<void>((resolve) => setImmediate(resolve))
+  expect(completionOrder).toStrictEqual(['second'])
+
+  first.resolve({ manifest: { name: 'first', version: '1.0.0' } })
+  const result = await resultPromise
+
+  expect(completionOrder).toStrictEqual(['second', 'first'])
+  expect(Object.keys(result.dependencies ?? {})).toStrictEqual(['first', 'second'])
+  expect(result.dependencies).toStrictEqual({
+    first: '1.0.0',
+    second: '2.0.0',
+  })
+})
+
+function deferred<T> (): Deferred<T> {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}

--- a/pnpm11/releasing/exportable-manifest/test/dependencyOrder.test.ts
+++ b/pnpm11/releasing/exportable-manifest/test/dependencyOrder.test.ts
@@ -1,6 +1,7 @@
 import path from 'node:path'
+import { setImmediate as tick } from 'node:timers/promises'
 
-import { expect, jest, test } from '@jest/globals'
+import { beforeEach, expect, jest, test } from '@jest/globals'
 import type { ProjectManifest } from '@pnpm/types'
 
 interface Deferred<T> {
@@ -8,7 +9,9 @@ interface Deferred<T> {
   resolve: (value: T) => void
 }
 
-type ManifestRead = { manifest: ProjectManifest }
+interface ManifestRead {
+  manifest: ProjectManifest
+}
 
 const reads = new Map<string, Deferred<ManifestRead>>()
 const completionOrder: string[] = []
@@ -27,6 +30,12 @@ jest.unstable_mockModule('@pnpm/workspace.project-manifest-reader', () => ({
 }))
 
 const { createExportableManifest } = await import('@pnpm/releasing.exportable-manifest')
+
+beforeEach(() => {
+  reads.clear()
+  completionOrder.length = 0
+  tryReadProjectManifest.mockClear()
+})
 
 test('workspace dependencies preserve declaration order when manifest reads resolve out of order', async () => {
   const first = deferred<ManifestRead>()
@@ -47,7 +56,7 @@ test('workspace dependencies preserve declaration order when manifest reads reso
   })
 
   second.resolve({ manifest: { name: 'second', version: '2.0.0' } })
-  await new Promise<void>((resolve) => setImmediate(resolve))
+  await tick()
   expect(completionOrder).toStrictEqual(['second'])
 
   first.resolve({ manifest: { name: 'first', version: '1.0.0' } })


### PR DESCRIPTION
## Summary

`p-map-values` records converted dependencies when each asynchronous mapper resolves. Resolving multiple `workspace:` dependencies can therefore change their key order between runs, which makes unchanged packed manifests produce different tarball bytes.

This keeps the concurrent conversion and rebuilds the result in the source manifest's dependency order. The Rust `pnpm/` port already inserts converted dependencies synchronously in source order, so it needs no matching production change.

Fixes pnpm/pnpm#10167.

## Squash Commit Body

```text
Workspace dependency manifests are read concurrently during packing. The converted dependency object was assembled in read-completion order, so identical inputs could serialize with different key orders.

Rebuild converted dependencies in their source manifest order after all conversions complete. This retains concurrency while making the generated package manifest deterministic.

Fixes pnpm/pnpm#10167.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13751"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788927974&installation_model_id=426870&pr_number=13751&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13751&signature=94816d7d94c879f079d910e52ff9ca84d43683e64022d54ddf32bf0df04b36a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed packed workspace manifests so dependencies retain their declared order, even when resolution completes in a different order.
  - Repeated `pnpm pack` operations now produce deterministic manifest output, with workspace dependency versions preserved correctly.
  - Improved consistency when workspace dependencies are resolved asynchronously.

- **Tests**
  - Added coverage for dependency ordering and resolved workspace versions in exported manifests.
  - Added regression checks for consistent output when dependency resolution completes out of order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->