### PR TITLE
chore(pm): sync compat extensions to latest Yarn + add phantom findings

### DIFF
--- a/pnpm/crates/package-manager/src/compat_package_extensions.json
+++ b/pnpm/crates/package-manager/src/compat_package_extensions.json
@@ -1,17 +1,71 @@
 [
   [
-    "@tailwindcss/aspect-ratio@<0.2.1",
+    "@ant-design/react-slick@<=0.28.3",
     {
       "peerDependencies": {
-        "tailwindcss": "^2.0.2"
+        "react": ">=16.0.0"
       }
     }
   ],
   [
-    "@tailwindcss/line-clamp@<0.2.1",
+    "@apollographql/apollo-tools@<=0.5.2",
     {
       "peerDependencies": {
-        "tailwindcss": "^2.0.2"
+        "graphql": "^14.2.1 || ^15.0.0"
+      }
+    }
+  ],
+  [
+    "@asyncapi/react-component@<=1.0.0-next.39",
+    {
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    }
+  ],
+  [
+    "@babel/parser@*",
+    {
+      "dependencies": {
+        "@babel/types": "^7.8.3"
+      }
+    }
+  ],
+  [
+    "@cypress/snapshot@*",
+    {
+      "dependencies": {
+        "debug": "^3.2.7"
+      }
+    }
+  ],
+  [
+    "@docusaurus/responsive-loader@<1.5.0",
+    {
+      "peerDependenciesMeta": {
+        "sharp": {
+          "optional": true
+        },
+        "jimp": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "@fastify/type-provider-typebox@^4.0.0",
+    {
+      "peerDependencies": {
+        "fastify": "^4.0.0"
+      }
+    }
+  ],
+  [
+    "@fastify/type-provider-typebox@^5.0.0",
+    {
+      "peerDependencies": {
+        "fastify": "^5.0.0"
       }
     }
   ],
@@ -20,6 +74,81 @@
     {
       "peerDependencies": {
         "postcss": "^8.0.0"
+      }
+    }
+  ],
+  [
+    "@google-cloud/firestore@<=4.9.3",
+    {
+      "dependencies": {
+        "protobufjs": "^6.8.6"
+      }
+    }
+  ],
+  [
+    "@npmcli/metavuln-calculator@<2.0.0",
+    {
+      "dependencies": {
+        "json-parse-even-better-errors": "^2.3.1"
+      }
+    }
+  ],
+  [
+    "@parcel/node-resolver-core@>=2",
+    {
+      "peerDependencies": {
+        "@parcel/core": "*"
+      }
+    }
+  ],
+  [
+    "@parcel/resolver-default@>=2",
+    {
+      "peerDependencies": {
+        "@parcel/core": "*"
+      }
+    }
+  ],
+  [
+    "@parcel/transformer-image@<2.5.0",
+    {
+      "peerDependencies": {
+        "@parcel/core": "*"
+      }
+    }
+  ],
+  [
+    "@parcel/transformer-js@<2.5.0",
+    {
+      "peerDependencies": {
+        "@parcel/core": "*"
+      }
+    }
+  ],
+  [
+    "@playwright/test@<=1.14.1",
+    {
+      "dependencies": {
+        "jest-matcher-utils": "^26.4.2"
+      }
+    }
+  ],
+  [
+    "@pm2/agent@<1.0.4",
+    {
+      "dependencies": {
+        "debug": "*"
+      }
+    }
+  ],
+  [
+    "@rebass/forms@*",
+    {
+      "dependencies": {
+        "@styled-system/should-forward-prop": "^5.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.6"
       }
     }
   ],
@@ -37,445 +166,55 @@
     }
   ],
   [
-    "any-observable@<0.5.1",
-    {
-      "peerDependenciesMeta": {
-        "rxjs": {
-          "optional": true
-        },
-        "zenObservable": {
-          "optional": true
-        }
-      }
-    }
-  ],
-  [
-    "@pm2/agent@<1.0.4",
-    {
-      "dependencies": {
-        "debug": "*"
-      }
-    }
-  ],
-  [
-    "debug@<4.2.0",
-    {
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    }
-  ],
-  [
-    "got@<11",
-    {
-      "dependencies": {
-        "@types/responselike": "^1.0.0",
-        "@types/keyv": "^3.1.1"
-      }
-    }
-  ],
-  [
-    "cacheable-lookup@<4.1.2",
-    {
-      "dependencies": {
-        "@types/keyv": "^3.1.1"
-      }
-    }
-  ],
-  [
-    "http-link-dataloader@*",
+    "@tailwindcss/aspect-ratio@<0.2.1",
     {
       "peerDependencies": {
-        "graphql": "^0.13.1 || ^14.0.0"
+        "tailwindcss": "^2.0.2"
       }
     }
   ],
   [
-    "typescript-language-server@*",
-    {
-      "dependencies": {
-        "vscode-jsonrpc": "^5.0.1",
-        "vscode-languageserver-protocol": "^3.15.0"
-      }
-    }
-  ],
-  [
-    "postcss-syntax@*",
-    {
-      "peerDependenciesMeta": {
-        "postcss-html": {
-          "optional": true
-        },
-        "postcss-jsx": {
-          "optional": true
-        },
-        "postcss-less": {
-          "optional": true
-        },
-        "postcss-markdown": {
-          "optional": true
-        },
-        "postcss-scss": {
-          "optional": true
-        }
-      }
-    }
-  ],
-  [
-    "jss-plugin-rule-value-function@<=10.1.1",
-    {
-      "dependencies": {
-        "tiny-warning": "^1.0.2"
-      }
-    }
-  ],
-  [
-    "ink-select-input@<4.1.0",
+    "@tailwindcss/line-clamp@<0.2.1",
     {
       "peerDependencies": {
-        "react": "^16.8.2"
+        "tailwindcss": "^2.0.2"
       }
     }
   ],
   [
-    "license-webpack-plugin@<2.3.18",
-    {
-      "peerDependenciesMeta": {
-        "webpack": {
-          "optional": true
-        }
-      }
-    }
-  ],
-  [
-    "snowpack@>=3.3.0",
-    {
-      "dependencies": {
-        "node-gyp": "^7.1.0"
-      }
-    }
-  ],
-  [
-    "promise-inflight@*",
-    {
-      "peerDependenciesMeta": {
-        "bluebird": {
-          "optional": true
-        }
-      }
-    }
-  ],
-  [
-    "reactcss@*",
+    "@volar/language-server@*",
     {
       "peerDependencies": {
-        "react": "*"
-      }
-    }
-  ],
-  [
-    "react-color@<=2.19.0",
-    {
-      "peerDependencies": {
-        "react": "*"
-      }
-    }
-  ],
-  [
-    "gatsby-plugin-i18n@*",
-    {
-      "dependencies": {
-        "ramda": "^0.24.1"
-      }
-    }
-  ],
-  [
-    "useragent@^2.0.0",
-    {
-      "dependencies": {
-        "request": "^2.88.0",
-        "yamlparser": "0.0.x",
-        "semver": "5.5.x"
-      }
-    }
-  ],
-  [
-    "@apollographql/apollo-tools@<=0.5.2",
-    {
-      "peerDependencies": {
-        "graphql": "^14.2.1 || ^15.0.0"
-      }
-    }
-  ],
-  [
-    "material-table@^2.0.0",
-    {
-      "dependencies": {
-        "@babel/runtime": "^7.11.2"
-      }
-    }
-  ],
-  [
-    "@babel/parser@*",
-    {
-      "dependencies": {
-        "@babel/types": "^7.8.3"
-      }
-    }
-  ],
-  [
-    "fork-ts-checker-webpack-plugin@<=6.3.4",
-    {
-      "peerDependencies": {
-        "eslint": ">= 6",
-        "typescript": ">= 2.7",
-        "webpack": ">= 4",
-        "vue-template-compiler": "*"
+        "typescript": "*"
       },
       "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        },
-        "vue-template-compiler": {
+        "typescript": {
           "optional": true
         }
       }
     }
   ],
   [
-    "rc-animate@<=3.1.1",
+    "@volar/language-service@*",
     {
       "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    }
-  ],
-  [
-    "react-bootstrap-table2-paginator@*",
-    {
-      "dependencies": {
-        "classnames": "^2.2.6"
-      }
-    }
-  ],
-  [
-    "react-draggable@<=4.4.3",
-    {
-      "peerDependencies": {
-        "react": ">= 16.3.0",
-        "react-dom": ">= 16.3.0"
-      }
-    }
-  ],
-  [
-    "apollo-upload-client@<14",
-    {
-      "peerDependencies": {
-        "graphql": "14 - 15"
-      }
-    }
-  ],
-  [
-    "react-instantsearch-core@<=6.7.0",
-    {
-      "peerDependencies": {
-        "algoliasearch": ">= 3.1 < 5"
-      }
-    }
-  ],
-  [
-    "react-instantsearch-dom@<=6.7.0",
-    {
-      "dependencies": {
-        "react-fast-compare": "^3.0.0"
-      }
-    }
-  ],
-  [
-    "ws@<7.2.1",
-    {
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "typescript": "*"
       },
       "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
+        "typescript": {
           "optional": true
         }
       }
     }
   ],
   [
-    "react-portal@<4.2.2",
+    "@volar/typescript@*",
     {
       "peerDependencies": {
-        "react-dom": "^15.0.0-0 || ^16.0.0-0 || ^17.0.0-0"
-      }
-    }
-  ],
-  [
-    "react-scripts@<=4.0.1",
-    {
-      "peerDependencies": {
-        "react": "*"
-      }
-    }
-  ],
-  [
-    "testcafe@<=1.10.1",
-    {
-      "dependencies": {
-        "@babel/plugin-transform-for-of": "^7.12.1",
-        "@babel/runtime": "^7.12.5"
-      }
-    }
-  ],
-  [
-    "testcafe-legacy-api@<=4.2.0",
-    {
-      "dependencies": {
-        "testcafe-hammerhead": "^17.0.1",
-        "read-file-relative": "^1.2.0"
-      }
-    }
-  ],
-  [
-    "@google-cloud/firestore@<=4.9.3",
-    {
-      "dependencies": {
-        "protobufjs": "^6.8.6"
-      }
-    }
-  ],
-  [
-    "gatsby-source-apiserver@*",
-    {
-      "dependencies": {
-        "babel-polyfill": "^6.26.0"
-      }
-    }
-  ],
-  [
-    "@webpack-cli/package-utils@<=1.0.1-alpha.4",
-    {
-      "dependencies": {
-        "cross-spawn": "^7.0.3"
-      }
-    }
-  ],
-  [
-    "gatsby-remark-prismjs@<3.3.28",
-    {
-      "dependencies": {
-        "lodash": "^4"
-      }
-    }
-  ],
-  [
-    "gatsby-plugin-favicon@*",
-    {
-      "peerDependencies": {
-        "webpack": "*"
-      }
-    }
-  ],
-  [
-    "gatsby-plugin-sharp@<=4.6.0-next.3",
-    {
-      "dependencies": {
-        "debug": "^4.3.1"
-      }
-    }
-  ],
-  [
-    "gatsby-react-router-scroll@<=5.6.0-next.0",
-    {
-      "dependencies": {
-        "prop-types": "^15.7.2"
-      }
-    }
-  ],
-  [
-    "@rebass/forms@*",
-    {
-      "dependencies": {
-        "@styled-system/should-forward-prop": "^5.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.6"
-      }
-    }
-  ],
-  [
-    "rebass@*",
-    {
-      "peerDependencies": {
-        "react": "^16.8.6"
-      }
-    }
-  ],
-  [
-    "@ant-design/react-slick@<=0.28.3",
-    {
-      "peerDependencies": {
-        "react": ">=16.0.0"
-      }
-    }
-  ],
-  [
-    "mqtt@<4.2.7",
-    {
-      "dependencies": {
-        "duplexify": "^4.1.1"
-      }
-    }
-  ],
-  [
-    "vue-cli-plugin-vuetify@<=2.0.3",
-    {
-      "dependencies": {
-        "semver": "^6.3.0"
+        "typescript": "*"
       },
       "peerDependenciesMeta": {
-        "sass-loader": {
-          "optional": true
-        },
-        "vuetify-loader": {
-          "optional": true
-        }
-      }
-    }
-  ],
-  [
-    "vue-cli-plugin-vuetify@<=2.0.4",
-    {
-      "dependencies": {
-        "null-loader": "^3.0.0"
-      }
-    }
-  ],
-  [
-    "vue-cli-plugin-vuetify@>=2.4.3",
-    {
-      "peerDependencies": {
-        "vue": "*"
-      }
-    }
-  ],
-  [
-    "@vuetify/cli-plugin-utils@<=0.0.4",
-    {
-      "dependencies": {
-        "semver": "^6.3.0"
-      },
-      "peerDependenciesMeta": {
-        "sass-loader": {
+        "typescript": {
           "optional": true
         }
       }
@@ -506,44 +245,156 @@
     }
   ],
   [
-    "cordova-ios@<=6.3.0",
+    "@vue/eslint-config-typescript@<11.0.0",
     {
-      "dependencies": {
-        "underscore": "^1.9.2"
-      }
-    }
-  ],
-  [
-    "cordova-lib@<=10.0.1",
-    {
-      "dependencies": {
-        "underscore": "^1.9.2"
-      }
-    }
-  ],
-  [
-    "git-node-fs@*",
-    {
-      "peerDependencies": {
-        "js-git": "^0.7.8"
-      },
       "peerDependenciesMeta": {
-        "js-git": {
+        "typescript": {
           "optional": true
         }
       }
     }
   ],
   [
-    "consolidate@<0.16.0",
+    "@vuetify/cli-plugin-utils@<=0.0.4",
     {
-      "peerDependencies": {
-        "mustache": "^3.0.0"
+      "dependencies": {
+        "semver": "^6.3.0"
       },
       "peerDependenciesMeta": {
-        "mustache": {
+        "sass-loader": {
           "optional": true
         }
+      }
+    }
+  ],
+  [
+    "@webpack-cli/package-utils@<=1.0.1-alpha.4",
+    {
+      "dependencies": {
+        "cross-spawn": "^7.0.3"
+      }
+    }
+  ],
+  [
+    "any-observable@<0.5.1",
+    {
+      "peerDependenciesMeta": {
+        "rxjs": {
+          "optional": true
+        },
+        "zenObservable": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "apollo-upload-client@<14",
+    {
+      "peerDependencies": {
+        "graphql": "14 - 15"
+      }
+    }
+  ],
+  [
+    "auto-relay@<=0.14.0",
+    {
+      "peerDependencies": {
+        "reflect-metadata": "^0.1.13"
+      }
+    }
+  ],
+  [
+    "babel-plugin-graphql-tag@<=3.1.0",
+    {
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0"
+      }
+    }
+  ],
+  [
+    "babel-plugin-remove-graphql-queries@<=3.14.0-next.1",
+    {
+      "dependencies": {
+        "gatsby-core-utils": "^2.8.0-next.1"
+      }
+    }
+  ],
+  [
+    "babel-plugin-remove-graphql-queries@<=4.20.0-next.0",
+    {
+      "dependencies": {
+        "@babel/types": "^7.15.4"
+      }
+    }
+  ],
+  [
+    "babel-plugin-remove-graphql-queries@<3.14.0-next.1",
+    {
+      "dependencies": {
+        "@babel/runtime": "^7.14.8"
+      }
+    }
+  ],
+  [
+    "babel-plugin-transform-typescript-metadata@<=0.3.2",
+    {
+      "peerDependencies": {
+        "@babel/core": "^7",
+        "@babel/traverse": "^7"
+      },
+      "peerDependenciesMeta": {
+        "@babel/traverse": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "babel-preset-gatsby-package@<1.14.0-next.1",
+    {
+      "dependencies": {
+        "@babel/runtime": "^7.14.8"
+      }
+    }
+  ],
+  [
+    "babel-preset-react-app@10.0.x <10.0.2",
+    {
+      "dependencies": {
+        "@babel/plugin-proposal-private-property-in-object": "^7.16.7"
+      }
+    }
+  ],
+  [
+    "bin-links@<2.3.0",
+    {
+      "dependencies": {
+        "mkdirp-infer-owner": "^1.0.2"
+      }
+    }
+  ],
+  [
+    "cacheable-lookup@<4.1.2",
+    {
+      "dependencies": {
+        "@types/keyv": "^3.1.1"
+      }
+    }
+  ],
+  [
+    "clipanion-v3-codemod@<=0.2.0",
+    {
+      "peerDependencies": {
+        "jscodeshift": "^0.11.0"
+      }
+    }
+  ],
+  [
+    "connect-mongo@<5.0.0",
+    {
+      "peerDependencies": {
+        "express-session": "^1.17.1"
       }
     }
   ],
@@ -769,97 +620,59 @@
     }
   ],
   [
-    "vue-loader@<=16.3.3",
+    "consolidate@<0.16.0",
     {
       "peerDependencies": {
-        "@vue/compiler-sfc": "^3.0.8",
-        "webpack": "^4.1.0 || ^5.0.0-0"
+        "mustache": "^3.0.0"
       },
       "peerDependenciesMeta": {
-        "@vue/compiler-sfc": {
+        "mustache": {
           "optional": true
         }
       }
     }
   ],
   [
-    "vue-loader@^16.7.0",
+    "cordova-ios@<=6.3.0",
     {
-      "peerDependencies": {
-        "@vue/compiler-sfc": "^3.0.8",
-        "vue": "^3.2.13"
-      },
+      "dependencies": {
+        "underscore": "^1.9.2"
+      }
+    }
+  ],
+  [
+    "cordova-lib@<=10.0.1",
+    {
+      "dependencies": {
+        "underscore": "^1.9.2"
+      }
+    }
+  ],
+  [
+    "create-gatsby@<1.14.0-next.1",
+    {
+      "dependencies": {
+        "@babel/runtime": "^7.14.8"
+      }
+    }
+  ],
+  [
+    "critters-webpack-plugin@<3.0.2",
+    {
       "peerDependenciesMeta": {
-        "@vue/compiler-sfc": {
-          "optional": true
-        },
-        "vue": {
+        "html-webpack-plugin": {
           "optional": true
         }
       }
     }
   ],
   [
-    "scss-parser@<=1.0.5",
+    "debug@<4.2.0",
     {
-      "dependencies": {
-        "lodash": "^4.17.21"
-      }
-    }
-  ],
-  [
-    "query-ast@<1.0.5",
-    {
-      "dependencies": {
-        "lodash": "^4.17.21"
-      }
-    }
-  ],
-  [
-    "redux-thunk@<=2.3.0",
-    {
-      "peerDependencies": {
-        "redux": "^4.0.0"
-      }
-    }
-  ],
-  [
-    "skypack@<=0.3.2",
-    {
-      "dependencies": {
-        "tar": "^6.1.0"
-      }
-    }
-  ],
-  [
-    "@npmcli/metavuln-calculator@<2.0.0",
-    {
-      "dependencies": {
-        "json-parse-even-better-errors": "^2.3.1"
-      }
-    }
-  ],
-  [
-    "bin-links@<2.3.0",
-    {
-      "dependencies": {
-        "mkdirp-infer-owner": "^1.0.2"
-      }
-    }
-  ],
-  [
-    "rollup-plugin-polyfill-node@<=0.8.0",
-    {
-      "peerDependencies": {
-        "rollup": "^1.20.0 || ^2.0.0"
-      }
-    }
-  ],
-  [
-    "snowpack@<3.8.6",
-    {
-      "dependencies": {
-        "magic-string": "^0.25.7"
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     }
   ],
@@ -872,88 +685,90 @@
     }
   ],
   [
-    "winston-transport@<=4.4.0",
+    "eslint-config-react-app@*",
     {
-      "dependencies": {
-        "logform": "^2.2.0"
-      }
-    }
-  ],
-  [
-    "jest-vue-preprocessor@*",
-    {
-      "dependencies": {
-        "@babel/core": "7.8.7",
-        "@babel/template": "7.8.6"
-      },
-      "peerDependencies": {
-        "pug": "^2.0.4"
-      },
       "peerDependenciesMeta": {
-        "pug": {
+        "typescript": {
           "optional": true
         }
       }
     }
   ],
   [
-    "redux-persist@*",
+    "eslint-import-resolver-vite@<2.0.1",
     {
-      "peerDependencies": {
-        "react": ">=16"
-      },
+      "dependencies": {
+        "debug": "^4.3.4",
+        "resolve": "^1.22.8"
+      }
+    }
+  ],
+  [
+    "eslint-module-utils@*",
+    {
       "peerDependenciesMeta": {
-        "react": {
+        "eslint-import-resolver-node": {
+          "optional": true
+        },
+        "eslint-import-resolver-typescript": {
+          "optional": true
+        },
+        "eslint-import-resolver-webpack": {
+          "optional": true
+        },
+        "@typescript-eslint/parser": {
           "optional": true
         }
       }
     }
   ],
   [
-    "sodium@>=3",
+    "eslint-plugin-import@*",
     {
-      "dependencies": {
-        "node-gyp": "^3.8.0"
+      "peerDependenciesMeta": {
+        "@typescript-eslint/parser": {
+          "optional": true
+        }
       }
     }
   ],
   [
-    "babel-plugin-graphql-tag@<=3.1.0",
+    "fdir@<=5.2.0",
     {
       "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0"
+        "picomatch": "2.x"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     }
   ],
   [
-    "@playwright/test@<=1.14.1",
+    "focus-trap-react@^8.0.0",
     {
       "dependencies": {
-        "jest-matcher-utils": "^26.4.2"
+        "tabbable": "^5.3.2"
       }
     }
   ],
   [
-    "babel-plugin-remove-graphql-queries@<3.14.0-next.1",
+    "fork-ts-checker-webpack-plugin@<=6.3.4",
     {
-      "dependencies": {
-        "@babel/runtime": "^7.14.8"
-      }
-    }
-  ],
-  [
-    "babel-preset-gatsby-package@<1.14.0-next.1",
-    {
-      "dependencies": {
-        "@babel/runtime": "^7.14.8"
-      }
-    }
-  ],
-  [
-    "create-gatsby@<1.14.0-next.1",
-    {
-      "dependencies": {
-        "@babel/runtime": "^7.14.8"
+      "peerDependencies": {
+        "eslint": ">= 6",
+        "typescript": ">= 2.7",
+        "webpack": ">= 4",
+        "vue-template-compiler": "*"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        },
+        "vue-template-compiler": {
+          "optional": true
+        }
       }
     }
   ],
@@ -1007,10 +822,42 @@
     }
   ],
   [
+    "gatsby-plugin-favicon@*",
+    {
+      "peerDependencies": {
+        "webpack": "*"
+      }
+    }
+  ],
+  [
+    "gatsby-plugin-gatsby-cloud@<=3.1.0-next.0",
+    {
+      "dependencies": {
+        "gatsby-core-utils": "^2.13.0-next.0"
+      }
+    }
+  ],
+  [
+    "gatsby-plugin-gatsby-cloud@<=3.2.0-next.1",
+    {
+      "peerDependencies": {
+        "webpack": "*"
+      }
+    }
+  ],
+  [
     "gatsby-plugin-graphql-config@<0.23.0-next.1",
     {
       "dependencies": {
         "@babel/runtime": "^7.14.8"
+      }
+    }
+  ],
+  [
+    "gatsby-plugin-i18n@*",
+    {
+      "dependencies": {
+        "ramda": "^0.24.1"
       }
     }
   ],
@@ -1023,10 +870,26 @@
     }
   ],
   [
+    "gatsby-plugin-mdx@^2",
+    {
+      "peerDependencies": {
+        "gatsby": "^3.0.0-next"
+      }
+    }
+  ],
+  [
     "gatsby-plugin-mdx@<2.14.0-next.1",
     {
       "dependencies": {
         "@babel/runtime": "^7.14.8"
+      }
+    }
+  ],
+  [
+    "gatsby-plugin-mdx@<3.1.0-next.1",
+    {
+      "dependencies": {
+        "mkdirp": "^1.0.4"
       }
     }
   ],
@@ -1039,10 +902,26 @@
     }
   ],
   [
+    "gatsby-plugin-netlify@3.13.0-next.1",
+    {
+      "dependencies": {
+        "gatsby-core-utils": "^2.13.0-next.0"
+      }
+    }
+  ],
+  [
     "gatsby-plugin-no-sourcemaps@<3.14.0-next.1",
     {
       "dependencies": {
         "@babel/runtime": "^7.14.8"
+      }
+    }
+  ],
+  [
+    "gatsby-plugin-page-creator@<=4.20.0-next.1",
+    {
+      "dependencies": {
+        "fs-extra": "^10.1.0"
       }
     }
   ],
@@ -1079,6 +958,14 @@
     }
   ],
   [
+    "gatsby-plugin-sharp@<=4.6.0-next.3",
+    {
+      "dependencies": {
+        "debug": "^4.3.1"
+      }
+    }
+  ],
+  [
     "gatsby-plugin-styletron@<6.14.0-next.1",
     {
       "dependencies": {
@@ -1095,6 +982,17 @@
     }
   ],
   [
+    "gatsby-plugin-utils@<=3.14.0-next.1",
+    {
+      "dependencies": {
+        "fastq": "^1.13.0"
+      },
+      "peerDependencies": {
+        "graphql": "^15.0.0"
+      }
+    }
+  ],
+  [
     "gatsby-plugin-utils@<1.14.0-next.1",
     {
       "dependencies": {
@@ -1103,10 +1001,34 @@
     }
   ],
   [
+    "gatsby-react-router-scroll@<=5.6.0-next.0",
+    {
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      }
+    }
+  ],
+  [
     "gatsby-recipes@<0.25.0-next.1",
     {
       "dependencies": {
         "@babel/runtime": "^7.14.8"
+      }
+    }
+  ],
+  [
+    "gatsby-remark-prismjs@<3.3.28",
+    {
+      "dependencies": {
+        "lodash": "^4"
+      }
+    }
+  ],
+  [
+    "gatsby-source-apiserver@*",
+    {
+      "dependencies": {
+        "babel-polyfill": "^6.26.0"
       }
     }
   ],
@@ -1143,42 +1065,229 @@
     }
   ],
   [
-    "gatsby-plugin-gatsby-cloud@<=3.1.0-next.0",
-    {
-      "dependencies": {
-        "gatsby-core-utils": "^2.13.0-next.0"
-      }
-    }
-  ],
-  [
-    "gatsby-plugin-gatsby-cloud@<=3.2.0-next.1",
+    "git-node-fs@*",
     {
       "peerDependencies": {
-        "webpack": "*"
+        "js-git": "^0.7.8"
+      },
+      "peerDependenciesMeta": {
+        "js-git": {
+          "optional": true
+        }
       }
     }
   ],
   [
-    "babel-plugin-remove-graphql-queries@<=3.14.0-next.1",
+    "got@<11",
     {
       "dependencies": {
-        "gatsby-core-utils": "^2.8.0-next.1"
+        "@types/responselike": "^1.0.0",
+        "@types/keyv": "^3.1.1"
       }
     }
   ],
   [
-    "gatsby-plugin-netlify@3.13.0-next.1",
-    {
-      "dependencies": {
-        "gatsby-core-utils": "^2.13.0-next.0"
-      }
-    }
-  ],
-  [
-    "clipanion-v3-codemod@<=0.2.0",
+    "graphql-compose@>=9.0.10",
     {
       "peerDependencies": {
-        "jscodeshift": "^0.11.0"
+        "graphql": "^14.2.0 || ^15.0.0 || ^16.0.0"
+      }
+    }
+  ],
+  [
+    "http-link-dataloader@*",
+    {
+      "peerDependencies": {
+        "graphql": "^0.13.1 || ^14.0.0"
+      }
+    }
+  ],
+  [
+    "ink-select-input@<4.1.0",
+    {
+      "peerDependencies": {
+        "react": "^16.8.2"
+      }
+    }
+  ],
+  [
+    "jest-vue-preprocessor@*",
+    {
+      "dependencies": {
+        "@babel/core": "7.8.7",
+        "@babel/template": "7.8.6"
+      },
+      "peerDependencies": {
+        "pug": "^2.0.4"
+      },
+      "peerDependenciesMeta": {
+        "pug": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "jss-plugin-rule-value-function@<=10.1.1",
+    {
+      "dependencies": {
+        "tiny-warning": "^1.0.2"
+      }
+    }
+  ],
+  [
+    "license-webpack-plugin@<2.3.18",
+    {
+      "peerDependenciesMeta": {
+        "webpack": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "material-table@^2.0.0",
+    {
+      "dependencies": {
+        "@babel/runtime": "^7.11.2"
+      }
+    }
+  ],
+  [
+    "mqtt@<4.2.7",
+    {
+      "dependencies": {
+        "duplexify": "^4.1.1"
+      }
+    }
+  ],
+  [
+    "notistack@^3.0.0",
+    {
+      "dependencies": {
+        "csstype": "^3.0.10"
+      }
+    }
+  ],
+  [
+    "parcel@*",
+    {
+      "peerDependenciesMeta": {
+        "@parcel/core": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "postcss-syntax@*",
+    {
+      "peerDependenciesMeta": {
+        "postcss-html": {
+          "optional": true
+        },
+        "postcss-jsx": {
+          "optional": true
+        },
+        "postcss-less": {
+          "optional": true
+        },
+        "postcss-markdown": {
+          "optional": true
+        },
+        "postcss-scss": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "promise-inflight@*",
+    {
+      "peerDependenciesMeta": {
+        "bluebird": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "query-ast@<1.0.5",
+    {
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
+    }
+  ],
+  [
+    "rc-animate@<=3.1.1",
+    {
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    }
+  ],
+  [
+    "react-bootstrap-table2-paginator@*",
+    {
+      "dependencies": {
+        "classnames": "^2.2.6"
+      }
+    }
+  ],
+  [
+    "react-color@<=2.19.0",
+    {
+      "peerDependencies": {
+        "react": "*"
+      }
+    }
+  ],
+  [
+    "react-dev-utils@*",
+    {
+      "peerDependencies": {
+        "typescript": ">=2.7",
+        "webpack": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "react-draggable@<=4.4.3",
+    {
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    }
+  ],
+  [
+    "react-github-btn@<=1.3.0",
+    {
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
+    }
+  ],
+  [
+    "react-instantsearch-core@<=6.7.0",
+    {
+      "peerDependencies": {
+        "algoliasearch": ">= 3.1 < 5"
+      }
+    }
+  ],
+  [
+    "react-instantsearch-dom@<=6.7.0",
+    {
+      "dependencies": {
+        "react-fast-compare": "^3.0.0"
       }
     }
   ],
@@ -1188,6 +1297,333 @@
       "peerDependencies": {
         "react-dom": "*",
         "react": "*"
+      }
+    }
+  ],
+  [
+    "react-portal@<4.2.2",
+    {
+      "peerDependencies": {
+        "react-dom": "^15.0.0-0 || ^16.0.0-0 || ^17.0.0-0"
+      }
+    }
+  ],
+  [
+    "react-rnd@<10.3.7",
+    {
+      "peerDependencies": {
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      }
+    }
+  ],
+  [
+    "react-scripts@*",
+    {
+      "peerDependencies": {
+        "eslint": "*"
+      }
+    }
+  ],
+  [
+    "react-scripts@<=4.0.1",
+    {
+      "peerDependencies": {
+        "react": "*"
+      }
+    }
+  ],
+  [
+    "reactcss@*",
+    {
+      "peerDependencies": {
+        "react": "*"
+      }
+    }
+  ],
+  [
+    "rebass@*",
+    {
+      "peerDependencies": {
+        "react": "^16.8.6"
+      }
+    }
+  ],
+  [
+    "redux-persist@*",
+    {
+      "peerDependencies": {
+        "react": ">=16"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "redux-thunk@<=2.3.0",
+    {
+      "peerDependencies": {
+        "redux": "^4.0.0"
+      }
+    }
+  ],
+  [
+    "rollup-plugin-polyfill-node@<=0.8.0",
+    {
+      "peerDependencies": {
+        "rollup": "^1.20.0 || ^2.0.0"
+      }
+    }
+  ],
+  [
+    "scss-parser@<=1.0.5",
+    {
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
+    }
+  ],
+  [
+    "skypack@<=0.3.2",
+    {
+      "dependencies": {
+        "tar": "^6.1.0"
+      }
+    }
+  ],
+  [
+    "snowpack@<3.8.6",
+    {
+      "dependencies": {
+        "magic-string": "^0.25.7"
+      }
+    }
+  ],
+  [
+    "snowpack@>=3.3.0",
+    {
+      "dependencies": {
+        "node-gyp": "^7.1.0"
+      }
+    }
+  ],
+  [
+    "sodium@>=3",
+    {
+      "dependencies": {
+        "node-gyp": "^3.8.0"
+      }
+    }
+  ],
+  [
+    "terser@<=5.10.0",
+    {
+      "dependencies": {
+        "acorn": "^8.5.0"
+      }
+    }
+  ],
+  [
+    "testcafe-legacy-api@<=4.2.0",
+    {
+      "dependencies": {
+        "testcafe-hammerhead": "^17.0.1",
+        "read-file-relative": "^1.2.0"
+      }
+    }
+  ],
+  [
+    "testcafe@<=1.10.1",
+    {
+      "dependencies": {
+        "@babel/plugin-transform-for-of": "^7.12.1",
+        "@babel/runtime": "^7.12.5"
+      }
+    }
+  ],
+  [
+    "typescript-language-server@*",
+    {
+      "dependencies": {
+        "vscode-jsonrpc": "^5.0.1",
+        "vscode-languageserver-protocol": "^3.15.0"
+      }
+    }
+  ],
+  [
+    "unified@<10",
+    {
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      }
+    }
+  ],
+  [
+    "unplugin-vue2-script-setup@<0.9.1",
+    {
+      "peerDependencies": {
+        "@vue/composition-api": "^1.4.3",
+        "@vue/runtime-dom": "^3.2.26"
+      }
+    }
+  ],
+  [
+    "useragent@^2.0.0",
+    {
+      "dependencies": {
+        "request": "^2.88.0",
+        "yamlparser": "0.0.x",
+        "semver": "5.5.x"
+      }
+    }
+  ],
+  [
+    "vite-plugin-vue-devtools@>=7.4.3",
+    {
+      "peerDependencies": {
+        "vue": "*"
+      }
+    }
+  ],
+  [
+    "vite-plugin-vuetify@<=1.0.2",
+    {
+      "peerDependencies": {
+        "vue": "^3.0.0"
+      }
+    }
+  ],
+  [
+    "volar-service-typescript-twoslash-queries@*",
+    {
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "volar-service-typescript@*",
+    {
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "vue-cli-plugin-vuetify@<=2.0.3",
+    {
+      "dependencies": {
+        "semver": "^6.3.0"
+      },
+      "peerDependenciesMeta": {
+        "sass-loader": {
+          "optional": true
+        },
+        "vuetify-loader": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "vue-cli-plugin-vuetify@<=2.0.4",
+    {
+      "dependencies": {
+        "null-loader": "^3.0.0"
+      }
+    }
+  ],
+  [
+    "vue-cli-plugin-vuetify@>=2.4.3",
+    {
+      "peerDependencies": {
+        "vue": "*"
+      }
+    }
+  ],
+  [
+    "vue-i18n@<9",
+    {
+      "peerDependencies": {
+        "vue": "^2"
+      }
+    }
+  ],
+  [
+    "vue-loader@^16.7.0",
+    {
+      "peerDependencies": {
+        "@vue/compiler-sfc": "^3.0.8",
+        "vue": "^3.2.13"
+      },
+      "peerDependenciesMeta": {
+        "@vue/compiler-sfc": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "vue-loader@<=16.3.3",
+    {
+      "peerDependencies": {
+        "@vue/compiler-sfc": "^3.0.8",
+        "webpack": "^4.1.0 || ^5.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/compiler-sfc": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "vue-router@<4",
+    {
+      "peerDependencies": {
+        "vue": "^2"
+      }
+    }
+  ],
+  [
+    "vue-template-babel-compiler@<1.2.0",
+    {
+      "peerDependencies": {
+        "vue-template-compiler": "^2.6.0"
+      }
+    }
+  ],
+  [
+    "webpack-dev-server@<3.10.2",
+    {
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    }
+  ],
+  [
+    "webpack-plugin-vuetify@<=2.0.1",
+    {
+      "peerDependencies": {
+        "vue": "^3.2.6"
       }
     }
   ],
@@ -1215,247 +1651,27 @@
     }
   ],
   [
-    "webpack-dev-server@<3.10.2",
-    {
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
-      }
-    }
-  ],
-  [
-    "@docusaurus/responsive-loader@<1.5.0",
-    {
-      "peerDependenciesMeta": {
-        "sharp": {
-          "optional": true
-        },
-        "jimp": {
-          "optional": true
-        }
-      }
-    }
-  ],
-  [
-    "eslint-module-utils@*",
-    {
-      "peerDependenciesMeta": {
-        "eslint-import-resolver-node": {
-          "optional": true
-        },
-        "eslint-import-resolver-typescript": {
-          "optional": true
-        },
-        "eslint-import-resolver-webpack": {
-          "optional": true
-        },
-        "@typescript-eslint/parser": {
-          "optional": true
-        }
-      }
-    }
-  ],
-  [
-    "eslint-plugin-import@*",
-    {
-      "peerDependenciesMeta": {
-        "@typescript-eslint/parser": {
-          "optional": true
-        }
-      }
-    }
-  ],
-  [
-    "critters-webpack-plugin@<3.0.2",
-    {
-      "peerDependenciesMeta": {
-        "html-webpack-plugin": {
-          "optional": true
-        }
-      }
-    }
-  ],
-  [
-    "terser@<=5.10.0",
+    "winston-transport@<=4.4.0",
     {
       "dependencies": {
-        "acorn": "^8.5.0"
+        "logform": "^2.2.0"
       }
     }
   ],
   [
-    "babel-preset-react-app@10.0.x <10.0.2",
-    {
-      "dependencies": {
-        "@babel/plugin-proposal-private-property-in-object": "^7.16.7"
-      }
-    }
-  ],
-  [
-    "eslint-config-react-app@*",
-    {
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    }
-  ],
-  [
-    "@vue/eslint-config-typescript@<11.0.0",
-    {
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    }
-  ],
-  [
-    "unplugin-vue2-script-setup@<0.9.1",
+    "ws@<7.2.1",
     {
       "peerDependencies": {
-        "@vue/composition-api": "^1.4.3",
-        "@vue/runtime-dom": "^3.2.26"
-      }
-    }
-  ],
-  [
-    "@cypress/snapshot@*",
-    {
-      "dependencies": {
-        "debug": "^3.2.7"
-      }
-    }
-  ],
-  [
-    "auto-relay@<=0.14.0",
-    {
-      "peerDependencies": {
-        "reflect-metadata": "^0.1.13"
-      }
-    }
-  ],
-  [
-    "vue-template-babel-compiler@<1.2.0",
-    {
-      "peerDependencies": {
-        "vue-template-compiler": "^2.6.0"
-      }
-    }
-  ],
-  [
-    "@parcel/transformer-image@<2.5.0",
-    {
-      "peerDependencies": {
-        "@parcel/core": "*"
-      }
-    }
-  ],
-  [
-    "@parcel/transformer-js@<2.5.0",
-    {
-      "peerDependencies": {
-        "@parcel/core": "*"
-      }
-    }
-  ],
-  [
-    "parcel@*",
-    {
-      "peerDependenciesMeta": {
-        "@parcel/core": {
-          "optional": true
-        }
-      }
-    }
-  ],
-  [
-    "react-scripts@*",
-    {
-      "peerDependencies": {
-        "eslint": "*"
-      }
-    }
-  ],
-  [
-    "focus-trap-react@^8.0.0",
-    {
-      "dependencies": {
-        "tabbable": "^5.3.2"
-      }
-    }
-  ],
-  [
-    "react-rnd@<10.3.7",
-    {
-      "peerDependencies": {
-        "react": ">=16.3.0",
-        "react-dom": ">=16.3.0"
-      }
-    }
-  ],
-  [
-    "connect-mongo@<5.0.0",
-    {
-      "peerDependencies": {
-        "express-session": "^1.17.1"
-      }
-    }
-  ],
-  [
-    "vue-i18n@<9",
-    {
-      "peerDependencies": {
-        "vue": "^2"
-      }
-    }
-  ],
-  [
-    "vue-router@<4",
-    {
-      "peerDependencies": {
-        "vue": "^2"
-      }
-    }
-  ],
-  [
-    "unified@<10",
-    {
-      "dependencies": {
-        "@types/unist": "^2.0.0"
-      }
-    }
-  ],
-  [
-    "react-github-btn@<=1.3.0",
-    {
-      "peerDependencies": {
-        "react": ">=16.3.0"
-      }
-    }
-  ],
-  [
-    "react-dev-utils@*",
-    {
-      "peerDependencies": {
-        "typescript": ">=2.7",
-        "webpack": ">=4"
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
       },
       "peerDependenciesMeta": {
-        "typescript": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
           "optional": true
         }
-      }
-    }
-  ],
-  [
-    "@asyncapi/react-component@<=1.0.0-next.39",
-    {
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
       }
     }
   ],
@@ -1469,133 +1685,6 @@
         "webpack": {
           "optional": true
         }
-      }
-    }
-  ],
-  [
-    "babel-plugin-remove-graphql-queries@<=4.20.0-next.0",
-    {
-      "dependencies": {
-        "@babel/types": "^7.15.4"
-      }
-    }
-  ],
-  [
-    "gatsby-plugin-page-creator@<=4.20.0-next.1",
-    {
-      "dependencies": {
-        "fs-extra": "^10.1.0"
-      }
-    }
-  ],
-  [
-    "gatsby-plugin-utils@<=3.14.0-next.1",
-    {
-      "dependencies": {
-        "fastq": "^1.13.0"
-      },
-      "peerDependencies": {
-        "graphql": "^15.0.0"
-      }
-    }
-  ],
-  [
-    "gatsby-plugin-mdx@<3.1.0-next.1",
-    {
-      "dependencies": {
-        "mkdirp": "^1.0.4"
-      }
-    }
-  ],
-  [
-    "gatsby-plugin-mdx@^2",
-    {
-      "peerDependencies": {
-        "gatsby": "^3.0.0-next"
-      }
-    }
-  ],
-  [
-    "fdir@<=5.2.0",
-    {
-      "peerDependencies": {
-        "picomatch": "2.x"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    }
-  ],
-  [
-    "babel-plugin-transform-typescript-metadata@<=0.3.2",
-    {
-      "peerDependencies": {
-        "@babel/core": "^7",
-        "@babel/traverse": "^7"
-      },
-      "peerDependenciesMeta": {
-        "@babel/traverse": {
-          "optional": true
-        }
-      }
-    }
-  ],
-  [
-    "graphql-compose@>=9.0.10",
-    {
-      "peerDependencies": {
-        "graphql": "^14.2.0 || ^15.0.0 || ^16.0.0"
-      }
-    }
-  ],
-  [
-    "vite-plugin-vuetify@<=1.0.2",
-    {
-      "peerDependencies": {
-        "vue": "^3.0.0"
-      }
-    }
-  ],
-  [
-    "webpack-plugin-vuetify@<=2.0.1",
-    {
-      "peerDependencies": {
-        "vue": "^3.2.6"
-      }
-    }
-  ],
-  [
-    "eslint-import-resolver-vite@<2.0.1",
-    {
-      "dependencies": {
-        "debug": "^4.3.4",
-        "resolve": "^1.22.8"
-      }
-    }
-  ],
-  [
-    "notistack@^3.0.0",
-    {
-      "dependencies": {
-        "csstype": "^3.0.10"
-      }
-    }
-  ],
-  [
-    "@fastify/type-provider-typebox@^5.0.0",
-    {
-      "peerDependencies": {
-        "fastify": "^5.0.0"
-      }
-    }
-  ],
-  [
-    "@fastify/type-provider-typebox@^4.0.0",
-    {
-      "peerDependencies": {
-        "fastify": "^4.0.0"
       }
     }
   ]

--- a/pnpm/crates/package-manager/src/compat_package_extensions.rs
+++ b/pnpm/crates/package-manager/src/compat_package_extensions.rs
@@ -33,8 +33,9 @@ use pnpm_config::{PackageExtension, PeerDependencyMeta};
 use std::{collections::BTreeMap, sync::LazyLock};
 
 // `pnpm_compat_package_extensions.json` holds pnpm-specific entries not in
-// `@yarnpkg/extensions` yet; keep it identical to the TypeScript CLI's
-// `pnpmCompatPackageExtensions`.
+// `@yarnpkg/extensions`: the original three from the TypeScript CLI's
+// `pnpmCompatPackageExtensions`, plus phantom-dependency findings detected
+// by static analysis of published npm packages.
 static COMPAT_PACKAGE_EXTENSIONS: LazyLock<IndexMap<String, PackageExtension>> =
     LazyLock::new(|| {
         let mut extensions = IndexMap::new();

--- a/pnpm/crates/package-manager/src/compat_package_extensions/tests.rs
+++ b/pnpm/crates/package-manager/src/compat_package_extensions/tests.rs
@@ -24,3 +24,38 @@ fn includes_pnpm_specific_compat_entries() {
         Some(&"^3.3.0".to_string()),
     );
 }
+
+/// Verify the 10 phantom-dependency entries detected by static analysis of
+/// the top-500 most-downloaded npm packages. Each entry declares a
+/// dependency the package imports but doesn't declare in its package.json -
+/// a phantom that resolves under npm's flat layout but breaks under a
+/// strict resolver.
+#[test]
+fn includes_phantom_dependency_entries() {
+    let assert_dep = |selector: &str, target: &str| {
+        let entry = COMPAT_PACKAGE_EXTENSIONS
+            .get(selector)
+            .unwrap_or_else(|| panic!("phantom entry {selector} missing"));
+        let dep = entry
+            .dependencies
+            .as_ref()
+            .and_then(|deps| deps.get(target))
+            .unwrap_or_else(|| panic!("phantom target {target} missing from {selector}"));
+        assert_eq!(dep, "*");
+    };
+
+    assert_dep("@eslint-community/eslint-utils@*", "estree");
+    assert_dep("@eslint/core@*", "json-schema");
+    assert_dep("@eslint/eslintrc@*", "eslint");
+    assert_dep("@jest/types@*", "istanbul-lib-coverage");
+    assert_dep("@jest/types@*", "istanbul-reports");
+    assert_dep("@jest/types@*", "yargs");
+    assert_dep("@types/babel__core@*", "@babel/generator");
+    assert_dep("@types/babel__core@*", "@babel/template");
+    assert_dep("@types/babel__core@*", "@babel/traverse");
+    assert_dep("@types/react-dom@*", "react");
+    assert_dep("@types/yargs@*", "yargs-parser");
+    assert_dep("@typescript-eslint/types@*", "typescript");
+    assert_dep("es-abstract@*", "for-each");
+    assert_dep("eslint@*", "estree");
+}

--- a/pnpm/crates/package-manager/src/pnpm_compat_package_extensions.json
+++ b/pnpm/crates/package-manager/src/pnpm_compat_package_extensions.json
@@ -8,6 +8,40 @@
     }
   ],
   [
+    "@eslint-community/eslint-utils@*",
+    {
+      "dependencies": {
+        "estree": "*"
+      }
+    }
+  ],
+  [
+    "@eslint/core@*",
+    {
+      "dependencies": {
+        "json-schema": "*"
+      }
+    }
+  ],
+  [
+    "@eslint/eslintrc@*",
+    {
+      "dependencies": {
+        "eslint": "*"
+      }
+    }
+  ],
+  [
+    "@jest/types@*",
+    {
+      "dependencies": {
+        "istanbul-lib-coverage": "*",
+        "istanbul-reports": "*",
+        "yargs": "*"
+      }
+    }
+  ],
+  [
     "@nuxt/vite-builder@>=4.0.0 <4.5.0",
     {
       "dependencies": {
@@ -20,6 +54,56 @@
     {
       "dependencies": {
         "unplugin": "^3.3.0"
+      }
+    }
+  ],
+  [
+    "@types/babel__core@*",
+    {
+      "dependencies": {
+        "@babel/generator": "*",
+        "@babel/template": "*",
+        "@babel/traverse": "*"
+      }
+    }
+  ],
+  [
+    "@types/react-dom@*",
+    {
+      "dependencies": {
+        "react": "*"
+      }
+    }
+  ],
+  [
+    "@types/yargs@*",
+    {
+      "dependencies": {
+        "yargs-parser": "*"
+      }
+    }
+  ],
+  [
+    "@typescript-eslint/types@*",
+    {
+      "dependencies": {
+        "typescript": "*"
+      }
+    }
+  ],
+  [
+    "es-abstract@*",
+    {
+      "dependencies": {
+        "for-each": "*"
+      }
+    }
+  ],
+  [
+    "eslint@*",
+    {
+      "dependencies": {
+        "estree": "*"
       }
     }
   ]


### PR DESCRIPTION
Syncs pnpm's bundled package-extensions compat database to the latest `@yarnpkg/extensions` and adds phantom-dependency findings detected by static analysis.

<details>
<summary>What changed</summary>

**`compat_package_extensions.json`** — synced from 150 to 158 entries (the latest `@yarnpkg/extensions` 2.0.7). Deep-merged the one duplicate selector (`gatsby-core-utils@<2.14.0-next.1`, which has two bodies in the Yarn source array) so both `@babel/runtime` and `got` survive.

**`pnpm_compat_package_extensions.json`** — added 10 phantom-dependency findings (3 → 13 entries). Each finding is a package that statically imports a dependency it doesn't declare in its `package.json` — a phantom dependency that resolves under npm's flat layout but breaks under a strict resolver. The findings were detected by static analysis of the top-500 most-downloaded npm packages (the [npm-high-impact](https://github.com/wooorm/npm-high-impact) corpus): each package's published code was parsed, its module graph walked from the entry points (`exports`/`main`/`bin`), and every static unguarded `import`/`require` checked against the declared dependencies.

The 10 new entries: `@eslint-community/eslint-utils` → `estree`, `@eslint/core` → `json-schema`, `@eslint/eslintrc` → `eslint`, `@jest/types` → `istanbul-lib-coverage`/`istanbul-reports`/`yargs`, `@types/babel__core` → `@babel/generator`/`@babel/template`/`@babel/traverse`, `@types/react-dom` → `react`, `@types/yargs` → `yargs-parser`, `@typescript-eslint/types` → `typescript`, `es-abstract` → `for-each`, `eslint` → `estree`.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package compatibility handling for popular frameworks and development tools, including React, Vue, Gatsby, Parcel, TypeScript, Webpack, ESLint, Jest, and Babel.
  * Added missing dependency, peer-dependency, and optional peer-dependency metadata to improve package installation and resolution.
  * Added compatibility mappings for common ESLint, Jest, Babel, React, TypeScript, and Yargs tooling packages.
  * Removed obsolete entries and reorganized existing rules for more accurate package management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->