### PR TITLE
fix(self-update): do not downgrade when a dist-tag points at the running version

### DIFF
--- a/.changeset/self-update-tag-no-downgrade.md
+++ b/.changeset/self-update-tag-no-downgrade.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/engine.pm.commands": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+`pnpm self-update <tag>` no longer downgrades when the dist-tag points at the pnpm version already running and that version is younger than `minimumReleaseAge`. The maturity cutoff moved the tag back to the previous mature release, so `pnpm self-update next-12` on v12.0.0-rc.4 switched to v12.0.0-rc.3.

--- a/pnpm/crates/cli/src/config_deps.rs
+++ b/pnpm/crates/cli/src/config_deps.rs
@@ -10,7 +10,7 @@
 use crate::config_overrides::apply_store_dir_override;
 use miette::{IntoDiagnostic, Result, WrapErr};
 use pnpm_catalogs_config::get_catalogs_from_workspace_manifest;
-use pnpm_config::{Config, Host, WorkspaceSettings};
+use pnpm_config::{Config, Host, PNPM_VERSION, WorkspaceSettings};
 use pnpm_env_installer::{
     ConfigDepsInstallOptions, pnpm_engine_packages, resolve_and_install_config_deps,
     resolve_package_manager_integrities,
@@ -164,14 +164,17 @@ pub async fn resolve_engine_version(
         }
         None => None,
     };
-    let published_by_exclude = config
-        .minimum_release_age_exclude
-        .as_deref()
-        .filter(|patterns| !patterns.is_empty())
-        .map(pnpm_config::version_policy::create_package_version_policy)
-        .transpose()
-        .into_diagnostic()
-        .wrap_err("compile the minimum-release-age-exclude policy")?;
+    // The running version is already on this machine, so hiding it behind the
+    // maturity cutoff protects nothing — it only makes a dist-tag that points
+    // at it fall back to an older release, downgrading the user
+    // (pnpm/pnpm#13883).
+    let mut exclude_patterns = config.minimum_release_age_exclude.clone().unwrap_or_default();
+    exclude_patterns.push(format!("pnpm@{PNPM_VERSION}"));
+    let published_by_exclude =
+        pnpm_config::version_policy::create_package_version_policy(&exclude_patterns)
+            .into_diagnostic()
+            .wrap_err("compile the minimum-release-age-exclude policy")
+            .map(Some)?;
     let trust_policy = match config.trust_policy {
         pnpm_config::TrustPolicy::Off => None,
         pnpm_config::TrustPolicy::NoDowngrade => Some(pnpm_config::TrustPolicy::NoDowngrade),

--- a/pnpm/crates/cli/src/config_deps/tests.rs
+++ b/pnpm/crates/cli/src/config_deps/tests.rs
@@ -1,6 +1,6 @@
 use std::{fs, path::Path};
 
-use pnpm_config::{Config, Host, TrustPolicy};
+use pnpm_config::{Config, Host, PNPM_VERSION, TrustPolicy};
 use pnpm_reporter::SilentReporter;
 
 use super::{resolve_engine_version, run_update_config_hooks};
@@ -390,4 +390,71 @@ async fn resolve_pnpm_version_forces_full_metadata_for_no_downgrade_despite_regi
         report.contains("trust downgrade"),
         "expected a trust-downgrade rejection, got: {report}",
     );
