### PR TITLE
fix(engine-pm): authenticate the Yarn releases fetch with GH_TOKEN / GITHUB_TOKEN

### DIFF
--- a/.changeset/yarn-releases-github-token.md
+++ b/.changeset/yarn-releases-github-token.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Resolving Yarn 6 authenticates its GitHub releases-API request with `GH_TOKEN` / `GITHUB_TOKEN` when one is set. The release list is the one unconditional GitHub API call the resolver makes, and the anonymous rate limit is counted per IP address — which CI runners share — so provisioning `yarn@6` in CI could fail with `ERR_PNPM_YARN_RELEASES_STATUS` no matter how rarely a single job asked. Exporting the token CI already has lifts the request onto the authenticated limit.
+Resolving Yarn 6 authenticates its GitHub releases-API request with `GH_TOKEN` / `GITHUB_TOKEN` when one is set. The release list is the one unconditional GitHub API call the resolver makes, and the anonymous rate limit is counted per IP address — which CI runners share — so provisioning `yarn@6` in CI could fail with `ERR_PNPM_YARN_RELEASES_STATUS` no matter how rarely a single job asked. Exporting the token CI already has lifts the request onto the authenticated limit. The token is withheld when the project turns off `strict-ssl`, so relaxing certificate verification for a registry never sends a GitHub credential over the connection it relaxed.

--- a/.changeset/yarn-releases-github-token.md
+++ b/.changeset/yarn-releases-github-token.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Resolving Yarn 6 authenticates its GitHub releases-API request with `GH_TOKEN` / `GITHUB_TOKEN` when one is set. The release list is the one unconditional GitHub API call the resolver makes, and the anonymous rate limit is counted per IP address — which CI runners share — so provisioning `yarn@6` in CI could fail with `ERR_PNPM_YARN_RELEASES_STATUS` no matter how rarely a single job asked. Exporting the token CI already has lifts the request onto the authenticated limit.

--- a/pnpm/crates/cli/src/engine_pm/pin.rs
+++ b/pnpm/crates/cli/src/engine_pm/pin.rs
@@ -136,9 +136,13 @@ async fn resolve_yarn_binary_version(
     )
     .into_diagnostic()
     .wrap_err("build the network client to resolve the Yarn release")?;
-    pnpm_engine_pm_yarn_resolver::resolve_yarn_version(&client, version_spec)
-        .await
-        .map_err(miette::Report::new)
+    pnpm_engine_pm_yarn_resolver::resolve_yarn_version(
+        &client,
+        version_spec,
+        bootstrap.tls.strict_ssl.unwrap_or(true),
+    )
+    .await
+    .map_err(miette::Report::new)
 }
 
 /// How the recorded pin reads back, for the line `pnpm add` prints.

--- a/pnpm/crates/engine-pm-yarn-resolver/src/read_yarn_releases.rs
+++ b/pnpm/crates/engine-pm-yarn-resolver/src/read_yarn_releases.rs
@@ -33,7 +33,7 @@ pub enum ReadYarnReleasesError {
     #[diagnostic(
         code(ERR_PNPM_YARN_RELEASES_STATUS),
         help(
-            "GitHub rate-limits anonymous requests. Wait for the limit to reset, or install Yarn 6 by hand."
+            "GitHub rate-limits anonymous requests. Set GITHUB_TOKEN (or GH_TOKEN) to authenticate, wait for the limit to reset, or install Yarn 6 by hand."
         )
     )]
     StatusNotOk { url: String, status: u16 },
