### PR TITLE
fix(pacquet): resolve repeat-install same-millisecond mtime collision…

### DIFF
--- a/.changeset/repeat-install-mtime-collision.md
+++ b/.changeset/repeat-install-mtime-collision.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed the repeat-install fast path getting permanently stuck on the content-check branch when a manifest's modification time shared the same millisecond as the baseline (such as during a fast install or when files are copied with identical timestamps). The validation baseline is now post-dated by 1ms after a successful content check, ensuring that subsequent repeat installs correctly converge to the pure-mtime fast path.

--- a/.changeset/repeat-install-mtime-collision.md
+++ b/.changeset/repeat-install-mtime-collision.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Fixed the repeat-install fast path getting permanently stuck on the content-check branch when a manifest's modification time shared the same millisecond as the baseline (such as during a fast install or when files are copied with identical timestamps). The validation baseline is now post-dated by 1ms after a successful content check, ensuring that subsequent repeat installs correctly converge to the pure-mtime fast path.
+Fixed repeat installs paying for a full lockfile comparison forever after a modification-time collision. When a `package.json` was last modified inside the same clock tick that the install recorded as its validation baseline — a fast install, a checkout that copied files with identical timestamps, or any filesystem that keeps only whole-second modification times — the manifest kept reading as possibly-modified, so every later `pnpm install` and `verify-deps-before-run` check re-compared the manifests against the lockfile instead of taking the fast path [#13907](https://github.com/pnpm/pnpm/issues/13907).

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
@@ -66,8 +66,8 @@ pub(crate) use settings::{
     recorded_supported_architectures_match, settings_match,
 };
 pub(crate) use timestamps::{
-    FileMtime, current_filesystem_time_ms, file_mtime, file_mtime_from_metadata,
-    lockfile_modified_since, modified_at_or_after, mtime_ms, validation_baseline_ms,
+    FileMtime, file_mtime, file_mtime_from_metadata, filesystem_now_ms, lockfile_modified_since,
+    modified_at_or_after, mtime_ms, refreshed_validation_baseline_ms, validation_baseline_ms,
     wanted_lockfile_modified,
 };
 
@@ -360,6 +360,8 @@ pub(crate) fn check_optimistic_repeat_install_ignoring(
     // than just the modified ones.
     let projects_to_check: Vec<&ManifestStat<'_>> =
         if lockfile_modified { manifest_stats.iter().collect() } else { modified };
+    let filesystem_now =
+        if is_workspace_install { filesystem_now_ms(workspace_root) } else { None };
     match modified_manifests_match_lockfile(check, &state, &projects_to_check, config.dedupe_peers)
     {
         Ok(loaded_current) => {
@@ -389,23 +391,10 @@ pub(crate) fn check_optimistic_repeat_install_ignoring(
                     project_manifests,
                     state.filtered_install,
                 );
-                // On a second-granularity filesystem (e.g. ext4 with 128-byte inodes,
-                // HFS+, or some CI runner disks), a file changed within the same
-                // second of the install is indistinguishable from the baseline by
-                // whole-second mtimes alone. In that case, we must post-date by a
-                // full second to ensure subsequent checks converge. On sub-second
-                // filesystems, post-dating by 1ms is sufficient. We take the max of
-                // the current filesystem time and this calculated baseline to ensure
-                // it post-dates both the validated mtimes and the time the check ran.
-                let fs_time = current_filesystem_time_ms(workspace_root)
-                    .unwrap_or(new_state.last_validated_timestamp);
-                let manifest_mtimes_are_coarse = project_manifests
-                    .iter()
-                    .filter_map(|(_, manifest)| file_mtime(manifest.path()))
-                    .any(|mtime| mtime.whole_second);
-                let delta = if manifest_mtimes_are_coarse { 1000 } else { 1 };
-                let baseline = new_state.last_validated_timestamp.saturating_add(delta);
-                new_state.last_validated_timestamp = std::cmp::max(fs_time, baseline);
+                new_state.last_validated_timestamp = refreshed_validation_baseline_ms(
+                    new_state.last_validated_timestamp,
+                    filesystem_now,
+                );
                 if let Err(error) = update_workspace_state(workspace_root, &new_state) {
                     tracing::warn!(
                         target: "pacquet::install",

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
@@ -353,7 +353,7 @@ pub(crate) fn check_optimistic_repeat_install_ignoring(
                 // `filtered_install` forward: clearing it would claim every
                 // importer is materialized when a filtered install left the
                 // unselected ones untouched.
-                let new_state = crate::install::build_workspace_state(
+                let mut new_state = crate::install::build_workspace_state(
                     workspace_root,
                     config,
                     node_linker,
@@ -363,6 +363,11 @@ pub(crate) fn check_optimistic_repeat_install_ignoring(
                     project_manifests,
                     state.filtered_install,
                 );
+                // Increment by 1 to post-date the validated mtimes and prevent
+                // same-millisecond mtime collisions from permanently forcing the
+                // content check.
+                new_state.last_validated_timestamp =
+                    new_state.last_validated_timestamp.saturating_add(1);
                 if let Err(error) = update_workspace_state(workspace_root, &new_state) {
                     tracing::warn!(
                         target: "pacquet::install",

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
@@ -378,7 +378,7 @@ pub(crate) fn check_optimistic_repeat_install_ignoring(
                 // `filtered_install` forward: clearing it would claim every
                 // importer is materialized when a filtered install left the
                 // unselected ones untouched.
-                let new_state = crate::install::build_workspace_state::<Host>(
+                let mut new_state = crate::install::build_workspace_state::<Host>(
                     workspace_root,
                     config,
                     node_linker,
@@ -388,6 +388,11 @@ pub(crate) fn check_optimistic_repeat_install_ignoring(
                     project_manifests,
                     state.filtered_install,
                 );
+                // Increment by 1 to post-date the validated mtimes and prevent
+                // same-millisecond mtime collisions from permanently forcing the
+                // content check.
+                new_state.last_validated_timestamp =
+                    new_state.last_validated_timestamp.saturating_add(1);
                 if let Err(error) = update_workspace_state(workspace_root, &new_state) {
                     tracing::warn!(
                         target: "pacquet::install",

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
@@ -66,8 +66,9 @@ pub(crate) use settings::{
     recorded_supported_architectures_match, settings_match,
 };
 pub(crate) use timestamps::{
-    FileMtime, file_mtime, file_mtime_from_metadata, lockfile_modified_since, modified_at_or_after,
-    mtime_ms, validation_baseline_ms, wanted_lockfile_modified,
+    FileMtime, current_filesystem_time_ms, file_mtime, file_mtime_from_metadata,
+    lockfile_modified_since, modified_at_or_after, mtime_ms, validation_baseline_ms,
+    wanted_lockfile_modified,
 };
 
 use std::{
@@ -363,11 +364,23 @@ pub(crate) fn check_optimistic_repeat_install_ignoring(
                     project_manifests,
                     state.filtered_install,
                 );
-                // Increment by 1 to post-date the validated mtimes and prevent
-                // same-millisecond mtime collisions from permanently forcing the
-                // content check.
-                new_state.last_validated_timestamp =
-                    new_state.last_validated_timestamp.saturating_add(1);
+                // On a second-granularity filesystem (e.g. ext4 with 128-byte inodes,
+                // HFS+, or some CI runner disks), a file changed within the same
+                // second of the install is indistinguishable from the baseline by
+                // whole-second mtimes alone. In that case, we must post-date by a
+                // full second to ensure subsequent checks converge. On sub-second
+                // filesystems, post-dating by 1ms is sufficient. We take the max of
+                // the current filesystem time and this calculated baseline to ensure
+                // it post-dates both the validated mtimes and the time the check ran.
+                let fs_time = current_filesystem_time_ms(workspace_root)
+                    .unwrap_or(new_state.last_validated_timestamp);
+                let manifest_mtimes_are_coarse = project_manifests
+                    .iter()
+                    .filter_map(|(_, manifest)| file_mtime(manifest.path()))
+                    .any(|mtime| mtime.whole_second);
+                let delta = if manifest_mtimes_are_coarse { 1000 } else { 1 };
+                let baseline = new_state.last_validated_timestamp.saturating_add(delta);
+                new_state.last_validated_timestamp = std::cmp::max(fs_time, baseline);
                 if let Err(error) = update_workspace_state(workspace_root, &new_state) {
                     tracing::warn!(
                         target: "pacquet::install",

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
@@ -66,8 +66,9 @@ pub(crate) use settings::{
     recorded_supported_architectures_match, settings_match,
 };
 pub(crate) use timestamps::{
-    FileMtime, file_mtime, file_mtime_from_metadata, lockfile_modified_since, modified_at_or_after,
-    mtime_ms, validation_baseline_ms, wanted_lockfile_modified,
+    FileMtime, current_filesystem_time_ms, file_mtime, file_mtime_from_metadata,
+    lockfile_modified_since, modified_at_or_after, mtime_ms, validation_baseline_ms,
+    wanted_lockfile_modified,
 };
 
 use std::{
@@ -388,11 +389,23 @@ pub(crate) fn check_optimistic_repeat_install_ignoring(
                     project_manifests,
                     state.filtered_install,
                 );
-                // Increment by 1 to post-date the validated mtimes and prevent
-                // same-millisecond mtime collisions from permanently forcing the
-                // content check.
-                new_state.last_validated_timestamp =
-                    new_state.last_validated_timestamp.saturating_add(1);
+                // On a second-granularity filesystem (e.g. ext4 with 128-byte inodes,
+                // HFS+, or some CI runner disks), a file changed within the same
+                // second of the install is indistinguishable from the baseline by
+                // whole-second mtimes alone. In that case, we must post-date by a
+                // full second to ensure subsequent checks converge. On sub-second
+                // filesystems, post-dating by 1ms is sufficient. We take the max of
+                // the current filesystem time and this calculated baseline to ensure
+                // it post-dates both the validated mtimes and the time the check ran.
+                let fs_time = current_filesystem_time_ms(workspace_root)
+                    .unwrap_or(new_state.last_validated_timestamp);
+                let manifest_mtimes_are_coarse = project_manifests
+                    .iter()
+                    .filter_map(|(_, manifest)| file_mtime(manifest.path()))
+                    .any(|mtime| mtime.whole_second);
+                let delta = if manifest_mtimes_are_coarse { 1000 } else { 1 };
+                let baseline = new_state.last_validated_timestamp.saturating_add(delta);
+                new_state.last_validated_timestamp = std::cmp::max(fs_time, baseline);
                 if let Err(error) = update_workspace_state(workspace_root, &new_state) {
                     tracing::warn!(
                         target: "pacquet::install",

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/deps_status.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/deps_status.rs
@@ -3,11 +3,11 @@
 use super::{
     Config, Host, Lockfile, LockfileConflictCheckFailure, ManifestStat, NodeLinker,
     OptimisticRepeatInstallCheck, WorkspaceState, catalogs_cache_matches,
-    current_filesystem_time_ms, current_lockfile_file_has_content,
-    current_lockfile_unusable_with_non_empty_wanted, file_mtime,
-    first_lockfile_requiring_conflict_safe_install, first_project_missing_modules_dir,
-    first_setting_drift, modified_at_or_after, modified_manifests_match_lockfile,
-    patches_modified_since, pnpmfiles_drift, project_structure_matches, stat_manifests,
+    current_lockfile_file_has_content, current_lockfile_unusable_with_non_empty_wanted,
+    filesystem_now_ms, first_lockfile_requiring_conflict_safe_install,
+    first_project_missing_modules_dir, first_setting_drift, modified_at_or_after,
+    modified_manifests_match_lockfile, patches_modified_since, pnpmfiles_drift,
+    project_structure_matches, refreshed_validation_baseline_ms, stat_manifests,
     update_workspace_state, wanted_lockfile_modified,
 };
 
@@ -152,6 +152,8 @@ pub fn check_deps_status_before_run(
 
     let projects_to_check: Vec<&ManifestStat<'_>> =
         if lockfile_modified { manifest_stats.iter().collect() } else { modified };
+    let filesystem_now =
+        if is_workspace_install { filesystem_now_ms(workspace_root) } else { None };
     // The TypeScript run/exec handler does not forward `dedupePeers`
     // into `checkDepsStatus`, so its pre-run lockfile check uses the
     // false default even when the workspace setting is true.
@@ -171,23 +173,10 @@ pub fn check_deps_status_before_run(
                     project_manifests,
                     state.filtered_install,
                 );
-                // On a second-granularity filesystem (e.g. ext4 with 128-byte inodes,
-                // HFS+, or some CI runner disks), a file changed within the same
-                // second of the install is indistinguishable from the baseline by
-                // whole-second mtimes alone. In that case, we must post-date by a
-                // full second to ensure subsequent checks converge. On sub-second
-                // filesystems, post-dating by 1ms is sufficient. We take the max of
-                // the current filesystem time and this calculated baseline to ensure
-                // it post-dates both the validated mtimes and the time the check ran.
-                let fs_time = current_filesystem_time_ms(workspace_root)
-                    .unwrap_or(new_state.last_validated_timestamp);
-                let manifest_mtimes_are_coarse = project_manifests
-                    .iter()
-                    .filter_map(|(_, manifest)| file_mtime(manifest.path()))
-                    .any(|mtime| mtime.whole_second);
-                let delta = if manifest_mtimes_are_coarse { 1000 } else { 1 };
-                let baseline = new_state.last_validated_timestamp.saturating_add(delta);
-                new_state.last_validated_timestamp = std::cmp::max(fs_time, baseline);
+                new_state.last_validated_timestamp = refreshed_validation_baseline_ms(
+                    new_state.last_validated_timestamp,
+                    filesystem_now,
+                );
                 // The gate ignored `dev`/`optional`/`production` drift
                 // above; writing today's (default-group) values here
                 // would clobber what the last real install recorded and

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/deps_status.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/deps_status.rs
@@ -3,7 +3,8 @@
 use super::{
     Config, Host, Lockfile, LockfileConflictCheckFailure, ManifestStat, NodeLinker,
     OptimisticRepeatInstallCheck, WorkspaceState, catalogs_cache_matches,
-    current_lockfile_file_has_content, current_lockfile_unusable_with_non_empty_wanted,
+    current_filesystem_time_ms, current_lockfile_file_has_content,
+    current_lockfile_unusable_with_non_empty_wanted, file_mtime,
     first_lockfile_requiring_conflict_safe_install, first_project_missing_modules_dir,
     first_setting_drift, modified_at_or_after, modified_manifests_match_lockfile,
     patches_modified_since, pnpmfiles_drift, project_structure_matches, stat_manifests,
@@ -170,11 +171,23 @@ pub fn check_deps_status_before_run(
                     project_manifests,
                     state.filtered_install,
                 );
-                // Increment by 1 to post-date the validated mtimes and prevent
-                // same-millisecond mtime collisions from permanently forcing the
-                // content check.
-                new_state.last_validated_timestamp =
-                    new_state.last_validated_timestamp.saturating_add(1);
+                // On a second-granularity filesystem (e.g. ext4 with 128-byte inodes,
+                // HFS+, or some CI runner disks), a file changed within the same
+                // second of the install is indistinguishable from the baseline by
+                // whole-second mtimes alone. In that case, we must post-date by a
+                // full second to ensure subsequent checks converge. On sub-second
+                // filesystems, post-dating by 1ms is sufficient. We take the max of
+                // the current filesystem time and this calculated baseline to ensure
+                // it post-dates both the validated mtimes and the time the check ran.
+                let fs_time = current_filesystem_time_ms(workspace_root)
+                    .unwrap_or(new_state.last_validated_timestamp);
+                let manifest_mtimes_are_coarse = project_manifests
+                    .iter()
+                    .filter_map(|(_, manifest)| file_mtime(manifest.path()))
+                    .any(|mtime| mtime.whole_second);
+                let delta = if manifest_mtimes_are_coarse { 1000 } else { 1 };
+                let baseline = new_state.last_validated_timestamp.saturating_add(delta);
+                new_state.last_validated_timestamp = std::cmp::max(fs_time, baseline);
                 // The gate ignored `dev`/`optional`/`production` drift
                 // above; writing today's (default-group) values here
                 // would clobber what the last real install recorded and

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/deps_status.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/deps_status.rs
@@ -3,7 +3,8 @@
 use super::{
     Config, Lockfile, LockfileConflictCheckFailure, ManifestStat, NodeLinker,
     OptimisticRepeatInstallCheck, WorkspaceState, catalogs_cache_matches,
-    current_lockfile_file_has_content, current_lockfile_unusable_with_non_empty_wanted,
+    current_filesystem_time_ms, current_lockfile_file_has_content,
+    current_lockfile_unusable_with_non_empty_wanted, file_mtime,
     first_lockfile_requiring_conflict_safe_install, first_project_missing_modules_dir,
     first_setting_drift, modified_at_or_after, modified_manifests_match_lockfile,
     patches_modified_since, pnpmfiles_drift, project_structure_matches, stat_manifests,
@@ -170,11 +171,23 @@ pub fn check_deps_status_before_run(
                     project_manifests,
                     state.filtered_install,
                 );
-                // Increment by 1 to post-date the validated mtimes and prevent
-                // same-millisecond mtime collisions from permanently forcing the
-                // content check.
-                new_state.last_validated_timestamp =
-                    new_state.last_validated_timestamp.saturating_add(1);
+                // On a second-granularity filesystem (e.g. ext4 with 128-byte inodes,
+                // HFS+, or some CI runner disks), a file changed within the same
+                // second of the install is indistinguishable from the baseline by
+                // whole-second mtimes alone. In that case, we must post-date by a
+                // full second to ensure subsequent checks converge. On sub-second
+                // filesystems, post-dating by 1ms is sufficient. We take the max of
+                // the current filesystem time and this calculated baseline to ensure
+                // it post-dates both the validated mtimes and the time the check ran.
+                let fs_time = current_filesystem_time_ms(workspace_root)
+                    .unwrap_or(new_state.last_validated_timestamp);
+                let manifest_mtimes_are_coarse = project_manifests
+                    .iter()
+                    .filter_map(|(_, manifest)| file_mtime(manifest.path()))
+                    .any(|mtime| mtime.whole_second);
+                let delta = if manifest_mtimes_are_coarse { 1000 } else { 1 };
+                let baseline = new_state.last_validated_timestamp.saturating_add(delta);
+                new_state.last_validated_timestamp = std::cmp::max(fs_time, baseline);
                 // The gate ignored `dev`/`optional`/`production` drift
                 // above; writing today's (default-group) values here
                 // would clobber what the last real install recorded and

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/deps_status.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/deps_status.rs
@@ -170,6 +170,11 @@ pub fn check_deps_status_before_run(
                     project_manifests,
                     state.filtered_install,
                 );
+                // Increment by 1 to post-date the validated mtimes and prevent
+                // same-millisecond mtime collisions from permanently forcing the
+                // content check.
+                new_state.last_validated_timestamp =
+                    new_state.last_validated_timestamp.saturating_add(1);
                 // The gate ignored `dev`/`optional`/`production` drift
                 // above; writing today's (default-group) values here
                 // would clobber what the last real install recorded and

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
@@ -2404,7 +2404,7 @@ fn workspace_content_check_resolves_same_millisecond_mtime_collision_and_converg
     // Stamp the workspace state's last_validated_timestamp to the EXACT SAME
     // millisecond as the manifest's mtime (simulating a collision).
     let settings =
-        current_settings(config, pacquet_config::NodeLinker::Isolated, isolated_included(), None);
+        current_settings(config, pnpm_config::NodeLinker::Isolated, isolated_included(), None);
     let mut projects = BTreeMap::new();
     projects.insert(
         dir.path().to_string_lossy().into_owned(),
@@ -2422,7 +2422,7 @@ fn workspace_content_check_resolves_same_millisecond_mtime_collision_and_converg
     assert_eq!(decision, Decision::UpToDate);
 
     // Verify the state was written.
-    let after_state = pacquet_workspace_state::load_workspace_state(dir.path()).unwrap().unwrap();
+    let after_state = pnpm_workspace_state::load_workspace_state(dir.path()).unwrap().unwrap();
     assert!(after_state.last_validated_timestamp > manifest_mtime_ms);
 
     // Second check: because the reference now post-dates the manifest's mtime,
@@ -2431,7 +2431,7 @@ fn workspace_content_check_resolves_same_millisecond_mtime_collision_and_converg
         content_check_decision(&dir, config, true, &[(dir.path().to_path_buf(), &manifest)]);
     assert_eq!(decision2, Decision::UpToDate);
 
-    let after_state2 = pacquet_workspace_state::load_workspace_state(dir.path()).unwrap().unwrap();
+    let after_state2 = pnpm_workspace_state::load_workspace_state(dir.path()).unwrap().unwrap();
     assert_eq!(after_state2.last_validated_timestamp, after_state.last_validated_timestamp);
 }
 
@@ -2462,7 +2462,7 @@ fn workspace_content_check_resolves_same_second_mtime_collision_and_converges() 
     // Stamp the workspace state's last_validated_timestamp to the EXACT SAME
     // millisecond as the manifest's mtime (simulating a collision).
     let settings =
-        current_settings(config, pacquet_config::NodeLinker::Isolated, isolated_included(), None);
+        current_settings(config, pnpm_config::NodeLinker::Isolated, isolated_included(), None);
     let mut projects = BTreeMap::new();
     projects.insert(
         dir.path().to_string_lossy().into_owned(),
@@ -2481,7 +2481,7 @@ fn workspace_content_check_resolves_same_second_mtime_collision_and_converges() 
     assert_eq!(decision, Decision::UpToDate);
 
     // Verify the state was written.
-    let after_state = pacquet_workspace_state::load_workspace_state(dir.path()).unwrap().unwrap();
+    let after_state = pnpm_workspace_state::load_workspace_state(dir.path()).unwrap().unwrap();
     assert!(after_state.last_validated_timestamp >= manifest_mtime_ms + 1000);
 
     // Second check: because the reference now post-dates the manifest's mtime + 1s,
@@ -2490,7 +2490,7 @@ fn workspace_content_check_resolves_same_second_mtime_collision_and_converges() 
         content_check_decision(&dir, config, true, &[(dir.path().to_path_buf(), &manifest)]);
     assert_eq!(decision2, Decision::UpToDate);
 
-    let after_state2 = pacquet_workspace_state::load_workspace_state(dir.path()).unwrap().unwrap();
+    let after_state2 = pnpm_workspace_state::load_workspace_state(dir.path()).unwrap().unwrap();
     assert_eq!(after_state2.last_validated_timestamp, after_state.last_validated_timestamp);
 }
 

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
@@ -2369,6 +2369,71 @@ fn workspace_content_check_refreshes_last_validated_timestamp() {
     assert!(after > before, "expected the state timestamp to advance ({before} -> {after})");
 }
 
+/// Workspace branch: a same-millisecond mtime collision between the manifest
+/// and the baseline causes a content check on the next run, but that check
+/// passes and refreshes `lastValidatedTimestamp` forward by 1ms. The run after
+/// that must then take the pure-mtime path without needing a content check.
+#[test]
+fn workspace_content_check_resolves_same_millisecond_mtime_collision_and_converges() {
+    let (dir, config) = setup_content_check_project();
+    let manifest_path = dir.path().join("package.json");
+
+    // Set the manifest's and lockfiles' mtimes to exactly 1,700,000,000s + 0.5ms.
+    let seconds = 1_700_000_000;
+    let nanos = 500_000; // 0.5 ms
+    let system_time = std::time::SystemTime::UNIX_EPOCH + std::time::Duration::new(seconds, nanos);
+
+    let file = std::fs::OpenOptions::new().write(true).open(&manifest_path).unwrap();
+    file.set_times(std::fs::FileTimes::new().set_modified(system_time)).unwrap();
+
+    let lockfile_path = dir.path().join(Lockfile::FILE_NAME);
+    let lockfile_file = std::fs::OpenOptions::new().write(true).open(&lockfile_path).unwrap();
+    lockfile_file.set_times(std::fs::FileTimes::new().set_modified(system_time)).unwrap();
+
+    let current_lockfile_path = config.virtual_store_dir.join(Lockfile::CURRENT_FILE_NAME);
+    let current_lockfile_file =
+        std::fs::OpenOptions::new().write(true).open(&current_lockfile_path).unwrap();
+    current_lockfile_file.set_times(std::fs::FileTimes::new().set_modified(system_time)).unwrap();
+
+    let manifest_mtime_ms = 1_700_000_000_000_i64;
+
+    // Stamp the workspace state's last_validated_timestamp to the EXACT SAME
+    // millisecond as the manifest's mtime (simulating a collision).
+    let settings =
+        current_settings(config, pacquet_config::NodeLinker::Isolated, isolated_included(), None);
+    let mut projects = BTreeMap::new();
+    projects.insert(
+        dir.path().to_string_lossy().into_owned(),
+        ProjectEntry { name: Some("root".into()), version: Some("1.0.0".into()) },
+    );
+    write_state(dir.path(), manifest_mtime_ms, settings, projects);
+
+    let manifest = PackageManifest::from_path(manifest_path).unwrap();
+
+    // First check: because of the collision (ns > ms), it does not take the
+    // pure-mtime fast path. It runs the content check, which passes and
+    // updates the workspace state to `baseline + 1` ms.
+    let decision =
+        content_check_decision(&dir, config, true, &[(dir.path().to_path_buf(), &manifest)]);
+    assert_eq!(decision, Decision::UpToDate);
+
+    // Verify the state was written with last_validated_timestamp = baseline + 1.
+    let after_state = pacquet_workspace_state::load_workspace_state(dir.path()).unwrap().unwrap();
+    assert_eq!(after_state.last_validated_timestamp, manifest_mtime_ms + 1);
+
+    // Second check: because the reference is now `manifest_mtime_ms + 1`,
+    // it post-dates the manifest's mtime. The check should exit on the
+    // pure-mtime fast path without updating the state again.
+    // To verify it didn't run the content check (which would rewrite the state),
+    // we check that the timestamp is still exactly `manifest_mtime_ms + 1`.
+    let decision2 =
+        content_check_decision(&dir, config, true, &[(dir.path().to_path_buf(), &manifest)]);
+    assert_eq!(decision2, Decision::UpToDate);
+
+    let after_state2 = pacquet_workspace_state::load_workspace_state(dir.path()).unwrap().unwrap();
+    assert_eq!(after_state2.last_validated_timestamp, manifest_mtime_ms + 1);
+}
+
 /// Workspace lockfile whose root importer links a sibling: the link
 /// stays valid while the sibling's version satisfies the manifest
 /// range, and a bump outside the range falls through to the full

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
@@ -14,7 +14,7 @@ use pnpm_config::Config;
 use pnpm_lockfile::{Lockfile, MaybeLazyLockfile};
 use pnpm_modules_yaml::IncludedDependencies;
 use pnpm_package_manifest::PackageManifest;
-use pnpm_testing_utils::fs::backdate_existing_files;
+use pnpm_testing_utils::fs::{backdate_existing_files, set_mtime};
 use pnpm_workspace_state::{
     ProjectEntry, WorkspaceState, WorkspaceStateSettings, load_workspace_state,
     update_workspace_state,
@@ -2373,125 +2373,170 @@ fn workspace_content_check_refreshes_last_validated_timestamp() {
     assert!(after > before, "expected the state timestamp to advance ({before} -> {after})");
 }
 
-/// Workspace branch: a same-millisecond mtime collision between the manifest
-/// and the baseline causes a content check on the next run, but that check
-/// passes and refreshes `lastValidatedTimestamp` forward by 1ms. The run after
-/// that must then take the pure-mtime path without needing a content check.
-#[test]
-fn workspace_content_check_resolves_same_millisecond_mtime_collision_and_converges() {
-    let (dir, config) = setup_content_check_project();
-    let manifest_path = dir.path().join("package.json");
+/// The instant every mtime-collision test stamps on the files the
+/// freshness check stats and on the recorded `lastValidatedTimestamp`.
+const COLLIDING_MTIME_SECS: u64 = 1_700_000_000;
+/// [`COLLIDING_MTIME_SECS`] in the milliseconds the state records.
+const COLLIDING_MTIME_MS: i64 = 1_700_000_000_000;
 
-    // Set the manifest's and lockfiles' mtimes to exactly 1,700,000,000s + 0.5ms.
-    let seconds = 1_700_000_000;
-    let nanos = 500_000; // 0.5 ms
-    let system_time = std::time::SystemTime::UNIX_EPOCH + std::time::Duration::new(seconds, nanos);
-
-    let file = std::fs::OpenOptions::new().write(true).open(&manifest_path).unwrap();
-    file.set_times(std::fs::FileTimes::new().set_modified(system_time)).unwrap();
-
-    let lockfile_path = dir.path().join(Lockfile::FILE_NAME);
-    let lockfile_file = std::fs::OpenOptions::new().write(true).open(&lockfile_path).unwrap();
-    lockfile_file.set_times(std::fs::FileTimes::new().set_modified(system_time)).unwrap();
-
-    let current_lockfile_path = config.virtual_store_dir.join(Lockfile::CURRENT_FILE_NAME);
-    let current_lockfile_file =
-        std::fs::OpenOptions::new().write(true).open(&current_lockfile_path).unwrap();
-    current_lockfile_file.set_times(std::fs::FileTimes::new().set_modified(system_time)).unwrap();
-
-    let manifest_mtime_ms = 1_700_000_000_000_i64;
-
-    // Stamp the workspace state's last_validated_timestamp to the EXACT SAME
-    // millisecond as the manifest's mtime (simulating a collision).
-    let settings =
-        current_settings(config, pnpm_config::NodeLinker::Isolated, isolated_included(), None);
+/// Reproduce the mtime-tick collision of
+/// [#13907](https://github.com/pnpm/pnpm/issues/13907): every file the
+/// freshness check stats is stamped `subsec_nanos` into the millisecond
+/// the workspace state records as validated, so the manifest reads as
+/// possibly-modified and the content check runs. A `subsec_nanos` of
+/// zero is the whole-second-mtime filesystem's version of the same
+/// collision.
+fn collide_mtimes_with_recorded_state(
+    workspace_root: &std::path::Path,
+    config: &Config,
+    subsec_nanos: u32,
+) {
+    let modified = std::time::SystemTime::UNIX_EPOCH
+        + std::time::Duration::new(COLLIDING_MTIME_SECS, subsec_nanos);
+    for path in [
+        workspace_root.join("package.json"),
+        workspace_root.join(Lockfile::FILE_NAME),
+        config.virtual_store_dir.join(Lockfile::CURRENT_FILE_NAME),
+    ] {
+        set_mtime(&path, modified);
+    }
     let mut projects = BTreeMap::new();
     projects.insert(
-        dir.path().to_string_lossy().into_owned(),
+        workspace_root.to_string_lossy().into_owned(),
         ProjectEntry { name: Some("root".into()), version: Some("1.0.0".into()) },
     );
-    write_state(dir.path(), manifest_mtime_ms, settings, projects);
+    write_state(
+        workspace_root,
+        COLLIDING_MTIME_MS,
+        current_settings(config, pnpm_config::NodeLinker::Isolated, isolated_included(), None),
+        projects,
+    );
+}
 
-    let manifest = PackageManifest::from_path(manifest_path).unwrap();
+/// Rewrite the wanted lockfile so a content check would report the
+/// project outdated while leaving its mtime untouched, so an up-to-date
+/// verdict after this can only have come from the pure-mtime fast path.
+fn poison_lockfile_content(workspace_root: &std::path::Path) {
+    let path = workspace_root.join(Lockfile::FILE_NAME);
+    let modified = fs::metadata(&path).unwrap().modified().unwrap();
+    fs::write(&path, FOO_LOCKFILE.replace("1.0.0", "1.0.1")).unwrap();
+    set_mtime(&path, modified);
+}
 
-    // First check: because of the collision (ns > ms), it does not take the
-    // pure-mtime fast path. It runs the content check, which passes and
-    // updates the workspace state.
-    let decision =
-        content_check_decision(&dir, config, true, &[(dir.path().to_path_buf(), &manifest)]);
-    assert_eq!(decision, Decision::UpToDate);
+fn recorded_timestamp(workspace_root: &std::path::Path) -> i64 {
+    load_workspace_state(workspace_root)
+        .expect("read the workspace state")
+        .expect("a workspace state to have been written")
+        .last_validated_timestamp
+}
 
-    // Verify the state was written.
-    let after_state = pnpm_workspace_state::load_workspace_state(dir.path()).unwrap().unwrap();
-    assert!(after_state.last_validated_timestamp > manifest_mtime_ms);
+fn assert_content_check_converges_after_collision(subsec_nanos: u32) {
+    let (dir, config) = setup_content_check_project();
+    collide_mtimes_with_recorded_state(dir.path(), config, subsec_nanos);
+    let manifest = PackageManifest::from_path(dir.path().join("package.json")).unwrap();
+    let project_manifests = [(dir.path().to_path_buf(), &manifest)];
 
-    // Second check: because the reference now post-dates the manifest's mtime,
-    // the check should exit on the pure-mtime fast path without updating the state again.
-    let decision2 =
-        content_check_decision(&dir, config, true, &[(dir.path().to_path_buf(), &manifest)]);
-    assert_eq!(decision2, Decision::UpToDate);
+    assert_eq!(content_check_decision(&dir, config, true, &project_manifests), Decision::UpToDate);
+    let refreshed = recorded_timestamp(dir.path());
+    assert!(
+        refreshed > COLLIDING_MTIME_MS,
+        "expected the passing content check to advance the baseline past {COLLIDING_MTIME_MS}, got {refreshed}",
+    );
 
-    let after_state2 = pnpm_workspace_state::load_workspace_state(dir.path()).unwrap().unwrap();
-    assert_eq!(after_state2.last_validated_timestamp, after_state.last_validated_timestamp);
+    poison_lockfile_content(dir.path());
+    assert_eq!(content_check_decision(&dir, config, true, &project_manifests), Decision::UpToDate);
+    assert_eq!(recorded_timestamp(dir.path()), refreshed);
 }
 
 #[test]
-fn workspace_content_check_resolves_same_second_mtime_collision_and_converges() {
+fn workspace_content_check_converges_after_a_same_millisecond_mtime_collision() {
+    assert_content_check_converges_after_collision(500_000);
+}
+
+#[test]
+fn workspace_content_check_converges_after_a_whole_second_mtime_collision() {
+    assert_content_check_converges_after_collision(0);
+}
+
+/// The refreshed baseline must not post-date the filesystem clock: an
+/// edit made after the content check passed still has to defeat the
+/// mtime fast path on the next run.
+#[test]
+fn workspace_content_check_does_not_bless_a_manifest_edited_after_it_passed() {
     let (dir, config) = setup_content_check_project();
-    let manifest_path = dir.path().join("package.json");
-
-    // Set the manifest's and lockfiles' mtimes to exactly 1,700,000,000s + 0ns (whole second).
-    let seconds = 1_700_000_000;
-    let nanos = 0;
-    let system_time = std::time::SystemTime::UNIX_EPOCH + std::time::Duration::new(seconds, nanos);
-
-    let file = std::fs::OpenOptions::new().write(true).open(&manifest_path).unwrap();
-    file.set_times(std::fs::FileTimes::new().set_modified(system_time)).unwrap();
-
-    let lockfile_path = dir.path().join(Lockfile::FILE_NAME);
-    let lockfile_file = std::fs::OpenOptions::new().write(true).open(&lockfile_path).unwrap();
-    lockfile_file.set_times(std::fs::FileTimes::new().set_modified(system_time)).unwrap();
-
-    let current_lockfile_path = config.virtual_store_dir.join(Lockfile::CURRENT_FILE_NAME);
-    let current_lockfile_file =
-        std::fs::OpenOptions::new().write(true).open(&current_lockfile_path).unwrap();
-    current_lockfile_file.set_times(std::fs::FileTimes::new().set_modified(system_time)).unwrap();
-
-    let manifest_mtime_ms = 1_700_000_000_000_i64;
-
-    // Stamp the workspace state's last_validated_timestamp to the EXACT SAME
-    // millisecond as the manifest's mtime (simulating a collision).
-    let settings =
-        current_settings(config, pnpm_config::NodeLinker::Isolated, isolated_included(), None);
-    let mut projects = BTreeMap::new();
-    projects.insert(
-        dir.path().to_string_lossy().into_owned(),
-        ProjectEntry { name: Some("root".into()), version: Some("1.0.0".into()) },
+    collide_mtimes_with_recorded_state(dir.path(), config, 500_000);
+    let manifest = PackageManifest::from_path(dir.path().join("package.json")).unwrap();
+    assert_eq!(
+        content_check_decision(&dir, config, true, &[(dir.path().to_path_buf(), &manifest)]),
+        Decision::UpToDate,
     );
-    write_state(dir.path(), manifest_mtime_ms, settings, projects);
 
-    let manifest = PackageManifest::from_path(manifest_path).unwrap();
+    fs::write(
+        dir.path().join("package.json"),
+        r#"{"name":"root","version":"1.0.0","dependencies":{"foo":"^1.0.0","bar":"^1.0.0"}}"#,
+    )
+    .unwrap();
+    let edited = PackageManifest::from_path(dir.path().join("package.json")).unwrap();
 
-    // First check: because of the collision, it does not take the fast path.
-    // It runs the content check, which passes and updates the workspace state.
-    // Since mtimes are coarse (whole_second), the new baseline should be at
-    // least `manifest_mtime_ms + 1000`.
     let decision =
-        content_check_decision(&dir, config, true, &[(dir.path().to_path_buf(), &manifest)]);
-    assert_eq!(decision, Decision::UpToDate);
+        content_check_decision(&dir, config, true, &[(dir.path().to_path_buf(), &edited)]);
+    assert!(
+        matches!(decision, Decision::Skipped { .. }),
+        "expected the edit to defeat the fast path, got {decision:?}",
+    );
+}
 
-    // Verify the state was written.
-    let after_state = pnpm_workspace_state::load_workspace_state(dir.path()).unwrap().unwrap();
-    assert!(after_state.last_validated_timestamp >= manifest_mtime_ms + 1000);
+fn workspace_deps_status(
+    dir: &tempfile::TempDir,
+    config: &'static Config,
+    project_manifests: &[(std::path::PathBuf, &PackageManifest)],
+) -> RunDepsStatus {
+    let state = load_workspace_state(dir.path())
+        .expect("read the workspace state")
+        .expect("a workspace state to have been written");
+    let lockfile = Lockfile::load_wanted_from_dir(dir.path()).expect("parse pnpm-lock.yaml");
+    check_deps_status_before_run(
+        &OptimisticRepeatInstallCheck {
+            workspace_root: dir.path(),
+            config,
+            node_linker: pnpm_config::NodeLinker::Isolated,
+            included: isolated_included(),
+            supported_architectures: None,
+            project_manifests,
+            is_workspace_install: true,
+            lockfile: MaybeLazyLockfile::Loaded(lockfile.as_ref()),
+            catalogs: &BTreeMap::default(),
+        },
+        &state,
+    )
+}
 
-    // Second check: because the reference now post-dates the manifest's mtime + 1s,
-    // the check should exit on the pure-mtime fast path without updating the state again.
-    let decision2 =
-        content_check_decision(&dir, config, true, &[(dir.path().to_path_buf(), &manifest)]);
-    assert_eq!(decision2, Decision::UpToDate);
+fn assert_deps_status_converges_after_collision(subsec_nanos: u32) {
+    let (dir, config) = setup_content_check_project();
+    collide_mtimes_with_recorded_state(dir.path(), config, subsec_nanos);
+    let manifest = PackageManifest::from_path(dir.path().join("package.json")).unwrap();
+    let project_manifests = [(dir.path().to_path_buf(), &manifest)];
 
-    let after_state2 = pnpm_workspace_state::load_workspace_state(dir.path()).unwrap().unwrap();
-    assert_eq!(after_state2.last_validated_timestamp, after_state.last_validated_timestamp);
+    assert_eq!(workspace_deps_status(&dir, config, &project_manifests), RunDepsStatus::UpToDate);
+    let refreshed = recorded_timestamp(dir.path());
+    assert!(
+        refreshed > COLLIDING_MTIME_MS,
+        "expected the passing content check to advance the baseline past {COLLIDING_MTIME_MS}, got {refreshed}",
+    );
+
+    poison_lockfile_content(dir.path());
+    assert_eq!(workspace_deps_status(&dir, config, &project_manifests), RunDepsStatus::UpToDate);
+    assert_eq!(recorded_timestamp(dir.path()), refreshed);
+}
+
+#[test]
+fn run_gate_converges_after_a_same_millisecond_mtime_collision() {
+    assert_deps_status_converges_after_collision(500_000);
+}
+
+#[test]
+fn run_gate_converges_after_a_whole_second_mtime_collision() {
+    assert_deps_status_converges_after_collision(0);
 }
 
 /// Workspace lockfile whose root importer links a sibling: the link

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
@@ -2416,26 +2416,82 @@ fn workspace_content_check_resolves_same_millisecond_mtime_collision_and_converg
 
     // First check: because of the collision (ns > ms), it does not take the
     // pure-mtime fast path. It runs the content check, which passes and
-    // updates the workspace state to `baseline + 1` ms.
+    // updates the workspace state.
     let decision =
         content_check_decision(&dir, config, true, &[(dir.path().to_path_buf(), &manifest)]);
     assert_eq!(decision, Decision::UpToDate);
 
-    // Verify the state was written with last_validated_timestamp = baseline + 1.
+    // Verify the state was written.
     let after_state = pacquet_workspace_state::load_workspace_state(dir.path()).unwrap().unwrap();
-    assert_eq!(after_state.last_validated_timestamp, manifest_mtime_ms + 1);
+    assert!(after_state.last_validated_timestamp > manifest_mtime_ms);
 
-    // Second check: because the reference is now `manifest_mtime_ms + 1`,
-    // it post-dates the manifest's mtime. The check should exit on the
-    // pure-mtime fast path without updating the state again.
-    // To verify it didn't run the content check (which would rewrite the state),
-    // we check that the timestamp is still exactly `manifest_mtime_ms + 1`.
+    // Second check: because the reference now post-dates the manifest's mtime,
+    // the check should exit on the pure-mtime fast path without updating the state again.
     let decision2 =
         content_check_decision(&dir, config, true, &[(dir.path().to_path_buf(), &manifest)]);
     assert_eq!(decision2, Decision::UpToDate);
 
     let after_state2 = pacquet_workspace_state::load_workspace_state(dir.path()).unwrap().unwrap();
-    assert_eq!(after_state2.last_validated_timestamp, manifest_mtime_ms + 1);
+    assert_eq!(after_state2.last_validated_timestamp, after_state.last_validated_timestamp);
+}
+
+#[test]
+fn workspace_content_check_resolves_same_second_mtime_collision_and_converges() {
+    let (dir, config) = setup_content_check_project();
+    let manifest_path = dir.path().join("package.json");
+
+    // Set the manifest's and lockfiles' mtimes to exactly 1,700,000,000s + 0ns (whole second).
+    let seconds = 1_700_000_000;
+    let nanos = 0;
+    let system_time = std::time::SystemTime::UNIX_EPOCH + std::time::Duration::new(seconds, nanos);
+
+    let file = std::fs::OpenOptions::new().write(true).open(&manifest_path).unwrap();
+    file.set_times(std::fs::FileTimes::new().set_modified(system_time)).unwrap();
+
+    let lockfile_path = dir.path().join(Lockfile::FILE_NAME);
+    let lockfile_file = std::fs::OpenOptions::new().write(true).open(&lockfile_path).unwrap();
+    lockfile_file.set_times(std::fs::FileTimes::new().set_modified(system_time)).unwrap();
+
+    let current_lockfile_path = config.virtual_store_dir.join(Lockfile::CURRENT_FILE_NAME);
+    let current_lockfile_file =
+        std::fs::OpenOptions::new().write(true).open(&current_lockfile_path).unwrap();
+    current_lockfile_file.set_times(std::fs::FileTimes::new().set_modified(system_time)).unwrap();
+
+    let manifest_mtime_ms = 1_700_000_000_000_i64;
+
+    // Stamp the workspace state's last_validated_timestamp to the EXACT SAME
+    // millisecond as the manifest's mtime (simulating a collision).
+    let settings =
+        current_settings(config, pacquet_config::NodeLinker::Isolated, isolated_included(), None);
+    let mut projects = BTreeMap::new();
+    projects.insert(
+        dir.path().to_string_lossy().into_owned(),
+        ProjectEntry { name: Some("root".into()), version: Some("1.0.0".into()) },
+    );
+    write_state(dir.path(), manifest_mtime_ms, settings, projects);
+
+    let manifest = PackageManifest::from_path(manifest_path).unwrap();
+
+    // First check: because of the collision, it does not take the fast path.
+    // It runs the content check, which passes and updates the workspace state.
+    // Since mtimes are coarse (whole_second), the new baseline should be at
+    // least `manifest_mtime_ms + 1000`.
+    let decision =
+        content_check_decision(&dir, config, true, &[(dir.path().to_path_buf(), &manifest)]);
+    assert_eq!(decision, Decision::UpToDate);
+
+    // Verify the state was written.
+    let after_state = pacquet_workspace_state::load_workspace_state(dir.path()).unwrap().unwrap();
+    assert!(after_state.last_validated_timestamp >= manifest_mtime_ms + 1000);
+
+    // Second check: because the reference now post-dates the manifest's mtime + 1s,
+    // the check should exit on the pure-mtime fast path without updating the state again.
+    let decision2 =
+        content_check_decision(&dir, config, true, &[(dir.path().to_path_buf(), &manifest)]);
+    assert_eq!(decision2, Decision::UpToDate);
+
+    let after_state2 = pacquet_workspace_state::load_workspace_state(dir.path()).unwrap().unwrap();
+    assert_eq!(after_state2.last_validated_timestamp, after_state.last_validated_timestamp);
 }
 
 /// Workspace lockfile whose root importer links a sibling: the link

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
@@ -2412,26 +2412,82 @@ fn workspace_content_check_resolves_same_millisecond_mtime_collision_and_converg
 
     // First check: because of the collision (ns > ms), it does not take the
     // pure-mtime fast path. It runs the content check, which passes and
-    // updates the workspace state to `baseline + 1` ms.
+    // updates the workspace state.
     let decision =
         content_check_decision(&dir, config, true, &[(dir.path().to_path_buf(), &manifest)]);
     assert_eq!(decision, Decision::UpToDate);
 
-    // Verify the state was written with last_validated_timestamp = baseline + 1.
+    // Verify the state was written.
     let after_state = pacquet_workspace_state::load_workspace_state(dir.path()).unwrap().unwrap();
-    assert_eq!(after_state.last_validated_timestamp, manifest_mtime_ms + 1);
+    assert!(after_state.last_validated_timestamp > manifest_mtime_ms);
 
-    // Second check: because the reference is now `manifest_mtime_ms + 1`,
-    // it post-dates the manifest's mtime. The check should exit on the
-    // pure-mtime fast path without updating the state again.
-    // To verify it didn't run the content check (which would rewrite the state),
-    // we check that the timestamp is still exactly `manifest_mtime_ms + 1`.
+    // Second check: because the reference now post-dates the manifest's mtime,
+    // the check should exit on the pure-mtime fast path without updating the state again.
     let decision2 =
         content_check_decision(&dir, config, true, &[(dir.path().to_path_buf(), &manifest)]);
     assert_eq!(decision2, Decision::UpToDate);
 
     let after_state2 = pacquet_workspace_state::load_workspace_state(dir.path()).unwrap().unwrap();
-    assert_eq!(after_state2.last_validated_timestamp, manifest_mtime_ms + 1);
+    assert_eq!(after_state2.last_validated_timestamp, after_state.last_validated_timestamp);
+}
+
+#[test]
+fn workspace_content_check_resolves_same_second_mtime_collision_and_converges() {
+    let (dir, config) = setup_content_check_project();
+    let manifest_path = dir.path().join("package.json");
+
+    // Set the manifest's and lockfiles' mtimes to exactly 1,700,000,000s + 0ns (whole second).
+    let seconds = 1_700_000_000;
+    let nanos = 0;
+    let system_time = std::time::SystemTime::UNIX_EPOCH + std::time::Duration::new(seconds, nanos);
+
+    let file = std::fs::OpenOptions::new().write(true).open(&manifest_path).unwrap();
+    file.set_times(std::fs::FileTimes::new().set_modified(system_time)).unwrap();
+
+    let lockfile_path = dir.path().join(Lockfile::FILE_NAME);
+    let lockfile_file = std::fs::OpenOptions::new().write(true).open(&lockfile_path).unwrap();
+    lockfile_file.set_times(std::fs::FileTimes::new().set_modified(system_time)).unwrap();
+
+    let current_lockfile_path = config.virtual_store_dir.join(Lockfile::CURRENT_FILE_NAME);
+    let current_lockfile_file =
+        std::fs::OpenOptions::new().write(true).open(&current_lockfile_path).unwrap();
+    current_lockfile_file.set_times(std::fs::FileTimes::new().set_modified(system_time)).unwrap();
+
+    let manifest_mtime_ms = 1_700_000_000_000_i64;
+
+    // Stamp the workspace state's last_validated_timestamp to the EXACT SAME
+    // millisecond as the manifest's mtime (simulating a collision).
+    let settings =
+        current_settings(config, pacquet_config::NodeLinker::Isolated, isolated_included(), None);
+    let mut projects = BTreeMap::new();
+    projects.insert(
+        dir.path().to_string_lossy().into_owned(),
+        ProjectEntry { name: Some("root".into()), version: Some("1.0.0".into()) },
+    );
+    write_state(dir.path(), manifest_mtime_ms, settings, projects);
+
+    let manifest = PackageManifest::from_path(manifest_path).unwrap();
+
+    // First check: because of the collision, it does not take the fast path.
+    // It runs the content check, which passes and updates the workspace state.
+    // Since mtimes are coarse (whole_second), the new baseline should be at
+    // least `manifest_mtime_ms + 1000`.
+    let decision =
+        content_check_decision(&dir, config, true, &[(dir.path().to_path_buf(), &manifest)]);
+    assert_eq!(decision, Decision::UpToDate);
+
+    // Verify the state was written.
+    let after_state = pacquet_workspace_state::load_workspace_state(dir.path()).unwrap().unwrap();
+    assert!(after_state.last_validated_timestamp >= manifest_mtime_ms + 1000);
+
+    // Second check: because the reference now post-dates the manifest's mtime + 1s,
+    // the check should exit on the pure-mtime fast path without updating the state again.
+    let decision2 =
+        content_check_decision(&dir, config, true, &[(dir.path().to_path_buf(), &manifest)]);
+    assert_eq!(decision2, Decision::UpToDate);
+
+    let after_state2 = pacquet_workspace_state::load_workspace_state(dir.path()).unwrap().unwrap();
+    assert_eq!(after_state2.last_validated_timestamp, after_state.last_validated_timestamp);
 }
 
 /// Workspace lockfile whose root importer links a sibling: the link

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
@@ -2373,6 +2373,71 @@ fn workspace_content_check_refreshes_last_validated_timestamp() {
     assert!(after > before, "expected the state timestamp to advance ({before} -> {after})");
 }
 
+/// Workspace branch: a same-millisecond mtime collision between the manifest
+/// and the baseline causes a content check on the next run, but that check
+/// passes and refreshes `lastValidatedTimestamp` forward by 1ms. The run after
+/// that must then take the pure-mtime path without needing a content check.
+#[test]
+fn workspace_content_check_resolves_same_millisecond_mtime_collision_and_converges() {
+    let (dir, config) = setup_content_check_project();
+    let manifest_path = dir.path().join("package.json");
+
+    // Set the manifest's and lockfiles' mtimes to exactly 1,700,000,000s + 0.5ms.
+    let seconds = 1_700_000_000;
+    let nanos = 500_000; // 0.5 ms
+    let system_time = std::time::SystemTime::UNIX_EPOCH + std::time::Duration::new(seconds, nanos);
+
+    let file = std::fs::OpenOptions::new().write(true).open(&manifest_path).unwrap();
+    file.set_times(std::fs::FileTimes::new().set_modified(system_time)).unwrap();
+
+    let lockfile_path = dir.path().join(Lockfile::FILE_NAME);
+    let lockfile_file = std::fs::OpenOptions::new().write(true).open(&lockfile_path).unwrap();
+    lockfile_file.set_times(std::fs::FileTimes::new().set_modified(system_time)).unwrap();
+
+    let current_lockfile_path = config.virtual_store_dir.join(Lockfile::CURRENT_FILE_NAME);
+    let current_lockfile_file =
+        std::fs::OpenOptions::new().write(true).open(&current_lockfile_path).unwrap();
+    current_lockfile_file.set_times(std::fs::FileTimes::new().set_modified(system_time)).unwrap();
+
+    let manifest_mtime_ms = 1_700_000_000_000_i64;
+
+    // Stamp the workspace state's last_validated_timestamp to the EXACT SAME
+    // millisecond as the manifest's mtime (simulating a collision).
+    let settings =
+        current_settings(config, pacquet_config::NodeLinker::Isolated, isolated_included(), None);
+    let mut projects = BTreeMap::new();
+    projects.insert(
+        dir.path().to_string_lossy().into_owned(),
+        ProjectEntry { name: Some("root".into()), version: Some("1.0.0".into()) },
+    );
+    write_state(dir.path(), manifest_mtime_ms, settings, projects);
+
+    let manifest = PackageManifest::from_path(manifest_path).unwrap();
+
+    // First check: because of the collision (ns > ms), it does not take the
+    // pure-mtime fast path. It runs the content check, which passes and
+    // updates the workspace state to `baseline + 1` ms.
+    let decision =
+        content_check_decision(&dir, config, true, &[(dir.path().to_path_buf(), &manifest)]);
+    assert_eq!(decision, Decision::UpToDate);
+
+    // Verify the state was written with last_validated_timestamp = baseline + 1.
+    let after_state = pacquet_workspace_state::load_workspace_state(dir.path()).unwrap().unwrap();
+    assert_eq!(after_state.last_validated_timestamp, manifest_mtime_ms + 1);
+
+    // Second check: because the reference is now `manifest_mtime_ms + 1`,
+    // it post-dates the manifest's mtime. The check should exit on the
+    // pure-mtime fast path without updating the state again.
+    // To verify it didn't run the content check (which would rewrite the state),
+    // we check that the timestamp is still exactly `manifest_mtime_ms + 1`.
+    let decision2 =
+        content_check_decision(&dir, config, true, &[(dir.path().to_path_buf(), &manifest)]);
+    assert_eq!(decision2, Decision::UpToDate);
+
+    let after_state2 = pacquet_workspace_state::load_workspace_state(dir.path()).unwrap().unwrap();
+    assert_eq!(after_state2.last_validated_timestamp, manifest_mtime_ms + 1);
+}
+
 /// Workspace lockfile whose root importer links a sibling: the link
 /// stays valid while the sibling's version satisfies the manifest
 /// range, and a bump outside the range falls through to the full

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/timestamps.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/timestamps.rs
@@ -102,19 +102,51 @@ pub(crate) fn validation_baseline_ms(
         .max()
 }
 
-/// The current time on the filesystem clock, obtained by writing a temporary
-/// file to the workspace directory and reading its modification time. This
-/// guarantees the baseline is on the same clock as the checked files and
-/// represents the exact time the validation finished, allowing repeat runs
-/// to converge to the fast path without hiding subsequent edits.
-pub(crate) fn current_filesystem_time_ms(workspace_root: &Path) -> Option<i64> {
-    let temp_path = workspace_root.join(".pnpm-state-tmp");
-    if std::fs::write(&temp_path, "").is_err() {
-        return None;
-    }
-    let mtime = mtime_ms(&temp_path);
-    let _ = std::fs::remove_file(&temp_path);
-    mtime
+/// The filesystem clock's current time in milliseconds, taken from an
+/// mtime the filesystem stamps itself, so it shares a clock with every
+/// file the repeat-install check compares — the reason
+/// [`validation_baseline_ms`] cannot use the wall clock either.
+///
+/// Read it *before* validating the contents it will later bless: a file
+/// written after the probe carries a later mtime and so still reads as
+/// modified, while one written before it is covered by the check that
+/// just passed.
+///
+/// The probe is an unnamed temporary file in the directory holding the
+/// workspace state — pnpm's own, on the volume the state write lands on
+/// — so nothing else can observe it and it needs no cleanup. `None` when
+/// it cannot be created or stat'd, leaving the caller with the
+/// mtime-derived baseline.
+pub(crate) fn filesystem_now_ms(workspace_root: &Path) -> Option<i64> {
+    let state_path = pnpm_workspace_state::get_file_path(workspace_root);
+    let probe = tempfile::tempfile_in(state_path.parent()?).ok()?;
+    file_mtime_from_metadata(&probe.metadata().ok()?).map(|mtime| mtime.ms)
+}
+
+/// The `lastValidatedTimestamp` to record once a repeat-install content
+/// check has passed: `baseline_ms` — the mtimes of the files it
+/// validated, per [`validation_baseline_ms`] — raised to the filesystem
+/// clock's `now_ms`.
+///
+/// `baseline_ms` on its own never converges. It is a file mtime
+/// truncated to milliseconds, and [`modified_at_or_after`] deliberately
+/// reads a file whose mtime falls inside that same millisecond — or, on
+/// a whole-second filesystem, inside that same second — as
+/// possibly-modified. The very file that forced this content check keeps
+/// forcing one on every later run, so the pure-mtime fast path becomes
+/// unreachable
+/// ([#13907](https://github.com/pnpm/pnpm/issues/13907)). Raising the
+/// baseline to the filesystem's *now* closes that window without
+/// post-dating it into the future, which would hide an edit made in the
+/// interval it skipped over. Keeping `baseline_ms` as the floor
+/// preserves the blessing of a validated file whose mtime already lies
+/// ahead of the filesystem clock.
+///
+/// pnpm's `checkDepsStatus` records `Date.now()` at this point. Reading
+/// the same *now* off the filesystem keeps the wall clock — which can
+/// run ahead of the mtime clock — out of the comparison.
+pub(crate) fn refreshed_validation_baseline_ms(baseline_ms: i64, now_ms: Option<i64>) -> i64 {
+    now_ms.map_or(baseline_ms, |now| baseline_ms.max(now))
 }
 
 /// Whether `<workspace_root>/pnpm-lock.yaml` has an mtime newer than the

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/timestamps.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/timestamps.rs
@@ -145,6 +145,12 @@ pub(crate) fn filesystem_now_ms(workspace_root: &Path) -> Option<i64> {
 /// pnpm's `checkDepsStatus` records `Date.now()` at this point. Reading
 /// the same *now* off the filesystem keeps the wall clock — which can
 /// run ahead of the mtime clock — out of the comparison.
+///
+/// A check that finishes inside the millisecond it is blessing leaves
+/// the baseline where it was, on purpose: `now_ms` is the present, not a
+/// point past it, and there is nothing later to record yet. The next run
+/// lands in a later millisecond and converges then, so the equality case
+/// costs one more content check rather than repeating forever.
 pub(crate) fn refreshed_validation_baseline_ms(baseline_ms: i64, now_ms: Option<i64>) -> i64 {
     now_ms.map_or(baseline_ms, |now| baseline_ms.max(now))
 }

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/timestamps.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/timestamps.rs
@@ -102,6 +102,21 @@ pub(crate) fn validation_baseline_ms(
         .max()
 }
 
+/// The current time on the filesystem clock, obtained by writing a temporary
+/// file to the workspace directory and reading its modification time. This
+/// guarantees the baseline is on the same clock as the checked files and
+/// represents the exact time the validation finished, allowing repeat runs
+/// to converge to the fast path without hiding subsequent edits.
+pub(crate) fn current_filesystem_time_ms(workspace_root: &Path) -> Option<i64> {
+    let temp_path = workspace_root.join(".pnpm-state-tmp");
+    if std::fs::write(&temp_path, "").is_err() {
+        return None;
+    }
+    let mtime = mtime_ms(&temp_path);
+    let _ = std::fs::remove_file(&temp_path);
+    mtime
+}
+
 /// Whether `<workspace_root>/pnpm-lock.yaml` has an mtime newer than the
 /// last validation. A lockfile-only change leaves every manifest
 /// untouched but must still defeat the manifest-mtime fast path. A

--- a/pnpm/crates/testing-utils/src/fs.rs
+++ b/pnpm/crates/testing-utils/src/fs.rs
@@ -101,7 +101,13 @@ pub fn mtime_ms(path: &Path) -> i64 {
 /// than assume the exact value survives.
 pub fn set_mtime_ms(path: &Path, ms: i64) {
     let ms = u64::try_from(ms).expect("an mtime at or after the Unix epoch");
-    let modified = SystemTime::UNIX_EPOCH + Duration::from_millis(ms);
+    set_mtime(path, SystemTime::UNIX_EPOCH + Duration::from_millis(ms));
+}
+
+/// Set `path`'s mtime to `modified`, keeping whatever sub-millisecond
+/// precision the filesystem stores — the granularity [`set_mtime_ms`]
+/// cannot express, and the one a same-millisecond mtime collision needs.
+pub fn set_mtime(path: &Path, modified: SystemTime) {
     fs::OpenOptions::new()
         .write(true)
         .open(path)


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Fixes the repeat-install fast path getting stuck on the content-check branch forever after a modification-time collision (pnpm/pnpm#13907).

`lastValidatedTimestamp` is recorded as a filesystem mtime truncated to milliseconds (the clock-skew fix from pnpm/pnpm#12981), and `modified_at_or_after` compares against it at nanosecond precision — deliberately, so an edit landing in the same millisecond as the lockfile write is not missed. The consequence is that a manifest whose mtime falls inside that same millisecond — or, on a whole-second-mtime filesystem, inside that same second — reads as possibly-modified on *every* later run. The content check passes and rewrites the state, but the rewritten baseline is the same truncated mtime, so the pure-mtime fast path is never reachable again: every repeat install pays the lockfile parse plus per-project comparison (~33 ms vs ~6 ms on the benchmark fixture).

The fix records `max(mtime baseline, filesystem "now")` after a passing content check, where "now" is read from an mtime the filesystem stamps itself. That converges in both the millisecond and the whole-second case, and it never moves the baseline ahead of the present, so an edit made after the check still carries a later mtime and is still seen. This is what pnpm's TypeScript `checkDepsStatus` does with `Date.now()`; reading the same "now" off the filesystem instead of the wall clock keeps the ~2 ms wall-vs-mtime skew of pnpm/pnpm#12981 out of the comparison.

Notes on the implementation:

- The probe is taken **before** the content check runs, so an edit landing while the check reads the lockfile is not blessed by the refreshed baseline.
- It runs only on the workspace branch that actually rewrites the state, and only on the content-check (slow) path — the pure-mtime fast path does no extra I/O.
- It is an unnamed `tempfile::tempfile_in` file stat'd through its own handle, created beside the workspace state in `node_modules/` rather than in the project root: no fixed path to redirect through a symlink, no name for a concurrent run to clobber, no cleanup by path.

Closes pnpm/pnpm#13907

## Squash Commit Body

```text
fix(pacquet): raise the repeat-install baseline to the filesystem clock

Record `lastValidatedTimestamp` as the greater of the validated files'
mtimes and the filesystem clock's current time, read from an unnamed
temporary file before the content check runs.

The mtime baseline alone cannot converge: it is a file mtime truncated
to milliseconds, and `modified_at_or_after` reads a file whose mtime
lands in that same millisecond -- or, on a whole-second filesystem, that
same second -- as possibly-modified, so the file that forced the content
check keeps forcing one on every later run. Post-dating the baseline by
a fixed delta converges but hides an edit made in the interval it skips
over. Raising it to the filesystem's now converges without ever moving
the baseline ahead of the present, which is what pnpm's
`checkDepsStatus` does with `Date.now()`; reading the same now off the
filesystem keeps the wall clock, which can run ahead of the mtime clock,
out of the comparison.

Closes pnpm/pnpm#13907
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting. *(Rust-only: the TypeScript CLI records `Date.now()` here, so it already converges and is unaffected by this collision.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests. *(Millisecond and whole-second collision convergence through both `check_optimistic_repeat_install` and `check_deps_status_before_run`, plus a guard that the refreshed baseline never blesses a manifest edited after the check passed.)*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13916"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789325944&installation_model_id=426870&pr_number=13916&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13916&signature=efa34694b189c2534f281daec88d30aae29dc948d4dd8e0b1cc2cbcf68966cd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed repeat installs that encounter identical or coarse filesystem modification times, allowing faster validation after successful content checks.
  * Prevented unnecessary full lockfile comparisons and workspace-state updates while still detecting edits made after validation.
  * Improved behavior for fast installs and dependency verification checks across different filesystem timestamp precision levels.

* **Tests**
  * Added regression coverage for timestamp collisions involving manifests and lockfiles at millisecond and whole-second precision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
