### PR TITLE
fix(config): resolve workspace NODE_PATH from the shared lockfile directory

### DIFF
--- a/.changeset/early-shared-node-path.md
+++ b/.changeset/early-shared-node-path.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config.reader": patch
+"pnpm": patch
+---
+
+Scripts run from a workspace package now resolve `NODE_PATH` against the workspace's shared virtual store when `preferSymlinkedExecutables` is enabled.

--- a/pnpm11/config/reader/src/index.ts
+++ b/pnpm11/config/reader/src/index.ts
@@ -657,6 +657,10 @@ export async function getConfig (opts: {
     pnpmConfig.extraBinPaths = []
   }
 
+  if (pnpmConfig.sharedWorkspaceLockfile && !pnpmConfig.lockfileDir && pnpmConfig.workspaceDir) {
+    pnpmConfig.lockfileDir = pnpmConfig.workspaceDir
+  }
+
   pnpmConfig.extraEnv = {
     pnpm_config_verify_deps_before_run: 'false',
   }
@@ -722,10 +726,6 @@ export async function getConfig (opts: {
   }
   pnpmConfig.sideEffectsCacheRead = pnpmConfig.sideEffectsCache ?? pnpmConfig.sideEffectsCacheReadonly
   pnpmConfig.sideEffectsCacheWrite = pnpmConfig.sideEffectsCache
-
-  if (pnpmConfig.sharedWorkspaceLockfile && !pnpmConfig.lockfileDir && pnpmConfig.workspaceDir) {
-    pnpmConfig.lockfileDir = pnpmConfig.workspaceDir
-  }
 
   pnpmConfig.workspaceConcurrency = getWorkspaceConcurrency(pnpmConfig.workspaceConcurrency)
 

--- a/pnpm11/pnpm/test/run.ts
+++ b/pnpm11/pnpm/test/run.ts
@@ -191,6 +191,75 @@ testOnPosix('pnpm run with preferSymlinkedExecutables and custom virtualStoreDir
   expect(result.stdout.toString()).toContain(`${path.sep}foo${path.sep}bar${path.sep}node_modules`)
 })
 
+testOnPosix('pnpm run from a workspace package uses the shared virtual store in NODE_PATH', () => {
+  const projects = preparePackages([
+    {
+      location: '.',
+      package: {
+        name: 'workspace',
+        private: true,
+      },
+    },
+    {
+      location: 'packages/app',
+      package: {
+        name: 'app',
+        private: true,
+        scripts: {
+          build: 'node -e "console.log(process.env.NODE_PATH)"',
+        },
+      },
+    },
+  ])
+
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    packages: ['packages/*'],
+    preferSymlinkedExecutables: true,
+  })
+
+  const result = execPnpmSync(['run', 'build'], {
+    cwd: projects.app.dir(),
+    expectSuccess: true,
+  })
+
+  expect(result.stdout.toString()).toContain(path.join(process.cwd(), 'node_modules/.pnpm/node_modules'))
+})
+
+testOnPosix('pnpm run from a workspace package uses its own virtual store when lockfiles are not shared', () => {
+  const projects = preparePackages([
+    {
+      location: '.',
+      package: {
+        name: 'workspace',
+        private: true,
+      },
+    },
+    {
+      location: 'packages/app',
+      package: {
+        name: 'app',
+        private: true,
+        scripts: {
+          build: 'node -e "console.log(process.env.NODE_PATH)"',
+        },
+      },
+    },
+  ])
+
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    packages: ['packages/*'],
+    preferSymlinkedExecutables: true,
+    sharedWorkspaceLockfile: false,
+  })
+
+  const result = execPnpmSync(['run', 'build'], {
+    cwd: projects.app.dir(),
+    expectSuccess: true,
+  })
+
+  expect(result.stdout.toString()).toContain(path.join(projects.app.dir(), 'node_modules/.pnpm/node_modules'))
+})
+
 test('collapse output when running multiple scripts in one project', async () => {
   prepare({
     scripts: {


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#13912.

When pnpm is invoked from a workspace package with `preferSymlinkedExecutables: true`, config construction used to derive `NODE_PATH` before normalizing `lockfileDir` to the workspace root. Scripts therefore searched a package-local virtual store that does not exist in a shared-lockfile workspace.

This moves the existing shared-workspace `lockfileDir` normalization before `NODE_PATH` is derived. The condition itself is unchanged, so `sharedWorkspaceLockfile: false` continues to use the package-local virtual store.

Regression coverage verifies both cases from a package working directory:

- shared lockfile: `NODE_PATH` points at the workspace-root virtual store;
- non-shared lockfile: `NODE_PATH` remains package-local.

The Rust port does not expose `preferSymlinkedExecutables`. Its existing `NODE_PATH` handling belongs to the separate dependency-shim/`extendNodePath` path, so there is no corresponding pacquet behavior to update.

## Squash Commit Body

```text
Normalize the shared workspace lockfile directory before deriving the lifecycle-script
NODE_PATH. This prevents package-cwd invocations from targeting a non-existent
package-local virtual store while preserving package-local resolution when
sharedWorkspaceLockfile is disabled.

Add regression coverage for both shared and non-shared lockfile workspaces.

Fixes pnpm/pnpm#13912.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) because this changes published packages.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789307861&installation_model_id=426870&pr_number=13914&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13914&signature=2e83357d03e5d8d26b0a6af845076d96a866873f38fc550a53634894c30114c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed workspace scripts so `NODE_PATH` correctly resolves from the shared virtual store when symlinked executables and shared workspace lockfiles are enabled.
  - Ensured scripts use the package’s own virtual store when shared workspace lockfiles are disabled.
  - Improved consistency when running commands from workspace packages.

- **Documentation**
  - Added release notes describing the corrected workspace script behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->