### PR TITLE
perf(resolver): share package ids across the occurrences that name them

### DIFF
--- a/.changeset/shared-package-ids.md
+++ b/.changeset/shared-package-ids.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Reduced peak memory usage while resolving peer dependencies further: each occurrence in the dependency tree now shares its package id with the edge it came from instead of owning a copy of it.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4194,6 +4194,7 @@ dependencies = [
 name = "pacquet-deps-path"
 version = "0.0.1"
 dependencies = [
+ "derive_more",
  "node-semver",
  "pacquet-crypto-hash",
 ]

--- a/pnpm/crates/deps-path/Cargo.toml
+++ b/pnpm/crates/deps-path/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace     = true
 repository.workspace  = true
 
 [dependencies]
+derive_more         = { workspace = true }
 node-semver         = { workspace = true }
 pacquet-crypto-hash = { workspace = true }
 

--- a/pnpm/crates/deps-path/src/dep_path.rs
+++ b/pnpm/crates/deps-path/src/dep_path.rs
@@ -12,7 +12,11 @@ use std::sync::Arc;
 /// resolver crate) so that lower-level helpers (peer-id construction,
 /// suffix scanning, filename escaping) can speak in depPath terms
 /// without forcing a back-dependency from `deps-path` to the resolver.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+/// `From<Arc<str>>` is derived: [`DepPath`] already wraps an `Arc<str>`,
+/// so a caller holding one hands over the refcount instead of copying the
+/// string. The `String` and `&str` conversions stay handwritten because
+/// they allocate.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, derive_more::From)]
 pub struct DepPath(Arc<str>);
 
 impl DepPath {
@@ -32,14 +36,6 @@ impl std::fmt::Display for DepPath {
 impl From<String> for DepPath {
     fn from(value: String) -> DepPath {
         DepPath(Arc::from(value))
-    }
-}
-
-impl From<Arc<str>> for DepPath {
-    /// Free: [`DepPath`] already wraps an `Arc<str>`, so a caller that
-    /// holds one hands over the refcount instead of copying the string.
-    fn from(value: Arc<str>) -> Self {
-        DepPath(value)
     }
 }
 

--- a/pnpm/crates/deps-path/src/dep_path.rs
+++ b/pnpm/crates/deps-path/src/dep_path.rs
@@ -35,6 +35,14 @@ impl From<String> for DepPath {
     }
 }
 
+impl From<Arc<str>> for DepPath {
+    /// Free: [`DepPath`] already wraps an `Arc<str>`, so a caller that
+    /// holds one hands over the refcount instead of copying the string.
+    fn from(value: Arc<str>) -> Self {
+        DepPath(value)
+    }
+}
+
 impl From<&str> for DepPath {
     fn from(value: &str) -> DepPath {
         DepPath(Arc::from(value))

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -1242,21 +1242,21 @@ fn snapshot_preserves_optional_child_edges_from_resolved_tree() {
         "dependencies": { "outer": "^1.0.0" },
     }));
 
-    let outer_id = "outer@1.0.0".to_string();
-    let inner_id = "inner@1.0.0".to_string();
+    let outer_id: Arc<str> = "outer@1.0.0".into();
+    let inner_id: Arc<str> = "inner@1.0.0".into();
     let outer_node_id = NodeId::next();
 
     let mut tree = ResolvedTree {
         direct: vec![DirectDep {
             alias: "outer".to_string(),
             node_id: outer_node_id.clone(),
-            id: outer_id.clone(),
+            id: outer_id.to_string(),
         }],
         packages: HashMap::from_iter([
             (
-                outer_id.clone(),
+                Arc::<str>::clone(&outer_id),
                 ResolvedPackage {
-                    id: outer_id.clone(),
+                    id: Arc::<str>::clone(&outer_id),
                     result: Arc::new(make_resolve_result(
                         "outer",
                         "1.0.0",
@@ -1268,9 +1268,9 @@ fn snapshot_preserves_optional_child_edges_from_resolved_tree() {
                 },
             ),
             (
-                inner_id.clone(),
+                Arc::<str>::clone(&inner_id),
                 ResolvedPackage {
-                    id: inner_id.clone(),
+                    id: Arc::<str>::clone(&inner_id),
                     result: Arc::new(make_resolve_result(
                         "inner",
                         "1.0.0",
@@ -1285,7 +1285,7 @@ fn snapshot_preserves_optional_child_edges_from_resolved_tree() {
         dependencies_tree: HashMap::from_iter([(
             outer_node_id,
             DependenciesTreeNode::new(
-                outer_id.clone(),
+                Arc::<str>::clone(&outer_id),
                 TreeChildren::Lazy { parent_ids: Arc::new(Vec::new()).into() },
                 0,
                 true,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/reuse.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/reuse.rs
@@ -577,10 +577,11 @@ where
                 }
             }
             ctx.workspace.record_package_write(&id);
+            let shared_id: Arc<str> = Arc::from(id.as_str());
             packages.insert(
-                Arc::from(id.clone()),
+                Arc::<str>::clone(&shared_id),
                 ResolvedPackage {
-                    id: Arc::from(id.clone()),
+                    id: shared_id,
                     result: Arc::clone(&result),
                     peer_dependencies,
                     optional: current_is_optional,
@@ -642,7 +643,7 @@ where
                 let optional = optional_by_alias.get(dep.alias.as_str()).copied().unwrap_or(false);
                 by_id.push(crate::resolved_tree::ChildEdge {
                     alias: dep.alias.clone(),
-                    pkg_id: Arc::from(dep.id.clone()),
+                    pkg_id: Arc::from(dep.id),
                     optional,
                 });
                 realized.insert(dep.alias, dep.node_id);

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/reuse.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/reuse.rs
@@ -564,7 +564,7 @@ where
 
     let package_is_new = {
         let mut packages = lock_recoverable(&ctx.workspace.packages);
-        if let Some(existing) = packages.get_mut(&id) {
+        if let Some(existing) = packages.get_mut(id.as_str()) {
             existing.optional = existing.optional && current_is_optional;
             false
         } else {
@@ -578,9 +578,9 @@ where
             }
             ctx.workspace.record_package_write(&id);
             packages.insert(
-                id.clone(),
+                Arc::from(id.clone()),
                 ResolvedPackage {
-                    id: id.clone(),
+                    id: Arc::from(id.clone()),
                     result: Arc::clone(&result),
                     peer_dependencies,
                     optional: current_is_optional,
@@ -642,7 +642,7 @@ where
                 let optional = optional_by_alias.get(dep.alias.as_str()).copied().unwrap_or(false);
                 by_id.push(crate::resolved_tree::ChildEdge {
                     alias: dep.alias.clone(),
-                    pkg_id: dep.id.clone(),
+                    pkg_id: Arc::from(dep.id.clone()),
                     optional,
                 });
                 realized.insert(dep.alias, dep.node_id);

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
@@ -443,7 +443,7 @@ where
     // [`fn@install_owner_peer_dependencies`]. Seeding only has to fill
     // a package nothing has resolved yet.
     let mut packages = lock_recoverable(&ctx.workspace.packages);
-    let package_is_new = if let Some(existing) = packages.get_mut(&id) {
+    let package_is_new = if let Some(existing) = packages.get_mut(id.as_str()) {
         existing.optional = existing.optional && current_is_optional;
         false
     } else {
@@ -455,9 +455,9 @@ where
         register_peer_dep_names(ctx, &peer_dependencies);
         ctx.workspace.record_package_write(&id);
         packages.insert(
-            id.clone(),
+            Arc::from(id.clone()),
             ResolvedPackage {
-                id: id.clone(),
+                id: Arc::from(id.clone()),
                 result: Arc::clone(&result),
                 peer_dependencies,
                 optional: current_is_optional,
@@ -639,7 +639,7 @@ fn install_owner_peer_dependencies(
     }
     let peer_dependencies = extract_peer_dependencies(&pending.result, &claim.peer_shadowed);
     let mut packages = lock_recoverable(&ctx.workspace.packages);
-    let Some(existing) = packages.get_mut(&pending.id) else { return };
+    let Some(existing) = packages.get_mut(pending.id.as_str()) else { return };
     if existing.peer_dependencies == peer_dependencies {
         return;
     }
@@ -756,7 +756,7 @@ fn record_walked_children(
         let optional = optional_by_alias.get(dep.alias.as_str()).copied().unwrap_or(false);
         by_id.push(crate::resolved_tree::ChildEdge {
             alias: dep.alias.clone(),
-            pkg_id: dep.id,
+            pkg_id: Arc::from(dep.id),
             optional,
         });
         realized.insert(dep.alias, dep.node_id);
@@ -835,13 +835,14 @@ where
     // it is cached unfiltered because which of the specs the package's
     // own `peerDependencies` shadow is a property of the owner
     // occurrence, not of the manifest.
-    let cached = lock_recoverable(&ctx.workspace.children_specs_by_id).get(&pending.id).cloned();
+    let cached =
+        lock_recoverable(&ctx.workspace.children_specs_by_id).get(pending.id.as_str()).cloned();
     let child_specs = if let Some(specs) = cached {
         specs
     } else {
         let specs = Arc::new(extract_children(&pending.result)?);
         lock_recoverable(&ctx.workspace.children_specs_by_id)
-            .entry(pending.id.clone())
+            .entry(Arc::from(pending.id.clone()))
             .or_insert_with(|| Arc::clone(&specs));
         specs
     };
@@ -1283,7 +1284,7 @@ pub(super) fn level_versions(ctx: &TreeCtx, seeds: &[NodeSeed]) -> BTreeMap<Stri
         let name_ver = match seed {
             NodeSeed::Pending(pending) => pending.result.name_ver.as_ref(),
             NodeSeed::Done(Some(dep)) => {
-                packages.get(&dep.id).and_then(|pkg| pkg.result.name_ver.as_ref())
+                packages.get(dep.id.as_str()).and_then(|pkg| pkg.result.name_ver.as_ref())
             }
             NodeSeed::Done(None) => None,
         };
@@ -1309,7 +1310,7 @@ fn pkgs_info_from_ids(
     ancestor_ids
         .iter()
         .map(|id| {
-            let name_ver = packages.get(id).and_then(|pkg| pkg.result.name_ver.as_ref());
+            let name_ver = packages.get(id.as_str()).and_then(|pkg| pkg.result.name_ver.as_ref());
             SkippedOptionalDependencyParent {
                 id: id.clone(),
                 name: name_ver.map(|name_ver| name_ver.name.to_string()).unwrap_or_default(),

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
@@ -454,10 +454,11 @@ where
         };
         register_peer_dep_names(ctx, &peer_dependencies);
         ctx.workspace.record_package_write(&id);
+        let shared_id: Arc<str> = Arc::from(id.as_str());
         packages.insert(
-            Arc::from(id.clone()),
+            Arc::<str>::clone(&shared_id),
             ResolvedPackage {
-                id: Arc::from(id.clone()),
+                id: shared_id,
                 result: Arc::clone(&result),
                 peer_dependencies,
                 optional: current_is_optional,
@@ -842,7 +843,7 @@ where
     } else {
         let specs = Arc::new(extract_children(&pending.result)?);
         lock_recoverable(&ctx.workspace.children_specs_by_id)
-            .entry(Arc::from(pending.id.clone()))
+            .entry(Arc::from(pending.id.as_str()))
             .or_insert_with(|| Arc::clone(&specs));
         specs
     };

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
@@ -231,7 +231,7 @@ pub struct WorkspaceTreeCtx {
     /// engine rebuilds its view instead of merging when this advanced
     /// since its last sync.
     children_rewrites: std::sync::atomic::AtomicU64,
-    pub(super) packages: Mutex<HashMap<String, ResolvedPackage>>,
+    pub(super) packages: Mutex<HashMap<Arc<str>, ResolvedPackage>>,
     /// `pkgIdWithPatchHash` of every importer-level direct dependency
     /// recorded so far (initial waves plus hoisted peers), across all
     /// importers. These are the roots [`Self::run_preferred_versions`]
@@ -253,22 +253,22 @@ pub struct WorkspaceTreeCtx {
     pub(super) applied_patches: Mutex<HashSet<String>>,
     pub(super) resolved_by_wanted:
         Mutex<HashMap<WantedKey, Arc<pacquet_resolving_resolver_base::ResolveResult>>>,
-    pub(super) children_specs_by_id: Mutex<HashMap<String, Arc<Vec<ChildSpec>>>>,
+    pub(super) children_specs_by_id: Mutex<HashMap<Arc<str>, Arc<Vec<ChildSpec>>>>,
     /// Package ids whose children have already been speculatively
     /// resolved. A package is warmed once, however many occurrences of
     /// it a level seeds — see [`fn@warm_children_resolutions`].
     ///
     /// [`fn@warm_children_resolutions`]: super::walk::warm_children_resolutions
-    warmed_children_by_id: Mutex<HashSet<String>>,
-    pub(super) children_by_id: Mutex<HashMap<String, RecordedChildren>>,
-    children_owner_by_id: Mutex<HashMap<String, ChildrenOwnerEntry>>,
+    warmed_children_by_id: Mutex<HashSet<Arc<str>>>,
+    pub(super) children_by_id: Mutex<HashMap<Arc<str>, RecordedChildren>>,
+    children_owner_by_id: Mutex<HashMap<Arc<str>, ChildrenOwnerEntry>>,
     node_parent_ids_by_id: Mutex<HashMap<NodeId, Arc<Vec<String>>>>,
     /// Reverse index over `dependencies_tree`: every occurrence node
     /// recorded for a `pkgIdWithPatchHash`. Keeps
     /// [`fn@make_non_owner_nodes_lazy`] proportional to the package's
     /// own occurrences — scanning the whole tree per recorded package
     /// made lockfile-reuse walks quadratic in workspace size.
-    nodes_by_pkg_id: Mutex<HashMap<String, Vec<NodeId>>>,
+    nodes_by_pkg_id: Mutex<HashMap<Arc<str>, Vec<NodeId>>>,
     /// See [`SyncLog`].
     sync_log: Mutex<SyncLog>,
     pub(super) manifest_hook: Option<ManifestHook>,
@@ -536,7 +536,9 @@ impl WorkspaceTreeCtx {
             applied_patches: lock_recoverable(&self.applied_patches).clone(),
             children_by_id: lock_recoverable(&self.children_by_id)
                 .iter()
-                .map(|(pkg_id, recorded)| (pkg_id.clone(), Arc::clone(&recorded.edges)))
+                .map(|(pkg_id, recorded)| {
+                    (std::sync::Arc::<str>::clone(pkg_id), Arc::clone(&recorded.edges))
+                })
                 .collect(),
         }
     }
@@ -568,7 +570,7 @@ impl WorkspaceTreeCtx {
             let Some(node) = dependencies_tree.get(&node_id) else {
                 continue;
             };
-            reachable_pkg_ids.insert(node.resolved_package_id.clone());
+            reachable_pkg_ids.insert(std::sync::Arc::<str>::clone(&node.resolved_package_id));
             if let crate::resolved_tree::TreeChildren::Realized(children) = &node.children {
                 pending_node_ids.extend(children.values().cloned());
             }
@@ -587,7 +589,7 @@ impl WorkspaceTreeCtx {
         let dependencies_tree = reachable_dependencies_tree;
 
         let all_children = lock_recoverable(&self.children_by_id);
-        let mut pending_pkg_ids: Vec<String> = reachable_pkg_ids.iter().cloned().collect();
+        let mut pending_pkg_ids: Vec<Arc<str>> = reachable_pkg_ids.iter().cloned().collect();
         let mut children_by_id = HashMap::default();
         while let Some(pkg_id) = pending_pkg_ids.pop() {
             let Some(children) = all_children.get(&pkg_id) else {
@@ -595,8 +597,8 @@ impl WorkspaceTreeCtx {
             };
             children_by_id.insert(pkg_id, Arc::clone(&children.edges));
             for child in children.edges.iter() {
-                if reachable_pkg_ids.insert(child.pkg_id.clone()) {
-                    pending_pkg_ids.push(child.pkg_id.clone());
+                if reachable_pkg_ids.insert(std::sync::Arc::<str>::clone(&child.pkg_id)) {
+                    pending_pkg_ids.push(std::sync::Arc::<str>::clone(&child.pkg_id));
                 }
             }
         }
@@ -605,7 +607,7 @@ impl WorkspaceTreeCtx {
         let packages = lock_recoverable(&self.packages);
         let packages = reachable_pkg_ids
             .into_iter()
-            .filter_map(|pkg_id| packages.get(&pkg_id).cloned().map(|pkg| (pkg_id, pkg)))
+            .filter_map(|pkg_id| packages.get(&*pkg_id).cloned().map(|pkg| (pkg_id, pkg)))
             .collect();
 
         ResolvedTree {
@@ -679,15 +681,15 @@ impl WorkspaceTreeCtx {
             }
             let recorded_by_current_owner = record
                 .map()
-                .get(pkg_id)
+                .get(&**pkg_id)
                 .is_some_and(|entry| entry.recorded_by.as_ref() == Some(owner));
             if !recorded_by_current_owner {
                 let names = missing_by_pkg
-                    .get(pkg_id.as_str())
+                    .get(&**pkg_id)
                     .map(|names| names.iter().map(str::to_owned).collect())
                     .unwrap_or_default();
                 record.map_mut().insert(
-                    pkg_id.clone(),
+                    std::sync::Arc::<str>::clone(pkg_id).to_string(),
                     OwnerMissingRecord { recorded_by: Some(owner.clone()), names },
                 );
             }
@@ -786,10 +788,10 @@ impl WorkspaceTreeCtx {
                 if !cache.visited.insert(pkg_id.clone()) {
                     continue;
                 }
-                if let Some(children) = children_by_id.get(&pkg_id) {
+                if let Some(children) = children_by_id.get(pkg_id.as_str()) {
                     for child in children.edges.iter() {
-                        if !cache.visited.contains(&child.pkg_id) {
-                            queue.push(child.pkg_id.clone());
+                        if !cache.visited.contains(&*child.pkg_id) {
+                            queue.push(std::sync::Arc::<str>::clone(&child.pkg_id).to_string());
                         }
                     }
                 }
@@ -799,7 +801,7 @@ impl WorkspaceTreeCtx {
         {
             let packages = lock_recoverable(&self.packages);
             for pkg_id in newly_visited {
-                match packages.get(&pkg_id).and_then(|pkg| pkg.result.name_ver.as_ref()) {
+                match packages.get(pkg_id.as_str()).and_then(|pkg| pkg.result.name_ver.as_ref()) {
                     Some(name_ver) => fold_version(
                         &mut cache.versions,
                         name_ver.name.to_string(),
@@ -924,10 +926,12 @@ impl WorkspaceTreeCtx {
             });
             let children_by_id = lock_recoverable(&self.children_by_id);
             for pkg_id in &written {
-                let Some(spec) = children_by_id.get(pkg_id).map(|recorded| &recorded.edges) else {
+                let Some(spec) =
+                    children_by_id.get(pkg_id.as_str()).map(|recorded| &recorded.edges)
+                else {
                     continue;
                 };
-                match tree.children_by_id.entry(pkg_id.clone()) {
+                match tree.children_by_id.entry(Arc::from(pkg_id.clone())) {
                     Entry::Vacant(entry) => {
                         entry.insert(Arc::clone(spec));
                     }
@@ -947,8 +951,8 @@ impl WorkspaceTreeCtx {
             let written = self.written_since(cursor.packages, next.packages, |log| &log.packages);
             let packages = lock_recoverable(&self.packages);
             for pkg_id in &written {
-                let Some(pkg) = packages.get(pkg_id) else { continue };
-                match tree.packages.entry(pkg_id.clone()) {
+                let Some(pkg) = packages.get(pkg_id.as_str()) else { continue };
+                match tree.packages.entry(Arc::from(pkg_id.clone())) {
                     Entry::Vacant(entry) => {
                         entry.insert(pkg.clone());
                     }
@@ -1009,11 +1013,13 @@ impl WorkspaceTreeCtx {
         };
         for (pkg_id, recorded) in lock_recoverable(&self.children_by_id).iter() {
             tree.children_by_id
-                .entry(pkg_id.clone())
+                .entry(std::sync::Arc::<str>::clone(pkg_id))
                 .or_insert_with(|| Arc::clone(&recorded.edges));
         }
         for (pkg_id, pkg) in lock_recoverable(&self.packages).iter() {
-            tree.packages.entry(pkg_id.clone()).or_insert_with(|| pkg.clone());
+            tree.packages
+                .entry(std::sync::Arc::<str>::clone(pkg_id))
+                .or_insert_with(|| pkg.clone());
         }
         for (node_id, node) in lock_recoverable(&self.dependencies_tree).iter() {
             tree.dependencies_tree.entry(node_id.clone()).or_insert_with(|| node.clone());
@@ -1052,7 +1058,7 @@ impl WorkspaceTreeCtx {
         node_ids
             .filter_map(|node_id| {
                 let pkg_id = &dependencies_tree.get(node_id)?.resolved_package_id;
-                packages.contains_key(pkg_id).then(|| (node_id.clone(), pkg_id.clone()))
+                packages.contains_key(&**pkg_id).then(|| (node_id.clone(), pkg_id.to_string()))
             })
             .collect()
     }
@@ -1277,7 +1283,7 @@ pub(super) fn claim_children_owner(
                     existing.is_some_and(|entry| *entry.peer_shadowed == peer_shadowed);
                 let peer_shadowed = Arc::new(peer_shadowed);
                 owners.insert(
-                    pkg_id.to_string(),
+                    Arc::from(pkg_id.to_string()),
                     ChildrenOwnerEntry {
                         owner: owner.clone(),
                         peer_shadowed: Arc::clone(&peer_shadowed),
@@ -1304,7 +1310,7 @@ pub(super) fn claim_children_warmup(ctx: &TreeCtx, pkg_id: &str) -> bool {
     // Every occurrence of a package offers, and all but the first are
     // turned away, so the owned key is built only for the one that
     // takes the warmup.
-    !warmed.contains(pkg_id) && warmed.insert(pkg_id.to_string())
+    !warmed.contains(pkg_id) && warmed.insert(Arc::from(pkg_id.to_string()))
 }
 
 /// Whether this package's recorded children were resolved under
@@ -1408,7 +1414,10 @@ pub(super) fn record_children(
             Some(recorded) if *recorded.edges == edges => ChildrenRecording::Published,
             Some(_) => ChildrenRecording::PublishedOverStale,
         };
-        children.insert(pkg_id.to_string(), RecordedChildren { edges: Arc::new(edges), context });
+        children.insert(
+            Arc::from(pkg_id.to_string()),
+            RecordedChildren { edges: Arc::new(edges), context },
+        );
         recording
     };
     ctx.workspace.record_children_by_id_write(pkg_id);
@@ -1467,7 +1476,12 @@ pub(super) fn insert_tree_node(
             false
         }
         std::collections::hash_map::Entry::Vacant(entry) => {
-            entry.insert(DependenciesTreeNode::new(pkg_id.to_string(), children, depth, true));
+            entry.insert(DependenciesTreeNode::new(
+                Arc::from(pkg_id.to_string()),
+                children,
+                depth,
+                true,
+            ));
             true
         }
     };
@@ -1476,7 +1490,7 @@ pub(super) fn insert_tree_node(
     }
     if inserted {
         lock_recoverable(&ctx.workspace.nodes_by_pkg_id)
-            .entry(pkg_id.to_string())
+            .entry(Arc::from(pkg_id.to_string()))
             .or_default()
             .push(node_id);
     }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
@@ -1283,7 +1283,7 @@ pub(super) fn claim_children_owner(
                     existing.is_some_and(|entry| *entry.peer_shadowed == peer_shadowed);
                 let peer_shadowed = Arc::new(peer_shadowed);
                 owners.insert(
-                    Arc::from(pkg_id.to_string()),
+                    Arc::from(pkg_id),
                     ChildrenOwnerEntry {
                         owner: owner.clone(),
                         peer_shadowed: Arc::clone(&peer_shadowed),

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx/tests.rs
@@ -24,7 +24,7 @@ fn importer_snapshot_excludes_other_importers_occurrence_nodes() {
         (
             root.clone(),
             DependenciesTreeNode::new(
-                "root@1.0.0".to_string(),
+                Arc::from("root@1.0.0".to_string()),
                 TreeChildren::Realized(
                     BTreeMap::from([("child".to_string(), child.clone())]).into(),
                 ),
@@ -34,12 +34,17 @@ fn importer_snapshot_excludes_other_importers_occurrence_nodes() {
         ),
         (
             child.clone(),
-            DependenciesTreeNode::new("child@1.0.0".to_string(), TreeChildren::empty(), 1, true),
+            DependenciesTreeNode::new(
+                Arc::from("child@1.0.0".to_string()),
+                TreeChildren::empty(),
+                1,
+                true,
+            ),
         ),
         (
             unrelated.clone(),
             DependenciesTreeNode::new(
-                "unrelated@1.0.0".to_string(),
+                Arc::from("unrelated@1.0.0".to_string()),
                 TreeChildren::empty(),
                 0,
                 true,
@@ -70,25 +75,26 @@ fn importer_snapshot_follows_lazy_edges_for_the_package_closure() {
     lock_recoverable(&workspace.dependencies_tree).insert(
         root.clone(),
         DependenciesTreeNode::new(
-            "root@1.0.0".to_string(),
+            Arc::from("root@1.0.0".to_string()),
             TreeChildren::Lazy { parent_ids: Arc::new(Vec::new()).into() },
             0,
             true,
         ),
     );
     for pkg_id in ["root@1.0.0", "lazy-child@1.0.0", "foreign@1.0.0"] {
-        lock_recoverable(&workspace.packages).insert(pkg_id.to_string(), snapshot_package(pkg_id));
+        lock_recoverable(&workspace.packages)
+            .insert(Arc::from(pkg_id.to_string()), snapshot_package(pkg_id));
     }
     lock_recoverable(&workspace.children_by_id).insert(
-        "root@1.0.0".to_string(),
+        Arc::from("root@1.0.0".to_string()),
         recorded(vec![ChildEdge {
             alias: "lazy-child".to_string(),
-            pkg_id: "lazy-child@1.0.0".to_string(),
+            pkg_id: Arc::from("lazy-child@1.0.0".to_string()),
             optional: false,
         }]),
     );
     lock_recoverable(&workspace.children_by_id)
-        .insert("foreign@1.0.0".to_string(), recorded(Vec::new()));
+        .insert(Arc::from("foreign@1.0.0".to_string()), recorded(Vec::new()));
 
     let snapshot = workspace.snapshot_reachable_from(vec![DirectDep {
         alias: "root".to_string(),
@@ -161,7 +167,7 @@ fn owner_missing_record_is_written_once_per_generation() {
         peer_shadowed: Arc::new(HashSet::default()),
     };
     lock_recoverable(&ctx.children_owner_by_id)
-        .insert("pkg@1.0.0".to_string(), entry(owner.clone()));
+        .insert(Arc::from("pkg@1.0.0".to_string()), entry(owner.clone()));
 
     let names = |names: &[&str]| -> HashSet<String> {
         names.iter().map(|name| (*name).to_string()).collect()
@@ -189,7 +195,8 @@ fn owner_missing_record_is_written_once_per_generation() {
     );
 
     let new_owner = ChildrenOwner { depth: 0, ..owner };
-    lock_recoverable(&ctx.children_owner_by_id).insert("pkg@1.0.0".to_string(), entry(new_owner));
+    lock_recoverable(&ctx.children_owner_by_id)
+        .insert(Arc::from("pkg@1.0.0".to_string()), entry(new_owner));
     ctx.record_first_walk_missing(".", &miss(&none));
     assert_eq!(
         ctx.first_walk_missing_by_pkg().get("pkg@1.0.0").map(HashSet::len),
@@ -214,7 +221,7 @@ fn owner_scope_snapshots_are_shared_until_a_write_changes_the_map() {
         importer_id: ".".to_string(),
     };
     lock_recoverable(&ctx.children_owner_by_id).insert(
-        "pkg@1.0.0".to_string(),
+        Arc::from("pkg@1.0.0".to_string()),
         ChildrenOwnerEntry { owner, peer_shadowed: Arc::new(HashSet::default()) },
     );
 
@@ -260,7 +267,7 @@ fn importer_scoped_update_owner_wins_before_discovery_order() {
 
 fn snapshot_package(pkg_id: &str) -> super::ResolvedPackage {
     super::ResolvedPackage {
-        id: pkg_id.to_string(),
+        id: Arc::from(pkg_id.to_string()),
         result: std::sync::Arc::new(manifest_result(serde_json::json!({}))),
         peer_dependencies: BTreeMap::new(),
         optional: false,
@@ -304,7 +311,8 @@ fn run_preferred_versions_grow_with_new_roots_and_rebuild_on_children_rewrites()
 
     // A children-ownership rewrite can drop edges, so the closure is
     // rebuilt rather than grown.
-    lock_recoverable(&workspace.children_by_id).insert("root@1.0.0".to_string(), recorded(vec![]));
+    lock_recoverable(&workspace.children_by_id)
+        .insert(Arc::from("root@1.0.0".to_string()), recorded(vec![]));
     workspace.record_children_rewrite();
     workspace.bump_revision();
     let cache = workspace.run_preferred_versions();
@@ -317,7 +325,7 @@ fn run_preferred_versions_grow_with_new_roots_and_rebuild_on_children_rewrites()
 fn run_preferred_versions_fold_workspace_manifest_identities_once_reachable() {
     let workspace = WorkspaceTreeCtx::default();
     lock_recoverable(&workspace.packages)
-        .insert("link:packages/opt".to_string(), snapshot_package("link:packages/opt"));
+        .insert(Arc::from("link:packages/opt".to_string()), snapshot_package("link:packages/opt"));
     workspace.record_workspace_manifest_identity("link:packages/opt", "opt", "1.0.0");
     insert_named_package(&workspace, "root", "1.0.0");
     workspace.record_preferred_version_roots(std::iter::once("root@1.0.0"));
@@ -338,7 +346,7 @@ fn run_preferred_versions_pick_up_an_identity_recorded_after_the_first_visit() {
     let workspace = WorkspaceTreeCtx::default();
     insert_named_package(&workspace, "root", "1.0.0");
     lock_recoverable(&workspace.packages)
-        .insert("link:packages/opt".to_string(), snapshot_package("link:packages/opt"));
+        .insert(Arc::from("link:packages/opt".to_string()), snapshot_package("link:packages/opt"));
     insert_child_edge(&workspace, "root@1.0.0", "opt", "link:packages/opt");
     workspace.record_preferred_version_roots(std::iter::once("root@1.0.0"));
     workspace.bump_revision();
@@ -359,21 +367,21 @@ fn insert_named_package(workspace: &WorkspaceTreeCtx, name: &str, version: &str)
     result.name_ver = Some(name_ver);
     let pkg_id = format!("{name}@{version}");
     let package = super::ResolvedPackage {
-        id: pkg_id.clone(),
+        id: Arc::from(pkg_id.clone()),
         result: std::sync::Arc::new(result),
         peer_dependencies: BTreeMap::new(),
         optional: false,
         is_leaf: false,
     };
-    lock_recoverable(&workspace.packages).insert(pkg_id, package);
+    lock_recoverable(&workspace.packages).insert(Arc::from(pkg_id), package);
 }
 
 fn insert_child_edge(workspace: &WorkspaceTreeCtx, parent_id: &str, alias: &str, child_id: &str) {
     lock_recoverable(&workspace.children_by_id).insert(
-        parent_id.to_string(),
+        Arc::from(parent_id.to_string()),
         recorded(vec![crate::resolved_tree::ChildEdge {
             alias: alias.to_string(),
-            pkg_id: child_id.to_string(),
+            pkg_id: Arc::from(child_id.to_string()),
             optional: false,
         }]),
     );
@@ -458,7 +466,7 @@ fn record_package(workspace: &WorkspaceTreeCtx, pkg_id: &str, peer_names: &[&str
         })
         .collect();
     lock_recoverable(&workspace.packages).insert(
-        pkg_id.to_string(),
+        Arc::from(pkg_id.to_string()),
         super::ResolvedPackage { peer_dependencies, ..snapshot_package(pkg_id) },
     );
     let mut all_peers = lock_recoverable(&workspace.all_peer_dep_names);
@@ -482,7 +490,7 @@ fn record_tree_node(workspace: &WorkspaceTreeCtx, node_id: &NodeId, pkg_id: &str
         }
         std::collections::hash_map::Entry::Vacant(entry) => {
             entry.insert(DependenciesTreeNode::new(
-                pkg_id.to_string(),
+                Arc::from(pkg_id.to_string()),
                 TreeChildren::empty(),
                 depth,
                 true,
@@ -636,7 +644,7 @@ fn re_recording_reports_whether_the_child_edges_moved() {
     let edges = |pkg_id: &str| {
         vec![crate::resolved_tree::ChildEdge {
             alias: "dep".to_string(),
-            pkg_id: pkg_id.to_string(),
+            pkg_id: Arc::from(pkg_id.to_string()),
             optional: false,
         }]
     };
@@ -680,7 +688,7 @@ fn re_recording_reports_whether_the_child_edges_moved() {
         .expect("pinned children")
         .edges
         .iter()
-        .map(|edge| edge.pkg_id.as_str())
+        .map(|edge| &*edge.pkg_id)
         .collect();
     assert_eq!(standing, ["dep@1.0.0"], "the pinned children are what every occurrence reads");
 }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -1226,7 +1226,7 @@ fn build_workspace_root_deps(
     let mut out = Vec::with_capacity(direct.len());
     let mut named = HashSet::default();
     for dep in direct {
-        let Some(pkg) = snapshot.packages.get(&dep.id) else { continue };
+        let Some(pkg) = snapshot.packages.get(dep.id.as_str()) else { continue };
         let Some(pkg_name) = resolved_pkg_name(&pkg.result) else { continue };
         named.insert(dep.alias.as_str());
         out.push(WorkspaceRootDep {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/cache.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/cache.rs
@@ -78,7 +78,7 @@ pub(super) struct CachedNodeOutput {
 enum DeferredChildResolution {
     Pure(DepPath),
     Cached(CachedNodeOutput),
-    Materialize(String),
+    Materialize(Arc<str>),
 }
 
 pub(super) struct CacheHitContext<'a> {
@@ -292,7 +292,7 @@ impl Walker<'_> {
                     else {
                         return FastCacheMatch::NoMatch;
                     };
-                    if cached_tree_node.resolved_package_id != Arc::from(child_pkg_id) {
+                    if &*cached_tree_node.resolved_package_id != child_pkg_id {
                         return FastCacheMatch::NoMatch;
                     }
                     let child_is_stable = self.pure_pkgs.contains_key(child_pkg_id)
@@ -415,10 +415,10 @@ impl Walker<'_> {
         &self,
         parent_ids: &AncestorIds,
         parent_refs: &ParentRefs,
-        pkg_id: &str,
+        pkg_id: &Arc<str>,
     ) -> DeferredChildResolution {
-        if let Some(dep_path) = self.pure_pkgs.get(pkg_id)
-            && self.tree.packages[pkg_id].peer_dependencies.is_empty()
+        if let Some(dep_path) = self.pure_pkgs.get(&**pkg_id)
+            && self.tree.packages[&**pkg_id].peer_dependencies.is_empty()
         {
             return DeferredChildResolution::Pure(dep_path.clone());
         }
@@ -429,7 +429,7 @@ impl Walker<'_> {
         {
             return DeferredChildResolution::Cached(cached);
         }
-        DeferredChildResolution::Materialize(pkg_id.to_string())
+        DeferredChildResolution::Materialize(Arc::<str>::clone(pkg_id))
     }
 
     pub(super) fn resolve_deferred_child(
@@ -460,7 +460,7 @@ impl Walker<'_> {
                 self.tree.dependencies_tree.insert(
                     node_id.clone(),
                     DependenciesTreeNode::new(
-                        Arc::from(pkg_id),
+                        pkg_id,
                         TreeChildren::Lazy { parent_ids: parent_ids.clone() },
                         depth,
                         true,
@@ -505,7 +505,7 @@ impl Walker<'_> {
                 .tree
                 .dependencies_tree
                 .get(parent_node_id)
-                .is_some_and(|node| node.resolved_package_id == Arc::from(current_pkg_id));
+                .is_some_and(|node| &*node.resolved_package_id == current_pkg_id);
             if same_pkg {
                 for (alias, child_node_id) in self.realize_children(parent_node_id).0.iter() {
                     children.entry(alias.clone()).or_insert_with(|| child_node_id.clone());
@@ -565,7 +565,7 @@ impl Walker<'_> {
             .peer_provider_children_by_pkg_id
             .get(&*pkg_id)
             .map_or(&[][..], |providers| providers.relevant_edge_indices.as_slice());
-        let full_chain = parent_ids.pushed(std::sync::Arc::<str>::clone(&pkg_id).to_string());
+        let full_chain = parent_ids.pushed(pkg_id.to_string());
         let mut providers = BTreeMap::new();
         let mut newly_inserted = Vec::new();
         for &edge_index in provider_edge_indices {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/cache.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/cache.rs
@@ -209,7 +209,7 @@ impl Walker<'_> {
             }
             if !(peer_deps_not_shadowed
                 || current_info.depth == max_depth
-                || self.pure_pkgs.contains_key(cached_pkg_id))
+                || self.pure_pkgs.contains_key(&**cached_pkg_id))
             {
                 return false;
             }
@@ -240,7 +240,7 @@ impl Walker<'_> {
         if parent_pkg_id != &cached_tree_node.resolved_package_id {
             return false;
         }
-        self.pure_pkgs.contains_key(parent_pkg_id)
+        self.pure_pkgs.contains_key(&**parent_pkg_id)
             || self.parent_packages_match(cached_node_id, current_node_id)
     }
 
@@ -292,7 +292,7 @@ impl Walker<'_> {
                     else {
                         return FastCacheMatch::NoMatch;
                     };
-                    if cached_tree_node.resolved_package_id != child_pkg_id {
+                    if cached_tree_node.resolved_package_id != Arc::from(child_pkg_id) {
                         return FastCacheMatch::NoMatch;
                     }
                     let child_is_stable = self.pure_pkgs.contains_key(child_pkg_id)
@@ -347,7 +347,7 @@ impl Walker<'_> {
             if child_pkg_id.is_some() {
                 return FastProvider::Ambiguous;
             }
-            child_pkg_id = Some(edge.pkg_id.as_str());
+            child_pkg_id = Some(&*edge.pkg_id);
         }
 
         match (inherited, child_pkg_id) {
@@ -374,8 +374,10 @@ impl Walker<'_> {
         self.undo_realize(node_id, preview_undo, None);
 
         if !output.missing_peers.is_empty() {
-            let pkg_id = self.tree.dependencies_tree[node_id].resolved_package_id.clone();
-            let chain_with_self = parent_pkg_ids_chain.pushed(pkg_id);
+            let pkg_id = std::sync::Arc::<str>::clone(
+                &self.tree.dependencies_tree[node_id].resolved_package_id,
+            );
+            let chain_with_self = parent_pkg_ids_chain.pushed(pkg_id.to_string());
             for (peer_name, info) in output.missing_peers.iter() {
                 if self.missing_issue_suppressed(&chain_with_self, peer_name) {
                     continue;
@@ -458,7 +460,7 @@ impl Walker<'_> {
                 self.tree.dependencies_tree.insert(
                     node_id.clone(),
                     DependenciesTreeNode::new(
-                        pkg_id,
+                        Arc::from(pkg_id),
                         TreeChildren::Lazy { parent_ids: parent_ids.clone() },
                         depth,
                         true,
@@ -503,7 +505,7 @@ impl Walker<'_> {
                 .tree
                 .dependencies_tree
                 .get(parent_node_id)
-                .is_some_and(|node| node.resolved_package_id == current_pkg_id);
+                .is_some_and(|node| node.resolved_package_id == Arc::from(current_pkg_id));
             if same_pkg {
                 for (alias, child_node_id) in self.realize_children(parent_node_id).0.iter() {
                     children.entry(alias.clone()).or_insert_with(|| child_node_id.clone());
@@ -551,17 +553,19 @@ impl Walker<'_> {
                         .collect();
                     return (providers, None);
                 }
-                TreeChildren::Lazy { parent_ids } => {
-                    (parent_ids.clone(), node.resolved_package_id.clone(), node.depth)
-                }
+                TreeChildren::Lazy { parent_ids } => (
+                    parent_ids.clone(),
+                    std::sync::Arc::<str>::clone(&node.resolved_package_id),
+                    node.depth,
+                ),
             }
         };
         let children = self.tree.children_by_id.get(&pkg_id).cloned().unwrap_or_default();
         let provider_edge_indices = self
             .peer_provider_children_by_pkg_id
-            .get(&pkg_id)
+            .get(&*pkg_id)
             .map_or(&[][..], |providers| providers.relevant_edge_indices.as_slice());
-        let full_chain = parent_ids.pushed(pkg_id.clone());
+        let full_chain = parent_ids.pushed(std::sync::Arc::<str>::clone(&pkg_id).to_string());
         let mut providers = BTreeMap::new();
         let mut newly_inserted = Vec::new();
         for &edge_index in provider_edge_indices {
@@ -576,7 +580,7 @@ impl Walker<'_> {
                 self.tree.dependencies_tree.insert(
                     child_node_id.clone(),
                     DependenciesTreeNode::new(
-                        edge.pkg_id.clone(),
+                        std::sync::Arc::<str>::clone(&edge.pkg_id),
                         TreeChildren::Lazy { parent_ids: full_chain.clone() },
                         depth + 1,
                         true,
@@ -625,9 +629,11 @@ impl Walker<'_> {
             match &node.children {
                 // Cheap: the realized map is shared, not copied per revisit.
                 TreeChildren::Realized(map) => return (Arc::clone(map), None),
-                TreeChildren::Lazy { parent_ids } => {
-                    (parent_ids.clone(), node.resolved_package_id.clone(), node.depth)
-                }
+                TreeChildren::Lazy { parent_ids } => (
+                    parent_ids.clone(),
+                    std::sync::Arc::<str>::clone(&node.resolved_package_id),
+                    node.depth,
+                ),
             }
         };
         let children_spec = match self.tree.children_by_id.get(&pkg_id) {
@@ -639,7 +645,7 @@ impl Walker<'_> {
         let child_depth = depth + 1;
         let mut realized: BTreeMap<String, NodeId> = BTreeMap::new();
         let mut newly_inserted: Vec<NodeId> = Vec::new();
-        let full_chain = parent_ids.pushed(pkg_id.clone());
+        let full_chain = parent_ids.pushed(pkg_id.to_string());
         for edge in children_spec.iter() {
             // Same cycle gate as the eager walk: keep the first
             // re-entry, drop a direct self-edge or a second lap.
@@ -668,7 +674,7 @@ impl Walker<'_> {
                 self.tree.dependencies_tree.insert(
                     child_node_id.clone(),
                     DependenciesTreeNode::new(
-                        edge.pkg_id.clone(),
+                        std::sync::Arc::<str>::clone(&edge.pkg_id),
                         TreeChildren::Lazy { parent_ids: child_parent_ids },
                         child_depth,
                         true,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/cache/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/cache/tests.rs
@@ -21,7 +21,7 @@ fn materialized_nodes_referenced_by_peer_outputs_are_retained() {
     let output = NodeOutput {
         dep_path: DepPath::from("consumer@1.0.0"),
         external_resolved_peers: Arc::new(HashMap::from_iter([(
-            "peer".to_string(),
+            "peer".into(),
             referenced.clone(),
         )])),
         auto_install_resolved_peers: HashMap::default(),
@@ -52,10 +52,7 @@ fn previously_resolved_children_prefers_closest_same_package_ancestor() {
 
     let mut tree = ResolvedTree {
         direct: Vec::new(),
-        packages: HashMap::from_iter([(
-            "loop@1.0.0".to_string(),
-            package("loop", "1.0.0", &[], false),
-        )]),
+        packages: HashMap::from_iter([("loop@1.0.0".into(), package("loop", "1.0.0", &[], false))]),
         dependencies_tree: HashMap::from_iter([
             (far_parent.clone(), tree_node("loop@1.0.0", far_children, 0)),
             (close_parent.clone(), tree_node("loop@1.0.0", close_children, 2)),

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/context.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/context.rs
@@ -54,7 +54,7 @@ pub(super) type ParentRefs = HashMap<String, ParentRef>;
 /// fall back to a pure `version` comparison.
 #[derive(Debug, Clone)]
 pub(super) struct ParentPkgInfo {
-    pub(super) pkg_id: Option<String>,
+    pub(super) pkg_id: Option<Arc<str>>,
     pub(super) version: Option<String>,
     pub(super) depth: i32,
     pub(super) occurrence: u32,
@@ -86,8 +86,14 @@ impl<Element> SharedChain<Element> {
 }
 
 impl<Element: PartialEq> SharedChain<Element> {
-    pub(super) fn contains(&self, value: &Element) -> bool {
-        self.iter().any(|item| item == value)
+    /// Takes `&str` rather than `&Element` so a caller holding a
+    /// shared package id can test membership without allocating a
+    /// `String` to compare against.
+    pub(super) fn contains_str(&self, value: &str) -> bool
+    where
+        Element: AsRef<str>,
+    {
+        self.iter().any(|item| item.as_ref() == value)
     }
 }
 
@@ -199,7 +205,7 @@ impl Walker<'_> {
                 .node_id
                 .as_ref()
                 .and_then(|nid| self.tree.dependencies_tree.get(nid))
-                .map(|tn| tn.resolved_package_id.clone());
+                .map(|tn| std::sync::Arc::<str>::clone(&tn.resolved_package_id));
             let version = pkg_id.is_none().then(|| parent_ref.version.clone());
             out.insert(
                 name.clone(),
@@ -285,7 +291,7 @@ impl Walker<'_> {
             TreeChildren::Realized(children) => children
                 .values()
                 .filter_map(|child_node_id| self.tree.dependencies_tree.get(child_node_id))
-                .map(|child| child.resolved_package_id.as_str())
+                .map(|child| &*child.resolved_package_id)
                 .collect(),
             TreeChildren::Lazy { .. } => self
                 .tree
@@ -293,7 +299,7 @@ impl Walker<'_> {
                 .get(&node.resolved_package_id)
                 .into_iter()
                 .flat_map(|children| children.iter())
-                .map(|child| child.pkg_id.as_str())
+                .map(|child| &*child.pkg_id)
                 .collect(),
         };
         for child_pkg_id in child_pkg_ids {
@@ -321,7 +327,7 @@ impl Walker<'_> {
                 .tree
                 .dependencies_tree
                 .get(current_node_id)
-                .is_none_or(|node| node.resolved_package_id != *inherited_pkg_id);
+                .is_none_or(|node| *node.resolved_package_id != **inherited_pkg_id);
         }
         inherited_peer.version.as_ref() != Some(&current_peer.version)
     }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/discovery/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/discovery/tests.rs
@@ -13,6 +13,7 @@ use crate::{
 use pacquet_deps_path::DepPath;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 /// See [`PeersCacheItem`] for why a cache hit reports no providers.
 #[test]
@@ -40,13 +41,13 @@ fn cached_subtree_reuse_reports_no_peer_providers() {
             },
         ],
         packages: HashMap::from_iter([
-            ("peerx@1.0.0".to_string(), package("peerx", "1.0.0", &[], true)),
-            ("peerpkg@2.0.0".to_string(), package("peerpkg", "2.0.0", &[], true)),
+            ("peerx@1.0.0".into(), package("peerx", "1.0.0", &[], true)),
+            ("peerpkg@2.0.0".into(), package("peerpkg", "2.0.0", &[], true)),
             (
-                "consumer@1.0.0".to_string(),
+                Arc::from("consumer@1.0.0".to_string()),
                 package("consumer", "1.0.0", &[("peerpkg", "*"), ("peerx", "*")], false),
             ),
-            ("mid@1.0.0".to_string(), package("mid", "1.0.0", &[], false)),
+            ("mid@1.0.0".into(), package("mid", "1.0.0", &[], false)),
         ]),
         dependencies_tree: HashMap::from_iter([
             (peerx, tree_node("peerx@1.0.0", BTreeMap::new(), 0)),

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/discovery/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/discovery/tests.rs
@@ -12,8 +12,7 @@ use crate::{
 };
 use pacquet_deps_path::DepPath;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
-use std::collections::BTreeMap;
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 
 /// See [`PeersCacheItem`] for why a cache hit reports no providers.
 #[test]

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/finalize.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/finalize.rs
@@ -196,7 +196,7 @@ impl Walker<'_> {
             })
             .or_insert(DependenciesGraphNode {
                 dep_path: dep_path.clone(),
-                resolved_package_id: pkg.id.clone(),
+                resolved_package_id: std::sync::Arc::<str>::clone(&pkg.id).to_string(),
                 resolve_result: Arc::clone(&pkg.result),
                 children: graph_children,
                 optional_children: optional_child_aliases,
@@ -396,7 +396,7 @@ impl Walker<'_> {
             if peers.is_empty() {
                 continue;
             }
-            let pkg_id = self.tree.dependencies_tree[node_id].resolved_package_id.as_str();
+            let pkg_id = &*self.tree.dependencies_tree[node_id].resolved_package_id;
             let edges = edges_of_pkg.entry(pkg_id).or_default();
             for peer_alias in peers.keys() {
                 edges.insert(peer_alias.as_str());
@@ -628,7 +628,9 @@ impl Walker<'_> {
         for (node_id, record) in &self.node_records {
             let dep_path = record_dep_paths[node_id].clone();
             let depth = min_depth.get(&dep_path).copied().unwrap_or(record.depth);
-            let pkg_id = self.tree.dependencies_tree[node_id].resolved_package_id.clone();
+            let pkg_id = std::sync::Arc::<str>::clone(
+                &self.tree.dependencies_tree[node_id].resolved_package_id,
+            );
             let pkg = &self.tree.packages[&pkg_id];
             let mut children: BTreeMap<String, DepPath> = BTreeMap::new();
             for (alias, edge_node_id) in &record.edges {
@@ -642,7 +644,7 @@ impl Walker<'_> {
                 .unwrap_or_default();
             let mut candidate = DependenciesGraphNode {
                 dep_path: dep_path.clone(),
-                resolved_package_id: pkg_id.clone(),
+                resolved_package_id: std::sync::Arc::<str>::clone(&pkg_id).to_string(),
                 resolve_result: Arc::clone(&pkg.result),
                 children,
                 optional_children: record.optional_child_aliases.clone(),

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/finalize/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/finalize/tests.rs
@@ -26,9 +26,9 @@ fn final_graph_keeps_first_equal_depth_payload_and_unions_transitive_peers() {
     let mut tree = ResolvedTree {
         direct: Vec::new(),
         packages: HashMap::from_iter([
-            ("same@1.0.0".to_string(), package("same", "1.0.0", &[("peer", "*")], false)),
-            ("child-a@1.0.0".to_string(), package("child-a", "1.0.0", &[], true)),
-            ("child-b@1.0.0".to_string(), package("child-b", "1.0.0", &[], true)),
+            ("same@1.0.0".into(), package("same", "1.0.0", &[("peer", "*")], false)),
+            ("child-a@1.0.0".into(), package("child-a", "1.0.0", &[], true)),
+            ("child-b@1.0.0".into(), package("child-b", "1.0.0", &[], true)),
         ]),
         dependencies_tree: HashMap::from_iter([
             (first.clone(), tree_node("same@1.0.0", BTreeMap::new(), 1)),
@@ -98,7 +98,7 @@ fn final_graph_duplicate_parent_prefers_child_variant_matching_parent_peers() {
     let mut tree = ResolvedTree {
         direct: Vec::new(),
         packages: HashMap::from_iter([(
-            "consumer@1.0.0".to_string(),
+            "consumer@1.0.0".into(),
             package("consumer", "1.0.0", &[], false),
         )]),
         dependencies_tree: HashMap::from_iter([
@@ -171,7 +171,7 @@ fn final_graph_peer_edge_keeps_the_providers_own_peer_suffix() {
         direct: Vec::new(),
         packages: HashMap::from_iter([
             (
-                "webpack-cli@6.0.1".to_string(),
+                "webpack-cli@6.0.1".into(),
                 package(
                     "webpack-cli",
                     "6.0.1",
@@ -184,7 +184,7 @@ fn final_graph_peer_edge_keeps_the_providers_own_peer_suffix() {
                 ),
             ),
             (
-                "@webpack-cli/serve@3.0.1".to_string(),
+                "@webpack-cli/serve@3.0.1".into(),
                 package(
                     "@webpack-cli/serve",
                     "3.0.1",
@@ -200,10 +200,10 @@ fn final_graph_peer_edge_keeps_the_providers_own_peer_suffix() {
             (consumer_revisit.clone(), tree_node("@webpack-cli/serve@3.0.1", BTreeMap::new(), 0)),
         ]),
         all_peer_dep_names: HashSet::from_iter([
-            "webpack".to_string(),
-            "webpack-cli".to_string(),
-            "webpack-dev-server".to_string(),
-            "webpack-bundle-analyzer".to_string(),
+            "webpack".into(),
+            "webpack-cli".into(),
+            "webpack-dev-server".into(),
+            "webpack-bundle-analyzer".into(),
         ]),
         policy_violations: Vec::new(),
         applied_patches: HashSet::default(),
@@ -312,7 +312,7 @@ fn final_graph_peer_edge_keeps_provider_transitive_peer_suffixes() {
         direct: Vec::new(),
         packages: HashMap::from_iter([
             (
-                "webpack-dev-server@5.2.2".to_string(),
+                "webpack-dev-server@5.2.2".into(),
                 package(
                     "webpack-dev-server",
                     "5.2.2",
@@ -321,7 +321,7 @@ fn final_graph_peer_edge_keeps_provider_transitive_peer_suffixes() {
                 ),
             ),
             (
-                "webpack-cli@6.0.1".to_string(),
+                "webpack-cli@6.0.1".into(),
                 package(
                     "webpack-cli",
                     "6.0.1",
@@ -340,13 +340,13 @@ fn final_graph_peer_edge_keeps_provider_transitive_peer_suffixes() {
             (consumer.clone(), tree_node("webpack-cli@6.0.1", BTreeMap::new(), 0)),
         ]),
         all_peer_dep_names: HashSet::from_iter([
-            "bufferutil".to_string(),
-            "tslib".to_string(),
-            "utf-8-validate".to_string(),
-            "webpack".to_string(),
-            "webpack-cli".to_string(),
-            "webpack-dev-server".to_string(),
-            "webpack-bundle-analyzer".to_string(),
+            "bufferutil".into(),
+            "tslib".into(),
+            "utf-8-validate".into(),
+            "webpack".into(),
+            "webpack-cli".into(),
+            "webpack-dev-server".into(),
+            "webpack-bundle-analyzer".into(),
         ]),
         policy_violations: Vec::new(),
         applied_patches: HashSet::default(),
@@ -362,9 +362,9 @@ fn final_graph_peer_edge_keeps_provider_transitive_peer_suffixes() {
             edges: BTreeMap::new(),
             optional_child_aliases: HashSet::default(),
             transitive_peer_dependencies: HashSet::from_iter([
-                "bufferutil".to_string(),
-                "tslib".to_string(),
-                "utf-8-validate".to_string(),
+                "bufferutil".into(),
+                "tslib".into(),
+                "utf-8-validate".into(),
             ]),
             depth: 1,
             installable: true,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/test_support.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/test_support.rs
@@ -18,7 +18,7 @@ pub(super) fn tree_node(
     depth: i32,
 ) -> DependenciesTreeNode {
     DependenciesTreeNode::new(
-        pkg_id.to_string(),
+        Arc::from(pkg_id.to_string()),
         TreeChildren::Realized(Arc::new(children)),
         depth,
         true,
@@ -60,7 +60,7 @@ pub(super) fn package_with_peer_dependencies(
         })
         .collect();
     ResolvedPackage {
-        id: format!("{name}@{version}"),
+        id: format!("{name}@{version}").into(),
         result: Arc::new(resolve_result(name, version)),
         peer_dependencies,
         optional: false,
@@ -70,7 +70,7 @@ pub(super) fn package_with_peer_dependencies(
 
 pub(super) fn linked_package(name: &str, id: &str, directory: &str) -> ResolvedPackage {
     ResolvedPackage {
-        id: id.to_string(),
+        id: Arc::from(id.to_string()),
         result: Arc::new(ResolveResult {
             id: PkgResolutionId::from(id.to_string()),
             name_ver: None,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -14,7 +14,7 @@ use crate::{
 use pacquet_deps_path::{DepPath, PeerId};
 use pacquet_resolving_resolver_base::PkgResolutionId;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, sync::Arc};
 
 #[test]
 fn same_package_child_does_not_shadow_inherited_parent_and_bubbles_by_name() {
@@ -45,11 +45,11 @@ fn same_package_child_does_not_shadow_inherited_parent_and_bubbles_by_name() {
             },
         ],
         packages: HashMap::from_iter([
-            ("x@1.0.0".to_string(), package("x", "1.0.0", &[], true)),
-            ("x@2.0.0".to_string(), package("x", "2.0.0", &[], true)),
-            ("p@1.0.0".to_string(), package("p", "1.0.0", &[("x", "*")], false)),
-            ("plugin@1.0.0".to_string(), package("plugin", "1.0.0", &[("p", "*")], false)),
-            ("mid@1.0.0".to_string(), package("mid", "1.0.0", &[], false)),
+            ("x@1.0.0".into(), package("x", "1.0.0", &[], true)),
+            ("x@2.0.0".into(), package("x", "2.0.0", &[], true)),
+            ("p@1.0.0".into(), package("p", "1.0.0", &[("x", "*")], false)),
+            ("plugin@1.0.0".into(), package("plugin", "1.0.0", &[("p", "*")], false)),
+            ("mid@1.0.0".into(), package("mid", "1.0.0", &[], false)),
         ]),
         dependencies_tree: HashMap::from_iter([
             (x1, tree_node("x@1.0.0", BTreeMap::new(), 0)),
@@ -95,9 +95,9 @@ fn own_peer_is_resolved_from_peer_relevant_child() {
             id: "consumer@1.0.0".to_string(),
         }],
         packages: HashMap::from_iter([
-            ("types@1.0.0".to_string(), package("types", "1.0.0", &[], true)),
+            ("types@1.0.0".into(), package("types", "1.0.0", &[], true)),
             (
-                "consumer@1.0.0".to_string(),
+                Arc::from("consumer@1.0.0".to_string()),
                 package_with_peer_dependencies("consumer", "1.0.0", &[("types", "*", true)], false),
             ),
         ]),
@@ -156,9 +156,9 @@ fn reports_a_conflict_for_an_optional_peer_with_an_incompatible_provider() {
             },
         ],
         packages: HashMap::from_iter([
-            ("peer@2.0.0".to_string(), package("peer", "2.0.0", &[], true)),
+            ("peer@2.0.0".into(), package("peer", "2.0.0", &[], true)),
             (
-                "consumer@1.0.0".to_string(),
+                Arc::from("consumer@1.0.0".to_string()),
                 package_with_peer_dependencies(
                     "consumer",
                     "1.0.0",
@@ -199,9 +199,9 @@ fn named_registry_peer_tree(peer_spec: &str) -> (ResolvedTree, DepPath) {
             id: "consumer@1.0.0".to_string(),
         }],
         packages: HashMap::from_iter([
-            ("types@1.0.0".to_string(), package("types", "1.0.0", &[], true)),
+            ("types@1.0.0".into(), package("types", "1.0.0", &[], true)),
             (
-                "consumer@1.0.0".to_string(),
+                Arc::from("consumer@1.0.0".to_string()),
                 package_with_peer_dependencies(
                     "consumer",
                     "1.0.0",
@@ -240,9 +240,9 @@ fn alias_child_resolves_peer_by_real_package_name() {
             id: "consumer@1.0.0".to_string(),
         }],
         packages: HashMap::from_iter([
-            ("consumer@1.0.0".to_string(), package("consumer", "1.0.0", &[], false)),
-            ("peer@1.0.0".to_string(), package("peer", "1.0.0", &[], true)),
-            ("plugin@1.0.0".to_string(), package("plugin", "1.0.0", &[("peer", "*")], false)),
+            ("consumer@1.0.0".into(), package("consumer", "1.0.0", &[], false)),
+            ("peer@1.0.0".into(), package("peer", "1.0.0", &[], true)),
+            ("plugin@1.0.0".into(), package("plugin", "1.0.0", &[("peer", "*")], false)),
         ]),
         dependencies_tree: HashMap::from_iter([
             (provider, tree_node("peer@1.0.0", BTreeMap::new(), 1)),
@@ -295,10 +295,10 @@ fn transitive_pending_peer_uses_provider_final_suffix() {
             },
         ],
         packages: HashMap::from_iter([
-            ("a@1.0.0".to_string(), package("a", "1.0.0", &[("c", "*")], false)),
-            ("b@1.0.0".to_string(), package("b", "1.0.0", &[("a", "*")], false)),
-            ("c@1.0.0".to_string(), package("c", "1.0.0", &[], true)),
-            ("x@1.0.0".to_string(), package("x", "1.0.0", &[("b", "*")], false)),
+            ("a@1.0.0".into(), package("a", "1.0.0", &[("c", "*")], false)),
+            ("b@1.0.0".into(), package("b", "1.0.0", &[("a", "*")], false)),
+            ("c@1.0.0".into(), package("c", "1.0.0", &[], true)),
+            ("x@1.0.0".into(), package("x", "1.0.0", &[("b", "*")], false)),
         ]),
         dependencies_tree: HashMap::from_iter([
             (a_node_id, tree_node("a@1.0.0", a_children, 0)),
@@ -355,10 +355,10 @@ fn resolved_peer_providers_from_direct_outputs_are_last_write_wins() {
             },
         ],
         packages: HashMap::from_iter([
-            ("peer@1.0.0".to_string(), package("peer", "1.0.0", &[], true)),
-            ("peer@2.0.0".to_string(), package("peer", "2.0.0", &[], true)),
-            ("first@1.0.0".to_string(), package("first", "1.0.0", &[("peer", "*")], false)),
-            ("second@1.0.0".to_string(), package("second", "1.0.0", &[("peer", "*")], false)),
+            ("peer@1.0.0".into(), package("peer", "1.0.0", &[], true)),
+            ("peer@2.0.0".into(), package("peer", "2.0.0", &[], true)),
+            ("first@1.0.0".into(), package("first", "1.0.0", &[("peer", "*")], false)),
+            ("second@1.0.0".into(), package("second", "1.0.0", &[("peer", "*")], false)),
         ]),
         dependencies_tree: HashMap::from_iter([
             (first_peer, tree_node("peer@1.0.0", BTreeMap::new(), 1)),
@@ -403,17 +403,14 @@ fn peer_name_cycle_collapses_provider_suffixes() {
         ],
         packages: HashMap::from_iter([
             (
-                "source-map-loader@1.0.0".to_string(),
+                "source-map-loader@1.0.0".into(),
                 package("source-map-loader", "1.0.0", &[("webpack", "*")], false),
             ),
             (
-                "webpack-cli@6.0.0".to_string(),
+                "webpack-cli@6.0.0".into(),
                 package("webpack-cli", "6.0.0", &[("webpack", "*")], false),
             ),
-            (
-                "webpack@5.0.0".to_string(),
-                package("webpack", "5.0.0", &[("webpack-cli", "*")], false),
-            ),
+            ("webpack@5.0.0".into(), package("webpack", "5.0.0", &[("webpack-cli", "*")], false)),
         ]),
         dependencies_tree: HashMap::from_iter([
             (loader, tree_node("source-map-loader@1.0.0", BTreeMap::new(), 0)),
@@ -458,7 +455,7 @@ fn missing_names_by_pkg_records_only_children_context_missing_peers() {
         }],
         packages: HashMap::from_iter([
             (
-                "parent@1.0.0".to_string(),
+                "parent@1.0.0".into(),
                 package_with_peer_dependencies(
                     "parent",
                     "1.0.0",
@@ -467,7 +464,7 @@ fn missing_names_by_pkg_records_only_children_context_missing_peers() {
                 ),
             ),
             (
-                "child@1.0.0".to_string(),
+                "child@1.0.0".into(),
                 package_with_peer_dependencies(
                     "child",
                     "1.0.0",
@@ -510,9 +507,9 @@ fn own_peer_is_resolved_from_aliased_sibling_real_name() {
             id: "parent@1.0.0".to_string(),
         }],
         packages: HashMap::from_iter([
-            ("peer-c@2.0.0".to_string(), package("peer-c", "2.0.0", &[], true)),
+            ("peer-c@2.0.0".into(), package("peer-c", "2.0.0", &[], true)),
             (
-                "consumer@1.0.0".to_string(),
+                Arc::from("consumer@1.0.0".to_string()),
                 package_with_peer_dependencies(
                     "consumer",
                     "1.0.0",
@@ -520,7 +517,7 @@ fn own_peer_is_resolved_from_aliased_sibling_real_name() {
                     false,
                 ),
             ),
-            ("parent@1.0.0".to_string(), package("parent", "1.0.0", &[], false)),
+            ("parent@1.0.0".into(), package("parent", "1.0.0", &[], false)),
         ]),
         dependencies_tree: HashMap::from_iter([
             (peer_c, tree_node("peer-c@2.0.0", BTreeMap::new(), 1)),
@@ -573,9 +570,9 @@ fn importer_parent_refs_skip_direct_deps_irrelevant_by_alias_and_real_name() {
             },
         ],
         packages: HashMap::from_iter([
-            ("alias-real@1.0.0".to_string(), package("alias-real", "1.0.0", &[], true)),
-            ("peer-c@2.0.0".to_string(), package("peer-c", "2.0.0", &[], true)),
-            ("unused@1.0.0".to_string(), package("unused", "1.0.0", &[], true)),
+            ("alias-real@1.0.0".into(), package("alias-real", "1.0.0", &[], true)),
+            ("peer-c@2.0.0".into(), package("peer-c", "2.0.0", &[], true)),
+            ("unused@1.0.0".into(), package("unused", "1.0.0", &[], true)),
         ]),
         dependencies_tree: HashMap::from_iter([
             (alias_relevant, tree_node("alias-real@1.0.0", BTreeMap::new(), 0)),
@@ -626,13 +623,13 @@ fn cached_optional_peer_resolution_does_not_match_later_parent_without_provider(
             },
         ],
         packages: HashMap::from_iter([
-            ("types@1.0.0".to_string(), package("types", "1.0.0", &[], true)),
+            ("types@1.0.0".into(), package("types", "1.0.0", &[], true)),
             (
-                "config@1.0.0".to_string(),
+                Arc::from("config@1.0.0".to_string()),
                 package_with_peer_dependencies("config", "1.0.0", &[("types", "*", true)], false),
             ),
-            ("core@1.0.0".to_string(), package("core", "1.0.0", &[], false)),
-            ("cli@1.0.0".to_string(), package("cli", "1.0.0", &[], false)),
+            ("core@1.0.0".into(), package("core", "1.0.0", &[], false)),
+            ("cli@1.0.0".into(), package("cli", "1.0.0", &[], false)),
         ]),
         dependencies_tree: HashMap::from_iter([
             (types, tree_node("types@1.0.0", BTreeMap::new(), 1)),
@@ -676,8 +673,8 @@ fn same_leaf_node_under_multiple_aliases_preserves_every_edge() {
             id: "parent@1.0.0".to_string(),
         }],
         packages: HashMap::from_iter([
-            ("shared@1.0.0".to_string(), package("shared", "1.0.0", &[], true)),
-            ("parent@1.0.0".to_string(), package("parent", "1.0.0", &[], false)),
+            ("shared@1.0.0".into(), package("shared", "1.0.0", &[], true)),
+            ("parent@1.0.0".into(), package("parent", "1.0.0", &[], false)),
         ]),
         dependencies_tree: HashMap::from_iter([
             (shared, tree_node("shared@1.0.0", BTreeMap::new(), 1)),
@@ -727,14 +724,14 @@ fn same_package_child_replaces_inherited_parent_when_peer_diamond_conflicts() {
             },
         ],
         packages: HashMap::from_iter([
-            ("ts@1.0.0".to_string(), package("ts", "1.0.0", &[], true)),
-            ("ts@2.0.0".to_string(), package("ts", "2.0.0", &[], true)),
-            ("parser@1.0.0".to_string(), package("parser", "1.0.0", &[("ts", "*")], false)),
+            ("ts@1.0.0".into(), package("ts", "1.0.0", &[], true)),
+            ("ts@2.0.0".into(), package("ts", "2.0.0", &[], true)),
+            ("parser@1.0.0".into(), package("parser", "1.0.0", &[("ts", "*")], false)),
             (
-                "plugin@1.0.0".to_string(),
+                Arc::from("plugin@1.0.0".to_string()),
                 package("plugin", "1.0.0", &[("parser", "*"), ("ts", "*")], false),
             ),
-            ("bundle@1.0.0".to_string(), package("bundle", "1.0.0", &[], false)),
+            ("bundle@1.0.0".into(), package("bundle", "1.0.0", &[], false)),
         ]),
         dependencies_tree: HashMap::from_iter([
             (ts1, tree_node("ts@1.0.0", BTreeMap::new(), 1)),
@@ -806,9 +803,9 @@ fn shared_package_optional_transitive_peer_resolves_deterministically() {
                 },
             ],
             packages: HashMap::from_iter([
-                ("@babel/core@7.0.0".to_string(), package("@babel/core", "7.0.0", &[], true)),
+                ("@babel/core@7.0.0".into(), package("@babel/core", "7.0.0", &[], true)),
                 (
-                    "styled-jsx@1.0.0".to_string(),
+                    Arc::from("styled-jsx@1.0.0".to_string()),
                     package_with_peer_dependencies(
                         "styled-jsx",
                         "1.0.0",
@@ -816,8 +813,8 @@ fn shared_package_optional_transitive_peer_resolves_deterministically() {
                         false,
                     ),
                 ),
-                ("app@1.0.0".to_string(), package("app", "1.0.0", &[], false)),
-                ("mid@1.0.0".to_string(), package("mid", "1.0.0", &[], false)),
+                ("app@1.0.0".into(), package("app", "1.0.0", &[], false)),
+                ("mid@1.0.0".into(), package("mid", "1.0.0", &[], false)),
             ]),
             dependencies_tree: HashMap::from_iter([
                 (babel, tree_node("@babel/core@7.0.0", BTreeMap::new(), 1)),
@@ -887,8 +884,8 @@ fn pruned_hoisted_provider_falls_back_to_root_resolution() {
             },
         ],
         packages: HashMap::from_iter([
-            ("prov@1.0.0".to_string(), package("prov", "1.0.0", &[], true)),
-            ("consumer@1.0.0".to_string(), package("consumer", "1.0.0", &[("prov", "*")], false)),
+            ("prov@1.0.0".into(), package("prov", "1.0.0", &[], true)),
+            ("consumer@1.0.0".into(), package("consumer", "1.0.0", &[("prov", "*")], false)),
         ]),
         dependencies_tree: HashMap::from_iter([
             (prov.clone(), tree_node("prov@1.0.0", BTreeMap::new(), 1)),
@@ -948,8 +945,8 @@ fn pruned_hoisted_provider_falls_back_in_workspace_pass() {
     let mut tree = ResolvedTree {
         direct: Vec::new(),
         packages: HashMap::from_iter([
-            ("prov@1.0.0".to_string(), package("prov", "1.0.0", &[], true)),
-            ("consumer@1.0.0".to_string(), package("consumer", "1.0.0", &[("prov", "*")], false)),
+            ("prov@1.0.0".into(), package("prov", "1.0.0", &[], true)),
+            ("consumer@1.0.0".into(), package("consumer", "1.0.0", &[("prov", "*")], false)),
         ]),
         dependencies_tree: HashMap::from_iter([
             (prov.clone(), tree_node("prov@1.0.0", BTreeMap::new(), 1)),
@@ -1033,9 +1030,9 @@ fn workspace_importers_get_distinct_instances_for_different_peer_versions() {
     let mut tree = ResolvedTree {
         direct: Vec::new(),
         packages: HashMap::from_iter([
-            ("peer@1.0.0".to_string(), package("peer", "1.0.0", &[], true)),
-            ("peer@2.0.0".to_string(), package("peer", "2.0.0", &[], true)),
-            ("consumer@1.0.0".to_string(), package("consumer", "1.0.0", &[("peer", "*")], false)),
+            ("peer@1.0.0".into(), package("peer", "1.0.0", &[], true)),
+            ("peer@2.0.0".into(), package("peer", "2.0.0", &[], true)),
+            ("consumer@1.0.0".into(), package("consumer", "1.0.0", &[("peer", "*")], false)),
         ]),
         dependencies_tree: HashMap::from_iter([
             (peer_v1, tree_node("peer@1.0.0", BTreeMap::new(), 0)),
@@ -1126,14 +1123,14 @@ fn a_shared_consumer_keeps_the_first_importers_peer_provider_variant() {
     let mut tree = ResolvedTree {
         direct: Vec::new(),
         packages: HashMap::from_iter([
-            ("plugin@1.0.0".to_string(), package("plugin", "1.0.0", &[("parser", "*")], false)),
-            ("plugin@2.0.0".to_string(), package("plugin", "2.0.0", &[("parser", "*")], false)),
+            ("plugin@1.0.0".into(), package("plugin", "1.0.0", &[("parser", "*")], false)),
+            ("plugin@2.0.0".into(), package("plugin", "2.0.0", &[("parser", "*")], false)),
             (
-                "utils@1.0.0".to_string(),
+                Arc::from("utils@1.0.0".to_string()),
                 package("utils", "1.0.0", &[("resolver", "*"), ("parser", "*")], false),
             ),
-            ("resolver@1.0.0".to_string(), package("resolver", "1.0.0", &[("plugin", "*")], false)),
-            ("parser@1.0.0".to_string(), package("parser", "1.0.0", &[], true)),
+            ("resolver@1.0.0".into(), package("resolver", "1.0.0", &[("plugin", "*")], false)),
+            ("parser@1.0.0".into(), package("parser", "1.0.0", &[], true)),
         ]),
         dependencies_tree: HashMap::from_iter([
             (
@@ -1159,9 +1156,9 @@ fn a_shared_consumer_keeps_the_first_importers_peer_provider_variant() {
             (parser, tree_node("parser@1.0.0", BTreeMap::new(), 0)),
         ]),
         all_peer_dep_names: HashSet::from_iter([
-            "plugin".to_string(),
-            "resolver".to_string(),
-            "parser".to_string(),
+            "plugin".into(),
+            "resolver".into(),
+            "parser".into(),
         ]),
         policy_violations: Vec::new(),
         applied_patches: HashSet::default(),
@@ -1239,10 +1236,10 @@ fn linked_peer_provider_uses_root_relative_snapshot_ref_in_workspace_fallback() 
         direct: Vec::new(),
         packages: HashMap::from_iter([
             (
-                "link:packages/peer".to_string(),
+                "link:packages/peer".into(),
                 linked_package("peer", "link:packages/peer", "packages/peer"),
             ),
-            ("consumer@1.0.0".to_string(), package("consumer", "1.0.0", &[("peer", "*")], false)),
+            ("consumer@1.0.0".into(), package("consumer", "1.0.0", &[("peer", "*")], false)),
         ]),
         dependencies_tree: HashMap::from_iter([
             (peer.clone(), tree_node("link:packages/peer", BTreeMap::new(), -1)),
@@ -1310,10 +1307,10 @@ fn workspace_internal_link_peer_keeps_its_node_id_when_exclude_links_on() {
         direct: Vec::new(),
         packages: HashMap::from_iter([
             (
-                "link:packages/peer".to_string(),
+                "link:packages/peer".into(),
                 linked_package("peer", "link:packages/peer", "../../packages/peer"),
             ),
-            ("consumer@1.0.0".to_string(), package("consumer", "1.0.0", &[("peer", "*")], false)),
+            ("consumer@1.0.0".into(), package("consumer", "1.0.0", &[("peer", "*")], false)),
         ]),
         dependencies_tree: HashMap::from_iter([
             (peer, tree_node("link:packages/peer", BTreeMap::new(), -1)),
@@ -1357,7 +1354,7 @@ fn single_importer_link_is_rendered_relative_to_project_root() {
             id: "link:packages/shared".to_string(),
         }],
         packages: HashMap::from_iter([(
-            "link:packages/shared".to_string(),
+            "link:packages/shared".into(),
             linked_package("shared", "link:packages/shared", "packages/shared"),
         )]),
         dependencies_tree: HashMap::from_iter([(
@@ -1415,10 +1412,10 @@ fn pruned_hoisted_providers_with_mutual_peers_resolve() {
             },
         ],
         packages: HashMap::from_iter([
-            ("lib-a@1.0.0".to_string(), package("lib-a", "1.0.0", &[("lib-b", "^1.0.0")], true)),
-            ("lib-b@1.0.0".to_string(), package("lib-b", "1.0.0", &[("lib-a", "^1.0.0")], true)),
+            ("lib-a@1.0.0".into(), package("lib-a", "1.0.0", &[("lib-b", "^1.0.0")], true)),
+            ("lib-b@1.0.0".into(), package("lib-b", "1.0.0", &[("lib-a", "^1.0.0")], true)),
             (
-                "consumer@1.0.0".to_string(),
+                Arc::from("consumer@1.0.0".to_string()),
                 package("consumer", "1.0.0", &[("lib-a", "^1.0.0"), ("lib-b", "^1.0.0")], false),
             ),
         ]),
@@ -1485,8 +1482,8 @@ fn own_direct_dep_and_pruned_provider_with_mutual_peers_resolve() {
             },
         ],
         packages: HashMap::from_iter([
-            ("main@1.0.0".to_string(), package("main", "1.0.0", &[("plugin", "^1.0.0")], false)),
-            ("plugin@1.0.0".to_string(), package("plugin", "1.0.0", &[("main", "^1.0.0")], true)),
+            ("main@1.0.0".into(), package("main", "1.0.0", &[("plugin", "^1.0.0")], false)),
+            ("plugin@1.0.0".into(), package("plugin", "1.0.0", &[("main", "^1.0.0")], true)),
         ]),
         dependencies_tree: HashMap::from_iter([
             (main, tree_node("main@1.0.0", BTreeMap::new(), 0)),
@@ -1549,9 +1546,9 @@ fn peer_cycle_between_own_dep_and_provider_at_tree_position_resolves() {
             },
         ],
         packages: HashMap::from_iter([
-            ("host@1.0.0".to_string(), package("host", "1.0.0", &[], false)),
-            ("main@1.0.0".to_string(), package("main", "1.0.0", &[("plugin", "^1.0.0")], false)),
-            ("plugin@1.0.0".to_string(), package("plugin", "1.0.0", &[("main", "^1.0.0")], false)),
+            ("host@1.0.0".into(), package("host", "1.0.0", &[], false)),
+            ("main@1.0.0".into(), package("main", "1.0.0", &[("plugin", "^1.0.0")], false)),
+            ("plugin@1.0.0".into(), package("plugin", "1.0.0", &[("main", "^1.0.0")], false)),
         ]),
         dependencies_tree: HashMap::from_iter([
             (
@@ -1607,6 +1604,7 @@ mod locked_peer_provider_preferences {
     use crate::resolve_peers::test_support::{package, package_with_peer_dependencies, tree_node};
     use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
     use std::collections::BTreeMap;
+    use std::sync::Arc;
 
     struct LockedTreeIds {
         current_peer: NodeId,
@@ -1658,12 +1656,12 @@ mod locked_peer_provider_preferences {
                 },
             ],
             packages: HashMap::from_iter([
-                ("peer@1.0.0".to_string(), package("peer", "1.0.0", &[], true)),
-                ("peer@2.0.0".to_string(), package("peer", "2.0.0", &[], true)),
-                ("retainer@1.0.0".to_string(), package("retainer", "1.0.0", &[], false)),
-                ("wrapper@1.0.0".to_string(), package("wrapper", "1.0.0", &[], false)),
+                ("peer@1.0.0".into(), package("peer", "1.0.0", &[], true)),
+                ("peer@2.0.0".into(), package("peer", "2.0.0", &[], true)),
+                ("retainer@1.0.0".into(), package("retainer", "1.0.0", &[], false)),
+                ("wrapper@1.0.0".into(), package("wrapper", "1.0.0", &[], false)),
                 (
-                    "consumer@1.0.0".to_string(),
+                    Arc::from("consumer@1.0.0".to_string()),
                     package_with_peer_dependencies(
                         "consumer",
                         "1.0.0",
@@ -1830,7 +1828,7 @@ fn repeated_pending_peer_edges_are_buffered_once() {
         walker.add_graph_child_or_pending(
             &mut graph_children,
             &parent,
-            "child".to_string(),
+            "child".into(),
             first_child.clone(),
         );
     }
@@ -1842,7 +1840,7 @@ fn repeated_pending_peer_edges_are_buffered_once() {
     walker.add_graph_child_or_pending(
         &mut graph_children,
         &parent,
-        "child".to_string(),
+        "child".into(),
         second_child.clone(),
     );
     assert_eq!(walker.pending_peer_edges.len(), 2, "dedup is by triple, not by (parent, alias)");
@@ -1880,7 +1878,7 @@ fn the_first_resolvable_pending_edge_keeps_the_slot() {
         walker.add_graph_child_or_pending(
             &mut graph_children,
             &parent,
-            "child".to_string(),
+            "child".into(),
             child.clone(),
         );
     }
@@ -1910,12 +1908,7 @@ fn pending_peer_edges_replay_after_a_drain() {
     let child = NodeId::next();
     let mut graph_children = BTreeMap::new();
 
-    walker.add_graph_child_or_pending(
-        &mut graph_children,
-        &parent,
-        "child".to_string(),
-        child.clone(),
-    );
+    walker.add_graph_child_or_pending(&mut graph_children, &parent, "child".into(), child.clone());
     walker.patch_pending_peer_edges();
     assert!(walker.pending_peer_edges.is_empty(), "the drain empties the buffer");
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -1941,3 +1941,44 @@ fn realized_children_are_shared_across_visits() {
         "an already-realized node realizes nothing, so there is nothing to undo",
     );
 }
+
+/// The peer walk realizes one occurrence node per distinct
+/// root-to-package path — millions of them on a large graph — and each
+/// names its package. Realization must hand the child edge's `Arc` to
+/// the node rather than copy the id into it, so this asserts pointer
+/// equality through `realize_children_with`, the path that creates
+/// those millions, rather than through the constructor alone.
+#[test]
+fn realizing_children_shares_the_edge_package_id() {
+    let parent = NodeId::next();
+    let edge_id: Arc<str> = "child@1.0.0".into();
+
+    let mut tree = ResolvedTree::default();
+    tree.children_by_id.insert(
+        "parent@1.0.0".into(),
+        Arc::new(vec![crate::resolved_tree::ChildEdge {
+            alias: "child".to_string(),
+            pkg_id: Arc::<str>::clone(&edge_id),
+            optional: false,
+        }]),
+    );
+    tree.dependencies_tree.insert(
+        parent.clone(),
+        crate::resolved_tree::DependenciesTreeNode::new(
+            "parent@1.0.0".into(),
+            crate::resolved_tree::TreeChildren::Lazy { parent_ids: Arc::new(Vec::new()).into() },
+            0,
+            true,
+        ),
+    );
+
+    let mut walker = walker_for_tests(&mut tree);
+    let (children, _) = walker.realize_children_with(&parent, None);
+    let child_node_id = children.get("child").expect("the edge is realized into a child node");
+    let realized = &walker.tree.dependencies_tree[child_node_id];
+
+    assert!(
+        Arc::ptr_eq(&edge_id, &realized.resolved_package_id),
+        "the occurrence points at the edge's id instead of owning a copy of it",
+    );
+}

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -1603,8 +1603,7 @@ mod locked_peer_provider_preferences {
     use super::{DepPath, DirectDep, NodeId, ResolvePeersOptions, ResolvedTree, resolve_peers};
     use crate::resolve_peers::test_support::{package, package_with_peer_dependencies, tree_node};
     use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
-    use std::collections::BTreeMap;
-    use std::sync::Arc;
+    use std::{collections::BTreeMap, sync::Arc};
 
     struct LockedTreeIds {
         current_peer: NodeId,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
@@ -158,7 +158,7 @@ impl<'tree> Walker<'tree> {
             peer_provider_index_peer_names.clone_from(&tree.all_peer_dep_names);
         }
         for (pkg_id, children) in &tree.children_by_id {
-            if peer_provider_children_by_pkg_id.contains_key(pkg_id) {
+            if peer_provider_children_by_pkg_id.contains_key(&**pkg_id) {
                 continue;
             }
             let mut providers = PeerProviderChildren::default();
@@ -182,7 +182,8 @@ impl<'tree> Walker<'tree> {
                     providers.edge_indices_by_name.entry(real_name).or_default().push(edge_index);
                 }
             }
-            peer_provider_children_by_pkg_id.insert(pkg_id.clone(), providers);
+            peer_provider_children_by_pkg_id
+                .insert(std::sync::Arc::<str>::clone(pkg_id).to_string(), providers);
         }
         Walker {
             tree,
@@ -451,7 +452,7 @@ impl Walker<'_> {
         for (node_id, missing) in &self.node_missing_peers_of_children {
             let Some(tree_node) = self.tree.dependencies_tree.get(node_id) else { continue };
             missing_names_by_pkg
-                .entry(tree_node.resolved_package_id.clone())
+                .entry(std::sync::Arc::<str>::clone(&tree_node.resolved_package_id).to_string())
                 .or_default()
                 .extend(missing.keys().cloned());
         }
@@ -536,10 +537,10 @@ impl Walker<'_> {
                 if tree_node.depth == -1 {
                     return Some((
                         tree_node.depth,
-                        DepPath::from(tree_node.resolved_package_id.clone()),
+                        DepPath::from(std::sync::Arc::<str>::clone(&tree_node.resolved_package_id)),
                     ));
                 }
-                let dep_path = self.pure_pkgs.get(&tree_node.resolved_package_id)?;
+                let dep_path = self.pure_pkgs.get(&*tree_node.resolved_package_id)?;
                 if !self.tree.packages[&tree_node.resolved_package_id].peer_dependencies.is_empty()
                     || (!self.discovery
                         && self
@@ -578,7 +579,7 @@ impl Walker<'_> {
             let tree_node = &self.tree.dependencies_tree[node_id];
             let pkg = &self.tree.packages[&tree_node.resolved_package_id];
             return NodeOutput {
-                dep_path: DepPath::from(pkg.id.clone()),
+                dep_path: DepPath::from(std::sync::Arc::<str>::clone(&pkg.id)),
                 external_resolved_peers: Arc::clone(&self.empty_resolved_peers),
                 auto_install_resolved_peers: HashMap::default(),
                 missing_peers: Arc::clone(&self.empty_missing_peers),
@@ -613,7 +614,7 @@ impl Walker<'_> {
         let (pkg_id, tree_node_depth, tree_node_installable, locked_peer_names) = {
             let tree_node = &self.tree.dependencies_tree[node_id];
             (
-                tree_node.resolved_package_id.clone(),
+                std::sync::Arc::<str>::clone(&tree_node.resolved_package_id),
                 tree_node.depth,
                 tree_node.installable,
                 tree_node.locked_peer_names().cloned(),
@@ -678,8 +679,8 @@ impl Walker<'_> {
             let node = &self.tree.dependencies_tree[node_id];
             if let TreeChildren::Lazy { parent_ids } = &node.children {
                 Some((
-                    self.tree.children_by_id.get(&pkg.id).cloned().unwrap_or_default(),
-                    parent_ids.pushed(pkg.id.clone()),
+                    self.tree.children_by_id.get(&*pkg.id).cloned().unwrap_or_default(),
+                    parent_ids.pushed(std::sync::Arc::<str>::clone(&pkg.id).to_string()),
                 ))
             } else {
                 None
@@ -694,10 +695,10 @@ impl Walker<'_> {
         };
         let realize_undo = merge_realize_undo(preview_undo, realize_undo);
         let current_parent_node_ids = parent_node_ids.pushed(node_id.clone());
-        let child_parent_pkg_ids_chain = if parent_pkg_ids_chain.contains(&pkg.id) {
+        let child_parent_pkg_ids_chain = if parent_pkg_ids_chain.contains_str(&pkg.id) {
             parent_pkg_ids_chain.clone()
         } else {
-            parent_pkg_ids_chain.pushed(pkg.id.clone())
+            parent_pkg_ids_chain.pushed(std::sync::Arc::<str>::clone(&pkg.id).to_string())
         };
         let child_chain_names = parent_chain_names.pushed(pkg_name.clone());
 
@@ -800,7 +801,7 @@ impl Walker<'_> {
         self.remember_resolved_node(node_id, &dep_path);
 
         let own_missing = (!missing_from_children.is_empty())
-            .then(|| (pkg.id.clone(), missing_from_children.keys().cloned().collect()));
+            .then(|| (pkg.id.to_string(), missing_from_children.keys().cloned().collect()));
         let subtree_missing_by_pkg = match (own_missing, missing_summaries.len()) {
             (None, 0) => None,
             (None, 1) => missing_summaries.pop(),
@@ -833,22 +834,26 @@ impl Walker<'_> {
         // that can see the full subtree, dropping their
         // `transitivePeerDependencies` depending on traversal order and
         // churning the lockfile (https://github.com/pnpm/pnpm/issues/5108).
-        let resolved_through_cycle = parent_pkg_ids_chain.contains(&pkg.id);
+        let resolved_through_cycle = parent_pkg_ids_chain.contains_str(&pkg.id);
         if resolved_through_cycle {
             // Leave both caches untouched so later occurrences re-resolve (or
             // hit the authoritative entry of the same package) instead of
             // reusing this partial one.
         } else if is_pure {
-            self.pure_pkgs.insert(pkg.id.clone(), dep_path.clone());
+            self.pure_pkgs
+                .insert(std::sync::Arc::<str>::clone(&pkg.id).to_string(), dep_path.clone());
         } else {
             self.retained_peer_node_ids.extend(all_resolved_peers.values().cloned());
-            self.peers_cache.entry(pkg.id.clone()).or_default().push(PeersCacheItem {
-                dep_path: dep_path.clone(),
-                resolved_peers: Arc::clone(&all_resolved_peers),
-                missing_peers: Arc::clone(&all_missing_peers),
-                missing_peers_of_children: Arc::clone(&missing_from_children),
-                subtree_missing_by_pkg: subtree_missing_by_pkg.clone(),
-            });
+            self.peers_cache
+                .entry(std::sync::Arc::<str>::clone(&pkg.id).to_string())
+                .or_default()
+                .push(PeersCacheItem {
+                    dep_path: dep_path.clone(),
+                    resolved_peers: Arc::clone(&all_resolved_peers),
+                    missing_peers: Arc::clone(&all_missing_peers),
+                    missing_peers_of_children: Arc::clone(&missing_from_children),
+                    subtree_missing_by_pkg: subtree_missing_by_pkg.clone(),
+                });
         }
 
         if !self.discovery {
@@ -1023,7 +1028,7 @@ impl Walker<'_> {
         }
 
         let dep_path = if all_resolved.is_empty() {
-            DepPath::from(pkg.id.clone())
+            DepPath::from(std::sync::Arc::<str>::clone(&pkg.id))
         } else {
             let peer_ids: Vec<PeerId> = all_resolved
                 .iter()
@@ -1319,7 +1324,7 @@ impl Walker<'_> {
             return dep_path;
         }
         let pkg_id = &self.tree.dependencies_tree[node_id].resolved_package_id;
-        DepPath::from(self.tree.packages[pkg_id].id.clone())
+        DepPath::from(std::sync::Arc::<str>::clone(&self.tree.packages[pkg_id].id))
     }
 
     pub(super) fn remember_parent_context_if_peer_provider(

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -459,7 +459,7 @@ async fn importer_scoped_update_route_owns_shared_parent_children_in_either_orde
         let parent_children =
             result.merged_tree.children_by_id.get("parent@1.0.0").expect("parent children");
         assert_eq!(parent_children.len(), 1);
-        assert_eq!(parent_children[0].pkg_id, "pkg@100.1.0");
+        assert_eq!(&*parent_children[0].pkg_id, "pkg@100.1.0");
         // Recording the winner's children is not enough on its own: the
         // occurrence that ran first realized the ones it resolved, and
         // only the handover makes it re-read them.
@@ -635,7 +635,7 @@ async fn catalogs_work_in_injected_workspace_packages() {
         .expect("injected workspace package children");
     assert_eq!(children.len(), 1);
     assert_eq!(children[0].alias, "is-positive");
-    assert_eq!(children[0].pkg_id, "is-positive@1.0.0");
+    assert_eq!(&*children[0].pkg_id, "is-positive@1.0.0");
     assert!(!children[0].optional);
 }
 
@@ -3096,7 +3096,7 @@ async fn a_pinned_subtree_keeps_its_children_against_a_fresh_walk() {
             .get("shared@1.0.0")
             .expect("shared children")
             .iter()
-            .map(|edge| edge.pkg_id.as_str())
+            .map(|edge| &*edge.pkg_id)
             .collect();
         assert_eq!(recorded, ["pin@1.0.0"], "the pins stand, held back: {slow:?}");
         assert!(

--- a/pnpm/crates/resolving-deps-resolver/src/resolved_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolved_tree.rs
@@ -26,7 +26,7 @@ pub type DependenciesTree = HashMap<NodeId, DependenciesTreeNode>;
 #[derive(Debug, Default, Clone)]
 pub struct ResolvedTree {
     pub direct: Vec<DirectDep>,
-    pub packages: HashMap<String, ResolvedPackage>,
+    pub packages: HashMap<Arc<str>, ResolvedPackage>,
     pub dependencies_tree: DependenciesTree,
     pub all_peer_dep_names: HashSet<String>,
     pub policy_violations: Vec<ResolutionPolicyViolation>,
@@ -42,7 +42,7 @@ pub struct ResolvedTree {
     /// entry. The peer-resolver's `realize_children` walks this to
     /// allocate per-occurrence `NodeId`s for a
     /// [`TreeChildren::Lazy`] node.
-    pub children_by_id: HashMap<String, Arc<Vec<ChildEdge>>>,
+    pub children_by_id: HashMap<Arc<str>, Arc<Vec<ChildEdge>>>,
 }
 
 /// One entry on [`ResolvedTree::children_by_id`] — the resolved
@@ -52,8 +52,10 @@ pub struct ChildEdge {
     /// Install alias in `node_modules` (the manifest key under
     /// `dependencies` / `optionalDependencies`).
     pub alias: String,
-    /// Resolved `pkgIdWithPatchHash` the alias points at.
-    pub pkg_id: String,
+    /// Resolved `pkgIdWithPatchHash` the alias points at. Shared: the
+    /// peer walk copies this onto every occurrence node it realizes,
+    /// millions of them for a few thousand distinct ids.
+    pub pkg_id: Arc<str>,
     /// `true` when the edge came from `optionalDependencies`. Used
     /// to thread `current_is_optional` correctly through lazy
     /// realisation so the [`ResolvedPackage::optional`] AND-fold
@@ -144,7 +146,7 @@ pub struct DirectDep {
 /// [`ResolvedPackage`] is the dedup-shared *envelope*, not a tree node.
 #[derive(Debug, Clone)]
 pub struct ResolvedPackage {
-    pub id: String,
+    pub id: Arc<str>,
     /// Held as `Arc` so cloning a [`ResolvedPackage`] (which the
     /// per-occurrence tree walk does on every snapshot, and which
     /// the peer-resolution pass does when it carves
@@ -234,8 +236,9 @@ pub struct LockedResolution {
 /// One per-occurrence node in the dependencies tree.
 #[derive(Debug, Clone)]
 pub struct DependenciesTreeNode {
-    /// Key into [`ResolvedTree::packages`].
-    pub resolved_package_id: String,
+    /// Key into [`ResolvedTree::packages`]. Shared rather than owned —
+    /// see [`ChildEdge::pkg_id`], which is where most of these come from.
+    pub resolved_package_id: Arc<str>,
     /// `alias → child NodeId` edges, possibly deferred.
     pub children: TreeChildren,
     /// Distance from the root importer (root = 0). A `depth = -1` marks
@@ -257,7 +260,7 @@ impl DependenciesTreeNode {
     /// Node with no wanted-lockfile carry-over (a fresh resolution).
     #[must_use]
     pub fn new(
-        resolved_package_id: String,
+        resolved_package_id: Arc<str>,
         children: TreeChildren,
         depth: i32,
         installable: bool,

--- a/pnpm/crates/resolving-deps-resolver/src/resolved_tree/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolved_tree/tests.rs
@@ -63,23 +63,3 @@ fn locked_resolution_is_unallocated_until_written() {
     );
     assert!(node.has_no_locked_peers(), "a previous depPath is not a locked peer");
 }
-
-/// Every occurrence node names its package, but a workspace has a few
-/// thousand distinct package ids and the walk realizes millions of
-/// occurrences. The id is shared from [`super::ChildEdge::pkg_id`]
-/// rather than copied, so realizing a child costs a refcount bump.
-#[test]
-fn realizing_an_occurrence_shares_the_package_id() {
-    let edge_id: Arc<str> = "a@1.0.0".into();
-    let node = super::DependenciesTreeNode::new(
-        Arc::clone(&edge_id),
-        super::TreeChildren::Realized(Arc::new(std::collections::BTreeMap::new())),
-        0,
-        true,
-    );
-
-    assert!(
-        Arc::ptr_eq(&edge_id, &node.resolved_package_id),
-        "the node points at the edge's id instead of owning a copy of it",
-    );
-}

--- a/pnpm/crates/resolving-deps-resolver/src/resolved_tree/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolved_tree/tests.rs
@@ -27,12 +27,12 @@ fn detects_cycle_sequences_across_base_and_appended_ids() {
 /// hundred megabytes. Wanted-lockfile carry-over lives behind
 /// [`super::LockedResolution`] for that reason; keep it there.
 ///
-/// 56 bytes is the current layout on a 64-bit target, not a budget with
+/// 48 bytes is the current layout on a 64-bit target, not a budget with
 /// room in it: inlining one more `Option<String>` would cost 24.
 #[test]
 fn tree_node_keeps_its_per_occurrence_footprint_small() {
     assert!(
-        size_of::<super::DependenciesTreeNode>() <= 56,
+        size_of::<super::DependenciesTreeNode>() <= 48,
         "DependenciesTreeNode grew to {} bytes; box rarely-set state instead of inlining it",
         size_of::<super::DependenciesTreeNode>(),
     );
@@ -41,7 +41,7 @@ fn tree_node_keeps_its_per_occurrence_footprint_small() {
 #[test]
 fn locked_resolution_is_unallocated_until_written() {
     let mut node = super::DependenciesTreeNode::new(
-        "a@1.0.0".to_string(),
+        Arc::from("a@1.0.0".to_string()),
         super::TreeChildren::Realized(Arc::new(std::collections::BTreeMap::new())),
         0,
         true,
@@ -62,4 +62,24 @@ fn locked_resolution_is_unallocated_until_written() {
         "the accessor reads back what `locked_mut` wrote",
     );
     assert!(node.has_no_locked_peers(), "a previous depPath is not a locked peer");
+}
+
+/// Every occurrence node names its package, but a workspace has a few
+/// thousand distinct package ids and the walk realizes millions of
+/// occurrences. The id is shared from [`super::ChildEdge::pkg_id`]
+/// rather than copied, so realizing a child costs a refcount bump.
+#[test]
+fn realizing_an_occurrence_shares_the_package_id() {
+    let edge_id: Arc<str> = "a@1.0.0".into();
+    let node = super::DependenciesTreeNode::new(
+        Arc::clone(&edge_id),
+        super::TreeChildren::Realized(Arc::new(std::collections::BTreeMap::new())),
+        0,
+        true,
+    );
+
+    assert!(
+        Arc::ptr_eq(&edge_id, &node.resolved_package_id),
+        "the node points at the edge's id instead of owning a copy of it",
+    );
 }

--- a/pnpm/crates/resolving-deps-resolver/src/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/tests.rs
@@ -245,7 +245,7 @@ async fn children_follow_the_shallowest_occurrence_however_late_it_resolves() {
 
     let shared_children = tree.children_by_id.get("shared@1.0.0").expect("shared children");
     assert_eq!(shared_children.len(), 1);
-    assert_eq!(shared_children[0].pkg_id, "pin@1.0.0");
+    assert_eq!(&*shared_children[0].pkg_id, "pin@1.0.0");
 }
 
 /// The winning occurrence's peer-shadowed set is the one that filters
@@ -317,7 +317,7 @@ async fn same_depth_occurrences_are_settled_by_parent_path() {
 
     let shared_children = tree.children_by_id.get("shared@1.0.0").expect("shared children");
     assert_eq!(shared_children.len(), 1);
-    assert_eq!(shared_children[0].pkg_id, "pin@1.0.0");
+    assert_eq!(&*shared_children[0].pkg_id, "pin@1.0.0");
 }
 
 fn fake_result(name: &str, version: &str, manifest: serde_json::Value) -> ResolveResult {
@@ -418,7 +418,7 @@ async fn walks_dependencies_and_builds_flat_tree() {
     assert_eq!(foo_tree_node.children.realized().len(), 1);
     let bar_node_id = foo_tree_node.children.realized().get("bar").unwrap();
     let bar_tree_node = tree.dependencies_tree.get(bar_node_id).unwrap();
-    assert_eq!(bar_tree_node.resolved_package_id, "bar@2.3.0");
+    assert_eq!(&*bar_tree_node.resolved_package_id, "bar@2.3.0");
     assert!(tree.policy_violations.is_empty());
 }
 
@@ -563,7 +563,7 @@ async fn shallower_revisit_takes_over_shared_children_context() {
     let shared_children = tree.children_by_id.get("shared@1.0.0").expect("shared children");
     assert_eq!(shared_children.len(), 1);
     assert_eq!(shared_children[0].alias, "cycle");
-    assert_eq!(shared_children[0].pkg_id, "cycle@1.0.0");
+    assert_eq!(&*shared_children[0].pkg_id, "cycle@1.0.0");
 }
 
 #[tokio::test]
@@ -634,8 +634,11 @@ async fn dedupes_when_the_same_package_appears_in_two_subtrees() {
     let shared_via_a = a_tree.children.realized().get("shared").unwrap();
     let shared_via_b = b_tree.children.realized().get("shared").unwrap();
     assert_eq!(shared_via_a, shared_via_b);
-    let shared_occurrences =
-        tree.dependencies_tree.values().filter(|n| n.resolved_package_id == "shared@1.0.0").count();
+    let shared_occurrences = tree
+        .dependencies_tree
+        .values()
+        .filter(|n| n.resolved_package_id == "shared@1.0.0".into())
+        .count();
     assert_eq!(shared_occurrences, 1);
 }
 
@@ -2284,7 +2287,7 @@ mod peers {
         let peer_only_node_ids: Vec<&NodeId> = tree
             .dependencies_tree
             .iter()
-            .filter(|(_, node)| node.resolved_package_id == "peer-only@1.0.0")
+            .filter(|(_, node)| node.resolved_package_id == "peer-only@1.0.0".into())
             .map(|(id, _)| id)
             .collect();
         assert!(!peer_only_node_ids.is_empty(), "expected at least one tree entry for peer-only");
@@ -2380,7 +2383,7 @@ mod peers {
         let pure_pre: Vec<(&crate::node_id::NodeId, bool)> = tree
             .dependencies_tree
             .iter()
-            .filter(|(_, node)| node.resolved_package_id == "pure@1.0.0")
+            .filter(|(_, node)| node.resolved_package_id == "pure@1.0.0".into())
             .map(|(id, node)| (id, matches!(node.children, TreeChildren::Lazy { .. })))
             .collect();
         assert_eq!(pure_pre.len(), 2, "expected two occurrences of pure, got {pure_pre:?}");
@@ -2401,7 +2404,7 @@ mod peers {
         let still_lazy = tree
             .dependencies_tree
             .iter()
-            .filter(|(_, node)| node.resolved_package_id == "pure@1.0.0")
+            .filter(|(_, node)| node.resolved_package_id == "pure@1.0.0".into())
             .filter(|(_, node)| matches!(node.children, TreeChildren::Lazy { .. }))
             .count();
         assert_eq!(


### PR DESCRIPTION
Follow-up to #13844 on the same workload from #13681.

A workspace has a few thousand distinct `pkgIdWithPatchHash` values, but the peer walk realizes one occurrence node per distinct root-to-package path — **2,007,292 of them for a 6,133-node graph**. Every one of those nodes owned a fresh `String` copy of its package id, and every parent-context snapshot copied it again.

### Changes

- **`DependenciesTreeNode::resolved_package_id` and `ChildEdge::pkg_id` become `Arc<str>`.** `realize_children` now hands over a refcount instead of allocating, and the node shrinks from 56 to 48 bytes. The maps keyed by package id move to `Arc<str>` keys with it — `Arc<str>: Borrow<str>` keeps `&str` lookups working, and `Arc<str>` hashes as its `str`, so iteration order is unchanged.
- **`ParentPkgInfo::pkg_id` follows.** Those snapshots held **1,327,035 entries** across the walk, each with its own copy of an id that already existed on the tree node it was read from.
- **`DepPath` gains `From<Arc<str>>`.** It already wraps an `Arc<str>`, so these conversions stop round-tripping through `String` and reallocating.

### Result

| | peak RSS |
| --- | --- |
| `main` | 3306 / 3236 / 3250 MB |
| this branch | 3008 / 3086 / 3044 MB |

**3264 → 3046 MB, −6.7%**, alternating A/B to control for drift, non-overlapping, 3 of 3.

Cumulative with #13844 the same install has gone **3670 → 3046 MB (−17%)**.

(The first version of this PR measured −5%. Review caught that the conversion had left `Arc::from` calls on paths that previously did no allocation at all — comparisons in the cache-matching loop, a double allocation in `packages.insert`, a `&str → String → Arc<str>` round-trip. Removing them is what took it to −6.7%.)

### Correctness

The lockfile is **byte-identical** — `main` twice and this branch once all produced the same file, and the package sets match exactly. (Worth noting given #13846: on this run the engine happened to be deterministic, so the control was clean; that is not always true.)

326 tests pass, plus `cargo clippy --all-targets`, `cargo fmt` and `cargo dylint` clean across the workspace.

Two tests cover the change: the existing footprint assertion drops from 56 to 48 bytes, and `realizing_children_shares_the_edge_package_id` asserts pointer equality through `realize_children_with` — the path that creates the two million occurrences — so a future copy fails rather than silently costing memory. I verified it fails when that path is made to copy; the first version of it did not, because it only checked that the constructor kept its argument.

### What this still does not fix

The occurrence count itself, which is the remaining ~85%. As measured in #13681, **91% of full walks end in a cycle** and cycle-resolved walks are never cached (#5108), so `find_hit` succeeds 155 times in 188,862 lookups and nearly every occurrence re-walks its subtree. Everything sized by that 2M count — the tree, `node_dep_paths`, `visited_this_call`, the three per-node peer maps — stays proportional to it.

Fixing that means caching cycle-resolved verdicts under a key that captures which ancestor repetition truncated the subtree. I have not attempted it because getting the invariant wrong produces wrong lockfiles rather than merely slow ones, and #5108 suggests it is subtle. Still happy to take it on with a steer on the intended rule.

Refs #13681

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789113768&installation_model_id=426870&pr_number=13855&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13855&signature=ea90820b0096f7c6299401e24f6e93c6649844e169b2674177f4b280c08fa28f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced peak memory usage during dependency resolution by sharing package identifiers across dependency-tree entries.
  * Reduced unnecessary string copying during peer-dependency and workspace resolution.

* **Bug Fixes**
  * Maintained existing dependency and peer-resolution behavior while improving identifier handling.

* **Tests**
  * Added coverage for shared identifier storage and memory usage.
  * Confirmed dependency graph and lockfile results remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
