### PR TITLE
perf(resolver): cache Node.js release metadata and skip the index for exact runtime pins

### DIFF
--- a/.changeset/runtime-shasums-cache.md
+++ b/.changeset/runtime-shasums-cache.md
@@ -1,0 +1,9 @@
+---
+"@pnpm/crypto.shasums-file": minor
+"@pnpm/engine.runtime.node-resolver": minor
+"@pnpm/resolving.default-resolver": patch
+"pnpm": minor
+"pacquet": minor
+---
+
+Resolving a Node.js runtime version (`devEngines.runtime` / `runtime:` specifiers) is now much faster and no longer needs the network once the version's release metadata has been fetched once. The signature-verified per-version `SHASUMS256.txt` bodies are cached under `<cacheDir>/v11/runtime-shasums/`, and an exact stable version such as `runtime:22.23.2` skips the Node.js release-index download entirely. This cuts the first `node` invocation in a project pinning an already-downloaded runtime from ~650ms to ~100ms [#13899](https://github.com/pnpm/pnpm/issues/13899).

--- a/.changeset/runtime-shasums-cache.md
+++ b/.changeset/runtime-shasums-cache.md
@@ -6,4 +6,4 @@
 "pacquet": minor
 ---
 
-Resolving a Node.js runtime version (`devEngines.runtime` / `runtime:` specifiers) is now much faster and no longer needs the network once the version's release metadata has been fetched once. The signature-verified per-version `SHASUMS256.txt` bodies are cached under `<cacheDir>/v11/runtime-shasums/`, and an exact stable version such as `runtime:22.23.2` skips the Node.js release-index download entirely. This cuts the first `node` invocation in a project pinning an already-downloaded runtime from ~650ms to ~100ms [#13899](https://github.com/pnpm/pnpm/issues/13899).
+Resolving a Node.js runtime version (`devEngines.runtime` / `runtime:` specifiers) is now much faster: the per-version release metadata is cached in the pnpm cache directory after its signature is verified, and an exact stable version such as `runtime:22.23.2` no longer downloads the Node.js release index. A pinned runtime whose metadata was fetched once resolves without any network access, which removes the noticeable delay on the first `node` invocation in a project pinning an already-downloaded runtime [#13899](https://github.com/pnpm/pnpm/issues/13899).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4173,6 +4173,7 @@ dependencies = [
  "pgp",
  "pretty_assertions",
  "reqwest",
+ "tempfile",
  "tokio",
 ]
 
@@ -4357,6 +4358,7 @@ dependencies = [
  "serde",
  "serde_json",
  "ssri",
+ "tempfile",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4167,6 +4167,7 @@ version = "0.0.1"
 dependencies = [
  "base64 0.22.1",
  "derive_more",
+ "libc",
  "miette 7.6.0",
  "mockito",
  "pacquet-network",

--- a/pnpm/crates/crypto-shasums-file/Cargo.toml
+++ b/pnpm/crates/crypto-shasums-file/Cargo.toml
@@ -19,6 +19,9 @@ miette      = { workspace = true }
 pgp         = { workspace = true }
 reqwest     = { workspace = true }
 
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
+
 [dev-dependencies]
 mockito           = { workspace = true }
 pretty_assertions = { workspace = true }

--- a/pnpm/crates/crypto-shasums-file/Cargo.toml
+++ b/pnpm/crates/crypto-shasums-file/Cargo.toml
@@ -22,6 +22,7 @@ reqwest     = { workspace = true }
 [dev-dependencies]
 mockito           = { workspace = true }
 pretty_assertions = { workspace = true }
+tempfile          = { workspace = true }
 tokio             = { workspace = true, features = ["macros", "rt"] }
 
 [lints]

--- a/pnpm/crates/crypto-shasums-file/src/disk_cache.rs
+++ b/pnpm/crates/crypto-shasums-file/src/disk_cache.rs
@@ -4,20 +4,25 @@
 //! (`.../v22.0.0/SHASUMS256.txt`), so its content is immutable: a body
 //! fetched once — and, for signed channels, verified once — never needs
 //! to be fetched again. Entries are stored under
-//! `<cache_dir>/v11/runtime-shasums/<host>/<url path>` so `pnpm cache
-//! delete` on the cache directory clears them together with the
-//! registry metadata mirror. The layout is shared with pnpm, which
+//! `<cache_dir>/v11/runtime-shasums/<trust>/<host>/<url path>` so
+//! `pnpm cache delete` on the cache directory clears them together with
+//! the registry metadata mirror. The layout is shared with pnpm, which
 //! reads and writes the same files.
 //!
 //! Only hand immutable URLs to this cache. A cached body is trusted on
 //! the same terms as the registry metadata mirror: verification (the
 //! `OpenPGP` signature check for signed channels) happens before the
-//! write, not after the read, so a reader never re-verifies.
+//! write, not after the read, so a reader never re-verifies. The
+//! `<trust>` path segment keeps signature-verified bodies and
+//! TLS-only bodies in disjoint subtrees, so an unverified fetch can
+//! never seed an entry that a signature-verifying reader would trust.
 
 use std::{
     fmt::Write as _,
     fs,
+    io::Write as _,
     path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
 };
 
 /// Directory under the pnpm cache dir holding the cached SHASUMS
@@ -26,11 +31,89 @@ use std::{
 /// versioning story.
 pub const RUNTIME_SHASUMS_CACHE_DIR: &str = "v11/runtime-shasums";
 
+/// How the body of a cache entry was authenticated before it was
+/// written. Each class caches into its own subtree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ShasumsTrust {
+    /// The body's detached `OpenPGP` signature verified against the
+    /// embedded release keys.
+    Verified,
+    /// The body is trusted only as far as the TLS fetch that produced
+    /// it (unsigned channels, unofficial-builds musl lists).
+    Unverified,
+}
+
+impl ShasumsTrust {
+    fn dir_name(self) -> &'static str {
+        match self {
+            ShasumsTrust::Verified => "verified",
+            ShasumsTrust::Unverified => "unverified",
+        }
+    }
+}
+
+/// The cached body for `url`, or `None` on any miss — a URL the
+/// mapping cannot represent, a missing file, unreadable content, or an
+/// empty file (never a valid SHASUMS body, so it only signals a torn
+/// write).
+pub(crate) fn read_cached_shasums(
+    cache_dir: Option<&Path>,
+    trust: ShasumsTrust,
+    url: &str,
+) -> Option<String> {
+    let path = shasums_cache_path(cache_dir?, trust, url)?;
+    fs::read_to_string(path).ok().filter(|body| !body.is_empty())
+}
+
+/// Best-effort write of `body` for `url`: a cache-write failure only
+/// costs a refetch on the next resolve, so errors are deliberately
+/// dropped rather than failing the resolution that produced the body.
+/// The exclusively-created temp file + rename keeps concurrent writers
+/// (two installs resolving the same version) from exposing a torn body.
+pub(crate) fn write_cached_shasums(
+    cache_dir: Option<&Path>,
+    trust: ShasumsTrust,
+    url: &str,
+    body: &str,
+) {
+    let Some(cache_dir) = cache_dir else { return };
+    let Some(path) = shasums_cache_path(cache_dir, trust, url) else { return };
+    let Some(parent) = path.parent() else { return };
+    if fs::create_dir_all(parent).is_err() {
+        return;
+    }
+    // The process id alone does not make the temp name unique (worker
+    // threads and concurrent tasks share it), so a process-wide counter
+    // joins it. `create_new` refuses to open a path that already exists
+    // — a colliding writer or a pre-seeded symlink fails the open
+    // instead of being followed — and any failure just skips the write.
+    static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+    let mut temp_name = path.file_name().unwrap_or_default().to_os_string();
+    temp_name.push(format!(
+        ".tmp-{}-{}",
+        std::process::id(),
+        TEMP_COUNTER.fetch_add(1, Ordering::Relaxed),
+    ));
+    let temp = path.with_file_name(temp_name);
+    let written = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temp)
+        .and_then(|mut file| file.write_all(body.as_bytes()));
+    if written.is_err() || fs::rename(&temp, &path).is_err() {
+        let _ = fs::remove_file(&temp);
+    }
+}
+
 /// The cache file backing `url`, or `None` when the URL has a shape
 /// the path mapping does not cover (non-HTTP scheme, embedded
 /// credentials, query string, empty or dot-only path segments).
 /// Returning `None` just disables caching for that URL.
-pub(crate) fn shasums_cache_path(cache_dir: &Path, url: &str) -> Option<PathBuf> {
+pub(crate) fn shasums_cache_path(
+    cache_dir: &Path,
+    trust: ShasumsTrust,
+    url: &str,
+) -> Option<PathBuf> {
     let rest = url.strip_prefix("https://").or_else(|| url.strip_prefix("http://"))?;
     if rest.contains(['?', '#', '@']) {
         return None;
@@ -49,7 +132,7 @@ pub(crate) fn shasums_cache_path(cache_dir: &Path, url: &str) -> Option<PathBuf>
         }
         segments.push(encode_path_segment(segment)?);
     }
-    let mut file = cache_dir.join(RUNTIME_SHASUMS_CACHE_DIR);
+    let mut file = cache_dir.join(RUNTIME_SHASUMS_CACHE_DIR).join(trust.dir_name());
     file.extend(segments);
     Some(file)
 }
@@ -70,35 +153,6 @@ fn encode_path_segment(segment: &str) -> Option<String> {
         }
     }
     Some(encoded)
-}
-
-/// The cached body for `url`, or `None` on any miss — a URL the
-/// mapping cannot represent, a missing file, unreadable content, or an
-/// empty file (never a valid SHASUMS body, so it only signals a torn
-/// write).
-pub(crate) fn read_cached_shasums(cache_dir: Option<&Path>, url: &str) -> Option<String> {
-    let path = shasums_cache_path(cache_dir?, url)?;
-    fs::read_to_string(path).ok().filter(|body| !body.is_empty())
-}
-
-/// Best-effort write of `body` for `url`: a cache-write failure only
-/// costs a refetch on the next resolve, so errors are deliberately
-/// dropped rather than failing the resolution that produced the body.
-/// The temp-file + rename keeps concurrent writers (two installs
-/// resolving the same version) from exposing a torn body.
-pub(crate) fn write_cached_shasums(cache_dir: Option<&Path>, url: &str, body: &str) {
-    let Some(cache_dir) = cache_dir else { return };
-    let Some(path) = shasums_cache_path(cache_dir, url) else { return };
-    let Some(parent) = path.parent() else { return };
-    if fs::create_dir_all(parent).is_err() {
-        return;
-    }
-    let mut temp_name = path.file_name().unwrap_or_default().to_os_string();
-    temp_name.push(format!(".tmp{}", std::process::id()));
-    let temp = path.with_file_name(temp_name);
-    if fs::write(&temp, body).is_ok() && fs::rename(&temp, &path).is_err() {
-        let _ = fs::remove_file(&temp);
-    }
 }
 
 #[cfg(test)]

--- a/pnpm/crates/crypto-shasums-file/src/disk_cache.rs
+++ b/pnpm/crates/crypto-shasums-file/src/disk_cache.rs
@@ -52,16 +52,25 @@ impl ShasumsTrust {
     }
 }
 
+/// Upper bound on a cache entry's size. Real SHASUMS bodies are a few
+/// kilobytes; anything past this bound is not a release asset list and
+/// is never read into memory or written.
+const MAX_CACHED_SHASUMS_LEN: u64 = 1024 * 1024;
+
 /// The cached body for `url`, or `None` on any miss — a URL the
-/// mapping cannot represent, a missing file, unreadable content, or an
+/// mapping cannot represent, a missing file, unreadable content, an
 /// empty file (never a valid SHASUMS body, so it only signals a torn
-/// write).
+/// write), or a file over [`MAX_CACHED_SHASUMS_LEN`].
 pub(crate) fn read_cached_shasums(
     cache_dir: Option<&Path>,
     trust: ShasumsTrust,
     url: &str,
 ) -> Option<String> {
     let path = shasums_cache_path(cache_dir?, trust, url)?;
+    let len = fs::metadata(&path).ok()?.len();
+    if len == 0 || len > MAX_CACHED_SHASUMS_LEN {
+        return None;
+    }
     fs::read_to_string(path).ok().filter(|body| !body.is_empty())
 }
 
