### PR TITLE
chore(license): attribute the Yarn code the Rust engine is derived from

### DIFF
--- a/.changeset/yarn-third-party-notices.md
+++ b/.changeset/yarn-third-party-notices.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+The published packages now ship a `THIRD-PARTY-NOTICES.md` file carrying the BSD 2-Clause license of the Yarn code that pnpm's hoisted-layout algorithm and built-in package-compatibility database are derived from.

--- a/pnpm/crates/package-manager/src/compat_package_extensions.rs
+++ b/pnpm/crates/package-manager/src/compat_package_extensions.rs
@@ -1,3 +1,32 @@
+// `compat_package_extensions.json` is a copy of the compatibility database in
+// `@yarnpkg/extensions`, which is distributed under the following license:
+//
+//     BSD 2-Clause License
+//
+//     Copyright (c) 2016-present, Yarn Contributors.
+//     All rights reserved.
+//
+//     Redistribution and use in source and binary forms, with or without
+//     modification, are permitted provided that the following conditions are met:
+//
+//     1. Redistributions of source code must retain the above copyright notice, this
+//        list of conditions and the following disclaimer.
+//
+//     2. Redistributions in binary form must reproduce the above copyright notice,
+//        this list of conditions and the following disclaimer in the documentation
+//        and/or other materials provided with the distribution.
+//
+//     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//     AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//     IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//     DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+//     FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+//     DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//     SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+//     CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+//     OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+//     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 use crate::PackageExtender;
 use indexmap::IndexMap;
 use pacquet_config::{PackageExtension, PeerDependencyMeta};

--- a/pnpm/crates/real-hoist/src/lib.rs
+++ b/pnpm/crates/real-hoist/src/lib.rs
@@ -1,3 +1,32 @@
+// This crate is a Rust port of the hoisting algorithm in `@yarnpkg/nm`,
+// which is distributed under the following license:
+//
+//     BSD 2-Clause License
+//
+//     Copyright (c) 2016-present, Yarn Contributors.
+//     All rights reserved.
+//
+//     Redistribution and use in source and binary forms, with or without
+//     modification, are permitted provided that the following conditions are met:
+//
+//     1. Redistributions of source code must retain the above copyright notice, this
+//        list of conditions and the following disclaimer.
+//
+//     2. Redistributions in binary form must reproduce the above copyright notice,
+//        this list of conditions and the following disclaimer in the documentation
+//        and/or other materials provided with the distribution.
+//
+//     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//     AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//     IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//     DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+//     FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+//     DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//     SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+//     CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+//     OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+//     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 //! Real-directory hoister for the `nodeLinker: hoisted` install layout.
 //!
 //! Implements pnpm's hoisted layout as a thin wrapper around the

--- a/pnpm/npm/napi/THIRD-PARTY-NOTICES.md
+++ b/pnpm/npm/napi/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,42 @@
+# Third-Party Notices
+
+This product includes software derived from third-party sources. The
+components below, and their license terms, are listed here in satisfaction
+of those terms.
+
+## Yarn (`@yarnpkg/nm`, `@yarnpkg/extensions`)
+
+- Source: <https://github.com/yarnpkg/berry>
+- License: BSD 2-Clause
+
+The `nodeLinker: hoisted` layout is produced by a Rust port of the hoisting
+algorithm in `@yarnpkg/nm`, and the built-in package-compatibility database
+is a copy of the one in `@yarnpkg/extensions`.
+
+```
+BSD 2-Clause License
+
+Copyright (c) 2016-present, Yarn Contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```

--- a/pnpm/npm/napi/THIRD-PARTY-NOTICES.md
+++ b/pnpm/npm/napi/THIRD-PARTY-NOTICES.md
@@ -13,7 +13,7 @@ The `nodeLinker: hoisted` layout is produced by a Rust port of the hoisting
 algorithm in `@yarnpkg/nm`, and the built-in package-compatibility database
 is a copy of the one in `@yarnpkg/extensions`.
 
-```
+```text
 BSD 2-Clause License
 
 Copyright (c) 2016-present, Yarn Contributors.

