### PR TITLE
fix: stabilize integrated benchmarks and shared slot repairs

### DIFF
--- a/.changeset/gvs-concurrent-slot-import.md
+++ b/.changeset/gvs-concurrent-slot-import.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Concurrent installs sharing a global virtual store no longer fail with `failed to remove existing directory ... prior to swap: Directory not empty`, and no longer briefly remove a package directory another process is reading.
+Concurrent installs sharing a global virtual store serialize forced repairs of incomplete package slots. They no longer fail with `failed to remove existing directory ... prior to swap: Directory not empty` or briefly remove a package directory another process is reading.

--- a/.github/workflows/pacquet-integrated-benchmark-comment.yml
+++ b/.github/workflows/pacquet-integrated-benchmark-comment.yml
@@ -183,5 +183,5 @@ jobs:
         if: hashFiles('benchmark-artifact/STABLE_SCENARIO_GATE_FAILED') != ''
         shell: bash
         run: |
-          echo "::error::A stable pacquet benchmark scenario regressed by more than 20%; see the benchmark comment for measurements."
+          echo "::error::The stable-scenario benchmark gate failed; see the benchmark comment and producer workflow logs for details."
           exit 1

--- a/.github/workflows/pacquet-integrated-benchmark-comment.yml
+++ b/.github/workflows/pacquet-integrated-benchmark-comment.yml
@@ -26,18 +26,18 @@ permissions:
   actions: read
   issues: write
   pull-requests: write
-  checks: write
 
 jobs:
   comment:
     name: Post benchmark comment
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    # Only post when the upstream benchmark ran on a PR and succeeded.
-    # Same gating as the original in-workflow comment, which only ran
-    # on the success path of the previous steps.
+    # A deferred regression gate fails only after the report artifact has been
+    # staged, so consume both successful and failed runs. Earlier failures have
+    # no artifact and fail safely in the download step.
     if: |
       github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success'
+      (github.event.workflow_run.conclusion == 'success' ||
+       github.event.workflow_run.conclusion == 'failure')
     steps:
       - name: Resolve PR number from workflow_run trigger
         # `workflow_run.pull_requests` is empty for fork PRs (the case
@@ -141,17 +141,16 @@ jobs:
         # workflow_run runs in the base-repo privilege context, so
         # BENCHER_API_TOKEN is available even for fork PRs. PR number
         # comes from the trusted workflow_run payload (resolved in
-        # `meta` above), never from the artifact body. `--ci-number`
-        # is required here because Bencher can't infer the PR from a
-        # workflow_run event the way it does on pull_request.
+        # `meta` above), never from the artifact body.
         #
         # One benchmark, two testbeds: `pacquet` (direct install) and
         # `pnpr` (the accelerated path). Each uploads from its own
-        # bencher-results file produced by the build workflow.
+        # bencher-results file produced by the build workflow. The dedicated
+        # summary above owns the PR comment; Bencher records the cross-run
+        # trends without creating a second comment or check.
         if: hashFiles('benchmark-artifact/bencher-results.json') != ''
         env:
           BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.meta.outputs.pr }}
         shell: bash
         run: |
@@ -159,9 +158,9 @@ jobs:
             echo "::notice::BENCHER_API_TOKEN not set, skipping Bencher upload"
             exit 0
           fi
-          # `--start-point-clone-thresholds` so the PR branch inherits the
-          # threshold configured on main; `--err` so the action surfaces
-          # a regression on the PR check.
+          # `--start-point-clone-thresholds` keeps cross-run alerts visible in
+          # Bencher. They are observational; the benchmark workflow owns the
+          # blocking same-run check for its stable scenarios.
           upload() {
             local testbed=$1 file=$2
             if [ ! -f "$file" ]; then
@@ -175,11 +174,8 @@ jobs:
               --start-point main \
               --start-point-reset \
               --start-point-clone-thresholds \
-              --err \
               --adapter json \
-              --file "$file" \
-              --ci-number "$PR_NUMBER" \
-              --github-actions "$GITHUB_TOKEN"
+              --file "$file"
           }
           upload pacquet benchmark-artifact/bencher-results.json
           upload pnpr benchmark-artifact/bencher-results-pnpr.json

