### PR TITLE
fix(lockfile): keep a recorded deprecation when an unchanged resolution is rebuilt

### DIFF
--- a/.changeset/preserve-unchanged-package-metadata.md
+++ b/.changeset/preserve-unchanged-package-metadata.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.deps-resolver": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+A lockfile entry whose resolution is unchanged no longer loses its recorded `deprecated` marker when a registry serves the package's metadata inconsistently — re-resolving to the same version keeps the deprecation instead of silently dropping the line [#13846](https://github.com/pnpm/pnpm/issues/13846).

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -723,12 +723,10 @@ fn build_packages_and_snapshots(
                 None => (sources.registry, sources.lockfile_include_tarball_url),
             };
             let mut metadata = build_package_metadata(node, key, registry, include_tarball_url);
-            // `deprecated` is the one registry-mutable field of a
-            // published version, and registries have been observed
-            // serving it inconsistently. An unchanged resolution never
-            // loses a recorded deprecation to such drift; a genuinely
-            // new deprecation still flows in through the fresh
-            // metadata.
+            // `deprecated` is the only registry-mutable field of a
+            // published version; an unchanged resolution must not lose
+            // a recorded deprecation to a registry serving it
+            // inconsistently (pnpm/pnpm#13846).
             if metadata.deprecated.is_none()
                 && let Some(previous) = sources.previous_packages.and_then(|prev| prev.get(key))
                 && previous.resolution == metadata.resolution

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -123,6 +123,10 @@ pub struct GraphToLockfileOptions<'a> {
     /// previous lockfile (a first install) or when `dedupeInjectedDeps`
     /// is off.
     pub previous_importers: Option<&'a HashMap<String, ProjectSnapshot>>,
+    /// The previous run's `packages:` map. A rebuilt entry whose
+    /// resolution is unchanged never loses a recorded `deprecated`
+    /// marker to registry metadata drift. `None` on a first install.
+    pub previous_packages: Option<&'a HashMap<PackageKey, PackageMetadata>>,
     /// How this install reuses the prior resolution, mapped from the
     /// `pacquet update` seed policy. Together with a spec change it
     /// decides whether an importer's workspace dependency is *targeted*
