### PR TITLE
feat: name the virtual store's type, keeping the boolean spelling

### DIFF
--- a/.changeset/virtual-store-type.md
+++ b/.changeset/virtual-store-type.md
@@ -11,6 +11,6 @@ Added `virtualStoreType`, which names where the virtual store lives — one stor
 virtualStoreType: global   # or: project
 ```
 
-It is the canonical spelling of `enableGlobalVirtualStore`, which keeps working. When a project sets both, `virtualStoreType` wins. The default is unchanged: pnpm 12 installs into the global store, pnpm 11 into a project-local one.
+It is the canonical spelling of `enableGlobalVirtualStore`, which keeps working. When a project sets both, `virtualStoreType` wins. It can also be set through `PNPM_CONFIG_VIRTUAL_STORE_TYPE` and read back with `pnpm config get virtualStoreType`. The default is unchanged: pnpm 12 installs into the global store, pnpm 11 into a project-local one.
 
 The setting is independent of `nodeLinker`. `isolated` and `pnp` both work with either store type, and `hoisted` writes no virtual store at all, so it is unaffected.

--- a/.changeset/virtual-store-type.md
+++ b/.changeset/virtual-store-type.md
@@ -11,6 +11,6 @@ Added `virtualStoreType`, which names where the virtual store lives — one stor
 virtualStoreType: global   # or: project
 ```
 
-It is the canonical spelling of `enableGlobalVirtualStore`, which keeps working. When a project sets both, `virtualStoreType` wins. It can also be set through `PNPM_CONFIG_VIRTUAL_STORE_TYPE` and read back with `pnpm config get virtualStoreType`. The default is unchanged: pnpm 12 installs into the global store, pnpm 11 into a project-local one.
+It is the canonical spelling of `enableGlobalVirtualStore`, which keeps working. When a project sets both, `virtualStoreType` wins. It can also be set through `PNPM_CONFIG_VIRTUAL_STORE_TYPE` and read back with `pnpm config get virtualStoreType`. The default is unchanged — `project`, so the shared store stays opt-in.
 
 The setting is independent of `nodeLinker`. `isolated` and `pnp` both work with either store type, and `hoisted` writes no virtual store at all, so it is unaffected.

--- a/.changeset/virtual-store-type.md
+++ b/.changeset/virtual-store-type.md
@@ -1,0 +1,16 @@
+---
+"@pnpm/types": minor
+"@pnpm/config.reader": minor
+"pnpm": minor
+"pacquet": minor
+---
+
+Added `virtualStoreType`, which names where the virtual store lives — one store per machine, or one per project:
+
+```yaml
+virtualStoreType: global   # or: project
+```
+
+It is the canonical spelling of `enableGlobalVirtualStore`, which keeps working. When a project sets both, `virtualStoreType` wins. The default is unchanged: pnpm 12 installs into the global store, pnpm 11 into a project-local one.
+
+The setting is independent of `nodeLinker`. `isolated` and `pnp` both work with either store type, and `hoisted` writes no virtual store at all, so it is unaffected.

