### PR TITLE
fix(deploy): deploy the workspace root when it is the selected project

### DIFF
--- a/.changeset/deploy-the-workspace-root.md
+++ b/.changeset/deploy-the-workspace-root.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm --filter . deploy` deploys the project in the current directory instead of the projects nested under it, so deploying the workspace root now copies the root project and installs its workspace dependencies [#13758](https://github.com/pnpm/pnpm/issues/13758). `pnpm deploy --legacy` no longer rewrites the source workspace's `pnpm-lock.yaml`.

--- a/pnpm/crates/cli/src/cli_args/deploy.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy.rs
@@ -303,13 +303,10 @@ impl DeployArgs {
             State::init(deploy_dir.join("package.json"), deploy_config, frozen_lockfile)
                 .wrap_err("initialize the deploy install state")?;
         if legacy {
-            // Legacy deploy still resolves workspace dependencies from the
-            // source workspace, but its synthetic project is not one of that
-            // workspace's importers: the deploy hook rewrites the copied
-            // manifest, so the workspace's own importer entries describe a
-            // different dependency shape. Anchoring the wanted lockfile at
-            // the deploy directory keeps the workspace lockfile out of the
-            // install — `run_legacy_deploy` keeps it from being written too.
+            // The deployed project is not one of the source workspace's
+            // importers — the deploy hook rewrites the copied manifest —
+            // so its resolution must not be seeded from the workspace
+            // lockfile.
             state.lockfile = if state.config.lockfile || frozen_lockfile {
                 LazyLockfile::deferred(deploy_dir.to_path_buf())
             } else {
@@ -318,14 +315,11 @@ impl DeployArgs {
         }
         let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
             &state;
-        // The deployed project is installed on its own, even when the
-        // copied files include a `pnpm-workspace.yaml` and the projects
-        // it globs — deploying the workspace root copies both. Handing
-        // the install the deployed project as the whole workspace keeps
-        // those copies out of the importer list, which the generated
-        // frozen lockfile does not describe (pnpm reaches the same
-        // outcome by installing the deploy directory with no workspace
-        // at all).
+        // Deploying the workspace root copies `pnpm-workspace.yaml` and
+        // the projects it globs, none of which the generated frozen
+        // lockfile describes. pnpm installs the deploy directory with no
+        // workspace at all; pacquet's equivalent is a workspace holding
+        // the deployed project alone.
         let workspace_projects_override = (!legacy).then(|| {
             vec![Project {
                 root_dir: deploy_dir.to_path_buf(),
@@ -427,9 +421,7 @@ fn cannot_deploy_error(dir: &Path) -> miette::Report {
 
 /// Resolve `--filter` / `--filter-prod` (and `-w`) to the single project
 /// to deploy, through the same selection every other filtered command
-/// runs: path selectors resolve against `dir` and match by glob, so
-/// `--filter .` names the project in `dir` rather than every project
-/// nested under it.
+/// runs against `dir`.
 fn select_project(
     config: &Config,
     workspace_dir: &Path,
@@ -445,9 +437,6 @@ fn select_project(
         .collect::<Vec<_>>();
 
     let selected_root = {
-        // Deploying the workspace root is a legitimate request
-        // (`--filter .` from the root), so the root is never
-        // auto-excluded from the selection.
         let selection =
             select_recursive_projects(&projects, config, dir, AutoExcludeRoot::Disabled)?;
         let mut selected = selection.selected.keys();

--- a/pnpm/crates/cli/src/cli_args/deploy.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy.rs
@@ -1,12 +1,14 @@
 use crate::{
     State,
-    cli_args::install::{InstallArgs, NodeLinkerArg, resolve_bool_override},
+    cli_args::{
+        install::{InstallArgs, NodeLinkerArg, resolve_bool_override},
+        recursive::{AutoExcludeRoot, discover_workspace_projects, select_recursive_projects},
+    },
 };
 use clap::Args;
 use derive_more::{Display, Error};
-use indexmap::IndexMap;
 use miette::{Context, Diagnostic, IntoDiagnostic};
-use pacquet_config::{Config, LinkWorkspacePackages, NodeLinker, PackageImportMethod};
+use pacquet_config::{Config, NodeLinker, PackageImportMethod};
 use pacquet_directory_fetcher::DirectoryFetcher;
 use pacquet_fs::{lexical_normalize, remove_dirent};
 use pacquet_lockfile::{
@@ -20,12 +22,7 @@ use pacquet_package_manager::{
 };
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_reporter::{LogEvent, LogLevel, PnpmLog, Reporter};
-use pacquet_workspace::{
-    FindWorkspaceProjectsOpts, Project, WORKSPACE_MANIFEST_FILENAME, find_workspace_projects,
-    importer_id_from_root_dir, read_workspace_manifest, workspace_package_patterns,
-};
-use pacquet_workspace_projects_filter::{FilterProjectsOptions, WorkspaceFilter, filter_projects};
-use pacquet_workspace_projects_graph::{BaseProject, GraphProject};
+use pacquet_workspace::{Project, WORKSPACE_MANIFEST_FILENAME, importer_id_from_root_dir};
 use serde_json::{Map, Value, json};
 use std::{
     collections::{HashMap, HashSet, VecDeque},
@@ -113,43 +110,6 @@ enum DeployError {
     UnsafeLockfilePath { path: PathBuf, workspace_dir: PathBuf },
 }
 
-#[derive(Clone, Copy)]
-struct GraphPkg<'a> {
-    project: &'a Project,
-}
-
-impl BaseProject for GraphPkg<'_> {
-    fn root_dir(&self) -> &Path {
-        &self.project.root_dir
-    }
-
-    fn manifest_name(&self) -> Option<&str> {
-        self.project.manifest.value().get("name").and_then(Value::as_str)
-    }
-}
-
-impl GraphProject for GraphPkg<'_> {
-    fn manifest_version(&self) -> Option<&str> {
-        self.project.manifest.value().get("version").and_then(Value::as_str)
-    }
-
-    fn merged_dependencies(&self, ignore_dev_deps: bool) -> Vec<(String, String)> {
-        let mut merged: IndexMap<String, String> = IndexMap::new();
-        let mut absorb = |group: DependencyGroup| {
-            for (name, spec) in self.project.manifest.dependencies([group]) {
-                merged.insert(name.to_string(), spec.to_string());
-            }
-        };
-        absorb(DependencyGroup::Peer);
-        if !ignore_dev_deps {
-            absorb(DependencyGroup::Dev);
-        }
-        absorb(DependencyGroup::Optional);
-        absorb(DependencyGroup::Prod);
-        merged.into_iter().collect()
-    }
-}
-
 #[derive(Clone)]
 struct ProjectInfo {
     root_dir: PathBuf,
@@ -203,7 +163,7 @@ impl DeployArgs {
     ) -> miette::Result<()> {
         let workspace_dir =
             config.workspace_dir.as_deref().ok_or_else(|| cannot_deploy_error(dir))?;
-        let selected = select_project(config, workspace_dir)?;
+        let selected = select_project(config, workspace_dir, dir)?;
         if self.target_dirs.len() != 1 {
             return Err(DeployError::InvalidDeployTarget.into());
         }
@@ -344,8 +304,12 @@ impl DeployArgs {
                 .wrap_err("initialize the deploy install state")?;
         if legacy {
             // Legacy deploy still resolves workspace dependencies from the
-            // source workspace, but its synthetic project owns a lockfile in
-            // the deploy directory.
+            // source workspace, but its synthetic project is not one of that
+            // workspace's importers: the deploy hook rewrites the copied
+            // manifest, so the workspace's own importer entries describe a
+            // different dependency shape. Anchoring the wanted lockfile at
+            // the deploy directory keeps the workspace lockfile out of the
+            // install — `run_legacy_deploy` keeps it from being written too.
             state.lockfile = if state.config.lockfile || frozen_lockfile {
                 LazyLockfile::deferred(deploy_dir.to_path_buf())
             } else {
@@ -354,6 +318,21 @@ impl DeployArgs {
         }
         let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
             &state;
+        // The deployed project is installed on its own, even when the
+        // copied files include a `pnpm-workspace.yaml` and the projects
+        // it globs — deploying the workspace root copies both. Handing
+        // the install the deployed project as the whole workspace keeps
+        // those copies out of the importer list, which the generated
+        // frozen lockfile does not describe (pnpm reaches the same
+        // outcome by installing the deploy directory with no workspace
+        // at all).
+        let workspace_projects_override = (!legacy).then(|| {
+            vec![Project {
+                root_dir: deploy_dir.to_path_buf(),
+                manifest: manifest.clone(),
+                dependency_manifest: None,
+            }]
+        });
 
         let supported_architectures = self
             .install_args
@@ -402,10 +381,10 @@ impl DeployArgs {
             catalogs_override: None,
             disable_optimistic_repeat_install: true,
             pnpmfile_hook_override: None,
-            workspace_projects_override: None,
+            workspace_projects_override,
         };
         if legacy {
-            install.run_with_root_importer::<ReporterT>().await
+            install.run_legacy_deploy::<ReporterT>().await
         } else {
             install.run::<ReporterT>().await
         }
@@ -446,18 +425,17 @@ fn cannot_deploy_error(dir: &Path) -> miette::Report {
     }
 }
 
-fn select_project(config: &Config, workspace_dir: &Path) -> miette::Result<SelectedProject> {
-    let manifest = read_workspace_manifest(workspace_dir)
-        .map_err(miette::Report::new)
-        .wrap_err("read workspace manifest")?
-        .unwrap_or_default();
-    let projects = find_workspace_projects(
-        workspace_dir,
-        &FindWorkspaceProjectsOpts { patterns: Some(workspace_package_patterns(&manifest)) },
-    )
-    .map_err(miette::Report::new)
-    .wrap_err("find workspace projects")?;
-
+/// Resolve `--filter` / `--filter-prod` (and `-w`) to the single project
+/// to deploy, through the same selection every other filtered command
+/// runs: path selectors resolve against `dir` and match by glob, so
+/// `--filter .` names the project in `dir` rather than every project
+/// nested under it.
+fn select_project(
+    config: &Config,
+    workspace_dir: &Path,
+    dir: &Path,
+) -> miette::Result<SelectedProject> {
+    let (projects, _patterns) = discover_workspace_projects(workspace_dir)?;
     let all_projects = projects
         .iter()
         .map(|project| ProjectInfo {
@@ -466,46 +444,24 @@ fn select_project(config: &Config, workspace_dir: &Path) -> miette::Result<Selec
         })
         .collect::<Vec<_>>();
 
-    let graph_projects = projects.iter().map(|project| GraphPkg { project }).collect::<Vec<_>>();
-    let filters =
-        config
-            .filter
-            .iter()
-            .map(|filter| WorkspaceFilter { filter: filter.clone(), follow_prod_deps_only: false })
-            .chain(config.filter_prod.iter().map(|filter| WorkspaceFilter {
-                filter: filter.clone(),
-                follow_prod_deps_only: true,
-            }))
-            .collect::<Vec<_>>();
-    let link_workspace_packages =
-        Some(config.link_workspace_packages != LinkWorkspacePackages::Off);
-    let selected = filter_projects(
-        graph_projects,
-        &filters,
-        &FilterProjectsOptions {
-            prefix: workspace_dir.to_path_buf(),
-            link_workspace_packages,
-            use_glob_dir_filtering: false,
-            workspace_dir: workspace_dir.to_path_buf(),
-            test_pattern: config.test_pattern.clone(),
-            changed_files_ignore_pattern: config.changed_files_ignore_pattern.clone(),
-        },
-    )
-    .map_err(miette::Report::new)
-    .wrap_err("filter workspace projects")?;
-
-    match selected.selected_projects.as_slice() {
-        [] => Err(DeployError::NothingToDeploy.into()),
-        [_one] if selected.selected_projects.len() == 1 => {
-            let selected_root = lexical_normalize(&selected.selected_projects[0]);
-            let project = projects
-                .into_iter()
-                .find(|project| lexical_normalize(&project.root_dir) == selected_root)
-                .ok_or(DeployError::NothingToDeploy)?;
-            Ok(SelectedProject { project, all_projects })
+    let selected_root = {
+        // Deploying the workspace root is a legitimate request
+        // (`--filter .` from the root), so the root is never
+        // auto-excluded from the selection.
+        let selection =
+            select_recursive_projects(&projects, config, dir, AutoExcludeRoot::Disabled)?;
+        let mut selected = selection.selected.keys();
+        match (selected.next(), selected.next()) {
+            (None, _) => return Err(DeployError::NothingToDeploy.into()),
+            (Some(root), None) => lexical_normalize(root),
+            (Some(_), Some(_)) => return Err(DeployError::CannotDeployMany.into()),
         }
-        _ => Err(DeployError::CannotDeployMany.into()),
-    }
+    };
+    let project = projects
+        .into_iter()
+        .find(|project| lexical_normalize(&project.root_dir) == selected_root)
+        .ok_or(DeployError::NothingToDeploy)?;
+    Ok(SelectedProject { project, all_projects })
 }
 
 fn resolve_target_dir(dir: &Path, target: &Path) -> PathBuf {

--- a/pnpm/crates/cli/tests/suite/deploy.rs
+++ b/pnpm/crates/cli/tests/suite/deploy.rs
@@ -500,8 +500,6 @@ fn deploy_from_shared_lockfile_installs_the_workspace_root_without_its_nested_pr
 
     let deploy_dir = workspace.join("deploy");
     assert!(deploy_dir.join("node_modules/lib").exists());
-    // The deployed root copies `pnpm-workspace.yaml` and the projects it
-    // globs, but only the deployed project itself is an importer.
     let deploy_lockfile = Lockfile::load_wanted_from_dir(&deploy_dir).unwrap().unwrap();
     assert_eq!(
         deploy_lockfile.importers.keys().collect::<Vec<_>>(),
@@ -592,9 +590,6 @@ fn write_root_project_depending_on_lib(workspace: &Path) {
     .unwrap();
 }
 
-/// The deployed project is not the workspace, so `pnpm deploy` must
-/// leave the workspace's own `pnpm-lock.yaml` exactly as the install
-/// wrote it.
 fn assert_workspace_lockfile_untouched(workspace: &Path, before: &str) {
     let after = fs::read_to_string(workspace.join("pnpm-lock.yaml")).unwrap();
     assert_eq!(after, before, "deploy must not rewrite the workspace lockfile");

--- a/pnpm/crates/cli/tests/suite/deploy.rs
+++ b/pnpm/crates/cli/tests/suite/deploy.rs
@@ -466,7 +466,9 @@ fn legacy_deploy_installs_selected_project() {
     let AddMockedRegistry { mock_instance, .. } = npmrc_info;
     write_workspace(&workspace, false);
 
-    pacquet
+    pacquet.with_arg("install").assert().success();
+    let workspace_lockfile = fs::read_to_string(workspace.join("pnpm-lock.yaml")).unwrap();
+    pacquet_cmd(&workspace)
         .with_args(["--filter", "app", "deploy", "--legacy", "--prod", "legacy-deploy"])
         .assert()
         .success();
@@ -476,6 +478,70 @@ fn legacy_deploy_installs_selected_project() {
     assert!(!deploy_dir.join("test.js").exists());
     assert!(deploy_dir.join("node_modules/lib").exists());
     assert!(!deploy_dir.join("node_modules/dev-only").exists());
+    assert_workspace_lockfile_untouched(&workspace, &workspace_lockfile);
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn deploy_from_shared_lockfile_installs_the_workspace_root_without_its_nested_projects() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    write_workspace(&workspace, true);
+    write_root_project_depending_on_lib(&workspace);
+
+    pacquet.with_arg("install").assert().success();
+    let workspace_lockfile = fs::read_to_string(workspace.join("pnpm-lock.yaml")).unwrap();
+    pacquet_cmd(&workspace)
+        .with_args(["--filter", ".", "deploy", "--prod", "deploy"])
+        .assert()
+        .success();
+
+    let deploy_dir = workspace.join("deploy");
+    assert!(deploy_dir.join("node_modules/lib").exists());
+    // The deployed root copies `pnpm-workspace.yaml` and the projects it
+    // globs, but only the deployed project itself is an importer.
+    let deploy_lockfile = Lockfile::load_wanted_from_dir(&deploy_dir).unwrap().unwrap();
+    assert_eq!(
+        deploy_lockfile.importers.keys().collect::<Vec<_>>(),
+        vec![Lockfile::ROOT_IMPORTER_KEY],
+    );
+    assert_workspace_lockfile_untouched(&workspace, &workspace_lockfile);
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn legacy_deploy_of_the_workspace_root_injects_its_workspace_dependencies() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    write_workspace(&workspace, false);
+    write_root_project_depending_on_lib(&workspace);
+
+    pacquet.with_arg("install").assert().success();
+    let workspace_lockfile = fs::read_to_string(workspace.join("pnpm-lock.yaml")).unwrap();
+    pacquet_cmd(&workspace)
+        .with_args(["--filter", ".", "deploy", "--legacy", "--prod", "legacy-deploy"])
+        .assert()
+        .success();
+
+    let deploy_dir = workspace.join("legacy-deploy");
+    let deploy_manifest: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(deploy_dir.join("package.json")).unwrap())
+            .unwrap();
+    assert_eq!(
+        deploy_manifest["name"], "root",
+        "`--filter .` should deploy the project in the current directory, not the projects nested under it: {deploy_manifest:#}",
+    );
+    assert!(deploy_dir.join("node_modules/lib").exists());
+    let virtual_store_entries = virtual_store_entries(&deploy_dir);
+    assert!(
+        virtual_store_entries.iter().any(|entry| entry.starts_with("lib@file+")),
+        "the root's workspace dependency should be injected into the deploy virtual store: {virtual_store_entries:#?}",
+    );
+    assert_workspace_lockfile_untouched(&workspace, &workspace_lockfile);
 
     drop((root, mock_instance));
 }
@@ -510,6 +576,28 @@ fn flatten_miette_report(stderr: &str) -> String {
         .filter(|token| !matches!(*token, "│" | "×" | "╰─▶"))
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+fn write_root_project_depending_on_lib(workspace: &Path) {
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "name": "root",
+            "version": "1.0.0",
+            "private": true,
+            "dependencies": { "lib": "workspace:*" },
+        })
+        .to_string(),
+    )
+    .unwrap();
+}
+
+/// The deployed project is not the workspace, so `pnpm deploy` must
+/// leave the workspace's own `pnpm-lock.yaml` exactly as the install
+/// wrote it.
+fn assert_workspace_lockfile_untouched(workspace: &Path, before: &str) {
+    let after = fs::read_to_string(workspace.join("pnpm-lock.yaml")).unwrap();
+    assert_eq!(after, before, "deploy must not rewrite the workspace lockfile");
 }
 
 fn pacquet_cmd(workspace: &Path) -> Command {

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -735,15 +735,32 @@ pub enum InstallError {
     ConfigConflictVirtualStoreOnlyWithNoModulesDir,
 }
 
-#[derive(Default)]
 struct InstallRunOptions<'install, 'selection> {
     lockfile_verification_override: Option<LockfileVerificationOverride<'install>>,
     rebuild: Option<RebuildOptions>,
     selection: Option<WorkspaceInstallSelection<'selection>>,
     root_manifest_as_workspace_root: bool,
+    /// pnpm's `saveLockfile`: whether the resolved graph may be written
+    /// to `<workspace_root>/pnpm-lock.yaml`. `false` for an install
+    /// whose resolution belongs to a project other than the one that
+    /// owns that lockfile, so the run must leave it untouched.
+    save_lockfile: bool,
     /// Forces the interactive-prompt eligibility that is otherwise derived
     /// from the process environment, so tests can exercise both branches.
     prompt_eligibility_override: Option<bool>,
+}
+
+impl Default for InstallRunOptions<'_, '_> {
+    fn default() -> Self {
+        InstallRunOptions {
+            lockfile_verification_override: None,
+            rebuild: None,
+            selection: None,
+            root_manifest_as_workspace_root: false,
+            save_lockfile: true,
+            prompt_eligibility_override: None,
+        }
+    }
 }
 
 impl<'a, DependencyGroupList> Install<'a, DependencyGroupList>
@@ -802,13 +819,21 @@ where
         .await
     }
 
-    /// Execute with the active manifest mapped to the root importer while
-    /// retaining workspace discovery for `workspace:` dependency resolution.
-    pub async fn run_with_root_importer<Reporter: self::Reporter + 'static>(
+    /// Execute the install a legacy `pacquet deploy` runs in its target
+    /// directory: the deployed manifest is the root importer, while
+    /// workspace discovery stays anchored at the source workspace so
+    /// `workspace:` dependencies still resolve to their projects.
+    ///
+    /// The source workspace also still owns `pnpm-lock.yaml`, and this
+    /// resolution describes the deployed project rather than the
+    /// workspace, so nothing is written to it (pnpm's
+    /// `saveLockfile: false`).
+    pub async fn run_legacy_deploy<Reporter: self::Reporter + 'static>(
         self,
     ) -> Result<(), InstallError> {
         Box::pin(self.run_inner::<Reporter>(InstallRunOptions {
             root_manifest_as_workspace_root: true,
+            save_lockfile: false,
             ..Default::default()
         }))
         .await

--- a/pnpm/crates/package-manager/src/install/apply_materialization.rs
+++ b/pnpm/crates/package-manager/src/install/apply_materialization.rs
@@ -254,6 +254,7 @@ struct CommitModulesStateInputs<'a> {
     take_frozen_path: bool,
     lockfile_synthesized_from_current: bool,
     lockfile_was_fast_updated: bool,
+    save_lockfile: bool,
     loaded_wanted_lockfile: Option<&'a Lockfile>,
 }
 
@@ -280,6 +281,7 @@ fn commit_modules_state(inputs: CommitModulesStateInputs<'_>) -> Result<(), Inst
         take_frozen_path,
         lockfile_synthesized_from_current,
         lockfile_was_fast_updated,
+        save_lockfile,
         loaded_wanted_lockfile,
     } = inputs;
     let now = SystemTime::now();
@@ -445,6 +447,7 @@ fn commit_modules_state(inputs: CommitModulesStateInputs<'_>) -> Result<(), Inst
     if take_frozen_path
         && (lockfile_synthesized_from_current || lockfile_was_fast_updated)
         && config.lockfile
+        && save_lockfile
         && let Some(updated) = loaded_wanted_lockfile
     {
         updated
@@ -626,6 +629,7 @@ pub(super) struct ApplyMaterializationInputs<'a, 'selection> {
     pub(super) take_frozen_path: bool,
     pub(super) lockfile_synthesized_from_current: bool,
     pub(super) lockfile_was_fast_updated: bool,
+    pub(super) save_lockfile: bool,
     pub(super) mutation: ProjectMutation,
     pub(super) manifest_dir: &'a Path,
     pub(super) selection: Option<WorkspaceInstallSelection<'selection>>,
@@ -668,6 +672,7 @@ pub(super) async fn apply_materialization_result<Reporter: self::Reporter + 'sta
         take_frozen_path,
         lockfile_synthesized_from_current,
         lockfile_was_fast_updated,
+        save_lockfile,
         mutation,
         manifest_dir,
         selection,
@@ -741,6 +746,7 @@ pub(super) async fn apply_materialization_result<Reporter: self::Reporter + 'sta
         take_frozen_path,
         lockfile_synthesized_from_current,
         lockfile_was_fast_updated,
+        save_lockfile,
         loaded_wanted_lockfile: lockfile,
     })?;
 

--- a/pnpm/crates/package-manager/src/install/materialize.rs
+++ b/pnpm/crates/package-manager/src/install/materialize.rs
@@ -52,6 +52,7 @@ pub(super) struct MaterializationInputs<'a, 'install> {
     pub(super) peer_issues_sink: Option<PeerIssuesSink>,
     pub(super) deps_requiring_build_sink: Option<DepsRequiringBuildSink>,
     pub(super) pnpmfile_hook: Option<Arc<dyn pacquet_hooks::PnpmfileHooks>>,
+    pub(super) save_lockfile: bool,
     pub(super) catalogs: &'a Catalogs,
     pub(super) prefix: &'a str,
 }
@@ -111,6 +112,7 @@ pub(super) async fn materialize<Reporter: self::Reporter + 'static>(
         peer_issues_sink,
         deps_requiring_build_sink,
         pnpmfile_hook,
+        save_lockfile,
         catalogs,
         prefix,
     } = inputs;
@@ -338,6 +340,7 @@ pub(super) async fn materialize<Reporter: self::Reporter + 'static>(
             lockfile_only: resolve_only,
             skip_runtimes,
             dry_run,
+            save_lockfile,
             can_prompt,
             persist_policy_excludes,
             is_full_install: mutation.is_full_install(),

--- a/pnpm/crates/package-manager/src/install/prepare_modules_state.rs
+++ b/pnpm/crates/package-manager/src/install/prepare_modules_state.rs
@@ -30,6 +30,7 @@ pub(super) struct PrepareModulesStateInputs<'a, 'install> {
         Option<super::LockfileVerificationOverride<'install>>,
     pub(super) lockfile_synthesized_from_current: bool,
     pub(super) lockfile_was_fast_updated: bool,
+    pub(super) save_lockfile: bool,
     pub(super) catalogs: &'a Catalogs,
     pub(super) project_manifests: &'a [(PathBuf, &'a PackageManifest)],
     pub(super) prefix: &'a str,
@@ -68,6 +69,7 @@ pub(super) async fn prepare_modules_state<'install, Reporter: self::Reporter + '
         lockfile_verification_override,
         lockfile_synthesized_from_current,
         lockfile_was_fast_updated,
+        save_lockfile,
         catalogs,
         project_manifests,
         prefix,
@@ -374,7 +376,10 @@ pub(super) async fn prepare_modules_state<'install, Reporter: self::Reporter + '
             prefix: prefix.to_string(),
             stage: Stage::ImportingDone,
         }));
-        if (lockfile_synthesized_from_current || lockfile_was_fast_updated) && config.lockfile {
+        if (lockfile_synthesized_from_current || lockfile_was_fast_updated)
+            && config.lockfile
+            && save_lockfile
+        {
             wanted_lockfile
                 .save_to_path(&workspace_root.join(Lockfile::FILE_NAME))
                 .map_err(InstallError::SaveWantedLockfile)?;

--- a/pnpm/crates/package-manager/src/install/run.rs
+++ b/pnpm/crates/package-manager/src/install/run.rs
@@ -30,6 +30,7 @@ where
             rebuild,
             selection,
             root_manifest_as_workspace_root,
+            save_lockfile,
             prompt_eligibility_override,
         } = options;
         let Install {
@@ -852,6 +853,7 @@ where
             lockfile_verification_override,
             lockfile_synthesized_from_current,
             lockfile_was_fast_updated,
+            save_lockfile,
             catalogs: &catalogs,
             project_manifests: &project_manifests,
             prefix: &prefix,
@@ -915,6 +917,7 @@ where
             peer_issues_sink,
             deps_requiring_build_sink,
             pnpmfile_hook,
+            save_lockfile,
             catalogs: &catalogs,
             prefix: &prefix,
         })
@@ -951,6 +954,7 @@ where
             take_frozen_path,
             lockfile_synthesized_from_current,
             lockfile_was_fast_updated,
+            save_lockfile,
             mutation,
             manifest_dir,
             selection,

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -216,6 +216,12 @@ pub struct InstallWithFreshLockfile<'a, DependencyGroupList> {
     pub prior_hoisted_dependencies: Option<&'a crate::HoistedDependencies>,
     /// See [`crate::PruneStaleModules::prune_orphans`].
     pub prune_orphans: bool,
+    /// pnpm's `saveLockfile`: whether the freshly built lockfile may be
+    /// written to `<lockfile_dir>/pnpm-lock.yaml`. `false` leaves that
+    /// file untouched — the resolved graph is still returned and still
+    /// drives `<virtual_store_dir>/lock.yaml`. See
+    /// [`crate::Install::run_legacy_deploy`].
+    pub save_lockfile: bool,
 }
 
 /// Which lockfile-pinned `(name, version)` pairs to *withhold* from the
@@ -687,6 +693,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             current_lockfile,
             prior_hoisted_dependencies,
             prune_orphans,
+            save_lockfile,
         } = self;
 
         // Shared once so the per-edge `ResolveOptions` clones below stay
@@ -1147,6 +1154,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
                 lockfile_dir,
                 requester,
                 dry_run,
+                save_lockfile,
                 after_all_resolved_hook: after_all_resolved_hook.as_ref(),
                 after_all_resolved_log,
                 store_index_writer,
@@ -1585,7 +1593,9 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
 
         // Saved after the build phase succeeds so a partial install can't
         // leave a lockfile pointing at slots that never landed on disk.
-        let (wanted_lockfile, can_record_lockfile_verification) = if config.lockfile {
+        let (wanted_lockfile, can_record_lockfile_verification) = if !config.lockfile {
+            (None, false)
+        } else if save_lockfile {
             let target = lockfile_dir.join(Lockfile::FILE_NAME);
             let can_record_lockfile_verification = save_wanted_lockfile(
                 &built_lockfile,
@@ -1596,7 +1606,9 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             .await?;
             (Some(built_lockfile), can_record_lockfile_verification)
         } else {
-            (None, false)
+            // Nothing was persisted, so there is no `pnpm-lock.yaml`
+            // whose verification a later install could key off.
+            (Some(built_lockfile), false)
         };
 
         Ok(InstallWithFreshLockfileResult {
@@ -1797,6 +1809,7 @@ struct LockfileOnlyOptions<'a> {
     lockfile_dir: &'a Path,
     requester: &'a str,
     dry_run: bool,
+    save_lockfile: bool,
     after_all_resolved_hook: Option<&'a Arc<dyn pacquet_hooks::PnpmfileHooks>>,
     after_all_resolved_log: Option<pacquet_hooks::LogFn>,
     store_index_writer: Arc<pacquet_store_dir::StoreIndexWriter>,
@@ -1819,13 +1832,14 @@ async fn finish_lockfile_only<Reporter: self::Reporter>(
         lockfile_dir,
         requester,
         dry_run,
+        save_lockfile,
         after_all_resolved_hook,
         after_all_resolved_log,
         store_index_writer,
         writer_task,
     } = opts;
 
-    let (wanted_lockfile, can_record_lockfile_verification) = if dry_run {
+    let (wanted_lockfile, can_record_lockfile_verification) = if dry_run || !save_lockfile {
         (Some(built_lockfile), false)
     } else if config.lockfile {
         let can_record_lockfile_verification = save_wanted_lockfile(


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#13758.

`pnpm deploy` resolved its `--filter` selectors against the workspace directory with the legacy (subtree) directory matcher, so `--filter .` named every project *nested under* the workspace root instead of the root project itself. In the issue's fixture that silently deployed `packages/shared`; in a workspace with more than one nested project it fails with `Cannot deploy more than 1 project`. Selection now runs through `select_recursive_projects`, the same path every other filtered command uses: glob directory matching (`legacyDirFiltering: false`) with selectors anchored at the current directory. That also removes a duplicated `GraphPkg` and picks up the `-w` root selector for free.

Two further fixes follow from the workspace root becoming selectable:

- **The legacy deploy no longer rewrites the workspace's `pnpm-lock.yaml`.** Its install ran with the source workspace as its workspace root, so it wrote the deployed project's resolution over the workspace lockfile — replacing the root importer with the deployed manifest. Legacy deploy now goes through `Install::run_legacy_deploy`, which carries pnpm's `saveLockfile: false` down the install: the resolved graph still drives `<virtual_store_dir>/lock.yaml`, but no `pnpm-lock.yaml` is written. This affected every legacy deploy, not just a root one.
- **The shared-lockfile deploy installs only the deployed project.** Deploying the root copies `pnpm-workspace.yaml` and the projects it globs into the deploy directory; the install then discovered those copies as importers and rejected the generated frozen lockfile, which only describes the deployed project. The install now receives the deployed project as its whole workspace — the TypeScript CLI reaches the same outcome by installing the deploy directory with `workspaceDir: undefined`.

Verified against the issue's fixture with both binaries: the deployed tree, the injected `shared` link, and the untouched workspace lockfile now match the TypeScript CLI. `--filter .` run from a nested project directory also selects that project in both stacks.

**pacquet only.** The TypeScript CLI already behaves correctly on this fixture (`useGlobDirFiltering: !legacyDirFiltering` in `main.ts`, `saveLockfile: false` in `deploy.ts`), so there is nothing to mirror.

## Squash Commit Body

```text
`pnpm deploy` resolved its `--filter` selectors against the workspace
directory with the legacy (subtree) directory matcher, so `--filter .`
named every project nested under the workspace root rather than the root
project itself. Deploying the root either copied the wrong project or
failed with "Cannot deploy more than 1 project". The selection now runs
through `select_recursive_projects`, the same path every other filtered
command uses: glob directory matching (`legacyDirFiltering: false`) and
selectors anchored at the current directory. That also drops a duplicate
`GraphPkg` and picks up the `-w` root selector for free.

