### PR TITLE
fix(change): exit cleanly when an interactive prompt is canceled

### DIFF
--- a/.changeset/change-prompt-cancel.md
+++ b/.changeset/change-prompt-cancel.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/releasing.commands": patch
+"pnpm": patch
+---
+
+Canceling a `pnpm change` prompt with Ctrl-c no longer prints a stack trace. It reports `Change canceled` and exits with a success status, like the other interactive commands [#13814](https://github.com/pnpm/pnpm/issues/13814).

--- a/pnpm11/releasing/commands/src/change/index.ts
+++ b/pnpm11/releasing/commands/src/change/index.ts
@@ -1,6 +1,7 @@
 import { checkbox, input, Separator } from '@inquirer/prompts'
 import type { Config } from '@pnpm/config.reader'
 import { PnpmError } from '@pnpm/error'
+import { globalInfo } from '@pnpm/logger'
 import {
   assembleReleasePlan,
   BUMP_TYPES,
@@ -84,7 +85,17 @@ export async function handler (opts: ChangeCommandOptions, params: string[]): Pr
   if (params.length === 1 && params[0] === 'status' && opts.bump == null && opts.summary == null) {
     return renderStatus(workspaceDir, opts)
   }
-  return recordChange(workspaceDir, opts, params)
+  try {
+    return await recordChange(workspaceDir, opts, params)
+  } catch (err: unknown) {
+    // Cancelling a prompt with Ctrl-c is how the user abandons the intent,
+    // not an error: report it and leave with a success status.
+    if (err instanceof Error && err.name === 'ExitPromptError') {
+      globalInfo('Change canceled')
+      process.exit(0)
+    }
+    throw err
+  }
 }
 
 async function recordChange (workspaceDir: string, opts: ChangeCommandOptions, params: string[]): Promise<string> {

--- a/pnpm11/releasing/commands/src/change/index.ts
+++ b/pnpm11/releasing/commands/src/change/index.ts
@@ -1,3 +1,5 @@
+import util from 'node:util'
+
 import { checkbox, input, Separator } from '@inquirer/prompts'
 import type { Config } from '@pnpm/config.reader'
 import { PnpmError } from '@pnpm/error'
@@ -88,9 +90,7 @@ export async function handler (opts: ChangeCommandOptions, params: string[]): Pr
   try {
     return await recordChange(workspaceDir, opts, params)
   } catch (err: unknown) {
-    // Cancelling a prompt with Ctrl-c is how the user abandons the intent,
-    // not an error: report it and leave with a success status.
-    if (err instanceof Error && err.name === 'ExitPromptError') {
+    if (util.types.isNativeError(err) && err.name === 'ExitPromptError') {
       globalInfo('Change canceled')
       process.exit(0)
     }

--- a/pnpm11/releasing/commands/test/change/cancel.test.ts
+++ b/pnpm11/releasing/commands/test/change/cancel.test.ts
@@ -1,0 +1,65 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, expect, it, jest } from '@jest/globals'
+
+jest.unstable_mockModule('@inquirer/prompts', () => {
+  class Separator {
+    separator: string
+    readonly type = 'separator' as const
+    constructor (separator: string) {
+      this.separator = separator
+    }
+  }
+  return {
+    Separator,
+    checkbox: jest.fn(),
+    confirm: jest.fn(),
+    input: jest.fn(),
+    password: jest.fn(),
+    select: jest.fn(),
+  }
+})
+const { checkbox } = await import('@inquirer/prompts')
+const { change } = await import('../../src/index.js')
+
+const mockCheckbox = jest.mocked(checkbox)
+
+let tempDir: string
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-change-cancel-test-'))
+  fs.writeFileSync(path.join(tempDir, 'pnpm-workspace.yaml'), 'packages:\n  - packages/*\n')
+})
+
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true })
+  mockCheckbox.mockReset()
+})
+
+it('change leaves without an error when the prompt is canceled', async () => {
+  const rootDir = path.join(tempDir, 'packages', 'lib')
+  fs.mkdirSync(rootDir, { recursive: true })
+  const manifest = { name: 'lib', version: '1.0.0' }
+  fs.writeFileSync(path.join(rootDir, 'package.json'), JSON.stringify(manifest, null, 2))
+
+  const canceled = new Error('User force closed the prompt')
+  canceled.name = 'ExitPromptError'
+  mockCheckbox.mockRejectedValue(canceled)
+  // `process.exit()` never returns in production, so the spy throws to stop
+  // the handler where the real call would.
+  const exited = new Error('process.exit')
+  const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
+    throw exited
+  })
+
+  try {
+    await expect(
+      change.handler({ dir: tempDir, workspaceDir: tempDir, allProjects: [{ rootDir, manifest }] } as any, []) // eslint-disable-line @typescript-eslint/no-explicit-any
+    ).rejects.toBe(exited)
+    expect(exitSpy).toHaveBeenCalledWith(0)
+  } finally {
+    exitSpy.mockRestore()
+  }
+})

--- a/pnpm11/releasing/commands/test/change/cancel.test.ts
+++ b/pnpm11/releasing/commands/test/change/cancel.test.ts
@@ -21,45 +21,70 @@ jest.unstable_mockModule('@inquirer/prompts', () => {
     select: jest.fn(),
   }
 })
-const { checkbox } = await import('@inquirer/prompts')
+const { checkbox, input } = await import('@inquirer/prompts')
 const { change } = await import('../../src/index.js')
 
 const mockCheckbox = jest.mocked(checkbox)
