### PR TITLE
feat: fast lockfile update for dependency group moves

### DIFF
--- a/.changeset/group-moves-fast-update.md
+++ b/.changeset/group-moves-fast-update.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.deps-installer": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+`pnpm install` after moving a dependency between `dependencies`, `devDependencies`, and `optionalDependencies` now updates the lockfile in place instead of re-resolving the whole dependency graph [#13696](https://github.com/pnpm/pnpm/issues/13696).

--- a/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
@@ -1205,3 +1205,90 @@ fn remove_command_drops_the_dependency_without_resolving() {
 
     drop((root, mock_instance));
 }
+
+#[test]
+fn moving_a_dependency_between_groups_skips_resolution() {
+    let CommandTempCwd { workspace, root, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, npmrc_path, .. } = npmrc_info;
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pkg-with-1-dep": "100.0.0",
+                "is-positive": "1.0.0"
+            }
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "dependencies": {
+                "is-positive": "1.0.0"
+            },
+            "optionalDependencies": {
+                "@pnpm.e2e/pkg-with-1-dep": "100.0.0"
+            }
+        })
+        .to_string(),
+    )
+    .expect("move the dependency to optionalDependencies");
+    let dead_registry = dead_registry_url();
+    let live_npmrc = fs::read_to_string(&npmrc_path).expect("read .npmrc");
+    let dead_npmrc = live_npmrc
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("registry="))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(&npmrc_path, format!("registry={dead_registry}\n{dead_npmrc}\n"))
+        .expect("rewrite .npmrc with a dead registry");
+
+    let assert = pacquet_at(&workspace).with_arg("install").assert().success();
+    assert!(
+        String::from_utf8_lossy(&assert.get_output().stdout)
+            .contains("Lockfile is up to date, resolution step is skipped"),
+        "moving a dependency between groups needs no resolution",
+    );
+    let wanted = pacquet_lockfile::Lockfile::load_wanted_from_dir(&workspace)
+        .expect("load updated wanted lockfile")
+        .expect("updated wanted lockfile");
+    let importer = &wanted.importers["."];
+    let moved_alias = "@pnpm.e2e/pkg-with-1-dep".parse().expect("alias");
+    assert!(
+        importer
+            .optional_dependencies
+            .as_ref()
+            .is_some_and(|dependencies| dependencies.contains_key(&moved_alias)),
+        "the importer records the moved dependency under optionalDependencies",
+    );
+    assert!(
+        !importer
+            .dependencies
+            .as_ref()
+            .is_some_and(|dependencies| dependencies.contains_key(&moved_alias)),
+        "and no longer under dependencies",
+    );
+    let snapshots = wanted.snapshots.as_ref().expect("snapshots");
+    for prefix in ["@pnpm.e2e/pkg-with-1-dep@", "@pnpm.e2e/dep-of-pkg-with-1-dep@"] {
+        let (key, snapshot) = snapshots
+            .iter()
+            .find(|(key, _)| key.to_string().starts_with(prefix))
+            .expect("moved subtree snapshot");
+        assert!(snapshot.optional, "{key} is only reachable through an optional edge now");
+    }
+    let is_positive_snapshot = snapshots
+        .iter()
+        .find_map(|(key, snapshot)| key.to_string().starts_with("is-positive@").then_some(snapshot))
+        .expect("is-positive snapshot");
+    assert!(!is_positive_snapshot.optional, "the untouched prod dependency keeps its flags");
+    assert!(
+        workspace.join("node_modules").join("@pnpm.e2e").join("pkg-with-1-dep").exists(),
+        "the moved dependency stays linked",
+    );
+
+    drop((root, mock_instance));
+}

--- a/pnpm/crates/package-manager/src/fast_update_importers.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers.rs
@@ -1,5 +1,7 @@
 use node_semver::Range;
-use pacquet_lockfile::{Lockfile, PkgName, ProjectSnapshot, ResolvedDependencySpec};
+use pacquet_lockfile::{
+    Lockfile, PkgName, ProjectSnapshot, ResolvedDependencyMap, ResolvedDependencySpec,
+};
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use std::collections::{HashMap, HashSet};
 
