### PR TITLE
fix(workspace): discover projects declared above the workspace root

### DIFF
--- a/.changeset/parent-relative-workspace-packages.md
+++ b/.changeset/parent-relative-workspace-packages.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Workspace packages declared with a parent-relative pattern in `pnpm-workspace.yaml` (`../shared`, `../../docs/*`) are discovered again. They were dropped from the project list, so `pnpm list -r` and `--filter` did not see them and a frozen install of a lockfile that already held their importer entries failed with `ERR_PNPM_PACKAGE_MANAGER_UNSAFE_IMPORTER_PATH`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -61,6 +61,19 @@ In particular:
   untrusted repository can influence what pnpm executes — in that starting
   position, code execution is already available to the attacker by design.
 
+- **The workspace's extent is defined by `pnpm-workspace.yaml` and may reach
+  outside the repository checkout.** `packages:` patterns may be
+  parent-relative (`../shared`), and pnpm treats the directories they name as
+  workspace projects: it reads their manifests, records them as lockfile
+  importers, and creates `node_modules` inside them. Those directories are part
+  of the project trust domain **by declaration**. A hostile edit to
+  `pnpm-workspace.yaml` that points the workspace outside the checkout is the
+  same starting position as the previous bullet: whoever can change that file
+  can already achieve code execution at install time through the configuration
+  it carries, so this is not an escalation. The lockfile does not define the
+  workspace — an importer entry for a path that no declared pattern matches
+  does not cause pnpm to install into that path.
+
 - **Some restrictions are hardening, not boundaries.** Environment variable
   expansion in repository-controlled configuration is suppressed for request
   destinations (`registry`, `proxy`, `pnprServer`) and for auth values. That

--- a/pnpm/crates/workspace/src/projects.rs
+++ b/pnpm/crates/workspace/src/projects.rs
@@ -24,7 +24,7 @@ use std::{
     path::{Path, PathBuf},
 };
 use wax::{
-    Glob,
+    Glob, Program,
     walk::{Entry, FileIterator},
 };
 
@@ -146,16 +146,22 @@ pub fn find_workspace_projects_no_check(
     // `Walk::not` call (both `Glob` and `Any` derive `Clone` in wax),
     // since `IGNORE_PATTERNS` is a constant and reparsing it on every
     // user-supplied pattern is wasted work.
-    let ignore_template = wax::any(
-        IGNORE_PATTERNS
-            .iter()
-            .copied()
-            .chain(user_negation_globs.iter().map(std::string::String::as_str)),
-    )
-    .map_err(|err| FindWorkspaceProjectsError::InvalidGlob {
-        pattern: "<built-in ignore>".to_string(),
-        message: err.to_string(),
+    let ignore_template = wax::any(IGNORE_PATTERNS.iter().copied()).map_err(|err| {
+        FindWorkspaceProjectsError::InvalidGlob {
+            pattern: "<built-in ignore>".to_string(),
+            message: err.to_string(),
+        }
     })?;
+
+    // User negations are written relative to the workspace root, while a
+    // parent-relative include walks from an ancestor of it, so they are
+    // matched against the path each entry has *from the workspace root*
+    // rather than handed to `Walk::not` alongside the built-in ignores.
+    let user_negations = wax::any(user_negation_globs.iter().map(std::string::String::as_str))
+        .map_err(|err| FindWorkspaceProjectsError::InvalidGlob {
+            pattern: "<negated pattern>".to_string(),
+            message: err.to_string(),
+        })?;
 
     // `NotFound` is the one error kind this enumeration absorbs, in both
     // the walk below and the manifest read after it: a pattern whose
@@ -204,7 +210,13 @@ pub fn find_workspace_projects_no_check(
                         });
                     }
                 };
-                manifest_paths.insert(entry.path().to_path_buf());
+                let manifest_path = entry.path();
+                if pathdiff::diff_paths(manifest_path, workspace_root)
+                    .is_some_and(|relative| user_negations.is_match(relative.as_path()))
+                {
+                    continue;
+                }
+                manifest_paths.insert(manifest_path.to_path_buf());
             }
         }
     }

