### PR TITLE
feat: compose the catalogs and overrides rewrites with other drift

### DIFF
--- a/.changeset/composed-catalog-and-override-rewrites.md
+++ b/.changeset/composed-catalog-and-override-rewrites.md
@@ -1,0 +1,9 @@
+---
+"@pnpm/installing.deps-installer": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+A changed `catalogs` or `pnpm.overrides` block no longer has to be the only change for `pnpm install` to update the lockfile in place. Editing an override while also removing a dependency, or changing a catalog entry in the same commit as a range bump, is now absorbed in one pass instead of re-resolving the whole dependency graph [#13799](https://github.com/pnpm/pnpm/issues/13799).
+
+Fixed the lockfile an in-place override update wrote when the overridden package was also a catalog entry: the entry kept the version it had before the override moved the package. The same could happen in reverse, when a catalog entry moved a package an override pins. Both cases now re-resolve instead.

--- a/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
@@ -312,6 +312,75 @@ fn dependency_removal_override_prunes_the_locked_subtree_without_resolving() {
     drop((root, mock_instance));
 }
 
+/// Both resolver-consulting rewrites in one edit: the catalog rewrite
+/// settles the widened range and the override rewrite replays the removal
+/// onto its result, so neither has to be the only change.
+#[test]
+fn a_catalog_edit_and_a_removal_override_are_absorbed_in_one_pass() {
+    let CommandTempCwd { workspace, root, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, npmrc_path, .. } = npmrc_info;
+    let manifest_path = workspace.join("package.json");
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    fs::write(
+        &manifest_path,
+        serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pkg-with-good-optional": "catalog:"
+            }
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    let workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    fs::write(
+        &workspace_yaml_path,
+        format!(
+            "{workspace_yaml}trustLockfile: true\nfetchRetries: 0\nfetchTimeout: 1000\ncatalog:\n  '@pnpm.e2e/pkg-with-good-optional': ^1.0.0\n",
+        ),
+    )
+    .expect("write initial catalog");
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    let workspace_yaml = fs::read_to_string(&workspace_yaml_path).expect("read initial catalog");
+    fs::write(
+        &workspace_yaml_path,
+        format!(
+            "{}overrides:\n  is-positive: '-'\n",
+            workspace_yaml.replace(
+                "'@pnpm.e2e/pkg-with-good-optional': ^1.0.0",
+                "'@pnpm.e2e/pkg-with-good-optional': '>=1.0.0 <2'",
+            ),
+        ),
+    )
+    .expect("widen the catalog range and add the removal override");
+    let dead_registry = dead_registry_url();
+    let npmrc = fs::read_to_string(&npmrc_path).expect("read .npmrc");
+    let npmrc = npmrc
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("registry="))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(&npmrc_path, format!("registry={dead_registry}\n{npmrc}\n"))
+        .expect("rewrite .npmrc with a dead registry");
+
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    let wanted = pacquet_lockfile::Lockfile::load_wanted_from_dir(&workspace)
+        .expect("load updated wanted lockfile")
+        .expect("updated wanted lockfile");
+    let entry = &wanted.catalogs.as_ref().expect("catalog snapshots")["default"]["@pnpm.e2e/pkg-with-good-optional"];
+    assert_eq!(entry.specifier, ">=1.0.0 <2");
+    assert_eq!(entry.version, "1.0.0");
+    let removed_key = "is-positive@1.0.0".parse().expect("removed package key");
+    assert!(
+        wanted.snapshots.as_ref().is_none_or(|snapshots| !snapshots.contains_key(&removed_key))
+    );
+
+    drop((root, mock_instance));
+}
+
 #[test]
 fn adding_and_removing_an_ignored_optional_dependency_uses_the_safe_path() {
     let CommandTempCwd { workspace, root, npmrc_info, .. } =

--- a/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
@@ -425,7 +425,7 @@ fn a_catalog_edit_and_a_removal_override_are_absorbed_in_one_pass() {
     assert!(
         wanted.snapshots.as_ref().is_none_or(|snapshots| !snapshots.contains_key(&removed_key)),
     );
-    assert!(wanted.packages.as_ref().is_none_or(|packages| !packages.contains_key(&removed_key)),);
+    assert!(wanted.packages.as_ref().is_none_or(|packages| !packages.contains_key(&removed_key)));
 
     drop((root, mock_instance));
 }

--- a/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
@@ -312,6 +312,54 @@ fn dependency_removal_override_prunes_the_locked_subtree_without_resolving() {
     drop((root, mock_instance));
 }
 
+/// An override on a cataloged package replaces the `catalog:` specifier
+/// outright, so the entry is dropped rather than moved. The seed only
+/// feeds the resolver — the catalogs section is rebuilt from what the
+/// resolution recorded — so the rewrite needs no guard for this.
+#[test]
+fn an_override_on_a_cataloged_package_drops_the_catalog_entry() {
+    let fixture = CommandTempCwd::init().add_mocked_registry();
+    let manifest_path = fixture.workspace.join("package.json");
+    let workspace_yaml_path = fixture.workspace.join("pnpm-workspace.yaml");
+    fs::write(
+        &manifest_path,
+        serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pkg-with-1-dep": "catalog:"
+            }
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    let workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    fs::write(
+        &workspace_yaml_path,
+        format!("{workspace_yaml}catalog:\n  '@pnpm.e2e/pkg-with-1-dep': 100.0.0\n"),
+    )
+    .expect("write initial catalog");
+    pacquet_at(&fixture.workspace).with_arg("install").assert().success();
+
+    let workspace_yaml = fs::read_to_string(&workspace_yaml_path).expect("read initial catalog");
+    fs::write(
+        &workspace_yaml_path,
+        format!("{workspace_yaml}overrides:\n  '@pnpm.e2e/pkg-with-1-dep': 100.1.0\n"),
+    )
+    .expect("add the override");
+    pacquet_at(&fixture.workspace).with_arg("install").assert().success();
+
+    let wanted = pacquet_lockfile::Lockfile::load_wanted_from_dir(&fixture.workspace)
+        .expect("load updated wanted lockfile")
+        .expect("updated wanted lockfile");
+    assert!(wanted.catalogs.is_none());
+    let name = "@pnpm.e2e/pkg-with-1-dep".parse().expect("package name");
+    let dependency = &wanted.importers["."].dependencies.as_ref().expect("dependencies")[&name];
+    assert_eq!(dependency.specifier, "100.1.0");
+    assert_eq!(dependency.version.to_string(), "100.1.0");
+
+    drop(fixture);
+}
+
 /// Both resolver-consulting rewrites in one edit: the catalog rewrite
 /// settles the widened range and the override rewrite replays the removal
 /// onto its result, so neither has to be the only change.

--- a/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
@@ -425,6 +425,7 @@ fn a_catalog_edit_and_a_removal_override_are_absorbed_in_one_pass() {
     assert!(
         wanted.snapshots.as_ref().is_none_or(|snapshots| !snapshots.contains_key(&removed_key)),
     );
+    assert!(wanted.packages.as_ref().is_none_or(|packages| !packages.contains_key(&removed_key)),);
 
     drop((root, mock_instance));
 }

--- a/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
@@ -375,7 +375,7 @@ fn a_catalog_edit_and_a_removal_override_are_absorbed_in_one_pass() {
     assert_eq!(entry.version, "1.0.0");
     let removed_key = "is-positive@1.0.0".parse().expect("removed package key");
     assert!(
-        wanted.snapshots.as_ref().is_none_or(|snapshots| !snapshots.contains_key(&removed_key))
+        wanted.snapshots.as_ref().is_none_or(|snapshots| !snapshots.contains_key(&removed_key)),
     );
 
     drop((root, mock_instance));

--- a/pnpm/crates/package-manager/src/fast_update_catalog_versions.rs
+++ b/pnpm/crates/package-manager/src/fast_update_catalog_versions.rs
@@ -25,9 +25,6 @@ pub(crate) async fn try_fast_update_catalog_versions(
     // The same gate the range-only path opens with: an importer pointing at
     // a catalog entry with nothing recorded for it needs the resolver, and
     // this path would otherwise never look at that entry.
-    // The same gate the range-only path opens with: an importer pointing at
-    // a catalog entry with nothing recorded for it needs the resolver, and
-    // this path would otherwise never look at that entry.
     if !crate::fast_update_catalogs::catalog_references_have_snapshots(context.lockfile, catalogs) {
         return None;
     }

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolve.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolve.rs
@@ -220,8 +220,10 @@ pub(super) struct ReuseSeedInputs<'a> {
 /// A changed `catalogs` or `pnpm.overrides` block normally withholds the
 /// seed entirely. Two shapes are cheap enough to rewrite in place
 /// instead — a catalog edit and an exact generic registry override — and
-/// each yields a dependency-shape-verified seed. Every other shape falls
-/// back to withholding.
+/// each yields a dependency-shape-verified seed. They compose: the
+/// catalog rewrite settles first and the override rewrite replays onto
+/// its result, the order a resolution applies the two in. Every other
+/// shape falls back to withholding.
 pub(super) async fn lockfile_reuse_seed(inputs: ReuseSeedInputs<'_>) -> Option<Arc<Lockfile>> {
     use crate::{
         fast_update_catalog_versions::try_fast_update_catalog_versions,
@@ -257,74 +259,68 @@ pub(super) async fn lockfile_reuse_seed(inputs: ReuseSeedInputs<'_>) -> Option<A
         FastCatalogUpdate::Unsupported => (false, None),
     };
 
-    let reusable_settings_lockfile = wanted_lockfile.filter(|lockfile| {
+    let lockfile = wanted_lockfile.filter(|lockfile| {
         lockfile.package_extensions_checksum.as_deref() == package_extensions_checksum
             && super::ignored_optional_dependencies_match(
                 lockfile.ignored_optional_dependencies.as_deref(),
                 config.ignored_optional_dependencies.as_deref(),
             )
-    });
-    let override_settings_match = reusable_settings_lockfile.is_some_and(|lockfile| {
-        super::overrides_match(lockfile.overrides.as_ref(), resolved_overrides)
-    });
+    })?;
+    let override_settings_match =
+        super::overrides_match(lockfile.overrides.as_ref(), resolved_overrides);
 
     let rewrite_manifest_hook = super::compose_manifest_hooks(manifest_hook, overrides_hook);
-    if let (Some(lockfile), Some(parsed), Some(resolved)) =
-        (reusable_settings_lockfile, parsed_overrides, resolved_overrides)
-        && catalogs_match
-        && !overrides_use_catalogs
-        && !override_settings_match
-        && fast_override_eligible
-        && let Some(seed) = try_fast_update_overrides(FastOverrideOptions {
-            context: RewriteContext {
-                lockfile,
-                resolver: npm_resolver,
-                resolve_options,
-                manifest_hook: rewrite_manifest_hook.as_ref(),
-                registries,
-                lockfile_include_tarball_url: config.lockfile_include_tarball_url,
-            },
-            parsed_overrides: parsed,
-            resolved_overrides: resolved,
-        })
-        .await
-    {
-        return Some(Arc::new(seed));
-    }
+    // An override whose value is a `catalog:` reference is only meaningful
+    // once the catalog rewrite has settled, which the range-only rewrite
+    // refuses to do under one. Neither rewrite composes with that.
+    let can_rewrite = fast_override_eligible && !overrides_use_catalogs;
 
-    // `override_settings_match` is computed with `is_some_and`, so it
-    // already implies `reusable_settings_lockfile` is `Some`.
-    if override_settings_match && let Some(seed) = fast_catalog_seed {
-        return Some(Arc::new(seed));
-    }
-
-    // A catalog entry that now names a version the locked one cannot
-    // satisfy left `catalogs_match` false with no seed above. Replacing the
-    // package is the same rewrite an exact override performs.
-    if let Some(lockfile) = reusable_settings_lockfile
-        && override_settings_match
-        && !overrides_use_catalogs
-        && fast_override_eligible
-        && let Some(seed) = try_fast_update_catalog_versions(
-            &RewriteContext {
-                lockfile,
-                resolver: npm_resolver,
-                resolve_options,
-                manifest_hook: rewrite_manifest_hook.as_ref(),
-                registries,
-                lockfile_include_tarball_url: config.lockfile_include_tarball_url,
-            },
-            catalogs,
+    let catalog_rewrite = if catalogs_match {
+        None
+    } else if let Some(seed) = fast_catalog_seed {
+        Some(seed)
+    } else if can_rewrite {
+        // A catalog entry that now names a version the locked one cannot
+        // satisfy left `catalogs_match` false with no seed above. Replacing
+        // the package is the same rewrite an exact override performs.
+        Some(
+            try_fast_update_catalog_versions(
+                &RewriteContext {
+                    lockfile,
+                    resolver: npm_resolver,
+                    resolve_options,
+                    manifest_hook: rewrite_manifest_hook.as_ref(),
+                    registries,
+                    lockfile_include_tarball_url: config.lockfile_include_tarball_url,
+                },
+                catalogs,
+            )
+            .await?,
         )
-        .await
-    {
-        return Some(Arc::new(seed));
-    }
+    } else {
+        return None;
+    };
 
-    (catalogs_match && override_settings_match)
-        .then_some(reusable_settings_lockfile)
-        .flatten()
-        .map(|lockfile| Arc::new(lockfile.clone()))
+    if override_settings_match {
+        return Some(Arc::new(catalog_rewrite.unwrap_or_else(|| lockfile.clone())));
+    }
+    if !can_rewrite {
+        return None;
+    }
+    let seed = try_fast_update_overrides(FastOverrideOptions {
+        context: RewriteContext {
+            lockfile: catalog_rewrite.as_ref().unwrap_or(lockfile),
+            resolver: npm_resolver,
+            resolve_options,
+            manifest_hook: rewrite_manifest_hook.as_ref(),
+            registries,
+            lockfile_include_tarball_url: config.lockfile_include_tarball_url,
+        },
+        parsed_overrides: parsed_overrides?,
+        resolved_overrides: resolved_overrides?,
+    })
+    .await?;
+    Some(Arc::new(seed))
 }
 
 /// Report the `pnpm.overrides` convergence entries whose pinned value is

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -110,11 +110,8 @@ import {
 import { linkPackages } from './link.js'
 import { reportPeerDependencyIssues } from './reportPeerDependencyIssues.js'
 import { tryComposeFastUpdates } from './tryComposeFastUpdates.js'
-import { tryFastUpdateCatalogs } from './tryFastUpdateCatalogs.js'
-import { tryFastUpdateCatalogVersions } from './tryFastUpdateCatalogVersions.js'
 import { hasChangedProjectSpecifiers } from './tryFastUpdateImporters.js'
 import { tryFastUpdateLockfile } from './tryFastUpdateLockfile.js'
-import { tryFastUpdateOverrides } from './tryFastUpdateOverrides.js'
 import { validateModules } from './validateModules.js'
 import { verifyLockfileResolutions } from './verifyLockfileResolutions.js'
 import { warnOnStaleConvergenceOverrides } from './warnOnStaleConvergenceOverrides.js'
@@ -138,7 +135,9 @@ const BROKEN_LOCKFILE_INTEGRITY_ERRORS = new Set([
 const DEV_PREINSTALL = 'pnpm:devPreinstall'
 
 const COMPOSABLE_CHANGED_FIELDS = new Set<ChangedField>([
+  'catalogs',
   'ignoredOptionalDependencies',
+  'overrides',
   'patchedDependencies',
 ])
 
@@ -742,30 +741,35 @@ export async function mutateModules (
     let didFastUpdateOverrides = false
     const contextProjects = Object.values(ctx.projects)
     const changedSettingsFields = changedLockfileSettings.filter(isSettingsField)
-    const allChangedFieldsAreComposable = changedLockfileSettings.every((field) =>
-      isSettingsField(field) || COMPOSABLE_CHANGED_FIELDS.has(field))
-    const changedFieldIsAsync = changedLockfileSettings.length === 1 &&
-      (changedLockfileSettings[0] === 'catalogs' || changedLockfileSettings[0] === 'overrides')
+    // An override whose value is a `catalog:` reference is only meaningful
+    // once the catalog rewrite has settled, and the range-only catalog
+    // rewrite refuses to run under one. Neither resolver-consulting rewrite
+    // composes with that, so both leave the drift to the resolver.
+    const overridesUseCatalogs = Object.values(opts.overrides)
+      .some((specifier) => parseCatalogProtocol(specifier) != null)
+    const hasAsyncDrift = changedLockfileSettings.includes('catalogs') ||
+      changedLockfileSettings.includes('overrides')
+    const allChangedFieldsAreComposable =
+      !(hasAsyncDrift && overridesUseCatalogs) &&
+      changedLockfileSettings.every((field) =>
+        isSettingsField(field) || COMPOSABLE_CHANGED_FIELDS.has(field))
     // A changed field nothing can absorb forces a resolution, so the
     // workspace-wide specifier scan would be wasted.
-    const hasChangedSpecifiers = (allChangedFieldsAreComposable || changedFieldIsAsync) &&
+    const hasChangedSpecifiers = allChangedFieldsAreComposable &&
       hasChangedProjectSpecifiers(ctx.wantedLockfile, contextProjects, opts.pruneLockfileImporters)
-    // The async rewrites (catalogs, overrides) consult the resolver and stay
-    // outside the composed pipeline, so they require being the only change.
-    const asyncChangedSetting = changedFieldIsAsync && !hasChangedSpecifiers
-      ? changedLockfileSettings[0]
-      : null
-    const syncDrift = {
+    const drift = {
       importers: hasChangedSpecifiers,
       ignoredOptionalDependencies: changedLockfileSettings.includes('ignoredOptionalDependencies'),
       patchedDependencies: changedLockfileSettings.includes('patchedDependencies'),
       settings: changedSettingsFields.length > 0,
+      catalogs: changedLockfileSettings.includes('catalogs'),
+      overrides: changedLockfileSettings.includes('overrides'),
     }
-    const composableSyncDrift =
+    const composableDrift =
       (hasChangedSpecifiers || changedLockfileSettings.length > 0) &&
       allChangedFieldsAreComposable
     const canTryFastUpdateLockfile =
-      (asyncChangedSetting != null || composableSyncDrift) &&
+      composableDrift &&
       !frozenLockfile &&
       // `pnpm fetch` installs from the lockfile alone; with its empty
       // manifests every recorded dependency would read as removed.
@@ -800,11 +804,9 @@ export async function mutateModules (
       // rewrite that introduces no new version needs no maintenance of it.
       // The resolver-consulting rewrites do introduce versions, whose dates
       // only a resolution can record.
-      (ctx.wantedLockfile.time == null || asyncChangedSetting == null)
+      (ctx.wantedLockfile.time == null || !hasAsyncDrift)
     if (canTryFastUpdateLockfile) {
       await verifyLockfilePromise
-      const overridesUseCatalogs = Object.values(opts.overrides)
-        .some((specifier) => parseCatalogProtocol(specifier) != null)
       const isLockfileUpToDate = (lockfile: LockfileObject) => allProjectsAreUpToDate(Object.values(ctx.projects), {
         catalogs: opts.catalogs,
         autoInstallPeers: opts.autoInstallPeers,
@@ -815,87 +817,63 @@ export async function mutateModules (
         workspacePackages: ctx.workspacePackages,
         lockfileDir: opts.lockfileDir,
       })
+      // Built only for the rewrites that consult the resolver: deriving the
+      // policies rejects a malformed pattern, which is the resolver's error
+      // to report on a run that has no use for them.
+      const rewriteOptions = hasAsyncDrift
+        ? {
+          ...getPublishedByPolicy(opts),
+          isLockfileUpToDate,
+          lockfileDir: opts.lockfileDir,
+          lockfileIncludeTarballUrl: opts.lockfileIncludeTarballUrl,
+          readPackageHook: opts.readPackageHook,
+          registries: ctx.registries,
+          requestPackage: opts.storeController.requestPackage,
+          trustPolicy: opts.trustPolicy,
+          trustPolicyExclude: opts.trustPolicyExclude
+            ? createPackageVersionPolicyOrThrow(opts.trustPolicyExclude, 'trustPolicyExclude')
+            : undefined,
+          trustPolicyIgnoreAfter: opts.trustPolicyIgnoreAfter,
+        }
+        : undefined
       if (
-        (asyncChangedSetting === 'catalogs' || !overridesUseCatalogs) &&
         await tryFastUpdateLockfile(ctx.wantedLockfile, {
-          update: async (candidate) => {
-            if (asyncChangedSetting === 'catalogs') {
-              // The range-only rewrite keeps the entries it cannot handle, so a
-              // mixed update still leaves an exact move for the rewrite below.
-              const rewroteRanges = tryFastUpdateCatalogs(candidate, {
-                catalogs: opts.catalogs,
-                overrides: opts.overrides,
-              })
-              if (overridesUseCatalogs) return rewroteRanges
-              const catalogPolicy = getPublishedByPolicy(opts)
-              const rewrite = await tryFastUpdateCatalogVersions(candidate, {
-                catalogs: opts.catalogs,
-                lockfileDir: opts.lockfileDir,
-                lockfileIncludeTarballUrl: opts.lockfileIncludeTarballUrl,
-                readPackageHook: opts.readPackageHook,
-                registries: ctx.registries,
-                requestPackage: opts.storeController.requestPackage,
-                publishedBy: catalogPolicy.publishedBy,
-                publishedByExclude: catalogPolicy.publishedByExclude,
-                trustPolicy: opts.trustPolicy,
-                trustPolicyExclude: opts.trustPolicyExclude
-                  ? createPackageVersionPolicyOrThrow(opts.trustPolicyExclude, 'trustPolicyExclude')
-                  : undefined,
-                trustPolicyIgnoreAfter: opts.trustPolicyIgnoreAfter,
-                isLockfileUpToDate,
-              })
-              // Only the "nothing moved" outcome may fall back on the
-              // range-only result. A move this cannot express has to reach the
-              // resolver, even though the range-only rewrite succeeded.
-              if (rewrite === 'applied') return true
-              return rewrite === 'nothing-to-move' && rewroteRanges
-            }
-            if (asyncChangedSetting == null) {
-              return tryComposeFastUpdates(candidate, {
-                drift: syncDrift,
-                projects: contextProjects,
-                workspacePackages: ctx.workspacePackages,
-                resolutionPicksLowest: opts.resolutionMode !== 'highest',
-                pruneLockfileImporters: opts.pruneLockfileImporters,
-                ignoredOptionalDependencies: opts.ignoredOptionalDependencies,
-                patchedDependencies: {
-                  patchedDependencies,
-                  allowUnusedPatches: opts.allowUnusedPatches,
-                },
-                settings: {
-                  changedSettings: changedSettingsFields,
-                  projects: contextProjects,
-                  settings: wantedLockfileSettings,
-                  workspacePackages: ctx.workspacePackages,
-                },
-              })
-            }
-            const { publishedBy, publishedByExclude } = getPublishedByPolicy(opts)
-            return tryFastUpdateOverrides(candidate, {
-              lockfileDir: opts.lockfileDir,
-              lockfileIncludeTarballUrl: opts.lockfileIncludeTarballUrl,
+          update: async (candidate) => tryComposeFastUpdates(candidate, {
+            drift,
+            projects: contextProjects,
+            workspacePackages: ctx.workspacePackages,
+            resolutionPicksLowest: opts.resolutionMode !== 'highest',
+            pruneLockfileImporters: opts.pruneLockfileImporters,
+            ignoredOptionalDependencies: opts.ignoredOptionalDependencies,
+            patchedDependencies: {
+              patchedDependencies,
+              allowUnusedPatches: opts.allowUnusedPatches,
+            },
+            settings: {
+              changedSettings: changedSettingsFields,
+              projects: contextProjects,
+              settings: wantedLockfileSettings,
+              workspacePackages: ctx.workspacePackages,
+            },
+            catalogs: rewriteOptions && {
+              ...rewriteOptions,
+              catalogs: opts.catalogs,
+              overrides: opts.overrides,
+              parsedOverrides: opts.parsedOverrides,
+            },
+            overrides: rewriteOptions && {
+              ...rewriteOptions,
               overrides: overridesMap,
               parsedOverrides: opts.parsedOverrides,
-              readPackageHook: opts.readPackageHook,
-              registries: ctx.registries,
-              requestPackage: opts.storeController.requestPackage,
-              publishedBy,
-              publishedByExclude,
-              trustPolicy: opts.trustPolicy,
-              trustPolicyExclude: opts.trustPolicyExclude
-                ? createPackageVersionPolicyOrThrow(opts.trustPolicyExclude, 'trustPolicyExclude')
-                : undefined,
-              trustPolicyIgnoreAfter: opts.trustPolicyIgnoreAfter,
-              isLockfileUpToDate,
-            })
-          },
+            },
+          }),
           isLockfileUpToDate,
           verifyLockfile: (lockfile) => verifyLockfileResolutions(lockfile, []),
         })
       ) {
         outdatedLockfileSettingName = null
         ctx.wantedLockfileIsModified = true
-        didFastUpdateOverrides = asyncChangedSetting === 'overrides'
+        didFastUpdateOverrides = drift.overrides
       }
     }
     const outdatedLockfileSettings = outdatedLockfileSettingName != null

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -741,11 +741,15 @@ export async function mutateModules (
     let didFastUpdateOverrides = false
     const contextProjects = Object.values(ctx.projects)
     const changedSettingsFields = changedLockfileSettings.filter(isSettingsField)
+    // Typed as required, but a caller that passes it through from its own
+    // optional config leaves it undefined, and this now runs on every
+    // install rather than only when the fast path opens.
+    const configuredOverrides = opts.overrides ?? {}
     // An override whose value is a `catalog:` reference is only meaningful
     // once the catalog rewrite has settled, and the range-only catalog
     // rewrite refuses to run under one. Neither resolver-consulting rewrite
     // composes with that, so both leave the drift to the resolver.
-    const overridesUseCatalogs = Object.values(opts.overrides)
+    const overridesUseCatalogs = Object.values(configuredOverrides)
       .some((specifier) => parseCatalogProtocol(specifier) != null)
     const hasAsyncDrift = changedLockfileSettings.includes('catalogs') ||
       changedLockfileSettings.includes('overrides')
@@ -858,7 +862,7 @@ export async function mutateModules (
             catalogs: rewriteOptions && {
               ...rewriteOptions,
               catalogs: opts.catalogs,
-              overrides: opts.overrides,
+              overrides: configuredOverrides,
               parsedOverrides: opts.parsedOverrides,
             },
             overrides: rewriteOptions && {

--- a/pnpm11/installing/deps-installer/src/install/tryComposeFastUpdates.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryComposeFastUpdates.ts
@@ -1,11 +1,18 @@
+import type { Catalogs } from '@pnpm/catalogs.types'
+import type { VersionOverride } from '@pnpm/config.parse-overrides'
 import { pruneSharedLockfile } from '@pnpm/lockfile.pruner'
 import type { LockfileObject } from '@pnpm/lockfile.types'
 import type { WorkspacePackages } from '@pnpm/resolving.resolver-base'
 
 import { type DroppedEdges, peerSuffixesAreIndependentOf } from './droppedEdges.js'
-import { pruneUnreferencedCatalogEntries } from './tryFastUpdateCatalogs.js'
+import { pruneUnreferencedCatalogEntries, tryFastUpdateCatalogs } from './tryFastUpdateCatalogs.js'
+import { tryFastUpdateCatalogVersions } from './tryFastUpdateCatalogVersions.js'
 import { tryFastUpdateIgnoredOptionalDependencies } from './tryFastUpdateIgnoredOptionalDependencies.js'
 import { type Project, tryFastUpdateImporters } from './tryFastUpdateImporters.js'
+import {
+  type FastRewriteOptions,
+  tryFastUpdateOverrides,
+} from './tryFastUpdateOverrides.js'
 import {
   type FastPatchedDependenciesUpdateOptions,
   tryFastUpdatePatchedDependencies,
@@ -31,12 +38,25 @@ export interface GraphEdits {
   optionalFlagsAreStale: boolean
 }
 
-/** The drift dimensions the composed sync handlers can absorb. */
+/** The drift dimensions the composed handlers can absorb. */
 export interface FastUpdateDrift {
   importers?: boolean
   ignoredOptionalDependencies?: boolean
   patchedDependencies?: boolean
   settings?: boolean
+  catalogs?: boolean
+  overrides?: boolean
+}
+
+export type FastCatalogsUpdateOptions = FastRewriteOptions & {
+  catalogs: Catalogs
+  overrides: Record<string, string>
+  parsedOverrides: VersionOverride[]
+}
+
+export type FastOverridesUpdateOptions = FastRewriteOptions & {
+  overrides: Record<string, string>
+  parsedOverrides: VersionOverride[]
 }
 
 export interface ComposeFastUpdatesOptions {
@@ -53,6 +73,8 @@ export interface ComposeFastUpdatesOptions {
   ignoredOptionalDependencies?: string[]
   patchedDependencies?: FastPatchedDependenciesUpdateOptions
   settings?: FastSettingsUpdateOptions
+  catalogs?: FastCatalogsUpdateOptions
+  overrides?: FastOverridesUpdateOptions
 }
 
 /**
@@ -60,16 +82,18 @@ export interface ComposeFastUpdatesOptions {
  * with absorbable drift onto the one candidate — no handler requires being
  * the only change. Removals apply first, then the shared graph epilogue
  * (`finishGraphEdits`), then patch rekeying — after the prune, so its guards
- * see the packages a full resolution would see — and the settings block last.
+ * see the packages a full resolution would see — the settings block, and the
+ * two resolver-consulting rewrites last: catalogs before overrides, the order
+ * a resolution applies them in.
  *
  * `false` — drift some handler cannot express — leaves the caller on the
  * full-resolution path; `candidate` may be partially rewritten by then, which
  * the coordinator's discard-on-failure makes safe.
  */
-export function tryComposeFastUpdates (
+export async function tryComposeFastUpdates (
   candidate: LockfileObject,
   opts: ComposeFastUpdatesOptions
-): boolean {
+): Promise<boolean> {
   const edits: GraphEdits = { dropped: new Set(), optionalFlagsAreStale: false }
   if (opts.drift.importers && !tryFastUpdateImporters(candidate, {
     projects: opts.projects,
@@ -91,7 +115,35 @@ export function tryComposeFastUpdates (
   if (opts.drift.settings && !tryFastUpdateSettings(candidate, opts.settings!)) {
     return false
   }
+  if (opts.drift.catalogs && !await applyCatalogsUpdate(candidate, opts.catalogs!)) {
+    return false
+  }
+  if (opts.drift.overrides && !await tryFastUpdateOverrides(candidate, opts.overrides!)) {
+    return false
+  }
   return true
+}
+
+/**
+ * Move the catalog entries the configuration changed, taking the range-only
+ * rewrite first so the entries it settles never reach the resolver.
+ */
+async function applyCatalogsUpdate (
+  candidate: LockfileObject,
+  opts: FastCatalogsUpdateOptions
+): Promise<boolean> {
+  // The range-only rewrite keeps the entries it cannot handle, so a mixed
+  // update still leaves an exact move for the rewrite below.
+  const rewroteRanges = tryFastUpdateCatalogs(candidate, {
+    catalogs: opts.catalogs,
+    overrides: opts.overrides,
+  })
+  const rewrite = await tryFastUpdateCatalogVersions(candidate, opts)
+  // Only the "nothing moved" outcome may fall back on the range-only result.
+  // A move this cannot express has to reach the resolver, even though the
+  // range-only rewrite succeeded.
+  if (rewrite === 'applied') return true
+  return rewrite === 'nothing-to-move' && rewroteRanges
 }
 
 /**

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateCatalogVersions.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateCatalogVersions.ts
@@ -1,5 +1,6 @@
 import { parseCatalogProtocol } from '@pnpm/catalogs.protocol-parser'
 import type { Catalogs } from '@pnpm/catalogs.types'
+import type { VersionOverride } from '@pnpm/config.parse-overrides'
 import type { LockfileObject, ProjectSnapshot, ResolvedDependencies } from '@pnpm/lockfile.types'
 import semver from 'semver'
 
@@ -34,7 +35,7 @@ export type CatalogVersionRewrite =
 
 export async function tryFastUpdateCatalogVersions (
   lockfile: LockfileObject,
-  opts: FastRewriteOptions & { catalogs: Catalogs }
+  opts: FastRewriteOptions & { catalogs: Catalogs, parsedOverrides: VersionOverride[] }
 ): Promise<CatalogVersionRewrite> {
   // The same gate the range-only path opens with: an importer pointing at a
   // catalog entry with nothing recorded for it needs the resolver, and this
@@ -55,8 +56,6 @@ export async function tryFastUpdateCatalogVersions (
       if (semver.valid(entry.version) == null) return 'unsupported'
       // A specifier the locked version still satisfies moves nothing but the
       // specifier, exactly as the range-only path would.
-      // A specifier the locked version still satisfies moves nothing but the
-      // specifier, exactly as the range-only path would.
       if (semver.validRange(specifier) != null && semver.satisfies(entry.version, specifier)) {
         catalogs[catalogName][alias] = { specifier, version: entry.version }
         continue
@@ -64,6 +63,7 @@ export async function tryFastUpdateCatalogVersions (
       const wanted = semver.valid(specifier)
       if (wanted == null) return 'unsupported'
       if (!catalogEntryIsSoleReference(lockfile, catalogName, alias)) return 'unsupported'
+      if (isOverridden(alias, opts.parsedOverrides)) return 'unsupported'
       fastOverrides.push({ name: alias, newVersion: wanted, oldVersion: entry.version })
       catalogs[catalogName][alias] = { specifier, version: wanted }
     }
@@ -73,6 +73,16 @@ export async function tryFastUpdateCatalogVersions (
   return await applyFastRewrite(lockfile, fastOverrides, opts, { catalogs })
     ? 'applied'
     : 'unsupported'
+}
+
+/**
+ * Whether an override decides `alias`'s version, making the catalog specifier
+ * no longer the last word on it. A `parent>child` selector names no importer
+ * edge, and only importer edges are what a catalog entry resolves.
+ */
+function isOverridden (alias: string, parsedOverrides: VersionOverride[]): boolean {
+  return parsedOverrides.some((override) =>
+    override.parentPkg == null && override.targetPkg.name === alias)
 }
 
 /** Whether the catalog entry is the only thing in the lockfile that reaches `alias`. */

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateOverrides.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateOverrides.ts
@@ -65,7 +65,23 @@ export async function tryFastUpdateOverrides (
 ): Promise<boolean> {
   const fastOverrides = getFastOverrides(lockfile, lockfile.overrides ?? {}, opts.overrides, opts.parsedOverrides)
   if (fastOverrides == null) return false
+  if (movesACatalogedPackage(lockfile, fastOverrides)) return false
   return applyFastRewrite(lockfile, fastOverrides, opts, { overrides: opts.overrides })
+}
+
+/**
+ * Whether any of `fastOverrides` moves a package a catalog entry records the
+ * version of. The entry would have to move with it — which is the catalog
+ * rewrite's job, not this one's — so the move goes to the resolver instead.
+ *
+ * A `parent>child` selector names no importer edge, and only importer edges
+ * are what a catalog entry resolves.
+ */
+function movesACatalogedPackage (lockfile: LockfileObject, fastOverrides: FastOverride[]): boolean {
+  const catalogedAliases = new Set(
+    Object.values(lockfile.catalogs ?? {}).flatMap((catalog) => Object.keys(catalog))
+  )
+  return fastOverrides.some(({ name, parent }) => parent == null && catalogedAliases.has(name))
 }
 
 /**

--- a/pnpm11/installing/deps-installer/test/install/catalogFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/catalogFastUpdate.ts
@@ -201,7 +201,7 @@ test('simultaneous catalog and override changes are absorbed in one pass', async
   expect(requestedPackages).toStrictEqual(['@pnpm.e2e/pkg-with-1-dep'])
   const written = project.readLockfile()
   expect(written.catalogs.default['@pnpm.e2e/parent-of-pkg-with-1-dep'].specifier).toBe('>=1 <2')
-  expect(written.snapshots['@pnpm.e2e/parent-of-pkg-with-1-dep@1.0.0'].dependencies['@pnpm.e2e/pkg-with-1-dep'])
+  expect(written.snapshots['@pnpm.e2e/parent-of-pkg-with-1-dep@1.0.0'].dependencies?.['@pnpm.e2e/pkg-with-1-dep'])
     .toBe('100.1.0')
 })
 

--- a/pnpm11/installing/deps-installer/test/install/catalogFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/catalogFastUpdate.ts
@@ -205,6 +205,57 @@ test('simultaneous catalog and override changes are absorbed in one pass', async
     .toBe('100.1.0')
 })
 
+test('a catalog edit and a removal override are absorbed in one pass', async () => {
+  const project = prepareEmpty()
+  const manifest: ProjectManifest = {
+    dependencies: {
+      '@pnpm.e2e/pkg-with-good-optional': 'catalog:',
+    },
+  }
+  const options = testDefaults({
+    catalogs: {
+      default: {
+        '@pnpm.e2e/pkg-with-good-optional': '1.0.0',
+      },
+    },
+  })
+
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, options)
+
+  const requestedPackages = trackRequestedPackages(options.storeController)
+  options.catalogs = {
+    default: {
+      '@pnpm.e2e/pkg-with-good-optional': '>=1.0.0 <2',
+    },
+  }
+  options.overrides = {
+    'is-positive': '-',
+  }
+
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, options)
+
+  // A removal names no new version, so the composed pass introduces nothing
+  // the registry has to answer for.
+  expect(requestedPackages).toStrictEqual([])
+  const written = project.readLockfile()
+  expect(written.catalogs.default['@pnpm.e2e/pkg-with-good-optional']).toStrictEqual({
+    specifier: '>=1.0.0 <2',
+    version: '1.0.0',
+  })
+  expect(written.snapshots['@pnpm.e2e/pkg-with-good-optional@1.0.0'].optionalDependencies)
+    .toBeUndefined()
+  expect(Object.keys(written.snapshots).some((depPath) => depPath.startsWith('is-positive@')))
+    .toBe(false)
+})
+
 test.each(['catalog:', 'catalog:default'])('a default catalog snapshot referenced as %s is not removed', (specifier) => {
   const lockfile = {
     catalogs: {

--- a/pnpm11/installing/deps-installer/test/install/catalogFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/catalogFastUpdate.ts
@@ -61,7 +61,7 @@ test('an incompatible package range update falls back without mutating the lockf
   } as LockfileObject
 
   expect(await tryFastUpdateLockfile(lockfile, {
-    update: (candidate) => tryFastUpdateImporters(candidate, [{
+    update: async (candidate) => tryFastUpdateImporters(candidate, [{
       id: '.' as ProjectId,
       manifest: {
         dependencies: {
@@ -156,8 +156,8 @@ test('an incompatible catalog range update falls back to resolution', async () =
   expect(requestedPackages).toContain('@pnpm.e2e/foobarqar')
 })
 
-test('simultaneous catalog and override changes fall back to resolution', async () => {
-  prepareEmpty()
+test('simultaneous catalog and override changes are absorbed in one pass', async () => {
+  const project = prepareEmpty()
   const manifest: ProjectManifest = {
     dependencies: {
       '@pnpm.e2e/parent-of-pkg-with-1-dep': 'catalog:',
@@ -196,7 +196,13 @@ test('simultaneous catalog and override changes fall back to resolution', async 
     rootDir: process.cwd() as ProjectRootDir,
   }, options)
 
-  expect(requestedPackages.length).toBeGreaterThan(0)
+  // Only the version the override names is resolved; the catalog entry moves
+  // through the range-only rewrite on the same candidate.
+  expect(requestedPackages).toStrictEqual(['@pnpm.e2e/pkg-with-1-dep'])
+  const written = project.readLockfile()
+  expect(written.catalogs.default['@pnpm.e2e/parent-of-pkg-with-1-dep'].specifier).toBe('>=1 <2')
+  expect(written.snapshots['@pnpm.e2e/parent-of-pkg-with-1-dep@1.0.0'].dependencies['@pnpm.e2e/pkg-with-1-dep'])
+    .toBe('100.1.0')
 })
 
 test.each(['catalog:', 'catalog:default'])('a default catalog snapshot referenced as %s is not removed', (specifier) => {
@@ -356,6 +362,6 @@ function trackRequestedPackages (storeController: StoreController): string[] {
   return requestedPackages
 }
 /** The composed pipeline restricted to manifest drift. */
-function tryFastUpdateImporters (lockfile: LockfileObject, projects: Project[]): boolean {
+async function tryFastUpdateImporters (lockfile: LockfileObject, projects: Project[]): Promise<boolean> {
   return tryComposeFastUpdates(lockfile, { drift: { importers: true }, projects, workspacePackages: new Map(), resolutionPicksLowest: false })
 }

--- a/pnpm11/installing/deps-installer/test/install/catalogFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/catalogFastUpdate.ts
@@ -252,8 +252,9 @@ test('a catalog edit and a removal override are absorbed in one pass', async () 
   })
   expect(written.snapshots['@pnpm.e2e/pkg-with-good-optional@1.0.0'].optionalDependencies)
     .toBeUndefined()
-  expect(Object.keys(written.snapshots).some((depPath) => depPath.startsWith('is-positive@')))
-    .toBe(false)
+  for (const section of [written.snapshots, written.packages]) {
+    expect(Object.keys(section).some((depPath) => depPath.startsWith('is-positive@'))).toBe(false)
+  }
 })
 
 test.each(['catalog:', 'catalog:default'])('a default catalog snapshot referenced as %s is not removed', (specifier) => {

--- a/pnpm11/installing/deps-installer/test/install/catalogVersionFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/catalogVersionFastUpdate.ts
@@ -30,6 +30,7 @@ function lockfile (): LockfileObject {
 function updateOptions (childRange: string, catalogSpecifier = '2.0.0') {
   return {
     catalogs: { default: { target: catalogSpecifier } },
+    parsedOverrides: [],
     lockfileDir: '/project',
     registries: { default: 'https://registry.npmjs.org/' },
     requestPackage: async () => ({
@@ -112,6 +113,16 @@ test('a satisfied range rides along with an exact move in one pass', async () =>
   )).toBe('applied')
   expect(subject.catalogs!.default.child).toStrictEqual({ specifier: '^1.1.0', version: '1.1.0' })
   expect(subject.catalogs!.default.target).toStrictEqual({ specifier: '2.0.0', version: '2.0.0' })
+})
+
+test('a move on a package an override pins falls back', async () => {
+  const opts = updateOptions('^1.0.0') as unknown as Record<string, unknown>
+  opts.parsedOverrides = [{ selector: 'target', newBareSpecifier: '1.0.0', targetPkg: { name: 'target' } }]
+
+  expect(await tryFastUpdateCatalogVersions(
+    lockfile(),
+    opts as unknown as Parameters<typeof tryFastUpdateCatalogVersions>[1]
+  )).toBe('unsupported')
 })
 
 test('a range the locked version still satisfies moves no package', async () => {

--- a/pnpm11/installing/deps-installer/test/install/composedFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/composedFastUpdate.ts
@@ -254,6 +254,38 @@ test('an override moving a cataloged package falls back', async () => {
   })).toBe(false)
 })
 
+test('an override on a cataloged package is left to the resolver', async () => {
+  const project = prepareEmpty()
+  const manifest: ProjectManifest = {
+    dependencies: { '@pnpm.e2e/pkg-with-1-dep': 'catalog:' },
+  }
+  const options = testDefaults({
+    catalogs: { default: { '@pnpm.e2e/pkg-with-1-dep': '100.0.0' } },
+  })
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, options)
+
+  options.overrides = { '@pnpm.e2e/pkg-with-1-dep': '100.1.0' }
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, options)
+
+  // The override replaces the `catalog:` specifier outright, so the entry is
+  // not moved but dropped — a rewrite that only moves packages around cannot
+  // express it.
+  const written = project.readLockfile()
+  expect(written.catalogs).toBeUndefined()
+  expect(written.importers['.'].dependencies['@pnpm.e2e/pkg-with-1-dep']).toStrictEqual({
+    specifier: '100.1.0',
+    version: '100.1.0',
+  })
+})
+
 /** The two changes a resolution away, in their own project. */
 async function resolveTheSameChanges (): Promise<unknown> {
   const previousCwd = process.cwd()

--- a/pnpm11/installing/deps-installer/test/install/composedFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/composedFastUpdate.ts
@@ -240,6 +240,8 @@ test('an override moving a cataloged package falls back', async () => {
   // move would have to carry it along — which only the catalog rewrite does.
   expect(await tryComposeFastUpdates(subject, {
     drift: { overrides: true },
+    workspacePackages: new Map(),
+    resolutionPicksLowest: false,
     projects: [],
     overrides: {
       overrides: { bar: '2.1.0' },

--- a/pnpm11/installing/deps-installer/test/install/composedFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/composedFastUpdate.ts
@@ -8,10 +8,10 @@ import type { DepPath, ProjectId, ProjectManifest, ProjectRootDir } from '@pnpm/
 import { tryComposeFastUpdates } from '../../src/install/tryComposeFastUpdates.js'
 import { testDefaults } from '../utils/index.js'
 
-test('a removal and a widened ignore list are absorbed in one pass', () => {
+test('a removal and a widened ignore list are absorbed in one pass', async () => {
   const subject = lockfile()
 
-  expect(tryComposeFastUpdates(subject, {
+  expect(await tryComposeFastUpdates(subject, {
     drift: { importers: true, ignoredOptionalDependencies: true },
     workspacePackages: new Map(),
     resolutionPicksLowest: false,
@@ -25,11 +25,11 @@ test('a removal and a widened ignore list are absorbed in one pass', () => {
   expect(importer.dependencies).toStrictEqual({ bar: '2.0.0' })
 })
 
-test('a group move and a settings change are absorbed in one pass', () => {
+test('a group move and a settings change are absorbed in one pass', async () => {
   const subject = lockfile()
   subject.settings = { autoInstallPeers: true, excludeLinksFromLockfile: false }
 
-  expect(tryComposeFastUpdates(subject, {
+  expect(await tryComposeFastUpdates(subject, {
     drift: { importers: true, settings: true },
     workspacePackages: new Map(),
     resolutionPicksLowest: false,
@@ -50,7 +50,7 @@ test('a group move and a settings change are absorbed in one pass', () => {
   expect(subject.settings).toStrictEqual({ autoInstallPeers: false, excludeLinksFromLockfile: false })
 })
 
-test('a peer setting is absorbed once the removal drops the last peer dependent', () => {
+test('a peer setting is absorbed once the removal drops the last peer dependent', async () => {
   const subject = lockfile()
   subject.settings = { autoInstallPeers: true, excludeLinksFromLockfile: false }
   subject.importers['.' as ProjectId].dependencies!['has-peer'] = '6.0.0'
@@ -60,7 +60,7 @@ test('a peer setting is absorbed once the removal drops the last peer dependent'
     peerDependencies: { foo: '^1.0.0' },
   }
 
-  expect(tryComposeFastUpdates(subject, {
+  expect(await tryComposeFastUpdates(subject, {
     drift: { importers: true, settings: true },
     workspacePackages: new Map(),
     resolutionPicksLowest: false,
@@ -79,11 +79,11 @@ test('a peer setting is absorbed once the removal drops the last peer dependent'
   expect(subject.packages!['has-peer@6.0.0' as DepPath]).toBeUndefined()
 })
 
-test('a composed update falls back when one of its changes cannot be absorbed', () => {
+test('a composed update falls back when one of its changes cannot be absorbed', async () => {
   const subject = lockfile()
   subject.settings = { autoInstallPeers: true, excludeLinksFromLockfile: false }
 
-  expect(tryComposeFastUpdates(subject, {
+  expect(await tryComposeFastUpdates(subject, {
     drift: { importers: true, settings: true },
     workspacePackages: new Map(),
     resolutionPicksLowest: false,
@@ -100,7 +100,7 @@ test('a composed update falls back when one of its changes cannot be absorbed', 
   })).toBe(false)
 })
 
-test('an ignored optional embedded in a surviving peer suffix falls back', () => {
+test('an ignored optional embedded in a surviving peer suffix falls back', async () => {
   const subject = lockfile()
   subject.importers['.' as ProjectId].dependencies!.baz = '4.0.0(opt@5.0.0)'
   subject.importers['.' as ProjectId].specifiers.baz = '^4.0.0'
@@ -109,7 +109,7 @@ test('an ignored optional embedded in a surviving peer suffix falls back', () =>
     dependencies: { opt: '5.0.0' },
   }
 
-  expect(tryComposeFastUpdates(subject, {
+  expect(await tryComposeFastUpdates(subject, {
     drift: { ignoredOptionalDependencies: true },
     workspacePackages: new Map(),
     resolutionPicksLowest: false,
@@ -118,14 +118,14 @@ test('an ignored optional embedded in a surviving peer suffix falls back', () =>
   })).toBe(false)
 })
 
-test('an ignored optional removal recomputes the survivors\' optional flags', () => {
+test('an ignored optional removal recomputes the survivors\' optional flags', async () => {
   const subject = lockfile()
   const importer = subject.importers['.' as ProjectId]
   importer.optionalDependencies!.bar = importer.dependencies!.bar
   delete importer.dependencies!.bar
   subject.packages!['bar@2.0.0' as DepPath].optional = true
 
-  expect(tryComposeFastUpdates(subject, {
+  expect(await tryComposeFastUpdates(subject, {
     drift: { ignoredOptionalDependencies: true },
     workspacePackages: new Map(),
     resolutionPicksLowest: false,
@@ -178,6 +178,122 @@ test('an install with combined manifest and ignore-list drift requests no packag
   project.has('is-positive')
   project.hasNot('@pnpm.e2e/pkg-with-1-dep')
 })
+
+test('an override change and a removal are absorbed in one pass', async () => {
+  const project = prepareEmpty()
+  await installOverrideFixture(testDefaults())
+
+  const options = testDefaults({ overrides: { '@pnpm.e2e/bar': '100.1.0' } })
+  const requestedPackages = trackRequestedPackages(options.storeController)
+  await mutateModulesInSingleProject({
+    dependencyNames: ['@pnpm.e2e/pkg-with-1-dep'],
+    manifest: overrideFixtureManifest(),
+    mutation: 'uninstallSome',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, options)
+
+  // Only the version the override names is resolved; the removal and the
+  // rest of the graph come from the lockfile.
+  expect(requestedPackages).toStrictEqual(['@pnpm.e2e/bar'])
+  expect(project.readLockfile()).toStrictEqual(await resolveTheSameChanges())
+})
+
+test('a catalog change and a removal are absorbed in one pass', async () => {
+  const project = prepareEmpty()
+  const manifest: ProjectManifest = {
+    dependencies: {
+      '@pnpm.e2e/pkg-with-1-dep': '100.0.0',
+      'is-positive': 'catalog:',
+    },
+  }
+  const options = testDefaults({ catalogs: { default: { 'is-positive': '1.0.0' } } })
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, options)
+
+  options.catalogs = { default: { 'is-positive': '>=1.0.0 <2' } }
+  const requestedPackages = trackRequestedPackages(options.storeController)
+  await mutateModulesInSingleProject({
+    dependencyNames: ['@pnpm.e2e/pkg-with-1-dep'],
+    manifest,
+    mutation: 'uninstallSome',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, options)
+
+  expect(requestedPackages).toStrictEqual([])
+  const written = project.readLockfile()
+  expect(written.catalogs.default['is-positive']).toStrictEqual({
+    specifier: '>=1.0.0 <2',
+    version: '1.0.0',
+  })
+  expect(Object.keys(written.snapshots)).toStrictEqual(['is-positive@1.0.0'])
+})
+
+test('an override moving a cataloged package falls back', async () => {
+  const subject = lockfile()
+  subject.catalogs = { default: { bar: { specifier: '^2.0.0', version: '2.0.0' } } }
+  subject.importers['.' as ProjectId].specifiers.bar = 'catalog:'
+
+  // The catalog entry records the version the importer resolved to, so the
+  // move would have to carry it along — which only the catalog rewrite does.
+  expect(await tryComposeFastUpdates(subject, {
+    drift: { overrides: true },
+    projects: [],
+    overrides: {
+      overrides: { bar: '2.1.0' },
+      parsedOverrides: [{ selector: 'bar', newBareSpecifier: '2.1.0', targetPkg: { name: 'bar' } }],
+      isLockfileUpToDate: async () => true,
+      lockfileDir: '/test',
+      registries: { default: 'https://registry.npmjs.org/' },
+      requestPackage: (() => {
+        throw new Error('the fast path must not resolve anything')
+      }) as never,
+    },
+  })).toBe(false)
+})
+
+/** The two changes a resolution away, in their own project. */
+async function resolveTheSameChanges (): Promise<unknown> {
+  const previousCwd = process.cwd()
+  try {
+    const project = prepareEmpty()
+    await installOverrideFixture(testDefaults())
+    await mutateModulesInSingleProject({
+      dependencyNames: ['@pnpm.e2e/pkg-with-1-dep'],
+      manifest: overrideFixtureManifest(),
+      mutation: 'uninstallSome',
+      rootDir: process.cwd() as ProjectRootDir,
+    }, testDefaults({
+      forceFullResolution: true,
+      overrides: { '@pnpm.e2e/bar': '100.1.0' },
+    }))
+    return project.readLockfile()
+  } finally {
+    // `prepareEmpty` moves the process into the new project, so a throw here
+    // would otherwise leave every later test in this worker there.
+    process.chdir(previousCwd)
+  }
+}
+
+/** `@pnpm.e2e/foobarqar` reaches `@pnpm.e2e/bar`, the package the override moves. */
+function overrideFixtureManifest (): ProjectManifest {
+  return {
+    dependencies: {
+      '@pnpm.e2e/foobarqar': '1.0.0',
+      '@pnpm.e2e/pkg-with-1-dep': '100.0.0',
+    },
+  }
+}
+
+async function installOverrideFixture (options: ReturnType<typeof testDefaults>): Promise<void> {
+  await mutateModulesInSingleProject({
+    manifest: overrideFixtureManifest(),
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, options)
+}
 
 function trackRequestedPackages (storeController: StoreController): string[] {
   const requestedPackages: string[] = []

--- a/pnpm11/installing/deps-installer/test/install/composedFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/composedFastUpdate.ts
@@ -280,7 +280,7 @@ test('an override on a cataloged package is left to the resolver', async () => {
   // express it.
   const written = project.readLockfile()
   expect(written.catalogs).toBeUndefined()
-  expect(written.importers['.'].dependencies['@pnpm.e2e/pkg-with-1-dep']).toStrictEqual({
+  expect(written.importers['.'].dependencies?.['@pnpm.e2e/pkg-with-1-dep']).toStrictEqual({
     specifier: '100.1.0',
     version: '100.1.0',
   })

--- a/pnpm11/installing/deps-installer/test/install/ignoredOptionalDependencies.ts
+++ b/pnpm11/installing/deps-installer/test/install/ignoredOptionalDependencies.ts
@@ -104,7 +104,7 @@ test('removing an ignored optional dependency falls back to resolution', async (
   expect(project.readLockfile().packages).toHaveProperty(['is-positive@1.0.0'])
 })
 
-test('fast update prunes only optional packages that become unreachable', () => {
+test('fast update prunes only optional packages that become unreachable', async () => {
   const lockfile = {
     importers: {
       '.': {
@@ -149,7 +149,7 @@ test('fast update prunes only optional packages that become unreachable', () => 
     },
   } as LockfileObject
 
-  expect(tryFastUpdateIgnoredOptionalDependencies(lockfile, [
+  expect(await tryFastUpdateIgnoredOptionalDependencies(lockfile, [
     'root-only',
     'shared',
     'unique',
@@ -165,7 +165,7 @@ test('fast update prunes only optional packages that become unreachable', () => 
   expect(lockfile.packages).not.toHaveProperty(['unique@1.0.0'])
 })
 
-test('fast update prunes a catalog entry its last referent was ignored', () => {
+test('fast update prunes a catalog entry its last referent was ignored', async () => {
   const lockfile = {
     catalogs: {
       default: {
@@ -188,28 +188,28 @@ test('fast update prunes a catalog entry its last referent was ignored', () => {
     },
   } as unknown as LockfileObject
 
-  expect(tryFastUpdateIgnoredOptionalDependencies(lockfile, ['is-positive'])).toBe(true)
+  expect(await tryFastUpdateIgnoredOptionalDependencies(lockfile, ['is-positive'])).toBe(true)
   expect(lockfile.catalogs).toBeUndefined()
 })
 
-test('fast update rejects a new exclusion pattern', () => {
+test('fast update rejects a new exclusion pattern', async () => {
   const lockfile = {
     ignoredOptionalDependencies: ['*'],
     importers: {},
     lockfileVersion: '9.0',
   } as LockfileObject
 
-  expect(tryFastUpdateIgnoredOptionalDependencies(lockfile, ['*', '!is-positive'])).toBe(false)
+  expect(await tryFastUpdateIgnoredOptionalDependencies(lockfile, ['*', '!is-positive'])).toBe(false)
 })
 
-test('fast update rejects adding an include to exclusion-only patterns', () => {
+test('fast update rejects adding an include to exclusion-only patterns', async () => {
   const lockfile = {
     ignoredOptionalDependencies: ['!foo'],
     importers: {},
     lockfileVersion: '9.0',
   } as LockfileObject
 
-  expect(tryFastUpdateIgnoredOptionalDependencies(lockfile, ['!foo', 'bar'])).toBe(false)
+  expect(await tryFastUpdateIgnoredOptionalDependencies(lockfile, ['!foo', 'bar'])).toBe(false)
 })
 
 function trackRequestedPackages (storeController: StoreController): string[] {
@@ -222,10 +222,10 @@ function trackRequestedPackages (storeController: StoreController): string[] {
   return requestedPackages
 }
 /** The composed pipeline restricted to `ignoredOptionalDependencies` drift. */
-function tryFastUpdateIgnoredOptionalDependencies (
+async function tryFastUpdateIgnoredOptionalDependencies (
   lockfile: LockfileObject,
   ignoredOptionalDependencies: string[]
-): boolean {
+): Promise<boolean> {
   return tryComposeFastUpdates(lockfile, {
     drift: { ignoredOptionalDependencies: true },
     workspacePackages: new Map(),

--- a/pnpm11/installing/deps-installer/test/install/importerGroupMoveFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/importerGroupMoveFastUpdate.ts
@@ -25,11 +25,11 @@ test('a dependency in its recorded group is not a change', () => {
   ])).toBe(false)
 })
 
-test('a move between prod and dev only edits the importer', () => {
+test('a move between prod and dev only edits the importer', async () => {
   const subject = lockfile()
   const packagesBefore = clone(subject.packages)
 
-  expect(tryFastUpdateImporters(subject, [
+  expect(await tryFastUpdateImporters(subject, [
     project({ dependencies: { foo: '^1.0.0' }, devDependencies: { bar: '^2.0.0' } }),
   ])).toBe(true)
   const importer = subject.importers['.' as ProjectId]
@@ -39,10 +39,10 @@ test('a move between prod and dev only edits the importer', () => {
   expect(subject.packages).toStrictEqual(packagesBefore)
 })
 
-test('a move into optionalDependencies marks the subtree optional', () => {
+test('a move into optionalDependencies marks the subtree optional', async () => {
   const subject = lockfile()
 
-  expect(tryFastUpdateImporters(subject, [
+  expect(await tryFastUpdateImporters(subject, [
     project({ dependencies: { foo: '^1.0.0' }, optionalDependencies: { bar: '^2.0.0' } }),
   ])).toBe(true)
   const importer = subject.importers['.' as ProjectId]
@@ -53,7 +53,7 @@ test('a move into optionalDependencies marks the subtree optional', () => {
   expect(subject.packages!['foo@1.1.0' as DepPath].optional).toBeUndefined()
 })
 
-test('a move out of optionalDependencies clears the subtree flags', () => {
+test('a move out of optionalDependencies clears the subtree flags', async () => {
   const subject = lockfile()
   const importer = subject.importers['.' as ProjectId]
   importer.optionalDependencies = { bar: importer.dependencies!.bar }
@@ -61,7 +61,7 @@ test('a move out of optionalDependencies clears the subtree flags', () => {
   subject.packages!['bar@2.0.0' as DepPath].optional = true
   subject.packages!['child@3.0.0' as DepPath].optional = true
 
-  expect(tryFastUpdateImporters(subject, [
+  expect(await tryFastUpdateImporters(subject, [
     project({ dependencies: { foo: '^1.0.0', bar: '^2.0.0' } }),
   ])).toBe(true)
   expect(subject.importers['.' as ProjectId].optionalDependencies).toBeUndefined()
@@ -70,7 +70,7 @@ test('a move out of optionalDependencies clears the subtree flags', () => {
   expect(subject.packages!['child@3.0.0' as DepPath].optional).toBeUndefined()
 })
 
-test('a subtree package another prod dependency reaches stays non-optional', () => {
+test('a subtree package another prod dependency reaches stays non-optional', async () => {
   const subject = lockfile()
   subject.importers['.' as ProjectId].dependencies!.parent = '4.0.0'
   subject.importers['.' as ProjectId].specifiers.parent = '^4.0.0'
@@ -79,7 +79,7 @@ test('a subtree package another prod dependency reaches stays non-optional', () 
     dependencies: { child: '3.0.0' },
   }
 
-  expect(tryFastUpdateImporters(subject, [
+  expect(await tryFastUpdateImporters(subject, [
     project({
       dependencies: { foo: '^1.0.0', parent: '^4.0.0' },
       optionalDependencies: { bar: '^2.0.0' },
@@ -89,10 +89,10 @@ test('a subtree package another prod dependency reaches stays non-optional', () 
   expect(subject.packages!['child@3.0.0' as DepPath].optional).toBeUndefined()
 })
 
-test('an alias in both prod and optional groups is recorded as optional', () => {
+test('an alias in both prod and optional groups is recorded as optional', async () => {
   const subject = lockfile()
 
-  expect(tryFastUpdateImporters(subject, [
+  expect(await tryFastUpdateImporters(subject, [
     project({
       dependencies: { foo: '^1.0.0', bar: '^2.0.0' },
       optionalDependencies: { bar: '^2.0.0' },
@@ -103,13 +103,13 @@ test('an alias in both prod and optional groups is recorded as optional', () => 
   expect(importer.optionalDependencies).toStrictEqual({ bar: '2.0.0' })
 })
 
-test('several dependencies move between groups in one pass', () => {
+test('several dependencies move between groups in one pass', async () => {
   const subject = lockfile()
   subject.importers['.' as ProjectId].devDependencies = { qux: '5.0.0' }
   subject.importers['.' as ProjectId].specifiers.qux = '^5.0.0'
   subject.packages!['qux@5.0.0' as DepPath] = { resolution: { integrity: 'sha512-qux' } }
 
-  expect(tryFastUpdateImporters(subject, [
+  expect(await tryFastUpdateImporters(subject, [
     project({
       dependencies: { qux: '^5.0.0' },
       devDependencies: { foo: '^1.0.0' },
@@ -126,10 +126,10 @@ test('several dependencies move between groups in one pass', () => {
   expect(subject.packages!['foo@1.1.0' as DepPath].optional).toBeUndefined()
 })
 
-test('a group move rides along with a satisfied range change', () => {
+test('a group move rides along with a satisfied range change', async () => {
   const subject = lockfile()
 
-  expect(tryFastUpdateImporters(subject, [
+  expect(await tryFastUpdateImporters(subject, [
     project({ dependencies: { foo: '^1.0.0' }, devDependencies: { bar: '^2.0.0 <3.0.0' } }),
   ])).toBe(true)
   const importer = subject.importers['.' as ProjectId]
@@ -217,6 +217,6 @@ function lockfile (): LockfileObject {
   }
 }
 /** The composed pipeline restricted to manifest drift. */
-function tryFastUpdateImporters (lockfile: LockfileObject, projects: ImporterProject[]): boolean {
+async function tryFastUpdateImporters (lockfile: LockfileObject, projects: ImporterProject[]): Promise<boolean> {
   return tryComposeFastUpdates(lockfile, { drift: { importers: true }, projects, workspacePackages: new Map(), resolutionPicksLowest: false })
 }

--- a/pnpm11/installing/deps-installer/test/install/importerRemovalFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/importerRemovalFastUpdate.ts
@@ -18,10 +18,10 @@ test('a dependency the manifest dropped is noticed as a change', () => {
   expect(hasChangedProjectSpecifiers(lockfile(), [project({ bar: '^2.0.0' })])).toBe(true)
 })
 
-test('a dropped dependency is removed and its subtree pruned', () => {
+test('a dropped dependency is removed and its subtree pruned', async () => {
   const subject = lockfile()
 
-  expect(tryFastUpdateImporters(subject, [project({ bar: '^2.0.0' })])).toBe(true)
+  expect(await tryFastUpdateImporters(subject, [project({ bar: '^2.0.0' })])).toBe(true)
   const importer = subject.importers['.' as ProjectId]
   expect(importer.specifiers).toStrictEqual({ bar: '^2.0.0' })
   expect(importer.dependencies).toStrictEqual({ bar: '2.0.0' })
@@ -39,7 +39,7 @@ test('dropping a dependency another package resolves as a peer falls back withou
   const before = clone(subject)
 
   expect(await tryFastUpdateLockfile(subject, {
-    update: (candidate) => tryFastUpdateImporters(candidate, [project({ bar: '^2.0.0', baz: '^4.0.0' })]),
+    update: async (candidate) => tryFastUpdateImporters(candidate, [project({ bar: '^2.0.0', baz: '^4.0.0' })]),
     isLockfileUpToDate: async () => true,
   })).toBe(false)
   expect(subject).toStrictEqual(before)
@@ -59,7 +59,7 @@ test('a lockfile key the update deletes is gone after the commit', async () => {
   expect(subject.catalogs).toBeUndefined()
 })
 
-test('dropping a dependency together with its peer-dependent succeeds', () => {
+test('dropping a dependency together with its peer-dependent succeeds', async () => {
   const subject = lockfile()
   subject.importers['.' as ProjectId].dependencies!.baz = '4.0.0(foo@1.1.0)'
   subject.importers['.' as ProjectId].specifiers.baz = '^4.0.0'
@@ -68,14 +68,14 @@ test('dropping a dependency together with its peer-dependent succeeds', () => {
     dependencies: { foo: '1.1.0' },
   }
 
-  expect(tryFastUpdateImporters(subject, [project({ bar: '^2.0.0' })])).toBe(true)
+  expect(await tryFastUpdateImporters(subject, [project({ bar: '^2.0.0' })])).toBe(true)
   expect(Object.keys(subject.packages!)).toStrictEqual(['bar@2.0.0', 'child@3.0.0'])
 })
 
-test('dropping one version of a dependency keeps a package whose peer suffix names another', () => {
+test('dropping one version of a dependency keeps a package whose peer suffix names another', async () => {
   const subject = lockfileWithPeerOnEachVersionOfFoo()
 
-  expect(tryFastUpdateImporters(subject, [project({ qux: '^5.0.0' })])).toBe(true)
+  expect(await tryFastUpdateImporters(subject, [project({ qux: '^5.0.0' })])).toBe(true)
   expect(Object.keys(subject.packages!).sort()).toStrictEqual([
     'baz@4.0.0(foo@2.0.0)',
     'foo@2.0.0',
@@ -83,7 +83,7 @@ test('dropping one version of a dependency keeps a package whose peer suffix nam
   ])
 })
 
-test('dropping a dependency keeps a surviving suffix that only ends with its name', () => {
+test('dropping a dependency keeps a surviving suffix that only ends with its name', async () => {
   const subject = lockfile()
   subject.importers['.' as ProjectId].dependencies!.qux = '5.0.0(@scope/foo@6.0.0)'
   subject.importers['.' as ProjectId].specifiers.qux = '^5.0.0'
@@ -93,10 +93,10 @@ test('dropping a dependency keeps a surviving suffix that only ends with its nam
   }
   subject.packages!['@scope/foo@6.0.0' as DepPath] = { resolution: { integrity: 'sha512-scoped-foo' } }
 
-  expect(tryFastUpdateImporters(subject, [project({ bar: '^2.0.0', qux: '^5.0.0' })])).toBe(true)
+  expect(await tryFastUpdateImporters(subject, [project({ bar: '^2.0.0', qux: '^5.0.0' })])).toBe(true)
 })
 
-test('dropping a dependency a nested peer suffix segment names falls back', () => {
+test('dropping a dependency a nested peer suffix segment names falls back', async () => {
   const subject = lockfileWithPeerOnEachVersionOfFoo()
   subject.importers['.' as ProjectId].dependencies!.baz = '4.0.0(qux@5.0.0(foo@1.1.0))'
   subject.importers['.' as ProjectId].specifiers.baz = '^4.0.0'
@@ -104,10 +104,10 @@ test('dropping a dependency a nested peer suffix segment names falls back', () =
     resolution: { integrity: 'sha512-baz' },
   }
 
-  expect(tryFastUpdateImporters(subject, [project({ qux: '^5.0.0', baz: '^4.0.0' })])).toBe(false)
+  expect(await tryFastUpdateImporters(subject, [project({ qux: '^5.0.0', baz: '^4.0.0' })])).toBe(false)
 })
 
-test('dropping a linked dependency a surviving peer suffix names falls back', () => {
+test('dropping a linked dependency a surviving peer suffix names falls back', async () => {
   const subject = lockfile()
   subject.importers['.' as ProjectId].specifiers.foo = 'workspace:*'
   subject.importers['.' as ProjectId].dependencies!.foo = 'link:packages/foo'
@@ -118,10 +118,10 @@ test('dropping a linked dependency a surviving peer suffix names falls back', ()
     resolution: { integrity: 'sha512-baz' },
   }
 
-  expect(tryFastUpdateImporters(subject, [project({ bar: '^2.0.0', baz: '^4.0.0' })])).toBe(false)
+  expect(await tryFastUpdateImporters(subject, [project({ bar: '^2.0.0', baz: '^4.0.0' })])).toBe(false)
 })
 
-test('dropping a dependency when a surviving peer suffix is hashed falls back', () => {
+test('dropping a dependency when a surviving peer suffix is hashed falls back', async () => {
   const subject = lockfile()
   subject.importers['.' as ProjectId].dependencies!.baz = '4.0.0(sha256-abcdef)'
   subject.importers['.' as ProjectId].specifiers.baz = '^4.0.0'
@@ -129,29 +129,29 @@ test('dropping a dependency when a surviving peer suffix is hashed falls back', 
     resolution: { integrity: 'sha512-baz' },
   }
 
-  expect(tryFastUpdateImporters(subject, [project({ bar: '^2.0.0', baz: '^4.0.0' })])).toBe(false)
+  expect(await tryFastUpdateImporters(subject, [project({ bar: '^2.0.0', baz: '^4.0.0' })])).toBe(false)
 })
 
-test('a dependency group emptied by the removal is deleted', () => {
+test('a dependency group emptied by the removal is deleted', async () => {
   const subject = lockfile()
   subject.importers['.' as ProjectId].devDependencies = { qux: '5.0.0' }
   subject.importers['.' as ProjectId].specifiers.qux = '^5.0.0'
   subject.packages!['qux@5.0.0' as DepPath] = { resolution: { integrity: 'sha512-qux' } }
 
-  expect(tryFastUpdateImporters(subject, [project({ foo: '^1.0.0', bar: '^2.0.0' })])).toBe(true)
+  expect(await tryFastUpdateImporters(subject, [project({ foo: '^1.0.0', bar: '^2.0.0' })])).toBe(true)
   expect(subject.importers['.' as ProjectId].devDependencies).toBeUndefined()
 })
 
-test('a catalog entry whose last referent is dropped is pruned', () => {
+test('a catalog entry whose last referent is dropped is pruned', async () => {
   const subject = lockfile()
   subject.catalogs = { default: { foo: { specifier: '^1.0.0', version: '1.1.0' } } }
   subject.importers['.' as ProjectId].specifiers.foo = 'catalog:'
 
-  expect(tryFastUpdateImporters(subject, [project({ bar: '^2.0.0' })])).toBe(true)
+  expect(await tryFastUpdateImporters(subject, [project({ bar: '^2.0.0' })])).toBe(true)
   expect(subject.catalogs).toBeUndefined()
 })
 
-test('a catalog entry referenced with the catalog:default spelling is kept', () => {
+test('a catalog entry referenced with the catalog:default spelling is kept', async () => {
   const subject = lockfile()
   subject.catalogs = { default: { foo: { specifier: '^1.0.0', version: '1.1.0' } } }
   subject.importers['.' as ProjectId].specifiers.foo = 'catalog:default'
@@ -160,14 +160,14 @@ test('a catalog entry referenced with the catalog:default spelling is kept', () 
     dependencies: { foo: '1.1.0', bar: '2.0.0' },
   }
 
-  expect(tryFastUpdateImporters(subject, [
+  expect(await tryFastUpdateImporters(subject, [
     project({ bar: '^2.0.0' }),
     { id: 'pkg-a' as ProjectId, manifest: { dependencies: { foo: 'catalog:default', bar: '^2.0.0' } } as ProjectManifest },
   ])).toBe(true)
   expect(subject.catalogs).toStrictEqual({ default: { foo: { specifier: '^1.0.0', version: '1.1.0' } } })
 })
 
-test('a catalog entry another importer references is kept', () => {
+test('a catalog entry another importer references is kept', async () => {
   const subject = lockfile()
   subject.catalogs = { default: { foo: { specifier: '^1.0.0', version: '1.1.0' } } }
   subject.importers['.' as ProjectId].specifiers.foo = 'catalog:'
@@ -176,7 +176,7 @@ test('a catalog entry another importer references is kept', () => {
     dependencies: { foo: '1.1.0' },
   }
 
-  expect(tryFastUpdateImporters(subject, [
+  expect(await tryFastUpdateImporters(subject, [
     project({ bar: '^2.0.0' }),
     { id: 'pkg-a' as ProjectId, manifest: { dependencies: { foo: 'catalog:' } } as ProjectManifest },
   ])).toBe(true)
@@ -350,6 +350,6 @@ test('removing the last catalog referent drops the catalogs section from the loc
   })
 })
 /** The composed pipeline restricted to manifest drift. */
-function tryFastUpdateImporters (lockfile: LockfileObject, projects: Project[]): boolean {
+async function tryFastUpdateImporters (lockfile: LockfileObject, projects: Project[]): Promise<boolean> {
   return tryComposeFastUpdates(lockfile, { drift: { importers: true }, projects, workspacePackages: new Map(), resolutionPicksLowest: false })
 }

--- a/pnpm11/installing/deps-installer/test/install/lockedVersionReuse.ts
+++ b/pnpm11/installing/deps-installer/test/install/lockedVersionReuse.ts
@@ -115,12 +115,12 @@ function trackRequestedPackages (storeController: StoreController): string[] {
   return requestedPackages
 }
 
-test('a higher version that exists only under a named registry falls back', () => {
+test('a higher version that exists only under a named registry falls back', async () => {
   // A registry-qualified key's semver only pins a version inside that named
   // registry, so it cannot become a plain importer reference.
   const subject = lockfileWithHigherVersionKeyedAs('@pnpm.e2e/foo@work:1.2.0' as DepPath)
 
-  expect(tryComposeFastUpdates(subject, {
+  expect(await tryComposeFastUpdates(subject, {
     drift: { importers: true },
     workspacePackages: new Map(),
     resolutionPicksLowest: false,
@@ -131,10 +131,10 @@ test('a higher version that exists only under a named registry falls back', () =
   })).toBe(false)
 })
 
-test('a higher version under a plain key is reused', () => {
+test('a higher version under a plain key is reused', async () => {
   const subject = lockfileWithHigherVersionKeyedAs('@pnpm.e2e/foo@1.2.0' as DepPath)
 
-  expect(tryComposeFastUpdates(subject, {
+  expect(await tryComposeFastUpdates(subject, {
     drift: { importers: true },
     workspacePackages: new Map(),
     resolutionPicksLowest: false,
@@ -148,10 +148,10 @@ test('a higher version under a plain key is reused', () => {
   })
 })
 
-test('a moved range keeps a package whose peer suffix names the version it moves to', () => {
+test('a moved range keeps a package whose peer suffix names the version it moves to', async () => {
   const subject = lockfileWithPeerDependentUnderQux()
 
-  expect(tryComposeFastUpdates(subject, {
+  expect(await tryComposeFastUpdates(subject, {
     drift: { importers: true },
     workspacePackages: new Map(),
     resolutionPicksLowest: false,
@@ -164,7 +164,7 @@ test('a moved range keeps a package whose peer suffix names the version it moves
   expect(Object.keys(subject.packages ?? {}).filter(isFoo)).toStrictEqual(['@pnpm.e2e/foo@1.2.0'])
 })
 
-test('a moved range falls back when a peer suffix names the version it moves off', () => {
+test('a moved range falls back when a peer suffix names the version it moves off', async () => {
   const subject = lockfileWithPeerDependentUnderQux()
   subject.importers['.' as ProjectId].specifiers['@pnpm.e2e/baz'] = '^4.0.0'
   subject.importers['.' as ProjectId].dependencies!['@pnpm.e2e/baz'] = '4.0.0(@pnpm.e2e/foo@1.0.0)'
@@ -173,7 +173,7 @@ test('a moved range falls back when a peer suffix names the version it moves off
     dependencies: { '@pnpm.e2e/foo': '1.0.0' },
   }
 
-  expect(tryComposeFastUpdates(subject, {
+  expect(await tryComposeFastUpdates(subject, {
     drift: { importers: true },
     workspacePackages: new Map(),
     resolutionPicksLowest: false,

--- a/pnpm11/installing/deps-installer/test/install/newImporterFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/newImporterFastUpdate.ts
@@ -154,10 +154,10 @@ test('a range several locked versions satisfy falls back when resolution picks t
   })
 })
 
-test('a new project that depends on a workspace sibling falls back to the resolver', () => {
+test('a new project that depends on a workspace sibling falls back to the resolver', async () => {
   const subject = lockfileWithAnEmptyEntryForANewProject()
 
-  expect(tryComposeFastUpdates(subject, {
+  expect(await tryComposeFastUpdates(subject, {
     drift: { importers: true },
     workspacePackages: new Map([
       ['@pnpm.e2e/foo', new Map([['1.2.0', {
@@ -173,10 +173,10 @@ test('a new project that depends on a workspace sibling falls back to the resolv
   })).toBe(false)
 })
 
-test('a new project that declares a `workspace:` dependency falls back to the resolver', () => {
+test('a new project that declares a `workspace:` dependency falls back to the resolver', async () => {
   const subject = lockfileWithAnEmptyEntryForANewProject()
 
-  expect(tryComposeFastUpdates(subject, {
+  expect(await tryComposeFastUpdates(subject, {
     drift: { importers: true },
     workspacePackages: new Map(),
     resolutionPicksLowest: false,
@@ -187,10 +187,10 @@ test('a new project that declares a `workspace:` dependency falls back to the re
   })).toBe(false)
 })
 
-test('a new project that declares a `link:` dependency falls back to the resolver', () => {
+test('a new project that declares a `link:` dependency falls back to the resolver', async () => {
   const subject = lockfileWithAnEmptyEntryForANewProject()
 
-  expect(tryComposeFastUpdates(subject, {
+  expect(await tryComposeFastUpdates(subject, {
     drift: { importers: true },
     workspacePackages: new Map(),
     resolutionPicksLowest: false,
@@ -201,10 +201,10 @@ test('a new project that declares a `link:` dependency falls back to the resolve
   })).toBe(false)
 })
 
-test('a new project that names a dependency the lockfile has never held falls back', () => {
+test('a new project that names a dependency the lockfile has never held falls back', async () => {
   const subject = lockfileWithAnEmptyEntryForANewProject()
 
-  expect(tryComposeFastUpdates(subject, {
+  expect(await tryComposeFastUpdates(subject, {
     drift: { importers: true },
     workspacePackages: new Map(),
     resolutionPicksLowest: false,


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

`catalogs` and `overrides` were the last two fast rewrites that still had to be
the only change in a run. Everything else was folded into the composed pipeline
by pnpm/pnpm#13766, so editing `pnpm.overrides` while also removing a dependency
— or changing a catalog entry in the same commit as a range bump — re-resolved
the whole graph even though either change alone is rewritten in place.

Both now join the pipeline, running last so their guards see the packages a full
resolution would see, with catalogs before overrides. The two conditions that
made them exclusive stay as gates on the whole run: an override whose value is a
`catalog:` reference, and a lockfile carrying a `time` section.

While covering the new catalogs × overrides interaction I found two lockfiles the
rewrites could already write wrong, both reachable before this change: an
override moving a package a catalog entry records left the entry naming the
version the override had just pruned, and a catalog entry moving a package an
unscoped override pins moved it past the pinned version. Each now hands the move
to the resolver; both have a regression test.

pacquet composes the two the same way, in the reuse seed it hands the resolver
(`lockfile_reuse_seed`), with a CLI test that fails without the change. Its
lockfile is always rebuilt from that resolution, catalog snapshots included, so
the two wrong-lockfile cases have no counterpart there and need no mirror.

Closes pnpm/pnpm#13799. Part of pnpm/pnpm#13696.

## Squash Commit Body

```text
The two resolver-consulting fast rewrites still had to arrive alone.
`catalogs` and `overrides` were absent from the composed pipeline, so
editing `pnpm.overrides` while also removing a dependency, or changing a
catalog entry in the same commit as a range bump, re-resolved the whole
graph even though either change on its own is rewritten in place.

Both now join the pipeline. They run last, after the shared graph
epilogue, patch rekeying and the settings block, so their guards see the
packages a full resolution would see; catalogs runs before overrides, the
order a resolution applies the two in. The conditions that made them
exclusive survive as gates: an override whose value is a `catalog:`
reference still sends the whole run to the resolver, and a lockfile
carrying a `time` section still bails whenever either rewrite is in play,
since only a resolution can record the publish date of a version they
introduce.

Two lockfiles the rewrites could write wrong are fixed on the way, both
reachable before this change and more likely once the two compose. An
override moving a package a catalog entry records left the entry naming
the version the override had just pruned; a catalog entry moving a
package an unscoped override pins moved it past the pinned version. Each
now hands the move to the resolver.

pacquet composes the two the same way, in the reuse seed it hands the
resolver. Its lockfile is always rebuilt from that resolution, catalog
snapshots included, so the two wrong-lockfile cases have no counterpart
there and need no mirror.

Closes pnpm/pnpm#13799. Part of pnpm/pnpm#13696.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789006718&installation_model_id=426870&pr_number=13804&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13804&signature=03e351a66bd31c000e6a34136aaacac58b9283ee4bf73a253d6c674f0960b40a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lockfile updates when dependency catalogs and overrides change together.
  * Preserved compatible locked versions while updating dependency ranges, including when the registry is unavailable.
  * Removed obsolete dependency entries and catalog references when dependencies are deleted.
  * Added safer fallback to full resolution when overrides affect cataloged packages.
  * Fixed stale package versions after combined catalog and override changes.
* **Tests**
  * Expanded coverage for optional dependencies, peer dependencies, and importer updates.
* **Documentation**
  * Added release notes for the affected packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->