### PR TITLE
fix(resolver): resolve hoisted peers as subdeps under resolutionMode

### DIFF
--- a/.changeset/hoisted-peers-resolve-as-subdeps.md
+++ b/.changeset/hoisted-peers-resolve-as-subdeps.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Auto-installed peer dependencies are no longer resolved to their lowest satisfying versions under `resolutionMode: lowest-direct` or `time-based`. A hoisted peer is not a dependency the project declares, so it resolves like a transitive dependency — to the highest version satisfying the peer range [#13871](https://github.com/pnpm/pnpm/pull/13871).
+Auto-installed peer dependencies are no longer resolved to their lowest satisfying versions under `resolutionMode: lowest-direct` or `time-based`. A hoisted peer is not a dependency the project declares, so it resolves like a transitive dependency — to the highest version satisfying the peer range (under `time-based`, the highest within the publish-date cutoff) [#13871](https://github.com/pnpm/pnpm/pull/13871).

--- a/.changeset/hoisted-peers-resolve-as-subdeps.md
+++ b/.changeset/hoisted-peers-resolve-as-subdeps.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Auto-installed peer dependencies are no longer resolved to their lowest satisfying versions under `resolutionMode: lowest-direct` or `time-based`. A hoisted peer is not a dependency the project declares, so it resolves like a transitive dependency — to the highest version satisfying the peer range [#13871](https://github.com/pnpm/pnpm/pull/13871).

--- a/pnpm/crates/cli/tests/suite/install.rs
+++ b/pnpm/crates/cli/tests/suite/install.rs
@@ -1567,11 +1567,7 @@ fn resolution_mode_time_based_applies_under_a_minimum_release_age() {
 
 /// A hoisted (auto-installed) peer is not a dependency the user
 /// declared, so the direct-dep pick of `lowest-direct` must not apply
-/// to it even though it lands at the importer level: like any
-/// transitive dep, it resolves to the highest satisfying version.
-/// `@pnpm.e2e/abc-parent-with-missing-peers` pulls in `@pnpm.e2e/abc`,
-/// whose `@pnpm.e2e/peer-a: ^1.0.0` peer nothing provides; the
-/// auto-install must land on `1.0.1`, not `1.0.0`.
+/// to it even though it installs at the importer level.
 #[test]
 fn resolution_mode_lowest_direct_resolves_hoisted_peers_to_highest() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
@@ -1596,6 +1592,38 @@ fn resolution_mode_lowest_direct_resolves_hoisted_peers_to_highest() {
     assert!(
         pnpm_dir.join("@pnpm.e2e+peer-a@1.0.1").exists(),
         "the hoisted peer must resolve to the highest satisfying version under lowest-direct",
+    );
+    assert!(!pnpm_dir.join("@pnpm.e2e+peer-a@1.0.0").exists());
+
+    drop((root, mock_instance));
+}
+
+/// `time-based` shares the hoisted-peer rule with `lowest-direct`: the
+/// hoist resolves like a transitive dep — highest satisfying, under the
+/// subdep publish-date cutoff.
+#[test]
+fn resolution_mode_time_based_resolves_hoisted_peers_to_highest() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let workspace_yaml = workspace.join("pnpm-workspace.yaml");
+    let mut existing = fs::read_to_string(&workspace_yaml).expect("read pnpm-workspace.yaml");
+    existing.push_str("resolutionMode: time-based\nminimumReleaseAge: 0\nautoInstallPeers: true\n");
+    fs::write(&workspace_yaml, existing).expect("write pnpm-workspace.yaml");
+
+    let manifest_path = workspace.join("package.json");
+    let package_json_content = serde_json::json!({
+        "dependencies": { "@pnpm.e2e/abc-parent-with-missing-peers": "1.0.0" },
+    });
+    fs::write(&manifest_path, package_json_content.to_string()).expect("write to package.json");
+
+    pacquet.with_arg("install").assert().success();
+
+    let pnpm_dir = workspace.join("node_modules/.pnpm");
+    assert!(
+        pnpm_dir.join("@pnpm.e2e+peer-a@1.0.1").exists(),
+        "the hoisted peer must resolve to the highest satisfying version under time-based",
     );
     assert!(!pnpm_dir.join("@pnpm.e2e+peer-a@1.0.0").exists());
 

--- a/pnpm/crates/cli/tests/suite/install.rs
+++ b/pnpm/crates/cli/tests/suite/install.rs
@@ -1565,6 +1565,43 @@ fn resolution_mode_time_based_applies_under_a_minimum_release_age() {
     drop((root, mock_instance));
 }
 
+/// A hoisted (auto-installed) peer is not a dependency the user
+/// declared, so the direct-dep pick of `lowest-direct` must not apply
+/// to it even though it lands at the importer level: like any
+/// transitive dep, it resolves to the highest satisfying version.
+/// `@pnpm.e2e/abc-parent-with-missing-peers` pulls in `@pnpm.e2e/abc`,
+/// whose `@pnpm.e2e/peer-a: ^1.0.0` peer nothing provides; the
+/// auto-install must land on `1.0.1`, not `1.0.0`.
+#[test]
+fn resolution_mode_lowest_direct_resolves_hoisted_peers_to_highest() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let workspace_yaml = workspace.join("pnpm-workspace.yaml");
+    let mut existing = fs::read_to_string(&workspace_yaml).expect("read pnpm-workspace.yaml");
+    existing
+        .push_str("resolutionMode: lowest-direct\nminimumReleaseAge: 0\nautoInstallPeers: true\n");
+    fs::write(&workspace_yaml, existing).expect("write pnpm-workspace.yaml");
+
+    let manifest_path = workspace.join("package.json");
+    let package_json_content = serde_json::json!({
+        "dependencies": { "@pnpm.e2e/abc-parent-with-missing-peers": "1.0.0" },
+    });
+    fs::write(&manifest_path, package_json_content.to_string()).expect("write to package.json");
+
+    pacquet.with_arg("install").assert().success();
+
+    let pnpm_dir = workspace.join("node_modules/.pnpm");
+    assert!(
+        pnpm_dir.join("@pnpm.e2e+peer-a@1.0.1").exists(),
+        "the hoisted peer must resolve to the highest satisfying version under lowest-direct",
+    );
+    assert!(!pnpm_dir.join("@pnpm.e2e+peer-a@1.0.0").exists());
+
+    drop((root, mock_instance));
+}
+
 /// Dropping `time:` would lose the publish dates a re-resolve falls back
 /// on when the registry's abbreviated metadata carries none, changing the
 /// cutoff every subdependency is resolved under.

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/tree_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/tree_ctx.rs
@@ -217,6 +217,22 @@ impl TreeCtx {
         self
     }
 
+    /// Resolve the depth-0 walks that follow with the subdep options.
+    ///
+    /// The importer orchestrator calls this once the manifest-declared
+    /// direct deps have seeded: every later [`extend_tree`] on this ctx
+    /// installs hoisted peers, which pnpm resolves like transitive deps
+    /// (highest satisfying version, under the subdep publish-date
+    /// cutoff) even though they land at the importer level — a hoisted
+    /// peer is not a dependency the user declared, so the direct-dep
+    /// pick of `resolutionMode: lowest-direct` / `time-based` must not
+    /// apply to it.
+    ///
+    /// [`extend_tree`]: super::extend_tree
+    pub fn resolve_new_direct_deps_as_subdeps(&mut self) {
+        self.direct_opts = self.subdep_opts.clone();
+    }
+
     /// The [`ResolveOptions`] to hand the resolver for a node at the
     /// given `depth`: importer-level deps (`depth == 0`) use
     /// [`Self::direct_opts`]; everything below uses

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -460,7 +460,7 @@ impl ImporterHoistState {
         )?;
         let project_dir = base_opts.project_dir.clone();
         let tree_lockfile_dir = lockfile_dir.clone().unwrap_or_else(|| project_dir.clone());
-        let ctx = TreeCtx::with_workspace(workspace, base_opts)
+        let mut ctx = TreeCtx::with_workspace(workspace, base_opts)
             .with_lockfile_dir(&tree_lockfile_dir)
             .with_importer_id(importer_id)
             .with_importer_order(importer_order)
@@ -502,6 +502,9 @@ impl ImporterHoistState {
         .await?;
         ctx.workspace().set_direct_locked_peer_names(&direct, &locked_peer_names_by_alias);
         parent_pkg_aliases.extend(direct.iter().map(|dep| dep.alias.clone()));
+        // Everything extend_tree walks from here on is a hoisted peer;
+        // see [`TreeCtx::resolve_new_direct_deps_as_subdeps`].
+        ctx.resolve_new_direct_deps_as_subdeps();
         Ok(ImporterHoistState {
             importer_id: importer_id.to_string(),
             ctx,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -502,8 +502,6 @@ impl ImporterHoistState {
         .await?;
         ctx.workspace().set_direct_locked_peer_names(&direct, &locked_peer_names_by_alias);
         parent_pkg_aliases.extend(direct.iter().map(|dep| dep.alias.clone()));
-        // Everything extend_tree walks from here on is a hoisted peer;
-        // see [`TreeCtx::resolve_new_direct_deps_as_subdeps`].
         ctx.resolve_new_direct_deps_as_subdeps();
         Ok(ImporterHoistState {
             importer_id: importer_id.to_string(),

--- a/pnpm11/installing/deps-installer/test/install/resolutionMode.ts
+++ b/pnpm11/installing/deps-installer/test/install/resolutionMode.ts
@@ -117,14 +117,27 @@ test('a hoisted peer of a transitive dependency is resolved to its highest satis
   await addDistTag({ package: '@pnpm.e2e/peer-a', version: '1.0.1', distTag: 'latest' })
   const project = prepareEmpty()
 
-  // A hoisted (auto-installed) peer is not a dependency the user declared,
-  // so the direct-dep pick of lowest-direct must not apply to it even though
-  // it is installed at the importer level.
+  // A hoisted peer is not a dependency the user declared, so the direct-dep pick must not apply to it.
   await install({
     dependencies: {
       '@pnpm.e2e/abc-parent-with-missing-peers': '1.0.0',
     },
   }, testDefaults({ resolutionMode: 'lowest-direct', autoInstallPeers: true }))
+
+  const lockfile = project.readLockfile()
+  expect(lockfile.packages['@pnpm.e2e/peer-a@1.0.1']).toBeTruthy()
+  expect(lockfile.packages['@pnpm.e2e/peer-a@1.0.0']).toBeFalsy()
+})
+
+test('a hoisted peer of a transitive dependency is resolved to its highest satisfying version when resolution mode is time-based', async () => {
+  await addDistTag({ package: '@pnpm.e2e/peer-a', version: '1.0.1', distTag: 'latest' })
+  const project = prepareEmpty()
+
+  await install({
+    dependencies: {
+      '@pnpm.e2e/abc-parent-with-missing-peers': '1.0.0',
+    },
+  }, testDefaults({ resolutionMode: 'time-based', autoInstallPeers: true }))
 
   const lockfile = project.readLockfile()
   expect(lockfile.packages['@pnpm.e2e/peer-a@1.0.1']).toBeTruthy()

--- a/pnpm11/installing/deps-installer/test/install/resolutionMode.ts
+++ b/pnpm11/installing/deps-installer/test/install/resolutionMode.ts
@@ -113,6 +113,24 @@ test('the lowest version of a direct dependency is installed when a minimum rele
   expect(lockfile.packages['@pnpm.e2e/pkg-with-1-dep@100.1.0']).toBeFalsy()
 })
 
+test('a hoisted peer of a transitive dependency is resolved to its highest satisfying version when resolution mode is lowest-direct', async () => {
+  await addDistTag({ package: '@pnpm.e2e/peer-a', version: '1.0.1', distTag: 'latest' })
+  const project = prepareEmpty()
+
+  // A hoisted (auto-installed) peer is not a dependency the user declared,
+  // so the direct-dep pick of lowest-direct must not apply to it even though
+  // it is installed at the importer level.
+  await install({
+    dependencies: {
+      '@pnpm.e2e/abc-parent-with-missing-peers': '1.0.0',
+    },
+  }, testDefaults({ resolutionMode: 'lowest-direct', autoInstallPeers: true }))
+
+  const lockfile = project.readLockfile()
+  expect(lockfile.packages['@pnpm.e2e/peer-a@1.0.1']).toBeTruthy()
+  expect(lockfile.packages['@pnpm.e2e/peer-a@1.0.0']).toBeFalsy()
+})
+
 test('the lowest version of a direct dependency is installed in time-based mode when a minimum release age is also configured', async () => {
   await addDistTag({ package: '@pnpm.e2e/pkg-with-1-dep', version: '100.1.0', distTag: 'latest' })
   const project = prepareEmpty()


### PR DESCRIPTION
## Summary

Under `resolutionMode: lowest-direct` (or `time-based`), pacquet resolved auto-installed (hoisted) peers of transitive dependencies to the **lowest** version satisfying the peer range. A hoisted peer is installed at the importer level, so the hoist arms of the importer orchestrator re-entered the tree walk at depth 0 and inherited the direct-dep pick options. The TypeScript CLI resolves hoisted peers through `importer.options`, which never carries `pickLowestVersion` — they resolve like transitive deps, to the highest satisfying version.

This is what blew up the lockfile diff in pnpm/pnpm#13871 (Related to pnpm/pnpm#13871): clipanion's `typanion: *` peer (deep under `@yarnpkg/core` / `@yarnpkg/shell`) resolved to `typanion@1.0.0`, whose published manifest ships its build tooling (`@babel/preset-env`, mocha, rollup, `@wessberg/*`, …) as runtime `dependencies`, dragging ~136 spurious packages into the lockfile. The bug was latent — before pnpm/pnpm#13831, any active release-age cutoff (including the built-in `minimumReleaseAge` default) disabled `resolutionMode` entirely — and pnpm/pnpm#13831 unmasked it.

The fix: once `ImporterHoistState::init` has seeded the manifest-declared direct deps, the importer's `TreeCtx` switches its depth-0 pick options to the subdep options (`TreeCtx::resolve_new_direct_deps_as_subdeps`). Every `extend_tree` after that point installs hoisted peers (required or optional), which now pick the highest satisfying version under the subdep publish-date cutoff — also matching the TypeScript CLI's `time-based` behavior, where hoisted peers resolve under the computed `publishedBy` cutoff. The importer's own manifest `peerDependencies` under `autoInstallPeers` still get the direct-dep pick, as in the TypeScript CLI.

The TypeScript CLI needed no behavior change; it gains a pinning test for the same scenario. Verified end-to-end against the real registry: the `@yarnpkg/shell` fixture resolves typanion to 3.14.0 again, while a direct `undici: ^7.27.2` under `minimumReleaseAge` still lands on 7.27.2 (the pnpm/pnpm#13831 fix is preserved). The change is outside `resolve_peers`, adds one `ResolveOptions` clone per importer, and leaves cache-key shapes unchanged, so it is perf-neutral.

## Squash Commit Body

```text
An auto-installed (hoisted) peer of a transitive dependency was
resolved with the importer-level pick options, so under
resolutionMode: lowest-direct / time-based it landed on the lowest
version satisfying the peer range. A hoisted peer is not a dependency
the user declared: the TypeScript CLI resolves it like a transitive
dep, to the highest satisfying version under the subdep publish-date
cutoff. pacquet now switches the importer ctx's depth-0 pick options
to the subdep options once the manifest-declared direct deps have
seeded — everything extend_tree walks after that point is a hoist arm.

The bug was latent (any active release-age cutoff disabled
resolutionMode entirely, masking it) and was unmasked by
pnpm/pnpm#13831. It surfaced in pnpm/pnpm#13871, where clipanion's
typanion "*" peer resolved to typanion@1.0.0 - whose published
manifest ships its build tooling as runtime dependencies - adding
~136 spurious packages to the lockfile.

The TypeScript CLI already behaves this way; it gains a pinning test
for the same scenario.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13877"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789152935&installation_model_id=426870&pr_number=13877&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13877&signature=6213a9a6567e15d8668883a1d27a6823f73c4a94de8bbcb80260920e77ecee78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected peer-dependency resolution for `lowest-direct` and `time-based` modes.
  * Auto-installed hoisted peers now resolve like transitive dependencies, selecting the highest version that satisfies the peer range.

* **Tests**
  * Added regression coverage for hoisted peer resolution across installation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->