### PR TITLE
fix(patching): commit patches from paths containing non-ASCII characters

### DIFF
--- a/.changeset/patch-commit-non-ascii-paths.md
+++ b/.changeset/patch-commit-non-ascii-paths.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/patching.commands": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+`pnpm patch-commit` no longer fails with `ERR_PNPM_INVALID_PATCH` and a `Bad diff line` error when the project directory or the edit directory contains non-ASCII characters [#13801](https://github.com/pnpm/pnpm/issues/13801).

--- a/cspell.json
+++ b/cspell.json
@@ -312,6 +312,7 @@
     "proxied",
     "pwsh",
     "qrcode",
+    "quotepath",
     "quux",
     "rcompare",
     "redownload",

--- a/cspell.json
+++ b/cspell.json
@@ -312,7 +312,6 @@
     "proxied",
     "pwsh",
     "qrcode",
-    "quotepath",
     "quux",
     "rcompare",
     "redownload",

--- a/pnpm/crates/patching/src/commit.rs
+++ b/pnpm/crates/patching/src/commit.rs
@@ -150,7 +150,7 @@ pub fn diff_folders(folder_a: &Path, folder_b: &Path) -> Result<String, PatchCom
         .arg("-c")
         .arg("core.safecrlf=false")
         .arg("-c")
-        .arg("core.quotepath=false")
+        .arg("core.quotePath=false")
         .arg("diff")
         .arg("--src-prefix=a/")
         .arg("--dst-prefix=b/")

--- a/pnpm/crates/patching/src/commit.rs
+++ b/pnpm/crates/patching/src/commit.rs
@@ -149,6 +149,8 @@ pub fn diff_folders(folder_a: &Path, folder_b: &Path) -> Result<String, PatchCom
     let status = Command::new("git")
         .arg("-c")
         .arg("core.safecrlf=false")
+        .arg("-c")
+        .arg("core.quotepath=false")
         .arg("diff")
         .arg("--src-prefix=a/")
         .arg("--dst-prefix=b/")

--- a/pnpm/crates/patching/src/commit/tests.rs
+++ b/pnpm/crates/patching/src/commit/tests.rs
@@ -67,6 +67,21 @@ fn patch_commit_diff_dirs_accepts_paths_that_start_with_dash() {
     assert!(diff.contains("diff --git a/index.js b/index.js"), "diff: {diff}");
 }
 
