### PR TITLE
fix(add): add to the existing allowBuilds instead of replacing it

### DIFF
--- a/.changeset/add-allow-build-keeps-existing-entries.md
+++ b/.changeset/add-allow-build-keeps-existing-entries.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.commands": patch
+"pnpm": patch
+---
+
+`pnpm add --allow-build` now adds to the `allowBuilds` entries already in `pnpm-workspace.yaml` instead of replacing them [#13872](https://github.com/pnpm/pnpm/issues/13872).

--- a/pnpm11/installing/commands/src/add.ts
+++ b/pnpm11/installing/commands/src/add.ts
@@ -293,7 +293,7 @@ export async function handler (
         })
       }
     }
-    const allowBuilds: Record<string, boolean> = {}
+    const allowBuilds = { ...opts.allowBuilds }
     for (const pkg of opts.allowBuild) {
       allowBuilds[pkg] = true
     }
@@ -307,14 +307,9 @@ export async function handler (
         },
       })
     }
-    // Pass the allowed packages to allowBuilds so they can build during this install
-    const mergedAllowBuilds = { ...opts.allowBuilds }
-    for (const pkg of opts.allowBuild) {
-      mergedAllowBuilds[pkg] = true
-    }
     await installDeps({
       ...opts,
-      allowBuilds: mergedAllowBuilds,
+      allowBuilds,
       rebuildHandler: commands?.rebuild,
       include,
       includeDirect: include,

--- a/pnpm11/pnpm/test/install/lifecycleScripts.ts
+++ b/pnpm11/pnpm/test/install/lifecycleScripts.ts
@@ -188,7 +188,7 @@ test('--allow-build flag keeps the packages already listed in allowBuilds', asyn
   writeYamlFileSync('pnpm-workspace.yaml', {
     allowBuilds: { '@pnpm.e2e/install-script-example': true },
   })
-  execPnpmSync(['add', '--allow-build=@pnpm.e2e/pre-and-postinstall-scripts-example', '@pnpm.e2e/pre-and-postinstall-scripts-example@1.0.0'])
+  execPnpmSync(['add', '--allow-build=@pnpm.e2e/pre-and-postinstall-scripts-example', '@pnpm.e2e/pre-and-postinstall-scripts-example@1.0.0'], { expectSuccess: true })
 
   const modulesManifest = await readWorkspaceManifest(project.dir())
   expect(modulesManifest?.allowBuilds).toStrictEqual({

--- a/pnpm11/pnpm/test/install/lifecycleScripts.ts
+++ b/pnpm11/pnpm/test/install/lifecycleScripts.ts
@@ -190,8 +190,8 @@ test('--allow-build flag keeps the packages already listed in allowBuilds', asyn
   })
   execPnpmSync(['add', '--allow-build=@pnpm.e2e/pre-and-postinstall-scripts-example', '@pnpm.e2e/pre-and-postinstall-scripts-example@1.0.0'], { expectSuccess: true })
 
-  const modulesManifest = await readWorkspaceManifest(project.dir())
-  expect(modulesManifest?.allowBuilds).toStrictEqual({
+  const workspaceManifest = await readWorkspaceManifest(project.dir())
+  expect(workspaceManifest?.allowBuilds).toStrictEqual({
     '@pnpm.e2e/install-script-example': true,
     '@pnpm.e2e/pre-and-postinstall-scripts-example': true,
   })

--- a/pnpm11/pnpm/test/install/lifecycleScripts.ts
+++ b/pnpm11/pnpm/test/install/lifecycleScripts.ts
@@ -183,6 +183,20 @@ test('selectively allow scripts in some dependencies by --allow-build flag', asy
   })
 })
 
+test('--allow-build flag keeps the packages already listed in allowBuilds', async () => {
+  const project = prepare({})
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    allowBuilds: { '@pnpm.e2e/install-script-example': true },
+  })
+  execPnpmSync(['add', '--allow-build=@pnpm.e2e/pre-and-postinstall-scripts-example', '@pnpm.e2e/pre-and-postinstall-scripts-example@1.0.0'])
+
+  const modulesManifest = await readWorkspaceManifest(project.dir())
+  expect(modulesManifest?.allowBuilds).toStrictEqual({
+    '@pnpm.e2e/install-script-example': true,
+    '@pnpm.e2e/pre-and-postinstall-scripts-example': true,
+  })
+})
+
 test('--allow-build flag should specify the package', async () => {
   const project = prepare({})
   const result = execPnpmSync(['add', '@pnpm.e2e/pre-and-postinstall-scripts-example@1.0.0', '--allow-build'])


### PR DESCRIPTION
## Summary

`pnpm add --allow-build=foo` writes `allowBuilds` from scratch out of the names the flag carried, so anything already in `pnpm-workspace.yaml` is gone after the command:

```console
$ pnpm add unrs-resolver --allow-build=unrs-resolver
$ cat pnpm-workspace.yaml
allowBuilds:
  unrs-resolver: true

$ pnpm add esbuild --allow-build=esbuild
$ cat pnpm-workspace.yaml
allowBuilds:
  esbuild: true
```

The next install then reports `unrs-resolver` as an ignored build again.

The handler built two maps. One started empty and went to `writeSettings`, the other started from `opts.allowBuilds` and went to `installDeps`. Only the second carried what was already on disk, which is why the install itself still ran every approved build while the file quietly lost entries. Seeding the written map the same way fixes it and makes the second map redundant. `approve-builds` and `pnpm add -g` already merge this way.

pacquet needs no counterpart: `set_allow_builds` upserts one entry at a time into the existing document and never rewrites the block.

Fixes pnpm/pnpm#13872

## Squash Commit Body

```text
`pnpm add --allow-build` built the `allowBuilds` map it wrote to
pnpm-workspace.yaml out of the flag's names alone, dropping every entry
already there. A second map, seeded from the current settings, was built
for the install itself, so the approved builds still ran and only the
file lost entries.

Seed the written map from the current settings too, and drop the now
redundant second one. This matches `approve-builds` and `pnpm add -g`,
which already merge. pacquet upserts entries individually and was never
affected.

Fixes pnpm/pnpm#13872
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789145293&installation_model_id=426870&pr_number=13873&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13873&signature=51edcc99a2ba2f67f03c5b894102535f645fcf2bdafa09bdfa7ecc7a1d6577ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `pnpm add --allow-build` now preserves existing `allowBuilds` entries while adding newly approved packages.
* **Bug Fixes**
  * Prevented existing build permissions from being unintentionally replaced when approving additional packages.
  * Existing build approvals in `pnpm-workspace.yaml` remain effective after adding new package approvals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->