### PR TITLE
feat(injected-deps-syncer): sync injected copies after the named scripts

### DIFF
--- a/.changeset/pacquet-sync-injected-deps-after-scripts.md
+++ b/.changeset/pacquet-sync-injected-deps-after-scripts.md
@@ -1,0 +1,5 @@
+---
+"pacquet": minor
+---
+
+Added support for the `syncInjectedDepsAfterScripts` setting. It names the scripts after which every injected copy of the package that ran them is brought back in step with its source, so a build script no longer leaves the copies in the virtual store holding stale files.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4536,6 +4536,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4024,6 +4024,7 @@ dependencies = [
  "pacquet-global",
  "pacquet-graph-hasher",
  "pacquet-hooks",
+ "pacquet-injected-deps-syncer",
  "pacquet-lockfile",
  "pacquet-lockfile-verification",
  "pacquet-modules-yaml",
@@ -4516,6 +4517,25 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+]
+
+[[package]]
+name = "pacquet-injected-deps-syncer"
+version = "0.0.1"
+dependencies = [
+ "derive_more",
+ "miette 7.6.0",
+ "pacquet-cmd-shim",
+ "pacquet-directory-fetcher",
+ "pacquet-fs",
+ "pacquet-modules-yaml",
+ "pacquet-package-manifest",
+ "pacquet-testing-utils",
+ "pacquet-workspace",
+ "pretty_assertions",
+ "serde_json",
+ "tempfile",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ pacquet-detect-libc                       = { path = "pnpm/crates/detect-libc" }
 pacquet-diagnostics                       = { path = "pnpm/crates/diagnostics" }
 pacquet-graph-hasher                      = { path = "pnpm/crates/graph-hasher" }
 pacquet-hooks                             = { path = "pnpm/crates/hooks" }
+pacquet-injected-deps-syncer              = { path = "pnpm/crates/injected-deps-syncer" }
 pacquet-store-dir                         = { path = "pnpm/crates/store-dir" }
 pacquet-reporter                          = { path = "pnpm/crates/reporter" }
 pacquet-patching                          = { path = "pnpm/crates/patching" }

--- a/pnpm/crates/cli/Cargo.toml
+++ b/pnpm/crates/cli/Cargo.toml
@@ -30,6 +30,7 @@ pacquet-fs                                = { workspace = true }
 pacquet-global                            = { workspace = true }
 pacquet-graph-hasher                      = { workspace = true }
 pacquet-hooks                             = { workspace = true }
+pacquet-injected-deps-syncer              = { workspace = true }
 pacquet-lockfile                          = { workspace = true }
 pacquet-lockfile-verification             = { workspace = true }
 pacquet-modules-yaml                      = { workspace = true }

--- a/pnpm/crates/cli/src/cli_args/run.rs
+++ b/pnpm/crates/cli/src/cli_args/run.rs
@@ -4,6 +4,7 @@ use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_config::Config;
 use pacquet_executor::{RunScript, ScriptsPrependNodePath, run_script};
+use pacquet_injected_deps_syncer::{SyncInjectedDeps, sync_injected_deps};
 use pacquet_package_manager::{make_node_package_map_option, package_map_path_for_execution};
 use pacquet_package_manifest::PackageManifest;
 use pacquet_reporter::LogEvent;
@@ -385,6 +386,14 @@ pub(super) fn run_stages(
         {
             return Ok(status);
         }
+    }
+
+    if ctx.config.sync_injected_deps_after_scripts.iter().any(|script| script == name) {
+        sync_injected_deps(&SyncInjectedDeps {
+            pkg_name: ctx.manifest.value().get("name").and_then(Value::as_str),
+            pkg_root_dir: ctx.dir,
+            workspace_dir: ctx.config.workspace_dir.as_deref(),
+        })?;
     }
 
     Ok(main_status)

--- a/pnpm/crates/cli/tests/suite/main.rs
+++ b/pnpm/crates/cli/tests/suite/main.rs
@@ -106,6 +106,7 @@ mod stale_pin_dedupe;
 mod star_tests;
 mod stars_tests;
 mod store;
+mod sync_injected_deps_after_scripts;
 mod tarball_url_dependency;
 mod team;
 mod test_command;

--- a/pnpm/crates/cli/tests/suite/sync_injected_deps_after_scripts.rs
+++ b/pnpm/crates/cli/tests/suite/sync_injected_deps_after_scripts.rs
@@ -1,0 +1,126 @@
+//! End-to-end coverage for `syncInjectedDepsAfterScripts`.
+//!
+//! An injected dependency is a tree of hardlinks into the virtual
+//! store, so a build script that rewrites the source package leaves
+//! every injected copy pointing at the old inodes. The setting names
+//! the scripts after which those copies are refreshed.
+
+use crate::_utils::pacquet_in;
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
+use std::{fs, path::Path};
+
+/// The injected copies of `project-1` inside the virtual store: every
+/// `project-1` directory under `node_modules/.pnpm`.
+fn injected_copies(workspace: &Path) -> Vec<std::path::PathBuf> {
+    let virtual_store = workspace.join("node_modules/.pnpm");
+    let mut copies: Vec<_> = fs::read_dir(&virtual_store)
+        .expect("read the virtual store")
+        .filter_map(|entry| {
+            let slot = entry.expect("read a virtual-store entry").path();
+            let candidate = slot.join("node_modules/project-1");
+            candidate.is_dir().then_some(candidate)
+        })
+        .collect();
+    copies.sort();
+    copies
+}
+
+fn write_workspace(workspace: &Path, sync_after: &str) {
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        format!(
+            "packages:\n  - 'project-*'\ninjectWorkspacePackages: true\ndedupeInjectedDeps: false\n{sync_after}",
+        ),
+    )
+    .expect("write pnpm-workspace.yaml");
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "name": "ws-root", "version": "0.0.0", "private": true }).to_string(),
+    )
+    .expect("write root package.json");
+
+    fs::create_dir_all(workspace.join("project-1/distribution")).expect("mkdir project-1");
+    fs::write(
+        workspace.join("project-1/package.json"),
+        serde_json::json!({
+            "name": "project-1",
+            "version": "1.0.0",
+            "scripts": { "build": "node build.cjs" },
+        })
+        .to_string(),
+    )
+    .expect("write project-1 package.json");
+    fs::write(
+        workspace.join("project-1/build.cjs"),
+        "require('fs').writeFileSync(__dirname + '/distribution/generated.js', 'generated')\n",
+    )
+    .expect("write project-1 build script");
+    fs::write(workspace.join("project-1/distribution/index.js"), "original")
+        .expect("write project-1 output");
+
+    fs::create_dir_all(workspace.join("project-2")).expect("mkdir project-2");
+    fs::write(
+        workspace.join("project-2/package.json"),
+        serde_json::json!({
+            "name": "project-2",
+            "version": "1.0.0",
+            "dependencies": { "project-1": "workspace:1.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write project-2 package.json");
+}
+
+#[test]
+fn a_listed_script_refreshes_every_injected_copy() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_workspace(&workspace, "syncInjectedDepsAfterScripts:\n  - build\n");
+
+    pacquet.with_arg("install").assert().success();
+
+    let copies = injected_copies(&workspace);
+    assert!(!copies.is_empty(), "the install should have injected project-1 somewhere");
+
+    pacquet_in(&workspace.join("project-1")).with_args(["run", "build"]).assert().success();
+
+    for copy in &copies {
+        assert_eq!(
+            fs::read_to_string(copy.join("distribution/generated.js"))
+                .expect("read the refreshed injected copy"),
+            "generated",
+            "the injected copy at {copy:?} should have gained the generated file",
+        );
+    }
+
+    drop((mock_instance, root));
+}
+
+#[test]
+fn an_unlisted_script_leaves_the_injected_copies_alone() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_workspace(&workspace, "");
+
+    pacquet.with_arg("install").assert().success();
+
+    let copies = injected_copies(&workspace);
+    assert!(!copies.is_empty(), "the install should have injected project-1 somewhere");
+
+    pacquet_in(&workspace.join("project-1")).with_args(["run", "build"]).assert().success();
+
+    for copy in &copies {
+        assert!(
+            !copy.join("distribution/generated.js").exists(),
+            "the injected copy at {copy:?} should not have gained the generated file",
+        );
+    }
+
+    drop((mock_instance, root));
+}

