### PR TITLE
fix(pnpr): resolve in the client's resolutionMode

### DIFF
--- a/.changeset/pnpr-resolution-mode.md
+++ b/.changeset/pnpr-resolution-mode.md
@@ -1,0 +1,11 @@
+---
+"@pnpm/installing.deps-installer": patch
+"@pnpm/pnpr.client": minor
+"@pnpm/pnpr": minor
+"pacquet": minor
+"pnpm": patch
+---
+
+A resolve request now carries the client's `resolutionMode`, so an install delegated to a pnpr server picks versions the way the client would. `time-based` and `lowest-direct` reached the server as nothing at all, leaving it on its `highest` default: the returned lockfile pinned the highest satisfying version of every dependency, and the setting appeared to be ignored.
+
+This adds a field to the resolve request body. A server older than its client ignores it and keeps resolving `highest`; the protocol is still experimental and unversioned.

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -1055,6 +1055,7 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
         prefer_frozen_lockfile: Some(link.prefer_frozen_lockfile),
         ignore_manifest_check: link.ignore_manifest_check,
         trust_lockfile: link.trust_lockfile,
+        resolution_mode: state.config.resolution_mode,
         minimum_release_age: state.config.minimum_release_age,
         minimum_release_age_exclude: state.config.minimum_release_age_exclude.clone(),
         minimum_release_age_ignore_missing_time: state

--- a/pnpm/crates/pnpr-client/src/lib.rs
+++ b/pnpm/crates/pnpr-client/src/lib.rs
@@ -22,7 +22,7 @@ use std::collections::{BTreeMap, HashSet};
 use derive_more::{Display, Error, From};
 use futures_util::StreamExt as _;
 use pnpm_catalogs_types::Catalogs;
-use pnpm_config::{RegistryDeclaration, TrustPolicy};
+use pnpm_config::{RegistryDeclaration, ResolutionMode, TrustPolicy};
 use pnpm_lockfile::Lockfile;
 use pnpm_lockfile_verification::{RenderedViolation, VerifyError};
 use reqwest::Client;
