### PR TITLE
fix(resolver): apply resolutionMode under a minimum release age

### DIFF
--- a/.changeset/lowest-direct-under-minimum-release-age.md
+++ b/.changeset/lowest-direct-under-minimum-release-age.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/resolving.npm-resolver": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+`resolutionMode` is no longer ignored when `minimumReleaseAge` is in effect. `lowest-direct` and `time-based` pick the lowest satisfying version of a direct dependency again; previously any active release-age cutoff — including the built-in default — silently forced the highest, so `resolutionMode` only worked when `minimumReleaseAge: 0` was set explicitly [#13752](https://github.com/pnpm/pnpm/issues/13752).

--- a/pnpm/crates/cli/tests/suite/install.rs
+++ b/pnpm/crates/cli/tests/suite/install.rs
@@ -1500,6 +1500,39 @@ fn resolution_mode_lowest_direct_picks_lowest_direct_version() {
     drop((root, mock_instance));
 }
 
+/// `minimumReleaseAge` narrows the versions on offer to the mature ones;
+/// it does not say which end of what is left to take, which is what
+/// `resolutionMode` says. The pair has to keep working together, since
+/// `minimumReleaseAge` is on by default.
+#[test]
+fn resolution_mode_lowest_direct_applies_under_a_minimum_release_age() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let workspace_yaml = workspace.join("pnpm-workspace.yaml");
+    let mut existing = fs::read_to_string(&workspace_yaml).expect("read pnpm-workspace.yaml");
+    existing.push_str("resolutionMode: lowest-direct\nminimumReleaseAge: 1\n");
+    fs::write(&workspace_yaml, existing).expect("write pnpm-workspace.yaml");
+
+    let manifest_path = workspace.join("package.json");
+    let package_json_content = serde_json::json!({
+        "dependencies": { "@pnpm.e2e/foo": "^100.0.0" },
+    });
+    fs::write(&manifest_path, package_json_content.to_string()).expect("write to package.json");
+
+    pacquet.with_arg("install").assert().success();
+
+    let pnpm_dir = workspace.join("node_modules/.pnpm");
+    assert!(
+        pnpm_dir.join("@pnpm.e2e+foo@100.0.0").exists(),
+        "lowest-direct must still resolve ^100.0.0 to 100.0.0 when a release age is configured",
+    );
+    assert!(!pnpm_dir.join("@pnpm.e2e+foo@100.1.0").exists());
+
+    drop((root, mock_instance));
+}
+
 /// Dropping `time:` would lose the publish dates a re-resolve falls back
 /// on when the registry's abbreviated metadata carries none, changing the
 /// cutoff every subdependency is resolved under.

--- a/pnpm/crates/cli/tests/suite/install.rs
+++ b/pnpm/crates/cli/tests/suite/install.rs
@@ -1533,6 +1533,38 @@ fn resolution_mode_lowest_direct_applies_under_a_minimum_release_age() {
     drop((root, mock_instance));
 }
 
+/// `time-based` picks the lowest satisfying version for a direct
+/// dependency too, so it has to survive a release-age cutoff the same way
+/// `lowest-direct` does.
+#[test]
+fn resolution_mode_time_based_applies_under_a_minimum_release_age() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let workspace_yaml = workspace.join("pnpm-workspace.yaml");
+    let mut existing = fs::read_to_string(&workspace_yaml).expect("read pnpm-workspace.yaml");
+    existing.push_str("resolutionMode: time-based\nminimumReleaseAge: 1\n");
+    fs::write(&workspace_yaml, existing).expect("write pnpm-workspace.yaml");
+
+    let manifest_path = workspace.join("package.json");
+    let package_json_content = serde_json::json!({
+        "dependencies": { "@pnpm.e2e/foo": "^100.0.0" },
+    });
+    fs::write(&manifest_path, package_json_content.to_string()).expect("write to package.json");
+
+    pacquet.with_arg("install").assert().success();
+
+    let pnpm_dir = workspace.join("node_modules/.pnpm");
+    assert!(
+        pnpm_dir.join("@pnpm.e2e+foo@100.0.0").exists(),
+        "time-based must still resolve ^100.0.0 to 100.0.0 when a release age is configured",
+    );
+    assert!(!pnpm_dir.join("@pnpm.e2e+foo@100.1.0").exists());
+
+    drop((root, mock_instance));
+}
+
 /// Dropping `time:` would lose the publish dates a re-resolve falls back
 /// on when the registry's abbreviated metadata carries none, changing the
 /// cutoff every subdependency is resolved under.

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package.rs
@@ -284,8 +284,9 @@ pub struct PickPackageOptions<'a> {
     /// `minimumReleaseAgeExclude` policy. `None` skips exclusion.
     pub published_by_exclude: Option<&'a PackageVersionPolicy>,
     /// Pick the lowest satisfying version instead of the highest.
