### PR TITLE
fix(modules-yaml): read manifests with long dependency paths

### DIFF
--- a/.changeset/long-modules-yaml-keys.md
+++ b/.changeset/long-modules-yaml-keys.md
@@ -1,5 +1,7 @@
 ---
+"@pnpm/installing.modules-yaml": patch
+"pnpm": patch
 "pacquet": patch
 ---
 
-Fixed pnpm failing to read `.modules.yaml` files containing long dependency paths.
+Fixed pnpm failing to read `.modules.yaml` files containing long dependency paths [#13875](https://github.com/pnpm/pnpm/issues/13875). The manifest is now parsed as JSON (the format pnpm writes it in), falling back to the YAML parser only for manifests written by old pnpm versions.

--- a/.changeset/long-modules-yaml-keys.md
+++ b/.changeset/long-modules-yaml-keys.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed pnpm failing to read `.modules.yaml` files containing long dependency paths.

--- a/pnpm/crates/modules-yaml/src/lib.rs
+++ b/pnpm/crates/modules-yaml/src/lib.rs
@@ -2,8 +2,9 @@
 //!
 //! The manifest is stored at `<modules_dir>/.modules.yaml`, where
 //! `modules_dir` is the path of a `node_modules` directory. The on-disk
-//! format is JSON (which YAML accepts), so reads use a YAML parser and writes
-//! emit [`serde_json::to_string_pretty`] output to match pnpm exactly.
+//! format is JSON: writes emit [`serde_json::to_string_pretty`] output to
+//! match pnpm exactly, and reads parse JSON first, falling back to a YAML
+//! parser for manifests written by old pnpm versions.
 
 use derive_more::{Display, Error, From, Into};
 use indexmap::{IndexMap, IndexSet};
@@ -382,83 +383,18 @@ pub enum WriteModulesError {
     WriteFile { path: PathBuf, source: io::Error },
 }
 
+/// Parse the manifest as JSON first (the format every current pnpm writes),
+/// falling back to the YAML parser for manifests written by old pnpm
+/// versions. JSON parsing also accepts object keys longer than YAML's
+/// 1,024-character simple-key limit, which long dependency paths can exceed.
 fn deserialize_modules<Manifest>(content: &str) -> Result<Manifest, serde_saphyr::Error>
 where
     Manifest: DeserializeOwned,
 {
-    match serde_saphyr::from_str(content) {
+    match serde_json::from_str(content) {
         Ok(manifest) => Ok(manifest),
-        Err(source) => {
-            let Some(content) = make_long_json_keys_explicit(content) else { return Err(source) };
-            serde_saphyr::from_str(&content)
-        }
+        Err(_) => serde_saphyr::from_str(content),
     }
-}
-
-/// Rewrite JSON object keys that exceed YAML's 1,024-character simple-key
-/// limit to the equivalent explicit-key form before retrying the YAML parser.
-fn make_long_json_keys_explicit(content: &str) -> Option<String> {
-    const YAML_MAX_INPUT_BYTES: usize = 256 * 1024 * 1024;
-    const YAML_SIMPLE_KEY_LIMIT: usize = 1024;
-
-    if content.len() > YAML_MAX_INPUT_BYTES || !content.trim_start().starts_with('{') {
-        return None;
-    }
-
-    let bytes = content.as_bytes();
-    let mut long_key_starts = Vec::new();
-    let mut index = 0;
-
-    while index < bytes.len() {
-        if bytes[index] != b'"' {
-            index += 1;
-            continue;
-        }
-
-        let key_start = index;
-        index += 1;
-        while index < bytes.len() {
-            match bytes[index] {
-                b'\\' => index = (index + 2).min(bytes.len()),
-                b'"' => {
-                    index += 1;
-                    let mut colon = index;
-                    while colon < bytes.len()
-                        && matches!(bytes[colon], b' ' | b'\t' | b'\r' | b'\n')
-                    {
-                        colon += 1;
-                    }
-                    if colon < bytes.len()
-                        && bytes[colon] == b':'
-                        && colon - key_start > YAML_SIMPLE_KEY_LIMIT
-                    {
-                        long_key_starts.push(key_start);
-                    }
-                    break;
-                }
-                _ => index += 1,
-            }
-        }
-    }
-
-    if long_key_starts.is_empty() {
-        return None;
-    }
-
-    let rewritten_len = content.len().checked_add(long_key_starts.len().checked_mul(2)?)?;
-    if rewritten_len > YAML_MAX_INPUT_BYTES {
-        return None;
-    }
-    let mut rewritten = String::new();
-    rewritten.try_reserve_exact(rewritten_len).ok()?;
-    let mut copied_until = 0;
-    for key_start in long_key_starts {
-        rewritten.push_str(&content[copied_until..key_start]);
-        rewritten.push_str("? ");
-        copied_until = key_start;
-    }
-    rewritten.push_str(&content[copied_until..]);
-    Some(rewritten)
 }
 
 /// Read `<modules_dir>/.modules.yaml` and return the normalized manifest.

--- a/pnpm/crates/modules-yaml/src/lib.rs
+++ b/pnpm/crates/modules-yaml/src/lib.rs
@@ -2,15 +2,15 @@
 //!
 //! The manifest is stored at `<modules_dir>/.modules.yaml`, where
 //! `modules_dir` is the path of a `node_modules` directory. The on-disk
-//! format is JSON (which YAML accepts), so reads use a YAML parser and
-//! writes emit [`serde_json::to_string_pretty`] output to match pnpm exactly.
+//! format is JSON (which YAML accepts), so reads use a YAML parser and writes
+//! emit [`serde_json::to_string_pretty`] output to match pnpm exactly.
 
 use derive_more::{Display, Error, From, Into};
 use indexmap::{IndexMap, IndexSet};
 use pipe_trait::Pipe;
 use pnpm_diagnostics::miette::{self, Diagnostic};
 use pnpm_fs::lexical_normalize;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use std::{
     collections::BTreeMap,
     fs, io, iter,
@@ -382,6 +382,79 @@ pub enum WriteModulesError {
     WriteFile { path: PathBuf, source: io::Error },
 }
 
+fn deserialize_modules<Manifest>(content: &str) -> Result<Manifest, serde_saphyr::Error>
+where
+    Manifest: DeserializeOwned,
+{
+    match serde_saphyr::from_str(content) {
+        Ok(manifest) => Ok(manifest),
+        Err(source) => {
+            let Some(content) = make_long_json_keys_explicit(content) else { return Err(source) };
+            serde_saphyr::from_str(&content)
+        }
+    }
+}
+
+/// Rewrite JSON object keys that exceed YAML's 1,024-character simple-key
+/// limit to the equivalent explicit-key form before retrying the YAML parser.
+fn make_long_json_keys_explicit(content: &str) -> Option<String> {
+    const YAML_SIMPLE_KEY_LIMIT: usize = 1024;
+
+    if !content.trim_start().starts_with('{') {
+        return None;
+    }
+
+    let bytes = content.as_bytes();
+    let mut long_key_starts = Vec::new();
+    let mut index = 0;
+
+    while index < bytes.len() {
+        if bytes[index] != b'"' {
+            index += 1;
+            continue;
+        }
+
+        let key_start = index;
+        index += 1;
+        while index < bytes.len() {
+            match bytes[index] {
+                b'\\' => index = (index + 2).min(bytes.len()),
+                b'"' => {
+                    index += 1;
+                    let mut colon = index;
+                    while colon < bytes.len()
+                        && matches!(bytes[colon], b' ' | b'\t' | b'\r' | b'\n')
+                    {
+                        colon += 1;
+                    }
+                    if colon < bytes.len()
+                        && bytes[colon] == b':'
+                        && colon - key_start > YAML_SIMPLE_KEY_LIMIT
+                    {
+                        long_key_starts.push(key_start);
+                    }
+                    break;
+                }
+                _ => index += 1,
+            }
+        }
+    }
+
+    if long_key_starts.is_empty() {
+        return None;
+    }
+
+    let mut rewritten = String::with_capacity(content.len() + long_key_starts.len() * 2);
+    let mut copied_until = 0;
+    for key_start in long_key_starts {
+        rewritten.push_str(&content[copied_until..key_start]);
+        rewritten.push_str("? ");
+        copied_until = key_start;
+    }
+    rewritten.push_str(&content[copied_until..]);
+    Some(rewritten)
+}
+
 /// Read `<modules_dir>/.modules.yaml` and return the normalized manifest.
 ///
 /// Returns `Ok(None)` when the file does not exist or contains a YAML
@@ -403,10 +476,9 @@ where
             return Err(ReadModulesError::ReadFile { path: manifest_path, source });
         }
     };
-    let parsed: Option<Modules> =
-        content.pipe_as_ref(serde_saphyr::from_str).map_err(|source| {
-            ReadModulesError::ParseYaml { path: manifest_path.clone(), source: Box::new(source) }
-        })?;
+    let parsed: Option<Modules> = content.pipe_as_ref(deserialize_modules).map_err(|source| {
+        ReadModulesError::ParseYaml { path: manifest_path.clone(), source: Box::new(source) }
+    })?;
     let Some(mut manifest) = parsed else { return Ok(None) };
     apply_legacy_shamefully_hoist(&mut manifest);
     resolve_virtual_store_dir(&mut manifest, modules_dir);
@@ -436,8 +508,9 @@ where
         }
     };
     let parsed: Option<ModulesLayout> =
