### PR TITLE
fix: validate packageExtensions when reading the config

### DIFF
--- a/.changeset/tidy-oranges-repeat.md
+++ b/.changeset/tidy-oranges-repeat.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config.reader": patch
+"pnpm": patch
+---
+
+`packageExtensions` is now validated when the configuration is read, so a malformed entry (for instance a dependency range set to `null`) fails with an actionable error instead of crashing later during peer dependency resolution [#13756](https://github.com/pnpm/pnpm/issues/13756).

--- a/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
+++ b/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
@@ -59,6 +59,9 @@ export function getOptionsFromPnpmSettings (
       }
     }
   }
+  if (settings.packageExtensions) {
+    assertValidPackageExtensions(settings.packageExtensions)
+  }
   if (pnpmSettings.patchedDependencies) {
     settings.patchedDependencies = { ...pnpmSettings.patchedDependencies }
     for (const [dep, patchFile] of Object.entries(pnpmSettings.patchedDependencies)) {
@@ -163,6 +166,38 @@ function assertValidOverrides (overrides: unknown): asserts overrides is Record<
   }
 }
 
+const PACKAGE_EXTENSION_DEPENDENCY_FIELDS = ['dependencies', 'optionalDependencies', 'peerDependencies'] as const
+
+// A malformed range here is not caught by anything downstream: the extender
+// merges the value onto the manifest as is, and it only surfaces once peer
+// resolution tries to read a version out of it, far away from the setting that
+// produced it.
+function assertValidPackageExtensions (packageExtensions: unknown): asserts packageExtensions is Record<string, PackageExtension> {
+  assertObjectSetting(packageExtensions, 'packageExtensions')
+  for (const [selector, extension] of Object.entries(packageExtensions as Record<string, unknown>)) {
+    const extensionPath = `packageExtensions['${selector}']`
+    assertObjectSetting(extension, extensionPath)
+    for (const field of PACKAGE_EXTENSION_DEPENDENCY_FIELDS) {
+      const deps = (extension as Record<string, unknown>)[field]
+      if (deps == null) continue
+      assertObjectSetting(deps, `${extensionPath}.${field}`)
+      for (const [depName, range] of Object.entries(deps as Record<string, unknown>)) {
+        assertString(range, `${extensionPath}.${field}.${depName}`)
+      }
+    }
+    const peerDependenciesMeta = (extension as Record<string, unknown>).peerDependenciesMeta
+    if (peerDependenciesMeta == null) continue
+    assertObjectSetting(peerDependenciesMeta, `${extensionPath}.peerDependenciesMeta`)
+    for (const [depName, meta] of Object.entries(peerDependenciesMeta as Record<string, unknown>)) {
+      const metaPath = `${extensionPath}.peerDependenciesMeta.${depName}`
+      assertObjectSetting(meta, metaPath)
+      const optional = (meta as Record<string, unknown>).optional
+      if (optional == null) continue
+      assertBoolean(optional, `${metaPath}.optional`)
+    }
+  }
+}
+
 function renderReceivedType (value: unknown): string {
   if (value === null) return 'null'
   if (Array.isArray(value)) return 'array'
@@ -171,7 +206,7 @@ function renderReceivedType (value: unknown): string {
 
 const AUDIT_LEVELS = new Set(['info', 'low', 'moderate', 'high', 'critical'])
 
-// The `update` and `audit` sections come from repo-controlled
+// The `update`, `audit` and `packageExtensions` sections come from repo-controlled
 // pnpm-workspace.yaml, which is parsed untyped — so their fields are validated
 // here (the Rust config reader rejects the same malformed shapes at parse
 // time). An invalid `audit.level` is especially worth catching: it would leave

--- a/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
+++ b/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
@@ -59,7 +59,7 @@ export function getOptionsFromPnpmSettings (
       }
     }
   }
