### PR TITLE
fix(update): keep versioned selectors targeted

### DIFF
--- a/.changeset/update-versioned-selector-stays-targeted.md
+++ b/.changeset/update-versioned-selector-stays-targeted.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-`pnpm update <pkg>@<version>` no longer re-resolves the entire dependency graph. Previously, any versioned selector disabled the per-package match predicate that scopes transitive updates, so unrelated transitive dependencies were re-resolved as well — every package floating under an in-range spec snapped to its latest eligible version on each update. Bare-name selectors already targeted correctly; pacquet already behaved correctly.
+`pnpm update <pkg>@<version>` now updates only the selected packages and leaves unrelated dependencies unchanged.

--- a/.changeset/update-versioned-selector-stays-targeted.md
+++ b/.changeset/update-versioned-selector-stays-targeted.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.commands": patch
+"pnpm": patch
+---
+
+`pnpm update <pkg>@<version>` no longer re-resolves the entire dependency graph. Previously, any versioned selector disabled the per-package match predicate that scopes transitive updates, so unrelated transitive dependencies were re-resolved as well — every package floating under an in-range spec snapped to its latest eligible version on each update. Bare-name selectors already targeted correctly; pacquet already behaved correctly.

--- a/pnpm11/installing/commands/src/update/index.ts
+++ b/pnpm11/installing/commands/src/update/index.ts
@@ -482,7 +482,8 @@ async function update (
 function updateTargetPatterns (selector: string): string[] {
   const { pattern, versionSpec } = parseUpdateParam(selector)
   if (versionSpec?.startsWith('npm:') !== true) return [pattern]
-  return [pattern, parseUpdateParam(versionSpec.slice('npm:'.length)).pattern]
+  const aliased = parseUpdateParam(versionSpec.slice('npm:'.length)).pattern
+  return [pattern, pattern.startsWith('!') ? `!${aliased}` : aliased]
 }
 
 function shouldUpdateGitHubActions (opts: UpdateCommandOptions, include: IncludedDependencies): boolean {

--- a/pnpm11/installing/commands/src/update/index.ts
+++ b/pnpm11/installing/commands/src/update/index.ts
@@ -435,9 +435,10 @@ async function update (
   let updateMatching: UpdateMatchingFunction | undefined
   if (opts.packageVulnerabilityAudit != null) {
     updateMatching = createVulnerabilityUpdateMatching(opts.packageVulnerabilityAudit)
-  } else if (
-    (packageDependencies.length > 0) && packageDependencies.every(dep => !dep.substring(1).includes('@')) && depth > 0 && !opts.latest
-  ) {
+  } else if ((packageDependencies.length > 0) && depth > 0 && !opts.latest) {
+    // `createMatcher` strips any `@version` from each selector before
+    // matching, so versioned selectors (`foo@1.2.3`) target the named
+    // packages like bare ones — not the whole graph.
     updateMatching = createMatcher(packageDependencies)
   }
   const generateChangeset = opts.changeset ?? opts.updateConfig?.changeset ?? false

--- a/pnpm11/installing/commands/src/update/index.ts
+++ b/pnpm11/installing/commands/src/update/index.ts
@@ -436,7 +436,7 @@ async function update (
   if (opts.packageVulnerabilityAudit != null) {
     updateMatching = createVulnerabilityUpdateMatching(opts.packageVulnerabilityAudit)
   } else if ((packageDependencies.length > 0) && depth > 0 && !opts.latest) {
-    updateMatching = createMatcher(packageDependencies.map((dep) => parseUpdateParam(dep).pattern))
+    updateMatching = createMatcher(packageDependencies.flatMap(updateTargetPatterns))
   }
   const generateChangeset = opts.changeset ?? opts.updateConfig?.changeset ?? false
   const changesetContext = generateChangeset ? await captureUpdateChangesetContext(opts) : undefined
@@ -470,6 +470,19 @@ async function update (
   if (changesetContext != null) {
     await generateUpdateChangeset(changesetContext)
   }
+}
+
+/**
+ * The names an update selector targets. The version part of `<pkg>@<version>`
+ * is not one of them: the resolver matches update targets by package name, so
+ * a selector that carries a version has to target the same names its bare form
+ * does. An `npm:` selector also contributes the aliased package's own name,
+ * because that — not the alias — is the name the resolver resolves it under.
+ */
+function updateTargetPatterns (selector: string): string[] {
+  const { pattern, versionSpec } = parseUpdateParam(selector)
+  if (versionSpec?.startsWith('npm:') !== true) return [pattern]
+  return [pattern, parseUpdateParam(versionSpec.slice('npm:'.length)).pattern]
 }
 
 function shouldUpdateGitHubActions (opts: UpdateCommandOptions, include: IncludedDependencies): boolean {

--- a/pnpm11/installing/commands/src/update/index.ts
+++ b/pnpm11/installing/commands/src/update/index.ts
@@ -436,10 +436,7 @@ async function update (
   if (opts.packageVulnerabilityAudit != null) {
     updateMatching = createVulnerabilityUpdateMatching(opts.packageVulnerabilityAudit)
   } else if ((packageDependencies.length > 0) && depth > 0 && !opts.latest) {
-    // `createMatcher` strips any `@version` from each selector before
-    // matching, so versioned selectors (`foo@1.2.3`) target the named
-    // packages like bare ones — not the whole graph.
-    updateMatching = createMatcher(packageDependencies)
+    updateMatching = createMatcher(packageDependencies.map((dep) => parseUpdateParam(dep).pattern))
   }
   const generateChangeset = opts.changeset ?? opts.updateConfig?.changeset ?? false
   const changesetContext = generateChangeset ? await captureUpdateChangesetContext(opts) : undefined

--- a/pnpm11/installing/commands/test/update/update.ts
+++ b/pnpm11/installing/commands/test/update/update.ts
@@ -174,6 +174,45 @@ test('update of a transitive dependency ignores the requested version and resolv
   expect(lockfile.packages['@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0']).toBeFalsy()
 })
 
+test('update a transitive dependency by name when a versioned direct-dep selector is also present', async () => {
+  // Pin the transitive @pnpm.e2e/dep-of-pkg-with-1-dep to 100.0.0 at install
+  // time, so the later update has an older version to bump from.
+  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.0.0', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/foo', version: '100.0.0', distTag: 'latest' })
+
+  const project = prepare({
+    dependencies: {
+      '@pnpm.e2e/foo': '^100.0.0',
+      '@pnpm.e2e/pkg-with-1-dep': '100.0.0',
+    },
+  })
+
+  await install.handler({
+    ...DEFAULT_OPTS,
+    dir: process.cwd(),
+  })
+
+  expect(project.readLockfile().packages['@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0']).toBeTruthy()
+
+  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.1.0', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/foo', version: '100.1.0', distTag: 'latest' })
+
+  // The versioned direct-dep selector `@pnpm.e2e/foo@100.1.0` must not
+  // disable transitive targeting of `@pnpm.e2e/dep-of-pkg-with-1-dep`.
+  // The bare-name selector still matches the transitive package and bumps
+  // it from 100.0.0 to 100.1.0, exactly like the all-bare-name case.
+  await update.handler({
+    ...DEFAULT_OPTS,
+    dir: process.cwd(),
+    save: false,
+  }, ['@pnpm.e2e/dep-of-pkg-with-1-dep', '@pnpm.e2e/foo@100.1.0'])
+
+  const lockfile = project.readLockfile()
+
+  expect(lockfile.packages['@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0']).toBeTruthy()
+  expect(lockfile.packages['@pnpm.e2e/foo@100.1.0']).toBeTruthy()
+})
+
 test('update with a version on a crafted package name does not pollute Object.prototype', async () => {
   const project = prepare({
     dependencies: {

--- a/pnpm11/installing/commands/test/update/update.ts
+++ b/pnpm11/installing/commands/test/update/update.ts
@@ -174,45 +174,6 @@ test('update of a transitive dependency ignores the requested version and resolv
   expect(lockfile.packages['@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0']).toBeFalsy()
 })
 
-test('update a transitive dependency by name when a versioned direct-dep selector is also present', async () => {
-  // Pin the transitive @pnpm.e2e/dep-of-pkg-with-1-dep to 100.0.0 at install
-  // time, so the later update has an older version to bump from.
-  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.0.0', distTag: 'latest' })
-  await addDistTag({ package: '@pnpm.e2e/foo', version: '100.0.0', distTag: 'latest' })
-
-  const project = prepare({
-    dependencies: {
-      '@pnpm.e2e/foo': '^100.0.0',
-      '@pnpm.e2e/pkg-with-1-dep': '100.0.0',
-    },
-  })
-
-  await install.handler({
-    ...DEFAULT_OPTS,
-    dir: process.cwd(),
-  })
-
-  expect(project.readLockfile().packages['@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0']).toBeTruthy()
-
-  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.1.0', distTag: 'latest' })
-  await addDistTag({ package: '@pnpm.e2e/foo', version: '100.1.0', distTag: 'latest' })
-
-  // The versioned direct-dep selector `@pnpm.e2e/foo@100.1.0` must not
-  // disable transitive targeting of `@pnpm.e2e/dep-of-pkg-with-1-dep`.
-  // The bare-name selector still matches the transitive package and bumps
-  // it from 100.0.0 to 100.1.0, exactly like the all-bare-name case.
-  await update.handler({
-    ...DEFAULT_OPTS,
-    dir: process.cwd(),
-    save: false,
-  }, ['@pnpm.e2e/dep-of-pkg-with-1-dep', '@pnpm.e2e/foo@100.1.0'])
-
-  const lockfile = project.readLockfile()
-
-  expect(lockfile.packages['@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0']).toBeTruthy()
-  expect(lockfile.packages['@pnpm.e2e/foo@100.1.0']).toBeTruthy()
-})
-
 test('update with a version on a crafted package name does not pollute Object.prototype', async () => {
   const project = prepare({
     dependencies: {

--- a/pnpm11/pnpm/test/update.ts
+++ b/pnpm11/pnpm/test/update.ts
@@ -33,33 +33,46 @@ test('update <dep>', async () => {
   expect(pkg.dependencies?.['@pnpm.e2e/dep-of-pkg-with-1-dep']).toBe('^101.0.0')
 })
 
-test('update <pkg>@<version> stays targeted and leaves unselected transitive deps unchanged', async () => {
-  await addDistTag('@pnpm.e2e/foo', '100.0.0', 'latest')
-  await addDistTag('@pnpm.e2e/dep-of-pkg-with-1-dep', '100.0.0', 'latest')
+test('update <pkg>@<version> updates only the selected package', async () => {
+  await Promise.all([
+    addDistTag('@pnpm.e2e/pkg-with-1-dep', '100.0.0', 'latest'),
+    addDistTag('@pnpm.e2e/dep-of-pkg-with-1-dep', '100.0.0', 'latest'),
+  ])
 
   const project = prepare({
     dependencies: {
-      '@pnpm.e2e/foo': '^100.0.0',
       '@pnpm.e2e/pkg-with-1-dep': '100.0.0',
     },
   })
 
   await execPnpm(['install', '--lockfile-only'])
 
-  const lockfileBefore = project.readLockfile()
-  expect(lockfileBefore.packages).toHaveProperty(['@pnpm.e2e/foo@100.0.0'])
-  expect(lockfileBefore.packages).toHaveProperty(['@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0'])
-
-  await addDistTag('@pnpm.e2e/foo', '100.1.0', 'latest')
   await addDistTag('@pnpm.e2e/dep-of-pkg-with-1-dep', '100.1.0', 'latest')
 
-  await execPnpm(['update', '--no-save', '@pnpm.e2e/foo@100.1.0', '--lockfile-only'])
+  await execPnpm(['update', '--no-save', '@pnpm.e2e/pkg-with-1-dep@100.0.0', '--lockfile-only'])
 
-  const lockfile = project.readLockfile()
-  expect(lockfile.packages).toHaveProperty(['@pnpm.e2e/foo@100.1.0'])
-  expect(lockfile.packages).not.toHaveProperty(['@pnpm.e2e/foo@100.0.0'])
-  expect(lockfile.packages).toHaveProperty(['@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0'])
-  expect(lockfile.packages).not.toHaveProperty(['@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0'])
+  expect(Object.keys(project.readLockfile().packages ?? {})).toStrictEqual([
+    '@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0',
+    '@pnpm.e2e/pkg-with-1-dep@100.0.0',
+  ])
+})
+
+test('update <alias>@npm:<pkg>@<version> updates the aliased package', async () => {
+  await addDistTag('@pnpm.e2e/qar', '100.0.0', 'latest')
+
+  const project = prepare({
+    dependencies: {
+      alias: 'npm:@pnpm.e2e/qar@^100.0.0',
+    },
+  })
+
+  await execPnpm(['install', '--lockfile-only'])
+
+  await addDistTag('@pnpm.e2e/qar', '100.1.0', 'latest')
+
+  await execPnpm(['update', 'alias@npm:@pnpm.e2e/qar@^100.0.0', '--lockfile-only'])
+
+  expect(Object.keys(project.readLockfile().packages ?? {})).toStrictEqual(['@pnpm.e2e/qar@100.1.0'])
 })
 
 test('update --no-save', async () => {

--- a/pnpm11/pnpm/test/update.ts
+++ b/pnpm11/pnpm/test/update.ts
@@ -75,6 +75,34 @@ test('update <alias>@npm:<pkg>@<version> updates the aliased package', async () 
   expect(Object.keys(project.readLockfile().packages ?? {})).toStrictEqual(['@pnpm.e2e/qar@100.1.0'])
 })
 
+test('an ignored <alias>@npm:<pkg> selector keeps the aliased package too', async () => {
+  await Promise.all([
+    addDistTag('@pnpm.e2e/qar', '100.0.0', 'latest'),
+    addDistTag('@pnpm.e2e/foo', '100.0.0', 'latest'),
+  ])
+
+  const project = prepare({
+    dependencies: {
+      '@pnpm.e2e/foo': '^100.0.0',
+      alias: 'npm:@pnpm.e2e/qar@^100.0.0',
+    },
+  })
+
+  await execPnpm(['install', '--lockfile-only'])
+
+  await Promise.all([
+    addDistTag('@pnpm.e2e/qar', '100.1.0', 'latest'),
+    addDistTag('@pnpm.e2e/foo', '100.1.0', 'latest'),
+  ])
+
+  await execPnpm(['update', '--no-save', '*', '!alias@npm:@pnpm.e2e/qar@^100.0.0', '--lockfile-only'])
+
+  expect(Object.keys(project.readLockfile().packages ?? {})).toStrictEqual([
+    '@pnpm.e2e/foo@100.1.0',
+    '@pnpm.e2e/qar@100.0.0',
+  ])
+})
+
 test('update --no-save', async () => {
   await addDistTag('@pnpm.e2e/foo', '100.1.0', 'latest')
   const project = prepare({

--- a/pnpm11/pnpm/test/update.ts
+++ b/pnpm11/pnpm/test/update.ts
@@ -33,6 +33,35 @@ test('update <dep>', async () => {
   expect(pkg.dependencies?.['@pnpm.e2e/dep-of-pkg-with-1-dep']).toBe('^101.0.0')
 })
 
+test('update <pkg>@<version> stays targeted and leaves unselected transitive deps unchanged', async () => {
+  await addDistTag('@pnpm.e2e/foo', '100.0.0', 'latest')
+  await addDistTag('@pnpm.e2e/dep-of-pkg-with-1-dep', '100.0.0', 'latest')
+
+  const project = prepare({
+    dependencies: {
+      '@pnpm.e2e/foo': '^100.0.0',
+      '@pnpm.e2e/pkg-with-1-dep': '100.0.0',
+    },
+  })
+
+  await execPnpm(['install', '--lockfile-only'])
+
+  const lockfileBefore = project.readLockfile()
+  expect(lockfileBefore.packages).toHaveProperty(['@pnpm.e2e/foo@100.0.0'])
+  expect(lockfileBefore.packages).toHaveProperty(['@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0'])
+
+  await addDistTag('@pnpm.e2e/foo', '100.1.0', 'latest')
+  await addDistTag('@pnpm.e2e/dep-of-pkg-with-1-dep', '100.1.0', 'latest')
+
+  await execPnpm(['update', '--no-save', '@pnpm.e2e/foo@100.1.0', '--lockfile-only'])
+
+  const lockfile = project.readLockfile()
+  expect(lockfile.packages).toHaveProperty(['@pnpm.e2e/foo@100.1.0'])
+  expect(lockfile.packages).not.toHaveProperty(['@pnpm.e2e/foo@100.0.0'])
+  expect(lockfile.packages).toHaveProperty(['@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0'])
+  expect(lockfile.packages).not.toHaveProperty(['@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0'])
+})
+
 test('update --no-save', async () => {
   await addDistTag('@pnpm.e2e/foo', '100.1.0', 'latest')
   const project = prepare({


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

`pnpm update <pkg>@<version>` re-resolved the entire dependency graph. The `every(dep => !dep.substring(1).includes('@'))` guard on the matcher-construction branch disabled the per-package match predicate whenever any selector carried a version, leaving `updateMatching == null` and forcing every transitive dep under the selected package to be re-resolved to its latest in-range version. Bare-name selectors already targeted correctly; the version pin broadened the scope instead of just changing the manifest rewrite.

The resolver matches update targets by **package name**, so the fix is to build the predicate from the names a selector targets rather than from the raw selector string:

- Strip the `@<version>` suffix with `parseUpdateParam`. The `createMatcher` used here is `@pnpm/config.matcher`, which matches the raw pattern — it does *not* parse versions (that is the separate `createMatcher` in `recursive.ts`). Passing `foo@1.2.3` unstripped builds a predicate that never matches anything.
- For an `npm:` selector, also contribute the aliased package's own name. `alias@npm:pkg@<range>` parses to the pattern `alias`, but the resolver resolves that edge under `pkg` (`infoFromLockfile.name`, or `wantedDependencyMatchesUpdateTarget` once a changed specifier has dropped the lockfile reference). Without this, `pnpm update alias@npm:pkg@<range>` stops updating whenever the range already matches the manifest — a regression the old guard happened to mask.

Closes https://github.com/pnpm/pnpm/issues/13825.

Reproduction (before vs. after) on `fathom-io/fathom-frontend@2783048282`:

```
$ pnpm up --no-save @angular/cli@21.2.20 --recursive --lockfile-only
# before: 230-line diff, @hono/node-server 2.0.12 -> 2.1.0, postcss 8.5.25 -> 8.5.26, ...
# after:   150-line diff, only @angular/* cascade (matches the bare-name form)
```

### Tests

Two e2e tests in `pnpm/test/update.ts`, both verified to fail without the corresponding fix:

- `update <pkg>@<version> updates only the selected package` — selects a package at the version it already resolves to and asserts its transitive dependency does not float to a newly published one. Without the guard removal the transitive dep moves to `100.1.0`.
- `update <alias>@npm:<pkg>@<version> updates the aliased package` — without the alias handling the aliased package keeps its seeded pin.

### Rust parity

pacquet already handles the versioned-selector case: `use_name_matcher` only gates whether to scan lockfile names, and the else branch still builds a matcher via `create_matcher(&patterns)` from version-stripped patterns and produces `UpdateSeedPolicy::DropOnly`.

The **alias** half still needs porting. pacquet's `drop_names` are collected from manifest keys (which hold the alias), while `is_update_target` matches `real_package_name_of(...)` and `subtree_fully_reusable` matches `key.name` — so `pnpm update <alias>@npm:<pkg>@<range>` has the same gap in `pnpm/crates/package-manager/src/update.rs`. Not included here; someone with Rust-side context should push the matching commit to this PR before it lands.

## Squash Commit Body

```text
`pnpm update <pkg>@<version>` re-resolved the dependency graph under the
selected package because the `every(dep => !dep.substring(1).includes('@'))`
guard on the matcher-construction branch (added in 8c1cf25b7d, predating
the matcher's ability to parse `@version`) disabled the per-package match
predicate whenever any selector carried a version. With the predicate
null, the resolver treated every package in reach as an update target and
unrelated transitive deps snapped to their latest in-range version.

The resolver matches update targets by package name, so build the
predicate from the names a selector targets. `parseUpdateParam` strips the
version suffix -- the `createMatcher` used here is the plain glob/exact
matcher from `@pnpm/config.matcher`, not the version-aware one in
`recursive.ts`, so an unstripped `foo@1.2.3` matches nothing. An `npm:`
selector additionally contributes the aliased package's own name, since
that is the name the resolver resolves the edge under; without it,
`pnpm update <alias>@npm:<pkg>@<range>` stops updating whenever the range
already matches the manifest.

The bare-name form was fixed in dcabb7862 (pnpm/pnpm#10662); this closes
the versioned-form gap tracked in pnpm/pnpm#13825.

Tests: `update <pkg>@<version> updates only the selected package` and
`update <alias>@npm:<pkg>@<version> updates the aliased package`, each
verified to fail without its corresponding fix.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [ ] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting. _(pacquet already handles versioned selectors; the `npm:` alias half still needs porting — see "Rust parity" above.)_
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed. _(No user-facing CLI change — the behavior now matches what the docs already describe.)_

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13826"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789039666&installation_model_id=426870&pr_number=13826&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13826&signature=e1a23ae83135d6a900d3eacc86d022424e42368cb22139b153bb9aba881a6577"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm update <package>@<version>` so it updates only the explicitly selected package.
  * Unrelated dependencies now remain at their existing versions during targeted updates.
  * Version-specific updates through `npm:` aliases now correctly update the aliased package.
* **Tests**
  * Added coverage for targeted version updates, including aliased packages and preservation of unselected dependencies.
* **Documentation**
  * Documented the targeted-update behavior in the release notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
