### PR TITLE
fix(resolver): keep the children a reused subtree pinned

### DIFF
--- a/.changeset/pinned-children-survive-a-fresh-walk.md
+++ b/.changeset/pinned-children-survive-a-fresh-walk.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm install` no longer re-resolves dependencies inside a subtree the lockfile pinned when another dependency reaches the same package. Those packages kept their locked versions in `node_modules` while `pnpm-lock.yaml` recorded newer ones, so an install could quietly move a transitive dependency — including across a major version — without anything asking it to.

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
@@ -174,6 +174,20 @@ pub(super) struct RecordedChildrenContext {
 }
 
 impl RecordedChildrenContext {
+    /// Whether a walk under `other` would re-resolve what the prior
+    /// lockfile pinned for this recording — the churn reuse exists to
+    /// avoid, and which leaves the occurrences that realized the
+    /// pinned subtree pointing at children the record no longer holds.
+    ///
+    /// An update policy is the one thing that re-resolves a pin on
+    /// purpose, so a walk under one is never held to the pins.
+    pub(super) fn pins_children_over(&self, other: &Self) -> bool {
+        self.peer_shadowed == other.peer_shadowed
+            && self.prior_key.is_some()
+            && other.prior_key.is_none()
+            && !other.update_active
+    }
+
     /// Two contexts produce the same children.
     ///
     /// The preferred-versions overlay is deliberately not part of the
@@ -1303,9 +1317,10 @@ pub(super) fn recorded_children_match(
     pkg_id: &str,
     context: &RecordedChildrenContext,
 ) -> bool {
-    lock_recoverable(&ctx.workspace.children_by_id)
-        .get(pkg_id)
-        .is_some_and(|recorded| recorded.context.produces_same_children_as(context))
+    lock_recoverable(&ctx.workspace.children_by_id).get(pkg_id).is_some_and(|recorded| {
+        recorded.context.produces_same_children_as(context)
+            || recorded.context.pins_children_over(context)
+    })
 }
 
 /// What [`fn@record_children`] did with a walk's child edges.
@@ -1377,16 +1392,20 @@ pub(super) fn record_children(
             // Nothing recorded yet, so no occurrence node can hold
             // realized children of this package to stale.
             None => ChildrenRecording::Published,
-            Some(recorded) if *recorded.edges == edges => ChildrenRecording::Published,
             // A recording the prior lockfile pinned outlives a fresh
-            // walk's different answer: the occurrences that reused the
-            // subtree keep it realized rather than re-resolving its open
-            // ranges, which is the churn the reuse existed to avoid.
-            Some(recorded)
-                if recorded.context.prior_key.is_some() && context.prior_key.is_none() =>
-            {
-                ChildrenRecording::Published
+            // walk's answer, so this walk publishes nothing and reads
+            // the pinned children like every occurrence that reused the
+            // subtree. Publishing over them would re-resolve the open
+            // ranges reuse exists to hold still, and would leave those
+            // occurrences realizing children the record no longer
+            // holds. This comes before the equal-edge arm because
+            // republishing even the same edges would carry this walk's
+            // unpinned context onto the record, leaving the next fresh
+            // walk to land on different edges nothing to hold it back.
+            Some(recorded) if recorded.context.pins_children_over(&context) => {
+                return ChildrenRecording::Declined;
             }
+            Some(recorded) if *recorded.edges == edges => ChildrenRecording::Published,
             Some(_) => ChildrenRecording::PublishedOverStale,
         };
         children.insert(pkg_id.to_string(), RecordedChildren { edges: Arc::new(edges), context });

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx/tests.rs
@@ -544,6 +544,40 @@ fn recorded_children_match_only_under_the_recording_context() {
     assert!(matches!(ctx.update_reuse_scope(), UpdateReuseScope::All));
 }
 
+/// Which of a package's dependencies its own peers supply is a
+/// property of the occurrence, and pinned children were filtered under
+/// the recording occurrence's set — so the pins stand in for a fresh
+/// walk only where the two shadow the same names.
+#[test]
+fn a_pin_stands_in_only_for_a_walk_that_shadows_the_same_dependencies() {
+    use super::RecordedChildrenContext;
+    use std::sync::Arc;
+
+    let fresh = RecordedChildrenContext {
+        peer_shadowed: Arc::default(),
+        prior_key: None,
+        update_active: false,
+    };
+    let pinned = RecordedChildrenContext {
+        prior_key: Some("pkg@1.0.0".parse().expect("parse snapshot key")),
+        ..fresh.clone()
+    };
+    assert!(pinned.pins_children_over(&fresh));
+
+    let shadowed = RecordedChildrenContext {
+        peer_shadowed: Arc::new(HashSet::from_iter(["peer".to_string()])),
+        ..pinned.clone()
+    };
+    assert!(!shadowed.pins_children_over(&fresh), "a different shadow set filtered them");
+    assert!(shadowed.pins_children_over(&RecordedChildrenContext {
+        peer_shadowed: Arc::clone(&shadowed.peer_shadowed),
+        ..fresh.clone()
+    }));
+
+    let updating = RecordedChildrenContext { update_active: true, ..fresh };
+    assert!(!pinned.pins_children_over(&updating), "an update re-resolves pins on purpose");
+}
+
 /// A walk that lost the claim while it ran must not overwrite the
 /// children the occurrence that outranked it published.
 #[test]
@@ -629,8 +663,22 @@ fn re_recording_reports_whether_the_child_edges_moved() {
         ChildrenRecording::PublishedOverStale,
     );
     assert_eq!(
+        record_children(&ctx, "pkg@1.0.0", &owner.owner, edges("dep@1.0.0"), context()),
+        ChildrenRecording::Declined,
+        "a fresh walk that agrees does not republish the pin away either",
+    );
+    assert_eq!(
         record_children(&ctx, "pkg@1.0.0", &owner.owner, edges("dep@2.0.0"), context()),
-        ChildrenRecording::Published,
+        ChildrenRecording::Declined,
         "a fresh walk does not unpin the subtree the lockfile-reusing occurrences realized",
     );
+    let standing = lock_recoverable(&workspace.children_by_id);
+    let standing: Vec<&str> = standing
+        .get("pkg@1.0.0")
+        .expect("pinned children")
+        .edges
+        .iter()
+        .map(|edge| edge.pkg_id.as_str())
+        .collect();
+    assert_eq!(standing, ["dep@1.0.0"], "the pinned children are what every occurrence reads");
 }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -3083,6 +3083,103 @@ async fn unchanged_shadow_ownership_handover_keeps_reused_subtree() {
         "the lockfile-reused subtree must survive the ownership handover",
     );
 }
+/// Publishing a fresh answer over pinned children re-resolves the open
+/// ranges reuse exists to hold still, and leaves the occurrences that
+/// realized the pinned subtree reading children the record no longer
+/// holds (<https://github.com/pnpm/pnpm/issues/13837>).
+#[tokio::test]
+async fn a_pinned_subtree_keeps_its_children_against_a_fresh_walk() {
+    for slow in [("fresh", "1.0.0"), ("reused", "1.0.0")] {
+        let tree = resolve_pinned_versus_fresh(slow).await;
+        let recorded: Vec<&str> = tree
+            .children_by_id
+            .get("shared@1.0.0")
+            .expect("shared children")
+            .iter()
+            .map(|edge| edge.pkg_id.as_str())
+            .collect();
+        assert_eq!(recorded, ["pin@1.0.0"], "the pins stand, held back: {slow:?}");
+        assert!(
+            !tree.packages.contains_key("pin@1.5.0"),
+            "and nothing re-resolves the range they pinned, held back: {slow:?}",
+        );
+    }
+}
+
+/// `slow` is the `(alias, range)` the resolver holds back, which
+/// decides whether the pinned subtree or the fresh edge records
+/// `shared`'s children first.
+async fn resolve_pinned_versus_fresh(slow: (&str, &str)) -> crate::ResolvedTree {
+    let dependencies = |deps| {
+        move |name: &str, version: &str| {
+            fake_result(
+                name,
+                version,
+                None,
+                serde_json::json!({ "name": name, "version": version, "dependencies": deps }),
+            )
+        }
+    };
+    let table = HashMap::from_iter([
+        (
+            ("reused".to_string(), "1.0.0".to_string()),
+            dependencies(serde_json::json!({ "shared": "1.0.0" }))("reused", "1.0.0"),
+        ),
+        (
+            ("fresh".to_string(), "1.0.0".to_string()),
+            dependencies(serde_json::json!({ "shared": "^1.0.0" }))("fresh", "1.0.0"),
+        ),
+        (
+            ("shared".to_string(), "1.0.0".to_string()),
+            dependencies(serde_json::json!({ "pin": "^1.0.0" }))("shared", "1.0.0"),
+        ),
+        (
+            ("shared".to_string(), "^1.0.0".to_string()),
+            dependencies(serde_json::json!({ "pin": "^1.0.0" }))("shared", "1.0.0"),
+        ),
+        (
+            ("pin".to_string(), "1.0.0".to_string()),
+            fake_result(
+                "pin",
+                "1.0.0",
+                None,
+                serde_json::json!({ "name": "pin", "version": "1.0.0" }),
+            ),
+        ),
+        (
+            ("pin".to_string(), "^1.0.0".to_string()),
+            fake_result(
+                "pin",
+                "1.5.0",
+                None,
+                serde_json::json!({ "name": "pin", "version": "1.5.0" }),
+            ),
+        ),
+    ]);
+    let resolver = SlowAliasResolver { table, slow: (slow.0.to_string(), slow.1.to_string()) };
+    let (tmp, manifest) = fake_manifest(serde_json::json!({ "reused": "1.0.0", "fresh": "1.0.0" }));
+    let importers = [WorkspaceImporter { id: ".".to_string(), manifest: &manifest }];
+
+    let mut opts = workspace_opts(false, false);
+    opts.wanted_lockfile = Some(Arc::new(reuse_graph_lockfile(
+        ".",
+        &[("reused", "1.0.0", "1.0.0")],
+        &[
+            ("reused@1.0.0", &[("shared", "1.0.0")]),
+            ("shared@1.0.0", &[("pin", "1.0.0")]),
+            ("pin@1.0.0", &[]),
+        ],
+        &[],
+    )));
+    let dir = tmp.path().to_path_buf();
+    resolve_workspace(&resolver, &importers, &[DependencyGroup::Prod], opts, |_| {
+        importer_opts(dir.clone(), None)
+    })
+    .await
+    .expect("resolve the pinned-versus-fresh contest")
+    .merged_tree
+}
+
 fn reuse_steal_lockfile() -> pacquet_lockfile::Lockfile {
     use pacquet_lockfile::{
         ComVer, ImporterDepVersion, Lockfile, LockfileVersion, PackageMetadata, PkgName,


### PR DESCRIPTION
## Summary

Investigating the lockfile-reuse half of pnpm/pnpm#13837 turned up a live bug rather than the ordering question I went looking for.

`record_children` says:

> A recording the prior lockfile pinned outlives a fresh walk's different answer: the occurrences that reused the subtree keep it realized rather than re-resolving its open ranges, which is the churn the reuse existed to avoid.

The arm implementing it returns `Published` — which only suppresses the staleness signal — and then falls through to `children.insert(...)` like every other arm. So the fresh answer *does* replace the pinned children, and because no occurrence is flagged stale, the ones that realized the pinned subtree go on holding children the record no longer lists.

### What it costs

Instrumented every recording that replaced an existing one with different edges, on a partially stale `@teambit/bit` lockfile (`install --lockfile-only --no-prefer-frozen-lockfile`, offline). **22 replacements per run, every one a pinned recording overwritten by a fresh walk** (`standing_prior=Some(…) incoming_prior=None`):

```
react-error-boundary@3.1.4     pinned @babel/runtime@7.23.2 → replaced with 7.29.7
enhanced-resolve@5.24.5        pinned graceful-fs@4.2.10    → replaced with 4.2.11
subscriptions-transport-ws     pinned ws@7.5.10             → replaced with 7.5.13
```

The resulting lockfile moved 24 edges nothing had asked it to move, including `@types/express-serve-static-core` from `4.19.9` to `5.1.3` — a major version bump of a transitive dependency on a plain install.

### The fix

A walk whose context carries no prior key publishes nothing over a pinned recording and reads the pinned children, like every occurrence that reused the subtree. The gate that decides whether to walk at all applies the same rule, so the fresh subtree is not resolved and then discarded. A walk under an update policy is exempt — re-resolving pins is what `pnpm update` is for.

### On the ordering question in pnpm/pnpm#13837

This also closes the reuse↔fresh contest the issue asks about: those recordings are no longer replaced, so there is nothing left for the two walks to race over. What I could not produce is a *pinned-vs-pinned* replacement — across three instrumented runs, all 22 replacements had `incoming_prior=None`. The hoist-wave and cross-importer half of the issue is unchanged and stays open there.

### Measurements

- Partially stale `@teambit/bit` lockfile: 3/3 identical lockfiles before the fix and 3/3 after; the 24 edges above now keep their pins.
- Fresh resolve (no lockfile): 6/6 identical, byte-for-byte what `main` produces — this path has no pins to protect.
- 8134 tests pass.

### Tests

`re_recording_reports_whether_the_child_edges_moved` asserted `Published` for exactly this case while its own message said "a fresh walk does not unpin the subtree the lockfile-reusing occurrences realized". It never checked the stored edges, which is why the bug sat under a passing test. It now asserts the recording is declined *and* that the pinned children are what stands.

`a_pinned_subtree_keeps_its_children_against_a_fresh_walk` resolves a package reached both from a pinned subtree and from a fresh edge, under both interleavings, and asserts the pins stand and that the range they pinned is never re-resolved. It fails on `main`.

## Squash Commit Body

```text
`record_children` documents that "a recording the prior lockfile pinned
outlives a fresh walk's different answer", and then inserts the fresh
answer over it. The arm only suppressed the staleness signal, so the
occurrences that realized the pinned subtree went on holding children
the record no longer listed, and the lockfile took whichever answer
landed last.

