### PR TITLE
feat: support --ignore-pnpmfile

### DIFF
--- a/.changeset/ignore-pnpmfile-flag.md
+++ b/.changeset/ignore-pnpmfile-flag.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm install --ignore-pnpmfile` is accepted again. The flag skips every pnpmfile hook for the install: neither the workspace `.pnpmfile.cjs` nor the pnpmfiles of config-dependency plugins are loaded.
+`--ignore-pnpmfile` is accepted again, on every command pnpm takes it on: `install`, `add`, `update`, `dedupe`, `fetch`, `unlink`, `deploy`, `ci`, and `install-test` [#13808](https://github.com/pnpm/pnpm/issues/13808). The flag skips every pnpmfile hook the command would otherwise run: neither the workspace `.pnpmfile.cjs` nor the pnpmfiles of config dependencies are loaded, so no `readPackage`, `updateConfig`, `afterAllResolved`, custom resolver, or custom fetcher runs.

--- a/.changeset/ignore-pnpmfile-flag.md
+++ b/.changeset/ignore-pnpmfile-flag.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm install --ignore-pnpmfile` is accepted again. The flag skips every pnpmfile hook for the install: neither the workspace `.pnpmfile.cjs` nor the pnpmfiles of config-dependency plugins are loaded.

--- a/pnpm/crates/cli/src/cli_args/add.rs
+++ b/pnpm/crates/cli/src/cli_args/add.rs
@@ -159,7 +159,8 @@ pub struct AddArgs {
     /// Force-enable lifecycle scripts for this invocation.
     #[clap(long = "no-ignore-scripts", overrides_with = "ignore_scripts")]
     pub no_ignore_scripts: bool,
-    /// Disable pnpm hooks defined in .pnpmfile.cjs
+    /// Disable pnpm hooks defined in `.pnpmfile.cjs`, including the
+    /// pnpmfiles of config dependencies.
     #[clap(long = "ignore-pnpmfile")]
     pub ignore_pnpmfile: bool,
     /// Reinstall every package the lockfile names: relink packages an

--- a/pnpm/crates/cli/src/cli_args/add.rs
+++ b/pnpm/crates/cli/src/cli_args/add.rs
@@ -159,6 +159,9 @@ pub struct AddArgs {
     /// Force-enable lifecycle scripts for this invocation.
     #[clap(long = "no-ignore-scripts", overrides_with = "ignore_scripts")]
     pub no_ignore_scripts: bool,
+    /// Disable pnpm hooks defined in .pnpmfile.cjs
+    #[clap(long = "ignore-pnpmfile")]
+    pub ignore_pnpmfile: bool,
     /// Reinstall every package the lockfile names: relink packages an
     /// earlier install already materialized, and install optional
     /// dependencies whose `cpu` / `os` / `libc` / `engines` don't match
@@ -174,6 +177,7 @@ impl AddArgs {
             self.no_ignore_scripts,
             config.ignore_scripts,
         );
+        config.ignore_pnpmfile = self.ignore_pnpmfile || config.ignore_pnpmfile;
         config.force = self.force || config.force;
     }
 

--- a/pnpm/crates/cli/src/cli_args/dedupe.rs
+++ b/pnpm/crates/cli/src/cli_args/dedupe.rs
@@ -18,6 +18,7 @@ use crate::{
 use clap::Args;
 use derive_more::{Display, Error};
 use miette::{Context, Diagnostic, IntoDiagnostic};
+use pacquet_config::Config;
 use pacquet_lockfile::{Lockfile, PkgNameVerPeer};
 use pacquet_modules_yaml::{Host, read_modules_manifest};
 use pacquet_package_manager::{
@@ -38,9 +39,18 @@ use tempfile::NamedTempFile;
 pub struct DedupeArgs {
     #[clap(long)]
     pub check: bool,
+
+    /// Disable pnpm hooks defined in `.pnpmfile.cjs`, including the
+    /// pnpmfiles of config dependencies.
+    #[clap(long = "ignore-pnpmfile")]
+    pub ignore_pnpmfile: bool,
 }
 
 impl DedupeArgs {
+    pub(crate) fn apply_cli_config(&self, config: &mut Config) {
+        config.ignore_pnpmfile = self.ignore_pnpmfile || config.ignore_pnpmfile;
+    }
+
     /// Run the deduplication install pipeline. In `--check` mode the method
     /// receives a pre-computed snapshot (`existing`) and drop guard created by
     /// the caller *before* config-dependency steps, so the gate covers any

--- a/pnpm/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_install.rs
@@ -323,6 +323,7 @@ pub(super) fn dedupe<'a>(ctx: &RunCtx<'a>, args: DedupeArgs) -> miette::Result<C
     let config = ctx.config;
     Ok(Box::pin(async move {
         let cfg = config()?;
+        args.apply_cli_config(cfg);
         let (config_root, package_manager_to_sync) =
             derive_config_root_and_package_manager_to_sync(cfg, dir, reporter)
                 .wrap_err("derive workspace root and package manager policy")?;
@@ -420,6 +421,7 @@ pub(super) fn unlink<'a>(ctx: &RunCtx<'a>, args: UnlinkArgs) -> miette::Result<C
     let config = ctx.config;
     Ok(Box::pin(async move {
         let cfg = config()?;
+        args.apply_cli_config(cfg);
         // Strip the matching `link:` overrides; stop early when there is
         // nothing to unlink.
         if !args.strip_link_overrides(cfg, manifest_path)? {

--- a/pnpm/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_install.rs
@@ -85,6 +85,7 @@ pub(super) fn add<'a>(ctx: &RunCtx<'a>, args: AddArgs) -> miette::Result<Command
 pub(super) fn update<'a>(ctx: &RunCtx<'a>, args: UpdateArgs) -> miette::Result<CommandFuture<'a>> {
     if args.global {
         let config = (ctx.global_config)()?;
+        args.apply_cli_config(config);
         return Ok(match ctx.reporter {
             ReporterType::Default | ReporterType::AppendOnly => {
                 Box::pin(args.run_global::<DefaultReporter>(config))
@@ -100,6 +101,7 @@ pub(super) fn update<'a>(ctx: &RunCtx<'a>, args: UpdateArgs) -> miette::Result<C
     let config = ctx.config;
     Ok(Box::pin(async move {
         let cfg = config()?;
+        args.apply_cli_config(cfg);
         let (config_root, package_manager_to_sync) =
             derive_config_root_and_package_manager_to_sync(cfg, dir, reporter)
                 .wrap_err("derive workspace root and package manager policy")?;

--- a/pnpm/crates/cli/src/cli_args/fetch.rs
+++ b/pnpm/crates/cli/src/cli_args/fetch.rs
@@ -11,12 +11,18 @@ pub struct FetchArgs {
     prod: bool,
     #[clap(short = 'D', long)]
     dev: bool,
+
+    /// Disable pnpm hooks defined in `.pnpmfile.cjs`, including the
+    /// pnpmfiles of config dependencies.
+    #[clap(long = "ignore-pnpmfile")]
+    ignore_pnpmfile: bool,
 }
 
 impl FetchArgs {
     pub async fn run<Reporter: self::Reporter + 'static>(self, state: State) -> miette::Result<()> {
         let lockfile_path = state.lockfile_path();
         let mut fetch_config = (*state.config).clone();
+        fetch_config.ignore_pnpmfile = self.ignore_pnpmfile || fetch_config.ignore_pnpmfile;
         fetch_config.virtual_store_only = true;
         fetch_config.enable_modules_dir = true;
         fetch_config.apply_virtual_store_only_derivation();
@@ -30,7 +36,8 @@ impl FetchArgs {
             resolved_packages,
         } = &state;
 
-        let &FetchArgs { prod, dev } = &self;
+        // `ignore_pnpmfile` is already folded into `fetch_config` above.
+        let &FetchArgs { prod, dev, ignore_pnpmfile: _ } = &self;
         let has_both = prod == dev;
         let include_prod = has_both || prod;
         let include_dev = has_both || dev;

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -157,7 +157,8 @@ pub struct InstallArgs {
     #[clap(long = "no-ignore-scripts", overrides_with = "ignore_scripts")]
     pub no_ignore_scripts: bool,
 
-    /// Disable pnpm hooks defined in .pnpmfile.cjs
+    /// Disable pnpm hooks defined in `.pnpmfile.cjs`, including the
+    /// pnpmfiles of config dependencies.
     #[clap(long = "ignore-pnpmfile")]
     pub ignore_pnpmfile: bool,
 

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -157,6 +157,10 @@ pub struct InstallArgs {
     #[clap(long = "no-ignore-scripts", overrides_with = "ignore_scripts")]
     pub no_ignore_scripts: bool,
 
+    /// Disable pnpm hooks defined in .pnpmfile.cjs
+    #[clap(long = "ignore-pnpmfile")]
+    pub ignore_pnpmfile: bool,
+
     /// Which node linker to use: `isolated` (the default, a symlinked
     /// store), `hoisted` (a flat `node_modules`), or `pnp` (Plug'n'Play).
     /// Overrides the configured value.
@@ -267,6 +271,7 @@ impl InstallArgs {
             no_runtime: false,
             ignore_scripts: false,
             no_ignore_scripts: false,
+            ignore_pnpmfile: false,
             node_linker: None,
             offline: false,
             no_offline: false,
@@ -430,13 +435,14 @@ impl InstallArgs {
             verify_deps_before_run_install,
             ignore_manifest_check,
             no_runtime,
-            // The `ignore_scripts` / `offline` / `frozen_store` /
-            // `prefer_offline` flags and their `--no-` inverses are
-            // resolved against config by `apply_install_cli_config` in the
-            // dispatch (`cli_args.rs`), so the install reads them from
-            // `config`, not from here.
+            // The `ignore_scripts` / `ignore_pnpmfile` / `offline` /
+            // `frozen_store` / `prefer_offline` flags and their `--no-`
+            // inverses are resolved against config by
+            // `apply_install_cli_config` in the dispatch (`cli_args.rs`),
+            // so the install reads them from `config`, not from here.
             ignore_scripts: _,
             no_ignore_scripts: _,
+            ignore_pnpmfile: _,
             node_linker,
             offline: _,
             no_offline: _,

--- a/pnpm/crates/cli/src/cli_args/install/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/install/tests.rs
@@ -111,6 +111,19 @@ fn ignore_manifest_check_flag_parses() {
     assert!(parsed.args.ignore_manifest_check, "flag present → true");
 }
 
+/// `--ignore-pnpmfile` parses to `true`. Absent → `false`. The flag is
+/// folded into `config.ignore_pnpmfile` at the dispatch in
+/// `cli_args.rs`, so the install path reads it off the config.
+#[test]
+fn ignore_pnpmfile_flag_parses() {
+    let parsed = InstallArgsHarness::try_parse_from(["pacquet-test"]).expect("parses");
+    assert!(!parsed.args.ignore_pnpmfile, "flag absent → false");
+
+    let parsed = InstallArgsHarness::try_parse_from(["pacquet-test", "--ignore-pnpmfile"])
+        .expect("parses --ignore-pnpmfile");
+    assert!(parsed.args.ignore_pnpmfile, "flag present → true");
+}
+
 #[test]
 fn dry_run_flag_parses() {
     let parsed = InstallArgsHarness::try_parse_from(["pacquet-test"]).expect("parses");

--- a/pnpm/crates/cli/src/cli_args/install/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/install/tests.rs
@@ -111,9 +111,6 @@ fn ignore_manifest_check_flag_parses() {
     assert!(parsed.args.ignore_manifest_check, "flag present → true");
 }
 
-/// `--ignore-pnpmfile` parses to `true`. Absent → `false`. The flag is
-/// folded into `config.ignore_pnpmfile` at the dispatch in
-/// `cli_args.rs`, so the install path reads it off the config.
 #[test]
 fn ignore_pnpmfile_flag_parses() {
     let parsed = InstallArgsHarness::try_parse_from(["pacquet-test"]).expect("parses");

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -674,6 +674,7 @@ pub(crate) fn apply_install_cli_config(cfg: &mut Config, args: &InstallArgs) {
         resolve_bool_override(args.frozen_store, args.no_frozen_store, cfg.frozen_store);
     cfg.ignore_scripts =
         resolve_bool_override(args.ignore_scripts, args.no_ignore_scripts, cfg.ignore_scripts);
+    cfg.ignore_pnpmfile = args.ignore_pnpmfile || cfg.ignore_pnpmfile;
     cfg.force = args.force || cfg.force;
     if let Some(network_concurrency) = args.network_concurrency {
         cfg.network_concurrency = network_concurrency;

--- a/pnpm/crates/cli/src/cli_args/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/tests.rs
@@ -2,12 +2,14 @@ use super::{
     CliArgs,
     add::AddArgs,
     cli_command::{CliCommand, WorkspaceRootError},
+    dedupe::DedupeArgs,
     install::{InstallArgs, resolve_bool_override},
     list::RecursionLimit,
     package_manager::{
         current_source_pnpm_version, package_manager_to_sync, parse_package_manager,
         read_manifest_json,
     },
+    unlink::UnlinkArgs,
 };
 use clap::Parser;
 use pacquet_default_reporter::SummaryScope;
@@ -815,4 +817,70 @@ fn add_ignore_pnpmfile_flag_applies_to_config() {
 
     add_args(&["pacquet", "add", "foo", "--ignore-pnpmfile"]).apply_cli_config(&mut config);
     assert!(config.ignore_pnpmfile, "flag present → config set");
+}
+
+/// The install-family commands pnpm accepts `--ignore-pnpmfile` on.
+/// `remove`, `prune`, `import`, `rebuild`, and `link` reject it there,
+/// so they must reject it here too.
+#[test]
+fn every_command_pnpm_takes_ignore_pnpmfile_on_takes_it() {
+    for argv in [
+        ["pacquet", "install", "--ignore-pnpmfile"].as_slice(),
+        ["pacquet", "add", "foo", "--ignore-pnpmfile"].as_slice(),
+        ["pacquet", "update", "--ignore-pnpmfile"].as_slice(),
+        ["pacquet", "dedupe", "--ignore-pnpmfile"].as_slice(),
+        ["pacquet", "fetch", "--ignore-pnpmfile"].as_slice(),
+        ["pacquet", "unlink", "--ignore-pnpmfile"].as_slice(),
+        ["pacquet", "deploy", "--ignore-pnpmfile", "out"].as_slice(),
+        ["pacquet", "ci", "--ignore-pnpmfile"].as_slice(),
+        ["pacquet", "install-test", "--ignore-pnpmfile"].as_slice(),
+    ] {
+        CliArgs::try_parse_from(argv).unwrap_or_else(|err| panic!("{argv:?} parses: {err}"));
+    }
+
+    for argv in [
+        ["pacquet", "remove", "foo", "--ignore-pnpmfile"].as_slice(),
+        ["pacquet", "prune", "--ignore-pnpmfile"].as_slice(),
+        ["pacquet", "import", "--ignore-pnpmfile"].as_slice(),
+        ["pacquet", "rebuild", "--ignore-pnpmfile"].as_slice(),
+        ["pacquet", "link", "--ignore-pnpmfile"].as_slice(),
+    ] {
+        CliArgs::try_parse_from(argv)
+            .err()
+            .unwrap_or_else(|| panic!("{argv:?} is rejected, as pnpm rejects it"));
+    }
+}
+
+#[test]
+fn dedupe_ignore_pnpmfile_flag_applies_to_config() {
+    let mut config = pacquet_config::Config::default();
+    dedupe_args(&["pacquet", "dedupe"]).apply_cli_config(&mut config);
+    assert!(!config.ignore_pnpmfile, "flag absent → config unchanged");
+
+    dedupe_args(&["pacquet", "dedupe", "--ignore-pnpmfile"]).apply_cli_config(&mut config);
+    assert!(config.ignore_pnpmfile, "flag present → config set");
+}
+
+#[test]
+fn unlink_ignore_pnpmfile_flag_applies_to_config() {
+    let mut config = pacquet_config::Config::default();
+    unlink_args(&["pacquet", "unlink"]).apply_cli_config(&mut config);
+    assert!(!config.ignore_pnpmfile, "flag absent → config unchanged");
+
+    unlink_args(&["pacquet", "unlink", "--ignore-pnpmfile"]).apply_cli_config(&mut config);
+    assert!(config.ignore_pnpmfile, "flag present → config set");
+}
+
+fn dedupe_args(argv: &[&str]) -> DedupeArgs {
+    match CliArgs::try_parse_from(argv).expect("parses").command {
+        CliCommand::Dedupe(dedupe) => dedupe,
+        other => panic!("expected dedupe, got {other:?}"),
+    }
+}
+
+fn unlink_args(argv: &[&str]) -> UnlinkArgs {
+    match CliArgs::try_parse_from(argv).expect("parses").command {
+        CliCommand::Unlink(unlink) => unlink,
+        other => panic!("expected unlink, got {other:?}"),
+    }
 }

--- a/pnpm/crates/cli/src/cli_args/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/tests.rs
@@ -806,3 +806,13 @@ fn config_merged_boolean_negations_parse() {
     assert!(args.no_frozen_store);
     assert!(args.no_ignore_scripts);
 }
+
+#[test]
+fn add_ignore_pnpmfile_flag_applies_to_config() {
+    let mut config = pacquet_config::Config::default();
+    add_args(&["pacquet", "add", "foo"]).apply_cli_config(&mut config);
+    assert!(!config.ignore_pnpmfile, "flag absent → config unchanged");
+
+    add_args(&["pacquet", "add", "foo", "--ignore-pnpmfile"]).apply_cli_config(&mut config);
+    assert!(config.ignore_pnpmfile, "flag present → config set");
+}

--- a/pnpm/crates/cli/src/cli_args/unlink.rs
+++ b/pnpm/crates/cli/src/cli_args/unlink.rs
@@ -12,9 +12,18 @@ use std::path::Path;
 #[derive(Debug, Args)]
 pub struct UnlinkArgs {
     pub package_names: Vec<String>,
+
+    /// Disable pnpm hooks defined in `.pnpmfile.cjs`, including the
+    /// pnpmfiles of config dependencies.
+    #[clap(long = "ignore-pnpmfile")]
+    pub ignore_pnpmfile: bool,
 }
 
 impl UnlinkArgs {
+    pub(crate) fn apply_cli_config(&self, config: &mut Config) {
+        config.ignore_pnpmfile = self.ignore_pnpmfile || config.ignore_pnpmfile;
+    }
+
     /// Strip the matching `link:` overrides from `config` (in memory) and
     /// from `pnpm-workspace.yaml`, returning whether the caller should
     /// reinstall.

--- a/pnpm/crates/cli/src/cli_args/update.rs
+++ b/pnpm/crates/cli/src/cli_args/update.rs
@@ -127,6 +127,10 @@ pub struct UpdateArgs {
     /// changeset generation by default.
     #[clap(long = "no-changeset", overrides_with = "changeset")]
     pub no_changeset: bool,
+
+    /// Disable pnpm hooks defined in .pnpmfile.cjs
+    #[clap(long = "ignore-pnpmfile")]
+    pub ignore_pnpmfile: bool,
 }
 
 /// The option combinations `--workspace` rejects, checked before any
@@ -144,6 +148,10 @@ enum WorkspaceUpdateError {
 }
 
 impl UpdateArgs {
+    pub(crate) fn apply_cli_config(&self, config: &mut Config) {
+        config.ignore_pnpmfile = self.ignore_pnpmfile || config.ignore_pnpmfile;
+    }
+
     pub async fn run<Reporter: self::Reporter + 'static>(
         self,
         mut state: State,

--- a/pnpm/crates/cli/src/cli_args/update.rs
+++ b/pnpm/crates/cli/src/cli_args/update.rs
@@ -128,7 +128,8 @@ pub struct UpdateArgs {
     #[clap(long = "no-changeset", overrides_with = "changeset")]
     pub no_changeset: bool,
 
-    /// Disable pnpm hooks defined in .pnpmfile.cjs
+    /// Disable pnpm hooks defined in `.pnpmfile.cjs`, including the
+    /// pnpmfiles of config dependencies.
     #[clap(long = "ignore-pnpmfile")]
     pub ignore_pnpmfile: bool,
 }

--- a/pnpm/crates/cli/src/cli_args/update/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/update/tests.rs
@@ -113,3 +113,13 @@ fn workspace_option_is_checked_before_anything_is_read() {
         .expect_err("--workspace with --latest");
     assert_eq!(with_latest.to_string(), "Cannot use --latest with --workspace simultaneously");
 }
+
+#[test]
+fn ignore_pnpmfile_flag_applies_to_config() {
+    let mut config = Config::default();
+    update_args(&[]).apply_cli_config(&mut config);
+    assert!(!config.ignore_pnpmfile, "flag absent → config unchanged");
+
+    update_args(&["--ignore-pnpmfile"]).apply_cli_config(&mut config);
+    assert!(config.ignore_pnpmfile, "flag present → config set");
+}

--- a/pnpm/crates/cli/src/config_deps.rs
+++ b/pnpm/crates/cli/src/config_deps.rs
@@ -396,6 +396,9 @@ impl EnvInstallerContext {
 /// pnpm's single loaded hooks object.
 #[must_use]
 pub fn resolve_pnpmfile_paths(config: &Config, root_dir: &Path) -> Vec<PathBuf> {
+    if config.ignore_pnpmfile {
+        return Vec::new();
+    }
     let config_modules_dir = root_dir.join("node_modules").join(".pnpm-config");
     let mut pnpmfiles: Vec<PathBuf> = match config.config_dependencies.as_ref() {
         Some(deps) => finder::calc_pnpmfile_paths_of_plugin_deps(

--- a/pnpm/crates/cli/tests/suite/config_dependencies.rs
+++ b/pnpm/crates/cli/tests/suite/config_dependencies.rs
@@ -4,6 +4,7 @@ use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pacquet_config::WorkspaceSettings;
 use pacquet_lockfile::EnvLockfile;
+use pacquet_modules_yaml::{Host, NodeLinker, read_modules_manifest};
 use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
 #[cfg(unix)]
 use pacquet_testing_utils::fs::is_symlink_or_junction;
@@ -320,4 +321,53 @@ fn update_config_observes_an_empty_cli_store_dir() {
     );
 
     drop(root);
+}
+
+/// `--ignore-pnpmfile` empties the whole pnpmfile set the config layer
+/// resolves, not just the workspace `.pnpmfile.cjs`: a config
+/// dependency's plugin pnpmfile stops contributing its `updateConfig`
+/// hook too. `@pnpm/plugin-pnpmfile` flips the node linker to
+/// `hoisted`, and the modules manifest records the linker the install
+/// ran with.
+#[test]
+fn ignore_pnpmfile_skips_a_config_dependency_plugin_pnpmfile() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "dependencies": { "@pnpm.e2e/foo": "100.0.0" } }).to_string(),
+    )
+    .expect("write package.json");
+    let yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut yaml = fs::read_to_string(&yaml_path).expect("read pnpm-workspace.yaml");
+    yaml.push_str("\nconfigDependencies:\n  '@pnpm/plugin-pnpmfile': 1.0.0\n");
+    fs::write(&yaml_path, yaml).expect("write pnpm-workspace.yaml");
+
+    let recorded_node_linker = || {
+        read_modules_manifest::<Host>(&workspace.join("node_modules"))
+            .expect("read the modules manifest")
+            .expect("the install wrote a modules manifest")
+            .node_linker
+    };
+
+    pacquet_at(&workspace).with_args(["install", "--ignore-pnpmfile"]).assert().success();
+    assert_eq!(
+        recorded_node_linker(),
+        Some(NodeLinker::Isolated),
+        "the plugin's updateConfig hook must not reach the install",
+    );
+
+    // Install again with the plugin honored, so the assertion above
+    // cannot pass on a fixture whose hook never ran.
+    fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
+    pacquet_at(&workspace).with_arg("install").assert().success();
+    assert_eq!(
+        recorded_node_linker(),
+        Some(NodeLinker::Hoisted),
+        "without the flag the plugin's updateConfig hook sets the linker",
+    );
+
+    drop((root, mock_instance));
 }

--- a/pnpm/crates/cli/tests/suite/custom_fetchers.rs
+++ b/pnpm/crates/cli/tests/suite/custom_fetchers.rs
@@ -130,3 +130,67 @@ fn custom_typed_resolution_without_a_fetcher_fails_the_install() {
 
     drop((root, mock_instance)); // cleanup
 }
+
+/// `pnpm fetch` takes `--ignore-pnpmfile` too, and its frozen path is
+/// the one that loads the custom fetchers. Without a fetcher the
+/// custom-typed resolution the lockfile records cannot be materialized,
+/// so the flag turns a working fetch into the same loud failure a
+/// missing `fetchers` export produces.
+#[test]
+fn ignore_pnpmfile_skips_the_custom_fetcher_on_fetch() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_manifest(&workspace);
+    fs::write(workspace.join(".pnpmfile.cjs"), custom_type_pnpmfile(&mock_instance.url(), true))
+        .expect("write pnpmfile");
+    pacquet.with_arg("install").assert().success();
+    fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
+
+    let output =
+        pacquet_at(&workspace).with_args(["fetch", "--ignore-pnpmfile"]).assert().failure();
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr).into_owned();
+    assert!(
+        stderr.contains(r#"Cannot fetch dependency with custom resolution type "custom:e2e""#),
+        "stderr: {stderr}",
+    );
+
+    // The same fetch with the pnpmfile honored, so the assertion above
+    // cannot pass on a fixture that could never fetch.
+    pacquet_at(&workspace).with_arg("fetch").assert().success();
+
+    drop((root, mock_instance)); // cleanup
+}
+
+/// The resolver half of the same pnpmfile: with `--ignore-pnpmfile` the
+/// custom resolver never claims the dependency, so the install resolves
+/// the version the manifest asks for instead of the one the resolver
+/// substitutes.
+#[test]
+fn ignore_pnpmfile_skips_the_custom_resolver_on_install() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_manifest(&workspace);
+    fs::write(workspace.join(".pnpmfile.cjs"), custom_type_pnpmfile(&mock_instance.url(), true))
+        .expect("write pnpmfile");
+
+    pacquet.with_args(["install", "--ignore-pnpmfile"]).assert().success();
+    assert_eq!(installed_version(&workspace), "100.0.0");
+    let lockfile = fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read lockfile");
+    assert!(
+        !lockfile.contains("type: custom:e2e"),
+        "the custom resolver must not reach the lockfile: {lockfile}",
+    );
+
+    // Resolve again with the pnpmfile honored, so the assertions above
+    // cannot pass on a fixture whose resolver never worked.
+    fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
+    fs::remove_file(workspace.join("pnpm-lock.yaml")).expect("remove pnpm-lock.yaml");
+    pacquet_at(&workspace).with_arg("install").assert().success();
+    assert_eq!(installed_version(&workspace), "100.1.0");
+
+    drop((root, mock_instance)); // cleanup
+}

--- a/pnpm/crates/cli/tests/suite/install.rs
+++ b/pnpm/crates/cli/tests/suite/install.rs
@@ -1955,6 +1955,53 @@ fn an_unmigrated_package_json_pnpm_field_is_not_reported() {
     drop(root);
 }
 
+/// `--ignore-pnpmfile` disables the hooks the workspace pnpmfile
+/// exports, so an install that passes it resolves the manifest as
+/// written and drops what a `readPackage` hook injected.
+#[test]
+fn ignore_pnpmfile_skips_the_read_package_hook() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join(".pnpmfile.cjs"),
+        r"module.exports = { hooks: { readPackage: (pkg) => {
+            if (pkg.name === '@pnpm.e2e/pkg-with-1-dep') {
+                pkg.dependencies['is-positive'] = '1.0.0';
+            }
+            return pkg;
+        } } }",
+    )
+    .expect("write pnpmfile");
+    fs::write(
+        workspace.join("package.json"),
+        r#"{"dependencies":{"@pnpm.e2e/pkg-with-1-dep":"100.0.0"}}"#,
+    )
+    .expect("write package.json");
+
+    let hook_applied = || {
+        pacquet_lockfile::Lockfile::load_wanted_from_dir(&workspace)
+            .expect("load wanted lockfile")
+            .expect("wanted lockfile")
+            .packages
+            .expect("packages")
+            .keys()
+            .any(|key| key.to_string().starts_with("is-positive@"))
+    };
+
+    pacquet.with_args(["install", "--lockfile-only", "--ignore-pnpmfile"]).assert().success();
+    assert!(!hook_applied(), "--ignore-pnpmfile resolves without the hook's dependency");
+
+    // Resolve the same project again with the hook honored, so the
+    // assertion above cannot pass on a fixture that never worked.
+    fs::remove_file(workspace.join("pnpm-lock.yaml")).expect("remove pnpm-lock.yaml");
+    pacquet_in(&workspace).with_args(["install", "--lockfile-only"]).assert().success();
+    assert!(hook_applied(), "without the flag the hook injects its dependency");
+
+    drop((root, mock_instance));
+}
+
 /// `virtualStoreOnly` populates the virtual store and creates no
 /// importer links. `.pnp.cjs` is how a `PnP` project resolves, so it is a
 /// project-level artifact of the same kind and must not be written

--- a/pnpm/crates/cli/tests/suite/install.rs
+++ b/pnpm/crates/cli/tests/suite/install.rs
@@ -1964,6 +1964,123 @@ fn ignore_pnpmfile_skips_the_read_package_hook() {
         CommandTempCwd::init().add_mocked_registry();
     let AddMockedRegistry { mock_instance, .. } = npmrc_info;
 
+    write_read_package_pnpmfile(&workspace);
+    fs::write(
+        workspace.join("package.json"),
+        r#"{"dependencies":{"@pnpm.e2e/pkg-with-1-dep":"100.0.0"}}"#,
+    )
+    .expect("write package.json");
+
+    pacquet.with_args(["install", "--lockfile-only", "--ignore-pnpmfile"]).assert().success();
+    assert!(
+        !read_package_hook_applied(&workspace),
+        "--ignore-pnpmfile resolves without the hook's dependency",
+    );
+
+    // Resolve the same project again with the hook honored, so the
+    // assertion above cannot pass on a fixture that never worked.
+    fs::remove_file(workspace.join("pnpm-lock.yaml")).expect("remove pnpm-lock.yaml");
+    pacquet_in(&workspace).with_args(["install", "--lockfile-only"]).assert().success();
+    assert!(
+        read_package_hook_applied(&workspace),
+        "without the flag the hook injects its dependency",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// `add` and `update` each merge their own CLI flags into the config,
+/// on a dispatch path `install` never takes.
+#[test]
+fn ignore_pnpmfile_skips_the_read_package_hook_on_add_and_update() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_read_package_pnpmfile(&workspace);
+    fs::write(workspace.join("package.json"), "{}").expect("write package.json");
+
+    pacquet
+        .with_args([
+            "add",
+            "@pnpm.e2e/pkg-with-1-dep@100.0.0",
+            "--lockfile-only",
+            "--ignore-pnpmfile",
+        ])
+        .assert()
+        .success();
+    assert!(!read_package_hook_applied(&workspace), "add resolves without the hook's dependency");
+
+    pacquet_in(&workspace)
+        .with_args(["update", "@pnpm.e2e/pkg-with-1-dep", "--lockfile-only", "--ignore-pnpmfile"])
+        .assert()
+        .success();
+    assert!(
+        !read_package_hook_applied(&workspace),
+        "update resolves without the hook's dependency",
+    );
+
+    // Re-resolve with the hook honored, so the assertions above cannot
+    // pass on a fixture that never worked.
+    fs::remove_file(workspace.join("pnpm-lock.yaml")).expect("remove pnpm-lock.yaml");
+    pacquet_in(&workspace)
+        .with_args(["update", "@pnpm.e2e/pkg-with-1-dep", "--lockfile-only"])
+        .assert()
+        .success();
+    assert!(
+        read_package_hook_applied(&workspace),
+        "without the flag the hook injects its dependency",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// `readPackage` is loaded off the install's own pnpmfile handle, while
+/// `updateConfig` runs earlier, off the pnpmfile set the config layer
+/// resolves. `--ignore-pnpmfile` has to empty that set too, or the
+/// install still runs on a hook-rewritten config.
+#[test]
+fn ignore_pnpmfile_skips_the_update_config_hook() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join(".pnpmfile.cjs"),
+        "module.exports = { hooks: { updateConfig (config) { config.autoInstallPeers = false; return config } } }\n",
+    )
+    .expect("write pnpmfile");
+    fs::write(
+        workspace.join("package.json"),
+        r#"{"dependencies":{"@pnpm.e2e/pkg-with-1-dep":"100.0.0"}}"#,
+    )
+    .expect("write package.json");
+
+    let recorded_auto_install_peers = || {
+        pacquet_lockfile::Lockfile::load_wanted_from_dir(&workspace)
+            .expect("load wanted lockfile")
+            .expect("wanted lockfile")
+            .settings
+            .expect("recorded settings")
+            .auto_install_peers
+    };
+
+    pacquet.with_args(["install", "--lockfile-only", "--ignore-pnpmfile"]).assert().success();
+    assert!(recorded_auto_install_peers(), "--ignore-pnpmfile installs on the unhooked config");
+
+    // Resolve the same project again with the hook honored, so the
+    // assertion above cannot pass on a fixture that never worked.
+    fs::remove_file(workspace.join("pnpm-lock.yaml")).expect("remove pnpm-lock.yaml");
+    pacquet_in(&workspace).with_args(["install", "--lockfile-only"]).assert().success();
+    assert!(!recorded_auto_install_peers(), "without the flag the hook rewrites the config");
+
+    drop((root, mock_instance));
+}
+
+/// A workspace pnpmfile whose single `readPackage` hook is observable in
+/// the lockfile: it gives `@pnpm.e2e/pkg-with-1-dep` a dependency the
+/// published package doesn't declare.
+fn write_read_package_pnpmfile(workspace: &Path) {
     fs::write(
         workspace.join(".pnpmfile.cjs"),
         r"module.exports = { hooks: { readPackage: (pkg) => {
@@ -1974,32 +2091,16 @@ fn ignore_pnpmfile_skips_the_read_package_hook() {
         } } }",
     )
     .expect("write pnpmfile");
-    fs::write(
-        workspace.join("package.json"),
-        r#"{"dependencies":{"@pnpm.e2e/pkg-with-1-dep":"100.0.0"}}"#,
-    )
-    .expect("write package.json");
+}
 
-    let hook_applied = || {
-        pacquet_lockfile::Lockfile::load_wanted_from_dir(&workspace)
-            .expect("load wanted lockfile")
-            .expect("wanted lockfile")
-            .packages
-            .expect("packages")
-            .keys()
-            .any(|key| key.to_string().starts_with("is-positive@"))
-    };
-
-    pacquet.with_args(["install", "--lockfile-only", "--ignore-pnpmfile"]).assert().success();
-    assert!(!hook_applied(), "--ignore-pnpmfile resolves without the hook's dependency");
-
-    // Resolve the same project again with the hook honored, so the
-    // assertion above cannot pass on a fixture that never worked.
-    fs::remove_file(workspace.join("pnpm-lock.yaml")).expect("remove pnpm-lock.yaml");
-    pacquet_in(&workspace).with_args(["install", "--lockfile-only"]).assert().success();
-    assert!(hook_applied(), "without the flag the hook injects its dependency");
-
-    drop((root, mock_instance));
+fn read_package_hook_applied(workspace: &Path) -> bool {
+    pacquet_lockfile::Lockfile::load_wanted_from_dir(workspace)
+        .expect("load wanted lockfile")
+        .expect("wanted lockfile")
+        .packages
+        .expect("packages")
+        .keys()
+        .any(|key| key.to_string().starts_with("is-positive@"))
 }
 
 /// `virtualStoreOnly` populates the virtual store and creates no

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -1515,6 +1515,16 @@ pub struct Config {
     /// when set, leaving `ignoredBuilds` empty. Default `false`.
     pub ignore_scripts: bool,
 
+    /// `--ignore-pnpmfile`. When `true`, no pnpmfile hooks run: neither
+    /// the workspace-root `.pnpmfile.{cjs,mjs}` nor the pnpmfiles of
+    /// config-dependency plugins are loaded, so `readPackage`,
+    /// `updateConfig`, `afterAllResolved`, custom resolvers and custom
+    /// fetchers are all skipped. A CLI-only boolean: pnpm excludes
+    /// `ignore-pnpmfile` from its config-file keys, so the yaml / env
+    /// overlay never populates it — the CLI layer sets it from the flag.
+    /// Default `false`.
+    pub ignore_pnpmfile: bool,
+
     /// `gitChecks` (`--no-git-checks`). When `true` (the default),
     /// `pnpm publish` verifies the git working tree is clean, on the
     /// expected branch, and up to date with the remote before publishing.

--- a/pnpm/crates/deps-restorer/src/install_frozen_lockfile.rs
+++ b/pnpm/crates/deps-restorer/src/install_frozen_lockfile.rs
@@ -594,7 +594,11 @@ where
             .await
             .map_err(InstallFrozenLockfileError::LockfileVerification)
         };
-        let custom_fetcher_picker = load_custom_fetcher_picker(workspace_root).await?;
+        let custom_fetcher_picker = if config.ignore_pnpmfile {
+            None
+        } else {
+            load_custom_fetcher_picker(workspace_root).await?
+        };
         let create_virtual_store_fut = async {
             CreateVirtualStore {
                 http_client,

--- a/pnpm/crates/deps-restorer/src/install_package_from_registry/tests.rs
+++ b/pnpm/crates/deps-restorer/src/install_package_from_registry/tests.rs
@@ -118,6 +118,7 @@ fn create_config(
         dangerously_allow_all_builds: false,
         strict_dep_builds: true,
         ignore_scripts: false,
+        ignore_pnpmfile: false,
         git_checks: true,
         scripts_prepend_node_path: Default::default(),
         enable_pre_post_scripts: false,

--- a/pnpm/crates/package-manager/src/install/run.rs
+++ b/pnpm/crates/package-manager/src/install/run.rs
@@ -441,8 +441,11 @@ where
         // costs a `stat`. The Node worker only starts if a gate has to
         // ask whether the pnpmfile exports hooks. The handle is handed to
         // the resolve path below so an install spawns at most one.
-        let pnpmfile_hook = pnpmfile_hook_override
-            .or_else(|| pacquet_hooks::finder::load_pnpmfile(&workspace_root));
+        let pnpmfile_hook = pnpmfile_hook_override.or_else(|| {
+            (!config.ignore_pnpmfile)
+                .then(|| pacquet_hooks::finder::load_pnpmfile(&workspace_root))
+                .flatten()
+        });
 
         // pnpm's `getContext` runs `readPackage` over every project
         // manifest before anything reads it, so a hook that rewrites a
@@ -795,6 +798,7 @@ where
                     // lockfile). A throwing hook aborts the install.
                     Ok(()) => {
                         lockfile_synthesized_from_current
+                            || config.ignore_pnpmfile
                             || !crate::check_custom_resolver_force_resolve::force_resolve_from_pnpmfile(
                                 lockfile,
                                 &workspace_root,

--- a/pnpm/crates/package-manager/src/install/workspace_state.rs
+++ b/pnpm/crates/package-manager/src/install/workspace_state.rs
@@ -563,7 +563,7 @@ pub(crate) fn build_workspace_state(
         )
         .unwrap_or_else(now_millis),
         projects: build_projects_map(project_manifests),
-        pnpmfiles: crate::optimistic_repeat_install::current_pnpmfiles(config, workspace_root),
+        pnpmfiles: crate::optimistic_repeat_install::current_pnpmfiles(workspace_root, config),
         filtered_install,
         config_dependencies: config.config_dependencies.clone(),
         // Settings construction is shared with

--- a/pnpm/crates/package-manager/src/install/workspace_state.rs
+++ b/pnpm/crates/package-manager/src/install/workspace_state.rs
@@ -563,7 +563,7 @@ pub(crate) fn build_workspace_state(
         )
         .unwrap_or_else(now_millis),
         projects: build_projects_map(project_manifests),
-        pnpmfiles: crate::optimistic_repeat_install::current_pnpmfiles(workspace_root),
+        pnpmfiles: crate::optimistic_repeat_install::current_pnpmfiles(config, workspace_root),
         filtered_install,
         config_dependencies: config.config_dependencies.clone(),
         // Settings construction is shared with

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolver_setup.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolver_setup.rs
@@ -321,8 +321,11 @@ pub(super) async fn build_resolver_chain<Reporter: pacquet_reporter::Reporter + 
         retry_opts: crate::retry_config::retry_opts_from_config(config),
     };
 
-    let pnpmfile_hook =
-        pnpmfile_hook_override.or_else(|| pacquet_hooks::finder::load_pnpmfile(lockfile_dir));
+    let pnpmfile_hook = pnpmfile_hook_override.or_else(|| {
+        (!config.ignore_pnpmfile)
+            .then(|| pacquet_hooks::finder::load_pnpmfile(lockfile_dir))
+            .flatten()
+    });
     let custom_resolvers: Vec<Arc<dyn pacquet_hooks::CustomResolver>> =
         if let Some(ref hook) = pnpmfile_hook {
             hook.get_custom_resolvers().await.map_err(|err| {

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
@@ -572,7 +572,7 @@ fn patches_modified_since(workspace_root: &Path, config: &Config, cutoff_ms: i64
 /// `config_dependencies` comparison instead. An install that ignores
 /// the pnpmfile records none, so the next install that honors it again
 /// sees the list change and re-validates.
-pub(crate) fn current_pnpmfiles(config: &Config, workspace_root: &Path) -> Vec<String> {
+pub(crate) fn current_pnpmfiles(workspace_root: &Path, config: &Config) -> Vec<String> {
     if config.ignore_pnpmfile {
         return Vec::new();
     }
@@ -604,7 +604,7 @@ fn pnpmfiles_drift(
     previous: &[String],
     cutoff_ms: i64,
 ) -> Option<String> {
-    let current = current_pnpmfiles(config, workspace_root);
+    let current = current_pnpmfiles(workspace_root, config);
     if current != previous {
         return Some("The list of pnpmfiles changed.".to_string());
     }

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
@@ -283,7 +283,12 @@ pub(crate) fn check_optimistic_repeat_install_ignoring(
     // resolution (readPackage rewrites, custom resolvers, a
     // `shouldRefreshResolution` verdict) without touching any manifest,
     // so it must defeat the mtime fast path.
-    if pnpmfiles_modified_since(workspace_root, &state.pnpmfiles, state.last_validated_timestamp) {
+    if pnpmfiles_modified_since(
+        workspace_root,
+        config,
+        &state.pnpmfiles,
+        state.last_validated_timestamp,
+    ) {
         return Decision::Skipped { reason: "a pnpmfile changed since the last validation" };
     }
 
@@ -564,8 +569,13 @@ fn patches_modified_since(workspace_root: &Path, config: &Config, cutoff_ms: i64
 /// The pnpmfile list recorded in the workspace state and compared by
 /// the freshness check: today just the workspace pnpmfile.
 /// Config-dependency plugin pnpmfiles are tracked via the
-/// `config_dependencies` comparison instead.
-pub(crate) fn current_pnpmfiles(workspace_root: &Path) -> Vec<String> {
+/// `config_dependencies` comparison instead. An install that ignores
+/// the pnpmfile records none, so the next install that honors it again
+/// sees the list change and re-validates.
+pub(crate) fn current_pnpmfiles(config: &Config, workspace_root: &Path) -> Vec<String> {
+    if config.ignore_pnpmfile {
+        return Vec::new();
+    }
     pacquet_hooks::finder::find_pnpmfile(workspace_root)
         .map(|path| path.to_string_lossy().into_owned())
         .into_iter()
@@ -576,15 +586,25 @@ pub(crate) fn current_pnpmfiles(workspace_root: &Path) -> Vec<String> {
 /// recorded pnpmfile list must match the current one, every recorded
 /// pnpmfile must still exist, and none may be newer than the last
 /// validation.
-fn pnpmfiles_modified_since(workspace_root: &Path, previous: &[String], cutoff_ms: i64) -> bool {
-    pnpmfiles_drift(workspace_root, previous, cutoff_ms).is_some()
+fn pnpmfiles_modified_since(
+    workspace_root: &Path,
+    config: &Config,
+    previous: &[String],
+    cutoff_ms: i64,
+) -> bool {
+    pnpmfiles_drift(workspace_root, config, previous, cutoff_ms).is_some()
 }
 
 /// [`pnpmfiles_modified_since`] with the drift spelled out in pnpm's
 /// issue wording, for the verify-deps-before-run gate's user-facing
 /// messages.
-fn pnpmfiles_drift(workspace_root: &Path, previous: &[String], cutoff_ms: i64) -> Option<String> {
-    let current = current_pnpmfiles(workspace_root);
+fn pnpmfiles_drift(
+    workspace_root: &Path,
+    config: &Config,
+    previous: &[String],
+    cutoff_ms: i64,
+) -> Option<String> {
+    let current = current_pnpmfiles(config, workspace_root);
     if current != previous {
         return Some("The list of pnpmfiles changed.".to_string());
     }

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/deps_status.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/deps_status.rs
@@ -117,7 +117,7 @@ pub fn check_deps_status_before_run(
         return outdated("Patches were modified".to_string());
     }
     if let Some(issue) =
-        pnpmfiles_drift(workspace_root, &state.pnpmfiles, state.last_validated_timestamp)
+        pnpmfiles_drift(workspace_root, config, &state.pnpmfiles, state.last_validated_timestamp)
     {
         return outdated(issue);
     }

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
@@ -127,7 +127,7 @@ fn returns_skipped_when_a_pnpmfile_is_modified() {
         now_millis(),
         current_settings(config, pacquet_config::NodeLinker::Isolated, isolated_included(), None),
         projects,
-        current_pnpmfiles(dir.path()),
+        current_pnpmfiles(config, dir.path()),
     );
     sleep(Duration::from_millis(20));
     fs::write(&pnpmfile, "module.exports = { hooks: {} }\n").expect("modify pnpmfile");

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
@@ -127,7 +127,7 @@ fn returns_skipped_when_a_pnpmfile_is_modified() {
         now_millis(),
         current_settings(config, pacquet_config::NodeLinker::Isolated, isolated_included(), None),
         projects,
-        current_pnpmfiles(config, dir.path()),
+        current_pnpmfiles(dir.path(), config),
     );
     sleep(Duration::from_millis(20));
     fs::write(&pnpmfile, "module.exports = { hooks: {} }\n").expect("modify pnpmfile");


### PR DESCRIPTION
## Summary

pnpm accepts `--ignore-pnpmfile` on `install`, `add`, `update`, `dedupe`, `fetch`, `unlink`, `deploy`, `ci`, and `install-test`. pacquet never grew the flag, so `pnpm install --ignore-pnpmfile` on 12.0.0-rc.3 dies in argument parsing. Renovate passes that flag unconditionally whenever scripts are disabled, so a repository that moves to pnpm 12 stops getting lockfile updates entirely.

This adds the flag and makes it skip every pnpmfile hook the command would otherwise load: the workspace `.pnpmfile.{cjs,mjs}` and the pnpmfiles of config-dependency plugins, which covers `readPackage`, `updateConfig`, `afterAllResolved`, custom resolvers and custom fetchers.

`remove`, `prune`, `import`, `rebuild`, and `link` reject `--ignore-pnpmfile` in pnpm — their option sets never pull it in — so they keep rejecting it here. A test pins the inventory in both directions so neither list can drift.

Closes pnpm/pnpm#13808.

## Squash Commit Body

```text
pnpm declares `--ignore-pnpmfile` on every install-family command whose
option set is built from `install`'s: `add` and `update` name it directly,
`dedupe` omits only `--frozen-lockfile` from it, and `fetch` and `unlink`
re-export it whole. pacquet declared it nowhere, so clap rejected the
argument before the install started.

`ignorePnpmfile` sits in pnpm's `excludedPnpmKeys`, so it is a CLI-only
boolean rather than a config-file key. It lands on the install, add,
update, dedupe, fetch, and unlink argument sets, is folded into `Config`
where each of those already merges its CLI flags, and gates the four
places an install reaches for a pnpmfile: the `readPackage` and checksum
handle in `install/run.rs`, the custom-resolver load in
`resolver_setup.rs`, the custom-fetcher load on the frozen path, and
`resolve_pnpmfile_paths`, which feeds both the `updateConfig` hook and the
plugin pnpmfiles of config dependencies. The `shouldRefreshResolution`
probe that can push a frozen install onto the resolve path is skipped for
the same reason. `deploy`, `ci`, and `install-test` embed `InstallArgs`,
so they inherit the flag.

The workspace state records the pnpmfiles an install honored, so a run
that ignores them records none. A later run that honors them again sees
the list change and re-validates instead of trusting the mtime fast path.

Only pacquet changes: the TypeScript CLI already has the flag.

Closes pnpm/pnpm#13808.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Description updated by an agent (Claude Code, claude-opus-5) after review fixes and the `dedupe` / `fetch` / `unlink` parity commits were pushed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `--ignore-pnpmfile` option to installation, fetching, adding, updating, deduplication, and unlink commands.
  * Package operations can skip workspace and configuration-dependent pnpmfile hooks.
  * Lockfile-only and frozen-lockfile operations respect the option.

* **Bug Fixes**
  * Prevented ignored pnpmfile hooks from affecting dependency resolution, custom fetchers, or lockfile contents.

* **Tests**
  * Added coverage confirming default behavior and support across applicable commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->