### PR TITLE
fix(git-resolver): keep the committish in the recorded git specifier

### DIFF
--- a/.changeset/git-specifier-keeps-committish.md
+++ b/.changeset/git-specifier-keeps-committish.md
@@ -4,4 +4,4 @@
 "pacquet": patch
 ---
 
-A git dependency that names a branch, tag, or version range no longer loses it from the specifier recorded in `package.json`. When a hosted repository resolved over HTTPS without being provably public — a private repository reachable through a credential helper, or a URL carrying its own credentials — `pnpm add owner/repo#develop` wrote back `git+https://github.com/owner/repo.git`, dropping `#develop`. The install itself pinned the right commit, so nothing looked wrong until the next `pnpm update` silently moved the dependency to the default branch [#13999](https://github.com/pnpm/pnpm/issues/13999).
+A git dependency installed over HTTPS from a hosted repository now keeps its branch, tag, or version range in the specifier recorded in `package.json`. It was written back without one, so the next `pnpm update` moved the dependency to the repository's default branch [#13999](https://github.com/pnpm/pnpm/issues/13999).

--- a/.changeset/git-specifier-keeps-committish.md
+++ b/.changeset/git-specifier-keeps-committish.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/resolving.git-resolver": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+A git dependency that names a branch, tag, or version range no longer loses it from the specifier recorded in `package.json`. When a hosted repository resolved over HTTPS without being provably public — a private repository reachable through a credential helper, or a URL carrying its own credentials — `pnpm add owner/repo#develop` wrote back `git+https://github.com/owner/repo.git`, dropping `#develop`. The install itself pinned the right commit, so nothing looked wrong until the next `pnpm update` silently moved the dependency to the default branch [#13999](https://github.com/pnpm/pnpm/issues/13999).

--- a/pnpm/crates/resolving-git-resolver/src/parse_bare_specifier.rs
+++ b/pnpm/crates/resolving-git-resolver/src/parse_bare_specifier.rs
@@ -207,14 +207,18 @@ fn from_hosted_git(hosted: HostedGit) -> HostedPackageSpec {
     let https_url = hosted.https(HostedGit::no_committish_no_git_plus());
     // URL-embedded credentials are explicit user content, not
     // transport — and the host's archive endpoint would not carry
-    // them, so the spec stays archive-ineligible.
+    // them, so the spec stays archive-ineligible. `https_url` is an
+    // `ls-remote` target and carries no committish; the specifier
+    // recorded in the manifest has to keep it, or the next re-resolve
+    // silently moves the dependency to the default branch.
     if hosted.auth.is_some()
         && let Some(https_url) = &https_url
+        && let Some(https_specifier) = hosted.https(HostedOpts::default())
     {
         return HostedPackageSpec {
             fetch_spec: https_url.clone(),
             hosted: None,
-            normalized_bare_specifier: format!("git+{https_url}"),
+            normalized_bare_specifier: https_specifier,
             git_committish: params.git_committish,
             git_range: params.git_range,
             path: params.path,

--- a/pnpm/crates/resolving-git-resolver/src/parse_bare_specifier.rs
+++ b/pnpm/crates/resolving-git-resolver/src/parse_bare_specifier.rs
@@ -207,10 +207,8 @@ fn from_hosted_git(hosted: HostedGit) -> HostedPackageSpec {
     let https_url = hosted.https(HostedGit::no_committish_no_git_plus());
     // URL-embedded credentials are explicit user content, not
     // transport — and the host's archive endpoint would not carry
-    // them, so the spec stays archive-ineligible. `https_url` is an
-    // `ls-remote` target and carries no committish; the specifier
-    // recorded in the manifest has to keep it, or the next re-resolve
-    // silently moves the dependency to the default branch.
+    // them, so the spec stays archive-ineligible. `https_url` is the
+    // `ls-remote` target, so it carries no committish.
     if hosted.auth.is_some()
         && let Some(https_url) = &https_url
         && let Some(https_specifier) = hosted.https(HostedOpts::default())

--- a/pnpm/crates/resolving-git-resolver/src/parse_bare_specifier/tests.rs
+++ b/pnpm/crates/resolving-git-resolver/src/parse_bare_specifier/tests.rs
@@ -141,7 +141,8 @@ fn finalize_hosted_auth_url_keeps_the_committish_in_the_recorded_specifier() {
 // The committish survives on some paths through the resolver and not
 // others only if one of them builds the specifier by hand, so both the
 // credentialed and the plain hosted branch are covered, for every kind
-// of committish. Each row is `(input, expected_normalized_bare_specifier)`.
+// of committish — branch, tag, commit, and semver range. Each row is
+// `(input, expected_normalized_bare_specifier)`.
 #[test]
 fn every_representation_of_a_hosted_specifier_keeps_its_committish() {
     let cases: &[(&str, &str)] = &[
@@ -149,8 +150,16 @@ fn every_representation_of_a_hosted_specifier_keeps_its_committish() {
         ("foo/bar#v1.0.0", "github:foo/bar#v1.0.0"),
         ("foo/bar#semver:^1.0.0", "github:foo/bar#semver:^1.0.0"),
         (
+            "foo/bar#0123456789abcdef0123456789abcdef01234567",
+            "github:foo/bar#0123456789abcdef0123456789abcdef01234567",
+        ),
+        (
             "git+https://token:x-oauth-basic@github.com/foo/bar.git#develop",
             "git+https://token:x-oauth-basic@github.com/foo/bar.git#develop",
+        ),
+        (
+            "git+https://token:x-oauth-basic@github.com/foo/bar.git#0123456789abcdef0123456789abcdef01234567",
+            "git+https://token:x-oauth-basic@github.com/foo/bar.git#0123456789abcdef0123456789abcdef01234567",
         ),
         (
             "git+https://token:x-oauth-basic@github.com/foo/bar.git#semver:^1.0.0",

--- a/pnpm/crates/resolving-git-resolver/src/parse_bare_specifier/tests.rs
+++ b/pnpm/crates/resolving-git-resolver/src/parse_bare_specifier/tests.rs
@@ -141,34 +141,45 @@ fn finalize_hosted_auth_url_keeps_the_committish_in_the_recorded_specifier() {
 // The committish survives on some paths through the resolver and not
 // others only if one of them builds the specifier by hand, so both the
 // credentialed and the plain hosted branch are covered, for every kind
-// of committish — branch, tag, commit, and semver range. Each row is
-// `(input, expected_normalized_bare_specifier)`.
+// of committish — branch, tag, commit, and semver range.
+//
+// The resolved committish is asserted next to the specifier because the
+// two are written from different sources: dropping the specifier's
+// suffix leaves resolution correct on its own, and it is the pair
+// agreeing that keeps a re-resolve on the ref the caller asked for.
+// Each row is `(input, normalized_bare_specifier, git_committish,
+// git_range)`.
 #[test]
 fn every_representation_of_a_hosted_specifier_keeps_its_committish() {
-    let cases: &[(&str, &str)] = &[
-        ("foo/bar#develop", "github:foo/bar#develop"),
-        ("foo/bar#v1.0.0", "github:foo/bar#v1.0.0"),
-        ("foo/bar#semver:^1.0.0", "github:foo/bar#semver:^1.0.0"),
+    const SHA: &str = "0123456789abcdef0123456789abcdef01234567";
+    let auth_url = |committish: &str| {
+        format!("git+https://token:x-oauth-basic@github.com/foo/bar.git#{committish}")
+    };
+    let cases: [(String, String, Option<&str>, Option<&str>); 7] = [
+        ("foo/bar#develop".into(), "github:foo/bar#develop".into(), Some("develop"), None),
+        ("foo/bar#v1.0.0".into(), "github:foo/bar#v1.0.0".into(), Some("v1.0.0"), None),
         (
-            "foo/bar#0123456789abcdef0123456789abcdef01234567",
-            "github:foo/bar#0123456789abcdef0123456789abcdef01234567",
+            "foo/bar#semver:^1.0.0".into(),
+            "github:foo/bar#semver:^1.0.0".into(),
+            None,
+            Some("^1.0.0"),
         ),
-        (
-            "git+https://token:x-oauth-basic@github.com/foo/bar.git#develop",
-            "git+https://token:x-oauth-basic@github.com/foo/bar.git#develop",
-        ),
-        (
-            "git+https://token:x-oauth-basic@github.com/foo/bar.git#0123456789abcdef0123456789abcdef01234567",
-            "git+https://token:x-oauth-basic@github.com/foo/bar.git#0123456789abcdef0123456789abcdef01234567",
-        ),
-        (
-            "git+https://token:x-oauth-basic@github.com/foo/bar.git#semver:^1.0.0",
-            "git+https://token:x-oauth-basic@github.com/foo/bar.git#semver:^1.0.0",
-        ),
+        (format!("foo/bar#{SHA}"), format!("github:foo/bar#{SHA}"), Some(SHA), None),
+        (auth_url("develop"), auth_url("develop"), Some("develop"), None),
+        (auth_url(SHA), auth_url(SHA), Some(SHA), None),
+        (auth_url("semver:^1.0.0"), auth_url("semver:^1.0.0"), None, Some("^1.0.0")),
     ];
-    for (input, expected) in cases {
+    for (input, expected_specifier, expected_committish, expected_range) in &cases {
         let spec = parse_bare_specifier(input).expect("hosted").finalize();
-        assert_eq!(spec.normalized_bare_specifier, *expected, "input: {input}");
+        assert_eq!(
+            (
+                spec.normalized_bare_specifier.as_str(),
+                spec.git_committish.as_deref(),
+                spec.git_range.as_deref(),
+            ),
+            (expected_specifier.as_str(), *expected_committish, *expected_range),
+            "input: {input}",
+        );
     }
 }
 

--- a/pnpm/crates/resolving-git-resolver/src/parse_bare_specifier/tests.rs
+++ b/pnpm/crates/resolving-git-resolver/src/parse_bare_specifier/tests.rs
@@ -121,34 +121,8 @@ fn finalize_hosted_auth_url_kept_verbatim_without_archive_eligibility() {
     assert!(spec.hosted.is_none(), "credentialed URL must never resolve to a host archive");
 }
 
-#[test]
-fn finalize_hosted_auth_url_keeps_the_committish_in_the_recorded_specifier() {
-    // The committish is what pins the dependency to a branch. A specifier
-    // that loses it resolves to the default branch on the next update,
-    // silently moving the dependency off the branch that was asked for.
-    let kind =
-        parse_bare_specifier("git+https://token:x-oauth-basic@github.com/foo/bar.git#develop")
-            .expect("hosted");
-    let spec = kind.finalize();
-    assert_eq!(spec.fetch_spec, "https://token:x-oauth-basic@github.com/foo/bar.git");
-    assert_eq!(
-        spec.normalized_bare_specifier,
-        "git+https://token:x-oauth-basic@github.com/foo/bar.git#develop",
-    );
-    assert_eq!(spec.git_committish.as_deref(), Some("develop"));
-}
-
-// The committish survives on some paths through the resolver and not
-// others only if one of them builds the specifier by hand, so both the
-// credentialed and the plain hosted branch are covered, for every kind
-// of committish — branch, tag, commit, and semver range.
-//
-// The resolved committish is asserted next to the specifier because the
-// two are written from different sources: dropping the specifier's
-// suffix leaves resolution correct on its own, and it is the pair
-// agreeing that keeps a re-resolve on the ref the caller asked for.
-// Each row is `(input, normalized_bare_specifier, git_committish,
-// git_range)`.
+// [pnpm/pnpm#13999](https://github.com/pnpm/pnpm/issues/13999). Each row
+// is `(input, normalized_bare_specifier, git_committish, git_range)`.
 #[test]
 fn every_representation_of_a_hosted_specifier_keeps_its_committish() {
     const SHA: &str = "0123456789abcdef0123456789abcdef01234567";
@@ -171,6 +145,7 @@ fn every_representation_of_a_hosted_specifier_keeps_its_committish() {
     ];
     for (input, expected_specifier, expected_committish, expected_range) in &cases {
         let spec = parse_bare_specifier(input).expect("hosted").finalize();
+        assert!(!spec.fetch_spec.contains('#'), "ls-remote target keeps a committish: {input}");
         assert_eq!(
             (
                 spec.normalized_bare_specifier.as_str(),

--- a/pnpm/crates/resolving-git-resolver/src/parse_bare_specifier/tests.rs
+++ b/pnpm/crates/resolving-git-resolver/src/parse_bare_specifier/tests.rs
@@ -121,6 +121,48 @@ fn finalize_hosted_auth_url_kept_verbatim_without_archive_eligibility() {
     assert!(spec.hosted.is_none(), "credentialed URL must never resolve to a host archive");
 }
 
+#[test]
+fn finalize_hosted_auth_url_keeps_the_committish_in_the_recorded_specifier() {
+    // The committish is what pins the dependency to a branch. A specifier
+    // that loses it resolves to the default branch on the next update,
+    // silently moving the dependency off the branch that was asked for.
+    let kind =
+        parse_bare_specifier("git+https://token:x-oauth-basic@github.com/foo/bar.git#develop")
+            .expect("hosted");
+    let spec = kind.finalize();
+    assert_eq!(spec.fetch_spec, "https://token:x-oauth-basic@github.com/foo/bar.git");
+    assert_eq!(
+        spec.normalized_bare_specifier,
+        "git+https://token:x-oauth-basic@github.com/foo/bar.git#develop",
+    );
+    assert_eq!(spec.git_committish.as_deref(), Some("develop"));
+}
+
+// The committish survives on some paths through the resolver and not
+// others only if one of them builds the specifier by hand, so both the
+// credentialed and the plain hosted branch are covered, for every kind
+// of committish. Each row is `(input, expected_normalized_bare_specifier)`.
+#[test]
+fn every_representation_of_a_hosted_specifier_keeps_its_committish() {
+    let cases: &[(&str, &str)] = &[
+        ("foo/bar#develop", "github:foo/bar#develop"),
+        ("foo/bar#v1.0.0", "github:foo/bar#v1.0.0"),
+        ("foo/bar#semver:^1.0.0", "github:foo/bar#semver:^1.0.0"),
+        (
+            "git+https://token:x-oauth-basic@github.com/foo/bar.git#develop",
+            "git+https://token:x-oauth-basic@github.com/foo/bar.git#develop",
+        ),
+        (
+            "git+https://token:x-oauth-basic@github.com/foo/bar.git#semver:^1.0.0",
+            "git+https://token:x-oauth-basic@github.com/foo/bar.git#semver:^1.0.0",
+        ),
+    ];
+    for (input, expected) in cases {
+        let spec = parse_bare_specifier(input).expect("hosted").finalize();
+        assert_eq!(spec.normalized_bare_specifier, *expected, "input: {input}");
+    }
+}
+
 // Ported `parsePref.test.ts` SCP-style URL repair cases. Each row
 // is `(input, expected_fetch_spec)`.
 #[test]

--- a/pnpm11/resolving/git-resolver/src/parseBareSpecifier.ts
+++ b/pnpm11/resolving/git-resolver/src/parseBareSpecifier.ts
@@ -104,11 +104,8 @@ async function fromHostedGit (hosted: any, dispatcherOptions: DispatcherOptions)
           _fill: hosted._fill,
           tarball: undefined,
         },
-        // `httpsUrl` is an `ls-remote` target, so it deliberately carries no
-        // committish. The specifier recorded in the manifest has to keep it:
-        // without it, the next re-resolve silently moves the dependency to the
-        // default branch.
-        normalizedBareSpecifier: `git+${hosted.https({ noGitPlus: true })}`,
+        // `httpsUrl` is the `ls-remote` target, so it carries no committish.
+        normalizedBareSpecifier: hosted.https(),
         ...parseGitParams(hosted.committish),
       }
     }

--- a/pnpm11/resolving/git-resolver/src/parseBareSpecifier.ts
+++ b/pnpm11/resolving/git-resolver/src/parseBareSpecifier.ts
@@ -104,7 +104,11 @@ async function fromHostedGit (hosted: any, dispatcherOptions: DispatcherOptions)
           _fill: hosted._fill,
           tarball: undefined,
         },
-        normalizedBareSpecifier: `git+${httpsUrl}`,
+        // `httpsUrl` is an `ls-remote` target, so it deliberately carries no
+        // committish. The specifier recorded in the manifest has to keep it:
+        // without it, the next re-resolve silently moves the dependency to the
+        // default branch.
+        normalizedBareSpecifier: `git+${hosted.https({ noGitPlus: true })}`,
         ...parseGitParams(hosted.committish),
       }
     }

--- a/pnpm11/resolving/git-resolver/test/index.ts
+++ b/pnpm11/resolving/git-resolver/test/index.ts
@@ -718,10 +718,8 @@ test('resolve a private repository using the HTTPS protocol with a commit hash',
   })
 })
 
-test('a private repository reached over authenticated HTTPS keeps the branch in the recorded specifier', async () => {
-  // The committish is what pins the dependency to a branch. A specifier that
-  // loses it resolves to the default branch on the next update, silently
-  // moving the dependency off the branch that was asked for.
+// [pnpm/pnpm#13999](https://github.com/pnpm/pnpm/issues/13999)
+test('a private repository reached over HTTPS keeps the branch in the recorded specifier', async () => {
   mockFetchAsPrivate()
   mockGit(async (args: string[]) => {
     if (args.includes('--exit-code')) return { stdout: `${'0'.repeat(40)}\tHEAD` }
@@ -741,10 +739,6 @@ test('a private repository reached over authenticated HTTPS keeps the branch in 
 })
 
 test('every representation of a hosted specifier keeps its committish', async () => {
-  // The committish survives on some paths through the resolver and not others
-  // only if one of them builds the specifier by hand, so all of them are
-  // covered: a public repo, a private one reached over HTTPS, and a
-  // credentialed URL.
   mockGit(async (args: string[]) => {
     if (args.includes('--exit-code')) return { stdout: `${'0'.repeat(40)}\tHEAD` }
     return { stdout: `${'1'.repeat(40)}\trefs/heads/develop` }

--- a/pnpm11/resolving/git-resolver/test/index.ts
+++ b/pnpm11/resolving/git-resolver/test/index.ts
@@ -707,7 +707,7 @@ test('resolve a private repository using the HTTPS protocol with a commit hash',
   const resolveResult = await resolveFromGit({ bareSpecifier: 'git+https://github.com/foo/bar.git#aabbccddeeff' })
   expect(resolveResult).toStrictEqual({
     id: 'git+https://github.com/foo/bar.git#aabbccddeeff',
-    normalizedBareSpecifier: 'git+https://github.com/foo/bar.git',
+    normalizedBareSpecifier: 'git+https://github.com/foo/bar.git#aabbccddeeff',
     resolution: {
       // cspell:ignore aabbccddeeff
       commit: 'aabbccddeeff',
@@ -716,6 +716,52 @@ test('resolve a private repository using the HTTPS protocol with a commit hash',
     },
     resolvedVia: 'git-repository',
   })
+})
+
+test('a private repository reached over authenticated HTTPS keeps the branch in the recorded specifier', async () => {
+  // The committish is what pins the dependency to a branch. A specifier that
+  // loses it resolves to the default branch on the next update, silently
+  // moving the dependency off the branch that was asked for.
+  mockFetchAsPrivate()
+  mockGit(async (args: string[]) => {
+    if (args.includes('--exit-code')) return { stdout: `${'0'.repeat(40)}\tHEAD` }
+    return { stdout: `${'1'.repeat(40)}\trefs/heads/develop` }
+  })
+  const resolveResult = await resolveFromGit({ bareSpecifier: 'foo/bar#develop' })
+  expect(resolveResult).toStrictEqual({
+    id: `git+https://github.com/foo/bar.git#${'1'.repeat(40)}`,
+    normalizedBareSpecifier: 'git+https://github.com/foo/bar.git#develop',
+    resolution: {
+      commit: '1'.repeat(40),
+      repo: 'https://github.com/foo/bar.git',
+      type: 'git',
+    },
+    resolvedVia: 'git-repository',
+  })
+})
+
+test('every representation of a hosted specifier keeps its committish', async () => {
+  // The committish survives on some paths through the resolver and not others
+  // only if one of them builds the specifier by hand, so all of them are
+  // covered: a public repo, a private one reached over HTTPS, and a
+  // credentialed URL.
+  mockGit(async (args: string[]) => {
+    if (args.includes('--exit-code')) return { stdout: `${'0'.repeat(40)}\tHEAD` }
+    return { stdout: `${'1'.repeat(40)}\trefs/heads/develop` }
+  })
+  const publicRepo = await resolveFromGit({ bareSpecifier: 'foo/bar#develop' })
+  mockFetchAsPrivate()
+  const privateRepo = await resolveFromGit({ bareSpecifier: 'foo/bar#develop' })
+  const credentialedRepo = await resolveFromGit({ bareSpecifier: 'git+https://hunter2:x-oauth-basic@github.com/foo/bar.git#develop' })
+  expect([
+    publicRepo?.normalizedBareSpecifier,
+    privateRepo?.normalizedBareSpecifier,
+    credentialedRepo?.normalizedBareSpecifier,
+  ]).toStrictEqual([
+    'github:foo/bar#develop',
+    'git+https://github.com/foo/bar.git#develop',
+    'git+https://hunter2:x-oauth-basic@github.com/foo/bar.git#develop',
+  ])
 })
 
 test('resolve a private repository using the HTTPS protocol and an auth token', async () => {


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#13999.

`fromHostedGit` builds one HTTPS URL and uses it for two different jobs. It is the `git ls-remote` target, so it is built with `noCommittish`:

```ts
const httpsUrl: string | null = hosted.https({ noCommittish: true, noGitPlus: true })
```

and the early return for a repository that is reachable over HTTPS without being provably public then records that same committish-free URL as the specifier:

```ts
normalizedBareSpecifier: `git+${httpsUrl}`,
```

Every other return path uses `hosted.shortcut()`, which keeps the committish. So `pnpm add owner/repo#develop` against a private repository wrote `git+https://github.com/owner/repo.git` into `package.json` — `#develop` gone.

The `...parseGitParams(hosted.committish)` spread on the same return keeps *resolution* correct: the committish reaches `resolveRef` and the lockfile pins the tip of `develop`. That is what makes this quiet. Nothing looks wrong at install time; the damage lands on the next re-resolve, where a specifier that no longer names a branch resolves to the default branch instead. The reporter had five `@company/*` dependencies move from `develop` to `master` in one `pnpm update`.

The branch itself predates 11.21. pnpm/pnpm#13290 changed which specifiers reach it: SSH is now probed before the HTTPS fallbacks only when `hosted.default === 'sshurl'`, and a shorthand specifier's default is `'shortcut'`, so a private repo whose HTTPS `ls-remote` succeeds through a credential helper now takes this route on any machine with working HTTPS credentials, not just keyless ones.

**The fix.** `fetchSpec` stays committish-free — it is an `ls-remote` target. The recorded specifier is built from the same host template with the committish left in:

```ts
normalizedBareSpecifier: `git+${hosted.https({ noGitPlus: true })}`,
```

Building it from `hosted.https()` rather than by hand keeps one owner for the URL shape, and it degrades correctly when there is no committish. Checked against `@pnpm/hosted-git-info@1.0.0` that the result round-trips — `fromUrl(normalized).committish` equals the original — for a branch, a tag, `semver:`, `path:`, and a combined `semver:…&path:…`.

I kept the HTTPS shape rather than switching the branch to `hosted.shortcut()` like its siblings. That branch deliberately resolves as `type: git` against *this exact URL* because the host's archive endpoint would carry neither the URL's credentials nor ambient ones, and `shortcut()` drops URL-embedded auth. Only the missing committish was wrong.

**Rust:** same defect, fixed alongside. pacquet has no visibility probe — its `from_hosted_git` is identity-based — so the early return is reached only when the URL carries its own credentials, but it drops the committish there in exactly the same way (`format!("git+{https_url}")` over a `no_committish_no_git_plus()` URL). The committish-carrying URL is now bound in the same `let` chain, so there is no unreachable fallback.

**Tests:** the TypeScript suite had the bug pinned as expected behavior — `resolve a private repository using the HTTPS protocol with a commit hash` asserted `normalizedBareSpecifier: 'git+https://github.com/foo/bar.git'` for the input `git+https://github.com/foo/bar.git#aabbccddeeff`. That expectation is corrected. Added the issue's exact shape (a private repo reached over authenticated HTTPS, resolved by branch), and, as the issue suggests, a case that walks every representation of a hosted specifier and asserts each keeps its committish — the defect was one branch disagreeing with the others, so the guard belongs across all of them rather than on the one that broke. Mirrored on the Rust side. Reverting the source change alone fails 3 TypeScript tests and 2 Rust tests.

## Squash Commit Body

```text
A hosted git specifier that resolved over HTTPS without the repository
being provably public lost its committish from the specifier written
back to the manifest: `pnpm add owner/repo#develop` recorded
`git+https://github.com/owner/repo.git`.

The URL that branch records doubles as the `git ls-remote` target, which
must carry no committish, so it was built with `noCommittish`. The
committish still reached resolveRef, so the install pinned the right
commit and nothing looked wrong — until the next re-resolve read a
specifier that no longer named a branch and moved the dependency to the
default branch.

Keep the `ls-remote` target committish-free and build the recorded
specifier from the same host template with the committish left in, which
is what every other branch of fromHostedGit already produced through
shortcut().

pacquet reaches its equivalent branch only for a URL carrying its own
credentials, and drops the committish there the same way; it is fixed
alongside.

Fixes pnpm/pnpm#13999
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14007"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789723748&installation_model_id=426870&pr_number=14007&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14007&signature=68bb3d035048f708aac180cbf4619e74518391073c6c0df1e80d25521812927f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Git dependencies now preserve requested branches, tags, commit hashes, and version ranges when resolved and recorded.
  - Improved handling of public, private, and credentialed HTTPS Git repositories.
  - Normalized Git URLs now retain requested committish information while fetch targets remain clean and reliable.
  - Added coverage for hosted repository shortcuts and authenticated HTTPS URLs across supported Git dependency formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->