### PR TITLE
fix(bins): clean up stale pnpm.ps1 shim on Windows

### DIFF
--- a/.changeset/fix-stale-pnpm-ps1.md
+++ b/.changeset/fix-stale-pnpm-ps1.md
@@ -4,4 +4,4 @@
 "pacquet": patch
 ---
 
-Fix `pnpm self-update` leaving behind a stale `pnpm.ps1` shim on Windows. Any existing `.ps1` shim for `pnpm` (or other commands that disable the PowerShell shim) is now deleted during bin linking to prevent it from shadowing the updated binary [pnpm/pnpm#13919](https://github.com/pnpm/pnpm/issues/13919).
+On Windows, upgrading pnpm no longer leaves a stale `pnpm.ps1` behind. PowerShell resolves `pnpm.ps1` ahead of `pnpm.cmd`, so a shim written by an older installation kept running the previous version. Linking the pnpm CLI's bins now deletes it [#13919](https://github.com/pnpm/pnpm/issues/13919).

--- a/.changeset/fix-stale-pnpm-ps1.md
+++ b/.changeset/fix-stale-pnpm-ps1.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/bins.linker": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+Fix `pnpm self-update` leaving behind a stale `pnpm.ps1` shim on Windows. Any existing `.ps1` shim for `pnpm` (or other commands that disable the PowerShell shim) is now deleted during bin linking to prevent it from shadowing the updated binary [pnpm/pnpm#13919](https://github.com/pnpm/pnpm/issues/13919).

--- a/pnpm/crates/cmd-shim/src/link_bins.rs
+++ b/pnpm/crates/cmd-shim/src/link_bins.rs
@@ -472,14 +472,13 @@ where
             shim_node_path(pkg, &options.extra_node_paths)
         };
         let pkg_name = pkg.manifest.get("name").and_then(Value::as_str).unwrap_or("");
-        let make_powershell_shim = pkg_name != "pnpm";
         write_shim::<Sys>(
             &command.path,
             &bins_dir.join(bin_name),
             &node_path,
             options.prefer_symlinked_executables,
             style,
-            make_powershell_shim,
+            wants_powershell_shim(pkg_name),
         )
     })?;
 
@@ -516,6 +515,15 @@ fn shim_node_path(pkg: &PackageBinSource, extra_node_paths: &[String]) -> Vec<St
     merged
 }
 
