### PR TITLE
perf(tarball): stream large tarball extraction into the store

### DIFF
--- a/.changeset/stream-large-tarball-extraction.md
+++ b/.changeset/stream-large-tarball-extraction.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Reduced peak memory usage when installing large packages. A tarball whose compressed size is at least 16 MiB, or whose registry-reported unpacked size is at least 64 MiB, is now extracted by streaming the decompression directly into the content-addressable store instead of materializing the whole decompressed archive in memory, and its large files are hashed and written to the store incrementally.

--- a/pnpm/crates/fs/src/ensure_file.rs
+++ b/pnpm/crates/fs/src/ensure_file.rs
@@ -363,8 +363,58 @@ fn file_equals_bytes(file_path: &Path, content: &[u8]) -> io::Result<bool> {
 fn write_atomic(
     file_path: &Path,
     content: &[u8],
-    #[cfg_attr(windows, allow(unused))] mode: Option<u32>,
+    mode: Option<u32>,
 ) -> Result<(), EnsureFileError> {
+    let parent = file_path.parent().unwrap_or_else(|| Path::new("."));
+    let name = file_path
+        .file_name()
+        .map(|file_name| file_name.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let (tmp_path, mut file) = create_exclusive_temp_file(parent, &strip_dash_suffix(&name), mode)?;
+
+    if let Err(error) = file.write_all(content) {
+        drop(file);
+        let _ = fs::remove_file(&tmp_path);
+        return Err(EnsureFileError::WriteFile { file_path: tmp_path, error });
+    }
+    // Close the handle before `rename`. Windows `MoveFileEx` over
+    // an open source file can fail with sharing-violation; Unix
+    // doesn't care but an early `close` lets the kernel commit
+    // dirty buffers before the rename commits the dirent change.
+    drop(file);
+
+    if let Err(error) = rename_with_retry(&tmp_path, file_path) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(EnsureFileError::RenameFile {
+            tmp_path,
+            file_path: file_path.to_path_buf(),
+            error,
+        });
+    }
+    Ok(())
+}
+
+/// Create a uniquely-named file inside `dir` with `O_CREAT | O_EXCL`
+/// semantics, returning its path and open handle. The name is
+/// `{base}{pid}{counter}`: the counter is a process-local
+/// monotonically-increasing atomic, giving uniqueness across rayon /
+/// tokio workers in the same process, and the pid avoids collisions
+/// when multiple install processes share a store dir.
+///
+/// The exclusive open means we never follow a symlink or truncate a
+/// file an attacker (or a crashed prior install) pre-seeded at our
+/// predicted temp path. If we hit `AlreadyExists` anyway — collisions
+/// are vanishingly rare given the pid + per-process atomic counter temp
+/// scheme, but cross-container shared-store setups can re-use pids — we
+/// advance the counter and try again, up to `MAX_TEMP_ATTEMPTS` times.
+///
+/// The caller owns the file's lifecycle: rename it into place on
+/// success, remove it on failure.
+pub fn create_exclusive_temp_file(
+    dir: &Path,
+    base: &str,
+    #[cfg_attr(windows, allow(unused))] mode: Option<u32>,
+) -> Result<(PathBuf, File), EnsureFileError> {
     /// Retries after `AlreadyExists` on the temp path. Sixteen fresh
     /// counter values is plenty — under benign conditions we never
     /// collide; under shared-store-across-containers the chance of
@@ -374,7 +424,7 @@ fn write_atomic(
     let mut last_already_exists: Option<io::Error> = None;
 
     for _ in 0..MAX_TEMP_ATTEMPTS {
-        let tmp_path = temp_path_for(file_path);
+        let tmp_path = temp_path_in(dir, base);
 
         let mut options = OpenOptions::new();
         options.write(true).create_new(true);
@@ -387,52 +437,30 @@ fn write_atomic(
             }
         }
 
-        let mut file = match retry_on_fd_pressure(|| options.open(&tmp_path)) {
-            Ok(file) => file,
+        match retry_on_fd_pressure(|| options.open(&tmp_path)) {
+            Ok(file) => return Ok((tmp_path, file)),
             Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
                 // Stale temp file or adversarial / concurrent pre-seed.
                 // Retry with a fresh counter; don't touch whatever is
                 // at the colliding path.
                 last_already_exists = Some(error);
-                continue;
             }
             Err(error) => {
                 return Err(EnsureFileError::CreateFile { file_path: tmp_path, error });
             }
-        };
-
-        if let Err(error) = file.write_all(content) {
-            drop(file);
-            let _ = fs::remove_file(&tmp_path);
-            return Err(EnsureFileError::WriteFile { file_path: tmp_path, error });
         }
-        // Close the handle before `rename`. Windows `MoveFileEx` over
-        // an open source file can fail with sharing-violation; Unix
-        // doesn't care but an early `close` lets the kernel commit
-        // dirty buffers before the rename commits the dirent change.
-        drop(file);
-
-        if let Err(error) = rename_with_retry(&tmp_path, file_path) {
-            let _ = fs::remove_file(&tmp_path);
-            return Err(EnsureFileError::RenameFile {
-                tmp_path,
-                file_path: file_path.to_path_buf(),
-                error,
-            });
-        }
-        return Ok(());
     }
 
     // Ran out of temp-name attempts. Surface the last `AlreadyExists`
-    // so the operator can see what happened; pick the file_path as
+    // so the operator can see what happened; pick the directory as
     // the best-effort context since we can't enumerate every temp
     // name we tried.
     Err(EnsureFileError::CreateFile {
-        file_path: file_path.to_path_buf(),
+        file_path: dir.to_path_buf(),
         error: last_already_exists.unwrap_or_else(|| {
             io::Error::new(
                 io::ErrorKind::AlreadyExists,
-                "exhausted temp-path attempts for atomic CAS rewrite",
+                "exhausted temp-path attempts for exclusive temp file",
             )
         }),
     })
@@ -516,35 +544,24 @@ fn is_transient_rename_error(
     }
 }
 
-/// Build a unique temp path next to `file_path`, of the form
-/// `{stripped_basename}{pid}{counter}`. The counter is a process-local
-/// monotonically-increasing `AtomicU64`, giving uniqueness across
-/// rayon / tokio workers in the same process; combining it with the
-/// pid avoids collisions when multiple install processes share a store
-/// dir.
-///
-/// We drop `-exec` / any dash-suffix, mainly so temp files don't look
-/// like executable CAS entries to any observer scanning the shard.
-fn temp_path_for(file_path: &Path) -> PathBuf {
+/// Build a unique temp path inside `dir`, of the form
+/// `{base}{pid}{counter}` per [`create_exclusive_temp_file`]'s
+/// uniqueness contract.
+fn temp_path_in(dir: &Path, base: &str) -> PathBuf {
     static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
     let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
     let pid = std::process::id();
 
-    let parent = file_path.parent().unwrap_or_else(|| Path::new("."));
-    let name = file_path
-        .file_name()
-        .map(|file_name| file_name.to_string_lossy().into_owned())
-        .unwrap_or_default();
-    let base = strip_dash_suffix(&name);
-
-    parent.join(format!("{base}{pid}{counter}"))
+    dir.join(format!("{base}{pid}{counter}"))
 }
 
 /// Strip the first `-…` tail; if the tail was `-exec`, append `x`. On
 /// pacquet's CAS names (`{hex}` or `{hex}-exec`) the only real input is
 /// those two shapes, but the general form is handled so any future
-/// suffix doesn't silently diverge.
+/// suffix doesn't silently diverge. Applied to [`write_atomic`]'s temp
+/// names mainly so temp files don't look like executable CAS entries to
+/// any observer scanning the shard.
 fn strip_dash_suffix(name: &str) -> String {
     let Some(dash_pos) = name.find('-') else {
         return name.to_string();

--- a/pnpm/crates/fs/src/ensure_file.rs
+++ b/pnpm/crates/fs/src/ensure_file.rs
@@ -413,6 +413,9 @@ fn write_atomic(
 pub fn create_exclusive_temp_file(
     dir: &Path,
     base: &str,
+    // `mode` feeds `OpenOptionsExt::mode` inside the `cfg(unix)` block
+    // below; Windows has no POSIX mode bits to set at open time, so the
+    // parameter is genuinely unused there.
     #[cfg_attr(windows, allow(unused))] mode: Option<u32>,
 ) -> Result<(PathBuf, File), EnsureFileError> {
     /// Retries after `AlreadyExists` on the temp path. Sixteen fresh

--- a/pnpm/crates/fs/src/ensure_file/tests.rs
+++ b/pnpm/crates/fs/src/ensure_file/tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    EnsureFileError, ensure_file, file_equals_bytes, is_transient_rename_error, rename_with_retry,
-    temp_path_for,
+    EnsureFileError, create_exclusive_temp_file, ensure_file, file_equals_bytes,
+    is_transient_rename_error, rename_with_retry, strip_dash_suffix, temp_path_in,
 };
 use std::{fs, io, path::Path};
 use tempfile::tempdir;
@@ -85,19 +85,38 @@ fn unix_mode_is_applied_on_new_files() {
 
 #[test]
 fn temp_path_strips_exec_suffix() {
-    let store_path = Path::new("/tmp/store/v11/files/ab/cdef-exec");
-    let tmp = temp_path_for(store_path);
+    let shard_dir = Path::new("/tmp/store/v11/files/ab");
+    let tmp = temp_path_in(shard_dir, &strip_dash_suffix("cdef-exec"));
     let name = tmp.file_name().unwrap().to_string_lossy().into_owned();
     assert!(name.starts_with("cdefx"), "got {name}");
 }
 
 #[test]
 fn temp_path_passes_plain_basename_through() {
-    let store_path = Path::new("/tmp/store/v11/files/ab/cdef");
-    let tmp = temp_path_for(store_path);
+    let shard_dir = Path::new("/tmp/store/v11/files/ab");
+    let tmp = temp_path_in(shard_dir, &strip_dash_suffix("cdef"));
     let name = tmp.file_name().unwrap().to_string_lossy().into_owned();
     assert!(name.starts_with("cdef"), "got {name}");
     assert_ne!(name, "cdef", "must include pid + counter suffix");
+}
+
+/// The exclusive temp helper hands back an open handle inside the
+/// requested directory; distinct calls never collide.
+#[test]
+fn create_exclusive_temp_file_yields_distinct_open_files() {
+    use std::io::Write;
+
+    let tmp = tempdir().unwrap();
+    let (path_a, mut file_a) =
+        create_exclusive_temp_file(tmp.path(), "stream", None).expect("first temp file");
+    let (path_b, _file_b) =
+        create_exclusive_temp_file(tmp.path(), "stream", None).expect("second temp file");
+
+    assert_ne!(path_a, path_b);
+    assert_eq!(path_a.parent().unwrap(), tmp.path());
+    file_a.write_all(b"payload").expect("write through the returned handle");
+    drop(file_a);
+    assert_eq!(fs::read(&path_a).unwrap(), b"payload");
 }
 
 /// Windows AV / indexer interference surfaces as

--- a/pnpm/crates/store-dir/src/cas_file.rs
+++ b/pnpm/crates/store-dir/src/cas_file.rs
@@ -111,10 +111,9 @@ impl StoreDir {
     /// Returns the CAS path, the content hash, and the streamed byte
     /// count. A reader that yields the same bytes as a `buffer` handed
     /// to [`StoreDir::write_cas_file`] lands at the same path with the
-    /// same guarantees: an existing regular file of the expected size
-    /// at the target is kept as the live entry (CAS paths are
-    /// hash-derived, so a size-matching file is the same content), and
-    /// anything else is atomically replaced.
+    /// same guarantees: an existing regular file at the target is kept
+    /// as the live entry only after a byte-compare against the streamed
+    /// content, and anything else is atomically replaced.
     pub fn write_cas_file_from_reader(
         &self,
         reader: &mut dyn Read,
@@ -166,8 +165,10 @@ impl StoreDir {
 
         let file_hash = hasher.finalize();
         let file_path = self.cas_file_path(file_hash, executable);
-        self.ensure_shard_dir(&file_path, file_hash[0])
-            .map_err(WriteCasFileFromReaderError::Write)?;
+        if let Err(error) = self.ensure_shard_dir(&file_path, file_hash[0]) {
+            let _ = fs::remove_file(&tmp_path);
+            return Err(WriteCasFileFromReaderError::Write(error));
+        }
 
         // Serialize with buffer-based writers ([`ensure_file`]) and
         // verifiers of the same path, per [`cas_write_lock`]'s
@@ -175,13 +176,16 @@ impl StoreDir {
         let lock = cas_write_lock(&file_path);
         let _guard = lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
 
-        // A regular file of the expected size at a hash-derived path is
-        // the same content — keep it as the live entry rather than
-        // replacing its inode. Anything else (missing, torn short blob,
-        // symlink or other non-regular dirent) is atomically replaced
-        // by the rename.
+        // A regular file already at the hash-derived target is kept —
+        // preserving its inode — only after its bytes are verified
+        // against the freshly streamed temp, the same guarantee
+        // [`ensure_file`]'s byte-compare gives the buffered writer.
+        // Anything else (missing, torn or corrupt blob, symlink or
+        // other non-regular dirent) is atomically replaced by the
+        // rename, which is self-healing in every such state.
         let existing_is_live = fs::symlink_metadata(&file_path)
-            .is_ok_and(|meta| meta.file_type().is_file() && meta.len() == size);
+            .is_ok_and(|meta| meta.file_type().is_file() && meta.len() == size)
+            && files_have_equal_contents(&tmp_path, &file_path);
         if existing_is_live {
             let _ = fs::remove_file(&tmp_path);
             return Ok((file_path, file_hash, size));
@@ -220,6 +224,32 @@ impl StoreDir {
 /// per-file allocation worth worrying about — the streaming path only
 /// runs for large entries.
 const COPY_BUFFER_SIZE: usize = 128 * 1024;
+
+/// Stream-compare two files' contents without loading either into
+/// memory. Any open or read failure counts as "not equal" — every
+/// caller's recovery for inequality (an atomic rename over the target)
+/// is safe in each such state, so distinguishing them buys nothing.
+fn files_have_equal_contents(left: &Path, right: &Path) -> bool {
+    use std::io::BufRead;
+
+    let Ok(file_a) = fs::File::open(left) else { return false };
+    let Ok(file_b) = fs::File::open(right) else { return false };
+    let mut reader_a = io::BufReader::with_capacity(COPY_BUFFER_SIZE, file_a);
+    let mut reader_b = io::BufReader::with_capacity(COPY_BUFFER_SIZE, file_b);
+    loop {
+        let Ok(chunk_a) = reader_a.fill_buf() else { return false };
+        let Ok(chunk_b) = reader_b.fill_buf() else { return false };
+        if chunk_a.is_empty() || chunk_b.is_empty() {
+            return chunk_a.is_empty() && chunk_b.is_empty();
+        }
+        let len = chunk_a.len().min(chunk_b.len());
+        if chunk_a[..len] != chunk_b[..len] {
+            return false;
+        }
+        reader_a.consume(len);
+        reader_b.consume(len);
+    }
+}
 
 #[cfg(test)]
 mod tests;

--- a/pnpm/crates/store-dir/src/cas_file.rs
+++ b/pnpm/crates/store-dir/src/cas_file.rs
@@ -2,11 +2,16 @@ use crate::{FileHash, StoreDir};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pnpm_fs::{
-    EnsureFileError, ensure_file, ensure_parent_dir,
+    EnsureFileError, cas_write_lock, create_exclusive_temp_file, ensure_file, ensure_parent_dir,
     file_mode::{EXEC_MODE, is_executable},
+    rename_with_retry,
 };
 use sha2::{Digest, Sha512};
-use std::path::PathBuf;
+use std::{
+    fs,
+    io::{self, Read, Write},
+    path::{Path, PathBuf},
+};
 
 impl StoreDir {
     /// Path to a file in the store directory.
@@ -63,6 +68,18 @@ pub enum WriteCasFileError {
     WriteFile(EnsureFileError),
 }
 
+/// Error type of [`StoreDir::write_cas_file_from_reader`]. Splits the
+/// reader side from the store side so the caller can attribute a
+/// mid-stream failure to its actual origin — a tar/gzip decode error is
+/// not a store-write error.
+#[derive(Debug, Display, Error, Diagnostic)]
+pub enum WriteCasFileFromReaderError {
+    /// The source reader failed while its bytes were being streamed in.
+    Read(io::Error),
+    /// The content-addressed store rejected the write.
+    Write(WriteCasFileError),
+}
+
 impl StoreDir {
     /// Write a file from an npm package to the store directory.
     pub fn write_cas_file(
@@ -74,25 +91,135 @@ impl StoreDir {
         let file_path = self.cas_file_path(file_hash, executable);
         let mode = executable.then_some(EXEC_MODE);
 
-        // Ensure the shard directory (`files/XX/`) exists. The CAS has
-        // 256 shards keyed by `file_hash[0]`; `create_dir_all` does a
-        // `stat` syscall every call even when the directory is already
-        // there, so remember which shards we've created and skip on
-        // repeat. Duplicate mkdirs across threads are benign — the first
-        // few writes into a fresh shard may each call `create_dir_all`,
-        // which is idempotent; once any of them completes and inserts
-        // into the cache, subsequent writes take the fast path.
-        let shard_byte = file_hash[0];
+        self.ensure_shard_dir(&file_path, file_hash[0])?;
+
+        ensure_file(&file_path, buffer, mode).map_err(WriteCasFileError::WriteFile)?;
+        Ok((file_path, file_hash))
+    }
+
+    /// Stream a file from an npm package into the store directory
+    /// without buffering it in memory.
+    ///
+    /// The content hash — and therefore the CAS path — is only known
+    /// once the reader is exhausted, so the bytes stream into an
+    /// exclusively-created temp file in the `files/` directory (same
+    /// filesystem as the shards, so the final rename never crosses a
+    /// mount) while the SHA-512 is computed incrementally, and the temp
+    /// file is renamed to its content-addressed path at the end. Peak
+    /// memory is one fixed copy buffer regardless of file size.
+    ///
+    /// Returns the CAS path, the content hash, and the streamed byte
+    /// count. A reader that yields the same bytes as a `buffer` handed
+    /// to [`StoreDir::write_cas_file`] lands at the same path with the
+    /// same guarantees: an existing regular file of the expected size
+    /// at the target is kept as the live entry (CAS paths are
+    /// hash-derived, so a size-matching file is the same content), and
+    /// anything else is atomically replaced.
+    pub fn write_cas_file_from_reader(
+        &self,
+        reader: &mut dyn Read,
+        executable: bool,
+    ) -> Result<(PathBuf, FileHash, u64), WriteCasFileFromReaderError> {
+        let write_error =
+            |error| WriteCasFileFromReaderError::Write(WriteCasFileError::WriteFile(error));
+        let io_write_error = |file_path: &PathBuf, error| {
+            write_error(EnsureFileError::WriteFile { file_path: file_path.clone(), error })
+        };
+
+        let files_dir = self.files_dir();
+        ensure_parent_dir(files_dir).map_err(write_error)?;
+        let mode = executable.then_some(EXEC_MODE);
+        let (tmp_path, file) =
+            create_exclusive_temp_file(files_dir, "stream", mode).map_err(write_error)?;
+
+        // Bytes arrive in decompressor-sized chunks (tens of KB);
+        // BufWriter coalesces them so the kernel sees fewer, larger
+        // writes.
+        let mut writer = io::BufWriter::with_capacity(COPY_BUFFER_SIZE, file);
+        let mut hasher = Sha512::new();
+        let mut copy_buffer = vec![0u8; COPY_BUFFER_SIZE];
+        let mut size: u64 = 0;
+        let result = loop {
+            match reader.read(&mut copy_buffer) {
+                Ok(0) => break Ok(()),
+                Ok(read) => {
+                    hasher.update(&copy_buffer[..read]);
+                    if let Err(error) = writer.write_all(&copy_buffer[..read]) {
+                        break Err(io_write_error(&tmp_path, error));
+                    }
+                    size += read as u64;
+                }
+                Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+                Err(error) => break Err(WriteCasFileFromReaderError::Read(error)),
+            }
+        };
+        let result = result.and_then(|()| {
+            writer
+                .into_inner()
+                .map_err(|error| io_write_error(&tmp_path, error.into_error()))
+                .map(drop)
+        });
+        if let Err(error) = result {
+            let _ = fs::remove_file(&tmp_path);
+            return Err(error);
+        }
+
+        let file_hash = hasher.finalize();
+        let file_path = self.cas_file_path(file_hash, executable);
+        self.ensure_shard_dir(&file_path, file_hash[0])
+            .map_err(WriteCasFileFromReaderError::Write)?;
+
+        // Serialize with buffer-based writers ([`ensure_file`]) and
+        // verifiers of the same path, per [`cas_write_lock`]'s
+        // coordination contract.
+        let lock = cas_write_lock(&file_path);
+        let _guard = lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        // A regular file of the expected size at a hash-derived path is
+        // the same content — keep it as the live entry rather than
+        // replacing its inode. Anything else (missing, torn short blob,
+        // symlink or other non-regular dirent) is atomically replaced
+        // by the rename.
+        let existing_is_live = fs::symlink_metadata(&file_path)
+            .is_ok_and(|meta| meta.file_type().is_file() && meta.len() == size);
+        if existing_is_live {
+            let _ = fs::remove_file(&tmp_path);
+            return Ok((file_path, file_hash, size));
+        }
+        if let Err(error) = rename_with_retry(&tmp_path, &file_path) {
+            let _ = fs::remove_file(&tmp_path);
+            return Err(write_error(EnsureFileError::RenameFile {
+                tmp_path,
+                file_path: file_path.clone(),
+                error,
+            }));
+        }
+        Ok((file_path, file_hash, size))
+    }
+
+    /// Ensure the shard directory (`files/XX/`) exists. The CAS has
+    /// 256 shards keyed by `file_hash[0]`; `create_dir_all` does a
+    /// `stat` syscall every call even when the directory is already
+    /// there, so remember which shards we've created and skip on
+    /// repeat. Duplicate mkdirs across threads are benign — the first
+    /// few writes into a fresh shard may each call `create_dir_all`,
+    /// which is idempotent; once any of them completes and inserts
+    /// into the cache, subsequent writes take the fast path.
+    fn ensure_shard_dir(&self, file_path: &Path, shard_byte: u8) -> Result<(), WriteCasFileError> {
         if !self.shard_already_ensured(shard_byte) {
             let parent = file_path.parent().expect("CAS file path always has a parent shard dir");
             ensure_parent_dir(parent).map_err(WriteCasFileError::WriteFile)?;
             self.mark_shard_ensured(shard_byte);
         }
-
-        ensure_file(&file_path, buffer, mode).map_err(WriteCasFileError::WriteFile)?;
-        Ok((file_path, file_hash))
+        Ok(())
     }
 }
+
+/// Chunk size for [`StoreDir::write_cas_file_from_reader`]'s read loop
+/// and its `BufWriter`. 128 KB keeps syscall count low without a
+/// per-file allocation worth worrying about — the streaming path only
+/// runs for large entries.
+const COPY_BUFFER_SIZE: usize = 128 * 1024;
 
 #[cfg(test)]
 mod tests;

--- a/pnpm/crates/store-dir/src/cas_file.rs
+++ b/pnpm/crates/store-dir/src/cas_file.rs
@@ -114,10 +114,17 @@ impl StoreDir {
     /// same guarantees: an existing regular file at the target is kept
     /// as the live entry only after a byte-compare against the streamed
     /// content, and anything else is atomically replaced.
+    ///
+    /// When `expected_size` is given, a reader that yields any other
+    /// number of bytes fails with the `Read` variant *before* anything
+    /// reaches a content-addressed path — a truncated source (e.g. a
+    /// cut-short archive) must not commit its partial content to the
+    /// store, even though such a blob would be correctly addressed.
     pub fn write_cas_file_from_reader(
         &self,
         reader: &mut dyn Read,
         executable: bool,
+        expected_size: Option<u64>,
     ) -> Result<(PathBuf, FileHash, u64), WriteCasFileFromReaderError> {
         let write_error =
             |error| WriteCasFileFromReaderError::Write(WriteCasFileError::WriteFile(error));
@@ -161,6 +168,15 @@ impl StoreDir {
         if let Err(error) = result {
             let _ = fs::remove_file(&tmp_path);
             return Err(error);
+        }
+        if let Some(expected) = expected_size
+            && size != expected
+        {
+            let _ = fs::remove_file(&tmp_path);
+            return Err(WriteCasFileFromReaderError::Read(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                format!("reader yielded {size} bytes where {expected} were expected"),
+            )));
         }
 
         let file_hash = hasher.finalize();

--- a/pnpm/crates/store-dir/src/cas_file/tests.rs
+++ b/pnpm/crates/store-dir/src/cas_file/tests.rs
@@ -1,6 +1,6 @@
-use crate::StoreDir;
+use crate::{StoreDir, WriteCasFileFromReaderError};
 use sha2::{Digest, Sha512};
-use std::path::PathBuf;
+use std::{io, path::PathBuf};
 
 #[test]
 fn cas_file_path() {
@@ -106,6 +106,112 @@ fn shard_cache_populates_on_first_write_and_skips_mkdir_thereafter() {
     // must succeed and materialize the file on disk.
     let (path_c, _) = store_dir.write_cas_file(b"goodbye world", false).unwrap();
     assert!(path_c.is_file());
+}
+
+/// The streaming writer must land the same bytes at the same
+/// hash-derived path as the buffer-based writer — the two are used
+/// interchangeably by tarball extraction, so any divergence in path,
+/// hash, or on-disk content splits the CAS.
+#[test]
+fn write_cas_file_from_reader_matches_write_cas_file() {
+    use tempfile::tempdir;
+
+    // Larger than the internal copy buffer so the read loop runs more
+    // than one iteration.
+    let content: Vec<u8> = (0u32..200_000).flat_map(u32::to_le_bytes).collect();
+
+    for executable in [false, true] {
+        eprintln!("CASE: executable = {executable:?}");
+        let buffered_dir = tempdir().unwrap();
+        let buffered_store = StoreDir::new(buffered_dir.path());
+        let (buffered_path, buffered_hash) =
+            buffered_store.write_cas_file(&content, executable).unwrap();
+
+        let streamed_dir = tempdir().unwrap();
+        let streamed_store = StoreDir::new(streamed_dir.path());
+        let (streamed_path, streamed_hash, streamed_size) =
+            streamed_store.write_cas_file_from_reader(&mut content.as_slice(), executable).unwrap();
+
+        assert_eq!(streamed_hash, buffered_hash);
+        assert_eq!(streamed_size, content.len() as u64);
+        assert_eq!(
+            streamed_path.strip_prefix(streamed_store.root()).unwrap(),
+            buffered_path.strip_prefix(buffered_store.root()).unwrap(),
+        );
+        assert_eq!(std::fs::read(&streamed_path).unwrap(), content);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&streamed_path).unwrap().permissions().mode();
+            assert_eq!(
+                pnpm_fs::file_mode::is_executable(mode),
+                executable,
+                "streamed CAS file mode {mode:o} must match executable = {executable}",
+            );
+        }
+    }
+}
+
+/// A live entry already at the target path is kept (same inode), and
+/// the temp file the stream wrote is cleaned out of `files/` — leaking
+/// it would accumulate one orphan per warm large-entry extraction.
+#[test]
+fn write_cas_file_from_reader_keeps_existing_live_entry_and_removes_temp() {
+    use tempfile::tempdir;
+
+    let dir = tempdir().unwrap();
+    let store_dir = StoreDir::new(dir.path());
+    let content = b"streamed twice";
+
+    let (first_path, _, _) =
+        store_dir.write_cas_file_from_reader(&mut content.as_slice(), false).unwrap();
+    let (second_path, _, second_size) =
+        store_dir.write_cas_file_from_reader(&mut content.as_slice(), false).unwrap();
+
+    assert_eq!(first_path, second_path);
+    assert_eq!(second_size, content.len() as u64);
+    assert_eq!(std::fs::read(&second_path).unwrap(), content);
+
+    // Only the 2-hex-char shard directories may remain in `files/`.
+    let stray: Vec<_> = std::fs::read_dir(store_dir.files_dir())
+        .unwrap()
+        .map(|dirent| dirent.unwrap())
+        .filter(|dirent| !dirent.file_type().unwrap().is_dir())
+        .map(|dirent| dirent.file_name())
+        .collect();
+    assert_eq!(stray, Vec::<std::ffi::OsString>::new(), "no temp files may leak into files/");
+}
+
+/// A reader failure mid-stream surfaces as the `Read` variant (so the
+/// tarball layer can attribute it to the archive, not the store) and
+/// leaves no temp file behind.
+#[test]
+fn write_cas_file_from_reader_cleans_up_temp_on_reader_error() {
+    use tempfile::tempdir;
+
+    struct FailingReader;
+    impl io::Read for FailingReader {
+        fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
+            Err(io::Error::other("simulated decode failure"))
+        }
+    }
+
+    let dir = tempdir().unwrap();
+    let store_dir = StoreDir::new(dir.path());
+
+    let err = store_dir
+        .write_cas_file_from_reader(&mut FailingReader, false)
+        .expect_err("reader failure must propagate");
+    assert!(
+        matches!(err, WriteCasFileFromReaderError::Read(_)),
+        "expected the Read variant, got: {err:?}",
+    );
+
+    let leftovers: Vec<_> = std::fs::read_dir(store_dir.files_dir())
+        .unwrap()
+        .map(|dirent| dirent.unwrap().file_name())
+        .collect();
+    assert_eq!(leftovers, Vec::<std::ffi::OsString>::new(), "failed stream must remove its temp");
 }
 
 #[test]

--- a/pnpm/crates/store-dir/src/cas_file/tests.rs
+++ b/pnpm/crates/store-dir/src/cas_file/tests.rs
@@ -129,8 +129,13 @@ fn write_cas_file_from_reader_matches_write_cas_file() {
 
         let streamed_dir = tempdir().unwrap();
         let streamed_store = StoreDir::new(streamed_dir.path());
-        let (streamed_path, streamed_hash, streamed_size) =
-            streamed_store.write_cas_file_from_reader(&mut content.as_slice(), executable).unwrap();
+        let (streamed_path, streamed_hash, streamed_size) = streamed_store
+            .write_cas_file_from_reader(
+                &mut content.as_slice(),
+                executable,
+                Some(content.len() as u64),
+            )
+            .unwrap();
 
         assert_eq!(streamed_hash, buffered_hash);
         assert_eq!(streamed_size, content.len() as u64);
@@ -163,10 +168,12 @@ fn write_cas_file_from_reader_keeps_existing_live_entry_and_removes_temp() {
     let store_dir = StoreDir::new(dir.path());
     let content = b"streamed twice";
 
-    let (first_path, _, _) =
-        store_dir.write_cas_file_from_reader(&mut content.as_slice(), false).unwrap();
-    let (second_path, _, second_size) =
-        store_dir.write_cas_file_from_reader(&mut content.as_slice(), false).unwrap();
+    let (first_path, _, _) = store_dir
+        .write_cas_file_from_reader(&mut content.as_slice(), false, Some(content.len() as u64))
+        .unwrap();
+    let (second_path, _, second_size) = store_dir
+        .write_cas_file_from_reader(&mut content.as_slice(), false, Some(content.len() as u64))
+        .unwrap();
 
     assert_eq!(first_path, second_path);
     assert_eq!(second_size, content.len() as u64);
@@ -194,12 +201,14 @@ fn write_cas_file_from_reader_replaces_same_length_corrupt_entry() {
     let store_dir = StoreDir::new(dir.path());
     let content = b"authentic cas payload";
 
-    let (file_path, _, _) =
-        store_dir.write_cas_file_from_reader(&mut content.as_slice(), false).unwrap();
+    let (file_path, _, _) = store_dir
+        .write_cas_file_from_reader(&mut content.as_slice(), false, Some(content.len() as u64))
+        .unwrap();
     std::fs::write(&file_path, vec![b'X'; content.len()]).unwrap();
 
-    let (second_path, _, _) =
-        store_dir.write_cas_file_from_reader(&mut content.as_slice(), false).unwrap();
+    let (second_path, _, _) = store_dir
+        .write_cas_file_from_reader(&mut content.as_slice(), false, Some(content.len() as u64))
+        .unwrap();
 
     assert_eq!(second_path, file_path);
     assert_eq!(std::fs::read(&file_path).unwrap(), content, "corrupt blob must be healed");
@@ -223,7 +232,7 @@ fn write_cas_file_from_reader_removes_temp_when_shard_creation_fails() {
     std::fs::write(&blocker, b"not a directory").unwrap();
 
     let err = store_dir
-        .write_cas_file_from_reader(&mut content.as_slice(), false)
+        .write_cas_file_from_reader(&mut content.as_slice(), false, Some(content.len() as u64))
         .expect_err("shard creation failure must propagate");
     assert!(
         matches!(err, WriteCasFileFromReaderError::Write(_)),
@@ -238,6 +247,37 @@ fn write_cas_file_from_reader_removes_temp_when_shard_creation_fails() {
         leftovers,
         vec![std::ffi::OsString::from(&shard)],
         "only the blocking file may remain — the stream temp must be removed",
+    );
+}
+
+/// A reader that ends short of `expected_size` (a truncated archive)
+/// must fail without committing anything to a content-addressed path —
+/// the partial blob would be correctly addressed but must not enter
+/// the store — and without leaking its temp file.
+#[test]
+fn write_cas_file_from_reader_rejects_short_reader_without_committing() {
+    use tempfile::tempdir;
+
+    let dir = tempdir().unwrap();
+    let store_dir = StoreDir::new(dir.path());
+    let content = b"cut short";
+
+    let err = store_dir
+        .write_cas_file_from_reader(&mut content.as_slice(), false, Some(content.len() as u64 + 7))
+        .expect_err("a short reader must not commit to the store");
+    assert!(
+        matches!(err, WriteCasFileFromReaderError::Read(_)),
+        "expected the Read variant, got: {err:?}",
+    );
+
+    let leftovers: Vec<_> = std::fs::read_dir(store_dir.files_dir())
+        .unwrap()
+        .map(|dirent| dirent.unwrap().file_name())
+        .collect();
+    assert_eq!(
+        leftovers,
+        Vec::<std::ffi::OsString>::new(),
+        "neither a CAS blob nor a temp file may remain after a short stream",
     );
 }
 
@@ -259,7 +299,7 @@ fn write_cas_file_from_reader_cleans_up_temp_on_reader_error() {
     let store_dir = StoreDir::new(dir.path());
 
     let err = store_dir
-        .write_cas_file_from_reader(&mut FailingReader, false)
+        .write_cas_file_from_reader(&mut FailingReader, false, None)
         .expect_err("reader failure must propagate");
     assert!(
         matches!(err, WriteCasFileFromReaderError::Read(_)),

--- a/pnpm/crates/store-dir/src/cas_file/tests.rs
+++ b/pnpm/crates/store-dir/src/cas_file/tests.rs
@@ -182,6 +182,65 @@ fn write_cas_file_from_reader_keeps_existing_live_entry_and_removes_temp() {
     assert_eq!(stray, Vec::<std::ffi::OsString>::new(), "no temp files may leak into files/");
 }
 
+/// A same-length blob at the target whose bytes differ (disk
+/// corruption, or a tampered store) must not be kept: the streamed
+/// writer byte-compares before trusting an existing entry, matching
+/// `ensure_file`'s guarantee for the buffered writer.
+#[test]
+fn write_cas_file_from_reader_replaces_same_length_corrupt_entry() {
+    use tempfile::tempdir;
+
+    let dir = tempdir().unwrap();
+    let store_dir = StoreDir::new(dir.path());
+    let content = b"authentic cas payload";
+
+    let (file_path, _, _) =
+        store_dir.write_cas_file_from_reader(&mut content.as_slice(), false).unwrap();
+    std::fs::write(&file_path, vec![b'X'; content.len()]).unwrap();
+
+    let (second_path, _, _) =
+        store_dir.write_cas_file_from_reader(&mut content.as_slice(), false).unwrap();
+
+    assert_eq!(second_path, file_path);
+    assert_eq!(std::fs::read(&file_path).unwrap(), content, "corrupt blob must be healed");
+}
+
+/// A shard-directory failure after the bytes have already streamed
+/// must not leak the temp file into `files/`.
+#[test]
+fn write_cas_file_from_reader_removes_temp_when_shard_creation_fails() {
+    use tempfile::tempdir;
+
+    let dir = tempdir().unwrap();
+    let store_dir = StoreDir::new(dir.path());
+    let content = b"shard blocked";
+
+    // Occupy the shard path with a regular file so `create_dir_all`
+    // for `files/XX/` fails after the stream completes.
+    let shard = format!("{:02x}", Sha512::digest(content)[0]);
+    std::fs::create_dir_all(store_dir.files_dir()).unwrap();
+    let blocker = store_dir.files_dir().join(&shard);
+    std::fs::write(&blocker, b"not a directory").unwrap();
+
+    let err = store_dir
+        .write_cas_file_from_reader(&mut content.as_slice(), false)
+        .expect_err("shard creation failure must propagate");
+    assert!(
+        matches!(err, WriteCasFileFromReaderError::Write(_)),
+        "expected the Write variant, got: {err:?}",
+    );
+
+    let leftovers: Vec<_> = std::fs::read_dir(store_dir.files_dir())
+        .unwrap()
+        .map(|dirent| dirent.unwrap().file_name())
+        .collect();
+    assert_eq!(
+        leftovers,
+        vec![std::ffi::OsString::from(&shard)],
+        "only the blocking file may remain — the stream temp must be removed",
+    );
+}
+
 /// A reader failure mid-stream surfaces as the `Read` variant (so the
 /// tarball layer can attribute it to the archive, not the store) and
 /// leaves no temp file behind.

--- a/pnpm/crates/store-dir/src/store_dir.rs
+++ b/pnpm/crates/store-dir/src/store_dir.rs
@@ -132,7 +132,7 @@ impl StoreDir {
     /// path calls this per CAFS file written, so caching the joined
     /// path saves one `PathBuf` allocation per call (~170k on the
     /// alotta-files clean install).
-    fn files_dir(&self) -> &PathBuf {
+    pub(crate) fn files_dir(&self) -> &PathBuf {
         self.cached_files_dir.get_or_init(|| self.root.join("files"))
     }
 

--- a/pnpm/crates/tarball/Cargo.toml
+++ b/pnpm/crates/tarball/Cargo.toml
@@ -20,6 +20,7 @@ pnpm-store-dir        = { workspace = true }
 
 dashmap      = { workspace = true }
 derive_more  = { workspace = true }
+flate2       = { workspace = true }
 futures-util = { workspace = true }
 miette       = { workspace = true }
 num_cpus     = { workspace = true }
@@ -38,7 +39,6 @@ zune-inflate = { workspace = true }
 
 [dev-dependencies]
 dashmap           = { workspace = true, features = ["raw-api"] }
-flate2            = { workspace = true }
 mockito           = { workspace = true }
 pretty_assertions = { workspace = true }
 tempfile          = { workspace = true }

--- a/pnpm/crates/tarball/src/download.rs
+++ b/pnpm/crates/tarball/src/download.rs
@@ -7,7 +7,8 @@ use super::{
     Arc, Duration, HashMap, HttpStatusError, IgnoreEntryFilter, Instant, NetworkError, PathBuf,
     PrefetchedCasPaths, SharedReportedProgressKeys, TarballError, VerifyChecksumError,
     allocate_tarball_buffer, decompress_gzip, extract_tarball_entries, local_file_tarball_path,
-    open_local_tarball, post_download_semaphore, read_local_tarball_buffer,
+    open_local_tarball, post_download_semaphore, read_local_tarball_buffer, should_stream_extract,
+    stream_extract_gzipped_tarball,
 };
 use pnpm_network::{AuthHeaders, MAX_THROUGHPUT_PRIORITY, RetryOpts, ThrottledClient};
 use pnpm_reporter::{
@@ -290,9 +291,23 @@ pub(crate) async fn extract_tarball_buffer(
                 expected_integrity,
                 package_url_owned,
             )?;
-            let tar_data = decompress_gzip(&buffer, package_unpacked_size)?;
+            // A large archive is extracted by streaming the gzip
+            // decode straight into the tar walk, so the only
+            // whole-archive allocation alive during extraction is the
+            // compressed body — the eager path would hold the
+            // decompressed archive (typically several times larger)
+            // next to it.
             let (cas_paths, pkg_files_idx) =
-                extract_tarball_entries(&tar_data, store_dir, ignore_file_pattern.as_deref())?;
+                if should_stream_extract(buffer.len(), package_unpacked_size) {
+                    stream_extract_gzipped_tarball(
+                        &buffer,
+                        store_dir,
+                        ignore_file_pattern.as_deref(),
+                    )?
+                } else {
+                    let tar_data = decompress_gzip(&buffer, package_unpacked_size)?;
+                    extract_tarball_entries(&tar_data, store_dir, ignore_file_pattern.as_deref())?
+                };
             Ok((integrity, cas_paths, pkg_files_idx))
         },
     )

--- a/pnpm/crates/tarball/src/extract.rs
+++ b/pnpm/crates/tarball/src/extract.rs
@@ -1,14 +1,16 @@
 //! Tarball decompression and entry extraction into the CAS.
 
 use super::{
-    Cursor, HashMap, IgnoreEntryFilter, IntoParallelRefIterator, MAX_UNTRUSTED_PREALLOC_BYTES,
-    ParallelIterator, PathBuf, TarballError, UNIX_EPOCH, cas_write_pool,
+    Cow, Cursor, HashMap, IgnoreEntryFilter, IntoParallelRefIterator, MAX_UNTRUSTED_PREALLOC_BYTES,
+    ParallelIterator, PathBuf, Read, TarballError, UNIX_EPOCH, cas_write_pool,
 };
 use pnpm_fs::file_mode;
 use pnpm_package_manifest::{
     files_include_install_scripts, manifest_requires_build, parse_manifest_bytes,
 };
-use pnpm_store_dir::{CafsFileInfo, PackageFilesIndex, StoreDir};
+use pnpm_store_dir::{
+    CafsFileInfo, FileHash, PackageFilesIndex, StoreDir, WriteCasFileFromReaderError,
+};
 use tar::Archive;
 use tracing::instrument;
 use zune_inflate::{DeflateDecoder, DeflateOptions};
@@ -59,6 +61,30 @@ pub(crate) fn decompress_gzip(
     DeflateDecoder::new_with_options(gz_data, options)
         .decode_gzip()
         .map_err(TarballError::DecodeGzip)
+}
+
+/// Compressed-size pivot for [`should_stream_extract`]. The compressed
+/// length is the one exact size we hold in hand; npm tarballs
+/// typically inflate ~3-5×, so 16 MiB compressed puts the eager path's
+/// whole-archive buffer well past [`MAX_UNTRUSTED_PREALLOC_BYTES`].
+pub(crate) const STREAM_EXTRACT_COMPRESSED_THRESHOLD: usize = 16 * 1024 * 1024;
+
+/// Whether a downloaded tarball should be extracted through the
+/// streaming path ([`stream_extract_gzipped_tarball`]) instead of the
+/// eager whole-archive decompression
+/// ([`decompress_gzip`] + [`extract_tarball_entries`]).
+///
+/// The eager path materializes the entire decompressed archive as one
+/// contiguous buffer, which for a large package multiplies across every
+/// concurrently extracting task. Stream once either signal says the
+/// archive is large: the exact compressed length, or the registry's
+/// `dist.unpackedSize` hint. The hint is attacker-controlled, but here
+/// it only picks between two correct extraction paths — a lying value
+/// costs at most the wrong path's performance profile, never
+/// correctness or unbounded memory.
+pub(crate) fn should_stream_extract(compressed_len: usize, unpacked_size: Option<usize>) -> bool {
+    compressed_len >= STREAM_EXTRACT_COMPRESSED_THRESHOLD
+        || unpacked_size.is_some_and(|size| size >= MAX_UNTRUSTED_PREALLOC_BYTES)
 }
 
 /// Pick the `package.json` fields downstream code actually reads — bin
@@ -144,13 +170,14 @@ pub(crate) fn normalize_bundled_manifest(value: &serde_json::Value) -> Option<se
 }
 
 /// One regular-file tar entry whose path has been validated and
-/// cleaned, paired with a borrow of its payload inside the decompressed
-/// archive buffer. Collected serially while walking the tar stream, then
-/// hashed and written to the CAFS — serially or across the rayon pool —
-/// in [`write_cas_entry`].
+/// cleaned, paired with its payload — a borrow into the decompressed
+/// archive buffer on the eager path, an owned copy on the streaming
+/// path. Collected serially while walking the tar stream, then hashed
+/// and written to the CAFS — serially or across the rayon pool — in
+/// [`write_cas_entry`].
 pub(crate) struct PendingFile<'a> {
     cleaned_path: String,
-    data: &'a [u8],
+    data: Cow<'a, [u8]>,
     executable: bool,
     mode: u32,
     size: u64,
@@ -164,21 +191,21 @@ pub(crate) fn write_cas_entry(
     store_dir: &StoreDir,
     file: &PendingFile<'_>,
 ) -> Result<(String, PathBuf, CafsFileInfo), TarballError> {
-    let (file_path, file_hash) =
-        store_dir.write_cas_file(file.data, file.executable).map_err(TarballError::WriteCasFile)?;
+    let (file_path, file_hash) = store_dir
+        .write_cas_file(&file.data, file.executable)
+        .map_err(TarballError::WriteCasFile)?;
+    Ok((file.cleaned_path.clone(), file_path, cafs_file_info(&file_hash, file.mode, file.size)))
+}
+
+/// Build the [`CafsFileInfo`] index row for a freshly written CAS file.
+pub(crate) fn cafs_file_info(file_hash: &FileHash, mode: u32, size: u64) -> CafsFileInfo {
     // `as_millis()` returns `u128`; narrow to `u64` to match the store
     // index schema (see `CafsFileInfo::checked_at`). Drop the timestamp
     // if the clock reports something unrepresentable — `checkedAt` is
     // optional and pnpm tolerates `None`.
     let checked_at =
         UNIX_EPOCH.elapsed().ok().and_then(|elapsed| u64::try_from(elapsed.as_millis()).ok());
-    let info = CafsFileInfo {
-        digest: format!("{file_hash:x}"),
-        mode: file.mode,
-        size: file.size,
-        checked_at,
-    };
-    Ok((file.cleaned_path.clone(), file_path, info))
+    CafsFileInfo { digest: format!("{file_hash:x}"), mode, size, checked_at }
 }
 
 /// Fold a synthesized `package.json` (pnpm's `appendManifest`) into a
@@ -327,33 +354,7 @@ pub(crate) fn extract_tarball_entries(
         let entry_data = tar_entry_payload(tar_data, &entry)?;
 
         let entry_path = entry.path().map_err(TarballError::ReadTarballEntries)?;
-        // Rejected rather than normalized so a tampered tarball is
-        // visible instead of silently landing outside the store.
-        //
-        // Joined by hand rather than with `PathBuf`, whose native
-        // separator would desynchronize these keys from pnpm's
-        // always-forward-slashed path layer and the `index.db` both
-        // implementations share. `to_string_lossy` coerces non-UTF-8
-        // bytes to U+FFFD per component.
-        let Some(mut parts) = archive_entry_segments(&entry_path.to_string_lossy()) else {
-            return Err(TarballError::ReadTarballEntries(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!(
-                    "tar entry path rejected (non-normal component, possible directory traversal): {entry_path:?}",
-                ),
-            )));
-        };
-        // Drop the top-level package directory (`package/`).
-        parts.remove(0);
-        if parts.is_empty() {
-            return Err(TarballError::ReadTarballEntries(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!(
-                    "tar entry path has no payload after dropping the top-level component: {entry_path:?}",
-                ),
-            )));
-        }
-        let cleaned_entry_path = parts.join("/");
+        let cleaned_entry_path = clean_archive_entry_path(&entry_path.to_string_lossy())?;
         // Drop ignored entries before the CAS write. Paths are matched
         // *after* the top-level prefix strip, so the callback sees the
         // cleaned relative path. Bypassing the CAS write here also
@@ -367,77 +368,61 @@ pub(crate) fn extract_tarball_entries(
         if files_include_install_scripts([cleaned_entry_path.as_str()]) {
             file_build_hooks = true;
         }
-        // Capture the parsed manifest whenever we see `package.json`.
-        // The narrowed manifest is stashed in `pkgFilesIndex.manifest`
-        // so install-side consumers (notably bin linking) can avoid
-        // re-reading the file from disk — the same place pnpm keeps it,
-        // so the shared `index.db` row carries it for both tools. The
-        // [`normalize_bundled_manifest`] pick drops fields downstream
-        // code doesn't use, keeping `index.db` rows tight.
-        //
-        // **Last-entry wins.** A duplicate `package.json` entry
-        // overwrites any earlier one, so the final entry is canonical
-        // — same shape as the `files` map, which already overwrites
-        // duplicates. Real npm tarballs never publish multiple
-        // `package.json` entries, but the consistency with the `files`
-        // map is what matters: `manifest` and `files` must describe the
-        // same file. Failed JSON parses degrade the field to `None` (the
-        // manifest is best-effort; a corrupt `package.json` is the
-        // publisher's fault and downstream code can fall back to
-        // disk reads).
         if cleaned_entry_path == "package.json" {
-            match parse_manifest_bytes(entry_data) {
-                Ok(parsed) => {
-                    manifest_build_scripts = manifest_requires_build(&parsed);
-                    manifest = normalize_bundled_manifest(&parsed);
-                }
-                Err(error) => {
-                    tracing::debug!(
-                        ?error,
-                        "package.json in tarball failed to parse as JSON; bundled manifest cleared",
-                    );
-                    manifest_build_scripts = false;
-                    manifest = None;
-                }
-            }
+            (manifest_build_scripts, manifest) = capture_bundled_manifest(entry_data);
         }
 
         pending.push(PendingFile {
             cleaned_path: cleaned_entry_path,
-            data: entry_data,
+            data: Cow::Borrowed(entry_data),
             executable: file_is_executable,
             mode: file_mode,
             size: file_size,
         });
     }
 
-    // Phase 2: hash and write every file into the content-addressed
-    // store. Extracting a package with thousands of files (e.g.
-    // `core-js`) on a single blocking thread pins one core while the
-    // rest sit idle — most costly at the makespan tail, when it's the
-    // last extraction still running. `write_cas_entry` is safe to run
-    // concurrently, so large tarballs fan out across the dedicated
-    // [`cas_write_pool`]; small ones stay serial to skip rayon's per-job
-    // dispatch cost when there's nothing to gain. The dedicated pool
-    // keeps this off the global pool the linker uses, so an extraction
-    // burst can't stall node_modules linking running concurrently.
-    const PARALLEL_EXTRACT_THRESHOLD: usize = 32;
-    let written: Vec<(String, PathBuf, CafsFileInfo)> =
-        if pending.len() >= PARALLEL_EXTRACT_THRESHOLD {
-            let write_all = || -> Result<Vec<(String, PathBuf, CafsFileInfo)>, TarballError> {
-                pending.par_iter().map(|file| write_cas_entry(store_dir, file)).collect()
-            };
-            match cas_write_pool() {
-                Some(pool) => pool.install(write_all),
-                None => write_all(),
-            }?
-        } else {
-            pending.iter().map(|file| write_cas_entry(store_dir, file)).collect::<Result<_, _>>()?
-        };
+    let written = write_pending_files(store_dir, &pending)?;
+    Ok(assemble_extract_output(written, manifest, manifest_build_scripts || file_build_hooks))
+}
 
-    // Phase 3 (serial): assemble the output maps. `written` preserves
-    // `pending` order, so a tarball with duplicate paths keeps the last
-    // entry — matching pnpm's last-wins `filesIndex.set`.
+/// Hash and write a slice of pending files into the content-addressed
+/// store, preserving input order in the returned rows.
+///
+/// Extracting a package with thousands of files (e.g. `core-js`) on a
+/// single blocking thread pins one core while the rest sit idle — most
+/// costly at the makespan tail, when it's the last extraction still
+/// running. `write_cas_entry` is safe to run concurrently, so large
+/// slices fan out across the dedicated [`cas_write_pool`]; small ones
+/// stay serial to skip rayon's per-job dispatch cost when there's
+/// nothing to gain. The dedicated pool keeps this off the global pool
+/// the linker uses, so an extraction burst can't stall `node_modules`
+/// linking running concurrently.
+fn write_pending_files(
+    store_dir: &StoreDir,
+    pending: &[PendingFile<'_>],
+) -> Result<Vec<(String, PathBuf, CafsFileInfo)>, TarballError> {
+    const PARALLEL_EXTRACT_THRESHOLD: usize = 32;
+    if pending.len() >= PARALLEL_EXTRACT_THRESHOLD {
+        let write_all = || -> Result<Vec<(String, PathBuf, CafsFileInfo)>, TarballError> {
+            pending.par_iter().map(|file| write_cas_entry(store_dir, file)).collect()
+        };
+        match cas_write_pool() {
+            Some(pool) => pool.install(write_all),
+            None => write_all(),
+        }
+    } else {
+        pending.iter().map(|file| write_cas_entry(store_dir, file)).collect()
+    }
+}
+
+/// Assemble the extraction outputs from written CAS rows. `written`
+/// preserves entry order, so a tarball with duplicate paths keeps the
+/// last entry — matching pnpm's last-wins `filesIndex.set`.
+fn assemble_extract_output(
+    written: Vec<(String, PathBuf, CafsFileInfo)>,
+    manifest: Option<serde_json::Value>,
+    requires_build: bool,
+) -> (HashMap<String, PathBuf>, PackageFilesIndex) {
     let mut cas_paths = HashMap::<String, PathBuf>::with_capacity(written.len());
     let mut files = HashMap::with_capacity(written.len());
     for (path, file_path, info) in written {
@@ -451,12 +436,245 @@ pub(crate) fn extract_tarball_entries(
 
     let pkg_files_idx = PackageFilesIndex {
         manifest,
-        requires_build: Some(manifest_build_scripts || file_build_hooks),
+        requires_build: Some(requires_build),
         algo: "sha512".to_string(),
         files,
         side_effects: None,
     };
-    Ok((cas_paths, pkg_files_idx))
+    (cas_paths, pkg_files_idx)
+}
+
+/// Parse a tarball's bundled `package.json`, returning its
+/// requires-build flag and the narrowed manifest for the store-index
+/// row.
+///
+/// The narrowed manifest is stashed in `pkgFilesIndex.manifest` so
+/// install-side consumers (notably bin linking) can avoid re-reading
+/// the file from disk — the same place pnpm keeps it, so the shared
+/// `index.db` row carries it for both tools. The
+/// [`normalize_bundled_manifest`] pick drops fields downstream code
+/// doesn't use, keeping `index.db` rows tight.
+///
+/// Callers apply this to every `package.json` entry they see, so a
+/// duplicate entry overwrites any earlier one and the final entry is
+/// canonical — same shape as the `files` map, which already overwrites
+/// duplicates. Real npm tarballs never publish multiple `package.json`
+/// entries, but the consistency with the `files` map is what matters:
+/// `manifest` and `files` must describe the same file.
+///
+/// Failed JSON parses degrade to `(false, None)` — the manifest is
+/// best-effort; a corrupt `package.json` is the publisher's fault and
+/// downstream code can fall back to disk reads.
+fn capture_bundled_manifest(entry_data: &[u8]) -> (bool, Option<serde_json::Value>) {
+    match parse_manifest_bytes(entry_data) {
+        Ok(parsed) => (manifest_requires_build(&parsed), normalize_bundled_manifest(&parsed)),
+        Err(error) => {
+            tracing::debug!(
+                ?error,
+                "package.json in tarball failed to parse as JSON; bundled manifest cleared",
+            );
+            (false, None)
+        }
+    }
+}
+
+/// Validate and clean one archive entry path: reject traversal, drop
+/// the top-level package directory (`package/`), and join the remaining
+/// segments with forward slashes.
+///
+/// Rejected rather than normalized so a tampered tarball is visible
+/// instead of silently landing outside the store.
+///
+/// Joined by hand rather than with `PathBuf`, whose native separator
+/// would desynchronize these keys from pnpm's always-forward-slashed
+/// path layer and the `index.db` both implementations share. Callers
+/// pass the `to_string_lossy` rendering, which coerces non-UTF-8 bytes
+/// to U+FFFD per component.
+fn clean_archive_entry_path(raw: &str) -> Result<String, TarballError> {
+    let Some(mut parts) = archive_entry_segments(raw) else {
+        return Err(TarballError::ReadTarballEntries(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "tar entry path rejected (non-normal component, possible directory traversal): {raw:?}",
+            ),
+        )));
+    };
+    parts.remove(0);
+    if parts.is_empty() {
+        return Err(TarballError::ReadTarballEntries(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "tar entry path has no payload after dropping the top-level component: {raw:?}",
+            ),
+        )));
+    }
+    Ok(parts.join("/"))
+}
+
+/// Ceiling for buffering one tar entry in memory on the streaming
+/// extraction path. Entries at or below this go through the batched
+/// [`write_pending_files`] fan-out; larger ones stream straight into
+/// the store via [`StoreDir::write_cas_file_from_reader`] without ever
+/// being held in memory. `package.json` is the exception — the bundled
+/// manifest must be parsed from bytes, so it is buffered up to
+/// [`MAX_UNTRUSTED_PREALLOC_BYTES`] regardless.
+pub(crate) const STREAM_ENTRY_BUFFER_MAX: u64 = 4 * 1024 * 1024;
+
+/// Byte budget for one batch of buffered entries on the streaming
+/// extraction path. A batch flushes to [`write_pending_files`] once it
+/// holds this much payload, so peak memory stays bounded by the budget
+/// (plus one in-flight entry) instead of the archive's unpacked size,
+/// while typical batches are still large enough for the parallel
+/// CAS-write fan-out to pay off.
+const STREAM_BATCH_BUDGET_BYTES: usize = 32 * 1024 * 1024;
+
+/// Decompress and extract a gzipped tarball without materializing the
+/// decompressed archive: [`extract_tarball_entries_streaming`] over a
+/// streaming gzip decoder.
+///
+/// The eager [`decompress_gzip`] + [`extract_tarball_entries`] pair
+/// stays the default for small tarballs, where the whole-archive
+/// buffer is cheap and buys zero-copy payload slices plus one big
+/// parallel write phase; [`should_stream_extract`] decides which path
+/// a download takes.
+pub(crate) fn stream_extract_gzipped_tarball(
+    gz_data: &[u8],
+    store_dir: &StoreDir,
+    ignore_file_pattern: Option<&IgnoreEntryFilter>,
+) -> Result<(HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
+    extract_tarball_entries_streaming(
+        flate2::read::GzDecoder::new(gz_data),
+        store_dir,
+        ignore_file_pattern,
+    )
+}
+
+/// Walk a tar stream, writing each regular-file entry into the CAFS
+/// and returning the same outputs as [`extract_tarball_entries`],
+/// while holding only a bounded window of the archive in memory.
+///
+/// Small entries are buffered and flushed in bounded batches through
+/// the same parallel write phase as the eager path; entries above
+/// [`STREAM_ENTRY_BUFFER_MAX`] stream straight into the store with an
+/// incremental hash. A batch always flushes before a streamed entry is
+/// written, so the output rows keep archive order and the last-wins
+/// duplicate semantics of [`assemble_extract_output`] hold.
+///
+/// Decoder failures (e.g. a corrupt gzip stream) surface through the
+/// reader as [`TarballError::ReadTarballEntries`]; the retry
+/// classifier treats them the same as an eager-path decode error.
+pub(crate) fn extract_tarball_entries_streaming(
+    reader: impl Read,
+    store_dir: &StoreDir,
+    ignore_file_pattern: Option<&IgnoreEntryFilter>,
+) -> Result<(HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
+    let truncated = || {
+        TarballError::ReadTarballEntries(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            "tar entry payload extends beyond archive",
+        ))
+    };
+
+    let mut archive = Archive::new(reader);
+    let mut written: Vec<(String, PathBuf, CafsFileInfo)> = Vec::new();
+    let mut batch: Vec<PendingFile<'static>> = Vec::new();
+    let mut batch_bytes: usize = 0;
+    let mut manifest = None;
+    let mut manifest_build_scripts = false;
+    let mut file_build_hooks = false;
+
+    for entry in archive.entries().map_err(TarballError::ReadTarballEntries)? {
+        let mut entry = entry.map_err(TarballError::ReadTarballEntries)?;
+        if !entry.header().entry_type().is_file() {
+            continue;
+        }
+
+        let file_mode = entry.header().mode().map_err(TarballError::ReadTarballEntries)?;
+        let file_is_executable = file_mode::is_executable(file_mode);
+        let file_size = entry.header().size().map_err(TarballError::ReadTarballEntries)?;
+        let cleaned_entry_path = {
+            let entry_path = entry.path().map_err(TarballError::ReadTarballEntries)?;
+            clean_archive_entry_path(&entry_path.to_string_lossy())?
+        };
+        // Same drop-before-the-CAS-write semantics as the eager loop:
+        // an ignored entry never surfaces in `files` or `manifest`.
+        if let Some(filter) = ignore_file_pattern
+            && filter(&cleaned_entry_path)
+        {
+            continue;
+        }
+        if files_include_install_scripts([cleaned_entry_path.as_str()]) {
+            file_build_hooks = true;
+        }
+
+        // `package.json` must be buffered whatever its header claims —
+        // the bundled manifest is parsed from bytes — but a hostile
+        // size still can't force an unbounded reservation.
+        let buffer_entry = file_size <= STREAM_ENTRY_BUFFER_MAX
+            || (cleaned_entry_path == "package.json"
+                && file_size <= MAX_UNTRUSTED_PREALLOC_BYTES as u64);
+        if buffer_entry {
+            let mut data = Vec::with_capacity(file_size as usize);
+            entry.read_to_end(&mut data).map_err(TarballError::ReadTarballEntries)?;
+            if data.len() as u64 != file_size {
+                return Err(truncated());
+            }
+            if cleaned_entry_path == "package.json" {
+                (manifest_build_scripts, manifest) = capture_bundled_manifest(&data);
+            }
+            batch_bytes += data.len();
+            batch.push(PendingFile {
+                cleaned_path: cleaned_entry_path,
+                data: Cow::Owned(data),
+                executable: file_is_executable,
+                mode: file_mode,
+                size: file_size,
+            });
+            if batch_bytes >= STREAM_BATCH_BUDGET_BYTES {
+                flush_pending_batch(store_dir, &mut batch, &mut batch_bytes, &mut written)?;
+            }
+        } else {
+            flush_pending_batch(store_dir, &mut batch, &mut batch_bytes, &mut written)?;
+            let (file_path, file_hash, streamed_size) = store_dir
+                .write_cas_file_from_reader(&mut entry, file_is_executable)
+                .map_err(|error| match error {
+                    WriteCasFileFromReaderError::Read(error) => {
+                        TarballError::ReadTarballEntries(error)
+                    }
+                    WriteCasFileFromReaderError::Write(error) => TarballError::WriteCasFile(error),
+                })?;
+            // A short stream leaves only a content-addressed orphan
+            // behind — harmless, and the re-fetch retry re-extracts.
+            if streamed_size != file_size {
+                return Err(truncated());
+            }
+            written.push((
+                cleaned_entry_path,
+                file_path,
+                cafs_file_info(&file_hash, file_mode, streamed_size),
+            ));
+        }
+    }
+    flush_pending_batch(store_dir, &mut batch, &mut batch_bytes, &mut written)?;
+
+    Ok(assemble_extract_output(written, manifest, manifest_build_scripts || file_build_hooks))
+}
+
+/// Hash and write the buffered batch into the CAFS, appending its rows
+/// to `written` in order and resetting the batch accumulator.
+fn flush_pending_batch(
+    store_dir: &StoreDir,
+    batch: &mut Vec<PendingFile<'_>>,
+    batch_bytes: &mut usize,
+    written: &mut Vec<(String, PathBuf, CafsFileInfo)>,
+) -> Result<(), TarballError> {
+    if batch.is_empty() {
+        return Ok(());
+    }
+    written.extend(write_pending_files(store_dir, batch)?);
+    batch.clear();
+    *batch_bytes = 0;
+    Ok(())
 }
 
 /// Borrow one tar entry's payload out of the decompressed archive.

--- a/pnpm/crates/tarball/src/extract.rs
+++ b/pnpm/crates/tarball/src/extract.rs
@@ -651,19 +651,18 @@ pub(crate) fn extract_tarball_entries_streaming(
             }
         } else {
             flush_pending_batch(store_dir, &mut batch, &mut batch_bytes, &mut written)?;
+            // `Some(file_size)` makes the store writer reject a short
+            // stream before anything is committed to a
+            // content-addressed path, so a truncated archive leaves no
+            // orphan blob behind.
             let (file_path, file_hash, streamed_size) = store_dir
-                .write_cas_file_from_reader(&mut entry, file_is_executable)
+                .write_cas_file_from_reader(&mut entry, file_is_executable, Some(file_size))
                 .map_err(|error| match error {
                     WriteCasFileFromReaderError::Read(error) => {
                         TarballError::ReadTarballEntries(error)
                     }
                     WriteCasFileFromReaderError::Write(error) => TarballError::WriteCasFile(error),
                 })?;
-            // A short stream leaves only a content-addressed orphan
-            // behind — harmless, and the re-fetch retry re-extracts.
-            if streamed_size != file_size {
-                return Err(truncated());
-            }
             written.push((
                 cleaned_entry_path,
                 file_path,

--- a/pnpm/crates/tarball/src/extract.rs
+++ b/pnpm/crates/tarball/src/extract.rs
@@ -516,8 +516,9 @@ fn clean_archive_entry_path(raw: &str) -> Result<String, TarballError> {
 /// [`write_pending_files`] fan-out; larger ones stream straight into
 /// the store via [`StoreDir::write_cas_file_from_reader`] without ever
 /// being held in memory. `package.json` is the exception — the bundled
-/// manifest must be parsed from bytes, so it is buffered up to
-/// [`MAX_UNTRUSTED_PREALLOC_BYTES`] regardless.
+/// manifest must be parsed from bytes (build-script detection depends
+/// on it), so it is buffered whatever its size, with only its
+/// preallocation bounded per [`MAX_UNTRUSTED_PREALLOC_BYTES`].
 pub(crate) const STREAM_ENTRY_BUFFER_MAX: u64 = 4 * 1024 * 1024;
 
 /// Byte budget for one batch of buffered entries on the streaming
@@ -608,13 +609,17 @@ pub(crate) fn extract_tarball_entries_streaming(
         }
 
         // `package.json` must be buffered whatever its header claims —
-        // the bundled manifest is parsed from bytes — but a hostile
-        // size still can't force an unbounded reservation.
-        let buffer_entry = file_size <= STREAM_ENTRY_BUFFER_MAX
-            || (cleaned_entry_path == "package.json"
-                && file_size <= MAX_UNTRUSTED_PREALLOC_BYTES as u64);
+        // the bundled manifest and its build-script detection are
+        // parsed from bytes, exactly as on the eager path — but a
+        // hostile size still can't force an unbounded reservation: the
+        // preallocation is capped, and the buffer then grows only to
+        // what the archive actually contains.
+        let buffer_entry =
+            file_size <= STREAM_ENTRY_BUFFER_MAX || cleaned_entry_path == "package.json";
         if buffer_entry {
-            let mut data = Vec::with_capacity(file_size as usize);
+            let prealloc =
+                usize::try_from(file_size).unwrap_or(usize::MAX).min(MAX_UNTRUSTED_PREALLOC_BYTES);
+            let mut data = Vec::with_capacity(prealloc);
             entry.read_to_end(&mut data).map_err(TarballError::ReadTarballEntries)?;
             if data.len() as u64 != file_size {
                 return Err(truncated());

--- a/pnpm/crates/tarball/src/extract.rs
+++ b/pnpm/crates/tarball/src/extract.rs
@@ -391,7 +391,7 @@ pub(crate) fn extract_tarball_entries(
 /// Extracting a package with thousands of files (e.g. `core-js`) on a
 /// single blocking thread pins one core while the rest sit idle — most
 /// costly at the makespan tail, when it's the last extraction still
-/// running. `write_cas_entry` is safe to run concurrently, so large
+/// running. [`write_cas_entry`] is safe to run concurrently, so large
 /// slices fan out across the dedicated [`cas_write_pool`]; small ones
 /// stay serial to skip rayon's per-job dispatch cost when there's
 /// nothing to gain. The dedicated pool keeps this off the global pool

--- a/pnpm/crates/tarball/src/extract.rs
+++ b/pnpm/crates/tarball/src/extract.rs
@@ -517,8 +517,8 @@ fn clean_archive_entry_path(raw: &str) -> Result<String, TarballError> {
 /// the store via [`StoreDir::write_cas_file_from_reader`] without ever
 /// being held in memory. `package.json` is the exception — the bundled
 /// manifest must be parsed from bytes (build-script detection depends
-/// on it), so it is buffered whatever its size, with only its
-/// preallocation bounded per [`MAX_UNTRUSTED_PREALLOC_BYTES`].
+/// on it), so it is buffered up to [`MAX_UNTRUSTED_PREALLOC_BYTES`],
+/// beyond which the archive is rejected as hostile.
 pub(crate) const STREAM_ENTRY_BUFFER_MAX: u64 = 4 * 1024 * 1024;
 
 /// Byte budget for one batch of buffered entries on the streaming
@@ -608,18 +608,29 @@ pub(crate) fn extract_tarball_entries_streaming(
             file_build_hooks = true;
         }
 
-        // `package.json` must be buffered whatever its header claims —
-        // the bundled manifest and its build-script detection are
-        // parsed from bytes, exactly as on the eager path — but a
-        // hostile size still can't force an unbounded reservation: the
-        // preallocation is capped, and the buffer then grows only to
-        // what the archive actually contains.
+        // `package.json` must be buffered — the bundled manifest and
+        // its build-script detection are parsed from bytes, exactly as
+        // on the eager path — so its size is hard-capped instead:
+        // buffering an unbounded manifest would defeat this path's
+        // bounded-memory guarantee, and silently skipping the parse
+        // would record wrong build metadata. A manifest beyond the cap
+        // exists only in a hostile archive (real ones are a few KB), so
+        // failing loudly is the honest outcome. A tar entry's payload
+        // can never exceed its header size, so the pre-read check is
+        // sufficient.
+        if cleaned_entry_path == "package.json" && file_size > MAX_UNTRUSTED_PREALLOC_BYTES as u64 {
+            return Err(TarballError::ReadTarballEntries(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "tar entry package.json is {file_size} bytes, which exceeds the \
+                     {MAX_UNTRUSTED_PREALLOC_BYTES}-byte manifest limit",
+                ),
+            )));
+        }
         let buffer_entry =
             file_size <= STREAM_ENTRY_BUFFER_MAX || cleaned_entry_path == "package.json";
         if buffer_entry {
-            let prealloc =
-                usize::try_from(file_size).unwrap_or(usize::MAX).min(MAX_UNTRUSTED_PREALLOC_BYTES);
-            let mut data = Vec::with_capacity(prealloc);
+            let mut data = Vec::with_capacity(file_size as usize);
             entry.read_to_end(&mut data).map_err(TarballError::ReadTarballEntries)?;
             if data.len() as u64 != file_size {
                 return Err(truncated());

--- a/pnpm/crates/tarball/src/lib.rs
+++ b/pnpm/crates/tarball/src/lib.rs
@@ -9,13 +9,15 @@ pub use download::*;
 pub use error::*;
 pub(crate) use extract::{
     allocate_tarball_buffer, apply_append_manifest, apply_placeholder_manifest, decompress_gzip,
-    extract_tarball_entries, normalize_bundled_manifest, tar_entry_payload,
+    extract_tarball_entries, normalize_bundled_manifest, should_stream_extract,
+    stream_extract_gzipped_tarball, tar_entry_payload,
 };
 pub use local_tarball::*;
 pub use prefetch::*;
 pub use zip_archive::*;
 
 use std::{
+    borrow::Cow,
     collections::HashMap,
     io::{self, Cursor, Read},
     path::{Component, Path, PathBuf},

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -6,9 +6,10 @@ use super::{
     },
     error::{HttpStatusError, NetworkError, TarballError, VerifyChecksumError},
     extract::{
-        allocate_tarball_buffer, apply_append_manifest, apply_placeholder_manifest,
-        bounded_gzip_size_hint, decompress_gzip, extract_tarball_entries,
-        normalize_bundled_manifest,
+        STREAM_ENTRY_BUFFER_MAX, STREAM_EXTRACT_COMPRESSED_THRESHOLD, allocate_tarball_buffer,
+        apply_append_manifest, apply_placeholder_manifest, bounded_gzip_size_hint, decompress_gzip,
+        extract_tarball_entries, normalize_bundled_manifest, should_stream_extract,
+        stream_extract_gzipped_tarball,
     },
     local_tarball::{
         allocate_local_tarball_buffer, local_file_tarball_path, open_local_tarball,
@@ -1180,6 +1181,283 @@ fn extract_tarball_reads_a_manifest_that_starts_with_a_utf8_bom() {
     assert_eq!(pkg_files_idx.requires_build, Some(true));
     assert!(pkg_files_idx.manifest.is_some(), "the bundled manifest must be recorded");
     drop(tempdir);
+}
+
+#[test]
+fn should_stream_extract_pivots_on_compressed_size_and_unpacked_hint() {
+    assert!(!should_stream_extract(0, None));
+    assert!(!should_stream_extract(STREAM_EXTRACT_COMPRESSED_THRESHOLD - 1, None));
+    assert!(should_stream_extract(STREAM_EXTRACT_COMPRESSED_THRESHOLD, None));
+    assert!(!should_stream_extract(0, Some(MAX_UNTRUSTED_PREALLOC_BYTES - 1)));
+    assert!(should_stream_extract(0, Some(MAX_UNTRUSTED_PREALLOC_BYTES)));
+    // A hostile hint only routes to the (still correct) streaming path.
+    assert!(should_stream_extract(0, Some(usize::MAX)));
+}
+
+/// Build a tar archive spanning every entry shape the streaming
+/// extractor branches on: a manifest, an executable, a small file, a
+/// directory (skipped), and one payload above
+/// [`STREAM_ENTRY_BUFFER_MAX`] that must take the
+/// direct-to-store streaming branch.
+fn mixed_size_tar() -> (Vec<u8>, Vec<u8>) {
+    let large_payload: Vec<u8> =
+        (0..=STREAM_ENTRY_BUFFER_MAX).map(|index| (index % 251) as u8).collect();
+
+    let mut builder = tar::Builder::new(Vec::new());
+    let mut dir_header = tar::Header::new_gnu();
+    dir_header.set_size(0);
+    dir_header.set_mode(0o755);
+    dir_header.set_entry_type(tar::EntryType::Directory);
+    dir_header.set_cksum();
+    builder.append_data(&mut dir_header, "package/lib/", &b""[..]).expect("append dir entry");
+    for (path, mode, body) in [
+        (
+            "package/package.json",
+            0o644,
+            &br#"{"name":"big","scripts":{"install":"node-gyp rebuild"}}"#[..],
+        ),
+        ("package/bin/tool", 0o755, &b"#!/bin/sh\necho hi\n"[..]),
+        ("package/big.bin", 0o644, large_payload.as_slice()),
+        ("package/lib/small.js", 0o644, &b"module.exports = 1\n"[..]),
+    ] {
+        let mut header = tar::Header::new_gnu();
+        header.set_size(body.len() as u64);
+        header.set_mode(mode);
+        header.set_entry_type(tar::EntryType::Regular);
+        header.set_cksum();
+        builder.append_data(&mut header, path, body).expect("append entry");
+    }
+    let tar_bytes = builder.into_inner().expect("finish tar");
+    (tar_bytes, large_payload)
+}
+
+fn gzip_bytes(bytes: &[u8]) -> Vec<u8> {
+    use std::io::Write;
+    let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+    encoder.write_all(bytes).expect("gzip bytes");
+    encoder.finish().expect("finish gzip")
+}
+
+/// The streaming extractor must produce byte-identical outputs to the
+/// eager whole-archive extractor — same store-relative CAS paths, same
+/// digests/modes/sizes in the index row, same bundled manifest and
+/// requires-build flag — because [`should_stream_extract`] routes
+/// between the two per download and the shared `index.db` must not be
+/// able to tell them apart.
+#[test]
+fn streaming_extract_matches_eager_extract() {
+    let (tar_bytes, large_payload) = mixed_size_tar();
+
+    let (eager_tempdir, eager_store) = tempdir_with_leaked_path();
+    let (eager_cas_paths, eager_idx) =
+        extract_tarball_entries(&tar_bytes, eager_store, None).expect("eager extraction");
+
+    let (streaming_tempdir, streaming_store) = tempdir_with_leaked_path();
+    let (streaming_cas_paths, streaming_idx) =
+        stream_extract_gzipped_tarball(&gzip_bytes(&tar_bytes), streaming_store, None)
+            .expect("streaming extraction");
+
+    let relative =
+        |cas_paths: &HashMap<String, PathBuf>, store: &StoreDir| -> HashMap<String, PathBuf> {
+            cas_paths
+                .iter()
+                .map(|(key, path)| {
+                    let path = path.strip_prefix(store.root()).expect("path within store");
+                    (key.clone(), path.to_path_buf())
+                })
+                .collect()
+        };
+    assert_eq!(
+        relative(&streaming_cas_paths, streaming_store),
+        relative(&eager_cas_paths, eager_store),
+    );
+
+    let comparable = |idx: &PackageFilesIndex| -> Vec<(String, String, u32, u64)> {
+        let mut rows: Vec<_> = idx
+            .files
+            .iter()
+            .map(|(path, info)| (path.clone(), info.digest.clone(), info.mode, info.size))
+            .collect();
+        rows.sort();
+        rows
+    };
+    assert_eq!(comparable(&streaming_idx), comparable(&eager_idx));
+    assert_eq!(streaming_idx.manifest, eager_idx.manifest);
+    assert_eq!(streaming_idx.requires_build, Some(true));
+    assert_eq!(streaming_idx.algo, eager_idx.algo);
+
+    let large_cas_path = &streaming_cas_paths["big.bin"];
+    assert_eq!(
+        std::fs::read(large_cas_path).expect("read streamed large entry"),
+        large_payload,
+        "the direct-to-store streamed entry must land byte-identical content",
+    );
+    assert!(
+        streaming_cas_paths["bin/tool"].to_string_lossy().ends_with("-exec"),
+        "executable entries must keep the -exec CAS suffix on the streaming path",
+    );
+
+    drop(eager_tempdir);
+    drop(streaming_tempdir);
+}
+
+/// Streaming-path counterpart of
+/// [`extract_rejects_parent_dir_component_in_entry_path`] — the
+/// traversal guard must hold on both extraction paths.
+#[test]
+fn streaming_extract_rejects_parent_dir_component_in_entry_path() {
+    let (tempdir, store_path) = tempdir_with_leaked_path();
+
+    let mut tar_bytes = Vec::new();
+    {
+        let mut builder = tar::Builder::new(&mut tar_bytes);
+        let mut header = tar::Header::new_gnu();
+        header.set_size(5);
+        header.set_mode(0o644);
+        header.set_entry_type(tar::EntryType::Regular);
+        // Same `set_path`-bypass as the eager-path test: raw name
+        // bytes + recomputed checksum.
+        let raw = header.as_mut_bytes();
+        let name = b"package/../evil.txt";
+        raw[..name.len()].copy_from_slice(name);
+        for result_b in &mut raw[name.len()..100] {
+            *result_b = 0;
+        }
+        header.set_cksum();
+        builder.append(&header, &b"evil!"[..]).expect("append entry");
+        builder.finish().expect("finalize tar");
+    }
+
+    let err = stream_extract_gzipped_tarball(&gzip_bytes(&tar_bytes), store_path, None)
+        .expect_err("parent-dir component must be rejected, not normalized");
+
+    match err {
+        TarballError::ReadTarballEntries(io_err) => {
+            assert_eq!(io_err.kind(), ErrorKind::InvalidData);
+        }
+        other => panic!("expected ReadTarballEntries(InvalidData), got: {other:?}"),
+    }
+
+    drop(tempdir);
+}
+
+/// Streaming-path counterpart of
+/// [`extract_tarball_applies_ignore_filter_dropping_entries_from_both_maps`].
+#[test]
+fn streaming_extract_applies_ignore_filter_dropping_entries_from_both_maps() {
+    let (tempdir, store_path) = tempdir_with_leaked_path();
+
+    let mut tar_bytes = Vec::new();
+    {
+        let mut builder = tar::Builder::new(&mut tar_bytes);
+        for (path, body) in [
+            ("package/bin/tool", &b"binary"[..]),
+            ("package/lib/node_modules/npm/package.json", &b"{}"[..]),
+            ("package/README.md", &b"readme"[..]),
+        ] {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(body.len() as u64);
+            header.set_mode(0o644);
+            header.set_entry_type(tar::EntryType::Regular);
+            header.set_cksum();
+            builder.append_data(&mut header, path, body).expect("append entry");
+        }
+        builder.finish().expect("finalize tar");
+    }
+
+    fn drop_npm(path: &str) -> bool {
+        path.starts_with("lib/node_modules/npm/")
+    }
+
+    let (cas_paths, pkg_files_idx) =
+        stream_extract_gzipped_tarball(&gzip_bytes(&tar_bytes), store_path, Some(&drop_npm))
+            .expect("streaming extraction with ignore filter");
+
+    dbg!(&cas_paths);
+    assert!(cas_paths.contains_key("bin/tool"));
+    assert!(cas_paths.contains_key("README.md"));
+    assert!(!cas_paths.contains_key("lib/node_modules/npm/package.json"));
+    assert!(!pkg_files_idx.files.contains_key("lib/node_modules/npm/package.json"));
+    assert_eq!(pkg_files_idx.requires_build, Some(false));
+
+    drop(tempdir);
+}
+
+/// Corrupt gzip bytes must surface as a [`TarballError`] the retry
+/// classifier treats as transient, matching the eager path's
+/// `DecodeGzip` handling; on the streaming path the decoder fails
+/// through the tar reader as `ReadTarballEntries`.
+#[test]
+fn streaming_extract_propagates_corrupt_gzip_as_read_error() {
+    let (tempdir, store_path) = tempdir_with_leaked_path();
+
+    let bogus: Vec<u8> = vec![0xFF; 1024];
+    let err = stream_extract_gzipped_tarball(&bogus, store_path, None)
+        .expect_err("corrupt gzip must surface a TarballError, not panic");
+
+    assert!(
+        matches!(err, TarballError::ReadTarballEntries(_)),
+        "expected ReadTarballEntries, got: {err:?}",
+    );
+    assert!(is_transient_error(&err), "a corrupt stream must remain retryable");
+
+    drop(tempdir);
+}
+
+/// A registry `dist.unpackedSize` at the streaming pivot routes the
+/// full download pipeline — integrity verification included — through
+/// the streaming extractor.
+#[tokio::test]
+async fn download_pipeline_extracts_via_streaming_path_for_large_unpacked_hint() {
+    let (store_dir_keep, store_path) = tempdir_with_leaked_path();
+    let (tar_bytes, large_payload) = mixed_size_tar();
+    let body = gzip_bytes(&tar_bytes);
+    let pkg_integrity = {
+        let mut opts = ssri::IntegrityOpts::new().algorithm(ssri::Algorithm::Sha512);
+        opts.input(&body);
+        opts.result()
+    };
+
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/pkg.tgz")
+        .with_status(200)
+        .with_body(&body)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let url = format!("{}/pkg.tgz", server.url());
+    let client = ThrottledClient::default();
+
+    let (computed_integrity, cas_paths, pkg_files_idx) =
+        fetch_and_extract_with_retry::<SilentReporter>(
+            &client,
+            &url,
+            Some(&pkg_integrity),
+            Some(MAX_UNTRUSTED_PREALLOC_BYTES),
+            0,
+            "test-pkg",
+            "",
+            store_path,
+            fast_retry_opts(),
+            &AuthHeaders::default(),
+            None,
+            None,
+        )
+        .await
+        .expect("download with a large unpacked-size hint");
+
+    assert_eq!(computed_integrity.to_string(), pkg_integrity.to_string());
+    assert!(cas_paths.contains_key("package.json"));
+    assert!(cas_paths.contains_key("bin/tool"));
+    assert_eq!(
+        std::fs::read(&cas_paths["big.bin"]).expect("read streamed large entry"),
+        large_payload,
+    );
+    assert_eq!(pkg_files_idx.requires_build, Some(true));
+    mock.assert_async().await;
+    drop(store_dir_keep);
 }
 
 /// `RetryOpts::default()` uses pnpm's network-fetch defaults: 2

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -1383,6 +1383,41 @@ fn streaming_extract_applies_ignore_filter_dropping_entries_from_both_maps() {
     drop(tempdir);
 }
 
+/// A `package.json` above [`STREAM_ENTRY_BUFFER_MAX`] must still be
+/// buffered and parsed on the streaming path — routing it through the
+/// direct-to-store branch would silently record
+/// `requires_build: Some(false)` and drop the bundled manifest.
+#[test]
+fn streaming_extract_parses_manifest_larger_than_entry_buffer() {
+    let (tempdir, store_path) = tempdir_with_leaked_path();
+
+    let padding = "p".repeat(usize::try_from(STREAM_ENTRY_BUFFER_MAX).unwrap() + 1);
+    let manifest =
+        format!(r#"{{"name":"pad","scripts":{{"install":"node-gyp rebuild"}},"x":"{padding}"}}"#);
+
+    let mut tar_bytes = Vec::new();
+    {
+        let mut builder = tar::Builder::new(&mut tar_bytes);
+        let mut header = tar::Header::new_gnu();
+        header.set_size(manifest.len() as u64);
+        header.set_mode(0o644);
+        header.set_entry_type(tar::EntryType::Regular);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, "package/package.json", manifest.as_bytes())
+            .expect("append manifest");
+        builder.finish().expect("finalize tar");
+    }
+
+    let (_cas_paths, pkg_files_idx) =
+        stream_extract_gzipped_tarball(&gzip_bytes(&tar_bytes), store_path, None)
+            .expect("streaming extraction");
+
+    assert_eq!(pkg_files_idx.requires_build, Some(true));
+    assert!(pkg_files_idx.manifest.is_some(), "the bundled manifest must be recorded");
+    drop(tempdir);
+}
+
 /// Corrupt gzip bytes must surface as a [`TarballError`] the retry
 /// classifier treats as transient, matching the eager path's
 /// `DecodeGzip` handling; on the streaming path the decoder fails

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -1418,6 +1418,36 @@ fn streaming_extract_parses_manifest_larger_than_entry_buffer() {
     drop(tempdir);
 }
 
+/// A `package.json` header claiming more than
+/// [`MAX_UNTRUSTED_PREALLOC_BYTES`] must be rejected before its payload
+/// is read — buffering it would defeat the streaming path's
+/// bounded-memory guarantee, and skipping the parse would record wrong
+/// build metadata. No payload follows the forged header below: the
+/// guard has to fire on the header alone.
+#[test]
+fn streaming_extract_rejects_manifest_beyond_prealloc_cap() {
+    let (tempdir, store_path) = tempdir_with_leaked_path();
+
+    let mut header = tar::Header::new_gnu();
+    header.set_path("package/package.json").expect("set tar entry path");
+    header.set_size(MAX_UNTRUSTED_PREALLOC_BYTES as u64 + 1);
+    header.set_mode(0o644);
+    header.set_entry_type(tar::EntryType::Regular);
+    header.set_cksum();
+
+    let err = stream_extract_gzipped_tarball(&gzip_bytes(header.as_bytes()), store_path, None)
+        .expect_err("oversized manifest must be rejected, not buffered");
+
+    match err {
+        TarballError::ReadTarballEntries(io_err) => {
+            assert_eq!(io_err.kind(), ErrorKind::InvalidData);
+        }
+        other => panic!("expected ReadTarballEntries(InvalidData), got: {other:?}"),
+    }
+
+    drop(tempdir);
+}
+
 /// Corrupt gzip bytes must surface as a [`TarballError`] the retry
 /// classifier treats as transient, matching the eager path's
 /// `DecodeGzip` handling; on the streaming path the decoder fails

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -1448,6 +1448,55 @@ fn streaming_extract_rejects_manifest_beyond_prealloc_cap() {
     drop(tempdir);
 }
 
+/// A large entry cut short by a truncated (but gzip-valid) archive
+/// must fail extraction without committing the partial payload to the
+/// CAS — the blob would be correctly content-addressed, but a
+/// cut-short transfer must leave the store as it found it.
+#[test]
+fn streaming_extract_truncated_large_entry_commits_nothing() {
+    let (tempdir, store_path) = tempdir_with_leaked_path();
+
+    let mut tar_bytes = Vec::new();
+    let mut header = tar::Header::new_gnu();
+    header.set_path("package/big.bin").expect("set tar entry path");
+    header.set_size(STREAM_ENTRY_BUFFER_MAX + 1);
+    header.set_mode(0o644);
+    header.set_entry_type(tar::EntryType::Regular);
+    header.set_cksum();
+    tar_bytes.extend_from_slice(header.as_bytes());
+    // Only 1 KiB of the claimed payload is present.
+    tar_bytes.extend_from_slice(&[0u8; 1024]);
+
+    let err = stream_extract_gzipped_tarball(&gzip_bytes(&tar_bytes), store_path, None)
+        .expect_err("truncated large entry must fail extraction");
+    assert!(
+        matches!(err, TarballError::ReadTarballEntries(_)),
+        "expected ReadTarballEntries, got: {err:?}",
+    );
+
+    fn count_files_recursively(dir: &Path) -> usize {
+        std::fs::read_dir(dir).map_or(0, |entries| {
+            entries
+                .map(|entry| entry.expect("read dirent"))
+                .map(|entry| {
+                    if entry.file_type().expect("dirent file type").is_dir() {
+                        count_files_recursively(&entry.path())
+                    } else {
+                        1
+                    }
+                })
+                .sum()
+        })
+    }
+    assert_eq!(
+        count_files_recursively(&store_path.root().join("files")),
+        0,
+        "the truncated entry must not commit anything to the CAS",
+    );
+
+    drop(tempdir);
+}
+
 /// Corrupt gzip bytes must surface as a [`TarballError`] the retry
 /// classifier treats as transient, matching the eager path's
 /// `DecodeGzip` handling; on the streaming path the decoder fails


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Reduces peak memory usage when installing large packages by adding a streaming extraction path to the Rust CLI's tarball pipeline.

Today both extraction inputs — the compressed body and the whole decompressed archive — are materialized as contiguous in-memory buffers, and they are alive simultaneously during extraction. For a 200 MB tarball that inflates to ~500 MB, that is ~700 MB per in-flight package, multiplied by the post-download concurrency (`num_cpus * 2`). This PR keeps only the compressed body in memory for large archives: the gzip decode now streams straight into the tar walk, and large files stream straight into the content-addressable store with an incremental SHA-512.

Routing (`should_stream_extract`, decided after integrity verification, so the trust model is unchanged):

- compressed size ≥ 16 MiB, **or** registry-reported `dist.unpackedSize` ≥ 64 MiB → streaming path;
- everything else → the existing eager path, unchanged, so the common case keeps zune-inflate's throughput, the zero-copy payload slices, and the single parallel CAS-write phase.

The `unpackedSize` hint is attacker-controlled, but it only picks between two correct extraction paths — a lying value costs at most the wrong path's performance profile, never correctness or unbounded memory.

On the streaming path:

- small entries (≤ 4 MiB) are buffered into batches capped at 32 MiB and flushed through the same parallel CAS-write pool as the eager path, so many-small-files packages keep their write parallelism;
- entries above 4 MiB stream through the new `StoreDir::write_cas_file_from_reader`: incremental SHA-512 while writing to an exclusively-created temp file inside `<store>/files/` (same filesystem as the shards), then an atomic rename to the content-addressed path. An existing live entry at the target is kept (same inode) and the temp is removed;
- `package.json` is always buffered (the bundled manifest must be parsed from bytes), bounded at 64 MiB;
- batches always flush before a directly-streamed entry is written, so duplicate-path last-wins ordering is identical to the eager path;
- a decoder failure surfaces as `TarballError::ReadTarballEntries`, which the retry classifier already treats as transient — same recovery semantics as an eager-path gzip/tar failure.

Supporting refactors: the exclusive-temp-file open loop moved from `write_atomic` into a reusable `pnpm_fs::create_exclusive_temp_file`; the shard-mkdir cache in `write_cas_file` moved into a shared `ensure_shard_dir`; the eager extractor's per-entry path cleaning, manifest capture, parallel write phase, and output assembly were factored into helpers shared with the streaming path. `flate2` moved from dev-dependency to dependency of `pnpm-tarball` (it is already a workspace dependency; zune-inflate has no streaming API).

Known trade-off: flate2's decoder is slower than zune-inflate, so a huge archive trades some decompression throughput for the ~3-5× smaller footprint; extraction overlaps decompression with hashing/writes on this path, which claws part of that back. The compressed body itself is still buffered in memory during download (streaming the download to disk is a possible follow-up), as is the zip path used by the binary fetcher.

**Rust-only by design.** This is a pure perf/memory change with no user-visible surface (no flags, formats, error codes, or reporter emissions change), so it does not require mirroring in the TypeScript CLI, and the request was to land it in pnpm v12 only.

## Squash Commit Body

```text
Both extraction inputs were materialized as contiguous in-memory
buffers — the compressed body and the whole decompressed archive —
and both were alive simultaneously during extraction, so a large
package cost compressed + unpacked bytes of RAM per in-flight task
(times the post-download concurrency of num_cpus * 2).

Add a streaming extraction path and route to it after integrity
verification when the compressed size is >= 16 MiB or the registry's
dist.unpackedSize hint is >= 64 MiB (the untrusted hint only picks
between two correct paths). The gzip decode (flate2, already a
workspace dependency; zune-inflate has no streaming API) feeds the
tar walk directly. Small entries batch up to 32 MiB and flush through
the existing parallel CAS-write pool; entries above 4 MiB stream into
the new StoreDir::write_cas_file_from_reader, which hashes
incrementally into an exclusively-created temp file in
<store>/files/ and atomically renames it to the content-addressed
path. package.json is always buffered (bounded at 64 MiB) so the
bundled manifest can be parsed. Batches flush before a streamed
entry is written, preserving last-wins duplicate ordering, and
decoder failures surface as ReadTarballEntries, which the retry
classifier already treats as transient.

Small tarballs keep the eager path unchanged: zune-inflate
throughput, zero-copy payload slices, one parallel write phase.

Supporting refactors: write_atomic's exclusive-temp open loop is now
pnpm_fs::create_exclusive_temp_file; the shard-mkdir cache is shared
via ensure_shard_dir; the eager extractor's path cleaning, manifest
capture, parallel write phase, and output assembly are helpers
shared with the streaming path.

Rust-only: pure perf/memory change with no user-visible surface, so
no TypeScript counterpart is required.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13960"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789555701&installation_model_id=426870&pr_number=13960&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13960&signature=3885ca3e34ea5756e040456ddf226704809dd77b95910c8c717e314da68afb84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced peak memory usage when installing large packages.
  * Large archives and files are processed incrementally instead of being fully loaded into memory.
  * Large compressed archives can be decompressed and extracted as a stream.

* **Reliability**
  * Improved temporary-file handling during package extraction and storage.
  * Added safeguards for extraction errors, duplicate files, invalid paths, incomplete archives, and corrupted content.

* **Compatibility**
  * Preserved existing results, file metadata, integrity verification, filtering, and optimized handling for large and small archives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->