### PR TITLE
fix(global): fail closed on incomplete bin ownership

### DIFF
--- a/.changeset/fail-closed-global-bin-enumeration.md
+++ b/.changeset/fail-closed-global-bin-enumeration.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/global.commands": patch
+"@pnpm/global.packages": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+Fixed `pnpm add -g`, `pnpm update -g`, and `pnpm remove -g` mutating global bins or install directories after only partially reading an installed package group. If any declared package manifest is missing, malformed, or unreadable, pnpm now fails before activation or removal and leaves the existing global installation intact [pnpm/pnpm#13796](https://github.com/pnpm/pnpm/issues/13796).

--- a/pnpm/crates/cli/src/cargo_deps/git/tests.rs
+++ b/pnpm/crates/cli/src/cargo_deps/git/tests.rs
@@ -1,12 +1,10 @@
 use super::{
-    CheckoutPackage, GitPackage, GitSource, Manifest, VendorSourceOptions, import_package,
-    vendor_source, vendored_package,
+    GitPackage, GitSource, Manifest, VendorSourceOptions, vendor_source, vendored_package,
 };
 use pnpm_reporter::SilentReporter;
 use pnpm_store_dir::StoreDir;
 use pnpm_testing_utils::git_repo::GitRepoFixture;
 use std::{
-    collections::BTreeSet,
     fs,
     path::{Path, PathBuf},
     sync::{Arc, atomic::AtomicU8},
@@ -392,7 +390,8 @@ fn a_crate_is_found_past_a_manifest_that_shares_its_name_and_reads_no_version() 
 #[cfg(all(unix, not(target_os = "macos")))]
 #[test]
 fn a_file_whose_name_is_not_utf8_is_refused() {
-    use std::{ffi::OsStr, os::unix::ffi::OsStrExt as _};
+    use super::{CheckoutPackage, import_package};
+    use std::{collections::BTreeSet, ffi::OsStr, os::unix::ffi::OsStrExt as _};
 
     let temp_dir = tempfile::tempdir().unwrap();
     let package_dir = temp_dir.path().join("crate");

--- a/pnpm/crates/cli/src/cli_args/global.rs
+++ b/pnpm/crates/cli/src/cli_args/global.rs
@@ -1133,7 +1133,7 @@ impl FsRemoveDirAll for CmdShimHost {
 }
 
 #[derive(Debug, Display, Error, Diagnostic)]
-#[display("Failed to clean up after global install preparation failed")]
+#[display("Failed to clean up after global install failed before activation")]
 struct GlobalInstallPreparationCleanupError {
     #[error(not(source))]
     #[related]

--- a/pnpm/crates/cli/src/cli_args/global.rs
+++ b/pnpm/crates/cli/src/cli_args/global.rs
@@ -262,7 +262,6 @@ pub async fn handle_global_add<Reporter: self::Reporter + 'static>(
         let existing = discard_install_dir_on_error(
             &install_dir,
             collect_existing_global_installs(&global_pkg_dir, &aliases, &aliases_to_replace)
-                .into_diagnostic()
                 .wrap_err("scan existing global installs"),
         )?;
         let prospective_bins = get_actual_bin_names::<CmdShimHost>(&pkgs, &bins_to_skip);
@@ -321,15 +320,46 @@ pub async fn handle_global_add<Reporter: self::Reporter + 'static>(
 
 /// Discard the half-built install directory when a step of the global
 /// install fails. It holds only this group's install, so leaving it
-/// behind would accumulate across failed runs.
+/// behind would accumulate across failed runs. A discard that fails is
+/// reported alongside the step's own error, naming the directory it left
+/// behind.
 fn discard_install_dir_on_error<Output, Failure>(
     install_dir: &Path,
     result: Result<Output, Failure>,
-) -> Result<Output, Failure> {
-    if result.is_err() {
-        let _ = fs::remove_dir_all(install_dir);
-    }
-    result
+) -> miette::Result<Output>
+where
+    Failure: Into<miette::Report>,
+{
+    discard_install_dir_on_error_with_fs::<CmdShimHost, _, _>(install_dir, result)
+}
+
+fn discard_install_dir_on_error_with_fs<Sys, Output, Failure>(
+    install_dir: &Path,
+    result: Result<Output, Failure>,
+) -> miette::Result<Output>
+where
+    Sys: FsRemoveDirAll,
+    Failure: Into<miette::Report>,
+{
+    let install_error = match result {
+        Ok(output) => return Ok(output),
+        Err(error) => error.into(),
+    };
+    Err(match Sys::remove_dir_all(install_dir) {
+        Ok(()) => install_error,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => install_error,
+        Err(source) => GlobalInstallPreparationCleanupError {
+            cleanup_reports: vec![ArtifactCleanupError {
+                context: format!(
+                    "remove fresh global install directory at {}",
+                    install_dir.display(),
+                ),
+                source,
+            }],
+            install_error: install_error.into(),
+        }
+        .into(),
+    })
 }
 
 /// `pnpm update -g`. Reinstalls each matching group (within its existing
@@ -415,17 +445,21 @@ pub async fn handle_global_update<Reporter: self::Reporter + 'static>(
             ),
         )?;
 
-        let protected = discard_install_dir_on_error(
+        let (group_to_replace, protected) = discard_install_dir_on_error(
             &install_dir,
-            bin_names_of_other_groups(&global_pkg_dir, &HashSet::from([pkg.hash.clone()]))
-                .into_diagnostic()
-                .wrap_err("scan global packages"),
+            (|| {
+                let group_to_replace = snapshot_global_package(pkg.clone())?;
+                let protected =
+                    bin_names_of_other_groups(&global_pkg_dir, &HashSet::from([pkg.hash.clone()]))?;
+                Ok::<_, miette::Report>((group_to_replace, protected))
+            })()
+            .wrap_err("scan global package bin ownership"),
         )?;
         let prospective_bins = get_actual_bin_names::<CmdShimHost>(&pkgs, &bins_to_skip);
         let replacement_plan = discard_install_dir_on_error(
             &install_dir,
             plan_replaced_global_bins(
-                std::slice::from_ref(pkg),
+                std::slice::from_ref(&group_to_replace),
                 &global_bin_dir,
                 &prospective_bins,
                 &protected,
@@ -460,7 +494,7 @@ pub async fn handle_global_update<Reporter: self::Reporter + 'static>(
         if let Some(leftover) = cleanup_replaced_global_installs(
             &global_pkg_dir,
             &global_bin_dir,
-            std::slice::from_ref(pkg),
+            std::slice::from_ref(&group_to_replace),
             &pkg.hash,
             &activated_bins,
             &protected,
@@ -639,10 +673,14 @@ pub fn handle_global_remove<Reporter: self::Reporter>(
 
     // Bins shared with (and owned by) groups that survive this removal must
     // not be unlinked, or we'd delete another global package's bin.
-    let exclude: HashSet<String> = groups.iter().map(|pkg| pkg.hash.clone()).collect();
+    let groups = groups
+        .into_iter()
+        .map(snapshot_global_package)
+        .collect::<miette::Result<Vec<_>>>()
+        .wrap_err("read global package bin ownership")?;
+    let exclude: HashSet<String> = groups.iter().map(|pkg| pkg.info.hash.clone()).collect();
     let protected = bin_names_of_other_groups(&global_pkg_dir, &exclude)
-        .into_diagnostic()
-        .wrap_err("scan global packages")?;
+        .wrap_err("scan global package bin ownership")?;
     let shims_to_restore = virtual_shims_to_restore(
         &groups,
         &global_bin_dir,
@@ -652,7 +690,7 @@ pub fn handle_global_remove<Reporter: self::Reporter>(
     let restored_bin_names = shims_to_restore.values().flatten().cloned().collect::<HashSet<_>>();
     let affected_bin_names = groups
         .iter()
-        .flat_map(get_installed_bin_names)
+        .flat_map(|group| group.bin_names.iter().cloned())
         .filter(|bin| !protected.contains(bin))
         .collect::<HashSet<_>>();
     let mut bins_to_keep = protected;
@@ -718,14 +756,14 @@ fn check_virtual_shim_conflicts(
 }
 
 fn virtual_shims_to_restore(
-    groups: &[GlobalPackageInfo],
+    groups: &[GlobalPackageBinSnapshot],
     global_bin_dir: &Path,
     protected: &HashSet<String>,
     enabled: &GlobalShims,
 ) -> miette::Result<BTreeMap<String, BTreeSet<String>>> {
     let mut shims = BTreeMap::<String, BTreeSet<String>>::new();
     for group in groups {
-        for package in read_installed_packages(&group.install_dir) {
+        for package in read_installed_packages(&group.info.install_dir) {
             add_package_shims_to_restore(&package, global_bin_dir, protected, enabled, &mut shims)?;
         }
     }
@@ -774,7 +812,7 @@ impl ReplacedGlobalBinPlan {
 }
 
 fn plan_replaced_global_bins(
-    groups: &[GlobalPackageInfo],
+    groups: &[GlobalPackageBinSnapshot],
     global_bin_dir: &Path,
     prospective_bins: &HashSet<String>,
     protected_bins: &HashSet<String>,
@@ -785,7 +823,7 @@ fn plan_replaced_global_bins(
         virtual_shims_to_restore(groups, global_bin_dir, &occupied_bins, enabled)?;
     let affected_bin_names = groups
         .iter()
-        .flat_map(get_installed_bin_names)
+        .flat_map(|group| group.bin_names.iter().cloned())
         .filter(|bin| !occupied_bins.contains(bin))
         .collect();
     Ok(ReplacedGlobalBinPlan { shims_to_restore, affected_bin_names })
@@ -1070,26 +1108,66 @@ async fn prompt_approve_global_builds<Reporter: self::Reporter + 'static>(
 }
 
 struct ExistingGlobalInstalls {
-    groups_to_replace: Vec<GlobalPackageInfo>,
+    groups_to_replace: Vec<GlobalPackageBinSnapshot>,
     protected_bins: HashSet<String>,
+}
+
+/// A global group paired with the bin names it owns, read before anything is
+/// mutated. Every destructive path decides what to unlink from this snapshot,
+/// so an unreadable manifest fails the command instead of silently narrowing
+/// the group's ownership mid-operation.
+#[derive(Clone)]
+struct GlobalPackageBinSnapshot {
+    info: GlobalPackageInfo,
+    bin_names: Vec<String>,
+}
+
+trait FsRemoveDirAll {
+    fn remove_dir_all(path: &Path) -> io::Result<()>;
+}
+
+impl FsRemoveDirAll for CmdShimHost {
+    fn remove_dir_all(path: &Path) -> io::Result<()> {
+        fs::remove_dir_all(path)
+    }
+}
+
+#[derive(Debug, Display, Error, Diagnostic)]
+#[display("Failed to clean up after global install preparation failed")]
+struct GlobalInstallPreparationCleanupError {
+    #[error(not(source))]
+    #[related]
+    cleanup_reports: Vec<ArtifactCleanupError>,
+    #[error(source)]
+    #[diagnostic_source]
+    install_error: Box<dyn Diagnostic + Send + Sync>,
+}
+
+fn snapshot_global_package(info: GlobalPackageInfo) -> miette::Result<GlobalPackageBinSnapshot> {
+    let bin_names = get_installed_bin_names(&info).map_err(miette::Report::new)?;
+    Ok(GlobalPackageBinSnapshot { info, bin_names })
 }
 
 fn collect_existing_global_installs(
     global_pkg_dir: &Path,
     aliases: &[String],
     aliases_to_replace: &[String],
-) -> std::io::Result<ExistingGlobalInstalls> {
+) -> miette::Result<ExistingGlobalInstalls> {
     let mut groups_to_replace = Vec::new();
     let mut seen = HashSet::new();
     for alias in aliases_to_replace {
-        if let Some(pkg) = find_global_package(global_pkg_dir, alias)?
+        if let Some(pkg) = find_global_package(global_pkg_dir, alias).into_diagnostic()?
             && should_replace_existing_package(&pkg, aliases, aliases_to_replace)
             && seen.insert(pkg.hash.clone())
         {
             groups_to_replace.push(pkg);
         }
     }
-    let exclude = groups_to_replace.iter().map(|pkg| pkg.hash.clone()).collect();
+    let groups_to_replace = groups_to_replace
+        .into_iter()
+        .map(snapshot_global_package)
+        .collect::<miette::Result<Vec<_>>>()?;
+    let exclude = groups_to_replace.iter().map(|pkg| pkg.info.hash.clone()).collect();
     let protected_bins = bin_names_of_other_groups(global_pkg_dir, &exclude)?;
     Ok(ExistingGlobalInstalls { groups_to_replace, protected_bins })
 }
@@ -1111,7 +1189,7 @@ struct GlobalInstallCleanup<'a> {
 }
 
 struct GlobalRemovalTransaction<'a> {
-    groups: &'a [GlobalPackageInfo],
+    groups: &'a [GlobalPackageBinSnapshot],
     cleanup: &'a GlobalInstallCleanup<'a>,
     affected_bin_names: &'a HashSet<String>,
 }
@@ -1140,7 +1218,7 @@ impl FsGlobalRemoval for CmdShimHost {}
 fn cleanup_replaced_global_installs(
     global_pkg_dir: &Path,
     global_bin_dir: &Path,
-    groups: &[GlobalPackageInfo],
+    groups: &[GlobalPackageBinSnapshot],
     active_hash: &str,
     activated_bins: &HashSet<String>,
     protected_bins: &HashSet<String>,
@@ -1153,7 +1231,7 @@ fn cleanup_replaced_global_installs(
     bins_to_keep.extend(restored_bin_names.iter().cloned());
     let affected_bin_names = groups
         .iter()
-        .flat_map(get_installed_bin_names)
+        .flat_map(|group| group.bin_names.iter().cloned())
         .filter(|bin| !bins_to_keep.contains(bin))
         .collect::<HashSet<_>>();
     let cleanup = GlobalInstallCleanup {
@@ -1198,8 +1276,8 @@ fn remove_global_install_entries<Sys: FsGlobalRemoval>(
 
     let mut removed_hash_groups = Vec::new();
     for group in transaction.groups {
-        match remove_global_hash_link::<Sys>(group, cleanup) {
-            Ok(true) => removed_hash_groups.push(group),
+        match remove_global_hash_link::<Sys>(&group.info, cleanup) {
+            Ok(true) => removed_hash_groups.push(&group.info),
             Ok(false) => {}
             Err(report) => {
                 return removed_global_install_result(restore_removed_hash_links::<Sys>(
@@ -1239,10 +1317,10 @@ fn restore_removed_hash_links<Sys: FsGlobalRemoval>(
 }
 
 fn cleanup_removed_global_install_dirs(
-    groups: &[GlobalPackageInfo],
+    groups: &[GlobalPackageBinSnapshot],
     cleanup: &GlobalInstallCleanup<'_>,
 ) -> Vec<ArtifactCleanupError> {
-    groups.iter().filter_map(|group| cleanup_global_install_dir(group, cleanup)).collect()
+    groups.iter().filter_map(|group| cleanup_global_install_dir(&group.info, cleanup)).collect()
 }
 
 fn removed_global_install_result(
@@ -1399,13 +1477,13 @@ fn npm_alias_target(spec: Option<&str>) -> Option<String> {
 fn bin_names_of_other_groups(
     global_pkg_dir: &Path,
     exclude_hashes: &HashSet<String>,
-) -> std::io::Result<HashSet<String>> {
+) -> miette::Result<HashSet<String>> {
     let mut names = HashSet::new();
-    for pkg in scan_global_packages(global_pkg_dir)? {
+    for pkg in scan_global_packages(global_pkg_dir).into_diagnostic()? {
         if exclude_hashes.contains(&pkg.hash) {
             continue;
         }
-        for bin in get_installed_bin_names(&pkg) {
+        for bin in get_installed_bin_names(&pkg).map_err(miette::Report::new)? {
             names.insert(bin);
         }
     }

--- a/pnpm/crates/cli/src/cli_args/global/activation/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/global/activation/tests.rs
@@ -1,7 +1,8 @@
 use super::{
     super::{
-        GlobalInstallCleanup, GlobalRemovalTransaction, cleanup_replaced_global_installs,
-        plan_replaced_global_bins, remove_global_install_entries, restore_virtual_shims,
+        GlobalInstallCleanup, GlobalPackageBinSnapshot, GlobalRemovalTransaction,
+        cleanup_replaced_global_installs, plan_replaced_global_bins, remove_global_install_entries,
+        restore_virtual_shims, snapshot_global_package,
     },
     BinSlotKind, FsArtifactProbe, FsRename, FsSwapHashLink, SavedBinSlot,
     activate_global_install_with_extra_bin_names, directory_symlink_slots, hash_linked_packages,
@@ -701,11 +702,12 @@ fn cleanup_after_activation_preserves_current_state_and_external_install() {
         "active-hash",
         &["activated", "survivor", "obsolete"],
     );
-    let external_group = GlobalPackageInfo {
+    let external_group = snapshot_global_package(GlobalPackageInfo {
         hash: "external-hash".to_string(),
         install_dir: external_install_dir.clone(),
         dependencies: Vec::new(),
-    };
+    })
+    .expect("snapshot the external group's bin ownership");
     for bin_name in ["activated", "survivor", "obsolete"] {
         fs::write(global_bin_dir.join(bin_name), b"bin\n").expect("seed global bin");
     }
@@ -834,11 +836,12 @@ fn replacing_a_package_that_drops_a_bin_restores_its_recorded_shim() {
     fs::write(global_bin_dir.join("node"), b"old global bin\n").expect("seed global bin");
     record_virtual_shim_state(&global_bin_dir, "node", &["node".to_string()])
         .expect("record shim restoration state");
-    let group = GlobalPackageInfo {
+    let group = snapshot_global_package(GlobalPackageInfo {
         hash: "old-hash".to_string(),
         install_dir: install_dir.clone(),
         dependencies: vec![("node".to_string(), "1.0.0".to_string())],
-    };
+    })
+    .expect("snapshot the replaced group's bin ownership");
     let old_hash_link = pnpm_global::get_hash_link(&global_pkg_dir, "old-hash");
     force_symlink_dir(&install_dir, &old_hash_link).expect("seed old hash link");
     fs::create_dir_all(&fresh_install_dir).expect("create fresh install directory");
@@ -949,7 +952,7 @@ fn global_removal_reports_cleanup_failure_and_keeps_the_group() {
     assert!(global_bin_dir.join("blocked").is_dir());
     assert!(!global_bin_dir.join("stale").exists());
     assert!(hash_link.exists());
-    assert!(group.install_dir.exists());
+    assert!(group.info.install_dir.exists());
 }
 
 #[cfg(windows)]
@@ -1377,7 +1380,11 @@ impl ActivationFixture {
     }
 }
 
-fn global_package_with_bins(install_dir: &Path, hash: &str, bins: &[&str]) -> GlobalPackageInfo {
+fn global_package_with_bins(
+    install_dir: &Path,
+    hash: &str,
+    bins: &[&str],
+) -> GlobalPackageBinSnapshot {
     let alias = "old-package";
     let package_dir = install_dir.join("node_modules").join(alias);
     fs::create_dir_all(&package_dir).expect("create installed package directory");
@@ -1395,11 +1402,12 @@ fn global_package_with_bins(install_dir: &Path, hash: &str, bins: &[&str]) -> Gl
         .expect("serialize installed package manifest"),
     )
     .expect("write installed package manifest");
-    GlobalPackageInfo {
+    snapshot_global_package(GlobalPackageInfo {
         hash: hash.to_string(),
         install_dir: install_dir.to_path_buf(),
         dependencies: vec![(alias.to_string(), "1.0.0".to_string())],
-    }
+    })
+    .expect("snapshot the installed group's bin ownership")
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/pnpm/crates/cli/src/cli_args/global/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/global/tests.rs
@@ -1,8 +1,10 @@
 use super::{
-    FsGlobalRemoval, GlobalInstallCleanup, GlobalRemovalTransaction, activation::FsRename,
-    check_virtual_shim_conflicts, commit_global_removal, infer_local_package_alias,
+    FsGlobalRemoval, FsRemoveDirAll, GlobalInstallCleanup, GlobalPackageBinSnapshot,
+    GlobalRemovalTransaction, activation::FsRename, check_virtual_shim_conflicts,
+    commit_global_removal, discard_install_dir_on_error_with_fs, infer_local_package_alias,
     is_windows_drive_path, replacement_aliases, resolve_local_param,
-    should_replace_existing_package, split_comma_separated, update_selectors,
+    should_replace_existing_package, snapshot_global_package, split_comma_separated,
+    update_selectors,
 };
 use miette::IntoDiagnostic;
 use pnpm_cmd_shim::{Host as CmdShimHost, PackageBinSource, remove_bin as remove_cmd_shim};
@@ -183,8 +185,8 @@ fn later_hash_cleanup_failure_restores_earlier_groups() {
         fs::read(fixture.global_bin_dir.join("first")).expect("read first bin"),
         b"old first\n",
     );
-    assert!(pnpm_global::get_hash_link(&fixture.global_pkg_dir, &first_group.hash).exists());
-    assert!(first_group.install_dir.exists());
+    assert!(pnpm_global::get_hash_link(&fixture.global_pkg_dir, &first_group.info.hash).exists());
+    assert!(first_group.info.install_dir.exists());
 }
 
 #[test]
@@ -343,11 +345,71 @@ fn exact_aliases_still_replace_mixed_groups() {
     ));
 }
 
+#[test]
+fn ownership_snapshot_preserves_manifest_diagnostic_codes() {
+    struct FailingFreshInstallCleanup;
+
+    impl FsRemoveDirAll for FailingFreshInstallCleanup {
+        fn remove_dir_all(_: &Path) -> io::Result<()> {
+            Err(io::Error::from(io::ErrorKind::PermissionDenied))
+        }
+    }
+
+    let root = tempfile::tempdir().expect("create ownership fixture");
+    let info = GlobalPackageInfo {
+        hash: "hash".to_string(),
+        install_dir: root.path().to_path_buf(),
+        dependencies: vec![("dependency".to_string(), "1.0.0".to_string())],
+    };
+    let manifest_path = root.path().join("node_modules/dependency/package.json");
+
+    let missing = snapshot_global_package(info.clone())
+        .err()
+        .expect("a missing ownership manifest must fail");
+    let missing: &(dyn miette::Diagnostic + Send + Sync) = missing.as_ref();
+    assert_eq!(
+        miette::Diagnostic::code(missing).map(|code| code.to_string()),
+        Some("ERR_PNPM_PACKAGE_MANIFEST_IO_ERROR".to_string()),
+    );
+
+    let missing = snapshot_global_package(info.clone())
+        .err()
+        .expect("a missing ownership manifest must fail");
+    let cleanup_error = discard_install_dir_on_error_with_fs::<FailingFreshInstallCleanup, (), _>(
+        root.path(),
+        Err(missing),
+    )
+    .expect_err("a fresh install that cannot be discarded must fail");
+    let cleanup_diagnostic: &(dyn miette::Diagnostic + Send + Sync) = cleanup_error.as_ref();
+    let install_diagnostic = miette::Diagnostic::diagnostic_source(cleanup_diagnostic)
+        .expect("cleanup failure retains the install diagnostic");
+    assert_eq!(
+        miette::Diagnostic::code(install_diagnostic).map(|code| code.to_string()),
+        Some("ERR_PNPM_PACKAGE_MANIFEST_IO_ERROR".to_string()),
+    );
+    let cleanup_reports = miette::Diagnostic::related(cleanup_diagnostic)
+        .expect("cleanup failure reports the remaining artifact")
+        .collect::<Vec<_>>();
+    assert_eq!(cleanup_reports.len(), 1);
+    assert!(cleanup_reports[0].to_string().contains(&root.path().display().to_string()));
+
+    std::fs::create_dir_all(manifest_path.parent().expect("manifest parent"))
+        .expect("create dependency directory");
+    std::fs::write(manifest_path, "{").expect("write malformed ownership manifest");
+    let malformed =
+        snapshot_global_package(info).err().expect("a malformed ownership manifest must fail");
+    let malformed: &(dyn miette::Diagnostic + Send + Sync) = malformed.as_ref();
+    assert_eq!(
+        miette::Diagnostic::code(malformed).map(|code| code.to_string()),
+        Some("ERR_PNPM_PACKAGE_MANIFEST_SERIALIZATION_ERROR".to_string()),
+    );
+}
+
 struct GlobalRemovalFixture {
     _root: TempDir,
     global_pkg_dir: PathBuf,
     global_bin_dir: PathBuf,
-    group: GlobalPackageInfo,
+    group: GlobalPackageBinSnapshot,
     affected_bin_names: HashSet<String>,
 }
 
@@ -399,7 +461,7 @@ impl GlobalRemovalFixture {
             _root: root,
             global_pkg_dir,
             global_bin_dir,
-            group,
+            group: snapshot_global_package(group).expect("snapshot fixture group ownership"),
             affected_bin_names: HashSet::from(["owner".to_string(), "other".to_string()]),
         }
     }
@@ -425,7 +487,7 @@ impl GlobalRemovalFixture {
         }
     }
 
-    fn seed_group(&self, spec: GlobalGroupSpec<'_>) -> GlobalPackageInfo {
+    fn seed_group(&self, spec: GlobalGroupSpec<'_>) -> GlobalPackageBinSnapshot {
         let install_dir = self.global_pkg_dir.join(format!("install-{}", spec.alias));
         let package_dir = install_dir.join("node_modules").join(spec.alias);
         fs::create_dir_all(&package_dir).expect("create installed package directory");
@@ -452,7 +514,7 @@ impl GlobalRemovalFixture {
             &pnpm_global::get_hash_link(&self.global_pkg_dir, &group.hash),
         )
         .expect("seed global hash link");
-        group
+        snapshot_global_package(group).expect("snapshot seeded group ownership")
     }
 
     fn assert_package_commands_restored(&self) {
@@ -464,8 +526,8 @@ impl GlobalRemovalFixture {
             fs::read(self.global_bin_dir.join("other")).expect("read other bin"),
             b"old other\n",
         );
-        assert!(pnpm_global::get_hash_link(&self.global_pkg_dir, &self.group.hash).exists());
-        assert!(self.group.install_dir.exists());
+        assert!(pnpm_global::get_hash_link(&self.global_pkg_dir, &self.group.info.hash).exists());
+        assert!(self.group.info.install_dir.exists());
         let backup_count = fs::read_dir(&self.global_bin_dir)
             .expect("read global bin directory")
             .filter_map(Result::ok)

--- a/pnpm/crates/cli/tests/suite/global.rs
+++ b/pnpm/crates/cli/tests/suite/global.rs
@@ -41,13 +41,27 @@ fn prepare_global_home(pnpm_home: &Path, npmrc_info: &AddMockedRegistry) {
 /// passes for the mutating commands).
 #[cfg(unix)]
 fn global_command(workspace: &Path, pnpm_home: &Path) -> Command {
+    // macOS temp paths use `/var` as an alias for `/private/var`, while
+    // scanning a hash symlink canonicalizes its install directory. Give the
+    // command the canonical fixture home so containment checks compare paths
+    // with the same spelling.
+    let pnpm_home = match fs::canonicalize(pnpm_home) {
+        Ok(pnpm_home) => pnpm_home,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            let parent = pnpm_home.parent().expect("pnpm test home parent");
+            fs::canonicalize(parent)
+                .expect("canonicalize the pnpm test home parent")
+                .join(pnpm_home.file_name().expect("pnpm test home name"))
+        }
+        Err(error) => panic!("canonicalize the pnpm test home: {error}"),
+    };
     let global_bin = pnpm_home.join("bin");
     let existing_path = std::env::var("PATH").unwrap_or_default();
     let path = format!("{}:{existing_path}", global_bin.display());
     Command::cargo_bin("pnpm")
         .expect("find the pnpm binary")
         .with_current_dir(workspace)
-        .with_env("PNPM_HOME", pnpm_home)
+        .with_env("PNPM_HOME", &pnpm_home)
         .with_env("PATH", path)
         .with_env("XDG_STATE_HOME", pnpm_home.join("state-home"))
         .with_env("XDG_CONFIG_HOME", pnpm_home.join("config-home"))

--- a/pnpm/crates/cli/tests/suite/global.rs
+++ b/pnpm/crates/cli/tests/suite/global.rs
@@ -74,6 +74,98 @@ fn symlink_entries(dir: &Path) -> Vec<PathBuf> {
         .collect()
 }
 
+#[cfg(unix)]
+#[derive(Debug, PartialEq, Eq)]
+struct FixtureEntry {
+    path: PathBuf,
+    kind: &'static str,
+    payload: Vec<u8>,
+}
+
+#[cfg(unix)]
+fn snapshot_tree(root: &Path) -> Vec<FixtureEntry> {
+    let mut entries = walkdir::WalkDir::new(root)
+        .min_depth(1)
+        .follow_links(false)
+        .into_iter()
+        .map(|entry| {
+            let entry = entry.expect("walk the global fixture tree");
+            let path = entry.path().strip_prefix(root).expect("fixture entry is under its root");
+            if entry.file_type().is_dir() {
+                FixtureEntry { path: path.to_path_buf(), kind: "directory", payload: Vec::new() }
+            } else if entry.file_type().is_symlink() {
+                FixtureEntry {
+                    path: path.to_path_buf(),
+                    kind: "symlink",
+                    payload: fs::read_link(entry.path())
+                        .expect("read fixture symlink")
+                        .to_string_lossy()
+                        .into_owned()
+                        .into_bytes(),
+                }
+            } else {
+                FixtureEntry {
+                    path: path.to_path_buf(),
+                    kind: "file",
+                    payload: fs::read(entry.path()).expect("read fixture file"),
+                }
+            }
+        })
+        .collect::<Vec<_>>();
+    entries.sort_by(|left, right| left.path.cmp(&right.path));
+    entries
+}
+
+#[cfg(unix)]
+fn dependency_manifest_path(install_dir: &Path, alias: &str) -> PathBuf {
+    install_dir.join("node_modules").join(alias).join("package.json")
+}
+
+#[cfg(unix)]
+fn seed_global_group(
+    global_pkg_dir: &Path,
+    hash: &str,
+    packages: &[(&str, Option<&str>)],
+) -> PathBuf {
+    let install_dir = global_pkg_dir.join(format!("{hash}-install"));
+    fs::create_dir_all(&install_dir).expect("create seeded global install directory");
+    let dependencies = packages
+        .iter()
+        .map(|(alias, _)| ((*alias).to_string(), serde_json::json!("1.0.0")))
+        .collect::<serde_json::Map<_, _>>();
+    fs::write(
+        install_dir.join("package.json"),
+        serde_json::json!({ "dependencies": dependencies }).to_string(),
+    )
+    .expect("write seeded global group manifest");
+    for (alias, manifest) in packages {
+        let manifest_path = dependency_manifest_path(&install_dir, alias);
+        fs::create_dir_all(manifest_path.parent().expect("dependency manifest parent"))
+            .expect("create seeded global dependency directory");
+        if let Some(manifest) = manifest {
+            fs::write(manifest_path, manifest).expect("write seeded global dependency manifest");
+        }
+    }
+    std::os::unix::fs::symlink(
+        install_dir.file_name().expect("seeded install directory name"),
+        global_pkg_dir.join(hash),
+    )
+    .expect("link seeded global group");
+    install_dir
+}
+
+#[cfg(unix)]
+fn assert_fixture_paths(root: &Path, paths: &[&Path]) {
+    for path in paths {
+        assert!(
+            path.starts_with(root),
+            "global test fixture path {} must stay under {}",
+            path.display(),
+            root.display(),
+        );
+    }
+}
+
 /// `pacquet add -g <pkg>` installs the package under the global packages
 /// directory, links its bin into the global bin directory, and records a
 /// cache-keyed hash symlink. `list -g` then reports it, and `remove -g`
@@ -908,6 +1000,296 @@ fn recursive_global_outdated_reads_each_global_install_lockfile() {
     );
 
     drop((root, npmrc_info));
+}
+
+#[cfg(unix)]
+#[test]
+fn global_update_preflights_incomplete_target_ownership_before_activation() {
+    use assert_cmd::assert::OutputAssertExt;
+
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let pnpm_home = root.path().join("pnpm-home");
+    let global_bin = pnpm_home.join("bin");
+    let global_pkg_dir = pnpm_home.join("global/v11");
+    prepare_global_home(&pnpm_home, &npmrc_info);
+    fs::create_dir_all(&global_pkg_dir).expect("create global packages directory");
+    assert_fixture_paths(
+        root.path(),
+        &[&pnpm_home, &global_bin, &global_pkg_dir, &npmrc_info.store_dir, &npmrc_info.cache_dir],
+    );
+
+    let target_install =
+        seed_global_group(&global_pkg_dir, "target-hash", &[("@pnpm.e2e/print-version", None)]);
+    let stale_bin = global_bin.join("stale-version-bin");
+    fs::write(&stale_bin, b"old command\n").expect("seed the stale global bin");
+    let packages_before = snapshot_tree(&global_pkg_dir);
+    let bins_before = snapshot_tree(&global_bin);
+
+    for attempt in 1..=2 {
+        let output = global_command(&workspace, &pnpm_home)
+            .with_args(["update", "-g", "--latest", "@pnpm.e2e/print-version"])
+            .output()
+            .expect("run global update with incomplete ownership");
+        assert!(
+            !output.status.success(),
+            "attempt {attempt} must reject incomplete ownership; stdout: {}; stderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+        assert_eq!(snapshot_tree(&global_pkg_dir), packages_before);
+        assert_eq!(snapshot_tree(&global_bin), bins_before);
+    }
+
+    fs::write(
+        dependency_manifest_path(&target_install, "@pnpm.e2e/print-version"),
+        r#"{"name":"@pnpm.e2e/print-version","version":"1.0.0","bin":{"stale-version-bin":"old.js"}}"#,
+    )
+    .expect("repair target dependency manifest");
+
+    global_command(&workspace, &pnpm_home)
+        .with_args(["update", "-g", "--latest", "@pnpm.e2e/print-version"])
+        .assert()
+        .success();
+    assert!(!stale_bin.exists(), "the repaired retry must remove the genuinely stale bin");
+    assert!(global_bin.join("print-version").exists());
+    assert!(!target_install.exists());
+    assert_eq!(symlink_entries(&global_pkg_dir).len(), 1);
+
+    global_command(&workspace, &pnpm_home)
+        .with_args(["update", "-g", "--latest", "@pnpm.e2e/print-version"])
+        .assert()
+        .success();
+    assert!(!stale_bin.exists());
+    assert!(global_bin.join("print-version").exists());
+    assert_eq!(symlink_entries(&global_pkg_dir).len(), 1);
+
+    drop((root, npmrc_info));
+}
+
+#[cfg(unix)]
+#[test]
+fn global_add_preflights_incomplete_survivor_ownership_before_activation() {
+    use assert_cmd::assert::OutputAssertExt;
+
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let pnpm_home = root.path().join("pnpm-home");
+    let global_bin = pnpm_home.join("bin");
+    let global_pkg_dir = pnpm_home.join("global/v11");
+    prepare_global_home(&pnpm_home, &npmrc_info);
+    fs::create_dir_all(&global_pkg_dir).expect("create global packages directory");
+    assert_fixture_paths(
+        root.path(),
+        &[&pnpm_home, &global_bin, &global_pkg_dir, &npmrc_info.store_dir, &npmrc_info.cache_dir],
+    );
+
+    let target_install = seed_global_group(
+        &global_pkg_dir,
+        "target-hash",
+        &[(
+            "@foo/touch-file-one-bin",
+            Some(
+                r#"{"name":"@foo/touch-file-one-bin","version":"0.0.0","bin":{"shared":"shared.js","stale":"stale.js"}}"#,
+            ),
+        )],
+    );
+    let survivor_install =
+        seed_global_group(&global_pkg_dir, "survivor-hash", &[("keeper", Some("{"))]);
+    let shared_bin = global_bin.join("shared");
+    let stale_bin = global_bin.join("stale");
+    fs::write(&shared_bin, b"keeper command\n").expect("seed survivor-owned bin");
+    fs::write(&stale_bin, b"target command\n").expect("seed target-owned bin");
+    let packages_before = snapshot_tree(&global_pkg_dir);
+    let bins_before = snapshot_tree(&global_bin);
+
+    for attempt in 1..=2 {
+        let output = global_command(&workspace, &pnpm_home)
+            .with_args(["add", "-g", "@foo/touch-file-one-bin"])
+            .output()
+            .expect("run global add with incomplete survivor ownership");
+        assert!(
+            !output.status.success(),
+            "attempt {attempt} must reject incomplete survivor ownership; stdout: {}; stderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+        assert_eq!(snapshot_tree(&global_pkg_dir), packages_before);
+        assert_eq!(snapshot_tree(&global_bin), bins_before);
+    }
+
+    fs::write(
+        dependency_manifest_path(&survivor_install, "keeper"),
+        r#"{"name":"keeper","version":"1.0.0","bin":{"shared":"keeper.js"}}"#,
+    )
+    .expect("repair survivor dependency manifest");
+
+    global_command(&workspace, &pnpm_home)
+        .with_args(["add", "-g", "@foo/touch-file-one-bin"])
+        .assert()
+        .success();
+    assert_eq!(fs::read(&shared_bin).expect("read survivor-owned bin"), b"keeper command\n");
+    assert!(!stale_bin.exists());
+    assert!(global_bin.join("touch-file-one-bin").exists());
+    assert!(!target_install.exists());
+    assert!(survivor_install.exists());
+    assert_eq!(symlink_entries(&global_pkg_dir).len(), 2);
+
+    global_command(&workspace, &pnpm_home)
+        .with_args(["add", "-g", "@foo/touch-file-one-bin"])
+        .assert()
+        .success();
+    assert_eq!(fs::read(&shared_bin).expect("read survivor-owned bin"), b"keeper command\n");
+    assert!(!stale_bin.exists());
+    assert!(global_bin.join("touch-file-one-bin").exists());
+    assert_eq!(symlink_entries(&global_pkg_dir).len(), 2);
+
+    drop((root, npmrc_info));
+}
+
+#[cfg(unix)]
+#[test]
+fn global_remove_preflights_all_targets_before_mutating_any_group() {
+    use assert_cmd::assert::OutputAssertExt;
+
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let pnpm_home = root.path().join("pnpm-home");
+    let global_bin = pnpm_home.join("bin");
+    let global_pkg_dir = pnpm_home.join("global/v11");
+    fs::create_dir_all(&global_bin).expect("create global bin directory");
+    fs::create_dir_all(&global_pkg_dir).expect("create global packages directory");
+    assert_fixture_paths(root.path(), &[&pnpm_home, &global_bin, &global_pkg_dir]);
+
+    let first_install = seed_global_group(
+        &global_pkg_dir,
+        "first-hash",
+        &[(
+            "victim-a",
+            Some(r#"{"name":"victim-a","version":"1.0.0","bin":{"victim-a-bin":"cli.js"}}"#),
+        )],
+    );
+    let second_install = seed_global_group(&global_pkg_dir, "second-hash", &[("victim-b", None)]);
+    let first_bin = global_bin.join("victim-a-bin");
+    let second_bin = global_bin.join("victim-b-bin");
+    fs::write(&first_bin, b"first command\n").expect("seed first target bin");
+    fs::write(&second_bin, b"second command\n").expect("seed second target bin");
+    let packages_before = snapshot_tree(&global_pkg_dir);
+    let bins_before = snapshot_tree(&global_bin);
+
+    for attempt in 1..=2 {
+        let output = global_command(&workspace, &pnpm_home)
+            .with_args(["remove", "-g", "victim-a", "victim-b"])
+            .output()
+            .expect("run multi-target global remove");
+        assert!(
+            !output.status.success(),
+            "attempt {attempt} must reject an incomplete target; stdout: {}; stderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+        assert_eq!(snapshot_tree(&global_pkg_dir), packages_before);
+        assert_eq!(snapshot_tree(&global_bin), bins_before);
+    }
+
+    fs::write(
+        dependency_manifest_path(&second_install, "victim-b"),
+        r#"{"name":"victim-b","version":"1.0.0","bin":{"victim-b-bin":"cli.js"}}"#,
+    )
+    .expect("repair second target dependency manifest");
+
+    global_command(&workspace, &pnpm_home)
+        .with_args(["remove", "-g", "victim-a", "victim-b"])
+        .assert()
+        .success();
+    assert!(!first_install.exists());
+    assert!(!second_install.exists());
+    assert!(!first_bin.exists());
+    assert!(!second_bin.exists());
+    assert!(snapshot_tree(&global_pkg_dir).is_empty());
+    let removed_packages = snapshot_tree(&global_pkg_dir);
+    let removed_bins = snapshot_tree(&global_bin);
+
+    let output = global_command(&workspace, &pnpm_home)
+        .with_args(["remove", "-g", "victim-a", "victim-b"])
+        .output()
+        .expect("repeat completed multi-target remove");
+    assert!(!output.status.success(), "the existing not-found contract is retained");
+    assert_eq!(snapshot_tree(&global_pkg_dir), removed_packages);
+    assert_eq!(snapshot_tree(&global_bin), removed_bins);
+
+    drop(root);
+}
+
+#[cfg(unix)]
+#[test]
+fn global_remove_preflights_survivors_before_mutating_targets() {
+    use assert_cmd::assert::OutputAssertExt;
+
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let pnpm_home = root.path().join("pnpm-home");
+    let global_bin = pnpm_home.join("bin");
+    let global_pkg_dir = pnpm_home.join("global/v11");
+    fs::create_dir_all(&global_bin).expect("create global bin directory");
+    fs::create_dir_all(&global_pkg_dir).expect("create global packages directory");
+    assert_fixture_paths(root.path(), &[&pnpm_home, &global_bin, &global_pkg_dir]);
+
+    let target_install = seed_global_group(
+        &global_pkg_dir,
+        "target-hash",
+        &[(
+            "victim",
+            Some(
+                r#"{"name":"victim","version":"1.0.0","bin":{"shared":"shared.js","stale":"stale.js"}}"#,
+            ),
+        )],
+    );
+    let survivor_install =
+        seed_global_group(&global_pkg_dir, "survivor-hash", &[("keeper", Some("{"))]);
+    let shared_bin = global_bin.join("shared");
+    let stale_bin = global_bin.join("stale");
+    fs::write(&shared_bin, b"keeper command\n").expect("seed survivor-owned bin");
+    fs::write(&stale_bin, b"target command\n").expect("seed target-owned bin");
+    let packages_before = snapshot_tree(&global_pkg_dir);
+    let bins_before = snapshot_tree(&global_bin);
+
+    for attempt in 1..=2 {
+        let output = global_command(&workspace, &pnpm_home)
+            .with_args(["remove", "-g", "victim"])
+            .output()
+            .expect("run global remove with incomplete survivor ownership");
+        assert!(
+            !output.status.success(),
+            "attempt {attempt} must reject incomplete survivor ownership; stdout: {}; stderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+        assert_eq!(snapshot_tree(&global_pkg_dir), packages_before);
+        assert_eq!(snapshot_tree(&global_bin), bins_before);
+    }
+
+    fs::write(
+        dependency_manifest_path(&survivor_install, "keeper"),
+        r#"{"name":"keeper","version":"1.0.0","bin":{"shared":"keeper.js"}}"#,
+    )
+    .expect("repair survivor dependency manifest");
+
+    global_command(&workspace, &pnpm_home).with_args(["remove", "-g", "victim"]).assert().success();
+    assert!(!target_install.exists());
+    assert!(survivor_install.exists());
+    assert_eq!(fs::read(&shared_bin).expect("read survivor-owned bin"), b"keeper command\n");
+    assert!(!stale_bin.exists());
+    let removed_packages = snapshot_tree(&global_pkg_dir);
+    let removed_bins = snapshot_tree(&global_bin);
+
+    let output = global_command(&workspace, &pnpm_home)
+        .with_args(["remove", "-g", "victim"])
+        .output()
+        .expect("repeat completed global remove");
+    assert!(!output.status.success(), "the existing not-found contract is retained");
+    assert_eq!(snapshot_tree(&global_pkg_dir), removed_packages);
+    assert_eq!(snapshot_tree(&global_bin), removed_bins);
+
+    drop(root);
 }
 
 /// `pacquet list -g` with nothing installed reports the empty state rather

--- a/pnpm/crates/global/src/scan.rs
+++ b/pnpm/crates/global/src/scan.rs
@@ -2,7 +2,9 @@
 //! directory and the details needed to list, update, and remove them.
 
 use crate::read_package_json;
-use pnpm_cmd_shim::{FsReadFile, Host, PackageBinSource, get_bins_from_package_manifest};
+use pnpm_cmd_shim::{
+    FsReadFile, FsWalkFiles, Host, PackageBinSource, get_bins_from_package_manifest,
+};
 use pnpm_fs::is_symlink_or_junction;
 use pnpm_package_manifest::{PackageManifestError, parse_manifest_bytes};
 use pnpm_resolving_deps_resolver::is_valid_dependency_alias;
@@ -139,7 +141,7 @@ fn get_installed_bin_names_with_fs<Sys>(
     info: &GlobalPackageInfo,
 ) -> Result<Vec<String>, PackageManifestError>
 where
-    Sys: FsReadFile,
+    Sys: FsReadFile + FsWalkFiles,
 {
     let modules_dir = info.install_dir.join("node_modules");
     let mut bins = BTreeSet::new();
@@ -149,7 +151,7 @@ where
         let bytes = Sys::read_file(&manifest_path).map_err(PackageManifestError::Io)?;
         let manifest = parse_manifest_bytes(&bytes)
             .map_err(|source| PackageManifestError::Parse { path: manifest_path, source })?;
-        for command in get_bins_from_package_manifest::<Host>(&manifest, &dep_dir) {
+        for command in get_bins_from_package_manifest::<Sys>(&manifest, &dep_dir) {
             bins.insert(command.name);
         }
     }

--- a/pnpm/crates/global/src/scan.rs
+++ b/pnpm/crates/global/src/scan.rs
@@ -148,7 +148,8 @@ where
     for (alias, _) in &info.dependencies {
         let dep_dir = modules_dir.join(alias);
         let manifest_path = dep_dir.join("package.json");
-        let bytes = Sys::read_file(&manifest_path).map_err(PackageManifestError::Io)?;
+        let bytes = Sys::read_file(&manifest_path)
+            .map_err(|source| PackageManifestError::Read { path: manifest_path.clone(), source })?;
         let manifest = parse_manifest_bytes(&bytes)
             .map_err(|source| PackageManifestError::Parse { path: manifest_path, source })?;
         for command in get_bins_from_package_manifest::<Sys>(&manifest, &dep_dir) {

--- a/pnpm/crates/global/src/scan.rs
+++ b/pnpm/crates/global/src/scan.rs
@@ -2,8 +2,9 @@
 //! directory and the details needed to list, update, and remove them.
 
 use crate::read_package_json;
-use pnpm_cmd_shim::{Host, PackageBinSource, get_bins_from_package_manifest};
+use pnpm_cmd_shim::{FsReadFile, Host, PackageBinSource, get_bins_from_package_manifest};
 use pnpm_fs::is_symlink_or_junction;
+use pnpm_package_manifest::{PackageManifestError, parse_manifest_bytes};
 use pnpm_resolving_deps_resolver::is_valid_dependency_alias;
 use serde_json::Value;
 use std::{
@@ -124,18 +125,35 @@ fn installed_packages(
 }
 
 /// The bin names installed by a group (deduplicated).
-#[must_use]
-pub fn get_installed_bin_names(info: &GlobalPackageInfo) -> Vec<String> {
+///
+/// Every declared dependency manifest must be readable and valid. Returning
+/// a partial set would make destructive callers mistake unknown ownership for
+/// an unowned bin.
+pub fn get_installed_bin_names(
+    info: &GlobalPackageInfo,
+) -> Result<Vec<String>, PackageManifestError> {
+    get_installed_bin_names_with_fs::<Host>(info)
+}
+
+fn get_installed_bin_names_with_fs<Sys>(
+    info: &GlobalPackageInfo,
+) -> Result<Vec<String>, PackageManifestError>
+where
+    Sys: FsReadFile,
+{
     let modules_dir = info.install_dir.join("node_modules");
     let mut bins = BTreeSet::new();
     for (alias, _) in &info.dependencies {
         let dep_dir = modules_dir.join(alias);
-        let Some(manifest) = read_package_json(&dep_dir) else { continue };
+        let manifest_path = dep_dir.join("package.json");
+        let bytes = Sys::read_file(&manifest_path).map_err(PackageManifestError::Io)?;
+        let manifest = parse_manifest_bytes(&bytes)
+            .map_err(|source| PackageManifestError::Parse { path: manifest_path, source })?;
         for command in get_bins_from_package_manifest::<Host>(&manifest, &dep_dir) {
             bins.insert(command.name);
         }
     }
-    bins.into_iter().collect()
+    Ok(bins.into_iter().collect())
 }
 
 /// Read the directly-installed packages of an install directory as

--- a/pnpm/crates/global/src/scan/tests.rs
+++ b/pnpm/crates/global/src/scan/tests.rs
@@ -164,7 +164,7 @@ fn installed_bin_names_preserves_permission_denied_manifest_reads() {
         .expect_err("permission denied must fail ownership enumeration");
 
     assert!(
-        matches!(error, PackageManifestError::Io(error) if error.kind() == io::ErrorKind::PermissionDenied)
+        matches!(error, PackageManifestError::Io(error) if error.kind() == io::ErrorKind::PermissionDenied),
     );
 }
 
@@ -179,7 +179,7 @@ fn scan_finds_a_globally_installed_runtime() {
     let groups = scan_global_packages(global_dir.path()).unwrap();
     assert_eq!(groups.len(), 1);
     assert!(groups[0].has_alias("node"));
-    assert_eq!(get_installed_bin_names(&groups[0]).unwrap(), vec!["node".to_string()],);
+    assert_eq!(get_installed_bin_names(&groups[0]).unwrap(), vec!["node".to_string()]);
 
     assert!(find_global_package(global_dir.path(), "node").unwrap().is_some());
 }

--- a/pnpm/crates/global/src/scan/tests.rs
+++ b/pnpm/crates/global/src/scan/tests.rs
@@ -1,14 +1,28 @@
 use super::{
-    find_global_package, get_installed_bin_names, read_direct_dependency_aliases,
-    read_installed_packages, scan_global_packages,
+    GlobalPackageInfo, find_global_package, get_installed_bin_names,
+    get_installed_bin_names_with_fs, read_direct_dependency_aliases, read_installed_packages,
+    scan_global_packages,
 };
+use pnpm_cmd_shim::FsReadFile;
+use pnpm_package_manifest::PackageManifestError;
 use serde_json::json;
-use std::path::Path;
+use std::{io, path::Path};
 use tempfile::TempDir;
 
 fn write_json(path: &Path, value: &serde_json::Value) {
     std::fs::create_dir_all(path.parent().expect("json path has a parent")).unwrap();
     std::fs::write(path, serde_json::to_string_pretty(value).unwrap()).unwrap();
+}
+
+fn package_group(install_dir: &Path, aliases: &[&str]) -> GlobalPackageInfo {
+    GlobalPackageInfo {
+        hash: "hashkey".to_string(),
+        install_dir: install_dir.to_path_buf(),
+        dependencies: aliases
+            .iter()
+            .map(|alias| ((*alias).to_string(), "1.0.0".to_string()))
+            .collect(),
+    }
 }
 
 /// Populate `install_dir` as a global group holding a downloaded Node.js
@@ -74,6 +88,86 @@ fn ordinary_engines_node_range_is_not_reified() {
     assert!(read_installed_packages(tmp.path()).is_empty());
 }
 
+#[test]
+fn installed_bin_names_accepts_a_readable_binless_manifest() {
+    let tmp = TempDir::new().unwrap();
+    write_json(
+        &tmp.path().join("node_modules/binless/package.json"),
+        &json!({ "name": "binless", "version": "1.0.0" }),
+    );
+    let info = package_group(tmp.path(), &["binless"]);
+
+    assert_eq!(get_installed_bin_names(&info).unwrap(), Vec::<String>::new());
+}
+
+#[test]
+fn installed_bin_names_rejects_a_missing_declared_alias_manifest() {
+    let tmp = TempDir::new().unwrap();
+    let info = package_group(tmp.path(), &["missing"]);
+
+    assert!(get_installed_bin_names(&info).is_err());
+}
+
+#[test]
+fn installed_bin_names_rejects_a_malformed_declared_alias_manifest() {
+    let tmp = TempDir::new().unwrap();
+    let manifest_path = tmp.path().join("node_modules/malformed/package.json");
+    std::fs::create_dir_all(manifest_path.parent().unwrap()).unwrap();
+    std::fs::write(manifest_path, "{ not valid JSON").unwrap();
+    let info = package_group(tmp.path(), &["malformed"]);
+
+    assert!(get_installed_bin_names(&info).is_err());
+}
+
+#[test]
+fn installed_bin_names_does_not_return_a_partial_set_when_one_manifest_is_missing() {
+    let tmp = TempDir::new().unwrap();
+    write_json(
+        &tmp.path().join("node_modules/readable/package.json"),
+        &json!({
+            "name": "readable",
+            "version": "1.0.0",
+            "bin": { "readable-command": "bin/cli.js" },
+        }),
+    );
+    let info = package_group(tmp.path(), &["readable", "missing"]);
+
+    assert!(get_installed_bin_names(&info).is_err());
+
+    write_json(
+        &tmp.path().join("node_modules/missing/package.json"),
+        &json!({
+            "name": "missing",
+            "version": "1.0.0",
+            "bin": { "missing-command": "bin/cli.js" },
+        }),
+    );
+    assert_eq!(
+        get_installed_bin_names(&info).unwrap(),
+        vec!["missing-command".to_string(), "readable-command".to_string()],
+    );
+}
+
+#[test]
+fn installed_bin_names_preserves_permission_denied_manifest_reads() {
+    struct PermissionDeniedManifestRead;
+
+    impl FsReadFile for PermissionDeniedManifestRead {
+        fn read_file(_: &Path) -> io::Result<Vec<u8>> {
+            Err(io::Error::from(io::ErrorKind::PermissionDenied))
+        }
+    }
+
+    let tmp = TempDir::new().unwrap();
+    let info = package_group(tmp.path(), &["unreadable"]);
+    let error = get_installed_bin_names_with_fs::<PermissionDeniedManifestRead>(&info)
+        .expect_err("permission denied must fail ownership enumeration");
+
+    assert!(
+        matches!(error, PackageManifestError::Io(error) if error.kind() == io::ErrorKind::PermissionDenied)
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn scan_finds_a_globally_installed_runtime() {
@@ -85,7 +179,7 @@ fn scan_finds_a_globally_installed_runtime() {
     let groups = scan_global_packages(global_dir.path()).unwrap();
     assert_eq!(groups.len(), 1);
     assert!(groups[0].has_alias("node"));
-    assert_eq!(get_installed_bin_names(&groups[0]), vec!["node".to_string()]);
+    assert_eq!(get_installed_bin_names(&groups[0]).unwrap(), vec!["node".to_string()],);
 
     assert!(find_global_package(global_dir.path(), "node").unwrap().is_some());
 }

--- a/pnpm/crates/global/src/scan/tests.rs
+++ b/pnpm/crates/global/src/scan/tests.rs
@@ -3,7 +3,7 @@ use super::{
     get_installed_bin_names_with_fs, read_direct_dependency_aliases, read_installed_packages,
     scan_global_packages,
 };
-use pnpm_cmd_shim::FsReadFile;
+use pnpm_cmd_shim::{FsReadFile, FsWalkFiles};
 use pnpm_package_manifest::PackageManifestError;
 use serde_json::json;
 use std::{io, path::Path};
@@ -155,6 +155,12 @@ fn installed_bin_names_preserves_permission_denied_manifest_reads() {
     impl FsReadFile for PermissionDeniedManifestRead {
         fn read_file(_: &Path) -> io::Result<Vec<u8>> {
             Err(io::Error::from(io::ErrorKind::PermissionDenied))
+        }
+    }
+
+    impl FsWalkFiles for PermissionDeniedManifestRead {
+        fn walk_files(_: &Path) -> io::Result<impl Iterator<Item = std::path::PathBuf>> {
+            Ok(std::iter::empty())
         }
     }
 

--- a/pnpm/crates/global/src/scan/tests.rs
+++ b/pnpm/crates/global/src/scan/tests.rs
@@ -169,9 +169,12 @@ fn installed_bin_names_preserves_permission_denied_manifest_reads() {
     let error = get_installed_bin_names_with_fs::<PermissionDeniedManifestRead>(&info)
         .expect_err("permission denied must fail ownership enumeration");
 
-    assert!(
-        matches!(error, PackageManifestError::Io(error) if error.kind() == io::ErrorKind::PermissionDenied),
-    );
+    assert!(matches!(
+        &error,
+        PackageManifestError::Read { path, source }
+            if path == &info.install_dir.join("node_modules/unreadable/package.json")
+                && source.kind() == io::ErrorKind::PermissionDenied
+    ));
 }
 
 #[cfg(unix)]

--- a/pnpm/crates/package-manifest/src/lib.rs
+++ b/pnpm/crates/package-manifest/src/lib.rs
@@ -35,6 +35,15 @@ pub enum PackageManifestError {
     #[diagnostic(code(ERR_PNPM_PACKAGE_MANIFEST_IO_ERROR))]
     Io(std::io::Error), // TODO: remove derive(From), split this variant
 
+    #[from(ignore)] // TODO: remove this after derive(From) has been removed
+    #[display("Failed to read {}: {source}", path.display())]
+    #[diagnostic(code(ERR_PNPM_PACKAGE_MANIFEST_IO_ERROR))]
+    Read {
+        path: PathBuf,
+        #[error(source)]
+        source: io::Error,
+    },
+
     #[display("package.json file already exists")]
     #[diagnostic(
         code(ERR_PNPM_PACKAGE_JSON_EXISTS),

--- a/pnpm11/global/commands/src/binOwnership.ts
+++ b/pnpm11/global/commands/src/binOwnership.ts
@@ -1,26 +1,28 @@
-import { getInstalledBinNames, scanGlobalPackages } from '@pnpm/global.packages'
+import {
+  getInstalledBinNames,
+  type GlobalPackageBinSnapshot,
+  type GlobalPackageInfo,
+  scanGlobalPackages,
+} from '@pnpm/global.packages'
 
 /**
- * The set of bin names provided by global package groups *other* than those
- * in `excludeHashes`.
+ * A complete ownership snapshot for the groups about to be replaced or
+ * removed, together with the bins owned by every group that will survive.
  *
- * Used before unlinking a group's bins (on remove / update / replace) so
- * that a bin name shared with — and owned by — another still-installed
- * group is never removed. Without this, removing one group could delete a
- * bin that actually belongs to a different global package.
+ * Every manifest read settles before the caller mutates global state. That
+ * makes an incomplete target or survivor fail closed instead of allowing a
+ * partial ownership result to drive removals.
  */
-export async function getBinNamesOfOtherGroups (
+export async function getGlobalBinOwnership (
   globalDir: string,
-  excludeHashes: Set<string>
-): Promise<Set<string>> {
-  const others = scanGlobalPackages(globalDir).filter((pkg) => !excludeHashes.has(pkg.hash))
-  const names = new Set<string>()
-  await Promise.all(
-    others.map(async (pkg) => {
-      for (const name of await getInstalledBinNames(pkg)) {
-        names.add(name)
-      }
-    })
+  targetGroups: GlobalPackageInfo[]
+): Promise<{ groups: GlobalPackageBinSnapshot[], protectedBins: Set<string> }> {
+  const targetHashes = new Set(targetGroups.map(({ hash }) => hash))
+  const survivingGroups = scanGlobalPackages(globalDir).filter((pkg) => !targetHashes.has(pkg.hash))
+  const binNamesByGroup = await Promise.all(
+    [...targetGroups, ...survivingGroups].map(async (pkg) => getInstalledBinNames(pkg))
   )
-  return names
+  const groups = targetGroups.map((info, index) => ({ info, binNames: binNamesByGroup[index] }))
+  const protectedBins = new Set(binNamesByGroup.slice(targetGroups.length).flat())
+  return { groups, protectedBins }
 }

--- a/pnpm11/global/commands/src/binOwnership.ts
+++ b/pnpm11/global/commands/src/binOwnership.ts
@@ -20,7 +20,7 @@ export async function getGlobalBinOwnership (
   const targetHashes = new Set(targetGroups.map(({ hash }) => hash))
   const survivingGroups = scanGlobalPackages(globalDir).filter((pkg) => !targetHashes.has(pkg.hash))
   const binNamesByGroup = await Promise.all(
-    [...targetGroups, ...survivingGroups].map(async (pkg) => getInstalledBinNames(pkg))
+    [...targetGroups, ...survivingGroups].map((pkg) => getInstalledBinNames(pkg))
   )
   const groups = targetGroups.map((info, index) => ({ info, binNames: binNamesByGroup[index] }))
   const protectedBins = new Set(binNamesByGroup.slice(targetGroups.length).flat())

--- a/pnpm11/global/commands/src/cleanupFailedGlobalInstall.ts
+++ b/pnpm11/global/commands/src/cleanupFailedGlobalInstall.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs'
+import util from 'node:util'
 
 import { getSingleLineErrorMessage } from './errorMessage.js'
 
@@ -9,8 +10,9 @@ import { getSingleLineErrorMessage } from './errorMessage.js'
  * installation exactly as the command found it.
  *
  * A removal that fails is reported alongside the original failure, which
- * stays the aggregate's `cause`: the directory it left behind is the only
- * trace of the aborted install, so the user has to hear about it.
+ * stays the aggregate's `cause` and lends it its `code`: the directory it
+ * left behind is the only trace of the aborted install, so the user has to
+ * hear about it, but the install still failed for the reason it reports.
  */
 export async function cleanupFailedGlobalInstall (
   installDir: string,
@@ -19,13 +21,24 @@ export async function cleanupFailedGlobalInstall (
   try {
     await fs.promises.rm(installDir, { recursive: true, force: true })
   } catch (cleanupError) {
-    throw new AggregateError(
+    const failure: AggregateError & { code?: string } = new AggregateError(
       [originalError, cleanupError],
       'Failed to clean up after global install failed before activation. ' +
         `Original error: ${getSingleLineErrorMessage(originalError)}. ` +
         `Cleanup error: ${getSingleLineErrorMessage(cleanupError)}.`,
-      { cause: originalError } // eslint-disable-line preserve-caught-error -- The failure before activation is primary; both errors remain in AggregateError.errors.
+      { cause: originalError }
     )
+    // The reporter and the parseable error output read `code` off the error
+    // they are handed, so without this the install that actually failed would
+    // be rendered as a generic error.
+    const code = getErrorCode(originalError)
+    if (code != null) failure.code = code
+    throw failure
   }
   throw originalError
+}
+
+function getErrorCode (err: unknown): string | undefined {
+  if (!util.types.isNativeError(err) || !('code' in err)) return undefined
+  return typeof err.code === 'string' ? err.code : undefined
 }

--- a/pnpm11/global/commands/src/cleanupFailedGlobalInstall.ts
+++ b/pnpm11/global/commands/src/cleanupFailedGlobalInstall.ts
@@ -1,0 +1,31 @@
+import fs from 'node:fs'
+
+import { getSingleLineErrorMessage } from './errorMessage.js'
+
+/**
+ * Discard the fresh install directory after a step that runs before
+ * activation failed, then rethrow that failure. Nothing outside the
+ * directory has been touched yet, so removing it leaves the global
+ * installation exactly as the command found it.
+ *
+ * A removal that fails is reported alongside the original failure, which
+ * stays the aggregate's `cause`: the directory it left behind is the only
+ * trace of the aborted install, so the user has to hear about it.
+ */
+export async function cleanupFailedGlobalInstall (
+  installDir: string,
+  originalError: unknown
+): Promise<never> {
+  try {
+    await fs.promises.rm(installDir, { recursive: true, force: true })
+  } catch (cleanupError) {
+    throw new AggregateError(
+      [originalError, cleanupError],
+      'Failed to clean up after global install failed before activation. ' +
+        `Original error: ${getSingleLineErrorMessage(originalError)}. ` +
+        `Cleanup error: ${getSingleLineErrorMessage(cleanupError)}.`,
+      { cause: originalError } // eslint-disable-line preserve-caught-error -- The failure before activation is primary; both errors remain in AggregateError.errors.
+    )
+  }
+  throw originalError
+}

--- a/pnpm11/global/commands/src/errorMessage.ts
+++ b/pnpm11/global/commands/src/errorMessage.ts
@@ -1,0 +1,23 @@
+import util from 'node:util'
+
+import { redactAndSanitize } from '@pnpm/error'
+
+export function getErrorMessage (err: unknown): string {
+  if (util.types.isNativeError(err)) return err.message
+  try {
+    return String(err)
+  } catch {
+    return 'Unknown error'
+  }
+}
+
+/**
+ * The message of `err`, safe to embed in a message of our own: credentials
+ * are redacted and every separator a terminal or a log line would act on is
+ * stripped, the Unicode line and paragraph separators included.
+ */
+export function getSingleLineErrorMessage (err: unknown): string {
+  return redactAndSanitize(getErrorMessage(err))
+    .replaceAll('\u2028', '')
+    .replaceAll('\u2029', '')
+}

--- a/pnpm11/global/commands/src/globalActivation.ts
+++ b/pnpm11/global/commands/src/globalActivation.ts
@@ -6,7 +6,7 @@ import { linkBinsOfPackages } from '@pnpm/bins.linker'
 import { removeBin } from '@pnpm/bins.remover'
 import { getBinsFromPackageManifest } from '@pnpm/bins.resolver'
 import { PnpmError } from '@pnpm/error'
-import { getHashLink, getInstalledBinNames, type GlobalPackageInfo } from '@pnpm/global.packages'
+import { getHashLink, type GlobalPackageBinSnapshot } from '@pnpm/global.packages'
 import { globalWarn } from '@pnpm/logger'
 import type { DependencyManifest } from '@pnpm/types'
 import { isSubdir } from 'is-subdir'
@@ -21,7 +21,7 @@ export interface ActivateGlobalInstallOptions {
 }
 
 export interface CleanupReplacedGlobalInstallsOptions {
-  groups: GlobalPackageInfo[]
+  groups: GlobalPackageBinSnapshot[]
   globalDir: string
   globalBinDir: string
   activeHash: string
@@ -96,23 +96,31 @@ export async function cleanupReplacedGlobalInstalls (
   }
 }
 
+export async function cleanupFailedGlobalInstall (
+  installDir: string,
+  originalError: unknown
+): Promise<never> {
+  try {
+    await fs.promises.rm(installDir, { recursive: true, force: true })
+  } catch (cleanupError) {
+    throw new AggregateError(
+      [originalError, cleanupError],
+      'Failed to clean up after global install failed before activation.',
+      { cause: originalError } // eslint-disable-line preserve-caught-error -- The failure before activation is primary; both errors remain in AggregateError.errors.
+    )
+  }
+  throw originalError
+}
+
 // Activation already succeeded when this runs, so every removal is
 // attempted even after one fails; the failures are aggregated instead of
 // aborting the remaining cleanup.
 async function cleanupReplacedGlobalInstall (
   opts: CleanupReplacedGlobalInstallsOptions,
-  group: GlobalPackageInfo
+  groupSnapshot: GlobalPackageBinSnapshot
 ): Promise<unknown[]> {
   const errors: unknown[] = []
-  let binNames: string[]
-  try {
-    binNames = await getInstalledBinNames(group)
-  } catch (err) {
-    // The install directory is the only record of which bins the group
-    // owns, so removing it now would strand them on PATH forever. Leave
-    // the group intact for a later run to clean up.
-    return [err]
-  }
+  const { info: group, binNames } = groupSnapshot
   let binRemovalFailed = false
   for (const binName of binNames) {
     if (opts.activatedBins.has(binName) || opts.protectedBins.has(binName)) continue

--- a/pnpm11/global/commands/src/globalActivation.ts
+++ b/pnpm11/global/commands/src/globalActivation.ts
@@ -5,7 +5,7 @@ import util from 'node:util'
 import { linkBinsOfPackages } from '@pnpm/bins.linker'
 import { removeBin } from '@pnpm/bins.remover'
 import { getBinsFromPackageManifest } from '@pnpm/bins.resolver'
-import { PnpmError } from '@pnpm/error'
+import { PnpmError, redactAndSanitize } from '@pnpm/error'
 import { getHashLink, type GlobalPackageBinSnapshot } from '@pnpm/global.packages'
 import { globalWarn } from '@pnpm/logger'
 import type { DependencyManifest } from '@pnpm/types'
@@ -105,7 +105,9 @@ export async function cleanupFailedGlobalInstall (
   } catch (cleanupError) {
     throw new AggregateError(
       [originalError, cleanupError],
-      'Failed to clean up after global install failed before activation.',
+      'Failed to clean up after global install failed before activation. ' +
+        `Original error: ${getSingleLineErrorMessage(originalError)}. ` +
+        `Cleanup error: ${getSingleLineErrorMessage(cleanupError)}.`,
       { cause: originalError } // eslint-disable-line preserve-caught-error -- The failure before activation is primary; both errors remain in AggregateError.errors.
     )
   }
@@ -396,4 +398,10 @@ function getErrorMessage (err: unknown): string {
   } catch {
     return 'Unknown error'
   }
+}
+
+function getSingleLineErrorMessage (err: unknown): string {
+  return redactAndSanitize(getErrorMessage(err))
+    .replaceAll('\u2028', '')
+    .replaceAll('\u2029', '')
 }

--- a/pnpm11/global/commands/src/globalActivation.ts
+++ b/pnpm11/global/commands/src/globalActivation.ts
@@ -133,8 +133,8 @@ async function cleanupReplacedGlobalInstall (
       binRemovalFailed = true
     }
   }
-  // A bin that could not be removed is only discoverable through the
-  // group's manifests, so keep the group until every one of them is gone.
+  // The group's install directory is what a later run reads its ownership
+  // from, so keep the group until every one of its bins is gone.
   if (binRemovalFailed) return errors
   if (group.hash !== opts.activeHash) {
     try {

--- a/pnpm11/global/commands/src/globalActivation.ts
+++ b/pnpm11/global/commands/src/globalActivation.ts
@@ -5,12 +5,14 @@ import util from 'node:util'
 import { linkBinsOfPackages } from '@pnpm/bins.linker'
 import { removeBin } from '@pnpm/bins.remover'
 import { getBinsFromPackageManifest } from '@pnpm/bins.resolver'
-import { PnpmError, redactAndSanitize } from '@pnpm/error'
+import { PnpmError } from '@pnpm/error'
 import { getHashLink, type GlobalPackageBinSnapshot } from '@pnpm/global.packages'
 import { globalWarn } from '@pnpm/logger'
 import type { DependencyManifest } from '@pnpm/types'
 import { isSubdir } from 'is-subdir'
 import { symlinkDir } from 'symlink-dir'
+
+import { getErrorMessage } from './errorMessage.js'
 
 export interface ActivateGlobalInstallOptions {
   installDir: string
@@ -94,24 +96,6 @@ export async function cleanupReplacedGlobalInstalls (
   if (errors.length > 1) {
     throw new AggregateError(errors, 'Failed to clean up replaced global installs')
   }
-}
-
-export async function cleanupFailedGlobalInstall (
-  installDir: string,
-  originalError: unknown
-): Promise<never> {
-  try {
-    await fs.promises.rm(installDir, { recursive: true, force: true })
-  } catch (cleanupError) {
-    throw new AggregateError(
-      [originalError, cleanupError],
-      'Failed to clean up after global install failed before activation. ' +
-        `Original error: ${getSingleLineErrorMessage(originalError)}. ` +
-        `Cleanup error: ${getSingleLineErrorMessage(cleanupError)}.`,
-      { cause: originalError } // eslint-disable-line preserve-caught-error -- The failure before activation is primary; both errors remain in AggregateError.errors.
-    )
-  }
-  throw originalError
 }
 
 // Activation already succeeded when this runs, so every removal is
@@ -389,19 +373,4 @@ async function pathExists (target: string): Promise<boolean> {
 
 function isErrorWithCode (err: unknown, code: string): boolean {
   return util.types.isNativeError(err) && 'code' in err && err.code === code
-}
-
-function getErrorMessage (err: unknown): string {
-  if (util.types.isNativeError(err)) return err.message
-  try {
-    return String(err)
-  } catch {
-    return 'Unknown error'
-  }
-}
-
-function getSingleLineErrorMessage (err: unknown): string {
-  return redactAndSanitize(getErrorMessage(err))
-    .replaceAll('\u2028', '')
-    .replaceAll('\u2029', '')
 }

--- a/pnpm11/global/commands/src/globalAdd.ts
+++ b/pnpm11/global/commands/src/globalAdd.ts
@@ -10,6 +10,7 @@ import {
   createInstallDir,
   findGlobalPackage,
   getHashLink,
+  type GlobalPackageBinSnapshot,
   type GlobalPackageInfo,
 } from '@pnpm/global.packages'
 import { readPackageJsonFromDirRawSync } from '@pnpm/pkg-manifest.reader'
@@ -252,7 +253,7 @@ function resolveLocalParam (param: string, baseDir: string): string {
 }
 
 interface ExistingGlobalInstalls {
-  groups: Array<{ info: GlobalPackageInfo, binNames: string[] }>
+  groups: GlobalPackageBinSnapshot[]
   protectedBins: Set<string>
 }
 

--- a/pnpm11/global/commands/src/globalAdd.ts
+++ b/pnpm11/global/commands/src/globalAdd.ts
@@ -15,9 +15,9 @@ import {
 import { readPackageJsonFromDirRawSync } from '@pnpm/pkg-manifest.reader'
 import type { CreateStoreControllerOptions } from '@pnpm/store.connection-manager'
 
-import { getBinNamesOfOtherGroups } from './binOwnership.js'
+import { getGlobalBinOwnership } from './binOwnership.js'
 import { checkGlobalBinConflicts } from './checkGlobalBinConflicts.js'
-import { activateGlobalInstall, cleanupReplacedGlobalInstalls } from './globalActivation.js'
+import { activateGlobalInstall, cleanupFailedGlobalInstall, cleanupReplacedGlobalInstalls } from './globalActivation.js'
 import { installGlobalPackages, type ResolutionPolicyViolation } from './installGlobalPackages.js'
 import { isPnpmCliDependency, isPnpmCliOnlyGroup, selectsPnpmCli } from './pnpmCliPackages.js'
 import { promptApproveGlobalBuilds } from './promptApproveGlobalBuilds.js'
@@ -147,15 +147,19 @@ async function installGroup (
       shouldSkip: (pkg) => shouldReplaceExistingGlobalInstall(pkg, aliases, replacementAliases),
     })
   } catch (err) {
-    await fs.promises.rm(installDir, { recursive: true, force: true })
-    throw err
+    return cleanupFailedGlobalInstall(installDir, err)
   }
 
-  const { groupsToReplace, protectedBins } = await collectExistingGlobalInstalls({
-    globalDir,
-    aliases,
-    replacementAliases,
-  })
+  let existingGlobalInstalls: ExistingGlobalInstalls
+  try {
+    existingGlobalInstalls = await collectExistingGlobalInstalls({
+      globalDir,
+      aliases,
+      replacementAliases,
+    })
+  } catch (err) {
+    return cleanupFailedGlobalInstall(installDir, err)
+  }
 
   const cacheHash = createGlobalCacheKey({
     aliases,
@@ -170,12 +174,12 @@ async function installGroup (
     binsToSkip,
   })
   await cleanupReplacedGlobalInstalls({
-    groups: groupsToReplace,
+    groups: existingGlobalInstalls.groups,
     globalDir,
     globalBinDir,
     activeHash: cacheHash,
     activatedBins,
-    protectedBins,
+    protectedBins: existingGlobalInstalls.protectedBins,
   })
   await opts.updateResolutionPolicyManifest?.(resolutionPolicyViolations, globalDir)
 }
@@ -248,7 +252,7 @@ function resolveLocalParam (param: string, baseDir: string): string {
 }
 
 interface ExistingGlobalInstalls {
-  groupsToReplace: GlobalPackageInfo[]
+  groups: Array<{ info: GlobalPackageInfo, binNames: string[] }>
   protectedBins: Set<string>
 }
 
@@ -273,6 +277,5 @@ async function collectExistingGlobalInstalls (
     }
   }
 
-  const protectedBins = await getBinNamesOfOtherGroups(globalDir, new Set(groupsToReplace.keys()))
-  return { groupsToReplace: [...groupsToReplace.values()], protectedBins }
+  return getGlobalBinOwnership(globalDir, [...groupsToReplace.values()])
 }

--- a/pnpm11/global/commands/src/globalAdd.ts
+++ b/pnpm11/global/commands/src/globalAdd.ts
@@ -18,7 +18,8 @@ import type { CreateStoreControllerOptions } from '@pnpm/store.connection-manage
 
 import { getGlobalBinOwnership } from './binOwnership.js'
 import { checkGlobalBinConflicts } from './checkGlobalBinConflicts.js'
-import { activateGlobalInstall, cleanupFailedGlobalInstall, cleanupReplacedGlobalInstalls } from './globalActivation.js'
+import { cleanupFailedGlobalInstall } from './cleanupFailedGlobalInstall.js'
+import { activateGlobalInstall, cleanupReplacedGlobalInstalls } from './globalActivation.js'
 import { installGlobalPackages, type ResolutionPolicyViolation } from './installGlobalPackages.js'
 import { isPnpmCliDependency, isPnpmCliOnlyGroup, selectsPnpmCli } from './pnpmCliPackages.js'
 import { promptApproveGlobalBuilds } from './promptApproveGlobalBuilds.js'

--- a/pnpm11/global/commands/src/globalRemove.ts
+++ b/pnpm11/global/commands/src/globalRemove.ts
@@ -36,7 +36,6 @@ export async function handleGlobalRemove (
   // not be unlinked, or we'd delete another global package's bin.
   const ownership = await getGlobalBinOwnership(globalDir, [...groupsToRemove.values()])
 
-  // Remove bins, hash symlinks, and install dirs for all affected groups in parallel
   await Promise.all(
     ownership.groups.map(async ({ info: pkg, binNames }) => {
       await Promise.all(

--- a/pnpm11/global/commands/src/globalRemove.ts
+++ b/pnpm11/global/commands/src/globalRemove.ts
@@ -6,12 +6,11 @@ import { PnpmError } from '@pnpm/error'
 import {
   findGlobalPackage,
   getHashLink,
-  getInstalledBinNames,
   type GlobalPackageInfo,
 } from '@pnpm/global.packages'
 import { isSubdir } from 'is-subdir'
 
-import { getBinNamesOfOtherGroups } from './binOwnership.js'
+import { getGlobalBinOwnership } from './binOwnership.js'
 
 export async function handleGlobalRemove (
   opts: {
@@ -35,18 +34,17 @@ export async function handleGlobalRemove (
 
   // Bins shared with (and owned by) groups that survive this removal must
   // not be unlinked, or we'd delete another global package's bin.
-  const protectedBins = await getBinNamesOfOtherGroups(globalDir, new Set(groupsToRemove.keys()))
+  const ownership = await getGlobalBinOwnership(globalDir, [...groupsToRemove.values()])
 
   // Remove bins, hash symlinks, and install dirs for all affected groups in parallel
   await Promise.all(
-    [...groupsToRemove.entries()].map(async ([hash, pkg]) => {
-      const binNames = await getInstalledBinNames(pkg)
+    ownership.groups.map(async ({ info: pkg, binNames }) => {
       await Promise.all(
         binNames
-          .filter((binName) => !protectedBins.has(binName))
+          .filter((binName) => !ownership.protectedBins.has(binName))
           .map((binName) => removeBin(path.join(globalBinDir, binName)))
       )
-      await fs.promises.rm(getHashLink(globalDir, hash), { force: true })
+      await fs.promises.rm(getHashLink(globalDir, pkg.hash), { force: true })
       if (isSubdir(globalDir, pkg.installDir)) {
         await fs.promises.rm(pkg.installDir, { recursive: true, force: true })
       }

--- a/pnpm11/global/commands/src/globalUpdate.ts
+++ b/pnpm11/global/commands/src/globalUpdate.ts
@@ -1,4 +1,3 @@
-import fs from 'node:fs'
 import path from 'node:path'
 
 import type { CommandHandlerMap } from '@pnpm/cli.command'
@@ -14,9 +13,9 @@ import {
 import type { CreateStoreControllerOptions } from '@pnpm/store.connection-manager'
 import semver from 'semver'
 
-import { getBinNamesOfOtherGroups } from './binOwnership.js'
+import { getGlobalBinOwnership } from './binOwnership.js'
 import { checkGlobalBinConflicts } from './checkGlobalBinConflicts.js'
-import { activateGlobalInstall, cleanupReplacedGlobalInstalls } from './globalActivation.js'
+import { activateGlobalInstall, cleanupFailedGlobalInstall, cleanupReplacedGlobalInstalls } from './globalActivation.js'
 import {
   installGlobalPackages,
   type InstallGlobalPackagesResult,
@@ -114,11 +113,15 @@ async function updateGlobalPackageGroup (
       shouldSkip: (existingPkg) => existingPkg.hash === pkg.hash,
     })
   } catch (err) {
-    await fs.promises.rm(installDir, { recursive: true, force: true })
-    throw err
+    return cleanupFailedGlobalInstall(installDir, err)
   }
 
-  const protectedBins = await getBinNamesOfOtherGroups(globalDir, new Set([pkg.hash]))
+  let ownership: Awaited<ReturnType<typeof getGlobalBinOwnership>>
+  try {
+    ownership = await getGlobalBinOwnership(globalDir, [pkg])
+  } catch (err) {
+    return cleanupFailedGlobalInstall(installDir, err)
+  }
   const hashLink = getHashLink(globalDir, pkg.hash)
   const activatedBins = await activateGlobalInstall({
     installDir,
@@ -128,12 +131,12 @@ async function updateGlobalPackageGroup (
     binsToSkip,
   })
   await cleanupReplacedGlobalInstalls({
-    groups: [pkg],
+    groups: ownership.groups,
     globalDir,
     globalBinDir,
     activeHash: pkg.hash,
     activatedBins,
-    protectedBins,
+    protectedBins: ownership.protectedBins,
   })
   await opts.updateResolutionPolicyManifest?.(resolutionPolicyViolations, globalDir)
 }

--- a/pnpm11/global/commands/src/globalUpdate.ts
+++ b/pnpm11/global/commands/src/globalUpdate.ts
@@ -15,7 +15,8 @@ import semver from 'semver'
 
 import { getGlobalBinOwnership } from './binOwnership.js'
 import { checkGlobalBinConflicts } from './checkGlobalBinConflicts.js'
-import { activateGlobalInstall, cleanupFailedGlobalInstall, cleanupReplacedGlobalInstalls } from './globalActivation.js'
+import { cleanupFailedGlobalInstall } from './cleanupFailedGlobalInstall.js'
+import { activateGlobalInstall, cleanupReplacedGlobalInstalls } from './globalActivation.js'
 import {
   installGlobalPackages,
   type InstallGlobalPackagesResult,

--- a/pnpm11/global/commands/test/getInstalledBinNames.test.ts
+++ b/pnpm11/global/commands/test/getInstalledBinNames.test.ts
@@ -1,0 +1,150 @@
+import { promises as fs } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import util from 'node:util'
+
+import { afterEach, expect, test } from '@jest/globals'
+import { getInstalledBinNames, type GlobalPackageInfo } from '@pnpm/global.packages'
+
+const fixtureRoots: string[] = []
+
+afterEach(async () => {
+  const roots = fixtureRoots.splice(0)
+  await Promise.all(roots.map(assertFixtureRootContained))
+  await Promise.all(roots.map(async (root) => fs.rm(root, { force: true, recursive: true })))
+})
+
+test('returns an empty complete result for a readable package without bins', async () => {
+  const info = await createGlobalPackageInfo({ withoutBins: readableManifest('without-bins') })
+
+  await expect(getInstalledBinNames(info)).resolves.toStrictEqual([])
+})
+
+test('rejects instead of treating one missing declared package as a complete empty result', async () => {
+  const info = await createGlobalPackageInfo({ missing: null })
+
+  await expectEnumerationToReject(info, (error) => {
+    expect(getErrorCode(error)).toBe('ENOENT')
+  })
+})
+
+test('rejects instead of returning known bins when another declared package is missing', async () => {
+  const info = await createGlobalPackageInfo({
+    known: readableManifest('known', { known: 'bin/known.js' }),
+    missing: null,
+  })
+  await expect(getInstalledBinNames(withAliases(info, ['known']))).resolves.toStrictEqual(['known'])
+
+  await expectEnumerationToReject(info, (error) => {
+    expect(getErrorCode(error)).toBe('ENOENT')
+  })
+
+  await fs.writeFile(
+    path.join(info.installDir, 'node_modules', 'missing', 'package.json'),
+    readableManifest('missing', { unknown: 'bin/unknown.js' })
+  )
+  const repairedBinNames = await getInstalledBinNames(info)
+  expect(repairedBinNames.sort()).toStrictEqual(['known', 'unknown'])
+  const repeatedBinNames = await getInstalledBinNames(info)
+  expect(repeatedBinNames.sort()).toStrictEqual(['known', 'unknown'])
+})
+
+test('rejects instead of returning known bins when another declared package has malformed JSON', async () => {
+  const info = await createGlobalPackageInfo({
+    known: readableManifest('known', { known: 'bin/known.js' }),
+    malformed: '{',
+  })
+  await expect(getInstalledBinNames(withAliases(info, ['known']))).resolves.toStrictEqual(['known'])
+
+  await expectEnumerationToReject(info, (error) => {
+    expect(getErrorCode(error)).toBe('ERR_PNPM_BAD_PACKAGE_JSON')
+  })
+})
+
+test('rejects instead of returning known bins after a real non-ENOENT filesystem read failure', async () => {
+  const info = await createGlobalPackageInfo({
+    known: readableManifest('known', { known: 'bin/known.js' }),
+    unreadable: PACKAGE_JSON_DIRECTORY,
+  })
+  await expect(getInstalledBinNames(withAliases(info, ['known']))).resolves.toStrictEqual(['known'])
+
+  await expectEnumerationToReject(info, (error) => {
+    expect(util.types.isNativeError(error)).toBe(true)
+    expect(getErrorCode(error)).toBeDefined()
+    expect(getErrorCode(error)).not.toBe('ENOENT')
+  })
+})
+
+const PACKAGE_JSON_DIRECTORY = Symbol('package.json directory')
+
+type PackageJsonFixture = string | null | typeof PACKAGE_JSON_DIRECTORY
+
+async function createGlobalPackageInfo (packages: Record<string, PackageJsonFixture>): Promise<GlobalPackageInfo> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-global-bin-enumeration-'))
+  await assertFixtureRootContained(root)
+  fixtureRoots.push(root)
+  const installDir = path.join(root, 'install')
+  const dependencies = Object.fromEntries(Object.keys(packages).map((alias) => [alias, '1.0.0']))
+
+  await Promise.all(Object.entries(packages).map(async ([alias, packageJson]) => {
+    const packageDir = path.join(installDir, 'node_modules', alias)
+    await fs.mkdir(packageDir, { recursive: true })
+    if (packageJson === null) return
+    const packageJsonPath = path.join(packageDir, 'package.json')
+    if (packageJson === PACKAGE_JSON_DIRECTORY) {
+      await fs.mkdir(packageJsonPath)
+    } else {
+      await fs.writeFile(packageJsonPath, packageJson)
+    }
+  }))
+
+  return {
+    dependencies,
+    hash: 'fixture-hash',
+    installDir,
+  }
+}
+
+async function assertFixtureRootContained (root: string): Promise<void> {
+  expect(root).not.toBe('')
+  const rootStat = await fs.stat(root)
+  expect(rootStat.isDirectory()).toBe(true)
+  const [canonicalRoot, canonicalTempDir] = await Promise.all([
+    fs.realpath(root),
+    fs.realpath(os.tmpdir()),
+  ])
+  expect(path.dirname(canonicalRoot)).toBe(canonicalTempDir)
+}
+
+function readableManifest (name: string, bin?: Record<string, string>): string {
+  return JSON.stringify({
+    bin,
+    name,
+    version: '1.0.0',
+  })
+}
+
+function withAliases (info: GlobalPackageInfo, aliases: string[]): GlobalPackageInfo {
+  return {
+    ...info,
+    dependencies: Object.fromEntries(aliases.map((alias) => [alias, info.dependencies[alias]])),
+  }
+}
+
+async function expectEnumerationToReject (
+  info: GlobalPackageInfo,
+  assertError: (error: unknown) => void
+): Promise<void> {
+  const outcome = await getInstalledBinNames(info).then(
+    (bins) => ({ bins, kind: 'resolved' as const }),
+    (error: unknown) => ({ error, kind: 'rejected' as const })
+  )
+  if (outcome.kind === 'resolved') {
+    throw new Error(`Expected incomplete enumeration to reject, but it resolved with ${JSON.stringify(outcome.bins)}`)
+  }
+  assertError(outcome.error)
+}
+
+function getErrorCode (error: unknown): unknown {
+  return typeof error === 'object' && error !== null && 'code' in error ? error.code : undefined
+}

--- a/pnpm11/global/commands/test/getInstalledBinNames.test.ts
+++ b/pnpm11/global/commands/test/getInstalledBinNames.test.ts
@@ -146,5 +146,5 @@ async function expectEnumerationToReject (
 }
 
 function getErrorCode (error: unknown): unknown {
-  return typeof error === 'object' && error !== null && 'code' in error ? error.code : undefined
+  return util.types.isNativeError(error) && 'code' in error ? error.code : undefined
 }

--- a/pnpm11/global/commands/test/globalActivation.test.ts
+++ b/pnpm11/global/commands/test/globalActivation.test.ts
@@ -5,7 +5,6 @@ import util from 'node:util'
 
 import { afterEach, expect, jest, test } from '@jest/globals'
 import { getBinsFromPackageManifest } from '@pnpm/bins.resolver'
-import type { GlobalPackageInfo } from '@pnpm/global.packages'
 import type { DependencyManifest } from '@pnpm/types'
 
 type LinkBinsOfPackages = typeof import('@pnpm/bins.linker').linkBinsOfPackages
@@ -26,7 +25,6 @@ const linkedBinNames: string[] = []
 const backupSymlinkTypes: Array<string | null | undefined> = []
 const activationBackupFileContents: Buffer[] = []
 const getHashLink = jest.fn((globalDir: string, hash: string) => path.join(globalDir, hash))
-const getInstalledBinNames = jest.fn<(pkg: GlobalPackageInfo) => Promise<string[]>>()
 const globalWarn = jest.fn<(message: string) => void>()
 const realRm = fs.rm.bind(fs)
 
@@ -125,11 +123,11 @@ jest.spyOn(fs, 'symlink').mockImplementation(async (target, linkPath, type) => {
 
 jest.unstable_mockModule('@pnpm/bins.linker', () => ({ linkBinsOfPackages }))
 jest.unstable_mockModule('@pnpm/bins.remover', () => ({ removeBin }))
-jest.unstable_mockModule('@pnpm/global.packages', () => ({ getHashLink, getInstalledBinNames }))
+jest.unstable_mockModule('@pnpm/global.packages', () => ({ getHashLink }))
 jest.unstable_mockModule('@pnpm/logger', () => ({ globalWarn }))
 jest.unstable_mockModule('symlink-dir', () => ({ symlinkDir }))
 
-const { cleanupReplacedGlobalInstalls, activateGlobalInstall } = await import('../src/globalActivation.js')
+const { cleanupFailedGlobalInstall, cleanupReplacedGlobalInstalls, activateGlobalInstall } = await import('../src/globalActivation.js')
 
 afterEach(async () => {
   const root = testRoot
@@ -150,12 +148,46 @@ afterEach(async () => {
     linkedBinNames.length = 0
     activationBackupFileContents.length = 0
     getHashLink.mockClear()
-    getInstalledBinNames.mockReset()
     globalWarn.mockClear()
     linkBinsOfPackages.mockClear()
     removeBin.mockClear()
     symlinkDir.mockClear()
   }
+})
+
+test('cleanup before activation rethrows the original error after removing the fresh install', async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-global-before-activation-cleanup-'))
+  testRoot = root
+  const installDir = path.join(root, 'fresh-install')
+  await fs.mkdir(installDir)
+  const originalError = new Error('ownership preflight failed')
+
+  await expect(cleanupFailedGlobalInstall(installDir, originalError)).rejects.toBe(originalError)
+
+  expect(existsSync(installDir)).toBe(false)
+})
+
+test('cleanup before activation preserves the original and cleanup errors', async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-global-before-activation-cleanup-'))
+  testRoot = root
+  const installDir = path.join(root, 'fresh-install')
+  await fs.mkdir(installDir)
+  const originalError = new Error('ownership preflight failed')
+  const cleanupError = new Error('fresh install cleanup failed')
+  freshCleanupFailure = { path: path.resolve(installDir), error: cleanupError }
+
+  let thrown: unknown
+  try {
+    await cleanupFailedGlobalInstall(installDir, originalError)
+  } catch (err) {
+    thrown = err
+  }
+
+  expect(thrown).toBeInstanceOf(AggregateError)
+  const aggregateError = thrown as AggregateError
+  expect(aggregateError.errors).toStrictEqual([originalError, cleanupError])
+  expect(aggregateError.cause).toBe(originalError)
+  expect(existsSync(installDir)).toBe(true)
 })
 
 test('restores exact bin slots when linking fails after a partial write', async () => {
@@ -642,7 +674,6 @@ test('removes an old bin slot when the linker skips a missing source', async () 
   await fs.writeFile(toolSlot, `#!/bin/sh\n${fixture.oldInstallDir}/bin/tool.js\n`)
   await fs.rm(path.join(fixture.packageDir, 'bin/tool.js'))
   skipMissingBinSources = true
-  getInstalledBinNames.mockResolvedValue(['tool'])
 
   const activatedBins = await activateGlobalInstall({
     installDir: fixture.freshInstallDir,
@@ -653,9 +684,12 @@ test('removes an old bin slot when the linker skips a missing source', async () 
   })
   await cleanupReplacedGlobalInstalls({
     groups: [{
-      dependencies: { replacement: '1.0.0' },
-      hash: 'hash-link',
-      installDir: fixture.oldInstallDir,
+      info: {
+        dependencies: { replacement: '1.0.0' },
+        hash: 'hash-link',
+        installDir: fixture.oldInstallDir,
+      },
+      binNames: ['tool'],
     }],
     globalDir: fixture.root,
     globalBinDir: fixture.globalBinDir,
@@ -678,10 +712,11 @@ test('preserves bin slots owned by the activated and surviving groups', async ()
     fs.writeFile(activatedSlot, 'activated\n'),
     fs.writeFile(protectedSlot, 'protected\n'),
   ])
-  getInstalledBinNames.mockResolvedValue(['activated', 'protected'])
-
   await cleanupReplacedGlobalInstalls({
-    groups: [{ dependencies: { old: '1.0.0' }, hash: 'active-hash', installDir: oldInstallDir }],
+    groups: [{
+      info: { dependencies: { old: '1.0.0' }, hash: 'active-hash', installDir: oldInstallDir },
+      binNames: ['activated', 'protected'],
+    }],
     globalDir,
     globalBinDir,
     activeHash: 'active-hash',
@@ -701,10 +736,12 @@ test('removes stale bins and the old install without removing the active hash li
   const staleSlot = path.join(globalBinDir, 'stale')
   await fs.writeFile(staleSlot, 'stale\n')
   await replaceDirectorySymlink(activeInstallDir, hashLink)
-  getInstalledBinNames.mockResolvedValue(['stale'])
 
   await cleanupReplacedGlobalInstalls({
-    groups: [{ dependencies: { old: '1.0.0' }, hash: 'active-hash', installDir: oldInstallDir }],
+    groups: [{
+      info: { dependencies: { old: '1.0.0' }, hash: 'active-hash', installDir: oldInstallDir },
+      binNames: ['stale'],
+    }],
     globalDir,
     globalBinDir,
     activeHash: 'active-hash',
@@ -729,10 +766,12 @@ test('drops the hash link of a group replaced by a different package set, keepin
     fs.writeFile(sharedSlot, 'relinked at the new hash\n'),
     fs.writeFile(droppedSlot, 'dropped\n'),
   ])
-  getInstalledBinNames.mockResolvedValue(['shared', 'dropped'])
 
   await cleanupReplacedGlobalInstalls({
-    groups: [{ dependencies: { old: '1.0.0' }, hash: 'old-hash', installDir: oldInstallDir }],
+    groups: [{
+      info: { dependencies: { old: '1.0.0' }, hash: 'old-hash', installDir: oldInstallDir },
+      binNames: ['shared', 'dropped'],
+    }],
     globalDir,
     globalBinDir,
     activeHash: 'new-hash',
@@ -755,10 +794,12 @@ test('does not delete an install directory outside the global directory', async 
   await fs.mkdir(outsideInstallDir, { recursive: true })
   const marker = path.join(outsideInstallDir, 'marker')
   await fs.writeFile(marker, 'outside\n')
-  getInstalledBinNames.mockResolvedValue([])
 
   await cleanupReplacedGlobalInstalls({
-    groups: [{ dependencies: { old: '1.0.0' }, hash: 'active-hash', installDir: outsideInstallDir }],
+    groups: [{
+      info: { dependencies: { old: '1.0.0' }, hash: 'active-hash', installDir: outsideInstallDir },
+      binNames: [],
+    }],
     globalDir,
     globalBinDir,
     activeHash: 'active-hash',
@@ -769,26 +810,6 @@ test('does not delete an install directory outside the global directory', async 
   expect(await fs.readFile(marker, 'utf8')).toBe('outside\n')
 })
 
-test('keeps a replaced group whose bin names cannot be enumerated', async () => {
-  const { globalDir, globalBinDir, oldInstallDir } = await createCleanupFixture()
-  const hashLink = path.join(globalDir, 'old-hash')
-  await replaceDirectorySymlink(oldInstallDir, hashLink)
-  const enumerationError = new Error('cannot read the installed manifest')
-  getInstalledBinNames.mockRejectedValue(enumerationError)
-
-  await expect(cleanupReplacedGlobalInstalls({
-    groups: [{ dependencies: { old: '1.0.0' }, hash: 'old-hash', installDir: oldInstallDir }],
-    globalDir,
-    globalBinDir,
-    activeHash: 'active-hash',
-    activatedBins: new Set(),
-    protectedBins: new Set(),
-  })).rejects.toBe(enumerationError)
-
-  expect(existsSync(oldInstallDir)).toBe(true)
-  expect(existsSync(hashLink)).toBe(true)
-})
-
 test('cleanup removes the other bins but keeps a group whose bin removal failed', async () => {
   const { globalDir, globalBinDir, oldInstallDir } = await createCleanupFixture()
   const blockedSlot = path.join(globalBinDir, 'blocked')
@@ -797,12 +818,14 @@ test('cleanup removes the other bins but keeps a group whose bin removal failed'
     fs.writeFile(blockedSlot, 'blocked\n'),
     fs.writeFile(staleSlot, 'stale\n'),
   ])
-  getInstalledBinNames.mockResolvedValue(['blocked', 'stale'])
   const removalError = new Error('bin removal failed')
   removeBinFailure = { name: 'blocked', error: removalError }
 
   await expect(cleanupReplacedGlobalInstalls({
-    groups: [{ dependencies: { old: '1.0.0' }, hash: 'old-hash', installDir: oldInstallDir }],
+    groups: [{
+      info: { dependencies: { old: '1.0.0' }, hash: 'old-hash', installDir: oldInstallDir },
+      binNames: ['blocked', 'stale'],
+    }],
     globalDir,
     globalBinDir,
     activeHash: 'active-hash',

--- a/pnpm11/global/commands/test/globalActivation.test.ts
+++ b/pnpm11/global/commands/test/globalActivation.test.ts
@@ -172,8 +172,8 @@ test('cleanup before activation preserves the original and cleanup errors', asyn
   testRoot = root
   const installDir = path.join(root, 'fresh-install')
   await fs.mkdir(installDir)
-  const originalError = new Error('ownership preflight failed')
-  const cleanupError = new Error('fresh install cleanup failed')
+  const originalError = new Error('ownership preflight failed \nfor https://user:pass@example.com/global \u2028manifest unreadable')
+  const cleanupError = new Error('fresh install cleanup failed \r\nwith EACCES \u2029at the fresh install')
   freshCleanupFailure = { path: path.resolve(installDir), error: cleanupError }
 
   let thrown: unknown
@@ -187,6 +187,12 @@ test('cleanup before activation preserves the original and cleanup errors', asyn
   const aggregateError = thrown as AggregateError
   expect(aggregateError.errors).toStrictEqual([originalError, cleanupError])
   expect(aggregateError.cause).toBe(originalError)
+  expect(aggregateError.message).toBe(
+    'Failed to clean up after global install failed before activation. ' +
+    'Original error: ownership preflight failed for https://example.com/global manifest unreadable. ' +
+    'Cleanup error: fresh install cleanup failed with EACCES at the fresh install.'
+  )
+  expect(aggregateError.message).not.toMatch(/[\r\n\u2028\u2029]/)
   expect(existsSync(installDir)).toBe(true)
 })
 

--- a/pnpm11/global/commands/test/globalActivation.test.ts
+++ b/pnpm11/global/commands/test/globalActivation.test.ts
@@ -183,7 +183,7 @@ test('cleanup before activation preserves the original and cleanup errors', asyn
     thrown = err
   }
 
-  expect(thrown).toBeInstanceOf(AggregateError)
+  expect(util.types.isNativeError(thrown)).toBe(true)
   const aggregateError = thrown as AggregateError
   expect(aggregateError.errors).toStrictEqual([originalError, cleanupError])
   expect(aggregateError.cause).toBe(originalError)

--- a/pnpm11/global/commands/test/globalActivation.test.ts
+++ b/pnpm11/global/commands/test/globalActivation.test.ts
@@ -127,7 +127,8 @@ jest.unstable_mockModule('@pnpm/global.packages', () => ({ getHashLink }))
 jest.unstable_mockModule('@pnpm/logger', () => ({ globalWarn }))
 jest.unstable_mockModule('symlink-dir', () => ({ symlinkDir }))
 
-const { cleanupFailedGlobalInstall, cleanupReplacedGlobalInstalls, activateGlobalInstall } = await import('../src/globalActivation.js')
+const { cleanupFailedGlobalInstall } = await import('../src/cleanupFailedGlobalInstall.js')
+const { cleanupReplacedGlobalInstalls, activateGlobalInstall } = await import('../src/globalActivation.js')
 
 afterEach(async () => {
   const root = testRoot

--- a/pnpm11/global/commands/test/globalActivation.test.ts
+++ b/pnpm11/global/commands/test/globalActivation.test.ts
@@ -173,7 +173,10 @@ test('cleanup before activation preserves the original and cleanup errors', asyn
   testRoot = root
   const installDir = path.join(root, 'fresh-install')
   await fs.mkdir(installDir)
-  const originalError = new Error('ownership preflight failed \nfor https://user:pass@example.com/global \u2028manifest unreadable')
+  const originalError = Object.assign(
+    new Error('ownership preflight failed \nfor https://user:pass@example.com/global \u2028manifest unreadable'),
+    { code: 'ERR_PNPM_BAD_PACKAGE_JSON' }
+  )
   const cleanupError = new Error('fresh install cleanup failed \r\nwith EACCES \u2029at the fresh install')
   freshCleanupFailure = { path: path.resolve(installDir), error: cleanupError }
 
@@ -194,6 +197,9 @@ test('cleanup before activation preserves the original and cleanup errors', asyn
     'Cleanup error: fresh install cleanup failed with EACCES at the fresh install.'
   )
   expect(aggregateError.message).not.toMatch(/[\r\n\u2028\u2029]/)
+  // The reporter renders this code, so the aborted install keeps identifying
+  // itself by the failure that aborted it.
+  expect((aggregateError as AggregateError & { code?: string }).code).toBe('ERR_PNPM_BAD_PACKAGE_JSON')
   expect(existsSync(installDir)).toBe(true)
 })
 

--- a/pnpm11/global/commands/test/globalAdd.test.ts
+++ b/pnpm11/global/commands/test/globalAdd.test.ts
@@ -268,7 +268,7 @@ test('global add retries safely and activates from a complete replacement owners
     activateGlobalInstall.mockImplementation(async (opts) => {
       ownershipReadsAtSwitch = getInstalledBinNames.mock.calls.length
       const installDir = (opts as { installDir: string }).installDir
-      fs.rmSync(oldHashLink, { force: true })
+      fs.unlinkSync(oldHashLink)
       fs.symlinkSync(installDir, oldHashLink, process.platform === 'win32' ? 'junction' : 'dir')
       return new Set(['pnpm'])
     })

--- a/pnpm11/global/commands/test/globalAdd.test.ts
+++ b/pnpm11/global/commands/test/globalAdd.test.ts
@@ -1,3 +1,7 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
 import { beforeEach, expect, jest, test } from '@jest/globals'
 import type { GlobalPackageInfo } from '@pnpm/global.packages'
 import type { DependencyManifest } from '@pnpm/types'
@@ -14,7 +18,7 @@ const createGlobalCacheKey = jest.fn().mockReturnValue('new-hash')
 const createInstallDir = jest.fn().mockReturnValue('/global/v11/new')
 const findGlobalPackage = jest.fn<(globalDir: string, alias: string) => GlobalPackageInfo | null>()
 const getHashLink = jest.fn((globalDir: string, hash: string) => `${globalDir}/${hash}`)
-const getInstalledBinNames = jest.fn<() => Promise<string[]>>().mockResolvedValue(['pnpm'])
+const getInstalledBinNames = jest.fn<(pkg: GlobalPackageInfo) => Promise<string[]>>().mockResolvedValue(['pnpm'])
 const scanGlobalPackages = jest.fn().mockReturnValue([])
 const readPackageJsonFromDirRawSync = jest.fn().mockReturnValue({
   dependencies: { '@pnpm/exe': 'file:/tmp/pnpm' },
@@ -27,6 +31,18 @@ const readInstalledPackages = jest.fn<() => Promise<[]>>().mockResolvedValue([])
 const summaryDebug = jest.fn()
 const activateGlobalInstall = jest.fn<(opts: unknown) => Promise<Set<string>>>().mockResolvedValue(new Set(['pnpm']))
 const cleanupReplacedGlobalInstalls = jest.fn<(opts: unknown) => Promise<void>>().mockResolvedValue(undefined)
+const cleanupFailedGlobalInstall = jest.fn(async (installDir: string, originalError: unknown): Promise<never> => {
+  try {
+    await fs.promises.rm(installDir, { recursive: true, force: true })
+  } catch (cleanupError) {
+    throw new AggregateError(
+      [originalError, cleanupError],
+      'Failed to clean up after global install failed before activation.',
+      { cause: originalError } // eslint-disable-line preserve-caught-error -- Matches the production contract: the failure before activation is primary.
+    )
+  }
+  throw originalError
+})
 
 jest.unstable_mockModule('@pnpm/core-loggers', () => ({ summaryLogger: { debug: summaryDebug } }))
 jest.unstable_mockModule('@pnpm/global.packages', () => ({
@@ -43,7 +59,11 @@ jest.unstable_mockModule('@pnpm/pkg-manifest.reader', () => ({
 }))
 jest.unstable_mockModule('../src/checkGlobalBinConflicts.js', () => ({ checkGlobalBinConflicts }))
 jest.unstable_mockModule('../src/installGlobalPackages.js', () => ({ installGlobalPackages }))
-jest.unstable_mockModule('../src/globalActivation.js', () => ({ cleanupReplacedGlobalInstalls, activateGlobalInstall }))
+jest.unstable_mockModule('../src/globalActivation.js', () => ({
+  activateGlobalInstall,
+  cleanupFailedGlobalInstall,
+  cleanupReplacedGlobalInstalls,
+}))
 jest.unstable_mockModule('../src/promptApproveGlobalBuilds.js', () => ({ promptApproveGlobalBuilds }))
 jest.unstable_mockModule('../src/readInstalledPackages.js', () => ({ readInstalledPackages }))
 
@@ -53,8 +73,10 @@ beforeEach(() => {
   jest.clearAllMocks()
   checkGlobalBinConflicts.mockResolvedValue(new Set())
   cleanupReplacedGlobalInstalls.mockResolvedValue(undefined)
+  createInstallDir.mockReturnValue('/global/v11/new')
   createGlobalCacheKey.mockReturnValue('new-hash')
   findGlobalPackage.mockReturnValue(null)
+  getInstalledBinNames.mockResolvedValue(['pnpm'])
   activateGlobalInstall.mockResolvedValue(new Set(['pnpm']))
   scanGlobalPackages.mockReturnValue([])
 })
@@ -107,12 +129,19 @@ test('global add activates before cleaning up a same-hash pnpm replacement', asy
     hash: 'old-pnpm',
     installDir: '/global/v11/old-pnpm',
   }
+  const survivor = {
+    dependencies: { eslint: '^9.0.0' },
+    hash: 'eslint',
+    installDir: '/global/v11/eslint',
+  }
   const activatedBins = new Set(['pnpm'])
   const updateResolutionPolicyManifest = jest.fn<() => Promise<void>>().mockResolvedValue(undefined)
   createGlobalCacheKey.mockReturnValue('old-pnpm')
   findGlobalPackage.mockImplementation((_globalDir: string, alias: string) => {
     return alias === 'pnpm' ? existingPnpm : null
   })
+  scanGlobalPackages.mockReturnValue([existingPnpm, survivor])
+  getInstalledBinNames.mockImplementation(async (pkg) => pkg === existingPnpm ? ['pnpm'] : ['eslint'])
   activateGlobalInstall.mockResolvedValue(activatedBins)
   checkGlobalBinConflicts.mockImplementation(async (opts) => {
     expect(opts.shouldSkip(existingPnpm)).toBe(true)
@@ -137,15 +166,215 @@ test('global add activates before cleaning up a same-hash pnpm replacement', asy
     binsToSkip: new Set(),
   })
   expect(cleanupReplacedGlobalInstalls).toHaveBeenCalledWith({
-    groups: [existingPnpm],
+    groups: [{ info: existingPnpm, binNames: ['pnpm'] }],
     globalDir: '/global/v11',
     globalBinDir: '/global/bin',
     activeHash: 'old-pnpm',
     activatedBins,
-    protectedBins: new Set(),
+    protectedBins: new Set(['eslint']),
   })
+  expect(getInstalledBinNames).toHaveBeenCalledTimes(2)
+  expect(getInstalledBinNames).toHaveBeenCalledWith(existingPnpm)
+  expect(getInstalledBinNames).toHaveBeenCalledWith(survivor)
+  for (const callOrder of getInstalledBinNames.mock.invocationCallOrder) {
+    expect(callOrder).toBeLessThan(activateGlobalInstall.mock.invocationCallOrder[0])
+  }
   expect(activateGlobalInstall.mock.invocationCallOrder[0]).toBeLessThan(cleanupReplacedGlobalInstalls.mock.invocationCallOrder[0])
   expect(cleanupReplacedGlobalInstalls.mock.invocationCallOrder[0]).toBeLessThan(updateResolutionPolicyManifest.mock.invocationCallOrder[0])
+})
+
+test('global add retries safely and activates from a complete replacement ownership snapshot after repair', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'global-add-ownership-'))
+  expect(fs.realpathSync(path.dirname(root))).toBe(fs.realpathSync(os.tmpdir()))
+  const globalDir = path.join(root, 'global')
+  const globalBinDir = path.join(root, 'bin')
+  const oldInstallDir = path.join(globalDir, 'old-install')
+  const survivorInstallDir = path.join(globalDir, 'eslint-install')
+  const oldHashLink = path.join(globalDir, 'old-pnpm')
+  const oldMarker = path.join(oldInstallDir, 'marker')
+  fs.mkdirSync(oldInstallDir, { recursive: true })
+  fs.mkdirSync(survivorInstallDir, { recursive: true })
+  fs.mkdirSync(globalBinDir, { recursive: true })
+  fs.writeFileSync(oldMarker, 'old install\n')
+  fs.writeFileSync(path.join(survivorInstallDir, 'marker'), 'survivor install\n')
+  fs.symlinkSync(oldInstallDir, oldHashLink, process.platform === 'win32' ? 'junction' : 'dir')
+
+  const existingPnpm = {
+    dependencies: { pnpm: '12.0.0-alpha.2' },
+    hash: 'old-pnpm',
+    installDir: oldInstallDir,
+  }
+  const survivor = {
+    dependencies: { eslint: '^9.0.0' },
+    hash: 'eslint',
+    installDir: survivorInstallDir,
+  }
+  const enumerationError = Object.assign(new Error('replacement package.json is missing'), { code: 'ENOENT' })
+  const freshInstallDirs: string[] = []
+  createInstallDir.mockImplementation(() => {
+    const freshInstallDir = path.join(globalDir, `fresh-install-${freshInstallDirs.length + 1}`)
+    const relative = path.relative(root, freshInstallDir)
+    expect(path.isAbsolute(relative) || relative === '..' || relative.startsWith(`..${path.sep}`)).toBe(false)
+    fs.mkdirSync(freshInstallDir, { recursive: true })
+    fs.writeFileSync(path.join(freshInstallDir, 'marker'), 'fresh install\n')
+    freshInstallDirs.push(freshInstallDir)
+    return freshInstallDir
+  })
+  createGlobalCacheKey.mockReturnValue('old-pnpm')
+  findGlobalPackage.mockImplementation((_globalDir: string, alias: string) => {
+    return alias === 'pnpm' ? existingPnpm : null
+  })
+  scanGlobalPackages.mockReturnValue([existingPnpm, survivor])
+  let ownershipBroken = true
+  getInstalledBinNames.mockImplementation(async (pkg) => {
+    if (pkg === existingPnpm && ownershipBroken) throw enumerationError
+    if (pkg === existingPnpm) return ['pnpm']
+    return ['eslint']
+  })
+  const add = async (): Promise<void> => handleGlobalAdd({
+    bin: globalBinDir,
+    dir: root,
+    globalPkgDir: globalDir,
+    registriesByScope: {},
+  } as any, ['file:/tmp/pnpm'], {}) // eslint-disable-line @typescript-eslint/no-explicit-any
+  const snapshotBeforeActivation = (): unknown => ({
+    binEntries: fs.readdirSync(globalBinDir).sort(),
+    globalEntries: fs.readdirSync(globalDir).sort(),
+    oldHashTarget: fs.realpathSync(oldHashLink),
+    oldMarker: fs.readFileSync(oldMarker, 'utf8'),
+    survivorMarker: fs.readFileSync(path.join(survivorInstallDir, 'marker'), 'utf8'),
+  })
+  const before = snapshotBeforeActivation()
+  const assertFailedAttempt = async (attempt: number): Promise<void> => {
+    let failure: unknown
+    try {
+      await add()
+    } catch (err) {
+      failure = err
+    }
+    expect({ attempt, failure }).toStrictEqual({ attempt, failure: enumerationError })
+    expect(snapshotBeforeActivation()).toStrictEqual(before)
+    expect(fs.existsSync(freshInstallDirs[attempt - 1])).toBe(false)
+    expect(activateGlobalInstall).not.toHaveBeenCalled()
+    expect(cleanupReplacedGlobalInstalls).not.toHaveBeenCalled()
+  }
+
+  try {
+    await assertFailedAttempt(1)
+    await assertFailedAttempt(2)
+
+    ownershipBroken = false
+    let ownershipReadsAtSwitch = 0
+    activateGlobalInstall.mockImplementation(async (opts) => {
+      ownershipReadsAtSwitch = getInstalledBinNames.mock.calls.length
+      const installDir = (opts as { installDir: string }).installDir
+      fs.rmSync(oldHashLink, { force: true })
+      fs.symlinkSync(installDir, oldHashLink, process.platform === 'win32' ? 'junction' : 'dir')
+      return new Set(['pnpm'])
+    })
+
+    await add()
+
+    expect(activateGlobalInstall).toHaveBeenCalledTimes(1)
+    expect(cleanupReplacedGlobalInstalls).toHaveBeenCalledTimes(1)
+    expect(cleanupReplacedGlobalInstalls).toHaveBeenCalledWith({
+      groups: [{ info: existingPnpm, binNames: ['pnpm'] }],
+      globalBinDir,
+      globalDir,
+      activeHash: 'old-pnpm',
+      activatedBins: new Set(['pnpm']),
+      protectedBins: new Set(['eslint']),
+    })
+    expect(getInstalledBinNames).toHaveBeenCalledTimes(ownershipReadsAtSwitch)
+    expect(freshInstallDirs).toHaveLength(3)
+    expect(fs.realpathSync(oldHashLink)).toBe(fs.realpathSync(freshInstallDirs[2]))
+    expect(fs.readFileSync(oldMarker, 'utf8')).toBe('old install\n')
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('global add preserves ownership state and both errors when fresh install cleanup fails', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'global-add-cleanup-failure-'))
+  expect(fs.realpathSync(path.dirname(root))).toBe(fs.realpathSync(os.tmpdir()))
+  const globalDir = path.join(root, 'global')
+  const globalBinDir = path.join(root, 'bin')
+  const oldInstallDir = path.join(globalDir, 'old-install')
+  const survivorInstallDir = path.join(globalDir, 'survivor-install')
+  const freshInstallDir = path.join(globalDir, 'fresh-install')
+  const oldHashLink = path.join(globalDir, 'old-pnpm')
+  const oldMarker = path.join(oldInstallDir, 'marker')
+  const oldBin = path.join(globalBinDir, 'pnpm')
+  fs.mkdirSync(oldInstallDir, { recursive: true })
+  fs.mkdirSync(survivorInstallDir, { recursive: true })
+  fs.mkdirSync(freshInstallDir, { recursive: true })
+  fs.mkdirSync(globalBinDir, { recursive: true })
+  fs.writeFileSync(oldMarker, 'old install\n')
+  fs.writeFileSync(path.join(survivorInstallDir, 'marker'), 'survivor install\n')
+  fs.writeFileSync(path.join(freshInstallDir, 'marker'), 'fresh install\n')
+  fs.writeFileSync(oldBin, 'old pnpm shim\n')
+  fs.symlinkSync(oldInstallDir, oldHashLink, process.platform === 'win32' ? 'junction' : 'dir')
+
+  const existingPnpm = {
+    dependencies: { pnpm: '12.0.0-alpha.2' },
+    hash: 'old-pnpm',
+    installDir: oldInstallDir,
+  }
+  const survivor = {
+    dependencies: { eslint: '^9.0.0' },
+    hash: 'eslint',
+    installDir: survivorInstallDir,
+  }
+  const enumerationError = Object.assign(new Error('replacement package.json is missing'), { code: 'ENOENT' })
+  const cleanupError = Object.assign(new Error('fresh install cleanup failed'), { code: 'EACCES' })
+  createInstallDir.mockReturnValue(freshInstallDir)
+  createGlobalCacheKey.mockReturnValue(existingPnpm.hash)
+  findGlobalPackage.mockImplementation((_globalDir: string, alias: string) => alias === 'pnpm' ? existingPnpm : null)
+  scanGlobalPackages.mockReturnValue([existingPnpm, survivor])
+  getInstalledBinNames.mockImplementation(async (pkg) => {
+    if (pkg === existingPnpm) throw enumerationError
+    return ['eslint']
+  })
+
+  const snapshot = (): unknown => ({
+    binEntries: fs.readdirSync(globalBinDir).sort(),
+    globalEntries: fs.readdirSync(globalDir).sort(),
+    oldBin: fs.readFileSync(oldBin, 'utf8'),
+    oldHashTarget: fs.realpathSync(oldHashLink),
+    oldMarker: fs.readFileSync(oldMarker, 'utf8'),
+  })
+  const before = snapshot()
+  const realRm = fs.promises.rm.bind(fs.promises)
+  const rmSpy = jest.spyOn(fs.promises, 'rm').mockImplementation(async (target, options) => {
+    if (path.resolve(String(target)) === path.resolve(freshInstallDir)) throw cleanupError
+    await realRm(target, options)
+  })
+
+  try {
+    let thrown: unknown
+    try {
+      await handleGlobalAdd({
+        bin: globalBinDir,
+        dir: root,
+        globalPkgDir: globalDir,
+        registriesByScope: {},
+      } as any, ['file:/tmp/pnpm'], {}) // eslint-disable-line @typescript-eslint/no-explicit-any
+    } catch (err) {
+      thrown = err
+    }
+
+    expect(thrown).toBeInstanceOf(AggregateError)
+    const aggregateError = thrown as AggregateError
+    expect(aggregateError.errors).toStrictEqual([enumerationError, cleanupError])
+    expect(aggregateError.cause).toBe(enumerationError)
+    expect(snapshot()).toStrictEqual(before)
+    expect(rmSpy).toHaveBeenCalledWith(freshInstallDir, { recursive: true, force: true })
+    expect(activateGlobalInstall).not.toHaveBeenCalled()
+    expect(cleanupReplacedGlobalInstalls).not.toHaveBeenCalled()
+  } finally {
+    rmSpy.mockRestore()
+    fs.rmSync(root, { recursive: true, force: true })
+  }
 })
 
 test('global add does not clean up or persist policy when activation fails', async () => {

--- a/pnpm11/global/commands/test/globalAdd.test.ts
+++ b/pnpm11/global/commands/test/globalAdd.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import util from 'node:util'
 
 import { beforeEach, expect, jest, test } from '@jest/globals'
+import { redactAndSanitize } from '@pnpm/error'
 import type { GlobalPackageInfo } from '@pnpm/global.packages'
 import type { DependencyManifest } from '@pnpm/types'
 
@@ -38,7 +39,9 @@ const cleanupFailedGlobalInstall = jest.fn(async (installDir: string, originalEr
   } catch (cleanupError) {
     throw new AggregateError(
       [originalError, cleanupError],
-      'Failed to clean up after global install failed before activation.',
+      'Failed to clean up after global install failed before activation. ' +
+        `Original error: ${formatErrorForMessage(originalError)}. ` +
+        `Cleanup error: ${formatErrorForMessage(cleanupError)}.`,
       { cause: originalError } // eslint-disable-line preserve-caught-error -- Matches the production contract: the failure before activation is primary.
     )
   }
@@ -368,6 +371,11 @@ test('global add preserves ownership state and both errors when fresh install cl
     const aggregateError = thrown as AggregateError
     expect(aggregateError.errors).toStrictEqual([enumerationError, cleanupError])
     expect(aggregateError.cause).toBe(enumerationError)
+    expect(aggregateError.message).toBe(
+      'Failed to clean up after global install failed before activation. ' +
+      'Original error: replacement package.json is missing. ' +
+      'Cleanup error: fresh install cleanup failed.'
+    )
     expect(snapshot()).toStrictEqual(before)
     expect(rmSpy).toHaveBeenCalledWith(freshInstallDir, { recursive: true, force: true })
     expect(activateGlobalInstall).not.toHaveBeenCalled()
@@ -377,6 +385,21 @@ test('global add preserves ownership state and both errors when fresh install cl
     fs.rmSync(root, { recursive: true, force: true })
   }
 })
+
+function formatErrorForMessage (err: unknown): string {
+  if (util.types.isNativeError(err)) return sanitizeSingleLineErrorMessage(err.message)
+  try {
+    return sanitizeSingleLineErrorMessage(String(err))
+  } catch {
+    return 'Unknown error'
+  }
+}
+
+function sanitizeSingleLineErrorMessage (message: string): string {
+  return redactAndSanitize(message)
+    .replaceAll('\u2028', '')
+    .replaceAll('\u2029', '')
+}
 
 test('global add does not clean up or persist policy when activation fails', async () => {
   const activationError = new Error('activation failed')

--- a/pnpm11/global/commands/test/globalAdd.test.ts
+++ b/pnpm11/global/commands/test/globalAdd.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import util from 'node:util'
 
 import { beforeEach, expect, jest, test } from '@jest/globals'
 import type { GlobalPackageInfo } from '@pnpm/global.packages'
@@ -363,7 +364,7 @@ test('global add preserves ownership state and both errors when fresh install cl
       thrown = err
     }
 
-    expect(thrown).toBeInstanceOf(AggregateError)
+    expect(util.types.isNativeError(thrown)).toBe(true)
     const aggregateError = thrown as AggregateError
     expect(aggregateError.errors).toStrictEqual([enumerationError, cleanupError])
     expect(aggregateError.cause).toBe(enumerationError)

--- a/pnpm11/global/commands/test/globalAdd.test.ts
+++ b/pnpm11/global/commands/test/globalAdd.test.ts
@@ -355,11 +355,6 @@ test('global add preserves ownership state and both errors when fresh install cl
     const aggregateError = thrown as AggregateError
     expect(aggregateError.errors).toStrictEqual([enumerationError, cleanupError])
     expect(aggregateError.cause).toBe(enumerationError)
-    expect(aggregateError.message).toBe(
-      'Failed to clean up after global install failed before activation. ' +
-      'Original error: replacement package.json is missing. ' +
-      'Cleanup error: fresh install cleanup failed.'
-    )
     expect(snapshot()).toStrictEqual(before)
     expect(rmSpy).toHaveBeenCalledWith(freshInstallDir, { recursive: true, force: true })
     expect(activateGlobalInstall).not.toHaveBeenCalled()

--- a/pnpm11/global/commands/test/globalAdd.test.ts
+++ b/pnpm11/global/commands/test/globalAdd.test.ts
@@ -32,9 +32,6 @@ const readInstalledPackages = jest.fn<() => Promise<[]>>().mockResolvedValue([])
 const summaryDebug = jest.fn()
 const activateGlobalInstall = jest.fn<(opts: unknown) => Promise<Set<string>>>().mockResolvedValue(new Set(['pnpm']))
 const cleanupReplacedGlobalInstalls = jest.fn<(opts: unknown) => Promise<void>>().mockResolvedValue(undefined)
-// The real cleanup runs here: these tests cover how the command wires it up,
-// while its diagnostics are asserted in globalActivation.test.ts.
-const { cleanupFailedGlobalInstall } = jest.requireActual<typeof import('../src/globalActivation.js')>('../src/globalActivation.js')
 
 jest.unstable_mockModule('@pnpm/core-loggers', () => ({ summaryLogger: { debug: summaryDebug } }))
 jest.unstable_mockModule('@pnpm/global.packages', () => ({
@@ -53,7 +50,6 @@ jest.unstable_mockModule('../src/checkGlobalBinConflicts.js', () => ({ checkGlob
 jest.unstable_mockModule('../src/installGlobalPackages.js', () => ({ installGlobalPackages }))
 jest.unstable_mockModule('../src/globalActivation.js', () => ({
   activateGlobalInstall,
-  cleanupFailedGlobalInstall,
   cleanupReplacedGlobalInstalls,
 }))
 jest.unstable_mockModule('../src/promptApproveGlobalBuilds.js', () => ({ promptApproveGlobalBuilds }))

--- a/pnpm11/global/commands/test/globalAdd.test.ts
+++ b/pnpm11/global/commands/test/globalAdd.test.ts
@@ -4,7 +4,6 @@ import path from 'node:path'
 import util from 'node:util'
 
 import { beforeEach, expect, jest, test } from '@jest/globals'
-import { redactAndSanitize } from '@pnpm/error'
 import type { GlobalPackageInfo } from '@pnpm/global.packages'
 import type { DependencyManifest } from '@pnpm/types'
 
@@ -33,20 +32,9 @@ const readInstalledPackages = jest.fn<() => Promise<[]>>().mockResolvedValue([])
 const summaryDebug = jest.fn()
 const activateGlobalInstall = jest.fn<(opts: unknown) => Promise<Set<string>>>().mockResolvedValue(new Set(['pnpm']))
 const cleanupReplacedGlobalInstalls = jest.fn<(opts: unknown) => Promise<void>>().mockResolvedValue(undefined)
-const cleanupFailedGlobalInstall = jest.fn(async (installDir: string, originalError: unknown): Promise<never> => {
-  try {
-    await fs.promises.rm(installDir, { recursive: true, force: true })
-  } catch (cleanupError) {
-    throw new AggregateError(
-      [originalError, cleanupError],
-      'Failed to clean up after global install failed before activation. ' +
-        `Original error: ${formatErrorForMessage(originalError)}. ` +
-        `Cleanup error: ${formatErrorForMessage(cleanupError)}.`,
-      { cause: originalError } // eslint-disable-line preserve-caught-error -- Matches the production contract: the failure before activation is primary.
-    )
-  }
-  throw originalError
-})
+// The real cleanup runs here: these tests cover how the command wires it up,
+// while its diagnostics are asserted in globalActivation.test.ts.
+const { cleanupFailedGlobalInstall } = jest.requireActual<typeof import('../src/globalActivation.js')>('../src/globalActivation.js')
 
 jest.unstable_mockModule('@pnpm/core-loggers', () => ({ summaryLogger: { debug: summaryDebug } }))
 jest.unstable_mockModule('@pnpm/global.packages', () => ({
@@ -385,21 +373,6 @@ test('global add preserves ownership state and both errors when fresh install cl
     fs.rmSync(root, { recursive: true, force: true })
   }
 })
-
-function formatErrorForMessage (err: unknown): string {
-  if (util.types.isNativeError(err)) return sanitizeSingleLineErrorMessage(err.message)
-  try {
-    return sanitizeSingleLineErrorMessage(String(err))
-  } catch {
-    return 'Unknown error'
-  }
-}
-
-function sanitizeSingleLineErrorMessage (message: string): string {
-  return redactAndSanitize(message)
-    .replaceAll('\u2028', '')
-    .replaceAll('\u2029', '')
-}
 
 test('global add does not clean up or persist policy when activation fails', async () => {
   const activationError = new Error('activation failed')

--- a/pnpm11/global/commands/test/globalRemove.test.ts
+++ b/pnpm11/global/commands/test/globalRemove.test.ts
@@ -2,13 +2,17 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
-import { expect, jest, test } from '@jest/globals'
+import { beforeEach, expect, jest, test } from '@jest/globals'
 
 const removeBin = jest.fn<(cmd: string) => Promise<void>>().mockResolvedValue(undefined)
 
 jest.unstable_mockModule('@pnpm/bins.remover', () => ({ removeBin }))
 
 const { handleGlobalRemove } = await import('../src/globalRemove.js')
+
+beforeEach(() => {
+  removeBin.mockClear()
+})
 
 // A malicious global package whose manifest declares reserved bin keys must not
 // reach the deletion sink: `path.join(globalBinDir, '.')` is the bin directory
@@ -45,3 +49,201 @@ test('global remove ignores reserved manifest bin names', async () => {
   expect(removeBin).toHaveBeenCalledTimes(1)
   expect(removeBin).toHaveBeenCalledWith(path.join(globalBinDir, 'good'))
 })
+
+test('global remove checks every target before deleting any group', async () => {
+  const globalDir = fs.mkdtempSync(path.join(os.tmpdir(), 'global-remove-target-preflight-'))
+  assertTemporaryRoot(globalDir)
+  const globalBinDir = path.join(globalDir, 'bin')
+  fs.mkdirSync(globalBinDir, { recursive: true })
+  const readable = createGlobalGroup(globalDir, 'readable-hash', 'readable', {
+    name: 'readable',
+    version: '1.0.0',
+    bin: { readable: 'bin/readable.js' },
+  })
+  const incomplete = createGlobalGroup(globalDir, 'incomplete-hash', 'incomplete')
+  const readableSlot = path.join(globalBinDir, 'readable')
+  fs.writeFileSync(readableSlot, 'readable shim\n')
+  const before = snapshotFilesystem(globalDir)
+  const assertFailedAttempt = async (attempt: number): Promise<void> => {
+    const failure = await captureError(() => handleGlobalRemove(
+      { globalPkgDir: globalDir, bin: globalBinDir },
+      ['readable', 'incomplete']
+    ))
+    expect({ attempt, errorCode: getErrorCode(failure) }).toStrictEqual({ attempt, errorCode: 'ENOENT' })
+    expect(snapshotFilesystem(globalDir)).toStrictEqual(before)
+    expect(removeBin).not.toHaveBeenCalled()
+  }
+
+  try {
+    await assertFailedAttempt(1)
+    await assertFailedAttempt(2)
+
+    writeDependencyManifest(incomplete, {
+      name: 'incomplete',
+      version: '1.0.0',
+    })
+    await handleGlobalRemove({ globalPkgDir: globalDir, bin: globalBinDir }, ['readable', 'incomplete'])
+
+    expect(removeBin).toHaveBeenCalledTimes(1)
+    expect(removeBin).toHaveBeenCalledWith(readableSlot)
+    expect(fs.existsSync(readable.hashLink)).toBe(false)
+    expect(fs.existsSync(readable.installDir)).toBe(false)
+    expect(fs.existsSync(incomplete.hashLink)).toBe(false)
+    expect(fs.existsSync(incomplete.installDir)).toBe(false)
+
+    const afterSuccess = snapshotFilesystem(globalDir)
+    const repeatError = await captureError(() => handleGlobalRemove(
+      { globalPkgDir: globalDir, bin: globalBinDir },
+      ['readable', 'incomplete']
+    ))
+    expect(getErrorCode(repeatError)).toBe('ERR_PNPM_GLOBAL_PKG_NOT_FOUND')
+    expect(snapshotFilesystem(globalDir)).toStrictEqual(afterSuccess)
+    expect(removeBin).toHaveBeenCalledTimes(1)
+  } finally {
+    fs.rmSync(globalDir, { recursive: true, force: true })
+  }
+})
+
+test('global remove checks surviving ownership before deleting a target', async () => {
+  const globalDir = fs.mkdtempSync(path.join(os.tmpdir(), 'global-remove-survivor-preflight-'))
+  assertTemporaryRoot(globalDir)
+  const globalBinDir = path.join(globalDir, 'bin')
+  fs.mkdirSync(globalBinDir, { recursive: true })
+  const target = createGlobalGroup(globalDir, 'target-hash', 'target', {
+    name: 'target',
+    version: '1.0.0',
+    bin: { shared: 'bin/shared.js' },
+  })
+  const survivor = createGlobalGroup(globalDir, 'survivor-hash', 'survivor')
+  const sharedSlot = path.join(globalBinDir, 'shared')
+  fs.writeFileSync(sharedSlot, 'shared shim\n')
+  const before = snapshotFilesystem(globalDir)
+  const assertFailedAttempt = async (attempt: number): Promise<void> => {
+    const failure = await captureError(() => handleGlobalRemove(
+      { globalPkgDir: globalDir, bin: globalBinDir },
+      ['target']
+    ))
+    expect({ attempt, errorCode: getErrorCode(failure) }).toStrictEqual({ attempt, errorCode: 'ENOENT' })
+    expect(snapshotFilesystem(globalDir)).toStrictEqual(before)
+    expect(removeBin).not.toHaveBeenCalled()
+  }
+
+  try {
+    await assertFailedAttempt(1)
+    await assertFailedAttempt(2)
+
+    writeDependencyManifest(survivor, {
+      name: 'survivor',
+      version: '1.0.0',
+      bin: { shared: 'bin/shared.js' },
+    })
+    await handleGlobalRemove({ globalPkgDir: globalDir, bin: globalBinDir }, ['target'])
+
+    expect(removeBin).not.toHaveBeenCalled()
+    expect(fs.existsSync(target.hashLink)).toBe(false)
+    expect(fs.existsSync(target.installDir)).toBe(false)
+    expect(fs.existsSync(survivor.hashLink)).toBe(true)
+    expect(fs.realpathSync(survivor.hashLink)).toBe(fs.realpathSync(survivor.installDir))
+    expect(fs.readFileSync(survivor.marker, 'utf8')).toBe('survivor install\n')
+    expect(fs.readFileSync(sharedSlot, 'utf8')).toBe('shared shim\n')
+
+    const afterSuccess = snapshotFilesystem(globalDir)
+    const repeatError = await captureError(() => handleGlobalRemove(
+      { globalPkgDir: globalDir, bin: globalBinDir },
+      ['target']
+    ))
+    expect(getErrorCode(repeatError)).toBe('ERR_PNPM_GLOBAL_PKG_NOT_FOUND')
+    expect(snapshotFilesystem(globalDir)).toStrictEqual(afterSuccess)
+    expect(removeBin).not.toHaveBeenCalled()
+  } finally {
+    fs.rmSync(globalDir, { recursive: true, force: true })
+  }
+})
+
+interface GlobalGroupFixture {
+  dependencyManifestPath: string
+  hashLink: string
+  installDir: string
+  marker: string
+}
+
+function createGlobalGroup (
+  globalDir: string,
+  hash: string,
+  alias: string,
+  dependencyManifest?: Record<string, unknown>
+): GlobalGroupFixture {
+  const installDir = path.join(globalDir, `${hash}-install`)
+  const depDir = path.join(installDir, 'node_modules', alias)
+  const dependencyManifestPath = path.join(depDir, 'package.json')
+  const hashLink = path.join(globalDir, hash)
+  const marker = path.join(installDir, 'marker')
+  assertPathInside(globalDir, installDir)
+  fs.mkdirSync(depDir, { recursive: true })
+  fs.writeFileSync(marker, `${alias} install\n`)
+  fs.writeFileSync(path.join(installDir, 'package.json'), JSON.stringify({
+    name: `${alias}-global-group`,
+    version: '1.0.0',
+    dependencies: { [alias]: '1.0.0' },
+  }))
+  if (dependencyManifest != null) {
+    fs.writeFileSync(dependencyManifestPath, JSON.stringify(dependencyManifest))
+  }
+  fs.symlinkSync(installDir, hashLink, process.platform === 'win32' ? 'junction' : 'dir')
+  return { dependencyManifestPath, hashLink, installDir, marker }
+}
+
+function writeDependencyManifest (fixture: GlobalGroupFixture, manifest: Record<string, unknown>): void {
+  fs.writeFileSync(fixture.dependencyManifestPath, JSON.stringify(manifest))
+}
+
+async function captureError (run: () => Promise<void>): Promise<unknown> {
+  try {
+    await run()
+    return undefined
+  } catch (err) {
+    return err
+  }
+}
+
+function getErrorCode (err: unknown): unknown {
+  return err != null && typeof err === 'object' && 'code' in err ? err.code : undefined
+}
+
+interface FilesystemEntry {
+  content?: string
+  kind: 'directory' | 'file' | 'symlink'
+  path: string
+  target?: string
+}
+
+function snapshotFilesystem (root: string): FilesystemEntry[] {
+  const result: FilesystemEntry[] = []
+  visit(root, '')
+  return result
+
+  function visit (dir: string, relativeDir: string): void {
+    for (const name of fs.readdirSync(dir).sort()) {
+      const absolutePath = path.join(dir, name)
+      const relativePath = path.join(relativeDir, name)
+      const stat = fs.lstatSync(absolutePath)
+      if (stat.isSymbolicLink()) {
+        result.push({ kind: 'symlink', path: relativePath, target: fs.readlinkSync(absolutePath) })
+      } else if (stat.isDirectory()) {
+        result.push({ kind: 'directory', path: relativePath })
+        visit(absolutePath, relativePath)
+      } else {
+        result.push({ content: fs.readFileSync(absolutePath).toString('base64'), kind: 'file', path: relativePath })
+      }
+    }
+  }
+}
+
+function assertTemporaryRoot (root: string): void {
+  expect(fs.realpathSync(path.dirname(root))).toBe(fs.realpathSync(os.tmpdir()))
+}
+
+function assertPathInside (root: string, candidate: string): void {
+  const relative = path.relative(root, candidate)
+  expect(path.isAbsolute(relative) || relative === '..' || relative.startsWith(`..${path.sep}`)).toBe(false)
+}

--- a/pnpm11/global/commands/test/globalRemove.test.ts
+++ b/pnpm11/global/commands/test/globalRemove.test.ts
@@ -51,8 +51,7 @@ test('global remove ignores reserved manifest bin names', async () => {
 })
 
 test('global remove checks every target before deleting any group', async () => {
-  const globalDir = fs.mkdtempSync(path.join(os.tmpdir(), 'global-remove-target-preflight-'))
-  assertTemporaryRoot(globalDir)
+  const globalDir = createTemporaryRoot('global-remove-target-preflight-')
   const globalBinDir = path.join(globalDir, 'bin')
   fs.mkdirSync(globalBinDir, { recursive: true })
   const readable = createGlobalGroup(globalDir, 'readable-hash', 'readable', {
@@ -105,8 +104,7 @@ test('global remove checks every target before deleting any group', async () => 
 })
 
 test('global remove checks surviving ownership before deleting a target', async () => {
-  const globalDir = fs.mkdtempSync(path.join(os.tmpdir(), 'global-remove-survivor-preflight-'))
-  assertTemporaryRoot(globalDir)
+  const globalDir = createTemporaryRoot('global-remove-survivor-preflight-')
   const globalBinDir = path.join(globalDir, 'bin')
   fs.mkdirSync(globalBinDir, { recursive: true })
   const target = createGlobalGroup(globalDir, 'target-hash', 'target', {
@@ -239,8 +237,13 @@ function snapshotFilesystem (root: string): FilesystemEntry[] {
   }
 }
 
-function assertTemporaryRoot (root: string): void {
-  expect(fs.realpathSync(path.dirname(root))).toBe(fs.realpathSync(os.tmpdir()))
+// The resolved path matters: an install directory is only deleted when
+// `isSubdir` places it under the global dir, and macOS reports a temporary
+// directory under a prefix that is itself a symlink.
+function createTemporaryRoot (prefix: string): string {
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), prefix)))
+  expect(path.dirname(root)).toBe(fs.realpathSync(os.tmpdir()))
+  return root
 }
 
 function assertPathInside (root: string, candidate: string): void {

--- a/pnpm11/global/commands/test/globalRemove.test.ts
+++ b/pnpm11/global/commands/test/globalRemove.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import util from 'node:util'
 
 import { beforeEach, expect, jest, test } from '@jest/globals'
 
@@ -54,12 +55,17 @@ test('global remove checks every target before deleting any group', async () => 
   const globalDir = createTemporaryRoot('global-remove-target-preflight-')
   const globalBinDir = path.join(globalDir, 'bin')
   fs.mkdirSync(globalBinDir, { recursive: true })
-  const readable = createGlobalGroup(globalDir, 'readable-hash', 'readable', {
-    name: 'readable',
-    version: '1.0.0',
-    bin: { readable: 'bin/readable.js' },
+  const readable = createGlobalGroup({
+    globalDir,
+    hash: 'readable-hash',
+    alias: 'readable',
+    dependencyManifest: {
+      name: 'readable',
+      version: '1.0.0',
+      bin: { readable: 'bin/readable.js' },
+    },
   })
-  const incomplete = createGlobalGroup(globalDir, 'incomplete-hash', 'incomplete')
+  const incomplete = createGlobalGroup({ globalDir, hash: 'incomplete-hash', alias: 'incomplete' })
   const readableSlot = path.join(globalBinDir, 'readable')
   fs.writeFileSync(readableSlot, 'readable shim\n')
   const before = snapshotFilesystem(globalDir)
@@ -107,12 +113,17 @@ test('global remove checks surviving ownership before deleting a target', async 
   const globalDir = createTemporaryRoot('global-remove-survivor-preflight-')
   const globalBinDir = path.join(globalDir, 'bin')
   fs.mkdirSync(globalBinDir, { recursive: true })
-  const target = createGlobalGroup(globalDir, 'target-hash', 'target', {
-    name: 'target',
-    version: '1.0.0',
-    bin: { shared: 'bin/shared.js' },
+  const target = createGlobalGroup({
+    globalDir,
+    hash: 'target-hash',
+    alias: 'target',
+    dependencyManifest: {
+      name: 'target',
+      version: '1.0.0',
+      bin: { shared: 'bin/shared.js' },
+    },
   })
-  const survivor = createGlobalGroup(globalDir, 'survivor-hash', 'survivor')
+  const survivor = createGlobalGroup({ globalDir, hash: 'survivor-hash', alias: 'survivor' })
   const sharedSlot = path.join(globalBinDir, 'shared')
   fs.writeFileSync(sharedSlot, 'shared shim\n')
   const before = snapshotFilesystem(globalDir)
@@ -165,11 +176,15 @@ interface GlobalGroupFixture {
   marker: string
 }
 
-function createGlobalGroup (
-  globalDir: string,
-  hash: string,
-  alias: string,
+interface GlobalGroupSpec {
+  globalDir: string
+  hash: string
+  alias: string
   dependencyManifest?: Record<string, unknown>
+}
+
+function createGlobalGroup (
+  { globalDir, hash, alias, dependencyManifest }: GlobalGroupSpec
 ): GlobalGroupFixture {
   const installDir = path.join(globalDir, `${hash}-install`)
   const depDir = path.join(installDir, 'node_modules', alias)
@@ -205,7 +220,7 @@ async function captureError (run: () => Promise<void>): Promise<unknown> {
 }
 
 function getErrorCode (err: unknown): unknown {
-  return err != null && typeof err === 'object' && 'code' in err ? err.code : undefined
+  return util.types.isNativeError(err) && 'code' in err ? err.code : undefined
 }
 
 interface FilesystemEntry {

--- a/pnpm11/global/commands/test/globalUpdate.test.ts
+++ b/pnpm11/global/commands/test/globalUpdate.test.ts
@@ -1,10 +1,15 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
 import { beforeEach, expect, jest, test } from '@jest/globals'
+import type { GlobalPackageInfo } from '@pnpm/global.packages'
 
 const cleanOrphanedInstallDirs = jest.fn()
 const createInstallDir = jest.fn()
 const getHashLink = jest.fn()
 const getGlobalPackageDetails = jest.fn<(pkg: unknown) => Promise<Array<{ alias: string, version: string }>>>().mockResolvedValue([])
-const getInstalledBinNames = jest.fn<() => Promise<string[]>>().mockResolvedValue([])
+const getInstalledBinNames = jest.fn<(pkg: GlobalPackageInfo) => Promise<string[]>>().mockResolvedValue([])
 const scanGlobalPackages = jest.fn()
 const checkGlobalBinConflicts = jest.fn<() => Promise<Set<string>>>().mockResolvedValue(new Set())
 const installGlobalPackages = jest.fn<(...args: unknown[]) => Promise<{ ignoredBuilds: undefined, resolutionPolicyViolations: [], resolvedVersions: Record<string, string> }>>()
@@ -14,6 +19,18 @@ const readInstalledPackages = jest.fn<(installDir: string) => Promise<Array<{ al
 const summaryDebug = jest.fn()
 const activateGlobalInstall = jest.fn<(opts: unknown) => Promise<Set<string>>>().mockResolvedValue(new Set(['fresh']))
 const cleanupReplacedGlobalInstalls = jest.fn<(opts: unknown) => Promise<void>>().mockResolvedValue(undefined)
+const cleanupFailedGlobalInstall = jest.fn(async (installDir: string, originalError: unknown): Promise<never> => {
+  try {
+    await fs.promises.rm(installDir, { recursive: true, force: true })
+  } catch (cleanupError) {
+    throw new AggregateError(
+      [originalError, cleanupError],
+      'Failed to clean up after global install failed before activation.',
+      { cause: originalError } // eslint-disable-line preserve-caught-error -- Matches the production contract: the failure before activation is primary.
+    )
+  }
+  throw originalError
+})
 
 jest.unstable_mockModule('@pnpm/core-loggers', () => ({ summaryLogger: { debug: summaryDebug } }))
 jest.unstable_mockModule('@pnpm/global.packages', () => ({
@@ -25,7 +42,11 @@ jest.unstable_mockModule('@pnpm/global.packages', () => ({
   scanGlobalPackages,
 }))
 jest.unstable_mockModule('../src/checkGlobalBinConflicts.js', () => ({ checkGlobalBinConflicts }))
-jest.unstable_mockModule('../src/globalActivation.js', () => ({ cleanupReplacedGlobalInstalls, activateGlobalInstall }))
+jest.unstable_mockModule('../src/globalActivation.js', () => ({
+  activateGlobalInstall,
+  cleanupFailedGlobalInstall,
+  cleanupReplacedGlobalInstalls,
+}))
 jest.unstable_mockModule('../src/installGlobalPackages.js', () => ({ installGlobalPackages }))
 jest.unstable_mockModule('../src/promptApproveGlobalBuilds.js', () => ({ promptApproveGlobalBuilds }))
 jest.unstable_mockModule('../src/readInstalledPackages.js', () => ({ readInstalledPackages }))
@@ -55,7 +76,7 @@ test('global update emits a single summary after updating all isolated groups', 
   getHashLink
     .mockReturnValueOnce('/global/v11/hash-foo')
     .mockReturnValueOnce('/global/v11/hash-bar')
-  const groups = [
+  const groups: GlobalPackageInfo[] = [
     {
       dependencies: { foo: '^1.0.0' },
       hash: 'hash-foo',
@@ -109,7 +130,7 @@ test('global update emits a single summary after updating all isolated groups', 
     binsToSkip: new Set(),
   })
   expect(cleanupReplacedGlobalInstalls).toHaveBeenNthCalledWith(1, {
-    groups: [groups[0]],
+    groups: [{ info: groups[0], binNames: [] }],
     globalDir: '/global/v11',
     globalBinDir: '/global/bin',
     activeHash: 'hash-foo',
@@ -117,19 +138,175 @@ test('global update emits a single summary after updating all isolated groups', 
     protectedBins: new Set(),
   })
   expect(cleanupReplacedGlobalInstalls).toHaveBeenNthCalledWith(2, {
-    groups: [groups[1]],
+    groups: [{ info: groups[1], binNames: [] }],
     globalDir: '/global/v11',
     globalBinDir: '/global/bin',
     activeHash: 'hash-bar',
     activatedBins: new Set(['fresh']),
     protectedBins: new Set(),
   })
+  const firstActivationOrder = activateGlobalInstall.mock.invocationCallOrder[0]
+  for (const group of groups) {
+    const ownershipCall = getInstalledBinNames.mock.calls.findIndex(([pkg]) => pkg === group)
+    expect(ownershipCall).toBeGreaterThanOrEqual(0)
+    expect(getInstalledBinNames.mock.invocationCallOrder[ownershipCall]).toBeLessThan(firstActivationOrder)
+  }
   for (const index of [0, 1]) {
     expect(activateGlobalInstall.mock.invocationCallOrder[index]).toBeLessThan(cleanupReplacedGlobalInstalls.mock.invocationCallOrder[index])
     expect(cleanupReplacedGlobalInstalls.mock.invocationCallOrder[index]).toBeLessThan(updateResolutionPolicyManifest.mock.invocationCallOrder[index])
   }
   expect(summaryDebug).toHaveBeenCalledTimes(1)
   expect(summaryDebug).toHaveBeenCalledWith({ prefix: '/global/v11' })
+})
+
+test('global update removes the fresh install and does not activate when target ownership cannot be enumerated', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'global-update-ownership-'))
+  expect(fs.realpathSync(path.dirname(root))).toBe(fs.realpathSync(os.tmpdir()))
+  expect(root).not.toBe('')
+  expect(fs.statSync(root).isDirectory()).toBe(true)
+  const globalDir = path.join(root, 'global')
+  const globalBinDir = path.join(root, 'bin')
+  const oldInstallDir = path.join(globalDir, 'old-install')
+  const freshInstallDir = path.join(globalDir, 'fresh-install')
+  const oldMarker = path.join(oldInstallDir, 'marker')
+  fs.mkdirSync(oldInstallDir, { recursive: true })
+  fs.mkdirSync(freshInstallDir, { recursive: true })
+  fs.mkdirSync(globalBinDir, { recursive: true })
+  fs.writeFileSync(oldMarker, 'old install\n')
+  fs.writeFileSync(path.join(freshInstallDir, 'marker'), 'fresh install\n')
+
+  const target = {
+    dependencies: { foo: '^1.0.0' },
+    hash: 'hash-foo',
+    installDir: oldInstallDir,
+  }
+  const survivor = {
+    dependencies: { bar: '^2.0.0' },
+    hash: 'hash-bar',
+    installDir: path.join(globalDir, 'bar-install'),
+  }
+  const enumerationError = Object.assign(new Error('target package.json is missing'), { code: 'ENOENT' })
+  createInstallDir.mockReturnValue(freshInstallDir)
+  getHashLink.mockReturnValue(path.join(globalDir, target.hash))
+  scanGlobalPackages.mockReturnValue([target, survivor])
+  getInstalledBinNames.mockImplementation(async (pkg) => {
+    if (pkg === target) throw enumerationError
+    return ['bar']
+  })
+
+  try {
+    let thrown: unknown
+    try {
+      await handleGlobalUpdate({
+        bin: globalBinDir,
+        globalPkgDir: globalDir,
+      } as any, ['foo'], {}) // eslint-disable-line @typescript-eslint/no-explicit-any
+    } catch (err) {
+      thrown = err
+    }
+
+    const observed = {
+      thrown,
+      activated: activateGlobalInstall.mock.calls.length,
+      cleanedUp: cleanupReplacedGlobalInstalls.mock.calls.length,
+      oldMarker: fs.readFileSync(oldMarker, 'utf8'),
+      freshInstallExists: fs.existsSync(freshInstallDir),
+    }
+
+    expect(observed).toMatchObject({
+      thrown: enumerationError,
+      activated: 0,
+      cleanedUp: 0,
+      oldMarker: 'old install\n',
+      freshInstallExists: false,
+    })
+  } finally {
+    expect(root).not.toBe('')
+    expect(fs.existsSync(root)).toBe(true)
+    expect(fs.statSync(root).isDirectory()).toBe(true)
+    expect(fs.realpathSync(path.dirname(root))).toBe(fs.realpathSync(os.tmpdir()))
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('global update preserves ownership state and both errors when fresh install cleanup fails', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'global-update-cleanup-failure-'))
+  expect(fs.realpathSync(path.dirname(root))).toBe(fs.realpathSync(os.tmpdir()))
+  const globalDir = path.join(root, 'global')
+  const globalBinDir = path.join(root, 'bin')
+  const oldInstallDir = path.join(globalDir, 'old-install')
+  const survivorInstallDir = path.join(globalDir, 'survivor-install')
+  const freshInstallDir = path.join(globalDir, 'fresh-install')
+  const oldHashLink = path.join(globalDir, 'hash-foo')
+  const oldMarker = path.join(oldInstallDir, 'marker')
+  const oldBin = path.join(globalBinDir, 'foo')
+  fs.mkdirSync(oldInstallDir, { recursive: true })
+  fs.mkdirSync(survivorInstallDir, { recursive: true })
+  fs.mkdirSync(freshInstallDir, { recursive: true })
+  fs.mkdirSync(globalBinDir, { recursive: true })
+  fs.writeFileSync(oldMarker, 'old install\n')
+  fs.writeFileSync(path.join(survivorInstallDir, 'marker'), 'survivor install\n')
+  fs.writeFileSync(path.join(freshInstallDir, 'marker'), 'fresh install\n')
+  fs.writeFileSync(oldBin, 'old foo shim\n')
+  fs.symlinkSync(oldInstallDir, oldHashLink, process.platform === 'win32' ? 'junction' : 'dir')
+
+  const target = {
+    dependencies: { foo: '^1.0.0' },
+    hash: 'hash-foo',
+    installDir: oldInstallDir,
+  }
+  const survivor = {
+    dependencies: { bar: '^2.0.0' },
+    hash: 'hash-bar',
+    installDir: survivorInstallDir,
+  }
+  const enumerationError = Object.assign(new Error('target package.json is missing'), { code: 'ENOENT' })
+  const cleanupError = Object.assign(new Error('fresh install cleanup failed'), { code: 'EACCES' })
+  createInstallDir.mockReturnValue(freshInstallDir)
+  getHashLink.mockReturnValue(oldHashLink)
+  scanGlobalPackages.mockReturnValue([target, survivor])
+  getInstalledBinNames.mockImplementation(async (pkg) => {
+    if (pkg === target) throw enumerationError
+    return ['bar']
+  })
+
+  const snapshot = (): unknown => ({
+    binEntries: fs.readdirSync(globalBinDir).sort(),
+    globalEntries: fs.readdirSync(globalDir).sort(),
+    oldBin: fs.readFileSync(oldBin, 'utf8'),
+    oldHashTarget: fs.realpathSync(oldHashLink),
+    oldMarker: fs.readFileSync(oldMarker, 'utf8'),
+  })
+  const before = snapshot()
+  const realRm = fs.promises.rm.bind(fs.promises)
+  const rmSpy = jest.spyOn(fs.promises, 'rm').mockImplementation(async (targetPath, options) => {
+    if (path.resolve(String(targetPath)) === path.resolve(freshInstallDir)) throw cleanupError
+    await realRm(targetPath, options)
+  })
+
+  try {
+    let thrown: unknown
+    try {
+      await handleGlobalUpdate({
+        bin: globalBinDir,
+        globalPkgDir: globalDir,
+      } as any, ['foo'], {}) // eslint-disable-line @typescript-eslint/no-explicit-any
+    } catch (err) {
+      thrown = err
+    }
+
+    expect(thrown).toBeInstanceOf(AggregateError)
+    const aggregateError = thrown as AggregateError
+    expect(aggregateError.errors).toStrictEqual([enumerationError, cleanupError])
+    expect(aggregateError.cause).toBe(enumerationError)
+    expect(snapshot()).toStrictEqual(before)
+    expect(rmSpy).toHaveBeenCalledWith(freshInstallDir, { recursive: true, force: true })
+    expect(activateGlobalInstall).not.toHaveBeenCalled()
+    expect(cleanupReplacedGlobalInstalls).not.toHaveBeenCalled()
+  } finally {
+    rmSpy.mockRestore()
+    fs.rmSync(root, { recursive: true, force: true })
+  }
 })
 
 test('global update only updates interactively selected groups', async () => {

--- a/pnpm11/global/commands/test/globalUpdate.test.ts
+++ b/pnpm11/global/commands/test/globalUpdate.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import util from 'node:util'
 
 import { beforeEach, expect, jest, test } from '@jest/globals'
+import { redactAndSanitize } from '@pnpm/error'
 import type { GlobalPackageInfo } from '@pnpm/global.packages'
 
 const cleanOrphanedInstallDirs = jest.fn()
@@ -26,7 +27,9 @@ const cleanupFailedGlobalInstall = jest.fn(async (installDir: string, originalEr
   } catch (cleanupError) {
     throw new AggregateError(
       [originalError, cleanupError],
-      'Failed to clean up after global install failed before activation.',
+      'Failed to clean up after global install failed before activation. ' +
+        `Original error: ${formatErrorForMessage(originalError)}. ` +
+        `Cleanup error: ${formatErrorForMessage(cleanupError)}.`,
       { cause: originalError } // eslint-disable-line preserve-caught-error -- Matches the production contract: the failure before activation is primary.
     )
   }
@@ -300,6 +303,11 @@ test('global update preserves ownership state and both errors when fresh install
     const aggregateError = thrown as AggregateError
     expect(aggregateError.errors).toStrictEqual([enumerationError, cleanupError])
     expect(aggregateError.cause).toBe(enumerationError)
+    expect(aggregateError.message).toBe(
+      'Failed to clean up after global install failed before activation. ' +
+      'Original error: target package.json is missing. ' +
+      'Cleanup error: fresh install cleanup failed.'
+    )
     expect(snapshot()).toStrictEqual(before)
     expect(rmSpy).toHaveBeenCalledWith(freshInstallDir, { recursive: true, force: true })
     expect(activateGlobalInstall).not.toHaveBeenCalled()
@@ -309,6 +317,21 @@ test('global update preserves ownership state and both errors when fresh install
     fs.rmSync(root, { recursive: true, force: true })
   }
 })
+
+function formatErrorForMessage (err: unknown): string {
+  if (util.types.isNativeError(err)) return sanitizeSingleLineErrorMessage(err.message)
+  try {
+    return sanitizeSingleLineErrorMessage(String(err))
+  } catch {
+    return 'Unknown error'
+  }
+}
+
+function sanitizeSingleLineErrorMessage (message: string): string {
+  return redactAndSanitize(message)
+    .replaceAll('\u2028', '')
+    .replaceAll('\u2029', '')
+}
 
 test('global update only updates interactively selected groups', async () => {
   createInstallDir.mockReturnValue('/global/v11/install-1')

--- a/pnpm11/global/commands/test/globalUpdate.test.ts
+++ b/pnpm11/global/commands/test/globalUpdate.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import util from 'node:util'
 
 import { beforeEach, expect, jest, test } from '@jest/globals'
 import type { GlobalPackageInfo } from '@pnpm/global.packages'
@@ -295,7 +296,7 @@ test('global update preserves ownership state and both errors when fresh install
       thrown = err
     }
 
-    expect(thrown).toBeInstanceOf(AggregateError)
+    expect(util.types.isNativeError(thrown)).toBe(true)
     const aggregateError = thrown as AggregateError
     expect(aggregateError.errors).toStrictEqual([enumerationError, cleanupError])
     expect(aggregateError.cause).toBe(enumerationError)

--- a/pnpm11/global/commands/test/globalUpdate.test.ts
+++ b/pnpm11/global/commands/test/globalUpdate.test.ts
@@ -4,7 +4,6 @@ import path from 'node:path'
 import util from 'node:util'
 
 import { beforeEach, expect, jest, test } from '@jest/globals'
-import { redactAndSanitize } from '@pnpm/error'
 import type { GlobalPackageInfo } from '@pnpm/global.packages'
 
 const cleanOrphanedInstallDirs = jest.fn()
@@ -21,20 +20,9 @@ const readInstalledPackages = jest.fn<(installDir: string) => Promise<Array<{ al
 const summaryDebug = jest.fn()
 const activateGlobalInstall = jest.fn<(opts: unknown) => Promise<Set<string>>>().mockResolvedValue(new Set(['fresh']))
 const cleanupReplacedGlobalInstalls = jest.fn<(opts: unknown) => Promise<void>>().mockResolvedValue(undefined)
-const cleanupFailedGlobalInstall = jest.fn(async (installDir: string, originalError: unknown): Promise<never> => {
-  try {
-    await fs.promises.rm(installDir, { recursive: true, force: true })
-  } catch (cleanupError) {
-    throw new AggregateError(
-      [originalError, cleanupError],
-      'Failed to clean up after global install failed before activation. ' +
-        `Original error: ${formatErrorForMessage(originalError)}. ` +
-        `Cleanup error: ${formatErrorForMessage(cleanupError)}.`,
-      { cause: originalError } // eslint-disable-line preserve-caught-error -- Matches the production contract: the failure before activation is primary.
-    )
-  }
-  throw originalError
-})
+// The real cleanup runs here: these tests cover how the command wires it up,
+// while its diagnostics are asserted in globalActivation.test.ts.
+const { cleanupFailedGlobalInstall } = jest.requireActual<typeof import('../src/globalActivation.js')>('../src/globalActivation.js')
 
 jest.unstable_mockModule('@pnpm/core-loggers', () => ({ summaryLogger: { debug: summaryDebug } }))
 jest.unstable_mockModule('@pnpm/global.packages', () => ({
@@ -317,21 +305,6 @@ test('global update preserves ownership state and both errors when fresh install
     fs.rmSync(root, { recursive: true, force: true })
   }
 })
-
-function formatErrorForMessage (err: unknown): string {
-  if (util.types.isNativeError(err)) return sanitizeSingleLineErrorMessage(err.message)
-  try {
-    return sanitizeSingleLineErrorMessage(String(err))
-  } catch {
-    return 'Unknown error'
-  }
-}
-
-function sanitizeSingleLineErrorMessage (message: string): string {
-  return redactAndSanitize(message)
-    .replaceAll('\u2028', '')
-    .replaceAll('\u2029', '')
-}
 
 test('global update only updates interactively selected groups', async () => {
   createInstallDir.mockReturnValue('/global/v11/install-1')

--- a/pnpm11/global/commands/test/globalUpdate.test.ts
+++ b/pnpm11/global/commands/test/globalUpdate.test.ts
@@ -20,9 +20,6 @@ const readInstalledPackages = jest.fn<(installDir: string) => Promise<Array<{ al
 const summaryDebug = jest.fn()
 const activateGlobalInstall = jest.fn<(opts: unknown) => Promise<Set<string>>>().mockResolvedValue(new Set(['fresh']))
 const cleanupReplacedGlobalInstalls = jest.fn<(opts: unknown) => Promise<void>>().mockResolvedValue(undefined)
-// The real cleanup runs here: these tests cover how the command wires it up,
-// while its diagnostics are asserted in globalActivation.test.ts.
-const { cleanupFailedGlobalInstall } = jest.requireActual<typeof import('../src/globalActivation.js')>('../src/globalActivation.js')
 
 jest.unstable_mockModule('@pnpm/core-loggers', () => ({ summaryLogger: { debug: summaryDebug } }))
 jest.unstable_mockModule('@pnpm/global.packages', () => ({
@@ -36,7 +33,6 @@ jest.unstable_mockModule('@pnpm/global.packages', () => ({
 jest.unstable_mockModule('../src/checkGlobalBinConflicts.js', () => ({ checkGlobalBinConflicts }))
 jest.unstable_mockModule('../src/globalActivation.js', () => ({
   activateGlobalInstall,
-  cleanupFailedGlobalInstall,
   cleanupReplacedGlobalInstalls,
 }))
 jest.unstable_mockModule('../src/installGlobalPackages.js', () => ({ installGlobalPackages }))

--- a/pnpm11/global/commands/test/globalUpdate.test.ts
+++ b/pnpm11/global/commands/test/globalUpdate.test.ts
@@ -287,11 +287,6 @@ test('global update preserves ownership state and both errors when fresh install
     const aggregateError = thrown as AggregateError
     expect(aggregateError.errors).toStrictEqual([enumerationError, cleanupError])
     expect(aggregateError.cause).toBe(enumerationError)
-    expect(aggregateError.message).toBe(
-      'Failed to clean up after global install failed before activation. ' +
-      'Original error: target package.json is missing. ' +
-      'Cleanup error: fresh install cleanup failed.'
-    )
     expect(snapshot()).toStrictEqual(before)
     expect(rmSpy).toHaveBeenCalledWith(freshInstallDir, { recursive: true, force: true })
     expect(activateGlobalInstall).not.toHaveBeenCalled()

--- a/pnpm11/global/packages/src/index.ts
+++ b/pnpm11/global/packages/src/index.ts
@@ -9,6 +9,7 @@ export {
   findGlobalPackage,
   getGlobalPackageDetails,
   getInstalledBinNames,
+  type GlobalPackageBinSnapshot,
   type GlobalPackageInfo,
   type InstalledGlobalPackage,
   isValidGlobalDependencyAlias,

--- a/pnpm11/global/packages/src/scanGlobalPackages.ts
+++ b/pnpm11/global/packages/src/scanGlobalPackages.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import util from 'node:util'
 
 import { getBinsFromPackageManifest } from '@pnpm/bins.resolver'
-import { readPackageJsonFromDirRawSync, safeReadPackageJsonFromDir } from '@pnpm/pkg-manifest.reader'
+import { readPackageJsonFromDir, readPackageJsonFromDirRawSync, safeReadPackageJsonFromDir } from '@pnpm/pkg-manifest.reader'
 import type { PackageManifest } from '@pnpm/types'
 
 const RESERVED_ALIASES = new Set(['node_modules', 'favicon.ico'])
@@ -46,6 +46,11 @@ export interface GlobalPackageInfo {
   hash: string
   installDir: string
   dependencies: Record<string, string>
+}
+
+export interface GlobalPackageBinSnapshot {
+  info: GlobalPackageInfo
+  binNames: string[]
 }
 
 export interface InstalledGlobalPackage {
@@ -154,8 +159,7 @@ export async function getInstalledBinNames (info: GlobalPackageInfo): Promise<st
   await Promise.all(
     aliases.map(async (alias) => {
       const depDir = path.join(modulesDir, alias)
-      const manifest = await safeReadPackageJsonFromDir(depDir)
-      if (!manifest) return
+      const manifest = await readPackageJsonFromDir(depDir)
       const binsOfPkg = await getBinsFromPackageManifest(manifest, depDir)
       for (const bin of binsOfPkg) {
         bins.add(bin.name)


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Fixes pnpm/pnpm#13796.

Global bin ownership enumeration previously treated a missing or unreadable
declared dependency manifest as though that package exposed no commands. Add,
update, and remove could therefore mutate global bins or installation
directories using a partial ownership set.

This change makes the shared TypeScript and Rust enumerators fail closed, then
snapshots target and surviving-group ownership before activation or deletion.
Replacement cleanup consumes the snapshot instead of rereading the old group
after its hash link changes, and direct remove now checks every target and
survivor before its first mutation. If cleaning a fresh install that has not
been activated also fails, both stacks preserve the original diagnostic and
report the cleanup failure instead of silently ignoring it.

The regression coverage exercises readable packages without bins, missing and
malformed manifests, non-ENOENT/PermissionDenied failures, partial multi-alias
enumeration, retry after repair, surviving shared bins, and command-wide remove
atomicity in both implementations.

This PR deliberately scopes completeness to each declared dependency manifest.
The existing tolerant group-root scan and `directories.bin` walker behavior are
separate concerns.

### Validation

Current PR head: `3faf11bc422e179eae01d96abdd3743f07e92bdd`.

- All checks on the current head completed with no failures: 36 passed and
  two non-actionable checks were skipped (`[code]smith` and downstream
  `capture`). TypeScript CI, Rust CI, Coverage, CodeQL, dependency audit,
  Micro-Benchmark, Integrated Benchmark, and downstream Bencher passed.
- Current-head workflow evidence: [TypeScript CI](https://github.com/pnpm/pnpm/actions/runs/32406121834),
  [Rust CI](https://github.com/pnpm/pnpm/actions/runs/32406121409),
  [Coverage](https://github.com/pnpm/pnpm/actions/runs/32406121437),
  [CodeQL](https://github.com/pnpm/pnpm/actions/runs/32406121482),
  [Micro-Benchmark](https://github.com/pnpm/pnpm/actions/runs/32406121432),
  [Integrated Benchmark](https://github.com/pnpm/pnpm/actions/runs/32406121533),
  and [Bencher](https://github.com/pnpm/pnpm/runs/96554892308).
- Greptile raised its [confidence score to 5/5](https://github.com/pnpm/pnpm/pull/13985#issuecomment-5349975822)
  after the diagnostic follow-up, added no new comments, and automatically
  resolved its original [P1 thread](https://github.com/pnpm/pnpm/pull/13985#discussion_r3817916470).
- CodeRabbit's [incremental review](https://github.com/pnpm/pnpm/pull/13985#pullrequestreview-4986392104)
  on the current head completed with no new inline comments; all review
  threads are resolved.
- Focused local validation for the diagnostic follow-up passed: 34/34 tests
  across three Jest suites, TypeScript build, ESLint, CSpell, and
  `git diff --check`. The pre-push hook passed TypeScript compile, lint,
  spellcheck, and metadata checks.
- Earlier ownership validation remains unchanged: 42 tests across five
  relevant Jest suites, `pnpm-global` 14/14, four Rust CLI ownership
  preflight regressions, Rust fmt, focused check, and focused Clippy. The
  latest commit changed only TypeScript diagnostics, and the full current-head
  Rust CI passed.
- The local worktree, fork branch, and PR head are synchronized.

## Squash Commit Body

```text
Global package cleanup previously interpreted a declared dependency manifest
that could not be read as a package with no commands. The resulting partial bin
set could orphan a replaced group's command or remove a command still owned by
a surviving group.

Make dependency-manifest ownership enumeration fallible in both the TypeScript
and Rust implementations. Snapshot target and survivor ownership before global
activation or deletion, make multi-target remove preflight the whole command,
and preserve both the ownership and fresh-install cleanup diagnostics when both
operations fail.

Add real-filesystem and CLI regressions for incomplete enumeration, repair and
retry, protected shared commands, and mutation-free failure paths.

Fixes pnpm/pnpm#13796.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port.
- [x] Added a changeset for the affected published packages.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13985"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789614775&installation_model_id=426870&pr_number=13985&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13985&signature=7eb73bd599866b484deb847dc60cf3882f2b93652a28840352316f2a6d6ac177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

---
Written by an agent (Codex, GPT-5.6 Sol).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Global add, update, and remove operations now fail safely when installed package metadata is missing, invalid, or unreadable.
  * Prevented partial filesystem changes when ownership information cannot be verified.
  * Preserved binaries still used by other installed packages while removing stale binaries.
  * Improved failed-install cleanup, including reporting both installation and cleanup errors.
  * Enabled successful retries after package metadata is repaired.
* **Tests**
  * Added coverage for malformed metadata, retry behavior, cleanup failures, and repeatable global operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->