+const mockInput = jest.mocked(input)
 
 let tempDir: string
+let opts: object
 
 beforeEach(() => {
   tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-change-cancel-test-'))
   fs.writeFileSync(path.join(tempDir, 'pnpm-workspace.yaml'), 'packages:\n  - packages/*\n')
+  const rootDir = path.join(tempDir, 'packages', 'lib')
+  fs.mkdirSync(rootDir, { recursive: true })
+  const manifest = { name: 'lib', version: '1.0.0' }
+  fs.writeFileSync(path.join(rootDir, 'package.json'), JSON.stringify(manifest, null, 2))
+  opts = { dir: tempDir, workspaceDir: tempDir, allProjects: [{ rootDir, manifest }] }
 })
 
 afterEach(() => {
   fs.rmSync(tempDir, { recursive: true, force: true })
   mockCheckbox.mockReset()
+  mockInput.mockReset()
 })
 
-it('change leaves without an error when the prompt is canceled', async () => {
-  const rootDir = path.join(tempDir, 'packages', 'lib')
-  fs.mkdirSync(rootDir, { recursive: true })
-  const manifest = { name: 'lib', version: '1.0.0' }
-  fs.writeFileSync(path.join(rootDir, 'package.json'), JSON.stringify(manifest, null, 2))
+function exitPromptError (): Error {
+  const err = new Error('User force closed the prompt')
+  err.name = 'ExitPromptError'
+  return err
+}
 
-  const canceled = new Error('User force closed the prompt')
-  canceled.name = 'ExitPromptError'
-  mockCheckbox.mockRejectedValue(canceled)
-  // `process.exit()` never returns in production, so the spy throws to stop
-  // the handler where the real call would.
+// `process.exit()` never returns in production, so the spy throws to stop the
+// handler where the real call would.
+async function expectExit (): Promise<void> {
   const exited = new Error('process.exit')
   const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
     throw exited
   })
-
   try {
-    await expect(
-      change.handler({ dir: tempDir, workspaceDir: tempDir, allProjects: [{ rootDir, manifest }] } as any, []) // eslint-disable-line @typescript-eslint/no-explicit-any
-    ).rejects.toBe(exited)
+    await expect(change.handler(opts as any, [])).rejects.toBe(exited) // eslint-disable-line @typescript-eslint/no-explicit-any
     expect(exitSpy).toHaveBeenCalledWith(0)
   } finally {
     exitSpy.mockRestore()
   }
+}
+
+it('change leaves without an error when the package prompt is canceled', async () => {
+  mockCheckbox.mockRejectedValue(exitPromptError())
+  await expectExit()
+})
+
+it('change leaves without an error when a bump prompt is canceled', async () => {
+  mockCheckbox.mockResolvedValueOnce(['lib']).mockRejectedValue(exitPromptError())
+  await expectExit()
+})
+
+it('change leaves without an error when the summary prompt is canceled', async () => {
+  mockCheckbox.mockResolvedValueOnce(['lib']).mockResolvedValue([])
+  mockInput.mockRejectedValue(exitPromptError())
+  await expectExit()
+})
+
+it('change rethrows a prompt failure that is not a cancellation', async () => {
+  const failed = new Error('the terminal is not interactive')
+  mockCheckbox.mockRejectedValue(failed)
+  await expect(change.handler(opts as any, [])).rejects.toBe(failed) // eslint-disable-line @typescript-eslint/no-explicit-any
 })


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#13814.

Ctrl-c out of a `pnpm change` prompt and the `ExitPromptError` that `@inquirer/prompts` throws travels all the way to the top-level handler, so backing out of the command ends in an error line plus a stack trace through pnpm's own internals. Every other interactive command already catches that error name at its prompt: `update`, `audit --fix`, `approve-builds`, `patch remove`, `login`, `publish`.

`change` now does the same, following what `update` does with it: print `Change canceled` and exit 0. The catch sits around `recordChange`, which covers all four prompts it can stop at (the package picker, the two bump pickers, the summary input). `pnpm change status` never prompts, so it stays outside the catch.

The Rust port needs nothing here. dialoguer reads keys through console's `read_key`, which re-raises `SIGINT` on Ctrl-c, so pacquet's `pnpm change` already ends quietly.

## Squash Commit Body

```text
Canceling any of the prompts of `pnpm change` let the ExitPromptError
that @inquirer/prompts throws reach the top-level error handler, which
printed it as a failure with a stack trace. Every other interactive
command catches that error name at its prompt.

Handle it the way `update` does: report the cancellation and exit with a
success status. The catch wraps recordChange, so it covers the package
picker, both bump pickers and the summary input; `change status` does
not prompt and stays outside it.

The Rust port is unaffected: dialoguer reads keys through console's
read_key, which re-raises SIGINT on Ctrl-c.

Closes pnpm/pnpm#13814.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13817"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789028051&installation_model_id=426870&pr_number=13817&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13817&signature=31fac3b173aad60804d4f307d9b8ce934165a0185f34ac10a900b8cd49809d9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Canceling the interactive change prompt with Ctrl-C now displays “Change canceled” and exits successfully.
  - Prevented an unnecessary stack trace from appearing when the prompt is canceled.
  - Other prompt errors continue to be reported normally.

- **Tests**
  - Added coverage for cancellation during package selection, version bump selection, and summary entry.
  - Added verification that prompt failures unrelated to cancellation are still surfaced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->