-    /// Forced to `false` when `published_by` is active (the maturity
-    /// filter always picks highest then falls back to lowest).
+    /// Honoured under `published_by` too: maturity narrows which
+    /// versions are on offer, and this decides which end of what is
+    /// left to take.
     pub pick_lowest_version: bool,
     /// Compare the spec-pick against a `latest`-tag pick and keep
     /// the higher of the two. Used by `pnpm add` to make sure a
@@ -911,24 +912,27 @@ fn pick_matching_version_final(
     }
 }
 
-/// `publishedBy` is active: try highest mature; if no mature
-/// version satisfies, fall back to lowest (regardless of maturity)
-/// so the orchestrator can report the violation inline and let the
-/// install layer decide what to do.
+/// `publishedBy` is active: pick from the mature versions by
+/// `pickLowestVersion`, since maturity narrows what is on offer and
+/// `resolutionMode` decides which end of the remainder to take. If no
+/// mature version satisfies, fall back to lowest (regardless of
+/// maturity) so the orchestrator can report the violation inline and
+/// let the install layer decide what to do.
 fn pick_respecting_min_release_age(
     picker_opts: &PickerOpts<'_>,
     spec: &RegistryPackageSpec,
     meta: &Package,
 ) -> Result<Option<Arc<PackageVersion>>, PickPackageFromMetaError> {
     run_picker(picker_opts, spec, |target_spec| {
-        let highest = pick_package_from_meta(
-            pick_version_by_version_range,
-            &meta_opts(picker_opts),
-            meta,
-            target_spec,
-        )?;
-        if highest.is_some() {
-            return Ok(highest);
+        let pick_mature = if picker_opts.pick_lowest_version {
+            pick_lowest_version_by_version_range
+        } else {
+            pick_version_by_version_range
+        };
+        let mature =
+            pick_package_from_meta(pick_mature, &meta_opts(picker_opts), meta, target_spec)?;
+        if mature.is_some() {
+            return Ok(mature);
         }
         // Fall-back lowest pick drops `publishedBy` so the picker
         // can return *something* even if every version is past the

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package.rs
@@ -912,12 +912,11 @@ fn pick_matching_version_final(
     }
 }
 
-/// `publishedBy` is active: pick from the mature versions by
-/// `pickLowestVersion`, since maturity narrows what is on offer and
-/// `resolutionMode` decides which end of the remainder to take. If no
-/// mature version satisfies, fall back to lowest (regardless of
-/// maturity) so the orchestrator can report the violation inline and
-/// let the install layer decide what to do.
+/// `publishedBy` is active: it narrows which versions are on offer, and
+/// `pick_lowest_version` decides which end of what is left to take. The
+/// fallback deliberately drops the maturity filter so a range no mature
+/// version satisfies still yields a pick, which the install layer
+/// reports as a violation.
 fn pick_respecting_min_release_age(
     picker_opts: &PickerOpts<'_>,
     spec: &RegistryPackageSpec,
@@ -934,11 +933,6 @@ fn pick_respecting_min_release_age(
         if mature.is_some() {
             return Ok(mature);
         }
-        // Fall-back lowest pick drops `publishedBy` so the picker
-        // can return *something* even if every version is past the
-        // cutoff. The install layer reads the resulting pick's
-        // publish timestamp and surfaces the violation through the
-        // verifier.
         let fallback_opts = PickPackageFromMetaOptions {
             preferred_version_selectors: picker_opts.preferred_version_selectors,
             published_by: None,

--- a/pnpm11/installing/deps-installer/test/install/resolutionMode.ts
+++ b/pnpm11/installing/deps-installer/test/install/resolutionMode.ts
@@ -112,3 +112,18 @@ test('the lowest version of a direct dependency is installed when a minimum rele
   expect(lockfile.packages['@pnpm.e2e/pkg-with-1-dep@100.0.0']).toBeTruthy()
   expect(lockfile.packages['@pnpm.e2e/pkg-with-1-dep@100.1.0']).toBeFalsy()
 })
+
+test('the lowest version of a direct dependency is installed in time-based mode when a minimum release age is also configured', async () => {
+  await addDistTag({ package: '@pnpm.e2e/pkg-with-1-dep', version: '100.1.0', distTag: 'latest' })
+  const project = prepareEmpty()
+
+  await install({
+    dependencies: {
+      '@pnpm.e2e/pkg-with-1-dep': '^100.0.0',
+    },
+  }, testDefaults({ resolutionMode: 'time-based', minimumReleaseAge: 1 }))
+
+  const lockfile = project.readLockfile()
+  expect(lockfile.packages['@pnpm.e2e/pkg-with-1-dep@100.0.0']).toBeTruthy()
+  expect(lockfile.packages['@pnpm.e2e/pkg-with-1-dep@100.1.0']).toBeFalsy()
+})

--- a/pnpm11/installing/deps-installer/test/install/resolutionMode.ts
+++ b/pnpm11/installing/deps-installer/test/install/resolutionMode.ts
@@ -94,3 +94,21 @@ test('the lowest version of a direct dependency is installed when resolution mod
     '@pnpm.e2e/pkg-with-1-dep': '^100.1.0',
   })
 })
+
+test('the lowest version of a direct dependency is installed when a minimum release age is also configured', async () => {
+  await addDistTag({ package: '@pnpm.e2e/pkg-with-1-dep', version: '100.1.0', distTag: 'latest' })
+  const project = prepareEmpty()
+
+  // `minimumReleaseAge` narrows the versions on offer to the mature ones. It
+  // does not say which end of what is left to take — that is what
+  // `resolutionMode` says.
+  await install({
+    dependencies: {
+      '@pnpm.e2e/pkg-with-1-dep': '^100.0.0',
+    },
+  }, testDefaults({ resolutionMode: 'lowest-direct', minimumReleaseAge: 1 }))
+
+  const lockfile = project.readLockfile()
+  expect(lockfile.packages['@pnpm.e2e/pkg-with-1-dep@100.0.0']).toBeTruthy()
+  expect(lockfile.packages['@pnpm.e2e/pkg-with-1-dep@100.1.0']).toBeFalsy()
+})

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -127,13 +127,11 @@ function pickMax (
 const pickHighest = pickPackageFromMeta.bind(null, pickVersionByVersionRange)
 const pickLowest = pickPackageFromMeta.bind(null, pickLowestVersionByVersionRange)
 
-// When minimumReleaseAge is active: pick from the mature versions by the
-// caller's `pickLowestVersion` preference, since maturity narrows which
-// versions are on offer and `resolutionMode` decides which end of what is
-// left to take. If no mature version satisfies the range, fall back to the
-// lowest version regardless of maturity so the resolver can report the
-// violation inline and let the install layer (or other caller) decide what to
-// do — never throw at this layer.
+// `minimumReleaseAge` narrows which versions are on offer; `pickLowestVersion`
+// decides which end of what is left to take. The fallback deliberately drops
+// the maturity filter so a range no mature version satisfies still yields a
+// pick, which the install layer reports as a violation rather than this layer
+// throwing.
 function pickRespectingMinReleaseAge (
   pickerOpts: PickerOptions,
   spec: RegistryPackageSpec,

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -127,18 +127,22 @@ function pickMax (
 const pickHighest = pickPackageFromMeta.bind(null, pickVersionByVersionRange)
 const pickLowest = pickPackageFromMeta.bind(null, pickLowestVersionByVersionRange)
 
-// When minimumReleaseAge is active: try the highest mature version; if none
-// satisfies the range, fall back to the lowest version regardless of maturity
-// so the resolver can report the violation inline and let the install layer
-// (or other caller) decide what to do — never throw at this layer.
+// When minimumReleaseAge is active: pick from the mature versions by the
+// caller's `pickLowestVersion` preference, since maturity narrows which
+// versions are on offer and `resolutionMode` decides which end of what is
+// left to take. If no mature version satisfies the range, fall back to the
+// lowest version regardless of maturity so the resolver can report the
+// violation inline and let the install layer (or other caller) decide what to
+// do — never throw at this layer.
 function pickRespectingMinReleaseAge (
   pickerOpts: PickerOptions,
   spec: RegistryPackageSpec,
   meta: PackageMeta
 ): PackageInRegistry | null {
   return runPicker(pickerOpts, spec, (targetSpec) => {
-    const highest = pickHighest(pickerOpts, meta, targetSpec)
-    if (highest) return highest
+    const pickMature = pickerOpts.pickLowestVersion ? pickLowest : pickHighest
+    const mature = pickMature(pickerOpts, meta, targetSpec)
+    if (mature) return mature
     return pickLowest({
       preferredVersionSelectors: pickerOpts.preferredVersionSelectors,
     }, meta, targetSpec)


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#13752.

`resolutionMode: lowest-direct` and `time-based` were ignored whenever a release-age cutoff was in effect. Since `minimumReleaseAge` has a non-zero built-in default, that is almost always — which is why the reporter found the setting worked only with an explicit `minimumReleaseAge: 0`, and why an invalid `resolutionMode` value produced no visible effect either.

**The two settings answer different questions, and the picker was treating them as alternatives.** `pickMatchingVersionFast` branches on whether `publishedBy` is set: with it, `pickRespectingMinReleaseAge` took the highest mature version and never read `pickLowestVersion`; without it, `pickIgnoringReleaseAge` honoured the mode. But `minimumReleaseAge` narrows *which versions are on offer* — `pickPackageFromMeta` applies the maturity filter to `meta` before picking — and `resolutionMode` decides *which end of what is left* to take. They compose. The maturity branch now picks by `pickLowestVersion` over the matured view.

The fallback is deliberately unchanged: when no mature version satisfies the range it still takes the lowest regardless of maturity, so the resolver reports the violation inline rather than throwing at that layer.

**Both stacks had the same shape.** pacquet's `PickerOpts::pick_lowest_version` even documented the interaction as intended — *"Forced to `false` when `published_by` is active"* — but nothing else justified it, and the surrounding comments only explain the fallback. That doc comment was describing the bug, so it is corrected rather than preserved.

**Why the existing tests missed it.** Both stacks' `lowest-direct` tests disable the interaction: the TypeScript one runs through `testDefaults`, which sets no `minimumReleaseAge`, and pacquet's `resolution_mode_lowest_direct_picks_lowest_direct_version` writes `minimumReleaseAge: 0` into `pnpm-workspace.yaml` — the issue's own workaround. The new tests keep a release age configured, and both were confirmed to fail before the change.

## Squash Commit Body

```text
`resolutionMode: lowest-direct` and `time-based` were ignored whenever a
release-age cutoff was in effect, which the built-in `minimumReleaseAge`
default means is almost always. The picker branched on `publishedBy`
rather than composing the two: the maturity branch always took the
highest mature version and never read `pickLowestVersion`, so the mode
only took effect when `minimumReleaseAge: 0` was set explicitly.

The two settings answer different questions. `minimumReleaseAge` narrows
which versions are on offer; `resolutionMode` picks an end of what is
left. So the maturity branch now picks by `pickLowestVersion` over the
matured view. The fallback is unchanged: when no mature version
satisfies the range it still takes the lowest regardless of maturity, so
the resolver reports the violation inline instead of throwing.

Both stacks had the same shape, and pacquet documented the interaction
as deliberate on `PickerOpts::pick_lowest_version` — that comment was
describing the bug, and is corrected.

Closes pnpm/pnpm#13752.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789046960&installation_model_id=426870&pr_number=13831&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13831&signature=4526233b540b771ce6122005b2d52a7029b4112833795c9b36e22e4974fabb61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected dependency resolution when `minimumReleaseAge` is configured with `lowest-direct` or `time-based` resolution.
  * The installer now selects the lowest eligible mature direct dependency version instead of always choosing the newest eligible version.
  * Preserved fallback behavior when no mature version satisfies the requested range.

* **Tests**
  * Added coverage for resolution behavior involving release-age restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->