Instrumented on a partially stale @teambit/bit lockfile, 22 recordings
per run were replaced this way, every one of them a pinned recording
overwritten by a fresh walk: enhanced-resolve lost its pinned
graceful-fs@4.2.10 for 4.2.11, subscriptions-transport-ws its ws@7.5.10
for 7.5.13, and @types/express-serve-static-core moved a major version.
A plain install re-resolved 24 edges nothing had asked it to.

Make the rule the comment describes: a walk whose context carries no
prior key publishes nothing over a pinned recording, and reads the
pinned children like every occurrence that reused the subtree. The gate
that decides whether to walk at all applies the same rule, so the fresh
subtree is not resolved and thrown away. An update policy still
re-resolves pins — that is what it is for.

Related to pnpm/pnpm#13837.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

`children_by_id` and the recorded-children context are pacquet's own machinery; `resolveDependencyTree.ts` keeps a package's children per `depPath` with no equivalent replacement path, so there is nothing to mirror.

---
Written by an agent (Claude Code, claude-opus-5[1m]).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789082169&installation_model_id=426870&pr_number=13839&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13839&signature=507c7ce8cf9259de7400e5171797b2acd4793a9b706028b5da34948487020308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where `pnpm install` could re-resolve dependencies within pinned subtrees.
  * Lockfile-pinned child dependencies now remain at their specified versions, regardless of resolution order.
  * Prevented installed dependency versions from diverging from the lockfile, including unintended major-version upgrades.

* **Documentation**
  * Added a release note documenting the dependency-resolution fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->