### PR TITLE
fix(deps-restorer): retire a project link `dedupeDirectDeps` makes redundant

### DIFF
--- a/.changeset/dedupe-removes-redundant-project-links.md
+++ b/.changeset/dedupe-removes-redundant-project-links.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+With `dedupeDirectDeps`, a project's symlink that becomes redundant — because the workspace root started providing the same dependency at the same resolution — is removed on the next install instead of surviving forever [#13775](https://github.com/pnpm/pnpm/issues/13775). The layout no longer depends on install history: an incremental install now ends up with the same `node_modules` a clean install of the same manifests produces.

--- a/pnpm/crates/cli/tests/suite/dedupe_direct_deps.rs
+++ b/pnpm/crates/cli/tests/suite/dedupe_direct_deps.rs
@@ -416,10 +416,9 @@ fn dedupes_only_overlapping_direct_deps() {
     drop((root, mock_instance));
 }
 
-/// A dedupe decision must not depend on install history: once the
-/// root acquires the dep a sibling already had linked, the sibling's
-/// now-redundant link is removed on the next install, leaving the same
-/// layout a clean install of these manifests produces.
+/// The dedupe decision must not depend on install history: two
+/// incremental installs land on the layout a clean install of the same
+/// manifests produces (pnpm/pnpm#13775).
 #[test]
 fn removes_a_project_link_the_root_starts_providing() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
