### PR TITLE
fix(cli): keep the escape bytes of nested styles in why and list trees

### DIFF
--- a/.changeset/why-list-colored-labels.md
+++ b/.changeset/why-list-colored-labels.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm why` and `pnpm list` no longer print stray `[90m`-style codes in their trees when the terminal supports colors. The bolded labels — the searched package in `pnpm why`, the project header and the matched package in `pnpm list` — dropped the escape byte of the styles they already carried, leaving the color codes as visible text.

--- a/pnpm/crates/cli/src/cli_args/deps_tree/render.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/render.rs
@@ -206,8 +206,24 @@ pub(crate) fn dim(text: &str) -> String {
     sanitize(text).if_supports_color(Stream::Stdout, |t| t.dimmed()).to_string()
 }
 
-pub(crate) fn bold(text: &str) -> String {
-    sanitize(text).if_supports_color(Stream::Stdout, |t| t.bold()).to_string()
+const BOLD: &str = "\u{1b}[1m";
+const RESET: &str = "\u{1b}[0m";
+
+/// Bold a label that the other helpers of this module already styled and
+/// sanitized.
+///
+/// Sanitizing here would strip the `ESC` of those styles and leave their
+/// bare `[1m` codes in the output, so the label is taken as-is; text that
+/// has not been through a helper yet must be passed through one first.
+/// The nested styles end in a full reset, so the bold is reopened after
+/// each of them to stay in effect through the whole label, the way
+/// `chalk` nests styles for the TypeScript CLI.
+pub(crate) fn bold_styled(styled: &str) -> String {
+    styled
+        .if_supports_color(Stream::Stdout, |text| {
+            format!("{BOLD}{}{RESET}", text.replace(RESET, &format!("{RESET}{BOLD}")))
+        })
+        .to_string()
 }
 
 pub(crate) fn cyan_bright(text: &str) -> String {

--- a/pnpm/crates/cli/src/cli_args/list/render.rs
+++ b/pnpm/crates/cli/src/cli_args/list/render.rs
@@ -12,9 +12,9 @@ use crate::cli_args::deps_tree::{
     DependencyNode,
     build::DependenciesHierarchy,
     render::{
-        ColorFn, LongPkgInfo, PeerVariants, TreeNode, TreeNodeGroup, blue, bold, cyan_bright,
-        deduped_label, dim, gray, name_at_version, peer_hash_suffix, plain, read_long_pkg_info,
-        red, render_archy, yellow,
+        ColorFn, LongPkgInfo, PeerVariants, TreeNode, TreeNodeGroup, blue, bold_styled,
+        cyan_bright, deduped_label, dim, gray, name_at_version, peer_hash_suffix, plain,
+        read_long_pkg_info, red, render_archy, yellow,
     },
 };
 
@@ -120,7 +120,7 @@ fn render_tree_for_project(
         });
     }
 
-    let root_label = bold(&label);
+    let root_label = bold_styled(&label);
     if groups.is_empty() {
         return Some(root_label);
     }
@@ -222,7 +222,7 @@ fn print_label(
     if node.deduped {
         label.push_str(&deduped_label());
     }
-    if node.searched { bold(&label) } else { label }
+    if node.searched { bold_styled(&label) } else { label }
 }
 
 fn find_multi_peer_packages(projects: &[ProjectHierarchy]) -> HashMap<String, usize> {

--- a/pnpm/crates/cli/src/cli_args/why/render.rs
+++ b/pnpm/crates/cli/src/cli_args/why/render.rs
@@ -7,7 +7,7 @@ use std::{collections::HashMap, path::Path};
 use crate::cli_args::deps_tree::{
     dependents::{DependentNode, DependentsTree},
     render::{
-        PeerVariants, TreeNode, bold, circular_label, deduped_label, dim, name_at_version,
+        PeerVariants, TreeNode, bold_styled, circular_label, deduped_label, dim, name_at_version,
         peer_hash_suffix, plain, read_long_pkg_info, render_archy,
     },
 };
@@ -33,7 +33,7 @@ pub(crate) fn render_dependents_tree(
             let displayed_name = tree.display_name.as_deref().unwrap_or(&tree.name);
             let mut root_label_parts = vec![format!(
                 "{}{}",
-                bold(&name_at_version_plain(displayed_name, &tree.version)),
+                bold_styled(&name_at_version_plain(displayed_name, &tree.version)),
                 peer_hash_suffix(
                     &multi_peer_pkgs,
                     &tree.name,
@@ -149,7 +149,7 @@ fn dependents_to_tree_nodes(
                 // An importer (leaf node).
                 format!(
                     "{} {}",
-                    bold(&name_at_version_plain(displayed_name, &dep.version)),
+                    bold_styled(&name_at_version_plain(displayed_name, &dep.version)),
                     dim(&format!("({})", dep_field.as_str())),
                 )
             } else {

--- a/pnpm/crates/cli/tests/suite/_utils/mod.rs
+++ b/pnpm/crates/cli/tests/suite/_utils/mod.rs
@@ -31,6 +31,29 @@ pub fn pacquet_in(workspace: &Path) -> Command {
         .without_ambient_pnpm_config()
 }
 
+/// Make the spawned `pnpm` style its output.
+///
+/// Whether a run carries ANSI styles is otherwise decided by the
+/// inherited `FORCE_COLOR` / `CLICOLOR_FORCE` / `NO_COLOR`, so a
+/// contributor's shell or a CI runner can flip it under a test that
+/// asserts on the styling. [`without_colors`] is the counterpart.
+#[must_use]
+pub fn with_colors(mut command: Command) -> Command {
+    command.env_remove("NO_COLOR");
+    command.env("FORCE_COLOR", "1");
+    command
+}
+
+/// Make the spawned `pnpm` leave its output unstyled. See
+/// [`with_colors`] for why a test pins this.
+#[must_use]
+pub fn without_colors(mut command: Command) -> Command {
+    command.env_remove("FORCE_COLOR");
+    command.env_remove("CLICOLOR_FORCE");
+    command.env("NO_COLOR", "1");
+    command
+}
+
 /// Strip whitespace and box-drawing glyphs out of a miette report so a
 /// substring assertion can't be broken by where the renderer chose to
 /// hard-wrap the message.

--- a/pnpm/crates/cli/tests/suite/list.rs
+++ b/pnpm/crates/cli/tests/suite/list.rs
@@ -600,9 +600,8 @@ fn listing_specific_package_with_lockfile_only() {
     );
 }
 
-/// Styling a label must not mangle the styles it already carries: the
-/// colored tree has to strip back to exactly the uncolored one. The
-/// searched package and the project label are the bolded ones.
+/// Bolding a label must not mangle the styles it already carries; the
+/// project header and a searched package are the bolded ones.
 #[test]
 fn list_styles_the_tree_without_corrupting_it() {
     let (_root, workspace, _registry) = setup_registry();
@@ -627,7 +626,8 @@ fn list_styles_the_tree_without_corrupting_it() {
     assert!(colored.status.success(), "colored list should succeed: {colored:?}");
 
     let colored_stdout = String::from_utf8_lossy(&colored.stdout);
-    assert!(colored_stdout.contains('\u{1b}'), "colors should be on: {colored_stdout:?}");
+    eprintln!("PLAIN:\n{plain}\nCOLORED:\n{colored_stdout}\n");
+    assert!(colored_stdout.contains('\u{1b}'), "colors should be on");
     assert_eq!(strip_ansi_codes(&colored_stdout), plain);
 }
 

--- a/pnpm/crates/cli/tests/suite/list.rs
+++ b/pnpm/crates/cli/tests/suite/list.rs
@@ -1,3 +1,4 @@
+use crate::_utils::{with_colors, without_colors};
 use assert_cmd::cargo::CommandCargoExt;
 use command_extra::CommandExtra;
 use console::strip_ansi_codes;
@@ -600,8 +601,8 @@ fn listing_specific_package_with_lockfile_only() {
     );
 }
 
-/// Bolding a label must not mangle the styles it already carries; the
-/// project header and a searched package are the bolded ones.
+/// The project header and a searched package are the bolded labels,
+/// hence the search argument.
 #[test]
 fn list_styles_the_tree_without_corrupting_it() {
     let (_root, workspace, _registry) = setup_registry();
@@ -618,17 +619,20 @@ fn list_styles_the_tree_without_corrupting_it() {
     .expect("write package.json");
     run_ok(&workspace, &["install", "--lockfile-only"]);
 
-    let plain = run_ok(&workspace, &["list", "--lockfile-only", PKG]);
-    let colored = pacquet_in(&workspace, ["list", "--lockfile-only", PKG])
-        .with_env("FORCE_COLOR", "1")
+    let plain = without_colors(pacquet_in(&workspace, ["list", "--lockfile-only", PKG]))
+        .output()
+        .expect("run pacquet list");
+    assert!(plain.status.success(), "list should succeed: {plain:?}");
+    let colored = with_colors(pacquet_in(&workspace, ["list", "--lockfile-only", PKG]))
         .output()
         .expect("run pacquet list with colors");
     assert!(colored.status.success(), "colored list should succeed: {colored:?}");
 
+    let plain_stdout = String::from_utf8_lossy(&plain.stdout);
     let colored_stdout = String::from_utf8_lossy(&colored.stdout);
-    eprintln!("PLAIN:\n{plain}\nCOLORED:\n{colored_stdout}\n");
+    eprintln!("PLAIN:\n{plain_stdout}\nCOLORED:\n{colored_stdout}\n");
     assert!(colored_stdout.contains('\u{1b}'), "colors should be on");
-    assert_eq!(strip_ansi_codes(&colored_stdout), plain);
+    assert_eq!(strip_ansi_codes(&colored_stdout), plain_stdout);
 }
 
 /// Port of upstream's `correctly report the value of the private field

--- a/pnpm/crates/cli/tests/suite/list.rs
+++ b/pnpm/crates/cli/tests/suite/list.rs
@@ -1,5 +1,6 @@
 use assert_cmd::cargo::CommandCargoExt;
 use command_extra::CommandExtra;
+use console::strip_ansi_codes;
 use pnpm_testing_utils::bin::CommandTempCwd;
 use serde_json::{Value, json};
 use std::{collections::BTreeSet, fs, path::Path, process::Command};
@@ -597,6 +598,37 @@ fn listing_specific_package_with_lockfile_only() {
             "{LEGEND}\n\nproject@0.0.0 {dir}\n\u{2502}\n\u{2502}   dependencies:\n\u{2514}\u{2500}\u{2500} {PKG}@100.0.0\n\n1 package\n"
         ),
     );
+}
+
+/// Styling a label must not mangle the styles it already carries: the
+/// colored tree has to strip back to exactly the uncolored one. The
+/// searched package and the project label are the bolded ones.
+#[test]
+fn list_styles_the_tree_without_corrupting_it() {
+    let (_root, workspace, _registry) = setup_registry();
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "name": "project",
+            "version": "0.0.0",
+            "private": true,
+            "dependencies": { PKG: "100.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    run_ok(&workspace, &["install", "--lockfile-only"]);
+
+    let plain = run_ok(&workspace, &["list", "--lockfile-only", PKG]);
+    let colored = pacquet_in(&workspace, ["list", "--lockfile-only", PKG])
+        .with_env("FORCE_COLOR", "1")
+        .output()
+        .expect("run pacquet list with colors");
+    assert!(colored.status.success(), "colored list should succeed: {colored:?}");
+
+    let colored_stdout = String::from_utf8_lossy(&colored.stdout);
+    assert!(colored_stdout.contains('\u{1b}'), "colors should be on: {colored_stdout:?}");
+    assert_eq!(strip_ansi_codes(&colored_stdout), plain);
 }
 
 /// Port of upstream's `correctly report the value of the private field

--- a/pnpm/crates/cli/tests/suite/why.rs
+++ b/pnpm/crates/cli/tests/suite/why.rs
@@ -1,3 +1,4 @@
+use crate::_utils::{with_colors, without_colors};
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use console::strip_ansi_codes;
@@ -524,17 +525,16 @@ fn why_marks_importer_dep_field_and_prints_summary() {
     );
 }
 
