### PR TITLE
feat(config): declare the time field per registry

### DIFF
--- a/.changeset/per-registry-time-field.md
+++ b/.changeset/per-registry-time-field.md
@@ -1,0 +1,22 @@
+---
+"@pnpm/config.normalize-registries": minor
+"@pnpm/store.connection-manager": minor
+"@pnpm/resolving.npm-resolver": minor
+"@pnpm/config.reader": minor
+"@pnpm/types": minor
+"pacquet": minor
+"pnpm": minor
+---
+
+A registry can now declare that its abbreviated metadata carries the `time` field, so `resolutionMode: time-based` reads the full metadata document only from the registries that need it:
+
+```yaml
+resolutionMode: time-based
+registries:
+  https://npm.internal.example/:
+    supportsTimeField: true
+```
+
+`registry.npmjs.org` omits `time` from abbreviated metadata, so a time-based resolution has to fall back to the much larger full document. That fallback used to be all-or-nothing: `registrySupportsTimeField` answered for every registry at once, so a project resolving from both the public registry and a Verdaccio instance either paid for full metadata everywhere or claimed a `time` field npmjs does not serve. The answer is now per registry, and `registrySupportsTimeField` remains the answer for every registry that does not declare one.
+
+The declaration is also sent to a pnpr server, which applies it to the resolution it runs on the client's behalf.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9304,6 +9304,9 @@ importers:
       '@pnpm/cli.meta':
         specifier: workspace:*
         version: link:../../cli/meta
+      '@pnpm/config.normalize-registries':
+        specifier: workspace:*
+        version: link:../../config/normalize-registries
       '@pnpm/config.reader':
         specifier: workspace:*
         version: link:../../config/reader
@@ -9322,6 +9325,9 @@ importers:
       '@pnpm/store.path':
         specifier: workspace:*
         version: link:../path
+      '@pnpm/types':
+        specifier: workspace:*
+        version: link:../../core/types
       dir-is-case-sensitive:
         specifier: 'catalog:'
         version: 3.0.0

--- a/pnpm/crates/cli/src/cli_args/config_warnings/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/config_warnings/tests.rs
@@ -12,7 +12,10 @@ fn config_with(registries: &[(&str, &str)], registry_options_by_url: &[&str]) ->
         .map(|registry| {
             (
                 (*registry).to_string(),
-                RegistryOptions { server_type: Some(RegistryServerType::Artifactory) },
+                RegistryOptions {
+                    server_type: Some(RegistryServerType::Artifactory),
+                    supports_time_field: None,
+                },
             )
         })
         .collect();

