### PR TITLE
fix(deps-resolver): copy a resolved manifest before writing to it

### DIFF
--- a/.changeset/fix-lockfile-peer-dependencies-rewrite.md
+++ b/.changeset/fix-lockfile-peer-dependencies-rewrite.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/resolving.npm-resolver": patch
+"@pnpm/installing.deps-resolver": patch
+"pnpm": patch
+---
+
+Fixed an issue where lockfile `packages[].peerDependencies` were rewritten from declared ranges to synthesized exact lower-bound versions on re-resolution when `autoInstallPeers` and `minimumReleaseAge` were active [#13988](https://github.com/pnpm/pnpm/issues/13988).

--- a/.changeset/fix-lockfile-peer-dependencies-rewrite.md
+++ b/.changeset/fix-lockfile-peer-dependencies-rewrite.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-Fixed manifest edits leaking between dependencies that resolve to the same package version. A `readPackage` hook that edits its argument in place, or a deprecation notice carried over from the lockfile, was written into the manifest the resolver caches and then reused for the next dependent [#13988](https://github.com/pnpm/pnpm/issues/13988).
+A `readPackage` hook that edits its argument in place no longer changes what a later install in the same command resolves. A `deprecated` notice read from the lockfile no longer carries over to another install either [#13988](https://github.com/pnpm/pnpm/issues/13988).

--- a/.changeset/fix-lockfile-peer-dependencies-rewrite.md
+++ b/.changeset/fix-lockfile-peer-dependencies-rewrite.md
@@ -1,7 +1,6 @@
 ---
-"@pnpm/resolving.npm-resolver": patch
 "@pnpm/installing.deps-resolver": patch
 "pnpm": patch
 ---
 
-Fixed an issue where lockfile `packages[].peerDependencies` were rewritten from declared ranges to synthesized exact lower-bound versions on re-resolution when `autoInstallPeers` and `minimumReleaseAge` were active [#13988](https://github.com/pnpm/pnpm/issues/13988).
+Fixed manifest edits leaking between dependencies that resolve to the same package version. A `readPackage` hook that edits its argument in place, or a deprecation notice carried over from the lockfile, was written into the manifest the resolver caches and then reused for the next dependent [#13988](https://github.com/pnpm/pnpm/issues/13988).

--- a/pnpm11/installing/deps-installer/test/install/autoInstallPeers.ts
+++ b/pnpm11/installing/deps-installer/test/install/autoInstallPeers.ts
@@ -827,3 +827,26 @@ test('a root dependency does not override the peers provided inside a self-conta
   // The root keeps its own explicitly declared version.
   expect(lockfile.importers['.'].dependencies?.['@pnpm.e2e/closure-peer-x']?.version).toBe('2.0.0')
 })
+
+test('preserve original declared peerDependencies range in lockfile when autoInstallPeers and minimumReleaseAge are enabled', async () => {
+  await addDistTag({ package: '@pnpm.e2e/peer-a', version: '1.0.0', distTag: 'latest' })
+  const project = prepareEmpty()
+  await install({
+    name: 'root',
+    version: '0.0.0',
+    private: true,
+    dependencies: {
+      '@pnpm.e2e/abc-optional-peers': '1.0.0',
+      '@pnpm.e2e/peer-of-itself': '1.0.0',
+    },
+  }, testDefaults({
+    autoInstallPeers: true,
+    minimumReleaseAge: 1440,
+  }))
+  const lockfile = project.readLockfile()
+  const pkgSnapshot = lockfile.snapshots['@pnpm.e2e/abc-optional-peers@1.0.0(@pnpm.e2e/peer-a@1.0.0)'] as unknown as Record<string, Record<string, string>>
+  if (pkgSnapshot?.peerDependencies?.['@pnpm.e2e/peer-a']) {
+    expect(pkgSnapshot.peerDependencies['@pnpm.e2e/peer-a']).not.toMatch(/^\d+\.\d+\.\d+$/)
+  }
+})
+

--- a/pnpm11/installing/deps-installer/test/install/autoInstallPeers.ts
+++ b/pnpm11/installing/deps-installer/test/install/autoInstallPeers.ts
@@ -828,25 +828,47 @@ test('a root dependency does not override the peers provided inside a self-conta
   expect(lockfile.importers['.'].dependencies?.['@pnpm.e2e/closure-peer-x']?.version).toBe('2.0.0')
 })
 
-test('preserve original declared peerDependencies range in lockfile when autoInstallPeers and minimumReleaseAge are enabled', async () => {
+test('a package entry keeps the declared peerDependencies ranges when the graph is re-resolved with minimumReleaseAge', async () => {
   await addDistTag({ package: '@pnpm.e2e/peer-a', version: '1.0.0', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/peer-c', version: '1.0.1', distTag: 'latest' })
   const project = prepareEmpty()
-  await install({
+  // pkg-with-events-and-peers declares `@pnpm.e2e/peer-c` as `*`, while
+  // abc-optional-peers declares the same peer as `^1.0.0`. Both peers are
+  // auto-installed, so each entry must still record the range its own manifest
+  // declares, not a version synthesized from the other declarer.
+  const manifest = (fooVersion: string): PackageManifest => ({
     name: 'root',
     version: '0.0.0',
-    private: true,
     dependencies: {
       '@pnpm.e2e/abc-optional-peers': '1.0.0',
-      '@pnpm.e2e/peer-of-itself': '1.0.0',
+      '@pnpm.e2e/foo': fooVersion,
+      '@pnpm.e2e/pkg-with-events-and-peers': '1.0.0',
     },
-  }, testDefaults({
-    autoInstallPeers: true,
-    minimumReleaseAge: 1440,
-  }))
-  const lockfile = project.readLockfile()
-  const pkgSnapshot = lockfile.snapshots['@pnpm.e2e/abc-optional-peers@1.0.0(@pnpm.e2e/peer-a@1.0.0)'] as unknown as Record<string, Record<string, string>>
-  if (pkgSnapshot?.peerDependencies?.['@pnpm.e2e/peer-a']) {
-    expect(pkgSnapshot.peerDependencies['@pnpm.e2e/peer-a']).not.toMatch(/^\d+\.\d+\.\d+$/)
-  }
-})
+  })
+  const opts = () => testDefaults({ autoInstallPeers: true, minimumReleaseAge: 1440 })
+  await install(manifest('100.0.0'), opts())
 
+  const declaredPeerRanges = () => {
+    const { packages } = project.readLockfile()
+    return {
+      abcOptionalPeers: packages['@pnpm.e2e/abc-optional-peers@1.0.0'].peerDependencies,
+      pkgWithEventsAndPeers: packages['@pnpm.e2e/pkg-with-events-and-peers@1.0.0'].peerDependencies,
+    }
+  }
+  const expectedPeerRanges = {
+    abcOptionalPeers: {
+      '@pnpm.e2e/peer-a': '^1.0.0',
+      '@pnpm.e2e/peer-b': '^1.0.0',
+      '@pnpm.e2e/peer-c': '^1.0.0',
+    },
+    pkgWithEventsAndPeers: {
+      '@pnpm.e2e/peer-c': '*',
+    },
+  }
+  expect(declaredPeerRanges()).toStrictEqual(expectedPeerRanges)
+
+  // Bumping an unrelated dependency re-resolves the graph against the lockfile
+  // written above.
+  await install(manifest('100.1.0'), opts())
+  expect(declaredPeerRanges()).toStrictEqual(expectedPeerRanges)
+})

--- a/pnpm11/installing/deps-installer/test/install/hooks.ts
+++ b/pnpm11/installing/deps-installer/test/install/hooks.ts
@@ -217,3 +217,30 @@ test('readPackage hooks array', async () => {
 
   project.storeHas('@pnpm.e2e/dep-of-pkg-with-1-dep', '100.0.0')
 })
+
+test('a readPackage hook that edits a manifest in place does not affect a later install without the hook', async () => {
+  // w/o the hook, 100.1.0 would be installed
+  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.1.0', distTag: 'latest' })
+
+  function readPackageHook (manifest: PackageManifest) {
+    if (manifest.name === '@pnpm.e2e/pkg-with-1-dep') {
+      manifest.dependencies!['@pnpm.e2e/dep-of-pkg-with-1-dep'] = '100.0.0'
+    }
+    return manifest
+  }
+
+  // Both installs share one store controller, so they share the resolver's
+  // metadata cache and the manifest objects it holds.
+  const opts = testDefaults()
+
+  const withHook = prepareEmpty()
+  await addDependenciesToPackage({}, ['@pnpm.e2e/pkg-with-1-dep'], {
+    ...opts,
+    hooks: { readPackage: [readPackageHook] },
+  })
+  expect(Object.keys(withHook.readLockfile().snapshots)).toContain('@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0')
+
+  const withoutHook = prepareEmpty()
+  await addDependenciesToPackage({}, ['@pnpm.e2e/pkg-with-1-dep'], opts)
+  expect(Object.keys(withoutHook.readLockfile().snapshots)).toContain('@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0')
+})

--- a/pnpm11/installing/deps-installer/test/install/hooks.ts
+++ b/pnpm11/installing/deps-installer/test/install/hooks.ts
@@ -11,7 +11,7 @@ import {
 import type { LockfileObject } from '@pnpm/lockfile.fs'
 import { prepareEmpty, preparePackages } from '@pnpm/prepare'
 import { addDistTag } from '@pnpm/testing.registry-mock'
-import type { ProjectId, ProjectRootDir } from '@pnpm/types'
+import type { ProjectId, ProjectRootDir, ReadPackageHook } from '@pnpm/types'
 import { readYamlFileSync } from 'read-yaml-file'
 
 import { testDefaults } from '../utils/index.js'
@@ -222,7 +222,7 @@ test('a readPackage hook that edits a manifest in place does not affect a later 
   // w/o the hook, 100.1.0 would be installed
   await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.1.0', distTag: 'latest' })
 
-  function readPackageHook (manifest: PackageManifest) {
+  const readPackageHook: ReadPackageHook = (manifest) => {
     if (manifest.name === '@pnpm.e2e/pkg-with-1-dep') {
       manifest.dependencies!['@pnpm.e2e/dep-of-pkg-with-1-dep'] = '100.0.0'
     }

--- a/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
+++ b/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
@@ -463,6 +463,7 @@ export async function resolveRootDependencies (
 
         const resolveDependenciesResult = await resolveDependencies(ctx, preferredVersions, wantedDependencies, {
           ...options,
+          pickLowestVersion: false,
           parentPkgAliases,
           publishedBy,
           updateToLatest: false,
@@ -484,6 +485,7 @@ export async function resolveRootDependencies (
           const wantedDependencies = getNonDevWantedDependencies({ optionalDependencies })
           const resolveDependenciesResult = await resolveDependencies(ctx, preferredVersions, wantedDependencies, {
             ...options,
+            pickLowestVersion: false,
             parentPkgAliases,
             publishedBy,
             updateToLatest: false,

--- a/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
+++ b/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
@@ -44,7 +44,7 @@ import type {
   StoreController,
 } from '@pnpm/store.controller-types'
 import { lexCompare } from '@pnpm/text.ordinal-comparator'
-import type { AllowBuild, AllowedDeprecatedVersions, DepPath, PackageManifest, PackageVersionPolicy, PkgIdWithPatchHash, RangeSpecStyle, ReadPackageHook, RegistryContext, SupportedArchitectures, TrustPolicy } from '@pnpm/types'
+import { type AllowBuild, type AllowedDeprecatedVersions, DEPENDENCIES_OR_PEER_FIELDS, type DepPath, type PackageManifest, type PackageVersionPolicy, type PkgIdWithPatchHash, type RangeSpecStyle, type ReadPackageHook, type RegistryContext, type SupportedArchitectures, type TrustPolicy } from '@pnpm/types'
 import normalizePath from 'normalize-path'
 import pDefer from 'p-defer'
 import { pathExists } from 'path-exists'
@@ -463,7 +463,6 @@ export async function resolveRootDependencies (
 
         const resolveDependenciesResult = await resolveDependencies(ctx, preferredVersions, wantedDependencies, {
           ...options,
-          pickLowestVersion: false,
           parentPkgAliases,
           publishedBy,
           updateToLatest: false,
@@ -485,7 +484,6 @@ export async function resolveRootDependencies (
           const wantedDependencies = getNonDevWantedDependencies({ optionalDependencies })
           const resolveDependenciesResult = await resolveDependencies(ctx, preferredVersions, wantedDependencies, {
             ...options,
-            pickLowestVersion: false,
             parentPkgAliases,
             publishedBy,
             updateToLatest: false,
@@ -2092,10 +2090,7 @@ async function resolveDependency (
 
     let prepare!: boolean
     let hasBin!: boolean
-    let pkg: PackageManifest = getManifestFromResponse(pkgResponse, wantedDependency, currentPkg)
-    if (!pkg.dependencies) {
-      pkg.dependencies = {}
-    }
+    let pkg: PackageManifest = copyResolvedManifest(getManifestFromResponse(pkgResponse, wantedDependency, currentPkg))
     if (ctx.readPackageHook != null) {
       pkg = await ctx.readPackageHook(pkg)
     }
@@ -2375,6 +2370,31 @@ export function getManifestFromResponse (
     name: wantedDependency.alias ? wantedDependency.alias : wantedDependency.bareSpecifier.split('/').pop()!,
     version: '0.0.0',
   }
+}
+
+/**
+ * A resolved manifest is the object the resolver's metadata cache holds, so
+ * every dependency that resolves to the same package version gets the same
+ * object. Resolving a dependency writes to the manifest it is given: the
+ * read-package hook rewrites dependency fields, a deprecation notice is carried
+ * over from the lockfile, and an `engines.runtime` entry becomes a dependency.
+ * Copying the fields those writes reach keeps one dependency's resolution from
+ * deciding what the next one sees.
+ *
+ * `dependencies` is always present on the copy, since both the peer handling
+ * and `convertEnginesRuntimeToDependencies` write into it.
+ */
+function copyResolvedManifest (manifest: PackageManifest): PackageManifest {
+  const copy: PackageManifest = { ...manifest, dependencies: { ...manifest.dependencies } }
+  for (const depsField of DEPENDENCIES_OR_PEER_FIELDS) {
+    if (manifest[depsField] != null) {
+      copy[depsField] = { ...manifest[depsField] }
+    }
+  }
+  if (manifest.peerDependenciesMeta != null) {
+    copy.peerDependenciesMeta = { ...manifest.peerDependenciesMeta }
+  }
+  return copy
 }
 
 // The materialized peer set is used (not the manifest's raw peerDependencies)

--- a/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
+++ b/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
@@ -2373,16 +2373,18 @@ export function getManifestFromResponse (
 }
 
 /**
- * A resolved manifest is the object the resolver's metadata cache holds, so
- * every dependency that resolves to the same package version gets the same
- * object. Resolving a dependency writes to the manifest it is given: the
- * read-package hook rewrites dependency fields, a deprecation notice is carried
- * over from the lockfile, and an `engines.runtime` entry becomes a dependency.
- * Copying the fields those writes reach keeps one dependency's resolution from
- * deciding what the next one sees.
+ * Returns a manifest that resolution may write to freely, leaving `manifest`
+ * untouched down to each `peerDependenciesMeta` entry. Every other field is
+ * shared with `manifest` and must stay read-only.
  *
- * `dependencies` is always present on the copy, since both the peer handling
- * and `convertEnginesRuntimeToDependencies` write into it.
+ * The resolver returns the manifest object its metadata cache holds, so every
+ * dependency that resolves to the same package version is handed the same
+ * object. What resolution writes to it decides the isolation this owes:
+ * dependency and peer records are rewritten by the read-package hook, a
+ * `deprecated` notice is carried over from the lockfile, and an
+ * `engines.runtime` entry becomes a dependency. `dependencies` is present on
+ * the result whether or not the manifest declares it, since the peer handling
+ * and `convertEnginesRuntimeToDependencies` both write into it.
  */
 function copyResolvedManifest (manifest: PackageManifest): PackageManifest {
   const copy: PackageManifest = { ...manifest, dependencies: { ...manifest.dependencies } }
@@ -2392,7 +2394,10 @@ function copyResolvedManifest (manifest: PackageManifest): PackageManifest {
     }
   }
   if (manifest.peerDependenciesMeta != null) {
-    copy.peerDependenciesMeta = { ...manifest.peerDependenciesMeta }
+    copy.peerDependenciesMeta = {}
+    for (const [peerName, peerMeta] of Object.entries(manifest.peerDependenciesMeta)) {
+      copy.peerDependenciesMeta[peerName] = { ...peerMeta }
+    }
   }
   return copy
 }

--- a/pnpm11/resolving/npm-resolver/src/index.ts
+++ b/pnpm11/resolving/npm-resolver/src/index.ts
@@ -793,7 +793,7 @@ async function resolveNpm (
   return {
     id,
     latest,
-    manifest: selectedPackage,
+    manifest: clone(selectedPackage),
     resolution,
     resolvedVia: 'npm-registry',
     publishedAt,
@@ -972,7 +972,7 @@ async function pickFromSimpleRegistry (
   return {
     id: `${pickedPackage.name}@${pickedPackage.version}` as PkgResolutionId,
     latest: latestAllowedByPolicy(meta, opts),
-    manifest: selectedPackage,
+    manifest: clone(selectedPackage),
     resolution,
     publishedAt,
     policyViolation: detectMinReleaseAgeViolation({

--- a/pnpm11/resolving/npm-resolver/src/index.ts
+++ b/pnpm11/resolving/npm-resolver/src/index.ts
@@ -793,7 +793,7 @@ async function resolveNpm (
   return {
     id,
     latest,
-    manifest: clone(selectedPackage),
+    manifest: selectedPackage,
     resolution,
     resolvedVia: 'npm-registry',
     publishedAt,
@@ -972,7 +972,7 @@ async function pickFromSimpleRegistry (
   return {
     id: `${pickedPackage.name}@${pickedPackage.version}` as PkgResolutionId,
     latest: latestAllowedByPolicy(meta, opts),
-    manifest: clone(selectedPackage),
+    manifest: selectedPackage,
     resolution,
     publishedAt,
     policyViolation: detectMinReleaseAgeViolation({


### PR DESCRIPTION
## Summary

The npm resolver returns the manifest object its metadata cache holds, so every dependency that resolves to the same package version is handed the same object. `resolveDependency` then writes to it: it defaults `dependencies`, the read-package hook rewrites dependency fields, a `deprecated` notice is carried over from the lockfile, and an `engines.runtime` entry is turned into a dependency. Those writes outlive the resolution that made them and reach the next install that resolves the same version.

This PR copies the manifest's dependency and peer fields, each `peerDependenciesMeta` entry included, before any of that runs.

The leak is observable. Two installs that share a store controller share the resolver's metadata cache. The new test in `test/install/hooks.ts` runs the first install with a `readPackage` hook that pins a transitive dependency by editing the manifest in place, then runs a second install with no hook at all. On `main` the second install inherits the pin; with this change it resolves the version its own range picks.

Related to pnpm/pnpm#13988. The exact symptom reported there, a `packages[].peerDependencies` range rewritten to an exact version on re-resolution, could not be reproduced from the conditions the issue describes, so this does not claim to close it. The reproduction attempt used a package declaring a peer as `*` alongside a second declarer of `^1.0.0`, both peers auto-installed, `minimumReleaseAge` active, over a fresh install and a re-resolution triggered by an unrelated dependency bump. The declared ranges survived on `main` as well, and `test/install/autoInstallPeers.ts` now pins that contract.

### Changes from the first revision of this PR

Two changes were dropped after review:

- The deep clone of every resolved registry manifest in `npm-resolver`. It addressed the same aliasing hazard, but `ramda.clone` measures ~37us per manifest against ~0.1us for the targeted field copy, on a path that runs once per resolved dependency edge. The copy now happens where the writes happen, which is also the pattern `createVersionsOverrider` already uses against this hazard.
- `pickLowestVersion: false` on the two hoisted-peer resolutions. `ImporterToResolveOptions` never carries that flag, so both spreads already yielded `undefined`. Auto-installed peers resolve to their highest match today; verified against `highest`, `time-based`, and `lowest-direct`.

The regression test was rewritten. It read `lockfile.snapshots`, whose entries never carry `peerDependencies`, and guarded its single assertion behind an `if`, so it passed vacuously.

## Squash Commit Body

```text
The npm resolver returns the manifest object its metadata cache holds, so every
dependency that resolves to the same package version gets the same object.
Resolving a dependency then writes to it: `dependencies` is defaulted, the
read-package hook rewrites dependency fields, a deprecation notice is carried
over from the lockfile, and an `engines.runtime` entry becomes a dependency.
Copy the dependency and peer fields first, down to each peerDependenciesMeta
entry, so one install cannot decide what the next one resolves.

The copy is deliberately shallow and limited to the fields those writes reach.
Deep-cloning the manifest in the resolver instead costs ~37us per manifest
against ~0.1us here, on a path that runs once per resolved dependency edge.

Related to pnpm/pnpm#13988. That issue's exact symptom could not be
reproduced, so this is not claimed as its fix.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version. (v12 shares no mutable manifest
  object across resolutions, so it needs no counterpart.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

## Test results

- `@pnpm/installing.deps-resolver`: 184 passed
- `@pnpm/installing.deps-installer`: 98 suites, 1084 passed, 19 skipped
- The new hooks test fails on `main` and passes with this change

---
Reviewed and revised by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented dependency manifest changes from carrying over between packages resolving to the same version.
  * Preserved declared peer dependency ranges when updating unrelated dependencies and reusing an existing lockfile.
  * Improved consistency when package metadata is modified during resolution.

* **Tests**
  * Added regression coverage for peer dependency handling with automatic peer installation and minimum release age settings.
  * Added coverage ensuring package-specific manifest changes do not affect subsequent installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->