### PR TITLE
fix(update) transitive dependency update with pinned version

### DIFF
--- a/pnpm/crates/cli/tests/suite/update.rs
+++ b/pnpm/crates/cli/tests/suite/update.rs
@@ -341,48 +341,6 @@ fn update_transitive_glob_mixed_with_direct_selector() {
     drop((root, anchor));
 }
 
-/// `pacquet update <pkg>@<version>` on a package that is only present
-/// as a transitive dependency ignores the version part: there is no
-/// manifest entry to write it into, and an update resolves the target
-/// the way a fresh install would. The version part triggers a warning
-/// recommending a `pnpm.overrides` entry — the mechanism that does pin
-/// transitive dependencies.
-#[test]
-fn update_transitive_ignores_requested_version() {
-    let (root, workspace, anchor) = setup();
-
-    // Pin the transitive dep-of-pkg-with-1-dep at 100.0.0 (via a direct
-    // exact entry), then drop it to a pure transitive of pkg-with-1-dep.
-    write_manifest(&workspace, &format!(r#"{{ "{PARENT}": "100.0.0", "{DEP}": "100.0.0" }}"#));
-    pacquet(&workspace, ["install"]).assert().success();
-    eprintln!("virtual store contents: {:?}", list_virtual_store(&workspace));
-    assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.0.0"));
-
-    write_manifest(&workspace, &format!(r#"{{ "{PARENT}": "100.0.0" }}"#));
-
-    // The update requests 100.0.0, but the version part of a
-    // transitive-only selector is ignored: the target re-resolves to the
-    // highest version in pkg-with-1-dep's ^100.0.0 range (100.1.0),
-    // exactly as a fresh install with the target's lockfile entries
-    // deleted would.
-    pacquet(&workspace, ["update", &format!("{DEP}@100.0.0")]).assert().success();
-
-    eprintln!("virtual store contents: {:?}", list_virtual_store(&workspace));
-    // Only presence is asserted: the update does not prune the previous
-    // version's now-orphaned virtual-store directory.
-    assert!(
-        virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.1.0"),
-        "the target should re-resolve to highest-in-range, like a fresh install",
-    );
-    let lock = fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read pnpm-lock.yaml");
-    assert!(
-        !lock.contains("dep-of-pkg-with-1-dep@100.0.0"),
-        "the ignored requested version must not pin the target in the lockfile",
-    );
-
-    drop((root, anchor));
-}
-
 /// `pacquet update --latest` ignores the manifest range, bumps to the
 /// `latest` dist-tag, and rewrites `package.json`.
 #[test]

--- a/pnpm/crates/cli/tests/suite/update_recursive.rs
+++ b/pnpm/crates/cli/tests/suite/update_recursive.rs
@@ -18,6 +18,7 @@ use tempfile::TempDir;
 /// Published at 100.0.0, 100.1.0, and 101.0.0.
 const DEP: &str = "@pnpm.e2e/dep-of-pkg-with-1-dep";
 const FOO: &str = "@pnpm.e2e/foo";
+const OPTIONAL_PARENT: &str = "@pnpm.e2e/pkg-with-good-optional";
 
 fn setup() -> (TempDir, std::path::PathBuf, AddMockedRegistry) {
     let CommandTempCwd { root, workspace, npmrc_info, .. } =
@@ -95,6 +96,10 @@ fn installed_version(project_dir: &Path, name: &str) -> Option<String> {
     let contents = fs::read_to_string(manifest_path).ok()?;
     let value: Value = serde_json::from_str(&contents).ok()?;
     value["version"].as_str().map(str::to_string)
+}
+
+fn wanted_lockfile_text(workspace: &Path) -> String {
+    fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read pnpm-lock.yaml")
 }
 
 /// Ports `recursive update`: a versioned selector reaches every project
@@ -208,6 +213,69 @@ fn recursive_update_keeps_an_aliased_workspace_dependency() {
         dep_spec(&project_1, "pkg").as_deref(),
         Some("workspace:project-2@^"),
         "the aliased workspace specifier should survive the update",
+    );
+
+    drop((root, anchor));
+}
+
+/// Ports the recursive pinned-transitive regression: an exact transitive
+/// selector should seed preferred versions strongly enough to beat a stale
+/// lockfile pin, while keeping unrelated packages untouched.
+#[test]
+fn recursive_update_pinned_transitive_prefers_the_requested_version() {
+    let (root, workspace, anchor) = setup();
+
+    write_workspace(
+        &workspace,
+        &[(
+            "project-1",
+            json!({ "name": "project-1", "version": "1.0.0", "dependencies": {
+                FOO: "1.0.0",
+                OPTIONAL_PARENT: "1.0.0"
+            }}),
+        )],
+    );
+    pacquet(&workspace, ["install"]).assert().success();
+
+    let mut lockfile = wanted_lockfile_text(&workspace);
+    assert!(
+        lockfile.contains(DEP),
+        "expected the transitive dependency to be present after install:\n{lockfile}",
+    );
+
+    pacquet(
+        &workspace,
+        [
+            "-r",
+            "update",
+            "--lockfile-only",
+            "--no-save",
+            &format!("{DEP}@100.1.0"),
+        ],
+    )
+    .assert()
+    .success();
+
+    lockfile = wanted_lockfile_text(&workspace);
+    assert!(
+        lockfile.contains(&format!("{DEP}@100.1.0")),
+        "the requested transitive version should be selected:\n{lockfile}",
+    );
+    assert!(
+        !lockfile.contains(&format!("{DEP}@100.0.0")),
+        "the stale transitive pin should be replaced:\n{lockfile}",
+    );
+    assert!(
+        !lockfile.contains(&format!("{DEP}@101.0.0")),
+        "an unrequested newer transitive version should not be chosen:\n{lockfile}",
+    );
+    assert!(
+        lockfile.contains(&format!("{FOO}@1.0.0")),
+        "unrelated dependency should keep its existing lockfile entry:\n{lockfile}",
+    );
+    assert!(
+        !lockfile.contains(&format!("{FOO}@2.0.0")),
+        "unrelated dependency should not be updated by the targeted selector:\n{lockfile}",
     );
 
     drop((root, anchor));

--- a/pnpm/crates/cli/tests/suite/update_recursive.rs
+++ b/pnpm/crates/cli/tests/suite/update_recursive.rs
@@ -245,13 +245,7 @@ fn recursive_update_pinned_transitive_prefers_the_requested_version() {
 
     pacquet(
         &workspace,
-        [
-            "-r",
-            "update",
-            "--lockfile-only",
-            "--no-save",
-            &format!("{DEP}@100.1.0"),
-        ],
+        ["-r", "update", "--lockfile-only", "--no-save", &format!("{DEP}@100.1.0")],
     )
     .assert()
     .success();

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -84,9 +84,12 @@ use std::{
 /// bare-name selectors (`foo`, `@scope/bar-*`) with `depth > 0` and no
 /// `--latest` match every package of that name **at any depth** (the
 /// match is applied against the lockfile's package names); selectors
-/// carrying a version (`foo@2`) or any selector under `--latest` match
-/// only direct dependencies, and the version (or fetched latest) is
-/// written into the manifest before resolving.
+/// carrying a version (`foo@2`) still rewrite only direct dependencies,
+/// but when no direct dependency matches and `depth > 0`, an exact-name
+/// selector also seeds that transitive package's preferred version in the
+/// resolver. Any selector under `--latest` matches only direct
+/// dependencies, and the fetched latest is written into the manifest
+/// before resolving.
 #[must_use]
 pub struct Update<'a> {
     pub tarball_mem_cache: Arc<MemCache>,
@@ -811,11 +814,21 @@ async fn prepare_manifest<Reporter: self::Reporter>(
             }
             for selector in &selectors {
                 let Some(version) = selector.version.as_deref() else { continue };
+                if selector_has_exact_name_pattern(&selector.pattern)
+                    && drop_names.contains(&selector.pattern)
+                {
+                    crate::install_with_fresh_lockfile::prefer_requested_version(
+                        &mut preferred_versions_override,
+                        &selector.pattern,
+                        version,
+                    );
+                    continue;
+                }
                 tracing::warn!(
                     target: "pnpm_package_manager::update",
                     pattern = selector.pattern,
                     version,
-                    r#""{}" is not a direct dependency, so the requested version "{version}" is ignored — "{}" is updated to what a fresh install would resolve. To force a version of a transitive dependency, add an override scoped to the range its dependents declare to pnpm-workspace.yaml, e.g.: overrides: {{ "{}@<declared range>": "{version}" }}"#,
+                    r#""{}" is not a direct dependency, so the requested version "{version}" is ignored — "{}" is updated to what a fresh install would resolve. To force non-exact or globbed transitive selectors to a version, add an override scoped to the range its dependents declare to pnpm-workspace.yaml, e.g.: overrides: {{ "{}@<declared range>": "{version}" }}"#,
                     selector.pattern,
                     selector.pattern,
                     selector.pattern,
@@ -1317,6 +1330,13 @@ fn judge_against_kept_range(requested: &str, kept: &str) -> KeptRangeVerdict {
 /// selector's version is applied to the right dep).
 fn matcher_one(pattern: &str) -> pnpm_config::matcher::Matcher {
     create_matcher(std::slice::from_ref(&pattern.to_string()))
+}
+
+/// `update <name>@<version>` can seed transitive preferred versions only
+/// for exact package-name selectors. Negated and globbed selectors may map
+/// to many names, and each may need a different target.
+fn selector_has_exact_name_pattern(pattern: &str) -> bool {
+    !pattern.starts_with('!') && !pattern.contains('*')
 }
 
 /// The workspace catalogs and the directories needed to read the existing

--- a/pnpm11/installing/commands/src/installDeps.ts
+++ b/pnpm11/installing/commands/src/installDeps.ts
@@ -22,7 +22,7 @@ import {
 } from '@pnpm/installing.deps-installer'
 import { writeWantedLockfile } from '@pnpm/lockfile.fs'
 import type { LockfileObject } from '@pnpm/lockfile.types'
-import { globalInfo, globalWarn, logger } from '@pnpm/logger'
+import { globalInfo, logger } from '@pnpm/logger'
 import { applyRuntimeOnFailOverride, filterDependenciesByType } from '@pnpm/pkg-manifest.utils'
 import { getRangeSpecStyle } from '@pnpm/pkg-manifest.utils'
 import type { PreferredVersions, VersionSelectors } from '@pnpm/resolving.resolver-base'
@@ -48,9 +48,9 @@ import { setupPolicyHandlers } from './policyHandlers.js'
 import {
   type CommandFullName,
   createMatcher,
+  createPreferredVersionsFromPinnedUpdateSpecs,
   makeIgnorePatterns,
   matchDependencies,
-  parseUpdateParam,
   recursive,
   type RecursiveOptions,
   type UpdateDepsMatcher,
@@ -379,8 +379,8 @@ export async function installDeps (
     updateMatch = null
     updateMatching = createVulnerabilityUpdateMatching(opts.packageVulnerabilityAudit)
   }
+  installOpts.preferredVersions = createPreferredVersionsFromPinnedUpdateSpecs(params, installOpts.preferredVersions)
   if (updateMatch != null) {
-    const updateSpecs = params
     params = matchDependencies(updateMatch, manifest, includeDirect)
     if (params.length === 0) {
       if (opts.latest) return
@@ -392,7 +392,6 @@ export async function installDeps (
       // Don't update package.json in this case, and limit updates to only matching dependencies
       updatePackageManifest = false
       updateMatching = (pkgName: string) => updateMatch!(pkgName) != null
-      warnAboutIgnoredVersionsOfIndirectUpdateSpecs(updateSpecs)
     }
   }
 
@@ -594,25 +593,6 @@ function getVulnerabilityPenalty (severity: VulnerabilitySeverity): number {
     case 'critical': return -4000
       // Treat unrecognized severity as the lowest severity
     default: return -1100
-  }
-}
-
-/**
- * `pnpm update <dep>@<version>` where `<dep>` matches only transitive
- * dependencies has no manifest entry to write the version into, and an
- * update resolves the target the same way a fresh install would — which a
- * command-line version cannot influence. Tell the user the version part is
- * ignored, and that an override is the mechanism that does pin a
- * transitive dependency. The recommended override is scoped to the
- * dependents' declared range so it cannot violate any consumer's range;
- * the range itself is not known at this layer (it lives in the dependents'
- * manifests), hence the placeholder.
- */
-function warnAboutIgnoredVersionsOfIndirectUpdateSpecs (updateSpecs: string[]): void {
-  for (const spec of updateSpecs) {
-    const { pattern, versionSpec } = parseUpdateParam(spec)
-    if (versionSpec == null) continue
-    globalWarn(`"${pattern}" is not a direct dependency, so the requested version "${versionSpec}" is ignored — "${pattern}" is updated to what a fresh install would resolve. To force a version of a transitive dependency, add an override scoped to the range its dependents declare to pnpm-workspace.yaml, e.g.: overrides: { "${pattern}@<declared range>": "${versionSpec}" }`)
   }
 }
 

--- a/pnpm11/installing/commands/src/recursive.ts
+++ b/pnpm11/installing/commands/src/recursive.ts
@@ -34,8 +34,8 @@ import {
 import { logger } from '@pnpm/logger'
 import { filterDependenciesByType } from '@pnpm/pkg-manifest.utils'
 import { getRangeSpecStyle } from '@pnpm/pkg-manifest.utils'
-import type { PreferredVersions } from '@pnpm/resolving.resolver-base'
 import type { ResolutionVerifier } from '@pnpm/resolving.resolver-base'
+import { EXISTING_VERSION_SELECTOR_WEIGHT, type PreferredVersions } from '@pnpm/resolving.resolver-base'
 import { createStoreController, type CreateStoreControllerOptions } from '@pnpm/store.connection-manager'
 import type { StoreController } from '@pnpm/store.controller'
 import type {
@@ -55,6 +55,7 @@ import { updateWorkspaceManifest } from '@pnpm/workspace.workspace-manifest-writ
 import { isSubdir } from 'is-subdir'
 import pFilter from 'p-filter'
 import pLimit from 'p-limit'
+import getVersionSelectorType from 'version-selector-type'
 
 import { getSaveType } from './getSaveType.js'
 import { handleIgnoredBuilds } from './handleIgnoredBuilds.js'
@@ -212,7 +213,10 @@ export async function recursive (
     resolutionVerifiers: store.resolutionVerifiers,
     workspacePackages,
     handleResolutionPolicyViolations: policyHandlers?.handleResolutionPolicyViolations,
-  }) as InstallOptions
+  }) as InstallOptions & {
+    preferredVersions?: PreferredVersions
+    updateMatching?: UpdateMatchingFunction
+  }
 
   const result: RecursiveSummary = {}
 
@@ -245,6 +249,13 @@ export async function recursive (
   } else {
     updateMatch = null
   }
+  const updateMatching = opts.updateMatching ?? (
+    cmdFullName === 'update' && params.length > 0 && (opts.depth ?? Infinity) > 0 && !opts.latest
+      ? createUpdateMatching(params)
+      : undefined
+  )
+  installOpts.preferredVersions = createPreferredVersionsFromPinnedUpdateSpecs(params, installOpts.preferredVersions)
+  installOpts.updateMatching = updateMatching
   // For a workspace with shared lockfile
   if (opts.lockfileDir && ['add', 'install', 'remove', 'update', 'import'].includes(cmdFullName)) {
     let importers = getImporters(opts)
@@ -312,7 +323,7 @@ export async function recursive (
             rootDir,
             targetDependenciesField,
             update: opts.update,
-            updateMatching: opts.updateMatching,
+            updateMatching,
             updatePackageManifest: opts.updatePackageManifest,
             updateToLatest: opts.latest,
           } as MutatedProject)
@@ -324,7 +335,7 @@ export async function recursive (
             pruneDirectDependencies: opts.pruneDirectDependencies,
             rootDir,
             update: opts.update,
-            updateMatching: opts.updateMatching,
+            updateMatching,
             updatePackageManifest: opts.updatePackageManifest,
             updateToLatest: opts.latest,
           } as MutatedProject)
@@ -595,6 +606,39 @@ export function matchDependencies (
     matchedDeps.push(spec ? `${dep}@${spec}` : dep)
   }
   return matchedDeps
+}
+
+function createUpdateMatching (params: string[]): UpdateMatchingFunction {
+  const patterns = params.map((param) => parseUpdateParam(param).pattern)
+  const matcher = createMatcherWithIndex(patterns)
+  return (pkgName: string) => matcher(pkgName) !== -1
+}
+
+export function createPreferredVersionsFromPinnedUpdateSpecs (
+  params: string[],
+  preferredVersions?: PreferredVersions
+): PreferredVersions | undefined {
+  let mergedPreferredVersions = preferredVersions
+  for (const param of params) {
+    const { pattern, versionSpec } = parseUpdateParam(param)
+    if (
+      versionSpec == null ||
+      pattern[0] === '!' ||
+      pattern.includes('*') ||
+      getVersionSelectorType(versionSpec)?.type !== 'version'
+    ) continue
+
+    if (mergedPreferredVersions == null) {
+      mergedPreferredVersions = Object.create(null) as PreferredVersions
+    } else if (mergedPreferredVersions === preferredVersions) {
+      mergedPreferredVersions = Object.assign(Object.create(null), mergedPreferredVersions)
+    }
+    const nextPreferredVersions = mergedPreferredVersions as PreferredVersions
+    nextPreferredVersions[pattern] = Object.assign(Object.create(null), nextPreferredVersions[pattern], {
+      [versionSpec]: { selectorType: 'version', weight: EXISTING_VERSION_SELECTOR_WEIGHT + 1 },
+    })
+  }
+  return mergedPreferredVersions
 }
 
 export type UpdateDepsMatcher = (input: string) => string | null

--- a/pnpm11/installing/commands/src/update/index.ts
+++ b/pnpm11/installing/commands/src/update/index.ts
@@ -435,10 +435,8 @@ async function update (
   let updateMatching: UpdateMatchingFunction | undefined
   if (opts.packageVulnerabilityAudit != null) {
     updateMatching = createVulnerabilityUpdateMatching(opts.packageVulnerabilityAudit)
-  } else if (
-    (packageDependencies.length > 0) && packageDependencies.every(dep => !dep.substring(1).includes('@')) && depth > 0 && !opts.latest
-  ) {
-    updateMatching = createMatcher(packageDependencies)
+  } else if (packageDependencies.length > 0 && depth > 0 && !opts.latest) {
+    updateMatching = createMatcher(packageDependencies.map((dependency) => parseUpdateParam(dependency).pattern))
   }
   const generateChangeset = opts.changeset ?? opts.updateConfig?.changeset ?? false
   const changesetContext = generateChangeset ? await captureUpdateChangesetContext(opts) : undefined

--- a/pnpm11/installing/commands/test/update/recursive.ts
+++ b/pnpm11/installing/commands/test/update/recursive.ts
@@ -261,7 +261,7 @@ test('recursive update of a pinned transitive dependency updates only the target
   await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.0.0', distTag: 'latest' })
   await addDistTag({ package: '@pnpm.e2e/foo', version: '1.0.0', distTag: 'latest' })
 
-  const projects = preparePackages([
+  preparePackages([
     {
       name: 'project-1',
       version: '1.0.0',

--- a/pnpm11/installing/commands/test/update/recursive.ts
+++ b/pnpm11/installing/commands/test/update/recursive.ts
@@ -257,6 +257,63 @@ test('recursive update with pattern and name in project', async () => {
   expect(projects['project-2'].requireModule('@pnpm.e2e/print-version/package.json').version).toBe('2.0.0')
 })
 
+test('recursive update of a pinned transitive dependency updates only the targeted lockfile slice', async () => {
+  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.0.0', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/foo', version: '1.0.0', distTag: 'latest' })
+
+  const projects = preparePackages([
+    {
+      name: 'project-1',
+      version: '1.0.0',
+
+      dependencies: {
+        '@pnpm.e2e/foo': '1.0.0',
+        '@pnpm.e2e/pkg-with-good-optional': '1.0.0',
+      },
+    },
+  ])
+
+  const lockfileDir = process.cwd()
+  const { allProjects, selectedProjectsGraph } = await filterProjectsBySelectorObjectsFromDir(process.cwd(), [])
+  await install.handler({
+    ...DEFAULT_OPTS,
+    allProjects,
+    dir: process.cwd(),
+    lockfileDir,
+    recursive: true,
+    selectedProjectsGraph,
+    workspaceDir: process.cwd(),
+  })
+
+  let lockfile = readYamlFileSync<LockfileObject>('./pnpm-lock.yaml')
+
+  expect(lockfile.packages?.['@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0']).toBeTruthy()
+
+  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.1.0', distTag: 'next' })
+  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '101.0.0', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/foo', version: '2.0.0', distTag: 'latest' })
+
+  await update.handler({
+    ...DEFAULT_OPTS,
+    allProjects,
+    dir: process.cwd(),
+    lockfileDir,
+    lockfileOnly: true,
+    recursive: true,
+    save: false,
+    selectedProjectsGraph,
+    workspaceDir: process.cwd(),
+  }, ['@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0'])
+
+  lockfile = readYamlFileSync<LockfileObject>('./pnpm-lock.yaml')
+
+  expect(lockfile.packages?.['@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0']).toBeTruthy()
+  expect(lockfile.packages?.['@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0']).toBeFalsy()
+  expect(lockfile.packages?.['@pnpm.e2e/dep-of-pkg-with-1-dep@101.0.0']).toBeFalsy()
+  expect(lockfile.packages?.['@pnpm.e2e/foo@2.0.0']).toBeFalsy()
+  expect(lockfile.packages?.['@pnpm.e2e/foo@1.0.0']).toBeTruthy()
+})
+
 test('recursive update --latest foo should only update projects that have foo', async () => {
   await addDistTag({ package: '@pnpm.e2e/foo', version: '100.0.0', distTag: 'latest' })
   await addDistTag({ package: '@pnpm.e2e/bar', version: '100.0.0', distTag: 'latest' })

--- a/pnpm11/installing/commands/test/update/recursive.ts
+++ b/pnpm11/installing/commands/test/update/recursive.ts
@@ -287,7 +287,7 @@ test('recursive update of a pinned transitive dependency updates only the target
 
   let lockfile = readYamlFileSync<LockfileObject>('./pnpm-lock.yaml')
 
-  expect(lockfile.packages?.['@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0']).toBeTruthy()
+  expect(Object.keys(lockfile.packages ?? {})).toContain('@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0')
 
   await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.1.0', distTag: 'next' })
   await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '101.0.0', distTag: 'latest' })
@@ -307,11 +307,14 @@ test('recursive update of a pinned transitive dependency updates only the target
 
   lockfile = readYamlFileSync<LockfileObject>('./pnpm-lock.yaml')
 
-  expect(lockfile.packages?.['@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0']).toBeTruthy()
-  expect(lockfile.packages?.['@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0']).toBeFalsy()
-  expect(lockfile.packages?.['@pnpm.e2e/dep-of-pkg-with-1-dep@101.0.0']).toBeFalsy()
-  expect(lockfile.packages?.['@pnpm.e2e/foo@2.0.0']).toBeFalsy()
-  expect(lockfile.packages?.['@pnpm.e2e/foo@1.0.0']).toBeTruthy()
+  const packageKeys = Object.keys(lockfile.packages ?? {})
+
+  expect(packageKeys).toContain('@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0')
+  expect(packageKeys).not.toContain('@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0')
+  expect(packageKeys).not.toContain('@pnpm.e2e/dep-of-pkg-with-1-dep@101.0.0')
+
+  expect(packageKeys).toContain('@pnpm.e2e/foo@1.0.0')
+  expect(packageKeys).not.toContain('@pnpm.e2e/foo@2.0.0')
 })
 
 test('recursive update --latest foo should only update projects that have foo', async () => {

--- a/pnpm11/installing/commands/test/update/update.ts
+++ b/pnpm11/installing/commands/test/update/update.ts
@@ -139,7 +139,7 @@ test('update transitive dependency when mixed with a direct dependency selector'
   expect(lockfile.packages['@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0']).toBeTruthy()
 })
 
-test('update of a transitive dependency ignores the requested version and resolves like a fresh install', async () => {
+test('update of a transitive dependency applies the requested pinned version when dependents allow it', async () => {
   // @pnpm.e2e/pkg-with-good-optional depends on @pnpm.e2e/dep-of-pkg-with-1-dep via "*".
   await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.0.0', distTag: 'latest' })
 
@@ -156,10 +156,11 @@ test('update of a transitive dependency ignores the requested version and resolv
 
   expect(project.readLockfile().packages['@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0']).toBeTruthy()
 
-  // The update requests 100.1.0, but a transitive dependency has no manifest
-  // entry to carry a version, and updates resolve the target the way a fresh
-  // install would — so the requested version is ignored (with a warning
-  // recommending an override) and the "*" range resolves to the new latest.
+  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.1.0', distTag: 'next' })
+
+  // The update requests 100.1.0. A transitive target keeps its dependents'
+  // ranges, but the named exact version should still be preferred strongly
+  // enough to outrank the old lockfile pin when those ranges admit it.
   await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '101.0.0', distTag: 'latest' })
 
   await update.handler({
@@ -169,9 +170,49 @@ test('update of a transitive dependency ignores the requested version and resolv
 
   const lockfile = project.readLockfile()
 
-  expect(lockfile.packages['@pnpm.e2e/dep-of-pkg-with-1-dep@101.0.0']).toBeTruthy()
+  expect(lockfile.packages['@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0']).toBeTruthy()
   expect(lockfile.packages['@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0']).toBeFalsy()
-  expect(lockfile.packages['@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0']).toBeFalsy()
+  expect(lockfile.packages['@pnpm.e2e/dep-of-pkg-with-1-dep@101.0.0']).toBeFalsy()
+})
+
+test('update with a pinned direct dependency only updates the targeted package', async () => {
+  await addDistTag({ package: '@pnpm.e2e/foo', version: '1.0.0', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/peer-a', version: '1.0.0', distTag: 'latest' })
+
+  const project = prepare({
+    dependencies: {
+      '@pnpm.e2e/foo': '^1.0.0',
+      '@pnpm.e2e/peer-a': '^1.0.0',
+    },
+  })
+
+  await install.handler({
+    ...DEFAULT_OPTS,
+    dir: process.cwd(),
+  })
+
+  await addDistTag({ package: '@pnpm.e2e/foo', version: '1.0.1', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/peer-a', version: '1.0.1', distTag: 'latest' })
+
+  await update.handler({
+    ...DEFAULT_OPTS,
+    dir: process.cwd(),
+    lockfileOnly: true,
+    save: false,
+  }, ['@pnpm.e2e/foo@1.0.1'])
+
+  const lockfile = project.readLockfile()
+
+  expect(lockfile.importers['.'].dependencies?.['@pnpm.e2e/foo']).toStrictEqual({
+    specifier: '^1.0.0',
+    version: '1.0.1',
+  })
+  expect(lockfile.importers['.'].dependencies?.['@pnpm.e2e/peer-a']).toStrictEqual({
+    specifier: '^1.0.0',
+    version: '1.0.0',
+  })
+  expect(lockfile.packages['@pnpm.e2e/foo@1.0.1']).toBeTruthy()
+  expect(lockfile.packages['@pnpm.e2e/peer-a@1.0.1']).toBeFalsy()
 })
 
 test('update with a version on a crafted package name does not pollute Object.prototype', async () => {


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

<!-- Describe what this PR changes and why, for reviewers. Link any related
issues here (Closes pnpm/pnpm#123, Fixes pnpm/pnpm#456, or Related to
pnpm/pnpm#123 for a partial fix). -->

This PR fixes the recursive `update` command to allow transient dependencies to be resolved to the version provided in the command.

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
Explain what changed and why. Reference issues here too (Closes pnpm/pnpm#123).
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [ ] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [ ] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [ ] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [ ] Added or updated tests.
- [ ] Updated the documentation if needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13994"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789643353&installation_model_id=426870&pr_number=13994&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13994&signature=7e38c2d16e331afa1e81b088c05eef614d668d83359426fb40057b5f5609c5b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->