### PR TITLE
fix(resolver): reuse disk-cached metadata when registry lacks ETag su…

### DIFF
--- a/.changeset/fix-resolution-ado-etags.md
+++ b/.changeset/fix-resolution-ado-etags.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/resolving.npm-resolver": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+Fixed an issue where dependency resolution against registries without `ETag` or `Last-Modified` support (such as Azure DevOps Artifacts) re-downloaded package metadata unnecessarily on range specifications [#13976](https://github.com/pnpm/pnpm/issues/13976).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ importers:
   .:
     configDependencies: {}
     packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: 12.0.0-rc.6
+        version: 12.0.0-rc.6
       pnpm:
         specifier: 12.0.0-rc.6
         version: 12.0.0-rc.6
@@ -56,6 +59,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@pnpm/exe@12.0.0-rc.6':
+    resolution: {integrity: sha512-rUOIrEZJEsHD8kQJwV+S81eXiFmhd/oJCuxxDjRkx5fnFdNaQN6KPrpatXzRJX0XjTrYnChLhoV8XOfEoonYrA==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
   pnpm@12.0.0-rc.6:
     resolution: {integrity: sha512-OSf85JwwVLflVB3HILzntOurB/RWL6b/zns5cgol5qdn12OEmE4iZcgAeZYT9/ecXEIun1ztybZs//0Iyjx3qQ==}
     engines: {node: '>=18.*'}
@@ -86,6 +94,17 @@ snapshots:
 
   '@pnpm/exe.win32-x64@12.0.0-rc.6':
     optional: true
+
+  '@pnpm/exe@12.0.0-rc.6':
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.0.0-rc.6
+      '@pnpm/exe.darwin-x64': 12.0.0-rc.6
+      '@pnpm/exe.linux-arm64': 12.0.0-rc.6
+      '@pnpm/exe.linux-arm64-musl': 12.0.0-rc.6
+      '@pnpm/exe.linux-x64': 12.0.0-rc.6
+      '@pnpm/exe.linux-x64-musl': 12.0.0-rc.6
+      '@pnpm/exe.win32-arm64': 12.0.0-rc.6
+      '@pnpm/exe.win32-x64': 12.0.0-rc.6
 
   pnpm@12.0.0-rc.6:
     optionalDependencies:

--- a/pnpm/crates/package-manager/src/add/tests.rs
+++ b/pnpm/crates/package-manager/src/add/tests.rs
@@ -334,7 +334,7 @@ async fn add_reuses_shared_packument_state_for_every_selector_path() {
             state.lock().unwrap().active -= 1;
             result
         })
-        .expect(2)
+        .expect(1)
         .create_async()
         .await;
 
@@ -379,8 +379,8 @@ async fn add_reuses_shared_packument_state_for_every_selector_path() {
         let requests = request_state.lock().unwrap();
         assert_eq!(
             (requests.max_active, requests.total),
-            (1, 2),
-            "every selector path should share one fetch before the follow-up install fetch",
+            (1, 1),
+            "every selector path should share the single packument fetch",
         );
     }
     packument.assert_async().await;

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package.rs
@@ -65,8 +65,8 @@ use crate::{
     FetchMetadataError, fetch_full_metadata, fetch_full_metadata_cached,
     mirror::{
         ABBREVIATED_META_DIR, FULL_FILTERED_META_DIR, FULL_META_DIR, clear_meta,
-        get_pkg_mirror_path, load_meta, load_meta_async, save_meta_indexed, save_meta_ndjson,
-        scoped_meta_dir,
+        get_pkg_mirror_path, load_meta, load_meta_async, load_meta_headers_async,
+        save_meta_indexed, save_meta_ndjson, scoped_meta_dir,
     },
     pick_package_from_meta::{
         PickPackageFromMetaError, PickPackageFromMetaOptions, RegistryPackageSpec,
@@ -673,6 +673,50 @@ pub async fn pick_package<Cache: PackageMetaCache>(
             // stale. Restore the (possibly upgraded) meta for later
             // paths that reuse the in-store load.
             meta_cached_in_store = Some(meta);
+        }
+    }
+
+    if !opts.update_checksums
+        && !opts.include_latest_tag
+        && spec.spec_type != RegistryPackageSpecType::Tag
+        && let Some(mirror_path) = pkg_mirror.as_deref()
+        && let Some(headers) = load_meta_headers_async(Some(mirror_path)).await
+        && headers.etag.is_none()
+        && headers.modified.is_none()
+    {
+        if meta_cached_in_store.is_none() {
+            meta_cached_in_store = load_meta_async(Some(mirror_path)).await.map(Arc::new);
+        }
+        if let Some(meta) = meta_cached_in_store.as_ref() {
+            let upgrade = maybe_upgrade_abbreviated_meta_for_release_age(
+                ctx,
+                spec,
+                opts,
+                full_metadata,
+                &cache_key,
+                Arc::clone(meta),
+            )
+            .await;
+            if let Ok(upgrade) = upgrade {
+                let mut meta = upgrade.meta;
+                if upgrade.upgraded && !opts.dry_run {
+                    if let Some(reloaded) =
+                        persist_upgraded_to_mirror(mirror_path, &meta, use_filtered_full_metadata)
+                    {
+                        meta = Arc::new(reloaded);
+                    }
+                    ctx.meta_cache.set(cache_key.clone(), Arc::clone(&meta));
+                }
+                if let Ok((picked_meta, picked)) =
+                    pick_from_meta(&picker_opts, spec, Arc::clone(&meta), opts.blocked_versions)
+                    && picked.is_some()
+                {
+                    if !upgrade.upgraded && !opts.dry_run {
+                        ctx.meta_cache.set_unverified(cache_key.clone(), Arc::clone(&meta));
+                    }
+                    return Ok(PickPackageResult { meta: picked_meta, picked_package: picked });
+                }
+            }
         }
     }
 

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package/tests.rs
@@ -16,7 +16,8 @@ use super::{
 };
 use crate::{
     mirror::{
-        ABBREVIATED_META_DIR, FULL_FILTERED_META_DIR, FULL_META_DIR, get_pkg_mirror_path, load_meta,
+        ABBREVIATED_META_DIR, FULL_FILTERED_META_DIR, FULL_META_DIR, get_pkg_mirror_path,
+        load_meta, save_meta_ndjson,
     },
     pick_package_from_meta::{RegistryPackageSpec, RegistryPackageSpecType},
     registry_url::to_registry_url,
@@ -250,6 +251,48 @@ async fn offline_with_mirror_picks_from_disk() {
         fetch_locker: &fetch_locker,
         cache_dir: Some(cache_dir.path()),
         offline: true,
+        prefer_offline: false,
+        ignore_missing_time_field: false,
+        full_metadata: false,
+        needs_full_metadata_for: None,
+        filter_metadata: false,
+        retry_opts: RetryOpts::default(),
+    };
+
+    let result = pick_package(&ctx, &range_spec("acme", "^1.0.0"), &default_opts(&registry))
+        .await
+        .expect("ok");
+    assert_eq!(result.picked_package.expect("picked").version.to_string(), "1.1.0");
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn non_etag_mirror_reuses_disk_without_network() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server.mock("GET", "/acme").expect(0).create_async().await;
+
+    let cache_dir = TempDir::new().expect("tempdir");
+    let registry = format!("{}/", server.url());
+    let mut preloaded: pnpm_registry::Package =
+        serde_json::from_str(PACKAGE_BODY).expect("parse packument");
+    preloaded.modified = None;
+    let mirror_path =
+        get_pkg_mirror_path(cache_dir.path(), ABBREVIATED_META_DIR, &registry, "acme")
+            .expect("path");
+    save_meta_ndjson(&mirror_path, &preloaded, None).expect("save mirror");
+
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let meta_cache = InMemoryPackageMetaCache::default();
+    let fetch_locker = shared_packument_fetch_locker();
+
+    let ctx = PickPackageContext {
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        meta_cache: &meta_cache,
+        fetch_locker: &fetch_locker,
+        cache_dir: Some(cache_dir.path()),
+        offline: false,
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -423,6 +423,31 @@ export async function pickPackage (
       const cacheHeaders = diskMeta != null
         ? { etag: diskMeta.etag, modified: diskMeta.modified ?? diskMeta.time?.modified }
         : await limit(async () => loadMetaHeaders(pkgMirror))
+      if (cacheHeaders != null && !cacheHeaders.etag && !cacheHeaders.modified && spec.type !== 'tag' && !opts.includeLatestTag && !opts.updateChecksums) {
+        diskMeta = diskMeta ?? await limit(loadMetaCondensed)
+        if (diskMeta != null) {
+          try {
+            const upgrade = await maybeUpgradeAbbreviatedMetaForReleaseAge(ctx, spec, opts, diskMeta)
+            diskMeta = upgradeMetaForCache(ctx, upgrade, { pkgMirror, dryRun: opts.dryRun })
+            if (upgrade.upgradedFrom != null) {
+              ctx.metaCache.set(cacheKey, diskMeta)
+            }
+            const pickedPackage = pickMatchingVersionFinal(pickerOpts, spec, diskMeta)
+            if (pickedPackage) {
+              if (upgrade.upgradedFrom == null) {
+                cacheDiskLoadedMeta(ctx.metaCache, cacheKey, diskMeta)
+              }
+              return {
+                meta: diskMeta,
+                pickedPackage,
+              }
+            }
+          } catch {
+            // Swallow fast-path errors (e.g. ERR_PNPM_NO_VERSIONS from empty/outdated cache)
+            // and fall through to the network fetch.
+          }
+        }
+      }
       const conditional = await ctx.fetch(spec.name, {
         authHeaderValue: opts.authHeaderValue,
         fullMetadata,

--- a/pnpm11/resolving/npm-resolver/test/metaCache.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/metaCache.test.ts
@@ -481,3 +481,31 @@ test('pickPackage propagates a cache-loss fallback error', async () => {
   expect(fetchCalls[1].etag).toBeUndefined()
   expect(fetchCalls[1].modified).toBeUndefined()
 })
+
+test('pickPackage reuses disk-cached meta without network fetch when registry lacks etag and modified headers', async () => {
+  const meta = fooMeta()
+  const cacheDir = temporaryDirectory()
+  const pkgMirror = getPkgMirrorPath(cacheDir, ABBREVIATED_META_DIR, REGISTRY, 'foo')
+  await saveMeta(pkgMirror, prepareJsonForDisk(meta, undefined))
+
+  const fetchCalls: FetchMetadataOptions[] = []
+  const ctx = {
+    fetch: async (_pkgName: string, opts: FetchMetadataOptions) => {
+      fetchCalls.push(opts)
+      return { meta, jsonText: JSON.stringify(meta), etag: undefined }
+    },
+    metaCache: createMetaCache(),
+    cacheDir,
+  }
+  const spec: RegistryPackageSpec = { type: 'range', name: 'foo', fetchSpec: '^1.0.0' }
+
+  const result = await pickPackage(ctx, spec, {
+    registry: REGISTRY,
+    dryRun: false,
+    preferredVersionSelectors: undefined,
+  })
+
+  expect(result.pickedPackage?.version).toBe('1.0.0')
+  expect(fetchCalls).toHaveLength(0)
+})
+


### PR DESCRIPTION
## Summary

Resolves an issue where dependency resolution against registries without `ETag` or `Last-Modified` headers (such as Azure DevOps Artifacts feeds) issued unconditional network `GET` requests for every package range spec, causing severe (4x to 6x) resolution slowdowns.

When pnpm validates disk-cached metadata against a registry, the absence of validator headers previously prevented conditional `304 Not Modified` checks and forced full metadata re-downloads. This PR updates the resolver to check if valid on-disk metadata exists without network validators (`etag` and `modified`). For non-tag version specs, if a matching version is present in the disk cache, pnpm serves it directly without issuing a network request.

Parity has been implemented across both the TypeScript resolver (`@pnpm/resolving.npm-resolver`) and the Rust pacquet resolver (`pnpm-resolving-npm-resolver`).

Fixes pnpm/pnpm#13976

## Squash Commit Body

```text
Avoid making unconditional network GET requests during package resolution when target registries do not return ETag or Last-Modified validator headers (such as Azure DevOps Artifacts feeds).

When resolving range and explicit version specifiers (where spec.type != 'tag'), version entries within package metadata are append-only. When on-disk cached metadata exists for a package but has no etag or modified headers, and contains a version satisfying the requested specifier, pnpm now serves the cached metadata directly instead of making an unconditional GET request.

Tag specifiers (e.g. 'latest') continue to perform network checks because tag pointers on the registry can change dynamically.

Fixes pnpm/pnpm#13976
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789655190&installation_model_id=426870&pr_number=13996&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13996&signature=e9671c3dce5bfee1829dde578e76da47de57b2f0a77865bc1bfcb88734eeb440"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed package resolution for version ranges when registry metadata lacks `ETag` or `Last-Modified` headers.
  - Reuses valid locally cached metadata instead of unnecessarily downloading it again.
  - Preserves release-age checks and package selection when using cached metadata.
  - Falls back to fetching updated metadata when cached resolution cannot satisfy the request.

- **Tests**
  - Added regression coverage confirming cached metadata can resolve packages without a network request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->