--- a/pnpm/npm/napi/package.json
+++ b/pnpm/npm/napi/package.json
@@ -28,6 +28,7 @@
   "files": [
     "index.js",
     "index.d.ts",
-    "README.md"
+    "README.md",
+    "THIRD-PARTY-NOTICES.md"
   ]
 }

--- a/pnpm/npm/napi/scripts/generate-packages.mjs
+++ b/pnpm/npm/napi/scripts/generate-packages.mjs
@@ -20,6 +20,10 @@ import * as fs from 'node:fs'
 const ARTIFACT_BASE = 'pnpm-napi'
 // The `.node` file name inside each native package (also the package `main`).
 const NATIVE_ADDON_FILE = 'pnpm-napi.node'
+// Ships with every package that carries the addon, wrapper or not: the BSD
+// 2-Clause code the engine is derived from asks for its notice in the
+// materials accompanying a binary distribution.
+const NOTICES_FILE = 'THIRD-PARTY-NOTICES.md'
 
 const WRAPPER_ROOT = resolve(fileURLToPath(import.meta.url), '../..')
 const PACKAGES_ROOT = resolve(WRAPPER_ROOT, '..')
@@ -67,7 +71,7 @@ function generateNativePackage(target) {
     os: [target.platform],
     cpu: [target.arch],
     main: NATIVE_ADDON_FILE,
-    files: [NATIVE_ADDON_FILE],
+    files: [NATIVE_ADDON_FILE, NOTICES_FILE],
     repository: { type: 'git', url: 'https://github.com/pnpm/pnpm' },
   }
   if (target.libc) {
@@ -75,6 +79,7 @@ function generateNativePackage(target) {
   }
   fs.writeFileSync(resolve(packageRoot, 'package.json'), `${JSON.stringify(manifestData, null, 2)}\n`)
   fs.copyFileSync(source, resolve(packageRoot, NATIVE_ADDON_FILE))
+  fs.copyFileSync(resolve(WRAPPER_ROOT, NOTICES_FILE), resolve(packageRoot, NOTICES_FILE))
   console.log(`Generated ${packageName}`)
   return true
 }

--- a/pnpm/npm/pnpm/THIRD-PARTY-NOTICES.md
+++ b/pnpm/npm/pnpm/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,42 @@
+# Third-Party Notices
+
+This product includes software derived from third-party sources. The
+components below, and their license terms, are listed here in satisfaction
+of those terms.
+
+## Yarn (`@yarnpkg/nm`, `@yarnpkg/extensions`)
+
+- Source: <https://github.com/yarnpkg/berry>
+- License: BSD 2-Clause
+
+The `nodeLinker: hoisted` layout is produced by a Rust port of the hoisting
+algorithm in `@yarnpkg/nm`, and the built-in package-compatibility database
+is a copy of the one in `@yarnpkg/extensions`.
+
+```
+BSD 2-Clause License
+
+Copyright (c) 2016-present, Yarn Contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```

--- a/pnpm/npm/pnpm/THIRD-PARTY-NOTICES.md
+++ b/pnpm/npm/pnpm/THIRD-PARTY-NOTICES.md
@@ -13,7 +13,7 @@ The `nodeLinker: hoisted` layout is produced by a Rust port of the hoisting
 algorithm in `@yarnpkg/nm`, and the built-in package-compatibility database
 is a copy of the one in `@yarnpkg/extensions`.
 
-```
+```text
 BSD 2-Clause License
 
 Copyright (c) 2016-present, Yarn Contributors.

--- a/pnpm/npm/pnpm/package.json
+++ b/pnpm/npm/pnpm/package.json
@@ -46,7 +46,8 @@
     "pnpx",
     "pnx",
     "install.js",
