### PR TITLE
fix(deploy): prefer source workspace lockfile versions in legacy deploy

### DIFF
--- a/.changeset/legacy-deploy-lockfile-preference.md
+++ b/.changeset/legacy-deploy-lockfile-preference.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm deploy --legacy` now prefers dependency versions pinned in the source workspace lockfile when they still satisfy the deployed project's range [pnpm/pnpm#13857](https://github.com/pnpm/pnpm/issues/13857).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4601,6 +4601,7 @@ dependencies = [
  "pnpm-install-coordinator",
  "pnpm-lockfile",
  "pnpm-lockfile-import",
+ "pnpm-lockfile-preferred-versions",
  "pnpm-lockfile-verification",
  "pnpm-modules-yaml",
  "pnpm-network",

--- a/pnpm/crates/cli/Cargo.toml
+++ b/pnpm/crates/cli/Cargo.toml
@@ -39,6 +39,7 @@ pnpm-injected-deps-syncer              = { workspace = true }
 pnpm-install-coordinator               = { workspace = true }
 pnpm-lockfile                          = { workspace = true }
 pnpm-lockfile-import                   = { workspace = true }
+pnpm-lockfile-preferred-versions       = { workspace = true }
 pnpm-lockfile-verification             = { workspace = true }
 pnpm-modules-yaml                      = { workspace = true }
 pnpm-network                           = { workspace = true }

--- a/pnpm/crates/cli/src/cli_args/deploy.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy.rs
@@ -17,12 +17,14 @@ use pnpm_lockfile::{
     ResolvedDependencyMap, ResolvedDependencySpec, SnapshotDepRef, SnapshotEntry,
     TarballResolution, VersionPart, WantedLockfileSelection,
 };
+use pnpm_lockfile_preferred_versions::get_preferred_versions_from_lockfile_and_manifests;
 use pnpm_package_manager::{
     ImportIndexedDirOpts, Install, ProjectMutation, UpdateSeedPolicy, apply_deploy_manifest_hook,
     import_indexed_dir,
 };
 use pnpm_package_manifest::{DependencyGroup, PackageManifest};
 use pnpm_reporter::{LogEvent, LogLevel, PnpmLog, Reporter};
+use pnpm_resolving_resolver_base::PreferredVersions;
 use pnpm_workspace::{Project, WORKSPACE_MANIFEST_FILENAME, importer_id_from_root_dir};
 use serde_json::{Map, Value};
 use std::{
@@ -218,6 +220,10 @@ impl DeployArgs {
         }
 
         apply_deploy_hook(&deploy_dir.join("package.json"))?;
+        let preferred_versions_override = legacy_deploy_preferred_versions::<ReporterT>(
+            config,
+            config.lockfile_dir_for(&selected.project.root_dir),
+        );
         // Boxed: the install future exceeds clippy's large-future threshold
         // (the captured `Config` is large).
         Box::pin(self.run_install_in_deploy_dir::<ReporterT>(
@@ -226,6 +232,7 @@ impl DeployArgs {
             DeployInstallMode::Legacy,
             false,
             source_hooks,
+            preferred_versions_override,
         ))
         .await
     }
@@ -288,6 +295,7 @@ impl DeployArgs {
             DeployInstallMode::Shared { workspace_config: deploy_files.workspace_config },
             true,
             source_hooks,
+            None,
         ))
         .await?;
         Ok(SharedDeployOutcome::Deployed)
@@ -300,6 +308,7 @@ impl DeployArgs {
         mode: DeployInstallMode,
         frozen_lockfile: bool,
         source_hooks: Option<Arc<dyn pnpm_hooks::PnpmfileHooks>>,
+        preferred_versions_override: Option<PreferredVersions>,
     ) -> miette::Result<()> {
         let legacy = matches!(&mode, DeployInstallMode::Legacy);
         let config = self.deploy_install_config(
@@ -371,7 +380,7 @@ impl DeployArgs {
             dry_run: false,
             persist_policy_excludes: false,
             update_seed_policy: UpdateSeedPolicy::KeepAll,
-            preferred_versions_override: None,
+            preferred_versions_override,
             auth_override: None,
             resolution_observer: None,
             peer_issues_sink: None,
@@ -481,6 +490,32 @@ fn source_pnpmfile_hooks(
         pnpm_package_manager::pnpmfile_selection(config),
     )
     .map_err(|error| miette::miette!(code = "ERR_PNPM_PNPMFILE_NOT_FOUND", "{error}"))
+}
+
+/// Loads source lockfile pins as preferred versions for legacy deploy.
+/// The source install's branch-lockfile selection is preserved, while a
+/// missing or malformed source lockfile falls back to fresh resolution.
+fn legacy_deploy_preferred_versions<ReporterT: Reporter>(
+    config: &Config,
+    source_lockfile_dir: &Path,
+) -> Option<PreferredVersions> {
+    if !config.lockfile {
+        return None;
+    }
+    match Lockfile::load_wanted(source_lockfile_dir, &config.wanted_lockfile_selection()) {
+        Ok(Some(lockfile)) => Some(get_preferred_versions_from_lockfile_and_manifests(
+            lockfile.snapshots.as_ref(),
+            &[],
+        )),
+        Ok(None) => None,
+        Err(error) => {
+            warn::<ReporterT>(
+                source_lockfile_dir,
+                format!("Ignoring broken lockfile at {}: {error}", source_lockfile_dir.display()),
+            );
+            None
+        }
+    }
 }
 
 fn create_deploy_install_config(

--- a/pnpm/crates/cli/tests/suite/deploy.rs
+++ b/pnpm/crates/cli/tests/suite/deploy.rs
@@ -2,7 +2,7 @@ use crate::_utils::append_workspace_yaml_key;
 
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
-use pnpm_lockfile::{Lockfile, PkgName};
+use pnpm_lockfile::{Lockfile, PackageKey, PkgName};
 use pnpm_testing_utils::{
     bin::{AddMockedRegistry, CommandTempCwd},
     fs::is_symlink_or_junction,
@@ -11,7 +11,7 @@ use std::{
     fmt::Write as _,
     fs,
     path::{Path, PathBuf},
-    process::Command,
+    process::{Command, Output},
 };
 
 #[test]
@@ -1186,6 +1186,351 @@ fn legacy_deploy_injects_transitive_workspace_dependencies() {
 }
 
 #[test]
+fn legacy_deploy_prefers_workspace_lockfile_versions() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    write_workspace(&workspace, false);
+    set_app_foo_dependency(&workspace, "100.0.0");
+
+    pacquet.with_arg("install").assert().success();
+    let source_lockfile_path = workspace.join(Lockfile::FILE_NAME);
+    let source_wanted_lockfile = Lockfile::load_wanted_from_dir(&workspace)
+        .expect("load source wanted lockfile")
+        .expect("source wanted lockfile exists");
+    let source_foo_key: PackageKey =
+        "@pnpm.e2e/foo@100.0.0".parse().expect("parse source package key");
+    assert!(
+        source_wanted_lockfile
+            .snapshots
+            .as_ref()
+            .is_some_and(|snapshots| snapshots.contains_key(&source_foo_key)),
+        "the source fixture must pin foo at 100.0.0",
+    );
+    let source_lockfile = fs::read(&source_lockfile_path).expect("read source lockfile");
+    set_app_foo_dependency(&workspace, "^100.0.0");
+
+    pacquet_cmd(&workspace)
+        .with_args(["--filter", "app", "deploy", "--legacy", "--prod", "legacy-deploy"])
+        .assert()
+        .success();
+
+    let deploy_dir = workspace.join("legacy-deploy");
+    assert_eq!(fs::read(&source_lockfile_path).unwrap(), source_lockfile);
+    assert_eq!(
+        deployed_package_version(&deploy_dir, "@pnpm.e2e/foo"),
+        "100.0.0",
+        "legacy deploy should prefer the satisfying version pinned by the source workspace lockfile",
+    );
+    let deploy_manifest: serde_json::Value = serde_json::from_slice(
+        &fs::read(deploy_dir.join("package.json")).expect("read deploy manifest"),
+    )
+    .expect("parse deploy manifest");
+    assert_eq!(deploy_manifest["name"], "app");
+    assert_eq!(deploy_manifest["dependencies"]["@pnpm.e2e/foo"], "^100.0.0");
+    assert_eq!(deploy_manifest["dependenciesMeta"]["lib"]["injected"], true);
+
+    let virtual_store_dir = deploy_dir.join("node_modules/.pnpm");
+    let current_lockfile = Lockfile::load_current_from_virtual_store_dir(&virtual_store_dir)
+        .expect("load deploy current lockfile")
+        .expect("deploy current lockfile exists");
+    assert_eq!(
+        current_lockfile.importers.keys().map(String::as_str).collect::<Vec<_>>(),
+        vec![Lockfile::ROOT_IMPORTER_KEY],
+        "the post-hook deploy manifest should be the sole root importer",
+    );
+    let root_importer = current_lockfile.root_project().expect("root deploy importer exists");
+    let foo_name = PkgName::parse("@pnpm.e2e/foo").expect("parse fixture package name");
+    let foo_dependency = root_importer
+        .dependencies
+        .as_ref()
+        .expect("root deploy dependencies exist")
+        .get(&foo_name)
+        .expect("root deploy importer contains foo");
+    assert_eq!(foo_dependency.specifier, "^100.0.0");
+    assert_eq!(foo_dependency.version.to_string(), "100.0.0");
+    assert_eq!(
+        root_importer.dependencies_meta.as_ref().expect("root deploy dependenciesMeta exists")["lib"]
+            ["injected"],
+        true,
+    );
+
+    let modules = pnpm_modules_yaml::read_modules_layout::<pnpm_modules_yaml::Host>(
+        &deploy_dir.join("node_modules"),
+    )
+    .expect("read deploy .modules.yaml")
+    .expect("deploy .modules.yaml exists");
+    assert_eq!(
+        dunce::canonicalize(&modules.virtual_store_dir)
+            .expect("canonicalize recorded deploy virtual store"),
+        dunce::canonicalize(&virtual_store_dir)
+            .expect("canonicalize expected deploy virtual store"),
+        "deploy .modules.yaml should record the target-local virtual store",
+    );
+    let deployed_foo_dir = dunce::canonicalize(deploy_dir.join("node_modules/@pnpm.e2e/foo"))
+        .expect("canonicalize deployed foo directory");
+    assert!(
+        deployed_foo_dir.starts_with(
+            dunce::canonicalize(&virtual_store_dir)
+                .expect("canonicalize expected deploy virtual store"),
+        ),
+        "the deployed package should resolve inside the target virtual store: {}",
+        deployed_foo_dir.display(),
+    );
+    assert!(
+        !deploy_dir.join(Lockfile::FILE_NAME).exists(),
+        "legacy deploy must not copy the source wanted lockfile into the target",
+    );
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn legacy_deploy_prefers_dedicated_lockfile_versions() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    write_workspace(&workspace, false);
+    append_workspace_yaml_key(&workspace, "sharedWorkspaceLockfile", false);
+    set_app_foo_dependency(&workspace, "100.0.0");
+
+    pacquet.with_args(["--filter", "app", "install"]).assert().success();
+    let app_dir = workspace.join("packages/app");
+    let source_lockfile_path = app_dir.join(Lockfile::FILE_NAME);
+    assert!(
+        !workspace.join(Lockfile::FILE_NAME).exists(),
+        "a dedicated install must not write the wanted lockfile at the workspace root",
+    );
+    let source_wanted_lockfile = Lockfile::load_wanted_from_dir(&app_dir)
+        .expect("load source project wanted lockfile")
+        .expect("source project wanted lockfile exists");
+    let source_foo_key: PackageKey =
+        "@pnpm.e2e/foo@100.0.0".parse().expect("parse source package key");
+    assert!(
+        source_wanted_lockfile
+            .snapshots
+            .as_ref()
+            .is_some_and(|snapshots| snapshots.contains_key(&source_foo_key)),
+        "the source project fixture must pin foo at 100.0.0",
+    );
+    let source_lockfile = fs::read(&source_lockfile_path).expect("read source project lockfile");
+    set_app_foo_dependency(&workspace, "^100.0.0");
+
+    pacquet_cmd(&workspace)
+        .with_args([
+            "--filter",
+            "app",
+            "deploy",
+            "--legacy",
+            "--prod",
+            "legacy-deploy-with-dedicated-lockfile",
+        ])
+        .assert()
+        .success();
+
+    let deploy_dir = workspace.join("legacy-deploy-with-dedicated-lockfile");
+    assert_eq!(
+        fs::read(&source_lockfile_path).expect("reread source project lockfile"),
+        source_lockfile,
+    );
+    assert!(
+        !workspace.join(Lockfile::FILE_NAME).exists(),
+        "legacy deploy must not write a wanted lockfile at the workspace root",
+    );
+    assert_eq!(
+        deployed_package_version(&deploy_dir, "@pnpm.e2e/foo"),
+        "100.0.0",
+        "legacy deploy should prefer the satisfying version pinned by the source project lockfile",
+    );
+    assert!(
+        !deploy_dir.join(Lockfile::FILE_NAME).exists(),
+        "legacy deploy must not copy the source project wanted lockfile into the target",
+    );
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn legacy_deploy_prefers_git_branch_lockfile_versions() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    write_workspace(&workspace, false);
+    fs::create_dir(workspace.join(".git")).expect("create source git directory");
+    fs::write(workspace.join(".git/HEAD"), "ref: refs/heads/feature\n")
+        .expect("write source git branch");
+    append_workspace_yaml_key(&workspace, "gitBranchLockfile", true);
+    set_app_foo_dependency(&workspace, "100.0.0");
+
+    pacquet.with_arg("install").assert().success();
+    let source_lockfile_path = workspace.join("pnpm-lock.feature.yaml");
+    let source_lockfile = fs::read(&source_lockfile_path).expect("read source branch lockfile");
+    assert!(!workspace.join(Lockfile::FILE_NAME).exists());
+    set_app_foo_dependency(&workspace, "^100.0.0");
+
+    pacquet_cmd(&workspace)
+        .with_args([
+            "--filter",
+            "app",
+            "deploy",
+            "--legacy",
+            "--prod",
+            "legacy-deploy-with-branch-lockfile",
+        ])
+        .assert()
+        .success();
+
+    let deploy_dir = workspace.join("legacy-deploy-with-branch-lockfile");
+    assert_eq!(deployed_package_version(&deploy_dir, "@pnpm.e2e/foo"), "100.0.0");
+    assert_eq!(
+        fs::read(&source_lockfile_path).expect("reread source branch lockfile"),
+        source_lockfile,
+    );
+    assert!(!workspace.join(Lockfile::FILE_NAME).exists());
+    assert!(!deploy_dir.join(Lockfile::FILE_NAME).exists());
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn legacy_deploy_without_dedicated_lockfile_fresh_resolves() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    write_workspace(&workspace, false);
+    append_workspace_yaml_key(&workspace, "sharedWorkspaceLockfile", false);
+    set_app_foo_dependency(&workspace, "^100.0.0");
+
+    let app_dir = workspace.join("packages/app");
+    assert!(!workspace.join(Lockfile::FILE_NAME).exists());
+    assert!(!app_dir.join(Lockfile::FILE_NAME).exists());
+    pacquet_cmd(&workspace)
+        .with_args([
+            "--filter",
+            "app",
+            "deploy",
+            "--legacy",
+            "--prod",
+            "legacy-deploy-without-dedicated-lockfile",
+        ])
+        .assert()
+        .success();
+
+    let deploy_dir = workspace.join("legacy-deploy-without-dedicated-lockfile");
+    assert_eq!(deployed_package_version(&deploy_dir, "@pnpm.e2e/foo"), "100.1.0");
+    assert!(!workspace.join(Lockfile::FILE_NAME).exists());
+    assert!(!app_dir.join(Lockfile::FILE_NAME).exists());
+    assert!(!deploy_dir.join(Lockfile::FILE_NAME).exists());
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn legacy_deploy_ignores_malformed_dedicated_lockfile() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    write_workspace(&workspace, false);
+    append_workspace_yaml_key(&workspace, "sharedWorkspaceLockfile", false);
+    set_app_foo_dependency(&workspace, "100.0.0");
+
+    pacquet.with_args(["--filter", "app", "install"]).assert().success();
+    set_app_foo_dependency(&workspace, "^100.0.0");
+    let app_dir = workspace.join("packages/app");
+    let source_lockfile_path = app_dir.join(Lockfile::FILE_NAME);
+    let source_lockfile =
+        fs::read_to_string(&source_lockfile_path).expect("read source project lockfile");
+    fs::write(&source_lockfile_path, format!("{source_lockfile}\nlockfileVersion: '9.0'\n"))
+        .expect("duplicate a source project lockfile key");
+    let malformed_source_lockfile =
+        fs::read(&source_lockfile_path).expect("read malformed source project lockfile");
+
+    let output = pacquet_cmd(&workspace)
+        .with_args([
+            "--reporter=ndjson",
+            "--filter",
+            "app",
+            "deploy",
+            "--legacy",
+            "--prod",
+            "legacy-deploy-with-malformed-dedicated-lockfile",
+        ])
+        .output()
+        .expect("deploy with a malformed source project lockfile");
+    assert_ignored_broken_source_lockfile(&output, &app_dir);
+    let deploy_dir = workspace.join("legacy-deploy-with-malformed-dedicated-lockfile");
+    assert_eq!(deployed_package_version(&deploy_dir, "@pnpm.e2e/foo"), "100.1.0");
+    assert!(!workspace.join(Lockfile::FILE_NAME).exists());
+    assert!(!deploy_dir.join(Lockfile::FILE_NAME).exists());
+    assert_eq!(
+        fs::read(&source_lockfile_path).expect("reread malformed source project lockfile"),
+        malformed_source_lockfile,
+    );
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn legacy_deploy_preserves_source_pnpmfile_hooks() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    write_workspace(&workspace, false);
+    set_app_foo_dependency(&workspace, "^100.0.0");
+    fs::write(
+        workspace.join(".pnpmfile.cjs"),
+        r"module.exports = { hooks: { readPackage (pkg) {
+  if (pkg.name === 'app') {
+    pkg.dependencies['@pnpm.e2e/foo'] =
+      pkg.dependencies['@pnpm.e2e/foo'] === '^100.0.0' ? '100.0.0' : '100.1.0'
+  }
+  return pkg
+} } }
+",
+    )
+    .expect("write source pnpmfile");
+
+    pacquet_cmd(&workspace)
+        .with_args([
+            "--filter",
+            "app",
+            "deploy",
+            "--legacy",
+            "--prod",
+            "legacy-deploy-with-pnpmfile",
+        ])
+        .assert()
+        .success();
+
+    let deploy_dir = workspace.join("legacy-deploy-with-pnpmfile");
+    assert!(!workspace.join(Lockfile::FILE_NAME).exists());
+    assert!(!deploy_dir.join(".pnpmfile.cjs").exists());
+    assert_eq!(deployed_package_version(&deploy_dir, "@pnpm.e2e/foo"), "100.0.0");
+    let deploy_manifest: serde_json::Value = serde_json::from_slice(
+        &fs::read(deploy_dir.join("package.json")).expect("read deploy manifest"),
+    )
+    .expect("parse deploy manifest");
+    assert_eq!(deploy_manifest["dependencies"]["@pnpm.e2e/foo"], "^100.0.0");
+    let current_lockfile =
+        Lockfile::load_current_from_virtual_store_dir(&deploy_dir.join("node_modules/.pnpm"))
+            .expect("load deploy current lockfile")
+            .expect("deploy current lockfile exists");
+    let foo_name = PkgName::parse("@pnpm.e2e/foo").expect("parse fixture package name");
+    let foo_dependency = current_lockfile
+        .root_project()
+        .expect("root deploy importer exists")
+        .dependencies
+        .as_ref()
+        .expect("root deploy dependencies exist")
+        .get(&foo_name)
+        .expect("root deploy importer contains foo");
+    assert_eq!(foo_dependency.specifier, "100.0.0");
+    assert_eq!(foo_dependency.version.to_string(), "100.0.0");
+
+    drop((root, mock_instance));
+}
+
+#[test]
 fn deploy_from_shared_lockfile_installs_the_workspace_root_without_its_nested_projects() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();
@@ -1252,8 +1597,14 @@ fn legacy_deploy_without_lockfile_installs_selected_project_at_root() {
         CommandTempCwd::init().add_mocked_registry();
     let AddMockedRegistry { mock_instance, .. } = npmrc_info;
     write_workspace(&workspace, false);
+    set_app_foo_dependency(&workspace, "100.0.0");
 
-    pacquet
+    pacquet.with_arg("install").assert().success();
+    let source_lockfile_path = workspace.join(Lockfile::FILE_NAME);
+    let source_lockfile = fs::read(&source_lockfile_path).expect("read source lockfile");
+    set_app_foo_dependency(&workspace, "^100.0.0");
+
+    pacquet_cmd(&workspace)
         .with_env("PNPM_CONFIG_LOCKFILE", "false")
         .with_args(["--filter", "app", "deploy", "--legacy", "--prod", "legacy-deploy-no-lockfile"])
         .assert()
@@ -1261,8 +1612,82 @@ fn legacy_deploy_without_lockfile_installs_selected_project_at_root() {
 
     let deploy_dir = workspace.join("legacy-deploy-no-lockfile");
     assert!(deploy_dir.join("node_modules/lib").exists());
+    assert_eq!(deployed_package_version(&deploy_dir, "@pnpm.e2e/foo"), "100.1.0");
     assert!(!deploy_dir.join("legacy-deploy-no-lockfile/node_modules").exists());
-    assert!(!deploy_dir.join("pnpm-lock.yaml").exists());
+    assert!(!deploy_dir.join(Lockfile::FILE_NAME).exists());
+    assert_eq!(fs::read(&source_lockfile_path).expect("reread source lockfile"), source_lockfile);
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn legacy_deploy_without_source_lockfile_fresh_resolves() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    write_workspace(&workspace, false);
+    set_app_foo_dependency(&workspace, "^100.0.0");
+
+    pacquet_cmd(&workspace)
+        .with_args([
+            "--filter",
+            "app",
+            "deploy",
+            "--legacy",
+            "--prod",
+            "legacy-deploy-without-source-lockfile",
+        ])
+        .assert()
+        .success();
+
+    let deploy_dir = workspace.join("legacy-deploy-without-source-lockfile");
+    assert_eq!(deployed_package_version(&deploy_dir, "@pnpm.e2e/foo"), "100.1.0");
+    assert!(!workspace.join(Lockfile::FILE_NAME).exists());
+    assert!(!deploy_dir.join(Lockfile::FILE_NAME).exists());
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn legacy_deploy_ignores_malformed_source_lockfile() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    write_workspace(&workspace, false);
+    set_app_foo_dependency(&workspace, "100.0.0");
+
+    pacquet.with_arg("install").assert().success();
+    set_app_foo_dependency(&workspace, "^100.0.0");
+    let source_lockfile_path = workspace.join(Lockfile::FILE_NAME);
+    let source_lockfile = fs::read_to_string(&source_lockfile_path).expect("read source lockfile");
+    fs::write(&source_lockfile_path, format!("{source_lockfile}\nlockfileVersion: '9.0'\n"))
+        .expect("duplicate a source lockfile key");
+    let malformed_source_lockfile =
+        fs::read(&source_lockfile_path).expect("read malformed source lockfile");
+
+    let output = pacquet_cmd(&workspace)
+        .with_args([
+            "--reporter=ndjson",
+            "--filter",
+            "app",
+            "deploy",
+            "--legacy",
+            "--prod",
+            "legacy-deploy-with-malformed-source-lockfile",
+        ])
+        .output()
+        .expect("deploy with a malformed source lockfile");
+    assert_ignored_broken_source_lockfile(&output, &workspace);
+    let deploy_dir = workspace.join("legacy-deploy-with-malformed-source-lockfile");
+    assert_eq!(deployed_package_version(&deploy_dir, "@pnpm.e2e/foo"), "100.1.0");
+    assert!(
+        !deploy_dir.join(Lockfile::FILE_NAME).exists(),
+        "legacy deploy must not write a wanted lockfile after ignoring the malformed source lockfile",
+    );
+    assert_eq!(
+        fs::read(&source_lockfile_path).expect("reread malformed source lockfile"),
+        malformed_source_lockfile,
+    );
 
     drop((root, mock_instance));
 }
@@ -1290,6 +1715,51 @@ fn write_root_project_depending_on_lib(workspace: &Path) {
         .to_string(),
     )
     .unwrap();
+}
+
+fn set_app_foo_dependency(workspace: &Path, specifier: &str) {
+    let manifest_path = workspace.join("packages/app/package.json");
+    let mut manifest: serde_json::Value =
+        serde_json::from_slice(&fs::read(&manifest_path).expect("read app manifest"))
+            .expect("parse app manifest");
+    manifest["dependencies"]["@pnpm.e2e/foo"] = specifier.into();
+    fs::write(manifest_path, manifest.to_string()).expect("write app manifest");
+}
+
+fn deployed_package_version(deploy_dir: &Path, package_name: &str) -> String {
+    let package_manifest: serde_json::Value = serde_json::from_slice(
+        &fs::read(deploy_dir.join("node_modules").join(package_name).join("package.json"))
+            .expect("read deployed package manifest"),
+    )
+    .expect("parse deployed package manifest");
+    package_manifest["version"].as_str().expect("deployed package has a version").to_string()
+}
+
+fn assert_ignored_broken_source_lockfile(output: &Output, lockfile_dir: &Path) {
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        output.status.success(),
+        "legacy deploy should ignore the malformed source lockfile:\n{combined}",
+    );
+    let prefix = dunce::canonicalize(lockfile_dir).expect("canonicalize the source lockfile dir");
+    assert!(
+        combined
+            .lines()
+            .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+            .any(|event| {
+                event["name"] == "pnpm"
+                    && event["level"] == "warn"
+                    && event["prefix"] == prefix.to_string_lossy().as_ref()
+                    && event["message"]
+                        .as_str()
+                        .is_some_and(|message| message.starts_with("Ignoring broken lockfile at "))
+            }),
+        "expected a warning for the ignored source lockfile; got:\n{combined}",
+    );
 }
 
 fn assert_workspace_lockfile_untouched(workspace: &Path, before: &str) {


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#13857.

- Seed pacquet's legacy deploy resolution from source wanted lockfile snapshots,
  preserving a satisfying pinned version instead of selecting the newest
  registry version.
- Keep the deploy manifest as the sole `.` importer and all lockfile and virtual
  store paths target-local, without modifying or copying the source lockfile.
- Preserve source workspace package and pnpmfile hook discovery, along with
  fresh-resolution fallback for disabled, missing, or malformed lockfiles.
- Leave the shared/frozen deploy path unchanged.
- The TypeScript CLI already has the expected behavior; this restores pacquet
  parity.

## Validation

- Rebased onto `main` at `7aab1f8adb`. Resolved the deploy conflict by
  preserving source pnpmfile hooks and source lockfile version preferences.
- `just ready` passed: 10,957 tests passed, 11 skipped by the test configuration.
  Spelling, formatting, workspace compilation, and Clippy also passed.
- Repository pre-push checks passed.
- GitHub CI for the rebased commit must complete separately.

## Squash Commit Body

```text
Legacy deploy initializes its target with a fresh wanted lockfile. Without
source snapshots, resolution chooses the newest registry version even when the
source workspace lockfile already pins a satisfying version.

