### PR TITLE
feat(pacquet)!: enable the global virtual store by default

### DIFF
--- a/.changeset/global-virtual-store-by-default.md
+++ b/.changeset/global-virtual-store-by-default.md
@@ -4,7 +4,7 @@
 
 The global virtual store is now enabled by default. Every package is materialized once per machine, under `<store-dir>/v11/links/`, and shared by all the projects that depend on it, instead of being re-created inside each project's `node_modules/.pnpm`. Repeat installs of a dependency another project already installed are close to free, and projects that share dependencies no longer pay for them twice on disk.
 
-The default flips back to off in CI, where the store is usually cold and there is nothing to share yet. Setting `enableGlobalVirtualStore` in `pnpm-workspace.yaml` pins the choice everywhere, CI included:
+The default is the same in every environment, CI included, so a build never runs against a layout nobody develops against. To opt out, set the setting in `pnpm-workspace.yaml`:
 
 ```yaml
 enableGlobalVirtualStore: false

--- a/.changeset/global-virtual-store-by-default.md
+++ b/.changeset/global-virtual-store-by-default.md
@@ -1,0 +1,13 @@
+---
+"pacquet": major
+---
+
+The global virtual store is now enabled by default. Every package is materialized once per machine, under `<store-dir>/v11/links/`, and shared by all the projects that depend on it, instead of being re-created inside each project's `node_modules/.pnpm`. Repeat installs of a dependency another project already installed are close to free, and projects that share dependencies no longer pay for them twice on disk.
+
+The default flips back to off in CI, where the store is usually cold and there is nothing to share yet. Setting `enableGlobalVirtualStore` in `pnpm-workspace.yaml` pins the choice everywhere, CI included:
+
+```yaml
+enableGlobalVirtualStore: false
+```
+
+Because the package directories now live outside the project, a dependency's own dependencies are reachable through symlinks and `NODE_PATH` rather than by walking up the filesystem from a package's real path. Tools that resolve modules by walking directories themselves, instead of asking Node.js to resolve them, may not find a dependency they used to find. Turning the setting off restores the project-local layout.

--- a/.changeset/global-virtual-store-by-default.md
+++ b/.changeset/global-virtual-store-by-default.md
@@ -2,7 +2,7 @@
 "pacquet": major
 ---
 
-The global virtual store is now enabled by default. Every package is materialized once per machine, under `<store-dir>/v11/links/`, and shared by all the projects that depend on it, instead of being re-created inside each project's `node_modules/.pnpm`. Repeat installs of a dependency another project already installed are close to free, and projects that share dependencies no longer pay for them twice on disk.
+The global virtual store is now enabled by default. A package is materialized under `<store-dir>/v11/links/` once per machine for each distinct set of dependencies it resolves to, and shared by every project that resolves it the same way, instead of being re-created inside each project's `node_modules/.pnpm`. Installing a dependency another project already installed the same way is close to free, and those projects no longer pay for it twice on disk.
 
 The default is the same in every environment, CI included, so a build never runs against a layout nobody develops against. To opt out, set the setting in `pnpm-workspace.yaml`:
 

--- a/pnpm/crates/cli/src/config_deps/tests.rs
+++ b/pnpm/crates/cli/src/config_deps/tests.rs
@@ -105,7 +105,11 @@ async fn update_config_can_extend_extra_bin_paths() {
 #[tokio::test]
 async fn update_config_can_set_extra_env() {
     let root = tempfile::tempdir().expect("workspace tempdir");
-    fs::write(root.path().join("pnpm-workspace.yaml"), "\n").expect("write workspace settings");
+    // The shared virtual store seeds `extraEnv` with the `NODE_PATH` /
+    // `NODE_OPTIONS` pair that makes hoisted dependencies resolvable, so
+    // turn it off to start the hook from an empty map.
+    fs::write(root.path().join("pnpm-workspace.yaml"), "enableGlobalVirtualStore: false\n")
+        .expect("write workspace settings");
     fs::write(
         root.path().join(".pnpmfile.cjs"),
         "module.exports = { hooks: { updateConfig (config) { config.extraEnv = { ...config.extraEnv, npm_config_nodedir: '/brazil/node' }; return config } } }",

--- a/pnpm/crates/cli/tests/suite/global_virtual_store.rs
+++ b/pnpm/crates/cli/tests/suite/global_virtual_store.rs
@@ -89,9 +89,27 @@ fn pkg_in_slot(hash_dir: &Path, name: &str) -> PathBuf {
 /// These tests re-set `allowBuilds` between installs, so they need a form
 /// that is idempotent.
 fn set_gvs_workspace_yaml(workspace: &Path, extra_yaml: &str) {
-    let yaml_path = workspace.join("pnpm-workspace.yaml");
-    let existing = fs::read_to_string(&yaml_path).expect("read pnpm-workspace.yaml");
-    let mut yaml: String = existing
+    let mut yaml = harness_store_and_cache_yaml(workspace);
+    yaml.push_str("enableGlobalVirtualStore: true\n");
+    yaml.push_str(extra_yaml);
+    fs::write(workspace.join("pnpm-workspace.yaml"), yaml).expect("write pnpm-workspace.yaml");
+}
+
+/// Rewrite `pnpm-workspace.yaml` with the harness's `storeDir` /
+/// `cacheDir` alone, dropping its `enableGlobalVirtualStore` pin so the
+/// install runs on whatever the setting defaults to.
+fn unset_gvs_workspace_yaml(workspace: &Path) {
+    let yaml = harness_store_and_cache_yaml(workspace);
+    fs::write(workspace.join("pnpm-workspace.yaml"), yaml).expect("write pnpm-workspace.yaml");
+}
+
+/// The `storeDir` / `cacheDir` lines
+/// [`CommandTempCwd::add_mocked_registry`] wrote, which every rewrite of
+/// the file has to carry over to keep the install inside the tempdir.
+fn harness_store_and_cache_yaml(workspace: &Path) -> String {
+    let existing = fs::read_to_string(workspace.join("pnpm-workspace.yaml"))
+        .expect("read pnpm-workspace.yaml");
+    let yaml: String = existing
         .lines()
         .filter(|line| line.starts_with("storeDir:") || line.starts_with("cacheDir:"))
         .fold(String::new(), |mut acc, line| {
@@ -104,9 +122,7 @@ fn set_gvs_workspace_yaml(workspace: &Path, extra_yaml: &str) {
         "expected the `storeDir` / `cacheDir` keys written by \
          `CommandTempCwd::add_mocked_registry` — has the helper changed?",
     );
-    yaml.push_str("enableGlobalVirtualStore: true\n");
-    yaml.push_str(extra_yaml);
-    fs::write(&yaml_path, yaml).expect("write pnpm-workspace.yaml");
+    yaml
 }
 
 fn write_manifest(workspace: &Path, deps: &serde_json::Value) {
@@ -1465,6 +1481,45 @@ fn scripts_resolve_phantom_esm_imports_through_the_private_hoist() {
     assert_eq!(
         fs::read_to_string(workspace.join("phantom.txt")).expect("read phantom.txt"),
         "resolved",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// A project that says nothing about `enableGlobalVirtualStore` gets the
+/// shared store, and a CI environment gets the project-local one instead.
+#[test]
+fn the_global_virtual_store_is_the_default_outside_ci() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { store_dir, mock_instance, .. } = npmrc_info;
+
+    unset_gvs_workspace_yaml(&workspace);
+    write_manifest(&workspace, &serde_json::json!({ "@pnpm.e2e/pkg-with-1-dep": "100.0.0" }));
+
+    eprintln!("Installing with no `enableGlobalVirtualStore` setting...");
+    pacquet(&workspace).with_arg("install").assert().success();
+
+    let version_dir = pkg_version_dir(&store_dir, "@pnpm.e2e/pkg-with-1-dep", "100.0.0");
+    let hash_dir = sole_hash_dir(&version_dir);
+    assert!(
+        pkg_in_slot(&hash_dir, "@pnpm.e2e/pkg-with-1-dep").join("package.json").exists(),
+        "the package must be materialized in its GVS slot",
+    );
+    assert!(
+        !workspace.join("node_modules/.pnpm/@pnpm.e2e+pkg-with-1-dep@100.0.0").exists(),
+        "no project-local slot is written under the shared store",
+    );
+
+    eprintln!("Reinstalling the same project as CI...");
+    fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
+    pacquet(&workspace).with_env("PNPM_CONFIG_CI", "true").with_arg("install").assert().success();
+
+    assert!(
+        workspace
+            .join("node_modules/.pnpm/@pnpm.e2e+pkg-with-1-dep@100.0.0/node_modules/@pnpm.e2e/pkg-with-1-dep/package.json")
+            .exists(),
+        "CI falls back to the project-local virtual store",
     );
 
     drop((root, mock_instance));

--- a/pnpm/crates/cli/tests/suite/global_virtual_store.rs
+++ b/pnpm/crates/cli/tests/suite/global_virtual_store.rs
@@ -1487,7 +1487,8 @@ fn scripts_resolve_phantom_esm_imports_through_the_private_hoist() {
 }
 
 /// A project that says nothing about `enableGlobalVirtualStore` gets the
-/// shared store, and a CI environment gets the project-local one instead.
+/// shared store, a CI environment gets the project-local one instead, and
+/// a CI environment that asks for the shared store still gets it.
 #[test]
 fn the_global_virtual_store_is_the_default_outside_ci() {
     let CommandTempCwd { root, workspace, npmrc_info, .. } =
@@ -1520,6 +1521,25 @@ fn the_global_virtual_store_is_the_default_outside_ci() {
             .join("node_modules/.pnpm/@pnpm.e2e+pkg-with-1-dep@100.0.0/node_modules/@pnpm.e2e/pkg-with-1-dep/package.json")
             .exists(),
         "CI falls back to the project-local virtual store",
+    );
+
+    eprintln!("Reinstalling as CI, with the shared store asked for by env var...");
+    fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
+    pacquet(&workspace)
+        .with_env("PNPM_CONFIG_CI", "true")
+        .with_env("PNPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE", "true")
+        .with_arg("install")
+        .assert()
+        .success();
+
+    assert!(
+        !workspace.join("node_modules/.pnpm/@pnpm.e2e+pkg-with-1-dep@100.0.0").exists(),
+        "an explicit opt-in outranks the CI fallback, wherever it comes from",
+    );
+    assert_eq!(
+        hash_dirs(&version_dir),
+        vec![hash_dir.file_name().expect("hash dir name").to_string_lossy()],
+        "the opted-in CI install reattaches to the slot the first install materialized",
     );
 
     drop((root, mock_instance));

--- a/pnpm/crates/cli/tests/suite/global_virtual_store.rs
+++ b/pnpm/crates/cli/tests/suite/global_virtual_store.rs
@@ -1487,10 +1487,11 @@ fn scripts_resolve_phantom_esm_imports_through_the_private_hoist() {
 }
 
 /// A project that says nothing about `enableGlobalVirtualStore` gets the
-/// shared store, a CI environment gets the project-local one instead, and
-/// a CI environment that asks for the shared store still gets it.
+/// shared store — in CI too, so a build never runs against a layout
+/// nobody develops against. Opting out is what changes the layout, from
+/// wherever the setting is set.
 #[test]
-fn the_global_virtual_store_is_the_default_outside_ci() {
+fn the_global_virtual_store_is_the_default_in_every_environment() {
     let CommandTempCwd { root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();
     let AddMockedRegistry { store_dir, mock_instance, .. } = npmrc_info;
@@ -1498,17 +1499,19 @@ fn the_global_virtual_store_is_the_default_outside_ci() {
     unset_gvs_workspace_yaml(&workspace);
     write_manifest(&workspace, &serde_json::json!({ "@pnpm.e2e/pkg-with-1-dep": "100.0.0" }));
 
+    let version_dir = pkg_version_dir(&store_dir, "@pnpm.e2e/pkg-with-1-dep", "100.0.0");
+    let project_local_slot = workspace.join("node_modules/.pnpm/@pnpm.e2e+pkg-with-1-dep@100.0.0");
+
     eprintln!("Installing with no `enableGlobalVirtualStore` setting...");
     pacquet(&workspace).with_arg("install").assert().success();
 
-    let version_dir = pkg_version_dir(&store_dir, "@pnpm.e2e/pkg-with-1-dep", "100.0.0");
     let hash_dir = sole_hash_dir(&version_dir);
     assert!(
         pkg_in_slot(&hash_dir, "@pnpm.e2e/pkg-with-1-dep").join("package.json").exists(),
         "the package must be materialized in its GVS slot",
     );
     assert!(
-        !workspace.join("node_modules/.pnpm/@pnpm.e2e+pkg-with-1-dep@100.0.0").exists(),
+        !project_local_slot.exists(),
         "no project-local slot is written under the shared store",
     );
 
@@ -1516,30 +1519,24 @@ fn the_global_virtual_store_is_the_default_outside_ci() {
     fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
     pacquet(&workspace).with_env("PNPM_CONFIG_CI", "true").with_arg("install").assert().success();
 
-    assert!(
-        workspace
-            .join("node_modules/.pnpm/@pnpm.e2e+pkg-with-1-dep@100.0.0/node_modules/@pnpm.e2e/pkg-with-1-dep/package.json")
-            .exists(),
-        "CI falls back to the project-local virtual store",
+    assert!(!project_local_slot.exists(), "CI gets the same layout as any other environment");
+    assert_eq!(
+        hash_dirs(&version_dir),
+        vec![hash_dir.file_name().expect("hash dir name").to_string_lossy()],
+        "the CI install reattaches to the slot the first install materialized",
     );
 
-    eprintln!("Reinstalling as CI, with the shared store asked for by env var...");
+    eprintln!("Reinstalling with the shared store turned off by env var...");
     fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
     pacquet(&workspace)
-        .with_env("PNPM_CONFIG_CI", "true")
-        .with_env("PNPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE", "true")
+        .with_env("PNPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE", "false")
         .with_arg("install")
         .assert()
         .success();
 
     assert!(
-        !workspace.join("node_modules/.pnpm/@pnpm.e2e+pkg-with-1-dep@100.0.0").exists(),
-        "an explicit opt-in outranks the CI fallback, wherever it comes from",
-    );
-    assert_eq!(
-        hash_dirs(&version_dir),
-        vec![hash_dir.file_name().expect("hash dir name").to_string_lossy()],
-        "the opted-in CI install reattaches to the slot the first install materialized",
+        project_local_slot.join("node_modules/@pnpm.e2e/pkg-with-1-dep/package.json").exists(),
+        "opting out moves the package back into the project",
     );
 
     drop((root, mock_instance));

--- a/pnpm/crates/cli/tests/suite/licenses.rs
+++ b/pnpm/crates/cli/tests/suite/licenses.rs
@@ -9,6 +9,11 @@ use std::{fs, path::Path};
 #[test]
 fn licenses_normalizes_metadata_and_orders_groups_by_package() {
     let workspace = tempfile::tempdir().expect("create workspace");
+    // The fixtures below are hand-placed in the project-local virtual
+    // store, which the default shared store would move out of the
+    // project entirely.
+    fs::write(workspace.path().join("pnpm-workspace.yaml"), "enableGlobalVirtualStore: false\n")
+        .expect("write pnpm-workspace.yaml");
     fs::write(
         workspace.path().join("package.json"),
         json!({

--- a/pnpm/crates/cli/tests/suite/sync_injected_deps_after_scripts.rs
+++ b/pnpm/crates/cli/tests/suite/sync_injected_deps_after_scripts.rs
@@ -27,11 +27,14 @@ fn injected_copies(workspace: &Path) -> Vec<std::path::PathBuf> {
     copies
 }
 
+/// Overwrites the harness's `pnpm-workspace.yaml`, so it has to restate
+/// its `enableGlobalVirtualStore: false` pin — [`injected_copies`] reads
+/// the project-local virtual store.
 fn write_workspace(workspace: &Path, sync_after: &str) {
     fs::write(
         workspace.join("pnpm-workspace.yaml"),
         format!(
-            "packages:\n  - 'project-*'\ninjectWorkspacePackages: true\ndedupeInjectedDeps: false\n{sync_after}",
+            "packages:\n  - 'project-*'\ninjectWorkspacePackages: true\ndedupeInjectedDeps: false\nenableGlobalVirtualStore: false\n{sync_after}",
         ),
     )
     .expect("write pnpm-workspace.yaml");

--- a/pnpm/crates/config/src/defaults.rs
+++ b/pnpm/crates/config/src/defaults.rs
@@ -221,8 +221,12 @@ pub fn default_virtual_store_dir() -> PathBuf {
 /// parity check that flags it is looking at a major-version boundary
 /// rather than at a gap.
 ///
-/// [`crate::Config::current`] turns it back off in a CI environment
-/// unless the setting is pinned explicitly.
+/// The default does not vary by environment. A CI machine gets the same
+/// layout a developer's machine does — under a shared store, package
+/// directories sit outside the project and scripts run with `NODE_PATH`
+/// and the ESM loader set, so a CI-only fallback to the project-local
+/// layout would run every build in a resolution environment nobody
+/// develops against.
 pub fn default_enable_global_virtual_store() -> bool {
     true
 }

--- a/pnpm/crates/config/src/defaults.rs
+++ b/pnpm/crates/config/src/defaults.rs
@@ -212,14 +212,17 @@ pub fn default_virtual_store_dir() -> PathBuf {
     env::current_dir().expect("current directory is unavailable").join("node_modules/.pnpm")
 }
 
-/// Default for `enableGlobalVirtualStore`: `false` for regular installs.
+/// Default for `enableGlobalVirtualStore`: `true`.
 ///
-/// It is only enabled by default on the `pnpm install --global` path.
-/// Pacquet doesn't have a `--global` CLI flag at all (only
-/// `install --frozen-lockfile`), so the only applicable default is the
-/// `false` one.
+/// pnpm 12 shares one virtual store across every project on the machine.
+/// pnpm 11 keeps the project-local `node_modules/.pnpm` instead, enabling
+/// the shared store only for `pnpm install --global`, so this is one of
+/// the defaults the two majors deliberately disagree on.
+///
+/// [`crate::Config::current`] turns it back off in a CI environment
+/// unless the setting is pinned explicitly.
 pub fn default_enable_global_virtual_store() -> bool {
-    false
+    true
 }
 
 #[must_use]

--- a/pnpm/crates/config/src/defaults.rs
+++ b/pnpm/crates/config/src/defaults.rs
@@ -212,12 +212,14 @@ pub fn default_virtual_store_dir() -> PathBuf {
     env::current_dir().expect("current directory is unavailable").join("node_modules/.pnpm")
 }
 
-/// Default for `enableGlobalVirtualStore`: `true`.
+/// Default for `enableGlobalVirtualStore`: `true` — one virtual store,
+/// shared by every project on the machine.
 ///
-/// pnpm 12 shares one virtual store across every project on the machine.
-/// pnpm 11 keeps the project-local `node_modules/.pnpm` instead, enabling
-/// the shared store only for `pnpm install --global`, so this is one of
-/// the defaults the two majors deliberately disagree on.
+/// This is a pnpm 12 default, and one the TypeScript CLI does not share:
+/// pnpm 11 defaults the setting off and reaches for the shared store only
+/// under `pnpm install --global`. The divergence is deliberate, so a
+/// parity check that flags it is looking at a major-version boundary
+/// rather than at a gap.
 ///
 /// [`crate::Config::current`] turns it back off in a CI environment
 /// unless the setting is pinned explicitly.

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -882,8 +882,7 @@ pub struct Config {
     /// project keeps its own virtual store at
     /// `<project>/node_modules/.pnpm`.
     ///
-    /// Defaults to `true`; [`Config::current`] turns it back off in CI
-    /// unless the setting is pinned explicitly. The TypeScript CLI
+    /// Defaults to `true`, in every environment. The TypeScript CLI
     /// defaults it off — see `default_enable_global_virtual_store` in
     /// `crates/config/src/defaults.rs` for why the two majors differ.
     #[default(_code = "default_enable_global_virtual_store()")]
@@ -2859,15 +2858,6 @@ impl Config {
         // workspace is case-sensitive and the home is not.
         if !store_dir_explicit {
             self.resolve_default_store_dir::<Sys>(start_dir);
-        }
-
-        // A shared virtual store buys little in CI, where the store it
-        // is shared through is usually cold anyway. A user who set the
-        // key still gets what they asked for — Nix builds and runners
-        // with a persistent store do keep it warm. Mirrors the pnpm
-        // config reader (`pnpm11/config/reader/src/index.ts`).
-        if self.ci && !self.explicit_settings.contains_key("enableGlobalVirtualStore") {
-            self.enable_global_virtual_store = false;
         }
 
         // Derive `global_virtual_store_dir` last so it sees the final

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -882,10 +882,10 @@ pub struct Config {
     /// project keeps its own virtual store at
     /// `<project>/node_modules/.pnpm`.
     ///
-    /// Defaults to `true` — pnpm 12 shares the virtual store by
-    /// default, where pnpm 11 only did so for `pnpm install --global`.
-    /// [`Config::current`] turns it back off in CI unless the setting
-    /// is pinned explicitly.
+    /// Defaults to `true`; [`Config::current`] turns it back off in CI
+    /// unless the setting is pinned explicitly. The TypeScript CLI
+    /// defaults it off — see `default_enable_global_virtual_store` in
+    /// `crates/config/src/defaults.rs` for why the two majors differ.
     #[default(_code = "default_enable_global_virtual_store()")]
     pub enable_global_virtual_store: bool,
 

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -882,13 +882,10 @@ pub struct Config {
     /// project keeps its own virtual store at
     /// `<project>/node_modules/.pnpm`.
     ///
-    /// Default `false` — the effective default for non-`--global`
-    /// installs. The `true` assignment applies only inside the
-    /// `if (cliOptions['global'])` block (see
-    /// `default_enable_global_virtual_store` in
-    /// `crates/config/src/defaults.rs` for the full reasoning).
-    /// Pacquet has no `--global` flow, so the only applicable
-    /// default is `false`.
+    /// Defaults to `true` — pnpm 12 shares the virtual store by
+    /// default, where pnpm 11 only did so for `pnpm install --global`.
+    /// [`Config::current`] turns it back off in CI unless the setting
+    /// is pinned explicitly.
     #[default(_code = "default_enable_global_virtual_store()")]
     pub enable_global_virtual_store: bool,
 
@@ -902,11 +899,13 @@ pub struct Config {
     /// `SmartDefault` value is overwritten there with the path derived
     /// from the resolved `store_dir` / `virtual_store_dir`. The default
     /// here is only meaningful when `Config::new()` is used in isolation
-    /// (mostly tests).
+    /// (mostly tests), and matches the derivation's own fallback so
+    /// such a config never points the shared store at the working
+    /// directory.
     ///
     /// [`enable_global_virtual_store`]: Self::enable_global_virtual_store
     /// [`virtual_store_dir`]: Self::virtual_store_dir
-    #[default(_code = "default_virtual_store_dir()")]
+    #[default(_code = "default_store_dir::<Host>().links()")]
     pub global_virtual_store_dir: PathBuf,
 
     /// `virtualStoreOnly`: populate the virtual store but perform no
@@ -2860,6 +2859,15 @@ impl Config {
         // workspace is case-sensitive and the home is not.
         if !store_dir_explicit {
             self.resolve_default_store_dir::<Sys>(start_dir);
+        }
+
+        // A shared virtual store buys little in CI, where the store it
+        // is shared through is usually cold anyway. A user who set the
+        // key still gets what they asked for — Nix builds and runners
+        // with a persistent store do keep it warm. Mirrors the pnpm
+        // config reader (`pnpm11/config/reader/src/index.ts`).
+        if self.ci && !self.explicit_settings.contains_key("enableGlobalVirtualStore") {
+            self.enable_global_virtual_store = false;
         }
 
         // Derive `global_virtual_store_dir` last so it sees the final

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -2081,16 +2081,31 @@ pub fn test_current_folder_fallback_to_default() {
 }
 
 #[test]
-pub fn gvs_default_is_off_and_paths_derive_cleanly() {
+pub fn gvs_default_is_on_and_paths_derive_cleanly() {
     let tmp = tempdir().unwrap();
-    let config =
-        Config::new().current::<HostNoHome>(tmp.path()).expect("workspace yaml absent => no error");
-    assert!(
-        !config.enable_global_virtual_store,
-        "GVS defaults to false (matches pnpm v11 for non-global installs)",
-    );
+    let config = Config { ci: false, ..Config::new() }
+        .current::<HostNoHome>(tmp.path())
+        .expect("workspace yaml absent => no error");
+    assert!(config.enable_global_virtual_store, "GVS is on by default in pnpm 12");
     assert_eq!(config.virtual_store_dir, tmp.path().join("node_modules/.pnpm"));
     assert_eq!(config.global_virtual_store_dir, config.store_dir.links());
+}
+
+#[test]
+pub fn ci_turns_gvs_off_unless_the_setting_is_pinned() {
+    let unpinned = tempdir().unwrap();
+    let config = Config { ci: true, ..Config::new() }
+        .current::<HostNoHome>(unpinned.path())
+        .expect("workspace yaml absent => no error");
+    assert!(!config.enable_global_virtual_store, "an unpinned GVS defaults to off in CI");
+
+    let pinned = tempdir().unwrap();
+    fs::write(pinned.path().join("pnpm-workspace.yaml"), "enableGlobalVirtualStore: true\n")
+        .expect("write to pnpm-workspace.yaml");
+    let config = Config { ci: true, ..Config::new() }
+        .current::<HostNoHome>(pinned.path())
+        .expect("yaml is valid");
+    assert!(config.enable_global_virtual_store, "an explicit opt-in survives CI");
 }
 
 #[test]
@@ -2098,7 +2113,9 @@ pub fn gvs_disabled_keeps_project_local_virtual_store() {
     let tmp = tempdir().unwrap();
     fs::write(tmp.path().join("pnpm-workspace.yaml"), "enableGlobalVirtualStore: false\n")
         .expect("write to pnpm-workspace.yaml");
-    let config = Config::new().current::<HostNoHome>(tmp.path()).expect("yaml is valid");
+    let config = Config { ci: false, ..Config::new() }
+        .current::<HostNoHome>(tmp.path())
+        .expect("yaml is valid");
     assert!(!config.enable_global_virtual_store);
     assert_eq!(config.virtual_store_dir, tmp.path().join("node_modules/.pnpm"));
     assert_eq!(config.global_virtual_store_dir, config.store_dir.links());
@@ -2153,11 +2170,9 @@ pub fn gvs_disabled_or_extend_node_path_off_injects_no_resolution_env() {
     }
 }
 
-/// The fixture also enables GVS explicitly. Pacquet's default
-/// is `enableGlobalVirtualStore: false` (matches pnpm v11 for
-/// non-`--global` installs), so without the explicit opt-in the
-/// GVS-on derivation path wouldn't run at all and the test
-/// would say nothing about that path's behaviour.
+/// The fixture also enables GVS explicitly, so the GVS-on derivation
+/// path is exercised even when the suite runs in CI (where an unpinned
+/// `enableGlobalVirtualStore` falls back to `false`).
 #[test]
 pub fn yaml_global_virtual_store_dir_wins_over_derivation() {
     let tmp = tempdir().unwrap();
@@ -2421,7 +2436,12 @@ pub fn global_config_yaml_enables_gvs() {
     host_current_dir!(HostWithXdgConfigHome);
 
     let tmp = tempdir().unwrap();
-    let config = Config::new().current::<HostWithXdgConfigHome>(tmp.path()).expect("config loads");
+    // `ci: true` would drop an unpinned `enableGlobalVirtualStore` back
+    // to `false`, so surviving it is the proof that the global
+    // config.yaml value reached the config rather than the default.
+    let config = Config { ci: true, ..Config::new() }
+        .current::<HostWithXdgConfigHome>(tmp.path())
+        .expect("config loads");
     assert!(
         config.enable_global_virtual_store,
         "enableGlobalVirtualStore from global config.yaml must apply",

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -2082,30 +2082,15 @@ pub fn test_current_folder_fallback_to_default() {
 
 #[test]
 pub fn gvs_default_is_on_and_paths_derive_cleanly() {
-    let tmp = tempdir().unwrap();
-    let config = Config { ci: false, ..Config::new() }
-        .current::<HostNoHome>(tmp.path())
-        .expect("workspace yaml absent => no error");
-    assert!(config.enable_global_virtual_store, "GVS is on by default in pnpm 12");
-    assert_eq!(config.virtual_store_dir, tmp.path().join("node_modules/.pnpm"));
-    assert_eq!(config.global_virtual_store_dir, config.store_dir.links());
-}
-
-#[test]
-pub fn ci_turns_gvs_off_unless_the_setting_is_pinned() {
-    let unpinned = tempdir().unwrap();
-    let config = Config { ci: true, ..Config::new() }
-        .current::<HostNoHome>(unpinned.path())
-        .expect("workspace yaml absent => no error");
-    assert!(!config.enable_global_virtual_store, "an unpinned GVS defaults to off in CI");
-
-    let pinned = tempdir().unwrap();
-    fs::write(pinned.path().join("pnpm-workspace.yaml"), "enableGlobalVirtualStore: true\n")
-        .expect("write to pnpm-workspace.yaml");
-    let config = Config { ci: true, ..Config::new() }
-        .current::<HostNoHome>(pinned.path())
-        .expect("yaml is valid");
-    assert!(config.enable_global_virtual_store, "an explicit opt-in survives CI");
+    for ci in [false, true] {
+        let tmp = tempdir().unwrap();
+        let config = Config { ci, ..Config::new() }
+            .current::<HostNoHome>(tmp.path())
+            .expect("workspace yaml absent => no error");
+        assert!(config.enable_global_virtual_store, "GVS is on by default in pnpm 12; ci: {ci}");
+        assert_eq!(config.virtual_store_dir, tmp.path().join("node_modules/.pnpm"));
+        assert_eq!(config.global_virtual_store_dir, config.store_dir.links());
+    }
 }
 
 #[test]
@@ -2113,9 +2098,7 @@ pub fn gvs_disabled_keeps_project_local_virtual_store() {
     let tmp = tempdir().unwrap();
     fs::write(tmp.path().join("pnpm-workspace.yaml"), "enableGlobalVirtualStore: false\n")
         .expect("write to pnpm-workspace.yaml");
-    let config = Config { ci: false, ..Config::new() }
-        .current::<HostNoHome>(tmp.path())
-        .expect("yaml is valid");
+    let config = Config::new().current::<HostNoHome>(tmp.path()).expect("yaml is valid");
     assert!(!config.enable_global_virtual_store);
     assert_eq!(config.virtual_store_dir, tmp.path().join("node_modules/.pnpm"));
     assert_eq!(config.global_virtual_store_dir, config.store_dir.links());
@@ -2170,9 +2153,6 @@ pub fn gvs_disabled_or_extend_node_path_off_injects_no_resolution_env() {
     }
 }
 
-/// The fixture also enables GVS explicitly, so the GVS-on derivation
-/// path is exercised even when the suite runs in CI (where an unpinned
-/// `enableGlobalVirtualStore` falls back to `false`).
 #[test]
 pub fn yaml_global_virtual_store_dir_wins_over_derivation() {
     let tmp = tempdir().unwrap();
@@ -2397,11 +2377,13 @@ pub fn empty_npm_config_workspace_dir_falls_through() {
 /// `<tempdir>/pnpm/config.yaml` rather than touching the
 /// developer's real config dir.
 #[test]
-pub fn global_config_yaml_enables_gvs() {
+pub fn global_config_yaml_disables_gvs() {
     let xdg = tempdir().unwrap();
     let config_dir = xdg.path().join("pnpm");
     fs::create_dir_all(&config_dir).unwrap();
-    fs::write(config_dir.join("config.yaml"), "enableGlobalVirtualStore: true\n")
+    // Opposite of the default, so the assertion below can only pass if
+    // the global config.yaml layer reached the config.
+    fs::write(config_dir.join("config.yaml"), "enableGlobalVirtualStore: false\n")
         .expect("write to global config.yaml");
 
     static XDG_CONFIG_HOME_PATH: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
@@ -2436,14 +2418,9 @@ pub fn global_config_yaml_enables_gvs() {
     host_current_dir!(HostWithXdgConfigHome);
 
     let tmp = tempdir().unwrap();
-    // `ci: true` would drop an unpinned `enableGlobalVirtualStore` back
-    // to `false`, so surviving it is the proof that the global
-    // config.yaml value reached the config rather than the default.
-    let config = Config { ci: true, ..Config::new() }
-        .current::<HostWithXdgConfigHome>(tmp.path())
-        .expect("config loads");
+    let config = Config::new().current::<HostWithXdgConfigHome>(tmp.path()).expect("config loads");
     assert!(
-        config.enable_global_virtual_store,
+        !config.enable_global_virtual_store,
         "enableGlobalVirtualStore from global config.yaml must apply",
     );
 }

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -115,12 +115,8 @@ pub struct WorkspaceSettings {
     pub node_package_map_type: Option<NodePackageMapType>,
     pub symlink: Option<bool>,
     pub virtual_store_dir: Option<String>,
-    /// `enableGlobalVirtualStore` from `pnpm-workspace.yaml`. Default
-    /// applied in [`Config`] is `false` — matches pnpm v11's
-    /// effective default for non-`--global` installs (the `true`
-    /// default applies only to `pnpm install --global`, and pacquet
-    /// has no `--global` flow). See
-    /// [`Config::enable_global_virtual_store`].
+    /// `enableGlobalVirtualStore` from `pnpm-workspace.yaml`. See
+    /// [`Config::enable_global_virtual_store`] for the default.
     pub enable_global_virtual_store: Option<bool>,
     /// `virtualStoreOnly` from `pnpm-workspace.yaml`. See
     /// [`Config::virtual_store_only`].

--- a/pnpm/crates/deps-restorer/src/build_modules/tests.rs
+++ b/pnpm/crates/deps-restorer/src/build_modules/tests.rs
@@ -2719,6 +2719,7 @@ fn pkg_root_for_key_isolated_uses_layout() {
     config.store_dir = dir.path().join("store").into();
     config.modules_dir = dir.path().join("node_modules");
     config.virtual_store_dir = dir.path().join("node_modules/.pacquet");
+    config.enable_global_virtual_store = false;
     let config = config.leak();
     let layout = VirtualStoreLayout::new(config, None, None, None, None, None);
 

--- a/pnpm/crates/deps-restorer/src/create_virtual_store/tests.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store/tests.rs
@@ -116,6 +116,11 @@ async fn cold_batch_links_slots_in_parallel() {
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir;
     config.virtual_store_dir = virtual_store_dir.clone();
+    // The shared store is the default, and a `Config` that never went
+    // through `Config::current` still points it at the machine's store
+    // rather than the tempdir one assigned above — materializing there
+    // would leave test packages in the developer's real store.
+    config.enable_global_virtual_store = false;
     config.package_import_method = PackageImportMethod::Copy;
     config.offline = true;
     let config = config.leak();

--- a/pnpm/crates/package-manager/src/add/tests.rs
+++ b/pnpm/crates/package-manager/src/add/tests.rs
@@ -3,8 +3,8 @@ use super::{
     persist_selected_manifests, prepare_selected_manifests, selected_project_indices,
     workspace_save_specifier,
 };
-use crate::ResolvedPackages;
-use pacquet_config::{Config, LinkWorkspacePackages};
+use crate::{ResolvedPackages, tests::project_local_config};
+use pacquet_config::LinkWorkspacePackages;
 use pacquet_network::ThrottledClient;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_registry::RangeSpecStyle;
@@ -22,7 +22,7 @@ const SCOPED_TEST_INTEGRITY: &str = "sha512-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 
 #[test]
 fn explicit_npm_specifier_is_not_rewritten_as_a_workspace_dependency() {
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.link_workspace_packages = LinkWorkspacePackages::DirectOnly;
 
     assert_eq!(
@@ -83,7 +83,7 @@ async fn add_routes_scoped_packages_to_configured_scoped_registry() {
         .create_async()
         .await;
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = dir.path().join("pacquet-store").into();
     config.modules_dir = modules_dir;
     config.virtual_store_dir = virtual_store_dir;
@@ -163,7 +163,7 @@ async fn add_resolves_package_selectors_concurrently_and_reports_in_selector_ord
 
     let request_state = Arc::new((Mutex::new(RequestState::default()), Condvar::new()));
     let packages = [("one", "a", 200), ("two", "b", 100), ("three", "c", 0)];
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = dir.path().join("pacquet-store").into();
     config.modules_dir = modules_dir;
     config.virtual_store_dir = virtual_store_dir;
@@ -338,7 +338,7 @@ async fn add_reuses_shared_packument_state_for_every_selector_path() {
         .create_async()
         .await;
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = dir.path().join("pacquet-store").into();
     config.cache_dir = dir.path().join("cache");
     config.modules_dir = modules_dir;
@@ -397,7 +397,7 @@ async fn add_reports_resolution_errors_in_selector_order() {
         .expect("create manifest");
 
     let packages = [("first", "a", 200), ("second", "b", 0)];
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = dir.path().join("pacquet-store").into();
     config.modules_dir = modules_dir;
     config.virtual_store_dir = virtual_store_dir;
@@ -475,7 +475,7 @@ async fn add_does_not_wait_for_a_slower_later_resolution_after_an_error() {
     // peer is still sleeping, with enough slack that a loaded machine
     // cannot push the fast path past the deadline.
     let packages = [("first", "a", 100), ("second", "b", 20_000)];
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = dir.path().join("pacquet-store").into();
     config.modules_dir = modules_dir;
     config.virtual_store_dir = virtual_store_dir;
@@ -643,7 +643,7 @@ async fn selected_add_prepares_and_persists_only_selected_projects() {
     let ordered_dirs = [projects[1].root_dir.clone(), projects[0].root_dir.clone()];
     let selected_dirs = ordered_dirs.iter().cloned().collect::<HashSet<_>>();
     let indices = selected_project_indices(&projects, &ordered_dirs, &selected_dirs);
-    let config = Box::leak(Box::new(Config::new()));
+    let config = Box::leak(Box::new(project_local_config()));
     let http_client = ThrottledClient::default();
     let http_client_arc = Arc::new(ThrottledClient::default());
 
@@ -690,7 +690,7 @@ async fn selected_add_merges_catalog_updates_in_command_order() {
     let ordered_dirs = [projects[1].root_dir.clone(), projects[0].root_dir.clone()];
     let selected_dirs = ordered_dirs.iter().cloned().collect::<HashSet<_>>();
     let indices = selected_project_indices(&projects, &ordered_dirs, &selected_dirs);
-    let config = Box::leak(Box::new(Config::new()));
+    let config = Box::leak(Box::new(project_local_config()));
     let http_client = ThrottledClient::default();
     let http_client_arc = Arc::new(ThrottledClient::default());
 

--- a/pnpm/crates/package-manager/src/catalog_cleanup/tests.rs
+++ b/pnpm/crates/package-manager/src/catalog_cleanup/tests.rs
@@ -1,5 +1,5 @@
 use super::{prune_minimum_release_age_excludes, resolved_package_versions};
-use pacquet_config::Config;
+use crate::tests::project_local_config;
 use pacquet_lockfile::Lockfile;
 use pacquet_package_manifest::PackageManifest;
 use std::path::Path;
@@ -67,7 +67,7 @@ fn skips_the_pass_when_the_workspace_lockfile_is_not_shared() {
         project_dir.join("package.json"),
         serde_json::json!({ "name": "project", "version": "1.0.0" }),
     );
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.minimum_release_age_exclude_prune = true;
     config.shared_workspace_lockfile = false;
 
@@ -100,7 +100,7 @@ fn prunes_against_the_shared_workspace_lockfile() {
         workspace_dir.join("package.json"),
         serde_json::json!({ "name": "project", "version": "1.0.0" }),
     );
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.minimum_release_age_exclude_prune = true;
 
     prune_minimum_release_age_excludes(&config, Some(workspace_dir), &manifest)

--- a/pnpm/crates/package-manager/src/install/tests.rs
+++ b/pnpm/crates/package-manager/src/install/tests.rs
@@ -10,6 +10,7 @@ use super::{
 };
 use crate::{
     AllowBuildPolicy, InstallWithFreshLockfileError, MinimumReleaseAgeError, VirtualStoreLayout,
+    tests::project_local_config,
 };
 use pacquet_config::{Config, NodePackageMapType};
 use pacquet_lockfile::{ComVer, Lockfile, LockfileVersion, MaybeLazyLockfile};
@@ -244,7 +245,7 @@ fn workspace_without_packages_field_enumerates_root_only() {
 
 #[test]
 fn package_map_writer_is_gated_to_supported_pacquet_mode() {
-    let mut config = Config::new();
+    let mut config = project_local_config();
     assert!(crate::should_write_package_map(&config, pacquet_config::NodeLinker::Isolated));
     assert!(!crate::should_write_package_map(&config, pacquet_config::NodeLinker::Hoisted));
     assert!(!crate::should_write_package_map(&config, pacquet_config::NodeLinker::Pnp));
@@ -283,7 +284,7 @@ async fn should_install_dependencies() {
 
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = virtual_store_dir.clone();
@@ -444,7 +445,7 @@ async fn fresh_install_reports_strict_minimum_release_age_violations_before_writ
         .unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = dir.path().join("store").into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = virtual_store_dir;
@@ -516,7 +517,7 @@ async fn fresh_install_persists_loose_minimum_release_age_picks_to_workspace_man
         .unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = dir.path().join("store").into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = virtual_store_dir;
@@ -598,7 +599,7 @@ async fn install_with_drop_all_seed_policy_bumps_dependency_within_range() {
         .unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.lockfile = true;
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
@@ -736,7 +737,7 @@ async fn install_prunes_surplus_virtual_store_dir() {
     let surplus = virtual_store_dir.join("surplus-pkg@9.9.9");
     std::fs::create_dir_all(&surplus).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = virtual_store_dir.clone();
@@ -821,7 +822,7 @@ async fn install_skips_prune_when_virtual_store_escapes_node_modules() {
     let surplus = virtual_store_dir.join("surplus-pkg@9.9.9");
     std::fs::create_dir_all(&surplus).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = virtual_store_dir.clone();
@@ -907,7 +908,7 @@ async fn lockfile_only_routes_scoped_packages_to_configured_scoped_registry() {
         .create_async()
         .await;
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = dir.path().join("pacquet-store").into();
     config.modules_dir = modules_dir;
     config.virtual_store_dir = virtual_store_dir;
@@ -971,7 +972,7 @@ async fn should_error_when_frozen_lockfile_is_requested_but_none_exists() {
     let manifest_path = dir.path().join("package.json");
     let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.lockfile = true;
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
@@ -1031,7 +1032,7 @@ async fn should_error_when_frozen_lockfile_and_update_checksums_are_both_set() {
     let manifest_path = dir.path().join("package.json");
     let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.lockfile = true;
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
@@ -1104,7 +1105,7 @@ async fn frozen_lockfile_flag_overrides_config_lockfile_false() {
     let manifest_path = dir.path().join("package.json");
     let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     // Explicitly disabled — this is the pacquet default today. The
     // CLI flag must still take over.
     config.lockfile = false;
@@ -1199,7 +1200,7 @@ async fn npm_alias_dependency_installs_under_alias_key() {
         .unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = virtual_store_dir.clone();
@@ -1298,7 +1299,7 @@ async fn unversioned_npm_alias_defaults_to_latest() {
         .unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = virtual_store_dir.clone();
@@ -1381,7 +1382,7 @@ async fn frozen_lockfile_flag_with_no_lockfile_errors() {
     let manifest_path = dir.path().join("package.json");
     let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.lockfile = false;
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
@@ -1473,7 +1474,7 @@ async fn install_emits_pnpm_event_sequence() {
     let manifest_path = dir.path().join("package.json");
     let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.lockfile = false;
     config.store_dir = store_dir.clone().into();
     config.modules_dir = modules_dir.clone();
@@ -1635,7 +1636,7 @@ async fn install_writes_modules_yaml() {
     let manifest_path = dir.path().join("package.json");
     let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.lockfile = false;
     config.store_dir = store_dir.clone().into();
     config.modules_dir = modules_dir.clone();
@@ -1759,7 +1760,7 @@ async fn install_writes_workspace_state() {
     let manifest_path = dir.path().join("package.json");
     let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.lockfile = false;
     config.store_dir = store_dir.clone().into();
     config.modules_dir = modules_dir.clone();
@@ -1883,7 +1884,7 @@ async fn install_writes_workspace_state() {
 /// every workspace project, not just the root.
 mod build_workspace_state_tests {
     use super::super::build_workspace_state;
-    use pacquet_config::Config;
+    use crate::tests::project_local_config;
     use pacquet_modules_yaml::IncludedDependencies;
     use pacquet_package_manifest::PackageManifest;
     use pacquet_workspace_state::ConfigDependency;
@@ -1902,7 +1903,7 @@ mod build_workspace_state_tests {
     #[test]
     fn empty_project_list_produces_empty_projects_map() {
         let dir = tempdir().unwrap();
-        let config = Config::new();
+        let config = project_local_config();
         let state = build_workspace_state(
             dir.path(),
             &config,
@@ -1937,7 +1938,7 @@ mod build_workspace_state_tests {
         let project_manifests: Vec<(PathBuf, &PackageManifest)> =
             manifests.iter().map(|(p, m)| (p.clone(), m)).collect();
 
-        let config = Config::new();
+        let config = project_local_config();
         let state = build_workspace_state(
             dir.path(),
             &config,
@@ -1969,7 +1970,7 @@ mod build_workspace_state_tests {
     /// stale, and reinstalls on every `pnpm run` / `pnpm node`.
     #[test]
     fn records_config_dependencies_from_config() {
-        let mut config = Config::new();
+        let mut config = project_local_config();
         config.config_dependencies = Some(BTreeMap::from([(
             "@pnpm/pacquet".to_string(),
             ConfigDependency::VersionWithIntegrity("0.2.2-14".to_string()),
@@ -2020,7 +2021,7 @@ async fn install_optional_failing_postinstall_dep_via_registry_mock_succeeds() {
         .unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = virtual_store_dir.clone();
@@ -2111,7 +2112,7 @@ async fn auto_install_peers_does_not_cascade_optional_peers() {
         .unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = virtual_store_dir.clone();
@@ -2222,7 +2223,7 @@ async fn meta_only_optional_peers_absent_from_the_graph_are_not_installed() {
         .unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = virtual_store_dir.clone();
@@ -2327,7 +2328,7 @@ async fn root_dependency_does_not_override_peers_of_self_contained_subtree() {
     manifest.add_dependency("@pnpm.e2e/closure-peer-x", "2.0.0", DependencyGroup::Prod).unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = virtual_store_dir;
@@ -2455,7 +2456,7 @@ async fn warm_reinstall_skips_snapshot_when_current_lockfile_matches() {
     manifest.add_dependency("placeholder", "1.0.0", DependencyGroup::Prod).unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     // Opt out of the (now-default) global virtual store: the
     // `seed_placeholder_virtual_store_slot` helper writes the legacy
     // `<virtual_store_dir>/<flat-name>` shape, which only matches the
@@ -2561,7 +2562,7 @@ async fn warm_reinstall_emits_broken_modules_when_dir_is_missing() {
     manifest.add_dependency("placeholder", "1.0.0", DependencyGroup::Prod).unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     // Opt out of the GVS layout — see the rationale on
     // [`warm_reinstall_skips_snapshot_when_current_lockfile_matches`].
     // The pre-seeded `<virtual_store_dir>/<flat-name>` slot is the
@@ -2684,7 +2685,7 @@ async fn context_log_reflects_current_lockfile_after_first_install() {
     manifest.add_dependency("placeholder", "1.0.0", DependencyGroup::Prod).unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = virtual_store_dir.clone();
@@ -2870,7 +2871,7 @@ async fn warm_reinstall_reports_added_zero_and_emits_no_imported_events() {
     manifest.add_dependency("placeholder", "1.0.0", DependencyGroup::Prod).unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     // Opt out of the GVS layout — the pre-seeded
     // `<virtual_store_dir>/<flat-name>` slot is the legacy shape the
     // skip probe matches under
@@ -2997,7 +2998,7 @@ async fn frozen_lockfile_errors_when_manifest_drifts_from_lockfile() {
     // drift case the check has to catch.
     let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = virtual_store_dir;
@@ -3075,7 +3076,7 @@ async fn ignore_manifest_check_bypasses_manifest_freshness_gate() {
     // install must accept the drift and move on to materialization.
     let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = virtual_store_dir;
@@ -3145,7 +3146,7 @@ async fn frozen_lockfile_errors_when_overrides_drift_from_lockfile() {
     let manifest_path = dir.path().join("package.json");
     let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = virtual_store_dir;
@@ -3238,7 +3239,7 @@ async fn frozen_lockfile_applies_overrides_to_manifest_before_freshness_check() 
     .unwrap();
     let manifest = PackageManifest::from_path(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = virtual_store_dir;
@@ -3358,7 +3359,7 @@ async fn frozen_lockfile_resolves_catalog_protocol_in_overrides_before_freshness
     .unwrap();
     let manifest = PackageManifest::from_path(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = virtual_store_dir;
@@ -3455,7 +3456,7 @@ async fn frozen_lockfile_errors_when_lockfile_has_no_root_importer() {
     let manifest_path = dir.path().join("package.json");
     let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = virtual_store_dir;
@@ -3514,10 +3515,7 @@ async fn frozen_lockfile_errors_when_lockfile_has_no_root_importer() {
 }
 
 /// GVS-on frozen-lockfile install. With
-/// `enable_global_virtual_store: true` (an explicit opt-in;
-/// pacquet's default is `false`, matching pnpm v11's effective
-/// default for non-`--global` installs — see
-/// [`pacquet_config::default_enable_global_virtual_store`]),
+/// `enable_global_virtual_store: true`,
 /// `Install::run` registers the project at
 /// `<store_dir>/projects/<short-hash>`
 /// and routes every per-snapshot slot through
@@ -3544,9 +3542,7 @@ async fn frozen_lockfile_under_gvs_registers_project_and_runs_clean() {
     let manifest_path = project_root.join("package.json");
     let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
 
-    let mut config = Config::new();
-    // Pin GVS on explicitly — pacquet's default is `false`, so this
-    // test would test the wrong path otherwise.
+    let mut config = project_local_config();
     config.enable_global_virtual_store = true;
     config.lockfile = false;
     config.store_dir = store_dir.clone().into();
@@ -3652,7 +3648,7 @@ async fn fresh_partial_install_preserves_optional_link_in_warm_gvs_slot() {
     manifest.add_dependency("@pnpm.e2e/peer-c", "link:../peer-c", DependencyGroup::Prod).unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.enable_global_virtual_store = true;
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir;
@@ -3808,7 +3804,7 @@ async fn gvs_persists_global_virtual_store_dir_in_modules_yaml_and_context_log()
     let manifest_path = project_root.join("package.json");
     let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     // GVS on — the whole point of the test.
     config.enable_global_virtual_store = true;
     config.lockfile = false;
@@ -3948,7 +3944,7 @@ async fn frozen_lockfile_with_gvs_off_skips_project_registry() {
     let manifest_path = project_root.join("package.json");
     let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.enable_global_virtual_store = false;
     config.lockfile = false;
     config.store_dir = store_dir.clone().into();
@@ -4036,7 +4032,7 @@ async fn frozen_lockfile_under_gvs_registers_workspace_root_only() {
     let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
     std::fs::write(web_dir.join("package.json"), "{}").expect("write packages/web/package.json");
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.enable_global_virtual_store = true;
     config.lockfile = false;
     config.store_dir = store_dir.clone().into();
@@ -4143,7 +4139,7 @@ fn build_modules_manifest_serializes_skipped_set() {
     use std::collections::HashSet;
 
     let dir = tempdir().unwrap();
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = dir.path().join("store").into();
     config.modules_dir = dir.path().join("node_modules");
     config.virtual_store_dir = dir.path().join("node_modules/.pacquet");
@@ -4193,7 +4189,7 @@ fn build_modules_manifest_skipped_is_empty_on_empty_set() {
     use pacquet_modules_yaml::IncludedDependencies;
 
     let dir = tempdir().unwrap();
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = dir.path().join("store").into();
     config.modules_dir = dir.path().join("node_modules");
     config.virtual_store_dir = dir.path().join("node_modules/.pacquet");
@@ -4243,7 +4239,7 @@ async fn frozen_install_preserves_seeded_skipped_across_reinstall() {
     let manifest_path = dir.path().join("package.json");
     let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.lockfile = false;
     config.store_dir = store_dir.clone().into();
     config.modules_dir = modules_dir.clone();
@@ -4388,7 +4384,7 @@ async fn frozen_install_silently_swallows_unreachable_optional_tarball() {
     manifest.add_dependency("broken-pkg", "1.0.0", DependencyGroup::Optional).unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.lockfile = false;
     // Opt out of the GVS layout so the assertion below can stat the
     // legacy `<virtual_store_dir>/<flat-name>` slot directly. With
@@ -4512,7 +4508,7 @@ async fn frozen_install_propagates_non_optional_fetch_failure() {
     manifest.add_dependency("broken-pkg", "1.0.0", DependencyGroup::Prod).unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.lockfile = false;
     // Match the sister test's GVS-off setup so both swallow tests
     // route through the same layout — sidesteps any GVS-routing
@@ -4627,7 +4623,7 @@ async fn frozen_install_no_optional_drops_optional_only_snapshots() {
     manifest.add_dependency("drop-me", "1.0.0", DependencyGroup::Optional).unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.lockfile = false;
     // Opt out of GVS so the slot-path assertion targets the legacy
     // `<virtual_store_dir>/<flat-name>` layout. Same pattern as the
@@ -4740,7 +4736,7 @@ async fn frozen_install_optional_included_surfaces_missing_metadata() {
     manifest.add_dependency("drop-me", "1.0.0", DependencyGroup::Optional).unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.lockfile = false;
     config.enable_global_virtual_store = false;
     config.store_dir = store_dir.into();
@@ -4848,7 +4844,7 @@ async fn frozen_install_no_optional_keeps_shared_non_optional_snapshot() {
     manifest.add_dependency("shared", "1.0.0", DependencyGroup::Optional).unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.lockfile = false;
     config.enable_global_virtual_store = false;
     config.store_dir = store_dir.into();
@@ -4952,7 +4948,7 @@ async fn hoisted_node_linker_empty_lockfile_writes_modules_yaml() {
     let manifest_path = project_root.join("package.json");
     let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.lockfile = false;
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
@@ -5056,7 +5052,7 @@ async fn hoisted_node_linker_does_not_create_virtual_store_root() {
     let manifest_path = project_root.join("package.json");
     let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.lockfile = false;
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
@@ -5147,7 +5143,7 @@ async fn frozen_lockfile_install_errors_when_no_variant_matches_host() {
     manifest.add_dependency("node", "runtime:22.0.0", DependencyGroup::Prod).unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = virtual_store_dir.clone();
@@ -5261,7 +5257,7 @@ async fn frozen_lockfile_install_skips_runtime_when_skip_runtimes_set() {
     manifest.add_dependency("node", "runtime:22.0.0", DependencyGroup::Prod).unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = virtual_store_dir.clone();
@@ -5386,7 +5382,7 @@ async fn install_rejects_invalid_minimum_release_age_exclude_pattern() {
     let manifest_path = dir.path().join("package.json");
     let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir;
     config.virtual_store_dir = virtual_store_dir;
@@ -5491,7 +5487,7 @@ async fn frozen_lockfile_gate_rejects_under_huge_minimum_release_age() {
         .unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir;
     config.virtual_store_dir = virtual_store_dir;
@@ -5615,7 +5611,7 @@ async fn fresh_install_writes_pnpm_lock_yaml_with_expected_shape() {
         .unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = virtual_store_dir;
@@ -5706,7 +5702,7 @@ async fn fresh_install_uses_final_peer_suffix_for_transitive_pending_peer() {
     manifest.add_dependency("@pnpm.e2e/final-peer-c", "1.0.0", DependencyGroup::Prod).unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = virtual_store_dir;
@@ -5793,7 +5789,7 @@ async fn fresh_install_splits_dev_and_prod_dependency_sections() {
     manifest.add_dependency("@pnpm/xyz", "1.0.0", DependencyGroup::Dev).unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = virtual_store_dir;
@@ -5877,7 +5873,7 @@ async fn fresh_install_records_user_written_specifier() {
         .unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = virtual_store_dir;
@@ -5959,7 +5955,7 @@ async fn fresh_install_lockfile_round_trips_through_load_save_load() {
         .unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = virtual_store_dir;
@@ -6039,7 +6035,7 @@ async fn fresh_install_with_lockfile_disabled_does_not_write_a_lockfile() {
         .unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.lockfile = false;
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
@@ -6123,7 +6119,7 @@ async fn fresh_install_also_writes_current_lockfile_under_virtual_store() {
         .unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = virtual_store_dir.clone();
@@ -6220,7 +6216,7 @@ async fn prefer_frozen_install_writes_missing_current_lockfile() {
         .unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir;
     config.virtual_store_dir = virtual_store_dir.clone();
@@ -6339,7 +6335,7 @@ async fn fresh_install_with_lockfile_disabled_skips_current_lockfile_too() {
         .unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.lockfile = false;
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
@@ -6418,7 +6414,7 @@ async fn fresh_install_marks_optional_snapshots_in_pnpm_lock_yaml() {
     manifest.add_dependency("@pnpm/xyz", "1.0.0", DependencyGroup::Optional).unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = virtual_store_dir.clone();
@@ -6523,7 +6519,7 @@ async fn fresh_install_skips_platform_incompatible_optional_dependency() {
         .unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.enable_global_virtual_store = false;
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
@@ -6639,7 +6635,7 @@ async fn fresh_install_hoisted_node_linker_records_modules_yaml() {
     let manifest_path = project_root.join("package.json");
     let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.lockfile = false;
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
@@ -6722,7 +6718,7 @@ async fn fresh_install_honors_skip_runtimes() {
     let manifest_path = dir.path().join("package.json");
     let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = virtual_store_dir.clone();
@@ -6796,7 +6792,7 @@ async fn prefer_frozen_lockfile_takes_frozen_path_when_lockfile_is_fresh() {
     manifest.add_dependency("placeholder", "1.0.0", DependencyGroup::Prod).unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     // Same legacy-layout opt-out as the sibling skip test — the seed
     // helper writes the flat-name slot shape.
     config.enable_global_virtual_store = false;
@@ -6880,7 +6876,7 @@ async fn no_prefer_frozen_lockfile_flag_forces_fresh_resolve() {
     manifest.add_dependency("placeholder", "1.0.0", DependencyGroup::Prod).unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     // Force the resolver onto an unreachable registry so the
     // fresh-resolve path errors out clearly; the frozen path would
     // never consult the registry at all.
@@ -6973,7 +6969,7 @@ async fn stale_lockfile_under_no_flag_falls_through_to_fresh_resolve() {
         .unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.registry = "http://invalid.local/".to_string();
     config.enable_global_virtual_store = false;
     config.store_dir = store_dir.into();
@@ -7043,7 +7039,7 @@ fn unapproved_recorded_ignored_builds_surfaces_invalid_allow_builds() {
         ignored_builds: Some([pacquet_modules_yaml::DepPath::from("pkg@1.0.0".to_string())].into()),
         ..Default::default()
     };
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.allow_builds.insert("foo@not-a-version".to_string(), true);
     let config = config.leak();
 
@@ -7220,7 +7216,7 @@ fn filtered_modules_metadata_keeps_empty_optional_maps_omitted() {
 fn is_modules_yaml_consistent_returns_false_when_modules_yaml_absent() {
     let dir = tempdir().unwrap();
     let modules_dir = dir.path().join("node_modules");
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.modules_dir = modules_dir.clone();
     let config = config.leak();
 
@@ -7243,7 +7239,7 @@ fn is_modules_yaml_consistent_returns_true_when_settings_match() {
     let dir = tempdir().unwrap();
     let modules_dir = dir.path().join("node_modules");
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = dir.path().join("pacquet-store").into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = modules_dir.join(".pacquet");
@@ -7284,7 +7280,7 @@ fn is_modules_yaml_consistent_returns_false_when_node_linker_drifts() {
     let dir = tempdir().unwrap();
     let modules_dir = dir.path().join("node_modules");
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = dir.path().join("pacquet-store").into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = modules_dir.join(".pacquet");
@@ -7319,7 +7315,7 @@ fn is_modules_yaml_consistent_returns_false_when_included_drifts() {
     let dir = tempdir().unwrap();
     let modules_dir = dir.path().join("node_modules");
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = dir.path().join("pacquet-store").into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = modules_dir.join(".pacquet");
@@ -7370,7 +7366,7 @@ fn included_drift_alone_does_not_make_the_layout_inconsistent() {
     let dir = tempdir().unwrap();
     let modules_dir = dir.path().join("node_modules");
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = dir.path().join("pacquet-store").into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = modules_dir.join(".pacquet");
@@ -7424,7 +7420,7 @@ fn layout_drift_still_makes_the_layout_inconsistent() {
     let dir = tempdir().unwrap();
     let modules_dir = dir.path().join("node_modules");
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = dir.path().join("pacquet-store").into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = modules_dir.join(".pacquet");
@@ -7463,7 +7459,7 @@ async fn run_purge_regression_install(
     dependency_groups: Vec<DependencyGroup>,
     virtual_store_dir_max_length: u64,
 ) {
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = store_dir.to_path_buf().into();
     config.modules_dir = modules_dir.to_path_buf();
     config.virtual_store_dir = virtual_store_dir.to_path_buf();
@@ -7642,7 +7638,7 @@ async fn frozen_install_short_circuits_when_modules_and_lockfile_are_consistent(
     manifest.add_dependency("sibling", "link:../sibling", DependencyGroup::Prod).unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.lockfile = false;
     config.store_dir = store_dir.clone().into();
     config.modules_dir = modules_dir.clone();
@@ -7813,7 +7809,7 @@ async fn optimistic_repeat_install_skips_entire_pipeline_when_state_is_fresh() {
     std::fs::write(project_root.join("pnpm-lock.yaml"), "lockfileVersion: '9.0'\n")
         .expect("seed pnpm-lock.yaml");
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.lockfile = false;
     config.store_dir = store_dir.clone().into();
     config.modules_dir = modules_dir.clone();
@@ -7970,7 +7966,7 @@ fn sync_fast_path_matches_optimistic_short_circuit() {
     std::fs::write(project_root.join("pnpm-lock.yaml"), "lockfileVersion: '9.0'\n")
         .expect("seed pnpm-lock.yaml");
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.lockfile = false;
     config.store_dir = dir.path().join("pacquet-store").into();
     config.modules_dir = modules_dir.clone();
@@ -8074,7 +8070,7 @@ fn sync_fast_path_reads_the_workspace_root_wanted_lockfile_from_a_member() {
     let wanted_path = workspace_root.join(Lockfile::FILE_NAME);
     std::fs::write(&wanted_path, current).expect("write wanted lockfile");
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.workspace_dir = Some(workspace_root.clone());
     config.store_dir = dir.path().join("pacquet-store").into();
     config.modules_dir = modules_dir;
@@ -8189,7 +8185,7 @@ async fn frozen_lockfile_disables_optimistic_short_circuit() {
     manifest.add_dependency("sibling", "link:../sibling", DependencyGroup::Prod).unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.lockfile = false;
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
@@ -8345,7 +8341,7 @@ async fn partial_install_disables_optimistic_short_circuit() {
     manifest.add_dependency("sibling", "link:../sibling", DependencyGroup::Prod).unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.lockfile = false;
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
@@ -8506,7 +8502,7 @@ async fn optimistic_repeat_install_does_not_short_circuit_when_lockfile_missing(
     // current `lock.yaml` in the virtual store — that's the scenario
     // under test.
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.lockfile = false;
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
@@ -8650,7 +8646,7 @@ async fn optimistic_repeat_install_round_trips_on_single_project_install() {
         .unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = virtual_store_dir;
@@ -8819,7 +8815,7 @@ async fn fresh_install_records_lockfile_verification_for_mtime_bypassed_noop() {
         .unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.cache_dir = cache_dir.clone();
     config.store_dir = store_dir.clone().into();
     config.modules_dir = modules_dir.clone();
@@ -8893,7 +8889,7 @@ async fn fresh_install_records_lockfile_verification_for_mtime_bypassed_noop() {
         }
     }
 
-    let mut second_config = Config::new();
+    let mut second_config = project_local_config();
     second_config.cache_dir = cache_dir;
     second_config.store_dir = store_dir.into();
     second_config.modules_dir = modules_dir;
@@ -8992,7 +8988,7 @@ async fn install_then_go_offline() -> (tempfile::TempDir, &'static Config, Packa
         .unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.cache_dir = cache_dir.clone();
     config.store_dir = store_dir.clone().into();
     config.modules_dir = modules_dir.clone();
@@ -9045,7 +9041,7 @@ async fn install_then_go_offline() -> (tempfile::TempDir, &'static Config, Packa
     // regression can't hide behind a cache hit.
     std::fs::remove_dir_all(&cache_dir).expect("wipe the cache dir");
 
-    let mut offline_config = Config::new();
+    let mut offline_config = project_local_config();
     offline_config.cache_dir = cache_dir;
     offline_config.store_dir = store_dir.into();
     offline_config.modules_dir = modules_dir;
@@ -9331,7 +9327,7 @@ async fn fresh_lockfile_only_with_overrides(
     }
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir;
     config.virtual_store_dir = virtual_store_dir;
@@ -9452,7 +9448,7 @@ async fn fresh_lockfile_only_with_compatibility_db(
     manifest.add_dependency("debug", "4.0.0", DependencyGroup::Prod).unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir;
     config.virtual_store_dir = virtual_store_dir;
@@ -9533,7 +9529,7 @@ async fn fresh_install_applies_package_extensions_to_dependency_manifest() {
         .unwrap();
     manifest.save().unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = virtual_store_dir;
@@ -9644,7 +9640,7 @@ async fn frozen_lockfile_errors_when_package_extensions_drift_from_lockfile() {
     let manifest_path = dir.path().join("package.json");
     let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = store_dir.into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = virtual_store_dir;
@@ -9724,7 +9720,7 @@ async fn frozen_lockfile_errors_when_pnpmfile_checksum_drifts() {
     std::fs::create_dir_all(&project_root).unwrap();
     let manifest = PackageManifest::create_if_needed(project_root.join("package.json")).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = dir.path().join("pacquet-store").into();
     config.modules_dir = modules_dir.clone();
     config.virtual_store_dir = modules_dir.join(".pacquet");
@@ -9821,7 +9817,7 @@ async fn install_with_pnpmfile_reporter<Reporter: self::Reporter + 'static>(
 
     std::fs::write(root.join(".pnpmfile.cjs"), pnpmfile_src).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = root.join("pacquet-store").into();
     config.modules_dir = modules_dir;
     config.virtual_store_dir = virtual_store_dir;
@@ -9981,7 +9977,7 @@ async fn install_workspace_member_with_pnpmfile(
     std::fs::write(root.join(".pnpmfile.cjs"), pnpmfile_src).unwrap();
 
     let modules_dir = root.join("node_modules");
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.workspace_dir = Some(root.to_path_buf());
     config.store_dir = root.join("pacquet-store").into();
     config.virtual_store_dir = modules_dir.join(".pacquet");
@@ -10431,13 +10427,13 @@ async fn test_install_purges_node_modules_on_layout_mismatch() {
     std::fs::create_dir_all(&project_root).unwrap();
     let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
 
-    let mut config_isolated = Config::new();
+    let mut config_isolated = project_local_config();
     config_isolated.lockfile = false;
     config_isolated.store_dir = store_dir.clone().into();
     config_isolated.modules_dir = modules_dir.clone();
     config_isolated.virtual_store_dir = virtual_store_dir.clone();
 
-    let mut config_hoisted = Config::new();
+    let mut config_hoisted = project_local_config();
     config_hoisted.lockfile = false;
     config_hoisted.store_dir = store_dir.clone().into();
     config_hoisted.modules_dir = modules_dir.clone();
@@ -10566,13 +10562,13 @@ async fn test_install_resolve_only_ignores_layout_mismatch() {
     std::fs::create_dir_all(&project_root).unwrap();
     let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
 
-    let mut config_isolated = Config::new();
+    let mut config_isolated = project_local_config();
     config_isolated.lockfile = false;
     config_isolated.store_dir = store_dir.clone().into();
     config_isolated.modules_dir = modules_dir.clone();
     config_isolated.virtual_store_dir = virtual_store_dir.clone();
 
-    let mut config_hoisted = Config::new();
+    let mut config_hoisted = project_local_config();
     config_hoisted.lockfile = false;
     config_hoisted.store_dir = store_dir.clone().into();
     config_hoisted.modules_dir = modules_dir.clone();

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile/tests.rs
@@ -3,6 +3,7 @@ use super::{
     full_resolution_required, include_transitive_optional_dependencies,
     is_partial_workspace_selection, update_reuse_scopes,
 };
+use crate::tests::project_local_config;
 use pacquet_config::{Config, PackageExtension};
 use pacquet_package_manifest::DependencyGroup;
 use pretty_assertions::assert_eq;
@@ -19,7 +20,7 @@ fn config_with_extensions(entries: &[(&str, &[(&str, &str)])]) -> Box<Config> {
             PackageExtension { dependencies: Some(dependencies), ..Default::default() },
         );
     }
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.package_extensions = Some(extensions);
     Box::new(config)
 }
@@ -76,7 +77,7 @@ fn compute_checksum_is_order_invariant_across_outer_keys() {
 /// fields and the drift gate would fire on no-op installs.
 #[test]
 fn compute_checksum_is_none_when_extensions_absent() {
-    let config = Config::new();
+    let config = project_local_config();
     assert_eq!(compute_package_extensions_checksum(&config), None);
 }
 
@@ -88,7 +89,7 @@ fn compute_checksum_is_none_when_extensions_absent() {
 /// field, causing spurious drift on cross-tool installs.
 #[test]
 fn compute_checksum_is_none_for_explicit_empty_map() {
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.package_extensions = Some(indexmap::IndexMap::new());
     assert_eq!(compute_package_extensions_checksum(&config), None);
 }

--- a/pnpm/crates/package-manager/src/minimum_release_age/tests.rs
+++ b/pnpm/crates/package-manager/src/minimum_release_age/tests.rs
@@ -1,6 +1,6 @@
 use std::{fs, sync::Mutex};
 
-use pacquet_config::Config;
+use crate::tests::project_local_config;
 use pacquet_lockfile::{LockfileResolution, RegistryResolution};
 use pacquet_reporter::{LogEvent, PromptAction, Reporter, SilentReporter};
 use pacquet_resolving_resolver_base::ResolutionPolicyViolation;
@@ -94,7 +94,7 @@ macro_rules! recording_reporter {
 
 #[test]
 fn strict_no_save_is_rejected_before_resolution() {
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.minimum_release_age = Some(60);
     config.minimum_release_age_strict = Some(true);
 
@@ -114,7 +114,7 @@ fn strict_no_save_is_rejected_before_resolution() {
 #[tokio::test]
 async fn non_interactive_strict_mode_reports_every_immature_pick() {
     let dir = tempdir().expect("temp dir");
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.minimum_release_age_strict = Some(true);
     let mut prompt = FakePrompt::default();
     let violations = vec![
@@ -152,7 +152,7 @@ async fn approval_persists_canonical_excludes_and_brackets_the_prompt() {
         "packages:\n  - packages/*\nminimumReleaseAgeExclude:\n  - foo@1.0.0\n",
     )
     .expect("write workspace manifest");
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.minimum_release_age_strict = Some(true);
     config.minimum_release_age_exclude = Some(vec!["foo@1.0.0".to_string()]);
     let mut prompt = FakePrompt { answer: true, messages: Vec::new() };
@@ -193,7 +193,7 @@ async fn loose_mode_persists_excludes_without_prompting() {
         "packages:\n  - packages/*\nminimumReleaseAgeExclude:\n  - foo@1.0.0\n",
     )
     .expect("write workspace manifest");
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.minimum_release_age = Some(60);
     config.minimum_release_age_exclude = Some(vec!["foo@1.0.0".to_string()]);
     let mut prompt = FakePrompt::default();
@@ -244,7 +244,7 @@ async fn strict_approval_without_persistence_proceeds_but_leaves_the_workspace_m
     let path = dir.path().join("pnpm-workspace.yaml");
     fs::write(&path, "packages:\n  - packages/*\n").expect("write workspace manifest");
     let original = fs::read_to_string(&path).expect("read original");
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.minimum_release_age_strict = Some(true);
     let mut prompt = FakePrompt { answer: true, messages: Vec::new() };
 
@@ -272,7 +272,7 @@ async fn loose_mode_without_persistence_leaves_the_workspace_manifest_unchanged(
     let path = dir.path().join("pnpm-workspace.yaml");
     fs::write(&path, "packages:\n  - packages/*\n").expect("write workspace manifest");
     let original = fs::read_to_string(&path).expect("read original");
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.minimum_release_age = Some(60);
     let mut prompt = FakePrompt::default();
 
@@ -300,7 +300,7 @@ async fn denying_approval_leaves_the_workspace_manifest_unchanged() {
     let path = dir.path().join("pnpm-workspace.yaml");
     fs::write(&path, "packages:\n  - packages/*\n").expect("write workspace manifest");
     let original = fs::read_to_string(&path).expect("read original");
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.minimum_release_age_strict = Some(true);
     let mut prompt = FakePrompt::default();
 
@@ -325,7 +325,7 @@ async fn prompt_input_error_releases_the_reporter() {
     recording_reporter!(reset_events, prompt_actions);
     reset_events();
     let dir = tempdir().expect("temp dir");
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.minimum_release_age_strict = Some(true);
 
     let error = handle_minimum_release_age_violations_with::<RecordingReporter, _>(

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
@@ -8,6 +8,7 @@ use super::{
     settings::{current_settings, current_settings_with_catalogs},
     timestamps::{FileMtime, lockfile_modified_since, modified_at_or_after},
 };
+use crate::tests::project_local_config;
 use indexmap::IndexMap;
 use pacquet_catalogs_types::Catalogs;
 use pacquet_config::Config;
@@ -201,7 +202,7 @@ fn setup_fresh_install_with_config(
     // the same millisecond bucket and `<=` vs `<` flips the test.
     sleep(Duration::from_millis(20));
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.modules_dir = workspace_root.join("node_modules");
     configure(&mut config);
     let config = Box::leak(Box::new(config));
@@ -736,7 +737,7 @@ fn returns_skipped_when_config_disabled() {
     fs::write(&manifest_path, r#"{"name":"root","version":"1.0.0"}"#).unwrap();
     let manifest = PackageManifest::from_path(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.modules_dir = workspace_root.join("node_modules");
     config.optimistic_repeat_install = false;
     let config = config.leak();
@@ -763,7 +764,7 @@ fn returns_skipped_when_no_state_file() {
     fs::write(&manifest_path, r#"{"name":"root","version":"1.0.0"}"#).unwrap();
     let manifest = PackageManifest::from_path(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.modules_dir = workspace_root.join("node_modules");
     let config = config.leak();
 
@@ -859,7 +860,7 @@ fn returns_skipped_when_overrides_drift() {
     fs::write(&manifest_path, r#"{"name":"root","version":"1.0.0"}"#).unwrap();
     let manifest = PackageManifest::from_path(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.modules_dir = workspace_root.join("node_modules");
     fs::create_dir_all(&config.modules_dir).unwrap();
     let mut overrides = indexmap::IndexMap::new();
@@ -868,7 +869,7 @@ fn returns_skipped_when_overrides_drift() {
     let config = config.leak();
 
     // Cached state has `foo: "1.0.0"` for the same key.
-    let mut stale_overrides_config = Config::new();
+    let mut stale_overrides_config = project_local_config();
     stale_overrides_config.modules_dir = config.modules_dir.clone();
     let mut overrides = indexmap::IndexMap::new();
     overrides.insert("foo".to_string(), "1.0.0".to_string());
@@ -909,13 +910,13 @@ fn returns_skipped_when_inject_workspace_packages_drifts() {
     fs::write(&manifest_path, r#"{"name":"root","version":"1.0.0"}"#).unwrap();
     let manifest = PackageManifest::from_path(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.modules_dir = workspace_root.join("node_modules");
     fs::create_dir_all(&config.modules_dir).unwrap();
     config.inject_workspace_packages = true;
     let config = config.leak();
 
-    let mut stale_config = Config::new();
+    let mut stale_config = project_local_config();
     stale_config.modules_dir = config.modules_dir.clone();
     stale_config.inject_workspace_packages = false;
     let stale_settings = current_settings(
@@ -953,13 +954,13 @@ fn returns_skipped_when_enable_global_virtual_store_drifts() {
     fs::write(&manifest_path, r#"{"name":"root","version":"1.0.0"}"#).unwrap();
     let manifest = PackageManifest::from_path(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.modules_dir = workspace_root.join("node_modules");
     fs::create_dir_all(&config.modules_dir).unwrap();
     config.enable_global_virtual_store = true;
     let config = config.leak();
 
-    let mut stale_config = Config::new();
+    let mut stale_config = project_local_config();
     stale_config.modules_dir = config.modules_dir.clone();
     stale_config.enable_global_virtual_store = false;
     let stale_settings = current_settings(
@@ -1027,13 +1028,13 @@ fn returns_skipped_when_exclude_links_from_lockfile_drifts() {
     fs::write(&manifest_path, r#"{"name":"root","version":"1.0.0"}"#).unwrap();
     let manifest = PackageManifest::from_path(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.modules_dir = workspace_root.join("node_modules");
     fs::create_dir_all(&config.modules_dir).unwrap();
     config.exclude_links_from_lockfile = true;
     let config = config.leak();
 
-    let mut stale_config = Config::new();
+    let mut stale_config = project_local_config();
     stale_config.modules_dir = config.modules_dir.clone();
     stale_config.exclude_links_from_lockfile = false;
     let stale_settings = current_settings(
@@ -1070,13 +1071,13 @@ fn returns_skipped_when_minimum_release_age_drifts() {
     fs::write(&manifest_path, r#"{"name":"root","version":"1.0.0"}"#).unwrap();
     let manifest = PackageManifest::from_path(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.modules_dir = workspace_root.join("node_modules");
     fs::create_dir_all(&config.modules_dir).unwrap();
     config.minimum_release_age = Some(2880);
     let config = config.leak();
 
-    let mut stale_config = Config::new();
+    let mut stale_config = project_local_config();
     stale_config.modules_dir = config.modules_dir.clone();
     stale_config.minimum_release_age = Some(1440);
     let stale_settings = current_settings(
@@ -1112,13 +1113,13 @@ fn returns_skipped_when_minimum_release_age_ignore_missing_time_drifts() {
     fs::write(&manifest_path, r#"{"name":"root","version":"1.0.0"}"#).unwrap();
     let manifest = PackageManifest::from_path(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.modules_dir = workspace_root.join("node_modules");
     fs::create_dir_all(&config.modules_dir).unwrap();
     config.minimum_release_age_ignore_missing_time = false;
     let config = config.leak();
 
-    let mut stale_config = Config::new();
+    let mut stale_config = project_local_config();
     stale_config.modules_dir = config.modules_dir.clone();
     stale_config.minimum_release_age_ignore_missing_time = true;
     let stale_settings = current_settings(
@@ -1153,13 +1154,13 @@ fn returns_skipped_when_ignored_optional_dependencies_drift() {
     fs::write(&manifest_path, r#"{"name":"root","version":"1.0.0"}"#).unwrap();
     let manifest = PackageManifest::from_path(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.modules_dir = workspace_root.join("node_modules");
     fs::create_dir_all(&config.modules_dir).unwrap();
     config.ignored_optional_dependencies = Some(vec!["new-pattern".to_string()]);
     let config = config.leak();
 
-    let mut stale_config = Config::new();
+    let mut stale_config = project_local_config();
     stale_config.modules_dir = config.modules_dir.clone();
     stale_config.ignored_optional_dependencies = Some(vec!["old-pattern".to_string()]);
     let stale_settings = current_settings(
@@ -1193,7 +1194,7 @@ fn returns_skipped_when_patched_dependencies_drift() {
     fs::write(&manifest_path, r#"{"name":"root","version":"1.0.0"}"#).unwrap();
     let manifest = PackageManifest::from_path(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.modules_dir = workspace_root.join("node_modules");
     fs::create_dir_all(&config.modules_dir).unwrap();
     let mut patched = indexmap::IndexMap::new();
@@ -1201,7 +1202,7 @@ fn returns_skipped_when_patched_dependencies_drift() {
     config.patched_dependencies = Some(patched);
     let config = config.leak();
 
-    let mut stale_config = Config::new();
+    let mut stale_config = project_local_config();
     stale_config.modules_dir = config.modules_dir.clone();
     let mut patched = indexmap::IndexMap::new();
     patched.insert("foo@1.0.0".to_string(), "patches/foo.patch".to_string());
@@ -1245,7 +1246,7 @@ fn returns_skipped_when_patch_file_modified_after_validation() {
     fs::create_dir_all(patch_path.parent().unwrap()).unwrap();
     fs::write(&patch_path, "--- a\n+++ b\n").unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.modules_dir = workspace_root.join("node_modules");
     fs::create_dir_all(&config.modules_dir).unwrap();
     let mut patched = indexmap::IndexMap::new();
@@ -1290,7 +1291,7 @@ fn returns_up_to_date_when_patch_file_unchanged() {
     fs::create_dir_all(patch_path.parent().unwrap()).unwrap();
     fs::write(&patch_path, "--- a\n+++ b\n").unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.modules_dir = workspace_root.join("node_modules");
     fs::create_dir_all(&config.modules_dir).unwrap();
     let mut patched = indexmap::IndexMap::new();
@@ -1328,13 +1329,13 @@ fn returns_skipped_when_dedupe_peers_drift() {
     fs::write(&manifest_path, r#"{"name":"root","version":"1.0.0"}"#).unwrap();
     let manifest = PackageManifest::from_path(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.modules_dir = workspace_root.join("node_modules");
     fs::create_dir_all(&config.modules_dir).unwrap();
     config.dedupe_peers = true;
     let config = config.leak();
 
-    let mut stale_config = Config::new();
+    let mut stale_config = project_local_config();
     stale_config.modules_dir = config.modules_dir.clone();
     stale_config.dedupe_peers = false;
     let stale_settings = current_settings(
@@ -1369,13 +1370,13 @@ fn returns_skipped_when_prefer_workspace_packages_drift() {
     fs::write(&manifest_path, r#"{"name":"root","version":"1.0.0"}"#).unwrap();
     let manifest = PackageManifest::from_path(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.modules_dir = workspace_root.join("node_modules");
     fs::create_dir_all(&config.modules_dir).unwrap();
     config.prefer_workspace_packages = true;
     let config = config.leak();
 
-    let mut stale_config = Config::new();
+    let mut stale_config = project_local_config();
     stale_config.modules_dir = config.modules_dir.clone();
     stale_config.prefer_workspace_packages = false;
     let stale_settings = current_settings(
@@ -1409,13 +1410,13 @@ fn returns_skipped_when_peers_suffix_max_length_drift() {
     fs::write(&manifest_path, r#"{"name":"root","version":"1.0.0"}"#).unwrap();
     let manifest = PackageManifest::from_path(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.modules_dir = workspace_root.join("node_modules");
     fs::create_dir_all(&config.modules_dir).unwrap();
     config.peers_suffix_max_length = 100;
     let config = config.leak();
 
-    let mut stale_config = Config::new();
+    let mut stale_config = project_local_config();
     stale_config.modules_dir = config.modules_dir.clone();
     stale_config.peers_suffix_max_length = 1000;
     let stale_settings = current_settings(
@@ -1453,7 +1454,7 @@ fn returns_skipped_when_package_extensions_drift() {
     deps.insert("dep-a".to_string(), "1.0.0".to_string());
     let extension =
         pacquet_config::PackageExtension { dependencies: Some(deps), ..Default::default() };
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.modules_dir = workspace_root.join("node_modules");
     fs::create_dir_all(&config.modules_dir).unwrap();
     let mut extensions = indexmap::IndexMap::new();
@@ -1462,7 +1463,7 @@ fn returns_skipped_when_package_extensions_drift() {
     let config = config.leak();
 
     // Cached state recorded a different `dep-a` version for `foo`.
-    let mut stale_config = Config::new();
+    let mut stale_config = project_local_config();
     stale_config.modules_dir = config.modules_dir.clone();
     let mut deps = std::collections::BTreeMap::new();
     deps.insert("dep-a".to_string(), "2.0.0".to_string());
@@ -1504,13 +1505,13 @@ fn returns_skipped_when_allow_builds_drift() {
     let manifest = PackageManifest::from_path(manifest_path).unwrap();
     write_empty_lockfile(workspace_root);
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.modules_dir = workspace_root.join("node_modules");
     fs::create_dir_all(&config.modules_dir).unwrap();
     config.allow_builds.insert("foo".to_string(), true);
     let config = config.leak();
 
-    let mut stale_config = Config::new();
+    let mut stale_config = project_local_config();
     stale_config.modules_dir = config.modules_dir.clone();
     stale_config.allow_builds.insert("foo".to_string(), false);
     let stale_settings = current_settings(
@@ -1563,13 +1564,13 @@ fn returns_skipped_when_dedupe_direct_deps_drifts() {
     fs::write(&manifest_path, r#"{"name":"root","version":"1.0.0"}"#).unwrap();
     let manifest = PackageManifest::from_path(manifest_path).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.modules_dir = workspace_root.join("node_modules");
     fs::create_dir_all(&config.modules_dir).unwrap();
     config.dedupe_direct_deps = true;
     let config = config.leak();
 
-    let mut stale_config = Config::new();
+    let mut stale_config = project_local_config();
     stale_config.modules_dir = config.modules_dir.clone();
     stale_config.dedupe_direct_deps = false;
     let stale_settings = current_settings(
@@ -1605,7 +1606,7 @@ fn returns_skipped_when_trust_policy_is_newly_configured() {
     let manifest = PackageManifest::from_path(manifest_path).unwrap();
     write_empty_lockfile(workspace_root);
 
-    let mut stale_config = Config::new();
+    let mut stale_config = project_local_config();
     stale_config.modules_dir = workspace_root.join("node_modules");
     let stale_settings = current_settings(
         &stale_config,
@@ -1621,7 +1622,7 @@ fn returns_skipped_when_trust_policy_is_newly_configured() {
     );
     write_state(workspace_root, now_millis() + 60_000, stale_settings, projects);
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.modules_dir = workspace_root.join("node_modules");
     fs::create_dir_all(&config.modules_dir).unwrap();
     config.trust_policy = pacquet_config::TrustPolicy::NoDowngrade;
@@ -1643,7 +1644,7 @@ fn returns_skipped_when_trust_policy_is_newly_configured() {
 /// resolution rule being mirrored.
 #[test]
 fn records_minimum_release_age_strict_like_pnpm_resolves_it() {
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.explicit_settings.insert("minimumReleaseAge".to_string(), serde_json::Value::from(1440));
     let settings =
         current_settings(&config, pacquet_config::NodeLinker::Isolated, isolated_included(), None);
@@ -1678,7 +1679,7 @@ fn returns_up_to_date_when_state_carries_unported_pnpm_settings() {
     let manifest = PackageManifest::from_path(manifest_path).unwrap();
     write_empty_lockfile(workspace_root);
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.modules_dir = workspace_root.join("node_modules");
     fs::create_dir_all(&config.modules_dir).unwrap();
     let config = config.leak();
@@ -1718,7 +1719,7 @@ fn returns_outdated_when_workspace_catalog_cache_changes() {
     let manifest = PackageManifest::from_path(manifest_path).unwrap();
     write_empty_lockfile(workspace_root);
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.modules_dir = workspace_root.join("node_modules");
     fs::create_dir_all(&config.modules_dir).unwrap();
     let config = config.leak();
@@ -1765,7 +1766,7 @@ fn returns_outdated_when_single_project_catalog_cache_changes() {
     let manifest = PackageManifest::from_path(manifest_path).unwrap();
     write_empty_lockfile(workspace_root);
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.modules_dir = workspace_root.join("node_modules");
     fs::create_dir_all(&config.modules_dir).unwrap();
     let config = config.leak();
@@ -1820,7 +1821,7 @@ fn returns_up_to_date_when_state_has_empty_allow_builds_and_current_has_none() {
     let manifest = PackageManifest::from_path(manifest_path).unwrap();
     write_empty_lockfile(workspace_root);
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.modules_dir = workspace_root.join("node_modules");
     fs::create_dir_all(&config.modules_dir).unwrap();
     let config = config.leak();
@@ -2169,7 +2170,7 @@ fn setup_content_check_project() -> (tempfile::TempDir, &'static Config) {
     fs::write(workspace_root.join("package.json"), FOO_MANIFEST).unwrap();
     fs::write(workspace_root.join(Lockfile::FILE_NAME), FOO_LOCKFILE).unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.modules_dir = workspace_root.join("node_modules");
     config.virtual_store_dir = workspace_root.join("node_modules/.pnpm");
     fs::create_dir_all(&config.virtual_store_dir).unwrap();
@@ -2428,7 +2429,7 @@ importers:
     )
     .unwrap();
 
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.modules_dir = workspace_root.join("node_modules");
     config.virtual_store_dir = workspace_root.join("node_modules/.pnpm");
     config.link_workspace_packages = link_workspace_packages;
@@ -2585,7 +2586,7 @@ importers:
 ",
     )
     .unwrap();
-    let config = Config::new();
+    let config = project_local_config();
     let project_manifests =
         [(workspace_root.to_path_buf(), &root_manifest), (sibling_dir, &sibling_manifest)];
     let context = LinkedPackagesContext::new(&config, &project_manifests);
@@ -2692,7 +2693,7 @@ fn does_not_regenerate_wanted_lockfile_when_lockfile_writing_disabled() {
     let (dir, config) = setup_content_check_project();
     // `Config` is leaked per test; build a second one with `lockfile`
     // off instead of mutating the shared reference.
-    let mut no_lockfile_config = Config::new();
+    let mut no_lockfile_config = project_local_config();
     no_lockfile_config.modules_dir = config.modules_dir.clone();
     no_lockfile_config.virtual_store_dir = config.virtual_store_dir.clone();
     no_lockfile_config.lockfile = false;

--- a/pnpm/crates/package-manager/src/patch/tests.rs
+++ b/pnpm/crates/package-manager/src/patch/tests.rs
@@ -3,6 +3,7 @@ use super::{
     compare_candidates, default_patch_target, executor_scripts_prepend_node_path,
     patch_candidates_from_lockfile, resolution_kind,
 };
+use crate::tests::project_local_config;
 use pacquet_config::ScriptsPrependNodePath;
 use pacquet_executor::ScriptsPrependNodePath as ExecScriptsPrependNodePath;
 use pacquet_lockfile::{
@@ -245,7 +246,7 @@ async fn patch_extract_records_download_in_store_index() {
     let store_dir = tmp.path().join("store");
     std::fs::create_dir_all(&store_dir).expect("create store dir");
 
-    let mut config = pacquet_config::Config::new();
+    let mut config = project_local_config();
     config.registry = registry.url();
     config.store_dir = StoreDir::new(&store_dir);
     let config: &'static pacquet_config::Config = Box::leak(Box::new(config));
@@ -376,7 +377,7 @@ async fn patch_extract_url_inferred_git_hosted_tarball_runs_packlist() {
 #[tokio::test]
 async fn patch_extract_rejects_unsupported_resolution_shape() {
     let tmp = tempfile::tempdir().expect("temp dir");
-    let mut config = pacquet_config::Config::new();
+    let mut config = project_local_config();
     config.store_dir = tmp.path().join("store").into();
     let config: &'static pacquet_config::Config = Box::leak(Box::new(config));
     let metadata: PackageMetadata = serde_json::from_value(json!({
@@ -411,7 +412,7 @@ async fn patch_extract_rejects_unsupported_resolution_shape() {
 #[tokio::test]
 async fn patch_extract_rejects_missing_package_metadata() {
     let tmp = tempfile::tempdir().expect("temp dir");
-    let mut config = pacquet_config::Config::new();
+    let mut config = project_local_config();
     config.store_dir = tmp.path().join("store").into();
     let config: &'static pacquet_config::Config = Box::leak(Box::new(config));
     let mem_cache = pacquet_tarball::MemCache::default();
@@ -564,7 +565,7 @@ impl PatchExtractFixture {
         let ignored = store_dir.join("ignore");
         std::fs::write(&ignored, "do not publish\n").expect("write ignored file");
 
-        let mut config = pacquet_config::Config::new();
+        let mut config = project_local_config();
         config.registry = "https://registry.test/".to_string();
         config.store_dir = store_dir.into();
         config.offline = true;

--- a/pnpm/crates/package-manager/src/prefetching_resolver/tests.rs
+++ b/pnpm/crates/package-manager/src/prefetching_resolver/tests.rs
@@ -1,6 +1,5 @@
 use super::PrefetchingResolver;
-use crate::PrefetchContext;
-use pacquet_config::Config;
+use crate::{PrefetchContext, tests::project_local_config};
 use pacquet_lockfile::{DirectoryResolution, LockfileResolution, TarballResolution};
 use pacquet_network::ThrottledClient;
 use pacquet_reporter::SilentReporter;
@@ -118,7 +117,7 @@ fn resolver_with_prefetch(
     inner: Box<dyn Resolver>,
     prefetch_downloads: bool,
 ) -> PrefetchingResolver<SilentReporter> {
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.store_dir = dir.join("store").into();
     config.cache_dir = dir.join("cache");
     let config = Box::leak(Box::new(config));

--- a/pnpm/crates/package-manager/src/tests.rs
+++ b/pnpm/crates/package-manager/src/tests.rs
@@ -3,16 +3,17 @@ use pacquet_config::Config;
 
 /// A [`Config`] pinned to the project-local virtual store.
 ///
-/// The shared global virtual store is the shipped default, and a
+/// The pin is what keeps a test's installs inside its own tempdir. A
 /// [`Config`] built here has never been through
-/// [`Config::current`](pacquet_config::Config::current) — so its
-/// `global_virtual_store_dir` still points at the *machine's* store
-/// rather than at the tempdir store a test assigns to `store_dir`.
-/// Installing through such a config would write test packages into the
-/// developer's real store and share those slots between concurrently
-/// running tests. Every test config in this crate starts here; the ones
-/// that exercise the shared store turn it back on and point
-/// `global_virtual_store_dir` inside their own tempdir.
+/// [`Config::current`](pacquet_config::Config::current), so assigning
+/// `store_dir` does not re-derive `global_virtual_store_dir` with it:
+/// that field still names the *machine's* store. On the shipped default
+/// — the shared store — an install through such a config would leave
+/// test packages in the developer's real store and share those slots
+/// with every concurrently running test. Every test config in this
+/// crate starts here; the ones that exercise the shared store turn it
+/// back on and point `global_virtual_store_dir` inside their own
+/// tempdir.
 pub(crate) fn project_local_config() -> Config {
     Config { enable_global_virtual_store: false, ..Config::new() }
 }

--- a/pnpm/crates/package-manager/src/tests.rs
+++ b/pnpm/crates/package-manager/src/tests.rs
@@ -1,4 +1,21 @@
 use super::script_thread_count;
+use pacquet_config::Config;
+
+/// A [`Config`] pinned to the project-local virtual store.
+///
+/// The shared global virtual store is the shipped default, and a
+/// [`Config`] built here has never been through
+/// [`Config::current`](pacquet_config::Config::current) — so its
+/// `global_virtual_store_dir` still points at the *machine's* store
+/// rather than at the tempdir store a test assigns to `store_dir`.
+/// Installing through such a config would write test packages into the
+/// developer's real store and share those slots between concurrently
+/// running tests. Every test config in this crate starts here; the ones
+/// that exercise the shared store turn it back on and point
+/// `global_virtual_store_dir` inside their own tempdir.
+pub(crate) fn project_local_config() -> Config {
+    Config { enable_global_virtual_store: false, ..Config::new() }
+}
 
 #[test]
 fn script_threads_are_bounded_by_work_and_the_safety_cap() {

--- a/pnpm/crates/package-manager/src/update/tests.rs
+++ b/pnpm/crates/package-manager/src/update/tests.rs
@@ -3,6 +3,7 @@ use super::{
     judge_against_kept_range, parse_update_param, persist_selected_manifests,
     prepare_selected_manifests, selected_project_indices,
 };
+use crate::tests::project_local_config;
 use pacquet_config::{CatalogMode, Config};
 use pacquet_network::ThrottledClient;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
@@ -163,7 +164,7 @@ async fn selected_update_prepares_and_persists_only_selected_projects() {
     let ordered_dirs = [projects[1].root_dir.clone(), projects[0].root_dir.clone()];
     let selected_dirs = ordered_dirs.iter().cloned().collect::<HashSet<_>>();
     let indices = selected_project_indices(&projects, &ordered_dirs, &selected_dirs);
-    let config = Config::new();
+    let config = project_local_config();
     let http_client = std::sync::Arc::new(ThrottledClient::default());
 
     let prepared = prepare_selected_manifests::<SilentReporter>(
@@ -207,7 +208,7 @@ async fn selected_update_no_save_mutates_in_memory_without_persisting() {
     let ordered_dirs = [projects[0].root_dir.clone()];
     let selected_dirs = ordered_dirs.iter().cloned().collect::<HashSet<_>>();
     let indices = selected_project_indices(&projects, &ordered_dirs, &selected_dirs);
-    let mut config = Config::new();
+    let mut config = project_local_config();
     config.catalog_mode = CatalogMode::Prefer;
     let http_client = std::sync::Arc::new(ThrottledClient::default());
 
@@ -255,7 +256,7 @@ async fn selected_update_no_save_skips_a_selector_outside_the_kept_range() {
     let ordered_dirs = [projects[0].root_dir.clone()];
     let selected_dirs = ordered_dirs.iter().cloned().collect::<HashSet<_>>();
     let indices = selected_project_indices(&projects, &ordered_dirs, &selected_dirs);
-    let config = Config::new();
+    let config = project_local_config();
     let http_client = std::sync::Arc::new(ThrottledClient::default());
 
     let prepared = prepare_selected_manifests::<SilentReporter>(
@@ -291,7 +292,7 @@ async fn selected_update_depth_zero_skips_projects_without_a_matching_dependency
     let dir = tempdir().expect("create tempdir");
     let mut projects = [project_without_foo(dir.path(), "a"), project_with_foo(dir.path(), "b")];
     let selected_indices = [0, 1];
-    let config = Config::new();
+    let config = project_local_config();
     let http_client = std::sync::Arc::new(ThrottledClient::default());
 
     let prepared = prepare_selected_manifests::<SilentReporter>(
@@ -323,7 +324,7 @@ async fn selected_update_latest_depth_zero_is_noop_when_no_project_matches() {
     let dir = tempdir().expect("create tempdir");
     let mut projects = [project_without_foo(dir.path(), "a"), project_without_foo(dir.path(), "b")];
     let selected_indices = [0, 1];
-    let config = Config::new();
+    let config = project_local_config();
     let http_client = std::sync::Arc::new(ThrottledClient::default());
 
     let prepared = prepare_selected_manifests::<SilentReporter>(
@@ -455,7 +456,11 @@ fn project_with_foo_specifier(root: &std::path::Path, name: &str, specifier: &st
 // loudly instead of hitting the network. Retries are off so that failure is
 // immediate rather than a minute of backoff.
 fn unroutable_registry_config() -> Config {
-    Config { registry: "http://127.0.0.1:1/".to_string(), fetch_retries: 0, ..Config::new() }
+    Config {
+        registry: "http://127.0.0.1:1/".to_string(),
+        fetch_retries: 0,
+        ..project_local_config()
+    }
 }
 
 fn project_without_foo(root: &std::path::Path, name: &str) -> Project {

--- a/pnpm/crates/testing-utils/src/bin.rs
+++ b/pnpm/crates/testing-utils/src/bin.rs
@@ -121,12 +121,15 @@ impl CommandTempCwd<()> {
         let npmrc_text = format!("registry={mocked_registry}\n{npmrc_text}");
         fs::write(&npmrc_path, npmrc_text).expect("write to .npmrc");
 
-        // Explicitly pin `enableGlobalVirtualStore: false` so a test
-        // is hermetic regardless of any GVS opt-in the developer
-        // has set in their global pnpm config (`~/.config/pnpm/config.yaml`
+        // Pin `enableGlobalVirtualStore: false` so a test is hermetic:
+        // the shared store is the default, and it is also what the
+        // developer's global pnpm config (`~/.config/pnpm/config.yaml`
         // on Linux/macOS-with-XDG, `~/Library/Preferences/pnpm/config.yaml`
-        // on macOS by default). Tests that exercise GVS explicitly
-        // override this — see `enable_gvs_in_workspace_yaml` in
+        // on macOS by default) may pin either way. Pinning here keeps
+        // every suite on the project-local layout it asserts on, and
+        // off the machine-wide store its assertions would race in.
+        // Tests that exercise GVS override this — see
+        // `enable_gvs_in_workspace_yaml` in
         // `pnpm/crates/cli/tests/_utils.rs`.
         let workspace_yaml = self.workspace.join("pnpm-workspace.yaml");
         let workspace_yaml_text = text_block_fnl! {

--- a/pnpm/tasks/ecosystem-e2e/src/runner.rs
+++ b/pnpm/tasks/ecosystem-e2e/src/runner.rs
@@ -153,9 +153,10 @@ fn prepare_cell(
 }
 
 /// Pin the store and cache inside the cell so pnpm and pacquet never share a
-/// store, and so every cell starts cold. The explicit
-/// `enableGlobalVirtualStore` matters under CI: CI defaults it to `false`,
-/// but an explicit value in `pnpm-workspace.yaml` is respected.
+/// store, and so every cell starts cold. `enableGlobalVirtualStore` is
+/// written explicitly because the two binaries default it differently —
+/// pnpm 11 off, pnpm 12 on — and the layout axis has to mean the same
+/// thing for both.
 ///
 /// `dangerouslyAllowAllBuilds` lets dependency build scripts run unattended
 /// (esbuild, etc.) so the build stage exercises a real, fully-built

--- a/pnpm/tasks/integrated-benchmark/src/fixtures/pnpm-workspace.yaml
+++ b/pnpm/tasks/integrated-benchmark/src/fixtures/pnpm-workspace.yaml
@@ -4,16 +4,12 @@ storeDir: ./store-dir
 # (`<project>/node_modules/.pnpm`) so the benchmark continues to
 # compare apples-to-apples across pacquet revisions.
 #
-# Pacquet's effective default is already `enableGlobalVirtualStore: false`
-# (matches pnpm v11 for non-`--global` installs — the `true`
-# assignment upstream lives only inside the `pnpm install --global`
-# branch). The pin is kept anyway so a future default flip surfaces
-# in CI rather than silently changing what the numbers measure:
-# with GVS on, slot directories move to
-# `<storeDir>/links/<scope>/<name>/<version>/<hash>`, a different
-# layout from the project-local baseline. Flip this to `true` in a
-# `--fixture-dir` override to benchmark the GVS path on its own
-# terms.
+# Pacquet defaults to `enableGlobalVirtualStore: true`, so this pin
+# deliberately opposes the default: with GVS on, slot directories move
+# to `<storeDir>/links/<scope>/<name>/<version>/<hash>`, a different
+# layout from the project-local baseline every historical number was
+# measured against. Flip this to `true` in a `--fixture-dir` override
+# to benchmark the GVS path on its own terms.
 enableGlobalVirtualStore: false
 
 # Force pnpm to install every optional dependency in the lockfile

--- a/pnpm/tasks/integrated-benchmark/src/fixtures/pnpm-workspace.yaml
+++ b/pnpm/tasks/integrated-benchmark/src/fixtures/pnpm-workspace.yaml
@@ -6,7 +6,7 @@ storeDir: ./store-dir
 #
 # Pacquet defaults to `enableGlobalVirtualStore: true`, so this pin
 # deliberately opposes the default: with GVS on, slot directories move
-# to `<storeDir>/links/<scope>/<name>/<version>/<hash>`, a different
+# to `<storeDir>/v11/links/<scope>/<name>/<version>/<hash>`, a different
 # layout from the project-local baseline every historical number was
 # measured against. Flip this to `true` in a `--fixture-dir` override
 # to benchmark the GVS path on its own terms.


### PR DESCRIPTION
## Summary

pnpm 12 now installs into the shared **global virtual store** by default:
`enableGlobalVirtualStore` flips from `false` to `true`. Every package is
materialized once per machine, under
`<store-dir>/v11/links/<scope>/<name>/<version>/<hash>`, and every project that
resolves the same dependency-graph node links to that one directory instead of
getting its own copy under `<project>/node_modules/.pnpm`.

Making this the default has been the plan for the feature since it shipped —
Related to pnpm/pnpm#9696, where it was ruled out for v11 specifically ("For
sure it won't be the default in v11 yet"). v12 is the major that can carry it.

**The default does not vary by environment.** An earlier revision of this PR
carried a CI carve-out, mirroring the (currently inert) rule in the TypeScript
config reader: in CI, fall back to the project-local layout. That is dropped.
The premise — a cold CI store has nothing to share, so the shared store is pure
overhead — is real but small, and it buys the overhead back by manufacturing a
"works on my machine" split: under the shared store, package directories sit
outside the project and every spawned process gets `NODE_PATH` and the ESM
loader flag, so phantom-dependency resolution differs. A CI-only fallback runs
every build in a resolution environment nobody develops against. The premise is
also weakening — a CI that caches the store directory caches the `links/` slots
with it, which is exactly where the shared store pays off.

Opting out is a setting, from any source: `pnpm-workspace.yaml`, the global
`config.yaml`, or `PNPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE`.

**Only the Rust CLI changes.** The TypeScript CLI is pnpm 11 and keeps its
project-local default; this is one of the defaults the two majors deliberately
disagree on, so there is nothing to port. Dropping the CI rule adds no
divergence either: the TypeScript one only fires when the setting is unset and
then assigns `false`, which is pnpm 11's default anyway, so it has never
changed an install.

### Coverage

- New `the_global_virtual_store_is_the_default_in_every_environment` end-to-end
  test: a project with no `enableGlobalVirtualStore` setting installs into the
  shared store; reinstalling with `PNPM_CONFIG_CI=true` reattaches to the same
  slot rather than switching layouts; and
  `PNPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE=false` moves the package back into
  the project. Each assertion was checked to fail when its input is flipped.
- The config default test now asserts the same result for `ci: false` and
  `ci: true`, and `global_config_yaml_disables_gvs` writes the value opposite
  the default so it can only pass if that layer actually applied.
- The global-virtual-store suites, the `pnpm_compatibility` layout-parity
  tests, and the daily [Ecosystem E2E](.github/workflows/ecosystem-e2e.yml)
  matrix (Next.js, Vite, Angular, Astro, SvelteKit, Nuxt, React Router; both
  binaries; both layouts) already exercise the shared store.

### Test-config churn

The other half of the diff keeps the test suites hermetic. A `Config` built
with `Config::new()` never goes through `Config::current`, so its
`global_virtual_store_dir` still points at the *machine's* store rather than at
the tempdir store the test assigns to `store_dir` — with the shared store now
on by default, those tests would install into the developer's real store and
share slots between concurrently running tests. Verified against a
`PNPM_HOME`-redirected store: the package-manager and deps-restorer suites now
write exactly what they wrote before this PR.

- `pacquet-package-manager` test configs are built through a new
  `project_local_config()` helper that pins the shared store off.
- The `deps-restorer`, `licenses`, `sync_injected_deps_after_scripts`, and
  `config_deps` tests that assert a project-local layout pin it themselves.
- `Config::default()`'s `global_virtual_store_dir` now defaults to
  `<store-dir>/links` (the same fallback the derivation uses) instead of
  `<cwd>/node_modules/.pnpm`, so an un-`current`ed config can never point the
  shared store at the working directory.

### Known follow-ups

- The open GVS bugs become reachable without an opt-in:
  pnpm/pnpm#13318, pnpm/pnpm#13210, pnpm/pnpm#12437. Tools that resolve modules
  by walking directories themselves, rather than through Node's resolver, are
  the common thread; `enableGlobalVirtualStore: false` is the escape hatch
  until they are fixed.
- pacquet's `--config.<key>` allowlist doesn't include
  `enable-global-virtual-store`, so a per-invocation opt-out has to go through
  `PNPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE=false` for now. Worth adding
  separately.
- pnpm.io's settings documentation needs the new default (separate repo).

## Squash Commit Body

```text
`enableGlobalVirtualStore` now defaults to `true`, in every environment.
Packages are materialized once per machine under `<store-dir>/v11/links/...`
and shared by every project, instead of being re-created under each
project's `node_modules/.pnpm`. Related to pnpm/pnpm#9696.

