### PR TITLE
fix: check peer suffixes against the version a fast update dropped

### DIFF
--- a/.changeset/peer-suffix-version-precision.md
+++ b/.changeset/peer-suffix-version-precision.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.deps-installer": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+Removing a dependency, or moving one to another already-locked version, no longer re-resolves the whole dependency graph just because some package resolves a peer with the same name. The lockfile update now compares the peer suffixes against the exact `name@version` the removal severed, so a suffix that names a different — still present — version of that dependency is left alone [#13781](https://github.com/pnpm/pnpm/issues/13781).

--- a/pnpm/crates/package-manager/src/fast_update_ignored_optional_dependencies.rs
+++ b/pnpm/crates/package-manager/src/fast_update_ignored_optional_dependencies.rs
@@ -1,4 +1,7 @@
-use crate::{fast_update_compose::Drift, fast_update_lockfile::GraphEdits};
+use crate::{
+    fast_update_compose::Drift,
+    fast_update_lockfile::{DroppedEdgeTarget, GraphEdits},
+};
 use pacquet_config::matcher::create_matcher;
 use pacquet_lockfile::{Lockfile, PkgName};
 use std::collections::{BTreeSet, HashMap, HashSet};
@@ -34,8 +37,8 @@ pub(crate) fn detect_ignored_optional_drift(
 }
 
 /// Remove every optional dependency the widened pattern list now
-/// ignores, from importers and snapshots alike, recording the removed
-/// aliases in `edits` for the shared epilogue.
+/// ignores, from importers and snapshots alike, recording the severed
+/// edges in `edits` for the shared epilogue.
 pub(crate) fn apply_ignored_optional_update(
     candidate: &mut Lockfile,
     ignored_optional_dependencies: &[String],
@@ -47,21 +50,22 @@ pub(crate) fn apply_ignored_optional_update(
             &mut importer.optional_dependencies,
             &mut importer.dependencies,
             &matcher,
+            edits,
         );
         if let Some(specifiers) = importer.specifiers.as_mut() {
             let removed_specifiers: HashSet<_> =
                 removed.iter().map(std::string::ToString::to_string).collect();
             specifiers.retain(|name, _| !removed_specifiers.contains(name));
         }
-        edits.dropped.extend(removed);
     }
     if let Some(snapshots) = candidate.snapshots.as_mut() {
         for snapshot in snapshots.values_mut() {
-            edits.dropped.extend(remove_ignored_optional_dependencies(
+            remove_ignored_optional_dependencies(
                 &mut snapshot.optional_dependencies,
                 &mut snapshot.dependencies,
                 &matcher,
-            ));
+                edits,
+            );
         }
     }
     let mut recorded: Vec<_> = ignored_optional_dependencies.to_vec();
@@ -70,18 +74,30 @@ pub(crate) fn apply_ignored_optional_update(
     candidate.ignored_optional_dependencies = Some(recorded);
 }
 
-fn remove_ignored_optional_dependencies<OptionalValue, DependencyValue>(
+fn remove_ignored_optional_dependencies<
+    OptionalValue: DroppedEdgeTarget,
+    DependencyValue: DroppedEdgeTarget,
+>(
     optional_dependencies: &mut Option<HashMap<PkgName, OptionalValue>>,
     dependencies: &mut Option<HashMap<PkgName, DependencyValue>>,
     matcher: &pacquet_config::matcher::Matcher,
+    edits: &mut GraphEdits,
 ) -> HashSet<PkgName> {
     let removed: HashSet<_> = optional_dependencies
         .as_ref()
         .into_iter()
         .flatten()
         .filter(|(name, _)| matches_package_name(matcher, name))
-        .map(|(name, _)| name.clone())
+        .map(|(name, dependency)| {
+            edits.dropped.record(name, dependency);
+            name.clone()
+        })
         .collect();
+    for (name, dependency) in dependencies.as_ref().into_iter().flatten() {
+        if removed.contains(name) {
+            edits.dropped.record(name, dependency);
+        }
+    }
     if let Some(optional_dependencies) = optional_dependencies.as_mut() {
         optional_dependencies.retain(|name, _| !removed.contains(name));
     }

--- a/pnpm/crates/package-manager/src/fast_update_importers.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers.rs
@@ -96,7 +96,9 @@ pub(crate) fn apply_importers_update(
             .into_iter()
             .flatten()
             {
-                edits.dropped.extend(group.keys().cloned());
+                for (alias, dependency) in group {
+                    edits.dropped.record(alias, dependency);
+                }
             }
         }
     }
@@ -134,8 +136,8 @@ pub(crate) fn apply_importers_update(
                     let Ok(moved) = wanted.to_string().parse() else {
                         return false;
                     };
+                    edits.dropped.record(alias, &*dependency);
                     dependency.version = ImporterDepVersion::Regular(moved);
-                    edits.dropped.insert(alias.clone());
                 }
                 dependency.specifier = (*specifier).to_string();
             }
@@ -144,7 +146,7 @@ pub(crate) fn apply_importers_update(
                     source == DependencyGroup::Optional || *target == DependencyGroup::Optional;
             }
         }
-        edits.dropped.extend(remove_dependencies_absent_from(importer, manifest_dependencies));
+        remove_dependencies_absent_from(importer, manifest_dependencies, edits);
     }
     true
 }
@@ -309,11 +311,12 @@ fn importer_group(
 }
 
 /// Drop every dependency the importer records that the manifest no longer
