### PR TITLE
fix(config): read node-version from pnpm config env

### DIFF
--- a/.changeset/config-node-version-env.md
+++ b/.changeset/config-node-version-env.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config.reader": patch
+"pnpm": patch
+---
+
+Fixed `PNPM_CONFIG_NODE_VERSION` being ignored when setting the Node.js version used for compatibility checks.

--- a/pnpm/crates/cli/tests/suite/install_runtimes.rs
+++ b/pnpm/crates/cli/tests/suite/install_runtimes.rs
@@ -329,6 +329,36 @@ fn explicit_node_version_takes_priority_over_the_manifest_runtime() {
     command(&workspace).with_arg("install").assert().success();
 }
 
+#[test]
+fn node_version_from_the_environment_takes_priority_over_the_manifest_runtime() {
+    let root = tempfile::tempdir().unwrap();
+    let workspace = prepare_workspace(&root, "engineStrict: true\n");
+    let dependency = workspace.join("dependency");
+    fs::create_dir(&dependency).unwrap();
+    fs::write(
+        dependency.join("package.json"),
+        json!({ "name": "dependency", "version": "1.0.0", "engines": { "node": "<21" } })
+            .to_string(),
+    )
+    .unwrap();
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "dependencies": { "dependency": "file:dependency" },
+            "devEngines": {
+                "runtime": { "name": "node", "version": "^22.0.0", "onFail": "ignore" },
+            },
+        })
+        .to_string(),
+    )
+    .unwrap();
+    command(&workspace)
+        .with_env("PNPM_CONFIG_NODE_VERSION", "20.0.0")
+        .with_arg("install")
+        .assert()
+        .success();
+}
+
 fn assert_runtime_missing_offline(name: &'static str, version: &'static str) {
     let root = tempfile::tempdir().unwrap();
     let workspace = prepare_workspace(&root, "");

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -3043,6 +3043,19 @@ pub fn engine_strict_node_version_and_max_sockets_from_workspace_yaml() {
 }
 
 #[test]
+pub fn node_version_from_pnpm_config_env_overrides_workspace_yaml() {
+    fake_env!(load_with_fake_env);
+    let tmp = tempdir().unwrap();
+    fs::write(tmp.path().join("pnpm-workspace.yaml"), "nodeVersion: 18.20.4\n")
+        .expect("write to pnpm-workspace.yaml");
+
+    set_fake_env(&[("PNPM_CONFIG_NODE_VERSION", "20.0.0")]);
+    let config = load_with_fake_env(tmp.path());
+
+    assert_eq!(config.node_version.as_deref(), Some("20.0.0"));
+}
+
+#[test]
 pub fn catalog_prune_from_workspace_yaml() {
     let tmp = tempdir().unwrap();
     let config = Config::new().current::<HostNoHome>(tmp.path()).expect("loads");

--- a/pnpm11/config/reader/src/index.ts
+++ b/pnpm11/config/reader/src/index.ts
@@ -567,11 +567,11 @@ export async function getConfig (opts: {
     pnpmConfig.registry = pnpmConfig.registriesByScope.default
   }
 
-  // omit some schema that the custom parser can't yet handle
   const envPnpmTypes = omit([
-    'init-version', // the type is a private function named 'semver'
-    'node-version', // the type is a private function named 'semver'
-    'umask', // the type is a private function named 'Umask'
+    // Keep pnpm and pacquet's init behavior aligned until pacquet reads init config.
+    'init-version',
+    // npm interprets leading-zero values as octal, while the Number schema does not.
+    'umask',
   ], types)
 
   let virtualStoreTypeFromEnv: VirtualStoreType | undefined

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -33,6 +33,7 @@ for (const suffix of [
 ]) {
   delete process.env[`npm_config_${suffix}`]
   delete process.env[`pnpm_config_${suffix}`]
+  delete process.env[`PNPM_CONFIG_${suffix.toUpperCase()}`]
 }
 
 const env = {
@@ -100,6 +101,63 @@ test('nodeVersion from config takes priority over devEngines.runtime', async () 
   const { config } = await getConfig({
     cliOptions: {
       'node-version': '20.0.0',
+    },
+    packageManager: {
+      name: 'pnpm',
+      version: '1.0.0',
+    },
+  })
+
+  expect(config.nodeVersion).toBe('20.0.0')
+})
+
+test('nodeVersion is read from pnpm_config_* environment variables', async () => {
+  const { config } = await getConfig({
+    cliOptions: {},
+    env: {
+      PNPM_CONFIG_NODE_VERSION: '20.0.0',
+    },
+    packageManager: {
+      name: 'pnpm',
+      version: '1.0.0',
+    },
+  })
+
+  expect(config.nodeVersion).toBe('20.0.0')
+})
+
+test('nodeVersion from pnpm_config_* environment variables takes priority over devEngines.runtime', async () => {
+  prepare({
+    devEngines: {
+      runtime: {
+        name: 'node',
+        version: '22.20.0',
+        onFail: 'download',
+      },
+    },
+  })
+
+  const { config } = await getConfig({
+    cliOptions: {},
+    env: {
+      PNPM_CONFIG_NODE_VERSION: '20.0.0',
+    },
+    packageManager: {
+      name: 'pnpm',
+      version: '1.0.0',
+    },
+  })
+
+  expect(config.nodeVersion).toBe('20.0.0')
+})
+
+test('nodeVersion from config takes priority over pnpm_config_* environment variables', async () => {
+  const { config } = await getConfig({
+    cliOptions: {
+      'node-version': '20.0.0',
+    },
+    env: {
+      PNPM_CONFIG_NODE_VERSION: '22.20.0',
     },
     packageManager: {
       name: 'pnpm',

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -111,7 +111,7 @@ test('nodeVersion from config takes priority over devEngines.runtime', async () 
   expect(config.nodeVersion).toBe('20.0.0')
 })
 
-test('nodeVersion is read from pnpm_config_* environment variables', async () => {
+test('nodeVersion is read from the PNPM_CONFIG_NODE_VERSION environment variable', async () => {
   const { config } = await getConfig({
     cliOptions: {},
     env: {
@@ -126,7 +126,7 @@ test('nodeVersion is read from pnpm_config_* environment variables', async () =>
   expect(config.nodeVersion).toBe('20.0.0')
 })
 
-test('nodeVersion from pnpm_config_* environment variables takes priority over devEngines.runtime', async () => {
+test('nodeVersion from PNPM_CONFIG_NODE_VERSION takes priority over devEngines.runtime', async () => {
   prepare({
     devEngines: {
       runtime: {
@@ -151,7 +151,7 @@ test('nodeVersion from pnpm_config_* environment variables takes priority over d
   expect(config.nodeVersion).toBe('20.0.0')
 })
 
-test('nodeVersion from config takes priority over pnpm_config_* environment variables', async () => {
+test('nodeVersion from config takes priority over PNPM_CONFIG_NODE_VERSION', async () => {
   const { config } = await getConfig({
     cliOptions: {
       'node-version': '20.0.0',


### PR DESCRIPTION
## Summary

Related to pnpm/pnpm#11254.

Restore `PNPM_CONFIG_NODE_VERSION` support in the TypeScript CLI's environment config reader. The key was excluded when its schema used a private semver parser, but it is now declared as `[null, String]`, which the current parser supports.

This changes only the Node.js version used for compatibility checks; it does not change the runtime that executes pnpm. The Rust CLI already reads `PNPM_CONFIG_NODE_VERSION`, so this restores parity without a pacquet production change.

The regression tests cover environment loading and the existing precedence contract: CLI > environment > `devEngines.runtime`.

## Squash Commit Body

```text
The pnpm_config environment reader excluded node-version when its npm config schema used a private semver parser. The schema is now parser-supported, but the exclusion remained and caused PNPM_CONFIG_NODE_VERSION to be ignored.

Remove only the stale node-version exclusion. Keep init-version excluded until pnpm and pacquet have matching init config behavior, and keep umask excluded because Number parsing does not preserve npm's octal semantics.

Add regression coverage for environment loading and CLI/environment/manifest precedence.

Related to pnpm/pnpm#11254.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs linked to it solves this.
- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port. The Rust port already supports this environment variable.
- [x] Added a changeset (`pnpm changeset`) for `@pnpm/config.reader` and `pnpm`.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789145389&installation_model_id=426870&pr_number=13874&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13874&signature=773027e703bc8a5a56a0456b78cb5c99d86b6dc60c7f85db0730bd5134ee57ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed compatibility checks so `PNPM_CONFIG_NODE_VERSION` is correctly recognized.
  - Restored expected precedence when determining the Node.js version: command-line and configuration settings take priority over environment variables, which take priority over runtime recommendations.
  - Improved handling of initialization version and `umask` environment settings for better compatibility.
  - Ensured uppercase PNPM configuration environment variables are consistently recognized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->