@@ -214,6 +218,7 @@ pub fn dependencies_graph_to_lockfile(
         named_registries,
         lockfile_include_tarball_url,
         previous_importers,
+        previous_packages,
         update_reuse_scope,
         update_reuse_scopes_by_importer,
         time,
@@ -223,9 +228,12 @@ pub fn dependencies_graph_to_lockfile(
     let (packages, snapshots) = build_packages_and_snapshots(
         graph,
         &optional_overrides,
-        registry,
-        named_registries,
-        lockfile_include_tarball_url,
+        &PackageMetadataSources {
+            registry,
+            named_registries,
+            lockfile_include_tarball_url,
+            previous_packages,
+        },
     )?;
 
     let mut importers: HashMap<String, ProjectSnapshot> =
@@ -658,12 +666,19 @@ type PackagesAndSnapshots =
 /// `optional_overrides` carries the corrected `optional` flag per
 /// depPath produced by [`compute_corrected_optional`]; a missing
 /// entry falls back to [`DependenciesGraphNode::optional`].
+/// What [`build_packages_and_snapshots`] renders `packages:` entries
+/// from, beyond the graph itself.
+struct PackageMetadataSources<'a> {
+    registry: &'a str,
+    named_registries: &'a HashMap<String, String>,
+    lockfile_include_tarball_url: bool,
+    previous_packages: Option<&'a HashMap<PackageKey, PackageMetadata>>,
+}
+
 fn build_packages_and_snapshots(
     graph: &DependenciesGraph,
     optional_overrides: &HashMap<DepPath, bool>,
-    registry: &str,
-    named_registries: &HashMap<String, String>,
-    lockfile_include_tarball_url: bool,
+    sources: &PackageMetadataSources<'_>,
 ) -> Result<PackagesAndSnapshots, DependenciesGraphToLockfileError> {
     let mut packages: HashMap<PackageKey, PackageMetadata> = HashMap::new();
     let mut snapshots: HashMap<PackageKey, SnapshotEntry> = HashMap::new();
@@ -699,13 +714,28 @@ fn build_packages_and_snapshots(
             // entry that no install can fetch. Keeping the URL is always
             // recoverable, so an unknown alias forces it to be written.
             let (registry, include_tarball_url) = match key.suffix.registry_qualified() {
-                Some((registry_name, _)) => match named_registries.get(registry_name) {
-                    Some(named_registry) => (named_registry.as_str(), lockfile_include_tarball_url),
-                    None => (registry, true),
+                Some((registry_name, _)) => match sources.named_registries.get(registry_name) {
+                    Some(named_registry) => {
+                        (named_registry.as_str(), sources.lockfile_include_tarball_url)
+                    }
+                    None => (sources.registry, true),
                 },
-                None => (registry, lockfile_include_tarball_url),
+                None => (sources.registry, sources.lockfile_include_tarball_url),
             };
-            build_package_metadata(node, key, registry, include_tarball_url)
+            let mut metadata = build_package_metadata(node, key, registry, include_tarball_url);
+            // `deprecated` is the one registry-mutable field of a
+            // published version, and registries have been observed
+            // serving it inconsistently. An unchanged resolution never
+            // loses a recorded deprecation to such drift; a genuinely
+            // new deprecation still flows in through the fresh
+            // metadata.
+            if metadata.deprecated.is_none()
+                && let Some(previous) = sources.previous_packages.and_then(|prev| prev.get(key))
+                && previous.resolution == metadata.resolution
+            {
+                metadata.deprecated.clone_from(&previous.deprecated);
+            }
+            metadata
         });
     }
 

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -2835,10 +2835,8 @@ fn an_unresolvable_alias_keeps_the_tarball_url() {
     }
 }
 
