### PR TITLE
fix(change): page the pickers to the terminal height

### DIFF
--- a/.changeset/change-picker-page-size.md
+++ b/.changeset/change-picker-page-size.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-The package and bump pickers of `pnpm change` now use the full height of the terminal instead of showing 7 rows at a time [`pnpm/pnpm#13815`](https://github.com/pnpm/pnpm/issues/13815).
+The package and bump pickers of `pnpm change` now size their page from the terminal height instead of always showing 7 rows. They fall back to 7 rows when the terminal height is unknown [`pnpm/pnpm#13815`](https://github.com/pnpm/pnpm/issues/13815).

--- a/.changeset/change-picker-page-size.md
+++ b/.changeset/change-picker-page-size.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/releasing.commands": patch
+"pnpm": patch
+---
+
+The package and bump pickers of `pnpm change` now use the full height of the terminal instead of showing 7 rows at a time [`pnpm/pnpm#13815`](https://github.com/pnpm/pnpm/issues/13815).

--- a/pnpm11/releasing/commands/src/change/index.ts
+++ b/pnpm11/releasing/commands/src/change/index.ts
@@ -1,6 +1,7 @@
 import util from 'node:util'
 
 import { checkbox, input, Separator } from '@inquirer/prompts'
+import { interactivePromptPageSize } from '@pnpm/cli.utils'
 import type { Config } from '@pnpm/config.reader'
 import { PnpmError } from '@pnpm/error'
 import { globalInfo } from '@pnpm/logger'
@@ -173,6 +174,7 @@ async function promptForPackages (
   return checkbox<string>({
     message: 'Which packages does this change affect?',
     choices,
+    pageSize: interactivePromptPageSize(),
     required: true,
   })
 }
@@ -237,6 +239,7 @@ async function promptBumpTypes (pkgRefs: string[]): Promise<Record<string, Inten
     const chosen = new Set(await checkbox<string>({
       message: `Which packages should have a ${bumpType} bump?`,
       choices: remaining.map((ref) => ({ value: ref })),
+      pageSize: interactivePromptPageSize(),
     }))
     for (const ref of chosen) bumpByRef.set(ref, bumpType)
     remaining = remaining.filter((ref) => !chosen.has(ref))

--- a/pnpm11/releasing/commands/test/change/prompts.ts
+++ b/pnpm11/releasing/commands/test/change/prompts.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import { expect, jest, test } from '@jest/globals'
+import { beforeEach, expect, jest, test } from '@jest/globals'
 import { temporaryDirectory } from 'tempy'
 
 jest.unstable_mockModule('@inquirer/prompts', () => {
@@ -27,7 +27,31 @@ const { change } = await import('@pnpm/releasing.commands')
 const mockCheckbox = jest.mocked(checkbox)
 const mockInput = jest.mocked(input)
 
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockCheckbox.mockResolvedValueOnce(['lib']).mockResolvedValue([])
+  mockInput.mockResolvedValue('Added a feature.')
+})
+
 test('change: every picker pages to the terminal height', async () => {
+  await recordChangeWithStdoutRows(24)
+
+  expect(mockCheckbox.mock.calls).toHaveLength(3)
+  for (const [options] of mockCheckbox.mock.calls) {
+    expect(options).toEqual(expect.objectContaining({ pageSize: 18 }))
+  }
+})
+
+test('change: every picker falls back to a 7-row page when the terminal height is unknown', async () => {
+  await recordChangeWithStdoutRows(undefined)
+
+  expect(mockCheckbox.mock.calls).toHaveLength(3)
+  for (const [options] of mockCheckbox.mock.calls) {
+    expect(options).toEqual(expect.objectContaining({ pageSize: 7 }))
+  }
+})
+
+async function recordChangeWithStdoutRows (stdoutRows: number | undefined): Promise<void> {
   const workspaceDir = temporaryDirectory()
   fs.writeFileSync(path.join(workspaceDir, 'pnpm-workspace.yaml'), 'packages:\n  - packages/*\n')
   const allProjects = ['cli', 'lib'].map((name) => {
@@ -38,11 +62,8 @@ test('change: every picker pages to the terminal height', async () => {
     return { rootDir, manifest }
   })
 
-  mockCheckbox.mockResolvedValueOnce(['lib']).mockResolvedValue([])
-  mockInput.mockResolvedValue('Added a feature.')
-
   const rows = Object.getOwnPropertyDescriptor(process.stdout, 'rows')
-  Object.defineProperty(process.stdout, 'rows', { value: 24, configurable: true })
+  Object.defineProperty(process.stdout, 'rows', { value: stdoutRows, configurable: true })
   try {
     const output = await change.handler({ dir: workspaceDir, workspaceDir, allProjects } as any, []) // eslint-disable-line @typescript-eslint/no-explicit-any
     expect(output).toMatch(/Recorded change intent \.changeset\/.+\.md/)
@@ -53,9 +74,4 @@ test('change: every picker pages to the terminal height', async () => {
       Object.defineProperty(process.stdout, 'rows', rows)
     }
   }
-
-  expect(mockCheckbox.mock.calls).toHaveLength(3)
-  for (const [options] of mockCheckbox.mock.calls) {
-    expect(options).toEqual(expect.objectContaining({ pageSize: 18 }))
-  }
-})
+}

--- a/pnpm11/releasing/commands/test/change/prompts.ts
+++ b/pnpm11/releasing/commands/test/change/prompts.ts
@@ -41,12 +41,21 @@ test('change: every picker pages to the terminal height', async () => {
   mockCheckbox.mockResolvedValueOnce(['lib']).mockResolvedValue([])
   mockInput.mockResolvedValue('Added a feature.')
 
-  const output = await change.handler({ dir: workspaceDir, workspaceDir, allProjects } as any, []) // eslint-disable-line @typescript-eslint/no-explicit-any
-  expect(output).toMatch(/Recorded change intent \.changeset\/.+\.md/)
+  const rows = Object.getOwnPropertyDescriptor(process.stdout, 'rows')
+  Object.defineProperty(process.stdout, 'rows', { value: 24, configurable: true })
+  try {
+    const output = await change.handler({ dir: workspaceDir, workspaceDir, allProjects } as any, []) // eslint-disable-line @typescript-eslint/no-explicit-any
+    expect(output).toMatch(/Recorded change intent \.changeset\/.+\.md/)
+  } finally {
+    if (rows == null) {
+      delete (process.stdout as Partial<Pick<NodeJS.WriteStream, 'rows'>>).rows
+    } else {
+      Object.defineProperty(process.stdout, 'rows', rows)
+    }
+  }
 
-  const pageSize = process.stdout.rows == null ? 7 : Math.max(7, process.stdout.rows - 6)
   expect(mockCheckbox.mock.calls).toHaveLength(3)
   for (const [options] of mockCheckbox.mock.calls) {
-    expect(options).toEqual(expect.objectContaining({ pageSize }))
+    expect(options).toEqual(expect.objectContaining({ pageSize: 18 }))
   }
 })

--- a/pnpm11/releasing/commands/test/change/prompts.ts
+++ b/pnpm11/releasing/commands/test/change/prompts.ts
@@ -1,0 +1,52 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { expect, jest, test } from '@jest/globals'
+import { temporaryDirectory } from 'tempy'
+
+jest.unstable_mockModule('@inquirer/prompts', () => {
+  class Separator {
+    separator: string
+    readonly type = 'separator' as const
+    constructor (separator: string) {
+      this.separator = separator
+    }
+  }
+  return {
+    Separator,
+    checkbox: jest.fn(),
+    confirm: jest.fn(),
+    input: jest.fn(),
+    password: jest.fn(),
+    select: jest.fn(),
+  }
+})
+const { checkbox, input } = await import('@inquirer/prompts')
+const { change } = await import('@pnpm/releasing.commands')
+
+const mockCheckbox = jest.mocked(checkbox)
+const mockInput = jest.mocked(input)
+
+test('change: every picker pages to the terminal height', async () => {
+  const workspaceDir = temporaryDirectory()
+  fs.writeFileSync(path.join(workspaceDir, 'pnpm-workspace.yaml'), 'packages:\n  - packages/*\n')
+  const allProjects = ['cli', 'lib'].map((name) => {
+    const rootDir = path.join(workspaceDir, 'packages', name)
+    fs.mkdirSync(rootDir, { recursive: true })
+    const manifest = { name, version: '1.0.0' }
+    fs.writeFileSync(path.join(rootDir, 'package.json'), JSON.stringify(manifest, null, 2))
+    return { rootDir, manifest }
+  })
+
+  mockCheckbox.mockResolvedValueOnce(['lib']).mockResolvedValue([])
+  mockInput.mockResolvedValue('Added a feature.')
+
+  const output = await change.handler({ dir: workspaceDir, workspaceDir, allProjects } as any, []) // eslint-disable-line @typescript-eslint/no-explicit-any
+  expect(output).toMatch(/Recorded change intent \.changeset\/.+\.md/)
+
+  const pageSize = process.stdout.rows == null ? 7 : Math.max(7, process.stdout.rows - 6)
+  expect(mockCheckbox.mock.calls).toHaveLength(3)
+  for (const [options] of mockCheckbox.mock.calls) {
+    expect(options).toEqual(expect.objectContaining({ pageSize }))
+  }
+})


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#13815.

`pnpm change` builds its package picker and its two bump pickers with `checkbox` from `@inquirer/prompts` and never passes `pageSize`, so all three fall back to inquirer's default of 7 rows however tall the terminal is. In a workspace with more than a handful of releasable packages that hides most of the list behind scrolling.

The three prompts now take `interactivePromptPageSize()`, the helper `pnpm update -i` and `pnpm audit --fix` already use, which sizes the page from `process.stdout.rows` and keeps 7 as the floor.

pacquet needs no counterpart. `dialoguer`'s `MultiSelect` already clamps its page to the terminal height when no `max_length` is set, and the Rust `change` command sets none.

## Squash Commit Body

```text
The package picker and the two bump pickers of `pnpm change` called
checkbox without a pageSize, so each one showed inquirer's default of 7
rows regardless of the terminal height. A workspace with more releasable
packages than that hid the rest behind scrolling.

All three now pass interactivePromptPageSize(), the helper the
interactive update and audit-fix prompts already use, which derives the
page from process.stdout.rows with 7 as the floor.

The Rust change command is unaffected: dialoguer clamps a MultiSelect
page to the terminal height when max_length is unset.

Fixes pnpm/pnpm#13815.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789028248&installation_model_id=426870&pr_number=13818&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13818&signature=bf15c49964e3da220a725ca927228c85a459d839b1c9e1b98ee1f8241c53aa70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated `pnpm change` package and version bump selection screens to use the terminal’s available height.
  * More options can now be displayed at once, reducing scrolling during interactive selections.
  * Added a seven-row fallback for environments where terminal height cannot be detected.

* **Tests**
  * Added coverage for page sizing across interactive selection prompts, including detected and unavailable terminal heights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->