### PR TITLE
fix(patching): support non-ASCII patch paths

### DIFF
--- a/.changeset/bright-pandas-quote.md
+++ b/.changeset/bright-pandas-quote.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/patching.commands": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+Fixed `pnpm patch-commit` in project and edit paths containing non-ASCII characters.

--- a/pnpm/crates/patching/src/commit.rs
+++ b/pnpm/crates/patching/src/commit.rs
@@ -149,6 +149,8 @@ pub fn diff_folders(folder_a: &Path, folder_b: &Path) -> Result<String, PatchCom
     let status = Command::new("git")
         .arg("-c")
         .arg("core.safecrlf=false")
+        .arg("-c")
+        .arg("core.quotePath=false")
         .arg("diff")
         .arg("--src-prefix=a/")
         .arg("--dst-prefix=b/")

--- a/pnpm/crates/patching/src/commit/tests.rs
+++ b/pnpm/crates/patching/src/commit/tests.rs
@@ -25,6 +25,23 @@ fn patch_commit_diff_dirs_strips_absolute_temp_paths() {
 }
 
 #[test]
+fn patch_commit_diff_dirs_supports_non_ascii_paths() {
+    let root = tempdir().expect("root dir");
+    let before = root.path().join("이전");
+    let after = root.path().join("이후");
+    fs::create_dir(&before).unwrap();
+    fs::create_dir(&after).unwrap();
+    fs::write(before.join("index.js"), "module.exports = false\n").unwrap();
+    fs::write(after.join("index.js"), "module.exports = true\n").unwrap();
+
+    let diff = diff_folders(&before, &after).expect("diff dirs");
+
+    assert!(diff.contains("diff --git a/index.js b/index.js"), "diff: {diff}");
+    assert!(!diff.contains(&before.display().to_string()), "diff: {diff}");
+    assert!(!diff.contains(&after.display().to_string()), "diff: {diff}");
+}
+
+#[test]
 fn patch_commit_diff_dirs_filters_ds_store_diffs() {
     let before = tempdir().expect("before dir");
     let after = tempdir().expect("after dir");

--- a/pnpm11/patching/commands/src/patchCommit.ts
+++ b/pnpm11/patching/commands/src/patchCommit.ts
@@ -152,7 +152,7 @@ async function diffFolders (folderA: string, folderB: string): Promise<string> {
   let stderr!: string
 
   try {
-    const result = await execa('git', ['-c', 'core.safecrlf=false', 'diff', '--src-prefix=a/', '--dst-prefix=b/', '--ignore-cr-at-eol', '--irreversible-delete', '--full-index', '--no-index', '--text', '--no-ext-diff', '--no-color', folderAN, folderBN], {
+    const result = await execa('git', ['-c', 'core.safecrlf=false', '-c', 'core.quotePath=false', 'diff', '--src-prefix=a/', '--dst-prefix=b/', '--ignore-cr-at-eol', '--irreversible-delete', '--full-index', '--no-index', '--text', '--no-ext-diff', '--no-color', folderAN, folderBN], {
       cwd: process.cwd(),
       env: {
         ...process.env,

--- a/pnpm11/patching/commands/src/patchCommit.ts
+++ b/pnpm11/patching/commands/src/patchCommit.ts
@@ -152,7 +152,7 @@ async function diffFolders (folderA: string, folderB: string): Promise<string> {
   let stderr!: string
 
   try {
-    const result = await execa('git', ['-c', 'core.safecrlf=false', '-c', 'core.quotePath=false', 'diff', '--src-prefix=a/', '--dst-prefix=b/', '--ignore-cr-at-eol', '--irreversible-delete', '--full-index', '--no-index', '--text', '--no-ext-diff', '--no-color', folderAN, folderBN], {
+    const result = await execa('git', ['-c', 'core.safecrlf=false', '-c', 'core.quotePath=false', 'diff', '--src-prefix=a/', '--dst-prefix=b/', '--ignore-cr-at-eol', '--irreversible-delete', '--full-index', '--no-index', '--text', '--no-ext-diff', '--no-color', '--', folderAN, folderBN], {
       cwd: process.cwd(),
       env: {
         ...process.env,

--- a/pnpm11/patching/commands/test/patch.test.ts
+++ b/pnpm11/patching/commands/test/patch.test.ts
@@ -387,29 +387,6 @@ describe('patch and commit', () => {
     expect(fs.readFileSync('node_modules/is-positive/index.js', 'utf8')).toContain('// test patching')
   })
 
-  test('patch and commit with a dash-prefixed relative edit dir', async () => {
-    const editDir = '-custom-edit-dir'
-
-    const output = await patch.handler({ ...defaultPatchOption, editDir }, ['is-positive@1.0.0'])
-    const patchDir = getPatchDirFromPatchOutput(output)
-
-    fs.appendFileSync(path.join(patchDir, 'index.js'), '// test patching', 'utf8')
-
-    await patchCommit.handler({
-      ...DEFAULT_OPTS,
-      cacheDir,
-      dir: process.cwd(),
-      rootProjectManifestDir: process.cwd(),
-      frozenLockfile: false,
-      fixLockfile: true,
-      storeDir,
-    }, [path.relative(process.cwd(), patchDir)])
-
-    const patchContent = fs.readFileSync('patches/is-positive@1.0.0.patch', 'utf8')
-    expect(patchContent).toContain('diff --git a/index.js b/index.js')
-    expect(fs.readFileSync('node_modules/is-positive/index.js', 'utf8')).toContain('// test patching')
-  })
-
   test('patch with relative path to custom edit dir and commit with absolute path', async () => {
     const editDir = 'custom-edit-dir'
 

--- a/pnpm11/patching/commands/test/patch.test.ts
+++ b/pnpm11/patching/commands/test/patch.test.ts
@@ -364,6 +364,29 @@ describe('patch and commit', () => {
     expect(fs.readFileSync('node_modules/is-positive/index.js', 'utf8')).toContain('// test patching')
   })
 
+  test('patch and commit with a non-ASCII edit dir', async () => {
+    const editDir = path.join(temporaryDirectory(), '한글')
+
+    const output = await patch.handler({ ...defaultPatchOption, editDir }, ['is-positive@1.0.0'])
+    const patchDir = getPatchDirFromPatchOutput(output)
+
+    fs.appendFileSync(path.join(patchDir, 'index.js'), '// test patching', 'utf8')
+
+    await patchCommit.handler({
+      ...DEFAULT_OPTS,
+      cacheDir,
+      dir: process.cwd(),
+      rootProjectManifestDir: process.cwd(),
+      frozenLockfile: false,
+      fixLockfile: true,
+      storeDir,
+    }, [patchDir])
+
+    const patchContent = fs.readFileSync('patches/is-positive@1.0.0.patch', 'utf8')
+    expect(patchContent).toContain('diff --git a/index.js b/index.js')
+    expect(fs.readFileSync('node_modules/is-positive/index.js', 'utf8')).toContain('// test patching')
+  })
+
   test('patch with relative path to custom edit dir and commit with absolute path', async () => {
     const editDir = 'custom-edit-dir'
 

--- a/pnpm11/patching/commands/test/patch.test.ts
+++ b/pnpm11/patching/commands/test/patch.test.ts
@@ -387,6 +387,29 @@ describe('patch and commit', () => {
     expect(fs.readFileSync('node_modules/is-positive/index.js', 'utf8')).toContain('// test patching')
   })
 
+  test('patch and commit with a dash-prefixed relative edit dir', async () => {
+    const editDir = '-custom-edit-dir'
+
+    const output = await patch.handler({ ...defaultPatchOption, editDir }, ['is-positive@1.0.0'])
+    const patchDir = getPatchDirFromPatchOutput(output)
+
+    fs.appendFileSync(path.join(patchDir, 'index.js'), '// test patching', 'utf8')
+
+    await patchCommit.handler({
+      ...DEFAULT_OPTS,
+      cacheDir,
+      dir: process.cwd(),
+      rootProjectManifestDir: process.cwd(),
+      frozenLockfile: false,
+      fixLockfile: true,
+      storeDir,
+    }, [path.relative(process.cwd(), patchDir)])
+
+    const patchContent = fs.readFileSync('patches/is-positive@1.0.0.patch', 'utf8')
+    expect(patchContent).toContain('diff --git a/index.js b/index.js')
+    expect(fs.readFileSync('node_modules/is-positive/index.js', 'utf8')).toContain('// test patching')
+  })
+
   test('patch with relative path to custom edit dir and commit with absolute path', async () => {
     const editDir = 'custom-edit-dir'
 

--- a/pnpm11/pnpm/test/patch/commit.ts
+++ b/pnpm11/pnpm/test/patch/commit.ts
@@ -1,0 +1,36 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { expect, test } from '@jest/globals'
+import { prepare } from '@pnpm/prepare'
+import { writeYamlFileSync } from 'write-yaml-file'
+
+import { execPnpmSync } from '../utils/index.js'
+
+test('patch and commit with a dash-prefixed relative edit dir', () => {
+  prepare({
+    dependencies: {
+      'is-positive': '1.0.0',
+    },
+  })
+  writeYamlFileSync('pnpm-workspace.yaml', { packages: ['.'] })
+  const cliOptions = {
+    env: {
+      pnpm_config_cache_dir: path.resolve('cache'),
+      pnpm_config_store_dir: path.resolve('store'),
+    },
+    expectSuccess: true,
+  }
+  execPnpmSync(['install'], cliOptions)
+
+  const editDir = '-custom-edit-dir'
+  execPnpmSync(['patch', 'is-positive@1.0.0', `--edit-dir=./${editDir}`], cliOptions)
+
+  fs.appendFileSync(path.join(editDir, 'index.js'), '// test patching', 'utf8')
+
+  execPnpmSync(['patch-commit', '--', editDir], cliOptions)
+
+  const patchContent = fs.readFileSync('patches/is-positive@1.0.0.patch', 'utf8')
+  expect(patchContent).toContain('diff --git a/index.js b/index.js')
+  expect(fs.readFileSync('node_modules/is-positive/index.js', 'utf8')).toContain('// test patching')
+})


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#13801.

Configure Git with `core.quotePath=false` while generating package diffs so `patch-commit` can normalize paths containing non-ASCII characters. The option and regression coverage are mirrored in both the TypeScript CLI and the Rust `pnpm/` port, with a changeset for the published packages.

## Squash Commit Body

```text
Pass core.quotePath=false when patch-commit asks Git to diff the extracted and edited package directories. Otherwise Git C-quotes non-ASCII arguments in diff headers, preventing pnpm from normalizing and parsing its own generated patch.

Mirror the option and regression coverage in the TypeScript CLI and the Rust pnpm port.

Closes pnpm/pnpm#13801.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port.
- [x] Added a changeset for `@pnpm/patching.commands`, `pnpm`, and `pacquet`.
- [x] Added or updated tests.

---
Written by an agent (OpenAI Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13802"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789005445&installation_model_id=426870&pr_number=13802&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13802&signature=b7acc1dbcfacc3cc124a3d2ce4fffbc577c0f39b0ff6256dd82a19432b55d2c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm patch-commit` failures when project or edit paths contain non-ASCII characters or begin with a dash.
  * Preserved readable, correct file paths in generated patches and diffs.
  * Ensured patched packages are correctly committed and installed in these scenarios.

* **Tests**
  * Added coverage for patch creation and commits involving non-ASCII and dash-prefixed paths.
  * Verified generated diffs use normalized relative paths without exposing temporary absolute paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->