-  if (settings.packageExtensions) {
+  if (settings.packageExtensions != null) {
     assertValidPackageExtensions(settings.packageExtensions)
   }
   if (pnpmSettings.patchedDependencies) {
@@ -172,6 +172,9 @@ const PACKAGE_EXTENSION_DEPENDENCY_FIELDS = ['dependencies', 'optionalDependenci
 // merges the value onto the manifest as is, and it only surfaces once peer
 // resolution tries to read a version out of it, far away from the setting that
 // produced it.
+//
+// A `null` field counts as absent rather than malformed — that is what a key
+// left empty in YAML parses to, and what pacquet's `Option` fields accept.
 function assertValidPackageExtensions (packageExtensions: unknown): asserts packageExtensions is Record<string, PackageExtension> {
   assertObjectSetting(packageExtensions, 'packageExtensions')
   for (const [selector, extension] of Object.entries(packageExtensions as Record<string, unknown>)) {

--- a/pnpm11/config/reader/test/getOptionsFromRootManifest.test.ts
+++ b/pnpm11/config/reader/test/getOptionsFromRootManifest.test.ts
@@ -237,7 +237,10 @@ test('getOptionsFromPnpmSettings() rejects non-object packageExtensions', () => 
 
 // A key left empty in pnpm-workspace.yaml parses to null. pacquet reads the same
 // shapes into `Option` fields, where null and an absent key are the same thing.
-test('getOptionsFromPnpmSettings() treats null packageExtensions fields as unset', () => {
+// The nulls are passed through rather than stripped: every reader of these
+// fields already treats them as unset, so normalizing them here would only add a
+// second spelling of the same state.
+test('getOptionsFromPnpmSettings() accepts null packageExtensions fields', () => {
   expect(getOptionsFromPnpmSettings(process.cwd(), {
     packageExtensions: {
       'foo@*': {

--- a/pnpm11/config/reader/test/getOptionsFromRootManifest.test.ts
+++ b/pnpm11/config/reader/test/getOptionsFromRootManifest.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, expect, test } from '@jest/globals'
+import type { PackageExtension } from '@pnpm/types'
 
 import { getOptionsFromPnpmSettings } from '../lib/getOptionsFromRootManifest.js'
 
@@ -124,4 +125,81 @@ test('getOptionsFromPnpmSettings() rejects non-object overrides values', () => {
     code: 'ERR_PNPM_INVALID_OVERRIDES',
     message: 'The overrides field should be an object, but got array',
   }))
+})
+
+test('getOptionsFromPnpmSettings() rejects a non-string range in packageExtensions', () => {
+  expect(() => getOptionsFromPnpmSettings(process.cwd(), {
+    packageExtensions: {
+      'officeparser@*': {
+        peerDependencies: {
+          puppeteer: null,
+        },
+      },
+    } as unknown as Record<string, PackageExtension>,
+  })).toThrow(expect.objectContaining({
+    code: 'ERR_PNPM_INVALID_SETTING',
+    message: 'The "packageExtensions[\'officeparser@*\'].peerDependencies.puppeteer" setting should be a string, but got null',
+  }))
+})
+
+test('getOptionsFromPnpmSettings() rejects a non-boolean optional flag in packageExtensions', () => {
+  expect(() => getOptionsFromPnpmSettings(process.cwd(), {
+    packageExtensions: {
+      'officeparser@*': {
+        peerDependenciesMeta: {
+          puppeteer: {
+            optional: 'yes',
+          },
+        },
+      },
+    } as unknown as Record<string, PackageExtension>,
+  })).toThrow(expect.objectContaining({
+    code: 'ERR_PNPM_INVALID_SETTING',
+    message: 'The "packageExtensions[\'officeparser@*\'].peerDependenciesMeta.puppeteer.optional" setting should be a boolean, but got string',
+  }))
+})
+
+test('getOptionsFromPnpmSettings() rejects a non-object package extension', () => {
+  expect(() => getOptionsFromPnpmSettings(process.cwd(), {
+    packageExtensions: {
+      'officeparser@*': [],
+    } as unknown as Record<string, PackageExtension>,
+  })).toThrow(expect.objectContaining({
+    code: 'ERR_PNPM_INVALID_SETTING',
+    message: 'The "packageExtensions[\'officeparser@*\']" setting should be an object, but got array',
+  }))
+})
+
+test('getOptionsFromPnpmSettings() accepts valid packageExtensions', () => {
+  expect(getOptionsFromPnpmSettings(process.cwd(), {
+    packageExtensions: {
+      'officeparser@*': {
+        dependencies: {
+          foo: '1.0.0',
+        },
+        peerDependencies: {
+          puppeteer: '*',
+        },
+        peerDependenciesMeta: {
+          puppeteer: {
+            optional: true,
+          },
+        },
+      },
+    },
+  }).packageExtensions).toStrictEqual({
+    'officeparser@*': {
+      dependencies: {
+        foo: '1.0.0',
+      },
+      peerDependencies: {
+        puppeteer: '*',
+      },
+      peerDependenciesMeta: {
+        puppeteer: {
+          optional: true,
+        },
+      },
+    },
+  })
 })

--- a/pnpm11/config/reader/test/getOptionsFromRootManifest.test.ts
+++ b/pnpm11/config/reader/test/getOptionsFromRootManifest.test.ts
@@ -170,6 +170,97 @@ test('getOptionsFromPnpmSettings() rejects a non-object package extension', () =
   }))
 })
 
+test('getOptionsFromPnpmSettings() rejects a non-object dependency field in packageExtensions', () => {
+  expect(() => getOptionsFromPnpmSettings(process.cwd(), {
+    packageExtensions: {
+      'foo@*': {
+        dependencies: [],
+      },
+    } as unknown as Record<string, PackageExtension>,
+  })).toThrow(expect.objectContaining({
+    code: 'ERR_PNPM_INVALID_SETTING',
+    message: 'The "packageExtensions[\'foo@*\'].dependencies" setting should be an object, but got array',
+  }))
+})
+
+test('getOptionsFromPnpmSettings() rejects a non-string range in optionalDependencies of packageExtensions', () => {
+  expect(() => getOptionsFromPnpmSettings(process.cwd(), {
+    packageExtensions: {
+      'foo@*': {
+        optionalDependencies: {
+          bar: 1,
+        },
+      },
+    } as unknown as Record<string, PackageExtension>,
+  })).toThrow(expect.objectContaining({
+    code: 'ERR_PNPM_INVALID_SETTING',
+    message: 'The "packageExtensions[\'foo@*\'].optionalDependencies.bar" setting should be a string, but got number',
+  }))
+})
+
+test('getOptionsFromPnpmSettings() rejects a non-object peerDependenciesMeta in packageExtensions', () => {
+  expect(() => getOptionsFromPnpmSettings(process.cwd(), {
+    packageExtensions: {
+      'foo@*': {
+        peerDependenciesMeta: 'bar',
+      },
+    } as unknown as Record<string, PackageExtension>,
+  })).toThrow(expect.objectContaining({
+    code: 'ERR_PNPM_INVALID_SETTING',
+    message: 'The "packageExtensions[\'foo@*\'].peerDependenciesMeta" setting should be an object, but got string',
+  }))
+})
+
+test('getOptionsFromPnpmSettings() rejects a non-object peerDependenciesMeta entry in packageExtensions', () => {
+  expect(() => getOptionsFromPnpmSettings(process.cwd(), {
+    packageExtensions: {
+      'foo@*': {
+        peerDependenciesMeta: {
+          bar: true,
+        },
+      },
+    } as unknown as Record<string, PackageExtension>,
+  })).toThrow(expect.objectContaining({
+    code: 'ERR_PNPM_INVALID_SETTING',
+    message: 'The "packageExtensions[\'foo@*\'].peerDependenciesMeta.bar" setting should be an object, but got boolean',
+  }))
+})
+
+test('getOptionsFromPnpmSettings() rejects non-object packageExtensions', () => {
+  expect(() => getOptionsFromPnpmSettings(process.cwd(), {
+    packageExtensions: false,
+  } as unknown as Record<string, unknown>)).toThrow(expect.objectContaining({
+    code: 'ERR_PNPM_INVALID_SETTING',
+    message: 'The "packageExtensions" setting should be an object, but got boolean',
+  }))
+})
+
+// A key left empty in pnpm-workspace.yaml parses to null. pacquet reads the same
+// shapes into `Option` fields, where null and an absent key are the same thing.
+test('getOptionsFromPnpmSettings() treats null packageExtensions fields as unset', () => {
+  expect(getOptionsFromPnpmSettings(process.cwd(), {
+    packageExtensions: {
+      'foo@*': {
+        dependencies: null,
+        peerDependenciesMeta: {
+          bar: {
+            optional: null,
+          },
+        },
+      },
+    },
+  } as unknown as Record<string, unknown>).packageExtensions).toStrictEqual({
+    'foo@*': {
+      dependencies: null,
+      peerDependenciesMeta: {
+        bar: {
+          optional: null,
+        },
+      },
+    },
+  })
+})
+
 test('getOptionsFromPnpmSettings() accepts valid packageExtensions', () => {
   expect(getOptionsFromPnpmSettings(process.cwd(), {
     packageExtensions: {

--- a/pnpm11/config/reader/test/getOptionsFromRootManifest.test.ts
+++ b/pnpm11/config/reader/test/getOptionsFromRootManifest.test.ts
@@ -130,24 +130,24 @@ test('getOptionsFromPnpmSettings() rejects non-object overrides values', () => {
 test('getOptionsFromPnpmSettings() rejects a non-string range in packageExtensions', () => {
   expect(() => getOptionsFromPnpmSettings(process.cwd(), {
     packageExtensions: {
-      'officeparser@*': {
+      'foo@*': {
         peerDependencies: {
-          puppeteer: null,
+          bar: null,
         },
       },
     } as unknown as Record<string, PackageExtension>,
   })).toThrow(expect.objectContaining({
     code: 'ERR_PNPM_INVALID_SETTING',
-    message: 'The "packageExtensions[\'officeparser@*\'].peerDependencies.puppeteer" setting should be a string, but got null',
+    message: 'The "packageExtensions[\'foo@*\'].peerDependencies.bar" setting should be a string, but got null',
   }))
 })
 
 test('getOptionsFromPnpmSettings() rejects a non-boolean optional flag in packageExtensions', () => {
   expect(() => getOptionsFromPnpmSettings(process.cwd(), {
     packageExtensions: {
-      'officeparser@*': {
+      'foo@*': {
         peerDependenciesMeta: {
-          puppeteer: {
+          bar: {
             optional: 'yes',
           },
         },
@@ -155,48 +155,48 @@ test('getOptionsFromPnpmSettings() rejects a non-boolean optional flag in packag
     } as unknown as Record<string, PackageExtension>,
   })).toThrow(expect.objectContaining({
     code: 'ERR_PNPM_INVALID_SETTING',
-    message: 'The "packageExtensions[\'officeparser@*\'].peerDependenciesMeta.puppeteer.optional" setting should be a boolean, but got string',
+    message: 'The "packageExtensions[\'foo@*\'].peerDependenciesMeta.bar.optional" setting should be a boolean, but got string',
   }))
 })
 
 test('getOptionsFromPnpmSettings() rejects a non-object package extension', () => {
   expect(() => getOptionsFromPnpmSettings(process.cwd(), {
     packageExtensions: {
-      'officeparser@*': [],
+      'foo@*': [],
     } as unknown as Record<string, PackageExtension>,
   })).toThrow(expect.objectContaining({
     code: 'ERR_PNPM_INVALID_SETTING',
-    message: 'The "packageExtensions[\'officeparser@*\']" setting should be an object, but got array',
+    message: 'The "packageExtensions[\'foo@*\']" setting should be an object, but got array',
   }))
 })
 
 test('getOptionsFromPnpmSettings() accepts valid packageExtensions', () => {
   expect(getOptionsFromPnpmSettings(process.cwd(), {
     packageExtensions: {
-      'officeparser@*': {
+      'foo@*': {
         dependencies: {
           foo: '1.0.0',
         },
         peerDependencies: {
-          puppeteer: '*',
+          bar: '*',
         },
         peerDependenciesMeta: {
-          puppeteer: {
+          bar: {
             optional: true,
           },
         },
       },
     },
   }).packageExtensions).toStrictEqual({
-    'officeparser@*': {
+    'foo@*': {
       dependencies: {
         foo: '1.0.0',
       },
       peerDependencies: {
-        puppeteer: '*',
+        bar: '*',
       },
       peerDependenciesMeta: {
-        puppeteer: {
+        bar: {
           optional: true,
         },
       },


### PR DESCRIPTION
## Summary

A `packageExtensions` entry whose dependency range is not a string is merged onto the target manifest untouched, and only blows up much later, in peer resolution:

```
TypeError: Cannot read properties of null (reading 'includes')
    at getPeerVersionRange
    at _resolvePeers
```

Reported with this config, where the YAML value is empty and therefore `null`:

```yaml
packageExtensions:
  "officeparser@*":
    peerDependencies:
      puppeteer:
```

Nothing in the crash points back at the setting that caused it. It also only reproduces when the target package declares the peer through `peerDependenciesMeta` without declaring it in `peerDependencies` (as `officeparser` does) — otherwise the manifest's own range wins the merge and hides the bad value.

This validates `packageExtensions` where `overrides` is already validated, when the settings are read, so the install fails up front naming the offending path:

```
[ERROR] The "packageExtensions['officeparser@*'].peerDependencies.puppeteer" setting should be a string, but got null
```

Validated: each extension is an object; `dependencies`, `optionalDependencies` and `peerDependencies` map to string ranges; `peerDependenciesMeta` entries are objects whose `optional`, when present, is a boolean. That is exactly the shape pacquet's `PackageExtension` deserializes into.

No Rust change is needed for parity: pacquet already rejects these shapes when it parses `pnpm-workspace.yaml`, and errors before doing any work. Its message does leak a Rust type (`cannot deserialize null into string; use Option<String>`) — that comes from the generic deserializer and applies to every setting, so it is left for a separate change.

Closes pnpm/pnpm#13756

## Squash Commit Body

```text
A `packageExtensions` entry whose dependency range is not a string was
merged onto the target manifest untouched, and only surfaced once peer
resolution read a version out of it — as `TypeError: Cannot read
properties of null (reading 'includes')`, with nothing pointing back at
the setting that caused it.

Validate the section where `overrides` is already validated, so the
install fails up front naming the offending path. This matches pacquet,
which rejects the same shapes when it parses pnpm-workspace.yaml.

Closes pnpm/pnpm#13756
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789120128&installation_model_id=426870&pr_number=13856&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13856&signature=717d7af0b3d9fe9e67df126ec5efe6da7033a4d6cf2021624b8ce6e52a3d0558"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added validation for `packageExtensions` during configuration loading.
  - Configuration now reports actionable errors for malformed extensions, invalid dependency ranges, invalid dependency metadata, and non-boolean optional flags.
  - Valid package extensions are accepted and preserved as expected.
  - Improved feedback helps identify and correct invalid configuration values more quickly.

- **Documentation**
  - Added release notes describing the improved configuration validation and error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->