### PR TITLE
fix(pack): write POSIX ustar headers for packed tarballs

### DIFF
--- a/.changeset/pack-regular-file-typeflag.md
+++ b/.changeset/pack-regular-file-typeflag.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Pack regular files with the POSIX `0` typeflag so generated tarballs are compatible with readers that do not recognize the legacy NUL form.

--- a/.changeset/pack-regular-file-typeflag.md
+++ b/.changeset/pack-regular-file-typeflag.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Pack regular files with the POSIX `0` typeflag so generated tarballs are compatible with readers that do not recognize the legacy NUL form.
+`pnpm pack` writes tar entries in the POSIX ustar header form npm uses — `ustar\0` magic and the explicit `0` regular-file typeflag — instead of the GNU form with a NUL typeflag, which strict tar readers such as publint mistake for the end-of-archive marker [#13924](https://github.com/pnpm/pnpm/issues/13924).

--- a/cspell.json
+++ b/cspell.json
@@ -420,6 +420,7 @@
     "tsparticles",
     "turso",
     "typecheck",
+    "typeflag",
     "TYPELESS",
     "unallowed",
     "undeprecate",

--- a/pnpm/crates/pack/src/tarball.rs
+++ b/pnpm/crates/pack/src/tarball.rs
@@ -77,6 +77,7 @@ fn append_entry<Writer: Write>(
     mode: u32,
 ) -> io::Result<()> {
     let mut header = tar::Header::new_gnu();
+    header.set_entry_type(tar::EntryType::Regular);
     header.set_size(data.len() as u64);
     header.set_mode(mode);
     header.set_mtime(REPRODUCIBLE_MTIME);

--- a/pnpm/crates/pack/src/tarball.rs
+++ b/pnpm/crates/pack/src/tarball.rs
@@ -76,7 +76,10 @@ fn append_entry<Writer: Write>(
     data: &[u8],
     mode: u32,
 ) -> io::Result<()> {
-    let mut header = tar::Header::new_gnu();
+    // The POSIX ustar form npm writes: `ustar\0` magic and an explicit `0`
+    // typeflag. Hand-rolled tar readers (e.g. publint) reject the GNU
+    // defaults, mistaking a NUL typeflag for the end-of-archive marker.
+    let mut header = tar::Header::new_ustar();
     header.set_entry_type(tar::EntryType::Regular);
     header.set_size(data.len() as u64);
     header.set_mode(mode);

--- a/pnpm/crates/pack/src/tests.rs
+++ b/pnpm/crates/pack/src/tests.rs
@@ -79,16 +79,16 @@ fn tarball_entry_names(tarball: &Path) -> Vec<String> {
         .collect()
 }
 
-// Read the raw ustar typeflag for one entry. The `tar` crate accepts both
-// NUL and `0` as regular-file markers, so checking the decoded entry type
-// would not catch an archive-format regression here.
-fn tarball_entry_typeflag(tarball: &Path, entry_name: &str) -> u8 {
+// Read the raw 512-byte tar header for one entry. The `tar` crate accepts
+// every header form (NUL or `0` typeflags, GNU or POSIX magic), so checking
+// decoded values would not catch an archive-format regression here.
+fn tarball_entry_header(tarball: &Path, entry_name: &str) -> [u8; 512] {
     let file = std::fs::File::open(tarball).unwrap();
     let mut archive = tar::Archive::new(GzDecoder::new(file));
     for entry in archive.entries().unwrap() {
         let entry = entry.unwrap();
         if entry.path().unwrap().to_str() == Some(entry_name) {
-            return entry.header().as_bytes()[156];
+            return *entry.header().as_bytes();
         }
     }
     panic!("entry {entry_name:?} not found in {}", tarball.display());
@@ -169,7 +169,7 @@ fn packs_a_basic_package_to_a_tarball() {
 }
 
 #[test]
-fn packs_regular_files_with_the_posix_regular_typeflag() {
+fn packs_regular_files_with_posix_ustar_headers() {
     let (dir, opts) = fixture(&json!({ "name": "foo", "version": "1.2.3" }));
     touch(dir.path(), "index.js", "module.exports = 1\n");
 
@@ -177,11 +177,14 @@ fn packs_regular_files_with_the_posix_regular_typeflag() {
 
     let tarball = dir.path().join("foo-1.2.3.tgz");
     for entry_name in ["package/index.js", "package/package.json"] {
+        let header = tarball_entry_header(&tarball, entry_name);
+        assert_eq!(header[156], b'0', "{entry_name} should use the POSIX regular-file typeflag");
         assert_eq!(
-            tarball_entry_typeflag(&tarball, entry_name),
-            b'0',
-            "{entry_name} should use the POSIX regular-file typeflag",
+            &header[257..263],
+            b"ustar\0",
+            "{entry_name} should carry the POSIX ustar magic",
         );
+        assert_eq!(&header[263..265], b"00", "{entry_name} should carry the POSIX ustar version");
     }
 }
 

--- a/pnpm/crates/pack/src/tests.rs
+++ b/pnpm/crates/pack/src/tests.rs
@@ -79,6 +79,21 @@ fn tarball_entry_names(tarball: &Path) -> Vec<String> {
         .collect()
 }
 
+/// Read the raw ustar typeflag for one entry. The `tar` crate accepts both
+/// NUL and `0` as regular-file markers, so checking the decoded entry type
+/// would not catch an archive-format regression here.
+fn tarball_entry_typeflag(tarball: &Path, entry_name: &str) -> u8 {
+    let file = std::fs::File::open(tarball).unwrap();
+    let mut archive = tar::Archive::new(GzDecoder::new(file));
+    for entry in archive.entries().unwrap() {
+        let entry = entry.unwrap();
+        if entry.path().unwrap().to_str() == Some(entry_name) {
+            return entry.header().as_bytes()[156];
+        }
+    }
+    panic!("entry {entry_name:?} not found in {}", tarball.display());
+}
+
 /// Read one entry's UTF-8 contents out of a written `.tgz`.
 fn tarball_entry_content(tarball: &Path, entry_name: &str) -> Option<String> {
     let file = std::fs::File::open(tarball).unwrap();
@@ -151,6 +166,23 @@ fn packs_a_basic_package_to_a_tarball() {
     let mut names = tarball_entry_names(&tarball);
     names.sort();
     assert_eq!(names, vec!["package/index.js".to_string(), "package/package.json".into()]);
+}
+
+#[test]
+fn packs_regular_files_with_the_posix_regular_typeflag() {
+    let (dir, opts) = fixture(&json!({ "name": "foo", "version": "1.2.3" }));
+    touch(dir.path(), "index.js", "module.exports = 1\n");
+
+    api::<SilentReporter, Host>(&opts).unwrap();
+
+    let tarball = dir.path().join("foo-1.2.3.tgz");
+    for entry_name in ["package/index.js", "package/package.json"] {
+        assert_eq!(
+            tarball_entry_typeflag(&tarball, entry_name),
+            b'0',
+            "{entry_name} should use the POSIX regular-file typeflag",
+        );
+    }
 }
 
 /// A symlink planted at the output `.tgz` path must not be followed:

--- a/pnpm/crates/pack/src/tests.rs
+++ b/pnpm/crates/pack/src/tests.rs
@@ -79,9 +79,9 @@ fn tarball_entry_names(tarball: &Path) -> Vec<String> {
         .collect()
 }
 
-/// Read the raw ustar typeflag for one entry. The `tar` crate accepts both
-/// NUL and `0` as regular-file markers, so checking the decoded entry type
-/// would not catch an archive-format regression here.
+// Read the raw ustar typeflag for one entry. The `tar` crate accepts both
+// NUL and `0` as regular-file markers, so checking the decoded entry type
+// would not catch an archive-format regression here.
 fn tarball_entry_typeflag(tarball: &Path, entry_name: &str) -> u8 {
     let file = std::fs::File::open(tarball).unwrap();
     let mut archive = tar::Archive::new(GzDecoder::new(file));


### PR DESCRIPTION
Fixes https://github.com/pnpm/pnpm/issues/13924

## Summary

- Write tar entries in the full POSIX ustar header form npm and pnpm 11 emit: `Header::new_ustar` for the `ustar\0` magic and `00` version, plus an explicit `0` regular-file typeflag (the typeflag byte stays NUL otherwise).
- Add a regression test that pins the raw typeflag, magic, and version header bytes, since tar readers accept every header form and decoded values would not catch a format regression.
- Add the required pacquet patch changeset, and `typeflag` to the cspell dictionary.

## Tests

- cargo nextest run -p pnpm-pack
- cargo fmt --all -- --check
- cargo clippy / dylint / typos / taplo (via the pre-push hook)

Written by an agent (Codex, GPT-5); rebased and extended to the full ustar header form by an agent (Claude Code, claude-fable-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Generated tarballs now mark regular files with the standard POSIX `0` typeflag, improving compatibility with tar tooling.
* **Tests**
  * Added coverage to verify regular package files use the correct tar header format.
* **Documentation**
  * Documented the tarball format correction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->