### PR TITLE
fix: stop the not-implemented stub from shadowing set-script

### DIFF
--- a/.changeset/set-script-is-no-longer-shadowed.md
+++ b/.changeset/set-script-is-no-longer-shadowed.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+`pnpm set-script` no longer fails with `ERR_PNPM_NOT_IMPLEMENTED`. The command was implemented but a leftover not-implemented stub was registered under the same name and shadowed it [`pnpm/pnpm#13956`](https://github.com/pnpm/pnpm/issues/13956).

--- a/.changeset/set-script-is-no-longer-shadowed.md
+++ b/.changeset/set-script-is-no-longer-shadowed.md
@@ -2,4 +2,4 @@
 "pnpm": patch
 ---
 
-`pnpm set-script` no longer fails with `ERR_PNPM_NOT_IMPLEMENTED`. The command was implemented but a leftover not-implemented stub was registered under the same name and shadowed it [`pnpm/pnpm#13956`](https://github.com/pnpm/pnpm/issues/13956).
+`pnpm set-script` now updates `package.json` instead of failing with `ERR_PNPM_NOT_IMPLEMENTED` [`pnpm/pnpm#13956`](https://github.com/pnpm/pnpm/issues/13956).

--- a/pnpm11/pnpm/src/cmd/notImplemented.ts
+++ b/pnpm11/pnpm/src/cmd/notImplemented.ts
@@ -5,7 +5,6 @@ import type { CommandDefinition } from './index.js'
 const NOT_IMPLEMENTED_COMMANDS = [
   'edit',
   'profile',
-  'set-script',
   'token',
   'xmas',
 ]

--- a/pnpm11/pnpm/test/cli.ts
+++ b/pnpm11/pnpm/test/cli.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 import { expect, test } from '@jest/globals'
+import { readPackageJsonFromDir } from '@pnpm/pkg-manifest.reader'
 import { prepare, prepareEmpty } from '@pnpm/prepare'
 import { fixtures } from '@pnpm/test-fixtures'
 import { rimrafSync } from '@zkochan/rimraf'
@@ -23,6 +24,16 @@ test('commands that were previously passed through to npm now fail', () => {
   expect(result.status).not.toBe(0)
   const output = result.stdout.toString() + result.stderr.toString()
   expect(output).toContain('ERR_PNPM_NOT_IMPLEMENTED')
+})
+
+test('set-script writes the script to package.json', async () => {
+  prepare({})
+
+  const result = execPnpmSync(['set-script', 'hello', 'node hello.js'])
+
+  expect(result.status).toBe(0)
+  const pkgJson = await readPackageJsonFromDir(process.cwd())
+  expect(pkgJson.scripts).toStrictEqual({ hello: 'node hello.js' })
 })
 
 test('installs in the folder where the package.json file is', async () => {


### PR DESCRIPTION
## Summary

`pnpm set-script` failed with `ERR_PNPM_NOT_IMPLEMENTED` even though the command is implemented in `@pnpm/pkg-manifest.commands` and registered in the commands list. `set-script` was still listed in `NOT_IMPLEMENTED_COMMANDS`, and `notImplementedCommandDefinitions` is spread at the end of the `commands` array, so the stub handler overwrote the real one under that name. The `ss` alias was unaffected, which is why only the full name broke. Removing the entry is enough; nothing else reads it. Fixes pnpm/pnpm#13956.

The Rust port already dispatches `set-script` to its own implementation, so nothing needs porting there.

## Squash Commit Body

```text
`set-script` was listed in NOT_IMPLEMENTED_COMMANDS while also being registered
as a real command. Since notImplementedCommandDefinitions is spread last into
the commands array, its stub handler won the handlerByCommandName lookup and
threw ERR_PNPM_NOT_IMPLEMENTED. The `ss` alias kept working because the stub
only declares the full name.

Dropping the entry restores the real handler and also stops main.ts from
letting unknown options through for the command. Covered by an e2e test in
pnpm/test/cli.ts.

Closes pnpm/pnpm#13956.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789554091&installation_model_id=426870&pr_number=13959&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13959&signature=65e6db6d2789d1c949ab45064d11a068b0a8b4dfc3719f9d0397a994e3d85cbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `pnpm set-script`, which no longer fails with an unsupported-command error.
  - Running `pnpm set-script` now successfully adds the specified script to `package.json`.

- **Tests**
  - Added coverage to verify successful script creation and the resulting package configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->