### PR TITLE
[codex] feat(update): link changelogs from interactive updates

### DIFF
--- a/.changeset/interactive-update-changelog-links.md
+++ b/.changeset/interactive-update-changelog-links.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/installing.commands": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+`pnpm update --interactive` now links npm packages to the changelog for their target version on
+npmx instead of linking to the package homepage.

--- a/pnpm/crates/cli/src/cli_args/update_interactive/choices.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive/choices.rs
@@ -152,8 +152,8 @@ fn render_rows(choices: &[&Choice<'_>], workspaces_enabled: bool) -> Vec<ChoiceR
     let mut cells = vec![header];
     for choice in choices {
         let package = choice.package;
-        // The name, workspaces, and homepage are read out of manifests
-        // and registry metadata, so they are stripped of control
+        // The name, workspaces, and package URL include values read out
+        // of manifests and registry metadata, so they are stripped of control
         // characters before reaching the terminal: an escape sequence
         // would corrupt the prompt's redraw, and a newline would break
         // the row apart.
@@ -173,7 +173,15 @@ fn render_rows(choices: &[&Choice<'_>], workspaces_enabled: bool) -> Vec<ChoiceR
                     .join(", "),
             );
         }
-        row.push(package.homepage.as_deref().map(sanitize_inline).unwrap_or_default().into_owned());
+        let package_url = if package.github_action {
+            package.homepage.clone().unwrap_or_default()
+        } else {
+            format!(
+                "https://npmx.dev/package-changelog/{}/v/{}",
+                package.package_name, package.target,
+            )
+        };
+        row.push(sanitize_inline(&package_url).into_owned());
         cells.push(row);
     }
 

--- a/pnpm/crates/cli/src/cli_args/update_interactive/choices/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive/choices/tests.rs
@@ -130,6 +130,7 @@ fn github_actions_form_their_own_group() {
     let mut action =
         pkg("actions/checkout", "actions/checkout", "4.1.0", "4.2.2", DependencyGroup::Dev);
     action.github_action = true;
+    action.homepage = Some("https://github.com/actions/checkout".to_string());
     let packages = [pkg("foo", "foo", "1.0.0", "2.0.0", DependencyGroup::Dev), action];
 
     let groups = update_choices(&packages.iter().collect::<Vec<_>>(), false);
@@ -140,6 +141,7 @@ fn github_actions_form_their_own_group() {
         rendered,
         vec![("devDependencies", vec!["foo"]), ("GitHub Actions", vec!["actions/checkout"])],
     );
+    assert!(groups[1].rows[1].label.contains("https://github.com/actions/checkout"));
 }
 
 /// A long version must not wrap the row onto a second line, and both
@@ -257,7 +259,23 @@ fn control_characters_in_registry_metadata_are_stripped() {
     let row = &groups[0].rows[1];
     assert!(!row.label.contains('\u{1b}'), "escape survived: {:?}", row.label);
     assert!(!row.label.contains('\n'), "newline survived: {:?}", row.label);
-    assert!(row.label.contains("https://example.test/"), "url lost: {:?}", row.label);
+    assert!(
+        row.label.contains("https://npmx.dev/package-changelog/") && row.label.contains("/v/2.0.0"),
+        "changelog URL missing: {:?}",
+        row.label,
+    );
+    assert!(!row.label.contains("https://example.test/"), "homepage survived: {:?}", row.label);
+}
+
+#[test]
+fn scoped_packages_link_to_their_npmx_changelog() {
+    let packages = [pkg("@pnpm/config", "@pnpm/config", "1.0.0", "2.0.0", DependencyGroup::Prod)];
+
+    let groups = update_choices(&packages.iter().collect::<Vec<_>>(), false);
+
+    assert!(
+        groups[0].rows[1].label.contains("https://npmx.dev/package-changelog/@pnpm/config/v/2.0.0"),
+    );
 }
 
 /// Inside a workspace the list gains a `Workspace` column naming the

--- a/pnpm11/installing/commands/src/update/getUpdateChoices.ts
+++ b/pnpm11/installing/commands/src/update/getUpdateChoices.ts
@@ -157,9 +157,13 @@ export function sanitizeUpdateChoiceText (text: string): string {
   return text.replace(/[\u0000-\u001F\u007F-\u009F\u00AD\u0600-\u0605\u061C\u06DD\u070F\u0890\u0891\u08E2\u180E\u200B-\u200F\u202A-\u202E\u2060-\u2064\u2066-\u206F\uFEFF\uFFF9-\uFFFB\u{110BD}\u{110CD}\u{13430}-\u{1343F}\u{1BCA0}-\u{1BCA3}\u{1D173}-\u{1D17A}\u{E0001}\u{E0020}-\u{E007F}]/gu, '')
 }
 
-function getPkgUrl (pkg: OutdatedPackage): string {
+function getPkgUrl (pkg: UpdateChoiceDependency): string {
+  if (pkg.dependencyType !== 'githubAction' && pkg.latestManifest != null) {
+    return `https://npmx.dev/package-changelog/${pkg.packageName}/v/${pkg.latestManifest.version}`
+  }
+
   if (pkg.latestManifest?.homepage) {
-    return pkg.latestManifest?.homepage
+    return pkg.latestManifest.homepage
   }
 
   if (typeof pkg.latestManifest?.repository !== 'string') {

--- a/pnpm11/installing/commands/test/update/getUpdateChoices.test.ts
+++ b/pnpm11/installing/commands/test/update/getUpdateChoices.test.ts
@@ -86,15 +86,15 @@ test('getUpdateChoices()', () => {
         message: 'dependencies',
         choices: [
           {
-            name: 'Package                                                    Current   Target            URL              ',
-            message: 'Package                                                    Current   Target            URL              ',
+            name: 'Package                                                    Current   Target            URL                                            ',
+            message: 'Package                                                    Current   Target            URL                                            ',
             disabled: true,
             hint: '',
             short: '',
             value: '',
           },
           {
-            message: `foo                                                          1.0.0 ❯ ${chalk.redBright.bold('2.0.0')}             https://pnpm.io/ `,
+            message: `foo                                                          1.0.0 ❯ ${chalk.redBright.bold('2.0.0')}             https://npmx.dev/package-changelog/foo/v/2.0.0 `,
             value: 'foo',
             name: 'foo',
             short: 'foo',
@@ -106,27 +106,27 @@ test('getUpdateChoices()', () => {
         message: 'devDependencies',
         choices: [
           {
-            name: 'Package                                                    Current   Target            URL ',
-            message: 'Package                                                    Current   Target            URL ',
+            name: 'Package                                                    Current   Target            URL                                            ',
+            message: 'Package                                                    Current   Target            URL                                            ',
             disabled: true,
             hint: '',
             short: '',
             value: '',
           },
           {
-            message: `qar                                                          1.0.0 ❯ 1.${chalk.yellowBright.bold('2.0')}                 `,
+            message: `qar                                                          1.0.0 ❯ 1.${chalk.yellowBright.bold('2.0')}             https://npmx.dev/package-changelog/qar/v/1.2.0 `,
             name: 'qar',
             short: 'qar',
             value: 'qar',
           },
           {
-            message: `zoo                                                          1.1.0 ❯ 1.${chalk.yellowBright.bold('2.0')}                 `,
+            message: `zoo                                                          1.1.0 ❯ 1.${chalk.yellowBright.bold('2.0')}             https://npmx.dev/package-changelog/zoo/v/1.2.0 `,
             name: 'zoo',
             short: 'zoo',
             value: 'zoo',
           },
           {
-            message: `foo                                                          1.0.1 ❯ 1.${chalk.yellowBright.bold('2.0')}                 `,
+            message: `foo                                                          1.0.1 ❯ 1.${chalk.yellowBright.bold('2.0')}             https://npmx.dev/package-changelog/foo/v/1.2.0 `,
             name: 'foo',
             short: 'foo',
             value: 'foo',
@@ -138,15 +138,15 @@ test('getUpdateChoices()', () => {
         message: 'optionalDependencies',
         choices: [
           {
-            name: 'Package                                                    Current   Target            URL ',
-            message: 'Package                                                    Current   Target            URL ',
+            name: 'Package                                                    Current   Target            URL                                            ',
+            message: 'Package                                                    Current   Target            URL                                            ',
             disabled: true,
             hint: '',
             short: '',
             value: '',
           },
           {
-            message: `qaz                                                          1.0.1 ❯ 1.${chalk.yellowBright.bold('2.0')}                 `,
+            message: `qaz                                                          1.0.1 ❯ 1.${chalk.yellowBright.bold('2.0')}             https://npmx.dev/package-changelog/qaz/v/1.2.0 `,
             name: 'qaz',
             short: 'qaz',
             value: 'qaz',
@@ -186,6 +186,7 @@ test('getUpdateChoices() handles long version strings without wrapping', () => {
   // within the version string, which would break a plain substring match
   // when chalk has colors enabled.
   expect(stripVTControlCharacters(dataRow.message)).toContain('7.0.0-dev.20251214.1')
+  expect(dataRow.message).toContain('https://npmx.dev/package-changelog/@typescript/native-preview/v/7.0.0-dev.20251214.1')
 })
 
 test('getUpdateChoices() sizes the version columns by their rendered width', () => {
@@ -229,6 +230,7 @@ test('getUpdateChoices() groups GitHub Actions separately', () => {
   expect(choices).toHaveLength(1)
   expect(choices[0].message).toBe('GitHub Actions')
   expect(choices[0].choices[1]).toMatchObject({ name: 'actions/checkout', value: 'actions/checkout' })
+  expect(stripVTControlCharacters(choices[0].choices[1].message)).toContain('https://github.com/actions/checkout')
 })
 
 test('getUpdateChoices() names every workspace a collapsed choice came from', () => {
@@ -278,7 +280,8 @@ test('getUpdateChoices() strips control and formatting characters from labels it
   expect(cells).not.toContain('\u001b')
   expect(dataRow.message).not.toContain('\n')
   expect(dataRow.message).not.toMatch(/[\u202E\u2066\u2069]/u)
-  expect(dataRow.message).toContain('https://example.test/')
+  expect(dataRow.message).toContain('https://npmx.dev/package-changelog/foo/v/2.0.0')
+  expect(dataRow.message).not.toContain('https://example.test/')
   expect(dataRow.value).toBe('foo\u202E')
   expect(dataRow.short).toBe('foo')
 })


### PR DESCRIPTION
## Summary

- Link npm package rows in `pnpm update --interactive` to the target version's changelog on npmx.
- Keep GitHub Actions linked to their repository homepage.
- Mirror the behavior in pacquet and cover unscoped, scoped, GitHub Action, and sanitized metadata cases.

This addresses the rendering layer behind https://github.com/voidzero-dev/vite-plus/issues/2424.

## Squash Commit Body

```text
Link npm package rows in interactive updates to their target-version changelog on npmx.
Keep GitHub Actions on their repository homepage and mirror the behavior in pacquet.

Related to https://github.com/voidzero-dev/vite-plus/issues/2424
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) because this changes published packages.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789086916&installation_model_id=426870&pr_number=13843&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13843&signature=e73ad8f715eb36d1c76123f033dcfb065b3acb3b5fe77db87617a43801b47bd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->