### PR TITLE
fix(lockfile): round-trip the lockfile's `time` section

### DIFF
--- a/.changeset/lockfile-time-section-round-trips.md
+++ b/.changeset/lockfile-time-section-round-trips.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+The lockfile's `time:` section is no longer dropped when `pnpm-lock.yaml` is rewritten. `resolutionMode: time-based` records each direct dependency's publish date there and now reads it back as the fallback for a package whose registry metadata carries no publish date, so a later resolution derives the same cutoff instead of picking different subdependency versions [#13776](https://github.com/pnpm/pnpm/issues/13776).

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -1020,13 +1020,6 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
     if let Some(registry) = benchmark_registry_override.as_ref() {
         registry.rewrite_lockfile(&mut outcome.lockfile);
     }
-    // The pnpr server does not resolve `time-based`, so its outcome
-    // never carries a `time:` section of its own; hand back what the
-    // previous lockfile recorded rather than dropping it. Saving prunes
-    // whatever is no longer a direct dependency.
-    if outcome.lockfile.time.is_none() {
-        outcome.lockfile.time = previous_wanted.as_ref().and_then(|wanted| wanted.time.clone());
-    }
     if let (Some((real_importer_ids, selected_importer_ids)), Some(workspace_root)) = (
         selection_importer_ids.as_ref().or(full_workspace_importer_ids.as_ref()),
         selection

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -1020,6 +1020,13 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
     if let Some(registry) = benchmark_registry_override.as_ref() {
         registry.rewrite_lockfile(&mut outcome.lockfile);
     }
+    // The pnpr server does not resolve `time-based`, so its outcome
+    // never carries a `time:` section of its own; hand back what the
+    // previous lockfile recorded rather than dropping it. Saving prunes
+    // whatever is no longer a direct dependency.
+    if outcome.lockfile.time.is_none() {
+        outcome.lockfile.time = previous_wanted.as_ref().and_then(|wanted| wanted.time.clone());
+    }
     if let (Some((real_importer_ids, selected_importer_ids)), Some(workspace_root)) = (
         selection_importer_ids.as_ref().or(full_workspace_importer_ids.as_ref()),
         selection

--- a/pnpm/crates/cli/src/cli_args/patch_commit/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/patch_commit/tests.rs
@@ -23,6 +23,7 @@ fn empty_lockfile() -> Lockfile {
         importers: HashMap::new(),
         packages: None,
         snapshots: None,
+        time: None,
     }
 }
 

--- a/pnpm/crates/cli/tests/suite/install.rs
+++ b/pnpm/crates/cli/tests/suite/install.rs
@@ -1500,11 +1500,9 @@ fn resolution_mode_lowest_direct_picks_lowest_direct_version() {
     drop((root, mock_instance));
 }
 
-/// `resolutionMode: time-based` records each direct dependency's publish
-/// date under `time:`, and every later install hands the section back.
-/// Dropping it would lose the dates a re-resolve falls back on when the
-/// registry's abbreviated metadata carries none, changing the cutoff
-/// every subdependency is resolved under.
+/// Dropping `time:` would lose the publish dates a re-resolve falls back
+/// on when the registry's abbreviated metadata carries none, changing the
+/// cutoff every subdependency is resolved under.
 #[test]
 fn time_based_install_records_and_preserves_the_lockfile_time_section() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =

--- a/pnpm/crates/cli/tests/suite/install.rs
+++ b/pnpm/crates/cli/tests/suite/install.rs
@@ -1526,9 +1526,9 @@ fn time_based_install_records_and_preserves_the_lockfile_time_section() {
     let recorded =
         read_lockfile(&lockfile_path).time.expect("a time-based install records `time:`");
     assert_eq!(
-        recorded.keys().filter(|dep_path| dep_path.starts_with("@pnpm.e2e/foo@")).count(),
-        1,
-        "the direct dependency's publish date is recorded: {recorded:?}",
+        recorded.keys().collect::<Vec<_>>(),
+        ["@pnpm.e2e/foo@100.0.0"],
+        "only the direct dependency's publish date is recorded: {recorded:?}",
     );
 
     new_pacquet_command(&workspace).with_arg("install").assert().success();

--- a/pnpm/crates/cli/tests/suite/install.rs
+++ b/pnpm/crates/cli/tests/suite/install.rs
@@ -1500,6 +1500,46 @@ fn resolution_mode_lowest_direct_picks_lowest_direct_version() {
     drop((root, mock_instance));
 }
 
+/// `resolutionMode: time-based` records each direct dependency's publish
+/// date under `time:`, and every later install hands the section back.
+/// Dropping it would lose the dates a re-resolve falls back on when the
+/// registry's abbreviated metadata carries none, changing the cutoff
+/// every subdependency is resolved under.
+#[test]
+fn time_based_install_records_and_preserves_the_lockfile_time_section() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let workspace_yaml = workspace.join("pnpm-workspace.yaml");
+    let mut existing = fs::read_to_string(&workspace_yaml).expect("read pnpm-workspace.yaml");
+    existing.push_str("resolutionMode: time-based\nminimumReleaseAge: 0\n");
+    fs::write(&workspace_yaml, existing).expect("write pnpm-workspace.yaml");
+
+    let manifest_path = workspace.join("package.json");
+    let package_json_content = serde_json::json!({
+        "dependencies": { "@pnpm.e2e/foo": "^100.0.0" },
+    });
+    fs::write(&manifest_path, package_json_content.to_string()).expect("write to package.json");
+
+    pacquet.with_arg("install").assert().success();
+
+    let lockfile_path = workspace.join("pnpm-lock.yaml");
+    let recorded =
+        read_lockfile(&lockfile_path).time.expect("a time-based install records `time:`");
+    assert_eq!(
+        recorded.keys().filter(|dep_path| dep_path.starts_with("@pnpm.e2e/foo@")).count(),
+        1,
+        "the direct dependency's publish date is recorded: {recorded:?}",
+    );
+
+    new_pacquet_command(&workspace).with_arg("install").assert().success();
+
+    assert_eq!(read_lockfile(&lockfile_path).time.as_ref(), Some(&recorded));
+
+    drop((root, mock_instance));
+}
+
 /// `@pnpm.e2e/abc-parent-with-ab@1.0.0` transitively peer-depends on
 /// `@pnpm.e2e/peer-c` (through its `@pnpm.e2e/abc` dependency). A diamond
 /// reaches it in two compatible peer contexts: the root supplies

--- a/pnpm/crates/cli/tests/suite/pnpr_install.rs
+++ b/pnpm/crates/cli/tests/suite/pnpr_install.rs
@@ -132,6 +132,64 @@ fn install_via_pnpr_links_node_modules() {
     drop((root, mock_instance));
 }
 
+/// A pnpr-resolved lockfile is rewritten wholesale from the server's
+/// answer, so `time:` has to survive the round trip the same way a
+/// locally resolved install preserves it.
+#[test]
+fn install_via_pnpr_preserves_the_lockfiles_time_section() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { npmrc_path, mock_instance, .. } = npmrc_info;
+
+    let (pnpr_url, token) = start_pnpr(&mock_instance.url());
+    configure_pnpr_auth(&npmrc_path, &pnpr_url, &token);
+
+    let manifest_path = workspace.join("package.json");
+    let write_manifest = |dependencies: serde_json::Value| {
+        fs::write(&manifest_path, serde_json::json!({ "dependencies": dependencies }).to_string())
+            .expect("write package.json");
+    };
+    let install_via_pnpr = || {
+        pacquet_at(&workspace)
+            .with_env("PNPM_CONFIG_REGISTRY", mock_instance.url())
+            .with_arg("install")
+            .with_arg("--pnpr-server")
+            .with_arg(&pnpr_url)
+            .assert()
+            .success();
+    };
+
+    write_manifest(serde_json::json!({ "@foo/has-dep-from-same-scope": "1.0.0" }));
+    install_via_pnpr();
+
+    // Appended as text: saving would prune the transitive entry before
+    // the install under test ever sees it.
+    let lockfile_path = workspace.join("pnpm-lock.yaml");
+    let mut recorded = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
+    recorded.push_str(
+        "\ntime:\n  '@foo/has-dep-from-same-scope@1.0.0': '2024-01-01T00:00:00.000Z'\n  '@foo/no-deps@1.0.0': '2024-01-02T00:00:00.000Z'\n",
+    );
+    fs::write(&lockfile_path, recorded).expect("record publish dates in pnpm-lock.yaml");
+
+    // A new dependency is what sends the second install back through the
+    // server rather than short-circuiting on the lockfile it just wrote.
+    write_manifest(
+        serde_json::json!({ "@foo/has-dep-from-same-scope": "1.0.0", "is-positive": "1.0.0" }),
+    );
+    install_via_pnpr();
+
+    let time = read_workspace_lockfile(&workspace).time.expect("`time:` survives a pnpr install");
+    assert_eq!(
+        time.into_iter().collect::<Vec<_>>(),
+        [(
+            "@foo/has-dep-from-same-scope@1.0.0".to_string(),
+            "2024-01-01T00:00:00.000Z".to_string(),
+        )],
+    );
+
+    drop((root, mock_instance));
+}
+
 #[test]
 fn frozen_install_via_pnpr_verifies_the_local_lockfile_without_resolving_or_redownloading() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =

--- a/pnpm/crates/deps-restorer/src/current_lockfile.rs
+++ b/pnpm/crates/deps-restorer/src/current_lockfile.rs
@@ -98,6 +98,7 @@ pub fn materialization_closure(
             importers,
             packages,
             snapshots,
+            time: lockfile.time.clone(),
         },
         importer_ids: reachable.importer_ids,
     }
