### PR TITLE
fix(self-update): bump caret/tilde devEngines.packageManager ranges

### DIFF
--- a/.changeset/self-update-bumps-simple-ranges.md
+++ b/.changeset/self-update-bumps-simple-ranges.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/engine.pm.commands": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+`pnpm self-update` now bumps `devEngines.packageManager.version` when it is a simple range (`^`/`~`) that the new version still satisfies, keeping the same operator — matching `pnpm update` and `pnpm runtime set`. Complex ranges such as `>=8.0.0` are still left unchanged.

--- a/.changeset/self-update-bumps-simple-ranges.md
+++ b/.changeset/self-update-bumps-simple-ranges.md
@@ -4,4 +4,4 @@
 "pacquet": patch
 ---
 
-`pnpm self-update` now bumps `devEngines.packageManager.version` when it is a simple range (`^`/`~`) that the new version still satisfies, keeping the same operator — matching `pnpm update` and `pnpm runtime set`. Complex ranges such as `>=8.0.0` are still left unchanged.
+`pnpm self-update` now rewrites a simple `devEngines.packageManager.version` range (`^`/`~`) to the newly installed version, keeping the operator — matching how `pnpm update` and `pnpm runtime set` rewrite ranges. Complex ranges such as `>=8.0.0` that the new version satisfies are still left unchanged [#13935](https://github.com/pnpm/pnpm/issues/13935).

--- a/pnpm/crates/cli/src/cli_args/self_update.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update.rs
@@ -473,18 +473,18 @@ fn package_manager_pin_specifier(
 }
 
 /// Returns the updated `devEngines.packageManager` version constraint.
-/// A constraint that still satisfies the new version is left as-is (the
+/// Exact pins and simple ranges (`^`, `~`) are rewritten to the new version
+/// while keeping the operator, matching `pnpm update` / `pnpm runtime set`.
+/// Complex ranges that still satisfy the new version are left as-is (the
 /// lockfile pins the exact version); otherwise the new version is written
-/// with the constraint's pinning style, falling back to a caret range.
+/// as a caret range.
 fn update_version_constraint(current: Option<&str>, new_version: &str) -> String {
     let Some(current) = current else {
         return new_version.to_string();
     };
-    if range_satisfies(current, new_version) {
-        return current.to_string();
-    }
     match infer_range_spec_style(current) {
         Some(pinned) => format!("{}{new_version}", pinned.range_prefix()),
+        None if range_satisfies(current, new_version) => current.to_string(),
         None => format!("^{new_version}"),
     }
 }

--- a/pnpm/crates/cli/src/cli_args/self_update/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/tests.rs
@@ -9,9 +9,12 @@ use std::{fs, path::Path};
 fn version_constraint_preserves_pinning_style() {
     // No prior constraint → the exact version.
     assert_eq!(update_version_constraint(None, "1.2.3"), "1.2.3");
-    // A range that still satisfies the new version is left untouched; the
-    // lockfile pins the exact version.
-    assert_eq!(update_version_constraint(Some("^1.0.0"), "1.5.0"), "^1.0.0");
+    // Simple ranges that still satisfy are bumped in place, keeping the operator.
+    assert_eq!(update_version_constraint(Some("^1.0.0"), "1.5.0"), "^1.5.0");
+    assert_eq!(update_version_constraint(Some("~1.2.0"), "1.2.5"), "~1.2.5");
+    // Complex ranges that still satisfy are left untouched; the lockfile pins
+    // the exact version.
+    assert_eq!(update_version_constraint(Some(">=1.0.0"), "1.5.0"), ">=1.0.0");
     // A range that no longer satisfies is rewritten in its own style.
     assert_eq!(update_version_constraint(Some("^1.0.0"), "2.0.0"), "^2.0.0");
     assert_eq!(update_version_constraint(Some("~1.0.0"), "2.0.0"), "~2.0.0");
@@ -47,9 +50,9 @@ fn pin_specifier_records_the_resolved_pin_not_the_cli_dist_tag() {
         package_manager_pin_specifier(false, Some("12.0.0-alpha.9"), "12.0.0-alpha.10"),
         "12.0.0-alpha.10",
     );
-    // A range pin is preserved (the lockfile pins the exact version), so the
+    // A range pin is rewritten to the new version, keeping the operator, so the
     // specifier is the range a later install reads back from the manifest.
-    assert_eq!(package_manager_pin_specifier(false, Some("^12.0.0"), "12.1.0"), "^12.0.0");
+    assert_eq!(package_manager_pin_specifier(false, Some("^12.0.0"), "12.1.0"), "^12.1.0");
     // A legacy `packageManager` pin is always exact.
     assert_eq!(package_manager_pin_specifier(true, Some("^12.0.0"), "12.1.0"), "12.1.0");
     // No prior constraint → the resolved version.

--- a/pnpm11/engine/pm/commands/src/self-updater/selfUpdate.ts
+++ b/pnpm11/engine/pm/commands/src/self-updater/selfUpdate.ts
@@ -366,24 +366,21 @@ function readShimTarget (shimPath: string): string | undefined {
 
 /**
  * Returns the updated version constraint for devEngines.packageManager.
- * - Exact versions and simple ranges (^, ~) are updated to the new version,
- *   preserving the range operator.
- * - Ranges that still satisfy the new version are returned unchanged
- *   (the exact version will be pinned in the lockfile instead).
- * - Complex ranges (>=x <y, etc.) that no longer satisfy the new version
- *   fall back to a caret range with the new version (`^${newVersion}`).
+ * - Exact versions and simple ranges (^, ~) are rewritten to the new version,
+ *   preserving the range operator — matching `pnpm update` and `pnpm runtime set`.
+ * - Complex ranges (>=x <y, etc.) that still satisfy the new version are left
+ *   unchanged (the exact version is pinned in the lockfile instead).
+ * - Complex ranges that no longer satisfy the new version fall back to a caret
+ *   range with the new version (`^${newVersion}`).
  */
 function updateVersionConstraint (current: string | undefined, newVersion: string): string | undefined {
   if (current == null) return newVersion
-  // Range that still satisfies the new version — leave it as-is (lockfile handles pinning)
-  if (semver.satisfies(newVersion, current, { includePrerelease: true })) return current
-  // Determine the pinning style of the current specifier
   const rangeSpecStyle = inferRangeSpecStyle(current)
-  if (rangeSpecStyle == null) {
-    // Complex range that can't be updated while preserving its structure — fall back to ^version
-    return `^${newVersion}`
+  if (rangeSpecStyle != null) {
+    return versionWithRangeSpecStyle(newVersion, rangeSpecStyle)
   }
-  return versionWithRangeSpecStyle(newVersion, rangeSpecStyle)
+  if (semver.satisfies(newVersion, current, { includePrerelease: true })) return current
+  return `^${newVersion}`
 }
 
 async function readProjectPinnedPnpmVersion (rootProjectManifestDir: string, spec: string | undefined): Promise<string | undefined> {

--- a/pnpm11/engine/pm/commands/test/self-updater/selfUpdate.test.ts
+++ b/pnpm11/engine/pm/commands/test/self-updater/selfUpdate.test.ts
@@ -904,31 +904,34 @@ test('should update pnpm entry in devEngines.packageManager array', async () => 
   expect(pkgJson.packageManager).toBeUndefined()
 })
 
-test('should bump caret/tilde devEngines.packageManager range when the resolved version still satisfies it', async () => {
+test.each([
+  ['^8.0.0', '8.5.0', '^8.5.0'],
+  ['~8.0.0', '8.0.5', '~8.0.5'],
+])('should bump devEngines.packageManager range %s when the resolved version still satisfies it', async (currentRange, resolvedVersion, expectedRange) => {
   const opts = prepare({
     devEngines: {
-      packageManager: { name: 'pnpm', version: '^8.0.0' },
+      packageManager: { name: 'pnpm', version: currentRange },
     },
   })
   const pkgJsonPath = path.join(opts.dir, 'package.json')
   getMockAgent().get(opts.registriesByScope.default.replace(/\/$/, ''))
     .intercept({ path: '/pnpm', method: 'GET' })
-    .reply(200, createMetadata('8.5.0', opts.registriesByScope.default)).persist()
-  mockExeMetadata(opts.registriesByScope.default, '8.5.0')
+    .reply(200, createMetadata(resolvedVersion, opts.registriesByScope.default)).persist()
+  mockExeMetadata(opts.registriesByScope.default, resolvedVersion)
 
   const output = await selfUpdate.handler({
     ...opts,
     wantedPackageManager: {
       name: 'pnpm',
-      version: '^8.0.0',
+      version: currentRange,
     },
   }, [])
 
-  expect(output).toBe('The current project has been updated to use pnpm v8.5.0')
+  expect(output).toBe(`The current project has been updated to use pnpm v${resolvedVersion}`)
   const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'))
-  expect(pkgJson.devEngines.packageManager.version).toBe('^8.5.0')
+  expect(pkgJson.devEngines.packageManager.version).toBe(expectedRange)
   const lockfile = fs.readFileSync(path.join(opts.dir, 'pnpm-lock.yaml'), 'utf8')
-  expect(lockfile).toContain('8.5.0')
+  expect(lockfile).toContain(resolvedVersion)
 })
 
 test('should not modify complex devEngines.packageManager range when resolved version still satisfies it', async () => {

--- a/pnpm11/engine/pm/commands/test/self-updater/selfUpdate.test.ts
+++ b/pnpm11/engine/pm/commands/test/self-updater/selfUpdate.test.ts
@@ -904,7 +904,34 @@ test('should update pnpm entry in devEngines.packageManager array', async () => 
   expect(pkgJson.packageManager).toBeUndefined()
 })
 
-test('should not modify devEngines.packageManager range when resolved version still satisfies it', async () => {
+test('should bump caret/tilde devEngines.packageManager range when the resolved version still satisfies it', async () => {
+  const opts = prepare({
+    devEngines: {
+      packageManager: { name: 'pnpm', version: '^8.0.0' },
+    },
+  })
+  const pkgJsonPath = path.join(opts.dir, 'package.json')
+  getMockAgent().get(opts.registries.default.replace(/\/$/, ''))
+    .intercept({ path: '/pnpm', method: 'GET' })
+    .reply(200, createMetadata('8.5.0', opts.registries.default)).persist()
+  mockExeMetadata(opts.registries.default, '8.5.0')
+
+  const output = await selfUpdate.handler({
+    ...opts,
+    wantedPackageManager: {
+      name: 'pnpm',
+      version: '^8.0.0',
+    },
+  }, [])
+
+  expect(output).toBe('The current project has been updated to use pnpm v8.5.0')
+  const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'))
+  expect(pkgJson.devEngines.packageManager.version).toBe('^8.5.0')
+  const lockfile = fs.readFileSync(path.join(opts.dir, 'pnpm-lock.yaml'), 'utf8')
+  expect(lockfile).toContain('8.5.0')
+})
+
+test('should not modify complex devEngines.packageManager range when resolved version still satisfies it', async () => {
   const opts = prepare({
     devEngines: {
       packageManager: { name: 'pnpm', version: '>=8.0.0' },

--- a/pnpm11/engine/pm/commands/test/self-updater/selfUpdate.test.ts
+++ b/pnpm11/engine/pm/commands/test/self-updater/selfUpdate.test.ts
@@ -911,10 +911,10 @@ test('should bump caret/tilde devEngines.packageManager range when the resolved 
     },
   })
   const pkgJsonPath = path.join(opts.dir, 'package.json')
-  getMockAgent().get(opts.registries.default.replace(/\/$/, ''))
+  getMockAgent().get(opts.registriesByScope.default.replace(/\/$/, ''))
     .intercept({ path: '/pnpm', method: 'GET' })
-    .reply(200, createMetadata('8.5.0', opts.registries.default)).persist()
-  mockExeMetadata(opts.registries.default, '8.5.0')
+    .reply(200, createMetadata('8.5.0', opts.registriesByScope.default)).persist()
+  mockExeMetadata(opts.registriesByScope.default, '8.5.0')
 
   const output = await selfUpdate.handler({
     ...opts,


### PR DESCRIPTION
## Summary
- `pnpm self-update` now rewrites a simple `^`/`~` `devEngines.packageManager.version` in place when the resolved version still satisfies the range, matching `pnpm update` and `pnpm runtime set`.
- Complex ranges such as `>=8.0.0` are still left unchanged (the lockfile keeps the exact pin).
- Applied in both the TypeScript CLI and pacquet.

Fixes https://github.com/pnpm/pnpm/issues/13935

## Test plan
- [x] Updated TS fixture: `^8.0.0` + resolved `8.5.0` writes `^8.5.0`; existing `>=8.0.0` test still leaves the range alone
- [x] Updated Rust unit tests for `update_version_constraint` / `package_manager_pin_specifier`
- [ ] `pnpm self-update` in a project pinned to `"devEngines.packageManager.version": "^11.15.0"` should write `^<installed>`


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789512783&installation_model_id=426870&pr_number=13949&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13949&signature=26681802ea209585532c8935ab34d8835b72d208f91e2a4edef884ded305fa03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `pnpm self-update` now updates simple caret (`^`) and tilde (`~`) package-manager version ranges while preserving their operators.
  * Exact version pins are updated to the resolved version.
  * Complex ranges remain unchanged when compatible; incompatible ranges fall back to a caret range.

* **Bug Fixes**
  * Improved consistency between manifest and lockfile versions after self-updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->