### PR TITLE
fix(deps-restorer): repair a shared virtual-store slot in place

### DIFF
--- a/.changeset/repair-shared-slot-in-place.md
+++ b/.changeset/repair-shared-slot-in-place.md
@@ -1,5 +1,8 @@
 ---
+"@pnpm/fs.indexed-pkg-importer": patch
+"@pnpm/store.controller-types": patch
 "pacquet": patch
+"pnpm": patch
 ---
 
 An install sharing a global virtual store no longer removes an incomplete package directory that another importer is still writing, which could fail with `failed to remove existing directory ... prior to swap: Directory not empty`. Such a directory is now repaired in place, and a package file left damaged by an interrupted install is restored instead of being kept.

--- a/.changeset/repair-shared-slot-in-place.md
+++ b/.changeset/repair-shared-slot-in-place.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+An install sharing a global virtual store no longer removes an incomplete package directory that another importer is still writing, which could fail with `failed to remove existing directory ... prior to swap: Directory not empty`.

--- a/.changeset/repair-shared-slot-in-place.md
+++ b/.changeset/repair-shared-slot-in-place.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-An install sharing a global virtual store no longer removes an incomplete package directory that another importer is still writing, which could fail with `failed to remove existing directory ... prior to swap: Directory not empty`.
+An install sharing a global virtual store no longer removes an incomplete package directory that another importer is still writing, which could fail with `failed to remove existing directory ... prior to swap: Directory not empty`. Such a directory is now repaired in place, and a package file left damaged by an interrupted install is restored instead of being kept.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4241,6 +4241,7 @@ dependencies = [
  "rayon",
  "reflink-copy",
  "rustc-hash 2.1.2",
+ "same-file",
  "serde",
  "serde-saphyr",
  "serde_json",

--- a/pnpm/crates/deps-restorer/Cargo.toml
+++ b/pnpm/crates/deps-restorer/Cargo.toml
@@ -68,5 +68,8 @@ tar               = { workspace = true }
 text-block-macros = { workspace = true }
 walkdir           = { workspace = true }
 
+[target.'cfg(windows)'.dependencies]
+same-file = { workspace = true }
+
 [lints]
 workspace = true

--- a/pnpm/crates/deps-restorer/src/import_indexed_dir.rs
+++ b/pnpm/crates/deps-restorer/src/import_indexed_dir.rs
@@ -257,7 +257,7 @@ fn populate_dir<Reporter: self::Reporter>(
     ordered.sort_by_key(|s| s.len());
     for rel in ordered {
         if placement == Placement::Repair {
-            clear_dirents_blocking_dir(dir_path, rel)?;
+            clear_dirent_blocking_dir(dir_path, rel)?;
         }
         let abs = dir_path.join(rel);
         fs::create_dir_all(&abs)
@@ -363,7 +363,7 @@ fn clear_dir_blocking_file(target: &Path) -> Result<(), ImportIndexedDirError> {
 /// Walking top-down means a component whose parent is itself a file is
 /// never stat-ed: the parent is cleared first, and everything below a
 /// missing component is missing too.
-fn clear_dirents_blocking_dir(root: &Path, rel: &str) -> Result<(), ImportIndexedDirError> {
+fn clear_dirent_blocking_dir(root: &Path, rel: &str) -> Result<(), ImportIndexedDirError> {
     let mut abs = root.to_path_buf();
     for component in Path::new(rel).components() {
         abs.push(component);

--- a/pnpm/crates/deps-restorer/src/import_indexed_dir.rs
+++ b/pnpm/crates/deps-restorer/src/import_indexed_dir.rs
@@ -396,15 +396,20 @@ fn stage_and_swap<Reporter: self::Reporter>(
         Some(_) | None => false,
     };
 
-    // 3b. Keep a complete content-addressed target instead of removing a directory that another
-    //     importer may be populating or reading. When step 3 moved `node_modules/`, continue with
-    //     the swap so that it can be restored.
+    // 3b. Never remove a content-addressed target another importer may be populating or reading:
+    //     keep it when it is complete, and otherwise repair it in place, which is non-destructive
+    //     and converges because the path identifies the contents. When step 3 moved
+    //     `node_modules/`, continue with the swap so that it can be restored.
     if safe_to_skip && !nm_moved {
         match fs::rename(&stage, dir_path) {
             Ok(()) => return Ok(()),
-            Err(error) if is_occupied_target(&error) && is_complete_import(dir_path, cas_paths) => {
+            Err(error) if is_occupied_target(&error) => {
                 let _ = fs::remove_dir_all(&stage);
-                return Ok(());
+                return if is_complete_import(dir_path, cas_paths) {
+                    Ok(())
+                } else {
+                    populate_dir::<Reporter>(logged_methods, import_method, dir_path, cas_paths)
+                };
             }
             Err(_) => {}
         }

--- a/pnpm/crates/deps-restorer/src/import_indexed_dir.rs
+++ b/pnpm/crates/deps-restorer/src/import_indexed_dir.rs
@@ -443,7 +443,7 @@ fn file_matches_store_entry(target: &Path, store_path: &Path) -> bool {
 
 /// Byte-compare two files without buffering either one.
 ///
-/// `populate_dir` runs its entries through rayon, so a repair can be
+/// [`populate_dir`] runs its entries through rayon, so a repair can be
 /// comparing as many packages as there are workers at once. Reading
 /// both sides whole would hold two allocations the size of the file per
 /// worker, and a store entry for a native binary (`@napi-rs/*`,

--- a/pnpm/crates/deps-restorer/src/import_indexed_dir.rs
+++ b/pnpm/crates/deps-restorer/src/import_indexed_dir.rs
@@ -227,13 +227,19 @@ pub fn import_indexed_dir<Reporter: self::Reporter>(
             )
             .inspect(|()| unquarantine())
         }
+        // A forced refresh of a shared slot still works in place. Building a
+        // complete stage first would duplicate every write before the rename
+        // inevitably discovers that the shared directory already exists.
+        (Some(file_type), true) if file_type.is_dir() && opts.safe_to_skip => {
+            import_into_shared_dir::<Reporter>(logged_methods, import_method, dir_path, cas_paths)
+                .inspect(|()| unquarantine())
+        }
         (Some(_), true) => stage_and_swap::<Reporter>(
             logged_methods,
             import_method,
             dir_path,
             cas_paths,
             opts.keep_modules_dir,
-            opts.safe_to_skip,
         )
         .inspect(|()| unquarantine()),
     }
@@ -458,26 +464,6 @@ fn marker_file(cas_paths: &HashMap<String, PathBuf>) -> Option<&str> {
     cas_paths.keys().map(String::as_str).filter(|path| *path != crate::NEEDS_BUILD_MARKER).min()
 }
 
-/// Whether a failed rename onto `dir_path` means the target is already
-/// there, so it can be adopted or repaired instead of replaced.
-///
-/// Supported platforms report an occupied directory with different
-/// error kinds, and Windows adds `ResourceBusy` for a target another
-/// process holds open — the common case here, since the whole point of
-/// a shared slot is that a second importer may be inside it. None of
-/// those kinds is conclusive on its own, though: `PermissionDenied` and
-/// `ResourceBusy` also cover failures that have nothing to do with the
-/// target, so the target itself has the final say.
-fn is_occupied_target(error: &io::Error, dir_path: &Path) -> bool {
-    matches!(
-        error.kind(),
-        io::ErrorKind::DirectoryNotEmpty
-            | io::ErrorKind::AlreadyExists
-            | io::ErrorKind::PermissionDenied
-            | io::ErrorKind::ResourceBusy,
-    ) && fs::symlink_metadata(dir_path).is_ok_and(|meta| meta.is_dir())
-}
-
 /// Whether `dir_path` already holds exactly this import, pnpm's
 /// `allFilesMatch`. Existence is not enough: the completion marker goes
 /// down last, but a file truncated by an interrupted copy or damaged
@@ -570,10 +556,10 @@ pub fn marker_present(dir_path: &Path, cas_paths: &HashMap<String, PathBuf>) -> 
 /// private temp sibling, then rename onto `target` so it is never
 /// observed half-written, and so a stale copy is replaced in one step
 /// under a reader. pacquet picks its import tier at runtime, so it
-/// always stages rather than predicting whether the import will copy. A
-/// concurrent importer that got there first surfaces as `AlreadyExists`
-/// or is replaced atomically; the content is content-addressed either
-/// way, so we just drop our temp.
+/// always stages rather than predicting whether the import will copy.
+/// A failed rename is accepted only when the destination now matches the
+/// store entry, which means a concurrent importer won the race with the
+/// same content.
 fn import_atomic<Reporter: self::Reporter>(
     logged_methods: &AtomicU8,
     import_method: PackageImportMethod,
@@ -581,11 +567,15 @@ fn import_atomic<Reporter: self::Reporter>(
     target: &Path,
 ) -> Result<(), ImportIndexedDirError> {
     let temp = pick_stage_path(target);
-    import_into_fresh_target::<Reporter>(logged_methods, import_method, store_path, &temp)
-        .map_err(ImportIndexedDirError::LinkFile)?;
-    match fs::rename(&temp, target) {
+    if let Err(error) =
+        import_into_fresh_target::<Reporter>(logged_methods, import_method, store_path, &temp)
+    {
+        let _ = fs::remove_file(&temp);
+        return Err(ImportIndexedDirError::LinkFile(error));
+    }
+    match pacquet_fs::rename_with_retry(&temp, target) {
         Ok(()) => Ok(()),
-        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+        Err(_) if file_matches_store_entry(target, store_path) => {
             let _ = fs::remove_file(&temp);
             Ok(())
         }
@@ -602,7 +592,6 @@ fn stage_and_swap<Reporter: self::Reporter>(
     dir_path: &Path,
     cas_paths: &HashMap<String, PathBuf>,
     keep_modules_dir: bool,
-    safe_to_skip: bool,
 ) -> Result<(), ImportIndexedDirError> {
     let stage = pick_stage_path(dir_path);
     let target_modules = dir_path.join("node_modules");
@@ -618,53 +607,11 @@ fn stage_and_swap<Reporter: self::Reporter>(
         return Err(error);
     }
 
-    // 2. A content-addressed target is never removed: other importers,
-    //    in this process or another install, may be populating or
-    //    reading it. Adopt it when it already matches, and otherwise
-    //    repair it entry by entry, which adds and replaces but never
-    //    unlinks, so two importers converge on the same tree. Repairing
-    //    in place also leaves a nested `node_modules/` where it is,
-    //    which is why this runs before the preservation dance below.
-    //
-    //    Every arm returns: a shared slot must never reach the
-    //    `remove_dir_all` in step 5. A rename can fail for reasons that
-    //    say nothing about the target — a sharing violation on Windows,
-    //    a busy mount point — and falling through on those would delete
-    //    the slot out from under whoever holds it, which is the bug
-    //    this branch exists to prevent.
-    if safe_to_skip {
-        match fs::rename(&stage, dir_path) {
-            Ok(()) => return Ok(()),
-            Err(error) if is_occupied_target(&error, dir_path) => {
-                let _ = fs::remove_dir_all(&stage);
-                return if all_files_match(dir_path, cas_paths) {
-                    Ok(())
-                } else {
-                    populate_dir::<Reporter>(
-                        logged_methods,
-                        import_method,
-                        dir_path,
-                        cas_paths,
-                        Placement::Repair,
-                    )
-                };
-            }
-            Err(error) => {
-                let _ = fs::remove_dir_all(&stage);
-                return Err(ImportIndexedDirError::Swap {
-                    from: stage,
-                    to: dir_path.to_path_buf(),
-                    error,
-                });
-            }
-        }
-    }
-
-    // 3. Inspect the existing `node_modules/` so nested deps survive
+    // 2. Inspect the existing `node_modules/` so nested deps survive
     //    the swap. Only `NotFound` is benign — `PermissionDenied` and
     //    other transient I/O failures must surface, otherwise the
     //    user's nested deps get silently clobbered when the directory
-    //    is removed in step 5.
+    //    is removed in step 4.
     let nm_kind = if keep_modules_dir {
         match fs::symlink_metadata(&target_modules) {
             Ok(meta) => Some(meta.file_type()),
@@ -678,8 +625,8 @@ fn stage_and_swap<Reporter: self::Reporter>(
         None
     };
 
-    // 4. Preserve `node_modules/` if it's a real directory. Track the
-    //    move so steps 5 and 6 can rescue it on failure.
+    // 3. Preserve `node_modules/` if it's a real directory. Track the
+    //    move so steps 4 and 5 can rescue it on failure.
     //
     //    Indexed file maps for npm tarballs never contain
     //    `node_modules/` entries (npm and pnpm strip them at pack
@@ -707,7 +654,7 @@ fn stage_and_swap<Reporter: self::Reporter>(
         Some(_) | None => false,
     };
 
-    // 5. Remove the old contents. If this fails after step 4, the
+    // 4. Remove the old contents. If this fails after step 3, the
     //    staged copy of `node_modules/` is the user's only copy —
     //    try to move it back into place before bailing, and leak
     //    the staging directory if the move can't run.
@@ -716,11 +663,11 @@ fn stage_and_swap<Reporter: self::Reporter>(
         return Err(ImportIndexedDirError::RemoveExisting { path: dir_path.to_path_buf(), error });
     }
 
-    // 6. Move the staged tree into place. There's a brief window
+    // 5. Move the staged tree into place. There's a brief window
     //    between `remove_dir_all` and `rename` where `dir_path` does
     //    not exist on disk — acceptable for a slot only this install
-    //    can reach, which is why a shared one returns at step 2. If
-    //    the rename fails, recreate
+    //    can reach; a shared slot never enters this function. If the
+    //    rename fails, recreate
     //    `dir_path` so the rescued `node_modules/` has somewhere to
     //    land.
     if let Err(error) = fs::rename(&stage, dir_path) {
@@ -738,7 +685,7 @@ fn stage_and_swap<Reporter: self::Reporter>(
     Ok(())
 }
 
-/// Combined post-failure cleanup for steps 5 and 6: restore the
+/// Combined post-failure cleanup for steps 4 and 5: restore the
 /// preserved `node_modules/` if it was moved, then rimraf the
 /// staging directory — but only if the restore actually ran.
 /// Leaving the staging directory on disk after a failed restore is

--- a/pnpm/crates/deps-restorer/src/import_indexed_dir.rs
+++ b/pnpm/crates/deps-restorer/src/import_indexed_dir.rs
@@ -393,14 +393,24 @@ fn marker_file(cas_paths: &HashMap<String, PathBuf>) -> Option<&str> {
     cas_paths.keys().map(String::as_str).filter(|path| *path != crate::NEEDS_BUILD_MARKER).min()
 }
 
-// Supported platforms report an occupied directory with different error kinds.
-fn is_occupied_target(error: &io::Error) -> bool {
+/// Whether a failed rename onto `dir_path` means the target is already
+/// there, so it can be adopted or repaired instead of replaced.
+///
+/// Supported platforms report an occupied directory with different
+/// error kinds, and Windows adds `ResourceBusy` for a target another
+/// process holds open — the common case here, since the whole point of
+/// a shared slot is that a second importer may be inside it. None of
+/// those kinds is conclusive on its own, though: `PermissionDenied` and
+/// `ResourceBusy` also cover failures that have nothing to do with the
+/// target, so the target itself has the final say.
+fn is_occupied_target(error: &io::Error, dir_path: &Path) -> bool {
     matches!(
         error.kind(),
         io::ErrorKind::DirectoryNotEmpty
             | io::ErrorKind::AlreadyExists
-            | io::ErrorKind::PermissionDenied,
-    )
+            | io::ErrorKind::PermissionDenied
+            | io::ErrorKind::ResourceBusy,
+    ) && fs::symlink_metadata(dir_path).is_ok_and(|meta| meta.is_dir())
 }
 
 /// Whether `dir_path` already holds exactly this import, pnpm's
@@ -428,7 +438,39 @@ fn file_matches_store_entry(target: &Path, store_path: &Path) -> bool {
         return true;
     }
     target_meta.len() == store_meta.len()
-        && matches!((fs::read(target), fs::read(store_path)), (Ok(target), Ok(store)) if target == store)
+        && files_have_equal_contents(target, store_path).unwrap_or(false)
+}
+
+/// Byte-compare two files without buffering either one.
+///
+/// `populate_dir` runs its entries through rayon, so a repair can be
+/// comparing as many packages as there are workers at once. Reading
+/// both sides whole would hold two allocations the size of the file per
+/// worker, and a store entry for a native binary (`@napi-rs/*`,
+/// `esbuild`) runs to tens of megabytes. Streaming holds one 8 KB
+/// buffer per side instead, and stops at the first differing chunk
+/// rather than reading two files that already disagree in byte one.
+/// `pacquet_fs`'s `file_equals_bytes` streams for the same reason.
+fn files_have_equal_contents(left: &Path, right: &Path) -> io::Result<bool> {
+    use std::io::BufRead;
+
+    let mut left = io::BufReader::new(fs::File::open(left)?);
+    let mut right = io::BufReader::new(fs::File::open(right)?);
+    loop {
+        let left_chunk = left.fill_buf()?;
+        let right_chunk = right.fill_buf()?;
+        // One side ending first means the sizes disagree after all —
+        // the caller's size check can only read stale metadata.
+        if left_chunk.is_empty() || right_chunk.is_empty() {
+            return Ok(left_chunk.is_empty() && right_chunk.is_empty());
+        }
+        let len = left_chunk.len().min(right_chunk.len());
+        if left_chunk[..len] != right_chunk[..len] {
+            return Ok(false);
+        }
+        left.consume(len);
+        right.consume(len);
+    }
 }
 
 /// Whether two stat results name one inode. Windows exposes a file index
@@ -513,10 +555,17 @@ fn stage_and_swap<Reporter: self::Reporter>(
     //    unlinks, so two importers converge on the same tree. Repairing
     //    in place also leaves a nested `node_modules/` where it is,
     //    which is why this runs before the preservation dance below.
+    //
+    //    Every arm returns: a shared slot must never reach the
+    //    `remove_dir_all` in step 5. A rename can fail for reasons that
+    //    say nothing about the target — a sharing violation on Windows,
+    //    a busy mount point — and falling through on those would delete
+    //    the slot out from under whoever holds it, which is the bug
+    //    this branch exists to prevent.
     if safe_to_skip {
         match fs::rename(&stage, dir_path) {
             Ok(()) => return Ok(()),
-            Err(error) if is_occupied_target(&error) => {
+            Err(error) if is_occupied_target(&error, dir_path) => {
                 let _ = fs::remove_dir_all(&stage);
                 return if all_files_match(dir_path, cas_paths) {
                     Ok(())
@@ -530,7 +579,14 @@ fn stage_and_swap<Reporter: self::Reporter>(
                     )
                 };
             }
-            Err(_) => {}
+            Err(error) => {
+                let _ = fs::remove_dir_all(&stage);
+                return Err(ImportIndexedDirError::Swap {
+                    from: stage,
+                    to: dir_path.to_path_buf(),
+                    error,
+                });
+            }
         }
     }
 

--- a/pnpm/crates/deps-restorer/src/import_indexed_dir.rs
+++ b/pnpm/crates/deps-restorer/src/import_indexed_dir.rs
@@ -92,13 +92,32 @@ pub enum ImportIndexedDirError {
         #[error(source)]
         error: io::Error,
     },
-    #[display("failed to place completion marker {from:?} at {to:?}: {error}")]
-    PlaceMarker {
+    #[display("failed to place imported file {from:?} at {to:?}: {error}")]
+    PlaceFile {
         from: PathBuf,
         to: PathBuf,
         #[error(source)]
         error: io::Error,
     },
+    #[display("failed to clear {path:?}, which blocks the repair of a partial import: {error}")]
+    ClearBlockingDirEntry {
+        path: PathBuf,
+        #[error(source)]
+        error: io::Error,
+    },
+}
+
+/// How [`populate_dir`] puts each indexed entry at its final path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Placement {
+    /// Nothing of this import is at the target yet: link straight at the
+    /// final path and adopt a dirent a concurrent importer placed first,
+    /// since the two are importing the same content-addressed file.
+    Fresh,
+    /// The target already holds part of an import: replace whatever does
+    /// not match the store entry, so a file damaged or truncated by an
+    /// interrupted import is healed rather than adopted.
+    Repair,
 }
 
 /// Materialize an indexed package's files into `dir_path`, the way
@@ -112,10 +131,10 @@ pub enum ImportIndexedDirError {
 /// (hardlink → reflink → copy, etc.), and the per-method
 /// `pnpm:package-import-method` log is emitted via `logged_methods`
 /// the first time each tier is used in this install. The pre-flight
-/// `fs::metadata` short-circuit lives on `link_file()`; `populate_dir`
-/// skips it and relies on `import_into_fresh_target`'s EEXIST tolerance,
-/// which is what keeps a marker-repair re-link over a partial directory
-/// correct.
+/// `fs::metadata` short-circuit lives on `link_file()`; an import into a
+/// private target skips it and relies on `import_into_fresh_target`'s
+/// EEXIST tolerance, which is what keeps a marker-repair re-link over a
+/// partial directory correct.
 pub fn import_indexed_dir<Reporter: self::Reporter>(
     logged_methods: &AtomicU8,
     import_method: PackageImportMethod,
@@ -141,19 +160,34 @@ pub fn import_indexed_dir<Reporter: self::Reporter>(
     // per-install `xattr` cost — exactly pnpm's `!pkgExistsAtTargetDir` gate.
     let unquarantine = || remove_quarantine_from_native_binaries(dir_path, cas_paths);
     match (existing_kind, opts.force) {
-        (None, _) => populate_dir::<Reporter>(logged_methods, import_method, dir_path, cas_paths)
-            .inspect(|()| unquarantine()),
+        (None, _) => populate_dir::<Reporter>(
+            logged_methods,
+            import_method,
+            dir_path,
+            cas_paths,
+            Placement::Fresh,
+        )
+        .inspect(|()| unquarantine()),
         // Short-circuit only when the completion marker is present
         // (pnpm's `pkgExistsAtTargetDir`, which checks `package.json`),
         // not on mere directory existence. A marker-less directory is a
         // partial import; repair it by re-running the non-destructive
-        // `populate_dir`. Ported from pnpm/pnpm#12204 (cbfeeef328).
+        // `populate_dir`. Ported from pnpm/pnpm#12204 (cbfeeef328), whose
+        // repair adopts an existing dirent rather than replacing it —
+        // pnpm's own fast path does, and a private slot has no second
+        // importer racing this one.
         (Some(file_type), false) if file_type.is_dir() => {
             if marker_present(dir_path, cas_paths) {
                 Ok(())
             } else {
-                populate_dir::<Reporter>(logged_methods, import_method, dir_path, cas_paths)
-                    .inspect(|()| unquarantine())
+                populate_dir::<Reporter>(
+                    logged_methods,
+                    import_method,
+                    dir_path,
+                    cas_paths,
+                    Placement::Fresh,
+                )
+                .inspect(|()| unquarantine())
             }
         }
         // A non-directory dirent is left as-is; only force=true clobbers it.
@@ -165,8 +199,14 @@ pub fn import_indexed_dir<Reporter: self::Reporter>(
             remove_non_dir_dirent(dir_path, file_type).map_err(|error| {
                 ImportIndexedDirError::ClearNonDirEntry { path: dir_path.to_path_buf(), error }
             })?;
-            populate_dir::<Reporter>(logged_methods, import_method, dir_path, cas_paths)
-                .inspect(|()| unquarantine())
+            populate_dir::<Reporter>(
+                logged_methods,
+                import_method,
+                dir_path,
+                cas_paths,
+                Placement::Fresh,
+            )
+            .inspect(|()| unquarantine())
         }
         (Some(_), true) => stage_and_swap::<Reporter>(
             logged_methods,
@@ -180,18 +220,19 @@ pub fn import_indexed_dir<Reporter: self::Reporter>(
     }
 }
 
-/// Fresh-target path: make the parent dir set, then run the parallel
-/// `import_into_fresh_target` over `cas_paths`. Mirrors pnpm v11's
-/// `tryImportIndexedDir`: collect the unique relative parent dirs,
-/// sort shortest-first, mkdir each sequentially, then dispatch the
-/// file imports in parallel. Sorting by length means the recursive
-/// mkdir for a deeper dir always finds its ancestor already on disk,
-/// so each call costs one `mkdirat` instead of walking up.
+/// Make the parent dir set, then run the parallel per-entry import over
+/// `cas_paths`. Mirrors pnpm v11's `tryImportIndexedDir`: collect the
+/// unique relative parent dirs, sort shortest-first, mkdir each
+/// sequentially, then dispatch the file imports in parallel. Sorting by
+/// length means the recursive mkdir for a deeper dir always finds its
+/// ancestor already on disk, so each call costs one `mkdirat` instead of
+/// walking up.
 fn populate_dir<Reporter: self::Reporter>(
     logged_methods: &AtomicU8,
     import_method: PackageImportMethod,
     dir_path: &Path,
     cas_paths: &HashMap<String, PathBuf>,
+    placement: Placement,
 ) -> Result<(), ImportIndexedDirError> {
     let mut rel_dirs: HashSet<&str> = HashSet::new();
     for entry in cas_paths.keys() {
@@ -215,6 +256,9 @@ fn populate_dir<Reporter: self::Reporter>(
     let mut ordered: Vec<&str> = rel_dirs.into_iter().collect();
     ordered.sort_by_key(|s| s.len());
     for rel in ordered {
+        if placement == Placement::Repair {
+            clear_dirents_blocking_dir(dir_path, rel)?;
+        }
         let abs = dir_path.join(rel);
         fs::create_dir_all(&abs)
             .map_err(|error| ImportIndexedDirError::CreateDir { dirname: abs, error })?;
@@ -228,26 +272,109 @@ fn populate_dir<Reporter: self::Reporter>(
         .par_iter()
         .filter(|(cleaned_entry, _)| Some(cleaned_entry.as_str()) != marker)
         .try_for_each(|(cleaned_entry, store_path)| {
-            // No pre-flight stat: `import_into_fresh_target` tolerates an
-            // existing target (the repair branch re-links over a partial
-            // directory), so the stat would be pure overhead — ~170k saved
-            // syscalls on the alotta-files fixture.
-            import_into_fresh_target::<Reporter>(
+            place_entry::<Reporter>(
+                placement,
                 logged_methods,
                 import_method,
                 store_path,
                 &dir_path.join(cleaned_entry),
             )
-        })
-        .map_err(ImportIndexedDirError::LinkFile)?;
+        })?;
 
     if let Some(marker) = marker {
-        import_marker_atomic::<Reporter>(
+        place_marker::<Reporter>(
+            placement,
             logged_methods,
             import_method,
             &cas_paths[marker],
             &dir_path.join(marker),
         )?;
+    }
+    Ok(())
+}
+
+/// Put one indexed entry at `target`.
+///
+/// [`Placement::Fresh`] links straight at the final path with no
+/// pre-flight stat: `import_into_fresh_target` tolerates an existing
+/// target, so the stat would be pure overhead — ~170k saved syscalls on
+/// the alotta-files fixture.
+///
+/// [`Placement::Repair`] instead asks whether what is already there is
+/// this store entry, and swaps a fresh copy in when it is not. A
+/// hardlinked or reflinked entry shares the store inode, so recognising
+/// an intact file costs two stats and no read.
+fn place_entry<Reporter: self::Reporter>(
+    placement: Placement,
+    logged_methods: &AtomicU8,
+    import_method: PackageImportMethod,
+    store_path: &Path,
+    target: &Path,
+) -> Result<(), ImportIndexedDirError> {
+    match placement {
+        Placement::Fresh => {
+            import_into_fresh_target::<Reporter>(logged_methods, import_method, store_path, target)
+                .map_err(ImportIndexedDirError::LinkFile)
+        }
+        Placement::Repair => {
+            if file_matches_store_entry(target, store_path) {
+                return Ok(());
+            }
+            clear_dir_blocking_file(target)?;
+            import_atomic::<Reporter>(logged_methods, import_method, store_path, target)
+        }
+    }
+}
+
+/// The completion marker is always placed atomically, in either
+/// placement, so no reader observes it half-written. A repair adds the
+/// clearing pass, since the marker path may hold a directory in a tree
+/// damaged badly enough to need one.
+fn place_marker<Reporter: self::Reporter>(
+    placement: Placement,
+    logged_methods: &AtomicU8,
+    import_method: PackageImportMethod,
+    store_path: &Path,
+    target: &Path,
+) -> Result<(), ImportIndexedDirError> {
+    if placement == Placement::Repair {
+        clear_dir_blocking_file(target)?;
+    }
+    import_atomic::<Reporter>(logged_methods, import_method, store_path, target)
+}
+
+/// Remove a directory sitting where a package file belongs: the rename
+/// in [`import_atomic`] replaces a file but never a directory.
+fn clear_dir_blocking_file(target: &Path) -> Result<(), ImportIndexedDirError> {
+    match fs::symlink_metadata(target) {
+        Ok(meta) if meta.is_dir() => fs::remove_dir_all(target).map_err(|error| {
+            ImportIndexedDirError::ClearBlockingDirEntry { path: target.to_path_buf(), error }
+        }),
+        Ok(_) => Ok(()),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => {
+            Err(ImportIndexedDirError::InspectTarget { path: target.to_path_buf(), error })
+        }
+    }
+}
+
+/// Remove any non-directory dirent along `rel`'s ancestry, so that the
+/// `create_dir_all` which follows has somewhere to put the directory.
+/// Walking top-down means a component whose parent is itself a file is
+/// never stat-ed: the parent is cleared first, and everything below a
+/// missing component is missing too.
+fn clear_dirents_blocking_dir(root: &Path, rel: &str) -> Result<(), ImportIndexedDirError> {
+    let mut abs = root.to_path_buf();
+    for component in Path::new(rel).components() {
+        abs.push(component);
+        match fs::symlink_metadata(&abs) {
+            Ok(meta) if meta.is_dir() => {}
+            Ok(meta) => remove_non_dir_dirent(&abs, meta.file_type()).map_err(|error| {
+                ImportIndexedDirError::ClearBlockingDirEntry { path: abs.clone(), error }
+            })?,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => break,
+            Err(error) => return Err(ImportIndexedDirError::InspectTarget { path: abs, error }),
+        }
     }
     Ok(())
 }
@@ -276,14 +403,45 @@ fn is_occupied_target(error: &io::Error) -> bool {
     )
 }
 
-// The completion marker is placed last. Verify every package file in case a completed import was
-// later damaged. The needs-build marker is transient and does not identify package contents.
-fn is_complete_import(dir_path: &Path, cas_paths: &HashMap<String, PathBuf>) -> bool {
-    marker_present(dir_path, cas_paths)
-        && cas_paths
-            .keys()
-            .filter(|entry| entry.as_str() != crate::NEEDS_BUILD_MARKER)
-            .all(|entry| dir_path.join(entry).exists())
+/// Whether `dir_path` already holds exactly this import, pnpm's
+/// `allFilesMatch`. Existence is not enough: the completion marker goes
+/// down last, but a file truncated by an interrupted copy or damaged
+/// after the import finished still exists, and treating that slot as
+/// done would leave it broken for every later install. The needs-build
+/// marker is transient and does not identify package contents.
+fn all_files_match(dir_path: &Path, cas_paths: &HashMap<String, PathBuf>) -> bool {
+    cas_paths
+        .iter()
+        .filter(|(entry, _)| entry.as_str() != crate::NEEDS_BUILD_MARKER)
+        .all(|(entry, store_path)| file_matches_store_entry(&dir_path.join(entry), store_path))
+}
+
+/// Whether `target` already carries `store_path`'s content. Imports that
+/// hardlink or reflink share the store inode, which settles it without a
+/// read; the copy tier falls back to comparing size and then bytes, the
+/// way pnpm's `allFilesMatch` does.
+fn file_matches_store_entry(target: &Path, store_path: &Path) -> bool {
+    let (Ok(target_meta), Ok(store_meta)) = (fs::metadata(target), fs::metadata(store_path)) else {
+        return false;
+    };
+    if is_same_file(&target_meta, &store_meta) {
+        return true;
+    }
+    target_meta.len() == store_meta.len()
+        && matches!((fs::read(target), fs::read(store_path)), (Ok(target), Ok(store)) if target == store)
+}
+
+/// Whether two stat results name one inode. Windows exposes a file index
+/// only through an open handle, so it always compares content there.
+#[cfg(unix)]
+fn is_same_file(left: &fs::Metadata, right: &fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    left.ino() == right.ino() && left.dev() == right.dev()
+}
+
+#[cfg(not(unix))]
+fn is_same_file(_left: &fs::Metadata, _right: &fs::Metadata) -> bool {
+    false
 }
 
 /// Whether `dir_path` holds the completion marker. An empty map has no
@@ -296,23 +454,24 @@ pub fn marker_present(dir_path: &Path, cas_paths: &HashMap<String, PathBuf>) -> 
     }
 }
 
-/// Place the marker atomically (pnpm's `importFileAtomic`): link it into a
-/// private temp sibling, then rename onto `marker_path` so it is never
-/// observed half-written. pacquet picks its import tier at runtime, so it
+/// Place a file atomically (pnpm's `importFileAtomic`): link it into a
+/// private temp sibling, then rename onto `target` so it is never
+/// observed half-written, and so a stale copy is replaced in one step
+/// under a reader. pacquet picks its import tier at runtime, so it
 /// always stages rather than predicting whether the import will copy. A
-/// concurrent importer that placed the marker first surfaces as
-/// `AlreadyExists` or is replaced atomically; the content is
-/// content-addressed either way, so we just drop our temp.
-fn import_marker_atomic<Reporter: self::Reporter>(
+/// concurrent importer that got there first surfaces as `AlreadyExists`
+/// or is replaced atomically; the content is content-addressed either
+/// way, so we just drop our temp.
+fn import_atomic<Reporter: self::Reporter>(
     logged_methods: &AtomicU8,
     import_method: PackageImportMethod,
     store_path: &Path,
-    marker_path: &Path,
+    target: &Path,
 ) -> Result<(), ImportIndexedDirError> {
-    let temp = pick_stage_path(marker_path);
+    let temp = pick_stage_path(target);
     import_into_fresh_target::<Reporter>(logged_methods, import_method, store_path, &temp)
         .map_err(ImportIndexedDirError::LinkFile)?;
-    match fs::rename(&temp, marker_path) {
+    match fs::rename(&temp, target) {
         Ok(()) => Ok(()),
         Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
             let _ = fs::remove_file(&temp);
@@ -320,11 +479,7 @@ fn import_marker_atomic<Reporter: self::Reporter>(
         }
         Err(error) => {
             let _ = fs::remove_file(&temp);
-            Err(ImportIndexedDirError::PlaceMarker {
-                from: temp,
-                to: marker_path.to_path_buf(),
-                error,
-            })
+            Err(ImportIndexedDirError::PlaceFile { from: temp, to: target.to_path_buf(), error })
         }
     }
 }
@@ -344,16 +499,46 @@ fn stage_and_swap<Reporter: self::Reporter>(
     // 1. Populate the staging directory with the new contents. On
     //    failure, the staging directory is the only thing on disk we
     //    own — a blanket rimraf is safe.
-    if let Err(error) = populate_dir::<Reporter>(logged_methods, import_method, &stage, cas_paths) {
+    if let Err(error) =
+        populate_dir::<Reporter>(logged_methods, import_method, &stage, cas_paths, Placement::Fresh)
+    {
         let _ = fs::remove_dir_all(&stage);
         return Err(error);
     }
 
-    // 2. Inspect the existing `node_modules/` so nested deps survive
+    // 2. A content-addressed target is never removed: other importers,
+    //    in this process or another install, may be populating or
+    //    reading it. Adopt it when it already matches, and otherwise
+    //    repair it entry by entry, which adds and replaces but never
+    //    unlinks, so two importers converge on the same tree. Repairing
+    //    in place also leaves a nested `node_modules/` where it is,
+    //    which is why this runs before the preservation dance below.
+    if safe_to_skip {
+        match fs::rename(&stage, dir_path) {
+            Ok(()) => return Ok(()),
+            Err(error) if is_occupied_target(&error) => {
+                let _ = fs::remove_dir_all(&stage);
+                return if all_files_match(dir_path, cas_paths) {
+                    Ok(())
+                } else {
+                    populate_dir::<Reporter>(
+                        logged_methods,
+                        import_method,
+                        dir_path,
+                        cas_paths,
+                        Placement::Repair,
+                    )
+                };
+            }
+            Err(_) => {}
+        }
+    }
+
+    // 3. Inspect the existing `node_modules/` so nested deps survive
     //    the swap. Only `NotFound` is benign — `PermissionDenied` and
     //    other transient I/O failures must surface, otherwise the
     //    user's nested deps get silently clobbered when the directory
-    //    is removed in step 4.
+    //    is removed in step 5.
     let nm_kind = if keep_modules_dir {
         match fs::symlink_metadata(&target_modules) {
             Ok(meta) => Some(meta.file_type()),
@@ -367,8 +552,8 @@ fn stage_and_swap<Reporter: self::Reporter>(
         None
     };
 
-    // 3. Preserve `node_modules/` if it's a real directory. Track the
-    //    move so steps 4 and 5 can rescue it on failure.
+    // 4. Preserve `node_modules/` if it's a real directory. Track the
+    //    move so steps 5 and 6 can rescue it on failure.
     //
     //    Indexed file maps for npm tarballs never contain
     //    `node_modules/` entries (npm and pnpm strip them at pack
@@ -396,26 +581,7 @@ fn stage_and_swap<Reporter: self::Reporter>(
         Some(_) | None => false,
     };
 
-    // 3b. Never remove a content-addressed target another importer may be populating or reading:
-    //     keep it when it is complete, and otherwise repair it in place, which is non-destructive
-    //     and converges because the path identifies the contents. When step 3 moved
-    //     `node_modules/`, continue with the swap so that it can be restored.
-    if safe_to_skip && !nm_moved {
-        match fs::rename(&stage, dir_path) {
-            Ok(()) => return Ok(()),
-            Err(error) if is_occupied_target(&error) => {
-                let _ = fs::remove_dir_all(&stage);
-                return if is_complete_import(dir_path, cas_paths) {
-                    Ok(())
-                } else {
-                    populate_dir::<Reporter>(logged_methods, import_method, dir_path, cas_paths)
-                };
-            }
-            Err(_) => {}
-        }
-    }
-
-    // 4. Remove the old contents. If this fails after step 3, the
+    // 5. Remove the old contents. If this fails after step 4, the
     //    staged copy of `node_modules/` is the user's only copy —
     //    try to move it back into place before bailing, and leak
     //    the staging directory if the move can't run.
@@ -424,11 +590,11 @@ fn stage_and_swap<Reporter: self::Reporter>(
         return Err(ImportIndexedDirError::RemoveExisting { path: dir_path.to_path_buf(), error });
     }
 
-    // 5. Move the staged tree into place. There's a brief window
+    // 6. Move the staged tree into place. There's a brief window
     //    between `remove_dir_all` and `rename` where `dir_path` does
-    //    not exist on disk — acceptable given pacquet runs one
-    //    install per process and the hoisted linker holds the install
-    //    graph's coarse lock. If the rename fails, recreate
+    //    not exist on disk — acceptable for a slot only this install
+    //    can reach, which is why a shared one returns at step 2. If
+    //    the rename fails, recreate
     //    `dir_path` so the rescued `node_modules/` has somewhere to
     //    land.
     if let Err(error) = fs::rename(&stage, dir_path) {
@@ -446,7 +612,7 @@ fn stage_and_swap<Reporter: self::Reporter>(
     Ok(())
 }
 
-/// Combined post-failure cleanup for steps 4 and 5: restore the
+/// Combined post-failure cleanup for steps 5 and 6: restore the
 /// preserved `node_modules/` if it was moved, then rimraf the
 /// staging directory — but only if the restore actually ran.
 /// Leaving the staging directory on disk after a failed restore is

--- a/pnpm/crates/deps-restorer/src/import_indexed_dir.rs
+++ b/pnpm/crates/deps-restorer/src/import_indexed_dir.rs
@@ -488,9 +488,14 @@ fn all_files_match(dir_path: &Path, cas_paths: &HashMap<String, PathBuf>) -> boo
 /// read; the copy tier falls back to comparing size and then bytes, the
 /// way pnpm's `allFilesMatch` does.
 fn file_matches_store_entry(target: &Path, store_path: &Path) -> bool {
-    let (Ok(target_meta), Ok(store_meta)) = (fs::metadata(target), fs::metadata(store_path)) else {
+    let (Ok(target_meta), Ok(store_meta)) =
+        (fs::symlink_metadata(target), fs::metadata(store_path))
+    else {
         return false;
     };
+    if !target_meta.is_file() {
+        return false;
+    }
     // Unix carries the file's identity in the stat results already.
     // Windows keeps it behind an open handle, which `same-file` opens —
     // worth two handles to spare a hardlinked package a full read on the

--- a/pnpm/crates/deps-restorer/src/import_indexed_dir.rs
+++ b/pnpm/crates/deps-restorer/src/import_indexed_dir.rs
@@ -120,6 +120,14 @@ enum Placement {
     Repair,
 }
 
+impl Placement {
+    /// How much an import into an occupied target may assume about what
+    /// is already there, given whether the target is shared.
+    fn for_target(safe_to_skip: bool) -> Self {
+        if safe_to_skip { Placement::Repair } else { Placement::Fresh }
+    }
+}
+
 /// Materialize an indexed package's files into `dir_path`, the way
 /// pnpm v11's `importIndexedDir` does at
 /// `fs/indexed-pkg-importer/src/importIndexedDir.ts`. The same function
@@ -160,6 +168,14 @@ pub fn import_indexed_dir<Reporter: self::Reporter>(
     // per-install `xattr` cost — exactly pnpm's `!pkgExistsAtTargetDir` gate.
     let unquarantine = || remove_quarantine_from_native_binaries(dir_path, cas_paths);
     match (existing_kind, opts.force) {
+        // An absent shared target says nothing: another importer can create it
+        // between the stat above and the first file written below, and then two
+        // importers are populating one directory each believing it owns it.
+        // Ownership is settled by an exclusive `mkdir` instead.
+        (None, _) if opts.safe_to_skip => {
+            import_into_shared_dir::<Reporter>(logged_methods, import_method, dir_path, cas_paths)
+                .inspect(|()| unquarantine())
+        }
         (None, _) => populate_dir::<Reporter>(
             logged_methods,
             import_method,
@@ -172,10 +188,13 @@ pub fn import_indexed_dir<Reporter: self::Reporter>(
         // (pnpm's `pkgExistsAtTargetDir`, which checks `package.json`),
         // not on mere directory existence. A marker-less directory is a
         // partial import; repair it by re-running the non-destructive
-        // `populate_dir`. Ported from pnpm/pnpm#12204 (cbfeeef328), whose
-        // repair adopts an existing dirent rather than replacing it —
-        // pnpm's own fast path does, and a private slot has no second
-        // importer racing this one.
+        // `populate_dir`. Ported from pnpm/pnpm#12204 (cbfeeef328).
+        //
+        // Whose partial import it is decides how much the repair may
+        // assume: a private target holds this install's own interrupted
+        // work, so an existing dirent is this package's file and is
+        // adopted, while a shared one may hold a file an importer died
+        // halfway through writing, which only a replacement heals.
         (Some(file_type), false) if file_type.is_dir() => {
             if marker_present(dir_path, cas_paths) {
                 Ok(())
@@ -185,7 +204,7 @@ pub fn import_indexed_dir<Reporter: self::Reporter>(
                     import_method,
                     dir_path,
                     cas_paths,
-                    Placement::Fresh,
+                    Placement::for_target(opts.safe_to_skip),
                 )
                 .inspect(|()| unquarantine())
             }
@@ -217,6 +236,52 @@ pub fn import_indexed_dir<Reporter: self::Reporter>(
             opts.safe_to_skip,
         )
         .inspect(|()| unquarantine()),
+    }
+}
+
+/// Import into a target whose path is shared with the installs running
+/// in other projects, without ever removing anything from it.
+///
+/// The importer that creates the directory populates it; the others heal
+/// what is there, because a slot that exists is either finished, being
+/// filled right now, or left behind by an importer that died mid-file —
+/// and the three are indistinguishable from the outside.
+fn import_into_shared_dir<Reporter: self::Reporter>(
+    logged_methods: &AtomicU8,
+    import_method: PackageImportMethod,
+    dir_path: &Path,
+    cas_paths: &HashMap<String, PathBuf>,
+) -> Result<(), ImportIndexedDirError> {
+    if claim_dir(dir_path)? {
+        return populate_dir::<Reporter>(
+            logged_methods,
+            import_method,
+            dir_path,
+            cas_paths,
+            Placement::Fresh,
+        );
+    }
+    if all_files_match(dir_path, cas_paths) {
+        return Ok(());
+    }
+    populate_dir::<Reporter>(logged_methods, import_method, dir_path, cas_paths, Placement::Repair)
+}
+
+/// Create `dir_path`, reporting whether this call is the one that created
+/// it. `create_dir_all` cannot answer that — it succeeds either way.
+fn claim_dir(dir_path: &Path) -> Result<bool, ImportIndexedDirError> {
+    if let Some(parent) = dir_path.parent() {
+        fs::create_dir_all(parent).map_err(|error| ImportIndexedDirError::CreateDir {
+            dirname: parent.to_path_buf(),
+            error,
+        })?;
+    }
+    match fs::create_dir(dir_path) {
+        Ok(()) => Ok(true),
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => Ok(false),
+        Err(error) => {
+            Err(ImportIndexedDirError::CreateDir { dirname: dir_path.to_path_buf(), error })
+        }
     }
 }
 
@@ -419,22 +484,40 @@ fn is_occupied_target(error: &io::Error, dir_path: &Path) -> bool {
 /// after the import finished still exists, and treating that slot as
 /// done would leave it broken for every later install. The needs-build
 /// marker is transient and does not identify package contents.
+///
+/// The marker is checked first, and `cas_paths` iterates in no
+/// particular order: a slot another importer is still filling is the
+/// common case here, and one `stat` settles it without comparing the
+/// files that did land.
 fn all_files_match(dir_path: &Path, cas_paths: &HashMap<String, PathBuf>) -> bool {
-    cas_paths
-        .iter()
-        .filter(|(entry, _)| entry.as_str() != crate::NEEDS_BUILD_MARKER)
-        .all(|(entry, store_path)| file_matches_store_entry(&dir_path.join(entry), store_path))
+    marker_present(dir_path, cas_paths)
+        && cas_paths
+            .iter()
+            .filter(|(entry, _)| entry.as_str() != crate::NEEDS_BUILD_MARKER)
+            .all(|(entry, store_path)| file_matches_store_entry(&dir_path.join(entry), store_path))
 }
 
 /// Whether `target` already carries `store_path`'s content. Imports that
-/// hardlink or reflink share the store inode, which settles it without a
+/// hardlink or reflink share the store file, which settles it without a
 /// read; the copy tier falls back to comparing size and then bytes, the
 /// way pnpm's `allFilesMatch` does.
 fn file_matches_store_entry(target: &Path, store_path: &Path) -> bool {
     let (Ok(target_meta), Ok(store_meta)) = (fs::metadata(target), fs::metadata(store_path)) else {
         return false;
     };
-    if is_same_file(&target_meta, &store_meta) {
+    // Unix carries the file's identity in the stat results already.
+    // Windows keeps it behind an open handle, which `same-file` opens —
+    // worth two handles to spare a hardlinked package a full read on the
+    // platform where hardlinking is the default tier.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        if target_meta.ino() == store_meta.ino() && target_meta.dev() == store_meta.dev() {
+            return true;
+        }
+    }
+    #[cfg(windows)]
+    if same_file::is_same_file(target, store_path).unwrap_or(false) {
         return true;
     }
     target_meta.len() == store_meta.len()
@@ -471,19 +554,6 @@ fn files_have_equal_contents(left: &Path, right: &Path) -> io::Result<bool> {
         left.consume(len);
         right.consume(len);
     }
-}
-
-/// Whether two stat results name one inode. Windows exposes a file index
-/// only through an open handle, so it always compares content there.
-#[cfg(unix)]
-fn is_same_file(left: &fs::Metadata, right: &fs::Metadata) -> bool {
-    use std::os::unix::fs::MetadataExt;
-    left.ino() == right.ino() && left.dev() == right.dev()
-}
-
-#[cfg(not(unix))]
-fn is_same_file(_left: &fs::Metadata, _right: &fs::Metadata) -> bool {
-    false
 }
 
 /// Whether `dir_path` holds the completion marker. An empty map has no

--- a/pnpm/crates/deps-restorer/src/import_indexed_dir/tests.rs
+++ b/pnpm/crates/deps-restorer/src/import_indexed_dir/tests.rs
@@ -771,6 +771,39 @@ fn safe_to_skip_still_repairs_an_incomplete_target() {
     assert_eq!(fs::read(target.join("index.js")).unwrap(), b"module.exports = 1");
 }
 
+// An incomplete slot is as often an importer mid-flight as an interrupted one, and swapping a
+// fresh directory over it would remove the files that importer is still writing.
+#[cfg(unix)]
+#[test]
+fn safe_to_skip_repairs_an_incomplete_target_without_replacing_it() {
+    use std::os::unix::fs::MetadataExt;
+
+    let tmp = tempdir().unwrap();
+    let src_root = tmp.path().join("cas");
+    fs::create_dir_all(&src_root).unwrap();
+    let pkg_json = write_source(&src_root, "package.json", b"{\"version\":\"1.0.0\"}");
+    let index = write_source(&src_root, "index.js", b"module.exports = 1");
+    let cas = cas_map(&[("package.json", pkg_json), ("index.js", index)]);
+
+    let target = tmp.path().join("slot");
+    fs::create_dir_all(&target).unwrap();
+    fs::write(target.join("index.js"), b"module.exports = 1").unwrap();
+    let occupied = fs::metadata(&target).unwrap().ino();
+
+    import_indexed_dir::<SilentReporter>(
+        &AtomicU8::new(0),
+        PackageImportMethod::Copy,
+        &target,
+        &cas,
+        FORCE_SHARED,
+    )
+    .expect("an incomplete slot must be repaired");
+
+    assert_eq!(fs::metadata(&target).unwrap().ino(), occupied);
+    assert_eq!(fs::read(target.join("package.json")).unwrap(), b"{\"version\":\"1.0.0\"}");
+    assert_eq!(fs::read(target.join("index.js")).unwrap(), b"module.exports = 1");
+}
+
 // Windows needs retry handling while a competing importer holds file handles.
 #[cfg(unix)]
 #[test]

--- a/pnpm/crates/deps-restorer/src/import_indexed_dir/tests.rs
+++ b/pnpm/crates/deps-restorer/src/import_indexed_dir/tests.rs
@@ -1,4 +1,4 @@
-use super::{ImportIndexedDirError, ImportIndexedDirOpts, import_indexed_dir};
+use super::{ImportIndexedDirError, ImportIndexedDirOpts, import_indexed_dir, is_occupied_target};
 use pacquet_config::PackageImportMethod;
 use pacquet_reporter::SilentReporter;
 use pretty_assertions::assert_eq;
@@ -807,6 +807,37 @@ fn safe_to_skip_repairs_an_incomplete_target_without_replacing_it() {
     assert_eq!(fs::read(target.join("index.js")).unwrap(), b"module.exports = 1");
 }
 
+// The classifier decides whether a failed swap adopts the target or gives up on it, and giving
+// up is the only safe answer for an error that says nothing about the target: the alternative
+// used to be a fall-through to `remove_dir_all`, which deletes a slot another importer holds.
+// A Windows sharing violation arrives as `ResourceBusy` and would have taken exactly that path.
+#[test]
+fn only_a_present_directory_counts_as_an_occupied_target() {
+    use std::io::{Error, ErrorKind};
+
+    let tmp = tempdir().unwrap();
+    let slot = tmp.path().join("slot");
+    fs::create_dir_all(&slot).unwrap();
+    let file = tmp.path().join("file");
+    fs::write(&file, b"not a slot").unwrap();
+    let missing = tmp.path().join("missing");
+
+    for kind in [
+        ErrorKind::DirectoryNotEmpty,
+        ErrorKind::AlreadyExists,
+        ErrorKind::PermissionDenied,
+        ErrorKind::ResourceBusy,
+    ] {
+        assert!(is_occupied_target(&Error::from(kind), &slot), "{kind:?} over a directory");
+        assert!(!is_occupied_target(&Error::from(kind), &missing), "{kind:?} over nothing");
+        assert!(!is_occupied_target(&Error::from(kind), &file), "{kind:?} over a file");
+    }
+
+    for kind in [ErrorKind::NotADirectory, ErrorKind::CrossesDevices, ErrorKind::Other] {
+        assert!(!is_occupied_target(&Error::from(kind), &slot), "{kind:?} is not conclusive");
+    }
+}
+
 // `fs::copy` overwrites, so only a linking tier can adopt a damaged file and keep it.
 #[test]
 fn safe_to_skip_replaces_a_damaged_file_the_linking_tiers_would_adopt() {
@@ -864,6 +895,38 @@ fn safe_to_skip_repairs_a_slot_damaged_after_it_was_completed() {
     .expect("a damaged slot must be repaired");
 
     assert_eq!(fs::read(target.join("index.js")).unwrap(), b"module.exports = 1");
+}
+
+// Same size, same leading bytes, damaged near the end: the compare has to run past its first
+// buffer to see it. The copy tier is the one that reads, since it shares no inode with the store.
+#[test]
+fn safe_to_skip_repairs_a_file_that_only_differs_past_the_first_read() {
+    let tmp = tempdir().unwrap();
+    let src_root = tmp.path().join("cas");
+    fs::create_dir_all(&src_root).unwrap();
+    let mut whole = vec![b'a'; 40 * 1024];
+    let pkg_json = write_source(&src_root, "package.json", b"{\"version\":\"1.0.0\"}");
+    let bundle = write_source(&src_root, "bundle.js", &whole);
+    let cas = cas_map(&[("package.json", pkg_json), ("bundle.js", bundle)]);
+
+    let target = tmp.path().join("slot");
+    fs::create_dir_all(&target).unwrap();
+    fs::write(target.join("package.json"), b"{\"version\":\"1.0.0\"}").unwrap();
+    let last = whole.len() - 1;
+    whole[last] = b'z';
+    fs::write(target.join("bundle.js"), &whole).unwrap();
+
+    import_indexed_dir::<SilentReporter>(
+        &AtomicU8::new(0),
+        PackageImportMethod::Copy,
+        &target,
+        &cas,
+        FORCE_SHARED,
+    )
+    .expect("a damaged slot must be repaired");
+
+    whole[last] = b'a';
+    assert_eq!(fs::read(target.join("bundle.js")).unwrap(), whole);
 }
 
 #[test]

--- a/pnpm/crates/deps-restorer/src/import_indexed_dir/tests.rs
+++ b/pnpm/crates/deps-restorer/src/import_indexed_dir/tests.rs
@@ -1,4 +1,6 @@
-use super::{ImportIndexedDirError, ImportIndexedDirOpts, import_indexed_dir, is_occupied_target};
+use super::{
+    ImportIndexedDirError, ImportIndexedDirOpts, claim_dir, import_indexed_dir, is_occupied_target,
+};
 use pacquet_config::PackageImportMethod;
 use pacquet_reporter::SilentReporter;
 use pretty_assertions::assert_eq;
@@ -29,6 +31,10 @@ const FORCE_ONLY: ImportIndexedDirOpts =
     ImportIndexedDirOpts { force: true, keep_modules_dir: false, safe_to_skip: false };
 const FORCE_SHARED: ImportIndexedDirOpts =
     ImportIndexedDirOpts { force: true, keep_modules_dir: false, safe_to_skip: true };
+// The shape the isolated linker uses for a shared slot: no force, since a warm slot is
+// short-circuited by its marker before the import runs.
+const SHARED: ImportIndexedDirOpts =
+    ImportIndexedDirOpts { force: false, keep_modules_dir: false, safe_to_skip: true };
 // The shape the isolated linker uses for a shared slot whose build was interrupted.
 const FORCE_SHARED_KEEP: ImportIndexedDirOpts =
     ImportIndexedDirOpts { force: true, keep_modules_dir: true, safe_to_skip: true };
@@ -1012,6 +1018,94 @@ fn safe_to_skip_repairs_a_slot_holding_a_nested_node_modules_in_place() {
     assert_eq!(fs::metadata(&target).unwrap().ino(), occupied);
     assert_eq!(fs::read(bundled.join("index.js")).unwrap(), b"bundled dependency");
     assert_eq!(fs::read(target.join("index.js")).unwrap(), b"module.exports = 1");
+    assert_eq!(fs::read(target.join("package.json")).unwrap(), b"{\"version\":\"1.0.0\"}");
+}
+
+// Both stacks let the exclusive mkdir, not the earlier stat, decide who imports a shared slot.
+#[test]
+fn claim_dir_reports_only_the_creating_call() {
+    let tmp = tempdir().unwrap();
+    let slot = tmp.path().join("nested").join("slot");
+
+    assert!(claim_dir(&slot).unwrap(), "the call that creates the slot owns it");
+    assert!(!claim_dir(&slot).unwrap(), "a later call finds it taken");
+}
+
+#[test]
+fn safe_to_skip_imports_into_an_absent_shared_slot() {
+    let tmp = tempdir().unwrap();
+    let src_root = tmp.path().join("cas");
+    fs::create_dir_all(&src_root).unwrap();
+    let pkg_json = write_source(&src_root, "package.json", b"{\"version\":\"1.0.0\"}");
+    let index = write_source(&src_root, "index.js", b"module.exports = 1");
+    let cas = cas_map(&[("package.json", pkg_json), ("lib/index.js", index)]);
+
+    let target = tmp.path().join("nested").join("slot");
+    import_indexed_dir::<SilentReporter>(
+        &AtomicU8::new(0),
+        PackageImportMethod::Hardlink,
+        &target,
+        &cas,
+        SHARED,
+    )
+    .expect("an absent shared slot must be created and filled");
+
+    assert_eq!(fs::read(target.join("package.json")).unwrap(), b"{\"version\":\"1.0.0\"}");
+    assert_eq!(fs::read(target.join("lib/index.js")).unwrap(), b"module.exports = 1");
+}
+
+// The isolated linker imports without `force`, so the marker-less repair is where a shared slot
+// left half-written by an importer that died is met on the next install.
+#[test]
+fn shared_slot_repair_without_force_replaces_a_damaged_file() {
+    let tmp = tempdir().unwrap();
+    let src_root = tmp.path().join("cas");
+    fs::create_dir_all(&src_root).unwrap();
+    let pkg_json = write_source(&src_root, "package.json", b"{\"version\":\"1.0.0\"}");
+    let index = write_source(&src_root, "index.js", b"module.exports = 1");
+    let cas = cas_map(&[("package.json", pkg_json), ("index.js", index)]);
+
+    let target = tmp.path().join("slot");
+    fs::create_dir_all(&target).unwrap();
+    fs::write(target.join("index.js"), b"half-written").unwrap();
+
+    import_indexed_dir::<SilentReporter>(
+        &AtomicU8::new(0),
+        PackageImportMethod::Hardlink,
+        &target,
+        &cas,
+        SHARED,
+    )
+    .expect("a marker-less shared slot must be repaired");
+
+    assert_eq!(fs::read(target.join("index.js")).unwrap(), b"module.exports = 1");
+    assert_eq!(fs::read(target.join("package.json")).unwrap(), b"{\"version\":\"1.0.0\"}");
+}
+
+// A private slot holds only this install's own interrupted work, so its repair keeps adopting.
+#[test]
+fn private_slot_repair_without_force_adopts_what_is_there() {
+    let tmp = tempdir().unwrap();
+    let src_root = tmp.path().join("cas");
+    fs::create_dir_all(&src_root).unwrap();
+    let pkg_json = write_source(&src_root, "package.json", b"{\"version\":\"1.0.0\"}");
+    let index = write_source(&src_root, "index.js", b"module.exports = 1");
+    let cas = cas_map(&[("package.json", pkg_json), ("index.js", index)]);
+
+    let target = tmp.path().join("slot");
+    fs::create_dir_all(&target).unwrap();
+    fs::write(target.join("index.js"), b"half-written").unwrap();
+
+    import_indexed_dir::<SilentReporter>(
+        &AtomicU8::new(0),
+        PackageImportMethod::Hardlink,
+        &target,
+        &cas,
+        ImportIndexedDirOpts::default(),
+    )
+    .expect("a marker-less private slot must be repaired");
+
+    assert_eq!(fs::read(target.join("index.js")).unwrap(), b"half-written");
     assert_eq!(fs::read(target.join("package.json")).unwrap(), b"{\"version\":\"1.0.0\"}");
 }
 

--- a/pnpm/crates/deps-restorer/src/import_indexed_dir/tests.rs
+++ b/pnpm/crates/deps-restorer/src/import_indexed_dir/tests.rs
@@ -848,6 +848,36 @@ fn safe_to_skip_replaces_a_damaged_file_the_linking_tiers_would_adopt() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn safe_to_skip_replaces_a_symlink_to_matching_store_content() {
+    use std::os::unix::fs::symlink;
+
+    let tmp = tempdir().unwrap();
+    let src_root = tmp.path().join("cas");
+    fs::create_dir_all(&src_root).unwrap();
+    let pkg_json = write_source(&src_root, "package.json", b"{\"version\":\"1.0.0\"}");
+    let index = write_source(&src_root, "index.js", b"module.exports = 1");
+    let cas = cas_map(&[("package.json", pkg_json), ("index.js", index.clone())]);
+
+    let target = tmp.path().join("slot");
+    fs::create_dir_all(&target).unwrap();
+    fs::write(target.join("package.json"), b"{\"version\":\"1.0.0\"}").unwrap();
+    symlink(&index, target.join("index.js")).unwrap();
+
+    import_indexed_dir::<SilentReporter>(
+        &AtomicU8::new(0),
+        PackageImportMethod::Hardlink,
+        &target,
+        &cas,
+        FORCE_SHARED,
+    )
+    .expect("a shared slot must not adopt a symlink to store content");
+
+    assert!(!fs::symlink_metadata(target.join("index.js")).unwrap().file_type().is_symlink());
+    assert_eq!(fs::read(target.join("index.js")).unwrap(), b"module.exports = 1");
+}
+
 // The marker says nothing about the files placed before it: a slot damaged after its import
 // finished carries a complete-looking tree, and existence checks would call it done forever.
 #[test]

--- a/pnpm/crates/deps-restorer/src/import_indexed_dir/tests.rs
+++ b/pnpm/crates/deps-restorer/src/import_indexed_dir/tests.rs
@@ -29,6 +29,9 @@ const FORCE_ONLY: ImportIndexedDirOpts =
     ImportIndexedDirOpts { force: true, keep_modules_dir: false, safe_to_skip: false };
 const FORCE_SHARED: ImportIndexedDirOpts =
     ImportIndexedDirOpts { force: true, keep_modules_dir: false, safe_to_skip: true };
+// The shape the isolated linker uses for a shared slot whose build was interrupted.
+const FORCE_SHARED_KEEP: ImportIndexedDirOpts =
+    ImportIndexedDirOpts { force: true, keep_modules_dir: true, safe_to_skip: true };
 
 #[test]
 fn fresh_target_links_files() {
@@ -802,6 +805,151 @@ fn safe_to_skip_repairs_an_incomplete_target_without_replacing_it() {
     assert_eq!(fs::metadata(&target).unwrap().ino(), occupied);
     assert_eq!(fs::read(target.join("package.json")).unwrap(), b"{\"version\":\"1.0.0\"}");
     assert_eq!(fs::read(target.join("index.js")).unwrap(), b"module.exports = 1");
+}
+
+// `fs::copy` overwrites, so only a linking tier can adopt a damaged file and keep it.
+#[test]
+fn safe_to_skip_replaces_a_damaged_file_the_linking_tiers_would_adopt() {
+    let tmp = tempdir().unwrap();
+    let src_root = tmp.path().join("cas");
+    fs::create_dir_all(&src_root).unwrap();
+    let pkg_json = write_source(&src_root, "package.json", b"{\"version\":\"1.0.0\"}");
+    let index = write_source(&src_root, "index.js", b"module.exports = 1");
+    let cas = cas_map(&[("package.json", pkg_json), ("index.js", index)]);
+
+    let target = tmp.path().join("slot");
+    fs::create_dir_all(&target).unwrap();
+    fs::write(target.join("index.js"), b"half-written").unwrap();
+    fs::write(target.join("build.node"), b"output of an interrupted build").unwrap();
+
+    import_indexed_dir::<SilentReporter>(
+        &AtomicU8::new(0),
+        PackageImportMethod::Hardlink,
+        &target,
+        &cas,
+        FORCE_SHARED,
+    )
+    .expect("an unfinished slot must be completed, not accepted");
+
+    assert_eq!(fs::read(target.join("index.js")).unwrap(), b"module.exports = 1");
+    assert!(
+        target.join("build.node").exists(),
+        "a file the package does not declare is not ours to remove from a shared slot",
+    );
+}
+
+// The marker says nothing about the files placed before it: a slot damaged after its import
+// finished carries a complete-looking tree, and existence checks would call it done forever.
+#[test]
+fn safe_to_skip_repairs_a_slot_damaged_after_it_was_completed() {
+    let tmp = tempdir().unwrap();
+    let src_root = tmp.path().join("cas");
+    fs::create_dir_all(&src_root).unwrap();
+    let pkg_json = write_source(&src_root, "package.json", b"{\"version\":\"1.0.0\"}");
+    let index = write_source(&src_root, "index.js", b"module.exports = 1");
+    let cas = cas_map(&[("package.json", pkg_json), ("index.js", index)]);
+
+    let target = tmp.path().join("slot");
+    fs::create_dir_all(&target).unwrap();
+    fs::write(target.join("package.json"), b"{\"version\":\"1.0.0\"}").unwrap();
+    fs::write(target.join("index.js"), b"corrupted after the import").unwrap();
+
+    import_indexed_dir::<SilentReporter>(
+        &AtomicU8::new(0),
+        PackageImportMethod::Hardlink,
+        &target,
+        &cas,
+        FORCE_SHARED,
+    )
+    .expect("a damaged slot must be repaired");
+
+    assert_eq!(fs::read(target.join("index.js")).unwrap(), b"module.exports = 1");
+}
+
+#[test]
+fn safe_to_skip_clears_a_file_where_the_package_needs_a_directory() {
+    let tmp = tempdir().unwrap();
+    let src_root = tmp.path().join("cas");
+    fs::create_dir_all(&src_root).unwrap();
+    let pkg_json = write_source(&src_root, "package.json", b"{\"version\":\"1.0.0\"}");
+    let index = write_source(&src_root, "index.js", b"module.exports = 1");
+    let cas = cas_map(&[("package.json", pkg_json), ("lib/nested/index.js", index)]);
+
+    let target = tmp.path().join("slot");
+    fs::create_dir_all(&target).unwrap();
+    fs::write(target.join("lib"), b"a file where a directory belongs").unwrap();
+
+    import_indexed_dir::<SilentReporter>(
+        &AtomicU8::new(0),
+        PackageImportMethod::Hardlink,
+        &target,
+        &cas,
+        FORCE_SHARED,
+    )
+    .expect("a dirent of the wrong kind must not wedge the install");
+
+    assert_eq!(fs::read(target.join("lib/nested/index.js")).unwrap(), b"module.exports = 1");
+}
+
+#[test]
+fn safe_to_skip_clears_a_directory_where_the_package_needs_a_file() {
+    let tmp = tempdir().unwrap();
+    let src_root = tmp.path().join("cas");
+    fs::create_dir_all(&src_root).unwrap();
+    let pkg_json = write_source(&src_root, "package.json", b"{\"version\":\"1.0.0\"}");
+    let index = write_source(&src_root, "index.js", b"module.exports = 1");
+    let cas = cas_map(&[("package.json", pkg_json), ("index.js", index)]);
+
+    let target = tmp.path().join("slot");
+    fs::create_dir_all(target.join("index.js")).unwrap();
+    fs::write(target.join("index.js").join("stray"), b"leftover").unwrap();
+
+    import_indexed_dir::<SilentReporter>(
+        &AtomicU8::new(0),
+        PackageImportMethod::Hardlink,
+        &target,
+        &cas,
+        FORCE_SHARED,
+    )
+    .expect("a dirent of the wrong kind must not wedge the install");
+
+    assert_eq!(fs::read(target.join("index.js")).unwrap(), b"module.exports = 1");
+}
+
+// A package with bundled dependencies ships its own node_modules/, and the interrupted-build
+// call shape asks for it to be preserved. Repairing in place preserves it by never removing
+// anything, so the slot must not take the staging swap that a shared slot is not allowed to run.
+#[cfg(unix)]
+#[test]
+fn safe_to_skip_repairs_a_slot_holding_a_nested_node_modules_in_place() {
+    use std::os::unix::fs::MetadataExt;
+
+    let tmp = tempdir().unwrap();
+    let src_root = tmp.path().join("cas");
+    fs::create_dir_all(&src_root).unwrap();
+    let pkg_json = write_source(&src_root, "package.json", b"{\"version\":\"1.0.0\"}");
+    let index = write_source(&src_root, "index.js", b"module.exports = 1");
+    let cas = cas_map(&[("package.json", pkg_json), ("index.js", index)]);
+
+    let target = tmp.path().join("slot");
+    let bundled = target.join("node_modules").join("bundled");
+    fs::create_dir_all(&bundled).unwrap();
+    fs::write(bundled.join("index.js"), b"bundled dependency").unwrap();
+    let occupied = fs::metadata(&target).unwrap().ino();
+
+    import_indexed_dir::<SilentReporter>(
+        &AtomicU8::new(0),
+        PackageImportMethod::Hardlink,
+        &target,
+        &cas,
+        FORCE_SHARED_KEEP,
+    )
+    .expect("an incomplete slot must be repaired");
+
+    assert_eq!(fs::metadata(&target).unwrap().ino(), occupied);
+    assert_eq!(fs::read(bundled.join("index.js")).unwrap(), b"bundled dependency");
+    assert_eq!(fs::read(target.join("index.js")).unwrap(), b"module.exports = 1");
+    assert_eq!(fs::read(target.join("package.json")).unwrap(), b"{\"version\":\"1.0.0\"}");
 }
 
 // Windows needs retry handling while a competing importer holds file handles.

--- a/pnpm/crates/deps-restorer/src/import_indexed_dir/tests.rs
+++ b/pnpm/crates/deps-restorer/src/import_indexed_dir/tests.rs
@@ -1,6 +1,4 @@
-use super::{
-    ImportIndexedDirError, ImportIndexedDirOpts, claim_dir, import_indexed_dir, is_occupied_target,
-};
+use super::{ImportIndexedDirError, ImportIndexedDirOpts, claim_dir, import_indexed_dir};
 use pacquet_config::PackageImportMethod;
 use pacquet_reporter::SilentReporter;
 use pretty_assertions::assert_eq;
@@ -705,8 +703,9 @@ fn safe_to_skip_keeps_a_target_a_concurrent_importer_already_completed() {
     fs::write(target.join("package.json"), b"{\"version\":\"1.0.0\"}").unwrap();
     fs::write(target.join("index.js"), b"module.exports = 1").unwrap();
 
+    let logged_methods = AtomicU8::new(0);
     import_indexed_dir::<SilentReporter>(
-        &AtomicU8::new(0),
+        &logged_methods,
         PackageImportMethod::Copy,
         &target,
         &cas,
@@ -716,6 +715,11 @@ fn safe_to_skip_keeps_a_target_a_concurrent_importer_already_completed() {
 
     assert_eq!(fs::read(target.join("package.json")).unwrap(), b"{\"version\":\"1.0.0\"}");
     assert_eq!(fs::read(target.join("index.js")).unwrap(), b"module.exports = 1");
+    assert_eq!(
+        logged_methods.load(std::sync::atomic::Ordering::Relaxed),
+        0,
+        "an already matching shared slot must not be imported into a throwaway stage",
+    );
     let strays: Vec<_> = fs::read_dir(tmp.path())
         .unwrap()
         .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
@@ -811,37 +815,6 @@ fn safe_to_skip_repairs_an_incomplete_target_without_replacing_it() {
     assert_eq!(fs::metadata(&target).unwrap().ino(), occupied);
     assert_eq!(fs::read(target.join("package.json")).unwrap(), b"{\"version\":\"1.0.0\"}");
     assert_eq!(fs::read(target.join("index.js")).unwrap(), b"module.exports = 1");
-}
-
-// The classifier decides whether a failed swap adopts the target or gives up on it, and giving
-// up is the only safe answer for an error that says nothing about the target: the alternative
-// used to be a fall-through to `remove_dir_all`, which deletes a slot another importer holds.
-// A Windows sharing violation arrives as `ResourceBusy` and would have taken exactly that path.
-#[test]
-fn only_a_present_directory_counts_as_an_occupied_target() {
-    use std::io::{Error, ErrorKind};
-
-    let tmp = tempdir().unwrap();
-    let slot = tmp.path().join("slot");
-    fs::create_dir_all(&slot).unwrap();
-    let file = tmp.path().join("file");
-    fs::write(&file, b"not a slot").unwrap();
-    let missing = tmp.path().join("missing");
-
-    for kind in [
-        ErrorKind::DirectoryNotEmpty,
-        ErrorKind::AlreadyExists,
-        ErrorKind::PermissionDenied,
-        ErrorKind::ResourceBusy,
-    ] {
-        assert!(is_occupied_target(&Error::from(kind), &slot), "{kind:?} over a directory");
-        assert!(!is_occupied_target(&Error::from(kind), &missing), "{kind:?} over nothing");
-        assert!(!is_occupied_target(&Error::from(kind), &file), "{kind:?} over a file");
-    }
-
-    for kind in [ErrorKind::NotADirectory, ErrorKind::CrossesDevices, ErrorKind::Other] {
-        assert!(!is_occupied_target(&Error::from(kind), &slot), "{kind:?} is not conclusive");
-    }
 }
 
 // `fs::copy` overwrites, so only a linking tier can adopt a damaged file and keep it.
@@ -1109,8 +1082,6 @@ fn private_slot_repair_without_force_adopts_what_is_there() {
     assert_eq!(fs::read(target.join("package.json")).unwrap(), b"{\"version\":\"1.0.0\"}");
 }
 
-// Windows needs retry handling while a competing importer holds file handles.
-#[cfg(unix)]
 #[test]
 fn concurrent_importers_of_one_shared_slot_both_succeed() {
     use std::sync::{Arc, Barrier};

--- a/pnpm/crates/fs/src/ensure_file.rs
+++ b/pnpm/crates/fs/src/ensure_file.rs
@@ -466,7 +466,7 @@ const RENAME_RETRY_BACKOFF_CAP: Duration = Duration::from_millis(100);
 /// (`link_file` → `fs::hard_link` / `reflink_copy`) don't keep file
 /// handles on the target, so there's no "parallel reader sees a gap"
 /// concern that would motivate swap-rename.
-fn rename_with_retry(src: &Path, dst: &Path) -> io::Result<()> {
+pub fn rename_with_retry(src: &Path, dst: &Path) -> io::Result<()> {
     let mut backoff = Duration::ZERO;
     let start = Instant::now();
 

--- a/pnpm11/fs/indexed-pkg-importer/src/importIndexedDir.ts
+++ b/pnpm11/fs/indexed-pkg-importer/src/importIndexedDir.ts
@@ -13,6 +13,9 @@ import { renameOverwriteSync } from 'rename-overwrite'
 import sanitizeFilename from 'sanitize-filename'
 
 const filenameConflictsLogger = logger('_filename-conflicts')
+const RENAME_RETRY_BUDGET_MS = 60_000
+const RENAME_RETRY_BACKOFF_CAP_MS = 100
+const renameRetrySleepBuffer = new Int32Array(new SharedArrayBuffer(4))
 
 export type ImportFile = (src: string, dest: string) => void
 
@@ -177,8 +180,40 @@ function replaceFileIfDifferent (importFile: ImportFile, src: string, dest: stri
     } catch {} // eslint-disable-line:no-empty
     throw err
   }
-  clearDirBlockingFile(dest)
-  renameOverwriteSync(tmp, dest)
+  try {
+    clearDirBlockingFile(dest)
+    renameFileWithRetry(tmp, dest)
+  } catch (err) {
+    try {
+      fs.unlinkSync(tmp)
+    } catch {} // eslint-disable-line:no-empty
+    if (mismatchReason(dest, src) === undefined) return
+    throw err
+  }
+}
+
+// Retry a Windows sharing violation without rename-overwrite's fallback of
+// deleting the destination. Another install may still be reading that dirent.
+function renameFileWithRetry (src: string, dest: string): void {
+  const startedAt = Date.now()
+  let backoffMs = 0
+  for (;;) {
+    try {
+      fs.renameSync(src, dest)
+      return
+    } catch (err) {
+      if (!isTransientRenameError(err) || Date.now() - startedAt >= RENAME_RETRY_BUDGET_MS) throw err
+      if (backoffMs > 0) Atomics.wait(renameRetrySleepBuffer, 0, 0, backoffMs)
+      backoffMs = Math.min(backoffMs + 10, RENAME_RETRY_BACKOFF_CAP_MS)
+    }
+  }
+}
+
+function isTransientRenameError (err: unknown): boolean {
+  return process.platform === 'win32' &&
+    util.types.isNativeError(err) &&
+    'code' in err &&
+    (err.code === 'EPERM' || err.code === 'EACCES' || err.code === 'EBUSY')
 }
 
 // A rename cannot put a file where a directory is (EISDIR), so one standing in

--- a/pnpm11/fs/indexed-pkg-importer/src/importIndexedDir.ts
+++ b/pnpm11/fs/indexed-pkg-importer/src/importIndexedDir.ts
@@ -35,12 +35,22 @@ export interface ImportIndexedDirOptions {
   resolvedFrom?: ResolvedFrom
 }
 
+// What one call to importIndexedDir is importing, threaded to the helpers that
+// need all of it — including the retries, which re-enter with a rewritten map.
+interface IndexedDirImport {
+  importer: Importer
+  newDir: string
+  filenames: Map<string, string>
+  opts: ImportIndexedDirOptions
+}
+
 export function importIndexedDir (
   importer: Importer,
   newDir: string,
   filenames: Map<string, string>,
   opts: ImportIndexedDirOptions
 ): void {
+  const dirImport: IndexedDirImport = { importer, newDir, filenames, opts }
   // Content-addressed target (e.g. global virtual store): the path is shared
   // across projects, so concurrent importers are expected and the directory
   // must never be removed or swapped out from under them.  It is populated in
@@ -52,7 +62,7 @@ export function importIndexedDir (
   // contents can change without the lockfile changing and the path pins
   // nothing.  Such a target is rebuilt below rather than adopted or repaired.
   if (opts.safeToSkip && opts.resolvedFrom !== 'local-dir') {
-    importIntoSharedDir(importer, newDir, filenames, opts)
+    importIntoSharedDir(dirImport)
     return
   }
   // Fast path: import directly without staging.  Callers already verified
@@ -80,7 +90,7 @@ export function importIndexedDir (
     try {
       rimrafSync(stage)
     } catch {} // eslint-disable-line:no-empty
-    if (retryWithFixedFileMap(err, importer, newDir, filenames, opts)) return
+    if (retryWithFixedFileMap(err, dirImport)) return
     throw err
   }
   try {
@@ -104,12 +114,8 @@ export function importIndexedDir (
 // that adopts what it finds keeps a file truncated by an interrupted copy, and
 // then puts the completion marker on top of it — after which the directory
 // looks finished to every later install and is never repaired.
-function importIntoSharedDir (
-  importer: Importer,
-  newDir: string,
-  filenames: Map<string, string>,
-  opts: ImportIndexedDirOptions
-): void {
+function importIntoSharedDir (dirImport: IndexedDirImport): void {
+  const { importer, newDir, filenames } = dirImport
   fs.mkdirSync(path.dirname(newDir), { recursive: true })
   let created = false
   try {
@@ -123,7 +129,7 @@ function importIntoSharedDir (
       tryImportIndexedDir(importer, newDir, filenames)
       return
     } catch (err: unknown) {
-      if (retryWithFixedFileMap(err, importer, newDir, filenames, opts)) return
+      if (retryWithFixedFileMap(err, dirImport)) return
       // Our own write stopped partway. Another importer may already be reading
       // what did land, so finish the directory in place instead of staging a
       // replacement for it.
@@ -131,9 +137,9 @@ function importIntoSharedDir (
   }
   if (allFilesMatch(newDir, filenames)) return
   try {
-    repairIndexedDir(importer, newDir, filenames)
+    repairIndexedDir(dirImport)
   } catch (err: unknown) {
-    if (retryWithFixedFileMap(err, importer, newDir, filenames, opts)) return
+    if (retryWithFixedFileMap(err, dirImport)) return
     throw err
   }
 }
@@ -142,11 +148,7 @@ function importIntoSharedDir (
 // entry. Files the package does not declare are left alone: a build output
 // belongs to whoever put it there, and a slot other installs are reading is
 // not somewhere to delete from speculatively.
-function repairIndexedDir (
-  importer: Importer,
-  newDir: string,
-  filenames: Map<string, string>
-): void {
+function repairIndexedDir ({ importer, newDir, filenames }: IndexedDirImport): void {
   makeFileMapDirs(newDir, filenames, { clearBlockers: true })
   let packageJsonSrc: string | undefined
   for (const [f, src] of filenames) {
@@ -220,13 +222,8 @@ function clearDirentBlockingDir (newDir: string, relativeDir: string): void {
 // outright. Both are recovered by rewriting the map and importing again.
 // Returns false for anything else, which the caller must treat as a real
 // failure.
-function retryWithFixedFileMap (
-  err: unknown,
-  importer: Importer,
-  newDir: string,
-  filenames: Map<string, string>,
-  opts: ImportIndexedDirOptions
-): boolean {
+function retryWithFixedFileMap (err: unknown, dirImport: IndexedDirImport): boolean {
+  const { importer, newDir, filenames, opts } = dirImport
   if (!util.types.isNativeError(err) || !('code' in err)) return false
   if (err.code === 'EEXIST') {
     const { uniqueFileMap, conflictingFileNames } = getUniqueFileMap(filenames)
@@ -245,7 +242,7 @@ function retryWithFixedFileMap (
     return true
   }
   if (err.code === 'ENOENT') {
-    return retryWithSanitizedFilenames(importer, newDir, filenames, opts)
+    return retryWithSanitizedFilenames(dirImport)
   }
   return false
 }
@@ -291,14 +288,23 @@ function tryExclusiveImport (
 }
 
 function allFilesMatch (dir: string, filenames: Map<string, string>): boolean {
+  // The completion marker is written last, so its absence settles the common
+  // case — a directory another importer is still filling — in one stat,
+  // wherever the map happens to hold it.
+  const markerSrc = filenames.get('package.json')
+  if (markerSrc !== undefined && !fileMatches(dir, 'package.json', markerSrc)) return false
   for (const [f, src] of filenames) {
-    const reason = mismatchReason(path.join(dir, f), src)
-    if (reason !== undefined) {
-      globalInfo(`Re-importing "${dir}" because file "${f}" ${reason}`)
-      return false
-    }
+    if (f === 'package.json') continue
+    if (!fileMatches(dir, f, src)) return false
   }
   return true
+}
+
+function fileMatches (dir: string, f: string, src: string): boolean {
+  const reason = mismatchReason(path.join(dir, f), src)
+  if (reason === undefined) return true
+  globalInfo(`Re-importing "${dir}" because file "${f}" ${reason}`)
+  return false
 }
 
 // Why `target` is not the store file at `src`, or undefined when it already
@@ -317,12 +323,7 @@ function mismatchReason (target: string, src: string): string | undefined {
   }
 }
 
-function retryWithSanitizedFilenames (
-  importer: Importer,
-  newDir: string,
-  filenames: Map<string, string>,
-  opts: ImportIndexedDirOptions
-): boolean {
+function retryWithSanitizedFilenames ({ importer, newDir, filenames, opts }: IndexedDirImport): boolean {
   const { sanitizedFilenames, invalidFilenames } = sanitizeFilenames(filenames)
   if (invalidFilenames.length === 0) return false
   globalWarn(`\

--- a/pnpm11/fs/indexed-pkg-importer/src/importIndexedDir.ts
+++ b/pnpm11/fs/indexed-pkg-importer/src/importIndexedDir.ts
@@ -4,6 +4,7 @@ import util from 'node:util'
 
 import gfs from '@pnpm/fs.graceful-fs'
 import { globalInfo, globalWarn, logger } from '@pnpm/logger'
+import type { ResolvedFrom } from '@pnpm/store.controller-types'
 import { rimrafSync } from '@zkochan/rimraf'
 import fsx from 'fs-extra'
 import { makeEmptyDirSync } from 'make-empty-dir'
@@ -24,15 +25,36 @@ export interface Importer {
   importFileAtomic: ImportFile
 }
 
+export interface ImportIndexedDirOptions {
+  keepModulesDir?: boolean
+  /**
+   * Whether a target that already holds this package is equivalent to the
+   * import, which requires that the target path pin its contents.
+   */
+  safeToSkip?: boolean
+  resolvedFrom?: ResolvedFrom
+}
+
 export function importIndexedDir (
   importer: Importer,
   newDir: string,
   filenames: Map<string, string>,
-  opts: {
-    keepModulesDir?: boolean
-    safeToSkip?: boolean
-  }
+  opts: ImportIndexedDirOptions
 ): void {
+  // Content-addressed target (e.g. global virtual store): the path is shared
+  // across projects, so concurrent importers are expected and the directory
+  // must never be removed or swapped out from under them.  It is populated in
+  // place, adopted when it already matches, and otherwise repaired entry by
+  // entry.  Repairing in place leaves a nested node_modules/ where it is, so
+  // keepModulesDir has nothing to preserve here either.
+  //
+  // A local directory is copied into the target at install time, so its
+  // contents can change without the lockfile changing and the path pins
+  // nothing.  Such a target is rebuilt below rather than adopted or repaired.
+  if (opts.safeToSkip && opts.resolvedFrom !== 'local-dir') {
+    importIntoSharedDir(importer, newDir, filenames, opts)
+    return
+  }
   // Fast path: import directly without staging.  Callers already verified
   // the target package is missing (pkgExistsAtTargetDir / pkgLinkedToStore),
   // so we can write straight into newDir and skip the temp dir + rename.
@@ -40,24 +62,8 @@ export function importIndexedDir (
   // handling (EEXIST dedup, ENOENT sanitized-filename retry, etc.) and
   // atomically swaps in a complete directory.
   // keepModulesDir needs the staging path to preserve the existing node_modules.
-  if (!opts.keepModulesDir) {
-    if (opts.safeToSkip) {
-      // Content-addressed target (e.g. global virtual store): the path is
-      // shared across projects, so concurrent importers are expected. Use a
-      // non-destructive mkdir and let importFile dedup via EEXIST. If another
-      // importer already completed the directory, there's nothing to do.
-      try {
-        fs.mkdirSync(newDir, { recursive: true })
-        tryImportIndexedDir(importer, newDir, filenames)
-        return
-      } catch (err) {
-        if (util.types.isNativeError(err) && 'code' in err && err.code === 'EEXIST' && allFilesMatch(newDir, filenames)) {
-          return
-        }
-      }
-    } else if (tryExclusiveImport(importer, newDir, filenames)) {
-      return
-    }
+  if (!opts.keepModulesDir && tryExclusiveImport(importer, newDir, filenames)) {
+    return
   }
   // Staging path: create in temp dir, then atomically rename.
   // The dir rename is itself atomic, so individual file atomicity is not
@@ -74,47 +80,8 @@ export function importIndexedDir (
     try {
       rimrafSync(stage)
     } catch {} // eslint-disable-line:no-empty
-    if (util.types.isNativeError(err) && 'code' in err && err.code === 'EEXIST') {
-      const { uniqueFileMap, conflictingFileNames } = getUniqueFileMap(filenames)
-      if (conflictingFileNames.size === 0) throw err
-      filenameConflictsLogger.debug({
-        conflicts: Object.fromEntries(conflictingFileNames),
-        writingTo: newDir,
-      })
-      globalWarn(
-        `Not all files were linked to "${path.relative(process.cwd(), newDir)}". ` +
-        'Some of the files have equal names in different case, ' +
-        'which is an issue on case-insensitive filesystems. ' +
-        `The conflicting file names are: ${JSON.stringify(Object.fromEntries(conflictingFileNames))}`
-      )
-      importIndexedDir(importer, newDir, uniqueFileMap, opts)
-      return
-    }
-    if (util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT') {
-      if (retryWithSanitizedFilenames(importer, newDir, filenames, opts)) return
-      throw err
-    }
+    if (retryWithFixedFileMap(err, importer, newDir, filenames, opts)) return
     throw err
-  }
-  if (opts.safeToSkip) {
-    // Content-addressable target (e.g. global virtual store): if the target
-    // already exists and has all expected files, it has the correct content.
-    // Skip instead of doing a swap-rename that temporarily removes the target
-    // directory — which breaks junctions read by other processes.
-    try {
-      fs.renameSync(stage, newDir)
-      return
-    } catch (err: unknown) {
-      if (util.types.isNativeError(err) && 'code' in err && (err.code === 'ENOTEMPTY' || err.code === 'EEXIST' || err.code === 'EPERM')) {
-        if (allFilesMatch(newDir, filenames)) {
-          try {
-            rimrafSync(stage)
-          } catch {} // eslint-disable-line:no-empty
-          return
-        }
-      }
-      // Files missing or other error — fall through to renameOverwriteSync
-    }
   }
   try {
     renameOverwriteSync(stage, newDir)
@@ -124,6 +91,163 @@ export function importIndexedDir (
     } catch {} // eslint-disable-line:no-empty
     throw renameErr
   }
+}
+
+// Import into a directory whose path is shared with other projects, and with
+// the installs running in them. Nothing here removes a dirent: the winner of
+// the exclusive mkdir writes the package, and everyone else adopts the result
+// when it already matches and otherwise replaces only the entries that do not,
+// so concurrent importers converge on the same tree.
+//
+// Replacing rather than adopting is what keeps a shared slot repairable. The
+// linking tiers report EEXIST for a dirent that is already there, so an import
+// that adopts what it finds keeps a file truncated by an interrupted copy, and
+// then puts the completion marker on top of it — after which the directory
+// looks finished to every later install and is never repaired.
+function importIntoSharedDir (
+  importer: Importer,
+  newDir: string,
+  filenames: Map<string, string>,
+  opts: ImportIndexedDirOptions
+): void {
+  fs.mkdirSync(path.dirname(newDir), { recursive: true })
+  let created = false
+  try {
+    fs.mkdirSync(newDir)
+    created = true
+  } catch (err) {
+    if (!util.types.isNativeError(err) || !('code' in err) || err.code !== 'EEXIST') throw err
+  }
+  if (created) {
+    try {
+      tryImportIndexedDir(importer, newDir, filenames)
+      return
+    } catch (err: unknown) {
+      if (retryWithFixedFileMap(err, importer, newDir, filenames, opts)) return
+      // Our own write stopped partway. Another importer may already be reading
+      // what did land, so finish the directory in place instead of staging a
+      // replacement for it.
+    }
+  }
+  if (allFilesMatch(newDir, filenames)) return
+  try {
+    repairIndexedDir(importer, newDir, filenames)
+  } catch (err: unknown) {
+    if (retryWithFixedFileMap(err, importer, newDir, filenames, opts)) return
+    throw err
+  }
+}
+
+// Bring an occupied shared directory up to date with the file map, entry by
+// entry. Files the package does not declare are left alone: a build output
+// belongs to whoever put it there, and a slot other installs are reading is
+// not somewhere to delete from speculatively.
+function repairIndexedDir (
+  importer: Importer,
+  newDir: string,
+  filenames: Map<string, string>
+): void {
+  makeFileMapDirs(newDir, filenames, { clearBlockingDirents: true })
+  let packageJsonSrc: string | undefined
+  for (const [f, src] of filenames) {
+    if (f === 'package.json') {
+      packageJsonSrc = src
+      continue
+    }
+    replaceFileIfDifferent(importer.importFile, src, path.join(newDir, f))
+  }
+  if (packageJsonSrc !== undefined) {
+    replaceFileIfDifferent(importer.importFile, packageJsonSrc, path.join(newDir, 'package.json'))
+  }
+}
+
+// Swap the file in through a temp sibling: a reader sees either the old dirent
+// or the new one, and the rename replaces what the linking tiers would have
+// refused to overwrite.
+function replaceFileIfDifferent (importFile: ImportFile, src: string, dest: string): void {
+  if (mismatchReason(dest, src) === undefined) return
+  const tmp = pathTemp(dest)
+  try {
+    importFile(src, tmp)
+  } catch (err) {
+    try {
+      fs.unlinkSync(tmp)
+    } catch {} // eslint-disable-line:no-empty
+    throw err
+  }
+  clearDirentBlockingFile(dest)
+  renameOverwriteSync(tmp, dest)
+}
+
+// A rename cannot put a file where a directory is (EISDIR), so one standing in
+// the way has to go first. Only a damaged tree has one.
+function clearDirentBlockingFile (dest: string): void {
+  let stats
+  try {
+    stats = fs.lstatSync(dest)
+  } catch (err) {
+    if (util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT') return
+    throw err
+  }
+  if (stats.isDirectory()) {
+    rimrafSync(dest)
+  }
+}
+
+// A file where the package needs a directory turns up only in a damaged tree,
+// and would fail the mkdir below. Walking top-down means a segment whose
+// parent is itself a file is never reached: the parent goes first, and
+// everything under a missing segment is missing too.
+function clearDirentsBlockingDir (newDir: string, relativeDir: string): void {
+  let dir = newDir
+  for (const segment of relativeDir.split(/[\\/]/)) {
+    dir = path.join(dir, segment)
+    let stats
+    try {
+      stats = fs.lstatSync(dir)
+    } catch (err) {
+      if (util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT') return
+      throw err
+    }
+    if (stats.isDirectory()) continue
+    fs.unlinkSync(dir)
+    return
+  }
+}
+
+// The two failures an indexed file map can cause on its own: names that
+// collide on a case-insensitive filesystem, and names the filesystem rejects
+// outright. Both are recovered by rewriting the map and importing again.
+// Returns false for anything else, which the caller must treat as a real
+// failure.
+function retryWithFixedFileMap (
+  err: unknown,
+  importer: Importer,
+  newDir: string,
+  filenames: Map<string, string>,
+  opts: ImportIndexedDirOptions
+): boolean {
+  if (!util.types.isNativeError(err) || !('code' in err)) return false
+  if (err.code === 'EEXIST') {
+    const { uniqueFileMap, conflictingFileNames } = getUniqueFileMap(filenames)
+    if (conflictingFileNames.size === 0) return false
+    filenameConflictsLogger.debug({
+      conflicts: Object.fromEntries(conflictingFileNames),
+      writingTo: newDir,
+    })
+    globalWarn(
+      `Not all files were linked to "${path.relative(process.cwd(), newDir)}". ` +
+      'Some of the files have equal names in different case, ' +
+      'which is an issue on case-insensitive filesystems. ' +
+      `The conflicting file names are: ${JSON.stringify(Object.fromEntries(conflictingFileNames))}`
+    )
+    importIndexedDir(importer, newDir, uniqueFileMap, opts)
+    return true
+  }
+  if (err.code === 'ENOENT') {
+    return retryWithSanitizedFilenames(importer, newDir, filenames, opts)
+  }
+  return false
 }
 
 // Fast path for the regular virtual store: write directly into newDir, but
@@ -168,34 +292,36 @@ function tryExclusiveImport (
 
 function allFilesMatch (dir: string, filenames: Map<string, string>): boolean {
   for (const [f, src] of filenames) {
-    const target = path.join(dir, f)
-    try {
-      const targetStat = gfs.statSync(target)
-      const srcStat = gfs.statSync(src)
-      // Fast path: hardlinks share the same inode
-      if (targetStat.ino === srcStat.ino && targetStat.dev === srcStat.dev) continue
-      // Copy path: compare size first, then content
-      if (targetStat.size !== srcStat.size) {
-        globalInfo(`Re-importing "${dir}" because file "${f}" has a different size`)
-        return false
-      }
-      if (!gfs.readFileSync(target).equals(gfs.readFileSync(src))) {
-        globalInfo(`Re-importing "${dir}" because file "${f}" has different content`)
-        return false
-      }
-    } catch {
-      globalInfo(`Re-importing "${dir}" because file "${f}" is missing or unreadable`)
+    const reason = mismatchReason(path.join(dir, f), src)
+    if (reason !== undefined) {
+      globalInfo(`Re-importing "${dir}" because file "${f}" ${reason}`)
       return false
     }
   }
   return true
 }
 
+// Why `target` is not the store file at `src`, or undefined when it already
+// is. Files imported by hardlink or reflink share the store inode, which
+// settles it without a read; the copy tier compares size first, then content.
+function mismatchReason (target: string, src: string): string | undefined {
+  try {
+    const targetStat = gfs.statSync(target)
+    const srcStat = gfs.statSync(src)
+    if (targetStat.ino === srcStat.ino && targetStat.dev === srcStat.dev) return undefined
+    if (targetStat.size !== srcStat.size) return 'has a different size'
+    if (!gfs.readFileSync(target).equals(gfs.readFileSync(src))) return 'has different content'
+    return undefined
+  } catch {
+    return 'is missing or unreadable'
+  }
+}
+
 function retryWithSanitizedFilenames (
   importer: Importer,
   newDir: string,
   filenames: Map<string, string>,
-  opts: { keepModulesDir?: boolean, safeToSkip?: boolean }
+  opts: ImportIndexedDirOptions
 ): boolean {
   const { sanitizedFilenames, invalidFilenames } = sanitizeFilenames(filenames)
   if (invalidFilenames.length === 0) return false
@@ -230,15 +356,7 @@ function tryImportIndexedDir (
   newDir: string,
   filenames: Map<string, string>
 ): void {
-  const allDirs = new Set<string>()
-  for (const f of filenames.keys()) {
-    const dir = path.dirname(f)
-    if (dir === '.') continue
-    allDirs.add(dir)
-  }
-  Array.from(allDirs)
-    .sort((d1, d2) => d1.length - d2.length) // from shortest to longest
-    .forEach((dir) => fs.mkdirSync(path.join(newDir, dir), { recursive: true }))
+  makeFileMapDirs(newDir, filenames)
   // Write package.json last so it acts as a completion marker.
   // pkgExistsAtTargetDir() checks for package.json to decide if a package
   // is already imported — writing it last ensures a crash mid-import won't
@@ -253,6 +371,27 @@ function tryImportIndexedDir (
   }
   if (packageJsonSrc !== undefined) {
     importFileAtomic(packageJsonSrc, path.join(newDir, 'package.json'))
+  }
+}
+
+// Sorting shortest-first means the recursive mkdir for a deeper directory
+// always finds its ancestor already on disk.
+function makeFileMapDirs (
+  newDir: string,
+  filenames: Map<string, string>,
+  opts?: { clearBlockingDirents: boolean }
+): void {
+  const allDirs = new Set<string>()
+  for (const f of filenames.keys()) {
+    const dir = path.dirname(f)
+    if (dir === '.') continue
+    allDirs.add(dir)
+  }
+  for (const dir of Array.from(allDirs).sort((d1, d2) => d1.length - d2.length)) {
+    if (opts?.clearBlockingDirents) {
+      clearDirentsBlockingDir(newDir, dir)
+    }
+    fs.mkdirSync(path.join(newDir, dir), { recursive: true })
   }
 }
 

--- a/pnpm11/fs/indexed-pkg-importer/src/importIndexedDir.ts
+++ b/pnpm11/fs/indexed-pkg-importer/src/importIndexedDir.ts
@@ -147,7 +147,7 @@ function repairIndexedDir (
   newDir: string,
   filenames: Map<string, string>
 ): void {
-  makeFileMapDirs(newDir, filenames, { clearBlockingDirents: true })
+  makeFileMapDirs(newDir, filenames, { clearBlockers: true })
   let packageJsonSrc: string | undefined
   for (const [f, src] of filenames) {
     if (f === 'package.json') {
@@ -175,13 +175,13 @@ function replaceFileIfDifferent (importFile: ImportFile, src: string, dest: stri
     } catch {} // eslint-disable-line:no-empty
     throw err
   }
-  clearDirentBlockingFile(dest)
+  clearDirBlockingFile(dest)
   renameOverwriteSync(tmp, dest)
 }
 
 // A rename cannot put a file where a directory is (EISDIR), so one standing in
 // the way has to go first. Only a damaged tree has one.
-function clearDirentBlockingFile (dest: string): void {
+function clearDirBlockingFile (dest: string): void {
   let stats
   try {
     stats = fs.lstatSync(dest)
@@ -198,7 +198,7 @@ function clearDirentBlockingFile (dest: string): void {
 // and would fail the mkdir below. Walking top-down means a segment whose
 // parent is itself a file is never reached: the parent goes first, and
 // everything under a missing segment is missing too.
-function clearDirentsBlockingDir (newDir: string, relativeDir: string): void {
+function clearDirentBlockingDir (newDir: string, relativeDir: string): void {
   let dir = newDir
   for (const segment of relativeDir.split(/[\\/]/)) {
     dir = path.join(dir, segment)
@@ -379,7 +379,7 @@ function tryImportIndexedDir (
 function makeFileMapDirs (
   newDir: string,
   filenames: Map<string, string>,
-  opts?: { clearBlockingDirents: boolean }
+  opts?: { clearBlockers: boolean }
 ): void {
   const allDirs = new Set<string>()
   for (const f of filenames.keys()) {
@@ -388,8 +388,8 @@ function makeFileMapDirs (
     allDirs.add(dir)
   }
   for (const dir of Array.from(allDirs).sort((d1, d2) => d1.length - d2.length)) {
-    if (opts?.clearBlockingDirents) {
-      clearDirentsBlockingDir(newDir, dir)
+    if (opts?.clearBlockers) {
+      clearDirentBlockingDir(newDir, dir)
     }
     fs.mkdirSync(path.join(newDir, dir), { recursive: true })
   }

--- a/pnpm11/fs/indexed-pkg-importer/src/importIndexedDir.ts
+++ b/pnpm11/fs/indexed-pkg-importer/src/importIndexedDir.ts
@@ -348,10 +348,14 @@ function fileMatches (dir: string, f: string, src: string): boolean {
 // settles it without a read; the copy tier compares size first, then content.
 function mismatchReason (target: string, src: string): string | undefined {
   try {
-    const targetStat = fs.lstatSync(target)
+    const targetStat = fs.lstatSync(target, { bigint: true })
     if (!targetStat.isFile()) return 'is not a regular file'
-    const srcStat = gfs.statSync(src)
-    if (targetStat.ino === srcStat.ino && targetStat.dev === srcStat.dev) return undefined
+    const srcStat = gfs.statSync(src, { bigint: true })
+    const hasSameFileIdentity = targetStat.ino !== 0n &&
+      targetStat.dev !== 0n &&
+      targetStat.ino === srcStat.ino &&
+      targetStat.dev === srcStat.dev
+    if (hasSameFileIdentity) return undefined
     if (targetStat.size !== srcStat.size) return 'has a different size'
     if (!filesHaveEqualContents(target, src)) return 'has different content'
     return undefined

--- a/pnpm11/fs/indexed-pkg-importer/src/importIndexedDir.ts
+++ b/pnpm11/fs/indexed-pkg-importer/src/importIndexedDir.ts
@@ -15,6 +15,7 @@ import sanitizeFilename from 'sanitize-filename'
 const filenameConflictsLogger = logger('_filename-conflicts')
 const RENAME_RETRY_BUDGET_MS = 60_000
 const RENAME_RETRY_BACKOFF_CAP_MS = 100
+const FILE_COMPARE_BUFFER_SIZE = 64 * 1024
 const renameRetrySleepBuffer = new Int32Array(new SharedArrayBuffer(4))
 
 export type ImportFile = (src: string, dest: string) => void
@@ -347,14 +348,37 @@ function fileMatches (dir: string, f: string, src: string): boolean {
 // settles it without a read; the copy tier compares size first, then content.
 function mismatchReason (target: string, src: string): string | undefined {
   try {
-    const targetStat = gfs.statSync(target)
+    const targetStat = fs.lstatSync(target)
+    if (!targetStat.isFile()) return 'is not a regular file'
     const srcStat = gfs.statSync(src)
     if (targetStat.ino === srcStat.ino && targetStat.dev === srcStat.dev) return undefined
     if (targetStat.size !== srcStat.size) return 'has a different size'
-    if (!gfs.readFileSync(target).equals(gfs.readFileSync(src))) return 'has different content'
+    if (!filesHaveEqualContents(target, src)) return 'has different content'
     return undefined
   } catch {
     return 'is missing or unreadable'
+  }
+}
+
+function filesHaveEqualContents (left: string, right: string): boolean {
+  const leftBuffer = Buffer.allocUnsafe(FILE_COMPARE_BUFFER_SIZE)
+  const rightBuffer = Buffer.allocUnsafe(FILE_COMPARE_BUFFER_SIZE)
+  const leftFd = fs.openSync(left, 'r')
+  try {
+    const rightFd = fs.openSync(right, 'r')
+    try {
+      for (;;) {
+        const leftBytes = fs.readSync(leftFd, leftBuffer, 0, leftBuffer.length, null)
+        const rightBytes = fs.readSync(rightFd, rightBuffer, 0, rightBuffer.length, null)
+        if (leftBytes !== rightBytes) return false
+        if (leftBytes === 0) return true
+        if (!leftBuffer.subarray(0, leftBytes).equals(rightBuffer.subarray(0, rightBytes))) return false
+      }
+    } finally {
+      fs.closeSync(rightFd)
+    }
+  } finally {
+    fs.closeSync(leftFd)
   }
 }
 

--- a/pnpm11/fs/indexed-pkg-importer/test/fixtures/concurrentSharedSlotImport.mjs
+++ b/pnpm11/fs/indexed-pkg-importer/test/fixtures/concurrentSharedSlotImport.mjs
@@ -1,0 +1,50 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import util from 'node:util'
+
+import { importIndexedDir } from '../../lib/importIndexedDir.js'
+
+const [role, newDir, srcDir, readyFile, releaseFile] = process.argv.slice(2)
+if ([role, newDir, srcDir, readyFile, releaseFile].some((arg) => arg == null)) {
+  throw new Error('expected role, target, source, ready, and release arguments')
+}
+
+let paused = false
+const importFile = (src, dest) => {
+  if (role === 'partial-writer' && !paused && path.basename(dest) === 'index.js') {
+    paused = true
+    fs.writeFileSync(dest, 'module.exports =')
+    fs.writeFileSync(path.join(newDir, 'writer-owned.txt'), 'the first importer is still using this directory')
+    fs.writeFileSync(readyFile, '')
+    waitForFile(releaseFile)
+    return
+  }
+  linkAdoptingExisting(src, dest)
+}
+
+importIndexedDir(
+  { importFile, importFileAtomic: role === 'partial-writer' ? importFile : linkAdoptingExisting },
+  newDir,
+  new Map([
+    ['index.js', path.join(srcDir, 'index.js')],
+    ['package.json', path.join(srcDir, 'package.json')],
+  ]),
+  { safeToSkip: true }
+)
+
+function linkAdoptingExisting (src, dest) {
+  try {
+    fs.linkSync(src, dest)
+  } catch (err) {
+    if (!(util.types.isNativeError(err) && 'code' in err && err.code === 'EEXIST')) throw err
+  }
+}
+
+function waitForFile (file) {
+  const sleepBuffer = new Int32Array(new SharedArrayBuffer(4))
+  const deadline = Date.now() + 20_000
+  while (!fs.existsSync(file)) {
+    if (Date.now() >= deadline) throw new Error(`timed out waiting for ${file}`)
+    Atomics.wait(sleepBuffer, 0, 0, 10)
+  }
+}

--- a/pnpm11/fs/indexed-pkg-importer/test/importIndexedDir.concurrent.test.ts
+++ b/pnpm11/fs/indexed-pkg-importer/test/importIndexedDir.concurrent.test.ts
@@ -36,7 +36,8 @@ test('a concurrent importer repairs a partial shared virtual-store slot before m
     ])
     execFileSync(process.execPath, importerArgs('contender'), { stdio: 'pipe', timeout: 20_000 })
   } finally {
-    if (!writer.kill()) fs.writeFileSync(releaseFile, '')
+    fs.writeFileSync(releaseFile, '')
+    writer.kill()
     await writerExit
   }
 

--- a/pnpm11/fs/indexed-pkg-importer/test/importIndexedDir.concurrent.test.ts
+++ b/pnpm11/fs/indexed-pkg-importer/test/importIndexedDir.concurrent.test.ts
@@ -1,0 +1,69 @@
+import { execFileSync, spawn } from 'node:child_process'
+import { once } from 'node:events'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { expect, test } from '@jest/globals'
+import { tempDir } from '@pnpm/prepare'
+
+const importerFixture = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  'fixtures/concurrentSharedSlotImport.mjs'
+)
+
+test('a concurrent importer repairs a partial shared virtual-store slot before marking it complete', async () => {
+  const tmp = tempDir()
+  const srcDir = path.join(tmp, 'src')
+  const newDir = path.join(tmp, 'slot')
+  const readyFile = path.join(tmp, 'writer-ready')
+  const releaseFile = path.join(tmp, 'release-writer')
+  fs.mkdirSync(srcDir)
+  fs.writeFileSync(path.join(srcDir, 'index.js'), 'module.exports = 1')
+  fs.writeFileSync(path.join(srcDir, 'package.json'), '{"name":"pkg"}')
+
+  // Separate installs may select different import tiers while sharing the GVS.
+  // Model a copy interrupted mid-file, then let a hardlink importer encounter
+  // that occupied dirent before the first process can place package.json.
+  const writer = spawn(process.execPath, importerArgs('partial-writer'), { stdio: 'inherit' })
+  const writerExit = once(writer, 'exit')
+  try {
+    await Promise.race([
+      waitForFile(readyFile),
+      writerExit.then(() => {
+        if (!fs.existsSync(readyFile)) throw new Error('partial writer exited before reaching the barrier')
+      }),
+    ])
+    execFileSync(process.execPath, importerArgs('contender'), { stdio: 'pipe', timeout: 20_000 })
+  } finally {
+    if (!writer.kill()) fs.writeFileSync(releaseFile, '')
+    await writerExit
+  }
+
+  expect(fs.readFileSync(path.join(newDir, 'index.js'), 'utf8')).toBe('module.exports = 1')
+  expect(fs.readFileSync(path.join(newDir, 'package.json'), 'utf8')).toBe('{"name":"pkg"}')
+  expect(fs.readFileSync(path.join(newDir, 'writer-owned.txt'), 'utf8')).toBe(
+    'the first importer is still using this directory'
+  )
+
+  function importerArgs (role: 'partial-writer' | 'contender'): string[] {
+    return [importerFixture, role, newDir, srcDir, readyFile, releaseFile]
+  }
+}, 30_000)
+
+function waitForFile (file: string): Promise<void> {
+  const deadline = Date.now() + 10_000
+  return new Promise((resolve, reject) => {
+    poll()
+
+    function poll (): void {
+      if (fs.existsSync(file)) {
+        resolve()
+      } else if (Date.now() >= deadline) {
+        reject(new Error(`timed out waiting for ${file}`))
+      } else {
+        setTimeout(poll, 10)
+      }
+    }
+  })
+}

--- a/pnpm11/fs/indexed-pkg-importer/test/importIndexedDir.test.ts
+++ b/pnpm11/fs/indexed-pkg-importer/test/importIndexedDir.test.ts
@@ -7,18 +7,6 @@ import { tempDir } from '@pnpm/prepare'
 
 import { importIndexedDir } from '../src/importIndexedDir.js'
 
-// The hardlink and clone importers treat an existing target as already
-// imported, which is why a repair cannot rely on them to replace a file.
-function linkAdoptingExisting (src: string, dest: string): void {
-  try {
-    fs.linkSync(src, dest)
-  } catch (err: unknown) {
-    if (!(util.types.isNativeError(err) && 'code' in err && err.code === 'EEXIST')) throw err
-  }
-}
-
-const linkingImporter = { importFile: linkAdoptingExisting, importFileAtomic: linkAdoptingExisting }
-
 test('importIndexedDir() keepModulesDir merges node_modules', async () => {
   const tmp = tempDir()
   fs.mkdirSync(path.join(tmp, 'src/node_modules/a'), { recursive: true })
@@ -167,3 +155,15 @@ test('importIndexedDir() safeToSkip repairs a directory holding a nested node_mo
   expect(fs.readFileSync(path.join(newDir, 'index.js'), 'utf8')).toBe('module.exports = 1')
   expect(fs.readFileSync(path.join(newDir, 'package.json'), 'utf8')).toBe('{"name":"pkg"}')
 })
+
+// The hardlink and clone importers treat an existing target as already
+// imported, which is why a repair cannot rely on them to replace a file.
+function linkAdoptingExisting (src: string, dest: string): void {
+  try {
+    fs.linkSync(src, dest)
+  } catch (err: unknown) {
+    if (!(util.types.isNativeError(err) && 'code' in err && err.code === 'EEXIST')) throw err
+  }
+}
+
+const linkingImporter = { importFile: linkAdoptingExisting, importFileAtomic: linkAdoptingExisting }

--- a/pnpm11/fs/indexed-pkg-importer/test/importIndexedDir.test.ts
+++ b/pnpm11/fs/indexed-pkg-importer/test/importIndexedDir.test.ts
@@ -1,10 +1,23 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import util from 'node:util'
 
 import { expect, test } from '@jest/globals'
 import { tempDir } from '@pnpm/prepare'
 
 import { importIndexedDir } from '../src/importIndexedDir.js'
+
+// The hardlink and clone importers treat an existing target as already
+// imported, which is why a repair cannot rely on them to replace a file.
+function linkAdoptingExisting (src: string, dest: string): void {
+  try {
+    fs.linkSync(src, dest)
+  } catch (err: unknown) {
+    if (!(util.types.isNativeError(err) && 'code' in err && err.code === 'EEXIST')) throw err
+  }
+}
+
+const linkingImporter = { importFile: linkAdoptingExisting, importFileAtomic: linkAdoptingExisting }
 
 test('importIndexedDir() keepModulesDir merges node_modules', async () => {
   const tmp = tempDir()
@@ -21,4 +34,136 @@ test('importIndexedDir() keepModulesDir merges node_modules', async () => {
   importIndexedDir({ importFile: fs.linkSync, importFileAtomic: fs.linkSync }, newDir, filenames, { keepModulesDir: true })
 
   expect(fs.readdirSync(path.join(newDir, 'node_modules')).sort()).toEqual(['a', 'b'])
+})
+
+test('importIndexedDir() safeToSkip replaces a damaged file a linking importer would adopt', async () => {
+  const tmp = tempDir()
+  const src = path.join(tmp, 'src')
+  fs.mkdirSync(src, { recursive: true })
+  fs.writeFileSync(path.join(src, 'package.json'), '{"name":"pkg"}')
+  fs.writeFileSync(path.join(src, 'index.js'), 'module.exports = 1')
+
+  const newDir = path.join(tmp, 'dest')
+  fs.mkdirSync(newDir, { recursive: true })
+  fs.writeFileSync(path.join(newDir, 'index.js'), 'half-written')
+  fs.writeFileSync(path.join(newDir, 'build.node'), 'output of an interrupted build')
+
+  const filenames = new Map([
+    ['index.js', path.join(src, 'index.js')],
+    ['package.json', path.join(src, 'package.json')],
+  ])
+  importIndexedDir(linkingImporter, newDir, filenames, { safeToSkip: true })
+
+  expect(fs.readFileSync(path.join(newDir, 'index.js'), 'utf8')).toBe('module.exports = 1')
+  // A file the package does not declare is not ours to remove from a directory
+  // other projects read.
+  expect(fs.existsSync(path.join(newDir, 'build.node'))).toBe(true)
+})
+
+test('importIndexedDir() safeToSkip repairs a directory damaged after it was completed', async () => {
+  const tmp = tempDir()
+  const src = path.join(tmp, 'src')
+  fs.mkdirSync(src, { recursive: true })
+  fs.writeFileSync(path.join(src, 'package.json'), '{"name":"pkg"}')
+  fs.writeFileSync(path.join(src, 'index.js'), 'module.exports = 1')
+
+  // The completion marker says nothing about the files placed before it.
+  const newDir = path.join(tmp, 'dest')
+  fs.mkdirSync(newDir, { recursive: true })
+  fs.writeFileSync(path.join(newDir, 'package.json'), '{"name":"pkg"}')
+  fs.writeFileSync(path.join(newDir, 'index.js'), 'corrupted after the import')
+
+  const filenames = new Map([
+    ['index.js', path.join(src, 'index.js')],
+    ['package.json', path.join(src, 'package.json')],
+  ])
+  importIndexedDir(linkingImporter, newDir, filenames, { safeToSkip: true })
+
+  expect(fs.readFileSync(path.join(newDir, 'index.js'), 'utf8')).toBe('module.exports = 1')
+})
+
+test('importIndexedDir() safeToSkip clears a file where the package needs a directory', async () => {
+  const tmp = tempDir()
+  const src = path.join(tmp, 'src')
+  fs.mkdirSync(src, { recursive: true })
+  fs.writeFileSync(path.join(src, 'package.json'), '{"name":"pkg"}')
+  fs.writeFileSync(path.join(src, 'index.js'), 'module.exports = 1')
+
+  const newDir = path.join(tmp, 'dest')
+  fs.mkdirSync(newDir, { recursive: true })
+  fs.writeFileSync(path.join(newDir, 'lib'), 'a file where a directory belongs')
+
+  const filenames = new Map([
+    ['lib/nested/index.js', path.join(src, 'index.js')],
+    ['package.json', path.join(src, 'package.json')],
+  ])
+  importIndexedDir(linkingImporter, newDir, filenames, { safeToSkip: true })
+
+  expect(fs.readFileSync(path.join(newDir, 'lib/nested/index.js'), 'utf8')).toBe('module.exports = 1')
+})
+
+test('importIndexedDir() safeToSkip clears a directory where the package needs a file', async () => {
+  const tmp = tempDir()
+  const src = path.join(tmp, 'src')
+  fs.mkdirSync(src, { recursive: true })
+  fs.writeFileSync(path.join(src, 'package.json'), '{"name":"pkg"}')
+  fs.writeFileSync(path.join(src, 'index.js'), 'module.exports = 1')
+
+  const newDir = path.join(tmp, 'dest')
+  fs.mkdirSync(path.join(newDir, 'index.js'), { recursive: true })
+  fs.writeFileSync(path.join(newDir, 'index.js', 'stray'), 'leftover')
+
+  const filenames = new Map([
+    ['index.js', path.join(src, 'index.js')],
+    ['package.json', path.join(src, 'package.json')],
+  ])
+  importIndexedDir(linkingImporter, newDir, filenames, { safeToSkip: true })
+
+  expect(fs.readFileSync(path.join(newDir, 'index.js'), 'utf8')).toBe('module.exports = 1')
+})
+
+test('importIndexedDir() rebuilds a local-dir target even when safeToSkip is set', async () => {
+  const tmp = tempDir()
+  const src = path.join(tmp, 'src')
+  fs.mkdirSync(src, { recursive: true })
+  fs.writeFileSync(path.join(src, 'package.json'), '{"name":"pkg"}')
+
+  // An injected local package is copied at install time, so its target holds
+  // whatever the previous install copied — including files since deleted from
+  // the source, which only a rebuild clears.
+  const newDir = path.join(tmp, 'dest')
+  fs.mkdirSync(newDir, { recursive: true })
+  fs.writeFileSync(path.join(newDir, 'package.json'), '{"name":"pkg"}')
+  fs.writeFileSync(path.join(newDir, 'removed-from-the-source.js'), 'stale')
+
+  const filenames = new Map([['package.json', path.join(src, 'package.json')]])
+  importIndexedDir(linkingImporter, newDir, filenames, { safeToSkip: true, resolvedFrom: 'local-dir' })
+
+  expect(fs.existsSync(path.join(newDir, 'removed-from-the-source.js'))).toBe(false)
+  expect(fs.readFileSync(path.join(newDir, 'package.json'), 'utf8')).toBe('{"name":"pkg"}')
+})
+
+test('importIndexedDir() safeToSkip repairs a directory holding a nested node_modules in place', async () => {
+  const tmp = tempDir()
+  const src = path.join(tmp, 'src')
+  fs.mkdirSync(src, { recursive: true })
+  fs.writeFileSync(path.join(src, 'package.json'), '{"name":"pkg"}')
+  fs.writeFileSync(path.join(src, 'index.js'), 'module.exports = 1')
+
+  // A package with bundled dependencies ships its own node_modules/, and the
+  // interrupted-build call shape asks for it to be kept. A directory repaired
+  // in place keeps it by never removing anything.
+  const newDir = path.join(tmp, 'dest')
+  fs.mkdirSync(path.join(newDir, 'node_modules/bundled'), { recursive: true })
+  fs.writeFileSync(path.join(newDir, 'node_modules/bundled/index.js'), 'bundled dependency')
+
+  const filenames = new Map([
+    ['index.js', path.join(src, 'index.js')],
+    ['package.json', path.join(src, 'package.json')],
+  ])
+  importIndexedDir(linkingImporter, newDir, filenames, { keepModulesDir: true, safeToSkip: true })
+
+  expect(fs.readFileSync(path.join(newDir, 'node_modules/bundled/index.js'), 'utf8')).toBe('bundled dependency')
+  expect(fs.readFileSync(path.join(newDir, 'index.js'), 'utf8')).toBe('module.exports = 1')
+  expect(fs.readFileSync(path.join(newDir, 'package.json'), 'utf8')).toBe('{"name":"pkg"}')
 })

--- a/pnpm11/fs/indexed-pkg-importer/test/importIndexedDir.test.ts
+++ b/pnpm11/fs/indexed-pkg-importer/test/importIndexedDir.test.ts
@@ -70,6 +70,49 @@ test('importIndexedDir() safeToSkip repairs a directory damaged after it was com
   expect(fs.readFileSync(path.join(newDir, 'index.js'), 'utf8')).toBe('module.exports = 1')
 })
 
+test('importIndexedDir() safeToSkip detects damage after the first comparison buffer', async () => {
+  const tmp = tempDir()
+  const src = path.join(tmp, 'src')
+  const newDir = path.join(tmp, 'dest')
+  const sharedPrefix = Buffer.alloc(70_000, 'a')
+  fs.mkdirSync(src, { recursive: true })
+  fs.writeFileSync(path.join(src, 'package.json'), '{"name":"pkg"}')
+  fs.writeFileSync(path.join(src, 'index.js'), Buffer.concat([sharedPrefix, Buffer.from('source')]))
+  fs.mkdirSync(newDir, { recursive: true })
+  fs.writeFileSync(path.join(newDir, 'package.json'), '{"name":"pkg"}')
+  fs.writeFileSync(path.join(newDir, 'index.js'), Buffer.concat([sharedPrefix, Buffer.from('target')]))
+
+  importIndexedDir(linkingImporter, newDir, new Map([
+    ['index.js', path.join(src, 'index.js')],
+    ['package.json', path.join(src, 'package.json')],
+  ]), { safeToSkip: true })
+
+  expect(fs.readFileSync(path.join(newDir, 'index.js'))).toEqual(
+    Buffer.concat([sharedPrefix, Buffer.from('source')])
+  )
+})
+
+test('importIndexedDir() safeToSkip replaces a symlink to matching content', async () => {
+  if (process.platform === 'win32') return
+  const tmp = tempDir()
+  const src = path.join(tmp, 'src')
+  const newDir = path.join(tmp, 'dest')
+  fs.mkdirSync(src, { recursive: true })
+  fs.writeFileSync(path.join(src, 'package.json'), '{"name":"pkg"}')
+  fs.writeFileSync(path.join(src, 'index.js'), 'module.exports = 1')
+  fs.mkdirSync(newDir, { recursive: true })
+  fs.writeFileSync(path.join(newDir, 'package.json'), '{"name":"pkg"}')
+  fs.symlinkSync(path.join(src, 'index.js'), path.join(newDir, 'index.js'), 'file')
+
+  importIndexedDir(linkingImporter, newDir, new Map([
+    ['index.js', path.join(src, 'index.js')],
+    ['package.json', path.join(src, 'package.json')],
+  ]), { safeToSkip: true })
+
+  expect(fs.lstatSync(path.join(newDir, 'index.js')).isSymbolicLink()).toBe(false)
+  expect(fs.readFileSync(path.join(newDir, 'index.js'), 'utf8')).toBe('module.exports = 1')
+})
+
 test('importIndexedDir() adopts a matching file placed by a concurrent repair', async () => {
   const tmp = tempDir()
   const src = path.join(tmp, 'src')

--- a/pnpm11/fs/indexed-pkg-importer/test/importIndexedDir.test.ts
+++ b/pnpm11/fs/indexed-pkg-importer/test/importIndexedDir.test.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import util from 'node:util'
 
 import { expect, jest, test } from '@jest/globals'
+import gfs from '@pnpm/fs.graceful-fs'
 import { tempDir } from '@pnpm/prepare'
 
 import { importIndexedDir } from '../src/importIndexedDir.js'
@@ -111,6 +112,39 @@ test('importIndexedDir() safeToSkip replaces a symlink to matching content', asy
 
   expect(fs.lstatSync(path.join(newDir, 'index.js')).isSymbolicLink()).toBe(false)
   expect(fs.readFileSync(path.join(newDir, 'index.js'), 'utf8')).toBe('module.exports = 1')
+})
+
+test('importIndexedDir() does not treat zero file IDs as the same file', () => {
+  const tmp = tempDir()
+  const src = path.join(tmp, 'src')
+  const newDir = path.join(tmp, 'dest')
+  fs.mkdirSync(src, { recursive: true })
+  fs.mkdirSync(newDir, { recursive: true })
+  fs.writeFileSync(path.join(src, 'index.js'), 'source')
+  fs.writeFileSync(path.join(newDir, 'index.js'), 'target')
+
+  const originalLstatSync = fs.lstatSync
+  const originalStatSync = gfs.statSync
+  const lstatSync = jest.spyOn(fs, 'lstatSync').mockImplementation(((filePath: fs.PathLike) => Object.assign(
+    originalLstatSync(filePath, { bigint: true }), {
+      dev: 0n,
+      ino: 0n,
+    })) as typeof fs.lstatSync)
+  const statSync = jest.spyOn(gfs, 'statSync').mockImplementation(((filePath: fs.PathLike) => Object.assign(
+    originalStatSync(filePath, { bigint: true }), {
+      dev: 0n,
+      ino: 0n,
+    })) as typeof gfs.statSync)
+  try {
+    importIndexedDir(linkingImporter, newDir, new Map([
+      ['index.js', path.join(src, 'index.js')],
+    ]), { safeToSkip: true })
+  } finally {
+    lstatSync.mockRestore()
+    statSync.mockRestore()
+  }
+
+  expect(fs.readFileSync(path.join(newDir, 'index.js'), 'utf8')).toBe('source')
 })
 
 test('importIndexedDir() adopts a matching file placed by a concurrent repair', async () => {

--- a/pnpm11/fs/indexed-pkg-importer/test/importIndexedDir.test.ts
+++ b/pnpm11/fs/indexed-pkg-importer/test/importIndexedDir.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import util from 'node:util'
 
-import { expect, test } from '@jest/globals'
+import { expect, jest, test } from '@jest/globals'
 import { tempDir } from '@pnpm/prepare'
 
 import { importIndexedDir } from '../src/importIndexedDir.js'
@@ -68,6 +68,63 @@ test('importIndexedDir() safeToSkip repairs a directory damaged after it was com
   importIndexedDir(linkingImporter, newDir, filenames, { safeToSkip: true })
 
   expect(fs.readFileSync(path.join(newDir, 'index.js'), 'utf8')).toBe('module.exports = 1')
+})
+
+test('importIndexedDir() adopts a matching file placed by a concurrent repair', async () => {
+  const tmp = tempDir()
+  const src = path.join(tmp, 'src')
+  fs.mkdirSync(src, { recursive: true })
+  fs.writeFileSync(path.join(src, 'package.json'), '{"name":"pkg"}')
+  fs.writeFileSync(path.join(src, 'index.js'), 'module.exports = 1')
+
+  const newDir = path.join(tmp, 'dest')
+  fs.mkdirSync(newDir, { recursive: true })
+  fs.writeFileSync(path.join(newDir, 'package.json'), '{"name":"pkg"}')
+  fs.writeFileSync(path.join(newDir, 'index.js'), 'damaged')
+
+  const renameSync = jest.spyOn(fs, 'renameSync').mockImplementationOnce((tmpFile, dest) => {
+    fs.copyFileSync(tmpFile, dest)
+    throw Object.assign(new Error('another importer won'), { code: 'EEXIST' })
+  })
+  try {
+    importIndexedDir(linkingImporter, newDir, new Map([
+      ['index.js', path.join(src, 'index.js')],
+      ['package.json', path.join(src, 'package.json')],
+    ]), { safeToSkip: true })
+  } finally {
+    renameSync.mockRestore()
+  }
+
+  expect(fs.readFileSync(path.join(newDir, 'index.js'), 'utf8')).toBe('module.exports = 1')
+  expect(fs.readdirSync(newDir).sort()).toEqual(['index.js', 'package.json'])
+})
+
+test('importIndexedDir() keeps a mismatching destination when its repair rename fails', async () => {
+  const tmp = tempDir()
+  const src = path.join(tmp, 'src')
+  fs.mkdirSync(src, { recursive: true })
+  fs.writeFileSync(path.join(src, 'package.json'), '{"name":"pkg"}')
+  fs.writeFileSync(path.join(src, 'index.js'), 'module.exports = 1')
+
+  const newDir = path.join(tmp, 'dest')
+  fs.mkdirSync(newDir, { recursive: true })
+  fs.writeFileSync(path.join(newDir, 'package.json'), '{"name":"pkg"}')
+  fs.writeFileSync(path.join(newDir, 'index.js'), 'damaged')
+
+  const renameSync = jest.spyOn(fs, 'renameSync').mockImplementationOnce(() => {
+    throw Object.assign(new Error('rename failed'), { code: 'EEXIST' })
+  })
+  try {
+    expect(() => importIndexedDir(linkingImporter, newDir, new Map([
+      ['index.js', path.join(src, 'index.js')],
+      ['package.json', path.join(src, 'package.json')],
+    ]), { safeToSkip: true })).toThrow('rename failed')
+  } finally {
+    renameSync.mockRestore()
+  }
+
+  expect(fs.readFileSync(path.join(newDir, 'index.js'), 'utf8')).toBe('damaged')
+  expect(fs.readdirSync(newDir).sort()).toEqual(['index.js', 'package.json'])
 })
 
 test('importIndexedDir() safeToSkip clears a file where the package needs a directory', async () => {

--- a/pnpm11/store/controller-types/src/index.ts
+++ b/pnpm11/store/controller-types/src/index.ts
@@ -31,7 +31,7 @@ import type {
   TrustPolicy,
 } from '@pnpm/types'
 
-export type { FilesMap, ImportPackageFunction, ImportPackageFunctionAsync, PackageFileInfo, PackageFilesResponse }
+export type { FilesMap, ImportPackageFunction, ImportPackageFunctionAsync, PackageFileInfo, PackageFilesResponse, ResolvedFrom }
 
 export * from '@pnpm/resolving.resolver-base'
 export type { BundledManifest }


### PR DESCRIPTION
## Summary

When two importers reach the same global virtual-store slot at once, the first one populates it in place and only writes the completion marker at the end. The second one arrives while that is happening, sees a directory that exists but has no marker, so its non-destructive rename fails on an occupied target, `is_complete_import` says no, and it drops through to `remove_dir_all`. That removes the files the first importer is still writing, and the final `rmdir` then loses the race against those writes and reports `ENOTEMPTY`.

A safe-to-skip target is content-addressed by its path, so an incomplete one does not have to be removed at all. It now takes the same in-place `populate_dir` repair that the marker-less path already uses for `force: false`, which is non-destructive and converges when both importers run it.

To confirm the diagnosis I ran the scenario with a 600-file package and the second thread held back until the slot appeared: 6 failures in 200 runs on `main` with the exact `RemoveExisting { ... code: 66 }` from the issue, 0 in 400 runs after the change.

Repairing in place has to heal the slot, not just fill in what is missing. The linking tiers report `EEXIST` for a dirent that is already there, so an in-place repair that adopts whatever it finds keeps a file truncated by an interrupted copy — and then puts the completion marker on top of it, so every later install sees a finished slot and never looks again. The destructive path used to hide this by rebuilding the tree.

So the gate is now pnpm's `allFilesMatch` (`fs/indexed-pkg-importer/src/importIndexedDir.ts`) rather than a check that each file exists, and the repair swaps a fresh copy in through a temp sibling for every entry that does not match its store file. An entry that shares the store inode is recognised without a read, so an intact slot still costs two stats per file. The repair also clears a dirent of the wrong kind, which the wipe used to take care of implicitly.

The shared-slot branch moved ahead of the `node_modules` preservation step. A slot repaired in place keeps a nested `node_modules/` by never removing anything, so a package with bundled dependencies no longer falls through to the destructive path this PR exists to avoid.

The regression tests assert the slot directory keeps its inode across a repair, that a damaged file is restored under a linking tier (the earlier tests all used `Copy`, where `fs::copy` overwrites and hides the difference), and that a file the package does not declare is left alone — removing strays from a slot other projects read is the destructive behavior being retired.

## The same fix in the TypeScript CLI

`importIndexedDir` there has its own `safeToSkip`, and both halves of the bug: a slot that fails `allFilesMatch` falls through to `renameOverwriteSync`, which removes the directory a concurrent importer is writing into, and the fast path that writes into a shared slot in place adopts whatever dirent it finds, so a truncated file survives and the completion marker lands on top of it.

A shared target is now populated by whoever wins an exclusive mkdir, adopted by everyone else when it matches, and otherwise repaired entry by entry, each mismatching file swapped in through a temp sibling. Nothing on that path unlinks, so a nested `node_modules/` survives without the staging dance `keepModulesDir` needed.

One addition the Rust side already had: `safeToSkip` is restricted to targets whose path pins their contents, which is what the flag has always asked of its callers. `link.ts` and `deps-restorer` pass `enableGlobalVirtualStore` straight through, so an injected local package — copied into its target at install time, and free to change with no lockfile change — was reaching the mode too. Its stale files still need a rebuild to clear, so `resolvedFrom: 'local-dir'` now takes the staging path, matching pacquet's `source_is_mutable` exclusion.

Fixes pnpm/pnpm#13806

## Squash Commit Body

```text
An importer that finds a shared virtual-store slot occupied but incomplete cannot tell an interrupted import from another importer that is still writing into it. Removing the directory in the second case deletes files that importer is in the middle of creating, and the trailing rmdir then fails with ENOTEMPTY.

Repair an incomplete safe-to-skip target in place instead of removing and swapping it. The mode is only used where the target path uniquely identifies its contents, so there are no stale files to clear, and two importers running the repair against one slot converge on the same tree.

Gate the slot on allFilesMatch rather than on existence, and place every entry that does not match its store file through a temp sibling, so a file left damaged by an interrupted import is healed rather than adopted. Run the whole branch before the node_modules preservation step, since repairing in place already preserves a nested node_modules by never removing anything.

Fixes pnpm/pnpm#13806
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change lands in both stacks: `importIndexedDir` in the TypeScript
  CLI has the same `safeToSkip` mode and the same two problems with it, and
  is fixed the same way here.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13810"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789022216&installation_model_id=426870&pr_number=13810&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13810&signature=6ab751a2d9b2739e1c9e293760b14cf3a2f16e45d8d3a6f607521fef91523eaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Repaired incomplete shared package installations in place without deleting active directories.
  * Replaced damaged files while preserving valid and unrelated content, including nested dependencies.
  * Resolved file-versus-directory conflicts and removed stale files from local installations.
  * Prevented unnecessary changes to complete installations during repair.
  * Improved recovery from interrupted or partially completed package installations.

* **Tests**
  * Added coverage for corrupted files, incomplete installations, directory mismatches, stale content, and structure preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
