### PR TITLE
fix(cli): restore CI frozen lockfile default

### DIFF
--- a/.changeset/ci-frozen-lockfile-default.md
+++ b/.changeset/ci-frozen-lockfile-default.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `pnpm install` in CI to use frozen lockfile mode by default when an existing `pnpm-lock.yaml` is non-empty. An outdated lockfile now fails without being rewritten, while projects without a lockfile or with an empty lockfile can still generate one.

--- a/.github/workflows/pacquet-codecov.yml
+++ b/.github/workflows/pacquet-codecov.yml
@@ -107,7 +107,7 @@ jobs:
           unset PNPM_HOME
           unset XDG_DATA_HOME
 
-          cargo codecov --lcov --output-path lcov.info
+          env PNPM_CONFIG_CI=false cargo codecov --lcov --output-path lcov.info
 
       - name: Report disk usage
         if: always()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4107,6 +4107,7 @@ dependencies = [
  "derive_more",
  "home",
  "indexmap 2.14.0",
+ "is_ci",
  "libc",
  "miette 7.6.0",
  "node-semver",

--- a/justfile
+++ b/justfile
@@ -51,7 +51,8 @@ check:
 
 # Run all the tests.
 test:
-  cargo nextest run
+  # Tests opt into CI-sensitive pnpm defaults explicitly.
+  env PNPM_CONFIG_CI=false cargo nextest run
 
 # A test process that is killed cannot run `TempDir`'s cleanup, so a
 # fail-fast or interrupted run abandons whole fixture trees — each holding a
@@ -67,7 +68,8 @@ sweep-test-temp:
 
 # Run pacquet package tests only.
 test-pacquet:
-  cargo nextest run --workspace --exclude pnpr --exclude pnpr-fixtures
+  # GitHub Actions sets CI=true; keep lockfile-mutating tests deterministic.
+  env PNPM_CONFIG_CI=false cargo nextest run --workspace --exclude pnpr --exclude pnpr-fixtures
 
 # Run pnpr package tests only.
 test-pnpr:

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -94,7 +94,8 @@ pub struct InstallArgs {
     #[clap(flatten)]
     pub supported_architectures: SupportedArchitecturesArgs,
 
-    /// Don't generate a lockfile, and fail if an update to it is needed.
+    /// Don't generate a lockfile, and fail if an update to it is needed. This
+    /// setting is enabled by default in CI when a lockfile is present.
     #[clap(long, overrides_with = "no_frozen_lockfile")]
     pub frozen_lockfile: bool,
 
@@ -387,11 +388,17 @@ impl InstallArgs {
     /// `--frozen-lockfile` / `--no-frozen-lockfile` layered over the
     /// `frozenLockfile` setting.
     pub(crate) fn effective_frozen_lockfile(&self, config: &pacquet_config::Config) -> bool {
-        resolve_bool_override(
-            self.frozen_lockfile,
-            self.no_frozen_lockfile,
-            config.frozen_lockfile.unwrap_or(false),
-        )
+        self.configured_frozen_lockfile(config).unwrap_or(false)
+    }
+
+    fn configured_frozen_lockfile(&self, config: &pacquet_config::Config) -> Option<bool> {
+        if self.frozen_lockfile {
+            Some(true)
+        } else if self.no_frozen_lockfile {
+            Some(false)
+        } else {
+            config.frozen_lockfile
+        }
     }
 
     pub async fn run<Reporter: self::Reporter + 'static>(self, state: State) -> miette::Result<()> {
@@ -411,9 +418,20 @@ impl InstallArgs {
         state: State,
         selection: Option<InstallFamilySelection>,
     ) -> miette::Result<()> {
+        let frozen_lockfile = match self.configured_frozen_lockfile(state.config) {
+            Some(value) => value,
+            None if state.config.ci
+                && !self.lockfile_only
+                && !self.prefer_frozen_lockfile
+                && !self.no_prefer_frozen_lockfile
+                && !state.config.explicit_settings.contains_key("preferFrozenLockfile") =>
+            {
+                state.lockfile.get()?.is_some_and(|lockfile| !lockfile.is_empty())
+            }
+            None => false,
+        };
         let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
             &state;
-        let frozen_lockfile = self.effective_frozen_lockfile(config);
         let InstallArgs {
             dependency_options,
             supported_architectures,

--- a/pnpm/crates/cli/src/config_deps.rs
+++ b/pnpm/crates/cli/src/config_deps.rs
@@ -509,6 +509,7 @@ pub async fn run_update_config_hooks<Reporter: self::Reporter>(
         return Ok(());
     }
     let changed_store_dir = delta.get("storeDir").and_then(Value::as_str).map(str::to_owned);
+    let changed_prefer_frozen_lockfile = delta.get("preferFrozenLockfile").cloned();
     let changed_virtual_store_dir = delta.get("virtualStoreDir").cloned();
     let changed_global_virtual_store_dir = delta.get("globalVirtualStoreDir").cloned();
     let virtual_store_dir_cleared = changed_virtual_store_dir.as_ref().is_some_and(Value::is_null);
@@ -541,6 +542,7 @@ pub async fn run_update_config_hooks<Reporter: self::Reporter>(
         config.virtual_store_dir = base_dir.join("node_modules/.pnpm");
     }
     for (key, value) in [
+        ("preferFrozenLockfile", changed_prefer_frozen_lockfile),
         ("virtualStoreDir", changed_virtual_store_dir),
         ("globalVirtualStoreDir", changed_global_virtual_store_dir),
     ] {

--- a/pnpm/crates/cli/src/config_deps/tests.rs
+++ b/pnpm/crates/cli/src/config_deps/tests.rs
@@ -6,6 +6,36 @@ use pacquet_reporter::SilentReporter;
 use super::{resolve_pnpm_version, run_update_config_hooks};
 
 #[tokio::test]
+async fn update_config_records_prefer_frozen_lockfile_as_explicit() {
+    for prefer_value in [true, false] {
+        let root = tempfile::tempdir().expect("workspace tempdir");
+        fs::write(root.path().join("pnpm-workspace.yaml"), "\n").expect("write workspace settings");
+        fs::write(
+            root.path().join(".pnpmfile.cjs"),
+            format!(
+                "module.exports = {{ hooks: {{ updateConfig (config) {{ config.preferFrozenLockfile = {prefer_value}; return config }} }} }}",
+            ),
+        )
+        .expect("write pnpmfile");
+        let mut config =
+            Config::default().current::<Host>(root.path()).expect("load configuration");
+
+        run_update_config_hooks::<SilentReporter>(&mut config, root.path())
+            .await
+            .expect("run updateConfig hook");
+
+        assert_eq!(config.prefer_frozen_lockfile, prefer_value);
+        assert_eq!(
+            config
+                .explicit_settings
+                .get("preferFrozenLockfile")
+                .and_then(serde_json::Value::as_bool),
+            Some(prefer_value),
+        );
+    }
+}
+
+#[tokio::test]
 async fn update_config_null_clears_virtual_store_dir() {
     let root = tempfile::tempdir().expect("workspace tempdir");
     fs::write(root.path().join("pnpm-workspace.yaml"), "virtualStoreDir: pinned-virtual\n")

--- a/pnpm/crates/cli/tests/suite/catalog.rs
+++ b/pnpm/crates/cli/tests/suite/catalog.rs
@@ -403,7 +403,7 @@ fn install_reruns_when_catalog_entry_changes() {
     )
     .expect("rewrite pnpm-workspace.yaml catalog entry");
 
-    run_ok(&workspace, &["install"]);
+    run_ok(&workspace, &["install", "--no-frozen-lockfile"]);
     assert_eq!(catalog_snapshot(&workspace, FOO), ("2.0.0".to_string(), "2.0.0".to_string()));
 
     drop((root, anchor));

--- a/pnpm/crates/cli/tests/suite/ci_frozen_lockfile.rs
+++ b/pnpm/crates/cli/tests/suite/ci_frozen_lockfile.rs
@@ -1,0 +1,279 @@
+use crate::_utils::pacquet_in;
+
+use assert_cmd::prelude::*;
+use std::{fs, path::Path, process::Command};
+use tempfile::{TempDir, tempdir};
+
+const OUTDATED_LOCKFILE: &str = "lockfileVersion: '9.0'\nimporters:\n  .:\n    dependencies:\n      old-dependency:\n        specifier: file:dependency\n        version: link:dependency\n";
+const EMPTY_LOCKFILE: &str = "lockfileVersion: '9.0'\nimporters:\n  .: {}\n";
+
+fn pacquet_in_ci(workspace: &Path) -> Command {
+    let mut command = pacquet_without_ci(workspace);
+    command.env("CI", "true");
+    command
+}
+
+fn pacquet_in_github_actions(workspace: &Path) -> Command {
+    let mut command = pacquet_without_ci(workspace);
+    command.env("GITHUB_ACTIONS", "true");
+    command
+}
+
+fn pacquet_without_ci(workspace: &Path) -> Command {
+    let mut command = pacquet_in(workspace);
+    command
+        .env_remove("PNPM_CONFIG_CI")
+        .env_remove("CI")
+        .env_remove("GITHUB_ACTION")
+        .env_remove("GITHUB_ACTIONS");
+    command
+}
+
+fn outdated_lockfile_project() -> TempDir {
+    let root = tempdir().expect("create temp directory");
+    let workspace = root.path();
+    let dependency_dir = workspace.join("dependency");
+    fs::create_dir(&dependency_dir).expect("create local dependency directory");
+    fs::write(
+        dependency_dir.join("package.json"),
+        serde_json::json!({ "name": "local-dependency", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write local dependency manifest");
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "dependencies": { "local-dependency": "file:dependency" } })
+            .to_string(),
+    )
+    .expect("write project manifest");
+    fs::write(workspace.join("pnpm-lock.yaml"), OUTDATED_LOCKFILE).expect("write stale lockfile");
+    root
+}
+
+fn assert_lockfile_was_updated(workspace: &Path) {
+    let lockfile =
+        fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read lockfile after install");
+    assert_ne!(lockfile, OUTDATED_LOCKFILE);
+    assert!(
+        lockfile.contains("local-dependency"),
+        "updated lockfile must contain the local dependency; got:\n{lockfile}",
+    );
+}
+
+#[test]
+fn ci_rejects_an_outdated_lockfile_by_default() {
+    for command_in_ci in [pacquet_in_ci, pacquet_in_github_actions] {
+        let root = outdated_lockfile_project();
+        let workspace = root.path();
+        let lockfile_path = workspace.join("pnpm-lock.yaml");
+
+        let assert = command_in_ci(workspace).arg("install").assert().failure();
+        let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+        eprintln!("STDERR:\n{stderr}\n");
+        assert!(
+            stderr.contains("ERR_PNPM_OUTDATED_LOCKFILE"),
+            "CI install must report the outdated lockfile; got:\n{stderr}",
+        );
+        assert_eq!(
+            fs::read_to_string(lockfile_path).expect("read lockfile after failed install"),
+            OUTDATED_LOCKFILE,
+        );
+    }
+
+    let root = outdated_lockfile_project();
+    let workspace = root.path();
+    pacquet_in(workspace)
+        .env("CI", "true")
+        .env("PNPM_CONFIG_CI", "false")
+        .arg("install")
+        .assert()
+        .success();
+}
+
+#[test]
+fn ci_values_enable_the_default_in_github_actions() {
+    for ci_value in ["1", "true"] {
+        let root = outdated_lockfile_project();
+        let workspace = root.path();
+
+        let assert = pacquet_without_ci(workspace)
+            .env("CI", ci_value)
+            .env("GITHUB_ACTIONS", "true")
+            .arg("install")
+            .assert()
+            .failure();
+        let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+        eprintln!("STDERR:\n{stderr}\n");
+        assert!(
+            stderr.contains("ERR_PNPM_OUTDATED_LOCKFILE"),
+            "CI={ci_value} in GitHub Actions must report the outdated lockfile; got:\n{stderr}",
+        );
+    }
+}
+
+#[test]
+fn ci_false_disables_the_default_in_github_actions() {
+    let root = outdated_lockfile_project();
+    let workspace = root.path();
+
+    pacquet_without_ci(workspace)
+        .env("CI", "false")
+        .env("GITHUB_ACTIONS", "true")
+        .arg("install")
+        .assert()
+        .success();
+
+    assert_lockfile_was_updated(workspace);
+}
+
+#[test]
+fn workspace_manifest_cannot_disable_ci_detection() {
+    let root = outdated_lockfile_project();
+    let workspace = root.path();
+    fs::write(workspace.join("pnpm-workspace.yaml"), "ci: false\n")
+        .expect("write workspace manifest");
+
+    let assert = pacquet_in_ci(workspace).arg("install").assert().failure();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("ERR_PNPM_OUTDATED_LOCKFILE"),
+        "workspace ci:false must not disable CI detection; got:\n{stderr}",
+    );
+    assert_eq!(
+        fs::read_to_string(workspace.join("pnpm-lock.yaml"))
+            .expect("read lockfile after failed install"),
+        OUTDATED_LOCKFILE,
+    );
+}
+
+#[test]
+fn ci_honors_explicit_prefer_frozen_lockfile_values() {
+    for prefer_arg in ["--prefer-frozen-lockfile", "--no-prefer-frozen-lockfile"] {
+        let root = outdated_lockfile_project();
+        let workspace = root.path();
+
+        pacquet_in_ci(workspace).args(["install", prefer_arg]).assert().success();
+
+        assert_lockfile_was_updated(workspace);
+    }
+}
+
+#[test]
+fn ci_honors_configured_prefer_frozen_lockfile_values() {
+    for prefer_value in ["true", "false"] {
+        let root = outdated_lockfile_project();
+        let workspace = root.path();
+
+        pacquet_in_ci(workspace)
+            .env("PNPM_CONFIG_PREFER_FROZEN_LOCKFILE", prefer_value)
+            .arg("install")
+            .assert()
+            .success();
+
+        assert_lockfile_was_updated(workspace);
+    }
+}
+
+#[test]
+fn ci_honors_pnpmfile_prefer_frozen_lockfile_values() {
+    for prefer_value in [true, false] {
+        let root = outdated_lockfile_project();
+        let workspace = root.path();
+        fs::write(
+            workspace.join(".pnpmfile.cjs"),
+            format!(
+                "module.exports = {{ hooks: {{ updateConfig (config) {{ config.preferFrozenLockfile = {prefer_value}; return config }} }} }}",
+            ),
+        )
+        .expect("write updateConfig hook");
+
+        pacquet_in_ci(workspace).arg("install").assert().success();
+
+        assert_lockfile_was_updated(workspace);
+    }
+}
+
+#[test]
+fn explicit_frozen_lockfile_values_take_priority_over_prefer_flags() {
+    for prefer_arg in ["--prefer-frozen-lockfile", "--no-prefer-frozen-lockfile"] {
+        let frozen_root = outdated_lockfile_project();
+        let frozen_workspace = frozen_root.path();
+        let assert = pacquet_in_ci(frozen_workspace)
+            .args(["install", prefer_arg, "--frozen-lockfile"])
+            .assert()
+            .failure();
+        let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+        assert!(stderr.contains("ERR_PNPM_OUTDATED_LOCKFILE"), "got:\n{stderr}");
+        assert_eq!(
+            fs::read_to_string(frozen_workspace.join("pnpm-lock.yaml"))
+                .expect("read lockfile after failed install"),
+            OUTDATED_LOCKFILE,
+        );
+
+        let mutable_root = outdated_lockfile_project();
+        let mutable_workspace = mutable_root.path();
+        pacquet_in_ci(mutable_workspace)
+            .args(["install", prefer_arg, "--no-frozen-lockfile"])
+            .assert()
+            .success();
+        assert_lockfile_was_updated(mutable_workspace);
+    }
+}
+
+#[test]
+fn configured_frozen_lockfile_values_take_priority_over_prefer_flags() {
+    for prefer_arg in ["--prefer-frozen-lockfile", "--no-prefer-frozen-lockfile"] {
+        let frozen_root = outdated_lockfile_project();
+        let frozen_workspace = frozen_root.path();
+        let assert = pacquet_in_ci(frozen_workspace)
+            .env("PNPM_CONFIG_FROZEN_LOCKFILE", "true")
+            .args(["install", prefer_arg])
+            .assert()
+            .failure();
+        let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+        assert!(stderr.contains("ERR_PNPM_OUTDATED_LOCKFILE"), "got:\n{stderr}");
+        assert_eq!(
+            fs::read_to_string(frozen_workspace.join("pnpm-lock.yaml"))
+                .expect("read lockfile after failed install"),
+            OUTDATED_LOCKFILE,
+        );
+
+        let mutable_root = outdated_lockfile_project();
+        let mutable_workspace = mutable_root.path();
+        pacquet_in_ci(mutable_workspace)
+            .env("PNPM_CONFIG_FROZEN_LOCKFILE", "false")
+            .args(["install", prefer_arg])
+            .assert()
+            .success();
+        assert_lockfile_was_updated(mutable_workspace);
+    }
+}
+
+#[test]
+fn ci_install_without_a_nonempty_lockfile_generates_one() {
+    for create_empty_lockfile in [false, true] {
+        let root = tempdir().expect("create temp directory");
+        let workspace = root.path();
+        fs::write(workspace.join("package.json"), "{}").expect("write project manifest");
+        if create_empty_lockfile {
+            fs::write(workspace.join("pnpm-lock.yaml"), "").expect("write empty lockfile");
+        }
+
+        pacquet_in_ci(workspace).arg("install").assert().success();
+
+        let lockfile =
+            fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read generated lockfile");
+        assert!(!lockfile.is_empty(), "CI install must create a non-empty lockfile");
+    }
+}
+
+#[test]
+fn ci_install_with_a_semantically_empty_lockfile_updates_it() {
+    let root = outdated_lockfile_project();
+    let workspace = root.path();
+    fs::write(workspace.join("pnpm-lock.yaml"), EMPTY_LOCKFILE)
+        .expect("write semantically empty lockfile");
+
+    pacquet_in_ci(workspace).arg("install").assert().success();
+
+    assert_lockfile_was_updated(workspace);
+}

--- a/pnpm/crates/cli/tests/suite/main.rs
+++ b/pnpm/crates/cli/tests/suite/main.rs
@@ -20,6 +20,7 @@ mod cat_file;
 mod cat_index;
 mod catalog;
 mod change;
+mod ci_frozen_lockfile;
 mod clean;
 mod completion;
 mod config_dependencies;

--- a/pnpm/crates/cli/tests/suite/sbom.rs
+++ b/pnpm/crates/cli/tests/suite/sbom.rs
@@ -1,5 +1,6 @@
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
+use pacquet_testing_utils::command_env::CommandTestExt;
 use std::{ffi::OsStr, fs, path::Path, process::Command};
 use tempfile::TempDir;
 
@@ -42,6 +43,8 @@ fn pacquet(workspace: &Path, args: impl IntoIterator<Item = impl AsRef<OsStr>>) 
     Command::cargo_bin("pnpm")
         .expect("find the pnpm binary")
         .with_current_dir(workspace)
+        .without_ambient_pnpm_config()
+        .with_env("PNPM_CONFIG_REGISTRY", "https://registry.npmjs.org/")
         .with_args(args)
 }
 

--- a/pnpm/crates/config/Cargo.toml
+++ b/pnpm/crates/config/Cargo.toml
@@ -26,6 +26,7 @@ pacquet-workspace-state        = { workspace = true }
 derive_more   = { workspace = true }
 home          = { workspace = true }
 indexmap      = { workspace = true }
+is_ci         = { workspace = true }
 miette        = { workspace = true }
 node-semver   = { workspace = true }
 pipe-trait    = { workspace = true }

--- a/pnpm/crates/config/src/env_overlay.rs
+++ b/pnpm/crates/config/src/env_overlay.rs
@@ -135,6 +135,7 @@ impl WorkspaceSettings {
             };
         }
 
+        json_field!(ci, "CI");
         json_field!(hoist, "HOIST");
         tri_array_field!(hoist_pattern, "HOIST_PATTERN");
         tri_array_field!(public_hoist_pattern, "PUBLIC_HOIST_PATTERN");

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -56,6 +56,17 @@ pub use workspace_yaml::{
     WORKSPACE_MANIFEST_FILENAME, WorkspaceSettings, decided_allow_builds, workspace_root_or,
 };
 
+fn default_ci<Sys: EnvVar>() -> bool {
+    let ci = Sys::var("CI");
+    if ci.as_deref() == Some("false") {
+        return false;
+    }
+
+    matches!(ci.as_deref(), Some("true" | "1" | "woodpecker"))
+        || Sys::var("GITHUB_ACTIONS").is_some()
+        || is_ci::cached()
+}
+
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum NodeLinker {
@@ -735,6 +746,12 @@ pub enum PackageImportMethod {
 /// (project-structural settings).
 #[derive(Debug, Clone, SmartDefault)]
 pub struct Config {
+    /// Whether pnpm is running in a continuous-integration environment.
+    /// Defaults to automatic CI detection and may be overridden through
+    /// configuration.
+    #[default(_code = "default_ci::<Host>()")]
+    pub ci: bool,
+
     /// When true, all dependencies are hoisted to `node_modules/.pnpm/node_modules`.
     /// This makes unlisted dependencies accessible to all packages inside `node_modules`.
     #[default = true]
@@ -2683,6 +2700,10 @@ impl Config {
             // writes it) never runs.
             self.workspace_dir = Some(base_dir.clone());
             if let Some(mut settings) = settings {
+                // CI detection is process state. A repository-controlled
+                // manifest must not be able to turn it off; trusted global
+                // config and PNPM_CONFIG_CI are applied in their own layers.
+                settings.ci = None;
                 // `|=` rather than `=` so an `enableGlobalVirtualStore` /
                 // `virtualStoreDir` set in the global `config.yaml` still
                 // counts as "explicitly set" when the workspace yaml

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -56,7 +56,7 @@ pub use workspace_yaml::{
     WORKSPACE_MANIFEST_FILENAME, WorkspaceSettings, decided_allow_builds, workspace_root_or,
 };
 
-fn default_ci<Sys: EnvVar>() -> bool {
+fn default_ci<Sys: EnvVar>(detect_ci: fn() -> bool) -> bool {
     let ci = Sys::var("CI");
     if ci.as_deref() == Some("false") {
         return false;
@@ -64,7 +64,7 @@ fn default_ci<Sys: EnvVar>() -> bool {
 
     matches!(ci.as_deref(), Some("true" | "1" | "woodpecker"))
         || Sys::var("GITHUB_ACTIONS").is_some()
-        || is_ci::cached()
+        || detect_ci()
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -749,7 +749,7 @@ pub struct Config {
     /// Whether pnpm is running in a continuous-integration environment.
     /// Defaults to automatic CI detection and may be overridden through
     /// configuration.
-    #[default(_code = "default_ci::<Host>()")]
+    #[default(_code = "default_ci::<Host>(is_ci::cached)")]
     pub ci: bool,
 
     /// When true, all dependencies are hoisted to `node_modules/.pnpm/node_modules`.

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -77,7 +77,25 @@ fn ci_false_disables_github_actions_detection() {
         }
     }
 
-    assert!(!default_ci::<GithubActionsWithCiFalse>());
+    assert!(!default_ci::<GithubActionsWithCiFalse>(|| true));
+}
+
+#[test]
+fn ci_detection_uses_injected_detector() {
+    struct InjectedCi;
+
+    impl EnvVar for InjectedCi {
+        fn var(_: &str) -> Option<String> {
+            None
+        }
+
+        fn vars() -> Vec<(String, String)> {
+            Vec::new()
+        }
+    }
+
+    assert!(default_ci::<InjectedCi>(|| true));
+    assert!(!default_ci::<InjectedCi>(|| false));
 }
 
 /// `Config::current` requires `Sys: LinkProbe` so the late-stage

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -1,6 +1,6 @@
 use super::{
     Config, EnvVar, EnvVarOs, GetCurrentDir, GetHomeDir, Host, LinkProbe, LoadWorkspaceYamlError,
-    NodeLinker, NodePackageMapType, PackageImportMethod, TrustPolicy, fs,
+    NodeLinker, NodePackageMapType, PackageImportMethod, TrustPolicy, default_ci, fs,
 };
 use crate::defaults::default_store_dir;
 use pacquet_store_dir::StoreDir;
@@ -57,6 +57,27 @@ fn capture_warnings<Func: FnOnce()>(f: Func) -> Vec<String> {
     let subscriber = tracing_subscriber::registry().with(CaptureLayer(messages_clone));
     tracing::subscriber::with_default(subscriber, f);
     Arc::try_unwrap(messages).unwrap().into_inner().unwrap()
+}
+
+#[test]
+fn ci_false_disables_github_actions_detection() {
+    struct GithubActionsWithCiFalse;
+
+    impl EnvVar for GithubActionsWithCiFalse {
+        fn var(name: &str) -> Option<String> {
+            match name {
+                "CI" => Some("false".to_string()),
+                "GITHUB_ACTIONS" => Some("true".to_string()),
+                _ => None,
+            }
+        }
+
+        fn vars() -> Vec<(String, String)> {
+            Vec::new()
+        }
+    }
+
+    assert!(!default_ci::<GithubActionsWithCiFalse>());
 }
 
 /// `Config::current` requires `Sys: LinkProbe` so the late-stage

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -96,6 +96,7 @@ pub fn decided_allow_builds(allow_builds: HashMap<String, AllowBuild>) -> HashMa
 #[derive(Debug, Default, PartialEq, serde::Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct WorkspaceSettings {
+    pub ci: Option<bool>,
     pub hoist: Option<bool>,
 
     /// Tri-state `hoistPattern` — see `deserialize_double_option`.
@@ -1013,7 +1014,7 @@ impl WorkspaceSettings {
         }
 
         apply! {
-            hoist, shamefully_hoist,
+            ci, hoist, shamefully_hoist,
             node_linker, node_experimental_package_map, node_package_map_type,
             symlink, package_import_method, modules_cache_max_age,
             virtual_store_dir_max_length,

--- a/pnpm/crates/deps-restorer/src/install_package_from_registry/tests.rs
+++ b/pnpm/crates/deps-restorer/src/install_package_from_registry/tests.rs
@@ -31,6 +31,7 @@ fn create_config(
     cache_dir: &Path,
 ) -> Config {
     Config {
+        ci: false,
         versioning: Default::default(),
         hoist: false,
         hoist_pattern: None,

--- a/pnpm/crates/testing-utils/src/command_env.rs
+++ b/pnpm/crates/testing-utils/src/command_env.rs
@@ -6,9 +6,9 @@ use std::{ffi::OsString, process::Command};
 /// Test-only additions to [`Command`].
 pub trait CommandTestExt {
     /// Strip the pnpm and npm configuration variables out of the inherited
-    /// environment, so the spawned process is configured only by the
-    /// test's own `.npmrc` / workspace YAML and whatever the caller sets
-    /// afterwards.
+    /// environment, then make the spawned process non-CI by default. The
+    /// process is otherwise configured only by the test's own `.npmrc` /
+    /// workspace YAML and whatever the caller sets afterwards.
     ///
     /// A spawned command inherits this process's environment, and pnpm
     /// reads settings from `PNPM_CONFIG_*` / `pnpm_config_*` as well as
@@ -28,6 +28,7 @@ impl CommandTestExt for Command {
         for name in ambient_pnpm_config_vars() {
             self.env_remove(name);
         }
+        self.env("PNPM_CONFIG_CI", "false");
         self
     }
 }

--- a/pnpm/crates/testing-utils/src/command_env/tests.rs
+++ b/pnpm/crates/testing-utils/src/command_env/tests.rs
@@ -4,6 +4,7 @@ use command_extra::CommandExtra;
 use std::{ffi::OsStr, process::Command};
 
 const SETTING: &str = "PNPM_CONFIG_GLOBAL_SHIMS";
+const CI_SETTING: &str = "PNPM_CONFIG_CI";
 
 #[test]
 fn pnpm_and_npm_settings_match_in_either_spelling() {
@@ -57,6 +58,16 @@ fn an_explicit_value_set_afterwards_survives_the_removal() {
         Some(OsStr::new(r#"{"node":"auto"}"#)),
         "a later `env` should win over the removal",
     );
+}
+
+#[test]
+fn spawned_pnpm_defaults_to_non_ci_after_ambient_config_is_removed() {
+    let guard = EnvGuard::snapshot([CI_SETTING]);
+    guard.set(CI_SETTING, "true");
+
+    let command = Command::new("pnpm").without_ambient_pnpm_config();
+
+    assert_eq!(env_value(&command, CI_SETTING).as_deref(), Some(OsStr::new("false")));
 }
 
 /// What `command` will pass for `name`: `None` once it is removed, `Some`


### PR DESCRIPTION
## Summary

- Restore the Rust CLI default that freezes an existing non-empty `pnpm-lock.yaml` in CI, so an outdated lockfile fails without being rewritten.
- Preserve explicit `frozenLockfile` and `preferFrozenLockfile` choices from CLI flags, trusted configuration, environment variables, and `.pnpmfile.cjs` hooks.
- Recognize `CI=1`, `CI=true`, and GitHub Actions; let explicit `CI=false` opt out, and prevent repository-controlled `pnpm-workspace.yaml` from overriding CI detection.
- Keep missing, byte-empty, and semantically empty lockfiles writable, and isolate CI-sensitive spawned commands in the Rust test workflow.

The TypeScript CLI already has this behavior; this brings the Rust `pnpm/` port back into parity.

Fixes pnpm/pnpm#13760.

### RED / GREEN

- RED: the issue reproducer let CI rewrite an outdated lockfile; `CI=1` did not enable the default; removing the explicit `CI=false` precedence made GitHub Actions freeze the lockfile; and workspace `ci: false` disabled CI detection.
- GREEN: the 11-case integration suite covers the CI default, GitHub Actions, explicit overrides, hook/config values, protected workspace detection, and missing or empty lockfiles.

### Validation

- `cargo nextest run -p pacquet-cli -E 'test(/^ci_frozen_lockfile::/)'` — 11 passed
- `cargo nextest run --locked -p pacquet-config` — 460 passed
- isolated full workspace `cargo nextest run --locked --workspace` — 8,016 passed, 4 skipped
- `cargo check --locked --workspace --all-targets`
- `cargo clippy --locked --workspace --all-targets -- --deny warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --workspace --all-features --quiet`
- `RUSTFLAGS='-D warnings' cargo dylint --all -- --all-targets --workspace`
- `cargo fmt --all -- --check`
- `taplo format --check`
- `typos pnpm pnpr`
- repository pre-push TypeScript compile and lint checks

## Squash Commit Body

```text
Restore the CI default that freezes an existing non-empty lockfile while preserving explicit frozen and prefer-frozen settings from CLI flags, trusted configuration, environment variables, and updateConfig hooks. Detect CI=1, CI=true, and GitHub Actions, honor explicit CI=false, prevent workspace manifests from overriding CI detection, and keep missing or semantically empty lockfiles writable.

Fixes pnpm/pnpm#13760.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] The TypeScript CLI already has the intended behavior; this updates the Rust `pnpm/` port to match it.
- [x] Added a changeset for `pacquet`.
- [x] Added and updated tests.
- [x] Documentation is not needed for this parity bug fix; the changeset contains the user-facing release note.

Written by an agent (OpenAI Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI installations now use frozen lockfile mode by default when a non-empty lockfile is present.
  * Outdated lockfiles fail in CI instead of being rewritten automatically.
  * Empty or missing lockfiles can still be created when appropriate.
  * Frozen lockfile behavior can be overridden through supported command-line or configuration settings.
  * CI detection respects explicit `CI=false` settings and supported CI environments.

* **Bug Fixes**
  * Configuration updates now correctly preserve frozen-lockfile preferences.

* **Tests**
  * Added coverage for CI defaults, overrides, precedence, and lockfile generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