--- a/.github/workflows/pacquet-integrated-benchmark-comment.yml
+++ b/.github/workflows/pacquet-integrated-benchmark-comment.yml
@@ -31,7 +31,7 @@ jobs:
   comment:
     name: Post benchmark comment
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    # Stable-scenario failures are carried in the successful run artifact and
+    # Benchmark-gate failures are carried in the successful run artifact and
     # re-raised below, after the report is posted. Early benchmark failures do
     # not have an artifact, so keep skipping them here.
     if: |
@@ -180,8 +180,15 @@ jobs:
           upload pnpr benchmark-artifact/bencher-observations-pnpr.json
 
       - name: Re-raise the stable-scenario gate
-        if: hashFiles('benchmark-artifact/STABLE_SCENARIO_GATE_FAILED') != ''
+        if: always() && hashFiles('benchmark-artifact/STABLE_SCENARIO_GATE_FAILED') != ''
         shell: bash
         run: |
           echo "::error::The stable-scenario benchmark gate failed; see the benchmark comment and producer workflow logs for details."
+          exit 1
+
+      - name: Re-raise the peer-heavy gate
+        if: always() && hashFiles('benchmark-artifact/PEER_HEAVY_GATE_FAILED') != ''
+        shell: bash
+        run: |
+          echo "::error::The peer-heavy benchmark gate failed; see the benchmark comment and producer workflow logs for details."
           exit 1

--- a/.github/workflows/pacquet-integrated-benchmark-comment.yml
+++ b/.github/workflows/pacquet-integrated-benchmark-comment.yml
@@ -133,7 +133,7 @@ jobs:
           body-file: benchmark-artifact/SUMMARY.md
 
       - name: Install Bencher CLI
-        if: hashFiles('benchmark-artifact/bencher-results.json') != ''
+        if: hashFiles('benchmark-artifact/bencher-observations.json') != ''
         uses: bencherdev/bencher@4c83b25441d145ee273adaf74be30f2382e6ba85 # v0.6.11
 
       - name: Upload PR results to Bencher
@@ -143,11 +143,11 @@ jobs:
         # `meta` above), never from the artifact body.
         #
         # One benchmark, two testbeds: `pacquet` (direct install) and
-        # `pnpr` (the accelerated path). Each uploads from its own
-        # bencher-results file produced by the build workflow. The dedicated
+        # `pnpr` (the accelerated path). Each uploads from its own observation
+        # file produced by the build workflow. The dedicated
         # summary above owns the PR comment; Bencher records the cross-run
         # trends without creating a second comment or check.
-        if: hashFiles('benchmark-artifact/bencher-results.json') != ''
+        if: hashFiles('benchmark-artifact/bencher-observations.json') != ''
         env:
           BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
           PR_NUMBER: ${{ steps.meta.outputs.pr }}
@@ -176,8 +176,8 @@ jobs:
               --adapter json \
               --file "$file"
           }
-          upload pacquet benchmark-artifact/bencher-results.json
-          upload pnpr benchmark-artifact/bencher-results-pnpr.json
+          upload pacquet benchmark-artifact/bencher-observations.json
+          upload pnpr benchmark-artifact/bencher-observations-pnpr.json
 
       - name: Re-raise the stable-scenario gate
         if: hashFiles('benchmark-artifact/STABLE_SCENARIO_GATE_FAILED') != ''

--- a/.github/workflows/pacquet-integrated-benchmark-comment.yml
+++ b/.github/workflows/pacquet-integrated-benchmark-comment.yml
@@ -31,13 +31,12 @@ jobs:
   comment:
     name: Post benchmark comment
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    # A deferred regression gate fails only after the report artifact has been
-    # staged, so consume both successful and failed runs. Earlier failures have
-    # no artifact and fail safely in the download step.
+    # Stable-scenario failures are carried in the successful run artifact and
+    # re-raised below, after the report is posted. Early benchmark failures do
+    # not have an artifact, so keep skipping them here.
     if: |
       github.event.workflow_run.event == 'pull_request' &&
-      (github.event.workflow_run.conclusion == 'success' ||
-       github.event.workflow_run.conclusion == 'failure')
+      github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Resolve PR number from workflow_run trigger
         # `workflow_run.pull_requests` is empty for fork PRs (the case
@@ -179,3 +178,10 @@ jobs:
           }
           upload pacquet benchmark-artifact/bencher-results.json
           upload pnpr benchmark-artifact/bencher-results-pnpr.json
