### PR TITLE
fix: record the lockfile verification after the build phase

### DIFF
--- a/.changeset/record-verification-after-build-scripts.md
+++ b/.changeset/record-verification-after-build-scripts.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.deps-installer": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+The lockfile verification result is now recorded once the install's build phase is over, rather than as soon as the lockfile passes. A dependency's lifecycle script runs inside the install and can write to the same log, so recording last keeps pnpm's own verdict distinguishable from anything a script wrote — which matters for CI setups that cache the log between jobs. An install that fails after verification no longer leaves a verdict behind either.

--- a/.changeset/record-verification-after-build-scripts.md
+++ b/.changeset/record-verification-after-build-scripts.md
@@ -4,4 +4,4 @@
 "pnpm": patch
 ---
 
-The lockfile verification result is now recorded once the install's build phase is over, rather than as soon as the lockfile passes. A dependency's lifecycle script runs inside the install and can write to the same log, so recording last keeps pnpm's own verdict distinguishable from anything a script wrote — which matters for CI setups that cache the log between jobs. An install that fails after verification no longer leaves a verdict behind either.
+The lockfile verification result is now recorded once the install has finished, rather than as soon as the lockfile passes. The log is read by the next install and the newest record for a lockfile wins, so an install should have the last word on the lockfile it verified: recording before the build phase let a dependency's lifecycle script append over pnpm's verdict, and left a "verified" record behind for an install that went on to fail.

--- a/pnpm/crates/cli/tests/suite/lockfile_verification.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_verification.rs
@@ -334,9 +334,8 @@ fn trust_lockfile_still_rejects_traversal_dependency_name() {
 
 /// The verdict is written only once the install's build phase is over.
 /// A dependency's lifecycle script runs inside the install and can append
-/// to the same log, so a verdict recorded ahead of it would be
-/// indistinguishable from whatever that script wrote; recording last makes
-/// any script-written record an extra one.
+/// to the same log, where the newest record for a lockfile wins — so a
+/// verdict recorded ahead of the scripts is one they can supersede.
 #[test]
 fn verification_is_recorded_after_dependency_build_scripts_run() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =

--- a/pnpm/crates/cli/tests/suite/lockfile_verification.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_verification.rs
@@ -14,8 +14,7 @@
 use crate::_utils;
 pub use _utils::*;
 
-use assert_cmd::assert::OutputAssertExt;
-use assert_cmd::cargo::CommandCargoExt;
+use assert_cmd::{assert::OutputAssertExt, cargo::CommandCargoExt};
 use command_extra::CommandExtra;
 use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
 use std::{fs, process::Command};

--- a/pnpm/crates/cli/tests/suite/lockfile_verification.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_verification.rs
@@ -14,9 +14,11 @@
 use crate::_utils;
 pub use _utils::*;
 
+use assert_cmd::assert::OutputAssertExt;
+use assert_cmd::cargo::CommandCargoExt;
 use command_extra::CommandExtra;
 use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
-use std::fs;
+use std::{fs, process::Command};
 
 /// `minimumReleaseAge` set to 100 years rejects every version the
 /// mocked registry has ever served. The install fails before any
@@ -327,6 +329,69 @@ fn trust_lockfile_still_rejects_traversal_dependency_name() {
             "no link may be created outside the project",
         );
     }
+
+    drop((root, mock_instance));
+}
+
+/// The verdict is written only once the install's build phase is over.
+/// A dependency's lifecycle script runs inside the install and can append
+/// to the same log, so a verdict recorded ahead of it would be
+/// indistinguishable from whatever that script wrote; recording last makes
+/// any script-written record an extra one.
+#[test]
+fn verification_is_recorded_after_dependency_build_scripts_run() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, cache_dir, .. } = npmrc_info;
+
+    let package_json = serde_json::json!({
+        "dependencies": { "@pnpm.e2e/install-script-example": "1.0.0" },
+    });
+    fs::write(workspace.join("package.json"), package_json.to_string())
+        .expect("write package.json");
+    // A policy has to be active for the gate to run a fan-out worth
+    // recording; one minute holds nothing back.
+    set_minimum_release_age(&workspace, 1);
+    append_workspace_yaml_key(&workspace, "dangerouslyAllowAllBuilds", true);
+
+    // The package's `install` script writes this file, so its presence
+    // marks the point in the install where lifecycle scripts have run.
+    let build_marker = workspace.join(
+        "node_modules/.pnpm/@pnpm.e2e+install-script-example@1.0.0\
+         /node_modules/@pnpm.e2e/install-script-example/generated-by-install.js",
+    );
+    let verification_log = cache_dir.join("lockfile-verified.jsonl");
+
+    // The first install resolves; the ordering under test is the frozen
+    // path's, which is what CI runs and what verifies concurrently with
+    // the fetch. Clear the log and the modules dir so the second install
+    // re-verifies and rebuilds.
+    pacquet.with_arg("install").assert().success();
+    fs::remove_file(&verification_log).expect("clear the verification log");
+    fs::remove_dir_all(workspace.join("node_modules")).expect("clear node_modules");
+
+    Command::cargo_bin("pnpm")
+        .expect("find the pnpm binary")
+        .with_current_dir(&workspace)
+        .with_args(["install", "--frozen-lockfile"])
+        .assert()
+        .success();
+
+    assert!(build_marker.exists(), "the dependency's build script must have run");
+    let log = fs::read_to_string(&verification_log).expect("read the verification log");
+    let records = log.lines().filter(|line| !line.trim().is_empty()).count();
+    assert_eq!(records, 1, "the install must append exactly one record; got:\n{log}");
+
+    let build_marker_written_at = fs::metadata(&build_marker)
+        .and_then(|metadata| metadata.modified())
+        .expect("build marker mtime");
+    let log_written_at = fs::metadata(&verification_log)
+        .and_then(|metadata| metadata.modified())
+        .expect("verification log mtime");
+    assert!(
+        log_written_at >= build_marker_written_at,
+        "the verdict must be recorded after the build script ran",
+    );
 
     drop((root, mock_instance));
 }