--- a/pnpm/crates/workspace/src/projects.rs
+++ b/pnpm/crates/workspace/src/projects.rs
@@ -167,16 +167,20 @@ pub fn find_workspace_projects_no_check(
     let mut manifest_paths: BTreeSet<PathBuf> = BTreeSet::new();
     for pattern in include_patterns {
         for normalized in normalize_manifest_patterns(pattern) {
-            if is_literal_pattern(&normalized) && !workspace_root.join(&normalized).is_file() {
+            let Some((walk_root, normalized)) = split_parent_prefix(workspace_root, &normalized)
+            else {
+                continue;
+            };
+            if is_literal_pattern(normalized) && !walk_root.join(normalized).is_file() {
                 continue;
             }
             let glob =
-                Glob::new(&normalized).map_err(|err| FindWorkspaceProjectsError::InvalidGlob {
+                Glob::new(normalized).map_err(|err| FindWorkspaceProjectsError::InvalidGlob {
                     pattern: pattern.to_string(),
                     message: err.to_string(),
                 })?;
 
-            let walk = glob.walk(workspace_root).not(ignore_template.clone()).map_err(|err| {
+            let walk = glob.walk(walk_root).not(ignore_template.clone()).map_err(|err| {
                 FindWorkspaceProjectsError::InvalidGlob {
                     pattern: pattern.to_string(),
                     message: err.to_string(),
@@ -195,7 +199,7 @@ pub fn find_workspace_projects_no_check(
                             continue;
                         }
                         return Err(FindWorkspaceProjectsError::Walk {
-                            root: workspace_root.to_path_buf(),
+                            root: walk_root.to_path_buf(),
                             source: err,
                         });
                     }
@@ -266,6 +270,24 @@ fn normalize_manifest_patterns(pattern: &str) -> Vec<String> {
         return Vec::new();
     }
     PROJECT_MANIFEST_BASENAMES.iter().map(|basename| format!("{trimmed}/{basename}")).collect()
+}
+
+/// Strip the pattern's leading `../` components, walking `workspace_root`
+/// up one directory for each. wax globs cannot express parent traversal,
+/// so a pattern such as `../shared/*` only matches when the walk starts
+/// from the ancestor it names. `None` — the traversal climbs past the
+/// filesystem root — matches nothing.
+fn split_parent_prefix<'root, 'pattern>(
+    workspace_root: &'root Path,
+    pattern: &'pattern str,
+) -> Option<(&'root Path, &'pattern str)> {
+    let mut walk_root = workspace_root;
+    let mut rest = pattern;
+    while let Some(tail) = rest.strip_prefix("../") {
+        walk_root = walk_root.parent()?;
+        rest = tail;
+    }
+    Some((walk_root, rest))
 }
 
 fn is_literal_pattern(pattern: &str) -> bool {

--- a/pnpm/crates/workspace/src/projects/tests.rs
+++ b/pnpm/crates/workspace/src/projects/tests.rs
@@ -314,6 +314,45 @@ fn non_notfound_walk_failure_still_errors() {
     );
 }
 
+/// A `packages:` entry may point outside the workspace root, and the
+/// declared project has to be enumerated all the same, or the install
+/// later rejects its lockfile importer as untrusted (pnpm/pnpm#13880).
+#[test]
+fn discovers_projects_declared_above_the_workspace_root() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), "shared", "shared-package");
+    make_project(tmp.path(), "vendor/libs/parser", "parser");
+    make_project(tmp.path(), "workspace", "workspace-root");
+    make_project(tmp.path(), "workspace/app", "example-app");
+
+    let projects = find_workspace_projects(
+        &tmp.path().join("workspace"),
+        &FindWorkspaceProjectsOpts {
+            patterns: Some(vec![
+                "app".to_string(),
+                "../shared".to_string(),
+                "../vendor/libs/*".to_string(),
+            ]),
+        },
+    )
+    .unwrap();
+
+    let mut names: Vec<String> = projects
+        .iter()
+        .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
+        .collect();
+    names.sort();
+    assert_eq!(
+        names,
+        vec![
+            "example-app".to_string(),
+            "parser".to_string(),
+            "shared-package".to_string(),
+            "workspace-root".to_string(),
+        ],
+    );
+}
+
 /// Workspaces do contain manifests written with a leading UTF-8 BOM —
 /// Vite ships one as the `utf8-bom-package` fixture — and discovery must
 /// enumerate them rather than failing the whole walk.

--- a/pnpm/crates/workspace/src/projects/tests.rs
+++ b/pnpm/crates/workspace/src/projects/tests.rs
@@ -384,6 +384,42 @@ fn negation_pattern_excludes_a_project_above_the_workspace_root() {
     );
 }
 
+/// A pattern may climb past the filesystem root, which has no ancestor to
+/// walk from. It matches nothing rather than falling back to the workspace
+/// root and enumerating whatever happens to sit there.
+#[test]
+fn pattern_climbing_past_the_filesystem_root_matches_nothing() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), "shared", "shared-package");
+    make_project(tmp.path(), "workspace", "workspace-root");
+    // Discovered only if the overflowed pattern is silently rebased onto
+    // the workspace root.
+    make_project(tmp.path(), "workspace/app", "example-app");
+
+    let workspace_root = tmp.path().join("workspace");
+    // One `../` per component plus a spare, so the climb runs out of
+    // ancestors wherever the temporary directory lives.
+    let overflow = "../".repeat(workspace_root.components().count() + 1);
+
+    let projects = find_workspace_projects(
+        &workspace_root,
+        &FindWorkspaceProjectsOpts {
+            patterns: Some(vec![format!("{overflow}*"), format!("{overflow}shared")]),
+        },
+    )
+    .unwrap();
+
+    let names: Vec<String> = projects
+        .iter()
+        .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(
+        names,
+        vec!["workspace-root".to_string()],
+        "a pattern that overflows the filesystem root must contribute no project",
+    );
+}
+
 /// Workspaces do contain manifests written with a leading UTF-8 BOM —
 /// Vite ships one as the `utf8-bom-package` fixture — and discovery must
 /// enumerate them rather than failing the whole walk.

--- a/pnpm/crates/workspace/src/projects/tests.rs
+++ b/pnpm/crates/workspace/src/projects/tests.rs
@@ -353,6 +353,37 @@ fn discovers_projects_declared_above_the_workspace_root() {
     );
 }
 
+/// A negation is written relative to the workspace root whichever
+/// ancestor the include it narrows walks from.
+#[test]
+fn negation_pattern_excludes_a_project_above_the_workspace_root() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), "shared/keep", "keep");
+    make_project(tmp.path(), "shared/drop", "drop");
+    make_project(tmp.path(), "workspace", "workspace-root");
+
+    let projects = find_workspace_projects(
+        &tmp.path().join("workspace"),
+        &FindWorkspaceProjectsOpts {
+            patterns: Some(vec!["../shared/*".to_string(), "!../shared/drop".to_string()]),
+        },
+    )
+    .unwrap();
+
+    let names: Vec<String> = projects
+        .iter()
+        .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
+        .collect();
+    assert!(
+        !names.contains(&"drop".to_string()),
+        "`!../shared/drop` must exclude the project it names: {names:?}",
+    );
+    assert!(
+        names.contains(&"keep".to_string()),
+        "expected the `keep` project to be enumerated; got {names:?}",
+    );
+}
+
 /// Workspaces do contain manifests written with a leading UTF-8 BOM —
 /// Vite ships one as the `utf8-bom-package` fixture — and discovery must
 /// enumerate them rather than failing the whole walk.


