### PR TITLE
fix: pin still-satisfied edges when a full re-resolution is forced

### DIFF
--- a/.changeset/proud-taxis-shave.md
+++ b/.changeset/proud-taxis-shave.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+A forced full re-resolution (config changes the fast lockfile update cannot absorb, such as a changed override or `packageExtensions`) no longer moves dependencies whose recorded versions still satisfy their ranges. The prior lockfile now pins each still-satisfied edge even when its recorded subtree cannot be reused wholesale, so open ranges like `@types/node: "*"` keep their locked versions instead of collapsing onto the highest locked version and churning the lockfile.

--- a/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
@@ -1755,6 +1755,113 @@ fn removing_a_workspace_project_prunes_its_importer_without_resolving() {
 }
 
 /// A workspace whose two members each depend on a package of their own.
+/// A config drift the fast rewrites cannot absorb (a changed
+/// `packageExtensions`) forces every subtree to re-resolve, but each
+/// edge whose recorded version still satisfies its range keeps it: the
+/// prior lockfile pins per edge even when it cannot seed subtree
+/// reuse. Without the pin, `@pnpm.e2e/foobar`'s open `^100.0.0` edge
+/// would re-pick the highest locked `@pnpm.e2e/foo` (100.1.0, locked
+/// by the other workspace member) and churn the lockfile.
+#[test]
+fn config_drift_full_resolve_keeps_still_satisfied_pins() {
+    let CommandTempCwd { workspace, root, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    fs::write(&workspace_yaml_path, format!("{workspace_yaml}packages:\n  - packages/*\n"))
+        .expect("declare the workspace members");
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "name": "root", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write the root package.json");
+    let write_member = |name: &str, dependencies: serde_json::Value| {
+        let dir = workspace.join("packages").join(name);
+        fs::create_dir_all(&dir).expect("create the member directory");
+        fs::write(
+            dir.join("package.json"),
+            serde_json::json!({
+                "name": name,
+                "version": "1.0.0",
+                "dependencies": dependencies,
+            })
+            .to_string(),
+        )
+        .expect("write the member package.json");
+    };
+    // The direct exact dep dedupes foobar's `^100.0.0` edge onto
+    // 100.0.0 while it is the only locked version.
+    write_member(
+        "a",
+        serde_json::json!({ "@pnpm.e2e/foobar": "100.0.0", "@pnpm.e2e/foo": "100.0.0" }),
+    );
+    write_member("b", serde_json::json!({}));
+    pacquet_at(&workspace).with_arg("install").assert().success();
+    let foobar_key = "@pnpm.e2e/foobar@100.0.0".parse().expect("foobar key");
+    let foo_name = "@pnpm.e2e/foo".parse().expect("foo name");
+    let foobar_foo_child = |lockfile: &pnpm_lockfile::Lockfile| {
+        lockfile
+            .snapshots
+            .as_ref()
+            .and_then(|snapshots| snapshots.get(&foobar_key))
+            .and_then(|snapshot| snapshot.dependencies.as_ref())
+            .and_then(|dependencies| dependencies.get(&foo_name))
+            .and_then(|dep_ref| dep_ref.resolve(&foo_name))
+            .map(|key| key.to_string())
+    };
+    let wanted = pnpm_lockfile::Lockfile::load_wanted_from_dir(&workspace)
+        .expect("load wanted lockfile")
+        .expect("wanted lockfile");
+    assert_eq!(foobar_foo_child(&wanted).as_deref(), Some("@pnpm.e2e/foo@100.0.0"));
+
+    // Lock a second, higher foo through the other member; foobar's
+    // subtree is untouched and keeps its recorded 100.0.0 child.
+    write_member("a", serde_json::json!({ "@pnpm.e2e/foobar": "100.0.0" }));
+    write_member("b", serde_json::json!({ "@pnpm.e2e/foo": "100.1.0" }));
+    pacquet_at(&workspace).with_arg("install").assert().success();
+    let wanted = pnpm_lockfile::Lockfile::load_wanted_from_dir(&workspace)
+        .expect("load wanted lockfile")
+        .expect("wanted lockfile");
+    assert_eq!(foobar_foo_child(&wanted).as_deref(), Some("@pnpm.e2e/foo@100.0.0"));
+
+    // Non-absorbable config drift: a package extension that visibly
+    // changes foobar's dependency set, so the assertion below also
+    // proves the recorded subtree was re-resolved (the extension
+    // applied) rather than reused wholesale under the drift.
+    let workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    fs::write(
+        &workspace_yaml_path,
+        format!(
+            "{workspace_yaml}packageExtensions:\n  '@pnpm.e2e/foobar':\n    dependencies:\n      is-positive: 1.0.0\n",
+        ),
+    )
+    .expect("add a package extension");
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    let wanted = pnpm_lockfile::Lockfile::load_wanted_from_dir(&workspace)
+        .expect("load wanted lockfile")
+        .expect("wanted lockfile");
+    assert_eq!(foobar_foo_child(&wanted).as_deref(), Some("@pnpm.e2e/foo@100.0.0"));
+    let extended_child = wanted
+        .snapshots
+        .as_ref()
+        .and_then(|snapshots| snapshots.get(&foobar_key))
+        .and_then(|snapshot| snapshot.dependencies.as_ref())
+        .and_then(|dependencies| dependencies.get(&"is-positive".parse().expect("name")))
+        .and_then(|dep_ref| dep_ref.resolve(&"is-positive".parse().expect("name")))
+        .map(|key| key.to_string());
+    assert_eq!(extended_child.as_deref(), Some("is-positive@1.0.0"));
+    let foo_100_1_0 = "@pnpm.e2e/foo@100.1.0".parse().expect("foo 100.1.0 key");
+    assert!(
+        wanted.snapshots.as_ref().is_some_and(|snapshots| snapshots.contains_key(&foo_100_1_0)),
+    );
+
+    drop((root, mock_instance));
+}
+
 fn write_two_member_workspace(workspace: &Path) {
     let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
     let workspace_yaml =

--- a/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
@@ -1754,7 +1754,6 @@ fn removing_a_workspace_project_prunes_its_importer_without_resolving() {
     drop((root, mock_instance));
 }
 
-/// A workspace whose two members each depend on a package of their own.
 /// A config drift the fast rewrites cannot absorb (a changed
 /// `packageExtensions`) forces every subtree to re-resolve, but each
 /// edge whose recorded version still satisfies its range keeps it: the
@@ -1862,6 +1861,7 @@ fn config_drift_full_resolve_keeps_still_satisfied_pins() {
     drop((root, mock_instance));
 }
 
+/// A workspace whose two members each depend on a package of their own.
 fn write_two_member_workspace(workspace: &Path) {
     let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
     let workspace_yaml =

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1036,6 +1036,16 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             &update_reuse_scope,
             &update_reuse_scopes_by_importer,
         );
+        let reuse_lockfile_subtrees = lockfile_reuse_seed.is_some();
+        // A withheld seed means config drift the fast rewrites cannot
+        // absorb, so recorded subtrees must re-resolve — but the prior
+        // lockfile still pins each edge whose recorded version satisfies
+        // its hook-rewritten manifest range. Without it every open range
+        // (`*`) would re-pick the highest locked version and churn the
+        // lockfile (the edges a changed override or extension actually
+        // reaches fail the satisfies gate and re-resolve).
+        let resolution_lockfile = lockfile_reuse_seed
+            .or_else(|| wanted_lockfile.map(|lockfile| Arc::new(lockfile.clone())));
 
         let phase_start = std::time::Instant::now();
         Reporter::emit(&LogEvent::Stage(StageLog {
@@ -1062,7 +1072,8 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             pick_lowest_direct,
             time_based,
             published_by,
-            lockfile_reuse_seed,
+            resolution_lockfile,
+            reuse_lockfile_subtrees,
             update_reuse_scope,
             update_reuse_scopes_by_importer,
             update_depth: update_seed_policy.max_depth(),

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1039,11 +1039,8 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         let reuse_lockfile_subtrees = lockfile_reuse_seed.is_some();
         // A withheld seed means config drift the fast rewrites cannot
         // absorb, so recorded subtrees must re-resolve — but the prior
-        // lockfile still pins each edge whose recorded version satisfies
-        // its hook-rewritten manifest range. Without it every open range
-        // (`*`) would re-pick the highest locked version and churn the
-        // lockfile (the edges a changed override or extension actually
-        // reaches fail the satisfies gate and re-resolve).
+        // lockfile still pins the edges the drift does not reach (see
+        // `WorkspaceResolveOptions::reuse_lockfile_subtrees`).
         let resolution_lockfile = lockfile_reuse_seed
             .or_else(|| wanted_lockfile.map(|lockfile| Arc::new(lockfile.clone())));
 

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolve.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolve.rs
@@ -416,9 +416,14 @@ pub(super) struct ResolvePassInputs<'a> {
     pub pick_lowest_direct: bool,
     pub time_based: bool,
     pub published_by: Option<chrono::DateTime<chrono::Utc>>,
-    /// The prior lockfile the walk may reuse subtrees from — see
-    /// [`lockfile_reuse_seed`].
-    pub lockfile_reuse_seed: Option<Arc<Lockfile>>,
+    /// The prior lockfile the walk resolves against — the granted
+    /// [`lockfile_reuse_seed`], or the raw wanted lockfile when the seed
+    /// was withheld and only per-edge version pinning remains safe.
+    pub resolution_lockfile: Option<Arc<Lockfile>>,
+    /// Whether [`Self::resolution_lockfile`] is a granted reuse seed the
+    /// walk may reuse whole subtrees from. `false` restricts it to
+    /// per-edge version pinning.
+    pub reuse_lockfile_subtrees: bool,
     pub update_reuse_scope: pnpm_resolving_deps_resolver::UpdateReuseScope,
     pub update_reuse_scopes_by_importer:
         BTreeMap<String, pnpm_resolving_deps_resolver::UpdateReuseScope>,
@@ -457,7 +462,8 @@ pub(super) async fn run_resolve_pass<Reporter: pnpm_reporter::Reporter>(
         pick_lowest_direct,
         time_based,
         published_by,
-        lockfile_reuse_seed,
+        resolution_lockfile,
+        reuse_lockfile_subtrees,
         update_reuse_scope,
         update_reuse_scopes_by_importer,
         update_depth,
@@ -500,7 +506,8 @@ pub(super) async fn run_resolve_pass<Reporter: pnpm_reporter::Reporter>(
         skipped_optional_log: Some(super::skipped_optional_log_fn::<Reporter>()),
         pick_lowest_direct,
         time_based,
-        wanted_lockfile: lockfile_reuse_seed,
+        wanted_lockfile: resolution_lockfile,
+        reuse_lockfile_subtrees,
         update_reuse_scope,
         update_reuse_scopes_by_importer,
         update_depth,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/reuse.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/reuse.rs
@@ -398,6 +398,29 @@ pub(super) fn real_package_name_of<'edge>(
     alias.map(Cow::Borrowed)
 }
 
+/// Whether the running `pacquet update` reaches this edge, so its
+/// locked-version pin must not survive — the update exists to move it.
+/// Unlike [`fn@is_update_target`], an update-everything scope
+/// ([`UpdateReuseScope::None`]) unpins every edge the depth ceiling
+/// reaches.
+pub(super) fn update_unpins_edge(
+    scope: UpdateScope<'_>,
+    wanted: &WantedDependency,
+    depth: i32,
+) -> bool {
+    if !scope.max_depth.reaches(depth) {
+        return false;
+    }
+    match scope.reuse {
+        UpdateReuseScope::All => false,
+        UpdateReuseScope::None => true,
+        UpdateReuseScope::Except(_) => {
+            real_package_name_of(wanted.alias.as_deref(), wanted.bare_specifier.as_deref())
+                .is_some_and(|name| update_excludes(scope, name.as_ref(), depth))
+        }
+    }
+}
+
 /// Whether `wanted` is one of the packages the user asked to update,
 /// given the install's [`UpdateReuseScope`]. Feeds the per-resolve
 /// `ResolveOptions::update_requested` flag, which gates the npm

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
@@ -36,7 +36,7 @@ use super::{
     reuse::{
         ReuseSource, higher_direct_dep_version, is_update_target,
         node_depends_on_changed_direct_dep, real_package_name_of, resolve_reused_node,
-        try_reuse_node, wanted_lockfile_contains_satisfying_entry,
+        try_reuse_node, update_unpins_edge, wanted_lockfile_contains_satisfying_entry,
     },
     tree_ctx::{
         TreeCtx, declaring_manifest_dir, opts_relative_to_declaring_manifest,
@@ -212,7 +212,8 @@ where
     // their manifest ranges where `seed_node_children` can redirect a
     // stale pin onto the higher direct-dep version (reusing the subtree
     // would keep the pin, leaving the lockfile non-convergent).
-    if reuse.allows_reuse()
+    if ctx.workspace.reuse_lockfile_subtrees
+        && reuse.allows_reuse()
         && !node_depends_on_changed_direct_dep(ctx, prior_key.as_ref())
         && let Some(reused) = try_reuse_node(ctx, &wanted, prior_key.as_ref(), depth)
     {
@@ -228,6 +229,30 @@ where
         )
         .await
         .map(NodeSeed::Done);
+    }
+
+    // Locked-version pin, the fresh-resolve counterpart of subtree
+    // reuse: a transitive edge whose recorded version still satisfies
+    // its manifest range (`prior_key` is satisfies-gated) resolves to
+    // exactly that version even when its subtree cannot be reused
+    // wholesale. Without it, a re-resolve picks open ranges (`*`)
+    // against the whole preferred-versions pool and lands every such
+    // edge on the highest locked version, churning the lockfile.
+    // Mirrors the TypeScript resolver's `replaceVersionInBareSpecifier`
+    // under `!update`: direct deps (depth 0) keep recomputing their
+    // specifier, and an edge a `pacquet update` reaches keeps
+    // re-picking. Only plain semver ranges pin; aliased (`npm:`),
+    // named-registry, and exotic specifiers keep today's behavior.
+    let mut wanted = wanted;
+    if depth > 0
+        && !update_unpins_edge(ctx.update_scope(), &wanted, depth)
+        && let Some(version) = prior_key.as_ref().and_then(|key| key.suffix.version_semver())
+        && wanted
+            .bare_specifier
+            .as_deref()
+            .is_some_and(|spec| spec.parse::<node_semver::Range>().is_ok())
+    {
+        wanted.bare_specifier = Some(version.to_string());
     }
 
     // Memoise the per-wanted resolve. The first caller for a given

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
@@ -288,12 +288,12 @@ pub struct WorkspaceTreeCtx {
     /// [`resolve_node`]: super::walk::resolve_node
     pub(super) wanted_lockfile: Option<Arc<pnpm_lockfile::Lockfile>>,
     /// Whether the walk may reuse whole already-resolved subtrees from
-    /// [`Self::wanted_lockfile`]. `false` keeps the lockfile as a
-    /// per-edge version-pin source only: every node re-resolves against
-    /// its (hook-rewritten) manifest range, and an edge whose recorded
-    /// version still satisfies that range stays on it. Used when config
-    /// drift (overrides, packageExtensions, ...) invalidates recorded
-    /// subtrees but not the versions the untouched edges resolved to.
+    /// [`Self::wanted_lockfile`]; `false` keeps it as a per-edge
+    /// version-pin source only. See
+    /// [`WorkspaceResolveOptions::reuse_lockfile_subtrees`] for the
+    /// contract.
+    ///
+    /// [`WorkspaceResolveOptions::reuse_lockfile_subtrees`]: crate::WorkspaceResolveOptions::reuse_lockfile_subtrees
     pub(super) reuse_lockfile_subtrees: bool,
     /// Lockfile-reuse suppression for `pacquet update`. `update`
     /// re-resolves its target deps to highest-in-range, so a reused

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
@@ -292,7 +292,7 @@ pub struct WorkspaceTreeCtx {
     /// per-edge version-pin source only: every node re-resolves against
     /// its (hook-rewritten) manifest range, and an edge whose recorded
     /// version still satisfies that range stays on it. Used when config
-    /// drift (overrides, packageExtensions, …) invalidates recorded
+    /// drift (overrides, packageExtensions, ...) invalidates recorded
     /// subtrees but not the versions the untouched edges resolved to.
     pub(super) reuse_lockfile_subtrees: bool,
     /// Lockfile-reuse suppression for `pacquet update`. `update`

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
@@ -287,6 +287,14 @@ pub struct WorkspaceTreeCtx {
     ///
     /// [`resolve_node`]: super::walk::resolve_node
     pub(super) wanted_lockfile: Option<Arc<pnpm_lockfile::Lockfile>>,
+    /// Whether the walk may reuse whole already-resolved subtrees from
+    /// [`Self::wanted_lockfile`]. `false` keeps the lockfile as a
+    /// per-edge version-pin source only: every node re-resolves against
+    /// its (hook-rewritten) manifest range, and an edge whose recorded
+    /// version still satisfies that range stays on it. Used when config
+    /// drift (overrides, packageExtensions, …) invalidates recorded
+    /// subtrees but not the versions the untouched edges resolved to.
+    pub(super) reuse_lockfile_subtrees: bool,
     /// Lockfile-reuse suppression for `pacquet update`. `update`
     /// re-resolves its target deps to highest-in-range, so a reused
     /// resolution would defeat the bump. See [`UpdateReuseScope`].
@@ -499,6 +507,7 @@ impl Default for WorkspaceTreeCtx {
             manifest_hook: None,
             overrides_hook: None,
             wanted_lockfile: None,
+            reuse_lockfile_subtrees: true,
             update_reuse_scope: UpdateReuseScope::All,
             update_reuse_scopes_by_importer: BTreeMap::new(),
             update_depth: UpdateDepth::UNLIMITED,
@@ -651,6 +660,14 @@ impl WorkspaceTreeCtx {
     /// The prior `pnpm-lock.yaml` to reuse resolutions from, if any.
     pub fn wanted_lockfile(&self) -> Option<&Arc<pnpm_lockfile::Lockfile>> {
         self.wanted_lockfile.as_ref()
+    }
+
+    /// Restrict [`Self::wanted_lockfile`] to per-edge version pinning.
+    /// See the `reuse_lockfile_subtrees` field.
+    #[must_use]
+    pub fn with_reuse_lockfile_subtrees(mut self, reuse_lockfile_subtrees: bool) -> Self {
+        self.reuse_lockfile_subtrees = reuse_lockfile_subtrees;
+        self
     }
 
     /// Snapshot of `pkg id → children-owner importer id`. See the field doc.

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -93,6 +93,15 @@ pub struct WorkspaceResolveOptions {
     /// first install or when reuse is disabled.
     pub wanted_lockfile: Option<Arc<pnpm_lockfile::Lockfile>>,
 
+    /// Whether the walk may reuse whole already-resolved subtrees from
+    /// [`Self::wanted_lockfile`]. `false` keeps the lockfile as a
+    /// per-edge version-pin source only: every node re-resolves against
+    /// its (hook-rewritten) manifest range, and an edge whose recorded
+    /// version still satisfies that range stays on it — mirroring the
+    /// TypeScript resolver's forced full resolution, which forces the
+    /// walk without unpinning still-satisfied edges.
+    pub reuse_lockfile_subtrees: bool,
+
     /// Which dependencies `pacquet update` excludes from lockfile-
     /// resolution reuse. [`UpdateReuseScope::All`] for `install` / `add`.
     pub update_reuse_scope: UpdateReuseScope,
@@ -197,6 +206,7 @@ where
         pick_lowest_direct,
         time_based,
         wanted_lockfile,
+        reuse_lockfile_subtrees,
         update_reuse_scope,
         update_reuse_scopes_by_importer,
         update_depth,
@@ -215,6 +225,7 @@ where
             .with_manifest_hook(manifest_hook)
             .with_overrides_hook(overrides_hook)
             .with_wanted_lockfile(wanted_lockfile)
+            .with_reuse_lockfile_subtrees(reuse_lockfile_subtrees)
             .with_update_reuse_scope(update_reuse_scope)
             .with_update_reuse_scopes_by_importer(update_reuse_scopes_by_importer)
             .with_update_depth(update_depth)

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -99,7 +99,10 @@ pub struct WorkspaceResolveOptions {
     /// its (hook-rewritten) manifest range, and an edge whose recorded
     /// version still satisfies that range stays on it — mirroring the
     /// TypeScript resolver's forced full resolution, which forces the
-    /// walk without unpinning still-satisfied edges.
+    /// walk without unpinning still-satisfied edges. The config drift
+    /// that denied subtree reuse stays effective: hooks rewrite the
+    /// drifted manifests before the satisfies check, so the edges a
+    /// changed override or extension reaches re-resolve.
     pub reuse_lockfile_subtrees: bool,
 
     /// Which dependencies `pacquet update` excludes from lockfile-

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -214,6 +214,7 @@ fn workspace_opts(pick_lowest_direct: bool, time_based: bool) -> WorkspaceResolv
         pick_lowest_direct,
         time_based,
         wanted_lockfile: None,
+        reuse_lockfile_subtrees: true,
         update_reuse_scope: crate::UpdateReuseScope::All,
         update_reuse_scopes_by_importer: BTreeMap::new(),
         update_depth: crate::UpdateDepth::UNLIMITED,
@@ -2348,8 +2349,11 @@ async fn fresh_resolved_parent_on_recorded_version_reuses_child_subtrees() {
                     }),
                 ),
             ),
+            // The cycle-membered subtree is denied reuse, so its edges
+            // resolve freshly with their recorded versions pinned as
+            // exact specs — the table serves the pinned form.
             (
-                ("cyclic".to_string(), "^1.0.0".to_string()),
+                ("cyclic".to_string(), "1.0.0".to_string()),
                 fake_result(
                     "cyclic",
                     "1.0.0",
@@ -2362,7 +2366,7 @@ async fn fresh_resolved_parent_on_recorded_version_reuses_child_subtrees() {
                 ),
             ),
             (
-                ("loop".to_string(), "^1.0.0".to_string()),
+                ("loop".to_string(), "1.0.0".to_string()),
                 fake_result(
                     "loop",
                     "1.0.0",

--- a/pnpm/tasks/micro-benchmark/src/workspace_resolution.rs
+++ b/pnpm/tasks/micro-benchmark/src/workspace_resolution.rs
@@ -287,6 +287,7 @@ fn workspace_options() -> WorkspaceResolveOptions {
         pick_lowest_direct: false,
         time_based: false,
         wanted_lockfile: None,
+        reuse_lockfile_subtrees: true,
         update_reuse_scope: UpdateReuseScope::All,
         update_reuse_scopes_by_importer: BTreeMap::new(),
         update_depth: UpdateDepth::UNLIMITED,


### PR DESCRIPTION
## Summary

Follow-up to pnpm/pnpm#13979, fixing the deeper half of the pnpm/pnpm#13975 lockfile churn: even when a full re-resolution is genuinely required, it should not move dependencies whose recorded versions still satisfy their ranges.

pacquet's lockfile reuse was all-or-nothing: config drift the fast rewrites cannot absorb (a changed override, `packageExtensions`, patches) withheld the reuse seed entirely, so the walk ran with only the name-global preferred-versions bias. With several versions of one package locked, every open range — jest's `@types/node: "*"` — collapsed onto the highest locked version (20 flips in the pnpm/pnpm#13975 repro). The TypeScript CLI does not do this: verified with `--resolution-only` on the same state, it forces the walk without unpinning still-satisfied edges.

Two changes mirror that proceed-vs-update split:

1. **Pin-only mode for the prior lockfile.** `lockfile_reuse_seed`'s caller now passes the wanted lockfile to the resolver even when the seed is withheld, with the new `reuse_lockfile_subtrees: false` restricting it to per-edge version pinning — recorded subtrees all re-resolve (so the drifted config actually applies), but each edge keeps its recorded version where it still satisfies.
2. **Hard pin on the fresh-resolve path.** A transitive edge with a satisfies-gated `prior_key` resolves with the recorded version as an exact spec (the counterpart of the TypeScript resolver's `replaceVersionInBareSpecifier` under `!update`). Edges a changed override/extension reaches fail the satisfies gate and re-resolve; `pacquet update` targets (`update_unpins_edge`) and the stale-pin refresh keep re-picking; direct deps (depth 0) keep recomputing their specifiers.

Verified against the pnpm/pnpm#13975 base commit: both the original `pnpm audit --fix` override scenario and a `packageExtensions` drift now produce zero `@types/node` churn (the override itself still applies, and a tree-changing extension is still picked up — the new e2e test asserts both). The new CLI test fails on `main` with exactly the churned version. All 335 deps-resolver, 601 package-manager, 27 reuse-suite, and 211 update-suite tests pass.

Perf: the changed paths only run under config drift (no benchmark exercises them), and pinning resolves exact versions, which is never more work than a range pick.

While validating on the real repo I hit a `main` regression that fresh eslint resolves 404 on the nonexistent `estree` package — that is split out as pnpm/pnpm#13981; this PR is independent of it (CI does not resolve eslint).

pacquet-only: the TypeScript resolver already pins still-satisfied edges during forced full resolution, so there is nothing to mirror.

## Squash Commit Body

```text
Config drift the fast lockfile rewrites cannot absorb (a changed
override, packageExtensions, patches) used to withhold the lockfile
reuse seed entirely, leaving the walk with only the name-global
preferred-versions bias. With several versions of one package locked,
every open range (jest's @types/node: "*") then collapsed onto the
highest locked version, churning unrelated lockfile entries - the
mechanism behind the churn investigated in pnpm/pnpm#13975.

Two changes, mirroring the TypeScript resolver's split between forcing
the walk (proceed) and unpinning (update):

1. The walk now takes the prior lockfile even when subtree reuse must
be denied, via the new reuse_lockfile_subtrees flag: false keeps the
lockfile as a per-edge version-pin source only.

2. The fresh-resolve path hard-pins a transitive edge whose recorded
version still satisfies its hook-rewritten manifest range (the
counterpart of replaceVersionInBareSpecifier under !update). Edges a
changed override or extension actually reaches fail the satisfies gate
and re-resolve; pacquet update targets and the stale-pin refresh keep
re-picking.

The TypeScript CLI already behaves this way, so nothing needs
mirroring there.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789598698&installation_model_id=426870&pr_number=13982&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13982&signature=16fea711740ad399a93add55c2e44098c5f419668c5e2683abc89af58b5ae513"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Forced full dependency re-resolution now preserves previously recorded versions when they continue to satisfy requested ranges.
  * Dependency overrides and `packageExtensions` are applied correctly without unnecessarily changing compatible locked versions.
  * Targeted updates now refresh only intended dependency edges while retaining unaffected resolutions.

* **Tests**
  * Added coverage for lockfile reuse, package extensions, and preserving separately locked dependencies during fresh resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->