### PR TITLE
fix(resolver): ignore a workspace root pin an optional peer's range rejects

### DIFF
--- a/.changeset/optional-peer-hoist-skips-a-rejected-root-pin.md
+++ b/.changeset/optional-peer-hoist-skips-a-rejected-root-pin.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.deps-resolver": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+The workspace root's own dependency on a package no longer bounds an auto-installed *optional* peer when it falls outside the declared peer range. A root that pins `date-fns@2.30.0` used to push that version into an importer whose only `date-fns` need was an optional `^4.0.0` peer, so pnpm reported its own resolution as unmet even though a satisfying `date-fns@4.4.0` was already in the graph. The root's pin now bounds the candidates only when it overlaps the wanted range [#13867](https://github.com/pnpm/pnpm/issues/13867).

--- a/.changeset/optional-peer-hoist-skips-a-rejected-root-pin.md
+++ b/.changeset/optional-peer-hoist-skips-a-rejected-root-pin.md
@@ -4,4 +4,4 @@
 "pnpm": patch
 ---
 
-The workspace root's own dependency on a package no longer bounds an auto-installed *optional* peer when it falls outside the declared peer range. A root that pins `date-fns@2.30.0` used to push that version into an importer whose only `date-fns` need was an optional `^4.0.0` peer, so pnpm reported its own resolution as unmet even though a satisfying `date-fns@4.4.0` was already in the graph. The root's pin now bounds the candidates only when it overlaps the wanted range [#13867](https://github.com/pnpm/pnpm/issues/13867).
+An auto-installed *optional* peer is now resolved to a version its declared peer range accepts, even when the workspace root depends on that package at a version outside the range. A root pinning `date-fns@2.30.0` used to hand that version to an importer whose only `date-fns` need was an optional `^4.0.0` peer, which pnpm then reported as an unmet peer [#13867](https://github.com/pnpm/pnpm/issues/13867).

--- a/.changeset/optional-peer-hoist-skips-a-rejected-root-pin.md
+++ b/.changeset/optional-peer-hoist-skips-a-rejected-root-pin.md
@@ -4,4 +4,4 @@
 "pnpm": patch
 ---
 
-An auto-installed *optional* peer is now resolved to a version its declared peer range accepts, even when the workspace root depends on that package at a version outside the range. A root pinning `date-fns@2.30.0` used to hand that version to an importer whose only `date-fns` need was an optional `^4.0.0` peer, which pnpm then reported as an unmet peer [#13867](https://github.com/pnpm/pnpm/issues/13867).
+An auto-installed optional peer is now resolved to a version its declared peer range accepts, even when the workspace root depends on that package at a version outside the range. Previously the root's version was used and then reported as an unmet optional peer [#13867](https://github.com/pnpm/pnpm/issues/13867).

--- a/pnpm/crates/resolving-deps-resolver/src/hoist_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/hoist_peers.rs
@@ -202,6 +202,13 @@ pub(crate) fn get_hoistable_optional_peers_with_locked_versions(
         else {
             continue;
         };
+        // A root specifier disjoint from the wanted ranges bounds the
+        // candidates down to none, and the importer then falls back to
+        // the root's own out-of-range version. Such a specifier has
+        // nothing to say about this peer, so leave the candidates
+        // unbounded instead.
+        let root_range =
+            root_range.filter(|root| parsed_ranges.iter().all(|parsed| root.allows_any(parsed)));
         let mut max_satisfying_version: Option<Version> = None;
         for (version_str, entry) in selectors {
             if locked_peer_versions

--- a/pnpm/crates/resolving-deps-resolver/src/hoist_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/hoist_peers.rs
@@ -202,11 +202,9 @@ pub(crate) fn get_hoistable_optional_peers_with_locked_versions(
         else {
             continue;
         };
-        // A root specifier disjoint from the wanted ranges bounds the
-        // candidates down to none, and the importer then falls back to
-        // the root's own out-of-range version. Such a specifier has
-        // nothing to say about this peer, so leave the candidates
-        // unbounded instead.
+        // A disjoint specifier would bound the candidates down to none, and
+        // the importer would then fall back to the root's own out-of-range
+        // version.
         let root_range =
             root_range.filter(|root| parsed_ranges.iter().all(|parsed| root.allows_any(parsed)));
         let mut max_satisfying_version: Option<Version> = None;

--- a/pnpm/crates/resolving-deps-resolver/src/hoist_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/hoist_peers/tests.rs
@@ -534,7 +534,7 @@ fn get_hoistable_optional_peers_stays_within_the_workspace_roots_range() {
 }
 
 #[test]
-fn get_hoistable_optional_peers_ignores_a_root_specifier_the_wanted_range_rejects() {
+fn get_hoistable_optional_peers_ignores_a_root_specifier_a_wanted_range_rejects() {
     let preferred = preferred(&[(
         "date-fns",
         &[
@@ -553,6 +553,26 @@ fn get_hoistable_optional_peers_ignores_a_root_specifier_the_wanted_range_reject
     let result = get_hoistable_optional_peers(&missing, &preferred, &root_deps);
     let mut expected = BTreeMap::new();
     expected.insert("date-fns".to_string(), "4.4.0".to_string());
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn get_hoistable_optional_peers_ignores_a_root_specifier_only_one_wanted_range_accepts() {
+    let preferred = preferred(&[("foo", &[("2.0.0", plain(VersionSelectorType::Version))])]);
+    let mut missing = BTreeMap::new();
+    missing.insert(
+        "foo".to_string(),
+        vec![">=1.0.0 <3.0.0".to_string(), ">=2.0.0 <4.0.0".to_string()],
+    );
+    let root_deps = [WorkspaceRootDep {
+        alias: "foo".to_string(),
+        pkg_name: "foo".to_string(),
+        normalized_bare_specifier: Some("1.0.0".to_string()),
+    }];
+
+    let result = get_hoistable_optional_peers(&missing, &preferred, &root_deps);
+    let mut expected = BTreeMap::new();
+    expected.insert("foo".to_string(), "2.0.0".to_string());
     assert_eq!(result, expected);
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/hoist_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/hoist_peers/tests.rs
@@ -534,6 +534,29 @@ fn get_hoistable_optional_peers_stays_within_the_workspace_roots_range() {
 }
 
 #[test]
+fn get_hoistable_optional_peers_ignores_a_root_specifier_the_wanted_range_rejects() {
+    let preferred = preferred(&[(
+        "date-fns",
+        &[
+            ("2.30.0", plain(VersionSelectorType::Version)),
+            ("4.4.0", plain(VersionSelectorType::Version)),
+        ],
+    )]);
+    let mut missing = BTreeMap::new();
+    missing.insert("date-fns".to_string(), vec!["^4.0.0".to_string()]);
+    let root_deps = [WorkspaceRootDep {
+        alias: "date-fns-v2".to_string(),
+        pkg_name: "date-fns".to_string(),
+        normalized_bare_specifier: Some("npm:date-fns@2.30.0".to_string()),
+    }];
+
+    let result = get_hoistable_optional_peers(&missing, &preferred, &root_deps);
+    let mut expected = BTreeMap::new();
+    expected.insert("date-fns".to_string(), "4.4.0".to_string());
+    assert_eq!(result, expected);
+}
+
+#[test]
 fn skips_a_workspace_root_dep_without_a_specifier_in_favor_of_one_with() {
     let root_deps = [
         WorkspaceRootDep {

--- a/pnpm11/installing/deps-resolver/src/hoistPeers.ts
+++ b/pnpm11/installing/deps-resolver/src/hoistPeers.ts
@@ -112,7 +112,14 @@ export function getHoistableOptionalPeers (
     // version body getPeerVersionRange extracts; one with no version body
     // yields `*` and leaves them unbounded.
     const rootBareSpecifier = findWorkspaceRootDep(workspaceRootDeps, missingOptionalPeerName)?.normalizedBareSpecifier
-    const rootRange = rootBareSpecifier != null ? semver.validRange(getPeerVersionRange(rootBareSpecifier)) : null
+    const rootSpecifierRange = rootBareSpecifier != null ? semver.validRange(getPeerVersionRange(rootBareSpecifier)) : null
+    // A root specifier disjoint from the wanted ranges bounds the candidates
+    // down to none, and the importer then falls back to the root's own
+    // out-of-range version. Such a specifier has nothing to say about this
+    // peer, so leave the candidates unbounded instead.
+    const rootRange = rootSpecifierRange != null && ranges.every(range => semver.validRange(range) != null && semver.intersects(rootSpecifierRange, range))
+      ? rootSpecifierRange
+      : null
 
     let maxSatisfyingVersion: string | undefined
     for (const [version, selector] of Object.entries(allPreferredVersions[missingOptionalPeerName])) {

--- a/pnpm11/installing/deps-resolver/src/hoistPeers.ts
+++ b/pnpm11/installing/deps-resolver/src/hoistPeers.ts
@@ -113,10 +113,7 @@ export function getHoistableOptionalPeers (
     // yields `*` and leaves them unbounded.
     const rootBareSpecifier = findWorkspaceRootDep(workspaceRootDeps, missingOptionalPeerName)?.normalizedBareSpecifier
     const rootSpecifierRange = rootBareSpecifier != null ? semver.validRange(getPeerVersionRange(rootBareSpecifier)) : null
-    // A root specifier disjoint from the wanted ranges bounds the candidates
-    // down to none, and the importer then falls back to the root's own
-    // out-of-range version. Such a specifier has nothing to say about this
-    // peer, so leave the candidates unbounded instead.
+    // A disjoint specifier would bound them down to none, and the importer would then fall back to the root's own out-of-range version.
     const rootRange = rootSpecifierRange != null && ranges.every(range => semver.validRange(range) != null && semver.intersects(rootSpecifierRange, range))
       ? rootSpecifierRange
       : null

--- a/pnpm11/installing/deps-resolver/test/hoistPeers.test.ts
+++ b/pnpm11/installing/deps-resolver/test/hoistPeers.test.ts
@@ -411,7 +411,7 @@ test('getHoistableOptionalPeers stays within the workspace root\'s range', () =>
   })
 })
 
-test('getHoistableOptionalPeers ignores a workspace root specifier that the wanted range rejects', () => {
+test('getHoistableOptionalPeers ignores a workspace root specifier that a wanted range rejects', () => {
   expect(getHoistableOptionalPeers({ 'date-fns': ['^4.0.0'] }, {
     'date-fns': {
       '2.30.0': 'version',
@@ -421,6 +421,18 @@ test('getHoistableOptionalPeers ignores a workspace root specifier that the want
     { alias: 'date-fns-v2', pkgName: 'date-fns', normalizedBareSpecifier: 'npm:date-fns@2.30.0' },
   ])).toStrictEqual({
     'date-fns': '4.4.0',
+  })
+})
+
+test('getHoistableOptionalPeers ignores a workspace root specifier that only one wanted range accepts', () => {
+  expect(getHoistableOptionalPeers({ foo: ['>=1.0.0 <3.0.0', '>=2.0.0 <4.0.0'] }, {
+    foo: {
+      '2.0.0': 'version',
+    },
+  }, [
+    { alias: 'foo', pkgName: 'foo', normalizedBareSpecifier: '1.0.0' },
+  ])).toStrictEqual({
+    foo: '2.0.0',
   })
 })
 

--- a/pnpm11/installing/deps-resolver/test/hoistPeers.test.ts
+++ b/pnpm11/installing/deps-resolver/test/hoistPeers.test.ts
@@ -411,6 +411,19 @@ test('getHoistableOptionalPeers stays within the workspace root\'s range', () =>
   })
 })
 
+test('getHoistableOptionalPeers ignores a workspace root specifier that the wanted range rejects', () => {
+  expect(getHoistableOptionalPeers({ 'date-fns': ['^4.0.0'] }, {
+    'date-fns': {
+      '2.30.0': 'version',
+      '4.4.0': 'version',
+    },
+  }, [
+    { alias: 'date-fns-v2', pkgName: 'date-fns', normalizedBareSpecifier: 'npm:date-fns@2.30.0' },
+  ])).toStrictEqual({
+    'date-fns': '4.4.0',
+  })
+})
+
 test('hoistPeers skips a workspace root dependency that has no specifier in favor of one that has', () => {
   const workspaceRootDeps = [
     { alias: 'postcss', pkgName: 'postcss' },


### PR DESCRIPTION
## Summary

`getHoistableOptionalPeers` bounds its candidates by the workspace root's own specifier for the package. When that specifier cannot satisfy the peer's declared range, the bound rules out every candidate, nothing gets hoisted, and the importer falls back to the root's version through `resolvePeersFromWorkspaceRoot`. So a workspace whose root keeps `"date-fns-v2": "npm:date-fns@2.30.0"` gave an importer `@base-ui/react@1.7.0(date-fns@2.30.0)` for an optional `date-fns@^4.0.0` peer, and `pnpm peers check` then flagged pnpm's own resolution as unmet, with `date-fns@4.4.0` already in the graph from a sibling importer.

The root's specifier now bounds the candidates only when it overlaps every wanted range. A pin that overlaps still wins, so the hoisting fixed in pnpm/pnpm#13369 is unaffected; a pin that is disjoint is ignored, and the highest version in the graph that satisfies the peer wins again, as it did before 11.18.0.

On the reproduction from the issue, `pkg-a` moves from `1.7.0(date-fns@2.30.0)` back to `1.7.0(date-fns@4.4.0)` and `pnpm peers check` reports no issues.

Fixes pnpm/pnpm#13867

## Squash Commit Body

```text
getHoistableOptionalPeers bounds its candidates by the workspace root's own
specifier for the package, so the root decides the version an optional peer
is hoisted at. A specifier disjoint from the declared peer range bounded the
candidates down to none: nothing was hoisted, and the importer then fell back
to the root's version through resolvePeersFromWorkspaceRoot, which is the very
version the peer range rejects. A root pinning date-fns 2.30.0 gave an
importer @base-ui/react(date-fns@2.30.0) for an optional date-fns@^4.0.0 peer
while date-fns@4.4.0 sat in the graph, and pnpm peers check then reported that
resolution as unmet.

The root's specifier is now consulted only when it overlaps every range
recorded for the peer. An overlapping pin still bounds the candidates as
before, so the hoisting corrected in pnpm/pnpm#13369 stays; a disjoint one is
dropped and the picker maximizes over the graph again.

Fixes pnpm/pnpm#13867
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13869"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789136143&installation_model_id=426870&pr_number=13869&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13869&signature=b2e384a78eb1becc47c234cfc18d04d6d71a7852ad302502aeb9ad3359da5a16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed optional peer dependency installation when a workspace root dependency specifies an incompatible version.
  * Incompatible or invalid root version ranges no longer prevent compatible optional peer versions from being selected.
  * Optional peers now correctly fall back to the highest preferred version that satisfies the requested version range.
  * Added regression coverage for aliased root dependencies with conflicting version specifications and multiple requested ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->