### PR TITLE
fix(cmd-shim): treat an empty bin string as no bin

### DIFF
--- a/.changeset/empty-bin-string-declares-no-command.md
+++ b/.changeset/empty-bin-string-declares-no-command.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-A dependency published with `"bin": ""` no longer fails the whole install with `ERR_PNPM_CMD_SHIM_PROBE_SHIM_SOURCE` [#13962](https://github.com/pnpm/pnpm/issues/13962). An empty `bin` means the package declares no command, as pnpm treats it, so no shim is created for it.
+A dependency published with `"bin": ""` no longer fails the whole install with `ERR_PNPM_CMD_SHIM_PROBE_SHIM_SOURCE` [#13962](https://github.com/pnpm/pnpm/issues/13962). An empty `bin` declares no command, as pnpm treats it, so no shim is created for it; a `directories.bin` entry on the same package is still linked.

--- a/.changeset/empty-bin-string-declares-no-command.md
+++ b/.changeset/empty-bin-string-declares-no-command.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+A dependency published with `"bin": ""` no longer fails the whole install with `ERR_PNPM_CMD_SHIM_PROBE_SHIM_SOURCE` [#13962](https://github.com/pnpm/pnpm/issues/13962). An empty `bin` means the package declares no command, as pnpm treats it, so no shim is created for it.

--- a/.changeset/empty-bin-string-declares-no-command.md
+++ b/.changeset/empty-bin-string-declares-no-command.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-A dependency published with `"bin": ""` no longer fails the whole install with `ERR_PNPM_CMD_SHIM_PROBE_SHIM_SOURCE` [#13962](https://github.com/pnpm/pnpm/issues/13962). An empty `bin` declares no command, as pnpm treats it, so no shim is created for it; a `directories.bin` entry on the same package is still linked.
+A dependency published with `"bin": ""`, such as `url-loader@1.1.2`, no longer fails the install with `ERR_PNPM_CMD_SHIM_PROBE_SHIM_SOURCE` [#13962](https://github.com/pnpm/pnpm/issues/13962). An empty `bin` declares no command, as it does in pnpm v11, so no shim is written for the package; a `directories.bin` entry on the same package is still linked.

--- a/pnpm/crates/cmd-shim/src/bin_resolver.rs
+++ b/pnpm/crates/cmd-shim/src/bin_resolver.rs
@@ -42,12 +42,15 @@ pub fn pkg_owns_bin(bin_name: &str, pkg_name: &str) -> bool {
 
 /// Read every bin declared by `manifest` and return them as [`Command`]s
 /// rooted at `pkg_path`.
+///
+/// An empty-string `bin` declares no command, matching the truthiness
+/// check the TypeScript CLI applies to the field.
 pub fn get_bins_from_package_manifest<Sys: FsWalkFiles>(
     manifest: &Value,
     pkg_path: &Path,
 ) -> Vec<Command> {
     let pkg_name = manifest.get("name").and_then(Value::as_str);
-    if let Some(bin) = manifest.get("bin") {
+    if let Some(bin) = manifest.get("bin").filter(|bin| bin.as_str() != Some("")) {
         return commands_from_bin(bin, pkg_name, pkg_path);
     }
     if let Some(bin_dir_rel) =

--- a/pnpm/crates/cmd-shim/src/bin_resolver.rs
+++ b/pnpm/crates/cmd-shim/src/bin_resolver.rs
@@ -43,8 +43,7 @@ pub fn pkg_owns_bin(bin_name: &str, pkg_name: &str) -> bool {
 /// Read every bin declared by `manifest` and return them as [`Command`]s
 /// rooted at `pkg_path`.
 ///
-/// An empty-string `bin` declares no command, matching the truthiness
-/// check the TypeScript CLI applies to the field.
+/// An empty-string `bin` declares no command, as it does in pnpm v11.
 pub fn get_bins_from_package_manifest<Sys: FsWalkFiles>(
     manifest: &Value,
     pkg_path: &Path,

--- a/pnpm/crates/cmd-shim/src/bin_resolver/tests.rs
+++ b/pnpm/crates/cmd-shim/src/bin_resolver/tests.rs
@@ -326,6 +326,26 @@ fn empty_bin_string_declares_no_command() {
     assert!(get_bins_from_package_manifest::<Host>(&manifest, Path::new("/p")).is_empty());
 }
 
+#[test]
+fn empty_bin_string_falls_through_to_directories_bin() {
+    let tmp = tempdir().unwrap();
+    let pkg = tmp.path().join("pkg");
+    let bin_dir = pkg.join("bin-dir");
+    create_dir_all(&bin_dir).unwrap();
+    write_file(bin_dir.join("tool.js"), "").unwrap();
+
+    let manifest = json!({
+        "name": "empty-bin",
+        "version": "1.0.0",
+        "bin": "",
+        "directories": {"bin": "bin-dir"},
+    });
+    let commands = get_bins_from_package_manifest::<Host>(&manifest, &pkg);
+    assert_eq!(commands.len(), 1);
+    assert_eq!(commands[0].name, "tool.js");
+    assert_eq!(commands[0].path, bin_dir.join("tool.js"));
+}
+
 /// The relative names `.` and `..` survive the URL-safe guard's character
 /// set (`.` is unescaped by `encodeURIComponent`) but resolve to the bin
 /// directory itself or its parent when joined to a target dir, so

--- a/pnpm/crates/cmd-shim/src/bin_resolver/tests.rs
+++ b/pnpm/crates/cmd-shim/src/bin_resolver/tests.rs
@@ -317,6 +317,15 @@ fn empty_bin_key_is_rejected() {
     assert_eq!(commands[0].name, "good");
 }
 
+/// `url-loader@1.1.2` is published with `"bin": ""`, which would otherwise
+/// resolve to the package directory and make the linker probe a directory
+/// as a shim source.
+#[test]
+fn empty_bin_string_declares_no_command() {
+    let manifest = json!({"name": "url-loader", "version": "1.1.2", "bin": ""});
+    assert!(get_bins_from_package_manifest::<Host>(&manifest, Path::new("/p")).is_empty());
+}
+
 /// The relative names `.` and `..` survive the URL-safe guard's character
 /// set (`.` is unescaped by `encodeURIComponent`) but resolve to the bin
 /// directory itself or its parent when joined to a target dir, so


### PR DESCRIPTION
## Summary

Installing a dependency published with `"bin": ""` fails the whole install with `ERR_PNPM_CMD_SHIM_PROBE_SHIM_SOURCE` — `pnpm add url-loader@1.1.2` reports `Failed to read shim source ".../node_modules/url-loader/": Is a directory`, and nothing gets linked or written to the lockfile. The empty string is joined onto the package directory, so the bin resolver hands the linker a command whose source is the package root.

The TypeScript CLI checks `manifest.bin` for truthiness, which drops an empty string before it reaches `commandsFromBin`. The Rust resolver only checked whether the field was present. It now skips an empty-string `bin` the same way, so such a package installs with no shim. Fixes pnpm/pnpm#13962.

## Squash Commit Body

```text
get_bins_from_package_manifest took any present `bin` field into
commands_from_bin. For `"bin": ""` that produced a command named after the
package whose path was pkg_path joined with an empty string, i.e. the package
directory itself, and link_bins then failed to probe a directory as a shim
source. Published packages carry this field, url-loader@1.1.2 among them, so a
single one anywhere in the graph aborted the install.

An empty string is now filtered out before the bin branch, matching the
truthiness check the TypeScript CLI applies to manifest.bin, which also lets
`directories.bin` still apply.

Closes pnpm/pnpm#13962.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed installation failures for packages with an empty `bin` declaration.
  * Prevented empty `bin` values from creating incorrect command shims.
  * Installation now correctly continues to other available binary declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->