### PR TITLE
fix(injected-deps-syncer): unlink a bin the script dropped

### DIFF
--- a/.changeset/injected-syncer-stale-bins.md
+++ b/.changeset/injected-syncer-stale-bins.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/workspace.injected-deps-syncer": patch
+"@pnpm/exec.commands": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+`syncInjectedDepsAfterScripts` now removes the bin link of a bin the script dropped. Previously only new bins were linked, so a build step that stopped declaring one left its shim behind, pointing at a command that was no longer there.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9749,6 +9749,12 @@ importers:
       '@pnpm/bins.linker':
         specifier: workspace:*
         version: link:../../bins/linker
+      '@pnpm/bins.remover':
+        specifier: workspace:*
+        version: link:../../bins/remover
+      '@pnpm/bins.resolver':
+        specifier: workspace:*
+        version: link:../../bins/resolver
       '@pnpm/error':
         specifier: workspace:*
         version: link:../../core/error

--- a/pnpm/crates/cli/src/cli_args/run.rs
+++ b/pnpm/crates/cli/src/cli_args/run.rs
@@ -393,6 +393,8 @@ pub(super) fn run_stages(
             pkg_name: ctx.manifest.value().get("name").and_then(Value::as_str),
             pkg_root_dir: ctx.dir,
             workspace_dir: ctx.config.workspace_dir.as_deref(),
+            // Read before the script ran, so a bin it drops can still be named.
+            manifest_before_scripts: Some(ctx.manifest.value()),
         })?;
     }
 

--- a/pnpm/crates/cli/tests/suite/sync_injected_deps_after_scripts.rs
+++ b/pnpm/crates/cli/tests/suite/sync_injected_deps_after_scripts.rs
@@ -151,3 +151,91 @@ fn a_project_outside_a_workspace_still_runs_the_script() {
 
     drop(root);
 }
+
+/// Every `.bin` directory under `dir` that holds a shim named `bin_name`,
+/// counting the Windows shim set as one.
+fn bin_dirs_holding(dir: &Path, bin_name: &str) -> Vec<std::path::PathBuf> {
+    fn walk(dir: &Path, bin_name: &str, found: &mut Vec<std::path::PathBuf>) {
+        let Ok(entries) = fs::read_dir(dir) else { return };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            if path.file_name().is_some_and(|name| name == ".bin") {
+                let holds =
+                    [bin_name.to_string(), format!("{bin_name}.CMD"), format!("{bin_name}.ps1")]
+                        .iter()
+                        .any(|candidate| path.join(candidate).exists());
+                if holds {
+                    found.push(path.clone());
+                }
+            }
+            walk(&path, bin_name, found);
+        }
+    }
+    let mut found = Vec::new();
+    walk(dir, bin_name, &mut found);
+    found.sort();
+    found
+}
+
+#[test]
+fn a_listed_script_removes_the_link_of_a_bin_it_dropped() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_workspace(&workspace, "syncInjectedDepsAfterScripts:\n  - build\n");
+
+    // Give project-1 two bins and a build script that drops one of them the
+    // way a step regenerating package.json would.
+    fs::create_dir_all(workspace.join("project-1/bin")).expect("mkdir project-1/bin");
+    fs::write(workspace.join("project-1/bin/kept.js"), "#!/usr/bin/env node\n")
+        .expect("write kept bin");
+    fs::write(workspace.join("project-1/bin/dropped.js"), "#!/usr/bin/env node\n")
+        .expect("write dropped bin");
+    fs::write(
+        workspace.join("project-1/package.json"),
+        serde_json::json!({
+            "name": "project-1",
+            "version": "1.0.0",
+            "bin": { "kept-cli": "bin/kept.js", "dropped-cli": "bin/dropped.js" },
+            "scripts": { "build": "node drop-bin.cjs" },
+        })
+        .to_string(),
+    )
+    .expect("write project-1 package.json");
+    fs::write(
+        workspace.join("project-1/drop-bin.cjs"),
+        concat!(
+            "const fs = require('fs')\n",
+            "const p = __dirname + '/package.json'\n",
+            "const m = JSON.parse(fs.readFileSync(p, 'utf8'))\n",
+            "delete m.bin['dropped-cli']\n",
+            "fs.writeFileSync(p, JSON.stringify(m, null, 2))\n",
+        ),
+    )
+    .expect("write drop-bin.cjs");
+
+    pacquet.with_arg("install").assert().success();
+
+    assert!(
+        !bin_dirs_holding(&workspace, "dropped-cli").is_empty(),
+        "the install should have linked the bin somewhere",
+    );
+
+    pacquet_in(&workspace.join("project-1")).with_args(["run", "build"]).assert().success();
+
+    assert_eq!(
+        bin_dirs_holding(&workspace, "dropped-cli"),
+        Vec::<std::path::PathBuf>::new(),
+        "the shim of the dropped bin should be gone everywhere",
+    );
+    assert!(
+        !bin_dirs_holding(&workspace, "kept-cli").is_empty(),
+        "the bin the script kept should still be linked",
+    );
+
+    drop((mock_instance, root));
+}

