### PR TITLE
fix(env-installer): take a migrated config dependency's tarball URL from the packument

### DIFF
--- a/.changeset/config-dep-tarball-from-packument.md
+++ b/.changeset/config-dep-tarball-from-packument.md
@@ -4,4 +4,4 @@
 "pacquet": patch
 ---
 
-A config dependency declared in the old `<version>+<integrity>` format now takes its tarball URL from the registry's packument instead of deriving it from the registry URL. On a registry that serves tarballs from a path pnpm cannot derive — GitLab's group endpoint, for one — installing such a config dependency failed with a 404 while the same package installed fine as a regular dependency [#13765](https://github.com/pnpm/pnpm/issues/13765).
+A config dependency carrying an inline integrity (the `<version>+<integrity>` form, or the object form without a `tarball`) now takes its tarball URL from the registry's packument instead of deriving it from the registry URL, so migrating one costs an extra metadata request. On a registry that serves tarballs from a path pnpm cannot derive, GitLab's group endpoint for one, installing such a config dependency failed with a 404 while the same package installed fine as a regular dependency [#13765](https://github.com/pnpm/pnpm/issues/13765).

--- a/.changeset/config-dep-tarball-from-packument.md
+++ b/.changeset/config-dep-tarball-from-packument.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.env-installer": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+A config dependency declared in the old `<version>+<integrity>` format now takes its tarball URL from the registry's packument instead of deriving it from the registry URL. On a registry that serves tarballs from a path pnpm cannot derive — GitLab's group endpoint, for one — installing such a config dependency failed with a 404 while the same package installed fine as a regular dependency [#13765](https://github.com/pnpm/pnpm/issues/13765).

--- a/pnpm/crates/env-installer/src/resolve_and_install_config_deps.rs
+++ b/pnpm/crates/env-installer/src/resolve_and_install_config_deps.rs
@@ -3,20 +3,24 @@
 //!
 //! Handles three input shapes:
 //! 1. old object form `{ tarball?, integrity }` — migrated inline into
-//!    the lockfile,
-//! 2. old string form `<version>+<integrity>` — migrated inline,
+//!    the lockfile when it carries a tarball URL, otherwise resolved,
+//! 2. old string form `<version>+<integrity>` — resolved against the
+//!    registry for its tarball URL, keeping the inline integrity,
 //! 3. new clean specifier (`1.2.0` / `^1.0.0`) — resolved against the
 //!    registry when it isn't already pinned in the lockfile.
 
 use crate::{
-    ConfigDepError, install_config_deps::install_config_deps, options::ConfigDepsInstallOptions,
-    parse_integrity::parse_integrity, prune::prune_env_lockfile,
+    ConfigDepError,
+    install_config_deps::install_config_deps,
+    options::ConfigDepsInstallOptions,
+    parse_integrity::parse_integrity,
+    prune::prune_env_lockfile,
     resolve_optional_subdeps::resolve_optional_subdeps,
-    verify_env_lockfile::write_verified_env_lockfile,
+    verify_env_lockfile::{assert_valid_migrated_config_dep, write_verified_env_lockfile},
 };
 use pnpm_lockfile::{
     EnvLockfile, LockfileFormOptions, LockfileResolution, PackageKey, PackageMetadata,
-    SnapshotEntry, SpecifierAndResolution, TarballResolution, TarballUrlOptions, npm_tarball_url,
+    SnapshotEntry, SpecifierAndResolution, TarballResolution,
 };
 use pnpm_reporter::Reporter;
 use pnpm_resolving_resolver_base::{ResolveOptions, Resolver, WantedDependency};
@@ -42,7 +46,7 @@ pub async fn resolve_and_install_config_deps<Reporter: self::Reporter>(
         .map_err(ConfigDepError::ReadLockfile)?
         .unwrap_or_else(EnvLockfile::create);
 
-    let mut to_resolve: Vec<(String, String)> = Vec::new();
+    let mut to_resolve: Vec<(String, String, Option<Integrity>)> = Vec::new();
     let mut lockfile_changed = false;
 
     // Drop env-lockfile entries for config deps that were removed from
@@ -61,43 +65,29 @@ pub async fn resolve_and_install_config_deps<Reporter: self::Reporter>(
             ConfigDependency::Detailed(detail) => {
                 if !has_config_dep(&env_lockfile, name) {
                     let (version, integrity) = parse_integrity(name, &detail.integrity)?;
-                    let registry = opts.pick_registry(name);
-                    let tarball = detail.tarball.clone().unwrap_or_else(|| {
-                        npm_tarball_url(
-                            name,
-                            &version,
-                            TarballUrlOptions { registry, server_type: None },
-                        )
-                    });
-                    migrate_into_lockfile(
-                        &mut env_lockfile,
-                        name,
-                        &version,
-                        integrity,
-                        tarball,
-                        registry,
-                    )?;
-                    lockfile_changed = true;
+                    assert_valid_migrated_config_dep(name, &version)?;
+                    match detail.tarball.clone() {
+                        Some(tarball) => {
+                            let registry = opts.pick_registry(name);
+                            migrate_into_lockfile(
+                                &mut env_lockfile,
+                                name,
+                                &version,
+                                integrity,
+                                tarball,
+                                registry,
+                            )?;
+                            lockfile_changed = true;
+                        }
+                        None => to_resolve.push((name.clone(), version, Some(integrity))),
+                    }
                 }
             }
             ConfigDependency::VersionWithIntegrity(value) if value.contains('+') => {
                 if !has_config_dep(&env_lockfile, name) {
                     let (version, integrity) = parse_integrity(name, value)?;
-                    let registry = opts.pick_registry(name);
-                    let tarball = npm_tarball_url(
-                        name,
-                        &version,
-                        TarballUrlOptions { registry, server_type: None },
-                    );
-                    migrate_into_lockfile(
-                        &mut env_lockfile,
-                        name,
-                        &version,
-                        integrity,
-                        tarball,
-                        registry,
-                    )?;
-                    lockfile_changed = true;
+                    assert_valid_migrated_config_dep(name, &version)?;
+                    to_resolve.push((name.clone(), version, Some(integrity)));
                 }
             }
             ConfigDependency::VersionWithIntegrity(specifier) => {
@@ -107,7 +97,7 @@ pub async fn resolve_and_install_config_deps<Reporter: self::Reporter>(
                 {
                     continue;
                 }
-                to_resolve.push((name.clone(), specifier.clone()));
+                to_resolve.push((name.clone(), specifier.clone(), None));
             }
         }
     }
@@ -128,8 +118,9 @@ pub async fn resolve_and_install_config_deps<Reporter: self::Reporter>(
         return install_config_deps::<Reporter>(&env_lockfile, opts).await;
     }
 
-    for (name, specifier) in &to_resolve {
-        resolve_one(&mut env_lockfile, resolver, opts, name, specifier).await?;
+    for (name, specifier, pinned_integrity) in &to_resolve {
+        resolve_one(&mut env_lockfile, resolver, opts, name, specifier, pinned_integrity.as_ref())
+            .await?;
     }
 
     prune_env_lockfile(&mut env_lockfile);
@@ -137,14 +128,15 @@ pub async fn resolve_and_install_config_deps<Reporter: self::Reporter>(
     install_config_deps::<Reporter>(&env_lockfile, opts).await
 }
 
-/// Resolve a single clean-specifier config dependency and record it
-/// (plus one level of optional subdeps) into the env lockfile.
+/// Resolve a single config dependency and record it (plus one level of
+/// optional subdeps) into the env lockfile.
 async fn resolve_one(
     env_lockfile: &mut EnvLockfile,
     resolver: &dyn Resolver,
     opts: &ConfigDepsInstallOptions<'_>,
     name: &str,
     specifier: &str,
+    pinned_integrity: Option<&Integrity>,
 ) -> Result<(), ConfigDepError> {
     let wanted = WantedDependency {
         alias: Some(name.to_string()),
@@ -178,9 +170,17 @@ async fn resolve_one(
         name.to_string(),
         SpecifierAndResolution { specifier: specifier.to_string(), version: version.clone() },
     );
+    let mut resolution = result.resolution.clone();
+    // A migrated dependency keeps the integrity pinned in pnpm-workspace.yaml,
+    // so the registry can hand over the tarball URL without loosening the pin.
+    if let (Some(pinned), LockfileResolution::Tarball(tarball)) =
+        (pinned_integrity, &mut resolution)
+    {
+        tarball.integrity = Some(pinned.clone());
+    }
     env_lockfile.packages.insert(
         key.clone(),
-        registry_package_metadata(result.resolution.to_lockfile_form(
+        registry_package_metadata(resolution.to_lockfile_form(
             name,
             &version,
             npm_lockfile_form(registry),

--- a/pnpm/crates/env-installer/src/resolve_and_install_config_deps.rs
+++ b/pnpm/crates/env-installer/src/resolve_and_install_config_deps.rs
@@ -172,7 +172,7 @@ async fn resolve_one(
     );
     let mut resolution = result.resolution.clone();
     // A migrated dependency keeps the integrity pinned in pnpm-workspace.yaml,
-    // so the registry can hand over the tarball URL without loosening the pin.
+    // so the registry hands over the tarball URL without loosening the pin.
     if let (Some(pinned), LockfileResolution::Tarball(tarball)) =
         (pinned_integrity, &mut resolution)
     {
@@ -187,11 +187,13 @@ async fn resolve_one(
         )),
     );
 
-    let optional_subdeps = match result.manifest.as_deref() {
-        Some(manifest) => {
+    // A pinned dependency covers only itself, so its optional subdeps stay out
+    // of the lockfile until it is declared as a clean specifier.
+    let optional_subdeps = match (pinned_integrity, result.manifest.as_deref()) {
+        (None, Some(manifest)) => {
             resolve_optional_subdeps(name, manifest, resolver, opts, env_lockfile).await?
         }
-        None => None,
+        _ => None,
     };
     env_lockfile.snapshots.insert(
         key,

--- a/pnpm/crates/env-installer/src/resolve_and_install_config_deps.rs
+++ b/pnpm/crates/env-installer/src/resolve_and_install_config_deps.rs
@@ -170,7 +170,7 @@ async fn resolve_one(
         name.to_string(),
         SpecifierAndResolution { specifier: specifier.to_string(), version: version.clone() },
     );
-    let mut resolution = result.resolution.clone();
+    let mut resolution = result.resolution;
     // A migrated dependency keeps the integrity pinned in pnpm-workspace.yaml,
     // so the registry hands over the tarball URL without loosening the pin.
     if let (Some(pinned), LockfileResolution::Tarball(tarball)) =

--- a/pnpm/crates/env-installer/src/tests.rs
+++ b/pnpm/crates/env-installer/src/tests.rs
@@ -963,8 +963,7 @@ async fn migrates_old_inline_integrity_format() {
     let (resolver, _cache) = build_resolver(&harness.registry_url);
     let root = TempDir::new().unwrap();
 
-    // The old format embeds the integrity inline as `<version>+<integrity>`,
-    // which the migration path records into the lockfile without re-resolving.
+    // The old format embeds the integrity inline as `<version>+<integrity>`.
     let integrity = integrity_of(&resolver, "@pnpm.e2e/foo", "100.0.0").await;
     let mut config_deps = BTreeMap::new();
     config_deps.insert(
@@ -989,6 +988,43 @@ async fn migrates_old_inline_integrity_format() {
     assert_eq!(entry.specifier, "100.0.0");
     assert_eq!(entry.version, "100.0.0");
     assert!(env.packages.contains_key(&"@pnpm.e2e/foo@100.0.0".parse().unwrap()));
+}
+
+/// Reaching the registry under a different host spelling than the one it
+/// advertises its tarballs on stands in for GitLab's npm registry, which
+/// serves tarballs from a project endpoint the group endpoint cannot
+/// derive. See <https://github.com/pnpm/pnpm/issues/13765>.
+#[tokio::test]
+async fn takes_old_format_tarball_url_from_the_packument() {
+    let harness = harness();
+    let aliased_registry = harness.registry_url.replace("127.0.0.1", "localhost");
+    let (resolver, _cache) = build_resolver(&aliased_registry);
+    let root = TempDir::new().unwrap();
+
+    let integrity = integrity_of(&resolver, "@pnpm.e2e/foo", "100.0.0").await;
+    let mut config_deps = BTreeMap::new();
+    config_deps.insert(
+        "@pnpm.e2e/foo".to_string(),
+        ConfigDependency::VersionWithIntegrity(format!("100.0.0+{integrity}")),
+    );
+
+    let registries = HashMap::from([("default".to_string(), aliased_registry)]);
+    let mut opts = options(&harness, root.path(), false);
+    opts.registries = &registries;
+
+    resolve_and_install_config_deps::<SilentReporter>(&config_deps, &resolver, &opts)
+        .await
+        .unwrap();
+
+    let env = EnvLockfile::read(root.path()).unwrap().expect("env lockfile written");
+    let key: PackageKey = "@pnpm.e2e/foo@100.0.0".parse().unwrap();
+    let resolution = &env.packages[&key].resolution;
+    dbg!(resolution);
+    let LockfileResolution::Tarball(tarball) = resolution else {
+        panic!("expected the tarball URL the packument advertises to be recorded");
+    };
+    assert!(tarball.tarball.starts_with(&harness.registry_url));
+    assert_eq!(tarball.integrity.as_ref().unwrap().to_string(), integrity);
 }
 
 #[tokio::test]

--- a/pnpm/crates/env-installer/src/tests.rs
+++ b/pnpm/crates/env-installer/src/tests.rs
@@ -48,6 +48,26 @@ async fn integrity_of(
     }
 }
 
+/// Resolve `name@version` against the mock registry and return the tarball
+/// URL its packument advertises, so a test can assert on the whole URL
+/// without hard-coding the registry's path layout.
+async fn tarball_url_of(
+    resolver: &NpmResolver<InMemoryPackageMetaCache>,
+    name: &str,
+    version: &str,
+) -> String {
+    let wanted = WantedDependency {
+        alias: Some(name.to_string()),
+        bare_specifier: Some(version.to_string()),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, &ResolveOptions::default()).await.unwrap().unwrap();
+    match result.resolution {
+        LockfileResolution::Tarball(tarball) => tarball.tarball,
+        other => panic!("unexpected resolution: {other:?}"),
+    }
+}
+
 /// Build an npm resolver pointing at the in-process mock registry.
 fn build_resolver(registry: &str) -> (NpmResolver<InMemoryPackageMetaCache>, TempDir) {
     let cache_dir = TempDir::new().unwrap();
@@ -1033,6 +1053,7 @@ async fn takes_old_format_tarball_url_from_the_packument() {
     let root = TempDir::new().unwrap();
 
     let integrity = integrity_of(&resolver, "@pnpm.e2e/foo", "100.0.0").await;
+    let advertised_tarball = tarball_url_of(&resolver, "@pnpm.e2e/foo", "100.0.0").await;
     let mut config_deps = BTreeMap::new();
     config_deps.insert(
         "@pnpm.e2e/foo".to_string(),
@@ -1054,10 +1075,7 @@ async fn takes_old_format_tarball_url_from_the_packument() {
     let LockfileResolution::Tarball(tarball) = resolution else {
         panic!("expected the tarball URL the packument advertises to be recorded");
     };
-    assert!(
-        tarball.tarball.starts_with(&harness.registry_url),
-        "tarball URL comes from the packument, not from the configured registry",
-    );
+    assert_eq!(tarball.tarball, advertised_tarball);
     assert_eq!(tarball.integrity.as_ref().unwrap().to_string(), integrity);
 }
 

--- a/pnpm/crates/env-installer/src/tests.rs
+++ b/pnpm/crates/env-installer/src/tests.rs
@@ -631,6 +631,38 @@ async fn rejects_optional_subdep_with_non_exact_version() {
     );
 }
 
+/// An inline integrity pins the config dependency alone, so a range in its
+/// optionalDependencies does not block the install the way it does for a
+/// clean specifier.
+#[tokio::test]
+async fn keeps_optional_subdeps_of_a_pinned_config_dep_out_of_the_lockfile() {
+    let harness = harness();
+    let (resolver, _cache) = build_resolver(&harness.registry_url);
+    let root = TempDir::new().unwrap();
+
+    let integrity = integrity_of(&resolver, "@pnpm.e2e/foobar", "100.0.0").await;
+    let mut config_deps = BTreeMap::new();
+    config_deps.insert(
+        "@pnpm.e2e/foobar".to_string(),
+        ConfigDependency::VersionWithIntegrity(format!("100.0.0+{integrity}")),
+    );
+
+    resolve_and_install_config_deps::<SilentReporter>(
+        &config_deps,
+        &resolver,
+        &options(&harness, root.path(), false),
+    )
+    .await
+    .unwrap();
+
+    let env = EnvLockfile::read(root.path()).unwrap().expect("env lockfile written");
+    let key: PackageKey = "@pnpm.e2e/foobar@100.0.0".parse().unwrap();
+    assert!(
+        env.snapshots[&key].optional_dependencies.is_none(),
+        "a pinned config dep records no optional subdeps",
+    );
+}
+
 /// Recursively search `dir` for an entry named `name`, without following
 /// symlinks (so it can't loop through the dir links a successful install leaves).
 fn contains_entry_named(dir: &Path, name: &str) -> bool {
@@ -963,7 +995,6 @@ async fn migrates_old_inline_integrity_format() {
     let (resolver, _cache) = build_resolver(&harness.registry_url);
     let root = TempDir::new().unwrap();
 
-    // The old format embeds the integrity inline as `<version>+<integrity>`.
     let integrity = integrity_of(&resolver, "@pnpm.e2e/foo", "100.0.0").await;
     let mut config_deps = BTreeMap::new();
     config_deps.insert(
@@ -1023,7 +1054,10 @@ async fn takes_old_format_tarball_url_from_the_packument() {
     let LockfileResolution::Tarball(tarball) = resolution else {
         panic!("expected the tarball URL the packument advertises to be recorded");
     };
-    assert!(tarball.tarball.starts_with(&harness.registry_url));
+    assert!(
+        tarball.tarball.starts_with(&harness.registry_url),
+        "tarball URL comes from the packument, not from the configured registry",
+    );
     assert_eq!(tarball.integrity.as_ref().unwrap().to_string(), integrity);
 }
 

--- a/pnpm/crates/env-installer/src/verify_env_lockfile.rs
+++ b/pnpm/crates/env-installer/src/verify_env_lockfile.rs
@@ -53,7 +53,7 @@ pub fn verify_env_lockfile(env_lockfile: &EnvLockfile) -> Result<(), ConfigDepEr
 
 /// The env lockfile is verified before it is written, but a migrated config
 /// dependency is resolved against the registry first, so its name and version
-/// are checked here instead of reaching the resolver.
+/// are checked here, before they reach the resolver.
 pub(crate) fn assert_valid_migrated_config_dep(
     name: &str,
     version: &str,

--- a/pnpm/crates/env-installer/src/verify_env_lockfile.rs
+++ b/pnpm/crates/env-installer/src/verify_env_lockfile.rs
@@ -51,6 +51,17 @@ pub fn verify_env_lockfile(env_lockfile: &EnvLockfile) -> Result<(), ConfigDepEr
     Ok(())
 }
 
+/// The env lockfile is verified before it is written, but a migrated config
+/// dependency is resolved against the registry first, so its name and version
+/// are checked here instead of reaching the resolver.
+pub(crate) fn assert_valid_migrated_config_dep(
+    name: &str,
+    version: &str,
+) -> Result<(), ConfigDepError> {
+    assert_valid_name(name, "The configDependencies in pnpm-workspace.yaml")?;
+    assert_valid_version(name, version)
+}
+
 fn assert_valid_name(name: &str, description: &str) -> Result<(), ConfigDepError> {
     if is_valid_old_npm_package_name(name) {
         Ok(())

--- a/pnpm11/installing/env-installer/src/resolveAndInstallConfigDeps.ts
+++ b/pnpm11/installing/env-installer/src/resolveAndInstallConfigDeps.ts
@@ -1,6 +1,5 @@
 import { pickRegistryForPackage } from '@pnpm/config.pick-registry-for-package'
 import { PnpmError } from '@pnpm/error'
-import { assertValidDependencyAliases } from '@pnpm/installing.deps-resolver'
 import {
   createEnvLockfile,
   type EnvLockfile,
@@ -12,11 +11,11 @@ import { createFetchFromRegistry, type CreateFetchFromRegistryOptions } from '@p
 import { createNpmResolver, type ResolverFactoryOptions } from '@pnpm/resolving.npm-resolver'
 import type { ConfigDependencies, RegistryConfig } from '@pnpm/types'
 
-import { assertValidConfigDepVersion } from './assertValidConfigDepVersion.js'
 import { installConfigDeps, type InstallConfigDepsOpts } from './installConfigDeps.js'
 import { parseIntegrity } from './parseIntegrity.js'
 import { pruneEnvLockfile } from './pruneEnvLockfile.js'
 import { resolveOptionalSubdeps } from './resolveOptionalSubdeps.js'
+import { assertValidMigratedConfigDep } from './verifyEnvLockfile.js'
 import { writeVerifiedEnvLockfile } from './writeVerifiedEnvLockfile.js'
 
 export type ResolveAndInstallConfigDepsOpts = CreateFetchFromRegistryOptions & ResolverFactoryOptions & InstallConfigDepsOpts & {
@@ -39,7 +38,7 @@ export async function resolveAndInstallConfigDeps (
   const envLockfile: EnvLockfile = (await readEnvLockfile(opts.rootDir)) ?? createEnvLockfile()
   const lockfileConfigDeps = envLockfile.importers['.'].configDependencies
 
-  const depsToResolve: Array<{ name: string, specifier: string, integrity?: string }> = []
+  const depsToResolve: Array<{ name: string, specifier: string, pinnedIntegrity?: string }> = []
   let lockfileChanged = false
 
   for (const [name, value] of Object.entries(configDeps)) {
@@ -48,9 +47,7 @@ export async function resolveAndInstallConfigDeps (
       if (!lockfileConfigDeps[name]) {
         const { version, integrity } = parseIntegrity(name, value.integrity)
         assertValidMigratedConfigDep(name, version)
-        if (value.tarball == null) {
-          depsToResolve.push({ name, specifier: version, integrity })
-        } else {
+        if (value.tarball != null) {
           const registry = pickRegistryForPackage(opts.registriesByScope, name)
           const pkgKey = `${name}@${version}`
           lockfileConfigDeps[name] = { specifier: version, version }
@@ -59,6 +56,8 @@ export async function resolveAndInstallConfigDeps (
           }
           envLockfile.snapshots[pkgKey] = {}
           lockfileChanged = true
+        } else {
+          depsToResolve.push({ name, specifier: version, pinnedIntegrity: integrity })
         }
       }
       continue
@@ -69,7 +68,7 @@ export async function resolveAndInstallConfigDeps (
       if (!lockfileConfigDeps[name]) {
         const { version, integrity } = parseIntegrity(name, value)
         assertValidMigratedConfigDep(name, version)
-        depsToResolve.push({ name, specifier: version, integrity })
+        depsToResolve.push({ name, specifier: version, pinnedIntegrity: integrity })
       }
       continue
     }
@@ -101,7 +100,7 @@ export async function resolveAndInstallConfigDeps (
   const getAuthHeader = createGetAuthHeaderByURI(opts.configByUri ?? {})
   const { resolveFromNpm } = createNpmResolver(fetch, getAuthHeader, opts)
 
-  await Promise.all(depsToResolve.map(async ({ name, specifier, integrity }) => {
+  await Promise.all(depsToResolve.map(async ({ name, specifier, pinnedIntegrity }) => {
     const resolution = await resolveFromNpm({ alias: name, bareSpecifier: specifier }, {
       lockfileDir: opts.rootDir,
       preferredVersions: {},
@@ -123,21 +122,24 @@ export async function resolveAndInstallConfigDeps (
       specifier,
       version,
     }
+    // A migrated dependency keeps the integrity pinned in pnpm-workspace.yaml,
+    // so the registry hands over the tarball URL without loosening the pin.
+    const pkgResolution = pinnedIntegrity == null
+      ? resolution.resolution
+      : { ...resolution.resolution, integrity: pinnedIntegrity }
     envLockfile.packages[pkgKey] = {
-      resolution: toLockfileResolution(
-        { name, version },
-        // A migrated dependency keeps the integrity pinned in pnpm-workspace.yaml,
-        // so the registry can hand over the tarball URL without loosening the pin.
-        integrity == null ? resolution.resolution : { ...resolution.resolution, integrity },
-        { registry }
-      ),
+      resolution: toLockfileResolution({ name, version }, pkgResolution, { registry }),
     }
-    const optionalSubdeps = await resolveOptionalSubdeps(name, resolution.manifest, {
-      envLockfile,
-      lockfileDir: opts.rootDir,
-      registriesByScope: opts.registriesByScope,
-      resolveFromNpm,
-    })
+    // A pinned dependency covers only itself, so its optional subdeps stay out
+    // of the lockfile until it is declared as a clean specifier.
+    const optionalSubdeps = pinnedIntegrity == null
+      ? await resolveOptionalSubdeps(name, resolution.manifest, {
+        envLockfile,
+        lockfileDir: opts.rootDir,
+        registriesByScope: opts.registriesByScope,
+        resolveFromNpm,
+      })
+      : undefined
     envLockfile.snapshots[pkgKey] = optionalSubdeps ? { optionalDependencies: optionalSubdeps } : {}
   }))
 
@@ -145,12 +147,4 @@ export async function resolveAndInstallConfigDeps (
 
   await writeVerifiedEnvLockfile(opts.rootDir, envLockfile)
   await installConfigDeps(envLockfile, opts)
-}
-
-// The env lockfile is verified before it is written, but a migrated dependency
-// is resolved against the registry first, so its name and version are checked
-// here instead of reaching the resolver.
-function assertValidMigratedConfigDep (name: string, version: string): void {
-  assertValidDependencyAliases({ [name]: version }, 'The configDependencies in pnpm-workspace.yaml')
-  assertValidConfigDepVersion(name, version)
 }

--- a/pnpm11/installing/env-installer/src/resolveAndInstallConfigDeps.ts
+++ b/pnpm11/installing/env-installer/src/resolveAndInstallConfigDeps.ts
@@ -1,5 +1,6 @@
 import { pickRegistryForPackage } from '@pnpm/config.pick-registry-for-package'
 import { PnpmError } from '@pnpm/error'
+import { assertValidDependencyAliases } from '@pnpm/installing.deps-resolver'
 import {
   createEnvLockfile,
   type EnvLockfile,
@@ -9,9 +10,9 @@ import { toLockfileResolution } from '@pnpm/lockfile.utils'
 import { createGetAuthHeaderByURI } from '@pnpm/network.auth-header'
 import { createFetchFromRegistry, type CreateFetchFromRegistryOptions } from '@pnpm/network.fetch'
 import { createNpmResolver, type ResolverFactoryOptions } from '@pnpm/resolving.npm-resolver'
-import { getNpmTarballUrl } from '@pnpm/resolving.tarball-url'
 import type { ConfigDependencies, RegistryConfig } from '@pnpm/types'
 
+import { assertValidConfigDepVersion } from './assertValidConfigDepVersion.js'
 import { installConfigDeps, type InstallConfigDepsOpts } from './installConfigDeps.js'
 import { parseIntegrity } from './parseIntegrity.js'
 import { pruneEnvLockfile } from './pruneEnvLockfile.js'
@@ -38,40 +39,37 @@ export async function resolveAndInstallConfigDeps (
   const envLockfile: EnvLockfile = (await readEnvLockfile(opts.rootDir)) ?? createEnvLockfile()
   const lockfileConfigDeps = envLockfile.importers['.'].configDependencies
 
-  const depsToResolve: Array<{ name: string, specifier: string }> = []
+  const depsToResolve: Array<{ name: string, specifier: string, integrity?: string }> = []
   let lockfileChanged = false
 
   for (const [name, value] of Object.entries(configDeps)) {
     if (typeof value === 'object') {
       // Old object format — migrate inline into lockfile
       if (!lockfileConfigDeps[name]) {
-        const registry = pickRegistryForPackage(opts.registriesByScope, name)
         const { version, integrity } = parseIntegrity(name, value.integrity)
-        const tarball = value.tarball ?? getNpmTarballUrl(name, version, { registry })
-        const pkgKey = `${name}@${version}`
-        lockfileConfigDeps[name] = { specifier: version, version }
-        envLockfile.packages[pkgKey] = {
-          resolution: toLockfileResolution({ name, version }, { integrity, tarball }, { registry }),
+        assertValidMigratedConfigDep(name, version)
+        if (value.tarball == null) {
+          depsToResolve.push({ name, specifier: version, integrity })
+        } else {
+          const registry = pickRegistryForPackage(opts.registriesByScope, name)
+          const pkgKey = `${name}@${version}`
+          lockfileConfigDeps[name] = { specifier: version, version }
+          envLockfile.packages[pkgKey] = {
+            resolution: toLockfileResolution({ name, version }, { integrity, tarball: value.tarball }, { registry }),
+          }
+          envLockfile.snapshots[pkgKey] = {}
+          lockfileChanged = true
         }
-        envLockfile.snapshots[pkgKey] = {}
-        lockfileChanged = true
       }
       continue
     }
 
     if (value.includes('+')) {
-      // Old string format with inline integrity — migrate into lockfile
+      // Old string format with inline integrity — resolve its tarball URL, then migrate
       if (!lockfileConfigDeps[name]) {
-        const registry = pickRegistryForPackage(opts.registriesByScope, name)
         const { version, integrity } = parseIntegrity(name, value)
-        const tarball = getNpmTarballUrl(name, version, { registry })
-        const pkgKey = `${name}@${version}`
-        lockfileConfigDeps[name] = { specifier: version, version }
-        envLockfile.packages[pkgKey] = {
-          resolution: toLockfileResolution({ name, version }, { integrity, tarball }, { registry }),
-        }
-        envLockfile.snapshots[pkgKey] = {}
-        lockfileChanged = true
+        assertValidMigratedConfigDep(name, version)
+        depsToResolve.push({ name, specifier: version, integrity })
       }
       continue
     }
@@ -103,7 +101,7 @@ export async function resolveAndInstallConfigDeps (
   const getAuthHeader = createGetAuthHeaderByURI(opts.configByUri ?? {})
   const { resolveFromNpm } = createNpmResolver(fetch, getAuthHeader, opts)
 
-  await Promise.all(depsToResolve.map(async ({ name, specifier }) => {
+  await Promise.all(depsToResolve.map(async ({ name, specifier, integrity }) => {
     const resolution = await resolveFromNpm({ alias: name, bareSpecifier: specifier }, {
       lockfileDir: opts.rootDir,
       preferredVersions: {},
@@ -128,7 +126,9 @@ export async function resolveAndInstallConfigDeps (
     envLockfile.packages[pkgKey] = {
       resolution: toLockfileResolution(
         { name, version },
-        resolution.resolution,
+        // A migrated dependency keeps the integrity pinned in pnpm-workspace.yaml,
+        // so the registry can hand over the tarball URL without loosening the pin.
+        integrity == null ? resolution.resolution : { ...resolution.resolution, integrity },
         { registry }
       ),
     }
@@ -145,4 +145,12 @@ export async function resolveAndInstallConfigDeps (
 
   await writeVerifiedEnvLockfile(opts.rootDir, envLockfile)
   await installConfigDeps(envLockfile, opts)
+}
+
+// The env lockfile is verified before it is written, but a migrated dependency
+// is resolved against the registry first, so its name and version are checked
+// here instead of reaching the resolver.
+function assertValidMigratedConfigDep (name: string, version: string): void {
+  assertValidDependencyAliases({ [name]: version }, 'The configDependencies in pnpm-workspace.yaml')
+  assertValidConfigDepVersion(name, version)
 }

--- a/pnpm11/installing/env-installer/src/verifyEnvLockfile.ts
+++ b/pnpm11/installing/env-installer/src/verifyEnvLockfile.ts
@@ -22,3 +22,11 @@ export function verifyEnvLockfile (envLockfile: EnvLockfile): void {
     }
   }
 }
+
+// The env lockfile is verified before it is written, but a migrated config
+// dependency is resolved against the registry first, so its name and version
+// are checked here, before they reach the resolver.
+export function assertValidMigratedConfigDep (name: string, version: string): void {
+  assertValidDependencyAliases({ [name]: version }, 'The configDependencies in pnpm-workspace.yaml')
+  assertValidConfigDepVersion(name, version)
+}

--- a/pnpm11/installing/env-installer/test/resolveAndInstallConfigDeps.test.ts
+++ b/pnpm11/installing/env-installer/test/resolveAndInstallConfigDeps.test.ts
@@ -25,58 +25,6 @@ function createOpts (registryUrl: string = registry) {
   }
 }
 
-// Stands up a registry that serves its tarballs from a path pnpm cannot derive
-// from the package name, version, and registry URL — the shape of GitLab's npm
-// registry. Packuments are proxied from pnpr with their `dist.tarball` pointed
-// at a `/tarballs/` prefix, and the derivable URL is answered with a 404.
-async function withNonDerivableTarballRegistry (run: (registryUrl: string) => Promise<void>): Promise<void> {
-  const upstreamBase = `http://localhost:${REGISTRY_MOCK_PORT}`
-  let proxyBase = ''
-  const server = http.createServer((req, res) => {
-    void (async () => {
-      const tarballPath = req.url!.startsWith('/tarballs/') ? req.url!.slice('/tarballs'.length) : undefined
-      if (tarballPath == null && req.url!.endsWith('.tgz')) {
-        res.writeHead(404)
-        res.end('Not Found')
-        return
-      }
-      const upstream = await fetch(`${upstreamBase}${tarballPath ?? req.url!}`, {
-        headers: { accept: req.headers.accept ?? '*/*' },
-      })
-      const contentType = upstream.headers.get('content-type') ?? ''
-      if (contentType.includes('json')) {
-        const body = (await upstream.text()).split(upstreamBase).join(`${proxyBase}/tarballs`)
-        res.writeHead(upstream.status, { 'content-type': 'application/json' })
-        res.end(body)
-      } else {
-        res.writeHead(upstream.status, { 'content-type': contentType })
-        res.end(Buffer.from(await upstream.arrayBuffer()))
-      }
-    })().catch((err: unknown) => {
-      res.writeHead(500)
-      res.end(String(err))
-    })
-  })
-  await new Promise<void>((resolve) => {
-    server.listen(0, resolve)
-  })
-  proxyBase = `http://localhost:${(server.address() as AddressInfo).port}`
-  try {
-    await run(`${proxyBase}/`)
-  } finally {
-    server.closeAllConnections()
-    await new Promise<void>((resolve, reject) => {
-      server.close((err) => {
-        if (err == null) {
-          resolve()
-        } else {
-          reject(err)
-        }
-      })
-    })
-  }
-}
-
 interface InstallingConfigDepsEvent { status: string, deps?: Array<{ name: string, version: string }> }
 
 // `streamParser` is a `split2` Transform stream that buffers writes until the
@@ -273,6 +221,58 @@ test('takes the tarball of an old-format config dep from the packument', async (
     tarball: advertisedTarball,
   })
 })
+
+// Stands up a registry that serves its tarballs from a path pnpm cannot derive
+// from the package name, version, and registry URL — the shape of GitLab's npm
+// registry. Packuments are proxied from pnpr with their `dist.tarball` pointed
+// at a `/tarballs/` prefix, and the derivable URL is answered with a 404.
+async function withNonDerivableTarballRegistry (run: (registryUrl: string) => Promise<void>): Promise<void> {
+  const upstreamBase = `http://localhost:${REGISTRY_MOCK_PORT}`
+  let proxyBase = ''
+  const server = http.createServer((req, res) => {
+    void (async () => {
+      const tarballPath = req.url!.startsWith('/tarballs/') ? req.url!.slice('/tarballs'.length) : undefined
+      if (tarballPath == null && req.url!.endsWith('.tgz')) {
+        res.writeHead(404)
+        res.end('Not Found')
+        return
+      }
+      const upstream = await fetch(`${upstreamBase}${tarballPath ?? req.url!}`, {
+        headers: { accept: req.headers.accept ?? '*/*' },
+      })
+      const contentType = upstream.headers.get('content-type') ?? ''
+      if (contentType.includes('json')) {
+        const body = (await upstream.text()).split(upstreamBase).join(`${proxyBase}/tarballs`)
+        res.writeHead(upstream.status, { 'content-type': 'application/json' })
+        res.end(body)
+      } else {
+        res.writeHead(upstream.status, { 'content-type': contentType })
+        res.end(Buffer.from(await upstream.arrayBuffer()))
+      }
+    })().catch((err: unknown) => {
+      res.writeHead(500)
+      res.end(String(err))
+    })
+  })
+  await new Promise<void>((resolve) => {
+    server.listen(0, resolve)
+  })
+  proxyBase = `http://localhost:${(server.address() as AddressInfo).port}`
+  try {
+    await run(`${proxyBase}/`)
+  } finally {
+    server.closeAllConnections()
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => {
+        if (err == null) {
+          resolve()
+        } else {
+          reject(err)
+        }
+      })
+    })
+  }
+}
 
 test('keeps optional subdeps of a pinned config dep out of the lockfile', async () => {
   prepareEmpty()

--- a/pnpm11/installing/env-installer/test/resolveAndInstallConfigDeps.test.ts
+++ b/pnpm11/installing/env-installer/test/resolveAndInstallConfigDeps.test.ts
@@ -1,3 +1,5 @@
+import http from 'node:http'
+import type { AddressInfo } from 'node:net'
 import path from 'node:path'
 
 import { afterAll, expect, test } from '@jest/globals'
@@ -11,15 +13,67 @@ import { loadJsonFileSync } from 'load-json-file'
 
 const registry = `http://localhost:${REGISTRY_MOCK_PORT}/`
 
-function createOpts () {
+function createOpts (registryUrl: string = registry) {
   const { storeController, storeDir } = createTempStore()
   return {
-    registriesByScope: { default: registry },
+    registriesByScope: { default: registryUrl },
     rootDir: process.cwd(),
     cacheDir: path.resolve('cache'),
     userConfig: {},
     store: storeController,
     storeDir,
+  }
+}
+
+// Stands up a registry that serves its tarballs from a path pnpm cannot derive
+// from the package name, version, and registry URL — the shape of GitLab's npm
+// registry. Packuments are proxied from pnpr with their `dist.tarball` pointed
+// at a `/tarballs/` prefix, and the derivable URL is answered with a 404.
+async function withNonDerivableTarballRegistry (run: (registryUrl: string) => Promise<void>): Promise<void> {
+  const upstreamBase = `http://localhost:${REGISTRY_MOCK_PORT}`
+  let proxyBase = ''
+  const server = http.createServer((req, res) => {
+    void (async () => {
+      const tarballPath = req.url!.startsWith('/tarballs/') ? req.url!.slice('/tarballs'.length) : undefined
+      if (tarballPath == null && req.url!.endsWith('.tgz')) {
+        res.writeHead(404)
+        res.end('Not Found')
+        return
+      }
+      const upstream = await fetch(`${upstreamBase}${tarballPath ?? req.url!}`, {
+        headers: { accept: req.headers.accept ?? '*/*' },
+      })
+      const contentType = upstream.headers.get('content-type') ?? ''
+      if (contentType.includes('json')) {
+        const body = (await upstream.text()).split(upstreamBase).join(`${proxyBase}/tarballs`)
+        res.writeHead(upstream.status, { 'content-type': 'application/json' })
+        res.end(body)
+      } else {
+        res.writeHead(upstream.status, { 'content-type': contentType })
+        res.end(Buffer.from(await upstream.arrayBuffer()))
+      }
+    })().catch((err: unknown) => {
+      res.writeHead(500)
+      res.end(String(err))
+    })
+  })
+  await new Promise<void>((resolve) => {
+    server.listen(0, resolve)
+  })
+  proxyBase = `http://localhost:${(server.address() as AddressInfo).port}`
+  try {
+    await run(`${proxyBase}/`)
+  } finally {
+    server.closeAllConnections()
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => {
+        if (err == null) {
+          resolve()
+        } else {
+          reject(err)
+        }
+      })
+    })
   }
 }
 
@@ -195,6 +249,27 @@ test('handles old format config deps via migration path', async () => {
   const manifest = loadJsonFileSync<{ name: string, version: string }>('node_modules/.pnpm-config/@pnpm.e2e/foo/package.json')
   expect(manifest.name).toBe('@pnpm.e2e/foo')
   expect(manifest.version).toBe('100.0.0')
+})
+
+test('takes the tarball of an old-format config dep from the packument', async () => {
+  prepareEmpty()
+  const integrity = getIntegrity('@pnpm.e2e/foo', '100.0.0')
+
+  await withNonDerivableTarballRegistry(async (registryUrl) => {
+    await resolveAndInstallConfigDeps({
+      '@pnpm.e2e/foo': `100.0.0+${integrity}`,
+    }, createOpts(registryUrl))
+  })
+
+  const manifest = loadJsonFileSync<{ name: string, version: string }>('node_modules/.pnpm-config/@pnpm.e2e/foo/package.json')
+  expect(manifest.name).toBe('@pnpm.e2e/foo')
+  expect(manifest.version).toBe('100.0.0')
+
+  const envLockfile = await readEnvLockfile(process.cwd())
+  expect(envLockfile!.packages['@pnpm.e2e/foo@100.0.0'].resolution).toStrictEqual({
+    integrity,
+    tarball: expect.stringContaining('/tarballs/@pnpm.e2e/foo/-/foo-100.0.0.tgz'),
+  })
 })
 
 test('handles mixed old-format and new-format config deps together', async () => {

--- a/pnpm11/installing/env-installer/test/resolveAndInstallConfigDeps.test.ts
+++ b/pnpm11/installing/env-installer/test/resolveAndInstallConfigDeps.test.ts
@@ -272,6 +272,24 @@ test('takes the tarball of an old-format config dep from the packument', async (
   })
 })
 
+test('keeps optional subdeps of a pinned config dep out of the lockfile', async () => {
+  prepareEmpty()
+  const opts = createOpts()
+
+  // @pnpm.e2e/foobar declares `@pnpm.e2e/bar: "^100.0.0"` as an
+  // optionalDependency — a range, which a clean specifier forbids.
+  const integrity = getIntegrity('@pnpm.e2e/foobar', '100.0.0')
+  await resolveAndInstallConfigDeps({
+    '@pnpm.e2e/foobar': `100.0.0+${integrity}`,
+  }, opts)
+
+  const manifest = loadJsonFileSync<{ name: string, version: string }>('node_modules/.pnpm-config/@pnpm.e2e/foobar/package.json')
+  expect(manifest.version).toBe('100.0.0')
+
+  const envLockfile = await readEnvLockfile(process.cwd())
+  expect(envLockfile!.snapshots['@pnpm.e2e/foobar@100.0.0']).toStrictEqual({})
+})
+
 test('handles mixed old-format and new-format config deps together', async () => {
   prepareEmpty()
   const opts = createOpts()

--- a/pnpm11/installing/env-installer/test/resolveAndInstallConfigDeps.test.ts
+++ b/pnpm11/installing/env-installer/test/resolveAndInstallConfigDeps.test.ts
@@ -255,7 +255,9 @@ test('takes the tarball of an old-format config dep from the packument', async (
   prepareEmpty()
   const integrity = getIntegrity('@pnpm.e2e/foo', '100.0.0')
 
+  let advertisedTarball = ''
   await withNonDerivableTarballRegistry(async (registryUrl) => {
+    advertisedTarball = `${registryUrl}tarballs/@pnpm.e2e/foo/-/foo-100.0.0.tgz`
     await resolveAndInstallConfigDeps({
       '@pnpm.e2e/foo': `100.0.0+${integrity}`,
     }, createOpts(registryUrl))
@@ -268,7 +270,7 @@ test('takes the tarball of an old-format config dep from the packument', async (
   const envLockfile = await readEnvLockfile(process.cwd())
   expect(envLockfile!.packages['@pnpm.e2e/foo@100.0.0'].resolution).toStrictEqual({
     integrity,
-    tarball: expect.stringContaining('/tarballs/@pnpm.e2e/foo/-/foo-100.0.0.tgz'),
+    tarball: advertisedTarball,
   })
 })
 


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#13765.

A config dependency written in the old `<version>+<integrity>` form never asked the registry where its tarball lives. The migration path built the URL from the registry, the package name and the version (`{registry}/{name}/-/{unscoped-name}-{version}.tgz`). That matches npmjs.org, but not a GitLab group endpoint, where the packument advertises a `projects/<id>` path and keeps the scope in the filename. The derived URL 404s there, while the same package installs fine as a regular dependency, because that path reads `dist.tarball`.

The failure mode is worse than a 404: GitLab answers an unknown tarball path with a 302 to registry.npmjs.org, so a request for a private scope lands on a public registry the organisation does not own, and a config dependency is installed before everything else and may execute a `.pnpmfile.mjs`.

Migrated config dependencies are now resolved against the registry for their tarball URL, the way clean specifiers already are. Deriving the URL stays in `installConfigDeps`, for lockfile entries that record no tarball, which is the order pnpm/pnpm#12164 assumes. The cost is one metadata request on the install that performs the migration; the changeset says so.

Three things a reviewer may want addressed up front:

The integrity pinned in `pnpm-workspace.yaml` is kept rather than the packument's, so the registry hands over a URL but never a hash and the download is still checked against what the user wrote. A disagreement between the two is not raised as an error, because the two values can legitimately differ in kind (a `sha1` shasum from the packument against a `sha512` pin), and the tarball fetch fails closed on a real mismatch either way.

Optional subdependencies are still not resolved for a dependency pinned this way, so an install that worked before keeps working. Routing these deps through the resolver would otherwise have started rejecting a config dependency whose manifest declares an optionalDependency by range, since config deps require exact versions there.

`migrateConfigDeps.ts` still derives the URL the same way. It is reached only through `installConfigDeps(configDeps, opts)`, which no production caller uses, and it has no pacquet counterpart, so it is left alone rather than grown into this change.

The new test in `pnpm11/installing/env-installer` puts a proxy in front of the mock registry that serves tarballs under a path pnpm cannot derive and 404s the derivable one; the Rust one reaches the registry under a host spelling that differs from the one it advertises. Both fail on `main`. The proxy helper is close to `withBasicAuthRegistry` in `pnpm11/installing/deps-installer/test/install/auth.ts`; factoring the two into a shared helper felt like more churn than a bug fix should carry, so I left it, happy to do it if you would rather.

## Squash Commit Body

```text
The old `<version>+<integrity>` config-dependency format was migrated
into the env lockfile with a tarball URL derived from the registry,
the package name and the version, without consulting the packument.
On registries that do not serve tarballs at that path, GitLab's group
endpoint among them, the derived URL 404s, and GitLab redirects
unknown tarball paths to registry.npmjs.org, so a private scope's
request reaches a registry the organisation does not control.

Migrated config dependencies now go through the resolver for their
tarball URL, like clean specifiers, and keep the inline integrity so
the download is still verified against the pinned hash. Deriving the
URL remains the fallback in installConfigDeps for lockfile entries
that record none. Their optional subdependencies stay unresolved, as
before, so a manifest declaring one by range still installs.

A migrated name and version are validated before resolution rather
than at lockfile-write time, so invalid ones are rejected with the
same errors as before.

Closes pnpm/pnpm#13765.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed installation failures for legacy configuration dependencies when registry tarball URLs cannot be derived automatically.
  - Resolves tarball URLs from registry metadata while preserving integrity information.
  - Added validation for migrated dependency names, versions, and aliases.
  - Ensures migrated dependencies are recorded with the correct tarball URL in the environment lockfile.
  - Prevents optional subdependencies from being added for dependencies with pinned integrity values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->