--- a/pnpm/crates/cli/src/config_deps.rs
+++ b/pnpm/crates/cli/src/config_deps.rs
@@ -364,6 +364,7 @@ impl EnvInstallerContext {
             // `minimumReleaseAge` and trust checks need — instead of failing
             // closed on abbreviated metadata that omits `time`.
             full_metadata: config.requires_full_metadata_for_resolution(),
+            needs_full_metadata_for: None,
             filter_metadata: config.requires_full_metadata_for_resolution(),
             retry_opts,
         };

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -2227,9 +2227,7 @@ impl Config {
     /// [`Self::requires_full_metadata_for_registry`] as a closure the resolver
     /// can hold, capturing the four facts it needs rather than the config.
     #[must_use]
-    pub fn requires_full_metadata_for_registry_fn(
-        &self,
-    ) -> Arc<dyn Fn(&str) -> bool + Send + Sync> {
+    pub fn requires_full_metadata_for_registry_fn(&self) -> NeedsFullMetadataFor {
         let registry_options_by_url = self.registry_options_by_url.clone();
         let default_supports_time_field = self.registry_supports_time_field;
         let trust_policy = self.trust_policy;
@@ -3112,6 +3110,10 @@ fn read_npm_env<Sys: EnvVar>(lower: &str, upper: &str) -> Option<String> {
 mod pnpm_default_parity;
 #[cfg(test)]
 mod tests;
+
+/// Whether the resolution has to read full packument metadata from a given
+/// registry, as [`Config::requires_full_metadata_for_registry_fn`] answers it.
+pub type NeedsFullMetadataFor = Arc<dyn Fn(&str) -> bool + Send + Sync>;
 
 /// Whether a resolution has to read full packument metadata: trust evidence
 /// (`_npmUser`) is never in the abbreviated form, and a time-based resolution

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -36,6 +36,7 @@ use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     fs,
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 pub use crate::defaults::{
@@ -2191,9 +2192,54 @@ impl Config {
     /// metadata mode from here so none of them can drift.
     #[must_use]
     pub fn requires_full_metadata_for_resolution(&self) -> bool {
-        self.trust_policy == TrustPolicy::NoDowngrade
-            || (self.resolution_mode == ResolutionMode::TimeBased
-                && !self.registry_supports_time_field)
+        self.full_metadata_policy(self.registry_supports_time_field)
+    }
+
+    /// The same policy, asked of one registry: a registry that declares
+    /// `supportsTimeField` answers for itself, so a time-based resolution
+    /// reads abbreviated metadata from the registries that carry `time` and
+    /// full metadata only from the ones that do not.
+    ///
+    /// A registry with no declaration answers exactly what
+    /// [`Self::requires_full_metadata_for_resolution`] does.
+    #[must_use]
+    pub fn requires_full_metadata_for_registry(&self, registry: &str) -> bool {
+        self.full_metadata_policy(self.registry_supports_time_field(registry))
+    }
+
+    /// Whether `registry`'s abbreviated metadata carries the `time` field,
+    /// from its own declaration if it has one and from the
+    /// `registrySupportsTimeField` setting otherwise.
+    #[must_use]
+    pub fn registry_supports_time_field(&self, registry: &str) -> bool {
+        pnpm_lockfile::registry_supports_time_field(&self.registry_options_by_url, registry)
+            .unwrap_or(self.registry_supports_time_field)
+    }
+
+    fn full_metadata_policy(&self, supports_time_field: bool) -> bool {
+        full_metadata_policy(
+            self.trust_policy,
+            self.resolution_mode == ResolutionMode::TimeBased,
+            supports_time_field,
+        )
+    }
+
+    /// [`Self::requires_full_metadata_for_registry`] as a closure the resolver
+    /// can hold, capturing the four facts it needs rather than the config.
+    #[must_use]
+    pub fn requires_full_metadata_for_registry_fn(
+        &self,
+    ) -> Arc<dyn Fn(&str) -> bool + Send + Sync> {
+        let registry_options_by_url = self.registry_options_by_url.clone();
+        let default_supports_time_field = self.registry_supports_time_field;
+        let trust_policy = self.trust_policy;
+        let time_based = self.resolution_mode == ResolutionMode::TimeBased;
+        Arc::new(move |registry: &str| {
+            let supports_time_field =
+                pnpm_lockfile::registry_supports_time_field(&registry_options_by_url, registry)
+                    .unwrap_or(default_supports_time_field);
+            full_metadata_policy(trust_policy, time_based, supports_time_field)
+        })
     }
 
     /// Registry map in pnpm's `Registries` shape: `default` plus the
@@ -3066,3 +3112,14 @@ fn read_npm_env<Sys: EnvVar>(lower: &str, upper: &str) -> Option<String> {
 mod pnpm_default_parity;
 #[cfg(test)]
 mod tests;
+
+/// Whether a resolution has to read full packument metadata: trust evidence
+/// (`_npmUser`) is never in the abbreviated form, and a time-based resolution
+/// needs `time`, which a registry may or may not carry there.
+fn full_metadata_policy(
+    trust_policy: TrustPolicy,
+    time_based: bool,
+    supports_time_field: bool,
+) -> bool {
+    trust_policy == TrustPolicy::NoDowngrade || (time_based && !supports_time_field)
+}

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -2207,6 +2207,22 @@ impl Config {
         self.full_metadata_policy(self.registry_supports_time_field(registry))
     }
 
+    /// Whether a full packument, once fetched, is stored and read in pnpm's
+    /// filtered form rather than verbatim.
+    ///
+    /// Answered for the most demanding registry — one that carries no `time`
+    /// — because [`Self::requires_full_metadata_for_registry`] can ask for a
+    /// full document at a registry
+    /// [`Self::requires_full_metadata_for_resolution`] would have left on
+    /// abbreviated metadata, and both have to agree on which mirror that
+    /// document lands in. It is consulted only when a full document is
+    /// actually fetched, so answering for the demanding case costs the others
+    /// nothing.
+    #[must_use]
+    pub fn requires_filtered_full_metadata(&self) -> bool {
+        self.full_metadata_policy(false)
+    }
+
     /// Whether `registry`'s abbreviated metadata carries the `time` field,
     /// from its own declaration if it has one and from the
     /// `registrySupportsTimeField` setting otherwise.

--- a/pnpm/crates/config/src/workspace_yaml/registries.rs
+++ b/pnpm/crates/config/src/workspace_yaml/registries.rs
@@ -62,6 +62,9 @@ pub enum RegistryEntry {
 pub struct RegistryDeclaration {
     #[serde(default)]
     pub server_type: Option<RegistryServerType>,
+    /// See [`RegistryOptions::supports_time_field`].
+    #[serde(default)]
+    pub supports_time_field: Option<bool>,
     /// The scopes routed here, `@`-prefixed. A bare `@` is the scope-less
     /// default registry, the one the `registry` setting names.
     #[serde(default)]
@@ -255,10 +258,14 @@ fn extend_lookups_with_declarations(
 ) {
     for (registry, declaration) in entries {
         let normalized = normalize_registry_url(&registry);
-        if let Some(server_type) = declaration.server_type {
-            lookups
-                .registry_options_by_url
-                .insert(normalized.clone(), RegistryOptions { server_type: Some(server_type) });
+        if declaration.server_type.is_some() || declaration.supports_time_field.is_some() {
+            lookups.registry_options_by_url.insert(
+                normalized.clone(),
+                RegistryOptions {
+                    server_type: declaration.server_type,
+                    supports_time_field: declaration.supports_time_field,
+                },
+            );
         }
         for scope in declaration.scopes.into_iter().flatten() {
             if scope == DEFAULT_REGISTRY_SCOPE {
@@ -301,7 +308,9 @@ pub fn to_declarations(lookups: &RegistryLookups) -> BTreeMap<String, RegistryDe
         declarations.entry(registry.clone()).or_default().prefix = Some(prefix.clone());
     }
     for (registry, options) in &lookups.registry_options_by_url {
-        declarations.entry(registry.clone()).or_default().server_type = options.server_type;
+        let declaration = declarations.entry(registry.clone()).or_default();
+        declaration.server_type = options.server_type;
+        declaration.supports_time_field = options.supports_time_field;
     }
     declarations
 }

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -2346,3 +2346,32 @@ registries:
     assert!(!config.requires_full_metadata_for_registry("https://registry.npmjs.org/"));
     assert!(config.requires_full_metadata_for_registry("https://old.example.com/"));
 }
+
+/// The filtered mirror is chosen once for the whole resolver, so it has to
+/// cover the registry that asks for the most: one the setting exempts but a
+/// declaration does not.
+#[test]
+fn the_filtered_mirror_covers_a_registry_the_setting_exempts() {
+    let yaml = r"
+resolutionMode: time-based
+registrySupportsTimeField: true
+registries:
+  https://old.example.com/: {supportsTimeField: false}
+";
+    let settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
+    let mut config = Config::new();
+    settings.apply_to(&mut config, Path::new("/irrelevant"));
+
+    assert!(!config.requires_full_metadata_for_resolution());
+    assert!(config.requires_full_metadata_for_registry("https://old.example.com/"));
+    assert!(config.requires_filtered_full_metadata());
+}
+
+/// Nothing is filtered when no registry can need full metadata.
+#[test]
+fn no_filtered_mirror_without_a_reason_for_full_metadata() {
+    let mut config = Config::new();
+    assert!(!config.requires_filtered_full_metadata());
+    config.resolution_mode = ResolutionMode::TimeBased;
+    assert!(config.requires_filtered_full_metadata());
+}

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -2236,7 +2236,10 @@ fn rebuilds_the_declarations_from_the_lookups() {
         BTreeMap::from([("work".to_owned(), "https://npm.corp.example/".to_owned())]);
     config.registry_options_by_url = BTreeMap::from([(
         "https://npm.corp.example/".to_owned(),
-        RegistryOptions { server_type: Some(RegistryServerType::Artifactory) },
+        RegistryOptions {
+            server_type: Some(RegistryServerType::Artifactory),
+            supports_time_field: None,
+        },
     )]);
 
     let declarations = config.registry_declarations();
@@ -2246,6 +2249,7 @@ fn rebuilds_the_declarations_from_the_lookups() {
             scopes: Some(vec!["@acme".to_owned(), "@acme-internal".to_owned()]),
             prefix: Some("work".to_owned()),
             server_type: Some(RegistryServerType::Artifactory),
+            supports_time_field: None,
             unknown: BTreeMap::new(),
         }),
     );
@@ -2287,4 +2291,58 @@ registries:
         })
         .collect();
     assert_eq!(rebuilt, original);
+}
+
+/// The public registry omits `time` from its abbreviated metadata, so a
+/// time-based resolution reads the full document from it. A registry that
+/// declares otherwise answers for itself, and paying for the full document at
+/// every registry because one of them needs it is the cost this removes.
+#[test]
+fn a_registry_declaring_the_time_field_needs_no_full_metadata() {
+    let yaml = r"
+resolutionMode: time-based
+registries:
+  https://time.example.com/: {supportsTimeField: true}
+";
+    let settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
+    let mut config = Config::new();
+    settings.apply_to(&mut config, Path::new("/irrelevant"));
+
+    assert!(!config.requires_full_metadata_for_registry("https://time.example.com/"));
+    assert!(config.requires_full_metadata_for_registry("https://registry.npmjs.org/"));
+    // However either side spelled the trailing slash.
+    assert!(!config.requires_full_metadata_for_registry("https://time.example.com"));
+}
+
+/// A reason that holds whatever the registry serves is not undone by one.
+#[test]
+fn a_declared_time_field_does_not_waive_the_trust_policy() {
+    let yaml = r"
+resolutionMode: time-based
+trustPolicy: no-downgrade
+registries:
+  https://time.example.com/: {supportsTimeField: true}
+";
+    let settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
+    let mut config = Config::new();
+    settings.apply_to(&mut config, Path::new("/irrelevant"));
+
+    assert!(config.requires_full_metadata_for_registry("https://time.example.com/"));
+}
+
+/// The setting is the answer for every registry that does not describe itself.
+#[test]
+fn the_time_field_setting_answers_for_an_undeclared_registry() {
+    let yaml = r"
+resolutionMode: time-based
+registrySupportsTimeField: true
+registries:
+  https://old.example.com/: {supportsTimeField: false}
+";
+    let settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
+    let mut config = Config::new();
+    settings.apply_to(&mut config, Path::new("/irrelevant"));
+
+    assert!(!config.requires_full_metadata_for_registry("https://registry.npmjs.org/"));
+    assert!(config.requires_full_metadata_for_registry("https://old.example.com/"));
 }

--- a/pnpm/crates/deps-restorer/src/install_package_from_registry/tests.rs
+++ b/pnpm/crates/deps-restorer/src/install_package_from_registry/tests.rs
@@ -205,6 +205,7 @@ async fn resolve_via_mock(
         prefer_offline: false,
         ignore_missing_time_field: true,
         full_metadata: false,
+        needs_full_metadata_for: None,
         filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };

--- a/pnpm/crates/env-installer/src/tests.rs
+++ b/pnpm/crates/env-installer/src/tests.rs
@@ -66,6 +66,7 @@ fn build_resolver(registry: &str) -> (NpmResolver<InMemoryPackageMetaCache>, Tem
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        needs_full_metadata_for: None,
         filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };

--- a/pnpm/crates/lockfile/src/resolution.rs
+++ b/pnpm/crates/lockfile/src/resolution.rs
@@ -436,6 +436,15 @@ pub enum RegistryServerType {
 pub struct RegistryOptions {
     #[serde(default)]
     pub server_type: Option<RegistryServerType>,
+    /// Whether this registry's abbreviated metadata carries the `time` field.
+    ///
+    /// `registry.npmjs.org` does not, which is why the default is `false` and
+    /// why a time-based resolution falls back to the far larger full metadata.
+    /// A registry that does carry it is worth declaring: the fallback is per
+    /// registry, so one that needs full metadata no longer costs it at the
+    /// others.
+    #[serde(default)]
+    pub supports_time_field: Option<bool>,
 }
 
 /// registry.npmjs.org is the one registry whose layout pnpm knows without
@@ -464,6 +473,25 @@ pub fn registry_server_type(
         Cow::Owned(format!("{registry}/"))
     };
     registry_options_by_url.get(key.as_ref()).copied().unwrap_or_default().server_type
+}
+
+/// Whether `registry`'s abbreviated metadata carries the `time` field, per its
+/// own declaration. [`None`] when it does not declare one, which leaves the
+/// answer to the `registrySupportsTimeField` setting.
+///
+/// Keyed like [`registry_server_type`], which is why the query is normalized
+/// the same way.
+#[must_use]
+pub fn registry_supports_time_field(
+    registry_options_by_url: &BTreeMap<String, RegistryOptions>,
+    registry: &str,
+) -> Option<bool> {
+    let key = if registry.ends_with('/') {
+        Cow::Borrowed(registry)
+    } else {
+        Cow::Owned(format!("{registry}/"))
+    };
+    registry_options_by_url.get(key.as_ref()).copied().unwrap_or_default().supports_time_field
 }
 
 /// A declared server type wins; otherwise the built-in layout of a known

--- a/pnpm/crates/lockfile/src/resolution/tests.rs
+++ b/pnpm/crates/lockfile/src/resolution/tests.rs
@@ -1064,7 +1064,10 @@ fn to_lockfile_form_keeps_the_artifactory_url_when_include_tarball_url_is_set() 
 fn registry_server_type_is_undeclared_by_default_and_tolerates_a_missing_trailing_slash() {
     let options = BTreeMap::from([(
         ARTIFACTORY_REGISTRY.to_string(),
-        RegistryOptions { server_type: Some(RegistryServerType::Artifactory) },
+        RegistryOptions {
+            server_type: Some(RegistryServerType::Artifactory),
+            supports_time_field: None,
+        },
     )]);
     assert_eq!(
         registry_server_type(&options, ARTIFACTORY_REGISTRY.trim_end_matches('/')),

--- a/pnpm/crates/napi/src/resolve.rs
+++ b/pnpm/crates/napi/src/resolve.rs
@@ -169,6 +169,7 @@ fn run_resolve_blocking(
         prefer_offline: config.prefer_offline,
         ignore_missing_time_field: config.minimum_release_age_ignore_missing_time,
         full_metadata,
+        needs_full_metadata_for: None,
         filter_metadata,
         retry_opts,
     });
@@ -225,6 +226,7 @@ fn run_resolve_blocking(
         prefer_offline: config.prefer_offline,
         ignore_missing_time_field: config.minimum_release_age_ignore_missing_time,
         full_metadata,
+        needs_full_metadata_for: None,
         filter_metadata,
         retry_opts,
     };

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -805,6 +805,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             time_based,
             pick_lowest_direct,
             full_metadata,
+            needs_full_metadata_for,
             published_by,
             published_by_exclude,
         } = crate::resolution_policy::PickPolicy::from_config_with_extra_excludes(
@@ -847,6 +848,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             requester,
             supported_architectures,
             registries: &registries,
+            needs_full_metadata_for: Arc::clone(&needs_full_metadata_for),
             registries_by_prefix: &merged_registries_by_prefix,
             full_metadata,
             wanted_lockfile,

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolver_setup.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolver_setup.rs
@@ -250,7 +250,7 @@ pub(super) async fn build_resolver_chain<Reporter: pnpm_reporter::Reporter + 'st
         // upgrades per-call where `published_by` / `optional` demand it.
         full_metadata,
         needs_full_metadata_for: Some(Arc::clone(&needs_full_metadata_for)),
-        filter_metadata: full_metadata,
+        filter_metadata: config.requires_filtered_full_metadata(),
         retry_opts: crate::retry_config::retry_opts_from_config(config),
     });
     // A git dep's specifier names a repo, not a package, so its name —
@@ -323,7 +323,7 @@ pub(super) async fn build_resolver_chain<Reporter: pnpm_reporter::Reporter + 'st
         // Same rationale as `NpmResolver.full_metadata` above.
         full_metadata,
         needs_full_metadata_for: Some(Arc::clone(&needs_full_metadata_for)),
-        filter_metadata: full_metadata,
+        filter_metadata: config.requires_filtered_full_metadata(),
         retry_opts: crate::retry_config::retry_opts_from_config(config),
     };
 

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolver_setup.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolver_setup.rs
@@ -146,6 +146,9 @@ pub(super) struct ResolverChainInputs<'a> {
     /// resolution or the `no-downgrade` trust policy needs the
     /// per-version `time` field.
     pub full_metadata: bool,
+    /// See `NpmResolver::needs_full_metadata_for` — the same question asked
+    /// of one registry.
+    pub needs_full_metadata_for: Arc<dyn Fn(&str) -> bool + Send + Sync>,
     pub wanted_lockfile: Option<&'a Lockfile>,
     pub store_index: Option<&'a SharedReadonlyStoreIndex>,
     pub store_index_writer: &'a Arc<StoreIndexWriter>,
@@ -205,6 +208,7 @@ pub(super) async fn build_resolver_chain<Reporter: pnpm_reporter::Reporter + 'st
         registries,
         registries_by_prefix,
         full_metadata,
+        needs_full_metadata_for,
         wanted_lockfile,
         store_index,
         store_index_writer,
@@ -245,6 +249,7 @@ pub(super) async fn build_resolver_chain<Reporter: pnpm_reporter::Reporter + 'st
         // abbreviated form). When `false`, [`pick_package`] still
         // upgrades per-call where `published_by` / `optional` demand it.
         full_metadata,
+        needs_full_metadata_for: Some(Arc::clone(&needs_full_metadata_for)),
         filter_metadata: full_metadata,
         retry_opts: crate::retry_config::retry_opts_from_config(config),
     });
@@ -317,6 +322,7 @@ pub(super) async fn build_resolver_chain<Reporter: pnpm_reporter::Reporter + 'st
         ignore_missing_time_field: config.minimum_release_age_ignore_missing_time,
         // Same rationale as `NpmResolver.full_metadata` above.
         full_metadata,
+        needs_full_metadata_for: Some(Arc::clone(&needs_full_metadata_for)),
         filter_metadata: full_metadata,
         retry_opts: crate::retry_config::retry_opts_from_config(config),
     };

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolver_setup.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolver_setup.rs
@@ -8,7 +8,7 @@
 
 use super::InstallWithFreshLockfileError;
 use crate::{PrefetchContext, PrefetchingResolver};
-use pnpm_config::Config;
+use pnpm_config::{Config, NeedsFullMetadataFor};
 use pnpm_engine_pm_yarn_resolver::YarnResolver;
 use pnpm_engine_runtime_bun_resolver::BunResolver;
 use pnpm_engine_runtime_deno_resolver::DenoResolver;
@@ -148,7 +148,7 @@ pub(super) struct ResolverChainInputs<'a> {
     pub full_metadata: bool,
     /// See `NpmResolver::needs_full_metadata_for` — the same question asked
     /// of one registry.
-    pub needs_full_metadata_for: Arc<dyn Fn(&str) -> bool + Send + Sync>,
+    pub needs_full_metadata_for: NeedsFullMetadataFor,
     pub wanted_lockfile: Option<&'a Lockfile>,
     pub store_index: Option<&'a SharedReadonlyStoreIndex>,
     pub store_index_writer: &'a Arc<StoreIndexWriter>,

--- a/pnpm/crates/package-manager/src/patch/tests.rs
+++ b/pnpm/crates/package-manager/src/patch/tests.rs
@@ -630,6 +630,7 @@ async fn resolve_registry_fixture(
         prefer_offline: false,
         ignore_missing_time_field: true,
         full_metadata: false,
+        needs_full_metadata_for: None,
         filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };

--- a/pnpm/crates/package-manager/src/resolution_policy.rs
+++ b/pnpm/crates/package-manager/src/resolution_policy.rs
@@ -14,6 +14,7 @@ use pnpm_network::ThrottledClient;
 use pnpm_resolving_npm_resolver::{
     InMemoryPackageMetaCache, PackumentFetchLocker, PickPackageContext,
 };
+use std::sync::Arc;
 
 /// The version-pick knobs derived purely from [`Config`]. Computed once and
 /// fed to both the resolver chain and the `add` pre-resolution so a single
@@ -28,6 +29,10 @@ pub(crate) struct PickPolicy {
     /// dates. Mirrors pnpm's `(time-based || no-downgrade) &&
     /// !registrySupportsTimeField`.
     pub full_metadata: bool,
+    /// The same question asked of one registry, so a registry that declares
+    /// `supportsTimeField` is not charged for full metadata because another
+    /// one needs it.
+    pub needs_full_metadata_for: Arc<dyn Fn(&str) -> bool + Send + Sync>,
     /// `minimumReleaseAge` cutoff: only versions published at or before
     /// this instant are eligible. `None` disables the maturity filter.
     pub published_by: Option<DateTime<Utc>>,
@@ -97,6 +102,7 @@ impl PickPolicy {
             time_based,
             pick_lowest_direct,
             full_metadata,
+            needs_full_metadata_for: config.requires_full_metadata_for_registry_fn(),
             published_by,
             published_by_exclude,
         })
@@ -113,7 +119,7 @@ impl PickPolicy {
 pub(crate) fn pick_package_context<'a>(
     http_client: &'a ThrottledClient,
     config: &'a Config,
-    policy: &PickPolicy,
+    policy: &'a PickPolicy,
     meta_cache: &'a InMemoryPackageMetaCache,
     fetch_locker: &'a PackumentFetchLocker,
 ) -> PickPackageContext<'a, InMemoryPackageMetaCache> {
@@ -127,6 +133,7 @@ pub(crate) fn pick_package_context<'a>(
         prefer_offline: config.prefer_offline,
         ignore_missing_time_field: config.minimum_release_age_ignore_missing_time,
         full_metadata: policy.full_metadata,
+        needs_full_metadata_for: Some(policy.needs_full_metadata_for.as_ref()),
         filter_metadata: policy.full_metadata,
         retry_opts: retry_opts_from_config(config),
     }

--- a/pnpm/crates/package-manager/src/resolution_policy.rs
+++ b/pnpm/crates/package-manager/src/resolution_policy.rs
@@ -7,14 +7,13 @@
 use crate::retry_config::retry_opts_from_config;
 use chrono::{DateTime, Utc};
 use pnpm_config::{
-    Config, ResolutionMode,
+    Config, NeedsFullMetadataFor, ResolutionMode,
     version_policy::{PackageVersionPolicy, VersionPolicyError, create_package_version_policy},
 };
 use pnpm_network::ThrottledClient;
 use pnpm_resolving_npm_resolver::{
     InMemoryPackageMetaCache, PackumentFetchLocker, PickPackageContext,
 };
-use std::sync::Arc;
 
 /// The version-pick knobs derived purely from [`Config`]. Computed once and
 /// fed to both the resolver chain and the `add` pre-resolution so a single
@@ -32,7 +31,7 @@ pub(crate) struct PickPolicy {
     /// The same question asked of one registry, so a registry that declares
     /// `supportsTimeField` is not charged for full metadata because another
     /// one needs it.
-    pub needs_full_metadata_for: Arc<dyn Fn(&str) -> bool + Send + Sync>,
+    pub needs_full_metadata_for: NeedsFullMetadataFor,
     /// `minimumReleaseAge` cutoff: only versions published at or before
     /// this instant are eligible. `None` disables the maturity filter.
     pub published_by: Option<DateTime<Utc>>,

--- a/pnpm/crates/package-manager/src/resolution_policy.rs
+++ b/pnpm/crates/package-manager/src/resolution_policy.rs
@@ -133,7 +133,7 @@ pub(crate) fn pick_package_context<'a>(
         ignore_missing_time_field: config.minimum_release_age_ignore_missing_time,
         full_metadata: policy.full_metadata,
         needs_full_metadata_for: Some(policy.needs_full_metadata_for.as_ref()),
-        filter_metadata: policy.full_metadata,
+        filter_metadata: config.requires_filtered_full_metadata(),
         retry_opts: retry_opts_from_config(config),
     }
 }

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -1520,7 +1520,7 @@ fn ensure_latest_resolver_chain<'chain>(
             ignore_missing_time_field: ctx.config.minimum_release_age_ignore_missing_time,
             full_metadata: policy.full_metadata,
             needs_full_metadata_for: Some(Arc::clone(&policy.needs_full_metadata_for)),
