### PR TITLE
fix(git-fetcher): say which dependency a git clone failed for, and how to fix it

### DIFF
--- a/.changeset/git-fetch-failure-hint.md
+++ b/.changeset/git-fetch-failure-hint.md
@@ -5,4 +5,4 @@
 "pnpm": patch
 ---
 
-A git dependency that fails to clone now reports which package it belongs to, under the `ERR_PNPM_GIT_FETCH_FAILED` code, with credentials in the repository URL redacted. When the lockfile records an SSH remote, the error also explains that fetching it needs an SSH key for that host, and that a lockfile entry written before pnpm v11.21 can be re-recorded over HTTPS with `pnpm update <package>` [#13743](https://github.com/pnpm/pnpm/issues/13743).
+A git dependency whose clone (or shallow fetch) fails now reports which package it belongs to, under the `ERR_PNPM_GIT_FETCH_FAILED` code, with credentials in the repository URL redacted. When the lockfile records an SSH remote, the error also explains that fetching it needs an SSH key for that host, and that a lockfile entry written before pnpm v11.21 can be re-recorded over HTTPS with `pnpm update <package>` [#13743](https://github.com/pnpm/pnpm/issues/13743).

--- a/.changeset/git-fetch-failure-hint.md
+++ b/.changeset/git-fetch-failure-hint.md
@@ -1,7 +1,8 @@
 ---
 "@pnpm/fetching.git-fetcher": patch
+"@pnpm/error": patch
 "pacquet": patch
 "pnpm": patch
 ---
 
-A git dependency that fails to clone now reports which package it belongs to, under the `ERR_PNPM_GIT_FETCH_FAILED` code. When the lockfile records an SSH remote, the error also explains that fetching it needs an SSH key for that host, and that a lockfile entry written before pnpm v11.21 can be re-recorded over HTTPS with `pnpm update <package>` [#13743](https://github.com/pnpm/pnpm/issues/13743).
+A git dependency that fails to clone now reports which package it belongs to, under the `ERR_PNPM_GIT_FETCH_FAILED` code, with credentials in the repository URL redacted. When the lockfile records an SSH remote, the error also explains that fetching it needs an SSH key for that host, and that a lockfile entry written before pnpm v11.21 can be re-recorded over HTTPS with `pnpm update <package>` [#13743](https://github.com/pnpm/pnpm/issues/13743).

--- a/.changeset/git-fetch-failure-hint.md
+++ b/.changeset/git-fetch-failure-hint.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/fetching.git-fetcher": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+A git dependency that fails to clone now reports which package it belongs to, under the `ERR_PNPM_GIT_FETCH_FAILED` code. When the lockfile records an SSH remote, the error also explains that fetching it needs an SSH key for that host, and that a lockfile entry written before pnpm v11.21 can be re-recorded over HTTPS with `pnpm update <package>` [#13743](https://github.com/pnpm/pnpm/issues/13743).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4461,6 +4461,7 @@ dependencies = [
  "pacquet-executor",
  "pacquet-fs",
  "pacquet-fs-packlist",
+ "pacquet-network",
  "pacquet-package-manifest",
  "pacquet-reporter",
  "pacquet-store-dir",

--- a/pnpm/crates/deps-restorer/src/install_package_by_snapshot.rs
+++ b/pnpm/crates/deps-restorer/src/install_package_by_snapshot.rs
@@ -604,6 +604,7 @@ impl InstallPackageBySnapshot<'_> {
                 // lock-step with `snapshot_cache_key`.
                 let built = !config.ignore_scripts;
                 let files_index_file = git_hosted_store_index_key(&package_id, built);
+                let package_name = package_key.name.to_string();
                 let GitFetchOutput { cas_paths, built: _built } = GitFetcher {
                     repo: &git_resolution.repo,
                     commit: &git_resolution.commit,
@@ -619,6 +620,7 @@ impl InstallPackageBySnapshot<'_> {
                     npm_execpath: None,
                     store_dir: &config.store_dir,
                     package_id: &package_id,
+                    package_name: &package_name,
                     requester,
                     store_index_writer,
                     files_index_file: &files_index_file,

--- a/pnpm/crates/git-fetcher/Cargo.toml
+++ b/pnpm/crates/git-fetcher/Cargo.toml
@@ -15,6 +15,7 @@ pacquet-diagnostics      = { workspace = true }
 pacquet-executor         = { workspace = true }
 pacquet-fs               = { workspace = true }
 pacquet-fs-packlist      = { workspace = true }
+pacquet-network          = { workspace = true }
 pacquet-package-manifest = { workspace = true }
 pacquet-reporter         = { workspace = true }
 pacquet-store-dir        = { workspace = true }

--- a/pnpm/crates/git-fetcher/src/error.rs
+++ b/pnpm/crates/git-fetcher/src/error.rs
@@ -61,6 +61,39 @@ pub enum GitFetcherError {
     #[diagnostic(code(ERR_PNPM_GIT_FETCHER_GIT_EXEC_FAILED))]
     GitExec { operation: &'static str, stderr: String, status: std::process::ExitStatus },
 
+    /// The clone (or shallow fetch) of a git dependency failed. Carries
+    /// the package the resolution belongs to, which [`Self::GitExec`]
+    /// alone cannot name — a bare `git clone` failure leaves the user to
+    /// work out which of their dependencies it came from.
+    #[display("Failed to fetch {package:?} from the git repository {repo:?}: {stderr}")]
+    #[diagnostic(code(ERR_PNPM_GIT_FETCH_FAILED))]
+    Fetch { package: String, repo: String, stderr: String },
+
+    /// [`Self::Fetch`] for a repository the lockfile pins to an SSH
+    /// remote. Split into its own variant purely so the derived
+    /// `Diagnostic` can carry the remediation `help`, which does not
+    /// apply to a transport that needs no key.
+    ///
+    /// A lockfile written before pnpm v11.21 could record an SSH URL for
+    /// a dependency whose specifier never asked for SSH, and resolution
+    /// is skipped while that lockfile stays up to date — so the entry
+    /// survives the upgrade that fixed it and the install keeps failing
+    /// wherever no SSH key is configured.
+    #[display("Failed to fetch {package:?} from the git repository {repo:?}: {stderr}")]
+    #[diagnostic(
+        code(ERR_PNPM_GIT_FETCH_FAILED),
+        help(
+            r#"The lockfile records an SSH remote for this dependency, so fetching it needs an SSH key for {host}.
+
+If its specifier does not ask for SSH (for example "github:owner/repo"), the lockfile entry was written before pnpm v11.21 and can be re-recorded over HTTPS:
+
+    pnpm update {package}
+
+"pnpm install --force" and "pnpm install --resolution-only" do not re-resolve git dependencies, so neither clears it."#,
+        )
+    )]
+    FetchOverSsh { package: String, repo: String, host: String, stderr: String },
+
     /// `git rev-parse HEAD` did not return the pinned commit, rejected
     /// with the `ERR_PNPM_GIT_CHECKOUT_FAILED` code.
     #[display("received commit {received} does not match expected value {expected}")]

--- a/pnpm/crates/git-fetcher/src/fetcher.rs
+++ b/pnpm/crates/git-fetcher/src/fetcher.rs
@@ -58,6 +58,11 @@ pub struct GitFetcher<'a> {
     /// Matches the `package_id` the rest of the install dispatcher uses
     /// — for a git dep, the bare `git+…#<commit>` id.
     pub package_id: &'a str,
+    /// Name of the package this resolution belongs to, used to say which
+    /// dependency a transport failure came from. Unlike
+    /// [`Self::package_id`], which for a git dep is the bare
+    /// `git+…#<commit>` id and carries no name.
+    pub package_name: &'a str,
     pub requester: &'a str,
     /// Install-scoped store-index writer. When provided, the fetcher
     /// queues a `PackageFilesIndex` row at [`Self::files_index_file`]
@@ -110,7 +115,8 @@ impl GitFetcher<'_> {
             git_shallow_hosts: self.git_shallow_hosts,
             git_bin: self.git_bin,
             dest: temp_location,
-        })?;
+        })
+        .map_err(|err| name_fetch_failure(self.repo, self.package_name, err))?;
 
         // `extra_env` is a borrow rather than `Option<&HashMap>`.
         // Bind an empty map to a local so the borrow has the same lifetime
@@ -184,6 +190,51 @@ impl GitFetcher<'_> {
 
         Ok(GitFetchOutput { cas_paths, built: should_be_built })
     }
