### PR TITLE
fix: decline a fast lockfile update that leaves a patch unused

### DIFF
--- a/.changeset/unused-patch-after-removal.md
+++ b/.changeset/unused-patch-after-removal.md
@@ -4,4 +4,4 @@
 "pnpm": patch
 ---
 
-Dropping the last dependent of a patched package no longer leaves its `patchedDependencies` entry behind. Removing a dependency, widening `ignoredOptionalDependencies`, or adding a removal override could each prune the package while the lockfile kept the patch, where a full resolution reports `ERR_PNPM_UNUSED_PATCH` [#13827](https://github.com/pnpm/pnpm/issues/13827).
+An install that drops the last dependent of a patched package no longer updates the lockfile in place and succeeds silently. Removing a dependency, widening `ignoredOptionalDependencies`, or adding a removal override could each prune the package while the patch stayed configured; such an install now falls back to a full resolution, which reports the unused patch with `ERR_PNPM_UNUSED_PATCH` [#13827](https://github.com/pnpm/pnpm/issues/13827).

--- a/.changeset/unused-patch-after-removal.md
+++ b/.changeset/unused-patch-after-removal.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.deps-installer": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+Dropping the last dependent of a patched package no longer leaves its `patchedDependencies` entry behind. Removing a dependency, widening `ignoredOptionalDependencies`, or adding a removal override could each prune the package while the lockfile kept the patch, where a full resolution reports `ERR_PNPM_UNUSED_PATCH` [#13827](https://github.com/pnpm/pnpm/issues/13827).

--- a/.changeset/unused-patch-after-removal.md
+++ b/.changeset/unused-patch-after-removal.md
@@ -4,4 +4,4 @@
 "pnpm": patch
 ---
 
-An install that drops the last dependent of a patched package no longer updates the lockfile in place and succeeds silently. Removing a dependency, widening `ignoredOptionalDependencies`, or adding a removal override could each prune the package while the patch stayed configured; such an install now falls back to a full resolution, which reports the unused patch with `ERR_PNPM_UNUSED_PATCH` [#13827](https://github.com/pnpm/pnpm/issues/13827).
+An install that drops the last dependent of a patched package no longer updates the lockfile in place and succeeds silently. Removing a dependency, widening `ignoredOptionalDependencies`, or adding a removal override could each prune the package while the patch stayed configured; such an install now falls back to a full resolution, which reports the unused patch with `ERR_PNPM_UNUSED_PATCH`. Under `allowUnusedPatches`, where the lockfile update is kept, the same install now warns that the patch went unused instead of saying nothing [#13827](https://github.com/pnpm/pnpm/issues/13827).

--- a/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
@@ -999,6 +999,11 @@ fn an_unused_patch_is_recorded_without_resolution_and_a_used_one_is_not() {
         vec!["absent-package@1.0.0".to_string()],
         "the new patchedDependencies entry is still recorded",
     );
+    assert!(
+        String::from_utf8_lossy(&assert.get_output().stdout)
+            .contains("The following patches were not used: absent-package@1.0.0"),
+        "and the rewrite still says what the resolution it replaced would have said",
+    );
 
     // Patching a locked package renames its snapshot, which the rewrite
     // does without asking the registry anything — the tarball it patches

--- a/pnpm/crates/package-manager/src/fast_update_compose.rs
+++ b/pnpm/crates/package-manager/src/fast_update_compose.rs
@@ -2,7 +2,7 @@ use crate::fast_update_lockfile::GraphEdits;
 use pacquet_config::Config;
 use pacquet_lockfile::Lockfile;
 use pacquet_package_manifest::PackageManifest;
-use std::path::PathBuf;
+use std::{collections::BTreeMap, path::PathBuf};
 
 /// What a fast-update handler's detector concluded about its slice of
 /// the configuration and manifests.
@@ -34,6 +34,7 @@ pub(crate) fn try_compose_fast_updates(
     manifests: &[(String, &PackageManifest)],
     project_manifests: &[(PathBuf, &PackageManifest)],
     config: &Config,
+    patch_hashes: Option<&BTreeMap<String, String>>,
     prune_stale_importers: bool,
 ) -> Option<Lockfile> {
     let ignored_optional_dependencies =
@@ -58,19 +59,12 @@ pub(crate) fn try_compose_fast_updates(
             Drift::Resolve => return None,
             drift => drift,
         };
-    // Reading and hashing the patch files is the only I/O this pipeline
-    // does, and both the drift check and the guard at the end need the
-    // result.
-    let Ok(patch_hashes) = config.patched_dependency_hashes() else {
-        return None;
-    };
-    let patched = match crate::fast_update_patched_dependencies::detect_patched_drift(
-        lockfile,
-        patch_hashes.as_ref(),
-    ) {
-        Drift::Resolve => return None,
-        drift => drift,
-    };
+    let patched =
+        match crate::fast_update_patched_dependencies::detect_patched_drift(lockfile, patch_hashes)
+        {
+            Drift::Resolve => return None,
+            drift => drift,
+        };
     let settings_drift =
         match crate::fast_update_settings::detect_settings_drift(lockfile, &settings) {
             Drift::Resolve => return None,
@@ -120,7 +114,7 @@ pub(crate) fn try_compose_fast_updates(
     }
     if !crate::fast_update_patched_dependencies::every_configured_patch_is_applied(
         &candidate,
-        patch_hashes.as_ref(),
+        patch_hashes,
         config.allow_unused_patches,
     ) {
         return None;

--- a/pnpm/crates/package-manager/src/fast_update_compose.rs
+++ b/pnpm/crates/package-manager/src/fast_update_compose.rs
@@ -22,7 +22,9 @@ pub(crate) enum Drift<Plan> {
 /// the shared graph epilogue
 /// ([`crate::fast_update_lockfile::finish_graph_edits`]), then patch
 /// rekeying — after the prune, so its guards see the packages a full
-/// resolution would see — and the settings block last.
+/// resolution would see — and the settings block last. What survives is
+/// then held to
+/// [`crate::fast_update_patched_dependencies::every_configured_patch_is_applied`].
 ///
 /// `None` — no drift, or drift some handler cannot express — leaves the
 /// caller on the full-resolution path; the caller still validates the
@@ -108,9 +110,6 @@ pub(crate) fn try_compose_fast_updates(
     {
         return None;
     }
-    // Last, over the settled graph: every handler above can drop the last
-    // dependent of a patched package, and the patch left with nothing to
-    // apply to is a state only a resolution reports.
     if !crate::fast_update_patched_dependencies::every_configured_patch_is_applied(
         &candidate, config,
     ) {

--- a/pnpm/crates/package-manager/src/fast_update_compose.rs
+++ b/pnpm/crates/package-manager/src/fast_update_compose.rs
@@ -108,6 +108,14 @@ pub(crate) fn try_compose_fast_updates(
     {
         return None;
     }
+    // Last, over the settled graph: every handler above can drop the last
+    // dependent of a patched package, and the patch left with nothing to
+    // apply to is a state only a resolution reports.
+    if !crate::fast_update_patched_dependencies::every_configured_patch_is_applied(
+        &candidate, config,
+    ) {
+        return None;
+    }
     Some(candidate)
 }
 

--- a/pnpm/crates/package-manager/src/fast_update_compose.rs
+++ b/pnpm/crates/package-manager/src/fast_update_compose.rs
@@ -58,11 +58,19 @@ pub(crate) fn try_compose_fast_updates(
             Drift::Resolve => return None,
             drift => drift,
         };
-    let patched =
-        match crate::fast_update_patched_dependencies::detect_patched_drift(lockfile, config) {
-            Drift::Resolve => return None,
-            drift => drift,
-        };
+    // Reading and hashing the patch files is the only I/O this pipeline
+    // does, and both the drift check and the guard at the end need the
+    // result.
+    let Ok(patch_hashes) = config.patched_dependency_hashes() else {
+        return None;
+    };
+    let patched = match crate::fast_update_patched_dependencies::detect_patched_drift(
+        lockfile,
+        patch_hashes.as_ref(),
+    ) {
+        Drift::Resolve => return None,
+        drift => drift,
+    };
     let settings_drift =
         match crate::fast_update_settings::detect_settings_drift(lockfile, &settings) {
             Drift::Resolve => return None,
@@ -111,7 +119,9 @@ pub(crate) fn try_compose_fast_updates(
         return None;
     }
     if !crate::fast_update_patched_dependencies::every_configured_patch_is_applied(
-        &candidate, config,
+        &candidate,
+        patch_hashes.as_ref(),
+        config.allow_unused_patches,
     ) {
         return None;
     }

--- a/pnpm/crates/package-manager/src/fast_update_compose/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_compose/tests.rs
@@ -233,7 +233,7 @@ fn lockfile_recording_a_patch_for_bar(config: &Config) -> Lockfile {
         &[(".".to_string(), &keeps_everything)],
         &[],
         config,
-        patch_hashes(&config).as_ref(),
+        patch_hashes(config).as_ref(),
         false,
     )
     .expect("the patch rekey alone is absorbed")

--- a/pnpm/crates/package-manager/src/fast_update_compose/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_compose/tests.rs
@@ -82,9 +82,15 @@ fn absorbs_a_removal_and_a_widened_ignore_list_in_one_pass() {
         ..Config::default()
     };
 
-    let updated =
-        try_compose_fast_updates(&lockfile(), &[(".".to_string(), &manifest)], &[], &config, false)
-            .expect("both kinds of drift are absorbable at once");
+    let updated = try_compose_fast_updates(
+        &lockfile(),
+        &[(".".to_string(), &manifest)],
+        &[],
+        &config,
+        patch_hashes(&config).as_ref(),
+        false,
+    )
+    .expect("both kinds of drift are absorbable at once");
 
     assert_eq!(
         snapshot_keys(&updated),
@@ -120,6 +126,7 @@ fn absorbs_a_group_move_and_a_settings_change_in_one_pass() {
         &[(".".to_string(), &manifest)],
         &[(PathBuf::from("/project"), &manifest)],
         &config,
+        patch_hashes(&config).as_ref(),
         false,
     )
     .expect("a peerless lockfile absorbs the setting alongside the move");
@@ -154,6 +161,7 @@ fn falls_back_when_one_of_the_composed_changes_cannot_be_absorbed() {
             &[(".".to_string(), &manifest)],
             &[(PathBuf::from("/project"), &manifest)],
             &config,
+            patch_hashes(&config).as_ref(),
             false,
         )
         .is_none(),
@@ -171,8 +179,15 @@ fn falls_back_when_a_removal_leaves_a_configured_patch_unused() {
     let config = Config { allow_unused_patches: false, ..patch_config(dir.path(), &["bar@2.0.0"]) };
 
     assert!(
-        try_compose_fast_updates(&lockfile(), &[(".".to_string(), &manifest)], &[], &config, false)
-            .is_none(),
+        try_compose_fast_updates(
+            &lockfile(),
+            &[(".".to_string(), &manifest)],
+            &[],
+            &config,
+            patch_hashes(&config).as_ref(),
+            false
+        )
+        .is_none(),
         "removing the patch's only referent is what the resolver reports as an unused patch",
     );
 }
@@ -186,9 +201,15 @@ fn rekeys_a_patched_survivor_alongside_a_removal() {
     }));
     let config = patch_config(dir.path(), &["bar@2.0.0"]);
 
-    let updated =
-        try_compose_fast_updates(&lockfile(), &[(".".to_string(), &manifest)], &[], &config, false)
-            .expect("the removal and the patch rekey compose");
+    let updated = try_compose_fast_updates(
+        &lockfile(),
+        &[(".".to_string(), &manifest)],
+        &[],
+        &config,
+        patch_hashes(&config).as_ref(),
+        false,
+    )
+    .expect("the removal and the patch rekey compose");
 
     assert!(
         snapshot_keys(&updated).iter().any(|key| key.starts_with("bar@2.0.0(patch_hash=")),
@@ -212,6 +233,7 @@ fn lockfile_recording_a_patch_for_bar(config: &Config) -> Lockfile {
         &[(".".to_string(), &keeps_everything)],
         &[],
         config,
+        patch_hashes(&config).as_ref(),
         false,
     )
     .expect("the patch rekey alone is absorbed")
@@ -228,8 +250,15 @@ fn falls_back_when_a_removal_orphans_a_patch_the_lockfile_already_records() {
     }));
 
     assert!(
-        try_compose_fast_updates(&subject, &[(".".to_string(), &drops_bar)], &[], &config, false)
-            .is_none(),
+        try_compose_fast_updates(
+            &subject,
+            &[(".".to_string(), &drops_bar)],
+            &[],
+            &config,
+            patch_hashes(&config).as_ref(),
+            false
+        )
+        .is_none(),
         "the patch is left with nothing to apply to, which only a resolution reports",
     );
 }
@@ -244,9 +273,15 @@ fn absorbs_a_removal_that_orphans_a_patch_under_allow_unused_patches() {
         "optionalDependencies": { "opt": "^5.0.0" },
     }));
 
-    let updated =
-        try_compose_fast_updates(&subject, &[(".".to_string(), &drops_bar)], &[], &config, false)
-            .expect("an unused patch is only a warning here");
+    let updated = try_compose_fast_updates(
+        &subject,
+        &[(".".to_string(), &drops_bar)],
+        &[],
+        &config,
+        patch_hashes(&config).as_ref(),
+        false,
+    )
+    .expect("an unused patch is only a warning here");
     assert!(!snapshot_keys(&updated).iter().any(|key| key.starts_with("bar@")));
 }
 
@@ -275,7 +310,15 @@ fn falls_back_when_an_ignored_optional_is_embedded_in_a_peer_suffix() {
     };
 
     assert!(
-        try_compose_fast_updates(&subject, &[], &[], &config, false).is_none(),
+        try_compose_fast_updates(
+            &subject,
+            &[],
+            &[],
+            &config,
+            patch_hashes(&config).as_ref(),
+            false
+        )
+        .is_none(),
         "the surviving dependent's key embeds the removed package, so it would rekey, not prune",
     );
 }
@@ -293,6 +336,7 @@ fn stands_aside_when_nothing_drifted() {
             &[(".".to_string(), &manifest)],
             &[],
             &Config::default(),
+            None,
             false,
         )
         .is_none(),
@@ -327,13 +371,26 @@ fn recomputes_optional_flags_for_an_ignored_optional_removal() {
         .expect("snapshot")
         .optional = true;
 
-    let updated = try_compose_fast_updates(&subject, &[], &[], &config, false)
-        .expect("widening the ignore list needs no resolution");
+    let updated = try_compose_fast_updates(
+        &subject,
+        &[],
+        &[],
+        &config,
+        patch_hashes(&config).as_ref(),
+        false,
+    )
+    .expect("widening the ignore list needs no resolution");
 
     assert!(
         snapshot_optional(&updated, "child@3.0.0"),
         "only the optional path reaches child once bar is ignored",
     );
+}
+
+/// The hashes the caller computes once per attempt and hands to the
+/// pipeline.
+fn patch_hashes(config: &Config) -> Option<std::collections::BTreeMap<String, String>> {
+    config.patched_dependency_hashes().expect("hash the configured patch files")
 }
 
 fn workspace(patches: &[&str]) -> TempDir {
@@ -401,6 +458,7 @@ fn absorbs_a_peer_setting_once_the_removal_drops_the_last_peer_dependent() {
         &[(".".to_string(), &manifest)],
         &[(PathBuf::from("/project"), &manifest)],
         &config,
+        patch_hashes(&config).as_ref(),
         false,
     )
     .expect("the removal prunes the only peer dependent, so the setting cannot affect the graph");

--- a/pnpm/crates/package-manager/src/fast_update_compose/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_compose/tests.rs
@@ -200,6 +200,56 @@ fn rekeys_a_patched_survivor_alongside_a_removal() {
     );
 }
 
+/// The patch configuration itself is unchanged here, so the patch handler
+/// never runs — only the removal drifts, and it is what orphans the patch.
+fn lockfile_recording_a_patch_for_bar(config: &Config) -> Lockfile {
+    let keeps_everything = manifest_from(json!({
+        "dependencies": { "foo": "^1.0.0", "bar": "^2.0.0" },
+        "optionalDependencies": { "opt": "^5.0.0" },
+    }));
+    try_compose_fast_updates(
+        &lockfile(),
+        &[(".".to_string(), &keeps_everything)],
+        &[],
+        config,
+        false,
+    )
+    .expect("the patch rekey alone is absorbed")
+}
+
+#[test]
+fn falls_back_when_a_removal_orphans_a_patch_the_lockfile_already_records() {
+    let dir = workspace(&["bar@2.0.0"]);
+    let config = Config { allow_unused_patches: false, ..patch_config(dir.path(), &["bar@2.0.0"]) };
+    let subject = lockfile_recording_a_patch_for_bar(&config);
+    let drops_bar = manifest_from(json!({
+        "dependencies": { "foo": "^1.0.0" },
+        "optionalDependencies": { "opt": "^5.0.0" },
+    }));
+
+    assert!(
+        try_compose_fast_updates(&subject, &[(".".to_string(), &drops_bar)], &[], &config, false)
+            .is_none(),
+        "the patch is left with nothing to apply to, which only a resolution reports",
+    );
+}
+
+#[test]
+fn absorbs_a_removal_that_orphans_a_patch_under_allow_unused_patches() {
+    let dir = workspace(&["bar@2.0.0"]);
+    let config = patch_config(dir.path(), &["bar@2.0.0"]);
+    let subject = lockfile_recording_a_patch_for_bar(&config);
+    let drops_bar = manifest_from(json!({
+        "dependencies": { "foo": "^1.0.0" },
+        "optionalDependencies": { "opt": "^5.0.0" },
+    }));
+
+    let updated =
+        try_compose_fast_updates(&subject, &[(".".to_string(), &drops_bar)], &[], &config, false)
+            .expect("an unused patch is only a warning here");
+    assert!(!snapshot_keys(&updated).iter().any(|key| key.starts_with("bar@")));
+}
+
 #[test]
 fn falls_back_when_an_ignored_optional_is_embedded_in_a_peer_suffix() {
     let mut subject = lockfile();

--- a/pnpm/crates/package-manager/src/fast_update_compose/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_compose/tests.rs
@@ -200,8 +200,8 @@ fn rekeys_a_patched_survivor_alongside_a_removal() {
     );
 }
 
-/// The patch configuration itself is unchanged here, so the patch handler
-/// never runs — only the removal drifts, and it is what orphans the patch.
+/// Records the patch so a later pass sees it already configured, leaving the
+/// removal as the only drift.
 fn lockfile_recording_a_patch_for_bar(config: &Config) -> Lockfile {
     let keeps_everything = manifest_from(json!({
         "dependencies": { "foo": "^1.0.0", "bar": "^2.0.0" },

--- a/pnpm/crates/package-manager/src/fast_update_ignored_optional_dependencies/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_ignored_optional_dependencies/tests.rs
@@ -15,6 +15,7 @@ fn try_fast_update_ignored_optional_dependencies(
             ignored_optional_dependencies: Some(ignored_optional_dependencies.to_vec()),
             ..pacquet_config::Config::default()
         },
+        None,
         false,
     )
 }

--- a/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
@@ -16,6 +16,7 @@ fn try_fast_update_importers(
         manifests,
         &[],
         &pacquet_config::Config::default(),
+        None,
         false,
     )
 }
@@ -906,6 +907,7 @@ fn rejects_a_new_project_that_depends_on_a_workspace_sibling() {
             &projects_of_a_new_project_lockfile(&existing, &locks_the_higher_child, &added),
             &[(PathBuf::from("/workspace/child"), &sibling)],
             &pacquet_config::Config::default(),
+            None,
             false,
         )
         .is_none(),
@@ -925,6 +927,7 @@ fn rejects_a_widened_range_when_resolution_would_pick_its_lowest_locked_version(
             &[(".".to_string(), &manifest), ("pkg-a".to_string(), &other)],
             &[],
             &config,
+            None,
             false,
         )
         .is_none(),
@@ -944,6 +947,7 @@ fn rejects_a_new_project_when_resolution_would_pick_the_lowest_of_several_locked
             &projects_of_a_new_project_lockfile(&existing, &locks_the_higher_child, &added),
             &[],
             &config,
+            None,
             false,
         )
         .is_none(),
@@ -1015,6 +1019,7 @@ fn try_prune_stale_importers(
         manifests,
         &[],
         &pacquet_config::Config::default(),
+        None,
         true,
     )
 }
@@ -1046,6 +1051,7 @@ fn keeps_the_importer_when_the_run_does_not_see_every_project() {
             &[("packages/a".to_string(), &manifest)],
             &[],
             &pacquet_config::Config::default(),
+            None,
             false,
         )
         .is_none(),
@@ -1444,6 +1450,7 @@ fn rejects_adding_a_dependency_naming_a_workspace_project() {
             &[(".".to_string(), &manifest)],
             &[(PathBuf::from("/child/package.json"), &sibling)],
             &pacquet_config::Config::default(),
+            None,
             false,
         )
         .is_none(),
@@ -1465,6 +1472,7 @@ fn rejects_adding_a_dependency_several_locked_versions_satisfy_when_resolution_p
             &[(".".to_string(), &manifest)],
             &[],
             &config,
+            None,
             false,
         )
         .is_none(),

--- a/pnpm/crates/package-manager/src/fast_update_patched_dependencies.rs
+++ b/pnpm/crates/package-manager/src/fast_update_patched_dependencies.rs
@@ -242,6 +242,38 @@ fn rewrite_importer_group(group: &mut ResolvedDependencyMap, rekeys: &Rekeys) {
 /// the hashes [`Config::patched_dependency_hashes`] already computed are
 /// the only payload the rewrite needs, so no patch file is read twice.
 ///
+/// Whether every configured patch still has a package to apply to.
+///
+/// A patch with none left is `ERR_PNPM_UNUSED_PATCH`, which only a
+/// resolution raises, so a rewrite that would produce one has to decline
+/// and let the resolver report it. Any handler that drops an edge can
+/// produce one, not only a changed patch configuration, so this runs over
+/// the settled graph rather than inside [`apply_patched_update`].
+///
+/// `allowUnusedPatches` turns that error into a warning the resolution
+/// emits, which no rewrite reproduces either; as elsewhere in this module,
+/// a warning is not worth a full resolution.
+pub(crate) fn every_configured_patch_is_applied(lockfile: &Lockfile, config: &Config) -> bool {
+    if config.allow_unused_patches {
+        return true;
+    }
+    let hashes = match config.patched_dependency_hashes() {
+        Ok(Some(hashes)) => hashes,
+        Ok(None) => return true,
+        Err(_) => return false,
+    };
+    if hashes.is_empty() {
+        return true;
+    }
+    let Some(groups) = groups_from_hashes(&hashes) else {
+        return false;
+    };
+    let Some(applied) = applied_patch_keys(lockfile, &groups) else {
+        return false;
+    };
+    !all_patch_keys(&groups).any(|key| !applied.contains(key))
+}
+
 /// `None` for a key whose version segment is neither a version nor a
 /// range, leaving `ERR_PNPM_PATCH_NON_SEMVER_RANGE` to the resolver.
 fn groups_from_hashes(hashes: &BTreeMap<String, String>) -> Option<PatchGroupRecord> {

--- a/pnpm/crates/package-manager/src/fast_update_patched_dependencies.rs
+++ b/pnpm/crates/package-manager/src/fast_update_patched_dependencies.rs
@@ -266,6 +266,23 @@ pub(crate) fn every_configured_patch_is_applied(
     !all_patch_keys(&groups).any(|key| !applied.contains(key))
 }
 
+/// The configured patches the committed lockfile leaves unused, as the
+/// resolution's own `verify_patches` would report them.
+///
+/// Only non-empty with `allowUnusedPatches` on: with it off,
+/// [`every_configured_patch_is_applied`] declines the rewrite instead, and
+/// the resolution that takes over raises `ERR_PNPM_UNUSED_PATCH`.
+pub(crate) fn unused_patches(
+    lockfile: &Lockfile,
+    hashes: Option<&BTreeMap<String, String>>,
+) -> Option<pacquet_patching::UnusedPatches> {
+    let hashes = hashes.filter(|hashes| !hashes.is_empty())?;
+    let groups = groups_from_hashes(hashes)?;
+    let applied = applied_patch_keys(lockfile, &groups)?;
+    let applied = applied.into_iter().map(str::to_string).collect();
+    pacquet_patching::verify_patches(&groups, &applied, true).ok().flatten()
+}
+
 /// Bucket `hashes` the way the resolver buckets configured patches.
 ///
 /// The patch file path is left out: nothing here applies a patch, and

--- a/pnpm/crates/package-manager/src/fast_update_patched_dependencies.rs
+++ b/pnpm/crates/package-manager/src/fast_update_patched_dependencies.rs
@@ -1,5 +1,4 @@
 use crate::fast_update_compose::Drift;
-use pacquet_config::Config;
 use pacquet_deps_path::{index_of_dep_path_suffix, remove_suffix};
 use pacquet_lockfile::{
     ImporterDepVersion, Lockfile, PackageKey, ProjectSnapshot, ResolvedDependencyMap,
@@ -29,16 +28,16 @@ pub(crate) struct PatchedPlan {
 }
 
 /// Whether `patchedDependencies` drifted from what the lockfile
-/// records. [`Drift::Resolve`] when a patch file cannot be read or
-/// hashed, or a key's version segment parses as neither a version nor a
-/// range — the resolver reports those.
-pub(crate) fn detect_patched_drift(lockfile: &Lockfile, config: &Config) -> Drift<PatchedPlan> {
+/// records, against the hashes of the configured patch files.
+/// [`Drift::Resolve`] when a key's version segment parses as neither a
+/// version nor a range — the resolver reports that.
+pub(crate) fn detect_patched_drift(
+    lockfile: &Lockfile,
+    hashes: Option<&BTreeMap<String, String>>,
+) -> Drift<PatchedPlan> {
     let empty = BTreeMap::new();
-    let Ok(hashes) = config.patched_dependency_hashes() else {
-        return Drift::Resolve;
-    };
     let recorded = lockfile.patched_dependencies.as_ref().unwrap_or(&empty);
-    let current = hashes.as_ref().unwrap_or(&empty);
+    let current = hashes.unwrap_or(&empty);
     if recorded == current {
         return Drift::Clean;
     }
@@ -253,19 +252,18 @@ fn rewrite_importer_group(group: &mut ResolvedDependencyMap, rekeys: &Rekeys) {
 /// `allowUnusedPatches` turns that error into a warning the resolution
 /// emits, which no rewrite reproduces either; as elsewhere in this module,
 /// a warning is not worth a full resolution.
-pub(crate) fn every_configured_patch_is_applied(lockfile: &Lockfile, config: &Config) -> bool {
-    if config.allow_unused_patches {
+pub(crate) fn every_configured_patch_is_applied(
+    lockfile: &Lockfile,
+    hashes: Option<&BTreeMap<String, String>>,
+    allow_unused_patches: bool,
+) -> bool {
+    if allow_unused_patches {
         return true;
     }
-    let hashes = match config.patched_dependency_hashes() {
-        Ok(Some(hashes)) => hashes,
-        Ok(None) => return true,
-        Err(_) => return false,
+    let Some(hashes) = hashes.filter(|hashes| !hashes.is_empty()) else {
+        return true;
     };
-    if hashes.is_empty() {
-        return true;
-    }
-    let Some(groups) = groups_from_hashes(&hashes) else {
+    let Some(groups) = groups_from_hashes(hashes) else {
         return false;
     };
     let Some(applied) = applied_patch_keys(lockfile, &groups) else {

--- a/pnpm/crates/package-manager/src/fast_update_patched_dependencies.rs
+++ b/pnpm/crates/package-manager/src/fast_update_patched_dependencies.rs
@@ -235,12 +235,6 @@ fn rewrite_importer_group(group: &mut ResolvedDependencyMap, rekeys: &Rekeys) {
     }
 }
 
-/// Bucket `hashes` the way the resolver buckets configured patches.
-///
-/// The patch file path is left out: nothing here applies a patch, and
-/// the hashes [`Config::patched_dependency_hashes`] already computed are
-/// the only payload the rewrite needs, so no patch file is read twice.
-///
 /// Whether every configured patch still has a package to apply to.
 ///
 /// A patch with none left is `ERR_PNPM_UNUSED_PATCH`, which only a
@@ -272,6 +266,13 @@ pub(crate) fn every_configured_patch_is_applied(
     !all_patch_keys(&groups).any(|key| !applied.contains(key))
 }
 
+/// Bucket `hashes` the way the resolver buckets configured patches.
+///
+/// The patch file path is left out: nothing here applies a patch, and
+/// the hashes [`pacquet_config::Config::patched_dependency_hashes`]
+/// already computed are the only payload the rewrite needs, so no patch
+/// file is read twice.
+///
 /// `None` for a key whose version segment is neither a version nor a
 /// range, leaving `ERR_PNPM_PATCH_NON_SEMVER_RANGE` to the resolver.
 fn groups_from_hashes(hashes: &BTreeMap<String, String>) -> Option<PatchGroupRecord> {

--- a/pnpm/crates/package-manager/src/fast_update_patched_dependencies/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_patched_dependencies/tests.rs
@@ -2,7 +2,19 @@
 /// every other input is neutral, so these tests exercise this handler
 /// alone.
 fn try_fast_update_patched_dependencies(lockfile: &Lockfile, config: &Config) -> Option<Lockfile> {
-    crate::fast_update_compose::try_compose_fast_updates(lockfile, &[], &[], config, false)
+    {
+        // As the caller does: an unreadable patch file declines the whole
+        // attempt rather than reading as no patches at all.
+        let hashes = config.patched_dependency_hashes().ok()?;
+        crate::fast_update_compose::try_compose_fast_updates(
+            lockfile,
+            &[],
+            &[],
+            config,
+            hashes.as_ref(),
+            false,
+        )
+    }
 }
 use indexmap::IndexMap;
 use pacquet_config::Config;

--- a/pnpm/crates/package-manager/src/install/lockfile_freshness.rs
+++ b/pnpm/crates/package-manager/src/install/lockfile_freshness.rs
@@ -28,11 +28,20 @@ pub(super) async fn try_fast_update_lockfile<Reporter: pacquet_reporter::Reporte
     opts: FastUpdateLockfileOptions<'_, '_>,
 ) -> Option<Lockfile> {
     let lockfile = opts.lockfile?;
+    // Hashed once for the whole attempt: the drift check, the unused-patch
+    // guard inside the pipeline, and the report below all need the same
+    // snapshot, and reading the patch files is the only I/O any of them do.
+    // `Err` is a patch file that cannot be read or hashed, which the
+    // resolver reports — not the same as having none configured.
+    let Ok(patch_hashes) = opts.config.patched_dependency_hashes() else {
+        return None;
+    };
     let candidate = crate::fast_update_compose::try_compose_fast_updates(
         lockfile,
         opts.manifests,
         opts.project_manifests,
         opts.config,
+        patch_hashes.as_ref(),
         opts.prune_stale_importers,
     )?;
     check_lockfile_freshness(
@@ -52,9 +61,8 @@ pub(super) async fn try_fast_update_lockfile<Reporter: pacquet_reporter::Reporte
     // Only the committed candidate is worth reporting on: a rewrite the
     // freshness gates reject is followed by the resolution, which reports it
     // itself.
-    let hashes = opts.config.patched_dependency_hashes().ok().flatten();
     if let Some(unused) =
-        crate::fast_update_patched_dependencies::unused_patches(&candidate, hashes.as_ref())
+        crate::fast_update_patched_dependencies::unused_patches(&candidate, patch_hashes.as_ref())
     {
         Reporter::emit(&pacquet_reporter::LogEvent::Global(pacquet_reporter::GlobalLog {
             level: pacquet_reporter::LogLevel::Warn,

--- a/pnpm/crates/package-manager/src/install/lockfile_freshness.rs
+++ b/pnpm/crates/package-manager/src/install/lockfile_freshness.rs
@@ -24,7 +24,7 @@ pub(super) struct FastUpdateLockfileOptions<'a, 'manifest> {
 /// the loaded lockfile once it passes every freshness gate, so a
 /// handler that rewrites too much falls back to the resolver instead
 /// of committing.
-pub(super) async fn try_fast_update_lockfile(
+pub(super) async fn try_fast_update_lockfile<Reporter: pacquet_reporter::Reporter>(
     opts: FastUpdateLockfileOptions<'_, '_>,
 ) -> Option<Lockfile> {
     let lockfile = opts.lockfile?;
@@ -49,6 +49,18 @@ pub(super) async fn try_fast_update_lockfile(
     )
     .await
     .ok()?;
+    // Only the committed candidate is worth reporting on: a rewrite the
+    // freshness gates reject is followed by the resolution, which reports it
+    // itself.
+    let hashes = opts.config.patched_dependency_hashes().ok().flatten();
+    if let Some(unused) =
+        crate::fast_update_patched_dependencies::unused_patches(&candidate, hashes.as_ref())
+    {
+        Reporter::emit(&pacquet_reporter::LogEvent::Global(pacquet_reporter::GlobalLog {
+            level: pacquet_reporter::LogLevel::Warn,
+            message: unused.to_string(),
+        }));
+    }
     Some(candidate)
 }
 

--- a/pnpm/crates/package-manager/src/install/run.rs
+++ b/pnpm/crates/package-manager/src/install/run.rs
@@ -572,7 +572,7 @@ where
             && prefer_frozen_lockfile
             && mutation.may_fast_update_lockfile();
         let fast_updated_lockfile = if can_fast_update_lockfile {
-            try_fast_update_lockfile(FastUpdateLockfileOptions {
+            try_fast_update_lockfile::<Reporter>(FastUpdateLockfileOptions {
                 lockfile,
                 manifests: &manifest_freshness_inputs,
                 project_manifests: &project_manifests,

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -114,6 +114,7 @@ import { type AddedManifests, tryAddLockedVersions } from './tryAddLockedVersion
 import { tryComposeFastUpdates } from './tryComposeFastUpdates.js'
 import { hasChangedProjectSpecifiers } from './tryFastUpdateImporters.js'
 import { tryFastUpdateLockfile } from './tryFastUpdateLockfile.js'
+import { warnUnusedPatches } from './tryFastUpdatePatchedDependencies.js'
 import { validateModules } from './validateModules.js'
 import { verifyLockfileResolutions } from './verifyLockfileResolutions.js'
 import { warnOnStaleConvergenceOverrides } from './warnOnStaleConvergenceOverrides.js'
@@ -929,6 +930,13 @@ export async function mutateModules (
           })
         }
         addedManifestsAreCommitted = true
+        // Only the committed candidate is worth reporting on: a rewrite the
+        // freshness gates reject is followed by the resolution, which reports
+        // it itself.
+        warnUnusedPatches(ctx.wantedLockfile, {
+          patchedDependencies,
+          allowUnusedPatches: opts.allowUnusedPatches,
+        })
       }
     }
     const outdatedLockfileSettings = outdatedLockfileSettingName != null

--- a/pnpm11/installing/deps-installer/src/install/tryComposeFastUpdates.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryComposeFastUpdates.ts
@@ -14,6 +14,7 @@ import {
   tryFastUpdateOverrides,
 } from './tryFastUpdateOverrides.js'
 import {
+  everyConfiguredPatchIsApplied,
   type FastPatchedDependenciesUpdateOptions,
   tryFastUpdatePatchedDependencies,
 } from './tryFastUpdatePatchedDependencies.js'
@@ -119,6 +120,13 @@ export async function tryComposeFastUpdates (
     return false
   }
   if (opts.drift.overrides && !await tryFastUpdateOverrides(candidate, opts.overrides!)) {
+    return false
+  }
+  // Last, over the settled graph: every handler above can drop the last
+  // dependent of a patched package, and the patch left with nothing to apply
+  // to is a state only a resolution reports.
+  if (opts.patchedDependencies != null &&
+    !everyConfiguredPatchIsApplied(candidate, opts.patchedDependencies)) {
     return false
   }
   return true

--- a/pnpm11/installing/deps-installer/src/install/tryComposeFastUpdates.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryComposeFastUpdates.ts
@@ -85,7 +85,8 @@ export interface ComposeFastUpdatesOptions {
  * (`finishGraphEdits`), then patch rekeying — after the prune, so its guards
  * see the packages a full resolution would see — the settings block, and the
  * two resolver-consulting rewrites last: catalogs before overrides, the order
- * a resolution applies them in.
+ * a resolution applies them in. What survives is then held to
+ * `everyConfiguredPatchIsApplied`.
  *
  * `false` — drift some handler cannot express — leaves the caller on the
  * full-resolution path; `candidate` may be partially rewritten by then, which
@@ -122,9 +123,6 @@ export async function tryComposeFastUpdates (
   if (opts.drift.overrides && !await tryFastUpdateOverrides(candidate, opts.overrides!)) {
     return false
   }
-  // Last, over the settled graph: every handler above can drop the last
-  // dependent of a patched package, and the patch left with nothing to apply
-  // to is a state only a resolution reports.
   if (opts.patchedDependencies != null &&
     !everyConfiguredPatchIsApplied(candidate, opts.patchedDependencies)) {
     return false

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdatePatchedDependencies.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdatePatchedDependencies.ts
@@ -6,6 +6,7 @@ import {
   getPatchInfo,
   groupPatchedDependencies,
   type PatchGroupRecord,
+  verifyPatches,
 } from '@pnpm/patching.config'
 import type { DepPath } from '@pnpm/types'
 
@@ -187,6 +188,28 @@ function changedKeys (
 ): string[] {
   const keys = new Set([...Object.keys(recorded), ...Object.keys(current)])
   return [...keys].filter((key) => recorded[key] !== current[key])
+}
+
+/**
+ * Report the patches the committed lockfile leaves unused, the way a
+ * resolution reports them.
+ *
+ * Only reachable with `allowUnusedPatches` on: with it off,
+ * `everyConfiguredPatchIsApplied` declines the rewrite instead, and the
+ * resolution that takes over raises `ERR_PNPM_UNUSED_PATCH`.
+ */
+export function warnUnusedPatches (
+  lockfile: LockfileObject,
+  opts: FastPatchedDependenciesUpdateOptions
+): void {
+  if (!opts.allowUnusedPatches) return
+  const configured = opts.patchedDependencies ?? {}
+  if (Object.keys(configured).length === 0) return
+  const groups = groupsFromHashes(configured)
+  if (groups == null) return
+  const applied = appliedPatchKeys(lockfile, groups)
+  if (applied == null) return
+  verifyPatches({ patchedDependencies: groups, appliedPatches: applied, allowUnusedPatches: true })
 }
 
 /**

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdatePatchedDependencies.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdatePatchedDependencies.ts
@@ -42,13 +42,7 @@ export function tryFastUpdatePatchedDependencies (
 
   const groups = groupsFromHashes(current)
   if (groups == null) return false
-  if (!opts.allowUnusedPatches) {
-    const applied = appliedPatchKeys(lockfile, groups)
-    if (applied == null) return false
-    for (const key of allPatchKeys(groups)) {
-      if (!applied.has(key)) return false
-    }
-  }
+  if (!everyConfiguredPatchIsApplied(lockfile, opts)) return false
 
   const rekeys = planRekeys(lockfile, groups)
   if (rekeys == null) return false
@@ -58,6 +52,35 @@ export function tryFastUpdatePatchedDependencies (
     delete lockfile.patchedDependencies
   } else {
     lockfile.patchedDependencies = current
+  }
+  return true
+}
+
+/**
+ * Whether every configured patch still has a package to apply to.
+ *
+ * A patch with none left is `ERR_PNPM_UNUSED_PATCH`, which only a resolution
+ * raises — `verifyPatches` runs from the resolver — so a rewrite that would
+ * produce one has to decline and let the resolver report it. Any handler that
+ * drops an edge can produce one, not only a changed patch configuration.
+ *
+ * `allowUnusedPatches` turns that error into a warning the resolution emits,
+ * which no rewrite reproduces either; as elsewhere in this file, a warning is
+ * not worth a full resolution.
+ */
+export function everyConfiguredPatchIsApplied (
+  lockfile: LockfileObject,
+  opts: FastPatchedDependenciesUpdateOptions
+): boolean {
+  if (opts.allowUnusedPatches) return true
+  const configured = opts.patchedDependencies ?? {}
+  if (Object.keys(configured).length === 0) return true
+  const groups = groupsFromHashes(configured)
+  if (groups == null) return false
+  const applied = appliedPatchKeys(lockfile, groups)
+  if (applied == null) return false
+  for (const key of allPatchKeys(groups)) {
+    if (!applied.has(key)) return false
   }
   return true
 }

--- a/pnpm11/installing/deps-installer/test/install/patchedDependenciesFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/patchedDependenciesFastUpdate.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import { expect, test } from '@jest/globals'
+import { expect, jest, test } from '@jest/globals'
 import { createHexHashFromFile } from '@pnpm/crypto.hash'
 import { mutateModulesInSingleProject } from '@pnpm/installing.deps-installer'
 import type { LockfileObject } from '@pnpm/lockfile.types'
@@ -209,6 +209,45 @@ test('adding a patch for a locked package rekeys it without resolution', async (
     version: `1.0.0(patch_hash=${patchFileHash})`,
   })
   expect(fs.readFileSync('node_modules/is-positive/index.js', 'utf8')).toContain('// patched')
+})
+
+test('a removal that orphans an allowed unused patch still reports it', async () => {
+  prepareEmpty()
+  const patchPath = path.join(f.find('patch-pkg'), 'is-positive@1.0.0.patch')
+  const manifest: ProjectManifest = {
+    dependencies: { 'is-positive': '1.0.0', '@pnpm.e2e/pkg-with-1-dep': '100.0.0' },
+  }
+  const options = testDefaults({
+    allowUnusedPatches: true,
+    patchedDependencies: { 'is-positive@1.0.0': patchPath },
+  })
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, options)
+
+  const reporter = jest.fn()
+  const removalOptions = testDefaults({
+    allowUnusedPatches: true,
+    patchedDependencies: { 'is-positive@1.0.0': patchPath },
+    reporter,
+  })
+  const requestedPackages = trackRequestedPackages(removalOptions.storeController)
+  await mutateModulesInSingleProject({
+    dependencyNames: ['is-positive'],
+    manifest,
+    mutation: 'uninstallSome',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, removalOptions)
+
+  // The rewrite keeps the fast path, and still says what the resolution it
+  // replaced would have said.
+  expect(requestedPackages).toStrictEqual([])
+  expect(reporter).toHaveBeenCalledWith(expect.objectContaining({
+    level: 'warn',
+    message: 'The following patches were not used: is-positive@1.0.0',
+  }))
 })
 
 test('the rekeyed lockfile matches what a full resolution writes', async () => {

--- a/pnpm11/installing/deps-installer/test/install/patchedDependenciesFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/patchedDependenciesFastUpdate.ts
@@ -10,6 +10,7 @@ import type { StoreController } from '@pnpm/store.controller-types'
 import { fixtures } from '@pnpm/test-fixtures'
 import type { DepPath, ProjectId, ProjectManifest, ProjectRootDir } from '@pnpm/types'
 
+import { tryComposeFastUpdates } from '../../src/install/tryComposeFastUpdates.js'
 import {
   type FastPatchedDependenciesUpdateOptions,
   tryFastUpdatePatchedDependencies,
@@ -235,6 +236,91 @@ test('the rekeyed lockfile matches what a full resolution writes', async () => {
   }, testDefaults({ patchedDependencies: { 'is-positive@1.0.0': patchPath } }))
 
   expect(rekeyedLockfile).toStrictEqual(resolved.readLockfile())
+})
+
+/**
+ * `parent` is the only thing that reaches the patched `victim`, so dropping it
+ * leaves the patch with nothing to apply to — `ERR_PNPM_UNUSED_PATCH`, which
+ * only a resolution raises.
+ */
+function lockfileWithAPatchedTransitiveDependency (): LockfileObject {
+  return {
+    lockfileVersion: '9.0',
+    patchedDependencies: { 'victim@1.0.0': 'victim-hash' },
+    importers: {
+      ['.' as ProjectId]: {
+        specifiers: { parent: '^1.0.0', keep: '^2.0.0' },
+        dependencies: { parent: '1.0.0', keep: '2.0.0' },
+      },
+    },
+    packages: {
+      ['parent@1.0.0' as DepPath]: {
+        resolution: { integrity: 'sha512-parent' },
+        dependencies: { victim: '1.0.0(patch_hash=victim-hash)' },
+      },
+      ['victim@1.0.0(patch_hash=victim-hash)' as DepPath]: { resolution: { integrity: 'sha512-victim' } },
+      ['keep@2.0.0' as DepPath]: { resolution: { integrity: 'sha512-keep' } },
+    },
+  } as unknown as LockfileObject
+}
+
+const patchedTransitive: FastPatchedDependenciesUpdateOptions = {
+  patchedDependencies: { 'victim@1.0.0': 'victim-hash' },
+  allowUnusedPatches: false,
+}
+
+test('a manifest removal that leaves a patch unused falls back', async () => {
+  expect(await tryComposeFastUpdates(lockfileWithAPatchedTransitiveDependency(), {
+    drift: { importers: true },
+    workspacePackages: new Map(),
+    resolutionPicksLowest: false,
+    projects: [{ id: '.' as ProjectId, manifest: { dependencies: { keep: '^2.0.0' } } as ProjectManifest }],
+    patchedDependencies: patchedTransitive,
+  })).toBe(false)
+})
+
+test('a removal override that leaves a patch unused falls back', async () => {
+  expect(await tryComposeFastUpdates(lockfileWithAPatchedTransitiveDependency(), {
+    drift: { overrides: true },
+    workspacePackages: new Map(),
+    resolutionPicksLowest: false,
+    projects: [],
+    patchedDependencies: patchedTransitive,
+    overrides: {
+      overrides: { victim: '-' },
+      parsedOverrides: [{ selector: 'victim', newBareSpecifier: '-', targetPkg: { name: 'victim' } }],
+      isLockfileUpToDate: async () => true,
+      lockfileDir: '/test',
+      registries: { default: 'https://registry.npmjs.org/' },
+      requestPackage: (() => {
+        throw new Error('a removal resolves nothing')
+      }) as never,
+    },
+  })).toBe(false)
+})
+
+test('a removal that keeps the patch applied is still absorbed', async () => {
+  const subject = lockfileWithAPatchedTransitiveDependency()
+
+  expect(await tryComposeFastUpdates(subject, {
+    drift: { importers: true },
+    workspacePackages: new Map(),
+    resolutionPicksLowest: false,
+    projects: [{ id: '.' as ProjectId, manifest: { dependencies: { parent: '^1.0.0' } } as ProjectManifest }],
+    patchedDependencies: patchedTransitive,
+  })).toBe(true)
+  expect(Object.keys(subject.packages!).sort())
+    .toStrictEqual(['parent@1.0.0', 'victim@1.0.0(patch_hash=victim-hash)'])
+})
+
+test('a removal that leaves a patch unused is absorbed under allowUnusedPatches', async () => {
+  expect(await tryComposeFastUpdates(lockfileWithAPatchedTransitiveDependency(), {
+    drift: { importers: true },
+    workspacePackages: new Map(),
+    resolutionPicksLowest: false,
+    projects: [{ id: '.' as ProjectId, manifest: { dependencies: { keep: '^2.0.0' } } as ProjectManifest }],
+    patchedDependencies: { ...patchedTransitive, allowUnusedPatches: true },
+  })).toBe(true)
 })
 
 function updateOptions (


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

A patch whose last dependent is dropped has nothing left to apply to.
`verifyPatches` runs from the resolver, so the composed fast-update pipeline
was the only path that could reach that state and not report it — it wrote a
lockfile whose `patchedDependencies` named a package it had just pruned, where
a resolution raises `ERR_PNPM_UNUSED_PATCH`:

```
applied: true
patchedDependencies: {"victim@1.0.0":"sha512-patch"}
packages: ["keep@2.0.0"]
```

The check already existed, but only inside the patched-dependencies handler,
which runs only when the patch configuration itself drifted. A removal is
exactly a run where it did not, so all three removal shapes were affected: a
dependency dropped from a manifest, a widened `ignoredOptionalDependencies`,
and a removal override.

It now runs over the settled graph at the end of the pipeline, after every
handler's removals are pruned, in both stacks. `allowUnusedPatches` keeps its
existing meaning — it downgrades the error to a warning the resolution emits,
and as elsewhere in these handlers a warning alone is not worth a full
resolution.

Both new tests were confirmed to fail against the unfixed source, so they pin
the behaviour rather than passing either way.

Closes pnpm/pnpm#13827.

## Squash Commit Body

```text
A patch whose last dependent is dropped has nothing left to apply to.
`verifyPatches` runs from the resolver, so the composed pipeline was the
only path that could reach that state and not report it: it wrote a
lockfile whose `patchedDependencies` named a package it had just pruned,
where a resolution raises `ERR_PNPM_UNUSED_PATCH`.

The check existed, but only inside the patched-dependencies handler,
which runs only when the patch configuration itself drifted. A removal
is exactly a run where it did not — whether the edge goes away with a
manifest dependency, a widened `ignoredOptionalDependencies`, or a
removal override.

It now runs over the settled graph at the end of the pipeline, where
every handler's removals are already pruned. `allowUnusedPatches` keeps
its existing meaning: it downgrades the error to a warning the
resolution emits, and as elsewhere in these handlers a warning alone is
not worth a full resolution.

Closes pnpm/pnpm#13827.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13828"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789043328&installation_model_id=426870&pr_number=13828&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13828&signature=0effe39e95839be29c168161da447b443c23321e406b2f30c913a38147a6fadb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Installs now perform full resolution when removing the last dependent of a patched package.
  * Unused patches are reported instead of silently updating the lockfile.
  * Fast updates now correctly fall back to resolution when configured patches are no longer applied.
  * Patched snapshots are pruned when unused patches are explicitly allowed.
  * Unused-patch warnings are shown only for successfully committed lockfile updates.
* **Tests**
  * Added coverage for patched dependency removal, overrides, transitive dependencies, and unused-patch handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->