### PR TITLE
fix(deps-resolver): scope the preserve-workspace-link guard to dedupeInjectedDeps

### DIFF
--- a/.changeset/deploy-injects-workspace-packages-again.md
+++ b/.changeset/deploy-injects-workspace-packages-again.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.deps-resolver": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+`pnpm deploy` injects workspace dependencies again, so the deploy directory is self-contained instead of symlinking back into the source workspace [#13754](https://github.com/pnpm/pnpm/issues/13754). Enabling `injectWorkspacePackages` with `dedupeInjectedDeps` disabled now also rewrites already-linked workspace dependencies to injected copies.

--- a/pnpm/crates/cli/tests/suite/dedupe_injected_deps.rs
+++ b/pnpm/crates/cli/tests/suite/dedupe_injected_deps.rs
@@ -284,16 +284,10 @@ fn injected_peer_suffixed_workspace_dep_stays_file_after_remove() {
     drop((root, mock_instance));
 }
 
-/// Injecting a workspace dep that a previous install recorded as
-/// `link:../b`, with `dedupeInjectedDeps: false`. The pnpm/pnpm#10433
-/// guard preserves an untargeted dep's prior `link:`, but it only
-/// compensates for the dedupe pass not running on every re-resolution
-/// path — with that pass off, nothing may collapse an injected dep back
-/// to `link:`, so the recorded entry is stale and the fresh `file:` has
-/// to win. `pnpm deploy` disables dedupe and injects every workspace
-/// dependency, so the guard leaking into this case left the deployed
-/// directory symlinked into the workspace it was built from
-/// (pnpm/pnpm#13754).
+/// The pnpm/pnpm#10433 guard preserves an untargeted workspace dep's
+/// prior `link:`, but it only compensates for the dedupe pass not
+/// running on every re-resolution path — with that pass off the recorded
+/// entry is stale (pnpm/pnpm#13754).
 #[test]
 fn newly_injected_workspace_dep_with_dedupe_off_replaces_recorded_link() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =

--- a/pnpm/crates/cli/tests/suite/dedupe_injected_deps.rs
+++ b/pnpm/crates/cli/tests/suite/dedupe_injected_deps.rs
@@ -287,7 +287,7 @@ fn injected_peer_suffixed_workspace_dep_stays_file_after_remove() {
 /// The pnpm/pnpm#10433 guard preserves an untargeted workspace dep's
 /// prior `link:`, but it only compensates for the dedupe pass not
 /// running on every re-resolution path — with that pass off the recorded
-/// entry is stale.
+/// entry is stale. Regression test for pnpm/pnpm#13754.
 #[test]
 fn newly_injected_workspace_dep_with_dedupe_off_replaces_recorded_link() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =

--- a/pnpm/crates/cli/tests/suite/dedupe_injected_deps.rs
+++ b/pnpm/crates/cli/tests/suite/dedupe_injected_deps.rs
@@ -287,7 +287,7 @@ fn injected_peer_suffixed_workspace_dep_stays_file_after_remove() {
 /// The pnpm/pnpm#10433 guard preserves an untargeted workspace dep's
 /// prior `link:`, but it only compensates for the dedupe pass not
 /// running on every re-resolution path — with that pass off the recorded
-/// entry is stale (pnpm/pnpm#13754).
+/// entry is stale.
 #[test]
 fn newly_injected_workspace_dep_with_dedupe_off_replaces_recorded_link() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =

--- a/pnpm/crates/cli/tests/suite/dedupe_injected_deps.rs
+++ b/pnpm/crates/cli/tests/suite/dedupe_injected_deps.rs
@@ -7,7 +7,7 @@
 
 use crate::_utils;
 
-use _utils::enable_gvs_in_workspace_yaml;
+use _utils::{enable_gvs_in_workspace_yaml, pacquet_in};
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pacquet_testing_utils::{
@@ -279,6 +279,104 @@ fn injected_peer_suffixed_workspace_dep_stays_file_after_remove() {
     assert!(
         !lockfile.contains("link:../b"),
         "remove must not collapse the peer-suffixed injected dep to link:../b:\n{lockfile}",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// Injecting a workspace dep that a previous install recorded as
+/// `link:../b`, with `dedupeInjectedDeps: false`. The pnpm/pnpm#10433
+/// guard preserves an untargeted dep's prior `link:`, but it only
+/// compensates for the dedupe pass not running on every re-resolution
+/// path — with that pass off, nothing may collapse an injected dep back
+/// to `link:`, so the recorded entry is stale and the fresh `file:` has
+/// to win. `pnpm deploy` disables dedupe and injects every workspace
+/// dependency, so the guard leaking into this case left the deployed
+/// directory symlinked into the workspace it was built from
+/// (pnpm/pnpm#13754).
+#[test]
+fn newly_injected_workspace_dep_with_dedupe_off_replaces_recorded_link() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "name": "ws-root", "version": "0.0.0", "private": true }).to_string(),
+    )
+    .expect("write root package.json");
+
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    if !workspace_yaml.ends_with('\n') {
+        workspace_yaml.push('\n');
+    }
+    workspace_yaml.push_str("packages:\n  - 'packages/*'\ndedupeInjectedDeps: false\n");
+    fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
+
+    let a_manifest_path = workspace.join("packages/a/package.json");
+    fs::create_dir_all(workspace.join("packages/a")).expect("mkdir packages/a");
+    fs::write(
+        &a_manifest_path,
+        serde_json::json!({
+            "name": "a",
+            "version": "1.0.0",
+            "dependencies": { "b": "workspace:*" },
+        })
+        .to_string(),
+    )
+    .expect("write packages/a/package.json");
+
+    fs::create_dir_all(workspace.join("packages/b")).expect("mkdir packages/b");
+    fs::write(
+        workspace.join("packages/b/package.json"),
+        serde_json::json!({ "name": "b", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write packages/b/package.json");
+
+    pacquet.with_arg("install").assert().success();
+
+    let lockfile_path = workspace.join("pnpm-lock.yaml");
+    let lockfile = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
+    assert!(
+        lockfile.contains("link:../b"),
+        "the plain install should record b as link:../b under packages/a:\n{lockfile}",
+    );
+
+    fs::write(
+        &a_manifest_path,
+        serde_json::json!({
+            "name": "a",
+            "version": "1.0.0",
+            "dependencies": { "b": "workspace:*" },
+            "dependenciesMeta": { "b": { "injected": true } },
+        })
+        .to_string(),
+    )
+    .expect("rewrite packages/a/package.json");
+
+    pacquet_in(&workspace).with_arg("install").assert().success();
+
+    let lockfile = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
+    assert!(
+        lockfile.contains("file:packages/b"),
+        "the injected install should record b as file:packages/b under packages/a:\n{lockfile}",
+    );
+    assert!(
+        !lockfile.contains("link:../b"),
+        "the injected install must not keep the stale link:../b entry:\n{lockfile}",
+    );
+
+    let dep = workspace.join("packages/a/node_modules/b");
+    assert!(
+        dep.join("package.json").is_file(),
+        "packages/a/node_modules/b should resolve to a materialised virtual-store slot",
+    );
+    assert_ne!(
+        fs::canonicalize(&dep).expect("canonicalize packages/a/node_modules/b"),
+        fs::canonicalize(workspace.join("packages/b")).expect("canonicalize packages/b"),
+        "packages/a/node_modules/b should be an injected copy, not the source project",
     );
 
     drop((root, mock_instance));

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -120,7 +120,8 @@ pub struct GraphToLockfileOptions<'a> {
     /// [`Self::importers`]. Used to preserve a workspace dependency's
     /// prior `link:` entry when this install does not target it — see
     /// `build_importer` and pnpm/pnpm#10433. `None` when there is no
-    /// previous lockfile (a first install).
+    /// previous lockfile (a first install), and when `dedupeInjectedDeps`
+    /// is off, which disables the guard entirely (pnpm/pnpm#13754).
     pub previous_importers: Option<&'a HashMap<String, ProjectSnapshot>>,
     /// How this install reuses the prior resolution, mapped from the
     /// `pacquet update` seed policy. Together with a spec change it
@@ -385,12 +386,13 @@ fn build_importer(
         };
         // pnpm/pnpm#10433: a fresh-lockfile install re-resolves every
         // importer, and an injected workspace dependency whose peer context
-        // genuinely diverges (or with `dedupeInjectedDeps` off) reaches
-        // `importer_dep_version`'s `file:` arm instead of deduping back to
-        // `link:`. When this install does not *target* that dependency, keep
-        // its previous `link:` importer entry rather than rewriting it to a
-        // peer-suffixed `file:`. `dedupe_injected_deps` runs earlier in the
-        // resolver and does not reach this finalization path.
+        // genuinely diverges reaches `importer_dep_version`'s `file:` arm
+        // instead of deduping back to `link:`. When this install does not
+        // *target* that dependency, keep its previous `link:` importer entry
+        // rather than rewriting it to a peer-suffixed `file:`.
+        // `dedupe_injected_deps` runs earlier in the resolver and does not
+        // reach this finalization path; when that pass is off there is nothing
+        // to compensate for and the caller withholds `previous_importer`.
         if let ImporterDepVersion::File(_) = &version
             && let Some(previous) =
                 previous_importer.and_then(|prev| previous_importer_dep(prev, &name_for_key))

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -120,8 +120,8 @@ pub struct GraphToLockfileOptions<'a> {
     /// [`Self::importers`]. Used to preserve a workspace dependency's
     /// prior `link:` entry when this install does not target it — see
     /// `build_importer` and pnpm/pnpm#10433. `None` when there is no
-    /// previous lockfile (a first install), and when `dedupeInjectedDeps`
-    /// is off, which disables the guard entirely (pnpm/pnpm#13754).
+    /// previous lockfile (a first install) or when `dedupeInjectedDeps`
+    /// is off.
     pub previous_importers: Option<&'a HashMap<String, ProjectSnapshot>>,
     /// How this install reuses the prior resolution, mapped from the
     /// `pacquet update` seed policy. Together with a spec change it
@@ -391,8 +391,7 @@ fn build_importer(
         // *target* that dependency, keep its previous `link:` importer entry
         // rather than rewriting it to a peer-suffixed `file:`.
         // `dedupe_injected_deps` runs earlier in the resolver and does not
-        // reach this finalization path; when that pass is off there is nothing
-        // to compensate for and the caller withholds `previous_importer`.
+        // reach this finalization path.
         if let ImporterDepVersion::File(_) = &version
             && let Some(previous) =
                 previous_importer.and_then(|prev| previous_importer_dep(prev, &name_for_key))

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -925,8 +925,17 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         // entries and this run's final update scope, but `update_reuse_scope`
         // is moved into the resolver options below and `wanted_lockfile` is
         // later shadowed by the freshly built lockfile.
+        //
+        // Withheld when `dedupe_injected_deps` is off: the guard exists only to
+        // compensate for that pass not running on every re-resolution path, and
+        // with it off no run may turn an injected workspace dependency back
+        // into a `link:`, so a recorded `link:` is stale and the freshly
+        // resolved `file:` has to win. `pacquet deploy` depends on this to
+        // produce a self-contained directory (pnpm/pnpm#13754).
         let guard_previous_importers: Option<&HashMap<String, pacquet_lockfile::ProjectSnapshot>> =
-            wanted_lockfile.map(|lockfile| &lockfile.importers);
+            wanted_lockfile
+                .filter(|_| config.dedupe_injected_deps)
+                .map(|lockfile| &lockfile.importers);
         let guard_update_reuse_scope = update_reuse_scope.clone();
         let guard_update_reuse_scopes_by_importer = update_reuse_scopes_by_importer.clone();
 

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -926,12 +926,9 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         // is moved into the resolver options below and `wanted_lockfile` is
         // later shadowed by the freshly built lockfile.
         //
-        // Withheld when `dedupe_injected_deps` is off: the guard exists only to
-        // compensate for that pass not running on every re-resolution path, and
-        // with it off no run may turn an injected workspace dependency back
-        // into a `link:`, so a recorded `link:` is stale and the freshly
-        // resolved `file:` has to win. `pacquet deploy` depends on this to
-        // produce a self-contained directory (pnpm/pnpm#13754).
+        // Withheld when `dedupe_injected_deps` is off: the guard only
+        // compensates for that pass not running on every re-resolution path, so
+        // with it off a recorded `link:` is stale (pnpm/pnpm#13754).
         let guard_previous_importers: Option<&HashMap<String, pacquet_lockfile::ProjectSnapshot>> =
             wanted_lockfile
                 .filter(|_| config.dedupe_injected_deps)

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -925,10 +925,8 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         // entries and this run's final update scope, but `update_reuse_scope`
         // is moved into the resolver options below and `wanted_lockfile` is
         // later shadowed by the freshly built lockfile.
-        //
-        // Withheld when `dedupe_injected_deps` is off: the guard only
-        // compensates for that pass not running on every re-resolution path, so
-        // with it off a recorded `link:` is stale (pnpm/pnpm#13754).
+        // Withheld when `dedupe_injected_deps` is off, since the guard only
+        // compensates for that pass not running on every re-resolution path.
         let guard_previous_importers: Option<&HashMap<String, pacquet_lockfile::ProjectSnapshot>> =
             wanted_lockfile
                 .filter(|_| config.dedupe_injected_deps)

--- a/pnpm11/installing/deps-installer/test/install/injectWorkspacePackagesPersistence.test.ts
+++ b/pnpm11/installing/deps-installer/test/install/injectWorkspacePackagesPersistence.test.ts
@@ -110,11 +110,8 @@ test('workspace packages should maintain link: protocol after single-project pnp
 })
 
 // The guard that preserves a prior `link:` only compensates for
-// dedupeInjectedDeps not running on every re-resolution path. With
-// dedupeInjectedDeps off nothing may turn an injected workspace dependency back
-// into a `link:`, so the freshly resolved `file:` has to win — this is what
-// `pnpm deploy` relies on to produce a self-contained directory
-// (https://github.com/pnpm/pnpm/issues/13754).
+// dedupeInjectedDeps not running on every re-resolution path, so with that pass
+// off a recorded `link:` is stale (https://github.com/pnpm/pnpm/issues/13754).
 test('workspace packages switch to file: protocol when injected with dedupeInjectedDeps disabled', async () => {
   const projectAManifest = {
     name: 'a',

--- a/pnpm11/installing/deps-installer/test/install/injectWorkspacePackagesPersistence.test.ts
+++ b/pnpm11/installing/deps-installer/test/install/injectWorkspacePackagesPersistence.test.ts
@@ -109,6 +109,61 @@ test('workspace packages should maintain link: protocol after single-project pnp
   expect(lockfileAfterRm.importers.a.dependencies!.b.version).toBe('link:../b')
 })
 
+// The guard that preserves a prior `link:` only compensates for
+// dedupeInjectedDeps not running on every re-resolution path. With
+// dedupeInjectedDeps off nothing may turn an injected workspace dependency back
+// into a `link:`, so the freshly resolved `file:` has to win — this is what
+// `pnpm deploy` relies on to produce a self-contained directory
+// (https://github.com/pnpm/pnpm/issues/13754).
+test('workspace packages switch to file: protocol when injected with dedupeInjectedDeps disabled', async () => {
+  const projectAManifest = {
+    name: 'a',
+    version: '1.0.0',
+    dependencies: {
+      b: 'workspace:*',
+    },
+  }
+  const projectBManifest = {
+    name: 'b',
+    version: '1.0.0',
+  }
+
+  preparePackages([
+    { location: 'a', package: projectAManifest },
+    { location: 'b', package: projectBManifest },
+  ])
+
+  const allProjects: ProjectOptions[] = [
+    {
+      buildIndex: 0,
+      manifest: projectAManifest,
+      rootDir: path.resolve('a') as ProjectRootDir,
+    },
+    {
+      buildIndex: 0,
+      manifest: projectBManifest,
+      rootDir: path.resolve('b') as ProjectRootDir,
+    },
+  ]
+  const mutations = allProjects.map(({ rootDir }) => ({ mutation: 'install' as const, rootDir }))
+
+  await mutateModules(mutations, testDefaults({
+    allProjects,
+    dedupeInjectedDeps: false,
+  }))
+
+  const rootModules = assertProject(process.cwd())
+  expect(rootModules.readLockfile().importers.a.dependencies!.b.version).toBe('link:../b')
+
+  await mutateModules(mutations, testDefaults({
+    allProjects,
+    dedupeInjectedDeps: false,
+    injectWorkspacePackages: true,
+  }))
+
+  expect(rootModules.readLockfile().importers.a.dependencies!.b.version).toBe('file:b')
+})
+
 test('workspace packages with their own dependencies should maintain link: protocol after single-project pnpm rm with injectWorkspacePackages', async () => {
   const projectAManifest: { name: string, version: string, dependencies: Record<string, string> } = {
     name: 'a',

--- a/pnpm11/installing/deps-installer/test/install/injectWorkspacePackagesPersistence.test.ts
+++ b/pnpm11/installing/deps-installer/test/install/injectWorkspacePackagesPersistence.test.ts
@@ -112,6 +112,7 @@ test('workspace packages should maintain link: protocol after single-project pnp
 // The guard that preserves a prior `link:` only compensates for
 // dedupeInjectedDeps not running on every re-resolution path, so with that pass
 // off a recorded `link:` is stale.
+// Regression test for https://github.com/pnpm/pnpm/issues/13754
 test('workspace packages switch to file: protocol when injected with dedupeInjectedDeps disabled', async () => {
   const projectAManifest = {
     name: 'a',

--- a/pnpm11/installing/deps-installer/test/install/injectWorkspacePackagesPersistence.test.ts
+++ b/pnpm11/installing/deps-installer/test/install/injectWorkspacePackagesPersistence.test.ts
@@ -111,7 +111,7 @@ test('workspace packages should maintain link: protocol after single-project pnp
 
 // The guard that preserves a prior `link:` only compensates for
 // dedupeInjectedDeps not running on every re-resolution path, so with that pass
-// off a recorded `link:` is stale (https://github.com/pnpm/pnpm/issues/13754).
+// off a recorded `link:` is stale.
 test('workspace packages switch to file: protocol when injected with dedupeInjectedDeps disabled', async () => {
   const projectAManifest = {
     name: 'a',

--- a/pnpm11/installing/deps-resolver/src/index.ts
+++ b/pnpm11/installing/deps-resolver/src/index.ts
@@ -304,9 +304,6 @@ export async function resolveDependencies (
     })
     : initiallyResolvedPeers
 
-  // The guard below only compensates for dedupeInjectedDeps not running on
-  // every re-resolution path, so with that pass off a recorded `link:` is
-  // stale. See pnpm/pnpm#13754.
   const preserveDedupedWorkspaceLinks = Boolean(opts.dedupeInjectedDeps)
   const linkedDependenciesByProjectId: Record<string, LinkedDependency[]> = {}
   await Promise.all(projectsToResolve.map(async (project, index) => {

--- a/pnpm11/installing/deps-resolver/src/index.ts
+++ b/pnpm11/installing/deps-resolver/src/index.ts
@@ -304,6 +304,13 @@ export async function resolveDependencies (
     })
     : initiallyResolvedPeers
 
+  // The guard below only compensates for dedupeInjectedDeps not running on
+  // every re-resolution path. With dedupeInjectedDeps off, no run may turn an
+  // injected workspace dependency into a `link:`, so a previously recorded
+  // `link:` is stale and the freshly resolved `file:` must win. `pnpm deploy`
+  // relies on this: it injects every workspace dependency with
+  // dedupeInjectedDeps disabled so the deployed directory is self-contained.
+  const preserveDedupedWorkspaceLinks = Boolean(opts.dedupeInjectedDeps)
   const linkedDependenciesByProjectId: Record<string, LinkedDependency[]> = {}
   await Promise.all(projectsToResolve.map(async (project, index) => {
     const resolvedImporter = resolvedImporters[project.id]
@@ -396,7 +403,7 @@ export async function resolveDependencies (
       const previousRef = previousDirectRefs[alias]
       const targetedByUpdate = updateTargetedAliases.has(alias) ||
         (updateMatching?.(depNode.name) ?? false)
-      if (!targetedByUpdate && ref.startsWith('file:') && previousRef?.startsWith('link:')) {
+      if (preserveDedupedWorkspaceLinks && !targetedByUpdate && ref.startsWith('file:') && previousRef?.startsWith('link:')) {
         ref = previousRef
       }
       if (projectSnapshot.dependencies?.[alias]) {

--- a/pnpm11/installing/deps-resolver/src/index.ts
+++ b/pnpm11/installing/deps-resolver/src/index.ts
@@ -305,11 +305,8 @@ export async function resolveDependencies (
     : initiallyResolvedPeers
 
   // The guard below only compensates for dedupeInjectedDeps not running on
-  // every re-resolution path. With dedupeInjectedDeps off, no run may turn an
-  // injected workspace dependency into a `link:`, so a previously recorded
-  // `link:` is stale and the freshly resolved `file:` must win. `pnpm deploy`
-  // relies on this: it injects every workspace dependency with
-  // dedupeInjectedDeps disabled so the deployed directory is self-contained.
+  // every re-resolution path, so with that pass off a recorded `link:` is
+  // stale. See pnpm/pnpm#13754.
   const preserveDedupedWorkspaceLinks = Boolean(opts.dedupeInjectedDeps)
   const linkedDependenciesByProjectId: Record<string, LinkedDependency[]> = {}
   await Promise.all(projectsToResolve.map(async (project, index) => {

--- a/pnpm11/releasing/commands/test/deploy/deploy.test.ts
+++ b/pnpm11/releasing/commands/test/deploy/deploy.test.ts
@@ -106,6 +106,68 @@ test('deploy without existing lockfile', async () => {
   expect(fs.existsSync('pnpm-lock.yaml')).toBeFalsy() // no changes to the lockfile are written
 })
 
+// Regression test for https://github.com/pnpm/pnpm/issues/13754
+// The legacy deploy injects every workspace dependency, so the deployed
+// directory must not reference the workspace it was built from, even though the
+// shared lockfile it re-resolves records those dependencies as `link:`.
+test('legacy deploy injects workspace dependencies that the shared lockfile links', async () => {
+  preparePackages([
+    {
+      location: '.',
+      package: {
+        name: 'root',
+        version: '1.0.0',
+        private: true,
+      },
+    },
+    {
+      name: 'project-1',
+      version: '1.0.0',
+      dependencies: {
+        'project-2': 'workspace:*',
+      },
+    },
+    {
+      name: 'project-2',
+      version: '1.0.0',
+    },
+  ])
+
+  const { allProjects, selectedProjectsGraph } = await filterProjectsBySelectorObjectsFromDir(process.cwd(), [{ namePattern: 'project-1' }])
+
+  await install.handler({
+    ...DEFAULT_OPTS,
+    allProjects,
+    dir: process.cwd(),
+    dev: true,
+    injectWorkspacePackages: false,
+    production: true,
+    sharedWorkspaceLockfile: true,
+    lockfileDir: process.cwd(),
+    workspaceDir: process.cwd(),
+  })
+  expect(assertProject(process.cwd()).readLockfile().importers['project-1'].dependencies['project-2'].version).toBe('link:../project-2')
+
+  await deploy.handler({
+    ...DEFAULT_OPTS,
+    allProjects,
+    dir: process.cwd(),
+    dev: false,
+    forceLegacyDeploy: true,
+    production: true,
+    recursive: true,
+    selectedProjectsGraph,
+    sharedWorkspaceLockfile: true,
+    lockfileDir: process.cwd(),
+    workspaceDir: process.cwd(),
+  }, ['deploy'])
+
+  const deployDir = path.resolve('deploy')
+  expect(fs.realpathSync(path.join(deployDir, 'node_modules/project-2'))).toBe(
+    path.join(deployDir, 'node_modules/.pnpm/project-2@file+project-2/node_modules/project-2')
+  )
+})
+
 test('deploy in workspace with shared-workspace-lockfile=false', async () => {
   preparePackages([
     {

--- a/pnpm11/releasing/commands/test/deploy/deploy.test.ts
+++ b/pnpm11/releasing/commands/test/deploy/deploy.test.ts
@@ -106,6 +106,7 @@ test('deploy without existing lockfile', async () => {
   expect(fs.existsSync('pnpm-lock.yaml')).toBeFalsy() // no changes to the lockfile are written
 })
 
+// Regression test for https://github.com/pnpm/pnpm/issues/13754
 test('legacy deploy injects workspace dependencies that the shared lockfile links', async () => {
   preparePackages([
     {

--- a/pnpm11/releasing/commands/test/deploy/deploy.test.ts
+++ b/pnpm11/releasing/commands/test/deploy/deploy.test.ts
@@ -107,9 +107,6 @@ test('deploy without existing lockfile', async () => {
 })
 
 // Regression test for https://github.com/pnpm/pnpm/issues/13754
-// The legacy deploy injects every workspace dependency, so the deployed
-// directory must not reference the workspace it was built from, even though the
-// shared lockfile it re-resolves records those dependencies as `link:`.
 test('legacy deploy injects workspace dependencies that the shared lockfile links', async () => {
   preparePackages([
     {

--- a/pnpm11/releasing/commands/test/deploy/deploy.test.ts
+++ b/pnpm11/releasing/commands/test/deploy/deploy.test.ts
@@ -106,7 +106,6 @@ test('deploy without existing lockfile', async () => {
   expect(fs.existsSync('pnpm-lock.yaml')).toBeFalsy() // no changes to the lockfile are written
 })
 
-// Regression test for https://github.com/pnpm/pnpm/issues/13754
 test('legacy deploy injects workspace dependencies that the shared lockfile links', async () => {
   preparePackages([
     {

--- a/pnpm11/releasing/commands/test/deploy/deploy.test.ts
+++ b/pnpm11/releasing/commands/test/deploy/deploy.test.ts
@@ -146,7 +146,7 @@ test('legacy deploy injects workspace dependencies that the shared lockfile link
     lockfileDir: process.cwd(),
     workspaceDir: process.cwd(),
   })
-  expect(assertProject(process.cwd()).readLockfile().importers['project-1'].dependencies['project-2'].version).toBe('link:../project-2')
+  expect(assertProject(process.cwd()).readLockfile().importers['project-1'].dependencies!['project-2'].version).toBe('link:../project-2')
 
   await deploy.handler({
     ...DEFAULT_OPTS,


### PR DESCRIPTION
## Summary

Since 11.19.0, `pnpm deploy` symlinked workspace dependencies back into the source workspace instead of injecting copies, so the deploy directory stopped being self-contained — copying it elsewhere (a Dockerfile `COPY`, a tarball, an artifact upload) left dangling symlinks. Neither `forceLegacyDeploy: true` nor `injectWorkspacePackages: true` restored the old behaviour.

The cause is the pnpm/pnpm#10433 guard added in pnpm/pnpm#13112. It keeps a workspace dependency's previously recorded `link:` when the run does not target it, compensating for `dedupeInjectedDeps` not running on every re-resolution path. The guard fired regardless of whether that pass was enabled — and `pnpm deploy` is exactly the configuration where it must not: deploy injects every workspace dependency (`deployHook` sets `dependenciesMeta[...].injected`) and disables `dedupeInjectedDeps` so the deployed tree is self-contained. The freshly resolved `file:` importer entry was rewritten back to the workspace lockfile's stale `link:`, which then propagated into the deploy directory's `node_modules`.

This PR gates the guard on `dedupeInjectedDeps`. With that pass off nothing may turn an injected workspace dependency back into a `link:`, so a recorded `link:` is stale and the fresh `file:` has to win.

The same hole existed outside deploy: enabling `injectWorkspacePackages` with `dedupeInjectedDeps: false` on a workspace whose lockfile already recorded `link:` never switched those dependencies to injected copies. Verified against both binaries before and after.

It also fixes pnpm/pnpm#13618, the same regression reported against a workspace dependency that carries `peerDependencies`. Its exact reproduction now yields the expected `readlink deploy/node_modules/shared` → `.pnpm/shared@file+packages+shared_ms@2.1.3/node_modules/shared`.

Closes pnpm/pnpm#13754
Closes pnpm/pnpm#13618

## Squash Commit Body

```text
The pnpm/pnpm#10433 guard keeps a workspace dependency's previously recorded
`link:` when the run doesn't target it, compensating for `dedupeInjectedDeps`
not running on every re-resolution path. It fired regardless of whether that
pass was enabled, so with it disabled a freshly resolved `file:` was rewritten
back to a stale `link:`.

`pnpm deploy` is exactly that configuration: it injects every workspace
dependency and disables `dedupeInjectedDeps` so the deployed tree is
self-contained. Since 11.19.0 the deploy directory instead symlinked its
workspace dependencies back into the source workspace, so copying it elsewhere
left dangling links. Enabling `injectWorkspacePackages` with
`dedupeInjectedDeps` off had the same problem: already-linked workspace
dependencies never switched to injected copies.

Gate the guard on `dedupeInjectedDeps`; with the pass off nothing may turn an
injected workspace dependency back into a `link:`, so the fresh `file:` has to
win. The pacquet side withholds the previous importers from its lockfile
builder for the same reason — its `deploy` was already unaffected (it resolves
the deploy dir as a new importer with no previous entry), but the
`injectWorkspacePackages` toggle reproduced there too.

Closes pnpm/pnpm#13754
Closes pnpm/pnpm#13618
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `pnpm deploy` so injected workspace dependencies are included in the deploy directory when workspace injection is enabled.
  - Ensured workspace links are rewritten to deployed package copies when dependency deduplication is disabled.
  - Improved repeated installs to update stale workspace references and maintain accurate lockfile entries.
  - Fixed legacy deployments so dependencies resolve within the deploy directory.

- **Tests**
  - Added regression coverage for injected dependencies, repeated installs, lockfile updates, and deployment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->