--- a/pnpm/crates/cli/tests/suite/sync_injected_deps_after_scripts.rs
+++ b/pnpm/crates/cli/tests/suite/sync_injected_deps_after_scripts.rs
@@ -124,3 +124,30 @@ fn an_unlisted_script_leaves_the_injected_copies_alone() {
 
     drop((mock_instance, root));
 }
+
+/// The setting reaches a non-workspace project through `PNPM_CONFIG_*`,
+/// which every schema key reads. A script that already succeeded must
+/// not have the run fail behind it.
+#[test]
+fn a_project_outside_a_workspace_still_runs_the_script() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "name": "solo",
+            "version": "1.0.0",
+            "scripts": { "build": "node --version" },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    pacquet
+        .with_env("PNPM_CONFIG_SYNC_INJECTED_DEPS_AFTER_SCRIPTS", r#"["build"]"#)
+        .with_args(["run", "build"])
+        .assert()
+        .success();
+
+    drop(root);
+}

--- a/pnpm/crates/config/src/env_overlay.rs
+++ b/pnpm/crates/config/src/env_overlay.rs
@@ -225,6 +225,7 @@ impl WorkspaceSettings {
         json_field!(workspace_concurrency, "WORKSPACE_CONCURRENCY");
         json_field!(git_shallow_hosts, "GIT_SHALLOW_HOSTS");
         json_field!(test_pattern, "TEST_PATTERN");
+        json_field!(sync_injected_deps_after_scripts, "SYNC_INJECTED_DEPS_AFTER_SCRIPTS");
         json_field!(changed_files_ignore_pattern, "CHANGED_FILES_IGNORE_PATTERN");
         json_field!(supported_architectures, "SUPPORTED_ARCHITECTURES");
         json_field!(ignored_optional_dependencies, "IGNORED_OPTIONAL_DEPENDENCIES");

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -1676,6 +1676,12 @@ pub struct Config {
     /// all match, the project is selected without its dependents.
     pub test_pattern: Vec<String>,
 
+    /// `syncInjectedDepsAfterScripts` from `pnpm-workspace.yaml` /
+    /// `PNPM_CONFIG_SYNC_INJECTED_DEPS_AFTER_SCRIPTS`. Names the scripts
+    /// after which every injected copy of the package that ran them is
+    /// re-synced from its source.
+    pub sync_injected_deps_after_scripts: Vec<String>,
+
     /// `changedFilesIgnorePattern` from `pnpm-workspace.yaml` /
     /// `PNPM_CONFIG_CHANGED_FILES_IGNORE_PATTERN`, overridable by the
     /// `--changed-files-ignore-pattern` CLI flag. Glob patterns of

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -388,6 +388,10 @@ pub struct WorkspaceSettings {
     /// [`Config::changed_files_ignore_pattern`].
     pub changed_files_ignore_pattern: Option<Vec<String>>,
 
+    /// `syncInjectedDepsAfterScripts` from `pnpm-workspace.yaml` — see
+    /// [`Config::sync_injected_deps_after_scripts`].
+    pub sync_injected_deps_after_scripts: Option<Vec<String>>,
+
     /// `supportedArchitectures` from `pnpm-workspace.yaml`. Drives the
     /// optional-dependency platform check at install time: a
     /// `name: ['darwin'], cpu: ['arm64']` setting tells pacquet to
@@ -891,6 +895,7 @@ impl WorkspaceSettings {
         self.package_extensions = None;
         self.test_pattern = None;
         self.changed_files_ignore_pattern = None;
+        self.sync_injected_deps_after_scripts = None;
         self.allow_unused_patches = None;
         self.save_catalog_name = None;
         self.save_peer = None;
@@ -1062,6 +1067,7 @@ impl WorkspaceSettings {
             virtual_store_only, enable_modules_dir,
             git_shallow_hosts,
             test_pattern, changed_files_ignore_pattern,
+            sync_injected_deps_after_scripts,
             resolution_mode, catalog_mode, catalog_prune,
             minimum_release_age_exclude_prune, save_peer, save_exact,
             registry_supports_time_field,

--- a/pnpm/crates/deps-restorer/src/install_package_from_registry/tests.rs
+++ b/pnpm/crates/deps-restorer/src/install_package_from_registry/tests.rs
@@ -135,6 +135,7 @@ fn create_config(
         filter_prod: Vec::new(),
         workspace_root: false,
         test_pattern: Vec::new(),
+        sync_injected_deps_after_scripts: Vec::new(),
         changed_files_ignore_pattern: Vec::new(),
         git_shallow_hosts: pacquet_config::default_git_shallow_hosts(),
         supported_architectures: None,

--- a/pnpm/crates/injected-deps-syncer/Cargo.toml
+++ b/pnpm/crates/injected-deps-syncer/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name                  = "pacquet-injected-deps-syncer"
+version               = "0.0.1"
+publish               = false
+authors.workspace     = true
+description.workspace = true
+edition.workspace     = true
+homepage.workspace    = true
+keywords.workspace    = true
+license.workspace     = true
+repository.workspace  = true
+
+[dependencies]
+pacquet-cmd-shim          = { workspace = true }
+pacquet-directory-fetcher = { workspace = true }
+pacquet-fs                = { workspace = true }
+pacquet-modules-yaml      = { workspace = true }
+pacquet-package-manifest  = { workspace = true }
+pacquet-workspace         = { workspace = true }
+
+derive_more = { workspace = true }
+miette      = { workspace = true }
+serde_json  = { workspace = true }
+tracing     = { workspace = true }
+
+[dev-dependencies]
+pacquet-testing-utils = { workspace = true }
+
+pretty_assertions = { workspace = true }
+tempfile          = { workspace = true }
+
+[lints]
+workspace = true

--- a/pnpm/crates/injected-deps-syncer/Cargo.toml
+++ b/pnpm/crates/injected-deps-syncer/Cargo.toml
@@ -23,6 +23,9 @@ miette      = { workspace = true }
 serde_json  = { workspace = true }
 tracing     = { workspace = true }
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem"] }
+
 [dev-dependencies]
 pacquet-testing-utils = { workspace = true }
 

--- a/pnpm/crates/injected-deps-syncer/src/dir_patcher.rs
+++ b/pnpm/crates/injected-deps-syncer/src/dir_patcher.rs
@@ -248,7 +248,7 @@ pub fn extend_files_map(files_map: &HashMap<String, PathBuf>) -> Result<InodeMap
             continue;
         };
         let value = if metadata.is_file() {
-            Value::File(inode_of(&metadata))
+            Value::File(file_inode(real_path, &metadata)?)
         } else if metadata.is_dir() {
             Value::Dir
         } else {
@@ -280,25 +280,51 @@ fn add_inode_and_ancestors(result: &mut InodeMap, relative_path: &str, value: Va
     }
 }
 
-/// Node reports 0 for a file whose index Windows will not hand over, and
-/// the TypeScript syncer compares that value as-is; matching it keeps
-/// the two implementations agreeing on what counts as unchanged.
-fn inode_of(metadata: &fs::Metadata) -> u64 {
+/// The file's identity: two paths share one exactly when they are the
+/// same inode, which is what makes an already-hardlinked file free to
+/// skip.
+///
+/// Windows has no stable way to read the file index from
+/// [`fs::Metadata`] — `MetadataExt::file_index` is still unstable — so
+/// the index comes from a handle instead, the same call libuv makes to
+/// fill Node's `Stats.ino`.
+fn file_inode(path: &Path, metadata: &fs::Metadata) -> Result<u64, PatchError> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::MetadataExt as _;
-        metadata.ino()
+        let _ = path;
+        Ok(metadata.ino())
     }
     #[cfg(windows)]
     {
-        use std::os::windows::fs::MetadataExt as _;
-        metadata.file_index().unwrap_or(0)
+        let _ = metadata;
+        windows_file_index(path)
+            .map_err(|error| PatchError::Stat { path: path.to_path_buf(), error })
     }
     #[cfg(not(any(unix, windows)))]
     {
-        let _ = metadata;
-        0
+        let _ = (path, metadata);
+        Ok(0)
     }
+}
+
+#[cfg(windows)]
+fn windows_file_index(path: &Path) -> io::Result<u64> {
+    use std::{mem::MaybeUninit, os::windows::io::AsRawHandle as _};
+    use windows_sys::Win32::Storage::FileSystem::{
+        BY_HANDLE_FILE_INFORMATION, GetFileInformationByHandle,
+    };
+
+    let file = fs::File::open(path)?;
+    let mut info = MaybeUninit::<BY_HANDLE_FILE_INFORMATION>::uninit();
+    // SAFETY: `file` owns a valid handle for this call and `info` points to
+    // writable storage of the exact structure the API initializes.
+    if unsafe { GetFileInformationByHandle(file.as_raw_handle() as _, info.as_mut_ptr()) } == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: a successful `GetFileInformationByHandle` initializes `info`.
+    let info = unsafe { info.assume_init() };
+    Ok((u64::from(info.nFileIndexHigh) << 32) | u64::from(info.nFileIndexLow))
 }
 
 #[cfg(test)]

--- a/pnpm/crates/injected-deps-syncer/src/dir_patcher.rs
+++ b/pnpm/crates/injected-deps-syncer/src/dir_patcher.rs
@@ -11,15 +11,26 @@ use std::{
     path::{Path, PathBuf},
 };
 
+/// A file's identity. An inode number is only unique within one
+/// filesystem, so the volume it came from is part of the identity:
+/// without it two unrelated files on different volumes can collide and
+/// be mistaken for the same one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FileId {
+    pub device: u64,
+    pub inode: u64,
+}
+
 /// What a path in an [`InodeMap`] holds.
 ///
-/// A file carries its inode number because that is all a hardlink
-/// comparison needs: two paths hold the same content exactly when they
-/// share an inode, so an unchanged file costs no filesystem work.
+/// A file carries its identity rather than its content, because that is
+/// all a hardlink comparison needs: two paths hold the same bytes
+/// exactly when they are the same file, so an unchanged file costs no
+/// filesystem work.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Value {
     Dir,
-    File(u64),
+    File(FileId),
 }
 
 /// Relative path → inode type, for every file and directory in a tree.
@@ -248,7 +259,7 @@ pub fn extend_files_map(files_map: &HashMap<String, PathBuf>) -> Result<InodeMap
             continue;
         };
         let value = if metadata.is_file() {
-            Value::File(file_inode(real_path, &metadata)?)
+            Value::File(file_id(real_path, &metadata)?)
         } else if metadata.is_dir() {
             Value::Dir
         } else {
@@ -280,36 +291,33 @@ fn add_inode_and_ancestors(result: &mut InodeMap, relative_path: &str, value: Va
     }
 }
 
-/// The file's identity: two paths share one exactly when they are the
-/// same inode, which is what makes an already-hardlinked file free to
-/// skip.
+/// Read a file's [`FileId`].
 ///
 /// Windows has no stable way to read the file index from
 /// [`fs::Metadata`] — `MetadataExt::file_index` is still unstable — so
-/// the index comes from a handle instead, the same call libuv makes to
-/// fill Node's `Stats.ino`.
-fn file_inode(path: &Path, metadata: &fs::Metadata) -> Result<u64, PatchError> {
+/// it comes from a handle instead, the same call libuv makes to fill
+/// Node's `Stats.ino`.
+fn file_id(path: &Path, metadata: &fs::Metadata) -> Result<FileId, PatchError> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::MetadataExt as _;
         let _ = path;
-        Ok(metadata.ino())
+        Ok(FileId { device: metadata.dev(), inode: metadata.ino() })
     }
     #[cfg(windows)]
     {
         let _ = metadata;
-        windows_file_index(path)
-            .map_err(|error| PatchError::Stat { path: path.to_path_buf(), error })
+        windows_file_id(path).map_err(|error| PatchError::Stat { path: path.to_path_buf(), error })
     }
     #[cfg(not(any(unix, windows)))]
     {
         let _ = (path, metadata);
-        Ok(0)
+        Ok(FileId { device: 0, inode: 0 })
     }
 }
 
 #[cfg(windows)]