This is a v12-only default. The TypeScript CLI is pnpm 11 and keeps the
project-local virtual store.

The default deliberately does not vary by environment. A CI carve-out
(which the TypeScript reader carries, inertly, since its own default is
already `false`) would run every build under a different resolution
environment than the one developers work in: under the shared store,
package directories sit outside the project and spawned processes get
`NODE_PATH` and the ESM loader flag, so phantom-dependency resolution
differs.

`Config::default()`'s `global_virtual_store_dir` now falls back to
`<store-dir>/links` rather than `<cwd>/node_modules/.pnpm`, matching the
derivation's own fallback: a `Config` that never went through
`Config::current` (tests, mostly) would otherwise point the shared store
at the working directory. For the same reason the test configs that
assert a project-local layout now pin the setting off — without that
they install into the developer's real store and share slots between
concurrently running tests.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed. (pnpm.io lives in another repo; the
  settings page needs the new default.)

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The global virtual store is now enabled by default in all environments, including CI.
  - Packages are shared through a common store, improving reuse across projects.
  - Set `enableGlobalVirtualStore: false` to restore project-local package storage.
  - External package locations use symlinks and `NODE_PATH`; tools relying on filesystem-based module resolution may require adjustments.

- **Documentation**
  - Updated configuration guidance to explain the shared virtual store default and how to opt out.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->