### PR TITLE
perf: absorb a removed workspace project into the fast lockfile update

### DIFF
--- a/.changeset/removed-importer-fast-update.md
+++ b/.changeset/removed-importer-fast-update.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-installer": patch
+"pnpm": patch
+---
+
+Removing a package from a workspace no longer forces a full re-resolution. The lockfile update drops the departed project's importer entry and prunes whatever only it depended on. A project that is still linked from a surviving project continues to be reported as an error [#13696](https://github.com/pnpm/pnpm/issues/13696).

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -782,8 +782,7 @@ export async function mutateModules (
       !ctx.lockfileHadConflicts &&
       ctx.wantedLockfile.lockfileVersion === LOCKFILE_VERSION &&
       !isEmptyLockfile(ctx.wantedLockfile) &&
-      // An importer the lockfile holds for a project that is gone is drift the
-      // importers handler absorbs, so only a *missing* one blocks the path.
+      // Extra importers are drift the handler absorbs; a missing one is not.
       contextProjects.every((project) => ctx.wantedLockfile.importers[project.id] != null) &&
       // `time` records publish dates for the importers' direct dependencies
       // and is pruned back to them whenever the lockfile is written, so a

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -736,7 +736,7 @@ export async function mutateModules (
     // A changed field nothing can absorb forces a resolution, so the
     // workspace-wide specifier scan would be wasted.
     const hasChangedSpecifiers = (allChangedFieldsAreComposable || changedFieldIsAsync) &&
-      hasChangedProjectSpecifiers(ctx.wantedLockfile, contextProjects)
+      hasChangedProjectSpecifiers(ctx.wantedLockfile, contextProjects, opts.pruneLockfileImporters)
     // The async rewrites (catalogs, overrides) consult the resolver and stay
     // outside the composed pipeline, so they require being the only change.
     const asyncChangedSetting = changedFieldIsAsync && !hasChangedSpecifiers
@@ -782,7 +782,9 @@ export async function mutateModules (
       !ctx.lockfileHadConflicts &&
       ctx.wantedLockfile.lockfileVersion === LOCKFILE_VERSION &&
       !isEmptyLockfile(ctx.wantedLockfile) &&
-      (!opts.pruneLockfileImporters || Object.keys(ctx.wantedLockfile.importers).length === Object.keys(ctx.projects).length) &&
+      // An importer the lockfile holds for a project that is gone is drift the
+      // importers handler absorbs, so only a *missing* one blocks the path.
+      contextProjects.every((project) => ctx.wantedLockfile.importers[project.id] != null) &&
       // `time` records publish dates for the importers' direct dependencies
       // and is pruned back to them whenever the lockfile is written, so a
       // rewrite that introduces no new version needs no maintenance of it.
@@ -842,6 +844,7 @@ export async function mutateModules (
               return tryComposeFastUpdates(candidate, {
                 drift: syncDrift,
                 projects: contextProjects,
+                pruneLockfileImporters: opts.pruneLockfileImporters,
                 ignoredOptionalDependencies: opts.ignoredOptionalDependencies,
                 patchedDependencies: {
                   patchedDependencies,

--- a/pnpm11/installing/deps-installer/src/install/tryComposeFastUpdates.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryComposeFastUpdates.ts
@@ -41,6 +41,8 @@ export interface FastUpdateDrift {
 export interface ComposeFastUpdatesOptions {
   drift: FastUpdateDrift
   projects: Project[]
+  /** Whether importers of removed projects are dropped from the lockfile. */
+  pruneLockfileImporters?: boolean
   ignoredOptionalDependencies?: string[]
   patchedDependencies?: FastPatchedDependenciesUpdateOptions
   settings?: FastSettingsUpdateOptions
@@ -62,7 +64,10 @@ export function tryComposeFastUpdates (
   opts: ComposeFastUpdatesOptions
 ): boolean {
   const edits: GraphEdits = { dropped: new Set(), movedAcrossOptional: false }
-  if (opts.drift.importers && !tryFastUpdateImporters(candidate, opts.projects, edits)) {
+  if (opts.drift.importers && !tryFastUpdateImporters(candidate, {
+    projects: opts.projects,
+    pruneLockfileImporters: opts.pruneLockfileImporters ?? false,
+  }, edits)) {
     return false
   }
   if (opts.drift.ignoredOptionalDependencies) {

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
@@ -1,3 +1,5 @@
+import path from 'node:path'
+
 import * as dp from '@pnpm/deps.path'
 import type { LockfileObject, ProjectSnapshot } from '@pnpm/lockfile.types'
 import { nameVerFromPkgSnapshot } from '@pnpm/lockfile.utils'
@@ -13,8 +15,10 @@ export interface Project {
 
 export function hasChangedProjectSpecifiers (
   lockfile: LockfileObject,
-  projects: Project[]
+  projects: Project[],
+  pruneLockfileImporters: boolean
 ): boolean {
+  if (pruneLockfileImporters && staleImporterIds(lockfile, projects).length > 0) return true
   return projects.some((project) => {
     const importer = lockfile.importers[project.id]
     if (importer == null) return false
@@ -35,10 +39,28 @@ export function hasChangedProjectSpecifiers (
  */
 export function tryFastUpdateImporters (
   lockfile: LockfileObject,
-  projects: Project[],
+  opts: { projects: Project[], pruneLockfileImporters: boolean },
   edits: GraphEdits
 ): boolean {
+  const { projects } = opts
   let changed = false
+  if (opts.pruneLockfileImporters) {
+    const stale = staleImporterIds(lockfile, projects)
+    // A project that is gone while something still links to it is a broken
+    // workspace, which only the resolver may report.
+    if (stale.some((importerId) => isLinkedFromASurvivor(lockfile, importerId, stale))) {
+      return false
+    }
+    for (const importerId of stale) {
+      // The project is gone, so every edge it held goes with it; whatever
+      // that orphans is the shared epilogue's to prune.
+      for (const alias of Object.keys(lockfile.importers[importerId].specifiers)) {
+        edits.dropped.add(alias)
+      }
+      delete lockfile.importers[importerId]
+      changed = true
+    }
+  }
   for (const project of projects) {
     const importer = lockfile.importers[project.id]
     if (importer == null) return false
@@ -128,6 +150,28 @@ function highestLockedVersionSatisfying (
   }
   if (versions.size === 0) return null
   return [...versions].sort(semver.rcompare)[0]
+}
+
+/** Whether an importer that survives the prune links to `importerId`. */
+function isLinkedFromASurvivor (
+  lockfile: LockfileObject,
+  importerId: ProjectId,
+  stale: ProjectId[]
+): boolean {
+  return Object.entries(lockfile.importers).some(([survivorId, importer]) => {
+    if (stale.includes(survivorId as ProjectId)) return false
+    return DEPENDENCIES_FIELDS.some((group) =>
+      Object.values(importer[group] ?? {}).some((reference) =>
+        reference.startsWith('link:') &&
+        path.posix.normalize(path.posix.join(survivorId, reference.slice('link:'.length))) === importerId))
+  })
+}
+
+/** Importers the lockfile records that no project claims any more. */
+function staleImporterIds (lockfile: LockfileObject, projects: Project[]): ProjectId[] {
+  const projectIds = new Set(projects.map(({ id }) => id))
+  return (Object.keys(lockfile.importers) as ProjectId[])
+    .filter((importerId) => !projectIds.has(importerId))
 }
 
 function dependencyGroupMoved (

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
@@ -16,7 +16,7 @@ export interface Project {
 export function hasChangedProjectSpecifiers (
   lockfile: LockfileObject,
   projects: Project[],
-  pruneLockfileImporters: boolean
+  pruneLockfileImporters: boolean = false
 ): boolean {
   if (pruneLockfileImporters && staleImporterIds(lockfile, projects).length > 0) return true
   return projects.some((project) => {

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
@@ -52,8 +52,6 @@ export function tryFastUpdateImporters (
       return false
     }
     for (const importerId of stale) {
-      // The project is gone, so every edge it held goes with it; whatever
-      // that orphans is the shared epilogue's to prune.
       for (const alias of Object.keys(lockfile.importers[importerId].specifiers)) {
         edits.dropped.add(alias)
       }

--- a/pnpm11/installing/deps-installer/test/install/removedImporterFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/removedImporterFastUpdate.ts
@@ -1,0 +1,113 @@
+import path from 'node:path'
+
+import { expect, test } from '@jest/globals'
+import { WANTED_LOCKFILE } from '@pnpm/constants'
+import { mutateModules } from '@pnpm/installing.deps-installer'
+import type { LockfileObject } from '@pnpm/lockfile.fs'
+import { preparePackages } from '@pnpm/prepare'
+import type { StoreController } from '@pnpm/store.controller-types'
+import type { ProjectId, ProjectRootDir } from '@pnpm/types'
+import { readYamlFileSync } from 'read-yaml-file'
+
+import { testDefaults } from '../utils/index.js'
+
+test('dropping a workspace package prunes its importer without resolving', async () => {
+  const { install, readLockfile } = prepareWorkspace()
+  await install([
+    { name: 'project-1', dependencies: { 'is-positive': '1.0.0' } },
+    { name: 'project-2' },
+  ])
+
+  const requestedPackages = await install([
+    { name: 'project-1', dependencies: { 'is-positive': '1.0.0' } },
+  ])
+
+  expect(requestedPackages).toStrictEqual([])
+  expect(Object.keys(readLockfile().importers)).toStrictEqual(['project-1'])
+})
+
+test('dropping a workspace package prunes what only it depended on', async () => {
+  const { install, readLockfile } = prepareWorkspace()
+  await install([
+    { name: 'project-1', dependencies: { 'is-positive': '1.0.0' } },
+    { name: 'project-2', dependencies: { '@pnpm.e2e/pkg-with-1-dep': '100.0.0' } },
+  ])
+
+  const requestedPackages = await install([
+    { name: 'project-1', dependencies: { 'is-positive': '1.0.0' } },
+  ])
+
+  expect(requestedPackages).toStrictEqual([])
+  const lockfile = readLockfile()
+  expect(Object.keys(lockfile.importers)).toStrictEqual(['project-1'])
+  expect(Object.keys(lockfile.packages ?? {})).toStrictEqual(['is-positive@1.0.0'])
+})
+
+test('a dependency the dropped package shared with a survivor stays', async () => {
+  const { install, readLockfile } = prepareWorkspace()
+  await install([
+    { name: 'project-1', dependencies: { 'is-positive': '1.0.0' } },
+    { name: 'project-2', dependencies: { 'is-positive': '1.0.0' } },
+  ])
+
+  const requestedPackages = await install([
+    { name: 'project-1', dependencies: { 'is-positive': '1.0.0' } },
+  ])
+
+  expect(requestedPackages).toStrictEqual([])
+  const lockfile = readLockfile()
+  expect(Object.keys(lockfile.importers)).toStrictEqual(['project-1'])
+  expect(Object.keys(lockfile.packages ?? {})).toStrictEqual(['is-positive@1.0.0'])
+  expect(lockfile.importers['project-1' as ProjectId].dependencies).toStrictEqual({
+    'is-positive': { specifier: '1.0.0', version: '1.0.0' },
+  })
+})
+
+interface WorkspaceProject {
+  name: string
+  dependencies?: Record<string, string>
+}
+
+function prepareWorkspace () {
+  const locations = ['project-1', 'project-2']
+  preparePackages(locations.map((name) => ({ location: name, package: { name } })))
+  const install = async (projects: WorkspaceProject[]): Promise<string[]> => {
+    const options = testDefaults({
+      allProjects: projects.map(({ name, dependencies }) => ({
+        buildIndex: 0,
+        manifest: { name, version: '1.0.0', ...(dependencies ? { dependencies } : {}) },
+        rootDir: path.resolve(name) as ProjectRootDir,
+      })),
+      pruneLockfileImporters: true,
+    })
+    const requestedPackages = trackRequestedPackages(options.storeController)
+    await mutateModules(projects.map(({ name }) => ({
+      mutation: 'install' as const,
+      rootDir: path.resolve(name) as ProjectRootDir,
+    })), options)
+    return requestedPackages
+  }
+  return { install, readLockfile: () => readYamlFileSync<LockfileObject>(WANTED_LOCKFILE) }
+}
+
+function trackRequestedPackages (storeController: StoreController): string[] {
+  const requestedPackages: string[] = []
+  const requestPackage = storeController.requestPackage
+  storeController.requestPackage = async (wantedDependency, requestOptions) => {
+    requestedPackages.push(wantedDependency.alias!)
+    return requestPackage(wantedDependency, requestOptions)
+  }
+  return requestedPackages
+}
+
+test('dropping a workspace package a survivor links to falls back to the resolver', async () => {
+  const { install } = prepareWorkspace()
+  await install([
+    { name: 'project-1', dependencies: { 'project-2': 'workspace:1.0.0' } },
+    { name: 'project-2' },
+  ])
+
+  await expect(install([
+    { name: 'project-1', dependencies: { 'project-2': 'workspace:1.0.0' } },
+  ])).rejects.toThrow()
+})

--- a/pnpm11/installing/deps-installer/test/install/removedImporterFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/removedImporterFastUpdate.ts
@@ -63,6 +63,24 @@ test('a dependency the dropped package shared with a survivor stays', async () =
   })
 })
 
+test('the fast path writes the lockfile a full resolution would', async () => {
+  const { install, readLockfile } = prepareWorkspace()
+  const initial: WorkspaceProject[] = [
+    { name: 'project-1', dependencies: { 'is-positive': '1.0.0' } },
+    { name: 'project-2', dependencies: { '@pnpm.e2e/pkg-with-1-dep': '100.0.0' } },
+  ]
+  const surviving = initial.slice(0, 1)
+
+  await install(initial)
+  await install(surviving)
+  const fastUpdated = readLockfile()
+
+  await install(initial)
+  await install(surviving, { forceFullResolution: true })
+
+  expect(fastUpdated).toStrictEqual(readLockfile())
+})
+
 interface WorkspaceProject {
   name: string
   dependencies?: Record<string, string>
@@ -71,7 +89,10 @@ interface WorkspaceProject {
 function prepareWorkspace () {
   const locations = ['project-1', 'project-2']
   preparePackages(locations.map((name) => ({ location: name, package: { name } })))
-  const install = async (projects: WorkspaceProject[]): Promise<string[]> => {
+  const install = async (
+    projects: WorkspaceProject[],
+    extraOptions?: { forceFullResolution: boolean }
+  ): Promise<string[]> => {
     const options = testDefaults({
       allProjects: projects.map(({ name, dependencies }) => ({
         buildIndex: 0,
@@ -79,6 +100,7 @@ function prepareWorkspace () {
         rootDir: path.resolve(name) as ProjectRootDir,
       })),
       pruneLockfileImporters: true,
+      ...extraOptions,
     })
     const requestedPackages = trackRequestedPackages(options.storeController)
     await mutateModules(projects.map(({ name }) => ({
@@ -109,5 +131,5 @@ test('dropping a workspace package a survivor links to falls back to the resolve
 
   await expect(install([
     { name: 'project-1', dependencies: { 'project-2': 'workspace:1.0.0' } },
-  ])).rejects.toThrow()
+  ])).rejects.toMatchObject({ code: 'ERR_PNPM_WORKSPACE_PKG_NOT_FOUND' })
 })


### PR DESCRIPTION
## Summary

Item 3 of pnpm/pnpm#13696, narrowed to the half that is actually broken.

The item covered adding *and* removing a dependency-free workspace package. Measured first: **adding one already works** — `getContext` seeds an empty importer for every project before the gate runs, so the counts match and the frozen path handles it with zero package requests. **Removing one does not**: the lockfile then holds an importer no project claims, the count check `importers.length === projects.length` fails, and the install pays a full re-resolution. That check is live for ordinary workspace installs, since `pruneLockfileImporters` defaults to true for an unfiltered recursive install.

The importers handler now drops importer entries no project claims and records their aliases as dropped, so the shared epilogue prunes whatever that orphans, recomputes `optional` flags, and applies the peer-suffix guard. The gate only requires that no project is *missing* an importer. This is not limited to dependency-free projects as the item framed it — a departing project with dependencies works the same way, because pruning orphans is what the epilogue already does.

**A guard the existing tests earned:** removing a project that a surviving project still links to must fail, and my first cut silently succeeded, leaving a project depending on something that no longer exists. `multipleImporters.ts`'s "some projects were removed from the workspace and the ones that are left depend on them" caught it. Such a stale importer now keeps the resolver, with its own regression test alongside.

**No pacquet mirror.** pacquet does not prune stale importers at all — verified with a workspace where the removed project's importer survives the reinstall — so there is no behavior to make fast yet. That is a divergence in its own right (the stale importer is a root in every reachability walk, so it also keeps dead packages alive), filed as pnpm/pnpm#13783; the mirror belongs with it.

## Squash Commit Body

```text
The fast path required the lockfile's importer count to equal the
project count whenever pruneLockfileImporters was on — which is the
default for an unfiltered recursive install — so deleting a package
from a workspace always paid a full resolution. The importers handler
now drops importer entries no project claims and records their aliases
as dropped, leaving the shared epilogue to prune whatever that
orphans, and the gate only requires that no project is *missing* an
importer.

A stale importer that a surviving importer still links to keeps the
resolver: a project that is gone while something depends on it is a
broken workspace, which must be reported rather than quietly rewritten
— the behavior an existing multipleImporters test already pinned.

No pacquet mirror yet: it does not prune stale importers at all,
filed as pnpm/pnpm#13783.

Item 3 of pnpm/pnpm#13696.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13784"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788984256&installation_model_id=426870&pr_number=13784&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13784&signature=3e87964aa3aee7c5e4ab948201bcc6888094d3106156abd5fc669dd62c6681a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lockfiles now update incrementally when a workspace package is removed.
  * Removed workspace entries and dependencies used only by them are automatically pruned.
  * Shared dependencies are preserved, avoiding unnecessary package resolution.

* **Bug Fixes**
  * Updates now detect and handle removed workspace links safely.
  * An error is reported when a remaining project still links to a removed package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->