-/// Bolding a label must not mangle the styles it already carries.
 #[test]
 fn why_styles_the_tree_without_corrupting_it() {
     let (_root, workspace, _anchor) = setup();
     write_manifest(&workspace, &format!(r#"{{ "{PKG}": "100.0.0" }}"#));
     pacquet(&workspace, ["install"]).assert().success();
 
-    let plain = pacquet(&workspace, ["why", PKG]).output().expect("run pacquet why");
+    let plain =
+        without_colors(pacquet(&workspace, ["why", PKG])).output().expect("run pacquet why");
     assert!(plain.status.success(), "why should succeed: {plain:?}");
-    let colored = pacquet(&workspace, ["why", PKG])
-        .with_env("FORCE_COLOR", "1")
+    let colored = with_colors(pacquet(&workspace, ["why", PKG]))
         .output()
         .expect("run pacquet why with colors");
     assert!(colored.status.success(), "colored why should succeed: {colored:?}");

--- a/pnpm/crates/cli/tests/suite/why.rs
+++ b/pnpm/crates/cli/tests/suite/why.rs
@@ -1,5 +1,6 @@
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
+use console::strip_ansi_codes;
 use pnpm_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
 use std::{ffi::OsStr, fs, path::Path, process::Command};
 use tempfile::TempDir;
@@ -521,6 +522,26 @@ fn why_marks_importer_dep_field_and_prints_summary() {
             "{PKG}@100.0.0\n\u{2514}\u{2500}\u{2500} project@0.0.0 (devDependencies)\n\nFound 1 version of {PKG}\n"
         ),
     );
+}
+
+/// Styling a label must not mangle the styles it already carries: the
+/// colored tree has to strip back to exactly the uncolored one.
+#[test]
+fn why_styles_the_tree_without_corrupting_it() {
+    let (_root, workspace, _anchor) = setup();
+    write_manifest(&workspace, &format!(r#"{{ "{PKG}": "100.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    let plain = pacquet(&workspace, ["why", PKG]).output().expect("run pacquet why");
+    let colored = pacquet(&workspace, ["why", PKG])
+        .with_env("FORCE_COLOR", "1")
+        .output()
+        .expect("run pacquet why with colors");
+    assert!(colored.status.success(), "colored why should succeed: {colored:?}");
+
+    let colored_stdout = String::from_utf8_lossy(&colored.stdout);
+    assert!(colored_stdout.contains('\u{1b}'), "colors should be on: {colored_stdout:?}");
+    assert_eq!(strip_ansi_codes(&colored_stdout), String::from_utf8_lossy(&plain.stdout));
 }
 
 fn write_finder_pnpmfile(workspace: &Path, message_expr: &str) {

--- a/pnpm/crates/cli/tests/suite/why.rs
+++ b/pnpm/crates/cli/tests/suite/why.rs
@@ -524,8 +524,7 @@ fn why_marks_importer_dep_field_and_prints_summary() {
     );
 }
 
-/// Styling a label must not mangle the styles it already carries: the
-/// colored tree has to strip back to exactly the uncolored one.
+/// Bolding a label must not mangle the styles it already carries.
 #[test]
 fn why_styles_the_tree_without_corrupting_it() {
     let (_root, workspace, _anchor) = setup();
@@ -539,9 +538,11 @@ fn why_styles_the_tree_without_corrupting_it() {
         .expect("run pacquet why with colors");
     assert!(colored.status.success(), "colored why should succeed: {colored:?}");
 
+    let plain_stdout = String::from_utf8_lossy(&plain.stdout);
     let colored_stdout = String::from_utf8_lossy(&colored.stdout);
-    assert!(colored_stdout.contains('\u{1b}'), "colors should be on: {colored_stdout:?}");
-    assert_eq!(strip_ansi_codes(&colored_stdout), String::from_utf8_lossy(&plain.stdout));
+    eprintln!("PLAIN:\n{plain_stdout}\nCOLORED:\n{colored_stdout}\n");
+    assert!(colored_stdout.contains('\u{1b}'), "colors should be on");
+    assert_eq!(strip_ansi_codes(&colored_stdout), plain_stdout);
 }
 
 fn write_finder_pnpmfile(workspace: &Path, message_expr: &str) {

--- a/pnpm/crates/cli/tests/suite/why.rs
+++ b/pnpm/crates/cli/tests/suite/why.rs
@@ -532,6 +532,7 @@ fn why_styles_the_tree_without_corrupting_it() {
     pacquet(&workspace, ["install"]).assert().success();
 
     let plain = pacquet(&workspace, ["why", PKG]).output().expect("run pacquet why");
+    assert!(plain.status.success(), "why should succeed: {plain:?}");
     let colored = pacquet(&workspace, ["why", PKG])
         .with_env("FORCE_COLOR", "1")
         .output()


### PR DESCRIPTION
## Summary

`pnpm why` and `pnpm list` printed stray SGR codes as visible text whenever the terminal supports colors:

```
jsdoc-type-pratt-parser[90m@7.3.0[39m
└─┬ eslint-plugin-regexp@3.1.1
  └── monorepo-root (devDependencies)
```

The color helpers in `pnpm/crates/cli/src/cli_args/deps_tree/render.rs` sanitize their input before styling it, which strips control characters — the `ESC` of an escape sequence included. Both commands bolded labels that the other helpers had *already* styled, so every nested sequence lost its `ESC` and its payload (`[90m`, `[2m`, `[0m`) survived as text. Four call sites were affected: the searched package and the importer leaves in `why`, and the project header and the matched package in `list` (`^[[1m[2m/path/to/project[0m^[[0m`).

Bolding a composed label now goes through `bold_styled`, which takes the label as-is and reopens the bold after each nested reset — the nesting behavior `chalk` gives the TypeScript CLI. Sanitizing still happens where raw text enters a label, so the ANSI-injection guard on store-derived names, versions, paths, and descriptions is unchanged.

Rust-only: `chalk` handles nesting itself and the TypeScript color helpers do not sanitize, so the TypeScript CLI never had this bug and needs no matching change.

## Squash Commit Body

```text
The color helpers in `deps_tree/render.rs` sanitize their input before
styling it, which strips control characters — the `ESC` of an escape
sequence included. `why` and `list` bolded labels the other helpers had
already styled, so the nested sequences lost their `ESC` and their bare
SGR codes reached the terminal as text: the searched package printed as
`jsdoc-type-pratt-parser[90m@7.3.0[39m`, the project header of `list` as
`[2m/path/to/project[0m`.

Bolding a composed label now goes through `bold_styled`, which takes the
label as-is and reopens the bold after each nested reset, the way chalk
nests styles for the TypeScript CLI. Sanitizing still happens where raw
text enters a label.

chalk handles nesting on its own, so the TypeScript CLI never had this
bug and needs no matching change.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

Each new test runs the command twice — once with `FORCE_COLOR=1`, once plain — and asserts the colored output strips back to exactly the uncolored one. Both fail on the previous code, reproducing the `[90m@100.0.0[39m` corruption verbatim.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789588362&installation_model_id=426870&pr_number=13973&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13973&signature=bd49293468418486ac9a07feec22667bc6db3834e717030a483460aa938ca386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed stray color escape text in `pnpm list` and `pnpm why` output when colors are enabled.
  - Preserved bold and other label styling across nested colored output.
  - Ensured colored output matches the corresponding uncolored text when ANSI formatting is removed.

- **Tests**
  - Added regression coverage for colored `list` and `why` command output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->