### PR TITLE
refactor: single staging layer for fast lockfile updates

### DIFF
--- a/.changeset/fast-update-single-staging.md
+++ b/.changeset/fast-update-single-staging.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.deps-installer": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+Removing the last dependency that references a catalog entry via the fast lockfile update no longer leaves the stale catalog entry in `pnpm-lock.yaml`.

--- a/pnpm/crates/package-manager/src/fast_update_importers.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers.rs
@@ -6,28 +6,27 @@ use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use std::collections::{HashMap, HashSet};
 
 /// Each manifest alias with its specifier and the group it is
-/// effectively declared under.
-type ManifestDependencies<'manifest> = HashMap<&'manifest str, (&'manifest str, DependencyGroup)>;
+/// effectively declared under. Keyed by [`PkgName`] so membership tests
+/// against importer records need no per-dependency conversions.
+type ManifestDependencies<'manifest> = HashMap<PkgName, (&'manifest str, DependencyGroup)>;
 
 pub(crate) fn try_fast_update_importers(
     lockfile: &Lockfile,
     manifests: &[(String, &PackageManifest)],
 ) -> Option<Lockfile> {
-    let manifest_dependencies: Vec<(&String, ManifestDependencies<'_>)> = manifests
-        .iter()
-        .map(|(importer_id, manifest)| {
-            // Later groups overwrite, so each alias ends at the group
-            // `satisfies_package_manifest` expects it recorded under when it
-            // appears in several: optional wins over prod, prod over dev.
-            let mut dependencies = HashMap::new();
-            for group in [DependencyGroup::Dev, DependencyGroup::Prod, DependencyGroup::Optional] {
-                for (name, specifier) in manifest.dependencies([group]) {
-                    dependencies.insert(name, (specifier, group));
-                }
+    let mut manifest_dependencies: Vec<(&String, ManifestDependencies<'_>)> = Vec::new();
+    for (importer_id, manifest) in manifests {
+        // Later groups overwrite, so each alias ends at the group
+        // `satisfies_package_manifest` expects it recorded under when it
+        // appears in several: optional wins over prod, prod over dev.
+        let mut dependencies = HashMap::new();
+        for group in [DependencyGroup::Dev, DependencyGroup::Prod, DependencyGroup::Optional] {
+            for (name, specifier) in manifest.dependencies([group]) {
+                dependencies.insert(PkgName::parse(name).ok()?, (specifier, group));
             }
-            (importer_id, dependencies)
-        })
-        .collect();
+        }
+        manifest_dependencies.push((importer_id, dependencies));
+    }
     // Cloning the lockfile is the expensive part, so nothing is cloned
     // until this cheap scan finds drift the loop below would act on.
     if !manifest_dependencies
@@ -43,8 +42,7 @@ pub(crate) fn try_fast_update_importers(
     for (importer_id, manifest_dependencies) in &manifest_dependencies {
         let importer = candidate.importers.get_mut(importer_id.as_str())?;
         for (alias, (specifier, target)) in manifest_dependencies {
-            let alias = PkgName::parse(*alias).ok()?;
-            let dependency = importer_dependency_mut(importer, &alias)?;
+            let dependency = importer_dependency_mut(importer, alias)?;
             if dependency.specifier != *specifier {
                 let range = Range::parse(specifier).ok()?;
                 let version = dependency.version.ver_peer()?.version_semver()?;
@@ -54,7 +52,7 @@ pub(crate) fn try_fast_update_importers(
                 dependency.specifier = (*specifier).to_string();
                 changed = true;
             }
-            if let Some(source) = move_dependency(importer, &alias, *target) {
+            if let Some(source) = move_dependency(importer, alias, *target) {
                 moved_across_optional |=
                     source == DependencyGroup::Optional || *target == DependencyGroup::Optional;
                 changed = true;
@@ -101,13 +99,10 @@ fn importer_diverges(
     .into_iter()
     .flatten()
     .flat_map(HashMap::keys)
-    .any(|alias| !manifest_dependencies.contains_key(alias.to_string().as_str()));
+    .any(|alias| !manifest_dependencies.contains_key(alias));
     recorded_but_undeclared
         || manifest_dependencies.iter().any(|(alias, (specifier, target))| {
-            let Ok(alias) = PkgName::parse(*alias) else {
-                return true;
-            };
-            let Some((recorded_in, dependency)) = importer_dependency(importer, &alias) else {
+            let Some((recorded_in, dependency)) = importer_dependency(importer, alias) else {
                 return true;
             };
             dependency.specifier != *specifier || recorded_in != *target
@@ -174,7 +169,7 @@ fn remove_dependencies_absent_from(
     importer: &mut ProjectSnapshot,
     manifest_dependencies: &ManifestDependencies<'_>,
 ) -> HashSet<PkgName> {
-    let declared = |alias: &PkgName| manifest_dependencies.contains_key(alias.to_string().as_str());
+    let declared = |alias: &PkgName| manifest_dependencies.contains_key(alias);
     let mut removed = HashSet::new();
     for group in [
         importer.dependencies.as_mut(),

--- a/pnpm/crates/package-manager/src/fast_update_importers.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers.rs
@@ -5,26 +5,44 @@ use pacquet_lockfile::{
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use std::collections::{HashMap, HashSet};
 
+/// Each manifest alias with its specifier and the group it is
+/// effectively declared under.
+type ManifestDependencies<'manifest> = HashMap<&'manifest str, (&'manifest str, DependencyGroup)>;
+
 pub(crate) fn try_fast_update_importers(
     lockfile: &Lockfile,
     manifests: &[(String, &PackageManifest)],
 ) -> Option<Lockfile> {
+    let manifest_dependencies: Vec<(&String, ManifestDependencies<'_>)> = manifests
+        .iter()
+        .map(|(importer_id, manifest)| {
+            // Later groups overwrite, so each alias ends at the group
+            // `satisfies_package_manifest` expects it recorded under when it
+            // appears in several: optional wins over prod, prod over dev.
+            let mut dependencies = HashMap::new();
+            for group in [DependencyGroup::Dev, DependencyGroup::Prod, DependencyGroup::Optional] {
+                for (name, specifier) in manifest.dependencies([group]) {
+                    dependencies.insert(name, (specifier, group));
+                }
+            }
+            (importer_id, dependencies)
+        })
+        .collect();
+    // Cloning the lockfile is the expensive part, so nothing is cloned
+    // until this cheap scan finds drift the loop below would act on.
+    if !manifest_dependencies
+        .iter()
+        .any(|(importer_id, dependencies)| importer_diverges(lockfile, importer_id, dependencies))
+    {
+        return None;
+    }
     let mut candidate = lockfile.clone();
     let mut changed = false;
     let mut moved_across_optional = false;
     let mut dropped = HashSet::new();
-    for (importer_id, manifest) in manifests {
-        let importer = candidate.importers.get_mut(importer_id)?;
-        // Later groups overwrite, so each alias ends at the group
-        // `satisfies_package_manifest` expects it recorded under when it
-        // appears in several: optional wins over prod, prod over dev.
-        let mut manifest_dependencies = HashMap::new();
-        for group in [DependencyGroup::Dev, DependencyGroup::Prod, DependencyGroup::Optional] {
-            for (name, specifier) in manifest.dependencies([group]) {
-                manifest_dependencies.insert(name, (specifier, group));
-            }
-        }
-        for (alias, (specifier, target)) in &manifest_dependencies {
+    for (importer_id, manifest_dependencies) in &manifest_dependencies {
+        let importer = candidate.importers.get_mut(importer_id.as_str())?;
+        for (alias, (specifier, target)) in manifest_dependencies {
             let alias = PkgName::parse(*alias).ok()?;
             let dependency = importer_dependency_mut(importer, &alias)?;
             if dependency.specifier != *specifier {
@@ -42,7 +60,7 @@ pub(crate) fn try_fast_update_importers(
                 changed = true;
             }
         }
-        let removed = remove_dependencies_absent_from(importer, &manifest_dependencies);
+        let removed = remove_dependencies_absent_from(importer, manifest_dependencies);
         changed |= !removed.is_empty();
         dropped.extend(removed);
     }
@@ -60,6 +78,55 @@ pub(crate) fn try_fast_update_importers(
         crate::fast_update_lockfile::recompute_optional_flags(&mut candidate);
     }
     changed.then_some(candidate)
+}
+
+/// Whether the importer's record differs from the manifest in a way the
+/// update loop would act on: a changed specifier, a dependency recorded
+/// under another group, a dependency the manifest no longer declares, or
+/// a manifest entry the importer does not record (which the loop turns
+/// into a fallback).
+fn importer_diverges(
+    lockfile: &Lockfile,
+    importer_id: &str,
+    manifest_dependencies: &ManifestDependencies<'_>,
+) -> bool {
+    let Some(importer) = lockfile.importers.get(importer_id) else {
+        return false;
+    };
+    let recorded_but_undeclared = [
+        importer.dependencies.as_ref(),
+        importer.dev_dependencies.as_ref(),
+        importer.optional_dependencies.as_ref(),
+    ]
+    .into_iter()
+    .flatten()
+    .flat_map(HashMap::keys)
+    .any(|alias| !manifest_dependencies.contains_key(alias.to_string().as_str()));
+    recorded_but_undeclared
+        || manifest_dependencies.iter().any(|(alias, (specifier, target))| {
+            let Ok(alias) = PkgName::parse(*alias) else {
+                return true;
+            };
+            let Some((recorded_in, dependency)) = importer_dependency(importer, &alias) else {
+                return true;
+            };
+            dependency.specifier != *specifier || recorded_in != *target
+        })
+}
+
+fn importer_dependency<'a>(
+    importer: &'a ProjectSnapshot,
+    alias: &PkgName,
+) -> Option<(DependencyGroup, &'a ResolvedDependencySpec)> {
+    [
+        (DependencyGroup::Optional, importer.optional_dependencies.as_ref()),
+        (DependencyGroup::Prod, importer.dependencies.as_ref()),
+        (DependencyGroup::Dev, importer.dev_dependencies.as_ref()),
+    ]
+    .into_iter()
+    .find_map(|(group, dependencies)| {
+        dependencies.and_then(|dependencies| dependencies.get(alias)).map(|spec| (group, spec))
+    })
 }
 
 /// Move the importer's record of `alias` into `target`, returning the group
@@ -105,7 +172,7 @@ fn importer_group(
 /// declares, returning their names.
 fn remove_dependencies_absent_from(
     importer: &mut ProjectSnapshot,
-    manifest_dependencies: &HashMap<&str, (&str, DependencyGroup)>,
+    manifest_dependencies: &ManifestDependencies<'_>,
 ) -> HashSet<PkgName> {
     let declared = |alias: &PkgName| manifest_dependencies.contains_key(alias.to_string().as_str());
     let mut removed = HashSet::new();

--- a/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
@@ -644,3 +644,13 @@ fn moves_several_dependencies_between_groups_in_one_pass() {
     assert!(!snapshot_optional(&updated, "foo@1.1.0"));
     assert!(!snapshot_optional(&updated, "qux@5.0.0"));
 }
+
+#[test]
+fn rejects_a_dependency_the_lockfile_does_not_record() {
+    let manifest = manifest_from(json!({ "dependencies": { "foo": "^1.0.0", "extra": "^1.0.0" } }));
+
+    assert!(
+        try_fast_update_importers(&lockfile(), &[(".".to_string(), &manifest)]).is_none(),
+        "an added dependency needs the resolver",
+    );
+}

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -139,6 +139,14 @@ const BROKEN_LOCKFILE_INTEGRITY_ERRORS = new Set([
 
 const DEV_PREINSTALL = 'pnpm:devPreinstall'
 
+/** The changed lockfile fields that have a dedicated fast-update handler. */
+const FAST_UPDATABLE_SETTINGS = new Set<ChangedField | null>([
+  'catalogs',
+  'ignoredOptionalDependencies',
+  'overrides',
+  'patchedDependencies',
+])
+
 interface InstallMutationOptions {
   update?: boolean
   updateToLatest?: boolean
@@ -731,10 +739,7 @@ export async function mutateModules (
     const onlyLockfileSettingsChanged = changedLockfileSettings.length > 0 &&
       changedLockfileSettings.length === changedSettingsFields.length
     const canTryFastUpdateLockfile =
-      (outdatedLockfileSettingName === 'catalogs' ||
-        outdatedLockfileSettingName === 'ignoredOptionalDependencies' ||
-        outdatedLockfileSettingName === 'overrides' ||
-        outdatedLockfileSettingName === 'patchedDependencies' ||
+      (FAST_UPDATABLE_SETTINGS.has(outdatedLockfileSettingName) ||
         onlyLockfileSettingsChanged ||
         hasChangedSpecifiers) &&
       !frozenLockfile &&

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -139,7 +139,6 @@ const BROKEN_LOCKFILE_INTEGRITY_ERRORS = new Set([
 
 const DEV_PREINSTALL = 'pnpm:devPreinstall'
 
-/** The changed lockfile fields that have a dedicated fast-update handler. */
 const FAST_UPDATABLE_SETTINGS = new Set<ChangedField | null>([
   'catalogs',
   'ignoredOptionalDependencies',

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
@@ -2,7 +2,6 @@ import * as dp from '@pnpm/deps.path'
 import { pruneSharedLockfile } from '@pnpm/lockfile.pruner'
 import type { LockfileObject, ProjectSnapshot } from '@pnpm/lockfile.types'
 import { DEPENDENCIES_FIELDS, type DependenciesField, type ProjectId, type ProjectManifest } from '@pnpm/types'
-import { clone } from 'ramda'
 import semver from 'semver'
 
 import { pruneUnreferencedCatalogEntries } from './tryFastUpdateCatalogs.js'
@@ -28,16 +27,20 @@ export function hasChangedProjectSpecifiers (
   })
 }
 
+/**
+ * Mutates `lockfile` in place and may leave it partially rewritten when it
+ * returns `false` — the caller passes the coordinator's disposable candidate,
+ * which is discarded on failure.
+ */
 export function tryFastUpdateImporters (
   lockfile: LockfileObject,
   projects: Project[]
 ): boolean {
-  const candidate = clone(lockfile)
   const dropped = new Set<string>()
   let changed = false
   let movedAcrossOptional = false
   for (const project of projects) {
-    const importer = candidate.importers[project.id]
+    const importer = lockfile.importers[project.id]
     if (importer == null) return false
     const manifestSpecifiers = getManifestSpecifiers(project.manifest)
     for (const [alias, specifier] of Object.entries(manifestSpecifiers)) {
@@ -90,30 +93,18 @@ export function tryFastUpdateImporters (
   // reaches it, which a move into or out of `optionalDependencies` changes
   // for the whole subtree.
   if (dropped.size > 0 || movedAcrossOptional) {
-    const pruned = pruneSharedLockfile(candidate)
+    const pruned = pruneSharedLockfile(lockfile)
     if (pruned.packages == null) {
-      delete candidate.packages
+      delete lockfile.packages
     } else {
-      candidate.packages = pruned.packages
+      lockfile.packages = pruned.packages
     }
   }
   if (dropped.size > 0) {
     // Pruned first: a peer-dependent package that the removal itself makes
     // unreachable needs no rekeying, so only the survivors are checked.
-    if (!peerSuffixesAreIndependentOf(candidate, dropped)) return false
-    pruneUnreferencedCatalogEntries(candidate)
-  }
-
-  lockfile.importers = candidate.importers
-  if (candidate.packages == null) {
-    delete lockfile.packages
-  } else {
-    lockfile.packages = candidate.packages
-  }
-  if (candidate.catalogs == null) {
-    delete lockfile.catalogs
-  } else {
-    lockfile.catalogs = candidate.catalogs
+    if (!peerSuffixesAreIndependentOf(lockfile, dropped)) return false
+    pruneUnreferencedCatalogEntries(lockfile)
   }
   return true
 }

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
@@ -42,6 +42,7 @@ export function tryFastUpdateImporters (
   for (const project of projects) {
     const importer = lockfile.importers[project.id]
     if (importer == null) return false
+    let editedGroups = false
     const manifestSpecifiers = getManifestSpecifiers(project.manifest)
     for (const [alias, specifier] of Object.entries(manifestSpecifiers)) {
       if (importer.specifiers[alias] !== specifier) {
@@ -70,6 +71,7 @@ export function tryFastUpdateImporters (
       if (recordedIn === 'optionalDependencies' || targetGroup === 'optionalDependencies') {
         movedAcrossOptional = true
       }
+      editedGroups = true
       changed = true
     }
     for (const alias of Object.keys(importer.specifiers)) {
@@ -79,11 +81,14 @@ export function tryFastUpdateImporters (
       for (const group of DEPENDENCIES_FIELDS) {
         delete importer[group]?.[alias]
       }
+      editedGroups = true
       changed = true
     }
-    for (const group of DEPENDENCIES_FIELDS) {
-      if (importer[group] != null && Object.keys(importer[group]).length === 0) {
-        delete importer[group]
+    if (editedGroups) {
+      for (const group of DEPENDENCIES_FIELDS) {
+        if (importer[group] != null && Object.keys(importer[group]).length === 0) {
+          delete importer[group]
+        }
       }
     }
   }

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateLockfile.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateLockfile.ts
@@ -1,6 +1,11 @@
 import type { LockfileObject } from '@pnpm/lockfile.types'
 import { clone } from 'ramda'
 
+/**
+ * The update runs on a disposable clone: it may mutate freely and return
+ * `false` at any point, and nothing reaches `lockfile` unless the candidate
+ * passes every gate.
+ */
 export async function tryFastUpdateLockfile (
   lockfile: LockfileObject,
   opts: {
@@ -14,6 +19,14 @@ export async function tryFastUpdateLockfile (
   if (!await opts.isLockfileUpToDate(candidate)) return false
   await opts.verifyLockfile?.(candidate)
 
+  // The candidate replaces the lockfile wholesale: a key the update deleted
+  // (an emptied `packages` or `catalogs` section) has to disappear too, which
+  // assignment alone would not do.
+  for (const key of Object.keys(lockfile)) {
+    if (!(key in candidate)) {
+      delete lockfile[key as keyof LockfileObject]
+    }
+  }
   Object.assign(lockfile, candidate)
   return true
 }

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateLockfile.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateLockfile.ts
@@ -23,7 +23,7 @@ export async function tryFastUpdateLockfile (
   // (an emptied `packages` or `catalogs` section) has to disappear too, which
   // assignment alone would not do.
   for (const key of Object.keys(lockfile)) {
-    if (!(key in candidate)) {
+    if (!Object.hasOwn(candidate, key)) {
       delete lockfile[key as keyof LockfileObject]
     }
   }

--- a/pnpm11/installing/deps-installer/test/install/catalogFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/catalogFastUpdate.ts
@@ -41,7 +41,7 @@ test('a compatible package range update retains the locked peer snapshot without
   })
 })
 
-test('an incompatible package range update falls back without mutating the lockfile', () => {
+test('an incompatible package range update falls back without mutating the lockfile', async () => {
   const lockfile = {
     importers: {
       '.': {
@@ -58,15 +58,18 @@ test('an incompatible package range update falls back without mutating the lockf
     lockfileVersion: '9.0',
   } as LockfileObject
 
-  expect(tryFastUpdateImporters(lockfile, [{
-    id: '.' as ProjectId,
-    manifest: {
-      dependencies: {
-        foo: '>=1.0.0 <2',
-        bar: '^2.0.0',
+  expect(await tryFastUpdateLockfile(lockfile, {
+    update: (candidate) => tryFastUpdateImporters(candidate, [{
+      id: '.' as ProjectId,
+      manifest: {
+        dependencies: {
+          foo: '>=1.0.0 <2',
+          bar: '^2.0.0',
+        },
       },
-    },
-  }])).toBe(false)
+    }]),
+    isLockfileUpToDate: async () => true,
+  })).toBe(false)
   expect(lockfile.importers['.' as ProjectId].specifiers).toStrictEqual({
     bar: '^1.0.0',
     foo: '^1.0.0',

--- a/pnpm11/installing/deps-installer/test/install/importerRemovalFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/importerRemovalFastUpdate.ts
@@ -10,6 +10,7 @@ import {
   hasChangedProjectSpecifiers,
   tryFastUpdateImporters,
 } from '../../src/install/tryFastUpdateImporters.js'
+import { tryFastUpdateLockfile } from '../../src/install/tryFastUpdateLockfile.js'
 import { testDefaults } from '../utils/index.js'
 
 test('a dependency the manifest dropped is noticed as a change', () => {
@@ -26,7 +27,7 @@ test('a dropped dependency is removed and its subtree pruned', () => {
   expect(Object.keys(subject.packages!).sort()).toStrictEqual(['bar@2.0.0', 'child@3.0.0'])
 })
 
-test('dropping a dependency another package resolves as a peer falls back without mutating the lockfile', () => {
+test('dropping a dependency another package resolves as a peer falls back without mutating the lockfile', async () => {
   const subject = lockfile()
   subject.importers['.' as ProjectId].dependencies!.baz = '4.0.0(foo@1.1.0)'
   subject.importers['.' as ProjectId].specifiers.baz = '^4.0.0'
@@ -36,8 +37,25 @@ test('dropping a dependency another package resolves as a peer falls back withou
   }
   const before = clone(subject)
 
-  expect(tryFastUpdateImporters(subject, [project({ bar: '^2.0.0', baz: '^4.0.0' })])).toBe(false)
+  expect(await tryFastUpdateLockfile(subject, {
+    update: (candidate) => tryFastUpdateImporters(candidate, [project({ bar: '^2.0.0', baz: '^4.0.0' })]),
+    isLockfileUpToDate: async () => true,
+  })).toBe(false)
   expect(subject).toStrictEqual(before)
+})
+
+test('a lockfile key the update deletes is gone after the commit', async () => {
+  const subject = lockfile()
+  subject.catalogs = { default: { foo: { specifier: '^1.0.0', version: '1.1.0' } } }
+
+  expect(await tryFastUpdateLockfile(subject, {
+    update: (candidate) => {
+      delete candidate.catalogs
+      return true
+    },
+    isLockfileUpToDate: async () => true,
+  })).toBe(true)
+  expect(subject.catalogs).toBeUndefined()
 })
 
 test('dropping a dependency together with its peer-dependent succeeds', () => {
@@ -189,3 +207,67 @@ function lockfile (): LockfileObject {
     },
   }
 }
+
+test('removing the last dependency drops the packages section from the lockfile', async () => {
+  const project = prepareEmpty()
+  const manifest: ProjectManifest = {
+    dependencies: {
+      'is-positive': '1.0.0',
+    },
+  }
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, testDefaults())
+
+  const options = testDefaults()
+  const requestedPackages = trackRequestedPackages(options.storeController)
+  await mutateModulesInSingleProject({
+    dependencyNames: ['is-positive'],
+    manifest,
+    mutation: 'uninstallSome',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, options)
+
+  expect(requestedPackages).toStrictEqual([])
+  const lockfile = project.readLockfile()
+  expect(lockfile.packages).toBeUndefined()
+  expect(lockfile.snapshots).toBeUndefined()
+  project.hasNot('is-positive')
+})
+
+test('removing the last catalog referent drops the catalogs section from the lockfile', async () => {
+  const project = prepareEmpty()
+  const manifest: ProjectManifest = {
+    dependencies: {
+      'is-positive': 'catalog:',
+      '@pnpm.e2e/pkg-with-1-dep': '100.0.0',
+    },
+  }
+  const options = testDefaults()
+  options.catalogs = { default: { 'is-positive': '1.0.0' } }
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, options)
+  expect(project.readLockfile().catalogs).toBeDefined()
+
+  const removeOptions = testDefaults()
+  removeOptions.catalogs = { default: { 'is-positive': '1.0.0' } }
+  const requestedPackages = trackRequestedPackages(removeOptions.storeController)
+  await mutateModulesInSingleProject({
+    dependencyNames: ['is-positive'],
+    manifest,
+    mutation: 'uninstallSome',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, removeOptions)
+
+  expect(requestedPackages).toStrictEqual([])
+  const lockfile = project.readLockfile()
+  expect(lockfile.catalogs).toBeUndefined()
+  expect(lockfile.importers['.'].dependencies).toStrictEqual({
+    '@pnpm.e2e/pkg-with-1-dep': { specifier: '100.0.0', version: '100.0.0' },
+  })
+})


### PR DESCRIPTION
## Summary

Related to pnpm/pnpm#13696. Builds on the group-moves work from pnpm/pnpm#13761 (merged); rebased onto `main`.

First stage of consolidating the fast lockfile update paths: one staging layer instead of two, and no lockfile clone before drift is detected.

- **One staging layer.** The coordinator (`tryFastUpdateLockfile`) already clones the lockfile and discards the candidate unless it passes the freshness gates, yet the importers handler staged its own inner clone and copied back on success. The handler now mutates the coordinator's candidate directly; the discard-on-failure invariant lives in one place and is pinned by coordinator-level tests.
- **Bug fix the restructure surfaced:** the coordinator committed with `Object.assign`, which cannot delete top-level keys — removing the last referent of a catalog entry through the fast path left the stale `catalogs:` section in the written lockfile (a full resolution drops it). The commit now replaces the lockfile's keys wholesale. Regression-tested at unit and install level; the install-level test failed before the fix.
- **Detect before clone (pacquet).** `try_fast_update_importers` cloned the whole lockfile before checking for drift, so every stale install paid a clone in this handler even when its drift lay elsewhere (a settings or patch change). It now scans for manifest drift on a borrow and clones only when it will act. The other three sync handlers already detected before cloning.
- The `canTryFastUpdateLockfile` trigger list is deduplicated into a `FAST_UPDATABLE_SETTINGS` constant.

No behavior changes apart from the catalog fix; both stacks fall back to the resolver under the same conditions as before. Stage 2 (composing handlers on one candidate instead of the exactly-one-fires rule) is filed separately.

## Squash Commit Body

```text
The fast-update coordinator already stages every rewrite on a clone
and discards it unless the candidate passes the freshness gates, so
the importers handler staging its own inner clone and copying back
was a second, redundant layer; it now mutates the coordinator's
candidate directly. The coordinator also commits by replacing the
lockfile's keys wholesale instead of Object.assign, which silently
kept top-level keys the update had deleted: removing the last
referent of a catalog entry through the fast path left the stale
catalogs section in the written lockfile.

pacquet's importers handler now scans for manifest drift before
cloning the lockfile, so installs whose drift lies elsewhere no
longer pay a full lockfile clone in the handler; the other pacquet
handlers already detected before cloning.

Related to pnpm/pnpm#13696.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788956180&installation_model_id=426870&pr_number=13762&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13762&signature=bd003860e57d0b19a8bcd9ac8081ae46b400bab955fafbafc17d319a002cd5e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fast lockfile updates now support moving dependencies between production, development, and optional dependency sections.
  * Lockfiles are updated in place without unnecessarily re-resolving the full dependency graph.
* **Bug Fixes**
  * Corrected optional dependency metadata and cleanup of unused packages, snapshots, and catalog entries.
  * Improved handling of compatible version changes, aliases, peer dependencies, and shared dependency subtrees.
  * Fast updates now fall back safely when changes cannot be applied without resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