@@ -98,11 +98,18 @@ struct GithubAsset {
 pub async fn fetch_yarn_releases(
     http_client: &ThrottledClient,
 ) -> Result<Vec<YarnRelease>, ReadYarnReleasesError> {
-    let response = http_client
+    let mut request = http_client
         .acquire_for_url(RELEASES_URL)
         .await
         .get(RELEASES_URL)
-        .header("accept", "application/vnd.github+json")
+        .header("accept", "application/vnd.github+json");
+    // The API's anonymous rate limit is counted per IP, which CI runners
+    // share, so a job that has a token is much better off spending it. The
+    // URL is a constant, so the token can only ever go to GitHub's API.
+    if let Some(token) = github_token() {
+        request = request.header("authorization", format!("Bearer {token}"));
+    }
+    let response = request
         .send()
         .await
         .map_err(|error| ReadYarnReleasesError::Network {
@@ -120,6 +127,23 @@ pub async fn fetch_yarn_releases(
         error: Arc::new(error),
     })?;
     parse_releases(&body)
+}
+
+/// A GitHub token from the environment, `GH_TOKEN` outranking
+/// `GITHUB_TOKEN` the way GitHub's own CLI reads them.
+fn github_token() -> Option<String> {
+    pick_token(std::env::var("GH_TOKEN").ok(), std::env::var("GITHUB_TOKEN").ok())
+}
+
+/// The first of the two tokens that holds more than whitespace. An empty
+/// exported variable is a common CI artifact and must read as "no token"
+/// rather than turn into an `Authorization` header GitHub rejects.
+fn pick_token(gh_token: Option<String>, github_token: Option<String>) -> Option<String> {
+    [gh_token, github_token]
+        .into_iter()
+        .flatten()
+        .map(|token| token.trim().to_string())
+        .find(|token| !token.is_empty())
 }
 
 pub fn parse_releases(body: &str) -> Result<Vec<YarnRelease>, ReadYarnReleasesError> {

--- a/pnpm/crates/engine-pm-yarn-resolver/src/read_yarn_releases.rs
+++ b/pnpm/crates/engine-pm-yarn-resolver/src/read_yarn_releases.rs
@@ -30,13 +30,8 @@ pub enum ReadYarnReleasesError {
     },
 
     #[display("Fetching the Yarn releases from {url} responded with status {status}")]
-    #[diagnostic(
-        code(ERR_PNPM_YARN_RELEASES_STATUS),
-        help(
-            "GitHub rate-limits anonymous requests. Set GH_TOKEN, or GITHUB_TOKEN if it is not set, to authenticate; wait for the limit to reset; or install Yarn 6 by hand."
-        )
-    )]
-    StatusNotOk { url: String, status: u16 },
+    #[diagnostic(code(ERR_PNPM_YARN_RELEASES_STATUS), help("{}", status_help(*status, *authenticated)))]
+    StatusNotOk { url: String, status: u16, authenticated: bool },
 
     #[display("Could not parse the Yarn releases from {url}: {error}")]
     #[diagnostic(code(ERR_PNPM_YARN_RELEASES_PARSE))]
@@ -111,7 +106,8 @@ pub async fn fetch_yarn_releases(
         .header("accept", "application/vnd.github+json");
     // The API's anonymous rate limit is counted per IP, which CI runners
     // share, so a job that has a token is much better off spending it.
-    if let Some(token) = github_token(authenticate) {
+    let token = github_token(authenticate);
+    if let Some(token) = &token {
         request = request.header("authorization", format!("Bearer {token}"));
     }
     let response = request.send().await.map_err(|error| ReadYarnReleasesError::Network {
@@ -122,6 +118,7 @@ pub async fn fetch_yarn_releases(
         return Err(ReadYarnReleasesError::StatusNotOk {
             url: RELEASES_URL.to_string(),
             status: response.status().as_u16(),
+            authenticated: token.is_some(),
         });
     }
     let body = response.text().await.map_err(|error| ReadYarnReleasesError::Network {
@@ -129,6 +126,23 @@ pub async fn fetch_yarn_releases(
         error: Arc::new(error),
     })?;
     parse_releases(&body)
+}
+
+/// What to suggest when GitHub turns the request down. Sending a credential
+/// gives the same status a different cause, so the advice has to follow which
+/// request was made rather than always describing the anonymous limit.
+fn status_help(status: u16, authenticated: bool) -> &'static str {
+    match status {
+        401 => {
+            "GitHub rejected the credential in GH_TOKEN/GITHUB_TOKEN. Check that it is valid and unexpired, or unset it to ask anonymously."
+        }
+        _ if authenticated => {
+            "GitHub refused the authenticated request. The token may lack access, or its rate limit may be spent — wait for it to reset, or install Yarn 6 by hand."
+        }
+        _ => {
+            "GitHub rate-limits anonymous requests. Set GH_TOKEN, or GITHUB_TOKEN if it is not set, to authenticate; wait for the limit to reset; or install Yarn 6 by hand."
+        }
+    }
 }
 
 /// A GitHub token from the environment. `GH_TOKEN` outranks `GITHUB_TOKEN`,

--- a/pnpm/crates/engine-pm-yarn-resolver/src/read_yarn_releases.rs
+++ b/pnpm/crates/engine-pm-yarn-resolver/src/read_yarn_releases.rs
@@ -33,7 +33,7 @@ pub enum ReadYarnReleasesError {
     #[diagnostic(
         code(ERR_PNPM_YARN_RELEASES_STATUS),
         help(
-            "GitHub rate-limits anonymous requests. Set GITHUB_TOKEN (or GH_TOKEN) to authenticate, wait for the limit to reset, or install Yarn 6 by hand."
+            "GitHub rate-limits anonymous requests. Set GH_TOKEN, or GITHUB_TOKEN if it is not set, to authenticate; wait for the limit to reset; or install Yarn 6 by hand."
         )
     )]
     StatusNotOk { url: String, status: u16 },
@@ -95,8 +95,14 @@ struct GithubAsset {
 }
 
 /// Fetch the published Yarn releases, newest first.
+///
+/// `authenticate` carries whether a token may be sent: the client this
+/// borrows verifies certificates only when the project's `strict-ssl` says
+/// so, and that setting is about the registry the project installs from, not
+/// about GitHub.
 pub async fn fetch_yarn_releases(
     http_client: &ThrottledClient,
+    authenticate: bool,
 ) -> Result<Vec<YarnRelease>, ReadYarnReleasesError> {
     let mut request = http_client
         .acquire_for_url(RELEASES_URL)
@@ -104,18 +110,14 @@ pub async fn fetch_yarn_releases(
         .get(RELEASES_URL)
         .header("accept", "application/vnd.github+json");
     // The API's anonymous rate limit is counted per IP, which CI runners
-    // share, so a job that has a token is much better off spending it. The
-    // URL is a constant, so the token can only ever go to GitHub's API.
-    if let Some(token) = github_token() {
+    // share, so a job that has a token is much better off spending it.
+    if let Some(token) = github_token(authenticate) {
         request = request.header("authorization", format!("Bearer {token}"));
     }
-    let response = request
-        .send()
-        .await
-        .map_err(|error| ReadYarnReleasesError::Network {
-            url: RELEASES_URL.to_string(),
-            error: Arc::new(error),
-        })?;
+    let response = request.send().await.map_err(|error| ReadYarnReleasesError::Network {
+        url: RELEASES_URL.to_string(),
+        error: Arc::new(error),
+    })?;
     if !response.status().is_success() {
         return Err(ReadYarnReleasesError::StatusNotOk {
             url: RELEASES_URL.to_string(),
@@ -129,16 +131,23 @@ pub async fn fetch_yarn_releases(
     parse_releases(&body)
 }
 
-/// A GitHub token from the environment, `GH_TOKEN` outranking
-/// `GITHUB_TOKEN` the way GitHub's own CLI reads them.
-fn github_token() -> Option<String> {
-    pick_token(std::env::var("GH_TOKEN").ok(), std::env::var("GITHUB_TOKEN").ok())
+/// A GitHub token from the environment. `GH_TOKEN` outranks `GITHUB_TOKEN`,
+/// the order GitHub's own CLI reads them in.
+fn github_token(authenticate: bool) -> Option<String> {
+    pick_token(authenticate, std::env::var("GH_TOKEN").ok(), std::env::var("GITHUB_TOKEN").ok())
 }
 
-/// The first of the two tokens that holds more than whitespace. An empty
-/// exported variable is a common CI artifact and must read as "no token"
-/// rather than turn into an `Authorization` header GitHub rejects.
-fn pick_token(gh_token: Option<String>, github_token: Option<String>) -> Option<String> {
+/// An exported variable holding only whitespace is a common CI artifact, and
+/// reads as no token rather than becoming an `Authorization` header GitHub
+/// rejects.
+fn pick_token(
+    authenticate: bool,
+    gh_token: Option<String>,
+    github_token: Option<String>,
+) -> Option<String> {
+    if !authenticate {
+        return None;
+    }
     [gh_token, github_token]
         .into_iter()
         .flatten()

--- a/pnpm/crates/engine-pm-yarn-resolver/src/read_yarn_releases/tests.rs
+++ b/pnpm/crates/engine-pm-yarn-resolver/src/read_yarn_releases/tests.rs
@@ -30,6 +30,13 @@ fn releases_body(extra_assets: &str) -> String {
     )
 }
 
+/// A project that relaxed certificate verification does not spend a GitHub
+/// credential on the connection it relaxed.
+#[test]
+fn no_token_is_sent_when_authentication_is_withheld() {
+    assert_eq!(pick_token(false, Some("gh".to_string()), Some("github".to_string())), None);
+}
+
 #[test]
 fn releases_are_read_with_the_v_prefix_stripped() {
     let releases = parse_releases(&releases_body("")).expect("parse the release list");
@@ -142,25 +149,25 @@ fn a_release_without_archives_is_an_error() {
 
 #[test]
 fn gh_token_outranks_github_token() {
-    let token = pick_token(Some("gh".to_string()), Some("github".to_string()));
+    let token = pick_token(true, Some("gh".to_string()), Some("github".to_string()));
     assert_eq!(token.as_deref(), Some("gh"));
 }
 
 #[test]
 fn a_blank_token_reads_as_no_token() {
-    assert_eq!(pick_token(Some("  ".to_string()), None), None);
-    assert_eq!(pick_token(Some(String::new()), Some(String::new())), None);
-    assert_eq!(pick_token(None, None), None);
+    assert_eq!(pick_token(true, Some("  ".to_string()), None), None);
+    assert_eq!(pick_token(true, Some(String::new()), Some(String::new())), None);
+    assert_eq!(pick_token(true, None, None), None);
 }
 
 #[test]
 fn a_blank_override_falls_through_to_the_other_token() {
-    let token = pick_token(Some(String::new()), Some("github".to_string()));
+    let token = pick_token(true, Some(String::new()), Some("github".to_string()));
     assert_eq!(token.as_deref(), Some("github"));
 }
 
 #[test]
 fn a_token_is_trimmed() {
-    let token = pick_token(None, Some(" github \n".to_string()));
+    let token = pick_token(true, None, Some(" github \n".to_string()));
     assert_eq!(token.as_deref(), Some("github"));
 }

--- a/pnpm/crates/engine-pm-yarn-resolver/src/read_yarn_releases/tests.rs
+++ b/pnpm/crates/engine-pm-yarn-resolver/src/read_yarn_releases/tests.rs
@@ -1,4 +1,4 @@
-use super::{ReadYarnReleasesError, asset_variants, parse_releases, pick_token};
+use super::{ReadYarnReleasesError, asset_variants, parse_releases, pick_token, status_help};
 use pnpm_lockfile::LockfileResolution;
 use pretty_assertions::assert_eq;
 
@@ -28,6 +28,15 @@ fn releases_body(extra_assets: &str) -> String {
           }}
         ]"#,
     )
+}
+
+/// Sending a credential gives 401 a cause the anonymous advice does not
+/// cover, so the help has to follow which request was actually made.
+#[test]
+fn a_rejected_credential_is_not_reported_as_an_anonymous_rate_limit() {
+    assert!(status_help(401, true).contains("rejected the credential"));
+    assert!(status_help(403, true).contains("authenticated request"));
+    assert!(status_help(403, false).contains("rate-limits anonymous"));
 }
 
 /// A project that relaxed certificate verification does not spend a GitHub

--- a/pnpm/crates/engine-pm-yarn-resolver/src/read_yarn_releases/tests.rs
+++ b/pnpm/crates/engine-pm-yarn-resolver/src/read_yarn_releases/tests.rs
@@ -1,4 +1,4 @@
-use super::{ReadYarnReleasesError, asset_variants, parse_releases};
+use super::{ReadYarnReleasesError, asset_variants, parse_releases, pick_token};
 use pnpm_lockfile::LockfileResolution;
 use pretty_assertions::assert_eq;
 
@@ -138,4 +138,29 @@ fn a_release_without_archives_is_an_error() {
     let releases = parse_releases(&releases_body("")).expect("parse the release list");
     let error = asset_variants(&releases[1]).expect_err("a release with no assets cannot resolve");
     assert!(matches!(error, ReadYarnReleasesError::NoUsableAssets { .. }), "{error:?}");
+}
+
+#[test]
+fn gh_token_outranks_github_token() {
+    let token = pick_token(Some("gh".to_string()), Some("github".to_string()));
+    assert_eq!(token.as_deref(), Some("gh"));
+}
+
+#[test]
+fn a_blank_token_reads_as_no_token() {
+    assert_eq!(pick_token(Some("  ".to_string()), None), None);
+    assert_eq!(pick_token(Some(String::new()), Some(String::new())), None);
+    assert_eq!(pick_token(None, None), None);
+}
+
+#[test]
+fn a_blank_override_falls_through_to_the_other_token() {
+    let token = pick_token(Some(String::new()), Some("github".to_string()));
+    assert_eq!(token.as_deref(), Some("github"));
+}
+
+#[test]
+fn a_token_is_trimmed() {
+    let token = pick_token(None, Some(" github \n".to_string()));
+    assert_eq!(token.as_deref(), Some("github"));
 }

--- a/pnpm/crates/engine-pm-yarn-resolver/src/yarn_resolver.rs
+++ b/pnpm/crates/engine-pm-yarn-resolver/src/yarn_resolver.rs
@@ -36,6 +36,11 @@ pub enum YarnResolverError {
 /// nothing here goes through a registry.
 pub struct YarnResolver {
     pub http_client: Arc<ThrottledClient>,
+    /// Whether the release fetch may carry a GitHub token. Turned off when
+    /// the project relaxed certificate verification: `strict-ssl` is aimed at
+    /// the registry it installs from, and spending it on a credential for
+    /// GitHub would take the setting somewhere it was never pointed.
+    pub authenticate: bool,
     /// The release list, fetched at most once per resolver. One command
     /// can resolve Yarn more than once — a resolve and a latest probe, or
     /// several importers pinning it — and the list is one unconditional
@@ -45,14 +50,14 @@ pub struct YarnResolver {
 }
 
 impl YarnResolver {
-    pub fn new(http_client: Arc<ThrottledClient>) -> Self {
-        Self { http_client, releases: tokio::sync::OnceCell::new() }
+    pub fn new(http_client: Arc<ThrottledClient>, authenticate: bool) -> Self {
+        Self { http_client, authenticate, releases: tokio::sync::OnceCell::new() }
     }
 
     async fn releases(&self) -> Result<&[YarnRelease], ReadYarnReleasesError> {
         self.releases
             .get_or_try_init(|| async {
-                fetch_yarn_releases(&self.http_client).await.map(Arc::new)
+                fetch_yarn_releases(&self.http_client, self.authenticate).await.map(Arc::new)
             })
             .await
             .map(|releases| releases.as_slice())
@@ -150,9 +155,11 @@ impl YarnResolver {
 pub async fn resolve_yarn_version(
     http_client: &ThrottledClient,
     version_spec: &str,
+    authenticate: bool,
 ) -> Result<String, YarnResolverError> {
-    let releases =
-        fetch_yarn_releases(http_client).await.map_err(YarnResolverError::ReadReleases)?;
+    let releases = fetch_yarn_releases(http_client, authenticate)
+        .await
+        .map_err(YarnResolverError::ReadReleases)?;
     pick_release(&releases, version_spec).map(|release| release.version.clone()).ok_or_else(|| {
         YarnResolverError::ResolutionFailure { spec: redact_and_sanitize(version_spec) }
     })

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolver_setup.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolver_setup.rs
@@ -307,7 +307,8 @@ pub(super) async fn build_resolver_chain<Reporter: pnpm_reporter::Reporter + 'st
     node_resolver.cache_dir = Some(config.cache_dir.clone());
     let deno_resolver = DenoResolver::new(Arc::clone(http_client_arc), Arc::clone(&npm_resolver));
     let bun_resolver = BunResolver::new(Arc::clone(http_client_arc), Arc::clone(&npm_resolver));
-    let yarn_resolver = YarnResolver::new(Arc::clone(http_client_arc));
+    let yarn_resolver =
+        YarnResolver::new(Arc::clone(http_client_arc), config.tls.strict_ssl.unwrap_or(true));
     let named_registry_resolver = NamedRegistryResolver {
         registries_by_prefix: registries_by_prefix.clone(),
         registry_names: registries_by_prefix.keys().cloned().collect(),

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -1907,7 +1907,10 @@ fn ensure_latest_resolver_chain<'chain>(
             Box::new(node_resolver),
             Box::new(DenoResolver::new(Arc::clone(ctx.http_client_arc), Arc::clone(&npm_resolver))),
             Box::new(BunResolver::new(Arc::clone(ctx.http_client_arc), Arc::clone(&npm_resolver))),
-            Box::new(YarnResolver::new(Arc::clone(ctx.http_client_arc))),
+            Box::new(YarnResolver::new(
+                Arc::clone(ctx.http_client_arc),
+                ctx.config.tls.strict_ssl.unwrap_or(true),
+            )),
         ]);
         *chain = Some(LatestResolverChain {
             resolver,

--- a/pnpm/crates/resolving-default-resolver/src/standalone.rs
+++ b/pnpm/crates/resolving-default-resolver/src/standalone.rs
@@ -117,7 +117,8 @@ pub fn build_standalone_chain(
     node_resolver.cache_dir = Some(config.cache_dir.clone());
     let deno_resolver = DenoResolver::new(Arc::clone(http_client), Arc::clone(&npm_resolver));
     let bun_resolver = BunResolver::new(Arc::clone(http_client), Arc::clone(&npm_resolver));
-    let yarn_resolver = YarnResolver::new(Arc::clone(http_client));
+    let yarn_resolver =
+        YarnResolver::new(Arc::clone(http_client), config.tls.strict_ssl.unwrap_or(true));
 
     // User-supplied named-registry aliases from
     // `pnpm-workspace.yaml#namedRegistries`, merged with pacquet's


### PR DESCRIPTION
The Yarn 6 release list is the one unconditional GitHub API request the resolver makes, and the anonymous rate limit it runs into is counted per IP address — which CI runners share — so provisioning `yarn@6` in CI could fail with `ERR_PNPM_YARN_RELEASES_STATUS` no matter how rarely a single job asked.

When the environment carries a GitHub token (`GH_TOKEN` outranking `GITHUB_TOKEN`, the way GitHub's own CLI reads them), the request now sends it and runs on the authenticated limit instead. Details:

- A blank exported variable is a common CI artifact and reads as no token rather than becoming an `Authorization` header GitHub rejects.
- The releases URL is a constant, so the token can only ever go to GitHub's API.
- The `ERR_PNPM_YARN_RELEASES_STATUS` help text now mentions the env vars.

Found while switching pnpm's own benchmarks to provision every package manager with pnpm 12 (pnpm/benchmarks#53); the benchmark workflow there exports `GITHUB_TOKEN` and relies on this.

Verified: unit tests for the token picking (precedence, blank/whitespace handling), plus a functional check with the built CLI — an invalid `GH_TOKEN` turns the request into a 401 (header is sent), blank tokens fall back to a working anonymous fetch, and a real token installs `yarn@6` successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789413364&installation_model_id=426870&pr_number=13928&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13928&signature=2848b00c9f1a08d95c6c46bad666dba826d64375422a13147fa2a25e63fd7281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Yarn release lookups with authenticated GitHub API requests when supported.
  * Added fallback support for alternate GitHub token configuration.
  * Improved rate-limit and authentication error guidance.
  * Yarn release resolution now respects the configured strict TLS setting and avoids authentication when certificate verification is disabled.

* **Tests**
  * Added coverage for token prioritization, trimming, and empty-value handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->