### PR TITLE
fix(hooks): bound the pnpmfile worker's in-flight requests

### DIFF
--- a/.changeset/bound-pnpmfile-worker-requests.md
+++ b/.changeset/bound-pnpmfile-worker-requests.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Bounded the number of requests in flight to the `.pnpmfile.cjs` worker process. An install that runs the `readPackage` hook for thousands of packages at once no longer keeps every request's payload in memory, and no longer risks failing with `ERR_PNPM_PNPMFILE_FAIL` on a hook timeout spent queueing rather than running the hook.

--- a/.changeset/bound-pnpmfile-worker-requests.md
+++ b/.changeset/bound-pnpmfile-worker-requests.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Bounded the number of requests in flight to the `.pnpmfile.cjs` worker process. An install that runs the `readPackage` hook for thousands of packages at once no longer keeps every request's payload in memory, and no longer risks failing with `ERR_PNPM_PNPMFILE_FAIL` on a hook timeout spent queueing rather than running the hook.
+Bounded the number of requests in flight to the `.pnpmfile.cjs` worker process. An install that runs the `readPackage` hook for thousands of packages at once no longer risks failing with `ERR_PNPM_PNPMFILE_FAIL` on a hook timeout spent waiting in the queue rather than running the hook, and holds fewer copies of the manifests it is hooking while it waits.