--- a/pnpm/crates/cli/src/cli_args/config/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/config/tests.rs
@@ -472,11 +472,11 @@ fn get_virtual_store_type_and_its_boolean_spelling() {
     );
     assert_eq!(
         config_get(&config, flags(true, None, false), "virtual-store-type").unwrap(),
-        "global"
+        "global",
     );
     assert_eq!(
         config_get(&config, flags(true, None, false), "virtualStoreType").unwrap(),
-        "global"
+        "global",
     );
     assert_eq!(
         config_get(&config, flags(true, None, false), "enable-global-virtual-store").unwrap(),

--- a/pnpm/crates/cli/src/cli_args/config/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/config/tests.rs
@@ -461,6 +461,29 @@ fn get_scalar_string_and_camel() {
     assert_eq!(config_get(&config, flags(true, None, false), "storeDir").unwrap(), "~/store");
 }
 
+/// Both spellings of the virtual store's type are `types` keys, so `get`
+/// answers either from the explicit-settings record instead of falling
+/// through to the config record, which carries neither name.
+#[test]
+fn get_virtual_store_type_and_its_boolean_spelling() {
+    let config = config_for_get(
+        &[("virtualStoreType", json!("global")), ("enableGlobalVirtualStore", json!(true))],
+        &[],
+    );
+    assert_eq!(
+        config_get(&config, flags(true, None, false), "virtual-store-type").unwrap(),
+        "global"
+    );
+    assert_eq!(
+        config_get(&config, flags(true, None, false), "virtualStoreType").unwrap(),
+        "global"
+    );
+    assert_eq!(
+        config_get(&config, flags(true, None, false), "enable-global-virtual-store").unwrap(),
+        "true",
+    );
+}
+
 #[test]
 fn get_boolean_and_array_and_object() {
     let config = config_for_get(

--- a/pnpm/crates/cli/tests/suite/global_virtual_store.rs
+++ b/pnpm/crates/cli/tests/suite/global_virtual_store.rs
@@ -1478,9 +1478,7 @@ fn scripts_resolve_phantom_esm_imports_through_the_private_hoist() {
     drop((root, mock_instance));
 }
 
-/// `virtualStoreType` is the spelling a project reaches for; the boolean
-/// `enableGlobalVirtualStore` it supersedes still works. Both are checked
-/// through a real install, because the setting only means anything once
+/// Driven through a real install: the setting only means anything once
 /// something has been materialized somewhere.
 #[test]
 fn virtual_store_type_selects_where_packages_are_materialized() {

--- a/pnpm/crates/cli/tests/suite/global_virtual_store.rs
+++ b/pnpm/crates/cli/tests/suite/global_virtual_store.rs
@@ -92,15 +92,14 @@ fn set_gvs_workspace_yaml(workspace: &Path, extra_yaml: &str) {
     let mut yaml = harness_store_and_cache_yaml(workspace);
     yaml.push_str("enableGlobalVirtualStore: true\n");
     yaml.push_str(extra_yaml);
-    fs::write(workspace.join("pnpm-workspace.yaml"), yaml)
-        .expect("write pnpm-workspace.yaml");
+    fs::write(workspace.join("pnpm-workspace.yaml"), yaml).expect("write pnpm-workspace.yaml");
 }
 
 /// The harness's `storeDir` / `cacheDir` lines on their own, for a test
 /// that writes its own virtual-store setting on top.
 fn harness_store_and_cache_yaml(workspace: &Path) -> String {
-    let existing =
-        fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("read pnpm-workspace.yaml");
+    let existing = fs::read_to_string(workspace.join("pnpm-workspace.yaml"))
+        .expect("read pnpm-workspace.yaml");
     let yaml: String = existing
         .lines()
         .filter(|line| line.starts_with("storeDir:") || line.starts_with("cacheDir:"))

--- a/pnpm/crates/cli/tests/suite/global_virtual_store.rs
+++ b/pnpm/crates/cli/tests/suite/global_virtual_store.rs
@@ -89,9 +89,19 @@ fn pkg_in_slot(hash_dir: &Path, name: &str) -> PathBuf {
 /// These tests re-set `allowBuilds` between installs, so they need a form
 /// that is idempotent.
 fn set_gvs_workspace_yaml(workspace: &Path, extra_yaml: &str) {
-    let yaml_path = workspace.join("pnpm-workspace.yaml");
-    let existing = fs::read_to_string(&yaml_path).expect("read pnpm-workspace.yaml");
-    let mut yaml: String = existing
+    let mut yaml = harness_store_and_cache_yaml(workspace);
+    yaml.push_str("enableGlobalVirtualStore: true\n");
+    yaml.push_str(extra_yaml);
+    fs::write(workspace.join("pnpm-workspace.yaml"), yaml)
+        .expect("write pnpm-workspace.yaml");
+}
+
+/// The harness's `storeDir` / `cacheDir` lines on their own, for a test
+/// that writes its own virtual-store setting on top.
+fn harness_store_and_cache_yaml(workspace: &Path) -> String {
+    let existing =
+        fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("read pnpm-workspace.yaml");
+    let yaml: String = existing
         .lines()
         .filter(|line| line.starts_with("storeDir:") || line.starts_with("cacheDir:"))
         .fold(String::new(), |mut acc, line| {
@@ -104,9 +114,7 @@ fn set_gvs_workspace_yaml(workspace: &Path, extra_yaml: &str) {
         "expected the `storeDir` / `cacheDir` keys written by \
          `CommandTempCwd::add_mocked_registry` — has the helper changed?",
     );
-    yaml.push_str("enableGlobalVirtualStore: true\n");
-    yaml.push_str(extra_yaml);
-    fs::write(&yaml_path, yaml).expect("write pnpm-workspace.yaml");
+    yaml
 }
 
 fn write_manifest(workspace: &Path, deps: &serde_json::Value) {
@@ -1468,4 +1476,45 @@ fn scripts_resolve_phantom_esm_imports_through_the_private_hoist() {
     );
 
     drop((root, mock_instance));
+}
+
+/// `virtualStoreType` is the spelling a project reaches for; the boolean
+/// `enableGlobalVirtualStore` it supersedes still works. Both are checked
+/// through a real install, because the setting only means anything once
+/// something has been materialized somewhere.
+#[test]
+fn virtual_store_type_selects_where_packages_are_materialized() {
+    for (yaml, expect_shared) in [
+        ("virtualStoreType: project\n", false),
+        ("virtualStoreType: global\n", true),
+        ("enableGlobalVirtualStore: false\n", false),
+        ("virtualStoreType: global\nenableGlobalVirtualStore: false\n", true),
+    ] {
+        let CommandTempCwd { root, workspace, npmrc_info, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        let AddMockedRegistry { store_dir, mock_instance, .. } = npmrc_info;
+
+        let mut workspace_yaml = harness_store_and_cache_yaml(&workspace);
+        workspace_yaml.push_str(yaml);
+        fs::write(workspace.join("pnpm-workspace.yaml"), workspace_yaml)
+            .expect("write pnpm-workspace.yaml");
+        write_manifest(&workspace, &serde_json::json!({ "@pnpm.e2e/pkg-with-1-dep": "100.0.0" }));
+
+        pacquet(&workspace).with_arg("install").assert().success();
+
+        let project_local_slot =
+            workspace.join("node_modules/.pnpm/@pnpm.e2e+pkg-with-1-dep@100.0.0");
+        assert_eq!(
+            gvs_root(&store_dir).is_dir(),
+            expect_shared,
+            "the shared store is populated only when asked for; yaml: {yaml}",
+        );
+        assert_eq!(
+            project_local_slot.is_dir(),
+            !expect_shared,
+            "the project-local slot is written only when asked for; yaml: {yaml}",
+        );
+
+        drop((root, mock_instance));
+    }
 }

--- a/pnpm/crates/cli/tests/suite/global_virtual_store.rs
+++ b/pnpm/crates/cli/tests/suite/global_virtual_store.rs
@@ -1486,6 +1486,7 @@ fn virtual_store_type_selects_where_packages_are_materialized() {
         ("virtualStoreType: global\n", true),
         ("enableGlobalVirtualStore: false\n", false),
         ("virtualStoreType: global\nenableGlobalVirtualStore: false\n", true),
+        ("virtualStoreType: project\nenableGlobalVirtualStore: true\n", false),
     ] {
         let CommandTempCwd { root, workspace, npmrc_info, .. } =
             CommandTempCwd::init().add_mocked_registry();

--- a/pnpm/crates/config/src/config_types.rs
+++ b/pnpm/crates/config/src/config_types.rs
@@ -141,6 +141,7 @@ const PNPM_TYPES: &[(&str, bool)] = &[
     ("global-virtual-store-dir", false),
     ("virtual-store-dir", false),
     ("virtual-store-only", false),
+    ("virtual-store-type", false),
     ("virtual-store-dir-max-length", true),
     ("peers-suffix-max-length", true),
     ("workspace-concurrency", true),
@@ -307,6 +308,7 @@ const PNPM_CONFIG_FILE_KEYS: &[&str] = &[
     "verify-store-integrity",
     "virtual-store-dir",
     "virtual-store-dir-max-length",
+    "virtual-store-type",
 ];
 
 /// Structured YAML settings parsed from `pnpm-workspace.yaml` / global

--- a/pnpm/crates/config/src/config_types/tests.rs
+++ b/pnpm/crates/config/src/config_types/tests.rs
@@ -6,6 +6,10 @@ fn type_membership() {
     assert!(is_type_key("store-dir"));
     assert!(is_type_key("registry"));
     assert!(is_type_key("virtual-store-dir"));
+    // Both spellings of the virtual store's type are introspectable, or
+    // `pnpm config get` would answer one of them with null.
+    assert!(is_type_key("virtual-store-type"));
+    assert!(is_type_key("enable-global-virtual-store"));
     assert!(!is_type_key("no-such-setting"));
     // prototype-chain names must not be members
     assert!(!is_type_key("constructor"));
@@ -45,6 +49,8 @@ fn config_file_keys() {
     assert!(is_config_file_key("store-dir"));
     assert!(is_config_file_key("fetch-timeout"));
     assert!(is_config_file_key("cache-dir"));
+    assert!(is_config_file_key("virtual-store-type"));
+    assert!(is_config_file_key("enable-global-virtual-store"));
     // npm-compatible, not excluded
     assert!(is_config_file_key("fetch-retries"));
     assert!(is_config_file_key("registry"));

--- a/pnpm/crates/config/src/env_overlay.rs
+++ b/pnpm/crates/config/src/env_overlay.rs
@@ -14,7 +14,7 @@
 use crate::{
     AuditLevel, CatalogMode, HoistingLimits, NodeLinker, NodePackageMapType, PackageImportMethod,
     PmOnFail, ResolutionMode, RuntimeOnFail, SaveWorkspaceProtocol, ScriptsPrependNodePath,
-    TrustPolicy, VerifyDepsBeforeRun, WorkspaceSettings, api::EnvVar,
+    TrustPolicy, VerifyDepsBeforeRun, VirtualStoreType, WorkspaceSettings, api::EnvVar,
 };
 use serde::de::DeserializeOwned;
 
@@ -147,6 +147,7 @@ impl WorkspaceSettings {
         enum_field!(node_package_map_type, "NODE_PACKAGE_MAP_TYPE", NodePackageMapType);
         json_field!(symlink, "SYMLINK");
         string_field!(virtual_store_dir, "VIRTUAL_STORE_DIR");
+        enum_field!(virtual_store_type, "VIRTUAL_STORE_TYPE", VirtualStoreType);
         json_field!(enable_global_virtual_store, "ENABLE_GLOBAL_VIRTUAL_STORE");
         json_field!(global_shims, "GLOBAL_SHIMS");
         string_field!(global_virtual_store_dir, "GLOBAL_VIRTUAL_STORE_DIR");

--- a/pnpm/crates/config/src/env_overlay/tests.rs
+++ b/pnpm/crates/config/src/env_overlay/tests.rs
@@ -210,5 +210,5 @@ fn virtual_store_type_env_var_parses_its_two_values() {
         WorkspaceSettings::from_pnpm_config_env::<EnvProject>().virtual_store_type,
         Some(VirtualStoreType::Project),
     );
-    assert_eq!(WorkspaceSettings::from_pnpm_config_env::<EnvNonsense>().virtual_store_type, None,);
+    assert_eq!(WorkspaceSettings::from_pnpm_config_env::<EnvNonsense>().virtual_store_type, None);
 }

--- a/pnpm/crates/config/src/env_overlay/tests.rs
+++ b/pnpm/crates/config/src/env_overlay/tests.rs
@@ -183,8 +183,6 @@ fn tri_array_env_var_parses_arrays_and_rejects_null() {
     assert_eq!(parse_tri_array("not-json"), None);
 }
 
-/// `PNPM_CONFIG_VIRTUAL_STORE_TYPE` carries the canonical spelling
-/// through the env layer, and rejects anything outside the two values.
 #[test]
 fn virtual_store_type_env_var_parses_its_two_values() {
     macro_rules! env_with_virtual_store_type {

--- a/pnpm/crates/config/src/env_overlay/tests.rs
+++ b/pnpm/crates/config/src/env_overlay/tests.rs
@@ -1,7 +1,7 @@
 use super::{WorkspaceSettings, parse_json_or_string, parse_tri_array};
 use crate::{
     NodeLinker, NodePackageMapType, SaveWorkspaceProtocol, ScriptsPrependNodePath, TrustPolicy,
-    api::EnvVar,
+    VirtualStoreType, api::EnvVar,
 };
 use pretty_assertions::assert_eq;
 
@@ -181,4 +181,34 @@ fn tri_array_env_var_parses_arrays_and_rejects_null() {
     assert_eq!(parse_tri_array(r#"["a","b"]"#), Some(Some(vec!["a".to_owned(), "b".to_owned()])));
     assert_eq!(parse_tri_array("null"), None);
     assert_eq!(parse_tri_array("not-json"), None);
+}
+
+/// `PNPM_CONFIG_VIRTUAL_STORE_TYPE` carries the canonical spelling
+/// through the env layer, and rejects anything outside the two values.
+#[test]
+fn virtual_store_type_env_var_parses_its_two_values() {
+    macro_rules! env_with_virtual_store_type {
+        ($name:ident, $value:expr) => {
+            struct $name;
+            impl EnvVar for $name {
+                fn var(name: &str) -> Option<String> {
+                    (name == "PNPM_CONFIG_VIRTUAL_STORE_TYPE").then(|| $value.to_owned())
+                }
+            }
+        };
+    }
+
+    env_with_virtual_store_type!(EnvGlobal, "global");
+    env_with_virtual_store_type!(EnvProject, "project");
+    env_with_virtual_store_type!(EnvNonsense, "shared");
+
+    assert_eq!(
+        WorkspaceSettings::from_pnpm_config_env::<EnvGlobal>().virtual_store_type,
+        Some(VirtualStoreType::Global),
+    );
+    assert_eq!(
+        WorkspaceSettings::from_pnpm_config_env::<EnvProject>().virtual_store_type,
+        Some(VirtualStoreType::Project),
+    );
+    assert_eq!(WorkspaceSettings::from_pnpm_config_env::<EnvNonsense>().virtual_store_type, None,);
 }

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -78,13 +78,12 @@ fn default_ci<Sys: EnvVar>(detect_ci: fn() -> bool) -> bool {
 /// Orthogonal to [`NodeLinker`], which picks how a project consumes the
 /// store: `pnp` and `isolated` both work with either type, and `hoisted`
 /// writes no virtual store at all, so the setting is inert there.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum VirtualStoreType {
     /// One store per machine, under `<store-dir>/links`. Slots are keyed
     /// by a dependency-graph hash, so every project resolving a package
     /// the same way links to one directory.
-    #[default]
     Global,
 
     /// One store per project, at `<project>/node_modules/.pnpm`. Slots

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -3078,6 +3078,12 @@ impl Config {
 /// `_auth` key is dropped — it carries credentials and never belongs in
 /// `pnpm config list` output (raw auth keys come from `raw_auth_config`,
 /// censored at render time).
+///
+/// `virtualStoreType` and `enableGlobalVirtualStore` are two spellings of one
+/// setting, so a source that sets the canonical one also decides the boolean:
+/// the record follows [`WorkspaceSettings::apply_to`] and derives it, or
+/// `pnpm config get enableGlobalVirtualStore` would report the spelling the
+/// install did not use.
 fn collect_explicit_settings(
     target: &mut serde_json::Map<String, serde_json::Value>,
     settings: &WorkspaceSettings,
@@ -3090,6 +3096,12 @@ fn collect_explicit_settings(
             continue;
         }
         target.insert(key, value);
+    }
+    if let Some(virtual_store_type) = settings.virtual_store_type {
+        target.insert(
+            "enableGlobalVirtualStore".to_string(),
+            serde_json::Value::Bool(virtual_store_type.is_global()),
+        );
     }
 }
 

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -3080,9 +3080,9 @@ impl Config {
 /// censored at render time).
 ///
 /// `virtualStoreType` and `enableGlobalVirtualStore` are two spellings of one
-/// setting, so a source that sets the canonical one also decides the boolean:
-/// the record follows [`WorkspaceSettings::apply_to`] and derives it, or
-/// `pnpm config get enableGlobalVirtualStore` would report the spelling the
+/// setting, so a source that sets either one decides both: the record follows
+/// [`WorkspaceSettings::apply_to`] and fills in the spelling the source left
+/// out, or `pnpm config get` would answer one of the two with the value the
 /// install did not use.
 fn collect_explicit_settings(
     target: &mut serde_json::Map<String, serde_json::Value>,
@@ -3097,7 +3097,12 @@ fn collect_explicit_settings(
         }
         target.insert(key, value);
     }
-    if let Some(virtual_store_type) = settings.virtual_store_type {
+    let virtual_store_type = settings
+        .virtual_store_type
+        .or_else(|| settings.enable_global_virtual_store.map(VirtualStoreType::from_enable_global));
+    if let Some(virtual_store_type) = virtual_store_type {
+        let Ok(named) = serde_json::to_value(virtual_store_type) else { return };
+        target.insert("virtualStoreType".to_string(), named);
         target.insert(
             "enableGlobalVirtualStore".to_string(),
             serde_json::Value::Bool(virtual_store_type.is_global()),

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -72,6 +72,40 @@ fn default_ci<Sys: EnvVar>(detect_ci: fn() -> bool) -> bool {
         || detect_ci()
 }
 
+/// `virtualStoreType`: where the virtual store lives, and therefore who
+/// shares it.
+///
+/// Orthogonal to [`NodeLinker`], which picks how a project consumes the
+/// store: `pnp` and `isolated` both work with either type, and `hoisted`
+/// writes no virtual store at all, so the setting is inert there.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum VirtualStoreType {
+    /// One store per machine, under `<store-dir>/links`. Slots are keyed
+    /// by a dependency-graph hash, so every project resolving a package
+    /// the same way links to one directory.
+    #[default]
+    Global,
+
+    /// One store per project, at `<project>/node_modules/.pnpm`. Slots
+    /// are keyed by the flat `<name>@<version>` form.
+    Project,
+}
+
+impl VirtualStoreType {
+    /// The `enableGlobalVirtualStore` spelling of this setting.
+    #[must_use]
+    pub fn is_global(self) -> bool {
+        matches!(self, VirtualStoreType::Global)
+    }
+
+    /// The type a given `enableGlobalVirtualStore` value selects.
+    #[must_use]
+    pub fn from_enable_global(enable_global: bool) -> Self {
+        if enable_global { VirtualStoreType::Global } else { VirtualStoreType::Project }
+    }
+}
+
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum NodeLinker {

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -2120,15 +2120,16 @@ pub fn virtual_store_type_supersedes_the_boolean_spelling() {
     }
 }
 
-/// `pnpm config get enableGlobalVirtualStore` reads the explicit-settings
-/// record, which therefore has to name the value the install will use, not
-/// the spelling the canonical key overrode.
+/// `pnpm config get` reads the explicit-settings record, which therefore has
+/// to answer both spellings with the value the install will use — whichever
+/// of the two the file was written in.
 #[test]
 pub fn explicit_settings_report_the_spelling_that_won() {
     for (yaml, expected) in [
         ("virtualStoreType: project\nenableGlobalVirtualStore: true\n", false),
         ("virtualStoreType: global\nenableGlobalVirtualStore: false\n", true),
         ("virtualStoreType: project\n", false),
+        ("enableGlobalVirtualStore: true\n", true),
     ] {
         let tmp = tempdir().unwrap();
         fs::write(tmp.path().join("pnpm-workspace.yaml"), yaml)
@@ -2137,6 +2138,11 @@ pub fn explicit_settings_report_the_spelling_that_won() {
         assert_eq!(
             config.explicit_settings.get("enableGlobalVirtualStore"),
             Some(&serde_json::Value::Bool(expected)),
+            "yaml: {yaml}",
+        );
+        assert_eq!(
+            config.explicit_settings.get("virtualStoreType").and_then(serde_json::Value::as_str),
+            Some(if expected { "global" } else { "project" }),
             "yaml: {yaml}",
         );
         assert_eq!(config.enable_global_virtual_store, expected, "yaml: {yaml}");

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -2101,10 +2101,7 @@ pub fn default_config_disables_gvs_and_points_it_at_the_store() {
     assert_eq!(config.global_virtual_store_dir, config.store_dir.links());
 }
 
-/// `virtualStoreType` is the canonical spelling; `enableGlobalVirtualStore`
-/// is the boolean one pnpm 11 shipped. Both reach the same field, and the
-/// canonical key wins when a file carries both — including when the two
-/// contradict each other.
+/// Both spellings reach one field, so which of them applies last decides.
 #[test]
 pub fn virtual_store_type_supersedes_the_boolean_spelling() {
     for (yaml, expected) in [
@@ -2119,6 +2116,29 @@ pub fn virtual_store_type_supersedes_the_boolean_spelling() {
         fs::write(tmp.path().join("pnpm-workspace.yaml"), yaml)
             .expect("write to pnpm-workspace.yaml");
         let config = Config::new().current::<HostNoHome>(tmp.path()).expect("yaml is valid");
+        assert_eq!(config.enable_global_virtual_store, expected, "yaml: {yaml}");
+    }
+}
+
+/// `pnpm config get enableGlobalVirtualStore` reads the explicit-settings
+/// record, which therefore has to name the value the install will use, not
+/// the spelling the canonical key overrode.
+#[test]
+pub fn explicit_settings_report_the_spelling_that_won() {
+    for (yaml, expected) in [
+        ("virtualStoreType: project\nenableGlobalVirtualStore: true\n", false),
+        ("virtualStoreType: global\nenableGlobalVirtualStore: false\n", true),
+        ("virtualStoreType: project\n", false),
+    ] {
+        let tmp = tempdir().unwrap();
+        fs::write(tmp.path().join("pnpm-workspace.yaml"), yaml)
+            .expect("write to pnpm-workspace.yaml");
+        let config = Config::new().current::<HostNoHome>(tmp.path()).expect("yaml is valid");
+        assert_eq!(
+            config.explicit_settings.get("enableGlobalVirtualStore"),
+            Some(&serde_json::Value::Bool(expected)),
+            "yaml: {yaml}",
+        );
         assert_eq!(config.enable_global_virtual_store, expected, "yaml: {yaml}");
     }
 }

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -2101,6 +2101,28 @@ pub fn default_config_disables_gvs_and_points_it_at_the_store() {
     assert_eq!(config.global_virtual_store_dir, config.store_dir.links());
 }
 
+/// `virtualStoreType` is the canonical spelling; `enableGlobalVirtualStore`
+/// is the boolean one pnpm 11 shipped. Both reach the same field, and the
+/// canonical key wins when a file carries both — including when the two
+/// contradict each other.
+#[test]
+pub fn virtual_store_type_supersedes_the_boolean_spelling() {
+    for (yaml, expected) in [
+        ("virtualStoreType: project\n", false),
+        ("virtualStoreType: global\n", true),
+        ("enableGlobalVirtualStore: false\n", false),
+        ("enableGlobalVirtualStore: true\n", true),
+        ("virtualStoreType: project\nenableGlobalVirtualStore: true\n", false),
+        ("virtualStoreType: global\nenableGlobalVirtualStore: false\n", true),
+    ] {
+        let tmp = tempdir().unwrap();
+        fs::write(tmp.path().join("pnpm-workspace.yaml"), yaml)
+            .expect("write to pnpm-workspace.yaml");
+        let config = Config::new().current::<HostNoHome>(tmp.path()).expect("yaml is valid");
+        assert_eq!(config.enable_global_virtual_store, expected, "yaml: {yaml}");
+    }
+}
+
 #[test]
 pub fn gvs_disabled_keeps_project_local_virtual_store() {
     let tmp = tempdir().unwrap();

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -2,6 +2,7 @@ use crate::{
     AuditConfig, AuditLevel, CatalogMode, Config, HoistingLimits, LinkWorkspacePackages,
     NodeLinker, NodePackageMapType, PackageImportMethod, PmOnFail, ResolutionMode, RuntimeOnFail,
     SaveWorkspaceProtocol, ScriptsPrependNodePath, TrustPolicy, VerifyDepsBeforeRun,
+    VirtualStoreType,
     api::EnvVar,
     proxy_keys::{ProxyKeys, ProxyValue},
     resolve_child_concurrency,
@@ -173,8 +174,13 @@ pub struct WorkspaceSettings {
     pub node_package_map_type: Option<NodePackageMapType>,
     pub symlink: Option<bool>,
     pub virtual_store_dir: Option<String>,
-    /// `enableGlobalVirtualStore` from `pnpm-workspace.yaml`. See
+    /// `virtualStoreType` from `pnpm-workspace.yaml`. See
+    /// [`crate::VirtualStoreType`], and
     /// [`Config::enable_global_virtual_store`] for the default.
+    pub virtual_store_type: Option<VirtualStoreType>,
+    /// `enableGlobalVirtualStore`, the boolean spelling of
+    /// [`Self::virtual_store_type`]. Superseded by it when both are set,
+    /// and kept working for projects written against pnpm 11.
     pub enable_global_virtual_store: Option<bool>,
     /// `virtualStoreOnly` from `pnpm-workspace.yaml`. See
     /// [`Config::virtual_store_only`].
@@ -1165,6 +1171,12 @@ impl WorkspaceSettings {
             config.catalog_prune = v;
         }
 
+        // `virtualStoreType` is the canonical spelling of the boolean
+        // `enableGlobalVirtualStore`, which the macro below applies. Both
+        // land in the same field, so applying this after the macro is what
+        // makes the canonical key win when a file carries both.
+        let virtual_store_type = self.virtual_store_type;
+
         macro_rules! apply {
             ($($field:ident),* $(,)?) => {$(
                 if let Some(v) = self.$field {
@@ -1214,6 +1226,10 @@ impl WorkspaceSettings {
             allowed_deprecated_versions, update_config, peer_dependency_rules,
             enable_pre_post_scripts, dlx_cache_max_age,
             allow_unused_patches,
+        }
+
+        if let Some(virtual_store_type) = virtual_store_type {
+            config.enable_global_virtual_store = virtual_store_type.is_global();
         }
 
         // `globalShims` merges key-wise instead of replacing,

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -179,8 +179,8 @@ pub struct WorkspaceSettings {
     /// [`Config::enable_global_virtual_store`] for the default.
     pub virtual_store_type: Option<VirtualStoreType>,
     /// `enableGlobalVirtualStore`, the boolean spelling of
-    /// [`Self::virtual_store_type`]. Superseded by it when both are set,
-    /// and kept working for projects written against pnpm 11.
+    /// [`Self::virtual_store_type`]. A file may carry either or both; the
+    /// canonical key wins.
     pub enable_global_virtual_store: Option<bool>,
     /// `virtualStoreOnly` from `pnpm-workspace.yaml`. See
     /// [`Config::virtual_store_only`].

--- a/pnpm11/config/reader/src/Config.ts
+++ b/pnpm11/config/reader/src/Config.ts
@@ -12,6 +12,7 @@ import type {
   RegistryOptions,
   TrustPolicy,
   VersioningSettings,
+  VirtualStoreType,
 } from '@pnpm/types'
 
 import type { OptionsFromRootManifest } from './getOptionsFromRootManifest.js'
@@ -187,6 +188,12 @@ export interface Config extends OptionsFromRootManifest {
   virtualStoreDir?: string
   virtualStoreOnly?: boolean
   enableGlobalVirtualStore?: boolean
+  /**
+   * The canonical spelling of {@link Config.enableGlobalVirtualStore}, derived
+   * from it so `pnpm config get` answers either name. Nothing installs off
+   * this field.
+   */
+  virtualStoreType?: VirtualStoreType
   verifyStoreIntegrity?: boolean
   frozenStore?: boolean
   maxSockets?: number

--- a/pnpm11/config/reader/src/configFileKey.ts
+++ b/pnpm11/config/reader/src/configFileKey.ts
@@ -75,6 +75,7 @@ export const pnpmConfigFileKeys = [
   'verify-store-integrity',
   'virtual-store-dir',
   'virtual-store-dir-max-length',
+  'virtual-store-type',
 ] as const satisfies readonly PnpmKey[]
 export type PnpmConfigFileKey = typeof pnpmConfigFileKeys[number]
 

--- a/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
+++ b/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
@@ -354,10 +354,10 @@ function translateAuditSettings (pnpmSettings: PnpmSettings, settings: OptionsFr
  * `enableGlobalVirtualStore` boolean the rest of pnpm reads, and removes the
  * raw key from the returned options.
  *
- * `enableGlobalVirtualStore` is the boolean spelling, kept working for
- * projects written against it. When both are set, `virtualStoreType` wins —
- * silently, like `catalogPrune` superseding `cleanupUnusedCatalogs`, because
- * naming one setting two ways is not itself a mistake worth warning about.
+ * `virtualStoreType` and `enableGlobalVirtualStore` are two spellings of one
+ * setting, and a manifest may carry either or both. The canonical one wins,
+ * silently: spelling a setting two ways is not itself a mistake worth
+ * warning about. Same rule as `catalogPrune` over `cleanupUnusedCatalogs`.
  */
 function translateVirtualStoreType (pnpmSettings: PnpmSettings, settings: OptionsFromRootManifest): void {
   delete (settings as { virtualStoreType?: unknown }).virtualStoreType

--- a/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
+++ b/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
@@ -13,6 +13,7 @@ import {
   type RegistryDeclaration,
   type RegistryOptions,
   type SupportedArchitectures,
+  type VirtualStoreType,
 } from '@pnpm/types'
 import normalizeRegistryUrl from 'normalize-registry-url'
 import { map as mapValues } from 'ramda'
@@ -82,6 +83,7 @@ export function getOptionsFromPnpmSettings (
   translateRegistrySettings(settings)
   translateUpdateSettings(pnpmSettings, settings)
   translateAuditSettings(pnpmSettings, settings)
+  translateVirtualStoreType(pnpmSettings, settings)
 
   return settings
 }
@@ -347,6 +349,26 @@ function translateAuditSettings (pnpmSettings: PnpmSettings, settings: OptionsFr
   }
 }
 
+/**
+ * Translates the user-facing `virtualStoreType` setting into the internal
+ * `enableGlobalVirtualStore` boolean the rest of pnpm reads, and removes the
+ * raw key from the returned options.
+ *
+ * `enableGlobalVirtualStore` is the boolean spelling, kept working for
+ * projects written against it. When both are set, `virtualStoreType` wins —
+ * silently, like `catalogPrune` superseding `cleanupUnusedCatalogs`, because
+ * naming one setting two ways is not itself a mistake worth warning about.
+ */
+function translateVirtualStoreType (pnpmSettings: PnpmSettings, settings: OptionsFromRootManifest): void {
+  delete (settings as { virtualStoreType?: unknown }).virtualStoreType
+  const virtualStoreType = pnpmSettings.virtualStoreType
+  if (virtualStoreType == null) return
+  if (!VIRTUAL_STORE_TYPES.has(virtualStoreType)) {
+    throw new PnpmError('INVALID_SETTING', `The "virtualStoreType" setting should be one of ${Array.from(VIRTUAL_STORE_TYPES).join(', ')}, but got ${JSON.stringify(virtualStoreType)}`)
+  }
+  ;(settings as { enableGlobalVirtualStore?: boolean }).enableGlobalVirtualStore = virtualStoreType === 'global'
+}
+
 function isGetOptionsFromPnpmSettingsOptions (
   value: ProjectManifest | GetOptionsFromPnpmSettingsOptions | undefined
 ): value is GetOptionsFromPnpmSettingsOptions {
@@ -406,6 +428,8 @@ function renderReceivedType (value: unknown): string {
 }
 
 const AUDIT_LEVELS = new Set(['info', 'low', 'moderate', 'high', 'critical'])
+
+const VIRTUAL_STORE_TYPES = new Set<VirtualStoreType>(['global', 'project'])
 
 // The `update`, `audit` and `packageExtensions` sections come from repo-controlled
 // pnpm-workspace.yaml, which is parsed untyped — so their fields are validated

--- a/pnpm11/config/reader/src/index.ts
+++ b/pnpm11/config/reader/src/index.ts
@@ -11,7 +11,7 @@ import { addEsmNodePathLoaderOption } from '@pnpm/exec.esm-node-path-loader'
 import { getCurrentBranch } from '@pnpm/network.git-utils'
 import { applyRuntimeOnFailOverride } from '@pnpm/pkg-manifest.utils'
 import { isCamelCase } from '@pnpm/text.naming-cases'
-import type { DevEngines, EngineDependency, ProjectManifest } from '@pnpm/types'
+import type { DevEngines, EngineDependency, ProjectManifest, VirtualStoreType } from '@pnpm/types'
 import { safeReadProjectManifestOnly } from '@pnpm/workspace.project-manifest-reader'
 import { readWorkspaceManifest, type WorkspaceManifest } from '@pnpm/workspace.workspace-manifest-reader'
 import { betterPathResolve } from 'better-path-resolve'
@@ -574,12 +574,22 @@ export async function getConfig (opts: {
     'umask', // the type is a private function named 'Umask'
   ], types)
 
+  let virtualStoreTypeFromEnv: VirtualStoreType | undefined
   for (const { key, value } of parseEnvVars(key => envPnpmTypes[key as keyof typeof envPnpmTypes], env)) {
     // undefined means that the env key was defined, but its value couldn't be parsed according to the schema
     // TODO: should we throw some error or print some warning here?
     if (value === undefined) continue
 
     if (Object.hasOwn(cliOptions, key) || Object.hasOwn(cliOptions, kebabCase(key))) continue
+
+    // Held back rather than assigned: the rest of pnpm reads the boolean
+    // spelling, and applying the translation after the loop is what makes
+    // the canonical key win over `PNPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE`
+    // whichever order the two arrive in.
+    if (key === 'virtualStoreType') {
+      virtualStoreTypeFromEnv = value as VirtualStoreType
+      continue
+    }
 
     // @ts-expect-error
     pnpmConfig[key] = value
@@ -592,6 +602,10 @@ export async function getConfig (opts: {
       pnpmConfig.registriesByScope.default = normalizeRegistryUrl(value)
       pnpmConfig.packageManagerRegistries.default = normalizeRegistryUrl(value)
     }
+  }
+  if (virtualStoreTypeFromEnv != null) {
+    pnpmConfig.enableGlobalVirtualStore = virtualStoreTypeFromEnv === 'global'
+    explicitlySetKeys.add('enableGlobalVirtualStore')
   }
 
   // After the env loop: PNPM_CONFIG_REGISTRY can still change

--- a/pnpm11/config/reader/src/index.ts
+++ b/pnpm11/config/reader/src/index.ts
@@ -727,6 +727,14 @@ export async function getConfig (opts: {
   // `catalogPrune`'s former name, still accepted. The canonical key wins
   // when both are set.
   pnpmConfig.catalogPrune ??= pnpmConfig.cleanupUnusedCatalogs
+  // Every layer folds `virtualStoreType` into the boolean the rest of pnpm
+  // reads, so the canonical spelling is restored here from the folded value
+  // rather than from any one layer — otherwise `pnpm config get
+  // virtualStoreType` could name the store a later layer overrode.
+  if (explicitlySetKeys.has('enableGlobalVirtualStore')) {
+    pnpmConfig.virtualStoreType = pnpmConfig.enableGlobalVirtualStore ? 'global' : 'project'
+    explicitlySetKeys.add('virtualStoreType')
+  }
   if (!pnpmConfig.httpsProxy) {
     // An empty `proxy=` is unset, so it must not suppress the environment
     // fallback. `false` and `null` keep their meaning: proxying is off.

--- a/pnpm11/config/reader/src/types.ts
+++ b/pnpm11/config/reader/src/types.ts
@@ -134,6 +134,7 @@ export const pnpmTypes = {
   'global-virtual-store-dir': String,
   'virtual-store-dir': String,
   'virtual-store-only': Boolean,
+  'virtual-store-type': ['global', 'project'],
   'virtual-store-dir-max-length': Number,
   'peers-suffix-max-length': Number,
   'workspace-concurrency': Number,

--- a/pnpm11/config/reader/test/getOptionsFromRootManifest.test.ts
+++ b/pnpm11/config/reader/test/getOptionsFromRootManifest.test.ts
@@ -553,3 +553,32 @@ test('getOptionsFromPnpmSettings() rejects a non-boolean supportsTimeField', () 
     },
   })).toThrow(/supportsTimeField" setting should be a boolean, but got string/)
 })
+
+test('getOptionsFromPnpmSettings() translates virtualStoreType to enableGlobalVirtualStore', () => {
+  for (const [virtualStoreType, expected] of [['global', true], ['project', false]] as const) {
+    const options = getOptionsFromPnpmSettings(process.cwd(), { virtualStoreType }) as any // eslint-disable-line
+    expect(options.enableGlobalVirtualStore).toBe(expected)
+    expect(options.virtualStoreType).toBeUndefined()
+  }
+})
+
+test('getOptionsFromPnpmSettings() lets virtualStoreType win over enableGlobalVirtualStore', () => {
+  const options = getOptionsFromPnpmSettings(process.cwd(), {
+    virtualStoreType: 'project',
+    enableGlobalVirtualStore: true,
+  }) as any // eslint-disable-line
+  expect(options.enableGlobalVirtualStore).toBe(false)
+})
+
+test('getOptionsFromPnpmSettings() keeps enableGlobalVirtualStore working on its own', () => {
+  const options = getOptionsFromPnpmSettings(process.cwd(), {
+    enableGlobalVirtualStore: true,
+  }) as any // eslint-disable-line
+  expect(options.enableGlobalVirtualStore).toBe(true)
+})
+
+test('getOptionsFromPnpmSettings() rejects an unknown virtualStoreType', () => {
+  expect(() => getOptionsFromPnpmSettings(process.cwd(), {
+    virtualStoreType: 'shared' as never,
+  })).toThrow(/The "virtualStoreType" setting should be one of global, project, but got "shared"/)
+})

--- a/pnpm11/config/reader/test/getOptionsFromRootManifest.test.ts
+++ b/pnpm11/config/reader/test/getOptionsFromRootManifest.test.ts
@@ -563,11 +563,16 @@ test('getOptionsFromPnpmSettings() translates virtualStoreType to enableGlobalVi
 })
 
 test('getOptionsFromPnpmSettings() lets virtualStoreType win over enableGlobalVirtualStore', () => {
-  const options = getOptionsFromPnpmSettings(process.cwd(), {
-    virtualStoreType: 'project',
-    enableGlobalVirtualStore: true,
-  }) as any // eslint-disable-line
-  expect(options.enableGlobalVirtualStore).toBe(false)
+  for (const [virtualStoreType, enableGlobalVirtualStore, expected] of [
+    ['project', true, false],
+    ['global', false, true],
+  ] as const) {
+    const options = getOptionsFromPnpmSettings(process.cwd(), {
+      virtualStoreType,
+      enableGlobalVirtualStore,
+    }) as any // eslint-disable-line
+    expect(options.enableGlobalVirtualStore).toBe(expected)
+  }
 })
 
 test('getOptionsFromPnpmSettings() keeps enableGlobalVirtualStore working on its own', () => {

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -4586,7 +4586,46 @@ test.each([
   })
 
   expect(config.enableGlobalVirtualStore).toBe(expected)
-  expect((config as { virtualStoreType?: unknown }).virtualStoreType).toBeUndefined()
+  expect(config.virtualStoreType).toBe(virtualStoreType)
+})
+
+// `pnpm config get` reads either spelling off the config, so the one the
+// user did not write has to carry the value the install will use.
+test.each([
+  [true, 'global'],
+  [false, 'project'],
+] as const)('enableGlobalVirtualStore=%s names the store type', async (enableGlobalVirtualStore, expected) => {
+  prepareEmpty()
+
+  writeYamlFileSync('pnpm-workspace.yaml', { enableGlobalVirtualStore })
+
+  const { config } = await getConfig({
+    cliOptions: {},
+    env,
+    packageManager: {
+      name: 'pnpm',
+      version: '1.0.0',
+    },
+    workspaceDir: process.cwd(),
+  })
+
+  expect(config.virtualStoreType).toBe(expected)
+})
+
+test('an unset virtual store type is not reported as either spelling', async () => {
+  prepareEmpty()
+
+  const { config } = await getConfig({
+    cliOptions: {},
+    env,
+    packageManager: {
+      name: 'pnpm',
+      version: '1.0.0',
+    },
+    workspaceDir: process.cwd(),
+  })
+
+  expect(config.virtualStoreType).toBeUndefined()
 })
 
 test('PNPM_CONFIG_VIRTUAL_STORE_TYPE wins over the boolean spelling in the same layer', async () => {
@@ -4607,6 +4646,7 @@ test('PNPM_CONFIG_VIRTUAL_STORE_TYPE wins over the boolean spelling in the same 
   })
 
   expect(config.enableGlobalVirtualStore).toBe(false)
+  expect(config.virtualStoreType).toBe('project')
 })
 
 test('enableGlobalVirtualStore exposes hoisted dependencies through NODE_PATH and the ESM loader', async () => {

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -4569,6 +4569,46 @@ test('ci respects explicit enableGlobalVirtualStore from config', async () => {
   expect(config.enableGlobalVirtualStore).toBe(true)
 })
 
+test.each([
+  ['global', true],
+  ['project', false],
+] as const)('PNPM_CONFIG_VIRTUAL_STORE_TYPE=%s selects the store type', async (virtualStoreType, expected) => {
+  prepareEmpty()
+
+  const { config } = await getConfig({
+    cliOptions: {},
+    env: { ...env, PNPM_CONFIG_VIRTUAL_STORE_TYPE: virtualStoreType },
+    packageManager: {
+      name: 'pnpm',
+      version: '1.0.0',
+    },
+    workspaceDir: process.cwd(),
+  })
+
+  expect(config.enableGlobalVirtualStore).toBe(expected)
+  expect((config as { virtualStoreType?: unknown }).virtualStoreType).toBeUndefined()
+})
+
+test('PNPM_CONFIG_VIRTUAL_STORE_TYPE wins over the boolean spelling in the same layer', async () => {
+  prepareEmpty()
+
+  const { config } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      PNPM_CONFIG_VIRTUAL_STORE_TYPE: 'project',
+      PNPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE: 'true',
+    },
+    packageManager: {
+      name: 'pnpm',
+      version: '1.0.0',
+    },
+    workspaceDir: process.cwd(),
+  })
+
+  expect(config.enableGlobalVirtualStore).toBe(false)
+})
+
 test('enableGlobalVirtualStore exposes hoisted dependencies through NODE_PATH and the ESM loader', async () => {
   prepareEmpty()
 

--- a/pnpm11/core/types/src/package.ts
+++ b/pnpm11/core/types/src/package.ts
@@ -280,7 +280,21 @@ export interface PnpmSettings {
   noProxy?: string | boolean
   pnprServer?: string
   versioning?: VersioningSettings
+  /**
+   * Where the virtual store lives, and therefore who shares it: one store
+   * per machine (`global`) or one per project (`project`).
+   *
+   * The canonical spelling of {@link PnpmSettings.enableGlobalVirtualStore},
+   * which is kept working. When both are set, this one wins.
+   */
+  virtualStoreType?: VirtualStoreType
+  /**
+   * The boolean spelling of {@link PnpmSettings.virtualStoreType}.
+   */
+  enableGlobalVirtualStore?: boolean
 }
+
+export type VirtualStoreType = 'global' | 'project'
 
 export interface ProjectManifest extends BaseManifest {
   packageManager?: string

--- a/pnpm11/core/types/src/package.ts
+++ b/pnpm11/core/types/src/package.ts
@@ -284,8 +284,8 @@ export interface PnpmSettings {
    * Where the virtual store lives, and therefore who shares it: one store
    * per machine (`global`) or one per project (`project`).
    *
-   * The canonical spelling of {@link PnpmSettings.enableGlobalVirtualStore},
-   * which is kept working. When both are set, this one wins.
+   * The canonical spelling of {@link PnpmSettings.enableGlobalVirtualStore}.
+   * When both are set, this one wins.
    */
   virtualStoreType?: VirtualStoreType
   /**


### PR DESCRIPTION
## Summary

Adds `virtualStoreType`, the canonical spelling of `enableGlobalVirtualStore`:

```yaml
virtualStoreType: global   # or: project
```

The boolean keeps working, so nothing set against pnpm 11 has to change. When a file carries both, `virtualStoreType` wins. The default is untouched on both sides — `project`, so the shared store stays opt-in, as pnpm/pnpm#13963 restored it.

### Why rename

`enableGlobalVirtualStore` doesn't follow the convention that a setting sorts under what it modifies: it belongs next to `virtualStoreDir`, `virtualStoreDirMaxLength`, and `virtualStoreOnly`, not under "enable". It also reads as a switch on one feature when what it selects is *which of two stores* an install materializes into — one per machine, slots keyed by dependency-graph hash, or one per project, slots keyed by the flat `<name>@<version>` form. Naming the axis leaves room for a third value later; a boolean does not.

### Why not a `nodeLinker` value

`nodeLinker` picks how a project *consumes* the store; this picks *where the store lives*. They compose, and pacquet already depends on that: `global_virtual_store.rs` has a test installing with `nodeLinker: pnp`, `symlink: false`, and the shared store, then repairing a deleted slot. Folding the store type into `nodeLinker` would make "PnP sharing the machine-wide store" inexpressible. `nodeLinker: hoisted` writes no virtual store at all, so the setting is inert there rather than invalid — there's no illegal-state problem to solve by merging them.

### Superseding is silent

Following `cleanupUnusedCatalogs` → `catalogPrune` (silent, canonical key wins) rather than `update` / `updateConfig` (warns). Spelling one setting two ways isn't itself a mistake, and silence keeps the two stacks observably identical: pacquet's config layer has no user-visible warning channel — its `updateConfig` warning goes to `tracing::warn!`, which is dropped unless `TRACE` is set, while the TypeScript one is a real `globalWarn`.

### Where the setting is accepted

Both stacks read it from `pnpm-workspace.yaml`, from the global config file, and from `PNPM_CONFIG_VIRTUAL_STORE_TYPE`. Within one source the canonical key wins; across sources the normal cascade applies, so an env-var `enableGlobalVirtualStore` still outranks a yaml `virtualStoreType`.

### `pnpm config get` answers either name

The two spellings are one setting, so reporting one and not the other would be a hole a user falls into as soon as they run `pnpm config get` with the name they didn't write. Whichever spelling a source uses, both are reported with the value the install will use:

- **pacquet** derives the missing one per source, in the same order `WorkspaceSettings::apply_to` folds them, so a later source that flips the setting flips both names with it.
- **TypeScript** derives `virtualStoreType` once from the folded boolean, because by then every layer has already collapsed into it. Nothing installs off that field; it exists so `config get` can answer.

### Both stacks

- **pacquet**: `VirtualStoreType` enum, the yaml key, the env var, and the `types` / config-file-key registrations that make it settable and gettable. Applied after the settings macro, which is what makes the canonical key win within a source.
- **TypeScript (pnpm 11)**: `translateVirtualStoreType` in `getOptionsFromRootManifest.ts`, mirroring `translateUpdateSettings`, plus the env var held back until the env loop finishes so it wins over `PNPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE` whichever order the two are read in. An unknown value throws `ERR_PNPM_INVALID_SETTING`. Same vocabulary, same default, so a `pnpm-workspace.yaml` written for pnpm 12 isn't silently misread by pnpm 11.

### Known gap

Neither stack accepts `--config.virtual-store-type` on the command line — the same gap `--config.enable-global-virtual-store` already has, and not one this PR widens.

### Testing

- Rust: a config-cascade test over all four spellings including the contradictory pairs, an explicit-settings test asserting both names report the winner, an env-var parse test (both values plus a rejected one), a `config get` test over both spellings, and an end-to-end install test asserting *where packages actually land* for each spelling.
- TypeScript: the translation, precedence, the boolean on its own, and the invalid-value error over `getOptionsFromPnpmSettings`; the env var, its precedence over the boolean, the backfilled canonical name, and the unset case over `getConfig`.
- Each side was deliberately broken to confirm the tests fail. Rebased over pnpm/pnpm#13963, which returned the shared store to opt-in: `pnpm-config` green (499 passed), the `global_virtual_store` suite green (29 passed), `pnpm-cli`'s `config` tests green (35 passed), `@pnpm/config.reader` green (409 passed), `@pnpm/config.commands` green (155 passed).

## Squash Commit Body

```text
Adds `virtualStoreType: global | project`, the canonical spelling of
`enableGlobalVirtualStore`. The boolean keeps working; when a source
carries both, the canonical key wins.

`enableGlobalVirtualStore` does not follow the convention that a setting
sorts under what it modifies — it belongs with `virtualStoreDir`,
`virtualStoreDirMaxLength`, and `virtualStoreOnly`, not under "enable".
It also reads as a switch on one feature when what it selects is which
of two stores an install materializes into: one per machine, keyed by
dependency-graph hash, or one per project, keyed by the flat
`<name>@<version>` form. Naming the axis leaves room for a third value
later, which a boolean does not.

It stays separate from `nodeLinker` rather than becoming a value of it:
the two compose. `pnp` installs into either store type (pacquet has a
test for pnp + the shared store), and `hoisted` writes no virtual store
at all, so the setting is inert there rather than invalid.

Superseding is silent, following the `cleanupUnusedCatalogs` ->
`catalogPrune` rename rather than the `update` / `updateConfig` pair
that warns: spelling a setting two ways is not itself a mistake. It
also keeps the stacks observably identical, since pacquet's config layer
has no user-visible warning channel.

Both names are accepted from `pnpm-workspace.yaml`, the global config
file, and the environment, and `pnpm config get` answers either one with
the value the install will use — the spelling a source leaves out is
derived from the one it sets.

The default is untouched on both sides: the shared store stays opt-in.
`VirtualStoreType` deliberately has no `Default` impl — nothing
constructs it that way, and an unused default is free to drift from
`default_enable_global_virtual_store` the next time that moves.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed. (pnpm.io lives in another repo;
  its settings page needs the new name alongside the old one.)

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `virtualStoreType` configuration with `global` and `project` options to control virtual-store placement.
  * Supports project and global configuration files, environment variables, root manifests, and configuration inspection commands.
  * The new setting takes precedence over the legacy `enableGlobalVirtualStore` option, which remains supported.
  * Invalid values are rejected with a clear configuration error.
  * Existing version-specific defaults are preserved, and the setting remains independent of the selected node linker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->