### PR TITLE
fix(config): support string values for verifyDepsBeforeRun in env vars

### DIFF
--- a/.changeset/verify-deps-before-run-env-string.md
+++ b/.changeset/verify-deps-before-run-env-string.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config.reader": patch
+"pnpm": patch
+---
+
+Fixed an issue where `verifyDepsBeforeRun` could not be configured with string values (`error`, `warn`, `install`, `prompt`) via environment variables (e.g. `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN`).

--- a/pnpm11/config/reader/src/types.ts
+++ b/pnpm11/config/reader/src/types.ts
@@ -128,7 +128,7 @@ export const pnpmTypes = {
   'trust-policy-ignore-after': Number,
   'use-beta-cli': Boolean,
   'use-stderr': Boolean,
-  'verify-deps-before-run': Boolean,
+  'verify-deps-before-run': [Boolean, 'install', 'warn', 'error', 'prompt'],
   'verify-store-integrity': Boolean,
   'frozen-store': Boolean,
   'global-virtual-store-dir': String,

--- a/pnpm11/config/reader/test/env.test.ts
+++ b/pnpm11/config/reader/test/env.test.ts
@@ -237,3 +237,25 @@ test('parseEnvVars skips keys that end with underscore character', () => {
     pnpm_config_foo_bar_: 'foo bar',
   }))).toStrictEqual({})
 })
+
+test('parseEnvVars works with verify-deps-before-run schema', () => {
+  const schema = [Boolean, 'install', 'warn', 'error', 'prompt']
+  expect(pairsToObject(parseEnvVars(alwaysSchema(schema), {
+    pnpm_config_foo: 'true',
+    pnpm_config_bar: 'false',
+    pnpm_config_baz: 'error',
+    pnpm_config_qux: 'warn',
+    pnpm_config_xyz: 'install',
+    pnpm_config_abc: 'prompt',
+    pnpm_config_invalid: 'invalid-value',
+  }))).toStrictEqual({
+    foo: true,
+    bar: false,
+    baz: 'error',
+    qux: 'warn',
+    xyz: 'install',
+    abc: 'prompt',
+    invalid: undefined,
+  })
+})
+

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -4471,3 +4471,22 @@ test('warning stays when PNPM_CONFIG_NPMRC_AUTH_FILE is a relative path that doe
     }
   }
 })
+
+test('verifyDepsBeforeRun can be set via env variable', async () => {
+  prepare()
+
+  const { config } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN: 'error',
+    },
+    packageManager: {
+      name: 'pnpm',
+      version: '1.0.0',
+    },
+  })
+
+  expect(config.verifyDepsBeforeRun).toBe('error')
+})
+


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

This PR fixes an issue where setting the `verifyDepsBeforeRun` setting via the environment variable `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN` silently failed when using string values (like `install`, `warn`, `error`, or `prompt`).

The TypeScript config reader parses environment variables according to the schema defined in `types.ts`. Since `verify-deps-before-run` was declared solely as `Boolean`, string values failed to parse and were silently dropped. This PR updates the schema to accept `[Boolean, 'install', 'warn', 'error', 'prompt']`.

Fixes https://github.com/pnpm/pnpm/issues/13816

## Squash Commit Body

```text
fix(config): support string values for verifyDepsBeforeRun in env vars

Allow setting verify-deps-before-run via environment variable
(e.g., PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN) to string values like
"error", "warn", "install", and "prompt".

The TypeScript config reader parses environment variables according to the schema
defined in types.ts. Previously, verify-deps-before-run was declared as Boolean,
causing string values to be rejected and silently dropped during environment
variable parsing. Updating the schema to accept both boolean and the supported
string values resolves the issue.

Note: The Rust side already correctly parses string and boolean values for
verifyDepsBeforeRun in config::env_overlay, so behavioral parity is maintained
without requiring additional Rust changes.

Closes https://github.com/pnpm/pnpm/issues/13816
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting. (Note: The Rust port already supports these values out-of-the-box).
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789030976&installation_model_id=426870&pr_number=13822&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13822&signature=fe0545c4e2535f129b04d54258b7066714a24d57f637ad072d9cb766aef93cf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Environment configuration now supports `verify-deps-before-run` string modes: `install`, `warn`, `error`, and `prompt`, in addition to boolean values.

* **Bug Fixes**
  * Fixed environment-variable parsing so valid string values are correctly recognized and applied.
  * Invalid values are safely ignored instead of being applied as configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->