+
+      - name: Re-raise the stable-scenario gate
+        if: hashFiles('benchmark-artifact/STABLE_SCENARIO_GATE_FAILED') != ''
+        shell: bash
+        run: |
+          echo "::error::A stable pacquet benchmark scenario regressed by more than 20%; see the benchmark comment for measurements."
+          exit 1

--- a/.github/workflows/pacquet-integrated-benchmark.yml
+++ b/.github/workflows/pacquet-integrated-benchmark.yml
@@ -676,7 +676,7 @@ jobs:
 
       - name: Stage artifact contents
         # The artifact carries the rendered report, the Bencher-shaped JSON,
-        # and a stable-gate failure marker when applicable. The PR number and
+        # and gate-failure markers when applicable. The PR number and
         # runner OS are derived from the trusted workflow_run event payload in
         # the comment workflow, not from fork-controlled artifact contents.
         shell: bash
@@ -687,6 +687,9 @@ jobs:
           cp bench-work-env/bencher-results-pnpr.json benchmark-artifact/bencher-observations-pnpr.json
           if [ "${{ steps.stable_scenarios.outcome }}" = 'failure' ]; then
             touch benchmark-artifact/STABLE_SCENARIO_GATE_FAILED
+          fi
+          if [ "${{ steps.peer_heavy.outcome }}" = 'failure' ]; then
+            touch benchmark-artifact/PEER_HEAVY_GATE_FAILED
           fi
 
       - name: Upload benchmark report
@@ -762,8 +765,9 @@ jobs:
       - name: Re-raise the peer-heavy gate
         # Deferred from the peer-heavy step so its cross-engine assertion
         # cannot abort the job before the run's data points are published.
-        # Runs even when an earlier step failed, so the gate is never skipped.
-        if: always() && steps.peer_heavy.outcome == 'failure'
+        # Pull requests re-raise this marker in the comment workflow, after it
+        # has posted the report. Direct runs have no second-stage workflow.
+        if: always() && github.event_name != 'pull_request' && steps.peer_heavy.outcome == 'failure'
         shell: bash
         run: |
           echo "::error::The peer-heavy benchmark step failed; see its log for the assertion or build error."

--- a/.github/workflows/pacquet-integrated-benchmark.yml
+++ b/.github/workflows/pacquet-integrated-benchmark.yml
@@ -683,8 +683,8 @@ jobs:
         run: |
           mkdir -p benchmark-artifact
           cp bench-work-env/SUMMARY.md benchmark-artifact/SUMMARY.md
-          cp bench-work-env/bencher-results.json benchmark-artifact/bencher-results.json
-          cp bench-work-env/bencher-results-pnpr.json benchmark-artifact/bencher-results-pnpr.json
+          cp bench-work-env/bencher-results.json benchmark-artifact/bencher-observations.json
+          cp bench-work-env/bencher-results-pnpr.json benchmark-artifact/bencher-observations-pnpr.json
           if [ "${{ steps.stable_scenarios.outcome }}" = 'failure' ]; then
             touch benchmark-artifact/STABLE_SCENARIO_GATE_FAILED
           fi

--- a/.github/workflows/pacquet-integrated-benchmark.yml
+++ b/.github/workflows/pacquet-integrated-benchmark.yml
@@ -633,27 +633,6 @@ jobs:
             'ISOLATED_FRESH_RESOLVE_HOT_CACHE_OFFLINE:isolated-linker.fresh-resolve.hot-cache.offline' \
             'ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE_COLD_PNPR:isolated-linker.fresh-restore.cold-cache.cold-store.cold-pnpr'
 
-      - name: Stage artifact contents
-        # The artifact carries the rendered report plus the
-        # Bencher-shaped JSON consumed by the comment-posting
-        # workflow. The PR number and runner OS are derived from the
-        # trusted workflow_run event payload in that workflow, not
-        # from fork-controlled artifact contents.
-        shell: bash
-        run: |
-          mkdir -p benchmark-artifact
-          cp bench-work-env/SUMMARY.md benchmark-artifact/SUMMARY.md
-          cp bench-work-env/bencher-results.json benchmark-artifact/bencher-results.json
-          cp bench-work-env/bencher-results-pnpr.json benchmark-artifact/bencher-results-pnpr.json
-
-      - name: Upload benchmark report
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: integrated-benchmark-report-ubuntu-latest
-          path: benchmark-artifact/
-          if-no-files-found: error
-          retention-days: 14
-
       - name: Check stable benchmark scenarios
         id: stable_scenarios
         if: github.ref_name != 'main'
