### PR TITLE
fix(install): keep pending approvals after remove

### DIFF
--- a/.changeset/approve-builds-after-remove.md
+++ b/.changeset/approve-builds-after-remove.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.deps-installer": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+Kept pending build approvals available after removing an unrelated dependency.

--- a/pnpm/crates/cli/tests/suite/approve_builds.rs
+++ b/pnpm/crates/cli/tests/suite/approve_builds.rs
@@ -358,6 +358,32 @@ fn install_two_with_ignored_builds() -> (CommandTempCwd<AddMockedRegistry>, std:
     (harness, workspace)
 }
 
+#[test]
+fn approve_builds_works_after_removing_an_unrelated_dependency() {
+    let (harness, workspace) = install_two_with_ignored_builds();
+
+    pacquet(&workspace).with_args(["remove", INSTALL]).assert().success();
+
+    let output = stdout_of(pacquet(&workspace).with_arg("ignored-builds").assert());
+    assert!(output.contains(PREPOST), "the remaining package stays pending: {output}");
+    assert!(
+        !output.contains(INSTALL),
+        "the removed package must not stay pending: {output}",
+    );
+
+    pacquet(&workspace).with_args(["approve-builds", "--all"]).assert().success();
+
+    assert!(workspace.join(PREPOST_MARKER).exists(), "remaining package built under --all");
+    assert!(!workspace.join(INSTALL_MARKER).exists(), "removed package was not rebuilt");
+    assert_eq!(
+        allow_builds(&workspace).get(PREPOST),
+        Some(&true),
+        "remaining package approval persisted",
+    );
+
+    drop(harness);
+}
+
 /// The `allowBuilds` map recorded in the workspace manifest.
 /// The *decided* `allowBuilds` entries. An install scaffolds an
 /// undecided placeholder for every build it blocked, which is a prompt to