--- a/pnpm/crates/injected-deps-syncer/src/lib.rs
+++ b/pnpm/crates/injected-deps-syncer/src/lib.rs
@@ -16,13 +16,17 @@ pub use dir_patcher::{
 
 use derive_more::{Display, Error};
 use miette::Diagnostic;
-use pacquet_cmd_shim::{LinkBinsError, PackageBinSource, link_bins, link_bins_of_packages};
+use pacquet_cmd_shim::{
+    LinkBinsError, PackageBinSource, get_bins_from_package_manifest, link_bins,
+    link_bins_of_packages, remove_bin,
+};
 use pacquet_modules_yaml::{ReadModulesError, read_modules_manifest};
 use pacquet_package_manifest::{PackageManifestError, safe_read_package_json_from_dir};
 use pacquet_workspace::{
     FindWorkspaceProjectsError, FindWorkspaceProjectsOpts, find_workspace_projects_no_check,
 };
 use std::{
+    collections::HashSet,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -56,6 +60,14 @@ pub enum SyncInjectedDepsError {
     #[diagnostic(transparent)]
     Patch(PatchError),
 
+    #[display("Failed to remove the bin link at {path:?}: {error}")]
+    #[diagnostic(code(ERR_PNPM_INJECTED_DEPS_SYNC_REMOVE_BIN))]
+    RemoveBin {
+        path: PathBuf,
+        #[error(source)]
+        error: std::io::Error,
+    },
+
     #[display("{_0}")]
     #[diagnostic(transparent)]
     LinkBins(LinkBinsError),
@@ -68,6 +80,11 @@ pub struct SyncInjectedDeps<'a> {
     pub pkg_name: Option<&'a str>,
     pub pkg_root_dir: &'a Path,
     pub workspace_dir: Option<&'a Path>,
+    /// The package's manifest as it was before the scripts ran. A script
+    /// that drops a bin leaves its shim behind, and the copies cannot say
+    /// which bins they used to have: their `package.json` is hardlinked to
+    /// the source, so an in-place rewrite has already reached them.
+    pub manifest_before_scripts: Option<&'a serde_json::Value>,
 }
 
 /// Bring every injected copy of `pkg_root_dir` back in step with it.
@@ -125,7 +142,23 @@ pub fn sync_injected_deps(opts: &SyncInjectedDeps<'_>) -> Result<(), SyncInjecte
         patcher.apply().map_err(SyncInjectedDepsError::Patch)?;
     }
 
-    sync_bin_links(&pkg_root_dir, &resolved_targets, workspace_dir)
+    let previous_bin_names = opts.manifest_before_scripts.map_or_else(Vec::new, |manifest| {
+        get_bins_from_package_manifest::<pacquet_cmd_shim::Host>(manifest, &pkg_root_dir)
+            .into_iter()
+            .map(|command| command.name)
+            .collect()
+    });
+    // The install hoists bins into the virtual store's own `.bin` as well.
+    let hoisted_bin_dir = modules.as_ref().map(|modules| {
+        workspace_dir.join(&modules.virtual_store_dir).join("node_modules").join(".bin")
+    });
+    sync_bin_links(&SyncBinLinks {
+        pkg_root_dir: &pkg_root_dir,
+        resolved_targets: &resolved_targets,
+        workspace_dir,
+        previous_bin_names: &previous_bin_names,
+        hoisted_bin_dir: hoisted_bin_dir.as_deref(),
+    })
 }
 
 /// The key `.modules.yaml` files an injected dependency under: the
@@ -138,26 +171,63 @@ fn injected_dep_key(workspace_dir: &Path, pkg_root_dir: &Path) -> String {
 /// Re-link the bins of a package whose files just changed: a build
 /// script can add, remove, or rewrite a bin, and the shims in the
 /// consuming projects have to follow.
-fn sync_bin_links(
-    pkg_root_dir: &Path,
-    resolved_targets: &[PathBuf],
-    workspace_dir: &Path,
-) -> Result<(), SyncInjectedDepsError> {
+struct SyncBinLinks<'a> {
+    pkg_root_dir: &'a Path,
+    resolved_targets: &'a [PathBuf],
+    workspace_dir: &'a Path,
+    previous_bin_names: &'a [String],
+    hoisted_bin_dir: Option<&'a Path>,
+}
+
+fn sync_bin_links(opts: &SyncBinLinks<'_>) -> Result<(), SyncInjectedDepsError> {
+    let SyncBinLinks {
+        pkg_root_dir,
+        resolved_targets,
+        workspace_dir,
+        previous_bin_names,
+        hoisted_bin_dir,
+    } = *opts;
     let manifest = safe_read_package_json_from_dir(pkg_root_dir).map_err(|error| {
         SyncInjectedDepsError::ReadManifest { dir: pkg_root_dir.to_path_buf(), error }
     })?;
-    let has_bin_and_name = manifest
-        .as_ref()
-        .is_some_and(|manifest| manifest.get("bin").is_some() && manifest.get("name").is_some());
-    if !has_bin_and_name {
+    let Some(manifest) = manifest.filter(|manifest| manifest.get("name").is_some()) else {
         return Ok(());
-    }
-    let manifest = Arc::new(manifest.expect("checked above"));
+    };
+
+    // `link_bins` only ever creates shims, so a bin the script dropped keeps
+    // its shim, pointing at a command that is no longer there.
+    let current_bin_names: HashSet<String> =
+        get_bins_from_package_manifest::<pacquet_cmd_shim::Host>(&manifest, pkg_root_dir)
+            .into_iter()
+            .map(|command| command.name)
+            .collect();
+    let stale_bin_names: Vec<&String> =
+        previous_bin_names.iter().filter(|name| !current_bin_names.contains(*name)).collect();
+
+    let has_bins = manifest.get("bin").is_some();
+    let manifest = Arc::new(manifest);
 
     for target_dir in resolved_targets {
         let Some(parent_modules_dir) = target_dir.parent() else {
             continue;
         };
+        // The installer writes an injected package's own bins inside the
+        // copy, while this function writes them beside it. A dropped bin has
+        // to be cleared from both, or the one this function never wrote
+        // survives.
+        let bin_dirs =
+            [parent_modules_dir.join(".bin"), target_dir.join("node_modules").join(".bin")];
+        for bin_dir in bin_dirs.iter().map(PathBuf::as_path).chain(hoisted_bin_dir) {
+            for name in &stale_bin_names {
+                remove_bin(&bin_dir.join(name.as_str())).map_err(|error| {
+                    SyncInjectedDepsError::RemoveBin { path: bin_dir.join(name.as_str()), error }
+                })?;
+            }
+        }
+
+        if !has_bins {
+            continue;
+        }
         let packages = [PackageBinSource::new(target_dir.clone(), Arc::clone(&manifest))];
         link_bins_of_packages::<pacquet_cmd_shim::Host>(
             &packages,
@@ -175,6 +245,18 @@ fn sync_bin_links(
             .map_err(|error| SyncInjectedDepsError::FindProjects { error })?;
     for project in projects {
         let project_modules_dir = project.root_dir.join("node_modules");
+        // A stale name another package legitimately owns is put back by the
+        // relink below, so removing first costs nothing and catches the shim
+        // this package left behind.
+        let project_bin_dir = project_modules_dir.join(".bin");
+        for name in &stale_bin_names {
+            remove_bin(&project_bin_dir.join(name.as_str())).map_err(|error| {
+                SyncInjectedDepsError::RemoveBin {
+                    path: project_bin_dir.join(name.as_str()),
+                    error,
+                }
+            })?;
+        }
         link_bins::<pacquet_cmd_shim::Host>(
             &project_modules_dir,
             &project_modules_dir.join(".bin"),

--- a/pnpm11/exec/commands/src/run.ts
+++ b/pnpm11/exec/commands/src/run.ts
@@ -16,7 +16,7 @@ import {
   runLifecycleHook,
   type RunLifecycleHookOptions,
 } from '@pnpm/exec.lifecycle'
-import type { PackageScripts, ProjectManifest } from '@pnpm/types'
+import type { DependencyManifest, PackageScripts, ProjectManifest } from '@pnpm/types'
 import { syncInjectedDeps } from '@pnpm/workspace.injected-deps-syncer'
 import pLimit from 'p-limit'
 import { pick } from 'ramda'
@@ -456,6 +456,8 @@ export async function runScript (opts: {
       pkgName: opts.manifest.name,
       pkgRootDir: opts.lifecycleOpts.pkgRoot,
       workspaceDir: opts.runScriptOptions.workspaceDir,
+      // Read before the script ran, so a bin it drops can still be named.
+      manifestBeforeScripts: opts.manifest as DependencyManifest,
     })
   }
 }

--- a/pnpm11/pnpm/test/syncInjectedDepsAfterScripts-bin.ts
+++ b/pnpm11/pnpm/test/syncInjectedDepsAfterScripts-bin.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs'
+import path from 'node:path'
 
 import { expect, test } from '@jest/globals'
 import { preparePackages } from '@pnpm/prepare'
@@ -66,3 +67,91 @@ test('sync bin links after build script', async () => {
   // Run the consumer's test script which uses the bin
   await execPnpm(['--filter=consumer', 'test'])
 })
+
+test('removes the bin link of a bin the build script dropped', async () => {
+  preparePackages([
+    {
+      name: 'cli-tool',
+      version: '1.0.0',
+      bin: {
+        'kept-cli': 'bin/kept.js',
+        'dropped-cli': 'bin/dropped.js',
+      },
+      scripts: {
+        // Rewrite the manifest without `dropped-cli`, the way a build step
+        // that regenerates package.json would.
+        build: 'node ./drop-bin.cjs',
+      },
+    },
+    {
+      name: 'consumer',
+      version: '1.0.0',
+      dependencies: {
+        'cli-tool': 'workspace:*',
+      },
+      dependenciesMeta: {
+        'cli-tool': {
+          injected: true,
+        },
+      },
+    },
+  ])
+
+  fs.mkdirSync('cli-tool/bin', { recursive: true })
+  fs.writeFileSync('cli-tool/bin/kept.js', '#!/usr/bin/env node\nconsole.log("kept")\n')
+  fs.writeFileSync('cli-tool/bin/dropped.js', '#!/usr/bin/env node\nconsole.log("dropped")\n')
+  fs.writeFileSync(
+    'cli-tool/drop-bin.cjs',
+    [
+      "const fs = require('fs')",
+      "const manifestPath = __dirname + '/package.json'",
+      "const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))",
+      "delete manifest.bin['dropped-cli']",
+      'fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2))',
+      "fs.rmSync(__dirname + '/bin/dropped.js')",
+      '',
+    ].join('\n')
+  )
+
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    packages: ['*'],
+    reporter: 'append-only',
+    injectWorkspacePackages: true,
+    dedupeInjectedDeps: false,
+    syncInjectedDepsAfterScripts: ['build'],
+  })
+
+  await execPnpm(['install'])
+
+  // The install spreads an injected package's bins over several `.bin`
+  // directories — beside the copy, inside it, and the hoisted one — so
+  // assert over every directory rather than the ones we happen to expect.
+  expect(binDirsHolding('.', 'dropped-cli')).not.toStrictEqual([])
+  expect(binDirsHolding('.', 'kept-cli')).not.toStrictEqual([])
+
+  await execPnpm(['--filter=cli-tool', 'run', 'build'])
+
+  expect(binDirsHolding('.', 'dropped-cli')).toStrictEqual([])
+  expect(binDirsHolding('.', 'kept-cli')).not.toStrictEqual([])
+})
+
+/** Every `.bin` directory under `dir` holding a shim named `binName`. */
+function binDirsHolding (dir: string, binName: string): string[] {
+  const found: string[] = []
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue
+    const child = path.join(dir, entry.name)
+    if (entry.name === '.bin' && binExists(path.join(child, binName))) {
+      found.push(child)
+    }
+    found.push(...binDirsHolding(child, binName))
+  }
+  return found.sort()
+}
+
+/** A bin is a symlink on POSIX and a set of shims on Windows. */
+function binExists (binPath: string): boolean {
+  return fs.existsSync(binPath) ||
+    fs.existsSync(`${binPath}.CMD`) ||
+    fs.existsSync(`${binPath}.ps1`)
+}

--- a/pnpm11/workspace/injected-deps-syncer/package.json
+++ b/pnpm11/workspace/injected-deps-syncer/package.json
@@ -32,6 +32,8 @@
   },
   "dependencies": {
     "@pnpm/bins.linker": "workspace:*",
+    "@pnpm/bins.remover": "workspace:*",
+    "@pnpm/bins.resolver": "workspace:*",
     "@pnpm/error": "workspace:*",
     "@pnpm/fetching.directory-fetcher": "workspace:*",
     "@pnpm/installing.modules-yaml": "workspace:*",

--- a/pnpm11/workspace/injected-deps-syncer/src/index.ts
+++ b/pnpm11/workspace/injected-deps-syncer/src/index.ts
@@ -1,6 +1,8 @@
 import path from 'node:path'
 
 import { linkBins, linkBinsOfPackages } from '@pnpm/bins.linker'
+import { removeBin } from '@pnpm/bins.remover'
+import { getBinsFromPackageManifest } from '@pnpm/bins.resolver'
 import { PnpmError } from '@pnpm/error'
 import { readModulesManifest } from '@pnpm/installing.modules-yaml'
 import { logger as createLogger } from '@pnpm/logger'
@@ -23,6 +25,13 @@ export interface SyncInjectedDepsOptions {
   pkgName: string | undefined
   pkgRootDir: string
   workspaceDir: string | undefined
+  /**
+   * The package's manifest as it was before the scripts ran. A script that
+   * drops a bin leaves its shim behind, and the copies cannot say which bins
+   * they used to have: their `package.json` is hardlinked to the source, so
+   * an in-place rewrite has already reached them.
+   */
+  manifestBeforeScripts?: DependencyManifest
 }
 
 export async function syncInjectedDeps (opts: SyncInjectedDepsOptions): Promise<void> {
@@ -58,33 +67,69 @@ export async function syncInjectedDeps (opts: SyncInjectedDepsOptions): Promise<
     })
     return
   }
-  const patchers = await DirPatcher.fromMultipleTargets(
-    pkgRootDir,
-    targetDirs.map(targetDir => path.resolve(opts.workspaceDir!, targetDir))
-  )
+  const resolvedTargetDirs = targetDirs.map(targetDir => path.resolve(opts.workspaceDir!, targetDir))
+  const patchers = await DirPatcher.fromMultipleTargets(pkgRootDir, resolvedTargetDirs)
+
   await Promise.all(patchers.map(patcher => patcher.apply()))
 
-  // After syncing files, also sync bin links if the package has binaries
-  await syncBinLinks(pkgRootDir, targetDirs, opts.workspaceDir)
+  await syncBinLinks({
+    // The install hoists bins into the virtual store's own `.bin` as well.
+    hoistedBinDir: modules.virtualStoreDir == null
+      ? undefined
+      : path.join(path.resolve(opts.workspaceDir, modules.virtualStoreDir), 'node_modules', '.bin'),
+    pkgRootDir,
+    previousBinNames: opts.manifestBeforeScripts == null
+      ? []
+      : (await getBinsFromPackageManifest(opts.manifestBeforeScripts, pkgRootDir)).map(command => command.name),
+    resolvedTargetDirs,
+    workspaceDir: opts.workspaceDir,
+  })
 }
 
