### PR TITLE
fix(package-manager): drop the importer of a removed workspace project

### DIFF
--- a/.changeset/prune-stale-importers.md
+++ b/.changeset/prune-stale-importers.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Removing a package from a workspace now drops its importer entry from `pnpm-lock.yaml`, along with the dependencies only it needed. Previously the entry survived every later install, which kept those dependencies reachable and made the lockfile diverge from the one the TypeScript CLI writes [#13783](https://github.com/pnpm/pnpm/issues/13783).

--- a/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
@@ -1503,34 +1503,28 @@ fn a_remove_keeps_the_specifiers_a_project_rewriting_pnpmfile_recorded() {
 }
 
 #[test]
+fn a_frozen_install_tolerates_the_importer_of_a_removed_workspace_project() {
+    let CommandTempCwd { workspace, root, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    write_two_member_workspace(&workspace);
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    fs::remove_dir_all(workspace.join("packages/b")).expect("remove the member");
+
+    // pnpm's importer-set gate lives in the auto-frozen branch, which an
+    // explicit `--frozen-lockfile` short-circuits past.
+    pacquet_at(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
+
+    drop((root, mock_instance));
+}
+
+#[test]
 fn removing_a_workspace_project_prunes_its_importer_without_resolving() {
     let CommandTempCwd { workspace, root, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();
     let AddMockedRegistry { mock_instance, npmrc_path, .. } = npmrc_info;
-    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
-    let workspace_yaml =
-        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
-    fs::write(&workspace_yaml_path, format!("{workspace_yaml}packages:\n  - packages/*\n"))
-        .expect("declare the workspace members");
-    fs::write(
-        workspace.join("package.json"),
-        serde_json::json!({ "name": "root", "version": "1.0.0" }).to_string(),
-    )
-    .expect("write the root package.json");
-    for (name, dependency) in [("a", "@pnpm.e2e/foo"), ("b", "@pnpm.e2e/bar")] {
-        let dir = workspace.join("packages").join(name);
-        fs::create_dir_all(&dir).expect("create the member directory");
-        fs::write(
-            dir.join("package.json"),
-            serde_json::json!({
-                "name": name,
-                "version": "1.0.0",
-                "dependencies": { dependency: "100.0.0" },
-            })
-            .to_string(),
-        )
-        .expect("write the member package.json");
-    }
+    write_two_member_workspace(&workspace);
     pacquet_at(&workspace).with_arg("install").assert().success();
 
     fs::remove_dir_all(workspace.join("packages/b")).expect("remove the member");
@@ -1571,4 +1565,32 @@ fn removing_a_workspace_project_prunes_its_importer_without_resolving() {
     );
 
     drop((root, mock_instance));
+}
+
+/// A workspace whose two members each depend on a package of their own.
+fn write_two_member_workspace(workspace: &Path) {
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    fs::write(&workspace_yaml_path, format!("{workspace_yaml}packages:\n  - packages/*\n"))
+        .expect("declare the workspace members");
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "name": "root", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write the root package.json");
+    for (name, dependency) in [("a", "@pnpm.e2e/foo"), ("b", "@pnpm.e2e/bar")] {
+        let dir = workspace.join("packages").join(name);
+        fs::create_dir_all(&dir).expect("create the member directory");
+        fs::write(
+            dir.join("package.json"),
+            serde_json::json!({
+                "name": name,
+                "version": "1.0.0",
+                "dependencies": { dependency: "100.0.0" },
+            })
+            .to_string(),
+        )
+        .expect("write the member package.json");
+    }
 }

--- a/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
@@ -1501,3 +1501,74 @@ fn a_remove_keeps_the_specifiers_a_project_rewriting_pnpmfile_recorded() {
 
     drop((root, mock_instance));
 }
+
+#[test]
+fn removing_a_workspace_project_prunes_its_importer_without_resolving() {
+    let CommandTempCwd { workspace, root, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, npmrc_path, .. } = npmrc_info;
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    fs::write(&workspace_yaml_path, format!("{workspace_yaml}packages:\n  - packages/*\n"))
+        .expect("declare the workspace members");
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "name": "root", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write the root package.json");
+    for (name, dependency) in [("a", "@pnpm.e2e/foo"), ("b", "@pnpm.e2e/bar")] {
+        let dir = workspace.join("packages").join(name);
+        fs::create_dir_all(&dir).expect("create the member directory");
+        fs::write(
+            dir.join("package.json"),
+            serde_json::json!({
+                "name": name,
+                "version": "1.0.0",
+                "dependencies": { dependency: "100.0.0" },
+            })
+            .to_string(),
+        )
+        .expect("write the member package.json");
+    }
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    fs::remove_dir_all(workspace.join("packages/b")).expect("remove the member");
+    let dead_registry = dead_registry_url();
+    let live_npmrc = fs::read_to_string(&npmrc_path).expect("read .npmrc");
+    let dead_npmrc = live_npmrc
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("registry="))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(&npmrc_path, format!("registry={dead_registry}\n{dead_npmrc}\n"))
+        .expect("rewrite .npmrc with a dead registry");
+
+    let assert = pacquet_at(&workspace).with_arg("install").assert().success();
+    assert!(
+        String::from_utf8_lossy(&assert.get_output().stdout)
+            .contains("Lockfile is up to date, resolution step is skipped"),
+        "dropping a workspace project needs no resolution",
+    );
+    let wanted = pacquet_lockfile::Lockfile::load_wanted_from_dir(&workspace)
+        .expect("load updated wanted lockfile")
+        .expect("updated wanted lockfile");
+    let mut importers: Vec<_> = wanted.importers.keys().map(String::as_str).collect();
+    importers.sort_unstable();
+    assert_eq!(
+        importers,
+        vec![".", "packages/a"],
+        "the departed project's importer is gone, the root and its sibling stay",
+    );
+    assert!(
+        !wanted
+            .packages
+            .as_ref()
+            .expect("packages")
+            .keys()
+            .any(|key| key.to_string().starts_with("@pnpm.e2e/bar@")),
+        "and so is what only it depended on",
+    );
+
+    drop((root, mock_instance));
+}

--- a/pnpm/crates/lockfile/src/freshness.rs
+++ b/pnpm/crates/lockfile/src/freshness.rs
@@ -74,6 +74,12 @@ pub enum StalenessReason {
     #[display(r#"the lockfile has no `importers["{importer_id}"]` entry"#)]
     NoImporter { importer_id: String },
 
+    /// The lockfile records an importer for a workspace project that
+    /// no longer exists. Only reported for an unfiltered install of the
+    /// whole workspace, where the project list is the complete one.
+    #[display(r#"the lockfile records `importers["{importer_id}"]`, but no such project exists"#)]
+    RemovedImporter { importer_id: String },
+
     /// The flat union of `dependencies ∪ devDependencies ∪
     /// optionalDependencies` from the manifest doesn't match the
     /// per-dep specifiers recorded in the importer entry: the
@@ -258,6 +264,7 @@ impl StalenessReason {
                 Some("settings.injectWorkspacePackages")
             }
             StalenessReason::NoImporter { .. }
+            | StalenessReason::RemovedImporter { .. }
             | StalenessReason::SpecifiersDiffer(_)
             | StalenessReason::PublishDirectoryMismatch { .. }
             | StalenessReason::DependenciesMetaMismatch { .. }

--- a/pnpm/crates/package-manager/src/fast_update_compose.rs
+++ b/pnpm/crates/package-manager/src/fast_update_compose.rs
@@ -32,13 +32,17 @@ pub(crate) fn try_compose_fast_updates(
     manifests: &[(String, &PackageManifest)],
     project_manifests: &[(PathBuf, &PackageManifest)],
     config: &Config,
+    prune_stale_importers: bool,
 ) -> Option<Lockfile> {
     let ignored_optional_dependencies =
         config.ignored_optional_dependencies.as_deref().unwrap_or_default();
     let settings = crate::fast_update_settings::lockfile_settings_from_config(config);
 
-    let importers = match crate::fast_update_importers::detect_importers_drift(lockfile, manifests)
-    {
+    let importers = match crate::fast_update_importers::detect_importers_drift(
+        lockfile,
+        manifests,
+        prune_stale_importers,
+    ) {
         Drift::Resolve => return None,
         drift => drift,
     };

--- a/pnpm/crates/package-manager/src/fast_update_compose/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_compose/tests.rs
@@ -83,7 +83,7 @@ fn absorbs_a_removal_and_a_widened_ignore_list_in_one_pass() {
     };
 
     let updated =
-        try_compose_fast_updates(&lockfile(), &[(".".to_string(), &manifest)], &[], &config)
+        try_compose_fast_updates(&lockfile(), &[(".".to_string(), &manifest)], &[], &config, false)
             .expect("both kinds of drift are absorbable at once");
 
     assert_eq!(
@@ -120,6 +120,7 @@ fn absorbs_a_group_move_and_a_settings_change_in_one_pass() {
         &[(".".to_string(), &manifest)],
         &[(PathBuf::from("/project"), &manifest)],
         &config,
+        false,
     )
     .expect("a peerless lockfile absorbs the setting alongside the move");
 
@@ -153,6 +154,7 @@ fn falls_back_when_one_of_the_composed_changes_cannot_be_absorbed() {
             &[(".".to_string(), &manifest)],
             &[(PathBuf::from("/project"), &manifest)],
             &config,
+            false,
         )
         .is_none(),
         "the incompatible range needs the resolver, and the settings change goes with it",
@@ -169,7 +171,7 @@ fn falls_back_when_a_removal_leaves_a_configured_patch_unused() {
     let config = Config { allow_unused_patches: false, ..patch_config(dir.path(), &["bar@2.0.0"]) };
 
     assert!(
-        try_compose_fast_updates(&lockfile(), &[(".".to_string(), &manifest)], &[], &config)
+        try_compose_fast_updates(&lockfile(), &[(".".to_string(), &manifest)], &[], &config, false)
             .is_none(),
         "removing the patch's only referent is what the resolver reports as an unused patch",
     );
@@ -185,7 +187,7 @@ fn rekeys_a_patched_survivor_alongside_a_removal() {
     let config = patch_config(dir.path(), &["bar@2.0.0"]);
 
     let updated =
-        try_compose_fast_updates(&lockfile(), &[(".".to_string(), &manifest)], &[], &config)
+        try_compose_fast_updates(&lockfile(), &[(".".to_string(), &manifest)], &[], &config, false)
             .expect("the removal and the patch rekey compose");
 
     assert!(
@@ -223,7 +225,7 @@ fn falls_back_when_an_ignored_optional_is_embedded_in_a_peer_suffix() {
     };
 
     assert!(
-        try_compose_fast_updates(&subject, &[], &[], &config).is_none(),
+        try_compose_fast_updates(&subject, &[], &[], &config, false).is_none(),
         "the surviving dependent's key embeds the removed package, so it would rekey, not prune",
     );
 }
@@ -241,6 +243,7 @@ fn stands_aside_when_nothing_drifted() {
             &[(".".to_string(), &manifest)],
             &[],
             &Config::default(),
+            false,
         )
         .is_none(),
         "no drift means the ordinary frozen path decides",
@@ -274,7 +277,7 @@ fn recomputes_optional_flags_for_an_ignored_optional_removal() {
         .expect("snapshot")
         .optional = true;
 
-    let updated = try_compose_fast_updates(&subject, &[], &[], &config)
+    let updated = try_compose_fast_updates(&subject, &[], &[], &config, false)
         .expect("widening the ignore list needs no resolution");
 
     assert!(
@@ -348,6 +351,7 @@ fn absorbs_a_peer_setting_once_the_removal_drops_the_last_peer_dependent() {
         &[(".".to_string(), &manifest)],
         &[(PathBuf::from("/project"), &manifest)],
         &config,
+        false,
     )
     .expect("the removal prunes the only peer dependent, so the setting cannot affect the graph");
 

--- a/pnpm/crates/package-manager/src/fast_update_ignored_optional_dependencies/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_ignored_optional_dependencies/tests.rs
@@ -15,6 +15,7 @@ fn try_fast_update_ignored_optional_dependencies(
             ignored_optional_dependencies: Some(ignored_optional_dependencies.to_vec()),
             ..pacquet_config::Config::default()
         },
+        false,
     )
 }
 

--- a/pnpm/crates/package-manager/src/fast_update_importers.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers.rs
@@ -17,6 +17,8 @@ type ManifestDependencies<'manifest> = HashMap<PkgName, (&'manifest str, Depende
 /// the parsed aliases.
 pub(crate) struct ImportersPlan<'a, 'manifest> {
     manifest_dependencies: Vec<(&'a String, ManifestDependencies<'manifest>)>,
+    /// Importers no project claims, to drop before the rest replays.
+    stale: Vec<String>,
 }
 
 /// Whether the importers' records diverge from the manifests, without
@@ -25,6 +27,7 @@ pub(crate) struct ImportersPlan<'a, 'manifest> {
 pub(crate) fn detect_importers_drift<'a, 'manifest>(
     lockfile: &Lockfile,
     manifests: &'a [(String, &'manifest PackageManifest)],
+    prune_stale_importers: bool,
 ) -> Drift<ImportersPlan<'a, 'manifest>> {
     let mut manifest_dependencies: Vec<(&String, ManifestDependencies<'_>)> = Vec::new();
     for (importer_id, manifest) in manifests {
@@ -42,11 +45,22 @@ pub(crate) fn detect_importers_drift<'a, 'manifest>(
         }
         manifest_dependencies.push((importer_id, dependencies));
     }
-    if manifest_dependencies
-        .iter()
-        .any(|(importer_id, dependencies)| importer_diverges(lockfile, importer_id, dependencies))
+    let stale: Vec<String> = if prune_stale_importers {
+        lockfile
+            .importers
+            .keys()
+            .filter(|importer_id| !manifests.iter().any(|(id, _)| id == *importer_id))
+            .cloned()
+            .collect()
+    } else {
+        Vec::new()
+    };
+    if !stale.is_empty()
+        || manifest_dependencies.iter().any(|(importer_id, dependencies)| {
+            importer_diverges(lockfile, importer_id, dependencies)
+        })
     {
-        Drift::Absorb(ImportersPlan { manifest_dependencies })
+        Drift::Absorb(ImportersPlan { manifest_dependencies, stale })
     } else {
         Drift::Clean
     }
@@ -63,6 +77,29 @@ pub(crate) fn apply_importers_update(
     plan: &ImportersPlan<'_, '_>,
     edits: &mut GraphEdits,
 ) -> bool {
+    // A project that is gone while something still links to it is a broken
+    // workspace, which only the resolver may report.
+    if plan
+        .stale
+        .iter()
+        .any(|importer_id| is_linked_from_a_survivor(candidate, importer_id, &plan.stale))
+    {
+        return false;
+    }
+    for importer_id in &plan.stale {
+        if let Some(importer) = candidate.importers.remove(importer_id) {
+            for group in [
+                importer.dependencies.as_ref(),
+                importer.dev_dependencies.as_ref(),
+                importer.optional_dependencies.as_ref(),
+            ]
+            .into_iter()
+            .flatten()
+            {
+                edits.dropped.extend(group.keys().cloned());
+            }
+        }
+    }
     let Lockfile { packages, importers, .. } = candidate;
     for (importer_id, manifest_dependencies) in &plan.manifest_dependencies {
         let Some(importer) = importers.get_mut(importer_id.as_str()) else {
@@ -110,6 +147,47 @@ pub(crate) fn apply_importers_update(
         edits.dropped.extend(remove_dependencies_absent_from(importer, manifest_dependencies));
     }
     true
+}
+
+/// Whether an importer that survives the prune links to `importer_id`.
+fn is_linked_from_a_survivor(lockfile: &Lockfile, importer_id: &str, stale: &[String]) -> bool {
+    lockfile.importers.iter().any(|(survivor_id, importer)| {
+        if stale.iter().any(|id| id == survivor_id) {
+            return false;
+        }
+        [
+            importer.dependencies.as_ref(),
+            importer.dev_dependencies.as_ref(),
+            importer.optional_dependencies.as_ref(),
+        ]
+        .into_iter()
+        .flatten()
+        .any(|group| {
+            group.values().any(|spec| {
+                spec.version
+                    .as_link_target()
+                    .is_some_and(|target| link_resolves_to(survivor_id, target, importer_id))
+            })
+        })
+    })
+}
+
+/// Whether `target`, a `link:` path relative to `from`'s directory,
+/// names the importer `importer_id`.
+fn link_resolves_to(from: &str, target: &str, importer_id: &str) -> bool {
+    let mut segments: Vec<&str> = if from == "." { Vec::new() } else { from.split('/').collect() };
+    for part in target.split('/') {
+        match part {
+            "." | "" => {}
+            ".." => {
+                if segments.pop().is_none() {
+                    return false;
+                }
+            }
+            other => segments.push(other),
+        }
+    }
+    segments.join("/") == importer_id
 }
 
 /// The version resolution would settle on for `alias` under `range`: the

--- a/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
@@ -15,6 +15,7 @@ fn try_fast_update_importers(
         manifests,
         &[],
         &pacquet_config::Config::default(),
+        false,
     )
 }
 
@@ -769,5 +770,102 @@ fn rejects_a_higher_version_that_exists_only_under_a_named_registry() {
     assert!(
         try_fast_update_importers(&subject, &[(".".to_string(), &manifest)]).is_none(),
         "a registry-qualified key's semver only pins a version inside that registry",
+    );
+}
+
+/// Two workspace members, each with a dependency of its own.
+const WITH_TWO_IMPORTERS: &str = r"
+lockfileVersion: '9.0'
+importers:
+  packages/a:
+    dependencies:
+      foo:
+        specifier: ^1.0.0
+        version: 1.1.0
+  packages/b:
+    dependencies:
+      bar:
+        specifier: ^2.0.0
+        version: 2.0.0
+packages:
+  foo@1.1.0:
+    resolution:
+      integrity: sha512-foo
+  bar@2.0.0:
+    resolution:
+      integrity: sha512-bar
+snapshots:
+  foo@1.1.0: {}
+  bar@2.0.0: {}
+";
+
+fn try_prune_stale_importers(
+    lockfile: &Lockfile,
+    manifests: &[(String, &PackageManifest)],
+) -> Option<Lockfile> {
+    crate::fast_update_compose::try_compose_fast_updates(
+        lockfile,
+        manifests,
+        &[],
+        &pacquet_config::Config::default(),
+        true,
+    )
+}
+
+#[test]
+fn drops_the_importer_of_a_workspace_project_that_is_gone() {
+    let manifest = manifest_from(json!({ "dependencies": { "foo": "^1.0.0" } }));
+
+    let updated = try_prune_stale_importers(
+        &parsed_lockfile(WITH_TWO_IMPORTERS),
+        &[("packages/a".to_string(), &manifest)],
+    )
+    .expect("dropping a project's importer needs no resolution");
+
+    assert_eq!(updated.importers.keys().collect::<Vec<_>>(), vec!["packages/a"]);
+    let mut packages: Vec<_> =
+        updated.packages.as_ref().expect("packages").keys().map(ToString::to_string).collect();
+    packages.sort();
+    assert_eq!(packages, vec!["foo@1.1.0".to_string()], "what only it needed goes with it");
+}
+
+#[test]
+fn keeps_the_importer_when_the_run_does_not_see_every_project() {
+    let manifest = manifest_from(json!({ "dependencies": { "foo": "^1.0.0" } }));
+
+    assert!(
+        crate::fast_update_compose::try_compose_fast_updates(
+            &parsed_lockfile(WITH_TWO_IMPORTERS),
+            &[("packages/a".to_string(), &manifest)],
+            &[],
+            &pacquet_config::Config::default(),
+            false,
+        )
+        .is_none(),
+        "a filtered run cannot tell a removed project from an unselected one",
+    );
+}
+
+#[test]
+fn rejects_dropping_an_importer_a_survivor_links_to() {
+    let mut subject = parsed_lockfile(WITH_TWO_IMPORTERS);
+    subject
+        .importers
+        .get_mut("packages/a")
+        .expect("importer")
+        .dependencies
+        .as_mut()
+        .expect("dependencies")
+        .insert(
+            "b".parse().expect("alias"),
+            serde_saphyr::from_str("{specifier: workspace:1.0.0, version: link:../b}")
+                .expect("dependency"),
+        );
+    let manifest =
+        manifest_from(json!({ "dependencies": { "foo": "^1.0.0", "b": "workspace:1.0.0" } }));
+
+    assert!(
+        try_prune_stale_importers(&subject, &[("packages/a".to_string(), &manifest)]).is_none(),
+        "a project that is gone while something links to it is a broken workspace",
     );
 }

--- a/pnpm/crates/package-manager/src/fast_update_patched_dependencies/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_patched_dependencies/tests.rs
@@ -2,7 +2,7 @@
 /// every other input is neutral, so these tests exercise this handler
 /// alone.
 fn try_fast_update_patched_dependencies(lockfile: &Lockfile, config: &Config) -> Option<Lockfile> {
-    crate::fast_update_compose::try_compose_fast_updates(lockfile, &[], &[], config)
+    crate::fast_update_compose::try_compose_fast_updates(lockfile, &[], &[], config, false)
 }
 use indexmap::IndexMap;
 use pacquet_config::Config;

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -66,8 +66,8 @@ use lifecycle::{
     run_dev_preinstall, run_projects_lifecycle_scripts,
 };
 pub(crate) use lockfile_freshness::{
-    CheckLockfileSettingsDriftOptions, FreshnessCheckError, check_importer_satisfies,
-    check_lockfile_settings_drift, parse_config_overrides,
+    CheckLockfileSettingsDriftOptions, FreshnessCheckError, FreshnessScope,
+    check_importer_satisfies, check_lockfile_settings_drift, parse_config_overrides,
 };
 use lockfile_freshness::{
     FastUpdateLockfileOptions, check_lockfile_freshness, try_fast_update_lockfile,

--- a/pnpm/crates/package-manager/src/install/lockfile_freshness.rs
+++ b/pnpm/crates/package-manager/src/install/lockfile_freshness.rs
@@ -12,6 +12,9 @@ pub(super) struct FastUpdateLockfileOptions<'a, 'manifest> {
     pub(super) catalogs: &'a Catalogs,
     pub(super) pnpmfile_hook: Option<&'a Arc<dyn pacquet_hooks::PnpmfileHooks>>,
     pub(super) ignore_manifest_check: bool,
+    /// Whether this run sees the complete project list, so an importer
+    /// no project claims may be dropped rather than kept.
+    pub(super) prune_stale_importers: bool,
 }
 
 /// Rewrite the loaded lockfile in place of a full resolution for the
@@ -30,6 +33,7 @@ pub(super) async fn try_fast_update_lockfile(
         opts.manifests,
         opts.project_manifests,
         opts.config,
+        opts.prune_stale_importers,
     )?;
     check_lockfile_freshness(
         &candidate,
@@ -37,12 +41,42 @@ pub(super) async fn try_fast_update_lockfile(
         opts.config,
         opts.catalogs,
         opts.pnpmfile_hook,
-        opts.ignore_manifest_check,
-        true,
+        FreshnessScope {
+            ignore_manifest_check: opts.ignore_manifest_check,
+            allow_missing_dependency_free_importers: true,
+            prune_stale_importers: opts.prune_stale_importers,
+        },
     )
     .await
     .ok()?;
     Some(candidate)
+}
+
+/// Which importers a freshness check may reason about, and how
+/// strictly. See [`check_lockfile_freshness`] for what each one admits.
+#[derive(Clone, Copy)]
+pub(crate) struct FreshnessScope {
+    /// Skip the per-importer specifier gate entirely.
+    pub(crate) ignore_manifest_check: bool,
+    /// Treat a project with no importer entry and no dependencies as
+    /// satisfied rather than missing.
+    pub(crate) allow_missing_dependency_free_importers: bool,
+    /// Treat an importer no project claims as staleness. Only an
+    /// unfiltered workspace install may, since only it sees the
+    /// complete project list.
+    pub(crate) prune_stale_importers: bool,
+}
+
+/// The first importer the lockfile records that no project claims.
+pub(super) fn removed_importer_id<'a>(
+    lockfile: &'a Lockfile,
+    manifest_freshness_inputs: &[(String, &PackageManifest)],
+) -> Option<&'a str> {
+    lockfile
+        .importers
+        .keys()
+        .find(|importer_id| !manifest_freshness_inputs.iter().any(|(id, _)| id == *importer_id))
+        .map(String::as_str)
 }
 
 /// Run every gate the frozen-lockfile dispatch consults before
@@ -78,9 +112,13 @@ pub(super) async fn check_lockfile_freshness(
     config: &Config,
     catalogs: &Catalogs,
     pnpmfile_hook: Option<&Arc<dyn pacquet_hooks::PnpmfileHooks>>,
-    ignore_manifest_check: bool,
-    allow_missing_dependency_free_importers: bool,
+    scope: FreshnessScope,
 ) -> Result<(), FreshnessCheckError> {
+    let FreshnessScope {
+        ignore_manifest_check,
+        allow_missing_dependency_free_importers,
+        prune_stale_importers,
+    } = scope;
     let parsed_overrides_opt = parse_config_overrides(config, catalogs)?;
     let pnpmfile_checksum = pacquet_hooks::current_pnpmfile_checksum(
         pnpmfile_hook,
@@ -100,6 +138,18 @@ pub(super) async fn check_lockfile_freshness(
 
     if ignore_manifest_check {
         return Ok(());
+    }
+
+    // An importer whose project is gone leaves the recorded graph wider
+    // than the workspace, and it is a root in every reachability walk, so
+    // it also keeps that project's dependencies alive. Only an unfiltered
+    // install sees the whole project list, so only it may conclude this.
+    if prune_stale_importers
+        && let Some(importer_id) = removed_importer_id(lockfile, manifest_freshness_inputs)
+    {
+        return Err(FreshnessCheckError::Stale(StalenessReason::RemovedImporter {
+            importer_id: importer_id.to_string(),
+        }));
     }
 
     let ignored_optional_matcher = pacquet_config::matcher::create_matcher(

--- a/pnpm/crates/package-manager/src/install/run.rs
+++ b/pnpm/crates/package-manager/src/install/run.rs
@@ -1,10 +1,10 @@
 use super::{
     ApplyMaterializationInputs, Arc, AtomicU8, ContextLog, DependencyGroup,
-    FastUpdateLockfileOptions, FreshnessCheckError, HashSet, Host, InMemoryPackageMetaCache,
-    IncludedDependencies, Install, InstallError, InstallRunOptions, IsTerminal, Lockfile, LogEvent,
-    LogLevel, MaterializationInputs, MaterializationOutput, OptimisticRepeatInstallCheck,
-    OptimisticRepeatInstallDecision, PackageManifest, Path, PathBuf, PnpmLog,
-    PrepareModulesStateInputs, PreparedModulesState, Reporter, ScopeLog, Stage, StageLog,
+    FastUpdateLockfileOptions, FreshnessCheckError, FreshnessScope, HashSet, Host,
+    InMemoryPackageMetaCache, IncludedDependencies, Install, InstallError, InstallRunOptions,
+    IsTerminal, Lockfile, LogEvent, LogLevel, MaterializationInputs, MaterializationOutput,
+    OptimisticRepeatInstallCheck, OptimisticRepeatInstallDecision, PackageManifest, Path, PathBuf,
+    PnpmLog, PrepareModulesStateInputs, PreparedModulesState, Reporter, ScopeLog, Stage, StageLog,
     SummaryLog, UpdateSeedPolicy, apply_materialization_result, build_project_manifests_list,
     build_resolution_verifiers, build_root_importer_project_manifests_list,
     build_selected_project_manifests_list, check_lockfile_freshness,
@@ -255,6 +255,16 @@ where
             ),
             None => build_project_manifests_list(&workspace_root, manifest, workspace_projects),
         };
+        // Only an unfiltered install of a whole workspace sees the complete
+        // project list, so only it may conclude that an importer the
+        // lockfile records belongs to a project that is gone. This is
+        // pnpm's `pruneLockfileImporters`, which its recursive install
+        // defaults to the same condition — outside a workspace there is no
+        // project list to compare against.
+        let prune_stale_importers = selection.is_none()
+            && mutation.is_full_install()
+            && workspace_projects.is_some()
+            && config.shared_workspace_lockfile;
         let selected_importer_ids = selection.as_ref().map(|selection| {
             selection
                 .selected_dirs
@@ -530,8 +540,11 @@ where
                     config,
                     &catalogs,
                     pnpmfile_hook.as_ref(),
-                    ignore_manifest_check,
-                    true,
+                    FreshnessScope {
+                        ignore_manifest_check,
+                        allow_missing_dependency_free_importers: true,
+                        prune_stale_importers,
+                    },
                 )
                 .await
                 .ok()
@@ -559,6 +572,7 @@ where
                 catalogs: &catalogs,
                 pnpmfile_hook: pnpmfile_hook.as_ref(),
                 ignore_manifest_check,
+                prune_stale_importers,
             })
             .await
         } else {
@@ -729,8 +743,11 @@ where
                 config,
                 &catalogs,
                 pnpmfile_hook.as_ref(),
-                ignore_manifest_check,
-                false,
+                FreshnessScope {
+                    ignore_manifest_check,
+                    allow_missing_dependency_free_importers: false,
+                    prune_stale_importers,
+                },
             )
             .await
             .map_err(InstallError::from)?;
@@ -752,8 +769,11 @@ where
                     config,
                     &catalogs,
                     pnpmfile_hook.as_ref(),
-                    ignore_manifest_check,
-                    true,
+                    FreshnessScope {
+                        ignore_manifest_check,
+                        allow_missing_dependency_free_importers: true,
+                        prune_stale_importers,
+                    },
                 )
                 .await
                 {

--- a/pnpm/crates/package-manager/src/install/run.rs
+++ b/pnpm/crates/package-manager/src/install/run.rs
@@ -261,9 +261,13 @@ where
         // pnpm's `pruneLockfileImporters`, which its recursive install
         // defaults to the same condition — outside a workspace there is no
         // project list to compare against.
+        // A `NodeApiProject[]` handed in by an API consumer carries no
+        // promise of listing every workspace project, so it cannot stand
+        // in for the project list either.
         let prune_stale_importers = selection.is_none()
             && mutation.is_full_install()
             && workspace_projects.is_some()
+            && !workspace_projects_are_overridden
             && config.shared_workspace_lockfile;
         let selected_importer_ids = selection.as_ref().map(|selection| {
             selection
@@ -746,7 +750,11 @@ where
                 FreshnessScope {
                     ignore_manifest_check,
                     allow_missing_dependency_free_importers: false,
-                    prune_stale_importers,
+                    // pnpm's importer-set gate sits in the auto-frozen branch
+                    // of `isFrozenInstallPossible`, which an explicit
+                    // `--frozen-lockfile` short-circuits past, so a removed
+                    // project does not fail the install there.
+                    prune_stale_importers: false,
                 },
             )
             .await


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#13783, the divergence found while doing item 3 of pnpm/pnpm#13696 (pnpm/pnpm#13784, the TypeScript half).

pacquet kept the importer entry of a workspace project that no longer exists. The freshness gates only ask whether every manifest has a satisfying importer, never whether an importer still has a project, so the lockfile read as up to date and was never rewritten. The writer was never the problem — forcing a resolution already produced the pruned file — the decision to skip resolving was.

The entry is not inert: `lockfile.importers` is the root set for `prune_unreachable_packages` and the `optional`-flag recompute, so the departed project's dependencies stayed reachable and survived every later install.

```
before: importers=2 is-negative=2
after:  importers=1 is-negative=0
```

An importer no project claims is now a `RemovedImporter` staleness reason, and the importers fast update absorbs it: the entry goes, its aliases are recorded as dropped, and the shared epilogue prunes what that orphans — so this both fixes the bug and gives pacquet the fast path pnpm/pnpm#13784 added on the other side.

**Two conditions worth calling out:**

- Only an unfiltered install of a whole workspace may conclude an importer is stale, since only it sees the complete project list; a filtered run cannot tell a removed project from an unselected one. This mirrors pnpm's `pruneLockfileImporters`, whose recursive default is the same condition. An existing GVS test caught the first version of this, which was too broad — it fired outside a workspace entirely.
- A stale importer that a surviving importer still links to keeps the resolver. A project that is gone while something depends on it is a broken workspace to report, not drift to absorb; the TypeScript side takes the same exit. Break-tested: with the guard disabled the regression test fails.

The three freshness flags move into a `FreshnessScope` struct rather than growing the parameter list to eight.

## Squash Commit Body

```text
pacquet kept an importer entry for a workspace project that no longer
exists: the freshness gates only ask whether every manifest has a
satisfying importer, never whether an importer still has a project, so
the lockfile was judged up to date and never rewritten. The entry is
not inert — it is a root in every reachability walk, so the departed
project's dependencies stayed reachable too, and the file diverged
from the one the TypeScript CLI writes.

An importer no project claims is now staleness (RemovedImporter), and
the importers fast update absorbs it: the entry goes, its aliases are
recorded as dropped, and the shared epilogue prunes what that orphans.
Only an unfiltered install of a whole workspace may conclude this,
since only it sees the complete project list — a filtered run cannot
tell a removed project from an unselected one. A stale importer that a
surviving importer still links to keeps the resolver: that is a broken
workspace to report, not drift to absorb, which is the exit the
TypeScript side takes too.

The three freshness flags move into a FreshnessScope struct rather
than growing the parameter list further.

Closes pnpm/pnpm#13783.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788988479&installation_model_id=426870&pr_number=13790&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13790&signature=d8945ba5c4a6e0aa35ec744831548aec994162f4b6b88574c5c24991e6003d8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed workspace projects are now automatically pruned from the lockfile during full workspace installs.
  * Exclusive dependencies belonging only to removed projects are also removed.
  * Installations fall back to full dependency resolution when remaining projects reference removed projects.
  * Lockfile freshness checks now detect projects that no longer exist.

* **Tests**
  * Added coverage for stale project removal, dependency cleanup, partial runs, and linked project references.

* **Documentation**
  * Added a changeset describing the lockfile cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->