-/// declares, returning their names.
+/// declares, recording the severed edges in `edits`.
 fn remove_dependencies_absent_from(
     importer: &mut ProjectSnapshot,
     manifest_dependencies: &ManifestDependencies<'_>,
-) -> HashSet<PkgName> {
+    edits: &mut GraphEdits,
+) {
     let declared = |alias: &PkgName| manifest_dependencies.contains_key(alias);
     let mut removed = HashSet::new();
     for group in [
@@ -324,10 +327,11 @@ fn remove_dependencies_absent_from(
     .into_iter()
     .flatten()
     {
-        group.retain(|alias, _| {
+        group.retain(|alias, dependency| {
             if declared(alias) {
                 return true;
             }
+            edits.dropped.record(alias, dependency);
             removed.insert(alias.clone());
             false
         });
@@ -344,7 +348,6 @@ fn remove_dependencies_absent_from(
     if let Some(specifiers) = importer.specifiers.as_mut() {
         specifiers.retain(|alias, _| !removed.iter().any(|name| name.to_string() == *alias));
     }
-    removed
 }
 
 fn importer_dependency_mut<'a>(

--- a/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
@@ -1023,6 +1023,45 @@ fn rejects_dropping_a_dependency_a_nested_peer_suffix_segment_names() {
     );
 }
 
+/// A peer suffix reaches the guard verbatim from the lockfile, so a
+/// segment may start with a character no package name would.
+const WITH_NON_ASCII_PEER_SUFFIX: &str = r"
+lockfileVersion: '9.0'
+importers:
+  .:
+    dependencies:
+      foo:
+        specifier: ^1.0.0
+        version: 1.1.0
+      baz:
+        specifier: ^4.0.0
+        version: 4.0.0(é@1.0.0)
+packages:
+  foo@1.1.0:
+    resolution:
+      integrity: sha512-foo
+  baz@4.0.0:
+    resolution:
+      integrity: sha512-baz
+snapshots:
+  foo@1.1.0: {}
+  baz@4.0.0(é@1.0.0): {}
+";
+
+#[test]
+fn reads_a_peer_suffix_segment_that_starts_with_a_multi_byte_character() {
+    let manifest = manifest_from(json!({ "dependencies": { "baz": "^4.0.0" } }));
+
+    assert!(
+        try_fast_update_importers(
+            &parsed_lockfile(WITH_NON_ASCII_PEER_SUFFIX),
+            &[(".".to_string(), &manifest)],
+        )
+        .is_some(),
+        "the segment names neither foo nor anything else dropped",
+    );
+}
+
 #[test]
 fn rejects_dropping_a_linked_dependency_a_surviving_peer_suffix_names() {
     let manifest = manifest_from(json!({ "dependencies": { "baz": "^4.0.0" } }));

--- a/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
@@ -934,6 +934,28 @@ snapshots:
   baz@4.0.0(qux@5.0.0(foo@1.1.0)): {}
 ";
 
+/// `foo` is a workspace sibling `baz` resolves as a peer. A link has no
+/// `name@version` for a suffix segment to be compared against — the
+/// segment carries the filename-safe form of the link path instead.
+const WITH_PEER_ON_REMOVABLE_LINK: &str = r"
+lockfileVersion: '9.0'
+importers:
+  .:
+    dependencies:
+      foo:
+        specifier: 'workspace:*'
+        version: link:packages/foo
+      baz:
+        specifier: ^4.0.0
+        version: 4.0.0(foo@packages+foo)
+packages:
+  baz@4.0.0:
+    resolution:
+      integrity: sha512-baz
+snapshots:
+  baz@4.0.0(foo@packages+foo): {}
+";
+
 fn sorted_snapshot_keys(lockfile: &Lockfile) -> Vec<String> {
     let mut keys: Vec<_> =
         lockfile.snapshots.as_ref().expect("snapshots").keys().map(ToString::to_string).collect();
@@ -998,6 +1020,20 @@ fn rejects_dropping_a_dependency_a_nested_peer_suffix_segment_names() {
         )
         .is_none(),
         "the peers of a peer are as much a part of baz's key as the top-level ones",
+    );
+}
+
+#[test]
+fn rejects_dropping_a_linked_dependency_a_surviving_peer_suffix_names() {
+    let manifest = manifest_from(json!({ "dependencies": { "baz": "^4.0.0" } }));
+
+    assert!(
+        try_fast_update_importers(
+            &parsed_lockfile(WITH_PEER_ON_REMOVABLE_LINK),
+            &[(".".to_string(), &manifest)],
+        )
+        .is_none(),
+        "nothing pins the link to a version, so every suffix naming it stays suspect",
     );
 }
 

--- a/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
@@ -869,3 +869,186 @@ fn rejects_dropping_an_importer_a_survivor_links_to() {
         "a project that is gone while something links to it is a broken workspace",
     );
 }
+
+/// The importer depends on `foo@1.0.0` directly, while `baz` — reached
+/// through `qux` — resolves `foo` as a peer at the version `qux`
+/// provides, `1.2.0`.
+const WITH_PEER_ON_ANOTHER_VERSION: &str = r"
+lockfileVersion: '9.0'
+importers:
+  .:
+    dependencies:
+      foo:
+        specifier: 1.0.0
+        version: 1.0.0
+      qux:
+        specifier: ^5.0.0
+        version: 5.0.0
+packages:
+  foo@1.0.0:
+    resolution:
+      integrity: sha512-foo-1
+  foo@1.2.0:
+    resolution:
+      integrity: sha512-foo-2
+  qux@5.0.0:
+    resolution:
+      integrity: sha512-qux
+  baz@4.0.0:
+    resolution:
+      integrity: sha512-baz
+snapshots:
+  foo@1.0.0: {}
+  foo@1.2.0: {}
+  qux@5.0.0:
+    dependencies:
+      foo: 1.2.0
+      baz: 4.0.0(foo@1.2.0)
+  baz@4.0.0(foo@1.2.0):
+    dependencies:
+      foo: 1.2.0
+";
+
+/// `baz` resolves `qux` as a peer, which in turn resolved `foo`, so the
+/// dropped `foo@1.1.0` is named one level down in `baz`'s key.
+const WITH_NESTED_PEER_ON_REMOVABLE_DEP: &str = r"
+lockfileVersion: '9.0'
+importers:
+  .:
+    dependencies:
+      foo:
+        specifier: ^1.0.0
+        version: 1.1.0
+      baz:
+        specifier: ^4.0.0
+        version: 4.0.0(qux@5.0.0(foo@1.1.0))
+packages:
+  foo@1.1.0:
+    resolution:
+      integrity: sha512-foo
+  baz@4.0.0:
+    resolution:
+      integrity: sha512-baz
+snapshots:
+  foo@1.1.0: {}
+  baz@4.0.0(qux@5.0.0(foo@1.1.0)): {}
+";
+
+fn sorted_snapshot_keys(lockfile: &Lockfile) -> Vec<String> {
+    let mut keys: Vec<_> =
+        lockfile.snapshots.as_ref().expect("snapshots").keys().map(ToString::to_string).collect();
+    keys.sort();
+    keys
+}
+
+#[test]
+fn drops_a_dependency_whose_version_no_surviving_peer_suffix_names() {
+    let manifest = manifest_from(json!({ "dependencies": { "qux": "^5.0.0" } }));
+
+    let updated = try_fast_update_importers(
+        &parsed_lockfile(WITH_PEER_ON_ANOTHER_VERSION),
+        &[(".".to_string(), &manifest)],
+    )
+    .expect("the surviving suffix names the version qux provides, not the dropped one");
+
+    assert_eq!(
+        sorted_snapshot_keys(&updated),
+        vec!["baz@4.0.0(foo@1.2.0)".to_string(), "foo@1.2.0".to_string(), "qux@5.0.0".to_string()],
+    );
+}
+
+#[test]
+fn drops_a_dependency_a_surviving_suffix_only_ends_with_the_name_of() {
+    let mut subject = parsed_lockfile(WITH_PEER_ON_ANOTHER_VERSION);
+    let snapshots = subject.snapshots.as_mut().expect("snapshots");
+    snapshots.insert(
+        "baz@4.0.0(@scope/foo@1.0.0)".parse().expect("snapshot key"),
+        serde_saphyr::from_str("dependencies:\n  '@scope/foo': 1.0.0").expect("snapshot"),
+    );
+    snapshots.insert(
+        "@scope/foo@1.0.0".parse().expect("snapshot key"),
+        pacquet_lockfile::SnapshotEntry::default(),
+    );
+    snapshots
+        .get_mut(&"qux@5.0.0".parse().expect("snapshot key"))
+        .expect("qux")
+        .dependencies
+        .as_mut()
+        .expect("dependencies")
+        .insert(
+            "baz".parse().expect("alias"),
+            "4.0.0(@scope/foo@1.0.0)".parse().expect("reference"),
+        );
+    let manifest = manifest_from(json!({ "dependencies": { "qux": "^5.0.0" } }));
+
+    assert!(
+        try_fast_update_importers(&subject, &[(".".to_string(), &manifest)]).is_some(),
+        "@scope/foo is not foo, however the two names end",
+    );
+}
+
+#[test]
+fn rejects_dropping_a_dependency_a_nested_peer_suffix_segment_names() {
+    let manifest = manifest_from(json!({ "dependencies": { "baz": "^4.0.0" } }));
+
+    assert!(
+        try_fast_update_importers(
+            &parsed_lockfile(WITH_NESTED_PEER_ON_REMOVABLE_DEP),
+            &[(".".to_string(), &manifest)],
+        )
+        .is_none(),
+        "the peers of a peer are as much a part of baz's key as the top-level ones",
+    );
+}
+
+#[test]
+fn moves_a_range_past_a_peer_suffix_naming_the_version_it_moves_to() {
+    let manifest = manifest_from(json!({ "dependencies": { "foo": "^1.1.0", "qux": "^5.0.0" } }));
+
+    let updated = try_fast_update_importers(
+        &parsed_lockfile(WITH_PEER_ON_ANOTHER_VERSION),
+        &[(".".to_string(), &manifest)],
+    )
+    .expect("baz already resolves the peer to the version the importer moves to");
+
+    let alias: PkgName = "foo".parse().expect("alias");
+    assert_eq!(
+        updated.importers["."].dependencies.as_ref().expect("dependencies")[&alias]
+            .version
+            .to_string(),
+        "1.2.0",
+    );
+    assert_eq!(
+        sorted_snapshot_keys(&updated),
+        vec!["baz@4.0.0(foo@1.2.0)".to_string(), "foo@1.2.0".to_string(), "qux@5.0.0".to_string()],
+    );
+}
+
+#[test]
+fn rejects_a_range_move_a_peer_suffix_names_the_version_it_moves_off() {
+    let mut subject = parsed_lockfile(WITH_PEER_ON_ANOTHER_VERSION);
+    subject
+        .importers
+        .get_mut(".")
+        .expect("importer")
+        .dependencies
+        .as_mut()
+        .expect("dependencies")
+        .insert(
+            "baz".parse().expect("alias"),
+            serde_saphyr::from_str("{specifier: ^4.0.0, version: 4.0.0(foo@1.0.0)}")
+                .expect("dependency"),
+        );
+    subject.snapshots.as_mut().expect("snapshots").insert(
+        "baz@4.0.0(foo@1.0.0)".parse().expect("snapshot key"),
+        serde_saphyr::from_str("dependencies:\n  foo: 1.0.0").expect("snapshot"),
+    );
+    let manifest = manifest_from(
+        json!({ "dependencies": { "foo": "^1.1.0", "qux": "^5.0.0", "baz": "^4.0.0" } }),
+    );
+
+    assert!(
+        try_fast_update_importers(&subject, &[(".".to_string(), &manifest)]).is_none(),
+        "baz resolved the peer to the version the importer moves off, so its key would change",
+    );
+}

--- a/pnpm/crates/package-manager/src/fast_update_lockfile.rs
+++ b/pnpm/crates/package-manager/src/fast_update_lockfile.rs
@@ -1,4 +1,6 @@
-use pacquet_lockfile::{Lockfile, PkgName, PkgNameVerPeer};
+use pacquet_lockfile::{
+    Lockfile, PkgName, PkgNameVerPeer, Prefix, ResolvedDependencySpec, SnapshotDepRef, VersionPart,
+};
 use std::collections::{HashSet, VecDeque};
 
 /// What the fast-update handlers did to the dependency graph, so the
@@ -8,11 +10,89 @@ use std::collections::{HashSet, VecDeque};
 /// per handler.
 #[derive(Default)]
 pub(crate) struct GraphEdits {
-    /// Aliases whose importer or snapshot edges were severed.
-    pub(crate) dropped: HashSet<PkgName>,
+    /// What the severed importer or snapshot edges pointed at.
+    pub(crate) dropped: DroppedEdges,
     /// Whether an edge into or out of `optionalDependencies` moved, which
     /// changes the reachability-derived `optional` flags for a subtree.
     pub(crate) moved_across_optional: bool,
+}
+
+/// What the edges a fast update severed pointed at, each written the way
+/// a peer suffix names a package: `name@version`, or a bare `name@` when
+/// the reference pins no version a suffix segment can be compared
+/// against — a link or a tarball, whose suffix segment carries the
+/// resolved manifest version instead — which makes every suffix naming
+/// that name suspect.
+#[derive(Default)]
+pub(crate) struct DroppedEdges(HashSet<String>);
+
+/// The `snapshots:` key a dependency record points at, across the
+/// importer-level and snapshot-level reference shapes, so a severed edge
+/// can be recorded from either.
+pub(crate) trait DroppedEdgeTarget {
+    fn resolved_key(&self, alias: &PkgName) -> Option<PkgNameVerPeer>;
+}
+
+impl DroppedEdgeTarget for ResolvedDependencySpec {
+    fn resolved_key(&self, alias: &PkgName) -> Option<PkgNameVerPeer> {
+        self.version.resolved_key(alias)
+    }
+}
+
+impl DroppedEdgeTarget for SnapshotDepRef {
+    fn resolved_key(&self, alias: &PkgName) -> Option<PkgNameVerPeer> {
+        self.resolve(alias)
+    }
+}
+
+impl DroppedEdges {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Record the edge from `alias` to `target` as severed.
+    pub(crate) fn record(&mut self, alias: &PkgName, target: &impl DroppedEdgeTarget) {
+        let peer_id = match target.resolved_key(alias) {
+            // A peer suffix names an aliased dependency by the package's
+            // own name, not by the name it is linked into `node_modules`
+            // under; a link has no key to take a name from at all.
+            Some(key) => peer_id_of(&key).unwrap_or_else(|| format!("{}@", key.name)),
+            None => format!("{alias}@"),
+        };
+        self.0.insert(peer_id);
+    }
+
+    /// Whether `peers` — the peer suffix of a snapshot key — names none
+    /// of the severed edges' targets, at any nesting depth. Without
+    /// `dedupePeers` a peer is named by its whole dep path, and the peers
+    /// that path pins are as much a part of the dependent's key as the
+    /// top-level ones. A `patch_hash=` segment names no package; a suffix
+    /// pnpm shortened into a hash names nothing that can be ruled out.
+    fn are_absent_from(&self, peers: &str) -> bool {
+        peers
+            .split(['(', ')'])
+            .filter(|peer_id| !peer_id.is_empty() && !peer_id.starts_with("patch_hash="))
+            .all(|peer_id| {
+                let Some(version_index) = peer_id[1..].find('@').map(|index| index + 2) else {
+                    return false;
+                };
+                !self.0.contains(peer_id) && !self.0.contains(&peer_id[..version_index])
+            })
+    }
+}
+
+/// The id a peer suffix names `key` by.
+fn peer_id_of(key: &PkgNameVerPeer) -> Option<String> {
+    if key.suffix.prefix() != Prefix::None {
+        return None;
+    }
+    match key.suffix.version() {
+        VersionPart::Semver(version) => Some(format!("{}@{version}", key.name)),
+        VersionPart::RegistryQualified { registry_name, version } => {
+            Some(format!("{}@{registry_name}:{version}", key.name))
+        }
+        VersionPart::File(_) | VersionPart::NonSemver(_) => None,
+    }
 }
 
 /// Settle the graph after every handler has run: drop what nothing
@@ -39,23 +119,13 @@ pub(crate) fn finish_graph_edits(candidate: &mut Lockfile, edits: &GraphEdits) -
 ///
 /// A dropped package that some snapshot reaches as a peer is embedded in
 /// that snapshot's key, so removing it would rekey the dependent rather
-/// than only prune. A peer suffix pnpm shortened into a hash cannot be
-/// read to rule that out.
-fn peer_suffixes_are_independent_of(lockfile: &Lockfile, dropped: &HashSet<PkgName>) -> bool {
+/// than only prune. A package the same alias still provides at another
+/// version is no such peer: the suffix names the version, not the alias.
+fn peer_suffixes_are_independent_of(lockfile: &Lockfile, dropped: &DroppedEdges) -> bool {
     let Some(snapshots) = lockfile.snapshots.as_ref() else {
         return true;
     };
-    let dropped_needles: Vec<String> = dropped.iter().map(|name| format!("{name}@")).collect();
-    snapshots.keys().all(|key| {
-        let peers = key.suffix.peer();
-        peers.is_empty()
-            || (peers
-                .trim_start_matches('(')
-                .trim_end_matches(')')
-                .split(")(")
-                .all(|segment| segment.contains('@'))
-                && !dropped_needles.iter().any(|needle| peers.contains(needle.as_str())))
-    })
+    snapshots.keys().all(|key| dropped.are_absent_from(key.suffix.peer()))
 }
 
 pub(crate) fn prune_unreachable_packages(lockfile: &mut Lockfile) {

--- a/pnpm/crates/package-manager/src/fast_update_lockfile.rs
+++ b/pnpm/crates/package-manager/src/fast_update_lockfile.rs
@@ -73,10 +73,15 @@ impl DroppedEdges {
             .split(['(', ')'])
             .filter(|peer_id| !peer_id.is_empty() && !peer_id.starts_with("patch_hash="))
             .all(|peer_id| {
-                let Some(version_index) = peer_id[1..].find('@').map(|index| index + 2) else {
+                // The `@` of a scoped name is not the separator, and a
+                // segment the lockfile put a multi-byte character in front
+                // of must not be sliced blindly.
+                let Some(separator) =
+                    peer_id.match_indices('@').map(|(index, _)| index).find(|index| *index > 0)
+                else {
                     return false;
                 };
-                !self.0.contains(peer_id) && !self.0.contains(&peer_id[..version_index])
+                !self.0.contains(peer_id) && !self.0.contains(&peer_id[..=separator])
             })
     }
 }

--- a/pnpm11/installing/deps-installer/src/install/droppedEdges.ts
+++ b/pnpm11/installing/deps-installer/src/install/droppedEdges.ts
@@ -1,0 +1,65 @@
+import * as dp from '@pnpm/deps.path'
+import type { LockfileObject } from '@pnpm/lockfile.types'
+
+/**
+ * What the edges a fast update severed pointed at, each written the way a
+ * peer suffix names a package: `name@version`, or a bare `name@` when the
+ * reference pins no version a suffix segment can be compared against — a
+ * link or a tarball, whose suffix segment carries the resolved manifest
+ * version instead — which makes every suffix naming that name suspect.
+ */
+export type DroppedEdges = Set<string>
+
+/** Record the edge from `alias` to `reference` as severed. */
+export function recordDroppedEdge (dropped: DroppedEdges, alias: string, reference: string | undefined): void {
+  dropped.add(droppedPeerId(alias, reference))
+}
+
+/**
+ * Whether no surviving package resolves a peer through one of `dropped`.
+ *
+ * A dropped package that some package reaches as a peer is embedded in that
+ * package's key, so removing it would rekey the dependent rather than only
+ * prune. A package the same alias still provides at another version is no
+ * such peer: the suffix names the version, not the alias. A peer suffix pnpm
+ * shortened into a hash names nothing that can be ruled out.
+ */
+export function peerSuffixesAreIndependentOf (lockfile: LockfileObject, dropped: DroppedEdges): boolean {
+  return Object.keys(lockfile.packages ?? {}).every((depPath) => {
+    const { peersIndex } = dp.indexOfDepPathSuffix(depPath)
+    return peersIndex === -1 || peerSuffixIsIndependentOf(depPath.substring(peersIndex), dropped)
+  })
+}
+
+/**
+ * The id a peer suffix would name the target of `alias` -> `reference` by.
+ */
+function droppedPeerId (alias: string, reference: string | undefined): string {
+  const depPath = reference == null ? null : dp.refToRelative(reference, alias)
+  if (depPath == null) return `${alias}@`
+  const { name, version, registryName } = dp.parse(depPath)
+  if (name == null) return `${alias}@`
+  if (version == null) return `${name}@`
+  return registryName == null ? `${name}@${version}` : `${name}@${registryName}:${version}`
+}
+
+function peerSuffixIsIndependentOf (peers: string, dropped: DroppedEdges): boolean {
+  return peerIdsIn(peers).every((peerId) => {
+    const versionIndex = peerId.indexOf('@', 1) + 1
+    if (versionIndex === 0) return false
+    return !dropped.has(peerId) && !dropped.has(peerId.substring(0, versionIndex))
+  })
+}
+
+/**
+ * The ids a peer suffix names, at every nesting depth: without `dedupePeers`
+ * a peer is named by its whole dep path, and the peers that path pins are as
+ * much a part of the dependent's key as the top-level ones. A `patch_hash=`
+ * segment names no package.
+ */
+function peerIdsIn (peers: string): string[] {
+  return peers
+    .split('(')
+    .flatMap((segment) => segment.split(')'))
+    .filter((segment) => segment !== '' && !segment.startsWith('patch_hash='))
+}

--- a/pnpm11/installing/deps-installer/src/install/tryComposeFastUpdates.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryComposeFastUpdates.ts
@@ -1,7 +1,7 @@
-import * as dp from '@pnpm/deps.path'
 import { pruneSharedLockfile } from '@pnpm/lockfile.pruner'
 import type { LockfileObject } from '@pnpm/lockfile.types'
 
+import { type DroppedEdges, peerSuffixesAreIndependentOf } from './droppedEdges.js'
 import { pruneUnreferencedCatalogEntries } from './tryFastUpdateCatalogs.js'
 import { tryFastUpdateIgnoredOptionalDependencies } from './tryFastUpdateIgnoredOptionalDependencies.js'
 import { type Project, tryFastUpdateImporters } from './tryFastUpdateImporters.js'
@@ -21,8 +21,8 @@ import {
  * runs once over the combined result instead of once per handler.
  */
 export interface GraphEdits {
-  /** Aliases whose importer or package edges were severed. */
-  dropped: Set<string>
+  /** What the severed importer or package edges pointed at. */
+  dropped: DroppedEdges
   /**
    * Whether an edge into or out of `optionalDependencies` moved, which
    * changes the reachability-derived `optional` flags for a subtree.
@@ -107,27 +107,4 @@ function finishGraphEdits (candidate: LockfileObject, edits: GraphEdits): boolea
     pruneUnreferencedCatalogEntries(candidate)
   }
   return true
-}
-
-/**
- * Whether no surviving package resolves a peer through one of `dropped`.
- *
- * A dropped package that some package reaches as a peer is embedded in that
- * package's key, so removing it would rekey the dependent rather than only
- * prune. A peer suffix pnpm shortened into a hash cannot be read to rule that
- * out.
- */
-function peerSuffixesAreIndependentOf (lockfile: LockfileObject, dropped: Set<string>): boolean {
-  const droppedNeedles = [...dropped].map((alias) => `${alias}@`)
-  return Object.keys(lockfile.packages ?? {}).every((depPath) => {
-    const { peersIndex } = dp.indexOfDepPathSuffix(depPath)
-    if (peersIndex === -1) return true
-    const peers = depPath.substring(peersIndex)
-    return peers
-      .replace(/^\(/, '')
-      .replace(/\)$/, '')
-      .split(')(')
-      .every((segment) => segment.includes('@')) &&
-      !droppedNeedles.some((needle) => peers.includes(needle))
-  })
 }

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateIgnoredOptionalDependencies.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateIgnoredOptionalDependencies.ts
@@ -5,12 +5,13 @@ import type {
   ResolvedDependencies,
 } from '@pnpm/lockfile.types'
 
+import { recordDroppedEdge } from './droppedEdges.js'
 import type { GraphEdits } from './tryComposeFastUpdates.js'
 
 /**
  * Remove every optional dependency a widened `ignoredOptionalDependencies`
- * now ignores, from importers and packages alike, recording the removed
- * aliases in `edits` for the shared epilogue. `false` — a narrowed list, a
+ * now ignores, from importers and packages alike, recording the severed
+ * edges in `edits` for the shared epilogue. `false` — a narrowed list, a
  * new exclusion, or a previous configuration that ignores by default — leaves
  * the caller on the full-resolution path, because only a resolution can bring
  * packages back.
@@ -53,9 +54,11 @@ function removeIgnoredOptionalDependencies (
 ): void {
   const removed = Object.keys(snapshot.optionalDependencies ?? {}).filter(isIgnored)
   for (const dependency of removed) {
-    edits.dropped.add(dependency)
-    delete snapshot.optionalDependencies![dependency]
-    delete snapshot.dependencies?.[dependency]
+    for (const references of [snapshot.optionalDependencies, snapshot.dependencies]) {
+      if (references?.[dependency] == null) continue
+      recordDroppedEdge(edits.dropped, dependency, references[dependency])
+      delete references[dependency]
+    }
     delete snapshot.specifiers?.[dependency]
   }
   if (snapshot.optionalDependencies != null && Object.keys(snapshot.optionalDependencies).length === 0) {

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
@@ -6,6 +6,7 @@ import { nameVerFromPkgSnapshot } from '@pnpm/lockfile.utils'
 import { DEPENDENCIES_FIELDS, type DependenciesField, type ProjectId, type ProjectManifest } from '@pnpm/types'
 import semver from 'semver'
 
+import { type DroppedEdges, recordDroppedEdge } from './droppedEdges.js'
 import type { GraphEdits } from './tryComposeFastUpdates.js'
 
 export interface Project {
@@ -34,8 +35,8 @@ export function hasChangedProjectSpecifiers (
 /**
  * Mutates `lockfile` in place and may leave it partially rewritten when it
  * returns `false` — the caller passes the coordinator's disposable candidate,
- * which is discarded on failure. The dropped aliases and optionality moves
- * are recorded in `edits` for the shared epilogue.
+ * which is discarded on failure. The severed edges and optionality moves are
+ * recorded in `edits` for the shared epilogue.
  */
 export function tryFastUpdateImporters (
   lockfile: LockfileObject,
@@ -52,8 +53,9 @@ export function tryFastUpdateImporters (
       return false
     }
     for (const importerId of stale) {
-      for (const alias of Object.keys(lockfile.importers[importerId].specifiers)) {
-        edits.dropped.add(alias)
+      const importer = lockfile.importers[importerId]
+      for (const alias of Object.keys(importer.specifiers)) {
+        recordDroppedImporterEdge(edits.dropped, importer, alias)
       }
       delete lockfile.importers[importerId]
       changed = true
@@ -79,7 +81,7 @@ export function tryFastUpdateImporters (
           // the lockfile, subtree and all.
           if (reference !== version) return false
           importer[recordedIn!]![alias] = wanted
-          edits.dropped.add(alias)
+          recordDroppedEdge(edits.dropped, alias, reference)
         }
         importer.specifiers[alias] = specifier
         changed = true
@@ -98,7 +100,7 @@ export function tryFastUpdateImporters (
     }
     for (const alias of Object.keys(importer.specifiers)) {
       if (manifestSpecifiers[alias] != null) continue
-      edits.dropped.add(alias)
+      recordDroppedImporterEdge(edits.dropped, importer, alias)
       delete importer.specifiers[alias]
       for (const group of DEPENDENCIES_FIELDS) {
         delete importer[group]?.[alias]
@@ -179,6 +181,12 @@ function dependencyGroupMoved (
 ): boolean {
   const recordedIn = recordedDependencyGroup(importer, alias)
   return recordedIn != null && recordedIn !== effectiveDependencyGroup(manifest, alias)
+}
+
+/** Record the edge from `importer` to `alias` as severed. */
+function recordDroppedImporterEdge (dropped: DroppedEdges, importer: ProjectSnapshot, alias: string): void {
+  const recordedIn = recordedDependencyGroup(importer, alias)
+  recordDroppedEdge(dropped, alias, recordedIn == null ? undefined : importer[recordedIn]![alias])
 }
 
 function recordedDependencyGroup (importer: ProjectSnapshot, alias: string): DependenciesField | null {

--- a/pnpm11/installing/deps-installer/test/install/importerRemovalFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/importerRemovalFastUpdate.ts
@@ -72,6 +72,41 @@ test('dropping a dependency together with its peer-dependent succeeds', () => {
   expect(Object.keys(subject.packages!)).toStrictEqual(['bar@2.0.0', 'child@3.0.0'])
 })
 
+test('dropping one version of a dependency keeps a package whose peer suffix names another', () => {
+  const subject = lockfileWithPeerOnEachVersionOfFoo()
+
+  expect(tryFastUpdateImporters(subject, [project({ qux: '^5.0.0' })])).toBe(true)
+  expect(Object.keys(subject.packages!).sort()).toStrictEqual([
+    'baz@4.0.0(foo@2.0.0)',
+    'foo@2.0.0',
+    'qux@5.0.0',
+  ])
+})
+
+test('dropping a dependency keeps a surviving suffix that only ends with its name', () => {
+  const subject = lockfile()
+  subject.importers['.' as ProjectId].dependencies!.qux = '5.0.0(@scope/foo@6.0.0)'
+  subject.importers['.' as ProjectId].specifiers.qux = '^5.0.0'
+  subject.packages!['qux@5.0.0(@scope/foo@6.0.0)' as DepPath] = {
+    resolution: { integrity: 'sha512-qux' },
+    dependencies: { '@scope/foo': '6.0.0' },
+  }
+  subject.packages!['@scope/foo@6.0.0' as DepPath] = { resolution: { integrity: 'sha512-scoped-foo' } }
+
+  expect(tryFastUpdateImporters(subject, [project({ bar: '^2.0.0', qux: '^5.0.0' })])).toBe(true)
+})
+
+test('dropping a dependency a nested peer suffix segment names falls back', () => {
+  const subject = lockfileWithPeerOnEachVersionOfFoo()
+  subject.importers['.' as ProjectId].dependencies!.baz = '4.0.0(qux@5.0.0(foo@1.1.0))'
+  subject.importers['.' as ProjectId].specifiers.baz = '^4.0.0'
+  subject.packages!['baz@4.0.0(qux@5.0.0(foo@1.1.0))' as DepPath] = {
+    resolution: { integrity: 'sha512-baz' },
+  }
+
+  expect(tryFastUpdateImporters(subject, [project({ qux: '^5.0.0', baz: '^4.0.0' })])).toBe(false)
+})
+
 test('dropping a dependency when a surviving peer suffix is hashed falls back', () => {
   const subject = lockfile()
   subject.importers['.' as ProjectId].dependencies!.baz = '4.0.0(sha256-abcdef)'
@@ -205,6 +240,34 @@ function lockfile (): LockfileObject {
         dependencies: { child: '3.0.0' },
       },
       ['child@3.0.0' as DepPath]: { resolution: { integrity: 'sha512-child' } },
+    },
+  }
+}
+
+/**
+ * The importer depends on `foo@1.1.0` directly, while `baz` — reached through
+ * `qux` — resolves `foo` as a peer at the version `qux` provides, `2.0.0`.
+ */
+function lockfileWithPeerOnEachVersionOfFoo (): LockfileObject {
+  return {
+    lockfileVersion: '9.0',
+    importers: {
+      ['.' as ProjectId]: {
+        specifiers: { foo: '^1.0.0', qux: '^5.0.0' },
+        dependencies: { foo: '1.1.0', qux: '5.0.0' },
+      },
+    },
+    packages: {
+      ['foo@1.1.0' as DepPath]: { resolution: { integrity: 'sha512-foo-1' } },
+      ['foo@2.0.0' as DepPath]: { resolution: { integrity: 'sha512-foo-2' } },
+      ['qux@5.0.0' as DepPath]: {
+        resolution: { integrity: 'sha512-qux' },
+        dependencies: { foo: '2.0.0', baz: '4.0.0(foo@2.0.0)' },
+      },
+      ['baz@4.0.0(foo@2.0.0)' as DepPath]: {
+        resolution: { integrity: 'sha512-baz' },
+        dependencies: { foo: '2.0.0' },
+      },
     },
   }
 }

--- a/pnpm11/installing/deps-installer/test/install/importerRemovalFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/importerRemovalFastUpdate.ts
@@ -107,6 +107,20 @@ test('dropping a dependency a nested peer suffix segment names falls back', () =
   expect(tryFastUpdateImporters(subject, [project({ qux: '^5.0.0', baz: '^4.0.0' })])).toBe(false)
 })
 
+test('dropping a linked dependency a surviving peer suffix names falls back', () => {
+  const subject = lockfile()
+  subject.importers['.' as ProjectId].specifiers.foo = 'workspace:*'
+  subject.importers['.' as ProjectId].dependencies!.foo = 'link:packages/foo'
+  subject.importers['.' as ProjectId].specifiers.baz = '^4.0.0'
+  subject.importers['.' as ProjectId].dependencies!.baz = '4.0.0(foo@packages+foo)'
+  delete subject.packages!['foo@1.1.0' as DepPath]
+  subject.packages!['baz@4.0.0(foo@packages+foo)' as DepPath] = {
+    resolution: { integrity: 'sha512-baz' },
+  }
+
+  expect(tryFastUpdateImporters(subject, [project({ bar: '^2.0.0', baz: '^4.0.0' })])).toBe(false)
+})
+
 test('dropping a dependency when a surviving peer suffix is hashed falls back', () => {
   const subject = lockfile()
   subject.importers['.' as ProjectId].dependencies!.baz = '4.0.0(sha256-abcdef)'

--- a/pnpm11/installing/deps-installer/test/install/lockedVersionReuse.ts
+++ b/pnpm11/installing/deps-installer/test/install/lockedVersionReuse.ts
@@ -144,6 +144,76 @@ test('a higher version under a plain key is reused', () => {
   })
 })
 
+test('a moved range keeps a package whose peer suffix names the version it moves to', () => {
+  const subject = lockfileWithPeerDependentUnderQux()
+
+  expect(tryComposeFastUpdates(subject, {
+    drift: { importers: true },
+    projects: [{
+      id: '.' as ProjectId,
+      manifest: { dependencies: { '@pnpm.e2e/foo': '^1.1.0', '@pnpm.e2e/qux': '^5.0.0' } } as ProjectManifest,
+    }],
+  })).toBe(true)
+  expect(subject.importers['.' as ProjectId].dependencies!['@pnpm.e2e/foo']).toBe('1.2.0')
+  expect(Object.keys(subject.packages ?? {}).filter(isFoo)).toStrictEqual(['@pnpm.e2e/foo@1.2.0'])
+})
+
+test('a moved range falls back when a peer suffix names the version it moves off', () => {
+  const subject = lockfileWithPeerDependentUnderQux()
+  subject.importers['.' as ProjectId].specifiers['@pnpm.e2e/baz'] = '^4.0.0'
+  subject.importers['.' as ProjectId].dependencies!['@pnpm.e2e/baz'] = '4.0.0(@pnpm.e2e/foo@1.0.0)'
+  subject.packages!['@pnpm.e2e/baz@4.0.0(@pnpm.e2e/foo@1.0.0)' as DepPath] = {
+    resolution: { integrity: 'sha512-baz-1' },
+    dependencies: { '@pnpm.e2e/foo': '1.0.0' },
+  }
+
+  expect(tryComposeFastUpdates(subject, {
+    drift: { importers: true },
+    projects: [{
+      id: '.' as ProjectId,
+      manifest: {
+        dependencies: {
+          '@pnpm.e2e/foo': '^1.1.0',
+          '@pnpm.e2e/qux': '^5.0.0',
+          '@pnpm.e2e/baz': '^4.0.0',
+        },
+      } as ProjectManifest,
+    }],
+  })).toBe(false)
+})
+
+/**
+ * The importer depends on `@pnpm.e2e/foo@1.0.0` directly, while
+ * `@pnpm.e2e/baz` — reached through `@pnpm.e2e/qux` — resolves it as a peer
+ * at the version `@pnpm.e2e/qux` provides, `1.2.0`.
+ */
+function lockfileWithPeerDependentUnderQux (): LockfileTypesObject {
+  return {
+    lockfileVersion: '9.0',
+    importers: {
+      ['.' as ProjectId]: {
+        specifiers: { '@pnpm.e2e/foo': '1.0.0', '@pnpm.e2e/qux': '^5.0.0' },
+        dependencies: { '@pnpm.e2e/foo': '1.0.0', '@pnpm.e2e/qux': '5.0.0' },
+      },
+    },
+    packages: {
+      ['@pnpm.e2e/foo@1.0.0' as DepPath]: { resolution: { integrity: 'sha512-foo-1' } },
+      ['@pnpm.e2e/foo@1.2.0' as DepPath]: { resolution: { integrity: 'sha512-foo-2' } },
+      ['@pnpm.e2e/qux@5.0.0' as DepPath]: {
+        resolution: { integrity: 'sha512-qux' },
+        dependencies: {
+          '@pnpm.e2e/foo': '1.2.0',
+          '@pnpm.e2e/baz': '4.0.0(@pnpm.e2e/foo@1.2.0)',
+        },
+      },
+      ['@pnpm.e2e/baz@4.0.0(@pnpm.e2e/foo@1.2.0)' as DepPath]: {
+        resolution: { integrity: 'sha512-baz-2' },
+        dependencies: { '@pnpm.e2e/foo': '1.2.0' },
+      },
+    },
+  }
+}
+
 function lockfileWithHigherVersionKeyedAs (higher: DepPath): LockfileTypesObject {
   return {
     lockfileVersion: '9.0',


### PR DESCRIPTION
## Summary

The fast-update peer-suffix guard (`peerSuffixesAreIndependentOf` / `peer_suffixes_are_independent_of`) rejected a candidate whenever any surviving package's peer suffix mentioned a dropped **alias**, found by substring-matching `<alias>@`. The question it means to ask is narrower: does a surviving suffix name the `name@version` the removal or range move actually severed? Both stacks now record what each severed edge pointed at and compare suffix segments against that, so a fast update survives:

- a **removal** whose alias other packages resolve as a peer at a different, still-present version;
- a **range move** (pnpm/pnpm#13779) onto a version some reachable package already names in its suffix;
- a near-miss name — the old substring needle made a dropped `foo` reject a suffix naming `@scope/foo`.

Closes pnpm/pnpm#13781.

**One deviation from the issue's proposal, deliberate.** The issue suggested rejecting only when a segment names *a key the lockfile no longer holds* after the prune. That is not safe: a resolved peer is recorded in its dependent's `dependencies`, so the dropped version stays reachable through the very package whose key names it, and the prune never removes it — exactly the graph in `dropping a dependency another package resolves as a peer falls back` / `rejects_dropping_a_dependency_another_package_resolves_as_a_peer`, which would have started accepting a candidate a full resolution disagrees with. The check is therefore against what the severed edge pointed at, not against what survives.

## Squash Commit Body

```text
The peer-suffix guard asked whether any surviving suffix mentions a
dropped alias, by substring-matching `<alias>@`. The question it means to
ask is narrower: does a surviving suffix name the `name@version` the
removal or range move severed? A dependent that resolves the same alias
at another version needs no rekeying, and neither does one whose peer
merely ends with the alias's name.

Both stacks now record what each severed edge pointed at, written the way
a peer suffix names a package — `name@version`, or a bare `name@` when
the reference pins no version to compare against, such as a link or a
tarball — and reject only a suffix that names one of those. Suffix
segments are read at every nesting depth, so the peers a `dedupePeers`-off
dep path pins are checked too, and the hashed-suffix bail stays: a
shortened suffix names nothing that can be ruled out.

A version the prune leaves behind is no proof the suffix is safe: a peer
stays reachable through the very dependent whose key names it, so the
check is against what the severed edge pointed at, not against what the
lockfile still holds.

Closes pnpm/pnpm#13781.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13789"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788987077&installation_model_id=426870&pr_number=13789&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13789&signature=3387aca7c6e10c62c3193087b3f9c58c600ac74021e0f9b4bfe2f8ad02776f20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fast lockfile updates when dependencies are removed or moved between versions.
  * Prevented unnecessary dependency graph re-resolution when peer-related lockfile entries remain valid.
  * Added support for scoped, nested, aliased, linked, and optional dependency scenarios.
  * Improved dependency cleanup while preserving valid peer-related lockfile entries.
* **Tests**
  * Added regression coverage for peer suffixes, alternate versions, workspace links, and version reuse.
  * Added coverage for safe fallback when peer-related entries require re-resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->