@@ -328,6 +329,7 @@ fn lockfile_with_graph(
         importers,
         packages,
         snapshots,
+        time: source.time.clone(),
     }
 }
 

--- a/pnpm/crates/deps-restorer/src/current_lockfile/tests.rs
+++ b/pnpm/crates/deps-restorer/src/current_lockfile/tests.rs
@@ -88,6 +88,7 @@ fn empty_lockfile() -> Lockfile {
         importers: HashMap::new(),
         packages: None,
         snapshots: None,
+        time: None,
     }
 }
 
@@ -130,6 +131,7 @@ fn lockfile_with_top_level(marker: &str, minor: u16) -> Lockfile {
         importers: HashMap::new(),
         packages: None,
         snapshots: None,
+        time: None,
     }
 }
 

--- a/pnpm/crates/deps-restorer/src/hoisted_dep_graph/tests.rs
+++ b/pnpm/crates/deps-restorer/src/hoisted_dep_graph/tests.rs
@@ -167,6 +167,7 @@ fn lockfile_with(
         importers,
         packages: Some(packages),
         snapshots: Some(snapshots),
+        time: None,
     }
 }
 
@@ -185,6 +186,7 @@ fn walker_empty_lockfile_produces_empty_result() {
         importers: HashMap::new(),
         packages: None,
         snapshots: None,
+        time: None,
     };
     let opts = LockfileToHoistedDepGraphOptions {
         lockfile_dir: PathBuf::from("/repo"),
@@ -604,6 +606,7 @@ fn prev_graph_none_when_current_lockfile_has_no_packages() {
         importers: HashMap::new(),
         packages: None,
         snapshots: None,
+        time: None,
     };
     let opts = LockfileToHoistedDepGraphOptions {
         lockfile_dir: PathBuf::from("/repo"),
@@ -642,6 +645,7 @@ fn prev_graph_none_when_current_lockfile_has_empty_packages() {
         importers: HashMap::new(),
         packages: Some(HashMap::new()),
         snapshots: Some(HashMap::new()),
+        time: None,
     };
     let opts = LockfileToHoistedDepGraphOptions {
         lockfile_dir: PathBuf::from("/repo"),
@@ -772,6 +776,7 @@ fn workspace_lockfile(
         importers,
         packages: Some(packages),
         snapshots: Some(snapshots),
+        time: None,
     }
 }
 

--- a/pnpm/crates/deps-restorer/src/package_map/tests.rs
+++ b/pnpm/crates/deps-restorer/src/package_map/tests.rs
@@ -460,6 +460,7 @@ fn empty_lockfile() -> Lockfile {
         importers: HashMap::new(),
         packages: None,
         snapshots: None,
+        time: None,
     }
 }
 

--- a/pnpm/crates/deps-restorer/src/prune_direct_deps/tests.rs
+++ b/pnpm/crates/deps-restorer/src/prune_direct_deps/tests.rs
@@ -28,6 +28,7 @@ fn lockfile_with_root_importer(snapshot: ProjectSnapshot) -> Lockfile {
         importers,
         packages: None,
         snapshots: None,
+        time: None,
     }
 }
 

--- a/pnpm/crates/lockfile-verification/src/hash_lockfile.rs
+++ b/pnpm/crates/lockfile-verification/src/hash_lockfile.rs
@@ -23,10 +23,16 @@ use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
 
 /// Sha256 hex digest of the lockfile content.
+///
+/// The same on-write normalization the writer applies runs first, so an
+/// in-memory lockfile hashes to what it will hash to once saved and read
+/// back — which is what lets an install record the verification its
+/// successor looks up.
 #[must_use]
 pub fn hash_lockfile(lockfile: &Lockfile) -> String {
-    let value = serde_json::to_value(lockfile)
+    let mut value = serde_json::to_value(lockfile)
         .expect("Lockfile serializes; serde_json::Value supports all JSON-shape variants");
+    pacquet_lockfile::prune_time(&mut value);
     let normalized = normalize(value);
     let mut hasher = HashWriter(Sha256::new());
     serde_json::to_writer(&mut hasher, &normalized)

--- a/pnpm/crates/lockfile-verification/src/hash_lockfile/tests.rs
+++ b/pnpm/crates/lockfile-verification/src/hash_lockfile/tests.rs
@@ -77,3 +77,26 @@ importers:
     );
     assert_ne!(hash_lockfile(&original), hash_lockfile(&drifted));
 }
+
+/// The digest has to describe the bytes the lockfile will be saved as,
+/// not the in-memory map: a `time:` entry the writer prunes must not
+/// move it, or a recorded verification would never be found again.
+#[test]
+fn a_pruned_time_entry_does_not_move_the_hash() {
+    let pruned_to_nothing = parse(&with_time("scheduler@0.20.2: '2020-10-20T00:00:00.000Z'"));
+    let empty = parse(&with_time("{}"));
+    assert_eq!(hash_lockfile(&pruned_to_nothing), hash_lockfile(&empty));
+}
+
+#[test]
+fn a_retained_time_entry_flips_the_hash() {
+    let direct = parse(&with_time("react@17.0.2: '2021-03-22T14:00:00.000Z'"));
+    let empty = parse(&with_time("{}"));
+    assert_ne!(hash_lockfile(&direct), hash_lockfile(&empty));
+}
+
+/// `entry` is either a single `depPath: date` pair or the literal `{}`.
+fn with_time(entry: &str) -> String {
+    let separator = if entry == "{}" { " " } else { "\n  " };
+    format!("{LOCKFILE_YAML}\ntime:{separator}{entry}\n")
+}

--- a/pnpm/crates/lockfile/src/lib.rs
+++ b/pnpm/crates/lockfile/src/lib.rs
@@ -183,7 +183,7 @@ pub struct Lockfile {
     /// abbreviated metadata carries none, so the cutoff a later
     /// time-based resolution derives stays the one this lockfile was
     /// written under. Sorted by key and pruned to the importers' direct
-    /// dependencies on save (see [`crate::prune_time`]), so it does not
+    /// dependencies on save (see [`crate::prune_time()`]), so it does not
     /// grow an entry per transitive package.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub time: Option<BTreeMap<String, String>>,

--- a/pnpm/crates/lockfile/src/lib.rs
+++ b/pnpm/crates/lockfile/src/lib.rs
@@ -13,6 +13,7 @@ mod pkg_name_ver;
 mod pkg_name_ver_peer;
 mod pkg_ver_peer;
 mod project_snapshot;
+mod prune_time;
 mod resolution;
 mod resolved_dependency;
 mod save_lockfile;
@@ -37,6 +38,7 @@ pub use pkg_name_ver::*;
 pub use pkg_name_ver_peer::*;
 pub use pkg_ver_peer::*;
 pub use project_snapshot::*;
+pub use prune_time::*;
 pub use resolution::*;
 pub use resolved_dependency::*;
 pub use save_lockfile::*;
@@ -174,6 +176,17 @@ pub struct Lockfile {
         serialize_with = "crate::serialize_yaml::sorted_map_opt"
     )]
     pub snapshots: Option<HashMap<PackageKey, SnapshotEntry>>,
