### PR TITLE
fix(version): make --dry-run leave the manifests untouched

### DIFF
--- a/.changeset/version-dry-run-writes-nothing.md
+++ b/.changeset/version-dry-run-writes-nothing.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/releasing.commands": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+`pnpm version <bump>` with `--dry-run` no longer edits `package.json` files. It now only reports the bumps it would make, and skips the working tree check, the version lifecycle scripts, the commit, and the tag.

--- a/.changeset/version-dry-run-writes-nothing.md
+++ b/.changeset/version-dry-run-writes-nothing.md
@@ -4,4 +4,4 @@
 "pnpm": patch
 ---
 
-`pnpm version <bump>` with `--dry-run` no longer edits `package.json` files. It now only reports the bumps it would make, and skips the working tree check, the version lifecycle scripts, the commit, and the tag.
+`pnpm version <bump>` with `--dry-run` no longer edits `package.json` files. It now only reports the bumps it would make, and skips the working tree check, the version lifecycle scripts, the commit, and the tag [`pnpm/pnpm#13953`](https://github.com/pnpm/pnpm/issues/13953).

--- a/pnpm/crates/cli/src/cli_args/version.rs
+++ b/pnpm/crates/cli/src/cli_args/version.rs
@@ -33,8 +33,7 @@ pub struct VersionArgs {
     /// apply the pending change intents instead.
     pub params: Vec<String>,
 
-    /// Print the release plan the pending change intents produce without
-    /// applying it.
+    /// Print what the command would do without changing anything.
     #[clap(long = "dry-run")]
     pub dry_run: bool,
 
@@ -161,7 +160,8 @@ impl VersionArgs {
         } else {
             parse_bump(raw)?
         };
-        if config.git_checks
+        if !self.dry_run
+            && config.git_checks
             && !self.no_git_checks
             && is_git_repo::<Host>(&git_cwd)
             && !is_working_tree_clean::<Host>(&git_cwd)
@@ -195,12 +195,19 @@ impl VersionArgs {
         // In recursive mode, multiple packages can be bumped to different
         // versions in a single run, and there is no obvious single version to
         // tag the commit with. Skip the git commit and tag entirely then.
-        if !recursive && !self.no_git_tag_version && is_git_repo::<Host>(&git_cwd) {
+        if !self.dry_run && !recursive && !self.no_git_tag_version && is_git_repo::<Host>(&git_cwd)
+        {
             self.commit_and_tag(&changes[0], &git_cwd)?;
         }
 
         for change in &changes {
-            run_version_lifecycle_hook::<Reporter>("postversion", change, config, dir)?;
+            run_version_lifecycle_hook::<Reporter>(
+                "postversion",
+                change,
+                config,
+                dir,
+                self.dry_run,
+            )?;
         }
 
         if self.json {
@@ -269,7 +276,13 @@ impl VersionArgs {
             path: pkg_dir.to_path_buf(),
             manifest_path: manifest_path.clone(),
         };
-        run_version_lifecycle_hook::<Reporter>("preversion", &pre_change, config, init_cwd)?;
+        run_version_lifecycle_hook::<Reporter>(
+            "preversion",
+            &pre_change,
+            config,
+            init_cwd,
+            self.dry_run,
+        )?;
 
         let new_version = match bump {
             Bump::Explicit(version) => version.clone(),
@@ -292,7 +305,9 @@ impl VersionArgs {
             .as_object_mut()
             .expect("package.json is an object — its version field was just read")
             .insert("version".to_string(), Value::String(new_version.clone()));
-        manifest.save().wrap_err_with(|| format!("saving {}", manifest_path.display()))?;
+        if !self.dry_run {
+            manifest.save().wrap_err_with(|| format!("saving {}", manifest_path.display()))?;
+        }
 
         let change = VersionChange {
             name,
@@ -301,7 +316,7 @@ impl VersionArgs {
             path: pkg_dir.to_path_buf(),
             manifest_path,
         };
-        run_version_lifecycle_hook::<Reporter>("version", &change, config, init_cwd)?;
+        run_version_lifecycle_hook::<Reporter>("version", &change, config, init_cwd, self.dry_run)?;
         Ok(Some(change))
     }
 
@@ -466,8 +481,9 @@ fn run_version_lifecycle_hook<Reporter: pnpm_reporter::Reporter>(
     change: &VersionChange,
     config: &Config,
     init_cwd: &Path,
+    dry_run: bool,
 ) -> miette::Result<()> {
-    if config.ignore_scripts {
+    if config.ignore_scripts || dry_run {
         return Ok(());
     }
     let manifest = PackageManifest::from_path(change.manifest_path.clone())

--- a/pnpm/crates/cli/src/cli_args/version.rs
+++ b/pnpm/crates/cli/src/cli_args/version.rs
@@ -227,7 +227,11 @@ impl VersionArgs {
         }
 
         use std::fmt::Write as _;
-        let mut output = String::from("Version bumped successfully:\n");
+        let mut output = String::from(if self.dry_run {
+            "Version bump plan:\n"
+        } else {
+            "Version bumped successfully:\n"
+        });
         for change in &changes {
             writeln!(
                 output,
@@ -241,8 +245,9 @@ impl VersionArgs {
     }
 
     /// Bump one package's manifest, running its `preversion` and `version`
-    /// lifecycle hooks around the write. Returns `None` — bumping nothing —
-    /// when the manifest has no name or no version.
+    /// lifecycle hooks around the write. Both the write and the hooks are
+    /// skipped on a dry run. Returns `None` — bumping nothing — when the
+    /// manifest has no name or no version.
     fn bump_package_version<Reporter: pnpm_reporter::Reporter>(
         &self,
         pkg_dir: &Path,
@@ -473,9 +478,9 @@ impl VersionArgs {
 }
 
 /// Run one `preversion` / `version` / `postversion` script of the bumped
-/// package, when the manifest declares it and scripts are not ignored.
-/// The manifest is re-read so the `version` and `postversion` hooks see
-/// the bumped version.
+/// package, when the manifest declares it, scripts are not ignored and this
+/// is not a dry run. The manifest is re-read so the `version` and
+/// `postversion` hooks see the bumped version.
 fn run_version_lifecycle_hook<Reporter: pnpm_reporter::Reporter>(
     stage: &str,
     change: &VersionChange,

--- a/pnpm/crates/cli/tests/suite/version.rs
+++ b/pnpm/crates/cli/tests/suite/version.rs
@@ -118,6 +118,10 @@ fn write_manifest(dir: &Path, json: &str) {
     fs::write(dir.join("package.json"), json).expect("write package.json");
 }
 
+fn manifest_text(dir: &Path) -> String {
+    fs::read_to_string(dir.join("package.json")).expect("read manifest")
+}
+
 fn manifest_version(dir: &Path) -> String {
     let manifest: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(dir.join("package.json")).expect("read manifest"))
@@ -643,13 +647,14 @@ fn recursive_mode_skips_the_commit_and_tag() {
 fn dry_run_reports_the_bump_without_writing_the_manifest() {
     let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
     write_manifest(&workspace, r#"{"name":"test-pkg","version":"1.0.0"}"#);
+    let manifest_before = manifest_text(&workspace);
 
     let output = pacquet_version(&workspace, &["patch", "--dry-run"]);
 
     assert!(output.status.success(), "{}", stderr_of(&output));
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("1.0.0 → 1.0.1"), "{stdout}");
-    assert_eq!(manifest_version(&workspace), "1.0.0");
+    assert_eq!(manifest_text(&workspace), manifest_before);
     drop(root);
 }
 
@@ -657,6 +662,7 @@ fn dry_run_reports_the_bump_without_writing_the_manifest() {
 fn dry_run_leaves_every_workspace_manifest_untouched() {
     let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
     let (pkg_a, pkg_b) = write_two_package_workspace(&workspace);
+    let manifests_before = [&workspace, &pkg_a, &pkg_b].map(|dir| manifest_text(dir));
 
     let output = pacquet_recursive_version(&workspace, &["-r", "version", "patch", "--dry-run"]);
 
@@ -664,8 +670,7 @@ fn dry_run_leaves_every_workspace_manifest_untouched() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("pkg-a: 1.0.0 → 1.0.1"), "{stdout}");
     assert!(stdout.contains("pkg-b: 2.3.0 → 2.3.1"), "{stdout}");
-    assert_eq!(manifest_version(&pkg_a), "1.0.0");
-    assert_eq!(manifest_version(&pkg_b), "2.3.0");
+    assert_eq!([&workspace, &pkg_a, &pkg_b].map(|dir| manifest_text(dir)), manifests_before);
     drop(root);
 }
 

--- a/pnpm/crates/cli/tests/suite/version.rs
+++ b/pnpm/crates/cli/tests/suite/version.rs
@@ -639,6 +639,70 @@ fn recursive_mode_skips_the_commit_and_tag() {
     drop(root);
 }
 
+#[test]
+fn dry_run_reports_the_bump_without_writing_the_manifest() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    write_manifest(&workspace, r#"{"name":"test-pkg","version":"1.0.0"}"#);
+
+    let output = pacquet_version(&workspace, &["patch", "--dry-run"]);
+
+    assert!(output.status.success(), "{}", stderr_of(&output));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("1.0.0 → 1.0.1"), "{stdout}");
+    assert_eq!(manifest_version(&workspace), "1.0.0");
+    drop(root);
+}
+
+#[test]
+fn dry_run_leaves_every_workspace_manifest_untouched() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let (pkg_a, pkg_b) = write_two_package_workspace(&workspace);
+
+    let output = pacquet_recursive_version(&workspace, &["-r", "version", "patch", "--dry-run"]);
+
+    assert!(output.status.success(), "{}", stderr_of(&output));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("pkg-a: 1.0.0 → 1.0.1"), "{stdout}");
+    assert!(stdout.contains("pkg-b: 2.3.0 → 2.3.1"), "{stdout}");
+    assert_eq!(manifest_version(&pkg_a), "1.0.0");
+    assert_eq!(manifest_version(&pkg_b), "2.3.0");
+    drop(root);
+}
+
+#[test]
+fn dry_run_skips_the_git_checks_the_lifecycle_scripts_and_the_commit() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let log_script = concat!(
+        r#"node -e "require('fs').appendFileSync('lifecycle.log',"#,
+        r#" process.env.npm_lifecycle_event + '\n')""#,
+    );
+    write_manifest(
+        &workspace,
+        &serde_json::json!({
+            "name": "test-pkg",
+            "version": "1.0.0",
+            "scripts": {
+                "preversion": log_script,
+                "version": log_script,
+                "postversion": log_script,
+            },
+        })
+        .to_string(),
+    );
+    init_git(&workspace);
+    git_commit_all(&workspace, "init");
+    let commits_before = git_stdout(&workspace, &["rev-list", "--count", "HEAD"]);
+    fs::write(workspace.join("dirty.txt"), "x").expect("dirty the tree");
+
+    let output = pacquet_version(&workspace, &["patch", "--dry-run"]);
+
+    assert!(output.status.success(), "{}", stderr_of(&output));
+    assert!(!workspace.join("lifecycle.log").exists(), "lifecycle scripts must not run");
+    assert_eq!(git_stdout(&workspace, &["tag", "--list"]), "");
+    assert_eq!(git_stdout(&workspace, &["rev-list", "--count", "HEAD"]), commits_before);
+    drop(root);
+}
+
 /// The npm-style and change-intents forms share one command: a version
 /// argument selects the npm-style bump even inside a workspace, and without
 /// `--recursive` it touches only the current package — never the workspace

--- a/pnpm/crates/cli/tests/suite/version.rs
+++ b/pnpm/crates/cli/tests/suite/version.rs
@@ -653,6 +653,7 @@ fn dry_run_reports_the_bump_without_writing_the_manifest() {
 
     assert!(output.status.success(), "{}", stderr_of(&output));
     let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Version bump plan:"), "{stdout}");
     assert!(stdout.contains("1.0.0 → 1.0.1"), "{stdout}");
     assert_eq!(manifest_text(&workspace), manifest_before);
     drop(root);

--- a/pnpm11/releasing/commands/src/version/index.ts
+++ b/pnpm11/releasing/commands/src/version/index.ts
@@ -113,7 +113,7 @@ export function help (): string {
             name: '--recursive',
           },
           {
-            description: 'Print the release plan the pending change intents produce without applying it',
+            description: 'Print what the command would do without changing anything',
             name: '--dry-run',
           },
         ],
@@ -168,7 +168,7 @@ export async function handler (
     throw new PnpmError('INVALID_VERSION_BUMP', `Invalid version argument: ${rawBump}. Must be a valid semver version (e.g. 1.2.3) or one of: major, minor, patch, premajor, preminor, prepatch, prerelease, from-git`)
   }
 
-  if (opts.gitChecks !== false && await isGitRepo({ cwd: gitCwd })) {
+  if (!opts.dryRun && opts.gitChecks !== false && await isGitRepo({ cwd: gitCwd })) {
     if (!await isWorkingTreeClean({ cwd: gitCwd })) {
       throw new PnpmError('UNCLEAN_WORKING_TREE', 'Working tree is not clean. Commit or stash your changes.')
     }
@@ -200,7 +200,7 @@ export async function handler (
   // In recursive mode, multiple packages can be bumped to different versions
   // in a single run, and there is no obvious single version to tag the commit
   // with. Skip the git commit and tag entirely in that case.
-  if (!opts.recursive && opts.gitTagVersion !== false && await isGitRepo({ cwd: gitCwd })) {
+  if (!opts.dryRun && !opts.recursive && opts.gitTagVersion !== false && await isGitRepo({ cwd: gitCwd })) {
     await commitAndTag(changes, { ...opts, cwd: gitCwd })
   }
 
@@ -368,7 +368,9 @@ async function bumpPackageVersion (
   }
 
   manifest.version = newVersion
-  await writeProjectManifest(manifest)
+  if (!opts.dryRun) {
+    await writeProjectManifest(manifest)
+  }
 
   const change = {
     name: manifest.name,
@@ -383,7 +385,7 @@ async function bumpPackageVersion (
 }
 
 async function runVersionLifecycleHook (stage: 'preversion' | 'version' | 'postversion', change: VersionChange, opts: VersionHandlerOptions): Promise<void> {
-  if (opts.ignoreScripts === true) return
+  if (opts.ignoreScripts === true || opts.dryRun) return
 
   const { manifest } = await readProjectManifest(change.path)
   const lifecycleOpts: RunLifecycleHookOptions = {

--- a/pnpm11/releasing/commands/src/version/index.ts
+++ b/pnpm11/releasing/commands/src/version/index.ts
@@ -210,7 +210,7 @@ export async function handler (
     return JSON.stringify(changes.map(({ manifestPath: _manifestPath, ...change }) => change), null, 2)
   }
 
-  let output = 'Version bumped successfully:\n'
+  let output = opts.dryRun ? 'Version bump plan:\n' : 'Version bumped successfully:\n'
   for (const change of changes) {
     output += `${change.name}: ${change.currentVersion} → ${change.newVersion}\n`
   }

--- a/pnpm11/releasing/commands/test/version/index.test.ts
+++ b/pnpm11/releasing/commands/test/version/index.test.ts
@@ -265,7 +265,9 @@ fs.appendFileSync(process.argv[2], process.argv[3] + ':' + manifest.version + '\
 
   describe('dry run', () => {
     it('should report the bump without writing the manifest', async () => {
-      fs.writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify({ name: 'test-pkg', version: '1.0.0' }))
+      const manifestPath = path.join(tempDir, 'package.json')
+      fs.writeFileSync(manifestPath, JSON.stringify({ name: 'test-pkg', version: '1.0.0' }))
+      const manifestBefore = fs.readFileSync(manifestPath, 'utf-8')
 
       const result = await handler({
         dir: tempDir,
@@ -276,7 +278,7 @@ fs.appendFileSync(process.argv[2], process.argv[3] + ':' + manifest.version + '\
       } as any, ['patch']) // eslint-disable-line @typescript-eslint/no-explicit-any
 
       expect(result).toContain('1.0.0 → 1.0.1')
-      expect(JSON.parse(fs.readFileSync(path.join(tempDir, 'package.json'), 'utf-8')).version).toBe('1.0.0')
+      expect(fs.readFileSync(manifestPath, 'utf-8')).toBe(manifestBefore)
     })
 
     it('should not write any workspace manifest in recursive mode', async () => {
@@ -289,6 +291,7 @@ fs.appendFileSync(process.argv[2], process.argv[3] + ':' + manifest.version + '\
       fs.writeFileSync(path.join(tempDir, 'pnpm-workspace.yaml'), 'packages:\n  - "packages/*"\n')
       fs.writeFileSync(path.join(pkgADir, 'package.json'), JSON.stringify({ name: 'pkg-a', version: '1.0.0' }))
       fs.writeFileSync(path.join(pkgBDir, 'package.json'), JSON.stringify({ name: 'pkg-b', version: '2.0.0' }))
+      const manifestsBefore = [tempDir, pkgADir, pkgBDir].map(dir => fs.readFileSync(path.join(dir, 'package.json'), 'utf-8'))
 
       const result = await handler({
         dir: tempDir,
@@ -306,8 +309,7 @@ fs.appendFileSync(process.argv[2], process.argv[3] + ':' + manifest.version + '\
       const resultStr = result as string
       expect(resultStr).toContain('pkg-a: 1.0.0 → 1.0.1')
       expect(resultStr).toContain('pkg-b: 2.0.0 → 2.0.1')
-      expect(JSON.parse(fs.readFileSync(path.join(pkgADir, 'package.json'), 'utf-8')).version).toBe('1.0.0')
-      expect(JSON.parse(fs.readFileSync(path.join(pkgBDir, 'package.json'), 'utf-8')).version).toBe('2.0.0')
+      expect([tempDir, pkgADir, pkgBDir].map(dir => fs.readFileSync(path.join(dir, 'package.json'), 'utf-8'))).toEqual(manifestsBefore)
     })
 
     it('should not run version lifecycle scripts', async () => {

--- a/pnpm11/releasing/commands/test/version/index.test.ts
+++ b/pnpm11/releasing/commands/test/version/index.test.ts
@@ -263,6 +263,81 @@ fs.appendFileSync(process.argv[2], process.argv[3] + ':' + manifest.version + '\
     )
   })
 
+  describe('dry run', () => {
+    it('should report the bump without writing the manifest', async () => {
+      fs.writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify({ name: 'test-pkg', version: '1.0.0' }))
+
+      const result = await handler({
+        dir: tempDir,
+        workspaceDir: tempDir,
+        dryRun: true,
+        gitChecks: false,
+        gitTagVersion: false,
+      } as any, ['patch']) // eslint-disable-line @typescript-eslint/no-explicit-any
+
+      expect(result).toContain('1.0.0 → 1.0.1')
+      expect(JSON.parse(fs.readFileSync(path.join(tempDir, 'package.json'), 'utf-8')).version).toBe('1.0.0')
+    })
+
+    it('should not write any workspace manifest in recursive mode', async () => {
+      const pkgADir = path.join(tempDir, 'packages', 'pkg-a')
+      const pkgBDir = path.join(tempDir, 'packages', 'pkg-b')
+      fs.mkdirSync(pkgADir, { recursive: true })
+      fs.mkdirSync(pkgBDir, { recursive: true })
+
+      fs.writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify({ name: 'my-workspace', version: '1.0.0' }))
+      fs.writeFileSync(path.join(tempDir, 'pnpm-workspace.yaml'), 'packages:\n  - "packages/*"\n')
+      fs.writeFileSync(path.join(pkgADir, 'package.json'), JSON.stringify({ name: 'pkg-a', version: '1.0.0' }))
+      fs.writeFileSync(path.join(pkgBDir, 'package.json'), JSON.stringify({ name: 'pkg-b', version: '2.0.0' }))
+
+      const result = await handler({
+        dir: tempDir,
+        workspaceDir: tempDir,
+        dryRun: true,
+        gitChecks: false,
+        gitTagVersion: false,
+        recursive: true,
+        selectedProjectsGraph: {
+          [pkgADir]: { dependencies: [], package: {} },
+          [pkgBDir]: { dependencies: [], package: {} },
+        },
+      } as any, ['patch']) // eslint-disable-line @typescript-eslint/no-explicit-any
+
+      const resultStr = result as string
+      expect(resultStr).toContain('pkg-a: 1.0.0 → 1.0.1')
+      expect(resultStr).toContain('pkg-b: 2.0.0 → 2.0.1')
+      expect(JSON.parse(fs.readFileSync(path.join(pkgADir, 'package.json'), 'utf-8')).version).toBe('1.0.0')
+      expect(JSON.parse(fs.readFileSync(path.join(pkgBDir, 'package.json'), 'utf-8')).version).toBe('2.0.0')
+    })
+
+    it('should not run version lifecycle scripts', async () => {
+      const lifecycleLog = path.join(tempDir, 'lifecycle.log')
+      const logLifecycleScript = path.join(tempDir, 'log-lifecycle.cjs')
+      fs.writeFileSync(logLifecycleScript, `const fs = require('fs')
+fs.appendFileSync(process.argv[2], process.argv[3] + '\\n')
+`)
+      fs.writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify({
+        name: 'test-pkg',
+        version: '1.0.0',
+        scripts: {
+          preversion: `node ${JSON.stringify(logLifecycleScript)} ${JSON.stringify(lifecycleLog)} preversion`,
+          version: `node ${JSON.stringify(logLifecycleScript)} ${JSON.stringify(lifecycleLog)} version`,
+          postversion: `node ${JSON.stringify(logLifecycleScript)} ${JSON.stringify(lifecycleLog)} postversion`,
+        },
+      }))
+
+      await handler({
+        dir: tempDir,
+        workspaceDir: tempDir,
+        dryRun: true,
+        gitChecks: false,
+        gitTagVersion: false,
+      } as any, ['patch']) // eslint-disable-line @typescript-eslint/no-explicit-any
+
+      expect(fs.existsSync(lifecycleLog)).toBe(false)
+    })
+  })
+
   describe('git integration', () => {
     let origCwd: string
 
@@ -424,6 +499,23 @@ fs.appendFileSync(process.argv[2], process.argv[3] + ':' + manifest.version + '\
         workspaceDir: tempDir,
         gitTagVersion: false,
       } as any, ['0.0.0']) // eslint-disable-line @typescript-eslint/no-explicit-any
+
+      const { stdout: tags } = await execa('git', ['tag', '--list'], { cwd: tempDir })
+      expect(tags).toBe('')
+
+      const { stdout: commitsAfter } = await execa('git', ['rev-list', '--count', 'HEAD'], { cwd: tempDir })
+      expect(commitsAfter).toBe(commitsBefore)
+    })
+
+    it('should skip the working tree check, the commit and the tag with --dry-run', async () => {
+      const { stdout: commitsBefore } = await execa('git', ['rev-list', '--count', 'HEAD'], { cwd: tempDir })
+      fs.writeFileSync(path.join(tempDir, 'dirty.txt'), 'x')
+
+      await handler({
+        dir: tempDir,
+        workspaceDir: tempDir,
+        dryRun: true,
+      } as any, ['patch']) // eslint-disable-line @typescript-eslint/no-explicit-any
 
       const { stdout: tags } = await execa('git', ['tag', '--list'], { cwd: tempDir })
       expect(tags).toBe('')

--- a/pnpm11/releasing/commands/test/version/index.test.ts
+++ b/pnpm11/releasing/commands/test/version/index.test.ts
@@ -277,6 +277,7 @@ fs.appendFileSync(process.argv[2], process.argv[3] + ':' + manifest.version + '\
         gitTagVersion: false,
       } as any, ['patch']) // eslint-disable-line @typescript-eslint/no-explicit-any
 
+      expect(result).toContain('Version bump plan:')
       expect(result).toContain('1.0.0 → 1.0.1')
       expect(fs.readFileSync(manifestPath, 'utf-8')).toBe(manifestBefore)
     })


### PR DESCRIPTION
## Summary

`pnpm version <bump> --dry-run` wrote the bumped version to disk anyway. In a workspace, `pnpm version patch -r --dry-run` rewrote every selected `package.json`, which is what the issue reports.

Only the bare `pnpm version -r` form, the one that consumes change intents, ever read `dryRun`. The npm-style bump path ignored it completely: it saved the manifest, ran the `preversion`/`version`/`postversion` scripts, and created the commit and tag. A dry run now reports the bumps it would make and stops there.

Two calls worth flagging, since neither is strictly required by the issue. All three lifecycle scripts are skipped, `preversion` included, because they are user scripts that touch the working tree and there is no bumped manifest for them to read. And the clean-working-tree check is skipped, the way the change-intents path already does, since there is nothing to protect when nothing is written.

The report is headed `Version bump plan:` rather than `Version bumped successfully:`, so a preview does not read like a finished bump.

Both stacks are changed, with tests in each.

Closes pnpm/pnpm#13953

## Squash Commit Body

```text
The npm-style bump path of the version command never looked at the dry-run
flag: only release_from_intents / releaseFromIntents did. So `pnpm version
<bump> --dry-run` saved the manifest, ran the version lifecycle scripts, and
created the commit and tag, and `-r` did it for every selected package.

Guard the manifest write, the lifecycle hooks, the commit and tag, and the
clean-working-tree check on the flag in both the TypeScript CLI and the Rust
port, so a dry run only reports the bumps it would make, under a plan header
rather than a success one.

Closes pnpm/pnpm#13953
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only version bump previews with `--dry-run`.
  * Reports planned package versions without modifying manifests.
  * Skips lifecycle scripts, Git checks, commits, and tags during dry runs.
  * Supports single-package and recursive version bump previews.

* **Documentation**
  * Updated dry-run help text to describe its behavior.

* **Tests**
  * Added coverage for manifest protection, lifecycle suppression, Git safety, and recursive previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->