-/// Registries can serve a `deprecated` flag that comes and goes
-/// upstream (pnpm/pnpm#13846). An entry whose resolution is unchanged
-/// never loses a recorded deprecation to that drift; a changed
-/// resolution takes the freshly served metadata.
+/// pnpm/pnpm#13846: registries serve `deprecated` inconsistently for
+/// the same published version.
 #[test]
 fn unchanged_resolutions_keep_their_previous_package_metadata() {
     let (_tmp, manifest) = write_manifest(json!({

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -7,8 +7,9 @@ use indexmap::IndexMap;
 use pacquet_deps_path::DepPath;
 use pacquet_lockfile::{
     DirectoryResolution, GitResolution, ImporterDepVersion, LockfileResolution, PackageKey,
-    PkgName, PkgNameVer, ProjectSnapshot, RegistryResolution, ResolvedDependencyMap,
-    ResolvedDependencySpec, SnapshotDepRef, TarballResolution, VariationsResolution,
+    PackageMetadata, PkgName, PkgNameVer, ProjectSnapshot, RegistryResolution,
+    ResolvedDependencyMap, ResolvedDependencySpec, SnapshotDepRef, TarballResolution,
+    VariationsResolution,
 };
 use pacquet_package_manifest::PackageManifest;
 use pacquet_resolving_deps_resolver::{
@@ -82,6 +83,7 @@ fn single_importer_opts<'a>(
         registry: "https://registry.npmjs.org",
         lockfile_include_tarball_url: false,
         previous_importers: None,
+        previous_packages: None,
         update_reuse_scope: UpdateReuseScope::All,
         update_reuse_scopes_by_importer: BTreeMap::new(),
         time: BTreeMap::new(),
@@ -477,6 +479,7 @@ fn dedupe_peers_round_trips_through_lockfile_settings() {
         registry: "https://registry.npmjs.org",
         lockfile_include_tarball_url: false,
         previous_importers: None,
+        previous_packages: None,
         update_reuse_scope: UpdateReuseScope::All,
         update_reuse_scopes_by_importer: BTreeMap::new(),
         time: BTreeMap::new(),
@@ -509,6 +512,7 @@ fn dedupe_peers_round_trips_through_lockfile_settings() {
         registry: "https://registry.npmjs.org",
         lockfile_include_tarball_url: false,
         previous_importers: None,
+        previous_packages: None,
         update_reuse_scope: UpdateReuseScope::All,
         update_reuse_scopes_by_importer: BTreeMap::new(),
         time: BTreeMap::new(),
@@ -595,6 +599,7 @@ fn patched_dependencies_flow_into_lockfile_and_empty_is_omitted() {
             registry: "https://registry.npmjs.org",
             lockfile_include_tarball_url: false,
             previous_importers: None,
+            previous_packages: None,
             update_reuse_scope: UpdateReuseScope::All,
             update_reuse_scopes_by_importer: BTreeMap::new(),
             time: BTreeMap::new(),
@@ -754,6 +759,7 @@ fn aliased_catalog_dependency_records_catalog_snapshot() {
         registry: "https://registry.npmjs.org",
         lockfile_include_tarball_url: false,
         previous_importers: None,
+        previous_packages: None,
         update_reuse_scope: UpdateReuseScope::All,
         update_reuse_scopes_by_importer: BTreeMap::new(),
         time: BTreeMap::new(),
@@ -1813,6 +1819,7 @@ fn snapshot_link_uses_lockfile_root_while_importer_link_uses_project_root() {
         registry: "https://registry.npmjs.org",
         lockfile_include_tarball_url: false,
         previous_importers: None,
+        previous_packages: None,
         update_reuse_scope: UpdateReuseScope::All,
         update_reuse_scopes_by_importer: BTreeMap::new(),
         time: BTreeMap::new(),
@@ -1905,6 +1912,7 @@ fn multi_importer_workspace_writes_per_project_lockfile_entries() {
         registry: "https://registry.npmjs.org",
         lockfile_include_tarball_url: false,
         previous_importers: None,
+        previous_packages: None,
         update_reuse_scope: UpdateReuseScope::All,
         update_reuse_scopes_by_importer: BTreeMap::new(),
         time: BTreeMap::new(),
@@ -2015,6 +2023,7 @@ fn multi_importer_pruner_marks_shared_dep_non_optional_when_any_importer_reaches
         registry: "https://registry.npmjs.org",
         lockfile_include_tarball_url: false,
         previous_importers: None,
+        previous_packages: None,
         update_reuse_scope: UpdateReuseScope::All,
         update_reuse_scopes_by_importer: BTreeMap::new(),
         time: BTreeMap::new(),
@@ -2151,6 +2160,7 @@ fn workspace_sibling_link_renders_per_importer_with_link_ref() {
         registry: "https://registry.npmjs.org",
         lockfile_include_tarball_url: false,
         previous_importers: None,
+        previous_packages: None,
         update_reuse_scope: UpdateReuseScope::All,
         update_reuse_scopes_by_importer: BTreeMap::new(),
         time: BTreeMap::new(),
@@ -2469,6 +2479,7 @@ fn injected_workspace_dep_renders_file_without_prior_link() {
     let lockfile = dependencies_graph_to_lockfile(GraphToLockfileOptions {
         named_registries: &EMPTY_NAMED_REGISTRIES,
         previous_importers: None,
+        previous_packages: None,
         update_reuse_scope: UpdateReuseScope::All,
         ..single_importer_opts(&manifest, &graph, direct, false, false, None, None)
     });
@@ -2822,4 +2833,68 @@ fn an_unresolvable_alias_keeps_the_tarball_url() {
         LockfileResolution::Tarball(resolution) => assert_eq!(resolution.tarball, tarball),
         other => panic!("an unresolvable alias must keep its tarball URL, got {other:?}"),
     }
+}
+
+/// Registries can serve a `deprecated` flag that comes and goes
+/// upstream (pnpm/pnpm#13846). An entry whose resolution is unchanged
+/// never loses a recorded deprecation to that drift; a changed
+/// resolution takes the freshly served metadata.
+#[test]
+fn unchanged_resolutions_keep_their_previous_package_metadata() {
+    let (_tmp, manifest) = write_manifest(json!({
+        "name": "fixture",
+        "version": "1.0.0",
+        "dependencies": { "react": "^17.0.2" },
+    }));
+    let build = |previous: Option<&std::collections::HashMap<PackageKey, PackageMetadata>>| {
+        let node = make_node(
+            "react",
+            "17.0.2",
+            json!({ "name": "react", "version": "17.0.2" }),
+            BTreeMap::new(),
+            BTreeMap::new(),
+            HashSet::default(),
+        );
+        let mut graph = DependenciesGraph::default();
+        graph.insert(node.dep_path.clone(), node);
+        let direct =
+            BTreeMap::from([("react".to_string(), DepPath::from("react@17.0.2".to_string()))]);
+        let mut opts = single_importer_opts(&manifest, &graph, direct, true, false, None, None);
+        opts.previous_packages = previous;
+        let lockfile = dependencies_graph_to_lockfile(opts);
+        let key: PackageKey = "react@17.0.2".parse().unwrap();
+        lockfile.packages.expect("packages map")[&key].clone()
+    };
+
+    let fresh = build(None);
+    assert_eq!(fresh.deprecated, None, "the freshly served metadata carries no deprecation");
+
+    let mut previous_entry = fresh;
+    previous_entry.deprecated = Some("No longer maintained".to_string());
+    let previous = std::collections::HashMap::from([(
+        "react@17.0.2".parse::<PackageKey>().unwrap(),
+        previous_entry.clone(),
+    )]);
+    assert_eq!(
+        build(Some(&previous)),
+        previous_entry,
+        "an unchanged resolution keeps its recorded deprecation",
+    );
+
+    let mut republished = previous_entry;
+    republished.resolution = LockfileResolution::Registry(RegistryResolution {
+        integrity: Integrity::from_str(
+            "sha512-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB==",
+        )
+        .expect("parse fake integrity"),
+    });
+    let previous = std::collections::HashMap::from([(
+        "react@17.0.2".parse::<PackageKey>().unwrap(),
+        republished,
+    )]);
+    assert_eq!(
+        build(Some(&previous)).deprecated,
+        None,
+        "a changed resolution takes the freshly served metadata",
+    );
 }

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -2132,6 +2132,7 @@ fn build_fresh_lockfile(
         named_registries: &named_registries,
         lockfile_include_tarball_url: config.lockfile_include_tarball_url,
         previous_importers,
+        previous_packages: wanted_lockfile.and_then(|lockfile| lockfile.packages.as_ref()),
         update_reuse_scope,
         update_reuse_scopes_by_importer,
         time: merge_recorded_time(wanted_lockfile, resolved_time),

--- a/pnpm11/installing/deps-resolver/src/updateLockfile.ts
+++ b/pnpm11/installing/deps-resolver/src/updateLockfile.ts
@@ -94,15 +94,6 @@ function toLockfileDependency (
     }
   }
 
-  // `deprecated` is the one registry-mutable field of a published
-  // version, and registries have been observed serving it
-  // inconsistently (pnpm/pnpm#13846). An unchanged resolution never
-  // loses a recorded deprecation to such drift; a genuinely new
-  // deprecation still flows in through the fresh metadata.
-  const prevDeprecated = opts.prevSnapshot != null && equals(opts.prevSnapshot.resolution, lockfileResolution)
-    ? opts.prevSnapshot.deprecated
-    : undefined
-
   const newResolvedDeps = updateResolvedDeps(
     opts.updatedDeps,
     opts.depGraph
@@ -185,8 +176,15 @@ function toLockfileDependency (
   }
   if (pkg.additionalInfo.deprecated) {
     result['deprecated'] = pkg.additionalInfo.deprecated
-  } else if (prevDeprecated != null) {
-    result['deprecated'] = prevDeprecated
+  } else if (
+    // `deprecated` is the only registry-mutable field of a published
+    // version; an unchanged resolution must not lose a recorded
+    // deprecation to a registry serving it inconsistently
+    // (pnpm/pnpm#13846).
+    opts.prevSnapshot?.deprecated != null &&
+    equals(opts.prevSnapshot.resolution, lockfileResolution)
+  ) {
+    result['deprecated'] = opts.prevSnapshot.deprecated
   }
   if (pkg.hasBin) {
     result['hasBin'] = true

--- a/pnpm11/installing/deps-resolver/src/updateLockfile.ts
+++ b/pnpm11/installing/deps-resolver/src/updateLockfile.ts
@@ -9,7 +9,7 @@ import { toLockfileResolution } from '@pnpm/lockfile.utils'
 import { logger } from '@pnpm/logger'
 import type { DepPath, Registries } from '@pnpm/types'
 import type { KeyValuePair } from 'ramda'
-import { partition } from 'ramda'
+import { equals, partition } from 'ramda'
 
 import { depPathToRef } from './depPathToRef.js'
 import type { DependenciesGraph } from './index.js'
@@ -94,6 +94,15 @@ function toLockfileDependency (
     }
   }
 
+  // `deprecated` is the one registry-mutable field of a published
+  // version, and registries have been observed serving it
+  // inconsistently (pnpm/pnpm#13846). An unchanged resolution never
+  // loses a recorded deprecation to such drift; a genuinely new
+  // deprecation still flows in through the fresh metadata.
+  const prevDeprecated = opts.prevSnapshot != null && equals(opts.prevSnapshot.resolution, lockfileResolution)
+    ? opts.prevSnapshot.deprecated
+    : undefined
+
   const newResolvedDeps = updateResolvedDeps(
     opts.updatedDeps,
     opts.depGraph
@@ -176,6 +185,8 @@ function toLockfileDependency (
   }
   if (pkg.additionalInfo.deprecated) {
     result['deprecated'] = pkg.additionalInfo.deprecated
+  } else if (prevDeprecated != null) {
+    result['deprecated'] = prevDeprecated
   }
   if (pkg.hasBin) {
     result['hasBin'] = true

--- a/pnpm11/installing/deps-resolver/test/updateLockfile.test.ts
+++ b/pnpm11/installing/deps-resolver/test/updateLockfile.test.ts
@@ -113,3 +113,30 @@ test.each([
   })
   expect(lockfile.packages![DEP_PATH].bundledDependencies).toEqual(expected)
 })
+
+test('an unchanged resolution never loses its recorded deprecation to metadata drift', () => {
+  const lockfile = updateLockfile({
+    dependenciesGraph: tarballGraph({ tarball: TARBALL_URL, integrity: INTEGRITY }),
+    lockfile: lockfileWith({
+      resolution: { tarball: TARBALL_URL, integrity: INTEGRITY },
+      deprecated: 'No longer maintained',
+    }),
+    prefix: '.',
+    registries: REGISTRIES,
+  })
+  expect(lockfile.packages![DEP_PATH].deprecated).toBe('No longer maintained')
+})
+
+test('a changed resolution takes the freshly served metadata', () => {
+  const newIntegrity = 'sha512-CccCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcC=='
+  const lockfile = updateLockfile({
+    dependenciesGraph: tarballGraph({ tarball: TARBALL_URL, integrity: newIntegrity }),
+    lockfile: lockfileWith({
+      resolution: { tarball: TARBALL_URL, integrity: INTEGRITY },
+      deprecated: 'No longer maintained',
+    }),
+    prefix: '.',
+    registries: REGISTRIES,
+  })
+  expect(lockfile.packages![DEP_PATH].deprecated).toBeUndefined()
+})


### PR DESCRIPTION
## Summary

The one lockfile flap still reproducible on `main` for the pnpm/pnpm#13846 workload is not a resolver-ordering bug: node-registry.bit.cloud serves `@teambit/base-react.hooks.use-queued-execution@0.0.3` **with and without its `deprecated` field across consecutive requests**. Whenever an operation re-resolves the containing subtree — an override edit, a targeted update — and lands on the *unchanged* resolution, the `packages:` entry was rebuilt from whatever document the registry happened to serve, silently dropping (or restoring) the `deprecated:` line. Identical dependencies, different lockfile.

Following the fast-path principle that an operation must not change entries it doesn't affect: `deprecated` is the one registry-mutable field of a published version, so it gets an asymmetric carry-over. A rebuilt entry whose resolution equals the previous lockfile entry's keeps its recorded deprecation when the fresh metadata lacks one; a genuinely new deprecation still flows in through the fresh metadata. Carrying the whole previous entry over verbatim was considered and rejected: it would freeze legacy field forms and defeat rebuild-time normalization (the `bundledDependencies` normalization tests pin that repair).

Implemented in **both stacks**:
- pacquet: the wanted lockfile's `packages:` map is threaded into `dependencies_graph_to_lockfile` next to the existing pnpm/pnpm#10433 `previous_importers` plumbing.
- TypeScript: the same rule in `updateLockfile`'s `toLockfileDependency`, which already threads `prevSnapshot` for the tarball-integrity carry-over.

Verified on the pnpm/pnpm#13846 workspace with the genuinely drifted cache from that investigation: adding an override re-resolves the subtree, and `main` drops the `deprecated:` line while this branch preserves all nine. Cold installs (no previous lockfile) are byte-identical to `main`'s output, and the full `pacquet-package-manager` suite (581) plus the TS `updateLockfile` tests (16, including the normalization matrix) pass. Cost is one map lookup and a resolution compare per rebuilt entry.

Related to pnpm/pnpm#13846.

## Squash Commit Body

```text
Registries can serve a published version's metadata inconsistently —
node-registry.bit.cloud was observed serving a package with and without
its deprecated field across consecutive requests. When an operation
re-resolves such a package (an override edit, a targeted update) and
lands on the unchanged resolution, the lockfile entry was rebuilt from
whatever document the registry happened to serve, silently dropping the
deprecated line: identical dependencies, different lockfile
(pnpm/pnpm#13846).

deprecated is the one registry-mutable field of a published version, so
it gets an asymmetric carry-over: a rebuilt entry whose resolution
equals the previous lockfile entry's keeps the recorded deprecation
when the fresh metadata lacks one, while a genuinely new deprecation
still flows in. Carrying the whole previous entry over verbatim was
considered and rejected — it would freeze legacy field forms and defeat
rebuild-time normalization.

Implemented in both stacks: pacquet threads the wanted lockfile's
packages map into dependencies_graph_to_lockfile next to the existing
pnpm/pnpm#10433 previous_importers plumbing; the TypeScript resolver
applies the same rule in updateLockfile's toLockfileDependency, which
already threads prevSnapshot for the tarball-integrity carry-over.

Related to pnpm/pnpm#13846.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package.
- [x] Added or updated tests.
- [ ] ~~Updated the documentation if needed.~~ (no user-facing surface changed)

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789154142&installation_model_id=426870&pr_number=13878&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13878&signature=6c4799298f5ccdc9f83f7f4bcde9ea2478f6b1dac49ea59f55a8927286959a27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved package deprecation notices in lockfiles when re-resolving to the same package version.
  * Prevented existing deprecation metadata from being lost when registry information is temporarily incomplete.
  * Updated deprecation information correctly when package resolutions or integrity values change.
  * Improved lockfile consistency during fresh lockfile generation while retaining relevant package metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->