### PR TITLE
fix(pm): drop the estree phantom compat entries

### DIFF
--- a/.changeset/eight-hoops-tickle.md
+++ b/.changeset/eight-hoops-tickle.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed installation of `eslint` and `@eslint-community/eslint-utils`: the compatibility database no longer injects a dependency on `estree`, which is not an npm package (its types live in `@types/estree`), so every fresh resolve of those packages failed with a 404.

--- a/.changeset/eight-hoops-tickle.md
+++ b/.changeset/eight-hoops-tickle.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Fixed installation of `eslint` and `@eslint-community/eslint-utils`: the compatibility database no longer injects a dependency on `estree`, which is not an npm package (its types live in `@types/estree`), so every fresh resolve of those packages failed with a 404.
+Fixed fresh installation of `eslint` and `@eslint-community/eslint-utils`, which failed to resolve with a 404 for `estree`.

--- a/.changeset/eight-hoops-tickle.md
+++ b/.changeset/eight-hoops-tickle.md
@@ -1,5 +1,0 @@
----
-"pacquet": patch
----
-
-Fixed fresh installation of `eslint` and `@eslint-community/eslint-utils`, which failed to resolve with a 404 for `estree`.

--- a/pnpm/crates/package-manager/src/compat_package_extensions/tests.rs
+++ b/pnpm/crates/package-manager/src/compat_package_extensions/tests.rs
@@ -62,9 +62,10 @@ fn includes_phantom_dependency_entries() {
 }
 
 /// The phantom findings must never name a target that is not an
-/// installable npm package. `estree` (a type-only import whose types
-/// live in `@types/estree`, with no runtime package behind it) slipped
-/// in once and made every fresh resolve of eslint fail with a 404.
+/// installable npm package. `estree` is a type-only import whose types
+/// live in `@types/estree` — there is no runtime package behind it, so
+/// an entry targeting it makes every fresh resolve of the extended
+/// package fail with a 404.
 #[test]
 fn phantom_entries_never_target_estree() {
     for (selector, extension) in COMPAT_PACKAGE_EXTENSIONS.iter() {

--- a/pnpm/crates/package-manager/src/compat_package_extensions/tests.rs
+++ b/pnpm/crates/package-manager/src/compat_package_extensions/tests.rs
@@ -25,11 +25,14 @@ fn includes_pnpm_specific_compat_entries() {
     );
 }
 
-/// Verify the 10 phantom-dependency entries detected by static analysis of
+/// Verify the phantom-dependency entries detected by static analysis of
 /// the top-500 most-downloaded npm packages. Each entry declares a
 /// dependency the package imports but doesn't declare in its package.json -
 /// a phantom that resolves under npm's flat layout but breaks under a
-/// strict resolver.
+/// strict resolver. Only phantoms that are installable packages belong
+/// here: a type-only import satisfied by a `@types/*` package (like
+/// eslint's `estree`) names no npm package at all, and an entry for it
+/// makes every fresh resolve of the extended package fail with a 404.
 #[test]
 fn includes_phantom_dependency_entries() {
     let assert_dep = |selector: &str, target: &str| {
@@ -44,7 +47,6 @@ fn includes_phantom_dependency_entries() {
         assert_eq!(dep, "*");
     };
 
-    assert_dep("@eslint-community/eslint-utils@*", "estree");
     assert_dep("@eslint/core@*", "json-schema");
     assert_dep("@eslint/eslintrc@*", "eslint");
     assert_dep("@jest/types@*", "istanbul-lib-coverage");
@@ -57,5 +59,18 @@ fn includes_phantom_dependency_entries() {
     assert_dep("@types/yargs@*", "yargs-parser");
     assert_dep("@typescript-eslint/types@*", "typescript");
     assert_dep("es-abstract@*", "for-each");
-    assert_dep("eslint@*", "estree");
+}
+
+/// The phantom findings must never name a target that is not an
+/// installable npm package. `estree` (a type-only import whose types
+/// live in `@types/estree`, with no runtime package behind it) slipped
+/// in once and made every fresh resolve of eslint fail with a 404.
+#[test]
+fn phantom_entries_never_target_estree() {
+    for (selector, extension) in COMPAT_PACKAGE_EXTENSIONS.iter() {
+        assert!(
+            extension.dependencies.as_ref().is_none_or(|deps| !deps.contains_key("estree")),
+            "{selector} must not depend on the nonexistent estree package",
+        );
+    }
 }

--- a/pnpm/crates/package-manager/src/pnpm_compat_package_extensions.json
+++ b/pnpm/crates/package-manager/src/pnpm_compat_package_extensions.json
@@ -8,14 +8,6 @@
     }
   ],
   [
-    "@eslint-community/eslint-utils@*",
-    {
-      "dependencies": {
-        "estree": "*"
-      }
-    }
-  ],
-  [
     "@eslint/core@*",
     {
       "dependencies": {
@@ -96,14 +88,6 @@
     {
       "dependencies": {
         "for-each": "*"
-      }
-    }
-  ],
-  [
-    "eslint@*",
-    {
-      "dependencies": {
-        "estree": "*"
       }
     }
   ]


### PR DESCRIPTION
## Summary

Every fresh resolve of `eslint` (and `@eslint-community/eslint-utils`) fails on `main` with `ERR_PNPM_FETCH_404` for `estree`. The phantom-dependency compat entries added in pnpm/pnpm#13970 include `estree` as a target, but `estree` is not an npm package — the import the static analysis detected is type-only, satisfied by `@types/estree` (which eslint already declares). Reproduce with a one-line `package.json` depending on `eslint@^10.0.0`: `pnpm install` 404s. Existing lockfiles mask it (the recorded subtree is reused), so it surfaces on fresh installs, `pnpm add eslint`, and any full re-resolution.

This PR drops the two `estree` entries and adds a test that the phantom findings never reintroduce this target. The other eight phantom targets were checked against the registry and all exist.

Found while validating pnpm/pnpm#13975's churn investigation: a full re-resolution of this repo's own lockfile hits the entry via `eslint@10.8.1`.

pacquet-only: the TypeScript CLI's `pnpmCompatPackageExtensions` never carried the phantom findings, so there is nothing to mirror.

## Squash Commit Body

```text
The phantom-dependency findings (pnpm/pnpm#13970) added the target
estree for eslint and @eslint-community/eslint-utils, but estree is not
an npm package - the import the analysis saw is type-only, satisfied by
@types/estree. Every fresh resolve of those packages fetched the
nonexistent package and failed with ERR_PNPM_FETCH_404; only subtree
reuse from an existing lockfile masked it.

Drops the two entries and pins the constraint with a test that no
phantom finding targets estree. The remaining phantom targets were
verified to exist in the registry.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] No changeset: the broken entries were added after the last release
  (pnpm/pnpm#13970), so no released version carries the bug.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13981"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789597924&installation_model_id=426870&pr_number=13981&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13981&signature=2636cac4a93e192e916108af93bcf961c3d9c0c24b56d3a4fbb86cd9398ff264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected compatibility metadata for ESLint-related packages.
  - Removed references to the non-installable, type-only `estree` package.
  - Updated phantom-dependency documentation and validation to reflect the corrected package behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