@@ -694,6 +673,29 @@ jobs:
             bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE_COLD_PNPR.json \
             'fresh restore, cold cache + cold store + cold pnpr'
           exit "$failed"
+
+      - name: Stage artifact contents
+        # The artifact carries the rendered report, the Bencher-shaped JSON,
+        # and a stable-gate failure marker when applicable. The PR number and
+        # runner OS are derived from the trusted workflow_run event payload in
+        # the comment workflow, not from fork-controlled artifact contents.
+        shell: bash
+        run: |
+          mkdir -p benchmark-artifact
+          cp bench-work-env/SUMMARY.md benchmark-artifact/SUMMARY.md
+          cp bench-work-env/bencher-results.json benchmark-artifact/bencher-results.json
+          cp bench-work-env/bencher-results-pnpr.json benchmark-artifact/bencher-results-pnpr.json
+          if [ "${{ steps.stable_scenarios.outcome }}" = 'failure' ]; then
+            touch benchmark-artifact/STABLE_SCENARIO_GATE_FAILED
+          fi
+
+      - name: Upload benchmark report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: integrated-benchmark-report-ubuntu-latest
+          path: benchmark-artifact/
+          if-no-files-found: error
+          retention-days: 14
 
       - name: Install Bencher CLI
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
@@ -749,7 +751,9 @@ jobs:
           upload pnpr bench-work-env/bencher-results-pnpr.json
 
       - name: Re-raise the stable-scenario gate
-        if: always() && steps.stable_scenarios.outcome == 'failure'
+        # Pull requests re-raise this marker in the comment workflow, after it
+        # has posted the report. Direct runs have no second-stage workflow.
+        if: always() && github.event_name != 'pull_request' && steps.stable_scenarios.outcome == 'failure'
         shell: bash
         run: |
           echo "::error::A stable pacquet benchmark scenario regressed by more than 20%; see the check step for measurements."

--- a/.github/workflows/pacquet-integrated-benchmark.yml
+++ b/.github/workflows/pacquet-integrated-benchmark.yml
@@ -55,7 +55,6 @@ concurrency:
 # the base-repo privilege context via `workflow_run`.
 permissions:
   contents: read
-  checks: write
 
 jobs:
   benchmark:
@@ -111,6 +110,10 @@ jobs:
       PNPR_LATENCY_MS: 50
       REGISTRY_LATENCY_MS: 50
       REGISTRY_BANDWIDTH_MBPS: 200
+      # The longer scenarios have stayed within this same-run HEAD/main
+      # boundary across the control runs that exposed the short-scenario
+      # noise. Short CPU/disk scenarios remain reported but non-blocking.
+      PACQUET_STABLE_SCENARIO_MAX_RATIO: 1.2
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -461,9 +464,9 @@ jobs:
             echo
             echo "**Commit:** [\`${SHA:0:12}\`](${{ github.server_url }}/${{ github.repository }}/commit/$SHA)"
             echo
-            echo 'Regular scenarios report direct and pnpr installs. The peer-heavy resolver scenario compares current Rust, main Rust, and TypeScript pnpm. Bencher consumes pacquet@HEAD and pnpr@HEAD.'
+            echo 'Regular scenarios report direct and pnpr installs. The peer-heavy resolver scenario compares current Rust, main Rust, and TypeScript pnpm. Bencher records pacquet@HEAD and pnpr@HEAD; the blocking regression check compares pacquet@HEAD with pacquet@main in the longer scenarios.'
             echo
-            echo 'The tables below show mean ± σ; Bencher thresholds on the **minimum** latency, which is far less perturbed by shared-runner contention (noise only adds time).'
+            echo 'The tables below show mean ± σ. Bencher records the **minimum** latency to reduce shared-runner contention, but its cross-run alerts are observational because the short scenarios can still move by more than the alert boundary.'
             echo
             echo '### Scenario: Isolated linker: fresh restore, cold cache + cold store'
             echo
@@ -570,18 +573,15 @@ jobs:
         # contributes only `pacquet@HEAD`.
         #
         # We report each scenario's *minimum* latency as the metric value, so