-        content.pipe_as_ref(serde_saphyr::from_str).map_err(|source| {
-            ReadModulesError::ParseYaml { path: manifest_path.clone(), source: Box::new(source) }
+        content.pipe_as_ref(deserialize_modules).map_err(|source| ReadModulesError::ParseYaml {
+            path: manifest_path.clone(),
+            source: Box::new(source),
         })?;
     let Some(mut manifest) = parsed else { return Ok(None) };
 

--- a/pnpm/crates/modules-yaml/src/lib.rs
+++ b/pnpm/crates/modules-yaml/src/lib.rs
@@ -398,9 +398,10 @@ where
 /// Rewrite JSON object keys that exceed YAML's 1,024-character simple-key
 /// limit to the equivalent explicit-key form before retrying the YAML parser.
 fn make_long_json_keys_explicit(content: &str) -> Option<String> {
+    const YAML_MAX_INPUT_BYTES: usize = 256 * 1024 * 1024;
     const YAML_SIMPLE_KEY_LIMIT: usize = 1024;
 
-    if !content.trim_start().starts_with('{') {
+    if content.len() > YAML_MAX_INPUT_BYTES || !content.trim_start().starts_with('{') {
         return None;
     }
 
@@ -444,7 +445,12 @@ fn make_long_json_keys_explicit(content: &str) -> Option<String> {
         return None;
     }
 
-    let mut rewritten = String::with_capacity(content.len() + long_key_starts.len() * 2);
+    let rewritten_len = content.len().checked_add(long_key_starts.len().checked_mul(2)?)?;
+    if rewritten_len > YAML_MAX_INPUT_BYTES {
+        return None;
+    }
+    let mut rewritten = String::new();
+    rewritten.try_reserve_exact(rewritten_len).ok()?;
     let mut copied_until = 0;
     for key_start in long_key_starts {
         rewritten.push_str(&content[copied_until..key_start]);

--- a/pnpm/crates/modules-yaml/tests/index.rs
+++ b/pnpm/crates/modules-yaml/tests/index.rs
@@ -6,7 +6,9 @@
 
 use indexmap::IndexMap;
 use pipe_trait::Pipe;
-use pnpm_modules_yaml::{HoistKind, Host, Modules, read_modules_manifest, write_modules_manifest};
+use pnpm_modules_yaml::{
+    HoistKind, Host, Modules, read_modules_layout, read_modules_manifest, write_modules_manifest,
+};
 use pretty_assertions::assert_eq;
 use serde_json::{Value, json};
 use std::{fs, path::Path};
@@ -183,6 +185,70 @@ fn write_modules_manifest_preserves_hoisted_dependency_order() {
         written.hoisted_dependencies["z@1.0.0"].keys().map(String::as_str).collect::<Vec<_>>(),
         vec!["z-alias", "a-alias"],
     );
+}
+
+#[test]
+fn write_and_read_manifest_with_long_dependency_path() {
+    let temp_dir = tempfile::tempdir().expect("create temporary directory");
+    let modules_dir = temp_dir.path();
+    let dependency_path = format!("@scope/package@1.0.0({})", "p".repeat(1001));
+    assert_eq!(dependency_path.len(), 1023);
+    let manifest = Modules {
+        hoisted_dependencies: IndexMap::from([(
+            dependency_path,
+            IndexMap::from([("@scope/package".to_string(), HoistKind::Private)]),
+        )]),
+        virtual_store_dir: modules_dir.join(".pnpm").display().to_string(),
+        ..Default::default()
+    };
+
+    write_modules_manifest::<Host>(modules_dir, manifest.clone()).expect("write manifest");
+
+    let actual = read_modules_manifest::<Host>(modules_dir)
+        .expect("read manifest")
+        .expect("manifest exists");
+    assert_eq!(actual.hoisted_dependencies, manifest.hoisted_dependencies);
+
+    read_modules_layout::<Host>(modules_dir).expect("read layout").expect("layout exists");
+}
+
+#[test]
+fn long_json_keys_keep_duplicate_key_validation() {
+    let temp_dir = tempfile::tempdir().expect("create temporary directory");
+    let modules_dir = temp_dir.path();
+    let dependency_path = format!("package@1.0.0({})", "p".repeat(1010));
+    let content = format!(
+        r#"{{"hoistedDependencies":{{"{dependency_path}":{{"package":"private"}},"{dependency_path}":{{"package":"public"}}}}}}"#,
+    );
+    fs::write(modules_dir.join(".modules.yaml"), content).expect("write manifest");
+
+    for result in [
+        read_modules_manifest::<Host>(modules_dir).map(drop),
+        read_modules_layout::<Host>(modules_dir).map(drop),
+    ] {
+        let error = result.expect_err("duplicate keys must be rejected");
+        assert!(error.to_string().to_lowercase().contains("duplicate"), "{error}");
+    }
+}
+
+#[test]
+fn long_json_keys_keep_yaml_depth_budget() {
+    let temp_dir = tempfile::tempdir().expect("create temporary directory");
+    let modules_dir = temp_dir.path();
+    let dependency_path = format!("package@1.0.0({})", "p".repeat(1010));
+    let nested_value = format!("{}null{}", "[".repeat(65), "]".repeat(65));
+    let content = format!(
+        r#"{{"hoistedDependencies":{{"{dependency_path}":{{"package":"private"}}}},"extra":{nested_value}}}"#,
+    );
+    fs::write(modules_dir.join(".modules.yaml"), content).expect("write manifest");
+
+    for result in [
+        read_modules_manifest::<Host>(modules_dir).map(drop),
+        read_modules_layout::<Host>(modules_dir).map(drop),
+    ] {
+        let error = result.expect_err("excessive depth must be rejected");
+        assert!(error.to_string().to_lowercase().contains("depth"), "{error}");
+    }
 }
 
 #[test]

--- a/pnpm/crates/modules-yaml/tests/index.rs
+++ b/pnpm/crates/modules-yaml/tests/index.rs
@@ -213,7 +213,7 @@ fn write_and_read_manifest_with_long_dependency_path() {
 }
 
 #[test]
-fn long_json_keys_keep_duplicate_key_validation() {
+fn duplicate_json_keys_resolve_to_the_last_value() {
     let temp_dir = tempfile::tempdir().expect("create temporary directory");
     let modules_dir = temp_dir.path();
     let dependency_path = format!("package@1.0.0({})", "p".repeat(1010));
@@ -222,24 +222,24 @@ fn long_json_keys_keep_duplicate_key_validation() {
     );
     fs::write(modules_dir.join(".modules.yaml"), content).expect("write manifest");
 
-    for result in [
-        read_modules_manifest::<Host>(modules_dir).map(drop),
-        read_modules_layout::<Host>(modules_dir).map(drop),
-    ] {
-        let error = result.expect_err("duplicate keys must be rejected");
-        assert!(error.to_string().to_lowercase().contains("duplicate"), "{error}");
-    }
+    let manifest = read_modules_manifest::<Host>(modules_dir)
+        .expect("read manifest")
+        .expect("manifest exists");
+    assert_eq!(
+        manifest.hoisted_dependencies,
+        IndexMap::from([(
+            dependency_path,
+            IndexMap::from([("package".to_string(), HoistKind::Public)]),
+        )]),
+    );
 }
 
 #[test]
-fn long_json_keys_keep_yaml_depth_budget() {
+fn yaml_fallback_keeps_depth_budget() {
     let temp_dir = tempfile::tempdir().expect("create temporary directory");
     let modules_dir = temp_dir.path();
-    let dependency_path = format!("package@1.0.0({})", "p".repeat(1010));
     let nested_value = format!("{}null{}", "[".repeat(65), "]".repeat(65));
-    let content = format!(
-        r#"{{"hoistedDependencies":{{"{dependency_path}":{{"package":"private"}}}},"extra":{nested_value}}}"#,
-    );
+    let content = format!("extra: {nested_value}\n");
     fs::write(modules_dir.join(".modules.yaml"), content).expect("write manifest");
 
     for result in [

--- a/pnpm11/installing/modules-yaml/src/index.ts
+++ b/pnpm11/installing/modules-yaml/src/index.ts
@@ -53,7 +53,13 @@ export async function readModulesManifest (modulesDir: string): Promise<Modules 
   const modulesYamlPath = path.join(modulesDir, MODULES_FILENAME)
   let modulesRaw!: ModulesRaw
   try {
-    modulesRaw = await readYamlFile<ModulesRaw>(modulesYamlPath)
+    const rawManifest = await fs.readFile(modulesYamlPath, 'utf8')
+    try {
+      modulesRaw = JSON.parse(rawManifest) as ModulesRaw
+    } catch {
+      // Manifests written by old pnpm versions are YAML.
+      modulesRaw = await readYamlFile<ModulesRaw>(modulesYamlPath)
+    }
     if (!modulesRaw) return modulesRaw
   } catch (err: any) { // eslint-disable-line
     if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {

--- a/pnpm11/installing/modules-yaml/test/index.ts
+++ b/pnpm11/installing/modules-yaml/test/index.ts
@@ -1,4 +1,5 @@
 /// <reference path="../../../__typings__/index.d.ts"/>
+import fs from 'node:fs'
 import path from 'node:path'
 
 import { expect, test } from '@jest/globals'
@@ -63,6 +64,17 @@ test('writeModulesManifest() and readModulesManifest() with a long dependency pa
   }
   await writeModulesManifest(modulesDir, modulesYaml)
   expect(await readModulesManifest(modulesDir)).toEqual(modulesYaml)
+})
+
+test('readModulesManifest() resolves duplicate JSON keys to the last value', async () => {
+  const modulesDir = temporaryDirectory()
+  const longDepPath = `package@1.0.0(${'p'.repeat(1010)})`
+  fs.writeFileSync(
+    path.join(modulesDir, '.modules.yaml'),
+    `{"hoistedDependencies":{"${longDepPath}":{"package":"private"},"${longDepPath}":{"package":"public"}}}`
+  )
+  const modulesYaml = await readModulesManifest(modulesDir)
+  expect(modulesYaml?.hoistedDependencies).toEqual({ [longDepPath]: { package: 'public' } })
 })
 
 test('backward compatible read of .modules.yaml created with shamefully-hoist=true', async () => {

--- a/pnpm11/installing/modules-yaml/test/index.ts
+++ b/pnpm11/installing/modules-yaml/test/index.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 
 import { expect, test } from '@jest/globals'
 import { type Modules, readModulesManifest, writeModulesManifest } from '@pnpm/installing.modules-yaml'
+import type { DepPath } from '@pnpm/types'
 import isWindows from 'is-windows'
 import { readYamlFileSync } from 'read-yaml-file'
 import { temporaryDirectory } from 'tempy'
@@ -34,6 +35,34 @@ test('writeModulesManifest() and readModulesManifest()', async () => {
   const raw = readYamlFileSync<any>(path.join(modulesDir, '.modules.yaml')) // eslint-disable-line @typescript-eslint/no-explicit-any
   expect(raw.virtualStoreDir).toBeDefined()
   expect(path.isAbsolute(raw.virtualStoreDir)).toEqual(isWindows())
+})
+
+test('writeModulesManifest() and readModulesManifest() with a long dependency path', async () => {
+  const modulesDir = temporaryDirectory()
+  const longDepPath = `@scope/package@1.0.0(${'p'.repeat(1001)})` as DepPath
+  const modulesYaml: Modules = {
+    hoistedDependencies: {
+      [longDepPath]: { '@scope/package': 'private' },
+    },
+    included: {
+      dependencies: true,
+      devDependencies: true,
+      optionalDependencies: true,
+    },
+    ignoredBuilds: new Set(),
+    layoutVersion: 1,
+    packageManager: 'pnpm@2',
+    pendingBuilds: [],
+    publicHoistPattern: [],
+    prunedAt: new Date().toUTCString(),
+    shamefullyHoist: false,
+    skipped: [],
+    storeDir: '/.pnpm-store',
+    virtualStoreDir: path.join(modulesDir, '.pnpm'),
+    virtualStoreDirMaxLength: 120,
+  }
+  await writeModulesManifest(modulesDir, modulesYaml)
+  expect(await readModulesManifest(modulesDir)).toEqual(modulesYaml)
 })
 
 test('backward compatible read of .modules.yaml created with shamefully-hoist=true', async () => {


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#13875.

Both stacks write `.modules.yaml` as JSON but read it back through a YAML parser, and the Rust YAML parser rejects object keys longer than YAML's 1,024-character simple-key limit. A sufficiently long dependency path could therefore produce a manifest that the next pnpm command could not read.

The readers in both stacks now parse the manifest as JSON first and fall back to the YAML parser only when JSON parsing fails (manifests written in YAML by old pnpm versions). Long dependency paths parse fine on the JSON path, and the YAML fallback keeps its legacy-format support and resource budgets. Duplicate JSON keys now resolve to the last value in both stacks, per standard JSON semantics, instead of being rejected by the YAML parser.

Tests:

- `cargo nextest run -p pnpm-modules-yaml`
- `cargo clippy -p pnpm-modules-yaml --all-targets -- -D warnings`
- `cargo fmt -p pnpm-modules-yaml -- --check`
- `pnpm --filter @pnpm/installing.modules-yaml test`
- The husky pre-push hook (rustfmt, taplo, clippy, cargo doc, dylint, typos, TS compile and lint)

## Squash Commit Body

```text
Both stacks write the modules manifest as JSON but read it back through a YAML parser, which rejects object keys longer than YAML's simple-key limit, so a long dependency path could make a manifest unreadable after it was written.

Parse the manifest as JSON first and fall back to the YAML parser only for manifests written in YAML by old pnpm versions. Duplicate JSON keys resolve to the last value per standard JSON semantics; the YAML fallback keeps its legacy-format support and resource budgets.

Closes pnpm/pnpm#13875.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5.6).
Updated to the JSON-first read strategy by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789192636&installation_model_id=426870&pr_number=13885&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13885&signature=2d5da04d79e8991b6015d23dcb44e3a2c7a15ae4ae74cd9bb010bc7abe9d20fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed failures when reading `.modules.yaml` files containing long dependency paths.
  * Improved compatibility with manifests written in JSON or YAML formats, including older pnpm manifests.
  * Preserved expected duplicate-key handling and nesting-depth validation for manifest and layout parsing.

* **Tests**
  * Added coverage for long dependency paths, duplicate keys, deeply nested YAML content, and JSON/YAML manifest round trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
