### PR TITLE
fix(install): enforce --frozen-lockfile for packageManagerDependencies

### DIFF
--- a/.changeset/frozen-lockfile-package-manager-deps.md
+++ b/.changeset/frozen-lockfile-package-manager-deps.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.env-installer": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+Ensure that running with `--frozen-lockfile` throws an outdated lockfile error when `packageManagerDependencies` is out of sync or not resolved in the lockfile, instead of silently updating the lockfile, resolving the bug described in [pnpm/pnpm#14009](https://github.com/pnpm/pnpm/issues/14009).

--- a/.changeset/frozen-lockfile-package-manager-deps.md
+++ b/.changeset/frozen-lockfile-package-manager-deps.md
@@ -1,7 +1,7 @@
 ---
 "@pnpm/installing.env-installer": patch
-"pnpm": patch
 "pacquet": patch
+"pnpm": patch
 ---
 
-Ensure that running with `--frozen-lockfile` throws an outdated lockfile error when `packageManagerDependencies` is out of sync or not resolved in the lockfile, instead of silently updating the lockfile, resolving the bug described in [pnpm/pnpm#14009](https://github.com/pnpm/pnpm/issues/14009).
+A frozen install no longer rewrites the `packageManagerDependencies` block of `pnpm-lock.yaml`. When the pnpm version pinned by `devEngines.packageManager` (or by `packageManager`) is missing from the lockfile or no longer matches it, `--frozen-lockfile` now fails with `ERR_PNPM_FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE` instead of resolving the version and saving it, so a manifest whose pin was bumped without regenerating the lockfile can no longer pass CI [#14009](https://github.com/pnpm/pnpm/issues/14009).

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -403,12 +403,18 @@ impl InstallArgs {
     }
 
     fn configured_frozen_lockfile(&self, config: &pnpm_config::Config) -> Option<bool> {
+        self.frozen_lockfile_flag().or(config.frozen_lockfile)
+    }
+
+    /// `--frozen-lockfile` / `--no-frozen-lockfile` as typed on the command
+    /// line, before the `frozenLockfile` setting is layered under it.
+    pub(crate) fn frozen_lockfile_flag(&self) -> Option<bool> {
         if self.frozen_lockfile {
             Some(true)
         } else if self.no_frozen_lockfile {
             Some(false)
         } else {
-            config.frozen_lockfile
+            None
         }
     }
 

--- a/pnpm/crates/cli/src/cli_args/pre_command.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command.rs
@@ -109,12 +109,16 @@ pub(crate) async fn execute_plan(
         PreCommandPlan::Switch(plan) => execute_switch(plan, child_argv).await,
         PreCommandPlan::SyncEnvLockfile(sync) => {
             let EnvLockfileSync { config, root_dir, package_manager } = sync;
+            // The install family syncs the pin in its own pipeline, with the
+            // `--frozen-lockfile` flag layered in; every other command reaches
+            // here, where only the `frozenLockfile` setting can forbid the write.
+            let frozen_lockfile = config.frozen_lockfile.unwrap_or(false);
             config_deps::sync_package_manager_dependencies(
                 &config,
                 &root_dir,
                 &package_manager.specifier,
                 &package_manager.version,
-                false,
+                frozen_lockfile,
                 false,
             )
             .await?;
@@ -143,7 +147,7 @@ async fn execute_switch(plan: SwitchPlan, child_argv: &[OsString]) -> miette::Re
             .await?;
             (version, bin_dir)
         }
-        SwitchSource::Resolve { env_root, force_resync } => {
+        SwitchSource::Resolve { env_root, frozen_lockfile, force_resync } => {
             let resolved = config_deps::resolve_engine_version(config, "pnpm", &spec)
                 .await?
                 .ok_or_else(|| miette::miette!(r#"Cannot resolve pnpm version for "{}""#, spec))?;
@@ -157,7 +161,7 @@ async fn execute_switch(plan: SwitchPlan, child_argv: &[OsString]) -> miette::Re
                         &env_root,
                         &spec,
                         &resolved.version,
-                        false,
+                        frozen_lockfile,
                         true,
                     )
                     .await?;
@@ -171,6 +175,7 @@ async fn execute_switch(plan: SwitchPlan, child_argv: &[OsString]) -> miette::Re
                 &env_root,
                 &spec,
                 &resolved.version,
+                frozen_lockfile,
                 force_resync,
             ))
             .await?;
@@ -228,7 +233,9 @@ fn pre_command_plan_from_input(
         let unmanaged_pin = switch_wanted && process_state.package_manager_switch_disabled;
         if on_fail != PmOnFail::Ignore && !unmanaged_pin {
             if switch_wanted && !process_state.executed_by_corepack {
-                if let Some(target) = switch_target(&config, &root_dir)? {
+                let frozen_lockfile =
+                    switch.frozen_lockfile.or(config.frozen_lockfile).unwrap_or(false);
+                if let Some(target) = switch_target(&config, &root_dir, frozen_lockfile)? {
                     if !version_satisfies(PNPM_VERSION, &target.spec) {
                         return Ok(Some(PreCommandPlan::Switch(SwitchPlan { config, target })));
                     }
@@ -597,6 +604,18 @@ fn syncs_env_lockfile_in_pipeline(command: &CliCommand) -> bool {
     )
 }
 
+/// `--frozen-lockfile` / `--no-frozen-lockfile` as typed on the command line.
+/// Only the install family carries the flags, and `pnpm ci` is a frozen
+/// install whether or not they were typed.
+fn frozen_lockfile_flag(command: &CliCommand) -> Option<bool> {
+    match command {
+        CliCommand::Install(args) => args.frozen_lockfile_flag(),
+        CliCommand::InstallTest(args) => args.install_args.frozen_lockfile_flag(),
+        CliCommand::Ci(_) => Some(true),
+        _ => None,
+    }
+}
+
 /// pnpm treats `--global` as an opt-out of the project's package manager
 /// and runtime pins — a global install does not belong to the project.
 fn is_global(command: &CliCommand) -> bool {
@@ -624,7 +643,11 @@ fn is_global(command: &CliCommand) -> bool {
     }
 }
 
-fn switch_target(config: &Config, root_dir: &Path) -> miette::Result<Option<SwitchTarget>> {
+fn switch_target(
+    config: &Config,
+    root_dir: &Path,
+    frozen_lockfile: bool,
+) -> miette::Result<Option<SwitchTarget>> {
     let Some(manifest) = read_manifest_json(&root_dir.join("package.json"))? else {
         return Ok(None);
     };
@@ -661,20 +684,31 @@ fn switch_target(config: &Config, root_dir: &Path) -> miette::Result<Option<Swit
         // shape.
         return Ok(Some(SwitchTarget {
             spec,
-            source: SwitchSource::Resolve { env_root: root_dir.to_path_buf(), force_resync: true },
+            source: SwitchSource::Resolve {
+                env_root: root_dir.to_path_buf(),
+                frozen_lockfile,
+                force_resync: true,
+            },
         }));
     }
 
-    let env_root = if persist_lockfile {
-        root_dir.to_path_buf()
+    // A pin that doesn't persist resolves into the global env lockfile, which
+    // is pnpm's own state rather than the project's — a frozen lockfile has
+    // nothing to say about it.
+    let (env_root, frozen_lockfile) = if persist_lockfile {
+        (root_dir.to_path_buf(), frozen_lockfile)
     } else {
-        config.global_pkg_dir.clone().ok_or_else(|| {
+        let global_pkg_dir = config.global_pkg_dir.clone().ok_or_else(|| {
             miette::miette!(
                 r#"Unable to find the global packages directory. Run "pnpm setup" to create it automatically, or set the global-bin-dir setting, or the PNPM_HOME env variable."#,
             )
-        })?
+        })?;
+        (global_pkg_dir, false)
     };
-    Ok(Some(SwitchTarget { spec, source: SwitchSource::Resolve { env_root, force_resync: false } }))
+    Ok(Some(SwitchTarget {
+        spec,
+        source: SwitchSource::Resolve { env_root, frozen_lockfile, force_resync: false },
+    }))
 }
 
 fn locked_package_manager_version(
@@ -935,6 +969,10 @@ enum SwitchSource {
     },
     Resolve {
         env_root: PathBuf,
+        /// Refuse to record the resolution instead of writing it. Only set
+        /// when `env_root` is the project itself: a global env lockfile is
+        /// not what `--frozen-lockfile` freezes.
+        frozen_lockfile: bool,
         /// Discard the recorded `packageManagerDependencies` and re-resolve
         /// them even when they look up to date — set when the recorded
         /// entries failed the bootstrap validation, so the resync heals the
@@ -947,6 +985,9 @@ struct SwitchInput {
     dir: PathBuf,
     npmrc_auth_file: Option<PathBuf>,
     command: Option<String>,
+    /// `--frozen-lockfile` / `--no-frozen-lockfile` as typed on the command
+    /// line. `None` leaves the `frozenLockfile` setting to answer.
+    frozen_lockfile: Option<bool>,
 }
 
 impl SwitchInput {
@@ -955,12 +996,18 @@ impl SwitchInput {
             dir: args.dir.clone(),
             npmrc_auth_file: args.npmrc_auth_file.clone(),
             command: Some(command_name(&args.command).to_string()),
+            frozen_lockfile: frozen_lockfile_flag(&args.command),
         }
     }
 
     fn from_version_argv(argv: &[OsString]) -> Self {
         let global_options = ArgTable::top_level(super::grammar());
-        let mut input = Self { dir: PathBuf::from("."), npmrc_auth_file: None, command: None };
+        let mut input = Self {
+            dir: PathBuf::from("."),
+            npmrc_auth_file: None,
+            command: None,
+            frozen_lockfile: None,
+        };
         let mut index = 1;
         while index < argv.len() {
             let Some(token) = argv[index].to_str() else {

--- a/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
@@ -1,8 +1,10 @@
 use super::{
-    KeyIssueReporting, PackageManagerToSync, PreCommandInput, PreCommandPlan, SwitchInput,
-    SwitchProcessState, SwitchSource, pre_command_plan_from_input, switch_target,
+    CliArgs, CliCommand, KeyIssueReporting, PackageManagerToSync, PreCommandInput, PreCommandPlan,
+    SwitchInput, SwitchProcessState, SwitchSource, frozen_lockfile_flag,
+    pre_command_plan_from_input, switch_target,
 };
-use crate::config_overrides::ConfigOverrides;
+use crate::{boolean_negations::with_boolean_negations, config_overrides::ConfigOverrides};
+use clap::{CommandFactory, FromArgMatches};
 use pnpm_config::{Config, PNPM_VERSION, PmOnFail};
 use pnpm_reporter::{Reporter, SilentReporter};
 use std::{
@@ -349,6 +351,7 @@ fn pre_command_input(dir: &Path) -> PreCommandInput {
             dir: dir.to_path_buf(),
             npmrc_auth_file: None,
             command: Some("run".to_string()),
+            frozen_lockfile: None,
         },
         global: false,
         check_runtimes: true,
@@ -399,7 +402,8 @@ snapshots:
 ",
     );
 
-    let target = switch_target(&Config::default(), root.path()).expect("target").expect("switch");
+    let target =
+        switch_target(&Config::default(), root.path(), false).expect("target").expect("switch");
 
     assert_eq!(target.spec, "^11.0.0-rc.5");
     let SwitchSource::LockedEnv { version, .. } = target.source else {
@@ -414,7 +418,8 @@ fn switch_target_accepts_peer_suffixed_package_manager_lockfile() {
     write_dev_engine_manifest(root.path(), "9.3.0");
     write_lockfile(root.path(), LOCKED_9_3_0_WITH_PEER_SUFFIX);
 
-    let target = switch_target(&Config::default(), root.path()).expect("target").expect("switch");
+    let target =
+        switch_target(&Config::default(), root.path(), false).expect("target").expect("switch");
 
     let SwitchSource::LockedEnv { version, .. } = target.source else {
         panic!("expected locked env target");
@@ -428,7 +433,8 @@ fn switch_target_accepts_v12_lockfile_without_legacy_wrapper_entry() {
     write_manifest(root.path(), r#"{"packageManager":"pnpm@99.0.0"}"#);
     write_lockfile(root.path(), LOCKED_99_0_0);
 
-    let target = switch_target(&Config::default(), root.path()).expect("target").expect("switch");
+    let target =
+        switch_target(&Config::default(), root.path(), false).expect("target").expect("switch");
 
     let SwitchSource::LockedEnv { version, .. } = target.source else {
         panic!("expected locked env target");
@@ -442,9 +448,12 @@ fn switch_target_discards_package_manager_lockfile_resolution_with_non_integrity
     write_dev_engine_manifest(root.path(), "9.3.0");
     write_lockfile(root.path(), LOCKED_9_3_0_WITH_TARBALL_RESOLUTION);
 
-    let target = switch_target(&Config::default(), root.path()).expect("target").expect("switch");
+    let target =
+        switch_target(&Config::default(), root.path(), false).expect("target").expect("switch");
 
-    let SwitchSource::Resolve { env_root, force_resync: true } = target.source else {
+    let SwitchSource::Resolve { env_root, frozen_lockfile: false, force_resync: true } =
+        target.source
+    else {
         panic!("expected a forced re-resolve, got {:?}", target.source);
     };
     assert_eq!(env_root, root.path());
@@ -456,9 +465,12 @@ fn switch_target_discards_package_manager_lockfile_dependency_with_non_registry_
     write_dev_engine_manifest(root.path(), "9.3.0");
     write_lockfile(root.path(), LOCKED_9_3_0_WITH_FILE_DEP_PATH);
 
-    let target = switch_target(&Config::default(), root.path()).expect("target").expect("switch");
+    let target =
+        switch_target(&Config::default(), root.path(), false).expect("target").expect("switch");
 
-    let SwitchSource::Resolve { env_root, force_resync: true } = target.source else {
+    let SwitchSource::Resolve { env_root, frozen_lockfile: false, force_resync: true } =
+        target.source
+    else {
         panic!("expected a forced re-resolve, got {:?}", target.source);
     };
     assert_eq!(env_root, root.path());
@@ -470,10 +482,13 @@ fn switch_target_reresolves_when_locked_version_no_longer_satisfies_range() {
     write_dev_engine_manifest(root.path(), ">=9.1.2 <9.1.4");
     write_lockfile(root.path(), LOCKED_9_1_1);
 
-    let target = switch_target(&Config::default(), root.path()).expect("target").expect("switch");
+    let target =
+        switch_target(&Config::default(), root.path(), false).expect("target").expect("switch");
 
     assert_eq!(target.spec, ">=9.1.2 <9.1.4");
-    let SwitchSource::Resolve { env_root, force_resync: false } = target.source else {
+    let SwitchSource::Resolve { env_root, frozen_lockfile: false, force_resync: false } =
+        target.source
+    else {
         panic!("expected resolve target");
     };
     assert_eq!(env_root, root.path());
@@ -488,11 +503,14 @@ fn switch_target_uses_global_env_for_legacy_package_manager_field() {
     let target = switch_target(
         &Config { global_pkg_dir: Some(global_pkg_dir.clone()), ..Config::default() },
         root.path(),
+        false,
     )
     .expect("target")
     .expect("switch");
 
-    let SwitchSource::Resolve { env_root, force_resync: false } = target.source else {
+    let SwitchSource::Resolve { env_root, frozen_lockfile: false, force_resync: false } =
+        target.source
+    else {
         panic!("expected resolve target");
     };
     assert_eq!(target.spec, "9.3.0");
@@ -511,10 +529,50 @@ fn switch_target_respects_pm_on_fail_ignore() {
             ..Config::default()
         },
         root.path(),
+        false,
     )
     .expect("target");
 
     assert!(target.is_none(), "unexpected switch target: {target:?}");
+}
+
+#[test]
+fn switch_target_refuses_to_record_a_persisting_pin_under_frozen_lockfile() {
+    let root = TempDir::new().expect("tmp dir");
+    write_dev_engine_manifest(root.path(), ">=9.1.2 <9.1.4");
+    write_lockfile(root.path(), LOCKED_9_1_1);
+
+    let target =
+        switch_target(&Config::default(), root.path(), true).expect("target").expect("switch");
+
+    let SwitchSource::Resolve { env_root, frozen_lockfile: true, force_resync: false } =
+        target.source
+    else {
+        panic!("expected a frozen resolve target, got {:?}", target.source);
+    };
+    assert_eq!(env_root, root.path());
+}
+
+#[test]
+fn switch_target_leaves_the_global_env_writable_under_frozen_lockfile() {
+    let root = TempDir::new().expect("tmp dir");
+    let global_pkg_dir = root.path().join("pnpm-home").join("global");
+    write_manifest(root.path(), r#"{"packageManager":"pnpm@9.3.0"}"#);
+
+    let target = switch_target(
+        &Config { global_pkg_dir: Some(global_pkg_dir.clone()), ..Config::default() },
+        root.path(),
+        true,
+    )
+    .expect("target")
+    .expect("switch");
+
+    let SwitchSource::Resolve { env_root, frozen_lockfile: false, force_resync: false } =
+        target.source
+    else {
+        panic!("expected an unfrozen resolve target, got {:?}", target.source);
+    };
+    assert_eq!(env_root, global_pkg_dir);
 }
 
 #[test]
@@ -525,9 +583,31 @@ fn switch_target_does_not_switch_dev_engine_without_download() {
         r#"{"devEngines":{"packageManager":{"name":"pnpm","version":"9.3.0","onFail":"error"}}}"#,
     );
 
-    let target = switch_target(&Config::default(), root.path()).expect("target");
+    let target = switch_target(&Config::default(), root.path(), false).expect("target");
 
     assert!(target.is_none(), "unexpected switch target: {target:?}");
+}
+
+#[test]
+fn the_switch_reads_frozen_lockfile_from_the_command_line() {
+    let flag_of = |argv: &[&str]| frozen_lockfile_flag(&parse_command(argv));
+
+    assert_eq!(flag_of(&["pnpm", "install", "--frozen-lockfile"]), Some(true));
+    assert_eq!(flag_of(&["pnpm", "install", "--no-frozen-lockfile"]), Some(false));
+    assert_eq!(flag_of(&["pnpm", "install"]), None);
+    assert_eq!(flag_of(&["pnpm", "install-test", "--frozen-lockfile"]), Some(true));
+    assert_eq!(flag_of(&["pnpm", "ci"]), Some(true));
+    // Only the install family carries the flag; every other command leaves the
+    // `frozenLockfile` setting to answer on its own.
+    assert_eq!(flag_of(&["pnpm", "run", "build"]), None);
+}
+
+fn parse_command(argv: &[&str]) -> CliCommand {
+    with_boolean_negations(CliArgs::command())
+        .try_get_matches_from(argv)
+        .and_then(|matches| CliArgs::from_arg_matches(&matches))
+        .expect("parse the command line")
+        .command
 }
 
 fn write_dev_engine_manifest(root: &Path, version: &str) {

--- a/pnpm/crates/cli/src/engine_pm/install.rs
+++ b/pnpm/crates/cli/src/engine_pm/install.rs
@@ -77,7 +77,7 @@ pub(crate) async fn install_engine_to_store<Reporter: self::Reporter + 'static>(
             packages.pinned,
             spec,
             version,
-            false,
+            config.frozen_lockfile.unwrap_or(false),
             force_resync,
         )
         .await?;

--- a/pnpm/crates/cli/src/engine_pm/install.rs
+++ b/pnpm/crates/cli/src/engine_pm/install.rs
@@ -52,13 +52,16 @@ use crate::{
 /// user's bare specifier (a version, range, or dist-tag) and `version` the
 /// exact version it resolved to. `force_resync` discards recorded
 /// `packageManagerDependencies` and re-resolves them even when they look
-/// up to date.
+/// up to date. `frozen_lockfile` refuses that write instead of performing
+/// it; only a caller whose `env_root` is the project itself passes it,
+/// since a global env lockfile is not what `--frozen-lockfile` freezes.
 pub(crate) async fn install_engine_to_store<Reporter: self::Reporter + 'static>(
     config: &'static Config,
     pm: PackageManager,
     env_root: &Path,
     spec: &str,
     version: &str,
+    frozen_lockfile: bool,
     force_resync: bool,
 ) -> miette::Result<PathBuf> {
     let packages = registry_engine_packages(pm, version)?;
@@ -77,7 +80,7 @@ pub(crate) async fn install_engine_to_store<Reporter: self::Reporter + 'static>(
             packages.pinned,
             spec,
             version,
-            config.frozen_lockfile.unwrap_or(false),
+            frozen_lockfile,
             force_resync,
         )
         .await?;

--- a/pnpm/crates/cli/src/engine_pm/provision.rs
+++ b/pnpm/crates/cli/src/engine_pm/provision.rs
@@ -109,6 +109,10 @@ async fn provision_from_registry<Reporter: self::Reporter + 'static>(
         &env_root,
         version_spec,
         &resolved.version,
+        // A foreign package manager's closure is recorded in a global env
+        // lockfile under the pnpm home directory, never in the project's
+        // `pnpm-lock.yaml`, so `--frozen-lockfile` has nothing to freeze here.
+        false,
         false,
     ))
     .await?;

--- a/pnpm11/installing/env-installer/src/resolvePackageManagerIntegrities.ts
+++ b/pnpm11/installing/env-installer/src/resolvePackageManagerIntegrities.ts
@@ -1,4 +1,5 @@
 import { parseRegistryQualifiedVersion } from '@pnpm/deps.path'
+import { PnpmError } from '@pnpm/error'
 import { convertToLockfileFile, createEnvLockfile, readEnvLockfile } from '@pnpm/lockfile.fs'
 import { pruneSharedLockfile } from '@pnpm/lockfile.pruner'
 import type { EnvLockfile, LockfileObject } from '@pnpm/lockfile.types'
@@ -27,6 +28,7 @@ export interface ResolvePackageManagerIntegritiesOpts {
    * resolved pnpm integrity info. Defaults to true.
    */
   save?: boolean
+  frozenLockfile?: boolean
 }
 
 /**
@@ -81,6 +83,13 @@ export async function resolvePackageManagerIntegrities (
 
   if (isPackageManagerResolved(envLockfile, pnpmVersion)) {
     return envLockfile
+  }
+
+  if (opts.frozenLockfile) {
+    throw new PnpmError(
+      'FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE',
+      'Cannot update packageManagerDependencies with "frozen-lockfile" because the lockfile is not up to date'
+    )
   }
 
   const lockfile = await resolveWantedPnpmPackages(pnpmVersion, opts)

--- a/pnpm11/installing/env-installer/src/resolvePackageManagerIntegrities.ts
+++ b/pnpm11/installing/env-installer/src/resolvePackageManagerIntegrities.ts
@@ -28,6 +28,11 @@ export interface ResolvePackageManagerIntegritiesOpts {
    * resolved pnpm integrity info. Defaults to true.
    */
   save?: boolean
+  /**
+   * Refuse to record entries that are missing or out of date, failing the
+   * command instead. Only meaningful together with `save`: an in-memory
+   * resolution changes no lockfile, so nothing can fall out of sync with it.
+   */
   frozenLockfile?: boolean
 }
 
@@ -72,7 +77,8 @@ function packageManagerDeps (pnpmVersion: string): readonly string[] {
  * resolveManifestDependencies. When `opts.save` is true (the default) the
  * results are written to the `packageManagerDependencies` section of
  * `pnpm-lock.yaml`; when false, resolution happens purely in memory and the
- * returned `EnvLockfile` is never persisted to disk.
+ * returned `EnvLockfile` is never persisted to disk. Under
+ * `opts.frozenLockfile` a write the lockfile still needs is an error instead.
  */
 export async function resolvePackageManagerIntegrities (
   pnpmVersion: string,
@@ -85,11 +91,8 @@ export async function resolvePackageManagerIntegrities (
     return envLockfile
   }
 
-  if (opts.frozenLockfile) {
-    throw new PnpmError(
-      'FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE',
-      'Cannot update packageManagerDependencies with "frozen-lockfile" because the lockfile is not up to date'
-    )
+  if (save && opts.frozenLockfile) {
+    throw new PnpmError('FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE', 'Cannot update packageManagerDependencies with "frozen-lockfile" because the lockfile is not up to date')
   }
 
   const lockfile = await resolveWantedPnpmPackages(pnpmVersion, opts)

--- a/pnpm11/installing/env-installer/test/resolvePackageManagerIntegrities.test.ts
+++ b/pnpm11/installing/env-installer/test/resolvePackageManagerIntegrities.test.ts
@@ -118,3 +118,17 @@ function envLockfile (packageManagerDependencies: Record<string, string>): EnvLo
     snapshots: {},
   } as unknown as EnvLockfile
 }
+
+test('throws an error if the lockfile is out of sync and frozenLockfile is true', async () => {
+  await expect(
+    resolvePackageManagerIntegrities('12.0.0', {
+      envLockfile: envLockfile({ pnpm: '11.0.0' }),
+      registriesByScope: { default: 'https://mirror.example.com/' },
+      rootDir: '/repo',
+      storeController: {} as never,
+      storeDir: '/store',
+      save: false,
+      frozenLockfile: true,
+    })
+  ).rejects.toThrow('Cannot update packageManagerDependencies with "frozen-lockfile" because the lockfile is not up to date')
+})

--- a/pnpm11/installing/env-installer/test/resolvePackageManagerIntegrities.test.ts
+++ b/pnpm11/installing/env-installer/test/resolvePackageManagerIntegrities.test.ts
@@ -103,6 +103,54 @@ test('registry tarball URLs are dropped from package-manager resolutions; file:,
   })
 })
 
+test('a lockfile that pins another version is not updated under frozenLockfile', async () => {
+  await expect(
+    resolvePackageManagerIntegrities('12.0.0', {
+      envLockfile: envLockfile({ pnpm: '11.0.0' }),
+      registriesByScope: { default: 'https://mirror.example.com/' },
+      rootDir: '/repo',
+      storeController: {} as never,
+      storeDir: '/store',
+      frozenLockfile: true,
+    })
+  ).rejects.toMatchObject({
+    code: 'ERR_PNPM_FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE',
+    message: 'Cannot update packageManagerDependencies with "frozen-lockfile" because the lockfile is not up to date',
+  })
+})
+
+// A resolution that is never saved cannot take the lockfile out of sync with
+// the manifest, so `--frozen-lockfile` has nothing to refuse. This is how a
+// legacy `packageManager` pin below v12 switches versions.
+test('an in-memory resolution is performed under frozenLockfile', async () => {
+  resolveManifestDependencies.mockResolvedValueOnce({
+    lockfileVersion: '9.0',
+    importers: {
+      '.': {
+        specifiers: { pnpm: '12.0.0' },
+        dependencies: { pnpm: '12.0.0' },
+      },
+    },
+    packages: {
+      'pnpm@12.0.0': { resolution: { integrity: 'sha512-pnpm' } },
+    },
+  } as unknown as LockfileObject)
+
+  const result = await resolvePackageManagerIntegrities('12.0.0', {
+    envLockfile: envLockfile({ pnpm: '11.0.0' }),
+    registriesByScope: { default: 'https://mirror.example.com/' },
+    rootDir: '/repo',
+    storeController: {} as never,
+    storeDir: '/store',
+    save: false,
+    frozenLockfile: true,
+  })
+
+  expect(result.importers['.'].packageManagerDependencies).toEqual({
+    pnpm: { specifier: '12.0.0', version: '12.0.0' },
+  })
+})
+
 function envLockfile (packageManagerDependencies: Record<string, string>): EnvLockfile {
   return {
     lockfileVersion: '9.0',
@@ -118,17 +166,3 @@ function envLockfile (packageManagerDependencies: Record<string, string>): EnvLo
     snapshots: {},
   } as unknown as EnvLockfile
 }
-
-test('throws an error if the lockfile is out of sync and frozenLockfile is true', async () => {
-  await expect(
-    resolvePackageManagerIntegrities('12.0.0', {
-      envLockfile: envLockfile({ pnpm: '11.0.0' }),
-      registriesByScope: { default: 'https://mirror.example.com/' },
-      rootDir: '/repo',
-      storeController: {} as never,
-      storeDir: '/store',
-      save: false,
-      frozenLockfile: true,
-    })
-  ).rejects.toThrow('Cannot update packageManagerDependencies with "frozen-lockfile" because the lockfile is not up to date')
-})

--- a/pnpm11/pnpm/src/switchCliVersion.ts
+++ b/pnpm11/pnpm/src/switchCliVersion.ts
@@ -47,6 +47,7 @@ export async function switchCliVersion (config: Config, context: ConfigContext):
       storeController: storeToUse.ctrl,
       storeDir: storeToUse.dir,
       save: persistLockfile,
+      frozenLockfile: config.frozenLockfile,
     })
     freshlyResolved = true
     pmVersion = envLockfile.importers['.'].packageManagerDependencies?.['pnpm']?.version
@@ -64,6 +65,7 @@ export async function switchCliVersion (config: Config, context: ConfigContext):
       storeController: storeToUse.ctrl,
       storeDir: storeToUse.dir,
       save: persistLockfile,
+      frozenLockfile: config.frozenLockfile,
     })
     freshlyResolved = true
   }
@@ -115,6 +117,7 @@ export async function switchCliVersion (config: Config, context: ConfigContext):
         storeController: storeToUse.ctrl,
         storeDir: storeToUse.dir,
         save: persistLockfile,
+        frozenLockfile: config.frozenLockfile,
       })
       pmVersion = envLockfile.importers['.'].packageManagerDependencies?.['pnpm']?.version
       if (!pmVersion) {

--- a/pnpm11/pnpm/src/syncEnvLockfile.test.ts
+++ b/pnpm11/pnpm/src/syncEnvLockfile.test.ts
@@ -11,7 +11,7 @@ import { tempDir } from '@pnpm/prepare'
 // Simulate what the real resolvePackageManagerIntegrities does that this test
 // cares about: record the resolved pnpm version under
 // packageManagerDependencies and persist the lockfile to disk.
-const resolvePackageManagerIntegrities = jest.fn<(version: string, opts: { envLockfile?: EnvLockfile, registries?: unknown, rootDir: string, save?: boolean }) => Promise<EnvLockfile>>(
+const resolvePackageManagerIntegrities = jest.fn<(version: string, opts: { envLockfile?: EnvLockfile, registries?: unknown, rootDir: string, save?: boolean, frozenLockfile?: boolean }) => Promise<EnvLockfile>>(
   async (version, opts) => {
     const lockfile = opts.envLockfile ?? ({ lockfileVersion: '9.0', importers: { '.': { configDependencies: {} } }, packages: {}, snapshots: {} } as EnvLockfile)
     lockfile.importers['.'].packageManagerDependencies = {

--- a/pnpm11/pnpm/src/syncEnvLockfile.test.ts
+++ b/pnpm11/pnpm/src/syncEnvLockfile.test.ts
@@ -27,7 +27,12 @@ const createStoreController = jest.fn<(opts: object) => Promise<{ ctrl: { close:
   dir: '/store',
 }))
 
+// Imported before the module is mocked, so the real check runs: which packages
+// a pnpm version pins is exactly what these tests exercise.
+const { isPackageManagerResolved } = await import('@pnpm/installing.env-installer')
+
 jest.unstable_mockModule('@pnpm/installing.env-installer', () => ({
+  isPackageManagerResolved,
   resolvePackageManagerIntegrities,
 }))
 
@@ -119,6 +124,31 @@ test('no-op when lockfile already records a satisfying version', async () => {
     wantedPackageManager: { name: 'pnpm', version: packageManager.version, fromDevEngines: true },
   }))
   expect(resolvePackageManagerIntegrities).not.toHaveBeenCalled()
+})
+
+test('updates the lockfile when the recorded pnpm satisfies but a sibling entry is stale', async () => {
+  const dir = tempDir()
+  writeEnvLockfileWithStaleExeEntry(dir, packageManager.version)
+  await syncEnvLockfile(baseConfig, makeContext(dir, {
+    wantedPackageManager: { name: 'pnpm', version: packageManager.version, fromDevEngines: true },
+  }))
+  expect(resolvePackageManagerIntegrities).toHaveBeenCalledTimes(1)
+  const updated = await readEnvLockfile(dir)
+  expect(updated!.importers['.'].packageManagerDependencies?.['@pnpm/exe']).toEqual({
+    specifier: packageManager.version,
+    version: packageManager.version,
+  })
+})
+
+test('forwards frozen-lockfile to the resolver, which refuses to update the lockfile', async () => {
+  const dir = tempDir()
+  writeStaleEnvLockfile(dir, '9.0.0')
+  await syncEnvLockfile({ ...baseConfig, frozenLockfile: true }, makeContext(dir, {
+    wantedPackageManager: { name: 'pnpm', version: packageManager.version, fromDevEngines: true },
+  }))
+  expect(resolvePackageManagerIntegrities).toHaveBeenCalledWith(packageManager.version, expect.objectContaining({
+    frozenLockfile: true,
+  }))
 })
 
 test('updates the lockfile when locked version no longer satisfies wanted version', async () => {
@@ -230,6 +260,26 @@ importers:
   '.':
     configDependencies: {}
     packageManagerDependencies:
+      pnpm:
+        specifier: ${pnpmVersion}
+        version: ${pnpmVersion}
+packages: {}
+snapshots: {}
+`
+  fs.writeFileSync(path.join(dir, 'pnpm-lock.yaml'), `---\n${envYaml}\n---\n`)
+}
+
+// No pnpm version pins this entry set: `@pnpm/exe` is either not pinned at
+// all, or pinned at the same version as `pnpm`.
+function writeEnvLockfileWithStaleExeEntry (dir: string, pnpmVersion: string): void {
+  const envYaml = `lockfileVersion: '9.0'
+importers:
+  '.':
+    configDependencies: {}
+    packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: 0.0.1
+        version: 0.0.1
       pnpm:
         specifier: ${pnpmVersion}
         version: ${pnpmVersion}

--- a/pnpm11/pnpm/src/syncEnvLockfile.ts
+++ b/pnpm11/pnpm/src/syncEnvLockfile.ts
@@ -41,6 +41,7 @@ export async function syncEnvLockfile (config: Config, context: ConfigContext): 
       storeController: store.ctrl,
       storeDir: store.dir,
       save: true,
+      frozenLockfile: config.frozenLockfile,
     })
   } finally {
     await store.ctrl.close()

--- a/pnpm11/pnpm/src/syncEnvLockfile.ts
+++ b/pnpm11/pnpm/src/syncEnvLockfile.ts
@@ -1,6 +1,6 @@
 import { packageManager } from '@pnpm/cli.meta'
 import { type Config, type ConfigContext, getPackageManagerBootstrapConfig, shouldPersistLockfile } from '@pnpm/config.reader'
-import { resolvePackageManagerIntegrities } from '@pnpm/installing.env-installer'
+import { isPackageManagerResolved, resolvePackageManagerIntegrities } from '@pnpm/installing.env-installer'
 import { readEnvLockfile } from '@pnpm/lockfile.fs'
 import { createStoreController } from '@pnpm/store.connection-manager'
 import semver from 'semver'
@@ -15,8 +15,9 @@ import semver from 'semver'
  * The currently running pnpm version has already been verified by
  * checkPackageManager to satisfy the wanted range, so recording it is safe.
  *
- * No-op when the project does not pin a pnpm version or when the recorded
- * version still satisfies the wanted range.
+ * No-op when the project does not pin a pnpm version, or when the recorded
+ * entry both satisfies the wanted range and pins every package that version
+ * is installed from.
  */
 export async function syncEnvLockfile (config: Config, context: ConfigContext): Promise<void> {
   const pm = context.wantedPackageManager
@@ -27,15 +28,19 @@ export async function syncEnvLockfile (config: Config, context: ConfigContext): 
   // checkPackageManager has already surfaced the mismatch to the user.
   if (!semver.satisfies(packageManager.version, pm.version, { includePrerelease: true })) return
 
-  const envLockfile = await readEnvLockfile(context.rootProjectManifestDir)
+  const envLockfile = await readEnvLockfile(context.rootProjectManifestDir) ?? undefined
   const lockedVersion = envLockfile?.importers['.'].packageManagerDependencies?.['pnpm']?.version
-  if (lockedVersion != null && semver.satisfies(lockedVersion, pm.version, { includePrerelease: true })) return
+  if (
+    lockedVersion != null &&
+    semver.satisfies(lockedVersion, pm.version, { includePrerelease: true }) &&
+    isPackageManagerResolved(envLockfile, lockedVersion)
+  ) return
 
   const packageManagerConfig = getPackageManagerBootstrapConfig(config)
   const store = await createStoreController({ ...config, ...context, ...packageManagerConfig })
   try {
     await resolvePackageManagerIntegrities(packageManager.version, {
-      envLockfile: envLockfile ?? undefined,
+      envLockfile,
       registriesByScope: packageManagerConfig.registriesByScope,
       rootDir: context.rootProjectManifestDir,
       storeController: store.ctrl,

--- a/pnpm11/pnpm/test/switchingVersions.test.ts
+++ b/pnpm11/pnpm/test/switchingVersions.test.ts
@@ -194,6 +194,43 @@ test('devEngines.packageManager re-resolves when locked version no longer satisf
   expect(secondRun.stdout.toString()).toContain('Version 9.1.3')
 })
 
+// https://github.com/pnpm/pnpm/issues/14009: a frozen install used to record
+// the bumped pin and carry on, hiding a lockfile that no longer matched the
+// manifest from every CI job that relies on the flag.
+test('devEngines.packageManager is not re-resolved under --frozen-lockfile', async () => {
+  prepare()
+  const pnpmHome = path.resolve('pnpm')
+  const env = { PNPM_HOME: pnpmHome }
+
+  writeJsonFileSync('package.json', {
+    devEngines: {
+      packageManager: {
+        name: 'pnpm',
+        version: '>=9.1.0 <9.1.2',
+        onFail: 'download',
+      },
+    },
+  })
+  expect(execPnpmSync(['help'], { env }).stdout.toString()).toContain('Version 9.1.1')
+  const lockfile = fs.readFileSync('pnpm-lock.yaml', 'utf8')
+
+  writeJsonFileSync('package.json', {
+    devEngines: {
+      packageManager: {
+        name: 'pnpm',
+        version: '>=9.1.2 <9.1.4',
+        onFail: 'download',
+      },
+    },
+  })
+
+  const { status, stderr } = execPnpmSync(['install', '--frozen-lockfile'], { env })
+
+  expect(status).toBe(1)
+  expect(stderr.toString()).toContain('Cannot update packageManagerDependencies with "frozen-lockfile" because the lockfile is not up to date')
+  expect(fs.readFileSync('pnpm-lock.yaml', 'utf8')).toBe(lockfile)
+})
+
 test('devEngines.packageManager without onFail=download does not switch version', async () => {
   prepare()
   const pnpmHome = path.resolve('pnpm')


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

A frozen install is not allowed to rewrite the `packageManagerDependencies` block of `pnpm-lock.yaml`. When the pnpm version pinned by `devEngines.packageManager` (or by `packageManager`) is missing from the lockfile or no longer matches it, `--frozen-lockfile` now fails with `ERR_PNPM_FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE` (`FrozenLockfileOutdated` in the Rust port) instead of resolving the version and saving it — the same way every other out-of-sync importer entry already behaves.

The check applies only where a lockfile is actually written:

- An in-memory resolution (`save: false`) is untouched. That is how a legacy `packageManager` pin below v12 switches versions; refusing it would break every command in such a project under `--frozen-lockfile`.
- A global package-manager env lockfile is untouched. Those live under the pnpm home directory — for a foreign package manager, or a pnpm pin that does not persist — and are pnpm's own state rather than the project's, so the flag has nothing to freeze there.

Fixes pnpm/pnpm#14009

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
With a pnpm version pinned in `devEngines.packageManager` (or the `packageManager` field), running `pnpm install --frozen-lockfile` when the locked version was out of sync or missing would silently resolve the version and write the updated `packageManagerDependencies` to `pnpm-lock.yaml`. The install then proceeded on a lockfile that no longer matched the manifest, so a pin bumped without regenerating the lockfile passed CI unnoticed.

`resolvePackageManagerIntegrities` now throws `FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE` when it would have to record entries under a frozen lockfile, and `switchCliVersion` and `syncEnvLockfile` pass the active `frozenLockfile` configuration into it. The throw is gated on `save`: a resolution that is never persisted cannot take the lockfile out of sync with the manifest, and that path is how a legacy `packageManager` pin below v12 switches versions.

`syncEnvLockfile` also gates its early return on `isPackageManagerResolved`, so an entry that satisfies the wanted range while pinning the wrong set of packages is re-resolved instead of returning before the frozen check. pacquet's `env_lockfile_sync` already did this.

On the Rust side, `--frozen-lockfile` is an `InstallArgs` flag that is never folded back into `Config`, so reading `config.frozen_lockfile` in the engine installer would have seen only the `frozenLockfile` setting. The parsed flag is threaded from the pre-command switch (`frozen_lockfile_flag`, layered over the setting) through `switch_target` into `SwitchSource::Resolve`, and `install_engine_to_store` takes it as a parameter. `switch_target` computes it next to `env_root` and passes `false` whenever that root is a global env lockfile, which `provision_from_registry` does as well.

The CI-implicit frozen default (`frozenLockfileIfExists`, and the Rust equivalent in `InstallArgs::run_inner`) is derived after the pre-command block has already run, so it is out of scope here and remains tracked separately.

Adds an end-to-end regression test for the reported case, unit tests for the saved and in-memory frozen paths and for the completeness gate, and Rust tests for the flag plumbing and for leaving global env roots writable.

Fixes pnpm/pnpm#14009
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789740887&installation_model_id=426870&pr_number=14013&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14013&signature=fc69c9329031b372a5e1243d2901bbdadf34b0d0c5944064f270f510227bd072"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Frozen-lockfile mode now fails when package-manager dependencies are missing or out of sync in the lockfile.
  - Prevents unintended lockfile updates when resolving package-manager versions under frozen-lockfile mode.
  - Frozen-lockfile settings are consistently honored across install, CI, and package-manager switching commands.

- **Tests**
  - Added regression coverage for outdated environment lockfiles and unchanged lockfile contents after failure.

- **Documentation**
  - Added release notes describing the updated frozen-lockfile behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
