### PR TITLE
perf: absorb a new workspace project into the fast lockfile update

### DIFF
--- a/.changeset/new-importer-fast-update.md
+++ b/.changeset/new-importer-fast-update.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.deps-installer": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+Adding a package to a workspace no longer forces a full re-resolution when every dependency it declares is already locked for a sibling. The lockfile update writes the new project's importer entry from the versions the lockfile already holds; a dependency no locked version satisfies still reaches the resolver [#13696](https://github.com/pnpm/pnpm/issues/13696).

--- a/pnpm/crates/package-manager/src/fast_update_compose.rs
+++ b/pnpm/crates/package-manager/src/fast_update_compose.rs
@@ -41,6 +41,7 @@ pub(crate) fn try_compose_fast_updates(
     let importers = match crate::fast_update_importers::detect_importers_drift(
         lockfile,
         manifests,
+        project_manifests,
         prune_stale_importers,
     ) {
         Drift::Resolve => return None,

--- a/pnpm/crates/package-manager/src/fast_update_compose.rs
+++ b/pnpm/crates/package-manager/src/fast_update_compose.rs
@@ -43,6 +43,7 @@ pub(crate) fn try_compose_fast_updates(
         manifests,
         project_manifests,
         prune_stale_importers,
+        config.resolution_mode.picks_lowest_direct(),
     ) {
         Drift::Resolve => return None,
         drift => drift,

--- a/pnpm/crates/package-manager/src/fast_update_importers.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers.rs
@@ -315,7 +315,8 @@ pub(crate) fn locked_version_resolution_would_pick(
     range: &Range,
     resolution_picks_lowest: bool,
 ) -> Option<Version> {
-    let mut satisfying: Vec<Version> = Vec::new();
+    let mut highest: Option<Version> = None;
+    let mut satisfying = 0_usize;
     for key in packages?.keys() {
         if &key.name != alias {
             continue;
@@ -325,13 +326,16 @@ pub(crate) fn locked_version_resolution_would_pick(
         }
         let Some(version) = key.suffix.version_semver() else { continue };
         if version.satisfies(range) {
-            satisfying.push(version.clone());
+            satisfying += 1;
+            if highest.as_ref().is_none_or(|best| version > best) {
+                highest = Some(version.clone());
+            }
         }
     }
-    if satisfying.len() > 1 && resolution_picks_lowest {
+    if satisfying > 1 && resolution_picks_lowest {
         return None;
     }
-    satisfying.into_iter().max()
+    highest
 }
 
 /// Whether the importer's record differs from the manifest in a way the

--- a/pnpm/crates/package-manager/src/fast_update_importers.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers.rs
@@ -28,6 +28,9 @@ pub(crate) struct ImportersPlan<'a, 'manifest> {
     /// Importers no project claims, to drop before the rest replays.
     stale: Vec<String>,
     workspace_package_names: HashSet<String>,
+    /// Whether `resolutionMode` resolves a direct dependency to its
+    /// lowest satisfying version rather than its highest.
+    resolution_picks_lowest: bool,
 }
 
 /// Whether the importers' records diverge from the manifests, without
@@ -38,6 +41,7 @@ pub(crate) fn detect_importers_drift<'a, 'manifest>(
     manifests: &'a [(String, &'manifest PackageManifest)],
     project_manifests: &[(PathBuf, &PackageManifest)],
     prune_stale_importers: bool,
+    resolution_picks_lowest: bool,
 ) -> Drift<ImportersPlan<'a, 'manifest>> {
     let mut manifest_dependencies: Vec<(&String, &PackageManifest, ManifestDependencies<'_>)> =
         Vec::new();
@@ -75,6 +79,7 @@ pub(crate) fn detect_importers_drift<'a, 'manifest>(
             manifest_dependencies,
             stale,
             workspace_package_names: workspace_package_names(project_manifests),
+            resolution_picks_lowest,
         })
     } else {
         Drift::Clean
@@ -120,13 +125,13 @@ pub(crate) fn apply_importers_update(
     let Lockfile { packages, importers, .. } = candidate;
     for (importer_id, manifest, manifest_dependencies) in &plan.manifest_dependencies {
         let records_nothing =
-            importers.get(importer_id.as_str()).is_none_or(has_no_recorded_dependencies);
+            importers.get(importer_id.as_str()).is_none_or(records_no_dependencies);
         if records_nothing && !manifest_dependencies.is_empty() {
             let Some(new_importer) = importer_from_locked_versions(
                 packages.as_ref(),
                 manifest,
                 manifest_dependencies,
-                &plan.workspace_package_names,
+                plan,
             ) else {
                 return false;
             };
@@ -155,9 +160,12 @@ pub(crate) fn apply_importers_update(
                 let Some(version) = ver_peer.version_semver() else {
                     return false;
                 };
-                let Some(wanted) =
-                    highest_locked_version_satisfying(packages.as_ref(), alias, &range)
-                else {
+                let Some(wanted) = locked_version_resolution_would_pick(
+                    packages.as_ref(),
+                    alias,
+                    &range,
+                    plan.resolution_picks_lowest,
+                ) else {
                     return false;
                 };
                 if wanted != *version {
@@ -184,10 +192,10 @@ pub(crate) fn apply_importers_update(
     true
 }
 
-/// Whether the lockfile records no dependency of this project. Together
-/// with a missing entry, that is what a project the lockfile has never
-/// seen looks like.
-fn has_no_recorded_dependencies(importer: &ProjectSnapshot) -> bool {
+/// Whether the lockfile records no dependency of this project — the
+/// shape a project it has never seen arrives in, alongside an absent
+/// entry.
+fn records_no_dependencies(importer: &ProjectSnapshot) -> bool {
     [&importer.dependencies, &importer.dev_dependencies, &importer.optional_dependencies]
         .into_iter()
         .flatten()
@@ -204,16 +212,21 @@ fn importer_from_locked_versions(
     packages: Option<&HashMap<PackageKey, pacquet_lockfile::PackageMetadata>>,
     manifest: &PackageManifest,
     manifest_dependencies: &ManifestDependencies<'_>,
-    workspace_package_names: &HashSet<String>,
+    plan: &ImportersPlan<'_, '_>,
 ) -> Option<ProjectSnapshot> {
     let mut importer = ProjectSnapshot::default();
     let mut specifiers = HashMap::new();
     for (alias, (specifier, group)) in manifest_dependencies {
-        if is_directory_dependency(&alias.to_string(), specifier, workspace_package_names) {
+        if is_directory_dependency(&alias.to_string(), specifier, &plan.workspace_package_names) {
             return None;
         }
         let range = Range::parse(specifier).ok()?;
-        let version = highest_locked_version_satisfying(packages, alias, &range)?;
+        let version = locked_version_resolution_would_pick(
+            packages,
+            alias,
+            &range,
+            plan.resolution_picks_lowest,
+        )?;
         let dependency = ResolvedDependencySpec {
             specifier: (*specifier).to_string(),
             version: ImporterDepVersion::Regular(version.to_string().parse().ok()?),
@@ -284,17 +297,25 @@ fn link_resolves_to(from: &str, target: &str, importer_id: &str) -> bool {
 /// record — for a widened range as much as for one the locked version
 /// cannot satisfy at all.
 ///
-/// `None` when nothing present satisfies (only the resolver can fetch a
-/// new version), or when the alias appears under a key this cannot turn
-/// back into a plain reference: a peer-suffixed one, where picking a
-/// variant would be a guess, or a registry-qualified one, whose semver
-/// only pins a version within its named registry.
-pub(crate) fn highest_locked_version_satisfying(
+/// `None` when the pick cannot be read off the lockfile:
+///
+/// - nothing present satisfies, so only the resolver can fetch a version;
+/// - `resolution_picks_lowest` and more than one locked version
+///   satisfies. Those resolution modes take the lowest preferred version
+///   for a direct dependency, but only when the run leaves the manifest
+///   alone, so which end of the range applies is not a property of the
+///   lockfile;
+/// - the alias appears under a key this cannot turn back into a plain
+///   reference: a peer-suffixed one, where picking a variant would be a
+///   guess, or a registry-qualified one, whose semver only pins a version
+///   within its named registry.
+pub(crate) fn locked_version_resolution_would_pick(
     packages: Option<&HashMap<PackageKey, pacquet_lockfile::PackageMetadata>>,
     alias: &PkgName,
     range: &Range,
+    resolution_picks_lowest: bool,
 ) -> Option<Version> {
-    let mut highest: Option<Version> = None;
+    let mut satisfying: Vec<Version> = Vec::new();
     for key in packages?.keys() {
         if &key.name != alias {
             continue;
@@ -303,11 +324,14 @@ pub(crate) fn highest_locked_version_satisfying(
             return None;
         }
         let Some(version) = key.suffix.version_semver() else { continue };
-        if version.satisfies(range) && highest.as_ref().is_none_or(|best| version > best) {
-            highest = Some(version.clone());
+        if version.satisfies(range) {
+            satisfying.push(version.clone());
         }
     }
-    highest
+    if satisfying.len() > 1 && resolution_picks_lowest {
+        return None;
+    }
+    satisfying.into_iter().max()
 }
 
 /// Whether the importer's record differs from the manifest in a way the

--- a/pnpm/crates/package-manager/src/fast_update_importers.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers.rs
@@ -1,11 +1,18 @@
-use crate::{fast_update_compose::Drift, fast_update_lockfile::GraphEdits};
+use crate::{
+    fast_update_compose::Drift,
+    fast_update_lockfile::GraphEdits,
+    fast_update_settings::{is_directory_dependency, workspace_package_names},
+};
 use node_semver::{Range, Version};
 use pacquet_lockfile::{
     ImporterDepVersion, Lockfile, PackageKey, PkgName, ProjectSnapshot, ResolvedDependencyMap,
     ResolvedDependencySpec,
 };
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+};
 
 /// Each manifest alias with its specifier and the group it is
 /// effectively declared under. Keyed by [`PkgName`] so membership tests
@@ -16,9 +23,11 @@ type ManifestDependencies<'manifest> = HashMap<PkgName, (&'manifest str, Depende
 /// importer's manifest map, built once so detection and application share
 /// the parsed aliases.
 pub(crate) struct ImportersPlan<'a, 'manifest> {
-    manifest_dependencies: Vec<(&'a String, ManifestDependencies<'manifest>)>,
+    manifest_dependencies:
+        Vec<(&'a String, &'manifest PackageManifest, ManifestDependencies<'manifest>)>,
     /// Importers no project claims, to drop before the rest replays.
     stale: Vec<String>,
+    workspace_package_names: HashSet<String>,
 }
 
 /// Whether the importers' records diverge from the manifests, without
@@ -27,9 +36,11 @@ pub(crate) struct ImportersPlan<'a, 'manifest> {
 pub(crate) fn detect_importers_drift<'a, 'manifest>(
     lockfile: &Lockfile,
     manifests: &'a [(String, &'manifest PackageManifest)],
+    project_manifests: &[(PathBuf, &PackageManifest)],
     prune_stale_importers: bool,
 ) -> Drift<ImportersPlan<'a, 'manifest>> {
-    let mut manifest_dependencies: Vec<(&String, ManifestDependencies<'_>)> = Vec::new();
+    let mut manifest_dependencies: Vec<(&String, &PackageManifest, ManifestDependencies<'_>)> =
+        Vec::new();
     for (importer_id, manifest) in manifests {
         // Later groups overwrite, so each alias ends at the group
         // `satisfies_package_manifest` expects it recorded under when it
@@ -43,7 +54,7 @@ pub(crate) fn detect_importers_drift<'a, 'manifest>(
                 dependencies.insert(name, (specifier, group));
             }
         }
-        manifest_dependencies.push((importer_id, dependencies));
+        manifest_dependencies.push((importer_id, *manifest, dependencies));
     }
     let stale: Vec<String> = if prune_stale_importers {
         lockfile
@@ -56,11 +67,15 @@ pub(crate) fn detect_importers_drift<'a, 'manifest>(
         Vec::new()
     };
     if !stale.is_empty()
-        || manifest_dependencies.iter().any(|(importer_id, dependencies)| {
+        || manifest_dependencies.iter().any(|(importer_id, _, dependencies)| {
             importer_diverges(lockfile, importer_id, dependencies)
         })
     {
-        Drift::Absorb(ImportersPlan { manifest_dependencies, stale })
+        Drift::Absorb(ImportersPlan {
+            manifest_dependencies,
+            stale,
+            workspace_package_names: workspace_package_names(project_manifests),
+        })
     } else {
         Drift::Clean
     }
@@ -103,7 +118,25 @@ pub(crate) fn apply_importers_update(
         }
     }
     let Lockfile { packages, importers, .. } = candidate;
-    for (importer_id, manifest_dependencies) in &plan.manifest_dependencies {
+    for (importer_id, manifest, manifest_dependencies) in &plan.manifest_dependencies {
+        let records_nothing =
+            importers.get(importer_id.as_str()).is_none_or(has_no_recorded_dependencies);
+        if records_nothing && !manifest_dependencies.is_empty() {
+            let Some(new_importer) = importer_from_locked_versions(
+                packages.as_ref(),
+                manifest,
+                manifest_dependencies,
+                &plan.workspace_package_names,
+            ) else {
+                return false;
+            };
+            importers.insert((*importer_id).clone(), new_importer);
+            // The only edit that adds reachability, so a package that until
+            // now only optional dependencies reached can have stopped being
+            // optional.
+            edits.optional_flags_are_stale = true;
+            continue;
+        }
         let Some(importer) = importers.get_mut(importer_id.as_str()) else {
             return false;
         };
@@ -142,13 +175,63 @@ pub(crate) fn apply_importers_update(
                 dependency.specifier = (*specifier).to_string();
             }
             if let Some(source) = move_dependency(importer, alias, *target) {
-                edits.moved_across_optional |=
+                edits.optional_flags_are_stale |=
                     source == DependencyGroup::Optional || *target == DependencyGroup::Optional;
             }
         }
         remove_dependencies_absent_from(importer, manifest_dependencies, edits);
     }
     true
+}
+
+/// Whether the lockfile records no dependency of this project. Together
+/// with a missing entry, that is what a project the lockfile has never
+/// seen looks like.
+fn has_no_recorded_dependencies(importer: &ProjectSnapshot) -> bool {
+    [&importer.dependencies, &importer.dev_dependencies, &importer.optional_dependencies]
+        .into_iter()
+        .flatten()
+        .all(HashMap::is_empty)
+}
+
+/// A project's whole importer entry, built from the versions the
+/// lockfile already holds.
+///
+/// `None` when a declared dependency needs the resolver: one that
+/// resolves to a directory rather than to a registry version, one whose
+/// specifier is not a semver range, and one no locked version satisfies.
+fn importer_from_locked_versions(
+    packages: Option<&HashMap<PackageKey, pacquet_lockfile::PackageMetadata>>,
+    manifest: &PackageManifest,
+    manifest_dependencies: &ManifestDependencies<'_>,
+    workspace_package_names: &HashSet<String>,
+) -> Option<ProjectSnapshot> {
+    let mut importer = ProjectSnapshot::default();
+    let mut specifiers = HashMap::new();
+    for (alias, (specifier, group)) in manifest_dependencies {
+        if is_directory_dependency(&alias.to_string(), specifier, workspace_package_names) {
+            return None;
+        }
+        let range = Range::parse(specifier).ok()?;
+        let version = highest_locked_version_satisfying(packages, alias, &range)?;
+        let dependency = ResolvedDependencySpec {
+            specifier: (*specifier).to_string(),
+            version: ImporterDepVersion::Regular(version.to_string().parse().ok()?),
+        };
+        importer_group(&mut importer, *group)
+            .get_or_insert_default()
+            .insert(alias.clone(), dependency);
+        specifiers.insert(alias.to_string(), (*specifier).to_string());
+    }
+    importer.specifiers = Some(specifiers);
+    importer.dependencies_meta = manifest.value().get("dependenciesMeta").cloned();
+    importer.publish_directory = manifest
+        .value()
+        .get("publishConfig")
+        .and_then(|publish_config| publish_config.get("directory"))
+        .and_then(serde_json::Value::as_str)
+        .map(ToString::to_string);
+    Some(importer)
 }
 
 /// Whether an importer that survives the prune links to `importer_id`.
@@ -238,7 +321,7 @@ fn importer_diverges(
     manifest_dependencies: &ManifestDependencies<'_>,
 ) -> bool {
     let Some(importer) = lockfile.importers.get(importer_id) else {
-        return false;
+        return !manifest_dependencies.is_empty();
     };
     let recorded_but_undeclared = [
         importer.dependencies.as_ref(),

--- a/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
@@ -1,3 +1,4 @@
+use pacquet_config::ResolutionMode::LowestDirect as LOWEST_DIRECT;
 use pacquet_lockfile::{Lockfile, PackageKey, PkgName};
 use pacquet_package_manifest::PackageManifest;
 use serde_json::json;
@@ -745,7 +746,8 @@ fn moves_to_a_higher_locked_version_even_when_the_locked_one_still_satisfies() {
 }
 
 /// One project with an optional dependency whose child is optional with
-/// it, and a second project the lockfile records nothing for yet.
+/// it, a second that locks a higher `child` a `^3.0.0` range also
+/// admits, and a third the lockfile records nothing for yet.
 const WITH_A_NEW_PROJECT: &str = r"
 lockfileVersion: '9.0'
 importers:
@@ -754,6 +756,11 @@ importers:
       opt:
         specifier: ^5.0.0
         version: 5.0.0
+  pkg-c:
+    dependencies:
+      child:
+        specifier: 3.1.0
+        version: 3.1.0
 packages:
   opt@5.0.0:
     resolution:
@@ -761,6 +768,9 @@ packages:
   child@3.0.0:
     resolution:
       integrity: sha512-child
+  child@3.1.0:
+    resolution:
+      integrity: sha512-child-1
 snapshots:
   opt@5.0.0:
     optional: true
@@ -768,16 +778,39 @@ snapshots:
       child: 3.0.0
   child@3.0.0:
     optional: true
+  child@3.1.0: {}
 ";
 
+/// The projects `WITH_A_NEW_PROJECT` already records, alongside the
+/// `pkg-b` the tests add.
+fn projects_of_a_new_project_lockfile<'a>(
+    existing: &'a PackageManifest,
+    locks_the_higher_child: &'a PackageManifest,
+    added: &'a PackageManifest,
+) -> Vec<(String, &'a PackageManifest)> {
+    vec![
+        ("pkg-a".to_string(), existing),
+        ("pkg-c".to_string(), locks_the_higher_child),
+        ("pkg-b".to_string(), added),
+    ]
+}
+
+fn a_new_project_lockfile_projects(added: &PackageManifest) -> [PackageManifest; 2] {
+    let _ = added;
+    [
+        manifest_from(json!({ "optionalDependencies": { "opt": "^5.0.0" } })),
+        manifest_from(json!({ "dependencies": { "child": "3.1.0" } })),
+    ]
+}
+
 #[test]
-fn writes_a_new_project_importer_from_locked_versions() {
-    let existing = manifest_from(json!({ "optionalDependencies": { "opt": "^5.0.0" } }));
+fn writes_a_new_project_importer_from_the_highest_locked_versions() {
     let added = manifest_from(json!({ "devDependencies": { "child": "^3.0.0" } }));
+    let [existing, locks_the_higher_child] = a_new_project_lockfile_projects(&added);
 
     let updated = try_fast_update_importers(
         &parsed_lockfile(WITH_A_NEW_PROJECT),
-        &[("pkg-a".to_string(), &existing), ("pkg-b".to_string(), &added)],
+        &projects_of_a_new_project_lockfile(&existing, &locks_the_higher_child, &added),
     )
     .expect("every version the new project needs is already locked");
 
@@ -786,24 +819,42 @@ fn writes_a_new_project_importer_from_locked_versions() {
         &updated.importers["pkg-b"].dev_dependencies.as_ref().expect("devDependencies")[&alias];
     assert_eq!(
         (recorded.specifier.as_str(), recorded.version.to_string().as_str()),
-        ("^3.0.0", "3.0.0"),
+        ("^3.0.0", "3.1.0"),
+        "resolution dedupes onto the highest locked version the range admits",
     );
     assert!(
-        !snapshot_optional(&updated, "child@3.0.0"),
-        "the new project reaches it outside optionalDependencies",
+        snapshot_optional(&updated, "child@3.0.0"),
+        "the version the new project did not take keeps the flag its only path gives it",
     );
     assert!(snapshot_optional(&updated, "opt@5.0.0"), "nothing else changed about the old path");
 }
 
 #[test]
+fn clears_an_optional_flag_a_new_projects_plain_dependency_reaches() {
+    let added = manifest_from(json!({ "dependencies": { "child": "3.0.0" } }));
+    let [existing, locks_the_higher_child] = a_new_project_lockfile_projects(&added);
+
+    let updated = try_fast_update_importers(
+        &parsed_lockfile(WITH_A_NEW_PROJECT),
+        &projects_of_a_new_project_lockfile(&existing, &locks_the_higher_child, &added),
+    )
+    .expect("the version the new project pins is already locked");
+
+    assert!(
+        !snapshot_optional(&updated, "child@3.0.0"),
+        "the new project reaches it outside optionalDependencies",
+    );
+}
+
+#[test]
 fn rejects_a_new_project_whose_dependency_is_not_locked() {
-    let existing = manifest_from(json!({ "optionalDependencies": { "opt": "^5.0.0" } }));
     let added = manifest_from(json!({ "dependencies": { "extra": "^1.0.0" } }));
+    let [existing, locks_the_higher_child] = a_new_project_lockfile_projects(&added);
 
     assert!(
         try_fast_update_importers(
             &parsed_lockfile(WITH_A_NEW_PROJECT),
-            &[("pkg-a".to_string(), &existing), ("pkg-b".to_string(), &added)],
+            &projects_of_a_new_project_lockfile(&existing, &locks_the_higher_child, &added),
         )
         .is_none(),
         "only the resolver can fetch a version the lockfile does not hold",
@@ -811,9 +862,39 @@ fn rejects_a_new_project_whose_dependency_is_not_locked() {
 }
 
 #[test]
+fn rejects_a_new_project_that_declares_a_workspace_protocol_dependency() {
+    let added = manifest_from(json!({ "dependencies": { "child": "workspace:^" } }));
+    let [existing, locks_the_higher_child] = a_new_project_lockfile_projects(&added);
+
+    assert!(
+        try_fast_update_importers(
+            &parsed_lockfile(WITH_A_NEW_PROJECT),
+            &projects_of_a_new_project_lockfile(&existing, &locks_the_higher_child, &added),
+        )
+        .is_none(),
+        "a workspace dependency resolves to a directory, not to a locked version",
+    );
+}
+
+#[test]
+fn rejects_a_new_project_that_declares_a_link_protocol_dependency() {
+    let added = manifest_from(json!({ "dependencies": { "child": "link:../child" } }));
+    let [existing, locks_the_higher_child] = a_new_project_lockfile_projects(&added);
+
+    assert!(
+        try_fast_update_importers(
+            &parsed_lockfile(WITH_A_NEW_PROJECT),
+            &projects_of_a_new_project_lockfile(&existing, &locks_the_higher_child, &added),
+        )
+        .is_none(),
+        "a link resolves to a directory, not to a locked version",
+    );
+}
+
+#[test]
 fn rejects_a_new_project_that_depends_on_a_workspace_sibling() {
-    let existing = manifest_from(json!({ "optionalDependencies": { "opt": "^5.0.0" } }));
     let added = manifest_from(json!({ "dependencies": { "child": "^3.0.0" } }));
+    let [existing, locks_the_higher_child] = a_new_project_lockfile_projects(&added);
     let sibling = PackageManifest::from_value(
         PathBuf::from("/workspace/child/package.json"),
         json!({ "name": "child", "version": "3.0.0" }),
@@ -822,13 +903,51 @@ fn rejects_a_new_project_that_depends_on_a_workspace_sibling() {
     assert!(
         crate::fast_update_compose::try_compose_fast_updates(
             &parsed_lockfile(WITH_A_NEW_PROJECT),
-            &[("pkg-a".to_string(), &existing), ("pkg-b".to_string(), &added)],
+            &projects_of_a_new_project_lockfile(&existing, &locks_the_higher_child, &added),
             &[(PathBuf::from("/workspace/child"), &sibling)],
             &pacquet_config::Config::default(),
             false,
         )
         .is_none(),
         "a plain range on a workspace project may resolve to a link, which only the resolver decides",
+    );
+}
+
+#[test]
+fn rejects_a_widened_range_when_resolution_would_pick_its_lowest_locked_version() {
+    let manifest = manifest_from(json!({ "dependencies": { "foo": "^1.0.0" } }));
+    let other = manifest_from(json!({ "dependencies": { "foo": "1.2.0" } }));
+    let config = pacquet_config::Config { resolution_mode: LOWEST_DIRECT, ..Default::default() };
+
+    assert!(
+        crate::fast_update_compose::try_compose_fast_updates(
+            &parsed_lockfile(WITH_TWO_LOCKED_VERSIONS),
+            &[(".".to_string(), &manifest), ("pkg-a".to_string(), &other)],
+            &[],
+            &config,
+            false,
+        )
+        .is_none(),
+        "which end of the range applies is not a property of the lockfile",
+    );
+}
+
+#[test]
+fn rejects_a_new_project_when_resolution_would_pick_the_lowest_of_several_locked_versions() {
+    let added = manifest_from(json!({ "dependencies": { "child": "^3.0.0" } }));
+    let [existing, locks_the_higher_child] = a_new_project_lockfile_projects(&added);
+    let config = pacquet_config::Config { resolution_mode: LOWEST_DIRECT, ..Default::default() };
+
+    assert!(
+        crate::fast_update_compose::try_compose_fast_updates(
+            &parsed_lockfile(WITH_A_NEW_PROJECT),
+            &projects_of_a_new_project_lockfile(&existing, &locks_the_higher_child, &added),
+            &[],
+            &config,
+            false,
+        )
+        .is_none(),
+        "which end of the range applies is not a property of the lockfile",
     );
 }
 

--- a/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
@@ -744,6 +744,94 @@ fn moves_to_a_higher_locked_version_even_when_the_locked_one_still_satisfies() {
     );
 }
 
+/// One project with an optional dependency whose child is optional with
+/// it, and a second project the lockfile records nothing for yet.
+const WITH_A_NEW_PROJECT: &str = r"
+lockfileVersion: '9.0'
+importers:
+  pkg-a:
+    optionalDependencies:
+      opt:
+        specifier: ^5.0.0
+        version: 5.0.0
+packages:
+  opt@5.0.0:
+    resolution:
+      integrity: sha512-opt
+  child@3.0.0:
+    resolution:
+      integrity: sha512-child
+snapshots:
+  opt@5.0.0:
+    optional: true
+    dependencies:
+      child: 3.0.0
+  child@3.0.0:
+    optional: true
+";
+
+#[test]
+fn writes_a_new_project_importer_from_locked_versions() {
+    let existing = manifest_from(json!({ "optionalDependencies": { "opt": "^5.0.0" } }));
+    let added = manifest_from(json!({ "devDependencies": { "child": "^3.0.0" } }));
+
+    let updated = try_fast_update_importers(
+        &parsed_lockfile(WITH_A_NEW_PROJECT),
+        &[("pkg-a".to_string(), &existing), ("pkg-b".to_string(), &added)],
+    )
+    .expect("every version the new project needs is already locked");
+
+    let alias: PkgName = "child".parse().expect("alias");
+    let recorded =
+        &updated.importers["pkg-b"].dev_dependencies.as_ref().expect("devDependencies")[&alias];
+    assert_eq!(
+        (recorded.specifier.as_str(), recorded.version.to_string().as_str()),
+        ("^3.0.0", "3.0.0"),
+    );
+    assert!(
+        !snapshot_optional(&updated, "child@3.0.0"),
+        "the new project reaches it outside optionalDependencies",
+    );
+    assert!(snapshot_optional(&updated, "opt@5.0.0"), "nothing else changed about the old path");
+}
+
+#[test]
+fn rejects_a_new_project_whose_dependency_is_not_locked() {
+    let existing = manifest_from(json!({ "optionalDependencies": { "opt": "^5.0.0" } }));
+    let added = manifest_from(json!({ "dependencies": { "extra": "^1.0.0" } }));
+
+    assert!(
+        try_fast_update_importers(
+            &parsed_lockfile(WITH_A_NEW_PROJECT),
+            &[("pkg-a".to_string(), &existing), ("pkg-b".to_string(), &added)],
+        )
+        .is_none(),
+        "only the resolver can fetch a version the lockfile does not hold",
+    );
+}
+
+#[test]
+fn rejects_a_new_project_that_depends_on_a_workspace_sibling() {
+    let existing = manifest_from(json!({ "optionalDependencies": { "opt": "^5.0.0" } }));
+    let added = manifest_from(json!({ "dependencies": { "child": "^3.0.0" } }));
+    let sibling = PackageManifest::from_value(
+        PathBuf::from("/workspace/child/package.json"),
+        json!({ "name": "child", "version": "3.0.0" }),
+    );
+
+    assert!(
+        crate::fast_update_compose::try_compose_fast_updates(
+            &parsed_lockfile(WITH_A_NEW_PROJECT),
+            &[("pkg-a".to_string(), &existing), ("pkg-b".to_string(), &added)],
+            &[(PathBuf::from("/workspace/child"), &sibling)],
+            &pacquet_config::Config::default(),
+            false,
+        )
+        .is_none(),
+        "a plain range on a workspace project may resolve to a link, which only the resolver decides",
+    );
+}
+
 #[test]
 fn rejects_a_range_no_locked_version_satisfies() {
     let manifest = manifest_from(json!({ "dependencies": { "foo": "^2.0.0" } }));

--- a/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
@@ -781,7 +781,7 @@ snapshots:
   child@3.1.0: {}
 ";
 
-/// The projects `WITH_A_NEW_PROJECT` already records, alongside the
+/// The projects [`WITH_A_NEW_PROJECT`] already records, alongside the
 /// `pkg-b` the tests add.
 fn projects_of_a_new_project_lockfile<'a>(
     existing: &'a PackageManifest,

--- a/pnpm/crates/package-manager/src/fast_update_lockfile.rs
+++ b/pnpm/crates/package-manager/src/fast_update_lockfile.rs
@@ -12,9 +12,10 @@ use std::collections::{HashSet, VecDeque};
 pub(crate) struct GraphEdits {
     /// What the severed importer or snapshot edges pointed at.
     pub(crate) dropped: DroppedEdges,
-    /// Whether an edge into or out of `optionalDependencies` moved, which
-    /// changes the reachability-derived `optional` flags for a subtree.
-    pub(crate) moved_across_optional: bool,
+    /// Whether an edge was added or moved into or out of
+    /// `optionalDependencies`, which changes the reachability-derived
+    /// `optional` flags for a subtree.
+    pub(crate) optional_flags_are_stale: bool,
 }
 
 /// What the edges a fast update severed pointed at, each written the way
@@ -114,7 +115,7 @@ pub(crate) fn finish_graph_edits(candidate: &mut Lockfile, edits: &GraphEdits) -
         }
         prune_unreferenced_catalog_entries(candidate);
     }
-    if !edits.dropped.is_empty() || edits.moved_across_optional {
+    if !edits.dropped.is_empty() || edits.optional_flags_are_stale {
         recompute_optional_flags(candidate);
     }
     true

--- a/pnpm/crates/package-manager/src/fast_update_overrides.rs
+++ b/pnpm/crates/package-manager/src/fast_update_overrides.rs
@@ -180,10 +180,13 @@ fn overridden_version(lockfile: &Lockfile, name: &PkgName, value: &str) -> Optio
         return Some(version);
     }
     let range = Range::parse(value).ok()?;
-    crate::fast_update_importers::highest_locked_version_satisfying(
+    // `resolutionMode` only moves direct dependencies to the low end of
+    // their range, and an override names a package at any depth.
+    crate::fast_update_importers::locked_version_resolution_would_pick(
         lockfile.packages.as_ref(),
         name,
         &range,
+        false,
     )
 }
 

--- a/pnpm/crates/package-manager/src/fast_update_settings.rs
+++ b/pnpm/crates/package-manager/src/fast_update_settings.rs
@@ -182,7 +182,11 @@ fn has_no_injectable_dependencies(
         })
 }
 
-fn is_directory_dependency(
+/// Whether `alias` resolves to a directory rather than to a registry
+/// version: the protocols that name one outright, and a plain range on
+/// a workspace project's name, which `linkWorkspacePackages` turns into
+/// a link.
+pub(crate) fn is_directory_dependency(
     alias: &str,
     bare_specifier: &str,
     workspace_package_names: &HashSet<String>,
@@ -213,7 +217,11 @@ fn declares_injected_dependency(manifest: &PackageManifest) -> bool {
     )
 }
 
-fn workspace_package_names(manifests: &[(PathBuf, &PackageManifest)]) -> HashSet<String> {
+/// The names every workspace project publishes under, which a plain
+/// range on one of them resolves to a directory through.
+pub(crate) fn workspace_package_names(
+    manifests: &[(PathBuf, &PackageManifest)],
+) -> HashSet<String> {
     manifests
         .iter()
         .filter_map(|(_, manifest)| {

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -782,8 +782,6 @@ export async function mutateModules (
       !ctx.lockfileHadConflicts &&
       ctx.wantedLockfile.lockfileVersion === LOCKFILE_VERSION &&
       !isEmptyLockfile(ctx.wantedLockfile) &&
-      // Extra importers are drift the handler absorbs; a missing one is not.
-      contextProjects.every((project) => ctx.wantedLockfile.importers[project.id] != null) &&
       // `time` records publish dates for the importers' direct dependencies
       // and is pruned back to them whenever the lockfile is written, so a
       // rewrite that introduces no new version needs no maintenance of it.
@@ -843,6 +841,7 @@ export async function mutateModules (
               return tryComposeFastUpdates(candidate, {
                 drift: syncDrift,
                 projects: contextProjects,
+                workspacePackages: ctx.workspacePackages,
                 pruneLockfileImporters: opts.pruneLockfileImporters,
                 ignoredOptionalDependencies: opts.ignoredOptionalDependencies,
                 patchedDependencies: {

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -842,6 +842,7 @@ export async function mutateModules (
                 drift: syncDrift,
                 projects: contextProjects,
                 workspacePackages: ctx.workspacePackages,
+                resolutionPicksLowest: opts.resolutionMode !== 'highest',
                 pruneLockfileImporters: opts.pruneLockfileImporters,
                 ignoredOptionalDependencies: opts.ignoredOptionalDependencies,
                 patchedDependencies: {

--- a/pnpm11/installing/deps-installer/src/install/tryComposeFastUpdates.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryComposeFastUpdates.ts
@@ -1,5 +1,6 @@
 import { pruneSharedLockfile } from '@pnpm/lockfile.pruner'
 import type { LockfileObject } from '@pnpm/lockfile.types'
+import type { WorkspacePackages } from '@pnpm/resolving.resolver-base'
 
 import { type DroppedEdges, peerSuffixesAreIndependentOf } from './droppedEdges.js'
 import { pruneUnreferencedCatalogEntries } from './tryFastUpdateCatalogs.js'
@@ -24,10 +25,10 @@ export interface GraphEdits {
   /** What the severed importer or package edges pointed at. */
   dropped: DroppedEdges
   /**
-   * Whether an edge into or out of `optionalDependencies` moved, which
-   * changes the reachability-derived `optional` flags for a subtree.
+   * Whether an edge was added or moved into or out of `optionalDependencies`,
+   * which changes the reachability-derived `optional` flags for a subtree.
    */
-  movedAcrossOptional: boolean
+  optionalFlagsAreStale: boolean
 }
 
 /** The drift dimensions the composed sync handlers can absorb. */
@@ -41,6 +42,7 @@ export interface FastUpdateDrift {
 export interface ComposeFastUpdatesOptions {
   drift: FastUpdateDrift
   projects: Project[]
+  workspacePackages: WorkspacePackages
   /** Whether importers of removed projects are dropped from the lockfile. */
   pruneLockfileImporters?: boolean
   ignoredOptionalDependencies?: string[]
@@ -63,10 +65,11 @@ export function tryComposeFastUpdates (
   candidate: LockfileObject,
   opts: ComposeFastUpdatesOptions
 ): boolean {
-  const edits: GraphEdits = { dropped: new Set(), movedAcrossOptional: false }
+  const edits: GraphEdits = { dropped: new Set(), optionalFlagsAreStale: false }
   if (opts.drift.importers && !tryFastUpdateImporters(candidate, {
     projects: opts.projects,
     pruneLockfileImporters: opts.pruneLockfileImporters ?? false,
+    workspacePackages: opts.workspacePackages,
   }, edits)) {
     return false
   }
@@ -92,7 +95,7 @@ export function tryComposeFastUpdates (
  * rewrite, not a prune — leaves the caller on the full-resolution path.
  */
 function finishGraphEdits (candidate: LockfileObject, edits: GraphEdits): boolean {
-  if (edits.dropped.size > 0 || edits.movedAcrossOptional) {
+  if (edits.dropped.size > 0 || edits.optionalFlagsAreStale) {
     const pruned = pruneSharedLockfile(candidate)
     if (pruned.packages == null) {
       delete candidate.packages

--- a/pnpm11/installing/deps-installer/src/install/tryComposeFastUpdates.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryComposeFastUpdates.ts
@@ -43,6 +43,11 @@ export interface ComposeFastUpdatesOptions {
   drift: FastUpdateDrift
   projects: Project[]
   workspacePackages: WorkspacePackages
+  /**
+   * Whether `resolutionMode` resolves a direct dependency to its lowest
+   * satisfying version rather than its highest.
+   */
+  resolutionPicksLowest: boolean
   /** Whether importers of removed projects are dropped from the lockfile. */
   pruneLockfileImporters?: boolean
   ignoredOptionalDependencies?: string[]
@@ -70,6 +75,7 @@ export function tryComposeFastUpdates (
     projects: opts.projects,
     pruneLockfileImporters: opts.pruneLockfileImporters ?? false,
     workspacePackages: opts.workspacePackages,
+    resolutionPicksLowest: opts.resolutionPicksLowest,
   }, edits)) {
     return false
   }

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
@@ -23,9 +23,9 @@ export function hasChangedProjectSpecifiers (
 ): boolean {
   if (pruneLockfileImporters && staleImporterIds(lockfile, projects).length > 0) return true
   return projects.some((project) => {
-    const importer = lockfile.importers[project.id]
-    if (importer == null) return false
     const manifestSpecifiers = getManifestSpecifiers(project.manifest)
+    const importer = lockfile.importers[project.id]
+    if (importer == null) return Object.keys(manifestSpecifiers).length > 0
     return Object.entries(manifestSpecifiers)
       .some(([alias, specifier]) =>
         importer.specifiers[alias] !== specifier ||
@@ -38,6 +38,11 @@ export interface FastImportersUpdateOptions {
   projects: Project[]
   pruneLockfileImporters: boolean
   workspacePackages: WorkspacePackages
+  /**
+   * Whether `resolutionMode` resolves a direct dependency to its lowest
+   * satisfying version rather than its highest.
+   */
+  resolutionPicksLowest: boolean
 }
 
 /**
@@ -71,16 +76,16 @@ export function tryFastUpdateImporters (
   }
   for (const project of projects) {
     const importer = lockfile.importers[project.id]
-    if (importer == null) return false
     const manifestSpecifiers = getManifestSpecifiers(project.manifest)
-    if (hasNoRecordedDependencies(importer) && Object.keys(manifestSpecifiers).length > 0) {
-      if (!writeImporterFromLockedVersions(lockfile, project, opts.workspacePackages)) return false
+    if (recordsNoDependencies(importer) && Object.keys(manifestSpecifiers).length > 0) {
+      if (!writeImporterFromLockedVersions(lockfile, project, opts)) return false
       // The only edit that adds reachability, so a package that until now
       // only optional dependencies reached can have stopped being optional.
       edits.optionalFlagsAreStale = true
       changed = true
       continue
     }
+    if (importer == null) return false
     let editedGroups = false
     for (const [alias, specifier] of Object.entries(manifestSpecifiers)) {
       if (importer.specifiers[alias] !== specifier) {
@@ -90,7 +95,10 @@ export function tryFastUpdateImporters (
         if (semver.validRange(specifier) == null || version == null || semver.valid(version) == null) {
           return false
         }
-        const wanted = highestLockedVersionSatisfying(lockfile, alias, specifier)
+        const wanted = lockedVersionResolutionWouldPick(lockfile, alias, {
+          specifier,
+          resolutionPicksLowest: opts.resolutionPicksLowest,
+        })
         if (wanted == null) return false
         if (wanted !== version) {
           // Safe without resolving because the target version is already in
@@ -136,12 +144,12 @@ export function tryFastUpdateImporters (
 }
 
 /**
- * Whether the lockfile records no dependency of this project. That is what a
- * project the lockfile has never seen looks like by the time a handler runs:
- * reading the lockfile seeds every project that has no entry with an empty
- * one, so a new project arrives as an importer with nothing in it.
+ * Whether the lockfile records no dependency of this project — the shape a
+ * project it has never seen arrives in. Usually an empty entry rather than an
+ * absent one, since reading the lockfile seeds every project that has none.
  */
-function hasNoRecordedDependencies (importer: ProjectSnapshot): boolean {
+function recordsNoDependencies (importer: ProjectSnapshot | undefined): boolean {
+  if (importer == null) return true
   return Object.keys(importer.specifiers).length === 0 &&
     DEPENDENCIES_FIELDS.every((group) => importer[group] == null || Object.keys(importer[group]).length === 0)
 }
@@ -157,13 +165,16 @@ function hasNoRecordedDependencies (importer: ProjectSnapshot): boolean {
 function writeImporterFromLockedVersions (
   lockfile: LockfileObject,
   project: Project,
-  workspacePackages: WorkspacePackages
+  opts: FastImportersUpdateOptions
 ): boolean {
   const importer: ProjectSnapshot = { specifiers: {} }
   for (const [alias, specifier] of Object.entries(getManifestSpecifiers(project.manifest))) {
-    if (isDirectoryDependency(alias, specifier, workspacePackages)) return false
+    if (isDirectoryDependency(alias, specifier, opts.workspacePackages)) return false
     if (semver.validRange(specifier) == null) return false
-    const version = highestLockedVersionSatisfying(lockfile, alias, specifier)
+    const version = lockedVersionResolutionWouldPick(lockfile, alias, {
+      specifier,
+      resolutionPicksLowest: opts.resolutionPicksLowest,
+    })
     if (version == null) return false
     const group = effectiveDependencyGroup(project.manifest, alias)
     ;(importer[group] ??= {})[alias] = version
@@ -187,16 +198,22 @@ function writeImporterFromLockedVersions (
  * the registry, so reusing what is present is what it would record — for a
  * widened range as much as for one the locked version cannot satisfy at all.
  *
- * `null` when nothing present satisfies (only the resolver can fetch a new
- * version), or when the alias appears under a key this cannot turn back
- * into a plain importer reference: a peer-suffixed one, where picking a
- * variant would be a guess, or a registry-qualified one, whose semver only
- * pins a version within its named registry.
+ * `null` when the pick cannot be read off the lockfile:
+ *
+ * - nothing present satisfies, so only the resolver can fetch a version;
+ * - `resolutionPicksLowest` and more than one locked version satisfies. Those
+ *   resolution modes take the lowest preferred version for a direct
+ *   dependency, but only when the run leaves the manifest alone, so which end
+ *   of the range applies is not a property of the lockfile;
+ * - the alias appears under a key this cannot turn back into a plain importer
+ *   reference: a peer-suffixed one, where picking a variant would be a guess,
+ *   or a registry-qualified one, whose semver only pins a version within its
+ *   named registry.
  */
-function highestLockedVersionSatisfying (
+function lockedVersionResolutionWouldPick (
   lockfile: LockfileObject,
   alias: string,
-  specifier: string
+  wanted: { specifier: string, resolutionPicksLowest: boolean }
 ): string | null {
   const versions = new Set<string>()
   for (const [depPath, snapshot] of Object.entries(lockfile.packages ?? {})) {
@@ -204,11 +221,12 @@ function highestLockedVersionSatisfying (
     if (name !== alias) continue
     if (nonSemverVersion != null) continue
     if (registryName != null || dp.parseDepPath(depPath).peerDepGraphHash !== '') return null
-    if (semver.valid(version) != null && semver.satisfies(version, specifier)) {
+    if (semver.valid(version) != null && semver.satisfies(version, wanted.specifier)) {
       versions.add(version)
     }
   }
   if (versions.size === 0) return null
+  if (versions.size > 1 && wanted.resolutionPicksLowest) return null
   return [...versions].sort(semver.rcompare)[0]
 }
 

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
@@ -3,11 +3,13 @@ import path from 'node:path'
 import * as dp from '@pnpm/deps.path'
 import type { LockfileObject, ProjectSnapshot } from '@pnpm/lockfile.types'
 import { nameVerFromPkgSnapshot } from '@pnpm/lockfile.utils'
+import type { WorkspacePackages } from '@pnpm/resolving.resolver-base'
 import { DEPENDENCIES_FIELDS, type DependenciesField, type ProjectId, type ProjectManifest } from '@pnpm/types'
 import semver from 'semver'
 
 import { type DroppedEdges, recordDroppedEdge } from './droppedEdges.js'
 import type { GraphEdits } from './tryComposeFastUpdates.js'
+import { isDirectoryDependency } from './tryFastUpdateSettings.js'
 
 export interface Project {
   id: ProjectId
@@ -32,6 +34,12 @@ export function hasChangedProjectSpecifiers (
   })
 }
 
+export interface FastImportersUpdateOptions {
+  projects: Project[]
+  pruneLockfileImporters: boolean
+  workspacePackages: WorkspacePackages
+}
+
 /**
  * Mutates `lockfile` in place and may leave it partially rewritten when it
  * returns `false` — the caller passes the coordinator's disposable candidate,
@@ -40,7 +48,7 @@ export function hasChangedProjectSpecifiers (
  */
 export function tryFastUpdateImporters (
   lockfile: LockfileObject,
-  opts: { projects: Project[], pruneLockfileImporters: boolean },
+  opts: FastImportersUpdateOptions,
   edits: GraphEdits
 ): boolean {
   const { projects } = opts
@@ -64,8 +72,16 @@ export function tryFastUpdateImporters (
   for (const project of projects) {
     const importer = lockfile.importers[project.id]
     if (importer == null) return false
-    let editedGroups = false
     const manifestSpecifiers = getManifestSpecifiers(project.manifest)
+    if (hasNoRecordedDependencies(importer) && Object.keys(manifestSpecifiers).length > 0) {
+      if (!writeImporterFromLockedVersions(lockfile, project, opts.workspacePackages)) return false
+      // The only edit that adds reachability, so a package that until now
+      // only optional dependencies reached can have stopped being optional.
+      edits.optionalFlagsAreStale = true
+      changed = true
+      continue
+    }
+    let editedGroups = false
     for (const [alias, specifier] of Object.entries(manifestSpecifiers)) {
       if (importer.specifiers[alias] !== specifier) {
         const recordedIn = recordedDependencyGroup(importer, alias)
@@ -93,7 +109,7 @@ export function tryFastUpdateImporters (
       target[alias] = importer[recordedIn]![alias]
       delete importer[recordedIn]![alias]
       if (recordedIn === 'optionalDependencies' || targetGroup === 'optionalDependencies') {
-        edits.movedAcrossOptional = true
+        edits.optionalFlagsAreStale = true
       }
       editedGroups = true
       changed = true
@@ -117,6 +133,50 @@ export function tryFastUpdateImporters (
     }
   }
   return changed
+}
+
+/**
+ * Whether the lockfile records no dependency of this project. That is what a
+ * project the lockfile has never seen looks like by the time a handler runs:
+ * reading the lockfile seeds every project that has no entry with an empty
+ * one, so a new project arrives as an importer with nothing in it.
+ */
+function hasNoRecordedDependencies (importer: ProjectSnapshot): boolean {
+  return Object.keys(importer.specifiers).length === 0 &&
+    DEPENDENCIES_FIELDS.every((group) => importer[group] == null || Object.keys(importer[group]).length === 0)
+}
+
+/**
+ * Write a project's whole importer entry from the versions the lockfile
+ * already holds.
+ *
+ * `false` when a declared dependency needs the resolver: one that resolves to
+ * a directory rather than to a registry version, one whose specifier is not a
+ * semver range, and one no locked version satisfies.
+ */
+function writeImporterFromLockedVersions (
+  lockfile: LockfileObject,
+  project: Project,
+  workspacePackages: WorkspacePackages
+): boolean {
+  const importer: ProjectSnapshot = { specifiers: {} }
+  for (const [alias, specifier] of Object.entries(getManifestSpecifiers(project.manifest))) {
+    if (isDirectoryDependency(alias, specifier, workspacePackages)) return false
+    if (semver.validRange(specifier) == null) return false
+    const version = highestLockedVersionSatisfying(lockfile, alias, specifier)
+    if (version == null) return false
+    const group = effectiveDependencyGroup(project.manifest, alias)
+    ;(importer[group] ??= {})[alias] = version
+    importer.specifiers[alias] = specifier
+  }
+  if (project.manifest.dependenciesMeta != null) {
+    importer.dependenciesMeta = project.manifest.dependenciesMeta
+  }
+  if (project.manifest.publishConfig?.directory != null) {
+    importer.publishDirectory = project.manifest.publishConfig.directory
+  }
+  lockfile.importers[project.id] = importer
+  return true
 }
 
 /**

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateSettings.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateSettings.ts
@@ -111,7 +111,12 @@ function hasNoInjectableDependencies (
   )
 }
 
-function isDirectoryDependency (
+/**
+ * Whether `alias` resolves to a directory rather than to a registry version:
+ * the protocols that name one outright, and a plain range on a workspace
+ * project's name, which `linkWorkspacePackages` turns into a link.
+ */
+export function isDirectoryDependency (
   alias: string,
   bareSpecifier: string,
   workspacePackages: WorkspacePackages

--- a/pnpm11/installing/deps-installer/test/install/catalogFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/catalogFastUpdate.ts
@@ -357,5 +357,5 @@ function trackRequestedPackages (storeController: StoreController): string[] {
 }
 /** The composed pipeline restricted to manifest drift. */
 function tryFastUpdateImporters (lockfile: LockfileObject, projects: Project[]): boolean {
-  return tryComposeFastUpdates(lockfile, { drift: { importers: true }, projects, workspacePackages: new Map() })
+  return tryComposeFastUpdates(lockfile, { drift: { importers: true }, projects, workspacePackages: new Map(), resolutionPicksLowest: false })
 }

--- a/pnpm11/installing/deps-installer/test/install/catalogFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/catalogFastUpdate.ts
@@ -357,5 +357,5 @@ function trackRequestedPackages (storeController: StoreController): string[] {
 }
 /** The composed pipeline restricted to manifest drift. */
 function tryFastUpdateImporters (lockfile: LockfileObject, projects: Project[]): boolean {
-  return tryComposeFastUpdates(lockfile, { drift: { importers: true }, projects })
+  return tryComposeFastUpdates(lockfile, { drift: { importers: true }, projects, workspacePackages: new Map() })
 }

--- a/pnpm11/installing/deps-installer/test/install/composedFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/composedFastUpdate.ts
@@ -13,6 +13,7 @@ test('a removal and a widened ignore list are absorbed in one pass', () => {
 
   expect(tryComposeFastUpdates(subject, {
     drift: { importers: true, ignoredOptionalDependencies: true },
+    workspacePackages: new Map(),
     projects: [project({ dependencies: { bar: '^2.0.0' }, optionalDependencies: { opt: '^5.0.0' } })],
     ignoredOptionalDependencies: ['opt'],
   })).toBe(true)
@@ -29,6 +30,7 @@ test('a group move and a settings change are absorbed in one pass', () => {
 
   expect(tryComposeFastUpdates(subject, {
     drift: { importers: true, settings: true },
+    workspacePackages: new Map(),
     projects: [project({
       devDependencies: { foo: '^1.0.0' },
       dependencies: { bar: '^2.0.0' },
@@ -58,6 +60,7 @@ test('a peer setting is absorbed once the removal drops the last peer dependent'
 
   expect(tryComposeFastUpdates(subject, {
     drift: { importers: true, settings: true },
+    workspacePackages: new Map(),
     projects: [project({
       dependencies: { foo: '^1.0.0', bar: '^2.0.0' },
       optionalDependencies: { opt: '^5.0.0' },
@@ -79,6 +82,7 @@ test('a composed update falls back when one of its changes cannot be absorbed', 
 
   expect(tryComposeFastUpdates(subject, {
     drift: { importers: true, settings: true },
+    workspacePackages: new Map(),
     projects: [project({
       dependencies: { foo: '^9.0.0', bar: '^2.0.0' },
       optionalDependencies: { opt: '^5.0.0' },
@@ -103,6 +107,7 @@ test('an ignored optional embedded in a surviving peer suffix falls back', () =>
 
   expect(tryComposeFastUpdates(subject, {
     drift: { ignoredOptionalDependencies: true },
+    workspacePackages: new Map(),
     projects: [],
     ignoredOptionalDependencies: ['opt'],
   })).toBe(false)
@@ -117,6 +122,7 @@ test('an ignored optional removal recomputes the survivors\' optional flags', ()
 
   expect(tryComposeFastUpdates(subject, {
     drift: { ignoredOptionalDependencies: true },
+    workspacePackages: new Map(),
     projects: [],
     ignoredOptionalDependencies: ['bar'],
   })).toBe(true)

--- a/pnpm11/installing/deps-installer/test/install/composedFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/composedFastUpdate.ts
@@ -14,6 +14,7 @@ test('a removal and a widened ignore list are absorbed in one pass', () => {
   expect(tryComposeFastUpdates(subject, {
     drift: { importers: true, ignoredOptionalDependencies: true },
     workspacePackages: new Map(),
+    resolutionPicksLowest: false,
     projects: [project({ dependencies: { bar: '^2.0.0' }, optionalDependencies: { opt: '^5.0.0' } })],
     ignoredOptionalDependencies: ['opt'],
   })).toBe(true)
@@ -31,6 +32,7 @@ test('a group move and a settings change are absorbed in one pass', () => {
   expect(tryComposeFastUpdates(subject, {
     drift: { importers: true, settings: true },
     workspacePackages: new Map(),
+    resolutionPicksLowest: false,
     projects: [project({
       devDependencies: { foo: '^1.0.0' },
       dependencies: { bar: '^2.0.0' },
@@ -61,6 +63,7 @@ test('a peer setting is absorbed once the removal drops the last peer dependent'
   expect(tryComposeFastUpdates(subject, {
     drift: { importers: true, settings: true },
     workspacePackages: new Map(),
+    resolutionPicksLowest: false,
     projects: [project({
       dependencies: { foo: '^1.0.0', bar: '^2.0.0' },
       optionalDependencies: { opt: '^5.0.0' },
@@ -83,6 +86,7 @@ test('a composed update falls back when one of its changes cannot be absorbed', 
   expect(tryComposeFastUpdates(subject, {
     drift: { importers: true, settings: true },
     workspacePackages: new Map(),
+    resolutionPicksLowest: false,
     projects: [project({
       dependencies: { foo: '^9.0.0', bar: '^2.0.0' },
       optionalDependencies: { opt: '^5.0.0' },
@@ -108,6 +112,7 @@ test('an ignored optional embedded in a surviving peer suffix falls back', () =>
   expect(tryComposeFastUpdates(subject, {
     drift: { ignoredOptionalDependencies: true },
     workspacePackages: new Map(),
+    resolutionPicksLowest: false,
     projects: [],
     ignoredOptionalDependencies: ['opt'],
   })).toBe(false)
@@ -123,6 +128,7 @@ test('an ignored optional removal recomputes the survivors\' optional flags', ()
   expect(tryComposeFastUpdates(subject, {
     drift: { ignoredOptionalDependencies: true },
     workspacePackages: new Map(),
+    resolutionPicksLowest: false,
     projects: [],
     ignoredOptionalDependencies: ['bar'],
   })).toBe(true)

--- a/pnpm11/installing/deps-installer/test/install/ignoredOptionalDependencies.ts
+++ b/pnpm11/installing/deps-installer/test/install/ignoredOptionalDependencies.ts
@@ -229,6 +229,7 @@ function tryFastUpdateIgnoredOptionalDependencies (
   return tryComposeFastUpdates(lockfile, {
     drift: { ignoredOptionalDependencies: true },
     workspacePackages: new Map(),
+    resolutionPicksLowest: false,
     projects: [],
     ignoredOptionalDependencies,
   })

--- a/pnpm11/installing/deps-installer/test/install/ignoredOptionalDependencies.ts
+++ b/pnpm11/installing/deps-installer/test/install/ignoredOptionalDependencies.ts
@@ -228,6 +228,7 @@ function tryFastUpdateIgnoredOptionalDependencies (
 ): boolean {
   return tryComposeFastUpdates(lockfile, {
     drift: { ignoredOptionalDependencies: true },
+    workspacePackages: new Map(),
     projects: [],
     ignoredOptionalDependencies,
   })

--- a/pnpm11/installing/deps-installer/test/install/importerGroupMoveFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/importerGroupMoveFastUpdate.ts
@@ -218,5 +218,5 @@ function lockfile (): LockfileObject {
 }
 /** The composed pipeline restricted to manifest drift. */
 function tryFastUpdateImporters (lockfile: LockfileObject, projects: ImporterProject[]): boolean {
-  return tryComposeFastUpdates(lockfile, { drift: { importers: true }, projects, workspacePackages: new Map() })
+  return tryComposeFastUpdates(lockfile, { drift: { importers: true }, projects, workspacePackages: new Map(), resolutionPicksLowest: false })
 }

--- a/pnpm11/installing/deps-installer/test/install/importerGroupMoveFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/importerGroupMoveFastUpdate.ts
@@ -218,5 +218,5 @@ function lockfile (): LockfileObject {
 }
 /** The composed pipeline restricted to manifest drift. */
 function tryFastUpdateImporters (lockfile: LockfileObject, projects: ImporterProject[]): boolean {
-  return tryComposeFastUpdates(lockfile, { drift: { importers: true }, projects })
+  return tryComposeFastUpdates(lockfile, { drift: { importers: true }, projects, workspacePackages: new Map() })
 }

--- a/pnpm11/installing/deps-installer/test/install/importerRemovalFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/importerRemovalFastUpdate.ts
@@ -351,5 +351,5 @@ test('removing the last catalog referent drops the catalogs section from the loc
 })
 /** The composed pipeline restricted to manifest drift. */
 function tryFastUpdateImporters (lockfile: LockfileObject, projects: Project[]): boolean {
-  return tryComposeFastUpdates(lockfile, { drift: { importers: true }, projects, workspacePackages: new Map() })
+  return tryComposeFastUpdates(lockfile, { drift: { importers: true }, projects, workspacePackages: new Map(), resolutionPicksLowest: false })
 }

--- a/pnpm11/installing/deps-installer/test/install/importerRemovalFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/importerRemovalFastUpdate.ts
@@ -351,5 +351,5 @@ test('removing the last catalog referent drops the catalogs section from the loc
 })
 /** The composed pipeline restricted to manifest drift. */
 function tryFastUpdateImporters (lockfile: LockfileObject, projects: Project[]): boolean {
-  return tryComposeFastUpdates(lockfile, { drift: { importers: true }, projects })
+  return tryComposeFastUpdates(lockfile, { drift: { importers: true }, projects, workspacePackages: new Map() })
 }

--- a/pnpm11/installing/deps-installer/test/install/lockedVersionReuse.ts
+++ b/pnpm11/installing/deps-installer/test/install/lockedVersionReuse.ts
@@ -122,6 +122,7 @@ test('a higher version that exists only under a named registry falls back', () =
 
   expect(tryComposeFastUpdates(subject, {
     drift: { importers: true },
+    workspacePackages: new Map(),
     projects: [{
       id: '.' as ProjectId,
       manifest: { dependencies: { '@pnpm.e2e/foo': '^1.1.0' } } as ProjectManifest,
@@ -134,6 +135,7 @@ test('a higher version under a plain key is reused', () => {
 
   expect(tryComposeFastUpdates(subject, {
     drift: { importers: true },
+    workspacePackages: new Map(),
     projects: [{
       id: '.' as ProjectId,
       manifest: { dependencies: { '@pnpm.e2e/foo': '^1.1.0' } } as ProjectManifest,
@@ -149,6 +151,7 @@ test('a moved range keeps a package whose peer suffix names the version it moves
 
   expect(tryComposeFastUpdates(subject, {
     drift: { importers: true },
+    workspacePackages: new Map(),
     projects: [{
       id: '.' as ProjectId,
       manifest: { dependencies: { '@pnpm.e2e/foo': '^1.1.0', '@pnpm.e2e/qux': '^5.0.0' } } as ProjectManifest,
@@ -169,6 +172,7 @@ test('a moved range falls back when a peer suffix names the version it moves off
 
   expect(tryComposeFastUpdates(subject, {
     drift: { importers: true },
+    workspacePackages: new Map(),
     projects: [{
       id: '.' as ProjectId,
       manifest: {

--- a/pnpm11/installing/deps-installer/test/install/lockedVersionReuse.ts
+++ b/pnpm11/installing/deps-installer/test/install/lockedVersionReuse.ts
@@ -123,6 +123,7 @@ test('a higher version that exists only under a named registry falls back', () =
   expect(tryComposeFastUpdates(subject, {
     drift: { importers: true },
     workspacePackages: new Map(),
+    resolutionPicksLowest: false,
     projects: [{
       id: '.' as ProjectId,
       manifest: { dependencies: { '@pnpm.e2e/foo': '^1.1.0' } } as ProjectManifest,
@@ -136,6 +137,7 @@ test('a higher version under a plain key is reused', () => {
   expect(tryComposeFastUpdates(subject, {
     drift: { importers: true },
     workspacePackages: new Map(),
+    resolutionPicksLowest: false,
     projects: [{
       id: '.' as ProjectId,
       manifest: { dependencies: { '@pnpm.e2e/foo': '^1.1.0' } } as ProjectManifest,
@@ -152,6 +154,7 @@ test('a moved range keeps a package whose peer suffix names the version it moves
   expect(tryComposeFastUpdates(subject, {
     drift: { importers: true },
     workspacePackages: new Map(),
+    resolutionPicksLowest: false,
     projects: [{
       id: '.' as ProjectId,
       manifest: { dependencies: { '@pnpm.e2e/foo': '^1.1.0', '@pnpm.e2e/qux': '^5.0.0' } } as ProjectManifest,
@@ -173,6 +176,7 @@ test('a moved range falls back when a peer suffix names the version it moves off
   expect(tryComposeFastUpdates(subject, {
     drift: { importers: true },
     workspacePackages: new Map(),
+    resolutionPicksLowest: false,
     projects: [{
       id: '.' as ProjectId,
       manifest: {

--- a/pnpm11/installing/deps-installer/test/install/newImporterFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/newImporterFastUpdate.ts
@@ -1,0 +1,226 @@
+import path from 'node:path'
+
+import { expect, test } from '@jest/globals'
+import { WANTED_LOCKFILE } from '@pnpm/constants'
+import { mutateModules } from '@pnpm/installing.deps-installer'
+import type { LockfileFile, LockfileObject } from '@pnpm/lockfile.types'
+import { preparePackages } from '@pnpm/prepare'
+import type { StoreController } from '@pnpm/store.controller-types'
+import type { DepPath, ProjectId, ProjectManifest, ProjectRootDir } from '@pnpm/types'
+import { readYamlFileSync } from 'read-yaml-file'
+
+import { tryComposeFastUpdates } from '../../src/install/tryComposeFastUpdates.js'
+import { testDefaults } from '../utils/index.js'
+
+test('adding a workspace package whose dependencies are locked resolves nothing', async () => {
+  const { install, readLockfile } = prepareWorkspace()
+  await install([
+    { name: 'project-1', dependencies: { 'is-positive': '1.0.0' } },
+  ])
+
+  const requestedPackages = await install([
+    { name: 'project-1', dependencies: { 'is-positive': '1.0.0' } },
+    { name: 'project-2', dependencies: { 'is-positive': '1.0.0' } },
+  ])
+
+  expect(requestedPackages).toStrictEqual([])
+  const lockfile = readLockfile()
+  expect(Object.keys(lockfile.importers)).toStrictEqual(['project-1', 'project-2'])
+  expect(lockfile.importers['project-2' as ProjectId].dependencies).toStrictEqual({
+    'is-positive': { specifier: '1.0.0', version: '1.0.0' },
+  })
+  expect(Object.keys(lockfile.packages ?? {})).toStrictEqual(['is-positive@1.0.0'])
+})
+
+test('a new project reuses the highest locked version its range admits', async () => {
+  const { install, readLockfile } = prepareWorkspace()
+  await install([
+    { name: 'project-1', dependencies: { '@pnpm.e2e/foo': '1.2.0' } },
+  ])
+
+  const requestedPackages = await install([
+    { name: 'project-1', dependencies: { '@pnpm.e2e/foo': '1.2.0' } },
+    { name: 'project-2', devDependencies: { '@pnpm.e2e/foo': '^1.0.0' } },
+  ])
+
+  expect(requestedPackages).toStrictEqual([])
+  const lockfile = readLockfile()
+  expect(lockfile.importers['project-2' as ProjectId].devDependencies).toStrictEqual({
+    '@pnpm.e2e/foo': { specifier: '^1.0.0', version: '1.2.0' },
+  })
+  expect(Object.keys(lockfile.packages ?? {})).toStrictEqual(['@pnpm.e2e/foo@1.2.0'])
+})
+
+test('a new project with a dependency no locked version satisfies falls back to the resolver', async () => {
+  const { install, readLockfile } = prepareWorkspace()
+  await install([
+    { name: 'project-1', dependencies: { 'is-positive': '1.0.0' } },
+  ])
+
+  const requestedPackages = await install([
+    { name: 'project-1', dependencies: { 'is-positive': '1.0.0' } },
+    { name: 'project-2', dependencies: { 'is-negative': '1.0.0' } },
+  ])
+
+  expect(requestedPackages).toContain('is-negative')
+  expect(readLockfile().importers['project-2' as ProjectId].dependencies).toStrictEqual({
+    'is-negative': { specifier: '1.0.0', version: '1.0.0' },
+  })
+})
+
+test("a new project's plain dependency clears the optional flag it inherited", async () => {
+  const { install, readLockfile } = prepareWorkspace()
+  await install([
+    { name: 'project-1', optionalDependencies: { 'is-positive': '1.0.0' } },
+  ])
+  expect(readLockfile().snapshots['is-positive@1.0.0' as DepPath].optional).toBe(true)
+
+  const requestedPackages = await install([
+    { name: 'project-1', optionalDependencies: { 'is-positive': '1.0.0' } },
+    { name: 'project-2', dependencies: { 'is-positive': '1.0.0' } },
+  ])
+
+  expect(requestedPackages).toStrictEqual([])
+  expect(readLockfile().snapshots['is-positive@1.0.0' as DepPath].optional).toBeUndefined()
+})
+
+test('the fast path writes the lockfile a full resolution would', async () => {
+  const { install, readLockfile } = prepareWorkspace()
+  const initial: WorkspaceProject[] = [
+    { name: 'project-1', optionalDependencies: { 'is-positive': '1.0.0' }, dependencies: { '@pnpm.e2e/foo': '1.2.0' } },
+  ]
+  const extended: WorkspaceProject[] = [
+    ...initial,
+    {
+      name: 'project-2',
+      dependencies: { 'is-positive': '1.0.0' },
+      devDependencies: { '@pnpm.e2e/foo': '^1.0.0' },
+    },
+  ]
+
+  await install(initial)
+  expect(await install(extended)).toStrictEqual([])
+  const fastUpdated = readLockfile()
+
+  await install(initial)
+  await install(extended, { forceFullResolution: true })
+
+  expect(fastUpdated).toStrictEqual(readLockfile())
+})
+
+test('a new project on a time-based lockfile writes what a full resolution would', async () => {
+  const { install, readLockfile } = prepareWorkspace({ resolutionMode: 'time-based' })
+  const initial: WorkspaceProject[] = [
+    { name: 'project-1', dependencies: { '@pnpm.e2e/pkg-with-1-dep': '100.0.0' } },
+  ]
+  const extended: WorkspaceProject[] = [
+    ...initial,
+    // Only a transitive dependency until now, so the lockfile has no publish
+    // date for it, and it becomes a direct one the `time` section covers.
+    { name: 'project-2', dependencies: { '@pnpm.e2e/dep-of-pkg-with-1-dep': '100.1.0' } },
+  ]
+
+  await install(initial)
+  expect(Object.keys(readLockfile().time)).toStrictEqual(['@pnpm.e2e/pkg-with-1-dep@100.0.0'])
+  expect(await install(extended)).toStrictEqual([])
+  const fastUpdated = readLockfile()
+
+  await install(initial)
+  await install(extended, { forceFullResolution: true })
+
+  expect(fastUpdated).toStrictEqual(readLockfile())
+})
+
+test('a new project that depends on a workspace sibling falls back to the resolver', () => {
+  const subject = lockfileWithSeededImporter()
+
+  expect(tryComposeFastUpdates(subject, {
+    drift: { importers: true },
+    workspacePackages: new Map([
+      ['@pnpm.e2e/foo', new Map([['1.2.0', {
+        rootDir: path.resolve('foo') as ProjectRootDir,
+        manifest: { name: '@pnpm.e2e/foo', version: '1.2.0' },
+      }]])],
+    ]),
+    projects: [
+      { id: 'project-1' as ProjectId, manifest: { dependencies: { '@pnpm.e2e/foo': '1.2.0' } } as ProjectManifest },
+      { id: 'project-2' as ProjectId, manifest: { dependencies: { '@pnpm.e2e/foo': '^1.0.0' } } as ProjectManifest },
+    ],
+  })).toBe(false)
+})
+
+test('a new project that names a dependency the lockfile has never held falls back', () => {
+  const subject = lockfileWithSeededImporter()
+
+  expect(tryComposeFastUpdates(subject, {
+    drift: { importers: true },
+    workspacePackages: new Map(),
+    projects: [
+      { id: 'project-1' as ProjectId, manifest: { dependencies: { '@pnpm.e2e/foo': '1.2.0' } } as ProjectManifest },
+      { id: 'project-2' as ProjectId, manifest: { dependencies: { '@pnpm.e2e/bar': '1.0.0' } } as ProjectManifest },
+    ],
+  })).toBe(false)
+})
+
+/**
+ * The shape a new project reaches a handler in: reading the lockfile seeds an
+ * empty importer entry for every project that has none.
+ */
+function lockfileWithSeededImporter (): LockfileObject {
+  return {
+    lockfileVersion: '9.0',
+    importers: {
+      ['project-1' as ProjectId]: {
+        specifiers: { '@pnpm.e2e/foo': '1.2.0' },
+        dependencies: { '@pnpm.e2e/foo': '1.2.0' },
+      },
+      ['project-2' as ProjectId]: { specifiers: {} },
+    },
+    packages: {
+      ['@pnpm.e2e/foo@1.2.0' as DepPath]: { resolution: { integrity: 'sha512-foo' } },
+    },
+  }
+}
+
+interface WorkspaceProject {
+  name: string
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+  optionalDependencies?: Record<string, string>
+}
+
+function prepareWorkspace (sharedOptions?: { resolutionMode: 'time-based' }) {
+  const locations = ['project-1', 'project-2']
+  preparePackages(locations.map((name) => ({ location: name, package: { name } })))
+  const install = async (
+    projects: WorkspaceProject[],
+    extraOptions?: { forceFullResolution: boolean }
+  ): Promise<string[]> => {
+    const options = testDefaults({
+      allProjects: projects.map(({ name, ...dependencyFields }) => ({
+        buildIndex: 0,
+        manifest: { name, version: '1.0.0', ...dependencyFields },
+        rootDir: path.resolve(name) as ProjectRootDir,
+      })),
+      ...sharedOptions,
+      ...extraOptions,
+    })
+    const requestedPackages = trackRequestedPackages(options.storeController)
+    await mutateModules(projects.map(({ name }) => ({
+      mutation: 'install' as const,
+      rootDir: path.resolve(name) as ProjectRootDir,
+    })), options)
+    return requestedPackages
+  }
+  return { install, readLockfile: () => readYamlFileSync<Required<LockfileFile>>(WANTED_LOCKFILE) }
+}
+
+function trackRequestedPackages (storeController: StoreController): string[] {
+  const requestedPackages: string[] = []
+  const requestPackage = storeController.requestPackage
+  storeController.requestPackage = async (wantedDependency, requestOptions) => {
+    requestedPackages.push(wantedDependency.alias!)
+    return requestPackage(wantedDependency, requestOptions)
+  }
+  return requestedPackages
+}

--- a/pnpm11/installing/deps-installer/test/install/newImporterFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/newImporterFastUpdate.ts
@@ -165,6 +165,7 @@ test('a new project that depends on a workspace sibling falls back to the resolv
         manifest: { name: '@pnpm.e2e/foo', version: '1.2.0' },
       }]])],
     ]),
+    resolutionPicksLowest: false,
     projects: [
       { id: 'project-1' as ProjectId, manifest: { dependencies: { '@pnpm.e2e/foo': '1.2.0' } } as ProjectManifest },
       { id: 'project-2' as ProjectId, manifest: { dependencies: { '@pnpm.e2e/foo': '^1.0.0' } } as ProjectManifest },

--- a/pnpm11/installing/deps-installer/test/install/newImporterFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/newImporterFastUpdate.ts
@@ -34,12 +34,10 @@ test('adding a workspace package whose dependencies are locked resolves nothing'
 
 test('a new project reuses the highest locked version its range admits', async () => {
   const { install, readLockfile } = prepareWorkspace()
-  await install([
-    { name: 'project-1', dependencies: { '@pnpm.e2e/foo': '1.2.0' } },
-  ])
+  await install(TWO_LOCKED_VERSIONS)
 
   const requestedPackages = await install([
-    { name: 'project-1', dependencies: { '@pnpm.e2e/foo': '1.2.0' } },
+    ...TWO_LOCKED_VERSIONS,
     { name: 'project-2', devDependencies: { '@pnpm.e2e/foo': '^1.0.0' } },
   ])
 
@@ -48,7 +46,10 @@ test('a new project reuses the highest locked version its range admits', async (
   expect(lockfile.importers['project-2' as ProjectId].devDependencies).toStrictEqual({
     '@pnpm.e2e/foo': { specifier: '^1.0.0', version: '1.2.0' },
   })
-  expect(Object.keys(lockfile.packages ?? {})).toStrictEqual(['@pnpm.e2e/foo@1.2.0'])
+  expect(Object.keys(lockfile.packages ?? {}).sort()).toStrictEqual([
+    '@pnpm.e2e/foo@1.0.0',
+    '@pnpm.e2e/foo@1.2.0',
+  ])
 })
 
 test('a new project with a dependency no locked version satisfies falls back to the resolver', async () => {
@@ -87,7 +88,8 @@ test("a new project's plain dependency clears the optional flag it inherited", a
 test('the fast path writes the lockfile a full resolution would', async () => {
   const { install, readLockfile } = prepareWorkspace()
   const initial: WorkspaceProject[] = [
-    { name: 'project-1', optionalDependencies: { 'is-positive': '1.0.0' }, dependencies: { '@pnpm.e2e/foo': '1.2.0' } },
+    ...TWO_LOCKED_VERSIONS,
+    { name: 'project-1', optionalDependencies: { 'is-positive': '1.0.0' } },
   ]
   const extended: WorkspaceProject[] = [
     ...initial,
@@ -113,15 +115,14 @@ test('a new project on a time-based lockfile writes what a full resolution would
   const initial: WorkspaceProject[] = [
     { name: 'project-1', dependencies: { '@pnpm.e2e/pkg-with-1-dep': '100.0.0' } },
   ]
-  const extended: WorkspaceProject[] = [
-    ...initial,
-    // Only a transitive dependency until now, so the lockfile has no publish
-    // date for it, and it becomes a direct one the `time` section covers.
-    { name: 'project-2', dependencies: { '@pnpm.e2e/dep-of-pkg-with-1-dep': '100.1.0' } },
-  ]
 
   await install(initial)
   expect(Object.keys(readLockfile().time)).toStrictEqual(['@pnpm.e2e/pkg-with-1-dep@100.0.0'])
+  // Transitive-only until now, so `time` carries no publish date for it.
+  const extended: WorkspaceProject[] = [
+    ...initial,
+    { name: 'project-2', dependencies: { '@pnpm.e2e/dep-of-pkg-with-1-dep': lockedTransitiveVersion() } },
+  ]
   expect(await install(extended)).toStrictEqual([])
   const fastUpdated = readLockfile()
 
@@ -129,10 +130,32 @@ test('a new project on a time-based lockfile writes what a full resolution would
   await install(extended, { forceFullResolution: true })
 
   expect(fastUpdated).toStrictEqual(readLockfile())
+
+  function lockedTransitiveVersion (): string {
+    const prefix = '@pnpm.e2e/dep-of-pkg-with-1-dep@'
+    const depPath = Object.keys(readLockfile().packages).find((key) => key.startsWith(prefix))
+    return depPath!.slice(prefix.length)
+  }
+})
+
+test('a range several locked versions satisfy falls back when resolution picks the lowest', async () => {
+  const { install, readLockfile } = prepareWorkspace({ resolutionMode: 'lowest-direct' })
+  const extended: WorkspaceProject[] = [
+    ...TWO_LOCKED_VERSIONS,
+    { name: 'project-2', dependencies: { '@pnpm.e2e/foo': '^1.0.0' } },
+  ]
+
+  await install(TWO_LOCKED_VERSIONS)
+  const requestedPackages = await install(extended)
+
+  expect(requestedPackages).not.toStrictEqual([])
+  expect(readLockfile().importers['project-2' as ProjectId].dependencies).toStrictEqual({
+    '@pnpm.e2e/foo': { specifier: '^1.0.0', version: '1.0.0' },
+  })
 })
 
 test('a new project that depends on a workspace sibling falls back to the resolver', () => {
-  const subject = lockfileWithSeededImporter()
+  const subject = lockfileWithAnEmptyEntryForANewProject()
 
   expect(tryComposeFastUpdates(subject, {
     drift: { importers: true },
@@ -149,12 +172,41 @@ test('a new project that depends on a workspace sibling falls back to the resolv
   })).toBe(false)
 })
 
-test('a new project that names a dependency the lockfile has never held falls back', () => {
-  const subject = lockfileWithSeededImporter()
+test('a new project that declares a `workspace:` dependency falls back to the resolver', () => {
+  const subject = lockfileWithAnEmptyEntryForANewProject()
 
   expect(tryComposeFastUpdates(subject, {
     drift: { importers: true },
     workspacePackages: new Map(),
+    resolutionPicksLowest: false,
+    projects: [
+      { id: 'project-1' as ProjectId, manifest: { dependencies: { '@pnpm.e2e/foo': '1.2.0' } } as ProjectManifest },
+      { id: 'project-2' as ProjectId, manifest: { dependencies: { '@pnpm.e2e/foo': 'workspace:^' } } as ProjectManifest },
+    ],
+  })).toBe(false)
+})
+
+test('a new project that declares a `link:` dependency falls back to the resolver', () => {
+  const subject = lockfileWithAnEmptyEntryForANewProject()
+
+  expect(tryComposeFastUpdates(subject, {
+    drift: { importers: true },
+    workspacePackages: new Map(),
+    resolutionPicksLowest: false,
+    projects: [
+      { id: 'project-1' as ProjectId, manifest: { dependencies: { '@pnpm.e2e/foo': '1.2.0' } } as ProjectManifest },
+      { id: 'project-2' as ProjectId, manifest: { dependencies: { '@pnpm.e2e/foo': 'link:../foo' } } as ProjectManifest },
+    ],
+  })).toBe(false)
+})
+
+test('a new project that names a dependency the lockfile has never held falls back', () => {
+  const subject = lockfileWithAnEmptyEntryForANewProject()
+
+  expect(tryComposeFastUpdates(subject, {
+    drift: { importers: true },
+    workspacePackages: new Map(),
+    resolutionPicksLowest: false,
     projects: [
       { id: 'project-1' as ProjectId, manifest: { dependencies: { '@pnpm.e2e/foo': '1.2.0' } } as ProjectManifest },
       { id: 'project-2' as ProjectId, manifest: { dependencies: { '@pnpm.e2e/bar': '1.0.0' } } as ProjectManifest },
@@ -162,11 +214,7 @@ test('a new project that names a dependency the lockfile has never held falls ba
   })).toBe(false)
 })
 
-/**
- * The shape a new project reaches a handler in: reading the lockfile seeds an
- * empty importer entry for every project that has none.
- */
-function lockfileWithSeededImporter (): LockfileObject {
+function lockfileWithAnEmptyEntryForANewProject (): LockfileObject {
   return {
     lockfileVersion: '9.0',
     importers: {
@@ -182,6 +230,12 @@ function lockfileWithSeededImporter (): LockfileObject {
   }
 }
 
+/** Two projects between them lock two versions a `^1.0.0` range admits. */
+const TWO_LOCKED_VERSIONS: WorkspaceProject[] = [
+  { name: 'project-1', dependencies: { '@pnpm.e2e/foo': '1.0.0' } },
+  { name: 'project-3', dependencies: { '@pnpm.e2e/foo': '1.2.0' } },
+]
+
 interface WorkspaceProject {
   name: string
   dependencies?: Record<string, string>
@@ -189,8 +243,8 @@ interface WorkspaceProject {
   optionalDependencies?: Record<string, string>
 }
 
-function prepareWorkspace (sharedOptions?: { resolutionMode: 'time-based' }) {
-  const locations = ['project-1', 'project-2']
+function prepareWorkspace (sharedOptions?: { resolutionMode: 'time-based' | 'lowest-direct' }) {
+  const locations = ['project-1', 'project-2', 'project-3']
   preparePackages(locations.map((name) => ({ location: name, package: { name } })))
   const install = async (
     projects: WorkspaceProject[],


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#13800, item 3 of pnpm/pnpm#13696.

Adding a package to a workspace always paid a full resolution, even when every dependency it declared was already locked for a sibling — the normal case for a package scaffolded from a template. The importers fast update now writes such a project's whole entry from the versions the lockfile already holds.

**The gate the issue named was not the blocker.** `contextProjects.every((project) => ctx.wantedLockfile.importers[project.id] != null)` is always true: `readLockfiles` seeds an empty `{ specifiers: {} }` entry for every project the lockfile has no entry for, before any handler runs. What actually fired was `tryFastUpdateImporters`' own fallback, on the first declared alias with no recorded reference. So a new project reaches the handler as an importer that records nothing, and that — not a missing key — is what the new branch keys on. The dead gate is removed. pacquet does not seed, so its handler takes both shapes.

**Which version the new edge gets** is the rule pnpm/pnpm#13779 established and measured: the already-locked version resolution would dedupe onto, because `preferredVersions` biases resolution toward what the graph already holds. Four things keep the resolver:

- a dependency that resolves to a **directory** — `workspace:`, `link:`, `file:`, and a plain range on a workspace project's name, which `linkWorkspacePackages` may turn into a link. Only the resolver decides that, and `linkedPackagesAreUpToDate` would not catch a wrong guess: it looks a workspace package up by the *recorded* version, so a registry version recorded where a link belonged reads as up to date. Break-tested in both stacks.
- a specifier that is not a semver range (aliases, tags, git, tarballs, `catalog:`).
- a range no locked version satisfies — only the resolver can fetch.
- **a range several locked versions satisfy under `resolutionMode: time-based` or `lowest-direct`.** Those modes resolve a direct dependency to the *lowest* satisfying version, so "the highest locked version" is the wrong end of the range — but only for a run that leaves the manifest alone, so which end applies is not a property of the lockfile. Rather than model that, the reuse declines when the candidates are ambiguous; with one candidate the two ends coincide, so an exact specifier keeps its fast path. Caught by Qodo in review, break-tested in both stacks, and it fixes the same latent gap in the existing changed-range reuse from pnpm/pnpm#13779. The overrides handler keeps taking the highest: `resolutionMode` moves only direct dependencies, and an override names a package at any depth.

A new importer is the one edit that **adds** reachability, so the shared epilogue has to recompute the `optional` flags rather than assume them: a package that until now only optional dependencies reached can stop being optional. `GraphEdits.movedAcrossOptional` is renamed `optionalFlagsAreStale` since it now covers both causes.

`isDirectoryDependency` already existed in the settings handler and is reused rather than restated; the same in pacquet, along with `workspace_package_names`.

**Confirmed rather than assumed,** as every item of pnpm/pnpm#13696 asks: two byte-identity tests run the same addition through the fast path and through `forceFullResolution` and compare the written lockfile. The second is on a `resolutionMode: time-based` lockfile, where the new project's dependency was transitive-only before and so carries no publish date of its own — the files still match, so no `time` bail is needed.

**Not covered, unchanged from before:** a new project declaring `peerDependencies` that `autoInstallPeers` folds into its dependencies. The candidate fails `satisfiesPackageManifest` and the run falls back to the resolver, exactly as today. The same gap already applies to existing importers with auto-installed peers, so it belongs in its own change.

## Squash Commit Body

```text
Adding a package to a workspace always paid a full resolution, even
when every dependency it declared was already locked for a sibling —
the normal case for a package scaffolded from a template. The importers
handler now writes such a project's whole entry from the versions the
lockfile already holds, by the rule pnpm/pnpm#13779 established for a
single changed range: the already-locked version resolution would
dedupe onto.

The project arrives as an importer with nothing recorded rather than a
missing one, because reading the lockfile seeds an empty entry for
every project that has none. The gate that asked whether every project
had an importer was therefore always satisfied; the fallback that
actually fired was the handler's, on the first alias with no recorded
reference. pacquet does not seed, so its handler takes both shapes.

A dependency that resolves to a directory keeps the resolver, since
only it decides whether a plain range on a workspace project's name
becomes a link. So do a non-semver specifier and a range no locked
version satisfies.

So does a range several locked versions satisfy under `resolutionMode:
time-based` or `lowest-direct`. Those modes resolve a direct dependency
to the lowest satisfying version, and they apply only to a run that
leaves the manifest alone, so which end of the range wins is not a
property of the lockfile. With one candidate the two ends coincide, so
an exact specifier keeps its fast path. This closes the same gap in the
changed-range reuse. The overrides handler keeps taking the highest:
`resolutionMode` moves only direct dependencies, and an override names
a package at any depth.

A new importer is the one edit that adds reachability, so the shared
epilogue has to recompute the `optional` flags rather than leave them:
a package only optional dependencies reached can stop being optional.
`GraphEdits.movedAcrossOptional` becomes `optionalFlagsAreStale` to
cover both causes.

Both stacks. A byte-identity test runs the same addition through the
fast path and through a forced resolution, including on a time-based
lockfile, where the new direct dependency was transitive-only before
and so carries no publish date of its own.

Item 3 of pnpm/pnpm#13696, closes pnpm/pnpm#13800.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added faster lockfile updates when adding workspace packages.
  - Reuses compatible locked dependency versions without full dependency resolution.
  - Initializes new workspace projects from available lockfile data while preserving dependency settings.

- **Bug Fixes**
  - Falls back to resolution when suitable locked versions are unavailable.
  - Respects resolution mode when selecting reusable versions.
  - Improves handling of directory, invalid-range, workspace-related, and ambiguous dependencies.
  - Refreshes optional dependency metadata when necessary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->