### PR TITLE
fix(deps-resolver): keep the missing-peer range intersection bounded

### DIFF
--- a/.changeset/dedupe-missing-peer-ranges.md
+++ b/.changeset/dedupe-missing-peer-ranges.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm install` and `pnpm dedupe` no longer eat all the available memory while resolving a graph in which many packages declare the same missing peer dependency, such as the `react` peer the `@radix-ui` packages share [#13786](https://github.com/pnpm/pnpm/issues/13786).

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -1063,10 +1063,9 @@ fn partition_missing_peers(
 /// `||`-join under `auto_install_peers_from_highest_match` — or `None`,
 /// dropping the peer on an unresolvable conflict.
 ///
-/// Only the unique ranges reach [`intersect_ranges`]. It intersects two
-/// unions as their Cartesian product without collapsing equivalent
-/// alternatives, so re-intersecting a range already folded in doubles
-/// the alternative count instead of leaving it unchanged.
+/// Only the unique ranges reach [`intersect_ranges`]: folding a range in
+/// a second time cannot narrow the result, and every pass costs another
+/// Cartesian product over the alternatives.
 fn merge_ranges(ranges: &[&str], auto_install_peers_from_highest_match: bool) -> Option<String> {
     if ranges.len() == 1 {
         return Some(ranges[0].to_string());
@@ -1094,9 +1093,48 @@ fn intersect_ranges(ranges: &[&str]) -> Option<String> {
     let mut iter = ranges.iter();
     let first = Range::parse(iter.next()?).ok()?;
     iter.try_fold(first, |acc, range| {
-        Range::parse(range).ok().and_then(|range| acc.intersect(&range))
+        Range::parse(range)
+            .ok()
+            .and_then(|range| acc.intersect(&range))
+            .map(|intersection| collapse_covered_alternatives(&intersection))
     })
     .map(|range| range.to_string())
+}
+
+/// Drop the alternatives of a union that another alternative already
+/// covers, leaving the same set of versions behind.
+///
+/// [`Range::intersect`] pairs every alternative of one union with every
+/// alternative of the other, so an alternative two consumers agree on
+/// survives once per pair and the next intersection multiplies that
+/// count again. `semver-range-intersect` collapses the union upstream,
+/// which is why the growth is pacquet's alone.
+fn collapse_covered_alternatives(range: &Range) -> Range {
+    let rendered = range.to_string();
+    let alternatives: Vec<&str> = rendered.split("||").collect();
+    if alternatives.len() < 2 {
+        return range.clone();
+    }
+    let Some(parsed) = alternatives
+        .iter()
+        .map(|alternative| Range::parse(alternative).ok())
+        .collect::<Option<Vec<Range>>>()
+    else {
+        return range.clone();
+    };
+    let mut kept: Vec<&str> = Vec::with_capacity(alternatives.len());
+    for (index, alternative) in parsed.iter().enumerate() {
+        // Of two alternatives that cover each other, only the first is kept.
+        let covered = parsed.iter().enumerate().any(|(other_index, other)| {
+            other_index != index
+                && other.allows_all(alternative)
+                && (other_index < index || !alternative.allows_all(other))
+        });
+        if !covered {
+            kept.push(alternatives[index]);
+        }
+    }
+    Range::parse(kept.join("||")).unwrap_or_else(|_| range.clone())
 }
 
 /// `link:` / `file:` and the path form of `workspace:` name a directory

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -1072,7 +1072,7 @@ fn merge_ranges(ranges: &[&str], auto_install_peers_from_highest_match: bool) ->
         return Some(ranges[0].to_string());
     }
     let mut seen: HashSet<&str> = HashSet::default();
-    let unique: Vec<&str> = ranges.iter().copied().filter(|range| seen.insert(range)).collect();
+    let unique: Vec<&str> = ranges.iter().copied().filter(|&range| seen.insert(range)).collect();
     if unique.len() == 1 {
         return Some(ranges[0].to_string());
     }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -1062,15 +1062,21 @@ fn partition_missing_peers(
 /// their semver intersection, and an empty intersection falls back to a
 /// `||`-join under `auto_install_peers_from_highest_match` — or `None`,
 /// dropping the peer on an unresolvable conflict.
+///
+/// Only the unique ranges reach [`intersect_ranges`]. It intersects two
+/// unions as their Cartesian product without collapsing equivalent
+/// alternatives, so re-intersecting a range already folded in doubles
+/// the alternative count instead of leaving it unchanged.
 fn merge_ranges(ranges: &[&str], auto_install_peers_from_highest_match: bool) -> Option<String> {
     if ranges.len() == 1 {
         return Some(ranges[0].to_string());
     }
-    let unique: BTreeSet<&&str> = ranges.iter().collect();
+    let mut seen: HashSet<&str> = HashSet::default();
+    let unique: Vec<&str> = ranges.iter().copied().filter(|range| seen.insert(range)).collect();
     if unique.len() == 1 {
         return Some(ranges[0].to_string());
     }
-    if let Some(intersection) = intersect_ranges(ranges) {
+    if let Some(intersection) = intersect_ranges(&unique) {
         return Some(intersection);
     }
     if auto_install_peers_from_highest_match {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
@@ -14,7 +14,7 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use super::{
     ImporterLockedPeerContext, discard_changed_direct_dep_peer_context,
-    importer_locked_peer_context,
+    importer_locked_peer_context, merge_ranges,
 };
 use crate::{
     DepPath, ResolveDependencyTreeError, resolve_importer,
@@ -805,6 +805,18 @@ async fn auto_install_does_not_install_when_no_intersection() {
     let direct: Vec<&str> =
         result.peers_result.direct_dependencies_by_alias.keys().map(String::as_str).collect();
     assert!(!direct.contains(&"peer-c"), "peer-c must not be hoisted on conflict: {direct:?}");
+}
+
+#[test]
+fn repeated_consumer_ranges_merge_into_the_unique_intersection() {
+    let react = "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc";
+    let narrower = "^18.0.0 || ^19.0.0";
+    let expected = merge_ranges(&[react, narrower], false).expect("the two ranges overlap");
+
+    let mut repeated = vec![react; 10];
+    repeated.push(narrower);
+
+    assert_eq!(merge_ranges(&repeated, false).as_deref(), Some(expected.as_str()));
 }
 
 #[tokio::test]

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
@@ -811,12 +811,104 @@ async fn auto_install_does_not_install_when_no_intersection() {
 fn repeated_consumer_ranges_merge_into_the_unique_intersection() {
     let react = "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc";
     let narrower = "^18.0.0 || ^19.0.0";
-    let expected = merge_ranges(&[react, narrower], false).expect("the two ranges overlap");
+    let merged = ">=18.0.0 <19.0.0-0||>=19.0.0 <20.0.0-0||>=19.0.0 <20.0.0-0";
+
+    assert_eq!(merge_ranges(&[react, narrower], false).as_deref(), Some(merged));
 
     let mut repeated = vec![react; 10];
     repeated.push(narrower);
 
-    assert_eq!(merge_ranges(&repeated, false).as_deref(), Some(expected.as_str()));
+    assert_eq!(merge_ranges(&repeated, false).as_deref(), Some(merged));
+}
+
+/// A scheme specifier is not a semver range, so intersecting it would
+/// drop the peer instead of hoisting it.
+#[test]
+fn repeated_scheme_specifier_stays_verbatim() {
+    assert_eq!(
+        merge_ranges(&["workspace:^", "workspace:^"], false).as_deref(),
+        Some("workspace:^"),
+    );
+}
+
+/// The `@radix-ui/react-dialog` shape of pnpm/pnpm#13786: four paths
+/// reach the same package, so every branch reports the identical missing
+/// `react` peer again. One narrower declarer turns the merge into a real
+/// intersection, and the stub resolves `react` only through the
+/// deduplicated one — a merge that folds the duplicates back in reaches
+/// a different range and leaves the peer unhoisted.
+#[tokio::test]
+async fn a_peer_reported_once_per_path_is_hoisted_through_one_intersection() {
+    let react_range = "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc";
+    let mut table = HashMap::default();
+    for (name, deps) in [
+        ("dialog", vec!["dismissable-layer", "focus-scope", "portal", "primitive"]),
+        ("dismissable-layer", vec!["primitive"]),
+        ("focus-scope", vec!["primitive"]),
+        ("portal", vec!["primitive"]),
+        ("primitive", vec![]),
+    ] {
+        let dependencies: serde_json::Map<String, serde_json::Value> = deps
+            .into_iter()
+            .map(|dep| (dep.to_string(), serde_json::Value::from("1.0.0")))
+            .collect();
+        table.insert(
+            (name.to_string(), "1.0.0".to_string()),
+            fake_result(
+                name,
+                "1.0.0",
+                serde_json::json!({
+                    "name": name,
+                    "version": "1.0.0",
+                    "dependencies": dependencies,
+                    "peerDependencies": { "react": react_range },
+                }),
+            ),
+        );
+    }
+    table.insert(
+        ("wants-react-18-or-19".to_string(), "1.0.0".to_string()),
+        fake_result(
+            "wants-react-18-or-19",
+            "1.0.0",
+            serde_json::json!({
+                "name": "wants-react-18-or-19",
+                "version": "1.0.0",
+                "peerDependencies": { "react": "^18.0.0 || ^19.0.0" },
+            }),
+        ),
+    );
+    table.insert(
+        (
+            "react".to_string(),
+            ">=18.0.0 <19.0.0-0||>=19.0.0 <20.0.0-0||>=19.0.0 <20.0.0-0".to_string(),
+        ),
+        fake_result("react", "19.0.0", serde_json::json!({ "name": "react", "version": "19.0.0" })),
+    );
+    let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+    let (_tmp, manifest) = fake_manifest(serde_json::json!({
+        "dialog": "1.0.0",
+        "wants-react-18-or-19": "1.0.0",
+    }));
+
+    let result = resolve_importer(&resolver, &manifest, [DependencyGroup::Prod], default_opts())
+        .await
+        .unwrap();
+
+    let direct: Vec<&str> =
+        result.peers_result.direct_dependencies_by_alias.keys().map(String::as_str).collect();
+    assert!(direct.contains(&"react"), "react should be hoisted: {direct:?}");
+    let react_entries: Vec<&DepPath> = result
+        .peers_result
+        .graph
+        .keys()
+        .filter(|dep_path| dep_path.to_string().starts_with("react@"))
+        .collect();
+    assert_eq!(react_entries.len(), 1, "expected one react entry, got: {react_entries:?}");
+    assert!(
+        react_entries[0].to_string().starts_with("react@19.0.0"),
+        "react must resolve through the intersected range: {react_entries:?}",
+    );
 }
 
 #[tokio::test]

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
@@ -811,12 +811,34 @@ async fn auto_install_does_not_install_when_no_intersection() {
 fn repeated_consumer_ranges_merge_into_the_unique_intersection() {
     let react = "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc";
     let narrower = "^18.0.0 || ^19.0.0";
-    let merged = ">=18.0.0 <19.0.0-0||>=19.0.0 <20.0.0-0||>=19.0.0 <20.0.0-0";
+    let merged = ">=18.0.0 <19.0.0-0||>=19.0.0 <20.0.0-0";
 
     assert_eq!(merge_ranges(&[react, narrower], false).as_deref(), Some(merged));
 
     let mut repeated = vec![react; 10];
     repeated.push(narrower);
+
+    assert_eq!(merge_ranges(&repeated, false).as_deref(), Some(merged));
+}
+
+/// Deduplication alone only sees ranges that are spelled identically.
+/// Consumers reach the same peer through spellings that differ, and each
+/// one that survives into the union multiplies the next intersection, so
+/// the merged range has to stay bounded across them too.
+#[test]
+fn differently_spelled_equivalent_ranges_do_not_grow_the_merged_range() {
+    let spellings = [
+        "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        ">=16.8 <17 || >=17 <18 || >=18 <19 || >=19 <20 || ^19.0.0-rc",
+        "16.8 - 16.x || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    ];
+    let merged =
+        ">=16.8.0 <17.0.0-0||>=17.0.0 <18.0.0-0||>=18.0.0 <19.0.0-0||>=19.0.0-rc <20.0.0-0";
+
+    assert_eq!(merge_ranges(&spellings, false).as_deref(), Some(merged));
+
+    let repeated: Vec<&str> = spellings.iter().cycle().copied().take(200).collect();
 
     assert_eq!(merge_ranges(&repeated, false).as_deref(), Some(merged));
 }
@@ -879,10 +901,7 @@ async fn a_peer_reported_once_per_path_is_hoisted_through_one_intersection() {
         ),
     );
     table.insert(
-        (
-            "react".to_string(),
-            ">=18.0.0 <19.0.0-0||>=19.0.0 <20.0.0-0||>=19.0.0 <20.0.0-0".to_string(),
-        ),
+        ("react".to_string(), ">=18.0.0 <19.0.0-0||>=19.0.0 <20.0.0-0".to_string()),
         fake_result("react", "19.0.0", serde_json::json!({ "name": "react", "version": "19.0.0" })),
     );
     let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#13786.

`merge_ranges` folds every dependent's report of a missing peer into one specifier. Two things let that grow without bound:

- A peer several dependents declare arrives at `merge_ranges` once per dependent, duplicates and all. Only the length check looked at the unique set; the intersection ran over the original list, so every duplicate got folded in again.
- `node-semver` intersects two unions as their Cartesian product and never drops an alternative another alternative already covers, so each pass multiplies the count even when the ranges are all distinct.

The reproduction's `@radix-ui/react-dialog` graph reports the `react` peer 35 times across three distinct range strings, which projects to billions of alternatives and eats the machine's memory in seconds.

The intersection now runs over the unique ranges, in the order they were reported, and drops the covered alternatives after each step. The merged range keeps the same set of versions and stays bounded: at 10 duplicates it carries 2 alternatives instead of 1025.

Deduplication alone would not have been enough — it only sees ranges spelled identically, and dependents of a peer like `react` spell the same range many ways. Four spellings of the reproduction's range grow the union from 5 alternatives to 36, geometric in the number of spellings; with the collapse those same four spellings stay at 4 alternatives however often they repeat.

The TypeScript CLI is not affected and needs no counterpart. `mergePkgsDeps` passes duplicates to `safeIntersect` too, but `semver-range-intersect` collapses equivalent alternatives, so the same 35 reports come out as one two-alternative range — the shape pacquet now produces as well.

## Squash Commit Body

```text
A missing peer declared by several dependents reaches merge_ranges once
per dependent. Only the length check consulted the unique set, so the
intersection folded every duplicate in again. node-semver intersects two
unions as their Cartesian product and keeps an alternative another one
already covers, so each pass multiplied the alternative count. The
reproduction reports the react peer 35 times across three distinct
ranges, which projects to billions of alternatives and exhausts memory
within seconds of starting resolution.

The intersection now runs over the unique ranges in report order and
collapses the covered alternatives after each step. The merged range is
unchanged as a set of versions, only bounded: at 10 duplicates it carries
2 alternatives instead of 1025, and four differently spelled variants of
the react range stay at 4 alternatives however often they repeat instead
of growing from 5 to 36.

semver-range-intersect collapses equivalent alternatives, so the
TypeScript CLI never had this behaviour and needs no counterpart change.

Fixes pnpm/pnpm#13786.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13791"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788988635&installation_model_id=426870&pr_number=13791&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13791&signature=e3f093c611a79694645423aa2e5ae85dd36ee066a836746e199324f35575b3a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced memory usage during `pnpm install` and `pnpm dedupe` when resolving repeated missing peer dependencies.
  - Prevented duplicate dependency ranges from being processed repeatedly, improving resolution efficiency while preserving results.

- **Tests**
  - Added regression coverage to verify consistent dependency resolution with repeated or deduplicated ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
