### PR TITLE
fix(package-manager): run readPackage over the project manifests

### DIFF
--- a/.changeset/pnpmfile-hooks-project-specifiers.md
+++ b/.changeset/pnpmfile-hooks-project-specifiers.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-A `readPackage` hook that rewrites one of the project's *own* dependency specifiers is honored again. `"is-positive": "^1.0.0"` rewritten to `1.0.0` by a `.pnpmfile.cjs` resolved against the raw range and recorded `specifier: ^1.0.0` for the importer, where pnpm resolves and records `1.0.0` [#13769](https://github.com/pnpm/pnpm/issues/13769).
+A `.pnpmfile.cjs` `readPackage` hook that rewrites one of a project's *own* dependency specifiers is now honored: rewriting `"is-positive": "^1.0.0"` to `1.0.0` installs 1.0.0 and records `specifier: 1.0.0` for the importer. Previously the hook was applied only to the manifests of resolved dependencies, so a project's own specifier resolved against the raw range from `package.json` [#13769](https://github.com/pnpm/pnpm/issues/13769).

--- a/.changeset/pnpmfile-hooks-project-specifiers.md
+++ b/.changeset/pnpmfile-hooks-project-specifiers.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+A `readPackage` hook that rewrites one of the project's *own* dependency specifiers is honored again. `"is-positive": "^1.0.0"` rewritten to `1.0.0` by a `.pnpmfile.cjs` resolved against the raw range and recorded `specifier: ^1.0.0` for the importer, where pnpm resolves and records `1.0.0` [#13769](https://github.com/pnpm/pnpm/issues/13769).

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -506,6 +506,12 @@ pub enum InstallError {
     #[diagnostic(code(ERR_PNPM_PNPMFILE_FAIL))]
     CustomResolverForceResolve(#[error(not(source))] pacquet_hooks::HookError),
 
+    /// The pnpmfile's `readPackage` hook threw while transforming a
+    /// workspace project's own manifest.
+    #[display("{_0}")]
+    #[diagnostic(code(ERR_PNPM_PNPMFILE_FAIL))]
+    ReadPackageHook(#[error(not(source))] pacquet_hooks::HookError),
+
     #[diagnostic(transparent)]
     FrozenLockfile(#[error(source)] InstallFrozenLockfileError),
 

--- a/pnpm/crates/package-manager/src/install/run.rs
+++ b/pnpm/crates/package-manager/src/install/run.rs
@@ -3,13 +3,14 @@ use super::{
     FastUpdateLockfileOptions, FreshnessCheckError, HashSet, Host, InMemoryPackageMetaCache,
     IncludedDependencies, Install, InstallError, InstallRunOptions, IsTerminal, Lockfile, LogEvent,
     LogLevel, MaterializationInputs, MaterializationOutput, OptimisticRepeatInstallCheck,
-    OptimisticRepeatInstallDecision, Path, PnpmLog, PrepareModulesStateInputs,
-    PreparedModulesState, Reporter, ScopeLog, Stage, StageLog, SummaryLog, UpdateSeedPolicy,
-    apply_materialization_result, build_project_manifests_list, build_resolution_verifiers,
-    build_root_importer_project_manifests_list, build_selected_project_manifests_list,
-    check_lockfile_freshness, check_optimistic_repeat_install,
-    configured_or_discovered_workspace_dir, dev_preinstall_already_ran,
-    emit_initial_package_manifest, get_catalogs_from_workspace_manifest, gvs_build_marker_present,
+    OptimisticRepeatInstallDecision, PackageManifest, Path, PathBuf, PnpmLog,
+    PrepareModulesStateInputs, PreparedModulesState, Reporter, ScopeLog, Stage, StageLog,
+    SummaryLog, UpdateSeedPolicy, apply_materialization_result, build_project_manifests_list,
+    build_resolution_verifiers, build_root_importer_project_manifests_list,
+    build_selected_project_manifests_list, check_lockfile_freshness,
+    check_optimistic_repeat_install, configured_or_discovered_workspace_dir,
+    dev_preinstall_already_ran, emit_initial_package_manifest,
+    get_catalogs_from_workspace_manifest, gvs_build_marker_present,
     gvs_build_markers_may_require_recovery, load_workspace_projects, map_frozen_lockfile_error,
     materialize, prepare_modules_state, run_dev_preinstall, selected_manifest_freshness_inputs,
     try_fast_update_lockfile, unapproved_recorded_ignored_builds, verify_lockfile_eagerly,
@@ -254,22 +255,6 @@ where
             ),
             None => build_project_manifests_list(&workspace_root, manifest, workspace_projects),
         };
-        let manifest_freshness_inputs = match selection.as_ref() {
-            Some(selection) => selected_manifest_freshness_inputs(
-                &workspace_root,
-                &project_manifests,
-                selection.selected_dirs,
-            ),
-            None => project_manifests
-                .iter()
-                .map(|(project_dir, manifest)| {
-                    (
-                        pacquet_workspace::importer_id_from_root_dir(&workspace_root, project_dir),
-                        *manifest,
-                    )
-                })
-                .collect(),
-        };
         let selected_importer_ids = selection.as_ref().map(|selection| {
             selection
                 .selected_dirs
@@ -443,6 +428,70 @@ where
         // the resolve path below so an install spawns at most one.
         let pnpmfile_hook = pnpmfile_hook_override
             .or_else(|| pacquet_hooks::finder::load_pnpmfile(&workspace_root));
+
+        // pnpm's `getContext` runs `readPackage` over every project
+        // manifest before anything reads it, so a hook that rewrites a
+        // project's own specifier steers the resolution, the freshness
+        // gates, and the importer entries the lockfile records alike.
+        // The optimistic repeat-install check above stays on the on-disk
+        // manifests on purpose: it is the one gate that must not spawn
+        // the Node worker.
+        let hooked_project_manifests: Vec<(PathBuf, PackageManifest)> = match pnpmfile_hook.as_ref()
+        {
+            Some(hook) => {
+                let log = hook.source_path().map_or_else(
+                    || Arc::new(|_| {}) as pacquet_hooks::LogFn,
+                    |from| {
+                        crate::install_with_fresh_lockfile::hook_log_fn::<Reporter>(
+                            &workspace_root,
+                            from,
+                            "readPackage",
+                        )
+                    },
+                );
+                futures_util::future::try_join_all(project_manifests.iter().map(
+                    |(project_dir, manifest)| {
+                        let ctx = pacquet_hooks::HookContext { log: Arc::clone(&log), dir: None };
+                        async move {
+                            let value = hook
+                                .read_package(manifest.value().clone(), ctx)
+                                .await
+                                .map_err(InstallError::ReadPackageHook)?;
+                            let mut hooked = (*manifest).clone();
+                            *hooked.value_mut() = (*value).clone();
+                            Ok::<_, InstallError>((project_dir.clone(), hooked))
+                        }
+                    },
+                ))
+                .await?
+            }
+            None => Vec::new(),
+        };
+        let project_manifests: Vec<(PathBuf, &PackageManifest)> =
+            if hooked_project_manifests.is_empty() {
+                project_manifests
+            } else {
+                hooked_project_manifests
+                    .iter()
+                    .map(|(project_dir, manifest)| (project_dir.clone(), manifest))
+                    .collect()
+            };
+        let manifest_freshness_inputs = match selection.as_ref() {
+            Some(selection) => selected_manifest_freshness_inputs(
+                &workspace_root,
+                &project_manifests,
+                selection.selected_dirs,
+            ),
+            None => project_manifests
+                .iter()
+                .map(|(project_dir, manifest)| {
+                    (
+                        pacquet_workspace::importer_id_from_root_dir(&workspace_root, project_dir),
+                        *manifest,
+                    )
+                })
+                .collect(),
+        };
 
         // Load the *current* lockfile that records what the previous
         // install actually materialized in `<virtual_store_dir>/lock.yaml`.

--- a/pnpm/crates/package-manager/src/install/tests.rs
+++ b/pnpm/crates/package-manager/src/install/tests.rs
@@ -9850,9 +9850,149 @@ async fn read_package_hook_rewrites_the_project_own_specifier() {
         .expect("dependencies map");
     let key = pacquet_lockfile::PkgName::parse("@pnpm.e2e/pkg-with-1-dep").unwrap();
     let recorded = root_deps.get(&key).expect("pkg-with-1-dep recorded at root");
-    dbg!(recorded);
     assert_eq!(recorded.specifier, "100.0.0");
     assert_eq!(recorded.version.to_string(), "100.0.0");
+
+    drop((dir, registry));
+}
+
+/// Same as [`install_with_pnpmfile`] but for a workspace whose member
+/// carries the dependencies, so a hook rewriting a member's own
+/// specifier is exercised rather than only the root's.
+async fn install_workspace_member_with_pnpmfile(
+    registry_url: String,
+    root: &std::path::Path,
+    member_deps: &[(&str, &str)],
+    pnpmfile_src: &str,
+) -> Result<(), InstallError> {
+    let member_dir = root.join("packages/member");
+    std::fs::create_dir_all(&member_dir).unwrap();
+    std::fs::write(root.join("pnpm-workspace.yaml"), "packages:\n  - packages/*\n").unwrap();
+
+    let dependencies: serde_json::Map<_, _> = member_deps
+        .iter()
+        .map(|(name, spec)| ((*name).to_string(), serde_json::Value::from(*spec)))
+        .collect();
+    std::fs::write(
+        member_dir.join("package.json"),
+        serde_json::json!({
+            "name": "member",
+            "version": "1.0.0",
+            "dependencies": dependencies,
+        })
+        .to_string(),
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("package.json"),
+        serde_json::json!({ "name": "workspace-root", "version": "1.0.0" }).to_string(),
+    )
+    .unwrap();
+    let manifest = PackageManifest::from_path(root.join("package.json")).unwrap();
+
+    std::fs::write(root.join(".pnpmfile.cjs"), pnpmfile_src).unwrap();
+
+    let modules_dir = root.join("node_modules");
+    let mut config = Config::new();
+    config.workspace_dir = Some(root.to_path_buf());
+    config.store_dir = root.join("pacquet-store").into();
+    config.virtual_store_dir = modules_dir.join(".pacquet");
+    config.modules_dir = modules_dir;
+    config.registry = registry_url;
+    let config = config.leak();
+
+    let http_client = Default::default();
+    Install {
+        tarball_mem_cache: Default::default(),
+        http_client: &http_client,
+        http_client_arc: std::sync::Arc::new(Default::default()),
+        config,
+        manifest: &manifest,
+        emit_initial_manifest: true,
+        lockfile: MaybeLazyLockfile::Loaded(None),
+        lockfile_path: None,
+        dependency_groups: [DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional],
+        frozen_lockfile: false,
+        prefer_frozen_lockfile: None,
+        ignore_manifest_check: false,
+        skip_runtimes: false,
+        trust_lockfile: false,
+        update_checksums: false,
+        mutation: ProjectMutation::InstallWorkspace,
+        installs_only: true,
+        supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
+        dry_run: false,
+        persist_policy_excludes: true,
+        resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
+        auth_override: None,
+        resolution_observer: None,
+        peer_issues_sink: None,
+        deps_requiring_build_sink: None,
+        catalogs_override: None,
+        disable_optimistic_repeat_install: false,
+        pnpmfile_hook_override: None,
+        workspace_projects_override: None,
+    }
+    .run::<SilentReporter>()
+    .await
+}
+
+// The hook rewrites a workspace *member*'s own dependency range. The
+// member's importer entry has to follow the hook exactly as the root's
+// does, and a second install must stay frozen against what the first
+// recorded rather than reading the raw range back off `package.json`.
+#[tokio::test]
+async fn read_package_hook_rewrites_a_workspace_member_own_specifier() {
+    let registry = TestRegistry::start();
+    let dir = tempdir().unwrap();
+    let pnpmfile = r"module.exports = { hooks: { readPackage (pkg) {
+  if (pkg.dependencies && pkg.dependencies['@pnpm.e2e/pkg-with-1-dep']) {
+    pkg.dependencies['@pnpm.e2e/pkg-with-1-dep'] = '100.0.0';
+  }
+  return pkg;
+} } }";
+
+    install_workspace_member_with_pnpmfile(
+        registry.url(),
+        dir.path(),
+        &[("@pnpm.e2e/pkg-with-1-dep", "^100.0.0")],
+        pnpmfile,
+    )
+    .await
+    .expect("install should succeed");
+
+    let key = pacquet_lockfile::PkgName::parse("@pnpm.e2e/pkg-with-1-dep").unwrap();
+    let member_dependency = |lockfile: &Lockfile| {
+        lockfile.importers["packages/member"].dependencies.as_ref().expect("member dependencies")
+            [&key]
+            .clone()
+    };
+    let read_lockfile = || {
+        let content = std::fs::read_to_string(dir.path().join(Lockfile::FILE_NAME))
+            .expect("read pnpm-lock.yaml");
+        serde_saphyr::from_str::<Lockfile>(&content).expect("parse pnpm-lock.yaml")
+    };
+
+    let recorded = member_dependency(&read_lockfile());
+    assert_eq!(recorded.specifier, "100.0.0");
+    assert_eq!(recorded.version.to_string(), "100.0.0");
+
+    install_workspace_member_with_pnpmfile(
+        registry.url(),
+        dir.path(),
+        &[("@pnpm.e2e/pkg-with-1-dep", "^100.0.0")],
+        pnpmfile,
+    )
+    .await
+    .expect("the repeat install must not see the raw range as drift");
+    assert_eq!(
+        member_dependency(&read_lockfile()),
+        recorded,
+        "the repeat install rewrites nothing"
+    );
 
     drop((dir, registry));
 }

--- a/pnpm/crates/package-manager/src/install/tests.rs
+++ b/pnpm/crates/package-manager/src/install/tests.rs
@@ -9816,6 +9816,47 @@ async fn read_package_hook_pins_transitive_dependency_version() {
     drop((dir, registry));
 }
 
+// The `readPackage` hook rewrites the project's OWN dependency range,
+// and both the resolution and the importer entry the lockfile records
+// follow the hook rather than the on-disk `package.json`. Declaring
+// `^100.0.0` would resolve to 100.1.0; the hook pins it to 100.0.0.
+#[tokio::test]
+async fn read_package_hook_rewrites_the_project_own_specifier() {
+    let registry = TestRegistry::start();
+    let dir = tempdir().unwrap();
+
+    install_with_pnpmfile(
+        registry.url(),
+        dir.path(),
+        &[("@pnpm.e2e/pkg-with-1-dep", "^100.0.0")],
+        r"module.exports = { hooks: { readPackage (pkg) {
+  if (pkg.dependencies && pkg.dependencies['@pnpm.e2e/pkg-with-1-dep']) {
+    pkg.dependencies['@pnpm.e2e/pkg-with-1-dep'] = '100.0.0';
+  }
+  return pkg;
+} } }",
+    )
+    .await
+    .expect("install should succeed");
+
+    let content =
+        std::fs::read_to_string(dir.path().join(Lockfile::FILE_NAME)).expect("read pnpm-lock.yaml");
+    let lockfile: Lockfile = serde_saphyr::from_str(&content).expect("parse pnpm-lock.yaml");
+    let root_deps = lockfile
+        .root_project()
+        .expect("root importer recorded")
+        .dependencies
+        .as_ref()
+        .expect("dependencies map");
+    let key = pacquet_lockfile::PkgName::parse("@pnpm.e2e/pkg-with-1-dep").unwrap();
+    let recorded = root_deps.get(&key).expect("pkg-with-1-dep recorded at root");
+    dbg!(recorded);
+    assert_eq!(recorded.specifier, "100.0.0");
+    assert_eq!(recorded.version.to_string(), "100.0.0");
+
+    drop((dir, registry));
+}
+
 // A `readPackage` hook that does not return the modified package
 // manifest makes the installation fail.
 #[tokio::test]

