### PR TITLE
fix(config): apply the minimum-release-age settings from --config.<key>

### DIFF
--- a/.changeset/minimum-release-age-config-flag.md
+++ b/.changeset/minimum-release-age-config-flag.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`--config.minimum-release-age` is no longer ignored. The flag, and its `minimum-release-age-exclude`, `minimum-release-age-ignore-missing-time`, and `minimum-release-age-strict` companions, now override `pnpm-workspace.yaml` the way every other `--config.<key>` token does, so tightening the release-age window for one install works again instead of silently leaving the configured value in place [#13929](https://github.com/pnpm/pnpm/issues/13929).

--- a/.changeset/minimum-release-age-config-flag.md
+++ b/.changeset/minimum-release-age-config-flag.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`--config.minimum-release-age` is no longer ignored. The flag, and its `minimum-release-age-exclude`, `minimum-release-age-ignore-missing-time`, and `minimum-release-age-strict` companions, now override `pnpm-workspace.yaml` the way every other `--config.<key>` token does, so tightening the release-age window for one install works again instead of silently leaving the configured value in place [#13929](https://github.com/pnpm/pnpm/issues/13929).
+`--config.minimum-release-age` is honored again, along with `--config.minimum-release-age-exclude`, `--config.minimum-release-age-ignore-missing-time` and `--config.minimum-release-age-strict`. Each overrides the matching `pnpm-workspace.yaml` setting, and the exclude flag may be repeated to build a list [#13929](https://github.com/pnpm/pnpm/issues/13929).

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -85,15 +85,15 @@ pub struct ConfigOverrides {
     deploy_all_files: Option<bool>,
     force_legacy_deploy: Option<bool>,
     inject_workspace_packages: Option<bool>,
+    minimum_release_age: Option<u64>,
+    minimum_release_age_exclude: Option<Vec<String>>,
+    minimum_release_age_ignore_missing_time: Option<bool>,
+    minimum_release_age_strict: Option<bool>,
     node_linker: Option<NodeLinker>,
     pm_on_fail: Option<PmOnFail>,
     runtime_on_fail: Option<RuntimeOnFail>,
     shared_workspace_lockfile: Option<bool>,
     verify_deps_before_run: Option<VerifyDepsBeforeRun>,
-    minimum_release_age: Option<u64>,
-    minimum_release_age_exclude: Option<Vec<String>>,
-    minimum_release_age_ignore_missing_time: Option<bool>,
-    minimum_release_age_strict: Option<bool>,
     https_proxy: Option<String>,
     http_proxy: Option<String>,
     no_proxy: Option<String>,
@@ -161,6 +161,24 @@ impl ConfigOverrides {
             self.inject_workspace_packages = parse_bool(value);
             return;
         }
+        if key == "minimum-release-age" {
+            self.minimum_release_age = value.parse().ok();
+            return;
+        }
+        if key == "minimum-release-age-exclude" {
+            // nopt collects a repeated key it has no type for into a list,
+            // and pnpm re-parses the `--config.` tokens without any types.
+            self.minimum_release_age_exclude.get_or_insert_default().push(value.to_string());
+            return;
+        }
+        if key == "minimum-release-age-ignore-missing-time" {
+            self.minimum_release_age_ignore_missing_time = parse_bool(value);
+            return;
+        }
+        if key == "minimum-release-age-strict" {
+            self.minimum_release_age_strict = parse_bool(value);
+            return;
+        }
         if key == "node-linker" {
             self.node_linker = parse_enum(value);
             return;
@@ -179,24 +197,6 @@ impl ConfigOverrides {
         }
         if key == "verify-deps-before-run" {
             self.verify_deps_before_run = value.parse().ok();
-            return;
-        }
-        if key == "minimum-release-age" {
-            self.minimum_release_age = value.parse().ok();
-            return;
-        }
-        if key == "minimum-release-age-exclude" {
-            // pnpm types this key as `[String, Array]`: repeating the
-            // token builds a list instead of replacing the previous value.
-            self.minimum_release_age_exclude.get_or_insert_default().push(value.to_string());
-            return;
-        }
-        if key == "minimum-release-age-ignore-missing-time" {
-            self.minimum_release_age_ignore_missing_time = parse_bool(value);
-            return;
-        }
-        if key == "minimum-release-age-strict" {
-            self.minimum_release_age_strict = parse_bool(value);
             return;
         }
         if let Some(scope) = scoped_registry_key(key) {
@@ -232,6 +232,29 @@ impl ConfigOverrides {
         if let Some(value) = self.inject_workspace_packages {
             config.inject_workspace_packages = value;
         }
+        // pnpm seeds `explicitlySetKeys` from the command line as well as
+        // from the config files, and the workspace state reads it back to
+        // decide whether `minimumReleaseAgeStrict` defaults to true.
+        if let Some(value) = self.minimum_release_age {
+            config.minimum_release_age = Some(value);
+            config.explicit_settings.insert("minimumReleaseAge".to_string(), value.into());
+        }
+        if let Some(value) = &self.minimum_release_age_exclude {
+            config.minimum_release_age_exclude = Some(value.clone());
+            config
+                .explicit_settings
+                .insert("minimumReleaseAgeExclude".to_string(), value.as_slice().into());
+        }
+        if let Some(value) = self.minimum_release_age_ignore_missing_time {
+            config.minimum_release_age_ignore_missing_time = value;
+            config
+                .explicit_settings
+                .insert("minimumReleaseAgeIgnoreMissingTime".to_string(), value.into());
+        }
+        if let Some(value) = self.minimum_release_age_strict {
+            config.minimum_release_age_strict = Some(value);
+            config.explicit_settings.insert("minimumReleaseAgeStrict".to_string(), value.into());
+        }
         if let Some(value) = self.node_linker {
             config.node_linker = value;
         }
@@ -243,18 +266,6 @@ impl ConfigOverrides {
         }
         if let Some(value) = self.shared_workspace_lockfile {
             config.shared_workspace_lockfile = value;
-        }
-        if let Some(value) = self.minimum_release_age {
-            config.minimum_release_age = Some(value);
-        }
-        if let Some(value) = &self.minimum_release_age_exclude {
-            config.minimum_release_age_exclude = Some(value.clone());
-        }
-        if let Some(value) = self.minimum_release_age_ignore_missing_time {
-            config.minimum_release_age_ignore_missing_time = value;
-        }
-        if let Some(value) = self.minimum_release_age_strict {
-            config.minimum_release_age_strict = Some(value);
         }
         // The `pnpm_config_verify_deps_before_run` env var outranks even
         // the CLI for this one key (pnpm's config reader applies it after

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -72,10 +72,11 @@ fn home_relative_store_dir(store_dir: &Path) -> Option<&Path> {
 ///
 /// Unknown keys are accepted silently: pnpm exposes a long tail of config
 /// keys, and erroring on an unrecognized one would break the moment pnpm
-/// adds a new key that pacquet hasn't ported yet. The token has already
-/// been honored by pnpm itself before delegation, so dropping it on
-/// pacquet's side just means the pacquet leg falls back to the yaml/npmrc
-/// value — never an incorrect override.
+/// adds a new key that pacquet hasn't ported yet. Dropping one is only
+/// harmless when pnpm parsed the token first and delegated, leaving the
+/// pacquet leg to fall back to the yaml value. When the binary runs
+/// standalone there is no other leg, so a setting that changes what gets
+/// installed has to be ported here.
 #[derive(Debug, Default)]
 pub struct ConfigOverrides {
     registry: Option<String>,
@@ -89,6 +90,10 @@ pub struct ConfigOverrides {
     runtime_on_fail: Option<RuntimeOnFail>,
     shared_workspace_lockfile: Option<bool>,
     verify_deps_before_run: Option<VerifyDepsBeforeRun>,
+    minimum_release_age: Option<u64>,
+    minimum_release_age_exclude: Option<Vec<String>>,
+    minimum_release_age_ignore_missing_time: Option<bool>,
+    minimum_release_age_strict: Option<bool>,
     https_proxy: Option<String>,
     http_proxy: Option<String>,
     no_proxy: Option<String>,
@@ -176,6 +181,24 @@ impl ConfigOverrides {
             self.verify_deps_before_run = value.parse().ok();
             return;
         }
+        if key == "minimum-release-age" {
+            self.minimum_release_age = value.parse().ok();
+            return;
+        }
+        if key == "minimum-release-age-exclude" {
+            // pnpm types this key as `[String, Array]`: repeating the
+            // token builds a list instead of replacing the previous value.
+            self.minimum_release_age_exclude.get_or_insert_default().push(value.to_string());
+            return;
+        }
+        if key == "minimum-release-age-ignore-missing-time" {
+            self.minimum_release_age_ignore_missing_time = parse_bool(value);
+            return;
+        }
+        if key == "minimum-release-age-strict" {
+            self.minimum_release_age_strict = parse_bool(value);
+            return;
+        }
         if let Some(scope) = scoped_registry_key(key) {
             self.registries.insert(scope.to_owned(), normalize_registry_url(value));
         }
@@ -220,6 +243,18 @@ impl ConfigOverrides {
         }
         if let Some(value) = self.shared_workspace_lockfile {
             config.shared_workspace_lockfile = value;
+        }
+        if let Some(value) = self.minimum_release_age {
+            config.minimum_release_age = Some(value);
+        }
+        if let Some(value) = &self.minimum_release_age_exclude {
+            config.minimum_release_age_exclude = Some(value.clone());
+        }
+        if let Some(value) = self.minimum_release_age_ignore_missing_time {
+            config.minimum_release_age_ignore_missing_time = value;
+        }
+        if let Some(value) = self.minimum_release_age_strict {
+            config.minimum_release_age_strict = Some(value);
         }
         // The `pnpm_config_verify_deps_before_run` env var outranks even
         // the CLI for this one key (pnpm's config reader applies it after

--- a/pnpm/crates/cli/src/config_overrides/tests.rs
+++ b/pnpm/crates/cli/src/config_overrides/tests.rs
@@ -188,19 +188,21 @@ fn extract_applies_the_minimum_release_age_overrides() {
     let (overrides, remaining) = ConfigOverrides::extract(argv([
         "pacquet",
         "--config.minimum-release-age=0",
-        "--config.minimum-release-age-strict=false",
         "--config.minimum-release-age-ignore-missing-time=false",
+        "--config.minimum-release-age-strict=false",
         "add",
         "pnpm",
     ]));
     assert_eq!(remaining, argv(["pacquet", "add", "pnpm"]));
     let mut config = Config::default();
-    assert_eq!(config.resolved_minimum_release_age(), Some(1440));
+    assert_eq!(config.minimum_release_age, Some(1440));
+    assert!(config.minimum_release_age_ignore_missing_time);
+    assert_eq!(config.minimum_release_age_strict, None);
     overrides.apply(&mut config);
     assert_eq!(config.minimum_release_age, Some(0));
-    assert_eq!(config.resolved_minimum_release_age(), None);
-    assert_eq!(config.minimum_release_age_strict, Some(false));
     assert!(!config.minimum_release_age_ignore_missing_time);
+    assert_eq!(config.minimum_release_age_strict, Some(false));
+    assert!(config.explicit_settings.contains_key("minimumReleaseAge"));
 }
 
 #[test]

--- a/pnpm/crates/cli/src/config_overrides/tests.rs
+++ b/pnpm/crates/cli/src/config_overrides/tests.rs
@@ -184,6 +184,43 @@ fn extract_applies_inject_workspace_packages_and_node_linker_overrides() {
 }
 
 #[test]
+fn extract_applies_the_minimum_release_age_overrides() {
+    let (overrides, remaining) = ConfigOverrides::extract(argv([
+        "pacquet",
+        "--config.minimum-release-age=0",
+        "--config.minimum-release-age-strict=false",
+        "--config.minimum-release-age-ignore-missing-time=false",
+        "add",
+        "pnpm",
+    ]));
+    assert_eq!(remaining, argv(["pacquet", "add", "pnpm"]));
+    let mut config = Config::default();
+    assert_eq!(config.resolved_minimum_release_age(), Some(1440));
+    overrides.apply(&mut config);
+    assert_eq!(config.minimum_release_age, Some(0));
+    assert_eq!(config.resolved_minimum_release_age(), None);
+    assert_eq!(config.minimum_release_age_strict, Some(false));
+    assert!(!config.minimum_release_age_ignore_missing_time);
+}
+
+#[test]
+fn repeated_minimum_release_age_exclude_overrides_collect_into_a_list() {
+    let (overrides, _) = ConfigOverrides::extract(argv([
+        "--config.minimum-release-age-exclude=pnpm",
+        "--config.minimum-release-age-exclude=@pnpm/exe",
+    ]));
+    let mut config = Config {
+        minimum_release_age_exclude: Some(vec!["from-yaml".to_string()]),
+        ..Config::default()
+    };
+    overrides.apply(&mut config);
+    assert_eq!(
+        config.minimum_release_age_exclude,
+        Some(vec!["pnpm".to_string(), "@pnpm/exe".to_string()]),
+    );
+}
+
+#[test]
 fn config_tokens_after_external_command_stay_in_argv() {
     let (overrides, remaining) = ConfigOverrides::extract(argv([
         "pacquet",


### PR DESCRIPTION
## Summary

The standalone Rust CLI drops `--config.minimum-release-age=<n>`, so the install keeps whatever the yaml layer or the built-in default says (Closes pnpm/pnpm#13929). `ConfigOverrides` re-applies only an allowlist of `--config.<key>` tokens once the file layers have run, and the release-age settings were never on that list.

Dropping an unported key was harmless while pnpm parsed the token first and delegated, because the pacquet leg then fell back to the value pnpm had already honored. With the binary as the entrypoint there is no other leg, so the token is simply lost: `=0` installs the previous release, and a CI run passing `=10080` to tighten the window silently gets the 24 hour default instead.

This ports `minimum-release-age` plus the three keys pnpm types next to it (`minimum-release-age-exclude`, `minimum-release-age-ignore-missing-time`, `minimum-release-age-strict`), which is also the set the `PNPM_CONFIG_*` overlay already covers. `minimum-release-age-exclude` appends rather than replaces when the token is repeated, since nopt collects a repeated key it has no type for into a list and pnpm re-parses the `--config.` tokens with no types at all. `minimum-release-age-exclude-prune` is left out, matching both the key set pnpm declares in `types.ts` and the one the env overlay reads.

The four keys also go into `Config::explicit_settings`, pacquet's stand-in for pnpm's `explicitlySetKeys`, which the yaml and env layers already feed. Without that, an install run with `--config.minimum-release-age` would record a different `minimumReleaseAgeStrict` in the workspace state than the same value written in `pnpm-workspace.yaml`.

On the `.npmrc` half of the issue: pnpm 11 reads only auth, registry and proxy keys out of `.npmrc` (`isNpmrcReadableKey` in `config/reader/src/localConfig.ts`), and pacquet documents the same subset on `Config::current`. A `minimum-release-age` line in `.npmrc` is therefore ignored by both stacks on purpose, so this PR leaves that alone. Nothing needs porting to the TypeScript CLI either, since it applies every `--config.<key>` token generically and only pacquet keeps an allowlist.

## Squash Commit Body

```text
`ConfigOverrides` re-applies only an allowlist of `--config.<key>` tokens
after the file-based config layers run, and the minimum-release-age
settings were missing from it. When pnpm parses the token and delegates,
dropping it costs nothing: the pacquet leg falls back to the value pnpm
already honored. When the binary is the entrypoint there is no other leg,
so the override is lost and the install silently uses the yaml value or
the 24 hour default (Closes pnpm/pnpm#13929).

Port `minimum-release-age`, `minimum-release-age-exclude`,
`minimum-release-age-ignore-missing-time` and `minimum-release-age-strict`,
the same four keys the PNPM_CONFIG_* overlay reads. The exclude list is
appended to when the token repeats, matching how nopt collects a repeated
key it has no type for.

The four keys also land in `Config::explicit_settings`, pacquet's stand-in
for pnpm's `explicitlySetKeys`, which the yaml and env layers already feed.
Otherwise a CLI-set `minimumReleaseAge` would record a different
`minimumReleaseAgeStrict` in the workspace state than the same value in
`pnpm-workspace.yaml`.

Reading these keys from `.npmrc` stays unsupported, matching pnpm 11,
which only reads auth, registry and proxy keys from there.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added command-line configuration options for minimum release age, including strictness, missing-time handling, and package exclusions.
  * Repeated exclusion options are supported and replace the configured exclusion list.

* **Documentation**
  * Documented that minimum release age command-line options override values in `pnpm-workspace.yaml`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->