### PR TITLE
fix(outdated): dereference catalog specifiers before the registry query

### DIFF
--- a/.changeset/outdated-resolves-catalog-specifiers.md
+++ b/.changeset/outdated-resolves-catalog-specifiers.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm outdated` and `pnpm update --interactive` now dereference `catalog:` specifiers before querying the registry. A catalog entry that is an npm alias (`'@types/zkochan__table': npm:@types/table@6.3.2`) no longer fails with `ERR_PNPM_OUTDATED_REGISTRY_ERROR` for the alias key, and `outdated --compatible` compares against the range the catalog holds instead of skipping the dependency. When a packument request does fail, the reported reason is now the registry's HTTP status (`404 Not Found`) rather than "error decoding response body".
+`pnpm outdated` and `pnpm update --interactive` now dereference `catalog:` specifiers before querying the registry. A catalog entry that is an npm alias (`'@types/zkochan__table': npm:@types/table@6.3.2`) no longer fails with `ERR_PNPM_OUTDATED_REGISTRY_ERROR` for the alias key, and `outdated --compatible` compares against the range the catalog holds instead of skipping the dependency.

--- a/.changeset/outdated-resolves-catalog-specifiers.md
+++ b/.changeset/outdated-resolves-catalog-specifiers.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm outdated` and `pnpm update --interactive` now dereference `catalog:` specifiers before querying the registry. A catalog entry that is an npm alias (`'@types/zkochan__table': npm:@types/table@6.3.2`) no longer fails with `ERR_PNPM_OUTDATED_REGISTRY_ERROR` for the alias key, and `outdated --compatible` compares against the range the catalog holds instead of skipping the dependency. When a packument request does fail, the reported reason is now the registry's HTTP status (`404 Not Found`) rather than "error decoding response body".

