### PR TITLE
feat: compose fast lockfile updates on one candidate

### DIFF
--- a/.changeset/composed-fast-updates.md
+++ b/.changeset/composed-fast-updates.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.deps-installer": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+`pnpm install` now updates the lockfile in place even when several kinds of changes happened since the last install — for example a removed dependency together with a widened `ignoredOptionalDependencies` list, or a dependency edit alongside a patch or settings change. Previously any combination of changes forced a full re-resolution [#13763](https://github.com/pnpm/pnpm/issues/13763).

--- a/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
@@ -1292,3 +1292,82 @@ fn moving_a_dependency_between_groups_skips_resolution() {
 
     drop((root, mock_instance));
 }
+
+#[test]
+fn combined_manifest_and_ignore_list_drift_skips_resolution() {
+    let CommandTempCwd { workspace, root, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, npmrc_path, .. } = npmrc_info;
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/foo": "100.0.0",
+                "@pnpm.e2e/pkg-with-1-dep": "100.0.0"
+            },
+            "optionalDependencies": {
+                "is-positive": "1.0.0"
+            }
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/foo": "100.0.0"
+            },
+            "optionalDependencies": {
+                "is-positive": "1.0.0"
+            }
+        })
+        .to_string(),
+    )
+    .expect("drop one prod dependency");
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    fs::write(
+        &workspace_yaml_path,
+        format!("{workspace_yaml}ignoredOptionalDependencies:\n  - is-positive\n"),
+    )
+    .expect("widen the ignore list");
+    let dead_registry = dead_registry_url();
+    let live_npmrc = fs::read_to_string(&npmrc_path).expect("read .npmrc");
+    let dead_npmrc = live_npmrc
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("registry="))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(&npmrc_path, format!("registry={dead_registry}\n{dead_npmrc}\n"))
+        .expect("rewrite .npmrc with a dead registry");
+
+    let assert = pacquet_at(&workspace).with_arg("install").assert().success();
+    assert!(
+        String::from_utf8_lossy(&assert.get_output().stdout)
+            .contains("Lockfile is up to date, resolution step is skipped"),
+        "the removal and the widened ignore list are absorbed in one pass",
+    );
+    let wanted = pacquet_lockfile::Lockfile::load_wanted_from_dir(&workspace)
+        .expect("load updated wanted lockfile")
+        .expect("updated wanted lockfile");
+    let packages: Vec<String> =
+        wanted.packages.as_ref().expect("packages").keys().map(ToString::to_string).collect();
+    assert!(
+        packages.iter().all(|key| key.starts_with("@pnpm.e2e/foo@")),
+        "both the removed dependency and the newly ignored optional are gone: {packages:?}",
+    );
+    assert_eq!(
+        wanted.ignored_optional_dependencies.as_deref(),
+        Some(&["is-positive".to_string()][..]),
+    );
+    assert!(
+        !workspace.join("node_modules").join("@pnpm.e2e").join("pkg-with-1-dep").exists(),
+        "the removed dependency is unlinked",
+    );
+
+    drop((root, mock_instance));
+}

--- a/pnpm/crates/package-manager/src/fast_update_compose.rs
+++ b/pnpm/crates/package-manager/src/fast_update_compose.rs
@@ -75,7 +75,7 @@ pub(crate) fn try_compose_fast_updates(
     };
     if matches!(
         (&importers, &ignored, &patched, &settings_drift),
-        (Drift::Clean, Drift::Clean, Drift::Clean, Drift::Clean)
+        (Drift::Clean, Drift::Clean, Drift::Clean, Drift::Clean),
     ) {
         return None;
     }

