### PR TITLE
fix(update): preserve prerelease range operators

### DIFF
--- a/.changeset/seven-pens-smile.md
+++ b/.changeset/seven-pens-smile.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/pkg-manifest.utils": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+`pnpm update` now preserves the existing range operator when updating a prerelease dependency. See pnpm/pnpm#7002.

--- a/pnpm/crates/cli/tests/suite/update.rs
+++ b/pnpm/crates/cli/tests/suite/update.rs
@@ -181,11 +181,22 @@ fn update_preserves_the_declared_range_operator() {
 fn update_preserves_an_existing_prerelease_range_operator() {
     let (root, workspace, anchor) = setup();
 
-    write_manifest(&workspace, &format!(r#"{{ "{HAS_PRERELEASE}": "^3.0.0-rc.0" }}"#));
+    write_manifest(&workspace, &format!(r#"{{ "{HAS_PRERELEASE}": "3.0.0-rc.0" }}"#));
     pacquet(&workspace, ["install"]).assert().success();
+    assert!(
+        virtual_store_has(&workspace, "@pnpm.e2e+has-prerelease@3.0.0-rc.0"),
+        "virtual store entries: {:?}",
+        list_virtual_store(&workspace),
+    );
 
+    write_manifest(&workspace, &format!(r#"{{ "{HAS_PRERELEASE}": "^3.0.0-rc.0" }}"#));
     pacquet(&workspace, ["update"]).assert().success();
 
+    assert!(
+        virtual_store_has(&workspace, "@pnpm.e2e+has-prerelease@3.0.0-rc.1"),
+        "virtual store entries: {:?}",
+        list_virtual_store(&workspace),
+    );
     assert_eq!(dep_spec(&workspace, HAS_PRERELEASE).as_deref(), Some("^3.0.0-rc.1"));
     pacquet(&workspace, ["install", "--frozen-lockfile"]).assert().success();
 

--- a/pnpm/crates/cli/tests/suite/update.rs
+++ b/pnpm/crates/cli/tests/suite/update.rs
@@ -14,6 +14,7 @@ use tempfile::TempDir;
 
 const DEP: &str = "@pnpm.e2e/dep-of-pkg-with-1-dep";
 const FOO: &str = "@pnpm.e2e/foo";
+const HAS_PRERELEASE: &str = "@pnpm.e2e/has-prerelease";
 /// Depends on `dep-of-pkg-with-1-dep@^100.0.0`, used to exercise
 /// indirect-dependency update behavior when the direct dep is ignored.
 const PARENT: &str = "@pnpm.e2e/pkg-with-1-dep";
@@ -172,6 +173,21 @@ fn update_preserves_the_declared_range_operator() {
     assert_eq!(dep_spec(&workspace, "@pnpm.e2e/bravo-dep").as_deref(), Some("~1.0.1"));
     assert_eq!(dep_spec(&workspace, FOO).as_deref(), Some("1.0.0"));
     assert_eq!(dep_spec(&workspace, PARENT).as_deref(), Some("^100.1.0"));
+
+    drop((root, anchor));
+}
+
+#[test]
+fn update_preserves_an_existing_prerelease_range_operator() {
+    let (root, workspace, anchor) = setup();
+
+    write_manifest(&workspace, &format!(r#"{{ "{HAS_PRERELEASE}": "^3.0.0-rc.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    pacquet(&workspace, ["update"]).assert().success();
+
+    assert_eq!(dep_spec(&workspace, HAS_PRERELEASE).as_deref(), Some("^3.0.0-rc.1"));
+    pacquet(&workspace, ["install", "--frozen-lockfile"]).assert().success();
 
     drop((root, anchor));
 }

--- a/pnpm/crates/package-manager/src/add.rs
+++ b/pnpm/crates/package-manager/src/add.rs
@@ -32,9 +32,9 @@ use pnpm_resolving_git_resolver::{
 };
 use pnpm_resolving_npm_resolver::{
     DeclaredSpecifiers, InMemoryPackageMetaCache, PackumentFetchLocker, PickPackageError,
-    PickPackageOptions, calc_specifier_for_workspace_dep, infer_range_spec_style,
-    parse_bare_specifier, pick_matching_local_version_or_null, pick_package,
-    pick_registry_for_package, shared_packument_fetch_locker,
+    PickPackageOptions, calc_specifier_for_workspace_dep, calc_version_range,
+    infer_range_spec_style, parse_bare_specifier, pick_matching_local_version_or_null,
+    pick_package, pick_registry_for_package, shared_packument_fetch_locker,
 };
 use pnpm_resolving_resolver_base::{GitResolveError, PreferredVersions, WorkspacePackages};
 use pnpm_tarball::MemCache;
@@ -928,7 +928,7 @@ async fn resolve_added_dependency<'a>(
                         name: package_name.to_string(),
                         error,
                     })?;
-                latest.serialize(range_spec_style)
+                calc_version_range(&latest.version, None, None, range_spec_style)
             }
         }
     };
@@ -1116,8 +1116,12 @@ async fn resolve_explicit_registry_spec(
     let prev_pin = prev_specifier
         .filter(|prev| is_registry_style_specifier(prev, package_name, &registry))
         .and_then(infer_range_spec_style);
-    let pin = prev_pin.or_else(|| infer_range_spec_style(spec)).unwrap_or(range_spec_style);
-    Ok(Some(picked.serialize(pin)))
+    Ok(Some(calc_version_range(
+        &picked.version,
+        prev_pin,
+        infer_range_spec_style(spec),
+        range_spec_style,
+    )))
 }
 
 /// Whether `specifier` is a plain registry range/tag/version for

--- a/pnpm/crates/package-manager/src/manifest_spec_bumps.rs
+++ b/pnpm/crates/package-manager/src/manifest_spec_bumps.rs
@@ -170,14 +170,8 @@ fn bumped_range(
         // A link or an injected directory has no version to pin.
         ImporterDepVersion::Link(_) | ImporterDepVersion::File(_) => return None,
     };
-    // No range operator expresses "this prerelease and later ones", so a
-    // prerelease pick is pinned exactly.
-    let range = if resolved.pre_release.is_empty() {
-        let style = infer_range_spec_style(declared_range).unwrap_or(default_style);
-        format!("{}{resolved}", style.range_prefix())
-    } else {
-        resolved.to_string()
-    };
+    let style = infer_range_spec_style(declared_range).unwrap_or(default_style);
+    let range = format!("{}{resolved}", style.range_prefix());
     let bumped = format!("{prefix}{range}");
     (bumped != declared).then_some(bumped)
 }

--- a/pnpm/crates/package-manager/src/manifest_spec_bumps.rs
+++ b/pnpm/crates/package-manager/src/manifest_spec_bumps.rs
@@ -9,7 +9,7 @@ use pnpm_lockfile::{
 use pnpm_lockfile_preferred_versions::get_version_selector_type;
 use pnpm_package_manifest::DependencyGroup;
 use pnpm_registry::RangeSpecStyle;
-use pnpm_resolving_npm_resolver::infer_range_spec_style;
+use pnpm_resolving_npm_resolver::{calc_version_range, infer_range_spec_style};
 use pnpm_resolving_resolver_base::VersionSelectorType;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
@@ -149,10 +149,8 @@ fn render_aliases<Bumped, Rendered>(
 /// The range that pins `version` for a dependency that currently declares
 /// `declared`, or `None` when the declaration is not a range this may move.
 ///
-/// The operator the declaration already pins wins over `default_style`, so
-/// an update never widens or narrows what the manifest asked for. Mirrors
-/// the npm resolver's `calc_specifier`, which decides the same text for a
-/// version it has just picked.
+/// The range text is [`calc_version_range`]'s decision — the same one the
+/// npm resolver's `calc_specifier` makes for a version it has just picked.
 fn bumped_range(
     declared: &str,
     version: &ImporterDepVersion,
@@ -170,13 +168,8 @@ fn bumped_range(
         // A link or an injected directory has no version to pin.
         ImporterDepVersion::Link(_) | ImporterDepVersion::File(_) => return None,
     };
-    let range = match infer_range_spec_style(declared_range) {
-        Some(style) => format!("{}{resolved}", style.range_prefix()),
-        // Match the TypeScript resolver's prerelease fallback: an unsupported
-        // comparator or compound range becomes an exact prerelease pick.
-        None if !resolved.pre_release.is_empty() => resolved.to_string(),
-        None => format!("{}{resolved}", default_style.range_prefix()),
-    };
+    let range =
+        calc_version_range(resolved, infer_range_spec_style(declared_range), None, default_style);
     let bumped = format!("{prefix}{range}");
     (bumped != declared).then_some(bumped)
 }

--- a/pnpm/crates/package-manager/src/manifest_spec_bumps.rs
+++ b/pnpm/crates/package-manager/src/manifest_spec_bumps.rs
@@ -170,8 +170,13 @@ fn bumped_range(
         // A link or an injected directory has no version to pin.
         ImporterDepVersion::Link(_) | ImporterDepVersion::File(_) => return None,
     };
-    let style = infer_range_spec_style(declared_range).unwrap_or(default_style);
-    let range = format!("{}{resolved}", style.range_prefix());
+    let range = match infer_range_spec_style(declared_range) {
+        Some(style) => format!("{}{resolved}", style.range_prefix()),
+        // Match the TypeScript resolver's prerelease fallback: an unsupported
+        // comparator or compound range becomes an exact prerelease pick.
+        None if !resolved.pre_release.is_empty() => resolved.to_string(),
+        None => format!("{}{resolved}", default_style.range_prefix()),
+    };
     let bumped = format!("{prefix}{range}");
     (bumped != declared).then_some(bumped)
 }

--- a/pnpm/crates/package-manager/src/manifest_spec_bumps/tests.rs
+++ b/pnpm/crates/package-manager/src/manifest_spec_bumps/tests.rs
@@ -36,8 +36,8 @@ fn a_dist_tag_keeps_tracking_its_tag() {
 
 #[test]
 fn a_prerelease_pick_keeps_the_declared_range_operator() {
-    assert_eq!(bump("^1.0.0-beta.1", "1.0.0-beta.2").as_deref(), Some("^1.0.0-beta.2"),);
-    assert_eq!(bump("~1.0.0-beta.1", "1.0.0-beta.2").as_deref(), Some("~1.0.0-beta.2"),);
+    assert_eq!(bump("^1.0.0-beta.1", "1.0.0-beta.2").as_deref(), Some("^1.0.0-beta.2"));
+    assert_eq!(bump("~1.0.0-beta.1", "1.0.0-beta.2").as_deref(), Some("~1.0.0-beta.2"));
 }
 
 #[test]

--- a/pnpm/crates/package-manager/src/manifest_spec_bumps/tests.rs
+++ b/pnpm/crates/package-manager/src/manifest_spec_bumps/tests.rs
@@ -38,6 +38,14 @@ fn a_dist_tag_keeps_tracking_its_tag() {
 fn a_prerelease_pick_keeps_the_declared_range_operator() {
     assert_eq!(bump("^1.0.0-beta.1", "1.0.0-beta.2").as_deref(), Some("^1.0.0-beta.2"));
     assert_eq!(bump("~1.0.0-beta.1", "1.0.0-beta.2").as_deref(), Some("~1.0.0-beta.2"));
+    assert_eq!(bump("1.0.0-beta.1", "1.0.0-beta.2").as_deref(), Some("1.0.0-beta.2"));
+    assert_eq!(bump("=1.0.0-beta.1", "1.0.0-beta.2").as_deref(), Some("=1.0.0-beta.2"));
+}
+
+#[test]
+fn a_prerelease_pick_uses_an_exact_fallback_for_an_unsupported_range() {
+    assert_eq!(bump(">=1.0.0-beta.1", "2.0.0-beta.1").as_deref(), Some("2.0.0-beta.1"));
+    assert_eq!(bump("1 || 2", "2.1.0-beta.1").as_deref(), Some("2.1.0-beta.1"));
 }
 
 #[test]

--- a/pnpm/crates/package-manager/src/manifest_spec_bumps/tests.rs
+++ b/pnpm/crates/package-manager/src/manifest_spec_bumps/tests.rs
@@ -35,8 +35,9 @@ fn a_dist_tag_keeps_tracking_its_tag() {
 }
 
 #[test]
-fn a_prerelease_pick_is_pinned_exactly() {
-    assert_eq!(bump("^1.0.0", "2.0.0-beta.1").as_deref(), Some("2.0.0-beta.1"));
+fn a_prerelease_pick_keeps_the_declared_range_operator() {
+    assert_eq!(bump("^1.0.0-beta.1", "1.0.0-beta.2").as_deref(), Some("^1.0.0-beta.2"),);
+    assert_eq!(bump("~1.0.0-beta.1", "1.0.0-beta.2").as_deref(), Some("~1.0.0-beta.2"),);
 }
 
 #[test]

--- a/pnpm/crates/registry/src/package/tests.rs
+++ b/pnpm/crates/registry/src/package/tests.rs
@@ -4,7 +4,7 @@ use node_semver::Version;
 use pretty_assertions::assert_eq;
 
 use super::{AuthHeaders, DerivedPackuments, Package, PackageVersion, ThrottledClient};
-use crate::{RangeSpecStyle, package_distribution::PackageDistribution};
+use crate::package_distribution::PackageDistribution;
 
 #[test]
 pub fn package_version_should_include_peers() {
@@ -32,50 +32,6 @@ pub fn package_version_should_include_peers() {
     assert!(dependencies(true).contains_key("fastify"));
     assert!(dependencies(true).contains_key("fast-querystring"));
     assert!(!dependencies(true).contains_key("hello-world"));
-}
-
-#[test]
-pub fn serialized_according_to_params() {
-    let version = PackageVersion {
-        name: String::new(),
-        version: Version { major: 3, minor: 2, patch: 1, build: vec![], pre_release: vec![] },
-        dist: PackageDistribution::default(),
-        dependencies: None,
-        dev_dependencies: None,
-        peer_dependencies: None,
-        optional_dependencies: None,
-        peer_dependencies_meta: None,
-        other: HashMap::default(),
-        npm_user: None,
-        deprecated: None,
-    };
-
-    assert_eq!(version.serialize(RangeSpecStyle::Patch), "3.2.1");
-    assert_eq!(version.serialize(RangeSpecStyle::Minor), "~3.2.1");
-    assert_eq!(version.serialize(RangeSpecStyle::Major), "^3.2.1");
-    assert_eq!(version.serialize(RangeSpecStyle::None), "^3.2.1");
-}
-
-#[test]
-pub fn serialize_keeps_prerelease_version_without_prefix() {
-    let version = PackageVersion {
-        name: String::new(),
-        version: Version::parse("2.1.0-rc.1").unwrap(),
-        dist: PackageDistribution::default(),
-        dependencies: None,
-        dev_dependencies: None,
-        peer_dependencies: None,
-        optional_dependencies: None,
-        peer_dependencies_meta: None,
-        other: HashMap::default(),
-        npm_user: None,
-        deprecated: None,
-    };
-
-    assert_eq!(version.serialize(RangeSpecStyle::Major), "2.1.0-rc.1");
-    assert_eq!(version.serialize(RangeSpecStyle::Minor), "2.1.0-rc.1");
-    assert_eq!(version.serialize(RangeSpecStyle::Patch), "2.1.0-rc.1");
-    assert_eq!(version.serialize(RangeSpecStyle::None), "2.1.0-rc.1");
 }
 
 #[tokio::test]

--- a/pnpm/crates/registry/src/package_version.rs
+++ b/pnpm/crates/registry/src/package_version.rs
@@ -4,10 +4,7 @@ use pipe_trait::Pipe;
 use pnpm_network::{AuthHeaders, ThrottledClient};
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    NetworkError, PackageTag, RangeSpecStyle, RegistryError,
-    package_distribution::PackageDistribution,
-};
+use crate::{NetworkError, PackageTag, RegistryError, package_distribution::PackageDistribution};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -298,14 +295,6 @@ impl PackageVersion {
         dependencies
             .chain(peer_dependencies)
             .map(|(name, version)| (name.as_str(), version.as_str()))
-    }
-
-    #[must_use]
-    pub fn serialize(&self, range_spec_style: RangeSpecStyle) -> String {
-        if !self.version.pre_release.is_empty() {
-            return self.version.to_string();
-        }
-        format!("{0}{1}", range_spec_style.range_prefix(), self.version)
     }
 }
 

--- a/pnpm/crates/resolving-npm-resolver/src/calc_specifier.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/calc_specifier.rs
@@ -3,13 +3,41 @@
 //! `add` and `update` rewrite `package.json` from what the resolver
 //! picked. What that text should look like is the resolver's business,
 //! not the command's: only the npm resolver knows that an npm alias
-//! round-trips as `npm:<real name>@<range>`, or that a prerelease pick
-//! is written without a range operator.
+//! round-trips as `npm:<real name>@<range>`, or how a prerelease pick
+//! is pinned.
 
-use node_semver::Range;
+use node_semver::{Range, Version};
 use pnpm_registry::{PackageVersion, RangeSpecStyle};
 
 use crate::infer_range_spec_style::infer_range_spec_style;
+
+/// The manifest range that pins `version` for a dependency whose existing
+/// manifest entry, if it already had one, pins `prev_style`, and whose
+/// requested specifier pins `spec_style`.
+///
+/// The existing entry's style wins over the requested specifier's, which
+/// wins over `default_style`, so a re-add keeps the pinning style the
+/// manifest already used. A prerelease keeps the existing entry's style and
+/// is otherwise pinned exactly — neither the requested specifier nor
+/// `default_style` widens a prerelease the manifest did not already widen.
+///
+/// Mirrors the TypeScript `calcVersionRange`.
+#[must_use]
+pub fn calc_version_range(
+    version: &Version,
+    prev_style: Option<RangeSpecStyle>,
+    spec_style: Option<RangeSpecStyle>,
+    default_style: RangeSpecStyle,
+) -> String {
+    if !version.pre_release.is_empty() {
+        return match prev_style {
+            Some(style) => format!("{}{version}", style.range_prefix()),
+            None => version.to_string(),
+        };
+    }
+    let style = prev_style.or(spec_style).unwrap_or(default_style);
+    format!("{}{version}", style.range_prefix())
+}
 
 /// The specifier to write for `picked` when the dependency currently
 /// declares `bare_specifier` under the install name `alias`.
@@ -28,7 +56,12 @@ pub fn calc_specifier(
     picked: &PackageVersion,
     default_pin: RangeSpecStyle,
 ) -> String {
-    let range = picked.serialize(infer_range_spec_style(bare_specifier).unwrap_or(default_pin));
+    let range = calc_version_range(
+        &picked.version,
+        infer_range_spec_style(bare_specifier),
+        None,
+        default_pin,
+    );
     match npm_alias_target(bare_specifier, alias) {
         Some(real_name) => format!("npm:{real_name}@{range}"),
         None => range,
@@ -55,7 +88,12 @@ pub fn calc_prefixed_specifier(
     picked: &PackageVersion,
     default_pin: RangeSpecStyle,
 ) -> String {
-    let range = picked.serialize(infer_range_spec_style(bare_specifier).unwrap_or(default_pin));
+    let range = calc_version_range(
+        &picked.version,
+        infer_range_spec_style(bare_specifier),
+        None,
+        default_pin,
+    );
     match alias {
         Some(alias) if !alias.is_empty() && alias != pkg_name => {
             format!("{prefix}{pkg_name}@{range}")

--- a/pnpm/crates/resolving-npm-resolver/src/calc_specifier/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/calc_specifier/tests.rs
@@ -1,6 +1,8 @@
+use node_semver::Version;
 use pnpm_registry::{PackageVersion, RangeSpecStyle};
 
-use super::{calc_prefixed_specifier, calc_specifier};
+use super::{calc_prefixed_specifier, calc_specifier, calc_version_range};
+use crate::infer_range_spec_style;
 
 fn picked(version: &str) -> PackageVersion {
     serde_json::from_value(serde_json::json!({
@@ -67,14 +69,50 @@ fn an_alias_that_names_the_install_name_round_trips_as_a_bare_range() {
     }
 }
 
-/// A prerelease has no meaningful range operator, so it is pinned exactly
-/// whatever the declared specifier or the default asks for.
 #[test]
-fn a_prerelease_pick_is_written_exactly() {
+fn a_prerelease_pick_keeps_the_declared_range_operator() {
     assert_eq!(
         calc_specifier("^1.0.0", Some("foo"), &picked("5.0.0-rc.1"), RangeSpecStyle::Major),
+        "^5.0.0-rc.1",
+    );
+    // A tag pins no operator, so the prerelease is pinned exactly rather
+    // than widened to the default pin.
+    assert_eq!(
+        calc_specifier("latest", Some("foo"), &picked("5.0.0-rc.1"), RangeSpecStyle::Major),
         "5.0.0-rc.1",
     );
+}
+
+#[test]
+fn calc_version_range_preserves_an_existing_prerelease_range_style() {
+    let version = Version::parse("3.0.0-rc.11").expect("parse prerelease version");
+    for (prev, expected) in [
+        ("^3.0.0-rc.8", "^3.0.0-rc.11"),
+        ("~3.0.0-rc.8", "~3.0.0-rc.11"),
+        ("3.0.0-rc.8", "3.0.0-rc.11"),
+        ("=3.0.0-rc.8", "=3.0.0-rc.11"),
+        (">=3.0.0-rc.8", "3.0.0-rc.11"),
+        ("2 || 3", "3.0.0-rc.11"),
+    ] {
+        assert_eq!(
+            calc_version_range(&version, infer_range_spec_style(prev), None, RangeSpecStyle::Major),
+            expected,
+            "range for previous specifier {prev}",
+        );
+    }
+    assert_eq!(calc_version_range(&version, None, None, RangeSpecStyle::Major), "3.0.0-rc.11");
+}
+
+#[test]
+fn calc_version_range_ignores_the_requested_specifier_style_for_a_prerelease() {
+    let prerelease = Version::parse("3.0.0-rc.11").expect("parse prerelease version");
+    let spec_style = infer_range_spec_style("~3.0.0-rc.8");
+    assert_eq!(
+        calc_version_range(&prerelease, None, spec_style, RangeSpecStyle::Major),
+        "3.0.0-rc.11",
+    );
+    let release = Version::parse("3.1.0").expect("parse release version");
+    assert_eq!(calc_version_range(&release, None, spec_style, RangeSpecStyle::Major), "~3.1.0");
 }
 
 #[test]

--- a/pnpm/crates/resolving-npm-resolver/src/lib.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/lib.rs
@@ -38,7 +38,7 @@ mod trust_checks;
 mod violation_codes;
 mod workspace_pref_to_npm;
 
-pub use calc_specifier::{calc_prefixed_specifier, calc_specifier};
+pub use calc_specifier::{calc_prefixed_specifier, calc_specifier, calc_version_range};
 pub use calc_specifier_for_workspace_dep::{DeclaredSpecifiers, calc_specifier_for_workspace_dep};
 pub use create_npm_resolution_verifier::{
     CreateNpmResolutionVerifierOptions, DistStats, NpmResolutionVerifier, ObservedDistStats,

--- a/pnpm11/pkg-manifest/utils/src/rangeSpecStyle.ts
+++ b/pnpm11/pkg-manifest/utils/src/rangeSpecStyle.ts
@@ -29,8 +29,8 @@ export function getRangeSpecStyle (opts: { saveExact?: boolean, savePrefix?: str
  *
  * The existing entry's range style wins over the requested specifier's, which
  * wins over the configured default, so a re-add keeps the pinning style the
- * manifest already used. A prerelease is pinned exactly: no range operator
- * expresses "this prerelease and later ones".
+ * manifest already used. A newly added prerelease is pinned exactly, while an
+ * updated prerelease keeps the existing entry's range style.
  */
 export function calcVersionRange (
   version: string,
@@ -41,7 +41,8 @@ export function calcVersionRange (
   }
 ): string {
   if (semver.parse(version)?.prerelease.length) {
-    return version
+    const prevRangeSpecStyle = opts.prevSpecifier ? inferRangeSpecStyle(opts.prevSpecifier) : undefined
+    return prevRangeSpecStyle ? versionWithRangeSpecStyle(version, prevRangeSpecStyle) : version
   }
   const rangeSpecStyle = (opts.prevSpecifier ? inferRangeSpecStyle(opts.prevSpecifier) : undefined) ??
     (opts.bareSpecifier ? inferRangeSpecStyle(opts.bareSpecifier) : undefined) ??

--- a/pnpm11/pkg-manifest/utils/test/rangeSpecStyle.test.ts
+++ b/pnpm11/pkg-manifest/utils/test/rangeSpecStyle.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@jest/globals'
-import { getRangeSpecStyle, rangeSpecGranularity, versionWithRangeSpecStyle } from '@pnpm/pkg-manifest.utils'
+import { calcVersionRange, getRangeSpecStyle, rangeSpecGranularity, versionWithRangeSpecStyle } from '@pnpm/pkg-manifest.utils'
 
 test('getRangeSpecStyle()', () => {
   expect(getRangeSpecStyle({ saveExact: true })).toBe('patch')
@@ -18,6 +18,14 @@ test('versionWithRangeSpecStyle()', () => {
   expect(versionWithRangeSpecStyle('1.2.3', 'exact')).toBe('=1.2.3')
   expect(versionWithRangeSpecStyle('1.2.3', 'none')).toBe('^1.2.3')
   expect(() => versionWithRangeSpecStyle('1.2.3', 'bogus' as never)).toThrow("Unknown range spec style: 'bogus'")
+})
+
+test('calcVersionRange() preserves an existing prerelease range style', () => {
+  expect(calcVersionRange('3.0.0-rc.11', { prevSpecifier: '^3.0.0-rc.8' })).toBe('^3.0.0-rc.11')
+  expect(calcVersionRange('3.0.0-rc.11', { prevSpecifier: '~3.0.0-rc.8' })).toBe('~3.0.0-rc.11')
+  expect(calcVersionRange('3.0.0-rc.11', { prevSpecifier: '3.0.0-rc.8' })).toBe('3.0.0-rc.11')
+  expect(calcVersionRange('3.0.0-rc.11', { prevSpecifier: '=3.0.0-rc.8' })).toBe('=3.0.0-rc.11')
+  expect(calcVersionRange('3.0.0-rc.11', {})).toBe('3.0.0-rc.11')
 })
 
 test('rangeSpecGranularity() collapses exact to patch', () => {

--- a/pnpm11/pkg-manifest/utils/test/rangeSpecStyle.test.ts
+++ b/pnpm11/pkg-manifest/utils/test/rangeSpecStyle.test.ts
@@ -25,6 +25,8 @@ test('calcVersionRange() preserves an existing prerelease range style', () => {
   expect(calcVersionRange('3.0.0-rc.11', { prevSpecifier: '~3.0.0-rc.8' })).toBe('~3.0.0-rc.11')
   expect(calcVersionRange('3.0.0-rc.11', { prevSpecifier: '3.0.0-rc.8' })).toBe('3.0.0-rc.11')
   expect(calcVersionRange('3.0.0-rc.11', { prevSpecifier: '=3.0.0-rc.8' })).toBe('=3.0.0-rc.11')
+  expect(calcVersionRange('3.0.0-rc.11', { prevSpecifier: '>=3.0.0-rc.8' })).toBe('3.0.0-rc.11')
+  expect(calcVersionRange('3.0.0-rc.11', { prevSpecifier: '2 || 3' })).toBe('3.0.0-rc.11')
   expect(calcVersionRange('3.0.0-rc.11', {})).toBe('3.0.0-rc.11')
 })
 

--- a/pnpm11/pkg-manifest/utils/test/rangeSpecStyle.test.ts
+++ b/pnpm11/pkg-manifest/utils/test/rangeSpecStyle.test.ts
@@ -30,6 +30,11 @@ test('calcVersionRange() preserves an existing prerelease range style', () => {
   expect(calcVersionRange('3.0.0-rc.11', {})).toBe('3.0.0-rc.11')
 })
 
+test('calcVersionRange() ignores the requested specifier range style for a prerelease', () => {
+  expect(calcVersionRange('3.0.0-rc.11', { bareSpecifier: '~3.0.0-rc.8' })).toBe('3.0.0-rc.11')
+  expect(calcVersionRange('3.1.0', { bareSpecifier: '~3.0.0' })).toBe('~3.1.0')
+})
+
 test('rangeSpecGranularity() collapses exact to patch', () => {
   expect(rangeSpecGranularity('exact')).toBe('patch')
   expect(rangeSpecGranularity('patch')).toBe('patch')

--- a/pnpm11/pnpm/test/update.ts
+++ b/pnpm11/pnpm/test/update.ts
@@ -728,6 +728,20 @@ test('update to latest without downgrading already defined prerelease (#7436)', 
   expect(lockfile3).not.toHaveProperty(['packages', '@pnpm.e2e/has-prerelease@2.0.0'])
 })
 
+test('update preserves an existing prerelease range operator', async function () {
+  prepare({
+    dependencies: {
+      '@pnpm.e2e/has-prerelease': '^3.0.0-rc.0',
+    },
+  })
+
+  await execPnpm(['install'])
+  await execPnpm(['update'])
+
+  const manifest = await readPackageJsonFromDir('.')
+  expect(manifest.dependencies?.['@pnpm.e2e/has-prerelease']).toBe('^3.0.0-rc.1')
+})
+
 test('update with tag @latest will downgrade prerelease', async function () {
   prepare()
 

--- a/pnpm11/pnpm/test/update.ts
+++ b/pnpm11/pnpm/test/update.ts
@@ -729,17 +729,28 @@ test('update to latest without downgrading already defined prerelease (#7436)', 
 })
 
 test('update preserves an existing prerelease range operator', async function () {
-  prepare({
+  const project = prepare({
     dependencies: {
-      '@pnpm.e2e/has-prerelease': '^3.0.0-rc.0',
+      '@pnpm.e2e/has-prerelease': '3.0.0-rc.0',
     },
   })
 
   await execPnpm(['install'])
+  project.storeHas('@pnpm.e2e/has-prerelease', '3.0.0-rc.0')
+
+  project.writePackageJson({
+    dependencies: {
+      '@pnpm.e2e/has-prerelease': '^3.0.0-rc.0',
+    },
+  })
   await execPnpm(['update'])
 
+  project.storeHas('@pnpm.e2e/has-prerelease', '3.0.0-rc.1')
+  const lockfile = project.readLockfile()
+  expect(lockfile.importers['.'].dependencies?.['@pnpm.e2e/has-prerelease'].version).toBe('3.0.0-rc.1')
   const manifest = await readPackageJsonFromDir('.')
   expect(manifest.dependencies?.['@pnpm.e2e/has-prerelease']).toBe('^3.0.0-rc.1')
+  await execPnpm(['install', '--frozen-lockfile'])
 })
 
 test('update with tag @latest will downgrade prerelease', async function () {

--- a/pnpr/.fixtures/packages/@pnpm.e2e/has-prerelease/3.0.0-rc.1/package.json
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/has-prerelease/3.0.0-rc.1/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@pnpm.e2e/has-prerelease",
+  "version": "3.0.0-rc.1"
+}


### PR DESCRIPTION
## Summary

`pnpm update` currently drops an existing range operator when the resolved version is a prerelease. This keeps the declaration's existing range style in both update implementations while leaving newly added prerelease dependencies pinned exactly.

- Preserve caret, tilde, bare, and equals-prefixed styles for prerelease updates.
- Keep the TypeScript CLI and Rust pacquet behavior in sync.
- Add unit and end-to-end regressions using a shared `3.0.0-rc.0` to `3.0.0-rc.1` registry fixture.
- Extract a shared `calc_version_range` in pacquet mirroring the TypeScript `calcVersionRange`, so the re-add and `pnpm update --latest` paths (including jsr/named registries) preserve the style the same way the shared TypeScript helper already does.

Fixes pnpm/pnpm#7002.

Validation:

- TypeScript range-style unit suite: 4 passed.
- TypeScript pnpm update end-to-end regression: 1 passed.
- Rust manifest bump unit regression: 1 passed.
- Rust pacquet update end-to-end regression: 1 passed.
- pnpm CLI lint, TypeScript build, pinned-runtime bundle, monorepo typecheck, CSpell, `cargo fmt --check`, and focused `cargo check`: passed.
- The full pre-push hook was run. Its TypeScript, formatting, and rustdoc phases passed; workspace Clippy stops on the unchanged Windows-only `pnpm/crates/fs/src/symlink_dir.rs:97` with `clippy::needless_return` under Rust 1.97.0.

## Squash Commit Body

```text
When update resolves a prerelease dependency, preserve the range style already
declared in the manifest in both the TypeScript and Rust implementations.
Newly added prerelease dependencies remain pinned exactly.

The TypeScript calcVersionRange serves plain update, re-add of a declared
dependency, and update --latest, so all three preserve the style. pacquet
routes those paths through a new calc_version_range helper mirroring it,
replacing the duplicated decision (PackageVersion::serialize is removed).

Add shared-fixture unit and end-to-end coverage for the prerelease update path.

Fixes pnpm/pnpm#7002.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it. The issue has no linked PR, and exact plus
  semantic searches across open and closed PRs found no duplicate.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port.
- [x] Added a changeset (`pnpm changeset`) for the published packages.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5.6).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13900"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789242766&installation_model_id=426870&pr_number=13900&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13900&signature=50ebe0b7856f6d7b2b3a6084ec2ce14922ecb57ca16ab04718030fa21eb9489e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - `pnpm update` now preserves existing range operators, such as `^` and `~`, when updating prerelease dependencies.
  - Prerelease dependencies retain their configured range style instead of being unexpectedly pinned to an exact version.
  - Newly added prerelease dependencies continue to use exact versions by default.

- **Tests**
  - Added coverage for caret, tilde, exact, and equals range styles.
  - Verified that updated dependencies remain compatible with frozen lockfile installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
