### PR TITLE
perf(pnpr): skip the server exchange when there is nothing to resolve

### DIFF
--- a/.changeset/pnpr-skip-server-when-nothing-to-resolve.md
+++ b/.changeset/pnpr-skip-server-when-nothing-to-resolve.md
@@ -2,7 +2,7 @@
 "pacquet": patch
 ---
 
-With a configured `pnprServer`, `pnpm install` no longer pays a server exchange when there is nothing to resolve, so enabling pnpr is never slower than a direct install [pnpm/pnpm#13904](https://github.com/pnpm/pnpm/issues/13904):
+With a configured `pnprServer`, `pnpm install` skips the server exchanges it does not need, closing the gap where an up-to-date project paid a full resolve round trip that a direct install answered locally [pnpm/pnpm#13904](https://github.com/pnpm/pnpm/issues/13904):
 
 - The repeat-install "Already up to date" fast path now runs with a pnpr server configured.
 - An install whose `pnpm-lock.yaml` still satisfies every manifest skips the server resolve exchange and materializes `node_modules` from the on-disk lockfile.

--- a/.changeset/pnpr-skip-server-when-nothing-to-resolve.md
+++ b/.changeset/pnpr-skip-server-when-nothing-to-resolve.md
@@ -1,0 +1,10 @@
+---
+"pacquet": patch
+---
+
+With a configured `pnprServer`, `pnpm install` no longer pays a server exchange when there is nothing to resolve, so enabling pnpr is never slower than a direct install [pnpm/pnpm#13904](https://github.com/pnpm/pnpm/issues/13904):
+
+- The repeat-install "Already up to date" fast path now runs with a pnpr server configured.
+- An install whose `pnpm-lock.yaml` still satisfies every manifest skips the server resolve exchange and materializes `node_modules` from the on-disk lockfile.
+- The input-lockfile verification round trip is skipped when the local `lockfile-verified.jsonl` cache already covers the lockfile under the current policy; server-verified and server-resolved lockfiles are now recorded into that cache.
+- Changing the `trustPolicy*`, `minimumReleaseAgeStrict`, or `minimumReleaseAgeExclude` settings now invalidates the repeat-install fast path, matching the TypeScript CLI's workspace-state check.

--- a/.github/workflows/pacquet-integrated-benchmark.yml
+++ b/.github/workflows/pacquet-integrated-benchmark.yml
@@ -301,6 +301,32 @@ jobs:
           cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_HOT_CACHE_HOT_STORE.md
           cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_HOT_CACHE_HOT_STORE.json
 
+      - name: 'Benchmark: Isolated linker: repeat install, hot cache + hot store'
+        shell: bash
+        # Populated, up-to-date `node_modules`: nothing is wiped between
+        # iterations, so the timed command is the repeat-install
+        # short-circuit ("Already up to date"). Guards pnpm/pnpm#13904 —
+        # the harness asserts pnpr@HEAD is not slower than pacquet@HEAD
+        # here, since a configured pnpr server must cost nothing when
+        # there is nothing to resolve. Cheapest scenario per iteration.
+        timeout-minutes: 15
+        run: |
+          just integrated-benchmark --reuse-prebuilt-binaries --scenario=isolated-linker.repeat-install.hot-cache.hot-store --registry=verdaccio --pnpr-latency-ms=${PNPR_LATENCY_MS} --registry-latency-ms=${REGISTRY_LATENCY_MS} --registry-bandwidth-mbps=${REGISTRY_BANDWIDTH_MBPS} $BENCHMARK_TARGETS
+          cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_ISOLATED_REPEAT_INSTALL_HOT_CACHE_HOT_STORE.md
+          cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_ISOLATED_REPEAT_INSTALL_HOT_CACHE_HOT_STORE.json
+
+      - name: 'Benchmark: Isolated linker: repeat install, cold cache + hot store'
+        shell: bash
+        # Same populated repeat install with `cache-dir` wiped per
+        # iteration: the up-to-date answer must be reached without any
+        # metadata or verification-cache reads, so a cold cache may not
+        # slow it down (same pnpm/pnpm#13904 gate as the hot variant).
+        timeout-minutes: 15
+        run: |
+          just integrated-benchmark --reuse-prebuilt-binaries --scenario=isolated-linker.repeat-install.cold-cache.hot-store --registry=verdaccio --pnpr-latency-ms=${PNPR_LATENCY_MS} --registry-latency-ms=${REGISTRY_LATENCY_MS} --registry-bandwidth-mbps=${REGISTRY_BANDWIDTH_MBPS} $BENCHMARK_TARGETS
+          cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_ISOLATED_REPEAT_INSTALL_COLD_CACHE_HOT_STORE.md
+          cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_ISOLATED_REPEAT_INSTALL_COLD_CACHE_HOT_STORE.json
+
       - name: 'Benchmark: Isolated linker: fresh install, cold cache + cold store'
         shell: bash
         # No-lockfile scenario: a fresh resolution runs longer than the
@@ -489,6 +515,30 @@ jobs:
             echo
             echo '</details>'
             echo
+            echo '### Scenario: Isolated linker: repeat install, hot cache + hot store'
+            echo
+            cat bench-work-env/BENCHMARK_REPORT_ISOLATED_REPEAT_INSTALL_HOT_CACHE_HOT_STORE.md
+            echo
+            echo '<details><summary>BENCHMARK_REPORT.json</summary>'
+            echo
+            echo '```json'
+            jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_ISOLATED_REPEAT_INSTALL_HOT_CACHE_HOT_STORE.json
+            echo '```'
+            echo
+            echo '</details>'
+            echo
+            echo '### Scenario: Isolated linker: repeat install, cold cache + hot store'
+            echo
+            cat bench-work-env/BENCHMARK_REPORT_ISOLATED_REPEAT_INSTALL_COLD_CACHE_HOT_STORE.md
+            echo
+            echo '<details><summary>BENCHMARK_REPORT.json</summary>'
+            echo
+            echo '```json'
+            jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_ISOLATED_REPEAT_INSTALL_COLD_CACHE_HOT_STORE.json
+            echo '```'
+            echo
+            echo '</details>'
+            echo
             echo '### Scenario: Isolated linker: fresh install, cold cache + cold store'
             echo
             cat bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_COLD_CACHE_COLD_STORE.md
@@ -617,6 +667,8 @@ jobs:
           build_bencher_file bench-work-env/bencher-results.json pacquet@HEAD \
             'ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE:isolated-linker.fresh-restore.cold-cache.cold-store' \
             'ISOLATED_FRESH_RESTORE_HOT_CACHE_HOT_STORE:isolated-linker.fresh-restore.hot-cache.hot-store' \
+            'ISOLATED_REPEAT_INSTALL_HOT_CACHE_HOT_STORE:isolated-linker.repeat-install.hot-cache.hot-store' \
+            'ISOLATED_REPEAT_INSTALL_COLD_CACHE_HOT_STORE:isolated-linker.repeat-install.cold-cache.hot-store' \
             'ISOLATED_FRESH_INSTALL_COLD_CACHE_COLD_STORE:isolated-linker.fresh-install.cold-cache.cold-store' \
             'ISOLATED_FRESH_INSTALL_HOT_CACHE_HOT_STORE:isolated-linker.fresh-install.hot-cache.hot-store' \
             'ISOLATED_FRESH_INSTALL_COLD_CACHE_HOT_STORE:isolated-linker.fresh-install.cold-cache.hot-store' \
@@ -627,6 +679,8 @@ jobs:
           build_bencher_file bench-work-env/bencher-results-pnpr.json pnpr@HEAD \
             'ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE:isolated-linker.fresh-restore.cold-cache.cold-store' \
             'ISOLATED_FRESH_RESTORE_HOT_CACHE_HOT_STORE:isolated-linker.fresh-restore.hot-cache.hot-store' \
+            'ISOLATED_REPEAT_INSTALL_HOT_CACHE_HOT_STORE:isolated-linker.repeat-install.hot-cache.hot-store' \
+            'ISOLATED_REPEAT_INSTALL_COLD_CACHE_HOT_STORE:isolated-linker.repeat-install.cold-cache.hot-store' \
             'ISOLATED_FRESH_INSTALL_COLD_CACHE_COLD_STORE:isolated-linker.fresh-install.cold-cache.cold-store' \
             'ISOLATED_FRESH_INSTALL_HOT_CACHE_HOT_STORE:isolated-linker.fresh-install.hot-cache.hot-store' \
             'ISOLATED_FRESH_INSTALL_COLD_CACHE_HOT_STORE:isolated-linker.fresh-install.cold-cache.hot-store' \

--- a/.github/workflows/pacquet-integrated-benchmark.yml
+++ b/.github/workflows/pacquet-integrated-benchmark.yml
@@ -693,10 +693,16 @@ jobs:
         # workflow. The PR number and runner OS are derived from the
         # trusted workflow_run event payload in that workflow, not
         # from fork-controlled artifact contents.
+        #
+        # The raw per-scenario hyperfine exports ride along too: they
+        # keep the per-run sample distributions that the summary's
+        # embedded JSON strips to stay under GitHub's comment size
+        # limit, so noise investigations still have the full data.
         shell: bash
         run: |
           mkdir -p benchmark-artifact
           cp bench-work-env/SUMMARY.md benchmark-artifact/SUMMARY.md
+          cp bench-work-env/BENCHMARK_REPORT_*.json benchmark-artifact/
           cp bench-work-env/bencher-results.json benchmark-artifact/bencher-results.json
           cp bench-work-env/bencher-results-pnpr.json benchmark-artifact/bencher-results-pnpr.json
 

--- a/.github/workflows/pacquet-integrated-benchmark.yml
+++ b/.github/workflows/pacquet-integrated-benchmark.yml
@@ -498,7 +498,7 @@ jobs:
             echo '<details><summary>BENCHMARK_REPORT.json</summary>'
             echo
             echo '```json'
-            jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE.json
+            jq 'del(.results[].exit_codes, .results[].times)' bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE.json
             echo '```'
             echo
             echo '</details>'
@@ -510,7 +510,7 @@ jobs:
             echo '<details><summary>BENCHMARK_REPORT.json</summary>'
             echo
             echo '```json'
-            jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_HOT_CACHE_HOT_STORE.json
+            jq 'del(.results[].exit_codes, .results[].times)' bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_HOT_CACHE_HOT_STORE.json
             echo '```'
             echo
             echo '</details>'
@@ -522,7 +522,7 @@ jobs:
             echo '<details><summary>BENCHMARK_REPORT.json</summary>'
             echo
             echo '```json'
-            jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_ISOLATED_REPEAT_INSTALL_HOT_CACHE_HOT_STORE.json
+            jq 'del(.results[].exit_codes, .results[].times)' bench-work-env/BENCHMARK_REPORT_ISOLATED_REPEAT_INSTALL_HOT_CACHE_HOT_STORE.json
             echo '```'
             echo
             echo '</details>'
@@ -534,7 +534,7 @@ jobs:
             echo '<details><summary>BENCHMARK_REPORT.json</summary>'
             echo
             echo '```json'
-            jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_ISOLATED_REPEAT_INSTALL_COLD_CACHE_HOT_STORE.json
+            jq 'del(.results[].exit_codes, .results[].times)' bench-work-env/BENCHMARK_REPORT_ISOLATED_REPEAT_INSTALL_COLD_CACHE_HOT_STORE.json
             echo '```'
             echo
             echo '</details>'
@@ -546,7 +546,7 @@ jobs:
             echo '<details><summary>BENCHMARK_REPORT.json</summary>'
             echo
             echo '```json'
-            jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_COLD_CACHE_COLD_STORE.json
+            jq 'del(.results[].exit_codes, .results[].times)' bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_COLD_CACHE_COLD_STORE.json
             echo '```'
             echo
             echo '</details>'
@@ -558,7 +558,7 @@ jobs:
             echo '<details><summary>BENCHMARK_REPORT.json</summary>'
             echo
             echo '```json'
-            jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_HOT_CACHE_HOT_STORE.json
+            jq 'del(.results[].exit_codes, .results[].times)' bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_HOT_CACHE_HOT_STORE.json
             echo '```'
             echo
             echo '</details>'
@@ -570,7 +570,7 @@ jobs:
             echo '<details><summary>BENCHMARK_REPORT.json</summary>'
             echo
             echo '```json'
-            jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_COLD_CACHE_HOT_STORE.json
+            jq 'del(.results[].exit_codes, .results[].times)' bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_COLD_CACHE_HOT_STORE.json
             echo '```'
             echo
             echo '</details>'
@@ -582,7 +582,7 @@ jobs:
             echo '<details><summary>BENCHMARK_REPORT.json</summary>'
             echo
             echo '```json'
-            jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESOLVE_HOT_CACHE_OFFLINE.json
+            jq 'del(.results[].exit_codes, .results[].times)' bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESOLVE_HOT_CACHE_OFFLINE.json
             echo '```'
             echo
             echo '</details>'
@@ -594,7 +594,7 @@ jobs:
             echo '<details><summary>BENCHMARK_REPORT.json</summary>'
             echo
             echo '```json'
-            jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_ISOLATED_PEER_HEAVY_RESOLVE_HOT_CACHE_OFFLINE.json
+            jq 'del(.results[].exit_codes, .results[].times)' bench-work-env/BENCHMARK_REPORT_ISOLATED_PEER_HEAVY_RESOLVE_HOT_CACHE_OFFLINE.json
             echo '```'
             echo
             echo '</details>'
@@ -606,7 +606,7 @@ jobs:
             echo '<details><summary>BENCHMARK_REPORT.json</summary>'
             echo
             echo '```json'
-            jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE_COLD_PNPR.json
+            jq 'del(.results[].exit_codes, .results[].times)' bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE_COLD_PNPR.json
             echo '```'
             echo
             echo '</details>'

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -756,12 +756,15 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
         return Err(FrozenStoreIncompatibleWithPnpr.into());
     }
 
-    let previous_wanted = if link.use_state_lockfile {
+    // Borrowed from the shared state, not cloned: the frozen branch
+    // below never needs an owned lockfile, so the exchange-free paths
+    // pay no deep copy. The server-exchange paths clone at the point a
+    // request body actually needs one.
+    let previous_wanted: Option<&Lockfile> = if link.use_state_lockfile {
         state
             .lockfile
             .get()
             .map_err(|err| miette::Report::new(err).wrap_err("load the lockfile"))?
-            .cloned()
     } else {
         None
     };
@@ -807,7 +810,7 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
         && !link.lockfile_only
         && link.prefer_frozen_lockfile
         && selection.is_none()
-        && match previous_wanted.as_ref() {
+        && match previous_wanted {
             Some(lockfile) => {
                 wanted_lockfile_satisfies_workspace(&WantedLockfileSatisfactionCheck {
                     config: state.config,
@@ -835,40 +838,6 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
         PnprBenchmarkRegistryOverride::resolve_registry,
     );
 
-    // Send the on-disk lockfile + the full client policy so the server
-    // verifies the input lockfile under *our* policy before resolving;
-    // the client never runs `verify_lockfile_resolutions` on the pnpr
-    // path ([pnpm/pnpm#12139](https://github.com/pnpm/pnpm/issues/12139)).
-    // `trustPolicy: no-downgrade` is enforced
-    // server-side now — both for reused entries (the input-lockfile
-    // verifier) and freshly-resolved ones (the resolver's pick-time
-    // gate, since the policy is wired into the server's config).
-    let opts = ResolveProjectsOptions {
-        projects,
-        registry: resolve_registry,
-        named_registries: state.config.named_registries.clone(),
-        // Only the caller's identity to pnpr is sent. Upstream registry
-        // credentials are never forwarded: pnpr selects them from its own
-        // route policy, so they stay out of the request body.
-        authorization: state.config.auth_headers.for_url(pnpr_server),
-        overrides,
-        catalogs,
-        lockfile: previous_wanted.clone(),
-        frozen_lockfile: link.frozen_lockfile,
-        prefer_frozen_lockfile: Some(link.prefer_frozen_lockfile),
-        ignore_manifest_check: link.ignore_manifest_check,
-        trust_lockfile: link.trust_lockfile,
-        minimum_release_age: state.config.minimum_release_age,
-        minimum_release_age_exclude: state.config.minimum_release_age_exclude.clone(),
-        minimum_release_age_ignore_missing_time: state
-            .config
-            .minimum_release_age_ignore_missing_time,
-        trust_policy: state.config.trust_policy,
-        trust_policy_exclude: state.config.trust_policy_exclude.clone(),
-        trust_policy_ignore_after: state.config.trust_policy_ignore_after,
-    };
-
-    let client = PnprClient::new(pnpr_server);
     let lockfile_dir = link.lockfile_path.and_then(|path| path.parent()).unwrap_or_else(|| {
         state.manifest.path().parent().expect("manifest path always has a parent dir")
     });
@@ -878,7 +847,7 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
 
     if (satisfied_without_server
         || (link.frozen_lockfile && (selection.is_some() || !link.lockfile_only)))
-        && let Some(lockfile) = previous_wanted.as_ref()
+        && let Some(lockfile) = previous_wanted
     {
         let prefetcher = if link.lockfile_only {
             None
@@ -951,8 +920,22 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
             ) {
                 None
             } else {
-                let verify_opts = VerifyLockfileOptions::from_resolve_projects_options(&opts)
-                    .expect("frozen pnpr verification requires the loaded lockfile");
+                let verify_opts = VerifyLockfileOptions {
+                    registry: resolve_registry.clone(),
+                    named_registries: state.config.named_registries.clone(),
+                    authorization: state.config.auth_headers.for_url(pnpr_server),
+                    overrides: overrides.clone(),
+                    lockfile: lockfile.clone(),
+                    trust_lockfile: link.trust_lockfile,
+                    minimum_release_age: state.config.minimum_release_age,
+                    minimum_release_age_exclude: state.config.minimum_release_age_exclude.clone(),
+                    minimum_release_age_ignore_missing_time: state
+                        .config
+                        .minimum_release_age_ignore_missing_time,
+                    trust_policy: state.config.trust_policy,
+                    trust_policy_exclude: state.config.trust_policy_exclude.clone(),
+                    trust_policy_ignore_after: state.config.trust_policy_ignore_after,
+                };
                 let verify_client = PnprClient::new(pnpr_server);
                 let cache_dir = state.config.cache_dir.clone();
                 let record_lockfile_path = lockfile_path.clone();
@@ -1047,6 +1030,40 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
         return Ok(());
     }
 
+    // Send the on-disk lockfile + the full client policy so the server
+    // verifies the input lockfile under *our* policy before resolving;
+    // the client never runs `verify_lockfile_resolutions` on the pnpr
+    // path ([pnpm/pnpm#12139](https://github.com/pnpm/pnpm/issues/12139)).
+    // `trustPolicy: no-downgrade` is enforced
+    // server-side now — both for reused entries (the input-lockfile
+    // verifier) and freshly-resolved ones (the resolver's pick-time
+    // gate, since the policy is wired into the server's config).
+    let opts = ResolveProjectsOptions {
+        projects,
+        registry: resolve_registry,
+        named_registries: state.config.named_registries.clone(),
+        // Only the caller's identity to pnpr is sent. Upstream registry
+        // credentials are never forwarded: pnpr selects them from its own
+        // route policy, so they stay out of the request body.
+        authorization: state.config.auth_headers.for_url(pnpr_server),
+        overrides,
+        catalogs,
+        lockfile: previous_wanted.cloned(),
+        frozen_lockfile: link.frozen_lockfile,
+        prefer_frozen_lockfile: Some(link.prefer_frozen_lockfile),
+        ignore_manifest_check: link.ignore_manifest_check,
+        trust_lockfile: link.trust_lockfile,
+        minimum_release_age: state.config.minimum_release_age,
+        minimum_release_age_exclude: state.config.minimum_release_age_exclude.clone(),
+        minimum_release_age_ignore_missing_time: state
+            .config
+            .minimum_release_age_ignore_missing_time,
+        trust_policy: state.config.trust_policy,
+        trust_policy_exclude: state.config.trust_policy_exclude.clone(),
+        trust_policy_ignore_after: state.config.trust_policy_ignore_after,
+    };
+    let client = PnprClient::new(pnpr_server);
+
     // Under `--lockfile-only` nothing is materialized, so skip the
     // prefetcher entirely and consume the stream with a no-op callback.
     // A partial install also waits for the merged lockfile before fetching,
@@ -1114,7 +1131,7 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
             .or(state.config.workspace_dir.as_deref()),
     ) {
         outcome.lockfile = merge_filtered_wanted_lockfile(
-            previous_wanted.as_ref(),
+            previous_wanted,
             outcome.lockfile,
             real_importer_ids,
             selected_importer_ids,

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -14,12 +14,14 @@ use pacquet_catalogs_config::get_catalogs_from_workspace_manifest;
 use pacquet_catalogs_types::Catalogs;
 use pacquet_config::NodeLinker;
 use pacquet_lockfile::{Lockfile, LockfileResolution, MaybeLazyLockfile};
+use pacquet_lockfile_verification::{lockfile_verification_is_cached, record_lockfile_verified};
 use pacquet_modules_yaml::IncludedDependencies;
 use pacquet_package_manager::{
     Install, InstallFrozenLockfileError, LockfileVerificationOverride, ProjectMutation,
     SkippedSnapshots, TarballPrefetcher, UpToDateFastPathCheck, UpdateSeedPolicy,
-    WorkspaceInstallSelection, install_already_up_to_date, materialization_closure,
-    merge_filtered_wanted_lockfile,
+    WantedLockfileSatisfactionCheck, WorkspaceInstallSelection, build_resolution_verifiers,
+    install_already_up_to_date, materialization_closure, merge_filtered_wanted_lockfile,
+    wanted_lockfile_satisfies_workspace,
 };
 use pacquet_package_manifest::DependencyGroup;
 use pacquet_pnpr_client::{
@@ -301,10 +303,15 @@ impl InstallArgs {
     /// (which checks `recursive` / `filter` before reaching here) plus
     /// every input that would make [`Install::run`] skip its own
     /// short-circuit or do extra pre-install work: an explicit
-    /// `--frozen-lockfile` / `--lockfile-only`, a configured pnpr
-    /// server (that path never runs the optimistic check), config
+    /// `--frozen-lockfile` / `--lockfile-only`, config
     /// dependencies, and pnpmfile `updateConfig` hooks (both can
-    /// mutate the config the check compares against).
+    /// mutate the config the check compares against). A configured
+    /// pnpr server deliberately does NOT bail: the check decides
+    /// purely locally that nothing changed since the previous
+    /// (workspace-state-recording) install, and asking the server
+    /// cannot change that answer — while trust/policy setting changes
+    /// fall through via the settings drift comparison
+    /// ([pnpm/pnpm#13904](https://github.com/pnpm/pnpm/issues/13904)).
     ///
     /// `false` means "not decided" — the caller proceeds with the full
     /// install path, which re-runs the same check cheaply and
@@ -319,11 +326,7 @@ impl InstallArgs {
             || self.lockfile_only
             || self.force
             || self.verify_deps_before_run_install
-            || self.pnpr_server.is_some()
         {
-            return false;
-        }
-        if config.pnpr_server.is_some() {
             return false;
         }
         // Dedicated per-project lockfiles run one install per workspace
@@ -722,6 +725,15 @@ fn resolve_project(
 /// frozen install fetches every tarball from the registries itself, like
 /// a normal install. Under `--lockfile-only` it stops after writing the
 /// lockfile (fetch nothing, link nothing).
+///
+/// The server is only contacted when there is resolution or
+/// verification work for it: an install whose on-disk lockfile still
+/// satisfies every manifest skips the resolve exchange and goes
+/// straight to the frozen materialization, and the input-lockfile
+/// verification round trip is skipped when the local
+/// `lockfile-verified.jsonl` cache already covers the lockfile under
+/// the current policy
+/// ([pnpm/pnpm#13904](https://github.com/pnpm/pnpm/issues/13904)).
 pub(crate) async fn install_via_pnpr<Reporter: self::Reporter + 'static>(
     state: &State,
     pnpr_server: &str,
@@ -789,6 +801,32 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
         (importer_ids.clone(), importer_ids)
     });
 
+    let catalogs = pnpr_catalogs(state)?;
+
+    // The local satisfaction gate ([pnpm/pnpm#13904](https://github.com/pnpm/pnpm/issues/13904)):
+    // when the on-disk lockfile still satisfies every manifest, there is
+    // nothing for the server to resolve, so the install goes straight to
+    // the frozen materialization below — the same dispatch the
+    // non-pnpr path takes via `preferFrozenLockfile`. Filtered installs
+    // keep the server exchange: their merge semantics live there.
+    let satisfied_without_server = !link.frozen_lockfile
+        && !link.lockfile_only
+        && link.prefer_frozen_lockfile
+        && selection.is_none()
+        && match previous_wanted.as_ref() {
+            Some(lockfile) => {
+                wanted_lockfile_satisfies_workspace(&WantedLockfileSatisfactionCheck {
+                    config: state.config,
+                    manifest: &state.manifest,
+                    catalogs: &catalogs.clone().unwrap_or_default(),
+                    lockfile,
+                    ignore_manifest_check: link.ignore_manifest_check,
+                })
+                .await
+            }
+            None => false,
+        };
+
     let overrides = state
         .config
         .overrides
@@ -820,7 +858,7 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
         // route policy, so they stay out of the request body.
         authorization: state.config.auth_headers.for_url(pnpr_server),
         overrides,
-        catalogs: pnpr_catalogs(state)?,
+        catalogs,
         lockfile: previous_wanted.clone(),
         frozen_lockfile: link.frozen_lockfile,
         prefer_frozen_lockfile: Some(link.prefer_frozen_lockfile),
@@ -844,8 +882,8 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
         .lockfile_path
         .map_or_else(|| lockfile_dir.join(Lockfile::FILE_NAME), std::path::Path::to_path_buf);
 
-    if link.frozen_lockfile
-        && (selection.is_some() || !link.lockfile_only)
+    if (satisfied_without_server
+        || (link.frozen_lockfile && (selection.is_some() || !link.lockfile_only)))
         && let Some(lockfile) = previous_wanted.as_ref()
     {
         let prefetcher = if link.lockfile_only {
@@ -898,16 +936,49 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
             Some(prefetcher)
         };
 
-        let lockfile_verification_override: Option<LockfileVerificationOverride<'_>> =
-            if link.trust_lockfile {
+        // Delegated to the server only when the local verification cache
+        // can't already vouch for this lockfile under the current policy
+        // — a warm `lockfile-verified.jsonl` makes the round trip pure
+        // overhead ([pnpm/pnpm#13904](https://github.com/pnpm/pnpm/issues/13904)).
+        // A server pass is recorded into the same cache, so the next
+        // install of the unchanged lockfile skips the exchange.
+        let lockfile_verification_override: Option<LockfileVerificationOverride<'_>> = if link
+            .trust_lockfile
+        {
+            None
+        } else {
+            let verifiers = build_resolution_verifiers(
+                state.config,
+                std::sync::Arc::clone(&state.http_client),
+                None,
+                None,
+                None,
+            )
+            .map_err(miette::Report::new)?;
+            if lockfile_verification_is_cached(
+                &state.config.cache_dir,
+                &lockfile_path,
+                lockfile,
+                &verifiers,
+            ) {
                 None
             } else {
                 let verify_opts = VerifyLockfileOptions::from_resolve_projects_options(&opts)
                     .expect("frozen pnpr verification requires the loaded lockfile");
                 let verify_client = PnprClient::new(pnpr_server);
+                let cache_dir = state.config.cache_dir.clone();
+                let record_lockfile_path = lockfile_path.clone();
                 Some(Box::pin(async move {
                     match verify_client.verify_lockfile(verify_opts).await {
-                        Ok(()) => Ok(()),
+                        Ok(()) => {
+                            record_lockfile_verified(
+                                Some(&cache_dir),
+                                &record_lockfile_path,
+                                lockfile,
+                                &verifiers,
+                            );
+                            Ok(())
+                        }
                         Err(PnprClientError::Verification(verify_err)) => {
                             Err(InstallFrozenLockfileError::LockfileVerification(verify_err))
                         }
@@ -916,7 +987,8 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
                         )),
                     }
                 }) as LockfileVerificationOverride<'_>)
-            };
+            }
+        };
 
         let install = Install {
             tarball_mem_cache: std::sync::Arc::clone(&state.tarball_mem_cache),
@@ -1069,6 +1141,26 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
             .save_to_path(&lockfile_path)
             .map_err(|err| miette::miette!("{err}"))
             .wrap_err("writing the pnpr-resolved lockfile")?;
+        // The server resolved and verified this lockfile under our
+        // policy, so mark it verified locally — pnpm's
+        // `writeWantedLockfileAndRecordVerified` — letting the next
+        // install's cache probe skip the server verification exchange.
+        if !link.trust_lockfile
+            && let Ok(verifiers) = build_resolution_verifiers(
+                state.config,
+                std::sync::Arc::clone(&state.http_client),
+                None,
+                None,
+                None,
+            )
+        {
+            record_lockfile_verified(
+                Some(&state.config.cache_dir),
+                &lockfile_path,
+                &outcome.lockfile,
+                &verifiers,
+            );
+        }
     }
 
     // `--lockfile-only`: the server resolved and returned the lockfile

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -803,12 +803,8 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
 
     let catalogs = pnpr_catalogs(state)?;
 
-    // The local satisfaction gate ([pnpm/pnpm#13904](https://github.com/pnpm/pnpm/issues/13904)):
-    // when the on-disk lockfile still satisfies every manifest, there is
-    // nothing for the server to resolve, so the install goes straight to
-    // the frozen materialization below — the same dispatch the
-    // non-pnpr path takes via `preferFrozenLockfile`. Filtered installs
-    // keep the server exchange: their merge semantics live there.
+    // Filtered installs keep the server exchange even when satisfied:
+    // their merge semantics live there.
     let satisfied_without_server = !link.frozen_lockfile
         && !link.lockfile_only
         && link.prefer_frozen_lockfile
@@ -936,12 +932,6 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
             Some(prefetcher)
         };
 
-        // Delegated to the server only when the local verification cache
-        // can't already vouch for this lockfile under the current policy
-        // — a warm `lockfile-verified.jsonl` makes the round trip pure
-        // overhead ([pnpm/pnpm#13904](https://github.com/pnpm/pnpm/issues/13904)).
-        // A server pass is recorded into the same cache, so the next
-        // install of the unchanged lockfile skips the exchange.
         let lockfile_verification_override: Option<LockfileVerificationOverride<'_>> = if link
             .trust_lockfile
         {
@@ -1141,10 +1131,9 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
             .save_to_path(&lockfile_path)
             .map_err(|err| miette::miette!("{err}"))
             .wrap_err("writing the pnpr-resolved lockfile")?;
-        // The server resolved and verified this lockfile under our
-        // policy, so mark it verified locally — pnpm's
-        // `writeWantedLockfileAndRecordVerified` — letting the next
-        // install's cache probe skip the server verification exchange.
+        // Recording is sound here because the server resolved and
+        // verified this lockfile under the client's own forwarded
+        // policy (pnpm's `writeWantedLockfileAndRecordVerified`).
         if !link.trust_lockfile
             && let Ok(verifiers) = build_resolution_verifiers(
                 state.config,

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -307,10 +307,8 @@ impl InstallArgs {
     /// dependencies, and pnpmfile `updateConfig` hooks (both can
     /// mutate the config the check compares against). A configured
     /// pnpr server deliberately does NOT bail: the check decides
-    /// purely locally that nothing changed since the previous
-    /// (workspace-state-recording) install, and asking the server
-    /// cannot change that answer — while trust/policy setting changes
-    /// fall through via the settings drift comparison
+    /// purely locally that nothing changed, and asking the server
+    /// cannot change that answer
     /// ([pnpm/pnpm#13904](https://github.com/pnpm/pnpm/issues/13904)).
     ///
     /// `false` means "not decided" — the caller proceeds with the full

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -1035,7 +1035,7 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
     // the client never runs `verify_lockfile_resolutions` on the pnpr
     // path ([pnpm/pnpm#12139](https://github.com/pnpm/pnpm/issues/12139)).
     // `trustPolicy: no-downgrade` is enforced
-    // server-side now — both for reused entries (the input-lockfile
+    // server-side — both for reused entries (the input-lockfile
     // verifier) and freshly-resolved ones (the resolver's pick-time
     // gate, since the policy is wired into the server's config).
     let opts = ResolveProjectsOptions {
@@ -1146,9 +1146,13 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
             .save_to_path(&lockfile_path)
             .map_err(|err| miette::miette!("{err}"))
             .wrap_err("writing the pnpr-resolved lockfile")?;
-        // Recording is sound here because the server resolved and
-        // verified this lockfile under the client's own forwarded
-        // policy (pnpm's `writeWantedLockfileAndRecordVerified`).
+        // Recording is sound here because every entry in the saved
+        // lockfile passed the server's gates under the client's own
+        // forwarded policy: freshly-resolved entries through the
+        // pick-time gate, and entries carried over by the filtered-
+        // install merge as part of the input lockfile the server
+        // verified before resolving (pnpm's
+        // `writeWantedLockfileAndRecordVerified`).
         if !link.trust_lockfile
             && let Ok(verifiers) = build_resolution_verifiers(
                 state.config,

--- a/pnpm/crates/cli/tests/suite/install.rs
+++ b/pnpm/crates/cli/tests/suite/install.rs
@@ -2016,6 +2016,60 @@ fn migrated_keys_are_reported_by_the_up_to_date_fast_path() {
     drop(root);
 }
 
+/// Trust/policy settings key the lockfile-verification gate, so a
+/// change must look like settings drift and defeat the repeat-install
+/// fast path — the full install re-runs the verifier fan-out and
+/// re-records the workspace state, after which the fast path applies
+/// again. pnpm records `trustPolicy*` in the workspace state for
+/// exactly this reason.
+#[test]
+fn trust_policy_change_defeats_the_up_to_date_fast_path() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "dependencies": { "@foo/no-deps": "1.0.0" } }).to_string(),
+    )
+    .expect("write package.json");
+
+    let run_install = || {
+        let assert = pacquet_in(&workspace)
+            .with_env("PNPM_CONFIG_REGISTRY", mock_instance.url())
+            .with_arg("install")
+            .assert()
+            .success();
+        String::from_utf8_lossy(&assert.get_output().stdout).into_owned()
+    };
+
+    pacquet
+        .with_env("PNPM_CONFIG_REGISTRY", mock_instance.url())
+        .with_arg("install")
+        .assert()
+        .success();
+    assert!(
+        run_install().contains("Already up to date"),
+        "an unchanged repeat install must take the fast path",
+    );
+
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    fs::write(&workspace_yaml_path, format!("{workspace_yaml}trustPolicy: no-downgrade\n"))
+        .expect("write pnpm-workspace.yaml");
+
+    assert!(
+        !run_install().contains("Already up to date"),
+        "a trustPolicy change must defeat the fast path",
+    );
+    assert!(
+        run_install().contains("Already up to date"),
+        "the full install re-records the state, so the fast path applies again",
+    );
+
+    drop((root, mock_instance));
+}
+
 /// Each emit site reads the root manifest on its own, and an editor may
 /// leave a UTF-8 BOM at its head. A reader that trips over one drops the
 /// warning without a trace, so both sites are exercised: the install

--- a/pnpm/crates/cli/tests/suite/install.rs
+++ b/pnpm/crates/cli/tests/suite/install.rs
@@ -2016,12 +2016,8 @@ fn migrated_keys_are_reported_by_the_up_to_date_fast_path() {
     drop(root);
 }
 
-/// Trust/policy settings key the lockfile-verification gate, so a
-/// change must look like settings drift and defeat the repeat-install
-/// fast path — the full install re-runs the verifier fan-out and
-/// re-records the workspace state, after which the fast path applies
-/// again. pnpm records `trustPolicy*` in the workspace state for
-/// exactly this reason.
+/// Trust/policy settings key the lockfile-verification gate, which is
+/// why pnpm records `trustPolicy*` in the workspace state.
 #[test]
 fn trust_policy_change_defeats_the_up_to_date_fast_path() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =

--- a/pnpm/crates/cli/tests/suite/pnpr_install.rs
+++ b/pnpm/crates/cli/tests/suite/pnpr_install.rs
@@ -269,10 +269,7 @@ fn frozen_install_via_pnpr_verifies_the_local_lockfile_without_resolving_or_redo
     drop((root, mock_instance));
 }
 
-/// A repeat `pnpm install` in an up-to-date tree finishes through the
-/// pre-runtime "Already up to date" fast path even with a pnpr server
-/// configured — the up-to-date verdict is decided purely locally, so no
-/// request reaches the server
+/// The up-to-date verdict is decided purely locally
 /// ([pnpm/pnpm#13904](https://github.com/pnpm/pnpm/issues/13904)).
 #[test]
 fn repeat_install_via_pnpr_short_circuits_without_contacting_the_server() {
@@ -317,12 +314,8 @@ fn repeat_install_via_pnpr_short_circuits_without_contacting_the_server() {
     drop((root, mock_instance));
 }
 
-/// An install whose lockfile still satisfies the manifest has nothing to
-/// resolve, so even with `node_modules` wiped (where the up-to-date fast
-/// path can't answer) the client materializes from the on-disk lockfile
-/// without any server exchange: no resolve — the satisfaction check is
-/// local — and no verification round trip, because the previous install
-/// recorded the lockfile in the local verification cache
+/// Zero exchanges, not one: the verification round trip is covered by
+/// the record the previous install left in the local verification cache
 /// ([pnpm/pnpm#13904](https://github.com/pnpm/pnpm/issues/13904)).
 #[test]
 fn install_via_pnpr_skips_the_server_when_the_lockfile_satisfies_the_manifest() {
@@ -370,10 +363,8 @@ fn install_via_pnpr_skips_the_server_when_the_lockfile_satisfies_the_manifest() 
     drop((root, mock_instance));
 }
 
-/// The satisfaction check skips only the *resolve* exchange on its own;
-/// with the local verification cache cold, the input lockfile is still
-/// verified through the server — one `verify-lockfile` request and no
-/// `resolve` ([pnpm/pnpm#13904](https://github.com/pnpm/pnpm/issues/13904)).
+/// The satisfaction check skips only the *resolve* exchange on its own
+/// ([pnpm/pnpm#13904](https://github.com/pnpm/pnpm/issues/13904)).
 #[test]
 fn satisfied_install_via_pnpr_delegates_verification_when_the_cache_is_cold() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =

--- a/pnpm/crates/cli/tests/suite/pnpr_install.rs
+++ b/pnpm/crates/cli/tests/suite/pnpr_install.rs
@@ -97,6 +97,25 @@ fn pacquet_at(workspace: &Path) -> Command {
     Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
 }
 
+/// Rewrite the `.npmrc` `registry=` line. Registry resolutions derive
+/// their tarball URLs from the configured registry at install time, so
+/// the swap is transparent to an existing lockfile.
+fn point_npmrc_registry_at(npmrc_path: &Path, registry_url: &str) {
+    let npmrc = fs::read_to_string(npmrc_path)
+        .expect("read .npmrc")
+        .lines()
+        .map(|line| {
+            if line.starts_with("registry=") {
+                format!("registry={registry_url}/")
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(npmrc_path, npmrc).expect("rewrite .npmrc");
+}
+
 #[test]
 fn install_via_pnpr_links_node_modules() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
@@ -194,6 +213,121 @@ fn install_via_pnpr_preserves_the_lockfiles_time_section() {
 fn frozen_install_via_pnpr_verifies_the_local_lockfile_without_resolving_or_redownloading() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { npmrc_path, cache_dir, mock_instance, .. } = npmrc_info;
+
+    let (pnpr_url, token) = start_pnpr(&mock_instance.url());
+    configure_pnpr_auth(&npmrc_path, &pnpr_url, &token);
+
+    let manifest_path = workspace.join("package.json");
+    let package_json = serde_json::json!({
+        "dependencies": { "@foo/no-deps": "1.0.0" },
+    });
+    fs::write(&manifest_path, package_json.to_string()).expect("write package.json");
+
+    pacquet
+        .with_env("PNPM_CONFIG_REGISTRY", mock_instance.url())
+        .with_arg("install")
+        .with_arg("--pnpr-server")
+        .with_arg(&pnpr_url)
+        .assert()
+        .success();
+    fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
+    // The first install recorded its lockfile as verified; wipe that
+    // cache so this test still exercises the server-delegated
+    // verification path instead of the cache short-circuit.
+    fs::remove_dir_all(&cache_dir).expect("wipe the client cache dir");
+
+    let mut verifier = mockito::Server::new();
+    let verify_mock = verifier
+        .mock("POST", "/-/pnpr/v0/verify-lockfile")
+        .with_status(200)
+        .with_header("content-type", "application/x-ndjson")
+        .with_body("{\"type\":\"done\"}\n")
+        .expect(1)
+        .create();
+
+    // The first install warmed the store, so the frozen restore must not
+    // fetch a single tarball: point the registry at a server that rejects
+    // every request.
+    let mut silent_registry = mockito::Server::new();
+    let no_downloads = silent_registry.mock("GET", mockito::Matcher::Any).expect(0).create();
+    point_npmrc_registry_at(&npmrc_path, &silent_registry.url());
+
+    pacquet_at(&workspace)
+        .with_arg("install")
+        .with_arg("--frozen-lockfile")
+        .with_arg("--pnpr-server")
+        .with_arg(verifier.url())
+        .assert()
+        .success();
+
+    verify_mock.assert();
+    no_downloads.assert();
+    let symlink_path = workspace.join("node_modules/@foo/no-deps");
+    assert!(is_symlink_or_junction(&symlink_path).unwrap(), "direct dep should be symlinked");
+
+    drop((root, mock_instance));
+}
+
+/// A repeat `pnpm install` in an up-to-date tree finishes through the
+/// pre-runtime "Already up to date" fast path even with a pnpr server
+/// configured — the up-to-date verdict is decided purely locally, so no
+/// request reaches the server
+/// ([pnpm/pnpm#13904](https://github.com/pnpm/pnpm/issues/13904)).
+#[test]
+fn repeat_install_via_pnpr_short_circuits_without_contacting_the_server() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { npmrc_path, mock_instance, .. } = npmrc_info;
+
+    let (pnpr_url, token) = start_pnpr(&mock_instance.url());
+    configure_pnpr_auth(&npmrc_path, &pnpr_url, &token);
+
+    let manifest_path = workspace.join("package.json");
+    let package_json = serde_json::json!({
+        "dependencies": { "@foo/no-deps": "1.0.0" },
+    });
+    fs::write(&manifest_path, package_json.to_string()).expect("write package.json");
+
+    pacquet
+        .with_env("PNPM_CONFIG_REGISTRY", mock_instance.url())
+        .with_arg("install")
+        .with_arg("--pnpr-server")
+        .with_arg(&pnpr_url)
+        .assert()
+        .success();
+
+    let mut silent_pnpr = mockito::Server::new();
+    let no_pnpr_requests = silent_pnpr.mock("POST", mockito::Matcher::Any).expect(0).create();
+
+    let assert = pacquet_at(&workspace)
+        .with_env("PNPM_CONFIG_REGISTRY", mock_instance.url())
+        .with_arg("install")
+        .with_arg("--pnpr-server")
+        .with_arg(silent_pnpr.url())
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout).into_owned();
+    assert!(
+        stdout.contains("Already up to date"),
+        "expected the up-to-date fast path's output; got:\n{stdout}",
+    );
+    no_pnpr_requests.assert();
+
+    drop((root, mock_instance));
+}
+
+/// An install whose lockfile still satisfies the manifest has nothing to
+/// resolve, so even with `node_modules` wiped (where the up-to-date fast
+/// path can't answer) the client materializes from the on-disk lockfile
+/// without any server exchange: no resolve — the satisfaction check is
+/// local — and no verification round trip, because the previous install
+/// recorded the lockfile in the local verification cache
+/// ([pnpm/pnpm#13904](https://github.com/pnpm/pnpm/issues/13904)).
+#[test]
+fn install_via_pnpr_skips_the_server_when_the_lockfile_satisfies_the_manifest() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
     let AddMockedRegistry { npmrc_path, mock_instance, .. } = npmrc_info;
 
     let (pnpr_url, token) = start_pnpr(&mock_instance.url());
@@ -214,6 +348,57 @@ fn frozen_install_via_pnpr_verifies_the_local_lockfile_without_resolving_or_redo
         .success();
     fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
 
+    let mut silent_pnpr = mockito::Server::new();
+    let no_pnpr_requests = silent_pnpr.mock("POST", mockito::Matcher::Any).expect(0).create();
+    // The warm store must serve every tarball; reject any registry fetch.
+    let mut silent_registry = mockito::Server::new();
+    let no_downloads = silent_registry.mock("GET", mockito::Matcher::Any).expect(0).create();
+    point_npmrc_registry_at(&npmrc_path, &silent_registry.url());
+
+    pacquet_at(&workspace)
+        .with_arg("install")
+        .with_arg("--pnpr-server")
+        .with_arg(silent_pnpr.url())
+        .assert()
+        .success();
+
+    no_pnpr_requests.assert();
+    no_downloads.assert();
+    let symlink_path = workspace.join("node_modules/@foo/no-deps");
+    assert!(is_symlink_or_junction(&symlink_path).unwrap(), "direct dep should be symlinked");
+
+    drop((root, mock_instance));
+}
+
+/// The satisfaction check skips only the *resolve* exchange on its own;
+/// with the local verification cache cold, the input lockfile is still
+/// verified through the server — one `verify-lockfile` request and no
+/// `resolve` ([pnpm/pnpm#13904](https://github.com/pnpm/pnpm/issues/13904)).
+#[test]
+fn satisfied_install_via_pnpr_delegates_verification_when_the_cache_is_cold() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { npmrc_path, cache_dir, mock_instance, .. } = npmrc_info;
+
+    let (pnpr_url, token) = start_pnpr(&mock_instance.url());
+    configure_pnpr_auth(&npmrc_path, &pnpr_url, &token);
+
+    let manifest_path = workspace.join("package.json");
+    let package_json = serde_json::json!({
+        "dependencies": { "@foo/no-deps": "1.0.0" },
+    });
+    fs::write(&manifest_path, package_json.to_string()).expect("write package.json");
+
+    pacquet
+        .with_env("PNPM_CONFIG_REGISTRY", mock_instance.url())
+        .with_arg("install")
+        .with_arg("--pnpr-server")
+        .with_arg(&pnpr_url)
+        .assert()
+        .success();
+    fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
+    fs::remove_dir_all(&cache_dir).expect("wipe the client cache dir");
+
     let mut verifier = mockito::Server::new();
     let verify_mock = verifier
         .mock("POST", "/-/pnpr/v0/verify-lockfile")
@@ -222,38 +407,18 @@ fn frozen_install_via_pnpr_verifies_the_local_lockfile_without_resolving_or_redo
         .with_body("{\"type\":\"done\"}\n")
         .expect(1)
         .create();
-
-    // The first install warmed the store, so the frozen restore must not
-    // fetch a single tarball: point the registry at a server that rejects
-    // every request. Registry resolutions derive their tarball URLs from
-    // the configured registry at install time, so the swap is transparent
-    // to the lockfile.
-    let mut silent_registry = mockito::Server::new();
-    let no_downloads = silent_registry.mock("GET", mockito::Matcher::Any).expect(0).create();
-    let npmrc = fs::read_to_string(&npmrc_path)
-        .expect("read .npmrc")
-        .lines()
-        .map(|line| {
-            if line.starts_with("registry=") {
-                format!("registry={}/", silent_registry.url())
-            } else {
-                line.to_string()
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
-    fs::write(&npmrc_path, npmrc).expect("rewrite .npmrc");
+    let no_resolve = verifier.mock("POST", "/-/pnpr/v0/resolve").expect(0).create();
 
     pacquet_at(&workspace)
+        .with_env("PNPM_CONFIG_REGISTRY", mock_instance.url())
         .with_arg("install")
-        .with_arg("--frozen-lockfile")
         .with_arg("--pnpr-server")
         .with_arg(verifier.url())
         .assert()
         .success();
 
     verify_mock.assert();
-    no_downloads.assert();
+    no_resolve.assert();
     let symlink_path = workspace.join("node_modules/@foo/no-deps");
     assert!(is_symlink_or_junction(&symlink_path).unwrap(), "direct dep should be symlinked");
 

--- a/pnpm/crates/lockfile-verification/src/lib.rs
+++ b/pnpm/crates/lockfile-verification/src/lib.rs
@@ -11,6 +11,7 @@
 //! JSONL stat-and-skip cache.
 //!
 //! Public surface today: [`verify_lockfile_resolutions()`],
+//! [`lockfile_verification_is_cached()`],
 //! [`verify_lockfile_dependency_names()`],
 //! [`collect_resolution_policy_violations()`], [`hash_lockfile()`],
 //! [`VerifyError`], and [`RenderedViolation`] — the last lets a caller
@@ -36,6 +37,6 @@ pub use hash_lockfile::hash_lockfile;
 pub use record_lockfile_verified::record_lockfile_verified;
 pub use verify_lockfile_resolutions::{
     RESOLUTION_SHAPE_MISMATCH_VIOLATION_CODE, VerifyLockfileResolutionsOptions,
-    collect_resolution_policy_violations, verify_lockfile_dependency_names,
-    verify_lockfile_resolutions,
+    collect_resolution_policy_violations, lockfile_verification_is_cached,
+    verify_lockfile_dependency_names, verify_lockfile_resolutions,
 };

--- a/pnpm/crates/lockfile-verification/src/verify_lockfile_resolutions.rs
+++ b/pnpm/crates/lockfile-verification/src/verify_lockfile_resolutions.rs
@@ -56,6 +56,38 @@ pub struct VerifyLockfileResolutionsOptions<'a> {
     pub cache_dir: Option<&'a Path>,
 }
 
+/// Whether a recorded verification already covers `lockfile` as it sits
+/// at `lockfile_path` under the policy `verifiers` currently demand —
+/// i.e. whether a [`verify_lockfile_resolutions`] call would
+/// short-circuit on the cache without running the fan-out. The offline
+/// structural dependency-name gate runs here too (it is cheap and the
+/// cache never covers a lockfile that fails it), so a `true` return
+/// carries the same guarantee as the runner's cache hit.
+///
+/// Lets the pnpr client decide locally whether the server-side
+/// `verify_lockfile` round trip can be skipped
+/// ([pnpm/pnpm#13904](https://github.com/pnpm/pnpm/issues/13904)).
+pub fn lockfile_verification_is_cached(
+    cache_dir: &Path,
+    lockfile_path: &Path,
+    lockfile: &Lockfile,
+    verifiers: &[Arc<dyn ResolutionVerifier>],
+) -> bool {
+    if verify_lockfile_dependency_names(lockfile).is_err() {
+        return false;
+    }
+    if lockfile.packages.is_none() {
+        return true;
+    }
+    try_lockfile_verification_cache(
+        cache_dir,
+        lockfile_path,
+        &with_offline_check_cache_identities(verifiers),
+        || hash_lockfile(lockfile),
+    )
+    .hit
+}
+
 /// Run every active [`ResolutionVerifier`] against every entry in
 /// `lockfile.packages`.
 ///

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -72,6 +72,9 @@ pub(crate) use lockfile_freshness::{
 use lockfile_freshness::{
     FastUpdateLockfileOptions, check_lockfile_freshness, try_fast_update_lockfile,
 };
+pub use lockfile_freshness::{
+    WantedLockfileSatisfactionCheck, wanted_lockfile_satisfies_workspace,
+};
 use materialize::{MaterializationInputs, MaterializationOutput, materialize};
 use modules_state::{
     build_modules_manifest, check_modules_settings_diff, drain_settled_projects,

--- a/pnpm/crates/package-manager/src/install/lockfile_freshness.rs
+++ b/pnpm/crates/package-manager/src/install/lockfile_freshness.rs
@@ -1,8 +1,98 @@
 use super::{
     Arc, Catalogs, Config, DependencyGroup, Diagnostic, Display, Error, InstallError,
     InstallWithFreshLockfileError, Lockfile, PackageManifest, Path, PathBuf, PnpmfileChecksumCheck,
-    StalenessReason, satisfies_package_manifest,
+    StalenessReason, build_project_manifests_list, configured_or_discovered_workspace_dir,
+    satisfies_package_manifest,
 };
+
+/// Inputs for [`wanted_lockfile_satisfies_workspace`].
+pub struct WantedLockfileSatisfactionCheck<'a> {
+    pub config: &'a Config,
+    /// The active project's manifest; the workspace and its sibling
+    /// projects are rediscovered from it exactly the way
+    /// [`super::Install::run`] does, so the two agree on the importer
+    /// set they compare against the lockfile.
+    pub manifest: &'a PackageManifest,
+    pub catalogs: &'a Catalogs,
+    pub lockfile: &'a Lockfile,
+    pub ignore_manifest_check: bool,
+}
+
+/// Whether an unfiltered install could materialize `node_modules` from
+/// `lockfile` as-is — the same settings-drift and per-importer
+/// specifier gates the explicit `--frozen-lockfile` dispatch runs, so a
+/// `true` verdict guarantees a subsequent frozen [`super::Install`] run
+/// over the same lockfile passes its freshness check instead of
+/// erroring.
+///
+/// Built for the pnpr client, which uses the verdict to skip the
+/// server resolve exchange when there is nothing to resolve
+/// ([pnpm/pnpm#13904](https://github.com/pnpm/pnpm/issues/13904)).
+/// Conservative on every input it cannot cheaply reason about — an
+/// empty lockfile, config dependencies, a workspace pnpmfile (whose
+/// hooks could rewrite manifests or force a re-resolve), or a failed
+/// workspace discovery all report `false`, sending the caller down its
+/// full (resolving) path.
+pub async fn wanted_lockfile_satisfies_workspace(
+    check: &WantedLockfileSatisfactionCheck<'_>,
+) -> bool {
+    let WantedLockfileSatisfactionCheck {
+        config,
+        manifest,
+        catalogs,
+        lockfile,
+        ignore_manifest_check,
+    } = *check;
+    if lockfile.is_empty() {
+        return false;
+    }
+    if config.config_dependencies.as_ref().is_some_and(|deps| !deps.is_empty()) {
+        return false;
+    }
+    let Some(manifest_dir) = manifest.path().parent() else {
+        return false;
+    };
+    let Ok(workspace_dir_opt) = configured_or_discovered_workspace_dir(config, manifest_dir) else {
+        return false;
+    };
+    let workspace_root = workspace_dir_opt.unwrap_or_else(|| manifest_dir.to_path_buf());
+    if !config.ignore_pnpmfile && pacquet_hooks::finder::find_pnpmfile(&workspace_root).is_some() {
+        return false;
+    }
+    let Ok(workspace_manifest) = pacquet_workspace::read_workspace_manifest(&workspace_root) else {
+        return false;
+    };
+    let Ok(workspace_projects) =
+        super::load_workspace_projects(&workspace_root, workspace_manifest.as_ref())
+    else {
+        return false;
+    };
+    let project_manifests =
+        build_project_manifests_list(&workspace_root, manifest, workspace_projects.as_deref());
+    let manifest_freshness_inputs: Vec<(String, &PackageManifest)> = project_manifests
+        .iter()
+        .map(|(project_dir, manifest)| {
+            (pacquet_workspace::importer_id_from_root_dir(&workspace_root, project_dir), *manifest)
+        })
+        .collect();
+    check_lockfile_freshness(
+        lockfile,
+        &manifest_freshness_inputs,
+        config,
+        catalogs,
+        None,
+        FreshnessScope {
+            ignore_manifest_check,
+            // Both stricter than the auto-frozen dispatch: the verdict
+            // must imply the explicit-frozen gates pass, and a stale
+            // importer needs the resolving path to prune it.
+            allow_missing_dependency_free_importers: false,
+            prune_stale_importers: true,
+        },
+    )
+    .await
+    .is_ok()
+}
 
 pub(super) struct FastUpdateLockfileOptions<'a, 'manifest> {
     pub(super) lockfile: Option<&'a Lockfile>,

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
@@ -79,14 +79,14 @@ use std::{
 
 use pacquet_catalogs_resolver::{CatalogResolutionResult, WantedDependency, resolve_from_catalog};
 use pacquet_catalogs_types::Catalogs;
-use pacquet_config::{Config, LinkWorkspacePackages, NodeLinker};
+use pacquet_config::{Config, LinkWorkspacePackages, NodeLinker, TrustPolicy};
 use pacquet_lockfile::{ImporterDepVersion, Lockfile, MaybeLazyLockfile, ProjectSnapshot};
 use pacquet_modules_yaml::IncludedDependencies;
 use pacquet_package_is_installable::SupportedArchitectures;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_workspace_state::{
-    NodeLinker as WorkspaceStateNodeLinker, WorkspaceState, WorkspaceStateSettings,
-    load_workspace_state, update_workspace_state,
+    NodeLinker as WorkspaceStateNodeLinker, TrustPolicy as WorkspaceStateTrustPolicy,
+    WorkspaceState, WorkspaceStateSettings, load_workspace_state, update_workspace_state,
 };
 
 /// Outcome of [`check_optimistic_repeat_install`].

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/settings.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/settings.rs
@@ -2,8 +2,8 @@
 
 use super::{
     Catalogs, Config, IncludedDependencies, LinkWorkspacePackages, NodeLinker, Path,
-    SupportedArchitectures, WorkspaceState, WorkspaceStateNodeLinker, WorkspaceStateSettings,
-    load_workspace_state,
+    SupportedArchitectures, TrustPolicy, WorkspaceState, WorkspaceStateNodeLinker,
+    WorkspaceStateSettings, WorkspaceStateTrustPolicy, load_workspace_state,
 };
 
 /// Whether the `supportedArchitectures` recorded by the last install
@@ -135,9 +135,17 @@ pub(crate) fn first_setting_drift(
     );
     return_drift_if!("minimumReleaseAge", recorded.minimum_release_age != live.minimum_release_age,);
     return_drift_if!(
+        "minimumReleaseAgeExclude",
+        recorded.minimum_release_age_exclude != live.minimum_release_age_exclude,
+    );
+    return_drift_if!(
         "minimumReleaseAgeIgnoreMissingTime",
         recorded.minimum_release_age_ignore_missing_time
             != live.minimum_release_age_ignore_missing_time,
+    );
+    return_drift_if!(
+        "minimumReleaseAgeStrict",
+        recorded.minimum_release_age_strict != live.minimum_release_age_strict,
     );
     return_drift_if!("nodeLinker", recorded.node_linker != live.node_linker);
     return_drift_if!("optional", recorded.optional != live.optional);
@@ -168,6 +176,15 @@ pub(crate) fn first_setting_drift(
         "supportedArchitectures",
         recorded.supported_architectures != live.supported_architectures,
     );
+    return_drift_if!("trustPolicy", recorded.trust_policy != live.trust_policy);
+    return_drift_if!(
+        "trustPolicyExclude",
+        recorded.trust_policy_exclude != live.trust_policy_exclude,
+    );
+    return_drift_if!(
+        "trustPolicyIgnoreAfter",
+        recorded.trust_policy_ignore_after != live.trust_policy_ignore_after,
+    );
 
     None
     // Deliberately *not* compared in this generic settings loop:
@@ -176,13 +193,7 @@ pub(crate) fn first_setting_drift(
     // `pnpm-workspace.yaml` or an `updateConfig` hook can invalidate
     // the cache.
     //
-    // The remaining omitted keys are left out because pnpm leaves them
-    // `undefined` by default, so omitting them here still matches pnpm's
-    // all-key freshness check (`undefined == undefined`):
-    //   minimumReleaseAgeStrict     (pnpm sets it only when the user
-    //                                explicitly sets minimumReleaseAge)
-    //   minimumReleaseAgeExclude
-    //   trustPolicy*                (all `undefined` until configured)
+    // The remaining omitted key:
     //   workspacePackagePatterns    (concrete for a multi-package
     //                                workspace, but lives in the
     //                                workspace manifest, not `Config`;
@@ -279,9 +290,17 @@ pub(crate) fn current_settings(
             config.link_workspace_packages,
         )),
         minimum_release_age: config.minimum_release_age,
+        minimum_release_age_exclude: config.minimum_release_age_exclude.clone(),
         minimum_release_age_ignore_missing_time: Some(
             config.minimum_release_age_ignore_missing_time,
         ),
+        // pnpm's config reader flips the unset value to `true` when
+        // `minimumReleaseAge` was explicitly configured, so the same
+        // resolution has to happen here for a pnpm-written state to
+        // match a pacquet run (and vice versa).
+        minimum_release_age_strict: config
+            .minimum_release_age_strict
+            .or_else(|| config.explicit_settings.contains_key("minimumReleaseAge").then_some(true)),
         node_linker: Some(map_node_linker(node_linker)),
         optional: Some(included.optional_dependencies),
         overrides: config
@@ -304,6 +323,16 @@ pub(crate) fn current_settings(
         // channel re-evaluates the skipped optionals on the next run.
         supported_architectures: supported_architectures
             .and_then(|value| serde_json::to_value(value).ok()),
+        // pnpm records the raw config value, which stays `undefined`
+        // until the user configures the setting — `explicit_settings` is
+        // how pacquet tells its resolved default apart from a real
+        // `trustPolicy: off`.
+        trust_policy: config
+            .explicit_settings
+            .contains_key("trustPolicy")
+            .then(|| map_trust_policy(config.trust_policy)),
+        trust_policy_exclude: config.trust_policy_exclude.clone(),
+        trust_policy_ignore_after: config.trust_policy_ignore_after,
         ..Default::default()
     }
 }
@@ -356,5 +385,12 @@ pub(crate) fn map_node_linker(linker: NodeLinker) -> WorkspaceStateNodeLinker {
         NodeLinker::Isolated => WorkspaceStateNodeLinker::Isolated,
         NodeLinker::Hoisted => WorkspaceStateNodeLinker::Hoisted,
         NodeLinker::Pnp => WorkspaceStateNodeLinker::Pnp,
+    }
+}
+
+fn map_trust_policy(policy: TrustPolicy) -> WorkspaceStateTrustPolicy {
+    match policy {
+        TrustPolicy::Off => WorkspaceStateTrustPolicy::Off,
+        TrustPolicy::NoDowngrade => WorkspaceStateTrustPolicy::NoDowngrade,
     }
 }

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/settings.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/settings.rs
@@ -294,10 +294,8 @@ pub(crate) fn current_settings(
         minimum_release_age_ignore_missing_time: Some(
             config.minimum_release_age_ignore_missing_time,
         ),
-        // pnpm's config reader flips the unset value to `true` when
-        // `minimumReleaseAge` was explicitly configured, so the same
-        // resolution has to happen here for a pnpm-written state to
-        // match a pacquet run (and vice versa).
+        // The resolved form pnpm records — see
+        // `WorkspaceStateSettings::minimum_release_age_strict`.
         minimum_release_age_strict: config
             .minimum_release_age_strict
             .or_else(|| config.explicit_settings.contains_key("minimumReleaseAge").then_some(true)),

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
@@ -1594,6 +1594,74 @@ fn returns_skipped_when_dedupe_direct_deps_drifts() {
     assert!(matches!(decision, Decision::Skipped { reason } if reason.contains("settings")));
 }
 
+/// Newly configuring `trustPolicy` invalidates the cached state: the
+/// lockfile-verification gate is keyed by the policy settings, so an
+/// install must not report up-to-date under a policy the previous
+/// verification never checked. The recorded value is gated on the
+/// setting being explicitly configured (pnpm records the raw,
+/// default-`undefined` config value), which is what `explicit_settings`
+/// stands in for here.
+#[test]
+fn returns_skipped_when_trust_policy_is_newly_configured() {
+    let dir = tempdir().unwrap();
+    let workspace_root = dir.path();
+    let manifest_path = workspace_root.join("package.json");
+    fs::write(&manifest_path, r#"{"name":"root","version":"1.0.0"}"#).unwrap();
+    let manifest = PackageManifest::from_path(manifest_path).unwrap();
+    write_empty_lockfile(workspace_root);
+
+    let mut stale_config = Config::new();
+    stale_config.modules_dir = workspace_root.join("node_modules");
+    let stale_settings = current_settings(
+        &stale_config,
+        pacquet_config::NodeLinker::Isolated,
+        isolated_included(),
+        None,
+    );
+    assert_eq!(stale_settings.trust_policy, None, "an unconfigured policy is not recorded");
+    let mut projects = BTreeMap::new();
+    projects.insert(
+        workspace_root.to_string_lossy().into_owned(),
+        ProjectEntry { name: Some("root".into()), version: Some("1.0.0".into()) },
+    );
+    write_state(workspace_root, now_millis() + 60_000, stale_settings, projects);
+
+    let mut config = Config::new();
+    config.modules_dir = workspace_root.join("node_modules");
+    fs::create_dir_all(&config.modules_dir).unwrap();
+    config.trust_policy = pacquet_config::TrustPolicy::NoDowngrade;
+    config
+        .explicit_settings
+        .insert("trustPolicy".to_string(), serde_json::Value::String("no-downgrade".to_string()));
+    let config = config.leak();
+
+    let decision = check(
+        workspace_root,
+        config,
+        pacquet_config::NodeLinker::Isolated,
+        &[(workspace_root.to_path_buf(), &manifest)],
+    );
+    assert!(matches!(decision, Decision::Skipped { reason } if reason.contains("settings")));
+}
+
+/// An explicitly configured `minimumReleaseAge` resolves the unset
+/// `minimumReleaseAgeStrict` to `true`, mirroring pnpm's config reader,
+/// so the recorded state matches what pnpm would write for the same
+/// configuration.
+#[test]
+fn records_minimum_release_age_strict_like_pnpm_resolves_it() {
+    let mut config = Config::new();
+    config.explicit_settings.insert("minimumReleaseAge".to_string(), serde_json::Value::from(1440));
+    let settings =
+        current_settings(&config, pacquet_config::NodeLinker::Isolated, isolated_included(), None);
+    assert_eq!(settings.minimum_release_age_strict, Some(true));
+
+    config.minimum_release_age_strict = Some(false);
+    let settings =
+        current_settings(&config, pacquet_config::NodeLinker::Isolated, isolated_included(), None);
+    assert_eq!(settings.minimum_release_age_strict, Some(false), "an explicit value wins");
+}
+
 /// State written by pnpm with a field pacquet doesn't read or
 /// consume during install (e.g. `packageExtensions`,
 /// `excludeLinksFromLockfile`) does NOT trip the settings-drift gate.

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
@@ -1594,13 +1594,8 @@ fn returns_skipped_when_dedupe_direct_deps_drifts() {
     assert!(matches!(decision, Decision::Skipped { reason } if reason.contains("settings")));
 }
 
-/// Newly configuring `trustPolicy` invalidates the cached state: the
-/// lockfile-verification gate is keyed by the policy settings, so an
-/// install must not report up-to-date under a policy the previous
-/// verification never checked. The recorded value is gated on the
-/// setting being explicitly configured (pnpm records the raw,
-/// default-`undefined` config value), which is what `explicit_settings`
-/// stands in for here.
+/// `explicit_settings` stands in for pnpm's raw (default-`undefined`)
+/// config value, which is what gates whether the policy is recorded.
 #[test]
 fn returns_skipped_when_trust_policy_is_newly_configured() {
     let dir = tempdir().unwrap();
@@ -1644,10 +1639,8 @@ fn returns_skipped_when_trust_policy_is_newly_configured() {
     assert!(matches!(decision, Decision::Skipped { reason } if reason.contains("settings")));
 }
 
-/// An explicitly configured `minimumReleaseAge` resolves the unset
-/// `minimumReleaseAgeStrict` to `true`, mirroring pnpm's config reader,
-/// so the recorded state matches what pnpm would write for the same
-/// configuration.
+/// See `WorkspaceStateSettings::minimum_release_age_strict` for the
+/// resolution rule being mirrored.
 #[test]
 fn records_minimum_release_age_strict_like_pnpm_resolves_it() {
     let mut config = Config::new();

--- a/pnpm/crates/workspace-state/src/lib.rs
+++ b/pnpm/crates/workspace-state/src/lib.rs
@@ -129,11 +129,18 @@ pub struct WorkspaceStateSettings {
     /// path after a pacquet install.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub minimum_release_age: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub minimum_release_age_exclude: Option<Vec<String>>,
     /// Whether versions whose registry metadata lacks a `time` field
     /// pass the maturity check. pnpm defaults this to `true`, so it is
     /// recorded for the same reason as [`Self::minimum_release_age`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub minimum_release_age_ignore_missing_time: Option<bool>,
+    /// pnpm resolves this to `true` when `minimumReleaseAge` is
+    /// explicitly configured and the user didn't set it themselves, so
+    /// the recorded value is that resolved form, not the raw setting.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub minimum_release_age_strict: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub node_linker: Option<NodeLinker>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -158,8 +165,30 @@ pub struct WorkspaceStateSettings {
     /// are re-evaluated.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub supported_architectures: Option<serde_json::Value>,
+    /// The lockfile-verification cache is keyed by the trust-policy
+    /// settings, like the `minimumReleaseAge*` family: a policy turned
+    /// on or an exclude list shrunk must make the workspace state look
+    /// stale so the repeat-install fast path doesn't skip the verifier
+    /// fan-out. Recorded only when the user configured the setting,
+    /// matching pnpm's raw (default-`undefined`) config values.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trust_policy: Option<TrustPolicy>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trust_policy_exclude: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trust_policy_ignore_after: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workspace_package_patterns: Option<Vec<String>>,
+}
+
+/// pnpm's `trustPolicy: 'no-downgrade' | 'off'`. Same wire format as
+/// `pacquet_config::TrustPolicy`; duplicated here for the same reason
+/// as [`NodeLinker`] below.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TrustPolicy {
+    Off,
+    NoDowngrade,
 }
 
 /// pnpm's `nodeLinker: 'hoisted' | 'isolated' | 'pnp'`. Same wire

--- a/pnpm/tasks/integrated-benchmark/src/cli_args.rs
+++ b/pnpm/tasks/integrated-benchmark/src/cli_args.rs
@@ -218,8 +218,7 @@ pub enum BenchmarkScenario {
     /// Populated, up-to-date `node_modules` + lockfile, hot cache + hot
     /// store: the plain repeat `pnpm install` in a current tree, which the
     /// up-to-date short-circuit should answer in tens of milliseconds.
-    /// Nothing is wiped between iterations. Guards
-    /// [pnpm/pnpm#13904](https://github.com/pnpm/pnpm/issues/13904): with a
+    /// Nothing is wiped between iterations. Guards pnpm/pnpm#13904: with a
     /// pnpr server configured this must cost the same as a direct install
     /// (no server exchange when there is nothing to resolve).
     #[value(name = "isolated-linker.repeat-install.hot-cache.hot-store")]

--- a/pnpm/tasks/integrated-benchmark/src/cli_args.rs
+++ b/pnpm/tasks/integrated-benchmark/src/cli_args.rs
@@ -216,17 +216,13 @@ pub enum BenchmarkScenario {
     #[value(name = "isolated-linker.fresh-restore.hot-cache.hot-store")]
     IsolatedFreshRestoreHotCacheHotStore,
     /// Populated, up-to-date `node_modules` + lockfile, hot cache + hot
-    /// store: the plain repeat `pnpm install` in a current tree, which the
-    /// up-to-date short-circuit should answer in tens of milliseconds.
-    /// Nothing is wiped between iterations. Guards pnpm/pnpm#13904: with a
-    /// pnpr server configured this must cost the same as a direct install
-    /// (no server exchange when there is nothing to resolve).
+    /// store: the plain repeat `pnpm install` in a current tree, measuring
+    /// the up-to-date short-circuit. Nothing is wiped between iterations.
     #[value(name = "isolated-linker.repeat-install.hot-cache.hot-store")]
     IsolatedRepeatInstallHotCacheHotStore,
     /// Same populated repeat install with `cache-dir` wiped per iteration:
     /// the up-to-date answer must be reached without any metadata (or
-    /// verification-cache) reads, so a cold cache may not slow it down —
-    /// and may not tempt either arm into a network exchange.
+    /// verification-cache) reads.
     #[value(name = "isolated-linker.repeat-install.cold-cache.hot-store")]
     IsolatedRepeatInstallColdCacheHotStore,
     /// `pnpm add <dep>` against an existing lockfile, hot cache + hot store.

--- a/pnpm/tasks/integrated-benchmark/src/cli_args.rs
+++ b/pnpm/tasks/integrated-benchmark/src/cli_args.rs
@@ -179,9 +179,9 @@ pub enum RegistryMode {
 /// dashboards can group by leading segment (`isolated-linker.*`,
 /// `gvs-linker.*`, future `hoisted-linker.*` / `pnp-linker.*`).
 ///
-/// Every current variant starts with `node_modules` wiped — "fresh"
-/// names that target state; future variants that begin with a
-/// populated `node_modules` will use a different action prefix.
+/// A `fresh-*` action starts with `node_modules` wiped; the
+/// `repeat-install` action starts with it populated and up to date, so
+/// it measures the repeat-install short-circuit.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum BenchmarkScenario {
     /// No lockfile, cold cache + cold store. Mirrors `pnpm install` with nothing on disk.
@@ -215,6 +215,21 @@ pub enum BenchmarkScenario {
     /// Frozen lockfile, hot cache + hot store. The repeat-headless-install shape.
     #[value(name = "isolated-linker.fresh-restore.hot-cache.hot-store")]
     IsolatedFreshRestoreHotCacheHotStore,
+    /// Populated, up-to-date `node_modules` + lockfile, hot cache + hot
+    /// store: the plain repeat `pnpm install` in a current tree, which the
+    /// up-to-date short-circuit should answer in tens of milliseconds.
+    /// Nothing is wiped between iterations. Guards
+    /// [pnpm/pnpm#13904](https://github.com/pnpm/pnpm/issues/13904): with a
+    /// pnpr server configured this must cost the same as a direct install
+    /// (no server exchange when there is nothing to resolve).
+    #[value(name = "isolated-linker.repeat-install.hot-cache.hot-store")]
+    IsolatedRepeatInstallHotCacheHotStore,
+    /// Same populated repeat install with `cache-dir` wiped per iteration:
+    /// the up-to-date answer must be reached without any metadata (or
+    /// verification-cache) reads, so a cold cache may not slow it down —
+    /// and may not tempt either arm into a network exchange.
+    #[value(name = "isolated-linker.repeat-install.cold-cache.hot-store")]
+    IsolatedRepeatInstallColdCacheHotStore,
     /// `pnpm add <dep>` against an existing lockfile, hot cache + hot store.
     #[value(name = "isolated-linker.fresh-add-dep.hot-cache.hot-store")]
     IsolatedFreshAddDepHotCacheHotStore,
@@ -257,7 +272,9 @@ impl BenchmarkScenario {
         match self {
             BenchmarkScenario::IsolatedFreshInstallColdCacheColdStore
             | BenchmarkScenario::IsolatedFreshInstallHotCacheHotStore
-            | BenchmarkScenario::IsolatedFreshInstallColdCacheHotStore => &["install"],
+            | BenchmarkScenario::IsolatedFreshInstallColdCacheHotStore
+            | BenchmarkScenario::IsolatedRepeatInstallHotCacheHotStore
+            | BenchmarkScenario::IsolatedRepeatInstallColdCacheHotStore => &["install"],
             BenchmarkScenario::IsolatedFreshRestoreColdCacheColdStore
             | BenchmarkScenario::IsolatedFreshRestoreColdCacheColdStoreColdPnpr
             | BenchmarkScenario::IsolatedFreshRestoreHotCacheHotStore
@@ -309,7 +326,9 @@ impl BenchmarkScenario {
             | BenchmarkScenario::IsolatedFreshAddDepHotCacheHotStore
             | BenchmarkScenario::IsolatedFreshResolveHotCacheOffline
             | BenchmarkScenario::IsolatedPeerHeavyResolveHotCacheOffline
-            | BenchmarkScenario::GvsFreshRestoreHotCacheHotStore => true,
+            | BenchmarkScenario::GvsFreshRestoreHotCacheHotStore
+            | BenchmarkScenario::IsolatedRepeatInstallHotCacheHotStore
+            | BenchmarkScenario::IsolatedRepeatInstallColdCacheHotStore => true,
         }
     }
 
@@ -365,6 +384,17 @@ impl BenchmarkScenario {
             BenchmarkScenario::IsolatedFreshRestoreHotCacheHotStore => {
                 Cleanup { remove: &["node_modules"], restore: &[SAVED_LOCKFILE] }
             }
+            // A repeat install mutates nothing, so nothing is removed or
+            // restored — restoring the lockfile would bump its mtime and
+            // push every iteration off the pure-mtime fast path into the
+            // heavier content re-check. The populated `node_modules` (and
+            // workspace state) come from the pre-warm pass.
+            BenchmarkScenario::IsolatedRepeatInstallHotCacheHotStore => {
+                Cleanup { remove: &[], restore: &[] }
+            }
+            BenchmarkScenario::IsolatedRepeatInstallColdCacheHotStore => {
+                Cleanup { remove: &["cache-dir"], restore: &[] }
+            }
             BenchmarkScenario::IsolatedFreshAddDepHotCacheHotStore => Cleanup {
                 remove: &["node_modules"],
                 restore: &[SAVED_LOCKFILE, SAVED_PACKAGE_JSON],
@@ -404,15 +434,33 @@ impl BenchmarkScenario {
         matches!(self, BenchmarkScenario::GvsFreshRestoreHotCacheHotStore)
     }
 
+    /// Whether the scenario's contract is a populated, up-to-date
+    /// `node_modules`. The pre-benchmark wipe empties it, so an untimed
+    /// install pass per target re-establishes it before hyperfine runs —
+    /// hyperfine's warmup run would too, but `--warmup 0` must not
+    /// silently turn the first timed run into a fresh install.
+    pub fn prewarms_node_modules(self) -> bool {
+        matches!(
+            self,
+            BenchmarkScenario::IsolatedRepeatInstallHotCacheHotStore
+                | BenchmarkScenario::IsolatedRepeatInstallColdCacheHotStore,
+        )
+    }
+
     /// Scenarios where pnpr's server-side resolution is expected to beat
-    /// or match a direct pacquet install. Hot-cache scenarios deliberately
-    /// skip this canary because there is little resolution work left to
-    /// offload and the remote pnpr hop can dominate.
+    /// or match a direct pacquet install. Hot-cache fresh scenarios
+    /// deliberately skip this canary because there is little resolution
+    /// work left to offload and the remote pnpr hop can dominate. The
+    /// repeat-install scenarios are the opposite: nothing may be
+    /// offloaded at all, so a configured pnpr server must cost nothing
+    /// ([pnpm/pnpm#13904](https://github.com/pnpm/pnpm/issues/13904)).
     pub fn expects_pnpr_not_slower_than_direct(self) -> bool {
         matches!(
             self,
             BenchmarkScenario::IsolatedFreshInstallColdCacheColdStore
-                | BenchmarkScenario::IsolatedFreshInstallColdCacheHotStore,
+                | BenchmarkScenario::IsolatedFreshInstallColdCacheHotStore
+                | BenchmarkScenario::IsolatedRepeatInstallHotCacheHotStore
+                | BenchmarkScenario::IsolatedRepeatInstallColdCacheHotStore,
         )
     }
 

--- a/pnpm/tasks/integrated-benchmark/src/work_env.rs
+++ b/pnpm/tasks/integrated-benchmark/src/work_env.rs
@@ -32,6 +32,11 @@ const PREWARM_SCRIPT: &str = "prewarm.bash";
 const BENCHMARK_DIAGNOSTICS_JSON: &str = "BENCHMARK_DIAGNOSTICS.json";
 const BENCHMARK_DIAGNOSTICS_MD: &str = "BENCHMARK_DIAGNOSTICS.md";
 const PNPR_DIRECT_RATIO_MAX: f64 = 1.05;
+// Absolute slack for the pnpr-vs-direct gate: the repeat-install
+// scenarios finish in tens of milliseconds, where run-to-run noise
+// alone can exceed 5% of the mean. A pnpr arm within this many seconds
+// of the direct arm passes regardless of the ratio.
+const PNPR_DIRECT_ABS_SLACK_SECONDS: f64 = 0.015;
 // A pacquet peer-resolution blowup lands *below* 1x on this DAG, so the floor
 // only has to clear measurement noise, not encode how far ahead pacquet is.
 // The TypeScript resolver's own hot-cache cost moves independently — offline
@@ -586,15 +591,16 @@ impl WorkEnv {
         // would have its server up if a scenario ever combines the two.
         let _pnpr_servers = self.start_pnpr_servers(pnpr_server_registry);
 
-        // For GVS-warm we need a pre-warm pass: hyperfine's `--warmup`
-        // would otherwise time-from-empty for the first run since the
-        // pre-benchmark wipe above just emptied `store-dir`. The
-        // scenario's contract is "GVS already populated", so prime it
-        // by running the install once per target before hyperfine
-        // starts measuring.
-        if scenario.enables_gvs() {
+        // For GVS-warm and repeat-install scenarios we need a pre-warm
+        // pass: hyperfine's `--warmup` would otherwise time-from-empty
+        // for the first run since the pre-benchmark wipe above just
+        // emptied `store-dir` (and `node_modules`). Their contracts are
+        // "GVS already populated" / "`node_modules` already up to date",
+        // so prime them by running the install once per target before
+        // hyperfine starts measuring.
+        if scenario.enables_gvs() || scenario.prewarms_node_modules() {
             for id in self.benchmarked_ids() {
-                eprintln!("Pre-warming GVS for {id}...");
+                eprintln!("Pre-warming the install state for {id}...");
                 Command::new("bash").arg(self.script_path(id)).pipe_mut(executor("install.bash"));
             }
         }
@@ -1172,7 +1178,9 @@ impl WorkEnv {
                 continue;
             }
             assert!(
-                ratio.ratio <= PNPR_DIRECT_RATIO_MAX,
+                ratio.ratio <= PNPR_DIRECT_RATIO_MAX
+                    || ratio.pnpr_mean_seconds - ratio.pacquet_mean_seconds
+                        <= PNPR_DIRECT_ABS_SLACK_SECONDS,
                 "pnpr@{} was slower than pacquet@{}: ratio {:.3} > {:.3} (pnpr {:.3}s, pacquet {:.3}s)",
                 ratio.revision,
                 ratio.revision,

--- a/pnpm/tasks/integrated-benchmark/src/work_env.rs
+++ b/pnpm/tasks/integrated-benchmark/src/work_env.rs
@@ -2183,6 +2183,18 @@ fn may_create_lockfile(dst_dir: &Path, scenario: BenchmarkScenario, src_dir: Opt
             .pipe(Cow::Owned)
     };
     if let Some(lockfile) = scenario.lockfile(load_lockfile) {
+        // Land the seeded lockfile in a strictly later millisecond than
+        // the just-written `package.json`. The kernel's file-timestamp
+        // clock ticks coarsely (~1 ms), so back-to-back writes can share
+        // one mtime — and the repeat-install fast path reads a manifest
+        // whose mtime equals its baseline (the lockfile mtime, truncated
+        // to ms) as possibly-modified, pushing every timed iteration
+        // onto the heavier content-check path for one bench dir but not
+        // the other. Real projects never hit this shape (the lockfile is
+        // written by an install that started after the manifest edit),
+        // so the pause keeps the measured runs on the representative
+        // pure-mtime path.
+        std::thread::sleep(std::time::Duration::from_millis(5));
         let path = dst_dir.join("pnpm-lock.yaml");
         fs::write(path, lockfile).expect("write pnpm-lock.yaml for the revision");
     }

--- a/pnpm/tasks/integrated-benchmark/src/work_env/tests.rs
+++ b/pnpm/tasks/integrated-benchmark/src/work_env/tests.rs
@@ -47,6 +47,31 @@ fn online_scenario_writes_no_prewarm_script() {
     assert!(!has_prewarm);
 }
 
+/// The repeat-install scenarios' contract is a populated, up-to-date
+/// `node_modules`: their per-iteration cleanup must not wipe it (or
+/// restore the lockfile, whose bumped mtime would push iterations off
+/// the pure-mtime fast path), and the pre-warm predicate must be set so
+/// the pre-benchmark wipe is repaired before hyperfine measures.
+#[test]
+fn repeat_install_scenarios_keep_node_modules_populated() {
+    for scenario in [
+        BenchmarkScenario::IsolatedRepeatInstallHotCacheHotStore,
+        BenchmarkScenario::IsolatedRepeatInstallColdCacheHotStore,
+    ] {
+        let cleanup = scenario.cleanup();
+        assert!(
+            !cleanup.remove.contains(&"node_modules"),
+            "{scenario:?} must not wipe node_modules between iterations",
+        );
+        assert!(
+            cleanup.restore.is_empty(),
+            "{scenario:?} must not restore files a repeat install never mutates",
+        );
+        assert!(scenario.prewarms_node_modules(), "{scenario:?} must pre-warm node_modules");
+        assert!(scenario.seeds_lockfile(), "{scenario:?} needs the seeded lockfile");
+    }
+}
+
 #[test]
 fn peer_heavy_scenario_generates_shared_subgraph_root() {
     let dir = std::env::temp_dir()

--- a/pnpm/tasks/integrated-benchmark/src/work_env/tests.rs
+++ b/pnpm/tasks/integrated-benchmark/src/work_env/tests.rs
@@ -47,11 +47,8 @@ fn online_scenario_writes_no_prewarm_script() {
     assert!(!has_prewarm);
 }
 
-/// The repeat-install scenarios' contract is a populated, up-to-date
-/// `node_modules`: their per-iteration cleanup must not wipe it (or
-/// restore the lockfile, whose bumped mtime would push iterations off
-/// the pure-mtime fast path), and the pre-warm predicate must be set so
-/// the pre-benchmark wipe is repaired before hyperfine measures.
+/// The whys live on the `cleanup()` arm and the
+/// `prewarms_node_modules` predicate this test pins.
 #[test]
 fn repeat_install_scenarios_keep_node_modules_populated() {
     for scenario in [

--- a/pnpm11/benchmarks/README.md
+++ b/pnpm11/benchmarks/README.md
@@ -46,14 +46,15 @@ leading segment groups runs by linker mode. Today there are two
 groups (`isolated-linker.*` and `gvs-linker.*`); future scenarios
 will add `hoisted-linker.*` and `pnp-linker.*`.
 
-Every current scenario starts with `node_modules` wiped — "fresh"
-names that target state; future variants that begin with a populated
-`node_modules` will use a different action prefix. (For fresh-resolve
-the wipe also keeps the install's up-to-date short-circuit from
-skipping the measured resolution.)
+A "fresh" scenario starts with `node_modules` wiped. (For
+fresh-resolve the wipe also keeps the install's up-to-date
+short-circuit from skipping the measured resolution.) A
+"repeat-install" scenario starts with `node_modules` populated and up
+to date, measuring exactly that short-circuit.
 
 | # | Slug | Lockfile | Cache | Store | Description |
 |---|---|---|---|---|---|
+| 0 | `isolated-linker.repeat-install.hot-cache.hot-store` | ✔ | hot | hot | Repeat `pnpm install` in a current tree — the up-to-date short-circuit |
 | 1 | `isolated-linker.fresh-restore.hot-cache.hot-store` | ✔ frozen | hot | hot | Restore from lockfile with both directories hot (repeat-headless shape) |
 | 2 | `isolated-linker.fresh-add-dep.hot-cache.hot-store` | ✔ + add dep | hot | hot | `pnpm add <dep>` against an existing lockfile |
 | 3 | `isolated-linker.fresh-install.hot-cache.hot-store` | ✗ | hot | hot | Resolve from scratch with both directories hot |

--- a/pnpm11/benchmarks/bench.sh
+++ b/pnpm11/benchmarks/bench.sh
@@ -47,13 +47,14 @@ fi
 
 # Scenario list: `slug:Display label`. The slug matches the
 # orchestrator's `--scenario` value (the clap-derived kebab-case name
-# from `BenchmarkScenario`). Every scenario starts with `node_modules`
-# wiped — "Fresh" names that target state (for fresh-resolve it also
-# keeps the up-to-date short-circuit from skipping the measured
-# resolution). "Isolated linker" names the `nodeLinker` mode;
-# alternatives (`hoisted`, `pnp`) and populated-node_modules
-# counterparts are reserved for future scenarios.
+# from `BenchmarkScenario`). A "fresh" scenario starts with
+# `node_modules` wiped (for fresh-resolve that also keeps the
+# up-to-date short-circuit from skipping the measured resolution);
+# "repeat install" starts with it populated and up to date and measures
+# that short-circuit. "Isolated linker" names the `nodeLinker` mode;
+# alternatives (`hoisted`, `pnp`) are reserved for future scenarios.
 SCENARIOS=(
+  "isolated-linker.repeat-install.hot-cache.hot-store:Isolated linker: repeat install, hot cache + hot store"
   "isolated-linker.fresh-restore.hot-cache.hot-store:Isolated linker: fresh restore, hot cache + hot store"
   "isolated-linker.fresh-add-dep.hot-cache.hot-store:Isolated linker: fresh add new dep, hot cache + hot store"
   "isolated-linker.fresh-install.hot-cache.hot-store:Isolated linker: fresh install, hot cache + hot store"


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Closes pnpm/pnpm#13904.

With a configured `pnprServer`, every `pnpm install` paid a full server exchange even when the answer was already on disk, making pnpr strictly slower than plain v12 whenever there was nothing to resolve. This PR makes the client decide locally that the server has nothing to add, at three layers (the issue's items 1–3-lite, 5):

1. **The up-to-date fast path now runs with pnpr configured** (issue item 1). Both `pnpr_server` bails in `finished_via_up_to_date_fast_path` are gone: the check decides purely locally that nothing changed since the last install, and asking the server cannot change that answer. The settings-hash guard the issue asks to keep is now real on the pacquet side too: `trustPolicy`, `trustPolicyExclude`, `trustPolicyIgnoreAfter`, `minimumReleaseAgeStrict`, and `minimumReleaseAgeExclude` are recorded into the workspace state and compared for drift — the same keys the TypeScript CLI already records (`WORKSPACE_STATE_SETTING_KEYS`), including pnpm's "explicit `minimumReleaseAge` resolves unset `minimumReleaseAgeStrict` to `true`" rule, so the state file stays interchangeable between the stacks.
2. **The resolve exchange is gated on a local satisfaction check** (issue item 2). `install_via_pnpr_inner` now runs `wanted_lockfile_satisfies_workspace` — the same settings-drift + per-importer `satisfies_package_manifest` gates as the `--frozen-lockfile` dispatch, assembled from the same workspace discovery `Install::run` uses — and a satisfied unfiltered install goes straight to the frozen materialization with the on-disk lockfile. Conservative bails (empty lockfile, config dependencies, a workspace pnpmfile, filtered installs) keep the server exchange.
3. **Input-lockfile verification is cache-first** (the issue's open question on item 2, resolved without a protocol change). Before delegating `verify_lockfile` to the server, the client probes the local `lockfile-verified.jsonl` cache (`lockfile_verification_is_cached`, new in `pacquet-lockfile-verification`); a hit under the current policy skips the round trip entirely. On a miss the server still verifies — keeping the warm-server win on cold restores — and the pass is recorded locally. Server-resolved lockfiles are recorded too, mirroring the TypeScript client's `writeWantedLockfileAndRecordVerified`, so the very next install of the unchanged lockfile is exchange-free.
4. **Repeat-install scenarios in the integrated benchmark** (issue item 5): `isolated-linker.repeat-install.hot-cache.hot-store` and `.cold-cache.hot-store`, the first populated-`node_modules` scenarios (pre-warmed once per target before hyperfine runs; nothing wiped or restored per iteration so the pure-mtime fast path is what's measured). Both are wired into the `expects_pnpr_not_slower_than_direct` CI gate, with a new 15 ms absolute-slack term so the 1.05 ratio cap doesn't flake on tens-of-milliseconds runs. The hot variant is also added to `pnpm11/benchmarks` for the TypeScript CLI.

Issue item 4 (skip the unchanged lockfile write) turned out to be already implemented: `save_value_to_path` compares the serialized content against the existing file and returns early on equality (since pnpm/pnpm#13075), so only the serialize-and-compare cost remains — the same shape as the TypeScript `writeLockfileDoc`. Issue item 3 (a conditional-resolve request in the pnpr protocol) is left as a follow-up; with items 1–2 the up-to-date paths make zero requests, which is strictly better than the 304-style exchange for these cases. The remaining case item 3 would improve is the *almost*-up-to-date install (delta responses).

TypeScript-side status: the TS client already runs its "Already up to date" fast path with `pnprServer` set, already records `trustPolicy*` in the workspace state, and already content-guards the lockfile write, so items 1 and 4 need no porting. The TS pnpr client still resolves through the server when its lockfile already satisfies the manifest (`installViaPnprServer` has no local satisfaction check) — that mirror of item 2 still needs porting and is tracked in pnpm/pnpm#13906, being a pure perf change split out rather than blocking this PR.

Benchmarked locally with the CI link emulation (50 ms client↔pnpr RTT, 50 ms / 200 Mbps registry link), `pnpr@HEAD` vs `pacquet@HEAD`:

| Scenario | pacquet@HEAD | pnpr@HEAD | ratio |
|---|---|---|---|
| `repeat-install.hot-cache.hot-store` (new) | 6.0 ms | 6.2 ms | 1.03 |
| `repeat-install.cold-cache.hot-store` (new) | 6.1 ms | 6.2 ms | 1.02 |
| `fresh-restore.hot-cache.hot-store` (the issue's +13% case) | 887.5 ms | 887.0 ms | 1.00 |

Before the fix, each repeat-install run on the pnpr arm would have paid at least one 50 ms round trip plus lockfile transfer both ways plus the full frozen walk.

While validating the new scenarios I hit and fixed a benchmark-infra flake (second commit): the work-env init could write `package.json` and the seeded lockfile in the same coarse file-timestamp tick, which pushed that bench dir's every iteration onto the fast path's heavier content-check branch (~33 ms vs ~6 ms) — turning the new ratio gate into a coin toss. The init now seeds the lockfile a few milliseconds later, pinning all arms to the representative pure-mtime path. The same collision is theoretically reachable outside the benchmark (a fast install writing the lockfile in the same tick as a manifest edit permanently forces the content-check path); that pre-existing wart is filed as pnpm/pnpm#13907 since fixing it means revisiting the truncated-baseline comparison from pnpm/pnpm#12981.

## Squash Commit Body

```text
With a configured pnprServer, every install paid a full server exchange
even when the answer was already on disk, making pnpr strictly slower
than a direct install on up-to-date projects. Close that gap in three
layers, each deciding locally that the server has nothing to add:

- Let the pre-runtime "Already up to date" fast path run with a pnpr
  server configured. The check decides purely locally that nothing
  changed since the last install; asking the server cannot change that
  answer. The trust/policy settings guard pnpm already records in the
  workspace state (trustPolicy, trustPolicyExclude,
  trustPolicyIgnoreAfter, minimumReleaseAgeStrict,
  minimumReleaseAgeExclude) is now recorded and compared by pacquet
  too, so a policy change still defeats the fast path.

- Gate the resolve exchange on a local satisfaction check: an
  unfiltered install whose on-disk lockfile still satisfies every
  manifest goes straight to the frozen materialization, exactly like
  the non-pnpr preferFrozenLockfile dispatch.

- Consult the local lockfile-verified.jsonl cache before delegating
  input-lockfile verification to the server, and record server-verified
  and server-resolved lockfiles into that cache (pnpm's
  writeWantedLockfileAndRecordVerified), so repeat verifications of an
  unchanged lockfile stay local.

Add repeat-install scenarios (populated node_modules, hot and cold
cache) to the integrated benchmark, pre-warmed before hyperfine runs
and wired into the pnpr-not-slower-than-direct gate with an absolute
slack for tens-of-milliseconds runs.

Closes pnpm/pnpm#13904
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-fable-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Repeat installs can now complete faster through an “Already up to date” path.
  - Satisfied lockfiles can be reused locally without contacting the package resolution service.
  - Verified lockfiles can skip redundant verification on subsequent installs.

- **Bug Fixes**
  - Changes to trust policies or release-age settings now correctly invalidate the fast path.
  - Install behavior more reliably respects current lockfile and workspace settings.

- **Tests**
  - Added coverage for repeat-install optimization, cache behavior, and settings changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->