### PR TITLE
test(pacquet): speed up the yaml scalar-budget lockfile test

### DIFF
--- a/.changeset/fix-allow-build.md
+++ b/.changeset/fix-allow-build.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-installation": patch
+"pnpm": patch
+---
+
+Fixed a bug where \`pnpm add --allow-build\` replaces existing \`allowBuilds\` config in \`pnpm-workspace.yaml\` instead of modifying it [#13872](https://github.com/pnpm/pnpm/issues/13872).

--- a/.changeset/fix-allow-build.md
+++ b/.changeset/fix-allow-build.md
@@ -1,6 +1,0 @@
----
-"@pnpm/plugin-commands-installation": patch
-"pnpm": patch
----
-
-Fixed a bug where \`pnpm add --allow-build\` replaces existing \`allowBuilds\` config in \`pnpm-workspace.yaml\` instead of modifying it [#13872](https://github.com/pnpm/pnpm/issues/13872).

--- a/pnpm/crates/fs/src/symlink_dir.rs
+++ b/pnpm/crates/fs/src/symlink_dir.rs
@@ -94,11 +94,11 @@ pub fn is_symlink_or_junction(link: &Path) -> io::Result<bool> {
         // rather than `Ok(false)`; for this question that is a plain
         // "no".
         const ERROR_NOT_A_REPARSE_POINT: i32 = 4390;
-        return match junction::exists(link) {
+        match junction::exists(link) {
             Ok(is_junction) => Ok(is_junction),
             Err(error) if error.raw_os_error() == Some(ERROR_NOT_A_REPARSE_POINT) => Ok(false),
             Err(error) => Err(error),
-        };
+        }
     }
     #[cfg(not(windows))]
     Ok(link.is_symlink())

--- a/pnpm/crates/injected-deps-syncer/src/dir_patcher.rs
+++ b/pnpm/crates/injected-deps-syncer/src/dir_patcher.rs
@@ -327,7 +327,7 @@ fn windows_file_id(path: &Path) -> io::Result<FileId> {
     let mut info = MaybeUninit::<BY_HANDLE_FILE_INFORMATION>::uninit();
     // SAFETY: `file` owns a valid handle for this call and `info` points to
     // writable storage of the exact structure the API initializes.
-    if unsafe { GetFileInformationByHandle(file.as_raw_handle() as _, info.as_mut_ptr()) } == 0 {
+    if unsafe { GetFileInformationByHandle(file.as_raw_handle().cast(), info.as_mut_ptr()) } == 0 {
         return Err(io::Error::last_os_error());
     }
     // SAFETY: a successful `GetFileInformationByHandle` initializes `info`.

--- a/pnpm/crates/lockfile/src/load_lockfile/tests.rs
+++ b/pnpm/crates/lockfile/src/load_lockfile/tests.rs
@@ -139,25 +139,22 @@ fn parses_lockfile_larger_than_default_yaml_node_budget() {
 
 #[test]
 fn parses_lockfile_larger_than_default_yaml_scalar_byte_budget() {
-    const IMPORTER_COUNT: usize = 1_000_000;
+    // A single huge scalar to push the document past the parser's 64 MiB default scalar budget,
+    // avoiding the O(N) allocation overhead of creating millions of individual AST nodes.
+    let mut content = String::from("lockfileVersion: '9.0'\n\npnpmfileChecksum: ");
+    let huge_string_len = 65 * 1024 * 1024;
+    content.reserve(huge_string_len + 100);
+    content.push_str(&"a".repeat(huge_string_len));
+    content.push_str("\n\nimporters:\n  .: {}\n");
 
-    // Each importer line contributes ~100 bytes of scalar text, pushing the
-    // document past the parser's 64 MiB default scalar budget.
-    let mut content = String::from("lockfileVersion: '9.0'\n\nimporters:\n");
-    for index in 0..IMPORTER_COUNT {
-        writeln!(
-            content,
-            "  padded-project-directory-name/deeply/nested/workspace-component-{index:07}: {{}}",
-        )
-        .expect("write importer");
-    }
     assert!(content.len() > 64 * 1024 * 1024, "fixture must exceed the default scalar budget");
 
     let lockfile = Lockfile::parse(&content, Path::new(Lockfile::FILE_NAME))
         .expect("parse large lockfile")
         .expect("large lockfile should be present");
 
-    assert_eq!(lockfile.importers.len(), IMPORTER_COUNT);
+    assert!(lockfile.pnpmfile_checksum.is_some());
+    assert_eq!(lockfile.pnpmfile_checksum.unwrap().len(), huge_string_len);
 }
 
 // A regression here makes every subsequent install re-resolve from

--- a/pnpm11/pnpm/test/install/lifecycleScripts.ts
+++ b/pnpm11/pnpm/test/install/lifecycleScripts.ts
@@ -186,13 +186,17 @@ test('selectively allow scripts in some dependencies by --allow-build flag', asy
 test('--allow-build flag keeps the packages already listed in allowBuilds', async () => {
   const project = prepare({})
   writeYamlFileSync('pnpm-workspace.yaml', {
-    allowBuilds: { '@pnpm.e2e/install-script-example': true },
+    allowBuilds: {
+      '@pnpm.e2e/install-script-example': true,
+      'some-string-package': 'reason',
+    },
   })
   execPnpmSync(['add', '--allow-build=@pnpm.e2e/pre-and-postinstall-scripts-example', '@pnpm.e2e/pre-and-postinstall-scripts-example@1.0.0'], { expectSuccess: true })
 
   const workspaceManifest = await readWorkspaceManifest(project.dir())
   expect(workspaceManifest?.allowBuilds).toStrictEqual({
     '@pnpm.e2e/install-script-example': true,
+    'some-string-package': 'reason',
     '@pnpm.e2e/pre-and-postinstall-scripts-example': true,
   })
 })


### PR DESCRIPTION
## Summary

This PR started as a fix for `pnpm add --allow-build` replacing the existing `allowBuilds` config ([pnpm/pnpm#13872](https://github.com/pnpm/pnpm/issues/13872)). That fix landed on main via [pnpm/pnpm#13873](https://github.com/pnpm/pnpm/pull/13873) while this PR was open, so after rebasing, the production TypeScript change is gone and what remains is the still-useful rest:

- **Speed up pacquet's yaml scalar-budget lockfile test.** The test built a 96 MB document out of a million importer lines, so parsing allocated a million AST nodes — on a dev machine it runs for over 10 minutes (measured: killed at 10 minutes, unfinished). A single 65 MiB scalar crosses the same 64 MiB scalar budget the test guards, and passes in 0.7 s.
- Two Windows-only cleanups, validated by Windows CI: drop a needless `return` in `pnpm-fs`'s `is_symlink_or_junction`, and use `.cast()` instead of `as _` for the raw handle passed to `GetFileInformationByHandle` in the injected-deps syncer.
- Extend the `--allow-build` merge test (added by pnpm/pnpm#13873) to also cover a string-valued `allowBuilds` entry surviving the merge.

No changeset: nothing here is user-visible (the original changeset was dropped as a duplicate of the one that landed with pnpm/pnpm#13873).

## Squash Commit Body

```text
The scalar-budget regression test built a 96 MB lockfile out of a
million importer lines, so parsing allocated a million AST nodes and
the test ran for many minutes (or timed out) instead of exercising the
one thing it guards: that a document larger than the parser's 64 MiB
default scalar budget still parses. A single 65 MiB scalar crosses the
same budget and parses in under a second.

Also drops a needless `return` in pnpm-fs's is_symlink_or_junction,
uses `.cast()` instead of `as _` for the raw handle passed to
GetFileInformationByHandle in the injected-deps syncer, and extends
the --allow-build merge test with a string-valued allowBuilds entry.

The allowBuilds fix this PR originally carried was superseded by
pnpm/pnpm#13873 (Closes pnpm/pnpm#13872 there).
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. (Test-only
  and internal changes; nothing user-visible to mirror.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
  (Not needed: no user-visible change.)
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).
