### PR TITLE
perf(resolver): shrink the peer walk's per-occurrence state

### DIFF
--- a/.changeset/peer-resolution-memory.md
+++ b/.changeset/peer-resolution-memory.md
@@ -1,5 +1,5 @@
 ---
-"pnpm": patch
+"pacquet": patch
 ---
 
-Reduced the memory the dependency resolver holds while resolving peer dependencies. Workspaces whose peer dependency graph contains many cycles realize millions of per-occurrence tree nodes, and each one was carrying more state than it needed.
+Reduced peak memory usage while resolving peer dependencies. Workspaces with large, deeply peer-dependent dependency graphs could need gigabytes to install; the same install now needs meaningfully less.

--- a/.changeset/peer-resolution-memory.md
+++ b/.changeset/peer-resolution-memory.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+Reduced the memory the dependency resolver holds while resolving peer dependencies. Workspaces whose peer dependency graph contains many cycles realize millions of per-occurrence tree nodes, and each one was carrying more state than it needed.

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
@@ -674,7 +674,7 @@ fn settle_seeds(
             insert_walked_node(
                 ctx,
                 &pending,
-                crate::resolved_tree::TreeChildren::Realized(BTreeMap::new()),
+                crate::resolved_tree::TreeChildren::Realized(std::sync::Arc::new(BTreeMap::new())),
             );
             continue;
         }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
@@ -1068,7 +1068,7 @@ impl WorkspaceTreeCtx {
                 continue;
             };
             if let Some(node) = tree.get_mut(&dep.node_id) {
-                node.locked_peer_names = Some(Arc::clone(names));
+                node.locked_mut().locked_peer_names = Some(Arc::clone(names));
             }
         }
     }
@@ -1351,10 +1351,10 @@ impl ChildrenRecording {
         match self {
             ChildrenRecording::Declined => (lazy_children(parent_ids), false),
             ChildrenRecording::Published => {
-                (crate::resolved_tree::TreeChildren::Realized(realized), false)
+                (crate::resolved_tree::TreeChildren::Realized(std::sync::Arc::new(realized)), false)
             }
             ChildrenRecording::PublishedOverStale => {
-                (crate::resolved_tree::TreeChildren::Realized(realized), true)
+                (crate::resolved_tree::TreeChildren::Realized(std::sync::Arc::new(realized)), true)
             }
         }
     }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx/tests.rs
@@ -25,7 +25,7 @@ fn importer_snapshot_excludes_other_importers_occurrence_nodes() {
             root.clone(),
             DependenciesTreeNode::new(
                 "root@1.0.0".to_string(),
-                TreeChildren::Realized(BTreeMap::from([("child".to_string(), child.clone())])),
+                TreeChildren::Realized(BTreeMap::from([("child".to_string(), child.clone())]).into()),
                 0,
                 true,
             ),

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx/tests.rs
@@ -25,7 +25,9 @@ fn importer_snapshot_excludes_other_importers_occurrence_nodes() {
             root.clone(),
             DependenciesTreeNode::new(
                 "root@1.0.0".to_string(),
-                TreeChildren::Realized(BTreeMap::from([("child".to_string(), child.clone())]).into()),
+                TreeChildren::Realized(
+                    BTreeMap::from([("child".to_string(), child.clone())]).into(),
+                ),
                 0,
                 true,
             ),

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -530,7 +530,7 @@ fn build_node_ids_by_previous_dep_path(
     let mut node_ids: Vec<&NodeId> = tree.dependencies_tree.keys().collect();
     node_ids.sort();
     for node_id in node_ids {
-        if let Some(previous) = tree.dependencies_tree[node_id].previous_dep_path.as_ref()
+        if let Some(previous) = tree.dependencies_tree[node_id].previous_dep_path()
             && !map.contains_key(previous)
         {
             map.insert(previous.clone(), node_id.clone());

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/cache.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/cache.rs
@@ -169,6 +169,8 @@ impl Walker<'_> {
         })
     }
 
+    
+
     /// Compare two `NodeId`s' recorded parent peer contexts:
     /// both nodes' contexts must have the same set of peer-relevant
     /// names, every name must resolve to the same version or
@@ -505,8 +507,8 @@ impl Walker<'_> {
                 .get(parent_node_id)
                 .is_some_and(|node| node.resolved_package_id == current_pkg_id);
             if same_pkg {
-                for (alias, child_node_id) in self.realize_children(parent_node_id).0 {
-                    children.entry(alias).or_insert(child_node_id);
+                for (alias, child_node_id) in self.realize_children(parent_node_id).0.iter() {
+                    children.entry(alias.clone()).or_insert_with(|| child_node_id.clone());
                 }
             }
         }
@@ -609,7 +611,7 @@ impl Walker<'_> {
     fn realize_children(
         &mut self,
         node_id: &NodeId,
-    ) -> (BTreeMap<String, NodeId>, Option<UndoRealize>) {
+    ) -> (Arc<BTreeMap<String, NodeId>>, Option<UndoRealize>) {
         self.realize_children_with(node_id, None)
     }
 
@@ -617,13 +619,14 @@ impl Walker<'_> {
         &mut self,
         node_id: &NodeId,
         previewed: Option<&BTreeMap<String, NodeId>>,
-    ) -> (BTreeMap<String, NodeId>, Option<UndoRealize>) {
+    ) -> (Arc<BTreeMap<String, NodeId>>, Option<UndoRealize>) {
         // Snapshot the bits we need; we'll mutate `self.tree` below
         // and can't hold a borrow on the entry across the mutation.
         let (parent_ids, pkg_id, depth) = {
             let node = &self.tree.dependencies_tree[node_id];
             match &node.children {
-                TreeChildren::Realized(map) => return (map.clone(), None),
+                // Cheap: the realized map is shared, not copied per revisit.
+                TreeChildren::Realized(map) => return (Arc::clone(map), None),
                 TreeChildren::Lazy { parent_ids } => {
                     (parent_ids.clone(), node.resolved_package_id.clone(), node.depth)
                 }
@@ -677,10 +680,11 @@ impl Walker<'_> {
             }
             realized.insert(edge.alias.clone(), child_node_id);
         }
+        let realized = Arc::new(realized);
         // Replace this node's `Lazy` with `Realized` so future
         // visitors reuse the work.
         if let Some(node) = self.tree.dependencies_tree.get_mut(node_id) {
-            node.children = TreeChildren::Realized(realized.clone());
+            node.children = TreeChildren::Realized(Arc::clone(&realized));
         }
         (realized, Some(UndoRealize { newly_inserted, prev_parent_ids: parent_ids }))
     }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/cache.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/cache.rs
@@ -169,8 +169,6 @@ impl Walker<'_> {
         })
     }
 