--- a/pnpm/crates/deps-restorer/src/install_frozen_lockfile.rs
+++ b/pnpm/crates/deps-restorer/src/install_frozen_lockfile.rs
@@ -577,10 +577,10 @@ where
         // `resolution_verifiers` is empty (`trustLockfile`).
         let verify_fut = async {
             if let Some(lockfile_verification_override) = lockfile_verification_override {
-                return lockfile_verification_override.await;
+                return lockfile_verification_override.await.map(|()| None);
             }
             if resolution_verifiers.is_empty() {
-                return Ok(());
+                return Ok(None);
             }
             verify_lockfile_resolutions::<Reporter>(
                 lockfile,
@@ -635,6 +635,7 @@ where
         // flight (the select drops `create_virtual_store_fut`); a fetch
         // failure waits for the verdict and only surfaces once the
         // lockfile is known trusted.
+        let pending_verification_record;
         let CreateVirtualStoreOutput {
             package_manifests,
             side_effects_maps_by_snapshot,
@@ -646,11 +647,11 @@ where
             let mut create_virtual_store_fut = std::pin::pin!(create_virtual_store_fut);
             tokio::select! {
                 verify = &mut verify_fut => {
-                    verify?;
+                    pending_verification_record = verify?;
                     create_virtual_store_fut.await?
                 }
                 output = &mut create_virtual_store_fut => {
-                    verify_fut.await?;
+                    pending_verification_record = verify_fut.await?;
                     output?
                 }
             }
@@ -808,6 +809,14 @@ where
                 extra_node_paths: &extra_node_paths,
             })
             .map_err(InstallFrozenLockfileError::BuildPhase)?;
+
+        // Only now that the build phase is over: a dependency's lifecycle
+        // script can append to the verification log, and recording ahead of
+        // them would leave pnpm's own verdict indistinguishable from
+        // whatever they wrote.
+        if let Some(pending_verification_record) = pending_verification_record {
+            pending_verification_record.record();
+        }
 
         // Drop the orchestrator's clone of the writer so the channel
         // closes once every per-snapshot clone has also been dropped;

--- a/pnpm/crates/deps-restorer/src/install_frozen_lockfile.rs
+++ b/pnpm/crates/deps-restorer/src/install_frozen_lockfile.rs
@@ -811,9 +811,8 @@ where
             .map_err(InstallFrozenLockfileError::BuildPhase)?;
 
         // Only now that the build phase is over: a dependency's lifecycle
-        // script can append to the verification log, and recording ahead of
-        // them would leave pnpm's own verdict indistinguishable from
-        // whatever they wrote.
+        // script can append to the verification log, and the newest record
+        // for a lockfile is the one the next install reads.
         if let Some(pending_verification_record) = pending_verification_record {
             pending_verification_record.record();
         }

--- a/pnpm/crates/lockfile-verification/src/lib.rs
+++ b/pnpm/crates/lockfile-verification/src/lib.rs
@@ -35,7 +35,7 @@ pub use errors::{RenderedViolation, VerifyError};
 pub use hash_lockfile::hash_lockfile;
 pub use record_lockfile_verified::record_lockfile_verified;
 pub use verify_lockfile_resolutions::{
-    RESOLUTION_SHAPE_MISMATCH_VIOLATION_CODE, VerifyLockfileResolutionsOptions,
-    collect_resolution_policy_violations, verify_lockfile_dependency_names,
-    verify_lockfile_resolutions,
+    PendingVerificationRecord, RESOLUTION_SHAPE_MISMATCH_VIOLATION_CODE,
+    VerifyLockfileResolutionsOptions, collect_resolution_policy_violations,
+    verify_lockfile_dependency_names, verify_lockfile_resolutions,
 };

--- a/pnpm/crates/lockfile-verification/src/verify_lockfile_resolutions.rs
+++ b/pnpm/crates/lockfile-verification/src/verify_lockfile_resolutions.rs
@@ -13,7 +13,13 @@
 //! emit boundaries — is in place so the cache slice only needs to
 //! plug into the existing call sites.
 
-use std::{collections::BTreeMap, path::Path, sync::Arc, time::Instant};
+use std::{
+    collections::BTreeMap,
+    fmt,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Instant,
+};
 
 use futures_util::{StreamExt, stream::FuturesUnordered};
 use pacquet_lockfile::{Lockfile, LockfileResolution, PkgName, is_git_hosted_tarball_url};
@@ -66,7 +72,7 @@ pub async fn verify_lockfile_resolutions<Reporter: self::Reporter>(
     lockfile: &Lockfile,
     verifiers: &[Arc<dyn ResolutionVerifier>],
     opts: &VerifyLockfileResolutionsOptions<'_>,
-) -> Result<(), VerifyError> {
+) -> Result<Option<PendingVerificationRecord>, VerifyError> {
     // Offline structural gate first: reject invalid dependency names
     // before the `packages`-absent short-circuit and the cache lookup,
     // so a lockfile that carries a path-traversal alias but no
@@ -74,7 +80,7 @@ pub async fn verify_lockfile_resolutions<Reporter: self::Reporter>(
     verify_lockfile_dependency_names(lockfile)?;
 
     if lockfile.packages.is_none() {
-        return Ok(());
+        return Ok(None);
     }
 
     // Caching activates only when both `cache_dir` and
@@ -124,7 +130,7 @@ pub async fn verify_lockfile_resolutions<Reporter: self::Reporter>(
                     },
                 );
             }
-            return Ok(());
+            return Ok(None);
         }
         cache_precomputed = result.precomputed;
     }
@@ -134,21 +140,17 @@ pub async fn verify_lockfile_resolutions<Reporter: self::Reporter>(
         return Err(build_verification_error(shape_violations));
     }
     if verifiers.is_empty() {
-        return Ok(());
+        return Ok(None);
     }
     if candidates.is_empty() {
-        // Persist the success so the next install can stat-only the
-        // lockfile. An empty fan-out is still a successful run.
-        if let Some((cache_dir, lockfile_path)) = cache_inputs {
-            record_verification(
-                cache_dir,
-                lockfile_path,
-                &cache_verifiers,
-                &mut hash_once,
-                cache_precomputed,
-            );
-        }
-        return Ok(());
+        // An empty fan-out is still a successful run, so it is worth
+        // persisting for the next install's stat-only path.
+        return Ok(pending_record(
+            cache_inputs,
+            &cache_verifiers,
+            &mut hash_once,
+            cache_precomputed,
+        ));
     }
 
     let entries = candidates.len() as u64;