+/// Whether the bins of `pkg_name` get a PowerShell shim next to the `.cmd`
+/// one. The pnpm CLI opts out, because PowerShell resolves `pnpm.ps1` ahead of
+/// `pnpm.cmd`: a shim written for one installation of the CLI would keep
+/// shadowing every later one, including an upgrade that ships a different
+/// executable.
+fn wants_powershell_shim(pkg_name: &str) -> bool {
+    pkg_name != "pnpm"
+}
+
 /// Return `true` when `candidate` should replace `existing` for `bin_name`.
 /// Applies a three-step direct-then-ownership-then-lexical comparison.
 fn pick_winner(
@@ -544,6 +552,10 @@ fn pick_winner(
 /// is Windows*. Idempotent on warm reinstalls via
 /// [`is_shim_pointing_at`].
 ///
+/// `make_powershell_shim` (see [`wants_powershell_shim`]) drops the
+/// `.ps1` sibling, and deletes any that an earlier install left
+/// behind.
+///
 /// The chmod step (`set_executable` for the canonical shim and
 /// `ensure_executable_bits` for the target binary) is wired through the
 /// [`FsSetExecutable`] / [`FsEnsureExecutableBits`] capability traits.
@@ -562,6 +574,15 @@ fn write_shim<Sys>(
 where
     Sys: FsReadToString + FsReadHead + FsWrite + FsSetExecutable + FsEnsureExecutableBits,
 {
+    // Not writing a `.ps1` is not enough to keep one out of the bin
+    // dir: an install that did want one leaves it there, and
+    // PowerShell keeps preferring it over the `.cmd` sibling. Delete
+    // it up front, above the short-circuits below — they all return
+    // without touching the Windows siblings.
+    if !make_powershell_shim {
+        remove_stale_bin(&with_extension_appended(shim_path, "ps1"))?;
+    }
+
     // pnpm's warm-install short-circuit: an existing symlink that
     // already resolves to the target is correct as-is — regardless of
     // `preferSymlinkedExecutables` — so a relink pass that doesn't
@@ -629,13 +650,15 @@ where
     // off the `relative_target_windows` allocation path entirely.
     let windows_shims = cfg!(windows).then(|| {
         let cmd_path = with_extension_appended(shim_path, "cmd");
-        let ps1_path = with_extension_appended(shim_path, "ps1");
         let cmd_body =
             generate_cmd_shim(target_path, &cmd_path, runtime.as_ref(), node_path, style);
-        let ps1_body = make_powershell_shim.then(|| {
-            generate_pwsh_shim(target_path, &ps1_path, runtime.as_ref(), node_path, style)
+        let powershell_shim = make_powershell_shim.then(|| {
+            let ps1_path = with_extension_appended(shim_path, "ps1");
+            let ps1_body =
+                generate_pwsh_shim(target_path, &ps1_path, runtime.as_ref(), node_path, style);
+            (ps1_path, ps1_body)
         });
-        (cmd_path, cmd_body, ps1_path, ps1_body)
+        (cmd_path, cmd_body, powershell_shim)
     });
 
     // Idempotent skip fires only when every flavor that *should* be
@@ -667,18 +690,19 @@ where
     };
     let windows_ok = match &windows_shims {
         None => true,
-        Some((cmd_path, cmd_body, ps1_path, ps1_body)) => {
+        Some((cmd_path, cmd_body, powershell_shim)) => {
             let cmd_ok = matches!(
                 Sys::read_to_string(cmd_path),
                 Ok(existing) if &existing == cmd_body,
             );
-            let ps1_ok = match ps1_body {
-                Some(body) => matches!(
+            // A suppressed `.ps1` is already gone, so there is nothing
+            // left for this check to compare.
+            let ps1_ok = powershell_shim.as_ref().is_none_or(|(ps1_path, ps1_body)| {
+                matches!(
                     Sys::read_to_string(ps1_path),
-                    Ok(existing) if &existing == body,
-                ),
-                None => Sys::read_to_string(ps1_path).is_err(),
-            };
+                    Ok(existing) if &existing == ps1_body,
+                )
+            });
             cmd_ok && ps1_ok
         }
     };
@@ -693,13 +717,13 @@ where
         remove_stale_bin(shim_path)?;
         Sys::write(shim_path, sh_body.as_bytes())
             .map_err(|error| LinkBinsError::WriteShim { path: shim_path.to_path_buf(), error })?;
-        if let Some((cmd_path, cmd_body, ps1_path, ps1_body)) = &windows_shims {
+        if let Some((cmd_path, cmd_body, powershell_shim)) = &windows_shims {
             remove_stale_bin(cmd_path)?;
             Sys::write(cmd_path, cmd_body.as_bytes())
                 .map_err(|error| LinkBinsError::WriteShim { path: cmd_path.clone(), error })?;
-            remove_stale_bin(ps1_path)?;
-            if let Some(body) = ps1_body {
-                Sys::write(ps1_path, body.as_bytes())
+            if let Some((ps1_path, ps1_body)) = powershell_shim {
+                remove_stale_bin(ps1_path)?;
+                Sys::write(ps1_path, ps1_body.as_bytes())
                     .map_err(|error| LinkBinsError::WriteShim { path: ps1_path.clone(), error })?;
             }
         }

--- a/pnpm/crates/cmd-shim/src/link_bins.rs
+++ b/pnpm/crates/cmd-shim/src/link_bins.rs
@@ -471,12 +471,15 @@ where
         } else {
             shim_node_path(pkg, &options.extra_node_paths)
         };
+        let pkg_name = pkg.manifest.get("name").and_then(Value::as_str).unwrap_or("");
+        let make_powershell_shim = pkg_name != "pnpm";
         write_shim::<Sys>(
             &command.path,
             &bins_dir.join(bin_name),
             &node_path,
             options.prefer_symlinked_executables,
             style,
+            make_powershell_shim,
         )
     })?;
 
@@ -554,6 +557,7 @@ fn write_shim<Sys>(
     node_path: &[String],
     prefer_symlinked_executables: bool,
     style: ShimStyle,
+    make_powershell_shim: bool,
 ) -> Result<(), LinkBinsError>
 where
     Sys: FsReadToString + FsReadHead + FsWrite + FsSetExecutable + FsEnsureExecutableBits,
@@ -628,8 +632,9 @@ where
         let ps1_path = with_extension_appended(shim_path, "ps1");
         let cmd_body =
             generate_cmd_shim(target_path, &cmd_path, runtime.as_ref(), node_path, style);
-        let ps1_body =
-            generate_pwsh_shim(target_path, &ps1_path, runtime.as_ref(), node_path, style);
+        let ps1_body = make_powershell_shim.then(|| {
+            generate_pwsh_shim(target_path, &ps1_path, runtime.as_ref(), node_path, style)
+        });
         (cmd_path, cmd_body, ps1_path, ps1_body)
     });
 
@@ -667,10 +672,13 @@ where
                 Sys::read_to_string(cmd_path),
                 Ok(existing) if &existing == cmd_body,
             );
-            let ps1_ok = matches!(
-                Sys::read_to_string(ps1_path),
-                Ok(existing) if &existing == ps1_body,
-            );
+            let ps1_ok = match ps1_body {
+                Some(body) => matches!(
+                    Sys::read_to_string(ps1_path),
+                    Ok(existing) if &existing == body,
+                ),
+                None => Sys::read_to_string(ps1_path).is_err(),
+            };
             cmd_ok && ps1_ok
         }
     };
