### PR TITLE
fix(resolver): settle children ownership one level at a time

### DIFF
--- a/.changeset/level-synchronous-children-ownership.md
+++ b/.changeset/level-synchronous-children-ownership.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed dependency resolution letting the order in which concurrent resolutions finished decide the outcome. When one package was reached from several places, whichever occurrence got there first decided the versions its dependencies were recorded at, so repeated installs of the same project could produce different `pnpm-lock.yaml` files.

--- a/pnpm/crates/resolving-deps-resolver/Cargo.toml
+++ b/pnpm/crates/resolving-deps-resolver/Cargo.toml
@@ -40,7 +40,7 @@ async-trait       = { workspace = true }
 node-semver       = { workspace = true }
 pretty_assertions = { workspace = true }
 tempfile          = { workspace = true }
-tokio             = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio             = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
 
 [lints]
 workspace = true

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -39,7 +39,7 @@ pub(crate) use workspace_ctx::SyncCursor;
 
 use reuse::{ReuseSource, record_direct_dep_versions};
 use walk::{
-    NodeSeed, level_aliases, level_versions, resolve_node_seed, walk_node_children,
+    NodeSeed, level_aliases, level_versions, resolve_node_seed, walk_from_seeds,
     warm_children_resolutions,
 };
 
@@ -586,24 +586,10 @@ where
         direct_versions,
     );
     let children_pkg_aliases = parent_pkg_aliases.extend(level_aliases(&seeds));
-    // Phase 2: walk each direct dep's children with the level overlay.
-    let results = seeds
-        .into_iter()
-        .map(|seed| {
-            let overlay = children_overlay.clone();
-            let pkg_aliases = Arc::clone(&children_pkg_aliases);
-            async move {
-                match seed {
-                    NodeSeed::Done(dep) => Ok(dep),
-                    NodeSeed::Pending(pending) => {
-                        walk_node_children(ctx, resolver, *pending, overlay, pkg_aliases).await
-                    }
-                }
-            }
-        })
-        .pipe(future::try_join_all)
-        .await?;
-    let direct: Vec<DirectDep> = results.into_iter().flatten().collect();
+    // Phase 2: settle this level's children ownership and walk the tree
+    // below it a level at a time.
+    let direct =
+        walk_from_seeds(ctx, resolver, seeds, children_overlay, children_pkg_aliases).await?;
     ctx.workspace.record_preferred_version_roots(direct.iter().map(|dep| dep.id.as_str()));
     // Second bump, after every write of this wave (including the roots
     // above) has landed: a `run_preferred_versions` read racing with

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/reuse.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/reuse.rs
@@ -229,10 +229,8 @@ pub(super) fn node_depends_on_changed_direct_dep(
 /// The highest resolved direct-dependency version of `name` strictly
 /// above `pinned` that still satisfies `range`, or `None`. Anchored to
 /// direct deps (the deterministic, resolved-before-the-walk signal).
-/// `direct_versions` is the importer's snapshot, taken once per walk by
-/// [`fn@walk_node_children`].
-///
-/// [`fn@walk_node_children`]: super::walk::walk_node_children
+/// `direct_versions` is the importer's snapshot, taken once per walked
+/// occurrence as it seeds its children.
 pub(super) fn higher_direct_dep_version(
     direct_versions: Option<&DirectDepVersions>,
     name: &str,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/reuse.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/reuse.rs
@@ -366,20 +366,21 @@ pub(crate) fn unwrap_package_name<'a>(
     }
 }
 
-/// Resolve the *real* package name a [`WantedDependency`] targets — the
-/// name update targeting matches against, not the local install alias,
-/// which an `npm:` alias or a `jsr:` specifier can differ from. The
-/// picker and the lockfile snapshots key on this name.
+/// Resolve the *real* package name an `(alias, bare_specifier)` edge
+/// targets — the name update targeting matches against, not the local
+/// install alias, which an `npm:` alias or a `jsr:` specifier can
+/// differ from. The picker and the lockfile snapshots key on this name.
 /// `walk::overlay_lookup_names` builds its candidate set from it.
 ///
 /// `None` when no name can be recovered; the caller reads that as "not
 /// a targeted update", since update targets are keyed by package name.
-pub(super) fn real_package_name_of(wanted: &WantedDependency) -> Option<Cow<'_, str>> {
-    let bare = wanted.bare_specifier.as_deref()?;
+pub(super) fn real_package_name_of<'edge>(
+    alias: Option<&'edge str>,
+    bare_specifier: Option<&'edge str>,
+) -> Option<Cow<'edge, str>> {
+    let bare = bare_specifier?;
     if let Some(rest) = bare.strip_prefix("npm:") {
-        let alias_keeps_name = wanted
-            .alias
-            .as_deref()
+        let alias_keeps_name = alias
             .is_some_and(|alias| !alias.is_empty() && rest.parse::<node_semver::Range>().is_ok());
         if !alias_keeps_name {
             let last_at =
@@ -392,15 +393,12 @@ pub(super) fn real_package_name_of(wanted: &WantedDependency) -> Option<Cow<'_, 
         }
     }
     if bare.starts_with("jsr:") {
-        let spec = pacquet_resolving_jsr_specifier_parser::parse_jsr_specifier(
-            bare,
-            wanted.alias.as_deref(),
-        )
-        .ok()
-        .flatten()?;
+        let spec = pacquet_resolving_jsr_specifier_parser::parse_jsr_specifier(bare, alias)
+            .ok()
+            .flatten()?;
         return Some(Cow::Owned(spec.npm_pkg_name));
     }
-    wanted.alias.as_deref().map(Cow::Borrowed)
+    alias.map(Cow::Borrowed)
 }
 
 /// Whether `wanted` is one of the packages the user asked to update,
@@ -419,7 +417,8 @@ pub(super) fn is_update_target(
     match scope.reuse {
         UpdateReuseScope::All | UpdateReuseScope::None => false,
         UpdateReuseScope::Except(_) => {
-            real_package_name_of(wanted).is_some_and(|n| update_excludes(scope, n.as_ref(), depth))
+            real_package_name_of(wanted.alias.as_deref(), wanted.bare_specifier.as_deref())
+                .is_some_and(|name| update_excludes(scope, name.as_ref(), depth))
         }
     }
 }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/reuse/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/reuse/tests.rs
