### PR TITLE
fix(config): report kebab-case keys in the global config.yaml

### DIFF
--- a/.changeset/quiet-pugs-invent.md
+++ b/.changeset/quiet-pugs-invent.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config.reader": patch
+"pnpm": patch
+---
+
+A setting written in kebab-case in the global `config.yaml` is now reported instead of being silently ignored [#13650](https://github.com/pnpm/pnpm/issues/13650).

--- a/pnpm11/config/reader/src/index.ts
+++ b/pnpm11/config/reader/src/index.ts
@@ -321,15 +321,27 @@ export async function getConfig (opts: {
     // Consumed by loadNpmrcConfig above; drop so it isn't flagged as unknown.
     delete (globalYamlConfig as unknown as Record<string, unknown>)._auth
     const ignoredKeys: string[] = []
+    // This gate is kebab-based, but the settings that survive it are picked up
+    // in camelCase. A kebab spelling would pass here and be dropped without a
+    // word, so it is reported instead — with the spelling that works.
+    const kebabKeys: string[] = []
     for (const key in globalYamlConfig) {
       if (!isConfigFileKey(kebabCase(key))) {
         ignoredKeys.push(key)
         delete globalYamlConfig[key as keyof typeof globalYamlConfig]
+      } else if (!isCamelCase(key)) {
+        kebabKeys.push(key)
+        delete globalYamlConfig[key as keyof typeof globalYamlConfig]
       }
     }
-    if (ignoredKeys.length > 0) {
+    if (ignoredKeys.length > 0 || kebabKeys.length > 0) {
       const globalYamlConfigPath = getGlobalConfigPath(configDir)
-      warnings.push(`The following settings cannot be set in the global config file ("${globalYamlConfigPath}") and were ignored: ${ignoredKeys.map(k => `"${k}"`).join(', ')}. Move them to a project-level pnpm-workspace.yaml. To share these settings across projects, use config dependencies: https://pnpm.io/11.x/config-dependencies`)
+      if (ignoredKeys.length > 0) {
+        warnings.push(`The following settings cannot be set in the global config file ("${globalYamlConfigPath}") and were ignored: ${ignoredKeys.map(k => `"${k}"`).join(', ')}. Move them to a project-level pnpm-workspace.yaml. To share these settings across projects, use config dependencies: https://pnpm.io/11.x/config-dependencies`)
+      }
+      if (kebabKeys.length > 0) {
+        warnings.push(`The following settings in the global config file ("${globalYamlConfigPath}") were ignored because they are not written in camelCase: ${kebabKeys.map(k => `"${k}" (use "${camelcase(k)}")`).join(', ')}.`)
+      }
     }
     addSettingsFromWorkspaceManifestToConfig(pnpmConfig, {
       configFromCliOpts,

--- a/pnpm11/config/reader/src/index.ts
+++ b/pnpm11/config/reader/src/index.ts
@@ -321,9 +321,7 @@ export async function getConfig (opts: {
     // Consumed by loadNpmrcConfig above; drop so it isn't flagged as unknown.
     delete (globalYamlConfig as unknown as Record<string, unknown>)._auth
     const ignoredKeys: string[] = []
-    // This gate is kebab-based, but the settings that survive it are picked up
-    // in camelCase. A kebab spelling would pass here and be dropped without a
-    // word, so it is reported instead — with the spelling that works.
+    // The gate below is kebab-based, but only camelCase keys are picked up later.
     const kebabKeys: string[] = []
     for (const key in globalYamlConfig) {
       if (!isConfigFileKey(kebabCase(key))) {

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -3802,6 +3802,33 @@ describe('global config.yaml', () => {
     expect(config.dangerouslyAllowAllBuilds).toBeDefined()
   })
 
+  test('warns about a kebab-case key in the global config.yaml', async () => {
+    prepareEmpty()
+
+    fs.mkdirSync('.config/pnpm', { recursive: true })
+    writeYamlFileSync('.config/pnpm/config.yaml', {
+      'state-dir': path.resolve('kebab-state'),
+      storeDir: path.resolve('camel-store'),
+    })
+
+    process.env.XDG_CONFIG_HOME = path.resolve('.config')
+
+    const { config, warnings } = await getConfig({
+      cliOptions: {},
+      packageManager: {
+        name: 'pnpm',
+        version: '1.0.0',
+      },
+      workspaceDir: process.cwd(),
+    })
+
+    expect(config.stateDir).not.toBe(path.resolve('kebab-state'))
+    expect(config.storeDir).toBe(path.resolve('camel-store'))
+    expect(warnings).toStrictEqual([
+      `The following settings in the global config file ("${path.resolve('.config/pnpm/config.yaml')}") were ignored because they are not written in camelCase: "state-dir" (use "stateDir").`,
+    ])
+  })
+
   test('expands request destination values from trusted global config.yaml', async () => {
     prepareEmpty()
 


### PR DESCRIPTION
## Summary

A key written in kebab-case in the global `config.yaml` passes the gate whose job is to reject unsupported keys, and is then discarded by the next one without a word:

```yaml
# ~/.config/pnpm/config.yaml
state-dir: /tmp/kebab-state
```

`getConfig` filters the file through `isConfigFileKey(kebabCase(key))`, which is kebab-based and accepts `state-dir`. What survives is handed to `addSettingsFromWorkspaceManifestToConfig`, whose loop drops every key failing `isCamelCase`. So the setting does nothing, `warnings` is empty, and the camelCase spelling of the same key in the same file works — the two spellings disagree and only one of them says so.

The kebab spellings are now collected in the same pass and reported, naming the spelling that works:

```
The following settings in the global config file ("/home/user/.config/pnpm/config.yaml") were ignored because they are not written in camelCase: "state-dir" (use "stateDir").
```

Reporting rather than accepting the kebab spelling keeps the file camelCase-only, which is what `pnpm config set --global` writes and what the docs describe.

This is TypeScript-only. pacquet parses `config.yaml` into a typed struct that does not use `deny_unknown_fields`, so serde drops a kebab key silently — it has no equivalent warning to extend, and none for the `isConfigFileKey` rejections either. I'll file that parity gap separately rather than grow this fix into it.

Closes pnpm/pnpm#13650

## Squash Commit Body

```text
The global config.yaml is filtered through `isConfigFileKey(kebabCase(key))`,
which accepts `state-dir`, and the settings that survive that gate are then
picked up in camelCase only — so the key passed the check whose job is to
report unsupported keys, and was dropped by the next one without a word.

Report those keys, naming the spelling that works. The two spellings
disagreed and only one of them said so.

Closes pnpm/pnpm#13650
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789126971&installation_model_id=426870&pr_number=13862&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13862&signature=d2f8a9cd921416f1fd7b41cf6962707b560dbde7526bfac255ea656b13b9172d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Global `config.yaml` settings written in kebab-case are now reported instead of silently ignored.
  * Warnings identify the expected camelCase equivalent for each affected setting.
  * Valid camelCase settings continue to be applied as expected.
  * Added coverage to verify this configuration behavior.

* **Documentation**
  * Added release notes describing the updated global configuration handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->