-            filter_metadata: policy.full_metadata,
+            filter_metadata: ctx.config.requires_filtered_full_metadata(),
             retry_opts: crate::retry_config::retry_opts_from_config(ctx.config),
         });
         let mut node_resolver = NodeResolver::new(Arc::clone(ctx.http_client_arc));

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -1519,6 +1519,7 @@ fn ensure_latest_resolver_chain<'chain>(
             prefer_offline: ctx.config.prefer_offline,
             ignore_missing_time_field: ctx.config.minimum_release_age_ignore_missing_time,
             full_metadata: policy.full_metadata,
+            needs_full_metadata_for: Some(Arc::clone(&policy.needs_full_metadata_for)),
             filter_metadata: policy.full_metadata,
             retry_opts: crate::retry_config::retry_opts_from_config(ctx.config),
         });

--- a/pnpm/crates/resolving-npm-resolver/src/named_registry_resolver.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/named_registry_resolver.rs
@@ -21,6 +21,7 @@ use std::{
     sync::Arc,
 };
 
+use pnpm_config::NeedsFullMetadataFor;
 use pnpm_network::{AuthHeaders, RetryOpts, ThrottledClient};
 use pnpm_resolving_resolver_base::{
     LatestInfo, LatestQuery, ResolveError, ResolveFuture, ResolveLatestFuture, ResolveOptions,
@@ -87,7 +88,7 @@ pub struct NamedRegistryResolver<Cache: PackageMetaCache> {
     pub full_metadata: bool,
     /// Per-registry answer to the same question. A prefix-addressed registry
     /// is declared like any other, so it is exempted like any other.
-    pub needs_full_metadata_for: Option<Arc<dyn Fn(&str) -> bool + Send + Sync>>,
+    pub needs_full_metadata_for: Option<NeedsFullMetadataFor>,
     /// When full metadata is forced, read and write pnpm's filtered
     /// full-metadata mirror.
     pub filter_metadata: bool,

--- a/pnpm/crates/resolving-npm-resolver/src/named_registry_resolver.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/named_registry_resolver.rs
@@ -85,6 +85,9 @@ pub struct NamedRegistryResolver<Cache: PackageMetaCache> {
     /// Install-wide bias toward full metadata. Threaded through to
     /// [`PickPackageContext::full_metadata`].
     pub full_metadata: bool,
+    /// Per-registry answer to the same question. A prefix-addressed registry
+    /// is declared like any other, so it is exempted like any other.
+    pub needs_full_metadata_for: Option<Arc<dyn Fn(&str) -> bool + Send + Sync>>,
     /// When full metadata is forced, read and write pnpm's filtered
     /// full-metadata mirror.
     pub filter_metadata: bool,
@@ -232,6 +235,7 @@ impl<Cache: PackageMetaCache + 'static> NamedRegistryResolver<Cache> {
             prefer_offline: self.prefer_offline,
             ignore_missing_time_field: self.ignore_missing_time_field,
             full_metadata: self.full_metadata,
+            needs_full_metadata_for: self.needs_full_metadata_for.as_deref(),
             filter_metadata: self.filter_metadata,
             retry_opts: self.retry_opts,
         };

--- a/pnpm/crates/resolving-npm-resolver/src/named_registry_resolver/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/named_registry_resolver/tests.rs
@@ -83,6 +83,7 @@ fn build_resolver(
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        needs_full_metadata_for: None,
         filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -27,7 +27,7 @@ use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
 use chrono::{DateTime, Utc};
 use node_semver::Version;
-use pnpm_config::{TrustPolicy, version_policy::PackageVersionPolicy};
+use pnpm_config::{NeedsFullMetadataFor, TrustPolicy, version_policy::PackageVersionPolicy};
 use pnpm_lockfile::{LockfileResolution, PkgName, PkgNameVer, TarballResolution};
 use pnpm_network::{AuthHeaders, RetryOpts, ThrottledClient, redact_and_sanitize};
 use pnpm_registry::{Package, PackageDistribution, PackageVersion, RangeSpecStyle};
@@ -120,7 +120,7 @@ pub struct NpmResolver<Cache: PackageMetaCache> {
     /// [`PickPackageContext::needs_full_metadata_for`]. Set from
     /// `Config::requires_full_metadata_for_registry` so a registry that
     /// declares `supportsTimeField` is not charged for full metadata.
-    pub needs_full_metadata_for: Option<Arc<dyn Fn(&str) -> bool + Send + Sync>>,
+    pub needs_full_metadata_for: Option<NeedsFullMetadataFor>,
     /// When full metadata is forced, read and write pnpm's filtered
     /// full-metadata mirror.
     pub filter_metadata: bool,

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -116,6 +116,11 @@ pub struct NpmResolver<Cache: PackageMetaCache> {
     /// Install-wide bias toward full metadata. Threaded through to
     /// [`PickPackageContext::full_metadata`].
     pub full_metadata: bool,
+    /// Per-registry answer to the same question, threaded through to
+    /// [`PickPackageContext::needs_full_metadata_for`]. Set from
+    /// `Config::requires_full_metadata_for_registry` so a registry that
+    /// declares `supportsTimeField` is not charged for full metadata.
+    pub needs_full_metadata_for: Option<Arc<dyn Fn(&str) -> bool + Send + Sync>>,
     /// When full metadata is forced, read and write pnpm's filtered
     /// full-metadata mirror.
     pub filter_metadata: bool,
@@ -392,6 +397,7 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
             prefer_offline: self.prefer_offline,
             ignore_missing_time_field: self.ignore_missing_time_field,
             full_metadata: self.full_metadata,
+            needs_full_metadata_for: self.needs_full_metadata_for.as_deref(),
             filter_metadata: self.filter_metadata,
             retry_opts: self.retry_opts,
         };

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -80,6 +80,7 @@ fn build_resolver_with_registries(
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        needs_full_metadata_for: None,
         filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
@@ -757,6 +758,7 @@ async fn shared_manifest_cache_does_not_leak_across_registries() {
             prefer_offline: false,
             ignore_missing_time_field: false,
             full_metadata: false,
+            needs_full_metadata_for: None,
             filter_metadata: false,
             retry_opts: RetryOpts::default(),
         };

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package.rs
@@ -260,6 +260,12 @@ pub struct PickPackageContext<'a, Cache: PackageMetaCache> {
     /// `false`; the verifier-time fetcher sets it `true` because
     /// it needs `time` and trust evidence for every entry.
     pub full_metadata: bool,
+    /// Asked instead of [`Self::full_metadata`] when the caller can answer
+    /// per registry — a registry that declares `supportsTimeField` needs no
+    /// full metadata for a time-based resolution even when the others do. The
+    /// mirror path and cache key below are already keyed by registry, so two
+    /// registries may disagree within one install.
+    pub needs_full_metadata_for: Option<&'a (dyn Fn(&str) -> bool + Send + Sync)>,
     /// When full metadata is forced, use pnpm's filtered full-metadata
     /// mirror and filtered packument shape.
     pub filter_metadata: bool,
@@ -436,7 +442,14 @@ pub async fn pick_package<Cache: PackageMetaCache>(
         ignore_missing_time_field: ctx.ignore_missing_time_field,
     };
 
-    let full_metadata = opts.optional || ctx.full_metadata;
+    // The per-registry answer is authoritative when the caller can give one:
+    // it already folds in the reasons that hold for every registry, so a
+    // registry that carries `time` is free to stay on abbreviated metadata
+    // while the others do not.
+    let policy_wants_full_metadata = ctx
+        .needs_full_metadata_for
+        .map_or(ctx.full_metadata, |needs_full_metadata| needs_full_metadata(opts.registry));
+    let full_metadata = opts.optional || policy_wants_full_metadata;
     let use_filtered_full_metadata = full_metadata && ctx.filter_metadata;
     let base_meta_dir = if full_metadata {
         if use_filtered_full_metadata { FULL_FILTERED_META_DIR } else { FULL_META_DIR }

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package/tests.rs
@@ -135,6 +135,7 @@ async fn cold_pick_fetches_and_picks_max_in_range() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        needs_full_metadata_for: None,
         filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
@@ -176,6 +177,7 @@ async fn filtered_full_metadata_reads_pnpm_jsonl_mirror_for_lowest_pick() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: true,
+        needs_full_metadata_for: None,
         filter_metadata: true,
         retry_opts: RetryOpts::default(),
     };
@@ -213,6 +215,7 @@ async fn warm_in_memory_cache_skips_network() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        needs_full_metadata_for: None,
         filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
@@ -250,6 +253,7 @@ async fn offline_with_mirror_picks_from_disk() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        needs_full_metadata_for: None,
         filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
@@ -279,6 +283,7 @@ async fn offline_without_mirror_errors() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        needs_full_metadata_for: None,
         filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
@@ -328,6 +333,7 @@ async fn offline_promotes_disk_loaded_packument_into_memory_cache() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        needs_full_metadata_for: None,
         filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
@@ -376,6 +382,7 @@ async fn prefer_offline_promotes_disk_loaded_packument_into_memory_cache() {
         prefer_offline: true,
         ignore_missing_time_field: false,
         full_metadata: false,
+        needs_full_metadata_for: None,
         filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
@@ -434,6 +441,7 @@ async fn stale_disk_promoted_entry_falls_back_to_registry_under_prefer_offline()
         prefer_offline: true,
         ignore_missing_time_field: false,
         full_metadata: false,
+        needs_full_metadata_for: None,
         filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
@@ -481,6 +489,7 @@ async fn version_spec_with_mirror_takes_fast_path() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        needs_full_metadata_for: None,
         filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
@@ -542,6 +551,7 @@ async fn version_spec_missing_in_mirror_fetches() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        needs_full_metadata_for: None,
         filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
@@ -580,6 +590,7 @@ async fn dry_run_skips_in_memory_cache() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        needs_full_metadata_for: None,
         filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
@@ -619,6 +630,7 @@ async fn pick_lowest_version_picks_min() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        needs_full_metadata_for: None,
         filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
@@ -703,6 +715,7 @@ async fn in_memory_cache_does_not_leak_across_registries() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        needs_full_metadata_for: None,
         filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
@@ -745,6 +758,7 @@ async fn invalid_package_name_errors_synchronously() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        needs_full_metadata_for: None,
         filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
@@ -811,6 +825,7 @@ async fn default_pick_targets_abbreviated_endpoint_and_mirror() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        needs_full_metadata_for: None,
         filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
@@ -863,6 +878,7 @@ async fn optional_opt_forces_full_metadata_endpoint() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        needs_full_metadata_for: None,
         filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
@@ -921,6 +937,7 @@ async fn cache_key_separates_abbreviated_from_full() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        needs_full_metadata_for: None,
         filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
@@ -964,6 +981,7 @@ async fn cache_key_separates_filtered_full_from_unfiltered_full() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: true,
+        needs_full_metadata_for: None,
         filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
@@ -977,6 +995,7 @@ async fn cache_key_separates_filtered_full_from_unfiltered_full() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: true,
+        needs_full_metadata_for: None,
         filter_metadata: true,
         retry_opts: RetryOpts::default(),
     };
@@ -1032,6 +1051,7 @@ async fn published_by_triggers_upgrade_when_modified_after_cutoff() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        needs_full_metadata_for: None,
         filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
@@ -1095,6 +1115,7 @@ async fn published_by_skips_upgrade_when_modified_equals_cutoff() {
         prefer_offline: false,
         ignore_missing_time_field: true,
         full_metadata: false,
+        needs_full_metadata_for: None,
         filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
@@ -1142,6 +1163,7 @@ async fn published_by_exclude_skips_upgrade_for_abbreviated_meta_without_time() 
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        needs_full_metadata_for: None,
         filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
@@ -1202,6 +1224,7 @@ async fn published_by_upgrade_not_modified_is_remembered_across_picks() {
         // take its warn-and-skip fallback instead of erroring.
         ignore_missing_time_field: true,
         full_metadata: false,
+        needs_full_metadata_for: None,
         filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
@@ -1284,6 +1307,7 @@ async fn published_by_excluded_package_bypasses_mtime_shortcut_and_revalidates()
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        needs_full_metadata_for: None,
         filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
@@ -1332,6 +1356,7 @@ async fn concurrent_picks_for_same_key_share_one_network_fetch() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        needs_full_metadata_for: None,
         filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
@@ -1383,6 +1408,7 @@ async fn update_checksums_bypasses_warm_in_memory_cache() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        needs_full_metadata_for: None,
         filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
@@ -1460,6 +1486,7 @@ async fn cache_fast_paths_record_route_through_hook() {
             prefer_offline: false,
             ignore_missing_time_field: false,
             full_metadata: false,
+            needs_full_metadata_for: None,
             filter_metadata: false,
             retry_opts: RetryOpts::default(),
         };
@@ -1491,6 +1518,7 @@ async fn cache_fast_paths_record_route_through_hook() {
             prefer_offline: false,
             ignore_missing_time_field: false,
             full_metadata: false,
+            needs_full_metadata_for: None,
             filter_metadata: false,
             retry_opts: RetryOpts::default(),
         };
@@ -1522,6 +1550,7 @@ async fn cache_fast_paths_record_route_through_hook() {
             prefer_offline: false,
             ignore_missing_time_field: false,
             full_metadata: false,
+            needs_full_metadata_for: None,
             filter_metadata: false,
             retry_opts: RetryOpts::default(),
         };
@@ -1622,6 +1651,7 @@ async fn private_scope_writes_descriptor_namespaced_mirror() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        needs_full_metadata_for: None,
         filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
@@ -1678,6 +1708,7 @@ async fn private_scope_fails_closed_on_401_without_disk_fallback() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        needs_full_metadata_for: None,
         filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };
@@ -1713,6 +1744,7 @@ async fn public_scope_falls_back_to_mirror_on_401() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        needs_full_metadata_for: None,
         filter_metadata: false,
         retry_opts: RetryOpts::default(),
     };

--- a/pnpm11/config/normalize-registries/src/index.ts
+++ b/pnpm11/config/normalize-registries/src/index.ts
@@ -82,8 +82,8 @@ export function toRegistryDeclarations (context: Partial<RegistryContext>): Reco
     declarationFor(registry).prefix = prefix
   }
   for (const [registry, options] of Object.entries(context.registryOptionsByUrl ?? {})) {
-    if (options.serverType == null) continue
-    declarationFor(registry).serverType = options.serverType
+    if (options.serverType != null) declarationFor(registry).serverType = options.serverType
+    if (options.supportsTimeField != null) declarationFor(registry).supportsTimeField = options.supportsTimeField
   }
   return declarations
 }
@@ -100,4 +100,20 @@ export function getRegistryServerType (
   registry: string
 ): RegistryServerType | undefined {
   return registryContext.registryOptionsByUrl?.[normalizeRegistryUrl(registry)]?.serverType
+}
+
+/**
+ * Whether `registry`'s abbreviated metadata carries the `time` field, from its
+ * own declaration if it has one and from the `registrySupportsTimeField`
+ * setting otherwise.
+ *
+ * The setting is the answer for every registry a project does not describe.
+ */
+export function registrySupportsTimeField (
+  registryContext: Pick<RegistryContext, 'registryOptionsByUrl'> & { registrySupportsTimeField?: boolean },
+  registry: string
+): boolean {
+  return registryContext.registryOptionsByUrl?.[normalizeRegistryUrl(registry)]?.supportsTimeField
+    ?? registryContext.registrySupportsTimeField
+    ?? false
 }

--- a/pnpm11/config/normalize-registries/test/toRegistryDeclarations.test.ts
+++ b/pnpm11/config/normalize-registries/test/toRegistryDeclarations.test.ts
@@ -67,3 +67,15 @@ test('toRegistryDeclarations() does not declare a built-in route the user did no
     'https://jsr.corp.example/': { scopes: ['@jsr'] },
   })
 })
