### PR TITLE
fix(pacquet): try chcp.com before chcp on Windows

### DIFF
--- a/.changeset/chcp-windows-setup.md
+++ b/.changeset/chcp-windows-setup.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed resolving the `chcp` command on Windows during `pnpm setup` by looking for `chcp.com` before `chcp` [pnpm/pnpm#13991](https://github.com/pnpm/pnpm/issues/13991).

--- a/pnpm/crates/cli/src/cli_args/setup/path_extender/windows.rs
+++ b/pnpm/crates/cli/src/cli_args/setup/path_extender/windows.rs
@@ -26,11 +26,11 @@ pub(super) fn add_dir_to_windows_env_path(
 ) -> Result<Vec<EnvVariableChange>, PathExtenderError> {
     // `chcp` makes `reg` use UTF-8 for output. Otherwise non-ASCII
     // characters in environment variables become garbled.
-    let chcp_output = run_capture("chcp", &[])
+    let chcp_output = run_capture_chcp(&[])
         .map_err(|err| PathExtenderError::Chcp { message: err.to_string() })?;
     let cp_bak = first_number(&chcp_output)
         .ok_or_else(|| PathExtenderError::Chcp { message: chcp_output.clone() })?;
-    run_capture("chcp", &["65001"])?;
+    run_capture_chcp(&["65001"])?;
 
     let result = (|| {
         let report = add_dir_to_windows_env_path_inner(dir, opts)?;
@@ -39,7 +39,7 @@ pub(super) fn add_dir_to_windows_env_path(
     })();
 
     // Restore the original code page even when the body failed.
-    let _ = run_capture("chcp", &[&cp_bak.to_string()]);
+    let _ = run_capture_chcp(&[&cp_bak.to_string()]);
     result
 }
 
@@ -154,6 +154,17 @@ fn run_capture(program: &str, args: &[&str]) -> Result<String, PathExtenderError
         });
     }
     Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Run `chcp`, attempting `chcp.com` first (the standard executable name on
+/// Windows) with a fallback to `chcp` if `chcp.com` is not found.
+fn run_capture_chcp(args: &[&str]) -> Result<String, PathExtenderError> {
+    match run_capture("chcp.com", args) {
+        Err(PathExtenderError::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {
+            run_capture("chcp", args)
+        }
+        res => res,
+    }
 }
 
 /// Parse a `reg query` line of the form `    <name>    <type>    <data>`

--- a/pnpm/crates/cli/src/cli_args/setup/path_extender/windows.rs
+++ b/pnpm/crates/cli/src/cli_args/setup/path_extender/windows.rs
@@ -162,7 +162,10 @@ fn run_capture_chcp(args: &[&str]) -> Result<String, PathExtenderError> {
     run_capture_chcp_with(args, run_capture)
 }
 
-fn run_capture_chcp_with<Runner>(args: &[&str], mut runner: Runner) -> Result<String, PathExtenderError>
+fn run_capture_chcp_with<Runner>(
+    args: &[&str],
+    mut runner: Runner,
+) -> Result<String, PathExtenderError>
 where
     Runner: FnMut(&str, &[&str]) -> Result<String, PathExtenderError>,
 {

--- a/pnpm/crates/cli/src/cli_args/setup/path_extender/windows.rs
+++ b/pnpm/crates/cli/src/cli_args/setup/path_extender/windows.rs
@@ -159,9 +159,16 @@ fn run_capture(program: &str, args: &[&str]) -> Result<String, PathExtenderError
 /// Run `chcp`, attempting `chcp.com` first (the standard executable name on
 /// Windows) with a fallback to `chcp` if `chcp.com` is not found.
 fn run_capture_chcp(args: &[&str]) -> Result<String, PathExtenderError> {
-    match run_capture("chcp.com", args) {
+    run_capture_chcp_with(args, run_capture)
+}
+
+fn run_capture_chcp_with<F>(args: &[&str], mut runner: F) -> Result<String, PathExtenderError>
+where
+    F: FnMut(&str, &[&str]) -> Result<String, PathExtenderError>,
+{
+    match runner("chcp.com", args) {
         Err(PathExtenderError::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {
-            run_capture("chcp", args)
+            runner("chcp", args)
         }
         res => res,
     }

--- a/pnpm/crates/cli/src/cli_args/setup/path_extender/windows.rs
+++ b/pnpm/crates/cli/src/cli_args/setup/path_extender/windows.rs
@@ -162,9 +162,9 @@ fn run_capture_chcp(args: &[&str]) -> Result<String, PathExtenderError> {
     run_capture_chcp_with(args, run_capture)
 }
 
-fn run_capture_chcp_with<F>(args: &[&str], mut runner: F) -> Result<String, PathExtenderError>
+fn run_capture_chcp_with<Runner>(args: &[&str], mut runner: Runner) -> Result<String, PathExtenderError>
 where
-    F: FnMut(&str, &[&str]) -> Result<String, PathExtenderError>,
+    Runner: FnMut(&str, &[&str]) -> Result<String, PathExtenderError>,
 {
     match runner("chcp.com", args) {
         Err(PathExtenderError::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {

--- a/pnpm/crates/cli/src/cli_args/setup/path_extender/windows/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/setup/path_extender/windows/tests.rs
@@ -6,6 +6,7 @@
 use super::{
     AddDirToEnvPathOpts, AddingPosition, EnvVariableChange, PathExtenderError,
     add_dir_to_windows_env_path_inner, first_number, get_env_value_from_registry,
+    run_capture_chcp_with,
 };
 use pretty_assertions::assert_eq;
 use std::path::Path;
@@ -68,4 +69,52 @@ fn render_report_lists_changed_variables() {
     assert!(report.config_file.is_none());
     assert_eq!(report.old_settings, r"Path=C:\old");
     assert_eq!(report.new_settings, "PNPM_HOME=C:\\pnpm\nPath=%PNPM_HOME%;C:\\old");
+}
+
+#[test]
+fn chcp_prefers_chcp_com_when_available() {
+    let mut calls = Vec::new();
+    let res = run_capture_chcp_with(&["65001"], |prog, args| {
+        calls.push((prog.to_string(), args.iter().map(|s| s.to_string()).collect::<Vec<_>>()));
+        Ok("Active code page: 65001\n".to_string())
+    });
+    assert!(res.is_ok());
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].0, "chcp.com");
+    assert_eq!(calls[0].1, vec!["65001"]);
+}
+
+#[test]
+fn chcp_falls_back_to_chcp_when_chcp_com_not_found() {
+    let mut calls = Vec::new();
+    let res = run_capture_chcp_with(&["65001"], |prog, args| {
+        calls.push((prog.to_string(), args.iter().map(|s| s.to_string()).collect::<Vec<_>>()));
+        if prog == "chcp.com" {
+            Err(PathExtenderError::Io(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "chcp.com not found",
+            )))
+        } else {
+            Ok("Active code page: 65001\n".to_string())
+        }
+    });
+    assert!(res.is_ok());
+    assert_eq!(calls.len(), 2);
+    assert_eq!(calls[0].0, "chcp.com");
+    assert_eq!(calls[1].0, "chcp");
+}
+
+#[test]
+fn chcp_propagates_non_not_found_errors_without_fallback() {
+    let mut calls = Vec::new();
+    let res = run_capture_chcp_with(&["65001"], |prog, args| {
+        calls.push((prog.to_string(), args.iter().map(|s| s.to_string()).collect::<Vec<_>>()));
+        Err(PathExtenderError::CommandFailed {
+            command: prog.to_string(),
+            stderr: "Access denied".to_string(),
+        })
+    });
+    assert!(matches!(res, Err(PathExtenderError::CommandFailed { .. })));
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].0, "chcp.com");
 }

--- a/pnpm/crates/cli/src/cli_args/setup/path_extender/windows/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/setup/path_extender/windows/tests.rs
@@ -75,7 +75,7 @@ fn render_report_lists_changed_variables() {
 fn chcp_prefers_chcp_com_when_available() {
     let mut calls = Vec::new();
     let res = run_capture_chcp_with(&["65001"], |prog, args| {
-        calls.push((prog.to_string(), args.iter().map(|s| s.to_string()).collect::<Vec<_>>()));
+        calls.push((prog.to_string(), args.iter().map(ToString::to_string).collect::<Vec<_>>()));
         Ok("Active code page: 65001\n".to_string())
     });
     assert!(res.is_ok());
@@ -88,7 +88,7 @@ fn chcp_prefers_chcp_com_when_available() {
 fn chcp_falls_back_to_chcp_when_chcp_com_not_found() {
     let mut calls = Vec::new();
     let res = run_capture_chcp_with(&["65001"], |prog, args| {
-        calls.push((prog.to_string(), args.iter().map(|s| s.to_string()).collect::<Vec<_>>()));
+        calls.push((prog.to_string(), args.iter().map(ToString::to_string).collect::<Vec<_>>()));
         if prog == "chcp.com" {
             Err(PathExtenderError::Io(std::io::Error::new(
                 std::io::ErrorKind::NotFound,
@@ -108,7 +108,7 @@ fn chcp_falls_back_to_chcp_when_chcp_com_not_found() {
 fn chcp_propagates_non_not_found_errors_without_fallback() {
     let mut calls = Vec::new();
     let res = run_capture_chcp_with(&["65001"], |prog, args| {
-        calls.push((prog.to_string(), args.iter().map(|s| s.to_string()).collect::<Vec<_>>()));
+        calls.push((prog.to_string(), args.iter().map(ToString::to_string).collect::<Vec<_>>()));
         Err(PathExtenderError::CommandFailed {
             command: prog.to_string(),
             stderr: "Access denied".to_string(),


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

When running `pnpm setup` on Windows, `pacquet` executes `chcp` to get and update the active code page. On Windows, `chcp` is named `chcp.com` (`C:\Windows\System32\chcp.com`). `std::process::Command::new("chcp")` calls Windows `CreateProcessW`, which appends `.exe` when an extension is omitted. Because `chcp.exe` does not exist, setup fails with `ERR_PNPM_CHCP: exec chcp failed: program not found`.

This PR updates the Windows path-extender in `pacquet` to attempt executing `chcp.com` first, with a fallback to `chcp` if `chcp.com` is not found (`ErrorKind::NotFound`).

Fixes pnpm/pnpm#13991.

## Squash Commit Body

```text
Look for chcp.com before falling back to chcp during pnpm setup on Windows, resolving program not found errors caused by CreateProcessW appending .exe.

Fixes pnpm/pnpm#13991
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13998"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789658955&installation_model_id=426870&pr_number=13998&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13998&signature=606365ac3f13b316f8a357d037e2b043832eee86d5d6116d6cd346353105ba09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Windows setup behavior by reliably locating the system code-page utility.
  - Improved code-page initialization and restoration by using `chcp.com` first and falling back to `chcp` when unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->