### PR TITLE
chore(toolchain): update to 1.97.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.97.0"
 profile = "default"


### PR DESCRIPTION
## Summary

Bumps the pinned Rust toolchain from 1.95.0 to 1.97.0 (current stable, released 2026-07-07).

This unblocks the dependabot bump of `yamlpatch` (pnpm/pnpm#13704): the zizmor-family crates (`yamlpatch`, `yamlpath`, `subfeature`, `tree-sitter-iter`) raised their MSRV to rustc 1.97 in their 1.28.0 releases, and `yamlpatch` has no 1.27.0, so no version newer than the currently locked 1.26.1 can compile on 1.95.

The bump was verified locally under 1.97.0 before opening this PR:

- `cargo clippy --locked --workspace --all-targets -- -D warnings` (on top of the workspace `pedantic` + `nursery` levels): clean, zero new lints.
- `cargo fmt --all -- --check`: clean.
- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --workspace --document-private-items` (with `target/doc` removed first): clean.

`rust-toolchain.toml` is the single source of truth for CI, release builds, and local builds; no crate declares a `rust-version`, and the dylint/perfectionist gate runs on its own pinned nightly, so this is a one-line change. Expect the first CI run to be slower due to cold toolchain-keyed caches.

## Squash Commit Body

```text
The zizmor-family crates (yamlpatch, yamlpath, subfeature,
tree-sitter-iter) require rustc 1.97 starting with their 1.28.0
releases, which blocks the yamlpatch dependabot bump
(pnpm/pnpm#13704); yamlpatch has no 1.27.0, so 1.26.1 is the newest
version compatible with 1.95. Clippy (pedantic + nursery,
-D warnings), rustfmt, and the rustdoc gate were verified clean
under 1.97.0 before the bump.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (Toolchain-only change; nothing to port.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. (Not needed: no user-visible change to any published package.)

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13764"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788959060&installation_model_id=426870&pr_number=13764&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13764&signature=10c08cd01d24f3e56e42b4331bdfdf9f0e06fb37b580171a78b209bdc30ab996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Rust toolchain to version 1.97.0.
  * Retained the existing default toolchain profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->