+
+    /// `time:` — the publish date of every direct dependency, recorded
+    /// by a `resolutionMode: time-based` install. It is the fallback
+    /// source of a package's publish date when the registry's
+    /// abbreviated metadata carries none, so the cutoff a later
+    /// time-based resolution derives stays the one this lockfile was
+    /// written under. Sorted by key and pruned to the importers' direct
+    /// dependencies on save (see [`crate::prune_time`]), so it does not
+    /// grow an entry per transitive package.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub time: Option<BTreeMap<String, String>>,
 }
 
 impl Lockfile {

--- a/pnpm/crates/lockfile/src/prune_time.rs
+++ b/pnpm/crates/lockfile/src/prune_time.rs
@@ -1,0 +1,55 @@
+//! The `time:` normalization pnpm applies on its way to disk.
+
+use crate::{ImporterDepVersion, PkgName};
+use serde_json::Value;
+use std::collections::HashSet;
+
+/// Dependency groups an importer records its direct dependencies under,
+/// named as they appear in the serialized document.
+const IMPORTER_DEPENDENCY_GROUPS: [&str; 3] =
+    ["dependencies", "devDependencies", "optionalDependencies"];
+
+/// Port of `pruneTimeInLockfile` (`lockfile/fs/src/lockfileFormatConverters.ts`):
+/// drop every `time:` entry that is not one of the importers' direct
+/// dependencies, so recording publish dates costs one entry per direct
+/// dependency rather than one per resolved package.
+///
+/// `document` is a serialized lockfile. Values that are not
+/// lockfile-shaped — the env lockfile, an `afterAllResolved` result that
+/// dropped a section — pass through untouched.
+pub fn prune_time(document: &mut Value) {
+    if !document.get("time").is_some_and(Value::is_object) {
+        return;
+    }
+    let direct_dep_paths = importer_dep_paths(document);
+    let Some(Value::Object(time)) = document.get_mut("time") else { return };
+    time.retain(|dep_path, _| direct_dep_paths.contains(dep_path));
+}
+
+/// Every depPath the importers depend on directly, peer suffix stripped —
+/// the keys a `time:` entry is allowed to carry.
+fn importer_dep_paths(document: &Value) -> HashSet<String> {
+    let mut dep_paths = HashSet::new();
+    let Some(Value::Object(importers)) = document.get("importers") else { return dep_paths };
+    for importer in importers.values() {
+        for group in IMPORTER_DEPENDENCY_GROUPS {
+            let Some(Value::Object(dependencies)) = importer.get(group) else { continue };
+            for (alias, dependency) in dependencies {
+                let Some(version) = dependency.get("version").and_then(Value::as_str) else {
+                    continue;
+                };
+                let (Ok(alias), Ok(version)) =
+                    (PkgName::parse(alias.as_str()), version.parse::<ImporterDepVersion>())
+                else {
+                    continue;
+                };
+                let Some(dep_path) = version.resolved_key(&alias) else { continue };
+                dep_paths.insert(dep_path.without_peer().to_string());
+            }
+        }
+    }
+    dep_paths
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/lockfile/src/prune_time/tests.rs
+++ b/pnpm/crates/lockfile/src/prune_time/tests.rs
@@ -55,9 +55,6 @@ fn every_dependency_group_of_every_importer_is_direct() {
     );
 }
 
-/// A `time:` key never carries a peer suffix, so the depPath a
-/// peer-qualified importer entry contributes must be stripped down to
-/// the one the entry is recorded under.
 #[test]
 fn a_peer_qualified_dependency_matches_its_peer_stripped_key() {
     let document = pruned(json!({
@@ -73,8 +70,6 @@ fn a_peer_qualified_dependency_matches_its_peer_stripped_key() {
     assert_eq!(document["time"], json!({ "react-dom@17.0.2": "2021-03-22T15:00:00.000Z" }));
 }
 
-/// An npm-aliased dependency is recorded under the aliased package's
-/// depPath, not under the name it is installed as.
 #[test]
 fn an_aliased_dependency_matches_its_target_key() {
     let document = pruned(json!({
@@ -93,8 +88,6 @@ fn an_aliased_dependency_matches_its_target_key() {
     assert_eq!(document["time"], json!({ "is-positive@1.0.0": "2016-02-02T00:00:00.000Z" }));
 }
 
-/// A workspace sibling resolves to no depPath, so it can never keep a
-/// `time:` entry alive.
 #[test]
 fn a_linked_dependency_keeps_nothing() {
     let document = pruned(json!({

--- a/pnpm/crates/lockfile/src/prune_time/tests.rs
+++ b/pnpm/crates/lockfile/src/prune_time/tests.rs
@@ -1,0 +1,120 @@
+use super::prune_time;
+use pretty_assertions::assert_eq;
+use serde_json::{Value, json};
+
+fn pruned(document: Value) -> Value {
+    let mut document = document;
+    prune_time(&mut document);
+    document
+}
+
+#[test]
+fn transitive_entries_are_dropped() {
+    let document = pruned(json!({
+        "importers": {
+            ".": {
+                "dependencies": {
+                    "is-positive": { "specifier": "1.0.0", "version": "1.0.0" },
+                },
+            },
+        },
+        "time": {
+            "is-negative@1.0.0": "2016-01-01T00:00:00.000Z",
+            "is-positive@1.0.0": "2016-02-02T00:00:00.000Z",
+        },
+    }));
+    assert_eq!(document["time"], json!({ "is-positive@1.0.0": "2016-02-02T00:00:00.000Z" }));
+}
+
+#[test]
+fn every_dependency_group_of_every_importer_is_direct() {
+    let document = pruned(json!({
+        "importers": {
+            ".": {
+                "devDependencies": {
+                    "typescript": { "specifier": "^5.1.6", "version": "5.1.6" },
+                },
+            },
+            "packages/app": {
+                "optionalDependencies": {
+                    "fsevents": { "specifier": "^2.3.3", "version": "2.3.3" },
+                },
+            },
+        },
+        "time": {
+            "fsevents@2.3.3": "2024-01-01T00:00:00.000Z",
+            "typescript@5.1.6": "2023-06-27T18:00:00.000Z",
+        },
+    }));
+    assert_eq!(
+        document["time"],
+        json!({
+            "fsevents@2.3.3": "2024-01-01T00:00:00.000Z",
+            "typescript@5.1.6": "2023-06-27T18:00:00.000Z",
+        }),
+    );
+}
+
+/// A `time:` key never carries a peer suffix, so the depPath a
+/// peer-qualified importer entry contributes must be stripped down to
+/// the one the entry is recorded under.
+#[test]
+fn a_peer_qualified_dependency_matches_its_peer_stripped_key() {
+    let document = pruned(json!({
+        "importers": {
+            ".": {
+                "dependencies": {
+                    "react-dom": { "specifier": "^17.0.2", "version": "17.0.2(react@17.0.2)" },
+                },
+            },
+        },
+        "time": { "react-dom@17.0.2": "2021-03-22T15:00:00.000Z" },
+    }));
+    assert_eq!(document["time"], json!({ "react-dom@17.0.2": "2021-03-22T15:00:00.000Z" }));
+}
+
+/// An npm-aliased dependency is recorded under the aliased package's
+/// depPath, not under the name it is installed as.
+#[test]
+fn an_aliased_dependency_matches_its_target_key() {
+    let document = pruned(json!({
+        "importers": {
+            ".": {
+                "dependencies": {
+                    "positive": { "specifier": "npm:is-positive@1.0.0", "version": "is-positive@1.0.0" },
+                },
+            },
+        },
+        "time": {
+            "is-positive@1.0.0": "2016-02-02T00:00:00.000Z",
+            "positive@1.0.0": "2016-02-02T00:00:00.000Z",
+        },
+    }));
+    assert_eq!(document["time"], json!({ "is-positive@1.0.0": "2016-02-02T00:00:00.000Z" }));
+}
+
+/// A workspace sibling resolves to no depPath, so it can never keep a
+/// `time:` entry alive.
+#[test]
+fn a_linked_dependency_keeps_nothing() {
+    let document = pruned(json!({
+        "importers": {
+            ".": {
+                "dependencies": {
+                    "shared": { "specifier": "workspace:*", "version": "link:packages/shared" },
+                },
+            },
+        },
+        "time": { "shared@1.0.0": "2024-01-01T00:00:00.000Z" },
+    }));
+    assert_eq!(document["time"], json!({}));
+}
+
+#[test]
+fn a_document_without_a_time_section_is_untouched() {
+    let document = json!({
+        "importers": { ".": { "dependencies": {} } },
+        "packages": { "is-positive@1.0.0": {} },
+    });
+    assert_eq!(pruned(document.clone()), document);
+}

--- a/pnpm/crates/lockfile/src/save_lockfile/tests.rs
+++ b/pnpm/crates/lockfile/src/save_lockfile/tests.rs
@@ -103,6 +103,59 @@ fn save_reproduces_pnpm_authored_bytes() {
     assert_eq!(saved_bytes, format!("{LOCKFILE_YAML}\n"));
 }
 
+/// A `resolutionMode: time-based` install records `time:`, and every
+/// later save has to hand it back — the recorded dates are what a
+/// registry whose abbreviated metadata omits publish times resolves
+/// against.
+#[test]
+fn time_survives_a_save_round_trip() {
+    let lockfile: Lockfile = serde_saphyr::from_str(&format!("{LOCKFILE_YAML}\n{DIRECT_TIME}"))
+        .expect("parse fixture lockfile");
+
+    let tmp = tempdir().expect("create tempdir");
+    let path = tmp.path().join("pnpm-lock.yaml");
+    lockfile.save_to_path(&path).expect("save lockfile");
+
+    let saved_bytes = std::fs::read_to_string(&path).expect("read saved lockfile");
+    assert_eq!(saved_bytes, format!("{LOCKFILE_YAML}\n{DIRECT_TIME}\n"));
+}
+
+/// Saving prunes `time:` to the importers' direct dependencies, the way
+/// pnpm's `pruneTimeInLockfile` does, so the section stays one entry per
+/// direct dependency instead of growing one per resolved package.
+#[test]
+fn time_is_pruned_to_the_importers_direct_dependencies() {
+    const TIME_WITH_TRANSITIVE: &str = text_block! {
+        ""
+        "time:"
+        "  object-assign@4.1.1: '2016-06-08T00:00:00.000Z'"
+        "  react-dom@17.0.2: '2021-03-22T15:00:00.000Z'"
+        "  react@17.0.2: '2021-03-22T14:00:00.000Z'"
+        "  typescript@5.1.6: '2023-06-27T18:00:00.000Z'"
+    };
+
+    let lockfile: Lockfile =
+        serde_saphyr::from_str(&format!("{LOCKFILE_YAML}\n{TIME_WITH_TRANSITIVE}"))
+            .expect("parse fixture lockfile");
+
+    let tmp = tempdir().expect("create tempdir");
+    let path = tmp.path().join("pnpm-lock.yaml");
+    lockfile.save_to_path(&path).expect("save lockfile");
+
+    let saved_bytes = std::fs::read_to_string(&path).expect("read saved lockfile");
+    assert_eq!(saved_bytes, format!("{LOCKFILE_YAML}\n{DIRECT_TIME}\n"));
+}
+
+/// The `time:` section of [`LOCKFILE_YAML`] once pruned: one entry per
+/// direct dependency, with `react-dom`'s peer suffix stripped.
+const DIRECT_TIME: &str = text_block! {
+    ""
+    "time:"
+    "  react-dom@17.0.2: '2021-03-22T15:00:00.000Z'"
+    "  react@17.0.2: '2021-03-22T14:00:00.000Z'"
+    "  typescript@5.1.6: '2023-06-27T18:00:00.000Z'"
+};
+
 #[test]
 fn workspace_lockfile_with_link_dep_round_trips() {
     const WORKSPACE_YAML: &str = text_block! {
@@ -229,6 +282,7 @@ fn peers_suffix_max_length_omitted_from_settings_when_unset() {
         importers: std::collections::HashMap::default(),
         packages: None,
         snapshots: None,
+        time: None,
     };
 
     let tmp = tempdir().expect("create tempdir");
@@ -265,6 +319,7 @@ fn peers_suffix_max_length_serialized_when_set() {
         importers: std::collections::HashMap::default(),
         packages: None,
         snapshots: None,
+        time: None,
     };
 
     let tmp = tempdir().expect("create tempdir");

--- a/pnpm/crates/lockfile/src/save_lockfile/tests.rs
+++ b/pnpm/crates/lockfile/src/save_lockfile/tests.rs
@@ -116,7 +116,6 @@ fn time_survives_a_save_round_trip() {
     assert_eq!(saved_bytes, format!("{LOCKFILE_YAML}\n{DIRECT_TIME}\n"));
 }
 
-/// Port of pnpm's `pruneTimeInLockfile`.
 #[test]
 fn time_is_pruned_to_the_importers_direct_dependencies() {
     const TIME_WITH_TRANSITIVE: &str = text_block! {

--- a/pnpm/crates/lockfile/src/save_lockfile/tests.rs
+++ b/pnpm/crates/lockfile/src/save_lockfile/tests.rs
@@ -103,10 +103,6 @@ fn save_reproduces_pnpm_authored_bytes() {
     assert_eq!(saved_bytes, format!("{LOCKFILE_YAML}\n"));
 }
 
-/// A `resolutionMode: time-based` install records `time:`, and every
-/// later save has to hand it back — the recorded dates are what a
-/// registry whose abbreviated metadata omits publish times resolves
-/// against.
 #[test]
 fn time_survives_a_save_round_trip() {
     let lockfile: Lockfile = serde_saphyr::from_str(&format!("{LOCKFILE_YAML}\n{DIRECT_TIME}"))
@@ -120,9 +116,7 @@ fn time_survives_a_save_round_trip() {
     assert_eq!(saved_bytes, format!("{LOCKFILE_YAML}\n{DIRECT_TIME}\n"));
 }
 
-/// Saving prunes `time:` to the importers' direct dependencies, the way
-/// pnpm's `pruneTimeInLockfile` does, so the section stays one entry per
-/// direct dependency instead of growing one per resolved package.
+/// Port of pnpm's `pruneTimeInLockfile`.
 #[test]
 fn time_is_pruned_to_the_importers_direct_dependencies() {
     const TIME_WITH_TRANSITIVE: &str = text_block! {

--- a/pnpm/crates/lockfile/src/serialize_yaml.rs
+++ b/pnpm/crates/lockfile/src/serialize_yaml.rs
@@ -4,7 +4,8 @@
 //! The byte-level YAML rendering lives in [`crate::yaml_emit`], a port of the
 //! `@zkochan/js-yaml` dumper pnpm uses for `pnpm-lock.yaml`. This module keeps
 //! the `serialize_with` helpers that canonicalize map key order before that
-//! rendering runs.
+//! rendering runs, plus the on-write normalization pnpm applies to the
+//! document as a whole.
 
 use serde::{
     Serialize,
@@ -13,8 +14,15 @@ use serde::{
 use std::{collections::HashMap, fmt::Display};
 
 /// Serialize `value` to a YAML string matching pnpm's lockfile formatting.
-pub(crate) fn to_string<Value: Serialize>(value: &Value) -> Result<String, serde_json::Error> {
-    crate::yaml_emit::to_string(value)
+///
+/// The document is normalized before rendering, the way pnpm's
+/// `normalizeLockfile` normalizes a lockfile on its way to disk.
+pub(crate) fn to_string<Document: Serialize>(
+    value: &Document,
+) -> Result<String, serde_json::Error> {
+    let mut document = serde_json::to_value(value)?;
+    crate::prune_time(&mut document);
+    Ok(crate::yaml_emit::to_string(document))
 }
 
 /// Serialize a [`HashMap`] with its entries emitted in canonical key order.

--- a/pnpm/crates/lockfile/src/yaml_emit.rs
+++ b/pnpm/crates/lockfile/src/yaml_emit.rs
@@ -73,14 +73,13 @@ const ROOT_KEYS: [&str; 9] = [
     "packages",
 ];
 
-/// Serialize `value` to a YAML string matching pnpm's lockfile formatting.
-pub(crate) fn to_string<Value: serde::Serialize>(
-    value: &Value,
-) -> Result<String, serde_json::Error> {
-    let value = sort_lockfile_keys(serde_json::to_value(value)?);
+/// Render an already-normalized lockfile document to a YAML string
+/// matching pnpm's lockfile formatting.
+pub(crate) fn to_string(value: Value) -> String {
+    let value = sort_lockfile_keys(value);
     let mut dump = render(&value, 0, true, true, None, false);
     dump.push('\n');
-    Ok(dump)
+    dump
 }
 
 /// Reorder a lockfile document's keys to match pnpm's on-write ordering:

--- a/pnpm/crates/lockfile/src/yaml_emit/tests.rs
+++ b/pnpm/crates/lockfile/src/yaml_emit/tests.rs
@@ -3,42 +3,40 @@ use serde_json::json;
 
 #[test]
 fn version_like_floats_are_single_quoted() {
-    let yaml = to_string(&json!({ "a": "9.0", "b": "11.5.2", "c": "1.0.0" })).unwrap();
+    let yaml = to_string(json!({ "a": "9.0", "b": "11.5.2", "c": "1.0.0" }));
     assert_eq!(yaml, "a: '9.0'\n\nb: 11.5.2\n\nc: 1.0.0\n");
 }
 
 #[test]
 fn leading_indicator_and_at_force_single_quotes() {
-    let yaml = to_string(&json!({
+    let yaml = to_string(json!({
         "node": ">=10",
         "name": "@scope/pkg@1.0.0",
-    }))
-    .unwrap();
+    }));
     assert_eq!(yaml, "name: '@scope/pkg@1.0.0'\n\nnode: '>=10'\n");
 }
 
 #[test]
 fn booleans_and_numbers_render_plain() {
-    let yaml = to_string(&json!({ "hasBin": true, "max": 1000 })).unwrap();
+    let yaml = to_string(json!({ "hasBin": true, "max": 1000 }));
     assert_eq!(yaml, "hasBin: true\n\nmax: 1000\n");
 }
 
 #[test]
 fn ambiguous_words_are_quoted() {
-    let yaml = to_string(&json!({ "a": "true", "b": "null", "c": "yes", "d": "no" })).unwrap();
+    let yaml = to_string(json!({ "a": "true", "b": "null", "c": "yes", "d": "no" }));
     assert_eq!(yaml, "a: 'true'\n\nb: 'null'\n\nc: yes\n\nd: no\n");
 }
 
 #[test]
 fn blank_lines_between_top_level_and_named_section_entries() {
-    let yaml = to_string(&json!({
+    let yaml = to_string(json!({
         "lockfileVersion": "9.0",
         "packages": {
             "a@1.0.0": { "x": 1 },
             "b@2.0.0": { "y": 2 },
         },
-    }))
-    .unwrap();
+    }));
     assert_eq!(
         yaml,
         "lockfileVersion: '9.0'\n\npackages:\n\n  a@1.0.0:\n    x: 1\n\n  b@2.0.0:\n    y: 2\n",
@@ -47,13 +45,12 @@ fn blank_lines_between_top_level_and_named_section_entries() {
 
 #[test]
 fn single_line_keys_render_flow() {
-    let yaml = to_string(&json!({
+    let yaml = to_string(json!({
         "resolution": { "integrity": "sha512-abc" },
         "engines": { "node": ">=10" },
         "cpu": ["x64"],
         "os": ["darwin", "linux"],
-    }))
-    .unwrap();
+    }));
     assert_eq!(
         yaml,
         "cpu: [x64]\n\nengines: {node: '>=10'}\n\nos: [darwin, linux]\n\nresolution: {integrity: sha512-abc}\n",
@@ -62,10 +59,9 @@ fn single_line_keys_render_flow() {
 
 #[test]
 fn variations_resolution_renders_block_not_flow() {
-    let yaml = to_string(&json!({
+    let yaml = to_string(json!({
         "resolution": { "type": "variations", "variants": ["a"] },
-    }))
-    .unwrap();
+    }));
     assert_eq!(yaml, "resolution:\n  type: variations\n  variants:\n    - a\n");
 }
 
@@ -79,21 +75,21 @@ fn nan_resolves_as_float() {
 
 #[test]
 fn timestamp_strings_are_quoted() {
-    let yaml = to_string(&json!({ "t": "2021-01-01" })).unwrap();
+    let yaml = to_string(json!({ "t": "2021-01-01" }));
     assert_eq!(yaml, "t: '2021-01-01'\n");
 }
 
 #[test]
 fn key_over_simple_key_limit_renders_as_explicit_pair() {
     let long_key = "k".repeat(1030);
-    let yaml = to_string(&json!({ &long_key: { "b": "c" } })).unwrap();
+    let yaml = to_string(json!({ &long_key: { "b": "c" } }));
     assert_eq!(yaml, format!("? {long_key}\n: b: c\n"));
 }
 
 #[test]
 fn key_at_simple_key_limit_renders_inline() {
     let key = "k".repeat(1024);
-    let yaml = to_string(&json!({ &key: { "b": "c" } })).unwrap();
+    let yaml = to_string(json!({ &key: { "b": "c" } }));
     assert_eq!(yaml, format!("{key}:\n  b: c\n"));
 }
 
@@ -102,6 +98,6 @@ fn key_at_simple_key_limit_renders_inline() {
 #[test]
 fn key_length_is_measured_in_utf16_code_units() {
     let key = "\u{1F600}".repeat(513);
-    let yaml = to_string(&json!({ &key: { "b": "c" } })).unwrap();
+    let yaml = to_string(json!({ &key: { "b": "c" } }));
     assert_eq!(yaml, format!("? {key}\n: b: c\n"));
 }

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -139,6 +139,11 @@ pub struct GraphToLockfileOptions<'a> {
     /// update targets the named dependency in the importer that declares
     /// it while leaving untouched importers' `link:` entries intact.
     pub update_reuse_scopes_by_importer: BTreeMap<String, UpdateReuseScope>,
+    /// The lockfile's `time:` section: the prior lockfile's recorded
+    /// publish dates with this run's freshly resolved ones layered over
+    /// them. Empty on a first install that did not resolve `time-based`.
+    /// Saving prunes it to the importers' direct dependencies.
+    pub time: BTreeMap<String, String>,
 }
 
 /// Error returned while converting a resolver graph into a lockfile.
@@ -211,6 +216,7 @@ pub fn dependencies_graph_to_lockfile(
         previous_importers,
         update_reuse_scope,
         update_reuse_scopes_by_importer,
+        time,
     } = opts;
 
     let optional_overrides = compute_corrected_optional(&importer_inputs, graph);
@@ -272,6 +278,7 @@ pub fn dependencies_graph_to_lockfile(
         importers,
         packages: (!packages.is_empty()).then_some(packages),
         snapshots: (!snapshots.is_empty()).then_some(snapshots),
+        time: (!time.is_empty()).then_some(time),
     })
 }
 

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -172,6 +172,56 @@ fn write_manifest(deps_value: serde_json::Value) -> (TempDir, PackageManifest) {
 }
 
 #[test]
+fn recorded_publish_dates_reach_the_lockfiles_time_section() {
+    let (_tmp, manifest) = write_manifest(json!({
+        "name": "fixture",
+        "version": "1.0.0",
+        "dependencies": { "react": "^17.0.2" },
+    }));
+    let node = make_node(
+        "react",
+        "17.0.2",
+        json!({ "name": "react", "version": "17.0.2" }),
+        BTreeMap::new(),
+        BTreeMap::new(),
+        HashSet::default(),
+    );
+    let mut graph = DependenciesGraph::default();
+    graph.insert(node.dep_path.clone(), node);
+    let direct = BTreeMap::from([("react".to_string(), DepPath::from("react@17.0.2".to_string()))]);
+
+    let time =
+        BTreeMap::from([("react@17.0.2".to_string(), "2021-03-22T14:00:00.000Z".to_string())]);
+    let mut opts = single_importer_opts(&manifest, &graph, direct, true, false, None, None);
+    opts.time = time.clone();
+
+    assert_eq!(dependencies_graph_to_lockfile(opts).time, Some(time));
+}
+
+/// An install that resolved no publish dates leaves the section out
+/// rather than writing an empty map.
+#[test]
+fn no_recorded_publish_dates_leave_out_the_time_section() {
+    let (_tmp, manifest) = write_manifest(json!({
+        "name": "fixture",
+        "version": "1.0.0",
+        "dependencies": { "react": "^17.0.2" },
+    }));
+    let graph = DependenciesGraph::default();
+    let lockfile = dependencies_graph_to_lockfile(single_importer_opts(
+        &manifest,
+        &graph,
+        BTreeMap::new(),
+        true,
+        false,
+        None,
+        None,
+    ));
+
+    assert_eq!(lockfile.time, None);
+}
+
+#[test]
 fn fresh_install_records_a_single_direct_dependency() {
     let (_tmp, manifest) = write_manifest(json!({
         "name": "fixture",

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -84,6 +84,7 @@ fn single_importer_opts<'a>(
         previous_importers: None,
         update_reuse_scope: UpdateReuseScope::All,
         update_reuse_scopes_by_importer: BTreeMap::new(),
+        time: BTreeMap::new(),
     }
 }
 
@@ -428,6 +429,7 @@ fn dedupe_peers_round_trips_through_lockfile_settings() {
         previous_importers: None,
         update_reuse_scope: UpdateReuseScope::All,
         update_reuse_scopes_by_importer: BTreeMap::new(),
+        time: BTreeMap::new(),
     });
     let on_settings = on.settings.as_ref().expect("settings written");
     assert_eq!(on_settings.dedupe_peers, Some(true));
@@ -459,6 +461,7 @@ fn dedupe_peers_round_trips_through_lockfile_settings() {
         previous_importers: None,
         update_reuse_scope: UpdateReuseScope::All,
         update_reuse_scopes_by_importer: BTreeMap::new(),
+        time: BTreeMap::new(),
     });
     let off_settings = off.settings.as_ref().expect("settings written");
     assert_eq!(off_settings.dedupe_peers, None);
@@ -544,6 +547,7 @@ fn patched_dependencies_flow_into_lockfile_and_empty_is_omitted() {
             previous_importers: None,
             update_reuse_scope: UpdateReuseScope::All,
             update_reuse_scopes_by_importer: BTreeMap::new(),
+            time: BTreeMap::new(),
         })
     };
 
@@ -702,6 +706,7 @@ fn aliased_catalog_dependency_records_catalog_snapshot() {
         previous_importers: None,
         update_reuse_scope: UpdateReuseScope::All,
         update_reuse_scopes_by_importer: BTreeMap::new(),
+        time: BTreeMap::new(),
     });
 
     let snapshots = lockfile.catalogs.as_ref().expect("catalogs snapshot present");
@@ -1760,6 +1765,7 @@ fn snapshot_link_uses_lockfile_root_while_importer_link_uses_project_root() {
         previous_importers: None,
         update_reuse_scope: UpdateReuseScope::All,
         update_reuse_scopes_by_importer: BTreeMap::new(),
+        time: BTreeMap::new(),
     });
 
     let importer = lockfile.importers.get("apps/nested/app").expect("nested importer");
@@ -1851,6 +1857,7 @@ fn multi_importer_workspace_writes_per_project_lockfile_entries() {
         previous_importers: None,
         update_reuse_scope: UpdateReuseScope::All,
         update_reuse_scopes_by_importer: BTreeMap::new(),
+        time: BTreeMap::new(),
     });
 
     let a_snap = lockfile.importers.get("packages/a").expect("importer a");
@@ -1960,6 +1967,7 @@ fn multi_importer_pruner_marks_shared_dep_non_optional_when_any_importer_reaches
         previous_importers: None,
         update_reuse_scope: UpdateReuseScope::All,
         update_reuse_scopes_by_importer: BTreeMap::new(),
+        time: BTreeMap::new(),
     });
 
     let snapshots = lockfile.snapshots.as_ref().expect("snapshots map");
@@ -2095,6 +2103,7 @@ fn workspace_sibling_link_renders_per_importer_with_link_ref() {
         previous_importers: None,
         update_reuse_scope: UpdateReuseScope::All,
         update_reuse_scopes_by_importer: BTreeMap::new(),
+        time: BTreeMap::new(),
     });
 
     let a_snap = lockfile.importers.get("packages/a").expect("importer a");

--- a/pnpm/crates/package-manager/src/install/tests.rs
+++ b/pnpm/crates/package-manager/src/install/tests.rs
@@ -49,6 +49,7 @@ fn empty_test_lockfile() -> Lockfile {
         importers: std::collections::HashMap::new(),
         packages: None,
         snapshots: None,
+        time: None,
     }
 }
 

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1059,6 +1059,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         }
         let merged_graph = workspace_result.peers.graph;
         let direct_by_importer = workspace_result.peers.direct_dependencies_by_importer;
+        let resolved_time = workspace_result.time;
         tracing::info!(
             target: "pacquet::install::phase",
             phase = "resolve_workspace",
@@ -1140,6 +1141,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
                 real_importer_ids,
                 selected_importer_ids,
                 lockfile_dir,
+                resolved_time,
             })?;
             return finish_lockfile_only::<Reporter>(LockfileOnlyOptions {
                 built_lockfile,
@@ -1228,6 +1230,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             real_importer_ids,
             selected_importer_ids,
             lockfile_dir,
+            resolved_time,
         })?;
         tracing::info!(
             target: "pacquet::install::phase",
@@ -1990,6 +1993,10 @@ struct FreshLockfileBuildOptions<'a> {
     real_importer_ids: Option<&'a std::collections::HashSet<String>>,
     selected_importer_ids: Option<&'a std::collections::HashSet<String>>,
     lockfile_dir: &'a Path,
+    /// Publish dates this run resolved for the direct dependencies,
+    /// layered over the ones [`Self::wanted_lockfile`] recorded. Empty
+    /// unless the install resolved `time-based`.
+    resolved_time: BTreeMap<String, String>,
 }
 
 /// Build the fresh lockfile, then — under a filtered install — splice it
@@ -2023,10 +2030,11 @@ fn build_fresh_lockfile(
     opts: FreshLockfileBuildOptions<'_>,
 ) -> Result<Lockfile, DependenciesGraphToLockfileError> {
     let FreshLockfileBuildOptions {
-        wanted_lockfile: _,
+        wanted_lockfile,
         real_importer_ids: _,
         selected_importer_ids: _,
         lockfile_dir: _,
+        resolved_time,
         config,
         importer_manifests,
         graph,
@@ -2077,8 +2085,26 @@ fn build_fresh_lockfile(
         previous_importers,
         update_reuse_scope,
         update_reuse_scopes_by_importer,
+        time: merge_recorded_time(wanted_lockfile, resolved_time),
     })?;
     Ok(lockfile)
+}
+
+/// The `time:` section the rewritten lockfile carries: what the prior
+/// lockfile recorded, with this run's freshly resolved publish dates
+/// layered over it. Keeping the prior entries is what preserves a
+/// recorded date for a dependency whose packument does not carry one;
+/// saving prunes whatever is no longer a direct dependency.
+fn merge_recorded_time(
+    wanted_lockfile: Option<&Lockfile>,
+    resolved_time: BTreeMap<String, String>,
+) -> BTreeMap<String, String> {
+    let Some(recorded) = wanted_lockfile.and_then(|lockfile| lockfile.time.as_ref()) else {
+        return resolved_time;
+    };
+    let mut time = recorded.clone();
+    time.extend(resolved_time);
+    time
 }
 
 pub(crate) fn compute_package_extensions_checksum(config: &Config) -> Option<String> {

--- a/pnpm/crates/package-manager/src/lockfile_diff/tests.rs
+++ b/pnpm/crates/package-manager/src/lockfile_diff/tests.rs
@@ -90,6 +90,7 @@ fn lockfile(root: ProjectSnapshot, snapshots: &[(&str, SnapshotEntry)]) -> Lockf
         importers: HashMap::from([(".".to_string(), root)]),
         packages: None,
         snapshots: Some(snapshots.iter().map(|(id, entry)| (key(id), entry.clone())).collect()),
+        time: None,
     }
 }
 

--- a/pnpm/crates/package-manager/src/patch/tests.rs
+++ b/pnpm/crates/package-manager/src/patch/tests.rs
@@ -37,6 +37,7 @@ fn empty_lockfile() -> Lockfile {
         importers: HashMap::new(),
         packages: None,
         snapshots: None,
+        time: None,
     }
 }
 

--- a/pnpm/crates/real-hoist/src/tests.rs
+++ b/pnpm/crates/real-hoist/src/tests.rs
@@ -46,6 +46,7 @@ fn empty_lockfile() -> Lockfile {
         importers: HashMap::new(),
         packages: None,
         snapshots: None,
+        time: None,
     }
 }
 
@@ -71,6 +72,7 @@ fn hoist_throws_on_broken_lockfile() {
         importers,
         packages: None,
         snapshots: None,
+        time: None,
     };
 
     let err = hoist(&lockfile, &HoistOpts::default()).expect_err("missing snapshot should error");
@@ -118,6 +120,7 @@ fn one_transitive_dep_hoists_to_root() {
         importers,
         packages: None,
         snapshots: Some(snapshots),
+        time: None,
     };
 
     let result = hoist(&lockfile, &HoistOpts::default()).expect("happy hoist should succeed");
@@ -168,6 +171,7 @@ fn diamond_dep_hoists_once_to_root() {
         importers,
         packages: None,
         snapshots: Some(snapshots),
+        time: None,
     };
 
     let result = hoist(&lockfile, &HoistOpts::default()).expect("hoist should succeed");
@@ -247,6 +251,7 @@ fn version_conflict_keeps_loser_at_parent() {
         importers,
         packages: None,
         snapshots: Some(snapshots),
+        time: None,
     };
 
     let result = hoist(&lockfile, &HoistOpts::default()).expect("hoist should succeed");
@@ -321,6 +326,7 @@ fn most_used_version_wins_root_slot() {
         importers,
         packages: None,
         snapshots: Some(snapshots),
+        time: None,
     };
 
     let result = hoist(&lockfile, &HoistOpts::default()).expect("hoist should succeed");
@@ -387,6 +393,7 @@ fn deep_chain_flattens_in_one_pass() {
         importers,
         packages: None,
         snapshots: Some(snapshots),
+        time: None,
     };
 
     let result = hoist(&lockfile, &HoistOpts::default()).expect("hoist should succeed");
@@ -424,6 +431,7 @@ fn external_dependencies_are_stripped_from_the_result() {
         importers,
         packages: None,
         snapshots: Some(snapshots),
+        time: None,
     };
 
     let opts = HoistOpts {
@@ -467,6 +475,7 @@ fn transitive_npm_alias_resolves_target_snapshot() {
         importers,
         packages: None,
         snapshots: Some(snapshots),
+        time: None,
     };
 
     let result =
@@ -562,6 +571,7 @@ fn peer_constrained_node_stays_under_parent_when_root_provides_different_ident()
         importers,
         packages: Some(packages),
         snapshots: Some(snapshots),
+        time: None,
     };
 
     let result = hoist(&lockfile, &HoistOpts::default()).expect("peer-aware hoist should succeed");
@@ -623,6 +633,7 @@ fn peer_check_uses_post_hoist_ancestor_path_not_queue_time_path() {
         importers,
         packages: Some(packages),
         snapshots: Some(snapshots),
+        time: None,
     };
 
     let result = hoist(&lockfile, &HoistOpts::default()).expect("hoist should succeed");
@@ -680,6 +691,7 @@ fn peer_constrained_node_hoists_when_ancestor_and_root_agree() {
         importers,
         packages: Some(packages),
         snapshots: Some(snapshots),
+        time: None,
     };
 
     let result = hoist(&lockfile, &HoistOpts::default()).expect("peer-aware hoist should succeed");
@@ -735,6 +747,7 @@ fn multi_round_unlocks_peer_friendly_hoist_after_blocker_moves() {
         importers,
         packages: Some(packages),
         snapshots: Some(snapshots),
+        time: None,
     };
 
     let result = hoist(&lockfile, &HoistOpts::default()).expect("multi-round should converge");
@@ -781,6 +794,7 @@ fn hoisting_limits_border_keeps_descendants_nested() {
         importers,
         packages: None,
         snapshots: Some(snapshots),
+        time: None,
     };
 
     let mut blocked = BTreeSet::new();
@@ -834,6 +848,7 @@ fn hoisting_limits_border_keeps_all_descendants_nested() {
         importers,
         packages: None,
         snapshots: Some(snapshots),
+        time: None,
     };
 
     let mut blocked = BTreeSet::new();
@@ -888,6 +903,7 @@ fn hoisting_limits_keyed_on_unrelated_importer_is_inert() {
         importers,
         packages: None,
         snapshots: Some(snapshots),
+        time: None,
     };
 
     let mut blocked = BTreeSet::new();
@@ -949,6 +965,7 @@ fn nested_hoist_uses_the_nested_root_locator() {
             importers,
             packages: None,
             snapshots: Some(snapshots),
+            time: None,
         },
         &opts,
     )
@@ -1009,6 +1026,7 @@ fn self_dependency_does_not_loop() {
         importers,
         packages: None,
         snapshots: Some(snapshots),
+        time: None,
     };
 
     let result = hoist(&lockfile, &HoistOpts::default()).expect("self-dep should not loop");
@@ -1056,6 +1074,7 @@ fn basic_cyclic_dependency_terminates() {
             importers,
             packages: None,
             snapshots: Some(snapshots),
+            time: None,
         },
         &HoistOpts::default(),
     )
@@ -1089,6 +1108,7 @@ fn multi_importer_lockfile_emits_workspace_children() {
         importers,
         packages: None,
         snapshots: None,
+        time: None,
     };
 
     let result = hoist(&lockfile, &HoistOpts::default()).expect("workspace hoist succeeds");
@@ -1137,6 +1157,7 @@ fn hoist_workspace_packages_false_keeps_workspace_children() {
         importers,
         packages: None,
         snapshots: None,
+        time: None,
     };
 
     let opts = HoistOpts { hoist_workspace_packages: false, ..HoistOpts::default() };

--- a/pnpm/crates/resolving-deps-resolver/src/lockfile_reuse/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/lockfile_reuse/tests.rs
@@ -42,6 +42,7 @@ fn empty_lockfile() -> Lockfile {
         importers: HashMap::new(),
         packages: None,
         snapshots: None,
+        time: None,
     }
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
@@ -55,6 +55,7 @@ fn locked_peer_context_is_recorded_by_direct_alias() {
         patched_dependencies: None,
         packages: None,
         snapshots: None,
+        time: None,
     };
 
     let ImporterLockedPeerContext { versions, names_by_alias } =
@@ -116,6 +117,7 @@ fn only_peer_suffix_versions_are_treated_as_locked_peer_providers() {
                 SnapshotEntry::default(),
             ),
         ])),
+        time: None,
     };
 
     assert_eq!(
@@ -181,6 +183,7 @@ fn hashed_peer_suffix_uses_package_peer_metadata() {
                 ..SnapshotEntry::default()
             },
         )])),
+        time: None,
     };
 
     let ImporterLockedPeerContext { versions, names_by_alias } =

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -157,6 +157,9 @@ pub struct WorkspaceResolveOptions {
 pub struct ResolveWorkspaceResult {
     pub merged_tree: ResolvedTree,
     pub peers: WorkspaceResolvePeersResult,
+    /// Publish date of every direct dependency, for the lockfile's
+    /// `time:` section. Empty unless the install ran `time-based`.
+    pub time: BTreeMap<String, String>,
 }
 
 /// Resolve every importer's dependencies, then run one workspace-wide
@@ -202,6 +205,8 @@ where
         registries,
         named_registries,
     } = opts;
+    // Taken before the lockfile moves into the workspace ctx below.
+    let recorded_time = wanted_lockfile.as_ref().and_then(|lockfile| lockfile.time.clone());
     let workspace = Arc::new(
         WorkspaceTreeCtx::default()
             .with_manifest_hook(manifest_hook)
@@ -240,7 +245,7 @@ where
     // importer's `base_opts.published_by` by the install layer; it is
     // the upper bound on the time-based cutoff.
     let maximum_published_by = importer_opts.first().and_then(|opts| opts.base_opts.published_by);
-    let subdep_published_by = if time_based {
+    let TimeBasedCutoff { published_by: subdep_published_by, time } = if time_based {
         compute_time_based_cutoff(
             resolver,
             importers,
@@ -248,10 +253,11 @@ where
             dependency_groups,
             pick_lowest_direct,
             maximum_published_by,
+            recorded_time.as_ref(),
         )
         .await
     } else {
-        maximum_published_by
+        TimeBasedCutoff { published_by: maximum_published_by, time: BTreeMap::new() }
     };
 
     // Phase 1: every importer's initial wave resolves before any peer
@@ -396,13 +402,29 @@ where
         resolve_peers_from_workspace_root,
         peer_opts,
     );
-    Ok(ResolveWorkspaceResult { merged_tree, peers })
+    Ok(ResolveWorkspaceResult { merged_tree, peers, time })
+}
+
+/// What a `time-based` pre-pass learned about the direct dependencies.
+struct TimeBasedCutoff {
+    /// The ceiling every transitive dependency's publish date must
+    /// respect.
+    published_by: Option<DateTime<Utc>>,
+    /// Publish date per direct dependency, for the lockfile's `time:`
+    /// section.
+    time: BTreeMap<String, String>,
 }
 
 /// Resolve every importer's direct dependencies and derive the
 /// `time-based` publish-date cutoff for transitive deps.
 ///
-/// Only the direct deps' `published_at` is read here, so the throwaway
+/// Each direct dependency's publish date comes from its packument, or —
+/// against a registry whose abbreviated metadata omits publish times —
+/// from `recorded_time`, the date the lockfile's `time:` section
+/// recorded for it. The cutoff is the newest of those dates plus an
+/// hour, clamped by `maximum_published_by`.
+///
+/// Only the direct deps' publish date is read here, so the throwaway
 /// resolves warm the resolver's packument cache for the real walk that
 /// follows. Resolver errors are ignored here — the real walk surfaces
 /// them.
@@ -413,11 +435,12 @@ async fn compute_time_based_cutoff<Chain>(
     dependency_groups: &[DependencyGroup],
     pick_lowest_direct: bool,
     maximum_published_by: Option<DateTime<Utc>>,
-) -> Option<DateTime<Utc>>
+    recorded_time: Option<&BTreeMap<String, String>>,
+) -> TimeBasedCutoff
 where
     Chain: Resolver + ?Sized,
 {
-    let mut newest: Option<DateTime<Utc>> = None;
+    let mut time = BTreeMap::new();
     for (importer, opts) in importers.iter().zip(importer_opts) {
         let Ok(specs) = importer_direct_wanted_specs(
             importer.manifest,
@@ -437,21 +460,25 @@ where
                 injected: injected.then_some(true),
                 ..WantedDependency::default()
             };
-            if let Ok(Some(result)) = resolver.resolve(&wanted, &direct_opts).await
-                && let Some(published_at) = result.published_at.as_deref()
-                && let Some(parsed) = parse_packument_timestamp(published_at)
-            {
-                newest = Some(newest.map_or(parsed, |current| current.max(parsed)));
+            let Ok(Some(result)) = resolver.resolve(&wanted, &direct_opts).await else { continue };
+            let published_at = result.published_at.or_else(|| {
+                recorded_time.and_then(|recorded| recorded.get(result.id.as_str())).cloned()
+            });
+            if let Some(published_at) = published_at {
+                time.insert(result.id.into_inner(), published_at);
             }
         }
     }
 
+    let newest =
+        time.values().filter_map(|published_at| parse_packument_timestamp(published_at)).max();
     let candidate = newest.and_then(|date| date.checked_add_signed(Duration::hours(1)));
-    match (candidate, maximum_published_by) {
+    let published_by = match (candidate, maximum_published_by) {
         (Some(candidate), Some(maximum)) => Some(candidate.min(maximum)),
         (Some(candidate), None) => Some(candidate),
         (None, maximum) => maximum,
-    }
+    };
+    TimeBasedCutoff { published_by, time }
 }
 
 #[cfg(test)]

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -205,8 +205,13 @@ where
         registries,
         named_registries,
     } = opts;
-    // Taken before the lockfile moves into the workspace ctx below.
-    let recorded_time = wanted_lockfile.as_ref().and_then(|lockfile| lockfile.time.clone());
+    // Taken before the lockfile moves into the workspace ctx below, and
+    // only for the pre-pass that reads it — a lockfile is untrusted
+    // input, so an install that will not consult the recorded dates
+    // must not copy them.
+    let recorded_time = time_based
+        .then(|| wanted_lockfile.as_ref().and_then(|lockfile| lockfile.time.clone()))
+        .flatten();
     let workspace = Arc::new(
         WorkspaceTreeCtx::default()
             .with_manifest_hook(manifest_hook)

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -306,6 +306,7 @@ fn importer_scoped_update_lockfile(
         importers,
         packages: Some(packages),
         snapshots: Some(snapshots),
+        time: None,
     }
 }
 
@@ -742,7 +743,7 @@ async fn time_based_cutoff_is_newest_direct_publish_plus_one_hour() {
     let (tmp, manifest) = fake_manifest(serde_json::json!({ "a": "^1.0.0", "b": "^1.0.0" }));
     let importers = [WorkspaceImporter { id: ".".to_string(), manifest: &manifest }];
 
-    resolve_workspace(
+    let result = resolve_workspace(
         &resolver,
         &importers,
         &[DependencyGroup::Prod],
@@ -764,6 +765,86 @@ async fn time_based_cutoff_is_newest_direct_publish_plus_one_hour() {
         (false, Some(expected_cutoff)),
         "subdep picks highest, constrained to newest-direct + 1h",
     );
+    assert_eq!(
+        result.time,
+        recorded_time(&[
+            ("a@1.0.0", "2024-03-01T10:00:00.000Z"),
+            ("b@1.0.0", "2024-05-20T08:00:00.000Z"),
+        ]),
+        "the direct deps' publish dates are handed to the lockfile's `time:` section",
+    );
+}
+
+/// Against a registry whose abbreviated metadata omits publish times,
+/// the dates the lockfile already recorded are what the cutoff is
+/// derived from — otherwise a re-resolve would compute a different
+/// cutoff and could pick different subdependency versions.
+#[tokio::test]
+async fn time_based_cutoff_falls_back_to_the_lockfiles_recorded_time() {
+    let mut table = HashMap::default();
+    table.insert(
+        ("a".to_string(), "^1.0.0".to_string()),
+        fake_result(
+            "a",
+            "1.0.0",
+            None,
+            serde_json::json!({ "name": "a", "version": "1.0.0", "dependencies": { "sub": "^2.0.0" } }),
+        ),
+    );
+    table.insert(
+        ("sub".to_string(), "^2.0.0".to_string()),
+        fake_result("sub", "2.0.0", None, serde_json::json!({ "name": "sub", "version": "2.0.0" })),
+    );
+    let resolver = RecordingResolver { table, seen: Mutex::new(HashMap::default()) };
+    let (tmp, manifest) = fake_manifest(serde_json::json!({ "a": "^1.0.0" }));
+    let importers = [WorkspaceImporter { id: ".".to_string(), manifest: &manifest }];
+
+    let mut opts = workspace_opts(true, true);
+    opts.wanted_lockfile =
+        Some(Arc::new(lockfile_recording_time(&[("a@1.0.0", "2024-05-20T08:00:00.000Z")])));
+
+    let result = resolve_workspace(&resolver, &importers, &[DependencyGroup::Prod], opts, |_| {
+        importer_opts(tmp.path().to_path_buf(), None)
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(
+        resolver.opts_for("sub"),
+        (false, Some(Utc.with_ymd_and_hms(2024, 5, 20, 9, 0, 0).unwrap())),
+        "the recorded publish date stands in for the missing one",
+    );
+    assert_eq!(
+        result.time,
+        recorded_time(&[("a@1.0.0", "2024-05-20T08:00:00.000Z")]),
+        "a recorded date is carried forward, not dropped",
+    );
+}
+
+fn recorded_time(entries: &[(&str, &str)]) -> BTreeMap<String, String> {
+    entries
+        .iter()
+        .map(|(pkg_id, published_at)| ((*pkg_id).to_string(), (*published_at).to_string()))
+        .collect()
+}
+
+fn lockfile_recording_time(entries: &[(&str, &str)]) -> pacquet_lockfile::Lockfile {
+    use pacquet_lockfile::{ComVer, Lockfile, LockfileVersion};
+
+    Lockfile {
+        lockfile_version: LockfileVersion::<9>::try_from(ComVer::new(9, 0)).expect("lockfile v9"),
+        settings: None,
+        catalogs: None,
+        overrides: None,
+        package_extensions_checksum: None,
+        pnpmfile_checksum: None,
+        ignored_optional_dependencies: None,
+        patched_dependencies: None,
+        importers: std::collections::HashMap::new(),
+        packages: None,
+        snapshots: None,
+        time: Some(recorded_time(entries)),
+    }
 }
 
 #[tokio::test]
@@ -978,6 +1059,7 @@ async fn shared_subtree_owner_context_suppresses_later_optional_hoist() {
             pacquet_lockfile::PkgNameVerPeer::from_str("shared@1.0.0(opt@25.0.0)").unwrap(),
             pacquet_lockfile::SnapshotEntry::default(),
         )])),
+        time: None,
     }));
     let mut next = 0;
     let result = resolve_workspace(&resolver, &importers, &[DependencyGroup::Prod], opts, |_| {
@@ -1568,6 +1650,7 @@ fn lockfile_with_package(key: &str) -> pacquet_lockfile::Lockfile {
         importers: std::collections::HashMap::new(),
         packages: Some(std::collections::HashMap::from([(key, metadata)])),
         snapshots: None,
+        time: None,
     }
 }
 
@@ -1999,6 +2082,7 @@ fn reuse_graph_lockfile(
         importers,
         packages: Some(packages),
         snapshots: Some(snapshots),
+        time: None,
     }
 }
 
@@ -3076,6 +3160,7 @@ fn reuse_steal_lockfile() -> pacquet_lockfile::Lockfile {
         importers,
         packages: Some(packages),
         snapshots: Some(snapshots),
+        time: None,
     }
 }
 


