### PR TITLE
perf: let projects with a pnpmfile use the fast lockfile updates

### DIFF
--- a/.changeset/pnpmfile-fast-update-gate.md
+++ b/.changeset/pnpmfile-fast-update-gate.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-installer": patch
+"pnpm": patch
+---
+
+Projects with a pnpmfile now use the fast lockfile update paths: an unchanged pnpmfile (proven by the recorded `pnpmfileChecksum`) no longer forces a full re-resolution for removals, dependency group moves, compatible range changes, and the other in-place lockfile rewrites [#13696](https://github.com/pnpm/pnpm/issues/13696).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5821,6 +5821,9 @@ importers:
       '@pnpm/assert-store':
         specifier: workspace:*
         version: link:../../__utils__/assert-store
+      '@pnpm/hooks.pnpmfile':
+        specifier: workspace:*
+        version: link:../../hooks/pnpmfile
       '@pnpm/installing.deps-installer':
         specifier: workspace:*
         version: 'link:'

--- a/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
@@ -1371,3 +1371,133 @@ fn combined_manifest_and_ignore_list_drift_skips_resolution() {
 
     drop((root, mock_instance));
 }
+
+#[test]
+fn a_remove_with_an_unchanged_pnpmfile_skips_resolution() {
+    let CommandTempCwd { workspace, root, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, npmrc_path, .. } = npmrc_info;
+    fs::write(
+        workspace.join(".pnpmfile.cjs"),
+        r#"module.exports = { hooks: { readPackage: (pkg) => {
+            if (pkg.name === '@pnpm.e2e/pkg-with-1-dep') {
+                pkg.dependencies['@pnpm.e2e/dep-of-pkg-with-1-dep'] = '100.0.0';
+            }
+            return pkg;
+        } } }"#,
+    )
+    .expect("write pnpmfile");
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pkg-with-1-dep": "100.0.0",
+                "is-positive": "1.0.0"
+            }
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    let dead_registry = dead_registry_url();
+    let live_npmrc = fs::read_to_string(&npmrc_path).expect("read .npmrc");
+    let dead_npmrc = live_npmrc
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("registry="))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(&npmrc_path, format!("registry={dead_registry}\n{dead_npmrc}\n"))
+        .expect("rewrite .npmrc with a dead registry");
+
+    let assert = pacquet_at(&workspace).with_args(["remove", "is-positive"]).assert().success();
+    assert!(
+        String::from_utf8_lossy(&assert.get_output().stdout)
+            .contains("Lockfile is up to date, resolution step is skipped"),
+        "an unchanged pnpmfile does not force resolution",
+    );
+    let wanted = pacquet_lockfile::Lockfile::load_wanted_from_dir(&workspace)
+        .expect("load updated wanted lockfile")
+        .expect("updated wanted lockfile");
+    let snapshots = wanted.snapshots.as_ref().expect("snapshots");
+    let pinned = snapshots
+        .iter()
+        .find(|(key, _)| key.to_string().starts_with("@pnpm.e2e/pkg-with-1-dep@"))
+        .expect("hooked package snapshot")
+        .1;
+    assert!(
+        pinned.dependencies.as_ref().is_some_and(|dependencies| dependencies
+            .get(&"@pnpm.e2e/dep-of-pkg-with-1-dep".parse().expect("alias"))
+            .is_some_and(|reference| reference.to_string() == "100.0.0")),
+        "the hook's pin survives the fast update",
+    );
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn a_remove_keeps_the_specifiers_a_project_rewriting_pnpmfile_recorded() {
+    let CommandTempCwd { workspace, root, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, npmrc_path, .. } = npmrc_info;
+    fs::write(
+        workspace.join(".pnpmfile.cjs"),
+        r#"module.exports = { hooks: { readPackage: (pkg) => {
+            if (pkg.dependencies && pkg.dependencies['is-positive']) {
+                pkg.dependencies['is-positive'] = '1.0.0';
+            }
+            return pkg;
+        } } }"#,
+    )
+    .expect("write pnpmfile");
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pkg-with-1-dep": "100.0.0",
+                "is-positive": "^1.0.0"
+            }
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    pacquet_at(&workspace).with_arg("install").assert().success();
+    let recorded_specifier = |lockfile: &pacquet_lockfile::Lockfile| {
+        lockfile.importers["."].dependencies.as_ref().expect("dependencies")
+            [&"is-positive".parse().expect("alias")]
+            .specifier
+            .clone()
+    };
+    let initial = pacquet_lockfile::Lockfile::load_wanted_from_dir(&workspace)
+        .expect("load wanted lockfile")
+        .expect("wanted lockfile");
+    let initial_specifier = recorded_specifier(&initial);
+
+    let dead_registry = dead_registry_url();
+    let live_npmrc = fs::read_to_string(&npmrc_path).expect("read .npmrc");
+    let dead_npmrc = live_npmrc
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("registry="))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(&npmrc_path, format!("registry={dead_registry}\n{dead_npmrc}\n"))
+        .expect("rewrite .npmrc with a dead registry");
+
+    let assert =
+        pacquet_at(&workspace).with_args(["remove", "@pnpm.e2e/pkg-with-1-dep"]).assert().success();
+    assert!(
+        String::from_utf8_lossy(&assert.get_output().stdout)
+            .contains("Lockfile is up to date, resolution step is skipped"),
+        "the removal needs no resolution",
+    );
+    let wanted = pacquet_lockfile::Lockfile::load_wanted_from_dir(&workspace)
+        .expect("load updated wanted lockfile")
+        .expect("updated wanted lockfile");
+    assert_eq!(
+        recorded_specifier(&wanted),
+        initial_specifier,
+        "the fast update must not rewrite the specifier the hooked resolution recorded",
+    );
+
+    drop((root, mock_instance));
+}

