### PR TITLE
perf(resolver): cache cycle-truncated peer verdicts, scoped to their truncation

### DIFF
--- a/.changeset/cycle-verdict-cache.md
+++ b/.changeset/cycle-verdict-cache.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Resolving peer dependencies in a workspace whose dependency graph contains many peer-dependency cycles now needs less than half the memory and finishes about twice as fast. Verdicts computed inside dependency cycles are now cached and reused for the occurrences they are provably valid for, instead of being recomputed for every occurrence.

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/cache.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/cache.rs
@@ -385,8 +385,10 @@ impl Walker<'_> {
         pkg_id: &str,
     ) -> Option<&PeersCacheItem> {
         self.peers_cache.get(pkg_id)?.iter().find(|item| {
-            // The fast paths have no ancestor chain to compare, so they
-            // stay on the entries that never needed one.
+            // Keyed entries are deliberately left to `find_hit`: this
+            // path could validate them against `parent_ids`, but it
+            // skips them to keep the fast path's matching unchanged.
+            // Skipping only loses hits, never correctness.
             item.cycle_key.is_none()
                 && matches!(
                     self.fast_cache_item_matches(parent_ids, parent_refs, pkg_id, item),

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/cache.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/cache.rs
@@ -36,6 +36,106 @@ use std::{collections::BTreeMap, sync::Arc};
 /// pnpm's resolver gives a not-new package `resolvedPeers: {}`
 /// (`resolveDependencies.ts`) — so only the walk that first resolved a
 /// subtree promotes its providers to importer level.
+/// Set of package ids, as bits over [`Walker::consulted_bit_by_pkg`].
+///
+/// A full walk collects here every package the cycle gate weighed while
+/// realizing the walk's subtree — the packages whose presence in the
+/// occurrence's ancestor chain could have changed what got truncated.
+/// Everything else in the chain is noise the verdict provably does not
+/// depend on, which is what makes [`CycleTruncationKey`] so much
+/// coarser (and so much more reusable) than the chain itself.
+///
+/// Kept normalized: no trailing zero words, so derived equality and
+/// hashing see one representation per set.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
+pub(super) struct ConsultedPkgs {
+    words: Vec<u64>,
+}
+
+impl ConsultedPkgs {
+    pub(super) fn set(&mut self, bit: u32) {
+        let word = (bit / 64) as usize;
+        if self.words.len() <= word {
+            self.words.resize(word + 1, 0);
+        }
+        self.words[word] |= 1 << (bit % 64);
+    }
+
+    pub(super) fn contains(&self, bit: u32) -> bool {
+        let word = (bit / 64) as usize;
+        self.words.get(word).is_some_and(|word| word & (1 << (bit % 64)) != 0)
+    }
+
+    pub(super) fn or(&mut self, other: &Self) {
+        if self.words.len() < other.words.len() {
+            self.words.resize(other.words.len(), 0);
+        }
+        for (ours, theirs) in self.words.iter_mut().zip(other.words.iter()) {
+            *ours |= theirs;
+        }
+    }
+}
+
+/// What scopes a cycle-truncated verdict to the occurrences it is
+/// authoritative for.
+///
+/// The cycle gate truncates a subtree as a function of the occurrence's
+/// ancestor chain — but only of the chain entries it actually weighs.
+/// Two occurrences whose chains agree on those entries (same ids, same
+/// order, same base/appended placement) truncate identically, so the
+/// recorded walk's verdict is exactly what a fresh walk would compute.
+#[derive(Debug)]
+pub(super) struct CycleTruncationKey {
+    /// The packages the recorded walk's gate weighed.
+    consulted: Arc<ConsultedPkgs>,
+    /// The recorded occurrence's ancestor chain restricted to
+    /// [`Self::consulted`], base entries first.
+    chain: Box<[Arc<str>]>,
+    /// How many of [`Self::chain`]'s entries came from the base half.
+    /// Order across the base/appended boundary is not comparable —
+    /// `forms_cycle` treats the halves differently — so the boundary is
+    /// part of the key.
+    base_len: u32,
+}
+
+impl CycleTruncationKey {
+    pub(super) fn new(consulted: Arc<ConsultedPkgs>, chain: Vec<Arc<str>>, base_len: u32) -> Self {
+        CycleTruncationKey { consulted, chain: chain.into_boxed_slice(), base_len }
+    }
+
+    pub(super) fn consulted(&self) -> &Arc<ConsultedPkgs> {
+        &self.consulted
+    }
+
+    /// `true` when `current`, restricted to the recorded walk's
+    /// consulted packages, is the recorded chain.
+    fn matches(
+        &self,
+        current: &AncestorIds,
+        bit_by_pkg: &HashMap<std::sync::Arc<str>, u32>,
+    ) -> bool {
+        let consulted =
+            |id: &str| bit_by_pkg.get(id).is_some_and(|bit| self.consulted.contains(*bit));
+        let mut expected = self.chain.iter();
+        let mut base_len = 0u32;
+        for id in current.base_ids().filter(|id| consulted(id)) {
+            if expected.next().map(|e| &**e) != Some(id) {
+                return false;
+            }
+            base_len += 1;
+        }
+        if base_len != self.base_len {
+            return false;
+        }
+        for id in current.appended_ids().filter(|id| consulted(id)) {
+            if expected.next().map(|e| &**e) != Some(id) {
+                return false;
+            }
+        }
+        expected.next().is_none()
+    }
+}
+
 #[derive(Debug)]
 pub(super) struct PeersCacheItem {
     pub(super) dep_path: DepPath,
@@ -47,6 +147,18 @@ pub(super) struct PeersCacheItem {
     /// subtree still reports the same per-package missing breakdown a
     /// full walk of it would.
     pub(super) subtree_missing_by_pkg: SubtreeMissingByPkg,
+    /// `None` for a verdict that saw its package's whole subtree, which
+    /// is the only kind this cache used to hold.
+    ///
+    /// A cycle re-entry resolves against children the cycle gate
+    /// truncated, so its peer sets describe *that* truncation rather
+    /// than the package as a whole. Reusing one where the subtree is
+    /// intact is what pnpm/pnpm#5108 is about. The truncation is a
+    /// function of the ancestor chain restricted to the packages the
+    /// gate weighed, though, so recording that restriction lets
+    /// [`Walker::find_hit`] hand the verdict back to exactly the
+    /// occurrences that would recompute it — and no others.
+    pub(super) cycle_key: Option<CycleTruncationKey>,
 }
 
 impl PeersCacheItem {
@@ -149,9 +261,18 @@ impl Walker<'_> {
         &self,
         parent_refs: &ParentRefs,
         pkg_id: &str,
+        ancestor_ids: Option<&AncestorIds>,
     ) -> Option<&PeersCacheItem> {
         let cache_items = self.peers_cache.get(pkg_id)?;
         cache_items.iter().find(|item| {
+            // A truncated verdict is only valid for an occurrence whose
+            // ancestors truncate it the same way.
+            if let Some(key) = &item.cycle_key
+                && !ancestor_ids
+                    .is_some_and(|current| key.matches(current, &self.consulted_bit_by_pkg))
+            {
+                return false;
+            }
             for (name, cached_node_id) in item.resolved_peers.iter() {
                 let Some(current_ref) = parent_refs.get(name) else {
                     return false;
@@ -264,10 +385,13 @@ impl Walker<'_> {
         pkg_id: &str,
     ) -> Option<&PeersCacheItem> {
         self.peers_cache.get(pkg_id)?.iter().find(|item| {
-            matches!(
-                self.fast_cache_item_matches(parent_ids, parent_refs, pkg_id, item),
-                FastCacheMatch::Match,
-            )
+            // The fast paths have no ancestor chain to compare, so they
+            // stay on the entries that never needed one.
+            item.cycle_key.is_none()
+                && matches!(
+                    self.fast_cache_item_matches(parent_ids, parent_refs, pkg_id, item),
+                    FastCacheMatch::Match,
+                )
         })
     }
 
@@ -561,6 +685,7 @@ impl Walker<'_> {
             }
         };
         let children = self.tree.children_by_id.get(&pkg_id).cloned().unwrap_or_default();
+        self.mark_realization_consulted(&pkg_id);
         let provider_edge_indices = self
             .peer_provider_children_by_pkg_id
             .get(&*pkg_id)
@@ -628,7 +753,15 @@ impl Walker<'_> {
             let node = &self.tree.dependencies_tree[node_id];
             match &node.children {
                 // Cheap: the realized map is shared, not copied per revisit.
-                TreeChildren::Realized(map) => return (Arc::clone(map), None),
+                TreeChildren::Realized(map) => {
+                    let map = Arc::clone(map);
+                    let pkg_id = std::sync::Arc::<str>::clone(&node.resolved_package_id);
+                    // The map embodies the gate answers of whichever walk
+                    // realized it, so reusing it consults the same
+                    // packages a fresh realization would have.
+                    self.mark_realization_consulted(&pkg_id);
+                    return (map, None);
+                }
                 TreeChildren::Lazy { parent_ids } => (
                     parent_ids.clone(),
                     std::sync::Arc::<str>::clone(&node.resolved_package_id),
@@ -642,6 +775,7 @@ impl Walker<'_> {
             // for this package id — defensive empty case.
             None => Arc::new(Vec::new()),
         };
+        self.mark_realization_consulted(&pkg_id);
         let child_depth = depth + 1;
         let mut realized: BTreeMap<String, NodeId> = BTreeMap::new();
         let mut newly_inserted: Vec<NodeId> = Vec::new();

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/cache.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/cache.rs
@@ -147,8 +147,8 @@ pub(super) struct PeersCacheItem {
     /// subtree still reports the same per-package missing breakdown a
     /// full walk of it would.
     pub(super) subtree_missing_by_pkg: SubtreeMissingByPkg,
-    /// `None` for a verdict that saw its package's whole subtree, which
-    /// is the only kind this cache used to hold.
+    /// `None` for a verdict that saw its package's whole subtree —
+    /// such verdicts are valid wherever the peer-context checks pass.
     ///
     /// A cycle re-entry resolves against children the cycle gate
     /// truncated, so its peer sets describe *that* truncation rather

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/cache/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/cache/tests.rs
@@ -1,6 +1,6 @@
 //! Unit tests for the walk's cache and child-realization decisions.
 
-use super::should_retain_materialized_node;
+use super::{ConsultedPkgs, CycleTruncationKey, PeersCacheItem, should_retain_materialized_node};
 use crate::{
     node_id::NodeId,
     resolve_peers::{
@@ -70,4 +70,110 @@ fn previously_resolved_children_prefers_closest_same_package_ancestor() {
         walker.previously_resolved_children(&parent_node_ids, &parent_pkg_ids, "loop@1.0.0");
 
     assert_eq!(children.get("shared"), Some(&close_child));
+}
+
+fn keyed_item(
+    walker: &mut crate::resolve_peers::walker::Walker<'_>,
+    chain: &[&str],
+) -> PeersCacheItem {
+    // Consulted set = exactly the ids in `chain`, registered through the
+    // walker's bit index the way a real walk would.
+    let mut bits = ConsultedPkgs::default();
+    for id in chain {
+        let next = walker.consulted_bit_by_pkg.len() as u32;
+        let bit = *walker.consulted_bit_by_pkg.entry(Arc::from(*id)).or_insert(next);
+        bits.set(bit);
+    }
+    PeersCacheItem {
+        dep_path: DepPath::from("cyclic@1.0.0"),
+        resolved_peers: Arc::new(HashMap::default()),
+        missing_peers: Arc::new(HashMap::default()),
+        missing_peers_of_children: Arc::new(HashMap::default()),
+        subtree_missing_by_pkg: None,
+        cycle_key: Some(CycleTruncationKey::new(
+            Arc::new(bits),
+            chain.iter().map(|id| Arc::from(*id)).collect(),
+            0,
+        )),
+    }
+}
+
+fn ancestors(base: &[&str], appended: &[&str]) -> crate::resolved_tree::AncestorIds {
+    appended.iter().fold(
+        crate::resolved_tree::AncestorIds::from(Arc::new(
+            base.iter().map(ToString::to_string).collect::<Vec<_>>(),
+        )),
+        |ids, id| ids.pushed((*id).to_string()),
+    )
+}
+
+/// The heart of the cycle-verdict cache: a truncated verdict is handed
+/// back exactly to the occurrences whose ancestors truncate the subtree
+/// the same way — same consulted ids, same order — and to no others.
+#[test]
+fn a_cycle_verdict_is_scoped_to_ancestors_that_truncate_identically() {
+    let mut tree = ResolvedTree::default();
+    let mut walker = walker_for_tests(&mut tree);
+    let item = keyed_item(&mut walker, &["cyclic@1.0.0", "dep@1.0.0"]);
+    walker.peers_cache.insert("cyclic@1.0.0".to_string(), vec![item]);
+    let refs = HashMap::default();
+
+    let hit = |walker: &crate::resolve_peers::walker::Walker<'_>,
+               ids: &crate::resolved_tree::AncestorIds| {
+        walker.find_hit(&refs, "cyclic@1.0.0", Some(ids)).is_some()
+    };
+
+    // Unconsulted ancestors are noise: chains differing only in them
+    // truncate identically.
+    assert!(
+        hit(&walker, &ancestors(&[], &["root@1.0.0", "cyclic@1.0.0", "dep@1.0.0"])),
+        "a chain equal on every consulted id reuses the verdict",
+    );
+    assert!(
+        hit(&walker, &ancestors(&[], &["other@2.0.0", "cyclic@1.0.0", "dep@1.0.0"])),
+        "swapping an unconsulted ancestor changes nothing the gate saw",
+    );
+
+    // Everything the gate weighed is load-bearing.
+    assert!(
+        !hit(&walker, &ancestors(&[], &["root@1.0.0"])),
+        "an occurrence whose ancestors do not truncate the subtree must re-walk — \
+         reusing the truncated verdict here is exactly pnpm/pnpm#5108",
+    );
+    assert!(
+        !hit(&walker, &ancestors(&[], &["root@1.0.0", "dep@1.0.0", "cyclic@1.0.0"])),
+        "the gate is order-sensitive, so the key is too",
+    );
+    assert!(
+        !hit(&walker, &ancestors(&[], &["root@1.0.0", "cyclic@1.0.0", "dep@1.0.0", "dep@1.0.0"]),),
+        "an extra occurrence of a consulted id is a different truncation",
+    );
+    assert!(
+        !hit(&walker, &ancestors(&["cyclic@1.0.0", "dep@1.0.0"], &[])),
+        "the same ids on the other side of the base/appended boundary answer \
+         `forms_cycle` differently, so they do not compare equal",
+    );
+    assert!(
+        walker.find_hit(&refs, "cyclic@1.0.0", None).is_none(),
+        "without ancestor ids there is nothing to validate the truncation against",
+    );
+}
+
+#[test]
+fn consulted_pkgs_equality_ignores_capacity_history() {
+    let mut low_first = ConsultedPkgs::default();
+    let mut high_first = ConsultedPkgs::default();
+    low_first.set(3);
+    low_first.set(200);
+    high_first.set(200);
+    high_first.set(3);
+    assert_eq!(low_first, high_first, "insertion order does not change the set");
+    assert!(low_first.contains(3) && low_first.contains(200) && !low_first.contains(64));
+
+    let mut merged = ConsultedPkgs::default();
+    merged.set(3);
+    let mut other = ConsultedPkgs::default();
+    other.set(200);
+    merged.or(&other);
+    assert_eq!(merged, low_first, "or() reaches the same set as direct insertion");
 }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/cache/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/cache/tests.rs
@@ -74,12 +74,13 @@ fn previously_resolved_children_prefers_closest_same_package_ancestor() {
 
 fn keyed_item(
     walker: &mut crate::resolve_peers::walker::Walker<'_>,
-    chain: &[&str],
+    base: &[&str],
+    appended: &[&str],
 ) -> PeersCacheItem {
-    // Consulted set = exactly the ids in `chain`, registered through the
+    // Consulted set = exactly the recorded ids, registered through the
     // walker's bit index the way a real walk would.
     let mut bits = ConsultedPkgs::default();
-    for id in chain {
+    for id in base.iter().chain(appended) {
         let next = walker.consulted_bit_by_pkg.len() as u32;
         let bit = *walker.consulted_bit_by_pkg.entry(Arc::from(*id)).or_insert(next);
         bits.set(bit);
@@ -92,8 +93,8 @@ fn keyed_item(
         subtree_missing_by_pkg: None,
         cycle_key: Some(CycleTruncationKey::new(
             Arc::new(bits),
-            chain.iter().map(|id| Arc::from(*id)).collect(),
-            0,
+            base.iter().chain(appended).map(|id| Arc::from(*id)).collect(),
+            base.len() as u32,
         )),
     }
 }
@@ -107,14 +108,11 @@ fn ancestors(base: &[&str], appended: &[&str]) -> crate::resolved_tree::Ancestor
     )
 }
 
-/// The heart of the cycle-verdict cache: a truncated verdict is handed
-/// back exactly to the occurrences whose ancestors truncate the subtree
-/// the same way — same consulted ids, same order — and to no others.
 #[test]
 fn a_cycle_verdict_is_scoped_to_ancestors_that_truncate_identically() {
     let mut tree = ResolvedTree::default();
     let mut walker = walker_for_tests(&mut tree);
-    let item = keyed_item(&mut walker, &["cyclic@1.0.0", "dep@1.0.0"]);
+    let item = keyed_item(&mut walker, &[], &["cyclic@1.0.0", "dep@1.0.0"]);
     walker.peers_cache.insert("cyclic@1.0.0".to_string(), vec![item]);
     let refs = HashMap::default();
 
@@ -156,6 +154,35 @@ fn a_cycle_verdict_is_scoped_to_ancestors_that_truncate_identically() {
     assert!(
         walker.find_hit(&refs, "cyclic@1.0.0", None).is_none(),
         "without ancestor ids there is nothing to validate the truncation against",
+    );
+}
+
+/// `build_cycle_key` records `base_len > 0` whenever a consulted id sits
+/// in the dependency walk's base half, so mixed keys occur in real walks.
+#[test]
+fn a_mixed_base_and_appended_key_pins_the_boundary() {
+    let mut tree = ResolvedTree::default();
+    let mut walker = walker_for_tests(&mut tree);
+    let item = keyed_item(&mut walker, &["cyclic@1.0.0"], &["dep@1.0.0"]);
+    walker.peers_cache.insert("cyclic@1.0.0".to_string(), vec![item]);
+    let refs = HashMap::default();
+
+    let hit = |walker: &crate::resolve_peers::walker::Walker<'_>,
+               ids: &crate::resolved_tree::AncestorIds| {
+        walker.find_hit(&refs, "cyclic@1.0.0", Some(ids)).is_some()
+    };
+
+    assert!(
+        hit(&walker, &ancestors(&["root@1.0.0", "cyclic@1.0.0"], &["noise@1.0.0", "dep@1.0.0"])),
+        "the same split, padded with unconsulted ids on both halves, matches",
+    );
+    assert!(
+        !hit(&walker, &ancestors(&[], &["cyclic@1.0.0", "dep@1.0.0"])),
+        "the same ids entirely in the appended half are a different truncation",
+    );
+    assert!(
+        !hit(&walker, &ancestors(&["cyclic@1.0.0", "dep@1.0.0"], &[])),
+        "and entirely in the base half likewise",
     );
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/discovery.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/discovery.rs
@@ -117,8 +117,7 @@ pub(crate) struct PeerDiscoveryCaches {
     pub(super) consulted_bit_by_pkg: HashMap<std::sync::Arc<str>, u32>,
     /// Dedupes the consulted sets those keys hold; walks of one package
     /// overwhelmingly weigh the same packages.
-    pub(super) consulted_sets:
-        HashMap<super::cache::ConsultedPkgs, std::sync::Arc<super::cache::ConsultedPkgs>>,
+    pub(super) consulted_sets: HashSet<std::sync::Arc<super::cache::ConsultedPkgs>>,
 }
 
 /// What one peer-hoist discovery pass reports back to the hoist loop —

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/discovery.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/discovery.rs
@@ -111,6 +111,14 @@ pub(crate) struct PeerDiscoveryCaches {
     pub(super) retained_peer_node_ids: HashSet<NodeId>,
     pub(super) peer_provider_children_by_pkg_id: HashMap<String, PeerProviderChildren>,
     pub(super) peer_provider_index_peer_names: HashSet<String>,
+    /// Interprets the bits in every [`PeersCacheItem`]'s
+    /// [`CycleTruncationKey`](super::cache::CycleTruncationKey), so it
+    /// must live exactly as long as the cache items do.
+    pub(super) consulted_bit_by_pkg: HashMap<std::sync::Arc<str>, u32>,
+    /// Dedupes the consulted sets those keys hold; walks of one package
+    /// overwhelmingly weigh the same packages.
+    pub(super) consulted_sets:
+        HashMap<super::cache::ConsultedPkgs, std::sync::Arc<super::cache::ConsultedPkgs>>,
 }
 
 /// What one peer-hoist discovery pass reports back to the hoist loop —

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -2055,9 +2055,9 @@ fn peer_cycle_fixture(
     let mut dependencies_tree = HashMap::default();
     let mut direct = Vec::new();
     let add_direct = |id: &str,
-                          alias: &str,
-                          dependencies_tree: &mut HashMap<NodeId, _>,
-                          direct: &mut Vec<DirectDep>| {
+                      alias: &str,
+                      dependencies_tree: &mut HashMap<NodeId, _>,
+                      direct: &mut Vec<DirectDep>| {
         let node_id = NodeId::next();
         dependencies_tree.insert(
             node_id.clone(),

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -1982,3 +1982,189 @@ fn realizing_children_shares_the_edge_package_id() {
         "the occurrence points at the edge's id instead of owning a copy of it",
     );
 }
+
+/// A ring of `ring_len` packages (`ring00 → ring01 → … → ring00`), each
+/// peering on `p` (provided at the top), with a consumer of peer `w`
+/// hanging off `ring01` and extra `skip` edges (`ringN → ringN+2`) when
+/// asked for. Each entry in `entries` is a direct dep
+/// `(alias, ring index it points at, its own w version)` — the
+/// per-entry `w` keeps one entry's untruncated ring verdicts from
+/// plainly matching another's, which is what forces the walk onto the
+/// cycle-verdict cache. Everything realizes lazily from
+/// `children_by_id`, the way production trees reach the peer walk.
+///
+/// The shape matters: `ring00` re-entered through the full lap has its
+/// `ring01` edge cut — no `w` in that subtree — while `ring00` reached
+/// under a `ring02` entry keeps `ring01` and resolves `w`. Same
+/// package, same `p` context, different truncation, different verdict:
+/// the pair a cycle-verdict cache must never merge.
+fn peer_cycle_fixture(
+    ring_len: usize,
+    entries: &[(&str, usize, &str)],
+    with_skips: bool,
+) -> ResolvedTree {
+    let ring_id = |index: usize| format!("ring{:02}@1.0.0", index % ring_len);
+    let edge = |alias: &str, pkg_id: &str| crate::resolved_tree::ChildEdge {
+        alias: alias.to_string(),
+        pkg_id: Arc::from(pkg_id),
+        optional: false,
+    };
+
+    let mut packages = HashMap::default();
+    let mut children_by_id: HashMap<Arc<str>, Arc<Vec<crate::resolved_tree::ChildEdge>>> =
+        HashMap::default();
+    for index in 0..ring_len {
+        let name = format!("ring{index:02}");
+        packages.insert(Arc::from(ring_id(index)), package(&name, "1.0.0", &[("p", "*")], false));
+        let mut edges = vec![edge("next", &ring_id(index + 1))];
+        if with_skips {
+            edges.push(edge("skip", &ring_id(index + 2)));
+        }
+        if with_skips && index % 2 == 0 && index != 0 {
+            // Every even member also re-enters the ring's entry, so one
+            // lap re-enters the cycle many times — each re-entry a
+            // truncated verdict whose subtree the cache can skip.
+            edges.push(edge("home", &ring_id(0)));
+        }
+        if with_skips && index % 2 == 0 {
+            // Fanout under the transferable members: what a cache hit
+            // saves is realizing the hit node's children, so the win
+            // only counts when there are children worth skipping.
+            for fan in 0..30 {
+                let fan_pkg = format!("fan{index:02}x{fan:02}@1.0.0");
+                packages.insert(
+                    Arc::from(&*fan_pkg),
+                    package(&format!("fan{index:02}x{fan:02}"), "1.0.0", &[("p", "*")], false),
+                );
+                children_by_id.insert(Arc::from(&*fan_pkg), Arc::new(Vec::new()));
+                edges.push(edge(&format!("fan{fan:02}"), &fan_pkg));
+            }
+        }
+        if index % 2 == 1 {
+            // Odd members consume `w`, so every untruncated verdict —
+            // and every keyless cached item — carries the entry's own
+            // `w` and never transfers across entries. Even members'
+            // cycle-truncated verdicts stay `{p}`-only and transferable.
+            edges.push(edge("wc", "wc@1.0.0"));
+        }
+        children_by_id.insert(Arc::from(ring_id(index)), Arc::new(edges));
+    }
+    packages.insert(Arc::from("wc@1.0.0"), package("wc", "1.0.0", &[("w", "*")], false));
+    packages.insert(Arc::from("p@1.0.0"), package("p", "1.0.0", &[], true));
+
+    let mut dependencies_tree = HashMap::default();
+    let mut direct = Vec::new();
+    let add_direct = |id: &str,
+                          alias: &str,
+                          dependencies_tree: &mut HashMap<NodeId, _>,
+                          direct: &mut Vec<DirectDep>| {
+        let node_id = NodeId::next();
+        dependencies_tree.insert(
+            node_id.clone(),
+            crate::resolved_tree::DependenciesTreeNode::new(
+                Arc::from(id),
+                crate::resolved_tree::TreeChildren::Lazy {
+                    parent_ids: Arc::new(Vec::new()).into(),
+                },
+                0,
+                true,
+            ),
+        );
+        direct.push(DirectDep { alias: alias.to_string(), node_id, id: id.to_string() });
+    };
+    add_direct("p@1.0.0", "p", &mut dependencies_tree, &mut direct);
+    for (alias, ring_index, w_version) in entries {
+        let entry_pkg = format!("{alias}@1.0.0");
+        let w_pkg = format!("w@{w_version}");
+        packages.entry(Arc::from(&*w_pkg)).or_insert_with(|| package("w", w_version, &[], true));
+        packages.insert(Arc::from(&*entry_pkg), package(alias, "1.0.0", &[], false));
+        children_by_id.insert(
+            Arc::from(&*entry_pkg),
+            Arc::new(vec![edge("ring", &ring_id(*ring_index)), edge("w", &w_pkg)]),
+        );
+        add_direct(&entry_pkg, alias, &mut dependencies_tree, &mut direct);
+    }
+
+    ResolvedTree {
+        direct,
+        packages,
+        dependencies_tree,
+        all_peer_dep_names: HashSet::from_iter(["p".to_string(), "w".to_string()]),
+        policy_violations: Vec::new(),
+        applied_patches: HashSet::default(),
+        children_by_id,
+    }
+}
+
+/// End-to-end guard for the reuse boundary, through outputs alone.
+///
+/// The first entry's lap stores the cycle-truncated `ring00` verdict —
+/// externals `{p}`, no `w`, because the truncation cut `ring01`. The
+/// second entry reaches `ring00` under `ring02` with an intact
+/// `ring01`, and its untruncated verdicts can't reuse the first entry's
+/// (its `w` differs), so the lookup lands exactly on the truncated
+/// keyed entry. A key that under-collects what the walk consulted — the
+/// failure mode of a misplaced walk frame — accepts it, and the second
+/// entry's `ring00` silently loses its `w`. This is pnpm/pnpm#5108 as a
+/// fixture.
+#[test]
+fn one_context_keeps_both_truncations_of_a_cycle_package_apart() {
+    let mut tree =
+        peer_cycle_fixture(4, &[("entry00", 0, "1.0.0"), ("entry01", 2, "2.0.0")], false);
+    let result = resolve_peers(&mut tree, ResolvePeersOptions::default());
+
+    assert!(
+        result.peer_dependency_issues.missing.is_empty(),
+        "unexpected missing peers: {:#?}",
+        result.peer_dependency_issues.missing,
+    );
+    let ring00_variants: Vec<&str> = result
+        .graph
+        .keys()
+        .map(pacquet_deps_path::DepPath::as_str)
+        .filter(|path| path.starts_with("ring00@1.0.0"))
+        .collect();
+    assert!(
+        ring00_variants.iter().any(|path| path.contains("w@2.0.0")),
+        "ring00 under the second entry sees ring01 untruncated and must keep          that entry's w — reusing the first entry's truncated verdict here is          pnpm/pnpm#5108; got {ring00_variants:?}",
+    );
+    assert!(
+        ring00_variants.iter().any(|path| path.contains("w@1.0.0")),
+        "ring00 under the first entry keeps its own w; got {ring00_variants:?}",
+    );
+}
+
+/// The integrity bound behind pnpm/pnpm#13681: a cycle re-walked under
+/// ancestors that truncate it identically must be a cache hit. Each
+/// entry's own `w` blocks plain reuse of the untruncated verdicts, so
+/// every entry re-enters the ring — but the lap's cycle-truncated
+/// verdicts repeat the same consulted chains, and all entries after the
+/// first resolve the lap from the cache. Uncached, every entry pays the
+/// whole lap again and the occurrence count multiplies past the bound.
+/// Deterministic, no wall clocks.
+#[test]
+fn cycle_re_walks_collapse_instead_of_multiplying_occurrences() {
+    // Each entry provides its own `w`, so nothing untruncated transfers
+    // across entries and only the cycle-verdict cache can collapse the
+    // repeated laps.
+    let names: Vec<(String, String)> =
+        (0..12).map(|index| (format!("entry{index:02}"), format!("{index}.0.0"))).collect();
+    let entries: Vec<(&str, usize, &str)> =
+        names.iter().map(|(alias, version)| (alias.as_str(), 0, version.as_str())).collect();
+    let mut tree = peer_cycle_fixture(10, &entries, true);
+    let result = resolve_peers(&mut tree, ResolvePeersOptions::default());
+
+    assert!(
+        result.peer_dependency_issues.missing.is_empty(),
+        "the bound only means something for a healthy resolution",
+    );
+    let occurrences = tree.dependencies_tree.len();
+    // The cached walk realizes ~2,230 occurrences here; with cycle-verdict
+    // reuse disabled it realizes ~4,360. The bound sits between, with
+    // headroom for fixture-neutral resolver changes on the cached side.
+    let bound = 3000;
+    assert!(
+        occurrences < bound,
+        "peer walk realized {occurrences} occurrence nodes (bound {bound});          the cycle-verdict cache has stopped collapsing re-walks",
+    );
+}

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
@@ -956,13 +956,14 @@ impl Walker<'_> {
             parent.or(frame);
         }
         // Without the occurrence's ancestor ids there is nothing to scope
-        // a truncated verdict to, so it stays uncached exactly as before.
+        // a truncated verdict to, so it stays uncached.
         let cycle_key = match (resolved_through_cycle, truncation_ids.as_ref(), frame.as_ref()) {
             (true, Some(ids), Some(frame)) => Some(self.build_cycle_key(ids, frame)),
             _ => None,
         };
         if resolved_through_cycle && cycle_key.is_none() {
-            // Leave both caches untouched, as before.
+            // A truncated verdict with no scope must not be reused
+            // anywhere, so neither cache records it.
         } else if !resolved_through_cycle && is_pure {
             self.pure_pkgs
                 .insert(std::sync::Arc::<str>::clone(&pkg.id).to_string(), dep_path.clone());

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
@@ -143,7 +143,7 @@ pub(super) struct Walker<'tree> {
     /// frame covers the outer walk's whole subtree.
     consulted_stack: Vec<ConsultedPkgs>,
     /// Dedupes the consulted sets stored on cycle-truncation keys.
-    consulted_sets: HashMap<ConsultedPkgs, Arc<ConsultedPkgs>>,
+    consulted_sets: HashSet<Arc<ConsultedPkgs>>,
     pub(super) empty_resolved_peers: Arc<HashMap<String, NodeId>>,
     pub(super) empty_missing_peers: Arc<HashMap<String, MissingPeerInfo>>,
 }
@@ -275,27 +275,36 @@ impl<'tree> Walker<'tree> {
     /// the occurrence's ancestor chain restricted to what the walk's
     /// gate weighed.
     fn build_cycle_key(&mut self, ids: &AncestorIds, frame: &ConsultedPkgs) -> CycleTruncationKey {
-        let consulted = |bit_by_pkg: &HashMap<Arc<str>, u32>, id: &str| {
-            bit_by_pkg.get(id).is_some_and(|bit| frame.contains(*bit))
-        };
         let mut chain: Vec<Arc<str>> = Vec::new();
         let mut base_len = 0u32;
-        for id in ids.base_ids() {
-            if consulted(&self.consulted_bit_by_pkg, id) {
-                chain.push(Arc::from(id));
-                base_len += 1;
+        {
+            let bit_by_pkg = &self.consulted_bit_by_pkg;
+            // The bit index already owns an `Arc` for every consulted id,
+            // so the chain shares those instead of allocating copies.
+            let push_if_consulted = |chain: &mut Vec<Arc<str>>, id: &str| {
+                let Some((interned, bit)) = bit_by_pkg.get_key_value(id) else {
+                    return false;
+                };
+                if !frame.contains(*bit) {
+                    return false;
+                }
+                chain.push(Arc::clone(interned));
+                true
+            };
+            for id in ids.base_ids() {
+                if push_if_consulted(&mut chain, id) {
+                    base_len += 1;
+                }
             }
-        }
-        for id in ids.appended_ids() {
-            if consulted(&self.consulted_bit_by_pkg, id) {
-                chain.push(Arc::from(id));
+            for id in ids.appended_ids() {
+                push_if_consulted(&mut chain, id);
             }
         }
         let shared = if let Some(hit) = self.consulted_sets.get(frame) {
             Arc::clone(hit)
         } else {
             let arc = Arc::new(frame.clone());
-            self.consulted_sets.insert(frame.clone(), Arc::clone(&arc));
+            self.consulted_sets.insert(Arc::clone(&arc));
             arc
         };
         CycleTruncationKey::new(shared, chain, base_len)

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
@@ -11,8 +11,8 @@ use crate::{
     resolve_peers::{
         ResolvePeersOptions, ResolvePeersResult,
         cache::{
-            CacheHitContext, DeferredChildContext, PeerProviderChildren, PeersCacheItem,
-            merge_realize_undo,
+            CacheHitContext, ConsultedPkgs, CycleTruncationKey, DeferredChildContext,
+            PeerProviderChildren, PeersCacheItem, merge_realize_undo,
         },
         context::{
             CurrentProviderSource, ParentPkgInfo, ParentRef, ParentRefs, SharedChain,
@@ -23,7 +23,9 @@ use crate::{
         discovery::PeerDiscoveryCaches,
         finalize::{NodeRecord, PendingPeerEdge, WalkedNode},
     },
-    resolved_tree::{ChildEdge, DirectDep, PeerDep, ResolvedPackage, ResolvedTree, TreeChildren},
+    resolved_tree::{
+        AncestorIds, ChildEdge, DirectDep, PeerDep, ResolvedPackage, ResolvedTree, TreeChildren,
+    },
 };
 use pacquet_deps_path::{
     DepPath, PeerId, create_peer_dep_graph_hash, index_of_dep_path_suffix,
@@ -131,6 +133,17 @@ pub(super) struct Walker<'tree> {
     packages_by_id: HashMap<String, Arc<ResolvedPackage>>,
     pub(super) peer_provider_children_by_pkg_id: HashMap<String, PeerProviderChildren>,
     peer_provider_index_peer_names: HashSet<String>,
+    /// `pkg id → bit` behind [`ConsultedPkgs`]. Persists with the
+    /// peers cache across walker instances — the bits in stored keys
+    /// mean nothing without it.
+    pub(super) consulted_bit_by_pkg: HashMap<Arc<str>, u32>,
+    /// One frame per full walk in progress. Realization marks the
+    /// packages the cycle gate weighs in the innermost frame; a
+    /// finished walk folds its frame into its parent's, so an outer
+    /// frame covers the outer walk's whole subtree.
+    consulted_stack: Vec<ConsultedPkgs>,
+    /// Dedupes the consulted sets stored on cycle-truncation keys.
+    consulted_sets: HashMap<ConsultedPkgs, Arc<ConsultedPkgs>>,
     pub(super) empty_resolved_peers: Arc<HashMap<String, NodeId>>,
     pub(super) empty_missing_peers: Arc<HashMap<String, MissingPeerInfo>>,
 }
@@ -152,6 +165,8 @@ impl<'tree> Walker<'tree> {
             retained_peer_node_ids,
             mut peer_provider_children_by_pkg_id,
             mut peer_provider_index_peer_names,
+            consulted_bit_by_pkg,
+            consulted_sets,
         } = caches;
         if peer_provider_index_peer_names != tree.all_peer_dep_names {
             peer_provider_children_by_pkg_id.clear();
@@ -212,6 +227,9 @@ impl<'tree> Walker<'tree> {
             packages_by_id: HashMap::default(),
             peer_provider_children_by_pkg_id,
             peer_provider_index_peer_names,
+            consulted_bit_by_pkg,
+            consulted_stack: Vec::new(),
+            consulted_sets,
             empty_resolved_peers: Arc::new(HashMap::default()),
             empty_missing_peers: Arc::new(HashMap::default()),
         }
@@ -226,7 +244,61 @@ impl<'tree> Walker<'tree> {
             retained_peer_node_ids: self.retained_peer_node_ids,
             peer_provider_children_by_pkg_id: self.peer_provider_children_by_pkg_id,
             peer_provider_index_peer_names: self.peer_provider_index_peer_names,
+            consulted_bit_by_pkg: self.consulted_bit_by_pkg,
+            consulted_sets: self.consulted_sets,
         }
+    }
+
+    /// Record that realizing (or re-reading the realization of)
+    /// `pkg_id`'s children weighed `pkg_id` and every one of its child
+    /// edge targets against the ancestor chain. Feeds the innermost
+    /// walk frame; see [`Walker::consulted_stack`].
+    pub(super) fn mark_realization_consulted(&mut self, pkg_id: &Arc<str>) {
+        if self.consulted_stack.is_empty() {
+            return;
+        }
+        let edges = self.tree.children_by_id.get(&**pkg_id).cloned();
+        let mut mark = |id: &Arc<str>| {
+            let next = self.consulted_bit_by_pkg.len() as u32;
+            let bit = *self.consulted_bit_by_pkg.entry(Arc::clone(id)).or_insert(next);
+            if let Some(frame) = self.consulted_stack.last_mut() {
+                frame.set(bit);
+            }
+        };
+        mark(pkg_id);
+        for edge in edges.iter().flat_map(|edges| edges.iter()) {
+            mark(&edge.pkg_id);
+        }
+    }
+
+    /// The [`CycleTruncationKey`] scoping this walk's truncated verdict:
+    /// the occurrence's ancestor chain restricted to what the walk's
+    /// gate weighed.
+    fn build_cycle_key(&mut self, ids: &AncestorIds, frame: &ConsultedPkgs) -> CycleTruncationKey {
+        let consulted = |bit_by_pkg: &HashMap<Arc<str>, u32>, id: &str| {
+            bit_by_pkg.get(id).is_some_and(|bit| frame.contains(*bit))
+        };
+        let mut chain: Vec<Arc<str>> = Vec::new();
+        let mut base_len = 0u32;
+        for id in ids.base_ids() {
+            if consulted(&self.consulted_bit_by_pkg, id) {
+                chain.push(Arc::from(id));
+                base_len += 1;
+            }
+        }
+        for id in ids.appended_ids() {
+            if consulted(&self.consulted_bit_by_pkg, id) {
+                chain.push(Arc::from(id));
+            }
+        }
+        let shared = if let Some(hit) = self.consulted_sets.get(frame) {
+            Arc::clone(hit)
+        } else {
+            let arc = Arc::new(frame.clone());
+            self.consulted_sets.insert(frame.clone(), Arc::clone(&arc));
+            arc
+        };
+        CycleTruncationKey::new(shared, chain, base_len)
     }
 }
 
@@ -525,6 +597,13 @@ impl Walker<'_> {
         parent_node_ids: &SharedChain<NodeId>,
         parent_pkg_ids_chain: &SharedChain<String>,
     ) -> NodeOutput {
+        // The cycle gate in `realize_children_with` truncates against these,
+        // so they identify the subtree this walk will actually see. Captured
+        // before realization flips the node to `Realized` and drops them.
+        let truncation_ids = match &self.tree.dependencies_tree.get(node_id).map(|n| &n.children) {
+            Some(TreeChildren::Lazy { parent_ids }) => Some(parent_ids.clone()),
+            _ => None,
+        };
         // `purePkgs` fast-path. When the subtree below this
         // `pkgIdWithPatchHash` resolved with zero external peers and
         // zero missing peers on a previous walk, AND this package
@@ -621,6 +700,10 @@ impl Walker<'_> {
             )
         };
         let pkg = self.owned_package(&pkg_id);
+        // From here on every gate consultation — the provider preview
+        // below included — feeds this walk's truncation key. Every exit
+        // past this point pops the frame.
+        self.consulted_stack.push(ConsultedPkgs::default());
         let (provider_children, preview_undo) = self.preview_peer_provider_children(node_id);
         let (pkg_name, _pkg_version) = pkg_name_version(&pkg.result);
         let ChildParentRefs {
@@ -662,8 +745,23 @@ impl Walker<'_> {
         // view) because a node's own children count as parents for
         // its own descendants' peer resolution.
         let cached =
-            self.find_hit(&child_parent_refs, &pkg.id).map(PeersCacheItem::to_cached_node_output);
-        if let Some(cached) = cached {
+            self.find_hit(&child_parent_refs, &pkg.id, truncation_ids.as_ref()).map(|item| {
+                (
+                    item.to_cached_node_output(),
+                    item.cycle_key.as_ref().map(|key| Arc::clone(key.consulted())),
+                )
+            });
+        if let Some((cached, consulted)) = cached {
+            // The reused verdict's chain-dependence becomes the caller's:
+            // whatever the recorded walk weighed, the walks above this
+            // node now transitively depend on.
+            let mut frame = self.consulted_stack.pop().unwrap_or_default();
+            if let Some(consulted) = consulted {
+                frame.or(&consulted);
+            }
+            if let Some(parent) = self.consulted_stack.last_mut() {
+                parent.or(&frame);
+            }
             return self.finish_cache_hit(
                 cached,
                 CacheHitContext {
@@ -830,16 +928,33 @@ impl Walker<'_> {
         // A cycle re-entry resolves against truncated children (the cycle is
         // broken by dropping the repeated package's subtree), so its empty or
         // partial peer sets are not authoritative for the package as a whole.
-        // Caching that verdict would let it short-circuit other occurrences
-        // that can see the full subtree, dropping their
+        // Caching that verdict *unconditionally* would let it short-circuit
+        // other occurrences that can see the full subtree, dropping their
         // `transitivePeerDependencies` depending on traversal order and
         // churning the lockfile (https://github.com/pnpm/pnpm/issues/5108).
+        //
+        // What the truncation depends on, though, is the ancestor chain: the
+        // gate in `realize_children_with` drops exactly the edges the chain
+        // already contains. So the verdict is authoritative for every
+        // occurrence reached through the same chain, and the entry carries
+        // that chain so `find_hit` can hand it back to those and no others.
+        // Dropping them entirely is what made this cache miss 999 lookups in
+        // 1000 on a peer-cyclic graph, since almost every walk of one ends in
+        // a cycle.
         let resolved_through_cycle = parent_pkg_ids_chain.contains_str(&pkg.id);
-        if resolved_through_cycle {
-            // Leave both caches untouched so later occurrences re-resolve (or
-            // hit the authoritative entry of the same package) instead of
-            // reusing this partial one.
-        } else if is_pure {
+        let frame = self.consulted_stack.pop();
+        if let (Some(frame), Some(parent)) = (frame.as_ref(), self.consulted_stack.last_mut()) {
+            parent.or(frame);
+        }
+        // Without the occurrence's ancestor ids there is nothing to scope
+        // a truncated verdict to, so it stays uncached exactly as before.
+        let cycle_key = match (resolved_through_cycle, truncation_ids.as_ref(), frame.as_ref()) {
+            (true, Some(ids), Some(frame)) => Some(self.build_cycle_key(ids, frame)),
+            _ => None,
+        };
+        if resolved_through_cycle && cycle_key.is_none() {
+            // Leave both caches untouched, as before.
+        } else if !resolved_through_cycle && is_pure {
             self.pure_pkgs
                 .insert(std::sync::Arc::<str>::clone(&pkg.id).to_string(), dep_path.clone());
         } else {
@@ -853,6 +968,7 @@ impl Walker<'_> {
                     missing_peers: Arc::clone(&all_missing_peers),
                     missing_peers_of_children: Arc::clone(&missing_from_children),
                     subtree_missing_by_pkg: subtree_missing_by_pkg.clone(),
+                    cycle_key,
                 });
         }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolved_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolved_tree.rs
@@ -74,6 +74,16 @@ pub struct AncestorIds {
 }
 
 impl AncestorIds {
+    /// The dependency walk's contiguous base ids, in order.
+    pub fn base_ids(&self) -> impl Iterator<Item = &str> {
+        self.base.iter().map(String::as_str)
+    }
+
+    /// The ids peer discovery appended after the base, in order.
+    pub fn appended_ids(&self) -> impl Iterator<Item = &str> {
+        self.appended.iter().map(|id| &**id)
+    }
+
     #[must_use]
     pub fn pushed(&self, id: String) -> Self {
         let mut appended = Vec::with_capacity(self.appended.len() + 1);


### PR DESCRIPTION
The third and largest piece of #13681, addressing what the first two PRs (#13844, #13855) deliberately left alone: the occurrence explosion itself.

### The problem

A walk that re-enters a package already on its ancestor chain resolves against a truncated subtree, so its verdict has never been cached — reusing it where the subtree is intact drops `transitivePeerDependencies` depending on traversal order (#5108). On a peer-cyclic graph this rule makes the peers cache inert. Resolving [bit](https://github.com/teambit/bit)'s env packages:

```
full walks:            188,707   (91% end in a cycle)
peers-cache hits:          155   of 188,862 lookups  (0.08%)
occurrence nodes:    2,008,130   for a 6,133-node graph
```

### The insight, measured before designed

The truncation is not arbitrary: `realize_children_with` drops exactly the edges `forms_cycle` finds in the occurrence's own ancestor ids. So a truncated verdict is a function of *(package, peer context, the chain entries the gate actually weighs)* — and everything else in the chain is noise. I instrumented the workload to check how much noise:

| candidate key | distinct keys / 171,508 cycle walks |
| --- | --- |
| full ancestor chain | 68,184 (2.5×) — and implemented honestly, memory got *worse* |
| chain ∩ reachable-set | 68,180 — useless, the cluster is one giant SCC |
| **chain ∩ consulted ids** | **~1,900 (91×)** |

### The mechanism

- Every full walk keeps a `ConsultedPkgs` frame — a bitset over interned package ids. Realization marks the package whose children are realized plus every child edge target (precisely the `forms_cycle` arguments); reusing an already-realized children map marks the same ids, since the map embodies the same answers. Finished walks fold their frame into their parent's; a cache hit folds the stored entry's set in. An outer frame therefore covers the dependence of everything under it.
- Cycle-resolved verdicts are now stored, tagged with a `CycleTruncationKey`: the consulted set plus the occurrence's ancestor ids restricted to it (base entries first — `forms_cycle` treats the halves differently, so the boundary is part of the key).
- `find_hit` hands a tagged verdict only to an occurrence whose ancestors, restricted to the entry's consulted set, are exactly the recorded chain. Equal restrictions ⇒ every gate answer equal ⇒ same realization, same truncation, same verdict, by induction on the walk. Non-matching occurrences — in particular ones whose ancestors don't truncate the subtree at all, the #5108 shape — re-walk exactly as before.

### Results

Same replayed install as the previous PRs (5 importers, 3,807 merged packages), alternating A/B:

| | peak RSS | wall time |
| --- | --- | --- |
| `main` | 3043 / 3056 / 3042 MB | 59 / 39 / 42 s |
| this branch | 1405 / 1416 / 1415 MB | 20 / 25 / 20 s |

**3047 → 1412 MB (−54%), roughly 2× faster.** Walk counts: full walks 188,707 → 33,648; cycle walks 171,508 → 16,563; the keyed entries hit 44,999 times. Cumulative across the three PRs the install has gone **3670 → 1412 MB (−62%)**.

### Correctness

This is the change #5108 exists to be afraid of, so I want to be explicit about the evidence and its limits.

- **328 tests pass**, including new ones that pin the key's semantics from both directions: unconsulted ancestors are noise (reuse happens), while order changes, extra occurrences, base/appended boundary moves, and — critically — *an occurrence whose ancestors don't truncate the subtree* all refuse reuse.
- **Repeat installs never churn.** Fixed-point checked both ways: the unmodified engine, handed this branch's lockfile as `wanted`, preserves it byte for byte; this branch preserves `main`'s lockfile byte for byte. Lockfile churn on repeat installs is the #5108 regression, and it cannot happen here.
- **Cold output is deterministic** — three cold runs, byte-identical.
- **Cold output differs from `main` in 13 snapshot entries** (52 diff lines of ~86k), all in the `@teambit/component → command-bar/pubsub/ui` cluster — the exact entries that already flip between *identical stock runs* (#13846, 96–197-line diffs). The branch picks a different valid peer variant there; the fixed-point check is what shows it is valid. I want to flag this honestly rather than bury it: if byte-identical cold output against current `main` is a hard requirement even inside the known-nondeterministic cluster, this needs a maintainer call.
- `cargo clippy --all-targets`, `cargo fmt`, and `cargo dylint` clean across the workspace.

### What I'd take a steer on

The one hole I know of and did not close: keyless (non-cycle) items whose subtrees *contain* cycle-resolved descendants re-entering ancestors **above** them embed chain-dependence today, on `main`, and are reused with ctx checks only. That is pre-existing behavior — this PR neither introduces nor widens it — and I suspect it is the root of #13846. Happy to attack it as a follow-up with the same consulted-set machinery (tagging any item whose frame intersects its chain).

Refs #13681

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13859"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789125506&installation_model_id=426870&pr_number=13859&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13859&signature=9993d183d46125bc22bc44efa3a84637e041291a053a05b672516ed3bc6e28ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved peer-dependency resolution speed and reduced memory usage.
  * Added safe caching for reusable cycle-resolution results, including lazy resolution paths.
* **Bug Fixes**
  * Prevented cached cycle results from being reused when dependency ancestry or consulted packages differ, improving resolution accuracy.
* **Tests**
  * Added coverage for cache matching across dependency orders, duplicates, ancestry boundaries, and repeated cycle traversals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->