### PR TITLE
fix(hooks): clone manifest to prevent overrides cache pollution

### DIFF
--- a/.changeset/fix-overrides-metadata-cache.md
+++ b/.changeset/fix-overrides-metadata-cache.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/hooks.read-package-hook": patch
+"pnpm": patch
+---
+
+Fixed an issue where package overrides were written into the metadata cache, causing removed overrides to keep applying on subsequent installs [pnpm/pnpm#13918](https://github.com/pnpm/pnpm/issues/13918).

--- a/pnpm11/hooks/read-package-hook/src/createVersionsOverrider.ts
+++ b/pnpm11/hooks/read-package-hook/src/createVersionsOverrider.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 
 import type { PackageSelector, VersionOverride as VersionOverrideBase } from '@pnpm/config.parse-overrides'
 import { isValidPeerRange } from '@pnpm/deps.peer-range'
-import type { Dependencies, PackageManifest, ReadPackageHook } from '@pnpm/types'
+import { type Dependencies, DEPENDENCIES_OR_PEER_FIELDS, type PackageManifest, type ReadPackageHook } from '@pnpm/types'
 import normalizePath from 'normalize-path'
 import { partition } from 'ramda'
 import semver from 'semver'
@@ -67,20 +67,13 @@ export function createVersionsOverrider (
         (!parentPkg.bareSpecifier || semver.satisfies(manifest.version, parentPkg.bareSpecifier))
       )
     })
-    const clonedManifest = {
-      ...manifest,
-    }
-    if (manifest.dependencies) {
-      clonedManifest.dependencies = { ...manifest.dependencies }
-    }
-    if (manifest.devDependencies) {
-      clonedManifest.devDependencies = { ...manifest.devDependencies }
-    }
-    if (manifest.optionalDependencies) {
-      clonedManifest.optionalDependencies = { ...manifest.optionalDependencies }
-    }
-    if (manifest.peerDependencies) {
-      clonedManifest.peerDependencies = { ...manifest.peerDependencies }
+    // The manifest may come from a shared cache, so the fields the overrides
+    // rewrite are cloned instead of mutated in place.
+    const clonedManifest = { ...manifest }
+    for (const depsField of DEPENDENCIES_OR_PEER_FIELDS) {
+      if (manifest[depsField] != null) {
+        clonedManifest[depsField] = { ...manifest[depsField] }
+      }
     }
     overrideDepsOfPkg({ manifest: clonedManifest, dir }, versionOverridesWithParent, genericVersionOverrides, {
       convergeVersions,

--- a/pnpm11/hooks/read-package-hook/src/createVersionsOverrider.ts
+++ b/pnpm11/hooks/read-package-hook/src/createVersionsOverrider.ts
@@ -67,12 +67,27 @@ export function createVersionsOverrider (
         (!parentPkg.bareSpecifier || semver.satisfies(manifest.version, parentPkg.bareSpecifier))
       )
     })
-    overrideDepsOfPkg({ manifest, dir }, versionOverridesWithParent, genericVersionOverrides, {
+    const clonedManifest = {
+      ...manifest,
+    }
+    if (manifest.dependencies) {
+      clonedManifest.dependencies = { ...manifest.dependencies }
+    }
+    if (manifest.devDependencies) {
+      clonedManifest.devDependencies = { ...manifest.devDependencies }
+    }
+    if (manifest.optionalDependencies) {
+      clonedManifest.optionalDependencies = { ...manifest.optionalDependencies }
+    }
+    if (manifest.peerDependencies) {
+      clonedManifest.peerDependencies = { ...manifest.peerDependencies }
+    }
+    overrideDepsOfPkg({ manifest: clonedManifest, dir }, versionOverridesWithParent, genericVersionOverrides, {
       convergeVersions,
       convergeDeclaredRanges: opts?.convergeDeclaredRanges,
     })
 
-    return manifest
+    return clonedManifest
   }) as ReadPackageHook
 }
 

--- a/pnpm11/hooks/read-package-hook/test/createVersionOverrider.test.ts
+++ b/pnpm11/hooks/read-package-hook/test/createVersionOverrider.test.ts
@@ -915,10 +915,19 @@ test('createVersionsOverrider() does not mutate the original manifest', () => {
       },
       newBareSpecifier: '2.12.0',
     },
+    {
+      targetPkg: {
+        name: 'bar',
+      },
+      newBareSpecifier: '2.0.0',
+    },
   ], process.cwd())
   const originalManifest = {
     dependencies: {
       foo: '^1.0.0',
+    },
+    peerDependencies: {
+      bar: '^1.0.0',
     },
   }
   const result = overrider(originalManifest)
@@ -926,8 +935,12 @@ test('createVersionsOverrider() does not mutate the original manifest', () => {
     dependencies: {
       foo: '2.12.0',
     },
+    peerDependencies: {
+      bar: '2.0.0',
+    },
   })
   expect(originalManifest.dependencies.foo).toBe('^1.0.0')
+  expect(originalManifest.peerDependencies.bar).toBe('^1.0.0')
 })
 
 describe('createDependencyOverrider()', () => {

--- a/pnpm11/hooks/read-package-hook/test/createVersionOverrider.test.ts
+++ b/pnpm11/hooks/read-package-hook/test/createVersionOverrider.test.ts
@@ -907,6 +907,29 @@ test('createVersionsOverrider() collects declared ranges of convergence-governed
   ]))
 })
 
+test('createVersionsOverrider() does not mutate the original manifest', () => {
+  const overrider = createVersionsOverrider([
+    {
+      targetPkg: {
+        name: 'foo',
+      },
+      newBareSpecifier: '2.12.0',
+    },
+  ], process.cwd())
+  const originalManifest = {
+    dependencies: {
+      foo: '^1.0.0',
+    },
+  }
+  const result = overrider(originalManifest)
+  expect(result).toStrictEqual({
+    dependencies: {
+      foo: '2.12.0',
+    },
+  })
+  expect(originalManifest.dependencies.foo).toBe('^1.0.0')
+})
+
 describe('createDependencyOverrider()', () => {
   test('resolves a generic override for a dependency that has no manifest', () => {
     const overrideDependency = createDependencyOverrider(parseOverrides({


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Cloned the manifest and its dependency properties in `createVersionsOverrider` to avoid mutating the cached manifest in-place.

Resolves https://github.com/pnpm/pnpm/issues/13918

## Squash Commit Body

Cloned the manifest and its dependency properties in `createVersionsOverrider` to avoid mutating the cached manifest in-place.

Resolves https://github.com/pnpm/pnpm/issues/13918

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting.
  > [!NOTE]
  > The Rust `pacquet` port does not suffer from this issue because `apply_to_arc` in `pnpm/crates/package-manager/src/overrides.rs` already clones the manifest value before modifying it in-place.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13938"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789461229&installation_model_id=426870&pr_number=13938&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13938&signature=4c349d02d9f32c269a2dacf07cd1fd9125432575c140db1ad7946bce4f11c88a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where package overrides could persist in the metadata cache across installs.
  * Ensured dependency and peer dependency overrides are applied without modifying the original package metadata.
  * Added regression coverage to prevent this issue from recurring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->