### PR TITLE
fix(config): normalize Windows store paths

### DIFF
--- a/.changeset/windows-store-path-prefix.md
+++ b/.changeset/windows-store-path-prefix.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+On Windows, `pnpm store path` now returns a conventional drive path without the `\\?\` verbatim prefix when the project and pnpm home are on different drives [#13987](https://github.com/pnpm/pnpm/issues/13987).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4409,6 +4409,7 @@ name = "pnpm-config"
 version = "0.0.1"
 dependencies = [
  "derive_more",
+ "dunce",
  "home",
  "indexmap 2.14.0",
  "is_ci",

--- a/pnpm/crates/config/Cargo.toml
+++ b/pnpm/crates/config/Cargo.toml
@@ -26,6 +26,7 @@ pnpm-versioning             = { workspace = true }
 pnpm-workspace-state        = { workspace = true }
 
 derive_more   = { workspace = true }
+dunce         = { workspace = true }
 home          = { workspace = true }
 indexmap      = { workspace = true }
 is_ci         = { workspace = true }
@@ -41,9 +42,6 @@ url           = { workspace = true }
 
 [target.'cfg(all(unix, not(target_os = "cygwin")))'.dependencies]
 libc = { workspace = true }
-
-[target.'cfg(windows)'.dependencies]
-dunce = { workspace = true }
 
 [dev-dependencies]
 pnpm-testing-utils = { workspace = true }

--- a/pnpm/crates/config/Cargo.toml
+++ b/pnpm/crates/config/Cargo.toml
@@ -42,6 +42,9 @@ url           = { workspace = true }
 [target.'cfg(all(unix, not(target_os = "cygwin")))'.dependencies]
 libc = { workspace = true }
 
+[target.'cfg(windows)'.dependencies]
+dunce = { workspace = true }
+
 [dev-dependencies]
 pnpm-testing-utils = { workspace = true }
 

--- a/pnpm/crates/config/src/store_path.rs
+++ b/pnpm/crates/config/src/store_path.rs
@@ -55,6 +55,8 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
+// Windows' standard canonicalizer returns `\\?\` verbatim paths;
+// `dunce` resolves the path without leaking that prefix to CLI output.
 #[cfg(windows)]
 use dunce::canonicalize;
 #[cfg(not(windows))]

--- a/pnpm/crates/config/src/store_path.rs
+++ b/pnpm/crates/config/src/store_path.rs
@@ -55,13 +55,6 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-// Windows' standard canonicalizer returns `\\?\` verbatim paths;
-// `dunce` resolves the path without leaking that prefix to CLI output.
-#[cfg(windows)]
-use dunce::canonicalize;
-#[cfg(not(windows))]
-use std::fs::canonicalize;
-
 /// Resolve where to place the default pnpm store given the `SmartDefault`
 /// home-based path and the project root.
 ///
@@ -72,7 +65,9 @@ pub fn resolve_store_dir<Sys: LinkProbe>(
     pnpm_home_dir: &Path,
     pkg_root: &Path,
 ) -> PathBuf {
-    let Ok(pkg_root) = canonicalize(pkg_root) else {
+    // `dunce` keeps the Windows result free of the `\\?\` verbatim prefix,
+    // which would otherwise leak into the user-visible store path.
+    let Ok(pkg_root) = dunce::canonicalize(pkg_root) else {
         return home_default;
     };
 

--- a/pnpm/crates/config/src/store_path.rs
+++ b/pnpm/crates/config/src/store_path.rs
@@ -55,6 +55,11 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
+#[cfg(windows)]
+use dunce::canonicalize;
+#[cfg(not(windows))]
+use std::fs::canonicalize;
+
 /// Resolve where to place the default pnpm store given the `SmartDefault`
 /// home-based path and the project root.
 ///
@@ -65,7 +70,7 @@ pub fn resolve_store_dir<Sys: LinkProbe>(
     pnpm_home_dir: &Path,
     pkg_root: &Path,
 ) -> PathBuf {
-    let Ok(pkg_root) = fs::canonicalize(pkg_root) else {
+    let Ok(pkg_root) = canonicalize(pkg_root) else {
         return home_default;
     };
 

--- a/pnpm/crates/config/src/store_path/tests.rs
+++ b/pnpm/crates/config/src/store_path/tests.rs
@@ -11,7 +11,7 @@ use tempfile::tempdir;
 // like `/Volumes/src/...`). On Windows, every consumer is excluded, so
 // gate the macro and its imports to keep clippy's `dead_code`/`unused`
 // lints happy under `-D warnings`.
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use crate::api::LinkProbe;
 #[cfg(unix)]
 use std::sync::Mutex;
@@ -69,6 +69,33 @@ fn resolve_store_dir_same_volume_uses_home_default() {
 
     let resolved = resolve_store_dir::<Host>(home_default.clone(), &pnpm_home, &pkg_root);
     assert_eq!(resolved, home_default);
+}
+
+#[test]
+#[cfg(windows)]
+fn resolve_store_dir_cross_volume_has_no_verbatim_prefix() {
+    struct RootProbe;
+    impl LinkProbe for RootProbe {
+        fn can_link_between_dirs(from_dir: &Path, to_dir: &Path) -> bool {
+            to_dir == filesystem_root(from_dir)
+        }
+    }
+
+    let tmp = tempdir().expect("create tempdir");
+    let pkg_root = tmp.path().join("project");
+    fs::create_dir_all(&pkg_root).expect("create project dir");
+    let project_drive = filesystem_root(&pkg_root);
+    let pnpm_home = if project_drive.to_string_lossy().eq_ignore_ascii_case(r"C:\") {
+        PathBuf::from(r"D:\pnpm-home")
+    } else {
+        PathBuf::from(r"C:\pnpm-home")
+    };
+    let home_default = pnpm_home.join("store");
+
+    let resolved = resolve_store_dir::<RootProbe>(home_default, &pnpm_home, &pkg_root);
+    let resolved_display = resolved.display().to_string();
+    eprintln!("RESOLVED STORE DIR:\n{resolved_display}\n");
+    assert!(!resolved_display.starts_with(r"\\?\"));
 }
 
 // Per-test [`LinkProbe`] fake whose `can_link_between_dirs` accepts a `to_dir`

--- a/pnpm/crates/config/src/store_path/tests.rs
+++ b/pnpm/crates/config/src/store_path/tests.rs
@@ -70,7 +70,7 @@ fn resolve_store_dir_same_volume_uses_home_default() {
 
 #[test]
 #[cfg_attr(not(windows), ignore = "requires Windows path canonicalization")]
-fn resolve_store_dir_cross_volume_has_no_verbatim_prefix() {
+fn resolve_store_dir_cross_volume_uses_project_drive_without_verbatim_prefix() {
     struct RootProbe;
     impl LinkProbe for RootProbe {
         fn can_link_between_dirs(from_dir: &Path, to_dir: &Path) -> bool {
@@ -88,11 +88,15 @@ fn resolve_store_dir_cross_volume_has_no_verbatim_prefix() {
         PathBuf::from(r"C:\pnpm-home")
     };
     let home_default = pnpm_home.join("store");
+    let expected = project_drive.join(".pnpm-store");
 
     let resolved = resolve_store_dir::<RootProbe>(home_default, &pnpm_home, &pkg_root);
+    assert_eq!(resolved, expected);
     let resolved_display = resolved.display().to_string();
-    eprintln!("RESOLVED STORE DIR:\n{resolved_display}\n");
-    assert!(!resolved_display.starts_with(r"\\?\"));
+    assert!(
+        !resolved_display.starts_with(r"\\?\"),
+        "resolved store dir has a verbatim prefix: {resolved_display}",
+    );
 }
 
 // Per-test [`LinkProbe`] fake whose `can_link_between_dirs` accepts a `to_dir`

--- a/pnpm/crates/config/src/store_path/tests.rs
+++ b/pnpm/crates/config/src/store_path/tests.rs
@@ -6,12 +6,9 @@ use std::{
 };
 use tempfile::tempdir;
 
-// The `prefix_probe!` fake below is only used by tests gated on
-// `cfg(unix)` (the cross-volume scenarios construct absolute Unix paths
-// like `/Volumes/src/...`). On Windows, every consumer is excluded, so
-// gate the macro and its imports to keep clippy's `dead_code`/`unused`
-// lints happy under `-D warnings`.
-#[cfg(any(unix, windows))]
+// `LinkProbe` is shared by the Windows regression test and the Unix-only
+// `prefix_probe!` fake below. Only the fake's allowlist needs `Mutex`, so
+// that import remains Unix-gated.
 use crate::api::LinkProbe;
 #[cfg(unix)]
 use std::sync::Mutex;
@@ -72,7 +69,7 @@ fn resolve_store_dir_same_volume_uses_home_default() {
 }
 
 #[test]
-#[cfg(windows)]
+#[cfg_attr(not(windows), ignore = "requires Windows path canonicalization")]
 fn resolve_store_dir_cross_volume_has_no_verbatim_prefix() {
     struct RootProbe;
     impl LinkProbe for RootProbe {


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Closes pnpm/pnpm#13987.

On Windows, `std::fs::canonicalize` returns extended-length paths with a `\\?\` prefix. When the project and pnpm home are on different drives, `resolve_store_dir` derives the store location from that canonicalized project path, causing `pnpm store path` to expose the prefix. GitHub Actions cache and glob handling then interprets `?` as a wildcard and rejects the path.

Use `dunce::canonicalize` on Windows to preserve canonicalization without exposing the verbatim prefix. Other platforms continue using `std::fs::canonicalize`. A Windows-gated `dunce` dependency and regression coverage are included.

This is specific to the Rust `pnpm/` implementation's store-placement heuristic. The TypeScript CLI has no corresponding logic and requires no change.

Verification:

 - `cargo test --locked -p pnpm-config`: 499 passed, 2 ignored
 - Rust formatting and clippy checks passed
 - Repository pre-push checks passed

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
On Windows, std::fs::canonicalize returns extended-length paths with a
\\?\ prefix. resolve_store_dir canonicalizes the project root before
selecting a same-volume store, so the prefix propagated into the
cross-drive store location and was printed by pnpm store path. Consumers
such as GitHub Actions cache then interpreted the question mark as a glob
and rejected the path.

Use dunce::canonicalize on Windows to resolve the project path without
leaking the verbatim prefix. Keep std::fs::canonicalize on other
platforms and scope the new dependency to Windows.

Add a regression test that uses a LinkProbe implementation to model
cross-drive store placement deterministically without requiring a second
physical volume. The test asserts that the resulting store path has no
verbatim prefix and is compiled but ignored on non-Windows platforms.

No TypeScript CLI change is needed because this store-placement heuristic
exists only in the Rust implementation.

Closes pnpm/pnpm#13987.
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] This issue is specific to the Rust store-placement heuristic, the TypeScript CLI has no corresponding logic and requires no change.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---

All annotations and documents are written and reviewed by the agent (Codex, GPT-5.6-Sol)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789626890&installation_model_id=426870&pr_number=13990&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13990&signature=0d71618c1ecaa5972c9c2f17edaefb02273b6fb5597762b4b78959d4d5810271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows package store path resolution when the project and package store are located on different drives.
  * Removed unnecessary `\\?\` verbatim prefixes from resolved Windows store paths.
  * Improved cross-platform path handling for more consistent results.
  * Ensured commands return clean, standard Windows paths that work reliably across drive volumes.
  * Added safeguards for cross-volume scenarios to prevent malformed or unusable store paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->