### PR TITLE
fix(engine-pm): record a satisfied range pin in the lockfile

### DIFF
--- a/.changeset/sync-satisfied-range-pin.md
+++ b/.changeset/sync-satisfied-range-pin.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+A `devEngines.packageManager` range pin on pnpm is now recorded in `pnpm-lock.yaml`'s `packageManagerDependencies` when the running pnpm already satisfies it, using the running version. Previously only an exact pin — or a range resolved on the way through a version switch — reached the lockfile, so a range pin written by hand (or by any tool other than `pnpm add` / `pnpm self-update`) left the project without the shared resolution the pin exists to provide.

--- a/pnpm/crates/cli/src/cli_args/package_manager.rs
+++ b/pnpm/crates/cli/src/cli_args/package_manager.rs
@@ -57,16 +57,13 @@ pub(crate) fn package_manager_to_sync(
     {
         return Some(PackageManagerToSync { specifier: wanted_version.to_string(), version });
     }
-    if let Some(version) = exact_version(wanted_version)
-        .filter(|version| version_satisfies(version, wanted_version))
+    if let Some(version) =
+        exact_version(wanted_version).filter(|version| version_satisfies(version, wanted_version))
     {
         return Some(PackageManagerToSync { specifier: wanted_version.to_string(), version });
     }
-    // A range pin resolves to no exact version on its own, so when the
-    // running pnpm satisfies it, the running version is the one the project
-    // actually uses — record that. Without this, a range pin written by hand
-    // (or by a tool other than `pnpm add` / `self-update`) only reached the
-    // lockfile when a version switch resolved it on the way.
+    // A range pin names no exact version, so the running pnpm's version is
+    // the one the project actually uses.
     version_satisfies(PNPM_VERSION, wanted_version).then(|| PackageManagerToSync {
         specifier: wanted_version.to_string(),
         version: PNPM_VERSION.to_string(),

--- a/pnpm/crates/cli/src/cli_args/package_manager.rs
+++ b/pnpm/crates/cli/src/cli_args/package_manager.rs
@@ -1,5 +1,5 @@
 use miette::IntoDiagnostic;
-use pnpm_config::PmOnFail;
+use pnpm_config::{PNPM_VERSION, PmOnFail};
 use pnpm_env_installer::is_package_manager_resolved;
 use pnpm_lockfile::EnvLockfile;
 use pnpm_package_manifest::{
@@ -57,9 +57,20 @@ pub(crate) fn package_manager_to_sync(
     {
         return Some(PackageManagerToSync { specifier: wanted_version.to_string(), version });
     }
-    exact_version(wanted_version)
+    if let Some(version) = exact_version(wanted_version)
         .filter(|version| version_satisfies(version, wanted_version))
-        .map(|version| PackageManagerToSync { specifier: wanted_version.to_string(), version })
+    {
+        return Some(PackageManagerToSync { specifier: wanted_version.to_string(), version });
+    }
+    // A range pin resolves to no exact version on its own, so when the
+    // running pnpm satisfies it, the running version is the one the project
+    // actually uses — record that. Without this, a range pin written by hand
+    // (or by a tool other than `pnpm add` / `self-update`) only reached the
+    // lockfile when a version switch resolved it on the way.
+    version_satisfies(PNPM_VERSION, wanted_version).then(|| PackageManagerToSync {
+        specifier: wanted_version.to_string(),
+        version: PNPM_VERSION.to_string(),
+    })
 }
 
 /// Whether the pnpm version the manifest at `root_dir` pins still has to be

--- a/pnpm/crates/cli/src/cli_args/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/tests.rs
@@ -725,6 +725,45 @@ fn package_manager_to_sync_preserves_dev_engine_specifier() {
     );
 }
 
+/// A range pin resolves to no exact version on its own, so the running
+/// pnpm's version is recorded when it satisfies the range. The range is
+/// built from `PNPM_VERSION` so the source checkout's version (a different
+/// major) can never satisfy it and answer first.
+#[test]
+fn package_manager_to_sync_records_the_running_version_for_a_satisfied_range_pin() {
+    let root = TempDir::new().expect("tmp dir");
+    let manifest_path = root.path().join("package.json");
+    let range = format!("^{}", pacquet_config::PNPM_VERSION);
+    std::fs::write(
+        &manifest_path,
+        format!(
+            r#"{{"devEngines":{{"packageManager":{{"name":"pnpm","version":"{range}","onFail":"download"}}}}}}"#,
+        ),
+    )
+    .expect("write manifest");
+
+    let manifest = read_manifest_json(&manifest_path).expect("read manifest").expect("manifest");
+    let package_manager =
+        package_manager_to_sync(&manifest, root.path(), None).expect("sync package manager");
+
+    assert_eq!(package_manager.specifier, range);
+    assert_eq!(package_manager.version, pacquet_config::PNPM_VERSION);
+}
+
+#[test]
+fn package_manager_to_sync_records_nothing_for_a_pin_nothing_satisfies() {
+    let root = TempDir::new().expect("tmp dir");
+    let manifest_path = root.path().join("package.json");
+    std::fs::write(
+        &manifest_path,
+        r#"{"devEngines":{"packageManager":{"name":"pnpm","version":"^999.0.0","onFail":"download"}}}"#,
+    )
+    .expect("write manifest");
+
+    let manifest = read_manifest_json(&manifest_path).expect("read manifest").expect("manifest");
+    assert_eq!(package_manager_to_sync(&manifest, root.path(), None), None);
+}
+
 #[test]
 fn resolve_bool_override_tri_state() {
     // force_on wins, force_off wins over a config `true`, and an unset

--- a/pnpm/crates/cli/src/cli_args/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/tests.rs
@@ -725,15 +725,13 @@ fn package_manager_to_sync_preserves_dev_engine_specifier() {
     );
 }
 
-/// A range pin resolves to no exact version on its own, so the running
-/// pnpm's version is recorded when it satisfies the range. The range is
-/// built from `PNPM_VERSION` so the source checkout's version (a different
-/// major) can never satisfy it and answer first.
+/// The range is built from `PNPM_VERSION` so the source checkout's version
+/// (a different major) can never satisfy it and answer first.
 #[test]
 fn package_manager_to_sync_records_the_running_version_for_a_satisfied_range_pin() {
     let root = TempDir::new().expect("tmp dir");
     let manifest_path = root.path().join("package.json");
-    let range = format!("^{}", pacquet_config::PNPM_VERSION);
+    let range = format!("^{}", pnpm_config::PNPM_VERSION);
     std::fs::write(
         &manifest_path,
         format!(
@@ -747,7 +745,7 @@ fn package_manager_to_sync_records_the_running_version_for_a_satisfied_range_pin
         package_manager_to_sync(&manifest, root.path(), None).expect("sync package manager");
 
     assert_eq!(package_manager.specifier, range);
-    assert_eq!(package_manager.version, pacquet_config::PNPM_VERSION);
+    assert_eq!(package_manager.version, pnpm_config::PNPM_VERSION);
 }
 
 #[test]


### PR DESCRIPTION
A `devEngines.packageManager` range pin on pnpm (e.g. `^12.0.0-rc.6`) never reached `pnpm-lock.yaml`'s `packageManagerDependencies` when the running pnpm already satisfied it: `package_manager_to_sync` could only produce a version for an exact pin or a source checkout, so the sync that `pre_command` plans for exactly this case — \"the pin still has to reach the lockfile, which the switch would otherwise have written on its way\" — had nothing to record. A range pin written by hand, or by any tool other than `pnpm add` / `pnpm self-update`, left the project without the shared resolution the pin exists to provide.

When the running pnpm satisfies the range, its version is the one the project actually uses, so that is what gets recorded now. An exact pin still records itself, and a source checkout still answers first.

Found while pinning pnpm/benchmarks to pnpm 12 through `devEngines.packageManager` (pnpm/benchmarks#57): `pnpm install` under 12.0.0-rc.6 with a hand-written `^12.0.0-rc.6` pin rewrote the lockfile without any pnpm entry.

Verified: unit tests for the satisfied-range and nothing-satisfies cases (the range is built from `PNPM_VERSION` so the source checkout's version can never answer first), plus a functional check — the built CLI now writes `specifier: ^12.0.0-rc.6 / version: 12.0.0-rc.6` on install, and the released rc.6 preserves that entry across installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789418859&installation_model_id=426870&pr_number=13932&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13932&signature=a48982c8f8387c553399ccaa646b483ae1f1bfb87e6b23a13749e1a9f45ebe87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pnpm package-manager synchronization for version ranges.
  * Satisfied ranges now record the running pnpm version in the lockfile.
  * Unsatisfied ranges continue to avoid recording an incompatible version.

* **Tests**
  * Added coverage for satisfied and unsatisfied package-manager version ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->