--- a/pnpm/crates/package-manager/src/fast_update_compose.rs
+++ b/pnpm/crates/package-manager/src/fast_update_compose.rs
@@ -1,0 +1,116 @@
+use crate::fast_update_lockfile::GraphEdits;
+use pacquet_config::Config;
+use pacquet_lockfile::Lockfile;
+use pacquet_package_manifest::PackageManifest;
+use std::path::PathBuf;
+
+/// What a fast-update handler's detector concluded about its slice of
+/// the configuration and manifests.
+pub(crate) enum Drift<Plan> {
+    /// Nothing changed; the handler has nothing to do.
+    Clean,
+    /// Something changed and the handler can rewrite the lockfile to
+    /// match, replaying `Plan` onto the shared candidate.
+    Absorb(Plan),
+    /// Something changed that only a resolution can express.
+    Resolve,
+}
+
+/// Rewrite the loaded lockfile in place of a full resolution for the
+/// drift the lockfile itself proves is safe to absorb, composing every
+/// applicable handler onto one candidate: manifest drift (compatible
+/// range changes, dependency group moves, removals), a widened
+/// `ignoredOptionalDependencies`, a changed `patchedDependencies`, and
+/// a setting change that cannot affect the recorded graph. Drift that
+/// spans several of those dimensions at once is absorbed in one pass —
+/// no handler requires being the only change.
+///
+/// The handlers run in a fixed order. Removals land first (manifest
+/// drift, then newly ignored optional dependencies), then the shared
+/// epilogue prunes what nothing reaches and refuses candidates whose
+/// surviving peer suffixes embed a dropped package. Patches rekey after
+/// that, so the unused-patch guard and the rekey plan see the packages
+/// a full resolution would see. The settings block, which touches no
+/// graph, is recorded last.
+///
+/// `None` — no drift, or drift some handler cannot express — leaves the
+/// caller on the full-resolution path. The caller still validates the
+/// candidate with the lockfile freshness gates before committing, so a
+/// handler that rewrites too much falls back rather than corrupting.
+pub(crate) fn try_compose_fast_updates(
+    lockfile: &Lockfile,
+    manifests: &[(String, &PackageManifest)],
+    project_manifests: &[(PathBuf, &PackageManifest)],
+    config: &Config,
+) -> Option<Lockfile> {
+    let ignored_optional_dependencies =
+        config.ignored_optional_dependencies.as_deref().unwrap_or_default();
+    let settings = crate::fast_update_settings::lockfile_settings_from_config(config);
+
+    let importers = match crate::fast_update_importers::detect_importers_drift(lockfile, manifests)
+    {
+        Drift::Resolve => return None,
+        drift => drift,
+    };
+    let ignored =
+        match crate::fast_update_ignored_optional_dependencies::detect_ignored_optional_drift(
+            lockfile,
+            ignored_optional_dependencies,
+        ) {
+            Drift::Resolve => return None,
+            drift => drift,
+        };
+    let patched =
+        match crate::fast_update_patched_dependencies::detect_patched_drift(lockfile, config) {
+            Drift::Resolve => return None,
+            drift => drift,
+        };
+    let settings_drift = match crate::fast_update_settings::detect_settings_drift(
+        lockfile,
+        &settings,
+        project_manifests,
+    ) {
+        Drift::Resolve => return None,
+        drift => drift,
+    };
+    if matches!(
+        (&importers, &ignored, &patched, &settings_drift),
+        (Drift::Clean, Drift::Clean, Drift::Clean, Drift::Clean)
+    ) {
+        return None;
+    }
+
+    let mut candidate = lockfile.clone();
+    let mut edits = GraphEdits::default();
+    if let Drift::Absorb(plan) = &importers
+        && !crate::fast_update_importers::apply_importers_update(&mut candidate, plan, &mut edits)
+    {
+        return None;
+    }
+    if matches!(ignored, Drift::Absorb(())) {
+        crate::fast_update_ignored_optional_dependencies::apply_ignored_optional_update(
+            &mut candidate,
+            ignored_optional_dependencies,
+            &mut edits,
+        );
+    }
+    if !crate::fast_update_lockfile::finish_graph_edits(&mut candidate, &edits) {
+        return None;
+    }
+    if let Drift::Absorb(plan) = &patched
+        && !crate::fast_update_patched_dependencies::apply_patched_update(
+            &mut candidate,
+            plan,
+            config.allow_unused_patches,
+        )
+    {
+        return None;
+    }
+    if matches!(settings_drift, Drift::Absorb(())) {
+        crate::fast_update_settings::apply_settings_update(&mut candidate, &settings);
+    }
+    Some(candidate)
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/package-manager/src/fast_update_compose.rs
+++ b/pnpm/crates/package-manager/src/fast_update_compose.rs
@@ -16,27 +16,17 @@ pub(crate) enum Drift<Plan> {
     Resolve,
 }
 
-/// Rewrite the loaded lockfile in place of a full resolution for the
-/// drift the lockfile itself proves is safe to absorb, composing every
-/// applicable handler onto one candidate: manifest drift (compatible
-/// range changes, dependency group moves, removals), a widened
-/// `ignoredOptionalDependencies`, a changed `patchedDependencies`, and
-/// a setting change that cannot affect the recorded graph. Drift that
-/// spans several of those dimensions at once is absorbed in one pass —
-/// no handler requires being the only change.
-///
-/// The handlers run in a fixed order. Removals land first (manifest
-/// drift, then newly ignored optional dependencies), then the shared
-/// epilogue prunes what nothing reaches and refuses candidates whose
-/// surviving peer suffixes embed a dropped package. Patches rekey after
-/// that, so the unused-patch guard and the rekey plan see the packages
-/// a full resolution would see. The settings block, which touches no
-/// graph, is recorded last.
+/// Rewrite the loaded lockfile in place of a full resolution, composing
+/// every handler with absorbable drift onto one shared candidate — no
+/// handler requires being the only change. Removals apply first, then
+/// the shared graph epilogue
+/// ([`crate::fast_update_lockfile::finish_graph_edits`]), then patch
+/// rekeying — after the prune, so its guards see the packages a full
+/// resolution would see — and the settings block last.
 ///
 /// `None` — no drift, or drift some handler cannot express — leaves the
-/// caller on the full-resolution path. The caller still validates the
-/// candidate with the lockfile freshness gates before committing, so a
-/// handler that rewrites too much falls back rather than corrupting.
+/// caller on the full-resolution path; the caller still validates the
+/// candidate with the freshness gates before committing.
 pub(crate) fn try_compose_fast_updates(
     lockfile: &Lockfile,
     manifests: &[(String, &PackageManifest)],
@@ -65,14 +55,11 @@ pub(crate) fn try_compose_fast_updates(
             Drift::Resolve => return None,
             drift => drift,
         };
-    let settings_drift = match crate::fast_update_settings::detect_settings_drift(
-        lockfile,
-        &settings,
-        project_manifests,
-    ) {
-        Drift::Resolve => return None,
-        drift => drift,
-    };
+    let settings_drift =
+        match crate::fast_update_settings::detect_settings_drift(lockfile, &settings) {
+            Drift::Resolve => return None,
+            drift => drift,
+        };
     if matches!(
         (&importers, &ignored, &patched, &settings_drift),
         (Drift::Clean, Drift::Clean, Drift::Clean, Drift::Clean),
@@ -106,8 +93,14 @@ pub(crate) fn try_compose_fast_updates(
     {
         return None;
     }
-    if matches!(settings_drift, Drift::Absorb(())) {
-        crate::fast_update_settings::apply_settings_update(&mut candidate, &settings);
+    if matches!(settings_drift, Drift::Absorb(()))
+        && !crate::fast_update_settings::apply_settings_update(
+            &mut candidate,
+            &settings,
+            project_manifests,
+        )
+    {
+        return None;
     }
     Some(candidate)
 }

--- a/pnpm/crates/package-manager/src/fast_update_compose/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_compose/tests.rs
@@ -309,3 +309,51 @@ fn patch_config(workspace_dir: &Path, keys: &[&str]) -> Config {
         ..Config::default()
     }
 }
+
+#[test]
+fn absorbs_a_peer_setting_once_the_removal_drops_the_last_peer_dependent() {
+    let mut subject = lockfile();
+    subject.settings =
+        Some(crate::fast_update_settings::lockfile_settings_from_config(&Config::default()));
+    subject
+        .importers
+        .get_mut(".")
+        .expect("importer")
+        .dependencies
+        .as_mut()
+        .expect("dependencies")
+        .insert(
+            "withpeer".parse().expect("alias"),
+            serde_saphyr::from_str("{specifier: ^6.0.0, version: 6.0.0}").expect("dependency"),
+        );
+    subject.packages.as_mut().expect("packages").insert(
+        "withpeer@6.0.0".parse().expect("package key"),
+        serde_saphyr::from_str(
+            "resolution:\n  integrity: sha512-withpeer\npeerDependencies:\n  foo: ^1.0.0",
+        )
+        .expect("package"),
+    );
+    subject.snapshots.as_mut().expect("snapshots").insert(
+        "withpeer@6.0.0".parse().expect("snapshot key"),
+        serde_saphyr::from_str("{}").expect("snapshot"),
+    );
+    let manifest = manifest_from(json!({
+        "dependencies": { "foo": "^1.0.0", "bar": "^2.0.0" },
+        "optionalDependencies": { "opt": "^5.0.0" },
+    }));
+    let config = Config { auto_install_peers: false, ..Config::default() };
+
+    let updated = try_compose_fast_updates(
+        &subject,
+        &[(".".to_string(), &manifest)],
+        &[(PathBuf::from("/project"), &manifest)],
+        &config,
+    )
+    .expect("the removal prunes the only peer dependent, so the setting cannot affect the graph");
+
+    assert!(!updated.settings.as_ref().expect("settings").auto_install_peers);
+    assert!(
+        !snapshot_keys(&updated).iter().any(|key| key.starts_with("withpeer@")),
+        "the peer-declaring package went with the removal",
+    );
+}

--- a/pnpm/crates/package-manager/src/fast_update_compose/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_compose/tests.rs
@@ -323,18 +323,18 @@ fn absorbs_a_peer_setting_once_the_removal_drops_the_last_peer_dependent() {
         .as_mut()
         .expect("dependencies")
         .insert(
-            "withpeer".parse().expect("alias"),
+            "has-peer".parse().expect("alias"),
             serde_saphyr::from_str("{specifier: ^6.0.0, version: 6.0.0}").expect("dependency"),
         );
     subject.packages.as_mut().expect("packages").insert(
-        "withpeer@6.0.0".parse().expect("package key"),
+        "has-peer@6.0.0".parse().expect("package key"),
         serde_saphyr::from_str(
-            "resolution:\n  integrity: sha512-withpeer\npeerDependencies:\n  foo: ^1.0.0",
+            "resolution:\n  integrity: sha512-has-peer\npeerDependencies:\n  foo: ^1.0.0",
         )
         .expect("package"),
     );
     subject.snapshots.as_mut().expect("snapshots").insert(
-        "withpeer@6.0.0".parse().expect("snapshot key"),
+        "has-peer@6.0.0".parse().expect("snapshot key"),
         serde_saphyr::from_str("{}").expect("snapshot"),
     );
     let manifest = manifest_from(json!({
@@ -353,7 +353,7 @@ fn absorbs_a_peer_setting_once_the_removal_drops_the_last_peer_dependent() {
 
     assert!(!updated.settings.as_ref().expect("settings").auto_install_peers);
     assert!(
-        !snapshot_keys(&updated).iter().any(|key| key.starts_with("withpeer@")),
+        !snapshot_keys(&updated).iter().any(|key| key.starts_with("has-peer@")),
         "the peer-declaring package went with the removal",
     );
 }

--- a/pnpm/crates/package-manager/src/fast_update_compose/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_compose/tests.rs
@@ -1,0 +1,308 @@
+use super::try_compose_fast_updates;
+use indexmap::IndexMap;
+use pacquet_config::Config;
+use pacquet_lockfile::Lockfile;
+use pacquet_package_manifest::PackageManifest;
+use serde_json::{Value, json};
+use std::{fs, path::Path, path::PathBuf};
+use tempfile::TempDir;
+
+/// `foo` and `bar` are prod dependencies (`bar` reaching `child`), and
+/// `opt` is an optional dependency reaching the same `child`.
+const LOCKFILE: &str = r"
+lockfileVersion: '9.0'
+importers:
+  .:
+    dependencies:
+      foo:
+        specifier: ^1.0.0
+        version: 1.1.0
+      bar:
+        specifier: ^2.0.0
+        version: 2.0.0
+    optionalDependencies:
+      opt:
+        specifier: ^5.0.0
+        version: 5.0.0
+packages:
+  foo@1.1.0:
+    resolution:
+      integrity: sha512-foo
+  bar@2.0.0:
+    resolution:
+      integrity: sha512-bar
+  child@3.0.0:
+    resolution:
+      integrity: sha512-child
+  opt@5.0.0:
+    resolution:
+      integrity: sha512-opt
+snapshots:
+  foo@1.1.0: {}
+  bar@2.0.0:
+    dependencies:
+      child: 3.0.0
+  child@3.0.0: {}
+  opt@5.0.0:
+    optional: true
+    dependencies:
+      child: 3.0.0
+";
+
+fn lockfile() -> Lockfile {
+    serde_saphyr::from_str(LOCKFILE).expect("parse lockfile")
+}
+
+fn manifest_from(value: Value) -> PackageManifest {
+    PackageManifest::from_value(PathBuf::from("/project/package.json"), value)
+}
+
+fn snapshot_keys(lockfile: &Lockfile) -> Vec<String> {
+    let mut keys: Vec<_> =
+        lockfile.snapshots.as_ref().expect("snapshots").keys().map(ToString::to_string).collect();
+    keys.sort();
+    keys
+}
+
+fn snapshot_optional(lockfile: &Lockfile, key: &str) -> bool {
+    lockfile.snapshots.as_ref().expect("snapshots")[&key.parse().expect("snapshot key")].optional
+}
+
+#[test]
+fn absorbs_a_removal_and_a_widened_ignore_list_in_one_pass() {
+    let manifest = manifest_from(json!({
+        "dependencies": { "bar": "^2.0.0" },
+        "optionalDependencies": { "opt": "^5.0.0" },
+    }));
+    let config = Config {
+        ignored_optional_dependencies: Some(vec!["opt".to_string()]),
+        ..Config::default()
+    };
+
+    let updated =
+        try_compose_fast_updates(&lockfile(), &[(".".to_string(), &manifest)], &[], &config)
+            .expect("both kinds of drift are absorbable at once");
+
+    assert_eq!(
+        snapshot_keys(&updated),
+        vec!["bar@2.0.0".to_string(), "child@3.0.0".to_string()],
+        "the removed dependency and the newly ignored optional both went, with their subtrees",
+    );
+    assert_eq!(updated.ignored_optional_dependencies, Some(vec!["opt".to_string()]));
+    let importer = &updated.importers["."];
+    assert!(importer.optional_dependencies.is_none());
+    assert!(
+        !importer
+            .dependencies
+            .as_ref()
+            .expect("dependencies")
+            .contains_key(&"foo".parse().expect("alias")),
+    );
+}
+
+#[test]
+fn absorbs_a_group_move_and_a_settings_change_in_one_pass() {
+    let manifest = manifest_from(json!({
+        "devDependencies": { "foo": "^1.0.0" },
+        "dependencies": { "bar": "^2.0.0" },
+        "optionalDependencies": { "opt": "^5.0.0" },
+    }));
+    let config = Config { auto_install_peers: false, ..Config::default() };
+    let mut subject = lockfile();
+    subject.settings =
+        Some(crate::fast_update_settings::lockfile_settings_from_config(&Config::default()));
+
+    let updated = try_compose_fast_updates(
+        &subject,
+        &[(".".to_string(), &manifest)],
+        &[(PathBuf::from("/project"), &manifest)],
+        &config,
+    )
+    .expect("a peerless lockfile absorbs the setting alongside the move");
+
+    let importer = &updated.importers["."];
+    assert!(
+        importer
+            .dev_dependencies
+            .as_ref()
+            .is_some_and(|deps| deps.contains_key(&"foo".parse().expect("alias"))),
+    );
+    assert!(
+        !updated.settings.as_ref().expect("settings").auto_install_peers,
+        "the settings block rode along with the manifest drift",
+    );
+}
+
+#[test]
+fn falls_back_when_one_of_the_composed_changes_cannot_be_absorbed() {
+    let manifest = manifest_from(json!({
+        "dependencies": { "foo": "^9.0.0", "bar": "^2.0.0" },
+        "optionalDependencies": { "opt": "^5.0.0" },
+    }));
+    let config = Config { auto_install_peers: false, ..Config::default() };
+    let mut subject = lockfile();
+    subject.settings =
+        Some(crate::fast_update_settings::lockfile_settings_from_config(&Config::default()));
+
+    assert!(
+        try_compose_fast_updates(
+            &subject,
+            &[(".".to_string(), &manifest)],
+            &[(PathBuf::from("/project"), &manifest)],
+            &config,
+        )
+        .is_none(),
+        "the incompatible range needs the resolver, and the settings change goes with it",
+    );
+}
+
+#[test]
+fn falls_back_when_a_removal_leaves_a_configured_patch_unused() {
+    let dir = workspace(&["bar@2.0.0"]);
+    let manifest = manifest_from(json!({
+        "dependencies": { "foo": "^1.0.0" },
+        "optionalDependencies": { "opt": "^5.0.0" },
+    }));
+    let config = Config { allow_unused_patches: false, ..patch_config(dir.path(), &["bar@2.0.0"]) };
+
+    assert!(
+        try_compose_fast_updates(&lockfile(), &[(".".to_string(), &manifest)], &[], &config)
+            .is_none(),
+        "removing the patch's only referent is what the resolver reports as an unused patch",
+    );
+}
+
+#[test]
+fn rekeys_a_patched_survivor_alongside_a_removal() {
+    let dir = workspace(&["bar@2.0.0"]);
+    let manifest = manifest_from(json!({
+        "dependencies": { "bar": "^2.0.0" },
+        "optionalDependencies": { "opt": "^5.0.0" },
+    }));
+    let config = patch_config(dir.path(), &["bar@2.0.0"]);
+
+    let updated =
+        try_compose_fast_updates(&lockfile(), &[(".".to_string(), &manifest)], &[], &config)
+            .expect("the removal and the patch rekey compose");
+
+    assert!(
+        snapshot_keys(&updated).iter().any(|key| key.starts_with("bar@2.0.0(patch_hash=")),
+        "the surviving patched package carries its hash segment",
+    );
+    assert!(
+        !snapshot_keys(&updated).iter().any(|key| key.starts_with("foo@")),
+        "while the removed dependency is pruned",
+    );
+}
+
+#[test]
+fn falls_back_when_an_ignored_optional_is_embedded_in_a_peer_suffix() {
+    let mut subject = lockfile();
+    subject.snapshots.as_mut().expect("snapshots").insert(
+        "baz@4.0.0(opt@5.0.0)".parse().expect("snapshot key"),
+        serde_saphyr::from_str("dependencies:\n  opt: 5.0.0").expect("snapshot"),
+    );
+    subject
+        .importers
+        .get_mut(".")
+        .expect("importer")
+        .dependencies
+        .as_mut()
+        .expect("dependencies")
+        .insert(
+            "baz".parse().expect("alias"),
+            serde_saphyr::from_str("{specifier: ^4.0.0, version: 4.0.0(opt@5.0.0)}")
+                .expect("dependency"),
+        );
+    let config = Config {
+        ignored_optional_dependencies: Some(vec!["opt".to_string()]),
+        ..Config::default()
+    };
+
+    assert!(
+        try_compose_fast_updates(&subject, &[], &[], &config).is_none(),
+        "the surviving dependent's key embeds the removed package, so it would rekey, not prune",
+    );
+}
+
+#[test]
+fn stands_aside_when_nothing_drifted() {
+    let manifest = manifest_from(json!({
+        "dependencies": { "foo": "^1.0.0", "bar": "^2.0.0" },
+        "optionalDependencies": { "opt": "^5.0.0" },
+    }));
+
+    assert!(
+        try_compose_fast_updates(
+            &lockfile(),
+            &[(".".to_string(), &manifest)],
+            &[],
+            &Config::default(),
+        )
+        .is_none(),
+        "no drift means the ordinary frozen path decides",
+    );
+}
+
+#[test]
+fn recomputes_optional_flags_for_an_ignored_optional_removal() {
+    let config = Config {
+        ignored_optional_dependencies: Some(vec!["bar".to_string()]),
+        ..Config::default()
+    };
+    let mut subject = lockfile();
+    let importer = subject.importers.get_mut(".").expect("importer");
+    let moved = importer
+        .dependencies
+        .as_mut()
+        .expect("dependencies")
+        .remove(&"bar".parse().expect("alias"))
+        .expect("bar");
+    importer
+        .optional_dependencies
+        .as_mut()
+        .expect("optionalDependencies")
+        .insert("bar".parse().expect("alias"), moved);
+    subject
+        .snapshots
+        .as_mut()
+        .expect("snapshots")
+        .get_mut(&"bar@2.0.0".parse().expect("key"))
+        .expect("snapshot")
+        .optional = true;
+
+    let updated = try_compose_fast_updates(&subject, &[], &[], &config)
+        .expect("widening the ignore list needs no resolution");
+
+    assert!(
+        snapshot_optional(&updated, "child@3.0.0"),
+        "only the optional path reaches child once bar is ignored",
+    );
+}
+
+fn workspace(patches: &[&str]) -> TempDir {
+    let dir = tempfile::tempdir().expect("create workspace dir");
+    fs::create_dir_all(dir.path().join("patches")).expect("create patches dir");
+    for patch in patches {
+        let path = dir.path().join("patches").join(patch_file_name(patch));
+        fs::write(path, "--- a\n+++ b\n").expect("write patch file");
+    }
+    dir
+}
+
+fn patch_file_name(key: &str) -> String {
+    format!("{}.patch", key.replace('/', "+"))
+}
+
+fn patch_config(workspace_dir: &Path, keys: &[&str]) -> Config {
+    Config {
+        workspace_dir: Some(workspace_dir.to_path_buf()),
+        allow_unused_patches: true,
+        patched_dependencies: (!keys.is_empty()).then(|| {
+            keys.iter()
+                .map(|key| (key.to_string(), format!("patches/{}", patch_file_name(key))))
+                .collect::<IndexMap<_, _>>()
+        }),
+        ..Config::default()
+    }
+}

--- a/pnpm/crates/package-manager/src/fast_update_compose/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_compose/tests.rs
@@ -4,7 +4,10 @@ use pacquet_config::Config;
 use pacquet_lockfile::Lockfile;
 use pacquet_package_manifest::PackageManifest;
 use serde_json::{Value, json};
-use std::{fs, path::Path, path::PathBuf};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 use tempfile::TempDir;
 
 /// `foo` and `bar` are prod dependencies (`bar` reaching `child`), and

--- a/pnpm/crates/package-manager/src/fast_update_ignored_optional_dependencies.rs
+++ b/pnpm/crates/package-manager/src/fast_update_ignored_optional_dependencies.rs
@@ -1,5 +1,4 @@
-use crate::fast_update_compose::Drift;
-use crate::fast_update_lockfile::GraphEdits;
+use crate::{fast_update_compose::Drift, fast_update_lockfile::GraphEdits};
 use pacquet_config::matcher::create_matcher;
 use pacquet_lockfile::{Lockfile, PkgName};
 use std::collections::{BTreeSet, HashMap, HashSet};

--- a/pnpm/crates/package-manager/src/fast_update_ignored_optional_dependencies.rs
+++ b/pnpm/crates/package-manager/src/fast_update_ignored_optional_dependencies.rs
@@ -1,11 +1,19 @@
+use crate::fast_update_compose::Drift;
+use crate::fast_update_lockfile::GraphEdits;
 use pacquet_config::matcher::create_matcher;
 use pacquet_lockfile::{Lockfile, PkgName};
 use std::collections::{BTreeSet, HashMap, HashSet};
 
-pub(crate) fn try_fast_update_ignored_optional_dependencies(
+/// Whether `ignoredOptionalDependencies` drifted from what the lockfile
+/// records, and whether the drift is a pure widening this rewrite can
+/// absorb. Anything else — a dropped pattern, a new exclusion, a
+/// previous configuration that ignores by default — is
+/// [`Drift::Resolve`], because only a resolution can bring packages
+/// back.
+pub(crate) fn detect_ignored_optional_drift(
     lockfile: &Lockfile,
     ignored_optional_dependencies: &[String],
-) -> Option<Lockfile> {
+) -> Drift<()> {
     let previous: BTreeSet<_> = lockfile
         .ignored_optional_dependencies
         .as_deref()
@@ -14,19 +22,27 @@ pub(crate) fn try_fast_update_ignored_optional_dependencies(
         .cloned()
         .collect();
     let current: BTreeSet<_> = ignored_optional_dependencies.iter().cloned().collect();
+    if previous == current {
+        return Drift::Clean;
+    }
     let added_exclusion = current.difference(&previous).any(|pattern| pattern.starts_with('!'));
     let previous_ignores_by_default =
         !previous.is_empty() && previous.iter().all(|pattern| pattern.starts_with('!'));
-    if previous == current
-        || !previous.is_subset(&current)
-        || added_exclusion
-        || previous_ignores_by_default
-    {
-        return None;
+    if !previous.is_subset(&current) || added_exclusion || previous_ignores_by_default {
+        return Drift::Resolve;
     }
+    Drift::Absorb(())
+}
 
+/// Remove every optional dependency the widened pattern list now
+/// ignores, from importers and snapshots alike, recording the removed
+/// aliases in `edits` for the shared epilogue.
+pub(crate) fn apply_ignored_optional_update(
+    candidate: &mut Lockfile,
+    ignored_optional_dependencies: &[String],
+    edits: &mut GraphEdits,
+) {
     let matcher = create_matcher(ignored_optional_dependencies);
-    let mut candidate = lockfile.clone();
     for importer in candidate.importers.values_mut() {
         let removed = remove_ignored_optional_dependencies(
             &mut importer.optional_dependencies,
@@ -35,23 +51,24 @@ pub(crate) fn try_fast_update_ignored_optional_dependencies(
         );
         if let Some(specifiers) = importer.specifiers.as_mut() {
             let removed_specifiers: HashSet<_> =
-                removed.into_iter().map(|name| name.to_string()).collect();
+                removed.iter().map(std::string::ToString::to_string).collect();
             specifiers.retain(|name, _| !removed_specifiers.contains(name));
         }
+        edits.dropped.extend(removed);
     }
     if let Some(snapshots) = candidate.snapshots.as_mut() {
         for snapshot in snapshots.values_mut() {
-            remove_ignored_optional_dependencies(
+            edits.dropped.extend(remove_ignored_optional_dependencies(
                 &mut snapshot.optional_dependencies,
                 &mut snapshot.dependencies,
                 &matcher,
-            );
+            ));
         }
     }
-    candidate.ignored_optional_dependencies = Some(current.into_iter().collect());
-    crate::fast_update_lockfile::prune_unreachable_packages(&mut candidate);
-    crate::fast_update_lockfile::prune_unreferenced_catalog_entries(&mut candidate);
-    Some(candidate)
+    let mut recorded: Vec<_> = ignored_optional_dependencies.to_vec();
+    recorded.sort();
+    recorded.dedup();
+    candidate.ignored_optional_dependencies = Some(recorded);
 }
 
 fn remove_ignored_optional_dependencies<OptionalValue, DependencyValue>(

--- a/pnpm/crates/package-manager/src/fast_update_ignored_optional_dependencies/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_ignored_optional_dependencies/tests.rs
@@ -1,5 +1,22 @@
-use super::try_fast_update_ignored_optional_dependencies;
 use pacquet_lockfile::Lockfile;
+
+/// The composed pipeline restricted to `ignoredOptionalDependencies`
+/// drift: every other input is neutral, so these tests exercise this
+/// handler and the shared epilogue alone.
+fn try_fast_update_ignored_optional_dependencies(
+    lockfile: &Lockfile,
+    ignored_optional_dependencies: &[String],
+) -> Option<Lockfile> {
+    crate::fast_update_compose::try_compose_fast_updates(
+        lockfile,
+        &[],
+        &[],
+        &pacquet_config::Config {
+            ignored_optional_dependencies: Some(ignored_optional_dependencies.to_vec()),
+            ..pacquet_config::Config::default()
+        },
+    )
+}
 
 fn lockfile(source: &str) -> Lockfile {
     serde_saphyr::from_str(source).expect("parse lockfile")

--- a/pnpm/crates/package-manager/src/fast_update_importers.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers.rs
@@ -1,3 +1,5 @@
+use crate::fast_update_compose::Drift;
+use crate::fast_update_lockfile::GraphEdits;
 use node_semver::Range;
 use pacquet_lockfile::{
     Lockfile, PkgName, ProjectSnapshot, ResolvedDependencyMap, ResolvedDependencySpec,
@@ -10,10 +12,20 @@ use std::collections::{HashMap, HashSet};
 /// against importer records need no per-dependency conversions.
 type ManifestDependencies<'manifest> = HashMap<PkgName, (&'manifest str, DependencyGroup)>;
 
-pub(crate) fn try_fast_update_importers(
+/// The prepared inputs [`apply_importers_update`] replays: each
+/// importer's manifest map, built once so detection and application share
+/// the parsed aliases.
+pub(crate) struct ImportersPlan<'a, 'manifest> {
+    manifest_dependencies: Vec<(&'a String, ManifestDependencies<'manifest>)>,
+}
+
+/// Whether the importers' records diverge from the manifests, without
+/// cloning anything. [`Drift::Resolve`] when an alias cannot be parsed,
+/// which the resolver reports.
+pub(crate) fn detect_importers_drift<'a, 'manifest>(
     lockfile: &Lockfile,
-    manifests: &[(String, &PackageManifest)],
-) -> Option<Lockfile> {
+    manifests: &'a [(String, &'manifest PackageManifest)],
+) -> Drift<ImportersPlan<'a, 'manifest>> {
     let mut manifest_dependencies: Vec<(&String, ManifestDependencies<'_>)> = Vec::new();
     for (importer_id, manifest) in manifests {
         // Later groups overwrite, so each alias ends at the group
@@ -22,60 +34,65 @@ pub(crate) fn try_fast_update_importers(
         let mut dependencies = HashMap::new();
         for group in [DependencyGroup::Dev, DependencyGroup::Prod, DependencyGroup::Optional] {
             for (name, specifier) in manifest.dependencies([group]) {
-                dependencies.insert(PkgName::parse(name).ok()?, (specifier, group));
+                let Ok(name) = PkgName::parse(name) else {
+                    return Drift::Resolve;
+                };
+                dependencies.insert(name, (specifier, group));
             }
         }
         manifest_dependencies.push((importer_id, dependencies));
     }
-    // Cloning the lockfile is the expensive part, so nothing is cloned
-    // until this cheap scan finds drift the loop below would act on.
-    if !manifest_dependencies
+    if manifest_dependencies
         .iter()
         .any(|(importer_id, dependencies)| importer_diverges(lockfile, importer_id, dependencies))
     {
-        return None;
+        Drift::Absorb(ImportersPlan { manifest_dependencies })
+    } else {
+        Drift::Clean
     }
-    let mut candidate = lockfile.clone();
-    let mut changed = false;
-    let mut moved_across_optional = false;
-    let mut dropped = HashSet::new();
-    for (importer_id, manifest_dependencies) in &manifest_dependencies {
-        let importer = candidate.importers.get_mut(importer_id.as_str())?;
+}
+
+/// Replay the manifests' drift onto `candidate`: compatible specifier
+/// changes, group moves, and removals, with the dropped aliases and
+/// optionality moves recorded in `edits` for the shared epilogue.
+/// `false` — an incompatible or non-semver change, or an alias the
+/// lockfile does not record — leaves the caller on the full-resolution
+/// path.
+pub(crate) fn apply_importers_update(
+    candidate: &mut Lockfile,
+    plan: &ImportersPlan<'_, '_>,
+    edits: &mut GraphEdits,
+) -> bool {
+    for (importer_id, manifest_dependencies) in &plan.manifest_dependencies {
+        let Some(importer) = candidate.importers.get_mut(importer_id.as_str()) else {
+            return false;
+        };
         for (alias, (specifier, target)) in manifest_dependencies {
-            let dependency = importer_dependency_mut(importer, alias)?;
+            let Some(dependency) = importer_dependency_mut(importer, alias) else {
+                return false;
+            };
             if dependency.specifier != *specifier {
-                let range = Range::parse(specifier).ok()?;
-                let version = dependency.version.ver_peer()?.version_semver()?;
+                let Ok(range) = Range::parse(specifier) else {
+                    return false;
+                };
+                let Some(version) =
+                    dependency.version.ver_peer().and_then(|ver_peer| ver_peer.version_semver())
+                else {
+                    return false;
+                };
                 if !version.satisfies(&range) {
-                    return None;
+                    return false;
                 }
                 dependency.specifier = (*specifier).to_string();
-                changed = true;
             }
             if let Some(source) = move_dependency(importer, alias, *target) {
-                moved_across_optional |=
+                edits.moved_across_optional |=
                     source == DependencyGroup::Optional || *target == DependencyGroup::Optional;
-                changed = true;
             }
         }
-        let removed = remove_dependencies_absent_from(importer, manifest_dependencies);
-        changed |= !removed.is_empty();
-        dropped.extend(removed);
+        edits.dropped.extend(remove_dependencies_absent_from(importer, manifest_dependencies));
     }
-    if !dropped.is_empty() {
-        // Prune first: a peer-dependent snapshot that the removal itself
-        // makes unreachable needs no rekeying, so only the survivors are
-        // checked.
-        crate::fast_update_lockfile::prune_unreachable_packages(&mut candidate);
-        if !peer_suffixes_are_independent_of(&candidate, &dropped) {
-            return None;
-        }
-        crate::fast_update_lockfile::prune_unreferenced_catalog_entries(&mut candidate);
-    }
-    if !dropped.is_empty() || moved_across_optional {
-        crate::fast_update_lockfile::recompute_optional_flags(&mut candidate);
-    }
-    changed.then_some(candidate)
+    true
 }
 
 /// Whether the importer's record differs from the manifest in a way the
@@ -200,28 +217,6 @@ fn remove_dependencies_absent_from(
         specifiers.retain(|alias, _| !removed.iter().any(|name| name.to_string() == *alias));
     }
     removed
-}
-
-/// Whether no surviving snapshot resolves a peer through one of `dropped`.
-///
-/// A dropped package that some snapshot reaches as a peer is embedded in
-/// that snapshot's key, so removing it would rekey the dependent rather
-/// than only prune. A peer suffix pnpm shortened into a hash cannot be
-/// read to rule that out.
-fn peer_suffixes_are_independent_of(lockfile: &Lockfile, dropped: &HashSet<PkgName>) -> bool {
-    let Some(snapshots) = lockfile.snapshots.as_ref() else {
-        return true;
-    };
-    snapshots.keys().all(|key| {
-        let peers = key.suffix.peer();
-        peers.is_empty()
-            || (peers
-                .trim_start_matches('(')
-                .trim_end_matches(')')
-                .split(")(")
-                .all(|segment| segment.contains('@'))
-                && !dropped.iter().any(|name| peers.contains(&format!("{name}@"))))
-    })
 }
 
 fn importer_dependency_mut<'a>(

--- a/pnpm/crates/package-manager/src/fast_update_importers.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers.rs
@@ -1,5 +1,4 @@
-use crate::fast_update_compose::Drift;
-use crate::fast_update_lockfile::GraphEdits;
+use crate::{fast_update_compose::Drift, fast_update_lockfile::GraphEdits};
 use node_semver::Range;
 use pacquet_lockfile::{
     Lockfile, PkgName, ProjectSnapshot, ResolvedDependencyMap, ResolvedDependencySpec,

--- a/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
@@ -1,8 +1,22 @@
-use super::try_fast_update_importers;
 use pacquet_lockfile::{Lockfile, PkgName};
 use pacquet_package_manifest::PackageManifest;
 use serde_json::json;
 use std::path::PathBuf;
+
+/// The composed pipeline restricted to manifest drift: every other
+/// input is neutral, so these tests exercise the importers handler and
+/// the shared epilogue alone.
+fn try_fast_update_importers(
+    lockfile: &Lockfile,
+    manifests: &[(String, &PackageManifest)],
+) -> Option<Lockfile> {
+    crate::fast_update_compose::try_compose_fast_updates(
+        lockfile,
+        manifests,
+        &[],
+        &pacquet_config::Config::default(),
+    )
+}
 
 fn lockfile() -> Lockfile {
     serde_saphyr::from_str(

--- a/pnpm/crates/package-manager/src/fast_update_lockfile.rs
+++ b/pnpm/crates/package-manager/src/fast_update_lockfile.rs
@@ -1,5 +1,61 @@
-use pacquet_lockfile::{Lockfile, PkgNameVerPeer};
+use pacquet_lockfile::{Lockfile, PkgName, PkgNameVerPeer};
 use std::collections::{HashSet, VecDeque};
+
+/// What the fast-update handlers did to the dependency graph, so the
+/// maintenance that keeps the lockfile consistent — pruning, the
+/// peer-suffix safety check, catalog entry pruning, and the `optional`
+/// flag recompute — runs once over the combined result instead of once
+/// per handler.
+#[derive(Default)]
+pub(crate) struct GraphEdits {
+    /// Aliases whose importer or snapshot edges were severed.
+    pub(crate) dropped: HashSet<PkgName>,
+    /// Whether an edge into or out of `optionalDependencies` moved, which
+    /// changes the reachability-derived `optional` flags for a subtree.
+    pub(crate) moved_across_optional: bool,
+}
+
+/// Settle the graph after every handler has run: drop what nothing
+/// reaches any more, refuse the update when a surviving peer suffix
+/// embeds a dropped package (its key would need a rewrite, not a prune),
+/// drop catalog entries with no referent left, and recompute the
+/// `optional` flags. `false` leaves the caller on the full-resolution
+/// path.
+pub(crate) fn finish_graph_edits(candidate: &mut Lockfile, edits: &GraphEdits) -> bool {
+    if !edits.dropped.is_empty() {
+        prune_unreachable_packages(candidate);
+        if !peer_suffixes_are_independent_of(candidate, &edits.dropped) {
+            return false;
+        }
+        prune_unreferenced_catalog_entries(candidate);
+    }
+    if !edits.dropped.is_empty() || edits.moved_across_optional {
+        recompute_optional_flags(candidate);
+    }
+    true
+}
+
+/// Whether no surviving snapshot resolves a peer through one of `dropped`.
+///
+/// A dropped package that some snapshot reaches as a peer is embedded in
+/// that snapshot's key, so removing it would rekey the dependent rather
+/// than only prune. A peer suffix pnpm shortened into a hash cannot be
+/// read to rule that out.
+fn peer_suffixes_are_independent_of(lockfile: &Lockfile, dropped: &HashSet<PkgName>) -> bool {
+    let Some(snapshots) = lockfile.snapshots.as_ref() else {
+        return true;
+    };
+    snapshots.keys().all(|key| {
+        let peers = key.suffix.peer();
+        peers.is_empty()
+            || (peers
+                .trim_start_matches('(')
+                .trim_end_matches(')')
+                .split(")(")
+                .all(|segment| segment.contains('@'))
+                && !dropped.iter().any(|name| peers.contains(&format!("{name}@"))))
+    })
+}
 
 pub(crate) fn prune_unreachable_packages(lockfile: &mut Lockfile) {
     let reachable = {

--- a/pnpm/crates/package-manager/src/fast_update_lockfile.rs
+++ b/pnpm/crates/package-manager/src/fast_update_lockfile.rs
@@ -45,6 +45,7 @@ fn peer_suffixes_are_independent_of(lockfile: &Lockfile, dropped: &HashSet<PkgNa
     let Some(snapshots) = lockfile.snapshots.as_ref() else {
         return true;
     };
+    let dropped_needles: Vec<String> = dropped.iter().map(|name| format!("{name}@")).collect();
     snapshots.keys().all(|key| {
         let peers = key.suffix.peer();
         peers.is_empty()
@@ -53,7 +54,7 @@ fn peer_suffixes_are_independent_of(lockfile: &Lockfile, dropped: &HashSet<PkgNa
                 .trim_end_matches(')')
                 .split(")(")
                 .all(|segment| segment.contains('@'))
-                && !dropped.iter().any(|name| peers.contains(&format!("{name}@"))))
+                && !dropped_needles.iter().any(|needle| peers.contains(needle.as_str())))
     })
 }
 

--- a/pnpm/crates/package-manager/src/fast_update_patched_dependencies.rs
+++ b/pnpm/crates/package-manager/src/fast_update_patched_dependencies.rs
@@ -1,3 +1,4 @@
+use crate::fast_update_compose::Drift;
 use pacquet_config::Config;
 use pacquet_deps_path::{index_of_dep_path_suffix, remove_suffix};
 use pacquet_lockfile::{
@@ -12,9 +13,6 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 /// Where a package's snapshot key moves to when its patch changes.
 type Rekeys = HashMap<PackageKey, PackageKey>;
 
-/// Absorb a changed `patchedDependencies` without resolving the
-/// dependency graph.
-///
 /// Resolution never reads a patch: it appends the patch file's hash to
 /// an already-resolved package id, so the set of packages and versions
 /// is the same either way. Only the affected packages' `snapshots:`
@@ -22,39 +20,64 @@ type Rekeys = HashMap<PackageKey, PackageKey>;
 /// the loaded lockfile rather than a re-resolve. `packages:` is keyed
 /// without the patch hash, so it stays as it is.
 ///
-/// `None` — nothing changed, a patched package is reachable as a peer,
-/// or the new configuration leaves a patch unused while
-/// `allowUnusedPatches` is off — leaves the caller on the
-/// full-resolution path, which is where `ERR_PNPM_UNUSED_PATCH` is
-/// raised.
-///
-/// A patch file that cannot be read or hashed also falls back, so the
-/// resolver reports it rather than this path swallowing the error.
-pub(crate) fn try_fast_update_patched_dependencies(
-    lockfile: &Lockfile,
-    config: &Config,
-) -> Option<Lockfile> {
+/// The plan holds the configured patches [`apply_patched_update`] moves
+/// the lockfile to: the hashes to record and their resolver-shaped
+/// grouping.
+pub(crate) struct PatchedPlan {
+    current: BTreeMap<String, String>,
+    groups: PatchGroupRecord,
+}
+
+/// Whether `patchedDependencies` drifted from what the lockfile
+/// records. [`Drift::Resolve`] when a patch file cannot be read or
+/// hashed, or a key's version segment parses as neither a version nor a
+/// range — the resolver reports those.
+pub(crate) fn detect_patched_drift(lockfile: &Lockfile, config: &Config) -> Drift<PatchedPlan> {
     let empty = BTreeMap::new();
-    let hashes = config.patched_dependency_hashes().ok()?;
+    let Ok(hashes) = config.patched_dependency_hashes() else {
+        return Drift::Resolve;
+    };
     let recorded = lockfile.patched_dependencies.as_ref().unwrap_or(&empty);
     let current = hashes.as_ref().unwrap_or(&empty);
     if recorded == current {
-        return None;
+        return Drift::Clean;
     }
+    match groups_from_hashes(current) {
+        Some(groups) => Drift::Absorb(PatchedPlan { current: current.clone(), groups }),
+        None => Drift::Resolve,
+    }
+}
 
-    let groups = groups_from_hashes(current)?;
-    if !config.allow_unused_patches {
-        let applied = applied_patch_keys(lockfile, &groups)?;
-        if all_patch_keys(&groups).any(|key| !applied.contains(key)) {
-            return None;
+/// Rekey the affected snapshots to the configured patches and record
+/// the new hashes.
+///
+/// Runs after removals have been applied and pruned, so the unused-patch
+/// guard and the rekey plan see the packages a full resolution would see
+/// — a patch whose only referent was just removed falls back exactly
+/// like the resolver raising `ERR_PNPM_UNUSED_PATCH` would.
+///
+/// `false` — a patched package reachable as a peer, an opaque peer
+/// suffix, or a patch left unused while `allowUnusedPatches` is off —
+/// leaves the caller on the full-resolution path.
+pub(crate) fn apply_patched_update(
+    candidate: &mut Lockfile,
+    plan: &PatchedPlan,
+    allow_unused_patches: bool,
+) -> bool {
+    if !allow_unused_patches {
+        let Some(applied) = applied_patch_keys(candidate, &plan.groups) else {
+            return false;
+        };
+        if all_patch_keys(&plan.groups).any(|key| !applied.contains(key)) {
+            return false;
         }
     }
-
-    let rekeys = plan_rekeys(lockfile, &groups)?;
-    let mut candidate = lockfile.clone();
-    apply_rekeys(&mut candidate, &rekeys);
-    candidate.patched_dependencies = (!current.is_empty()).then(|| current.clone());
-    Some(candidate)
+    let Some(rekeys) = plan_rekeys(candidate, &plan.groups) else {
+        return false;
+    };
+    apply_rekeys(candidate, &rekeys);
+    candidate.patched_dependencies = (!plan.current.is_empty()).then(|| plan.current.clone());
+    true
 }
 
 /// Where every snapshot key moves to once `groups` is the configured

--- a/pnpm/crates/package-manager/src/fast_update_patched_dependencies/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_patched_dependencies/tests.rs
@@ -1,4 +1,9 @@
-use super::try_fast_update_patched_dependencies;
+/// The composed pipeline restricted to `patchedDependencies` drift:
+/// every other input is neutral, so these tests exercise this handler
+/// alone.
+fn try_fast_update_patched_dependencies(lockfile: &Lockfile, config: &Config) -> Option<Lockfile> {
+    crate::fast_update_compose::try_compose_fast_updates(lockfile, &[], &[], config)
+}
 use indexmap::IndexMap;
 use pacquet_config::Config;
 use pacquet_lockfile::Lockfile;

--- a/pnpm/crates/package-manager/src/fast_update_settings.rs
+++ b/pnpm/crates/package-manager/src/fast_update_settings.rs
@@ -34,33 +34,39 @@ pub(crate) enum ChangedSetting {
 }
 
 /// Whether the lockfile's recorded `settings` block drifted from the
-/// current configuration, restricted to the drift the lockfile itself
-/// proves cannot affect its graph: the peer settings when nothing
-/// declares a peer dependency, and the link and injection settings when
-/// no project depends on a directory or on another workspace project.
-/// Everything else is [`Drift::Resolve`].
-pub(crate) fn detect_settings_drift(
-    lockfile: &Lockfile,
-    settings: &LockfileSettings,
-    manifests: &[(PathBuf, &PackageManifest)],
-) -> Drift<()> {
-    let changed = changed_settings(lockfile.settings.as_ref(), settings);
-    if changed.is_empty() {
-        return Drift::Clean;
-    }
-    let workspace_package_names = workspace_package_names(manifests);
-    if changed.iter().all(|setting| {
-        setting_cannot_affect_lockfile(*setting, lockfile, manifests, &workspace_package_names)
-    }) {
-        Drift::Absorb(())
+/// current configuration. Whether the drift is absorbable is
+/// [`apply_settings_update`]'s question: it depends on the graph, which
+/// the handlers running before it may have rewritten.
+pub(crate) fn detect_settings_drift(lockfile: &Lockfile, settings: &LockfileSettings) -> Drift<()> {
+    if changed_settings(lockfile.settings.as_ref(), settings).is_empty() {
+        Drift::Clean
     } else {
-        Drift::Resolve
+        Drift::Absorb(())
     }
 }
 
-/// Record the current configuration's `settings` block on `candidate`.
-pub(crate) fn apply_settings_update(candidate: &mut Lockfile, settings: &LockfileSettings) {
+/// Record the current configuration's `settings` block on `candidate`,
+/// restricted to the drift the candidate itself proves cannot affect
+/// its graph: the peer settings when nothing declares a peer
+/// dependency, and the link and injection settings when no project
+/// depends on a directory or on another workspace project. Checked
+/// against the candidate the earlier handlers already rewrote — a peer
+/// dependent they removed no longer blocks the setting. `false` leaves
+/// the caller on the full-resolution path.
+pub(crate) fn apply_settings_update(
+    candidate: &mut Lockfile,
+    settings: &LockfileSettings,
+    manifests: &[(PathBuf, &PackageManifest)],
+) -> bool {
+    let changed = changed_settings(candidate.settings.as_ref(), settings);
+    let workspace_package_names = workspace_package_names(manifests);
+    if !changed.iter().all(|setting| {
+        setting_cannot_affect_lockfile(*setting, candidate, manifests, &workspace_package_names)
+    }) {
+        return false;
+    }
     candidate.settings = Some(settings.clone());
+    true
 }
 
 fn changed_settings(

--- a/pnpm/crates/package-manager/src/fast_update_settings.rs
+++ b/pnpm/crates/package-manager/src/fast_update_settings.rs
@@ -1,3 +1,4 @@
+use crate::fast_update_compose::Drift;
 use pacquet_config::Config;
 use pacquet_lockfile::{ImporterDepVersion, Lockfile, LockfileSettings, ProjectSnapshot};
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
@@ -32,32 +33,34 @@ pub(crate) enum ChangedSetting {
     InjectWorkspacePackages,
 }
 
-/// Record a changed lockfile setting without resolving the dependency
-/// graph, for the settings that the lockfile itself proves cannot
-/// affect its graph: the peer settings when nothing declares a peer
-/// dependency, and the link and injection settings when no project
-/// depends on a directory or on another workspace project.
-///
-/// `None` — nothing changed, or a changed setting could affect the
-/// graph — leaves the caller on the full-resolution path.
-pub(crate) fn try_fast_update_settings(
+/// Whether the lockfile's recorded `settings` block drifted from the
+/// current configuration, restricted to the drift the lockfile itself
+/// proves cannot affect its graph: the peer settings when nothing
+/// declares a peer dependency, and the link and injection settings when
+/// no project depends on a directory or on another workspace project.
+/// Everything else is [`Drift::Resolve`].
+pub(crate) fn detect_settings_drift(
     lockfile: &Lockfile,
     settings: &LockfileSettings,
     manifests: &[(PathBuf, &PackageManifest)],
-) -> Option<Lockfile> {
+) -> Drift<()> {
     let changed = changed_settings(lockfile.settings.as_ref(), settings);
     if changed.is_empty() {
-        return None;
+        return Drift::Clean;
     }
     let workspace_package_names = workspace_package_names(manifests);
-    if !changed.iter().all(|setting| {
+    if changed.iter().all(|setting| {
         setting_cannot_affect_lockfile(*setting, lockfile, manifests, &workspace_package_names)
     }) {
-        return None;
+        Drift::Absorb(())
+    } else {
+        Drift::Resolve
     }
-    let mut candidate = lockfile.clone();
+}
+
+/// Record the current configuration's `settings` block on `candidate`.
+pub(crate) fn apply_settings_update(candidate: &mut Lockfile, settings: &LockfileSettings) {
     candidate.settings = Some(settings.clone());
-    Some(candidate)
 }
 
 fn changed_settings(

--- a/pnpm/crates/package-manager/src/fast_update_settings/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_settings/tests.rs
@@ -1,8 +1,25 @@
-use super::try_fast_update_settings;
 use pacquet_lockfile::{Lockfile, LockfileSettings};
 use pacquet_package_manifest::PackageManifest;
 use serde_json::{Value, json};
 use std::path::PathBuf;
+
+/// Detection and application chained the way the composed pipeline
+/// chains them, with an arbitrary `settings` block instead of one
+/// derived from a `Config`.
+fn try_fast_update_settings(
+    lockfile: &Lockfile,
+    settings: &LockfileSettings,
+    manifests: &[(PathBuf, &PackageManifest)],
+) -> Option<Lockfile> {
+    match super::detect_settings_drift(lockfile, settings, manifests) {
+        crate::fast_update_compose::Drift::Absorb(()) => {
+            let mut candidate = lockfile.clone();
+            super::apply_settings_update(&mut candidate, settings);
+            Some(candidate)
+        }
+        _ => None,
+    }
+}
 
 const PEERLESS_LOCKFILE: &str = r"
 lockfileVersion: '9.0'

--- a/pnpm/crates/package-manager/src/fast_update_settings/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_settings/tests.rs
@@ -11,11 +11,10 @@ fn try_fast_update_settings(
     settings: &LockfileSettings,
     manifests: &[(PathBuf, &PackageManifest)],
 ) -> Option<Lockfile> {
-    match super::detect_settings_drift(lockfile, settings, manifests) {
+    match super::detect_settings_drift(lockfile, settings) {
         crate::fast_update_compose::Drift::Absorb(()) => {
             let mut candidate = lockfile.clone();
-            super::apply_settings_update(&mut candidate, settings);
-            Some(candidate)
+            super::apply_settings_update(&mut candidate, settings, manifests).then_some(candidate)
         }
         _ => None,
     }

--- a/pnpm/crates/package-manager/src/install/lockfile_freshness.rs
+++ b/pnpm/crates/package-manager/src/install/lockfile_freshness.rs
@@ -15,42 +15,22 @@ pub(super) struct FastUpdateLockfileOptions<'a, 'manifest> {
 }
 
 /// Rewrite the loaded lockfile in place of a full resolution for the
-/// drift the lockfile itself proves is safe to absorb: a compatible
-/// direct-dependency range change, an addition to
-/// `ignoredOptionalDependencies`, a `patchedDependencies` change that
-/// matches no locked package, or a setting change that cannot affect
-/// the recorded graph. The candidate only replaces the loaded
-/// lockfile once it passes every freshness gate, so a handler that
-/// rewrites too much falls back to the resolver instead of committing.
-///
-/// Each handler rewrites the same loaded lockfile, so their candidates
-/// cannot be composed: when more than one fires, the resolver takes
-/// over rather than committing a candidate that drops another's rewrite.
+/// drift the lockfile itself proves is safe to absorb — see
+/// [`crate::fast_update_compose::try_compose_fast_updates`] for the
+/// handlers and their composition order. The candidate only replaces
+/// the loaded lockfile once it passes every freshness gate, so a
+/// handler that rewrites too much falls back to the resolver instead
+/// of committing.
 pub(super) async fn try_fast_update_lockfile(
     opts: FastUpdateLockfileOptions<'_, '_>,
 ) -> Option<Lockfile> {
     let lockfile = opts.lockfile?;
-    let mut candidates = [
-        crate::fast_update_importers::try_fast_update_importers(lockfile, opts.manifests),
-        crate::fast_update_ignored_optional_dependencies::try_fast_update_ignored_optional_dependencies(
-            lockfile,
-            opts.config.ignored_optional_dependencies.as_deref().unwrap_or_default(),
-        ),
-        crate::fast_update_settings::try_fast_update_settings(
-            lockfile,
-            &crate::fast_update_settings::lockfile_settings_from_config(opts.config),
-            opts.project_manifests,
-        ),
-        crate::fast_update_patched_dependencies::try_fast_update_patched_dependencies(
-            lockfile,
-            opts.config,
-        ),
-    ]
-    .into_iter()
-    .flatten();
-    let (Some(candidate), None) = (candidates.next(), candidates.next()) else {
-        return None;
-    };
+    let candidate = crate::fast_update_compose::try_compose_fast_updates(
+        lockfile,
+        opts.manifests,
+        opts.project_manifests,
+        opts.config,
+    )?;
     check_lockfile_freshness(
         &candidate,
         opts.manifests,

--- a/pnpm/crates/package-manager/src/lib.rs
+++ b/pnpm/crates/package-manager/src/lib.rs
@@ -8,6 +8,7 @@ mod compat_package_extensions;
 mod dependencies_graph_to_lockfile;
 mod fast_update_catalog_versions;
 mod fast_update_catalogs;
+mod fast_update_compose;
 mod fast_update_ignored_optional_dependencies;
 mod fast_update_importers;
 mod fast_update_lockfile;

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -109,14 +109,12 @@ import {
 } from './extendInstallOptions.js'
 import { linkPackages } from './link.js'
 import { reportPeerDependencyIssues } from './reportPeerDependencyIssues.js'
+import { tryComposeFastUpdates } from './tryComposeFastUpdates.js'
 import { tryFastUpdateCatalogs } from './tryFastUpdateCatalogs.js'
 import { tryFastUpdateCatalogVersions } from './tryFastUpdateCatalogVersions.js'
-import { tryFastUpdateIgnoredOptionalDependencies } from './tryFastUpdateIgnoredOptionalDependencies.js'
-import { hasChangedProjectSpecifiers, tryFastUpdateImporters } from './tryFastUpdateImporters.js'
+import { hasChangedProjectSpecifiers } from './tryFastUpdateImporters.js'
 import { tryFastUpdateLockfile } from './tryFastUpdateLockfile.js'
 import { tryFastUpdateOverrides } from './tryFastUpdateOverrides.js'
-import { tryFastUpdatePatchedDependencies } from './tryFastUpdatePatchedDependencies.js'
-import { tryFastUpdateSettings } from './tryFastUpdateSettings.js'
 import { validateModules } from './validateModules.js'
 import { verifyLockfileResolutions } from './verifyLockfileResolutions.js'
 import { warnOnStaleConvergenceOverrides } from './warnOnStaleConvergenceOverrides.js'
@@ -139,10 +137,8 @@ const BROKEN_LOCKFILE_INTEGRITY_ERRORS = new Set([
 
 const DEV_PREINSTALL = 'pnpm:devPreinstall'
 
-const FAST_UPDATABLE_SETTINGS = new Set<ChangedField | null>([
-  'catalogs',
+const COMPOSABLE_CHANGED_FIELDS = new Set<ChangedField>([
   'ignoredOptionalDependencies',
-  'overrides',
   'patchedDependencies',
 ])
 
@@ -732,15 +728,26 @@ export async function mutateModules (
     const upToDateLockfileMajorVersion = ctx.wantedLockfile.lockfileVersion.toString().startsWith(`${LOCKFILE_MAJOR_VERSION}.`)
     let didFastUpdateOverrides = false
     const contextProjects = Object.values(ctx.projects)
-    const hasChangedSpecifiers = outdatedLockfileSettingName == null &&
-      hasChangedProjectSpecifiers(ctx.wantedLockfile, contextProjects)
+    const hasChangedSpecifiers = hasChangedProjectSpecifiers(ctx.wantedLockfile, contextProjects)
     const changedSettingsFields = changedLockfileSettings.filter(isSettingsField)
-    const onlyLockfileSettingsChanged = changedLockfileSettings.length > 0 &&
-      changedLockfileSettings.length === changedSettingsFields.length
+    // The async rewrites (catalogs, overrides) consult the resolver and stay
+    // outside the composed pipeline, so they require being the only change.
+    const asyncChangedSetting = changedLockfileSettings.length === 1 && !hasChangedSpecifiers &&
+      (changedLockfileSettings[0] === 'catalogs' || changedLockfileSettings[0] === 'overrides')
+      ? changedLockfileSettings[0]
+      : null
+    const syncDrift = {
+      importers: hasChangedSpecifiers,
+      ignoredOptionalDependencies: changedLockfileSettings.includes('ignoredOptionalDependencies'),
+      patchedDependencies: changedLockfileSettings.includes('patchedDependencies'),
+      settings: changedSettingsFields.length > 0,
+    }
+    const composableSyncDrift =
+      (hasChangedSpecifiers || changedLockfileSettings.length > 0) &&
+      changedLockfileSettings.every((field) =>
+        isSettingsField(field) || COMPOSABLE_CHANGED_FIELDS.has(field))
     const canTryFastUpdateLockfile =
-      (FAST_UPDATABLE_SETTINGS.has(outdatedLockfileSettingName) ||
-        onlyLockfileSettingsChanged ||
-        hasChangedSpecifiers) &&
+      (asyncChangedSetting != null || composableSyncDrift) &&
       !frozenLockfile &&
       // `pnpm fetch` installs from the lockfile alone; with its empty
       // manifests every recorded dependency would read as removed.
@@ -767,11 +774,9 @@ export async function mutateModules (
       (!opts.pruneLockfileImporters || Object.keys(ctx.wantedLockfile.importers).length === Object.keys(ctx.projects).length) &&
       ctx.wantedLockfile.time == null
     if (canTryFastUpdateLockfile) {
-      const changedSetting = outdatedLockfileSettingName
       await verifyLockfilePromise
       const overridesUseCatalogs = Object.values(opts.overrides)
         .some((specifier) => parseCatalogProtocol(specifier) != null)
-      const onlyChangedSetting = onlyLockfileSettingsChanged || changedLockfileSettings.length <= 1
       const isLockfileUpToDate = (lockfile: LockfileObject) => allProjectsAreUpToDate(Object.values(ctx.projects), {
         catalogs: opts.catalogs,
         autoInstallPeers: opts.autoInstallPeers,
@@ -783,19 +788,10 @@ export async function mutateModules (
         lockfileDir: opts.lockfileDir,
       })
       if (
-        onlyChangedSetting &&
-        (changedSetting === 'catalogs' || !overridesUseCatalogs) &&
+        (asyncChangedSetting === 'catalogs' || !overridesUseCatalogs) &&
         await tryFastUpdateLockfile(ctx.wantedLockfile, {
           update: async (candidate) => {
-            if (onlyLockfileSettingsChanged) {
-              return tryFastUpdateSettings(candidate, {
-                changedSettings: changedSettingsFields,
-                projects: contextProjects,
-                settings: wantedLockfileSettings,
-                workspacePackages: ctx.workspacePackages,
-              })
-            }
-            if (changedSetting === 'catalogs') {
+            if (asyncChangedSetting === 'catalogs') {
               // The range-only rewrite keeps the entries it cannot handle, so a
               // mixed update still leaves an exact move for the rewrite below.
               const rewroteRanges = tryFastUpdateCatalogs(candidate, {
@@ -826,17 +822,22 @@ export async function mutateModules (
               if (rewrite === 'applied') return true
               return rewrite === 'nothing-to-move' && rewroteRanges
             }
-            if (changedSetting === 'ignoredOptionalDependencies') {
-              return tryFastUpdateIgnoredOptionalDependencies(candidate, opts.ignoredOptionalDependencies)
-            }
-            if (changedSetting === 'patchedDependencies') {
-              return tryFastUpdatePatchedDependencies(candidate, {
-                patchedDependencies,
-                allowUnusedPatches: opts.allowUnusedPatches,
+            if (asyncChangedSetting == null) {
+              return tryComposeFastUpdates(candidate, {
+                drift: syncDrift,
+                projects: contextProjects,
+                ignoredOptionalDependencies: opts.ignoredOptionalDependencies,
+                patchedDependencies: {
+                  patchedDependencies,
+                  allowUnusedPatches: opts.allowUnusedPatches,
+                },
+                settings: {
+                  changedSettings: changedSettingsFields,
+                  projects: contextProjects,
+                  settings: wantedLockfileSettings,
+                  workspacePackages: ctx.workspacePackages,
+                },
               })
-            }
-            if (changedSetting == null) {
-              return tryFastUpdateImporters(candidate, contextProjects)
             }
             const { publishedBy, publishedByExclude } = getPublishedByPolicy(opts)
             return tryFastUpdateOverrides(candidate, {
@@ -863,7 +864,7 @@ export async function mutateModules (
       ) {
         outdatedLockfileSettingName = null
         ctx.wantedLockfileIsModified = true
-        didFastUpdateOverrides = changedSetting === 'overrides'
+        didFastUpdateOverrides = asyncChangedSetting === 'overrides'
       }
     }
     const outdatedLockfileSettings = outdatedLockfileSettingName != null

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -728,12 +728,18 @@ export async function mutateModules (
     const upToDateLockfileMajorVersion = ctx.wantedLockfile.lockfileVersion.toString().startsWith(`${LOCKFILE_MAJOR_VERSION}.`)
     let didFastUpdateOverrides = false
     const contextProjects = Object.values(ctx.projects)
-    const hasChangedSpecifiers = hasChangedProjectSpecifiers(ctx.wantedLockfile, contextProjects)
     const changedSettingsFields = changedLockfileSettings.filter(isSettingsField)
+    const allChangedFieldsAreComposable = changedLockfileSettings.every((field) =>
+      isSettingsField(field) || COMPOSABLE_CHANGED_FIELDS.has(field))
+    const changedFieldIsAsync = changedLockfileSettings.length === 1 &&
+      (changedLockfileSettings[0] === 'catalogs' || changedLockfileSettings[0] === 'overrides')
+    // A changed field nothing can absorb forces a resolution, so the
+    // workspace-wide specifier scan would be wasted.
+    const hasChangedSpecifiers = (allChangedFieldsAreComposable || changedFieldIsAsync) &&
+      hasChangedProjectSpecifiers(ctx.wantedLockfile, contextProjects)
     // The async rewrites (catalogs, overrides) consult the resolver and stay
     // outside the composed pipeline, so they require being the only change.
-    const asyncChangedSetting = changedLockfileSettings.length === 1 && !hasChangedSpecifiers &&
-      (changedLockfileSettings[0] === 'catalogs' || changedLockfileSettings[0] === 'overrides')
+    const asyncChangedSetting = changedFieldIsAsync && !hasChangedSpecifiers
       ? changedLockfileSettings[0]
       : null
     const syncDrift = {
@@ -744,8 +750,7 @@ export async function mutateModules (
     }
     const composableSyncDrift =
       (hasChangedSpecifiers || changedLockfileSettings.length > 0) &&
-      changedLockfileSettings.every((field) =>
-        isSettingsField(field) || COMPOSABLE_CHANGED_FIELDS.has(field))
+      allChangedFieldsAreComposable
     const canTryFastUpdateLockfile =
       (asyncChangedSetting != null || composableSyncDrift) &&
       !frozenLockfile &&

--- a/pnpm11/installing/deps-installer/src/install/tryComposeFastUpdates.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryComposeFastUpdates.ts
@@ -1,0 +1,137 @@
+import * as dp from '@pnpm/deps.path'
+import { pruneSharedLockfile } from '@pnpm/lockfile.pruner'
+import type { LockfileObject } from '@pnpm/lockfile.types'
+
+import { pruneUnreferencedCatalogEntries } from './tryFastUpdateCatalogs.js'
+import { tryFastUpdateIgnoredOptionalDependencies } from './tryFastUpdateIgnoredOptionalDependencies.js'
+import { type Project, tryFastUpdateImporters } from './tryFastUpdateImporters.js'
+import {
+  type FastPatchedDependenciesUpdateOptions,
+  tryFastUpdatePatchedDependencies,
+} from './tryFastUpdatePatchedDependencies.js'
+import {
+  type FastSettingsUpdateOptions,
+  tryFastUpdateSettings,
+} from './tryFastUpdateSettings.js'
+
+/**
+ * What the fast-update handlers did to the dependency graph, so the
+ * maintenance that keeps the lockfile consistent — pruning, the peer-suffix
+ * safety check, catalog entry pruning, and the `optional` flag recompute —
+ * runs once over the combined result instead of once per handler.
+ */
+export interface GraphEdits {
+  /** Aliases whose importer or package edges were severed. */
+  dropped: Set<string>
+  /**
+   * Whether an edge into or out of `optionalDependencies` moved, which
+   * changes the reachability-derived `optional` flags for a subtree.
+   */
+  movedAcrossOptional: boolean
+}
+
+/** The drift dimensions the composed sync handlers can absorb. */
+export interface FastUpdateDrift {
+  importers?: boolean
+  ignoredOptionalDependencies?: boolean
+  patchedDependencies?: boolean
+  settings?: boolean
+}
+
+export interface ComposeFastUpdatesOptions {
+  drift: FastUpdateDrift
+  projects: Project[]
+  ignoredOptionalDependencies?: string[]
+  patchedDependencies?: FastPatchedDependenciesUpdateOptions
+  settings?: FastSettingsUpdateOptions
+}
+
+/**
+ * Rewrite `candidate` in place of a full resolution for the drift the
+ * lockfile itself proves is safe to absorb, composing every applicable
+ * handler onto the one candidate: manifest drift (compatible range changes,
+ * dependency group moves, removals), a widened `ignoredOptionalDependencies`,
+ * a changed `patchedDependencies`, and a setting change that cannot affect
+ * the recorded graph. Drift that spans several of those dimensions at once is
+ * absorbed in one pass — no handler requires being the only change.
+ *
+ * The handlers run in a fixed order. Removals land first (manifest drift,
+ * then newly ignored optional dependencies), then the shared epilogue prunes
+ * what nothing reaches and refuses candidates whose surviving peer suffixes
+ * embed a dropped package. Patches rekey after that, so the unused-patch
+ * guard and the rekey plan see the packages a full resolution would see. The
+ * settings block, which touches no graph, is recorded last.
+ *
+ * `false` — drift some handler cannot express — leaves the caller on the
+ * full-resolution path; `candidate` may be partially rewritten by then, which
+ * the coordinator's discard-on-failure makes safe. The caller still validates
+ * the candidate with the freshness gates before committing.
+ */
+export function tryComposeFastUpdates (
+  candidate: LockfileObject,
+  opts: ComposeFastUpdatesOptions
+): boolean {
+  const edits: GraphEdits = { dropped: new Set(), movedAcrossOptional: false }
+  if (opts.drift.importers && !tryFastUpdateImporters(candidate, opts.projects, edits)) {
+    return false
+  }
+  if (opts.drift.ignoredOptionalDependencies) {
+    if (!tryFastUpdateIgnoredOptionalDependencies(candidate, opts.ignoredOptionalDependencies ?? [], edits)) {
+      return false
+    }
+  }
+  if (!finishGraphEdits(candidate, edits)) return false
+  if (opts.drift.patchedDependencies && !tryFastUpdatePatchedDependencies(candidate, opts.patchedDependencies!)) {
+    return false
+  }
+  if (opts.drift.settings && !tryFastUpdateSettings(candidate, opts.settings!)) {
+    return false
+  }
+  return true
+}
+
+/**
+ * Settle the graph after every handler has run. The prune also recomputes
+ * each package's `optional` flag from what still reaches it. `false` — a
+ * surviving peer suffix embeds a dropped package, so its key would need a
+ * rewrite, not a prune — leaves the caller on the full-resolution path.
+ */
+function finishGraphEdits (candidate: LockfileObject, edits: GraphEdits): boolean {
+  if (edits.dropped.size > 0 || edits.movedAcrossOptional) {
+    const pruned = pruneSharedLockfile(candidate)
+    if (pruned.packages == null) {
+      delete candidate.packages
+    } else {
+      candidate.packages = pruned.packages
+    }
+  }
+  if (edits.dropped.size > 0) {
+    // Pruned first: a peer-dependent package that the removals themselves
+    // make unreachable needs no rekeying, so only the survivors are checked.
+    if (!peerSuffixesAreIndependentOf(candidate, edits.dropped)) return false
+    pruneUnreferencedCatalogEntries(candidate)
+  }
+  return true
+}
+
+/**
+ * Whether no surviving package resolves a peer through one of `dropped`.
+ *
+ * A dropped package that some package reaches as a peer is embedded in that
+ * package's key, so removing it would rekey the dependent rather than only
+ * prune. A peer suffix pnpm shortened into a hash cannot be read to rule that
+ * out.
+ */
+function peerSuffixesAreIndependentOf (lockfile: LockfileObject, dropped: Set<string>): boolean {
+  return Object.keys(lockfile.packages ?? {}).every((depPath) => {
+    const { peersIndex } = dp.indexOfDepPathSuffix(depPath)
+    if (peersIndex === -1) return true
+    const peers = depPath.substring(peersIndex)
+    return peers
+      .replace(/^\(/, '')
+      .replace(/\)$/, '')
+      .split(')(')
+      .every((segment) => segment.includes('@')) &&
+      ![...dropped].some((alias) => peers.includes(`${alias}@`))
+  })
+}

--- a/pnpm11/installing/deps-installer/src/install/tryComposeFastUpdates.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryComposeFastUpdates.ts
@@ -47,25 +47,15 @@ export interface ComposeFastUpdatesOptions {
 }
 
 /**
- * Rewrite `candidate` in place of a full resolution for the drift the
- * lockfile itself proves is safe to absorb, composing every applicable
- * handler onto the one candidate: manifest drift (compatible range changes,
- * dependency group moves, removals), a widened `ignoredOptionalDependencies`,
- * a changed `patchedDependencies`, and a setting change that cannot affect
- * the recorded graph. Drift that spans several of those dimensions at once is
- * absorbed in one pass — no handler requires being the only change.
- *
- * The handlers run in a fixed order. Removals land first (manifest drift,
- * then newly ignored optional dependencies), then the shared epilogue prunes
- * what nothing reaches and refuses candidates whose surviving peer suffixes
- * embed a dropped package. Patches rekey after that, so the unused-patch
- * guard and the rekey plan see the packages a full resolution would see. The
- * settings block, which touches no graph, is recorded last.
+ * Rewrite `candidate` in place of a full resolution, composing every handler
+ * with absorbable drift onto the one candidate — no handler requires being
+ * the only change. Removals apply first, then the shared graph epilogue
+ * (`finishGraphEdits`), then patch rekeying — after the prune, so its guards
+ * see the packages a full resolution would see — and the settings block last.
  *
  * `false` — drift some handler cannot express — leaves the caller on the
  * full-resolution path; `candidate` may be partially rewritten by then, which
- * the coordinator's discard-on-failure makes safe. The caller still validates
- * the candidate with the freshness gates before committing.
+ * the coordinator's discard-on-failure makes safe.
  */
 export function tryComposeFastUpdates (
   candidate: LockfileObject,
@@ -123,6 +113,7 @@ function finishGraphEdits (candidate: LockfileObject, edits: GraphEdits): boolea
  * out.
  */
 function peerSuffixesAreIndependentOf (lockfile: LockfileObject, dropped: Set<string>): boolean {
+  const droppedNeedles = [...dropped].map((alias) => `${alias}@`)
   return Object.keys(lockfile.packages ?? {}).every((depPath) => {
     const { peersIndex } = dp.indexOfDepPathSuffix(depPath)
     if (peersIndex === -1) return true
@@ -132,6 +123,6 @@ function peerSuffixesAreIndependentOf (lockfile: LockfileObject, dropped: Set<st
       .replace(/\)$/, '')
       .split(')(')
       .every((segment) => segment.includes('@')) &&
-      ![...dropped].some((alias) => peers.includes(`${alias}@`))
+      !droppedNeedles.some((needle) => peers.includes(needle))
   })
 }

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateIgnoredOptionalDependencies.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateIgnoredOptionalDependencies.ts
@@ -1,16 +1,24 @@
 import { createMatcher } from '@pnpm/config.matcher'
-import { pruneSharedLockfile } from '@pnpm/lockfile.pruner'
 import type {
   LockfileObject,
   ProjectSnapshot,
   ResolvedDependencies,
 } from '@pnpm/lockfile.types'
 
-import { pruneUnreferencedCatalogEntries } from './tryFastUpdateCatalogs.js'
+import type { GraphEdits } from './tryComposeFastUpdates.js'
 
+/**
+ * Remove every optional dependency a widened `ignoredOptionalDependencies`
+ * now ignores, from importers and packages alike, recording the removed
+ * aliases in `edits` for the shared epilogue. `false` — a narrowed list, a
+ * new exclusion, or a previous configuration that ignores by default — leaves
+ * the caller on the full-resolution path, because only a resolution can bring
+ * packages back.
+ */
 export function tryFastUpdateIgnoredOptionalDependencies (
   lockfile: LockfileObject,
-  ignoredOptionalDependencies: string[]
+  ignoredOptionalDependencies: string[],
+  edits: GraphEdits
 ): boolean {
   const previous = new Set(lockfile.ignoredOptionalDependencies ?? [])
   const current = new Set(ignoredOptionalDependencies)
@@ -27,20 +35,12 @@ export function tryFastUpdateIgnoredOptionalDependencies (
 
   const isIgnored = createMatcher(ignoredOptionalDependencies)
   for (const importer of Object.values(lockfile.importers)) {
-    removeIgnoredOptionalDependencies(importer, isIgnored)
+    removeIgnoredOptionalDependencies(importer, isIgnored, edits)
   }
   for (const snapshot of Object.values(lockfile.packages ?? {})) {
-    removeIgnoredOptionalDependencies(snapshot, isIgnored)
+    removeIgnoredOptionalDependencies(snapshot, isIgnored, edits)
   }
   lockfile.ignoredOptionalDependencies = [...current].sort()
-
-  const pruned = pruneSharedLockfile(lockfile)
-  if (pruned.packages == null) {
-    delete lockfile.packages
-  } else {
-    lockfile.packages = pruned.packages
-  }
-  pruneUnreferencedCatalogEntries(lockfile)
   return true
 }
 
@@ -48,10 +48,12 @@ function removeIgnoredOptionalDependencies (
   snapshot: Pick<ProjectSnapshot, 'dependencies' | 'optionalDependencies'> & {
     specifiers?: ResolvedDependencies
   },
-  isIgnored: (dependency: string) => boolean
+  isIgnored: (dependency: string) => boolean,
+  edits: GraphEdits
 ): void {
   const removed = Object.keys(snapshot.optionalDependencies ?? {}).filter(isIgnored)
   for (const dependency of removed) {
+    edits.dropped.add(dependency)
     delete snapshot.optionalDependencies![dependency]
     delete snapshot.dependencies?.[dependency]
     delete snapshot.specifiers?.[dependency]

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
@@ -1,12 +1,11 @@
 import * as dp from '@pnpm/deps.path'
-import { pruneSharedLockfile } from '@pnpm/lockfile.pruner'
 import type { LockfileObject, ProjectSnapshot } from '@pnpm/lockfile.types'
 import { DEPENDENCIES_FIELDS, type DependenciesField, type ProjectId, type ProjectManifest } from '@pnpm/types'
 import semver from 'semver'
 
-import { pruneUnreferencedCatalogEntries } from './tryFastUpdateCatalogs.js'
+import type { GraphEdits } from './tryComposeFastUpdates.js'
 
-interface Project {
+export interface Project {
   id: ProjectId
   manifest: ProjectManifest
 }
@@ -30,15 +29,15 @@ export function hasChangedProjectSpecifiers (
 /**
  * Mutates `lockfile` in place and may leave it partially rewritten when it
  * returns `false` — the caller passes the coordinator's disposable candidate,
- * which is discarded on failure.
+ * which is discarded on failure. The dropped aliases and optionality moves
+ * are recorded in `edits` for the shared epilogue.
  */
 export function tryFastUpdateImporters (
   lockfile: LockfileObject,
-  projects: Project[]
+  projects: Project[],
+  edits: GraphEdits
 ): boolean {
-  const dropped = new Set<string>()
   let changed = false
-  let movedAcrossOptional = false
   for (const project of projects) {
     const importer = lockfile.importers[project.id]
     if (importer == null) return false
@@ -69,14 +68,14 @@ export function tryFastUpdateImporters (
       target[alias] = importer[recordedIn]![alias]
       delete importer[recordedIn]![alias]
       if (recordedIn === 'optionalDependencies' || targetGroup === 'optionalDependencies') {
-        movedAcrossOptional = true
+        edits.movedAcrossOptional = true
       }
       editedGroups = true
       changed = true
     }
     for (const alias of Object.keys(importer.specifiers)) {
       if (manifestSpecifiers[alias] != null) continue
-      dropped.add(alias)
+      edits.dropped.add(alias)
       delete importer.specifiers[alias]
       for (const group of DEPENDENCIES_FIELDS) {
         delete importer[group]?.[alias]
@@ -92,48 +91,7 @@ export function tryFastUpdateImporters (
       }
     }
   }
-  if (!changed) return false
-
-  // The prune also recomputes each package's `optional` flag from what still
-  // reaches it, which a move into or out of `optionalDependencies` changes
-  // for the whole subtree.
-  if (dropped.size > 0 || movedAcrossOptional) {
-    const pruned = pruneSharedLockfile(lockfile)
-    if (pruned.packages == null) {
-      delete lockfile.packages
-    } else {
-      lockfile.packages = pruned.packages
-    }
-  }
-  if (dropped.size > 0) {
-    // Pruned first: a peer-dependent package that the removal itself makes
-    // unreachable needs no rekeying, so only the survivors are checked.
-    if (!peerSuffixesAreIndependentOf(lockfile, dropped)) return false
-    pruneUnreferencedCatalogEntries(lockfile)
-  }
-  return true
-}
-
-/**
- * Whether no surviving package resolves a peer through one of `dropped`.
- *
- * A dropped package that some package reaches as a peer is embedded in that
- * package's key, so removing it would rekey the dependent rather than only
- * prune. A peer suffix pnpm shortened into a hash cannot be read to rule that
- * out.
- */
-function peerSuffixesAreIndependentOf (lockfile: LockfileObject, dropped: Set<string>): boolean {
-  return Object.keys(lockfile.packages ?? {}).every((depPath) => {
-    const { peersIndex } = dp.indexOfDepPathSuffix(depPath)
-    if (peersIndex === -1) return true
-    const peers = depPath.substring(peersIndex)
-    return peers
-      .replace(/^\(/, '')
-      .replace(/\)$/, '')
-      .split(')(')
-      .every((segment) => segment.includes('@')) &&
-      ![...dropped].some((alias) => peers.includes(`${alias}@`))
-  })
+  return changed
 }
 
 function dependencyGroupMoved (

--- a/pnpm11/installing/deps-installer/test/install/catalogFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/catalogFastUpdate.ts
@@ -5,10 +5,16 @@ import { prepareEmpty } from '@pnpm/prepare'
 import type { StoreController } from '@pnpm/store.controller-types'
 import type { ProjectId, ProjectManifest, ProjectRootDir } from '@pnpm/types'
 
+import { tryComposeFastUpdates } from '../../src/install/tryComposeFastUpdates.js'
 import { tryFastUpdateCatalogs } from '../../src/install/tryFastUpdateCatalogs.js'
-import { tryFastUpdateImporters } from '../../src/install/tryFastUpdateImporters.js'
+import type { Project } from '../../src/install/tryFastUpdateImporters.js'
 import { tryFastUpdateLockfile } from '../../src/install/tryFastUpdateLockfile.js'
 import { testDefaults } from '../utils/index.js'
+
+/** The composed pipeline restricted to manifest drift. */
+function tryFastUpdateImporters (lockfile: LockfileObject, projects: Project[]): boolean {
+  return tryComposeFastUpdates(lockfile, { drift: { importers: true }, projects })
+}
 
 test('a compatible package range update retains the locked peer snapshot without resolution', async () => {
   const project = prepareEmpty()

--- a/pnpm11/installing/deps-installer/test/install/catalogFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/catalogFastUpdate.ts
@@ -11,10 +11,6 @@ import type { Project } from '../../src/install/tryFastUpdateImporters.js'
 import { tryFastUpdateLockfile } from '../../src/install/tryFastUpdateLockfile.js'
 import { testDefaults } from '../utils/index.js'
 
-/** The composed pipeline restricted to manifest drift. */
-function tryFastUpdateImporters (lockfile: LockfileObject, projects: Project[]): boolean {
-  return tryComposeFastUpdates(lockfile, { drift: { importers: true }, projects })
-}
 
 test('a compatible package range update retains the locked peer snapshot without resolution', async () => {
   const project = prepareEmpty()
@@ -358,4 +354,8 @@ function trackRequestedPackages (storeController: StoreController): string[] {
     return requestPackage(wantedDependency, requestOptions)
   }
   return requestedPackages
+}
+/** The composed pipeline restricted to manifest drift. */
+function tryFastUpdateImporters (lockfile: LockfileObject, projects: Project[]): boolean {
+  return tryComposeFastUpdates(lockfile, { drift: { importers: true }, projects })
 }

--- a/pnpm11/installing/deps-installer/test/install/composedFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/composedFastUpdate.ts
@@ -1,0 +1,188 @@
+import { expect, test } from '@jest/globals'
+import { mutateModulesInSingleProject } from '@pnpm/installing.deps-installer'
+import type { LockfileObject } from '@pnpm/lockfile.types'
+import { prepareEmpty } from '@pnpm/prepare'
+import type { StoreController } from '@pnpm/store.controller-types'
+import type { DepPath, ProjectId, ProjectManifest, ProjectRootDir } from '@pnpm/types'
+
+import { tryComposeFastUpdates } from '../../src/install/tryComposeFastUpdates.js'
+import { testDefaults } from '../utils/index.js'
+
+test('a removal and a widened ignore list are absorbed in one pass', () => {
+  const subject = lockfile()
+
+  expect(tryComposeFastUpdates(subject, {
+    drift: { importers: true, ignoredOptionalDependencies: true },
+    projects: [project({ dependencies: { bar: '^2.0.0' }, optionalDependencies: { opt: '^5.0.0' } })],
+    ignoredOptionalDependencies: ['opt'],
+  })).toBe(true)
+  expect(Object.keys(subject.packages!).sort()).toStrictEqual(['bar@2.0.0', 'child@3.0.0'])
+  expect(subject.ignoredOptionalDependencies).toStrictEqual(['opt'])
+  const importer = subject.importers['.' as ProjectId]
+  expect(importer.optionalDependencies).toBeUndefined()
+  expect(importer.dependencies).toStrictEqual({ bar: '2.0.0' })
+})
+
+test('a group move and a settings change are absorbed in one pass', () => {
+  const subject = lockfile()
+  subject.settings = { autoInstallPeers: true, excludeLinksFromLockfile: false }
+
+  expect(tryComposeFastUpdates(subject, {
+    drift: { importers: true, settings: true },
+    projects: [project({
+      devDependencies: { foo: '^1.0.0' },
+      dependencies: { bar: '^2.0.0' },
+      optionalDependencies: { opt: '^5.0.0' },
+    })],
+    settings: {
+      changedSettings: ['settings.autoInstallPeers'],
+      projects: [project({ devDependencies: { foo: '^1.0.0' } })],
+      settings: { autoInstallPeers: false, excludeLinksFromLockfile: false },
+      workspacePackages: new Map(),
+    },
+  })).toBe(true)
+  const importer = subject.importers['.' as ProjectId]
+  expect(importer.devDependencies).toStrictEqual({ foo: '1.1.0' })
+  expect(subject.settings).toStrictEqual({ autoInstallPeers: false, excludeLinksFromLockfile: false })
+})
+
+test('a composed update falls back when one of its changes cannot be absorbed', () => {
+  const subject = lockfile()
+  subject.settings = { autoInstallPeers: true, excludeLinksFromLockfile: false }
+
+  expect(tryComposeFastUpdates(subject, {
+    drift: { importers: true, settings: true },
+    projects: [project({
+      dependencies: { foo: '^9.0.0', bar: '^2.0.0' },
+      optionalDependencies: { opt: '^5.0.0' },
+    })],
+    settings: {
+      changedSettings: ['settings.autoInstallPeers'],
+      projects: [],
+      settings: { autoInstallPeers: false, excludeLinksFromLockfile: false },
+      workspacePackages: new Map(),
+    },
+  })).toBe(false)
+})
+
+test('an ignored optional embedded in a surviving peer suffix falls back', () => {
+  const subject = lockfile()
+  subject.importers['.' as ProjectId].dependencies!.baz = '4.0.0(opt@5.0.0)'
+  subject.importers['.' as ProjectId].specifiers.baz = '^4.0.0'
+  subject.packages!['baz@4.0.0(opt@5.0.0)' as DepPath] = {
+    resolution: { integrity: 'sha512-baz' },
+    dependencies: { opt: '5.0.0' },
+  }
+
+  expect(tryComposeFastUpdates(subject, {
+    drift: { ignoredOptionalDependencies: true },
+    projects: [],
+    ignoredOptionalDependencies: ['opt'],
+  })).toBe(false)
+})
+
+test('an ignored optional removal recomputes the survivors\' optional flags', () => {
+  const subject = lockfile()
+  const importer = subject.importers['.' as ProjectId]
+  importer.optionalDependencies!.bar = importer.dependencies!.bar
+  delete importer.dependencies!.bar
+  subject.packages!['bar@2.0.0' as DepPath].optional = true
+
+  expect(tryComposeFastUpdates(subject, {
+    drift: { ignoredOptionalDependencies: true },
+    projects: [],
+    ignoredOptionalDependencies: ['bar'],
+  })).toBe(true)
+  expect(subject.packages!['child@3.0.0' as DepPath].optional).toBe(true)
+})
+
+test('an install with combined manifest and ignore-list drift requests no packages', async () => {
+  const project = prepareEmpty()
+  const manifest: ProjectManifest = {
+    dependencies: {
+      '@pnpm.e2e/pkg-with-1-dep': '100.0.0',
+      'is-positive': '1.0.0',
+    },
+    optionalDependencies: {
+      '@pnpm.e2e/pkg-with-good-optional': '1.0.0',
+    },
+  }
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, testDefaults())
+
+  const options = testDefaults({ ignoredOptionalDependencies: ['@pnpm.e2e/pkg-with-good-optional'] })
+  const requestedPackages = trackRequestedPackages(options.storeController)
+  await mutateModulesInSingleProject({
+    manifest: {
+      dependencies: { 'is-positive': '1.0.0' },
+      optionalDependencies: { '@pnpm.e2e/pkg-with-good-optional': '1.0.0' },
+    },
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, options)
+
+  expect(requestedPackages).toStrictEqual([])
+  const written = project.readLockfile()
+  expect(written.ignoredOptionalDependencies).toStrictEqual(['@pnpm.e2e/pkg-with-good-optional'])
+  expect(Object.keys(written.snapshots).some((depPath) =>
+    depPath.startsWith('@pnpm.e2e/pkg-with-1-dep@') ||
+    depPath.startsWith('@pnpm.e2e/pkg-with-good-optional@'))
+  ).toBe(false)
+  expect(written.importers['.']).toStrictEqual({
+    dependencies: {
+      'is-positive': { specifier: '1.0.0', version: '1.0.0' },
+    },
+  })
+  project.has('is-positive')
+  project.hasNot('@pnpm.e2e/pkg-with-1-dep')
+})
+
+function trackRequestedPackages (storeController: StoreController): string[] {
+  const requestedPackages: string[] = []
+  const requestPackage = storeController.requestPackage
+  storeController.requestPackage = async (wantedDependency, requestOptions) => {
+    requestedPackages.push(wantedDependency.alias!)
+    return requestPackage(wantedDependency, requestOptions)
+  }
+  return requestedPackages
+}
+
+function project (manifest: Pick<ProjectManifest, 'dependencies' | 'devDependencies' | 'optionalDependencies'>) {
+  return {
+    id: '.' as ProjectId,
+    manifest: manifest as ProjectManifest,
+  }
+}
+
+/**
+ * `foo` and `bar` are prod dependencies (`bar` reaching `child`), and `opt`
+ * is an optional dependency reaching the same `child`.
+ */
+function lockfile (): LockfileObject {
+  return {
+    lockfileVersion: '9.0',
+    importers: {
+      ['.' as ProjectId]: {
+        specifiers: { foo: '^1.0.0', bar: '^2.0.0', opt: '^5.0.0' },
+        dependencies: { foo: '1.1.0', bar: '2.0.0' },
+        optionalDependencies: { opt: '5.0.0' },
+      },
+    },
+    packages: {
+      ['foo@1.1.0' as DepPath]: { resolution: { integrity: 'sha512-foo' } },
+      ['bar@2.0.0' as DepPath]: {
+        resolution: { integrity: 'sha512-bar' },
+        dependencies: { child: '3.0.0' },
+      },
+      ['child@3.0.0' as DepPath]: { resolution: { integrity: 'sha512-child' } },
+      ['opt@5.0.0' as DepPath]: {
+        resolution: { integrity: 'sha512-opt' },
+        optional: true,
+        dependencies: { child: '3.0.0' },
+      },
+    },
+  }
+}

--- a/pnpm11/installing/deps-installer/test/install/composedFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/composedFastUpdate.ts
@@ -49,10 +49,10 @@ test('a group move and a settings change are absorbed in one pass', () => {
 test('a peer setting is absorbed once the removal drops the last peer dependent', () => {
   const subject = lockfile()
   subject.settings = { autoInstallPeers: true, excludeLinksFromLockfile: false }
-  subject.importers['.' as ProjectId].dependencies!.withpeer = '6.0.0'
-  subject.importers['.' as ProjectId].specifiers.withpeer = '^6.0.0'
-  subject.packages!['withpeer@6.0.0' as DepPath] = {
-    resolution: { integrity: 'sha512-withpeer' },
+  subject.importers['.' as ProjectId].dependencies!['has-peer'] = '6.0.0'
+  subject.importers['.' as ProjectId].specifiers['has-peer'] = '^6.0.0'
+  subject.packages!['has-peer@6.0.0' as DepPath] = {
+    resolution: { integrity: 'sha512-has-peer' },
     peerDependencies: { foo: '^1.0.0' },
   }
 
@@ -70,7 +70,7 @@ test('a peer setting is absorbed once the removal drops the last peer dependent'
     },
   })).toBe(true)
   expect(subject.settings).toStrictEqual({ autoInstallPeers: false, excludeLinksFromLockfile: false })
-  expect(subject.packages!['withpeer@6.0.0' as DepPath]).toBeUndefined()
+  expect(subject.packages!['has-peer@6.0.0' as DepPath]).toBeUndefined()
 })
 
 test('a composed update falls back when one of its changes cannot be absorbed', () => {

--- a/pnpm11/installing/deps-installer/test/install/composedFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/composedFastUpdate.ts
@@ -46,6 +46,33 @@ test('a group move and a settings change are absorbed in one pass', () => {
   expect(subject.settings).toStrictEqual({ autoInstallPeers: false, excludeLinksFromLockfile: false })
 })
 
+test('a peer setting is absorbed once the removal drops the last peer dependent', () => {
+  const subject = lockfile()
+  subject.settings = { autoInstallPeers: true, excludeLinksFromLockfile: false }
+  subject.importers['.' as ProjectId].dependencies!.withpeer = '6.0.0'
+  subject.importers['.' as ProjectId].specifiers.withpeer = '^6.0.0'
+  subject.packages!['withpeer@6.0.0' as DepPath] = {
+    resolution: { integrity: 'sha512-withpeer' },
+    peerDependencies: { foo: '^1.0.0' },
+  }
+
+  expect(tryComposeFastUpdates(subject, {
+    drift: { importers: true, settings: true },
+    projects: [project({
+      dependencies: { foo: '^1.0.0', bar: '^2.0.0' },
+      optionalDependencies: { opt: '^5.0.0' },
+    })],
+    settings: {
+      changedSettings: ['settings.autoInstallPeers'],
+      projects: [],
+      settings: { autoInstallPeers: false, excludeLinksFromLockfile: false },
+      workspacePackages: new Map(),
+    },
+  })).toBe(true)
+  expect(subject.settings).toStrictEqual({ autoInstallPeers: false, excludeLinksFromLockfile: false })
+  expect(subject.packages!['withpeer@6.0.0' as DepPath]).toBeUndefined()
+})
+
 test('a composed update falls back when one of its changes cannot be absorbed', () => {
   const subject = lockfile()
   subject.settings = { autoInstallPeers: true, excludeLinksFromLockfile: false }

--- a/pnpm11/installing/deps-installer/test/install/ignoredOptionalDependencies.ts
+++ b/pnpm11/installing/deps-installer/test/install/ignoredOptionalDependencies.ts
@@ -5,10 +5,22 @@ import { prepareEmpty } from '@pnpm/prepare'
 import type { StoreController } from '@pnpm/store.controller-types'
 import type { DepPath, ProjectId, ProjectManifest } from '@pnpm/types'
 
-import { tryFastUpdateIgnoredOptionalDependencies } from '../../src/install/tryFastUpdateIgnoredOptionalDependencies.js'
+import { tryComposeFastUpdates } from '../../src/install/tryComposeFastUpdates.js'
 import {
   testDefaults,
 } from '../utils/index.js'
+
+/** The composed pipeline restricted to `ignoredOptionalDependencies` drift. */
+function tryFastUpdateIgnoredOptionalDependencies (
+  lockfile: LockfileObject,
+  ignoredOptionalDependencies: string[]
+): boolean {
+  return tryComposeFastUpdates(lockfile, {
+    drift: { ignoredOptionalDependencies: true },
+    projects: [],
+    ignoredOptionalDependencies,
+  })
+}
 
 test('ignoredOptionalDependencies causes listed optional dependencies to be skipped', async () => {
   const project = prepareEmpty()

--- a/pnpm11/installing/deps-installer/test/install/ignoredOptionalDependencies.ts
+++ b/pnpm11/installing/deps-installer/test/install/ignoredOptionalDependencies.ts
@@ -10,17 +10,6 @@ import {
   testDefaults,
 } from '../utils/index.js'
 
-/** The composed pipeline restricted to `ignoredOptionalDependencies` drift. */
-function tryFastUpdateIgnoredOptionalDependencies (
-  lockfile: LockfileObject,
-  ignoredOptionalDependencies: string[]
-): boolean {
-  return tryComposeFastUpdates(lockfile, {
-    drift: { ignoredOptionalDependencies: true },
-    projects: [],
-    ignoredOptionalDependencies,
-  })
-}
 
 test('ignoredOptionalDependencies causes listed optional dependencies to be skipped', async () => {
   const project = prepareEmpty()
@@ -231,4 +220,15 @@ function trackRequestedPackages (storeController: StoreController): string[] {
     return requestPackage(wantedDependency, requestOptions)
   }
   return requestedPackages
+}
+/** The composed pipeline restricted to `ignoredOptionalDependencies` drift. */
+function tryFastUpdateIgnoredOptionalDependencies (
+  lockfile: LockfileObject,
+  ignoredOptionalDependencies: string[]
+): boolean {
+  return tryComposeFastUpdates(lockfile, {
+    drift: { ignoredOptionalDependencies: true },
+    projects: [],
+    ignoredOptionalDependencies,
+  })
 }

--- a/pnpm11/installing/deps-installer/test/install/importerGroupMoveFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/importerGroupMoveFastUpdate.ts
@@ -6,10 +6,16 @@ import type { StoreController } from '@pnpm/store.controller-types'
 import type { DepPath, ProjectId, ProjectManifest, ProjectRootDir } from '@pnpm/types'
 import { clone } from 'ramda'
 
+import { tryComposeFastUpdates } from '../../src/install/tryComposeFastUpdates.js'
 import {
   hasChangedProjectSpecifiers,
-  tryFastUpdateImporters,
+  type Project as ImporterProject,
 } from '../../src/install/tryFastUpdateImporters.js'
+
+/** The composed pipeline restricted to manifest drift. */
+function tryFastUpdateImporters (lockfile: LockfileObject, projects: ImporterProject[]): boolean {
+  return tryComposeFastUpdates(lockfile, { drift: { importers: true }, projects })
+}
 import { testDefaults } from '../utils/index.js'
 
 test('a dependency moved to another group is noticed as a change', () => {

--- a/pnpm11/installing/deps-installer/test/install/importerGroupMoveFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/importerGroupMoveFastUpdate.ts
@@ -11,11 +11,6 @@ import {
   hasChangedProjectSpecifiers,
   type Project as ImporterProject,
 } from '../../src/install/tryFastUpdateImporters.js'
-
-/** The composed pipeline restricted to manifest drift. */
-function tryFastUpdateImporters (lockfile: LockfileObject, projects: ImporterProject[]): boolean {
-  return tryComposeFastUpdates(lockfile, { drift: { importers: true }, projects })
-}
 import { testDefaults } from '../utils/index.js'
 
 test('a dependency moved to another group is noticed as a change', () => {
@@ -220,4 +215,8 @@ function lockfile (): LockfileObject {
       ['child@3.0.0' as DepPath]: { resolution: { integrity: 'sha512-child' } },
     },
   }
+}
+/** The composed pipeline restricted to manifest drift. */
+function tryFastUpdateImporters (lockfile: LockfileObject, projects: ImporterProject[]): boolean {
+  return tryComposeFastUpdates(lockfile, { drift: { importers: true }, projects })
 }

--- a/pnpm11/installing/deps-installer/test/install/importerRemovalFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/importerRemovalFastUpdate.ts
@@ -12,11 +12,6 @@ import {
   type Project,
 } from '../../src/install/tryFastUpdateImporters.js'
 import { tryFastUpdateLockfile } from '../../src/install/tryFastUpdateLockfile.js'
-
-/** The composed pipeline restricted to manifest drift. */
-function tryFastUpdateImporters (lockfile: LockfileObject, projects: Project[]): boolean {
-  return tryComposeFastUpdates(lockfile, { drift: { importers: true }, projects })
-}
 import { testDefaults } from '../utils/index.js'
 
 test('a dependency the manifest dropped is noticed as a change', () => {
@@ -277,3 +272,7 @@ test('removing the last catalog referent drops the catalogs section from the loc
     '@pnpm.e2e/pkg-with-1-dep': { specifier: '100.0.0', version: '100.0.0' },
   })
 })
+/** The composed pipeline restricted to manifest drift. */
+function tryFastUpdateImporters (lockfile: LockfileObject, projects: Project[]): boolean {
+  return tryComposeFastUpdates(lockfile, { drift: { importers: true }, projects })
+}

--- a/pnpm11/installing/deps-installer/test/install/importerRemovalFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/importerRemovalFastUpdate.ts
@@ -6,11 +6,17 @@ import type { StoreController } from '@pnpm/store.controller-types'
 import type { DepPath, ProjectId, ProjectManifest, ProjectRootDir } from '@pnpm/types'
 import { clone } from 'ramda'
 
+import { tryComposeFastUpdates } from '../../src/install/tryComposeFastUpdates.js'
 import {
   hasChangedProjectSpecifiers,
-  tryFastUpdateImporters,
+  type Project,
 } from '../../src/install/tryFastUpdateImporters.js'
 import { tryFastUpdateLockfile } from '../../src/install/tryFastUpdateLockfile.js'
+
+/** The composed pipeline restricted to manifest drift. */
+function tryFastUpdateImporters (lockfile: LockfileObject, projects: Project[]): boolean {
+  return tryComposeFastUpdates(lockfile, { drift: { importers: true }, projects })
+}
 import { testDefaults } from '../utils/index.js'
 
 test('a dependency the manifest dropped is noticed as a change', () => {


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#13763. Part of pnpm/pnpm#13696.

The sync fast-update handlers (importers, `ignoredOptionalDependencies`, `patchedDependencies`, settings) used to stage separate candidates, so an install carrying more than one kind of absorbable drift always fell back to a full resolution — the "exactly one handler may fire" rule. This PR replaces that rule with composition in both stacks:

- Each handler is split into a cheap **detector** (borrows only; concludes clean / absorbable / needs-resolver) and an **application** that replays onto one shared candidate. In pacquet nothing is cloned until some detector finds absorbable drift.
- Applications run in a fixed, documented order: manifest drift first, then newly ignored optionals, then a **shared graph epilogue** — prune unreachable packages, peer-suffix safety check over the union of dropped aliases, catalog entry prune, `optional`-flag recompute — then patch rekeying, which thereby sees the pruned graph a full resolution would see (a patch whose only referent was just removed falls back, matching `ERR_PNPM_UNUSED_PATCH`), and the settings block last.
- Any handler that cannot express its change aborts the candidate and the resolver takes over. The freshness gates still validate the composed candidate before it commits, unchanged.
- The async rewrites (catalogs, overrides) consult the resolver and stay outside the pipeline; they keep requiring being the only change. pacquet's `lockfile_reuse_seed` path is untouched.

The shared epilogue also hardens two spots the per-handler maintenance handled unevenly: ignored-optional removals now recompute the survivors' `optional` flags (previously stale in pacquet) and are covered by the peer-suffix safety check (previously skipped in both stacks), identically in both stacks.

Dispatch shrinks accordingly: the TypeScript `changedSetting` if-chain becomes one `tryComposeFastUpdates` call, and pacquet's candidate array plus exactly-one tuple match becomes `try_compose_fast_updates`.

Tested with composition unit tests in both stacks (removal x ignore-list, group move x settings, abort propagation, removal-makes-patch-unused, peer-suffix-embedded ignored optional, flag recompute), a dead-registry pacquet e2e and a TS install-level test for combined drift (both verified to fail with composition disabled), and all pre-existing handler tests re-routed through the composed pipeline so the old single-drift behavior stays pinned.

## Squash Commit Body

```text
The sync fast-update handlers (importers, ignoredOptionalDependencies,
patchedDependencies, settings) used to stage separate candidates, so
an install carrying more than one kind of absorbable drift always fell
back to a full resolution (the exactly-one-fires rule). Each handler
is now split into a cheap detector and an application that replays
onto one shared candidate, composed in a fixed order: manifest drift
first, then newly ignored optional dependencies, then a shared graph
epilogue (prune, peer-suffix safety check over the union of dropped
aliases, catalog entry prune, optional-flag recompute), then patch
rekeying - which thereby sees the pruned graph a full resolution
would see - and the settings block last. Any handler that cannot
express its change aborts the candidate and the resolver takes over,
and the freshness gates still validate the result before it commits.

The async rewrites (catalogs, overrides) consult the resolver and stay
outside the pipeline; they keep requiring being the only change.

The shared epilogue also hardens two spots the per-handler maintenance
handled unevenly: ignored-optional removals now recompute the
survivors' optional flags and are covered by the peer-suffix check in
both stacks.

Closes pnpm/pnpm#13763. Part of pnpm/pnpm#13696.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13766"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788962317&installation_model_id=426870&pr_number=13766&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13766&signature=c24614ebbcb8079d1333962d82a00d262d27e521d161ee80045676836f018931"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `pnpm install` can now update the lockfile in place when compatible dependency, ignored optional dependency, patch, or settings changes occur together.
  * Combined updates are handled in a single fast-update operation, reducing unnecessary dependency resolution and registry requests.
* **Bug Fixes**
  * Improved cleanup of removed dependencies and optional packages from the lockfile and filesystem.
  * Added safer fallback to full resolution for unsupported or incompatible changes.
* **Tests**
  * Added coverage for combined updates, dependency removals, patch changes, settings changes, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->