-        # Bencher's threshold tracks the min rather than the mean. On a shared
-        # CI runner, contention only ever *adds* time, so the minimum is the run
-        # least perturbed by a noisy neighbour and the truest signal of a real
-        # code regression — the mean drifts run-to-run with whatever else the
-        # machine is doing (the latency-free offline scenario is pure CPU/disk
-        # and swung ~30% between runs, tripping a spurious alert on a control
-        # run whose HEAD and main binaries were byte-identical). Because the
-        # minimum only needs one uncontended run, hyperfine's default sampling
-        # suffices for regular scenarios. The peer-heavy case is noisier and
-        # fixes its own count instead. The human-readable
-        # comment still reports mean ± σ; only the alerting signal moves to the
-        # min.
+        # Bencher records the min rather than the mean. On a shared CI runner,
+        # contention only ever *adds* time, so the minimum is less perturbed by
+        # a noisy neighbour. It does not eliminate cross-run noise: the short
+        # CPU/disk scenarios have breached the alert boundary on changes that
+        # cannot execute in the measured path. Bencher therefore keeps every
+        # scenario as an observational trend, while the separate blocking gate
+        # compares HEAD with main in the same run and only for the longer,
+        # empirically stable scenarios. The human-readable comment still
+        # reports mean ± σ.
         #
         # BMF rather than the `shell_hyperfine` adapter with a doctored `mean`:
         # this reports the min honestly as the value instead of relabelling it.
@@ -654,6 +654,47 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+      - name: Check stable benchmark scenarios
+        id: stable_scenarios
+        if: github.ref_name != 'main'
+        continue-on-error: true
+        shell: bash
+        run: |
+          failed=0
+          check_scenario() {
+            local report=$1 scenario=$2
+            local head_min main_min regression_percent
+            head_min=$(jq -er 'first(.results[] | select(.command == "pacquet@HEAD")).min' "$report")
+            main_min=$(jq -er 'first(.results[] | select(.command == "pacquet@main")).min' "$report")
+            if jq -en \
+              --argjson head "$head_min" \
+              --argjson main "$main_min" \
+              --argjson max "$PACQUET_STABLE_SCENARIO_MAX_RATIO" \
+              '$head <= $main * $max' > /dev/null; then
+              return
+            fi
+            regression_percent=$(jq -nr \
+              --argjson head "$head_min" \
+              --argjson main "$main_min" \
+              '(($head / $main - 1) * 10000 | round) / 100')
+            echo "::error title=Pacquet benchmark regression::$scenario: pacquet@HEAD minimum ${head_min}s is ${regression_percent}% slower than pacquet@main ${main_min}s"
+            failed=1
+          }
+
+          check_scenario \
+            bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE.json \
+            'fresh restore, cold cache + cold store'
+          check_scenario \
+            bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_COLD_CACHE_COLD_STORE.json \
+            'fresh install, cold cache + cold store'
+          check_scenario \
+            bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_COLD_CACHE_HOT_STORE.json \
+            'fresh install, cold cache + hot store'
+          check_scenario \
+            bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE_COLD_PNPR.json \
+            'fresh restore, cold cache + cold store + cold pnpr'
+          exit "$failed"
+
       - name: Install Bencher CLI
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         uses: bencherdev/bencher@4c83b25441d145ee273adaf74be30f2382e6ba85 # v0.6.11
@@ -666,7 +707,6 @@ jobs:
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         env:
           BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REF_NAME: ${{ github.ref_name }}
         shell: bash
         run: |
@@ -677,10 +717,10 @@ jobs:
           # One run is one benchmark, two testbeds: `pacquet` (direct
           # install, all scenarios) and `pnpr` (accelerated path, hot
           # scenarios). Upload each from its own bencher-results file.
-          # `--start-point-clone-thresholds` so the forked branch inherits
-          # the threshold configured on main; `--err` so the workflow fails
-          # when a sample breaches the upper boundary. Main pushes skip
-          # both — by then the regression has already landed.
+          # `--start-point-clone-thresholds` lets Bencher continue surfacing
+          # cross-run alerts. They are observational: the blocking gate above
+          # uses the same-run comparison for the stable scenarios. Main pushes
+          # skip the branch setup because they establish the baseline.
           upload() {
             local testbed=$1 file=$2
             if [ ! -f "$file" ]; then
@@ -692,7 +732,6 @@ jobs:
               --testbed "$testbed"
               --adapter json
               --file "$file"
-              --github-actions "$GITHUB_TOKEN"
             )
             if [ "$REF_NAME" = "main" ]; then
               args+=(--branch main)
@@ -702,13 +741,19 @@ jobs:
                 --start-point main
                 --start-point-reset
                 --start-point-clone-thresholds
