### PR TITLE
chore: add fix:rust script for clippy autofix

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "compile-only": "tsgo --build pnpm11/workspace/workspace-manifest-reader pnpm11/workspace/projects-reader && pnx node@runtime:26.7.0 pnpm11/__utils__/scripts/src/typecheck-only.ts && pn -F=pnpm compile",
     "compile": "pn compile-only && pn update-manifests",
     "build:pnpm": "cargo build --release --bin pnpm",
+    "fix:rust": "cargo clippy --fix --workspace --all-targets --allow-dirty --allow-staged -- -D warnings",
     "make-lcov": "shx mkdir -p coverage && lcov-result-merger 'pnpm11/**/coverage/lcov.info' 'coverage/lcov.info'",
     "update-manifests": "pn meta-updater && pn install",
     "meta-updater": "pn --filter=@pnpm-private/updater compile && pn exec meta-updater",


### PR DESCRIPTION
Adds a `fix:rust` npm script that applies clippy's machine-applicable autofixes across the Rust workspace via `cargo clippy --fix`, matching the existing `build:pnpm` root invocation.

`cargo clippy --fix --workspace --all-targets --allow-dirty --allow-staged -- -D warnings`

Run on a dirty tree is intended (`--allow-dirty --allow-staged`); review the diff before committing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13968"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789584567&installation_model_id=426870&pr_number=13968&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13968&signature=f137444ba3dda64c51565c367e2a4430ec2ed60fd187e772e204e0185e3b3fee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a command to automatically apply Rust lint fixes across the project.
  * Configured the command to check all targets and treat warnings as errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->