Build a preferred-version seed from source wanted lockfile snapshots only for
legacy, lockfile-enabled deploys. Keep the target lockfile carrier and output
paths unchanged, and keep the copied post-hook manifest as the sole `.`
importer. Missing or malformed source lockfiles continue to fresh-resolve;
lockfile-disabled and shared/frozen deploys do not receive the seed.

Keep workspace discovery anchored at the source so workspace packages and
pnpmfile hooks continue to work. Add regression coverage for the pinned
version, importer shape, target-local paths, source-lockfile immutability,
hooks, and fallback behavior.

Closes pnpm/pnpm#13857
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The TypeScript CLI already implements the expected behavior; this PR
  restores parity in the Rust `pnpm/` port.
- [x] Added a `pacquet` patch changeset.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-6).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789614681&installation_model_id=426870&pr_number=13984&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13984&signature=0a31f94a86be5412f19cc1002043d6f3982be6969d89ac9f72906d5af561b25e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Legacy deployments now prefer package versions from the available source lockfile.
  - Deployments without a lockfile can resolve dependencies normally.
  - Source lockfiles remain unchanged during deployment.
  - Support includes shared, dedicated, and Git-branch lockfile scenarios.

- **Bug Fixes**
  - Malformed or unavailable source lockfiles are safely ignored, with warnings reported through machine-readable output.
  - Dependency versions, manifests, injected dependencies, and isolated deployment lockfiles are handled consistently.

- **Documentation**
  - Documented legacy deployment lockfile preference behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
