### PR TITLE
fix(resolver): pick the platform variant matching the host

### DIFF
--- a/.changeset/runtime-matches-the-host-architecture.md
+++ b/.changeset/runtime-matches-the-host-architecture.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/resolving.resolver-base": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+A runtime installed through `devEngines.runtime` now matches the host when `supportedArchitectures` lists several platforms. Listing `os: [darwin, linux]` and `cpu: [x64, arm64]` used to install the runtime built for the first entry of each list, so a machine running Linux on arm64 got a macOS x64 Node.js that could not execute [#13898](https://github.com/pnpm/pnpm/issues/13898).

--- a/pnpm/crates/deps-restorer/src/install_package_by_snapshot.rs
+++ b/pnpm/crates/deps-restorer/src/install_package_by_snapshot.rs
@@ -843,32 +843,29 @@ pub fn host_platform_selector() -> PlatformSelector {
     PlatformSelector { os: host_platform().to_string(), cpu: host_arch().to_string(), libc }
 }
 
-/// Resolve the runtime archive selector from `supportedArchitectures`, using
-/// the first requested value on each axis and expanding `current` to the host.
+/// Resolve the runtime archive selector from `supportedArchitectures`. Only
+/// one archive is installed, so each axis keeps the host's own value whenever
+/// the requested values allow it, either by listing it or by listing
+/// `current`. Values that exclude the host fall back to the first requested
+/// one.
 #[must_use]
 pub fn runtime_platform_selector(
     supported: Option<&pnpm_package_is_installable::SupportedArchitectures>,
 ) -> PlatformSelector {
     let host = host_platform_selector();
-    let pick = |values: Option<&Vec<String>>, current: &str| {
-        values.and_then(|values| values.first()).map_or_else(
-            || current.to_string(),
-            |value| {
-                if value == "current" { current.to_string() } else { value.clone() }
-            },
-        )
+    let pick = |values: Option<&Vec<String>>, current: Option<&str>| -> Option<String> {
+        let values = values.filter(|values| !values.is_empty())?;
+        if values.iter().any(|value| value == "current" || Some(value.as_str()) == current) {
+            return current.map(str::to_string);
+        }
+        values.first().cloned()
     };
     PlatformSelector {
-        os: pick(supported.and_then(|value| value.os.as_ref()), &host.os),
-        cpu: pick(supported.and_then(|value| value.cpu.as_ref()), &host.cpu),
-        libc: match supported
-            .and_then(|value| value.libc.as_ref())
-            .and_then(|values| values.first())
-        {
-            None => host.libc,
-            Some(value) if value == "current" => host.libc,
-            Some(value) => Some(value.clone()),
-        },
+        os: pick(supported.and_then(|value| value.os.as_ref()), Some(&host.os))
+            .unwrap_or_else(|| host.os.clone()),
+        cpu: pick(supported.and_then(|value| value.cpu.as_ref()), Some(&host.cpu))
+            .unwrap_or_else(|| host.cpu.clone()),
+        libc: pick(supported.and_then(|value| value.libc.as_ref()), host.libc.as_deref()),
     }
 }
 

--- a/pnpm/crates/deps-restorer/src/install_package_by_snapshot.rs
+++ b/pnpm/crates/deps-restorer/src/install_package_by_snapshot.rs
@@ -865,7 +865,8 @@ pub fn runtime_platform_selector(
             .unwrap_or_else(|| host.os.clone()),
         cpu: pick(supported.and_then(|value| value.cpu.as_ref()), Some(&host.cpu))
             .unwrap_or_else(|| host.cpu.clone()),
-        libc: pick(supported.and_then(|value| value.libc.as_ref()), host.libc.as_deref()),
+        libc: pick(supported.and_then(|value| value.libc.as_ref()), host.libc.as_deref())
+            .or_else(|| host.libc.clone()),
     }
 }
 

--- a/pnpm/crates/deps-restorer/src/install_package_by_snapshot.rs
+++ b/pnpm/crates/deps-restorer/src/install_package_by_snapshot.rs
@@ -843,31 +843,42 @@ pub fn host_platform_selector() -> PlatformSelector {
     PlatformSelector { os: host_platform().to_string(), cpu: host_arch().to_string(), libc }
 }
 
