### PR TITLE
fix: reuse the version resolution would dedupe onto for a changed range

### DIFF
--- a/.changeset/locked-version-reuse.md
+++ b/.changeset/locked-version-reuse.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.deps-installer": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+Widening a dependency's range no longer leaves the project on an older version. The lockfile update now points the project at the highest version of that dependency already in the lockfile that satisfies the new range — matching what a full resolution records — instead of keeping the locked version whenever it happened to satisfy, which could leave a duplicate behind. A range change that only an already-locked version satisfies is now also handled without re-resolving [#13778](https://github.com/pnpm/pnpm/issues/13778).

--- a/pnpm/crates/package-manager/src/fast_update_importers.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers.rs
@@ -1,7 +1,8 @@
 use crate::{fast_update_compose::Drift, fast_update_lockfile::GraphEdits};
-use node_semver::Range;
+use node_semver::{Range, Version};
 use pacquet_lockfile::{
-    Lockfile, PkgName, ProjectSnapshot, ResolvedDependencyMap, ResolvedDependencySpec,
+    ImporterDepVersion, Lockfile, PackageKey, PkgName, ProjectSnapshot, ResolvedDependencyMap,
+    ResolvedDependencySpec,
 };
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use std::collections::{HashMap, HashSet};
@@ -62,6 +63,7 @@ pub(crate) fn apply_importers_update(
     plan: &ImportersPlan<'_, '_>,
     edits: &mut GraphEdits,
 ) -> bool {
+    let packages = candidate.packages.clone().unwrap_or_default();
     for (importer_id, manifest_dependencies) in &plan.manifest_dependencies {
         let Some(importer) = candidate.importers.get_mut(importer_id.as_str()) else {
             return false;
@@ -70,17 +72,34 @@ pub(crate) fn apply_importers_update(
             let Some(dependency) = importer_dependency_mut(importer, alias) else {
                 return false;
             };
-            if dependency.specifier != *specifier {
+            let specifier_changed = dependency.specifier != *specifier;
+            if specifier_changed {
                 let Ok(range) = Range::parse(specifier) else {
                     return false;
                 };
-                let Some(version) =
-                    dependency.version.ver_peer().and_then(|ver_peer| ver_peer.version_semver())
+                let Some(ver_peer) = dependency.version.ver_peer() else {
+                    return false;
+                };
+                let Some(version) = ver_peer.version_semver() else {
+                    return false;
+                };
+                let Some(wanted) = highest_locked_version_satisfying(&packages, alias, &range)
                 else {
                     return false;
                 };
-                if !version.satisfies(&range) {
-                    return false;
+                if wanted != *version {
+                    // The alias moves to a version the lockfile already
+                    // holds, so its subtree is already recorded. The one it
+                    // leaves may now be unreachable, which the shared
+                    // epilogue prunes.
+                    if ver_peer.peer() != "" {
+                        return false;
+                    }
+                    let Ok(moved) = wanted.to_string().parse() else {
+                        return false;
+                    };
+                    dependency.version = ImporterDepVersion::Regular(moved);
+                    edits.dropped.insert(alias.clone());
                 }
                 dependency.specifier = (*specifier).to_string();
             }
@@ -92,6 +111,39 @@ pub(crate) fn apply_importers_update(
         edits.dropped.extend(remove_dependencies_absent_from(importer, manifest_dependencies));
     }
     true
+}
+
+/// The version resolution would settle on for `alias` under `range`: the
+/// highest version of it the lockfile already holds that satisfies the
+/// range.
+///
+/// Resolution prefers a version already in the graph over a higher one
+/// from the registry, so reusing what is present is what it would
+/// record — for a widened range as much as for one the locked version
+/// cannot satisfy at all.
+///
+/// `None` when nothing present satisfies (only the resolver can fetch a
+/// new version), or when a candidate exists under several peer-suffixed
+/// keys, where picking one of them would be a guess.
+fn highest_locked_version_satisfying(
+    packages: &HashMap<PackageKey, pacquet_lockfile::PackageMetadata>,
+    alias: &PkgName,
+    range: &Range,
+) -> Option<Version> {
+    let mut highest: Option<Version> = None;
+    for key in packages.keys() {
+        if &key.name != alias {
+            continue;
+        }
+        if !key.suffix.peer().is_empty() {
+            return None;
+        }
+        let Some(version) = key.suffix.version_semver() else { continue };
+        if version.satisfies(range) && highest.as_ref().is_none_or(|best| version > best) {
+            highest = Some(version.clone());
+        }
+    }
+    highest
 }
 
 /// Whether the importer's record differs from the manifest in a way the

--- a/pnpm/crates/package-manager/src/fast_update_importers.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers.rs
@@ -63,9 +63,9 @@ pub(crate) fn apply_importers_update(
     plan: &ImportersPlan<'_, '_>,
     edits: &mut GraphEdits,
 ) -> bool {
-    let packages = candidate.packages.clone().unwrap_or_default();
+    let Lockfile { packages, importers, .. } = candidate;
     for (importer_id, manifest_dependencies) in &plan.manifest_dependencies {
-        let Some(importer) = candidate.importers.get_mut(importer_id.as_str()) else {
+        let Some(importer) = importers.get_mut(importer_id.as_str()) else {
             return false;
         };
         for (alias, (specifier, target)) in manifest_dependencies {
@@ -83,15 +83,14 @@ pub(crate) fn apply_importers_update(
                 let Some(version) = ver_peer.version_semver() else {
                     return false;
                 };
-                let Some(wanted) = highest_locked_version_satisfying(&packages, alias, &range)
+                let Some(wanted) =
+                    highest_locked_version_satisfying(packages.as_ref(), alias, &range)
                 else {
                     return false;
                 };
                 if wanted != *version {
-                    // The alias moves to a version the lockfile already
-                    // holds, so its subtree is already recorded. The one it
-                    // leaves may now be unreachable, which the shared
-                    // epilogue prunes.
+                    // Safe without resolving because the target version is
+                    // already in the lockfile, subtree and all.
                     if ver_peer.peer() != "" {
                         return false;
                     }
@@ -126,12 +125,12 @@ pub(crate) fn apply_importers_update(
 /// new version), or when a candidate exists under several peer-suffixed
 /// keys, where picking one of them would be a guess.
 fn highest_locked_version_satisfying(
-    packages: &HashMap<PackageKey, pacquet_lockfile::PackageMetadata>,
+    packages: Option<&HashMap<PackageKey, pacquet_lockfile::PackageMetadata>>,
     alias: &PkgName,
     range: &Range,
 ) -> Option<Version> {
     let mut highest: Option<Version> = None;
-    for key in packages.keys() {
+    for key in packages?.keys() {
         if &key.name != alias {
             continue;
         }

--- a/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
@@ -757,3 +757,17 @@ fn rejects_a_range_no_locked_version_satisfies() {
         "only the resolver can fetch a version the lockfile does not hold",
     );
 }
+
+#[test]
+fn rejects_a_higher_version_that_exists_only_under_a_named_registry() {
+    let mut subject = parsed_lockfile(WITH_TWO_LOCKED_VERSIONS);
+    let packages = subject.packages.as_mut().expect("packages");
+    let higher = packages.remove(&"foo@1.2.0".parse().expect("package key")).expect("foo@1.2.0");
+    packages.insert("foo@work:1.2.0".parse().expect("package key"), higher);
+    let manifest = manifest_from(json!({ "dependencies": { "foo": "^1.1.0" } }));
+
+    assert!(
+        try_fast_update_importers(&subject, &[(".".to_string(), &manifest)]).is_none(),
+        "a registry-qualified key's semver only pins a version inside that registry",
+    );
+}

--- a/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
@@ -719,7 +719,7 @@ fn moves_a_widened_range_to_the_higher_version_another_importer_locks() {
     assert_eq!(
         packages,
         vec!["foo@1.2.0".to_string()],
-        "the version it left is unreachable and goes"
+        "the version it left is unreachable and goes",
     );
 }
 

--- a/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
@@ -668,3 +668,92 @@ fn rejects_a_dependency_the_lockfile_does_not_record() {
         "an added dependency needs the resolver",
     );
 }
+
+/// Two importers hold different versions of `foo`; the registry also has
+/// a higher 1.3.0 that nothing locks.
+const WITH_TWO_LOCKED_VERSIONS: &str = r"
+lockfileVersion: '9.0'
+importers:
+  .:
+    dependencies:
+      foo:
+        specifier: 1.0.0
+        version: 1.0.0
+  pkg-a:
+    dependencies:
+      foo:
+        specifier: 1.2.0
+        version: 1.2.0
+packages:
+  foo@1.0.0:
+    resolution:
+      integrity: sha512-foo-1
+  foo@1.2.0:
+    resolution:
+      integrity: sha512-foo-2
+snapshots:
+  foo@1.0.0: {}
+  foo@1.2.0: {}
+";
+
+#[test]
+fn moves_a_widened_range_to_the_higher_version_another_importer_locks() {
+    let manifest = manifest_from(json!({ "dependencies": { "foo": "^1.1.0" } }));
+    let other = manifest_from(json!({ "dependencies": { "foo": "1.2.0" } }));
+
+    let updated = try_fast_update_importers(
+        &parsed_lockfile(WITH_TWO_LOCKED_VERSIONS),
+        &[(".".to_string(), &manifest), ("pkg-a".to_string(), &other)],
+    )
+    .expect("the version is already in the lockfile, so nothing needs resolving");
+
+    let alias: PkgName = "foo".parse().expect("alias");
+    let recorded = &updated.importers["."].dependencies.as_ref().expect("dependencies")[&alias];
+    assert_eq!(
+        (recorded.specifier.as_str(), recorded.version.to_string().as_str()),
+        ("^1.1.0", "1.2.0"),
+    );
+    let mut packages: Vec<_> =
+        updated.packages.as_ref().expect("packages").keys().map(ToString::to_string).collect();
+    packages.sort();
+    assert_eq!(
+        packages,
+        vec!["foo@1.2.0".to_string()],
+        "the version it left is unreachable and goes"
+    );
+}
+
+#[test]
+fn moves_to_a_higher_locked_version_even_when_the_locked_one_still_satisfies() {
+    let manifest = manifest_from(json!({ "dependencies": { "foo": ">=1.0.0" } }));
+    let other = manifest_from(json!({ "dependencies": { "foo": "1.2.0" } }));
+
+    let updated = try_fast_update_importers(
+        &parsed_lockfile(WITH_TWO_LOCKED_VERSIONS),
+        &[(".".to_string(), &manifest), ("pkg-a".to_string(), &other)],
+    )
+    .expect("resolution would dedupe onto the higher locked version");
+
+    let alias: PkgName = "foo".parse().expect("alias");
+    assert_eq!(
+        updated.importers["."].dependencies.as_ref().expect("dependencies")[&alias]
+            .version
+            .to_string(),
+        "1.2.0",
+    );
+}
+
+#[test]
+fn rejects_a_range_no_locked_version_satisfies() {
+    let manifest = manifest_from(json!({ "dependencies": { "foo": "^2.0.0" } }));
+    let other = manifest_from(json!({ "dependencies": { "foo": "1.2.0" } }));
+
+    assert!(
+        try_fast_update_importers(
+            &parsed_lockfile(WITH_TWO_LOCKED_VERSIONS),
+            &[(".".to_string(), &manifest), ("pkg-a".to_string(), &other)],
+        )
+        .is_none(),
+        "only the resolver can fetch a version the lockfile does not hold",
+    );
+}

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
@@ -55,9 +55,8 @@ export function tryFastUpdateImporters (
         const wanted = highestLockedVersionSatisfying(lockfile, alias, specifier)
         if (wanted == null) return false
         if (wanted !== version) {
-          // The alias moves to a version the lockfile already holds, so its
-          // subtree is already recorded. The old one may now be unreachable,
-          // which the shared epilogue prunes.
+          // Safe without resolving because the target version is already in
+          // the lockfile, subtree and all.
           if (reference !== version) return false
           importer[recordedIn!]![alias] = wanted
           edits.dropped.add(alias)
@@ -107,8 +106,10 @@ export function tryFastUpdateImporters (
  * widened range as much as for one the locked version cannot satisfy at all.
  *
  * `null` when nothing present satisfies (only the resolver can fetch a new
- * version), or when a candidate exists under several peer-suffixed keys,
- * where picking one of them would be a guess.
+ * version), or when the alias appears under a key this cannot turn back
+ * into a plain importer reference: a peer-suffixed one, where picking a
+ * variant would be a guess, or a registry-qualified one, whose semver only
+ * pins a version within its named registry.
  */
 function highestLockedVersionSatisfying (
   lockfile: LockfileObject,
@@ -117,9 +118,10 @@ function highestLockedVersionSatisfying (
 ): string | null {
   const versions = new Set<string>()
   for (const [depPath, snapshot] of Object.entries(lockfile.packages ?? {})) {
-    const { name, version, nonSemverVersion } = nameVerFromPkgSnapshot(depPath, snapshot)
-    if (name !== alias || nonSemverVersion != null) continue
-    if (dp.parseDepPath(depPath).peerDepGraphHash !== '') return null
+    const { name, version, nonSemverVersion, registryName } = nameVerFromPkgSnapshot(depPath, snapshot)
+    if (name !== alias) continue
+    if (nonSemverVersion != null) continue
+    if (registryName != null || dp.parseDepPath(depPath).peerDepGraphHash !== '') return null
     if (semver.valid(version) != null && semver.satisfies(version, specifier)) {
       versions.add(version)
     }

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
@@ -1,5 +1,6 @@
 import * as dp from '@pnpm/deps.path'
 import type { LockfileObject, ProjectSnapshot } from '@pnpm/lockfile.types'
+import { nameVerFromPkgSnapshot } from '@pnpm/lockfile.utils'
 import { DEPENDENCIES_FIELDS, type DependenciesField, type ProjectId, type ProjectManifest } from '@pnpm/types'
 import semver from 'semver'
 
@@ -45,18 +46,21 @@ export function tryFastUpdateImporters (
     const manifestSpecifiers = getManifestSpecifiers(project.manifest)
     for (const [alias, specifier] of Object.entries(manifestSpecifiers)) {
       if (importer.specifiers[alias] !== specifier) {
-        const reference =
-          importer.optionalDependencies?.[alias] ??
-          importer.dependencies?.[alias] ??
-          importer.devDependencies?.[alias]
+        const recordedIn = recordedDependencyGroup(importer, alias)
+        const reference = recordedIn == null ? undefined : importer[recordedIn]![alias]
         const version = reference == null ? null : dp.removeSuffix(reference)
-        if (
-          semver.validRange(specifier) == null ||
-          version == null ||
-          semver.valid(version) == null ||
-          !semver.satisfies(version, specifier)
-        ) {
+        if (semver.validRange(specifier) == null || version == null || semver.valid(version) == null) {
           return false
+        }
+        const wanted = highestLockedVersionSatisfying(lockfile, alias, specifier)
+        if (wanted == null) return false
+        if (wanted !== version) {
+          // The alias moves to a version the lockfile already holds, so its
+          // subtree is already recorded. The old one may now be unreachable,
+          // which the shared epilogue prunes.
+          if (reference !== version) return false
+          importer[recordedIn!]![alias] = wanted
+          edits.dropped.add(alias)
         }
         importer.specifiers[alias] = specifier
         changed = true
@@ -92,6 +96,36 @@ export function tryFastUpdateImporters (
     }
   }
   return changed
+}
+
+/**
+ * The version resolution would settle on for `alias` under `specifier`: the
+ * highest version of it the lockfile already holds that satisfies the range.
+ *
+ * Resolution prefers a version already in the graph over a higher one from
+ * the registry, so reusing what is present is what it would record — for a
+ * widened range as much as for one the locked version cannot satisfy at all.
+ *
+ * `null` when nothing present satisfies (only the resolver can fetch a new
+ * version), or when a candidate exists under several peer-suffixed keys,
+ * where picking one of them would be a guess.
+ */
+function highestLockedVersionSatisfying (
+  lockfile: LockfileObject,
+  alias: string,
+  specifier: string
+): string | null {
+  const versions = new Set<string>()
+  for (const [depPath, snapshot] of Object.entries(lockfile.packages ?? {})) {
+    const { name, version, nonSemverVersion } = nameVerFromPkgSnapshot(depPath, snapshot)
+    if (name !== alias || nonSemverVersion != null) continue
+    if (dp.parseDepPath(depPath).peerDepGraphHash !== '') return null
+    if (semver.valid(version) != null && semver.satisfies(version, specifier)) {
+      versions.add(version)
+    }
+  }
+  if (versions.size === 0) return null
+  return [...versions].sort(semver.rcompare)[0]
 }
 
 function dependencyGroupMoved (

--- a/pnpm11/installing/deps-installer/test/install/lockedVersionReuse.ts
+++ b/pnpm11/installing/deps-installer/test/install/lockedVersionReuse.ts
@@ -4,11 +4,13 @@ import { expect, test } from '@jest/globals'
 import { WANTED_LOCKFILE } from '@pnpm/constants'
 import { mutateModules } from '@pnpm/installing.deps-installer'
 import type { LockfileObject } from '@pnpm/lockfile.fs'
+import type { LockfileObject as LockfileTypesObject } from '@pnpm/lockfile.types'
 import { preparePackages } from '@pnpm/prepare'
 import type { StoreController } from '@pnpm/store.controller-types'
-import type { ProjectId, ProjectRootDir } from '@pnpm/types'
+import type { DepPath, ProjectId, ProjectManifest, ProjectRootDir } from '@pnpm/types'
 import { readYamlFileSync } from 'read-yaml-file'
 
+import { tryComposeFastUpdates } from '../../src/install/tryComposeFastUpdates.js'
 import { testDefaults } from '../utils/index.js'
 
 test('a widened range moves to the higher version another importer already locks', async () => {
@@ -111,4 +113,49 @@ function trackRequestedPackages (storeController: StoreController): string[] {
     return requestPackage(wantedDependency, requestOptions)
   }
   return requestedPackages
+}
+
+test('a higher version that exists only under a named registry falls back', () => {
+  // A registry-qualified key's semver only pins a version inside that named
+  // registry, so it cannot become a plain importer reference.
+  const subject = lockfileWithHigherVersionKeyedAs('@pnpm.e2e/foo@work:1.2.0' as DepPath)
+
+  expect(tryComposeFastUpdates(subject, {
+    drift: { importers: true },
+    projects: [{
+      id: '.' as ProjectId,
+      manifest: { dependencies: { '@pnpm.e2e/foo': '^1.1.0' } } as ProjectManifest,
+    }],
+  })).toBe(false)
+})
+
+test('a higher version under a plain key is reused', () => {
+  const subject = lockfileWithHigherVersionKeyedAs('@pnpm.e2e/foo@1.2.0' as DepPath)
+
+  expect(tryComposeFastUpdates(subject, {
+    drift: { importers: true },
+    projects: [{
+      id: '.' as ProjectId,
+      manifest: { dependencies: { '@pnpm.e2e/foo': '^1.1.0' } } as ProjectManifest,
+    }],
+  })).toBe(true)
+  expect(subject.importers['.' as ProjectId].dependencies).toStrictEqual({
+    '@pnpm.e2e/foo': '1.2.0',
+  })
+})
+
+function lockfileWithHigherVersionKeyedAs (higher: DepPath): LockfileTypesObject {
+  return {
+    lockfileVersion: '9.0',
+    importers: {
+      ['.' as ProjectId]: {
+        specifiers: { '@pnpm.e2e/foo': '1.0.0' },
+        dependencies: { '@pnpm.e2e/foo': '1.0.0' },
+      },
+    },
+    packages: {
+      ['@pnpm.e2e/foo@1.0.0' as DepPath]: { resolution: { integrity: 'sha512-foo-1' } },
+      [higher]: { resolution: { integrity: 'sha512-foo-2' } },
+    },
+  }
 }

--- a/pnpm11/installing/deps-installer/test/install/lockedVersionReuse.ts
+++ b/pnpm11/installing/deps-installer/test/install/lockedVersionReuse.ts
@@ -1,0 +1,114 @@
+import path from 'node:path'
+
+import { expect, test } from '@jest/globals'
+import { WANTED_LOCKFILE } from '@pnpm/constants'
+import { mutateModules } from '@pnpm/installing.deps-installer'
+import type { LockfileObject } from '@pnpm/lockfile.fs'
+import { preparePackages } from '@pnpm/prepare'
+import type { StoreController } from '@pnpm/store.controller-types'
+import type { ProjectId, ProjectRootDir } from '@pnpm/types'
+import { readYamlFileSync } from 'read-yaml-file'
+
+import { testDefaults } from '../utils/index.js'
+
+test('a widened range moves to the higher version another importer already locks', async () => {
+  const { install, readLockfile } = prepareWorkspace([
+    { name: 'project-1', dependencies: { '@pnpm.e2e/foo': '1.0.0' } },
+    { name: 'project-2', dependencies: { '@pnpm.e2e/foo': '1.2.0' } },
+  ])
+  await install()
+
+  const requestedPackages = await install([
+    { name: 'project-1', dependencies: { '@pnpm.e2e/foo': '^1.1.0' } },
+    { name: 'project-2', dependencies: { '@pnpm.e2e/foo': '1.2.0' } },
+  ])
+
+  expect(requestedPackages).toStrictEqual([])
+  const lockfile = readLockfile()
+  expect(lockfile.importers['project-1' as ProjectId].dependencies).toStrictEqual({
+    '@pnpm.e2e/foo': { specifier: '^1.1.0', version: '1.2.0' },
+  })
+  expect(Object.keys(lockfile.packages ?? {})).toStrictEqual(['@pnpm.e2e/foo@1.2.0'])
+})
+
+test('a widened range the locked version still satisfies moves to the higher locked version', async () => {
+  const { install, readLockfile } = prepareWorkspace([
+    { name: 'project-1', dependencies: { '@pnpm.e2e/foo': '100.0.0' } },
+    { name: 'project-2', dependencies: { '@pnpm.e2e/has-foo-100.1.0-dep-2': '1.0.0' } },
+  ])
+  await install()
+  expect(Object.keys(readLockfile().packages ?? {}).filter(isFoo)).toStrictEqual([
+    '@pnpm.e2e/foo@100.0.0',
+    '@pnpm.e2e/foo@100.1.0',
+  ])
+
+  const requestedPackages = await install([
+    { name: 'project-1', dependencies: { '@pnpm.e2e/foo': '>=100.0.0' } },
+    { name: 'project-2', dependencies: { '@pnpm.e2e/has-foo-100.1.0-dep-2': '1.0.0' } },
+  ])
+
+  expect(requestedPackages).toStrictEqual([])
+  const lockfile = readLockfile()
+  expect(lockfile.importers['project-1' as ProjectId].dependencies).toStrictEqual({
+    '@pnpm.e2e/foo': { specifier: '>=100.0.0', version: '100.1.0' },
+  })
+  expect(Object.keys(lockfile.packages ?? {}).filter(isFoo)).toStrictEqual(['@pnpm.e2e/foo@100.1.0'])
+})
+
+test('a range no locked version satisfies falls back to the resolver', async () => {
+  const { install, readLockfile } = prepareWorkspace([
+    { name: 'project-1', dependencies: { '@pnpm.e2e/foo': '1.0.0' } },
+    { name: 'project-2', dependencies: { '@pnpm.e2e/foo': '1.2.0' } },
+  ])
+  await install()
+
+  const requestedPackages = await install([
+    { name: 'project-1', dependencies: { '@pnpm.e2e/foo': '2.0.0' } },
+    { name: 'project-2', dependencies: { '@pnpm.e2e/foo': '1.2.0' } },
+  ])
+
+  expect(requestedPackages).not.toStrictEqual([])
+  expect(readLockfile().importers['project-1' as ProjectId].dependencies).toStrictEqual({
+    '@pnpm.e2e/foo': { specifier: '2.0.0', version: '2.0.0' },
+  })
+})
+
+function isFoo (depPath: string): boolean {
+  return depPath.startsWith('@pnpm.e2e/foo@')
+}
+
+interface WorkspaceProject {
+  name: string
+  dependencies: Record<string, string>
+}
+
+function prepareWorkspace (initial: WorkspaceProject[]) {
+  preparePackages(initial.map(({ name }) => ({ location: name, package: { name } })))
+  const mutation = initial.map(({ name }) => ({
+    mutation: 'install' as const,
+    rootDir: path.resolve(name) as ProjectRootDir,
+  }))
+  const install = async (projects: WorkspaceProject[] = initial): Promise<string[]> => {
+    const options = testDefaults({
+      allProjects: projects.map(({ name, dependencies }) => ({
+        buildIndex: 0,
+        manifest: { name, version: '1.0.0', dependencies },
+        rootDir: path.resolve(name) as ProjectRootDir,
+      })),
+    })
+    const requestedPackages = trackRequestedPackages(options.storeController)
+    await mutateModules(mutation, options)
+    return requestedPackages
+  }
+  return { install, readLockfile: () => readYamlFileSync<LockfileObject>(WANTED_LOCKFILE) }
+}
+
+function trackRequestedPackages (storeController: StoreController): string[] {
+  const requestedPackages: string[] = []
+  const requestPackage = storeController.requestPackage
+  storeController.requestPackage = async (wantedDependency, requestOptions) => {
+    requestedPackages.push(wantedDependency.alias!)
+    return requestPackage(wantedDependency, requestOptions)
+  }
+  return requestedPackages
+}


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#13778. Item 4 of pnpm/pnpm#13696.

Item 4 asked for a range change to reuse a version already in the lockfile instead of resolving. Establishing that the resolver actually behaves that way turned up a bug in the shipped fast path, and both turn out to be the same rule.

**What resolution actually does** (measured, not assumed — three probes against the real resolver):

| setup | new range | resolution picks |
| --- | --- | --- |
| sibling locks `foo@1.2.0`, registry has `1.3.0` | `^1.1.0` | **1.2.0** — a locked version beats a higher published one |
| siblings lock `1.1.0` and `1.2.0` | `^1.1.0` | **1.2.0** — the highest locked satisfying version |
| `foo@100.1.0` present only as a transitive dep, importer locks `100.0.0` | `>=100.0.0` | **100.1.0**, and `100.0.0` is pruned |

`preferredVersions` makes the resolver dedupe onto what the graph already holds. The fast path asked a different question — "does the locked version satisfy?" — and kept it whenever it did. The third row is where that diverges: the fast path leaves the importer on `100.0.0` **and** keeps a duplicate `foo` the resolver would have collapsed. That is pnpm/pnpm#13778, present since the original fast-update work, not introduced here.

**The fix, in both stacks:** pick the highest version of the alias already in the lockfile that satisfies the new range, and let the shared epilogue prune whatever the move orphans. That repairs the widening case and closes item 4 (a range only an already-present version satisfies) in one rule. Bails kept for a candidate that exists under peer-suffixed keys — choosing one would be a guess — and for anything that is not plain semver.

Tested at install level in TypeScript (all three rows, asserting zero `requestPackage` calls, plus a fall-back case where nothing present satisfies) and as unit tests in pacquet.

## Squash Commit Body

```text
The importers fast update asked whether the locked version satisfies
the new range and kept it when it did. Resolution asks a different
question: preferredVersions makes it reuse the highest version of that
alias already in the graph, which beats picking the highest published
one. The two answers differ whenever some other importer or transitive
dependency already holds a higher satisfying version, so widening a
range through the fast path left the importer behind and kept a
duplicate the resolver would have collapsed.

Both stacks now pick the highest already-locked satisfying version,
letting the shared epilogue prune whatever the move orphans. That also
covers a range the locked version cannot satisfy at all but a present
one can, which no longer falls back to the resolver.

Bails kept for a candidate under peer-suffixed keys (the choice would
be a guess) and for anything that is not plain semver.

Closes pnpm/pnpm#13778. Item 4 of pnpm/pnpm#13696.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13779"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788976666&installation_model_id=426870&pr_number=13779&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13779&signature=82530f8c8b8fe91ce9764760e74ed4a1bc9ac0dc488371521cb2e2c550bb43f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency updates to reuse the highest compatible version already recorded in the lockfile.
  * Prevented duplicate locked versions when widening dependency ranges.
  * Correctly handles ranges satisfied only by existing locked versions without unnecessary re-resolution.
  * Removes outdated, unreachable dependency entries during updates.
  * Falls back to resolution when no compatible locked version is available.
  * Avoids reusing ambiguous peer- or registry-qualified package entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->