@@ -690,8 +698,10 @@ where
             Sys::write(cmd_path, cmd_body.as_bytes())
                 .map_err(|error| LinkBinsError::WriteShim { path: cmd_path.clone(), error })?;
             remove_stale_bin(ps1_path)?;
-            Sys::write(ps1_path, ps1_body.as_bytes())
-                .map_err(|error| LinkBinsError::WriteShim { path: ps1_path.clone(), error })?;
+            if let Some(body) = ps1_body {
+                Sys::write(ps1_path, body.as_bytes())
+                    .map_err(|error| LinkBinsError::WriteShim { path: ps1_path.clone(), error })?;
+            }
         }
     }
 

--- a/pnpm/crates/cmd-shim/src/link_bins/tests.rs
+++ b/pnpm/crates/cmd-shim/src/link_bins/tests.rs
@@ -1483,8 +1483,13 @@ fn prefer_symlinked_executables_links_a_bin_whose_target_is_missing() {
     );
 }
 
+/// The pnpm CLI's own package opts out of the PowerShell shim
+/// ([`super::wants_powershell_shim`]), and a `.ps1` an earlier install
+/// wrote — a pre-v12 `@pnpm/exe` wrapper carried the same bin names —
+/// has to be deleted, not merely left unwritten: PowerShell would keep
+/// preferring it over the `.cmd` shim and run the version it points at.
 #[test]
