### PR TITLE
feat: absorb a parent-scoped override into the fast lockfile update

### DIFF
--- a/.changeset/parent-scoped-overrides.md
+++ b/.changeset/parent-scoped-overrides.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.deps-installer": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+Changing a parent-scoped `pnpm.overrides` entry (`"parent>child": "2.0.0"`) now updates the lockfile in place instead of re-resolving the whole dependency graph. Only the named parent's dependency moves; every other package keeps the version it had [#13795](https://github.com/pnpm/pnpm/issues/13795).

--- a/pnpm/crates/package-manager/src/fast_update_overrides.rs
+++ b/pnpm/crates/package-manager/src/fast_update_overrides.rs
@@ -139,7 +139,6 @@ fn build_rewrite_plan(
         let removes_dependency = new_value == "-";
         if parsed.target_pkg.bare_specifier.is_some()
             || parsed.converge
-            || !removes_dependency && parsed.parent_pkg.is_some()
             || parsed_overrides.iter().any(|candidate| {
                 candidate.selector != *selector
                     && candidate.target_pkg.name == parsed.target_pkg.name
@@ -437,6 +436,11 @@ fn rewrite_importer_dependencies(
     for (alias, spec) in map.iter_mut() {
         let Some(old_key) = spec.version.resolved_key(alias) else { continue };
         let Some(new_key) = plan.replacements.get(&old_key) else { continue };
+        // An importer is not a package, so a `parent>child` selector never
+        // names it — the same exit removals take here.
+        if !should_replace_dependency(alias, None, &plan.overrides) {
+            continue;
+        }
         spec.version = ImporterDepVersion::Regular(new_key.suffix.clone());
     }
     if map.is_empty() {
@@ -465,6 +469,9 @@ fn rewrite_snapshot_dependency_map(
     for (alias, dep_ref) in dependencies {
         let Some(old_key) = dep_ref.resolve(alias) else { continue };
         let Some(new_key) = plan.replacements.get(&old_key) else { continue };
+        if !should_replace_dependency(alias, parent_key, &plan.overrides) {
+            continue;
+        }
         *dep_ref = SnapshotDepRef::Plain(new_key.suffix.clone());
     }
 }
@@ -475,21 +482,44 @@ fn should_remove_dependency(
     overrides: &[FastOverride],
 ) -> bool {
     overrides.iter().any(|override_entry| {
-        if override_entry.new_version.is_some() || override_entry.name != *alias {
-            return false;
-        }
-        let Some(parent) = override_entry.parent.as_ref() else { return true };
-        let Some(parent_key) = parent_key else { return false };
-        if parent_key.name.to_string() != parent.name {
-            return false;
-        }
-        match parent.bare_specifier.as_deref() {
-            None => true,
-            Some(range) => parent_key.suffix.version_semver().is_some_and(|version| {
-                Range::parse(range).is_ok_and(|range| range.satisfies(version))
-            }),
-        }
+        override_entry.new_version.is_none()
+            && override_entry.name == *alias
+            && override_applies_to(override_entry, parent_key)
     })
+}
+
+/// Whether an edge on `alias` owned by `parent_key` is one a replacing
+/// override moves. A `parent>child` selector names only the edges out of
+/// that parent, so other dependents keep the version they have and the
+/// shared prune decides whether it survives.
+fn should_replace_dependency(
+    alias: &PkgName,
+    parent_key: Option<&PackageKey>,
+    overrides: &[FastOverride],
+) -> bool {
+    overrides.iter().any(|override_entry| {
+        override_entry.new_version.is_some()
+            && override_entry.name == *alias
+            && override_applies_to(override_entry, parent_key)
+    })
+}
+
+/// Whether `override_entry`'s parent selector names `parent_key`. A
+/// selector without a parent names every edge; one with a parent names
+/// only edges out of a package it matches, which an importer never is.
+fn override_applies_to(override_entry: &FastOverride, parent_key: Option<&PackageKey>) -> bool {
+    let Some(parent) = override_entry.parent.as_ref() else { return true };
+    let Some(parent_key) = parent_key else { return false };
+    if parent_key.name.to_string() != parent.name {
+        return false;
+    }
+    match parent.bare_specifier.as_deref() {
+        None => true,
+        Some(range) => parent_key
+            .suffix
+            .version_semver()
+            .is_some_and(|version| Range::parse(range).is_ok_and(|range| range.satisfies(version))),
+    }
 }
 
 fn validate_dependencies(

--- a/pnpm/crates/package-manager/src/fast_update_overrides/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_overrides/tests.rs
@@ -591,3 +591,116 @@ async fn a_range_override_no_locked_version_satisfies_falls_back() {
     );
     assert_eq!(resolver.calls.load(Ordering::Relaxed), 0, "and it bails before resolving");
 }
+
+/// `parent` and `other` both depend on `target@1.0.0`, so a selector
+/// naming only `parent` has to leave `other` where it is.
+fn lockfile_with_two_dependents() -> Lockfile {
+    let mut lockfile = lockfile();
+    lockfile.overrides = None;
+    lockfile.packages.as_mut().expect("packages").insert(
+        "other@1.0.0".parse().expect("package key"),
+        serde_json::from_value(json!({ "resolution": { "integrity": "sha512-other" } }))
+            .expect("package"),
+    );
+    lockfile.snapshots.as_mut().expect("snapshots").insert(
+        "other@1.0.0".parse().expect("snapshot key"),
+        serde_json::from_value(json!({ "dependencies": { "target": "1.0.0" } })).expect("snapshot"),
+    );
+    lockfile
+        .importers
+        .get_mut(".")
+        .expect("importer")
+        .dependencies
+        .as_mut()
+        .expect("dependencies")
+        .insert(
+            "other".parse().expect("alias"),
+            serde_json::from_value(json!({ "specifier": "1.0.0", "version": "1.0.0" }))
+                .expect("dependency"),
+        );
+    lockfile
+}
+
+fn parent_scoped_override() -> Vec<VersionOverride> {
+    vec![VersionOverride {
+        selector: "parent>target".to_string(),
+        parent_pkg: Some(PackageSelector { name: "parent".to_string(), bare_specifier: None }),
+        target_pkg: PackageSelector { name: "target".to_string(), bare_specifier: None },
+        new_bare_specifier: "2.0.0".to_string(),
+        converge: false,
+    }]
+}
+
+#[tokio::test]
+async fn a_parent_scoped_override_moves_only_that_parents_edge() {
+    let lockfile = lockfile_with_two_dependents();
+    let overrides = IndexMap::from([("parent>target".to_string(), "2.0.0".to_string())]);
+    let resolver = StubResolver {
+        calls: AtomicUsize::new(0),
+        manifest: json!({ "name": "target", "version": "2.0.0", "dependencies": { "child": "^1.0.0" } }),
+    };
+
+    let updated = try_update(&lockfile, &parent_scoped_override(), &overrides, &resolver)
+        .await
+        .expect("moving one parent's edge needs no resolution");
+
+    let target: PkgName = "target".parse().expect("package name");
+    let edge_of = |owner: &str| {
+        updated
+            .snapshots
+            .as_ref()
+            .and_then(|snapshots| snapshots.get(&owner.parse().expect("snapshot key")))
+            .and_then(|snapshot| snapshot.dependencies.as_ref())
+            .and_then(|dependencies| dependencies.get(&target))
+            .map(ToString::to_string)
+    };
+    assert_eq!(edge_of("parent@1.0.0").as_deref(), Some("2.0.0"), "the named parent moves");
+    assert_eq!(edge_of("other@1.0.0").as_deref(), Some("1.0.0"), "the other dependent does not");
+    let mut keys: Vec<_> = updated
+        .snapshots
+        .as_ref()
+        .expect("snapshots")
+        .keys()
+        .map(ToString::to_string)
+        .filter(|key| key.starts_with("target@"))
+        .collect();
+    keys.sort();
+    assert_eq!(
+        keys,
+        vec!["target@1.0.0".to_string(), "target@2.0.0".to_string()],
+        "both versions survive, one per dependent",
+    );
+}
+
+#[tokio::test]
+async fn a_parent_scoped_override_prunes_the_old_version_when_nothing_else_holds_it() {
+    let mut lockfile = lockfile_with_two_dependents();
+    // `other` no longer reaches `target`, so the named parent is its last
+    // dependent and the version it leaves becomes unreachable.
+    lockfile
+        .snapshots
+        .as_mut()
+        .expect("snapshots")
+        .get_mut(&"other@1.0.0".parse().expect("snapshot key"))
+        .expect("other snapshot")
+        .dependencies = None;
+    let overrides = IndexMap::from([("parent>target".to_string(), "2.0.0".to_string())]);
+    let resolver = StubResolver {
+        calls: AtomicUsize::new(0),
+        manifest: json!({ "name": "target", "version": "2.0.0", "dependencies": { "child": "^1.0.0" } }),
+    };
+
+    let updated = try_update(&lockfile, &parent_scoped_override(), &overrides, &resolver)
+        .await
+        .expect("moving one parent's edge needs no resolution");
+
+    let keys: Vec<_> = updated
+        .snapshots
+        .as_ref()
+        .expect("snapshots")
+        .keys()
+        .map(ToString::to_string)
+        .filter(|key| key.starts_with("target@"))
+        .collect();
+    assert_eq!(keys, vec!["target@2.0.0".to_string()], "the version it left is unreachable");
+}

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateOverrides.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateOverrides.ts
@@ -34,6 +34,8 @@ interface RewriteContext {
   peerNames: Set<string>
   removals: FastOverride[]
   replacements: Map<DepPath, DepPath>
+  /** The replacing overrides, needed to scope a `parent>child` selector. */
+  moves: FastOverride[]
 }
 
 interface ResolverPolicyOptions {
@@ -83,6 +85,7 @@ export async function applyFastRewrite (
   settings: Partial<LockfileObject>
 ): Promise<boolean> {
   const removals = fastOverrides.filter(({ newVersion }) => newVersion == null)
+  const moves = fastOverrides.filter(({ newVersion }) => newVersion != null)
   const peerNames = getPeerNames(lockfile)
   if (removals.some(({ name }) => peerNames.has(name))) return false
 
@@ -94,7 +97,7 @@ export async function applyFastRewrite (
       .filter(({ newVersion }) => newVersion != null)
       .map(({ name }) => name)
   )
-  const rewriteContext = { changedNames, peerNames, removals, replacements }
+  const rewriteContext = { changedNames, peerNames, removals, replacements, moves }
   const manifests = await resolveNewManifests(fastOverrides, replacements, opts)
   if (manifests == null) return false
 
@@ -157,7 +160,6 @@ function getFastOverrides (
       override.targetPkg.bareSpecifier != null ||
       override.converge === true ||
       !removesDependency && (
-        override.parentPkg != null ||
         overriddenVersion(lockfile, override.targetPkg.name, newValue) == null ||
         oldVersion != null && semver.valid(oldVersion) == null
       ) ||
@@ -486,7 +488,7 @@ function validateAndRewriteDependencies (opts: {
     const lockedReference = lockedDependencies?.[name]
     const reference = lockedReference == null
       ? findReusableReference({ name, packages, range, rewriteContext })
-      : rewriteReference(name, lockedReference, rewriteContext)
+      : rewriteReference(name, lockedReference, rewriteContext, parentDepPath)
     if (reference == null) return null
     const depPath = dp.refToRelative(reference, name)
     const version = depPath == null ? null : dp.parse(depPath).version
@@ -584,7 +586,7 @@ function rewriteResolvedDependencies (
       .filter(([alias]) => !shouldRemoveDependency(alias, parentDepPath, rewriteContext.removals))
       .map(([alias, reference]) => [
         alias,
-        rewriteReference(alias, reference, rewriteContext),
+        rewriteReference(alias, reference, rewriteContext, parentDepPath),
       ])
   )
   return Object.keys(rewritten).length === 0 ? undefined : rewritten
@@ -595,16 +597,30 @@ function shouldRemoveDependency (
   parentDepPath: DepPath | undefined,
   removals: FastOverride[]
 ): boolean {
-  return removals.some((removal) => {
-    if (removal.name !== alias) return false
-    if (removal.parent == null) return true
+  return overrideApplies(alias, parentDepPath, removals)
+}
+
+/**
+ * Whether any of `overrides` names an edge on `alias` owned by
+ * `parentDepPath`. A selector without a parent names every edge; one with a
+ * parent names only edges out of a package it matches, which an importer
+ * never is.
+ */
+function overrideApplies (
+  alias: string,
+  parentDepPath: DepPath | undefined,
+  overrides: FastOverride[]
+): boolean {
+  return overrides.some((override) => {
+    if (override.name !== alias) return false
+    if (override.parent == null) return true
     if (parentDepPath == null) return false
     const parent = dp.parse(parentDepPath)
-    return parent.name === removal.parent.name &&
+    return parent.name === override.parent.name &&
       parent.version != null &&
       (
-        removal.parent.bareSpecifier == null ||
-        semver.satisfies(parent.version, removal.parent.bareSpecifier)
+        override.parent.bareSpecifier == null ||
+        semver.satisfies(parent.version, override.parent.bareSpecifier)
       )
   })
 }
@@ -612,9 +628,13 @@ function shouldRemoveDependency (
 function rewriteReference (
   alias: string,
   reference: string,
-  { changedNames, replacements }: RewriteContext
+  { changedNames, replacements, moves }: RewriteContext,
+  parentDepPath?: DepPath
 ): string {
   if (!changedNames.has(alias)) return reference
+  // A `parent>child` selector names only the edges out of that parent, so
+  // the other dependents keep the version they have.
+  if (!overrideApplies(alias, parentDepPath, moves)) return reference
   const oldDepPath = dp.refToRelative(reference, alias)
   if (oldDepPath == null) return reference
   const newDepPath = replacements.get(oldDepPath)

--- a/pnpm11/installing/deps-installer/test/install/overrideRangeFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/overrideRangeFastUpdate.ts
@@ -107,10 +107,19 @@ function makeSharedDependencyLockfile (): LockfileObject {
   } as unknown as LockfileObject
 }
 
-test('a parent-scoped override reaches the resolution step', async () => {
-  const requested: string[] = []
+/** Resolves `target` at whatever version is asked for, with no dependencies. */
+const resolveTarget = (async (wanted: { alias?: string, bareSpecifier?: string }) => ({
+  body: {
+    id: `${wanted.alias!}@${wanted.bareSpecifier!}`,
+    isLocal: false as const,
+    manifest: { name: wanted.alias!, version: wanted.bareSpecifier! },
+    resolution: { integrity: 'sha512-CCCC' },
+    resolvedVia: 'npm-registry',
+  },
+})) as unknown as RequestPackageFunction
 
-  await expect(tryFastUpdateOverrides(makeSharedDependencyLockfile(), {
+function parentScopedOpts (requestPackage: RequestPackageFunction) {
+  return {
     lockfileDir: '/test',
     overrides: { 'parent>target': '2.0.0' },
     parsedOverrides: [{
@@ -120,11 +129,32 @@ test('a parent-scoped override reaches the resolution step', async () => {
       parentPkg: { name: 'parent' },
     }],
     registries,
-    requestPackage: trackResolvedVersions(requested),
+    requestPackage,
     isLockfileUpToDate: async () => true,
-  } as never)).rejects.toThrow('reached the resolution step')
+  } as never
+}
 
-  // Getting this far is the assertion: the parent-scoped form used to bail
-  // before resolving anything.
-  expect(requested).toStrictEqual(['2.0.0'])
+test('a parent-scoped override moves only that parent\'s edge', async () => {
+  const lockfile = makeSharedDependencyLockfile()
+
+  expect(await tryFastUpdateOverrides(lockfile, parentScopedOpts(resolveTarget))).toBe(true)
+
+  expect(lockfile.packages!['parent@1.0.0' as DepPath].dependencies)
+    .toStrictEqual({ target: '2.0.0' })
+  expect(lockfile.packages!['other@1.0.0' as DepPath].dependencies)
+    .toStrictEqual({ target: '1.0.0' })
+  expect(Object.keys(lockfile.packages ?? {}).filter((key) => key.startsWith('target@')).sort())
+    .toStrictEqual(['target@1.0.0', 'target@2.0.0'])
+})
+
+test('a parent-scoped override prunes the version it leaves when nothing else holds it', async () => {
+  const lockfile = makeSharedDependencyLockfile()
+  // `other` no longer reaches `target`, so the named parent is its last
+  // dependent and the version it leaves becomes unreachable.
+  delete lockfile.packages!['other@1.0.0' as DepPath].dependencies
+
+  expect(await tryFastUpdateOverrides(lockfile, parentScopedOpts(resolveTarget))).toBe(true)
+
+  expect(Object.keys(lockfile.packages ?? {}).filter((key) => key.startsWith('target@')))
+    .toStrictEqual(['target@2.0.0'])
 })

--- a/pnpm11/installing/deps-installer/test/install/overrideRangeFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/overrideRangeFastUpdate.ts
@@ -79,3 +79,52 @@ test('an exact override still names the version it was given', async () => {
 
   expect(requested).toStrictEqual(['1.3.0'])
 })
+
+/**
+ * `parent` and `other` both depend on `target@1.0.0`, so a selector naming
+ * only `parent` has to leave `other` where it is.
+ */
+function makeSharedDependencyLockfile (): LockfileObject {
+  return {
+    lockfileVersion: LOCKFILE_VERSION,
+    importers: {
+      ['.' as ProjectId]: {
+        dependencies: { parent: '1.0.0', other: '1.0.0' },
+        specifiers: { parent: '1.0.0', other: '1.0.0' },
+      },
+    },
+    packages: {
+      ['parent@1.0.0' as DepPath]: {
+        resolution: { integrity: 'sha512-parent' },
+        dependencies: { target: '1.0.0' },
+      },
+      ['other@1.0.0' as DepPath]: {
+        resolution: { integrity: 'sha512-other' },
+        dependencies: { target: '1.0.0' },
+      },
+      ['target@1.0.0' as DepPath]: { resolution: { integrity: 'sha512-target' } },
+    },
+  } as unknown as LockfileObject
+}
+
+test('a parent-scoped override reaches the resolution step', async () => {
+  const requested: string[] = []
+
+  await expect(tryFastUpdateOverrides(makeSharedDependencyLockfile(), {
+    lockfileDir: '/test',
+    overrides: { 'parent>target': '2.0.0' },
+    parsedOverrides: [{
+      selector: 'parent>target',
+      newBareSpecifier: '2.0.0',
+      targetPkg: { name: 'target' },
+      parentPkg: { name: 'parent' },
+    }],
+    registries,
+    requestPackage: trackResolvedVersions(requested),
+    isLockfileUpToDate: async () => true,
+  } as never)).rejects.toThrow('reached the resolution step')
+
+  // Getting this far is the assertion: the parent-scoped form used to bail
+  // before resolving anything.
+  expect(requested).toStrictEqual(['2.0.0'])
+})


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#13795 — the half of item 6 of pnpm/pnpm#13696 left out when the range half landed in pnpm/pnpm#13792.

A parent-scoped override (`"parent>child": "2.0.0"`) bailed to the resolver in both stacks unless it was a removal. Measured what a full resolution actually does with one, before touching anything — `parent` and `other` both depending on `dep@100.0.0`, then overriding only `parent`'s edge:

- the named parent's edge moves to the new version;
- **the other dependents keep the version they had** — no deduplication onto the new one, which was the open question on the issue;
- the version left behind is pruned once nothing reaches it.

That turned out to be expressible with the plan as it stands. The apply step already inserts the new version *alongside* the old and leaves reachability to the shared prune, so the old key survives on its own whenever another dependent still points at it — I had expected to need per-edge plan entries and did not. What was actually missing is that the repoint ignored the selector's parent and moved every edge to the package.

It now consults the same predicate parent-scoped **removals** have always used, extracted so both share it (`override_applies_to` / `overrideApplies`). Importer edges keep the exit removals take there, since a `parent>child` selector never names an importer.

Both stacks are tested at the handler level: the named parent moves while the other dependent does not and both versions survive; the version left behind is pruned when it becomes unreachable. The pacquet scoping is break-tested — removing the parent check makes the "moves only that parent's edge" test fail.

## Squash Commit Body

```text
A parent-scoped override (parent>child) bailed to the resolver in both
stacks unless it was a removal. Measured what a full resolution does
with one: only the named parent's edge moves, the other dependents keep
the version they had, and the version left behind is pruned when
nothing reaches it any more.

That is expressible. The plan already inserts the new version alongside
the old and leaves reachability to the shared prune, so the old key
survives on its own whenever another dependent still points at it. What
was missing is that the repoint ignored the selector's parent and moved
every edge; it now consults the same predicate parent-scoped removals
already use, extracted so both share it. Importer edges keep the exit
removals take there, since a parent selector never names an importer.

Closes pnpm/pnpm#13795.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788997549&installation_model_id=426870&pr_number=13797&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13797&signature=eb8d2051b4e5338982f7c559d8693f2856c510dc678b82ed3be5d2985f3c2798"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of dependency overrides using semver ranges by selecting the highest compatible locked version when available.
  - Parent-scoped overrides now update only the specified dependency relationship while preserving versions used elsewhere.
  - Obsolete package versions are removed when no longer referenced.
- **Tests**
  - Added coverage for range-based overrides, parent-scoped updates, shared dependencies, fallback behavior, and package cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->