--- a/pnpm/crates/package-manager/src/install/tests.rs
+++ b/pnpm/crates/package-manager/src/install/tests.rs
@@ -9940,10 +9940,8 @@ async fn install_workspace_member_with_pnpmfile(
     .await
 }
 
-// The hook rewrites a workspace *member*'s own dependency range. The
-// member's importer entry has to follow the hook exactly as the root's
-// does, and a second install must stay frozen against what the first
-// recorded rather than reading the raw range back off `package.json`.
+// Declaring `^100.0.0` would resolve to 100.1.0; the hook pins it to
+// 100.0.0, this time on a workspace member rather than the root.
 #[tokio::test]
 async fn read_package_hook_rewrites_a_workspace_member_own_specifier() {
     let registry = TestRegistry::start();

--- a/pnpm/crates/package-manager/src/install/tests.rs
+++ b/pnpm/crates/package-manager/src/install/tests.rs
@@ -9991,7 +9991,7 @@ async fn read_package_hook_rewrites_a_workspace_member_own_specifier() {
     assert_eq!(
         member_dependency(&read_lockfile()),
         recorded,
-        "the repeat install rewrites nothing"
+        "the repeat install rewrites nothing",
     );
 
     drop((dir, registry));

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1675,7 +1675,7 @@ fn collect_prefetch_cache_keys_from_graph(
 /// `context.log(message)` call emits a `pnpm:hook` event through the
 /// install's reporter, carrying the project `prefix`, the pnpmfile path
 /// (`from`), and the hook name.
-fn hook_log_fn<Reporter: self::Reporter>(
+pub(crate) fn hook_log_fn<Reporter: self::Reporter>(
     prefix: &Path,
     from: &Path,
     hook: &'static str,

--- a/pnpm11/installing/deps-installer/test/install/hooks.ts
+++ b/pnpm11/installing/deps-installer/test/install/hooks.ts
@@ -2,6 +2,7 @@ import { expect, jest, test } from '@jest/globals'
 import { LOCKFILE_VERSION } from '@pnpm/constants'
 import {
   addDependenciesToPackage,
+  install,
   type PackageManifest,
 } from '@pnpm/installing.deps-installer'
 import type { LockfileObject } from '@pnpm/lockfile.fs'
@@ -84,6 +85,36 @@ test('readPackage, afterAllResolved async hooks', async () => {
 
   const wantedLockfile = project.readLockfile()
   expect(wantedLockfile).toHaveProperty(['foo'], 'foo')
+})
+
+test('readPackage rewrites the specifier of the project own dependency', async () => {
+  const project = prepareEmpty()
+
+  // w/o the hook, 100.1.0 would be installed
+  await addDistTag({ package: '@pnpm.e2e/pkg-with-1-dep', version: '100.1.0', distTag: 'latest' })
+
+  function readPackageHook (manifest: PackageManifest) {
+    if (manifest.dependencies?.['@pnpm.e2e/pkg-with-1-dep'] != null) {
+      manifest.dependencies['@pnpm.e2e/pkg-with-1-dep'] = '100.0.0'
+    }
+    return manifest
+  }
+
+  await install({
+    dependencies: {
+      '@pnpm.e2e/pkg-with-1-dep': '^100.0.0',
+    },
+  }, testDefaults({
+    hooks: {
+      readPackage: [readPackageHook],
+    },
+  }))
+
+  const lockfile = project.readLockfile()
+  expect(lockfile.importers['.'].dependencies?.['@pnpm.e2e/pkg-with-1-dep']).toStrictEqual({
+    specifier: '100.0.0',
+    version: '100.0.0',
+  })
 })
 
 test('readPackage hooks array', async () => {

--- a/pnpm11/installing/deps-installer/test/install/hooks.ts
+++ b/pnpm11/installing/deps-installer/test/install/hooks.ts
@@ -1,13 +1,18 @@
+import path from 'node:path'
+
 import { expect, jest, test } from '@jest/globals'
-import { LOCKFILE_VERSION } from '@pnpm/constants'
+import { LOCKFILE_VERSION, WANTED_LOCKFILE } from '@pnpm/constants'
 import {
   addDependenciesToPackage,
   install,
+  mutateModules,
   type PackageManifest,
 } from '@pnpm/installing.deps-installer'
 import type { LockfileObject } from '@pnpm/lockfile.fs'
-import { prepareEmpty } from '@pnpm/prepare'
+import { prepareEmpty, preparePackages } from '@pnpm/prepare'
 import { addDistTag } from '@pnpm/testing.registry-mock'
+import type { ProjectId, ProjectRootDir } from '@pnpm/types'
+import { readYamlFileSync } from 'read-yaml-file'
 
 import { testDefaults } from '../utils/index.js'
 
@@ -115,6 +120,63 @@ test('readPackage rewrites the specifier of the project own dependency', async (
     specifier: '100.0.0',
     version: '100.0.0',
   })
+})
+
+test('readPackage rewrites the specifier of a workspace member own dependency', async () => {
+  preparePackages([
+    {
+      location: 'project-1',
+      package: { name: 'project-1' },
+    },
+  ])
+
+  // w/o the hook, 100.1.0 would be installed
+  await addDistTag({ package: '@pnpm.e2e/pkg-with-1-dep', version: '100.1.0', distTag: 'latest' })
+
+  function readPackageHook (manifest: PackageManifest) {
+    if (manifest.dependencies?.['@pnpm.e2e/pkg-with-1-dep'] != null) {
+      manifest.dependencies['@pnpm.e2e/pkg-with-1-dep'] = '100.0.0'
+    }
+    return manifest
+  }
+  const allProjects = [
+    {
+      buildIndex: 0,
+      manifest: {
+        name: 'project-1',
+        version: '1.0.0',
+        dependencies: {
+          '@pnpm.e2e/pkg-with-1-dep': '^100.0.0',
+        },
+      },
+      rootDir: path.resolve('project-1') as ProjectRootDir,
+    },
+  ]
+  const mutation = [{ mutation: 'install' as const, rootDir: path.resolve('project-1') as ProjectRootDir }]
+
+  await mutateModules(mutation, testDefaults({
+    allProjects,
+    hooks: { readPackage: [readPackageHook] },
+  }))
+
+  const recorded = {
+    specifier: '100.0.0',
+    version: '100.0.0',
+  }
+  const readMemberEntry = (): unknown => {
+    const lockfile = readYamlFileSync<LockfileObject>(WANTED_LOCKFILE)
+    return lockfile.importers['project-1' as ProjectId].dependencies?.['@pnpm.e2e/pkg-with-1-dep']
+  }
+  expect(readMemberEntry()).toStrictEqual(recorded)
+
+  // The repeat install must compare against the hooked manifest too, or
+  // the raw range reads as drift and the entry is rewritten.
+  await mutateModules(mutation, testDefaults({
+    allProjects,
+    hooks: { readPackage: [readPackageHook] },
+  }))
+
+  expect(readMemberEntry()).toStrictEqual(recorded)
 })
 
 test('readPackage hooks array', async () => {


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#13769.

pacquet never ran the pnpmfile's `readPackage` over the workspace projects' own manifests, only over the manifests the resolver got back for their dependencies. A hook that rewrites one of the project's own specifiers was therefore ignored on the way in: the importer's wanted dependencies, and the `specifier:` the lockfile records for it, both came straight off `package.json`.

The divergence is wider than the recorded specifier. With `"is-positive": "^1.0.0"` in `package.json` and a `.pnpmfile.cjs` rewriting it to `3.1.0`, pnpm installs 3.1.0 and records `specifier: 3.1.0`; pacquet installed 1.0.0 and recorded `^1.0.0`.

The fix applies the hook where pnpm's `getContext` does — once over every project manifest, before anything reads them — so resolution, the freshness gates, and the lockfile importer entries all see the same hooked view and stay consistent with each other. Recording the hooked specifier without that would have broken `--frozen-lockfile`, since the gate compares the lockfile against the manifest. The optimistic repeat-install check stays on the on-disk manifests deliberately: it runs before the pnpmfile is loaded and must not spawn the Node worker.

The TypeScript CLI already behaves this way; its side of this PR is a test pinning it.

Verified against pnpm 11.20.0 on the issue's repro: the two lockfiles are now byte-identical, and repeat installs, `--frozen-lockfile`, and `pnpm add` all agree between the stacks (`pnpm add` still writes the raw range back to `package.json` in both).

## Squash Commit Body

```text
pacquet ran the pnpmfile's readPackage only over the manifests the
resolver returned for a project's dependencies, never over the project
manifests themselves, so a hook rewriting one of a project's own
specifiers was dropped: the importer's wanted dependencies and the
specifier the lockfile recorded for it both came from package.json.
A hook turning "^1.0.0" into "3.1.0" left pacquet installing 1.0.0 and
recording "^1.0.0" where pnpm installs 3.1.0 and records "3.1.0".

The hook now runs once over every project manifest at the point pnpm's
getContext runs it, before the freshness gates, the fast-update
candidate, and the resolver read them, so all three agree on the hooked
view. Recording the hooked specifier alone would have made every
--frozen-lockfile install fail with SpecifiersDiffer, since that gate
compares the lockfile against the manifest. The optimistic
repeat-install check keeps reading the on-disk manifests: it runs ahead
of the pnpmfile load and must not spawn the Node worker.

Closes pnpm/pnpm#13769.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13773"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788970494&installation_model_id=426870&pr_number=13773&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13773&signature=6168531d91291f152f627574f4fc34f941487e5e405da95750ff04c0ca292c5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Restored support for `.pnpmfile.cjs` `readPackage` hooks that rewrite a project’s own dependency specifications.
  - Rewritten specifications are now used during installation and recorded accurately in the lockfile, including the resolved version.
  - Installation now reports clear errors when a `readPackage` hook fails.
- **Tests**
  - Added coverage for dependency-specifier rewrites in both standard and API-based installation workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->