-fn windows_file_index(path: &Path) -> io::Result<u64> {
+fn windows_file_id(path: &Path) -> io::Result<FileId> {
     use std::{mem::MaybeUninit, os::windows::io::AsRawHandle as _};
     use windows_sys::Win32::Storage::FileSystem::{
         BY_HANDLE_FILE_INFORMATION, GetFileInformationByHandle,
@@ -324,7 +332,10 @@ fn windows_file_index(path: &Path) -> io::Result<u64> {
     }
     // SAFETY: a successful `GetFileInformationByHandle` initializes `info`.
     let info = unsafe { info.assume_init() };
-    Ok((u64::from(info.nFileIndexHigh) << 32) | u64::from(info.nFileIndexLow))
+    Ok(FileId {
+        device: u64::from(info.dwVolumeSerialNumber),
+        inode: (u64::from(info.nFileIndexHigh) << 32) | u64::from(info.nFileIndexLow),
+    })
 }
 
 #[cfg(test)]

--- a/pnpm/crates/injected-deps-syncer/src/dir_patcher.rs
+++ b/pnpm/crates/injected-deps-syncer/src/dir_patcher.rs
@@ -146,11 +146,10 @@ pub fn diff_dir(old_index: &InodeMap, new_index: &InodeMap) -> DirDiff {
 
 /// Apply a diff produced by [`diff_dir`] to `target_dir`.
 ///
-/// Removals run first, so a path the source turned from a directory
-/// into a file still has its old children under a directory when they
-/// are unlinked. Directories then go in ahead of the files they hold,
-/// so a directory is always empty when it displaces whatever the
-/// target held at its path.
+/// The phase order is load-bearing: removals before changes so that a
+/// path the source turned into a file still has its old children under
+/// a directory, and directories before files so that displacing a
+/// blocking inode never takes a populated directory with it.
 pub fn apply_patch(
     patch: &DirDiff,
     source_dir: &Path,
@@ -211,7 +210,7 @@ fn is_already_exists(error: &PatchError) -> bool {
     matches!(
         error,
         PatchError::CreateDir { error, .. } | PatchError::Link { error, .. }
-            if error.kind() == io::ErrorKind::AlreadyExists
+            if error.kind() == io::ErrorKind::AlreadyExists,
     )
 }
 

--- a/pnpm/crates/injected-deps-syncer/src/dir_patcher.rs
+++ b/pnpm/crates/injected-deps-syncer/src/dir_patcher.rs
@@ -1,0 +1,306 @@
+//! Bring one directory tree in step with another by hardlinking, so an
+//! injected copy of a workspace package can be refreshed in place
+//! without re-running the installer.
+
+use derive_more::{Display, Error};
+use miette::Diagnostic;
+use pacquet_directory_fetcher::{DirectoryFetcher, DirectoryFetcherError};
+use std::{
+    collections::{BTreeMap, HashMap},
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+/// What a path in an [`InodeMap`] holds.
+///
+/// A file carries its inode number because that is all a hardlink
+/// comparison needs: two paths hold the same content exactly when they
+/// share an inode, so an unchanged file costs no filesystem work.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Value {
+    Dir,
+    File(u64),
+}
+
+/// Relative path → inode type, for every file and directory in a tree.
+///
+/// Ordering matters and comes for free: a directory's path is a strict
+/// prefix of every path beneath it, so an ancestor always sorts before
+/// its descendants. [`apply_patch`] leans on that to put a directory in
+/// place before what it holds, and to delete children before parents.
+pub type InodeMap = BTreeMap<String, Value>;
+
+/// A path the target must end up holding, paired with what it holds
+/// now. `old_value` is `None` when the target has nothing there.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Change {
+    pub path: String,
+    pub old_value: Option<Value>,
+    pub new_value: Value,
+}
+
+/// The work needed to turn a target tree into a copy of a source tree.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct DirDiff {
+    pub changes: Vec<Change>,
+    /// Paths the target holds that the source does not, deepest first
+    /// so a directory is empty by the time it is removed.
+    pub removed: Vec<String>,
+}
+
+/// Error type for [`DirPatcher`].
+#[derive(Debug, Display, Error, Diagnostic)]
+pub enum PatchError {
+    #[display("Failed to read the directory at {dir:?}: {error}")]
+    #[diagnostic(code(ERR_PNPM_INJECTED_DEPS_SYNC_READ_DIR))]
+    ReadDir {
+        dir: PathBuf,
+        #[error(source)]
+        error: DirectoryFetcherError,
+    },
+
+    #[display("Failed to stat {path:?}: {error}")]
+    #[diagnostic(code(ERR_PNPM_INJECTED_DEPS_SYNC_STAT))]
+    Stat {
+        path: PathBuf,
+        #[error(source)]
+        error: io::Error,
+    },
+
+    #[display("Failed to create the directory at {path:?}: {error}")]
+    #[diagnostic(code(ERR_PNPM_INJECTED_DEPS_SYNC_CREATE_DIR))]
+    CreateDir {
+        path: PathBuf,
+        #[error(source)]
+        error: io::Error,
+    },
+
+    #[display("Failed to hardlink {source:?} to {target:?}: {error}")]
+    #[diagnostic(code(ERR_PNPM_INJECTED_DEPS_SYNC_LINK))]
+    Link {
+        source: PathBuf,
+        target: PathBuf,
+        #[error(source)]
+        error: io::Error,
+    },
+
+    #[display("Failed to remove {path:?}: {error}")]
+    #[diagnostic(code(ERR_PNPM_INJECTED_DEPS_SYNC_REMOVE))]
+    Remove {
+        path: PathBuf,
+        #[error(source)]
+        error: io::Error,
+    },
+}
+
+/// One source directory paired with one target that must mirror it.
+pub struct DirPatcher {
+    source_dir: PathBuf,
+    target_dir: PathBuf,
+    patch: DirDiff,
+}
+
+impl DirPatcher {
+    /// Diff `source_dir` against each of `target_dirs`, reading each
+    /// tree once.
+    pub fn from_multiple_targets(
+        source_dir: &Path,
+        target_dirs: &[PathBuf],
+    ) -> Result<Vec<Self>, PatchError> {
+        let source_map = load_inode_map(source_dir)?;
+        target_dirs
+            .iter()
+            .map(|target_dir| {
+                Ok(DirPatcher {
+                    source_dir: source_dir.to_path_buf(),
+                    target_dir: target_dir.clone(),
+                    patch: diff_dir(&load_inode_map(target_dir)?, &source_map),
+                })
+            })
+            .collect()
+    }
+
+    pub fn apply(&self) -> Result<(), PatchError> {
+        apply_patch(&self.patch, &self.source_dir, &self.target_dir)
+    }
+}
+
+/// The difference between two trees: what `new_index` has that
+/// `old_index` does not or holds differently, and what only
+/// `old_index` has.
+#[must_use]
+pub fn diff_dir(old_index: &InodeMap, new_index: &InodeMap) -> DirDiff {
+    let changes = new_index
+        .iter()
+        .filter(|(path, new_value)| old_index.get(*path) != Some(*new_value))
+        .map(|(path, new_value)| Change {
+            path: path.clone(),
+            old_value: old_index.get(path).copied(),
+            new_value: *new_value,
+        })
+        .collect();
+    let removed =
+        old_index.keys().filter(|path| !new_index.contains_key(*path)).rev().cloned().collect();
+    DirDiff { changes, removed }
+}
+
+/// Apply a diff produced by [`diff_dir`] to `target_dir`.
+///
+/// Removals run first, so a path the source turned from a directory
+/// into a file still has its old children under a directory when they
+/// are unlinked. Directories then go in ahead of the files they hold,
+/// so a directory is always empty when it displaces whatever the
+/// target held at its path.
+pub fn apply_patch(
+    patch: &DirDiff,
+    source_dir: &Path,
+    target_dir: &Path,
+) -> Result<(), PatchError> {
+    for path in &patch.removed {
+        remove_recursive(&target_dir.join(path))?;
+    }
+    let (new_dirs, new_files): (Vec<_>, Vec<_>) =
+        patch.changes.iter().partition(|change| change.new_value == Value::Dir);
+    for change in new_dirs.into_iter().chain(new_files) {
+        apply_change(change, source_dir, target_dir)?;
+    }
+    Ok(())
+}
+
+fn apply_change(change: &Change, source_dir: &Path, target_dir: &Path) -> Result<(), PatchError> {
+    let target_path = target_dir.join(&change.path);
+    if change.old_value.is_some() {
+        remove_recursive(&target_path)?;
+    }
+    match change.new_value {
+        Value::Dir => retry_over_blocking_inode(&target_path, || {
+            fs::create_dir_all(&target_path)
+                .map_err(|error| PatchError::CreateDir { path: target_path.clone(), error })
+        }),
+        Value::File(_) => {
+            let source_path = source_dir.join(&change.path);
+            retry_over_blocking_inode(&target_path, || {
+                fs::hard_link(&source_path, &target_path).map_err(|error| PatchError::Link {
+                    source: source_path.clone(),
+                    target: target_path.clone(),
+                    error,
+                })
+            })
+        }
+    }
+}
+
+/// The target may hold an inode that [`extend_files_map`] skips — a
+/// FIFO, a socket, a device. No diff can see it, so it is never
+/// scheduled for removal, and creating over it fails with `EEXIST`.
+/// Clear that path and retry once instead of failing the sync.
+fn retry_over_blocking_inode(
+    target_path: &Path,
+    add: impl Fn() -> Result<(), PatchError>,
+) -> Result<(), PatchError> {
+    match add() {
+        Err(error) if is_already_exists(&error) => {
+            remove_recursive(target_path)?;
+            add()
+        }
+        result => result,
+    }
+}
+
+fn is_already_exists(error: &PatchError) -> bool {
+    matches!(
+        error,
+        PatchError::CreateDir { error, .. } | PatchError::Link { error, .. }
+            if error.kind() == io::ErrorKind::AlreadyExists
+    )
+}
+
+fn remove_recursive(target_path: &Path) -> Result<(), PatchError> {
+    match pacquet_fs::remove_dirent(target_path) {
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        result => {
+            result.map_err(|error| PatchError::Remove { path: target_path.to_path_buf(), error })
+        }
+    }
+}
+
+fn load_inode_map(dir: &Path) -> Result<InodeMap, PatchError> {
+    let output = DirectoryFetcher {
+        directory: dir.to_path_buf(),
+        include_only_package_files: false,
+        resolve_symlinks: false,
+        allow_path_escape: false,
+    }
+    .run()
+    .map_err(|error| PatchError::ReadDir { dir: dir.to_path_buf(), error })?;
+    extend_files_map(&output.files_map)
+}
+
+/// Expand a relative-path → real-path map into an [`InodeMap`] that
+/// also names every ancestor directory.
+///
+/// An inode that is neither a file nor a directory — a FIFO, a socket,
+/// a device — cannot be hardlinked into the injected copy, so it is
+/// left out of the map.
+pub fn extend_files_map(files_map: &HashMap<String, PathBuf>) -> Result<InodeMap, PatchError> {
+    let mut result = InodeMap::from([(".".to_string(), Value::Dir)]);
+    for (relative_path, real_path) in files_map {
+        let Some(metadata) = stat_skipping_missing(real_path)? else {
+            continue;
+        };
+        let value = if metadata.is_file() {
+            Value::File(inode_of(&metadata))
+        } else if metadata.is_dir() {
+            Value::Dir
+        } else {
+            continue;
+        };
+        add_inode_and_ancestors(&mut result, relative_path, value);
+    }
+    Ok(result)
+}
+
+/// A path the walker listed can be gone by the time it is stat'd — a
+/// build script that deletes as it goes, or a symlink that broke.
+fn stat_skipping_missing(path: &Path) -> Result<Option<fs::Metadata>, PatchError> {
+    match fs::metadata(path) {
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        result => {
+            result.map(Some).map_err(|error| PatchError::Stat { path: path.to_path_buf(), error })
+        }
+    }
+}
+
+fn add_inode_and_ancestors(result: &mut InodeMap, relative_path: &str, value: Value) {
+    let mut path = relative_path;
+    let mut value = value;
+    while !path.is_empty() && path != "." && !result.contains_key(path) {
+        result.insert(path.to_string(), value);
+        path = path.rsplit_once('/').map_or("", |(parent, _)| parent);
+        value = Value::Dir;
+    }
+}
+
+/// Node reports 0 for a file whose index Windows will not hand over, and
+/// the TypeScript syncer compares that value as-is; matching it keeps
+/// the two implementations agreeing on what counts as unchanged.
+fn inode_of(metadata: &fs::Metadata) -> u64 {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt as _;
+        metadata.ino()
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt as _;
+        metadata.file_index().unwrap_or(0)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = metadata;
+        0
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/injected-deps-syncer/src/dir_patcher/tests.rs
+++ b/pnpm/crates/injected-deps-syncer/src/dir_patcher/tests.rs
@@ -1,0 +1,143 @@
+use super::{DirPatcher, InodeMap, Value, extend_files_map, inode_of};
+use pretty_assertions::assert_eq;
+#[cfg(unix)]
+use std::os::unix::fs::FileTypeExt as _;
+use std::{collections::HashMap, fs, path::PathBuf};
+use tempfile::TempDir;
+
+fn create_file(path: &std::path::Path, content: &str) {
+    fs::create_dir_all(path.parent().expect("file has a parent")).expect("create parent");
+    fs::write(path, content).expect("write file");
+}
+
+#[cfg(unix)]
+fn create_fifo(path: &std::path::Path) {
+    fs::create_dir_all(path.parent().expect("fifo has a parent")).expect("create parent");
+    let status = std::process::Command::new("mkfifo").arg(path).status().expect("run mkfifo");
+    assert!(status.success(), "mkfifo failed for {path:?}");
+}
+
+fn files_map(root: &std::path::Path, relative_paths: &[&str]) -> HashMap<String, PathBuf> {
+    relative_paths.iter().map(|relative| ((*relative).to_string(), root.join(relative))).collect()
+}
+
+fn sync(source: &std::path::Path, target: &std::path::Path) {
+    let patchers = DirPatcher::from_multiple_targets(source, &[target.to_path_buf()])
+        .expect("diff source against target");
+    for patcher in patchers {
+        patcher.apply().expect("apply patch");
+    }
+}
+
+#[test]
+fn extend_files_map_names_every_ancestor() {
+    let dir = TempDir::new().expect("temp dir");
+    create_file(&dir.path().join("distribution/index.js"), "");
+
+    let map = extend_files_map(&files_map(dir.path(), &["distribution/index.js"]))
+        .expect("build inode map");
+
+    let inode = inode_of(&fs::metadata(dir.path().join("distribution/index.js")).expect("stat"));
+    assert_eq!(
+        map,
+        InodeMap::from([
+            (".".to_string(), Value::Dir),
+            ("distribution".to_string(), Value::Dir),
+            ("distribution/index.js".to_string(), Value::File(inode)),
+        ]),
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn extend_files_map_skips_an_inode_that_cannot_be_hardlinked() {
+    let dir = TempDir::new().expect("temp dir");
+    create_file(&dir.path().join("distribution/index.js"), "");
+    create_fifo(&dir.path().join(".env"));
+
+    let map = extend_files_map(&files_map(dir.path(), &["distribution/index.js", ".env"]))
+        .expect("build inode map");
+
+    assert!(!map.contains_key(".env"), "a FIFO belongs in no inode map: {map:?}");
+    assert!(map.contains_key("distribution/index.js"));
+}
+
+#[test]
+fn sync_replaces_a_target_entry_whose_inode_type_changed_in_the_source() {
+    let dir = TempDir::new().expect("temp dir");
+    let (source, target) = (dir.path().join("source"), dir.path().join("target"));
+    create_file(&source.join("became-a-dir/index.js"), "inner");
+    create_file(&source.join("became-a-file"), "now a file");
+    create_file(&target.join("became-a-dir"), "was a file");
+    create_file(&target.join("became-a-file/index.js"), "was a dir");
+
+    sync(&source, &target);
+
+    assert_eq!(
+        fs::read_to_string(target.join("became-a-dir/index.js")).expect("read replaced dir"),
+        "inner",
+    );
+    assert_eq!(
+        fs::read_to_string(target.join("became-a-file")).expect("read replaced file"),
+        "now a file",
+    );
+}
+
+#[test]
+fn sync_removes_what_the_source_no_longer_has() {
+    let dir = TempDir::new().expect("temp dir");
+    let (source, target) = (dir.path().join("source"), dir.path().join("target"));
+    create_file(&source.join("keep.txt"), "kept");
+    create_file(&target.join("keep.txt"), "kept");
+    create_file(&target.join("stale/nested.txt"), "stale");
+
+    sync(&source, &target);
+
+    assert!(target.join("keep.txt").exists());
+    assert!(!target.join("stale").exists(), "a directory the source dropped is removed");
+}
+
+#[cfg(unix)]
+#[test]
+fn sync_replaces_a_skipped_inode_the_target_holds() {
+    let dir = TempDir::new().expect("temp dir");
+    let (source, target) = (dir.path().join("source"), dir.path().join("target"));
+    create_file(&source.join("config.env"), "real");
+    create_file(&source.join("other.txt"), "");
+    // The diff cannot see a FIFO, so it never schedules one for
+    // removal and creating over it would fail with EEXIST.
+    create_fifo(&target.join("config.env"));
+
+    sync(&source, &target);
+
+    assert_eq!(fs::read_to_string(target.join("config.env")).expect("read replacement"), "real");
+    assert!(target.join("other.txt").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn sync_leaves_a_skipped_inode_the_source_does_not_cover() {
+    let dir = TempDir::new().expect("temp dir");
+    let (source, target) = (dir.path().join("source"), dir.path().join("target"));
+    create_file(&source.join("keep.txt"), "kept");
+    create_fifo(&target.join("own.env"));
+
+    sync(&source, &target);
+
+    let metadata = fs::symlink_metadata(target.join("own.env")).expect("stat the FIFO");
+    assert!(metadata.file_type().is_fifo(), "a FIFO of the target's own is left alone");
+}
+
+#[test]
+fn sync_shares_inodes_with_the_source() {
+    let dir = TempDir::new().expect("temp dir");
+    let (source, target) = (dir.path().join("source"), dir.path().join("target"));
+    create_file(&source.join("lib/index.js"), "built");
+    fs::create_dir_all(&target).expect("create target");
+
+    sync(&source, &target);
+
+    let source_stat = fs::metadata(source.join("lib/index.js")).expect("stat source");
+    let target_stat = fs::metadata(target.join("lib/index.js")).expect("stat target");
+    assert_eq!(inode_of(&source_stat), inode_of(&target_stat));
+}

--- a/pnpm/crates/injected-deps-syncer/src/dir_patcher/tests.rs
+++ b/pnpm/crates/injected-deps-syncer/src/dir_patcher/tests.rs
@@ -1,4 +1,4 @@
-use super::{DirPatcher, InodeMap, Value, extend_files_map, file_inode};
+use super::{DirPatcher, InodeMap, Value, extend_files_map, file_id};
 use pretty_assertions::assert_eq;
 #[cfg(unix)]
 use std::os::unix::fs::FileTypeExt as _;
@@ -38,13 +38,13 @@ fn extend_files_map_names_every_ancestor() {
         .expect("build inode map");
 
     let index_js = dir.path().join("distribution/index.js");
-    let inode = file_inode(&index_js, &fs::metadata(&index_js).expect("stat")).expect("inode");
+    let id = file_id(&index_js, &fs::metadata(&index_js).expect("stat")).expect("file id");
     assert_eq!(
         map,
         InodeMap::from([
             (".".to_string(), Value::Dir),
             ("distribution".to_string(), Value::Dir),
-            ("distribution/index.js".to_string(), Value::File(inode)),
+            ("distribution/index.js".to_string(), Value::File(id)),
         ]),
     );
 }
@@ -142,7 +142,7 @@ fn sync_shares_inodes_with_the_source() {
     let source_stat = fs::metadata(&source_path).expect("stat source");
     let target_stat = fs::metadata(&target_path).expect("stat target");
     assert_eq!(
-        file_inode(&source_path, &source_stat).expect("source inode"),
-        file_inode(&target_path, &target_stat).expect("target inode"),
+        file_id(&source_path, &source_stat).expect("source file id"),
+        file_id(&target_path, &target_stat).expect("target file id"),
     );
 }

--- a/pnpm/crates/injected-deps-syncer/src/dir_patcher/tests.rs
+++ b/pnpm/crates/injected-deps-syncer/src/dir_patcher/tests.rs
@@ -1,4 +1,4 @@
-use super::{DirPatcher, InodeMap, Value, extend_files_map, inode_of};
+use super::{DirPatcher, InodeMap, Value, extend_files_map, file_inode};
 use pretty_assertions::assert_eq;
 #[cfg(unix)]
 use std::os::unix::fs::FileTypeExt as _;
@@ -37,7 +37,8 @@ fn extend_files_map_names_every_ancestor() {
     let map = extend_files_map(&files_map(dir.path(), &["distribution/index.js"]))
         .expect("build inode map");
 
-    let inode = inode_of(&fs::metadata(dir.path().join("distribution/index.js")).expect("stat"));
+    let index_js = dir.path().join("distribution/index.js");
+    let inode = file_inode(&index_js, &fs::metadata(&index_js).expect("stat")).expect("inode");
     assert_eq!(
         map,
         InodeMap::from([
@@ -137,7 +138,11 @@ fn sync_shares_inodes_with_the_source() {
 
     sync(&source, &target);
 
-    let source_stat = fs::metadata(source.join("lib/index.js")).expect("stat source");
-    let target_stat = fs::metadata(target.join("lib/index.js")).expect("stat target");
-    assert_eq!(inode_of(&source_stat), inode_of(&target_stat));
+    let (source_path, target_path) = (source.join("lib/index.js"), target.join("lib/index.js"));
+    let source_stat = fs::metadata(&source_path).expect("stat source");
+    let target_stat = fs::metadata(&target_path).expect("stat target");
+    assert_eq!(
+        file_inode(&source_path, &source_stat).expect("source inode"),
+        file_inode(&target_path, &target_stat).expect("target inode"),
+    );
 }

--- a/pnpm/crates/injected-deps-syncer/src/lib.rs
+++ b/pnpm/crates/injected-deps-syncer/src/lib.rs
@@ -10,7 +10,7 @@
 mod dir_patcher;
 
 pub use dir_patcher::{
-    Change, DirDiff, DirPatcher, InodeMap, PatchError, Value, apply_patch, diff_dir,
+    Change, DirDiff, DirPatcher, FileId, InodeMap, PatchError, Value, apply_patch, diff_dir,
     extend_files_map,
 };
 

--- a/pnpm/crates/injected-deps-syncer/src/lib.rs
+++ b/pnpm/crates/injected-deps-syncer/src/lib.rs
@@ -30,10 +30,6 @@ use std::{
 /// Error type for [`sync_injected_deps`].
 #[derive(Debug, Display, Error, Diagnostic)]
 pub enum SyncInjectedDepsError {
-    #[display("Cannot update injected dependencies without workspace dir")]
-    #[diagnostic(code(ERR_PNPM_NO_WORKSPACE_DIR))]
-    NoWorkspaceDir,
-
     #[display("Failed to read the modules manifest: {error}")]
     #[diagnostic(code(ERR_PNPM_INJECTED_DEPS_SYNC_READ_MODULES))]
     ReadModules {
@@ -84,8 +80,17 @@ pub fn sync_injected_deps(opts: &SyncInjectedDeps<'_>) -> Result<(), SyncInjecte
         );
         return Ok(());
     }
+    // Outside a workspace nothing can be injected, so there is nothing
+    // to sync. The setting reaches here anyway because every schema key
+    // also reads from `PNPM_CONFIG_*`, and a script that already ran and
+    // succeeded must not fail the run over it.
     let Some(workspace_dir) = opts.workspace_dir else {
-        return Err(SyncInjectedDepsError::NoWorkspaceDir);
+        tracing::debug!(
+            target: "pacquet::sync_injected_deps",
+            pkg_root_dir = ?opts.pkg_root_dir,
+            "Skipping sync of injected dependencies because there is no workspace",
+        );
+        return Ok(());
     };
 
     let pkg_root_dir = workspace_dir.join(opts.pkg_root_dir);

--- a/pnpm/crates/injected-deps-syncer/src/lib.rs
+++ b/pnpm/crates/injected-deps-syncer/src/lib.rs
@@ -1,0 +1,181 @@
+//! Refresh every injected copy of a workspace package.
+//!
+//! An injected dependency is materialized as a tree of hardlinks into
+//! the virtual store. A build script that rewrites the source package
+//! writes new inodes, which the copies do not share, so after such a
+//! script the copies have to be diffed against the source and patched
+//! in place. `syncInjectedDepsAfterScripts` names the scripts that
+//! should trigger it.
+
+mod dir_patcher;
+
+pub use dir_patcher::{
+    Change, DirDiff, DirPatcher, InodeMap, PatchError, Value, apply_patch, diff_dir,
+    extend_files_map,
+};
+
+use derive_more::{Display, Error};
+use miette::Diagnostic;
+use pacquet_cmd_shim::{LinkBinsError, PackageBinSource, link_bins, link_bins_of_packages};
+use pacquet_modules_yaml::{ReadModulesError, read_modules_manifest};
+use pacquet_package_manifest::{PackageManifestError, safe_read_package_json_from_dir};
+use pacquet_workspace::{
+    FindWorkspaceProjectsError, FindWorkspaceProjectsOpts, find_workspace_projects_no_check,
+};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+/// Error type for [`sync_injected_deps`].
+#[derive(Debug, Display, Error, Diagnostic)]
+pub enum SyncInjectedDepsError {
+    #[display("Cannot update injected dependencies without workspace dir")]
+    #[diagnostic(code(ERR_PNPM_NO_WORKSPACE_DIR))]
+    NoWorkspaceDir,
+
+    #[display("Failed to read the modules manifest: {error}")]
+    #[diagnostic(code(ERR_PNPM_INJECTED_DEPS_SYNC_READ_MODULES))]
+    ReadModules {
+        #[error(source)]
+        error: ReadModulesError,
+    },
+
+    #[display("Failed to read the manifest of {dir:?}: {error}")]
+    #[diagnostic(code(ERR_PNPM_INJECTED_DEPS_SYNC_READ_MANIFEST))]
+    ReadManifest {
+        dir: PathBuf,
+        #[error(source)]
+        error: PackageManifestError,
+    },
+
+    #[display("Failed to enumerate the workspace projects: {error}")]
+    #[diagnostic(code(ERR_PNPM_INJECTED_DEPS_SYNC_FIND_PROJECTS))]
+    FindProjects {
+        #[error(source)]
+        error: FindWorkspaceProjectsError,
+    },
+
+    #[display("{_0}")]
+    #[diagnostic(transparent)]
+    Patch(PatchError),
+
+    #[display("{_0}")]
+    #[diagnostic(transparent)]
+    LinkBins(LinkBinsError),
+}
+
+/// Which package to sync, and where its workspace lives.
+pub struct SyncInjectedDeps<'a> {
+    /// A package without a name cannot be a dependency, so there is
+    /// nothing to sync.
+    pub pkg_name: Option<&'a str>,
+    pub pkg_root_dir: &'a Path,
+    pub workspace_dir: Option<&'a Path>,
+}
+
+/// Bring every injected copy of `pkg_root_dir` back in step with it.
+pub fn sync_injected_deps(opts: &SyncInjectedDeps<'_>) -> Result<(), SyncInjectedDepsError> {
+    if opts.pkg_name.is_none() {
+        tracing::debug!(
+            target: "pacquet::sync_injected_deps",
+            pkg_root_dir = ?opts.pkg_root_dir,
+            "Skipping sync as an injected dependency because, without a name, it cannot be a dependency",
+        );
+        return Ok(());
+    }
+    let Some(workspace_dir) = opts.workspace_dir else {
+        return Err(SyncInjectedDepsError::NoWorkspaceDir);
+    };
+
+    let pkg_root_dir = workspace_dir.join(opts.pkg_root_dir);
+    let modules =
+        read_modules_manifest::<pacquet_modules_yaml::Host>(&workspace_dir.join("node_modules"))
+            .map_err(|error| SyncInjectedDepsError::ReadModules { error })?;
+    let Some(injected_deps) = modules.as_ref().and_then(|modules| modules.injected_deps.as_ref())
+    else {
+        tracing::debug!(
+            target: "pacquet::sync_injected_deps",
+            "Skipping sync of injected dependencies because none were detected",
+        );
+        return Ok(());
+    };
+
+    let injected_dep_key = injected_dep_key(workspace_dir, &pkg_root_dir);
+    let Some(target_dirs) = injected_deps.get(&injected_dep_key).filter(|dirs| !dirs.is_empty())
+    else {
+        tracing::debug!(
+            target: "pacquet::sync_injected_deps",
+            pkg_root_dir = ?opts.pkg_root_dir,
+            "There are no injected dependencies from this package",
+        );
+        return Ok(());
+    };
+
+    let resolved_targets: Vec<PathBuf> =
+        target_dirs.iter().map(|target_dir| workspace_dir.join(target_dir)).collect();
+    for patcher in DirPatcher::from_multiple_targets(&pkg_root_dir, &resolved_targets)
+        .map_err(SyncInjectedDepsError::Patch)?
+    {
+        patcher.apply().map_err(SyncInjectedDepsError::Patch)?;
+    }
+
+    sync_bin_links(&pkg_root_dir, &resolved_targets, workspace_dir)
+}
+
+/// The key `.modules.yaml` files an injected dependency under: the
+/// package's path relative to the workspace root, with forward slashes
+/// on every host.
+fn injected_dep_key(workspace_dir: &Path, pkg_root_dir: &Path) -> String {
+    pacquet_fs::relative_path(workspace_dir, pkg_root_dir).to_string_lossy().replace('\\', "/")
+}
+
+/// Re-link the bins of a package whose files just changed: a build
+/// script can add, remove, or rewrite a bin, and the shims in the
+/// consuming projects have to follow.
+fn sync_bin_links(
+    pkg_root_dir: &Path,
+    resolved_targets: &[PathBuf],
+    workspace_dir: &Path,
+) -> Result<(), SyncInjectedDepsError> {
+    let manifest = safe_read_package_json_from_dir(pkg_root_dir).map_err(|error| {
+        SyncInjectedDepsError::ReadManifest { dir: pkg_root_dir.to_path_buf(), error }
+    })?;
+    let has_bin_and_name = manifest
+        .as_ref()
+        .is_some_and(|manifest| manifest.get("bin").is_some() && manifest.get("name").is_some());
+    if !has_bin_and_name {
+        return Ok(());
+    }
+    let manifest = Arc::new(manifest.expect("checked above"));
+
+    for target_dir in resolved_targets {
+        let Some(parent_modules_dir) = target_dir.parent() else {
+            continue;
+        };
+        let packages = [PackageBinSource::new(target_dir.clone(), Arc::clone(&manifest))];
+        link_bins_of_packages::<pacquet_cmd_shim::Host>(
+            &packages,
+            &parent_modules_dir.join(".bin"),
+            &[],
+        )
+        .map_err(SyncInjectedDepsError::LinkBins)?;
+    }
+
+    // Any project in the workspace may consume the injected package, so
+    // every project's bin directory is refreshed rather than only the
+    // ones this sync touched.
+    let projects =
+        find_workspace_projects_no_check(workspace_dir, &FindWorkspaceProjectsOpts::default())
+            .map_err(|error| SyncInjectedDepsError::FindProjects { error })?;
+    for project in projects {
+        let project_modules_dir = project.root_dir.join("node_modules");
+        link_bins::<pacquet_cmd_shim::Host>(
+            &project_modules_dir,
+            &project_modules_dir.join(".bin"),
+            &[],
+        )
+        .map_err(SyncInjectedDepsError::LinkBins)?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Brings `syncInjectedDepsAfterScripts` to pacquet. The TypeScript CLI has honored the setting since it grew it; pacquet recognized the config key in `config_types.rs` and did nothing else with it, so a build script in a workspace package left every injected copy of that package stale until the next install.

An injected dependency is materialized as a tree of hardlinks into the virtual store. A build script that *replaces* a file — or adds or deletes one — writes inodes the copies do not share, so the copies have to be re-diffed against the source and patched in place. (A script that rewrites a file *in place* propagates through the hardlink on its own; that is why the tests below assert on a file the script creates rather than one it overwrites.)

**What landed**

- A new `pacquet-injected-deps-syncer` crate. It reads the source and each target with the same `DirectoryFetcher` flags the installer uses for injected deps (`include_only_package_files: false, resolve_symlinks: false, allow_path_escape: false`), expands both into inode maps, diffs them, and patches each target.
- `Config::sync_injected_deps_after_scripts`, wired from `pnpm-workspace.yaml` and `PNPM_CONFIG_SYNC_INJECTED_DEPS_AFTER_SCRIPTS`.
- A call in `run_stages`, placed after the `post<name>` stage so it is reached only when every stage succeeded — the same condition as the TypeScript call site, where a failing `runLifecycleHook` throws before the sync.

**Design notes**

- The inode map is a `BTreeMap`, which gets the ordering the patcher needs for free: a directory's path is a strict prefix of everything beneath it, so an ancestor always sorts before its descendants. The TypeScript side sorts explicitly with `comparePaths` because JS objects do not order.
- `apply_patch` is sequential rather than concurrent. The TypeScript implementation runs its three phases under `Promise.all`, which is where its ordering hazards came from; doing the phases in sequence makes the invariants trivially hold.
- Removals run **before** the changes. Writing the sequential version surfaced this: when the source turns a directory into a file of the same name, that path is a change while its old children are removals, and patching the change first leaves the removals hitting `ENOTDIR`. Under `Promise.all` the TypeScript side has the same hazard as a timing-dependent race — see the note below.
- The two crates that this one builds on each define their own `Host` capability provider, and no single type implements both trait families. Since every test here uses a real `TempDir` fixture, the DI seam would not have earned its keep, so `sync_injected_deps` is not generic and uses each crate's own `Host` internally — per the gating rule in `pnpm/AGENTS.md`.
- Skipping an inode that cannot be hardlinked (a FIFO, a socket, a device), and clearing one that blocks a target, mirror pnpm/pnpm#13663.

**Parity**

This is the pacquet half of a setting the TypeScript CLI already implements, so there is no matching TypeScript change to make. One follow-up worth its own PR: `applyPatch` in `@pnpm/workspace.injected-deps-syncer` still runs its removals concurrently with its changes, so the `ENOTDIR` failure this PR fixes deterministically exists there as a latent race. I flagged it while reviewing pnpm/pnpm#13663 and left it alone rather than swallow `ENOTDIR` without a test that could provoke it; the ordering fix used here is the better shape for it.

**Tests**

- Seven unit tests over the patcher: ancestor expansion, skipping a real FIFO, replacing a skipped inode the target holds, leaving a skipped inode of the target's own alone, the file↔directory transition, removal of what the source dropped, and inode sharing with the source.
- Two end-to-end tests in `crates/cli/tests/suite/`: a listed script refreshes every injected copy, and an unlisted one leaves them alone. Together they pin the gate — the first fails if the sync never fires, the second if it always does.

## Squash Commit Body

```text
An injected dependency is materialized as a tree of hardlinks into the
virtual store, so a build script that rewrites its source package leaves
every copy pointing at the old inodes. The TypeScript CLI has taken
syncInjectedDepsAfterScripts since it grew the setting; pacquet
recognized the config key and did nothing with it.

Add the crate that does the work. It walks the source and each target
with the same directory fetcher the installer uses, diffs the two into
inode maps, and patches each target: removals first, then directories
shallowest-first, then the hardlinks. An inode that cannot be
hardlinked — a FIFO, a socket, a device — is left out of the map, and a
target holding one is cleared and retried rather than failing the sync.
Bins are re-linked afterwards, since a build script can add or drop one.

pnpm run calls it after a script whose name the setting lists, and only
when the script succeeded, matching the TypeScript call site.

Removals run before the changes, which the sequential implementation
forced into the open: when the source turns a directory into a file of
the same name, that path is a change while its old children are
removals, and patching the change first leaves the removals hitting
ENOTDIR. The TypeScript applyPatch runs the two concurrently and has the
same hazard as a latent race; fixing it there is a separate PR.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5[1m]).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789051478&installation_model_id=426870&pr_number=13834&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13834&signature=bfb9f7e4563661167370d9c10a1383e6579fc85f258850990e4985a26d197915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `syncInjectedDepsAfterScripts`, refreshing injected dependency copies after configured scripts complete successfully.
  * Added configuration through workspace settings and the `PNPM_CONFIG_SYNC_INJECTED_DEPS_AFTER_SCRIPTS` environment variable.
  * Synchronization now updates generated files and package links across affected workspace projects.

* **Tests**
  * Added coverage for configured and unlisted scripts, non-workspace projects using environment-based configuration, and synchronization edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->