+
+test('toRegistryDeclarations() carries every fact a registry declares', () => {
+  expect(toRegistryDeclarations({
+    registryOptionsByUrl: {
+      'https://npm.corp.example/': { serverType: 'artifactory', supportsTimeField: true },
+      'https://time.example/': { supportsTimeField: false },
+    },
+  })).toStrictEqual({
+    'https://npm.corp.example/': { serverType: 'artifactory', supportsTimeField: true },
+    'https://time.example/': { supportsTimeField: false },
+  })
+})

--- a/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
+++ b/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
@@ -100,7 +100,7 @@ const SECRET_REGISTRY_KEYS = new Set([
 ])
 
 /** The fields a `registries` entry may carry. Anything else is a typo. */
-const REGISTRY_DECLARATION_FIELDS = new Set(['serverType', 'scopes', 'prefix'])
+const REGISTRY_DECLARATION_FIELDS = new Set(['serverType', 'supportsTimeField', 'scopes', 'prefix'])
 
 /**
  * Turns the settings that name registries into the three lookups the rest of
@@ -205,13 +205,19 @@ function splitRegistryDeclarations (entries: Array<[string, RegistryDeclaration]
     // resolved from matches its declaration however either one spelled the
     // trailing slash.
     const normalizedRegistry = normalizeRegistryUrl(registry)
-    const { serverType, scopes, prefix } = declaration
-    if (serverType != null) {
-      if (!REGISTRY_SERVER_TYPES.has(serverType)) {
-        throw new PnpmError('INVALID_SETTING',
-          `The "${settingPath}.serverType" setting should be one of ${quoteAndJoin([...REGISTRY_SERVER_TYPES])}, but got ${JSON.stringify(serverType)}`)
+    const { serverType, supportsTimeField, scopes, prefix } = declaration
+    if (serverType != null && !REGISTRY_SERVER_TYPES.has(serverType)) {
+      throw new PnpmError('INVALID_SETTING',
+        `The "${settingPath}.serverType" setting should be one of ${quoteAndJoin([...REGISTRY_SERVER_TYPES])}, but got ${JSON.stringify(serverType)}`)
+    }
+    if (supportsTimeField != null) {
+      assertBoolean(supportsTimeField, `${settingPath}.supportsTimeField`)
+    }
+    if (serverType != null || supportsTimeField != null) {
+      lookups.registryOptionsByUrl[normalizedRegistry] = {
+        ...(serverType != null ? { serverType } : {}),
+        ...(supportsTimeField != null ? { supportsTimeField } : {}),
       }
-      lookups.registryOptionsByUrl[normalizedRegistry] = { serverType }
     }
     if (scopes != null) {
       assertStringArray(scopes, `${settingPath}.scopes`)

--- a/pnpm11/config/reader/test/getOptionsFromRootManifest.test.ts
+++ b/pnpm11/config/reader/test/getOptionsFromRootManifest.test.ts
@@ -532,3 +532,24 @@ test('getOptionsFromPnpmSettings() rejects an unknown field in a registry declar
     },
   })).toThrow(/is not a known registry setting/)
 })
+
+test('getOptionsFromPnpmSettings() reads a declared supportsTimeField', () => {
+  const options = getOptionsFromPnpmSettings(process.cwd(), {
+    registries: {
+      'https://npm.corp.example/': { supportsTimeField: true },
+      'https://artifactory.example/': { serverType: 'artifactory', supportsTimeField: false },
+    },
+  })
+  expect(options.registryOptionsByUrl).toStrictEqual({
+    'https://npm.corp.example/': { supportsTimeField: true },
+    'https://artifactory.example/': { serverType: 'artifactory', supportsTimeField: false },
+  })
+})
+
+test('getOptionsFromPnpmSettings() rejects a non-boolean supportsTimeField', () => {
+  expect(() => getOptionsFromPnpmSettings(process.cwd(), {
+    registries: {
+      'https://npm.corp.example/': { supportsTimeField: 'yes' as never },
+    },
+  })).toThrow(/supportsTimeField" setting should be a boolean, but got string/)
+})

--- a/pnpm11/core/types/src/misc.ts
+++ b/pnpm11/core/types/src/misc.ts
@@ -58,6 +58,16 @@ export type RegistryServerType = 'npm' | 'artifactory'
  */
 export interface RegistryOptions {
   serverType?: RegistryServerType
+  /**
+   * Whether this registry's abbreviated metadata carries the `time` field.
+   *
+   * `registry.npmjs.org` does not, which is why the default is `false` and why
+   * a time-based resolution falls back to the far larger full metadata. A
+   * registry that does carry it — Verdaccio and several proxies — is worth
+   * declaring: the fallback is per registry, so one that needs full metadata
+   * no longer costs it at the others.
+   */
+  supportsTimeField?: boolean
 }
 
 /**

--- a/pnpm11/resolving/npm-resolver/src/index.ts
+++ b/pnpm11/resolving/npm-resolver/src/index.ts
@@ -140,6 +140,13 @@ export interface ResolverFactoryOptions {
   storeDir?: string
   frozenStore?: boolean
   fullMetadata?: boolean
+  /**
+   * Asked instead of {@link ResolverFactoryOptions.fullMetadata} when the
+   * caller can answer per registry — a registry that declares
+   * `supportsTimeField` needs no full metadata for a time-based resolution
+   * even when the others do.
+   */
+  needsFullMetadataFor?: (registry: string) => boolean
   filterMetadata?: boolean
   offline?: boolean
   preferOffline?: boolean