### PR DESCRIPTION
## Summary

A `packages:` entry that points outside the workspace root (`../shared`, `../../docs/*`) was silently dropped from pacquet's project list. `normalize_manifest_patterns` turns such an entry into `../shared/package.json` and hands it to wax, whose globs cannot express parent traversal, so a walk rooted at the workspace root matched nothing and raised no error.

The declared project therefore never reached the install's project list, which is what `trusted_importer_ids` is built from. Installing a lockfile that pnpm 11 wrote for the same workspace then rejected its `../shared` importer key as malformed with `ERR_PNPM_PACKAGE_MANAGER_UNSAFE_IMPORTER_PATH`, and `pnpm list -r` and `--filter shared-package` did not see the package at all.

Discovery now strips the leading `../` components off each normalized pattern and starts the walk from the ancestor they name, so the glob wax receives stays traversal free. A pattern that climbs past the filesystem root matches nothing. Since a walk can now start above the workspace root while a `!` pattern is still written relative to the workspace root, user negations moved out of `Walk::not` and are matched against the path each entry has from the workspace root, which keeps `!../shared` able to narrow `../**`.

pacquet only. The TypeScript CLI globs through tinyglobby, which already handles the parent-relative form, and pnpm 11 was reported working on the same fixture.

Verified against the reproduction in the issue: the fixed binary reports `Scope: all 3 workspace projects`, writes the same `../shared: {}` importer as pnpm 11, and completes `install --offline --frozen-lockfile` with `app/node_modules/shared-package` linked.

Closes pnpm/pnpm#13880.

## Squash Commit Body

```text
A packages: entry pointing outside the workspace root (../shared,
../../docs/*) was silently dropped from the project list.
normalize_manifest_patterns turns it into ../shared/package.json and
hands it to wax, whose globs cannot express parent traversal, so a walk
rooted at the workspace root matched nothing and raised no error.

The declared project never reached the install's project list, which is
what trusted_importer_ids is built from, so a lockfile pnpm 11 wrote for
the same workspace failed with
ERR_PNPM_PACKAGE_MANAGER_UNSAFE_IMPORTER_PATH on its ../shared importer
key. pnpm list -r and --filter did not see the package either.

Discovery now strips the leading ../ components off each normalized
pattern and starts the walk from the ancestor they name, keeping the
glob handed to wax traversal free. A pattern that climbs past the
filesystem root matches nothing. A walk can therefore start above the
workspace root, while a ! pattern stays written relative to the
workspace root, so user negations moved out of Walk::not and are matched
against each entry's path from the workspace root instead.

pacquet only: the TypeScript CLI globs through tinyglobby, which handles
the parent-relative form already.

Closes pnpm/pnpm#13880.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation: SECURITY.md now states in the threat model that parent-relative `packages:` patterns extend the workspace outside the checkout by declaration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace projects can now be discovered using patterns that reference parent directories, including glob patterns.
  * Parent-relative workspace packages appear in recursive listings and filtering results.
  * Frozen installs now support lockfiles containing importer entries for these packages.

* **Bug Fixes**
  * Negation patterns now correctly exclude parent-relative projects.
  * Invalid patterns that traverse above the filesystem root are safely ignored.

* **Documentation**
  * Clarified the security implications of including directories outside the workspace in workspace configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
