### PR TITLE
fix(approve-builds): clear legacy build settings from pnpm-workspace.yaml

### DIFF
--- a/.changeset/approve-builds-clears-legacy-settings.md
+++ b/.changeset/approve-builds-clears-legacy-settings.md
@@ -1,0 +1,9 @@
+---
+"@pnpm/building.commands": patch
+"@pnpm/config.writer": patch
+"@pnpm/workspace.workspace-manifest-writer": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+`pnpm approve-builds` now removes `onlyBuiltDependencies`, `onlyBuiltDependenciesFile`, `neverBuiltDependencies`, and `ignoredBuiltDependencies` from `pnpm-workspace.yaml` when it writes `allowBuilds`. Those settings were replaced by `allowBuilds` in pnpm 11 and silently ignored since, so a workspace migrated from pnpm 10 kept them around looking active.

--- a/pnpm/crates/cli/src/cli_args/approve_builds.rs
+++ b/pnpm/crates/cli/src/cli_args/approve_builds.rs
@@ -5,7 +5,7 @@ use miette::{Diagnostic, IntoDiagnostic};
 use pnpm_config::Config;
 use pnpm_modules_yaml::{Host, write_modules_manifest};
 use pnpm_package_manager::allow_build_key_from_ignored_build;
-use pnpm_workspace_manifest_writer::{remove_legacy_build_settings, set_allow_builds};
+use pnpm_workspace_manifest_writer::set_allow_builds_clearing_legacy;
 use std::{
     collections::{BTreeMap, HashSet},
     path::Path,
@@ -136,12 +136,11 @@ impl ApproveBuildsArgs {
 
         let settings_dir =
             initial_config.workspace_dir.clone().unwrap_or_else(|| dir.to_path_buf());
-        set_allow_builds(
+        set_allow_builds_clearing_legacy(
             &settings_dir,
             decisions.iter().map(|(pkg, &value)| (pkg.as_str(), value)),
         )
         .into_diagnostic()?;
-        remove_legacy_build_settings(&settings_dir).into_diagnostic()?;
 
         clear_decided_ignored_builds(
             scan.modules_manifest,

--- a/pnpm/crates/cli/src/cli_args/approve_builds.rs
+++ b/pnpm/crates/cli/src/cli_args/approve_builds.rs
@@ -5,7 +5,7 @@ use miette::{Diagnostic, IntoDiagnostic};
 use pnpm_config::Config;
 use pnpm_modules_yaml::{Host, write_modules_manifest};
 use pnpm_package_manager::allow_build_key_from_ignored_build;
-use pnpm_workspace_manifest_writer::set_allow_builds;
+use pnpm_workspace_manifest_writer::{remove_legacy_build_settings, set_allow_builds};
 use std::{
     collections::{BTreeMap, HashSet},
     path::Path,
@@ -141,6 +141,7 @@ impl ApproveBuildsArgs {
             decisions.iter().map(|(pkg, &value)| (pkg.as_str(), value)),
         )
         .into_diagnostic()?;
+        remove_legacy_build_settings(&settings_dir).into_diagnostic()?;
 
         clear_decided_ignored_builds(
             scan.modules_manifest,

--- a/pnpm/crates/cli/tests/suite/approve_builds.rs
+++ b/pnpm/crates/cli/tests/suite/approve_builds.rs
@@ -478,6 +478,36 @@ fn approve_builds_preserves_existing_allow_builds_entries() {
 }
 
 #[test]
+fn approve_builds_clears_legacy_build_settings() {
+    let (harness, workspace) = install_two_with_ignored_builds();
+
+    let yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut yaml = fs::read_to_string(&yaml_path).expect("read pnpm-workspace.yaml");
+    yaml.push_str(concat!(
+        "onlyBuiltDependencies:\n  - esbuild\n",
+        "onlyBuiltDependenciesFile: allowed.json\n",
+        "neverBuiltDependencies:\n  - fsevents\n",
+        "ignoredBuiltDependencies:\n  - nan\n",
+    ));
+    fs::write(&yaml_path, yaml).expect("write pnpm-workspace.yaml");
+
+    pacquet(&workspace).with_args(["approve-builds", PREPOST]).assert().success();
+
+    let yaml = fs::read_to_string(&yaml_path).expect("read pnpm-workspace.yaml");
+    for key in [
+        "onlyBuiltDependencies",
+        "onlyBuiltDependenciesFile",
+        "neverBuiltDependencies",
+        "ignoredBuiltDependencies",
+    ] {
+        assert!(!yaml.contains(key), "legacy setting {key} must be cleared: {yaml}");
+    }
+    assert_eq!(allow_builds(&workspace).get(PREPOST), Some(&true), "approved package recorded");
+
+    drop(harness);
+}
+
+#[test]
 fn approve_builds_all_with_args_is_rejected() {
     let CommandTempCwd { workspace, root, .. } = CommandTempCwd::init();
     fs::write(workspace.join("package.json"), "{}").expect("write package.json");

--- a/pnpm/crates/workspace-manifest-writer/src/lib.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/lib.rs
@@ -564,6 +564,42 @@ pub fn remove_overrides(
     write_or_remove_manifest(&path, manifest)
 }
 
+/// Top-level `pnpm-workspace.yaml` settings replaced by `allowBuilds:` in
+/// pnpm v11. Left behind by an untouched manifest, they are dead config.
+pub const LEGACY_BUILD_SETTINGS: &[&str] = &[
+    "onlyBuiltDependencies",
+    "onlyBuiltDependenciesFile",
+    "neverBuiltDependencies",
+    "ignoredBuiltDependencies",
+];
+
+/// Delete [`LEGACY_BUILD_SETTINGS`] from `dir`'s `pnpm-workspace.yaml`,
+/// preserving the rest of the document's formatting and writing back only
+/// when something actually changed. A missing file is a no-op. Used by
+/// `pnpm approve-builds`.
+pub fn remove_legacy_build_settings(dir: &Path) -> Result<(), UpdateWorkspaceManifestError> {
+    let path = dir.join(WORKSPACE_MANIFEST_FILENAME);
+
+    let original = match fs::read_to_string(&path) {
+        Ok(text) => text,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(source) => return Err(UpdateWorkspaceManifestError::Read { path, source }),
+    };
+
+    let mut manifest = Manifest::parse(Some(&original))
+        .map_err(|source| UpdateWorkspaceManifestError::Parse { path: path.clone(), source })?;
+
+    let mut changed = false;
+    for key in LEGACY_BUILD_SETTINGS {
+        changed |= edit::remove_top_level_field(&mut manifest, key);
+    }
+    if !changed {
+        return Ok(());
+    }
+
+    write_or_remove_manifest(&path, manifest)
+}
+
 /// Set or delete an arbitrary top-level field in the YAML manifest at `path`
 /// (a `pnpm-workspace.yaml` or a global `config.yaml`), preserving the rest of
 /// the document's formatting and writing back only when something changed.

--- a/pnpm/crates/workspace-manifest-writer/src/lib.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/lib.rs
@@ -283,6 +283,40 @@ pub fn set_allow_builds<'a, Entries>(
 where
     Entries: IntoIterator<Item = (&'a str, bool)>,
 {
+    update_allow_builds(dir, entries, false)
+}
+
+/// Top-level `pnpm-workspace.yaml` settings that `allowBuilds:` replaced in
+/// pnpm v11.
+pub const LEGACY_BUILD_SETTINGS: &[&str] = &[
+    "onlyBuiltDependencies",
+    "onlyBuiltDependenciesFile",
+    "neverBuiltDependencies",
+    "ignoredBuiltDependencies",
+];
+
+/// Same as [`set_allow_builds`], but also deletes the
+/// [`LEGACY_BUILD_SETTINGS`] in the same write. Used by `pnpm
+/// approve-builds` so a workspace migrated from pnpm v10 is not left with
+/// dead build settings next to the `allowBuilds:` it writes.
+pub fn set_allow_builds_clearing_legacy<'a, Entries>(
+    dir: &Path,
+    entries: Entries,
+) -> Result<(), UpdateWorkspaceManifestError>
+where
+    Entries: IntoIterator<Item = (&'a str, bool)>,
+{
+    update_allow_builds(dir, entries, true)
+}
+
+fn update_allow_builds<'a, Entries>(
+    dir: &Path,
+    entries: Entries,
+    clear_legacy_settings: bool,
+) -> Result<(), UpdateWorkspaceManifestError>
+where
+    Entries: IntoIterator<Item = (&'a str, bool)>,
+{
     let path = dir.join(WORKSPACE_MANIFEST_FILENAME);
 
     let original = match fs::read_to_string(&path) {
@@ -306,6 +340,11 @@ where
             });
         }
         changed |= edit::add_allow_build(&mut manifest, name, value);
+    }
+    if clear_legacy_settings {
+        for key in LEGACY_BUILD_SETTINGS {
+            changed |= edit::remove_top_level_field(&mut manifest, key);
+        }
     }
     if !changed {
         return Ok(());
@@ -558,42 +597,6 @@ pub fn remove_overrides(
         .map_err(|source| UpdateWorkspaceManifestError::Parse { path: path.clone(), source })?;
 
     if !edit::remove_overrides(&mut manifest, selectors) {
-        return Ok(());
-    }
-
-    write_or_remove_manifest(&path, manifest)
-}
-
-/// Top-level `pnpm-workspace.yaml` settings replaced by `allowBuilds:` in
-/// pnpm v11. Left behind by an untouched manifest, they are dead config.
-pub const LEGACY_BUILD_SETTINGS: &[&str] = &[
-    "onlyBuiltDependencies",
-    "onlyBuiltDependenciesFile",
-    "neverBuiltDependencies",
-    "ignoredBuiltDependencies",
-];
-
-/// Delete [`LEGACY_BUILD_SETTINGS`] from `dir`'s `pnpm-workspace.yaml`,
-/// preserving the rest of the document's formatting and writing back only
-/// when something actually changed. A missing file is a no-op. Used by
-/// `pnpm approve-builds`.
-pub fn remove_legacy_build_settings(dir: &Path) -> Result<(), UpdateWorkspaceManifestError> {
-    let path = dir.join(WORKSPACE_MANIFEST_FILENAME);
-
-    let original = match fs::read_to_string(&path) {
-        Ok(text) => text,
-        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(()),
-        Err(source) => return Err(UpdateWorkspaceManifestError::Read { path, source }),
-    };
-
-    let mut manifest = Manifest::parse(Some(&original))
-        .map_err(|source| UpdateWorkspaceManifestError::Parse { path: path.clone(), source })?;
-
-    let mut changed = false;
-    for key in LEGACY_BUILD_SETTINGS {
-        changed |= edit::remove_top_level_field(&mut manifest, key);
-    }
-    if !changed {
         return Ok(());
     }
 

--- a/pnpm/crates/workspace-manifest-writer/src/tests.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/tests.rs
@@ -747,15 +747,17 @@ fn run_remove_overrides(original: Option<&str>, selectors: &[&str]) -> Option<St
     fs::read_to_string(&path).ok()
 }
 
-/// Run `remove_legacy_build_settings` against `original` and return the
-/// resulting file contents, or `None` when no file exists afterward.
-fn run_remove_legacy_build_settings(original: Option<&str>) -> Option<String> {
+fn run_allow_builds_clearing_legacy(
+    original: Option<&str>,
+    entries: &[(&str, bool)],
+) -> Option<String> {
     let dir = TempDir::new().expect("temp dir");
     let path = dir.path().join(WORKSPACE_MANIFEST_FILENAME);
     if let Some(text) = original {
         fs::write(&path, text).expect("seed manifest");
     }
-    crate::remove_legacy_build_settings(dir.path()).expect("remove succeeds");
+    crate::set_allow_builds_clearing_legacy(dir.path(), entries.iter().copied())
+        .expect("update succeeds");
     fs::read_to_string(&path).ok()
 }
 
@@ -1098,28 +1100,29 @@ fn remove_overrides_keeps_block_when_only_non_string_entry_remains() {
 }
 
 #[test]
-fn remove_legacy_build_settings_drops_every_known_key() {
-    let original = "packages:\n  - '*'\nonlyBuiltDependencies:\n  - esbuild\nignoredBuiltDependencies:\n  - foo\nallowBuilds:\n  esbuild: true\n";
-    let out = run_remove_legacy_build_settings(Some(original)).expect("file kept");
+fn allow_builds_clearing_legacy_drops_every_legacy_key_in_the_same_write() {
+    let original = "packages:\n  - '*'\nonlyBuiltDependencies:\n  - esbuild\nonlyBuiltDependenciesFile: allowed.json\nneverBuiltDependencies:\n  - fsevents\nignoredBuiltDependencies:\n  - foo\n";
+    let out =
+        run_allow_builds_clearing_legacy(Some(original), &[("esbuild", true)]).expect("file kept");
     assert_eq!(out, "packages:\n  - '*'\nallowBuilds:\n  esbuild: true\n");
 }
 
 #[test]
-fn remove_legacy_build_settings_deletes_the_file_when_nothing_remains() {
+fn allow_builds_clearing_legacy_deletes_the_file_when_nothing_remains() {
     let original = "onlyBuiltDependencies:\n  - esbuild\n";
-    assert_eq!(run_remove_legacy_build_settings(Some(original)), None);
+    assert_eq!(run_allow_builds_clearing_legacy(Some(original), &[]), None);
 }
 
 #[test]
-fn remove_legacy_build_settings_is_a_noop_when_absent() {
+fn allow_builds_clearing_legacy_is_a_noop_when_no_legacy_key_is_present() {
     let original = "packages:\n  - '*'\nallowBuilds:\n  esbuild: true\n";
-    let out = run_remove_legacy_build_settings(Some(original)).expect("file kept");
+    let out = run_allow_builds_clearing_legacy(Some(original), &[]).expect("file kept");
     assert_eq!(out, original);
 }
 
 #[test]
-fn remove_legacy_build_settings_is_a_noop_when_the_manifest_is_missing() {
-    assert_eq!(run_remove_legacy_build_settings(None), None);
+fn allow_builds_clearing_legacy_is_a_noop_when_the_manifest_is_missing() {
+    assert_eq!(run_allow_builds_clearing_legacy(None, &[]), None);
 }
 
 #[test]

--- a/pnpm/crates/workspace-manifest-writer/src/tests.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/tests.rs
@@ -747,6 +747,18 @@ fn run_remove_overrides(original: Option<&str>, selectors: &[&str]) -> Option<St
     fs::read_to_string(&path).ok()
 }
 
+/// Run `remove_legacy_build_settings` against `original` and return the
+/// resulting file contents, or `None` when no file exists afterward.
+fn run_remove_legacy_build_settings(original: Option<&str>) -> Option<String> {
+    let dir = TempDir::new().expect("temp dir");
+    let path = dir.path().join(WORKSPACE_MANIFEST_FILENAME);
+    if let Some(text) = original {
+        fs::write(&path, text).expect("seed manifest");
+    }
+    crate::remove_legacy_build_settings(dir.path()).expect("remove succeeds");
+    fs::read_to_string(&path).ok()
+}
+
 #[test]
 fn overrides_block_is_created() {
     let out = run_overrides(None, &overrides(&[("foo@<1.0.1", "^1.0.1")])).expect("written");
@@ -1083,6 +1095,31 @@ fn remove_overrides_keeps_block_when_only_non_string_entry_remains() {
     let original = "overrides:\n  foo: link:../foo\n  bar:\n    nested: value\n";
     let out = run_remove_overrides(Some(original), &["foo"]).expect("file kept");
     assert!(out.contains("bar:"), "non-string override must survive: {out}");
+}
+
+#[test]
+fn remove_legacy_build_settings_drops_every_known_key() {
+    let original = "packages:\n  - '*'\nonlyBuiltDependencies:\n  - esbuild\nignoredBuiltDependencies:\n  - foo\nallowBuilds:\n  esbuild: true\n";
+    let out = run_remove_legacy_build_settings(Some(original)).expect("file kept");
+    assert_eq!(out, "packages:\n  - '*'\nallowBuilds:\n  esbuild: true\n");
+}
+
+#[test]
+fn remove_legacy_build_settings_deletes_the_file_when_nothing_remains() {
+    let original = "onlyBuiltDependencies:\n  - esbuild\n";
+    assert_eq!(run_remove_legacy_build_settings(Some(original)), None);
+}
+
+#[test]
+fn remove_legacy_build_settings_is_a_noop_when_absent() {
+    let original = "packages:\n  - '*'\nallowBuilds:\n  esbuild: true\n";
+    let out = run_remove_legacy_build_settings(Some(original)).expect("file kept");
+    assert_eq!(out, original);
+}
+
+#[test]
+fn remove_legacy_build_settings_is_a_noop_when_the_manifest_is_missing() {
+    assert_eq!(run_remove_legacy_build_settings(None), None);
 }
 
 #[test]

--- a/pnpm/crates/workspace-manifest-writer/src/tests.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/tests.rs
@@ -1104,6 +1104,7 @@ fn allow_builds_clearing_legacy_drops_every_legacy_key_in_the_same_write() {
     let original = "packages:\n  - '*'\nonlyBuiltDependencies:\n  - esbuild\nonlyBuiltDependenciesFile: allowed.json\nneverBuiltDependencies:\n  - fsevents\nignoredBuiltDependencies:\n  - foo\n";
     let out =
         run_allow_builds_clearing_legacy(Some(original), &[("esbuild", true)]).expect("file kept");
+    eprintln!("MANIFEST:\n{out}\n");
     assert_eq!(out, "packages:\n  - '*'\nallowBuilds:\n  esbuild: true\n");
 }
 
@@ -1117,6 +1118,7 @@ fn allow_builds_clearing_legacy_deletes_the_file_when_nothing_remains() {
 fn allow_builds_clearing_legacy_is_a_noop_when_no_legacy_key_is_present() {
     let original = "packages:\n  - '*'\nallowBuilds:\n  esbuild: true\n";
     let out = run_allow_builds_clearing_legacy(Some(original), &[]).expect("file kept");
+    eprintln!("MANIFEST:\n{out}\n");
     assert_eq!(out, original);
 }
 

--- a/pnpm11/building/commands/src/policy/approveBuilds.ts
+++ b/pnpm11/building/commands/src/policy/approveBuilds.ts
@@ -28,6 +28,9 @@ export type ApproveBuildsCommandOpts = Pick<Config, 'modulesDir' | 'dir' | 'allo
 
 export const commandNames = ['approve-builds']
 
+// Superseded by allowBuilds in v11; a leftover copy is dead config, so approve-builds clears it out.
+const LEGACY_BUILD_SETTINGS = ['onlyBuiltDependencies', 'onlyBuiltDependenciesFile', 'neverBuiltDependencies', 'ignoredBuiltDependencies']
+
 export const recursiveByDefault = true
 
 export function help (): string {
@@ -190,6 +193,7 @@ export async function handler (opts: ApproveBuildsCommandOpts & RebuildCommandOp
     ...opts,
     workspaceDir: opts.settingsDir ?? opts.workspaceDir ?? opts.rootProjectManifestDir,
     updatedSettings: { allowBuilds },
+    deletedLegacyKeys: LEGACY_BUILD_SETTINGS,
   })
   if (modulesManifest?.ignoredBuilds) {
     if (params.length) {

--- a/pnpm11/building/commands/src/policy/approveBuilds.ts
+++ b/pnpm11/building/commands/src/policy/approveBuilds.ts
@@ -28,7 +28,7 @@ export type ApproveBuildsCommandOpts = Pick<Config, 'modulesDir' | 'dir' | 'allo
 
 export const commandNames = ['approve-builds']
 
-// Superseded by allowBuilds in v11; a leftover copy is dead config, so approve-builds clears it out.
+// pnpm-workspace.yaml settings that allowBuilds replaced in pnpm 11.
 const LEGACY_BUILD_SETTINGS = ['onlyBuiltDependencies', 'onlyBuiltDependenciesFile', 'neverBuiltDependencies', 'ignoredBuiltDependencies']
 
 export const recursiveByDefault = true

--- a/pnpm11/building/commands/test/policy/approveBuilds.test.ts
+++ b/pnpm11/building/commands/test/policy/approveBuilds.test.ts
@@ -490,6 +490,8 @@ test('clears legacy build settings when writing allowBuilds', async () => {
   writeYamlFileSync(workspaceManifestFile, {
     packages: ['packages/*'],
     onlyBuiltDependencies: ['@pnpm.e2e/existing-package'],
+    onlyBuiltDependenciesFile: 'allowed.json',
+    neverBuiltDependencies: ['fsevents'],
     ignoredBuiltDependencies: ['esbuild'],
   })
 

--- a/pnpm11/building/commands/test/policy/approveBuilds.test.ts
+++ b/pnpm11/building/commands/test/policy/approveBuilds.test.ts
@@ -474,6 +474,36 @@ test('should retain existing allowBuilds entries when approving builds', async (
   })
 })
 
+test('clears legacy build settings when writing allowBuilds', async () => {
+  const temp = tempDir()
+
+  prepare({
+    dependencies: {
+      '@pnpm.e2e/pre-and-postinstall-scripts-example': '1.0.0',
+      '@pnpm.e2e/install-script-example': '*',
+    },
+  }, {
+    tempDir: temp,
+  })
+
+  const workspaceManifestFile = path.join(temp, 'pnpm-workspace.yaml')
+  writeYamlFileSync(workspaceManifestFile, {
+    packages: ['packages/*'],
+    onlyBuiltDependencies: ['@pnpm.e2e/existing-package'],
+    ignoredBuiltDependencies: ['esbuild'],
+  })
+
+  await approveSomeBuilds({ workspaceDir: temp, rootProjectManifestDir: temp })
+
+  expect(readYamlFileSync(workspaceManifestFile)).toStrictEqual({
+    packages: ['packages/*'],
+    allowBuilds: {
+      '@pnpm.e2e/install-script-example': false,
+      '@pnpm.e2e/pre-and-postinstall-scripts-example': true,
+    },
+  })
+})
+
 // Regression test for the global-install path: globalAdd invokes
 // approve-builds with globalPkgDir set (so writeSettings updates the global
 // pnpm-workspace.yaml) but without workspaceDir. If approve-builds were to

--- a/pnpm11/config/writer/src/index.ts
+++ b/pnpm11/config/writer/src/index.ts
@@ -5,6 +5,7 @@ export interface WriteSettingsOptions {
   updatedSettings?: PnpmSettings
   updatedOverrides?: Record<string, string>
   addedMinimumReleaseAgeExcludes?: string[]
+  deletedLegacyKeys?: string[]
   rootProjectManifest?: ProjectManifest
   rootProjectManifestDir: string
   workspaceDir: string
@@ -15,5 +16,6 @@ export async function writeSettings (opts: WriteSettingsOptions): Promise<void> 
     updatedFields: opts.updatedSettings,
     updatedOverrides: opts.updatedOverrides,
     addedMinimumReleaseAgeExcludes: opts.addedMinimumReleaseAgeExcludes,
+    deletedLegacyKeys: opts.deletedLegacyKeys,
   })
 }

--- a/pnpm11/workspace/workspace-manifest-writer/src/index.ts
+++ b/pnpm11/workspace/workspace-manifest-writer/src/index.ts
@@ -48,6 +48,7 @@ export async function updateWorkspaceManifest (dir: string, opts: {
   updatedCatalogs?: Catalogs
   updatedOverrides?: Record<string, string>
   addedMinimumReleaseAgeExcludes?: string[]
+  deletedLegacyKeys?: string[]
   fileName?: FileName
   catalogPrune?: boolean
   allProjects?: Project[]
@@ -93,6 +94,13 @@ export async function updateWorkspaceManifest (dir: string, opts: {
     if (equals(manifest[key as keyof WorkspaceManifest], value)) continue
     shouldBeUpdated = true
     manifest[key as keyof WorkspaceManifest] = value
+  }
+  const untypedManifest = manifest as Record<string, unknown>
+  for (const key of opts.deletedLegacyKeys ?? []) {
+    if (key in untypedManifest) {
+      delete untypedManifest[key]
+      shouldBeUpdated = true
+    }
   }
   if (opts.updatedOverrides) {
     manifest.overrides ??= {}

--- a/pnpm11/workspace/workspace-manifest-writer/src/index.ts
+++ b/pnpm11/workspace/workspace-manifest-writer/src/index.ts
@@ -97,7 +97,7 @@ export async function updateWorkspaceManifest (dir: string, opts: {
   }
   const untypedManifest = manifest as Record<string, unknown>
   for (const key of opts.deletedLegacyKeys ?? []) {
-    if (key in untypedManifest) {
+    if (Object.hasOwn(untypedManifest, key)) {
       delete untypedManifest[key]
       shouldBeUpdated = true
     }

--- a/pnpm11/workspace/workspace-manifest-writer/test/updateWorkspaceManifest.test.ts
+++ b/pnpm11/workspace/workspace-manifest-writer/test/updateWorkspaceManifest.test.ts
@@ -36,9 +36,16 @@ test('updateWorkspaceManifest removes an existing setting', async () => {
 test('updateWorkspaceManifest deletes legacy keys not part of WorkspaceManifest', async () => {
   const dir = tempDir(false)
   const filePath = path.join(dir, WORKSPACE_MANIFEST_FILENAME)
-  writeYamlFileSync(filePath, { packages: ['*'], onlyBuiltDependencies: ['esbuild'], allowBuilds: { esbuild: true } })
+  writeYamlFileSync(filePath, {
+    packages: ['*'],
+    onlyBuiltDependencies: ['esbuild'],
+    onlyBuiltDependenciesFile: 'allowed.json',
+    neverBuiltDependencies: ['fsevents'],
+    ignoredBuiltDependencies: ['nan'],
+    allowBuilds: { esbuild: true },
+  })
   await updateWorkspaceManifest(dir, {
-    deletedLegacyKeys: ['onlyBuiltDependencies', 'neverBuiltDependencies'],
+    deletedLegacyKeys: ['onlyBuiltDependencies', 'onlyBuiltDependenciesFile', 'neverBuiltDependencies', 'ignoredBuiltDependencies'],
   })
   expect(readYamlFileSync(filePath)).toStrictEqual({
     packages: ['*'],

--- a/pnpm11/workspace/workspace-manifest-writer/test/updateWorkspaceManifest.test.ts
+++ b/pnpm11/workspace/workspace-manifest-writer/test/updateWorkspaceManifest.test.ts
@@ -33,6 +33,19 @@ test('updateWorkspaceManifest removes an existing setting', async () => {
   })
 })
 
+test('updateWorkspaceManifest deletes legacy keys not part of WorkspaceManifest', async () => {
+  const dir = tempDir(false)
+  const filePath = path.join(dir, WORKSPACE_MANIFEST_FILENAME)
+  writeYamlFileSync(filePath, { packages: ['*'], onlyBuiltDependencies: ['esbuild'], allowBuilds: { esbuild: true } })
+  await updateWorkspaceManifest(dir, {
+    deletedLegacyKeys: ['onlyBuiltDependencies', 'neverBuiltDependencies'],
+  })
+  expect(readYamlFileSync(filePath)).toStrictEqual({
+    packages: ['*'],
+    allowBuilds: { esbuild: true },
+  })
+})
+
 test('updateWorkspaceManifest updates an existing setting', async () => {
   const dir = tempDir(false)
   const filePath = path.join(dir, WORKSPACE_MANIFEST_FILENAME)


### PR DESCRIPTION
## Summary

`allowBuilds` replaced `onlyBuiltDependencies`, `onlyBuiltDependenciesFile`, `neverBuiltDependencies`, and `ignoredBuiltDependencies` in pnpm 11, but a workspace that migrated from pnpm 10 keeps those fields in `pnpm-workspace.yaml` untouched, since nothing reads or removes them anymore. Running `pnpm approve-builds` on such a workspace writes `allowBuilds` next to the old fields, which still look active and are confusing during migration.

`pnpm approve-builds` now deletes those four legacy keys from `pnpm-workspace.yaml` whenever it writes `allowBuilds`, in both the TypeScript CLI and pacquet.

Fixes pnpm/pnpm#13845

## Squash Commit Body

```text
allowBuilds replaced onlyBuiltDependencies, onlyBuiltDependenciesFile,
neverBuiltDependencies, and ignoredBuiltDependencies in pnpm 11, but nothing
removed them from pnpm-workspace.yaml, so a workspace migrated from pnpm 10
kept them around looking active even though they're silently ignored.

approve-builds now clears those four keys in the same manifest write that
records allowBuilds, via a new deletedLegacyKeys option on the TypeScript
workspace-manifest writer and a matching set_allow_builds_clearing_legacy
in pacquet's Rust writer.

Fixes pnpm/pnpm#13845
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port.
- [x] Added a changeset.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789104305&installation_model_id=426870&pr_number=13849&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13849&signature=7a2f683df0f29701ea0631ed3839f55816c9037a50b0f4f15d019f63fe2c2c5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `pnpm approve-builds` now removes obsolete build configuration settings when saving the unified `allowBuilds` configuration.
  * Existing workspace settings and unrelated manifest content are preserved.
  * Empty or missing workspace manifests are handled safely.

* **Tests**
  * Added coverage for legacy setting removal, preservation of current settings, and no-op scenarios.
  * Added integration coverage confirming approved packages are recorded correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
