### PR TITLE
fix(injected-deps-syncer): identify a file by its device as well as its inode

### DIFF
--- a/.changeset/injected-syncer-volume-identity.md
+++ b/.changeset/injected-syncer-volume-identity.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/workspace.injected-deps-syncer": patch
+"pnpm": patch
+---
+
+`syncInjectedDepsAfterScripts` now identifies a file by its device as well as its inode number. An inode number is only unique within one filesystem, so on its own it could match an unrelated file on another device and leave that path stale in the injected copy.

--- a/pnpm11/workspace/injected-deps-syncer/src/DirPatcher.ts
+++ b/pnpm11/workspace/injected-deps-syncer/src/DirPatcher.ts
@@ -6,9 +6,15 @@ import { fetchFromDir, type FetchFromDirOptions } from '@pnpm/fetching.directory
 
 export const DIR: unique symbol = Symbol('Path is a directory')
 
-// symbols and numbers are used instead of discriminated union because
+// symbols and strings are used instead of discriminated union because
 // it's faster and simpler to compare primitives than to deep compare objects
-export type File = number // representing the file's inode, which is sufficient for hardlinks
+/**
+ * A file's identity, as `<device>:<inode>`. An inode number is only unique
+ * within one filesystem, so the device it came from is part of the identity:
+ * without it two unrelated files on different devices can collide and be
+ * taken for the same file, leaving the injected copy stale.
+ */
+export type File = string
 export type Dir = typeof DIR
 
 export type Value = File | Dir
