### PR TITLE
fix: absorb an override change under an unchanged `catalog:` override

### DIFF
--- a/.changeset/spicy-hoops-brake.md
+++ b/.changeset/spicy-hoops-brake.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.deps-installer": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+An override change is now absorbed by the fast lockfile update even when another, unchanged override uses the `catalog:` protocol. Previously any `catalog:`-valued override forced a full re-resolution whenever the override list changed, which could move unrelated packages in the lockfile (for example after `pnpm audit --fix` added an override).

--- a/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
@@ -312,6 +312,70 @@ fn dependency_removal_override_prunes_the_locked_subtree_without_resolving() {
     drop((root, mock_instance));
 }
 
+/// A changed override is absorbed even though an unchanged override's
+/// configured value is a `catalog:` reference. Override values are
+/// compared catalog-resolved, so with the catalogs settled the
+/// `catalog:` override shows no drift and only the added removal is
+/// applied — which the dead registry proves needs no resolution.
+#[test]
+fn removal_override_composes_with_a_settled_catalog_override() {
+    let CommandTempCwd { workspace, root, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, npmrc_path, .. } = npmrc_info;
+    let manifest_path = workspace.join("package.json");
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    fs::write(
+        &manifest_path,
+        serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pkg-with-good-optional": "1.0.0",
+                "@pnpm.e2e/bar": "catalog:"
+            }
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    let workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    fs::write(
+        &workspace_yaml_path,
+        format!(
+            "{workspace_yaml}trustLockfile: true\ncatalog:\n  '@pnpm.e2e/bar': 100.0.0\n  '@pnpm.e2e/foo': 1.0.0\noverrides:\n  '@pnpm.e2e/foo': 'catalog:'\n"
+        ),
+    )
+    .expect("write the settled catalog override");
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    let workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    fs::write(&workspace_yaml_path, format!("{workspace_yaml}  is-positive: '-'\n"))
+        .expect("add dependency removal override");
+    let dead_registry = dead_registry_url();
+    let npmrc = fs::read_to_string(&npmrc_path).expect("read .npmrc");
+    let npmrc = npmrc
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("registry="))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(&npmrc_path, format!("registry={dead_registry}\n{npmrc}\n"))
+        .expect("rewrite .npmrc with a dead registry");
+
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    let wanted = pnpm_lockfile::Lockfile::load_wanted_from_dir(&workspace)
+        .expect("load updated wanted lockfile")
+        .expect("updated wanted lockfile");
+    let overrides = wanted.overrides.as_ref().expect("recorded overrides");
+    assert_eq!(overrides["@pnpm.e2e/foo"], "1.0.0");
+    assert_eq!(overrides["is-positive"], "-");
+    let removed_key = "is-positive@1.0.0".parse().expect("removed package key");
+    assert!(
+        wanted.snapshots.as_ref().is_none_or(|snapshots| !snapshots.contains_key(&removed_key)),
+    );
+
+    drop((root, mock_instance));
+}
+
 /// An override on a cataloged package replaces the `catalog:` specifier
 /// outright, so the entry is dropped rather than moved. The seed only
 /// feeds the resolver — the catalogs section is rebuilt from what the