+}
+
+/// Restate a failure of the transport-touching part of
+/// [`checkout_commit`] as [`GitFetcherError::Fetch`] — or, when the
+/// lockfile pins an SSH remote, [`GitFetcherError::FetchOverSsh`], which
+/// carries the remediation help.
+///
+/// Only `init` / `remote` / `clone` / `fetch` are restated. A failing
+/// `checkout` or `rev-parse` says nothing about reaching the remote, and
+/// its own error already describes it.
+fn name_fetch_failure(repo: &str, package: &str, err: GitFetcherError) -> GitFetcherError {
+    let GitFetcherError::GitExec {
+        operation: "init" | "remote" | "clone" | "fetch", stderr, ..
+    } = &err
+    else {
+        return err;
+    };
+    let host = ssh_repo_host(repo).map(str::to_string);
+    let (package, repo, stderr) =
+        (package.to_string(), repo.to_string(), stderr.trim().to_string());
+    match host {
+        Some(host) => GitFetcherError::FetchOverSsh { package, repo, host, stderr },
+        None => GitFetcherError::Fetch { package, repo, stderr },
+    }
+}
+
+/// The host an SSH git reference points at, or `None` if `repo` is not one.
+///
+/// Covers the URL form (`[git+]ssh://[user@]host[:port]/path`) and the
+/// scp-style shorthand (`[user@]host:path`) that carries no scheme. The
+/// `user@` is mandatory in the shorthand, which is what keeps a Windows
+/// drive path (`C:\repo`) from being read as a host.
+fn ssh_repo_host(repo: &str) -> Option<&str> {
+    if let Some(rest) = repo.strip_prefix("ssh://").or_else(|| repo.strip_prefix("git+ssh://")) {
+        let authority = rest.split('/').next().unwrap_or(rest);
+        let host = authority.rsplit_once('@').map_or(authority, |(_user, host)| host);
+        let host = host.split_once(':').map_or(host, |(host, _port)| host);
+        return (!host.is_empty()).then_some(host);
+    }
+    if repo.contains("://") {
+        return None;
+    }
+    let (authority, _path) = repo.split_once(':')?;
+    let (_user, host) = authority.rsplit_once('@')?;
+    (!host.is_empty()).then_some(host)
 }
 
 /// Wrap `PreparePackageError` to convey the "Failed to prepare

--- a/pnpm/crates/git-fetcher/src/fetcher.rs
+++ b/pnpm/crates/git-fetcher/src/fetcher.rs
@@ -18,6 +18,7 @@ use crate::{
 };
 use pacquet_executor::ScriptsPrependNodePath;
 use pacquet_fs_packlist::packlist;
+use pacquet_network::{redact_and_sanitize, redact_and_sanitize_multiline};
 use pacquet_package_manifest::safe_read_package_json_from_dir;
 use pacquet_reporter::Reporter;
 use pacquet_store_dir::{PackageFilesIndex, StoreDir, StoreIndexWriter};
@@ -207,9 +208,16 @@ fn name_fetch_failure(repo: &str, package: &str, err: GitFetcherError) -> GitFet
     else {
         return err;
     };
