### PR TITLE
fix(resolver): settle contested children under the owner's overlay

### DIFF
--- a/.changeset/deterministic-contested-children.md
+++ b/.changeset/deterministic-contested-children.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Resolution no longer depends on the order in which concurrent resolutions of the same package finish. When one package was reached from several places, whichever occurrence happened to walk it first decided the versions its dependencies were recorded at, so repeated installs of the same project could produce different `pnpm-lock.yaml` files.

--- a/pnpm/crates/resolving-deps-resolver/Cargo.toml
+++ b/pnpm/crates/resolving-deps-resolver/Cargo.toml
@@ -40,7 +40,7 @@ async-trait       = { workspace = true }
 node-semver       = { workspace = true }
 pretty_assertions = { workspace = true }
 tempfile          = { workspace = true }
-tokio             = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio             = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
 
 [lints]
 workspace = true

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/reuse.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/reuse.rs
@@ -29,9 +29,9 @@ use super::{
     tree_ctx::TreeCtx,
     walk::{node_alias, parent_ids_contain_sequence, resolve_node},
     workspace_ctx::{
-        DirectDepVersions, RecordedChildrenContext, claim_children_owner, insert_tree_node,
-        is_current_children_owner, lazy_children, make_non_owner_nodes_lazy, record_children,
-        remember_node_parent_ids,
+        ChildrenOverlayView, DirectDepVersions, RecordedChildrenContext, claim_children_owner,
+        insert_tree_node, is_current_children_owner, lazy_children, make_non_owner_nodes_lazy,
+        record_children, remember_node_parent_ids,
     },
 };
 
@@ -659,6 +659,10 @@ where
                     peer_shadowed: Arc::clone(&children_owner.peer_shadowed),
                     prior_key: Some(key.clone()),
                     update_active: !matches!(ctx.update_reuse_scope(), UpdateReuseScope::All),
+                    // The snapshot pins every child to an exact
+                    // version, so no preferred-versions overlay entry
+                    // can move this recording's edges.
+                    overlay_view: ChildrenOverlayView::new(),
                 },
             );
             recording.into_children(realized, ancestor_ids)

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
@@ -15,7 +15,7 @@ use pacquet_resolving_resolver_base::{
 use pipe_trait::Pipe;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use serde_json::Value;
-use std::{borrow::Cow, collections::BTreeMap, path::Path, sync::Arc};
+use std::{collections::BTreeMap, path::Path, sync::Arc};
 
 use crate::{
     lockfile_reuse::{current_pkg_from_lockfile, prior_child_key},
@@ -42,10 +42,10 @@ use super::{
         project_relative_cache_scope,
     },
     workspace_ctx::{
-        ChildSpec, ChildrenOwnerClaim, RecordedChildrenContext, WantedKey, claim_children_owner,
-        insert_tree_node, is_current_children_owner, lazy_children, make_non_owner_nodes_lazy,
-        record_children, recorded_children_match, register_peer_dep_names,
-        remember_node_parent_ids,
+        ChildSpec, ChildrenOverlayView, ChildrenOwnerClaim, RecordedChildrenContext, WantedKey,
+        claim_children_owner, insert_tree_node, is_current_children_owner, lazy_children,
+        make_non_owner_nodes_lazy, record_children, recorded_children_match,
+        register_peer_dep_names, remember_node_parent_ids,
     },
 };
 
@@ -559,13 +559,6 @@ where
         current_is_optional,
         prior_key,
     } = pending;