@@ -266,6 +273,7 @@ export function createNpmResolver (
     pickPackage: pickPackage.bind(null, {
       fetch,
       fullMetadata: opts.fullMetadata,
+      needsFullMetadataFor: opts.needsFullMetadataFor,
       filterMetadata: opts.filterMetadata,
       metaCache,
       offline: opts.offline,

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -236,6 +236,15 @@ export async function pickPackage (
   ctx: {
     fetch: (pkgName: string, opts: { registry: string, authHeaderValue?: string, cacheBypass?: boolean, fullMetadata?: boolean, etag?: string, modified?: string }) => Promise<FetchMetadataResult | FetchMetadataNotModifiedResult>
     fullMetadata?: boolean
+    /**
+     * Whether a time-based resolution has to read the full metadata of
+     * `registry`, because that registry's abbreviated form carries no `time`.
+     * Asked per registry: the answer differs between the public registry and a
+     * proxy that does carry it, and the mirror path and cache key below are
+     * already keyed by registry, so two registries may disagree within one
+     * install.
+     */
+    needsFullMetadataFor?: (registry: string) => boolean
     metaCache: PackageMetaCache
     cacheDir: string
     offline?: boolean
@@ -261,7 +270,12 @@ export async function pickPackage (
 
   // Use full metadata for optional dependencies to get libc field.
   // See: https://github.com/pnpm/pnpm/issues/9950
-  const fullMetadata = opts.optional === true || ctx.fullMetadata === true
+  // The per-registry answer is authoritative when the caller can give one: it
+  // already folds in the reasons that hold for every registry, so a registry
+  // that carries `time` is free to stay on abbreviated metadata while the
+  // others do not.
+  const policyWantsFullMetadata = ctx.needsFullMetadataFor?.(opts.registry) ?? ctx.fullMetadata === true
+  const fullMetadata = opts.optional === true || policyWantsFullMetadata
   const metaDir = fullMetadata
     ? (ctx.filterMetadata ? FULL_FILTERED_META_DIR : FULL_META_DIR)
     : ABBREVIATED_META_DIR

--- a/pnpm11/resolving/npm-resolver/test/needsFullMetadataFor.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/needsFullMetadataFor.test.ts
@@ -65,7 +65,7 @@ test('a registry that carries the time field is asked for abbreviated metadata, 
     .intercept({ path: '/pkg', method: 'GET' })
     .reply(capture('public'))
   getMockAgent().get('https://time.example.com')
-    .intercept({ path: `/${TIME_PKG.replace('/', '%2F')}`, method: 'GET' })
+    .intercept({ path: `/@${encodeURIComponent(TIME_PKG.slice(1))}`, method: 'GET' })
     .reply(capture('time'))
 
   const { resolveFromNpm } = createResolveFromNpm({

--- a/pnpm11/resolving/npm-resolver/test/needsFullMetadataFor.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/needsFullMetadataFor.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, expect, test } from '@jest/globals'
+import { createFetchFromRegistry } from '@pnpm/network.fetch'
+import { createNpmResolver } from '@pnpm/resolving.npm-resolver'
+import type { PackageMeta } from '@pnpm/resolving.registry.types'
+import type { RegistriesByScope } from '@pnpm/types'
+import { temporaryDirectory } from 'tempy'
+
+import { getMockAgent, setupMockAgent, teardownMockAgent } from './utils/index.js'
+
+const PUBLIC_REGISTRY = 'https://registry.npmjs.org/'
+const TIME_REGISTRY = 'https://time.example.com/'
+const ABBREVIATED_ACCEPT = 'application/vnd.npm.install-v1+json'
+const TIME_PKG = '@time/pkg'
+
+const registriesByScope: RegistriesByScope = {
+  default: PUBLIC_REGISTRY,
+  '@time': TIME_REGISTRY,
+}
+
+const fetch = createFetchFromRegistry({})
+const getAuthHeader = () => undefined
+const createResolveFromNpm = createNpmResolver.bind(null, fetch, getAuthHeader)
+
+function metaOf (name: string): PackageMeta {
+  return {
+    name,
+    'dist-tags': { latest: '1.0.0' },
+    versions: {
+      '1.0.0': {
+        name,
+        version: '1.0.0',
+        dist: { shasum: '', tarball: `${PUBLIC_REGISTRY}${name}/-/pkg-1.0.0.tgz` },
+      },
+    },
+    time: { '1.0.0': '2020-02-01T00:00:00.000Z' },
+  }
+}
+
+beforeEach(async () => {
+  await setupMockAgent()
+})
+
+afterEach(async () => {
+  await teardownMockAgent()
+})
+
+/**
+ * The public registry omits `time` from its abbreviated metadata, so a
+ * time-based resolution has to read the full document from it. A registry that
+ * declares `supportsTimeField` does not, and paying for the full document at
+ * every registry because one of them needs it is the cost this removes.
+ */
+test('a registry that carries the time field is asked for abbreviated metadata, the others for full', async () => {
+  const accepts: Record<string, string | undefined> = {}
+  const capture = (registry: string) => (opts: { headers?: unknown }): { statusCode: number, data: PackageMeta } => {
+    const headers = opts.headers as Record<string, string>
+    accepts[registry] = headers.accept ?? headers.Accept
+    return {
+      statusCode: 200,
+      data: metaOf(registry === 'public' ? 'pkg' : TIME_PKG),
+    }
+  }
+
+  getMockAgent().get('https://registry.npmjs.org')
+    .intercept({ path: '/pkg', method: 'GET' })
+    .reply(capture('public'))
+  getMockAgent().get('https://time.example.com')
+    .intercept({ path: `/${TIME_PKG.replace('/', '%2F')}`, method: 'GET' })
+    .reply(capture('time'))
+
+  const { resolveFromNpm } = createResolveFromNpm({
+    cacheDir: temporaryDirectory(),
+    storeDir: temporaryDirectory(),
+    registriesByScope,
+    // What `needsFullMetadataForRegistry` answers for a time-based resolution
+    // where only the second registry declares `supportsTimeField: true`.
+    needsFullMetadataFor: (registry: string) => registry !== TIME_REGISTRY,
+  })
+
+  await resolveFromNpm({ alias: 'pkg', bareSpecifier: '1.0.0' }, {})
+  await resolveFromNpm({ alias: TIME_PKG, bareSpecifier: '1.0.0' }, {})
+
+  expect(accepts.public).not.toContain(ABBREVIATED_ACCEPT)
+  expect(accepts.time).toContain(ABBREVIATED_ACCEPT)
+})

--- a/pnpm11/store/connection-manager/package.json
+++ b/pnpm11/store/connection-manager/package.json
@@ -33,12 +33,14 @@
   },
   "dependencies": {
     "@pnpm/cli.meta": "workspace:*",
+    "@pnpm/config.normalize-registries": "workspace:*",
     "@pnpm/config.reader": "workspace:*",
     "@pnpm/installing.client": "workspace:*",
     "@pnpm/resolving.resolver-base": "workspace:*",
     "@pnpm/store.controller": "workspace:*",
     "@pnpm/store.index": "workspace:*",
     "@pnpm/store.path": "workspace:*",
+    "@pnpm/types": "workspace:*",
     "dir-is-case-sensitive": "catalog:"
   },
   "peerDependencies": {

--- a/pnpm11/store/connection-manager/src/createNewStoreController.ts
+++ b/pnpm11/store/connection-manager/src/createNewStoreController.ts
@@ -88,7 +88,7 @@ export async function createNewStoreController (
     fetchWarnTimeoutMs: opts.fetchWarnTimeoutMs,
     fetchMinSpeedKiBps: opts.fetchMinSpeedKiBps,
     fullMetadata,
-    filterMetadata: fullMetadata,
+    filterMetadata: shouldFilterMetadata(opts),
     needsFullMetadataFor: needsFullMetadataForRegistry(opts),
     httpProxy: opts.httpProxy,
     httpsProxy: opts.httpsProxy,
@@ -197,6 +197,21 @@ function fullMetadataPolicy (opts: FullMetadataPolicyOptions, supportsTimeField:
     opts.trustPolicy === 'no-downgrade' ||
     (opts.resolutionMode === 'time-based' && !supportsTimeField)
   )
+}
+
+/**
+ * Whether a full packument, once fetched, is stored and read in pnpm's
+ * filtered form rather than verbatim.
+ *
+ * Answered for the most demanding registry — one that carries no `time` —
+ * because {@link needsFullMetadataForRegistry} can ask for a full document at
+ * a registry that {@link shouldFetchFullMetadata} would have left on
+ * abbreviated metadata, and both have to agree on which mirror that document
+ * lands in. It is consulted only when a full document is actually fetched, so
+ * answering for the demanding case costs the others nothing.
+ */
+export function shouldFilterMetadata (opts: FullMetadataPolicyOptions): boolean {
+  return fullMetadataPolicy(opts, false)
 }
 
 /**

--- a/pnpm11/store/connection-manager/src/createNewStoreController.ts
+++ b/pnpm11/store/connection-manager/src/createNewStoreController.ts
@@ -1,11 +1,13 @@
 import { promises as fs } from 'node:fs'
 
 import { packageManager } from '@pnpm/cli.meta'
+import { registrySupportsTimeField } from '@pnpm/config.normalize-registries'
 import type { Config, ConfigContext } from '@pnpm/config.reader'
 import { type ClientOptions, createClient } from '@pnpm/installing.client'
 import type { ResolutionVerifier } from '@pnpm/resolving.resolver-base'
 import { type CafsLocker, createPackageStore, type StoreController } from '@pnpm/store.controller'
 import { ReadOnlyStoreIndex, StoreIndex } from '@pnpm/store.index'
+import type { RegistryContext } from '@pnpm/types'
 
 type CreateResolverOptions = Pick<Config,
 | 'fetchRetries'
@@ -47,6 +49,7 @@ export type CreateNewStoreControllerOptions = CreateResolverOptions & Pick<Confi
 | 'preserveAbsolutePaths'
 | 'registriesByScope'
 | 'registriesByPrefix'
+| 'registryOptionsByUrl'
 | 'registrySupportsTimeField'
 | 'resolutionMode'
 | 'saveWorkspaceProtocol'
@@ -86,6 +89,7 @@ export async function createNewStoreController (
     fetchMinSpeedKiBps: opts.fetchMinSpeedKiBps,
     fullMetadata,
     filterMetadata: fullMetadata,
+    needsFullMetadataFor: needsFullMetadataForRegistry(opts),
     httpProxy: opts.httpProxy,
     httpsProxy: opts.httpsProxy,
     ignoreScripts: opts.ignoreScripts,
@@ -174,17 +178,49 @@ export async function createNewStoreController (
  *   `time` field in abbreviated metadata.
  */
 export function shouldFetchFullMetadata (
-  opts: Pick<CreateNewStoreControllerOptions,
-  | 'fetchFullMetadata'
-  | 'registrySupportsTimeField'
-  | 'resolutionMode'
-  | 'supportedArchitectures'
-  | 'trustPolicy'
-  >
+  opts: FullMetadataPolicyOptions
 ): boolean {
+  return fullMetadataPolicy(opts, opts.registrySupportsTimeField ?? false)
+}
+
+type FullMetadataPolicyOptions = Pick<CreateNewStoreControllerOptions,
+| 'fetchFullMetadata'
+| 'registrySupportsTimeField'
+| 'resolutionMode'
+| 'supportedArchitectures'
+| 'trustPolicy'
+> & Pick<RegistryContext, 'registryOptionsByUrl'>
+
+function fullMetadataPolicy (opts: FullMetadataPolicyOptions, supportsTimeField: boolean): boolean {
   return opts.fetchFullMetadata ?? (
     opts.supportedArchitectures?.libc != null ||
     opts.trustPolicy === 'no-downgrade' ||
-    (opts.resolutionMode === 'time-based' && !opts.registrySupportsTimeField)
+    (opts.resolutionMode === 'time-based' && !supportsTimeField)
   )
+}
+
+/**
+ * The same policy, asked of one registry: a registry that declares
+ * `supportsTimeField` answers for itself, so a time-based resolution reads
+ * abbreviated metadata from the registries that carry `time` and full metadata
+ * only from the ones that do not.
+ *
+ * A registry with no declaration answers exactly what
+ * {@link shouldFetchFullMetadata} does.
+ *
+ * Memoized because the resolver asks once per package and a project has a
+ * handful of registries.
+ */
+export function needsFullMetadataForRegistry (
+  opts: FullMetadataPolicyOptions
+): (registry: string) => boolean {
+  const answers = new Map<string, boolean>()
+  return (registry: string): boolean => {
+    let answer = answers.get(registry)
+    if (answer == null) {
+      answer = fullMetadataPolicy(opts, registrySupportsTimeField(opts, registry))
+      answers.set(registry, answer)
+    }
+    return answer
+  }
 }

--- a/pnpm11/store/connection-manager/test/shouldFetchFullMetadata.test.ts
+++ b/pnpm11/store/connection-manager/test/shouldFetchFullMetadata.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@jest/globals'
 
-import { shouldFetchFullMetadata } from '../src/createNewStoreController.js'
+import { needsFullMetadataForRegistry, shouldFetchFullMetadata } from '../src/createNewStoreController.js'
 
 test('returns false by default', () => {
   expect(shouldFetchFullMetadata({})).toBe(false)
@@ -66,4 +66,48 @@ test('trustPolicy requires full metadata even when the registry has the time fie
     trustPolicy: 'no-downgrade',
     registrySupportsTimeField: true,
   })).toBe(true)
+})
+
+const PUBLIC_REGISTRY = 'https://registry.npmjs.org/'
+const TIME_REGISTRY = 'https://time.example.com/'
+
+test('a registry that declares the time field answers for itself, without exempting the others', () => {
+  const needsFullMetadata = needsFullMetadataForRegistry({
+    resolutionMode: 'time-based',
+    registryOptionsByUrl: { [TIME_REGISTRY]: { supportsTimeField: true } },
+  })
+
+  expect(needsFullMetadata(TIME_REGISTRY)).toBe(false)
+  expect(needsFullMetadata(PUBLIC_REGISTRY)).toBe(true)
+})
+
+test('a registry with no declaration answers what the setting answers', () => {
+  const needsFullMetadata = needsFullMetadataForRegistry({
+    resolutionMode: 'time-based',
+    registrySupportsTimeField: true,
+    registryOptionsByUrl: { [TIME_REGISTRY]: { supportsTimeField: false } },
+  })
+
+  expect(needsFullMetadata(PUBLIC_REGISTRY)).toBe(false)
+  // A declaration overrides the setting in both directions.
+  expect(needsFullMetadata(TIME_REGISTRY)).toBe(true)
+})
+
+test('a reason that holds for every registry is not undone by a declaration', () => {
+  const needsFullMetadata = needsFullMetadataForRegistry({
+    resolutionMode: 'time-based',
+    trustPolicy: 'no-downgrade',
+    registryOptionsByUrl: { [TIME_REGISTRY]: { supportsTimeField: true } },
+  })
+
+  expect(needsFullMetadata(TIME_REGISTRY)).toBe(true)
+})
+
+test('the declaration is matched however either side spelled the trailing slash', () => {
+  const needsFullMetadata = needsFullMetadataForRegistry({
+    resolutionMode: 'time-based',
+    registryOptionsByUrl: { [TIME_REGISTRY]: { supportsTimeField: true } },
+  })
+
+  expect(needsFullMetadata('https://time.example.com')).toBe(false)
 })

--- a/pnpm11/store/connection-manager/test/shouldFetchFullMetadata.test.ts
+++ b/pnpm11/store/connection-manager/test/shouldFetchFullMetadata.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@jest/globals'
 
-import { needsFullMetadataForRegistry, shouldFetchFullMetadata } from '../src/createNewStoreController.js'
+import { needsFullMetadataForRegistry, shouldFetchFullMetadata, shouldFilterMetadata } from '../src/createNewStoreController.js'
 
 test('returns false by default', () => {
   expect(shouldFetchFullMetadata({})).toBe(false)
@@ -110,4 +110,24 @@ test('the declaration is matched however either side spelled the trailing slash'
   })
 
   expect(needsFullMetadata('https://time.example.com')).toBe(false)
+})
+
+// The filtered mirror is chosen once for the whole client, so it has to cover
+// the registry that asks for the most: one the setting exempts but a
+// declaration does not.
+test('the filtered mirror is used for a registry that needs full metadata though the setting exempts it', () => {
+  const opts = {
+    resolutionMode: 'time-based',
+    registrySupportsTimeField: true,
+    registryOptionsByUrl: { [TIME_REGISTRY]: { supportsTimeField: false } },
+  } as const
+
+  expect(shouldFetchFullMetadata(opts)).toBe(false)
+  expect(needsFullMetadataForRegistry(opts)(TIME_REGISTRY)).toBe(true)
+  expect(shouldFilterMetadata(opts)).toBe(true)
+})
+
+test('nothing is filtered when no registry can need full metadata', () => {
+  expect(shouldFilterMetadata({ resolutionMode: 'highest' })).toBe(false)
+  expect(shouldFilterMetadata({ resolutionMode: 'time-based', fetchFullMetadata: false })).toBe(false)
 })

--- a/pnpm11/store/connection-manager/tsconfig.json
+++ b/pnpm11/store/connection-manager/tsconfig.json
@@ -13,10 +13,16 @@
       "path": "../../cli/meta"
     },
     {
+      "path": "../../config/normalize-registries"
+    },
+    {
       "path": "../../config/reader"
     },
     {
       "path": "../../core/logger"
+    },
+    {
+      "path": "../../core/types"
     },
     {
       "path": "../../installing/client"


### PR DESCRIPTION
## Summary

`resolutionMode: time-based` needs each version's publish time. `registry.npmjs.org` omits `time` from abbreviated metadata, so pnpm falls back to the full packument — and `registrySupportsTimeField` made that a single answer for every registry a project resolves from. For a project with more than one registry it is wrong in both directions: left `false`, it buys full metadata from a Verdaccio instance that does carry `time`; set `true`, it claims a field npmjs does not serve.

The registry entry added in pnpm/pnpm#13942 now carries the answer:

```yaml
resolutionMode: time-based
registries:
  https://npm.internal.example/:
    supportsTimeField: true
```

`registrySupportsTimeField` stays as the answer for every registry that declares nothing, so nothing changes for a project that describes no registry.

The declaration is forwarded to a pnpr server, which already inverts the client's `registries` through the same lookups, so a pnpr-served resolve applies it too.

Follow-up to pnpm/pnpm#13942 and pnpm/pnpm#13951.

## Squash Commit Body

```text
`resolutionMode: time-based` needs each version's publish time, which
`registry.npmjs.org` omits from abbreviated metadata, so pnpm falls back
to the far larger full packument. `registrySupportsTimeField` answered
that question for every registry at once, which is wrong in both
directions for a project that resolves from more than one: it either
buys full metadata from a registry that does carry `time`, or claims a
`time` field npmjs does not serve.

A registry entry now carries `supportsTimeField`, and the fallback is
decided per registry:

    resolutionMode: time-based
    registries:
      https://npm.internal.example/:
        supportsTimeField: true

The resolver asks a `needsFullMetadataFor(registry)` callback where it
used to read a single `fullMetadata` flag; the metadata mirror path and
the cache key are already keyed by registry, so two registries can
disagree within one install. A registry that declares nothing answers
exactly what the global setting says, so nothing changes unless a
project describes a registry.

The declaration reaches a pnpr server too — it already inverts the
client's `registries` through the same lookups, so a pnpr-served resolve
applies it to the resolution it runs on the caller's behalf.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port.
- [x] Added a changeset.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed. <!-- pnpm.io needs the `registries`
  setting documented, including this field; that doc PR covers pnpm/pnpm#13942 too. -->

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789520326&installation_model_id=426870&pr_number=13952&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13952&signature=542239a702119717166f01f9ac63ae3917be573f553dd81f346bc8b1d296a80a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added registry-specific support for declaring whether abbreviated metadata includes time information.
  * Improved package resolution to request full metadata only when required for each registry.
  * Added validation and configuration support for the new registry setting.

* **Bug Fixes**
  * Preserved existing global metadata and trust-policy behavior.
  * Improved registry matching by handling trailing slashes consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->