### PR TITLE
fix(audit): correct patched version ranges against actually published versions

### DIFF
--- a/.changeset/audit-fix-age-excludes-unpublished-versions.md
+++ b/.changeset/audit-fix-age-excludes-unpublished-versions.md
@@ -5,6 +5,8 @@
 "pacquet": patch
 ---
 
-`pnpm audit` no longer reports a patched version that was never published. The inferred patched range (e.g. `>=2.0.3` from `<=2.0.2`) is now checked against the registry packument, and when no published version satisfies it the report shows `Patched versions: None`. This also prevents `pnpm audit --fix` from adding overrides or `minimumReleaseAgeExclude` entries for patches that do not exist [#13824](https://github.com/pnpm/pnpm/issues/13824).
+`pnpm audit` no longer reports a patched version that was never published or is deprecated. The inferred patched range (e.g. `>=4.17.24` from `<=4.17.23`) is now checked against the registry packument, and the report is corrected to the lowest non-deprecated published version that satisfies it (e.g. `>=4.18.1` when `4.17.24` does not exist and `4.18.0` is deprecated). When no published version satisfies the range, the report shows `Patched versions: None`. This also prevents `pnpm audit --fix` from adding overrides or `minimumReleaseAgeExclude` entries for patches that do not exist [#13824](https://github.com/pnpm/pnpm/issues/13824).
 
 `pnpm audit --fix` and `pnpm audit --fix update` no longer add a `minimumReleaseAgeExclude` entry when the registry packument shows that the minimum patched version was never published. Previously such entries were written for versions that do not exist, which would have let a later publish of that version bypass the `minimumReleaseAge` gate [#11563](https://github.com/pnpm/pnpm/issues/11563).
+
+The `--json` output of `pnpm audit` now returns `patched_versions: null` for advisories whose inferred patch is not available (never published, skipped, yanked, or deprecated), making it easier for tooling to distinguish "no fix available" from "fix available at version X".

--- a/.changeset/audit-fix-age-excludes-unpublished-versions.md
+++ b/.changeset/audit-fix-age-excludes-unpublished-versions.md
@@ -1,0 +1,10 @@
+---
+"@pnpm/deps.compliance.commands": patch
+"@pnpm/deps.compliance.audit": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+`pnpm audit` no longer reports a patched version that was never published. The inferred patched range (e.g. `>=2.0.3` from `<=2.0.2`) is now checked against the registry packument, and when no published version satisfies it the report shows `Patched versions: None`. This also prevents `pnpm audit --fix` from adding overrides or `minimumReleaseAgeExclude` entries for patches that do not exist [#13824](https://github.com/pnpm/pnpm/issues/13824).
+
+`pnpm audit --fix` and `pnpm audit --fix update` no longer add a `minimumReleaseAgeExclude` entry when the registry packument shows that the minimum patched version was never published. Previously such entries were written for versions that do not exist, which would have let a later publish of that version bypass the `minimumReleaseAge` gate [#11563](https://github.com/pnpm/pnpm/issues/11563).

--- a/pnpm/crates/cli/src/cli_args/audit.rs
+++ b/pnpm/crates/cli/src/cli_args/audit.rs
@@ -36,8 +36,9 @@ mod request;
 mod version_ranges;
 
 pub(crate) use fix::{
-    AuditFixObserver, VulnerabilityGuard, filter_advisories_for_fix, fix_override, fix_with_update,
-    format_fix_with_update_output, ignore_vulnerabilities, interactive_select,
+    AuditFixObserver, VulnerabilityGuard, fetch_publish_times, filter_advisories_for_fix,
+    fix_override, fix_with_update, format_fix_with_update_output, ignore_vulnerabilities,
+    interactive_select,
 };
 pub(crate) use paths::{AuditPathIndex, PathInfo, build_audit_path_index, package_version};
 pub(crate) use render::{
@@ -210,7 +211,7 @@ impl AuditArgs {
         // `--fix update` path can re-borrow `state` mutably. Registry errors
         // are swallowed (per `--ignore-registry-errors`) the same way for
         // every path, matching pnpm's catch around the `audit()` call.
-        let report = {
+        let mut report = {
             let lockfile = state
                 .lockfile
                 .get()
@@ -243,6 +244,16 @@ impl AuditArgs {
                 Err(err) => return Err(err.into()),
             }
         };
+        // The inferred patched range is syntactic: verify a published version
+        // actually satisfies it before the report and any fix flow can claim
+        // one. The fetched publish-time maps are reused by the fix flows for
+        // the age-gate exclusion check.
+        let publish_times = drop_unsatisfiable_patched_versions(
+            &mut report,
+            state.config,
+            state.http_client.as_ref(),
+        )
+        .await;
 
         if let Some(fix_method) = fix_method {
             // Pre-filter by audit-level and ignored GHSAs so the interactive
@@ -260,13 +271,9 @@ impl AuditArgs {
             };
             return match fix_method {
                 FixMethod::Override => {
-                    let output = fix_override(
-                        &filtered,
-                        &settings_dir,
-                        state.config,
-                        state.http_client.as_ref(),
-                    )
-                    .await?;
+                    let output =
+                        fix_override(&filtered, &settings_dir, state.config, &publish_times)
+                            .await?;
                     print!("{output}");
                     let _ = std::io::stdout().flush();
                     Ok(AuditOutcome::Clean)
@@ -277,6 +284,7 @@ impl AuditArgs {
                         &filtered,
                         &lockfile_dir,
                         &settings_dir,
+                        &publish_times,
                     )
                     .await?;
                     let mut output = format_fix_with_update_output(&fixed, &remaining, &filtered);
@@ -312,7 +320,6 @@ impl AuditArgs {
             return Ok(AuditOutcome::Clean);
         }
 
-        let mut report = report;
         let total_vulnerability_count = report.metadata.vulnerabilities.total();
         let ignored = filter_ignored_advisories(&mut report, state.config);
 
@@ -473,6 +480,54 @@ fn retry_opts_from_config(config: &Config) -> RetryOpts {
         min_timeout: Duration::from_millis(config.fetch_retry_mintimeout),
         max_timeout: Duration::from_millis(config.fetch_retry_maxtimeout),
     }
+}
+
+/// Drops inferred `patched_versions` ranges that no published version
+/// satisfies: the inference from `vulnerable_versions` is purely syntactic,
+/// so an advisory can claim a patch (e.g. `>=2.0.3`) that was never released.
+/// A failed packument lookup leaves the range untouched (fail open). The
+/// publish-time map's keys double as the published version list; `created`
+/// and `modified` are metadata, not versions. Ports pnpm's
+/// `dropUnsatisfiablePatchedVersions`.
+///
+/// Returns the fetched publish-time maps so the fix flows can reuse them for
+/// the age-gate exclusion check instead of re-fetching each packument.
+async fn drop_unsatisfiable_patched_versions(
+    report: &mut AuditReport,
+    config: &Config,
+    http_client: &pacquet_network::ThrottledClient,
+) -> HashMap<String, Option<HashMap<String, String>>> {
+    let names: HashSet<&str> = report
+        .advisories
+        .values()
+        .filter(|advisory| advisory.patched_versions.is_some())
+        .map(|advisory| advisory.module_name.trim())
+        .collect();
+    if names.is_empty() {
+        return HashMap::new();
+    }
+    let registries: HashMap<String, String> = config.resolved_registries().into_iter().collect();
+    let mut time_maps: HashMap<String, Option<HashMap<String, String>>> = HashMap::new();
+    for name in names {
+        let registry = pick_registry_for_package(&registries, name, None);
+        let times = fetch_publish_times(name, &registry, config, http_client).await;
+        time_maps.insert(name.to_string(), times);
+    }
+    for advisory in report.advisories.values_mut() {
+        let Some(patched) = advisory.patched_versions.as_deref() else { continue };
+        let Some(Some(times)) = time_maps.get(advisory.module_name.trim()) else { continue };
+        let Ok(range) = patched.parse::<Range>() else { continue };
+        let fix_published = times
+            .keys()
+            .filter(|key| key.as_str() != "created" && key.as_str() != "modified")
+            .filter_map(|version| version.parse::<Version>().ok())
+            .any(|version| satisfies_including_prerelease(&version, &range));
+        if !fix_published {
+            advisory.patched_versions = None;
+            advisory.patched_versions_unpublished = Some(true);
+        }
+    }
+    time_maps
 }
 
 impl<'a> AuditGraph<'a> {

--- a/pnpm/crates/cli/src/cli_args/audit.rs
+++ b/pnpm/crates/cli/src/cli_args/audit.rs
@@ -36,9 +36,9 @@ mod request;
 mod version_ranges;
 
 pub(crate) use fix::{
-    AuditFixObserver, VulnerabilityGuard, fetch_publish_times, filter_advisories_for_fix,
-    fix_override, fix_with_update, format_fix_with_update_output, ignore_vulnerabilities,
-    interactive_select,
+    AuditFixObserver, PackumentPublishInfo, VulnerabilityGuard, fetch_publish_times,
+    filter_advisories_for_fix, fix_override, fix_with_update, format_fix_with_update_output,
+    ignore_vulnerabilities, interactive_select,
 };
 pub(crate) use paths::{AuditPathIndex, PathInfo, build_audit_path_index, package_version};
 pub(crate) use render::{
@@ -248,7 +248,7 @@ impl AuditArgs {
         // actually satisfies it before the report and any fix flow can claim
         // one. The fetched publish-time maps are reused by the fix flows for
         // the age-gate exclusion check.
-        let publish_times = drop_unsatisfiable_patched_versions(
+        let publish_infos = correct_inferred_patched_versions(
             &mut report,
             state.config,
             state.http_client.as_ref(),
@@ -272,7 +272,7 @@ impl AuditArgs {
             return match fix_method {
                 FixMethod::Override => {
                     let output =
-                        fix_override(&filtered, &settings_dir, state.config, &publish_times)
+                        fix_override(&filtered, &settings_dir, state.config, &publish_infos)
                             .await?;
                     print!("{output}");
                     let _ = std::io::stdout().flush();
@@ -284,7 +284,7 @@ impl AuditArgs {
                         &filtered,
                         &lockfile_dir,
                         &settings_dir,
-                        &publish_times,
+                        &publish_infos,
                     )
                     .await?;
                     let mut output = format_fix_with_update_output(&fixed, &remaining, &filtered);
@@ -482,21 +482,23 @@ fn retry_opts_from_config(config: &Config) -> RetryOpts {
     }
 }
 
-/// Drops inferred `patched_versions` ranges that no published version
-/// satisfies: the inference from `vulnerable_versions` is purely syntactic,
-/// so an advisory can claim a patch (e.g. `>=2.0.3`) that was never released.
-/// A failed packument lookup leaves the range untouched (fail open). The
-/// publish-time map's keys double as the published version list; `created`
-/// and `modified` are metadata, not versions. Ports pnpm's
-/// `dropUnsatisfiablePatchedVersions`.
+/// Corrects inferred `patched_versions` ranges against the registry: the
+/// inference from `vulnerable_versions` is purely syntactic, so the inferred
+/// minimum may not be a viable fix — it may never have been published, been
+/// skipped, been yanked, or been deprecated. When the inferred range is
+/// satisfiable, it is narrowed to the lowest non-deprecated published version
+/// (e.g. `>=4.17.24` becomes `>=4.18.1` when 4.17.24 does not exist and
+/// 4.18.0 is deprecated). When no published version satisfies it, the range
+/// is dropped entirely. A failed packument lookup leaves the range untouched
+/// (fail open). Ports pnpm's `correctInferredPatchedVersions`.
 ///
 /// Returns the fetched publish-time maps so the fix flows can reuse them for
 /// the age-gate exclusion check instead of re-fetching each packument.
-async fn drop_unsatisfiable_patched_versions(
+async fn correct_inferred_patched_versions(
     report: &mut AuditReport,
     config: &Config,
     http_client: &pacquet_network::ThrottledClient,
-) -> HashMap<String, Option<HashMap<String, String>>> {
+) -> HashMap<String, Option<PackumentPublishInfo>> {
     let names: HashSet<&str> = report
         .advisories
         .values()
@@ -507,27 +509,35 @@ async fn drop_unsatisfiable_patched_versions(
         return HashMap::new();
     }
     let registries: HashMap<String, String> = config.resolved_registries().into_iter().collect();
-    let mut time_maps: HashMap<String, Option<HashMap<String, String>>> = HashMap::new();
+    let mut publish_infos: HashMap<String, Option<PackumentPublishInfo>> = HashMap::new();
     for name in names {
         let registry = pick_registry_for_package(&registries, name, None);
-        let times = fetch_publish_times(name, &registry, config, http_client).await;
-        time_maps.insert(name.to_string(), times);
+        let info = fetch_publish_times(name, &registry, config, http_client).await;
+        publish_infos.insert(name.to_string(), info);
     }
     for advisory in report.advisories.values_mut() {
         let Some(patched) = advisory.patched_versions.as_deref() else { continue };
-        let Some(Some(times)) = time_maps.get(advisory.module_name.trim()) else { continue };
+        let Some(Some(info)) = publish_infos.get(advisory.module_name.trim()) else { continue };
         let Ok(range) = patched.parse::<Range>() else { continue };
-        let fix_published = times
+        let lowest = info
+            .time
             .keys()
             .filter(|key| key.as_str() != "created" && key.as_str() != "modified")
+            .filter(|key| !info.deprecated.contains(key.as_str()))
             .filter_map(|version| version.parse::<Version>().ok())
-            .any(|version| satisfies_including_prerelease(&version, &range));
-        if !fix_published {
-            advisory.patched_versions = None;
-            advisory.patched_versions_unpublished = Some(true);
+            .filter(|version| satisfies_including_prerelease(version, &range))
+            .min();
+        match lowest {
+            None => {
+                advisory.patched_versions = None;
+                advisory.patched_versions_unpublished = Some(true);
+            }
+            Some(lowest) => {
+                advisory.patched_versions = Some(format!(">={lowest}"));
+            }
         }
     }
-    time_maps
+    publish_infos
 }
 
 impl<'a> AuditGraph<'a> {

--- a/pnpm/crates/cli/src/cli_args/audit.rs
+++ b/pnpm/crates/cli/src/cli_args/audit.rs
@@ -497,7 +497,7 @@ fn retry_opts_from_config(config: &Config) -> RetryOpts {
 async fn correct_inferred_patched_versions(
     report: &mut AuditReport,
     config: &Config,
-    http_client: &pacquet_network::ThrottledClient,
+    http_client: &pnpm_network::ThrottledClient,
 ) -> HashMap<String, Option<PackumentPublishInfo>> {
     let names: HashSet<&str> = report
         .advisories
@@ -509,30 +509,24 @@ async fn correct_inferred_patched_versions(
         return HashMap::new();
     }
     let registries: HashMap<String, String> = config.resolved_registries().into_iter().collect();
-    let mut publish_infos: HashMap<String, Option<PackumentPublishInfo>> = HashMap::new();
-    for name in names {
+    let fetches = names.into_iter().map(|name| {
         let registry = pick_registry_for_package(&registries, name, None);
-        let info = fetch_publish_times(name, &registry, config, http_client).await;
-        publish_infos.insert(name.to_string(), info);
-    }
+        async move {
+            (name.to_string(), fetch_publish_times(name, &registry, config, http_client).await)
+        }
+    });
+    let publish_infos: HashMap<String, Option<PackumentPublishInfo>> =
+        futures_util::future::join_all(fetches).await.into_iter().collect();
     for advisory in report.advisories.values_mut() {
         let Some(patched) = advisory.patched_versions.as_deref() else { continue };
         let Some(Some(info)) = publish_infos.get(advisory.module_name.trim()) else { continue };
         let Ok(range) = patched.parse::<Range>() else { continue };
-        let lowest = info
-            .time
-            .keys()
-            .filter(|key| key.as_str() != "created" && key.as_str() != "modified")
-            .filter(|key| !info.deprecated.contains(key.as_str()))
-            .filter_map(|version| version.parse::<Version>().ok())
-            .filter(|version| satisfies_including_prerelease(version, &range))
-            .min();
-        match lowest {
+        match info.lowest_non_deprecated_version(&range) {
             None => {
                 advisory.patched_versions = None;
                 advisory.patched_versions_unpublished = Some(true);
             }
-            Some(lowest) => {
+            Some((_, lowest)) => {
                 advisory.patched_versions = Some(format!(">={lowest}"));
             }
         }

--- a/pnpm/crates/cli/src/cli_args/audit/fix.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/fix.rs
@@ -158,12 +158,15 @@ async fn resolve_minimum_release_age_excludes(
 
 /// The `minimumReleaseAgeExclude` entries needed to keep the age gate from
 /// blocking the patched versions: one `name@minVersion` spec per fixable
-/// advisory whose minimum patched version is younger than `cutoff`. A version
-/// published at or before the cutoff doesn't need a bypass, and a version
-/// whose publish time is unknown keeps its entry so a genuinely fresh fix
-/// stays installable. A version missing from a successfully fetched packument
-/// was never published — no fix has shipped — so it gets no entry. Ports
-/// pnpm's `createMinimumReleaseAgeExcludes`.
+/// advisory whose minimum published version satisfying the patched range is
+/// younger than `cutoff`. The theoretical range minimum may never have been
+/// published (a skipped or yanked release), so the lowest published version
+/// that satisfies the range is used instead — that is the version the
+/// override actually resolves to. A version published at or before the cutoff
+/// doesn't need a bypass, and a version whose publish time is unknown keeps
+/// its entry so a genuinely fresh fix stays installable. A version missing
+/// from a successfully fetched packument was never published — no fix has
+/// shipped — so it gets no entry. Ports pnpm's `createMinimumReleaseAgeExcludes`.
 pub(crate) fn minimum_release_age_excludes(
     advisories: &BTreeMap<String, AuditAdvisory>,
     publish_times: &HashMap<String, Option<HashMap<String, String>>>,
@@ -180,12 +183,22 @@ pub(crate) fn minimum_release_age_excludes(
             let Some(times) = publish_times.get(name).and_then(Option::as_ref) else {
                 return Some(format!("{name}@{min}"));
             };
-            let raw = times.get(min.to_string().as_str())?;
+            // The theoretical range minimum may not exist on the registry;
+            // use the lowest published version that satisfies the range,
+            // which is what the override actually resolves to.
+            let range = patched.parse::<Range>().ok()?;
+            let lowest = times
+                .keys()
+                .filter(|key| key.as_str() != "created" && key.as_str() != "modified")
+                .filter_map(|version| version.parse::<Version>().ok())
+                .filter(|version| satisfies_including_prerelease(version, &range))
+                .min()?;
+            let raw = times.get(lowest.to_string().as_str())?;
             match parse_packument_timestamp(raw) {
                 Some(published_at) if published_at <= cutoff => None,
                 // A present-but-unparsable timestamp fails open like unknown
                 // publish times.
-                _ => Some(format!("{name}@{min}")),
+                _ => Some(format!("{name}@{lowest}")),
             }
         })
         .collect();

--- a/pnpm/crates/cli/src/cli_args/audit/fix.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/fix.rs
@@ -5,9 +5,9 @@ use super::{
     DependencyGroup, Deserialize, HashMap, HashSet, IntoDiagnostic, Lockfile, MultiSelect,
     PackageVersionGuard, Range, Reporter, ResolutionObserver, State, Update, Utc, Version, blue,
     caret_range_for_patched, color_severity, encode_package_name, green, normalize_ghsa_id,
-    normalize_registry, parse_packument_timestamp, pick_registry_for_package, red,
-    redact_url_userinfo, retry_opts_from_config, satisfies_including_prerelease, send_with_retry,
-    severity_name, severity_number,
+    normalize_registry, parse_packument_timestamp, red, redact_url_userinfo,
+    retry_opts_from_config, satisfies_including_prerelease, send_with_retry, severity_name,
+    severity_number,
 };
 
 /// Filter `report`'s advisories down to the set both fix methods and the
@@ -57,11 +57,13 @@ pub(crate) fn create_overrides(
 
 /// Write the override-method fixes to `pnpm-workspace.yaml` and return the
 /// user-facing summary. Mirrors the override branch of pnpm's audit handler.
+/// `publish_times` reuses the packument maps the report validation already
+/// fetched so the age-gate check doesn't request them again.
 pub(crate) async fn fix_override(
     advisories: &BTreeMap<String, AuditAdvisory>,
     settings_dir: &std::path::Path,
     config: &Config,
-    http_client: &pnpm_network::ThrottledClient,
+    publish_times: &HashMap<String, Option<HashMap<String, String>>>,
 ) -> miette::Result<String> {
     let overrides = create_overrides(advisories);
     if overrides.is_empty() {
@@ -77,13 +79,9 @@ pub(crate) async fn fix_override(
         overrides.len(),
     );
     if let Some(minimum_release_age) = config.resolved_minimum_release_age() {
-        let added = resolve_minimum_release_age_excludes(
-            advisories,
-            config,
-            http_client,
-            minimum_release_age,
-        )
-        .await?;
+        let added =
+            resolve_minimum_release_age_excludes(advisories, publish_times, minimum_release_age)
+                .await?;
         if !added.is_empty() {
             write_age_excludes(settings_dir, config, &added)?;
             let note = format!(
@@ -102,7 +100,7 @@ pub(crate) async fn fix_override(
 /// registry answered non-200, or the packument carries no usable `time` field.
 /// Ports pnpm's `createPublishTimesFetcher`; `None` must read as "no
 /// information", not "old", so a genuinely fresh fix keeps its exclusion.
-async fn fetch_publish_times(
+pub(crate) async fn fetch_publish_times(
     name: &str,
     registry: &str,
     config: &Config,
@@ -137,14 +135,13 @@ async fn fetch_publish_times(
     response.json::<PackumentTimes>().await.ok()?.time
 }
 
-/// Compute the age-gate exclusions for `advisories`, consulting the
-/// packuments of the affected packages so a patched version published long
-/// before the cutoff gets no pointless `minimumReleaseAgeExclude` entry.
+/// Compute the age-gate exclusions for `advisories` using the publish-time
+/// maps the report validation already fetched, so a patched version published
+/// long before the cutoff gets no pointless `minimumReleaseAgeExclude` entry.
 /// Ports the publish-time lookup of pnpm's `createMinimumReleaseAgeExcludes`.
 async fn resolve_minimum_release_age_excludes(
     advisories: &BTreeMap<String, AuditAdvisory>,
-    config: &Config,
-    http_client: &pnpm_network::ThrottledClient,
+    publish_times: &HashMap<String, Option<HashMap<String, String>>>,
     minimum_release_age: u64,
 ) -> miette::Result<Vec<String>> {
     // On overflow leave the cutoff uncomputable, as `PickPolicy::from_config`
@@ -156,22 +153,7 @@ async fn resolve_minimum_release_age_excludes(
     else {
         return Ok(Vec::new());
     };
-    // One fetch per package name, however many advisories it carries. The
-    // name comes from the registry's advisory feed, so normalize it like
-    // `classify_for_update` does before using it in requests and config.
-    let names: HashSet<&str> = advisories
-        .values()
-        .filter(|advisory| advisory.patched_versions.is_some())
-        .map(|advisory| advisory.module_name.trim())
-        .collect();
-    let registries: HashMap<String, String> = config.resolved_registries().into_iter().collect();
-    let mut publish_times = HashMap::new();
-    for name in names {
-        let registry = pick_registry_for_package(&registries, name, None);
-        let times = fetch_publish_times(name, &registry, config, http_client).await;
-        publish_times.insert(name.to_string(), times);
-    }
-    minimum_release_age_excludes(advisories, &publish_times, cutoff)
+    minimum_release_age_excludes(advisories, publish_times, cutoff)
 }
 
 /// The `minimumReleaseAgeExclude` entries needed to keep the age gate from
@@ -179,7 +161,9 @@ async fn resolve_minimum_release_age_excludes(
 /// advisory whose minimum patched version is younger than `cutoff`. A version
 /// published at or before the cutoff doesn't need a bypass, and a version
 /// whose publish time is unknown keeps its entry so a genuinely fresh fix
-/// stays installable. Ports pnpm's `createMinimumReleaseAgeExcludes`.
+/// stays installable. A version missing from a successfully fetched packument
+/// was never published — no fix has shipped — so it gets no entry. Ports
+/// pnpm's `createMinimumReleaseAgeExcludes`.
 pub(crate) fn minimum_release_age_excludes(
     advisories: &BTreeMap<String, AuditAdvisory>,
     publish_times: &HashMap<String, Option<HashMap<String, String>>>,
@@ -193,13 +177,14 @@ pub(crate) fn minimum_release_age_excludes(
                 .strip_prefix(">=")
                 .and_then(|version| version.trim().parse::<Version>().ok())?;
             let name = advisory.module_name.trim();
-            let published_at = publish_times
-                .get(name)
-                .and_then(Option::as_ref)
-                .and_then(|times| times.get(min.to_string().as_str()))
-                .and_then(|raw| parse_packument_timestamp(raw));
-            match published_at {
+            let Some(times) = publish_times.get(name).and_then(Option::as_ref) else {
+                return Some(format!("{name}@{min}"));
+            };
+            let raw = times.get(min.to_string().as_str())?;
+            match parse_packument_timestamp(raw) {
                 Some(published_at) if published_at <= cutoff => None,
+                // A present-but-unparsable timestamp fails open like unknown
+                // publish times.
                 _ => Some(format!("{name}@{min}")),
             }
         })
@@ -413,6 +398,7 @@ pub(crate) async fn fix_with_update<Reporter: self::Reporter + 'static>(
     advisories: &BTreeMap<String, AuditAdvisory>,
     lockfile_dir: &std::path::Path,
     settings_dir: &std::path::Path,
+    publish_times: &HashMap<String, Option<HashMap<String, String>>>,
 ) -> miette::Result<(Vec<u64>, Vec<u64>, Vec<String>)> {
     let UpdateClassification { vulnerabilities, unfixable, unparsable } =
         classify_for_update(advisories);
@@ -421,22 +407,19 @@ pub(crate) async fn fix_with_update<Reporter: self::Reporter + 'static>(
     // fresher than the cutoff; record the ones that actually are as
     // exclusions (persisted to config and injected into this resolve) so the
     // picker may install them.
-    let age_excludes =
-        if let Some(minimum_release_age) = state.config.resolved_minimum_release_age() {
-            let added = resolve_minimum_release_age_excludes(
-                advisories,
-                state.config,
-                state.http_client.as_ref(),
-                minimum_release_age,
-            )
-            .await?;
-            if !added.is_empty() {
-                write_age_excludes(settings_dir, state.config, &added)?;
-            }
-            added
-        } else {
-            Vec::new()
-        };
+    let age_excludes = if let Some(minimum_release_age) =
+        state.config.resolved_minimum_release_age()
+    {
+        let added =
+            resolve_minimum_release_age_excludes(advisories, publish_times, minimum_release_age)
+                .await?;
+        if !added.is_empty() {
+            write_age_excludes(settings_dir, state.config, &added)?;
+        }
+        added
+    } else {
+        Vec::new()
+    };
 
     let guard_ranges: HashMap<String, Vec<Range>> = vulnerabilities
         .iter()

--- a/pnpm/crates/cli/src/cli_args/audit/fix.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/fix.rs
@@ -97,7 +97,7 @@ pub(crate) async fn fix_override(
 
 /// The packument publish info of one package: the `time` map plus the set of
 /// deprecated versions, or `None` when the packument could not be fetched or
-/// carries no usable `time` field. Ports pnpm's `PackumentPublishInfo`.
+/// carries no usable `time` field. Ports pnpm's publish-info structure.
 #[derive(Debug, Clone)]
 pub(crate) struct PackumentPublishInfo {
     /// The packument `time` map: version → raw publish timestamp. Includes

--- a/pnpm/crates/cli/src/cli_args/audit/fix.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/fix.rs
@@ -57,13 +57,13 @@ pub(crate) fn create_overrides(
 
 /// Write the override-method fixes to `pnpm-workspace.yaml` and return the
 /// user-facing summary. Mirrors the override branch of pnpm's audit handler.
-/// `publish_times` reuses the packument maps the report validation already
-/// fetched so the age-gate check doesn't request them again.
+/// `publish_infos` reuses the packument data the report validation already
+/// fetched so the age-gate check doesn't request it again.
 pub(crate) async fn fix_override(
     advisories: &BTreeMap<String, AuditAdvisory>,
     settings_dir: &std::path::Path,
     config: &Config,
-    publish_times: &HashMap<String, Option<HashMap<String, String>>>,
+    publish_infos: &HashMap<String, Option<PackumentPublishInfo>>,
 ) -> miette::Result<String> {
     let overrides = create_overrides(advisories);
     if overrides.is_empty() {
@@ -80,7 +80,7 @@ pub(crate) async fn fix_override(
     );
     if let Some(minimum_release_age) = config.resolved_minimum_release_age() {
         let added =
-            resolve_minimum_release_age_excludes(advisories, publish_times, minimum_release_age)
+            resolve_minimum_release_age_excludes(advisories, publish_infos, minimum_release_age)
                 .await?;
         if !added.is_empty() {
             write_age_excludes(settings_dir, config, &added)?;
@@ -95,20 +95,39 @@ pub(crate) async fn fix_override(
     Ok(output)
 }
 
-/// The packument `time` map of one package: version to raw publish timestamp,
-/// or `None` when the publish times are unknown — the request failed, the
-/// registry answered non-200, or the packument carries no usable `time` field.
-/// Ports pnpm's `createPublishTimesFetcher`; `None` must read as "no
-/// information", not "old", so a genuinely fresh fix keeps its exclusion.
+/// The packument publish info of one package: the `time` map plus the set of
+/// deprecated versions, or `None` when the packument could not be fetched or
+/// carries no usable `time` field. Ports pnpm's `PackumentPublishInfo`.
+#[derive(Debug, Clone)]
+pub(crate) struct PackumentPublishInfo {
+    /// The packument `time` map: version → raw publish timestamp. Includes
+    /// the `created` and `modified` metadata keys alongside version keys.
+    pub(crate) time: HashMap<String, String>,
+    /// Versions the packument marks as deprecated. Deprecated versions are
+    /// excluded from patched-version validation — a deprecated release is
+    /// not a viable fix even though it exists on the registry.
+    pub(crate) deprecated: HashSet<String>,
+}
+
+/// The packument publish info of one package, or `None` when the packument
+/// could not be fetched or carries no usable `time` field. Ports pnpm's
+/// `createPublishTimesFetcher`; `None` must read as "no information", not
+/// "old", so a genuinely fresh fix keeps its exclusion.
 pub(crate) async fn fetch_publish_times(
     name: &str,
     registry: &str,
     config: &Config,
     http_client: &pnpm_network::ThrottledClient,
-) -> Option<HashMap<String, String>> {
+) -> Option<PackumentPublishInfo> {
     #[derive(Deserialize)]
     struct PackumentTimes {
         time: Option<HashMap<String, String>>,
+        versions: Option<HashMap<String, PackumentVersion>>,
+    }
+
+    #[derive(Deserialize)]
+    struct PackumentVersion {
+        deprecated: Option<String>,
     }
 
     let registry = normalize_registry(registry);
@@ -132,7 +151,16 @@ pub(crate) async fn fetch_publish_times(
     if response.status().as_u16() != 200 {
         return None;
     }
-    response.json::<PackumentTimes>().await.ok()?.time
+    let body = response.json::<PackumentTimes>().await.ok()?;
+    let time = body.time?;
+    let deprecated = body
+        .versions
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|(_, manifest)| manifest.deprecated.is_some())
+        .map(|(version, _)| version)
+        .collect();
+    Some(PackumentPublishInfo { time, deprecated })
 }
 
 /// Compute the age-gate exclusions for `advisories` using the publish-time
@@ -141,7 +169,7 @@ pub(crate) async fn fetch_publish_times(
 /// Ports the publish-time lookup of pnpm's `createMinimumReleaseAgeExcludes`.
 async fn resolve_minimum_release_age_excludes(
     advisories: &BTreeMap<String, AuditAdvisory>,
-    publish_times: &HashMap<String, Option<HashMap<String, String>>>,
+    publish_infos: &HashMap<String, Option<PackumentPublishInfo>>,
     minimum_release_age: u64,
 ) -> miette::Result<Vec<String>> {
     // On overflow leave the cutoff uncomputable, as `PickPolicy::from_config`
@@ -153,24 +181,25 @@ async fn resolve_minimum_release_age_excludes(
     else {
         return Ok(Vec::new());
     };
-    minimum_release_age_excludes(advisories, publish_times, cutoff)
+    minimum_release_age_excludes(advisories, publish_infos, cutoff)
 }
 
 /// The `minimumReleaseAgeExclude` entries needed to keep the age gate from
 /// blocking the patched versions: one `name@minVersion` spec per fixable
-/// advisory whose minimum published version satisfying the patched range is
-/// younger than `cutoff`. The theoretical range minimum may never have been
-/// published (a skipped or yanked release), so the lowest published version
-/// that satisfies the range is used instead — that is the version the
-/// override actually resolves to. A version published at or before the cutoff
-/// doesn't need a bypass, and a version whose publish time is unknown keeps
-/// its entry so a genuinely fresh fix stays installable. A version absent
-/// from a successfully fetched packument is not available — whether it was
-/// never published, skipped, or yanked — so it gets no entry. Ports pnpm's
+/// advisory whose minimum non-deprecated published version satisfying the
+/// patched range is younger than `cutoff`. The theoretical range minimum may
+/// not exist on the registry (a skipped, yanked, or deprecated release), so
+/// the lowest non-deprecated published version that satisfies the range is
+/// used instead — that is the version the override actually resolves to. A
+/// version published at or before the cutoff doesn't need a bypass, and a
+/// version whose publish time is unknown keeps its entry so a genuinely fresh
+/// fix stays installable. A version absent from a successfully fetched
+/// packument is not available — whether it was never published, skipped,
+/// yanked, or deprecated — so it gets no entry. Ports pnpm's
 /// `createMinimumReleaseAgeExcludes`.
 pub(crate) fn minimum_release_age_excludes(
     advisories: &BTreeMap<String, AuditAdvisory>,
-    publish_times: &HashMap<String, Option<HashMap<String, String>>>,
+    publish_infos: &HashMap<String, Option<PackumentPublishInfo>>,
     cutoff: DateTime<Utc>,
 ) -> miette::Result<Vec<String>> {
     let specs: Vec<String> = advisories
@@ -181,22 +210,24 @@ pub(crate) fn minimum_release_age_excludes(
                 .strip_prefix(">=")
                 .and_then(|version| version.trim().parse::<Version>().ok())?;
             let name = advisory.module_name.trim();
-            let Some(times) = publish_times.get(name).and_then(Option::as_ref) else {
+            let Some(info) = publish_infos.get(name).and_then(Option::as_ref) else {
                 return Some(format!("{name}@{min}"));
             };
             // The theoretical range minimum may not exist on the registry;
-            // use the lowest published version that satisfies the range,
-            // which is what the override actually resolves to. The original
-            // key is retained because the registry may use a non-normalized
-            // form (e.g. `v1.2.3`) that the parsed Version drops.
+            // use the lowest non-deprecated published version that satisfies
+            // the range, which is what the override actually resolves to. The
+            // original key is retained because the registry may use a
+            // non-normalized form (e.g. `v1.2.3`) that the parsed Version drops.
             let range = patched.parse::<Range>().ok()?;
-            let lowest = times
+            let lowest = info
+                .time
                 .keys()
                 .filter(|key| key.as_str() != "created" && key.as_str() != "modified")
+                .filter(|key| !info.deprecated.contains(key.as_str()))
                 .filter_map(|key| key.parse::<Version>().ok().map(|parsed| (key, parsed)))
                 .filter(|(_, parsed)| satisfies_including_prerelease(parsed, &range))
                 .min_by(|(_, a), (_, b)| a.cmp(b))?;
-            let raw = times.get(lowest.0)?;
+            let raw = info.time.get(lowest.0)?;
             match parse_packument_timestamp(raw) {
                 Some(published_at) if published_at <= cutoff => None,
                 // A present-but-unparsable timestamp fails open like unknown
@@ -414,7 +445,7 @@ pub(crate) async fn fix_with_update<Reporter: self::Reporter + 'static>(
     advisories: &BTreeMap<String, AuditAdvisory>,
     lockfile_dir: &std::path::Path,
     settings_dir: &std::path::Path,
-    publish_times: &HashMap<String, Option<HashMap<String, String>>>,
+    publish_infos: &HashMap<String, Option<PackumentPublishInfo>>,
 ) -> miette::Result<(Vec<u64>, Vec<u64>, Vec<String>)> {
     let UpdateClassification { vulnerabilities, unfixable, unparsable } =
         classify_for_update(advisories);
@@ -427,7 +458,7 @@ pub(crate) async fn fix_with_update<Reporter: self::Reporter + 'static>(
         state.config.resolved_minimum_release_age()
     {
         let added =
-            resolve_minimum_release_age_excludes(advisories, publish_times, minimum_release_age)
+            resolve_minimum_release_age_excludes(advisories, publish_infos, minimum_release_age)
                 .await?;
         if !added.is_empty() {
             write_age_excludes(settings_dir, state.config, &added)?;

--- a/pnpm/crates/cli/src/cli_args/audit/fix.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/fix.rs
@@ -164,9 +164,10 @@ async fn resolve_minimum_release_age_excludes(
 /// that satisfies the range is used instead — that is the version the
 /// override actually resolves to. A version published at or before the cutoff
 /// doesn't need a bypass, and a version whose publish time is unknown keeps
-/// its entry so a genuinely fresh fix stays installable. A version missing
-/// from a successfully fetched packument was never published — no fix has
-/// shipped — so it gets no entry. Ports pnpm's `createMinimumReleaseAgeExcludes`.
+/// its entry so a genuinely fresh fix stays installable. A version absent
+/// from a successfully fetched packument is not available — whether it was
+/// never published, skipped, or yanked — so it gets no entry. Ports pnpm's
+/// `createMinimumReleaseAgeExcludes`.
 pub(crate) fn minimum_release_age_excludes(
     advisories: &BTreeMap<String, AuditAdvisory>,
     publish_times: &HashMap<String, Option<HashMap<String, String>>>,
@@ -185,20 +186,22 @@ pub(crate) fn minimum_release_age_excludes(
             };
             // The theoretical range minimum may not exist on the registry;
             // use the lowest published version that satisfies the range,
-            // which is what the override actually resolves to.
+            // which is what the override actually resolves to. The original
+            // key is retained because the registry may use a non-normalized
+            // form (e.g. `v1.2.3`) that the parsed Version drops.
             let range = patched.parse::<Range>().ok()?;
             let lowest = times
                 .keys()
                 .filter(|key| key.as_str() != "created" && key.as_str() != "modified")
-                .filter_map(|version| version.parse::<Version>().ok())
-                .filter(|version| satisfies_including_prerelease(version, &range))
-                .min()?;
-            let raw = times.get(lowest.to_string().as_str())?;
+                .filter_map(|key| key.parse::<Version>().ok().map(|parsed| (key, parsed)))
+                .filter(|(_, parsed)| satisfies_including_prerelease(parsed, &range))
+                .min_by(|(_, a), (_, b)| a.cmp(b))?;
+            let raw = times.get(lowest.0)?;
             match parse_packument_timestamp(raw) {
                 Some(published_at) if published_at <= cutoff => None,
                 // A present-but-unparsable timestamp fails open like unknown
                 // publish times.
-                _ => Some(format!("{name}@{lowest}")),
+                _ => Some(format!("{name}@{}", lowest.1)),
             }
         })
         .collect();

--- a/pnpm/crates/cli/src/cli_args/audit/fix.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/fix.rs
@@ -103,8 +103,10 @@ pub(crate) struct PackumentPublishInfo {
     pub(crate) time: HashMap<String, String>,
     /// Versions the packument marks as deprecated. Deprecated versions are
     /// excluded from patched-version validation — a deprecated release is
-    /// not a viable fix even though it exists on the registry.
-    pub(crate) deprecated: HashSet<String>,
+    /// not a viable fix even though it exists on the registry. Parsed rather
+    /// than kept as raw keys, because the `time` and `versions` maps may spell
+    /// the same release differently (`v1.2.3` vs `1.2.3`).
+    pub(crate) deprecated: HashSet<Version>,
 }
 
 impl PackumentPublishInfo {
@@ -114,14 +116,20 @@ impl PackumentPublishInfo {
     /// (e.g. `v1.2.3`) that the parsed version drops. `None` when no published
     /// version satisfies the range, whether it was never published, skipped,
     /// yanked, or deprecated.
+    ///
+    /// Stable releases outrank prereleases regardless of order, so a
+    /// `4.18.0-beta.1` published before `4.18.0` is never advertised as the
+    /// fix. A prerelease still wins when nothing else satisfies the range.
     pub(crate) fn lowest_non_deprecated_version(&self, range: &Range) -> Option<(&str, Version)> {
         self.time
             .keys()
             .filter(|key| key.as_str() != "created" && key.as_str() != "modified")
-            .filter(|key| !self.deprecated.contains(key.as_str()))
             .filter_map(|key| Some((key.as_str(), key.parse::<Version>().ok()?)))
+            .filter(|(_, version)| !self.deprecated.contains(version))
             .filter(|(_, version)| satisfies_including_prerelease(version, range))
-            .min_by(|(_, a), (_, b)| a.cmp(b))
+            .min_by(|(_, a), (_, b)| {
+                a.is_prerelease().cmp(&b.is_prerelease()).then_with(|| a.cmp(b))
+            })
     }
 }
 
@@ -174,7 +182,7 @@ pub(crate) async fn fetch_publish_times(
         .unwrap_or_default()
         .into_iter()
         .filter(|(_, manifest)| manifest.deprecated.is_some())
-        .map(|(version, _)| version)
+        .filter_map(|(version, _)| version.parse::<Version>().ok())
         .collect();
     Some(PackumentPublishInfo { time, deprecated })
 }

--- a/pnpm/crates/cli/src/cli_args/audit/fix.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/fix.rs
@@ -80,8 +80,7 @@ pub(crate) async fn fix_override(
     );
     if let Some(minimum_release_age) = config.resolved_minimum_release_age() {
         let added =
-            resolve_minimum_release_age_excludes(advisories, publish_infos, minimum_release_age)
-                .await?;
+            resolve_minimum_release_age_excludes(advisories, publish_infos, minimum_release_age)?;
         if !added.is_empty() {
             write_age_excludes(settings_dir, config, &added)?;
             let note = format!(
@@ -96,8 +95,7 @@ pub(crate) async fn fix_override(
 }
 
 /// The packument publish info of one package: the `time` map plus the set of
-/// deprecated versions, or `None` when the packument could not be fetched or
-/// carries no usable `time` field. Ports pnpm's publish-info structure.
+/// deprecated versions.
 #[derive(Debug, Clone)]
 pub(crate) struct PackumentPublishInfo {
     /// The packument `time` map: version → raw publish timestamp. Includes
@@ -107,6 +105,24 @@ pub(crate) struct PackumentPublishInfo {
     /// excluded from patched-version validation — a deprecated release is
     /// not a viable fix even though it exists on the registry.
     pub(crate) deprecated: HashSet<String>,
+}
+
+impl PackumentPublishInfo {
+    /// The lowest non-deprecated published version satisfying `range` — the
+    /// version an inferred patched range actually resolves to — paired with
+    /// its `time` key, which the registry may spell in a non-normalized form
+    /// (e.g. `v1.2.3`) that the parsed version drops. `None` when no published
+    /// version satisfies the range, whether it was never published, skipped,
+    /// yanked, or deprecated.
+    pub(crate) fn lowest_non_deprecated_version(&self, range: &Range) -> Option<(&str, Version)> {
+        self.time
+            .keys()
+            .filter(|key| key.as_str() != "created" && key.as_str() != "modified")
+            .filter(|key| !self.deprecated.contains(key.as_str()))
+            .filter_map(|key| Some((key.as_str(), key.parse::<Version>().ok()?)))
+            .filter(|(_, version)| satisfies_including_prerelease(version, range))
+            .min_by(|(_, a), (_, b)| a.cmp(b))
+    }
 }
 
 /// The packument publish info of one package, or `None` when the packument
@@ -167,7 +183,7 @@ pub(crate) async fn fetch_publish_times(
 /// maps the report validation already fetched, so a patched version published
 /// long before the cutoff gets no pointless `minimumReleaseAgeExclude` entry.
 /// Ports the publish-time lookup of pnpm's `createMinimumReleaseAgeExcludes`.
-async fn resolve_minimum_release_age_excludes(
+fn resolve_minimum_release_age_excludes(
     advisories: &BTreeMap<String, AuditAdvisory>,
     publish_infos: &HashMap<String, Option<PackumentPublishInfo>>,
     minimum_release_age: u64,
@@ -185,17 +201,13 @@ async fn resolve_minimum_release_age_excludes(
 }
 
 /// The `minimumReleaseAgeExclude` entries needed to keep the age gate from
-/// blocking the patched versions: one `name@minVersion` spec per fixable
-/// advisory whose minimum non-deprecated published version satisfying the
-/// patched range is younger than `cutoff`. The theoretical range minimum may
-/// not exist on the registry (a skipped, yanked, or deprecated release), so
-/// the lowest non-deprecated published version that satisfies the range is
-/// used instead — that is the version the override actually resolves to. A
-/// version published at or before the cutoff doesn't need a bypass, and a
-/// version whose publish time is unknown keeps its entry so a genuinely fresh
-/// fix stays installable. A version absent from a successfully fetched
-/// packument is not available — whether it was never published, skipped,
-/// yanked, or deprecated — so it gets no entry. Ports pnpm's
+/// blocking the patched versions: one `name@version` spec per fixable
+/// advisory whose fix — the version
+/// [`PackumentPublishInfo::lowest_non_deprecated_version`] resolves the
+/// patched range to — is younger than `cutoff`. A version published at or
+/// before the cutoff doesn't need a bypass, and a version whose publish time
+/// is unknown keeps its entry so a genuinely fresh fix stays installable. An
+/// advisory the packument offers no fix for gets no entry. Ports pnpm's
 /// `createMinimumReleaseAgeExcludes`.
 pub(crate) fn minimum_release_age_excludes(
     advisories: &BTreeMap<String, AuditAdvisory>,
@@ -213,26 +225,13 @@ pub(crate) fn minimum_release_age_excludes(
             let Some(info) = publish_infos.get(name).and_then(Option::as_ref) else {
                 return Some(format!("{name}@{min}"));
             };
-            // The theoretical range minimum may not exist on the registry;
-            // use the lowest non-deprecated published version that satisfies
-            // the range, which is what the override actually resolves to. The
-            // original key is retained because the registry may use a
-            // non-normalized form (e.g. `v1.2.3`) that the parsed Version drops.
             let range = patched.parse::<Range>().ok()?;
-            let lowest = info
-                .time
-                .keys()
-                .filter(|key| key.as_str() != "created" && key.as_str() != "modified")
-                .filter(|key| !info.deprecated.contains(key.as_str()))
-                .filter_map(|key| key.parse::<Version>().ok().map(|parsed| (key, parsed)))
-                .filter(|(_, parsed)| satisfies_including_prerelease(parsed, &range))
-                .min_by(|(_, a), (_, b)| a.cmp(b))?;
-            let raw = info.time.get(lowest.0)?;
-            match parse_packument_timestamp(raw) {
+            let (key, lowest) = info.lowest_non_deprecated_version(&range)?;
+            match info.time.get(key).and_then(|raw| parse_packument_timestamp(raw)) {
                 Some(published_at) if published_at <= cutoff => None,
                 // A present-but-unparsable timestamp fails open like unknown
                 // publish times.
-                _ => Some(format!("{name}@{}", lowest.1)),
+                _ => Some(format!("{name}@{lowest}")),
             }
         })
         .collect();
@@ -458,8 +457,7 @@ pub(crate) async fn fix_with_update<Reporter: self::Reporter + 'static>(
         state.config.resolved_minimum_release_age()
     {
         let added =
-            resolve_minimum_release_age_excludes(advisories, publish_infos, minimum_release_age)
-                .await?;
+            resolve_minimum_release_age_excludes(advisories, publish_infos, minimum_release_age)?;
         if !added.is_empty() {
             write_age_excludes(settings_dir, state.config, &added)?;
         }

--- a/pnpm/crates/cli/src/cli_args/audit/render.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/render.rs
@@ -78,7 +78,12 @@ pub(crate) fn render_advisory(advisory: &AuditAdvisory) -> String {
         .push_record(vec!["Vulnerable versions".to_string(), advisory.vulnerable_versions.clone()]);
     builder.push_record(vec![
         "Patched versions".to_string(),
-        advisory.patched_versions.clone().unwrap_or_else(|| "(unknown)".to_string()),
+        advisory.patched_versions.clone().unwrap_or_else(|| {
+            match advisory.patched_versions_unpublished {
+                Some(true) => "None".to_string(),
+                _ => "(unknown)".to_string(),
+            }
+        }),
     ]);
     builder.push_record(vec!["Paths".to_string(), rendered_paths]);
     builder.push_record(vec!["More info".to_string(), advisory.url.clone()]);

--- a/pnpm/crates/cli/src/cli_args/audit/report.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/report.rs
@@ -131,6 +131,11 @@ pub(crate) struct AuditAdvisory {
     pub(crate) module_name: String,
     pub(crate) vulnerable_versions: String,
     pub(crate) patched_versions: Option<String>,
+    /// True when `patched_versions` was inferred but then dropped because no
+    /// published version satisfies it. Distinguishes "no fix shipped yet"
+    /// from "no fix could be inferred" in the report.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) patched_versions_unpublished: Option<bool>,
     pub(crate) severity: ConfigAuditLevel,
     pub(crate) cwe: String,
     pub(crate) github_advisory_id: String,
@@ -268,6 +273,7 @@ pub(crate) fn normalize_advisory(
         module_name,
         vulnerable_versions: raw.vulnerable_versions.clone(),
         patched_versions: infer_patched_versions(&raw.vulnerable_versions),
+        patched_versions_unpublished: None,
         severity,
         cwe: raw.cwe.map_or_else(String::new, Cwe::into_string),
         github_advisory_id: derive_github_advisory_id(&url),

--- a/pnpm/crates/cli/src/cli_args/audit/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/tests.rs
@@ -984,6 +984,71 @@ fn text_report_separates_advisory_table_from_summary() {
 }
 
 #[test]
+fn text_report_shows_none_when_patched_version_was_unpublished() {
+    let mut adv = advisory(1, "high issue", ConfigAuditLevel::High, "GHSA-high-3333-4444");
+    adv.patched_versions = None;
+    adv.patched_versions_unpublished = Some(true);
+    let report = AuditReport {
+        advisories: BTreeMap::from([("1".to_string(), adv)]),
+        metadata: AuditMetadata {
+            vulnerabilities: AuditVulnerabilityCounts {
+                info: 0,
+                low: 0,
+                moderate: 0,
+                high: 1,
+                critical: 0,
+            },
+            dependencies: 1,
+            dev_dependencies: 0,
+            optional_dependencies: 0,
+            total_dependencies: 1,
+        },
+    };
+
+    let output =
+        render_text_report(&report, ConfigAuditLevel::Low, 1, &AuditVulnerabilityCounts::default());
+    assert!(output.contains("Patched versions"), "row label should be present:\n{output}");
+    assert!(
+        output.contains("Patched versions    │ None"),
+        "an unpublished patch renders as None:\n{output}",
+    );
+    assert!(
+        !output.contains("(unknown)"),
+        "unpublished must not render as the inference-failed fallback:\n{output}",
+    );
+}
+
+#[test]
+fn text_report_shows_unknown_when_patched_version_cannot_be_inferred() {
+    let mut adv = advisory(1, "high issue", ConfigAuditLevel::High, "GHSA-high-3333-4444");
+    adv.patched_versions = None;
+    adv.patched_versions_unpublished = None;
+    let report = AuditReport {
+        advisories: BTreeMap::from([("1".to_string(), adv)]),
+        metadata: AuditMetadata {
+            vulnerabilities: AuditVulnerabilityCounts {
+                info: 0,
+                low: 0,
+                moderate: 0,
+                high: 1,
+                critical: 0,
+            },
+            dependencies: 1,
+            dev_dependencies: 0,
+            optional_dependencies: 0,
+            total_dependencies: 1,
+        },
+    };
+
+    let output =
+        render_text_report(&report, ConfigAuditLevel::Low, 1, &AuditVulnerabilityCounts::default());
+    assert!(
+        output.contains("Patched versions    │ (unknown)"),
+        "a non-inferable range renders as (unknown):\n{output}",
+    );
+}
+
+#[test]
 fn redact_url_userinfo_removes_credentials_from_audit_endpoint() {
     assert_eq!(
         redact_url_userinfo(
@@ -1017,6 +1082,7 @@ fn advisory(id: u64, title: &str, severity: ConfigAuditLevel, ghsa: &str) -> Aud
         module_name: "pkg".to_string(),
         vulnerable_versions: "<2.0.0".to_string(),
         patched_versions: Some(">=2.0.0".to_string()),
+        patched_versions_unpublished: None,
         severity,
         cwe: String::new(),
         github_advisory_id: normalize_ghsa_id(ghsa),
@@ -1249,17 +1315,11 @@ fn minimum_release_age_excludes_drops_versions_published_exactly_at_the_cutoff()
 #[test]
 fn minimum_release_age_excludes_keeps_versions_with_unknown_publish_times() {
     let advisories = report_of(vec![
-        fix_advisory(1, "absent", "<2.0.0", Some(">=2.0.0"), ConfigAuditLevel::High, "GHSA-a"),
         fix_advisory(2, "garbled", "<3.0.0", Some(">=3.0.0"), ConfigAuditLevel::High, "GHSA-b"),
         fix_advisory(3, "unfetchable", "<4.0.0", Some(">=4.0.0"), ConfigAuditLevel::High, "GHSA-c"),
     ])
     .advisories;
     let times = HashMap::from([
-        // The version is absent from the packument's `time` map.
-        (
-            "absent".to_string(),
-            Some(HashMap::from([("1.0.0".to_string(), "2020-01-01T00:00:00Z".to_string())])),
-        ),
         // The timestamp does not parse.
         (
             "garbled".to_string(),
@@ -1274,13 +1334,30 @@ fn minimum_release_age_excludes_keeps_versions_with_unknown_publish_times() {
 
     assert_eq!(
         excludes,
-        vec![
-            "absent@2.0.0".to_string(),
-            "garbled@3.0.0".to_string(),
-            "unfetchable@4.0.0".to_string()
-        ],
+        vec!["garbled@3.0.0".to_string(), "unfetchable@4.0.0".to_string()],
         "unknown publish times fail open so a fresh fix stays installable",
     );
+}
+
+#[test]
+fn minimum_release_age_excludes_drops_versions_missing_from_the_packument() {
+    let advisories = report_of(vec![fix_advisory(
+        1,
+        "absent",
+        "<2.0.0",
+        Some(">=2.0.0"),
+        ConfigAuditLevel::High,
+        "GHSA-a",
+    )])
+    .advisories;
+    // The packument was fetched but names no such version: the patched
+    // release was never published.
+    let times = publish_times("absent", &[("1.0.0", "2020-01-01T00:00:00Z")]);
+
+    let excludes =
+        minimum_release_age_excludes(&advisories, &times, age_cutoff()).expect("compute excludes");
+
+    assert!(excludes.is_empty(), "an unpublished patched version gets no bypass: {excludes:?}");
 }
 
 #[test]

--- a/pnpm/crates/cli/src/cli_args/audit/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/tests.rs
@@ -1361,6 +1361,31 @@ fn minimum_release_age_excludes_drops_versions_missing_from_the_packument() {
 }
 
 #[test]
+fn minimum_release_age_excludes_uses_lowest_published_version_satisfying_range() {
+    let advisories = report_of(vec![fix_advisory(
+        1,
+        "foo",
+        "<2.0.0",
+        Some(">=2.0.0"),
+        ConfigAuditLevel::High,
+        "GHSA-a",
+    )])
+    .advisories;
+    // 2.0.0 was never published; 2.0.1 is the lowest published version
+    // satisfying >=2.0.0 and it is fresh enough to need the bypass.
+    let times = publish_times("foo", &[("2.0.1", "2026-06-01T00:00:00Z")]);
+
+    let excludes =
+        minimum_release_age_excludes(&advisories, &times, age_cutoff()).expect("compute excludes");
+
+    assert_eq!(
+        excludes,
+        vec!["foo@2.0.1".to_string()],
+        "the lowest published satisfying version is used"
+    );
+}
+
+#[test]
 fn classify_for_update_routes_unparsable_ranges_to_remaining() {
     let advisories = report_of(vec![
         fix_advisory(1, "ok", "<2.0.0", Some(">=2.0.0"), ConfigAuditLevel::High, "GHSA-a"),

--- a/pnpm/crates/cli/src/cli_args/audit/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/tests.rs
@@ -1257,6 +1257,19 @@ fn publish_times(
     )])
 }
 
+fn deprecate(
+    publish_infos: &mut HashMap<String, Option<PackumentPublishInfo>>,
+    package: &str,
+    version: &str,
+) {
+    publish_infos
+        .get_mut(package)
+        .and_then(Option::as_mut)
+        .expect("publish info for the package")
+        .deprecated
+        .insert(version.parse().expect("valid deprecated version"));
+}
+
 #[test]
 fn minimum_release_age_excludes_uses_patched_minimums_and_skips_unfixable() {
     let advisories = report_of(vec![
@@ -1415,7 +1428,7 @@ fn minimum_release_age_excludes_skips_deprecated_versions() {
         "lodash-es",
         &[("4.18.0", "2026-06-01T00:00:00Z"), ("4.18.1", "2026-06-01T01:00:00Z")],
     );
-    info.get_mut("lodash-es").unwrap().as_mut().unwrap().deprecated.insert("4.18.0".to_string());
+    deprecate(&mut info, "lodash-es", "4.18.0");
 
     let excludes =
         minimum_release_age_excludes(&advisories, &info, age_cutoff()).expect("compute excludes");
@@ -1424,6 +1437,63 @@ fn minimum_release_age_excludes_skips_deprecated_versions() {
         excludes,
         vec!["lodash-es@4.18.1".to_string()],
         "the deprecated version is skipped in favor of the next non-deprecated one",
+    );
+}
+
+#[test]
+fn minimum_release_age_excludes_skips_deprecated_versions_spelled_differently() {
+    let advisories = report_of(vec![fix_advisory(
+        1,
+        "lodash-es",
+        "<4.18.0",
+        Some(">=4.18.0"),
+        ConfigAuditLevel::High,
+        "GHSA-a",
+    )])
+    .advisories;
+    // The `time` map spells 4.18.0 with a leading `v` while `versions` — the
+    // source of the deprecation set — does not.
+    let mut info = publish_times(
+        "lodash-es",
+        &[("v4.18.0", "2026-06-01T00:00:00Z"), ("4.18.1", "2026-06-01T01:00:00Z")],
+    );
+    deprecate(&mut info, "lodash-es", "4.18.0");
+
+    let excludes =
+        minimum_release_age_excludes(&advisories, &info, age_cutoff()).expect("compute excludes");
+
+    assert_eq!(
+        excludes,
+        vec!["lodash-es@4.18.1".to_string()],
+        "deprecation is matched on the parsed version, not the raw packument key",
+    );
+}
+
+#[test]
+fn minimum_release_age_excludes_prefers_a_stable_release_over_a_lower_prerelease() {
+    let advisories = report_of(vec![fix_advisory(
+        1,
+        "foo",
+        "<=1.9.9",
+        Some(">=1.9.10"),
+        ConfigAuditLevel::High,
+        "GHSA-a",
+    )])
+    .advisories;
+    // 2.0.0-beta.1 sorts below 2.0.0 but is not a release users should be
+    // pointed at as the fix.
+    let times = publish_times(
+        "foo",
+        &[("2.0.0-beta.1", "2026-06-01T00:00:00Z"), ("2.0.0", "2026-06-01T01:00:00Z")],
+    );
+
+    let excludes =
+        minimum_release_age_excludes(&advisories, &times, age_cutoff()).expect("compute excludes");
+
+    assert_eq!(
+        excludes,
+        vec!["foo@2.0.0".to_string()],
+        "the stable release outranks the lower-sorting prerelease",
     );
 }
 

--- a/pnpm/crates/cli/src/cli_args/audit/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/tests.rs
@@ -2,9 +2,9 @@ use super::{
     BTreeMap, Config, ConfigAuditLevel, HashMap, MAX_PATHS_PER_FINDING, PackageVersionGuard,
     PackageVersionGuardDecision, Range, SnapshotDepRef, filter_ignored_advisories,
     fix::{
-        InstalledPackages, VulnerabilityGuard, classify_for_update, create_overrides,
-        filter_advisories_for_fix, format_fix_with_update_output, minimum_release_age_excludes,
-        report_fixed_remaining,
+        InstalledPackages, PackumentPublishInfo, VulnerabilityGuard, classify_for_update,
+        create_overrides, filter_advisories_for_fix, format_fix_with_update_output,
+        minimum_release_age_excludes, report_fixed_remaining,
     },
     paths::{AuditPathIndex, PathInfo, build_audit_path_index},
     render::{render_json_report, render_text_report},
@@ -1244,12 +1244,16 @@ fn age_cutoff() -> DateTime<Utc> {
 fn publish_times(
     package: &str,
     entries: &[(&str, &str)],
-) -> HashMap<String, Option<HashMap<String, String>>> {
+) -> HashMap<String, Option<PackumentPublishInfo>> {
     HashMap::from([(
         package.to_string(),
-        Some(
-            entries.iter().map(|(version, time)| (version.to_string(), time.to_string())).collect(),
-        ),
+        Some(PackumentPublishInfo {
+            time: entries
+                .iter()
+                .map(|(version, time)| (version.to_string(), time.to_string()))
+                .collect(),
+            deprecated: HashSet::new(),
+        }),
     )])
 }
 
@@ -1279,11 +1283,17 @@ fn minimum_release_age_excludes_drops_versions_older_than_the_cutoff() {
     let times = HashMap::from([
         (
             "old".to_string(),
-            Some(HashMap::from([("2.0.0".to_string(), "2020-01-01T00:00:00Z".to_string())])),
+            Some(PackumentPublishInfo {
+                time: HashMap::from([("2.0.0".to_string(), "2020-01-01T00:00:00Z".to_string())]),
+                deprecated: HashSet::new(),
+            }),
         ),
         (
             "fresh".to_string(),
-            Some(HashMap::from([("3.0.0".to_string(), "2026-06-01T00:00:00Z".to_string())])),
+            Some(PackumentPublishInfo {
+                time: HashMap::from([("3.0.0".to_string(), "2026-06-01T00:00:00Z".to_string())]),
+                deprecated: HashSet::new(),
+            }),
         ),
     ]);
 
@@ -1323,7 +1333,10 @@ fn minimum_release_age_excludes_keeps_versions_with_unknown_publish_times() {
         // The timestamp does not parse.
         (
             "garbled".to_string(),
-            Some(HashMap::from([("3.0.0".to_string(), "not-a-date".to_string())])),
+            Some(PackumentPublishInfo {
+                time: HashMap::from([("3.0.0".to_string(), "not-a-date".to_string())]),
+                deprecated: HashSet::new(),
+            }),
         ),
         // The fetch failed outright.
         ("unfetchable".to_string(), None),
@@ -1382,6 +1395,35 @@ fn minimum_release_age_excludes_uses_lowest_published_version_satisfying_range()
         excludes,
         vec!["foo@2.0.1".to_string()],
         "the lowest published satisfying version is used",
+    );
+}
+
+#[test]
+fn minimum_release_age_excludes_skips_deprecated_versions() {
+    let advisories = report_of(vec![fix_advisory(
+        1,
+        "lodash-es",
+        "<4.18.0",
+        Some(">=4.18.0"),
+        ConfigAuditLevel::High,
+        "GHSA-a",
+    )])
+    .advisories;
+    // 4.18.0 is deprecated; 4.18.1 is the lowest non-deprecated published
+    // version satisfying >=4.18.0.
+    let mut info = publish_times(
+        "lodash-es",
+        &[("4.18.0", "2026-06-01T00:00:00Z"), ("4.18.1", "2026-06-01T01:00:00Z")],
+    );
+    info.get_mut("lodash-es").unwrap().as_mut().unwrap().deprecated.insert("4.18.0".to_string());
+
+    let excludes =
+        minimum_release_age_excludes(&advisories, &info, age_cutoff()).expect("compute excludes");
+
+    assert_eq!(
+        excludes,
+        vec!["lodash-es@4.18.1".to_string()],
+        "the deprecated version is skipped in favor of the next non-deprecated one",
     );
 }
 

--- a/pnpm/crates/cli/src/cli_args/audit/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/tests.rs
@@ -1381,7 +1381,7 @@ fn minimum_release_age_excludes_uses_lowest_published_version_satisfying_range()
     assert_eq!(
         excludes,
         vec!["foo@2.0.1".to_string()],
-        "the lowest published satisfying version is used"
+        "the lowest published satisfying version is used",
     );
 }
 

--- a/pnpm/crates/cli/tests/suite/audit.rs
+++ b/pnpm/crates/cli/tests/suite/audit.rs
@@ -422,6 +422,71 @@ fn audit_level_info_includes_info_advisories() {
 }
 
 #[test]
+fn audit_reports_the_lowest_non_deprecated_published_patch() {
+    let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
+    let mut registry = mockito::Server::new();
+    let mock = audit_mock(
+        &mut registry,
+        &advisory_response("vulnerable", 123, "high", "<2.0.0", "test", "GHSA-test-1111-2222"),
+    )
+    .create();
+    // 2.0.0 is deprecated, so the inferred >=2.0.0 patch resolves to 2.0.1.
+    let packument_mock = registry
+        .mock("GET", "/vulnerable")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"time":{"2.0.0":"2020-01-01T00:00:00.000Z","2.0.1":"2020-02-01T00:00:00.000Z"},"versions":{"2.0.0":{"deprecated":"do not use"},"2.0.1":{}}}"#,
+        )
+        .create();
+    write_audit_workspace(&workspace, &registry.url(), "");
+
+    let output = pacquet.arg("audit").output().expect("run pacquet audit");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = stdout(&output);
+    assert!(
+        stdout.contains(">=2.0.1"),
+        "the report should name the lowest non-deprecated published patch:\n{stdout}",
+    );
+    mock.assert();
+    packument_mock.assert();
+}
+
+#[test]
+fn audit_reports_no_patched_version_when_none_was_published() {
+    let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
+    let mut registry = mockito::Server::new();
+    let mock = audit_mock(
+        &mut registry,
+        &advisory_response("vulnerable", 123, "high", "<2.0.0", "test", "GHSA-test-1111-2222"),
+    )
+    .create();
+    let packument_mock = registry
+        .mock("GET", "/vulnerable")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"time":{"1.0.0":"2020-01-01T00:00:00.000Z"}}"#)
+        .create();
+    write_audit_workspace(&workspace, &registry.url(), "");
+
+    let output = pacquet.arg("audit").output().expect("run pacquet audit");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = stdout(&output);
+    assert!(
+        stdout.contains("Patched versions") && stdout.contains("None"),
+        "an unpublished patch renders as None:\n{stdout}",
+    );
+    assert!(
+        !stdout.contains("(unknown)"),
+        "unpublished must not render as the inference-failed fallback:\n{stdout}",
+    );
+    mock.assert();
+    packument_mock.assert();
+}
+
+#[test]
 fn audit_defaults_to_low_and_ignores_info_for_exit_code() {
     let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
     let mut registry = mockito::Server::new();

--- a/pnpm/crates/cli/tests/suite/audit.rs
+++ b/pnpm/crates/cli/tests/suite/audit.rs
@@ -729,9 +729,11 @@ fn audit_fix_override_skips_age_exclude_when_patched_version_is_old() {
     )
     .create();
     // The patched version predates the cutoff, so the age gate would not
-    // block it and no exclusion entry is needed.
+    // block it and no exclusion entry is needed. The packument is fetched
+    // once: validation and the age-gate check share the same publish-time map.
     let packument_mock = registry
         .mock("GET", "/vulnerable")
+        .expect(1)
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(r#"{"time":{"2.0.0":"2020-01-01T00:00:00.000Z"}}"#)
@@ -763,10 +765,49 @@ fn audit_fix_override_skips_age_exclude_when_patched_version_is_old() {
 }
 
 #[test]
+fn audit_fix_override_makes_no_changes_when_patched_version_is_unpublished() {
+    let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
+    let mut registry = mockito::Server::new();
+    let mock = audit_mock(
+        &mut registry,
+        &advisory_response("vulnerable", 123, "high", "<2.0.0", "test", "GHSA-test-1111-2222"),
+    )
+    .create();
+    // The packument names no 2.0.0: the patched release was never published,
+    // so the inferred range is dropped and nothing is written.
+    let packument_mock = registry
+        .mock("GET", "/vulnerable")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"time":{"1.0.0":"2020-01-01T00:00:00.000Z"}}"#)
+        .create();
+    write_audit_workspace(&workspace, &registry.url(), "minimumReleaseAge: 1440\n");
+
+    let output = pacquet.arg("audit").arg("--fix").output().expect("run pacquet audit --fix");
+
+    assert_success(&output);
+    assert!(
+        stdout(&output).contains("No fixes were made"),
+        "an unpublished patch has no fix to apply:\n{}",
+        stdout(&output),
+    );
+    let manifest =
+        fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("read workspace manifest");
+    assert!(!manifest.contains("overrides:"), "manifest should hold no override:\n{manifest}");
+    assert!(
+        !manifest.contains("minimumReleaseAgeExclude:"),
+        "manifest should hold no exclusion:\n{manifest}",
+    );
+    mock.assert();
+    packument_mock.assert();
+}
+
+#[test]
 fn audit_fix_override_writes_age_exclude_when_patched_version_is_within_the_window() {
     let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
     let mut registry = mockito::Server::new();
-    // Two advisories on one package: the packument is fetched once.
+    // Two advisories on one package: the packument is fetched once and shared
+    // between validation and the age-gate check.
     let mock = audit_mock(
         &mut registry,
         r#"{
@@ -1013,10 +1054,10 @@ fn audit_fix_update_moves_to_a_non_vulnerable_version() {
 }
 
 /// `--fix update` with `minimumReleaseAge`: the inferred patched version
-/// (3.0.0) has no entry in the packument's `time` map, so its publish time is
-/// unknown and the exclusion fails open — it must be written and reported.
+/// (3.0.0) has no entry in the packument's `time` map because it was never
+/// published, so no exclusion entry is written for it.
 #[test]
-fn audit_fix_update_writes_age_exclude_when_patched_publish_time_is_unknown() {
+fn audit_fix_update_skips_age_exclude_when_patched_version_is_unpublished() {
     const PKG: &str = "@pnpm.e2e/audit-multi-version";
     let CommandTempCwd { workspace, root, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();
@@ -1068,15 +1109,14 @@ fn audit_fix_update_writes_age_exclude_when_patched_publish_time_is_unknown() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("vulnerability was fixed"), "stdout should report the fix:\n{stdout}");
     assert!(
-        stdout.contains("entries were added to minimumReleaseAgeExclude"),
-        "stdout should report the exclusion:\n{stdout}",
+        !stdout.contains("entries were added to minimumReleaseAgeExclude"),
+        "no exclusion should be reported:\n{stdout}",
     );
     let manifest =
         fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("read workspace manifest");
     assert!(
-        manifest.contains("minimumReleaseAgeExclude:")
-            && manifest.contains("@pnpm.e2e/audit-multi-version@3.0.0"),
-        "manifest should hold the patched-version exclusion:\n{manifest}",
+        !manifest.contains("minimumReleaseAgeExclude:"),
+        "manifest should hold no exclusion:\n{manifest}",
     );
     mock.assert();
     drop((root, npmrc_info));

--- a/pnpm11/deps/compliance/audit/src/index.ts
+++ b/pnpm11/deps/compliance/audit/src/index.ts
@@ -164,7 +164,7 @@ function isBulkResponseShape (body: unknown): body is BulkAdvisoriesResponse {
   )
 }
 
-function satisfiesSafe (version: string, range: string): boolean {
+export function satisfiesSafe (version: string, range: string): boolean {
   try {
     return semver.satisfies(version, range, { includePrerelease: true, loose: true })
   } catch {

--- a/pnpm11/deps/compliance/audit/src/types.ts
+++ b/pnpm11/deps/compliance/audit/src/types.ts
@@ -34,7 +34,7 @@ export interface AuditAdvisory {
   vulnerable_versions: string
   // Inferred from vulnerable_versions. Undefined when inference fails —
   // `audit --fix` and `--ignore-unfixable` treat that as "no fix available".
-  patched_versions?: string
+  patched_versions?: string | null
   // True when `patched_versions` was inferred but then dropped because no
   // published version satisfies it. Distinguishes "no fix shipped yet" from
   // "no fix could be inferred" in the report.

--- a/pnpm11/deps/compliance/audit/src/types.ts
+++ b/pnpm11/deps/compliance/audit/src/types.ts
@@ -35,6 +35,10 @@ export interface AuditAdvisory {
   // Inferred from vulnerable_versions. Undefined when inference fails —
   // `audit --fix` and `--ignore-unfixable` treat that as "no fix available".
   patched_versions?: string
+  // True when `patched_versions` was inferred but then dropped because no
+  // published version satisfies it. Distinguishes "no fix shipped yet" from
+  // "no fix could be inferred" in the report.
+  patched_versions_unpublished?: boolean
   severity: AuditLevelString
   cwe: string
   github_advisory_id: string

--- a/pnpm11/deps/compliance/audit/src/types.ts
+++ b/pnpm11/deps/compliance/audit/src/types.ts
@@ -32,8 +32,10 @@ export interface AuditAdvisory {
   title: string
   module_name: string
   vulnerable_versions: string
-  // Inferred from vulnerable_versions. Undefined when inference fails —
-  // `audit --fix` and `--ignore-unfixable` treat that as "no fix available".
+  // Inferred from vulnerable_versions, then narrowed to the version the
+  // registry actually publishes. Undefined when inference fails and null when
+  // no published version satisfies the inferred range — `audit --fix` and
+  // `--ignore-unfixable` treat both as "no fix available".
   patched_versions?: string | null
   // True when `patched_versions` was inferred but then dropped because no
   // published version satisfies it. Distinguishes "no fix shipped yet" from

--- a/pnpm11/deps/compliance/commands/src/audit/audit.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/audit.ts
@@ -17,6 +17,7 @@ import { fix } from './fix.js'
 import { fixWithUpdate, type FixWithUpdateResult } from './fixWithUpdate.js'
 import { getAuditFixChoices } from './getAuditFixChoices.js'
 import { ignore } from './ignore.js'
+import { createPublishTimesFetcher, dropUnsatisfiablePatchedVersions } from './publishTimes.js'
 import { auditSignatures } from './signatures.js'
 
 const AUDIT_LEVEL_NUMBER = {
@@ -157,6 +158,8 @@ export function help (): string {
   })
 }
 
+export type PublishTimesFetcher = (pkgName: string) => Promise<Record<string, string> | undefined>
+
 export type AuditOptions = Pick<UniversalOptions, 'dir'> & {
   fix?: boolean | 'override' | 'update'
   ignoreRegistryErrors?: boolean
@@ -166,6 +169,13 @@ export type AuditOptions = Pick<UniversalOptions, 'dir'> & {
   registriesByScope: RegistriesByScope
   ignore?: string[]
   ignoreUnfixable?: boolean
+  /**
+   * Memoized packument publish-time lookup shared between patched-version
+   * validation and the age-gate exclusion flow so each package is fetched at
+   * most once per `pnpm audit` run. When unset, each consumer creates its own
+   * fetcher.
+   */
+  getPublishTimes?: PublishTimesFetcher
 } & Pick<Config, 'auditConfig'
 | 'auditLevel'
 | 'minimumReleaseAge'
@@ -244,6 +254,12 @@ export async function handler (opts: AuditOptions, params: string[] = []): Promi
 
     throw err
   }
+  // The inferred patched range is syntactic: verify a published version
+  // actually satisfies it before the report and any fix flow can claim one.
+  // One fetcher is shared with the fix flows below so each affected package
+  // is requested at most once.
+  const getPublishTimes = createPublishTimesFetcher(opts)
+  await dropUnsatisfiablePatchedVersions(auditReport.advisories, getPublishTimes)
   let fixMethod: 'update' | 'override' | undefined
   if (opts.fix === 'update' || opts.fix === 'override') {
     fixMethod = opts.fix
@@ -266,7 +282,7 @@ export async function handler (opts: AuditOptions, params: string[] = []): Promi
       filteredAuditReport = await interactiveAuditFix(filteredAuditReport)
     }
     if (fixMethod === 'update') {
-      const result = await fixWithUpdate(filteredAuditReport, { ...opts, include })
+      const result = await fixWithUpdate(filteredAuditReport, { ...opts, getPublishTimes, include })
       let output = formatFixWithUpdateOutput(result, filteredAuditReport)
       if (result.addedAgeExcludes.length > 0) {
         output += `\n${result.addedAgeExcludes.length} entries were added to minimumReleaseAgeExclude to allow installing the patched versions:\n${result.addedAgeExcludes.join('\n')}\n`
@@ -276,7 +292,7 @@ export async function handler (opts: AuditOptions, params: string[] = []): Promi
         output,
       }
     }
-    const { vulnOverrides, addedAgeExcludes } = await fix(filteredAuditReport, opts)
+    const { vulnOverrides, addedAgeExcludes } = await fix(filteredAuditReport, { ...opts, getPublishTimes })
     if (Object.values(vulnOverrides).length === 0) {
       return {
         exitCode: 0,
@@ -361,7 +377,7 @@ ${newIgnores.join('\n')}`,
       [AUDIT_COLOR[advisory.severity](advisory.severity), chalk.bold(advisory.title)],
       ['Package', advisory.module_name],
       ['Vulnerable versions', advisory.vulnerable_versions],
-      ['Patched versions', advisory.patched_versions ?? '(unknown)'],
+      ['Patched versions', advisory.patched_versions ?? (advisory.patched_versions_unpublished === true ? 'None' : '(unknown)')],
       [
         'Paths',
         (paths.length > MAX_PATHS_COUNT

--- a/pnpm11/deps/compliance/commands/src/audit/audit.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/audit.ts
@@ -17,7 +17,7 @@ import { fix } from './fix.js'
 import { fixWithUpdate, type FixWithUpdateResult } from './fixWithUpdate.js'
 import { getAuditFixChoices } from './getAuditFixChoices.js'
 import { ignore } from './ignore.js'
-import { createPublishTimesFetcher, correctInferredPatchedVersions, type PublishTimesFetcher } from './publishTimes.js'
+import { correctInferredPatchedVersions, createPublishTimesFetcher, type PublishTimesFetcher } from './publishTimes.js'
 import { auditSignatures } from './signatures.js'
 
 const AUDIT_LEVEL_NUMBER = {

--- a/pnpm11/deps/compliance/commands/src/audit/audit.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/audit.ts
@@ -17,7 +17,7 @@ import { fix } from './fix.js'
 import { fixWithUpdate, type FixWithUpdateResult } from './fixWithUpdate.js'
 import { getAuditFixChoices } from './getAuditFixChoices.js'
 import { ignore } from './ignore.js'
-import { createPublishTimesFetcher, dropUnsatisfiablePatchedVersions } from './publishTimes.js'
+import { createPublishTimesFetcher, correctInferredPatchedVersions, type PublishTimesFetcher } from './publishTimes.js'
 import { auditSignatures } from './signatures.js'
 
 const AUDIT_LEVEL_NUMBER = {
@@ -158,7 +158,7 @@ export function help (): string {
   })
 }
 
-export type PublishTimesFetcher = (pkgName: string) => Promise<Record<string, string> | undefined>
+export type { PublishTimesFetcher } from './publishTimes.js'
 
 export type AuditOptions = Pick<UniversalOptions, 'dir'> & {
   fix?: boolean | 'override' | 'update'
@@ -259,7 +259,7 @@ export async function handler (opts: AuditOptions, params: string[] = []): Promi
   // One fetcher is shared with the fix flows below so each affected package
   // is requested at most once.
   const getPublishTimes = createPublishTimesFetcher(opts)
-  await dropUnsatisfiablePatchedVersions(auditReport.advisories, getPublishTimes)
+  await correctInferredPatchedVersions(auditReport.advisories, getPublishTimes)
   let fixMethod: 'update' | 'override' | undefined
   if (opts.fix === 'update' || opts.fix === 'override') {
     fixMethod = opts.fix

--- a/pnpm11/deps/compliance/commands/src/audit/fix.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/fix.ts
@@ -117,11 +117,22 @@ export async function createMinimumReleaseAgeExcludes (
     if (!lowest) return undefined
     const lowestSpec = `${advisory.module_name}@${lowest.parsed.version}`
     const publishTime: unknown = times[lowest.key]
-    // The time map comes from an untrusted registry response: only a string
-    // can carry a real timestamp; anything else is treated as unknown.
+    // The time map comes from an untrusted registry response: only a strict
+    // ISO 8601 timestamp counts; anything else (including bare numbers and
+    // non-ISO strings the Date constructor would accept) is treated as unknown.
     if (typeof publishTime !== 'string') return lowestSpec
-    const publishedAt = new Date(publishTime).getTime()
-    return Number.isNaN(publishedAt) || publishedAt > cutoff ? lowestSpec : undefined
+    const publishedAt = parseIsoTimestamp(publishTime)
+    return publishedAt == null || publishedAt > cutoff ? lowestSpec : undefined
   }))
   return mergePackageVersionSpecs(specs.filter((spec): spec is string => spec != null))
+}
+
+// RFC 3339 / ISO 8601 date-time, e.g. 2020-01-01T00:00:00.000Z.
+// Rejects bare numbers and other non-ISO strings that `new Date()` would parse.
+const ISO_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/
+
+function parseIsoTimestamp (input: string): number | undefined {
+  if (!ISO_TIMESTAMP_RE.test(input)) return undefined
+  const ms = new Date(input).getTime()
+  return Number.isNaN(ms) ? undefined : ms
 }

--- a/pnpm11/deps/compliance/commands/src/audit/fix.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/fix.ts
@@ -5,7 +5,7 @@ import { sortDirectKeys } from '@pnpm/object.key-sorting'
 import semver from 'semver'
 
 import type { AuditOptions } from './audit.js'
-import { createPublishTimesFetcher, type PublishTimesFetcher } from './publishTimes.js'
+import { createPublishTimesFetcher, lowestNonDeprecatedVersion, type PublishTimesFetcher } from './publishTimes.js'
 
 export interface FixResult {
   vulnOverrides: Record<string, string>
@@ -77,16 +77,12 @@ export interface CreateMinimumReleaseAgeExcludesOptions {
 
 /**
  * The `minimumReleaseAgeExclude` entries needed to keep the age gate from
- * blocking the patched versions: one entry per fixable advisory whose minimum
- * published version satisfying the patched range is younger than the cutoff.
- * The theoretical range minimum may never have been published (a skipped or
- * yanked release), so the lowest published version that satisfies the range
- * is used instead — that is the version the override actually resolves to.
- * A version published at or before the cutoff doesn't need a bypass, and a
- * version whose publish time is unknown keeps its entry so a genuinely fresh
- * fix stays installable. A version absent from a successfully fetched
- * packument is not available — whether it was never published, skipped, or
- * yanked — so it gets no entry.
+ * blocking the patched versions: one entry per fixable advisory whose fix —
+ * the version {@link lowestNonDeprecatedVersion} resolves the patched range
+ * to — is younger than the cutoff. A version published at or before the
+ * cutoff doesn't need a bypass, and a version whose publish time is unknown
+ * keeps its entry so a genuinely fresh fix stays installable. An advisory the
+ * packument offers no fix for gets no entry.
  */
 export async function createMinimumReleaseAgeExcludes (
   advisories: AuditAdvisory[],
@@ -98,23 +94,11 @@ export async function createMinimumReleaseAgeExcludes (
     if (!patchedVersions) return undefined
     const minVersion = semver.minVersion(patchedVersions)
     if (!minVersion) return undefined
-    const spec = `${advisory.module_name}@${minVersion.version}`
     const publishInfo = await opts.getPublishTimes(advisory.module_name)
-    if (publishInfo == null) return spec
-    // The theoretical range minimum may not exist on the registry; use the
-    // lowest non-deprecated published version that satisfies the range, which
-    // is what the override actually resolves to. The original key is retained
-    // because the registry may use a non-normalized form (e.g. `v1.2.3`) that
-    // the parsed SemVer drops.
-    const published = Object.keys(publishInfo.time)
-      .filter((key) => key !== 'created' && key !== 'modified' && !publishInfo.deprecated.has(key))
-      .map((key) => ({ key, parsed: semver.parse(key, { loose: true }) }))
-      .filter((entry): entry is { key: string, parsed: semver.SemVer } => entry.parsed != null)
-      .filter((entry) => semver.satisfies(entry.parsed, patchedVersions))
-      .sort((a, b) => semver.compare(a.parsed, b.parsed))
-    const lowest = published[0]
-    if (!lowest) return undefined
-    const lowestSpec = `${advisory.module_name}@${lowest.parsed.version}`
+    if (publishInfo == null) return `${advisory.module_name}@${minVersion.version}`
+    const lowest = lowestNonDeprecatedVersion(publishInfo, patchedVersions)
+    if (lowest == null) return undefined
+    const lowestSpec = `${advisory.module_name}@${lowest.version}`
     const publishTime: unknown = publishInfo.time[lowest.key]
     // The time map comes from an untrusted registry response: only a strict
     // ISO 8601 timestamp counts; anything else (including bare numbers and

--- a/pnpm11/deps/compliance/commands/src/audit/fix.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/fix.ts
@@ -5,7 +5,7 @@ import { sortDirectKeys } from '@pnpm/object.key-sorting'
 import semver from 'semver'
 
 import type { AuditOptions } from './audit.js'
-import { createPublishTimesFetcher } from './publishTimes.js'
+import { createPublishTimesFetcher, type PublishTimesFetcher } from './publishTimes.js'
 
 export interface FixResult {
   vulnOverrides: Record<string, string>
@@ -64,11 +64,10 @@ export function caretRangeForPatched (patchedRange: string): string {
 
 export interface CreateMinimumReleaseAgeExcludesOptions {
   /**
-   * Publish-time lookup (the packument's `time` map) per package name.
-   * `undefined` means the publish times are unknown; a resolved map that
-   * lacks a version means that version was never published.
+   * Publish-time lookup (the packument's `time` map plus deprecated version
+   * set) per package name. `undefined` means the publish info is unknown.
    */
-  getPublishTimes: (pkgName: string) => Promise<Record<string, string> | undefined>
+  getPublishTimes: PublishTimesFetcher
   /**
    * In minutes, same unit as the `minimumReleaseAge` setting.
    */
@@ -100,15 +99,15 @@ export async function createMinimumReleaseAgeExcludes (
     const minVersion = semver.minVersion(patchedVersions)
     if (!minVersion) return undefined
     const spec = `${advisory.module_name}@${minVersion.version}`
-    const times = await opts.getPublishTimes(advisory.module_name)
-    if (times == null) return spec
+    const publishInfo = await opts.getPublishTimes(advisory.module_name)
+    if (publishInfo == null) return spec
     // The theoretical range minimum may not exist on the registry; use the
-    // lowest published version that satisfies the range, which is what the
-    // override actually resolves to. The original key is retained because
-    // the registry may use a non-normalized form (e.g. `v1.2.3`) that the
-    // parsed SemVer drops.
-    const published = Object.keys(times)
-      .filter((key) => key !== 'created' && key !== 'modified')
+    // lowest non-deprecated published version that satisfies the range, which
+    // is what the override actually resolves to. The original key is retained
+    // because the registry may use a non-normalized form (e.g. `v1.2.3`) that
+    // the parsed SemVer drops.
+    const published = Object.keys(publishInfo.time)
+      .filter((key) => key !== 'created' && key !== 'modified' && !publishInfo.deprecated.has(key))
       .map((key) => ({ key, parsed: semver.parse(key, { loose: true }) }))
       .filter((entry): entry is { key: string, parsed: semver.SemVer } => entry.parsed != null)
       .filter((entry) => semver.satisfies(entry.parsed, patchedVersions))
@@ -116,7 +115,7 @@ export async function createMinimumReleaseAgeExcludes (
     const lowest = published[0]
     if (!lowest) return undefined
     const lowestSpec = `${advisory.module_name}@${lowest.parsed.version}`
-    const publishTime: unknown = times[lowest.key]
+    const publishTime: unknown = publishInfo.time[lowest.key]
     // The time map comes from an untrusted registry response: only a strict
     // ISO 8601 timestamp counts; anything else (including bare numbers and
     // non-ISO strings the Date constructor would accept) is treated as unknown.

--- a/pnpm11/deps/compliance/commands/src/audit/fix.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/fix.ts
@@ -18,7 +18,7 @@ export async function fix (auditReport: AuditReport, opts: AuditOptions): Promis
   if (Object.values(vulnOverrides).length === 0) return { vulnOverrides, addedAgeExcludes: [] }
   const addedAgeExcludes = opts.minimumReleaseAge
     ? await createMinimumReleaseAgeExcludes(fixableAdvisories, {
-      getPublishTimes: createPublishTimesFetcher(opts),
+      getPublishTimes: opts.getPublishTimes ?? createPublishTimesFetcher(opts),
       minimumReleaseAge: opts.minimumReleaseAge,
     })
     : []
@@ -65,7 +65,8 @@ export function caretRangeForPatched (patchedRange: string): string {
 export interface CreateMinimumReleaseAgeExcludesOptions {
   /**
    * Publish-time lookup (the packument's `time` map) per package name.
-   * `undefined` means the publish times are unknown.
+   * `undefined` means the publish times are unknown; a resolved map that
+   * lacks a version means that version was never published.
    */
   getPublishTimes: (pkgName: string) => Promise<Record<string, string> | undefined>
   /**
@@ -81,6 +82,8 @@ export interface CreateMinimumReleaseAgeExcludesOptions {
  * patched version is younger than the cutoff. A version published at or
  * before the cutoff doesn't need a bypass, and a version whose publish time
  * is unknown keeps its entry so a genuinely fresh fix stays installable.
+ * A version missing from a successfully fetched packument was never
+ * published — no fix has shipped — so it gets no entry.
  */
 export async function createMinimumReleaseAgeExcludes (
   advisories: AuditAdvisory[],
@@ -93,7 +96,10 @@ export async function createMinimumReleaseAgeExcludes (
     const minVersion = semver.minVersion(patchedVersions)
     if (!minVersion) return undefined
     const spec = `${advisory.module_name}@${minVersion.version}`
-    const publishTime: unknown = (await opts.getPublishTimes(advisory.module_name))?.[minVersion.version]
+    const times = await opts.getPublishTimes(advisory.module_name)
+    if (times == null) return spec
+    if (!Object.hasOwn(times, minVersion.version)) return undefined
+    const publishTime: unknown = times[minVersion.version]
     // The time map comes from an untrusted registry response: only a string
     // can carry a real timestamp; anything else is treated as unknown.
     if (typeof publishTime !== 'string') return spec

--- a/pnpm11/deps/compliance/commands/src/audit/fix.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/fix.ts
@@ -85,8 +85,9 @@ export interface CreateMinimumReleaseAgeExcludesOptions {
  * is used instead — that is the version the override actually resolves to.
  * A version published at or before the cutoff doesn't need a bypass, and a
  * version whose publish time is unknown keeps its entry so a genuinely fresh
- * fix stays installable. A version missing from a successfully fetched
- * packument was never published — no fix has shipped — so it gets no entry.
+ * fix stays installable. A version absent from a successfully fetched
+ * packument is not available — whether it was never published, skipped, or
+ * yanked — so it gets no entry.
  */
 export async function createMinimumReleaseAgeExcludes (
   advisories: AuditAdvisory[],
@@ -103,17 +104,19 @@ export async function createMinimumReleaseAgeExcludes (
     if (times == null) return spec
     // The theoretical range minimum may not exist on the registry; use the
     // lowest published version that satisfies the range, which is what the
-    // override actually resolves to.
+    // override actually resolves to. The original key is retained because
+    // the registry may use a non-normalized form (e.g. `v1.2.3`) that the
+    // parsed SemVer drops.
     const published = Object.keys(times)
       .filter((key) => key !== 'created' && key !== 'modified')
-      .map((key) => semver.parse(key, { loose: true }))
-      .filter((v): v is semver.SemVer => v != null)
-      .filter((v) => semver.satisfies(v, patchedVersions))
-      .sort(semver.compare)
+      .map((key) => ({ key, parsed: semver.parse(key, { loose: true }) }))
+      .filter((entry): entry is { key: string, parsed: semver.SemVer } => entry.parsed != null)
+      .filter((entry) => semver.satisfies(entry.parsed, patchedVersions))
+      .sort((a, b) => semver.compare(a.parsed, b.parsed))
     const lowest = published[0]
     if (!lowest) return undefined
-    const lowestSpec = `${advisory.module_name}@${lowest.version}`
-    const publishTime: unknown = times[lowest.version]
+    const lowestSpec = `${advisory.module_name}@${lowest.parsed.version}`
+    const publishTime: unknown = times[lowest.key]
     // The time map comes from an untrusted registry response: only a string
     // can carry a real timestamp; anything else is treated as unknown.
     if (typeof publishTime !== 'string') return lowestSpec

--- a/pnpm11/deps/compliance/commands/src/audit/fix.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/fix.ts
@@ -79,11 +79,14 @@ export interface CreateMinimumReleaseAgeExcludesOptions {
 /**
  * The `minimumReleaseAgeExclude` entries needed to keep the age gate from
  * blocking the patched versions: one entry per fixable advisory whose minimum
- * patched version is younger than the cutoff. A version published at or
- * before the cutoff doesn't need a bypass, and a version whose publish time
- * is unknown keeps its entry so a genuinely fresh fix stays installable.
- * A version missing from a successfully fetched packument was never
- * published — no fix has shipped — so it gets no entry.
+ * published version satisfying the patched range is younger than the cutoff.
+ * The theoretical range minimum may never have been published (a skipped or
+ * yanked release), so the lowest published version that satisfies the range
+ * is used instead — that is the version the override actually resolves to.
+ * A version published at or before the cutoff doesn't need a bypass, and a
+ * version whose publish time is unknown keeps its entry so a genuinely fresh
+ * fix stays installable. A version missing from a successfully fetched
+ * packument was never published — no fix has shipped — so it gets no entry.
  */
 export async function createMinimumReleaseAgeExcludes (
   advisories: AuditAdvisory[],
@@ -98,13 +101,24 @@ export async function createMinimumReleaseAgeExcludes (
     const spec = `${advisory.module_name}@${minVersion.version}`
     const times = await opts.getPublishTimes(advisory.module_name)
     if (times == null) return spec
-    if (!Object.hasOwn(times, minVersion.version)) return undefined
-    const publishTime: unknown = times[minVersion.version]
+    // The theoretical range minimum may not exist on the registry; use the
+    // lowest published version that satisfies the range, which is what the
+    // override actually resolves to.
+    const published = Object.keys(times)
+      .filter((key) => key !== 'created' && key !== 'modified')
+      .map((key) => semver.parse(key, { loose: true }))
+      .filter((v): v is semver.SemVer => v != null)
+      .filter((v) => semver.satisfies(v, patchedVersions))
+      .sort(semver.compare)
+    const lowest = published[0]
+    if (!lowest) return undefined
+    const lowestSpec = `${advisory.module_name}@${lowest.version}`
+    const publishTime: unknown = times[lowest.version]
     // The time map comes from an untrusted registry response: only a string
     // can carry a real timestamp; anything else is treated as unknown.
-    if (typeof publishTime !== 'string') return spec
+    if (typeof publishTime !== 'string') return lowestSpec
     const publishedAt = new Date(publishTime).getTime()
-    return Number.isNaN(publishedAt) || publishedAt > cutoff ? spec : undefined
+    return Number.isNaN(publishedAt) || publishedAt > cutoff ? lowestSpec : undefined
   }))
   return mergePackageVersionSpecs(specs.filter((spec): spec is string => spec != null))
 }

--- a/pnpm11/deps/compliance/commands/src/audit/fixWithUpdate.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/fixWithUpdate.ts
@@ -95,7 +95,7 @@ export async function fixWithUpdate (auditReport: AuditReport, opts: FixWithUpda
   // can install them even when minimumReleaseAge would otherwise block them.
   const addedAgeExcludes = opts.minimumReleaseAge
     ? await createMinimumReleaseAgeExcludes(Object.values(auditReport.advisories), {
-      getPublishTimes: createPublishTimesFetcher(opts),
+      getPublishTimes: opts.getPublishTimes ?? createPublishTimesFetcher(opts),
       minimumReleaseAge: opts.minimumReleaseAge,
     })
     : []

--- a/pnpm11/deps/compliance/commands/src/audit/publishTimes.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/publishTimes.ts
@@ -7,6 +7,22 @@ import npa from '@pnpm/npm-package-arg'
 import type { AuditOptions } from './audit.js'
 import { createAuditNetworkOptions } from './auditContext.js'
 
+export interface PackumentPublishInfo {
+  /**
+   * The packument `time` map: version → raw publish timestamp. Includes the
+   * `created` and `modified` metadata keys alongside version keys.
+   */
+  time: Record<string, string>
+  /**
+   * Versions the packument marks as deprecated. Deprecated versions are
+   * excluded from patched-version validation — a deprecated release is not a
+   * viable fix even though it exists on the registry.
+   */
+  deprecated: ReadonlySet<string>
+}
+
+export type PublishTimesFetcher = (pkgName: string) => Promise<PackumentPublishInfo | undefined>
+
 /**
  * Returns a memoized lookup of each package's publish-time map (the `time`
  * field of its packument), so callers can tell whether a version is young
@@ -14,7 +30,7 @@ import { createAuditNetworkOptions } from './auditContext.js'
  * publish times are unknown — the request failed or the packument carries no
  * `time` field; callers must treat that as "no information", not as "old".
  */
-export function createPublishTimesFetcher (opts: AuditOptions): (pkgName: string) => Promise<Record<string, string> | undefined> {
+export function createPublishTimesFetcher (opts: AuditOptions): PublishTimesFetcher {
   const networkOptions = createAuditNetworkOptions(opts)
   const getAuthHeader = createGetAuthHeaderByURI(opts.configByUri)
   const fetchFromRegistry = createFetchFromRegistry({
@@ -29,7 +45,7 @@ export function createPublishTimesFetcher (opts: AuditOptions): (pkgName: string
     strictSsl: networkOptions.strictSsl,
     configByUri: opts.configByUri,
   })
-  const timesByPkg = new Map<string, Promise<Record<string, string> | undefined>>()
+  const timesByPkg = new Map<string, Promise<PackumentPublishInfo | undefined>>()
   return (pkgName) => {
     let times = timesByPkg.get(pkgName)
     if (times == null) {
@@ -39,7 +55,7 @@ export function createPublishTimesFetcher (opts: AuditOptions): (pkgName: string
     return times
   }
 
-  async function fetchTimes (pkgName: string): Promise<Record<string, string> | undefined> {
+  async function fetchTimes (pkgName: string): Promise<PackumentPublishInfo | undefined> {
     try {
       const registry = pickRegistryForPackage(opts.registriesByScope, pkgName)
       const packageUrl = new URL(npa(pkgName).escapedName, registry.endsWith('/') ? registry : `${registry}/`).href
@@ -51,8 +67,20 @@ export function createPublishTimesFetcher (opts: AuditOptions): (pkgName: string
         timeout: networkOptions.fetchTimeout,
       })
       if (!res.ok) return undefined
-      const body = await res.json() as { time?: Record<string, string> }
-      return body.time != null && typeof body.time === 'object' && !Array.isArray(body.time) ? body.time as Record<string, string> : undefined
+      const body = await res.json() as {
+        time?: Record<string, string>
+        versions?: Record<string, { deprecated?: string }>
+      }
+      if (body.time == null || typeof body.time !== 'object' || Array.isArray(body.time)) return undefined
+      const deprecated = new Set<string>()
+      if (body.versions != null && typeof body.versions === 'object') {
+        for (const [version, manifest] of Object.entries(body.versions)) {
+          if (manifest != null && typeof manifest === 'object' && typeof manifest.deprecated === 'string') {
+            deprecated.add(version)
+          }
+        }
+      }
+      return { time: body.time as Record<string, string>, deprecated }
     } catch {
       // A failed lookup must not break the fix flow: the caller keeps its
       // current behavior (the exclude entry) when the age is unknown.
@@ -62,28 +90,63 @@ export function createPublishTimesFetcher (opts: AuditOptions): (pkgName: string
 }
 
 /**
- * Drops inferred `patched_versions` ranges that no published version
- * satisfies: the inference from `vulnerable_versions` is purely syntactic,
- * so an advisory can claim a patch (e.g. `>=2.0.3`) that was never released.
- * A failed packument lookup leaves the range untouched (fail open). The
- * publish-time map's keys double as the published version list; `created`
- * and `modified` are metadata, not versions.
+ * Returns the lowest non-deprecated published version satisfying `range`, or
+ * `undefined` when no published version satisfies it (whether it was never
+ * published, skipped, yanked, or deprecated). A failed packument lookup
+ * (`undefined` publish info) also returns `undefined`.
  */
-export async function dropUnsatisfiablePatchedVersions (
+export function lowestNonDeprecatedVersion (
+  publishInfo: PackumentPublishInfo | undefined,
+  range: string
+): string | undefined {
+  if (publishInfo == null) return undefined
+  const versions = Object.keys(publishInfo.time)
+    .filter((key) => key !== 'created' && key !== 'modified' && !publishInfo.deprecated.has(key))
+  let lowest: string | undefined
+  for (const version of versions) {
+    if (satisfiesSafe(version, range) && (lowest == null || compareVersions(version, lowest) < 0)) {
+      lowest = version
+    }
+  }
+  return lowest
+}
+
+function compareVersions (a: string, b: string): number {
+  const pa = a.split('.').map(Number)
+  const pb = b.split('.').map(Number)
+  for (let i = 0; i < 3; i++) {
+    const diff = (pa[i] || 0) - (pb[i] || 0)
+    if (diff !== 0) return diff
+  }
+  return 0
+}
+
+/**
+ * Corrects inferred `patched_versions` ranges against the registry: the
+ * inference from `vulnerable_versions` is purely syntactic, so the inferred
+ * minimum may not be a viable fix — it may never have been published, been
+ * skipped, been yanked, or been deprecated. When the inferred range is
+ * satisfiable, it is narrowed to the lowest non-deprecated published version
+ * (e.g. `>=4.17.24` becomes `>=4.18.1` when 4.17.24 does not exist and
+ * 4.18.0 is deprecated). When no published version satisfies it, the range
+ * is dropped entirely. A failed packument lookup leaves the range untouched
+ * (fail open). Ports pnpm's `correctInferredPatchedVersions`.
+ */
+export async function correctInferredPatchedVersions (
   advisories: Record<string, AuditAdvisory>,
-  getPublishTimes: (pkgName: string) => Promise<Record<string, string> | undefined>
+  getPublishTimes: PublishTimesFetcher
 ): Promise<void> {
   await Promise.all(Object.values(advisories).map(async (advisory) => {
     const patched = advisory.patched_versions
     if (patched == null) return
-    const times = await getPublishTimes(advisory.module_name)
-    if (times == null) return
-    const fixPublished = Object.keys(times)
-      .filter((key) => key !== 'created' && key !== 'modified')
-      .some((version) => satisfiesSafe(version, patched))
-    if (!fixPublished) {
-      advisory.patched_versions = undefined
+    const publishInfo = await getPublishTimes(advisory.module_name)
+    if (publishInfo == null) return
+    const lowest = lowestNonDeprecatedVersion(publishInfo, patched)
+    if (lowest == null) {
+      advisory.patched_versions = null
       advisory.patched_versions_unpublished = true
+    } else {
+      advisory.patched_versions = `>=${lowest}`
     }
   }))
 }

--- a/pnpm11/deps/compliance/commands/src/audit/publishTimes.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/publishTimes.ts
@@ -3,6 +3,7 @@ import { type AuditAdvisory, satisfiesSafe } from '@pnpm/deps.compliance.audit'
 import { createGetAuthHeaderByURI } from '@pnpm/network.auth-header'
 import { createFetchFromRegistry } from '@pnpm/network.fetch'
 import npa from '@pnpm/npm-package-arg'
+import semver from 'semver'
 
 import type { AuditOptions } from './audit.js'
 import { createAuditNetworkOptions } from './auditContext.js'
@@ -24,11 +25,11 @@ export interface PackumentPublishInfo {
 export type PublishTimesFetcher = (pkgName: string) => Promise<PackumentPublishInfo | undefined>
 
 /**
- * Returns a memoized lookup of each package's publish-time map (the `time`
- * field of its packument), so callers can tell whether a version is young
- * enough that `minimumReleaseAge` would block it. `undefined` means the
- * publish times are unknown — the request failed or the packument carries no
- * `time` field; callers must treat that as "no information", not as "old".
+ * Returns a memoized lookup of each package's {@link PackumentPublishInfo}, so
+ * callers can tell which versions exist and whether one is young enough that
+ * `minimumReleaseAge` would block it. `undefined` means the packument is
+ * unknown — the request failed or it carries no `time` field; callers must
+ * treat that as "no information", not as "old".
  */
 export function createPublishTimesFetcher (opts: AuditOptions): PublishTimesFetcher {
   const networkOptions = createAuditNetworkOptions(opts)
@@ -89,36 +90,39 @@ export function createPublishTimesFetcher (opts: AuditOptions): PublishTimesFetc
   }
 }
 
-/**
- * Returns the lowest non-deprecated published version satisfying `range`, or
- * `undefined` when no published version satisfies it (whether it was never
- * published, skipped, yanked, or deprecated). A failed packument lookup
- * (`undefined` publish info) also returns `undefined`.
- */
-export function lowestNonDeprecatedVersion (
-  publishInfo: PackumentPublishInfo | undefined,
-  range: string
-): string | undefined {
-  if (publishInfo == null) return undefined
-  const versions = Object.keys(publishInfo.time)
-    .filter((key) => key !== 'created' && key !== 'modified' && !publishInfo.deprecated.has(key))
-  let lowest: string | undefined
-  for (const version of versions) {
-    if (satisfiesSafe(version, range) && (lowest == null || compareVersions(version, lowest) < 0)) {
-      lowest = version
-    }
-  }
-  return lowest
+export interface PublishedVersion {
+  /**
+   * The `time` key the version was found under. The registry may spell it in
+   * a non-normalized form (e.g. `v1.2.3`) that the parsed version drops, so
+   * the key is what a publish-time lookup must use.
+   */
+  key: string
+  /**
+   * The normalized version.
+   */
+  version: string
 }
 
-function compareVersions (a: string, b: string): number {
-  const pa = a.split('.').map(Number)
-  const pb = b.split('.').map(Number)
-  for (let i = 0; i < 3; i++) {
-    const diff = (pa[i] || 0) - (pb[i] || 0)
-    if (diff !== 0) return diff
+/**
+ * Returns the lowest non-deprecated published version satisfying `range` — the
+ * version an inferred patched range actually resolves to — or `undefined` when
+ * no published version satisfies it, whether it was never published, skipped,
+ * yanked, or deprecated.
+ */
+export function lowestNonDeprecatedVersion (
+  publishInfo: PackumentPublishInfo,
+  range: string
+): PublishedVersion | undefined {
+  let lowest: { key: string, parsed: semver.SemVer } | undefined
+  for (const key of Object.keys(publishInfo.time)) {
+    if (key === 'created' || key === 'modified' || publishInfo.deprecated.has(key)) continue
+    const parsed = semver.parse(key, { loose: true })
+    if (parsed == null || !satisfiesSafe(parsed.version, range)) continue
+    if (lowest == null || semver.compare(parsed, lowest.parsed) < 0) {
+      lowest = { key, parsed }
+    }
   }
-  return 0
+  return lowest && { key: lowest.key, version: lowest.parsed.version }
 }
 
 /**
@@ -130,7 +134,7 @@ function compareVersions (a: string, b: string): number {
  * (e.g. `>=4.17.24` becomes `>=4.18.1` when 4.17.24 does not exist and
  * 4.18.0 is deprecated). When no published version satisfies it, the range
  * is dropped entirely. A failed packument lookup leaves the range untouched
- * (fail open). Ports pnpm's `correctInferredPatchedVersions`.
+ * (fail open).
  */
 export async function correctInferredPatchedVersions (
   advisories: Record<string, AuditAdvisory>,
@@ -146,7 +150,7 @@ export async function correctInferredPatchedVersions (
       advisory.patched_versions = null
       advisory.patched_versions_unpublished = true
     } else {
-      advisory.patched_versions = `>=${lowest}`
+      advisory.patched_versions = `>=${lowest.version}`
     }
   }))
 }

--- a/pnpm11/deps/compliance/commands/src/audit/publishTimes.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/publishTimes.ts
@@ -1,4 +1,5 @@
 import { pickRegistryForPackage } from '@pnpm/config.pick-registry-for-package'
+import { type AuditAdvisory, satisfiesSafe } from '@pnpm/deps.compliance.audit'
 import { createGetAuthHeaderByURI } from '@pnpm/network.auth-header'
 import { createFetchFromRegistry } from '@pnpm/network.fetch'
 import npa from '@pnpm/npm-package-arg'
@@ -58,4 +59,31 @@ export function createPublishTimesFetcher (opts: AuditOptions): (pkgName: string
       return undefined
     }
   }
+}
+
+/**
+ * Drops inferred `patched_versions` ranges that no published version
+ * satisfies: the inference from `vulnerable_versions` is purely syntactic,
+ * so an advisory can claim a patch (e.g. `>=2.0.3`) that was never released.
+ * A failed packument lookup leaves the range untouched (fail open). The
+ * publish-time map's keys double as the published version list; `created`
+ * and `modified` are metadata, not versions.
+ */
+export async function dropUnsatisfiablePatchedVersions (
+  advisories: Record<string, AuditAdvisory>,
+  getPublishTimes: (pkgName: string) => Promise<Record<string, string> | undefined>
+): Promise<void> {
+  await Promise.all(Object.values(advisories).map(async (advisory) => {
+    const patched = advisory.patched_versions
+    if (patched == null) return
+    const times = await getPublishTimes(advisory.module_name)
+    if (times == null) return
+    const fixPublished = Object.keys(times)
+      .filter((key) => key !== 'created' && key !== 'modified')
+      .some((version) => satisfiesSafe(version, patched))
+    if (!fixPublished) {
+      advisory.patched_versions = undefined
+      advisory.patched_versions_unpublished = true
+    }
+  }))
 }

--- a/pnpm11/deps/compliance/commands/src/audit/publishTimes.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/publishTimes.ts
@@ -17,7 +17,9 @@ export interface PackumentPublishInfo {
   /**
    * Versions the packument marks as deprecated. Deprecated versions are
    * excluded from patched-version validation — a deprecated release is not a
-   * viable fix even though it exists on the registry.
+   * viable fix even though it exists on the registry. Normalized rather than
+   * kept as raw keys, because the `time` and `versions` maps may spell the
+   * same release differently (`v1.2.3` vs `1.2.3`).
    */
   deprecated: ReadonlySet<string>
 }
@@ -77,7 +79,8 @@ export function createPublishTimesFetcher (opts: AuditOptions): PublishTimesFetc
       if (body.versions != null && typeof body.versions === 'object') {
         for (const [version, manifest] of Object.entries(body.versions)) {
           if (manifest != null && typeof manifest === 'object' && typeof manifest.deprecated === 'string') {
-            deprecated.add(version)
+            const parsed = semver.parse(version, { loose: true })
+            if (parsed != null) deprecated.add(parsed.version)
           }
         }
       }
@@ -108,6 +111,10 @@ export interface PublishedVersion {
  * version an inferred patched range actually resolves to — or `undefined` when
  * no published version satisfies it, whether it was never published, skipped,
  * yanked, or deprecated.
+ *
+ * Stable releases outrank prereleases regardless of order, so a
+ * `4.18.0-beta.1` published before `4.18.0` is never advertised as the fix.
+ * A prerelease still wins when nothing else satisfies the range.
  */
 export function lowestNonDeprecatedVersion (
   publishInfo: PackumentPublishInfo,
@@ -115,14 +122,22 @@ export function lowestNonDeprecatedVersion (
 ): PublishedVersion | undefined {
   let lowest: { key: string, parsed: semver.SemVer } | undefined
   for (const key of Object.keys(publishInfo.time)) {
-    if (key === 'created' || key === 'modified' || publishInfo.deprecated.has(key)) continue
+    if (key === 'created' || key === 'modified') continue
     const parsed = semver.parse(key, { loose: true })
-    if (parsed == null || !satisfiesSafe(parsed.version, range)) continue
-    if (lowest == null || semver.compare(parsed, lowest.parsed) < 0) {
+    if (parsed == null || publishInfo.deprecated.has(parsed.version)) continue
+    if (!satisfiesSafe(parsed.version, range)) continue
+    if (lowest == null || compareFixCandidates(parsed, lowest.parsed) < 0) {
       lowest = { key, parsed }
     }
   }
   return lowest && { key: lowest.key, version: lowest.parsed.version }
+}
+
+function compareFixCandidates (a: semver.SemVer, b: semver.SemVer): number {
+  const aIsPrerelease = a.prerelease.length > 0
+  const bIsPrerelease = b.prerelease.length > 0
+  if (aIsPrerelease !== bIsPrerelease) return aIsPrerelease ? 1 : -1
+  return semver.compare(a, b)
 }
 
 /**

--- a/pnpm11/deps/compliance/commands/test/audit/fix.ts
+++ b/pnpm11/deps/compliance/commands/test/audit/fix.ts
@@ -1,3 +1,4 @@
+import { existsSync as fsExistsSync } from 'node:fs'
 import path from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, test } from '@jest/globals'
@@ -91,6 +92,45 @@ test('no minimumReleaseAgeExclude entries are added for patched versions publish
   const manifest = readYamlFileSync<{ overrides?: Record<string, string>, minimumReleaseAgeExclude?: string[] }>(path.join(tmp, 'pnpm-workspace.yaml'))
   expect(manifest.overrides?.['axios@<=0.18.0']).toBe('^0.18.1')
   expect(manifest.minimumReleaseAgeExclude).toBeUndefined()
+})
+
+test('no overrides or minimumReleaseAgeExclude entries are added when the inferred patched version was never published', async () => {
+  const tmp = f.prepare('has-vulnerabilities')
+
+  getMockAgent().get(AUDIT_REGISTRY.replace(/\/$/, ''))
+    .intercept({ path: '/-/npm/v1/security/advisories/bulk', method: 'POST' })
+    .reply(200, {
+      axios: [
+        {
+          id: 1,
+          title: 'vulnerability in axios',
+          severity: 'high',
+          vulnerable_versions: '<=0.18.0',
+          url: 'https://github.com/advisories/GHSA-mock-mock-mock',
+        },
+      ],
+    })
+  // The packument names no version satisfying the inferred `>=0.18.1` patch:
+  // the fix was never released, so there is nothing to fix with.
+  getMockAgent().get(AUDIT_REGISTRY.replace(/\/$/, ''))
+    .intercept({ path: '/axios', method: 'GET' })
+    .reply(200, {
+      name: 'axios',
+      time: { '0.18.0': '2020-01-01T00:00:00.000Z' },
+    })
+
+  const { exitCode, output } = await audit.handler({
+    ...AUDIT_REGISTRY_OPTS,
+    auditLevel: 'moderate',
+    minimumReleaseAge: 1440,
+    dir: tmp,
+    rootProjectManifestDir: tmp,
+    fix: true,
+  })
+
+  expect(exitCode).toBe(0)
+  expect(output).toBe('No fixes were made')
+  expect(fsExistsSync(path.join(tmp, 'pnpm-workspace.yaml'))).toBe(false)
 })
 
 test('minimumReleaseAgeExclude entries are added for patched versions published after the cutoff', async () => {
@@ -309,13 +349,15 @@ describe('createMinimumReleaseAgeExcludes', () => {
     expect(excludes).toEqual(['lodash@4.17.21'])
   })
 
-  test('keeps entries whose publish time is missing from the packument', async () => {
+  test('omits entries for patched versions missing from the packument', async () => {
     const advisories = [
       advisory('axios', '<=0.18.0', '>=0.18.1'),
       advisory('lodash', '<4.17.21', '>=4.17.21'),
     ]
     const publishTimes: Record<string, Record<string, string>> = {
       axios: { '0.18.1': '2026-01-01T00:00:00.000Z' },
+      // The packument was fetched but names no 4.17.21: the patched release
+      // was never published, so it gets no bypass entry.
       lodash: {},
     }
     const excludes = await createMinimumReleaseAgeExcludes(advisories, {
@@ -323,7 +365,7 @@ describe('createMinimumReleaseAgeExcludes', () => {
       minimumReleaseAge: 60,
       now: new Date('2026-01-08T00:00:00.000Z').getTime(),
     })
-    expect(excludes).toEqual(['lodash@4.17.21'])
+    expect(excludes).toEqual([])
   })
 
   test('omits entries for patched versions published exactly at the cutoff', async () => {

--- a/pnpm11/deps/compliance/commands/test/audit/fix.ts
+++ b/pnpm11/deps/compliance/commands/test/audit/fix.ts
@@ -269,6 +269,10 @@ describe('createMinimumReleaseAgeExcludes', () => {
   // The publish times are unknown: every entry is kept.
   const unknownPublishTimes = async (): Promise<undefined> => undefined
 
+  function publishInfo (time: Record<string, string>, deprecated: string[] = []) {
+    return { time, deprecated: new Set(deprecated) }
+  }
+
   test('combines multiple advisories for the same module into a single sorted entry', async () => {
     const advisories = [
       advisory('axios', '<0.21.2', '>=0.21.2'),
@@ -342,7 +346,7 @@ describe('createMinimumReleaseAgeExcludes', () => {
       lodash: { '4.17.21': '2026-01-07T23:30:00.000Z' },
     }
     const excludes = await createMinimumReleaseAgeExcludes(advisories, {
-      getPublishTimes: async (pkgName) => publishTimes[pkgName],
+      getPublishTimes: async (pkgName) => publishTimes[pkgName] ? publishInfo(publishTimes[pkgName]) : undefined,
       minimumReleaseAge: 60,
       now: new Date('2026-01-08T00:00:00.000Z').getTime(),
     })
@@ -361,7 +365,7 @@ describe('createMinimumReleaseAgeExcludes', () => {
       lodash: {},
     }
     const excludes = await createMinimumReleaseAgeExcludes(advisories, {
-      getPublishTimes: async (pkgName) => publishTimes[pkgName],
+      getPublishTimes: async (pkgName) => publishTimes[pkgName] ? publishInfo(publishTimes[pkgName]) : undefined,
       minimumReleaseAge: 60,
       now: new Date('2026-01-08T00:00:00.000Z').getTime(),
     })
@@ -378,11 +382,30 @@ describe('createMinimumReleaseAgeExcludes', () => {
       axios: { '0.18.2': '2026-01-07T23:30:00.000Z' },
     }
     const excludes = await createMinimumReleaseAgeExcludes(advisories, {
-      getPublishTimes: async (pkgName) => publishTimes[pkgName],
+      getPublishTimes: async (pkgName) => publishTimes[pkgName] ? publishInfo(publishTimes[pkgName]) : undefined,
       minimumReleaseAge: 60,
       now: new Date('2026-01-08T00:00:00.000Z').getTime(),
     })
     expect(excludes).toEqual(['axios@0.18.2'])
+  })
+
+  test('skips deprecated versions when selecting the lowest published fix', async () => {
+    const advisories = [
+      advisory('lodash-es', '<4.18.0', '>=4.18.0'),
+    ]
+    // 4.18.0 is deprecated; 4.18.1 is the lowest non-deprecated published
+    // version satisfying >=4.18.0.
+    const publishTimes: Record<string, Record<string, string>> = {
+      'lodash-es': { '4.18.0': '2026-01-07T23:00:00.000Z', '4.18.1': '2026-01-07T23:30:00.000Z' },
+    }
+    const excludes = await createMinimumReleaseAgeExcludes(advisories, {
+      getPublishTimes: async (pkgName) => publishTimes[pkgName]
+        ? publishInfo(publishTimes[pkgName], ['4.18.0'])
+        : undefined,
+      minimumReleaseAge: 60,
+      now: new Date('2026-01-08T00:00:00.000Z').getTime(),
+    })
+    expect(excludes).toEqual(['lodash-es@4.18.1'])
   })
 
   test('omits entries for patched versions published exactly at the cutoff', async () => {
@@ -390,7 +413,7 @@ describe('createMinimumReleaseAgeExcludes', () => {
       advisory('axios', '<=0.18.0', '>=0.18.1'),
     ]
     const excludes = await createMinimumReleaseAgeExcludes(advisories, {
-      getPublishTimes: async () => ({ '0.18.1': '2026-01-07T23:00:00.000Z' }),
+      getPublishTimes: async () => publishInfo({ '0.18.1': '2026-01-07T23:00:00.000Z' }),
       minimumReleaseAge: 60,
       now: new Date('2026-01-08T00:00:00.000Z').getTime(),
     })
@@ -412,7 +435,7 @@ describe('createMinimumReleaseAgeExcludes', () => {
       underscore: { '1.13.1': '0' },
     }
     const excludes = await createMinimumReleaseAgeExcludes(advisories, {
-      getPublishTimes: async (pkgName) => publishTimes[pkgName],
+      getPublishTimes: async (pkgName) => publishTimes[pkgName] ? publishInfo(publishTimes[pkgName]) : undefined,
       minimumReleaseAge: 60,
       now: new Date('2026-01-08T00:00:00.000Z').getTime(),
     })

--- a/pnpm11/deps/compliance/commands/test/audit/fix.ts
+++ b/pnpm11/deps/compliance/commands/test/audit/fix.ts
@@ -401,18 +401,22 @@ describe('createMinimumReleaseAgeExcludes', () => {
     const advisories = [
       advisory('axios', '<=0.18.0', '>=0.18.1'),
       advisory('lodash', '<4.17.21', '>=4.17.21'),
+      advisory('underscore', '<1.13.0', '>=1.13.1'),
     ]
     const publishTimes: Record<string, Record<string, string>> = {
       axios: { '0.18.1': 'not-a-date' },
       // A non-string value smuggled past the registry response type.
       lodash: { '4.17.21': 0 as unknown as string },
+      // A bare number parses as epoch 0 with `new Date()`, which is not a
+      // real publish timestamp and must be treated as unknown.
+      underscore: { '1.13.1': '0' },
     }
     const excludes = await createMinimumReleaseAgeExcludes(advisories, {
       getPublishTimes: async (pkgName) => publishTimes[pkgName],
       minimumReleaseAge: 60,
       now: new Date('2026-01-08T00:00:00.000Z').getTime(),
     })
-    expect(excludes).toEqual(['axios@0.18.1', 'lodash@4.17.21'])
+    expect(excludes).toEqual(['axios@0.18.1', 'lodash@4.17.21', 'underscore@1.13.1'])
   })
 })
 

--- a/pnpm11/deps/compliance/commands/test/audit/fix.ts
+++ b/pnpm11/deps/compliance/commands/test/audit/fix.ts
@@ -408,6 +408,42 @@ describe('createMinimumReleaseAgeExcludes', () => {
     expect(excludes).toEqual(['lodash-es@4.18.1'])
   })
 
+  test('skips deprecated versions the time map spells differently', async () => {
+    const advisories = [
+      advisory('lodash-es', '<4.18.0', '>=4.18.0'),
+    ]
+    // The `time` map spells 4.18.0 with a leading `v` while `versions` — the
+    // source of the deprecation set — does not.
+    const publishTimes: Record<string, Record<string, string>> = {
+      'lodash-es': { 'v4.18.0': '2026-01-07T23:00:00.000Z', '4.18.1': '2026-01-07T23:30:00.000Z' },
+    }
+    const excludes = await createMinimumReleaseAgeExcludes(advisories, {
+      getPublishTimes: async (pkgName) => publishTimes[pkgName]
+        ? publishInfo(publishTimes[pkgName], ['4.18.0'])
+        : undefined,
+      minimumReleaseAge: 60,
+      now: new Date('2026-01-08T00:00:00.000Z').getTime(),
+    })
+    expect(excludes).toEqual(['lodash-es@4.18.1'])
+  })
+
+  test('prefers a stable release over a lower-sorting prerelease', async () => {
+    const advisories = [
+      advisory('axios', '<=1.9.9', '>=1.9.10'),
+    ]
+    // 2.0.0-beta.1 sorts below 2.0.0 but is not a release users should be
+    // pointed at as the fix.
+    const publishTimes: Record<string, Record<string, string>> = {
+      axios: { '2.0.0-beta.1': '2026-01-07T23:00:00.000Z', '2.0.0': '2026-01-07T23:30:00.000Z' },
+    }
+    const excludes = await createMinimumReleaseAgeExcludes(advisories, {
+      getPublishTimes: async (pkgName) => publishTimes[pkgName] ? publishInfo(publishTimes[pkgName]) : undefined,
+      minimumReleaseAge: 60,
+      now: new Date('2026-01-08T00:00:00.000Z').getTime(),
+    })
+    expect(excludes).toEqual(['axios@2.0.0'])
+  })
+
   test('omits entries for patched versions published exactly at the cutoff', async () => {
     const advisories = [
       advisory('axios', '<=0.18.0', '>=0.18.1'),

--- a/pnpm11/deps/compliance/commands/test/audit/fix.ts
+++ b/pnpm11/deps/compliance/commands/test/audit/fix.ts
@@ -368,6 +368,23 @@ describe('createMinimumReleaseAgeExcludes', () => {
     expect(excludes).toEqual([])
   })
 
+  test('uses the lowest published version satisfying the patched range', async () => {
+    const advisories = [
+      advisory('axios', '<=0.18.0', '>=0.18.1'),
+    ]
+    // 0.18.1 was never published; 0.18.2 is the lowest published version
+    // satisfying >=0.18.1 and it is fresh enough to need the bypass.
+    const publishTimes: Record<string, Record<string, string>> = {
+      axios: { '0.18.2': '2026-01-07T23:30:00.000Z' },
+    }
+    const excludes = await createMinimumReleaseAgeExcludes(advisories, {
+      getPublishTimes: async (pkgName) => publishTimes[pkgName],
+      minimumReleaseAge: 60,
+      now: new Date('2026-01-08T00:00:00.000Z').getTime(),
+    })
+    expect(excludes).toEqual(['axios@0.18.2'])
+  })
+
   test('omits entries for patched versions published exactly at the cutoff', async () => {
     const advisories = [
       advisory('axios', '<=0.18.0', '>=0.18.1'),

--- a/pnpm11/deps/compliance/commands/test/audit/index.ts
+++ b/pnpm11/deps/compliance/commands/test/audit/index.ts
@@ -78,6 +78,81 @@ describe('plugin-commands-audit', () => {
     expect(stripAnsi(output)).toMatchSnapshot()
   })
 
+  test('audit reports the lowest non-deprecated published version as the patch', async () => {
+    getMockAgent().get(AUDIT_REGISTRY.replace(/\/$/, ''))
+      .intercept({ path: '/-/npm/v1/security/advisories/bulk', method: 'POST' })
+      .reply(200, {
+        axios: [
+          {
+            id: 1,
+            title: 'vulnerability in axios',
+            severity: 'high',
+            vulnerable_versions: '<=0.18.0',
+            url: 'https://github.com/advisories/GHSA-mock-mock-mock',
+          },
+        ],
+      })
+    // 0.18.1 was never published and 0.18.2 is deprecated, so the inferred
+    // >=0.18.1 patch resolves to 0.18.3.
+    getMockAgent().get(AUDIT_REGISTRY.replace(/\/$/, ''))
+      .intercept({ path: '/axios', method: 'GET' })
+      .reply(200, {
+        name: 'axios',
+        time: {
+          '0.18.0': '2020-01-01T00:00:00.000Z',
+          '0.18.2': '2020-02-01T00:00:00.000Z',
+          '0.18.3': '2020-03-01T00:00:00.000Z',
+        },
+        versions: {
+          '0.18.0': {},
+          '0.18.2': { deprecated: 'do not use' },
+          '0.18.3': {},
+        },
+      })
+
+    const { output, exitCode } = await audit.handler({
+      ...AUDIT_REGISTRY_OPTS,
+      dir: hasVulnerabilitiesDir,
+      rootProjectManifestDir: hasVulnerabilitiesDir,
+    })
+
+    expect(exitCode).toBe(1)
+    expect(stripAnsi(output)).toContain('>=0.18.3')
+  })
+
+  test('audit reports no patched versions when none was published', async () => {
+    getMockAgent().get(AUDIT_REGISTRY.replace(/\/$/, ''))
+      .intercept({ path: '/-/npm/v1/security/advisories/bulk', method: 'POST' })
+      .reply(200, {
+        axios: [
+          {
+            id: 1,
+            title: 'vulnerability in axios',
+            severity: 'high',
+            vulnerable_versions: '<=0.18.0',
+            url: 'https://github.com/advisories/GHSA-mock-mock-mock',
+          },
+        ],
+      })
+    getMockAgent().get(AUDIT_REGISTRY.replace(/\/$/, ''))
+      .intercept({ path: '/axios', method: 'GET' })
+      .reply(200, {
+        name: 'axios',
+        time: { '0.18.0': '2020-01-01T00:00:00.000Z' },
+      })
+
+    const { output, exitCode } = await audit.handler({
+      ...AUDIT_REGISTRY_OPTS,
+      dir: hasVulnerabilitiesDir,
+      rootProjectManifestDir: hasVulnerabilitiesDir,
+    })
+
+    expect(exitCode).toBe(1)
+    expect(stripAnsi(output)).toContain('Patched versions')
+    expect(stripAnsi(output)).toContain('None')
+    expect(stripAnsi(output)).not.toContain('(unknown)')
+  })
+
   test('audit: no vulnerabilities', async () => {
     getMockAgent().get(AUDIT_REGISTRY.replace(/\/$/, ''))
       .intercept({ path: '/-/npm/v1/security/advisories/bulk', method: 'POST' })


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary
close #13824 https://github.com/pnpm/pnpm/pull/13678#issuecomment-5251471477
<!-- Describe what this PR changes and why, for reviewers. Link any related
issues here (Closes pnpm/pnpm#123, Fixes pnpm/pnpm#456, or Related to
pnpm/pnpm#123 for a partial fix). -->

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
`pnpm audit` no longer reports a patched version that was never published or is deprecated. The inferred patched range (e.g. `>=4.17.24` from `<=4.17.23`) is now checked against the registry packument, and the report is corrected to the lowest non-deprecated published version that satisfies it (e.g. `>=4.18.1` when `4.17.24` does not exist and `4.18.0` is deprecated). When no published version satisfies the range, the report shows `Patched versions: None`. This also prevents `pnpm audit --fix` from adding overrides or `minimumReleaseAgeExclude` entries for patches that do not exist [#13824](https://github.com/pnpm/pnpm/issues/13824).

`pnpm audit --fix` and `pnpm audit --fix update` no longer add a `minimumReleaseAgeExclude` entry when the registry packument shows that the minimum patched version was never published. Previously such entries were written for versions that do not exist, which would have let a later publish of that version bypass the `minimumReleaseAge` gate [#11563](https://github.com/pnpm/pnpm/issues/11563).

The `--json` output of `pnpm audit` now returns `patched_versions: null` for advisories whose inferred patch is not available (never published, skipped, yanked, or deprecated), making it easier for tooling to distinguish "no fix available" from "fix available at version X".
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [ ] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [ ] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [ ] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [ ] Added or updated tests.
- [ ] Updated the documentation if needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789050385&installation_model_id=426870&pr_number=13832&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13832&signature=b1aebbe6ebbe5d69707e14640d8b2b5e6870e7cd49b3862ebd4276eb71c3952e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Audit now ignores inferred patched versions that are not published in the registry.
  * Audit fix no longer adds invalid overrides or minimum-release-age exclusions for unpublished versions.
  * The lowest published version satisfying a patch range is selected when calculating exclusions.
  * Audit output displays `None` when no valid patched version is available.
  * Existing exclusions are preserved when registry metadata is unavailable or cannot be interpreted.
* **Tests**
  * Expanded coverage for unpublished versions and unavailable publication metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->