-    
-
     /// Compare two `NodeId`s' recorded parent peer contexts:
     /// both nodes' contexts must have the same set of peer-relevant
     /// names, every name must resolve to the same version or

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/finalize.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/finalize.rs
@@ -220,6 +220,9 @@ impl Walker<'_> {
     /// and the absence already surfaced via
     /// [`crate::PeerDependencyIssues::missing`].
     pub(super) fn patch_pending_peer_edges(&mut self) {
+        // Cleared with the buffer: a triple pushed after this drain must be
+        // applied again, since the graph it patches has moved on.
+        self.pending_peer_edge_keys.clear();
         for edge in std::mem::take(&mut self.pending_peer_edges) {
             let Some(child_dep_path) = self.node_dep_paths.get(&edge.child_node_id).cloned() else {
                 continue;
@@ -710,11 +713,22 @@ impl Walker<'_> {
             // edge can use it verbatim.
             graph_children.insert(alias, link_dep_path);
         } else {
-            self.pending_peer_edges.push(PendingPeerEdge {
-                parent_dep_path: parent_dep_path.clone(),
-                child_alias: alias,
-                child_node_id: node_id,
-            });
+            // Exact duplicates are no-ops: `patch_pending_peer_edges`
+            // resolves the same `child_node_id` to the same `DepPath` and
+            // then `or_insert`s the same `(parent, alias)` slot. A parent
+            // reached through many occurrences pushes the same triple over
+            // and over, so drop repeats instead of buffering millions.
+            if self.pending_peer_edge_keys.insert((
+                parent_dep_path.clone(),
+                alias.clone(),
+                node_id.clone(),
+            )) {
+                self.pending_peer_edges.push(PendingPeerEdge {
+                    parent_dep_path: parent_dep_path.clone(),
+                    child_alias: alias,
+                    child_node_id: node_id,
+                });
+            }
         }
     }
 }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/test_support.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/test_support.rs
@@ -17,7 +17,12 @@ pub(super) fn tree_node(
     children: BTreeMap<String, NodeId>,
     depth: i32,
 ) -> DependenciesTreeNode {
-    DependenciesTreeNode::new(pkg_id.to_string(), TreeChildren::Realized(Arc::new(children)), depth, true)
+    DependenciesTreeNode::new(
+        pkg_id.to_string(),
+        TreeChildren::Realized(Arc::new(children)),
+        depth,
+        true,
+    )
 }
 
 pub(super) fn walker_for_tests(tree: &mut ResolvedTree) -> Walker<'_> {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/test_support.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/test_support.rs