@@ -178,18 +180,82 @@ pub async fn verify_lockfile_resolutions<Reporter: self::Reporter>(
             elapsed_ms: started_at.elapsed().as_millis() as u64,
             lockfile_path: lockfile_path_str,
         });
-        if let Some((cache_dir, lockfile_path)) = cache_inputs {
-            record_verification(
-                cache_dir,
-                lockfile_path,
-                &cache_verifiers,
-                &mut hash_once,
-                cache_precomputed,
-            );
-        }
-        return Ok(());
+        return Ok(pending_record(
+            cache_inputs,
+            &cache_verifiers,
+            &mut hash_once,
+            cache_precomputed,
+        ));
     }
     Err(build_verification_error(violations))
+}
+
+/// A verification that passed but has not been written to the log yet.
+///
+/// The log is read by the *next* install, so when it is written matters:
+/// an install's own dependency lifecycle scripts run before it finishes,
+/// and they can append to the same file. Recording only once the install
+/// is otherwise done means any record a script wrote is an extra one
+/// rather than a substitute for pnpm's, which is what makes tampering
+/// detectable by whoever caches the log.
+///
+/// Dropping the value without calling [`record`](Self::record) persists
+/// nothing — an install that fails after verification leaves no verdict
+/// behind.
+#[must_use = "the verification is only persisted by calling record()"]
+pub struct PendingVerificationRecord {
+    cache_dir: PathBuf,
+    lockfile_path: PathBuf,
+    verifiers: Vec<Arc<dyn ResolutionVerifier>>,
+    hash: String,
+    precomputed: CachePrecomputed,
+}
+
+/// Hand-written because the verifiers are trait objects; the fields that
+/// identify *which* verification this is are the interesting ones anyway.
+impl fmt::Debug for PendingVerificationRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PendingVerificationRecord")
+            .field("cache_dir", &self.cache_dir)
+            .field("lockfile_path", &self.lockfile_path)
+            .field("hash", &self.hash)
+            .field("verifiers", &self.verifiers.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl PendingVerificationRecord {
+    /// Append the verdict to the log. Call once the install has run
+    /// everything that could write to the log itself — its build phase
+    /// above all.
+    pub fn record(self) {
+        record_verification(
+            &self.cache_dir,
+            &self.lockfile_path,
+            &self.verifiers,
+            || self.hash.clone(),
+            self.precomputed,
+        );
+    }
+}
+
+/// Capture what [`PendingVerificationRecord::record`] needs, or `None`
+/// when the caller runs without a cache (tests, and callers that pass
+/// no `cache_dir`/`lockfile_path`).
+fn pending_record(
+    cache_inputs: Option<(&Path, &Path)>,
+    verifiers: &[Arc<dyn ResolutionVerifier>],
+    hash_once: &mut impl FnMut() -> String,
+    precomputed: CachePrecomputed,
+) -> Option<PendingVerificationRecord> {
+    let (cache_dir, lockfile_path) = cache_inputs?;
+    Some(PendingVerificationRecord {
+        cache_dir: cache_dir.to_path_buf(),
+        lockfile_path: lockfile_path.to_path_buf(),
+        verifiers: verifiers.to_vec(),
+        hash: hash_once(),
+        precomputed,
+    })
 }
 
 /// Collect-mode sibling of [`verify_lockfile_resolutions`] that

--- a/pnpm/crates/lockfile-verification/src/verify_lockfile_resolutions.rs
+++ b/pnpm/crates/lockfile-verification/src/verify_lockfile_resolutions.rs
@@ -192,12 +192,18 @@ pub async fn verify_lockfile_resolutions<Reporter: self::Reporter>(
 
 /// A verification that passed but has not been written to the log yet.
 ///
-/// The log is read by the *next* install, so when it is written matters:
-/// an install's own dependency lifecycle scripts run before it finishes,
-/// and they can append to the same file. Recording only once the install
-/// is otherwise done means any record a script wrote is an extra one
-/// rather than a substitute for pnpm's, which is what makes tampering
-/// detectable by whoever caches the log.
+/// The log is read by the *next* install, and the log is last-writer-wins
+/// per lockfile. An install's own dependency lifecycle scripts run before
+/// it finishes and can append to the same file, so a verdict written ahead
+/// of them is a verdict they can supersede. Holding the record back until
+/// everything else is done keeps the install's verdict its last word on
+/// the lockfile it verified.
+///
+/// This is ordering, not integrity: a lifecycle script runs with the same
+/// privileges as pnpm and can rewrite the log — or the lockfile, or
+/// `node_modules` — however it likes, and nothing marks a line in the log
+/// as pnpm's. Whether such a script runs at all is what `allowBuilds`
+/// governs.
 ///
 /// Dropping the value without calling [`record`](Self::record) persists
 /// nothing — an install that fails after verification leaves no verdict
@@ -225,9 +231,8 @@ impl fmt::Debug for PendingVerificationRecord {
 }
 
 impl PendingVerificationRecord {
-    /// Append the verdict to the log. Call once the install has run
-    /// everything that could write to the log itself — its build phase
-    /// above all.
+    /// Append the verdict to the log. Call once the install has finished
+    /// every dependency lifecycle script it runs.
     pub fn record(self) {
         record_verification(
             &self.cache_dir,

--- a/pnpm/crates/lockfile-verification/src/verify_lockfile_resolutions/tests.rs
+++ b/pnpm/crates/lockfile-verification/src/verify_lockfile_resolutions/tests.rs
@@ -601,13 +601,17 @@ async fn second_run_with_cache_skips_fan_out() {
         ..Default::default()
     };
 
+    // An install records once its build phase is over; here that is this
+    // `record()` call, without which the second run has nothing to reuse.
     verify_lockfile_resolutions::<SilentReporter>(
         &lockfile,
         std::slice::from_ref(&verifier),
         &opts,
     )
     .await
-    .expect("first run");
+    .expect("first run")
+    .expect("a passing run yields a record")
+    .record();
     assert_eq!(CALLS.load(Ordering::SeqCst), 1, "first run ran the verifier");
 
     verify_lockfile_resolutions::<SilentReporter>(
@@ -649,7 +653,9 @@ async fn cache_hit_emits_cached_event() {
         &opts,
     )
     .await
-    .expect("first run");
+    .expect("first run")
+    .expect("a passing run yields a record")
+    .record();
     verify_lockfile_resolutions::<RecordingReporter>(
         &lockfile,
         std::slice::from_ref(&verifier),
@@ -706,7 +712,9 @@ async fn cache_hit_with_no_policy_verifiers_stays_silent() {
         &opts,
     )
     .await
-    .expect("first run");
+    .expect("first run")
+    .expect("a passing run yields a record")
+    .record();
     verify_lockfile_resolutions::<RecordingReporter>(&lockfile, &[], &opts)
         .await
         .expect("second run");

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -23,8 +23,8 @@ use pacquet_lockfile::{
     SaveLockfileError, StalenessReason, VersionPart, satisfies_package_manifest,
 };
 use pacquet_lockfile_verification::{
-    VerifyError, VerifyLockfileResolutionsOptions, record_lockfile_verified,
-    verify_lockfile_resolutions,
+    PendingVerificationRecord, VerifyError, VerifyLockfileResolutionsOptions,
+    record_lockfile_verified, verify_lockfile_resolutions,
 };
 use pacquet_modules_yaml::{
     Host, IncludedDependencies, LayoutVersion, Modules, NodeLinker as ModulesNodeLinker,
@@ -104,14 +104,18 @@ mod tests;
 /// up-to-date short-circuits); the frozen materialization path instead
 /// runs verification concurrently with the fetch inside
 /// [`InstallFrozenLockfile`]. A no-op when `verifiers` is empty.
+///
+/// The verdict is returned unrecorded: see [`PendingVerificationRecord`]
+/// for why a caller that goes on to run lifecycle scripts must persist it
+/// after them.
 async fn verify_lockfile_eagerly<Reporter: pacquet_reporter::Reporter>(
     lockfile: &Lockfile,
     verifiers: &[Arc<dyn ResolutionVerifier>],
     lockfile_path: Option<&Path>,
     cache_dir: &Path,
-) -> Result<(), InstallError> {
+) -> Result<Option<PendingVerificationRecord>, InstallError> {
     if verifiers.is_empty() {
-        return Ok(());
+        return Ok(None);
     }
     verify_lockfile_resolutions::<Reporter>(
         lockfile,

--- a/pnpm/crates/package-manager/src/install/materialize.rs
+++ b/pnpm/crates/package-manager/src/install/materialize.rs
@@ -201,11 +201,12 @@ pub(super) async fn materialize<Reporter: self::Reporter + 'static>(
         debug_assert!(supported_lockfile_major);
 
         let mut frozen_verification_override = lockfile_verification_override;
+        let mut pending_verification_record = None;
         if requested_importer_ids.is_some() {
             if let Some(verification_override) = frozen_verification_override.take() {
                 verification_override.await.map_err(map_frozen_lockfile_error)?;
             } else {
-                verify_lockfile_eagerly::<Reporter>(
+                pending_verification_record = verify_lockfile_eagerly::<Reporter>(
                     lockfile,
                     &resolution_verifiers,
                     derived_lockfile_path.as_deref(),
@@ -270,6 +271,13 @@ pub(super) async fn materialize<Reporter: self::Reporter + 'static>(
         // is the same gate, just run alongside the fetch.
         .map_err(map_frozen_lockfile_error)?;
 
+        // Held back until the frozen run's build phase is over, for the
+        // reason [`PendingVerificationRecord`] documents. The non-selective
+        // frozen path records inside that run, past its own build phase.
+        if let Some(pending_verification_record) = pending_verification_record {
+            pending_verification_record.record();
+        }
+
         ignored_builds = frozen_result.ignored_builds;
         deferred_builds = frozen_result.deferred_builds;
         injected_deps = frozen_result.injected_deps;
@@ -286,10 +294,11 @@ pub(super) async fn materialize<Reporter: self::Reporter + 'static>(
         // resolver re-resolves from it. No-op when there's no lockfile
         // (state 4) or verification is disabled. The fresh path's own
         // resolution is the slow part, so this stays a blocking gate.
+        let mut pending_verification_record = None;
         if let Some(lockfile_verification_override) = lockfile_verification_override {
             lockfile_verification_override.await.map_err(map_frozen_lockfile_error)?;
         } else if let Some(loaded_lockfile) = lockfile {
-            verify_lockfile_eagerly::<Reporter>(
+            pending_verification_record = verify_lockfile_eagerly::<Reporter>(
                 loaded_lockfile,
                 &resolution_verifiers,
                 derived_lockfile_path.as_deref(),
@@ -366,6 +375,13 @@ pub(super) async fn materialize<Reporter: self::Reporter + 'static>(
         .run::<Reporter>()
         .await
         .map_err(InstallError::WithFreshLockfile)?;
+
+        // Both records land past the fresh run's build phase: this one
+        // covers the lockfile as it was verified before the resolve, the
+        // one below the lockfile the resolve produced.
+        if let Some(pending_verification_record) = pending_verification_record {
+            pending_verification_record.record();
+        }
 
         if fresh_result.can_record_lockfile_verification
             && let Some(lockfile) = fresh_result.wanted_lockfile.as_ref()

--- a/pnpm/crates/package-manager/src/install/prepare_modules_state.rs
+++ b/pnpm/crates/package-manager/src/install/prepare_modules_state.rs
@@ -342,14 +342,17 @@ pub(super) async fn prepare_modules_state<'install, Reporter: self::Reporter + '
         // eagerly before the up-to-date early return.
         if let Some(lockfile_verification_override) = lockfile_verification_override {
             lockfile_verification_override.await.map_err(map_frozen_lockfile_error)?;
-        } else {
-            verify_lockfile_eagerly::<Reporter>(
-                wanted_lockfile,
-                resolution_verifiers,
-                derived_lockfile_path,
-                &config.cache_dir,
-            )
-            .await?;
+        } else if let Some(pending_verification_record) = verify_lockfile_eagerly::<Reporter>(
+            wanted_lockfile,
+            resolution_verifiers,
+            derived_lockfile_path,
+            &config.cache_dir,
+        )
+        .await?
+        {
+            // The up-to-date path materializes nothing, so no lifecycle
+            // script runs between the verdict and this record.
+            pending_verification_record.record();
         }
         // Keep `strictDepBuilds` enforced on the up-to-date path: a
         // rerun after an `ERR_PNPM_IGNORED_BUILDS` failure must not

--- a/pnpm/crates/package-manager/src/install/run.rs
+++ b/pnpm/crates/package-manager/src/install/run.rs
@@ -851,14 +851,17 @@ where
             // verify eagerly to keep the gate before the early return.
             if let Some(lockfile_verification_override) = lockfile_verification_override {
                 lockfile_verification_override.await.map_err(map_frozen_lockfile_error)?;
-            } else {
-                verify_lockfile_eagerly::<Reporter>(
-                    lockfile,
-                    &resolution_verifiers,
-                    derived_lockfile_path.as_deref(),
-                    &config.cache_dir,
-                )
-                .await?;
+            } else if let Some(pending_verification_record) = verify_lockfile_eagerly::<Reporter>(
+                lockfile,
+                &resolution_verifiers,
+                derived_lockfile_path.as_deref(),
+                &config.cache_dir,
+            )
+            .await?
+            {
+                // Nothing is materialized here, so no lifecycle script runs
+                // between the verdict and this record.
+                pending_verification_record.record();
             }
             if config.lockfile {
                 lockfile

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -542,13 +542,6 @@ export async function mutateModules (
 
   const result = await settleInstall(_install(), verifyLockfilePromise)
 
-  // Recorded only now: the install has run its build phase, and a
-  // dependency's lifecycle script can append to the same log. Recording
-  // ahead of them would leave pnpm's own verdict indistinguishable from
-  // whatever they wrote. An install that threw never reaches this line, so
-  // it leaves no verdict behind.
-  ;(await verifyLockfilePromise)?.record()
-
   // @ts-expect-error
   if (global['verifiedFileIntegrity'] > 1000) {
     // @ts-expect-error
@@ -611,6 +604,13 @@ export async function mutateModules (
   ignoredScriptsLogger.debug({
     packageNames: ignoredBuilds ? dedupePackageNamesFromIgnoredBuilds(ignoredBuilds) : [],
   })
+
+  // Recorded only now that every lifecycle script this install runs is
+  // done — `runUnignoredDependencyBuilds` above rebuilds the packages
+  // approved since the last install, well past the install proper. An
+  // install that threw never reaches this line, so it leaves no verdict
+  // behind either.
+  ;(await verifyLockfilePromise)?.record()
 
   detachReporter()
 

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -117,7 +117,7 @@ import { hasChangedProjectSpecifiers } from './tryFastUpdateImporters.js'
 import { tryFastUpdateLockfile } from './tryFastUpdateLockfile.js'
 import { warnUnusedPatches } from './tryFastUpdatePatchedDependencies.js'
 import { validateModules } from './validateModules.js'
-import { verifyLockfileResolutions } from './verifyLockfileResolutions.js'
+import { type PendingVerificationRecord, verifyLockfileResolutions } from './verifyLockfileResolutions.js'
 import { warnOnStaleConvergenceOverrides } from './warnOnStaleConvergenceOverrides.js'
 import { writeLockfilesAndRecordVerified } from './writeLockfilesAndRecordVerified.js'
 import { writeWantedLockfileAndRecordVerified } from './writeWantedLockfileAndRecordVerified.js'
@@ -466,7 +466,7 @@ export async function mutateModules (
       // so violations can be returned to the command layer.
       (opts.saveLockfile && opts.runPacquet.supportsResolution && opts.frozenLockfile !== true && opts.nodeLinker !== 'hoisted' && opts.handleResolutionPolicyViolations == null)
     )
-  let verifyLockfilePromise: Promise<void> | undefined
+  let verifyLockfilePromise: Promise<PendingVerificationRecord | undefined> | undefined
   if (!willDelegateToPacquet && !opts.trustLockfile) {
     const cacheActive = opts.cacheDir != null && opts.resolutionVerifiers.length > 0
     const wantedLockfilePath = cacheActive
@@ -489,8 +489,12 @@ export async function mutateModules (
   // verification, but no dependency lifecycle script may run until the verdict
   // is in. Awaiting the promise here throws if verification failed, aborting
   // before any script executes. `settleInstall` is the catch-all that still
-  // reconciles the verdict on paths that never reach the build phase.
-  const verifyLockfile = verifyLockfilePromise && (() => verifyLockfilePromise)
+  // reconciles the verdict on paths that never reach the build phase. The
+  // verdict is only awaited, never recorded here — that happens once the
+  // build phase this gates is over.
+  const verifyLockfile = verifyLockfilePromise && (async () => {
+    await verifyLockfilePromise
+  })
 
   if (opts.hooks.preResolution) {
     for (const preResolution of opts.hooks.preResolution) {
@@ -537,6 +541,13 @@ export async function mutateModules (
   }
 
   const result = await settleInstall(_install(), verifyLockfilePromise)
+
+  // Recorded only now: the install has run its build phase, and a
+  // dependency's lifecycle script can append to the same log. Recording
+  // ahead of them would leave pnpm's own verdict indistinguishable from
+  // whatever they wrote. An install that threw never reaches this line, so
+  // it leaves no verdict behind.
+  ;(await verifyLockfilePromise)?.record()
 
   // @ts-expect-error
   if (global['verifiedFileIntegrity'] > 1000) {
@@ -636,7 +647,7 @@ export async function mutateModules (
   // a rejected install.
   async function settleInstall (
     install: Promise<InnerInstallResult>,
-    verification: Promise<void> | undefined
+    verification: Promise<PendingVerificationRecord | undefined> | undefined
   ): Promise<InnerInstallResult> {
     if (verification == null) return install
     // Handle the install's eventual rejection up front so a fail-fast
@@ -913,7 +924,9 @@ export async function mutateModules (
             },
           }),
           isLockfileUpToDate,
-          verifyLockfile: (lockfile) => verifyLockfileResolutions(lockfile, []),
+          verifyLockfile: async (lockfile) => {
+            await verifyLockfileResolutions(lockfile, [])
+          },
         })
       ) {
         outdatedLockfileSettingName = null

--- a/pnpm11/installing/deps-installer/src/install/verifyLockfileResolutions.ts
+++ b/pnpm11/installing/deps-installer/src/install/verifyLockfileResolutions.ts
@@ -79,6 +79,29 @@ export interface VerifyLockfileResolutionsOptions {
 }
 
 /**
+ * A verification that passed but has not been written to the log yet.
+ *
+ * The log is read by the *next* install, so when it is written matters:
+ * an install's own dependency lifecycle scripts run before it finishes,
+ * and they can append to the same file. Recording only once the install
+ * is otherwise done means any record a script wrote is an extra one
+ * rather than a substitute for pnpm's, which is what makes tampering
+ * detectable by whoever caches the log.
+ *
+ * Discarding the value without calling {@link PendingVerificationRecord.record}
+ * persists nothing — an install that fails after verification leaves no
+ * verdict behind.
+ */
+export interface PendingVerificationRecord {
+  /**
+   * Append the verdict to the log. Call once the install has run
+   * everything that could write to the log itself — its build phase
+   * above all.
+   */
+  record: () => void
+}
+
+/**
  * Policy-neutral pass that asks every resolver-supplied
  * {@link ResolutionVerifier} to check every entry in a lockfile loaded
  * from disk. Iteration runs before resolution decisions are touched and
@@ -109,8 +132,8 @@ export async function verifyLockfileResolutions (
   lockfile: LockfileObject,
   verifiers: ResolutionVerifier[],
   options?: VerifyLockfileResolutionsOptions
-): Promise<void> {
-  if (!lockfile.packages) return
+): Promise<PendingVerificationRecord | undefined> {
+  if (!lockfile.packages) return undefined
 
   // Caching kicks in only when the caller surfaced both a writable
   // cache directory and the lockfile's absolute path — that's the
@@ -136,6 +159,19 @@ export async function verifyLockfileResolutions (
     if (cachedHash == null) cachedHash = hashObject(lockfile)
     return cachedHash
   }
+  const pendingRecord = (): PendingVerificationRecord | undefined => {
+    if (!cache) return undefined
+    return {
+      record: () => {
+        recordVerification(cache.cacheDir, {
+          lockfilePath: cache.lockfilePath,
+          verifiers: cacheVerifiers,
+          hashLockfile,
+        }, cachePrecomputed)
+      },
+    }
+  }
+
   if (cache) {
     const result = tryLockfileVerificationCache(cache.cacheDir, {
       lockfilePath: cache.lockfilePath,
@@ -154,7 +190,7 @@ export async function verifyLockfileResolutions (
           lockfilePath: options?.lockfilePath,
         })
       }
-      return
+      return undefined
     }
     cachePrecomputed = result.precomputed
   }
@@ -174,16 +210,11 @@ export async function verifyLockfileResolutions (
   if (shapeViolations.length > 0) {
     throw buildVerificationError(shapeViolations)
   }
-  if (verifiers.length === 0) return
+  if (verifiers.length === 0) return undefined
   if (candidates.size === 0) {
-    if (cache) {
-      recordVerification(cache.cacheDir, {
-        lockfilePath: cache.lockfilePath,
-        verifiers: cacheVerifiers,
-        hashLockfile,
-      }, cachePrecomputed)
-    }
-    return
+    // An empty fan-out is still a successful run, so it is worth
+    // persisting for the next install's stat-only path.
+    return pendingRecord()
   }
   const startedAt = Date.now()
   lockfileVerificationLogger.debug({
@@ -202,15 +233,7 @@ export async function verifyLockfileResolutions (
     const violations = await iterateLockfileViolations(candidates, verifiers, options?.concurrency)
     if (violations.length === 0) {
       terminalStatus = 'done'
-      // Persist the success so the next install can stat-only the lockfile.
-      if (cache) {
-        recordVerification(cache.cacheDir, {
-          lockfilePath: cache.lockfilePath,
-          verifiers: cacheVerifiers,
-          hashLockfile,
-        }, cachePrecomputed)
-      }
-      return
+      return pendingRecord()
     }
     throw buildVerificationError(violations)
   } finally {

--- a/pnpm11/installing/deps-installer/src/install/verifyLockfileResolutions.ts
+++ b/pnpm11/installing/deps-installer/src/install/verifyLockfileResolutions.ts
@@ -81,12 +81,18 @@ export interface VerifyLockfileResolutionsOptions {
 /**
  * A verification that passed but has not been written to the log yet.
  *
- * The log is read by the *next* install, so when it is written matters:
- * an install's own dependency lifecycle scripts run before it finishes,
- * and they can append to the same file. Recording only once the install
- * is otherwise done means any record a script wrote is an extra one
- * rather than a substitute for pnpm's, which is what makes tampering
- * detectable by whoever caches the log.
+ * The log is read by the *next* install, and the log is last-writer-wins
+ * per lockfile. An install's own dependency lifecycle scripts run before
+ * it finishes and can append to the same file, so a verdict written ahead
+ * of them is a verdict they can supersede. Holding the record back until
+ * everything else is done keeps the install's verdict its last word on
+ * the lockfile it verified.
+ *
+ * This is ordering, not integrity: a lifecycle script runs with the same
+ * privileges as pnpm and can rewrite the log — or the lockfile, or
+ * `node_modules` — however it likes, and nothing marks a line in the log
+ * as pnpm's. Whether such a script runs at all is what `allowBuilds`
+ * governs.
  *
  * Discarding the value without calling {@link PendingVerificationRecord.record}
  * persists nothing — an install that fails after verification leaves no
@@ -94,9 +100,8 @@ export interface VerifyLockfileResolutionsOptions {
  */
 export interface PendingVerificationRecord {
   /**
-   * Append the verdict to the log. Call once the install has run
-   * everything that could write to the log itself — its build phase
-   * above all.
+   * Append the verdict to the log. Call once the install has finished
+   * every dependency lifecycle script it runs.
    */
   record: () => void
 }

--- a/pnpm11/installing/deps-installer/test/install/verifyLockfileResolutions.ts
+++ b/pnpm11/installing/deps-installer/test/install/verifyLockfileResolutions.ts
@@ -274,10 +274,12 @@ test('skips the verifier when the cache holds an unchanged lockfile + matching p
       return { ok: true }
     }, exampleSlot(60))
 
-    // First call has no cache record yet — verifier runs.
-    await verifyLockfileResolutions(lockfile, [counting], {
+    // First call has no cache record yet — verifier runs. The install
+    // persists the verdict once its build phase is over; here that is the
+    // `record()` call.
+    ;(await verifyLockfileResolutions(lockfile, [counting], {
       cacheDir, lockfilePath,
-    })
+    }))?.record()
     expect(calls).toBe(1)
 
     // Second call against the same lockfile + policy — cache short-circuit.
@@ -301,7 +303,7 @@ test('emits a cached event when the cache short-circuits verification', async ()
     })
     const verifier = wrap(async () => ({ ok: true }), exampleSlot(60))
 
-    await verifyLockfileResolutions(lockfile, [verifier], { cacheDir, lockfilePath })
+    ;(await verifyLockfileResolutions(lockfile, [verifier], { cacheDir, lockfilePath }))?.record()
 
     const debugSpy = jest.spyOn(lockfileVerificationLogger, 'debug')
     try {
@@ -331,9 +333,9 @@ test('reuses the cached verdict silently when no policy verifiers are active', a
       'a@1.0.0': { resolution: tarballResolution('sha512-a') },
     })
 
-    await verifyLockfileResolutions(lockfile, [wrap(async () => ({ ok: true }), exampleSlot(60))], {
+    ;(await verifyLockfileResolutions(lockfile, [wrap(async () => ({ ok: true }), exampleSlot(60))], {
       cacheDir, lockfilePath,
-    })
+    }))?.record()
 
     const debugSpy = jest.spyOn(lockfileVerificationLogger, 'debug')
     try {
@@ -587,4 +589,31 @@ test('registry-qualified entries are verified separately, each with its own regi
   expect(seen.every((entry) => entry.name === 'foo' && entry.version === '1.0.0')).toBe(true)
   expect(new Set(seen.map((entry) => entry.registryName)))
     .toStrictEqual(new Set([undefined, 'work', 'gh']))
+})
+
+test('a passing verification writes nothing until the caller records it', async () => {
+  const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'pnpm-vlr-'))
+  try {
+    const cacheDir = path.join(tmpDir, 'cache')
+    const lockfilePath = path.join(tmpDir, 'pnpm-lock.yaml')
+    await fs.promises.writeFile(lockfilePath, 'lockfileVersion: \'9.0\'\n')
+    const lockfile = makeLockfile({
+      'a@1.0.0': { resolution: tarballResolution('sha512-a') },
+    })
+    const logPath = path.join(cacheDir, 'lockfile-verified.jsonl')
+
+    // An install records once its build phase is over, so that a lifecycle
+    // script writing to the same log cannot pass its record off as pnpm's.
+    // Until then the verdict is held, and an install that throws in between
+    // leaves nothing behind.
+    const pending = await verifyLockfileResolutions(lockfile, [wrap(async () => ({ ok: true }), exampleSlot(60))], {
+      cacheDir, lockfilePath,
+    })
+    expect(fs.existsSync(logPath)).toBe(false)
+
+    pending!.record()
+    expect(fs.existsSync(logPath)).toBe(true)
+  } finally {
+    await fs.promises.rm(tmpDir, { recursive: true, force: true })
+  }
 })

--- a/pnpm11/installing/deps-installer/test/install/verifyLockfileResolutions.ts
+++ b/pnpm11/installing/deps-installer/test/install/verifyLockfileResolutions.ts
@@ -602,9 +602,9 @@ test('a passing verification writes nothing until the caller records it', async 
     })
     const logPath = path.join(cacheDir, 'lockfile-verified.jsonl')
 
-    // An install records once its build phase is over, so that a lifecycle
-    // script writing to the same log cannot pass its record off as pnpm's.
-    // Until then the verdict is held, and an install that throws in between
+    // An install records once its lifecycle scripts are done, so that a
+    // script writing to the same log cannot supersede pnpm's record. Until
+    // then the verdict is held, and an install that throws in between
     // leaves nothing behind.
     const pending = await verifyLockfileResolutions(lockfile, [wrap(async () => ({ ok: true }), exampleSlot(60))], {
       cacheDir, lockfilePath,

--- a/pnpm11/pnpm/test/install/minimumReleaseAge.ts
+++ b/pnpm11/pnpm/test/install/minimumReleaseAge.ts
@@ -445,4 +445,55 @@ describe('lockfile minimumReleaseAge verification', () => {
       { ...omitMinReleaseAgeEnv, expectSuccess: true }
     )
   })
+
+  test('the verdict is recorded after the builds approved since the last install', () => {
+    // Approving a build the previous install ignored makes this install
+    // run that build after the install proper is over — the last point at
+    // which a dependency's script can append to the verification log, and
+    // therefore the point the verdict has to be recorded past.
+    prepare({
+      dependencies: {
+        'is-positive': '1.0.0',
+        'log-reading-dep': 'file:./log-reading-dep',
+      },
+    })
+    const cacheDir = path.resolve('pnpm-cache')
+    const cacheFile = path.join(cacheDir, 'lockfile-verified.jsonl')
+    // What the dependency's build script saw in the log, written by the
+    // script itself — the log as it stood mid-install, which no assertion
+    // made afterwards can reconstruct.
+    const logAsSeenByTheBuild = path.resolve('log-as-seen-by-the-build.txt')
+    fs.mkdirSync('log-reading-dep')
+    fs.writeFileSync('log-reading-dep/package.json', JSON.stringify({
+      name: 'log-reading-dep',
+      version: '1.0.0',
+      scripts: { postinstall: 'node snapshot-log.cjs' },
+    }))
+    fs.writeFileSync('log-reading-dep/snapshot-log.cjs', [
+      "const fs = require('fs')",
+      `const log = ${JSON.stringify(cacheFile)}`,
+      `fs.writeFileSync(${JSON.stringify(logAsSeenByTheBuild)}, fs.existsSync(log) ? fs.readFileSync(log, 'utf8') : '')`,
+    ].join('\n'))
+
+    const policy = { minimumReleaseAge: 1, minimumReleaseAgeStrict: true, cacheDir }
+    writeYamlFileSync('pnpm-workspace.yaml', policy)
+    // Ends in ERR_PNPM_IGNORED_BUILDS under the test env's strictDepBuilds,
+    // having installed everything and recorded the ignored build.
+    execPnpmSync([PUBLIC_REGISTRY, 'install'], omitMinReleaseAgeEnv)
+    expect(fs.existsSync(logAsSeenByTheBuild)).toBe(false)
+
+    // Clearing the log makes the record this install writes the only one.
+    fs.rmSync(cacheFile)
+    writeYamlFileSync('pnpm-workspace.yaml', {
+      ...policy,
+      // A name-keyed `allowBuilds` entry wouldn't approve a `file:`
+      // dependency: package-name approvals don't extend to artifacts whose
+      // identity the name can't vouch for.
+      dangerouslyAllowAllBuilds: true,
+    })
+    execPnpmSync([PUBLIC_REGISTRY, 'install'], { ...omitMinReleaseAgeEnv, expectSuccess: true })
+
+    expect(fs.readFileSync(logAsSeenByTheBuild, 'utf8')).toBe('')
+    expect(fs.readFileSync(cacheFile, 'utf8').split('\n').filter(Boolean)).toHaveLength(1)
+  })
 })


### PR DESCRIPTION
## Summary

The frozen install path recorded its verification verdict as soon as the gate passed — before materialization, and therefore before any dependency lifecycle script ran. Those scripts can append to the same log, and the log is last-writer-wins per lockfile, so a verdict written ahead of them is a verdict they can supersede.

Measured against 12.0.0-rc.4, with a dependency whose `postinstall` reports what it sees:

| install path | log at build-script time | |
| --- | --- | --- |
| fresh lockfile | `exists = false` | already recorded after builds |
| frozen lockfile (what CI runs) | `exists = true, records = 1` | recorded before builds |

So on the path CI actually takes, an allow-listed dependency's script ran with pnpm's verdict already on disk and the install's writing to the log finished — free to append a record for some *other* lockfile, or to rewrite the file so only its own record remains, and have that be what the next install reads. Recording last means pnpm's genuine record always lands after everything the install runs, so a script cannot substitute its own for it within the install; an extra record it appends is one the log's consumer sees as growth the install cannot account for.

To be clear about what this is and isn't: it is ordering, not integrity. Nothing in the log marks a line as pnpm's; a lifecycle script runs with pnpm's privileges and could rewrite the log — or the lockfile, or `node_modules` — however it likes, and could spawn a process that writes after the install exits. What `allowBuilds` gates is whether such a script runs at all. The property this PR buys is narrow and worth having: an install's verdict is its last word on the lockfile it verified.

This also settles the two paths on the same behaviour: an install that fails after verification now leaves no verdict behind on either, as the fresh path already did.

## Approach

`verify_lockfile_resolutions` / `verifyLockfileResolutions` return the passing verdict **unrecorded**, as a `PendingVerificationRecord`. The install persists it once every lifecycle script it runs is done. Dropping the value without recording persists nothing, so a failed install can't leave one behind — `#[must_use]` on the Rust side keeps that from happening by accident.

On the TypeScript side that point is the end of `mutateModules`, not the end of the install proper: `runUnignoredDependencyBuilds` rebuilds the packages approved since the last install *after* the install has settled, and it is the last thing that can run a dependency's script. pacquet has no equivalent post-build step, so its record sits at the end of its build phase.

The install paths that materialize nothing — `--lockfile-only` and the up-to-date short-circuit — record immediately, since no script can run between the verdict and the record.

Recording moved, not changed: an install still appends exactly one record, so nothing about the cache's hit rate or its `can_trust_past_check` comparison changes.

## Testing

- `verification_is_recorded_after_dependency_build_scripts_run` (Rust, CLI integration) installs a package with a real `install` script on the **frozen** path and asserts the log is written after the build marker. Confirmed it fails when the fix is reverted (`the verdict must be recorded after the build script ran`) — the first version of this test passed against the broken code because it exercised the fresh path, which was already correct.
- `the verdict is recorded after the builds approved since the last install` (TS e2e) covers the `runUnignoredDependencyBuilds` path: a dependency whose `postinstall` snapshots the log is left unapproved by one install and approved for the next, and the snapshot the rebuild takes must be empty. Confirmed it fails against the earlier record placement, with the snapshot holding pnpm's record.
- `a passing verification writes nothing until the caller records it` (TS unit) pins the deferred contract directly.
- Existing cache tests in both stacks that seed a record for a second run now call `record()` where the install would, which is the same wiring the production path uses.
- `cargo test -p pacquet-lockfile-verification -p pacquet-package-manager -p pacquet-deps-restorer`, the CLI `lockfile_verification` suite, the deps-installer verification suites, and `pnpm/test/install/minimumReleaseAge.ts` all pass; fmt / clippy / doc / dylint / typos / taplo clean.

## Squash Commit Body

```text
The frozen path recorded its verdict as soon as the gate passed, which is
before materialization and therefore before any dependency lifecycle script
runs. Those scripts can append to the same log, where the newest record for a
lockfile is the one the next install reads — so a verdict written ahead of them
is a verdict they can supersede: an allow-listed dependency could rewrite the
log to claim some other lockfile had passed verification, and have that be what
whatever caches the file between CI jobs picks up. Recording last means pnpm's
record always lands after everything the install runs, so an install's verdict
is its last word on the lockfile it verified.

The fresh path already recorded after its build phase, so this is also the two
paths agreeing. verify_lockfile_resolutions now returns the verdict unrecorded
and the install persists it once its lifecycle scripts are done — on the
TypeScript side that is past runUnignoredDependencyBuilds, which rebuilds the
packages approved since the last install after the install proper has settled.
The install paths that materialize nothing (lockfile-only, up-to-date) record
straight away, having no scripts to run. An install that fails in between drops
the pending record and leaves no verdict behind, which the fresh path already
did.

This is ordering, not integrity: nothing marks a line in the log as pnpm's, and
a lifecycle script runs with pnpm's privileges. allowBuilds is what governs
whether one runs at all.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port.
- [x] Added a changeset.
- [x] Added or updated tests.
- [x] Updated the documentation if needed. — no user-facing surface changes; the contract is documented on `PendingVerificationRecord` in both stacks.

## Related

Companion to the action-side change in pnpm/setup#30 and pnpm/action-setup#287, which cache this log between CI jobs and check that it only grew the way an install grows it. That check is where an extra record surfaces — it compares against a baseline the job's own scripts cannot reach. Ordering is what keeps pnpm's record from being the one that gets replaced.

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Lockfile verification results are now recorded only after dependency installation and lifecycle scripts complete successfully.
  - Failed installations and script errors no longer leave ambiguous verification records.
  - Verification errors continue to be reported normally.
  - Verification cache results remain accurate across repeated installations and supported installation modes.

- **Tests**
  - Added coverage for verification timing, cache persistence, successful installs, failed installations, and lifecycle-script interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->