### PR TITLE
test(outdated): cover the missing catalog entry of a walked dependency

### DIFF
--- a/pnpm/crates/cli/tests/suite/outdated.rs
+++ b/pnpm/crates/cli/tests/suite/outdated.rs
@@ -461,6 +461,33 @@ fn outdated_compatible_uses_the_catalog_range() {
     drop((root, anchor));
 }
 
+/// A dependency left on `catalog:` after its catalog entry is gone
+/// fails with pnpm's catalog error, not with whatever the registry
+/// answers for the bare dependency key.
+#[test]
+fn outdated_catalog_entry_missing_is_a_catalog_error() {
+    let (root, workspace, anchor) = setup();
+
+    append_workspace_yaml_key(&workspace, "catalog", format!("{{ '{DEP}': '^100.0.0' }}"));
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "catalog:" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    let workspace_yaml = workspace.join("pnpm-workspace.yaml");
+    let yaml = fs::read_to_string(&workspace_yaml).expect("read pnpm-workspace.yaml");
+    let without_catalog =
+        yaml.lines().filter(|line| !line.starts_with("catalog:")).collect::<Vec<_>>().join("\n");
+    fs::write(&workspace_yaml, without_catalog).expect("drop the catalog entry");
+
+    let output = pacquet(&workspace, ["outdated"]).output().expect("run pacquet outdated");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC"),
+        "missing catalog entry should be reported as such: {stderr}",
+    );
+
+    drop((root, anchor));
+}
+
 /// `--prod` and `--dev` restrict the report to the matching dependency
 /// group. Ports pnpm's "showing only prod or dev dependencies".
 #[test]

--- a/pnpm/crates/cli/tests/suite/outdated.rs
+++ b/pnpm/crates/cli/tests/suite/outdated.rs
@@ -480,6 +480,7 @@ fn outdated_catalog_entry_missing_is_a_catalog_error() {
 
     let output = pacquet(&workspace, ["outdated"]).output().expect("run pacquet outdated");
     let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(output.status.code(), Some(1), "the run should fail: {stderr}");
     assert!(
         stderr.contains("ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC"),
         "missing catalog entry should be reported as such: {stderr}",


### PR DESCRIPTION
## Summary

Follow-up to pnpm/pnpm#13974, which landed before this last test was pushed.

That PR made `outdated` dereference `catalog:` specifiers, which gave the walk a
third outcome it had not had before: a dependency whose `catalog:` specifier has
no matching catalog entry now raises pnpm's catalog error. Nothing covered that
branch. This adds the case — install with a catalog entry, delete the entry, run
`outdated` — and asserts `ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC` rather than
whatever the registry answers for the bare dependency key.

Test-only, so no changeset and nothing to port to the TypeScript CLI (its
`outdated` rethrows the same misconfiguration through
`matchCatalogResolveResult`).

## Squash Commit Body

```text
A dependency still on `catalog:` after its catalog entry is deleted must fail
with pnpm's catalog error rather than querying the registry for the bare
dependency key. The branch arrived with the catalog dereference in
pnpm/pnpm#13974 and was the one outcome of `dereference_catalog` left uncovered.
```

## Checklist

- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789590010&installation_model_id=426870&pr_number=13977&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13977&signature=972f92fd18fdccc044c99acd92ef9a0ff06dc7fb7013d58d8d4c0220775a2421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when a dependency references a removed catalog entry.
  * The correct catalog-entry-not-found error is now reported instead of attempting an unnecessary registry lookup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->