### PR TITLE
fix(git-fetcher): suggest an allowBuilds entry that approves the blocked build

### DIFF
--- a/.changeset/git-dep-allow-builds-help-key.md
+++ b/.changeset/git-dep-allow-builds-help-key.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+When a git-hosted dependency is blocked from running build scripts, the error now suggests an `allowBuilds` entry that actually approves it. It quoted the bare package name, which never matches a git-hosted package, so following the suggestion left the install failing the same way [#14002](https://github.com/pnpm/pnpm/issues/14002).

--- a/pnpm/crates/git-fetcher/src/error.rs
+++ b/pnpm/crates/git-fetcher/src/error.rs
@@ -26,6 +26,11 @@ pub enum PreparePackageError {
         /// plus the resolution id, not the manifest version. A
         /// name-only key cannot approve a git artifact, so quoting
         /// anything else here suggests an entry that never matches.
+        ///
+        /// Redacted: a resolution id can embed `user:pass@`
+        /// credentials, which must not reach a terminal or a CI log.
+        /// A specifier that carries them therefore needs its own copy
+        /// of the key rather than this example verbatim.
         dep_path: String,
     },
 

--- a/pnpm/crates/git-fetcher/src/error.rs
+++ b/pnpm/crates/git-fetcher/src/error.rs
@@ -16,10 +16,18 @@ pub enum PreparePackageError {
     #[diagnostic(
         code(ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED),
         help(
-            "Add the package to \"allowBuilds\" in your project's pnpm-workspace.yaml to allow it to run scripts. For example:\nallowBuilds:\n  {name}: true",
+            "Add the package to \"allowBuilds\" in your project's pnpm-workspace.yaml to allow it to run scripts. For example:\nallowBuilds:\n  {dep_path}: true",
         )
     )]
-    NotAllowed { name: String, version: String },
+    NotAllowed {
+        name: String,
+        version: String,
+        /// The identity `allowBuilds` is checked against — the name
+        /// plus the resolution id, not the manifest version. A
+        /// name-only key cannot approve a git artifact, so quoting
+        /// anything else here suggests an entry that never matches.
+        dep_path: String,
+    },
 
     /// A lifecycle script invoked by `preparePackage` failed, stamped
     /// with the `ERR_PNPM_PREPARE_PACKAGE` code.

