### PR TITLE
fix(config): build NODE_PATH from the workspace root

### DIFF
--- a/.changeset/node-path-uses-the-workspace-virtual-store.md
+++ b/.changeset/node-path-uses-the-workspace-virtual-store.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-With `preferSymlinkedExecutables`, `NODE_PATH` again points at the virtual store of the workspace root when pnpm is run from inside a workspace package. It was built from the package directory instead, so scripts could not resolve anything that only lives in the hoisted store [#13912](https://github.com/pnpm/pnpm/issues/13912).
+With `preferSymlinkedExecutables`, `NODE_PATH` again points at the virtual store of the workspace root when pnpm is run from inside a workspace package, so scripts can resolve dependencies that live only in the hoisted store [#13912](https://github.com/pnpm/pnpm/issues/13912).

--- a/.changeset/node-path-uses-the-workspace-virtual-store.md
+++ b/.changeset/node-path-uses-the-workspace-virtual-store.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config.reader": patch
+"pnpm": patch
+---
+
+With `preferSymlinkedExecutables`, `NODE_PATH` again points at the virtual store of the workspace root when pnpm is run from inside a workspace package. It was built from the package directory instead, so scripts could not resolve anything that only lives in the hoisted store [#13912](https://github.com/pnpm/pnpm/issues/13912).

--- a/pnpm11/config/reader/src/index.ts
+++ b/pnpm11/config/reader/src/index.ts
@@ -684,6 +684,10 @@ export async function getConfig (opts: {
     pnpmConfig.filterProd = (pnpmConfig.filterProd as string).split(' ')
   }
 
+  if (pnpmConfig.sharedWorkspaceLockfile && !pnpmConfig.lockfileDir && pnpmConfig.workspaceDir) {
+    pnpmConfig.lockfileDir = pnpmConfig.workspaceDir
+  }
+
   if (pnpmConfig.workspaceDir) {
     pnpmConfig.extraBinPaths = [path.join(pnpmConfig.workspaceDir, 'node_modules', '.bin')]
   } else {
@@ -763,10 +767,6 @@ export async function getConfig (opts: {
   }
   pnpmConfig.sideEffectsCacheRead = pnpmConfig.sideEffectsCache ?? pnpmConfig.sideEffectsCacheReadonly
   pnpmConfig.sideEffectsCacheWrite = pnpmConfig.sideEffectsCache
-
-  if (pnpmConfig.sharedWorkspaceLockfile && !pnpmConfig.lockfileDir && pnpmConfig.workspaceDir) {
-    pnpmConfig.lockfileDir = pnpmConfig.workspaceDir
-  }
 
   pnpmConfig.workspaceConcurrency = getWorkspaceConcurrency(pnpmConfig.workspaceConcurrency)
 

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -10,6 +10,7 @@ import { esmNodePathLoaderImportFlag } from '@pnpm/exec.esm-node-path-loader'
 import { prepare, prepareEmpty } from '@pnpm/prepare'
 import { fixtures } from '@pnpm/test-fixtures'
 import { isCI } from 'ci-info'
+import isWindows from 'is-windows'
 import PATH from 'path-name'
 import { symlinkDir } from 'symlink-dir'
 import { writeYamlFileSync } from 'write-yaml-file'
@@ -41,6 +42,7 @@ const env = {
   [PATH]: path.join(import.meta.dirname, 'bin'),
 }
 const f = fixtures(import.meta.dirname)
+const testOnPosix = isWindows() ? test.skip : test
 
 test('getConfig()', async () => {
   const { config } = await getConfig({
@@ -3759,6 +3761,28 @@ test('preferSymlinkedExecutables should be true when nodeLinker is hoisted', asy
     },
   })
   expect(config.preferSymlinkedExecutables).toBeTruthy()
+})
+
+testOnPosix('NODE_PATH points to the virtual store of the workspace root when pnpm runs from a workspace package', async () => {
+  prepareEmpty()
+
+  const workspaceDir = process.cwd()
+  const pkgDir = path.join(workspaceDir, 'packages/app')
+  fs.mkdirSync(pkgDir, { recursive: true })
+
+  const { config } = await getConfig({
+    cliOptions: {
+      dir: pkgDir,
+      'prefer-symlinked-executables': true,
+    },
+    packageManager: {
+      name: 'pnpm',
+      version: '1.0.0',
+    },
+    workspaceDir,
+  })
+
+  expect(config.extraEnv['NODE_PATH']).toBe(path.join(workspaceDir, 'node_modules/.pnpm/node_modules'))
 })
 
 test('return a warning when the .npmrc has an env variable that does not exist', async () => {


### PR DESCRIPTION
## Summary

With `preferSymlinkedExecutables`, running pnpm from inside a workspace package exported a `NODE_PATH` pointing at `<pkg>/node_modules/.pnpm/node_modules`, a directory that does not exist. The virtual store lives at the workspace root, so any script that shelled out to Node and relied on the hoisted store failed with `Cannot find module`. The same command from the workspace root worked.

`getConfig` builds `extraEnv.NODE_PATH` from `lockfileDir ?? dir`, but the line that fills `lockfileDir` in from `workspaceDir` under `sharedWorkspaceLockfile` ran about seventy lines later, so `lockfileDir` was still unset and the package directory won. Setting it explicitly made no difference for the same reason. This moves that assignment above the `extraEnv` block. Nothing else in `getConfig` reads `lockfileDir` in between, so the returned config is otherwise unchanged.

pacquet has no `preferSymlinkedExecutables` handling yet, so there is nothing to port.

Fixes pnpm/pnpm#13912

## Squash Commit Body

```text
getConfig derived extraEnv.NODE_PATH from `lockfileDir ?? dir`, but
sharedWorkspaceLockfile only set lockfileDir from workspaceDir further down the
function. Run from a workspace package, NODE_PATH therefore pointed at that
package's non-existent virtual store instead of the workspace root's, and
scripts could not resolve dependencies that live only in the hoisted store. The
lockfileDir assignment now happens before extraEnv is built; no other read of
lockfileDir sits between the two positions.

Closes pnpm/pnpm#13912
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users. It becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13913"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789307365&installation_model_id=426870&pr_number=13913&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13913&signature=114c194ecb90358c5cf7315f5431653dd77c1335c00179ad5d04ee6ce32689cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored `NODE_PATH` to the workspace root’s virtual store when running commands from a workspace package with symlinked executables enabled.
  * Improved lockfile directory handling for shared workspace lockfiles.
  * Added patch release notes documenting these corrections.

* **Tests**
  * Added coverage for workspace `NODE_PATH` behavior on supported platforms, including Windows-specific handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->