### PR TITLE
feat(resolver): read per-version time from abbreviated metadata

### DIFF
--- a/pnpm/crates/package-manager/src/build_resolution_verifiers.rs
+++ b/pnpm/crates/package-manager/src/build_resolution_verifiers.rs
@@ -110,6 +110,7 @@ pub fn build_resolution_verifiers(
 
     let opts = CreateNpmResolutionVerifierOptions {
         minimum_release_age: config.resolved_minimum_release_age(),
+        registry_supports_time_field: config.registry_supports_time_field,
         minimum_release_age_exclude: min_age_exclude,
         minimum_release_age_exclude_patterns: config
             .minimum_release_age_exclude

--- a/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
@@ -100,6 +100,13 @@ pub struct CreateNpmResolutionVerifierOptions {
     /// `true` and the registry strips per-version `time`, the verifier
     /// passes the entry instead of failing closed. Default `false`.
     pub ignore_missing_time_field: bool,
+    /// Backs `registrySupportsTimeField`: the registry serves the
+    /// per-version `time` map in abbreviated metadata (Verdaccio
+    /// 5.15.1+, pnpr), so the verifier can take a version's publish
+    /// timestamp from the document it already fetched instead of
+    /// paying an attestation round-trip and a full-packument download
+    /// per cold-cache package. Default `false`.
+    pub registry_supports_time_field: bool,
     /// `'no-downgrade'` enables the trust check;
     /// [`TrustPolicy::Off`] disables it. Stored as an [`Option`] so
     /// `None` and `Some(Off)` both disable the check while still
@@ -160,6 +167,7 @@ pub struct NpmResolutionVerifier {
     cutoff: Option<DateTime<Utc>>,
     minimum_release_age_exclude: Option<PackageVersionPolicy>,
     ignore_missing_time_field: bool,
+    registry_supports_time_field: bool,
     trust_policy: Option<TrustPolicy>,
     trust_policy_exclude: Option<PackageVersionPolicy>,
     trust_policy_ignore_after: Option<u64>,
@@ -192,6 +200,7 @@ impl std::fmt::Debug for NpmResolutionVerifier {
             .field("minimum_release_age_minutes", &self.minimum_release_age_minutes)
             .field("cutoff", &self.cutoff)
             .field("ignore_missing_time_field", &self.ignore_missing_time_field)
+            .field("registry_supports_time_field", &self.registry_supports_time_field)
             .field("trust_policy", &self.trust_policy)
             .field("trust_policy_ignore_after", &self.trust_policy_ignore_after)
             .field("offline", &self.offline)
@@ -250,6 +259,7 @@ pub fn create_npm_resolution_verifier(
         cutoff,
         minimum_release_age_exclude: opts.minimum_release_age_exclude,
         ignore_missing_time_field: opts.ignore_missing_time_field,
+        registry_supports_time_field: opts.registry_supports_time_field,
         trust_policy: opts.trust_policy,
         trust_policy_exclude: opts.trust_policy_exclude,
         trust_policy_ignore_after: opts.trust_policy_ignore_after,
@@ -645,13 +655,19 @@ impl NpmResolutionVerifier {
     ///    timestamps. Costs at most one abbreviated GET per name on
     ///    cold cache; the full-meta fallback below is hundreds of KB
     ///    bigger per package.
-    /// 2. **On-disk full-meta mirror.** If a previous verification
+    /// 2. **Abbreviated per-version `time`** — only with
+    ///    `registrySupportsTimeField`. Registries that serve the `time`
+    ///    map in abbreviated metadata (Verdaccio 5.15.1+, pnpr) already
+    ///    gave us the exact per-version timestamp in the document step 1
+    ///    fetched, so a recent `modified` does not have to escalate to
+    ///    the per-version fallbacks below.
+    /// 3. **On-disk full-meta mirror.** If a previous verification
     ///    populated `<cache_dir>/v11/metadata-full/.../<name>.jsonl`,
     ///    take the per-version timestamp from there with no network.
-    /// 3. **Npm attestation endpoint.** Small payload, just this
+    /// 4. **Npm attestation endpoint.** Small payload, just this
     ///    version's Sigstore-anchored timestamp. Wins on cold cache
     ///    when the package was published with provenance.
-    /// 4. **Full metadata fetch.** Last resort.
+    /// 5. **Full metadata fetch.** Last resort.
     async fn resolve_published_at(
         &self,
         registry: &str,
@@ -659,6 +675,11 @@ impl NpmResolutionVerifier {
         version: &str,
     ) -> Result<Option<String>, String> {
         if let Some(value) = self.try_abbreviated_modified_shortcut(registry, name, version).await {
+            return Ok(Some(value));
+        }
+        if self.registry_supports_time_field
+            && let Some(value) = self.abbreviated_version_time(registry, name, version).await
+        {
             return Ok(Some(value));
         }
         if let Some(map) = self.read_local_meta_time(registry, name).await
@@ -705,6 +726,22 @@ impl NpmResolutionVerifier {
         Some(modified)
     }
 
+    /// The pinned version's publish timestamp from the abbreviated
+    /// document's `time` map. Reuses the same cached projection as the
+    /// `modified` shortcut, so with `registrySupportsTimeField` the
+    /// whole lookup stays within the one document the verifier already
+    /// holds. A fetch failure or an absent entry falls through to the
+    /// per-version fallbacks, exactly like the shortcut above.
+    async fn abbreviated_version_time(
+        &self,
+        registry: &str,
+        name: &PkgName,
+        version: &str,
+    ) -> Option<String> {
+        let meta = self.fetch_abbreviated_meta(registry, name).await.ok()?;
+        meta.version_time.as_ref()?.get(version).cloned()
+    }
+
     /// Per-`(registry, name)` abbreviated-meta lookup. The result is
     /// projected down to `(modified, versionNames)` and cached so
     /// repeat verifications of the same package within an install
@@ -737,7 +774,7 @@ impl NpmResolutionVerifier {
         let value = cell
             .get_or_init(|| async {
                 if let Some(shared) = self.read_shared_meta(registry, name) {
-                    return Ok(project_abbreviated_meta(&shared));
+                    return Ok(project_abbreviated_meta(&shared, self.registry_supports_time_field));
                 }
                 let opts = FetchFullMetadataCachedOptions {
                     registry,
@@ -755,7 +792,7 @@ impl NpmResolutionVerifier {
                 // from a version genuinely absent from the metadata, otherwise
                 // it reports a 403 as a tampering-style mismatch.
                 match fetch_full_metadata_cached(&name.to_string(), &opts).await {
-                    Ok(meta) => Ok(project_abbreviated_meta(&meta)),
+                    Ok(meta) => Ok(project_abbreviated_meta(&meta, self.registry_supports_time_field)),
                     Err(error) => Err(render_fetch_metadata_error(&error)),
                 }
             })
@@ -1159,7 +1196,10 @@ fn project_trust_package_version(version: &PackageVersion) -> PackageVersion {
 /// needs out of a packument document. Works against either the
 /// abbreviated or the full form — both carry `modified` and a
 /// `versions` map with per-version `dist.tarball`.
-fn project_abbreviated_meta(meta: &Package) -> crate::lookup_context::AbbreviatedMetaProjection {
+fn project_abbreviated_meta(
+    meta: &Package,
+    include_time: bool,
+) -> crate::lookup_context::AbbreviatedMetaProjection {
     let version_tarballs = meta
         .versions
         .iter()
@@ -1177,10 +1217,21 @@ fn project_abbreviated_meta(meta: &Package) -> crate::lookup_context::Abbreviate
                 .then(|| (version.clone(), stats))
         })
         .collect();
+    // `time` also carries package-level `created`/`modified` keys; keeping
+    // them is harmless (lookups are by exact version) and cheaper than
+    // filtering against the versions map.
+    let version_time = include_time.then(|| {
+        meta.time
+            .iter()
+            .flatten()
+            .filter_map(|(key, value)| Some((key.clone(), value.as_str()?.to_owned())))
+            .collect()
+    });
     crate::lookup_context::AbbreviatedMetaProjection {
         modified: meta.modified.clone(),
         version_tarballs: Some(version_tarballs),
         version_dist_stats: Some(version_dist_stats),
+        version_time,
     }
 }
 

--- a/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
@@ -774,7 +774,10 @@ impl NpmResolutionVerifier {
         let value = cell
             .get_or_init(|| async {
                 if let Some(shared) = self.read_shared_meta(registry, name) {
-                    return Ok(project_abbreviated_meta(&shared, self.registry_supports_time_field));
+                    return Ok(project_abbreviated_meta(
+                        &shared,
+                        self.registry_supports_time_field,
+                    ));
                 }
                 let opts = FetchFullMetadataCachedOptions {
                     registry,
@@ -792,7 +795,9 @@ impl NpmResolutionVerifier {
                 // from a version genuinely absent from the metadata, otherwise
                 // it reports a 403 as a tampering-style mismatch.
                 match fetch_full_metadata_cached(&name.to_string(), &opts).await {
-                    Ok(meta) => Ok(project_abbreviated_meta(&meta, self.registry_supports_time_field)),
+                    Ok(meta) => {
+                        Ok(project_abbreviated_meta(&meta, self.registry_supports_time_field))
+                    }
                     Err(error) => Err(render_fetch_metadata_error(&error)),
                 }
             })

--- a/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/tests.rs
@@ -1459,7 +1459,6 @@ async fn version_absent_from_fetched_metadata_stays_tarball_url_mismatch() {
     assert_eq!(code, "TARBALL_URL_MISMATCH");
 }
 
-
 /// With `registrySupportsTimeField`, a version's publish timestamp is
 /// taken from the `time` map of the abbreviated document the verifier
 /// already fetched. The `modified` shortcut cannot answer here (the

--- a/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/tests.rs
@@ -1559,6 +1559,15 @@ async fn without_registry_supports_time_field_abbreviated_time_is_not_consulted(
         .expect(2)
         .create_async()
         .await;
+    // Without the flag the per-version fallbacks run in order, so the
+    // attestation endpoint is consulted (and 404s) before the full
+    // packument. Asserting it makes the escalation the flag avoids explicit.
+    let attestation_mock = server
+        .mock("GET", "/-/npm/v1/attestations/aged-pkg@1.0.0")
+        .with_status(404)
+        .expect(1)
+        .create_async()
+        .await;
     let mut opts = default_opts(&registry);
     opts.minimum_release_age = Some(60 * 24);
     let verifier = create_npm_resolution_verifier(opts);
@@ -1572,4 +1581,5 @@ async fn without_registry_supports_time_field_abbreviated_time_is_not_consulted(
     let result = verifier.verify(&resolution, ctx(&name, "1.0.0")).await;
     assert_eq!(result, ResolutionVerification::Ok);
     meta_mock.assert_async().await;
+    attestation_mock.assert_async().await;
 }

--- a/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/tests.rs
@@ -57,6 +57,7 @@ fn default_opts(registry_url: &str) -> CreateNpmResolutionVerifierOptions {
         minimum_release_age_exclude: None,
         minimum_release_age_exclude_patterns: Vec::new(),
         ignore_missing_time_field: false,
+        registry_supports_time_field: false,
         trust_policy: None,
         trust_policy_exclude: None,
         trust_policy_exclude_patterns: Vec::new(),
@@ -1456,4 +1457,119 @@ async fn version_absent_from_fetched_metadata_stays_tarball_url_mismatch() {
         panic!("expected Err, got {result:?}");
     };
     assert_eq!(code, "TARBALL_URL_MISMATCH");
+}
+
+
+/// With `registrySupportsTimeField`, a version's publish timestamp is
+/// taken from the `time` map of the abbreviated document the verifier
+/// already fetched. The `modified` shortcut cannot answer here (the
+/// package was modified inside the cutoff window), and no other source
+/// is mocked, so a passing verification proves the timestamp came from
+/// the abbreviated document — the attestation round-trip and the
+/// full-packument download never happen.
+#[tokio::test]
+async fn registry_supports_time_field_reads_version_time_from_abbreviated_meta() {
+    let mut server = mockito::Server::new_async().await;
+    let registry = format!("{}/", server.url());
+    let server_url = server.url();
+    let now = Utc::now();
+    let meta = serde_json::json!({
+        "name": "aged-pkg",
+        "dist-tags": { "latest": "1.0.0" },
+        // Package touched *inside* the cutoff window: the modified
+        // shortcut must fall through.
+        "modified": now.to_rfc3339(),
+        "time": {
+            "created": "2020-01-01T00:00:00.000Z",
+            "modified": now.to_rfc3339(),
+            // The pinned version itself is years old.
+            "1.0.0": "2020-01-01T00:00:00.000Z"
+        },
+        "versions": {
+            "1.0.0": {
+                "name": "aged-pkg",
+                "version": "1.0.0",
+                "dist": {
+                    "integrity": FAKE_INTEGRITY,
+                    "shasum": "0000000000000000000000000000000000000000",
+                    "tarball": format!("{server_url}/aged-pkg/-/aged-pkg-1.0.0.tgz"),
+                }
+            }
+        }
+    });
+    let meta_mock = server
+        .mock("GET", "/aged-pkg")
+        .with_status(200)
+        .with_body(meta.to_string())
+        // The whole point: one abbreviated fetch answers everything. A
+        // second hit would be the full-packument fallback this flag
+        // exists to avoid.
+        .expect(1)
+        .create_async()
+        .await;
+    let mut opts = default_opts(&registry);
+    opts.minimum_release_age = Some(60 * 24); // 24h
+    opts.registry_supports_time_field = true;
+    let verifier = create_npm_resolution_verifier(opts);
+    let resolution = LockfileResolution::Tarball(TarballResolution {
+        tarball: format!("{server_url}/aged-pkg/-/aged-pkg-1.0.0.tgz"),
+        integrity: Some(fake_integrity()),
+        git_hosted: None,
+        path: None,
+    });
+    let name: PkgName = "aged-pkg".parse().expect("parse");
+    let result = verifier.verify(&resolution, ctx(&name, "1.0.0")).await;
+    assert_eq!(result, ResolutionVerification::Ok);
+    meta_mock.assert_async().await;
+}
+
+/// Same registry document, flag unset: the verifier still passes, but
+/// only by escalating to the full-packument fetch — a second request
+/// for the same document. Guards both directions: the new step never
+/// runs without the flag, and the request the flag saves is real.
+#[tokio::test]
+async fn without_registry_supports_time_field_abbreviated_time_is_not_consulted() {
+    let mut server = mockito::Server::new_async().await;
+    let registry = format!("{}/", server.url());
+    let server_url = server.url();
+    let now = Utc::now();
+    let meta = serde_json::json!({
+        "name": "aged-pkg",
+        "dist-tags": { "latest": "1.0.0" },
+        "modified": now.to_rfc3339(),
+        "time": { "1.0.0": "2020-01-01T00:00:00.000Z" },
+        "versions": {
+            "1.0.0": {
+                "name": "aged-pkg",
+                "version": "1.0.0",
+                "dist": {
+                    "integrity": FAKE_INTEGRITY,
+                    "shasum": "0000000000000000000000000000000000000000",
+                    "tarball": format!("{server_url}/aged-pkg/-/aged-pkg-1.0.0.tgz"),
+                }
+            }
+        }
+    });
+    let meta_mock = server
+        .mock("GET", "/aged-pkg")
+        .with_status(200)
+        .with_body(meta.to_string())
+        // Abbreviated fetch for the modified shortcut, then the
+        // full-packument fallback for the per-version timestamp.
+        .expect(2)
+        .create_async()
+        .await;
+    let mut opts = default_opts(&registry);
+    opts.minimum_release_age = Some(60 * 24);
+    let verifier = create_npm_resolution_verifier(opts);
+    let resolution = LockfileResolution::Tarball(TarballResolution {
+        tarball: format!("{server_url}/aged-pkg/-/aged-pkg-1.0.0.tgz"),
+        integrity: Some(fake_integrity()),
+        git_hosted: None,
+        path: None,
+    });
+    let name: PkgName = "aged-pkg".parse().expect("parse");
+    let result = verifier.verify(&resolution, ctx(&name, "1.0.0")).await;
+    assert_eq!(result, ResolutionVerification::Ok);
+    meta_mock.assert_async().await;
 }

--- a/pnpm/crates/resolving-npm-resolver/src/lookup_context.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/lookup_context.rs
@@ -47,6 +47,12 @@ pub(crate) struct AbbreviatedMetaProjection {
     ///
     /// [`ObservedDistStats`]: crate::ObservedDistStats
     pub version_dist_stats: Option<HashMap<String, crate::DistStats>>,
+    /// version → publish timestamp from the document's `time` map, for
+    /// registries that serve it in abbreviated metadata
+    /// (`registrySupportsTimeField`). Populated only when the verifier
+    /// asked for it, so registries without the field pay no memory for
+    /// an always-empty map.
+    pub version_time: Option<HashMap<String, String>>,
 }
 
 /// Slot map of singleflight cells. Outer mutex guards lookup/insert;


### PR DESCRIPTION
Fixes pnpm/pnpm#13936.

## The problem

When a registry serves the per-version `time` map in its **abbreviated** metadata (Verdaccio 5.15.1+, pnpr), `registrySupportsTimeField: true` is supposed to let the `minimumReleaseAge` check take a version's publish timestamp from the abbreviated document instead of escalating to per-version lookups.

The pnpm-12 Rust verifier never consulted the setting. `resolve_published_at` layered: abbreviated-`modified` shortcut → on-disk full-meta mirror → attestation endpoint → full packument. Any package whose package-level `modified` falls inside the cutoff window — every actively published package, since the default cutoff is 24h — skips the shortcut and, on a cold cache, pays an attestation round-trip **plus a full-packument download**, even against a registry whose abbreviated document already carried the exact per-version timestamp needed.

As @zkochan noted on the issue, pnpr deliberately includes `time` in abbreviated metadata *for this check*, and the client was going out of its way not to read it.

## The change

A new step slots between the `modified` shortcut and the on-disk mirror: when `registrySupportsTimeField` is set, read `time[version]` from the abbreviated projection the verifier already fetched.

- The flag is threaded `CreateNpmResolutionVerifierOptions` → the verifier → the config builder (`build_resolution_verifiers.rs`), mirroring the existing `ignore_missing_time_field` plumbing.
- The projection carries the `time` map **only when the flag is set**, so registries without the field pay no memory for an always-empty map.
- A fetch failure or an absent entry falls through to the existing per-version fallbacks unchanged — the step can only save work, never change a verdict.

## Verification

Two tests in `create_npm_resolution_verifier/tests.rs`, both against a package whose `modified` is inside the cutoff window (so the shortcut can't answer) with the pinned version years old in `time`:

- **with the flag:** verification passes and the mocked registry sees **exactly one** metadata request — the abbreviated document answers everything.
- **without the flag:** verification still passes, but only by escalating to the full-packument fetch — the mock sees **two** requests. This guards both directions: the new step never runs unflagged, and the request the flag saves is real.

Run via `cargo test -p pacquet-resolving-npm-resolver create_npm_resolution_verifier`; the full module is green.

## TypeScript side

The TypeScript verifier has the **same gap**: `resolving/npm-resolver/src/createNpmResolutionVerifier.ts`'s `resolvePublishedAt` also goes abbreviated-`modified` shortcut → local mirror → attestation → full metadata, with no `registrySupportsTimeField` step. This issue is specifically about the pnpm-12 Rust entrypoint, so I've done the Rust side here; per `AGENTS.md` I'm flagging the equivalent TS change as still needing to follow. Happy to add it to this PR if you'd prefer it land together.

---
Written by an agent (Claude Code, claude-sonnet-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789495612&installation_model_id=426870&pr_number=13946&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13946&signature=684048fc9d60c7cfc2127852a6141f8bba7ac3f0ca2fb5eb272edaa96fc94bdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved minimum release age validation using publish timestamps from abbreviated registry metadata when available.
  * Reduced additional metadata lookups during package resolution.
  * Added compatibility for registries that do not provide per-version publish times.

* **Bug Fixes**
  * Improved consistency of publish-time checks across supported registry configurations.

* **Tests**
  * Added coverage for timestamp-based validation, reduced lookups, and fallback behavior across registry configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->