--- a/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
@@ -1379,12 +1379,12 @@ fn a_remove_with_an_unchanged_pnpmfile_skips_resolution() {
     let AddMockedRegistry { mock_instance, npmrc_path, .. } = npmrc_info;
     fs::write(
         workspace.join(".pnpmfile.cjs"),
-        r#"module.exports = { hooks: { readPackage: (pkg) => {
+        r"module.exports = { hooks: { readPackage: (pkg) => {
             if (pkg.name === '@pnpm.e2e/pkg-with-1-dep') {
                 pkg.dependencies['@pnpm.e2e/dep-of-pkg-with-1-dep'] = '100.0.0';
             }
             return pkg;
-        } } }"#,
+        } } }",
     )
     .expect("write pnpmfile");
     fs::write(
@@ -1442,12 +1442,12 @@ fn a_remove_keeps_the_specifiers_a_project_rewriting_pnpmfile_recorded() {
     let AddMockedRegistry { mock_instance, npmrc_path, .. } = npmrc_info;
     fs::write(
         workspace.join(".pnpmfile.cjs"),
-        r#"module.exports = { hooks: { readPackage: (pkg) => {
+        r"module.exports = { hooks: { readPackage: (pkg) => {
             if (pkg.dependencies && pkg.dependencies['is-positive']) {
                 pkg.dependencies['is-positive'] = '1.0.0';
             }
             return pkg;
-        } } }"#,
+        } } }",
     )
     .expect("write pnpmfile");
     fs::write(

--- a/pnpm11/hooks/pnpmfile/src/requireHooks.ts
+++ b/pnpm11/hooks/pnpmfile/src/requireHooks.ts
@@ -43,6 +43,13 @@ export interface CookedHooks {
   customResolvers?: CustomResolver[]
   customFetchers?: CustomFetcher[]
   calculatePnpmfileChecksum?: () => Promise<string>
+  /**
+   * Whether a `readPackage` hook came from a pnpmfile the checksum does not
+   * cover (the global pnpmfile) — its drift is invisible to
+   * `pnpmfileChecksum` comparisons, so nothing downstream may treat the
+   * checksum as proof the hooks are unchanged.
+   */
+  hasUntrackedReadPackageHook?: boolean
 }
 
 export interface RequireHooksResult {
@@ -128,6 +135,9 @@ export async function requireHooks (
     updateConfig: [],
   }
 
+  cookedHooks.hasUntrackedReadPackageHook = entries.some(
+    (entry) => entry.hooks?.readPackage != null && !entry.includeInChecksum
+  )
   // calculate combined checksum for all included files
   if (entries.some((entry) => entry.hooks != null)) {
     cookedHooks.calculatePnpmfileChecksum = async () => {

--- a/pnpm11/hooks/pnpmfile/test/__fixtures__/globalReadPackage.js
+++ b/pnpm11/hooks/pnpmfile/test/__fixtures__/globalReadPackage.js
@@ -1,0 +1,5 @@
+module.exports = {
+  hooks: {
+    readPackage: (pkg) => pkg,
+  }
+}

--- a/pnpm11/installing/deps-installer/package.json
+++ b/pnpm11/installing/deps-installer/package.json
@@ -135,6 +135,7 @@
     "@jest/globals": "catalog:",
     "@pnpm/assert-project": "workspace:*",
     "@pnpm/assert-store": "workspace:*",
+    "@pnpm/hooks.pnpmfile": "workspace:*",
     "@pnpm/installing.deps-installer": "workspace:*",
     "@pnpm/lockfile.types": "workspace:*",
     "@pnpm/logger": "workspace:*",

--- a/pnpm11/installing/deps-installer/src/install/extendInstallOptions.ts
+++ b/pnpm11/installing/deps-installer/src/install/extendInstallOptions.ts
@@ -110,6 +110,7 @@ export interface StrictInstallOptions {
     customResolvers?: CustomResolver[]
     customFetchers?: CustomFetcher[]
     calculatePnpmfileChecksum?: () => Promise<string | undefined>
+    hasUntrackedReadPackageHook?: boolean
   }
   sideEffectsCacheRead: boolean
   sideEffectsCacheWrite: boolean

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -769,11 +769,11 @@ export async function mutateModules (
       !opts.force &&
       !opts.forceFullResolution &&
       !forceResolutionFromHook &&
-      // A pnpmfile's `readPackage` needs no gate here: `getContext` applies
-      // it to every project manifest, so detection and the handlers compare
-      // hooked manifests against the hooked state the lockfile records, and
-      // a changed pnpmfile surfaces as `pnpmfileChecksum` drift, which is
-      // not composable.
+      // A pnpmfile's `readPackage` hook is safe here — `getContext` applies
+      // it to every project manifest and a changed pnpmfile surfaces as
+      // `pnpmfileChecksum` drift. A programmatic hook has no checksum
+      // proving it unchanged, so it keeps forcing the resolver.
+      (!opts.hooks.readPackage?.length || opts.hooks.calculatePnpmfileChecksum != null) &&
       !opts.hooks.preResolution?.length &&
       !opts.hooks.afterAllResolved?.length &&
       opts.hooks.customResolvers == null &&

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -771,9 +771,11 @@ export async function mutateModules (
       !forceResolutionFromHook &&
       // A pnpmfile's `readPackage` hook is safe here — `getContext` applies
       // it to every project manifest and a changed pnpmfile surfaces as
-      // `pnpmfileChecksum` drift. A programmatic hook has no checksum
-      // proving it unchanged, so it keeps forcing the resolver.
-      (!opts.hooks.readPackage?.length || opts.hooks.calculatePnpmfileChecksum != null) &&
+      // `pnpmfileChecksum` drift. A hook the checksum cannot vouch for — a
+      // programmatic one, or one from the checksum-excluded global pnpmfile
+      // — keeps forcing the resolver.
+      (!opts.hooks.readPackage?.length ||
+        (opts.hooks.calculatePnpmfileChecksum != null && !opts.hooks.hasUntrackedReadPackageHook)) &&
       !opts.hooks.preResolution?.length &&
       !opts.hooks.afterAllResolved?.length &&
       opts.hooks.customResolvers == null &&

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -769,7 +769,11 @@ export async function mutateModules (
       !opts.force &&
       !opts.forceFullResolution &&
       !forceResolutionFromHook &&
-      !opts.hooks.readPackage?.length &&
+      // A pnpmfile's `readPackage` needs no gate here: `getContext` applies
+      // it to every project manifest, so detection and the handlers compare
+      // hooked manifests against the hooked state the lockfile records, and
+      // a changed pnpmfile surfaces as `pnpmfileChecksum` drift, which is
+      // not composable.
       !opts.hooks.preResolution?.length &&
       !opts.hooks.afterAllResolved?.length &&
       opts.hooks.customResolvers == null &&

--- a/pnpm11/installing/deps-installer/test/install/pnpmfileFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/pnpmfileFastUpdate.ts
@@ -1,0 +1,96 @@
+import { expect, test } from '@jest/globals'
+import { mutateModulesInSingleProject } from '@pnpm/installing.deps-installer'
+import { prepareEmpty } from '@pnpm/prepare'
+import type { StoreController } from '@pnpm/store.controller-types'
+import type { PackageManifest, ProjectManifest, ProjectRootDir } from '@pnpm/types'
+
+import { testDefaults } from '../utils/index.js'
+
+test('a remove with an unchanged pnpmfile skips resolution', async () => {
+  const project = prepareEmpty()
+  // The hook pins a transitive dependency, so its effect is visible in the
+  // lockfile and must survive the fast update.
+  function readPackage (manifest: PackageManifest) {
+    if (manifest.name === '@pnpm.e2e/pkg-with-1-dep') {
+      manifest.dependencies!['@pnpm.e2e/dep-of-pkg-with-1-dep'] = '100.0.0'
+    }
+    return manifest
+  }
+  const manifest: ProjectManifest = {
+    dependencies: {
+      '@pnpm.e2e/pkg-with-1-dep': '100.0.0',
+      'is-positive': '1.0.0',
+    },
+  }
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, testDefaults({ hooks: { readPackage: [readPackage] } }))
+
+  const options = testDefaults({ hooks: { readPackage: [readPackage] } })
+  const requestedPackages = trackRequestedPackages(options.storeController)
+  await mutateModulesInSingleProject({
+    dependencyNames: ['is-positive'],
+    manifest,
+    mutation: 'uninstallSome',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, options)
+
+  expect(requestedPackages).toStrictEqual([])
+  const lockfile = project.readLockfile()
+  expect(Object.keys(lockfile.packages).some((depPath) => depPath.startsWith('is-positive@'))).toBe(false)
+  expect(lockfile.snapshots['@pnpm.e2e/pkg-with-1-dep@100.0.0'].dependencies).toStrictEqual({
+    '@pnpm.e2e/dep-of-pkg-with-1-dep': '100.0.0',
+  })
+})
+
+test('a remove keeps the specifiers a project-rewriting pnpmfile recorded', async () => {
+  const project = prepareEmpty()
+  // The hook pins a direct dependency of the project itself, so the recorded
+  // specifier differs from the raw manifest. The fast update must compare
+  // hooked manifests — absorbing the raw specifier would commit a lockfile a
+  // full resolution would never write.
+  function readPackage (manifest: PackageManifest) {
+    if (manifest.dependencies?.['is-positive'] != null) {
+      manifest.dependencies['is-positive'] = '1.0.0'
+    }
+    return manifest
+  }
+  const manifest: ProjectManifest = {
+    dependencies: {
+      '@pnpm.e2e/pkg-with-1-dep': '100.0.0',
+      'is-positive': '^1.0.0',
+    },
+  }
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, testDefaults({ hooks: { readPackage: [readPackage] } }))
+  expect(project.readLockfile().importers['.'].dependencies['is-positive'].specifier).toBe('1.0.0')
+
+  const options = testDefaults({ hooks: { readPackage: [readPackage] } })
+  const requestedPackages = trackRequestedPackages(options.storeController)
+  await mutateModulesInSingleProject({
+    dependencyNames: ['@pnpm.e2e/pkg-with-1-dep'],
+    manifest,
+    mutation: 'uninstallSome',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, options)
+
+  expect(requestedPackages).toStrictEqual([])
+  const lockfile = project.readLockfile()
+  expect(lockfile.importers['.'].dependencies['is-positive'].specifier).toBe('1.0.0')
+  expect(Object.keys(lockfile.packages).some((depPath) => depPath.startsWith('@pnpm.e2e/pkg-with-1-dep@'))).toBe(false)
+})
+
+function trackRequestedPackages (storeController: StoreController): string[] {
+  const requestedPackages: string[] = []
+  const requestPackage = storeController.requestPackage
+  storeController.requestPackage = async (wantedDependency, requestOptions) => {
+    requestedPackages.push(wantedDependency.alias!)
+    return requestPackage(wantedDependency, requestOptions)
+  }
+  return requestedPackages
+}

--- a/pnpm11/installing/deps-installer/test/install/pnpmfileFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/pnpmfileFastUpdate.ts
@@ -112,6 +112,34 @@ test('a programmatic hook without a pnpmfile checksum still resolves', async () 
   expect(requestedPackages).not.toStrictEqual([])
 })
 
+test('a hook from the checksum-excluded global pnpmfile still resolves', async () => {
+  prepareEmpty()
+  const manifest: ProjectManifest = {
+    dependencies: {
+      '@pnpm.e2e/pkg-with-1-dep': '100.0.0',
+      'is-positive': '1.0.0',
+    },
+  }
+  const readPackage = (pkg: PackageManifest) => pkg
+  const hooks = { readPackage: [readPackage], calculatePnpmfileChecksum, hasUntrackedReadPackageHook: true }
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, testDefaults({ hooks }))
+
+  const options = testDefaults({ hooks })
+  const requestedPackages = trackRequestedPackages(options.storeController)
+  await mutateModulesInSingleProject({
+    dependencyNames: ['is-positive'],
+    manifest,
+    mutation: 'uninstallSome',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, options)
+
+  expect(requestedPackages).not.toStrictEqual([])
+})
+
 /**
  * Marks the hooks as coming from a pnpmfile whose content is stable across
  * the installs of one test, the way `requireHooks` tracks real pnpmfiles.

--- a/pnpm11/installing/deps-installer/test/install/pnpmfileFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/pnpmfileFastUpdate.ts
@@ -26,9 +26,9 @@ test('a remove with an unchanged pnpmfile skips resolution', async () => {
     manifest,
     mutation: 'install',
     rootDir: process.cwd() as ProjectRootDir,
-  }, testDefaults({ hooks: { readPackage: [readPackage] } }))
+  }, testDefaults({ hooks: { readPackage: [readPackage], calculatePnpmfileChecksum } }))
 
-  const options = testDefaults({ hooks: { readPackage: [readPackage] } })
+  const options = testDefaults({ hooks: { readPackage: [readPackage], calculatePnpmfileChecksum } })
   const requestedPackages = trackRequestedPackages(options.storeController)
   await mutateModulesInSingleProject({
     dependencyNames: ['is-positive'],
@@ -67,10 +67,10 @@ test('a remove keeps the specifiers a project-rewriting pnpmfile recorded', asyn
     manifest,
     mutation: 'install',
     rootDir: process.cwd() as ProjectRootDir,
-  }, testDefaults({ hooks: { readPackage: [readPackage] } }))
+  }, testDefaults({ hooks: { readPackage: [readPackage], calculatePnpmfileChecksum } }))
   expect(project.readLockfile().importers['.'].dependencies!['is-positive'].specifier).toBe('1.0.0')
 
-  const options = testDefaults({ hooks: { readPackage: [readPackage] } })
+  const options = testDefaults({ hooks: { readPackage: [readPackage], calculatePnpmfileChecksum } })
   const requestedPackages = trackRequestedPackages(options.storeController)
   await mutateModulesInSingleProject({
     dependencyNames: ['@pnpm.e2e/pkg-with-1-dep'],
@@ -84,6 +84,41 @@ test('a remove keeps the specifiers a project-rewriting pnpmfile recorded', asyn
   expect(lockfile.importers['.'].dependencies!['is-positive'].specifier).toBe('1.0.0')
   expect(Object.keys(lockfile.packages).some((depPath) => depPath.startsWith('@pnpm.e2e/pkg-with-1-dep@'))).toBe(false)
 })
+
+test('a programmatic hook without a pnpmfile checksum still resolves', async () => {
+  prepareEmpty()
+  const manifest: ProjectManifest = {
+    dependencies: {
+      '@pnpm.e2e/pkg-with-1-dep': '100.0.0',
+      'is-positive': '1.0.0',
+    },
+  }
+  const readPackage = (pkg: PackageManifest) => pkg
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, testDefaults({ hooks: { readPackage: [readPackage] } }))
+
+  const options = testDefaults({ hooks: { readPackage: [readPackage] } })
+  const requestedPackages = trackRequestedPackages(options.storeController)
+  await mutateModulesInSingleProject({
+    dependencyNames: ['is-positive'],
+    manifest,
+    mutation: 'uninstallSome',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, options)
+
+  expect(requestedPackages).not.toStrictEqual([])
+})
+
+/**
+ * Marks the hooks as coming from a pnpmfile whose content is stable across
+ * the installs of one test, the way `requireHooks` tracks real pnpmfiles.
+ */
+async function calculatePnpmfileChecksum (): Promise<string> {
+  return 'test-pnpmfile-checksum'
+}
 
 function trackRequestedPackages (storeController: StoreController): string[] {
   const requestedPackages: string[] = []

--- a/pnpm11/installing/deps-installer/test/install/pnpmfileFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/pnpmfileFastUpdate.ts
@@ -1,4 +1,8 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
 import { expect, test } from '@jest/globals'
+import { requireHooks } from '@pnpm/hooks.pnpmfile'
 import { mutateModulesInSingleProject } from '@pnpm/installing.deps-installer'
 import { prepareEmpty } from '@pnpm/prepare'
 import type { StoreController } from '@pnpm/store.controller-types'
@@ -114,21 +118,23 @@ test('a programmatic hook without a pnpmfile checksum still resolves', async () 
 
 test('a hook from the checksum-excluded global pnpmfile still resolves', async () => {
   prepareEmpty()
+  fs.writeFileSync('global-pnpmfile.cjs', 'module.exports = { hooks: { readPackage: (pkg) => pkg } }')
+  const loadHooks = async () => (await requireHooks(process.cwd(), {
+    globalPnpmfile: path.resolve('global-pnpmfile.cjs'),
+  })).hooks
   const manifest: ProjectManifest = {
     dependencies: {
       '@pnpm.e2e/pkg-with-1-dep': '100.0.0',
       'is-positive': '1.0.0',
     },
   }
-  const readPackage = (pkg: PackageManifest) => pkg
-  const hooks = { readPackage: [readPackage], calculatePnpmfileChecksum, hasUntrackedReadPackageHook: true }
   await mutateModulesInSingleProject({
     manifest,
     mutation: 'install',
     rootDir: process.cwd() as ProjectRootDir,
-  }, testDefaults({ hooks }))
+  }, testDefaults({ hooks: await loadHooks() }))
 
-  const options = testDefaults({ hooks })
+  const options = testDefaults({ hooks: await loadHooks() })
   const requestedPackages = trackRequestedPackages(options.storeController)
   await mutateModulesInSingleProject({
     dependencyNames: ['is-positive'],

--- a/pnpm11/installing/deps-installer/test/install/pnpmfileFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/pnpmfileFastUpdate.ts
@@ -68,7 +68,7 @@ test('a remove keeps the specifiers a project-rewriting pnpmfile recorded', asyn
     mutation: 'install',
     rootDir: process.cwd() as ProjectRootDir,
   }, testDefaults({ hooks: { readPackage: [readPackage] } }))
-  expect(project.readLockfile().importers['.'].dependencies['is-positive'].specifier).toBe('1.0.0')
+  expect(project.readLockfile().importers['.'].dependencies!['is-positive'].specifier).toBe('1.0.0')
 
   const options = testDefaults({ hooks: { readPackage: [readPackage] } })
   const requestedPackages = trackRequestedPackages(options.storeController)
@@ -81,7 +81,7 @@ test('a remove keeps the specifiers a project-rewriting pnpmfile recorded', asyn
 
   expect(requestedPackages).toStrictEqual([])
   const lockfile = project.readLockfile()
-  expect(lockfile.importers['.'].dependencies['is-positive'].specifier).toBe('1.0.0')
+  expect(lockfile.importers['.'].dependencies!['is-positive'].specifier).toBe('1.0.0')
   expect(Object.keys(lockfile.packages).some((depPath) => depPath.startsWith('@pnpm.e2e/pkg-with-1-dep@'))).toBe(false)
 })
 

--- a/pnpm11/installing/deps-installer/tsconfig.json
+++ b/pnpm11/installing/deps-installer/tsconfig.json
@@ -106,6 +106,9 @@
       "path": "../../fs/symlink-dependency"
     },
     {
+      "path": "../../hooks/pnpmfile"
+    },
+    {
       "path": "../../hooks/read-package-hook"
     },
     {

--- a/pnpm11/pnpm/test/install/lifecycleScripts.ts
+++ b/pnpm11/pnpm/test/install/lifecycleScripts.ts
@@ -564,8 +564,9 @@ test('a remove in a workspace member runs no project postinstall', () => {
 
 test('a remove that falls back to resolution runs no project postinstall', () => {
   prepareInstalledWorkspace(['a', 'b'])
-  // A pnpmfile keeps the remove off the fast lockfile update, so the
-  // removal takes the resolve-then-materialize path.
+  // A pnpmfile added after the install changes the recorded
+  // pnpmfileChecksum, which keeps the remove off the fast lockfile update,
+  // so the removal takes the resolve-then-materialize path.
   fs.writeFileSync('.pnpmfile.cjs', 'module.exports = { hooks: { readPackage: (pkg) => pkg } }')
 
   execPnpmSync(['remove', DEP], { cwd: path.resolve('packages/a'), expectSuccess: true })


### PR DESCRIPTION
## Summary

Item 7 of pnpm/pnpm#13696 — the one the issue flags as highest value: the blanket `!opts.hooks.readPackage?.length` gate disabled every fast lockfile update for any project with a pnpmfile, exactly the population (large monorepos) where re-resolution hurts most.

The premise was proven with failing tests first, then the gate turned out to be unnecessary rather than merely liftable:

- `getContext` already applies the composed `readPackage` hook to every project manifest, so drift detection and the handlers compare **hooked** manifests against the hooked state the lockfile records. The adversarial case — a hook that rewrites one of the project's own specifiers (raw `^1.0.0` hooked to a `1.0.0` pin) — is absorbed correctly: the fast update keeps the hooked specifier and never writes the raw one (pinned by a test that fails if detection ran on raw manifests).
- A *changed* pnpmfile surfaces as `pnpmfileChecksum` drift, which is not a composable field, so it falls back to the resolver. Hooks the checksum cannot vouch for keep forcing the resolver: a programmatic `readPackage` hook (no `calculatePnpmfileChecksum` behind it) and a hook from the checksum-excluded **global pnpmfile** (reported by the new `hasUntrackedReadPackageHook` flag on `requireHooks`) both stay on the full-resolution path, each pinned by a test.
- The freshness gates that validate every fast-update candidate are the same `allProjectsAreUpToDate` machinery that already admits frozen-like installs for pnpmfile projects on every repeat install, so the fast path's eligibility now matches the frozen path's.

pacquet has no such gate and already behaved this way; it gains the regression e2e pair (dead registry: unchanged-pnpmfile remove skips resolution and keeps the hook's transitive pin; a project-rewriting hook's recorded specifier survives a fast update untouched). Writing those tests surfaced a pre-existing recording divergence between the stacks — the TypeScript CLI records the hooked specifier for the importer entry while pacquet records the raw one — filed separately as pnpm/pnpm#13769; both fast-update paths preserve whatever their resolver recorded, so neither is affected by it.

The CLI e2e that used a pnpmfile to force the resolution fallback still forces it (a newly added pnpmfile changes `pnpmfileChecksum`); its comment now states the actual reason.

## Squash Commit Body

```text
The blanket readPackage gate on canTryFastUpdateLockfile predates the
machinery that makes it unnecessary: getContext applies the composed
readPackage hook to every project manifest, so drift detection and the
handlers compare hooked manifests against the hooked state the
lockfile records, and a changed pnpmfile surfaces as pnpmfileChecksum
drift, which is not composable and falls back to the resolver. The
freshness gates that validate every candidate are the same ones that
already admit frozen-like installs for pnpmfile projects.

pacquet has no such gate and already behaved this way; it gains the
regression e2e tests, including one pinning that a fast update never
rewrites a specifier a project-rewriting hook recorded. Writing that
test surfaced a pre-existing recording divergence between the stacks,
filed as pnpm/pnpm#13769.

Item 7 of pnpm/pnpm#13696.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13770"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788966397&installation_model_id=426870&pr_number=13770&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13770&signature=047e4a3be8ecb58678c666e989476ebf25d63bb397bd3da0c15d66b24e682d41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Faster lockfile updates when project configuration remains unchanged, avoiding unnecessary package resolution.
  * Supported configuration hooks can now run during fast updates when their integrity can be verified.

* **Bug Fixes**
  * Dependency removals preserve pins and rewritten version specifications supplied by configuration hooks.
  * Configuration changes, or hooks without verifiable integrity information, continue to trigger full dependency resolution when needed.
  * Untracked configuration hooks correctly prevent fast updates when their changes cannot be verified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