@@ -59,34 +59,24 @@ mod higher_direct_dep_version {
 }
 
 mod real_package_name_of {
-    use pacquet_resolving_resolver_base::WantedDependency;
-
     use super::super::real_package_name_of;
-
-    fn wanted(alias: Option<&str>, bare_specifier: Option<&str>) -> WantedDependency {
-        WantedDependency {
-            alias: alias.map(str::to_string),
-            bare_specifier: bare_specifier.map(str::to_string),
-            ..WantedDependency::default()
-        }
-    }
 
     #[test]
     fn returns_none_when_bare_specifier_is_missing() {
-        assert_eq!(real_package_name_of(&wanted(Some("foo"), None)).as_deref(), None);
+        assert_eq!(real_package_name_of(Some("foo"), None).as_deref(), None);
     }
 
     #[test]
     fn falls_back_to_alias_for_plain_dep() {
         assert_eq!(
-            real_package_name_of(&wanted(Some("foo"), Some("^1.0.0"))).as_deref(),
+            real_package_name_of(Some("foo"), Some("^1.0.0")).as_deref(),
             Some("foo"),
         );
     }
 
     #[test]
     fn falls_back_to_none_when_alias_is_missing_for_plain_dep() {
-        assert_eq!(real_package_name_of(&wanted(None, Some("^1.0.0"))).as_deref(), None);
+        assert_eq!(real_package_name_of(None, Some("^1.0.0")).as_deref(), None);
     }
 
     #[test]
@@ -94,7 +84,7 @@ mod real_package_name_of {
         // Update targeting is keyed by the real name (matches the depPath
         // recorded in the lockfile, not the install alias).
         assert_eq!(
-            real_package_name_of(&wanted(Some("foo"), Some("npm:bar@^4"))).as_deref(),
+            real_package_name_of(Some("foo"), Some("npm:bar@^4")).as_deref(),
             Some("bar"),
         );
     }
@@ -102,7 +92,7 @@ mod real_package_name_of {
     #[test]
     fn parses_real_name_from_npm_alias_without_version() {
         assert_eq!(
-            real_package_name_of(&wanted(Some("foo"), Some("npm:bar"))).as_deref(),
+            real_package_name_of(Some("foo"), Some("npm:bar")).as_deref(),
             Some("bar"),
         );
     }
@@ -113,7 +103,7 @@ mod real_package_name_of {
         // guard skips it and the search finds the `@` separating name
         // from version.
         assert_eq!(
-            real_package_name_of(&wanted(Some("foo"), Some("npm:@scope/pkg@^4"))).as_deref(),
+            real_package_name_of(Some("foo"), Some("npm:@scope/pkg@^4")).as_deref(),
             Some("@scope/pkg"),
         );
     }
@@ -123,7 +113,7 @@ mod real_package_name_of {
         // Only one `@` (the scope marker) at index 0, which the
         // `idx >= 1` guard skips — the whole `rest` is the name.
         assert_eq!(
-            real_package_name_of(&wanted(Some("foo"), Some("npm:@scope/pkg"))).as_deref(),
+            real_package_name_of(Some("foo"), Some("npm:@scope/pkg")).as_deref(),
             Some("@scope/pkg"),
         );
     }
@@ -132,7 +122,7 @@ mod real_package_name_of {
     fn returns_none_for_empty_npm_alias_target() {
         // Defensive: filtered out so the caller treats this as "not a
         // targeted update."
-        assert_eq!(real_package_name_of(&wanted(Some("foo"), Some("npm:"))).as_deref(), None);
+        assert_eq!(real_package_name_of(Some("foo"), Some("npm:")).as_deref(), None);
     }
 
     #[test]
@@ -142,7 +132,7 @@ mod real_package_name_of {
         // name — without this branch, the range string itself would
         // be returned as the name and update targeting would miss.
         assert_eq!(
-            real_package_name_of(&wanted(Some("foo"), Some("npm:^1.0.0"))).as_deref(),
+            real_package_name_of(Some("foo"), Some("npm:^1.0.0")).as_deref(),
             Some("foo"),
         );
     }
@@ -152,7 +142,7 @@ mod real_package_name_of {
         // The `npm:<range>` form supports any valid semver range in
         // the body — `>=1.0.0 <2.0.0`, `~1.2.3`, `1.x`, etc.
         assert_eq!(
-            real_package_name_of(&wanted(Some("foo"), Some("npm:>=1.0.0 <2.0.0"))).as_deref(),
+            real_package_name_of(Some("foo"), Some("npm:>=1.0.0 <2.0.0")).as_deref(),
             Some("foo"),
         );
     }
@@ -165,7 +155,7 @@ mod real_package_name_of {
         // folded name, not the original jsr name, or jsr deps would
         // never count as update targets.
         assert_eq!(
-            real_package_name_of(&wanted(Some("foo"), Some("jsr:@foo/bar@^1"))).as_deref(),
+            real_package_name_of(Some("foo"), Some("jsr:@foo/bar@^1")).as_deref(),
             Some("@jsr/foo__bar"),
         );
     }
@@ -174,7 +164,7 @@ mod real_package_name_of {
     fn folds_jsr_specifier_to_npm_registry_name_without_version() {
         // Default-tag form `jsr:@foo/bar`: still folds to `@jsr/foo__bar`.
         assert_eq!(
-            real_package_name_of(&wanted(Some("foo"), Some("jsr:@foo/bar"))).as_deref(),
+            real_package_name_of(Some("foo"), Some("jsr:@foo/bar")).as_deref(),
             Some("@jsr/foo__bar"),
         );
     }
@@ -186,7 +176,7 @@ mod real_package_name_of {
         // jsr dep could match an update target by alias and wrongly be
         // treated as one.
         assert_eq!(
-            real_package_name_of(&wanted(Some("foo"), Some("jsr:foo@^1.0.0"))).as_deref(),
+            real_package_name_of(Some("foo"), Some("jsr:foo@^1.0.0")).as_deref(),
             None,
         );
     }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/reuse/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/reuse/tests.rs
@@ -68,10 +68,7 @@ mod real_package_name_of {
 
     #[test]
     fn falls_back_to_alias_for_plain_dep() {
-        assert_eq!(
-            real_package_name_of(Some("foo"), Some("^1.0.0")).as_deref(),
-            Some("foo"),
-        );
+        assert_eq!(real_package_name_of(Some("foo"), Some("^1.0.0")).as_deref(), Some("foo"));
     }
 
     #[test]
@@ -83,18 +80,12 @@ mod real_package_name_of {
     fn parses_real_name_from_npm_alias_with_version_range() {
         // Update targeting is keyed by the real name (matches the depPath
         // recorded in the lockfile, not the install alias).
-        assert_eq!(
-            real_package_name_of(Some("foo"), Some("npm:bar@^4")).as_deref(),
-            Some("bar"),
-        );
+        assert_eq!(real_package_name_of(Some("foo"), Some("npm:bar@^4")).as_deref(), Some("bar"));
     }
 
     #[test]
     fn parses_real_name_from_npm_alias_without_version() {
-        assert_eq!(
-            real_package_name_of(Some("foo"), Some("npm:bar")).as_deref(),
-            Some("bar"),
-        );
+        assert_eq!(real_package_name_of(Some("foo"), Some("npm:bar")).as_deref(), Some("bar"));
     }
 
     #[test]
@@ -131,10 +122,7 @@ mod real_package_name_of {
         // not a name. The install alias `foo` is the real package
         // name — without this branch, the range string itself would
         // be returned as the name and update targeting would miss.
-        assert_eq!(
-            real_package_name_of(Some("foo"), Some("npm:^1.0.0")).as_deref(),
-            Some("foo"),
-        );
+        assert_eq!(real_package_name_of(Some("foo"), Some("npm:^1.0.0")).as_deref(), Some("foo"));
     }
 
     #[test]
@@ -175,10 +163,7 @@ mod real_package_name_of {
         // must not fall back to the install alias — otherwise a broken
         // jsr dep could match an update target by alias and wrongly be
         // treated as one.
-        assert_eq!(
-            real_package_name_of(Some("foo"), Some("jsr:foo@^1.0.0")).as_deref(),
-            None,
-        );
+        assert_eq!(real_package_name_of(Some("foo"), Some("jsr:foo@^1.0.0")).as_deref(), None);
     }
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
@@ -285,19 +285,23 @@ where
     let overlay_versions: Vec<(String, Vec<String>)> = pick_overlay
         .as_ref()
         .map(|overlay| {
-            let mut view: Vec<(String, Vec<String>)> = overlay_lookup_names(&wanted)
-                .into_iter()
-                .filter_map(|name| {
-                    let mut versions: Vec<String> =
-                        overlay.versions_for(&name).into_iter().map(str::to_string).collect();
-                    if versions.is_empty() {
-                        return None;
-                    }
-                    versions.sort_unstable();
-                    versions.dedup();
-                    Some((name, versions))
-                })
-                .collect();
+            let mut view: Vec<(String, Vec<String>)> = overlay_lookup_names(
+                wanted.alias.as_deref(),
+                wanted.bare_specifier.as_deref(),
+            )
+            .into_iter()
+            .flatten()
+            .filter_map(|name| {
+                let mut versions: Vec<String> =
+                    overlay.versions_for(&name).into_iter().map(str::to_string).collect();
+                if versions.is_empty() {
+                    return None;
+                }
+                versions.sort_unstable();
+                versions.dedup();
+                Some((name.into_owned(), versions))
+            })
+            .collect();
             view.sort_unstable();
             view
         })
@@ -814,19 +818,18 @@ fn landed_on_prior_entry(prior_key: &PkgNameVerPeer, resolved_pkg_id: &str) -> b
 /// `jsr:` specifier) — mirroring the name derivation in the npm
 /// resolver's `parse_bare_specifier`, which keys its overlay merge by
 /// the resolved `spec.name` rather than the outer alias.
-fn overlay_lookup_names(wanted: &WantedDependency) -> Vec<String> {
-    let mut names: Vec<String> = Vec::new();
-    if let Some(alias) = wanted.alias.as_deref()
-        && !alias.is_empty()
-    {
-        names.push(alias.to_string());
-    }
-    if let Some(real_name) = real_package_name_of(wanted)
-        && !names.iter().any(|name| name == real_name.as_ref())
-    {
-        names.push(real_name.into_owned());
-    }
-    names
+///
+/// Borrowed and slot-shaped rather than a `Vec<String>`: every edge of
+/// every walked package asks for these, and the overwhelming majority
+/// resolve to one borrowed alias.
+fn overlay_lookup_names<'edge>(
+    alias: Option<&'edge str>,
+    bare_specifier: Option<&'edge str>,
+) -> [Option<Cow<'edge, str>>; 2] {
+    let alias = alias.filter(|alias| !alias.is_empty());
+    let real_name = real_package_name_of(alias, bare_specifier)
+        .filter(|real_name| alias.is_none_or(|alias| alias != real_name.as_ref()));
+    [alias.map(Cow::Borrowed), real_name]
 }
 
 /// Look the wanted edge up in the per-wanted dedup cache or run the

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
@@ -1,9 +1,10 @@
 //! The fresh-resolve walk: seeding one edge's package
-//! ([`fn@resolve_node_seed`]), walking its children
-//! ([`fn@walk_node_children`]), and the per-wanted resolve cache both
-//! go through. The two phases are separate so a whole sibling level
-//! resolves before any of its subtrees start, letting the level's
-//! versions seed the children's preferred-versions overlay.
+//! ([`fn@resolve_node_seed`]), seeding a settled occurrence's children
+//! ([`fn@seed_node_children`]), and the per-wanted resolve cache both
+//! go through. Seeding and settling are separate phases so a whole
+//! depth level resolves before any of it is settled — which is what
+//! makes children ownership, and with it the lockfile, independent of
+//! the order concurrent subtrees finish in ([`fn@walk_from_seeds`]).
 
 use async_recursion::async_recursion;
 use futures_util::future;
@@ -43,15 +44,15 @@ use super::{
     },
     workspace_ctx::{
         ChildSpec, ChildrenOwnerClaim, RecordedChildrenContext, WantedKey, claim_children_owner,
-        insert_tree_node, is_current_children_owner, lazy_children, make_non_owner_nodes_lazy,
-        record_children, recorded_children_match, register_peer_dep_names,
-        remember_node_parent_ids,
+        claim_children_warmup, insert_tree_node, is_current_children_owner, lazy_children,
+        make_non_owner_nodes_lazy, record_children, recorded_children_match,
+        register_peer_dep_names, remember_node_parent_ids,
     },
 };
 
 /// Resolve one `(alias, range)` edge end-to-end with no
 /// preferred-versions overlay: [`fn@resolve_node_seed`] then
-/// [`fn@walk_node_children`]. Used where per-level preference folding
+/// [`fn@walk_from_seeds`]. Used where per-level preference folding
 /// does not apply — the lockfile-reuse subtree walk, whose versions
 /// are exact pins.
 ///
@@ -80,7 +81,7 @@ where
     Chain: Resolver + ?Sized,
 {
     let base_overlay = ctx.base_opts.preferred_versions_overlay.clone();
-    match resolve_node_seed(
+    let seed = resolve_node_seed(
         ctx,
         resolver,
         wanted,
@@ -92,35 +93,27 @@ where
         None,
         parent_pkg_aliases,
     )
-    .await?
-    {
-        NodeSeed::Done(dep) => Ok(dep),
-        NodeSeed::Pending(pending) => {
-            walk_node_children(
-                ctx,
-                resolver,
-                *pending,
-                base_overlay,
-                Arc::clone(parent_pkg_aliases),
-            )
-            .await
-        }
-    }
+    .await?;
+    let direct =
+        walk_from_seeds(ctx, resolver, vec![seed], base_overlay, Arc::clone(parent_pkg_aliases))
+            .await?;
+    Ok(direct.into_iter().next())
 }
 
 /// Outcome of [`fn@resolve_node_seed`]: either the edge completed
 /// without a children walk (lockfile reuse, cycle break), or the
-/// package resolved and its children walk is still pending — the
-/// caller runs it via [`fn@walk_node_children`] once every sibling
-/// seed settled, so the children's resolution sees the whole level's
+/// package resolved and its children are still pending — the level
+/// settles which occurrence of it walks them, and only then does that
+/// one seed its children, so their resolution sees the whole level's
 /// versions in its preferred-versions overlay.
 pub(super) enum NodeSeed {
     Done(Option<DirectDep>),
     Pending(Box<PendingNode>),
 }
 
-/// A resolved-but-not-walked node: everything
-/// [`fn@walk_node_children`] needs to recurse into the children.
+/// A resolved-but-not-settled node: everything the level settlement
+/// needs to decide whether this occurrence walks the package's
+/// children, and [`fn@seed_node_children`] needs to seed them.
 pub(super) struct PendingNode {
     result: Arc<pacquet_resolving_resolver_base::ResolveResult>,
     id: String,
@@ -129,12 +122,19 @@ pub(super) struct PendingNode {
     is_link: bool,
     parent_ancestors: Arc<Vec<String>>,
     next_ancestors: Arc<Vec<String>>,
-    /// The deterministic children-ownership claim taken at seed time;
-    /// the walk phase re-checks it before recording the children, so
-    /// a better-placed occurrence seeded after this one still wins.
-    /// It also carries the peer-shadowed dependency names the walk
-    /// phase filters this package's children by.
-    children_owner: ChildrenOwnerClaim,
+    /// The dependency names this occurrence's own `peerDependencies`
+    /// shadow. Ownership of the package's children is settled across
+    /// the whole level once it has seeded (see
+    /// [`fn@assign_level_owners`]), and the winner's set is the one
+    /// that filters the children and splits the envelope's peers.
+    ///
+    /// Readable up to that settlement only: settling moves the winner's
+    /// set onto its claim and leaves this one empty. The speculative
+    /// child prewarm reads it while the level is still seeding.
+    peer_shadowed: HashSet<String>,
+    /// The claim [`fn@assign_level_owners`] settled for this
+    /// occurrence, once its level has seeded in full.
+    claim: Option<ChildrenOwnerClaim>,
     depth: i32,
     current_is_optional: bool,
     /// The edge's recorded snapshot key in the prior lockfile, if
@@ -207,7 +207,7 @@ where
     //
     // Stale-pin refresh: a node depending on a changed direct dep is
     // resolved fresh rather than reused, so its children walk against
-    // their manifest ranges where `walk_node_children` can redirect a
+    // their manifest ranges where `seed_node_children` can redirect a
     // stale pin onto the higher direct-dep version (reusing the subtree
     // would keep the pin, leaving the lockfile non-convergent).
     if reuse.allows_reuse()
@@ -285,23 +285,21 @@ where
     let overlay_versions: Vec<(String, Vec<String>)> = pick_overlay
         .as_ref()
         .map(|overlay| {
-            let mut view: Vec<(String, Vec<String>)> = overlay_lookup_names(
-                wanted.alias.as_deref(),
-                wanted.bare_specifier.as_deref(),
-            )
-            .into_iter()
-            .flatten()
-            .filter_map(|name| {
-                let mut versions: Vec<String> =
-                    overlay.versions_for(&name).into_iter().map(str::to_string).collect();
-                if versions.is_empty() {
-                    return None;
-                }
-                versions.sort_unstable();
-                versions.dedup();
-                Some((name.into_owned(), versions))
-            })
-            .collect();
+            let mut view: Vec<(String, Vec<String>)> =
+                overlay_lookup_names(wanted.alias.as_deref(), wanted.bare_specifier.as_deref())
+                    .into_iter()
+                    .flatten()
+                    .filter_map(|name| {
+                        let mut versions: Vec<String> =
+                            overlay.versions_for(&name).into_iter().map(str::to_string).collect();
+                        if versions.is_empty() {
+                            return None;
+                        }
+                        versions.sort_unstable();
+                        versions.dedup();
+                        Some((name.into_owned(), versions))
+                    })
+                    .collect();
             view.sort_unstable();
             view
         })
@@ -435,39 +433,25 @@ where
     let is_leaf = is_link || pkg_is_leaf(&result);
     let node_id = if is_leaf { NodeId::leaf(&id) } else { NodeId::next() };
 
-    // The claim is taken while holding the `packages` lock so claims and
-    // envelope writes stay in the same order: an occurrence that lost the
-    // claim in between would otherwise leave its peer set on an envelope
-    // whose children the winning occurrence walked.
-    let mut packages = lock_recoverable(&ctx.workspace.packages);
-    let children_owner = claim_children_owner(
-        ctx,
-        &id,
-        depth,
-        ancestor_ids,
-        peer_shadowed_dependencies(
-            result.manifest.as_deref(),
-            parent_pkg_aliases,
-            ctx.workspace.auto_install_peers,
-        ),
+    let peer_shadowed = peer_shadowed_dependencies(
+        result.manifest.as_deref(),
+        parent_pkg_aliases,
+        ctx.workspace.auto_install_peers,
     );
-    let peer_dependencies = if is_link {
-        BTreeMap::new()
-    } else {
-        extract_peer_dependencies(&result, &children_owner.peer_shadowed)
-    };
+    // The envelope's peer split follows the occurrence that owns the
+    // package's children, which this level's settlement decides — see
+    // [`fn@install_owner_peer_dependencies`]. Seeding only has to fill
+    // a package nothing has resolved yet.
+    let mut packages = lock_recoverable(&ctx.workspace.packages);
     let package_is_new = if let Some(existing) = packages.get_mut(&id) {
         existing.optional = existing.optional && current_is_optional;
-        // A fresh claim can shadow a different set of dependencies than
-        // the occurrence that populated the envelope did, which moves
-        // names between the package's children and its peers.
-        if children_owner.owns_children && existing.peer_dependencies != peer_dependencies {
-            register_peer_dep_names(ctx, &peer_dependencies);
-            existing.peer_dependencies = peer_dependencies;
-            ctx.workspace.record_package_write(&id);
-        }
         false
     } else {
+        let peer_dependencies = if is_link {
+            BTreeMap::new()
+        } else {
+            extract_peer_dependencies(&result, &peer_shadowed)
+        };
         register_peer_dep_names(ctx, &peer_dependencies);
         ctx.workspace.record_package_write(&id);
         packages.insert(
@@ -500,7 +484,8 @@ where
         is_link,
         parent_ancestors: Arc::clone(ancestor_ids),
         next_ancestors,
-        children_owner,
+        peer_shadowed,
+        claim: None,
         depth,
         current_is_optional,
         prior_key,
@@ -528,258 +513,448 @@ pub(super) fn node_alias(
         .unwrap_or_else(|| id.to_string())
 }
 
-/// Walk a seeded node's children. `children_overlay` is the preferred-versions
-/// overlay covering this node's own level (built by the caller from
-/// every sibling seed); the grandchildren's overlay layers this
-/// node's resolved children on top, extending the per-level fold.
-/// `children_pkg_aliases` follows the same shape: the caller folds this
-/// node's whole level into the scope, and the grandchildren's scope
-/// layers this node's resolved children on top.
-///
-/// Only the deterministic children owner walks this package's
-/// manifest children. Other occurrences stay lazy and expand from
-/// `children_by_id`, applying their own `parent_ids` cycle break.
-#[async_recursion]
-pub(super) async fn walk_node_children<Chain>(
-    ctx: &TreeCtx,
-    resolver: &Chain,
-    pending: PendingNode,
+/// One occurrence whose children the walk still has to seed, with the
+/// scope they resolve in: `children_overlay` is the preferred-versions
+/// overlay covering the occurrence's own level (the caller folds every
+/// sibling of that level into it), and `children_pkg_aliases` the
+/// alias scope that level installs.
+struct FrontierNode {
+    pending: Box<PendingNode>,
+    claim: ChildrenOwnerClaim,
     children_overlay: Option<Arc<PreferredVersionsOverlay>>,
     children_pkg_aliases: Arc<ParentPkgAliases>,
-) -> Result<Option<DirectDep>, ResolveDependencyTreeError>
+}
+
+/// A frontier node that has seeded its children — what settling the
+/// level needs to record its edges and to hand the children that own
+/// their own packages on to the next level.
+struct SeededNode {
+    node: FrontierNode,
+    child_specs: Arc<Vec<ChildSpec>>,
+    seeds: Vec<NodeSeed>,
+    grandchild_overlay: Option<Arc<PreferredVersionsOverlay>>,
+    grandchild_pkg_aliases: Arc<ParentPkgAliases>,
+}
+
+/// Walk `seeds` and everything below them, one depth level at a time,
+/// and report the seeds' own edges back to the caller.
+///
+/// A level is seeded in full before any of it is settled, so every
+/// occurrence of a package at that depth is in hand when the package's
+/// children ownership is decided ([`fn@assign_level_owners`]).
+/// Ownership then never passes to an occurrence seeded later, and the
+/// children each package records stop depending on which subtree
+/// happened to reach it first — the arrival-order dependence behind
+/// <https://github.com/pnpm/pnpm/issues/13685>. It is also why no
+/// occurrence ever re-walks a package another one recorded, which the
+/// exponential blowup of <https://github.com/pnpm/pnpm/issues/13574>
+/// made the alternative to.
+#[async_recursion]
+pub(super) async fn walk_from_seeds<Chain>(
+    ctx: &TreeCtx,
+    resolver: &Chain,
+    mut seeds: Vec<NodeSeed>,
+    children_overlay: Option<Arc<PreferredVersionsOverlay>>,
+    children_pkg_aliases: Arc<ParentPkgAliases>,
+) -> Result<Vec<DirectDep>, ResolveDependencyTreeError>
 where
     Chain: Resolver + ?Sized,
 {
-    let PendingNode {
-        result,
-        id,
-        alias,
-        node_id,
-        is_link,
-        parent_ancestors,
-        next_ancestors,
-        children_owner,
-        depth,
-        current_is_optional,
-        prior_key,
-    } = pending;
-    // Built on demand: a linked node and a losing occurrence never
-    // reach either the reuse test or the recording.
-    let children_context = || RecordedChildrenContext {
-        peer_shadowed: Arc::clone(&children_owner.peer_shadowed),
-        prior_key: prior_key.clone(),
-        update_active: !matches!(ctx.update_reuse_scope(), super::UpdateReuseScope::All),
-    };
-    let (children, others_stale) = if is_link {
-        // Linked nodes don't walk their manifest's deps — see the
-        // `is_link` comment block above. They get an empty `Realized`
-        // map: a linked node has no children of its own here.
-        (crate::resolved_tree::TreeChildren::Realized(BTreeMap::new()), false)
-    } else if !children_owner.owns_children {
-        (lazy_children(&parent_ancestors), false)
-    } else if !resolves_children_through_catalogs(&result)
-        && recorded_children_match(ctx, &id, &children_context())
-    {
-        // A winning claim means this occurrence outranks the one that
-        // recorded the children, not that the children differ.
-        // Occurrences of one package race for the claim, so walking on
-        // every win costs a redundant subtree walk and a second set of
-        // occurrence nodes per race — enough, down a peer-carrying
-        // chain, to expand exponentially with its depth
-        // (https://github.com/pnpm/pnpm/issues/13574).
-        (lazy_children(&parent_ancestors), false)
-    } else {
-        // Look up cached children specs first; only walk the manifest on
-        // a miss. The cache value is held by `Arc` so revisits clone the
-        // refcount instead of the inner `Vec<(String, String, bool)>`.
-        let child_specs = {
-            let cache = lock_recoverable(&ctx.workspace.children_specs_by_id);
-            cache.get(&id).map(Arc::clone)
-        };
-        let child_specs = if let Some(specs) = child_specs {
-            specs
-        } else {
-            let specs = Arc::new(extract_children(&result)?);
-            lock_recoverable(&ctx.workspace.children_specs_by_id)
-                .entry(id.clone())
-                .or_insert_with(|| Arc::clone(&specs));
-            specs
-        };
-        // The specs are cached unfiltered because which of them the
-        // package's own `peerDependencies` shadow is a property of the
-        // owner occurrence, not of the manifest.
-        let peer_shadowed = &children_owner.peer_shadowed;
-        let child_specs: Cow<'_, [ChildSpec]> = if peer_shadowed.is_empty() {
-            Cow::Borrowed(child_specs.as_slice())
-        } else {
-            Cow::Owned(
-                child_specs
-                    .iter()
-                    .filter(|(name, _, optional)| *optional || !peer_shadowed.contains(name))
-                    .cloned()
-                    .collect(),
-            )
-        };
-        let child_specs =
-            if result.resolved_via == "workspace" && result.id.as_str().starts_with("file:") {
-                Cow::Owned(
-                    child_specs
-                        .iter()
-                        .map(|(name, range, optional)| {
-                            resolve_catalog_specifier(name.clone(), range.clone(), &ctx.catalogs)
-                                .map(|(name, range)| (name, range, *optional))
-                        })
-                        .collect::<Result<Vec<_>, _>>()?,
-                )
-            } else {
-                child_specs
-            };
-        // An *updated* parent (one that landed on a different version
-        // than the lockfile recorded, or a new dep) discards its
-        // `resolvedDependencies` child refs, forcing its subtree to
-        // re-resolve. A parent that freshly resolved but landed back on
-        // its previously recorded version keeps the prior child refs
-        // alive (pnpm's non-`parentPkg.updated` arm), and each child
-        // edge re-enters the reuse gate with its recorded key — so a
-        // still-satisfied subtree is reused rather than re-resolved.
-        // Re-resolving those children would re-pick open ranges (`*`)
-        // at their newest versions and churn the lockfile.
-        let prior_children_snapshot = prior_key
-            .as_ref()
-            .filter(|key| landed_on_prior_entry(key, &id))
-            .and_then(|key| ctx.workspace.wanted_lockfile.as_ref()?.snapshots.as_ref()?.get(key));
-        // Phase 1: resolve every child package before any grandchild
-        // walk starts, so the level's resolved versions can feed the
-        // grandchildren's preferred-versions overlay — the
-        // postponed-resolution barrier.
-        // Snapshot this importer's direct-dep versions once for the whole
-        // child fanout instead of locking per edge.
-        let direct_versions = lock_recoverable(&ctx.workspace.direct_dep_versions)
-            .get(&ctx.importer_id)
-            .map(Arc::clone);
-        let declaring_dir = declaring_manifest_dir(ctx, &result);
-        let child_seeds = child_specs
-            .iter()
-            .map(|(child_name, child_range, child_optional)| {
-                let mut child_wanted = WantedDependency {
-                    alias: Some(child_name.clone()),
-                    bare_specifier: Some(child_range.clone()),
-                    optional: Some(*child_optional),
-                    ..WantedDependency::default()
-                };
-                let mut child_prior = prior_children_snapshot
-                    .and_then(|snapshot| prior_child_key(snapshot, child_name, child_range));
-                // Stale-pin refresh: force the edge onto a higher in-range
-                // direct-dep version instead of reusing the pin, so the
-                // pinned version is never resolved or fetched.
-                let forced_version = child_prior
-                    .as_ref()
-                    .and_then(|key| key.suffix.version_semver().cloned())
-                    .zip(child_range.parse::<node_semver::Range>().ok())
-                    .and_then(|(pinned, range)| {
-                        higher_direct_dep_version(
-                            direct_versions.as_deref(),
-                            child_name,
-                            &pinned,
-                            &range,
-                        )
-                    });
-                if let Some(higher) = forced_version {
-                    child_wanted.bare_specifier = Some(higher.to_string());
-                    child_prior = None;
-                }
-                let next_ancestors = Arc::clone(&next_ancestors);
-                let pick_overlay = children_overlay.clone();
-                let declaring_dir = declaring_dir.clone();
-                let parent_pkg_aliases = &children_pkg_aliases;
-                async move {
-                    let seed = resolve_node_seed(
-                        ctx,
-                        resolver,
-                        child_wanted,
-                        &next_ancestors,
-                        depth + 1,
-                        current_is_optional,
-                        ReuseSource::Transitive { key: child_prior },
-                        pick_overlay,
-                        declaring_dir.as_deref(),
-                        parent_pkg_aliases,
-                    )
-                    .await?;
-                    warm_children_resolutions(ctx, resolver, &seed).await;
-                    Ok::<NodeSeed, ResolveDependencyTreeError>(seed)
-                }
-            })
-            .pipe(future::try_join_all)
-            .await?;
-        let grandchild_overlay = PreferredVersionsOverlay::layer(
-            children_overlay.clone(),
-            level_versions(ctx, &child_seeds),
-        );
-        let grandchild_pkg_aliases = children_pkg_aliases.extend(level_aliases(&child_seeds));
-        // Phase 2: walk each child's own children with the extended
-        // overlay.
-        let child_results = child_seeds
+    assign_level_owners(ctx, seeds.iter_mut());
+    let direct: Vec<DirectDep> = seeds.iter().filter_map(seeded_dep).collect();
+    let mut frontier = settle_seeds(ctx, seeds, children_overlay.as_ref(), &children_pkg_aliases);
+    while !frontier.is_empty() {
+        let seeded = frontier
             .into_iter()
-            .map(|seed| {
-                let overlay = grandchild_overlay.clone();
-                let pkg_aliases = Arc::clone(&grandchild_pkg_aliases);
-                async move {
-                    match seed {
-                        NodeSeed::Done(dep) => Ok(dep),
-                        NodeSeed::Pending(pending) => {
-                            walk_node_children(ctx, resolver, *pending, overlay, pkg_aliases).await
-                        }
-                    }
-                }
-            })
+            .map(|node| seed_node_children(ctx, resolver, node))
             .pipe(future::try_join_all)
             .await?;
-        if is_current_children_owner(ctx, &id, &children_owner.owner) {
-            // Build the realized `(alias → NodeId)` map for THIS
-            // occurrence and the per-pkg `children_by_id` entry future
-            // revisits will reuse. `children_by_id` records the resolved
-            // child pkg ids (not NodeIds) plus the `optional` flag so
-            // lazy realisation can thread `current_is_optional` correctly.
-            let mut realized: BTreeMap<String, NodeId> = BTreeMap::new();
-            let mut by_id: Vec<crate::resolved_tree::ChildEdge> = Vec::new();
-            let optional_by_alias: HashMap<&str, bool> =
-                child_specs.iter().map(|(name, _, optional)| (name.as_str(), *optional)).collect();
-            for dep in child_results.into_iter().flatten() {
-                let optional = optional_by_alias.get(dep.alias.as_str()).copied().unwrap_or(false);
-                by_id.push(crate::resolved_tree::ChildEdge {
-                    alias: dep.alias.clone(),
-                    pkg_id: dep.id.clone(),
-                    optional,
-                });
-                realized.insert(dep.alias, dep.node_id);
-            }
-            record_children(ctx, &id, &children_owner.owner, by_id, children_context())
-                .into_children(realized, &parent_ancestors)
-        } else {
-            (lazy_children(&parent_ancestors), false)
-        }
-    };
-
-    // Repeat-visit leaves collapse onto one tree node; keep the
-    // shallowest depth seen so downstream consumers that read
-    // `tree_node.depth` (the peer pass folds it onto the graph node's
-    // `depth`) take the minimum across visits.
-    // Per-occurrence counter ids are unique by construction, so the
-    // `and_modify` arm is dead for non-leaves.
-    // Linked nodes carry `depth = -1` so the peer-resolution pass
-    // short-circuits them in `resolve_node`.
-    let node_depth = if is_link { -1 } else { depth };
-    remember_node_parent_ids(ctx, &node_id, parent_ancestors);
-    insert_tree_node(ctx, node_id.clone(), &id, children, node_depth);
-    if children_owner.owns_children
-        && (others_stale || !children_owner.children_context_unchanged)
-        && is_current_children_owner(ctx, &id, &children_owner.owner)
-    {
-        make_non_owner_nodes_lazy(ctx, &id, &node_id);
+        frontier = settle_level(ctx, seeded);
     }
+    Ok(direct)
+}
 
-    Ok(Some(DirectDep { alias, node_id, id }))
+/// Settle children ownership across every occurrence one level seeded.
+///
+/// The ownership rank is `(update policy, depth, importer order,
+/// parent path)` and a level shares the first three, so the
+/// best-placed occurrence of a package is the one whose parent path
+/// sorts first. Only that one claims: the losers cannot win against a
+/// standing owner either, since they do not even outrank their own
+/// level's winner.
+fn assign_level_owners<'seed>(ctx: &TreeCtx, seeds: impl Iterator<Item = &'seed mut NodeSeed>) {
+    // Linked nodes resolve their dependencies as their own importer,
+    // so they never own children here.
+    let mut level: Vec<&mut Box<PendingNode>> = seeds
+        .filter_map(|seed| match seed {
+            NodeSeed::Pending(pending) if !pending.is_link => Some(pending),
+            _ => None,
+        })
+        .collect();
+    let winners: Vec<usize> = {
+        let mut best: HashMap<&str, usize> = HashMap::default();
+        for (index, pending) in level.iter().enumerate() {
+            let best_so_far = *best.entry(pending.id.as_str()).or_insert(index);
+            let standing = &level[best_so_far];
+            // Depth joins the comparison even though one level shares
+            // it, so this cannot drift from [`ChildrenOwner::wins_over`]
+            // if a frontier ever carries more than one depth.
+            if (standing.depth, &standing.parent_ancestors)
+                > (pending.depth, &pending.parent_ancestors)
+            {
+                best.insert(pending.id.as_str(), index);
+            }
+        }
+        let mut winners: Vec<usize> = best.into_values().collect();
+        winners.sort_unstable();
+        winners
+    };
+    for index in winners {
+        let pending = &mut *level[index];
+        let peer_shadowed = std::mem::take(&mut pending.peer_shadowed);
+        let claim = claim_children_owner(
+            ctx,
+            &pending.id,
+            pending.depth,
+            &pending.parent_ancestors,
+            peer_shadowed,
+        );
+        install_owner_peer_dependencies(ctx, pending, &claim);
+        pending.claim = Some(claim);
+    }
+}
+
+/// Split the package's envelope into children and peers the way its
+/// children owner reads its manifest. Which of a package's
+/// dependencies its own `peerDependencies` shadow follows from the
+/// scope the occurrence resolved in, so a package first seeded by one
+/// occurrence and owned by another has to be re-split.
+fn install_owner_peer_dependencies(
+    ctx: &TreeCtx,
+    pending: &PendingNode,
+    claim: &ChildrenOwnerClaim,
+) {
+    if pending.is_link || !claim.owns_children {
+        return;
+    }
+    let peer_dependencies = extract_peer_dependencies(&pending.result, &claim.peer_shadowed);
+    let mut packages = lock_recoverable(&ctx.workspace.packages);
+    let Some(existing) = packages.get_mut(&pending.id) else { return };
+    if existing.peer_dependencies == peer_dependencies {
+        return;
+    }
+    existing.peer_dependencies = peer_dependencies.clone();
+    drop(packages);
+    register_peer_dep_names(ctx, &peer_dependencies);
+    ctx.workspace.record_package_write(&pending.id);
+}
+
+/// Give every occurrence of a settled level its tree node, and collect
+/// the ones that still have to walk children of their own.
+///
+/// An occurrence walks only when it owns its package's children and
+/// nothing has recorded them under its context; every other one reads
+/// them from the owner's recording, under its own `parent_ids` cycle
+/// break.
+fn settle_seeds(
+    ctx: &TreeCtx,
+    seeds: Vec<NodeSeed>,
+    children_overlay: Option<&Arc<PreferredVersionsOverlay>>,
+    children_pkg_aliases: &Arc<ParentPkgAliases>,
+) -> Vec<FrontierNode> {
+    let mut frontier = Vec::new();
+    for seed in seeds {
+        let NodeSeed::Pending(mut pending) = seed else { continue };
+        let claim = pending.claim.take();
+        // Linked nodes don't walk their manifest's deps — see the
+        // `is_link` comment block in [`fn@resolve_node_seed`]. They get
+        // an empty `Realized` map: a linked node has no children of its
+        // own here.
+        if pending.is_link {
+            insert_walked_node(
+                ctx,
+                &pending,
+                crate::resolved_tree::TreeChildren::Realized(BTreeMap::new()),
+            );
+            continue;
+        }
+        let Some(claim) = claim.filter(|claim| claim.owns_children) else {
+            let children = lazy_children(&pending.parent_ancestors);
+            insert_walked_node(ctx, &pending, children);
+            continue;
+        };
+        if !resolves_children_through_catalogs(&pending.result)
+            && recorded_children_match(ctx, &pending.id, &children_context(ctx, &pending, &claim))
+        {
+            let children = lazy_children(&pending.parent_ancestors);
+            insert_walked_node(ctx, &pending, children);
+            continue;
+        }
+        frontier.push(FrontierNode {
+            pending,
+            claim,
+            children_overlay: children_overlay.cloned(),
+            children_pkg_aliases: Arc::clone(children_pkg_aliases),
+        });
+    }
+    frontier
+}
+
+/// Record what each occurrence of a seeded level resolved for its
+/// children, and settle that level's own seeds into the next frontier.
+fn settle_level(ctx: &TreeCtx, mut seeded: Vec<SeededNode>) -> Vec<FrontierNode> {
+    assign_level_owners(ctx, seeded.iter_mut().flat_map(|node| node.seeds.iter_mut()));
+    let mut frontier = Vec::new();
+    for node in seeded {
+        let SeededNode {
+            node: FrontierNode { pending, claim, .. },
+            child_specs,
+            seeds,
+            grandchild_overlay,
+            grandchild_pkg_aliases,
+        } = node;
+        let (children, others_stale) =
+            record_walked_children(ctx, &pending, &claim, &child_specs, &seeds);
+        insert_walked_node(ctx, &pending, children);
+        if (others_stale || !claim.children_context_unchanged)
+            && is_current_children_owner(ctx, &pending.id, &claim.owner)
+        {
+            make_non_owner_nodes_lazy(ctx, &pending.id, &pending.node_id);
+        }
+        frontier.extend(settle_seeds(
+            ctx,
+            seeds,
+            grandchild_overlay.as_ref(),
+            &grandchild_pkg_aliases,
+        ));
+    }
+    frontier
+}
+
+/// Publish the child edges one occurrence resolved, and report the
+/// children to hang on its own tree node.
+///
+/// `children_by_id` records the resolved child pkg ids (not `NodeIds`)
+/// plus the `optional` flag so lazy realisation can thread
+/// `current_is_optional` correctly; the occurrence's own node keeps the
+/// realized `(alias → NodeId)` map.
+fn record_walked_children(
+    ctx: &TreeCtx,
+    pending: &PendingNode,
+    claim: &ChildrenOwnerClaim,
+    child_specs: &[ChildSpec],
+    seeds: &[NodeSeed],
+) -> (crate::resolved_tree::TreeChildren, bool) {
+    if !is_current_children_owner(ctx, &pending.id, &claim.owner) {
+        return (lazy_children(&pending.parent_ancestors), false);
+    }
+    let optional_by_alias: HashMap<&str, bool> =
+        child_specs.iter().map(|(name, _, optional)| (name.as_str(), *optional)).collect();
+    let mut realized: BTreeMap<String, NodeId> = BTreeMap::new();
+    let mut by_id: Vec<crate::resolved_tree::ChildEdge> = Vec::new();
+    for dep in seeds.iter().filter_map(seeded_dep) {
+        let optional = optional_by_alias.get(dep.alias.as_str()).copied().unwrap_or(false);
+        by_id.push(crate::resolved_tree::ChildEdge {
+            alias: dep.alias.clone(),
+            pkg_id: dep.id,
+            optional,
+        });
+        realized.insert(dep.alias, dep.node_id);
+    }
+    record_children(ctx, &pending.id, &claim.owner, by_id, children_context(ctx, pending, claim))
+        .into_children(realized, &pending.parent_ancestors)
+}
+
+/// The edge one seed contributes to its parent's children. `None` for
+/// a seed the walk dropped — a cycle re-entry or a skipped optional.
+fn seeded_dep(seed: &NodeSeed) -> Option<DirectDep> {
+    match seed {
+        NodeSeed::Done(dep) => dep.clone(),
+        NodeSeed::Pending(pending) => Some(DirectDep {
+            alias: pending.alias.clone(),
+            node_id: pending.node_id.clone(),
+            id: pending.id.clone(),
+        }),
+    }
+}
+
+/// What a walk resolved its children under, which a later occurrence
+/// compares its own against before reading them.
+fn children_context(
+    ctx: &TreeCtx,
+    pending: &PendingNode,
+    claim: &ChildrenOwnerClaim,
+) -> RecordedChildrenContext {
+    RecordedChildrenContext {
+        peer_shadowed: Arc::clone(&claim.peer_shadowed),
+        prior_key: pending.prior_key.clone(),
+        update_active: !matches!(ctx.update_reuse_scope(), super::UpdateReuseScope::All),
+    }
+}
+
+/// Record an occurrence in the shared tree.
+///
+/// Repeat-visit leaves collapse onto one tree node; keep the
+/// shallowest depth seen so downstream consumers that read
+/// `tree_node.depth` (the peer pass folds it onto the graph node's
+/// `depth`) take the minimum across visits. Per-occurrence counter ids
+/// are unique by construction, so that only ever fires for leaves.
+/// Linked nodes carry `depth = -1` so the peer-resolution pass
+/// short-circuits them.
+fn insert_walked_node(
+    ctx: &TreeCtx,
+    pending: &PendingNode,
+    children: crate::resolved_tree::TreeChildren,
+) {
+    let depth = if pending.is_link { -1 } else { pending.depth };
+    remember_node_parent_ids(ctx, &pending.node_id, Arc::clone(&pending.parent_ancestors));
+    insert_tree_node(ctx, pending.node_id.clone(), &pending.id, children, depth);
+}
+
+/// Seed every child edge of one occurrence — its manifest's
+/// dependencies less the names its own `peerDependencies` shadow, with
+/// a workspace project's catalog specifiers resolved — and derive the
+/// scope its grandchildren will resolve in.
+///
+/// The whole level seeds before any of it settles, so this resolves
+/// packages and takes no ownership: [`fn@assign_level_owners`] does
+/// that once every occurrence of the level is in.
+#[async_recursion]
+async fn seed_node_children<Chain>(
+    ctx: &TreeCtx,
+    resolver: &Chain,
+    node: FrontierNode,
+) -> Result<SeededNode, ResolveDependencyTreeError>
+where
+    Chain: Resolver + ?Sized,
+{
+    let FrontierNode { pending, claim, children_overlay, children_pkg_aliases } = node;
+    // Look up cached children specs first; only read the manifest on a
+    // miss. The cache value is held by `Arc` so revisits clone the
+    // refcount instead of the inner `Vec<(String, String, bool)>`, and
+    // it is cached unfiltered because which of the specs the package's
+    // own `peerDependencies` shadow is a property of the owner
+    // occurrence, not of the manifest.
+    let cached = lock_recoverable(&ctx.workspace.children_specs_by_id).get(&pending.id).cloned();
+    let child_specs = if let Some(specs) = cached {
+        specs
+    } else {
+        let specs = Arc::new(extract_children(&pending.result)?);
+        lock_recoverable(&ctx.workspace.children_specs_by_id)
+            .entry(pending.id.clone())
+            .or_insert_with(|| Arc::clone(&specs));
+        specs
+    };
+    let peer_shadowed = &claim.peer_shadowed;
+    let child_specs = if peer_shadowed.is_empty() {
+        child_specs
+    } else {
+        child_specs
+            .iter()
+            .filter(|(name, _, optional)| *optional || !peer_shadowed.contains(name))
+            .cloned()
+            .collect::<Vec<ChildSpec>>()
+            .pipe(Arc::new)
+    };
+    let child_specs = if resolves_children_through_catalogs(&pending.result) {
+        child_specs
+            .iter()
+            .map(|(name, range, optional)| {
+                resolve_catalog_specifier(name.clone(), range.clone(), &ctx.catalogs)
+                    .map(|(name, range)| (name, range, *optional))
+            })
+            .collect::<Result<Vec<ChildSpec>, ResolveDependencyTreeError>>()?
+            .pipe(Arc::new)
+    } else {
+        child_specs
+    };
+    // An *updated* parent (one that landed on a different version than
+    // the lockfile recorded, or a new dep) discards its
+    // `resolvedDependencies` child refs, forcing its subtree to
+    // re-resolve. A parent that freshly resolved but landed back on its
+    // previously recorded version keeps the prior child refs alive
+    // (pnpm's non-`parentPkg.updated` arm), and each child edge
+    // re-enters the reuse gate with its recorded key — so a
+    // still-satisfied subtree is reused rather than re-resolved.
+    // Re-resolving those children would re-pick open ranges (`*`) at
+    // their newest versions and churn the lockfile.
+    let prior_children_snapshot = pending
+        .prior_key
+        .as_ref()
+        .filter(|key| landed_on_prior_entry(key, &pending.id))
+        .and_then(|key| ctx.workspace.wanted_lockfile.as_ref()?.snapshots.as_ref()?.get(key));
+    // Snapshot this importer's direct-dep versions once for the whole
+    // child fanout instead of locking per edge.
+    let direct_versions =
+        lock_recoverable(&ctx.workspace.direct_dep_versions).get(&ctx.importer_id).map(Arc::clone);
+    let declaring_dir = declaring_manifest_dir(ctx, &pending.result);
+    let child_depth = pending.depth + 1;
+    let child_optional_parent = pending.current_is_optional;
+    let next_ancestors = Arc::clone(&pending.next_ancestors);
+    let seeds = child_specs
+        .iter()
+        .map(|(child_name, child_range, child_optional)| {
+            let mut child_wanted = WantedDependency {
+                alias: Some(child_name.clone()),
+                bare_specifier: Some(child_range.clone()),
+                optional: Some(*child_optional),
+                ..WantedDependency::default()
+            };
+            let mut child_prior = prior_children_snapshot
+                .and_then(|snapshot| prior_child_key(snapshot, child_name, child_range));
+            // Stale-pin refresh: force the edge onto a higher in-range
+            // direct-dep version instead of reusing the pin, so the
+            // pinned version is never resolved or fetched.
+            let forced_version = child_prior
+                .as_ref()
+                .and_then(|key| key.suffix.version_semver().cloned())
+                .zip(child_range.parse::<node_semver::Range>().ok())
+                .and_then(|(pinned, range)| {
+                    higher_direct_dep_version(
+                        direct_versions.as_deref(),
+                        child_name,
+                        &pinned,
+                        &range,
+                    )
+                });
+            if let Some(higher) = forced_version {
+                child_wanted.bare_specifier = Some(higher.to_string());
+                child_prior = None;
+            }
+            let next_ancestors = Arc::clone(&next_ancestors);
+            let pick_overlay = children_overlay.clone();
+            let declaring_dir = declaring_dir.clone();
+            let parent_pkg_aliases = &children_pkg_aliases;
+            async move {
+                let seed = resolve_node_seed(
+                    ctx,
+                    resolver,
+                    child_wanted,
+                    &next_ancestors,
+                    child_depth,
+                    child_optional_parent,
+                    ReuseSource::Transitive { key: child_prior },
+                    pick_overlay,
+                    declaring_dir.as_deref(),
+                    parent_pkg_aliases,
+                )
+                .await?;
+                warm_children_resolutions(ctx, resolver, &seed).await;
+                Ok::<NodeSeed, ResolveDependencyTreeError>(seed)
+            }
+        })
+        .pipe(future::try_join_all)
+        .await?;
+    let grandchild_overlay =
+        PreferredVersionsOverlay::layer(children_overlay.clone(), level_versions(ctx, &seeds));
+    let grandchild_pkg_aliases = children_pkg_aliases.extend(level_aliases(&seeds));
+    Ok(SeededNode {
+        node: FrontierNode { pending, claim, children_overlay, children_pkg_aliases },
+        child_specs,
+        seeds,
+        grandchild_overlay,
+        grandchild_pkg_aliases,
+    })
 }
 
 /// Whether the `parent → child` edge closes a dependency cycle's
@@ -1024,7 +1199,7 @@ pub(super) async fn warm_children_resolutions<Chain>(
         return;
     }
     let NodeSeed::Pending(pending) = seed else { return };
-    if pending.is_link || !pending.children_owner.owns_children {
+    if pending.is_link || !claim_children_warmup(ctx, &pending.id) {
         return;
     }
     let Ok(specs) = extract_children(&pending.result) else { return };
@@ -1032,9 +1207,7 @@ pub(super) async fn warm_children_resolutions<Chain>(
     let declaring_dir = declaring_manifest_dir(ctx, &pending.result);
     specs
         .iter()
-        .filter(|(name, _, optional)| {
-            *optional || !pending.children_owner.peer_shadowed.contains(name)
-        })
+        .filter(|(name, _, optional)| *optional || !pending.peer_shadowed.contains(name))
         .map(|(name, range, optional)| {
             let wanted = WantedDependency {
                 alias: Some(name.clone()),

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
@@ -240,6 +240,12 @@ pub struct WorkspaceTreeCtx {
     pub(super) resolved_by_wanted:
         Mutex<HashMap<WantedKey, Arc<pacquet_resolving_resolver_base::ResolveResult>>>,
     pub(super) children_specs_by_id: Mutex<HashMap<String, Arc<Vec<ChildSpec>>>>,
+    /// Package ids whose children have already been speculatively
+    /// resolved. A package is warmed once, however many occurrences of
+    /// it a level seeds — see [`fn@warm_children_resolutions`].
+    ///
+    /// [`fn@warm_children_resolutions`]: super::walk::warm_children_resolutions
+    warmed_children_by_id: Mutex<HashSet<String>>,
     pub(super) children_by_id: Mutex<HashMap<String, RecordedChildren>>,
     children_owner_by_id: Mutex<HashMap<String, ChildrenOwnerEntry>>,
     node_parent_ids_by_id: Mutex<HashMap<NodeId, Arc<Vec<String>>>>,
@@ -471,6 +477,7 @@ impl Default for WorkspaceTreeCtx {
             applied_patches: Mutex::new(HashSet::default()),
             resolved_by_wanted: Mutex::new(HashMap::default()),
             children_specs_by_id: Mutex::new(HashMap::default()),
+            warmed_children_by_id: Mutex::new(HashSet::default()),
             children_by_id: Mutex::new(HashMap::default()),
             children_owner_by_id: Mutex::new(HashMap::default()),
             node_parent_ids_by_id: Mutex::new(HashMap::default()),
@@ -1273,6 +1280,17 @@ pub(super) fn claim_children_owner(
         }
     }
     ChildrenOwnerClaim { owner, owns_children, peer_shadowed, children_context_unchanged }
+}
+
+/// Whether this occurrence is the first to offer to warm its package's
+/// children, so the speculative resolutions run once per package
+/// rather than once per occurrence of it.
+pub(super) fn claim_children_warmup(ctx: &TreeCtx, pkg_id: &str) -> bool {
+    let mut warmed = lock_recoverable(&ctx.workspace.warmed_children_by_id);
+    // Every occurrence of a package offers, and all but the first are
+    // turned away, so the owned key is built only for the one that
+    // takes the warmup.
+    !warmed.contains(pkg_id) && warmed.insert(pkg_id.to_string())
 }
 
 /// Whether this package's recorded children were resolved under

--- a/pnpm/crates/resolving-deps-resolver/src/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/tests.rs
@@ -77,6 +77,249 @@ impl Resolver for DelayedAliasResolver {
     }
 }
 
+/// Stub resolver fed from a `name` → versions table, picking the way
+/// the npm resolver does: the highest version the range admits, except
+/// that a version the walk's preferred-versions overlay carries wins
+/// over it. Lets a test vary one edge's pick by the level it resolves
+/// under. `delayed` holds back one `(alias, range)` edge, so the
+/// occurrence behind it reaches a shared package second.
+struct OverlayPickResolver {
+    versions: HashMap<String, Vec<ResolveResult>>,
+    delayed: (String, String),
+}
+
+impl Resolver for OverlayPickResolver {
+    fn resolve<'a>(
+        &'a self,
+        wanted: &'a WantedDependency,
+        opts: &'a ResolveOptions,
+    ) -> ResolveFuture<'a> {
+        let name = wanted.alias.clone().unwrap_or_default();
+        let bare = wanted.bare_specifier.clone().unwrap_or_default();
+        let range = node_semver::Range::from_str(&bare).expect("test range");
+        let preferred: Vec<&str> = opts
+            .preferred_versions_overlay
+            .as_ref()
+            .map(|overlay| overlay.versions_for(&name))
+            .unwrap_or_default();
+        let satisfying: Vec<&ResolveResult> = self
+            .versions
+            .get(&name)
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+            .iter()
+            .filter(|result| {
+                result.name_ver.as_ref().is_some_and(|name_ver| range.satisfies(&name_ver.suffix))
+            })
+            .collect();
+        let highest = |from: Vec<&ResolveResult>| {
+            from.into_iter()
+                .max_by(|left, right| {
+                    version_of(left).partial_cmp(version_of(right)).expect("comparable versions")
+                })
+                .cloned()
+        };
+        let result = highest(
+            satisfying
+                .iter()
+                .copied()
+                .filter(|result| preferred.contains(&version_of(result).to_string().as_str()))
+                .collect(),
+        )
+        .or_else(|| highest(satisfying));
+        let delayed = (name, bare) == self.delayed;
+        Box::pin(async move {
+            if delayed {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            Ok::<_, ResolveError>(result)
+        })
+    }
+
+    fn resolve_latest<'a>(
+        &'a self,
+        _query: &'a LatestQuery,
+        _opts: &'a ResolveOptions,
+    ) -> ResolveLatestFuture<'a> {
+        Box::pin(async { Ok(None) })
+    }
+}
+
+fn version_of(result: &ResolveResult) -> &node_semver::Version {
+    &result.name_ver.as_ref().expect("test result carries a name and version").suffix
+}
+
+/// The versions table both settlement tests resolve against: `pin` in
+/// two versions, and a `shared` package whose own `pin` edge the level
+/// it is reached from decides.
+fn settlement_versions(
+    extra: impl IntoIterator<Item = (String, Vec<ResolveResult>)>,
+) -> HashMap<String, Vec<ResolveResult>> {
+    let mut versions: HashMap<String, Vec<ResolveResult>> = HashMap::from_iter([
+        (
+            "shared".to_string(),
+            vec![fake_result(
+                "shared",
+                "1.0.0",
+                serde_json::json!({
+                    "name": "shared",
+                    "version": "1.0.0",
+                    "dependencies": { "pin": "^1.0.0" }
+                }),
+            )],
+        ),
+        (
+            "pin".to_string(),
+            vec![
+                fake_result(
+                    "pin",
+                    "1.0.0",
+                    serde_json::json!({ "name": "pin", "version": "1.0.0" }),
+                ),
+                fake_result(
+                    "pin",
+                    "1.5.0",
+                    serde_json::json!({ "name": "pin", "version": "1.5.0" }),
+                ),
+            ],
+        ),
+    ]);
+    versions.extend(extra);
+    versions
+}
+
+fn dependency_result(name: &str, dependencies: &serde_json::Value) -> (String, Vec<ResolveResult>) {
+    (
+        name.to_string(),
+        vec![fake_result(
+            name,
+            "1.0.0",
+            serde_json::json!({ "name": name, "version": "1.0.0", "dependencies": dependencies }),
+        )],
+    )
+}
+
+async fn resolve_settlement_tree(
+    resolver: &OverlayPickResolver,
+    root_deps: serde_json::Value,
+) -> crate::ResolvedTree {
+    let (_tmp, manifest) = fake_manifest(root_deps);
+    resolve_dependency_tree(
+        resolver,
+        &manifest,
+        [DependencyGroup::Prod],
+        ResolveDependencyTreeOptions {
+            base_opts: ResolveOptions::default(),
+            patched_dependencies: None,
+            manifest_hook: None,
+            overrides_hook: None,
+            pnpmfile_hook: None,
+            read_package_log: None,
+            auto_install_peers: false,
+        },
+    )
+    .await
+    .unwrap()
+}
+
+/// A package's children follow the occurrence that owns them — the
+/// shallowest, here the one under `wrap`, whose level prefers
+/// `pin@1.0.0` — however slowly that occurrence resolves
+/// (<https://github.com/pnpm/pnpm/issues/13685>).
+#[tokio::test(start_paused = true)]
+async fn children_follow_the_shallowest_occurrence_however_late_it_resolves() {
+    let resolver = OverlayPickResolver {
+        versions: settlement_versions([
+            dependency_result("slow", &serde_json::json!({ "wrap": "1.0.0" })),
+            dependency_result("wrap", &serde_json::json!({ "pin": "1.0.0", "shared": "^1.0.0" })),
+            dependency_result("deep", &serde_json::json!({ "mid": "1.0.0" })),
+            dependency_result("mid", &serde_json::json!({ "nested": "1.0.0" })),
+            dependency_result("nested", &serde_json::json!({ "shared": "^1.0.0" })),
+        ]),
+        delayed: ("wrap".to_string(), "1.0.0".to_string()),
+    };
+
+    let tree =
+        resolve_settlement_tree(&resolver, serde_json::json!({ "deep": "1.0.0", "slow": "1.0.0" }))
+            .await;
+
+    let shared_children = tree.children_by_id.get("shared@1.0.0").expect("shared children");
+    assert_eq!(shared_children.len(), 1);
+    assert_eq!(shared_children[0].pkg_id, "pin@1.0.0");
+}
+
+/// The winning occurrence's peer-shadowed set is the one that filters
+/// the package's children: `shared` declares `pin` as both a
+/// dependency and a peer, so the edge survives only where the scope
+/// reaching it cannot supply the peer itself. Down `a-parent`, which
+/// resolves `pin` beside the node that depends on `shared`, it does
+/// not — and `a-parent` sorts first.
+#[tokio::test(start_paused = true)]
+async fn peer_shadowing_follows_the_occurrence_that_wins_the_level() {
+    let shadowing_shared = fake_result(
+        "shared",
+        "1.0.0",
+        serde_json::json!({
+            "name": "shared",
+            "version": "1.0.0",
+            "dependencies": { "pin": "1.0.0" },
+            "peerDependencies": { "pin": "^1.0.0" }
+        }),
+    );
+    // `shared` is reached at the same depth down both paths, and its
+    // own peer-shadowing scope is the level of the parent that reaches
+    // it: only `a-parent`'s level resolves `pin`.
+    let mut versions = settlement_versions([
+        dependency_result("a-parent", &serde_json::json!({ "mid-a": "1.0.0", "pin": "1.0.0" })),
+        dependency_result("mid-a", &serde_json::json!({ "shared": "^1.0.0" })),
+        dependency_result("b-parent", &serde_json::json!({ "mid-b": "1.0.0" })),
+        dependency_result("mid-b", &serde_json::json!({ "shared": "1.0.0" })),
+    ]);
+    versions.insert("shared".to_string(), vec![shadowing_shared]);
+    let resolver =
+        OverlayPickResolver { versions, delayed: ("shared".to_string(), "^1.0.0".to_string()) };
+
+    let tree = resolve_settlement_tree(
+        &resolver,
+        serde_json::json!({ "a-parent": "1.0.0", "b-parent": "1.0.0" }),
+    )
+    .await;
+
+    let shared_children = tree.children_by_id.get("shared@1.0.0").expect("shared children");
+    eprintln!("SHARED CHILDREN:\n{shared_children:#?}\n");
+    assert!(shared_children.is_empty());
+}
+
+/// Occurrences at the same depth are settled by their parent path, so
+/// the one under `a-parent` decides even when the one under `b-parent`
+/// resolves first.
+#[tokio::test(start_paused = true)]
+async fn same_depth_occurrences_are_settled_by_parent_path() {
+    let resolver = OverlayPickResolver {
+        versions: settlement_versions([
+            dependency_result(
+                "a-parent",
+                &serde_json::json!({ "pin": "1.0.0", "shared": "^1.0.0" }),
+            ),
+            dependency_result(
+                "b-parent",
+                &serde_json::json!({ "pin": "1.5.0", "shared": "1.0.0" }),
+            ),
+        ]),
+        delayed: ("shared".to_string(), "^1.0.0".to_string()),
+    };
+
+    let tree = resolve_settlement_tree(
+        &resolver,
+        serde_json::json!({ "a-parent": "1.0.0", "b-parent": "1.0.0" }),
+    )
+    .await;
+
+    let shared_children = tree.children_by_id.get("shared@1.0.0").expect("shared children");
+    assert_eq!(shared_children.len(), 1);
+    assert_eq!(shared_children[0].pkg_id, "pin@1.0.0");
+}
+
 fn fake_result(name: &str, version: &str, manifest: serde_json::Value) -> ResolveResult {
     use pacquet_lockfile::{LockfileResolution, PkgName, PkgNameVer, TarballResolution};
     let name_ver = PkgNameVer::new(


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#13685. **Rewritten** — this no longer resembles pnpm/pnpm#13830 (merged, then reverted in pnpm/pnpm#13833 for a 23% resolve regression). The comments below trace how that approach was measured, found to be both expensive and incomplete, and replaced.

### The bug

Occurrences of a package race to claim its children. Whichever one reaches it while the claim stands vacant walks the package and records what *its own* level's preferred-versions overlay resolved; a better-placed occurrence arriving later keeps that recording rather than walking again — walking on every claim win is what expanded exponentially in pnpm/pnpm#13574. Which occurrence gets there first is thread timing, so identical inputs produced different lockfiles run to run.

### Why the first attempt could not fix it

pnpm/pnpm#13830 made the later occurrence re-walk when its own level offered its child edges different versions. That settles the *recording*, but not which occurrences exist. Traced on the repro, `test-exclude@6.0.0` recorded its children exactly once per run, in the first walk, under a different owner each time:

```
run A: edges=[…, minimatch@3.1.5] parent_path=[…, @teambit/aspect, jest, …, babel-plugin-istanbul]
run B: edges=[…, minimatch@3.0.5] parent_path=[…, @teambit/jest,   jest, …, babel-plugin-istanbul]
```

`@teambit/aspect@1.0.1095` sorts before `@teambit/jest@1.0.1095`, so the first occurrence outranks the second — but in run B it never exists, because an ancestor on that path matched its own recording, stayed lazy, and never walked that subtree. Settling the recording makes the children the answer of the best-ranked occurrence *that got walked*, and the walked set is itself arrival-ordered.

### What this does instead

The walk advances a depth level at a time. A level is seeded in full before any of it is settled, so every occurrence of a package at that depth is in hand when its children ownership is decided. The rank is `(update policy, depth, importer order, parent path)` and a level shares the first three, so the best-placed occurrence is the one whose parent path sorts first — and it is the only one that claims.

Ownership therefore never passes to an occurrence seeded later, no occurrence re-walks children another one recorded, and what a package records stops depending on which subtree reached it first. The recursion in `walk_node_children` becomes a frontier loop (`walk_from_seeds` → `seed_node_children` → `assign_level_owners` → `settle_level`); `resolve_node_seed` no longer claims, since a claim taken at seed time is exactly the arrival-ordered decision being removed.

### Measurements

Repro from the issue (`@teambit/bit@2.0.67`, offline, warm cache), `rm -rf node_modules pnpm-lock.yaml && pnpm install --lockfile-only --ignore-scripts --offline`:

| | lockfiles produced | resolve |
| --- | --- | --- |
| `main` | 3 distinct, over 4 runs | 4.287 s |
| pnpm/pnpm#13830 (reverted) | 2 distinct, over 16 runs | 5.256 s (+23%) |
| this PR | **1, over 46 runs** — every run byte-identical | 4.29 s (±0%) |

`isolated-linker.peer-heavy-resolve.hot-cache.offline` — the scenario that alerted on pnpm/pnpm#13830 — run locally through the integrated-benchmark harness, 20 runs: **467 ms against `main`'s 844 ms**. Settling the level rather than each parent's fanout means a package's children are seeded once instead of once per occurrence that wins its claim, and the speculative child prewarm now runs once per package instead of once per occurrence.

Two regression tests cover the orderings, both on a paused clock so the ordering is a property of the runtime rather than a wall-clock margin: a deeper occurrence that resolves first must not decide (fails on `main`'s walk), and two occurrences at the same depth are settled by parent path (fails if the assignment's comparison is inverted).

Children ownership is pacquet's own machinery, so there is nothing to mirror in `resolveDependencyTree.ts`.

## Squash Commit Body

```text
Occurrences of a package race to claim its children: whichever one
reaches it while the claim stands vacant records what its own level's
preferred-versions overlay resolved, and a better-placed occurrence
arriving later keeps that recording rather than walking again — walking
on every claim win is what expanded exponentially in pnpm/pnpm#13574. Which
occurrence gets there first is thread timing, so identical inputs
produced different lockfiles run to run.

Settling the recording alone does not fix it: traced on the repro, the
better-ranked occurrence of a package sometimes does not exist at all,
because an ancestor on its path matched its own recording and never
walked that subtree. The walked set is arrival-ordered too.

The walk now advances a depth level at a time. A level is seeded in full
before any of it is settled, so every occurrence of a package at that
depth is in hand when its children ownership is decided; the rank's
first three keys are shared within a level, so the occurrence whose
parent path sorts first wins, and it is the only one that claims.
Ownership never passes to an occurrence seeded later and no occurrence
re-walks children another one recorded.

Removing those handovers is why this costs nothing: the repro resolves
in 4.29s against 4.29s on main and is byte-identical across 46 runs,
where main produces 3 distinct lockfiles in 4, and the peer-heavy
resolve benchmark drops from 844ms to 467ms.

Closes pnpm/pnpm#13685.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5[1m]).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency resolution consistency when packages are reached through multiple paths.
  * Prevented lockfile differences caused by concurrent resolution order.
  * Improved handling of package aliases, peer-shadowed dependencies, and shared package versions.
  * Ensured deterministic selection of shared dependencies across traversal paths and resolution levels.

* **Tests**
  * Added regression coverage for deterministic shared-package resolution, peer shadowing, and dependency path ordering.
  * Expanded coverage for aliases, version ranges, and JSR package references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->