### PR TITLE
fix(catalogs): honor a wanted version the catalog entry already resolves past

### DIFF
--- a/.changeset/catalog-locked-version-noop.md
+++ b/.changeset/catalog-locked-version-noop.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-installer": patch
+"pnpm": patch
+---
+
+`pnpm add <pkg>@<version>` and `pnpm update <pkg>@<version>` under a non-manual `catalogMode` now move the catalog entry's resolution to the requested version. Previously, when the catalog entry was a range that covered the requested version but resolved to a different one, the request was dropped silently: nothing was installed, nothing was written, and no error was raised.

--- a/pnpm11/installing/deps-installer/src/install/extendInstallOptions.ts
+++ b/pnpm11/installing/deps-installer/src/install/extendInstallOptions.ts
@@ -11,7 +11,7 @@ import type { ProjectOptions } from '@pnpm/installing.context'
 import type { HoistingLimits } from '@pnpm/installing.deps-restorer'
 import type { IncludedDependencies } from '@pnpm/installing.modules-yaml'
 import type { LockfileObject } from '@pnpm/lockfile.fs'
-import type { ResolutionPolicyViolation, ResolutionVerifier, WorkspacePackages } from '@pnpm/resolving.resolver-base'
+import type { PreferredVersions, ResolutionPolicyViolation, ResolutionVerifier, WorkspacePackages } from '@pnpm/resolving.resolver-base'
 import type { StoreController } from '@pnpm/store.controller-types'
 import type {
   AllowedDeprecatedVersions,
@@ -397,6 +397,12 @@ const defaults = (opts: InstallOptions): StrictInstallOptions => {
 
 export interface ProcessedInstallOptions extends StrictInstallOptions {
   readPackageHook?: ReadPackageHook
+  /**
+   * Version preferences layered on top of the seed resolution takes from the lockfile, by
+   * package name. Callers pass them in (an audit fix penalizing vulnerable versions), and
+   * `mutateModules` adds its own for a catalog entry it moves.
+   */
+  preferredVersions?: PreferredVersions
   parsedOverrides: VersionOverride[]
   /**
    * Present when the overrides contain convergence entries (`"pkg@"`). The

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -76,9 +76,10 @@ import { globalInfo, logger, streamParser } from '@pnpm/logger'
 import { groupPatchedDependencies, type PatchGroupRecord } from '@pnpm/patching.config'
 import { createVersionSpecFromResolvedVersion, getAllDependenciesFromManifest, getAllUniqueSpecs } from '@pnpm/pkg-manifest.utils'
 import { parseWantedDependency } from '@pnpm/resolving.parse-wanted-dependency'
-import type {
-  PreferredVersions,
-  ResolutionPolicyViolation,
+import {
+  EXISTING_VERSION_SELECTOR_WEIGHT,
+  type PreferredVersions,
+  type ResolutionPolicyViolation,
 } from '@pnpm/resolving.resolver-base'
 import { lexCompare } from '@pnpm/text.ordinal-comparator'
 import type {
@@ -974,6 +975,7 @@ export async function mutateModules (
     }
 
     const projectsToInstall = [] as ImporterToUpdate[]
+    const installedProjectIds = new Set<string>(projects.map((project) => ctx.projects[project.rootDir].id))
 
     let preferredSpecs: Record<string, string> | null = null
 
@@ -1182,6 +1184,11 @@ export async function mutateModules (
             // catalog: every project referencing the entry stays on the one version the entry
             // resolves to. Keeping the wanted version as the specifier would pin it in the
             // manifest instead, dropping the project out of the catalog.
+            resolveCatalogEntryTo({
+              alias: wantedDep.alias,
+              catalogName: perDepCatalogName,
+              version: wantedDep.bareSpecifier!,
+            })
             wantedDep.bareSpecifier = catalogBareSpecifier
             wantedDep.saveCatalogName = perDepCatalogName
             continue
@@ -1206,6 +1213,49 @@ export async function mutateModules (
         updateToLatest,
         wantedDependencies: wantedDeps.map(wantedDep => ({ ...wantedDep, isNew: !currentBareSpecifiers[wantedDep.alias], updateSpec: true })),
       } as ImporterToUpdate)
+    }
+
+    /**
+     * Resolve a catalog entry to the version a command asked for, leaving the range the
+     * workspace declared for it alone.
+     *
+     * A cataloged dependency takes its version from the catalog, so a wanted version the
+     * entry covers has to move the entry's resolution — otherwise the lockfile keeps the
+     * version the entry resolved to before and the request is dropped without a word.
+     */
+    function resolveCatalogEntryTo (
+      { alias, catalogName, version }: {
+        alias: string
+        catalogName: string
+        version: string
+      }
+    ): void {
+      if (ctx.wantedLockfile.catalogs?.[catalogName]?.[alias]?.version === version) return
+
+      // Drop the recorded resolution, along with the ones the installed projects took from
+      // it, so the entry is resolved again instead of reused at the version it named before.
+      // Projects outside this install keep theirs until they are installed themselves.
+      delete ctx.wantedLockfile.catalogs?.[catalogName]?.[alias]
+      for (const [id, importer] of Object.entries(ctx.wantedLockfile.importers ?? {})) {
+        if (!installedProjectIds.has(id)) continue
+        const specifier = importer.specifiers?.[alias]
+        if (specifier == null || parseCatalogProtocol(specifier) !== catalogName) continue
+        delete importer.dependencies?.[alias]
+        delete importer.devDependencies?.[alias]
+        delete importer.optionalDependencies?.[alias]
+      }
+
+      // Without this, resolution takes the version the lockfile pins for the package, or the
+      // newest one the entry's range allows — not the one that was asked for. The weight
+      // outranks the pin the lockfile seeds, since naming a version is a request to move off
+      // whatever is currently resolved.
+      opts.preferredVersions = {
+        ...opts.preferredVersions,
+        [alias]: {
+          ...opts.preferredVersions?.[alias],
+          [version]: { selectorType: 'version', weight: EXISTING_VERSION_SELECTOR_WEIGHT + 1 },
+        },
+      }
     }
 
     // Unfortunately, the private lockfile may differ from the public one.

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -1219,9 +1219,11 @@ export async function mutateModules (
      * Resolve a catalog entry to the version a command asked for, leaving the range the
      * workspace declared for it alone.
      *
-     * A cataloged dependency takes its version from the catalog, so a wanted version the
-     * entry covers has to move the entry's resolution — otherwise the lockfile keeps the
-     * version the entry resolved to before and the request is dropped without a word.
+     * A cataloged dependency takes its version from the catalog, so the entry's recorded
+     * resolution is what a wanted version has to move. Reusing it instead drops the request
+     * without a word. Only the projects in this install follow the entry to the new version;
+     * the rest keep their resolutions until they are installed, as they do for any other
+     * catalog change.
      */
     function resolveCatalogEntryTo (
       { alias, catalogName, version }: {
@@ -1232,9 +1234,6 @@ export async function mutateModules (
     ): void {
       if (ctx.wantedLockfile.catalogs?.[catalogName]?.[alias]?.version === version) return
 
-      // Drop the recorded resolution, along with the ones the installed projects took from
-      // it, so the entry is resolved again instead of reused at the version it named before.
-      // Projects outside this install keep theirs until they are installed themselves.
       delete ctx.wantedLockfile.catalogs?.[catalogName]?.[alias]
       for (const [id, importer] of Object.entries(ctx.wantedLockfile.importers ?? {})) {
         if (!installedProjectIds.has(id)) continue
@@ -1245,17 +1244,15 @@ export async function mutateModules (
         delete importer.optionalDependencies?.[alias]
       }
 
-      // Without this, resolution takes the version the lockfile pins for the package, or the
-      // newest one the entry's range allows — not the one that was asked for. The weight
-      // outranks the pin the lockfile seeds, since naming a version is a request to move off
-      // whatever is currently resolved.
-      opts.preferredVersions = {
-        ...opts.preferredVersions,
-        [alias]: {
-          ...opts.preferredVersions?.[alias],
-          [version]: { selectorType: 'version', weight: EXISTING_VERSION_SELECTOR_WEIGHT + 1 },
-        },
-      }
+      // Outranks the pin the lockfile seeds for the package: naming a version is a request to
+      // move off whatever is resolved now, and without that the pin wins.
+      // Null-prototype merge targets so a package named `__proto__` lands as a plain own key
+      // instead of invoking the prototype setter.
+      const preferredVersions: PreferredVersions = Object.assign(Object.create(null), opts.preferredVersions)
+      preferredVersions[alias] = Object.assign(Object.create(null), preferredVersions[alias], {
+        [version]: { selectorType: 'version', weight: EXISTING_VERSION_SELECTOR_WEIGHT + 1 },
+      })
+      opts.preferredVersions = preferredVersions
     }
 
     // Unfortunately, the private lockfile may differ from the public one.

--- a/pnpm11/installing/deps-installer/test/catalogs.ts
+++ b/pnpm11/installing/deps-installer/test/catalogs.ts
@@ -1647,8 +1647,8 @@ describe('add', () => {
 
     await mutateModules(installProjects(projects), mutateOpts)
 
-    // Widen the catalog to a range that keeps 1.0.0 locked. The wanted version below is
-    // inside that range but is not the version the catalog currently resolves to.
+    // Widen the catalog to a range that keeps 1.0.0 locked, so the wanted version below is
+    // inside the range but is not what the entry resolves to.
     catalogs.default['@pnpm.e2e/foo'] = '^1.0.0'
     await mutateModules(installProjects(projects), mutateOpts)
 
@@ -1661,9 +1661,6 @@ describe('add', () => {
         allowNew: true,
       })
 
-    // A cataloged dependency takes its version from the catalog, so the request moves what
-    // the entry resolves to instead of being dropped, and saving re-renders the declared
-    // range onto that version the way it does for a manifest dependency.
     expect(updatedManifest).toEqual({
       name: 'project1',
       dependencies: {
@@ -1674,12 +1671,17 @@ describe('add', () => {
       default: { '@pnpm.e2e/foo': '^1.1.0' },
     })
 
-    // The entry resolves to the version that was asked for rather than to the version it
-    // was locked on, or to the newest one its range allows.
-    expect(readLockfile()).toMatchObject({
+    // project2 was not part of the add, so it keeps the version the entry resolved to
+    // before until it is installed itself.
+    const lockfile = readLockfile()
+    expect(lockfile).toMatchObject({
       catalogs: { default: { '@pnpm.e2e/foo': { specifier: '^1.1.0', version: '1.1.0' } } },
-      importers: { project1: { dependencies: { '@pnpm.e2e/foo': { specifier: 'catalog:', version: '1.1.0' } } } },
+      importers: {
+        project1: { dependencies: { '@pnpm.e2e/foo': { specifier: 'catalog:', version: '1.1.0' } } },
+        project2: { dependencies: { '@pnpm.e2e/foo': { specifier: 'catalog:', version: '1.0.0' } } },
+      },
     })
+    expect(Object.keys(lockfile.snapshots).sort()).toEqual(['@pnpm.e2e/foo@1.0.0', '@pnpm.e2e/foo@1.1.0'])
   })
 
   test('adding mismatched version with catalogMode: prefer will warn and use direct', async () => {
@@ -1905,12 +1907,8 @@ describe('update', () => {
       mutateOpts
     )
 
-    // Every project on the entry follows it to the version that was asked for — not to the
-    // newest one the range allows — and the declared range is left as the workspace wrote it.
     expect(updatedProjects[0]?.manifest?.dependencies?.['@pnpm.e2e/foo']).toBe('catalog:')
     expect(updatedProjects[1]?.manifest?.dependencies?.['@pnpm.e2e/foo']).toBe('catalog:')
-    // Saving an update re-renders the declared range onto the resolved version, as it does
-    // for a manifest dependency.
     expect(updatedCatalogs).toEqual({
       default: { '@pnpm.e2e/foo': '^1.1.0' },
     })

--- a/pnpm11/installing/deps-installer/test/catalogs.ts
+++ b/pnpm11/installing/deps-installer/test/catalogs.ts
@@ -1622,6 +1622,66 @@ describe('add', () => {
     })
   })
 
+  test('adding a version the catalog range covers moves a catalog locked on another version', async () => {
+    const { options, projects, readLockfile } = preparePackagesAndReturnObjects([{
+      name: 'project1',
+      dependencies: {
+        '@pnpm.e2e/foo': 'catalog:',
+      },
+    }, {
+      name: 'project2',
+      dependencies: {
+        '@pnpm.e2e/foo': 'catalog:',
+      },
+    }])
+
+    const catalogs = {
+      default: { '@pnpm.e2e/foo': '1.0.0' },
+    }
+    const mutateOpts = {
+      ...options,
+      lockfileOnly: true,
+      catalogs,
+      catalogMode: 'strict' as const,
+    }
+
+    await mutateModules(installProjects(projects), mutateOpts)
+
+    // Widen the catalog to a range that keeps 1.0.0 locked. The wanted version below is
+    // inside that range but is not the version the catalog currently resolves to.
+    catalogs.default['@pnpm.e2e/foo'] = '^1.0.0'
+    await mutateModules(installProjects(projects), mutateOpts)
+
+    const { updatedManifest, updatedCatalogs } = await addDependenciesToPackage(
+      projects['project1' as ProjectId],
+      ['@pnpm.e2e/foo@1.1.0'],
+      {
+        ...mutateOpts,
+        dir: path.join(options.lockfileDir, 'project1'),
+        allowNew: true,
+      })
+
+    // A cataloged dependency takes its version from the catalog, so the request moves what
+    // the entry resolves to instead of being dropped, and saving re-renders the declared
+    // range onto that version the way it does for a manifest dependency.
+    expect(updatedManifest).toEqual({
+      name: 'project1',
+      dependencies: {
+        '@pnpm.e2e/foo': 'catalog:',
+      },
+    })
+    expect(updatedCatalogs).toEqual({
+      default: { '@pnpm.e2e/foo': '^1.1.0' },
+    })
+
+    // The entry resolves to the version that was asked for rather than to the version it
+    // was locked on, or to the newest one its range allows.
+    expect(readLockfile()).toMatchObject({
+      catalogs: { default: { '@pnpm.e2e/foo': { specifier: '^1.1.0', version: '1.1.0' } } },
+      importers: { project1: { dependencies: { '@pnpm.e2e/foo': { specifier: 'catalog:', version: '1.1.0' } } } },
+    })
+  })
+
   test('adding mismatched version with catalogMode: prefer will warn and use direct', async () => {
     const { options, projects, readLockfile } = preparePackagesAndReturnObjects([{
       name: 'project1',
@@ -1837,7 +1897,7 @@ describe('update', () => {
         ...manifest,
         rootDir: path.resolve(id) as ProjectRootDir,
         mutation: 'installSome' as const,
-        dependencySelectors: ['@pnpm.e2e/foo@1.3.0'],
+        dependencySelectors: ['@pnpm.e2e/foo@1.1.0'],
         allowNew: false,
         update: true,
         updatePackageManifest: true,
@@ -1845,17 +1905,25 @@ describe('update', () => {
       mutateOpts
     )
 
+    // Every project on the entry follows it to the version that was asked for — not to the
+    // newest one the range allows — and the declared range is left as the workspace wrote it.
     expect(updatedProjects[0]?.manifest?.dependencies?.['@pnpm.e2e/foo']).toBe('catalog:')
     expect(updatedProjects[1]?.manifest?.dependencies?.['@pnpm.e2e/foo']).toBe('catalog:')
+    // Saving an update re-renders the declared range onto the resolved version, as it does
+    // for a manifest dependency.
     expect(updatedCatalogs).toEqual({
-      default: { '@pnpm.e2e/foo': '^1.3.0' },
+      default: { '@pnpm.e2e/foo': '^1.1.0' },
     })
 
     const lockfile = readLockfile()
     expect(lockfile.catalogs).toEqual({
-      default: { '@pnpm.e2e/foo': { specifier: '^1.3.0', version: '1.3.0' } },
+      default: { '@pnpm.e2e/foo': { specifier: '^1.1.0', version: '1.1.0' } },
     })
-    expect(Object.keys(lockfile.snapshots)).toEqual(['@pnpm.e2e/foo@1.3.0'])
+    expect(lockfile.importers).toMatchObject({
+      project1: { dependencies: { '@pnpm.e2e/foo': { specifier: 'catalog:', version: '1.1.0' } } },
+      project2: { dependencies: { '@pnpm.e2e/foo': { specifier: 'catalog:', version: '1.1.0' } } },
+    })
+    expect(Object.keys(lockfile.snapshots)).toEqual(['@pnpm.e2e/foo@1.1.0'])
   })
 
   test('overrides that reference a catalog are updated in the lockfile when the catalog is updated', async () => {


### PR DESCRIPTION
## Summary

Follow-up to pnpm/pnpm#13716, which stopped `catalogMode: strict` from rejecting a version a
range-based catalog entry covers. That left a hole: when the entry's *recorded resolution*
names a different version than the one asked for, the request was dropped silently.

```yaml
# pnpm-workspace.yaml — entry covers 1.1.0, but the lockfile resolves it to 1.0.0
catalogMode: strict
catalog:
  '@pnpm.e2e/foo': ^1.0.0
```

`pnpm add @pnpm.e2e/foo@1.1.0` (or `pnpm update @pnpm.e2e/foo@1.1.0`) wrote nothing — not the
lockfile, not `pnpm-workspace.yaml` — and raised no error. The same swallows an explicit
downgrade: with the entry resolved to 1.3.0, asking for `@1.1.0` also did nothing.

A cataloged dependency takes its version from the catalog, so the wanted version now moves the
entry's resolution: the recorded resolution is cleared, along with the resolutions the
installed projects took from it, and the wanted version is preferred above the pin the lockfile
seeds. The range the workspace declared is not touched by this — saving still re-renders it
onto the resolved version, exactly as it does for a manifest dependency.

Projects outside the install keep their resolutions until they are installed themselves, which
is what already happens for any other catalog change.

Related to pnpm/pnpm#13715.

## Squash Commit Body

```text
Under a non-manual catalogMode, a wanted version the catalog entry covers resolves through the
catalog. When the entry was a range whose recorded resolution named a different version, that
resolution was reused and the wanted version was dropped without a word: `pnpm add
<pkg>@<version>` and `pnpm update <pkg>@<version>` wrote nothing to the lockfile and raised no
error, so the command looked like it had worked.

The recorded resolution is now cleared for the entry, along with the resolutions the installed
projects took from it, and the wanted version is preferred above the pin the lockfile seeds, so
the entry resolves to the version that was asked for. The range the workspace declared is
untouched by this; saving still re-renders it onto the resolved version the way it does for a
manifest dependency.

Projects outside the install keep their resolutions, as they already do for any catalog change,
until they are installed themselves.

Related to pnpm/pnpm#13715.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [ ] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

**Still to port:** pacquet honors the wanted version on `update` already — measured with a
range entry resolved to 100.0.0, `pacquet update <pkg>@100.1.0` moves the lockfile to 100.1.0 —
but `pacquet add <pkg>@<version>` has the same silent no-op this PR fixes for pnpm. I'm working
on that port next; it belongs in this PR before it lands.

One pre-existing difference the two stacks keep either way, which this PR does not touch:
pnpm re-renders a catalog entry's declared range when a save moves it (`^1.0.0` → `^1.1.0`),
pacquet leaves the range alone and moves only the resolved version.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789084053&installation_model_id=426870&pr_number=13841&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13841&signature=290102a610e5786c975fd900fe81e0348211410071a35a07ebbd5b0b3b98d3d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Version-pinned `pnpm add` and `pnpm update` commands now update catalog resolutions to the requested version when applicable.
  - Catalog dependency ranges and lockfile entries are updated consistently while preserving `catalog:` references.
  - Prevented requested dependency versions from being silently ignored when an existing catalog range resolves differently.
  - Updated projects now resolve to the requested version without unnecessarily invalidating unrelated catalog resolutions.

- **Tests**
  - Added regression coverage for catalog dependency updates, importer behavior, and lockfile changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->