+}
+
+/// pnpm/pnpm#13883: a dist-tag pointing at the running pnpm, published
+/// within the `minimumReleaseAge` cutoff, must still resolve to it. The
+/// maturity filter moved such a tag back to the previous mature release,
+/// so `pnpm self-update <tag>` downgraded instead of doing nothing.
+#[tokio::test]
+async fn resolve_pnpm_version_keeps_a_dist_tag_on_the_running_version() {
+    let running = node_semver::Version::parse(PNPM_VERSION).expect("parse the running version");
+    let older = if running.pre_release.is_empty() {
+        format!("{}.0.0", running.major - 1)
+    } else {
+        format!("{}.{}.{}-0", running.major, running.minor, running.patch)
+    };
+    let body = format!(
+        r#"{{
+    "name": "pnpm",
+    "dist-tags": {{ "latest": "{PNPM_VERSION}" }},
+    "time": {{
+        "{older}": "2024-01-10T08:30:00.000Z",
+        "{PNPM_VERSION}": "{fresh}"
+    }},
+    "versions": {{
+        "{older}": {{
+            "name": "pnpm",
+            "version": "{older}",
+            "dist": {{
+                "integrity": "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+                "shasum": "0000000000000000000000000000000000000000",
+                "tarball": "https://registry/pnpm-{older}.tgz"
+            }}
+        }},
+        "{PNPM_VERSION}": {{
+            "name": "pnpm",
+            "version": "{PNPM_VERSION}",
+            "dist": {{
+                "integrity": "sha512-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB==",
+                "shasum": "1111111111111111111111111111111111111111",
+                "tarball": "https://registry/pnpm-{PNPM_VERSION}.tgz"
+            }}
+        }}
+    }}
+}}"#,
+        fresh = chrono::Utc::now().to_rfc3339(),
+    );
+    let mut server = mockito::Server::new_async().await;
+    let _packument = server
+        .mock("GET", "/pnpm")
+        .with_status(200)
+        .with_body(&body)
+        .expect_at_least(1)
+        .create_async()
+        .await;
+    let cache_dir = tempfile::TempDir::new().expect("cache tempdir");
+    let mut config = Config {
+        minimum_release_age: Some(24 * 60),
+        cache_dir: cache_dir.path().to_path_buf(),
+        ..Config::default()
+    };
+    config.package_manager_bootstrap.registry = format!("{}/", server.url());
+
+    let resolved = resolve_engine_version(&config, "pnpm", "latest")
+        .await
+        .expect("the tag must resolve")
+        .expect("a matching pnpm version resolves");
+
+    assert_eq!(resolved.version, PNPM_VERSION);
 }

--- a/pnpm11/engine/pm/commands/src/self-updater/selfUpdate.ts
+++ b/pnpm11/engine/pm/commands/src/self-updater/selfUpdate.ts
@@ -102,7 +102,16 @@ export async function handler (
     ignoreMissingTimeField: opts.minimumReleaseAgeIgnoreMissingTime,
   })
   const pkgName = 'pnpm'
-  const { publishedBy, publishedByExclude } = getPublishedByPolicy(opts)
+  // The running version is already on this machine, so hiding it behind the
+  // maturity cutoff protects nothing — it only makes a dist-tag that points
+  // at it fall back to an older release, downgrading the user (pnpm/pnpm#13883).
+  const { publishedBy, publishedByExclude } = getPublishedByPolicy({
+    ...opts,
+    minimumReleaseAgeExclude: [
+      ...opts.minimumReleaseAgeExclude ?? [],
+      `${pkgName}@${packageManager.version}`,
+    ],
+  })
   // `pnpm self-update` (no args) defaults to the `latest` dist-tag, but we
   // refuse to downgrade in that case — `latest` on the registry can lag the
   // installed version when a new major has shipped without being tagged.

--- a/pnpm11/engine/pm/commands/test/self-updater/selfUpdate.test.ts
+++ b/pnpm11/engine/pm/commands/test/self-updater/selfUpdate.test.ts
@@ -556,6 +556,36 @@ test('global self-update respects minimumReleaseAge: skips immature latest, no-o
   expect(fs.readdirSync(opts.globalPkgDir).sort()).toStrictEqual(globalEntriesBefore)
 })
 