@@ -17,7 +17,7 @@ pub(super) fn tree_node(
     children: BTreeMap<String, NodeId>,
     depth: i32,
 ) -> DependenciesTreeNode {
-    DependenciesTreeNode::new(pkg_id.to_string(), TreeChildren::Realized(children), depth, true)
+    DependenciesTreeNode::new(pkg_id.to_string(), TreeChildren::Realized(Arc::new(children)), depth, true)
 }
 
 pub(super) fn walker_for_tests(tree: &mut ResolvedTree) -> Walker<'_> {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -1789,6 +1789,25 @@ fn peer_id_pair_leaves_an_ordinary_registry_package_bare() {
     assert_eq!(version, "1.0.0");
 }
 
+/// A graph node carrying nothing but its identity — enough for the
+/// pending-edge tests, which only read and write `children`.
+fn graph_node(dep_path: &DepPath) -> crate::dependencies_graph::DependenciesGraphNode {
+    crate::dependencies_graph::DependenciesGraphNode {
+        dep_path: dep_path.clone(),
+        resolved_package_id: dep_path.to_string(),
+        resolve_result: std::sync::Arc::new(resolve_result("parent", "1.0.0")),
+        children: BTreeMap::new(),
+        optional_children: HashSet::default(),
+        peer_dependencies: BTreeMap::new(),
+        transitive_peer_dependencies: HashSet::default(),
+        resolved_peer_names: HashSet::default(),
+        depth: 0,
+        installable: true,
+        is_pure: true,
+        optional: false,
+    }
+}
+
 /// A parent reached through many occurrences enqueues the identical
 /// `(parent_dep_path, alias, child_node_id)` triple over and over —
 /// millions of times on a cyclic peer graph. Replaying a repeat is a
@@ -1824,9 +1843,59 @@ fn repeated_pending_peer_edges_are_buffered_once() {
         &mut graph_children,
         &parent,
         "child".to_string(),
-        second_child,
+        second_child.clone(),
     );
     assert_eq!(walker.pending_peer_edges.len(), 2, "dedup is by triple, not by (parent, alias)");