-/// Resolve the runtime archive selector from `supportedArchitectures`. Only
-/// one archive is installed, so each axis keeps the host's own value whenever
-/// the requested values allow it, either by listing it or by listing
-/// `current`. Values that exclude the host fall back to the first requested
-/// one.
+/// Resolve the runtime archive selector from `supportedArchitectures`.
+///
+/// Exactly one archive is installed per runtime, so each axis prefers
+/// the host's own value: an archive built for another platform cannot
+/// run here.
+///
+/// <https://github.com/pnpm/pnpm/issues/13898>
 #[must_use]
 pub fn runtime_platform_selector(
     supported: Option<&pnpm_package_is_installable::SupportedArchitectures>,
 ) -> PlatformSelector {
     let host = host_platform_selector();
-    let pick = |values: Option<&Vec<String>>, current: Option<&str>| -> Option<String> {
-        let values = values.filter(|values| !values.is_empty())?;
-        if values.iter().any(|value| value == "current" || Some(value.as_str()) == current) {
-            return current.map(str::to_string);
+    let (requested_os, requested_cpu, requested_libc) = match supported {
+        Some(supported) => {
+            (supported.os.as_deref(), supported.cpu.as_deref(), supported.libc.as_deref())
         }
-        values.first().cloned()
+        None => (None, None, None),
     };
     PlatformSelector {
-        os: pick(supported.and_then(|value| value.os.as_ref()), Some(&host.os))
-            .unwrap_or_else(|| host.os.clone()),
-        cpu: pick(supported.and_then(|value| value.cpu.as_ref()), Some(&host.cpu))
-            .unwrap_or_else(|| host.cpu.clone()),
-        libc: pick(supported.and_then(|value| value.libc.as_ref()), host.libc.as_deref())
-            .or_else(|| host.libc.clone()),
+        os: pick_supported(requested_os, Some(&host.os)).unwrap_or(&host.os).to_string(),
+        cpu: pick_supported(requested_cpu, Some(&host.cpu)).unwrap_or(&host.cpu).to_string(),
+        libc: pick_supported(requested_libc, host.libc.as_deref()).map(str::to_string),
     }
+}
+
+fn pick_supported<'a>(
+    requested: Option<&'a [String]>,
+    host_value: Option<&'a str>,
+) -> Option<&'a str> {
+    let Some(requested) = requested.filter(|requested| !requested.is_empty()) else {
+        return host_value;
+    };
+    if requested.iter().any(|value| value == "current" || Some(value.as_str()) == host_value) {
+        return host_value;
+    }
+    requested.first().map(String::as_str)
 }
 
 /// Hand-coded matcher for the

--- a/pnpm/crates/deps-restorer/src/install_package_by_snapshot/tests.rs
+++ b/pnpm/crates/deps-restorer/src/install_package_by_snapshot/tests.rs
@@ -232,18 +232,32 @@ fn host_platform_selector_omits_libc_on_non_linux_hosts() {
 }
 
 #[test]