-    "dist/"
+    "dist/",
+    "THIRD-PARTY-NOTICES.md"
   ],
   "dependencies": {
     "node-gyp": "catalog:"

--- a/pnpm/npm/pnpm/scripts/generate-packages.mjs
+++ b/pnpm/npm/pnpm/scripts/generate-packages.mjs
@@ -24,8 +24,10 @@ const PACKAGE_DIR_PREFIX = "pacquet";
 const NATIVE_BIN_FILE = "pnpm";
 const EXE_WRAPPER_NAME = "@pnpm/exe";
 const EXE_WRAPPER_DIR = "pnpm-exe";
-// Files shared verbatim by both wrappers: the root-level bins + preinstall + README.
-const WRAPPER_FILES = ["pnpm", "pn", "pnpx", "pnx", "install.js", "README.md"];
+// Files shared verbatim by both wrappers: the root-level bins + preinstall +
+// README + the third-party notices. Both wrappers publish the same `files`
+// list, so anything named there has to be copied here too.
+const WRAPPER_FILES = ["pnpm", "pn", "pnpx", "pnx", "install.js", "README.md", "THIRD-PARTY-NOTICES.md"];
 
 const PNPM_ROOT = resolve(fileURLToPath(import.meta.url), "../..");
 const PACKAGES_ROOT = resolve(PNPM_ROOT, "..");

--- a/pnpm/npm/pnpm/scripts/generate-packages.mjs
+++ b/pnpm/npm/pnpm/scripts/generate-packages.mjs
@@ -24,10 +24,14 @@ const PACKAGE_DIR_PREFIX = "pacquet";
 const NATIVE_BIN_FILE = "pnpm";
 const EXE_WRAPPER_NAME = "@pnpm/exe";
 const EXE_WRAPPER_DIR = "pnpm-exe";
+// Ships with every package that carries the native binary, wrapper or not:
+// the BSD 2-Clause code the engine is derived from asks for its notice in the
+// materials accompanying a binary distribution.
+const NOTICES_FILE = "THIRD-PARTY-NOTICES.md";
 // Files shared verbatim by both wrappers: the root-level bins + preinstall +
 // README + the third-party notices. Both wrappers publish the same `files`
 // list, so anything named there has to be copied here too.
-const WRAPPER_FILES = ["pnpm", "pn", "pnpx", "pnx", "install.js", "README.md", "THIRD-PARTY-NOTICES.md"];
+const WRAPPER_FILES = ["pnpm", "pn", "pnpx", "pnx", "install.js", "README.md", NOTICES_FILE];
 
 const PNPM_ROOT = resolve(fileURLToPath(import.meta.url), "../..");
 const PACKAGES_ROOT = resolve(PNPM_ROOT, "..");
@@ -84,6 +88,9 @@ function generateNativePackage(target) {
   console.log(`Copy binary ${binaryTarget}`);
   fs.copyFileSync(binarySource, binaryTarget);
   fs.chmodSync(binaryTarget, 0o755);
+
+  // The manifest declares no `files`, so everything staged here is published.
+  fs.copyFileSync(resolve(PNPM_ROOT, NOTICES_FILE), resolve(packageRoot, NOTICES_FILE));
 }
 
 // Rewrite the committed `pacquet` manifest into the publishable one: no


### PR DESCRIPTION
## Summary

Two parts of the Rust engine are derived from Yarn's BSD 2-Clause code, and neither carried its license.

- **`crates/real-hoist`** is a Rust port of the hoisting algorithm in `@yarnpkg/nm`. Not a clean-room reimplementation: it mirrors the upstream decomposition function for function (`nm_hoist`, `hoist_subtree`, `is_preferred_ident`, `would_shadow_peer`), keeps its type names (`HoisterTree`, `HoisterResult`, `HoisterDependencyKind`), and ~12 of its doc comments cite specific `hoist.ts` line numbers. Copyright doesn't cover algorithms, but a source-to-source port that preserves structure and naming is the textbook derivative work — and citing the source in writing while omitting its license is a worse position than either doing it properly or never having read it.
- **`crates/package-manager/src/compat_package_extensions.json`** is a verbatim copy of the compatibility database in `@yarnpkg/extensions` — no rewrite involved, so no analysis needed.

The license text is reproduced verbatim from berry's `LICENSE.md` at commit `4287909f`, the same commit the `real-hoist` doc comments already link to. The copyright line stays exactly as upstream writes it, "2016-present" included: clause 1 asks that the notice be *retained*, and narrowing someone else's copyright term to the date we happened to port the code isn't ours to do.

**Placement follows what each clause asks for.**

Clause 1 (source redistribution) → an inline comment at the top of each of the two files.

Clause 2 (binary redistribution) asks for the notice in the materials accompanying the distribution → a `THIRD-PARTY-NOTICES.md` in each wrapper package that ships the compiled engine:

| Package | How |
| --- | --- |
| `pnpm` | committed + in `files` |
| `@pnpm/exe` | via the `WRAPPER_FILES` copy |
| `@pnpm/napi` | committed + in `files` |
| `@pnpm/exe.<target>` (8) | staged by `generateNativePackage` |
| `@pnpm/napi.<target>` (8) | staged by `generateNativePackage` + in `files` |

Three details the packaging forced:

- The `@pnpm/exe` wrapper is assembled by copying `WRAPPER_FILES` but publishes the same patched manifest as `pnpm`, so the notices file had to go in that list — otherwise the manifest would name a file absent from its tarball.
- The `@pnpm/exe.<target>` manifest declares no `files`, so npm publishes whatever is staged in the directory and the copy alone is enough.
- The `@pnpm/napi.<target>` manifest *does* declare one, so the notice had to be added to that allowlist too or the copy would be dropped at pack time.

The platform packages are the artifacts that literally contain the compiled code. A wrapper always pulls its platform package in, so the notice reached every real install even before that second commit — but the changeset promises the published packages ship it, and 16 of 19 didn't. Putting the notice next to the binary seemed better than narrowing the release note.

`cargo tree --invert` confirms both components reach `pacquet-napi` (through `pacquet-package-manager`), so the addon's notice is accurate and not just copied for symmetry. The two `THIRD-PARTY-NOTICES.md` copies are byte-identical; `diff pnpm/npm/{pnpm,napi}/THIRD-PARTY-NOTICES.md` is the guard if drift ever needs enforcing.

**No TypeScript counterpart is needed.** `@pnpm/installing.linking.real-hoist` and `@pnpm/hooks.read-package-hook` take `@yarnpkg/nm` and `@yarnpkg/extensions` as real dependencies, so their license installs into `node_modules` on its own. Nothing user-visible changes in either stack.

## Squash Commit Body

```text
Two parts of the Rust engine are derived from Yarn's BSD 2-Clause code, and
neither carried its license:

- `crates/real-hoist` is a port of the hoisting algorithm in `@yarnpkg/nm`.
  It is not a clean-room reimplementation: the port mirrors the upstream
  decomposition function for function, keeps its type and function names,
  and its doc comments cite specific `hoist.ts` line numbers. That is the
  derivative-work end of the spectrum, and citing the source while omitting
  its license is a worse position than either doing it properly or never
  having read it.
- `crates/package-manager/src/compat_package_extensions.json` is a verbatim
  copy of the compatibility database in `@yarnpkg/extensions`.

The license text is reproduced verbatim from berry's `LICENSE.md` at the same
commit the `real-hoist` doc comments already reference. The copyright line is
left exactly as upstream writes it, "2016-present" included — clause 1 asks
that the notice be retained, and narrowing someone else's copyright term to
the date we happened to port the code is not ours to do.

Placement follows what each clause asks for. Clause 1 (source) is satisfied by
the inline comment at the top of each of the two files. Clause 2 (binary) asks
for the notice in the materials accompanying the distribution, so every
published package that carries the compiled engine now ships a
`THIRD-PARTY-NOTICES.md`.

Each of the three packaging paths needed its own handling. The `@pnpm/exe`
wrapper is assembled by copying `WRAPPER_FILES` but publishes the same patched
manifest as `pnpm`, so the notices file has to be in that list or it would name
a file absent from the tarball. The `@pnpm/exe.<target>` manifest declares no
`files`, so staging the file in the package directory is enough. The
`@pnpm/napi.<target>` manifest does declare one, so the notice had to be added
to that allowlist as well or the copy would be dropped at pack time.

The TypeScript CLI needs no equivalent: it depends on `@yarnpkg/nm` and
`@yarnpkg/extensions` as real packages, so their license installs into
`node_modules` on its own. Nothing user-visible changes in either stack, so
this needs no parity work.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.

---
Written by an agent (Claude Code, claude-opus-5[1m]).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added third-party notices documenting Yarn-derived components, attribution, and BSD 2-Clause licensing.
  * Included the notices in published packages and generated native package distributions.
* **Chores**
  * Prepared a patch release reflecting the updated licensing and attribution documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->