-                --err
               )
             fi
             bencher run "${args[@]}"
           }
           upload pacquet bench-work-env/bencher-results.json
           upload pnpr bench-work-env/bencher-results-pnpr.json
+
+      - name: Re-raise the stable-scenario gate
+        if: always() && steps.stable_scenarios.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::error::A stable pacquet benchmark scenario regressed by more than 20%; see the check step for measurements."
+          exit 1
 
       - name: Re-raise the peer-heavy gate
         # Deferred from the peer-heavy step so its cross-engine assertion

--- a/.github/workflows/pacquet-integrated-benchmark.yml
+++ b/.github/workflows/pacquet-integrated-benchmark.yml
@@ -756,7 +756,7 @@ jobs:
         if: always() && github.event_name != 'pull_request' && steps.stable_scenarios.outcome == 'failure'
         shell: bash
         run: |
-          echo "::error::A stable pacquet benchmark scenario regressed by more than 20%; see the check step for measurements."
+          echo "::error::The stable-scenario benchmark gate failed; see the check step for details."
           exit 1
 
       - name: Re-raise the peer-heavy gate

--- a/pnpm/crates/deps-restorer/src/import_indexed_dir.rs
+++ b/pnpm/crates/deps-restorer/src/import_indexed_dir.rs
@@ -5,6 +5,7 @@ use crate::{
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_config::PackageImportMethod;
+use pacquet_fs::DirLock;
 use pacquet_reporter::Reporter;
 use rayon::prelude::*;
 use std::{
@@ -12,8 +13,11 @@ use std::{
     fs, io,
     path::{Path, PathBuf},
     sync::atomic::{AtomicU8, AtomicU64, Ordering},
-    time::{SystemTime, UNIX_EPOCH},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
+
+const SHARED_IMPORT_LOCK_WAIT: Duration = Duration::from_mins(5);
+const SHARED_IMPORT_LOCK_ABANDONED_AFTER: Duration = Duration::from_mins(30);
 
 /// Options for [`import_indexed_dir`].
 ///
@@ -99,6 +103,14 @@ pub enum ImportIndexedDirError {
         #[error(source)]
         error: io::Error,
     },
+    #[display("failed to lock shared package target {path:?}: {error}")]
+    LockSharedTarget {
+        path: PathBuf,
+        #[error(source)]
+        error: io::Error,
+    },
+    #[display("timed out waiting to lock shared package target {path:?}")]
+    LockSharedTargetTimeout { path: PathBuf },
 }
 
 /// Materialize an indexed package's files into `dir_path`, the way
@@ -123,6 +135,12 @@ pub fn import_indexed_dir<Reporter: self::Reporter>(
     cas_paths: &HashMap<String, PathBuf>,
     opts: ImportIndexedDirOpts,
 ) -> Result<(), ImportIndexedDirError> {
+    let _shared_import_lock = if opts.safe_to_skip && opts.force {
+        Some(acquire_shared_import_lock(dir_path)?)
+    } else {
+        None
+    };
+
     let existing_kind = match fs::symlink_metadata(dir_path) {
         Ok(meta) => Some(meta.file_type()),
         Err(err) if err.kind() == io::ErrorKind::NotFound => None,
@@ -177,6 +195,21 @@ pub fn import_indexed_dir<Reporter: self::Reporter>(
             opts.safe_to_skip,
         )
         .inspect(|()| unquarantine()),
+    }
+}
+
+fn acquire_shared_import_lock(dir_path: &Path) -> Result<DirLock, ImportIndexedDirError> {
+    let parent = dir_path.parent().unwrap_or_else(|| Path::new("."));
+    let name = dir_path.file_name().and_then(|name| name.to_str()).unwrap_or("package");
+    let path = parent.join(format!(".{name}_pacquet-import.lock"));
+    match DirLock::acquire(
+        path.clone(),
+        SHARED_IMPORT_LOCK_WAIT,
+        SHARED_IMPORT_LOCK_ABANDONED_AFTER,
+    ) {
+        Ok(Some(lock)) => Ok(lock),
+        Ok(None) => Err(ImportIndexedDirError::LockSharedTargetTimeout { path }),
+        Err(error) => Err(ImportIndexedDirError::LockSharedTarget { path, error }),
     }
 }
 

--- a/pnpm/crates/deps-restorer/src/import_indexed_dir.rs
+++ b/pnpm/crates/deps-restorer/src/import_indexed_dir.rs
@@ -109,8 +109,6 @@ pub enum ImportIndexedDirError {
         #[error(source)]
         error: io::Error,
     },
-    #[display("timed out waiting to lock shared package target {path:?}")]
-    LockSharedTargetTimeout { path: PathBuf },
 }
 
 /// Materialize an indexed package's files into `dir_path`, the way
@@ -136,7 +134,11 @@ pub fn import_indexed_dir<Reporter: self::Reporter>(
     opts: ImportIndexedDirOpts,
 ) -> Result<(), ImportIndexedDirError> {
     let _shared_import_lock = if opts.safe_to_skip && opts.force {
-        Some(acquire_shared_import_lock(dir_path)?)
+        acquire_shared_import_lock(
+            dir_path,
+            SHARED_IMPORT_LOCK_WAIT,
+            SHARED_IMPORT_LOCK_ABANDONED_AFTER,
+        )?
     } else {
         None
     };
@@ -198,19 +200,17 @@ pub fn import_indexed_dir<Reporter: self::Reporter>(
     }
 }
 
-fn acquire_shared_import_lock(dir_path: &Path) -> Result<DirLock, ImportIndexedDirError> {
+fn acquire_shared_import_lock(
+    dir_path: &Path,
+    wait: Duration,
+    abandoned_after: Duration,
+) -> Result<Option<DirLock>, ImportIndexedDirError> {
     let parent = dir_path.parent().unwrap_or_else(|| Path::new("."));
     let name = dir_path.file_name().and_then(|name| name.to_str()).unwrap_or("package");
-    let path = parent.join(format!(".{name}_pacquet-import.lock"));
-    match DirLock::acquire(
-        path.clone(),
-        SHARED_IMPORT_LOCK_WAIT,
-        SHARED_IMPORT_LOCK_ABANDONED_AFTER,
-    ) {
-        Ok(Some(lock)) => Ok(lock),
-        Ok(None) => Err(ImportIndexedDirError::LockSharedTargetTimeout { path }),
-        Err(error) => Err(ImportIndexedDirError::LockSharedTarget { path, error }),
-    }
+    let lock_path = parent.join(format!(".{name}_pacquet-import.lock"));
+    DirLock::acquire(lock_path, wait, abandoned_after).map_err(|error| {
+        ImportIndexedDirError::LockSharedTarget { path: dir_path.to_path_buf(), error }
+    })
 }
 
 /// Fresh-target path: make the parent dir set, then run the parallel

--- a/pnpm/crates/deps-restorer/src/import_indexed_dir/tests.rs
+++ b/pnpm/crates/deps-restorer/src/import_indexed_dir/tests.rs
@@ -1,4 +1,6 @@
-use super::{ImportIndexedDirError, ImportIndexedDirOpts, import_indexed_dir};
+use super::{
+    ImportIndexedDirError, ImportIndexedDirOpts, acquire_shared_import_lock, import_indexed_dir,
+};
 use pacquet_config::PackageImportMethod;
 use pacquet_reporter::SilentReporter;
 use pretty_assertions::assert_eq;
@@ -7,6 +9,7 @@ use std::{
     fs,
     path::{Path, PathBuf},
     sync::atomic::AtomicU8,
+    time::Duration,
 };
 use tempfile::tempdir;
 
@@ -817,6 +820,37 @@ fn concurrent_importers_of_one_shared_slot_both_succeed() {
         .filter(|name| name != "cas" && name != "slot")
         .collect();
     assert_eq!(strays, Vec::<String>::new(), "neither importer may leak a staging dir");
+}
+
+#[test]
+fn shared_import_lock_timeout_is_non_fatal() {
+    let tmp = tempdir().unwrap();
+    let target = tmp.path().join("slot");
+    let abandoned_after = Duration::from_mins(1);
+    let _held = acquire_shared_import_lock(&target, Duration::ZERO, abandoned_after)
+        .expect("first acquisition should succeed")
+        .expect("first acquisition should take the lock");
+
+    let timed_out = acquire_shared_import_lock(&target, Duration::ZERO, abandoned_after)
+        .expect("a held lock is not an I/O failure");
+
+    assert!(timed_out.is_none(), "a timed-out import proceeds without the advisory lock");
+}
+
+#[test]
+fn shared_import_lock_setup_failure_reports_the_package_target() {
+    let tmp = tempdir().unwrap();
+    let non_directory = tmp.path().join("not-a-directory");
+    fs::write(&non_directory, b"file").unwrap();
+    let target = non_directory.join("slot");
+
+    let error = acquire_shared_import_lock(&target, Duration::ZERO, Duration::from_mins(1))
+        .expect_err("a lock cannot be created below a file");
+
+    match error {
+        ImportIndexedDirError::LockSharedTarget { path, .. } => assert_eq!(path, target),
+        other => panic!("unexpected error: {other}"),
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#13660.

The integrated benchmark now keeps all scenarios in its summary and Bencher history without allowing noisy cross-run Bencher alerts to fail a pull request. Its blocking 20% regression gate compares `pacquet@HEAD` with `pacquet@main` on the same runner for the four longer scenarios whose measured floors remained stable across the control runs and reruns. The four short CPU/disk scenarios remain observational.

For pull requests, the benchmark records a failed stable or peer-heavy gate in the uploaded artifact while allowing the producer workflow to finish successfully. The privileged comment workflow posts the measurements, uploads the observational Bencher data, and then re-raises the marker. Unrelated failures before artifact creation still skip the comment workflow. Removing Bencher's GitHub integration also removes the unused `checks: write` permissions. The producer and consumer use new `bencher-observations*.json` artifact names so the current default-branch `workflow_run` definition cannot consume a new artifact with its retired blocking upload policy during rollout.

Full validation exposed a race in concurrent forced repairs of an incomplete global virtual store slot. Those rare repairs now use the existing directory lock before inspecting or replacing the shared target; ordinary imports remain parallel. A bounded lock timeout remains non-fatal under the advisory-lock contract, while lock setup errors identify the affected package target. The existing pending pacquet changeset for concurrent slot imports was updated. TypeScript pnpm already provides the corresponding safe shared-store behavior, so no TypeScript implementation change is needed.

Validation:

- `just ready` after rebasing onto the current `main`: 8,000 tests passed, plus formatting, checks, Clippy, and documentation checks.
- The repository pre-push hook passed, including TypeScript compile/lint and Rust formatting, Clippy, docs, Dylint, spelling, and TOML checks.
- `actionlint` 1.7.7 passed on both edited workflows, accounting for the repository's custom Blacksmith runner labels.
- All 26 indexed-import tests passed, including concurrent shared-slot import, non-fatal lock timeout, lock setup failure, and all `safe_to_skip` cases.
- A focused gate fixture confirmed that a 19% same-run regression passes and a 21% regression fails with the measured minima in the diagnostic.
- The PR-head integrated benchmark and same-run gate passed; its report artifact and comment were produced successfully.

## Squash Commit Body

```text
Bencher's cross-run minimum-latency thresholds could move beyond their 20% boundary on short CPU and disk scenarios whose measured code was unchanged. Removing only the CLI error flag is insufficient because Bencher also concludes its GitHub Check as failed whenever an alert exists.

Keep every scenario in the benchmark summary and Bencher history, but stop Bencher from creating the duplicate blocking check. Compare pacquet HEAD with main in the same run for the four longer scenarios whose floors stayed stable in the control data. Carry a failed gate in the artifact so the privileged workflow can publish the report and observational data before re-raising it, while early unrelated failures still stop without a redundant comment-workflow failure. Version the observation artifact names with this producer/consumer change so the default-branch workflow cannot apply its retired blocking upload policy during rollout.

Full validation also exposed concurrent forced repairs racing over one incomplete global virtual store slot. Guard that rare repair path with the existing advisory directory lock so one process normally cannot remove a target while another is writing it; keep ordinary imports parallel and preserve the lock's non-fatal bounded-timeout behavior.

Fixes pnpm/pnpm#13660.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Benchmarking**
  - Benchmark workflows now process results from successful and failed runs, including deferred regression artifacts.
  - Selected non-main scenarios enforce a 1.2 stability gate.
  - Uploads remain observational, while same-run gate failures block workflows after results are published.
  - Reports distinguish informational cross-run alerts from blocking stability failures.

- **Bug Fixes**
  - Concurrent installs now serialize forced repairs of incomplete shared package slots, reducing directory-removal and transient read failures.
  - Lock timeouts no longer cause unnecessary failures during shared package repairs.
  - Shared repair lock setup failures now provide clearer diagnostics.

- **Security**
  - Reduced workflow permissions and removed unnecessary token sharing during benchmark publication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->