### PR TITLE
fix(config): report the keys dropped from the global config.yaml (pacquet)

### DIFF
--- a/.changeset/pacquet-global-config-yaml-ignored-keys.md
+++ b/.changeset/pacquet-global-config-yaml-ignored-keys.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+A setting in the global `config.yaml` that pnpm does not read from that file, or that is written in kebab-case instead of camelCase, is now reported instead of being ignored silently.

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -11,6 +11,7 @@ mod override_version_references;
 pub mod property_path;
 pub mod protected_settings;
 pub mod proxy_keys;
+pub mod refused_keys;
 mod store_path;
 pub mod version_policy;
 mod workspace_yaml;

--- a/pnpm/crates/config/src/refused_keys.rs
+++ b/pnpm/crates/config/src/refused_keys.rs
@@ -1,0 +1,105 @@
+//! The configuration keys no manifest may set, and where each belongs
+//! instead.
+//!
+//! Mirrors `isRefusedByAProjectManifest` / `whereRefusedKeyBelongs` in
+//! pnpm's `config.reader`, so that the two stacks cannot disagree on what
+//! was dropped from a config file or on the route a warning offers for it.
+
+use crate::{
+    config_types::is_config_file_key,
+    naming_cases::{to_camel_case, to_kebab_case},
+};
+use std::{collections::HashSet, sync::OnceLock};
+
+/// The camelCase keys a project's `pnpm-workspace.yaml` does not contribute
+/// (pnpm's `PROJECT_MANIFEST_SKIPPED_KEYS`): where the machine keeps what it
+/// holds across runs, the directories the current command reads and writes
+/// in, and which credentials pnpm sends to whom.
+const PROJECT_MANIFEST_SKIPPED_KEYS: &[&str] = &[
+    "configDir",
+    "globalBinDir",
+    "globalDir",
+    "globalPkgDir",
+    "npmrcAuthFile",
+    "pnpmHomeDir",
+    "stateDir",
+    "userconfig",
+    "bin",
+    "dir",
+    "rootProjectManifestDir",
+    "workspaceDir",
+    "authConfig",
+    "userConfig",
+    "configByUri",
+    "packageManagerNetworkConfig",
+    "packageManagerRegistries",
+];
+
+/// The reader's own bookkeeping (pnpm's `CONFIG_CONTEXT_KEYS`), which in the
+/// TypeScript CLI shares one object with the settings but is not settable by
+/// anyone.
+const CONFIG_CONTEXT_KEYS: &[&str] = &[
+    "hooks",
+    "finders",
+    "allProjects",
+    "selectedProjectsGraph",
+    "allProjectsGraph",
+    "prodAllProjectsGraph",
+    "prodOnlySelectedProjectDirs",
+    "rootProjectManifest",
+    "rootProjectManifestDir",
+    "cliOptions",
+    "explicitlySetKeys",
+    "packageManager",
+    "wantedPackageManager",
+];
+
+fn refused_keys() -> &'static HashSet<&'static str> {
+    static SET: OnceLock<HashSet<&'static str>> = OnceLock::new();
+    SET.get_or_init(|| {
+        PROJECT_MANIFEST_SKIPPED_KEYS.iter().chain(CONFIG_CONTEXT_KEYS).copied().collect()
+    })
+}
+
+/// Whether a project's `pnpm-workspace.yaml` drops `key`, given in either
+/// camelCase or kebab-case, whether as a value a project may not contribute
+/// or as the reader's own bookkeeping.
+#[must_use]
+pub fn is_refused_by_a_project_manifest(key: &str) -> bool {
+    refused_keys().contains(to_camel_case(key).as_str())
+}
+
+/// The global config file key that sets a refused setting, where it is not
+/// that setting's own name.
+///
+/// `userconfig` is accepted under its own name, but never read back: the
+/// user-level `.npmrc` comes from `npmrcAuthFile`, so its own name would
+/// send the user to a command that changes nothing.
+fn global_equivalent_key(camel_key: &str) -> Option<&'static str> {
+    match camel_key {
+        // Derived from the global bin directory.
+        "bin" => Some("global-bin-dir"),
+        // Derived from the global directory.
+        "globalPkgDir" => Some("global-dir"),
+        "userconfig" => Some("npmrc-auth-file"),
+        _ => None,
+    }
+}
+
+/// Where `camel_key` can be set, for a key a project manifest refuses.
+#[must_use]
+pub fn where_refused_key_belongs(camel_key: &str) -> String {
+    if camel_key == "dir" {
+        return "Pass --dir on the command line instead".to_string();
+    }
+    let kebab_key =
+        global_equivalent_key(camel_key).map_or_else(|| to_kebab_case(camel_key), str::to_string);
+    if is_config_file_key(&kebab_key) {
+        format!("Set it for the machine instead: pnpm config set --global {kebab_key}")
+    } else {
+        "This is not a pnpm setting".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/config/src/refused_keys.rs
+++ b/pnpm/crates/config/src/refused_keys.rs
@@ -11,10 +11,10 @@ use crate::{
 };
 use std::{collections::HashSet, sync::OnceLock};
 
-/// The camelCase keys a project's `pnpm-workspace.yaml` does not contribute
-/// (pnpm's `PROJECT_MANIFEST_SKIPPED_KEYS`): where the machine keeps what it
-/// holds across runs, the directories the current command reads and writes
-/// in, and which credentials pnpm sends to whom.
+/// The camelCase keys a project's `pnpm-workspace.yaml` does not contribute,
+/// named as in pnpm's `config.reader`: where the machine keeps what it holds
+/// across runs, the directories the current command reads and writes in, and
+/// which credentials pnpm sends to whom.
 const PROJECT_MANIFEST_SKIPPED_KEYS: &[&str] = &[
     "configDir",
     "globalBinDir",
@@ -35,9 +35,8 @@ const PROJECT_MANIFEST_SKIPPED_KEYS: &[&str] = &[
     "packageManagerRegistries",
 ];
 
-/// The reader's own bookkeeping (pnpm's `CONFIG_CONTEXT_KEYS`), which in the
-/// TypeScript CLI shares one object with the settings but is not settable by
-/// anyone.
+/// The reader's own bookkeeping, named as in pnpm's `config.reader`, which
+/// there shares one object with the settings but is not settable by anyone.
 const CONFIG_CONTEXT_KEYS: &[&str] = &[
     "hooks",
     "finders",

--- a/pnpm/crates/config/src/refused_keys/tests.rs
+++ b/pnpm/crates/config/src/refused_keys/tests.rs
@@ -1,0 +1,67 @@
+use super::{is_refused_by_a_project_manifest, where_refused_key_belongs};
+
+/// The global config file takes these under a name of their own.
+#[test]
+fn a_key_the_global_config_file_takes_is_routed_there() {
+    for (camel_key, kebab_key) in [
+        ("stateDir", "state-dir"),
+        ("globalDir", "global-dir"),
+        ("globalBinDir", "global-bin-dir"),
+        ("npmrcAuthFile", "npmrc-auth-file"),
+    ] {
+        assert_eq!(
+            where_refused_key_belongs(camel_key),
+            format!("Set it for the machine instead: pnpm config set --global {kebab_key}"),
+        );
+    }
+}
+
+/// These are derived from a key the global config file does take, and naming
+/// their own spelling would send the user to a command that does nothing.
+#[test]
+fn a_derived_key_is_routed_to_the_key_it_derives_from() {
+    for (camel_key, kebab_key) in [
+        ("bin", "global-bin-dir"),
+        ("globalPkgDir", "global-dir"),
+        ("userconfig", "npmrc-auth-file"),
+    ] {
+        assert_eq!(
+            where_refused_key_belongs(camel_key),
+            format!("Set it for the machine instead: pnpm config set --global {kebab_key}"),
+        );
+    }
+}
+
+#[test]
+fn dir_names_the_flag_that_sets_it() {
+    assert_eq!(where_refused_key_belongs("dir"), "Pass --dir on the command line instead");
+}
+
+/// Naming where pnpm gets these would publish how it resolves them, and would
+/// imply the key was a setting that only reached the wrong file.
+#[test]
+fn a_key_that_is_no_setting_is_not_offered_a_route() {
+    for camel_key in [
+        "configDir",
+        "pnpmHomeDir",
+        "rootProjectManifestDir",
+        "workspaceDir",
+        "authConfig",
+        "userConfig",
+        "configByUri",
+        "packageManagerNetworkConfig",
+        "packageManagerRegistries",
+    ] {
+        assert_eq!(where_refused_key_belongs(camel_key), "This is not a pnpm setting");
+    }
+}
+
+/// The refusal reads both spellings, since a config file may carry either.
+#[test]
+fn refusal_is_spelling_insensitive() {
+    assert!(is_refused_by_a_project_manifest("authConfig"));
+    assert!(is_refused_by_a_project_manifest("auth-config"));
+    assert!(is_refused_by_a_project_manifest("hooks"));
+    assert!(!is_refused_by_a_project_manifest("storeDir"));
+    assert!(!is_refused_by_a_project_manifest("node-linker"));
+}

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -3559,9 +3559,8 @@ pub fn global_config_yaml_keys_settable_nowhere_are_reported_with_their_route() 
     );
 }
 
-/// A camelCase key pnpm honors in this file stays silent even where pacquet
-/// does not read it yet: the warning output must match pnpm's on the same
-/// file, and the fix for such a key is to honor it, not to report it.
+/// A dropped key pnpm honors in this file gets no warning; the rationale
+/// lives on `warn_about_dropped_keys`.
 #[test]
 pub fn global_config_yaml_key_pnpm_honors_stays_silent() {
     let config_dir = tempdir().expect("config tempdir");

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -3535,14 +3535,60 @@ pub fn global_config_yaml_keys_it_cannot_set_are_reported() {
     );
 }
 
-/// An explicit null sets nothing, so it is not reported. A file carrying
-/// both kinds of dropped key gets both warnings, in pnpm's order.
+/// A key no configuration file may set is reported with the route pnpm
+/// offers for it, not with the move-to-workspace advice.
 #[test]
-pub fn global_config_yaml_null_key_is_silent_and_both_warnings_are_ordered() {
+pub fn global_config_yaml_keys_settable_nowhere_are_reported_with_their_route() {
     let config_dir = tempdir().expect("config tempdir");
     let config_file = config_dir.path().join("config.yaml");
-    fs::write(&config_file, "scriptShell: null\nstore-dir: /kebab-store\nnodeLinker: hoisted\n")
+    fs::write(&config_file, "configDir: /elsewhere\nbin: /usr/local/bin\ndir: /work\n")
         .expect("write global config.yaml");
+
+    let warnings = capture_warnings(|| {
+        WorkspaceSettings::load_global(config_dir.path())
+            .expect("load global config.yaml")
+            .expect("global config.yaml is present");
+    });
+
+    assert_eq!(
+        warnings,
+        [format!(
+            r#"The following settings cannot be set in the global config file ("{}") and were ignored: "configDir" (This is not a pnpm setting), "bin" (Set it for the machine instead: pnpm config set --global global-bin-dir), "dir" (Pass --dir on the command line instead)."#,
+            config_file.display(),
+        )],
+    );
+}
+
+/// A camelCase key pnpm honors in this file stays silent even where pacquet
+/// does not read it yet: the warning output must match pnpm's on the same
+/// file, and the fix for such a key is to honor it, not to report it.
+#[test]
+pub fn global_config_yaml_key_pnpm_honors_stays_silent() {
+    let config_dir = tempdir().expect("config tempdir");
+    let config_file = config_dir.path().join("config.yaml");
+    fs::write(&config_file, "globalBinDir: /usr/local/pnpm-bin\n")
+        .expect("write global config.yaml");
+
+    let warnings = capture_warnings(|| {
+        WorkspaceSettings::load_global(config_dir.path())
+            .expect("load global config.yaml")
+            .expect("global config.yaml is present");
+    });
+
+    assert_eq!(warnings, Vec::<String>::new());
+}
+
+/// An explicit null sets nothing, so it is not reported. A file carrying
+/// every kind of dropped key gets all three warnings, in pnpm's order.
+#[test]
+pub fn global_config_yaml_null_key_is_silent_and_the_warnings_are_ordered() {
+    let config_dir = tempdir().expect("config tempdir");
+    let config_file = config_dir.path().join("config.yaml");
+    fs::write(
+        &config_file,
+        "scriptShell: null\nstore-dir: /kebab-store\nconfigDir: /elsewhere\nnodeLinker: hoisted\n",
+    )
+    .expect("write global config.yaml");
 
     let warnings = capture_warnings(|| {
         WorkspaceSettings::load_global(config_dir.path())
@@ -3555,6 +3601,10 @@ pub fn global_config_yaml_null_key_is_silent_and_both_warnings_are_ordered() {
         [
             format!(
                 r#"The following settings cannot be set in the global config file ("{}") and were ignored: "nodeLinker". Move them to a project-level pnpm-workspace.yaml. To share these settings across projects, use config dependencies: https://pnpm.io/11.x/config-dependencies"#,
+                config_file.display(),
+            ),
+            format!(
+                r#"The following settings cannot be set in the global config file ("{}") and were ignored: "configDir" (This is not a pnpm setting)."#,
                 config_file.display(),
             ),
             format!(

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -1,6 +1,7 @@
 use super::{
     Config, EnvVar, EnvVarOs, GetCurrentDir, GetHomeDir, Host, LinkProbe, LoadWorkspaceYamlError,
-    NodeLinker, NodePackageMapType, PackageImportMethod, TrustPolicy, default_ci, fs,
+    NodeLinker, NodePackageMapType, PackageImportMethod, TrustPolicy, WorkspaceSettings,
+    default_ci, fs,
 };
 use crate::defaults::default_store_dir;
 use pnpm_store_dir::StoreDir;
@@ -3481,4 +3482,56 @@ pub fn extra_bin_paths_lists_workspace_root_bin_only_inside_a_workspace() {
         .expect("write pnpm-workspace.yaml");
     let config = load_with_fake_env(project.path());
     assert_eq!(config.extra_bin_paths, vec![project.path().join("node_modules").join(".bin")]);
+}
+
+/// A key spelled in kebab-case in the global `config.yaml` is read by
+/// nothing, since only camelCase reaches the settings, so it is reported
+/// naming the spelling that works.
+#[test]
+pub fn global_config_yaml_kebab_case_key_is_reported() {
+    let config_dir = tempdir().expect("config tempdir");
+    fs::write(
+        config_dir.path().join("config.yaml"),
+        "store-dir: /kebab-store\nstoreDir: /camel-store\n",
+    )
+    .expect("write global config.yaml");
+
+    let warnings = capture_warnings(|| {
+        let settings = WorkspaceSettings::load_global(config_dir.path())
+            .expect("load global config.yaml")
+            .expect("global config.yaml is present");
+        assert_eq!(settings.store_dir.as_deref(), Some("/camel-store"));
+    });
+
+    assert_eq!(
+        warnings,
+        [format!(
+            r#"The following settings in the global config file ("{}") were ignored because they are not written in camelCase: "store-dir" (use "storeDir")."#,
+            config_dir.path().join("config.yaml").display(),
+        )]
+    );
+}
+
+/// A workspace-only setting and a key that is no setting at all are both
+/// dropped from the global `config.yaml`, so both are reported.
+#[test]
+pub fn global_config_yaml_keys_it_cannot_set_are_reported() {
+    let config_dir = tempdir().expect("config tempdir");
+    fs::write(config_dir.path().join("config.yaml"), "nodeLinker: hoisted\npackages:\n  - lib/*\n")
+        .expect("write global config.yaml");
+
+    let warnings = capture_warnings(|| {
+        let settings = WorkspaceSettings::load_global(config_dir.path())
+            .expect("load global config.yaml")
+            .expect("global config.yaml is present");
+        assert_eq!(settings.node_linker, None);
+    });
+
+    assert_eq!(
+        warnings,
+        [format!(
+            r#"The following settings cannot be set in the global config file ("{}") and were ignored: "nodeLinker", "packages". Move them to a project-level pnpm-workspace.yaml. To share these settings across projects, use config dependencies: https://pnpm.io/11.x/config-dependencies"#,
+            config_dir.path().join("config.yaml").display(),
+        )]
+    );
 }

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -3534,3 +3534,33 @@ pub fn global_config_yaml_keys_it_cannot_set_are_reported() {
         )]
     );
 }
+
+/// An explicit null sets nothing, so it is not reported. A file carrying
+/// both kinds of dropped key gets both warnings, in pnpm's order.
+#[test]
+pub fn global_config_yaml_null_key_is_silent_and_both_warnings_are_ordered() {
+    let config_dir = tempdir().expect("config tempdir");
+    let config_file = config_dir.path().join("config.yaml");
+    fs::write(&config_file, "scriptShell: null\nstore-dir: /kebab-store\nnodeLinker: hoisted\n")
+        .expect("write global config.yaml");
+
+    let warnings = capture_warnings(|| {
+        WorkspaceSettings::load_global(config_dir.path())
+            .expect("load global config.yaml")
+            .expect("global config.yaml is present");
+    });
+
+    assert_eq!(
+        warnings,
+        [
+            format!(
+                r#"The following settings cannot be set in the global config file ("{}") and were ignored: "nodeLinker". Move them to a project-level pnpm-workspace.yaml. To share these settings across projects, use config dependencies: https://pnpm.io/11.x/config-dependencies"#,
+                config_file.display(),
+            ),
+            format!(
+                r#"The following settings in the global config file ("{}") were ignored because they are not written in camelCase: "store-dir" (use "storeDir")."#,
+                config_file.display(),
+            ),
+        ]
+    );
+}

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -3490,11 +3490,9 @@ pub fn extra_bin_paths_lists_workspace_root_bin_only_inside_a_workspace() {
 #[test]
 pub fn global_config_yaml_kebab_case_key_is_reported() {
     let config_dir = tempdir().expect("config tempdir");
-    fs::write(
-        config_dir.path().join("config.yaml"),
-        "store-dir: /kebab-store\nstoreDir: /camel-store\n",
-    )
-    .expect("write global config.yaml");
+    let config_file = config_dir.path().join("config.yaml");
+    fs::write(&config_file, "store-dir: /kebab-store\nstoreDir: /camel-store\n")
+        .expect("write global config.yaml");
 
     let warnings = capture_warnings(|| {
         let settings = WorkspaceSettings::load_global(config_dir.path())
@@ -3507,7 +3505,7 @@ pub fn global_config_yaml_kebab_case_key_is_reported() {
         warnings,
         [format!(
             r#"The following settings in the global config file ("{}") were ignored because they are not written in camelCase: "store-dir" (use "storeDir")."#,
-            config_dir.path().join("config.yaml").display(),
+            config_file.display(),
         )]
     );
 }
@@ -3517,7 +3515,8 @@ pub fn global_config_yaml_kebab_case_key_is_reported() {
 #[test]
 pub fn global_config_yaml_keys_it_cannot_set_are_reported() {
     let config_dir = tempdir().expect("config tempdir");
-    fs::write(config_dir.path().join("config.yaml"), "nodeLinker: hoisted\npackages:\n  - lib/*\n")
+    let config_file = config_dir.path().join("config.yaml");
+    fs::write(&config_file, "nodeLinker: hoisted\npackages:\n  - lib/*\n")
         .expect("write global config.yaml");
 
     let warnings = capture_warnings(|| {
@@ -3531,7 +3530,7 @@ pub fn global_config_yaml_keys_it_cannot_set_are_reported() {
         warnings,
         [format!(
             r#"The following settings cannot be set in the global config file ("{}") and were ignored: "nodeLinker", "packages". Move them to a project-level pnpm-workspace.yaml. To share these settings across projects, use config dependencies: https://pnpm.io/11.x/config-dependencies"#,
-            config_dir.path().join("config.yaml").display(),
+            config_file.display(),
         )]
     );
 }

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -3506,7 +3506,7 @@ pub fn global_config_yaml_kebab_case_key_is_reported() {
         [format!(
             r#"The following settings in the global config file ("{}") were ignored because they are not written in camelCase: "store-dir" (use "storeDir")."#,
             config_file.display(),
-        )]
+        )],
     );
 }
 
@@ -3531,7 +3531,7 @@ pub fn global_config_yaml_keys_it_cannot_set_are_reported() {
         [format!(
             r#"The following settings cannot be set in the global config file ("{}") and were ignored: "nodeLinker", "packages". Move them to a project-level pnpm-workspace.yaml. To share these settings across projects, use config dependencies: https://pnpm.io/11.x/config-dependencies"#,
             config_file.display(),
-        )]
+        )],
     );
 }
 
@@ -3561,6 +3561,6 @@ pub fn global_config_yaml_null_key_is_silent_and_both_warnings_are_ordered() {
                 r#"The following settings in the global config file ("{}") were ignored because they are not written in camelCase: "store-dir" (use "storeDir")."#,
                 config_file.display(),
             ),
-        ]
+        ],
     );
 }

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -968,9 +968,7 @@ impl WorkspaceSettings {
     }
 
     /// Warn about the keys of the global `config.yaml` that never reach the
-    /// settings, in the three messages pnpm emits for that file: movable to a
-    /// project's `pnpm-workspace.yaml`, settable nowhere, and spelled in
-    /// kebab-case.
+    /// settings, in the three messages pnpm emits for that file.
     ///
     /// What survived is read back off `self` rather than off a second list of
     /// key names, which would drift from the struct: a key serde did not

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -7,6 +7,7 @@ use crate::{
     config_types::is_config_file_key,
     naming_cases::{is_camel_case, to_camel_case, to_kebab_case},
     proxy_keys::{ProxyKeys, ProxyValue},
+    refused_keys::{is_refused_by_a_project_manifest, where_refused_key_belongs},
     resolve_child_concurrency,
 };
 use derive_more::{Display, Error};
@@ -967,12 +968,18 @@ impl WorkspaceSettings {
     }
 
     /// Warn about the keys of the global `config.yaml` that never reach the
-    /// settings, in the two messages pnpm emits for that file.
+    /// settings, in the three messages pnpm emits for that file: movable to a
+    /// project's `pnpm-workspace.yaml`, settable nowhere, and spelled in
+    /// kebab-case.
     ///
     /// What survived is read back off `self` rather than off a second list of
     /// key names, which would drift from the struct: a key serde did not
     /// recognize is absent from the serialized settings, and one
     /// [`Self::clear_workspace_only_fields`] zeroed is null there.
+    ///
+    /// A dropped camelCase key pnpm's `isConfigFileKey` accepts stays silent:
+    /// pnpm honors it in this file, so the fix is to honor it too, and until
+    /// then a warning would diverge from pnpm's output on the same file.
     fn warn_about_dropped_keys(&self, text: &str, path: &Path) {
         let Ok(document) = serde_saphyr::from_str::<IndexMap<String, Option<IgnoredAny>>>(text)
         else {
@@ -982,25 +989,40 @@ impl WorkspaceSettings {
             return;
         };
 
-        let mut ignored = Vec::new();
+        let mut movable = Vec::new();
+        let mut nowhere = Vec::new();
         let mut kebab_case = Vec::new();
         for key in document.iter().filter(|(_, value)| value.is_some()).map(|(key, _)| key) {
-            match kept.get(key) {
-                Some(value) if !value.is_null() => {}
-                Some(_) => ignored.push(format!(r#""{key}""#)),
-                None if !is_camel_case(key) && is_config_file_key(&to_kebab_case(key)) => {
-                    kebab_case.push(format!(r#""{key}" (use "{}")"#, to_camel_case(key)));
+            if matches!(kept.get(key), Some(value) if !value.is_null()) {
+                continue;
+            }
+            if !is_config_file_key(&to_kebab_case(key)) {
+                if is_refused_by_a_project_manifest(key) {
+                    nowhere.push(format!(
+                        r#""{key}" ({})"#,
+                        where_refused_key_belongs(&to_camel_case(key)),
+                    ));
+                } else {
+                    movable.push(format!(r#""{key}""#));
                 }
-                None => ignored.push(format!(r#""{key}""#)),
+            } else if !is_camel_case(key) {
+                kebab_case.push(format!(r#""{key}" (use "{}")"#, to_camel_case(key)));
             }
         }
 
         let path = path.display();
-        if !ignored.is_empty() {
-            let ignored = ignored.join(", ");
+        if !movable.is_empty() {
+            let movable = movable.join(", ");
             tracing::warn!(
                 target: "pacquet::config",
-                r#"The following settings cannot be set in the global config file ("{path}") and were ignored: {ignored}. Move them to a project-level pnpm-workspace.yaml. To share these settings across projects, use config dependencies: https://pnpm.io/11.x/config-dependencies"#,
+                r#"The following settings cannot be set in the global config file ("{path}") and were ignored: {movable}. Move them to a project-level pnpm-workspace.yaml. To share these settings across projects, use config dependencies: https://pnpm.io/11.x/config-dependencies"#,
+            );
+        }
+        if !nowhere.is_empty() {
+            let nowhere = nowhere.join(", ");
+            tracing::warn!(
+                target: "pacquet::config",
+                r#"The following settings cannot be set in the global config file ("{path}") and were ignored: {nowhere}."#,
             );
         }
         if !kebab_case.is_empty() {

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -999,17 +999,17 @@ impl WorkspaceSettings {
 
         let path = path.display();
         if !ignored.is_empty() {
+            let ignored = ignored.join(", ");
             tracing::warn!(
                 target: "pacquet::config",
-                r#"The following settings cannot be set in the global config file ("{path}") and were ignored: {}. Move them to a project-level pnpm-workspace.yaml. To share these settings across projects, use config dependencies: https://pnpm.io/11.x/config-dependencies"#,
-                ignored.join(", "),
+                r#"The following settings cannot be set in the global config file ("{path}") and were ignored: {ignored}. Move them to a project-level pnpm-workspace.yaml. To share these settings across projects, use config dependencies: https://pnpm.io/11.x/config-dependencies"#,
             );
         }
         if !kebab_case.is_empty() {
+            let kebab_case = kebab_case.join(", ");
             tracing::warn!(
                 target: "pacquet::config",
-                r#"The following settings in the global config file ("{path}") were ignored because they are not written in camelCase: {}."#,
-                kebab_case.join(", "),
+                r#"The following settings in the global config file ("{path}") were ignored because they are not written in camelCase: {kebab_case}."#,
             );
         }
     }

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -4,6 +4,8 @@ use crate::{
     SaveWorkspaceProtocol, ScriptsPrependNodePath, TrustPolicy, VerifyDepsBeforeRun,
     VirtualStoreType,
     api::EnvVar,
+    config_types::is_config_file_key,
+    naming_cases::{is_camel_case, to_camel_case, to_kebab_case},
     proxy_keys::{ProxyKeys, ProxyValue},
     resolve_child_concurrency,
 };
@@ -17,7 +19,7 @@ use pnpm_package_is_installable::SupportedArchitectures;
 use pnpm_store_dir::StoreDir;
 use pnpm_workspace_state::ConfigDependency;
 use registries::RegistryEntry;
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, de::IgnoredAny};
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     fs,
@@ -945,9 +947,10 @@ impl WorkspaceSettings {
         };
         let mut settings: WorkspaceSettings = serde_saphyr::from_str(&text)
             .map_err(Box::new)
-            .map_err(|source| LoadWorkspaceYamlError::ParseYaml { path, source })?;
+            .map_err(|source| LoadWorkspaceYamlError::ParseYaml { path: path.clone(), source })?;
         settings.validate_registries()?;
         settings.clear_workspace_only_fields();
+        settings.warn_about_dropped_keys(&text, &path);
         Ok(Some(settings))
     }
 
@@ -961,6 +964,54 @@ impl WorkspaceSettings {
     fn validate_registries(&self) -> Result<(), LoadWorkspaceYamlError> {
         let Some(entries) = self.registries.as_ref() else { return Ok(()) };
         registries::validate(entries)
+    }
+
+    /// Warn about the keys of the global `config.yaml` that never reach the
+    /// settings: one that cannot be set in that file at all, and one spelled
+    /// in kebab-case where only camelCase is read. Both messages match the
+    /// ones pnpm emits for the same file.
+    ///
+    /// What survived is read back off `self` rather than off a second list of
+    /// key names, which would drift from the struct: a key serde did not
+    /// recognize is absent from the serialized settings, and one
+    /// [`Self::clear_workspace_only_fields`] zeroed is null there.
+    fn warn_about_dropped_keys(&self, text: &str, path: &Path) {
+        let Ok(document) = serde_saphyr::from_str::<IndexMap<String, Option<IgnoredAny>>>(text)
+        else {
+            return;
+        };
+        let Ok(serde_json::Value::Object(kept)) = serde_json::to_value(self) else {
+            return;
+        };
+
+        let mut ignored = Vec::new();
+        let mut kebab_case = Vec::new();
+        for key in document.iter().filter(|(_, value)| value.is_some()).map(|(key, _)| key) {
+            match kept.get(key) {
+                Some(value) if !value.is_null() => {}
+                Some(_) => ignored.push(format!(r#""{key}""#)),
+                None if !is_camel_case(key) && is_config_file_key(&to_kebab_case(key)) => {
+                    kebab_case.push(format!(r#""{key}" (use "{}")"#, to_camel_case(key)));
+                }
+                None => ignored.push(format!(r#""{key}""#)),
+            }
+        }
+
+        let path = path.display();
+        if !ignored.is_empty() {
+            tracing::warn!(
+                target: "pacquet::config",
+                r#"The following settings cannot be set in the global config file ("{path}") and were ignored: {}. Move them to a project-level pnpm-workspace.yaml. To share these settings across projects, use config dependencies: https://pnpm.io/11.x/config-dependencies"#,
+                ignored.join(", "),
+            );
+        }
+        if !kebab_case.is_empty() {
+            tracing::warn!(
+                target: "pacquet::config",
+                r#"The following settings in the global config file ("{path}") were ignored because they are not written in camelCase: {}."#,
+                kebab_case.join(", "),
+            );
+        }
     }
 
     /// Zero out the release-age and trust policies for `self-update`.

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -967,9 +967,7 @@ impl WorkspaceSettings {
     }
 
     /// Warn about the keys of the global `config.yaml` that never reach the
-    /// settings: one that cannot be set in that file at all, and one spelled
-    /// in kebab-case where only camelCase is read. Both messages match the
-    /// ones pnpm emits for the same file.
+    /// settings, in the two messages pnpm emits for that file.
     ///
     /// What survived is read back off `self` rather than off a second list of
     /// key names, which would drift from the struct: a key serde did not


### PR DESCRIPTION
## Summary

pacquet parses the global `config.yaml` into `WorkspaceSettings`, whose fields are camelCase and which does not use `deny_unknown_fields`, and then zeroes the workspace-only fields. Both passes are silent, so a key the file cannot carry and a key spelled in kebab-case do nothing at all and say nothing about it:

```yaml
# ~/.config/pnpm/config.yaml
store-dir: /kebab-store
nodeLinker: hoisted
```

The TypeScript CLI reports both cases against the same file, the second one as of pnpm/pnpm#13862. pacquet now emits the same warnings, with the same texts, so the parity tests can compare them:

```
The following settings cannot be set in the global config file ("/home/user/.config/pnpm/config.yaml") and were ignored: "nodeLinker". Move them to a project-level pnpm-workspace.yaml. ...
The following settings in the global config file ("/home/user/.config/pnpm/config.yaml") were ignored because they are not written in camelCase: "store-dir" (use "storeDir").
```

pnpm splits the first case further: a key no configuration file may set — machine locations, the current run's directories, credentials, and the reader's own bookkeeping — is reported in a third message with the route pnpm offers for it instead of the move-to-workspace advice. pacquet ports that refusal list and `whereRefusedKeyBelongs`'s routes (as `refused_keys`) so those texts match too:

```
The following settings cannot be set in the global config file ("/home/user/.config/pnpm/config.yaml") and were ignored: "configDir" (This is not a pnpm setting), "bin" (Set it for the machine instead: pnpm config set --global global-bin-dir), "dir" (Pass --dir on the command line instead).
```

Which keys were dropped is read back off the settings after the clearing pass, not from a second list of key names that would drift from the struct: a key serde did not recognize is missing from the serialized settings, and a key the clearing pass zeroed is null there. A key written as an explicit null is skipped, since nothing was dropped in that case either way. A dropped camelCase key pnpm's `isConfigFileKey` accepts (`globalBinDir` and friends, which pacquet does not read from this file yet) stays silent: pnpm honors it there, so the fix is to honor it too, and until then a warning would diverge from pnpm's output on the same file.

One gap this leaves open on purpose: pacquet honors a handful of keys from that file which pnpm's `isConfigFileKey` rejects (`workspaceConcurrency`, `maxSockets`, `audit`, and a few more). Those stay silent, because warning that a setting was ignored while still honoring it reads worse than saying nothing. Closing that gap changes what the file does rather than what it reports, so it wants its own change and its own tests.

Closes pnpm/pnpm#13863

## Squash Commit Body

```text
The global config.yaml is parsed into a struct with camelCase fields and
no `deny_unknown_fields`, and the workspace-only fields are then zeroed.
Both passes are silent, so a key that cannot be set in that file and a
key spelled in kebab-case each did nothing and said nothing, while the
TypeScript CLI reports both against the same file.

Report them from pacquet too, with the texts pnpm uses, including the
third message pnpm has for a key no configuration file may set: the
refusal list and whereRefusedKeyBelongs's routes are ported as
refused_keys. What was dropped is read back off the settings after the
clearing pass rather than from a second list of key names: a key serde
did not recognize is missing from the serialized settings, and a key the
clearing pass zeroed is null there, so the report cannot drift from the
struct.

The keys pacquet honors but pnpm's `isConfigFileKey` rejects stay silent.
Warning about a setting that is still honored would be worse than the
silence, and closing that gap is a behavior change rather than a report.
The mirror gap is silent too: a camelCase key pnpm honors in this file
but pacquet does not read yet gets no warning, since the fix for it is
to honor it, not to report it.

Closes pnpm/pnpm#13863
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13864"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789128820&installation_model_id=426870&pr_number=13864&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13864&signature=fff6da17871ea68971c7b2bf2f805482dddf84ea3ab21cc1ed99d6038ebcb7bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Global configuration now reports unsupported or workspace-only settings instead of silently ignoring them.
  * Warnings identify kebab-case configuration keys and suggest the supported camelCase names.
  * Configuration warnings preserve correct handling of empty or null values.
  * Each affected setting is reported separately, making configuration issues easier to identify and correct.
  * Warnings include configuration guidance and identify where the affected setting was found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
