### PR TITLE
fix(git-resolver): say which git dependency could not be reached, and how

### DIFF
--- a/.changeset/git-resolve-failure-hint.md
+++ b/.changeset/git-resolve-failure-hint.md
@@ -4,6 +4,8 @@
 "pnpm": patch
 ---
 
-A git dependency whose remote `git ls-remote` cannot reach now fails with the `ERR_PNPM_GIT_RESOLVE_FAILED` code, naming the dependency instead of printing a bare `git` invocation, with credentials in the repository URL redacted. A specifier that does not ask for SSH resolves over HTTPS, because the URL recorded in the lockfile has to work on every machine that installs it, so the error explains how to substitute the transport on a machine that can only reach the host over SSH (`git config --global url."git@<host>:".insteadOf "https://<host>/"`) [#13743](https://github.com/pnpm/pnpm/issues/13743).
+A git dependency whose `git ls-remote` fails now reports the `ERR_PNPM_GIT_RESOLVE_FAILED` code, naming the dependency instead of printing a bare `git` invocation, with credentials in the repository URL redacted. A specifier that does not ask for SSH resolves over HTTPS, because the URL recorded in the lockfile has to work on every machine that installs it, so the error explains how to substitute the transport on a machine that can only reach the host over SSH (`git config --global url."git@<host>:".insteadOf "https://<host>/"`) [#13743](https://github.com/pnpm/pnpm/issues/13743).
 
-A public repository is no longer probed with an extra `git ls-remote` before resolution: the probe's outcome could not change what gets recorded, and skipping it saves a round-trip per git dependency.
+A missing `git` executable is reported as one, instead of surfacing the raw failure to start the process.
+
+Resolving a public repository makes one `git ls-remote` round-trip instead of two.

--- a/.changeset/git-resolve-failure-hint.md
+++ b/.changeset/git-resolve-failure-hint.md
@@ -1,0 +1,9 @@
+---
+"@pnpm/resolving.git-resolver": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+A git dependency whose remote `git ls-remote` cannot reach now fails with the `ERR_PNPM_GIT_RESOLVE_FAILED` code, naming the dependency instead of printing a bare `git` invocation, with credentials in the repository URL redacted. A specifier that does not ask for SSH resolves over HTTPS, because the URL recorded in the lockfile has to work on every machine that installs it, so the error explains how to substitute the transport on a machine that can only reach the host over SSH (`git config --global url."git@<host>:".insteadOf "https://<host>/"`) [#13743](https://github.com/pnpm/pnpm/issues/13743).
+
+A public repository is no longer probed with an extra `git ls-remote` before resolution: the probe's outcome could not change what gets recorded, and skipping it saves a round-trip per git dependency.

--- a/.changeset/git-resolve-failure-hint.md
+++ b/.changeset/git-resolve-failure-hint.md
@@ -8,4 +8,6 @@ A git dependency whose `git ls-remote` fails now reports the `ERR_PNPM_GIT_RESOL
 
 A missing `git` executable is reported as one, instead of surfacing the raw failure to start the process.
 
+Credentials embedded in a git specifier are redacted from the "Could not resolve \<ref\> to a commit of \<repo\>" errors too.
+
 Resolving a public repository makes one `git ls-remote` round-trip instead of two.

--- a/pnpm/crates/package-manager/src/add.rs
+++ b/pnpm/crates/package-manager/src/add.rs
@@ -20,7 +20,7 @@ use pacquet_config::{Config, SaveWorkspaceProtocol};
 use pacquet_engine_runtime_node_resolver::{NodeResolver, NodeResolverError};
 use pacquet_lockfile::{Lockfile, MaybeLazyLockfile};
 use pacquet_lockfile_preferred_versions::get_preferred_versions_from_lockfile_and_manifests;
-use pacquet_network::ThrottledClient;
+use pacquet_network::{ThrottledClient, redact_and_sanitize};
 use pacquet_package_manifest::{DependencyGroup, PackageManifest, PackageManifestError};
 use pacquet_registry::RangeSpecStyle;
 use pacquet_reporter::{LogEvent, LogLevel, PackageManifestLog, PackageManifestMessage, Reporter};
@@ -836,9 +836,11 @@ async fn resolve_aliasless_git(
     .await
     .map_err(|source| match source.downcast::<GitResolveError>() {
         Ok(git_resolve) => AddError::GitResolve(*git_resolve),
-        Err(source) => AddError::ResolveGit { specifier: specifier.to_string(), source },
+        // A specifier can carry `user:pass@` credentials, and every error here
+        // echoes it back.
+        Err(source) => AddError::ResolveGit { specifier: redact_and_sanitize(specifier), source },
     })?
-    .ok_or_else(|| AddError::GitPackageName { specifier: specifier.to_string() })?;
+    .ok_or_else(|| AddError::GitPackageName { specifier: redact_and_sanitize(specifier) })?;
     let package_name = result
         .manifest
         .as_ref()
@@ -846,10 +848,10 @@ async fn resolve_aliasless_git(
         .and_then(serde_json::Value::as_str)
         .map(str::to_string)
         .or_else(|| HostedGit::from_url(specifier).map(|hosted| hosted.project))
-        .ok_or_else(|| AddError::GitPackageName { specifier: specifier.to_string() })?;
+        .ok_or_else(|| AddError::GitPackageName { specifier: redact_and_sanitize(specifier) })?;
     if !is_valid_dependency_alias(&package_name) {
         return Err(AddError::InvalidGitPackageName {
-            specifier: specifier.to_string(),
+            specifier: redact_and_sanitize(specifier),
             name: package_name,
         });
     }

--- a/pnpm/crates/package-manager/src/add.rs
+++ b/pnpm/crates/package-manager/src/add.rs
@@ -139,11 +139,11 @@ pub enum AddError {
         source: pacquet_resolving_resolver_base::ResolveError,
     },
 
-    /// The git dependency's remote could not be reached. Kept as the
-    /// diagnostic the resolver raised, which already names the specifier and
-    /// carries the `ERR_PNPM_GIT_RESOLVE_FAILED` code and its remediation.
+    /// The git dependency's `git ls-remote` failed. Kept as the diagnostic the
+    /// resolver raised, which already names the specifier and carries the
+    /// `ERR_PNPM_GIT_RESOLVE_FAILED` code and its remediation.
     #[diagnostic(transparent)]
-    GitRemoteUnreachable(#[error(source)] GitResolveError),
+    GitResolve(#[error(source)] GitResolveError),
 
     #[display("Could not determine the package name of git dependency {specifier:?}")]
     #[diagnostic(code(ERR_PNPM_PACKAGE_MANAGER_ADD_GIT_PACKAGE_NAME))]
@@ -835,7 +835,7 @@ async fn resolve_aliasless_git(
     )
     .await
     .map_err(|source| match source.downcast::<GitResolveError>() {
-        Ok(unreachable) => AddError::GitRemoteUnreachable(*unreachable),
+        Ok(git_resolve) => AddError::GitResolve(*git_resolve),
         Err(source) => AddError::ResolveGit { specifier: specifier.to_string(), source },
     })?
     .ok_or_else(|| AddError::GitPackageName { specifier: specifier.to_string() })?;

--- a/pnpm/crates/package-manager/src/add.rs
+++ b/pnpm/crates/package-manager/src/add.rs
@@ -34,7 +34,7 @@ use pacquet_resolving_npm_resolver::{
     parse_bare_specifier, pick_matching_local_version_or_null, pick_package,
     pick_registry_for_package, shared_packument_fetch_locker,
 };
-use pacquet_resolving_resolver_base::WorkspacePackages;
+use pacquet_resolving_resolver_base::{GitResolveError, WorkspacePackages};
 use pacquet_tarball::MemCache;
 use pacquet_workspace_range_resolver::resolve_workspace_range;
 use pacquet_workspace_spec::WorkspaceSpec;
@@ -138,6 +138,12 @@ pub enum AddError {
         #[error(source)]
         source: pacquet_resolving_resolver_base::ResolveError,
     },
+
+    /// The git dependency's remote could not be reached. Kept as the
+    /// diagnostic the resolver raised, which already names the specifier and
+    /// carries the `ERR_PNPM_GIT_RESOLVE_FAILED` code and its remediation.
+    #[diagnostic(transparent)]
+    GitRemoteUnreachable(#[error(source)] GitResolveError),
 
     #[display("Could not determine the package name of git dependency {specifier:?}")]
     #[diagnostic(code(ERR_PNPM_PACKAGE_MANAGER_ADD_GIT_PACKAGE_NAME))]
@@ -828,7 +834,10 @@ async fn resolve_aliasless_git(
         &pacquet_resolving_resolver_base::ResolveOptions::default(),
     )
     .await
-    .map_err(|source| AddError::ResolveGit { specifier: specifier.to_string(), source })?
+    .map_err(|source| match source.downcast::<GitResolveError>() {
+        Ok(unreachable) => AddError::GitRemoteUnreachable(*unreachable),
+        Err(source) => AddError::ResolveGit { specifier: specifier.to_string(), source },
+    })?
     .ok_or_else(|| AddError::GitPackageName { specifier: specifier.to_string() })?;
     let package_name = result
         .manifest

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -7,8 +7,8 @@ use pacquet_hooks::PnpmfileHooks;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_patching::{PatchGroupRecord, PatchKeyConflictError};
 use pacquet_resolving_resolver_base::{
-    NoMatchingVersionError, PreferredVersionsOverlay, RegistryResponseError, ResolveOptions,
-    Resolver, WantedDependency,
+    GitResolveError, NoMatchingVersionError, PreferredVersionsOverlay, RegistryResponseError,
+    ResolveOptions, Resolver, WantedDependency,
 };
 use pipe_trait::Pipe;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
@@ -233,6 +233,11 @@ pub enum ResolveDependencyTreeError {
     /// raised with the matching `ERR_PNPM_FETCH_<status>` code.
     #[diagnostic(transparent)]
     RegistryResponse(#[error(source)] RegistryResponseError),
+
+    /// A git dependency's remote could not be reached, raised with the
+    /// `ERR_PNPM_GIT_RESOLVE_FAILED` code.
+    #[diagnostic(transparent)]
+    GitResolve(#[error(source)] GitResolveError),
 
     /// An optional dependency failed to resolve while the wanted
     /// lockfile still holds a package entry satisfying the wanted

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -234,7 +234,7 @@ pub enum ResolveDependencyTreeError {
     #[diagnostic(transparent)]
     RegistryResponse(#[error(source)] RegistryResponseError),
 
-    /// A git dependency's remote could not be reached, raised with the
+    /// A git dependency's `git ls-remote` failed, raised with the
     /// `ERR_PNPM_GIT_RESOLVE_FAILED` code.
     #[diagnostic(transparent)]
     GitResolve(#[error(source)] GitResolveError),

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
@@ -9,8 +9,8 @@ use async_recursion::async_recursion;
 use futures_util::future;
 use pacquet_lockfile::PkgNameVerPeer;
 use pacquet_resolving_resolver_base::{
-    CurrentPkg, NoMatchingVersionError, PreferredVersionsOverlay, RegistryResponseError,
-    ResolveError, ResolveOptions, Resolver, WantedDependency,
+    CurrentPkg, GitResolveError, NoMatchingVersionError, PreferredVersionsOverlay,
+    RegistryResponseError, ResolveError, ResolveOptions, Resolver, WantedDependency,
 };
 use pipe_trait::Pipe;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
@@ -330,6 +330,7 @@ where
                 err @ (ResolveDependencyTreeError::Resolve(_)
                 | ResolveDependencyTreeError::NoMatchingVersion(_)
                 | ResolveDependencyTreeError::RegistryResponse(_)
+                | ResolveDependencyTreeError::GitResolve(_)
                 | ResolveDependencyTreeError::SpecNotSupported { .. }),
             ) if wanted.optional.unwrap_or(false) => {
                 if wanted_lockfile_contains_satisfying_entry(
@@ -994,8 +995,12 @@ fn map_resolve_error(err: ResolveError) -> ResolveDependencyTreeError {
         }
         Err(err) => err,
     };
-    match err.downcast::<RegistryResponseError>() {
-        Ok(response) => ResolveDependencyTreeError::RegistryResponse(*response),
+    let err = match err.downcast::<RegistryResponseError>() {
+        Ok(response) => return ResolveDependencyTreeError::RegistryResponse(*response),
+        Err(err) => err,
+    };
+    match err.downcast::<GitResolveError>() {
+        Ok(git) => ResolveDependencyTreeError::GitResolve(*git),
         Err(err) => ResolveDependencyTreeError::Resolve(err.to_string()),
     }
 }

--- a/pnpm/crates/resolving-git-resolver/src/git_resolver.rs
+++ b/pnpm/crates/resolving-git-resolver/src/git_resolver.rs
@@ -283,7 +283,7 @@ async fn build_resolve_result<Probe: GitProbe + ?Sized, Runner: GitCommandRunner
 }
 
 /// Box a ref-resolution failure as a [`ResolveError`], naming the dependency
-/// when the remote could not be reached at all.
+/// when the `git ls-remote` invocation itself failed.
 ///
 /// [`GitResolveError`] has to be the outermost box for the tree walker's
 /// downcast to find it, which is what keeps its code and help alive across
@@ -293,11 +293,11 @@ fn ref_resolution_error(
     wanted_dependency: &WantedDependency,
     repo: &str,
 ) -> ResolveError {
-    let GitResolveRefError::Runner(unreachable) = &err else {
+    let GitResolveRefError::Runner(ls_remote) = &err else {
         return Box::new(err) as ResolveError;
     };
     let specifier = wanted_dependency.bare_specifier.as_deref().unwrap_or_default();
-    Box::new(GitResolveError::new(specifier, repo, &unreachable.to_string())) as ResolveError
+    Box::new(GitResolveError::new(specifier, repo, &ls_remote.to_string())) as ResolveError
 }
 
 /// Pick between a tarball and a git resolution — see [`GitProbe`] for

--- a/pnpm/crates/resolving-git-resolver/src/git_resolver.rs
+++ b/pnpm/crates/resolving-git-resolver/src/git_resolver.rs
@@ -9,8 +9,8 @@ use pacquet_lockfile::{GitResolution, LockfileResolution, TarballResolution};
 use pacquet_network::{AuthHeaders, ThrottledClient};
 use pacquet_reporter::SilentReporter;
 use pacquet_resolving_resolver_base::{
-    LatestInfo, LatestQuery, ResolveError, ResolveFuture, ResolveLatestFuture, ResolveOptions,
-    ResolveResult, Resolver, WantedDependency,
+    GitResolveError, LatestInfo, LatestQuery, ResolveError, ResolveFuture, ResolveLatestFuture,
+    ResolveOptions, ResolveResult, Resolver, WantedDependency,
 };
 use pacquet_store_dir::{StoreDir, StoreIndexWriter};
 use pacquet_tarball::{FetchTarballForResolution, RetryOpts};
@@ -19,7 +19,7 @@ use crate::{
     create_git_hosted_pkg_id::create_git_hosted_pkg_id,
     hosted_git::HostedOpts,
     parse_bare_specifier::{HostedPackageSpec, parse_bare_specifier},
-    resolve_ref::{GitCommandRunner, resolve_ref},
+    resolve_ref::{GitCommandRunner, GitResolveRefError, resolve_ref},
 };
 
 /// Boxed-future return type used by [`GitProbe`]. Same shape as the
@@ -145,7 +145,7 @@ impl<Probe: GitProbe + 'static, Runner: GitCommandRunner + 'static> GitResolver<
             spec,
             self.probe.as_ref(),
             self.runner.as_ref(),
-            wanted_dependency.alias.as_deref(),
+            wanted_dependency,
         )
         .await?;
         self.read_package_metadata(&mut result).await?;
@@ -240,7 +240,7 @@ async fn build_resolve_result<Probe: GitProbe + ?Sized, Runner: GitCommandRunner
     spec: HostedPackageSpec,
     probe: &Probe,
     runner: &Runner,
-    alias: Option<&str>,
+    wanted_dependency: &WantedDependency,
 ) -> Result<ResolveResult, ResolveError> {
     let ref_for_ls_remote = match spec.git_committish.as_deref() {
         Some(committish) if !committish.is_empty() => committish,
@@ -249,7 +249,7 @@ async fn build_resolve_result<Probe: GitProbe + ?Sized, Runner: GitCommandRunner
     let commit =
         resolve_ref(runner, &spec.fetch_spec, ref_for_ls_remote, spec.git_range.as_deref())
             .await
-            .map_err(|err| Box::new(err) as ResolveError)?;
+            .map_err(|err| ref_resolution_error(err, wanted_dependency, &spec.fetch_spec))?;
 
     let resolution = pick_resolution(&spec, probe, &commit).await;
 
@@ -277,9 +277,27 @@ async fn build_resolve_result<Probe: GitProbe + ?Sized, Runner: GitCommandRunner
         resolution,
         resolved_via: "git-repository".to_string(),
         normalized_bare_specifier: Some(spec.normalized_bare_specifier),
-        alias: alias.map(str::to_string),
+        alias: wanted_dependency.alias.clone(),
         policy_violation: None,
     })
+}
+
+/// Box a ref-resolution failure as a [`ResolveError`], naming the dependency
+/// when the remote could not be reached at all.
+///
+/// [`GitResolveError`] has to be the outermost box for the tree walker's
+/// downcast to find it, which is what keeps its code and help alive across
+/// the type-erased resolver seam.
+fn ref_resolution_error(
+    err: GitResolveRefError,
+    wanted_dependency: &WantedDependency,
+    repo: &str,
+) -> ResolveError {
+    let GitResolveRefError::Runner(unreachable) = &err else {
+        return Box::new(err) as ResolveError;
+    };
+    let specifier = wanted_dependency.bare_specifier.as_deref().unwrap_or_default();
+    Box::new(GitResolveError::new(specifier, repo, &unreachable.to_string())) as ResolveError
 }
 
 /// Pick between a tarball and a git resolution — see [`GitProbe`] for

--- a/pnpm/crates/resolving-git-resolver/src/git_resolver/tests.rs
+++ b/pnpm/crates/resolving-git-resolver/src/git_resolver/tests.rs
@@ -1,7 +1,10 @@
 use super::{GitProbe, GitResolver, ProbeFuture};
 use crate::resolve_ref::{GitCommandRunner, GitRunError};
+use miette::Diagnostic;
 use pacquet_lockfile::LockfileResolution;
-use pacquet_resolving_resolver_base::{ResolveOptions, ResolveResult, Resolver, WantedDependency};
+use pacquet_resolving_resolver_base::{
+    GitResolveError, ResolveOptions, ResolveResult, Resolver, WantedDependency,
+};
 use std::{
     future::Future,
     pin::Pin,
@@ -43,6 +46,39 @@ impl GitCommandRunner for FakeRunner {
         let stdout = self.stdout.clone();
         Box::pin(async move { Ok(stdout) })
     }
+}
+
+/// Stands in for a git that cannot reach the remote at all — a machine
+/// without the host's CA certificates, without an SSH key, offline.
+struct UnreachableRunner {
+    stderr: String,
+}
+
+impl GitCommandRunner for UnreachableRunner {
+    fn ls_remote<'a>(
+        &'a self,
+        _repo: &'a str,
+        _ref_: Option<&'a str>,
+    ) -> Pin<Box<dyn Future<Output = Result<String, GitRunError>> + Send + 'a>> {
+        let message = self.stderr.clone();
+        Box::pin(async move { Err(GitRunError { message }) })
+    }
+}
+
+async fn resolve_unreachable(bare_specifier: &str, stderr: &str) -> GitResolveError {
+    let resolver = GitResolver::new(
+        Arc::new(FakeProbe::new(true)),
+        Arc::new(UnreachableRunner { stderr: stderr.to_string() }),
+    );
+    let wanted = WantedDependency {
+        bare_specifier: Some(bare_specifier.to_string()),
+        ..WantedDependency::default()
+    };
+    let err = resolver
+        .resolve(&wanted, &ResolveOptions::default())
+        .await
+        .expect_err("unreachable remote");
+    *err.downcast::<GitResolveError>().expect("the resolver's own diagnostic, boxed outermost")
 }
 
 fn runner(stdout: &str) -> FakeRunner {
@@ -279,4 +315,40 @@ async fn credentialed_https_url_keeps_the_authenticated_url() {
         [(AUTH_URL.to_string(), Some("HEAD".to_string()))],
     );
     assert!(probe.calls.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn unreachable_remote_names_the_dependency_and_how_to_substitute_the_transport() {
+    let err = resolve_unreachable(
+        "zkochan/is-negative#next",
+        "fatal: unable to access 'https://github.com/zkochan/is-negative.git/': SSL certificate problem",
+    )
+    .await;
+
+    assert_eq!(err.code().expect("code").to_string(), "ERR_PNPM_GIT_RESOLVE_FAILED");
+    assert_eq!(
+        err.to_string(),
+        r#"Failed to resolve git dependency "zkochan/is-negative#next": git ls-remote failed: fatal: unable to access 'https://github.com/zkochan/is-negative.git/': SSL certificate problem"#,
+    );
+    let help = err.help().expect("help").to_string();
+    assert!(
+        help.contains(
+            r#"git config --global url."git@github.com:".insteadOf "https://github.com/""#
+        ),
+        "{help}",
+    );
+}
+
+// A known host's SSH URL is an identity that finalises to HTTPS (see
+// `parse_bare_specifier`), so the hint applies there too. Only an unknown
+// host's URL keeps the transport the user wrote.
+#[tokio::test]
+async fn unreachable_ssh_remote_carries_no_transport_substitution_hint() {
+    let err = resolve_unreachable(
+        "git+ssh://git@example.com/foo/bar.git",
+        "git@example.com: Permission denied (publickey).",
+    )
+    .await;
+
+    assert!(err.help().is_none());
 }

--- a/pnpm/crates/resolving-git-resolver/src/resolve_ref.rs
+++ b/pnpm/crates/resolving-git-resolver/src/resolve_ref.rs
@@ -12,6 +12,7 @@ use std::{
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use node_semver::{Range, Version};
+use pacquet_network::redact_and_sanitize;
 
 /// Capability seam for `git ls-remote`.
 ///
@@ -59,7 +60,9 @@ pub enum GitResolveRefError {
         commit: String,
     },
 
-    /// Plain `Could not resolve <ref> to a commit of <repo>.` error.
+    /// Plain `Could not resolve <ref> to a commit of <repo>.` error. The repo
+    /// is redacted: a specifier can carry `user:pass@` credentials, which the
+    /// resolution URL keeps.
     #[display("Could not resolve {ref_} to a commit of {repo}.")]
     UnknownRef {
         #[error(not(source))]
@@ -176,7 +179,7 @@ fn resolve_ref_from_refs(
         }
         return Err(GitResolveRefError::UnknownRef {
             ref_: ref_.to_string(),
-            repo: repo.to_string(),
+            repo: redact_and_sanitize(repo),
         });
     };
 
@@ -200,7 +203,7 @@ fn resolve_ref_from_refs(
 
     let parsed_range = Range::parse(range).map_err(|_| GitResolveRefError::UnknownRange {
         range: range.to_string(),
-        repo: repo.to_string(),
+        repo: redact_and_sanitize(repo),
         available: v_tags.iter().cloned().collect::<Vec<_>>().join(", "),
     })?;
     let pick = resolve_v_tags(&v_tags, &parsed_range);
@@ -215,7 +218,7 @@ fn resolve_ref_from_refs(
     }
     Err(GitResolveRefError::UnknownRange {
         range: range.to_string(),
-        repo: repo.to_string(),
+        repo: redact_and_sanitize(repo),
         available: v_tags.iter().cloned().collect::<Vec<_>>().join(", "),
     })
 }

--- a/pnpm/crates/resolving-git-resolver/src/resolve_ref/tests.rs
+++ b/pnpm/crates/resolving-git-resolver/src/resolve_ref/tests.rs
@@ -122,3 +122,17 @@ fn parse_ls_remote_ignores_blank_lines() {
     assert_eq!(refs.len(), 1);
     assert_eq!(refs.get("refs/heads/main").map(String::as_str), Some("abc"));
 }
+
+#[tokio::test]
+async fn an_unknown_ref_redacts_the_credentials_the_repository_url_carries() {
+    let err = resolve_ref(
+        &stub(""),
+        "https://hunter2:x-oauth-basic@github.com/foo/bar.git",
+        "no-such-branch",
+        None,
+    )
+    .await
+    .expect_err("unknown ref");
+
+    assert!(!err.to_string().contains("hunter2"), "{err}");
+}

--- a/pnpm/crates/resolving-git-resolver/src/resolve_ref/tests.rs
+++ b/pnpm/crates/resolving-git-resolver/src/resolve_ref/tests.rs
@@ -123,16 +123,42 @@ fn parse_ls_remote_ignores_blank_lines() {
     assert_eq!(refs.get("refs/heads/main").map(String::as_str), Some("abc"));
 }
 
+const AUTHENTICATED_REPO: &str = "https://hunter2:x-oauth-basic@github.com/foo/bar.git";
+
+/// The whole `user:pass@` goes, not just one half of it — a GitHub token is
+/// the *user* in `<token>:x-oauth-basic@` — while the part of the URL that
+/// tells the reader which repository failed stays.
+#[track_caller]
+fn assert_repo_redacted(err: &GitResolveRefError) {
+    let message = err.to_string();
+    assert!(!message.contains("hunter2"), "{message}");
+    assert!(!message.contains("x-oauth-basic"), "{message}");
+    assert!(message.contains("https://github.com/foo/bar.git"), "{message}");
+}
+
 #[tokio::test]
 async fn an_unknown_ref_redacts_the_credentials_the_repository_url_carries() {
-    let err = resolve_ref(
-        &stub(""),
-        "https://hunter2:x-oauth-basic@github.com/foo/bar.git",
-        "no-such-branch",
-        None,
-    )
-    .await
-    .expect_err("unknown ref");
+    let err = resolve_ref(&stub(""), AUTHENTICATED_REPO, "no-such-branch", None)
+        .await
+        .expect_err("unknown ref");
 
-    assert!(!err.to_string().contains("hunter2"), "{err}");
+    assert_repo_redacted(&err);
+}
+
+#[tokio::test]
+async fn an_unparsable_range_redacts_the_credentials_the_repository_url_carries() {
+    let err = resolve_ref(&stub(""), AUTHENTICATED_REPO, "HEAD", Some("not-a-range"))
+        .await
+        .expect_err("unparsable range");
+
+    assert_repo_redacted(&err);
+}
+
+#[tokio::test]
+async fn a_range_matching_no_tag_redacts_the_credentials_the_repository_url_carries() {
+    let err = resolve_ref(&stub(""), AUTHENTICATED_REPO, "HEAD", Some("^1.0.0"))
+        .await
+        .expect_err("no matching tag");
+
+    assert_repo_redacted(&err);
 }

--- a/pnpm/crates/resolving-git-resolver/src/runners.rs
+++ b/pnpm/crates/resolving-git-resolver/src/runners.rs
@@ -135,13 +135,23 @@ fn run_ls_remote_blocking(
                 last_err = Some(String::from_utf8_lossy(&out.stderr).into_owned());
             }
             Err(err) => {
-                last_err = Some(err.to_string());
+                last_err = Some(spawn_failure(&err));
             }
         }
     }
     Err(GitRunError {
         message: last_err.unwrap_or_else(|| "ls-remote failed with unknown error".to_string()),
     })
+}
+
+/// pnpm does not bundle git, so a missing binary is a setup problem rather
+/// than a transport one and is worth saying outright.
+fn spawn_failure(err: &std::io::Error) -> String {
+    if err.kind() == std::io::ErrorKind::NotFound {
+        return "`git` executable not found on PATH. Install git to resolve git-hosted packages."
+            .to_string();
+    }
+    err.to_string()
 }
 
 fn ls_remote_command(bin: Option<&PathBuf>, repo: &str, ref_: Option<&str>) -> Command {

--- a/pnpm/crates/resolving-git-resolver/src/runners/tests.rs
+++ b/pnpm/crates/resolving-git-resolver/src/runners/tests.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use pacquet_network::ThrottledClient;
 
-use super::{RealGitProbe, ls_remote_command};
-use crate::git_resolver::GitProbe;
+use super::{RealGitProbe, RealGitRunner, ls_remote_command};
+use crate::{git_resolver::GitProbe, resolve_ref::GitCommandRunner};
 
 fn args(ref_: Option<&str>) -> Vec<String> {
     ls_remote_command(None, "--upload-pack=malicious", ref_)
@@ -85,4 +85,16 @@ async fn head_probe_retries_transient_statuses_to_exhaustion() {
         server.mock("HEAD", "/foo/bar/tar.gz/abc").with_status(429).expect(3).create_async().await;
     assert!(!real_probe().anonymous_head_ok(&format!("{}/foo/bar/tar.gz/abc", server.url())).await);
     mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn a_missing_git_binary_is_reported_as_one() {
+    let runner = RealGitRunner { git_bin: Some("/nonexistent/git".into()) };
+
+    let err = runner.ls_remote("https://github.com/foo/bar.git", None).await.unwrap_err();
+
+    assert_eq!(
+        err.to_string(),
+        "git ls-remote failed: `git` executable not found on PATH. Install git to resolve git-hosted packages.",
+    );
 }

--- a/pnpm/crates/resolving-git-resolver/src/runners/tests.rs
+++ b/pnpm/crates/resolving-git-resolver/src/runners/tests.rs
@@ -87,6 +87,9 @@ async fn head_probe_retries_transient_statuses_to_exhaustion() {
     mock.assert_async().await;
 }
 
+// Every production `RealGitRunner` leaves `git_bin` unset and spawns `git`
+// from `PATH`, so a configured missing path is the portable way to make the
+// spawn fail; the message asserted here is the one a user without git gets.
 #[tokio::test]
 async fn a_missing_git_binary_is_reported_as_one() {
     let runner = RealGitRunner { git_bin: Some("/nonexistent/git".into()) };

--- a/pnpm/crates/resolving-resolver-base/src/errors.rs
+++ b/pnpm/crates/resolving-resolver-base/src/errors.rs
@@ -13,7 +13,7 @@ use std::fmt::{self, Write as _};
 use chrono::{Local, TimeDelta, Utc};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
-use pacquet_network::hide_auth_information;
+use pacquet_network::{hide_auth_information, redact_and_sanitize, redact_and_sanitize_multiline};
 use pacquet_registry::Package;
 
 /// `ERR_PNPM_NO_MATCHING_VERSION`: the registry served the package's
@@ -218,6 +218,81 @@ fn consume_trailing_digits(bytes: &[u8], end: usize) -> usize {
 
 fn is_semver(candidate: &str) -> bool {
     candidate.parse::<node_semver::Version>().is_ok()
+}
+
+/// `ERR_PNPM_GIT_RESOLVE_FAILED`: `git ls-remote` could not reach the remote a
+/// git specifier points at, so its committish cannot be pinned to a commit.
+///
+/// Distinct from the failures that describe the refs a remote *did* serve (an
+/// unknown ref, an ambiguous commit-ish): those already name the repository
+/// they came from and need no remediation.
+///
+/// [`Diagnostic`] is implemented by hand because the help is conditional.
+#[derive(Debug, Display, Error)]
+#[display("Failed to resolve git dependency {specifier:?}: {detail}")]
+pub struct GitResolveError {
+    #[error(not(source))]
+    pub specifier: String,
+    /// What git reported, redacted.
+    pub detail: String,
+    pub hint: Option<String>,
+}
+
+impl Diagnostic for GitResolveError {
+    fn code(&self) -> Option<Box<dyn fmt::Display + '_>> {
+        Some(Box::new("ERR_PNPM_GIT_RESOLVE_FAILED"))
+    }
+
+    fn help(&self) -> Option<Box<dyn fmt::Display + '_>> {
+        self.hint.as_ref().map(|hint| Box::new(hint) as Box<dyn fmt::Display + '_>)
+    }
+}
+
+impl GitResolveError {
+    /// `repo` is the remote the resolution went to; `detail` is git's own
+    /// account of the failure, which can echo back a URL carrying
+    /// `user:pass@` credentials and is redacted here.
+    #[must_use]
+    pub fn new(specifier: &str, repo: &str, detail: &str) -> Self {
+        Self {
+            specifier: redact_and_sanitize(specifier),
+            detail: redact_and_sanitize_multiline(detail),
+            hint: https_transport_hint(repo),
+        }
+    }
+}
+
+/// Guidance for a specifier that resolved over HTTPS on a machine whose git
+/// cannot use that transport, or `None` when the resolution already went over
+/// SSH — there, the transport that failed is the one the specifier asked for.
+///
+/// Substituting the transport is git's job rather than pnpm's: the URL pnpm
+/// records has to work for every machine that installs the lockfile, while
+/// `insteadOf` rewrites it for this one only.
+fn https_transport_hint(repo: &str) -> Option<String> {
+    let (scheme, authority) = repo.split_once("://")?;
+    if scheme != "https" && scheme != "http" {
+        return None;
+    }
+    let host = authority.split('/').next().unwrap_or(authority);
+    let host = host.rsplit_once('@').map_or(host, |(_userinfo, host)| host);
+    if host.is_empty() {
+        return None;
+    }
+    // A bracketed IPv6 literal is full of colons, so the port has to be looked
+    // for after the closing bracket rather than at the first colon.
+    let hostname = match host.split_once(']') {
+        Some((address, _port)) if host.starts_with('[') => &host[..=address.len()],
+        _ => host.split_once(':').map_or(host, |(hostname, _port)| hostname),
+    };
+    let (host, hostname) = (redact_and_sanitize(host), redact_and_sanitize(hostname));
+    Some(format!(
+        r#"pnpm resolves this specifier over HTTPS because it does not ask for SSH, and the URL it records has to work on every machine that installs the lockfile.
+
+If git can only reach {hostname} over SSH here, substitute the transport locally, leaving the recorded URL alone:
+
+    git config --global url."git@{hostname}:".insteadOf "{scheme}://{host}/""#,
+    ))
 }
 
 #[cfg(test)]

--- a/pnpm/crates/resolving-resolver-base/src/errors.rs
+++ b/pnpm/crates/resolving-resolver-base/src/errors.rs
@@ -220,8 +220,9 @@ fn is_semver(candidate: &str) -> bool {
     candidate.parse::<node_semver::Version>().is_ok()
 }
 
-/// `ERR_PNPM_GIT_RESOLVE_FAILED`: `git ls-remote` could not reach the remote a
-/// git specifier points at, so its committish cannot be pinned to a commit.
+/// `ERR_PNPM_GIT_RESOLVE_FAILED`: a git specifier's `git ls-remote` failed —
+/// the remote was unreachable, refused the request, or git could not be run —
+/// so the committish cannot be pinned to a commit.
 ///
 /// Distinct from the failures that describe the refs a remote *did* serve (an
 /// unknown ref, an ambiguous commit-ish): those already name the repository
@@ -285,6 +286,10 @@ fn https_transport_hint(repo: &str) -> Option<String> {
         Some((address, _port)) if host.starts_with('[') => &host[..=address.len()],
         _ => host.split_once(':').map_or(host, |(hostname, _port)| hostname),
     };
+    // The scheme's own port is dropped from the `insteadOf` prefix, matching
+    // what git and the TypeScript CLI's `URL` both normalize the remote to.
+    let default_port = if scheme == "https" { ":443" } else { ":80" };
+    let host = host.strip_suffix(default_port).unwrap_or(host);
     let (host, hostname) = (redact_and_sanitize(host), redact_and_sanitize(hostname));
     Some(format!(
         r#"pnpm resolves this specifier over HTTPS because it does not ask for SSH, and the URL it records has to work on every machine that installs the lockfile.

--- a/pnpm/crates/resolving-resolver-base/src/errors/tests.rs
+++ b/pnpm/crates/resolving-resolver-base/src/errors/tests.rs
@@ -5,8 +5,8 @@ use miette::Diagnostic;
 use pacquet_registry::{DerivedPackuments, Package, PackageDistribution, PackageVersion};
 
 use super::{
-    NoMatchingVersionError, RegistryResponseError, RegistryResponseErrorOptions, stringify_date,
-    strip_trailing_semver_suffix,
+    GitResolveError, NoMatchingVersionError, RegistryResponseError, RegistryResponseErrorOptions,
+    stringify_date, strip_trailing_semver_suffix,
 };
 
 fn make_package(name: &str, versions: &[&str], dist_tags: &[(&str, &str)]) -> Package {
@@ -207,4 +207,66 @@ fn a_plain_name_suggests_nothing() {
     assert_eq!(strip_trailing_semver_suffix("@scope/pkg"), None);
     assert_eq!(strip_trailing_semver_suffix("is-odd@latest"), None);
     assert_eq!(strip_trailing_semver_suffix("4.17.21"), None);
+}
+
+#[test]
+fn an_unreachable_https_remote_explains_the_transport_and_how_to_substitute_it() {
+    let err = GitResolveError::new(
+        "zkochan/is-negative#next",
+        "https://github.com/zkochan/is-negative.git",
+        "git ls-remote failed: fatal: unable to access",
+    );
+
+    assert_eq!(err.code().expect("code").to_string(), "ERR_PNPM_GIT_RESOLVE_FAILED");
+    assert_eq!(
+        err.to_string(),
+        r#"Failed to resolve git dependency "zkochan/is-negative#next": git ls-remote failed: fatal: unable to access"#,
+    );
+    let help = err.help().expect("help").to_string();
+    assert!(
+        help.contains(
+            r#"git config --global url."git@github.com:".insteadOf "https://github.com/""#
+        ),
+        "{help}",
+    );
+}
+
+#[test]
+fn an_unreachable_ssh_remote_carries_no_transport_substitution_hint() {
+    let err = GitResolveError::new(
+        "git+ssh://git@github.com/foo/bar.git",
+        "git+ssh://git@github.com/foo/bar.git",
+        "git ls-remote failed: Permission denied (publickey)",
+    );
+
+    assert!(err.help().is_none());
+}
+
+#[test]
+fn the_transport_hint_keeps_a_non_default_port_out_of_the_ssh_remote() {
+    let err = GitResolveError::new(
+        "https://git.example.com:8443/foo/bar.git",
+        "https://git.example.com:8443/foo/bar.git",
+        "git ls-remote failed: connection refused",
+    );
+
+    let help = err.help().expect("help").to_string();
+    assert!(
+        help.contains(
+            r#"git config --global url."git@git.example.com:".insteadOf "https://git.example.com:8443/""#
+        ),
+        "{help}",
+    );
+}
+
+#[test]
+fn an_unreachable_remote_redacts_the_credentials_git_echoes_back() {
+    let err = GitResolveError::new(
+        "git+https://hunter2:x-oauth-basic@github.com/foo/bar.git",
+        "https://hunter2:x-oauth-basic@github.com/foo/bar.git",
+        "git ls-remote failed: fatal: unable to access 'https://hunter2:x-oauth-basic@github.com/foo/bar.git/'",
+    );
+
+    assert!(!err.to_string().contains("hunter2"), "{err}");
+    assert!(!err.help().expect("help").to_string().contains("hunter2"));
 }

--- a/pnpm/crates/resolving-resolver-base/src/errors/tests.rs
+++ b/pnpm/crates/resolving-resolver-base/src/errors/tests.rs
@@ -270,3 +270,20 @@ fn an_unreachable_remote_redacts_the_credentials_git_echoes_back() {
     assert!(!err.to_string().contains("hunter2"), "{err}");
     assert!(!err.help().expect("help").to_string().contains("hunter2"));
 }
+
+#[test]
+fn the_transport_hint_drops_the_scheme_s_own_port() {
+    let err = GitResolveError::new(
+        "https://github.com:443/foo/bar.git",
+        "https://github.com:443/foo/bar.git",
+        "git ls-remote failed: connection refused",
+    );
+
+    let help = err.help().expect("help").to_string();
+    assert!(
+        help.contains(
+            r#"git config --global url."git@github.com:".insteadOf "https://github.com/""#
+        ),
+        "{help}",
+    );
+}

--- a/pnpm/crates/resolving-resolver-base/src/lib.rs
+++ b/pnpm/crates/resolving-resolver-base/src/lib.rs
@@ -24,7 +24,9 @@ mod resolve;
 mod semver_range;
 mod verifier;
 
-pub use errors::{NoMatchingVersionError, RegistryResponseError, RegistryResponseErrorOptions};
+pub use errors::{
+    GitResolveError, NoMatchingVersionError, RegistryResponseError, RegistryResponseErrorOptions,
+};
 pub use peer_range::{get_peer_version_range, is_acceptable_peer_spec, is_valid_peer_range};
 pub use publish_time::parse_packument_timestamp;
 pub use resolve::{

--- a/pnpm11/resolving/git-resolver/src/index.ts
+++ b/pnpm11/resolving/git-resolver/src/index.ts
@@ -174,7 +174,7 @@ function resolveRefFromRefs (refs: { [ref: string]: string }, repo: string, ref:
       if (commits.length === 1) {
         commitId = commits[0]
       } else {
-        throw new Error(`Could not resolve ${ref} to a commit of ${repo}.`)
+        throw new Error(`Could not resolve ${ref} to a commit of ${redactAndSanitize(repo)}.`)
       }
     }
 
@@ -197,7 +197,7 @@ function resolveRefFromRefs (refs: { [ref: string]: string }, repo: string, ref:
         refs[`refs/tags/${refVTag}`])
 
     if (!commitId) {
-      throw new Error(`Could not resolve ${range} to a commit of ${repo}. Available versions are: ${vTags.join(', ')}`)
+      throw new Error(`Could not resolve ${range} to a commit of ${redactAndSanitize(repo)}. Available versions are: ${vTags.join(', ')}`)
     }
 
     return commitId

--- a/pnpm11/resolving/git-resolver/src/index.ts
+++ b/pnpm11/resolving/git-resolver/src/index.ts
@@ -1,4 +1,7 @@
-import { PnpmError } from '@pnpm/error'
+import assert from 'node:assert'
+import util from 'node:util'
+
+import { PnpmError, redactAndSanitize } from '@pnpm/error'
 import type { DispatcherOptions } from '@pnpm/network.fetch'
 import type { GitResolution, LatestInfo, LatestQuery, PkgResolutionId, ResolveOptions, ResolveResult, TarballResolution } from '@pnpm/resolving.resolver-base'
 import semver from 'semver'
@@ -55,7 +58,13 @@ export function createGitResolver (
     const bareSpecifier = parsedSpec.gitCommittish == null || parsedSpec.gitCommittish === ''
       ? 'HEAD'
       : parsedSpec.gitCommittish
-    const commit = await resolveRef(parsedSpec.fetchSpec, bareSpecifier, parsedSpec.gitRange)
+    let commit: string
+    try {
+      commit = await resolveRef(parsedSpec.fetchSpec, bareSpecifier, parsedSpec.gitRange)
+    } catch (err: unknown) {
+      assert(util.types.isNativeError(err))
+      throw gitResolveError(err, wantedDependency.bareSpecifier, parsedSpec.fetchSpec)
+    }
     let resolution: GitResolution | TarballResolution | undefined
 
     if ((parsedSpec.hosted != null) && !isSsh(parsedSpec.fetchSpec)) {
@@ -193,6 +202,48 @@ function resolveRefFromRefs (refs: { [ref: string]: string }, repo: string, ref:
 
     return commitId
   }
+}
+
+/**
+ * Restate a failure to reach the remote as `ERR_PNPM_GIT_RESOLVE_FAILED`,
+ * naming the dependency it was resolving. Errors that describe the refs the
+ * remote did return (an unknown ref, an ambiguous commit-ish) already say
+ * which repository they came from and are left alone.
+ */
+function gitResolveError (err: Error, bareSpecifier: string, repo: string): Error {
+  if ((err as { code?: string }).code !== 'ERR_PNPM_GIT_LS_REMOTE_FAILED') return err
+  return new PnpmError(
+    'GIT_RESOLVE_FAILED',
+    `Failed to resolve git dependency "${redactAndSanitize(bareSpecifier)}": ${err.message}`,
+    { hint: httpsTransportHint(repo) }
+  )
+}
+
+/**
+ * Guidance for a specifier that resolved over HTTPS on a machine whose git
+ * cannot use that transport, or `undefined` when the resolution already went
+ * over SSH — there, the transport that failed is the one the specifier asked
+ * for.
+ *
+ * Substituting the transport is git's job rather than pnpm's: the URL pnpm
+ * records has to work for every machine that installs the lockfile, while
+ * `insteadOf` rewrites it for this one only.
+ */
+function httpsTransportHint (repo: string): string | undefined {
+  let url: URL
+  try {
+    url = new URL(repo)
+  } catch {
+    return undefined
+  }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') return undefined
+  const host = redactAndSanitize(url.host)
+  const hostname = redactAndSanitize(url.hostname)
+  return `pnpm resolves this specifier over HTTPS because it does not ask for SSH, and the URL it records has to work on every machine that installs the lockfile.
+
+If git can only reach ${hostname} over SSH here, substitute the transport locally, leaving the recorded URL alone:
+
+    git config --global url."git@${hostname}:".insteadOf "${url.protocol}//${host}/"`
 }
 
 function isSsh (gitSpec: string): boolean {

--- a/pnpm11/resolving/git-resolver/src/index.ts
+++ b/pnpm11/resolving/git-resolver/src/index.ts
@@ -205,10 +205,10 @@ function resolveRefFromRefs (refs: { [ref: string]: string }, repo: string, ref:
 }
 
 /**
- * Restate a failure to reach the remote as `ERR_PNPM_GIT_RESOLVE_FAILED`,
- * naming the dependency it was resolving. Errors that describe the refs the
- * remote did return (an unknown ref, an ambiguous commit-ish) already say
- * which repository they came from and are left alone.
+ * Restate a failed `git ls-remote` as `ERR_PNPM_GIT_RESOLVE_FAILED`, naming the
+ * dependency it was resolving. Errors that describe the refs the remote did
+ * return (an unknown ref, an ambiguous commit-ish) already say which repository
+ * they came from and are left alone.
  */
 function gitResolveError (err: Error, bareSpecifier: string, repo: string): Error {
   if ((err as { code?: string }).code !== 'ERR_PNPM_GIT_LS_REMOTE_FAILED') return err

--- a/pnpm11/resolving/git-resolver/src/lsRemote.ts
+++ b/pnpm11/resolving/git-resolver/src/lsRemote.ts
@@ -1,3 +1,4 @@
+import { PnpmError, redactAndSanitizeMultiline } from '@pnpm/error'
 import { safeExeca as execa } from 'execa'
 
 /**
@@ -6,6 +7,8 @@ import { safeExeca as execa } from 'execa'
  * ls-remote invocations must go through this function to keep that guarantee.
  *
  * Failed runs are retried immediately, matching the Rust runner's policy.
+ * A run that fails every attempt throws `ERR_PNPM_GIT_LS_REMOTE_FAILED`,
+ * which the git resolver restates with the dependency it was resolving.
  */
 export async function lsRemote (args: string[], opts: { retries: number }): Promise<{ stdout: string }> {
   let lastErr: unknown
@@ -21,5 +24,23 @@ export async function lsRemote (args: string[], opts: { retries: number }): Prom
       lastErr = err
     }
   }
-  throw lastErr
+  throw lsRemoteError(lastErr)
+}
+
+/**
+ * git's stderr is untrusted: the repository URL it echoes back can carry
+ * `user:pass@` credentials, so it goes through
+ * {@link redactAndSanitizeMultiline} rather than being restated verbatim.
+ */
+function lsRemoteError (err: unknown): PnpmError {
+  return new PnpmError('GIT_LS_REMOTE_FAILED', `git ls-remote failed: ${redactAndSanitizeMultiline(lsRemoteFailureDetail(err))}`)
+}
+
+function lsRemoteFailureDetail (err: unknown): string {
+  if ((err as { code?: string }).code === 'ENOENT') {
+    return '`git` executable not found on PATH. Install git to resolve git-hosted packages.'
+  }
+  const stderr = (err as { stderr?: string }).stderr?.trim()
+  if (stderr != null && stderr !== '') return stderr
+  return (err as { message?: string }).message ?? String(err)
 }

--- a/pnpm11/resolving/git-resolver/src/parseBareSpecifier.ts
+++ b/pnpm11/resolving/git-resolver/src/parseBareSpecifier.ts
@@ -77,9 +77,16 @@ async function fromHostedGit (hosted: any, dispatcherOptions: DispatcherOptions)
   // (`shortcut`, `https`, ...) an SSH remote was never asked for, and recording one
   // in the lockfile breaks installs in environments without SSH keys, so every
   // HTTPS transport is exhausted first.
+  //
+  // Such a specifier therefore resolves over HTTPS whether or not git can reach
+  // the host that way on this machine, and its HTTPS access is not probed at all:
+  // the probe could not change what is recorded, and a machine that reaches the
+  // host only over SSH substitutes the transport itself through git's
+  // `url.<base>.insteadOf`. Only an explicit SSH URL, which HTTPS may displace,
+  // is worth the round-trip.
   const preferSsh = hosted.default === 'sshurl'
   const repoIsPublic = httpsUrl != null && await isRepoPublic(httpsUrl, dispatcherOptions)
-  if (httpsUrl && repoIsPublic && await accessRepository(httpsUrl)) {
+  if (httpsUrl && repoIsPublic && (!preferSsh || await accessRepository(httpsUrl))) {
     fetchSpec = httpsUrl
   }
   if (!fetchSpec && preferSsh && sshUrl && await accessRepository(sshUrl)) {

--- a/pnpm11/resolving/git-resolver/test/index.ts
+++ b/pnpm11/resolving/git-resolver/test/index.ts
@@ -617,6 +617,17 @@ test('an unreachable remote names the dependency and how to substitute the trans
   expect(err.hint).toContain('git config --global url."git@github.com:".insteadOf "https://github.com/"')
 })
 
+test('an unreachable remote redacts the credentials git echoes back', async () => {
+  mockGit(async () => {
+    throw Object.assign(new Error('Command failed with exit code 128'), {
+      stderr: "fatal: unable to access 'https://hunter2:x-oauth-basic@github.com/foo/bar.git/': not found",
+    })
+  })
+  const err = await resolveFailure(resolveFromGit({ bareSpecifier: 'git+https://hunter2:x-oauth-basic@github.com/foo/bar.git' }))
+  expect(err.message).not.toContain('hunter2')
+  expect(err.hint).not.toContain('hunter2')
+})
+
 test('a missing git binary is reported as one', async () => {
   mockGit(async () => {
     throw Object.assign(new Error('spawn git ENOENT'), { code: 'ENOENT' })

--- a/pnpm11/resolving/git-resolver/test/index.ts
+++ b/pnpm11/resolving/git-resolver/test/index.ts
@@ -2,6 +2,7 @@
 import path from 'node:path'
 
 import { beforeEach, expect, jest, test } from '@jest/globals'
+import type { PnpmError } from '@pnpm/error'
 import isWindows from 'is-windows'
 
 jest.unstable_mockModule('@pnpm/network.fetch', () => ({
@@ -578,6 +579,62 @@ test('resolve over HTTPS when the visibility probe fails but anonymous HTTPS git
   expect(gitCalls.flat().some((arg) => arg.includes('git@'))).toBe(false)
 })
 
+test('a public repository resolves over HTTPS without probing git access', async () => {
+  const gitCalls: string[][] = []
+  mockGit(async (args: string[]) => {
+    gitCalls.push(args)
+    return lsRemoteFromFixture(args)
+  })
+  await resolveFromGit({ bareSpecifier: 'zkochan/is-negative#master' })
+  expect(gitCalls).toStrictEqual([
+    ['ls-remote', '--', 'https://github.com/zkochan/is-negative.git', 'master', 'master^{}'],
+  ])
+})
+
+test('an explicit SSH specifier resolves over SSH when git cannot use HTTPS', async () => {
+  mockGit(async (args: string[]) => {
+    if (args.some((arg) => arg.startsWith('https://'))) throw new Error('SSL certificate problem')
+    return { stdout: '0'.repeat(40) + '\tHEAD' }
+  })
+  const resolveResult = await resolveFromGit({ bareSpecifier: 'git+ssh://git@github.com/foo/bar.git' })
+  expect(resolveResult?.resolution).toStrictEqual({
+    commit: '0'.repeat(40),
+    repo: 'git@github.com:foo/bar.git',
+    type: 'git',
+  })
+})
+
+// Covers https://github.com/pnpm/pnpm/issues/13743.
+test('an unreachable remote names the dependency and how to substitute the transport', async () => {
+  mockGit(async () => {
+    throw Object.assign(new Error('Command failed with exit code 128'), {
+      stderr: "fatal: unable to access 'https://github.com/zkochan/is-negative.git/': SSL certificate problem",
+    })
+  })
+  const err = await resolveFailure(resolveFromGit({ bareSpecifier: 'zkochan/is-negative#next' }))
+  expect(err.code).toBe('ERR_PNPM_GIT_RESOLVE_FAILED')
+  expect(err.message).toBe('Failed to resolve git dependency "zkochan/is-negative#next": git ls-remote failed: fatal: unable to access \'https://github.com/zkochan/is-negative.git/\': SSL certificate problem')
+  expect(err.hint).toContain('git config --global url."git@github.com:".insteadOf "https://github.com/"')
+})
+
+test('a missing git binary is reported as one', async () => {
+  mockGit(async () => {
+    throw Object.assign(new Error('spawn git ENOENT'), { code: 'ENOENT' })
+  })
+  const err = await resolveFailure(resolveFromGit({ bareSpecifier: 'zkochan/is-negative#master' }))
+  expect(err.message).toBe('Failed to resolve git dependency "zkochan/is-negative#master": git ls-remote failed: `git` executable not found on PATH. Install git to resolve git-hosted packages.')
+})
+
+test('an unreachable SSH remote carries no transport substitution hint', async () => {
+  mockFetchAsPrivate()
+  mockGit(async () => {
+    throw new Error('Permission denied (publickey)')
+  })
+  const err = await resolveFailure(resolveFromGit({ bareSpecifier: 'git+ssh://git@github.com/foo/bar.git' }))
+  expect(err.code).toBe('ERR_PNPM_GIT_RESOLVE_FAILED')
+  expect(err.hint).toBeUndefined()
+})
+
 test('resolve an explicit SSH specifier over SSH when only SSH access works', async () => {
   mockFetchAsPrivate()
   mockGit(async (args: string[]) => {
@@ -716,6 +773,15 @@ function mockFetchAsPrivate (): void {
   jest.mocked(fetchWithDispatcher).mockImplementation(async (_url, _opts) => {
     return { ok: false } as any // eslint-disable-line @typescript-eslint/no-explicit-any
   })
+}
+
+async function resolveFailure (resolving: Promise<unknown>): Promise<PnpmError> {
+  return resolving.then(
+    () => {
+      throw new Error('expected the git resolution to fail')
+    },
+    (err: unknown) => err as PnpmError
+  )
 }
 
 async function lsRemoteFromFixture (args: string[]): Promise<{ stdout: string }> {

--- a/pnpm11/resolving/git-resolver/test/index.ts
+++ b/pnpm11/resolving/git-resolver/test/index.ts
@@ -628,6 +628,14 @@ test('an unreachable remote redacts the credentials git echoes back', async () =
   expect(err.hint).not.toContain('hunter2')
 })
 
+test('an unresolvable ref redacts the credentials the repository URL carries', async () => {
+  mockGit(async () => ({ stdout: `${'0'.repeat(40)}\tHEAD` }))
+  mockFetchAsPrivate()
+  const err = await resolveFailure(resolveFromGit({ bareSpecifier: 'git+https://hunter2:x-oauth-basic@github.com/foo/bar.git#no-such-branch' }))
+  expect(err.message).toContain('Could not resolve no-such-branch to a commit of')
+  expect(err.message).not.toContain('hunter2')
+})
+
 test('a missing git binary is reported as one', async () => {
   mockGit(async () => {
     throw Object.assign(new Error('spawn git ENOENT'), { code: 'ENOENT' })

--- a/pnpm11/resolving/git-resolver/test/index.ts
+++ b/pnpm11/resolving/git-resolver/test/index.ts
@@ -625,15 +625,24 @@ test('an unreachable remote redacts the credentials git echoes back', async () =
   })
   const err = await resolveFailure(resolveFromGit({ bareSpecifier: 'git+https://hunter2:x-oauth-basic@github.com/foo/bar.git' }))
   expect(err.message).not.toContain('hunter2')
+  expect(err.message).not.toContain('x-oauth-basic')
   expect(err.hint).not.toContain('hunter2')
 })
 
-test('an unresolvable ref redacts the credentials the repository URL carries', async () => {
+test.each([
+  ['an unresolvable ref', 'no-such-branch', 'Could not resolve no-such-branch to a commit of'],
+  ['a range matching no tag', 'semver:^1.0.0', 'Could not resolve ^1.0.0 to a commit of'],
+])('%s redacts the credentials the repository URL carries', async (_name, committish, expected) => {
   mockGit(async () => ({ stdout: `${'0'.repeat(40)}\tHEAD` }))
   mockFetchAsPrivate()
-  const err = await resolveFailure(resolveFromGit({ bareSpecifier: 'git+https://hunter2:x-oauth-basic@github.com/foo/bar.git#no-such-branch' }))
-  expect(err.message).toContain('Could not resolve no-such-branch to a commit of')
+  const err = await resolveFailure(resolveFromGit({ bareSpecifier: `git+https://hunter2:x-oauth-basic@github.com/foo/bar.git#${committish}` }))
+  expect(err.message).toContain(expected)
+  // The whole `user:pass@` goes, not just one half of it — a GitHub token is
+  // the *user* in `<token>:x-oauth-basic@` — while the part of the URL that
+  // tells the reader which repository failed stays.
   expect(err.message).not.toContain('hunter2')
+  expect(err.message).not.toContain('x-oauth-basic')
+  expect(err.message).toContain('https://github.com/foo/bar.git')
 })
 
 test('a missing git binary is reported as one', async () => {


### PR DESCRIPTION
## Summary

Follow-up on [pnpm/pnpm#13743](https://github.com/pnpm/pnpm/issues/13743). The reporter's newest failure is not the stale lockfile the issue started with — it is resolution itself, in a dev container whose git cannot do HTTPS (no CA certificates in the OpenSSL store; Node's fetch is unaffected because it carries its own roots). Reproduced with `GIT_SSL_CAINFO=/dev/null` and a `git` wrapper logging argv:

```
GITCALL: ls-remote --exit-code https://github.com/logux/core.git HEAD   <- probe, fails
GITCALL: ls-remote -- https://github.com/logux/core.git next next^{}    <- used anyway, fails
```

Two things came out of that trace.

**The error said nothing useful.** A raw execa dump plus a JS stack, naming neither the dependency nor a way forward. Now:

```
[ERR_PNPM_GIT_RESOLVE_FAILED] Failed to resolve git dependency "github:logux/core#next": git ls-remote
failed: fatal: unable to access 'https://github.com/logux/core.git/': error adding trust anchors...

pnpm resolves this specifier over HTTPS because it does not ask for SSH, and the URL it records has to
work on every machine that installs the lockfile.

If git can only reach github.com over SSH here, substitute the transport locally, leaving the recorded
URL alone:

    git config --global url."git@github.com:".insteadOf "https://github.com/"
```

Verified end-to-end in both stacks against that repro (TypeScript bundle and a locally built pacquet render the same code, message, and help). `url.<base>.insteadOf` is the right escape hatch rather than a pnpm-side SSH fallback: pnpm shells out to plain `git`, so the rewrite applies to the exact `ls-remote` call — verified — and unlike a fallback it changes nothing about what the lockfile records. It also matches what pacquet's `parse_bare_specifier` module doc already says about transport being the machine's business.

**The HTTPS access probe's answer was thrown away.** For a repository the visibility HEAD probe proved public, both outcomes of `accessRepository(httpsUrl)` land on the same `fetchSpec` and the same returned object, so the probe's only effect was one extra `git ls-remote` per git dependency (measured 0.45–0.48s). It is now skipped there and kept where it decides something: an explicitly written SSH URL, and repositories not provably public. pacquet never probed, so this brings the TypeScript CLI to its behavior. Confirmed unchanged resolutions — the existing 78 resolver tests pass untouched, and a real `pnpm add github:zkochan/is-negative#master` records the identical codeload tarball with one `ls-remote` instead of two.

Notes on the details:

- **A missing `git` binary now says so** instead of surfacing `spawn git ENOENT` / `No such file or directory (os error 2)`, with the same sentence in both stacks.
- **The hint is gated structurally** — on the resolution having gone over HTTPS — not by parsing git's stderr, the same choice [pnpm/pnpm#13759](https://github.com/pnpm/pnpm/pull/13759) made for the fetcher.
- **Only the unreachable-remote failure is restated.** An unknown ref or an ambiguous commit-ish describes refs the remote *did* serve, already names its repository, and has no remediation to offer.
- **pacquet needs the diagnostic to survive `ResolveError`'s type erasure**, which drops the `miette::Diagnostic` facet. `resolving-resolver-base/src/errors.rs` documents the mechanism for exactly this — box outermost, recover by downcast — so the new `GitResolveError` lives there and is downcast in the tree walker and in `add`. The walker's optional-dependency skip list gains the new variant so an unreachable optional git dep still degrades the way it did.
- Left alone, as on the issue: `--resolution-only` does not re-resolve git dependencies despite its help text. Separate bug.

Related to [pnpm/pnpm#13743](https://github.com/pnpm/pnpm/issues/13743).

## Squash Commit Body

```text
A specifier that does not ask for SSH resolves over HTTPS, because the URL
pnpm records is shared by every machine that installs the lockfile
(pnpm/pnpm#13290). On a machine whose git cannot use that transport - a
container without the host's CA certificates, say - resolution then failed
with a raw execa dump: "Command failed with exit code 128: git ls-remote --
'https://github.com/...'" and a JS stack, naming neither the dependency nor
a way forward.

A failed ls-remote is now ERR_PNPM_GIT_RESOLVE_FAILED, naming the dependency
and redacting the credentials a URL git echoes back can carry. When the
resolution went over HTTPS, the error also says why, and points at git's own
url.<base>.insteadOf to substitute the transport on this machine only,
leaving the recorded URL alone. A missing git binary says so instead of
surfacing a bare spawn error.

The TypeScript resolver also stops probing anonymous HTTPS git access for a
repository the visibility probe already proved public: both outcomes of that
probe recorded the same resolution, so its only effect was an extra
ls-remote round-trip per git dependency. pacquet never probed.

Carrying the code and the remediation across pacquet's type-erased resolver
seam takes the mechanism resolver-base documents for exactly that: the
diagnostic is boxed outermost and recovered by downcast, in the tree walker
and in add.

Related to pnpm/pnpm#13743.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5[1m]).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13794"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788996466&installation_model_id=426870&pr_number=13794&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13794&signature=8ff1aa5d37757281b8082f0c4b12659928ea644b35be3e0c9d22dea293d93b4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git dependency resolution errors with clearer messages and the `ERR_PNPM_GIT_RESOLVE_FAILED` code.
  * Dependency names and repository details are now shown safely with credentials redacted.
  * Added guidance for switching HTTPS repositories to SSH when appropriate.
  * Improved messages when Git is unavailable or remote repositories cannot be reached.
  * Public repositories no longer receive an unnecessary preliminary connectivity check.
* **Tests**
  * Added coverage for Git transport selection, error details, credential redaction, and missing Git installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->