### PR TITLE
perf: let time-based lockfiles use the fast lockfile updates

### DIFF
--- a/.changeset/time-based-fast-update.md
+++ b/.changeset/time-based-fast-update.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-installer": patch
+"pnpm": patch
+---
+
+Projects using `resolutionMode: time-based` now benefit from the fast lockfile update paths. A removal, a dependency group move, or a compatible range change no longer forces a full re-resolution just because the lockfile carries a `time` field [#13696](https://github.com/pnpm/pnpm/issues/13696).

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -783,7 +783,12 @@ export async function mutateModules (
       ctx.wantedLockfile.lockfileVersion === LOCKFILE_VERSION &&
       !isEmptyLockfile(ctx.wantedLockfile) &&
       (!opts.pruneLockfileImporters || Object.keys(ctx.wantedLockfile.importers).length === Object.keys(ctx.projects).length) &&
-      ctx.wantedLockfile.time == null
+      // `time` records publish dates for the importers' direct dependencies
+      // and is pruned back to them whenever the lockfile is written, so a
+      // rewrite that introduces no new version needs no maintenance of it.
+      // The resolver-consulting rewrites do introduce versions, whose dates
+      // only a resolution can record.
+      (ctx.wantedLockfile.time == null || asyncChangedSetting == null)
     if (canTryFastUpdateLockfile) {
       await verifyLockfilePromise
       const overridesUseCatalogs = Object.values(opts.overrides)

--- a/pnpm11/installing/deps-installer/test/install/timeFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/timeFastUpdate.ts
@@ -38,35 +38,37 @@ test('a removal from a time-based lockfile skips resolution and writes what a re
   const fastUpdated = project.readLockfile()
   expect(Object.keys(fastUpdated.time)).toStrictEqual(['@pnpm.e2e/bravo@1.0.0'])
 
-  // The same removal, resolved rather than rewritten: the two lockfiles have
-  // to agree, or the fast path writes something the resolver never would.
-  const baseline = await resolveTheSameRemoval()
-  expect(fastUpdated).toStrictEqual(baseline)
+  expect(fastUpdated).toStrictEqual(await resolveTheSameRemoval())
 })
 
+/** The same removal a resolution away, in its own project. */
 async function resolveTheSameRemoval (): Promise<unknown> {
   const previousCwd = process.cwd()
-  const project = prepareEmpty()
-  const manifest: ProjectManifest = {
-    dependencies: {
-      '@pnpm.e2e/bravo': '1.0.0',
-      '@pnpm.e2e/romeo': '1.0.0',
-    },
+  try {
+    const project = prepareEmpty()
+    const manifest: ProjectManifest = {
+      dependencies: {
+        '@pnpm.e2e/bravo': '1.0.0',
+        '@pnpm.e2e/romeo': '1.0.0',
+      },
+    }
+    await mutateModulesInSingleProject({
+      manifest,
+      mutation: 'install',
+      rootDir: process.cwd() as ProjectRootDir,
+    }, testDefaults({ resolutionMode: 'time-based' }))
+    await mutateModulesInSingleProject({
+      dependencyNames: ['@pnpm.e2e/romeo'],
+      manifest,
+      mutation: 'uninstallSome',
+      rootDir: process.cwd() as ProjectRootDir,
+    }, testDefaults({ resolutionMode: 'time-based', forceFullResolution: true }))
+    return project.readLockfile()
+  } finally {
+    // `prepareEmpty` moves the process into the new project, so a throw
+    // here would otherwise leave every later test in this worker there.
+    process.chdir(previousCwd)
   }
-  await mutateModulesInSingleProject({
-    manifest,
-    mutation: 'install',
-    rootDir: process.cwd() as ProjectRootDir,
-  }, testDefaults({ resolutionMode: 'time-based' }))
-  await mutateModulesInSingleProject({
-    dependencyNames: ['@pnpm.e2e/romeo'],
-    manifest,
-    mutation: 'uninstallSome',
-    rootDir: process.cwd() as ProjectRootDir,
-  }, testDefaults({ resolutionMode: 'time-based', forceFullResolution: true }))
-  const baseline = project.readLockfile()
-  process.chdir(previousCwd)
-  return baseline
 }
 
 function trackRequestedPackages (storeController: StoreController): string[] {

--- a/pnpm11/installing/deps-installer/test/install/timeFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/timeFastUpdate.ts
@@ -1,0 +1,80 @@
+import { expect, test } from '@jest/globals'
+import { mutateModulesInSingleProject } from '@pnpm/installing.deps-installer'
+import { prepareEmpty } from '@pnpm/prepare'
+import type { StoreController } from '@pnpm/store.controller-types'
+import type { ProjectManifest, ProjectRootDir } from '@pnpm/types'
+
+import { testDefaults } from '../utils/index.js'
+
+test('a removal from a time-based lockfile skips resolution and writes what a resolution would', async () => {
+  const project = prepareEmpty()
+  const manifest: ProjectManifest = {
+    dependencies: {
+      '@pnpm.e2e/bravo': '1.0.0',
+      '@pnpm.e2e/romeo': '1.0.0',
+    },
+  }
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, testDefaults({ resolutionMode: 'time-based' }))
+  const installed = project.readLockfile()
+  expect(Object.keys(installed.time).sort()).toStrictEqual([
+    '@pnpm.e2e/bravo@1.0.0',
+    '@pnpm.e2e/romeo@1.0.0',
+  ])
+
+  const options = testDefaults({ resolutionMode: 'time-based' })
+  const requestedPackages = trackRequestedPackages(options.storeController)
+  await mutateModulesInSingleProject({
+    dependencyNames: ['@pnpm.e2e/romeo'],
+    manifest,
+    mutation: 'uninstallSome',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, options)
+
+  expect(requestedPackages).toStrictEqual([])
+  const fastUpdated = project.readLockfile()
+  expect(Object.keys(fastUpdated.time)).toStrictEqual(['@pnpm.e2e/bravo@1.0.0'])
+
+  // The same removal, resolved rather than rewritten: the two lockfiles have
+  // to agree, or the fast path writes something the resolver never would.
+  const baseline = await resolveTheSameRemoval()
+  expect(fastUpdated).toStrictEqual(baseline)
+})
+
+async function resolveTheSameRemoval (): Promise<unknown> {
+  const previousCwd = process.cwd()
+  const project = prepareEmpty()
+  const manifest: ProjectManifest = {
+    dependencies: {
+      '@pnpm.e2e/bravo': '1.0.0',
+      '@pnpm.e2e/romeo': '1.0.0',
+    },
+  }
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, testDefaults({ resolutionMode: 'time-based' }))
+  await mutateModulesInSingleProject({
+    dependencyNames: ['@pnpm.e2e/romeo'],
+    manifest,
+    mutation: 'uninstallSome',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, testDefaults({ resolutionMode: 'time-based', forceFullResolution: true }))
+  const baseline = project.readLockfile()
+  process.chdir(previousCwd)
+  return baseline
+}
+
+function trackRequestedPackages (storeController: StoreController): string[] {
+  const requestedPackages: string[] = []
+  const requestPackage = storeController.requestPackage
+  storeController.requestPackage = async (wantedDependency, requestOptions) => {
+    requestedPackages.push(wantedDependency.alias!)
+    return requestPackage(wantedDependency, requestOptions)
+  }
+  return requestedPackages
+}


### PR DESCRIPTION
## Summary

Item 8 of pnpm/pnpm#13696 — the issue asked whether the `ctx.wantedLockfile.time == null` bail is still necessary. Answer: not for the rewrites that introduce no new version.

`time` records publish dates for the importers' *direct* dependencies, and `pruneTimeInLockfile` prunes it back to exactly those every time the lockfile is written. So a removal's now-stale entries are dropped by the writer — the handlers need no maintenance of the field at all. The regression test proves this rather than asserting it: it runs the same removal twice, once through the fast path and once with `forceFullResolution`, and requires the two lockfiles to be deep-equal (they are, `time` section included). Break-tested by restoring the old gate, which makes it fail.

The bail is kept for the resolver-consulting rewrites (`catalogs`, `overrides`). Those introduce versions whose publish dates only a resolution can record, and I could not construct a case where that path actually fired, so there is no evidence either way — narrowing rather than removing keeps the change to what is demonstrated.

**No pacquet mirror.** pacquet has no `time` field on its `Lockfile` at all, so it has nothing to gate on. That is not a fast-path difference but a bug in its own right, which this investigation surfaced: pacquet silently drops the `time:` section when it rewrites a lockfile, and because pnpm's resolver falls back to those recorded dates when a registry's abbreviated metadata omits publish times, the loss can change which subdependency versions a later time-based resolution picks. Filed as pnpm/pnpm#13776 with a reproduction.

## Squash Commit Body

```text
The fast paths bailed on any lockfile carrying a time field. That was
unnecessary for the rewrites that introduce no new version: time
records publish dates for the importers' direct dependencies, and
pruneTimeInLockfile prunes it back to exactly those on every write, so
a removal's stale entries are dropped by the writer rather than needing
maintenance in the handlers. A removal on a time-based lockfile now
produces a file byte-identical to the one a full resolution writes,
which the new test asserts by running the same removal both ways.

The bail stays for the resolver-consulting rewrites (catalogs,
overrides): those introduce versions whose publish dates only a
resolution can record, and no evidence was gathered either way.

pacquet needs no mirror: it does not model the time field at all,
which is its own bug (pnpm/pnpm#13776) rather than a fast-path
difference.

Item 8 of pnpm/pnpm#13696.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788975768&installation_model_id=426870&pr_number=13777&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13777&signature=db2f6cb8143f34e30d81f42e5b98a1b6a179287f6506761ae1108ea769e01b06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Projects using time-based resolution can now update lockfiles faster for dependency removals, dependency-group moves, and compatible range changes.
  * Catalog and override updates can proceed efficiently even when lockfile timing metadata is unavailable.

* **Bug Fixes**
  * Avoided unnecessary full dependency resolution during eligible lockfile updates.
  * Improved consistency by ensuring fast updates produce the same results as full resolution.
  * Dependency removals now update only the intended dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->