@@ -96,6 +96,9 @@ pub struct ResolveOptions {
     /// skips verifying the input lockfile (it still reuses it for
     /// resolution), mirroring the local `--trust-lockfile` opt-out.
     pub trust_lockfile: bool,
+    /// The client's `resolutionMode`. The server picks versions the way
+    /// the client would, instead of falling back to its own default.
+    pub resolution_mode: ResolutionMode,
     /// The client's verification policy. The server verifies the input
     /// lockfile under *this* policy (not its own) before resolving.
     pub minimum_release_age: Option<u64>,
@@ -141,6 +144,8 @@ pub struct ResolveProjectsOptions {
     pub prefer_frozen_lockfile: Option<bool>,
     pub ignore_manifest_check: bool,
     pub trust_lockfile: bool,
+    /// See [`ResolveOptions::resolution_mode`].
+    pub resolution_mode: ResolutionMode,
     pub minimum_release_age: Option<u64>,
     pub minimum_release_age_exclude: Option<Vec<String>>,
     pub minimum_release_age_ignore_missing_time: bool,
@@ -173,6 +178,7 @@ impl From<ResolveOptions> for ResolveProjectsOptions {
             prefer_frozen_lockfile: opts.prefer_frozen_lockfile,
             ignore_manifest_check: opts.ignore_manifest_check,
             trust_lockfile: opts.trust_lockfile,
+            resolution_mode: opts.resolution_mode,
             minimum_release_age: opts.minimum_release_age,
             minimum_release_age_exclude: opts.minimum_release_age_exclude,
             minimum_release_age_ignore_missing_time: opts.minimum_release_age_ignore_missing_time,
@@ -474,6 +480,7 @@ impl PnprClient {
             "preferFrozenLockfile": opts.prefer_frozen_lockfile,
             "ignoreManifestCheck": opts.ignore_manifest_check,
             "trustLockfile": opts.trust_lockfile,
+            "resolutionMode": opts.resolution_mode,
             "minimumReleaseAge": opts.minimum_release_age,
             "minimumReleaseAgeExclude": opts.minimum_release_age_exclude,
             "minimumReleaseAgeIgnoreMissingTime": opts.minimum_release_age_ignore_missing_time,

--- a/pnpm/crates/pnpr-client/src/tests.rs
+++ b/pnpm/crates/pnpr-client/src/tests.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use pnpm_config::TrustPolicy;
+use pnpm_config::{ResolutionMode, TrustPolicy};
 use serde_json::json;
 
 use super::{
@@ -23,6 +23,7 @@ async fn the_resolve_request_carries_the_catalogs_and_the_whole_policy() {
             "autoInstallPeers": false,
             "dedupePeers": true,
             "excludeLinksFromLockfile": false,
+            "resolutionMode": "time-based",
             "minimumReleaseAge": 1440,
             "minimumReleaseAgeExclude": ["@acme/*"],
             "minimumReleaseAgeIgnoreMissingTime": false,
@@ -69,6 +70,7 @@ fn resolve_projects_options() -> ResolveProjectsOptions {
         prefer_frozen_lockfile: None,
         ignore_manifest_check: false,
         trust_lockfile: true,
+        resolution_mode: ResolutionMode::TimeBased,
         minimum_release_age: Some(1440),
         minimum_release_age_exclude: Some(vec!["@acme/*".to_string()]),
         minimum_release_age_ignore_missing_time: false,

--- a/pnpm/crates/pnpr-client/tests/integration.rs
+++ b/pnpm/crates/pnpr-client/tests/integration.rs
@@ -219,6 +219,7 @@ fn options(
         prefer_frozen_lockfile: None,
         ignore_manifest_check: false,
         trust_lockfile: false,
+        resolution_mode: pnpm_config::ResolutionMode::default(),
         minimum_release_age: None,
         minimum_release_age_exclude: None,
         minimum_release_age_ignore_missing_time: true,

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -3079,6 +3079,7 @@ async function installViaPnprServer (
       autoInstallPeers: opts.autoInstallPeers,
       dedupePeers: opts.dedupePeers,
       excludeLinksFromLockfile: opts.excludeLinksFromLockfile,
+      resolutionMode: opts.resolutionMode,
       minimumReleaseAge: opts.minimumReleaseAge,
       minimumReleaseAgeExclude: opts.minimumReleaseAgeExclude,
       minimumReleaseAgeIgnoreMissingTime: opts.minimumReleaseAgeIgnoreMissingTime,
@@ -3086,7 +3087,7 @@ async function installViaPnprServer (
       trustPolicyExclude: opts.trustPolicyExclude,
       trustPolicyIgnoreAfter: opts.trustPolicyIgnoreAfter,
       trustLockfile: opts.trustLockfile,
-      // Resolution mode. Without these the server always reuse-and-updates,
+      // Lockfile reuse. Without these the server always reuse-and-updates,
       // so `--frozen-lockfile` would silently resolve and rewrite the very
       // lockfile it promises to leave alone.
       frozenLockfile: opts.frozenLockfile === true || (opts.frozenLockfileIfExists === true && existingLockfile != null),

--- a/pnpr/client/src/resolveViaPnprServer.ts
+++ b/pnpr/client/src/resolveViaPnprServer.ts
@@ -75,6 +75,11 @@ export interface ResolveViaPnprServerOptions {
   dedupePeers?: boolean
   excludeLinksFromLockfile?: boolean
   /**
+   * The client's `resolutionMode`. The server picks versions the way the
+   * client would, instead of falling back to its own default.
+   */
+  resolutionMode?: 'highest' | 'time-based' | 'lowest-direct'
+  /**
    * The client's verification policy. The server is the only place these
    * run on the pnpr path — the client skips its own
    * `verifyLockfileResolutions` whenever a pnpr server is configured — so
@@ -164,6 +169,7 @@ export async function resolveViaPnprServer (
     excludeLinksFromLockfile: opts.excludeLinksFromLockfile,
     os: process.platform,
     arch: process.arch,
+    resolutionMode: opts.resolutionMode,
     minimumReleaseAge: opts.minimumReleaseAge,
     minimumReleaseAgeExclude: opts.minimumReleaseAgeExclude,
     minimumReleaseAgeIgnoreMissingTime: opts.minimumReleaseAgeIgnoreMissingTime,

--- a/pnpr/client/test/resolveViaPnprServer.test.ts
+++ b/pnpr/client/test/resolveViaPnprServer.test.ts
@@ -6,6 +6,7 @@ import { type PnprProject, resolveViaPnprServer, type ResolveViaPnprServerOption
 
 interface CapturedResolveRequest {
   projects: Array<Record<string, unknown>>
+  resolutionMode?: string
 }
 
 const resolverSettingNames = ['autoInstallPeers', 'dedupePeers', 'excludeLinksFromLockfile'] as const
@@ -66,6 +67,21 @@ test.each(resolverSettingNames)('serializes %s independently', async (setting) =
       expect(Object.hasOwn(request, key)).toBe(key === setting)
     }
   }))
+})
+
+// The mode decides which version every pick lands on, so a server resolving
+// on the client's behalf has to be told it — omitted, it resolves `highest`
+// and hands back a lockfile the client would never have written.
+test.each(['time-based', 'lowest-direct', 'highest'] as const)('serializes resolutionMode %s', async (resolutionMode) => {
+  const request = await captureResolveRequest({ dependencies: {}, resolutionMode })
+
+  expect(request).toMatchObject({ resolutionMode })
+})
+
+test('omits resolutionMode when the caller has none', async () => {
+  const request = await captureResolveRequest({ dependencies: {} })
+
+  expect(Object.hasOwn(request, 'resolutionMode')).toBe(false)
 })
 
 async function captureResolveRequest (

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -338,6 +338,7 @@ fn intern_config(
         "resolverSettings": resolver_settings,
         "registries": &request.registries,
         "overrides": overrides_key,
+        "resolutionMode": request.resolution_mode,
         "minimumReleaseAge": request.minimum_release_age,
         "minimumReleaseAgeExclude": request.minimum_release_age_exclude,
         "minimumReleaseAgeIgnoreMissingTime": request.minimum_release_age_ignore_missing_time,
@@ -378,10 +379,12 @@ fn intern_config(
     config.modules_dir = PathBuf::from("node_modules");
     config.lockfile = true;
     config.verify_store_integrity = true;
-    // The client's verification policy drives both the input-lockfile
-    // verifier and the resolver's pick-time `minimumReleaseAge` /
-    // `trustPolicy` checks, so newly-resolved entries are held to the
-    // same policy as the reused ones.
+    // The client's resolution and verification policies drive both the
+    // input-lockfile verifier and the resolver's pick-time
+    // `minimumReleaseAge` / `trustPolicy` checks, so a newly-resolved
+    // entry is picked the way the client would have picked it and held
+    // to the same policy as the reused ones.
+    config.resolution_mode = request.resolution_mode;
     config.minimum_release_age = request.minimum_release_age;
     config.minimum_release_age_exclude.clone_from(&request.minimum_release_age_exclude);
     if let Some(ignore_missing_time) = request.minimum_release_age_ignore_missing_time {
@@ -814,6 +817,7 @@ fn resolution_cache_key(config: &PacquetConfig, request: &ResolveRequest) -> Opt
         "preferFrozenLockfile": request.prefer_frozen_lockfile,
         "ignoreManifestCheck": request.ignore_manifest_check,
         "trustLockfile": request.trust_lockfile,
+        "resolutionMode": request.resolution_mode,
         "minimumReleaseAge": request.minimum_release_age,
         "minimumReleaseAgeExclude": &request.minimum_release_age_exclude,
         "minimumReleaseAgeIgnoreMissingTime": request.minimum_release_age_ignore_missing_time,

--- a/pnpr/crates/pnpr/src/resolver/protocol.rs
+++ b/pnpr/crates/pnpr/src/resolver/protocol.rs
@@ -122,6 +122,13 @@ pub struct ResolveRequest {
     /// `trustLockfile` opt-out.
     #[serde(default)]
     pub trust_lockfile: bool,
+    /// The client's `resolutionMode`, which decides how a version is
+    /// picked: highest satisfying, lowest-satisfying direct, or
+    /// time-based (lowest direct, with subdependencies constrained to
+    /// what was published by the newest direct dependency). A client
+    /// that sends none gets the `highest` default.
+    #[serde(default)]
+    pub resolution_mode: pnpm_config::ResolutionMode,
     /// Minimum package age (minutes) before a version is acceptable.
     #[serde(default)]
     pub minimum_release_age: Option<u64>,

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -1,5 +1,5 @@
 use axum::http::StatusCode;
-use pnpm_config::{Config as PacquetConfig, RegistryDeclaration};
+use pnpm_config::{Config as PacquetConfig, RegistryDeclaration, ResolutionMode};
 use pnpm_lockfile::Lockfile;
 use pnpm_resolving_resolver_base::{
     PackageVersionGuard, PackageVersionGuardDecision, PackageVersionGuardFuture,
@@ -275,12 +275,18 @@ fn resolution_cache_key_changes_with_dependencies_and_policy() {
         minimum_release_age: Some(60),
         ..ResolveRequest::default()
     };
+    let different_mode = ResolveRequest {
+        dependencies: Some(deps(&[("foo", "^1.0.0")])),
+        resolution_mode: ResolutionMode::TimeBased,
+        ..ResolveRequest::default()
+    };
 
     let config = config();
     let base_key = resolution_cache_key(&config, &base);
 
     assert_ne!(base_key, resolution_cache_key(&config, &different_dep));
     assert_ne!(base_key, resolution_cache_key(&config, &different_policy));
+    assert_ne!(base_key, resolution_cache_key(&config, &different_mode));
 }
 
 #[test]
@@ -1427,4 +1433,34 @@ fn intern_config_keys_overrides_canonically_regardless_of_order() {
     let second = intern(serde_json::json!({ "b": "2.0.0", "a": "1.0.0" })).expect("config reused");
     assert!(std::ptr::eq(first, second));
     assert_eq!(configs.lock().expect("config cache poisoned").len(), 1);
+}
+
+/// The client's `resolutionMode` decides which version a pick lands on, so a
+/// server resolving on the client's behalf has to run the client's mode
+/// rather than its own default — and two modes cannot share one interned
+/// config.
+#[test]
+fn intern_config_resolves_in_the_client_s_resolution_mode() {
+    use pnpm_store_dir::StoreDir;
+
+    use super::intern_config;
+
+    let configs = Mutex::new(HashMap::new());
+    let store_dir = StoreDir::new(PathBuf::from("/tmp/pnpr-resolution-mode-store"));
+    let cache_dir = PathBuf::from("/tmp/pnpr-resolution-mode-cache");
+    let intern = |request: &ResolveRequest| {
+        intern_config(&configs, &store_dir, &cache_dir, request, 10, usize::MAX)
+            .expect("intern config")
+    };
+
+    let legacy = ResolveRequest::default();
+    assert_eq!(legacy.resolution_mode, ResolutionMode::Highest);
+    assert_eq!(intern(&legacy).resolution_mode, ResolutionMode::Highest);
+
+    for mode in [ResolutionMode::TimeBased, ResolutionMode::LowestDirect] {
+        let request = ResolveRequest { resolution_mode: mode, ..ResolveRequest::default() };
+        assert_eq!(intern(&request).resolution_mode, mode);
+    }
+
+    assert_eq!(configs.lock().expect("config cache").len(), 3);
 }


### PR DESCRIPTION
## Summary

A pnpr resolve request carried the client's `minimumReleaseAge` and `trustPolicy`, but never its `resolutionMode` — and `intern_config` never set `config.resolution_mode` — so every pnpr-delegated resolve ran on the server's `highest` default. A project configured for `time-based` or `lowest-direct` got back a lockfile pinning the highest satisfying version of everything, with nothing to indicate the setting had been dropped.

The mode now travels with the request and reaches the interned config, which is what `PickPolicy::from_config` reads server-side (`Install` is handed that same config). It also joins both cache keys — the interned-config key and the resolution cache key — so two modes can neither share a config nor replay each other's resolution.

`VerifyLockfileOptions` deliberately does not carry it: verification judges an existing lockfile against the client's policy and picks no version.

Found while reviewing pnpm/pnpm#13952 (a review bot mis-attributed it to that change; the gap is older and wider than the `time` field).

## Squash Commit Body

```text
A resolve request carried the client's `minimumReleaseAge` and
`trustPolicy` but not its `resolutionMode`, and `intern_config` never
set `config.resolution_mode`, so every pnpr-delegated resolve ran on the
server's `highest` default. A project configured for `time-based` or
`lowest-direct` got a lockfile pinning the highest satisfying version of
everything, with nothing to show that the setting had been dropped.

The mode now travels with the request and reaches the interned config,
which is what `PickPolicy::from_config` reads on the server side. It
also joins both cache keys — the interned-config key and the resolution
cache key — so two modes can neither share a config nor replay each
other's resolution.

`VerifyLockfileOptions` deliberately does not carry it: verification
judges an existing lockfile against the client's policy and picks no
version.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port (both pnpr clients send the field).
- [x] Added a changeset.
- [x] Added or updated tests — wire coverage for both clients, the server's
  interned config per mode, and both cache keys.
- [x] Updated the documentation if needed (no user-facing setting changed;
  `resolutionMode` is documented already).

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13958"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789553763&installation_model_id=426870&pr_number=13958&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13958&signature=41f82f9445860ed820ed18f8672edc9c50691babf4f73672b714ed327ba434d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dependency resolution requests now preserve the configured resolution mode: highest, time-based, or lowest-direct.
  * pnpr servers apply the client’s selected resolution strategy consistently for single-project and workspace installations.
* **Bug Fixes**
  * Resolution results are now kept separate across different modes, preventing reuse of incompatible cached results.
  * Older pnpr servers remain compatible and continue using highest resolution when the setting is unavailable.
* **Tests**
  * Added coverage for resolution-mode serialization, defaults, and cache isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->