### PR TITLE
fix(scripts): document private items in the pre-push doc check

### DIFF
--- a/pnpm/scripts/pre-push-rust.sh
+++ b/pnpm/scripts/pre-push-rust.sh
@@ -25,8 +25,13 @@ if command -v cargo >/dev/null 2>&1; then
         failed=1
     fi
 
-    yellow '▸ RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace --all-features'
-    if ! RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --workspace --all-features --quiet; then
+    # `--document-private-items` is what the "Rust CI / Doc" job passes.
+    # Nearly every item in these crates is private or `pub(super)`, and
+    # rustdoc only resolves the doc links of the items it documents — so
+    # without the flag a link to a renamed or deleted private item passes
+    # here and fails there.
+    yellow '▸ RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace --all-features --document-private-items'
+    if ! RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --workspace --all-features --document-private-items --quiet; then
         red '✗ cargo doc reported warnings — fix the rustdoc diagnostics and commit.'
         failed=1
     fi


### PR DESCRIPTION
## Summary

The `Rust CI / Doc` job runs

```
RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --workspace --document-private-items
```

and `pnpm/scripts/pre-push-rust.sh` ran the same thing **without** `--document-private-items`. Nearly every item in these crates is private or `pub(super)`, and rustdoc only resolves the doc links of the items it documents — so a link to a renamed or deleted private item passes the local check and fails CI.

Reproduced by pointing one doc comment at a name that does not exist (`[`fn@walk_node_children_renamed`]`), with `target/doc` removed before each run:

| command | result |
| --- | --- |
| `cargo doc --no-deps --workspace --all-features` (before) | passes, reports nothing |
| `cargo doc --no-deps --workspace --all-features --document-private-items` (after) | `error: unresolved link to 'walk_node_children_renamed'` |

`--all-features` stays, so the local gate remains a superset of CI's.

Found the slow way: two red `Rust CI / Doc` runs on pnpm/pnpm#13835, where deleting a private function left doc links to it behind and the pre-push check waved them through both times.

No changeset — this touches a developer script, not a published package.

## Squash Commit Body

```text
The "Rust CI / Doc" job runs `cargo doc` with `--document-private-items`
and the pre-push check did not. Nearly every item in these crates is
private or `pub(super)`, and rustdoc only resolves the doc links of the
items it documents, so a link to a renamed or deleted private item
passed the local check and failed CI.

Reproduced by pointing one doc comment at a name that does not exist:
the old command reports nothing, the CI command reports `unresolved
link`. Caught after two red `Rust CI / Doc` runs on pnpm/pnpm#13835.
```

## Checklist

- [x] Added or updated tests.

The check is its own test: running the updated script against a deliberately broken doc link fails, and against `main` passes end to end (fmt, clippy, doc, dylint, typos, taplo).

---
Written by an agent (Claude Code, claude-opus-5[1m]).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789078847&installation_model_id=426870&pr_number=13838&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13838&signature=c8caa659db7f98271a7699ceb5ef6bb8c7c2161ef117639659bc290b18d53ba3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Rust documentation checks to validate links for private items, aligning local pre-push checks with CI validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->