--- a/pnpm/crates/hooks/src/worker.rs
+++ b/pnpm/crates/hooks/src/worker.rs
@@ -28,11 +28,21 @@ use std::{
 use tokio::{
     io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
     process::{Child, ChildStdin, Command},
-    sync::{Mutex, oneshot},
+    sync::{Mutex, Semaphore, oneshot},
     time::{Duration, timeout},
 };
 
 const HOOK_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// How many requests may be in flight to one worker at a time.
+///
+/// Callers fan out far wider: the resolver runs `readPackage` once per
+/// resolved package, all at once, which on a large install is thousands
+/// of requests. One worker is one Node process, so writing them all at
+/// once buys no throughput — it only makes each request queue behind the
+/// rest while its [`HOOK_TIMEOUT`] runs, until a batch of fast hooks
+/// fails the install on a timeout none of them caused.
+const MAX_IN_FLIGHT_REQUESTS: usize = 16;
 
 /// Callback invoked for each `context.log(...)` a hook emits while it runs.
 pub type LogFn = Arc<dyn Fn(String) + Send + Sync>;
@@ -89,6 +99,10 @@ pub struct NodeWorker {
     stdin: Mutex<ChildStdin>,
     pending: PendingMap,
     next_id: AtomicU64,
+    in_flight: Semaphore,
+    /// How long a request may take from the moment it is written to the
+    /// worker. [`HOOK_TIMEOUT`] outside tests.
+    request_timeout: Duration,
     /// Kept so the child is killed when the worker is dropped (`kill_on_drop`).
     _child: Child,
 }
@@ -96,6 +110,13 @@ pub struct NodeWorker {
 impl NodeWorker {
     /// Spawn the worker for `file` and start reading its responses.
     pub async fn spawn(file: &Path) -> Result<Arc<NodeWorker>, HookError> {
+        NodeWorker::spawn_with_request_timeout(file, HOOK_TIMEOUT).await
+    }
+
+    async fn spawn_with_request_timeout(
+        file: &Path,
+        request_timeout: Duration,
+    ) -> Result<Arc<NodeWorker>, HookError> {
         let pnpmfile = file.to_string_lossy().into_owned();
         let exec_err =
             |message: String| HookError::Execution { pnpmfile: pnpmfile.clone(), message };
@@ -141,6 +162,8 @@ impl NodeWorker {
             stdin: Mutex::new(stdin),
             pending,
             next_id: AtomicU64::new(0),
+            in_flight: Semaphore::new(MAX_IN_FLIGHT_REQUESTS),
+            request_timeout,
             _child: child,
         }))
     }
@@ -271,7 +294,13 @@ impl NodeWorker {
     /// await its reply, stamping in the request id and routing any
     /// `context.log(...)` lines to `log`. `label` names the request in a
     /// timeout error.
+    ///
+    /// Waits for one of the worker's [`MAX_IN_FLIGHT_REQUESTS`] slots
+    /// first, so a request's timeout window covers only the time the
+    /// worker had it, not the time its caller's fan-out spent queued.
     async fn request(&self, label: &str, mut body: Value, log: LogFn) -> Result<Value, HookError> {
+        let _in_flight = self.in_flight.acquire().await.expect("the semaphore is never closed");
+
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
         let (done, rx) = oneshot::channel();
         self.pending.lock().unwrap().insert(id, Pending { log, done });
@@ -287,11 +316,11 @@ impl NodeWorker {
             stdin.flush().await.map_err(|err| self.exec_err(err.to_string()))?;
         }
 
-        match timeout(HOOK_TIMEOUT, rx).await {
+        match timeout(self.request_timeout, rx).await {
             Ok(Ok(Ok(value))) => Ok(value),
             Ok(Ok(Err(message))) => Err(self.exec_err(message)),
             Ok(Err(_)) => Err(self.exec_err("pnpmfile worker dropped the response")),
-            Err(_) => Err(HookError::Timeout(label.to_string(), HOOK_TIMEOUT.as_secs())),
+            Err(_) => Err(HookError::Timeout(label.to_string(), self.request_timeout.as_secs())),
         }
     }
 }

--- a/pnpm/crates/hooks/src/worker/tests.rs
+++ b/pnpm/crates/hooks/src/worker/tests.rs
@@ -1,9 +1,12 @@
 use std::sync::Arc;
 
 use tempfile::TempDir;
-use tokio::time::{Duration, timeout};
+use tokio::{
+    task::JoinSet,
+    time::{Duration, timeout},
+};
 
-use super::NodeWorker;
+use super::{MAX_IN_FLIGHT_REQUESTS, NodeWorker};
 
 #[tokio::test]
 async fn cancelled_request_removes_its_pending_entry() {
@@ -24,4 +27,85 @@ async fn cancelled_request_removes_its_pending_entry() {
         worker.pending.lock().unwrap().is_empty(),
         "a cancelled request must not leak its pending entry",
     );
+}
+
+#[tokio::test]
+async fn a_fan_out_of_requests_reaches_the_worker_at_the_in_flight_cap() {
+    let tmp = TempDir::new().expect("temp dir");
+    let pnpmfile_path = tmp.path().join(".pnpmfile.cjs");
+    std::fs::write(
+        &pnpmfile_path,
+        r"let inFlight = 0
+let peak = 0
+module.exports = {
+  hooks: {
+    readPackage: async (pkg) => {
+      inFlight++
+      peak = Math.max(peak, inFlight)
+      await new Promise((resolve) => setTimeout(resolve, 100))
+      inFlight--
+      pkg.peak = peak
+      return pkg
+    },
+  },
+}
+",
+    )
+    .expect("write pnpmfile");
+    let worker = NodeWorker::spawn(&pnpmfile_path).await.expect("spawn worker");
+
+    let peak = call_read_package_concurrently(&worker, 100).await;
+    assert_eq!(
+        peak, MAX_IN_FLIGHT_REQUESTS,
+        "every slot should be used, and no request should reach the worker beyond them",
+    );
+}
+
+#[tokio::test]
+async fn a_queued_request_does_not_spend_its_timeout_waiting_for_its_turn() {
+    let tmp = TempDir::new().expect("temp dir");
+    let pnpmfile_path = tmp.path().join(".pnpmfile.cjs");
+    // The hook blocks Node's event loop, so the worker services the fan-out
+    // strictly one request at a time: 100 of them outlast the timeout below
+    // several times over, and only a request whose window starts at its turn
+    // can survive.
+    std::fs::write(
+        &pnpmfile_path,
+        r"module.exports = {
+  hooks: {
+    readPackage: (pkg) => {
+      const until = Date.now() + 30
+      while (Date.now() < until) {}
+      return pkg
+    },
+  },
+}
+",
+    )
+    .expect("write pnpmfile");
+    let worker = NodeWorker::spawn_with_request_timeout(&pnpmfile_path, Duration::from_secs(2))
+        .await
+        .expect("spawn worker");
+
+    call_read_package_concurrently(&worker, 100).await;
+}
+
+/// Call `readPackage` `count` times at once, requiring every call to
+/// succeed. Returns the highest `peak` any of them reported back, which is
+/// `0` for a hook that reports none.
+async fn call_read_package_concurrently(worker: &Arc<NodeWorker>, count: usize) -> usize {
+    let mut calls = JoinSet::new();
+    for _ in 0..count {
+        let worker = Arc::clone(worker);
+        calls.spawn(async move {
+            worker.call("readPackage", serde_json::json!({}), Arc::new(|_| {})).await
+        });
+    }
+
+    let mut peak = 0;
+    while let Some(call) = calls.join_next().await {
+        let result = call.expect("join the call").expect("the hook should not fail");
+        peak = peak.max(result["peak"].as_u64().unwrap_or(0) as usize);
+    }
+    peak
 }

--- a/pnpm/crates/hooks/src/worker/tests.rs
+++ b/pnpm/crates/hooks/src/worker/tests.rs
@@ -90,9 +90,8 @@ async fn a_queued_request_does_not_spend_its_timeout_waiting_for_its_turn() {
     call_read_package_concurrently(&worker, 100).await;
 }
 
-/// Call `readPackage` `count` times at once, requiring every call to
-/// succeed. Returns the highest `peak` any of them reported back, which is
-/// `0` for a hook that reports none.
+/// Every call must succeed; the value returned is the highest `peak` the
+/// hook reported back.
 async fn call_read_package_concurrently(worker: &Arc<NodeWorker>, count: usize) -> usize {
     let mut calls = JoinSet::new();
     for _ in 0..count {


### PR DESCRIPTION
## Summary

`NodeWorker::request` (`pnpm/crates/hooks/src/worker.rs`) put no bound on in-flight requests: every caller inserted a `pending` entry, wrote its line to the worker's stdin, and started its own 30s `HOOK_TIMEOUT` at *send* time. Behind that is a single Node process, and the callers fan out without a bound of their own — the resolver's dependency walk runs `readPackage` once per resolved package, all at once, which on a large install is thousands of simultaneously pending requests.

Two consequences, both proportional to the batch size rather than to any single hook's cost:

1. Peak memory — every pending request holds its payload and `pending` entry until its reply arrives.
2. Spurious `ERR_PNPM_PNPMFILE_FAIL` timeouts — a request queued behind thousands of others could burn its whole 30s window waiting for its turn, failing an install whose hooks are all fast.

`request` now takes one of 16 in-flight slots before it writes. The bound lands in the worker rather than at the call sites, so every caller inherits it, and — because the permit is acquired *before* the pending entry, the write, and the timer — each request's timeout window covers only the time the worker actually had it. The serialized request line and the pending bookkeeping a fan-out holds in memory are bounded with it. A caller clones the manifest before it awaits the hook, so that clone stays resident in its queued future — bounding those belongs at the fan-out (`walk.rs`), not in the worker, and is left out of this PR.

The cap is 16: one worker is one Node process, so a wider batch buys no throughput, while a narrower one would throttle hooks that do async work.

Tests: two new ones in `worker/tests.rs`, both verified to fail with the semaphore acquisition removed.

- `a_fan_out_of_requests_reaches_the_worker_at_the_in_flight_cap` — a hook that reports the peak number of concurrent invocations it saw; 100 concurrent calls peak at exactly 16.
- `a_queued_request_does_not_spend_its_timeout_waiting_for_its_turn` — 100 concurrent calls into a hook that blocks Node's event loop for 30ms each (3s of serial work) against a 2s request timeout. Every call succeeds only if its timer starts at its turn; before the fix, the later ones time out.

To make the second test possible without a 30s run, `spawn` now delegates to a private `spawn_with_request_timeout`, and the timeout lives on the worker rather than being read from the constant at the point of use. `HOOK_TIMEOUT` is unchanged for every production caller.

Closes pnpm/pnpm#13774.

This is a pacquet-only concern: the TypeScript CLI runs pnpmfile hooks in-process and has no worker to queue against, so there is nothing to mirror.

## Squash Commit Body

```text
Every caller of the pnpmfile worker fans out without a bound — the
resolver runs `readPackage` once per resolved package, all at once —
while one worker is one Node process that services them a few at a
time. Each request also started its 30s timer when it was written, so a
request queued behind thousands of others could exhaust its window
before the worker ever reached it and fail the install with
ERR_PNPM_PNPMFILE_FAIL on hooks that are all fast.

`NodeWorker::request` now takes one of 16 in-flight slots before it
writes, so the bound (and the timer's start at the request's turn)
covers every call site instead of having to be repeated at each one.
The serialized request line and the pending bookkeeping are bounded
with it; a caller's own manifest clone predates the call and stays
resident in its queued future, which is the fan-out's to bound.

The per-request timeout moved from a constant read at the point of use
onto the worker, so a test can drive it without a 30s wait;
`HOOK_TIMEOUT` is unchanged for every production caller.

Closes pnpm/pnpm#13774
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package processing reliability by limiting concurrent worker requests.
  * Reduced memory usage from queued requests during high-volume processing.
  * Prevented requests from timing out while waiting for an available processing slot.
  * Improved timeout reporting with clearer, more accurate diagnostics.
  * Increased stability when handling many package operations concurrently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->