--- a/pnpm/crates/cli/tests/suite/approve_builds.rs
+++ b/pnpm/crates/cli/tests/suite/approve_builds.rs
@@ -366,10 +366,7 @@ fn approve_builds_works_after_removing_an_unrelated_dependency() {
 
     let output = stdout_of(pacquet(&workspace).with_arg("ignored-builds").assert());
     assert!(output.contains(PREPOST), "the remaining package stays pending: {output}");
-    assert!(
-        !output.contains(INSTALL),
-        "the removed package must not stay pending: {output}",
-    );
+    assert!(!output.contains(INSTALL), "the removed package must not stay pending: {output}",);
 
     pacquet(&workspace).with_args(["approve-builds", "--all"]).assert().success();
 

--- a/pnpm/crates/cli/tests/suite/approve_builds.rs
+++ b/pnpm/crates/cli/tests/suite/approve_builds.rs
@@ -366,7 +366,7 @@ fn approve_builds_works_after_removing_an_unrelated_dependency() {
 
     let output = stdout_of(pacquet(&workspace).with_arg("ignored-builds").assert());
     assert!(output.contains(PREPOST), "the remaining package stays pending: {output}");
-    assert!(!output.contains(INSTALL), "the removed package must not stay pending: {output}",);
+    assert!(!output.contains(INSTALL), "the removed package must not stay pending: {output}");
 
     pacquet(&workspace).with_args(["approve-builds", "--all"]).assert().success();
 

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -77,9 +77,10 @@ pub use lockfile_freshness::{
 use materialize::{MaterializationInputs, MaterializationOutput, materialize};
 use modules_state::{
     build_modules_manifest, check_modules_settings_diff, drain_settled_projects,
-    frozen_tree_intact, gvs_build_marker_present, gvs_build_markers_may_require_recovery,
-    has_newly_allowed_ignored_builds, has_revoked_allowed_builds, manifest_string_field,
-    merge_filtered_modules_metadata, merge_pending_builds, modules_consistent_with,
+    current_contains_dep_path, frozen_tree_intact, gvs_build_marker_present,
+    gvs_build_markers_may_require_recovery, has_newly_allowed_ignored_builds,
+    has_revoked_allowed_builds, manifest_string_field, merge_filtered_modules_metadata,
+    merge_pending_builds, modules_consistent_with,
     modules_layout_consistent_with, project_requires_lifecycle_scripts,
     unapproved_recorded_ignored_builds,
 };

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -76,13 +76,12 @@ pub use lockfile_freshness::{
 };
 use materialize::{MaterializationInputs, MaterializationOutput, materialize};
 use modules_state::{
-    build_modules_manifest, check_modules_settings_diff, drain_settled_projects,
-    current_contains_dep_path, frozen_tree_intact, gvs_build_marker_present,
+    build_modules_manifest, check_modules_settings_diff, current_contains_dep_path,
+    drain_settled_projects, frozen_tree_intact, gvs_build_marker_present,
     gvs_build_markers_may_require_recovery, has_newly_allowed_ignored_builds,
     has_revoked_allowed_builds, manifest_string_field, merge_filtered_modules_metadata,
-    merge_pending_builds, modules_consistent_with,
-    modules_layout_consistent_with, project_requires_lifecycle_scripts,
-    unapproved_recorded_ignored_builds,
+    merge_pending_builds, modules_consistent_with, modules_layout_consistent_with,
+    project_requires_lifecycle_scripts, unapproved_recorded_ignored_builds,
 };
 use prepare_modules_state::{
     PrepareModulesStateInputs, PreparedModulesState, prepare_modules_state,

--- a/pnpm/crates/package-manager/src/install/apply_materialization.rs
+++ b/pnpm/crates/package-manager/src/install/apply_materialization.rs
@@ -469,7 +469,7 @@ fn commit_modules_state(inputs: CommitModulesStateInputs<'_>) -> Result<(), Inst
 
 fn retain_current_ignored_builds(
     next: &mut Modules,
-    previous: &pacquet_modules_yaml::ModulesLayout,
+    previous: &pnpm_modules_yaml::ModulesLayout,
     current: &Lockfile,
     allow_build_policy: &crate::AllowBuildPolicy,
 ) {

--- a/pnpm/crates/package-manager/src/install/apply_materialization.rs
+++ b/pnpm/crates/package-manager/src/install/apply_materialization.rs
@@ -376,14 +376,18 @@ fn commit_modules_state(inputs: CommitModulesStateInputs<'_>) -> Result<(), Inst
     // selected, approved dependency always runs (force-rebuild
     // bypasses the side-effects cache gate), so policy approval is a
     // faithful stand-in for "was rebuilt".
-    let rebuild_build_policy =
-        rebuild.as_ref().and_then(|_| crate::AllowBuildPolicy::from_config(config).ok());
+    let allow_build_policy = (rebuild.is_some()
+        || (prior_modules.is_some() && materialized_current_lockfile.is_some()))
+    .then(|| crate::AllowBuildPolicy::from_config(config))
+    .transpose()
+    .map_err(InstallWithFreshLockfileError::AllowBuildsPolicy)
+    .map_err(InstallError::WithFreshLockfile)?;
     let pending_builds = merge_pending_builds(
         previous_pending_builds,
         deferred_projects.into_iter().flatten().chain(deferred_builds),
         materialized_current_lockfile,
         rebuild,
-        rebuild_build_policy.as_ref(),
+        allow_build_policy.as_ref(),
     );
 
     // Rebuild reads hoisted locations from `.modules.yaml` and reports
@@ -400,11 +404,10 @@ fn commit_modules_state(inputs: CommitModulesStateInputs<'_>) -> Result<(), Inst
         pending_builds,
         pruned_at,
     );
-    if let (Some(previous), Some(current)) = (prior_modules, materialized_current_lockfile) {
-        let allow_build_policy = crate::AllowBuildPolicy::from_config(config)
-            .map_err(InstallWithFreshLockfileError::AllowBuildsPolicy)
-            .map_err(InstallError::WithFreshLockfile)?;
-        retain_current_ignored_builds(&mut next_modules, previous, current, &allow_build_policy);
+    if let (Some(previous), Some(current), Some(policy)) =
+        (prior_modules, materialized_current_lockfile, allow_build_policy.as_ref())
+    {
+        retain_current_ignored_builds(&mut next_modules, previous, current, policy);
     }
     if filtered_install
         && !matches!(node_linker, NodeLinker::Hoisted)

--- a/pnpm/crates/package-manager/src/install/apply_materialization.rs
+++ b/pnpm/crates/package-manager/src/install/apply_materialization.rs
@@ -4,8 +4,8 @@ use super::{
     LogLevel, Modules, NodeLinker, PackageManifest, Path, PathBuf, ProjectMutation,
     ProjectScriptsInputs, RebuildOptions, Reporter, SummaryLog, SystemTime,
     WorkspaceInstallSelection, build_modules_manifest, build_workspace_state,
-    drain_settled_projects, merge_filtered_modules_metadata, merge_pending_builds,
-    order_project_lifecycle_groups, project_requires_lifecycle_scripts,
+    current_contains_dep_path, drain_settled_projects, merge_filtered_modules_metadata,
+    merge_pending_builds, order_project_lifecycle_groups, project_requires_lifecycle_scripts,
     projects_running_own_scripts, run_projects_lifecycle_scripts, update_workspace_state,
     write_modules_manifest,
 };
@@ -400,6 +400,12 @@ fn commit_modules_state(inputs: CommitModulesStateInputs<'_>) -> Result<(), Inst
         pending_builds,
         pruned_at,
     );
+    if let (Some(previous), Some(current)) = (modules_manifest, materialized_current_lockfile) {
+        let allow_build_policy = crate::AllowBuildPolicy::from_config(config)
+            .map_err(InstallWithFreshLockfileError::AllowBuildsPolicy)
+            .map_err(InstallError::WithFreshLockfile)?;
+        retain_current_ignored_builds(&mut next_modules, previous, current, &allow_build_policy);
+    }
     if filtered_install
         && !matches!(node_linker, NodeLinker::Hoisted)
         && !is_inconsistent
@@ -459,6 +465,22 @@ fn commit_modules_state(inputs: CommitModulesStateInputs<'_>) -> Result<(), Inst
     }
 
     Ok(())
+}
+
+fn retain_current_ignored_builds(
+    next: &mut Modules,
+    previous: &pacquet_modules_yaml::ModulesLayout,
+    current: &Lockfile,
+    allow_build_policy: &crate::AllowBuildPolicy,
+) {
+    let Some(previous_ignored) = previous.ignored_builds.as_ref() else { return };
+    for dep_path in previous_ignored {
+        if current_contains_dep_path(current, dep_path.as_str())
+            && allow_build_policy.check(dep_path.as_str()).is_none()
+        {
+            next.ignored_builds.get_or_insert_default().insert(dep_path.clone());
+        }
+    }
 }
 
 #[derive(Clone, Copy)]

--- a/pnpm/crates/package-manager/src/install/apply_materialization.rs
+++ b/pnpm/crates/package-manager/src/install/apply_materialization.rs
@@ -400,7 +400,7 @@ fn commit_modules_state(inputs: CommitModulesStateInputs<'_>) -> Result<(), Inst
         pending_builds,
         pruned_at,
     );
-    if let (Some(previous), Some(current)) = (modules_manifest, materialized_current_lockfile) {
+    if let (Some(previous), Some(current)) = (prior_modules, materialized_current_lockfile) {
         let allow_build_policy = crate::AllowBuildPolicy::from_config(config)
             .map_err(InstallWithFreshLockfileError::AllowBuildsPolicy)
             .map_err(InstallError::WithFreshLockfile)?;

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -2176,6 +2176,15 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
     ctx.pendingBuilds = ctx.pendingBuilds
       .filter((relDepPath) => !result.removedDepPaths.has(relDepPath))
 
+    if (ctx.modulesFile?.ignoredBuilds?.size) {
+      for (const ignoredBuild of ctx.modulesFile.ignoredBuilds.values()) {
+        if (result.currentLockfile.packages?.[ignoredBuild] && !isBuildExplicitlyDisallowed(ignoredBuild, opts.allowBuild)) {
+          ignoredBuilds ??= new Set()
+          ignoredBuilds.add(ignoredBuild)
+        }
+      }
+    }
+
     if (result.newDepPaths?.length) {
       if (opts.ignoreScripts) {
         // we can use concat here because we always only append new packages, which are guaranteed to not be there by definition
@@ -2206,7 +2215,7 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
         }
         // Dependency lifecycle scripts must not run on an unverified lockfile.
         await opts.verifyLockfile?.()
-        ignoredBuilds = (await buildModules(dependenciesGraph, rootNodes, {
+        const ignoredBuildsFromBuild = (await buildModules(dependenciesGraph, rootNodes, {
           allowBuild: opts.allowBuild,
           childConcurrency: opts.childConcurrency,
           depsStateCache,
@@ -2229,12 +2238,10 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
           enableGlobalVirtualStore: opts.enableGlobalVirtualStore,
           frozenStore: opts.frozenStore,
         })).ignoredBuilds
-        if (ctx.modulesFile?.ignoredBuilds?.size) {
+        if (ignoredBuildsFromBuild?.size) {
           ignoredBuilds ??= new Set()
-          for (const ignoredBuild of ctx.modulesFile.ignoredBuilds.values()) {
-            if (result.currentLockfile.packages?.[ignoredBuild] && !isBuildExplicitlyDisallowed(ignoredBuild, opts.allowBuild)) {
-              ignoredBuilds.add(ignoredBuild)
-            }
+          for (const ignoredBuild of ignoredBuildsFromBuild.values()) {
+            ignoredBuilds.add(ignoredBuild)
           }
         }
       }

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -2176,9 +2176,12 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
     ctx.pendingBuilds = ctx.pendingBuilds
       .filter((relDepPath) => !result.removedDepPaths.has(relDepPath))
 
-    if (ctx.modulesFile?.ignoredBuilds?.size) {
+    if (ctx.modulesFile?.ignoredBuilds?.size && result.currentLockfile.packages != null) {
       for (const ignoredBuild of ctx.modulesFile.ignoredBuilds.values()) {
-        if (result.currentLockfile.packages?.[ignoredBuild] && !isBuildExplicitlyDisallowed(ignoredBuild, opts.allowBuild)) {
+        // `Object.hasOwn` keeps a `.modules.yaml` entry named like an
+        // `Object.prototype` key from matching a package the lockfile
+        // doesn't contain.
+        if (Object.hasOwn(result.currentLockfile.packages, ignoredBuild) && !isBuildExplicitlyDisallowed(ignoredBuild, opts.allowBuild)) {
           ignoredBuilds ??= new Set()
           ignoredBuilds.add(ignoredBuild)
         }

--- a/pnpm11/pnpm/test/install/lifecycleScripts.ts
+++ b/pnpm11/pnpm/test/install/lifecycleScripts.ts
@@ -485,6 +485,36 @@ test('approve-builds works after stashing and re-adding a dependency (#12221)', 
   expect(secondApprove.stdout.toString()).not.toContain('No packages awaiting approval')
 })
 
+test('approve-builds works after removing an unrelated dependency (#13891)', async () => {
+  const project = prepare({})
+
+  const pendingPkg = '@pnpm.e2e/pre-and-postinstall-scripts-example'
+  const removedPkg = '@pnpm.e2e/install-script-example'
+
+  const firstAdd = execPnpmSync(['add', `${pendingPkg}@1.0.0`])
+  expect(firstAdd.status).toBe(1)
+  expect(firstAdd.stdout.toString()).toContain('Ignored build scripts:')
+
+  const secondAdd = execPnpmSync(['add', `${removedPkg}@1.0.0`])
+  expect(secondAdd.status).toBe(1)
+  expect(secondAdd.stdout.toString()).toContain('Ignored build scripts:')
+
+  const remove = execPnpmSync(['remove', removedPkg])
+  expect(remove.status).toBe(0)
+
+  const modulesManifest = project.readModulesManifest()
+  const ignoredNames = Array.from(modulesManifest?.ignoredBuilds ?? []).map((depPath) => parse(depPath).name)
+  expect(ignoredNames).toContain(pendingPkg)
+  expect(ignoredNames).not.toContain(removedPkg)
+
+  const approve = execPnpmSync(['approve-builds', '--all'])
+  expect(approve.status).toBe(0)
+  expect(approve.stdout.toString()).not.toContain('There are no packages awaiting approval')
+
+  const wsManifest = await readWorkspaceManifest(process.cwd())
+  expect(wsManifest!.allowBuilds?.[pendingPkg]).toBe(true)
+})
+
 // Which projects run their own lifecycle scripts is decided by the
 // mutated-importer list the command layer builds: the projects the
 // command was pointed at, plus the workspace root, which the recursive

--- a/pnpm11/pnpm/test/install/lifecycleScripts.ts
+++ b/pnpm11/pnpm/test/install/lifecycleScripts.ts
@@ -506,10 +506,16 @@ test('approve-builds works after removing an unrelated dependency (#13891)', asy
   const ignoredNames = Array.from(modulesManifest?.ignoredBuilds ?? []).map((depPath) => parse(depPath).name)
   expect(ignoredNames).toContain(pendingPkg)
   expect(ignoredNames).not.toContain(removedPkg)
+  expect(fs.existsSync(`node_modules/${pendingPkg}/generated-by-preinstall.js`)).toBeFalsy()
+  expect(fs.existsSync(`node_modules/${pendingPkg}/generated-by-postinstall.js`)).toBeFalsy()
+  expect(fs.existsSync(`node_modules/${removedPkg}/generated-by-install.js`)).toBeFalsy()
 
   const approve = execPnpmSync(['approve-builds', '--all'])
   expect(approve.status).toBe(0)
   expect(approve.stdout.toString()).not.toContain('There are no packages awaiting approval')
+  expect(fs.existsSync(`node_modules/${pendingPkg}/generated-by-preinstall.js`)).toBeTruthy()
+  expect(fs.existsSync(`node_modules/${pendingPkg}/generated-by-postinstall.js`)).toBeTruthy()
+  expect(fs.existsSync(`node_modules/${removedPkg}/generated-by-install.js`)).toBeFalsy()
 
   const wsManifest = await readWorkspaceManifest(process.cwd())
   expect(wsManifest!.allowBuilds?.[pendingPkg]).toBe(true)


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#13891. `pnpm remove` could drop pending build approvals for packages still installed.

Fix: Retain eligible `ignoredBuilds` entries before merging new build results, and mirror that behavior with `retain_current_ignored_builds` in the Rust path.

Test: Added pending-approval retention coverage in both TypeScript and Rust paths.

## Squash Commit Body

```text
Retain pending build approvals for packages that remain installed after `pnpm remove`.

This keeps previously ignored builds eligible before merging new build results, and mirrors the behavior in the Rust path.

Closes pnpm/pnpm#13891.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved pending build approvals when unrelated dependencies are removed.
  * Removed deleted dependencies from the pending build list.
  * Ensured `approve-builds --all` builds and records approval for remaining dependencies.
  * Prevented previously ignored builds from being lost during subsequent installations.
  * Removed obsolete build configuration entries when approvals are recorded.

* **Tests**
  * Added coverage for dependency removal, pending approvals, approval persistence, and lifecycle script execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->