### PR TITLE
fix(injected-deps-syncer): remove what the source dropped before replacing its parent

### DIFF
--- a/.changeset/injected-syncer-removal-order.md
+++ b/.changeset/injected-syncer-removal-order.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/workspace.injected-deps-syncer": patch
+"pnpm": patch
+---
+
+`syncInjectedDepsAfterScripts` no longer fails with `ENOTDIR` when a workspace package replaced a directory with a file of the same name and the injected copy still held that directory's contents.

--- a/cspell.json
+++ b/cspell.json
@@ -97,6 +97,7 @@
     "endregion",
     "eneedauth",
     "enoent",
+    "enotdir",
     "enotempty",
     "enten",
     "eotp",

--- a/pnpm11/workspace/injected-deps-syncer/src/DirPatcher.ts
+++ b/pnpm11/workspace/injected-deps-syncer/src/DirPatcher.ts
@@ -133,25 +133,22 @@ export async function applyPatch (optimizedDirPatch: DirDiff, sourceDir: string,
   const newDirs = changes.filter(item => item.newValue === DIR).sort((a, b) => comparePaths(a.path, b.path))
   const newFiles = changes.filter(item => item.newValue !== DIR)
 
-  // Every directory is in place, shallowest first, before anything is linked
-  // into it, so that a directory is always empty when it displaces what the
-  // target held at its path: a removal landing late would otherwise take out
+  // The phase order is load-bearing twice over. Removals go first, so a path
+  // the source turned from a directory into a file still has a directory in it
+  // when its dropped children are unlinked. Directories then go in ahead of the
+  // files they hold, so a directory is always empty when it displaces what the
+  // target held at its path — otherwise a removal landing late would take out
   // files a sibling had already linked. A path the target holds as a file and
   // the source as a directory lands in `modified` rather than `added`, so both
-  // arrays feed this pass.
-  const changing = (async () => {
-    for (const item of newDirs) {
-      await applyChange(item) // eslint-disable-line no-await-in-loop
-    }
-    await Promise.all(newFiles.map(applyChange))
-  })()
-
-  const removing = Promise.all(optimizedDirPatch.removed.map(async item => {
-    const targetPath = path.join(targetDir, item.path)
-    await removeRecursive(targetPath)
+  // arrays feed the directory pass.
+  await Promise.all(optimizedDirPatch.removed.map(async item => {
+    await removeRecursive(path.join(targetDir, item.path))
   }))
 
-  await Promise.all([changing, removing])
+  for (const item of newDirs) {
+    await applyChange(item) // eslint-disable-line no-await-in-loop
+  }
+  await Promise.all(newFiles.map(applyChange))
 }
 
 export type ExtendFilesMapStats = Pick<fs.Stats, 'ino' | 'isFile' | 'isDirectory'>

--- a/pnpm11/workspace/injected-deps-syncer/test/DirPatcher.test.ts
+++ b/pnpm11/workspace/injected-deps-syncer/test/DirPatcher.test.ts
@@ -327,3 +327,28 @@ testOnPosix('keeps the files linked into a directory that replaced a blocking in
 
   expect(fs.readdirSync('target/blocked').sort()).toStrictEqual(fileNames.sort())
 })
+
+test('removes what the source dropped before replacing the directory that held it', async () => {
+  prepareEmpty()
+
+  createFile('source/became-a-file', 'now a file')
+  createFile('target/became-a-file/dropped.txt', 'was a dir')
+
+  // `became-a-file` is a modification, `became-a-file/dropped.txt` a
+  // removal. Hold the removal back so it would land after the
+  // modification has linked a file over its parent — at which point
+  // the path it was given no longer has a directory in it.
+  let delayNextRemoval = true
+  fs.promises.rm = (async (target: fs.PathLike, options?: fs.RmOptions) => {
+    if (delayNextRemoval && String(target).endsWith('dropped.txt')) {
+      delayNextRemoval = false
+      await delay(30)
+    }
+    return originalRm(target, options)
+  }) as typeof fs.promises.rm
+
+  const patchers = await DirPatcher.fromMultipleTargets('source', ['target'])
+  await Promise.all(patchers.map(async patcher => patcher.apply()))
+
+  expect(fs.readFileSync('target/became-a-file', 'utf8')).toBe('now a file')
+})


### PR DESCRIPTION
## Summary

`applyPatch` ran its removals concurrently with its changes, so a workspace package that replaced a directory with a file of the same name could abort `syncInjectedDepsAfterScripts` partway through.

That path lands in `modified` (the target holds a directory, the source a file) while the directory's contents land in `removed`. Both phases were started together, so a removal could be issued against a path whose parent had already been relinked as a file and come back `ENOTDIR`, which `removeRecursive` rethrows — it only tolerates `ENOENT`.

Reproduced against the current tree before changing anything, with the removal held back 30 ms so it lands after the modification has linked:

```
● removes what the source dropped before replacing the directory that held it

  ENOTDIR: not a directory, lstat 'target/became-a-file/dropped.txt'
```

The removals are now awaited before any change is applied. Nothing a change needs can be removed: a path absent from the source has all its children absent too, so a removal is never an ancestor of an added or modified path. The two orderings the patcher depends on are now stated together in one comment — removals before changes, and directories before the files they hold.

Removals no longer overlap with the linking phase. In an injected-dep sync the removed set is whatever the source dropped since the last sync, normally a handful of paths against a full relink of the package, so the serialization is not worth trading correctness for.

**Rust:** already correct. The Rust CLI reached this ordering in pnpm/pnpm#13834 — its patcher is sequential, which turned the same hazard into a deterministic failure and forced it out into the open there. This PR is the TypeScript half, and was called out as a follow-up in that PR's review.

**Tests:** one case in `DirPatcher.test.ts`. It delays the descendant's removal so the race is forced rather than hoped for; reverting the source change alone fails it with the `ENOTDIR` above. The `pnpm/test/syncInjectedDepsAfterScripts` end-to-end suite still passes against a rebuilt bundle.

`cspell` gained `enotdir`, alongside the `enoent` and `enotempty` already there.

## Squash Commit Body

```text
When a workspace package replaced a directory with a file of the same
name, that path landed in `modified` while the directory's contents
landed in `removed`. The two ran concurrently, so a removal could be
issued against a path whose parent had already been relinked as a file
and come back ENOTDIR, which removeRecursive rethrows — aborting
syncInjectedDepsAfterScripts partway through.

Await the removals before applying any change. Nothing a change needs
can be removed: a path absent from the source has all its children
absent too, so no removal is ever an ancestor of an added or modified
path.

The Rust CLI reached the same ordering in pnpm/pnpm#13834, where a
sequential patcher made this a deterministic failure rather than a race.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5[1m]).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789083119&installation_model_id=426870&pr_number=13840&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13840&signature=2fcc2557e01573b1ebb380df2e3e095753d7329217bd4908d445481e518b46e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed injected workspace dependency synchronization when a directory is replaced by a file with the same name.
  - Prevented `ENOTDIR` errors and ensured replacement files remain intact after synchronization.

- **Tests**
  - Added regression coverage for directory-to-file replacements during synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->