### PR TITLE
feat: absorb an override that names a range, not just an exact version

### DIFF
--- a/.changeset/override-range-fast-update.md
+++ b/.changeset/override-range-fast-update.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.deps-installer": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+Changing a `pnpm.overrides` entry to a version range now updates the lockfile in place when a version the lockfile already holds satisfies the range, instead of re-resolving the whole dependency graph. Only exact versions were handled before [#13696](https://github.com/pnpm/pnpm/issues/13696).

--- a/pnpm/crates/package-manager/src/fast_update_importers.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers.rs
@@ -204,7 +204,7 @@ fn link_resolves_to(from: &str, target: &str, importer_id: &str) -> bool {
 /// `None` when nothing present satisfies (only the resolver can fetch a
 /// new version), or when a candidate exists under several peer-suffixed
 /// keys, where picking one of them would be a guess.
-fn highest_locked_version_satisfying(
+pub(crate) fn highest_locked_version_satisfying(
     packages: Option<&HashMap<PackageKey, pacquet_lockfile::PackageMetadata>>,
     alias: &PkgName,
     range: &Range,

--- a/pnpm/crates/package-manager/src/fast_update_importers.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers.rs
@@ -202,8 +202,10 @@ fn link_resolves_to(from: &str, target: &str, importer_id: &str) -> bool {
 /// cannot satisfy at all.
 ///
 /// `None` when nothing present satisfies (only the resolver can fetch a
-/// new version), or when a candidate exists under several peer-suffixed
-/// keys, where picking one of them would be a guess.
+/// new version), or when the alias appears under a key this cannot turn
+/// back into a plain reference: a peer-suffixed one, where picking a
+/// variant would be a guess, or a registry-qualified one, whose semver
+/// only pins a version within its named registry.
 pub(crate) fn highest_locked_version_satisfying(
     packages: Option<&HashMap<PackageKey, pacquet_lockfile::PackageMetadata>>,
     alias: &PkgName,
@@ -214,7 +216,7 @@ pub(crate) fn highest_locked_version_satisfying(
         if &key.name != alias {
             continue;
         }
-        if !key.suffix.peer().is_empty() {
+        if !key.suffix.peer().is_empty() || key.suffix.registry_qualified().is_some() {
             return None;
         }
         let Some(version) = key.suffix.version_semver() else { continue };

--- a/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
@@ -1,4 +1,4 @@
-use pacquet_lockfile::{Lockfile, PkgName};
+use pacquet_lockfile::{Lockfile, PackageKey, PkgName};
 use pacquet_package_manifest::PackageManifest;
 use serde_json::json;
 use std::path::PathBuf;
@@ -1125,5 +1125,19 @@ fn rejects_a_range_move_a_peer_suffix_names_the_version_it_moves_off() {
     assert!(
         try_fast_update_importers(&subject, &[(".".to_string(), &manifest)]).is_none(),
         "baz resolved the peer to the version the importer moves off, so its key would change",
+    );
+}
+
+#[test]
+fn rejects_a_range_when_the_alias_also_has_a_named_registry_key() {
+    let mut subject = parsed_lockfile(WITH_TWO_LOCKED_VERSIONS);
+    let packages = subject.packages.as_mut().expect("packages");
+    let extra = packages[&"foo@1.2.0".parse::<PackageKey>().expect("package key")].clone();
+    packages.insert("foo@work:1.4.0".parse().expect("package key"), extra);
+    let manifest = manifest_from(json!({ "dependencies": { "foo": "^1.1.0" } }));
+
+    assert!(
+        try_fast_update_importers(&subject, &[(".".to_string(), &manifest)]).is_none(),
+        "the alias spans two registries, so a plain reference cannot say which is meant",
     );
 }

--- a/pnpm/crates/package-manager/src/fast_update_overrides.rs
+++ b/pnpm/crates/package-manager/src/fast_update_overrides.rs
@@ -148,8 +148,11 @@ fn build_rewrite_plan(
             return None;
         }
         let name = PkgName::parse(&parsed.target_pkg.name).ok()?;
-        let new_version =
-            if removes_dependency { None } else { Some(Version::parse(new_value).ok()?) };
+        let new_version = if removes_dependency {
+            None
+        } else {
+            Some(overridden_version(lockfile, &name, new_value)?)
+        };
         overrides.push(FastOverride {
             name,
             new_version,
@@ -166,6 +169,26 @@ fn build_rewrite_plan(
     }
 
     build_replacement_plan(lockfile, overrides)
+}
+
+/// The version an override moves its target to.
+///
+/// An exact value names it outright. A range names whichever version
+/// resolution would settle on, which is the highest already-locked one
+/// that satisfies it: `preferredVersions` makes the resolver reuse a
+/// version the graph already holds rather than the highest published.
+/// `None` when the range matches nothing locked, since only the resolver
+/// can fetch a version that is not there.
+fn overridden_version(lockfile: &Lockfile, name: &PkgName, value: &str) -> Option<Version> {
+    if let Ok(version) = Version::parse(value) {
+        return Some(version);
+    }
+    let range = Range::parse(value).ok()?;
+    crate::fast_update_importers::highest_locked_version_satisfying(
+        lockfile.packages.as_ref(),
+        name,
+        &range,
+    )
 }
 
 /// Work out which locked packages each entry of `overrides` moves, and

--- a/pnpm/crates/package-manager/src/fast_update_overrides.rs
+++ b/pnpm/crates/package-manager/src/fast_update_overrides.rs
@@ -173,12 +173,9 @@ fn build_rewrite_plan(
 
 /// The version an override moves its target to.
 ///
-/// An exact value names it outright. A range names whichever version
-/// resolution would settle on, which is the highest already-locked one
-/// that satisfies it: `preferredVersions` makes the resolver reuse a
-/// version the graph already holds rather than the highest published.
-/// `None` when the range matches nothing locked, since only the resolver
-/// can fetch a version that is not there.
+/// A range names the highest already-locked version satisfying it,
+/// because `preferredVersions` makes the resolver reuse a version the
+/// graph already holds rather than the highest published.
 fn overridden_version(lockfile: &Lockfile, name: &PkgName, value: &str) -> Option<Version> {
     if let Ok(version) = Version::parse(value) {
         return Some(version);

--- a/pnpm/crates/package-manager/src/fast_update_overrides/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_overrides/tests.rs
@@ -496,3 +496,98 @@ async fn applies_exact_replacements_and_dependency_removals_together() {
             .is_some_and(|snapshots| !snapshots.contains_key(&"obsolete@1.0.0".parse().unwrap())),
     );
 }
+
+/// The same graph plus a second, higher version of `target` that another
+/// importer holds. The registry has 2.0.0 too, which nothing locks.
+fn lockfile_with_two_target_versions() -> Lockfile {
+    let mut lockfile = lockfile();
+    // No override recorded yet: one at 1.0.0 could not coexist with an
+    // importer holding 1.5.0, since it would have moved that edge too.
+    lockfile.overrides = None;
+    lockfile.importers.insert(
+        "pkg-a".to_string(),
+        serde_json::from_value(json!({
+            "dependencies": { "target": { "specifier": "1.5.0", "version": "1.5.0" } }
+        }))
+        .expect("importer"),
+    );
+    lockfile.packages.as_mut().expect("packages").insert(
+        "target@1.5.0".parse().expect("package key"),
+        serde_json::from_value(json!({ "resolution": { "integrity": "sha512-target-2" } }))
+            .expect("package"),
+    );
+    lockfile.snapshots.as_mut().expect("snapshots").insert(
+        "target@1.5.0".parse().expect("snapshot key"),
+        serde_json::from_value(json!({})).expect("snapshot"),
+    );
+    lockfile
+}
+
+fn range_override(value: &str) -> Vec<VersionOverride> {
+    vec![VersionOverride {
+        selector: "target".to_string(),
+        parent_pkg: None,
+        target_pkg: PackageSelector { name: "target".to_string(), bare_specifier: None },
+        new_bare_specifier: value.to_string(),
+        converge: false,
+    }]
+}
+
+/// Records the version each resolution asks for. The rewrite that follows
+/// is the pre-existing machinery; what this pins is the version the range
+/// maps to.
+struct RecordingResolver {
+    requested: std::sync::Mutex<Vec<String>>,
+}
+
+impl Resolver for RecordingResolver {
+    fn resolve<'a>(
+        &'a self,
+        wanted_dependency: &'a WantedDependency,
+        _opts: &'a ResolveOptions,
+    ) -> ResolveFuture<'a> {
+        self.requested
+            .lock()
+            .expect("record the requested version")
+            .push(wanted_dependency.bare_specifier.clone().expect("version"));
+        Box::pin(async { Ok(None) })
+    }
+
+    fn resolve_latest<'a>(
+        &'a self,
+        _query: &'a LatestQuery,
+        _opts: &'a ResolveOptions,
+    ) -> ResolveLatestFuture<'a> {
+        Box::pin(async { Ok(None) })
+    }
+}
+
+#[tokio::test]
+async fn a_range_override_moves_to_the_version_the_graph_already_holds() {
+    let lockfile = lockfile_with_two_target_versions();
+    let overrides = IndexMap::from([("target".to_string(), "^1.2.0".to_string())]);
+    let resolver = RecordingResolver { requested: std::sync::Mutex::new(Vec::new()) };
+
+    // The rewrite itself stops at the stub's empty resolution; the version
+    // it asked for is the decision under test.
+    let _ = try_update(&lockfile, &range_override("^1.2.0"), &overrides, &resolver).await;
+
+    assert_eq!(
+        *resolver.requested.lock().expect("requested versions"),
+        vec!["1.5.0".to_string()],
+        "resolution prefers the locked 1.5.0 over the registry's higher versions",
+    );
+}
+
+#[tokio::test]
+async fn a_range_override_no_locked_version_satisfies_falls_back() {
+    let lockfile = lockfile_with_two_target_versions();
+    let overrides = IndexMap::from([("target".to_string(), "^3.0.0".to_string())]);
+    let resolver = StubResolver { calls: AtomicUsize::new(0), manifest: json!({}) };
+
+    assert!(
+        try_update(&lockfile, &range_override("^3.0.0"), &overrides, &resolver).await.is_none(),
+        "only the resolver can fetch a version the lockfile does not hold",
+    );
+    assert_eq!(resolver.calls.load(Ordering::Relaxed), 0, "and it bails before resolving");
+}

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateOverrides.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateOverrides.ts
@@ -194,12 +194,9 @@ function getFastOverrides (
 /**
  * The version an override moves its target to.
  *
- * An exact value names it outright. A range names whichever version
- * resolution would settle on, which is the highest already-locked one that
- * satisfies it: `preferredVersions` makes the resolver reuse a version the
- * graph already holds rather than the highest published. `null` when the
- * range matches nothing locked, since only the resolver can fetch a version
- * that is not there.
+ * A range names the highest already-locked version satisfying it, because
+ * `preferredVersions` makes the resolver reuse a version the graph already
+ * holds rather than the highest published.
  */
 function overriddenVersion (
   lockfile: LockfileObject,

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateOverrides.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateOverrides.ts
@@ -5,6 +5,7 @@ import type {
   PackageSnapshot,
   ResolvedDependencies,
 } from '@pnpm/lockfile.types'
+import { nameVerFromPkgSnapshot } from '@pnpm/lockfile.utils'
 import { toLockfileResolution } from '@pnpm/lockfile.utils'
 import type { RequestPackageFunction } from '@pnpm/store.controller-types'
 import type {
@@ -60,7 +61,7 @@ export async function tryFastUpdateOverrides (
     parsedOverrides: VersionOverride[]
   }
 ): Promise<boolean> {
-  const fastOverrides = getFastOverrides(lockfile.overrides ?? {}, opts.overrides, opts.parsedOverrides)
+  const fastOverrides = getFastOverrides(lockfile, lockfile.overrides ?? {}, opts.overrides, opts.parsedOverrides)
   if (fastOverrides == null) return false
   return applyFastRewrite(lockfile, fastOverrides, opts, { overrides: opts.overrides })
 }
@@ -132,6 +133,7 @@ export async function applyFastRewrite (
 }
 
 function getFastOverrides (
+  lockfile: LockfileObject,
   oldOverrides: Record<string, string>,
   newOverrides: Record<string, string>,
   parsedOverrides: VersionOverride[]
@@ -156,7 +158,7 @@ function getFastOverrides (
       override.converge === true ||
       !removesDependency && (
         override.parentPkg != null ||
-        semver.valid(newValue) == null ||
+        overriddenVersion(lockfile, override.targetPkg.name, newValue) == null ||
         oldVersion != null && semver.valid(oldVersion) == null
       ) ||
       changedNames.has(override.targetPkg.name) ||
@@ -178,10 +180,44 @@ function getFastOverrides (
             bareSpecifier: override.parentPkg.bareSpecifier,
           },
         },
-      ...removesDependency ? {} : { newVersion: newValue, oldVersion },
+      ...removesDependency
+        ? {}
+        : {
+          newVersion: overriddenVersion(lockfile, override.targetPkg.name, newValue)!,
+          oldVersion,
+        },
     })
   }
   return result
+}
+
+/**
+ * The version an override moves its target to.
+ *
+ * An exact value names it outright. A range names whichever version
+ * resolution would settle on, which is the highest already-locked one that
+ * satisfies it: `preferredVersions` makes the resolver reuse a version the
+ * graph already holds rather than the highest published. `null` when the
+ * range matches nothing locked, since only the resolver can fetch a version
+ * that is not there.
+ */
+function overriddenVersion (
+  lockfile: LockfileObject,
+  name: string,
+  value: string
+): string | null {
+  if (semver.valid(value) != null) return value
+  if (semver.validRange(value) == null) return null
+  const versions: string[] = []
+  for (const [depPath, snapshot] of Object.entries(lockfile.packages ?? {})) {
+    const parsed = nameVerFromPkgSnapshot(depPath, snapshot)
+    if (parsed.name !== name || parsed.nonSemverVersion != null) continue
+    if (parsed.registryName != null || dp.parseDepPath(depPath).peerDepGraphHash !== '') return null
+    if (semver.valid(parsed.version) != null && semver.satisfies(parsed.version, value)) {
+      versions.push(parsed.version)
+    }
+  }
+  return versions.sort(semver.rcompare)[0] ?? null
 }
 
 function collectReplacements (

--- a/pnpm11/installing/deps-installer/test/install/overrideRangeFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/overrideRangeFastUpdate.ts
@@ -1,0 +1,81 @@
+import { expect, jest, test } from '@jest/globals'
+import { LOCKFILE_VERSION } from '@pnpm/constants'
+import type { LockfileObject } from '@pnpm/lockfile.fs'
+import type { RequestPackageFunction } from '@pnpm/store.controller-types'
+import type { DepPath, ProjectId, Registries } from '@pnpm/types'
+
+import { tryFastUpdateOverrides } from '../../src/install/tryFastUpdateOverrides.js'
+
+const registries: Registries = { default: 'https://registry.npmjs.org/' }
+
+/**
+ * Two importers hold `foo` at 1.0.0 and 1.2.0. The registry also has 1.3.0,
+ * which nothing locks — resolution prefers a version the graph already
+ * holds, so a range override has to land on 1.2.0 rather than 1.3.0.
+ */
+function makeLockfile (): LockfileObject {
+  return {
+    lockfileVersion: LOCKFILE_VERSION,
+    importers: {
+      ['.' as ProjectId]: {
+        dependencies: { foo: '1.0.0' },
+        specifiers: { foo: '1.0.0' },
+      },
+      ['pkg-a' as ProjectId]: {
+        dependencies: { foo: '1.2.0' },
+        specifiers: { foo: '1.2.0' },
+      },
+    },
+    packages: {
+      ['foo@1.0.0' as DepPath]: { resolution: { integrity: 'sha512-AAAA' } },
+      ['foo@1.2.0' as DepPath]: { resolution: { integrity: 'sha512-BBBB' } },
+    },
+  } as unknown as LockfileObject
+}
+
+function opts (newValue: string, requestPackage: RequestPackageFunction) {
+  return {
+    lockfileDir: '/test',
+    overrides: { foo: newValue },
+    parsedOverrides: [{ selector: 'foo', newBareSpecifier: newValue, targetPkg: { name: 'foo' } }],
+    registries,
+    requestPackage,
+    isLockfileUpToDate: async () => true,
+  } as never
+}
+
+/** Records the version each resolution asks for, then stops the rewrite. */
+function trackResolvedVersions (requested: string[]): RequestPackageFunction {
+  return jest.fn(async (wanted: { bareSpecifier?: string }) => {
+    requested.push(wanted.bareSpecifier!)
+    throw new Error('reached the resolution step')
+  }) as unknown as RequestPackageFunction
+}
+
+test('a range override resolves the version the graph already holds', async () => {
+  const requested: string[] = []
+
+  await expect(tryFastUpdateOverrides(makeLockfile(), opts('^1.1.0', trackResolvedVersions(requested))))
+    .rejects.toThrow('reached the resolution step')
+
+  expect(requested).toStrictEqual(['1.2.0'])
+})
+
+test('a range override no locked version satisfies bails before resolving', async () => {
+  const requestPackage = jest.fn() as unknown as RequestPackageFunction
+
+  const applied = await tryFastUpdateOverrides(makeLockfile(), opts('^2.0.0', requestPackage))
+
+  expect(applied).toBe(false)
+  // Only the resolver can fetch a version the lockfile does not hold.
+  expect(requestPackage).not.toHaveBeenCalled()
+})
+
+test('an exact override still names the version it was given', async () => {
+  const requested: string[] = []
+
+  await expect(tryFastUpdateOverrides(makeLockfile(), opts('1.3.0', trackResolvedVersions(requested))))
+    .rejects.toThrow('reached the resolution step')
+
+  expect(requested).toStrictEqual(['1.3.0'])
+})


### PR DESCRIPTION
## Summary

Item 6 of pnpm/pnpm#13696, the range half. Parent-scoped overrides stay on the resolver — see below.

An overrides entry whose value is a range (`"foo": "^1.1.0"`) bailed in both stacks; only exact versions were rewritten. Measured what resolution does with such a range, the same way item 4 was measured: with `foo@1.0.0` and `foo@1.2.0` locked and `1.3.0` also published, adding the override resolves to **1.2.0** — `preferredVersions` makes the resolver reuse a version the graph already holds rather than the highest published. So the rewrite can name that version itself: the highest already-locked one satisfying the range. A range nothing locked satisfies still bails, since only the resolver can fetch a version that is not there.

Everything downstream is untouched — the plan still carries a concrete version, and the existing guards decide whether the rewrite is expressible. Worth noting for review: a range that resolves to an already-locked version necessarily lands on the *merge* path (its key exists), where two pre-existing guards refuse the rewrite unless the rebuilt snapshot **and** package metadata equal what the lockfile already records. That is the right conservatism and I have not touched it; it does mean this widening only pays off when the target version's recorded entry agrees with what a resolution would rebuild, which for a registry package it normally does.

**Parent-scoped overrides (`parent>child`) are deliberately left out.** They move a single edge rather than every edge to a package, so the lockfile would have to hold the old and new versions simultaneously and split the dependents between them. `build_replacement_plan` maps one old key to one new key and cannot express that; supporting it is a different change, not a relaxed guard.

Tested at the handler level in both stacks — the layer where these tests already live — asserting which version the range resolves to, that an unsatisfiable range bails before any resolution, and that exact overrides still name the version given. Both stacks break-tested.

## Squash Commit Body

```text
An overrides entry whose value is a range bailed to the resolver in
both stacks. Resolution settles such a range on whichever version the
graph already holds — preferredVersions beats picking the highest
published, measured the same way item 4 of the roadmap was — so the
rewrite can name that version itself: the highest already-locked one
satisfying the range. A range nothing locked satisfies still bails,
since only the resolver can fetch a version that is not there.

Everything downstream is unchanged: the plan still carries a concrete
version, and the existing guards decide whether the rewrite can be
expressed — including the pair that refuse to merge onto a key whose
recorded snapshot or metadata would not match what the rewrite
rebuilds.

Parent-scoped overrides stay on the resolver. Those move one edge
rather than every edge to a package, so the lockfile would have to
hold both versions at once, which this rewrite cannot express.

Item 6 of pnpm/pnpm#13696.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788992751&installation_model_id=426870&pr_number=13792&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13792&signature=4b8e43946ef85b885da0665983e6dab05ec8957202773bdacf313a9563dd26a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compatible `pnpm.overrides` version ranges now update the existing lockfile using the highest matching locked version.
  * Exact version overrides and dependency removals continue to work as before.

* **Bug Fixes**
  * Incompatible or unsupported override ranges safely fall back without re-resolving dependencies.
  * Ambiguous package aliases across registries are now rejected during fast updates.

* **Tests**
  * Added coverage for compatible and incompatible ranges, exact versions, multiple locked versions, and registry-specific aliases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->