### PR TITLE
ci(benchmark): measure the shared virtual store

### DIFF
--- a/.github/workflows/pacquet-integrated-benchmark.yml
+++ b/.github/workflows/pacquet-integrated-benchmark.yml
@@ -432,6 +432,31 @@ jobs:
           cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE_COLD_PNPR.md
           cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE_COLD_PNPR.json
 
+      - name: 'Benchmark: GVS linker: fresh restore, hot cache + hot store'
+        shell: bash
+        # The layout pnpm 12 installs into by default, which no other
+        # scenario measures — every `isolated-linker.*` fixture pins
+        # `enableGlobalVirtualStore: false`.
+        #
+        # Same frozen install as the isolated fresh-restore hot/hot
+        # scenario, against the same warm cache and store, so the pair
+        # brackets what the layout is worth: the per-iteration wipe takes
+        # `node_modules` either way, but under the shared store the
+        # materialized package directories live outside it and survive,
+        # leaving symlinking as the measured work. Locally that is ~190 ms
+        # against ~1.05 s for the isolated scenario, so this is also the
+        # scenario where a regression in slot reuse would show up as a
+        # jump toward that isolated number.
+        #
+        # The harness pre-warms the shared store per target before
+        # hyperfine starts, because the scenario's contract is a
+        # populated GVS and the pre-benchmark wipe empties it.
+        timeout-minutes: 15
+        run: |
+          just integrated-benchmark --reuse-prebuilt-binaries --scenario=gvs-linker.fresh-restore.hot-cache.hot-store --registry=verdaccio --pnpr-latency-ms=${PNPR_LATENCY_MS} --registry-latency-ms=${REGISTRY_LATENCY_MS} --registry-bandwidth-mbps=${REGISTRY_BANDWIDTH_MBPS} $BENCHMARK_TARGETS
+          cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_GVS_FRESH_RESTORE_HOT_CACHE_HOT_STORE.md
+          cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_GVS_FRESH_RESTORE_HOT_CACHE_HOT_STORE.json
+
       # When a scenario fails, hyperfine aborts and the benchmarked install's
       # own output is invisible: each target's script redirects stdout+stderr to
       # `bench-work-env/<target>/BENCHMARK_OUTPUT.ndjson` (to keep hyperfine's
@@ -610,6 +635,20 @@ jobs:
             echo '```'
             echo
             echo '</details>'
+            echo
+            echo '### Scenario: GVS linker: fresh restore, hot cache + hot store'
+            echo
+            echo 'Same install as the isolated fresh-restore hot/hot scenario, into the shared virtual store — the layout pnpm 12 installs into by default. Comparable to that scenario head-to-head.'
+            echo
+            cat bench-work-env/BENCHMARK_REPORT_GVS_FRESH_RESTORE_HOT_CACHE_HOT_STORE.md
+            echo
+            echo '<details><summary>BENCHMARK_REPORT.json</summary>'
+            echo
+            echo '```json'
+            jq 'del(.results[].exit_codes, .results[].times)' bench-work-env/BENCHMARK_REPORT_GVS_FRESH_RESTORE_HOT_CACHE_HOT_STORE.json
+            echo '```'
+            echo
+            echo '</details>'
           ) > bench-work-env/SUMMARY.md
 
       - name: Build Bencher-shaped report
@@ -674,7 +713,8 @@ jobs:
             'ISOLATED_FRESH_INSTALL_COLD_CACHE_HOT_STORE:isolated-linker.fresh-install.cold-cache.hot-store' \
             'ISOLATED_FRESH_RESOLVE_HOT_CACHE_OFFLINE:isolated-linker.fresh-resolve.hot-cache.offline' \
             'ISOLATED_PEER_HEAVY_RESOLVE_HOT_CACHE_OFFLINE:isolated-linker.peer-heavy-resolve.hot-cache.offline' \
-            'ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE_COLD_PNPR:isolated-linker.fresh-restore.cold-cache.cold-store.cold-pnpr'
+            'ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE_COLD_PNPR:isolated-linker.fresh-restore.cold-cache.cold-store.cold-pnpr' \
+            'GVS_FRESH_RESTORE_HOT_CACHE_HOT_STORE:gvs-linker.fresh-restore.hot-cache.hot-store'
 
           build_bencher_file bench-work-env/bencher-results-pnpr.json pnpr@HEAD \
             'ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE:isolated-linker.fresh-restore.cold-cache.cold-store' \
