### PR TITLE
fix(config): make deleting an unset setting a no-op

### DIFF
--- a/.changeset/olive-doors-smoke.md
+++ b/.changeset/olive-doors-smoke.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/workspace.workspace-manifest-writer": patch
+"pnpm": patch
+---
+
+`pnpm config delete <key>` no longer fails with `ENOENT` when the config file it would edit does not exist. Clearing a setting that was never set is a no-op [#13651](https://github.com/pnpm/pnpm/issues/13651).

--- a/pnpm/crates/workspace-manifest-writer/src/tests.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/tests.rs
@@ -1153,6 +1153,12 @@ fn delete_unset_field_is_noop() {
     assert_eq!(parsed["cacheDir"], serde_json::json!("~/cache"));
 }
 
+#[test]
+fn delete_field_without_a_manifest_is_noop() {
+    let out = run_update_field(None, "virtualStoreDir", &serde_json::Value::Null);
+    assert_eq!(out, None);
+}
+
 /// Ported from upstream `removeCatalogs.test.ts`. The upstream tests
 /// assert the parsed shape; these assert the format-preserving text the
 /// pacquet writer produces for the same inputs.

--- a/pnpm11/config/commands/test/configDelete.test.ts
+++ b/pnpm11/config/commands/test/configDelete.test.ts
@@ -123,3 +123,35 @@ test('config delete on pnpm-specific key set', async () => {
 
   expect(fs.readdirSync(configDir)).not.toContain('config.yaml')
 })
+
+test('config delete on a project key when the project has no pnpm-workspace.yaml', async () => {
+  const tmp = tempDir()
+  const configDir = path.join(tmp, 'global-config')
+  fs.mkdirSync(configDir, { recursive: true })
+
+  await config.handler(createConfigCommandOpts({
+    dir: tmp,
+    cliOptions: {},
+    configDir,
+    location: 'project',
+    authConfig: {},
+  }), ['delete', 'virtual-store-dir'])
+
+  expect(fs.readdirSync(tmp)).not.toContain('pnpm-workspace.yaml')
+})
+
+test('config delete on a global key when there is no config.yaml', async () => {
+  const tmp = tempDir()
+  const configDir = path.join(tmp, 'global-config')
+  fs.mkdirSync(configDir, { recursive: true })
+
+  await config.handler(createConfigCommandOpts({
+    dir: tmp,
+    cliOptions: {},
+    configDir,
+    global: true,
+    authConfig: {},
+  }), ['delete', 'store-dir'])
+
+  expect(fs.readdirSync(configDir)).not.toContain('config.yaml')
+})

--- a/pnpm11/workspace/workspace-manifest-writer/src/index.ts
+++ b/pnpm11/workspace/workspace-manifest-writer/src/index.ts
@@ -81,14 +81,18 @@ export async function updateWorkspaceManifest (dir: string, opts: {
   const updatedFields = { ...opts.updatedFields }
 
   for (const [key, value] of Object.entries(updatedFields)) {
-    if (!equals(manifest[key as keyof WorkspaceManifest], value)) {
+    if (value == null) {
+      // Clearing a field the manifest never had changes nothing. Counting it as
+      // an update would take the empty-manifest branch below and try to remove a
+      // file that may not exist.
+      if (!Object.hasOwn(manifest, key)) continue
       shouldBeUpdated = true
-      if (value == null) {
-        delete manifest[key as keyof WorkspaceManifest]
-      } else {
-        manifest[key as keyof WorkspaceManifest] = value
-      }
+      delete manifest[key as keyof WorkspaceManifest]
+      continue
     }
+    if (equals(manifest[key as keyof WorkspaceManifest], value)) continue
+    shouldBeUpdated = true
+    manifest[key as keyof WorkspaceManifest] = value
   }
   if (opts.updatedOverrides) {
     manifest.overrides ??= {}


### PR DESCRIPTION
## Summary

`pnpm config delete <key>` fails instead of doing nothing when the file it would edit does not exist:

```console
$ pnpm config delete virtualStoreDir
ENOENT: no such file or directory, lstat '<dir>/pnpm-workspace.yaml'
```

`updateWorkspaceManifest` decided whether anything changed with `equals(manifest[key], value)`. Deleting passes `null`, and an absent field reads as `undefined`, so `equals(undefined, null)` — `false` — flagged the write as needed even though nothing had changed. The manifest was then empty, which takes the remove-the-file branch, and `rm` ran against a file that never existed.

Clearing a field the manifest does not have is now skipped, so the write never starts. That also stops `pnpm config set` from creating a file when the value it would write is already there.

Both locations were affected — the project `pnpm-workspace.yaml` and the global `config.yaml` — and there is a regression test for each.

pacquet needs no change: `remove_top_level_field` reports no change for an absent key, so `update_manifest_field` returns before writing, and its removal path already treats a missing file as success. Added a Rust test pinning that, since it is the behaviour this PR restores parity with.

Closes pnpm/pnpm#13651

## Squash Commit Body

```text
`updateWorkspaceManifest` compared the field's current value against the
new one with `equals(undefined, null)`, which is `false`, so clearing a
field the manifest never had still counted as a change. The manifest was
then empty, which takes the remove-the-file path, and `rm` ran against a
file that never existed:

    pnpm config delete virtualStoreDir
    ENOENT: no such file or directory, lstat '<dir>/pnpm-workspace.yaml'

Skip the field instead when there is nothing to clear. That also stops
`pnpm config set` from writing a file when the value it would set is
already there.

pacquet is unaffected: `remove_top_level_field` reports no change for an
absent key, and its removal path already tolerates a missing file. A
regression test pins that.

Closes pnpm/pnpm#13651
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13861"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789126705&installation_model_id=426870&pr_number=13861&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13861&signature=a79604ee615e2dd27767b59f0f50b2f26876fddb6dce79ab7655987cfdac2caf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `pnpm config delete <key>` now succeeds when the configuration file or setting does not exist.
  * Deleting an unset workspace or global setting no longer creates an empty configuration file.
  * Existing configuration fields are correctly removed when requested.

* **Tests**
  * Added coverage for missing workspace and global configuration files.
  * Added regression tests for deleting fields from unavailable workspace manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->