-    let host = ssh_repo_host(repo).map(str::to_string);
-    let (package, repo, stderr) =
-        (package.to_string(), repo.to_string(), stderr.trim().to_string());
+    // Every value is untrusted: a lockfile URL can carry `user:pass@`
+    // credentials, and git echoes it back through stderr. Only the values are
+    // sanitized — `redact_and_sanitize` strips control characters, which would
+    // collapse the deliberately multi-line help.
+    let host = ssh_repo_host(repo).map(redact_and_sanitize);
+    let (package, repo, stderr) = (
+        redact_and_sanitize(package),
+        redact_and_sanitize(repo),
+        redact_and_sanitize_multiline(stderr.trim()),
+    );
     match host {
         Some(host) => GitFetcherError::FetchOverSsh { package, repo, host, stderr },
         None => GitFetcherError::Fetch { package, repo, stderr },
@@ -222,11 +230,19 @@ fn name_fetch_failure(repo: &str, package: &str, err: GitFetcherError) -> GitFet
 /// scp-style shorthand (`[user@]host:path`) that carries no scheme. The
 /// `user@` is mandatory in the shorthand, which is what keeps a Windows
 /// drive path (`C:\repo`) from being read as a host.
+///
+/// An IPv6 literal keeps its brackets, matching what `URL.hostname` hands
+/// the TypeScript CLI for the same reference.
 fn ssh_repo_host(repo: &str) -> Option<&str> {
     if let Some(rest) = repo.strip_prefix("ssh://").or_else(|| repo.strip_prefix("git+ssh://")) {
         let authority = rest.split('/').next().unwrap_or(rest);
         let host = authority.rsplit_once('@').map_or(authority, |(_user, host)| host);
-        let host = host.split_once(':').map_or(host, |(host, _port)| host);
+        // A bracketed IPv6 literal is full of colons, so the port has to be
+        // looked for after the closing bracket rather than at the first colon.
+        let host = match host.split_once(']') {
+            Some((address, _port)) if host.starts_with('[') => &host[..=address.len()],
+            _ => host.split_once(':').map_or(host, |(host, _port)| host),
+        };
         return (!host.is_empty()).then_some(host);
     }
     if repo.contains("://") {

--- a/pnpm/crates/git-fetcher/src/fetcher/tests.rs
+++ b/pnpm/crates/git-fetcher/src/fetcher/tests.rs
@@ -1314,6 +1314,27 @@ async fn a_failed_clone_over_ssh_names_the_package_and_how_to_re_record_it() {
 
 #[cfg(unix)]
 #[tokio::test(flavor = "multi_thread")]
+async fn a_failed_shallow_fetch_is_reported_like_a_failed_clone() {
+    let tmp = tempdir().unwrap();
+    let shim_path = write_failing_git_shim(&tmp.path().join("shim"));
+    let store_root = tempdir().unwrap();
+    let store_dir = StoreDir::from(store_root.path().to_path_buf());
+    let shallow_hosts = vec!["github.com".to_string()];
+
+    let mut fetcher =
+        failing_fetcher("ssh://git@github.com/acme/widget.git", &store_dir, &shim_path);
+    fetcher.git_shallow_hosts = &shallow_hosts;
+    let err = fetcher.run::<SilentReporter>().await.expect_err("the shim fails every fetch");
+
+    let GitFetcherError::FetchOverSsh { package, host, .. } = &err else {
+        panic!("expected FetchOverSsh; got {err:?}");
+    };
+    assert_eq!(package, "@scope/pkg");
+    assert_eq!(host, "github.com");
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread")]
 async fn a_failed_clone_over_https_carries_no_ssh_remediation() {
     let tmp = tempdir().unwrap();
     let shim_path = write_failing_git_shim(&tmp.path().join("shim"));

--- a/pnpm/crates/git-fetcher/src/fetcher/tests.rs
+++ b/pnpm/crates/git-fetcher/src/fetcher/tests.rs
@@ -6,6 +6,7 @@ use crate::{
     error::{GitFetcherError, PreparePackageError},
     prepare_package::AllowBuildRef,
 };
+use miette::Diagnostic;
 use pacquet_executor::ScriptsPrependNodePath;
 use pacquet_reporter::SilentReporter;
 use pacquet_store_dir::StoreDir;
@@ -1267,6 +1268,9 @@ fn ssh_repo_host_recognises_only_ssh_references() {
         ssh_repo_host("ssh://git@gitlab.example.com:2222/org/repo.git"),
         Some("gitlab.example.com"),
     );
+    // Brackets are kept, matching what `URL.hostname` hands the TypeScript CLI.
+    assert_eq!(ssh_repo_host("ssh://git@[2001:db8::1]:2222/org/repo.git"), Some("[2001:db8::1]"));
+    assert_eq!(ssh_repo_host("ssh://[2001:db8::1]/org/repo.git"), Some("[2001:db8::1]"));
 
     assert_eq!(ssh_repo_host("https://github.com/acme/widget.git"), None);
     assert_eq!(ssh_repo_host("git://github.com/acme/widget.git"), None);
@@ -1274,9 +1278,7 @@ fn ssh_repo_host_recognises_only_ssh_references() {
     assert_eq!(ssh_repo_host(r"C:\src\repo"), None);
 }
 
-/// A lockfile that predates the resolver fix keeps cloning over SSH, and the
-/// raw `git clone` failure named neither the dependency nor a way out. Covers
-/// <https://github.com/pnpm/pnpm/issues/13743>.
+/// Covers <https://github.com/pnpm/pnpm/issues/13743>.
 #[cfg(unix)]
 #[tokio::test(flavor = "multi_thread")]
 async fn a_failed_clone_over_ssh_names_the_package_and_how_to_re_record_it() {
@@ -1297,6 +1299,17 @@ async fn a_failed_clone_over_ssh_names_the_package_and_how_to_re_record_it() {
     assert_eq!(repo, "git@github.com:acme/widget.git");
     assert_eq!(host, "github.com");
     assert_eq!(stderr, "ssh: connect to host port 22: Connection refused");
+
+    assert_eq!(err.code().expect("a diagnostic code").to_string(), "ERR_PNPM_GIT_FETCH_FAILED");
+    let rendered = err.to_string();
+    dbg!(&rendered);
+    assert!(rendered.contains(r#"Failed to fetch "@scope/pkg""#), "{rendered}");
+
+    let help = err.help().expect("SSH remediation help").to_string();
+    dbg!(&help);
+    assert!(help.contains("needs an SSH key for github.com"), "{help}");
+    assert!(help.contains("pnpm update @scope/pkg"), "{help}");
+    assert!(help.contains("do not re-resolve git dependencies"), "{help}");
 }
 
 #[cfg(unix)]
@@ -1313,10 +1326,12 @@ async fn a_failed_clone_over_https_carries_no_ssh_remediation() {
         .expect_err("the shim fails every clone");
 
     assert!(matches!(err, GitFetcherError::Fetch { .. }), "{err:?}");
+    assert_eq!(err.code().expect("a diagnostic code").to_string(), "ERR_PNPM_GIT_FETCH_FAILED");
+    assert!(err.help().is_none(), "an HTTPS remote needs no SSH remediation");
 }
 
-/// A `git` shim that fails every invocation with a canned stderr, so the
-/// transport-failure branch is reachable without a remote.
+/// A `git` shim that fails every invocation, so the transport-failure branch
+/// is reachable without a remote.
 #[cfg(unix)]
 fn write_failing_git_shim(dir: &Path) -> PathBuf {
     use std::os::unix::fs::PermissionsExt;
@@ -1331,8 +1346,7 @@ exit 128
     shim_path
 }
 
-/// A fetcher over `repo` with no shallow hosts configured, so it takes the
-/// `git clone` branch the transport-failure tests drive through the shim.
+/// No shallow hosts, so the fetcher takes the `git clone` branch.
 #[cfg(unix)]
 fn failing_fetcher<'a>(
     repo: &'a str,

--- a/pnpm/crates/git-fetcher/src/fetcher/tests.rs
+++ b/pnpm/crates/git-fetcher/src/fetcher/tests.rs
@@ -1,6 +1,6 @@
 use super::{
     GitFetcher, GitManifestQuery, exec_git_with, extract_host, is_safe_repo_arg,
-    is_valid_commit_hash, read_git_manifest, should_use_shallow,
+    is_valid_commit_hash, read_git_manifest, should_use_shallow, ssh_repo_host,
 };
 use crate::{
     error::{GitFetcherError, PreparePackageError},
@@ -161,6 +161,7 @@ async fn fetcher_rejects_option_shaped_commit() {
         npm_execpath: None,
         store_dir: &store_dir,
         package_id: "pkg@1.0.0",
+        package_name: "pkg",
         requester: "/test",
         store_index_writer: None,
         files_index_file: "pkg@1.0.0\tbuilt",
@@ -194,6 +195,7 @@ async fn fetcher_rejects_partial_commit_before_running_git() {
         npm_execpath: None,
         store_dir: &store_dir,
         package_id: "pkg@1.0.0",
+        package_name: "pkg",
         requester: "/test",
         store_index_writer: None,
         files_index_file: "pkg@1.0.0\tbuilt",
@@ -242,6 +244,7 @@ async fn fetcher_imports_package_into_cas() {
         npm_execpath: None,
         store_dir: &store_dir,
         package_id: "pkg@1.0.0",
+        package_name: "pkg",
         requester: "/test",
         store_index_writer: None,
         files_index_file: "pkg@1.0.0\tbuilt",
@@ -287,6 +290,7 @@ async fn fetcher_rejects_commit_mismatch() {
         npm_execpath: None,
         store_dir: &store_dir,
         package_id: "pkg@1.0.0",
+        package_name: "pkg",
         requester: "/test",
         store_index_writer: None,
         files_index_file: "pkg@1.0.0\tbuilt",
@@ -343,6 +347,7 @@ async fn fetcher_blocks_build_when_not_allowed() {
         npm_execpath: None,
         store_dir: &store_dir,
         package_id: "naughty@2.0.0",
+        package_name: "pkg",
         requester: "/test",
         store_index_writer: None,
         files_index_file: "naughty@2.0.0\tbuilt",
@@ -441,6 +446,7 @@ async fn fetcher_packs_subfolder_when_path_set() {
         npm_execpath: None,
         store_dir: &store_dir,
         package_id: "sub@1.0.0",
+        package_name: "pkg",
         requester: "/test",
         store_index_writer: None,
         files_index_file: "sub@1.0.0\tbuilt",
@@ -482,6 +488,7 @@ async fn fetcher_handles_repo_without_package_json() {
         npm_execpath: None,
         store_dir: &store_dir,
         package_id: "anon@0.0.0",
+        package_name: "pkg",
         requester: "/test",
         store_index_writer: None,
         files_index_file: "anon@0.0.0\tbuilt",
@@ -537,6 +544,7 @@ async fn fetcher_skips_build_when_ignore_scripts() {
         npm_execpath: None,
         store_dir: &store_dir,
         package_id: "x@1.0.0",
+        package_name: "pkg",
         requester: "/test",
         store_index_writer: None,
         // The key's `built` dimension reflects what the *dispatcher*
@@ -593,6 +601,7 @@ async fn fetcher_runs_prepare_script_when_allowed() {
         npm_execpath: None,
         store_dir: &store_dir,
         package_id: "x@1.0.0",
+        package_name: "pkg",
         requester: "/test",
         store_index_writer: None,
         files_index_file: "x@1.0.0\tbuilt",
@@ -641,6 +650,7 @@ async fn fetcher_surfaces_prepare_failure() {
         npm_execpath: None,
         store_dir: &store_dir,
         package_id: "x@1.0.0",
+        package_name: "pkg",
         requester: "/test",
         store_index_writer: None,
         files_index_file: "x@1.0.0\tbuilt",
@@ -709,6 +719,7 @@ async fn fetcher_runs_prepare_when_allow_build_returns_true() {
         npm_execpath: None,
         store_dir: &store_dir,
         package_id: "git+file:///tmp/repo.git#abc123",
+        package_name: "pkg",
         requester: "/test",
         store_index_writer: None,
         files_index_file: "git+file:///tmp/repo.git#abc123\tbuilt",
@@ -756,6 +767,7 @@ async fn fetcher_rejects_untrusted_manifest_identity() {
         npm_execpath: None,
         store_dir: &store_dir,
         package_id: "git+file:///tmp/repo.git#abc123",
+        package_name: "pkg",
         requester: "/test",
         store_index_writer: None,
         files_index_file: "git+file:///tmp/repo.git#abc123\tbuilt",
@@ -806,6 +818,7 @@ async fn fetcher_allows_untrusted_manifest_identity_by_dep_path() {
         npm_execpath: None,
         store_dir: &store_dir,
         package_id,
+        package_name: "pkg",
         requester: "/test",
         store_index_writer: None,
         files_index_file: "git+file:///tmp/repo.git#abc123\tbuilt",
@@ -973,6 +986,7 @@ async fn fetcher_uses_shallow_fetch_for_allowed_hosts() {
         npm_execpath: None,
         store_dir: &store_dir,
         package_id: "x@1.0.0",
+        package_name: "pkg",
         requester: "/test",
         store_index_writer: None,
         files_index_file: "x@1.0.0\tbuilt",
@@ -1053,6 +1067,7 @@ async fn fetcher_clones_when_host_not_in_shallow_list() {
         npm_execpath: None,
         store_dir: &store_dir,
         package_id: "x@1.0.0",
+        package_name: "pkg",
         requester: "/test",
         store_index_writer: None,
         files_index_file: "x@1.0.0\tbuilt",
@@ -1241,4 +1256,108 @@ fn is_safe_repo_arg_rejects_option_shaped_values() {
     assert!(!is_safe_repo_arg("-oProxyCommand=curl evil.example"));
     assert!(!is_safe_repo_arg(""));
     assert!(!is_safe_repo_arg("https://example.com/\0/x"));
+}
+
+#[test]
+fn ssh_repo_host_recognises_only_ssh_references() {
+    assert_eq!(ssh_repo_host("git@github.com:acme/widget.git"), Some("github.com"));
+    assert_eq!(ssh_repo_host("ssh://git@github.com/acme/widget.git"), Some("github.com"));
+    assert_eq!(ssh_repo_host("git+ssh://git@github.com/acme/widget.git"), Some("github.com"));
+    assert_eq!(
+        ssh_repo_host("ssh://git@gitlab.example.com:2222/org/repo.git"),
+        Some("gitlab.example.com"),
+    );
+
+    assert_eq!(ssh_repo_host("https://github.com/acme/widget.git"), None);
+    assert_eq!(ssh_repo_host("git://github.com/acme/widget.git"), None);
+    assert_eq!(ssh_repo_host("file:///home/zoltan/src/repo"), None);
+    assert_eq!(ssh_repo_host(r"C:\src\repo"), None);
+}
+
+/// A lockfile that predates the resolver fix keeps cloning over SSH, and the
+/// raw `git clone` failure named neither the dependency nor a way out. Covers
+/// <https://github.com/pnpm/pnpm/issues/13743>.
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread")]
+async fn a_failed_clone_over_ssh_names_the_package_and_how_to_re_record_it() {
+    let tmp = tempdir().unwrap();
+    let shim_path = write_failing_git_shim(&tmp.path().join("shim"));
+    let store_root = tempdir().unwrap();
+    let store_dir = StoreDir::from(store_root.path().to_path_buf());
+
+    let err = failing_fetcher("git@github.com:acme/widget.git", &store_dir, &shim_path)
+        .run::<SilentReporter>()
+        .await
+        .expect_err("the shim fails every clone");
+
+    let GitFetcherError::FetchOverSsh { package, repo, host, stderr } = &err else {
+        panic!("expected FetchOverSsh; got {err:?}");
+    };
+    assert_eq!(package, "@scope/pkg");
+    assert_eq!(repo, "git@github.com:acme/widget.git");
+    assert_eq!(host, "github.com");
+    assert_eq!(stderr, "ssh: connect to host port 22: Connection refused");
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread")]
+async fn a_failed_clone_over_https_carries_no_ssh_remediation() {
+    let tmp = tempdir().unwrap();
+    let shim_path = write_failing_git_shim(&tmp.path().join("shim"));
+    let store_root = tempdir().unwrap();
+    let store_dir = StoreDir::from(store_root.path().to_path_buf());
+
+    let err = failing_fetcher("https://github.com/acme/widget.git", &store_dir, &shim_path)
+        .run::<SilentReporter>()
+        .await
+        .expect_err("the shim fails every clone");
+
+    assert!(matches!(err, GitFetcherError::Fetch { .. }), "{err:?}");
+}
+
+/// A `git` shim that fails every invocation with a canned stderr, so the
+/// transport-failure branch is reachable without a remote.
+#[cfg(unix)]
+fn write_failing_git_shim(dir: &Path) -> PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+    fs::create_dir_all(dir).unwrap();
+    let shim_path = dir.join("git");
+    let body = r#"#!/bin/sh
+printf 'ssh: connect to host port 22: Connection refused\n' >&2
+exit 128
+"#;
+    fs::write(&shim_path, body).unwrap();
+    fs::set_permissions(&shim_path, fs::Permissions::from_mode(0o755)).unwrap();
+    shim_path
+}
+
+/// A fetcher over `repo` with no shallow hosts configured, so it takes the
+/// `git clone` branch the transport-failure tests drive through the shim.
+#[cfg(unix)]
+fn failing_fetcher<'a>(
+    repo: &'a str,
+    store_dir: &'a StoreDir,
+    git_bin: &'a Path,
+) -> GitFetcher<'a> {
+    GitFetcher {
+        repo,
+        commit: "c9b30e71d704cd30fa71f2edd1ecc7dcc4985493",
+        path: None,
+        git_shallow_hosts: &[],
+        allow_build: deny_all_builds(),
+        ignore_scripts: false,
+        unsafe_perm: true,
+        user_agent: None,
+        scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+        script_shell: None,
+        node_execpath: None,
+        npm_execpath: None,
+        store_dir,
+        package_id: "git+ssh://git@github.com/acme/widget.git#c9b30e71d704cd30fa71f2edd1ecc7dcc4985493",
+        package_name: "@scope/pkg",
+        requester: "/test",
+        store_index_writer: None,
+        files_index_file: "@scope/pkg@1.0.0\tbuilt",
+        git_bin: Some(git_bin),
+    }
 }

--- a/pnpm/crates/git-fetcher/src/fetcher/tests.rs
+++ b/pnpm/crates/git-fetcher/src/fetcher/tests.rs
@@ -1322,10 +1322,10 @@ fn write_failing_git_shim(dir: &Path) -> PathBuf {
     use std::os::unix::fs::PermissionsExt;
     fs::create_dir_all(dir).unwrap();
     let shim_path = dir.join("git");
-    let body = r#"#!/bin/sh
+    let body = r"#!/bin/sh
 printf 'ssh: connect to host port 22: Connection refused\n' >&2
 exit 128
-"#;
+";
     fs::write(&shim_path, body).unwrap();
     fs::set_permissions(&shim_path, fs::Permissions::from_mode(0o755)).unwrap();
     shim_path

--- a/pnpm/crates/network/src/auth.rs
+++ b/pnpm/crates/network/src/auth.rs
@@ -799,6 +799,21 @@ pub fn redact_and_sanitize(text: &str) -> String {
     redact_url_credentials(&sanitized)
 }
 
+/// [`redact_and_sanitize`] for text whose line breaks are worth keeping, such
+/// as a subprocess's multi-line stderr.
+///
+/// Line breaks are kept only when doing so redacts exactly as much as
+/// collapsing the text would: a newline can fall inside a `user:pass@`
+/// authority — git echoes such a URL back verbatim, password included — and
+/// redacting each line separately would leave the credentials split but
+/// readable. Whenever the two disagree, the collapsed form wins.
+#[must_use]
+pub fn redact_and_sanitize_multiline(text: &str) -> String {
+    let collapsed = redact_and_sanitize(text);
+    let per_line = text.split('\n').map(redact_and_sanitize).collect::<Vec<_>>().join("\n");
+    if per_line.replace('\n', "") == collapsed { per_line } else { collapsed }
+}
+
 /// If the authority leading `text` contains `userinfo@`, return the slice after
 /// the **last** `@` within it; otherwise `None`. The authority ends at the first
 /// `/`, `?`, `#`, or whitespace. Stripping to the last `@` keeps a raw `@` inside

--- a/pnpm/crates/network/src/auth/tests.rs
+++ b/pnpm/crates/network/src/auth/tests.rs
@@ -1,6 +1,6 @@
 use super::{
     AuthHeaders, DEFAULT_REGISTRY_SCOPE, UpstreamRouteHook, base64_encode, hide_auth_information,
-    nerf_dart, redact_and_sanitize, redact_url_credentials,
+    nerf_dart, redact_and_sanitize, redact_and_sanitize_multiline, redact_url_credentials,
 };
 use crate::TokenHelperOutput;
 use pretty_assertions::assert_eq;
@@ -578,4 +578,22 @@ fn nerf_dart_handles_url_with_no_path_separator() {
 fn empty_user_info_returns_no_basic_header() {
     let empty = AuthHeaders::default();
     assert_eq!(empty.for_url("https://@reg.com/"), None);
+}
+
+#[test]
+fn redact_and_sanitize_multiline_keeps_line_breaks() {
+    assert_eq!(
+        redact_and_sanitize_multiline("cloning https://user:pass@host/x.git\r\nfailed"),
+        "cloning https://host/x.git\nfailed",
+    );
+}
+
+#[test]
+fn redact_and_sanitize_multiline_collapses_when_a_newline_splits_credentials() {
+    // Redacting each line on its own would leave "user:pass" readable, so the
+    // collapsed form wins over the more readable one.
+    let redacted = redact_and_sanitize_multiline("url: https://user:pass\n@host/x.git\nfailed");
+    dbg!(&redacted);
+    assert!(!redacted.contains("user:pass"), "{redacted}");
+    assert_eq!(redacted, redact_and_sanitize("url: https://user:pass\n@host/x.git\nfailed"));
 }

--- a/pnpm/crates/network/src/lib.rs
+++ b/pnpm/crates/network/src/lib.rs
@@ -11,7 +11,7 @@ mod token_helper;
 pub use auth::{
     AuthHeaders, AuthHeadersByScope, DEFAULT_REGISTRY_SCOPE, MetadataCacheScope, UpstreamRouteHook,
     base64_encode, hide_auth_information, nerf_dart, normalize_auth_key, redact_and_sanitize,
-    redact_url_credentials,
+    redact_and_sanitize_multiline, redact_url_credentials,
 };
 pub use limited_body::{LimitedBody, read_limited_body};
 pub use token_helper::{TokenHelperOutput, TokenHelperRunner};

--- a/pnpm11/core/error/src/index.ts
+++ b/pnpm11/core/error/src/index.ts
@@ -122,6 +122,22 @@ export function redactAndSanitize (text: string): string {
   return redactUrlCredentials(sanitized)
 }
 
+/**
+ * {@link redactAndSanitize} for text whose line breaks are worth keeping, such
+ * as a subprocess's multi-line stderr.
+ *
+ * Line breaks are kept only when doing so redacts exactly as much as
+ * collapsing the text would: a newline can fall inside a `user:pass@`
+ * authority — git echoes such a URL back verbatim, password included — and
+ * redacting each line separately would leave the credentials split but
+ * readable. Whenever the two disagree, the collapsed form wins.
+ */
+export function redactAndSanitizeMultiline (text: string): string {
+  const collapsed = redactAndSanitize(text)
+  const perLine = text.split('\n').map(redactAndSanitize).join('\n')
+  return perLine.replaceAll('\n', '') === collapsed ? perLine : collapsed
+}
+
 function isSchemeTailChar (code: number): boolean {
   return (code >= 0x30 && code <= 0x39) || (code >= 0x41 && code <= 0x5a) || (code >= 0x61 && code <= 0x7a)
 }

--- a/pnpm11/core/error/test/index.ts
+++ b/pnpm11/core/error/test/index.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@jest/globals'
-import { FetchError, PnpmError, redactAndSanitize, redactUrlCredentials } from '@pnpm/error'
+import { FetchError, PnpmError, redactAndSanitize, redactAndSanitizeMultiline, redactUrlCredentials } from '@pnpm/error'
 
 test('PnpmError exposes cause when provided', () => {
   const cause = new Error('original failure')
@@ -90,4 +90,17 @@ test('redactAndSanitize', () => {
   // A control character inside the userinfo must not break the redaction:
   // controls are stripped first, then credentials are redacted.
   expect(redactAndSanitize('https://user:pass\r@host/x')).toBe('https://host/x')
+})
+
+test('redactAndSanitizeMultiline', () => {
+  // Only the ESC introducer is removed, as in redactAndSanitize; the residual
+  // "[0m" is inert text.
+  expect(redactAndSanitizeMultiline('fatal: could not read\r\nfrom remote\u001b[0m'))
+    .toBe('fatal: could not read\nfrom remote[0m')
+  expect(redactAndSanitizeMultiline('cloning https://user:pass@host/x.git\nfailed'))
+    .toBe('cloning https://host/x.git\nfailed')
+  // A newline inside the userinfo would leave the credentials split but
+  // readable if each line were redacted on its own, so the collapsed form wins.
+  expect(redactAndSanitizeMultiline('url: https://user:pass\n@host/x.git\nfailed'))
+    .toBe('url: https://host/x.gitfailed')
 })

--- a/pnpm11/fetching/git-fetcher/src/index.ts
+++ b/pnpm11/fetching/git-fetcher/src/index.ts
@@ -31,12 +31,20 @@ export function createGitFetcher (createOpts: CreateGitFetcherOptions): { git: G
       throw new PnpmError('INVALID_GIT_COMMIT', `Invalid git commit hash "${resolution.commit}" for repository "${resolution.repo}". Expected a 40-character hexadecimal SHA.`)
     }
     const tempLocation = await cafs.tempDir()
-    if (allowedHosts.size > 0 && shouldUseShallow(resolution.repo, allowedHosts)) {
-      await execGit(['init'], { cwd: tempLocation })
-      await execGit(['remote', 'add', 'origin', resolution.repo], { cwd: tempLocation })
-      await execGit(['fetch', '--depth', '1', 'origin', resolution.commit], { cwd: tempLocation })
-    } else {
-      await execGit(['clone', resolution.repo, tempLocation])
+    try {
+      if (allowedHosts.size > 0 && shouldUseShallow(resolution.repo, allowedHosts)) {
+        await execGit(['init'], { cwd: tempLocation })
+        await execGit(['remote', 'add', 'origin', resolution.repo], { cwd: tempLocation })
+        await execGit(['fetch', '--depth', '1', 'origin', resolution.commit], { cwd: tempLocation })
+      } else {
+        await execGit(['clone', resolution.repo, tempLocation])
+      }
+    } catch (err: unknown) {
+      assert(util.types.isNativeError(err))
+      const pkgName = opts.pkg?.name
+      throw new PnpmError('GIT_FETCH_FAILED', `Failed to fetch ${pkgName ? `"${pkgName}" ` : ''}from the git repository "${resolution.repo}": ${gitFailureDetail(err)}`, {
+        hint: sshRemediationHint(resolution.repo, pkgName),
+      })
     }
     await execGit(['checkout', resolution.commit], { cwd: tempLocation })
     const receivedCommit = await execGit(['rev-parse', 'HEAD'], { cwd: tempLocation })
@@ -85,6 +93,59 @@ export function createGitFetcher (createOpts: CreateGitFetcherOptions): { git: G
 
 function isValidCommitHash (commit: string): boolean {
   return /^[0-9a-f]{40}$/i.test(commit)
+}
+
+// git appends the child's stderr to its own message, which repeats the repository
+// and leaks the store's temp directory. The stderr alone is what the user needs.
+function gitFailureDetail (err: Error): string {
+  const stderr = (err as { stderr?: string }).stderr?.trim()
+  return stderr ?? err.message
+}
+
+/**
+ * Guidance for a git dependency locked to an SSH remote, or `undefined` when the
+ * lockfile records a transport that needs no key.
+ *
+ * A lockfile written before pnpm v11.21 could record an SSH URL for a dependency
+ * whose specifier never asked for SSH, and resolution is skipped while that
+ * lockfile stays up to date — so the entry survives the upgrade that fixed it and
+ * the install keeps failing wherever no SSH key is configured.
+ */
+function sshRemediationHint (repo: string, pkgName?: string): string | undefined {
+  const host = sshRepoHost(repo)
+  if (host == null) return undefined
+  return `The lockfile records an SSH remote for this dependency, so fetching it needs an SSH key for ${host}.
+
+If its specifier does not ask for SSH (for example "github:owner/repo"), the lockfile entry was written before pnpm v11.21 and can be re-recorded over HTTPS:
+
+    pnpm update ${pkgName ?? '<package>'}
+
+"pnpm install --force" and "pnpm install --resolution-only" do not re-resolve git dependencies, so neither clears it.`
+}
+
+/**
+ * The host an SSH git reference points at, or `undefined` if `repo` is not one.
+ *
+ * Covers the URL form (`[git+]ssh://[user@]host[:port]/path`) and the scp-style
+ * shorthand (`[user@]host:path`) that carries no scheme. The `user@` is mandatory
+ * in the shorthand, which is what keeps a Windows drive path (`C:\repo`) from
+ * being read as a host.
+ */
+function sshRepoHost (repo: string): string | undefined {
+  const sshUrl = repo.replace(/^git\+/, '')
+  if (sshUrl.startsWith('ssh://')) {
+    try {
+      return new URL(sshUrl).hostname || undefined
+    } catch {
+      return undefined
+    }
+  }
+  if (repo.includes('://')) return undefined
+  const colonPos = repo.indexOf(':')
+  if (colonPos === -1) return undefined
+  const authority = repo.slice(0, colonPos)
+  const atPos = authority.lastIndexOf('@')
+  return atPos === -1 ? undefined : authority.slice(atPos + 1) || undefined
 }
 
 function shouldUseShallow (repoUrl: string, allowedHosts: Set<string>): boolean {

--- a/pnpm11/fetching/git-fetcher/src/index.ts
+++ b/pnpm11/fetching/git-fetcher/src/index.ts
@@ -118,7 +118,7 @@ function gitFetchError (err: Error, repo: string, pkgName?: string): PnpmError {
 // and leaks the store's temp directory. The stderr alone is what the user needs.
 function gitFailureDetail (err: Error): string {
   const stderr = (err as { stderr?: string }).stderr?.trim()
-  return stderr ?? err.message
+  return stderr == null || stderr === '' ? err.message : stderr
 }
 
 /**

--- a/pnpm11/fetching/git-fetcher/src/index.ts
+++ b/pnpm11/fetching/git-fetcher/src/index.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import { URL } from 'node:url'
 import util from 'node:util'
 
-import { PnpmError } from '@pnpm/error'
+import { PnpmError, redactAndSanitize, redactAndSanitizeMultiline } from '@pnpm/error'
 import { preparePackage } from '@pnpm/exec.prepare-package'
 import type { GitFetcher } from '@pnpm/fetching.fetcher-base'
 import { packlist } from '@pnpm/fs.packlist'
@@ -41,10 +41,7 @@ export function createGitFetcher (createOpts: CreateGitFetcherOptions): { git: G
       }
     } catch (err: unknown) {
       assert(util.types.isNativeError(err))
-      const pkgName = opts.pkg?.name
-      throw new PnpmError('GIT_FETCH_FAILED', `Failed to fetch ${pkgName ? `"${pkgName}" ` : ''}from the git repository "${resolution.repo}": ${gitFailureDetail(err)}`, {
-        hint: sshRemediationHint(resolution.repo, pkgName),
-      })
+      throw gitFetchError(err, resolution.repo, opts.pkg?.name)
     }
     await execGit(['checkout', resolution.commit], { cwd: tempLocation })
     const receivedCommit = await execGit(['rev-parse', 'HEAD'], { cwd: tempLocation })
@@ -95,6 +92,28 @@ function isValidCommitHash (commit: string): boolean {
   return /^[0-9a-f]{40}$/i.test(commit)
 }
 
+/**
+ * Restate a failure of the transport-touching git invocations, naming the
+ * package the resolution belongs to.
+ *
+ * Every interpolated value is untrusted: a lockfile URL can carry `user:pass@`
+ * credentials, and git echoes it back through stderr. Only the values go
+ * through {@link redactAndSanitize} — it strips control characters, which would
+ * collapse the deliberately multi-line hint.
+ */
+function gitFetchError (err: Error, repo: string, pkgName?: string): PnpmError {
+  if ((err as { code?: string }).code === 'ENOENT') {
+    return new PnpmError('GIT_FETCHER_GIT_NOT_FOUND', '`git` executable not found on PATH. Install git to fetch git-hosted packages.')
+  }
+  const safePkgName = pkgName == null ? undefined : redactAndSanitize(pkgName)
+  const subject = safePkgName == null ? '' : `"${safePkgName}" `
+  return new PnpmError(
+    'GIT_FETCH_FAILED',
+    `Failed to fetch ${subject}from the git repository "${redactAndSanitize(repo)}": ${redactAndSanitizeMultiline(gitFailureDetail(err))}`,
+    { hint: sshRemediationHint(repo, safePkgName) }
+  )
+}
+
 // git appends the child's stderr to its own message, which repeats the repository
 // and leaks the store's temp directory. The stderr alone is what the user needs.
 function gitFailureDetail (err: Error): string {
@@ -114,7 +133,7 @@ function gitFailureDetail (err: Error): string {
 function sshRemediationHint (repo: string, pkgName?: string): string | undefined {
   const host = sshRepoHost(repo)
   if (host == null) return undefined
-  return `The lockfile records an SSH remote for this dependency, so fetching it needs an SSH key for ${host}.
+  return `The lockfile records an SSH remote for this dependency, so fetching it needs an SSH key for ${redactAndSanitize(host)}.
 
 If its specifier does not ask for SSH (for example "github:owner/repo"), the lockfile entry was written before pnpm v11.21 and can be re-recorded over HTTPS:
 

--- a/pnpm11/fetching/git-fetcher/test/index.ts
+++ b/pnpm11/fetching/git-fetcher/test/index.ts
@@ -355,7 +355,7 @@ test('fetch only the included files', async () => {
 test('a failed clone over SSH names the package and how to re-record it', async () => {
   const storeDir = temporaryDirectory()
   const fetch = createGitFetcher({ storeIndex: createStoreIndex(storeDir) }).git
-  const err = await withoutSsh(async () => fetch(
+  const err = await fetchFailure(withoutSsh(async () => fetch(
     createCafsStore(storeDir),
     {
       commit: 'c9b30e71d704cd30fa71f2edd1ecc7dcc4985493',
@@ -366,7 +366,7 @@ test('a failed clone over SSH names the package and how to re-record it', async 
       filesIndexFile: path.join(storeDir, 'index.json'),
       pkg: { name: '@scope/pkg', version: '1.0.0' },
     }
-  )).catch((err: unknown) => err as PnpmError)
+  )))
 
   expect(err.code).toBe('ERR_PNPM_GIT_FETCH_FAILED')
   expect(err.message).toContain('Failed to fetch "@scope/pkg" from the git repository "git@github.com:pnpm-e2e/this-repository-does-not-exist.git"')
@@ -377,7 +377,7 @@ test('a failed clone over SSH names the package and how to re-record it', async 
 test('a failed clone over HTTPS carries no SSH remediation', async () => {
   const storeDir = temporaryDirectory()
   const fetch = createGitFetcher({ storeIndex: createStoreIndex(storeDir) }).git
-  const err = await fetch(
+  const err = await fetchFailure(fetch(
     createCafsStore(storeDir),
     {
       commit: 'c9b30e71d704cd30fa71f2edd1ecc7dcc4985493',
@@ -388,11 +388,20 @@ test('a failed clone over HTTPS carries no SSH remediation', async () => {
       filesIndexFile: path.join(storeDir, 'index.json'),
       pkg: { name: '@scope/pkg', version: '1.0.0' },
     }
-  ).catch((err: unknown) => err as PnpmError)
+  ))
 
   expect(err.code).toBe('ERR_PNPM_GIT_FETCH_FAILED')
   expect(err.hint).toBeUndefined()
 })
+
+async function fetchFailure (fetching: Promise<unknown>): Promise<PnpmError> {
+  return fetching.then(
+    () => {
+      throw new Error('expected the git fetch to fail')
+    },
+    (err: unknown) => err as PnpmError
+  )
+}
 
 async function withoutSsh<T> (fn: () => Promise<T>): Promise<T> {
   const original = process.env.GIT_SSH_COMMAND

--- a/pnpm11/fetching/git-fetcher/test/index.ts
+++ b/pnpm11/fetching/git-fetcher/test/index.ts
@@ -2,6 +2,7 @@
 import path from 'node:path'
 
 import { afterAll, beforeEach, expect, jest, test } from '@jest/globals'
+import type { PnpmError } from '@pnpm/error'
 import { createCafsStore } from '@pnpm/store.create-cafs-store'
 import { StoreIndex } from '@pnpm/store.index'
 import { lexCompare } from '@pnpm/text.ordinal-comparator'
@@ -347,3 +348,62 @@ test('fetch only the included files', async () => {
     'package.json',
   ])
 })
+
+// Covers https://github.com/pnpm/pnpm/issues/13743, where a lockfile that
+// predates the resolver fix keeps cloning over SSH and the raw git failure
+// named neither the dependency nor a way out.
+test('a failed clone over SSH names the package and how to re-record it', async () => {
+  const storeDir = temporaryDirectory()
+  const fetch = createGitFetcher({ storeIndex: createStoreIndex(storeDir) }).git
+  const err = await withoutSsh(async () => fetch(
+    createCafsStore(storeDir),
+    {
+      commit: 'c9b30e71d704cd30fa71f2edd1ecc7dcc4985493',
+      repo: 'git@github.com:pnpm-e2e/this-repository-does-not-exist.git',
+      type: 'git',
+    },
+    {
+      filesIndexFile: path.join(storeDir, 'index.json'),
+      pkg: { name: '@scope/pkg', version: '1.0.0' },
+    }
+  )).catch((err: unknown) => err as PnpmError)
+
+  expect(err.code).toBe('ERR_PNPM_GIT_FETCH_FAILED')
+  expect(err.message).toContain('Failed to fetch "@scope/pkg" from the git repository "git@github.com:pnpm-e2e/this-repository-does-not-exist.git"')
+  expect(err.hint).toContain('needs an SSH key for github.com')
+  expect(err.hint).toContain('pnpm update @scope/pkg')
+})
+
+test('a failed clone over HTTPS carries no SSH remediation', async () => {
+  const storeDir = temporaryDirectory()
+  const fetch = createGitFetcher({ storeIndex: createStoreIndex(storeDir) }).git
+  const err = await fetch(
+    createCafsStore(storeDir),
+    {
+      commit: 'c9b30e71d704cd30fa71f2edd1ecc7dcc4985493',
+      repo: 'https://github.com/pnpm-e2e/this-repository-does-not-exist.git',
+      type: 'git',
+    },
+    {
+      filesIndexFile: path.join(storeDir, 'index.json'),
+      pkg: { name: '@scope/pkg', version: '1.0.0' },
+    }
+  ).catch((err: unknown) => err as PnpmError)
+
+  expect(err.code).toBe('ERR_PNPM_GIT_FETCH_FAILED')
+  expect(err.hint).toBeUndefined()
+})
+
+async function withoutSsh<T> (fn: () => Promise<T>): Promise<T> {
+  const original = process.env.GIT_SSH_COMMAND
+  process.env.GIT_SSH_COMMAND = 'false'
+  try {
+    return await fn()
+  } finally {
+    if (original == null) {
+      delete process.env.GIT_SSH_COMMAND
+    } else {
+      process.env.GIT_SSH_COMMAND = original
+    }
+  }
+}

--- a/pnpm11/fetching/git-fetcher/test/index.ts
+++ b/pnpm11/fetching/git-fetcher/test/index.ts
@@ -392,6 +392,28 @@ test('a failed clone over HTTPS carries no SSH remediation', async () => {
   expect(err.hint).toBeUndefined()
 })
 
+test('a failed shallow fetch is reported like a failed clone', async () => {
+  const storeDir = temporaryDirectory()
+  const fetch = createGitFetcher({ gitShallowHosts: ['github.com'], storeIndex: createStoreIndex(storeDir) }).git
+  const err = await fetchFailure(withoutSsh(async () => fetch(
+    createCafsStore(storeDir),
+    {
+      commit: 'c9b30e71d704cd30fa71f2edd1ecc7dcc4985493',
+      repo: 'ssh://git@github.com/pnpm-e2e/this-repository-does-not-exist.git',
+      type: 'git',
+    },
+    {
+      filesIndexFile: path.join(storeDir, 'index.json'),
+      pkg: { name: '@scope/pkg', version: '1.0.0' },
+    }
+  )))
+
+  expect(jest.mocked(execa).mock.calls.some(([, args]) => (args as string[])?.includes('fetch'))).toBe(true)
+  expect(err.code).toBe('ERR_PNPM_GIT_FETCH_FAILED')
+  expect(err.message).toContain('Failed to fetch "@scope/pkg" from the git repository')
+  expect(err.hint).toContain('needs an SSH key for github.com')
+})
+
 // An IPv6 literal keeps its brackets, matching what pacquet's ssh_repo_host
 // returns for the same reference.
 test('the SSH remediation names a bracketed IPv6 host', async () => {

--- a/pnpm11/fetching/git-fetcher/test/index.ts
+++ b/pnpm11/fetching/git-fetcher/test/index.ts
@@ -349,9 +349,7 @@ test('fetch only the included files', async () => {
   ])
 })
 
-// Covers https://github.com/pnpm/pnpm/issues/13743, where a lockfile that
-// predates the resolver fix keeps cloning over SSH and the raw git failure
-// named neither the dependency nor a way out.
+// Covers https://github.com/pnpm/pnpm/issues/13743.
 test('a failed clone over SSH names the package and how to re-record it', async () => {
   const storeDir = temporaryDirectory()
   const fetch = createGitFetcher({ storeIndex: createStoreIndex(storeDir) }).git
@@ -391,6 +389,70 @@ test('a failed clone over HTTPS carries no SSH remediation', async () => {
   ))
 
   expect(err.code).toBe('ERR_PNPM_GIT_FETCH_FAILED')
+  expect(err.hint).toBeUndefined()
+})
+
+// An IPv6 literal keeps its brackets, matching what pacquet's ssh_repo_host
+// returns for the same reference.
+test('the SSH remediation names a bracketed IPv6 host', async () => {
+  const storeDir = temporaryDirectory()
+  const fetch = createGitFetcher({ storeIndex: createStoreIndex(storeDir) }).git
+  const err = await fetchFailure(withoutSsh(async () => fetch(
+    createCafsStore(storeDir),
+    {
+      commit: 'c9b30e71d704cd30fa71f2edd1ecc7dcc4985493',
+      repo: 'ssh://git@[2001:db8::1]:2222/org/repo.git',
+      type: 'git',
+    },
+    {
+      filesIndexFile: path.join(storeDir, 'index.json'),
+      pkg: { name: '@scope/pkg', version: '1.0.0' },
+    }
+  )))
+
+  expect(err.hint).toContain('needs an SSH key for [2001:db8::1]')
+})
+
+test('credentials in the repository URL are redacted from the failure', async () => {
+  const storeDir = temporaryDirectory()
+  const fetch = createGitFetcher({ storeIndex: createStoreIndex(storeDir) }).git
+  const err = await fetchFailure(fetch(
+    createCafsStore(storeDir),
+    {
+      commit: 'c9b30e71d704cd30fa71f2edd1ecc7dcc4985493',
+      repo: 'https://s3cr3t-t0ken:x-oauth-basic@github.com/pnpm-e2e/this-repository-does-not-exist.git',
+      type: 'git',
+    },
+    {
+      filesIndexFile: path.join(storeDir, 'index.json'),
+      pkg: { name: '@scope/pkg', version: '1.0.0' },
+    }
+  ))
+
+  expect(err.message).not.toContain('s3cr3t-t0ken')
+  expect(err.message).toContain('https://github.com/pnpm-e2e/this-repository-does-not-exist.git')
+})
+
+test('a missing git executable is reported as such, not as a fetch failure', async () => {
+  const storeDir = temporaryDirectory()
+  const fetch = createGitFetcher({ storeIndex: createStoreIndex(storeDir) }).git
+  jest.mocked(execa).mockImplementationOnce(() => {
+    throw Object.assign(new Error('spawn git ENOENT'), { code: 'ENOENT' })
+  })
+  const err = await fetchFailure(fetch(
+    createCafsStore(storeDir),
+    {
+      commit: 'c9b30e71d704cd30fa71f2edd1ecc7dcc4985493',
+      repo: 'git@github.com:acme/widget.git',
+      type: 'git',
+    },
+    {
+      filesIndexFile: path.join(storeDir, 'index.json'),
+      pkg: { name: '@scope/pkg', version: '1.0.0' },
+    }
+  ))
+
+  expect(err.code).toBe('ERR_PNPM_GIT_FETCHER_GIT_NOT_FOUND')
   expect(err.hint).toBeUndefined()
 })
 


### PR DESCRIPTION
## Summary

Follow-up to closing [pnpm/pnpm#13747](https://github.com/pnpm/pnpm/pull/13747). The resolver bug behind [pnpm/pnpm#13743](https://github.com/pnpm/pnpm/issues/13743) is fixed and the reporter's lockfile has a supported repair (`pnpm update <the git deps>`) — what was missing is any way to *find that out* from the failure. This PR fixes the message, not the behavior: nothing changes about what gets fetched.

The failure the reporter hit was a raw execa error:

```
[ERROR] Command failed with exit code 128: git clone 'git@github.com:logux/client.git' /home/runner/setup-pnpm/node_modules/.bin/store/v11/tmp/_tmp_aPUZzB

Cloning into '...'...
ssh: connect to host github.com port 22: Connection refused
fatal: Could not read from remote repository.
```

No package name, no pnpm error code, and no indication that the SSH URL came from a lockfile entry written before [pnpm/pnpm#13290](https://github.com/pnpm/pnpm/pull/13290) shipped — the actual cause, and one the resolver fix can't reach retroactively because resolution is skipped while the lockfile is up to date.

Now (verified end-to-end, TypeScript CLI on the left, pacquet identical):

```
[ERR_PNPM_GIT_FETCH_FAILED] Failed to fetch "@logux/core" from the git repository
"git@github.com:logux/core.git": fatal: Could not read from remote repository.
...

The lockfile records an SSH remote for this dependency, so fetching it needs an SSH key
for github.com.

If its specifier does not ask for SSH (for example "github:owner/repo"), the lockfile
entry was written before pnpm v11.21 and can be re-recorded over HTTPS:

    pnpm update @logux/core

"pnpm install --force" and "pnpm install --resolution-only" do not re-resolve git
dependencies, so neither clears it.
```

Notes on the details:

- **Naming the package** is the part that matters most in a workspace — the reporter's repo has four git dependencies across eight projects, and the old error identified none of them. The fetcher gets it from `opts.pkg.name` (TypeScript) / `package_key.name` (pacquet); a git dep's `package_id` is the bare `git+…#<commit>` and carries no name.
- **The `--force` / `--resolution-only` line is not padding.** I measured all four commands against a poisoned lockfile: only `pnpm update` clears the SSH entry. The git resolver returns `currentPkg`'s existing resolution unless `update` is set, so `--resolution-only` does not re-run resolution for git deps despite what its help says. Without that line the hint sends people to the two flags that look right and do nothing.
- **Only the transport-touching steps are restated** (`init` / `remote` / `clone` / `fetch`). A failing `checkout` or `rev-parse` says nothing about reaching the remote, and its own error already describes it.
- **The SSH hint is attached whenever the recorded remote is an SSH URL**, not gated on parsing git's stderr for an auth failure — that would be brittle, and "check your key for this host" is right for any SSH transport failure.
- pacquet splits `Fetch` / `FetchOverSsh` into two variants sharing one code, purely so the derived `Diagnostic` can carry the `help` only where it applies.

Left deliberately alone: `--resolution-only` not honouring its help text for git deps. It's a real bug but a separate one, and noted on the issue.

## Squash Commit Body

```text
The failure the reporter of pnpm/pnpm#13743 hit surfaced as a raw execa
error: "Command failed with exit code 128: git clone 'git@github.com:...'
/home/runner/.../_tmp_aPUZzB". It named no package, carried no pnpm error
code, and gave no indication that the SSH URL came from a lockfile written
before pnpm/pnpm#13290 shipped - the actual cause, and one the resolver fix
cannot reach retroactively because resolution is skipped while the lockfile
is up to date.

A failed clone or shallow fetch is now ERR_PNPM_GIT_FETCH_FAILED, naming the
package the resolution belongs to. When the recorded remote is an SSH URL,
the error also carries a hint: fetching needs a key for that host, an entry
written before v11.21 can be re-recorded over HTTPS with pnpm update, and
--force / --resolution-only will not do it (the git resolver returns the
locked resolution unless update is set).

Only the transport-touching steps are restated. A failing checkout or
rev-parse says nothing about reaching the remote.

Nothing changes about what gets fetched.

Related to pnpm/pnpm#13743.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5[1m]).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13759"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788949837&installation_model_id=426870&pr_number=13759&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13759&signature=7e8f4d014952c6cf1f7c095c1d51d81f510eba5b653e02a8aeb06dd4c834dafd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git dependency fetch errors by identifying the affected package and repository.
  * Added clearer SSH-specific guidance, including SSH key requirements and instructions for correcting stale lockfile entries with `pnpm update`.
  * HTTPS fetch failures now provide relevant error details without displaying SSH-only guidance.
  * Sensitive repository credentials are now redacted from multiline error messages.
  * Added clearer messaging when Git is not installed or cannot be found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->