-fn runtime_platform_selector_uses_the_first_configured_target() {
+fn runtime_platform_selector_uses_the_first_configured_target_the_host_is_absent_from() {
     let supported = SupportedArchitectures {
-        os: Some(vec!["win32".to_string(), "linux".to_string()]),
-        cpu: Some(vec!["x64".to_string(), "arm64".to_string()]),
+        os: Some(vec!["freebsd".to_string(), "openbsd".to_string()]),
+        cpu: Some(vec!["ppc64".to_string(), "s390x".to_string()]),
         libc: Some(vec!["current".to_string(), "musl".to_string()]),
     };
 
     let selector = runtime_platform_selector(Some(&supported));
 
-    assert_eq!(selector.os, "win32");
-    assert_eq!(selector.cpu, "x64");
+    assert_eq!(selector.os, "freebsd");
+    assert_eq!(selector.cpu, "ppc64");
     assert_eq!(selector.libc, host_platform_selector().libc);
+}
+
+#[test]
+fn runtime_platform_selector_prefers_the_host_over_the_other_configured_targets() {
+    let host = host_platform_selector();
+    let supported = SupportedArchitectures {
+        os: Some(vec!["freebsd".to_string(), host.os.clone()]),
+        cpu: Some(vec!["ppc64".to_string(), host.cpu.clone()]),
+        libc: None,
+    };
+
+    let selector = runtime_platform_selector(Some(&supported));
+
+    assert_eq!(selector, host);
 }
 
 #[test]

--- a/pnpm/crates/deps-restorer/src/install_package_by_snapshot/tests.rs
+++ b/pnpm/crates/deps-restorer/src/install_package_by_snapshot/tests.rs
@@ -232,7 +232,7 @@ fn host_platform_selector_omits_libc_on_non_linux_hosts() {
 }
 
 #[test]
-fn runtime_platform_selector_uses_the_first_configured_target_the_host_is_absent_from() {
+fn runtime_platform_selector_falls_back_to_the_first_configured_target_the_host_is_absent_from() {
     let supported = SupportedArchitectures {
         os: Some(vec!["freebsd".to_string(), "openbsd".to_string()]),
         cpu: Some(vec!["ppc64".to_string(), "s390x".to_string()]),

--- a/pnpm/crates/deps-restorer/src/install_package_by_snapshot/tests.rs
+++ b/pnpm/crates/deps-restorer/src/install_package_by_snapshot/tests.rs
@@ -261,6 +261,19 @@ fn runtime_platform_selector_prefers_the_host_over_the_other_configured_targets(
 }
 
 #[test]
+fn runtime_platform_selector_expands_current_to_the_host() {
+    let supported = SupportedArchitectures {
+        os: Some(vec!["freebsd".to_string(), "current".to_string()]),
+        cpu: Some(vec!["current".to_string()]),
+        libc: Some(vec!["current".to_string()]),
+    };
+
+    let selector = runtime_platform_selector(Some(&supported));
+
+    assert_eq!(selector, host_platform_selector());
+}
+
+#[test]
 fn render_variant_targets_formats_each_triple_with_optional_libc() {
     let variants = vec![
         PlatformAssetResolution {

--- a/pnpm11/installing/deps-installer/test/install/nodeRuntime.ts
+++ b/pnpm11/installing/deps-installer/test/install/nodeRuntime.ts
@@ -423,7 +423,7 @@ test('installing Node.js runtime for the host, when it is not the first supporte
   const isWindows = process.platform === 'win32'
   const supportedArchitectures = {
     os: [isWindows ? 'linux' : 'win32', process.platform],
-    cpu: ['x64', process.arch],
+    cpu: [process.arch === 'x64' ? 'arm64' : 'x64', process.arch],
   }
   const expectedBinLocation = isWindows ? 'node/node.exe' : 'node/bin/node'
   const project = prepareEmpty()

--- a/pnpm11/installing/deps-installer/test/install/nodeRuntime.ts
+++ b/pnpm11/installing/deps-installer/test/install/nodeRuntime.ts
@@ -419,6 +419,28 @@ test('installing Node.js runtime for the given supported architecture', async ()
   project.has(expectedBinLocation)
 })
 
+test('installing Node.js runtime for the host, when it is not the first supported architecture', async () => {
+  const isWindows = process.platform === 'win32'
+  const supportedArchitectures = {
+    os: [isWindows ? 'linux' : 'win32', process.platform],
+    cpu: ['x64', process.arch],
+  }
+  const expectedBinLocation = isWindows ? 'node/node.exe' : 'node/bin/node'
+  const project = prepareEmpty()
+  const { updatedManifest: manifest } = await addDependenciesToPackage(
+    {},
+    ['node@runtime:22.0.0'],
+    testDefaults({
+      fastUnpack: false,
+      supportedArchitectures,
+    })
+  )
+  project.has(expectedBinLocation)
+  rimrafSync('node_modules')
+  await install(manifest, testDefaults({ frozenLockfile: true, supportedArchitectures }))
+  project.has(expectedBinLocation)
+})
+
 test('installing Node.js runtime, when it is set via the engines field of a dependency', async () => {
   prepareEmpty()
   await addDependenciesToPackage(

--- a/pnpm11/resolving/resolver-base/src/index.ts
+++ b/pnpm11/resolving/resolver-base/src/index.ts
@@ -270,11 +270,10 @@ export interface PlatformSelector {
 
 /**
  * Resolve a {@link PlatformSelector} from the user's supportedArchitectures config
- * and the host's own platform/arch/libc. Variant selection picks exactly one
- * (os, cpu, libc) triplet per install, so each axis keeps the host's own value
- * whenever `supportedArchitectures.xxx` allows it, either by listing it or by
- * listing `"current"`. Only a config that excludes the host falls back to the
- * first requested value.
+ * and the host's own platform/arch/libc. Exactly one (os, cpu, libc) triplet is
+ * installed, so each axis prefers the host's own value: a variant built for
+ * another platform cannot run here.
+ * @see https://github.com/pnpm/pnpm/issues/13898
  */
 export function resolvePlatformSelector (
   supportedArchitectures: SupportedArchitectures | undefined,

--- a/pnpm11/resolving/resolver-base/src/index.ts
+++ b/pnpm11/resolving/resolver-base/src/index.ts
@@ -270,19 +270,20 @@ export interface PlatformSelector {
 
 /**
  * Resolve a {@link PlatformSelector} from the user's supportedArchitectures config
- * and the host's own platform/arch/libc. When `supportedArchitectures.xxx` is set
- * and its first entry is not `"current"`, that entry wins; otherwise the host's
- * value is used. Additional entries beyond the first are ignored — variant
- * selection picks exactly one (os, cpu, libc) triplet per install.
+ * and the host's own platform/arch/libc. Variant selection picks exactly one
+ * (os, cpu, libc) triplet per install, so each axis keeps the host's own value
+ * whenever `supportedArchitectures.xxx` allows it, either by listing it or by
+ * listing `"current"`. Only a config that excludes the host falls back to the
+ * first requested value.
  */
 export function resolvePlatformSelector (
   supportedArchitectures: SupportedArchitectures | undefined,
   host: { platform: string, arch: string, libc: string | null | undefined }
 ): PlatformSelector {
   return {
-    os: pickFirstNonCurrent(supportedArchitectures?.os) ?? host.platform,
-    cpu: pickFirstNonCurrent(supportedArchitectures?.cpu) ?? host.arch,
-    libc: pickFirstNonCurrent(supportedArchitectures?.libc) ?? host.libc,
+    os: pickSupported(supportedArchitectures?.os, host.platform),
+    cpu: pickSupported(supportedArchitectures?.cpu, host.arch),
+    libc: pickSupported(supportedArchitectures?.libc, host.libc),
   }
 }
 
@@ -312,11 +313,10 @@ function libcMatches (variantLibc: string | undefined, requestedLibc: string | n
   return variantLibc === requestedLibc
 }
 
-function pickFirstNonCurrent (requirements: string[] | undefined): string | undefined {
-  if (requirements?.length && requirements[0] !== 'current') {
-    return requirements[0]
-  }
-  return undefined
+function pickSupported<T extends string | null | undefined> (requirements: string[] | undefined, hostValue: T): string | T {
+  if (!requirements?.length) return hostValue
+  if (requirements.some((requirement) => requirement === 'current' || requirement === hostValue)) return hostValue
+  return requirements[0]
 }
 
 export interface ResolveResult {

--- a/pnpm11/resolving/resolver-base/test/index.ts
+++ b/pnpm11/resolving/resolver-base/test/index.ts
@@ -42,7 +42,7 @@ test('resolvePlatformSelector() prefers the host over the other supported archit
   const host = { platform: 'darwin', arch: 'arm64', libc: 'glibc' }
   expect(resolvePlatformSelector({ os: ['darwin', 'linux'], cpu: ['x64', 'arm64'], libc: ['musl', 'glibc'] }, host))
     .toStrictEqual({ os: 'darwin', cpu: 'arm64', libc: 'glibc' })
-  expect(resolvePlatformSelector({ os: ['linux', 'current'], cpu: ['current'] }, host))
+  expect(resolvePlatformSelector({ os: ['linux', 'current'], cpu: ['current'], libc: ['current'] }, host))
     .toStrictEqual({ os: 'darwin', cpu: 'arm64', libc: 'glibc' })
 })
 

--- a/pnpm11/resolving/resolver-base/test/index.ts
+++ b/pnpm11/resolving/resolver-base/test/index.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@jest/globals'
-import { classifyResolution, isGitHostedTarballUrl, type Resolution } from '@pnpm/resolving.resolver-base'
+import { classifyResolution, isGitHostedTarballUrl, type Resolution, resolvePlatformSelector } from '@pnpm/resolving.resolver-base'
 
 const GIT_COMMIT = '0123456789abcdef0123456789abcdef01234567'
 
@@ -36,6 +36,20 @@ test('classifyResolution() treats a YAML `type: null` as a tarball, not custom',
 test('classifyResolution() does not crash on a non-string tarball from a tampered lockfile', () => {
   expect(classifyResolution({ tarball: ['https://attacker.example/foo.tgz'] } as unknown as Resolution)).toBe('remoteTarball')
   expect(classifyResolution({ tarball: 42 } as unknown as Resolution)).toBe('remoteTarball')
+})
+
+test('resolvePlatformSelector() prefers the host over the other supported architectures', () => {
+  const host = { platform: 'darwin', arch: 'arm64', libc: 'glibc' }
+  expect(resolvePlatformSelector({ os: ['darwin', 'linux'], cpu: ['x64', 'arm64'], libc: ['musl', 'glibc'] }, host))
+    .toStrictEqual({ os: 'darwin', cpu: 'arm64', libc: 'glibc' })
+  expect(resolvePlatformSelector({ os: ['linux', 'current'], cpu: ['current'] }, host))
+    .toStrictEqual({ os: 'darwin', cpu: 'arm64', libc: 'glibc' })
+})
+
+test('resolvePlatformSelector() falls back to the first architecture the host is absent from', () => {
+  const host = { platform: 'darwin', arch: 'arm64', libc: null }
+  expect(resolvePlatformSelector({ os: ['linux', 'win32'], cpu: ['x64'], libc: ['musl'] }, host))
+    .toStrictEqual({ os: 'linux', cpu: 'x64', libc: 'musl' })
 })
 
 test('isGitHostedTarballUrl() recognizes git provider archive URLs (case-insensitive)', () => {


### PR DESCRIPTION
## Summary

A project that combines `devEngines.runtime` with a multi-platform `supportedArchitectures` gets a runtime built for the wrong machine. `resolvePlatformSelector` read only the first entry of `os`, `cpu` and `libc`, so `os: [darwin, linux]` with `cpu: [x64, arm64]` always selected `darwin-x64`. On a Linux arm64 host the installed `node_modules/.bin/node` is then a Mach-O binary that fails with `Exec format error`. Putting `current` first was the only workaround.

Only one archive is installed per runtime, so each axis now keeps the host's own value when the configured list allows it, either by naming it or by naming `current`. A list that leaves the host out still falls back to its first entry, so installing for a foreign platform on purpose (`os: [win32]` on Linux) keeps working.

`supportedArchitectures` carries two different meanings for the two kinds of artifact it now
controls. For optional dependencies it is a set: every listed platform is installed and the
variants coexist in `node_modules`, and a list that omits the host really does exclude the
host's own variants. A runtime has a single slot — one `node_modules/node`, one `.bin/node` —
so the same list can only act as a filter that has to collapse to one triple, and the fallback
ordering here is that collapse rule, not an incidental detail. The rule is that the runtime
matches the platform the rest of `node_modules` is being assembled for; when the config admits
several platforms, the host is the only one we know can execute. This reading is not documented
anywhere user-facing yet.

The same change lands in pacquet's `runtime_platform_selector`.

Fixes pnpm/pnpm#13898

## Squash Commit Body

```text
resolvePlatformSelector took the first entry of each supportedArchitectures
list, so a project with devEngines.runtime and several supported platforms
downloaded the runtime for the first configured OS and CPU rather than for the
host. Each axis now prefers the host's own value when the list allows it, by
naming the value or by naming `current`, and falls back to the first entry only
when the list leaves the host out. pacquet's runtime_platform_selector follows
the same rule.

Closes pnpm/pnpm#13898
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users. It becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789248582&installation_model_id=426870&pr_number=13902&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13902&signature=716227ca214eb6879d3a9852514df5c54d8e07142da5a2ec599e17887ca1a4bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime platform selection when multiple operating systems, CPU architectures, or libc variants are supported.
  * The host platform is now preferred when listed or when using `current`; otherwise, the first configured platform is selected.
  * Fixed runtime installations and frozen-lockfile reinstalls to use the correct platform-specific binaries.

* **Tests**
  * Added coverage for host-platform preference, fallback behavior, `current` resolution, and platform-specific runtime installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
