### PR TITLE
fix(resolver): process workspace importers in project-id order

### DIFF
--- a/.changeset/importer-order-invariance.md
+++ b/.changeset/importer-order-invariance.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+The resolved dependency graph and lockfile no longer depend on the order in which workspace projects are listed or discovered: importers are processed in project-id order, so reordering the `packages` globs in `pnpm-workspace.yaml` (or any other change to project listing order) produces a byte-identical lockfile [#13846](https://github.com/pnpm/pnpm/issues/13846). This also makes auto-installed peer placement, deprecation-warning attribution, and cycle back-edge bindings a function of the project set alone.

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -355,13 +355,23 @@ pub fn resolve_peers_workspace(
         false,
     );
 
+    // Walk importers in id order. Occurrence realization and the shared
+    // verdict caches are first-writer-wins, so a stable walk order makes
+    // the graph a function of the importer set rather than of the
+    // caller's listing order (pnpm/pnpm#13846).
+    let importers: Vec<&ImporterPeerInput> = {
+        let mut sorted: Vec<&ImporterPeerInput> = importers.iter().collect();
+        sorted.sort_by(|left, right| left.id.cmp(&right.id));
+        sorted
+    };
+
     let mut direct_dependencies_by_importer: BTreeMap<String, BTreeMap<String, DepPath>> =
         BTreeMap::new();
     let mut peer_dependency_issues_by_importer: BTreeMap<String, PeerDependencyIssues> =
         BTreeMap::new();
     let mut importer_root_dirs: BTreeMap<String, PathBuf> = BTreeMap::new();
     let root_importer = resolve_peers_from_workspace_root
-        .then(|| importers.iter().find(|importer| importer.id == "."))
+        .then(|| importers.iter().copied().find(|importer| importer.id == "."))
         .flatten();
     let root_parents = root_importer.map(|importer| {
         let previous_dirs = (walker.opts.project_dir.clone(), walker.opts.modules_dir.clone());
@@ -371,7 +381,7 @@ pub fn resolve_peers_workspace(
         (walker.opts.project_dir, walker.opts.modules_dir) = previous_dirs;
         parents
     });
-    for importer in importers {
+    for importer in &importers {
         importer_root_dirs.insert(importer.id.clone(), importer.root_dir.clone());
         // Swap the per-importer `project_dir` / `modules_dir` in before
         // the walk so the `excludeLinksFromLockfile` link-remap inside
@@ -450,7 +460,7 @@ pub fn resolve_peers_workspace(
     // importer is walked, then rebuild the graph and re-key each
     // importer's direct deps.
     let final_dep_paths = walker.build_final_dep_paths();
-    for importer in importers {
+    for importer in &importers {
         let direct_by_alias: BTreeMap<String, DepPath> = importer
             .direct
             .iter()

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -2207,6 +2207,102 @@ fn cycle_re_walks_collapse_instead_of_multiplying_occurrences() {
     );
 }
 
+/// Importers are walked in id order, so reordering them cannot change
+/// which context first realizes a shared back-edge occurrence — even
+/// when their overlays provide conflicting versions (pnpm/pnpm#13846).
+#[test]
+fn backedge_bindings_do_not_depend_on_importer_order() {
+    let graph_for_order = |first: &str, second: &str| {
+        let edge = |alias: &str, pkg_id: &str| crate::resolved_tree::ChildEdge {
+            alias: alias.to_string(),
+            pkg_id: Arc::from(pkg_id),
+            optional: false,
+        };
+        let mut packages = HashMap::default();
+        packages.insert(Arc::from("p@1.0.0"), package("p", "1.0.0", &[], true));
+        packages.insert(Arc::from("p@2.0.0"), package("p", "2.0.0", &[], true));
+        packages
+            .insert(Arc::from("ring00@1.0.0"), package("ring00", "1.0.0", &[("p", "*")], false));
+        packages.insert(Arc::from("ring01@1.0.0"), package("ring01", "1.0.0", &[], false));
+        packages.insert(Arc::from("enter-a@1.0.0"), package("enter-a", "1.0.0", &[], false));
+        packages.insert(Arc::from("enter-b@1.0.0"), package("enter-b", "1.0.0", &[], false));
+        let children_by_id: HashMap<Arc<str>, Arc<Vec<crate::resolved_tree::ChildEdge>>> =
+            HashMap::from_iter([
+                (Arc::from("ring00@1.0.0"), Arc::new(vec![edge("next", "ring01@1.0.0")])),
+                (Arc::from("ring01@1.0.0"), Arc::new(vec![edge("back", "ring00@1.0.0")])),
+                (Arc::from("enter-a@1.0.0"), Arc::new(vec![edge("ring", "ring00@1.0.0")])),
+                (Arc::from("enter-b@1.0.0"), Arc::new(vec![edge("ring", "ring01@1.0.0")])),
+            ]);
+
+        let mut dependencies_tree = HashMap::default();
+        let mut direct_dep = |pkg_id: &str, alias: &str| {
+            let node_id = NodeId::next();
+            dependencies_tree.insert(
+                node_id.clone(),
+                crate::resolved_tree::DependenciesTreeNode::new(
+                    Arc::from(pkg_id),
+                    crate::resolved_tree::TreeChildren::Lazy {
+                        parent_ids: Arc::new(Vec::new()).into(),
+                    },
+                    0,
+                    true,
+                ),
+            );
+            DirectDep { alias: alias.to_string(), node_id, id: pkg_id.to_string() }
+        };
+        let importer = |id: &str, direct: Vec<DirectDep>| ImporterPeerInput {
+            id: id.to_string(),
+            direct,
+            hoisted_optional_peer_node_ids: HashSet::default(),
+            root_dir: std::path::PathBuf::from(format!("/repo/{id}")),
+            modules_dir: None,
+        };
+        let root = importer(".", vec![direct_dep("p@1.0.0", "p")]);
+        let importer_a =
+            importer("a", vec![direct_dep("enter-a@1.0.0", "enter-a"), direct_dep("p@2.0.0", "p")]);
+        let importer_b = importer("b", vec![direct_dep("enter-b@1.0.0", "enter-b")]);
+        let importers: Vec<ImporterPeerInput> = [first, second]
+            .iter()
+            .map(|id| match *id {
+                "a" => importer_a.clone(),
+                _ => importer_b.clone(),
+            })
+            .collect();
+        let importers = [vec![root], importers].concat();
+
+        let mut tree = ResolvedTree {
+            direct: Vec::new(),
+            packages,
+            dependencies_tree,
+            all_peer_dep_names: HashSet::from_iter(["p".to_string()]),
+            policy_violations: Vec::new(),
+            applied_patches: HashSet::default(),
+            children_by_id,
+        };
+        let result = resolve_peers_workspace(
+            &mut tree,
+            &importers,
+            std::path::Path::new("/repo"),
+            false,
+            false,
+            true,
+            ResolvePeersOptions::default(),
+        );
+        let mut keys: Vec<String> =
+            result.graph.keys().map(|path| path.as_str().to_string()).collect();
+        keys.sort_unstable();
+        keys
+    };
+
+    let a_first = graph_for_order("a", "b");
+    let b_first = graph_for_order("b", "a");
+    assert!(
+        a_first.iter().any(|key| key == "ring00@1.0.0(p@2.0.0)"),
+        "the back-edge occurrence binds the id-ordered first realizer's context;          got {a_first:#?}",
+    );
+    assert_eq!(a_first, b_first, "the graph must not depend on the importers' order");
+}
+
 /// The graph `entries` produce over the pnpm/pnpm#13865 ring, as sorted
 /// depPath keys, for comparing walk orders.
 fn peer_cycle_graph_keys(entries: &[(&str, usize, &str)], shape: PeerCycleShape) -> Vec<String> {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -246,6 +246,19 @@ where
         })
         .collect();
 
+    // Resolve importers in id order. Children-owner claims are ranked
+    // by importer position and the hoist rounds run sequentially in
+    // list order, so a stable order makes ownership, the first-walk
+    // missing scope, and every auto-install decision a function of the
+    // importer set rather than of the caller's listing order
+    // (pnpm/pnpm#13846).
+    let (importers, importer_opts): (Vec<&WorkspaceImporter<'a>>, Vec<ResolveImporterOptions>) = {
+        let mut paired: Vec<(&WorkspaceImporter<'a>, ResolveImporterOptions)> =
+            importers.iter().zip(importer_opts).collect();
+        paired.sort_by(|(left, _), (right, _)| left.id.cmp(&right.id));
+        paired.into_iter().unzip()
+    };
+
     // The `minimumReleaseAge` cutoff is set uniformly on every
     // importer's `base_opts.published_by` by the install layer; it is
     // the upper bound on the time-based cutoff.
@@ -253,7 +266,7 @@ where
     let TimeBasedCutoff { published_by: subdep_published_by, time } = if time_based {
         compute_time_based_cutoff(
             resolver,
-            importers,
+            &importers,
             &importer_opts,
             dependency_groups,
             pick_lowest_direct,
@@ -435,7 +448,7 @@ struct TimeBasedCutoff {
 /// them.
 async fn compute_time_based_cutoff<Chain>(
     resolver: &Chain,
-    importers: &[WorkspaceImporter<'_>],
+    importers: &[&WorkspaceImporter<'_>],
     importer_opts: &[ResolveImporterOptions],
     dependency_groups: &[DependencyGroup],
     pick_lowest_direct: bool,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -1886,9 +1886,11 @@ async fn deprecated_package_is_reported_only_on_its_first_occurrence() {
     let (_transitive_tmp, transitive_manifest) =
         fake_manifest(serde_json::json!({ "wrapper": "1.0.0" }));
     let (_direct_tmp, direct_manifest) = fake_manifest(serde_json::json!({ "old": "1.0.0" }));
+    // Ids chosen so the transitive importer is walked first under the
+    // resolver's id-ordered importer processing.
     let importers = [
-        WorkspaceImporter { id: "transitive".to_string(), manifest: &transitive_manifest },
-        WorkspaceImporter { id: "direct".to_string(), manifest: &direct_manifest },
+        WorkspaceImporter { id: "a-transitive".to_string(), manifest: &transitive_manifest },
+        WorkspaceImporter { id: "b-direct".to_string(), manifest: &direct_manifest },
     ];
     let resolver = RecordingResolver {
         table: HashMap::from_iter([
@@ -1941,8 +1943,78 @@ async fn deprecated_package_is_reported_only_on_its_first_occurrence() {
     assert_eq!(deprecation.depth, 1);
     assert_eq!(
         deprecation.prefix,
-        std::path::PathBuf::from("/repo").join("transitive").display().to_string(),
+        std::path::PathBuf::from("/repo").join("a-transitive").display().to_string(),
     );
+}
+
+/// The listing order of importers is not part of the input: processing
+/// is id-ordered, so a reversed listing attributes the deprecation to
+/// the same first occurrence (pnpm/pnpm#13846).
+#[tokio::test]
+async fn deprecation_attribution_does_not_depend_on_importer_listing_order() {
+    let deprecation_prefix_for = |reversed: bool| async move {
+        let (_transitive_tmp, transitive_manifest) =
+            fake_manifest(serde_json::json!({ "wrapper": "1.0.0" }));
+        let (_direct_tmp, direct_manifest) = fake_manifest(serde_json::json!({ "old": "1.0.0" }));
+        let mut importers = vec![
+            WorkspaceImporter { id: "a-transitive".to_string(), manifest: &transitive_manifest },
+            WorkspaceImporter { id: "b-direct".to_string(), manifest: &direct_manifest },
+        ];
+        if reversed {
+            importers.reverse();
+        }
+        let resolver = RecordingResolver {
+            table: HashMap::from_iter([
+                (
+                    ("wrapper".to_string(), "1.0.0".to_string()),
+                    fake_result(
+                        "wrapper",
+                        "1.0.0",
+                        None,
+                        serde_json::json!({
+                            "name": "wrapper",
+                            "version": "1.0.0",
+                            "dependencies": { "old": "1.0.0" },
+                        }),
+                    ),
+                ),
+                (
+                    ("old".to_string(), "1.0.0".to_string()),
+                    fake_result(
+                        "old",
+                        "1.0.0",
+                        None,
+                        serde_json::json!({
+                            "name": "old",
+                            "version": "1.0.0",
+                            "deprecated": "use new instead",
+                        }),
+                    ),
+                ),
+            ]),
+            seen: Mutex::new(HashMap::default()),
+        };
+        let notifications = std::sync::Arc::new(Mutex::new(Vec::new()));
+        let sink = std::sync::Arc::clone(&notifications);
+        let mut opts = workspace_opts(false, false);
+        opts.deprecation_log = Some(std::sync::Arc::new(move |deprecation: crate::Deprecation| {
+            sink.lock().unwrap().push(deprecation);
+        }));
+        resolve_workspace(&resolver, &importers, &[DependencyGroup::Prod], opts, |importer| {
+            importer_opts(std::path::PathBuf::from("/repo").join(&importer.id), None)
+        })
+        .await
+        .expect("resolve the workspace");
+        let notifications = notifications.lock().unwrap();
+        let [deprecation] = notifications.as_slice() else {
+            panic!("expected one deprecation: {notifications:?}");
+        };
+        deprecation.prefix.clone()
+    };
+
+    let listed = deprecation_prefix_for(false).await;
+    let reversed = deprecation_prefix_for(true).await;
+    assert_eq!(listed, reversed, "attribution must not depend on the listing order");
 }
 
 /// A dependency reused from the wanted lockfile still notifies the
@@ -3044,8 +3116,11 @@ async fn unchanged_shadow_ownership_handover_keeps_reused_subtree() {
     );
     let resolver = RecordingResolver { table, seen: Mutex::new(HashMap::default()) };
     let (tmp_b, b_manifest) = fake_manifest(serde_json::json!({ "wrapperB": "1.0.0" }));
-    let (tmp_root, root_manifest) =
-        fake_manifest(serde_json::json!({ "shared2": "1.0.0", "needyC": "1.0.0" }));
+    // The root carries only the peer consumer: with importers walked in
+    // id order the root's wave runs first, so the shared subtree must
+    // be claimed by pkg-b's wave and reach the root only through the
+    // later peer-hoist round for a handover to occur at all.
+    let (tmp_root, root_manifest) = fake_manifest(serde_json::json!({ "needyC": "1.0.0" }));
     let importers = [
         WorkspaceImporter { id: "pkg-b".to_string(), manifest: &b_manifest },
         WorkspaceImporter { id: ".".to_string(), manifest: &root_manifest },


### PR DESCRIPTION
## Summary

Closes the two follow-ups recorded on https://github.com/pnpm/pnpm/pull/13866: the resolved graph and lockfile are now a function of the **workspace's project set**, independent of the order projects are listed or discovered.

Both `resolve_workspace` and `resolve_peers_workspace` sort importers by project id up front. That one ordering decision canonicalizes everything downstream that was first-writer-wins: children-owner claims (ranked by importer position), the auto-install hoist loop's first-walk missing scope, deprecation-warning attribution, and which context first realizes a shared cycle back-edge occurrence. Per-importer options are still built in the caller's listing order before the sort, so positional options callbacks keep lining up.

Validation:
- An explicit **reversed `packages` listing** of the 5-importer bit fixture produces a **byte-identical lockfile** — the residual importer-order axis of pnpm/pnpm#13846.
- Both bit fixtures are **byte-identical to current main's output** (single-importer `0d5c2ec7c0`, 5-importer `6565464007`), at unchanged speed and memory (ws resolve 0.73 s / 0.60 GB) — production callers already supply id-sorted importers, so the sort only pins what discovery order made incidental.
- Two new regression tests fail without the sort and pass with it: `backedge_bindings_do_not_depend_on_importer_order` (peers level) and `deprecation_attribution_does_not_depend_on_importer_listing_order` (workspace level).
- Two tests that pinned a non-production importer order (a non-root importer walking before the root) are re-pinned with their intent preserved: the ownership-handover fixture now routes the shared subtree through the peer-hoist round — the only way a handover can occur under root-first order — and still asserts the wanted-lockfile subtree survives it.
- Suites: resolver 334/334, package-manager + CLI 3,202/3,202; fmt/clippy clean.

An earlier design (binding back-edge occurrences at bare workspace-root context) was measured and rejected: +18.6% lockfile on the 5-importer fixture. The id-sort achieves the same invariance at zero output change.

Not mirrored in the TypeScript CLI: this hardens v12's canonical-resolution guarantee (pnpm/pnpm#13866); the v11 TypeScript CLI keeps v11 semantics.

## Squash Commit Body

```text
Process workspace importers in project-id order in resolve_workspace
and resolve_peers_workspace. Children-owner claims rank by importer
position, hoist rounds run sequentially in list order, and shared
canonical back-edge occurrences bind whichever importer's walk
realizes them first — so the caller's listing order leaked into
ownership, the first-walk missing scope, auto-install decisions,
deprecation attribution, and cycle back-edge bindings (Closes
pnpm/pnpm#13846). Per-importer options are still built in the
caller's order first, so positional options callbacks line up.

A reversed packages listing of the 5-importer bit fixture now
produces a byte-identical lockfile, and both bit fixtures are
byte-identical to the unsorted resolver's output at unchanged
speed and memory. Regression tests pin both levels; two tests that
pinned a non-root importer walking before the root are re-pinned
with their scenarios preserved.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting. *(v12-only: hardens the canonical-resolution guarantee introduced in pnpm/pnpm#13866.)*

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789226129&installation_model_id=426870&pr_number=13895&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13895&signature=c82e15100b49f2d29374bddb4370038dd2dfab785bf64c8d4b27044adfac940a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dependency resolution now produces consistent results regardless of workspace project ordering.
  * Lockfiles and dependency graphs use deterministic peer dependency placement, including cyclic dependencies.
  * Deprecation notices are attributed consistently across different importer orders.

* **Tests**
  * Added coverage to verify identical dependency outcomes when workspace projects are listed in different orders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->