-async function syncBinLinks (
-  pkgRootDir: string,
-  targetDirs: string[],
-  workspaceDir: string
-): Promise<void> {
-  const manifest = await safeReadPackageJsonFromDir(pkgRootDir) as DependencyManifest | undefined
+/** The commands a package declares, or none when it declares no bins. */
+async function readBinNames (pkgDir: string): Promise<string[]> {
+  const manifest = await safeReadPackageJsonFromDir(pkgDir) as DependencyManifest | undefined
+  if (!manifest?.name) return []
+  const commands = await getBinsFromPackageManifest(manifest, pkgDir)
+  return commands.map(command => command.name)
+}
 
-  if (!manifest?.bin || !manifest?.name) {
+interface SyncBinLinksOptions {
+  hoistedBinDir: string | undefined
+  pkgRootDir: string
+  previousBinNames: string[]
+  resolvedTargetDirs: string[]
+  workspaceDir: string
+}
+
+async function syncBinLinks (opts: SyncBinLinksOptions): Promise<void> {
+  const manifest = await safeReadPackageJsonFromDir(opts.pkgRootDir) as DependencyManifest | undefined
+
+  if (!manifest?.name) {
     return
   }
 
+  // A script can drop a bin as easily as it can add one. `linkBins` only ever
+  // creates shims, so without this the shim for a dropped bin survives and
+  // points at a command that is no longer there.
+  const currentBinNames = new Set(await readBinNames(opts.pkgRootDir))
+  const staleBinNames = opts.previousBinNames.filter(name => !currentBinNames.has(name))
+
   // Step 1: Link bins in .pnpm virtual store
-  const binLinkPromises = targetDirs.map(async (targetDir) => {
-    const resolvedTargetDir = path.resolve(workspaceDir, targetDir)
+  const binLinkPromises = opts.resolvedTargetDirs.map(async (resolvedTargetDir) => {
     const parentNodeModulesDir = path.dirname(resolvedTargetDir)
     const binDir = path.join(parentNodeModulesDir, '.bin')
 
+    // The installer writes an injected package's own bins inside the copy,
+    // while this function writes them beside it. A dropped bin has to be
+    // cleared from both, or the one this function never wrote survives.
+    const binDirs = [binDir, path.join(resolvedTargetDir, 'node_modules', '.bin')]
+    if (opts.hoistedBinDir != null) binDirs.push(opts.hoistedBinDir)
+    await Promise.all(binDirs.flatMap(
+      dir => staleBinNames.map(async name => removeBin(path.join(dir, name)))
+    ))
+
+    if (manifest.bin == null) return
     await linkBinsOfPackages(
       [{
         manifest,
@@ -99,11 +144,16 @@ async function syncBinLinks (
   // We need to relink bins for all workspace projects because injected deps
   // can be used by any project in the workspace. We relink all bins (not just
   // this package) to ensure consistency.
-  const allProjects = await findWorkspaceProjectsNoCheck(workspaceDir, {})
+  const allProjects = await findWorkspaceProjectsNoCheck(opts.workspaceDir, {})
 
   const consumerLinkPromises = allProjects.map(async (project) => {
     const projectNodeModules = path.join(project.rootDir, 'node_modules')
     const projectBinDir = path.join(projectNodeModules, '.bin')
+
+    // A stale name another package legitimately owns is put back by the
+    // relink below, so removing first costs nothing and catches the shim
+    // this package left behind.
+    await Promise.all(staleBinNames.map(async name => removeBin(path.join(projectBinDir, name))))
 
     // Relink all bins in the project's node_modules
     await linkBins(projectNodeModules, projectBinDir, {

--- a/pnpm11/workspace/injected-deps-syncer/tsconfig.json
+++ b/pnpm11/workspace/injected-deps-syncer/tsconfig.json
@@ -16,6 +16,12 @@
       "path": "../../bins/linker"
     },
     {
+      "path": "../../bins/remover"
+    },
+    {
+      "path": "../../bins/resolver"
+    },
+    {
       "path": "../../core/error"
     },
     {


### PR DESCRIPTION
## Summary

Both stacks only ever *created* bin links. A build step that stopped declaring a bin left its shim behind, pointing at a command that was no longer there — `linkBins` re-derives shims from the current manifests but never prunes.

This is the last of the three follow-ups from the pnpm/pnpm#13834 review, and the only one that was broken in **both** stacks, so it lands in both at once.

### Where the old bin set comes from

The obvious source — read the copy's `package.json` before patching it — does not work, and the reason is worth recording. An injected copy is a tree of **hardlinks**, `package.json` included. A build step that rewrites the manifest in place writes through the same inode, so the copies already show the new manifest before the sync starts; by sync time no record of the old bins survives on disk. Instrumenting the first attempt showed exactly that: `previous=['kept-cli'] current=['kept-cli'] stale=[]`.

`pnpm run` already holds the manifest as it stood *before* the script ran, so it now passes it down and the diff is taken against that. `getBinsFromPackageManifest` derives names from the `bin` map without touching the filesystem, so a bin whose file the script also deleted is still named correctly.

### Which directories get cleared

An install spreads an injected package's bins over three `.bin` directories, and this function had only ever written to the first:

- beside the copy — `<slot>/node_modules/.bin`, where the syncer links
- inside the copy — `<slot>/node_modules/<pkg>/node_modules/.bin`, where the install writes
- the hoisted one — `<virtualStoreDir>/node_modules/.bin`, taken from the modules manifest

plus each workspace project's `node_modules/.bin`. All are cleared before relinking. A stale name another package legitimately owns is put back by the relink that follows, so removing first costs nothing.

**Tests:** one end-to-end case per stack, driving a build script that rewrites its own `package.json` to drop a bin. Both assert over *every* `.bin` directory under the workspace rather than a hard-coded list — which is how the third directory was found in the first place, after the pacquet test failed with the shim surviving in `node_modules/.pnpm/node_modules/.bin`.

## Squash Commit Body

```text
Both stacks only ever created bin links. A build step that stopped
declaring a bin left its shim behind in every `.bin` the install had
written it to, pointing at a command that was no longer there.

Take the bin set from the manifest as it stood *before* the scripts ran
and unlink whatever the new manifest no longer declares. The copies
cannot answer that question themselves: their `package.json` is
hardlinked to the source, so a script that rewrites it in place has
already changed the copies too, and by sync time no record of the old
bins survives on disk. `pnpm run` already holds the pre-script manifest,
so it passes it down.

The install spreads an injected package's bins over three directories —
beside the copy, inside it, and the virtual store's hoisted `.bin` — and
this function had only ever written to the first. All three are cleared.
A stale name another package legitimately owns is put back by the relink
that follows, so removing first costs nothing.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5[1m]).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789104093&installation_model_id=426870&pr_number=13848&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13848&signature=463f08736d5f6add3fec53e07e16a26d8e40122896eb39fa40f3ae8f3958753d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed stale `.bin` links when build scripts delete previously declared package binaries.
  - Preserved links for binaries that remain declared.
  - Improved synchronization across virtual-store, copied-package, hoisted, and workspace locations.
  - Added support for packages whose current manifest no longer contains a `bin` declaration.

- **Tests**
  - Added cross-platform regression coverage for Unix, CMD, and PowerShell binary shims.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->