+test('self-update by dist-tag does not downgrade below the active version', async () => {
+  // Reproduces pnpm/pnpm#13883: `next-9` points at the version already
+  // running, but it is younger than minimumReleaseAge, so the maturity
+  // filter moved the tag back to the previous mature release and switched
+  // the user to it.
+  mockPackageManager.version = '9.1.0'
+  const opts = prepare()
+  seedGlobalPnpm(opts, '9.1.0')
+  const globalEntriesBefore = fs.readdirSync(opts.globalPkgDir).sort()
+  const now = Date.now()
+  const metadata = {
+    ...createMetadata('9.1.0', opts.registriesByScope.default, ['9.0.0'], {
+      '9.0.0': new Date(now - 48 * 60 * 60 * 1000).toISOString(),
+      '9.1.0': new Date(now - 8 * 60 * 60 * 1000).toISOString(),
+    }),
+    'dist-tags': { latest: '9.0.0', 'next-9': '9.1.0' },
+  }
+  getMockAgent().get(opts.registriesByScope.default.replace(/\/$/, ''))
+    .intercept({ path: '/pnpm', method: 'GET' })
+    .reply(200, metadata)
+
+  const output = await selfUpdate.handler({
+    ...opts,
+    minimumReleaseAge: 24 * 60,
+  }, ['next-9'])
+
+  expect(output).toBe('The currently active pnpm v9.1.0 is already "next-9" and doesn\'t need an update')
+  expect(fs.readdirSync(opts.globalPkgDir).sort()).toStrictEqual(globalEntriesBefore)
+})
+
 test('self-update respects minimumReleaseAgeExclude for implicit latest resolution', async () => {
   const opts = prepare({
     packageManager: 'pnpm@8.0.0',


### PR DESCRIPTION
## Summary

`pnpm self-update next-12` on v12.0.0-rc.4 switched down to v12.0.0-rc.3. The `next-12` tag did point at rc.4, but rc.4 was about 11 hours old, so the built-in `minimumReleaseAge` default (1440 minutes) dropped it from the packument and `filterPkgMetadataByPublishDate` repopulated the tag to the newest mature release below it, rc.3. Self-update then resolved a version older than the one already running and installed it.

The no-downgrade guard from pnpm/pnpm#11435 only covers implicit `latest`, and widening it to every tag would take away the escape hatch it deliberately left: an explicit `pnpm self-update latest` still has to force a downgrade when the registry's `latest` genuinely lags a new major.

So self-update now adds the running version to `minimumReleaseAgeExclude` for its own resolve instead. That version is already on the machine, so keeping it hidden buys no protection, and keeping it visible stops a dist-tag that points at it, or at anything newer, from falling back to an older release. `pnpm self-update <tag>` on a fresh release is now a no-op until something newer matures, which is what the cutoff means. An explicit version or a tag that really points at an older release still downgrades as before.

The same change lands in pacquet's `resolve_pnpm_version`, which builds the identical policy for its own probe.

Closes pnpm/pnpm#13883.

## Squash Commit Body

```text
The minimumReleaseAge cutoff filters an immature version out of the
packument and repopulates every dist-tag pointing at it to the newest
mature release below it. For a dependency that is the right answer,
but self-update reads the tag as "which pnpm should I be running", so
a tag pointing at the freshly published version the user already runs
resolved to the previous release and downgraded them: pnpm
self-update next-12 on 12.0.0-rc.4 switched to 12.0.0-rc.3.

The no-downgrade guard added in pnpm/pnpm#11435 does not cover this,
and cannot be widened to every tag without losing the explicit
"pnpm self-update latest" downgrade it deliberately allows.

Self-update now appends the running version to
minimumReleaseAgeExclude before it resolves. That version is already
installed, so the cutoff protects nothing by hiding it, and keeping
it visible pins any tag that points at it or past it to it. Mirrored
in pacquet's resolve_pnpm_version.

Closes pnpm/pnpm#13883.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13889"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789196540&installation_model_id=426870&pr_number=13889&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13889&signature=98dd1cef35f6c173c560d6b3faeab9945b1a5d66cded3edc3d15cd9e16abd892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm self-update <tag>` incorrectly downgrading an immature active version.
  * Self-update now keeps the currently running version when it matches the requested dist-tag, even when release-age restrictions apply.
  * Improved version resolution for the active pnpm release.
  * No-op updates leave the global installation unchanged.

* **Tests**
  * Added coverage for tagged self-updates involving immature releases and minimum release-age settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->