@@ -77,6 +86,9 @@ pub(crate) fn write_cached_shasums(
     body: &str,
 ) {
     let Some(cache_dir) = cache_dir else { return };
+    if body.len() as u64 > MAX_CACHED_SHASUMS_LEN {
+        return;
+    }
     let Some(path) = shasums_cache_path(cache_dir, trust, url) else { return };
     let Some(parent) = path.parent() else { return };
     if fs::create_dir_all(parent).is_err() {
@@ -95,11 +107,15 @@ pub(crate) fn write_cached_shasums(
         TEMP_COUNTER.fetch_add(1, Ordering::Relaxed),
     ));
     let temp = path.with_file_name(temp_name);
-    let written = fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(&temp)
-        .and_then(|mut file| file.write_all(body.as_bytes()));
+    // `sync_all` before the rename so a crash cannot persist the
+    // renamed name pointing at partially-written content — a torn
+    // SHASUMS prefix still parses and would otherwise be served
+    // (missing platform rows) until the cache is cleared.
+    let written =
+        fs::OpenOptions::new().write(true).create_new(true).open(&temp).and_then(|mut file| {
+            file.write_all(body.as_bytes())?;
+            file.sync_all()
+        });
     if written.is_err() || fs::rename(&temp, &path).is_err() {
         let _ = fs::remove_file(&temp);
     }

--- a/pnpm/crates/crypto-shasums-file/src/disk_cache.rs
+++ b/pnpm/crates/crypto-shasums-file/src/disk_cache.rs
@@ -1,0 +1,104 @@
+//! On-disk cache for per-version runtime `SHASUMS256.txt` bodies.
+//!
+//! A release's SHASUMS file lives under a version-pinned URL
+//! (`.../v22.0.0/SHASUMS256.txt`), so its content is immutable: a body
+//! fetched once — and, for signed channels, verified once — never needs
+//! to be fetched again. Entries are stored under
+//! `<cache_dir>/v11/runtime-shasums/<host>/<url path>` so `pnpm cache
+//! delete` on the cache directory clears them together with the
+//! registry metadata mirror. The layout is shared with pnpm, which
+//! reads and writes the same files.
+//!
+//! Only hand immutable URLs to this cache. A cached body is trusted on
+//! the same terms as the registry metadata mirror: verification (the
+//! `OpenPGP` signature check for signed channels) happens before the
+//! write, not after the read, so a reader never re-verifies.
+
+use std::{
+    fmt::Write as _,
+    fs,
+    path::{Path, PathBuf},
+};
+
+/// Directory under the pnpm cache dir holding the cached SHASUMS
+/// bodies. The `v11/` prefix groups it with the registry metadata
+/// mirror dirs (`v11/metadata`, ...), which share the cache dir's
+/// versioning story.
+pub const RUNTIME_SHASUMS_CACHE_DIR: &str = "v11/runtime-shasums";
+
+/// The cache file backing `url`, or `None` when the URL has a shape
+/// the path mapping does not cover (non-HTTP scheme, embedded
+/// credentials, query string, empty or dot-only path segments).
+/// Returning `None` just disables caching for that URL.
+pub(crate) fn shasums_cache_path(cache_dir: &Path, url: &str) -> Option<PathBuf> {
+    let rest = url.strip_prefix("https://").or_else(|| url.strip_prefix("http://"))?;
+    if rest.contains(['?', '#', '@']) {
+        return None;
+    }
+    let (host, path) = rest.split_once('/')?;
+    if host.is_empty() {
+        return None;
+    }
+    // `:` (a port separator) is not portable in file names; `+` is the
+    // same encoding the registry metadata mirror uses for it.
+    let host = host.to_ascii_lowercase().replace(':', "+");
+    let mut segments = vec![encode_path_segment(&host)?];
+    for segment in path.split('/') {
+        if segment.is_empty() || segment == "." || segment == ".." {
+            return None;
+        }
+        segments.push(encode_path_segment(segment)?);
+    }
+    let mut file = cache_dir.join(RUNTIME_SHASUMS_CACHE_DIR);
+    file.extend(segments);
+    Some(file)
+}
+
+/// Percent-encode the bytes of `segment` that are not portable across
+/// filesystems, keeping `[A-Za-z0-9._+-]` as-is. pnpm applies the same
+/// encoding, so both tools address one file.
+fn encode_path_segment(segment: &str) -> Option<String> {
+    if segment.len() > 200 {
+        return None;
+    }
+    let mut encoded = String::with_capacity(segment.len());
+    for byte in segment.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'+' | b'-') {
+            encoded.push(byte as char);
+        } else {
+            write!(encoded, "%{byte:02X}").expect("writing to a String cannot fail");
+        }
+    }
+    Some(encoded)
+}
+
+/// The cached body for `url`, or `None` on any miss — an unmappable
+/// URL, a missing file, unreadable content, or an empty file (never a
+/// valid SHASUMS body, so it only signals a torn write).
+pub(crate) fn read_cached_shasums(cache_dir: Option<&Path>, url: &str) -> Option<String> {
+    let path = shasums_cache_path(cache_dir?, url)?;
+    fs::read_to_string(path).ok().filter(|body| !body.is_empty())
+}
+
+/// Best-effort write of `body` for `url`: a cache-write failure only
+/// costs a refetch on the next resolve, so errors are deliberately
+/// dropped rather than failing the resolution that produced the body.
+/// The temp-file + rename keeps concurrent writers (two installs
+/// resolving the same version) from exposing a torn body.
+pub(crate) fn write_cached_shasums(cache_dir: Option<&Path>, url: &str, body: &str) {
+    let Some(cache_dir) = cache_dir else { return };
+    let Some(path) = shasums_cache_path(cache_dir, url) else { return };
+    let Some(parent) = path.parent() else { return };
+    if fs::create_dir_all(parent).is_err() {
+        return;
+    }
+    let mut temp_name = path.file_name().unwrap_or_default().to_os_string();
+    temp_name.push(format!(".tmp{}", std::process::id()));
+    let temp = path.with_file_name(temp_name);
+    if fs::write(&temp, body).is_ok() && fs::rename(&temp, &path).is_err() {
+        let _ = fs::remove_file(&temp);
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/crypto-shasums-file/src/disk_cache.rs
+++ b/pnpm/crates/crypto-shasums-file/src/disk_cache.rs
@@ -72,9 +72,10 @@ fn encode_path_segment(segment: &str) -> Option<String> {
     Some(encoded)
 }
 
-/// The cached body for `url`, or `None` on any miss — an unmappable
-/// URL, a missing file, unreadable content, or an empty file (never a
-/// valid SHASUMS body, so it only signals a torn write).
+/// The cached body for `url`, or `None` on any miss — a URL the
+/// mapping cannot represent, a missing file, unreadable content, or an
+/// empty file (never a valid SHASUMS body, so it only signals a torn
+/// write).
 pub(crate) fn read_cached_shasums(cache_dir: Option<&Path>, url: &str) -> Option<String> {
     let path = shasums_cache_path(cache_dir?, url)?;
     fs::read_to_string(path).ok().filter(|body| !body.is_empty())

--- a/pnpm/crates/crypto-shasums-file/src/disk_cache.rs
+++ b/pnpm/crates/crypto-shasums-file/src/disk_cache.rs
@@ -66,12 +66,19 @@ pub(crate) fn read_cached_shasums(
     trust: ShasumsTrust,
     url: &str,
 ) -> Option<String> {
+    use std::io::Read as _;
+
     let path = shasums_cache_path(cache_dir?, trust, url)?;
-    let len = fs::metadata(&path).ok()?.len();
-    if len == 0 || len > MAX_CACHED_SHASUMS_LEN {
-        return None;
-    }
-    fs::read_to_string(path).ok().filter(|body| !body.is_empty())
+    // A bounded reader rather than a metadata check keeps the cap
+    // race-free: at most one byte past the bound is ever read,
+    // whatever the file's size becomes between open and read.
+    let mut body = String::new();
+    let bytes_read = fs::File::open(&path)
+        .ok()?
+        .take(MAX_CACHED_SHASUMS_LEN + 1)
+        .read_to_string(&mut body)
+        .ok()?;
+    (bytes_read > 0 && bytes_read as u64 <= MAX_CACHED_SHASUMS_LEN).then_some(body)
 }
 
 /// Best-effort write of `body` for `url`: a cache-write failure only

--- a/pnpm/crates/crypto-shasums-file/src/disk_cache.rs
+++ b/pnpm/crates/crypto-shasums-file/src/disk_cache.rs
@@ -69,15 +69,28 @@ pub(crate) fn read_cached_shasums(
     use std::io::Read as _;
 
     let path = shasums_cache_path(cache_dir?, trust, url)?;
+    let mut options = fs::OpenOptions::new();
+    options.read(true);
+    // A FIFO planted at the entry path would block a plain `open` until
+    // a writer appears; `O_NONBLOCK` makes the open return immediately
+    // and is a no-op for regular files. (Windows directory entries
+    // cannot be named pipes, so the plain open is safe there.)
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.custom_flags(libc::O_NONBLOCK);
+    }
+    let file = options.open(&path).ok()?;
+    // Checked on the opened handle, so nothing can swap the regular
+    // file for a special one between check and read.
+    if !file.metadata().ok()?.is_file() {
+        return None;
+    }
     // A bounded reader rather than a metadata check keeps the cap
     // race-free: at most one byte past the bound is ever read,
     // whatever the file's size becomes between open and read.
     let mut body = String::new();
-    let bytes_read = fs::File::open(&path)
-        .ok()?
-        .take(MAX_CACHED_SHASUMS_LEN + 1)
-        .read_to_string(&mut body)
-        .ok()?;
+    let bytes_read = file.take(MAX_CACHED_SHASUMS_LEN + 1).read_to_string(&mut body).ok()?;
     (bytes_read > 0 && bytes_read as u64 <= MAX_CACHED_SHASUMS_LEN).then_some(body)
 }
 

--- a/pnpm/crates/crypto-shasums-file/src/disk_cache.rs
+++ b/pnpm/crates/crypto-shasums-file/src/disk_cache.rs
@@ -9,13 +9,24 @@
 //! the registry metadata mirror. The layout is shared with pnpm, which
 //! reads and writes the same files.
 //!
-//! Only hand immutable URLs to this cache. A cached body is trusted on
-//! the same terms as the registry metadata mirror: verification (the
-//! `OpenPGP` signature check for signed channels) happens before the
-//! write, not after the read, so a reader never re-verifies. The
-//! `<trust>` path segment keeps signature-verified bodies and
-//! TLS-only bodies in disjoint subtrees, so an unverified fetch can
-//! never seed an entry that a signature-verifying reader would trust.
+//! Only hand immutable URLs to this cache. The cache directory is
+//! *project-configurable* (`cacheDir`), so entries under it must never
+//! carry more authority than the project that could have written them:
+//!
+//! - Signed-channel readers persist the detached signature next to the
+//!   body and re-verify it against the embedded release keys on every
+//!   read (see `fetch_verified_node_shasums_file_cached`), so a
+//!   pre-seeded entry is only accepted if it is a genuine release
+//!   body.
+//! - Unverified entries are trusted on read, which grants a project
+//!   nothing new: the unsigned channels' mirrors are already
+//!   project-configurable (their bodies were project-controllable
+//!   before the cache existed), and the musl list's download URLs are
+//!   derived from the hardcoded unofficial-builds base, never from the
+//!   cached body.
+//!
+//! The `<trust>` path segment keeps the two classes in disjoint
+//! subtrees so their read policies cannot be confused.
 
 use std::{
     fmt::Write as _,
@@ -57,15 +68,24 @@ impl ShasumsTrust {
 /// is never read into memory or written.
 const MAX_CACHED_SHASUMS_LEN: u64 = 1024 * 1024;
 
-/// The cached body for `url`, or `None` on any miss — a URL the
-/// mapping cannot represent, a missing file, unreadable content, an
-/// empty file (never a valid SHASUMS body, so it only signals a torn
-/// write), or a file over [`MAX_CACHED_SHASUMS_LEN`].
+/// The cached body for `url` as UTF-8 text, via [`read_cached_bytes`].
 pub(crate) fn read_cached_shasums(
     cache_dir: Option<&Path>,
     trust: ShasumsTrust,
     url: &str,
 ) -> Option<String> {
+    String::from_utf8(read_cached_bytes(cache_dir, trust, url)?).ok()
+}
+
+/// The cached bytes for `url`, or `None` on any miss — a URL the
+/// mapping cannot represent, a missing or non-regular file, unreadable
+/// content, an empty file (never a valid entry, so it only signals a
+/// torn write), or a file over [`MAX_CACHED_SHASUMS_LEN`].
+pub(crate) fn read_cached_bytes(
+    cache_dir: Option<&Path>,
+    trust: ShasumsTrust,
+    url: &str,
+) -> Option<Vec<u8>> {
     use std::io::Read as _;
 
     let path = shasums_cache_path(cache_dir?, trust, url)?;
@@ -89,8 +109,8 @@ pub(crate) fn read_cached_shasums(
     // A bounded reader rather than a metadata check keeps the cap
     // race-free: at most one byte past the bound is ever read,
     // whatever the file's size becomes between open and read.
-    let mut body = String::new();
-    let bytes_read = file.take(MAX_CACHED_SHASUMS_LEN + 1).read_to_string(&mut body).ok()?;
+    let mut body = Vec::new();
+    let bytes_read = file.take(MAX_CACHED_SHASUMS_LEN + 1).read_to_end(&mut body).ok()?;
     (bytes_read > 0 && bytes_read as u64 <= MAX_CACHED_SHASUMS_LEN).then_some(body)
 }
 
@@ -103,7 +123,7 @@ pub(crate) fn write_cached_shasums(
     cache_dir: Option<&Path>,
     trust: ShasumsTrust,
     url: &str,
-    body: &str,
+    body: &[u8],
 ) {
     let Some(cache_dir) = cache_dir else { return };
     if body.len() as u64 > MAX_CACHED_SHASUMS_LEN {
@@ -133,7 +153,7 @@ pub(crate) fn write_cached_shasums(
     // (missing platform rows) until the cache is cleared.
     let written =
         fs::OpenOptions::new().write(true).create_new(true).open(&temp).and_then(|mut file| {
-            file.write_all(body.as_bytes())?;
+            file.write_all(body)?;
             file.sync_all()
         });
     if written.is_err() || fs::rename(&temp, &path).is_err() {

--- a/pnpm/crates/crypto-shasums-file/src/disk_cache/tests.rs
+++ b/pnpm/crates/crypto-shasums-file/src/disk_cache/tests.rs
@@ -1,0 +1,74 @@
+use std::path::Path;
+
+use pretty_assertions::assert_eq;
+
+use super::{read_cached_shasums, shasums_cache_path, write_cached_shasums};
+
+#[test]
+fn maps_a_shasums_url_under_the_cache_dir() {
+    let path = shasums_cache_path(
+        Path::new("/cache"),
+        "https://nodejs.org/download/release/v22.11.0/SHASUMS256.txt",
+    )
+    .expect("mappable URL");
+    assert_eq!(
+        path,
+        Path::new("/cache/v11/runtime-shasums/nodejs.org/download/release/v22.11.0/SHASUMS256.txt"),
+    );
+}
+
+#[test]
+fn encodes_hosts_ports_and_unusual_segments() {
+    let path = shasums_cache_path(
+        Path::new("/cache"),
+        "http://Mirror.Example.com:8443/Node%20Dist/v22.11.0/SHASUMS256.txt",
+    )
+    .expect("mappable URL");
+    assert_eq!(
+        path,
+        Path::new(
+            "/cache/v11/runtime-shasums/mirror.example.com+8443/Node%2520Dist/v22.11.0/SHASUMS256.txt",
+        ),
+    );
+}
+
+#[test]
+fn rejects_urls_the_mapping_cannot_represent() {
+    let unmappable = [
+        "ftp://nodejs.org/v22.11.0/SHASUMS256.txt",
+        "https://nodejs.org/v22.11.0/SHASUMS256.txt?token=1",
+        "https://nodejs.org/v22.11.0/SHASUMS256.txt#fragment",
+        "https://user@nodejs.org/v22.11.0/SHASUMS256.txt",
+        "https://nodejs.org/v22.11.0/../SHASUMS256.txt",
+        "https://nodejs.org//SHASUMS256.txt",
+        "https://nodejs.org",
+        "https:///v22.11.0/SHASUMS256.txt",
+    ];
+    for url in unmappable {
+        assert_eq!(shasums_cache_path(Path::new("/cache"), url), None, "url={url:?}");
+    }
+}
+
+#[test]
+fn round_trips_a_cached_body() {
+    let cache_dir = tempfile::tempdir().expect("create temp cache dir");
+    let url = "https://nodejs.org/download/release/v22.11.0/SHASUMS256.txt";
+
+    assert_eq!(read_cached_shasums(Some(cache_dir.path()), url), None);
+    write_cached_shasums(Some(cache_dir.path()), url, "abc123  node-v22.11.0-linux-x64.tar.gz\n");
+    assert_eq!(
+        read_cached_shasums(Some(cache_dir.path()), url).as_deref(),
+        Some("abc123  node-v22.11.0-linux-x64.tar.gz\n"),
+    );
+}
+
+/// An empty file can only come from a torn write; it must read as a
+/// miss so the next resolve refetches instead of resolving zero assets.
+#[test]
+fn treats_an_empty_cache_file_as_a_miss() {
+    let cache_dir = tempfile::tempdir().expect("create temp cache dir");
+    let url = "https://nodejs.org/download/release/v22.11.0/SHASUMS256.txt";
+    write_cached_shasums(Some(cache_dir.path()), url, "");
+
+    assert_eq!(read_cached_shasums(Some(cache_dir.path()), url), None);
+}

--- a/pnpm/crates/crypto-shasums-file/src/disk_cache/tests.rs
+++ b/pnpm/crates/crypto-shasums-file/src/disk_cache/tests.rs
@@ -2,18 +2,21 @@ use std::path::Path;
 
 use pretty_assertions::assert_eq;
 
-use super::{read_cached_shasums, shasums_cache_path, write_cached_shasums};
+use super::{ShasumsTrust, read_cached_shasums, shasums_cache_path, write_cached_shasums};
 
 #[test]
 fn maps_a_shasums_url_under_the_cache_dir() {
     let path = shasums_cache_path(
         Path::new("/cache"),
+        ShasumsTrust::Verified,
         "https://nodejs.org/download/release/v22.11.0/SHASUMS256.txt",
     )
     .expect("mappable URL");
     assert_eq!(
         path,
-        Path::new("/cache/v11/runtime-shasums/nodejs.org/download/release/v22.11.0/SHASUMS256.txt"),
+        Path::new(
+            "/cache/v11/runtime-shasums/verified/nodejs.org/download/release/v22.11.0/SHASUMS256.txt",
+        ),
     );
 }
 
@@ -21,13 +24,14 @@ fn maps_a_shasums_url_under_the_cache_dir() {
 fn encodes_hosts_ports_and_unusual_segments() {
     let path = shasums_cache_path(
         Path::new("/cache"),
+        ShasumsTrust::Unverified,
         "http://Mirror.Example.com:8443/Node%20Dist/v22.11.0/SHASUMS256.txt",
     )
     .expect("mappable URL");
     assert_eq!(
         path,
         Path::new(
-            "/cache/v11/runtime-shasums/mirror.example.com+8443/Node%2520Dist/v22.11.0/SHASUMS256.txt",
+            "/cache/v11/runtime-shasums/unverified/mirror.example.com+8443/Node%2520Dist/v22.11.0/SHASUMS256.txt",
         ),
     );
 }
@@ -45,7 +49,11 @@ fn rejects_urls_the_mapping_cannot_represent() {
         "https:///v22.11.0/SHASUMS256.txt",
     ];
     for url in not_representable {
-        assert_eq!(shasums_cache_path(Path::new("/cache"), url), None, "url={url:?}");
+        assert_eq!(
+            shasums_cache_path(Path::new("/cache"), ShasumsTrust::Verified, url),
+            None,
+            "url={url:?}",
+        );
     }
 }
 
@@ -54,11 +62,32 @@ fn round_trips_a_cached_body() {
     let cache_dir = tempfile::tempdir().expect("create temp cache dir");
     let url = "https://nodejs.org/download/release/v22.11.0/SHASUMS256.txt";
 
-    assert_eq!(read_cached_shasums(Some(cache_dir.path()), url), None);
-    write_cached_shasums(Some(cache_dir.path()), url, "abc123  node-v22.11.0-linux-x64.tar.gz\n");
+    assert_eq!(read_cached_shasums(Some(cache_dir.path()), ShasumsTrust::Verified, url), None);
+    write_cached_shasums(
+        Some(cache_dir.path()),
+        ShasumsTrust::Verified,
+        url,
+        "abc123  node-v22.11.0-linux-x64.tar.gz\n",
+    );
     assert_eq!(
-        read_cached_shasums(Some(cache_dir.path()), url).as_deref(),
+        read_cached_shasums(Some(cache_dir.path()), ShasumsTrust::Verified, url).as_deref(),
         Some("abc123  node-v22.11.0-linux-x64.tar.gz\n"),
+    );
+}
+
+/// The two trust classes cache into disjoint subtrees: a body written
+/// by an unverified fetch must never satisfy a reader that expects a
+/// signature-verified body.
+#[test]
+fn trust_classes_do_not_share_entries() {
+    let cache_dir = tempfile::tempdir().expect("create temp cache dir");
+    let url = "https://nodejs.org/download/release/v22.11.0/SHASUMS256.txt";
+    write_cached_shasums(Some(cache_dir.path()), ShasumsTrust::Unverified, url, "unverified body");
+
+    assert_eq!(read_cached_shasums(Some(cache_dir.path()), ShasumsTrust::Verified, url), None);
+    assert_eq!(
+        read_cached_shasums(Some(cache_dir.path()), ShasumsTrust::Unverified, url).as_deref(),
+        Some("unverified body"),
     );
 }
 
@@ -68,7 +97,7 @@ fn round_trips_a_cached_body() {
 fn treats_an_empty_cache_file_as_a_miss() {
     let cache_dir = tempfile::tempdir().expect("create temp cache dir");
     let url = "https://nodejs.org/download/release/v22.11.0/SHASUMS256.txt";
-    write_cached_shasums(Some(cache_dir.path()), url, "");
+    write_cached_shasums(Some(cache_dir.path()), ShasumsTrust::Verified, url, "");
 
-    assert_eq!(read_cached_shasums(Some(cache_dir.path()), url), None);
+    assert_eq!(read_cached_shasums(Some(cache_dir.path()), ShasumsTrust::Verified, url), None);
 }

--- a/pnpm/crates/crypto-shasums-file/src/disk_cache/tests.rs
+++ b/pnpm/crates/crypto-shasums-file/src/disk_cache/tests.rs
@@ -67,7 +67,7 @@ fn round_trips_a_cached_body() {
         Some(cache_dir.path()),
         ShasumsTrust::Verified,
         url,
-        "abc123  node-v22.11.0-linux-x64.tar.gz\n",
+        b"abc123  node-v22.11.0-linux-x64.tar.gz\n",
     );
     assert_eq!(
         read_cached_shasums(Some(cache_dir.path()), ShasumsTrust::Verified, url).as_deref(),
@@ -82,7 +82,7 @@ fn round_trips_a_cached_body() {
 fn trust_classes_do_not_share_entries() {
     let cache_dir = tempfile::tempdir().expect("create temp cache dir");
     let url = "https://nodejs.org/download/release/v22.11.0/SHASUMS256.txt";
-    write_cached_shasums(Some(cache_dir.path()), ShasumsTrust::Unverified, url, "unverified body");
+    write_cached_shasums(Some(cache_dir.path()), ShasumsTrust::Unverified, url, b"unverified body");
 
     assert_eq!(read_cached_shasums(Some(cache_dir.path()), ShasumsTrust::Verified, url), None);
     assert_eq!(
@@ -97,7 +97,7 @@ fn trust_classes_do_not_share_entries() {
 fn treats_an_empty_cache_file_as_a_miss() {
     let cache_dir = tempfile::tempdir().expect("create temp cache dir");
     let url = "https://nodejs.org/download/release/v22.11.0/SHASUMS256.txt";
-    write_cached_shasums(Some(cache_dir.path()), ShasumsTrust::Verified, url, "");
+    write_cached_shasums(Some(cache_dir.path()), ShasumsTrust::Verified, url, b"");
 
     assert_eq!(read_cached_shasums(Some(cache_dir.path()), ShasumsTrust::Verified, url), None);
 }

--- a/pnpm/crates/crypto-shasums-file/src/disk_cache/tests.rs
+++ b/pnpm/crates/crypto-shasums-file/src/disk_cache/tests.rs
@@ -34,7 +34,7 @@ fn encodes_hosts_ports_and_unusual_segments() {
 
 #[test]
 fn rejects_urls_the_mapping_cannot_represent() {
-    let unmappable = [
+    let not_representable = [
         "ftp://nodejs.org/v22.11.0/SHASUMS256.txt",
         "https://nodejs.org/v22.11.0/SHASUMS256.txt?token=1",
         "https://nodejs.org/v22.11.0/SHASUMS256.txt#fragment",
@@ -44,7 +44,7 @@ fn rejects_urls_the_mapping_cannot_represent() {
         "https://nodejs.org",
         "https:///v22.11.0/SHASUMS256.txt",
     ];
-    for url in unmappable {
+    for url in not_representable {
         assert_eq!(shasums_cache_path(Path::new("/cache"), url), None, "url={url:?}");
     }
 }

--- a/pnpm/crates/crypto-shasums-file/src/lib.rs
+++ b/pnpm/crates/crypto-shasums-file/src/lib.rs
@@ -31,7 +31,7 @@ use pgp::{
     types::KeyDetails,
 };
 
-use disk_cache::{ShasumsTrust, read_cached_shasums, write_cached_shasums};
+use disk_cache::{ShasumsTrust, read_cached_bytes, read_cached_shasums, write_cached_shasums};
 use node_release_keys::{NODE_RELEASE_KEYS, NodeReleaseKey};
 
 pub use disk_cache::RUNTIME_SHASUMS_CACHE_DIR;
@@ -175,6 +175,18 @@ pub async fn fetch_verified_node_shasums(
     http_client: &ThrottledClient,
     shasums_url: &str,
 ) -> Result<String, FetchVerifiedNodeShasumsError> {
+    let (body, _signature) =
+        fetch_verified_node_shasums_with_signature(http_client, shasums_url).await?;
+    Ok(body)
+}
+
+/// [`fetch_verified_node_shasums`], additionally returning the verified
+/// detached signature so the disk cache can persist it as the entry's
+/// verification evidence.
+async fn fetch_verified_node_shasums_with_signature(
+    http_client: &ThrottledClient,
+    shasums_url: &str,
+) -> Result<(String, Vec<u8>), FetchVerifiedNodeShasumsError> {
     let shasums_bytes =
         fetch_node_shasums_bytes(http_client, shasums_url, "SHASUMS256.txt").await?;
     let signature_url = format!("{shasums_url}.sig");
@@ -187,10 +199,13 @@ pub async fn fetch_verified_node_shasums(
         });
     }
 
-    String::from_utf8(shasums_bytes).map_err(|error| FetchVerifiedNodeShasumsError::InvalidUtf8 {
-        url: shasums_url.to_string(),
-        error: Arc::new(error),
-    })
+    let body = String::from_utf8(shasums_bytes).map_err(|error| {
+        FetchVerifiedNodeShasumsError::InvalidUtf8 {
+            url: shasums_url.to_string(),
+            error: Arc::new(error),
+        }
+    })?;
+    Ok((body, signature_bytes))
 }
 
 /// Like [`fetch_shasums_file`], but first verifies the SHASUMS file's
@@ -203,21 +218,30 @@ pub async fn fetch_verified_node_shasums_file(
 }
 
 /// Like [`fetch_verified_node_shasums_file`], backed by the disk cache
-/// when `cache_dir` is given: a body cached by an earlier resolve is
-/// served without network access or signature re-verification, and a
-/// freshly fetched body is cached only after its signature checks out.
-/// `shasums_url` must be version-pinned — a mutable URL must never be
-/// handed to the cache.
+/// when `cache_dir` is given. The cache stores the body together with
+/// its detached signature, and a cache hit re-verifies that signature
+/// against the embedded release keys: the cache directory is
+/// project-configurable, so a pre-seeded entry must prove it is a
+/// genuine release body before it is served. Any verification failure
+/// is a miss and the pair is refetched. `shasums_url` must be
+/// version-pinned — a mutable URL must never be handed to the cache.
 pub async fn fetch_verified_node_shasums_file_cached(
     http_client: &ThrottledClient,
     shasums_url: &str,
     cache_dir: Option<&Path>,
 ) -> Result<Vec<ShasumsFileItem>, FetchVerifiedNodeShasumsError> {
-    if let Some(body) = read_cached_shasums(cache_dir, ShasumsTrust::Verified, shasums_url) {
+    let signature_url = format!("{shasums_url}.sig");
+    if let Some(body) = read_cached_shasums(cache_dir, ShasumsTrust::Verified, shasums_url)
+        && let Some(signature) =
+            read_cached_bytes(cache_dir, ShasumsTrust::Verified, &signature_url)
+        && is_signed_by_trusted_node_release_key(body.as_bytes(), &signature).unwrap_or(false)
+    {
         return Ok(parse_shasums_file(&body));
     }
-    let body = fetch_verified_node_shasums(http_client, shasums_url).await?;
-    write_cached_shasums(cache_dir, ShasumsTrust::Verified, shasums_url, &body);
+    let (body, signature) =
+        fetch_verified_node_shasums_with_signature(http_client, shasums_url).await?;
+    write_cached_shasums(cache_dir, ShasumsTrust::Verified, shasums_url, body.as_bytes());
+    write_cached_shasums(cache_dir, ShasumsTrust::Verified, &signature_url, &signature);
     Ok(parse_shasums_file(&body))
 }
 
@@ -235,7 +259,7 @@ pub async fn fetch_shasums_file_cached(
         return Ok(parse_shasums_file(&body));
     }
     let body = fetch_shasums_file_raw(http_client, shasums_url).await?;
-    write_cached_shasums(cache_dir, ShasumsTrust::Unverified, shasums_url, &body);
+    write_cached_shasums(cache_dir, ShasumsTrust::Unverified, shasums_url, body.as_bytes());
     Ok(parse_shasums_file(&body))
 }
 

--- a/pnpm/crates/crypto-shasums-file/src/lib.rs
+++ b/pnpm/crates/crypto-shasums-file/src/lib.rs
@@ -31,7 +31,7 @@ use pgp::{
     types::KeyDetails,
 };
 
-use disk_cache::{read_cached_shasums, write_cached_shasums};
+use disk_cache::{ShasumsTrust, read_cached_shasums, write_cached_shasums};
 use node_release_keys::{NODE_RELEASE_KEYS, NodeReleaseKey};
 
 pub use disk_cache::RUNTIME_SHASUMS_CACHE_DIR;
@@ -213,11 +213,11 @@ pub async fn fetch_verified_node_shasums_file_cached(
     shasums_url: &str,
     cache_dir: Option<&Path>,
 ) -> Result<Vec<ShasumsFileItem>, FetchVerifiedNodeShasumsError> {
-    if let Some(body) = read_cached_shasums(cache_dir, shasums_url) {
+    if let Some(body) = read_cached_shasums(cache_dir, ShasumsTrust::Verified, shasums_url) {
         return Ok(parse_shasums_file(&body));
     }
     let body = fetch_verified_node_shasums(http_client, shasums_url).await?;
-    write_cached_shasums(cache_dir, shasums_url, &body);
+    write_cached_shasums(cache_dir, ShasumsTrust::Verified, shasums_url, &body);
     Ok(parse_shasums_file(&body))
 }
 
@@ -231,11 +231,11 @@ pub async fn fetch_shasums_file_cached(
     shasums_url: &str,
     cache_dir: Option<&Path>,
 ) -> Result<Vec<ShasumsFileItem>, FetchShasumsFileError> {
-    if let Some(body) = read_cached_shasums(cache_dir, shasums_url) {
+    if let Some(body) = read_cached_shasums(cache_dir, ShasumsTrust::Unverified, shasums_url) {
         return Ok(parse_shasums_file(&body));
     }
     let body = fetch_shasums_file_raw(http_client, shasums_url).await?;
-    write_cached_shasums(cache_dir, shasums_url, &body);
+    write_cached_shasums(cache_dir, ShasumsTrust::Unverified, shasums_url, &body);
     Ok(parse_shasums_file(&body))
 }
 

--- a/pnpm/crates/crypto-shasums-file/src/lib.rs
+++ b/pnpm/crates/crypto-shasums-file/src/lib.rs
@@ -17,9 +17,10 @@
 //!   downloaded body to extract the integrity of a single file. The
 //!   verifier path uses it when only one variant's hash is needed.
 
+mod disk_cache;
 mod node_release_keys;
 
-use std::{io::Cursor, string::FromUtf8Error, sync::Arc};
+use std::{io::Cursor, path::Path, string::FromUtf8Error, sync::Arc};
 
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use derive_more::{Display, Error};
@@ -30,7 +31,10 @@ use pgp::{
     types::KeyDetails,
 };
 
+use disk_cache::{read_cached_shasums, write_cached_shasums};
 use node_release_keys::{NODE_RELEASE_KEYS, NodeReleaseKey};
+
+pub use disk_cache::RUNTIME_SHASUMS_CACHE_DIR;
 
 /// One row parsed out of a `SHASUMS256.txt` body.
 ///
@@ -195,7 +199,43 @@ pub async fn fetch_verified_node_shasums_file(
     http_client: &ThrottledClient,
     shasums_url: &str,
 ) -> Result<Vec<ShasumsFileItem>, FetchVerifiedNodeShasumsError> {
+    fetch_verified_node_shasums_file_cached(http_client, shasums_url, None).await
+}
+
+/// Like [`fetch_verified_node_shasums_file`], backed by the disk cache
+/// when `cache_dir` is given: a body cached by an earlier resolve is
+/// served without network access or signature re-verification, and a
+/// freshly fetched body is cached only after its signature checks out.
+/// `shasums_url` must be version-pinned — a mutable URL must never be
+/// handed to the cache.
+pub async fn fetch_verified_node_shasums_file_cached(
+    http_client: &ThrottledClient,
+    shasums_url: &str,
+    cache_dir: Option<&Path>,
+) -> Result<Vec<ShasumsFileItem>, FetchVerifiedNodeShasumsError> {
+    if let Some(body) = read_cached_shasums(cache_dir, shasums_url) {
+        return Ok(parse_shasums_file(&body));
+    }
     let body = fetch_verified_node_shasums(http_client, shasums_url).await?;
+    write_cached_shasums(cache_dir, shasums_url, &body);
+    Ok(parse_shasums_file(&body))
+}
+
+/// Like [`fetch_shasums_file`], backed by the disk cache when
+/// `cache_dir` is given. For mirrors whose SHASUMS files carry no
+/// verifiable signature the cached body is trusted exactly as far as
+/// the TLS fetch that produced it. `shasums_url` must be
+/// version-pinned — a mutable URL must never be handed to the cache.
+pub async fn fetch_shasums_file_cached(
+    http_client: &ThrottledClient,
+    shasums_url: &str,
+    cache_dir: Option<&Path>,
+) -> Result<Vec<ShasumsFileItem>, FetchShasumsFileError> {
+    if let Some(body) = read_cached_shasums(cache_dir, shasums_url) {
+        return Ok(parse_shasums_file(&body));
+    }
+    let body = fetch_shasums_file_raw(http_client, shasums_url).await?;
+    write_cached_shasums(cache_dir, shasums_url, &body);
     Ok(parse_shasums_file(&body))
 }
 

--- a/pnpm/crates/crypto-shasums-file/src/tests.rs
+++ b/pnpm/crates/crypto-shasums-file/src/tests.rs
@@ -2,8 +2,9 @@ use pretty_assertions::assert_eq;
 
 use super::{
     FetchVerifiedNodeShasumsError, PickFileChecksumError, ShasumsFileItem,
-    fetch_verified_node_shasums, is_signed_by_trusted_node_release_key, parse_shasums_file,
-    pick_file_checksum_from_shasums_file,
+    fetch_shasums_file_cached, fetch_verified_node_shasums,
+    fetch_verified_node_shasums_file_cached, is_signed_by_trusted_node_release_key,
+    parse_shasums_file, pick_file_checksum_from_shasums_file,
 };
 
 #[test]
@@ -141,6 +142,98 @@ async fn missing_node_shasums_signature_fails() {
         err,
         FetchVerifiedNodeShasumsError::StatusNotOk { what: "SHASUMS256.txt.sig", status: 404, .. },
     ));
+}
+
+/// The second fetch must be served from the cache: the mocks expect
+/// exactly one hit each, and signature verification is not repeated
+/// (the cache stores only bodies that already verified).
+#[tokio::test]
+async fn verified_fetch_caches_the_body_after_verification() {
+    let mut server = mockito::Server::new_async().await;
+    let shasums = server
+        .mock("GET", "/download/release/v22.11.0/SHASUMS256.txt")
+        .with_status(200)
+        .with_body(NODE_22_11_0_SHASUMS)
+        .expect(1)
+        .create_async()
+        .await;
+    let signature = server
+        .mock("GET", "/download/release/v22.11.0/SHASUMS256.txt.sig")
+        .with_status(200)
+        .with_body(node_22_11_0_signature())
+        .expect(1)
+        .create_async()
+        .await;
+    let cache_dir = tempfile::tempdir().expect("create temp cache dir");
+    let client = pacquet_network::ThrottledClient::new_for_installs();
+    let url = format!("{}/download/release/v22.11.0/SHASUMS256.txt", server.url());
+
+    let fetched = fetch_verified_node_shasums_file_cached(&client, &url, Some(cache_dir.path()))
+        .await
+        .expect("fetch and verify");
+    let cached = fetch_verified_node_shasums_file_cached(&client, &url, Some(cache_dir.path()))
+        .await
+        .expect("serve from cache");
+
+    assert_eq!(fetched, cached);
+    shasums.assert_async().await;
+    signature.assert_async().await;
+}
+
+/// A body that fails signature verification must not be cached: the
+/// retry after the failure still refetches.
+#[tokio::test]
+async fn verified_fetch_does_not_cache_an_unverified_body() {
+    let mut server = mockito::Server::new_async().await;
+    let _shasums = server
+        .mock("GET", "/download/release/v22.11.0/SHASUMS256.txt")
+        .with_status(200)
+        .with_body(NODE_22_11_0_SHASUMS)
+        .expect(2)
+        .create_async()
+        .await;
+    let signature = server
+        .mock("GET", "/download/release/v22.11.0/SHASUMS256.txt.sig")
+        .with_status(404)
+        .expect(2)
+        .create_async()
+        .await;
+    let cache_dir = tempfile::tempdir().expect("create temp cache dir");
+    let client = pacquet_network::ThrottledClient::new_for_installs();
+    let url = format!("{}/download/release/v22.11.0/SHASUMS256.txt", server.url());
+
+    for _ in 0..2 {
+        fetch_verified_node_shasums_file_cached(&client, &url, Some(cache_dir.path()))
+            .await
+            .expect_err("missing signature must fail");
+    }
+    signature.assert_async().await;
+}
+
+#[tokio::test]
+async fn plain_fetch_caches_the_body() {
+    let mut server = mockito::Server::new_async().await;
+    let shasums = server
+        .mock("GET", "/download/v1.2.3/SHASUMS256.txt")
+        .with_status(200)
+        .with_body("ed52239294ad517fbe91a268146d5d2aa8a17d2d62d64873e43219078ba71c4e  foo.tar.gz\n")
+        .expect(1)
+        .create_async()
+        .await;
+    let cache_dir = tempfile::tempdir().expect("create temp cache dir");
+    let client = pacquet_network::ThrottledClient::new_for_installs();
+    let url = format!("{}/download/v1.2.3/SHASUMS256.txt", server.url());
+
+    let fetched = fetch_shasums_file_cached(&client, &url, Some(cache_dir.path()))
+        .await
+        .expect("fetch the body");
+    let cached = fetch_shasums_file_cached(&client, &url, Some(cache_dir.path()))
+        .await
+        .expect("serve from cache");
+
+    assert_eq!(fetched, cached);
+    assert_eq!(fetched.len(), 1);
+    shasums.assert_async().await;
 }
 
 fn node_22_11_0_signature() -> Vec<u8> {

--- a/pnpm/crates/crypto-shasums-file/src/tests.rs
+++ b/pnpm/crates/crypto-shasums-file/src/tests.rs
@@ -145,8 +145,8 @@ async fn missing_node_shasums_signature_fails() {
 }
 
 /// The second fetch must be served from the cache: the mocks expect
-/// exactly one hit each, and signature verification is not repeated
-/// (the cache stores only bodies that already verified).
+/// exactly one hit each. The persisted signature is re-verified on the
+/// cached read.
 #[tokio::test]
 async fn verified_fetch_caches_the_body_after_verification() {
     let mut server = mockito::Server::new_async().await;
@@ -234,6 +234,58 @@ async fn plain_fetch_caches_the_body() {
     assert_eq!(fetched, cached);
     assert_eq!(fetched.len(), 1);
     shasums.assert_async().await;
+}
+
+/// A pre-seeded verified entry whose persisted signature does not
+/// verify is a miss: the cache directory is project-configurable, so a
+/// verified hit must prove itself against the release keys on every
+/// read. The refetched genuine pair then replaces the seeded one.
+#[tokio::test]
+async fn seeded_verified_cache_without_valid_signature_is_refetched() {
+    use crate::disk_cache::{ShasumsTrust, write_cached_shasums};
+
+    let mut server = mockito::Server::new_async().await;
+    let shasums = server
+        .mock("GET", "/download/release/v22.11.0/SHASUMS256.txt")
+        .with_status(200)
+        .with_body(NODE_22_11_0_SHASUMS)
+        .expect(1)
+        .create_async()
+        .await;
+    let signature = server
+        .mock("GET", "/download/release/v22.11.0/SHASUMS256.txt.sig")
+        .with_status(200)
+        .with_body(node_22_11_0_signature())
+        .expect(1)
+        .create_async()
+        .await;
+    let cache_dir = tempfile::tempdir().expect("create temp cache dir");
+    let client = pacquet_network::ThrottledClient::new_for_installs();
+    let url = format!("{}/download/release/v22.11.0/SHASUMS256.txt", server.url());
+    write_cached_shasums(
+        Some(cache_dir.path()),
+        ShasumsTrust::Verified,
+        &url,
+        b"0000000000000000000000000000000000000000000000000000000000000000  node-v22.11.0-linux-x64.tar.gz\n",
+    );
+    write_cached_shasums(
+        Some(cache_dir.path()),
+        ShasumsTrust::Verified,
+        &format!("{url}.sig"),
+        b"not a signature",
+    );
+
+    let refetched = fetch_verified_node_shasums_file_cached(&client, &url, Some(cache_dir.path()))
+        .await
+        .expect("seeded entry rejected, genuine pair fetched");
+    let cached = fetch_verified_node_shasums_file_cached(&client, &url, Some(cache_dir.path()))
+        .await
+        .expect("genuine pair now serves from the cache");
+
+    assert_eq!(refetched, cached);
+    assert!(refetched.iter().any(|item| item.file_name == "node-v22.11.0-linux-x64.tar.gz"));
+    shasums.assert_async().await;
+    signature.assert_async().await;
 }
 
 fn node_22_11_0_signature() -> Vec<u8> {

--- a/pnpm/crates/engine-runtime-node-resolver/Cargo.toml
+++ b/pnpm/crates/engine-runtime-node-resolver/Cargo.toml
@@ -28,6 +28,7 @@ tokio       = { workspace = true }
 [dev-dependencies]
 mockito           = { workspace = true }
 pretty_assertions = { workspace = true }
+tempfile          = { workspace = true }
 tokio             = { workspace = true, features = ["macros", "rt"] }
 
 [lints]

--- a/pnpm/crates/engine-runtime-node-resolver/src/node_resolver.rs
+++ b/pnpm/crates/engine-runtime-node-resolver/src/node_resolver.rs
@@ -8,6 +8,7 @@
 
 use std::{
     collections::{BTreeMap, HashMap},
+    path::{Path, PathBuf},
     sync::Arc,
 };
 
@@ -15,8 +16,8 @@ use derive_more::{Display, Error};
 use miette::Diagnostic;
 use node_semver::Version;
 use pacquet_crypto_shasums_file::{
-    FetchShasumsFileError, FetchVerifiedNodeShasumsError, fetch_shasums_file,
-    fetch_verified_node_shasums_file,
+    FetchShasumsFileError, FetchVerifiedNodeShasumsError, fetch_shasums_file_cached,
+    fetch_verified_node_shasums_file_cached,
 };
 use pacquet_lockfile::{
     BinaryArchive, BinaryResolution, BinarySpec, LockfileResolution, PlatformAssetResolution,
@@ -34,7 +35,7 @@ use crate::{
     get_node_mirror::{
         DEFAULT_NODE_MIRROR_BASE_URL, UNOFFICIAL_NODE_MIRROR_BASE_URL, get_node_mirror,
     },
-    parse_node_specifier::{ParseNodeSpecifierError, parse_node_specifier},
+    parse_node_specifier::{NodeSpecifier, ParseNodeSpecifierError, parse_node_specifier},
     resolve_node_version::{ResolveNodeVersionError, resolve_node_version},
 };
 
@@ -94,12 +95,16 @@ pub struct NodeResolver {
     pub http_client: Arc<ThrottledClient>,
     pub node_download_mirrors: HashMap<String, String>,
     pub offline: bool,
+    /// The pnpm cache directory backing the per-version SHASUMS disk
+    /// cache. `None` disables the cache and every resolve fetches the
+    /// asset lists from the mirror.
+    pub cache_dir: Option<PathBuf>,
 }
 
 impl NodeResolver {
     #[must_use]
     pub fn new(http_client: Arc<ThrottledClient>) -> Self {
-        Self { http_client, node_download_mirrors: HashMap::new(), offline: false }
+        Self { http_client, node_download_mirrors: HashMap::new(), offline: false, cache_dir: None }
     }
 }
 
@@ -138,11 +143,39 @@ impl NodeResolver {
         // resolve re-fetches the asset list. Add the fast path once the
         // seam carries it.
 
-        let PickedNodeVersion { version, mirror, release_channel } = self
+        let picked = self
             .pick_node_version(version_spec)
             .await
             .map_err(|err| Box::new(err) as ResolveError)?;
-        let variants = self.read_node_assets(&mirror, &version, &release_channel).await?;
+        let variants = match self
+            .read_node_assets(&picked.mirror, &picked.version, &picked.release_channel)
+            .await
+        {
+            Ok(variants) => variants,
+            // An exact-specifier pick skipped the release index, so a
+            // failed asset read is ambiguous: the version may simply not
+            // exist. Consult the index now, purely to raise the same
+            // `ERR_PNPM_NODEJS_VERSION_NOT_FOUND` the index-first path
+            // raises for a nonexistent version; any other outcome
+            // re-raises the asset error unchanged.
+            Err(error) if picked.resolved_without_index => {
+                let error = match resolve_node_version(
+                    &self.http_client,
+                    &picked.version,
+                    Some(&picked.mirror),
+                )
+                .await
+                {
+                    Ok(None) => {
+                        NodeResolverError::VersionNotFound { spec: version_spec.to_string() }
+                    }
+                    _ => error,
+                };
+                return Err(Box::new(error));
+            }
+            Err(error) => return Err(Box::new(error)),
+        };
+        let PickedNodeVersion { version, .. } = picked;
         let range = normalize_node_runtime_version_specifier(
             version_spec,
             &version,
@@ -170,6 +203,12 @@ impl NodeResolver {
 
     /// Parse a `runtime:` version spec, pick the mirror for its release
     /// channel, and resolve the spec to a concrete version.
+    ///
+    /// An exact stable-release specifier is its own resolution, so the
+    /// release-index fetch is skipped for it and existence is proven by
+    /// the asset-list fetch that follows —
+    /// [`resolve_impl`](Self::resolve_impl) maps that fetch's failure
+    /// back to the canonical not-found error.
     async fn pick_node_version(
         &self,
         version_spec: &str,
@@ -180,6 +219,14 @@ impl NodeResolver {
         let parsed =
             parse_node_specifier(version_spec).map_err(NodeResolverError::InvalidReleaseChannel)?;
         let mirror = get_node_mirror(Some(&self.node_download_mirrors), &parsed.release_channel);
+        if let Some(version) = exact_release_version(&parsed) {
+            return Ok(PickedNodeVersion {
+                version,
+                mirror,
+                release_channel: parsed.release_channel,
+                resolved_without_index: true,
+            });
+        }
         let version =
             resolve_node_version(&self.http_client, &parsed.version_specifier, Some(&mirror))
                 .await
@@ -187,7 +234,12 @@ impl NodeResolver {
                 .ok_or_else(|| NodeResolverError::VersionNotFound {
                     spec: version_spec.to_string(),
                 })?;
-        Ok(PickedNodeVersion { version, mirror, release_channel: parsed.release_channel })
+        Ok(PickedNodeVersion {
+            version,
+            mirror,
+            release_channel: parsed.release_channel,
+            resolved_without_index: false,
+        })
     }
 
     /// The specifier an `add node@runtime:<spec>` request saves to the
@@ -201,6 +253,16 @@ impl NodeResolver {
         version_spec: &str,
         prev_specifier: Option<&str>,
     ) -> Result<String, NodeResolverError> {
+        // An exact stable-release specifier normalizes to itself
+        // (`normalize_node_runtime_version_specifier` returns the
+        // resolved version verbatim when it equals the spec), so no
+        // version pick is needed. Whether the version exists is settled
+        // by the resolve that follows the save.
+        let parsed =
+            parse_node_specifier(version_spec).map_err(NodeResolverError::InvalidReleaseChannel)?;
+        if let Some(version) = exact_release_version(&parsed) {
+            return Ok(format!("{BARE_SPEC_PREFIX}{version}"));
+        }
         let picked = self.pick_node_version(version_spec).await?;
         let range =
             normalize_node_runtime_version_specifier(version_spec, &picked.version, prev_specifier);
@@ -256,13 +318,14 @@ impl NodeResolver {
         mirror: &str,
         version: &str,
         release_channel: &str,
-    ) -> Result<Vec<PlatformAssetResolution>, ResolveError> {
+    ) -> Result<Vec<PlatformAssetResolution>, NodeResolverError> {
         let mut assets = read_node_assets_from_mirror(
             &self.http_client,
             mirror,
             version,
             /* musl_only */ false,
             /* verify_signature */ release_channel == "release",
+            self.cache_dir.as_deref(),
         )
         .await?;
         if mirror == DEFAULT_NODE_MIRROR_BASE_URL
@@ -272,6 +335,7 @@ impl NodeResolver {
                 version,
                 /* musl_only */ true,
                 /* verify_signature */ false,
+                self.cache_dir.as_deref(),
             )
             .await
         {
@@ -281,12 +345,33 @@ impl NodeResolver {
     }
 }
 
+/// The concrete version an exact stable-release specifier names, when
+/// the specifier is already in canonical `X.Y.Z` form. Such a specifier
+/// needs no release-index lookup: the index would resolve it to itself.
+/// Prereleases are excluded — on the `release` channel they never
+/// exist, so routing them through the index keeps the canonical
+/// not-found error path.
+fn exact_release_version(parsed: &NodeSpecifier) -> Option<String> {
+    if parsed.release_channel != "release" {
+        return None;
+    }
+    Version::parse(&parsed.version_specifier)
+        .ok()
+        .filter(|version| version.pre_release.is_empty() && version.build.is_empty())
+        .map(|version| version.to_string())
+        .filter(|version| *version == parsed.version_specifier)
+}
+
 /// A concrete Node.js version picked for a `runtime:` version spec, plus
 /// the mirror and release channel it was picked from.
 struct PickedNodeVersion {
     version: String,
     mirror: String,
     release_channel: String,
+    /// `true` when the pick came from
+    /// [`exact_release_version`] — the release index was never
+    /// consulted, so the version's existence is still unproven.
+    resolved_without_index: bool,
 }
 
 /// Strip `runtime:` from a `(alias, bareSpecifier)` pair when both
@@ -338,16 +423,19 @@ async fn read_node_assets_from_mirror(
     version: &str,
     musl_only: bool,
     verify_signature: bool,
-) -> Result<Vec<PlatformAssetResolution>, ResolveError> {
+    cache_dir: Option<&Path>,
+) -> Result<Vec<PlatformAssetResolution>, NodeResolverError> {
+    // The URL is pinned to one released version, which is what makes it
+    // eligible for the SHASUMS disk cache.
     let integrities_url = format!("{node_mirror_base_url}v{version}/SHASUMS256.txt");
     let items = if verify_signature {
-        fetch_verified_node_shasums_file(http_client, &integrities_url).await.map_err(|err| {
-            Box::new(NodeResolverError::FetchVerifiedNodeShasums(err)) as ResolveError
-        })?
-    } else {
-        fetch_shasums_file(http_client, &integrities_url)
+        fetch_verified_node_shasums_file_cached(http_client, &integrities_url, cache_dir)
             .await
-            .map_err(|err| Box::new(NodeResolverError::FetchShasumsFile(err)) as ResolveError)?
+            .map_err(NodeResolverError::FetchVerifiedNodeShasums)?
+    } else {
+        fetch_shasums_file_cached(http_client, &integrities_url, cache_dir)
+            .await
+            .map_err(NodeResolverError::FetchShasumsFile)?
     };
     let mut assets = Vec::new();
     for item in items {
@@ -371,13 +459,12 @@ async fn read_node_assets_from_mirror(
         let url = format!("{}/{}{}", address.dirname, address.basename, address.extname);
         let archive =
             if address.extname == ".zip" { BinaryArchive::Zip } else { BinaryArchive::Tarball };
-        let integrity: Integrity = item.integrity.parse().map_err(|error| {
-            Box::new(NodeResolverError::ParseIntegrity {
+        let integrity: Integrity =
+            item.integrity.parse().map_err(|error| NodeResolverError::ParseIntegrity {
                 integrity: item.integrity.clone(),
                 file_name: item.file_name.clone(),
                 error: Arc::new(error),
-            }) as ResolveError
-        })?;
+            })?;
         let prefix = matches!(archive, BinaryArchive::Zip).then(|| address.basename.clone());
         let binary = BinaryResolution {
             url,

--- a/pnpm/crates/engine-runtime-node-resolver/src/node_resolver/tests.rs
+++ b/pnpm/crates/engine-runtime-node-resolver/src/node_resolver/tests.rs
@@ -5,8 +5,9 @@ use pacquet_resolving_resolver_base::{ResolveOptions, Resolver, WantedDependency
 use pretty_assertions::assert_eq;
 
 use super::{
-    NodeResolver, NodeResolverError, bin_spec_for_platform,
-    normalize_node_runtime_version_specifier, parse_node_file_name, read_node_assets_from_mirror,
+    NodeResolver, NodeResolverError, bin_spec_for_platform, exact_release_version,
+    normalize_node_runtime_version_specifier, parse_node_file_name, parse_node_specifier,
+    read_node_assets_from_mirror,
 };
 
 fn resolver() -> NodeResolver {
@@ -197,10 +198,10 @@ async fn release_asset_reader_requires_signature_when_requested() {
         "22.11.0",
         false,
         true,
+        None,
     )
     .await
     .expect_err("stable release assets must require a SHASUMS signature");
-    let err = err.downcast_ref::<NodeResolverError>().expect("NodeResolverError");
 
     assert!(matches!(err, NodeResolverError::FetchVerifiedNodeShasums(_)));
 }
@@ -220,11 +221,153 @@ async fn prerelease_asset_reader_does_not_require_signature() {
         "22.11.0",
         false,
         false,
+        None,
     )
     .await
     .expect("unsigned channels use the raw SHASUMS file");
 
     assert_eq!(assets.len(), 1);
+}
+
+#[test]
+fn exact_release_versions_are_their_own_resolution() {
+    let exact = |specifier: &str| {
+        exact_release_version(&parse_node_specifier(specifier).expect("valid specifier"))
+    };
+    assert_eq!(exact("22.11.0").as_deref(), Some("22.11.0"));
+    assert_eq!(exact("release/22.11.0").as_deref(), Some("22.11.0"));
+    assert_eq!(exact("^22.11.0"), None);
+    assert_eq!(exact("22.11"), None);
+    assert_eq!(exact("v22.11.0"), None);
+    assert_eq!(exact("22.11.0-rc.1"), None);
+    assert_eq!(exact("rc/22.11.0"), None);
+    assert_eq!(exact("latest"), None);
+    assert_eq!(exact("lts"), None);
+}
+
+/// An exact stable version is saved verbatim without consulting the
+/// release index: the mirror here is unroutable, so any network access
+/// would fail the call.
+#[tokio::test]
+async fn resolve_save_specifier_saves_an_exact_version_without_network() {
+    let mut resolver = resolver();
+    resolver
+        .node_download_mirrors
+        .insert("release".to_string(), "http://127.0.0.1:9/download/release/".to_string());
+
+    assert_eq!(resolver.resolve_save_specifier("22.11.0", None).await.unwrap(), "runtime:22.11.0",);
+}
+
+/// An exact-version resolve skips the release index, so a nonexistent
+/// version first fails its asset fetch; the resolver must then consult
+/// the index and raise the canonical not-found error rather than the
+/// raw fetch failure.
+#[tokio::test]
+async fn exact_resolve_of_a_nonexistent_version_raises_version_not_found() {
+    let mut server = mockito::Server::new_async().await;
+    let _shasums = server
+        .mock("GET", "/download/release/v22.99.0/SHASUMS256.txt")
+        .with_status(404)
+        .create_async()
+        .await;
+    let index = server
+        .mock("GET", "/download/release/index.json")
+        .with_status(200)
+        .with_body(r#"[{"version": "v22.11.0", "lts": false}]"#)
+        .expect(1)
+        .create_async()
+        .await;
+    let mut resolver = resolver();
+    resolver
+        .node_download_mirrors
+        .insert("release".to_string(), format!("{}/download/release/", server.url()));
+    let wanted = WantedDependency {
+        alias: Some("node".to_string()),
+        bare_specifier: Some("runtime:22.99.0".to_string()),
+        ..WantedDependency::default()
+    };
+
+    let err = resolver.resolve(&wanted, &ResolveOptions::default()).await.unwrap_err();
+    let code: &dyn miette::Diagnostic =
+        err.downcast_ref::<NodeResolverError>().expect("error is a NodeResolverError");
+    assert_eq!(
+        code.code().map(|code| code.to_string()).as_deref(),
+        Some("ERR_PNPM_NODEJS_VERSION_NOT_FOUND"),
+    );
+    index.assert_async().await;
+}
+
+/// When the index confirms the exact version exists, the asset-fetch
+/// failure is the real error and must surface unchanged.
+#[tokio::test]
+async fn exact_resolve_keeps_the_asset_error_when_the_version_exists() {
+    let mut server = mockito::Server::new_async().await;
+    let _shasums = server
+        .mock("GET", "/download/release/v22.11.0/SHASUMS256.txt")
+        .with_status(500)
+        .create_async()
+        .await;
+    let _index = server
+        .mock("GET", "/download/release/index.json")
+        .with_status(200)
+        .with_body(r#"[{"version": "v22.11.0", "lts": false}]"#)
+        .create_async()
+        .await;
+    let mut resolver = resolver();
+    resolver
+        .node_download_mirrors
+        .insert("release".to_string(), format!("{}/download/release/", server.url()));
+    let wanted = WantedDependency {
+        alias: Some("node".to_string()),
+        bare_specifier: Some("runtime:22.11.0".to_string()),
+        ..WantedDependency::default()
+    };
+
+    let err = resolver.resolve(&wanted, &ResolveOptions::default()).await.unwrap_err();
+    let err = err.downcast_ref::<NodeResolverError>().expect("error is a NodeResolverError");
+    assert!(matches!(err, NodeResolverError::FetchVerifiedNodeShasums(_)));
+}
+
+/// A SHASUMS body cached by an earlier resolve serves the next one
+/// without any network access: the mock expects exactly one hit.
+#[tokio::test]
+async fn asset_reader_serves_repeat_reads_from_the_cache() {
+    let mut server = mockito::Server::new_async().await;
+    let shasums = server
+        .mock("GET", "/download/rc/v22.11.0/SHASUMS256.txt")
+        .with_status(200)
+        .with_body(SHASUMS_WITH_ONE_NODE_ASSET)
+        .expect(1)
+        .create_async()
+        .await;
+    let cache_dir = tempfile::tempdir().expect("create temp cache dir");
+    let client = ThrottledClient::new_for_installs();
+    let mirror = format!("{}/download/rc/", server.url());
+
+    let fetched = read_node_assets_from_mirror(
+        &client,
+        &mirror,
+        "22.11.0",
+        false,
+        false,
+        Some(cache_dir.path()),
+    )
+    .await
+    .expect("fetch the asset list");
+    let cached = read_node_assets_from_mirror(
+        &client,
+        &mirror,
+        "22.11.0",
+        false,
+        false,
+        Some(cache_dir.path()),
+    )
+    .await
+    .expect("serve the asset list from the cache");
+
+    assert_eq!(fetched.len(), 1);
+    assert_eq!(cached.len(), 1);
+    shasums.assert_async().await;
 }
 
 const SHASUMS_WITH_ONE_NODE_ASSET: &str = "\

--- a/pnpm/crates/engine-runtime-node-resolver/src/node_resolver/tests.rs
+++ b/pnpm/crates/engine-runtime-node-resolver/src/node_resolver/tests.rs
@@ -255,7 +255,7 @@ async fn resolve_save_specifier_saves_an_exact_version_without_network() {
         .node_download_mirrors
         .insert("release".to_string(), "http://127.0.0.1:9/download/release/".to_string());
 
-    assert_eq!(resolver.resolve_save_specifier("22.11.0", None).await.unwrap(), "runtime:22.11.0",);
+    assert_eq!(resolver.resolve_save_specifier("22.11.0", None).await.unwrap(), "runtime:22.11.0");
 }
 
 /// An exact-version resolve skips the release index, so a nonexistent

--- a/pnpm/crates/napi/src/resolve.rs
+++ b/pnpm/crates/napi/src/resolve.rs
@@ -195,6 +195,7 @@ fn run_resolve_blocking(
 
     let mut node_resolver = NodeResolver::new(Arc::clone(&http_client));
     node_resolver.offline = config.offline;
+    node_resolver.cache_dir = Some(config.cache_dir.clone());
     let deno_resolver = DenoResolver::new(Arc::clone(&http_client), Arc::clone(&npm_resolver));
     let bun_resolver = BunResolver::new(Arc::clone(&http_client), Arc::clone(&npm_resolver));
 

--- a/pnpm/crates/package-manager/src/add.rs
+++ b/pnpm/crates/package-manager/src/add.rs
@@ -885,6 +885,7 @@ async fn resolve_added_dependency<'a>(
         let mut node_resolver = NodeResolver::new(std::sync::Arc::clone(http_client_arc));
         node_resolver.node_download_mirrors.clone_from(&config.node_download_mirrors);
         node_resolver.offline = config.offline;
+        node_resolver.cache_dir = Some(config.cache_dir.clone());
         node_resolver
             .resolve_save_specifier(version_spec, prev_specifier.as_deref())
             .await

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolver_setup.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolver_setup.rs
@@ -301,6 +301,7 @@ pub(super) async fn build_resolver_chain<Reporter: pacquet_reporter::Reporter + 
     let mut node_resolver = NodeResolver::new(Arc::clone(http_client_arc));
     node_resolver.node_download_mirrors.clone_from(&config.node_download_mirrors);
     node_resolver.offline = config.offline;
+    node_resolver.cache_dir = Some(config.cache_dir.clone());
     let deno_resolver = DenoResolver::new(Arc::clone(http_client_arc), Arc::clone(&npm_resolver));
     let bun_resolver = BunResolver::new(Arc::clone(http_client_arc), Arc::clone(&npm_resolver));
     let named_registry_resolver = NamedRegistryResolver {

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -1526,6 +1526,7 @@ fn ensure_latest_resolver_chain<'chain>(
         let mut node_resolver = NodeResolver::new(Arc::clone(ctx.http_client_arc));
         node_resolver.node_download_mirrors.clone_from(&ctx.config.node_download_mirrors);
         node_resolver.offline = ctx.config.offline;
+        node_resolver.cache_dir = Some(ctx.config.cache_dir.clone());
         let resolver = DefaultResolver::new(vec![
             Box::new(Arc::clone(&npm_resolver)) as Box<dyn Resolver>,
             Box::new(node_resolver),

--- a/pnpm11/crypto/shasums-file/src/diskCache.ts
+++ b/pnpm11/crypto/shasums-file/src/diskCache.ts
@@ -59,11 +59,13 @@ export async function readCachedShasums (url: string, opts: ShasumsCacheOpts): P
   const bytes = await readCachedBytes(url, opts)
   if (bytes == null) return undefined
   try {
-    return new TextDecoder('utf8', { fatal: true }).decode(bytes)
+    return strictUtf8Decoder.decode(bytes)
   } catch {
     return undefined
   }
 }
+
+const strictUtf8Decoder = new TextDecoder('utf8', { fatal: true })
 
 /**
  * The cached bytes for `url`, or `undefined` on any miss — a URL the mapping

--- a/pnpm11/crypto/shasums-file/src/diskCache.ts
+++ b/pnpm11/crypto/shasums-file/src/diskCache.ts
@@ -13,13 +13,22 @@ import { threadId } from 'node:worker_threads'
  * cache directory clears them together with the registry metadata mirror. The
  * layout is shared with pacquet, which reads and writes the same files.
  *
- * Only hand immutable URLs to this cache. A cached body is trusted on the
- * same terms as the registry metadata mirror: verification (the OpenPGP
- * signature check for signed channels) happens before the write, not after
- * the read, so a reader never re-verifies. The `<trust>` path segment keeps
- * signature-verified bodies and TLS-only bodies in disjoint subtrees, so an
- * unverified fetch can never seed an entry that a signature-verifying reader
- * would trust.
+ * Only hand immutable URLs to this cache. The cache directory is
+ * *project-configurable* (`cacheDir`), so entries under it must never carry
+ * more authority than the project that could have written them:
+ *
+ * - Signed-channel readers persist the detached signature next to the body
+ *   and re-verify it against the embedded release keys on every read (see
+ *   `fetchVerifiedNodeShasumsFileCached`), so a pre-seeded entry is only
+ *   accepted if it is a genuine release body.
+ * - Unverified entries are trusted on read, which grants a project nothing
+ *   new: the unsigned channels' mirrors are already project-configurable
+ *   (their bodies were project-controllable before the cache existed), and
+ *   the musl list's download URLs are derived from the hardcoded
+ *   unofficial-builds base, never from the cached body.
+ *
+ * The `<trust>` path segment keeps the two classes in disjoint subtrees so
+ * their read policies cannot be confused.
  */
 export const RUNTIME_SHASUMS_DIR = 'v11/runtime-shasums'
 
@@ -42,12 +51,19 @@ export interface ShasumsCacheOpts {
 const MAX_CACHED_SHASUMS_LEN = 1024 * 1024
 
 /**
- * The cached body for `url`, or `undefined` on any miss — a URL the mapping
- * cannot represent, a missing file, unreadable content, an empty file (never
- * a valid SHASUMS body, so it only signals a torn write), or a file over
- * {@link MAX_CACHED_SHASUMS_LEN}.
+ * The cached body for `url` as UTF-8 text, via {@link readCachedBytes}.
  */
 export async function readCachedShasums (url: string, opts: ShasumsCacheOpts): Promise<string | undefined> {
+  return (await readCachedBytes(url, opts))?.toString('utf8')
+}
+
+/**
+ * The cached bytes for `url`, or `undefined` on any miss — a URL the mapping
+ * cannot represent, a missing or non-regular file, unreadable content, an
+ * empty file (never a valid entry, so it only signals a torn write), or a
+ * file over {@link MAX_CACHED_SHASUMS_LEN}.
+ */
+export async function readCachedBytes (url: string, opts: ShasumsCacheOpts): Promise<Buffer | undefined> {
   if (opts.cacheDir == null) return undefined
   const filePath = shasumsCachePath(opts.cacheDir, opts.trust, url)
   if (filePath == null) return undefined
@@ -67,7 +83,7 @@ export async function readCachedShasums (url: string, opts: ShasumsCacheOpts): P
       const buffer = Buffer.allocUnsafe(MAX_CACHED_SHASUMS_LEN + 1)
       const { bytesRead } = await file.read(buffer, 0, buffer.length, 0)
       if (bytesRead === 0 || bytesRead > MAX_CACHED_SHASUMS_LEN) return undefined
-      return buffer.toString('utf8', 0, bytesRead)
+      return buffer.subarray(0, bytesRead)
     } finally {
       await file.close()
     }
@@ -83,7 +99,7 @@ export async function readCachedShasums (url: string, opts: ShasumsCacheOpts): P
  * file + rename keeps concurrent writers (two installs resolving the same
  * version) from exposing a torn body.
  */
-export async function writeCachedShasums (url: string, body: string, opts: ShasumsCacheOpts): Promise<void> {
+export async function writeCachedShasums (url: string, body: string | Uint8Array, opts: ShasumsCacheOpts): Promise<void> {
   if (opts.cacheDir == null) return
   if (Buffer.byteLength(body) > MAX_CACHED_SHASUMS_LEN) return
   const filePath = shasumsCachePath(opts.cacheDir, opts.trust, url)

--- a/pnpm11/crypto/shasums-file/src/diskCache.ts
+++ b/pnpm11/crypto/shasums-file/src/diskCache.ts
@@ -69,7 +69,7 @@ function encodePathSegment (segment: string): string | undefined {
 }
 
 /**
- * The cached body for `url`, or `undefined` on any miss — an unmappable URL,
+ * The cached body for `url`, or `undefined` on any miss — a URL the mapping cannot represent,
  * a missing file, unreadable content, or an empty file (never a valid SHASUMS
  * body, so it only signals a torn write).
  */

--- a/pnpm11/crypto/shasums-file/src/diskCache.ts
+++ b/pnpm11/crypto/shasums-file/src/diskCache.ts
@@ -51,15 +51,22 @@ export async function readCachedShasums (url: string, opts: ShasumsCacheOpts): P
   if (opts.cacheDir == null) return undefined
   const filePath = shasumsCachePath(opts.cacheDir, opts.trust, url)
   if (filePath == null) return undefined
-  let body: string
   try {
-    const { size } = await fs.promises.stat(filePath)
-    if (size === 0 || size > MAX_CACHED_SHASUMS_LEN) return undefined
-    body = await fs.promises.readFile(filePath, 'utf8')
+    // A bounded read rather than a stat check keeps the cap race-free: at
+    // most one byte past the bound is ever read, whatever the file's size
+    // becomes between open and read.
+    const file = await fs.promises.open(filePath, 'r')
+    try {
+      const buffer = Buffer.allocUnsafe(MAX_CACHED_SHASUMS_LEN + 1)
+      const { bytesRead } = await file.read(buffer, 0, buffer.length, 0)
+      if (bytesRead === 0 || bytesRead > MAX_CACHED_SHASUMS_LEN) return undefined
+      return buffer.toString('utf8', 0, bytesRead)
+    } finally {
+      await file.close()
+    }
   } catch {
     return undefined
   }
-  return body || undefined
 }
 
 /**
@@ -71,7 +78,7 @@ export async function readCachedShasums (url: string, opts: ShasumsCacheOpts): P
  */
 export async function writeCachedShasums (url: string, body: string, opts: ShasumsCacheOpts): Promise<void> {
   if (opts.cacheDir == null) return
-  if (body.length > MAX_CACHED_SHASUMS_LEN) return
+  if (Buffer.byteLength(body) > MAX_CACHED_SHASUMS_LEN) return
   const filePath = shasumsCachePath(opts.cacheDir, opts.trust, url)
   if (filePath == null) return
   // The process id alone does not make the temp name unique (worker threads

--- a/pnpm11/crypto/shasums-file/src/diskCache.ts
+++ b/pnpm11/crypto/shasums-file/src/diskCache.ts
@@ -35,9 +35,17 @@ export interface ShasumsCacheOpts {
 }
 
 /**
+ * Upper bound on a cache entry's size. Real SHASUMS bodies are a few
+ * kilobytes; anything past this bound is not a release asset list and is
+ * never read into memory or written.
+ */
+const MAX_CACHED_SHASUMS_LEN = 1024 * 1024
+
+/**
  * The cached body for `url`, or `undefined` on any miss — a URL the mapping
- * cannot represent, a missing file, unreadable content, or an empty file
- * (never a valid SHASUMS body, so it only signals a torn write).
+ * cannot represent, a missing file, unreadable content, an empty file (never
+ * a valid SHASUMS body, so it only signals a torn write), or a file over
+ * {@link MAX_CACHED_SHASUMS_LEN}.
  */
 export async function readCachedShasums (url: string, opts: ShasumsCacheOpts): Promise<string | undefined> {
   if (opts.cacheDir == null) return undefined
@@ -45,6 +53,8 @@ export async function readCachedShasums (url: string, opts: ShasumsCacheOpts): P
   if (filePath == null) return undefined
   let body: string
   try {
+    const { size } = await fs.promises.stat(filePath)
+    if (size === 0 || size > MAX_CACHED_SHASUMS_LEN) return undefined
     body = await fs.promises.readFile(filePath, 'utf8')
   } catch {
     return undefined
@@ -61,6 +71,7 @@ export async function readCachedShasums (url: string, opts: ShasumsCacheOpts): P
  */
 export async function writeCachedShasums (url: string, body: string, opts: ShasumsCacheOpts): Promise<void> {
   if (opts.cacheDir == null) return
+  if (body.length > MAX_CACHED_SHASUMS_LEN) return
   const filePath = shasumsCachePath(opts.cacheDir, opts.trust, url)
   if (filePath == null) return
   // The process id alone does not make the temp name unique (worker threads
@@ -71,7 +82,17 @@ export async function writeCachedShasums (url: string, body: string, opts: Shasu
   const tempPath = `${filePath}.tmp-${process.pid.toString()}-${threadId.toString()}-${(tempCounter++).toString()}`
   try {
     await fs.promises.mkdir(path.dirname(filePath), { recursive: true })
-    await fs.promises.writeFile(tempPath, body, { flag: 'wx' })
+    // Sync before the rename so a crash cannot persist the renamed name
+    // pointing at partially-written content — a torn SHASUMS prefix still
+    // parses and would otherwise be served (missing platform rows) until the
+    // cache is cleared.
+    const tempFile = await fs.promises.open(tempPath, 'wx')
+    try {
+      await tempFile.writeFile(body)
+      await tempFile.sync()
+    } finally {
+      await tempFile.close()
+    }
     await fs.promises.rename(tempPath, filePath)
   } catch {
     try {

--- a/pnpm11/crypto/shasums-file/src/diskCache.ts
+++ b/pnpm11/crypto/shasums-file/src/diskCache.ts
@@ -1,0 +1,110 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+/**
+ * On-disk cache for per-version runtime `SHASUMS256.txt` bodies.
+ *
+ * A release's SHASUMS file lives under a version-pinned URL
+ * (`.../v22.0.0/SHASUMS256.txt`), so its content is immutable: a body fetched
+ * once — and, for signed channels, verified once — never needs to be fetched
+ * again. Entries live under `<cacheDir>/v11/runtime-shasums/<host>/<url path>`
+ * so clearing the cache directory clears them together with the registry
+ * metadata mirror. The layout is shared with pacquet, which reads and writes
+ * the same files.
+ *
+ * Only hand immutable URLs to this cache. A cached body is trusted on the
+ * same terms as the registry metadata mirror: verification (the OpenPGP
+ * signature check for signed channels) happens before the write, not after
+ * the read, so a reader never re-verifies.
+ */
+export const RUNTIME_SHASUMS_DIR = 'v11/runtime-shasums'
+
+/**
+ * The cache file backing `url`, or `undefined` when the URL has a shape the
+ * path mapping does not cover (non-HTTP scheme, embedded credentials, query
+ * string, empty or dot-only path segments). Returning `undefined` just
+ * disables caching for that URL.
+ */
+export function shasumsCachePath (cacheDir: string, url: string): string | undefined {
+  let rest: string
+  if (url.startsWith('https://')) {
+    rest = url.substring('https://'.length)
+  } else if (url.startsWith('http://')) {
+    rest = url.substring('http://'.length)
+  } else {
+    return undefined
+  }
+  if (/[?#@]/.test(rest)) return undefined
+  const firstSlash = rest.indexOf('/')
+  if (firstSlash <= 0) return undefined
+  // `:` (a port separator) is not portable in file names; `+` is the same
+  // encoding the registry metadata mirror uses for it.
+  const host = rest.substring(0, firstSlash).toLowerCase().replaceAll(':', '+')
+  const parts = [encodePathSegment(host)]
+  for (const segment of rest.substring(firstSlash + 1).split('/')) {
+    if (!segment || segment === '.' || segment === '..') return undefined
+    parts.push(encodePathSegment(segment))
+  }
+  if (parts.some((part) => part == null)) return undefined
+  return path.join(cacheDir, RUNTIME_SHASUMS_DIR, ...(parts as string[]))
+}
+
+/**
+ * Percent-encode the bytes of `segment` that are not portable across
+ * filesystems, keeping `[A-Za-z0-9._+-]` as-is. pacquet applies the same
+ * encoding, so both tools address one file.
+ */
+function encodePathSegment (segment: string): string | undefined {
+  if (segment.length > 200) return undefined
+  let encoded = ''
+  for (const byte of Buffer.from(segment)) {
+    const char = String.fromCharCode(byte)
+    if (/[\w.+-]/.test(char)) {
+      encoded += char
+    } else {
+      encoded += `%${byte.toString(16).toUpperCase().padStart(2, '0')}`
+    }
+  }
+  return encoded
+}
+
+/**
+ * The cached body for `url`, or `undefined` on any miss — an unmappable URL,
+ * a missing file, unreadable content, or an empty file (never a valid SHASUMS
+ * body, so it only signals a torn write).
+ */
+export function readCachedShasums (cacheDir: string | undefined, url: string): string | undefined {
+  if (cacheDir == null) return undefined
+  const filePath = shasumsCachePath(cacheDir, url)
+  if (filePath == null) return undefined
+  let body: string
+  try {
+    body = fs.readFileSync(filePath, 'utf8')
+  } catch {
+    return undefined
+  }
+  return body || undefined
+}
+
+/**
+ * Best-effort write of `body` for `url`: a cache-write failure only costs a
+ * refetch on the next resolve, so errors are deliberately dropped rather than
+ * failing the resolution that produced the body. The temp-file + rename keeps
+ * concurrent writers (two installs resolving the same version) from exposing
+ * a torn body.
+ */
+export function writeCachedShasums (cacheDir: string | undefined, url: string, body: string): void {
+  if (cacheDir == null) return
+  const filePath = shasumsCachePath(cacheDir, url)
+  if (filePath == null) return
+  const tempPath = `${filePath}.tmp${process.pid.toString()}`
+  try {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true })
+    fs.writeFileSync(tempPath, body)
+    fs.renameSync(tempPath, filePath)
+  } catch {
+    try {
+      fs.rmSync(tempPath, { force: true })
+    } catch {}
+  }
+}

--- a/pnpm11/crypto/shasums-file/src/diskCache.ts
+++ b/pnpm11/crypto/shasums-file/src/diskCache.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import { threadId } from 'node:worker_threads'
 
 /**
  * On-disk cache for per-version runtime `SHASUMS256.txt` bodies.
@@ -7,17 +8,79 @@ import path from 'node:path'
  * A release's SHASUMS file lives under a version-pinned URL
  * (`.../v22.0.0/SHASUMS256.txt`), so its content is immutable: a body fetched
  * once — and, for signed channels, verified once — never needs to be fetched
- * again. Entries live under `<cacheDir>/v11/runtime-shasums/<host>/<url path>`
- * so clearing the cache directory clears them together with the registry
- * metadata mirror. The layout is shared with pacquet, which reads and writes
- * the same files.
+ * again. Entries live under
+ * `<cacheDir>/v11/runtime-shasums/<trust>/<host>/<url path>` so clearing the
+ * cache directory clears them together with the registry metadata mirror. The
+ * layout is shared with pacquet, which reads and writes the same files.
  *
  * Only hand immutable URLs to this cache. A cached body is trusted on the
  * same terms as the registry metadata mirror: verification (the OpenPGP
  * signature check for signed channels) happens before the write, not after
- * the read, so a reader never re-verifies.
+ * the read, so a reader never re-verifies. The `<trust>` path segment keeps
+ * signature-verified bodies and TLS-only bodies in disjoint subtrees, so an
+ * unverified fetch can never seed an entry that a signature-verifying reader
+ * would trust.
  */
 export const RUNTIME_SHASUMS_DIR = 'v11/runtime-shasums'
+
+/**
+ * How the body of a cache entry was authenticated before it was written.
+ * Each class caches into its own subtree.
+ */
+export type ShasumsTrust = 'verified' | 'unverified'
+
+export interface ShasumsCacheOpts {
+  cacheDir?: string
+  trust: ShasumsTrust
+}
+
+/**
+ * The cached body for `url`, or `undefined` on any miss — a URL the mapping
+ * cannot represent, a missing file, unreadable content, or an empty file
+ * (never a valid SHASUMS body, so it only signals a torn write).
+ */
+export async function readCachedShasums (url: string, opts: ShasumsCacheOpts): Promise<string | undefined> {
+  if (opts.cacheDir == null) return undefined
+  const filePath = shasumsCachePath(opts.cacheDir, opts.trust, url)
+  if (filePath == null) return undefined
+  let body: string
+  try {
+    body = await fs.promises.readFile(filePath, 'utf8')
+  } catch {
+    return undefined
+  }
+  return body || undefined
+}
+
+/**
+ * Best-effort write of `body` for `url`: a cache-write failure only costs a
+ * refetch on the next resolve, so errors are deliberately dropped rather than
+ * failing the resolution that produced the body. The exclusively-created temp
+ * file + rename keeps concurrent writers (two installs resolving the same
+ * version) from exposing a torn body.
+ */
+export async function writeCachedShasums (url: string, body: string, opts: ShasumsCacheOpts): Promise<void> {
+  if (opts.cacheDir == null) return
+  const filePath = shasumsCachePath(opts.cacheDir, opts.trust, url)
+  if (filePath == null) return
+  // The process id alone does not make the temp name unique (worker threads
+  // share it), so the thread id and a counter join it. The `wx` flag refuses
+  // to open a path that already exists — a colliding writer or a pre-seeded
+  // symlink fails the open instead of being followed — and any failure just
+  // skips the write.
+  const tempPath = `${filePath}.tmp-${process.pid.toString()}-${threadId.toString()}-${(tempCounter++).toString()}`
+  try {
+    await fs.promises.mkdir(path.dirname(filePath), { recursive: true })
+    await fs.promises.writeFile(tempPath, body, { flag: 'wx' })
+    await fs.promises.rename(tempPath, filePath)
+  } catch {
+    try {
+      await fs.promises.rm(tempPath, { force: true })
+    } catch {}
+  }
+}
+
+let tempCounter = 0
 
 /**
  * The cache file backing `url`, or `undefined` when the URL has a shape the
@@ -25,7 +88,7 @@ export const RUNTIME_SHASUMS_DIR = 'v11/runtime-shasums'
  * string, empty or dot-only path segments). Returning `undefined` just
  * disables caching for that URL.
  */
-export function shasumsCachePath (cacheDir: string, url: string): string | undefined {
+function shasumsCachePath (cacheDir: string, trust: ShasumsTrust, url: string): string | undefined {
   let rest: string
   if (url.startsWith('https://')) {
     rest = url.substring('https://'.length)
@@ -46,7 +109,7 @@ export function shasumsCachePath (cacheDir: string, url: string): string | undef
     parts.push(encodePathSegment(segment))
   }
   if (parts.some((part) => part == null)) return undefined
-  return path.join(cacheDir, RUNTIME_SHASUMS_DIR, ...(parts as string[]))
+  return path.join(cacheDir, RUNTIME_SHASUMS_DIR, trust, ...(parts as string[]))
 }
 
 /**
@@ -66,45 +129,4 @@ function encodePathSegment (segment: string): string | undefined {
     }
   }
   return encoded
-}
-
-/**
- * The cached body for `url`, or `undefined` on any miss — a URL the mapping cannot represent,
- * a missing file, unreadable content, or an empty file (never a valid SHASUMS
- * body, so it only signals a torn write).
- */
-export function readCachedShasums (cacheDir: string | undefined, url: string): string | undefined {
-  if (cacheDir == null) return undefined
-  const filePath = shasumsCachePath(cacheDir, url)
-  if (filePath == null) return undefined
-  let body: string
-  try {
-    body = fs.readFileSync(filePath, 'utf8')
-  } catch {
-    return undefined
-  }
-  return body || undefined
-}
-
-/**
- * Best-effort write of `body` for `url`: a cache-write failure only costs a
- * refetch on the next resolve, so errors are deliberately dropped rather than
- * failing the resolution that produced the body. The temp-file + rename keeps
- * concurrent writers (two installs resolving the same version) from exposing
- * a torn body.
- */
-export function writeCachedShasums (cacheDir: string | undefined, url: string, body: string): void {
-  if (cacheDir == null) return
-  const filePath = shasumsCachePath(cacheDir, url)
-  if (filePath == null) return
-  const tempPath = `${filePath}.tmp${process.pid.toString()}`
-  try {
-    fs.mkdirSync(path.dirname(filePath), { recursive: true })
-    fs.writeFileSync(tempPath, body)
-    fs.renameSync(tempPath, filePath)
-  } catch {
-    try {
-      fs.rmSync(tempPath, { force: true })
-    } catch {}
-  }
 }

--- a/pnpm11/crypto/shasums-file/src/diskCache.ts
+++ b/pnpm11/crypto/shasums-file/src/diskCache.ts
@@ -52,9 +52,17 @@ const MAX_CACHED_SHASUMS_LEN = 1024 * 1024
 
 /**
  * The cached body for `url` as UTF-8 text, via {@link readCachedBytes}.
+ * Invalid UTF-8 is a miss — a lossy decode would turn a corrupted entry
+ * into malformed rows instead of a refetch.
  */
 export async function readCachedShasums (url: string, opts: ShasumsCacheOpts): Promise<string | undefined> {
-  return (await readCachedBytes(url, opts))?.toString('utf8')
+  const bytes = await readCachedBytes(url, opts)
+  if (bytes == null) return undefined
+  try {
+    return new TextDecoder('utf8', { fatal: true }).decode(bytes)
+  } catch {
+    return undefined
+  }
 }
 
 /**

--- a/pnpm11/crypto/shasums-file/src/diskCache.ts
+++ b/pnpm11/crypto/shasums-file/src/diskCache.ts
@@ -52,11 +52,18 @@ export async function readCachedShasums (url: string, opts: ShasumsCacheOpts): P
   const filePath = shasumsCachePath(opts.cacheDir, opts.trust, url)
   if (filePath == null) return undefined
   try {
-    // A bounded read rather than a stat check keeps the cap race-free: at
-    // most one byte past the bound is ever read, whatever the file's size
-    // becomes between open and read.
-    const file = await fs.promises.open(filePath, 'r')
+    // A FIFO planted at the entry path would block a plain open until a
+    // writer appears; O_NONBLOCK (a no-op for regular files, absent on
+    // Windows, whose directory entries cannot be named pipes) makes the open
+    // return immediately.
+    const file = await fs.promises.open(filePath, fs.constants.O_RDONLY | (fs.constants.O_NONBLOCK ?? 0))
     try {
+      // Checked on the opened handle, so nothing can swap the regular file
+      // for a special one between check and read.
+      if (!(await file.stat()).isFile()) return undefined
+      // A bounded read rather than a stat check keeps the cap race-free: at
+      // most one byte past the bound is ever read, whatever the file's size
+      // becomes between open and read.
       const buffer = Buffer.allocUnsafe(MAX_CACHED_SHASUMS_LEN + 1)
       const { bytesRead } = await file.read(buffer, 0, buffer.length, 0)
       if (bytesRead === 0 || bytesRead > MAX_CACHED_SHASUMS_LEN) return undefined

--- a/pnpm11/crypto/shasums-file/src/index.ts
+++ b/pnpm11/crypto/shasums-file/src/index.ts
@@ -3,8 +3,13 @@ import type {
   FetchFromRegistry,
 } from '@pnpm/fetching.types'
 
-import { readCachedShasums, RUNTIME_SHASUMS_DIR, writeCachedShasums } from './diskCache.js'
-import { type ArmoredKey, fetchVerifiedNodeShasums } from './verifyNodeShasums.js'
+import { readCachedBytes, readCachedShasums, RUNTIME_SHASUMS_DIR, writeCachedShasums } from './diskCache.js'
+import {
+  type ArmoredKey,
+  fetchVerifiedNodeShasums,
+  fetchVerifiedNodeShasumsWithSignature,
+  nodeShasumsSignatureVerifies,
+} from './verifyNodeShasums.js'
 
 export { fetchVerifiedNodeShasums, RUNTIME_SHASUMS_DIR }
 
@@ -43,10 +48,13 @@ export interface FetchVerifiedNodeShasumsFileCachedOpts extends FetchShasumsFile
 
 /**
  * Like {@link fetchVerifiedNodeShasumsFile}, backed by the disk cache when
- * `opts.cacheDir` is given: a body cached by an earlier resolve is served
- * without network access or signature re-verification, and a freshly fetched
- * body is cached only after its signature checks out. `shasumsUrl` must be
- * version-pinned — a mutable URL must never be handed to the cache.
+ * `opts.cacheDir` is given. The cache stores the body together with its
+ * detached signature, and a cache hit re-verifies that signature against the
+ * embedded release keys: the cache directory is project-configurable, so a
+ * pre-seeded entry must prove it is a genuine release body before it is
+ * served. Any verification failure is a miss and the pair is refetched.
+ * `shasumsUrl` must be version-pinned — a mutable URL must never be handed to
+ * the cache.
  */
 export async function fetchVerifiedNodeShasumsFileCached (
   fetch: FetchFromRegistry,
@@ -54,10 +62,22 @@ export async function fetchVerifiedNodeShasumsFileCached (
   opts?: FetchVerifiedNodeShasumsFileCachedOpts
 ): Promise<ShasumsFileItem[]> {
   const cacheOpts = { cacheDir: opts?.cacheDir, trust: 'verified' as const }
-  const cached = await readCachedShasums(shasumsUrl, cacheOpts)
-  if (cached != null) return parseShasumsFile(cached)
-  const body = await fetchVerifiedNodeShasums(fetch, shasumsUrl, opts?.trustedKeys)
-  await writeCachedShasums(shasumsUrl, body, cacheOpts)
+  const signatureUrl = `${shasumsUrl}.sig`
+  const [cachedBody, cachedSignature] = await Promise.all([
+    readCachedShasums(shasumsUrl, cacheOpts),
+    readCachedBytes(signatureUrl, cacheOpts),
+  ])
+  if (
+    cachedBody != null && cachedSignature != null &&
+    await nodeShasumsSignatureVerifies(Buffer.from(cachedBody, 'utf8'), cachedSignature, opts?.trustedKeys)
+  ) {
+    return parseShasumsFile(cachedBody)
+  }
+  const { body, signature } = await fetchVerifiedNodeShasumsWithSignature(fetch, shasumsUrl, opts?.trustedKeys)
+  await Promise.all([
+    writeCachedShasums(shasumsUrl, body, cacheOpts),
+    writeCachedShasums(signatureUrl, signature, cacheOpts),
+  ])
   return parseShasumsFile(body)
 }
 

--- a/pnpm11/crypto/shasums-file/src/index.ts
+++ b/pnpm11/crypto/shasums-file/src/index.ts
@@ -4,7 +4,7 @@ import type {
 } from '@pnpm/fetching.types'
 
 import { readCachedShasums, RUNTIME_SHASUMS_DIR, writeCachedShasums } from './diskCache.js'
-import { fetchVerifiedNodeShasums } from './verifyNodeShasums.js'
+import { type ArmoredKey, fetchVerifiedNodeShasums } from './verifyNodeShasums.js'
 
 export { fetchVerifiedNodeShasums, RUNTIME_SHASUMS_DIR }
 
@@ -33,29 +33,37 @@ export async function fetchVerifiedNodeShasumsFile (
   return parseShasumsFile(await fetchVerifiedNodeShasums(fetch, shasumsUrl))
 }
 
+export interface FetchShasumsFileCachedOpts {
+  cacheDir?: string
+}
+
+export interface FetchVerifiedNodeShasumsFileCachedOpts extends FetchShasumsFileCachedOpts {
+  trustedKeys?: readonly ArmoredKey[]
+}
+
 /**
  * Like {@link fetchVerifiedNodeShasumsFile}, backed by the disk cache when
- * `cacheDir` is given: a body cached by an earlier resolve is served without
- * network access or signature re-verification, and a freshly fetched body is
- * cached only after its signature checks out. `shasumsUrl` must be
+ * `opts.cacheDir` is given: a body cached by an earlier resolve is served
+ * without network access or signature re-verification, and a freshly fetched
+ * body is cached only after its signature checks out. `shasumsUrl` must be
  * version-pinned — a mutable URL must never be handed to the cache.
  */
 export async function fetchVerifiedNodeShasumsFileCached (
   fetch: FetchFromRegistry,
   shasumsUrl: string,
-  cacheDir?: string,
-  trustedKeys?: Parameters<typeof fetchVerifiedNodeShasums>[2]
+  opts?: FetchVerifiedNodeShasumsFileCachedOpts
 ): Promise<ShasumsFileItem[]> {
-  const cached = readCachedShasums(cacheDir, shasumsUrl)
+  const cacheOpts = { cacheDir: opts?.cacheDir, trust: 'verified' as const }
+  const cached = await readCachedShasums(shasumsUrl, cacheOpts)
   if (cached != null) return parseShasumsFile(cached)
-  const body = await fetchVerifiedNodeShasums(fetch, shasumsUrl, trustedKeys)
-  writeCachedShasums(cacheDir, shasumsUrl, body)
+  const body = await fetchVerifiedNodeShasums(fetch, shasumsUrl, opts?.trustedKeys)
+  await writeCachedShasums(shasumsUrl, body, cacheOpts)
   return parseShasumsFile(body)
 }
 
 /**
- * Like {@link fetchShasumsFile}, backed by the disk cache when `cacheDir` is
- * given. For mirrors whose SHASUMS files carry no verifiable signature the
+ * Like {@link fetchShasumsFile}, backed by the disk cache when `opts.cacheDir`
+ * is given. For mirrors whose SHASUMS files carry no verifiable signature the
  * cached body is trusted exactly as far as the TLS fetch that produced it.
  * `shasumsUrl` must be version-pinned — a mutable URL must never be handed to
  * the cache.
@@ -63,12 +71,13 @@ export async function fetchVerifiedNodeShasumsFileCached (
 export async function fetchShasumsFileCached (
   fetch: FetchFromRegistry,
   shasumsUrl: string,
-  cacheDir?: string
+  opts?: FetchShasumsFileCachedOpts
 ): Promise<ShasumsFileItem[]> {
-  const cached = readCachedShasums(cacheDir, shasumsUrl)
+  const cacheOpts = { cacheDir: opts?.cacheDir, trust: 'unverified' as const }
+  const cached = await readCachedShasums(shasumsUrl, cacheOpts)
   if (cached != null) return parseShasumsFile(cached)
   const body = await fetchShasumsFileRaw(fetch, shasumsUrl)
-  writeCachedShasums(cacheDir, shasumsUrl, body)
+  await writeCachedShasums(shasumsUrl, body, cacheOpts)
   return parseShasumsFile(body)
 }
 

--- a/pnpm11/crypto/shasums-file/src/index.ts
+++ b/pnpm11/crypto/shasums-file/src/index.ts
@@ -3,9 +3,10 @@ import type {
   FetchFromRegistry,
 } from '@pnpm/fetching.types'
 
+import { readCachedShasums, RUNTIME_SHASUMS_DIR, writeCachedShasums } from './diskCache.js'
 import { fetchVerifiedNodeShasums } from './verifyNodeShasums.js'
 
-export { fetchVerifiedNodeShasums }
+export { fetchVerifiedNodeShasums, RUNTIME_SHASUMS_DIR }
 
 export interface ShasumsFileItem {
   integrity: string
@@ -30,6 +31,45 @@ export async function fetchVerifiedNodeShasumsFile (
   shasumsUrl: string
 ): Promise<ShasumsFileItem[]> {
   return parseShasumsFile(await fetchVerifiedNodeShasums(fetch, shasumsUrl))
+}
+
+/**
+ * Like {@link fetchVerifiedNodeShasumsFile}, backed by the disk cache when
+ * `cacheDir` is given: a body cached by an earlier resolve is served without
+ * network access or signature re-verification, and a freshly fetched body is
+ * cached only after its signature checks out. `shasumsUrl` must be
+ * version-pinned — a mutable URL must never be handed to the cache.
+ */
+export async function fetchVerifiedNodeShasumsFileCached (
+  fetch: FetchFromRegistry,
+  shasumsUrl: string,
+  cacheDir?: string,
+  trustedKeys?: Parameters<typeof fetchVerifiedNodeShasums>[2]
+): Promise<ShasumsFileItem[]> {
+  const cached = readCachedShasums(cacheDir, shasumsUrl)
+  if (cached != null) return parseShasumsFile(cached)
+  const body = await fetchVerifiedNodeShasums(fetch, shasumsUrl, trustedKeys)
+  writeCachedShasums(cacheDir, shasumsUrl, body)
+  return parseShasumsFile(body)
+}
+
+/**
+ * Like {@link fetchShasumsFile}, backed by the disk cache when `cacheDir` is
+ * given. For mirrors whose SHASUMS files carry no verifiable signature the
+ * cached body is trusted exactly as far as the TLS fetch that produced it.
+ * `shasumsUrl` must be version-pinned — a mutable URL must never be handed to
+ * the cache.
+ */
+export async function fetchShasumsFileCached (
+  fetch: FetchFromRegistry,
+  shasumsUrl: string,
+  cacheDir?: string
+): Promise<ShasumsFileItem[]> {
+  const cached = readCachedShasums(cacheDir, shasumsUrl)
+  if (cached != null) return parseShasumsFile(cached)
+  const body = await fetchShasumsFileRaw(fetch, shasumsUrl)
+  writeCachedShasums(cacheDir, shasumsUrl, body)
+  return parseShasumsFile(body)
 }
 
 export function parseShasumsFile (shasumsFileContent: string): ShasumsFileItem[] {

--- a/pnpm11/crypto/shasums-file/src/verifyNodeShasums.ts
+++ b/pnpm11/crypto/shasums-file/src/verifyNodeShasums.ts
@@ -46,6 +46,20 @@ export async function fetchVerifiedNodeShasums (
   shasumsUrl: string,
   trustedKeys: readonly ArmoredKey[] = NODE_RELEASE_KEYS
 ): Promise<string> {
+  const { body } = await fetchVerifiedNodeShasumsWithSignature(fetch, shasumsUrl, trustedKeys)
+  return body
+}
+
+/**
+ * {@link fetchVerifiedNodeShasums}, additionally returning the verified
+ * detached signature so the disk cache can persist it as the entry's
+ * verification evidence.
+ */
+export async function fetchVerifiedNodeShasumsWithSignature (
+  fetch: FetchFromRegistry,
+  shasumsUrl: string,
+  trustedKeys: readonly ArmoredKey[] = NODE_RELEASE_KEYS
+): Promise<{ body: string, signature: Uint8Array }> {
   const [shasumsBytes, signatureBytes] = await Promise.all([
     fetchBytes(fetch, shasumsUrl, 'SHASUMS256.txt'),
     fetchBytes(fetch, `${shasumsUrl}.sig`, 'SHASUMS256.txt.sig'),
@@ -59,7 +73,25 @@ export async function fetchVerifiedNodeShasums (
     )
   }
 
-  return Buffer.from(shasumsBytes).toString('utf8')
+  return { body: Buffer.from(shasumsBytes).toString('utf8'), signature: signatureBytes }
+}
+
+/**
+ * Whether `signatureBytes` is a valid detached signature of `content` under
+ * the trusted keys, reporting any unreadable input as `false` rather than
+ * throwing. This is the read-side check for persisted cache evidence, where
+ * any failure just means a cache miss.
+ */
+export async function nodeShasumsSignatureVerifies (
+  content: Uint8Array,
+  signatureBytes: Uint8Array,
+  trustedKeys: readonly ArmoredKey[] = NODE_RELEASE_KEYS
+): Promise<boolean> {
+  try {
+    return await isSignedByTrustedKey(content, signatureBytes, trustedKeys)
+  } catch {
+    return false
+  }
 }
 
 async function isSignedByTrustedKey (

--- a/pnpm11/crypto/shasums-file/test/diskCache.ts
+++ b/pnpm11/crypto/shasums-file/test/diskCache.ts
@@ -1,0 +1,100 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { expect, test } from '@jest/globals'
+import {
+  fetchShasumsFileCached,
+  fetchVerifiedNodeShasumsFileCached,
+  RUNTIME_SHASUMS_DIR,
+} from '@pnpm/crypto.shasums-file'
+import type { FetchFromRegistry } from '@pnpm/fetching.types'
+import * as openpgp from 'openpgp'
+
+function temporaryDirectory (): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-shasums-cache-'))
+}
+
+const SHASUMS_URL = 'https://nodejs.example.test/download/release/v22.11.0/SHASUMS256.txt'
+const SHASUMS = 'deadbeef'.repeat(8) + '  node-v22.11.0-darwin-arm64.tar.gz\n'
+
+function countingFetch (responses: Record<string, () => Response>): { fetch: FetchFromRegistry, calls: string[] } {
+  const calls: string[] = []
+  const fetch = (async (url: string) => {
+    calls.push(url)
+    const response = responses[url]
+    if (!response) return new Response(null, { status: 404 })
+    return response()
+  }) as unknown as FetchFromRegistry
+  return { fetch, calls }
+}
+
+test('fetchShasumsFileCached() serves repeat reads from the cache', async () => {
+  const cacheDir = temporaryDirectory()
+  const { fetch, calls } = countingFetch({
+    [SHASUMS_URL]: () => new Response(SHASUMS),
+  })
+
+  const fetched = await fetchShasumsFileCached(fetch, SHASUMS_URL, cacheDir)
+  const cached = await fetchShasumsFileCached(fetch, SHASUMS_URL, cacheDir)
+
+  expect(cached).toStrictEqual(fetched)
+  expect(calls).toStrictEqual([SHASUMS_URL])
+  expect(fs.readFileSync(
+    path.join(cacheDir, RUNTIME_SHASUMS_DIR, 'nodejs.example.test/download/release/v22.11.0/SHASUMS256.txt'),
+    'utf8'
+  )).toBe(SHASUMS)
+})
+
+test('fetchVerifiedNodeShasumsFileCached() caches the body after verification and skips re-verification', async () => {
+  const { privateKey, publicKey } = await openpgp.generateKey({
+    userIDs: [{ name: 'Test Node Releaser', email: 'test@nodejs.example' }],
+    format: 'armored',
+  })
+  const signingKey = await openpgp.readPrivateKey({ armoredKey: privateKey })
+  const message = await openpgp.createMessage({ binary: new TextEncoder().encode(SHASUMS) })
+  const signature = await openpgp.sign({ message, signingKeys: signingKey, detached: true, format: 'binary' }) as Uint8Array
+  const trustedKeys = [{ armoredKey: publicKey }]
+  const cacheDir = temporaryDirectory()
+  const { fetch, calls } = countingFetch({
+    [SHASUMS_URL]: () => new Response(new TextEncoder().encode(SHASUMS)),
+    [`${SHASUMS_URL}.sig`]: () => new Response(signature.slice().buffer as ArrayBuffer),
+  })
+
+  const fetched = await fetchVerifiedNodeShasumsFileCached(fetch, SHASUMS_URL, cacheDir, trustedKeys)
+  const cached = await fetchVerifiedNodeShasumsFileCached(fetch, SHASUMS_URL, cacheDir, trustedKeys)
+
+  expect(cached).toStrictEqual(fetched)
+  expect(calls).toStrictEqual([SHASUMS_URL, `${SHASUMS_URL}.sig`])
+})
+
+test('fetchVerifiedNodeShasumsFileCached() does not cache a body that failed verification', async () => {
+  const { publicKey } = await openpgp.generateKey({
+    userIDs: [{ name: 'Test Node Releaser', email: 'test@nodejs.example' }],
+    format: 'armored',
+  })
+  const trustedKeys = [{ armoredKey: publicKey }]
+  const cacheDir = temporaryDirectory()
+  const { fetch } = countingFetch({
+    [SHASUMS_URL]: () => new Response(new TextEncoder().encode(SHASUMS)),
+  })
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    // eslint-disable-next-line no-await-in-loop
+    await expect(fetchVerifiedNodeShasumsFileCached(fetch, SHASUMS_URL, cacheDir, trustedKeys)).rejects.toThrow()
+  }
+  expect(fs.existsSync(path.join(cacheDir, RUNTIME_SHASUMS_DIR))).toBe(false)
+})
+
+test('a URL the cache path mapping cannot represent is fetched every time', async () => {
+  const cacheDir = temporaryDirectory()
+  const url = 'https://nodejs.example.test/download/release/v22.11.0/SHASUMS256.txt?token=1'
+  const { fetch, calls } = countingFetch({
+    [url]: () => new Response(SHASUMS),
+  })
+
+  await fetchShasumsFileCached(fetch, url, cacheDir)
+  await fetchShasumsFileCached(fetch, url, cacheDir)
+
+  expect(calls).toStrictEqual([url, url])
+})

--- a/pnpm11/crypto/shasums-file/test/diskCache.ts
+++ b/pnpm11/crypto/shasums-file/test/diskCache.ts
@@ -83,6 +83,31 @@ test('an unverified cache entry does not serve a verified read', async () => {
   expect(calls).toStrictEqual([SHASUMS_URL, SHASUMS_URL, `${SHASUMS_URL}.sig`])
 })
 
+// The cache directory is project-configurable, so a verified hit must prove
+// itself against the trusted keys on every read: a pre-seeded entry without a
+// valid persisted signature is a miss and gets refetched.
+test('a seeded verified cache entry without a valid signature is refetched', async () => {
+  const { signature, trustedKeys } = await signedShasums()
+  const cacheDir = await temporaryDirectory()
+  const entryDir = path.join(cacheDir, RUNTIME_SHASUMS_DIR, 'verified/nodejs.example.test/download/release/v22.11.0')
+  await fs.promises.mkdir(entryDir, { recursive: true })
+  await fs.promises.writeFile(path.join(entryDir, 'SHASUMS256.txt'), '0'.repeat(64) + '  node-v22.11.0-darwin-arm64.tar.gz\n')
+  await fs.promises.writeFile(path.join(entryDir, 'SHASUMS256.txt.sig'), 'not a signature')
+  const { fetch, calls } = countingFetch({
+    [SHASUMS_URL]: () => new Response(new TextEncoder().encode(SHASUMS)),
+    [`${SHASUMS_URL}.sig`]: () => new Response(signature.slice().buffer as ArrayBuffer),
+  })
+
+  const refetched = await fetchVerifiedNodeShasumsFileCached(fetch, SHASUMS_URL, { cacheDir, trustedKeys })
+  const cached = await fetchVerifiedNodeShasumsFileCached(fetch, SHASUMS_URL, { cacheDir, trustedKeys })
+
+  // The seeded pair was rejected and replaced by the genuine fetched pair,
+  // which then serves the second read from the cache.
+  expect(refetched[0].integrity).not.toContain('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=')
+  expect(cached).toStrictEqual(refetched)
+  expect(calls).toStrictEqual([SHASUMS_URL, `${SHASUMS_URL}.sig`])
+})
+
 test('a URL the cache path mapping cannot represent is fetched every time', async () => {
   const cacheDir = await temporaryDirectory()
   const url = 'https://nodejs.example.test/download/release/v22.11.0/SHASUMS256.txt?token=1'

--- a/pnpm11/crypto/shasums-file/test/diskCache.ts
+++ b/pnpm11/crypto/shasums-file/test/diskCache.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
-import { expect, test } from '@jest/globals'
+import { afterAll, expect, test } from '@jest/globals'
 import {
   fetchShasumsFileCached,
   fetchVerifiedNodeShasumsFileCached,
@@ -11,12 +11,98 @@ import {
 import type { FetchFromRegistry } from '@pnpm/fetching.types'
 import * as openpgp from 'openpgp'
 
-function temporaryDirectory (): string {
-  return fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-shasums-cache-'))
-}
-
 const SHASUMS_URL = 'https://nodejs.example.test/download/release/v22.11.0/SHASUMS256.txt'
 const SHASUMS = 'deadbeef'.repeat(8) + '  node-v22.11.0-darwin-arm64.tar.gz\n'
+
+afterAll(async () => {
+  await Promise.all(temporaryDirectories.map((dir) => fs.promises.rm(dir, { recursive: true, force: true })))
+})
+
+test('fetchShasumsFileCached() serves repeat reads from the cache', async () => {
+  const cacheDir = await temporaryDirectory()
+  const { fetch, calls } = countingFetch({
+    [SHASUMS_URL]: () => new Response(SHASUMS),
+  })
+
+  const fetched = await fetchShasumsFileCached(fetch, SHASUMS_URL, { cacheDir })
+  const cached = await fetchShasumsFileCached(fetch, SHASUMS_URL, { cacheDir })
+
+  expect(cached).toStrictEqual(fetched)
+  expect(calls).toStrictEqual([SHASUMS_URL])
+  expect(await fs.promises.readFile(
+    path.join(cacheDir, RUNTIME_SHASUMS_DIR, 'unverified/nodejs.example.test/download/release/v22.11.0/SHASUMS256.txt'),
+    'utf8'
+  )).toBe(SHASUMS)
+})
+
+test('fetchVerifiedNodeShasumsFileCached() caches the body after verification and skips re-verification', async () => {
+  const { signature, trustedKeys } = await signedShasums()
+  const cacheDir = await temporaryDirectory()
+  const { fetch, calls } = countingFetch({
+    [SHASUMS_URL]: () => new Response(new TextEncoder().encode(SHASUMS)),
+    [`${SHASUMS_URL}.sig`]: () => new Response(signature.slice().buffer as ArrayBuffer),
+  })
+
+  const fetched = await fetchVerifiedNodeShasumsFileCached(fetch, SHASUMS_URL, { cacheDir, trustedKeys })
+  const cached = await fetchVerifiedNodeShasumsFileCached(fetch, SHASUMS_URL, { cacheDir, trustedKeys })
+
+  expect(cached).toStrictEqual(fetched)
+  expect(calls).toStrictEqual([SHASUMS_URL, `${SHASUMS_URL}.sig`])
+})
+
+test('fetchVerifiedNodeShasumsFileCached() does not cache a body that failed verification', async () => {
+  const { trustedKeys } = await signedShasums()
+  const cacheDir = await temporaryDirectory()
+  const { fetch } = countingFetch({
+    [SHASUMS_URL]: () => new Response(new TextEncoder().encode(SHASUMS)),
+  })
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    // eslint-disable-next-line no-await-in-loop
+    await expect(fetchVerifiedNodeShasumsFileCached(fetch, SHASUMS_URL, { cacheDir, trustedKeys })).rejects.toThrow()
+  }
+  expect(fs.existsSync(path.join(cacheDir, RUNTIME_SHASUMS_DIR))).toBe(false)
+})
+
+// The two trust classes cache into disjoint subtrees: a body written by an
+// unverified fetch must never satisfy a reader that expects a
+// signature-verified body.
+test('an unverified cache entry does not serve a verified read', async () => {
+  const { signature, trustedKeys } = await signedShasums()
+  const cacheDir = await temporaryDirectory()
+  const { fetch, calls } = countingFetch({
+    [SHASUMS_URL]: () => new Response(new TextEncoder().encode(SHASUMS)),
+    [`${SHASUMS_URL}.sig`]: () => new Response(signature.slice().buffer as ArrayBuffer),
+  })
+
+  await fetchShasumsFileCached(fetch, SHASUMS_URL, { cacheDir })
+  await fetchVerifiedNodeShasumsFileCached(fetch, SHASUMS_URL, { cacheDir, trustedKeys })
+
+  // The verified read went to the network (and verified) despite the
+  // unverified entry for the same URL.
+  expect(calls).toStrictEqual([SHASUMS_URL, SHASUMS_URL, `${SHASUMS_URL}.sig`])
+})
+
+test('a URL the cache path mapping cannot represent is fetched every time', async () => {
+  const cacheDir = await temporaryDirectory()
+  const url = 'https://nodejs.example.test/download/release/v22.11.0/SHASUMS256.txt?token=1'
+  const { fetch, calls } = countingFetch({
+    [url]: () => new Response(SHASUMS),
+  })
+
+  await fetchShasumsFileCached(fetch, url, { cacheDir })
+  await fetchShasumsFileCached(fetch, url, { cacheDir })
+
+  expect(calls).toStrictEqual([url, url])
+})
+
+const temporaryDirectories: string[] = []
+
+async function temporaryDirectory (): Promise<string> {
+  const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'pnpm-shasums-cache-'))
+  temporaryDirectories.push(dir)
+  return dir
+}
 
 function countingFetch (responses: Record<string, () => Response>): { fetch: FetchFromRegistry, calls: string[] } {
   const calls: string[] = []
@@ -29,24 +115,7 @@ function countingFetch (responses: Record<string, () => Response>): { fetch: Fet
   return { fetch, calls }
 }
 
-test('fetchShasumsFileCached() serves repeat reads from the cache', async () => {
-  const cacheDir = temporaryDirectory()
-  const { fetch, calls } = countingFetch({
-    [SHASUMS_URL]: () => new Response(SHASUMS),
-  })
-
-  const fetched = await fetchShasumsFileCached(fetch, SHASUMS_URL, cacheDir)
-  const cached = await fetchShasumsFileCached(fetch, SHASUMS_URL, cacheDir)
-
-  expect(cached).toStrictEqual(fetched)
-  expect(calls).toStrictEqual([SHASUMS_URL])
-  expect(fs.readFileSync(
-    path.join(cacheDir, RUNTIME_SHASUMS_DIR, 'nodejs.example.test/download/release/v22.11.0/SHASUMS256.txt'),
-    'utf8'
-  )).toBe(SHASUMS)
-})
-
-test('fetchVerifiedNodeShasumsFileCached() caches the body after verification and skips re-verification', async () => {
+async function signedShasums (): Promise<{ signature: Uint8Array, trustedKeys: Array<{ armoredKey: string }> }> {
   const { privateKey, publicKey } = await openpgp.generateKey({
     userIDs: [{ name: 'Test Node Releaser', email: 'test@nodejs.example' }],
     format: 'armored',
@@ -54,47 +123,5 @@ test('fetchVerifiedNodeShasumsFileCached() caches the body after verification an
   const signingKey = await openpgp.readPrivateKey({ armoredKey: privateKey })
   const message = await openpgp.createMessage({ binary: new TextEncoder().encode(SHASUMS) })
   const signature = await openpgp.sign({ message, signingKeys: signingKey, detached: true, format: 'binary' }) as Uint8Array
-  const trustedKeys = [{ armoredKey: publicKey }]
-  const cacheDir = temporaryDirectory()
-  const { fetch, calls } = countingFetch({
-    [SHASUMS_URL]: () => new Response(new TextEncoder().encode(SHASUMS)),
-    [`${SHASUMS_URL}.sig`]: () => new Response(signature.slice().buffer as ArrayBuffer),
-  })
-
-  const fetched = await fetchVerifiedNodeShasumsFileCached(fetch, SHASUMS_URL, cacheDir, trustedKeys)
-  const cached = await fetchVerifiedNodeShasumsFileCached(fetch, SHASUMS_URL, cacheDir, trustedKeys)
-
-  expect(cached).toStrictEqual(fetched)
-  expect(calls).toStrictEqual([SHASUMS_URL, `${SHASUMS_URL}.sig`])
-})
-
-test('fetchVerifiedNodeShasumsFileCached() does not cache a body that failed verification', async () => {
-  const { publicKey } = await openpgp.generateKey({
-    userIDs: [{ name: 'Test Node Releaser', email: 'test@nodejs.example' }],
-    format: 'armored',
-  })
-  const trustedKeys = [{ armoredKey: publicKey }]
-  const cacheDir = temporaryDirectory()
-  const { fetch } = countingFetch({
-    [SHASUMS_URL]: () => new Response(new TextEncoder().encode(SHASUMS)),
-  })
-
-  for (let attempt = 0; attempt < 2; attempt++) {
-    // eslint-disable-next-line no-await-in-loop
-    await expect(fetchVerifiedNodeShasumsFileCached(fetch, SHASUMS_URL, cacheDir, trustedKeys)).rejects.toThrow()
-  }
-  expect(fs.existsSync(path.join(cacheDir, RUNTIME_SHASUMS_DIR))).toBe(false)
-})
-
-test('a URL the cache path mapping cannot represent is fetched every time', async () => {
-  const cacheDir = temporaryDirectory()
-  const url = 'https://nodejs.example.test/download/release/v22.11.0/SHASUMS256.txt?token=1'
-  const { fetch, calls } = countingFetch({
-    [url]: () => new Response(SHASUMS),
-  })
-
-  await fetchShasumsFileCached(fetch, url, cacheDir)
-  await fetchShasumsFileCached(fetch, url, cacheDir)
-
-  expect(calls).toStrictEqual([url, url])
-})
+  return { signature, trustedKeys: [{ armoredKey: publicKey }] }
+}

--- a/pnpm11/engine/runtime/node-resolver/src/index.ts
+++ b/pnpm11/engine/runtime/node-resolver/src/index.ts
@@ -1,4 +1,4 @@
-import { fetchShasumsFile, fetchVerifiedNodeShasumsFile } from '@pnpm/crypto.shasums-file'
+import { fetchShasumsFileCached, fetchVerifiedNodeShasumsFileCached } from '@pnpm/crypto.shasums-file'
 import { PnpmError } from '@pnpm/error'
 import type { FetchFromRegistry } from '@pnpm/fetching.types'
 import type {
@@ -41,6 +41,7 @@ export async function resolveNodeRuntime (
     fetchFromRegistry: FetchFromRegistry
     nodeDownloadMirrors?: Record<string, string>
     offline?: boolean
+    cacheDir?: string
   },
   wantedDependency: WantedDependency,
   opts?: Partial<ResolveOptions>
@@ -59,11 +60,31 @@ export async function resolveNodeRuntime (
   const versionSpec = normalizeRuntimeSpec(wantedDependency.bareSpecifier.substring('runtime:'.length))
   const { releaseChannel, versionSpecifier } = parseNodeSpecifier(versionSpec)
   const nodeMirrorBaseUrl = getNodeMirror(ctx.nodeDownloadMirrors, releaseChannel)
-  const version = await resolveNodeVersion(ctx.fetchFromRegistry, versionSpecifier, nodeMirrorBaseUrl)
-  if (!version) {
-    throw new PnpmError('NODEJS_VERSION_NOT_FOUND', `Could not find a Node.js version that satisfies ${versionSpec}`)
+  // An exact stable-release specifier is its own resolution, so the
+  // release-index fetch is skipped for it and existence is proven by the
+  // asset-list fetch below.
+  const exactVersion = exactReleaseVersion(releaseChannel, versionSpecifier)
+  let version = exactVersion
+  if (version == null) {
+    version = await resolveNodeVersion(ctx.fetchFromRegistry, versionSpecifier, nodeMirrorBaseUrl) ?? undefined
+    if (!version) {
+      throw new PnpmError('NODEJS_VERSION_NOT_FOUND', `Could not find a Node.js version that satisfies ${versionSpec}`)
+    }
   }
-  const variants = await readNodeAssets(ctx.fetchFromRegistry, nodeMirrorBaseUrl, version, releaseChannel)
+  let variants: PlatformAssetResolution[]
+  try {
+    variants = await readNodeAssets(ctx.fetchFromRegistry, nodeMirrorBaseUrl, version, releaseChannel, ctx.cacheDir)
+  } catch (err: unknown) {
+    // The exact-specifier pick skipped the release index, so a failed asset
+    // read is ambiguous: the version may simply not exist. Consult the index
+    // now, purely to raise the same NODEJS_VERSION_NOT_FOUND the index-first
+    // path raises for a nonexistent version; any other outcome re-raises the
+    // asset error unchanged.
+    if (exactVersion != null && await versionMissingFromIndex(ctx.fetchFromRegistry, exactVersion, nodeMirrorBaseUrl)) {
+      throw new PnpmError('NODEJS_VERSION_NOT_FOUND', `Could not find a Node.js version that satisfies ${versionSpec}`)
+    }
+    throw err
+  }
   const range = createNodeRuntimeVersionSpec(versionSpec, version, wantedDependency)
   return {
     id: `node@runtime:${version}` as PkgResolutionId,
@@ -113,13 +134,35 @@ function createNodeRuntimeVersionSpec (
   return resolvedVersion
 }
 
-async function readNodeAssets (fetch: FetchFromRegistry, nodeMirrorBaseUrl: string, version: string, releaseChannel: string): Promise<PlatformAssetResolution[]> {
+/**
+ * The concrete version an exact stable-release specifier names, when the
+ * specifier is already in canonical `X.Y.Z` form. Such a specifier needs no
+ * release-index lookup: the index would resolve it to itself. Prereleases are
+ * excluded — on the `release` channel they never exist, so routing them
+ * through the index keeps the canonical not-found error path.
+ */
+function exactReleaseVersion (releaseChannel: string, versionSpecifier: string): string | undefined {
+  if (releaseChannel !== 'release') return undefined
+  const parsed = semver.parse(versionSpecifier)
+  if (parsed == null || parsed.prerelease.length > 0 || parsed.build.length > 0 || parsed.version !== versionSpecifier) return undefined
+  return parsed.version
+}
+
+async function versionMissingFromIndex (fetch: FetchFromRegistry, version: string, nodeMirrorBaseUrl: string): Promise<boolean> {
+  try {
+    return (await resolveNodeVersion(fetch, version, nodeMirrorBaseUrl)) == null
+  } catch {
+    return false
+  }
+}
+
+async function readNodeAssets (fetch: FetchFromRegistry, nodeMirrorBaseUrl: string, version: string, releaseChannel: string, cacheDir?: string): Promise<PlatformAssetResolution[]> {
   // The mirror is repository-configurable, so the SHASUMS file's hashes are only
   // trustworthy once its OpenPGP signature is verified against the Node.js
   // release keys embedded in pnpm. Only the `release` channel publishes a signed
   // SHASUMS256.txt; pre-release channels (rc, nightly, …) are unsigned by Node,
   // so they cannot be verified this way.
-  const assets = await readNodeAssetsFromMirror(fetch, { nodeMirrorBaseUrl, version, muslOnly: false, verifySignature: releaseChannel === 'release' })
+  const assets = await readNodeAssetsFromMirror(fetch, { nodeMirrorBaseUrl, version, muslOnly: false, verifySignature: releaseChannel === 'release', cacheDir })
 
   // When using the default mirror, also fetch musl variants from unofficial-builds.nodejs.org,
   // since musl builds are not available on the official mirror. That URL is hardcoded (not
@@ -127,7 +170,7 @@ async function readNodeAssets (fetch: FetchFromRegistry, nodeMirrorBaseUrl: stri
   // over TLS rather than verified against the official release keys.
   if (nodeMirrorBaseUrl === DEFAULT_NODE_MIRROR_BASE_URL) {
     try {
-      const muslAssets = await readNodeAssetsFromMirror(fetch, { nodeMirrorBaseUrl: UNOFFICIAL_NODE_MIRROR_BASE_URL, version, muslOnly: true, verifySignature: false })
+      const muslAssets = await readNodeAssetsFromMirror(fetch, { nodeMirrorBaseUrl: UNOFFICIAL_NODE_MIRROR_BASE_URL, version, muslOnly: true, verifySignature: false, cacheDir })
       assets.push(...muslAssets)
     } catch {
       // Musl variants may not be available for all Node.js versions (e.g. very old ones)
@@ -144,13 +187,16 @@ async function readNodeAssetsFromMirror (
     version: string
     muslOnly: boolean
     verifySignature: boolean
+    cacheDir?: string
   }
 ): Promise<PlatformAssetResolution[]> {
-  const { nodeMirrorBaseUrl, version, muslOnly, verifySignature } = opts
+  const { nodeMirrorBaseUrl, version, muslOnly, verifySignature, cacheDir } = opts
+  // The URL is pinned to one released version, which is what makes it
+  // eligible for the SHASUMS disk cache.
   const integritiesFileUrl = `${nodeMirrorBaseUrl}v${version}/SHASUMS256.txt`
   const shasumsFileItems = verifySignature
-    ? await fetchVerifiedNodeShasumsFile(fetch, integritiesFileUrl)
-    : await fetchShasumsFile(fetch, integritiesFileUrl)
+    ? await fetchVerifiedNodeShasumsFileCached(fetch, integritiesFileUrl, cacheDir)
+    : await fetchShasumsFileCached(fetch, integritiesFileUrl, cacheDir)
   const escaped = version.replace(/\\/g, '\\\\').replace(/\./g, '\\.')
   // The second capture group uses [^.-]+ to stop at a dash, so that the optional
   // third group can capture the '-musl' suffix separately (e.g. 'x64' + '-musl').

--- a/pnpm11/engine/runtime/node-resolver/src/index.ts
+++ b/pnpm11/engine/runtime/node-resolver/src/index.ts
@@ -73,7 +73,7 @@ export async function resolveNodeRuntime (
   }
   let variants: PlatformAssetResolution[]
   try {
-    variants = await readNodeAssets(ctx.fetchFromRegistry, nodeMirrorBaseUrl, version, releaseChannel, ctx.cacheDir)
+    variants = await readNodeAssets(ctx.fetchFromRegistry, { nodeMirrorBaseUrl, version, releaseChannel, cacheDir: ctx.cacheDir })
   } catch (err: unknown) {
     // The exact-specifier pick skipped the release index, so a failed asset
     // read is ambiguous: the version may simply not exist. Consult the index
@@ -156,7 +156,16 @@ async function versionMissingFromIndex (fetch: FetchFromRegistry, version: strin
   }
 }
 
-async function readNodeAssets (fetch: FetchFromRegistry, nodeMirrorBaseUrl: string, version: string, releaseChannel: string, cacheDir?: string): Promise<PlatformAssetResolution[]> {
+async function readNodeAssets (
+  fetch: FetchFromRegistry,
+  opts: {
+    nodeMirrorBaseUrl: string
+    version: string
+    releaseChannel: string
+    cacheDir?: string
+  }
+): Promise<PlatformAssetResolution[]> {
+  const { nodeMirrorBaseUrl, version, releaseChannel, cacheDir } = opts
   // The mirror is repository-configurable, so the SHASUMS file's hashes are only
   // trustworthy once its OpenPGP signature is verified against the Node.js
   // release keys embedded in pnpm. Only the `release` channel publishes a signed
@@ -195,8 +204,8 @@ async function readNodeAssetsFromMirror (
   // eligible for the SHASUMS disk cache.
   const integritiesFileUrl = `${nodeMirrorBaseUrl}v${version}/SHASUMS256.txt`
   const shasumsFileItems = verifySignature
-    ? await fetchVerifiedNodeShasumsFileCached(fetch, integritiesFileUrl, cacheDir)
-    : await fetchShasumsFileCached(fetch, integritiesFileUrl, cacheDir)
+    ? await fetchVerifiedNodeShasumsFileCached(fetch, integritiesFileUrl, { cacheDir })
+    : await fetchShasumsFileCached(fetch, integritiesFileUrl, { cacheDir })
   const escaped = version.replace(/\\/g, '\\\\').replace(/\./g, '\\.')
   // The second capture group uses [^.-]+ to stop at a dash, so that the optional
   // third group can capture the '-musl' suffix separately (e.g. 'x64' + '-musl').

--- a/pnpm11/engine/runtime/node-resolver/test/resolveNodeRuntime.test.ts
+++ b/pnpm11/engine/runtime/node-resolver/test/resolveNodeRuntime.test.ts
@@ -1,3 +1,7 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
 import { expect, test } from '@jest/globals'
 import type { FetchFromRegistry } from '@pnpm/fetching.types'
 
@@ -37,4 +41,82 @@ test.each([
   })
 
   expect(resolution?.normalizedBareSpecifier).toBe(expected)
+})
+
+const RELEASE_MIRROR = 'https://node.example/download/release/'
+
+function countingFetch (responses: Record<string, () => Response>): { fetch: FetchFromRegistry, calls: string[] } {
+  const calls: string[] = []
+  const countedFetch = (async (url: string) => {
+    calls.push(url)
+    const response = responses[url]
+    if (!response) return new Response(null, { status: 404 })
+    return response()
+  }) as unknown as FetchFromRegistry
+  return { fetch: countedFetch, calls }
+}
+
+// An exact-specifier resolve skips the release index, so a nonexistent
+// version first fails its asset fetch; the resolver must then consult the
+// index and raise the canonical not-found error rather than the raw fetch
+// failure.
+test('resolveNodeRuntime() raises NODEJS_VERSION_NOT_FOUND for a nonexistent exact version', async () => {
+  const { fetch: countedFetch, calls } = countingFetch({
+    [`${RELEASE_MIRROR}index.json`]: () => new Response(JSON.stringify([{ version: 'v22.11.0', lts: false }])),
+  })
+
+  await expect(resolveNodeRuntime({
+    fetchFromRegistry: countedFetch,
+    nodeDownloadMirrors: { release: RELEASE_MIRROR },
+  }, {
+    alias: 'node',
+    bareSpecifier: 'runtime:22.99.0',
+  })).rejects.toThrow(/Could not find a Node.js version that satisfies 22.99.0/)
+  // The asset fetch runs first; the index is only consulted to classify the
+  // failure.
+  expect(calls[0]).toBe(`${RELEASE_MIRROR}v22.99.0/SHASUMS256.txt`)
+  expect(calls).toContain(`${RELEASE_MIRROR}index.json`)
+})
+
+// When the index confirms the exact version exists, the asset-fetch failure
+// is the real error and must surface unchanged.
+test('resolveNodeRuntime() keeps the asset error when the exact version exists', async () => {
+  const { fetch: countedFetch } = countingFetch({
+    [`${RELEASE_MIRROR}index.json`]: () => new Response(JSON.stringify([{ version: 'v22.11.0', lts: false }])),
+    [`${RELEASE_MIRROR}v22.11.0/SHASUMS256.txt`]: () => new Response(null, { status: 500 }),
+  })
+
+  await expect(resolveNodeRuntime({
+    fetchFromRegistry: countedFetch,
+    nodeDownloadMirrors: { release: RELEASE_MIRROR },
+  }, {
+    alias: 'node',
+    bareSpecifier: 'runtime:22.11.0',
+  })).rejects.toThrow(/SHASUMS256.txt/)
+})
+
+// A SHASUMS body cached by an earlier resolve serves the next one without
+// refetching it; only the (mutable) release index is fetched again.
+test('resolveNodeRuntime() serves repeat asset reads from the cache', async () => {
+  const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-node-resolver-'))
+  const { fetch: countedFetch, calls } = countingFetch({
+    [`${MIRROR}index.json`]: () => new Response(JSON.stringify([{ version: 'v22.11.0', lts: false }])),
+    [`${MIRROR}v22.11.0/SHASUMS256.txt`]: () => new Response('ed52239294ad517fbe91a268146d5d2aa8a17d2d62d64873e43219078ba71c4e  node-v22.11.0-linux-x64.tar.gz\n'),
+  })
+
+  for (let run = 0; run < 2; run++) {
+    // eslint-disable-next-line no-await-in-loop
+    const resolution = await resolveNodeRuntime({
+      fetchFromRegistry: countedFetch,
+      nodeDownloadMirrors: { rc: MIRROR },
+      cacheDir,
+    }, {
+      alias: 'node',
+      bareSpecifier: 'runtime:rc/22',
+    })
+    expect(resolution?.resolution.variants).toHaveLength(1)
+  }
+
+  expect(calls.filter((url) => url === `${MIRROR}v22.11.0/SHASUMS256.txt`)).toHaveLength(1)
+  expect(calls.filter((url) => url === `${MIRROR}index.json`)).toHaveLength(2)
 })

--- a/pnpm11/engine/runtime/node-resolver/test/resolveNodeRuntime.test.ts
+++ b/pnpm11/engine/runtime/node-resolver/test/resolveNodeRuntime.test.ts
@@ -45,17 +45,6 @@ test.each([
 
 const RELEASE_MIRROR = 'https://node.example/download/release/'
 
-function countingFetch (responses: Record<string, () => Response>): { fetch: FetchFromRegistry, calls: string[] } {
-  const calls: string[] = []
-  const countedFetch = (async (url: string) => {
-    calls.push(url)
-    const response = responses[url]
-    if (!response) return new Response(null, { status: 404 })
-    return response()
-  }) as unknown as FetchFromRegistry
-  return { fetch: countedFetch, calls }
-}
-
 // An exact-specifier resolve skips the release index, so a nonexistent
 // version first fails its asset fetch; the resolver must then consult the
 // index and raise the canonical not-found error rather than the raw fetch
@@ -98,25 +87,40 @@ test('resolveNodeRuntime() keeps the asset error when the exact version exists',
 // A SHASUMS body cached by an earlier resolve serves the next one without
 // refetching it; only the (mutable) release index is fetched again.
 test('resolveNodeRuntime() serves repeat asset reads from the cache', async () => {
-  const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-node-resolver-'))
-  const { fetch: countedFetch, calls } = countingFetch({
-    [`${MIRROR}index.json`]: () => new Response(JSON.stringify([{ version: 'v22.11.0', lts: false }])),
-    [`${MIRROR}v22.11.0/SHASUMS256.txt`]: () => new Response('ed52239294ad517fbe91a268146d5d2aa8a17d2d62d64873e43219078ba71c4e  node-v22.11.0-linux-x64.tar.gz\n'),
-  })
-
-  for (let run = 0; run < 2; run++) {
-    // eslint-disable-next-line no-await-in-loop
-    const resolution = await resolveNodeRuntime({
-      fetchFromRegistry: countedFetch,
-      nodeDownloadMirrors: { rc: MIRROR },
-      cacheDir,
-    }, {
-      alias: 'node',
-      bareSpecifier: 'runtime:rc/22',
+  const cacheDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'pnpm-node-resolver-'))
+  try {
+    const { fetch: countedFetch, calls } = countingFetch({
+      [`${MIRROR}index.json`]: () => new Response(JSON.stringify([{ version: 'v22.11.0', lts: false }])),
+      [`${MIRROR}v22.11.0/SHASUMS256.txt`]: () => new Response('ed52239294ad517fbe91a268146d5d2aa8a17d2d62d64873e43219078ba71c4e  node-v22.11.0-linux-x64.tar.gz\n'),
     })
-    expect(resolution?.resolution.variants).toHaveLength(1)
-  }
 
-  expect(calls.filter((url) => url === `${MIRROR}v22.11.0/SHASUMS256.txt`)).toHaveLength(1)
-  expect(calls.filter((url) => url === `${MIRROR}index.json`)).toHaveLength(2)
+    for (let run = 0; run < 2; run++) {
+      // eslint-disable-next-line no-await-in-loop
+      const resolution = await resolveNodeRuntime({
+        fetchFromRegistry: countedFetch,
+        nodeDownloadMirrors: { rc: MIRROR },
+        cacheDir,
+      }, {
+        alias: 'node',
+        bareSpecifier: 'runtime:rc/22',
+      })
+      expect(resolution?.resolution.variants).toHaveLength(1)
+    }
+
+    expect(calls.filter((url) => url === `${MIRROR}v22.11.0/SHASUMS256.txt`)).toHaveLength(1)
+    expect(calls.filter((url) => url === `${MIRROR}index.json`)).toHaveLength(2)
+  } finally {
+    await fs.promises.rm(cacheDir, { recursive: true, force: true })
+  }
 })
+
+function countingFetch (responses: Record<string, () => Response>): { fetch: FetchFromRegistry, calls: string[] } {
+  const calls: string[] = []
+  const countedFetch = (async (url: string) => {
+    calls.push(url)
+    const response = responses[url]
+    if (!response) return new Response(null, { status: 404 })
+    return response()
+  }) as unknown as FetchFromRegistry
+  return { fetch: countedFetch, calls }
+}

--- a/pnpm11/resolving/default-resolver/src/index.ts
+++ b/pnpm11/resolving/default-resolver/src/index.ts
@@ -120,7 +120,7 @@ export function createResolver (
   const localCtx = { preserveAbsolutePaths: pnpmOpts.preserveAbsolutePaths }
   const _resolveFromLocalScheme = resolveFromLocalScheme.bind(null, localCtx)
   const _resolveFromLocalPath = resolveFromLocalPath.bind(null, localCtx)
-  const _resolveNodeRuntime = resolveNodeRuntime.bind(null, { fetchFromRegistry, offline: pnpmOpts.offline, nodeDownloadMirrors: pnpmOpts.nodeDownloadMirrors })
+  const _resolveNodeRuntime = resolveNodeRuntime.bind(null, { fetchFromRegistry, offline: pnpmOpts.offline, nodeDownloadMirrors: pnpmOpts.nodeDownloadMirrors, cacheDir: pnpmOpts.cacheDir })
   const _resolveDenoRuntime = resolveDenoRuntime.bind(null, { fetchFromRegistry, offline: pnpmOpts.offline, resolveFromNpm })
   const _resolveBunRuntime = resolveBunRuntime.bind(null, { fetchFromRegistry, offline: pnpmOpts.offline, resolveFromNpm })
   const _resolveLatestNodeRuntime = resolveLatestNodeRuntime.bind(null, { fetchFromRegistry, nodeDownloadMirrors: pnpmOpts.nodeDownloadMirrors })


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Closes [pnpm/pnpm#13899](https://github.com/pnpm/pnpm/issues/13899).

The first `node` shim run in a project pinning a runtime through `devEngines.runtime` took ~650ms even when the exact version was already in the store. Profiling the shim's `materialize_runtime` showed ~530ms of that was network — all of it re-downloading immutable, already-verified Node.js release metadata:

| Step | Time |
|---|---|
| pre-save specifier normalization: cold `index.json` fetch | ~115ms |
| resolver: `index.json` again (warm connection) | ~30ms |
| resolver: `SHASUMS256.txt` + `.sig` fetch + OpenPGP verify | ~20ms |
| resolver: musl `SHASUMS256.txt` from a cold connection to unofficial-builds.nodejs.org | ~360ms |
| linking the runtime tree into the global virtual store (2733 files) | ~57ms |
| lockfile, env bookkeeping, misc | ~65ms |

Two changes, mirrored in the TypeScript CLI and pacquet:

- **Exact stable-release specifiers (`runtime:22.23.2`) skip the release index.** The specifier is its own resolution; existence is proven by the asset-list fetch. When that fetch fails, the index is consulted after the fact so a nonexistent version still raises `ERR_PNPM_NODEJS_VERSION_NOT_FOUND`, and a genuine mirror failure surfaces unchanged. The pacquet-only pre-save normalization (`resolve_save_specifier`) takes the same shortcut.
- **Per-version `SHASUMS256.txt` bodies are cached on disk** under `<cacheDir>/v11/runtime-shasums/<host>/<url path>`. The URLs are version-pinned, so the bodies are immutable. Signed bodies are cached only after their OpenPGP signature verified; a cached body is then trusted on the same terms as the registry metadata mirror (no re-verification on read). Both stacks share the layout and address the same files.

Measured on the issue's reproduction (runtime already in the store via `pnpm runtime set`, project pins the exact version):

- before: first run ~650ms
- after: first run ~100ms (~80ms with the network blocked entirely — the warm path is fully offline now)
- steady-state runs stay at ~7ms

The remaining ~100ms is dominated by materializing the ~2700-file runtime tree into the global virtual store (comparable to `cp -al` of the same tree), which only happens once per version per store.

Range specifiers (`runtime:^22`, `lts`, channels) still consult the release index — a range's answer changes over time, so it cannot be cached. `resolveLatestNodeRuntime` / `resolve_latest` (used by `pnpm outdated`) are deliberately unchanged.

## Squash Commit Body

```text
The first node shim run in a project pinning a runtime through
devEngines.runtime took ~650ms even when the exact version was already
in the store. ~530ms of that was network, re-downloading immutable and
already-verified release metadata: a cold index.json fetch during
pre-save specifier normalization, a second index.json fetch in the
resolver, the SHASUMS256.txt + signature fetch, and a cold connection to
unofficial-builds.nodejs.org for the musl SHASUMS.

Two changes, mirrored in both stacks:

- Exact stable-release specifiers (runtime:22.23.2) skip the release
  index: the specifier is its own resolution and existence is proven by
  the asset-list fetch. When that fetch fails, the index is consulted
  after the fact so a nonexistent version still raises
  ERR_PNPM_NODEJS_VERSION_NOT_FOUND. The pacquet-only pre-save
  normalization takes the same shortcut.

- Per-version SHASUMS256.txt bodies are cached under
  <cacheDir>/v11/runtime-shasums/<host>/<url path>. The URLs are
  version-pinned and immutable; signed bodies are cached only after
  their OpenPGP signature verified, and a cached body is trusted like
  the registry metadata mirror (no re-verification on read). Both
  stacks share the layout.

With a warm store, the first shim run drops from ~650ms to ~100ms — the
remainder is materializing the runtime tree into the global virtual
store — and no longer needs the network at all.

Closes pnpm/pnpm#13899.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789247086&installation_model_id=426870&pr_number=13901&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13901&signature=2a893d5f82b5c01514c3ed2709f1d7dddec225539ebc0d5b0f6aacfedabefd48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added caching for verified and unverified Node.js runtime checksum data, reducing repeated network requests.
  - Previously fetched pinned runtimes can resolve without network access.
  - Exact stable Node.js versions can skip release-index downloads when appropriate.
  - Cache entries are safely stored, isolated by verification status, and reused across runtime resolution operations.

- **Bug Fixes**
  - Improved handling of missing Node.js versions and asset-download failures with clearer, consistent resolution errors.
  - Invalid, unsupported, or incomplete cache entries are safely ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->