+
+    // What the buffer holds only matters through the graph it patches.
+    // Leave the first child unresolved: `patch_pending_peer_edges` is
+    // first-*resolvable*-wins, so the edge must come from the second
+    // triple. Deduplicating by `(parent, alias)` instead of by whole
+    // triple would have dropped that triple and left no edge at all.
+    let second_dep_path = DepPath::from("child@2.0.0");
+    walker.node_dep_paths.insert(second_child, second_dep_path.clone());
+    walker.graph.insert(parent.clone(), graph_node(&parent));
+    walker.patch_pending_peer_edges();
+
+    assert_eq!(
+        walker.graph[&parent].children.get("child"),
+        Some(&second_dep_path),
+        "an unresolvable first triple yields to the next one for the same slot",
+    );
+}
+
+/// The other half of first-resolvable-wins: when the earlier triple
+/// does resolve, it keeps the slot and the later one is ignored.
+#[test]
+fn the_first_resolvable_pending_edge_keeps_the_slot() {
+    let mut tree = ResolvedTree::default();
+    let mut walker = walker_for_tests(&mut tree);
+
+    let parent = DepPath::from("parent@1.0.0");
+    let first_child = NodeId::next();
+    let second_child = NodeId::next();
+    let mut graph_children = BTreeMap::new();
+
+    for child in [&first_child, &second_child] {
+        walker.add_graph_child_or_pending(
+            &mut graph_children,
+            &parent,
+            "child".to_string(),
+            child.clone(),
+        );
+    }
+
+    let first_dep_path = DepPath::from("child@1.0.0");
+    walker.node_dep_paths.insert(first_child, first_dep_path.clone());
+    walker.node_dep_paths.insert(second_child, DepPath::from("child@2.0.0"));
+    walker.graph.insert(parent.clone(), graph_node(&parent));
+    walker.patch_pending_peer_edges();
+
+    assert_eq!(
+        walker.graph[&parent].children.get("child"),
+        Some(&first_dep_path),
+        "`or_insert` leaves an already-filled slot alone",
+    );
 }
 
 /// The membership guard lives and dies with the buffer: once the edges

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -1633,11 +1633,11 @@ mod locked_peer_provider_preferences {
     /// binding `peer` to `peer@2.0.0`.
     fn locked_provider_tree(ids: &LockedTreeIds, peer_range: &str) -> ResolvedTree {
         let mut current_peer_node = tree_node("peer@1.0.0", BTreeMap::new(), 0);
-        current_peer_node.previous_dep_path = Some(DepPath::from("peer@1.0.0"));
+        current_peer_node.locked_mut().previous_dep_path = Some(DepPath::from("peer@1.0.0"));
         let mut retained_peer_node = tree_node("peer@2.0.0", BTreeMap::new(), 1);
-        retained_peer_node.previous_dep_path = Some(DepPath::from("peer@2.0.0"));
+        retained_peer_node.locked_mut().previous_dep_path = Some(DepPath::from("peer@2.0.0"));
         let mut consumer_node = tree_node("consumer@1.0.0", BTreeMap::new(), 1);
-        consumer_node.locked_peer_context =
+        consumer_node.locked_mut().locked_peer_context =
             Some(BTreeMap::from([("peer".to_string(), DepPath::from("peer@2.0.0"))]));
         ResolvedTree {
             direct: vec![

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -1788,3 +1788,95 @@ fn peer_id_pair_leaves_an_ordinary_registry_package_bare() {
     assert_eq!(name, "foo");
     assert_eq!(version, "1.0.0");
 }
+
+/// A parent reached through many occurrences enqueues the identical
+/// `(parent_dep_path, alias, child_node_id)` triple over and over —
+/// millions of times on a cyclic peer graph. Replaying a repeat is a
+/// no-op, because it resolves the same `DepPath` and `or_insert`s a
+/// slot that is already filled, so the buffer keeps only the first.
+/// Distinct triples must still all be kept: dedup is by whole triple,
+/// never by `(parent, alias)` slot, or the first-resolvable-wins
+/// behaviour of `patch_pending_peer_edges` would change.
+#[test]
+fn repeated_pending_peer_edges_are_buffered_once() {
+    let mut tree = ResolvedTree::default();
+    let mut walker = walker_for_tests(&mut tree);
+
+    let parent = DepPath::from("parent@1.0.0");
+    let first_child = NodeId::next();
+    let second_child = NodeId::next();
+    let mut graph_children = BTreeMap::new();
+
+    for _ in 0..3 {
+        walker.add_graph_child_or_pending(
+            &mut graph_children,
+            &parent,
+            "child".to_string(),
+            first_child.clone(),
+        );
+    }
+
+    assert!(graph_children.is_empty(), "the child has no depPath yet, so nothing is a graph edge");
+    assert_eq!(walker.pending_peer_edges.len(), 1, "the same triple is buffered once");
+
+    // Same slot, different child: a distinct triple, so it is kept.
+    walker.add_graph_child_or_pending(
+        &mut graph_children,
+        &parent,
+        "child".to_string(),
+        second_child,
+    );
+    assert_eq!(walker.pending_peer_edges.len(), 2, "dedup is by triple, not by (parent, alias)");
+}
+
+/// The membership guard lives and dies with the buffer: once the edges
+/// are drained into the graph, a triple enqueued again describes a
+/// graph that has moved on and must be replayed.
+#[test]
+fn pending_peer_edges_replay_after_a_drain() {
+    let mut tree = ResolvedTree::default();
+    let mut walker = walker_for_tests(&mut tree);
+
+    let parent = DepPath::from("parent@1.0.0");
+    let child = NodeId::next();
+    let mut graph_children = BTreeMap::new();
+
+    walker.add_graph_child_or_pending(
+        &mut graph_children,
+        &parent,
+        "child".to_string(),
+        child.clone(),
+    );
+    walker.patch_pending_peer_edges();
+    assert!(walker.pending_peer_edges.is_empty(), "the drain empties the buffer");
+
+    walker.add_graph_child_or_pending(&mut graph_children, &parent, "child".to_string(), child);
+    assert_eq!(walker.pending_peer_edges.len(), 1, "the guard cleared with the buffer");
+}
+
+/// Every revisit of an already-realized node hands back the same map
+/// rather than a copy of it. The walk revisits nodes millions of times
+/// on a cyclic peer graph, and the map owns a `String` per child alias,
+/// so cloning here is what the shared `Arc` exists to avoid.
+#[test]
+fn realized_children_are_shared_across_visits() {
+    let parent = NodeId::next();
+    let mut children = BTreeMap::new();
+    children.insert("child".to_string(), NodeId::leaf("child@1.0.0"));
+
+    let mut tree = ResolvedTree::default();
+    tree.dependencies_tree.insert(parent.clone(), tree_node("parent@1.0.0", children, 0));
+    let mut walker = walker_for_tests(&mut tree);
+
+    let (first, first_undo) = walker.realize_children_with(&parent, None);
+    let (second, second_undo) = walker.realize_children_with(&parent, None);
+
+    assert!(
+        std::sync::Arc::ptr_eq(&first, &second),
+        "a revisit reuses the realized map instead of cloning it",
+    );
+    assert!(
+        first_undo.is_none() && second_undo.is_none(),
+        "an already-realized node realizes nothing, so there is nothing to undo",
+    );
+}

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
@@ -72,6 +72,9 @@ pub(super) struct Walker<'tree> {
     /// would walk the parent's `children` map and find no symlink edge
     /// for the child, leaving the package without it in its slot.
     pub(super) pending_peer_edges: Vec<PendingPeerEdge>,
+    /// Membership guard for [`Walker::pending_peer_edges`], keeping the
+    /// buffer free of exact duplicates. Cleared whenever the buffer drains.
+    pub(super) pending_peer_edge_keys: HashSet<(DepPath, String, NodeId)>,
     /// Set of `pkgIdWithPatchHash` values whose full subtree resolved
     /// with zero external peers and zero missing peers. A revisit of
     /// any such package whose own `peerDependencies` is empty
@@ -133,6 +136,7 @@ pub(super) struct Walker<'tree> {
 }
 
 impl<'tree> Walker<'tree> {
+
     pub(super) fn new(
         tree: &'tree mut ResolvedTree,
         opts: ResolvePeersOptions,
@@ -194,6 +198,7 @@ impl<'tree> Walker<'tree> {
             resolved_peer_providers_by_alias: BTreeMap::new(),
             in_progress: HashSet::default(),
             pending_peer_edges: Vec::new(),
+            pending_peer_edge_keys: HashSet::default(),
             pure_pkgs,
             peers_cache,
             parent_pkgs_of_node,
@@ -585,7 +590,7 @@ impl Walker<'_> {
 
         let fast_cached = {
             let tree_node = &self.tree.dependencies_tree[node_id];
-            (tree_node.locked_peer_names.is_none() && tree_node.locked_peer_context.is_none())
+            tree_node.has_no_locked_peers()
                 .then(|| {
                     self.find_fast_hit(node_id, parent_parent_refs, &tree_node.resolved_package_id)
                 })
@@ -611,7 +616,7 @@ impl Walker<'_> {
                 tree_node.resolved_package_id.clone(),
                 tree_node.depth,
                 tree_node.installable,
-                tree_node.locked_peer_names.clone(),
+                tree_node.locked_peer_names().cloned(),
             )
         };
         let pkg = self.owned_package(&pkg_id);
@@ -683,7 +688,7 @@ impl Walker<'_> {
             None
         };
         let (children_map, realize_undo) = if discovery_children.is_some() {
-            (BTreeMap::new(), None)
+            (Arc::new(BTreeMap::new()), None)
         } else {
             self.realize_children_with(node_id, Some(&provider_children))
         };
@@ -744,7 +749,7 @@ impl Walker<'_> {
         } else {
             let child_aliases = ChildAliases::Realized(&children_map);
             for repeated in [true, false] {
-                for (alias, child_node_id) in &children_map {
+                for (alias, child_node_id) in children_map.iter() {
                     if child_parent_refs.contains_key(alias) != repeated {
                         continue;
                     }
@@ -1056,7 +1061,7 @@ impl Walker<'_> {
             self.tree
                 .dependencies_tree
                 .get(node_id)
-                .and_then(|tree_node| tree_node.locked_peer_context.as_ref()),
+                .and_then(crate::resolved_tree::DependenciesTreeNode::locked_peer_context),
             self.opts.resolved_peer_provider_paths.as_ref(),
         ) else {
             return pins;
@@ -1146,7 +1151,7 @@ impl Walker<'_> {
                                 .tree
                                 .dependencies_tree
                                 .get(peer_node_id)
-                                .is_none_or(|node| node.previous_dep_path.is_none())))
+                                .is_none_or(|node| node.previous_dep_path().is_none())))
                 {
                     return true;
                 }
@@ -1157,7 +1162,7 @@ impl Walker<'_> {
                 continue;
             };
             let Some(must_win) =
-                parent_node.dependency_names_whose_current_provider_must_win.as_ref()
+                parent_node.must_win_dependency_names()
             else {
                 continue;
             };

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
@@ -136,7 +136,6 @@ pub(super) struct Walker<'tree> {
 }
 
 impl<'tree> Walker<'tree> {
-
     pub(super) fn new(
         tree: &'tree mut ResolvedTree,
         opts: ResolvePeersOptions,
@@ -590,7 +589,8 @@ impl Walker<'_> {
 
         let fast_cached = {
             let tree_node = &self.tree.dependencies_tree[node_id];
-            tree_node.has_no_locked_peers()
+            tree_node
+                .has_no_locked_peers()
                 .then(|| {
                     self.find_fast_hit(node_id, parent_parent_refs, &tree_node.resolved_package_id)
                 })
@@ -1161,9 +1161,7 @@ impl Walker<'_> {
             let Some(parent_node) = self.tree.dependencies_tree.get(parent_node_id) else {
                 continue;
             };
-            let Some(must_win) =
-                parent_node.must_win_dependency_names()
-            else {
+            let Some(must_win) = parent_node.must_win_dependency_names() else {
                 continue;
             };
             // Ancestors on the walk path always have realized children.

--- a/pnpm/crates/resolving-deps-resolver/src/resolved_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolved_tree.rs
@@ -196,21 +196,12 @@ pub struct PeerDep {
     pub optional: bool,
 }
 
-/// One per-occurrence node in the dependencies tree.
-#[derive(Debug, Clone)]
-pub struct DependenciesTreeNode {
-    /// Key into [`ResolvedTree::packages`].
-    pub resolved_package_id: String,
-    /// `alias → child NodeId` edges, possibly deferred.
-    pub children: TreeChildren,
-    /// Distance from the root importer (root = 0). A `depth = -1` marks
-    /// linked / pruned nodes; pacquet doesn't emit `-1` today because
-    /// workspace-link resolution hasn't been implemented.
-    pub depth: i32,
-    /// Whether the package may be skipped when an optional dep fails
-    /// for its host platform. Always `true` for the npm-shaped slice
-    /// pacquet currently exposes.
-    pub installable: bool,
+/// The wanted-lockfile carry-over a [`DependenciesTreeNode`] may hold.
+///
+/// Split out of the node so the common case — a fresh resolution, with
+/// none of these set — costs one null pointer instead of four `Option`s.
+#[derive(Debug, Clone, Default)]
+pub struct LockedResolution {
     /// `DepPath` this occurrence's package resolved to in the wanted
     /// lockfile, when its resolution was reused from it. Feeds the
     /// reverse index that locked-peer-provider reuse looks providers
@@ -240,6 +231,28 @@ pub struct DependenciesTreeNode {
     pub locked_peer_names: Option<Arc<HashSet<String>>>,
 }
 
+/// One per-occurrence node in the dependencies tree.
+#[derive(Debug, Clone)]
+pub struct DependenciesTreeNode {
+    /// Key into [`ResolvedTree::packages`].
+    pub resolved_package_id: String,
+    /// `alias → child NodeId` edges, possibly deferred.
+    pub children: TreeChildren,
+    /// Distance from the root importer (root = 0). A `depth = -1` marks
+    /// linked / pruned nodes; pacquet doesn't emit `-1` today because
+    /// workspace-link resolution hasn't been implemented.
+    pub depth: i32,
+    /// Whether the package may be skipped when an optional dep fails
+    /// for its host platform. Always `true` for the npm-shaped slice
+    /// pacquet currently exposes.
+    pub installable: bool,
+    /// Wanted-lockfile carry-over for this occurrence, boxed because it
+    /// is `None` for every fresh resolution — which is every node the
+    /// resolver produces today. Inline, its four rarely-set fields cost
+    /// ~88 bytes on each of the millions of nodes the peer walk realizes.
+    pub locked: Option<Box<LockedResolution>>,
+}
+
 impl DependenciesTreeNode {
     /// Node with no wanted-lockfile carry-over (a fresh resolution).
     #[must_use]
@@ -254,11 +267,46 @@ impl DependenciesTreeNode {
             children,
             depth,
             installable,
-            previous_dep_path: None,
-            locked_peer_context: None,
-            dependency_names_whose_current_provider_must_win: None,
-            locked_peer_names: None,
+            locked: None,
         }
+    }
+
+    /// Wanted-lockfile `DepPath` for this occurrence, if it carried one.
+    #[must_use]
+    pub fn previous_dep_path(&self) -> Option<&DepPath> {
+        self.locked.as_ref()?.previous_dep_path.as_ref()
+    }
+
+    /// Locked `peer name → provider DepPath` bindings, if any.
+    #[must_use]
+    pub fn locked_peer_context(&self) -> Option<&BTreeMap<String, DepPath>> {
+        self.locked.as_ref()?.locked_peer_context.as_ref()
+    }
+
+    /// Child aliases whose current provider must win over a locked one.
+    #[must_use]
+    pub fn must_win_dependency_names(&self) -> Option<&HashSet<String>> {
+        self.locked.as_ref()?.dependency_names_whose_current_provider_must_win.as_ref()
+    }
+
+    /// Peer names from this direct dependency's wanted-lockfile suffix.
+    #[must_use]
+    pub fn locked_peer_names(&self) -> Option<&Arc<HashSet<String>>> {
+        self.locked.as_ref()?.locked_peer_names.as_ref()
+    }
+
+    /// `true` when neither locked peer names nor a locked peer context is
+    /// recorded — the fast-cache precondition.
+    #[must_use]
+    pub fn has_no_locked_peers(&self) -> bool {
+        self.locked.as_ref().is_none_or(|locked| {
+            locked.locked_peer_names.is_none() && locked.locked_peer_context.is_none()
+        })
+    }
+
+    /// The carry-over slot, allocated on first write.
+    pub fn locked_mut(&mut self) -> &mut LockedResolution {
+        self.locked.get_or_insert_with(Box::default)
     }
 }
 
@@ -276,7 +324,9 @@ pub enum TreeChildren {
     /// `alias → child NodeId` map, fully populated. `BTreeMap` keeps
     /// iteration order stable so downstream peer-suffix construction
     /// is deterministic.
-    Realized(BTreeMap<String, NodeId>),
+    /// Shared: a node's realized children are immutable once built, and
+    /// the peer walk hands the same map to every revisit of the node.
+    Realized(Arc<BTreeMap<String, NodeId>>),
     /// Children are known by spec only. `parent_ids` is the chain of
     /// `pkgIdWithPatchHash` ancestors this occurrence reached the
     /// node through, excluding the node itself. The reader appends the
@@ -295,7 +345,7 @@ impl TreeChildren {
     /// to construct an empty `BTreeMap` themselves.
     #[must_use]
     pub fn empty() -> Self {
-        TreeChildren::Realized(BTreeMap::new())
+        TreeChildren::Realized(Arc::new(BTreeMap::new()))
     }
 
     /// Borrow the realized children map.

--- a/pnpm/crates/resolving-deps-resolver/src/resolved_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolved_tree.rs
@@ -200,7 +200,7 @@ pub struct PeerDep {
 ///
 /// Split out of the node so the common case — a fresh resolution, with
 /// none of these set — costs one null pointer instead of four `Option`s.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct LockedResolution {
     /// `DepPath` this occurrence's package resolved to in the wanted
     /// lockfile, when its resolution was reused from it. Feeds the
@@ -262,13 +262,7 @@ impl DependenciesTreeNode {
         depth: i32,
         installable: bool,
     ) -> Self {
-        DependenciesTreeNode {
-            resolved_package_id,
-            children,
-            depth,
-            installable,
-            locked: None,
-        }
+        DependenciesTreeNode { resolved_package_id, children, depth, installable, locked: None }
     }
 
     /// Wanted-lockfile `DepPath` for this occurrence, if it carried one.

--- a/pnpm/crates/resolving-deps-resolver/src/resolved_tree/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolved_tree/tests.rs
@@ -20,3 +20,46 @@ fn detects_cycle_sequences_across_base_and_appended_ids() {
     assert!(!ids.forms_cycle("e", "a"));
     assert!(!ids.forms_cycle("missing", "e"));
 }
+
+/// The peer walk realizes one of these per distinct root-to-package
+/// path — millions of them on a workspace with a large, cyclic peer
+/// graph — so an extra inline field is not a few bytes but a few
+/// hundred megabytes. Wanted-lockfile carry-over lives behind
+/// [`super::LockedResolution`] for that reason; keep it there.
+///
+/// 56 bytes is the current layout on a 64-bit target, not a budget with
+/// room in it: inlining one more `Option<String>` would cost 24.
+#[test]
+fn tree_node_keeps_its_per_occurrence_footprint_small() {
+    assert!(
+        size_of::<super::DependenciesTreeNode>() <= 56,
+        "DependenciesTreeNode grew to {} bytes; box rarely-set state instead of inlining it",
+        size_of::<super::DependenciesTreeNode>(),
+    );
+}
+
+#[test]
+fn locked_resolution_is_unallocated_until_written() {
+    let mut node = super::DependenciesTreeNode::new(
+        "a@1.0.0".to_string(),
+        super::TreeChildren::Realized(Arc::new(std::collections::BTreeMap::new())),
+        0,
+        true,
+    );
+
+    assert!(node.locked.is_none(), "a fresh resolution carries no wanted-lockfile state");
+    assert!(node.previous_dep_path().is_none());
+    assert!(node.locked_peer_context().is_none());
+    assert!(node.must_win_dependency_names().is_none());
+    assert!(node.locked_peer_names().is_none());
+    assert!(node.has_no_locked_peers());
+
+    node.locked_mut().previous_dep_path = Some(pacquet_deps_path::DepPath::from("a@1.0.0"));
+
+    assert_eq!(
+        node.previous_dep_path(),
+        Some(&pacquet_deps_path::DepPath::from("a@1.0.0")),
+        "the accessor reads back what `locked_mut` wrote",
+    );
+    assert!(node.has_no_locked_peers(), "a previous depPath is not a locked peer");
+}


### PR DESCRIPTION
Resolving peer dependencies realizes one tree node per distinct root-to-package path. In a workspace whose peer graph is highly cyclic that count is enormous: resolving the [bit](https://github.com/teambit/bit) monorepo's env packages realizes **2,008,313 occurrences to produce a 6,133-node graph**. Every byte held per occurrence, and every allocation made per visit, is therefore paid two million times.

This PR attacks the per-occurrence cost. It does not change what the walk resolves.

### Changes

**1. `DependenciesTreeNode` carried four wanted-lockfile fields inline.** `previous_dep_path`, `locked_peer_context`, `dependency_names_whose_current_provider_must_win` and `locked_peer_names` are all `None` on a fresh resolution — which is every node the resolver produces today, as three of them are marked "the resolver does not capture this yet" — yet they cost ~88 bytes on every node. Moving them behind a boxed `LockedResolution` takes the node from **144 to 64 bytes**, and the tree's hash table from **676 MB to 356 MB**.

**2. `TreeChildren::Realized` held its children map by value.** `realize_children` therefore cloned the entire `BTreeMap`, every key `String` included, on each revisit of an already-realized node, and stored a second copy on the node itself. The map is immutable once built, so it is now shared through an `Arc`.

**3. `add_graph_child_or_pending` buffered one pending edge per occurrence.** A parent reached through many occurrences pushes the identical `(parent_dep_path, alias, child_node_id)` triple over and over, and replaying a duplicate is a no-op — it resolves the same `DepPath` and `or_insert`s the same slot. Dropping exact repeats takes the buffer from **2,224,865 entries to 114,778**.

### Result

Replaying the same install through `@pnpm/napi` (5 importers, 3,807 merged packages):

| | peak RSS |
| --- | --- |
| before | 3638 / 3698 / 3633 MB |
| after | 3250 / 3229 / 3225 MB |

**3656 → 3235 MB, -11.5%**, n=3 each, non-overlapping ranges, no change in wall time. (Re-measured against `main` after rebasing; the earlier numbers were against the published `12.0.0-rc.1` and were materially the same.)

Byte attribution over the walker's fields, before → after:

| | before | after |
| --- | --- | --- |
| `dependencies_tree` (2.0M entries) | 676 MB | 356 MB |
| `pending_peer_edges` | 224 MB (2,224,865) | 7 MB (114,778) |

### Correctness

`cargo test -p pacquet-resolving-deps-resolver`: 324 passed. `cargo check --workspace --all-targets`, `cargo clippy --all-targets` and `cargo fmt` are clean.

Five of those tests are new, because none of these savings changes observable resolution — so without them nothing in the suite notices a regression. I checked each one actually fails when its fix is reverted: dropping the dedup guard turns `repeated_pending_peer_edges_are_buffered_once` into `left: 3, right: 1`, and inlining a field back onto the node trips the footprint assertion.

- `tree_node_keeps_its_per_occurrence_footprint_small` — 56 bytes is the current layout, not a budget with room in it.
- `repeated_pending_peer_edges_are_buffered_once` — pins *both* halves: repeats collapse, but two distinct triples sharing a `(parent, alias)` slot are both kept, since dropping the second would change which edge `patch_pending_peer_edges` lands on.
- `pending_peer_edges_replay_after_a_drain` — the guard's lifetime is the buffer's.
- `realized_children_are_shared_across_visits` — pointer equality, so map reuse is checked rather than assumed.
- `locked_resolution_is_unallocated_until_written` — the accessors and their lazy allocation.

The lockfile stays within the engine's existing run-to-run variance. Worth flagging on its own: **the engine is not deterministic across runs today.** Two stock runs of the identical install differ from each other by 197 diff lines; stock vs. this branch differs by 173 and 88. All pairs churn the same packages (`classnames`, `tippy.js`, `lodash`, `postcss`), so this branch sits inside the existing envelope rather than adding to it — but the envelope should probably not exist. I can open a separate issue for that.

### What this does *not* fix

The underlying expansion. Instrumenting the walk on this workload:

```
WALK_STATS full_walks=188707 ended_in_cycle=171508 ended_pure=6806 ended_cacheable=10393
HIT_STATS  find_hit_calls=188862 miss_no_bucket=51803 miss_context_mismatch=136904 hits=155
```

**91% of full walks end in a cycle**, and a cycle-resolved walk deliberately caches nothing (#5108 — its truncated subtree makes its peer sets non-authoritative). Only 10,393 walks ever store a `PeersCacheItem`, so `find_hit` hits **155 times in 188,862 lookups (0.08%)** and nearly every occurrence re-walks its whole subtree.

That is the real driver of the 2M occurrences, and fixing it — caching cycle-resolved verdicts under a key that captures the truncation, so they are reused only where valid — would be worth far more than this PR. I did not attempt it here because getting it wrong produces wrong lockfiles rather than merely slow ones. Happy to take it on with guidance on the intended invariant.

Refs #13681

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789091151&installation_model_id=426870&pr_number=13844&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13844&signature=ebe3f19d5c0b4052870ff5c1b3f02f6edf6edbde84c2b9a09ed94f68dfa7ed6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced peak memory usage during dependency resolution, especially for large workspaces with deeply nested peer dependencies.
  * Improved sharing and reuse of dependency data to reduce memory duplication.

* **Bug Fixes**
  * Prevented duplicate peer-dependency edges from being processed.
  * Improved handling of peer dependencies queued across multiple resolution passes.
  * Improved consistency when revisiting resolved dependency data.

* **Release**
  * Included these improvements in a patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