--- a/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
@@ -340,7 +340,7 @@ fn removal_override_composes_with_a_settled_catalog_override() {
     fs::write(
         &workspace_yaml_path,
         format!(
-            "{workspace_yaml}trustLockfile: true\ncatalog:\n  '@pnpm.e2e/bar': 100.0.0\n  '@pnpm.e2e/foo': 1.0.0\noverrides:\n  '@pnpm.e2e/foo': 'catalog:'\n"
+            "{workspace_yaml}trustLockfile: true\ncatalog:\n  '@pnpm.e2e/bar': 100.0.0\n  '@pnpm.e2e/foo': 1.0.0\noverrides:\n  '@pnpm.e2e/foo': 'catalog:'\n",
         ),
     )
     .expect("write the settled catalog override");

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolve.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolve.rs
@@ -294,16 +294,20 @@ pub(super) async fn lockfile_reuse_seed(inputs: ReuseSeedInputs<'_>) -> Option<A
         super::overrides_match(lockfile.overrides.as_ref(), resolved_overrides);
 
     let rewrite_manifest_hook = super::compose_manifest_hooks(manifest_hook, overrides_hook);
-    // An override whose value is a `catalog:` reference is only meaningful
-    // once the catalog rewrite has settled, which the range-only rewrite
-    // refuses to do under one. Neither rewrite composes with that.
-    let can_rewrite = fast_override_eligible && !overrides_use_catalogs;
+    // A catalog move can change the effective value of an override whose
+    // configured value is a `catalog:` reference — an effect no catalog
+    // rewrite can express — so catalog drift under such an override goes to
+    // the resolver. The override rewrite itself is safe under one: it runs
+    // only once the catalogs are settled, and override values are compared
+    // catalog-resolved, so a settled `catalog:` override shows no drift and
+    // only the genuinely changed entries are rewritten.
+    let can_rewrite_catalogs = fast_override_eligible && !overrides_use_catalogs;
 
     let catalog_rewrite = if catalogs_match {
         None
     } else if let Some(seed) = fast_catalog_seed {
         Some(seed)
-    } else if can_rewrite {
+    } else if can_rewrite_catalogs {
         // A catalog entry that now names a version the locked one cannot
         // satisfy left `catalogs_match` false with no seed above. Replacing
         // the package is the same rewrite an exact override performs.
@@ -329,7 +333,7 @@ pub(super) async fn lockfile_reuse_seed(inputs: ReuseSeedInputs<'_>) -> Option<A
     if override_settings_match {
         return Some(Arc::new(catalog_rewrite.unwrap_or_else(|| lockfile.clone())));
     }
-    if !can_rewrite {
+    if !fast_override_eligible {
         return None;
     }
     let seed = try_fast_update_overrides(FastOverrideOptions {

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -794,16 +794,19 @@ export async function mutateModules (
     // optional config leaves it undefined, and this now runs on every
     // install rather than only when the fast path opens.
     const configuredOverrides = opts.overrides ?? {}
-    // An override whose value is a `catalog:` reference is only meaningful
-    // once the catalog rewrite has settled, and the range-only catalog
-    // rewrite refuses to run under one. Neither resolver-consulting rewrite
-    // composes with that, so both leave the drift to the resolver.
+    // A catalog move can change the effective value of an override whose
+    // configured value is a `catalog:` reference — an effect no catalog
+    // rewrite can express — so catalog drift under such an override goes to
+    // the resolver. Override drift alone composes: override values are
+    // compared catalog-resolved, so a settled `catalog:` override shows no
+    // drift and only the genuinely changed entries reach the override
+    // rewrite.
     const overridesUseCatalogs = Object.values(configuredOverrides)
       .some((specifier) => parseCatalogProtocol(specifier) != null)
     const hasAsyncDrift = changedLockfileSettings.includes('catalogs') ||
       changedLockfileSettings.includes('overrides')
     const allChangedFieldsAreComposable =
-      !(hasAsyncDrift && overridesUseCatalogs) &&
+      !(changedLockfileSettings.includes('catalogs') && overridesUseCatalogs) &&
       changedLockfileSettings.every((field) =>
         isSettingsField(field) || COMPOSABLE_CHANGED_FIELDS.has(field))
     // A changed field nothing can absorb forces a resolution, so the

--- a/pnpm11/installing/deps-installer/test/install/composedFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/composedFastUpdate.ts
@@ -288,6 +288,35 @@ test('an override on a cataloged package is left to the resolver', async () => {
   })
 })
 
+test('an override change composes when an unchanged override uses the catalog protocol', async () => {
+  const project = prepareEmpty()
+  const catalogs = { default: { '@pnpm.e2e/dep-of-pkg-with-1-dep': '100.0.0' } }
+  const settledOverrides = { '@pnpm.e2e/dep-of-pkg-with-1-dep': 'catalog:' }
+  await installOverrideFixture(testDefaults({ catalogs, overrides: settledOverrides }))
+
+  const options = testDefaults({
+    catalogs,
+    overrides: { ...settledOverrides, '@pnpm.e2e/bar': '100.1.0' },
+  })
+  const requestedPackages = trackRequestedPackages(options.storeController)
+  await mutateModulesInSingleProject({
+    manifest: overrideFixtureManifest(),
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, options)
+
+  // Only the version the new override names is resolved; the `catalog:`
+  // override is compared catalog-resolved, so it shows no drift.
+  expect(requestedPackages).toStrictEqual(['@pnpm.e2e/bar'])
+  const written = project.readLockfile()
+  expect(written.overrides).toStrictEqual({
+    '@pnpm.e2e/dep-of-pkg-with-1-dep': '100.0.0',
+    '@pnpm.e2e/bar': '100.1.0',
+  })
+  expect(Object.keys(written.snapshots)).toContain('@pnpm.e2e/bar@100.1.0')
+  expect(Object.keys(written.snapshots)).not.toContain('@pnpm.e2e/bar@100.0.0')
+})
+
 /** The two changes a resolution away, in their own project. */
 async function resolveTheSameChanges (): Promise<unknown> {
   const previousCwd = process.cwd()


### PR DESCRIPTION
## Summary

Adding or changing an override forced a **full re-resolution of the whole workspace** whenever *any* configured override used the `catalog:` protocol — even when the catalog-backed overrides themselves were unchanged. Full resolution re-resolves loose ranges, so unrelated packages could move in the lockfile. This is exactly what happened in pnpm/pnpm#13975 (Related to pnpm/pnpm#13975): `pnpm audit --fix` added a `deepmerge-ts` override, and the next `pnpm install` moved `@types/node` in every jest snapshot because this repo's four long-standing `catalog:` overrides disqualified the fast override rewrite.

The fast-path guard now bails on catalog-valued overrides only when the **catalogs** drifted (a catalog move can change such an override's effective value — an effect no catalog rewrite can express). Override drift alone composes: override values are compared catalog-resolved on both sides of the drift check, so a settled `catalog:` override shows no drift and only the genuinely changed entries reach the override rewrite.

Both stacks are fixed: the TypeScript guard in `deps-installer`'s `allChangedFieldsAreComposable`, and pacquet's `lockfile_reuse_seed`, where the `!overrides_use_catalogs` condition now applies only to the catalog-versions rewrite, not to the override rewrite (which runs only once the catalogs are settled).

Both new tests were verified to fail against the old guard:

- TS: with the old guard the second install re-resolves 5 extra packages; with the fix only the changed override's version is requested.
- pacquet: the second install (which only adds a removal override) runs against a dead registry and succeeds only when the seed is not withheld.

## Squash Commit Body

```text
Adding or changing an override forced a full re-resolution whenever any
configured override used the catalog: protocol, even when the
catalog-backed overrides themselves were unchanged. Full resolution
re-resolves loose ranges, so unrelated packages (for example every jest
snapshot's @types/node in this repo) could move in the lockfile after
something as small as `pnpm audit --fix` adding an override
(pnpm/pnpm#13975).

The guard now bails only when the catalogs themselves drifted under a
catalog-valued override, since a catalog move can change such an
override's effective value - an effect no catalog rewrite can express.
Override drift alone composes: override values are compared
catalog-resolved on both sides of the drift check, so a settled catalog:
override shows no drift and the fast override rewrite only sees the
genuinely changed entries.

Applied to both stacks: the TypeScript guard in deps-installer's
allChangedFieldsAreComposable, and pacquet's lockfile_reuse_seed, where
!overrides_use_catalogs now gates only the catalog-versions rewrite -
the override rewrite runs only once the catalogs are settled, where a
catalog-valued override is inert.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789591525&installation_model_id=426870&pr_number=13979&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13979&signature=ed151d74061512fe82036fd7b180f9f537a096c2751ff993b2fce26e9ecc7423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fast lockfile updates now correctly handle override changes when existing overrides use the `catalog:` protocol.
  - Avoids unnecessary full dependency re-resolution and unrelated lockfile changes.
  - Ensures removed package snapshots are pruned while settled catalog-based overrides remain intact.

- **Tests**
  - Added coverage for composed override updates and successful installations without unnecessary resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->