@@ -83,7 +89,7 @@ export async function applyPatch (optimizedDirPatch: DirDiff, sourceDir: string,
   async function addRecursive (sourcePath: string, targetPath: string, value: Value): Promise<void> {
     if (value === DIR) {
       await retryOverBlockingInode(targetPath, async () => fs.promises.mkdir(targetPath, { recursive: true }))
-    } else if (typeof value === 'number') {
+    } else if (typeof value === 'string') {
       fs.mkdirSync(path.dirname(targetPath), { recursive: true })
       await retryOverBlockingInode(targetPath, async () => fs.promises.link(sourcePath, targetPath))
     } else {
@@ -151,7 +157,7 @@ export async function applyPatch (optimizedDirPatch: DirDiff, sourceDir: string,
   await Promise.all(newFiles.map(applyChange))
 }
 
-export type ExtendFilesMapStats = Pick<fs.Stats, 'ino' | 'isFile' | 'isDirectory'>
+export type ExtendFilesMapStats = Pick<fs.Stats, 'dev' | 'ino' | 'isFile' | 'isDirectory'>
 
 export interface ExtendFilesMapOptions {
   /** Map relative path of each file to their real path */
@@ -180,7 +186,7 @@ export async function extendFilesMap ({ filesMap, filesStats }: ExtendFilesMapOp
   await Promise.all(Array.from(filesMap.entries()).map(async ([relativePath, realPath]) => {
     const stats = filesStats?.[relativePath] ?? await fs.promises.stat(realPath)
     if (stats.isFile()) {
-      addInodeAndAncestors(relativePath, stats.ino)
+      addInodeAndAncestors(relativePath, fileId(stats))
     } else if (stats.isDirectory()) {
       addInodeAndAncestors(relativePath, DIR)
     }
@@ -190,6 +196,8 @@ export async function extendFilesMap ({ filesMap, filesStats }: ExtendFilesMapOp
 
   return result
 }
+
+const fileId = (stats: Pick<ExtendFilesMapStats, 'dev' | 'ino'>): File => `${stats.dev}:${stats.ino}`
 
 export class DirPatcher {
   private readonly sourceDir: string

--- a/pnpm11/workspace/injected-deps-syncer/test/DirPatcher.test.ts
+++ b/pnpm11/workspace/injected-deps-syncer/test/DirPatcher.test.ts
@@ -59,7 +59,10 @@ function createFifo (fifoPath: string): void {
   execFileSync('mkfifo', [path.resolve(fifoPath)])
 }
 
-const inodeNumber = (filePath: string): number => fs.lstatSync(filePath).ino
+const fileId = (filePath: string): string => {
+  const stats = fs.lstatSync(filePath)
+  return `${stats.dev}:${stats.ino}`
+}
 
 test('optimally synchronizes source and target', async () => {
   prepareEmpty()
@@ -124,11 +127,11 @@ test('optimally synchronizes source and target', async () => {
   expect(
     filesToModify
       .map(suffix => path.resolve(targetDir, suffix))
-      .map(inodeNumber)
+      .map(fileId)
   ).not.toStrictEqual(
     filesToModify
       .map(suffix => path.resolve(sourceDir, suffix))
-      .map(inodeNumber)
+      .map(fileId)
   )
 
   let fsMethods = mockFsPromises()
@@ -150,11 +153,11 @@ test('optimally synchronizes source and target', async () => {
   expect(
     filesToModify
       .map(suffix => path.resolve(targetDir, suffix))
-      .map(inodeNumber)
+      .map(fileId)
   ).toStrictEqual(
     filesToModify
       .map(suffix => path.resolve(sourceDir, suffix))
-      .map(inodeNumber)
+      .map(fileId)
   )
 
   // does not touch filesToKeep

--- a/pnpm11/workspace/injected-deps-syncer/test/applyPatch.test.ts
+++ b/pnpm11/workspace/injected-deps-syncer/test/applyPatch.test.ts
@@ -45,7 +45,10 @@ function createHardlink (existingPath: string, newPath: string): void {
   fs.linkSync(existingPath, newPath)
 }
 
-const inodeNumber = (filePath: string): number => fs.lstatSync(filePath).ino
+const fileId = (filePath: string): string => {
+  const stats = fs.lstatSync(filePath)
+  return `${stats.dev}:${stats.ino}`
+}
 
 test('applies a patch on a directory', async () => {
   prepareEmpty()
@@ -111,7 +114,7 @@ test('applies a patch on a directory', async () => {
         path: 'files-to-add/a',
         newValue: DIR,
       },
-      ...filesToAdd.map(path => ({ path, newValue: inodeNumber(`source/${path}`) })),
+      ...filesToAdd.map(path => ({ path, newValue: fileId(`source/${path}`) })),
     ],
     removed: [
       {
@@ -122,13 +125,13 @@ test('applies a patch on a directory', async () => {
         path: 'files-to-remove/a',
         oldValue: DIR,
       } as const,
-      ...filesToRemove.map(path => ({ path, oldValue: inodeNumber(`target/${path}`) })),
+      ...filesToRemove.map(path => ({ path, oldValue: fileId(`target/${path}`) })),
     ].reverse(),
     modified: [
       ...filesToModify.map(path => ({
         path,
-        oldValue: inodeNumber(`target/${path}`),
-        newValue: inodeNumber(`source/${path}`),
+        oldValue: fileId(`target/${path}`),
+        newValue: fileId(`source/${path}`),
       })),
     ],
   }
@@ -139,11 +142,11 @@ test('applies a patch on a directory', async () => {
   expect(
     filesToModify
       .map(suffix => `target/${suffix}`)
-      .map(inodeNumber)
+      .map(fileId)
   ).not.toStrictEqual(
     filesToModify
       .map(suffix => `source/${suffix}`)
-      .map(inodeNumber)
+      .map(fileId)
   )
 
   const fsMethods = mockFsPromises()
@@ -156,11 +159,11 @@ test('applies a patch on a directory', async () => {
   expect(
     filesToModify
       .map(suffix => `target/${suffix}`)
-      .map(inodeNumber)
+      .map(fileId)
   ).toStrictEqual(
     filesToModify
       .map(suffix => `source/${suffix}`)
-      .map(inodeNumber)
+      .map(fileId)
   )
 
   // does not touch filesToKeep

--- a/pnpm11/workspace/injected-deps-syncer/test/diffDir.test.ts
+++ b/pnpm11/workspace/injected-deps-syncer/test/diffDir.test.ts
@@ -6,38 +6,38 @@ test('produces a diff', () => {
   const unchangedParts = {
     'not-changed': DIR,
     'not-changed/foo': DIR,
-    'not-changed/foo/foo.txt': 123,
-    'not-changed/foo/bar.txt': 456,
+    'not-changed/foo/foo.txt': '66:123',
+    'not-changed/foo/bar.txt': '66:456',
     'not-changed/bar': DIR,
-    'some-files-changed/not-changed.txt': 623,
-    'some-parts-deleted/file-not-deleted.txt': 624,
-    'some-parts-added/file-not-added.txt': 145,
+    'some-files-changed/not-changed.txt': '66:623',
+    'some-parts-deleted/file-not-deleted.txt': '66:624',
+    'some-parts-added/file-not-added.txt': '66:145',
   } satisfies InodeMap
 
   const oldModifiedParts = {
     'some-files-changed': DIR,
-    'some-files-changed/changed-file.txt': 887,
+    'some-files-changed/changed-file.txt': '66:887',
   } satisfies InodeMap
 
   const newModifiedParts: typeof oldModifiedParts = {
     'some-files-changed': DIR,
-    'some-files-changed/changed-file.txt': 553,
+    'some-files-changed/changed-file.txt': '66:553',
   }
 
   const oldOnlyParts = {
     'some-parts-deleted': DIR,
-    'some-parts-deleted/file-deleted.txt': 654,
+    'some-parts-deleted/file-deleted.txt': '66:654',
     'some-parts-deleted/dir-deleted': DIR,
-    'some-parts-deleted/dir-deleted/foo.txt': 325,
-    'some-parts-deleted/dir-deleted/bar.txt': 231,
+    'some-parts-deleted/dir-deleted/foo.txt': '66:325',
+    'some-parts-deleted/dir-deleted/bar.txt': '66:231',
   } satisfies InodeMap
 
   const newOnlyParts = {
     'some-parts-added': DIR,
-    'some-parts-added/file-added.txt': 362,
+    'some-parts-added/file-added.txt': '66:362',
     'some-parts-added/dir-added': DIR,
-    'some-parts-added/dir-added/foo.txt': 472,
-    'some-parts-added/dir-added/bar.txt': 241,
+    'some-parts-added/dir-added/foo.txt': '66:472',
+    'some-parts-added/dir-added/bar.txt': '66:241',
   } satisfies InodeMap
 
   const oldIndex: InodeMap = {

--- a/pnpm11/workspace/injected-deps-syncer/test/extendFilesMap.test.ts
+++ b/pnpm11/workspace/injected-deps-syncer/test/extendFilesMap.test.ts
@@ -13,6 +13,11 @@ import { DIR, extendFilesMap, type ExtendFilesMapStats, type InodeMap } from '..
 // branch on every platform.
 const testOnPosix = isWindows() ? test.skip : test
 
+const fileId = (filePath: string): string => {
+  const stats = fs.statSync(filePath)
+  return `${stats.dev}:${stats.ino}`
+}
+
 const originalStat = fs.promises.stat
 
 function mockFsPromiseStat (): jest.Mock {
@@ -52,11 +57,11 @@ test('without provided stats', async () => {
     'deep/a/b/c': DIR,
     'deep/a/b/c/d': DIR,
     'deep/a/b/c/d/e': DIR,
-    'deep/a/b/c/d/e/f.txt': fs.statSync('deep/a/b/c/d/e/f.txt').ino,
+    'deep/a/b/c/d/e/f.txt': fileId('deep/a/b/c/d/e/f.txt'),
     foo: DIR,
-    'foo/foo.txt': fs.statSync('foo/foo.txt').ino,
-    'foo/bar.txt': fs.statSync('foo/bar.txt').ino,
-    'foo_bar.txt': fs.statSync('foo_bar.txt').ino,
+    'foo/foo.txt': fileId('foo/foo.txt'),
+    'foo/bar.txt': fileId('foo/bar.txt'),
+    'foo_bar.txt': fileId('foo_bar.txt'),
   } as InodeMap)
 
   for (const filePath of filePaths) {
@@ -67,6 +72,7 @@ test('without provided stats', async () => {
 test('with provided stats', async () => {
   prepareEmpty()
 
+  const dev = 66
   const startingIno = 7000
   const inoIncrement = 100
   const filePaths = [
@@ -81,6 +87,7 @@ test('with provided stats', async () => {
   for (const filePath of filePaths) {
     filesMap.set(filePath, path.resolve(filePath))
     filesStats[filePath] = {
+      dev,
       ino,
       isDirectory: () => false,
       isFile: () => true,
@@ -98,11 +105,11 @@ test('with provided stats', async () => {
     'deep/a/b/c': DIR,
     'deep/a/b/c/d': DIR,
     'deep/a/b/c/d/e': DIR,
-    'deep/a/b/c/d/e/f.txt': startingIno,
+    'deep/a/b/c/d/e/f.txt': `${dev}:${startingIno}`,
     foo: DIR,
-    'foo/foo.txt': startingIno + inoIncrement,
-    'foo/bar.txt': startingIno + 2 * inoIncrement,
-    'foo_bar.txt': startingIno + 3 * inoIncrement,
+    'foo/foo.txt': `${dev}:${startingIno + inoIncrement}`,
+    'foo/bar.txt': `${dev}:${startingIno + 2 * inoIncrement}`,
+    'foo_bar.txt': `${dev}:${startingIno + 3 * inoIncrement}`,
   } as InodeMap)
 
   expect(statMethod).not.toHaveBeenCalled()
@@ -120,12 +127,14 @@ test('skips inodes that are neither files nor directories', async () => {
   ])
   const filesStats: Record<string, ExtendFilesMapStats> = {
     'distribution/index.js': {
+      dev: 66,
       ino: 7000,
       isDirectory: () => false,
       isFile: () => true,
     },
     // A FIFO — 1Password's environments create one for `.env`.
     '.env': {
+      dev: 66,
       ino: 7100,
       isDirectory: () => false,
       isFile: () => false,
@@ -135,8 +144,36 @@ test('skips inodes that are neither files nor directories', async () => {
   expect(await extendFilesMap({ filesMap, filesStats })).toStrictEqual({
     '.': DIR,
     distribution: DIR,
-    'distribution/index.js': 7000,
+    'distribution/index.js': '66:7000',
   } as InodeMap)
+})
+
+test('tells apart two files that share an inode number on different devices', async () => {
+  prepareEmpty()
+
+  const filesMap = new Map<string, string>([
+    ['on-one-device.txt', path.resolve('on-one-device.txt')],
+    ['on-another.txt', path.resolve('on-another.txt')],
+  ])
+  const sharedIno = 7000
+  const filesStats: Record<string, ExtendFilesMapStats> = {
+    'on-one-device.txt': {
+      dev: 66,
+      ino: sharedIno,
+      isDirectory: () => false,
+      isFile: () => true,
+    },
+    'on-another.txt': {
+      dev: 2049,
+      ino: sharedIno,
+      isDirectory: () => false,
+      isFile: () => true,
+    },
+  }
+
+  const result = await extendFilesMap({ filesMap, filesStats })
+
+  expect(result['on-one-device.txt']).not.toBe(result['on-another.txt'])
 })
 
 testOnPosix('skips a real FIFO', async () => {
@@ -154,6 +191,6 @@ testOnPosix('skips a real FIFO', async () => {
   expect(await extendFilesMap({ filesMap })).toStrictEqual({
     '.': DIR,
     distribution: DIR,
-    'distribution/index.js': fs.statSync('distribution/index.js').ino,
+    'distribution/index.js': fileId('distribution/index.js'),
   } as InodeMap)
 })


### PR DESCRIPTION
## Summary

`extendFilesMap` identified a file by its inode number alone. An inode number is only unique within one filesystem, so an unrelated file on another device could collide with the one being synced — the diff reads the two as the same file, skips the replacement, and leaves that path stale in the injected copy.

A file's identity is now `<device>:<inode>`. `dev` comes from the same `stat` that already supplied `ino`, so this costs no extra syscall, and the identity stays a *primitive* — the property the inode map is built around, per the note above `File`:

> symbols and strings are used instead of discriminated union because it's faster and simpler to compare primitives than to deep compare objects

so the comparison is still a `===` rather than a structural one. The cost is one short string per file instead of a number; a template literal was chosen over packing both halves into a single number because `dev` and `ino` are each up to 64-bit and would not survive the 53-bit safe-integer range.

**Scope of the behavior change is narrow, and worth being explicit about.** An injected copy is materialized with `fs.link`, which cannot cross a filesystem, so in any configuration where the feature works at all the device is equal on both sides and `<device>:<inode>` and bare `<inode>` are the same comparison. This only bites in the already-broken cross-device case, where a coincidental inode collision previously caused a silent skip and a stale file; now the file is scheduled and `fs.link` surfaces a clear `EXDEV`. That is a better failure rather than a fix to a working setup.

**Rust:** already correct. pacquet took `FileId { device, inode }` in pnpm/pnpm#13834 — this is the TypeScript half, called out as a follow-up in that PR's review, and closes the divergence.

**Tests:** a new case in `extendFilesMap.test.ts` drives two files that share an inode number on different devices through the injected-stats seam and asserts their identities differ; it fails when the device is dropped from the identity. The existing fixtures across `extendFilesMap`, `diffDir`, `applyPatch`, and `DirPatcher` now carry a device. The `pnpm/test/syncInjectedDepsAfterScripts` end-to-end suite still passes against a rebuilt bundle.

No cross-device fixture: a test would have to mount a second filesystem, which the suite cannot do portably, and the only assertion available to it (`fs.link` rejects with `EXDEV`) is the platform's behavior rather than this package's.

## Squash Commit Body

```text
An inode number is only unique within one filesystem, so comparing bare
inode numbers lets an unrelated file on another device collide with the
one being synced. The diff then reads the two as the same file, skips
the replacement, and leaves that path stale in the injected copy.

Carry the device alongside it, as a `<device>:<inode>` string. The
identity stays a primitive, so the comparison the inode map is built
around is still a `===` rather than a structural one; `dev` comes from
the same stat that already supplied `ino`, so this costs no extra
syscall.

Nothing changes where injection works at all: a hardlink cannot cross a
filesystem, so the device is equal on both sides and the comparison is
the one it was before. It only affects the broken cross-device case,
which now reaches a clear EXDEV from `fs.link` instead of silently
skipping the file.

Matches pacquet, which took the same identity in pnpm/pnpm#13834.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5[1m]).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13847"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789102754&installation_model_id=426870&pr_number=13847&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13847&signature=4a9725629c27241a5f4cd5828d4108abff35052088d88bff435904e34984e609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization of injected dependencies across multiple filesystems.
  * Prevented files on different devices from being incorrectly treated as the same file when they share an inode number.
  * Preserved accurate handling of hard links and special file types during synchronization.

* **Tests**
  * Added regression coverage for files with matching inode numbers on different devices.

* **Documentation**
  * Included patch release notes for the affected packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->