--- a/pnpm/crates/git-fetcher/src/fetcher/tests.rs
+++ b/pnpm/crates/git-fetcher/src/fetcher/tests.rs
@@ -367,6 +367,7 @@ async fn fetcher_blocks_build_when_not_allowed() {
         GitFetcherError::Prepare(crate::error::PreparePackageError::NotAllowed {
             name,
             version,
+            ..
         }) => {
             assert_eq!(name, "naughty");
             assert_eq!(version, "2.0.0");
@@ -794,6 +795,7 @@ async fn fetcher_rejects_untrusted_manifest_identity() {
         GitFetcherError::Prepare(crate::error::PreparePackageError::NotAllowed {
             name,
             version,
+            ..
         }) => {
             assert_eq!(name, "x");
             assert_eq!(version, "1.0.0");

--- a/pnpm/crates/git-fetcher/src/prepare_package.rs
+++ b/pnpm/crates/git-fetcher/src/prepare_package.rs
@@ -112,10 +112,12 @@ pub fn prepare_package<Reporter: self::Reporter>(
     // identity from it and name-only rules can't approve the build.
     let name = manifest.get("name").and_then(Value::as_str).unwrap_or("");
     let version = manifest.get("version").and_then(Value::as_str).unwrap_or("");
-    if !(opts.allow_build)(&format!("{name}@{}", opts.pkg_resolution_id)) {
+    let allow_build_dep_path = format!("{name}@{}", opts.pkg_resolution_id);
+    if !(opts.allow_build)(&allow_build_dep_path) {
         return Err(PreparePackageError::NotAllowed {
             name: name.to_string(),
             version: version.to_string(),
+            dep_path: allow_build_dep_path,
         });
     }
 

--- a/pnpm/crates/git-fetcher/src/prepare_package.rs
+++ b/pnpm/crates/git-fetcher/src/prepare_package.rs
@@ -14,6 +14,7 @@ use crate::{
 use pnpm_executor::{
     LifecycleScriptError, RunPostinstallHooks, ScriptsPrependNodePath, run_lifecycle_hook,
 };
+use pnpm_network::redact_and_sanitize;
 use pnpm_package_manifest::safe_read_package_json_from_dir;
 use pnpm_reporter::{LogEvent, LogLevel, PnpmLog, Reporter};
 use serde_json::Value;
@@ -117,7 +118,7 @@ pub fn prepare_package<Reporter: self::Reporter>(
         return Err(PreparePackageError::NotAllowed {
             name: name.to_string(),
             version: version.to_string(),
-            dep_path: allow_build_dep_path,
+            dep_path: redact_and_sanitize(&allow_build_dep_path),
         });
     }
 

--- a/pnpm/crates/git-fetcher/src/prepare_package/tests.rs
+++ b/pnpm/crates/git-fetcher/src/prepare_package/tests.rs
@@ -219,6 +219,34 @@ fn prepare_rejection_suggests_the_allow_builds_key_the_gate_checked() {
 }
 
 #[test]
+fn prepare_rejection_keeps_resolution_id_credentials_out_of_the_diagnostic() {
+    // The suggested key is built from the resolution id, which for a
+    // private repository can carry the credentials git authenticated
+    // with. Rendering it puts them on a terminal and into CI logs.
+    let dir = tempdir().unwrap();
+    write_manifest(
+        dir.path(),
+        &json!({
+            "name": "naughty", "version": "1.0.0",
+            "scripts": { "prepare": "tsc" },
+        }),
+    );
+    let mut opts = opts(false, false);
+    opts.pkg_resolution_id =
+        "git+https://s3cr3t-token:hunter2@github.com/foo/bar.git#0123456789abcdef";
+
+    let err = prepare_package::<SilentReporter>(&opts, dir.path(), None).unwrap_err();
+    let rendered = format!("{err}{}", err.help().expect("NotAllowed carries a help message"));
+    for secret in ["s3cr3t-token", "hunter2"] {
+        assert!(!rendered.contains(secret), "{secret:?} leaked into the diagnostic: {rendered}");
+    }
+    assert!(
+        rendered.contains("github.com/foo/bar.git#0123456789abcdef"),
+        "the repository the reader has to allow must survive redaction: {rendered}",
+    );
+}
+
+#[test]
 fn prepare_rejects_untrusted_manifest_identity() {
     let dir = tempdir().unwrap();
     write_manifest(

--- a/pnpm/crates/git-fetcher/src/prepare_package/tests.rs
+++ b/pnpm/crates/git-fetcher/src/prepare_package/tests.rs
@@ -3,10 +3,16 @@ use super::{
     safe_join_path,
 };
 use crate::error::PreparePackageError;
+use miette::Diagnostic;
 use pnpm_executor::ScriptsPrependNodePath;
 use pnpm_reporter::SilentReporter;
 use serde_json::json;
-use std::{collections::HashMap, fs, path::Path, sync::LazyLock};
+use std::{
+    collections::HashMap,
+    fs,
+    path::Path,
+    sync::{Arc, LazyLock, Mutex},
+};
 use tempfile::tempdir;
 
 /// A single process-wide empty env map shared across every test
@@ -167,12 +173,49 @@ fn prepare_rejects_when_allow_build_returns_false() {
 
     let err = prepare_package::<SilentReporter>(&opts(false, false), dir.path(), None).unwrap_err();
     match err {
-        PreparePackageError::NotAllowed { name, version } => {
+        PreparePackageError::NotAllowed { name, version, .. } => {
             assert_eq!(name, "naughty");
             assert_eq!(version, "1.0.0");
         }
         other => panic!("expected NotAllowed, got {other:?}"),
     }
+}
+
+#[test]
+fn prepare_rejection_suggests_the_allow_builds_key_the_gate_checked() {
+    // The bare package name cannot approve a git artifact, so an example
+    // built from it sends the reader in a circle: they add the entry the
+    // error asked for and the next install fails the same way.
+    let dir = tempdir().unwrap();
+    write_manifest(
+        dir.path(),
+        &json!({
+            "name": "naughty", "version": "1.0.0",
+            "scripts": { "prepare": "tsc" },
+        }),
+    );
+    let checked = Arc::new(Mutex::new(Vec::<String>::new()));
+    let recorder = Arc::clone(&checked);
+    let mut opts = opts(false, false);
+    opts.allow_build = Box::new(move |dep_path| {
+        recorder.lock().unwrap().push(dep_path.to_string());
+        false
+    });
+
+    let err = prepare_package::<SilentReporter>(&opts, dir.path(), None).unwrap_err();
+    let help = err.help().expect("NotAllowed carries a help message").to_string();
+    let checked = checked.lock().unwrap();
+    let [gated_key] = checked.as_slice() else {
+        panic!("expected exactly one allowBuild check, got {checked:?}");
+    };
+    assert!(
+        help.contains(&format!("  {gated_key}: true")),
+        "the help must quote the key the gate checked ({gated_key}), got: {help}",
+    );
+    assert!(
+        !help.contains("  naughty: true"),
+        "a bare-name entry never approves a git artifact, got: {help}",
+    );
 }
 
 #[test]
@@ -190,7 +233,7 @@ fn prepare_rejects_untrusted_manifest_identity() {
         prepare_package::<SilentReporter>(&opts_allow_registry_artifacts_only(), dir.path(), None)
             .unwrap_err();
     match err {
-        PreparePackageError::NotAllowed { name, version } => {
+        PreparePackageError::NotAllowed { name, version, .. } => {
             assert_eq!(name, "naughty");
             assert_eq!(version, "1.0.0");
         }

--- a/pnpm/crates/git-fetcher/src/tarball_fetcher/tests.rs
+++ b/pnpm/crates/git-fetcher/src/tarball_fetcher/tests.rs
@@ -165,7 +165,7 @@ async fn rejects_build_when_not_allowed() {
     .unwrap_err();
 
     match err {
-        GitFetcherError::Prepare(PreparePackageError::NotAllowed { name, version }) => {
+        GitFetcherError::Prepare(PreparePackageError::NotAllowed { name, version, .. }) => {
             assert_eq!(name, "naughty");
             assert_eq!(version, "2.0.0");
         }


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#14002.

`prepare_package` gates a git-hosted build on the identity a lockfile would record — the fetched manifest's name plus the resolution id:

```rust
if !(opts.allow_build)(&format!("{name}@{}", opts.pkg_resolution_id)) {
```

but `PreparePackageError::NotAllowed`'s `help` interpolated the bare name:

```
allowBuilds:
  {name}: true
```

A bare name cannot approve that package — and not by accident. `AllowBuildPolicy::check` refuses to consult its name rules unless the dep path's version half parses as semver, because a package-name rule requires a trusted package identity and a git artifact's resolution id is never semver-shaped. So the error was quoting an entry the policy is designed to reject. The reporter did exactly what it asked, twice, and got the same failure; their own comparison with 11.22.0 — which prints the resolution-id-qualified key and then installs fine — is the diff.

**The fix.** Carry the gated dep path on the error and quote that. This is what the TypeScript CLI already does: `pnpm11/exec/prepare-package/src/index.ts` builds `const depPath = \`${manifest.name}@${opts.pkgResolutionId}\``, checks it, and interpolates the same value into the hint, so after this change both stacks name the same key.

I considered suggesting the commit-independent repo key instead (`<name>@git+https://<host>/<repo>.git`), which `AllowBuildPolicy` also accepts and which survives a moving branch. Two reasons not to: the helper that derives it (`git_repo_allow_build_key_from_dep_path`) lives in `pnpm-deps-restorer`, which depends on `pnpm-git-fetcher` and not the other way round, so reaching it means either inverting that edge or duplicating the URL normalization; and the TypeScript CLI quotes the exact dep path, so quoting anything else would leave the two stacks giving different advice for the same error. Worth doing later on both sides together, not here.

**Rust-only:** the TypeScript CLI's `help` is already correct, so there is nothing to mirror and the changeset targets `pacquet` alone.

**Tests:** a new unit test records the key the gate was actually handed and asserts the rendered `help` quotes that key, so the test cannot drift from the gate the way a hardcoded string can, and it also asserts the bare-name form is not what gets suggested. Reverting the format string alone fails it. The existing `NotAllowed` matches ignore the added field.

## Squash Commit Body

```text
The `allowBuilds` gate gives the policy `<manifest name>@<resolution id>`,
the identity a lockfile would record. Resolution ids of git artifacts are
never semver-shaped, so a name-only rule cannot approve one — but the
ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED help quoted the bare name, and the
reader who added exactly what it asked for hit the same error again.

Carry the gated dep path on the error and quote that instead, which is
what the TypeScript CLI's preparePackage already does.

Fixes pnpm/pnpm#14002
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14010"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789727476&installation_model_id=426870&pr_number=14010&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14010&signature=216641ce9f02d4059d4fcb4dd975edc51f505590bc8ee1b30416cd8f5afc2e27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blocked git-hosted dependency build errors to recommend the exact `allowBuilds` entry needed.
  * Error guidance now includes the complete dependency path, reducing configuration mistakes.
  * Sensitive credentials are now removed from dependency resolution details while preserving useful repository information.
  * Updated diagnostics and validation to ensure suggested configuration keys match the checks performed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->