-fn does_not_write_powershell_shim_for_pnpm_package_on_windows() {
+fn linking_the_pnpm_cli_deletes_a_stale_powershell_shim() {
     let tmp = tempdir().unwrap();
     let pkg_dir = tmp.path().join("node_modules/pnpm");
     create_dir_all(&pkg_dir).unwrap();
@@ -1497,28 +1502,33 @@ fn does_not_write_powershell_shim_for_pnpm_package_on_windows() {
     write_file(pkg_dir.join("cli.js"), "#!/usr/bin/env node\n").unwrap();
 
     let bins_dir = tmp.path().join("node_modules/.bin");
+    create_dir_all(&bins_dir).unwrap();
+    for bin_name in ["pnpm", "pn"] {
+        write_file(bins_dir.join(format!("{bin_name}.ps1")), "an older install wrote this")
+            .unwrap();
+    }
+
     let manifest_value: Value =
         serde_json::from_slice(&read_file(pkg_dir.join("package.json")).unwrap()).unwrap();
+    let packages = [PackageBinSource::new(pkg_dir, Arc::new(manifest_value))];
+    link_bins_of_packages::<Host>(&packages, &bins_dir, &LinkBinsOptions::default()).unwrap();
 
-    // Create a stale pnpm.ps1 to make sure it gets cleaned up
-    let stale_ps1 = bins_dir.join("pnpm.ps1");
-    create_dir_all(&bins_dir).unwrap();
-    write_file(&stale_ps1, "stale content").unwrap();
-
-    link_bins_of_packages::<Host>(
-        &[PackageBinSource::new(pkg_dir, Arc::new(manifest_value))],
-        &bins_dir,
-        &LinkBinsOptions::default(),
-    )
-    .unwrap();
-
-    let sh = bins_dir.join("pnpm");
-    let cmd = bins_dir.join("pnpm.cmd");
-    let ps1 = bins_dir.join("pnpm.ps1");
-
-    assert!(sh.exists());
-    if cfg!(windows) {
-        assert!(cmd.exists());
-        assert!(!ps1.exists(), "stale pnpm.ps1 must be removed and not recreated");
+    for bin_name in ["pnpm", "pn"] {
+        assert!(bins_dir.join(bin_name).exists(), "{bin_name} must be linked");
+        assert!(
+            !bins_dir.join(format!("{bin_name}.ps1")).exists(),
+            "the stale {bin_name}.ps1 must be deleted, not left to shadow the linked bin",
+        );
+        assert_eq!(
+            bins_dir.join(format!("{bin_name}.cmd")).exists(),
+            cfg!(windows),
+            "{bin_name}.cmd is the Windows entry point and must survive the cleanup",
+        );
     }
+
+    // The warm-relink short-circuit must not let a `.ps1` planted
+    // after the first link survive.
+    write_file(bins_dir.join("pnpm.ps1"), "planted after the first link").unwrap();
+    link_bins_of_packages::<Host>(&packages, &bins_dir, &LinkBinsOptions::default()).unwrap();
+    assert!(!bins_dir.join("pnpm.ps1").exists());
 }

--- a/pnpm/crates/cmd-shim/src/link_bins/tests.rs
+++ b/pnpm/crates/cmd-shim/src/link_bins/tests.rs
@@ -1482,3 +1482,43 @@ fn prefer_symlinked_executables_links_a_bin_whose_target_is_missing() {
         Path::new("../foo/cli.js"),
     );
 }
+
+#[test]
+fn does_not_write_powershell_shim_for_pnpm_package_on_windows() {
+    let tmp = tempdir().unwrap();
+    let pkg_dir = tmp.path().join("node_modules/pnpm");
+    create_dir_all(&pkg_dir).unwrap();
+    write_file(
+        pkg_dir.join("package.json"),
+        json!({"name": "pnpm", "version": "1.0.0", "bin": {"pnpm": "cli.js", "pn": "cli.js"}})
+            .to_string(),
+    )
+    .unwrap();
+    write_file(pkg_dir.join("cli.js"), "#!/usr/bin/env node\n").unwrap();
+
+    let bins_dir = tmp.path().join("node_modules/.bin");
+    let manifest_value: Value =
+        serde_json::from_slice(&read_file(pkg_dir.join("package.json")).unwrap()).unwrap();
+
+    // Create a stale pnpm.ps1 to make sure it gets cleaned up
+    let stale_ps1 = bins_dir.join("pnpm.ps1");
+    create_dir_all(&bins_dir).unwrap();
+    write_file(&stale_ps1, "stale content").unwrap();
+
+    link_bins_of_packages::<Host>(
+        &[PackageBinSource::new(pkg_dir, Arc::new(manifest_value))],
+        &bins_dir,
+        &LinkBinsOptions::default(),
+    )
+    .unwrap();
+
+    let sh = bins_dir.join("pnpm");
+    let cmd = bins_dir.join("pnpm.cmd");
+    let ps1 = bins_dir.join("pnpm.ps1");
+
+    assert!(sh.exists());
+    if cfg!(windows) {
+        assert!(cmd.exists());
+        assert!(!ps1.exists(), "stale pnpm.ps1 must be removed and not recreated");
+    }
+}

--- a/pnpm11/bins/linker/src/index.ts
+++ b/pnpm11/bins/linker/src/index.ts
@@ -274,6 +274,13 @@ async function linkBin (cmd: CommandInfo, binsDir: string, opts?: LinkBinOptions
       const content = await fs.readFile(externalBinPath, 'utf8')
       isCorrectlyLinked = isShimPointingAt(content, cmd.path)
     }
+    if (isCorrectlyLinked) {
+      if (cmd.makePowerShellShim) {
+        isCorrectlyLinked = existsSync(`${externalBinPath}.ps1`)
+      } else {
+        isCorrectlyLinked = !existsSync(`${externalBinPath}.ps1`)
+      }
+    }
   } catch {}
   if (isCorrectlyLinked) {
     // If a previous install failed, we may have re-copied the bin script from
@@ -354,6 +361,13 @@ async function linkBin (cmd: CommandInfo, binsDir: string, opts?: LinkBinOptions
       nodePath,
       nodeExecPath: cmd.nodeExecPath,
     })
+    if (!cmd.makePowerShellShim) {
+      try {
+        await fs.unlink(`${externalBinPath}.ps1`)
+      } catch (err: any) { // eslint-disable-line
+        if (err.code !== 'ENOENT') throw err
+      }
+    }
   } catch (err: any) { // eslint-disable-line
     if (err.code === 'ENOENT' || err.code === 'EISDIR') {
       globalWarn(`Failed to create bin at ${externalBinPath}. ${err.message as string}`)

--- a/pnpm11/bins/linker/src/index.ts
+++ b/pnpm11/bins/linker/src/index.ts
@@ -126,6 +126,13 @@ export async function linkBinsOfPackages (
 interface CommandInfo extends Command {
   pkgName: string
   pkgVersion: string
+  /**
+   * Whether the owning package wants a PowerShell shim next to its .cmd one.
+   * The pnpm CLI opts out: PowerShell resolves `pnpm.ps1` ahead of `pnpm.cmd`,
+   * so a shim written for one installation of the CLI would keep shadowing
+   * every later one, including an upgrade that ships a different executable.
+   * Platform support is applied where the shim is created, not here.
+   */
   makePowerShellShim: boolean
   nodeExecPath?: string
 }
@@ -241,7 +248,7 @@ async function getPackageBinsFromManifest (manifest: DependencyManifest, pkgDir:
     ...cmd,
     pkgName: manifest.name,
     pkgVersion: manifest.version,
-    makePowerShellShim: POWER_SHELL_IS_SUPPORTED && manifest.name !== 'pnpm',
+    makePowerShellShim: manifest.name !== 'pnpm',
     nodeExecPath,
   }))
 }