Two fixes follow from the root becoming selectable:

- The legacy deploy install ran with the source workspace as its
  workspace root, so it wrote the deployed project's resolution over the
  workspace's own `pnpm-lock.yaml` — replacing the root importer with
  the deployed manifest. Legacy deploy now takes
  `Install::run_legacy_deploy`, which carries pnpm's
  `saveLockfile: false` through the install: the resolved graph still
  drives `<virtual_store_dir>/lock.yaml`, but no `pnpm-lock.yaml` is
  written. This applies to every legacy deploy, not only a root one.

- Deploying the root copies `pnpm-workspace.yaml` and the projects it
  globs into the deploy directory. The shared-lockfile install then
  discovered those copies as importers and rejected the generated frozen
  lockfile, which only describes the deployed project. The install now
  receives the deployed project as its whole workspace, matching pnpm,
  which installs the deploy directory with no workspace at all.

pacquet only: the TypeScript CLI already behaves this way on the same
fixture.

Closes pnpm/pnpm#13758
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788986347&installation_model_id=426870&pr_number=13788&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13788&signature=432bec8248e73ece9e900e631e10f65e181fa25a6cbf737347a6e6b8190a384b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Deploy the workspace root and its dependencies with `pnpm --filter . deploy`.
  - Legacy deployments support workspace-root deployment while preserving the source workspace lockfile.
  - Shared-lockfile deployments include only the deployed project in the generated lockfile.

- **Bug Fixes**
  - Deployments no longer modify the source workspace lockfile.
  - Dependencies are resolved and packages materialized even when lockfile saving is disabled.

- **Documentation**
  - Documented workspace-root deployment and legacy lockfile behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->