@@ -685,7 +725,8 @@ jobs:
             'ISOLATED_FRESH_INSTALL_HOT_CACHE_HOT_STORE:isolated-linker.fresh-install.hot-cache.hot-store' \
             'ISOLATED_FRESH_INSTALL_COLD_CACHE_HOT_STORE:isolated-linker.fresh-install.cold-cache.hot-store' \
             'ISOLATED_FRESH_RESOLVE_HOT_CACHE_OFFLINE:isolated-linker.fresh-resolve.hot-cache.offline' \
-            'ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE_COLD_PNPR:isolated-linker.fresh-restore.cold-cache.cold-store.cold-pnpr'
+            'ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE_COLD_PNPR:isolated-linker.fresh-restore.cold-cache.cold-store.cold-pnpr' \
+            'GVS_FRESH_RESTORE_HOT_CACHE_HOT_STORE:gvs-linker.fresh-restore.hot-cache.hot-store'
 
       - name: Stage artifact contents
         # The artifact carries the rendered report plus the


### PR DESCRIPTION
## Summary

Adds `gvs-linker.fresh-restore.hot-cache.hot-store` to the integrated-benchmark job, feeding both Bencher testbeds.

The harness has carried this scenario for a while, but nothing invoked it: every scenario the workflow runs pins `enableGlobalVirtualStore: false` in its fixture. Since pnpm/pnpm#13940 that pin is the opposite of what users get, so the layout pnpm 12 installs into by default had no continuous measurement at all — a regression in slot reuse could land with no gate noticing.

It pairs with `isolated-linker.fresh-restore.hot-cache.hot-store`: same frozen install, same warm cache and store, and the per-iteration wipe takes `node_modules` either way, so the delta between them is what the layout is worth. Measured locally, 5 runs each on one machine:

| Scenario | mean ± σ | min |
|---|---|---|
| `gvs-linker.fresh-restore.hot-cache.hot-store` | **187.8 ms ± 5.6** | 178.1 ms |
| `isolated-linker.fresh-restore.hot-cache.hot-store` | 1.047 s ± 0.119 | 915 ms |

The gap is the point of the shared store: the materialized package directories live outside `node_modules`, so the wipe doesn't destroy them and only the symlinks have to be rebuilt. It also makes this the scenario where a slot-reuse regression shows up — as a jump back toward that isolated number.

### pnpr under the shared store

Both testbeds get the scenario, so this is the first time `pnpr@HEAD` runs with the global virtual store — the pre-warm site in `work_env.rs` calls that combination hypothetical ("so a pnpr target *would* have its server up if a scenario ever combines the two"). I ran it end to end before wiring it in: the server starts, both targets pre-warm, and both installs measure clean.

### Notes for review

- The new Bencher benchmark starts with no baseline, so the first runs on `main` seed it and no threshold fires until it has history.
- The job grows by one ~15-minute-timeout step; the scenario itself is the cheapest install shape in the matrix.
- No changeset: CI-only change, no published package is affected.

## Squash Commit Body

```text
Adds `gvs-linker.fresh-restore.hot-cache.hot-store` to the integrated
benchmark job, feeding both Bencher testbeds.

The harness has carried this scenario for a while, but nothing invoked
it: every scenario the workflow ran pins `enableGlobalVirtualStore:
false` in its fixture. Since pnpm/pnpm#13940 that pin is the opposite
of what users get, so the layout pnpm 12 installs into by default had
no continuous measurement at all — a regression in slot reuse could
land without any gate noticing.

It pairs with the isolated fresh-restore hot/hot scenario: same frozen
install, same warm cache and store, and the per-iteration wipe takes
`node_modules` either way, so the difference is what the layout is
worth. Measured locally over 5 runs: 187.8 ms ± 5.6 shared versus
1.047 s ± 0.119 project-local, because the materialized package
directories survive the wipe under the shared store and only the
symlinks have to be rebuilt.

Both testbeds get the scenario. `pnpr@HEAD` under the shared store had
never been exercised — the pre-warm site notes it as hypothetical — so
it was run end to end first: the server starts, both targets pre-warm,
and both installs measure clean.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. (CI
  configuration for the Rust benchmark harness; no CLI behavior changes.)
- [x] Added a changeset if this PR changes any published package. (None
  is affected.)
- [x] Added or updated tests. (The scenario was validated end to end
  locally, including the previously untried pnpr + shared-store target.)
- [x] Updated the documentation if needed. (`pnpm11/benchmarks/README.md`
  already documents the scenario.)

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13944"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789471103&installation_model_id=426870&pr_number=13944&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13944&signature=13e8a96f6dea1f6d76d5085d033def47697052bd7114be294ad25b42fd21b863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added benchmark coverage for fresh restores using a warm cache and store.
  * Added automated report generation and captured benchmark artifacts.
  * Included the new scenario in package manager benchmark result reporting.

* **Chores**
  * Improved performance monitoring for restore workflows without changing user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->