--- a/.changeset/packument-status-before-decode.md
+++ b/.changeset/packument-status-before-decode.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+A failed packument request now reports the status the registry returned (`404 Not Found`) instead of "error decoding response body".

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4310,6 +4310,7 @@ dependencies = [
  "pnpm-auth-commands",
  "pnpm-catalogs-config",
  "pnpm-catalogs-protocol-parser",
+ "pnpm-catalogs-resolver",
  "pnpm-catalogs-types",
  "pnpm-cmd-shim",
  "pnpm-config",

--- a/pnpm/crates/cli/Cargo.toml
+++ b/pnpm/crates/cli/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/bin/main.rs"
 pnpm-auth-commands                     = { workspace = true }
 pnpm-catalogs-config                   = { workspace = true }
 pnpm-catalogs-protocol-parser          = { workspace = true }
+pnpm-catalogs-resolver                 = { workspace = true }
 pnpm-catalogs-types                    = { workspace = true }
 pnpm-cmd-shim                          = { workspace = true }
 pnpm-crypto-hash                       = { workspace = true }

--- a/pnpm/crates/cli/src/cli_args.rs
+++ b/pnpm/crates/cli/src/cli_args.rs
@@ -7,6 +7,7 @@ pub mod bugs;
 pub mod cache;
 pub mod cat_file;
 pub mod cat_index;
+pub(crate) mod catalogs;
 pub mod change;
 pub mod changelog;
 pub mod ci;

--- a/pnpm/crates/cli/src/cli_args/catalogs.rs
+++ b/pnpm/crates/cli/src/cli_args/catalogs.rs
@@ -1,0 +1,27 @@
+//! The catalogs a command dereferences `catalog:` specifiers against.
+
+use miette::{Context, IntoDiagnostic};
+use pnpm_catalogs_config::get_catalogs_from_workspace_manifest;
+use pnpm_catalogs_types::Catalogs;
+use pnpm_config::Config;
+use pnpm_workspace::read_workspace_manifest;
+
+/// The hook-injected set when an `updateConfig` pnpmfile provided one
+/// ([`Config::catalogs`] is `Some`), otherwise the `catalog:` /
+/// `catalogs:` tables of the workspace manifest — the same fallback the
+/// install performs. Empty outside a workspace, where no catalog can be
+/// declared.
+pub(crate) fn configured_catalogs(config: &Config) -> miette::Result<Catalogs> {
+    if let Some(catalogs) = &config.catalogs {
+        return Ok(catalogs.clone());
+    }
+    let Some(workspace_dir) = config.workspace_dir.as_deref() else {
+        return Ok(Catalogs::default());
+    };
+    let workspace_manifest = read_workspace_manifest(workspace_dir)
+        .into_diagnostic()
+        .wrap_err("read the workspace manifest for catalogs")?;
+    get_catalogs_from_workspace_manifest(workspace_manifest.as_ref())
+        .into_diagnostic()
+        .wrap_err("read the workspace catalogs")
+}

--- a/pnpm/crates/cli/src/cli_args/outdated.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated.rs
@@ -28,6 +28,7 @@ use clap::{Args, ValueEnum};
 use miette::IntoDiagnostic;
 use node_semver::Version;
 use owo_colors::{OwoColorize, Stream};
+use pnpm_catalogs_protocol_parser::parse_catalog_protocol;
 use pnpm_catalogs_resolver::{CatalogResolutionResult, WantedDependency, resolve_from_catalog};
 use pnpm_catalogs_types::Catalogs;
 use pnpm_config::{
@@ -296,6 +297,12 @@ fn dereference_catalog<'a>(
     alias: &str,
     bare_specifier: &'a str,
 ) -> miette::Result<Cow<'a, str>> {
+    // Most dependencies are not catalog entries, and every walked
+    // dependency reaches this, so screen them out before the resolver's
+    // owned `WantedDependency`.
+    if parse_catalog_protocol(bare_specifier).is_none() {
+        return Ok(Cow::Borrowed(bare_specifier));
+    }
     let wanted =
         WantedDependency { alias: alias.to_string(), bare_specifier: bare_specifier.to_string() };
     match resolve_from_catalog(catalogs, &wanted) {

--- a/pnpm/crates/cli/src/cli_args/outdated.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated.rs
@@ -18,6 +18,7 @@
 use crate::{
     State,
     cli_args::{
+        catalogs::configured_catalogs,
         recursive::{AutoExcludeRoot, discover_workspace_projects, select_recursive_projects},
         sanitize::sanitize_inline,
     },
@@ -27,6 +28,8 @@ use clap::{Args, ValueEnum};
 use miette::IntoDiagnostic;
 use node_semver::Version;
 use owo_colors::{OwoColorize, Stream};
+use pnpm_catalogs_resolver::{CatalogResolutionResult, WantedDependency, resolve_from_catalog};
+use pnpm_catalogs_types::Catalogs;
 use pnpm_config::{
     Config,
     matcher::{Matcher, create_matcher},
@@ -38,6 +41,7 @@ use pnpm_registry::{Package, PackageVersion, RegistryError};
 use pnpm_reporter::Reporter;
 use pnpm_resolving_npm_resolver::pick_registry_for_package;
 use std::{
+    borrow::Cow,
     collections::HashMap,
     io::Write,
     path::PathBuf,
@@ -46,6 +50,24 @@ use std::{
 use tokio::sync::OnceCell;
 
 type PackumentCache = Mutex<HashMap<(String, String), Arc<OnceCell<Arc<Package>>>>>;
+
+/// State shared by every importer inspected in one `outdated` (or
+/// `update --interactive`) run: the packument memo, so a dependency
+/// several workspace projects share is fetched once, and the catalogs
+/// their `catalog:` specifiers dereference against.
+pub(crate) struct OutdatedRun {
+    packument_cache: PackumentCache,
+    catalogs: Catalogs,
+}
+
+impl OutdatedRun {
+    pub(crate) fn new(config: &Config) -> miette::Result<Self> {
+        Ok(Self {
+            packument_cache: PackumentCache::default(),
+            catalogs: configured_catalogs(config)?,
+        })
+    }
+}
 
 /// Which registry version a dependency is compared against to decide
 /// whether it is outdated.
@@ -156,26 +178,26 @@ pub(crate) async fn collect_outdated_for_importer(
     http_client: &ThrottledClient,
     query: &OutdatedQuery<'_>,
 ) -> miette::Result<Vec<OutdatedPackage>> {
-    collect_outdated_for_importer_with_cache(
+    collect_outdated_for_importer_in_run(
         manifest,
         lockfile,
         importer_id,
         config,
         http_client,
         query,
-        &PackumentCache::default(),
+        &OutdatedRun::new(config)?,
     )
     .await
 }
 
-async fn collect_outdated_for_importer_with_cache(
+pub(crate) async fn collect_outdated_for_importer_in_run(
     manifest: &PackageManifest,
     lockfile: Option<&Lockfile>,
     importer_id: &str,
     config: &Config,
     http_client: &ThrottledClient,
     query: &OutdatedQuery<'_>,
-    packument_cache: &PackumentCache,
+    run: &OutdatedRun,
 ) -> miette::Result<Vec<OutdatedPackage>> {
     let current_versions =
         current_versions_from_importer(lockfile, importer_id, query.include_direct);
@@ -214,14 +236,15 @@ async fn collect_outdated_for_importer_with_cache(
             })
         })
         .map(|(alias, group, bare_specifier, current)| async move {
+            let bare_specifier = dereference_catalog(&run.catalogs, alias, bare_specifier)?;
             let (package_name, range) =
-                PackageManifest::resolve_registry_dependency(alias, bare_specifier);
+                PackageManifest::resolve_registry_dependency(alias, &bare_specifier);
             let registries: HashMap<String, String> =
                 config.resolved_registries().into_iter().collect();
             let registry =
-                pick_registry_for_package(&registries, package_name, Some(bare_specifier));
+                pick_registry_for_package(&registries, package_name, Some(&bare_specifier));
             let package = fetch_package_cached(
-                packument_cache,
+                &run.packument_cache,
                 package_name,
                 http_client,
                 &registry,
@@ -262,6 +285,26 @@ async fn collect_outdated_for_importer_with_cache(
         .into_iter()
         .collect::<miette::Result<Vec<_>>>()?;
     Ok(fetched.into_iter().flatten().collect())
+}
+
+/// Replace a `catalog:` specifier with the specifier the catalog holds,
+/// so both the queried package name and the `--compatible` range come
+/// from the catalog entry — which may itself be an npm alias
+/// (`npm:@types/table@^6`). Any other specifier passes through.
+fn dereference_catalog<'a>(
+    catalogs: &Catalogs,
+    alias: &str,
+    bare_specifier: &'a str,
+) -> miette::Result<Cow<'a, str>> {
+    let wanted =
+        WantedDependency { alias: alias.to_string(), bare_specifier: bare_specifier.to_string() };
+    match resolve_from_catalog(catalogs, &wanted) {
+        CatalogResolutionResult::Found(found) => Ok(Cow::Owned(found.resolution.specifier)),
+        CatalogResolutionResult::Misconfiguration(misconfiguration) => {
+            Err(miette::Report::new(misconfiguration.error))
+        }
+        CatalogResolutionResult::Unused => Ok(Cow::Borrowed(bare_specifier)),
+    }
 }
 
 async fn fetch_package_cached(
@@ -588,7 +631,7 @@ impl OutdatedArgs {
             };
             project_inputs.push((project_dir, project, project_lockfile));
         }
-        let packument_cache = PackumentCache::default();
+        let run = OutdatedRun::new(config)?;
         let project_queries =
             project_inputs.iter().map(|(project_dir, project, project_lockfile)| async {
                 let (lockfile, importer_id) = if config.shared_workspace_lockfile {
@@ -607,14 +650,14 @@ impl OutdatedArgs {
                     };
                     return Err(no_lockfile_error(lockfile_dir));
                 };
-                let project_outdated = collect_outdated_for_importer_with_cache(
+                let project_outdated = collect_outdated_for_importer_in_run(
                     &project.manifest,
                     Some(lockfile),
                     &importer_id,
                     config,
                     &state.http_client,
                     &query,
-                    &packument_cache,
+                    &run,
                 )
                 .await?;
                 let dependent = DependentProject {

--- a/pnpm/crates/cli/src/cli_args/pack.rs
+++ b/pnpm/crates/cli/src/cli_args/pack.rs
@@ -10,12 +10,15 @@
 //! `embedReadme` / `extraEnv` config keys are not surfaced by `Config`
 //! yet, so they take their `false` / empty defaults.
 
-use crate::cli_args::recursive::{
-    AutoExcludeRoot, discover_workspace_projects, select_recursive_projects, sort_filtered_projects,
+use crate::cli_args::{
+    catalogs::configured_catalogs,
+    recursive::{
+        AutoExcludeRoot, discover_workspace_projects, select_recursive_projects,
+        sort_filtered_projects,
+    },
 };
 use clap::Args;
-use miette::{Context, IntoDiagnostic};
-use pnpm_catalogs_config::get_catalogs_from_workspace_manifest;
+use miette::Context;
 use pnpm_catalogs_types::Catalogs;
 use pnpm_config::Config;
 use pnpm_hooks::PnpmfileHooks;
@@ -23,7 +26,6 @@ use pnpm_pack::{
     Host, PackError, PackOptions, PackResultJson, api, format_pack_output, to_pack_result_json,
 };
 use pnpm_reporter::Reporter;
-use pnpm_workspace::read_workspace_manifest;
 use std::{
     path::{Path, PathBuf},
     sync::Arc,
@@ -34,26 +36,6 @@ use std::{
 /// underlying pack diagnostic instead of this wrapper, so the two sites must
 /// share one definition.
 pub(crate) const PACK_ERROR_CONTEXT: &str = "pack the package";
-
-/// The catalogs `catalog:` specifiers resolve against when packing a
-/// package for `pack` / `publish`: the hook-injected set when an
-/// `updateConfig` pnpmfile provided one ([`Config::catalogs`] is `Some`),
-/// otherwise the `catalog:` / `catalogs:` tables of the workspace
-/// manifest — the same fallback the install performs.
-pub(crate) fn pack_catalogs(config: &Config) -> miette::Result<Catalogs> {
-    if let Some(catalogs) = &config.catalogs {
-        return Ok(catalogs.clone());
-    }
-    let Some(workspace_dir) = config.workspace_dir.as_deref() else {
-        return Ok(Catalogs::default());
-    };
-    let workspace_manifest = read_workspace_manifest(workspace_dir)
-        .into_diagnostic()
-        .wrap_err("read the workspace manifest for catalogs")?;
-    get_catalogs_from_workspace_manifest(workspace_manifest.as_ref())
-        .into_diagnostic()
-        .wrap_err("read the workspace catalogs")
-}
 
 /// Create a tarball from a package.
 #[derive(Debug, Args)]
@@ -107,7 +89,7 @@ impl PackArgs {
             let mut options = self.pack_options(
                 dir.to_path_buf(),
                 config,
-                pack_catalogs(config)?,
+                configured_catalogs(config)?,
                 self.out.clone(),
                 self.pack_destination.clone(),
                 crate::config_deps::load_before_packing_hooks(config, pnpmfile_root),
@@ -155,7 +137,7 @@ impl PackArgs {
         // to the CLI dir), so every tarball lands in one place regardless
         // of each project's own root.
         let (out, pack_destination) = self.resolve_recursive_destination(dir);
-        let catalogs = pack_catalogs(config)?;
+        let catalogs = configured_catalogs(config)?;
         // Load the pnpmfiles once for the whole workspace (they live at the
         // workspace root); cloning the Arcs into each project shares one
         // worker per pnpmfile instead of re-spawning it per packed project.

--- a/pnpm/crates/cli/src/cli_args/publish.rs
+++ b/pnpm/crates/cli/src/cli_args/publish.rs
@@ -300,7 +300,7 @@ impl PublishArgs {
             crate::config_deps::load_before_packing_hooks(config, pnpmfile_root);
         let mut options = PackOptions {
             dir: dir.to_path_buf(),
-            catalogs: crate::cli_args::pack::pack_catalogs(config)?,
+            catalogs: crate::cli_args::catalogs::configured_catalogs(config)?,
             ignore_scripts: self.should_ignore_scripts(config),
             unsafe_perm: config.unsafe_perm,
             embed_readme: false,

--- a/pnpm/crates/cli/src/cli_args/update_interactive.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive.rs
@@ -17,7 +17,10 @@
 
 use crate::{
     cli_args::{
-        outdated::{OutdatedPackage, OutdatedQuery, TargetVersion, collect_outdated_for_importer},
+        outdated::{
+            OutdatedPackage, OutdatedQuery, OutdatedRun, TargetVersion,
+            collect_outdated_for_importer, collect_outdated_for_importer_in_run,
+        },
         pipelines::InstallFamilySelection,
         sanitize::sanitize_inline,
     },
@@ -257,14 +260,18 @@ async fn collect_choices(
         match_names: None,
         include_deprecated: false,
     };
+    // One run for the whole workspace, so the projects share both the
+    // catalogs read and the packument memo.
+    let run = OutdatedRun::new(config)?;
     let choices = futures_util::future::join_all(projects.iter().map(|project| {
-        collect_outdated_for_importer(
+        collect_outdated_for_importer_in_run(
             project.manifest,
             lockfile,
             &project.importer_id,
             config,
             http_client,
             &query,
+            &run,
         )
     }))
     .await;

--- a/pnpm/crates/cli/src/cli_args/update_interactive.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive.rs
@@ -260,8 +260,6 @@ async fn collect_choices(
         match_names: None,
         include_deprecated: false,
     };
-    // One run for the whole workspace, so the projects share both the
-    // catalogs read and the packument memo.
     let run = OutdatedRun::new(config)?;
     let choices = futures_util::future::join_all(projects.iter().map(|project| {
         collect_outdated_for_importer_in_run(

--- a/pnpm/crates/cli/src/cli_args/update_interactive/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive/tests.rs
@@ -109,7 +109,7 @@ importers:
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(package_body("foo", &registry))
-        .expect(2)
+        .expect(1)
         .create_async()
         .await;
     let mut config = Config::new();
@@ -169,7 +169,7 @@ importers:
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(package_body("foo", &registry))
-        .expect(2)
+        .expect(1)
         .create_async()
         .await;
     let mut config = Config::new();

--- a/pnpm/crates/cli/tests/suite/outdated.rs
+++ b/pnpm/crates/cli/tests/suite/outdated.rs
@@ -1,3 +1,4 @@
+use crate::_utils::append_workspace_yaml_key;
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pnpm_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
@@ -412,6 +413,50 @@ fn outdated_npm_alias_reports_real_name() {
     assert_eq!(output.status.code(), Some(1));
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains(FOO), "report should use the real package name: {stdout}");
+
+    drop((root, anchor));
+}
+
+/// A `catalog:` dependency is checked against the specifier the catalog
+/// holds, so an npm-aliased catalog entry is reported under the real
+/// registry name instead of failing on the alias key.
+#[test]
+fn outdated_catalog_npm_alias_reports_real_name() {
+    let (root, workspace, anchor) = setup();
+
+    append_workspace_yaml_key(&workspace, "catalog", format!("{{ positive: 'npm:{FOO}@^1.0.0' }}"));
+    write_manifest(&workspace, r#"{ "positive": "catalog:" }"#);
+    pacquet(&workspace, ["install"]).assert().success();
+
+    let output = pacquet(&workspace, ["outdated"]).output().expect("run pacquet outdated");
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains(FOO), "report should use the catalog entry's package name: {stdout}");
+
+    drop((root, anchor));
+}
+
+/// `--compatible` compares against the range the catalog entry holds.
+#[test]
+fn outdated_compatible_uses_the_catalog_range() {
+    let (root, workspace, anchor) = setup();
+
+    append_workspace_yaml_key(&workspace, "catalog", format!("{{ '{DEP}': '100.0.0' }}"));
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "catalog:" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    // Widening the catalog range without reinstalling leaves the lockfile
+    // pinned at 100.0.0 while 100.1.0 is now in range.
+    let workspace_yaml = workspace.join("pnpm-workspace.yaml");
+    let yaml = fs::read_to_string(&workspace_yaml).expect("read pnpm-workspace.yaml");
+    fs::write(&workspace_yaml, yaml.replace("'100.0.0'", "'^100.0.0'"))
+        .expect("widen the catalog range");
+
+    let output =
+        pacquet(&workspace, ["outdated", "--compatible"]).output().expect("run pacquet outdated");
+    assert_eq!(output.status.code(), Some(1), "the in-range 100.1.0 should be reported");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("100.1.0"), "report should show the in-range version: {stdout}");
 
     drop((root, anchor));
 }

--- a/pnpm/crates/registry/src/package.rs
+++ b/pnpm/crates/registry/src/package.rs
@@ -199,6 +199,11 @@ impl Package {
             .send()
             .await
             .map_err(network_error)?
+            // A registry answers an unknown package with a JSON error
+            // body, which would otherwise surface as a decode failure
+            // instead of the status the registry actually returned.
+            .error_for_status()
+            .map_err(network_error)?
             .json::<Package>()
             .await
             .map_err(network_error)?

--- a/pnpm/crates/registry/src/package.rs
+++ b/pnpm/crates/registry/src/package.rs
@@ -199,9 +199,8 @@ impl Package {
             .send()
             .await
             .map_err(network_error)?
-            // A registry answers an unknown package with a JSON error
-            // body, which would otherwise surface as a decode failure
-            // instead of the status the registry actually returned.
+            // An unknown package answers with a JSON error body, which
+            // decodes into neither a `Package` nor a useful message.
             .error_for_status()
             .map_err(network_error)?
             .json::<Package>()

--- a/pnpm/crates/registry/src/package/tests.rs
+++ b/pnpm/crates/registry/src/package/tests.rs
@@ -106,6 +106,33 @@ async fn fetch_from_registry_attaches_authorization_header() {
     mock.assert_async().await;
 }
 
+#[tokio::test]
+async fn fetch_from_registry_reports_the_status_of_an_unknown_package() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/acme")
+        .with_status(404)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"error":"Not found"}"#)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let registry = format!("{}/", server.url());
+    let error = Package::fetch_from_registry(
+        "acme",
+        &ThrottledClient::default(),
+        &registry,
+        &AuthHeaders::default(),
+    )
+    .await
+    .expect_err("a 404 packument is not a package");
+
+    let message = error.to_string();
+    assert!(message.contains("404"), "{message}");
+    mock.assert_async().await;
+}
+
 fn package_with_versions(name: &str, versions: &[&str], latest: &str) -> Package {
     let versions_map = versions
         .iter()

--- a/pnpm/crates/registry/src/package_version.rs
+++ b/pnpm/crates/registry/src/package_version.rs
@@ -269,6 +269,9 @@ impl PackageVersion {
             .send()
             .await
             .map_err(network_error)?
+            // See the same guard in `Package::fetch_from_registry`.
+            .error_for_status()
+            .map_err(network_error)?
             .json::<PackageVersion>()
             .await
             .map_err(network_error)?


### PR DESCRIPTION
## Summary

`pnpm outdated -r` in this repo's own workspace fails outright:

```
Error: ERR_PNPM_OUTDATED_REGISTRY_ERROR

  × Failed to fetch metadata for "@types/zkochan__table": Failed to request
  │ https://registry.npmjs.org/@types%2Fzkochan__table: error decoding response body
```

`collect_outdated` passed the manifest's raw bare specifier to the registry, so a
`catalog:` entry was never dereferenced. Our catalog holds an npm alias —
`'@types/zkochan__table': npm:@types/table@6.3.2` — so pacquet asked npm for the
alias key, got a 404, and aborted the whole recursive run. The same gap made
`outdated --compatible` silently drop every `catalog:` dependency, because
`catalog:` is not a semver range and the range parse failed.

The fix resolves the specifier through `pnpm-catalogs-resolver` before
`resolve_registry_dependency`, the way the TypeScript CLI's `outdated` already
does (`replaceCatalogProtocolIfNecessary` in
`deps/inspection/outdated/src/outdated.ts`), so the catalog entry decides the
package name queried, the registry routed to, and the range compared against.

Rust-only: the TypeScript side already had this, so there is nothing to port.

Also in here, from the same debugging session: a packument fetch decoded the
response body without checking the status, which is why a plain 404 surfaced as
"error decoding response body". Both registry fetchers now check the status
first.

## Squash Commit Body

```text
`outdated` (and the `update --interactive` list behind it) sent the manifest's
raw bare specifier to the registry, so a `catalog:` entry was never
dereferenced. An npm-aliased catalog entry — the shape this repo itself uses,
'@types/zkochan__table': npm:@types/table@6.3.2 — was then requested under its
alias key and failed the whole command with ERR_PNPM_OUTDATED_REGISTRY_ERROR,
while `--compatible` silently dropped every catalog dependency because
`catalog:` is not a semver range.

Resolve the specifier through pnpm-catalogs-resolver first, the way the
TypeScript CLI's `outdated` already does, so the catalog entry decides the
package name queried, the registry routed to, and the range compared against.
The catalogs and the packument memo now travel together as one per-run value,
shared across every importer an interactive update walks; the "hook catalogs,
else workspace manifest" lookup that `pack` and `publish` kept privately moves
to a shared helper.

A packument request also skipped its status check, so the registry's 404 for
the missing package surfaced as "error decoding response body"; check the
status before decoding in both registry fetchers.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13974"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789588420&installation_model_id=426870&pr_number=13974&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13974&signature=42f8be073f9c29b9ef0289f654938d8be75c3ce03dfa58b0291a730fef11dfa9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `outdated` and interactive updates now resolve `catalog:` dependency ranges, including npm aliases and compatible-version checks.
  * Catalog configuration is consistently supported when packing, publishing, and processing workspaces.
* **Bug Fixes**
  * Registry failures now report clear HTTP status and network errors instead of JSON parsing errors.
  * Unused catalog entries remain supported without affecting results.
* **Documentation**
  * Added release documentation for catalog resolution and improved registry error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->