-    // Built on demand: a linked node and a losing occurrence never
-    // reach either the reuse test or the recording.
-    let children_context = || RecordedChildrenContext {
-        peer_shadowed: Arc::clone(&children_owner.peer_shadowed),
-        prior_key: prior_key.clone(),
-        update_active: !matches!(ctx.update_reuse_scope(), super::UpdateReuseScope::All),
-    };
     let (children, others_stale) = if is_link {
         // Linked nodes don't walk their manifest's deps — see the
         // `is_link` comment block above. They get an empty `Realized`
@@ -573,187 +566,155 @@ where
         (crate::resolved_tree::TreeChildren::Realized(BTreeMap::new()), false)
     } else if !children_owner.owns_children {
         (lazy_children(&parent_ancestors), false)
-    } else if !resolves_children_through_catalogs(&result)
-        && recorded_children_match(ctx, &id, &children_context())
-    {
-        // A winning claim means this occurrence outranks the one that
-        // recorded the children, not that the children differ.
-        // Occurrences of one package race for the claim, so walking on
-        // every win costs a redundant subtree walk and a second set of
-        // occurrence nodes per race — enough, down a peer-carrying
-        // chain, to expand exponentially with its depth
-        // (https://github.com/pnpm/pnpm/issues/13574).
-        (lazy_children(&parent_ancestors), false)
     } else {
-        // Look up cached children specs first; only walk the manifest on
-        // a miss. The cache value is held by `Arc` so revisits clone the
-        // refcount instead of the inner `Vec<(String, String, bool)>`.
-        let child_specs = {
-            let cache = lock_recoverable(&ctx.workspace.children_specs_by_id);
-            cache.get(&id).map(Arc::clone)
+        let child_specs = owned_child_specs(ctx, &id, &result, &children_owner.peer_shadowed)?;
+        let children_context = RecordedChildrenContext {
+            peer_shadowed: Arc::clone(&children_owner.peer_shadowed),
+            prior_key: prior_key.clone(),
+            update_active: !matches!(ctx.update_reuse_scope(), super::UpdateReuseScope::All),
+            overlay_view: children_overlay_view(&child_specs, children_overlay.as_deref()),
         };
-        let child_specs = if let Some(specs) = child_specs {
-            specs
+        if !resolves_children_through_catalogs(&result)
+            && recorded_children_match(ctx, &id, &children_context)
+        {
+            // The standing recording resolved its children under this
+            // occurrence's own context, so walking would reach the same
+            // ones. Occurrences of one package race for the claim, so
+            // walking on every win costs a redundant subtree walk and a
+            // second set of occurrence nodes per race — enough, down a
+            // peer-carrying chain, to expand exponentially with its
+            // depth (https://github.com/pnpm/pnpm/issues/13574).
+            (lazy_children(&parent_ancestors), false)
         } else {
-            let specs = Arc::new(extract_children(&result)?);
-            lock_recoverable(&ctx.workspace.children_specs_by_id)
-                .entry(id.clone())
-                .or_insert_with(|| Arc::clone(&specs));
-            specs
-        };
-        // The specs are cached unfiltered because which of them the
-        // package's own `peerDependencies` shadow is a property of the
-        // owner occurrence, not of the manifest.
-        let peer_shadowed = &children_owner.peer_shadowed;
-        let child_specs: Cow<'_, [ChildSpec]> = if peer_shadowed.is_empty() {
-            Cow::Borrowed(child_specs.as_slice())
-        } else {
-            Cow::Owned(
-                child_specs
-                    .iter()
-                    .filter(|(name, _, optional)| *optional || !peer_shadowed.contains(name))
-                    .cloned()
-                    .collect(),
-            )
-        };
-        let child_specs =
-            if result.resolved_via == "workspace" && result.id.as_str().starts_with("file:") {
-                Cow::Owned(
-                    child_specs
-                        .iter()
-                        .map(|(name, range, optional)| {
-                            resolve_catalog_specifier(name.clone(), range.clone(), &ctx.catalogs)
-                                .map(|(name, range)| (name, range, *optional))
-                        })
-                        .collect::<Result<Vec<_>, _>>()?,
-                )
-            } else {
-                child_specs
-            };
-        // An *updated* parent (one that landed on a different version
-        // than the lockfile recorded, or a new dep) discards its
-        // `resolvedDependencies` child refs, forcing its subtree to
-        // re-resolve. A parent that freshly resolved but landed back on
-        // its previously recorded version keeps the prior child refs
-        // alive (pnpm's non-`parentPkg.updated` arm), and each child
-        // edge re-enters the reuse gate with its recorded key — so a
-        // still-satisfied subtree is reused rather than re-resolved.
-        // Re-resolving those children would re-pick open ranges (`*`)
-        // at their newest versions and churn the lockfile.
-        let prior_children_snapshot = prior_key
-            .as_ref()
-            .filter(|key| landed_on_prior_entry(key, &id))
-            .and_then(|key| ctx.workspace.wanted_lockfile.as_ref()?.snapshots.as_ref()?.get(key));
-        // Phase 1: resolve every child package before any grandchild
-        // walk starts, so the level's resolved versions can feed the
-        // grandchildren's preferred-versions overlay — the
-        // postponed-resolution barrier.
-        // Snapshot this importer's direct-dep versions once for the whole
-        // child fanout instead of locking per edge.
-        let direct_versions = lock_recoverable(&ctx.workspace.direct_dep_versions)
-            .get(&ctx.importer_id)
-            .map(Arc::clone);
-        let declaring_dir = declaring_manifest_dir(ctx, &result);
-        let child_seeds = child_specs
-            .iter()
-            .map(|(child_name, child_range, child_optional)| {
-                let mut child_wanted = WantedDependency {
-                    alias: Some(child_name.clone()),
-                    bare_specifier: Some(child_range.clone()),
-                    optional: Some(*child_optional),
-                    ..WantedDependency::default()
-                };
-                let mut child_prior = prior_children_snapshot
-                    .and_then(|snapshot| prior_child_key(snapshot, child_name, child_range));
-                // Stale-pin refresh: force the edge onto a higher in-range
-                // direct-dep version instead of reusing the pin, so the
-                // pinned version is never resolved or fetched.
-                let forced_version = child_prior
-                    .as_ref()
-                    .and_then(|key| key.suffix.version_semver().cloned())
-                    .zip(child_range.parse::<node_semver::Range>().ok())
-                    .and_then(|(pinned, range)| {
-                        higher_direct_dep_version(
-                            direct_versions.as_deref(),
-                            child_name,
-                            &pinned,
-                            &range,
+            // An *updated* parent (one that landed on a different version
+            // than the lockfile recorded, or a new dep) discards its
+            // `resolvedDependencies` child refs, forcing its subtree to
+            // re-resolve. A parent that freshly resolved but landed back on
+            // its previously recorded version keeps the prior child refs
+            // alive (pnpm's non-`parentPkg.updated` arm), and each child
+            // edge re-enters the reuse gate with its recorded key — so a
+            // still-satisfied subtree is reused rather than re-resolved.
+            // Re-resolving those children would re-pick open ranges (`*`)
+            // at their newest versions and churn the lockfile.
+            let prior_children_snapshot =
+                prior_key.as_ref().filter(|key| landed_on_prior_entry(key, &id)).and_then(|key| {
+                    ctx.workspace.wanted_lockfile.as_ref()?.snapshots.as_ref()?.get(key)
+                });
+            // Phase 1: resolve every child package before any grandchild
+            // walk starts, so the level's resolved versions can feed the
+            // grandchildren's preferred-versions overlay — the
+            // postponed-resolution barrier.
+            // Snapshot this importer's direct-dep versions once for the whole
+            // child fanout instead of locking per edge.
+            let direct_versions = lock_recoverable(&ctx.workspace.direct_dep_versions)
+                .get(&ctx.importer_id)
+                .map(Arc::clone);
+            let declaring_dir = declaring_manifest_dir(ctx, &result);
+            let child_seeds = child_specs
+                .iter()
+                .map(|(child_name, child_range, child_optional)| {
+                    let mut child_wanted = WantedDependency {
+                        alias: Some(child_name.clone()),
+                        bare_specifier: Some(child_range.clone()),
+                        optional: Some(*child_optional),
+                        ..WantedDependency::default()
+                    };
+                    let mut child_prior = prior_children_snapshot
+                        .and_then(|snapshot| prior_child_key(snapshot, child_name, child_range));
+                    // Stale-pin refresh: force the edge onto a higher in-range
+                    // direct-dep version instead of reusing the pin, so the
+                    // pinned version is never resolved or fetched.
+                    let forced_version = child_prior
+                        .as_ref()
+                        .and_then(|key| key.suffix.version_semver().cloned())
+                        .zip(child_range.parse::<node_semver::Range>().ok())
+                        .and_then(|(pinned, range)| {
+                            higher_direct_dep_version(
+                                direct_versions.as_deref(),
+                                child_name,
+                                &pinned,
+                                &range,
+                            )
+                        });
+                    if let Some(higher) = forced_version {
+                        child_wanted.bare_specifier = Some(higher.to_string());
+                        child_prior = None;
+                    }
+                    let next_ancestors = Arc::clone(&next_ancestors);
+                    let pick_overlay = children_overlay.clone();
+                    let declaring_dir = declaring_dir.clone();
+                    let parent_pkg_aliases = &children_pkg_aliases;
+                    async move {
+                        let seed = resolve_node_seed(
+                            ctx,
+                            resolver,
+                            child_wanted,
+                            &next_ancestors,
+                            depth + 1,
+                            current_is_optional,
+                            ReuseSource::Transitive { key: child_prior },
+                            pick_overlay,
+                            declaring_dir.as_deref(),
+                            parent_pkg_aliases,
                         )
-                    });
-                if let Some(higher) = forced_version {
-                    child_wanted.bare_specifier = Some(higher.to_string());
-                    child_prior = None;
-                }
-                let next_ancestors = Arc::clone(&next_ancestors);
-                let pick_overlay = children_overlay.clone();
-                let declaring_dir = declaring_dir.clone();
-                let parent_pkg_aliases = &children_pkg_aliases;
-                async move {
-                    let seed = resolve_node_seed(
-                        ctx,
-                        resolver,
-                        child_wanted,
-                        &next_ancestors,
-                        depth + 1,
-                        current_is_optional,
-                        ReuseSource::Transitive { key: child_prior },
-                        pick_overlay,
-                        declaring_dir.as_deref(),
-                        parent_pkg_aliases,
-                    )
-                    .await?;
-                    warm_children_resolutions(ctx, resolver, &seed).await;
-                    Ok::<NodeSeed, ResolveDependencyTreeError>(seed)
-                }
-            })
-            .pipe(future::try_join_all)
-            .await?;
-        let grandchild_overlay = PreferredVersionsOverlay::layer(
-            children_overlay.clone(),
-            level_versions(ctx, &child_seeds),
-        );
-        let grandchild_pkg_aliases = children_pkg_aliases.extend(level_aliases(&child_seeds));
-        // Phase 2: walk each child's own children with the extended
-        // overlay.
-        let child_results = child_seeds
-            .into_iter()
-            .map(|seed| {
-                let overlay = grandchild_overlay.clone();
-                let pkg_aliases = Arc::clone(&grandchild_pkg_aliases);
-                async move {
-                    match seed {
-                        NodeSeed::Done(dep) => Ok(dep),
-                        NodeSeed::Pending(pending) => {
-                            walk_node_children(ctx, resolver, *pending, overlay, pkg_aliases).await
+                        .await?;
+                        warm_children_resolutions(ctx, resolver, &seed).await;
+                        Ok::<NodeSeed, ResolveDependencyTreeError>(seed)
+                    }
+                })
+                .pipe(future::try_join_all)
+                .await?;
+            let grandchild_overlay = PreferredVersionsOverlay::layer(
+                children_overlay.clone(),
+                level_versions(ctx, &child_seeds),
+            );
+            let grandchild_pkg_aliases = children_pkg_aliases.extend(level_aliases(&child_seeds));
+            // Phase 2: walk each child's own children with the extended
+            // overlay.
+            let child_results = child_seeds
+                .into_iter()
+                .map(|seed| {
+                    let overlay = grandchild_overlay.clone();
+                    let pkg_aliases = Arc::clone(&grandchild_pkg_aliases);
+                    async move {
+                        match seed {
+                            NodeSeed::Done(dep) => Ok(dep),
+                            NodeSeed::Pending(pending) => {
+                                walk_node_children(ctx, resolver, *pending, overlay, pkg_aliases)
+                                    .await
+                            }
                         }
                     }
+                })
+                .pipe(future::try_join_all)
+                .await?;
+            if is_current_children_owner(ctx, &id, &children_owner.owner) {
+                // Build the realized `(alias → NodeId)` map for THIS
+                // occurrence and the per-pkg `children_by_id` entry future
+                // revisits will reuse. `children_by_id` records the resolved
+                // child pkg ids (not NodeIds) plus the `optional` flag so
+                // lazy realisation can thread `current_is_optional` correctly.
+                let mut realized: BTreeMap<String, NodeId> = BTreeMap::new();
+                let mut by_id: Vec<crate::resolved_tree::ChildEdge> = Vec::new();
+                let optional_by_alias: HashMap<&str, bool> = child_specs
+                    .iter()
+                    .map(|(name, _, optional)| (name.as_str(), *optional))
+                    .collect();
+                for dep in child_results.into_iter().flatten() {
+                    let optional =
+                        optional_by_alias.get(dep.alias.as_str()).copied().unwrap_or(false);
+                    by_id.push(crate::resolved_tree::ChildEdge {
+                        alias: dep.alias.clone(),
+                        pkg_id: dep.id.clone(),
+                        optional,
+                    });
+                    realized.insert(dep.alias, dep.node_id);
                 }
-            })
-            .pipe(future::try_join_all)
-            .await?;
-        if is_current_children_owner(ctx, &id, &children_owner.owner) {
-            // Build the realized `(alias → NodeId)` map for THIS
-            // occurrence and the per-pkg `children_by_id` entry future
-            // revisits will reuse. `children_by_id` records the resolved
-            // child pkg ids (not NodeIds) plus the `optional` flag so
-            // lazy realisation can thread `current_is_optional` correctly.
-            let mut realized: BTreeMap<String, NodeId> = BTreeMap::new();
-            let mut by_id: Vec<crate::resolved_tree::ChildEdge> = Vec::new();
-            let optional_by_alias: HashMap<&str, bool> =
-                child_specs.iter().map(|(name, _, optional)| (name.as_str(), *optional)).collect();
-            for dep in child_results.into_iter().flatten() {
-                let optional = optional_by_alias.get(dep.alias.as_str()).copied().unwrap_or(false);
-                by_id.push(crate::resolved_tree::ChildEdge {
-                    alias: dep.alias.clone(),
-                    pkg_id: dep.id.clone(),
-                    optional,
-                });
-                realized.insert(dep.alias, dep.node_id);
+                record_children(ctx, &id, &children_owner.owner, by_id, children_context)
+                    .into_children(realized, &parent_ancestors)
+            } else {
+                (lazy_children(&parent_ancestors), false)
             }
-            record_children(ctx, &id, &children_owner.owner, by_id, children_context())
-                .into_children(realized, &parent_ancestors)
-        } else {
-            (lazy_children(&parent_ancestors), false)
         }
     };
 
@@ -776,6 +737,92 @@ where
     }
 
     Ok(Some(DirectDep { alias, node_id, id }))
+}
+
+/// The child edges a package's children owner walks: the manifest's
+/// `dependencies` plus `optionalDependencies`, less the names the
+/// package's own `peerDependencies` shadow, with a workspace project's
+/// catalog specifiers resolved.
+///
+/// Only the manifest's own specs are cached per package id — which of
+/// them are shadowed follows from the owner occurrence's parent scope,
+/// not from the manifest.
+fn owned_child_specs(
+    ctx: &TreeCtx,
+    pkg_id: &str,
+    result: &pacquet_resolving_resolver_base::ResolveResult,
+    peer_shadowed: &HashSet<String>,
+) -> Result<Arc<Vec<ChildSpec>>, ResolveDependencyTreeError> {
+    let cached = lock_recoverable(&ctx.workspace.children_specs_by_id).get(pkg_id).map(Arc::clone);
+    let specs = if let Some(specs) = cached {
+        specs
+    } else {
+        let specs = Arc::new(extract_children(result)?);
+        lock_recoverable(&ctx.workspace.children_specs_by_id)
+            .entry(pkg_id.to_string())
+            .or_insert_with(|| Arc::clone(&specs));
+        specs
+    };
+    let specs = if peer_shadowed.is_empty() {
+        specs
+    } else {
+        specs
+            .iter()
+            .filter(|(name, _, optional)| *optional || !peer_shadowed.contains(name))
+            .cloned()
+            .collect::<Vec<ChildSpec>>()
+            .pipe(Arc::new)
+    };
+    if !resolves_children_through_catalogs(result) {
+        return Ok(specs);
+    }
+    specs
+        .iter()
+        .map(|(name, range, optional)| {
+            resolve_catalog_specifier(name.clone(), range.clone(), &ctx.catalogs)
+                .map(|(name, range)| (name, range, *optional))
+        })
+        .collect::<Result<Vec<ChildSpec>, ResolveDependencyTreeError>>()
+        .map(Arc::new)
+}
+
+/// What the walk's preferred-versions overlay offers a package's child
+/// edges: for every name such an edge looks the overlay up under (see
+/// [`fn@overlay_lookup_names`]), the versions the chain prefers for it.
+/// Names no level resolved are left out, which keeps the view empty for
+/// most packages.
+///
+/// This is the whole of the overlay chain a child edge's version pick
+/// can read — it is what joins the per-wanted resolve cache key — so
+/// two occurrences of one package that agree on it resolve their
+/// children to the same packages. See
+/// [`RecordedChildrenContext::overlay_view`].
+fn children_overlay_view(
+    specs: &[ChildSpec],
+    overlay: Option<&PreferredVersionsOverlay>,
+) -> ChildrenOverlayView {
+    let mut view = ChildrenOverlayView::new();
+    let Some(overlay) = overlay else { return view };
+    for (child_name, child_range, _) in specs {
+        let wanted = WantedDependency {
+            alias: Some(child_name.clone()),
+            bare_specifier: Some(child_range.clone()),
+            ..WantedDependency::default()
+        };
+        for name in overlay_lookup_names(&wanted) {
+            if view.contains_key(&name) {
+                continue;
+            }
+            let mut versions: Vec<String> =
+                overlay.versions_for(&name).into_iter().map(str::to_string).collect();
+            if versions.is_empty() {
+                continue;
+            }
+            versions.sort_unstable();
+            view.insert(name, versions);
+        }
+    }
+    view
 }
 
 /// Whether the `parent → child` edge closes a dependency cycle's

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
@@ -790,13 +790,8 @@ fn owned_child_specs(
 /// edges: for every name such an edge looks the overlay up under (see
 /// [`fn@overlay_lookup_names`]), the versions the chain prefers for it.
 /// Names no level resolved are left out, which keeps the view empty for
-/// most packages.
-///
-/// This is the whole of the overlay chain a child edge's version pick
-/// can read — it is what joins the per-wanted resolve cache key — so
-/// two occurrences of one package that agree on it resolve their
-/// children to the same packages. See
-/// [`RecordedChildrenContext::overlay_view`].
+/// most packages. See [`RecordedChildrenContext::overlay_view`] for
+/// what the projection settles.
 fn children_overlay_view(
     specs: &[ChildSpec],
     overlay: Option<&PreferredVersionsOverlay>,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
@@ -111,6 +111,11 @@ pub(super) type DirectDepVersions = HashMap<String, Vec<node_semver::Version>>;
 /// `optionalDependencies` sections.
 pub(super) type ChildSpec = (String, String, bool);
 
+/// What the preferred-versions overlay offers one package's child
+/// edges: `name → preferred versions` over the names those edges look
+/// the overlay up under. See [`RecordedChildrenContext::overlay_view`].
+pub(super) type ChildrenOverlayView = BTreeMap<String, Vec<String>>;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct ChildrenOwner {
     update_active: bool,
@@ -171,22 +176,26 @@ pub(super) struct RecordedChildrenContext {
     /// Whether the resolving importer had an active update policy, which
     /// re-resolves what a keep-all importer reuses.
     pub(super) update_active: bool,
+    /// What the walk's preferred-versions overlay offered the package's
+    /// child edges, projected down to the names those edges look up.
+    ///
+    /// The overlay chain itself is per-occurrence — it carries every
+    /// ancestor level's resolved versions — so comparing chains would
+    /// mean requiring identical parents, which the occurrences of one
+    /// package never have. The projection is the part of the chain a
+    /// child edge's version pick can read: it joins the per-wanted
+    /// resolve cache key, so two occurrences that agree on it resolve
+    /// every child edge to the same package.
+    pub(super) overlay_view: ChildrenOverlayView,
 }
 
 impl RecordedChildrenContext {
     /// Two contexts produce the same children.
-    ///
-    /// The preferred-versions overlay is deliberately not part of the
-    /// test. `children_by_id` records one child list per package id,
-    /// and every occurrence that does not own the children already
-    /// expands from it whatever its own overlay says — the overlay
-    /// only ever decides which occurrence's versions get *recorded*.
-    /// Requiring identical overlays here would mean requiring identical
-    /// parents, which the occurrences that race never have.
     pub(super) fn produces_same_children_as(&self, other: &Self) -> bool {
         self.peer_shadowed == other.peer_shadowed
             && self.prior_key == other.prior_key
             && self.update_active == other.update_active
+            && self.overlay_view == other.overlay_view
     }
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx/tests.rs
@@ -499,6 +499,7 @@ fn recorded(edges: Vec<crate::resolved_tree::ChildEdge>) -> super::RecordedChild
             peer_shadowed: Arc::default(),
             prior_key: None,
             update_active: false,
+            overlay_view: super::ChildrenOverlayView::new(),
         },
     }
 }
@@ -509,8 +510,8 @@ fn recorded(edges: Vec<crate::resolved_tree::ChildEdge>) -> super::RecordedChild
 fn recorded_children_match_only_under_the_recording_context() {
     use super::super::{UpdateReuseScope, tree_ctx::TreeCtx};
     use super::{
-        ChildrenRecording, RecordedChildrenContext, claim_children_owner, record_children,
-        recorded_children_match,
+        ChildrenOverlayView, ChildrenRecording, RecordedChildrenContext, claim_children_owner,
+        record_children, recorded_children_match,
     };
     use std::sync::Arc;
 
@@ -521,6 +522,7 @@ fn recorded_children_match_only_under_the_recording_context() {
         peer_shadowed: Arc::default(),
         prior_key: None,
         update_active: false,
+        overlay_view: ChildrenOverlayView::new(),
     };
     assert!(!recorded_children_match(&ctx, "pkg@1.0.0", &context()), "nothing recorded yet");
     assert_ne!(
@@ -550,7 +552,8 @@ fn recorded_children_match_only_under_the_recording_context() {
 fn children_are_published_only_by_the_standing_owner() {
     use super::super::tree_ctx::TreeCtx;
     use super::{
-        ChildrenRecording, RecordedChildrenContext, claim_children_owner, record_children,
+        ChildrenOverlayView, ChildrenRecording, RecordedChildrenContext, claim_children_owner,
+        record_children,
     };
     use std::sync::Arc;
 
@@ -560,6 +563,7 @@ fn children_are_published_only_by_the_standing_owner() {
         peer_shadowed: Arc::default(),
         prior_key: None,
         update_active: false,
+        overlay_view: ChildrenOverlayView::new(),
     };
     let deep = claim_children_owner(&ctx, "pkg@1.0.0", 5, &[], HashSet::default());
     let shallow = claim_children_owner(&ctx, "pkg@1.0.0", 0, &[], HashSet::default());
@@ -586,7 +590,8 @@ fn children_are_published_only_by_the_standing_owner() {
 fn re_recording_reports_whether_the_child_edges_moved() {
     use super::super::tree_ctx::TreeCtx;
     use super::{
-        ChildrenRecording, RecordedChildrenContext, claim_children_owner, record_children,
+        ChildrenOverlayView, ChildrenRecording, RecordedChildrenContext, claim_children_owner,
+        record_children,
     };
     use std::sync::Arc;
 
@@ -596,6 +601,7 @@ fn re_recording_reports_whether_the_child_edges_moved() {
         peer_shadowed: Arc::default(),
         prior_key: None,
         update_active: false,
+        overlay_view: ChildrenOverlayView::new(),
     };
     let edges = |pkg_id: &str| {
         vec![crate::resolved_tree::ChildEdge {

--- a/pnpm/crates/resolving-deps-resolver/src/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/tests.rs
@@ -315,18 +315,10 @@ async fn passes_optional_flag_to_the_resolver() {
     assert_eq!(*resolver.optional.lock().unwrap(), vec![Some(true)]);
 }
 
-/// Which occurrence of a package walks its children first is a race,
-/// and the levels they sit under offer their children different
-/// preferred versions — so the children a package records must follow
-/// the occurrence that owns them, not the one that got there first
-/// (<https://github.com/pnpm/pnpm/issues/13685>).
-///
-/// Here `shared` is reached at depth 2 under `wrap`, whose level pins
-/// `pin@1.0.0`, and at depth 3 under `nested`, whose levels pin
-/// nothing. `wrap` resolves slowly, so the depth-3 occurrence always
-/// records `pin@1.5.0` first and the depth-2 occurrence claims the
-/// children afterwards.
-#[tokio::test]
+/// Delaying `wrap` puts the deeper occurrence of `shared` — the one
+/// whose levels prefer no `pin` version — in front of the occurrence
+/// that owns the children (<https://github.com/pnpm/pnpm/issues/13685>).
+#[tokio::test(start_paused = true)]
 async fn deeper_occurrences_children_are_rewalked_by_the_owner() {
     let resolver = OverlayPickResolver {
         versions: HashMap::from_iter([
@@ -443,7 +435,6 @@ async fn deeper_occurrences_children_are_rewalked_by_the_owner() {
     .unwrap();
 
     let shared_children = tree.children_by_id.get("shared@1.0.0").expect("shared children");
-    dbg!(shared_children);
     assert_eq!(shared_children.len(), 1);
     assert_eq!(shared_children[0].pkg_id, "pin@1.0.0");
 }

--- a/pnpm/crates/resolving-deps-resolver/src/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/tests.rs
@@ -77,6 +77,78 @@ impl Resolver for DelayedAliasResolver {
     }
 }
 
+/// Stub resolver fed from a `name` → versions table, picking the way
+/// the npm resolver does: the highest version the range admits, except
+/// that a version the walk's preferred-versions overlay carries wins
+/// over it. Lets a test vary one edge's pick by the level it resolves
+/// under. `delayed_alias` is held back so the branch behind it walks
+/// second.
+struct OverlayPickResolver {
+    versions: HashMap<String, Vec<ResolveResult>>,
+    delayed_alias: String,
+}
+
+impl Resolver for OverlayPickResolver {
+    fn resolve<'a>(
+        &'a self,
+        wanted: &'a WantedDependency,
+        opts: &'a ResolveOptions,
+    ) -> ResolveFuture<'a> {
+        let name = wanted.alias.clone().unwrap_or_default();
+        let range = node_semver::Range::from_str(wanted.bare_specifier.as_deref().unwrap_or("*"))
+            .expect("test range");
+        let preferred: Vec<&str> = opts
+            .preferred_versions_overlay
+            .as_ref()
+            .map(|overlay| overlay.versions_for(&name))
+            .unwrap_or_default();
+        let satisfying: Vec<&ResolveResult> = self
+            .versions
+            .get(&name)
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+            .iter()
+            .filter(|result| {
+                result.name_ver.as_ref().is_some_and(|name_ver| range.satisfies(&name_ver.suffix))
+            })
+            .collect();
+        let highest = |from: Vec<&ResolveResult>| {
+            from.into_iter()
+                .max_by(|left, right| {
+                    version_of(left).partial_cmp(version_of(right)).expect("comparable versions")
+                })
+                .cloned()
+        };
+        let result = highest(
+            satisfying
+                .iter()
+                .copied()
+                .filter(|result| preferred.contains(&version_of(result).to_string().as_str()))
+                .collect(),
+        )
+        .or_else(|| highest(satisfying));
+        let delayed = name == self.delayed_alias;
+        Box::pin(async move {
+            if delayed {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            Ok::<_, ResolveError>(result)
+        })
+    }
+
+    fn resolve_latest<'a>(
+        &'a self,
+        _query: &'a LatestQuery,
+        _opts: &'a ResolveOptions,
+    ) -> ResolveLatestFuture<'a> {
+        Box::pin(async { Ok(None) })
+    }
+}
+
+fn version_of(result: &ResolveResult) -> &node_semver::Version {
+    &result.name_ver.as_ref().expect("test result carries a name and version").suffix
+}
+
 fn fake_result(name: &str, version: &str, manifest: serde_json::Value) -> ResolveResult {
     use pacquet_lockfile::{LockfileResolution, PkgName, PkgNameVer, TarballResolution};
     let name_ver = PkgNameVer::new(
@@ -241,6 +313,139 @@ async fn passes_optional_flag_to_the_resolver() {
     .expect("resolve optional dependency");
 
     assert_eq!(*resolver.optional.lock().unwrap(), vec![Some(true)]);
+}
+
+/// Which occurrence of a package walks its children first is a race,
+/// and the levels they sit under offer their children different
+/// preferred versions — so the children a package records must follow
+/// the occurrence that owns them, not the one that got there first
+/// (<https://github.com/pnpm/pnpm/issues/13685>).
+///
+/// Here `shared` is reached at depth 2 under `wrap`, whose level pins
+/// `pin@1.0.0`, and at depth 3 under `nested`, whose levels pin
+/// nothing. `wrap` resolves slowly, so the depth-3 occurrence always
+/// records `pin@1.5.0` first and the depth-2 occurrence claims the
+/// children afterwards.
+#[tokio::test]
+async fn deeper_occurrences_children_are_rewalked_by_the_owner() {
+    let resolver = OverlayPickResolver {
+        versions: HashMap::from_iter([
+            (
+                "slow".to_string(),
+                vec![fake_result(
+                    "slow",
+                    "1.0.0",
+                    serde_json::json!({
+                        "name": "slow",
+                        "version": "1.0.0",
+                        "dependencies": { "wrap": "1.0.0" }
+                    }),
+                )],
+            ),
+            (
+                "wrap".to_string(),
+                vec![fake_result(
+                    "wrap",
+                    "1.0.0",
+                    serde_json::json!({
+                        "name": "wrap",
+                        "version": "1.0.0",
+                        "dependencies": { "pin": "1.0.0", "shared": "^1.0.0" }
+                    }),
+                )],
+            ),
+            (
+                "deep".to_string(),
+                vec![fake_result(
+                    "deep",
+                    "1.0.0",
+                    serde_json::json!({
+                        "name": "deep",
+                        "version": "1.0.0",
+                        "dependencies": { "mid": "1.0.0" }
+                    }),
+                )],
+            ),
+            (
+                "mid".to_string(),
+                vec![fake_result(
+                    "mid",
+                    "1.0.0",
+                    serde_json::json!({
+                        "name": "mid",
+                        "version": "1.0.0",
+                        "dependencies": { "nested": "1.0.0" }
+                    }),
+                )],
+            ),
+            (
+                "nested".to_string(),
+                vec![fake_result(
+                    "nested",
+                    "1.0.0",
+                    serde_json::json!({
+                        "name": "nested",
+                        "version": "1.0.0",
+                        "dependencies": { "shared": "^1.0.0" }
+                    }),
+                )],
+            ),
+            (
+                "shared".to_string(),
+                vec![fake_result(
+                    "shared",
+                    "1.0.0",
+                    serde_json::json!({
+                        "name": "shared",
+                        "version": "1.0.0",
+                        "dependencies": { "pin": "^1.0.0" }
+                    }),
+                )],
+            ),
+            (
+                "pin".to_string(),
+                vec![
+                    fake_result(
+                        "pin",
+                        "1.0.0",
+                        serde_json::json!({ "name": "pin", "version": "1.0.0" }),
+                    ),
+                    fake_result(
+                        "pin",
+                        "1.5.0",
+                        serde_json::json!({ "name": "pin", "version": "1.5.0" }),
+                    ),
+                ],
+            ),
+        ]),
+        delayed_alias: "wrap".to_string(),
+    };
+    let (_tmp, manifest) = fake_manifest(serde_json::json!({
+        "deep": "1.0.0",
+        "slow": "1.0.0"
+    }));
+
+    let tree = resolve_dependency_tree(
+        &resolver,
+        &manifest,
+        [DependencyGroup::Prod],
+        ResolveDependencyTreeOptions {
+            base_opts: ResolveOptions::default(),
+            patched_dependencies: None,
+            manifest_hook: None,
+            overrides_hook: None,
+            pnpmfile_hook: None,
+            read_package_log: None,
+            auto_install_peers: false,
+        },
+    )
+    .await
+    .unwrap();
+
+    let shared_children = tree.children_by_id.get("shared@1.0.0").expect("shared children");
+    dbg!(shared_children);
+    assert_eq!(shared_children.len(), 1);
+    assert_eq!(shared_children[0].pkg_id, "pin@1.0.0");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#13685.

Resolving the same project twice could produce different `pnpm-lock.yaml` files. Occurrences of one package race for the children-ownership claim: a worse-ranked occurrence that arrives while the claim is vacant walks the package's children and records them, resolved under **its own** level's preferred-versions overlay. When the deterministically better-placed occurrence claims afterwards, `recorded_children_match` waved it through — the overlay was deliberately left out of `RecordedChildrenContext` — so whichever occurrence's walk got there first decided the lockfile.

pnpm/pnpm#13714 fixed the neighbouring half of this (a re-recording now stales the other occurrences' realized children) and explicitly left the `recorded_children_match` early return, the arrival-order dependence itself, untouched. This PR closes that.

The recorded context now carries the overlay **projected down to the names the package's child edges look the overlay up under** (alias, plus the `npm:` / `jsr:` target name — the same names `resolve_node_seed` puts in the per-wanted resolve cache key). That projection is the whole of the overlay chain a child edge's version pick can read, so:

- two occurrences that agree on it resolve every child edge to the same package, and the later owner keeps the standing recording as before;
- when they disagree, the owner walks its children again and records its own answer, so the children settle on the ranked owner's, not the first arriver's.

Comparing the overlay *chains* instead would mean requiring identical parents, which racing occurrences never have. The re-walk stays bounded — it stops descending wherever the projections agree — unlike the full re-walk on every claim win that pnpm/pnpm#13574 reverted for exponential blowup.

**Verified on the issue's `@teambit/bit@2.0.67` repro** (single importer, `nodeLinker: hoisted`, `autoInstallPeers`, `dedupePeerDependents`, `peersSuffixMaxLength: 1000`; offline, warm cache), repeated `rm -rf node_modules pnpm-lock.yaml && pnpm install --lockfile-only --ignore-scripts --offline`:

| | distinct lockfiles | resolve time | peak RSS |
| --- | --- | --- | --- |
| `main` | 2 in 8 runs, 3 in 3 runs under load (the `classnames` and `lodash` flips from the issue) | 4.35 s (5.10 s under load) | 1.213 GB |
| this PR | 1 in 8 runs, 1 in 3 runs under load | 5.40 s (6.30 s under load) | 1.210 GB |

Repeat installs against the resulting lockfile are byte-stable, so the lockfile-reuse path does not churn. Storing the projections is not measurable in peak RSS.

The ~25% resolve-time cost on that graph splits about evenly between computing the projection (paid on every owner walk) and the added walks (the fix itself) — measured by running with the projection computed but excluded from the comparison. A follow-up could thread the projection out of the seed phase, which already computes the same per-child views for the resolve cache key, instead of recomputing it. All of this is on a deliberately pathological graph (~20k packages, peer-heavy, `peersSuffixMaxLength: 1000`).

Known residual: an occurrence only re-walks the children it *records*, so a subtree that stays lazy at every level below a matching projection is not re-checked against the owner's overlay. Closing that needs the projections of a whole subtree, not one level; the repro is deterministic across every run measured here.

Not mirrored in the TypeScript CLI: children ownership, the claim ranking and `children_by_id` are pacquet's own machinery, with no counterpart in `resolveDependencies`.

## Squash Commit Body

```text
Occurrences of one package race for the children-ownership claim. A
worse-ranked occurrence that arrives while the claim is vacant walks the
package's children and records them, resolved under its own level's
preferred-versions overlay; when the deterministically better-placed
occurrence claims afterwards it kept those children, because the overlay
was left out of the recorded resolution context. Which occurrence got
there first is thread timing, so identical inputs produced different
lockfiles run to run.

Record the overlay projected down to the names the package's child edges
look up — the whole of the overlay a child's version pick can read — as
part of that context. A later owner then keeps the recording only when
its own level offers those edges the same versions, and walks them again
otherwise, so the children settle on the ranked owner's answer. The
re-walk stays bounded: it stops descending wherever the projections
agree, unlike the full re-walk on every claim win reverted in
pnpm/pnpm#13574.

Verified on the issue's @teambit/bit repro (offline, warm cache): 8
identical resolves produced 2 distinct lockfiles before and 8 identical
ones after, at ~25% more resolve time on that graph (4.4s -> 5.4s), half
of it the projection and half the added walks.

Closes pnpm/pnpm#13685.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5[1m]).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789045443&installation_model_id=426870&pr_number=13830&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13830&signature=323944cd255cec0cf071447f558a35a05dbc8e19c48c038dce321fd33d19a756"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dependency resolution is now deterministic, regardless of concurrent resolution order.
  * Prevented inconsistent dependency versions and lockfiles when packages are reached through multiple dependency paths.
  * Ensured shared dependencies respect the appropriate preferred versions for each resolution context.
  * Improved consistency when resolving dependencies with overlapping version preferences.

* **Tests**
  * Added regression coverage for concurrent traversal and preferred-version resolution scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->