@@ -461,7 +460,6 @@ fn removes_a_project_link_the_root_starts_providing() {
 
     pacquet.with_arg("install").assert().success();
 
-    // Nothing to dedupe against yet, so the project owns the link.
     let dup_link = workspace.join("packages/dup/node_modules/@pnpm.e2e/hello-world-js-bin");
     let dup_link_linked = is_symlink_or_junction(&dup_link).expect("query dup symlink");
     eprintln!("dup_link={dup_link:?} linked={dup_link_linked}");

--- a/pnpm/crates/cli/tests/suite/dedupe_direct_deps.rs
+++ b/pnpm/crates/cli/tests/suite/dedupe_direct_deps.rs
@@ -426,16 +426,28 @@ fn removes_a_project_link_the_root_starts_providing() {
     let AddMockedRegistry { mock_instance, .. } = npmrc_info;
 
     let root_manifest_path = workspace.join("package.json");
-    fs::write(
-        &root_manifest_path,
-        serde_json::json!({
-            "name": "ws-root",
-            "version": "0.0.0",
-            "private": true,
-        })
-        .to_string(),
-    )
-    .expect("write root package.json");
+    let write_root_manifest = |dependencies: serde_json::Value| {
+        fs::write(
+            &root_manifest_path,
+            serde_json::json!({
+                "name": "ws-root",
+                "version": "0.0.0",
+                "private": true,
+                "dependencies": dependencies,
+            })
+            .to_string(),
+        )
+        .expect("write root package.json");
+    };
+    // `Path::exists` follows the link, so a leftover whose target the
+    // install also pruned would read as absent — stat the entry itself.
+    let assert_absent = |path: &Path, what: &str| match fs::symlink_metadata(path) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Ok(metadata) => panic!("{what} survived at {path:?} ({:?})", metadata.file_type()),
+        Err(error) => panic!("stat {path:?}: {error}"),
+    };
+
+    write_root_manifest(serde_json::json!({}));
 
     let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
     let mut workspace_yaml =
@@ -467,35 +479,24 @@ fn removes_a_project_link_the_root_starts_providing() {
     let dup_bin = workspace.join("packages/dup/node_modules/.bin/hello-world-js-bin");
     assert!(dup_bin.exists(), "project bin shim missing at {dup_bin:?} before dedupe");
 
-    fs::write(
-        &root_manifest_path,
-        serde_json::json!({
-            "name": "ws-root",
-            "version": "0.0.0",
-            "private": true,
-            "dependencies": { "@pnpm.e2e/hello-world-js-bin": "1.0.0" },
-        })
-        .to_string(),
-    )
-    .expect("rewrite root package.json");
-
+    write_root_manifest(serde_json::json!({ "@pnpm.e2e/hello-world-js-bin": "1.0.0" }));
     pacquet_at(&workspace).with_arg("install").assert().success();
 
     let root_link = workspace.join("node_modules/@pnpm.e2e/hello-world-js-bin");
     let root_link_linked = is_symlink_or_junction(&root_link).expect("query root symlink");
     eprintln!("root_link={root_link:?} linked={root_link_linked}");
     assert!(root_link_linked, "root node_modules direct-dep symlink missing");
+    assert_absent(&dup_link, "the project link the root made redundant");
+    assert_absent(&dup_bin, "the deduped dep's bin shim");
 
-    let dup_link_exists = dup_link.exists();
-    eprintln!("dup_link={dup_link:?} exists={dup_link_exists}");
-    assert!(
-        !dup_link_exists,
-        "the project link became redundant once the root declared the same resolution, but \
-         {dup_link:?} survived",
-    );
-    let dup_bin_exists = dup_bin.exists();
-    eprintln!("dup_bin={dup_bin:?} exists={dup_bin_exists}");
-    assert!(!dup_bin_exists, "the deduped dep's bin shim survived at {dup_bin:?}");
+    // Dropping the root's declaration hands the dep back to the project.
+    write_root_manifest(serde_json::json!({}));
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    let dup_link_relinked = is_symlink_or_junction(&dup_link).expect("query relinked dup symlink");
+    eprintln!("dup_link={dup_link:?} linked={dup_link_relinked}");
+    assert!(dup_link_relinked, "project direct-dep symlink not restored at {dup_link:?}");
+    assert!(dup_bin.exists(), "project bin shim not restored at {dup_bin:?}");
 
     drop((root, mock_instance));
 }

--- a/pnpm/crates/cli/tests/suite/dedupe_direct_deps.rs
+++ b/pnpm/crates/cli/tests/suite/dedupe_direct_deps.rs
@@ -12,6 +12,9 @@
 //! per-project symlink — is covered by
 //! [`dedupe_off_by_default_keeps_shared_workspace_link`].
 
+use crate::_utils;
+
+use _utils::append_workspace_yaml_key;
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pacquet_testing_utils::{
@@ -449,14 +452,8 @@ fn removes_a_project_link_the_root_starts_providing() {
 
     write_root_manifest(serde_json::json!({}));
 
-    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
-    let mut workspace_yaml =
-        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
-    if !workspace_yaml.ends_with('\n') {
-        workspace_yaml.push('\n');
-    }
-    workspace_yaml.push_str("packages:\n  - 'packages/*'\ndedupeDirectDeps: true\n");
-    fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
+    append_workspace_yaml_key(&workspace, "packages", "['packages/*']");
+    append_workspace_yaml_key(&workspace, "dedupeDirectDeps", true);
 
     fs::create_dir_all(workspace.join("packages/dup")).expect("mkdir packages/dup");
     fs::write(
@@ -780,14 +777,8 @@ fn relative_link_payloads_survive_the_dedupe_prune() {
     )
     .expect("write root package.json");
 
-    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
-    let mut workspace_yaml =
-        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
-    if !workspace_yaml.ends_with('\n') {
-        workspace_yaml.push('\n');
-    }
-    workspace_yaml.push_str("packages:\n  - 'packages/*'\ndedupeDirectDeps: true\n");
-    fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
+    append_workspace_yaml_key(&workspace, "packages", "['packages/*']");
+    append_workspace_yaml_key(&workspace, "dedupeDirectDeps", true);
 
     fs::create_dir_all(workspace.join("vendor/x")).expect("mkdir vendor/x");
     fs::write(

--- a/pnpm/crates/cli/tests/suite/dedupe_direct_deps.rs
+++ b/pnpm/crates/cli/tests/suite/dedupe_direct_deps.rs
@@ -756,3 +756,79 @@ fn dedupe_under_shamefully_hoist() {
 
     drop((root, mock_instance));
 }
+
+/// `link:` payloads are stored relative to their own importer, so two
+/// importers can spell the same string while resolving to different
+/// directories. The prune's version-string dedupe fires on the pair
+/// anyway; the relink behind it is what keeps the importer pointing at
+/// its own target.
+#[test]
+fn relative_link_payloads_survive_the_dedupe_prune() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "name": "ws-root",
+            "version": "0.0.0",
+            "private": true,
+            "dependencies": { "x": "link:vendor/x" },
+        })
+        .to_string(),
+    )
+    .expect("write root package.json");
+
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    if !workspace_yaml.ends_with('\n') {
+        workspace_yaml.push('\n');
+    }
+    workspace_yaml.push_str("packages:\n  - 'packages/*'\ndedupeDirectDeps: true\n");
+    fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
+
+    fs::create_dir_all(workspace.join("vendor/x")).expect("mkdir vendor/x");
+    fs::write(
+        workspace.join("vendor/x/package.json"),
+        serde_json::json!({ "name": "@scope/root-x", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write vendor/x/package.json");
+
+    fs::create_dir_all(workspace.join("packages/app/vendor/x")).expect("mkdir app vendor/x");
+    fs::write(
+        workspace.join("packages/app/vendor/x/package.json"),
+        serde_json::json!({ "name": "@scope/app-x", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write app vendor/x/package.json");
+    fs::write(
+        workspace.join("packages/app/package.json"),
+        serde_json::json!({
+            "name": "@scope/app",
+            "version": "1.0.0",
+            "dependencies": { "x": "link:vendor/x" },
+        })
+        .to_string(),
+    )
+    .expect("write packages/app/package.json");
+
+    pacquet.with_arg("install").assert().success();
+    // The second install is the one that prunes: only then does a
+    // current lockfile record the importer's link.
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    let app_link = workspace.join("packages/app/node_modules/x");
+    let app_link_linked = is_symlink_or_junction(&app_link).expect("query app symlink");
+    eprintln!("app_link={app_link:?} linked={app_link_linked}");
+    assert!(app_link_linked, "app's link must survive at {app_link:?}");
+    let linked_manifest =
+        fs::read_to_string(app_link.join("package.json")).expect("read the linked manifest");
+    eprintln!("linked_manifest={linked_manifest}");
+    assert!(
+        linked_manifest.contains("@scope/app-x"),
+        "app's `link:vendor/x` must resolve to its own vendor/x, not the root's",
+    );
+
+    drop((root, mock_instance));
+}

--- a/pnpm/crates/cli/tests/suite/dedupe_direct_deps.rs
+++ b/pnpm/crates/cli/tests/suite/dedupe_direct_deps.rs
@@ -416,6 +416,92 @@ fn dedupes_only_overlapping_direct_deps() {
     drop((root, mock_instance));
 }
 
+/// A dedupe decision must not depend on install history: once the
+/// root acquires the dep a sibling already had linked, the sibling's
+/// now-redundant link is removed on the next install, leaving the same
+/// layout a clean install of these manifests produces.
+#[test]
+fn removes_a_project_link_the_root_starts_providing() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let root_manifest_path = workspace.join("package.json");
+    fs::write(
+        &root_manifest_path,
+        serde_json::json!({
+            "name": "ws-root",
+            "version": "0.0.0",
+            "private": true,
+        })
+        .to_string(),
+    )
+    .expect("write root package.json");
+
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    if !workspace_yaml.ends_with('\n') {
+        workspace_yaml.push('\n');
+    }
+    workspace_yaml.push_str("packages:\n  - 'packages/*'\ndedupeDirectDeps: true\n");
+    fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
+
+    fs::create_dir_all(workspace.join("packages/dup")).expect("mkdir packages/dup");
+    fs::write(
+        workspace.join("packages/dup/package.json"),
+        serde_json::json!({
+            "name": "@scope/dup",
+            "version": "1.0.0",
+            "dependencies": { "@pnpm.e2e/hello-world-js-bin": "1.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write packages/dup/package.json");
+
+    pacquet.with_arg("install").assert().success();
+
+    // Nothing to dedupe against yet, so the project owns the link.
+    let dup_link = workspace.join("packages/dup/node_modules/@pnpm.e2e/hello-world-js-bin");
+    let dup_link_linked = is_symlink_or_junction(&dup_link).expect("query dup symlink");
+    eprintln!("dup_link={dup_link:?} linked={dup_link_linked}");
+    assert!(dup_link_linked, "project direct-dep symlink missing before the root declares it");
+    let dup_bin = workspace.join("packages/dup/node_modules/.bin/hello-world-js-bin");
+    assert!(dup_bin.exists(), "project bin shim missing at {dup_bin:?} before dedupe");
+
+    fs::write(
+        &root_manifest_path,
+        serde_json::json!({
+            "name": "ws-root",
+            "version": "0.0.0",
+            "private": true,
+            "dependencies": { "@pnpm.e2e/hello-world-js-bin": "1.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("rewrite root package.json");
+
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    let root_link = workspace.join("node_modules/@pnpm.e2e/hello-world-js-bin");
+    let root_link_linked = is_symlink_or_junction(&root_link).expect("query root symlink");
+    eprintln!("root_link={root_link:?} linked={root_link_linked}");
+    assert!(root_link_linked, "root node_modules direct-dep symlink missing");
+
+    let dup_link_exists = dup_link.exists();
+    eprintln!("dup_link={dup_link:?} exists={dup_link_exists}");
+    assert!(
+        !dup_link_exists,
+        "the project link became redundant once the root declared the same resolution, but \
+         {dup_link:?} survived",
+    );
+    let dup_bin_exists = dup_bin.exists();
+    eprintln!("dup_bin={dup_bin:?} exists={dup_bin_exists}");
+    assert!(!dup_bin_exists, "the deduped dep's bin shim survived at {dup_bin:?}");
+
+    drop((root, mock_instance));
+}
+
 /// Two `link:` deps that resolve to the same physical directory via
 /// different relative paths must still dedupe. Pnpm's dedupe runs
 /// `path.relative` on stored symlink targets — which Node normalises

--- a/pnpm/crates/deps-restorer/src/prune_stale_modules.rs
+++ b/pnpm/crates/deps-restorer/src/prune_stale_modules.rs
@@ -1,7 +1,8 @@
 //! Reconcile an existing `node_modules` with the wanted lockfile before
 //! linking: the port of the removal half of pnpm's `modules-cleaner`
 //! `prune`. Removes direct-dependency links (and their bin shims) the
-//! wanted lockfile no longer records, unlinks hoisted aliases whose
+//! wanted lockfile no longer records — or, under `dedupeDirectDeps`, that
+//! the workspace root now provides — unlinks hoisted aliases whose
 //! owner snapshot disappeared, and emits the `pnpm:root` `removed` and
 //! `pnpm:stats` `removed` events pnpm emits from the same spot. Runs
 //! before the link passes so a follow-up hoist can claim the vacated
@@ -86,6 +87,22 @@ impl PruneStaleModules<'_> {
         let modules_dir_name: &OsStr =
             config.modules_dir.file_name().unwrap_or_else(|| OsStr::new("node_modules"));
 
+        // `dedupeDirectDeps`'s removal half. The link pass only decides
+        // which links to *create*, so a sibling's link that an earlier
+        // install legitimately created has to be retired here once the
+        // root starts providing the same resolution — otherwise the
+        // layout would depend on install history rather than on the
+        // manifests. Pnpm folds the same condition into this diff.
+        let wanted_root_deps: Option<HashMap<&PkgName, &ImporterDepVersion>> =
+            config.dedupe_direct_deps.then(|| wanted_lockfile.importers.get(".")).flatten().map(
+                |root_snapshot| {
+                    direct_deps_of(root_snapshot, included_groups)
+                        .into_iter()
+                        .map(|(alias, spec, _)| (alias, &spec.version))
+                        .collect()
+                },
+            );
+
         for (importer_id, current_snapshot) in &current_lockfile.importers {
             // An importer the wanted lockfile doesn't cover was not
             // re-materialized; leave its links alone (the partial
@@ -102,12 +119,19 @@ impl PruneStaleModules<'_> {
                 continue;
             };
             let wanted_specs = direct_deps_of(wanted_snapshot, included_groups);
+            // Root is what the others dedupe *against*; it keeps every
+            // link the wanted lockfile still records.
+            let dedupe_against_root =
+                (importer_id != ".").then_some(wanted_root_deps.as_ref()).flatten();
             let prefix = importer_dir.display().to_string();
             for (alias, current_spec, group) in direct_deps_of(current_snapshot, &RECORDED_GROUPS) {
-                if wanted_specs
+                let still_wanted = wanted_specs
                     .iter()
-                    .any(|(name, spec, _)| *name == alias && spec.version == current_spec.version)
-                {
+                    .any(|(name, spec, _)| *name == alias && spec.version == current_spec.version);
+                let deduped_by_root = dedupe_against_root.is_some_and(|root_deps| {
+                    root_deps.get(alias).is_some_and(|version| **version == current_spec.version)
+                });
+                if still_wanted && !deduped_by_root {
                     continue;
                 }
                 remove_direct_dep_link(&modules_dir, &alias.to_string())?;


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Closes pnpm/pnpm#13775.

With `dedupeDirectDeps: true`, a project's direct-dependency symlink that becomes
redundant — because the workspace root later starts providing the same dependency
at the same resolution — was never removed. `dedupeDirectDeps` was only consulted
when *creating* links (`SymlinkDirectDependencies`), so a link an earlier install
legitimately wrote survived every subsequent install, and the on-disk layout
depended on install history rather than on the manifests. A clean install of the
same manifests produced a different tree.

The removal half lives in the prune pass. `PruneStaleModules` already diffs each
importer's current direct deps against the wanted lockfile; it now also drops a
non-root importer's entry whose alias the wanted root importer resolves to the
same version — the same condition pnpm's `modules-cleaner` prune folds into that
diff:

```ts
opts.dedupeDirectDeps && id !== '.' && wantedPkgs[depName] === wantedRootPkgs[depName]
```

Removal goes through the existing `remove_direct_dep_link`, so the dep's bin
shims are retired with it, and a `pnpm:root removed` event fires as for any other
pruned link. Over-removal stays self-healing: everything the install still wants
is re-linked by `SymlinkDirectDependencies` right after.

This is a Rust-only fix. The behavior is a pacquet regression against pnpm 10 and
11 — the TypeScript CLI already applies this condition, so there is nothing to
mirror.

Note on the remaining gap (pre-existing, present in **both** stacks): the
comparison is on lockfile version strings, so it does not fire for `link:`
workspace deps whose root and importer entries spell the same directory
differently (`link:packages/shared` vs `link:../shared`). Link-time dedupe
compares resolved paths and *does* catch those, so a `link:` dep that becomes
redundant still leaves a stale link in pnpm 10/11/12 alike. Fixing that means
resolving `link:` targets in both prunes; out of scope here, happy to follow up.

## Squash Commit Body

```text
`dedupeDirectDeps` only decided which direct-dependency links to create,
never which existing ones to retire. Once the workspace root started
providing a dependency a project already had linked, that project's
now-redundant symlink survived every later install, so the on-disk layout
depended on install history rather than on the manifests.

The prune pass now folds the same root comparison pnpm's `modules-cleaner`
prune applies into its diff, so an incremental install converges on the
layout a clean install of the same manifests produces.

Closes pnpm/pnpm#13775
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5[1m]).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788977287&installation_model_id=426870&pr_number=13780&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13780&signature=e9f63114cea84fe897c90a2f9251128da171acb20e947f35d2f4761c1959163f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed redundant dependency links and command shims when the workspace root provides the same dependency and version.
  * Ensured clean and incremental installs produce consistent dependency layouts.
  * Preserved valid project-specific links and restored them when the root dependency is removed.
  * Improved handling of importer-relative links during dependency cleanup.

* **Tests**
  * Added regression coverage for repeated installs, deduplication, links, and command shims.

* **Documentation**
  * Documented the updated dependency cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->