### PR DESCRIPTION
## Summary

pacquet's `Lockfile` struct had no `time` field, so serde discarded the section on load and never wrote it back. Any `pnpm-lock.yaml` carrying the publish dates a `resolutionMode: time-based` install records lost them the first time pacquet rewrote it.

That is not only lockfile churn. In the TypeScript CLI, `getPublishedByDate` builds each direct dependency's publish date from the resolver's `publishedAt` **and falls back to the lockfile's `time` entry when the registry's abbreviated metadata carries none**. The newest of those dates (plus an hour) is the cutoff every subdependency is resolved under, so dropping the section can make a later time-based resolution pick different subdependency versions.

This PR:

- adds `time: Option<BTreeMap<String, String>>` to `Lockfile`, so the section round-trips;
- fills it from the `time-based` pre-pass — the prior lockfile's entries with this run's freshly resolved publish dates layered over them, matching upstream's `{...wantedLockfile.time, ...time}`;
- prunes it to the importers' direct dependencies on save, a port of `pruneTimeInLockfile` (peer suffix stripped, `link:` deps contribute nothing, npm aliases match their target's depPath);
- reads it back in `compute_time_based_cutoff` as the fallback publish date for a direct dependency whose packument carries none.

The prune runs where pnpm's `normalizeLockfile` runs — on the serialized document, on the way to disk — so it covers every write path (fresh resolve, the fast lockfile update, the current lockfile under `node_modules/.pnpm`, and an `afterAllResolved` result) rather than one lockfile-building site. It also runs ahead of the verification cache's content hash, so an in-memory lockfile still hashes to what it will hash to once saved and read back.