+#[test]
+fn patch_commit_diff_dirs_accepts_paths_with_non_ascii_characters() {
+    let tmp = tempdir().expect("temp dir");
+    let before = tmp.path().join("한글-before");
+    let after = tmp.path().join("한글-after");
+    fs::create_dir(&before).unwrap();
+    fs::create_dir(&after).unwrap();
+    fs::write(before.join("index.js"), "before\n").unwrap();
+    fs::write(after.join("index.js"), "after\n").unwrap();
+
+    let diff = diff_folders(&before, &after).expect("diff dirs");
+
+    assert!(diff.contains("diff --git a/index.js b/index.js"), "diff: {diff}");
+}
+
 #[cfg(unix)]
 #[test]
 fn patch_commit_diff_temp_files_are_owner_only() {

--- a/pnpm11/patching/commands/src/patchCommit.ts
+++ b/pnpm11/patching/commands/src/patchCommit.ts
@@ -152,7 +152,7 @@ async function diffFolders (folderA: string, folderB: string): Promise<string> {
   let stderr!: string
 
   try {
-    const result = await execa('git', ['-c', 'core.safecrlf=false', '-c', 'core.quotepath=false', 'diff', '--src-prefix=a/', '--dst-prefix=b/', '--ignore-cr-at-eol', '--irreversible-delete', '--full-index', '--no-index', '--text', '--no-ext-diff', '--no-color', folderAN, folderBN], {
+    const result = await execa('git', ['-c', 'core.safecrlf=false', '-c', 'core.quotePath=false', 'diff', '--src-prefix=a/', '--dst-prefix=b/', '--ignore-cr-at-eol', '--irreversible-delete', '--full-index', '--no-index', '--text', '--no-ext-diff', '--no-color', '--', folderAN, folderBN], {
       cwd: process.cwd(),
       env: {
         ...process.env,

--- a/pnpm11/patching/commands/src/patchCommit.ts
+++ b/pnpm11/patching/commands/src/patchCommit.ts
@@ -152,7 +152,7 @@ async function diffFolders (folderA: string, folderB: string): Promise<string> {
   let stderr!: string
 
   try {
-    const result = await execa('git', ['-c', 'core.safecrlf=false', 'diff', '--src-prefix=a/', '--dst-prefix=b/', '--ignore-cr-at-eol', '--irreversible-delete', '--full-index', '--no-index', '--text', '--no-ext-diff', '--no-color', folderAN, folderBN], {
+    const result = await execa('git', ['-c', 'core.safecrlf=false', '-c', 'core.quotepath=false', 'diff', '--src-prefix=a/', '--dst-prefix=b/', '--ignore-cr-at-eol', '--irreversible-delete', '--full-index', '--no-index', '--text', '--no-ext-diff', '--no-color', folderAN, folderBN], {
       cwd: process.cwd(),
       env: {
         ...process.env,

--- a/pnpm11/patching/commands/test/patch.test.ts
+++ b/pnpm11/patching/commands/test/patch.test.ts
@@ -364,6 +364,32 @@ describe('patch and commit', () => {
     expect(fs.readFileSync('node_modules/is-positive/index.js', 'utf8')).toContain('// test patching')
   })
 
+  test('patch and commit with a custom edit dir containing non-ASCII characters', async () => {
+    const editDir = path.join(temporaryDirectory(), '한글')
+
+    const output = await patch.handler({ ...defaultPatchOption, editDir }, ['is-positive@1.0.0'])
+    const patchDir = getPatchDirFromPatchOutput(output)
+
+    expect(patchDir).toBe(editDir)
+    expect(fs.existsSync(patchDir)).toBe(true)
+
+    fs.appendFileSync(path.join(patchDir, 'index.js'), '// test patching', 'utf8')
+
+    await patchCommit.handler({
+      ...DEFAULT_OPTS,
+      cacheDir,
+      dir: process.cwd(),
+      rootProjectManifestDir: process.cwd(),
+      frozenLockfile: false,
+      fixLockfile: true,
+      storeDir,
+    }, [patchDir])
+
+    const patchContent = fs.readFileSync('patches/is-positive@1.0.0.patch', 'utf8')
+    expect(patchContent).toContain('diff --git a/index.js b/index.js')
+    expect(fs.readFileSync('node_modules/is-positive/index.js', 'utf8')).toContain('// test patching')
+  })
+
   test('patch with relative path to custom edit dir and commit with absolute path', async () => {
     const editDir = 'custom-edit-dir'
 


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#13801.

`pnpm patch-commit` fails with `ERR_PNPM_INVALID_PATCH` and a `Bad diff line` error when the project directory or the edit directory contains a non-ASCII character. Both stacks run the diff with the system and global git configs neutralized so the output is predictable, which also leaves `core.quotepath` at its default of `true`. Git then escapes the non-ASCII bytes and wraps the whole pathname in quotes:

```text
diff --git a/index.js "b/.../\355\225\234\352\270\200/index.js"
```

Normalization strips the two directory prefixes by matching them literally, and neither matches the escaped spelling, so the absolute path survives into the patch file and the applier rejects the header it produces.

The diff now also runs with `-c core.quotepath=false`, next to the `core.safecrlf=false` that was already there. Git writes the pathname verbatim, the prefixes match, and the header comes out as `diff --git a/index.js b/index.js` the same way it does for an ASCII path.

## Squash Commit Body

```text
patch-commit ran git diff with the system and global configs neutralized
for predictable output, which left core.quotepath at its default of
true. A pathname holding a non-ASCII byte therefore came back escaped
and quoted, as "b/.../\355\225\234\352\270\200/index.js". Normalization
strips the two directory prefixes by matching them literally and neither
matched that spelling, so the absolute path stayed in the patch file and
the applier rejected the header with ERR_PNPM_INVALID_PATCH and a Bad
diff line error.

The diff now runs with core.quotepath=false alongside the existing
core.safecrlf=false in both stacks, so git writes the pathname verbatim
and the header normalizes to a/index.js b/index.js as it does for an
ASCII path.

Fixes pnpm/pnpm#13801.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13809"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789021401&installation_model_id=426870&pr_number=13809&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13809&signature=f72681b0f909f57440da5a3b149ce90b0cc8f3b269858bf7c6505fc29df161ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm patch-commit` failures when project or edit directory paths contain non-ASCII characters.
  * Prevented `ERR_PNPM_INVALID_PATCH` and `Bad diff line` errors in these scenarios.

* **Tests**
  * Added coverage for creating and committing patches from directories with non-ASCII names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->