@@ -9,6 +11,7 @@ pub(crate) fn try_fast_update_importers(
 ) -> Option<Lockfile> {
     let mut candidate = lockfile.clone();
     let mut changed = false;
+    let mut moved_across_optional = false;
     let mut dropped = HashSet::new();
     for (importer_id, manifest) in manifests {
         let importer = candidate.importers.get_mut(importer_id)?;
@@ -18,16 +21,21 @@ pub(crate) fn try_fast_update_importers(
         for (alias, specifier) in &manifest_specifiers {
             let alias = PkgName::parse(*alias).ok()?;
             let dependency = importer_dependency_mut(importer, &alias)?;
-            if dependency.specifier == *specifier {
-                continue;
+            if dependency.specifier != *specifier {
+                let range = Range::parse(specifier).ok()?;
+                let version = dependency.version.ver_peer()?.version_semver()?;
+                if !version.satisfies(&range) {
+                    return None;
+                }
+                dependency.specifier = (*specifier).to_string();
+                changed = true;
             }
-            let range = Range::parse(specifier).ok()?;
-            let version = dependency.version.ver_peer()?.version_semver()?;
-            if !version.satisfies(&range) {
-                return None;
+            let target = effective_dependency_group(manifest, &alias);
+            if let Some(source) = move_dependency(importer, &alias, target) {
+                moved_across_optional |=
+                    source == DependencyGroup::Optional || target == DependencyGroup::Optional;
+                changed = true;
             }
-            dependency.specifier = (*specifier).to_string();
-            changed = true;
         }
         let removed = remove_dependencies_absent_from(importer, &manifest_specifiers);
         changed |= !removed.is_empty();
@@ -43,7 +51,64 @@ pub(crate) fn try_fast_update_importers(
         }
         crate::fast_update_lockfile::prune_unreferenced_catalog_entries(&mut candidate);
     }
+    if !dropped.is_empty() || moved_across_optional {
+        crate::fast_update_lockfile::recompute_optional_flags(&mut candidate);
+    }
     changed.then_some(candidate)
+}
+
+/// The group `satisfies_package_manifest` expects a manifest dependency to
+/// be recorded under when it appears in several: optional wins over prod,
+/// prod over dev.
+fn effective_dependency_group(manifest: &PackageManifest, alias: &PkgName) -> DependencyGroup {
+    let declared_in =
+        |group| manifest.dependencies([group]).any(|(name, _)| alias.to_string() == name);
+    if declared_in(DependencyGroup::Optional) {
+        DependencyGroup::Optional
+    } else if declared_in(DependencyGroup::Prod) {
+        DependencyGroup::Prod
+    } else {
+        DependencyGroup::Dev
+    }
+}
+
+/// Move the importer's record of `alias` into `target`, returning the group
+/// it was recorded under, or `None` when it is not recorded or already
+/// there.
+fn move_dependency(
+    importer: &mut ProjectSnapshot,
+    alias: &PkgName,
+    target: DependencyGroup,
+) -> Option<DependencyGroup> {
+    let source = [DependencyGroup::Optional, DependencyGroup::Prod, DependencyGroup::Dev]
+        .into_iter()
+        .find(|group| {
+            importer_group(importer, *group)
+                .as_ref()
+                .is_some_and(|dependencies| dependencies.contains_key(alias))
+        })?;
+    if source == target {
+        return None;
+    }
+    let source_group = importer_group(importer, source);
+    let dependency = source_group.as_mut()?.remove(alias)?;
+    if source_group.as_ref().is_some_and(HashMap::is_empty) {
+        *source_group = None;
+    }
+    importer_group(importer, target).get_or_insert_default().insert(alias.clone(), dependency);
+    Some(source)
+}
+
+fn importer_group(
+    importer: &mut ProjectSnapshot,
+    group: DependencyGroup,
+) -> &mut Option<ResolvedDependencyMap> {
+    match group {
+        DependencyGroup::Prod => &mut importer.dependencies,
+        DependencyGroup::Dev => &mut importer.dev_dependencies,
+        DependencyGroup::Optional => &mut importer.optional_dependencies,
+        DependencyGroup::Peer => unreachable!("peerDependencies is not an importer group"),
+    }
 }
 
 /// Drop every dependency the importer records that the manifest no longer

--- a/pnpm/crates/package-manager/src/fast_update_importers.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers.rs
@@ -15,10 +15,16 @@ pub(crate) fn try_fast_update_importers(
     let mut dropped = HashSet::new();
     for (importer_id, manifest) in manifests {
         let importer = candidate.importers.get_mut(importer_id)?;
-        let manifest_specifiers = manifest
-            .dependencies([DependencyGroup::Dev, DependencyGroup::Prod, DependencyGroup::Optional])
-            .collect::<HashMap<_, _>>();
-        for (alias, specifier) in &manifest_specifiers {
+        // Later groups overwrite, so each alias ends at the group
+        // `satisfies_package_manifest` expects it recorded under when it
+        // appears in several: optional wins over prod, prod over dev.
+        let mut manifest_dependencies = HashMap::new();
+        for group in [DependencyGroup::Dev, DependencyGroup::Prod, DependencyGroup::Optional] {
+            for (name, specifier) in manifest.dependencies([group]) {
+                manifest_dependencies.insert(name, (specifier, group));
+            }
+        }
+        for (alias, (specifier, target)) in &manifest_dependencies {
             let alias = PkgName::parse(*alias).ok()?;
             let dependency = importer_dependency_mut(importer, &alias)?;
             if dependency.specifier != *specifier {
@@ -30,14 +36,13 @@ pub(crate) fn try_fast_update_importers(
                 dependency.specifier = (*specifier).to_string();
                 changed = true;
             }
-            let target = effective_dependency_group(manifest, &alias);
-            if let Some(source) = move_dependency(importer, &alias, target) {
+            if let Some(source) = move_dependency(importer, &alias, *target) {
                 moved_across_optional |=
-                    source == DependencyGroup::Optional || target == DependencyGroup::Optional;
+                    source == DependencyGroup::Optional || *target == DependencyGroup::Optional;
                 changed = true;
             }
         }
-        let removed = remove_dependencies_absent_from(importer, &manifest_specifiers);
+        let removed = remove_dependencies_absent_from(importer, &manifest_dependencies);
         changed |= !removed.is_empty();
         dropped.extend(removed);
     }
@@ -55,21 +60,6 @@ pub(crate) fn try_fast_update_importers(
         crate::fast_update_lockfile::recompute_optional_flags(&mut candidate);
     }
     changed.then_some(candidate)
-}
-
-/// The group `satisfies_package_manifest` expects a manifest dependency to
-/// be recorded under when it appears in several: optional wins over prod,
-/// prod over dev.
-fn effective_dependency_group(manifest: &PackageManifest, alias: &PkgName) -> DependencyGroup {
-    let declared_in =
-        |group| manifest.dependencies([group]).any(|(name, _)| alias.to_string() == name);
-    if declared_in(DependencyGroup::Optional) {
-        DependencyGroup::Optional
-    } else if declared_in(DependencyGroup::Prod) {
-        DependencyGroup::Prod
-    } else {
-        DependencyGroup::Dev
-    }
 }
 
 /// Move the importer's record of `alias` into `target`, returning the group
@@ -115,9 +105,9 @@ fn importer_group(
 /// declares, returning their names.
 fn remove_dependencies_absent_from(
     importer: &mut ProjectSnapshot,
-    manifest_specifiers: &HashMap<&str, &str>,
+    manifest_dependencies: &HashMap<&str, (&str, DependencyGroup)>,
 ) -> HashSet<PkgName> {
-    let declared = |alias: &PkgName| manifest_specifiers.contains_key(alias.to_string().as_str());
+    let declared = |alias: &PkgName| manifest_dependencies.contains_key(alias.to_string().as_str());
     let mut removed = HashSet::new();
     for group in [
         importer.dependencies.as_mut(),

--- a/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
@@ -571,3 +571,76 @@ fn moves_a_group_alongside_a_satisfied_range_change() {
         [&"bar".parse::<PkgName>().expect("alias")];
     assert_eq!(moved.specifier, ">=2 <3");
 }
+
+/// `foo` and `bar` are prod dependencies (`bar` reaching `child`), `qux`
+/// is a dev dependency.
+const WITH_THREE_GROUPS: &str = r"
+lockfileVersion: '9.0'
+importers:
+  .:
+    dependencies:
+      foo:
+        specifier: ^1.0.0
+        version: 1.1.0
+      bar:
+        specifier: ^2.0.0
+        version: 2.0.0
+    devDependencies:
+      qux:
+        specifier: ^5.0.0
+        version: 5.0.0
+packages:
+  foo@1.1.0:
+    resolution:
+      integrity: sha512-foo
+  bar@2.0.0:
+    resolution:
+      integrity: sha512-bar
+  child@3.0.0:
+    resolution:
+      integrity: sha512-child
+  qux@5.0.0:
+    resolution:
+      integrity: sha512-qux
+snapshots:
+  foo@1.1.0: {}
+  bar@2.0.0:
+    dependencies:
+      child: 3.0.0
+  child@3.0.0: {}
+  qux@5.0.0: {}
+";
+
+#[test]
+fn moves_several_dependencies_between_groups_in_one_pass() {
+    let manifest = manifest_from(json!({
+        "dependencies": { "qux": "^5.0.0" },
+        "devDependencies": { "foo": "^1.0.0" },
+        "optionalDependencies": { "bar": "^2.0.0" },
+    }));
+
+    let updated = try_fast_update_importers(
+        &parsed_lockfile(WITH_THREE_GROUPS),
+        &[(".".to_string(), &manifest)],
+    )
+    .expect("group moves need no resolution");
+
+    let importer = &updated.importers["."];
+    let recorded_aliases = |group: &Option<pacquet_lockfile::ResolvedDependencyMap>| {
+        group
+            .as_ref()
+            .map(|dependencies| {
+                let mut aliases: Vec<_> = dependencies.keys().map(ToString::to_string).collect();
+                aliases.sort();
+                aliases
+            })
+            .unwrap_or_default()
+    };
+    assert_eq!(recorded_aliases(&importer.dependencies), vec!["qux".to_string()]);
+    assert_eq!(recorded_aliases(&importer.dev_dependencies), vec!["foo".to_string()]);
+    assert_eq!(recorded_aliases(&importer.optional_dependencies), vec!["bar".to_string()]);
+    assert!(snapshot_optional(&updated, "bar@2.0.0"));
+    assert!(snapshot_optional(&updated, "child@3.0.0"));
+    assert!(!snapshot_optional(&updated, "foo@1.1.0"));
+    assert!(!snapshot_optional(&updated, "qux@5.0.0"));
+}

--- a/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
@@ -465,7 +465,7 @@ fn clears_the_subtree_flags_on_a_move_out_of_optional_dependencies() {
         .expect("a group move needs no resolution");
 
     assert!(
-        updated.importers["."].dependencies.as_ref().is_some_and(|deps| deps.contains_key(&alias))
+        updated.importers["."].dependencies.as_ref().is_some_and(|deps| deps.contains_key(&alias)),
     );
     assert!(!snapshot_optional(&updated, "bar@2.0.0"));
     assert!(!snapshot_optional(&updated, "child@3.0.0"), "bar reaches child non-optionally again");

--- a/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
@@ -354,3 +354,220 @@ fn keeps_a_catalog_entry_referenced_with_the_catalog_default_spelling() {
         "the catalog:default spelling counts as a reference to the default catalog",
     );
 }
+
+/// `bar` is a prod dependency reaching `child`; `opt` is an optional
+/// dependency reaching the same `child`, which is therefore non-optional.
+const WITH_SHARED_OPTIONAL_CHILD: &str = r"
+lockfileVersion: '9.0'
+importers:
+  .:
+    dependencies:
+      bar:
+        specifier: ^2.0.0
+        version: 2.0.0
+    optionalDependencies:
+      opt:
+        specifier: ^5.0.0
+        version: 5.0.0
+packages:
+  bar@2.0.0:
+    resolution:
+      integrity: sha512-bar
+  opt@5.0.0:
+    resolution:
+      integrity: sha512-opt
+  child@3.0.0:
+    resolution:
+      integrity: sha512-child
+snapshots:
+  bar@2.0.0:
+    dependencies:
+      child: 3.0.0
+  opt@5.0.0:
+    optional: true
+    dependencies:
+      child: 3.0.0
+  child@3.0.0: {}
+";
+
+fn snapshot_optional(lockfile: &Lockfile, key: &str) -> bool {
+    lockfile.snapshots.as_ref().expect("snapshots")[&key.parse().expect("snapshot key")].optional
+}
+
+#[test]
+fn moves_a_dependency_between_prod_and_dev_without_touching_snapshots() {
+    let manifest = manifest_from(json!({
+        "dependencies": { "foo": "^1.0.0" },
+        "devDependencies": { "bar": "^2.0.0" },
+    }));
+
+    let updated = try_fast_update_importers(
+        &parsed_lockfile(WITH_REMOVABLE_DEP),
+        &[(".".to_string(), &manifest)],
+    )
+    .expect("a group move needs no resolution");
+
+    let importer = &updated.importers["."];
+    let alias: PkgName = "bar".parse().expect("alias");
+    assert!(importer.dependencies.as_ref().is_some_and(|deps| !deps.contains_key(&alias)));
+    let moved = &importer.dev_dependencies.as_ref().expect("devDependencies")[&alias];
+    assert_eq!((moved.specifier.as_str(), moved.version.to_string().as_str()), ("^2.0.0", "2.0.0"));
+    assert_eq!(updated.snapshots, parsed_lockfile(WITH_REMOVABLE_DEP).snapshots);
+}
+
+#[test]
+fn marks_the_subtree_optional_on_a_move_into_optional_dependencies() {
+    let manifest = manifest_from(json!({
+        "dependencies": { "foo": "^1.0.0" },
+        "optionalDependencies": { "bar": "^2.0.0" },
+    }));
+
+    let updated = try_fast_update_importers(
+        &parsed_lockfile(WITH_REMOVABLE_DEP),
+        &[(".".to_string(), &manifest)],
+    )
+    .expect("a group move needs no resolution");
+
+    let alias: PkgName = "bar".parse().expect("alias");
+    assert!(
+        updated.importers["."]
+            .optional_dependencies
+            .as_ref()
+            .is_some_and(|deps| deps.contains_key(&alias)),
+    );
+    assert!(snapshot_optional(&updated, "bar@2.0.0"));
+    assert!(snapshot_optional(&updated, "child@3.0.0"));
+    assert!(!snapshot_optional(&updated, "foo@1.1.0"));
+}
+
+#[test]
+fn clears_the_subtree_flags_on_a_move_out_of_optional_dependencies() {
+    let manifest = manifest_from(json!({
+        "dependencies": { "bar": "^2.0.0" },
+        "optionalDependencies": { "opt": "^5.0.0" },
+    }));
+    let mut subject = parsed_lockfile(WITH_SHARED_OPTIONAL_CHILD);
+    let importer = subject.importers.get_mut(".").expect("importer");
+    let alias: PkgName = "bar".parse().expect("alias");
+    let moved = importer.dependencies.as_mut().expect("dependencies").remove(&alias).expect("bar");
+    importer.dependencies = None;
+    importer
+        .optional_dependencies
+        .as_mut()
+        .expect("optionalDependencies")
+        .insert(alias.clone(), moved);
+    let snapshots = subject.snapshots.as_mut().expect("snapshots");
+    for key in ["bar@2.0.0", "child@3.0.0"] {
+        snapshots.get_mut(&key.parse().expect("snapshot key")).expect("snapshot").optional = true;
+    }
+
+    let updated = try_fast_update_importers(&subject, &[(".".to_string(), &manifest)])
+        .expect("a group move needs no resolution");
+
+    assert!(
+        updated.importers["."].dependencies.as_ref().is_some_and(|deps| deps.contains_key(&alias))
+    );
+    assert!(!snapshot_optional(&updated, "bar@2.0.0"));
+    assert!(!snapshot_optional(&updated, "child@3.0.0"), "bar reaches child non-optionally again");
+    assert!(snapshot_optional(&updated, "opt@5.0.0"));
+}
+
+#[test]
+fn stands_aside_when_every_dependency_is_in_its_recorded_group() {
+    let manifest = manifest_from(json!({
+        "dependencies": { "bar": "^2.0.0" },
+        "optionalDependencies": { "opt": "^5.0.0" },
+    }));
+
+    let updated = try_fast_update_importers(
+        &parsed_lockfile(WITH_SHARED_OPTIONAL_CHILD),
+        &[(".".to_string(), &manifest)],
+    );
+
+    assert!(updated.is_none(), "nothing changed, so the handler stands aside");
+}
+
+#[test]
+fn keeps_a_child_another_prod_dependency_reaches_non_optional() {
+    let mut subject = parsed_lockfile(WITH_SHARED_OPTIONAL_CHILD);
+    let importer = subject.importers.get_mut(".").expect("importer");
+    importer.dependencies.as_mut().expect("dependencies").insert(
+        "keeper".parse().expect("alias"),
+        serde_saphyr::from_str("{specifier: ^6.0.0, version: 6.0.0}").expect("dependency"),
+    );
+    let snapshots = subject.snapshots.as_mut().expect("snapshots");
+    snapshots.insert(
+        "keeper@6.0.0".parse().expect("snapshot key"),
+        serde_saphyr::from_str("dependencies:\n  child: 3.0.0").expect("snapshot"),
+    );
+    let manifest = manifest_from(json!({
+        "dependencies": { "keeper": "^6.0.0" },
+        "optionalDependencies": { "bar": "^2.0.0", "opt": "^5.0.0" },
+    }));
+
+    let updated = try_fast_update_importers(&subject, &[(".".to_string(), &manifest)])
+        .expect("a group move needs no resolution");
+
+    assert!(snapshot_optional(&updated, "bar@2.0.0"));
+    assert!(
+        !snapshot_optional(&updated, "child@3.0.0"),
+        "keeper still reaches child through prod edges",
+    );
+}
+
+#[test]
+fn flips_a_shared_child_optional_when_a_removal_severs_the_prod_path() {
+    let manifest = manifest_from(json!({ "optionalDependencies": { "opt": "^5.0.0" } }));
+
+    let updated = try_fast_update_importers(
+        &parsed_lockfile(WITH_SHARED_OPTIONAL_CHILD),
+        &[(".".to_string(), &manifest)],
+    )
+    .expect("dropping an importer edge needs no resolution");
+
+    assert!(
+        snapshot_optional(&updated, "child@3.0.0"),
+        "only the optional path reaches child once bar is gone",
+    );
+}
+
+#[test]
+fn records_an_alias_declared_in_both_prod_and_optional_as_optional() {
+    let manifest = manifest_from(json!({
+        "dependencies": { "foo": "^1.0.0", "bar": "^2.0.0" },
+        "optionalDependencies": { "bar": "^2.0.0" },
+    }));
+
+    let updated = try_fast_update_importers(
+        &parsed_lockfile(WITH_REMOVABLE_DEP),
+        &[(".".to_string(), &manifest)],
+    )
+    .expect("a group move needs no resolution");
+
+    let alias: PkgName = "bar".parse().expect("alias");
+    assert!(
+        updated.importers["."]
+            .optional_dependencies
+            .as_ref()
+            .is_some_and(|deps| deps.contains_key(&alias)),
+        "optional wins when the manifest declares both",
+    );
+}
+
+#[test]
+fn moves_a_group_alongside_a_satisfied_range_change() {
+    let manifest = manifest_from(json!({
+        "dependencies": { "foo": "^1.0.0" },
+        "devDependencies": { "bar": ">=2 <3" },
+    }));
+
+    let updated = try_fast_update_importers(
+        &parsed_lockfile(WITH_REMOVABLE_DEP),
+        &[(".".to_string(), &manifest)],
+    )
+    .expect("both edits stay within the importer");
+
+    let moved = &updated.importers["."].dev_dependencies.as_ref().expect("devDependencies")
+        [&"bar".parse::<PkgName>().expect("alias")];
+    assert_eq!(moved.specifier, ">=2 <3");
+}

--- a/pnpm/crates/package-manager/src/fast_update_lockfile.rs
+++ b/pnpm/crates/package-manager/src/fast_update_lockfile.rs
@@ -57,6 +57,63 @@ pub(crate) fn prune_unreachable_packages(lockfile: &mut Lockfile) {
     }
 }
 
+/// Recompute every snapshot's `optional` flag from what still reaches it:
+/// set when every path from any importer goes through an
+/// `optionalDependencies` edge, cleared otherwise. An importer edge that
+/// moves into or out of `optionalDependencies`, or a removal that severs
+/// the last non-optional path, changes the flag for the whole subtree.
+pub(crate) fn recompute_optional_flags(lockfile: &mut Lockfile) {
+    let only_optionally_reached = {
+        let Some(snapshots) = lockfile.snapshots.as_ref() else { return };
+        // Walk `(key, reached-optionally)`: `dependencies` edges keep the
+        // context, `optionalDependencies` edges always enter it.
+        let mut visited = HashSet::new();
+        let mut queue = VecDeque::new();
+        for importer in lockfile.importers.values() {
+            for (dependencies, optional) in [
+                (importer.dependencies.as_ref(), false),
+                (importer.dev_dependencies.as_ref(), false),
+                (importer.optional_dependencies.as_ref(), true),
+            ] {
+                for (alias, spec) in dependencies.into_iter().flatten() {
+                    if let Some(key) = spec.version.resolved_key(alias) {
+                        queue.push_back((key, optional));
+                    }
+                }
+            }
+        }
+        while let Some((key, optional)) = queue.pop_front() {
+            if !visited.insert((key.clone(), optional)) {
+                continue;
+            }
+            let Some(snapshot) = snapshots.get(&key) else { continue };
+            for (dependencies, next_optional) in [
+                (snapshot.dependencies.as_ref(), optional),
+                (snapshot.optional_dependencies.as_ref(), true),
+            ] {
+                for (alias, dep_ref) in dependencies.into_iter().flatten() {
+                    if let Some(key) = dep_ref.resolve(alias) {
+                        queue.push_back((key, next_optional));
+                    }
+                }
+            }
+        }
+        let non_optional: HashSet<_> = visited
+            .iter()
+            .filter_map(|(key, optional)| (!optional).then_some(key.clone()))
+            .collect();
+        visited
+            .into_iter()
+            .filter_map(|(key, optional)| (optional && !non_optional.contains(&key)).then_some(key))
+            .collect::<HashSet<_>>()
+    };
+    if let Some(snapshots) = lockfile.snapshots.as_mut() {
+        for (key, snapshot) in snapshots.iter_mut() {
+            snapshot.optional = only_optionally_reached.contains(key);
+        }
+    }
+}
+
 /// Drop every catalog snapshot entry that no importer references any
 /// more, matching what a full resolution records after the same removal.
 pub(crate) fn prune_unreferenced_catalog_entries(lockfile: &mut Lockfile) {

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
@@ -61,14 +61,9 @@ export function tryFastUpdateImporters (
       const recordedIn = recordedDependencyGroup(importer, alias)
       const targetGroup = effectiveDependencyGroup(project.manifest, alias)
       if (recordedIn == null || recordedIn === targetGroup) continue
-      importer[targetGroup] = {
-        ...importer[targetGroup],
-        [alias]: importer[recordedIn]![alias],
-      }
+      const target = importer[targetGroup] ??= {}
+      target[alias] = importer[recordedIn]![alias]
       delete importer[recordedIn]![alias]
-      if (Object.keys(importer[recordedIn]!).length === 0) {
-        delete importer[recordedIn]
-      }
       if (recordedIn === 'optionalDependencies' || targetGroup === 'optionalDependencies') {
         movedAcrossOptional = true
       }
@@ -78,13 +73,15 @@ export function tryFastUpdateImporters (
       if (manifestSpecifiers[alias] != null) continue
       dropped.add(alias)
       delete importer.specifiers[alias]
-      for (const group of ['dependencies', 'devDependencies', 'optionalDependencies'] as const) {
+      for (const group of DEPENDENCIES_FIELDS) {
         delete importer[group]?.[alias]
-        if (importer[group] != null && Object.keys(importer[group]).length === 0) {
-          delete importer[group]
-        }
       }
       changed = true
+    }
+    for (const group of DEPENDENCIES_FIELDS) {
+      if (importer[group] != null && Object.keys(importer[group]).length === 0) {
+        delete importer[group]
+      }
     }
   }
   if (!changed) return false

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
@@ -1,7 +1,7 @@
 import * as dp from '@pnpm/deps.path'
 import { pruneSharedLockfile } from '@pnpm/lockfile.pruner'
-import type { LockfileObject } from '@pnpm/lockfile.types'
-import type { ProjectId, ProjectManifest } from '@pnpm/types'
+import type { LockfileObject, ProjectSnapshot } from '@pnpm/lockfile.types'
+import { DEPENDENCIES_FIELDS, type DependenciesField, type ProjectId, type ProjectManifest } from '@pnpm/types'
 import { clone } from 'ramda'
 import semver from 'semver'
 
@@ -21,7 +21,9 @@ export function hasChangedProjectSpecifiers (
     if (importer == null) return false
     const manifestSpecifiers = getManifestSpecifiers(project.manifest)
     return Object.entries(manifestSpecifiers)
-      .some(([alias, specifier]) => importer.specifiers[alias] !== specifier) ||
+      .some(([alias, specifier]) =>
+        importer.specifiers[alias] !== specifier ||
+        dependencyGroupMoved(importer, project.manifest, alias)) ||
       Object.keys(importer.specifiers).some((alias) => manifestSpecifiers[alias] == null)
   })
 }
@@ -33,26 +35,43 @@ export function tryFastUpdateImporters (
   const candidate = clone(lockfile)
   const dropped = new Set<string>()
   let changed = false
+  let movedAcrossOptional = false
   for (const project of projects) {
     const importer = candidate.importers[project.id]
     if (importer == null) return false
     const manifestSpecifiers = getManifestSpecifiers(project.manifest)
     for (const [alias, specifier] of Object.entries(manifestSpecifiers)) {
-      if (importer.specifiers[alias] === specifier) continue
-      const reference =
-        importer.optionalDependencies?.[alias] ??
-        importer.dependencies?.[alias] ??
-        importer.devDependencies?.[alias]
-      const version = reference == null ? null : dp.removeSuffix(reference)
-      if (
-        semver.validRange(specifier) == null ||
-        version == null ||
-        semver.valid(version) == null ||
-        !semver.satisfies(version, specifier)
-      ) {
-        return false
+      if (importer.specifiers[alias] !== specifier) {
+        const reference =
+          importer.optionalDependencies?.[alias] ??
+          importer.dependencies?.[alias] ??
+          importer.devDependencies?.[alias]
+        const version = reference == null ? null : dp.removeSuffix(reference)
+        if (
+          semver.validRange(specifier) == null ||
+          version == null ||
+          semver.valid(version) == null ||
+          !semver.satisfies(version, specifier)
+        ) {
+          return false
+        }
+        importer.specifiers[alias] = specifier
+        changed = true
       }
-      importer.specifiers[alias] = specifier
+      const recordedIn = recordedDependencyGroup(importer, alias)
+      const targetGroup = effectiveDependencyGroup(project.manifest, alias)
+      if (recordedIn == null || recordedIn === targetGroup) continue
+      importer[targetGroup] = {
+        ...importer[targetGroup],
+        [alias]: importer[recordedIn]![alias],
+      }
+      delete importer[recordedIn]![alias]
+      if (Object.keys(importer[recordedIn]!).length === 0) {
+        delete importer[recordedIn]
+      }
+      if (recordedIn === 'optionalDependencies' || targetGroup === 'optionalDependencies') {
+        movedAcrossOptional = true
+      }
       changed = true
     }
     for (const alias of Object.keys(importer.specifiers)) {
@@ -70,13 +89,18 @@ export function tryFastUpdateImporters (
   }
   if (!changed) return false
 
-  if (dropped.size > 0) {
+  // The prune also recomputes each package's `optional` flag from what still
+  // reaches it, which a move into or out of `optionalDependencies` changes
+  // for the whole subtree.
+  if (dropped.size > 0 || movedAcrossOptional) {
     const pruned = pruneSharedLockfile(candidate)
     if (pruned.packages == null) {
       delete candidate.packages
     } else {
       candidate.packages = pruned.packages
     }
+  }
+  if (dropped.size > 0) {
     // Pruned first: a peer-dependent package that the removal itself makes
     // unreachable needs no rekeying, so only the survivors are checked.
     if (!peerSuffixesAreIndependentOf(candidate, dropped)) return false
@@ -117,6 +141,30 @@ function peerSuffixesAreIndependentOf (lockfile: LockfileObject, dropped: Set<st
       .every((segment) => segment.includes('@')) &&
       ![...dropped].some((alias) => peers.includes(`${alias}@`))
   })
+}
+
+function dependencyGroupMoved (
+  importer: ProjectSnapshot,
+  manifest: ProjectManifest,
+  alias: string
+): boolean {
+  const recordedIn = recordedDependencyGroup(importer, alias)
+  return recordedIn != null && recordedIn !== effectiveDependencyGroup(manifest, alias)
+}
+
+function recordedDependencyGroup (importer: ProjectSnapshot, alias: string): DependenciesField | null {
+  return DEPENDENCIES_FIELDS.find((group) => importer[group]?.[alias] != null) ?? null
+}
+
+/**
+ * The group `satisfiesPackageManifest` expects a manifest dependency to be
+ * recorded under when it appears in several: optional wins over prod, prod
+ * over dev.
+ */
+function effectiveDependencyGroup (manifest: ProjectManifest, alias: string): DependenciesField {
+  if (manifest.optionalDependencies?.[alias] != null) return 'optionalDependencies'
+  if (manifest.dependencies?.[alias] != null) return 'dependencies'
+  return 'devDependencies'
 }
 
 function getManifestSpecifiers (manifest: ProjectManifest): Record<string, string> {

--- a/pnpm11/installing/deps-installer/test/install/importerGroupMoveFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/importerGroupMoveFastUpdate.ts
@@ -1,0 +1,194 @@
+import { expect, test } from '@jest/globals'
+import { mutateModulesInSingleProject } from '@pnpm/installing.deps-installer'
+import type { LockfileObject } from '@pnpm/lockfile.types'
+import { prepareEmpty } from '@pnpm/prepare'
+import type { StoreController } from '@pnpm/store.controller-types'
+import type { DepPath, ProjectId, ProjectManifest, ProjectRootDir } from '@pnpm/types'
+import { clone } from 'ramda'
+
+import {
+  hasChangedProjectSpecifiers,
+  tryFastUpdateImporters,
+} from '../../src/install/tryFastUpdateImporters.js'
+import { testDefaults } from '../utils/index.js'
+
+test('a dependency moved to another group is noticed as a change', () => {
+  expect(hasChangedProjectSpecifiers(lockfile(), [
+    project({ dependencies: { foo: '^1.0.0' }, devDependencies: { bar: '^2.0.0' } }),
+  ])).toBe(true)
+})
+
+test('a dependency in its recorded group is not a change', () => {
+  expect(hasChangedProjectSpecifiers(lockfile(), [
+    project({ dependencies: { foo: '^1.0.0', bar: '^2.0.0' } }),
+  ])).toBe(false)
+})
+
+test('a move between prod and dev only edits the importer', () => {
+  const subject = lockfile()
+  const packagesBefore = clone(subject.packages)
+
+  expect(tryFastUpdateImporters(subject, [
+    project({ dependencies: { foo: '^1.0.0' }, devDependencies: { bar: '^2.0.0' } }),
+  ])).toBe(true)
+  const importer = subject.importers['.' as ProjectId]
+  expect(importer.dependencies).toStrictEqual({ foo: '1.1.0' })
+  expect(importer.devDependencies).toStrictEqual({ bar: '2.0.0' })
+  expect(importer.specifiers).toStrictEqual({ foo: '^1.0.0', bar: '^2.0.0' })
+  expect(subject.packages).toStrictEqual(packagesBefore)
+})
+
+test('a move into optionalDependencies marks the subtree optional', () => {
+  const subject = lockfile()
+
+  expect(tryFastUpdateImporters(subject, [
+    project({ dependencies: { foo: '^1.0.0' }, optionalDependencies: { bar: '^2.0.0' } }),
+  ])).toBe(true)
+  const importer = subject.importers['.' as ProjectId]
+  expect(importer.dependencies).toStrictEqual({ foo: '1.1.0' })
+  expect(importer.optionalDependencies).toStrictEqual({ bar: '2.0.0' })
+  expect(subject.packages!['bar@2.0.0' as DepPath].optional).toBe(true)
+  expect(subject.packages!['child@3.0.0' as DepPath].optional).toBe(true)
+  expect(subject.packages!['foo@1.1.0' as DepPath].optional).toBeUndefined()
+})
+
+test('a move out of optionalDependencies clears the subtree flags', () => {
+  const subject = lockfile()
+  const importer = subject.importers['.' as ProjectId]
+  importer.optionalDependencies = { bar: importer.dependencies!.bar }
+  importer.dependencies = { foo: importer.dependencies!.foo }
+  subject.packages!['bar@2.0.0' as DepPath].optional = true
+  subject.packages!['child@3.0.0' as DepPath].optional = true
+
+  expect(tryFastUpdateImporters(subject, [
+    project({ dependencies: { foo: '^1.0.0', bar: '^2.0.0' } }),
+  ])).toBe(true)
+  expect(subject.importers['.' as ProjectId].optionalDependencies).toBeUndefined()
+  expect(subject.importers['.' as ProjectId].dependencies).toStrictEqual({ foo: '1.1.0', bar: '2.0.0' })
+  expect(subject.packages!['bar@2.0.0' as DepPath].optional).toBeUndefined()
+  expect(subject.packages!['child@3.0.0' as DepPath].optional).toBeUndefined()
+})
+
+test('a subtree package another prod dependency reaches stays non-optional', () => {
+  const subject = lockfile()
+  subject.importers['.' as ProjectId].dependencies!.parent = '4.0.0'
+  subject.importers['.' as ProjectId].specifiers.parent = '^4.0.0'
+  subject.packages!['parent@4.0.0' as DepPath] = {
+    resolution: { integrity: 'sha512-parent' },
+    dependencies: { child: '3.0.0' },
+  }
+
+  expect(tryFastUpdateImporters(subject, [
+    project({
+      dependencies: { foo: '^1.0.0', parent: '^4.0.0' },
+      optionalDependencies: { bar: '^2.0.0' },
+    }),
+  ])).toBe(true)
+  expect(subject.packages!['bar@2.0.0' as DepPath].optional).toBe(true)
+  expect(subject.packages!['child@3.0.0' as DepPath].optional).toBeUndefined()
+})
+
+test('an alias in both prod and optional groups is recorded as optional', () => {
+  const subject = lockfile()
+
+  expect(tryFastUpdateImporters(subject, [
+    project({
+      dependencies: { foo: '^1.0.0', bar: '^2.0.0' },
+      optionalDependencies: { bar: '^2.0.0' },
+    }),
+  ])).toBe(true)
+  const importer = subject.importers['.' as ProjectId]
+  expect(importer.dependencies).toStrictEqual({ foo: '1.1.0' })
+  expect(importer.optionalDependencies).toStrictEqual({ bar: '2.0.0' })
+})
+
+test('a group move rides along with a satisfied range change', () => {
+  const subject = lockfile()
+
+  expect(tryFastUpdateImporters(subject, [
+    project({ dependencies: { foo: '^1.0.0' }, devDependencies: { bar: '^2.0.0 <3.0.0' } }),
+  ])).toBe(true)
+  const importer = subject.importers['.' as ProjectId]
+  expect(importer.devDependencies).toStrictEqual({ bar: '2.0.0' })
+  expect(importer.specifiers.bar).toBe('^2.0.0 <3.0.0')
+})
+
+test('moving a dependency between groups requests no packages', async () => {
+  const project = prepareEmpty()
+  const manifest: ProjectManifest = {
+    dependencies: {
+      '@pnpm.e2e/pkg-with-1-dep': '100.0.0',
+      'is-positive': '1.0.0',
+    },
+  }
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, testDefaults())
+
+  const options = testDefaults()
+  const requestedPackages = trackRequestedPackages(options.storeController)
+  await mutateModulesInSingleProject({
+    manifest: {
+      dependencies: { 'is-positive': '1.0.0' },
+      optionalDependencies: { '@pnpm.e2e/pkg-with-1-dep': '100.0.0' },
+    },
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, options)
+
+  expect(requestedPackages).toStrictEqual([])
+  const lockfile = project.readLockfile()
+  expect(lockfile.importers['.']).toStrictEqual({
+    dependencies: {
+      'is-positive': { specifier: '1.0.0', version: '1.0.0' },
+    },
+    optionalDependencies: {
+      '@pnpm.e2e/pkg-with-1-dep': { specifier: '100.0.0', version: '100.0.0' },
+    },
+  })
+  expect(lockfile.snapshots['@pnpm.e2e/pkg-with-1-dep@100.0.0'].optional).toBe(true)
+  const depOfPkgSnapshot = Object.entries(lockfile.snapshots)
+    .find(([depPath]) => depPath.startsWith('@pnpm.e2e/dep-of-pkg-with-1-dep@'))?.[1]
+  expect(depOfPkgSnapshot?.optional).toBe(true)
+  project.has('@pnpm.e2e/pkg-with-1-dep')
+  project.has('is-positive')
+})
+
+function trackRequestedPackages (storeController: StoreController): string[] {
+  const requestedPackages: string[] = []
+  const requestPackage = storeController.requestPackage
+  storeController.requestPackage = async (wantedDependency, requestOptions) => {
+    requestedPackages.push(wantedDependency.alias!)
+    return requestPackage(wantedDependency, requestOptions)
+  }
+  return requestedPackages
+}
+
+function project (manifest: Pick<ProjectManifest, 'dependencies' | 'devDependencies' | 'optionalDependencies'>) {
+  return {
+    id: '.' as ProjectId,
+    manifest: manifest as ProjectManifest,
+  }
+}
+
+function lockfile (): LockfileObject {
+  return {
+    lockfileVersion: '9.0',
+    importers: {
+      ['.' as ProjectId]: {
+        specifiers: { foo: '^1.0.0', bar: '^2.0.0' },
+        dependencies: { foo: '1.1.0', bar: '2.0.0' },
+      },
+    },
+    packages: {
+      ['foo@1.1.0' as DepPath]: { resolution: { integrity: 'sha512-foo' } },
+      ['bar@2.0.0' as DepPath]: {
+        resolution: { integrity: 'sha512-bar' },
+        dependencies: { child: '3.0.0' },
+      },
+      ['child@3.0.0' as DepPath]: { resolution: { integrity: 'sha512-child' } },
+    },
+  }
+}

--- a/pnpm11/installing/deps-installer/test/install/importerGroupMoveFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/importerGroupMoveFastUpdate.ts
@@ -102,6 +102,29 @@ test('an alias in both prod and optional groups is recorded as optional', () => 
   expect(importer.optionalDependencies).toStrictEqual({ bar: '2.0.0' })
 })
 
+test('several dependencies move between groups in one pass', () => {
+  const subject = lockfile()
+  subject.importers['.' as ProjectId].devDependencies = { qux: '5.0.0' }
+  subject.importers['.' as ProjectId].specifiers.qux = '^5.0.0'
+  subject.packages!['qux@5.0.0' as DepPath] = { resolution: { integrity: 'sha512-qux' } }
+
+  expect(tryFastUpdateImporters(subject, [
+    project({
+      dependencies: { qux: '^5.0.0' },
+      devDependencies: { foo: '^1.0.0' },
+      optionalDependencies: { bar: '^2.0.0' },
+    }),
+  ])).toBe(true)
+  const importer = subject.importers['.' as ProjectId]
+  expect(importer.dependencies).toStrictEqual({ qux: '5.0.0' })
+  expect(importer.devDependencies).toStrictEqual({ foo: '1.1.0' })
+  expect(importer.optionalDependencies).toStrictEqual({ bar: '2.0.0' })
+  expect(subject.packages!['bar@2.0.0' as DepPath].optional).toBe(true)
+  expect(subject.packages!['child@3.0.0' as DepPath].optional).toBe(true)
+  expect(subject.packages!['qux@5.0.0' as DepPath].optional).toBeUndefined()
+  expect(subject.packages!['foo@1.1.0' as DepPath].optional).toBeUndefined()
+})
+
 test('a group move rides along with a satisfied range change', () => {
   const subject = lockfile()
 


### PR DESCRIPTION
## Summary

Related to pnpm/pnpm#13696 (item 2).

A dependency moved between `dependencies`, `devDependencies`, and `optionalDependencies` keeps its resolved version — only the importer group it is recorded under changes, plus the reachability-derived `optional` flags on its subtree when `optionalDependencies` is involved. Until now this was a double miss: `hasChangedProjectSpecifiers` compares specifier strings, so it never noticed, while `satisfiesPackageManifest` checks group membership and failed freshness — so the change always paid a full resolution.

Both stacks now absorb group moves in the importers fast-update handler:

- The importer entry moves to the group the manifest declares, using the precedence the freshness check expects (optional over prod over dev).
- On a move into or out of `optionalDependencies`, the per-snapshot `optional` flags are recomputed from what still reaches each package. The TypeScript side reuses `pruneSharedLockfile`, which already rebuilds the flags during its walk; pacquet gains a `recompute_optional_flags` walk with the same semantics (a package is optional iff every path from any importer goes through an `optionalDependencies` edge).
- pacquet's removal path now runs the recompute too, fixing a latent parity gap: severing the last non-optional path to a shared child left the child's `optional` flag stale, where the TypeScript handler already recomputed it via the pruner.

Both stacks fall back to the resolver under identical conditions, unchanged from before.

Tested with unit tests on both handlers (dev↔prod, prod↔optional both directions, shared-child stays non-optional, both-groups precedence, move + satisfied range change, removal severing the last prod path), an install-level TS test asserting zero `requestPackage` calls, and a pacquet e2e against a dead registry asserting the "resolution step is skipped" path. The install-level and e2e tests were verified to fail with the handler disabled.

## Squash Commit Body

```text
A dependency moved between dependencies, devDependencies, and
optionalDependencies keeps its resolved version; only the importer
group it is recorded under changes, plus the reachability-derived
optional flags on its subtree when optionalDependencies is involved.
Both stacks now absorb such moves in the importers fast-update
handler instead of paying a full resolution: the importer entry moves
to the group the manifest declares (optional over prod over dev, the
precedence the freshness check expects), and the optional flags are
recomputed from what still reaches each snapshot.

pacquet gains a recompute_optional_flags walk for this, and the
removal path now runs it too: severing the last non-optional path to
a shared child previously left the child's optional flag stale,
where the TypeScript handler already recomputed it via the pruner.

Related to pnpm/pnpm#13696.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788953104&installation_model_id=426870&pr_number=13761&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13761&signature=1bc2e4a410e3627d0d69ef892d3ce12a57766fae476fd5d988e9c74d29e647ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dependency moves between production, development, and optional sections now update the lockfile in place without re-resolving the entire dependency graph.
  * Lockfile metadata and optional dependency relationships are recalculated to preserve accurate installation behavior.
* **Bug Fixes**
  * Improved handling of moved, dropped, overlapping, and shared dependencies during fast updates.
  * Preserved existing package data and avoided unnecessary package requests when dependencies remain resolvable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->