The pnpr-assisted install path needs nothing of its own: the server resolves through the same fresh-lockfile pipeline, so the input lockfile's recorded dates already reach its answer. An end-to-end test against an in-process pnpr pins that.

This is a pacquet-only fix — the TypeScript CLI already models, writes, prunes, and reads the section. No TypeScript changes are needed for parity.

Closes pnpm/pnpm#13776

## Squash Commit Body

```text
pacquet's `Lockfile` had no `time` field, so serde discarded the section
on load and never wrote it back: a `pnpm-lock.yaml` carrying the publish
dates a `resolutionMode: time-based` install records lost them the first
time pacquet rewrote it.

Model the section, fill it from the `time-based` pre-pass (the prior
lockfile's entries with this run's freshly resolved ones layered over
them), prune it to the importers' direct dependencies on save the way
`pruneTimeInLockfile` does, and read it back as the fallback publish date
for a direct dependency whose packument carries none — so against a
registry whose abbreviated metadata omits publish times, a later
resolution derives the cutoff the lockfile was written under rather than
a different one.

The prune runs on the serialized document, where pnpm's
`normalizeLockfile` runs, so every write path is covered: the fresh
resolve, the fast lockfile update, the current lockfile under
`node_modules/.pnpm`, and an `afterAllResolved` result. It also runs
ahead of the verification cache's content hash, so an in-memory lockfile
still hashes to what it will hash to once saved and read back.

Closes pnpm/pnpm#13776
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).