@@ -260,6 +267,13 @@ export interface LinkBinOptions {
 
 async function linkBin (cmd: CommandInfo, binsDir: string, opts?: LinkBinOptions): Promise<void> {
   const externalBinPath = path.join(binsDir, cmd.name)
+  // Not writing a PowerShell shim is not enough to keep one out of the bin
+  // directory: an install that did want one leaves it behind, and PowerShell
+  // keeps preferring it over the .cmd shim. This runs above the short-circuits
+  // below, which all return without touching the .ps1 sibling.
+  if (!cmd.makePowerShellShim) {
+    await rimraf(`${externalBinPath}.ps1`)
+  }
   // Skip if the existing bin already references the correct target.
   // This avoids redundant I/O on warm installs and EACCES on read-only stores.
   // We verify the target path — not just existence — so that conflict resolution
@@ -273,13 +287,6 @@ async function linkBin (cmd: CommandInfo, binsDir: string, opts?: LinkBinOptions
     } else if (stat.isFile() && stat.size < CMD_SHIM_MAX_SIZE) {
       const content = await fs.readFile(externalBinPath, 'utf8')
       isCorrectlyLinked = isShimPointingAt(content, cmd.path)
-    }
-    if (isCorrectlyLinked) {
-      if (cmd.makePowerShellShim) {
-        isCorrectlyLinked = existsSync(`${externalBinPath}.ps1`)
-      } else {
-        isCorrectlyLinked = !existsSync(`${externalBinPath}.ps1`)
-      }
     }
   } catch {}
   if (isCorrectlyLinked) {
@@ -357,17 +364,10 @@ async function linkBin (cmd: CommandInfo, binsDir: string, opts?: LinkBinOptions
       }
     }
     await cmdShim(cmd.path, externalBinPath, {
-      createPwshFile: cmd.makePowerShellShim,
+      createPwshFile: POWER_SHELL_IS_SUPPORTED && cmd.makePowerShellShim,
       nodePath,
       nodeExecPath: cmd.nodeExecPath,
     })
-    if (!cmd.makePowerShellShim) {
-      try {
-        await fs.unlink(`${externalBinPath}.ps1`)
-      } catch (err: any) { // eslint-disable-line
-        if (err.code !== 'ENOENT') throw err
-      }
-    }
   } catch (err: any) { // eslint-disable-line
     if (err.code === 'ENOENT' || err.code === 'EISDIR') {
       globalWarn(`Failed to create bin at ${externalBinPath}. ${err.message as string}`)

--- a/pnpm11/bins/linker/test/fixtures/pnpm-cli/node_modules/pnpm/package.json
+++ b/pnpm11/bins/linker/test/fixtures/pnpm-cli/node_modules/pnpm/package.json
@@ -1,5 +1,8 @@
 {
   "name": "pnpm",
   "version": "1.0.0",
-  "bin": "index.js"
+  "bin": {
+    "pnpm": "index.js",
+    "pn": "index.js"
+  }
 }

--- a/pnpm11/bins/linker/test/index.ts
+++ b/pnpm11/bins/linker/test/index.ts
@@ -154,6 +154,23 @@ test('linkBins() never creates a PowerShell shim for the pnpm CLI', async () => 
   expect(bins).not.toContain('pnpm.ps1')
 })
 
+test('linkBins() deletes any pre-existing/stale pnpm.ps1 shim for the pnpm CLI', async () => {
+  const binTarget = temporaryDirectory()
+  const fixture = f.prepare('pnpm-cli')
+  const warn = jest.fn()
+
+  const stalePs1 = path.join(binTarget, 'pnpm.ps1')
+  fs.mkdirSync(binTarget, { recursive: true })
+  fs.writeFileSync(stalePs1, 'stale content')
+
+  await linkBins(path.join(fixture, 'node_modules'), binTarget, { warn })
+
+  const bins = fs.readdirSync(binTarget)
+  expect(bins).toContain('pnpm')
+  expect(bins).not.toContain('pnpm.ps1')
+  expect(fs.existsSync(stalePs1)).toBe(false)
+})
+
 test('linkBins() finds exotic manifests', async () => {
   const binTarget = temporaryDirectory()
   const exoticManifestFixture = f.prepare('exotic-manifest')

--- a/pnpm11/bins/linker/test/index.ts
+++ b/pnpm11/bins/linker/test/index.ts
@@ -154,21 +154,32 @@ test('linkBins() never creates a PowerShell shim for the pnpm CLI', async () => 
   expect(bins).not.toContain('pnpm.ps1')
 })
 
-test('linkBins() deletes any pre-existing/stale pnpm.ps1 shim for the pnpm CLI', async () => {
+test('linkBins() deletes a PowerShell shim left by an older install of the pnpm CLI', async () => {
   const binTarget = temporaryDirectory()
   const fixture = f.prepare('pnpm-cli')
   const warn = jest.fn()
 
-  const stalePs1 = path.join(binTarget, 'pnpm.ps1')
   fs.mkdirSync(binTarget, { recursive: true })
-  fs.writeFileSync(stalePs1, 'stale content')
+  for (const binName of ['pnpm', 'pn']) {
+    fs.writeFileSync(path.join(binTarget, `${binName}.ps1`), 'an older install wrote this')
+  }
 
   await linkBins(path.join(fixture, 'node_modules'), binTarget, { warn })
 
   const bins = fs.readdirSync(binTarget)
-  expect(bins).toContain('pnpm')
-  expect(bins).not.toContain('pnpm.ps1')
-  expect(fs.existsSync(stalePs1)).toBe(false)
+  for (const binName of ['pnpm', 'pn']) {
+    expect(bins).toContain(binName)
+    expect(bins).not.toContain(`${binName}.ps1`)
+    if (IS_WINDOWS) {
+      expect(bins).toContain(`${binName}.cmd`)
+    }
+  }
+
+  // The warm-relink short-circuit must not let a .ps1 planted after the first
+  // link survive.
+  fs.writeFileSync(path.join(binTarget, 'pnpm.ps1'), 'planted after the first link')
+  await linkBins(path.join(fixture, 'node_modules'), binTarget, { warn })
+  expect(fs.readdirSync(binTarget)).not.toContain('pnpm.ps1')
 })
 
 test('linkBins() finds exotic manifests', async () => {


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

This PR fixes `pnpm self-update` leaving behind a stale `pnpm.ps1` shim on Windows. Because PowerShell prioritizes `.ps1` files over `.cmd` or `.exe`, this issue caused PowerShell to execute the old pnpm version even after an upgrade.

We've updated both the TypeScript and Rust `pacquet` CLI stacks to check if a PowerShell shim is needed for a command. If not (such as for `pnpm`), we explicitly delete any existing `.ps1` file in the destination bin directory to prevent it from shadowing the updated binary.

Closes pnpm/pnpm#13919.

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
PowerShell resolves `<name>.ps1` ahead of `<name>.cmd`, so a shim written by an
older installation of the CLI keeps running that version after an upgrade. pnpm
already declines to write a `.ps1` for its own package, but not writing one is
not enough to keep one out of the bin directory: `pnpm self-update` from a
release that installed the CLI as `@pnpm/exe` (which does get PowerShell shims)
leaves `pnpm.ps1` and `pn.ps1` behind in PNPM_HOME/bin, and every later version
installs as `pnpm` and never touches them.

Bin linking now deletes the `.ps1` for a package that opts out, instead of
merely not writing it. The removal sits above every short-circuit in
`linkBin` / `write_shim` -- the correctly-linked fast path, the node-bin
special case, and `preferSymlinkedExecutables` all return without reaching the
shim writer, so a stale `.ps1` next to an already-correct bin would otherwise
survive a warm relink.

On the Rust side the idempotence check no longer has to reason about a
suppressed flavor: `windows_shims` carries the `.ps1` path and body only when
one is wanted, and the check skips it otherwise.

On the TypeScript side `makePowerShellShim` now carries the package's policy
alone (`name !== 'pnpm'`); `POWER_SHELL_IS_SUPPORTED` is applied at the
`cmdShim` call where the shim is created. Folding both into the field made it
false for every package off Windows, which would have run the cleanup once per
bin on every Linux and macOS install. Removal goes through `rimraf`, which
copes with a dangling symlink or a directory at that name, and sits outside the
handler that turns EISDIR and Windows EPERM into a warning, so a real failure
propagates.

Implemented symmetrically in both:
- TypeScript bins linker (`@pnpm/bins.linker`)
- Rust cmd-shim crate (pnpm-cmd-shim)

Regression tests in both stacks seed a stale `pnpm.ps1` and `pn.ps1`, assert
both are deleted while the `.cmd` shim survives, and relink a second time with
a freshly planted `.ps1` to pin the warm-install path.

Closes pnpm/pnpm#13919.
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789460612&installation_model_id=426870&pr_number=13937&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13937&signature=5c1f880040342b8f86f5bbb3ee16e90216c46298cdc874845fa3b4bb732be50c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows command linking so stale PowerShell `.ps1` shims for the pnpm CLI are removed.
  * Prevented outdated PowerShell shims from shadowing updated pnpm binaries.
  * Preserved the correct executable and `.cmd` shim while removing obsolete files.
  * Added patch release updates for the affected pnpm command-linking components.
* **Tests**
  * Added regression coverage for stale PowerShell shim cleanup during command linking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
