### PR TITLE
test: type the install option helpers so a stale key cannot pass

### DIFF
--- a/.changeset/typed-test-option-helpers.md
+++ b/.changeset/typed-test-option-helpers.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/testing.temp-store": patch
+---
+
+`createTempStore`'s `storeOptions` are typed as a partial, which is how they are used: they are spread over the store's own defaults, so a caller that overrides one knob no longer has to restate the other five.

--- a/pnpm11/installing/deps-installer/test/lockfile.ts
+++ b/pnpm11/installing/deps-installer/test/lockfile.ts
@@ -466,7 +466,7 @@ test('scoped module from different registry', async () => {
     '@zkochan': `http://localhost:${REGISTRY_MOCK_PORT}`,
     '@foo': `http://localhost:${REGISTRY_MOCK_PORT}`,
   }
-  await addDependenciesToPackage({}, ['@zkochan/foo', '@foo/has-dep-from-same-scope', 'is-positive'], testDefaults({ registries }, { registries }))
+  await addDependenciesToPackage({}, ['@zkochan/foo', '@foo/has-dep-from-same-scope', 'is-positive'], testDefaults({ registriesByScope: registries }, { registriesByScope: registries }))
 
   project.has('@zkochan/foo')
 

--- a/pnpm11/installing/deps-installer/test/utils/testDefaults.ts
+++ b/pnpm11/installing/deps-installer/test/utils/testDefaults.ts
@@ -19,6 +19,17 @@ export function testDefaults<T> (
     minimumReleaseAge?: number
     minimumReleaseAgeStrict?: boolean
     minimumReleaseAgeExclude?: string[]
+    /**
+     * Renamed to `registriesByScope`. Declared `never` so an options object
+     * that still carries the old key is a compile error: `T` is inferred from
+     * the argument, so an unknown key would otherwise be absorbed into it and
+     * the test would silently exercise the default registry instead.
+     */
+    registries?: 'renamed: use registriesByScope'
+    /** Renamed to `registriesByPrefix`. See `registries` above. */
+    namedRegistries?: 'renamed: use registriesByPrefix'
+    /** Renamed to `registryOptionsByUrl`. See `registries` above. */
+    registryOptions?: 'renamed: use registryOptionsByUrl'
   },
   resolveOpts?: any, // eslint-disable-line
   fetchOpts?: any, // eslint-disable-line

--- a/pnpm11/installing/deps-installer/test/utils/testDefaults.ts
+++ b/pnpm11/installing/deps-installer/test/utils/testDefaults.ts
@@ -20,10 +20,14 @@ export function testDefaults<T> (
     minimumReleaseAgeStrict?: boolean
     minimumReleaseAgeExclude?: string[]
     /**
-     * Renamed to `registriesByScope`. Declared `never` so an options object
-     * that still carries the old key is a compile error: `T` is inferred from
-     * the argument, so an unknown key would otherwise be absorbed into it and
-     * the test would silently exercise the default registry instead.
+     * Renamed to `registriesByScope`, and kept here so an options object that
+     * still carries the old key fails to compile: `T` is inferred from the
+     * argument, so an unknown key is otherwise absorbed into it and the test
+     * silently exercises the default registry instead.
+     *
+     * Typed as the replacement's name rather than `never` so the compiler
+     * prints the fix — `not assignable to type '… & "renamed: use
+     * registriesByScope"'`.
      */
     registries?: 'renamed: use registriesByScope'
     /** Renamed to `registriesByPrefix`. See `registries` above. */

--- a/pnpm11/installing/deps-restorer/test/index.ts
+++ b/pnpm11/installing/deps-restorer/test/index.ts
@@ -301,15 +301,12 @@ test('installing only optional deps', async () => {
   const prefix = f.prepare('simple')
 
   await headlessInstall(await testDefaults({
-    development: false,
     include: {
       dependencies: false,
       devDependencies: false,
       optionalDependencies: true,
     },
     lockfileDir: prefix,
-    optional: true,
-    production: false,
   }))
 
   const project = assertProject(prefix)
@@ -536,7 +533,7 @@ test('installing using passed in lockfile files', async () => {
 
   await headlessInstall(await testDefaults({
     lockfileDir: prefix,
-    wantedLockfile,
+    wantedLockfile: wantedLockfile ?? undefined,
   }))
 
   const project = assertProject(prefix)
@@ -570,7 +567,7 @@ test('installing with hoistPattern=*', async () => {
   const prefix = prepareFixtureWithIntegrity('simple-shamefully-flatten')
   const reporter = jest.fn()
 
-  await headlessInstall(await testDefaults({ lockfileDir: prefix, reporter, hoistPattern: '*' }))
+  await headlessInstall(await testDefaults({ lockfileDir: prefix, reporter, hoistPattern: ['*'] }))
 
   const project = assertProject(prefix)
   expect(project.requireModule('is-positive')).toBeTruthy()
@@ -629,7 +626,7 @@ test('installing with publicHoistPattern=*', async () => {
   const prefix = prepareFixtureWithIntegrity('simple-shamefully-flatten')
   const reporter = jest.fn()
 
-  await headlessInstall(await testDefaults({ lockfileDir: prefix, reporter, publicHoistPattern: '*' }))
+  await headlessInstall(await testDefaults({ lockfileDir: prefix, reporter, publicHoistPattern: ['*'] }))
 
   const project = assertProject(prefix)
   expect(project.requireModule('is-positive')).toBeTruthy()
@@ -694,7 +691,7 @@ test('installing with publicHoistPattern=* in a project with external lockfile',
   await headlessInstall(await testDefaults({
     lockfileDir,
     projects: [prefix],
-    publicHoistPattern: '*',
+    publicHoistPattern: ['*'],
   }))
 
   const project = assertProject(lockfileDir)
@@ -703,7 +700,7 @@ test('installing with publicHoistPattern=* in a project with external lockfile',
 
 const ENGINE_DIR = `${process.platform}-${process.arch}-node-${process.version.split('.')[0]}`
 
-test.each([['isolated'], ['hoisted']])('using side effects cache with nodeLinker=%s', async (nodeLinker) => {
+test.each([['isolated'], ['hoisted']] as const)('using side effects cache with nodeLinker=%s', async (nodeLinker) => {
   let prefix = prepareFixtureWithIntegrity('side-effects')
 
   // Right now, hardlink does not work with side effects, so we specify copy as the packageImportMethod
@@ -764,7 +761,7 @@ test.skip('using side effects cache and hoistPattern=*', async () => {
   // Right now, hardlink does not work with side effects, so we specify copy as the packageImportMethod
   // We disable verifyStoreIntegrity because we are going to change the cache
   const opts = await testDefaults({
-    hoistPattern: '*',
+    hoistPattern: ['*'],
     lockfileDir,
     sideEffectsCacheRead: true,
     sideEffectsCacheWrite: true,

--- a/pnpm11/installing/deps-restorer/test/utils/testDefaults.ts
+++ b/pnpm11/installing/deps-restorer/test/utils/testDefaults.ts
@@ -95,9 +95,6 @@ export async function testDefaults (
     skipped: new Set<DepPath>(),
     storeController,
     storeDir,
-    // Required by `HeadlessOptions` and read by the install, but left unset
-    // while this helper took `any`: every one of them arrived as `undefined`.
-    // The values here are what the install effectively behaved as.
     configByUri: {},
     globalVirtualStoreDir: path.join(storeDir, 'links'),
     ignoreScripts: false,

--- a/pnpm11/installing/deps-restorer/test/utils/testDefaults.ts
+++ b/pnpm11/installing/deps-restorer/test/utils/testDefaults.ts
@@ -6,25 +6,44 @@ import { safeReadPackageJsonFromDir } from '@pnpm/pkg-manifest.reader'
 import { getStorePath } from '@pnpm/store.path'
 import { REGISTRY_MOCK_PORT } from '@pnpm/testing.registry-mock'
 import { createTempStore } from '@pnpm/testing.temp-store'
+import type { DepPath, ProjectRootDir } from '@pnpm/types'
 import { temporaryDirectory } from 'tempy'
 
 const registry = `http://localhost:${REGISTRY_MOCK_PORT}/`
 
+/**
+ * The options a test may override, on top of what this helper fills in.
+ *
+ * Typed rather than `any` so a key the headless install does not read is a
+ * compile error here: an options object is the whole input to the subject
+ * under test, and a misspelled or renamed key in one silently exercises the
+ * default instead of the case the test is named for.
+ */
+export type TestHeadlessOptions = Partial<HeadlessOptions> & {
+  /** Project directories, expanded into `HeadlessOptions.projects`. */
+  projects?: string[]
+  /**
+   * Forwarded to the package store, which is what reads it — the headless
+   * install itself has no such option.
+   */
+  verifyStoreIntegrity?: boolean
+}
+
 export async function testDefaults (
-  opts?: any, // eslint-disable-line
-  resolveOpts?: any, // eslint-disable-line
-  fetchOpts?: any, // eslint-disable-line
-  storeOpts?: any, // eslint-disable-line
+  opts?: TestHeadlessOptions,
+  resolveOpts?: Record<string, unknown>,
+  fetchOpts?: Record<string, unknown>,
+  storeOpts?: Record<string, unknown>
 ): Promise<HeadlessOptions> {
   const tmp = temporaryDirectory()
   let storeDir = opts?.storeDir ?? path.join(tmp, 'store')
   const lockfileDir = opts?.lockfileDir ?? process.cwd()
   const { include, pendingBuilds, projects } = await readProjectsContext(
-    opts.projects
-      ? opts.projects.map((rootDir: string) => ({ rootDir }))
+    opts?.projects
+      ? opts.projects.map((rootDir) => ({ rootDir: rootDir as ProjectRootDir }))
       : [
         {
-          rootDir: lockfileDir,
+          rootDir: lockfileDir as ProjectRootDir,
         },
       ],
     { lockfileDir }
@@ -41,7 +60,13 @@ export async function testDefaults (
         ...resolveOpts,
         ...fetchOpts,
       },
-      storeOptions: storeOpts,
+      storeOptions: {
+        // The package store reads this, not the headless install.
+        ...(opts?.verifyStoreIntegrity != null
+          ? { verifyStoreIntegrity: opts.verifyStoreIntegrity }
+          : {}),
+        ...storeOpts,
+      },
     }
   )
   return {
@@ -60,20 +85,28 @@ export async function testDefaults (
       version: '1.0.0',
     },
     pendingBuilds,
-    selectedProjectDirs: opts.selectedProjectDirs ?? projects.map((project) => project.rootDir),
+    selectedProjectDirs: opts?.selectedProjectDirs ?? projects.map((project) => project.rootDir),
     allProjects: Object.fromEntries(
       await Promise.all(projects.map(async (project) => [project.rootDir, { ...project, manifest: await safeReadPackageJsonFromDir(project.rootDir) }]))
     ),
-    authConfig: {},
     registriesByScope: {
       default: registry,
     },
-    sideEffectsCache: true,
-    skipped: new Set<string>(),
+    skipped: new Set<DepPath>(),
     storeController,
     storeDir,
+    // Required by `HeadlessOptions` and read by the install, but left unset
+    // while this helper took `any`: every one of them arrived as `undefined`.
+    // The values here are what the install effectively behaved as.
+    configByUri: {},
+    globalVirtualStoreDir: path.join(storeDir, 'links'),
+    ignoreScripts: false,
+    pruneStore: false,
+    sideEffectsCacheRead: false,
+    sideEffectsCacheWrite: false,
+    userAgent: 'pnpm/0.0.0 npm/? node/0.0.0 test test',
+    virtualStoreDirMaxLength: process.platform === 'win32' ? 60 : 120,
     unsafePerm: true,
-    verifyStoreIntegrity: true,
     ...opts,
   }
 }

--- a/pnpm11/testing/temp-store/src/index.ts
+++ b/pnpm11/testing/temp-store/src/index.ts
@@ -20,7 +20,7 @@ export function createTempStore (opts?: {
   fastUnpack?: boolean
   storeDir?: string
   clientOptions?: Partial<ClientOptions>
-  storeOptions?: CreatePackageStoreOptions
+  storeOptions?: Partial<CreatePackageStoreOptions>
 }): CreateTempStoreResult {
   const configByUri: ClientOptions['configByUri'] = {}
   const cacheDir = path.resolve('cache')


### PR DESCRIPTION
## Summary

A test's options object is the entire input to the subject under test, so a key that nothing reads does not fail — it quietly runs the default instead of the case the test is named for. Both install helpers accepted anything:

- `deps-restorer`'s `testDefaults` took `opts?: any`.
- `deps-installer`'s takes `opts?: T & { … }`, where an unknown key is absorbed into the inferred `T`.

That is how the `registries` → `registriesByScope` rename in pnpm/pnpm#13942 left seven suites pointed at the wrong registry with a green type-check, and only CI to say so — one package per round.

The headless helper now takes a `Partial<HeadlessOptions>`. Everything that surfaced was real:

| what the `any` hid | effect |
|---|---|
| `configByUri`, `globalVirtualStoreDir`, `pruneStore`, `sideEffectsCacheRead`/`Write`, `userAgent`, `virtualStoreDirMaxLength` never set | `HeadlessOptions` requires all seven and the install reads them; every headless test ran with them `undefined` |
| `verifyStoreIntegrity` passed as a headless option | it is a package-store option — the three tests that "disable" it were setting a key nobody read |
| `hoistPattern: '*'`, `publicHoistPattern: '*'` | the field is `string[]`; a one-character string iterates like a one-element array, which is the only reason these worked |
| `development`, `optional`, `production`, `sideEffectsCache` | superseded by `include` and by the read/write split; none were read |

The seven required fields now carry the values the install effectively behaved as, and `verifyStoreIntegrity` is forwarded to the store, so the comment above those three tests is true for the first time.

**The install helper keeps its generic.** Constraining `T` to `Partial<InstallOptions>` produces 162 errors, mostly unrelated to options keys (hook signatures, `ProjectOptions` shapes, options belonging to other functions) — worth doing, but not here. Instead the three renamed keys are declared with a literal type that names the replacement, so a stale key fails with:

```text
Type '{ default: string; }' is not assignable to type '{ default: string; } & "renamed: use registriesByScope"'
```

That guard caught one more live case on the way in (`deps-installer/test/lockfile.ts`), which CI had not reached yet.

`@pnpm/testing.temp-store`'s `storeOptions` are typed as a partial, matching how they are used — they are spread over the store's own defaults.

## Squash Commit Body

```text
A test's options object is the entire input to the subject under test, so a
key nothing reads does not fail: it quietly runs the default instead of the
case the test is named for. Both install helpers accepted anything — the
headless one took `opts?: any`, and the install one takes `opts?: T & {...}`,
where an unknown key is absorbed into the inferred `T`. That is how the
`registries` -> `registriesByScope` rename left seven suites pointed at the
wrong registry with a green type-check, and only CI to say so.

The headless helper now takes a `Partial<HeadlessOptions>`. Everything that
surfaced was real:

- Seven fields `HeadlessOptions` requires and reads — `configByUri`,
  `globalVirtualStoreDir`, `pruneStore`, `sideEffectsCacheRead`/`Write`,
  `userAgent`, `virtualStoreDirMaxLength` — were never set, so every headless
  test ran with them `undefined`. They now carry the values the install
  behaved as.
- `verifyStoreIntegrity` is a package-store option, not a headless one. The
  three tests that "disable" it were setting a key nobody read; it is now
  forwarded to the store.
- `hoistPattern: '*'` and `publicHoistPattern: '*'` are `string[]`. A
  one-character string iterates like a one-element array, which is the only
  reason they worked.
- `development`, `optional`, `production` predate `include`, which the same
  calls already set, and `sideEffectsCache` predates the read/write split.

Constraining the install helper's `T` is a bigger job — 162 errors, mostly
unrelated to options keys — so it keeps its generic and gains a narrow guard
instead: the three renamed keys are declared with a literal type that names
the replacement. It caught one more live case on the way in.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <!-- TypeScript-only: these are TypeScript test helpers; pacquet's suites
  build their options in Rust, where an unknown field is already an error. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed. <!-- No user-facing surface changes. -->

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789515600&installation_model_id=426870&pr_number=13951&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13951&signature=bcdad3cb4a3d7bb8f97b8290c2f46d515bd4b639986e14056542bfb1f2232026"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `createTempStore` now allows callers to override individual store options without providing every default.

* **Bug Fixes**
  * Updated installation and restoration tests to use current registry, dependency, lockfile, hoisting, and cache option formats.
  * Added compile-time guidance when deprecated registry option names are used.

* **Tests**
  * Improved test helper typing, project path handling, store integrity configuration, and default install behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->