### PR TITLE
fix(config): accept the string values of verifyDepsBeforeRun from the environment

### DIFF
--- a/.changeset/verify-deps-before-run-from-env.md
+++ b/.changeset/verify-deps-before-run-from-env.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config.reader": patch
+"pnpm": patch
+---
+
+Fixed `verifyDepsBeforeRun` being ignored when set to `install`, `warn`, `error`, or `prompt` through the `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN` environment variable or the `--config.verify-deps-before-run` flag [#13816](https://github.com/pnpm/pnpm/issues/13816). Only the boolean values were accepted before, so a string value was silently dropped.

--- a/pnpm11/config/reader/src/types.ts
+++ b/pnpm11/config/reader/src/types.ts
@@ -128,7 +128,7 @@ export const pnpmTypes = {
   'trust-policy-ignore-after': Number,
   'use-beta-cli': Boolean,
   'use-stderr': Boolean,
-  'verify-deps-before-run': Boolean,
+  'verify-deps-before-run': [Boolean, 'install', 'warn', 'error', 'prompt'],
   'verify-store-integrity': Boolean,
   'frozen-store': Boolean,
   'global-virtual-store-dir': String,

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -3922,6 +3922,13 @@ test('loads setting from environment variable pnpm_config_*', async () => {
   expect(config.registriesByScope.default).toBe('https://registry.example.com/')
 })
 
+// The two boolean rows only pin down parsing, not runtime meaning. `false` turns the
+// check off. Bare `true` turns the check on but selects none of the four actions, because
+// `runDepsStatusCheck` switches on the string modes alone. That is the behavior pnpm has
+// always had for this setting, and `VerifyDepsBeforeRun` in `Config.ts` keeps `true` out of
+// the type on purpose. The Rust config crate models it the same way, as a `True` variant that
+// maps to no action (`pnpm/crates/config/src/lib.rs`). Keep these rows as a record of what the
+// parser returns; do not read them as a promise that bare `true` does an install.
 test.each([
   ['install', 'install'],
   ['warn', 'warn'],

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -3922,12 +3922,19 @@ test('loads setting from environment variable pnpm_config_*', async () => {
   expect(config.registriesByScope.default).toBe('https://registry.example.com/')
 })
 
-test('loads verifyDepsBeforeRun from environment variable pnpm_config_*', async () => {
+test.each([
+  ['install', 'install'],
+  ['warn', 'warn'],
+  ['error', 'error'],
+  ['prompt', 'prompt'],
+  ['true', true],
+  ['false', false],
+])('loads verifyDepsBeforeRun=%s from environment variable pnpm_config_*', async (envValue: string, expectedValue: string | boolean) => {
   prepareEmpty()
   const { config } = await getConfig({
     cliOptions: {},
     env: {
-      PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN: 'error',
+      PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN: envValue,
     },
     packageManager: {
       name: 'pnpm',
@@ -3935,7 +3942,7 @@ test('loads verifyDepsBeforeRun from environment variable pnpm_config_*', async 
     },
     workspaceDir: process.cwd(),
   })
-  expect(config.verifyDepsBeforeRun).toBe('error')
+  expect(config.verifyDepsBeforeRun).toBe(expectedValue)
 })
 
 test('environment variable pnpm_config_* should override pnpm-workspace.yaml', async () => {

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -3922,6 +3922,22 @@ test('loads setting from environment variable pnpm_config_*', async () => {
   expect(config.registriesByScope.default).toBe('https://registry.example.com/')
 })
 
+test('loads verifyDepsBeforeRun from environment variable pnpm_config_*', async () => {
+  prepareEmpty()
+  const { config } = await getConfig({
+    cliOptions: {},
+    env: {
+      PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN: 'error',
+    },
+    packageManager: {
+      name: 'pnpm',
+      version: '1.0.0',
+    },
+    workspaceDir: process.cwd(),
+  })
+  expect(config.verifyDepsBeforeRun).toBe('error')
+})
+
 test('environment variable pnpm_config_* should override pnpm-workspace.yaml', async () => {
   prepareEmpty()
 


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#13816.

`verify-deps-before-run` is registered as `Boolean` in the config schema, so the env var parser drops any value other than `true` or `false`. `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=error` (and `--config.verify-deps-before-run=error`) silently left the setting on its default, while the same value in `pnpm-workspace.yaml` worked. The schema entry now lists the string values next to `Boolean`, the shape `color` already uses.

pacquet reads the env var through `parse_json_or_string::<VerifyDepsBeforeRun>`, so it already accepts these values and needs no change.

## Squash Commit Body

```text
The config schema typed verify-deps-before-run as Boolean, so parseEnvVars
returned undefined for install/warn/error/prompt and the value was dropped
before it reached the config. Only the lowercase pnpm_config_ env var
survived, through the explicit assignment in updateConfigFromWorkspaceManifest
that keeps the setting's priority right.

Typing it as [Boolean, 'install', 'warn', 'error', 'prompt'] matches the
VerifyDepsBeforeRun type and covers the CLI flag too. Unrecognized values
still parse to undefined and are skipped, as before.

Closes pnpm/pnpm#13816
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789030486&installation_model_id=426870&pr_number=13821&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13821&signature=f5aff496d3d226dbd71b4140ea2a0b0c7080b3815d5e8cb0da6142a683a58168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `verifyDepsBeforeRun` now correctly accepts `install`, `warn`, `error`, and `prompt` through environment variables and command-line options.
  * Boolean values (`true` and `false`) continue to work as expected.
  * Unsupported non-boolean values are no longer silently ignored.

* **Documentation**
  * Added release notes describing the supported configuration values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->