### PR TITLE
chore(deny): stop the h2 advisory ignore from covering more than it should

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -64,13 +64,17 @@ ignore = [
   # Unbounded queueing of empty HTTP/2 DATA frames (low-severity DoS). Only the
   # `h2` 0.3 line is left unpatched here: pnpr's own HTTP/2 server surface runs
   # on axum 0.8 -> hyper 1.x, which is on the fixed h2 0.4.16. The 0.3 copy is
-  # reached solely through libsql's gRPC client stack
-  # (libsql -> tonic 0.11 -> axum 0.6 -> hyper 0.14), which pnpr uses to talk
-  # out to the operator-configured libsql/sqld backend, so the frames it queues
+  # reached solely through libsql's gRPC client stack, whose `tonic` 0.11 and
+  # `hyper` 0.14 both depend on it directly. pnpr uses that client to talk out
+  # to the operator-configured libsql/sqld backend, so the frames it queues
   # come from that backend rather than from untrusted registry clients. The fix
   # ships only in h2 0.4.16 and 0.3.27 is the final 0.3 release, so no upgrade
   # is reachable while the newest stable libsql (0.9.30) is pinned to tonic
   # 0.11. Revisit when libsql 0.10 leaves prerelease.
+  #
+  # cargo-deny scopes an ignore to an advisory id, never to a version, so this
+  # entry would also silence the advisory on the 0.4 line. The `h2` bans below
+  # hold that line instead.
   { id = "RUSTSEC-2026-0258", reason = "Temporary risk acceptance: the unpatched h2 0.3 copy is reached only by libsql's outbound gRPC client to the operator-configured backend; pnpr's own server is on the patched h2 0.4.16, and no stable libsql release moves off tonic 0.11." },
 ]
 
@@ -131,7 +135,16 @@ highlight = "all"
 workspace-default-features = "allow"
 external-default-features = "allow"
 allow = []
-deny = []
+deny = [
+  # RUSTSEC-2026-0258 is ignored above, and cargo-deny can only ignore an
+  # advisory for the whole workspace. These two bans keep that ignore from
+  # covering more than the one copy it was accepted for: a vulnerable `h2` on
+  # the 0.4 line is refused outright, and the unpatched 0.3 line stays reachable
+  # only from libsql's gRPC stack, whose `tonic` and `hyper` are its sole direct
+  # dependents. Drop both once libsql moves off tonic 0.11 and the ignore goes.
+  { name = "h2", version = ">=0.4, <0.4.16" },
+  { name = "h2", version = "<0.4", wrappers = ["hyper", "tonic"] },
+]
 skip = []
 skip-tree = []
 


### PR DESCRIPTION
## Summary

Follow-up to the `h2` security bump that landed in pnpm/pnpm#13971, addressing a review comment posted there after the merge.

That PR accepts RUSTSEC-2026-0258 for one copy of `h2`: the 0.3.27 pulled in by libsql's gRPC stack, which has no patched release (the advisory patches only `>= 0.4.16`, and 0.3.27 is the final 0.3 release). cargo-deny scopes an ignore to an advisory id and never to a version, so that entry also silences the advisory on the 0.4 line — a downgrade below the patched 0.4.16 would sail through the check.

Two `bans.deny` entries hold that line instead of a hand-rolled dependency-tree script:

- `h2 >=0.4, <0.4.16` is refused outright, so the accepted exception cannot spread to a regressed 0.4.
- `h2 <0.4` is allowed only behind `wrappers = ["hyper", "tonic"]`, its current direct dependents, so a new crate reaching for the unpatched line fails rather than inheriting the exception.

Both were negative-tested by widening them until they fire (`h2 = 0.4.16 is explicitly banned` and `h2 = 0.3.27 is explicitly banned` respectively), so neither guard is decorative. `cargo deny check` is green as committed.

This also corrects the dependency path in the ignore's rationale. It named axum on the chain to `h2`, but neither axum 0.6 nor axum 0.8 depends on `h2` at all — the direct dependents of `h2` 0.3.27 are `tonic` 0.11.0 and `hyper` 0.14.32.

## Squash Commit Body

```text
RUSTSEC-2026-0258 is accepted for one copy of h2: the 0.3.27 that
libsql's gRPC stack pulls in, which has no patched release. cargo-deny
scopes an ignore to an advisory id and never to a version, so that entry
also silences the advisory on the 0.4 line, where a downgrade below the
patched 0.4.16 would pass the check unnoticed.

Two bans hold that line: a vulnerable 0.4 is refused outright, and the
0.3 line is allowed only behind its current direct dependents, so a new
crate reaching for it fails instead of inheriting the exception. Both
were negative-tested by widening them until they fire.

Also corrects the dependency path in the ignore's rationale. It named
axum on the chain to h2, but neither axum 0.6 nor 0.8 depends on h2 at
all; the direct dependents of h2 0.3.27 are tonic 0.11 and hyper 0.14.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  *(`deny.toml` is workspace-wide tooling config; there is no per-stack equivalent to port.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. *(Not needed — CI configuration only, no published package changes.)*
- [x] Added or updated tests.
  *(Both bans were negative-tested against the real lockfile; `deny.toml` has no test harness.)*

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13992"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789637898&installation_model_id=426870&pr_number=13992&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13992&signature=3d1ed6a10941c07038a2d4972edfb7bdbea41c6c84b8c0a9221b8d36b62b92fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency security policies for the `h2` package.
  * Added safeguards against vulnerable `h2` versions while preserving approved compatibility paths.
  * Clarified workspace-wide handling of the related security advisory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->