### PR TITLE
fix(package-manager): apply packageExtensions to the freshness manifests

### DIFF
--- a/.changeset/frozen-lockfile-package-extensions-peer.md
+++ b/.changeset/frozen-lockfile-package-extensions-peer.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`--frozen-lockfile` no longer rejects a lockfile pnpm just generated when `packageExtensions` adds a peer dependency to a workspace project. The peer is auto-installed and recorded in the importer entry, but the freshness check compared against the `package.json` on disk, which has no such peer, and reported the entry as a removed dependency [#13836](https://github.com/pnpm/pnpm/issues/13836).

--- a/pnpm/crates/cli/tests/suite/install.rs
+++ b/pnpm/crates/cli/tests/suite/install.rs
@@ -1782,6 +1782,54 @@ fn set_dir_modes(path: &std::path::Path, mode: u32) {
 /// headless install `--frozen-lockfile` does, and `--no-frozen-lockfile`
 /// overrides it back off.
 #[test]
+fn frozen_lockfile_accepts_a_peer_package_extensions_injected() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    if !workspace_yaml.ends_with('\n') {
+        workspace_yaml.push('\n');
+    }
+    workspace_yaml.push_str(concat!(
+        "autoInstallPeers: true\n",
+        "packageExtensions:\n",
+        "  root:\n",
+        "    peerDependencies:\n",
+        "      '@pnpm.e2e/foo': ^100.0.0\n",
+    ));
+    fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "name": "root", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write package.json");
+
+    pacquet.with_arg("install").assert().success();
+
+    // The extension made `@pnpm.e2e/foo` a peer of the project, so
+    // `autoInstallPeers` recorded it as a dependency of the importer. The
+    // freshness check has to see the same peer, or it reads that entry as a
+    // dependency the manifest dropped.
+    let wanted = pacquet_lockfile::Lockfile::load_wanted_from_dir(&workspace)
+        .expect("load wanted lockfile")
+        .expect("wanted lockfile");
+    assert!(
+        wanted.importers["."].dependencies.as_ref().is_some_and(
+            |dependencies| dependencies.contains_key(&"@pnpm.e2e/foo".parse().expect("alias"))
+        ),
+        "the injected peer is auto-installed into the importer",
+    );
+
+    new_pacquet_command(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
+
+    drop((root, mock_instance));
+}
+
+#[test]
 fn frozen_lockfile_setting_drives_the_headless_install() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -458,6 +458,14 @@ pub enum InstallError {
     #[diagnostic(code(ERR_PNPM_NO_LOCKFILE))]
     NoLockfile,
 
+    /// A `packageExtensions` selector the freshness gates could not parse.
+    /// The resolver reports the same error; this reaches it first because
+    /// the gates apply the extensions before deciding whether to resolve.
+    #[diagnostic(transparent)]
+    InvalidPackageExtensionSelector(
+        #[error(source)] crate::package_extender::InvalidPackageExtensionSelector,
+    ),
+
     // The three `*_DIFF` errors below mirror pnpm's `validateModules`:
     // a non-plain-install mutation refuses to touch a modules directory
     // whose persisted layout settings disagree with the current config.

--- a/pnpm/crates/package-manager/src/install/run.rs
+++ b/pnpm/crates/package-manager/src/install/run.rs
@@ -15,6 +15,7 @@ use super::{
     materialize, prepare_modules_state, run_dev_preinstall, selected_manifest_freshness_inputs,
     try_fast_update_lockfile, unapproved_recorded_ignored_builds, verify_lockfile_eagerly,
 };
+use pacquet_config::Config;
 use pacquet_executor::DEV_PREINSTALL_STAGE;
 
 impl<'a, DependencyGroupList> Install<'a, DependencyGroupList>
@@ -454,6 +455,23 @@ where
         // The optimistic repeat-install check above stays on the on-disk
         // manifests on purpose: it is the one gate that must not spawn
         // the Node worker.
+        // `packageExtensions` runs ahead of the pnpmfile's `readPackage`,
+        // the order the resolver applies them in. The freshness gates below
+        // compare against these, because the lockfile they check was written
+        // from the extended manifests too — a peer an extension injects into
+        // a workspace project is auto-installed and recorded, so a check that
+        // read the file on disk would see it as a dependency that vanished.
+        let extended_project_manifests: Vec<(PathBuf, PackageManifest)> =
+            extend_project_manifests(config, &project_manifests)?;
+        let project_manifests: Vec<(PathBuf, &PackageManifest)> =
+            if extended_project_manifests.is_empty() {
+                project_manifests
+            } else {
+                extended_project_manifests
+                    .iter()
+                    .map(|(project_dir, manifest)| (project_dir.clone(), manifest))
+                    .collect()
+            };
         let hooked_project_manifests: Vec<(PathBuf, PackageManifest)> = match pnpmfile_hook.as_ref()
         {
             Some(hook) => {
@@ -995,4 +1013,40 @@ where
         })
         .await
     }
+}
+
+/// `project_manifests` with `packageExtensions` applied — pnpm's built-in
+/// compatibility set and the user's, in that order, matching what the
+/// resolver hands the rest of the install.
+///
+/// Empty when no extension applies, so the caller keeps using the manifests
+/// it read from disk rather than a set of identical clones.
+fn extend_project_manifests(
+    config: &Config,
+    project_manifests: &[(PathBuf, &PackageManifest)],
+) -> Result<Vec<(PathBuf, PackageManifest)>, InstallError> {
+    let compat_extender = (!config.ignore_compatibility_db)
+        .then(crate::compat_package_extensions::compat_package_extender);
+    let extender = match config.package_extensions.as_ref() {
+        Some(extensions) => crate::PackageExtender::new(extensions)
+            .map(|extender| (!extender.is_empty()).then_some(extender))
+            .map_err(InstallError::InvalidPackageExtensionSelector)?,
+        None => None,
+    };
+    if compat_extender.is_none() && extender.is_none() {
+        return Ok(Vec::new());
+    }
+    Ok(project_manifests
+        .iter()
+        .map(|(project_dir, manifest)| {
+            let mut extended = (*manifest).clone();
+            if let Some(compat_extender) = compat_extender {
+                compat_extender.apply(extended.value_mut());
+            }
+            if let Some(extender) = extender.as_ref() {
+                extender.apply(extended.value_mut());
+            }
+            (project_dir.clone(), extended)
+        })
+        .collect())
 }

--- a/pnpm/crates/package-manager/src/install/run.rs
+++ b/pnpm/crates/package-manager/src/install/run.rs
@@ -1033,7 +1033,14 @@ fn extend_project_manifests(
             .map_err(InstallError::InvalidPackageExtensionSelector)?,
         None => None,
     };
-    if compat_extender.is_none() && extender.is_none() {
+    let selects = |manifest: &PackageManifest| {
+        compat_extender.is_some_and(|extender| extender.matches(manifest.value()))
+            || extender.as_ref().is_some_and(|extender| extender.matches(manifest.value()))
+    };
+    // A workspace project is rarely named by an extension — pnpm's
+    // compatibility set names published packages — so this usually finds
+    // nothing and the caller keeps the manifests it read from disk.
+    if !project_manifests.iter().any(|(_, manifest)| selects(manifest)) {
         return Ok(Vec::new());
     }
     Ok(project_manifests

--- a/pnpm/crates/package-manager/src/package_extender.rs
+++ b/pnpm/crates/package-manager/src/package_extender.rs
@@ -113,6 +113,23 @@ impl PackageExtender {
         self.by_pkg_name.is_empty()
     }
 
+    /// Whether any extension entry selects `manifest` — the name bucket
+    /// and the per-entry range both. Callers use it to skip the deep
+    /// clone for a manifest nothing extends; the cost scales with the
+    /// actual hit count rather than with the number of manifests.
+    #[must_use]
+    pub fn matches(&self, manifest: &Value) -> bool {
+        if self.is_empty() {
+            return false;
+        }
+        let Some(map) = manifest.as_object() else { return false };
+        let Some(name) = map.get("name").and_then(Value::as_str) else { return false };
+        let Some(entries) = self.by_pkg_name.get(name) else { return false };
+        let version =
+            map.get("version").and_then(Value::as_str).and_then(|raw| raw.parse::<Version>().ok());
+        entries.iter().any(|entry| entry_matches(&entry.range, version.as_ref()))
+    }
+
     /// Apply extensions in place to a single manifest.
     pub fn apply(&self, manifest: &mut Value) {
         let Some(map) = manifest.as_object_mut() else { return };
@@ -138,24 +155,14 @@ impl PackageExtender {
     /// consumer a fresh manifest without paying the deep-clone tax
     /// when nothing changed.
     ///
-    /// The name-bucket check on its own is not enough — a selector
-    /// `is-positive@^1` against a `2.0.0` manifest shares the bucket
-    /// but never matches, so a per-entry range pre-check happens
-    /// before the deep-clone. The result is the only allocation site
-    /// on the resolve hot path; an over-eager clone here would scale
-    /// with package count instead of with the actual extension hit
-    /// count.
+    /// [`Self::matches`] does the pre-check, range included: a selector
+    /// `is-positive@^1` against a `2.0.0` manifest shares the name
+    /// bucket but never matches. This is the only allocation site on
+    /// the resolve hot path; an over-eager clone here would scale with
+    /// package count instead of with the actual extension hit count.
+    #[must_use]
     pub fn apply_to_arc(&self, manifest: Arc<Value>) -> Arc<Value> {
-        if self.is_empty() {
-            return manifest;
-        }
-        let Some(map) = manifest.as_object() else { return manifest };
-        let Some(name) = map.get("name").and_then(Value::as_str) else { return manifest };
-        let Some(entries) = self.by_pkg_name.get(name) else { return manifest };
-        let version =
-            map.get("version").and_then(Value::as_str).and_then(|raw| raw.parse::<Version>().ok());
-        let has_match = entries.iter().any(|entry| entry_matches(&entry.range, version.as_ref()));
-        if !has_match {
+        if !self.matches(&manifest) {
             return manifest;
         }
         let mut cloned: Value = Value::clone(&manifest);


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#13836.

`--frozen-lockfile` rejected a lockfile the same pnpm had just written, whenever `packageExtensions` added a peer dependency to a workspace project. `autoInstallPeers` records that peer as a dependency of the importer, but the freshness gates compared the entry against the `package.json` on disk — which declares no such peer — and reported it as `1 dependency was removed`.

**pacquet-only, and the reporter's guess at the cause was right.** I ran their repro against both stacks on `main` (`7bee7dac`): the TypeScript CLI accepts the lockfile that pacquet rejects. `getContext` applies the whole `readPackage` hook — `packageExtensions` included — to the project manifests, so `satisfiesPackageManifest` already compares against the extended shape.

**The fix follows a path the install already has.** `run.rs` re-reads the project manifests through the pnpmfile's `readPackage` before the gates, for exactly this reason — the gates have to see what the lockfile was written from. `packageExtensions` runs ahead of that hook in the resolver (`packageExtensions` → `readPackage` → `overrides`), so this applies it in the same place and the same order: pnpm's built-in compatibility set, then the user's.

Two details worth a reviewer's eye:

- The extended manifests are built only for a workspace some extension actually names. My first version guarded only on both extenders being absent, which was wrong — the built-in compatibility set is present unless `ignoreCompatibilityDb` is set, so that guard almost never fired and every manifest was cloned on every install (caught in review). `PackageExtender::matches` now answers the name-bucket-plus-range question up front; it is the same pre-check `apply_to_arc` already used on the resolve hot path, extracted so both call sites share it. A workspace project is rarely named by an extension, so the usual answer is "none" and the caller keeps the manifests it read from disk.
- A `packageExtensions` selector that fails to parse now surfaces from the gates rather than the resolver. It is the same error either way (`InvalidPackageExtensionSelector`, transparent), just raised before the decision to resolve instead of after.

**Not included: `overrides`.** They are the third stage of the same chain, and TypeScript folds them into the manifests the gates see too. I left them out because I have no failing case for them, and unlike the extensions they can rewrite an importer's own specifiers — worth its own change with its own repro rather than riding along here.

## Squash Commit Body

```text
`--frozen-lockfile` rejected a lockfile the same pnpm had just written
whenever `packageExtensions` added a peer dependency to a workspace
project: `autoInstallPeers` records that peer as a dependency of the
importer, but the freshness gates compared the entry against the
`package.json` on disk, which declares no such peer, and reported it as
a dependency that had been removed.

The install already re-reads the project manifests through the
pnpmfile's `readPackage` before the gates, for exactly this reason.
`packageExtensions` runs ahead of that hook in the resolver, so apply it
in the same place and in the same order — pnpm's built-in compatibility
set, then the user's — leaving the gates comparing against the manifests
the lockfile was written from.

The extended manifests are built only when an extension applies, so a
workspace that configures none keeps using what it read from disk rather
than a set of identical clones. A selector that fails to parse now
surfaces from the gates instead of the resolver, which is the same error
either way.

TypeScript is unaffected: `getContext` applies the whole `readPackage`
hook — `packageExtensions` included — to the project manifests, so
`satisfiesPackageManifest` already compares against the extended shape.
Confirmed against the reporter's repro: the TypeScript CLI accepts the
lockfile pacquet rejected.

Closes pnpm/pnpm#13836.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed frozen-lockfile installs for workspace projects where `packageExtensions` add peer dependencies.
  * Ensured configured package extensions are applied during installation and recorded consistently in the lockfile.
  * Improved diagnostics for invalid package-extension selectors.

* **Tests**
  * Added end-to-end coverage verifying successful frozen-lockfile installs with injected peer dependencies.
  * Added validation for package-extension matching and installation behavior across supported project configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->