### PR TITLE
fix(cli): support --config.ignore-scripts override

### DIFF
--- a/.changeset/pacquet-config-ignore-scripts.md
+++ b/.changeset/pacquet-config-ignore-scripts.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `--config.ignore-scripts=true` not being honored by CLI commands such as `pnpm pack` [#13986](https://github.com/pnpm/pnpm/issues/13986).

--- a/cspell.json
+++ b/cspell.json
@@ -44,6 +44,7 @@
     "canva",
     "cerbos",
     "certfile",
+    "chcp",
     "chmods",
     "clonedeep",
     "clonefile",

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -234,8 +234,12 @@ impl ConfigOverrides {
         if let Some(value) = self.force_legacy_deploy {
             config.force_legacy_deploy = value;
         }
+        // `pnpm config get ignore-scripts` answers from the explicitly-set
+        // settings, so a CLI-set value has to be recorded there to be
+        // reported as set while it suppresses the scripts.
         if let Some(value) = self.ignore_scripts {
             config.ignore_scripts = value;
+            config.explicit_settings.insert("ignoreScripts".to_string(), value.into());
         }
         if let Some(value) = self.inject_workspace_packages {
             config.inject_workspace_packages = value;

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -84,7 +84,6 @@ pub struct ConfigOverrides {
     registries: BTreeMap<String, String>,
     deploy_all_files: Option<bool>,
     force_legacy_deploy: Option<bool>,
-    /// `--config.ignore-scripts=<bool>` CLI override.
     ignore_scripts: Option<bool>,
     inject_workspace_packages: Option<bool>,
     minimum_release_age: Option<u64>,
@@ -235,7 +234,6 @@ impl ConfigOverrides {
         if let Some(value) = self.force_legacy_deploy {
             config.force_legacy_deploy = value;
         }
-        // Override ignore_scripts from --config.ignore-scripts=<bool>
         if let Some(value) = self.ignore_scripts {
             config.ignore_scripts = value;
         }

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -84,6 +84,8 @@ pub struct ConfigOverrides {
     registries: BTreeMap<String, String>,
     deploy_all_files: Option<bool>,
     force_legacy_deploy: Option<bool>,
+    /// `--config.ignore-scripts=<bool>` CLI override.
+    ignore_scripts: Option<bool>,
     inject_workspace_packages: Option<bool>,
     minimum_release_age: Option<u64>,
     minimum_release_age_exclude: Option<Vec<String>>,
@@ -157,6 +159,10 @@ impl ConfigOverrides {
             self.force_legacy_deploy = parse_bool(value);
             return;
         }
+        if key == "ignore-scripts" {
+            self.ignore_scripts = parse_bool(value);
+            return;
+        }
         if key == "inject-workspace-packages" {
             self.inject_workspace_packages = parse_bool(value);
             return;
@@ -228,6 +234,10 @@ impl ConfigOverrides {
         }
         if let Some(value) = self.force_legacy_deploy {
             config.force_legacy_deploy = value;
+        }
+        // Override ignore_scripts from --config.ignore-scripts=<bool>
+        if let Some(value) = self.ignore_scripts {
+            config.ignore_scripts = value;
         }
         if let Some(value) = self.inject_workspace_packages {
             config.inject_workspace_packages = value;

--- a/pnpm/crates/cli/src/config_overrides/tests.rs
+++ b/pnpm/crates/cli/src/config_overrides/tests.rs
@@ -256,6 +256,23 @@ fn node_linker_override_rederives_prefer_symlinked_executables() {
 }
 
 #[test]
+fn extract_applies_ignore_scripts_override() {
+    let (overrides, remaining) =
+        ConfigOverrides::extract(argv(["pacquet", "--config.ignore-scripts=true", "pack"]));
+    assert_eq!(remaining, argv(["pacquet", "pack"]));
+    let mut config = Config::default();
+    assert!(!config.ignore_scripts);
+    overrides.apply(&mut config);
+    assert!(config.ignore_scripts);
+
+    let (overrides, _) =
+        ConfigOverrides::extract(argv(["pacquet", "--config.ignore-scripts=false", "pack"]));
+    let mut config = Config { ignore_scripts: true, ..Config::default() };
+    overrides.apply(&mut config);
+    assert!(!config.ignore_scripts);
+}
+
+#[test]
 fn config_tokens_after_external_command_stay_in_argv() {
     let (overrides, remaining) = ConfigOverrides::extract(argv([
         "pacquet",

--- a/pnpm/crates/cli/src/config_overrides/tests.rs
+++ b/pnpm/crates/cli/src/config_overrides/tests.rs
@@ -264,12 +264,17 @@ fn extract_applies_ignore_scripts_override() {
     assert!(!config.ignore_scripts);
     overrides.apply(&mut config);
     assert!(config.ignore_scripts);
+    assert_eq!(config.explicit_settings.get("ignoreScripts"), Some(&serde_json::Value::Bool(true)));
 
     let (overrides, _) =
         ConfigOverrides::extract(argv(["pacquet", "--config.ignore-scripts=false", "pack"]));
     let mut config = Config { ignore_scripts: true, ..Config::default() };
     overrides.apply(&mut config);
     assert!(!config.ignore_scripts);
+    assert_eq!(
+        config.explicit_settings.get("ignoreScripts"),
+        Some(&serde_json::Value::Bool(false)),
+    );
 }
 
 #[test]

--- a/pnpm/crates/cli/tests/suite/pack.rs
+++ b/pnpm/crates/cli/tests/suite/pack.rs
@@ -201,7 +201,9 @@ fn config_ignore_scripts_override_suppresses_prepack() {
         .assert()
         .success();
     assert!(marker.exists(), "prepack must run when nothing suppresses it");
+    let tarball = out.join("pkg-1.0.0.tgz");
     fs::remove_file(&marker).expect("remove marker");
+    fs::remove_file(&tarball).expect("remove the first tarball");
 
     let CommandTempCwd { pacquet: ignoring, root: ignoring_root, .. } = CommandTempCwd::init();
     ignoring
@@ -213,7 +215,7 @@ fn config_ignore_scripts_override_suppresses_prepack() {
         .assert()
         .success();
     assert!(!marker.exists(), "--config.ignore-scripts=true must suppress prepack");
-    assert!(out.join("pkg-1.0.0.tgz").exists(), "the tarball must still be packed");
+    assert!(tarball.exists(), "the tarball must still be packed");
 
     drop((root, ignoring_root));
 }

--- a/pnpm/crates/cli/tests/suite/pack.rs
+++ b/pnpm/crates/cli/tests/suite/pack.rs
@@ -1,5 +1,6 @@
-//! Single-project `pack` integration tests, focused on the
-//! `beforePacking` pnpmfile hook: the published manifest a package is
+//! Single-project `pack` integration tests, covering the `beforePacking`
+//! pnpmfile hook and the settings that suppress the pack lifecycle
+//! scripts. For the hook: the published manifest a package is
 //! packed with must reflect what the hook returns, exactly as pnpm's
 //! `pnpm pack` / `pnpm publish` apply it. This is the mechanism the pnpm
 //! CLI's own release relies on to strip its bundled dependency fields
@@ -168,6 +169,53 @@ fn recursive_pack_applies_before_packing_hook_to_every_project() {
     }
 
     drop(root);
+}
+
+/// `--config.ignore-scripts=true` suppresses the pack lifecycle scripts
+/// just like the bare `--ignore-scripts` flag does for the commands that
+/// declare it. `pack` has no such flag, so the dotted override is the only
+/// way to skip its `prepack` (pnpm/pnpm#13986).
+#[test]
+fn config_ignore_scripts_override_suppresses_prepack() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "name": "pkg",
+            "version": "1.0.0",
+            "scripts": {
+                "prepack": r#"node -e "require('fs').writeFileSync('prepack-ran.txt','ran')""#,
+            },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    let out = workspace.join("tarballs");
+    fs::create_dir_all(&out).expect("create out dir");
+    let marker = workspace.join("prepack-ran.txt");
+
+    pacquet
+        .with_arg("pack")
+        .with_arg("--pack-destination")
+        .with_arg(out.to_str().expect("utf8 out dir"))
+        .assert()
+        .success();
+    assert!(marker.exists(), "prepack must run when nothing suppresses it");
+    fs::remove_file(&marker).expect("remove marker");
+
+    let CommandTempCwd { pacquet: ignoring, root: ignoring_root, .. } = CommandTempCwd::init();
+    ignoring
+        .with_current_dir(&workspace)
+        .with_arg("pack")
+        .with_arg("--config.ignore-scripts=true")
+        .with_arg("--pack-destination")
+        .with_arg(out.to_str().expect("utf8 out dir"))
+        .assert()
+        .success();
+    assert!(!marker.exists(), "--config.ignore-scripts=true must suppress prepack");
+    assert!(out.join("pkg-1.0.0.tgz").exists(), "the tarball must still be packed");
+
+    drop((root, ignoring_root));
 }
 
 /// Extract `package/package.json` from a packed tarball.


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

In `pacquet` (the Rust pnpm CLI), dotted config overrides passed via `--config.<key>=<value>` are extracted from `argv` and recognized by `ConfigOverrides::set`. Previously, `ignore-scripts` was missing from `ConfigOverrides`, so `--config.ignore-scripts=true` was silently dropped, causing commands like `pnpm pack` to run lifecycle scripts (`prepack`) despite the override flag.

This PR adds `ignore_scripts` handling to `ConfigOverrides::set` and `ConfigOverrides::apply`, allowing `--config.ignore-scripts=true` to properly update `config.ignore_scripts`.

Fixes https://github.com/pnpm/pnpm/issues/13986

## Squash Commit Body

```text
Recognize ignore-scripts in ConfigOverrides::set and apply it to config.ignore_scripts in ConfigOverrides::apply.

Previously, ConfigOverrides::set only recognized a specific allowlist of dotted config keys. Unrecognized tokens like --config.ignore-scripts=true were silently dropped, causing lifecycle scripts (e.g., prepack during pnpm pack) to execute even when ignore-scripts was explicitly set via CLI overrides.

Fixes https://github.com/pnpm/pnpm/issues/13986
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789639377&installation_model_id=426870&pr_number=13993&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13993&signature=3f8ea31c206dbab3c67ea9df36305a672c7a442b340604c254ea6b4354b8a70c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring script execution from the command line with `--config.ignore-scripts=true` or `false`.
  * Packaging workflows now honor this setting, allowing packages to be created without running prepack scripts while still producing the tarball.

* **Bug Fixes**
  * Fixed command-line configuration handling so `ignore-scripts` overrides are correctly recognized and applied, including when existing configuration values are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->