### PR TITLE
fix(cli): treat pnpm install with package names as pnpm add

### DIFF
--- a/.changeset/pacquet-install-with-package-names.md
+++ b/.changeset/pacquet-install-with-package-names.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm install <pkg>` now adds the package, the same as `pnpm add <pkg>` and matching the JavaScript CLI. It previously ended in a usage error: `pnpm i valibot` printed `error: unexpected argument 'valibot' found` instead of saving the dependency [#13886](https://github.com/pnpm/pnpm/issues/13886).

--- a/pnpm/crates/cli/src/flag_relocation.rs
+++ b/pnpm/crates/cli/src/flag_relocation.rs
@@ -29,19 +29,42 @@ use std::{
     ffi::OsString,
 };
 
+/// Where [`scan_for_positional`] stopped: at a positional token, or at
+/// the `--` terminator.
+pub(crate) enum PositionalScan {
+    Positional(usize),
+    Separator(usize),
+}
+
 /// The index of the next positional token at or after `index`, stepping
 /// over option tokens (and the values they consume, per the arity tables).
 /// `None` when argv ends or a `--` terminator is reached first.
 pub(crate) fn find_positional(
     argv: &[OsString],
-    mut index: usize,
+    index: usize,
     top_level: &ArgTable,
     subcommand_union: &ArgTable,
 ) -> Option<usize> {
+    match scan_for_positional(argv, index, top_level, subcommand_union)? {
+        PositionalScan::Positional(index) => Some(index),
+        PositionalScan::Separator(_) => None,
+    }
+}
+
+/// [`find_positional`]'s scan with the stop reason kept: a caller that
+/// mirrors nopt — which strips the `--` terminator and treats what
+/// follows as positionals — needs to tell the terminator apart from
+/// running out of argv (`None`).
+pub(crate) fn scan_for_positional(
+    argv: &[OsString],
+    mut index: usize,
+    top_level: &ArgTable,
+    subcommand_union: &ArgTable,
+) -> Option<PositionalScan> {
     loop {
         let token = argv.get(index).and_then(|token| token.to_str())?;
         if token == "--" {
-            return None;
+            return Some(PositionalScan::Separator(index));
         }
         if let Some(rest) = token.strip_prefix("--") {
             let (name, has_inline_value) =
@@ -62,7 +85,7 @@ pub(crate) fn find_positional(
                 index += token_width(consumes_value && is_bare_short, false);
             }
         } else {
-            return Some(index);
+            return Some(PositionalScan::Positional(index));
         }
     }
 }

--- a/pnpm/crates/cli/src/install_as_add.rs
+++ b/pnpm/crates/cli/src/install_as_add.rs
@@ -14,7 +14,7 @@
 //!
 //! [`relocate_pre_subcommand_flags`]: crate::flag_relocation::relocate_pre_subcommand_flags
 
-use crate::flag_relocation::{ArgTable, find_positional};
+use crate::flag_relocation::{ArgTable, PositionalScan, find_positional, scan_for_positional};
 use clap::Command;
 use std::ffi::OsString;
 
@@ -30,9 +30,18 @@ pub(crate) fn rewrite(cmd: &Command, mut argv: Vec<OsString>) -> Vec<OsString> {
     let names_install = cmd
         .find_subcommand(&argv[subcommand_index])
         .is_some_and(|subcommand| subcommand.get_name() == "install");
-    if !names_install
-        || find_positional(&argv, subcommand_index + 1, &top_level, &subcommand_union).is_none()
-    {
+    if !names_install {
+        return argv;
+    }
+    let names_package =
+        match scan_for_positional(&argv, subcommand_index + 1, &top_level, &subcommand_union) {
+            Some(PositionalScan::Positional(_)) => true,
+            // nopt strips the `--` terminator and treats what follows as
+            // positionals, so `pnpm install -- <pkg>` names a package too.
+            Some(PositionalScan::Separator(separator_index)) => separator_index + 1 < argv.len(),
+            None => false,
+        };
+    if !names_package {
         return argv;
     }
     argv[subcommand_index] = OsString::from("add");

--- a/pnpm/crates/cli/src/install_as_add.rs
+++ b/pnpm/crates/cli/src/install_as_add.rs
@@ -1,0 +1,43 @@
+//! `pnpm install <pkg>` as a spelling of `pnpm add <pkg>`.
+//!
+//! pnpm resolves the command name before it parses argv, and an `install`
+//! that was given a package name resolves to `add`, so `pnpm i valibot`
+//! saves the dependency instead of installing the project. Clap has no
+//! such step: `install` declares no positional, so the package name ends
+//! the parse with "unexpected argument" (pnpm/pnpm#13886).
+//!
+//! Renaming the subcommand token in argv hands the whole command line to
+//! `add`'s grammar, which is the same thing pnpm's own parser does with
+//! it. The scan runs after [`relocate_pre_subcommand_flags`], so an option
+//! written before the subcommand already sits after it and cannot be
+//! mistaken for the package name.
+//!
+//! [`relocate_pre_subcommand_flags`]: crate::flag_relocation::relocate_pre_subcommand_flags
+
+use crate::flag_relocation::{ArgTable, find_positional};
+use clap::Command;
+use std::ffi::OsString;
+
+/// Rewrite the `install` subcommand token to `add` when a package name
+/// follows it. A no-op for every other command line, `pnpm install` with
+/// options but no package included.
+pub(crate) fn rewrite(cmd: &Command, mut argv: Vec<OsString>) -> Vec<OsString> {
+    let top_level = ArgTable::top_level(cmd);
+    let subcommand_union = ArgTable::subcommand_union(cmd);
+    let Some(subcommand_index) = find_positional(&argv, 1, &top_level, &subcommand_union) else {
+        return argv;
+    };
+    let names_install = cmd
+        .find_subcommand(&argv[subcommand_index])
+        .is_some_and(|subcommand| subcommand.get_name() == "install");
+    if !names_install
+        || find_positional(&argv, subcommand_index + 1, &top_level, &subcommand_union).is_none()
+    {
+        return argv;
+    }
+    argv[subcommand_index] = OsString::from("add");
+    argv
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/install_as_add/tests.rs
+++ b/pnpm/crates/cli/src/install_as_add/tests.rs
@@ -1,0 +1,75 @@
+use super::rewrite;
+use crate::{
+    boolean_negations::with_boolean_negations,
+    cli_args::{CliArgs, cli_command::CliCommand},
+    flag_relocation::relocate_pre_subcommand_flags,
+};
+use clap::{CommandFactory, FromArgMatches};
+use pretty_assertions::assert_eq;
+use std::ffi::OsString;
+
+fn rewritten(tokens: &[&str]) -> Vec<String> {
+    let cmd = with_boolean_negations(CliArgs::command());
+    let argv = relocate_pre_subcommand_flags(&cmd, tokens.iter().map(OsString::from).collect());
+    rewrite(&cmd, argv)
+        .into_iter()
+        .map(|token| token.into_string().expect("test tokens are UTF-8"))
+        .collect()
+}
+
+fn parse(tokens: &[&str]) -> CliArgs {
+    let cmd = with_boolean_negations(CliArgs::command());
+    let argv = relocate_pre_subcommand_flags(&cmd, tokens.iter().map(OsString::from).collect());
+    let argv = rewrite(&cmd, argv);
+    cmd.try_get_matches_from(argv)
+        .and_then(|matches| CliArgs::from_arg_matches(&matches))
+        .expect("parses after the rewrite")
+}
+
+#[test]
+fn install_with_a_package_name_becomes_add() {
+    for command in ["install", "i"] {
+        let argv = rewritten(&["pnpm", command, "valibot"]);
+        assert_eq!(argv, ["pnpm", "add", "valibot"], "command: {command}");
+    }
+}
+
+#[test]
+fn install_without_a_package_name_stays_install() {
+    assert_eq!(rewritten(&["pnpm", "install"]), ["pnpm", "install"]);
+    assert_eq!(
+        rewritten(&["pnpm", "install", "--frozen-lockfile"]),
+        ["pnpm", "install", "--frozen-lockfile"],
+    );
+}
+
+#[test]
+fn a_value_taking_option_is_not_mistaken_for_a_package_name() {
+    assert_eq!(
+        rewritten(&["pnpm", "install", "--reporter", "silent"]),
+        ["pnpm", "install", "--reporter", "silent"],
+    );
+}
+
+#[test]
+fn install_test_is_left_alone() {
+    assert_eq!(rewritten(&["pnpm", "install-test"]), ["pnpm", "install-test"]);
+}
+
+#[test]
+fn a_recursive_install_with_a_package_name_becomes_add() {
+    assert_eq!(
+        rewritten(&["pnpm", "recursive", "install", "valibot"]),
+        ["pnpm", "--recursive", "add", "valibot"],
+    );
+}
+
+#[test]
+fn the_rewritten_invocation_parses_as_add() {
+    let args = parse(&["pnpm", "i", "-D", "valibot", "vitest"]);
+
+    let CliCommand::Add(add) = args.command else {
+        panic!("expected add");
+    };
+    assert_eq!(add.package_names, ["valibot", "vitest"]);
+}

--- a/pnpm/crates/cli/src/install_as_add/tests.rs
+++ b/pnpm/crates/cli/src/install_as_add/tests.rs
@@ -57,6 +57,19 @@ fn install_test_is_left_alone() {
 }
 
 #[test]
+fn a_package_name_after_the_separator_becomes_add() {
+    assert_eq!(
+        rewritten(&["pnpm", "install", "--lockfile-only", "--", "valibot"]),
+        ["pnpm", "add", "--lockfile-only", "--", "valibot"],
+    );
+}
+
+#[test]
+fn a_trailing_separator_alone_stays_install() {
+    assert_eq!(rewritten(&["pnpm", "install", "--"]), ["pnpm", "install", "--"]);
+}
+
+#[test]
 fn a_recursive_install_with_a_package_name_becomes_add() {
     assert_eq!(
         rewritten(&["pnpm", "recursive", "install", "valibot"]),
@@ -72,4 +85,14 @@ fn the_rewritten_invocation_parses_as_add() {
         panic!("expected add");
     };
     assert_eq!(add.package_names, ["valibot", "vitest"]);
+}
+
+#[test]
+fn the_separator_spelling_parses_as_add() {
+    let args = parse(&["pnpm", "install", "--", "valibot"]);
+
+    let CliCommand::Add(add) = args.command else {
+        panic!("expected add");
+    };
+    assert_eq!(add.package_names, ["valibot"]);
 }

--- a/pnpm/crates/cli/src/lib.rs
+++ b/pnpm/crates/cli/src/lib.rs
@@ -6,6 +6,7 @@ mod engine_pm;
 mod executable_link;
 mod flag_relocation;
 mod github_actions;
+mod install_as_add;
 mod job_control;
 mod leading_separator;
 mod parse_boundary;
@@ -98,6 +99,10 @@ fn run_cli() -> miette::Result<()> {
     // options written before the subcommand to after it so clap agrees.
     // See `flag_relocation`.
     let argv = relocate_pre_subcommand_flags(&command, argv);
+    // `pnpm install <pkg>` is pnpm's spelling of `pnpm add <pkg>`; clap's
+    // `install` takes no package name, so rename the subcommand token.
+    // See `install_as_add`.
+    let argv = install_as_add::rewrite(&command, argv);
     // A command whose arguments begin at a `--` would otherwise lose it to
     // clap's escape handling. See `leading_separator`.
     let argv = leading_separator::preserve_leading_separator(argv);


### PR DESCRIPTION
## Summary

`pnpm i valibot` on 12.0.0-rc.4 ends with `error: unexpected argument 'valibot' found` instead of adding the dependency.

pnpm resolves the command name before it parses argv, and `getCommandName` in `@pnpm/parse-cli-args` resolves an `install` that was given a package name to `add`. Clap has no equivalent step, and its `install` declares no positional, so the package name ends the parse.

This adds a pre-clap pass that renames the `install` subcommand token to `add` when a positional follows it, handing the whole command line to `add`'s grammar. It runs after the flag relocation pass, so an option written before the subcommand already sits after it and cannot be mistaken for the package name. The scan also follows nopt across the `--` terminator — nopt strips it and keeps what follows as positionals — so `pnpm install -- <pkg>` adds the package too, as the TypeScript CLI does.

Closes pnpm/pnpm#13886

## Squash Commit Body

```text
pnpm resolves the command name before parsing argv: getCommandName in
@pnpm/parse-cli-args maps an `install` that carries a package name to
`add`, which is why `pnpm i valibot` saves the dependency. Clap scopes
positionals to the subcommand that declares them, and `install` declares
none, so the same command line aborted with "unexpected argument"
(Closes pnpm/pnpm#13886).

The new `install_as_add` pass renames the subcommand token in argv, so
`add`'s grammar parses the rest of the line, aliases and all. It sits
after `relocate_pre_subcommand_flags` in the pre-clap chain, which means
options written ahead of the subcommand have already moved behind it and
the scan for a package name cannot trip over an option's value. Command
and arity lookups both come from the clap tree rather than a hand-written
list of names, so `install-test` and `pnpm install --reporter silent` are
left alone.

The scan for a package name follows nopt across the `--` terminator:
nopt strips it and keeps what follows as positionals, so
`pnpm install -- <pkg>` maps to `add` too, matching the TypeScript CLI.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (The TypeScript CLI already does this; only the Rust port was missing it.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13888"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789195804&installation_model_id=426870&pr_number=13888&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13888&signature=2ceeff4f07fd04a07fc3c3efad40f477c9d53f329a8ad0f96c905d7ddde951a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `pnpm install <package>` now adds and saves the specified package, matching `pnpm add <package>`.
  - Supports package names with shorthand, recursive, and separator-based install commands.
  - Development-dependency options are preserved during conversion.

- **Bug Fixes**
  - Prevented package arguments from being incorrectly rejected by `pnpm install`.
  - Package-less installs, option values, and related commands continue to behave as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
