### PR TITLE
fix: honor minimumReleaseAgeIgnoreMissingTime in the trust check

### DIFF
--- a/.changeset/trust-check-honors-ignore-missing-time.md
+++ b/.changeset/trust-check-honors-ignore-missing-time.md
@@ -4,6 +4,8 @@
 "pacquet": patch
 ---
 
-`trustPolicy: no-downgrade` no longer aborts the install with `ERR_PNPM_MISSING_TIME` on registries that serve no per-version `time` field when `minimumReleaseAgeIgnoreMissingTime` is set. The trust check reads the same publish dates the `minimumReleaseAge` check does, so it now honors the same opt-in and skips the affected package with a warning [#12446](https://github.com/pnpm/pnpm/issues/12446). A packument that dates its other versions but not the one being installed still fails, since that is a gap in the metadata rather than a registry that omits the field.
+`trustPolicy: no-downgrade` no longer aborts the install with `ERR_PNPM_MISSING_TIME` on registries that serve no per-version `time` field when `minimumReleaseAgeIgnoreMissingTime` is set. The trust check reads the same publish dates the `minimumReleaseAge` check does, so it now honors the same opt-in and skips the affected package with a warning [#12446](https://github.com/pnpm/pnpm/issues/12446).
 
-The missing-`time` warning now names each check it is reporting on, so a package whose `minimumReleaseAge` and `trustPolicy` checks are both skipped warns about both instead of only the first.
+`minimumReleaseAgeIgnoreMissingTime` no longer lets a lockfile entry the registry does not list pass the `minimumReleaseAge` check during lockfile verification. The opt-in covers a registry that cannot date its releases; a packument that does date every version it lists is saying it never published this one, which stays a hard failure.
+
+The missing-`time` warning now names the check it is reporting on, so a package whose `minimumReleaseAge` and `trustPolicy` checks are both skipped warns about both instead of only the first.

--- a/.changeset/trust-check-honors-ignore-missing-time.md
+++ b/.changeset/trust-check-honors-ignore-missing-time.md
@@ -1,6 +1,9 @@
 ---
 "@pnpm/resolving.npm-resolver": patch
 "pnpm": patch
+"pacquet": patch
 ---
 
 `trustPolicy: no-downgrade` no longer aborts the install with `ERR_PNPM_MISSING_TIME` on registries that serve no per-version `time` field when `minimumReleaseAgeIgnoreMissingTime` is set. The trust check reads the same publish dates the `minimumReleaseAge` check does, so it now honors the same opt-in and skips the affected package with a warning [#12446](https://github.com/pnpm/pnpm/issues/12446). A packument that dates its other versions but not the one being installed still fails, since that is a gap in the metadata rather than a registry that omits the field.
+
+The missing-`time` warning now names each check it is reporting on, so a package whose `minimumReleaseAge` and `trustPolicy` checks are both skipped warns about both instead of only the first.

--- a/.changeset/trust-check-honors-ignore-missing-time.md
+++ b/.changeset/trust-check-honors-ignore-missing-time.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/resolving.npm-resolver": patch
+"pnpm": patch
+---
+
+`trustPolicy: no-downgrade` no longer aborts the install with `ERR_PNPM_MISSING_TIME` on registries that serve no per-version `time` field when `minimumReleaseAgeIgnoreMissingTime` is set. The trust check reads the same publish dates the `minimumReleaseAge` check does, so it now honors the same opt-in and skips the affected package with a warning [#12446](https://github.com/pnpm/pnpm/issues/12446). A packument that dates its other versions but not the one being installed still fails, since that is a gap in the metadata rather than a registry that omits the field.

--- a/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
@@ -46,7 +46,7 @@ use crate::{
     fetch_attestation_published_at, fetch_full_metadata_cached,
     lookup_context::{PublishedAtLookupContext, PublishedAtTimeMap, package_key, version_key},
     named_registry::{named_registry_tarball_prefixes, pick_registry_for_package},
-    pick_package::PackageMetaCache,
+    pick_package::{PackageMetaCache, SkippedTimeCheck, warn_missing_time_once},
     registry_url::to_registry_url,
     trust_checks::fail_if_trust_downgraded,
     violation_codes::{
@@ -101,7 +101,10 @@ pub struct CreateNpmResolutionVerifierOptions {
     /// `true` and the registry strips per-version `time`, the verifier
     /// passes the entry instead of failing closed. Applies to the
     /// maturity cutoff and to the trust check, which has no publish
-    /// order to walk without the field either. Default `false`.
+    /// order to walk without the field either. Scoped to a packument
+    /// with no usable `time` map: one that dates every version it lists
+    /// is saying it never published this pin, which fails closed either
+    /// way. Default `false`.
     pub ignore_missing_time_field: bool,
     /// Backs `registrySupportsTimeField`: the registry serves the
     /// per-version `time` map in abbreviated metadata (Verdaccio
@@ -617,9 +620,23 @@ impl NpmResolutionVerifier {
             Err(message) => return Some(ResolutionVerification::FetchFailed { message }),
         };
         let Some(published) = published else {
-            // No source surfaced a publish timestamp; mirror the
-            // resolver's `minimumReleaseAgeIgnoreMissingTime` opt-in.
-            if self.ignore_missing_time_field {
+            // No source surfaced a publish timestamp. What
+            // `minimumReleaseAgeIgnoreMissingTime` opts out of is a
+            // registry that cannot date its releases, so the skip is
+            // granted only when the packument carries no usable `time`
+            // map at all — the same shape the picker warns and skips on,
+            // so the verifier can't be stricter than fresh resolution. A
+            // packument that does date every version it lists is instead
+            // telling us this pin is not one of them
+            // (`Package::drop_incomplete_publish_times` leaves no partial
+            // maps for that to be ambiguous), and an unpublished
+            // or never-published pin must fail closed however the flag is
+            // set.
+            if self.ignore_missing_time_field
+                // Already awaited by the lookup above, so this is a cache hit.
+                && matches!(self.fetch_full_meta_time(registry, name).await, Ok(None))
+            {
+                warn_missing_time_once(&name.to_string(), SkippedTimeCheck::MinimumReleaseAge);
                 return None;
             }
             return Some(ResolutionVerification::Err {

--- a/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
@@ -99,7 +99,9 @@ pub struct CreateNpmResolutionVerifierOptions {
     pub minimum_release_age_exclude_patterns: Vec<String>,
     /// Backs the `minimumReleaseAgeIgnoreMissingTime` opt-in: when
     /// `true` and the registry strips per-version `time`, the verifier
-    /// passes the entry instead of failing closed. Default `false`.
+    /// passes the entry instead of failing closed. Applies to the
+    /// maturity cutoff and to the trust check, which has no publish
+    /// order to walk without the field either. Default `false`.
     pub ignore_missing_time_field: bool,
     /// Backs `registrySupportsTimeField`: the registry serves the
     /// per-version `time` map in abbreviated metadata (Verdaccio
@@ -257,14 +259,15 @@ pub fn create_npm_resolution_verifier(
     let sorted_trust_excludes = sorted_unique(&opts.trust_policy_exclude_patterns);
     let named_registries_routing = named_registries_routing_digest(&registries_by_prefix);
 
-    let policy_snapshot = build_policy_snapshot(
-        opts.minimum_release_age.unwrap_or(0),
-        &sorted_min_age_excludes,
-        opts.trust_policy,
-        &sorted_trust_excludes,
-        opts.trust_policy_ignore_after,
-        &named_registries_routing,
-    );
+    let policy_snapshot = build_policy_snapshot(&BuildPolicySnapshot {
+        minimum_release_age: opts.minimum_release_age.unwrap_or(0),
+        sorted_min_age_excludes: &sorted_min_age_excludes,
+        ignore_missing_time_field: opts.ignore_missing_time_field,
+        trust_policy: opts.trust_policy,
+        sorted_trust_excludes: &sorted_trust_excludes,
+        trust_policy_ignore_after: opts.trust_policy_ignore_after,
+        named_registries_routing: &named_registries_routing,
+    });
 
     NpmResolutionVerifier {
         minimum_release_age_minutes: opts.minimum_release_age,
@@ -385,6 +388,20 @@ impl ResolutionVerifier for NpmResolutionVerifier {
         let past_ignore_after =
             cached_policy.get("trustPolicyIgnoreAfter").and_then(JsonValue::as_u64);
         if past_ignore_after != self.trust_policy_ignore_after {
+            return false;
+        }
+
+        // Missing-time tolerance: a cached run that failed closed on an
+        // absent `time` field accepted a subset of what today's tolerant
+        // policy accepts, so it stays trustworthy. Turning the tolerance
+        // off invalidates it — entries the past run waved through are the
+        // ones today's policy exists to reject. Older records (no field)
+        // read as intolerant, which is the safe direction.
+        let past_ignore_missing_time = cached_policy
+            .get("minimumReleaseAgeIgnoreMissingTime")
+            .and_then(JsonValue::as_bool)
+            .unwrap_or(false);
+        if past_ignore_missing_time && !self.ignore_missing_time_field {
             return false;
         }
 
@@ -650,6 +667,7 @@ impl NpmResolutionVerifier {
             trust_policy_exclude: self.trust_policy_exclude.as_ref(),
             trust_policy_ignore_after_minutes: self.trust_policy_ignore_after,
             now: self.now,
+            ignore_missing_time_field: self.ignore_missing_time_field,
         };
         match fail_if_trust_downgraded(&meta, version, &trust_opts) {
             Ok(()) => None,
@@ -1158,14 +1176,28 @@ fn named_registries_routing_digest(registries_by_prefix: &HashMap<String, String
     format!("{:x}", Sha256::digest(encoded))
 }
 
-fn build_policy_snapshot(
+/// Argument bundle for [`build_policy_snapshot`].
+#[derive(Clone, Copy)]
+struct BuildPolicySnapshot<'a> {
     minimum_release_age: u64,
-    sorted_min_age_excludes: &[String],
+    sorted_min_age_excludes: &'a [String],
+    ignore_missing_time_field: bool,
     trust_policy: Option<TrustPolicy>,
-    sorted_trust_excludes: &[String],
+    sorted_trust_excludes: &'a [String],
     trust_policy_ignore_after: Option<u64>,
-    named_registries_routing: &str,
-) -> serde_json::Map<String, JsonValue> {
+    named_registries_routing: &'a str,
+}
+
+fn build_policy_snapshot(opts: &BuildPolicySnapshot<'_>) -> serde_json::Map<String, JsonValue> {
+    let &BuildPolicySnapshot {
+        minimum_release_age,
+        sorted_min_age_excludes,
+        ignore_missing_time_field,
+        trust_policy,
+        sorted_trust_excludes,
+        trust_policy_ignore_after,
+        named_registries_routing,
+    } = opts;
     let mut map = serde_json::Map::new();
     // Marks runs that enforced the (unconditional) tarball-URL binding so
     // `can_trust_past_check` rejects pre-rule cache records and re-verifies.
@@ -1202,6 +1234,10 @@ fn build_policy_snapshot(
             Some(value) => JsonValue::from(value),
             None => JsonValue::Null,
         },
+    );
+    map.insert(
+        "minimumReleaseAgeIgnoreMissingTime".to_string(),
+        JsonValue::Bool(ignore_missing_time_field),
     );
     map
 }

--- a/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/tests.rs
@@ -883,6 +883,42 @@ async fn min_age_missing_time_passes_when_ignored() {
     assert_eq!(result, ResolutionVerification::Ok);
 }
 
+/// The opt-in speaks for a registry that cannot date its releases, not
+/// for a pin it has never heard of: a packument that dates every version
+/// it lists is saying this one is not among them.
+#[tokio::test]
+async fn min_age_unlisted_version_fails_when_missing_time_is_ignored() {
+    let mut server = mockito::Server::new_async().await;
+    let registry = format!("{}/", server.url());
+    let _attestation_mock = server
+        .mock("GET", "/-/npm/v1/attestations/acme@1.0.1")
+        .with_status(404)
+        .create_async()
+        .await;
+    let _full_mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_body(min_age_packument_json("acme", "1.0.0", "2025-01-01T00:00:00.000Z").to_string())
+        .create_async()
+        .await;
+    let mut opts = default_opts(&registry);
+    opts.minimum_release_age = Some(60 * 24);
+    opts.ignore_missing_time_field = true;
+    opts.now = Some(now_at("2025-12-01T00:00:00Z"));
+    let verifier = create_npm_resolution_verifier(opts);
+    let result = verifier
+        .verify(&registry_resolution(), ctx(&"acme".parse::<PkgName>().expect("parse"), "1.0.1"))
+        .await;
+    let ResolutionVerification::Err { code, reason } = result else {
+        panic!("expected Err, got {result:?}");
+    };
+    assert_eq!(code, "MINIMUM_RELEASE_AGE_VIOLATION");
+    assert!(
+        reason.contains("could not be checked against minimumReleaseAge"),
+        "got reason: {reason}",
+    );
+}
+
 #[tokio::test]
 async fn trust_downgrade_publisher_to_provenance_fails() {
     let mut server = mockito::Server::new_async().await;

--- a/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/tests.rs
@@ -929,6 +929,92 @@ async fn trust_downgrade_pass_when_no_weaker_evidence() {
     assert_eq!(result, ResolutionVerification::Ok);
 }
 
+/// Same fixture as [`trust_downgrade_packument`] minus the `time` map:
+/// a downgrade the check cannot see because it has no publish order to
+/// walk.
+fn time_free_trust_packument(name: &str) -> serde_json::Value {
+    let mut body = trust_downgrade_packument(name);
+    body.as_object_mut().expect("packument is an object").remove("time");
+    body
+}
+
+#[tokio::test]
+async fn trust_time_free_packument_fails_closed_by_default() {
+    let mut server = mockito::Server::new_async().await;
+    let registry = format!("{}/", server.url());
+    let _full_mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_body(time_free_trust_packument("acme").to_string())
+        .expect(1)
+        .create_async()
+        .await;
+    let mut opts = default_opts(&registry);
+    opts.trust_policy = Some(TrustPolicy::NoDowngrade);
+    opts.now = Some(now_at("2025-12-01T00:00:00Z"));
+    let verifier = create_npm_resolution_verifier(opts);
+    let result = verifier
+        .verify(&registry_resolution(), ctx(&"acme".parse::<PkgName>().expect("parse"), "1.1.0"))
+        .await;
+    let ResolutionVerification::Err { code, reason } = result else {
+        panic!("expected Err, got {result:?}");
+    };
+    assert_eq!(code, "TRUST_DOWNGRADE");
+    assert!(reason.contains(r#"missing the "time" field"#), "got reason: {reason}");
+}
+
+/// The same registry deficiency the age check already tolerates under
+/// this opt-in: with no `time` map there is no publish order for the
+/// downgrade walk to read, so the verifier passes the entry rather than
+/// locking the user out of a registry that never serves the field.
+#[tokio::test]
+async fn trust_time_free_packument_passes_when_ignored() {
+    let mut server = mockito::Server::new_async().await;
+    let registry = format!("{}/", server.url());
+    let _full_mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_body(time_free_trust_packument("acme").to_string())
+        .expect(1)
+        .create_async()
+        .await;
+    let mut opts = default_opts(&registry);
+    opts.trust_policy = Some(TrustPolicy::NoDowngrade);
+    opts.ignore_missing_time_field = true;
+    opts.now = Some(now_at("2025-12-01T00:00:00Z"));
+    let verifier = create_npm_resolution_verifier(opts);
+    let result = verifier
+        .verify(&registry_resolution(), ctx(&"acme".parse::<PkgName>().expect("parse"), "1.1.0"))
+        .await;
+    assert_eq!(result, ResolutionVerification::Ok);
+}
+
+#[tokio::test]
+async fn trust_downgrade_still_reported_when_ignored_and_time_is_complete() {
+    let mut server = mockito::Server::new_async().await;
+    let registry = format!("{}/", server.url());
+    let _full_mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_body(trust_downgrade_packument("acme").to_string())
+        .expect(1)
+        .create_async()
+        .await;
+    let mut opts = default_opts(&registry);
+    opts.trust_policy = Some(TrustPolicy::NoDowngrade);
+    opts.ignore_missing_time_field = true;
+    opts.now = Some(now_at("2025-12-01T00:00:00Z"));
+    let verifier = create_npm_resolution_verifier(opts);
+    let result = verifier
+        .verify(&registry_resolution(), ctx(&"acme".parse::<PkgName>().expect("parse"), "1.1.0"))
+        .await;
+    let ResolutionVerification::Err { code, reason } = result else {
+        panic!("expected Err, got {result:?}");
+    };
+    assert_eq!(code, "TRUST_DOWNGRADE");
+    assert!(reason.contains("trust downgrade"), "got reason: {reason}");
+}
+
 #[tokio::test]
 async fn verify_routes_via_named_registry_prefix() {
     let mut server = mockito::Server::new_async().await;
@@ -1027,6 +1113,43 @@ fn policy_snapshot_records_all_fields_sorted_and_deduped() {
         policy.get("trustPolicyIgnoreAfter").and_then(serde_json::Value::as_u64),
         Some(60 * 24 * 30),
     );
+    assert_eq!(
+        policy.get("minimumReleaseAgeIgnoreMissingTime").and_then(serde_json::Value::as_bool),
+        Some(false),
+    );
+}
+
+/// Dropping the missing-time tolerance invalidates a cached run that
+/// may have waved entries through on it; adding the tolerance keeps a
+/// stricter cached run trustworthy, since it accepted a subset of what
+/// today's policy accepts.
+#[test]
+fn can_trust_past_check_tracks_ignore_missing_time_field() {
+    let mut tolerant_opts = default_opts("https://registry.example/");
+    tolerant_opts.trust_policy = Some(TrustPolicy::NoDowngrade);
+    tolerant_opts.ignore_missing_time_field = true;
+    let tolerant = create_npm_resolution_verifier(tolerant_opts);
+
+    let mut strict_opts = default_opts("https://registry.example/");
+    strict_opts.trust_policy = Some(TrustPolicy::NoDowngrade);
+    let strict = create_npm_resolution_verifier(strict_opts);
+
+    assert!(!strict.can_trust_past_check(tolerant.policy()));
+    assert!(tolerant.can_trust_past_check(strict.policy()));
+}
+
+/// A record written before the field existed reads as intolerant, which
+/// is the safe direction: it cannot have passed anything today's
+/// stricter policy would reject.
+#[test]
+fn can_trust_past_check_reads_a_missing_tolerance_field_as_intolerant() {
+    let mut opts = default_opts("https://registry.example/");
+    opts.trust_policy = Some(TrustPolicy::NoDowngrade);
+    let verifier = create_npm_resolution_verifier(opts);
+
+    let mut cached = verifier.policy().clone();
+    cached.remove("minimumReleaseAgeIgnoreMissingTime");
+    assert!(verifier.can_trust_past_check(&cached));
 }
 
 /// A previously-cached run with a stricter (larger) cutoff stays

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -281,7 +281,7 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
             }
         };
 
-        fail_if_trust_downgraded_for_pick(opts, &picked)?;
+        fail_if_trust_downgraded_for_pick(opts, &picked, self.ignore_missing_time_field)?;
 
         if let Some(workspace_packages) = workspace_packages_active
             && let Some(mut result) = try_workspace_shadow(
@@ -948,6 +948,7 @@ pub(crate) fn calc_specifier_from<'a>(
 fn fail_if_trust_downgraded_for_pick(
     opts: &ResolveOptions,
     picked: &PickedFromRegistry,
+    ignore_missing_time_field: bool,
 ) -> Result<(), ResolveError> {
     if opts.trust_policy != Some(TrustPolicy::NoDowngrade) {
         return Ok(());
@@ -956,6 +957,7 @@ fn fail_if_trust_downgraded_for_pick(
         trust_policy_exclude: opts.trust_policy_exclude.as_ref(),
         trust_policy_ignore_after_minutes: opts.trust_policy_ignore_after,
         now: None,
+        ignore_missing_time_field,
     };
     fail_if_trust_downgraded(&picked.meta, &picked.version.version.to_string(), &trust_opts)
         .map_err(|err| Box::new(err) as ResolveError)

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -462,6 +462,66 @@ async fn trust_downgrade_at_resolve_time_fails_under_no_downgrade() {
     assert!(err.to_string().contains("trust downgrade"), "got {err}");
 }
 
+/// [`TRUST_DOWNGRADE_PACKAGE_BODY`] as a registry that strips the
+/// per-version `time` field serves it.
+fn trust_downgrade_body_without_time() -> String {
+    let mut body: serde_json::Value =
+        serde_json::from_str(TRUST_DOWNGRADE_PACKAGE_BODY).expect("parse fixture packument");
+    body.as_object_mut().expect("packument is an object").remove("time");
+    body.to_string()
+}
+
+#[tokio::test]
+async fn trust_check_fails_at_resolve_time_when_the_registry_serves_no_time_field() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_body(trust_downgrade_body_without_time())
+        .create_async()
+        .await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    let opts = ResolveOptions {
+        trust_policy: Some(TrustPolicy::NoDowngrade),
+        ..ResolveOptions::default()
+    };
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("^1.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let err = resolver.resolve(&wanted, &opts).await.expect_err("missing time should fail closed");
+    assert!(err.to_string().contains(r#"missing the "time" field"#), "got {err}");
+}
+
+#[tokio::test]
+async fn trust_check_skipped_at_resolve_time_when_missing_time_is_ignored() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_body(trust_downgrade_body_without_time())
+        .create_async()
+        .await;
+    let registry = format!("{}/", server.url());
+    let (mut resolver, _tempdir) = build_resolver(&registry);
+    resolver.ignore_missing_time_field = true;
+
+    let opts = ResolveOptions {
+        trust_policy: Some(TrustPolicy::NoDowngrade),
+        ..ResolveOptions::default()
+    };
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("^1.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, &opts).await.unwrap().unwrap();
+    assert_eq!(result.name_ver.as_ref().expect("name_ver").suffix.to_string(), "1.1.0");
+}
+
 #[tokio::test]
 async fn trust_downgrade_ignored_when_trust_policy_off() {
     let mut server = mockito::Server::new_async().await;

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package.rs
@@ -1182,7 +1182,7 @@ fn get_file_mtime(path: &Path) -> Option<DateTime<Utc>> {
 /// takes down. `minimumReleaseAge` and `trustPolicy` both read that one
 /// field, so a registry that strips it disables both, and each names
 /// itself in the warning it emits.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Display)]
+#[derive(Debug, Display, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum SkippedTimeCheck {
     #[display("minimumReleaseAge")]
     MinimumReleaseAge,

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package.rs
@@ -1005,7 +1005,7 @@ fn pick_matching_version_final(
         Err(PickPackageFromMetaError::MissingTime { pkg_name })
             if picker_opts.ignore_missing_time_field =>
         {
-            warn_missing_time_once(&pkg_name);
+            warn_missing_time_once(&pkg_name, SkippedTimeCheck::MinimumReleaseAge);
             let fallback = PickerOpts {
                 preferred_version_selectors: picker_opts.preferred_version_selectors,
                 published_by: None,
@@ -1178,19 +1178,39 @@ fn get_file_mtime(path: &Path) -> Option<DateTime<Utc>> {
     Some(mtime)
 }
 
-/// Bounded set of package names we've already warned about for the
-/// missing-`time` field. Capped at 1024 entries to keep long-lived
-/// processes (daemons, store servers) from leaking memory through it.
+/// Time-dependent check a packument with no per-version `time` map
+/// takes down. `minimumReleaseAge` and `trustPolicy` both read that one
+/// field, so a registry that strips it disables both, and each names
+/// itself in the warning it emits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Display)]
+pub(crate) enum SkippedTimeCheck {
+    #[display("minimumReleaseAge")]
+    MinimumReleaseAge,
+    #[display("trustPolicy")]
+    TrustPolicy,
+}
+
+/// Bounded set of `(package name, skipped check)` pairs we've already
+/// warned about for the missing-`time` field. Capped at 1024 entries to
+/// keep long-lived processes (daemons, store servers) from leaking
+/// memory through it.
+///
+/// Keyed by the pair rather than the package name alone: when both
+/// checks are configured they go dark together, and a package-only key
+/// would let whichever check ran first silence the other's warning,
+/// leaving the user told about only one of the two skips.
 ///
 /// `IndexSet` (not `Vec`) gives O(1) `contains` + cheap insertion-
 /// ordered eviction via `shift_remove_index(0)`.
 const MAX_WARNED_MISSING_TIME: usize = 1024;
-static WARNED_MISSING_TIME: std::sync::LazyLock<Mutex<indexmap::IndexSet<String>>> =
-    std::sync::LazyLock::new(|| Mutex::new(indexmap::IndexSet::new()));
+static WARNED_MISSING_TIME: std::sync::LazyLock<
+    Mutex<indexmap::IndexSet<(String, SkippedTimeCheck)>>,
+> = std::sync::LazyLock::new(|| Mutex::new(indexmap::IndexSet::new()));
 
-fn warn_missing_time_once(pkg_name: &str) {
+pub(crate) fn warn_missing_time_once(pkg_name: &str, skipped_check: SkippedTimeCheck) {
     let mut warned = WARNED_MISSING_TIME.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-    if warned.contains(pkg_name) {
+    let key = (pkg_name.to_string(), skipped_check);
+    if warned.contains(&key) {
         return;
     }
     if warned.len() >= MAX_WARNED_MISSING_TIME {
@@ -1198,11 +1218,11 @@ fn warn_missing_time_once(pkg_name: &str) {
         // (index 0) so the bound stays at MAX_WARNED_MISSING_TIME.
         warned.shift_remove_index(0);
     }
-    warned.insert(pkg_name.to_string());
+    warned.insert(key);
     tracing::warn!(
         target: "pnpm_resolving_npm_resolver::pick_package",
         pkg_name,
-        r#"The metadata of {pkg_name} is missing the "time" field; skipping the minimumReleaseAge check for this package."#,
+        r#"The metadata of {pkg_name} is missing the "time" field; skipping the {skipped_check} check for this package."#,
     );
 }
 

--- a/pnpm/crates/resolving-npm-resolver/src/trust_checks.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/trust_checks.rs
@@ -94,15 +94,19 @@ pub struct TrustCheckOptions<'a> {
     pub now: Option<DateTime<Utc>>,
 
     /// The `minimumReleaseAgeIgnoreMissingTime` opt-in, which declares
-    /// that the registry serves no per-version `time` at all. The
-    /// downgrade check orders history by publish date, so a packument
-    /// with no `time` map leaves it nothing to order and the check is
-    /// skipped with a warning rather than aborting the install.
+    /// that the registry cannot date its releases. The downgrade check
+    /// orders history by publish date, so a packument with no `time`
+    /// map leaves it nothing to order and the check is skipped with a
+    /// warning rather than aborting the install.
     ///
-    /// Scoped to the whole map being absent. A `time` map that dates
-    /// other versions but not this one is not a registry that omits the
-    /// field, it is a packument that lost one entry, so that shape keeps
-    /// failing closed however this flag is set.
+    /// Scoped to the whole map being absent, which
+    /// [`Package::drop_incomplete_publish_times`] makes the only shape a
+    /// registry that dates some of its versions can reach here in. A
+    /// packument that dates every version it lists is instead saying it
+    /// does not have this one, so that shape keeps failing closed
+    /// however this flag is set.
+    ///
+    /// [`Package::drop_incomplete_publish_times`]: pnpm_registry::Package::drop_incomplete_publish_times
     pub ignore_missing_time_field: bool,
 }
 
@@ -127,11 +131,6 @@ pub fn fail_if_trust_downgraded(
         }
     }
 
-    // A packument with no `time` map at all is the shape a registry that
-    // strips the field produces, and is what the opt-in tolerates. A map
-    // that dates other versions but not this one is a gap in the
-    // metadata rather than a registry policy, so it stays a hard failure
-    // below however the flag is set.
     if meta.time.is_none() {
         if opts.ignore_missing_time_field {
             warn_missing_time_once(&meta.name, SkippedTimeCheck::TrustPolicy);

--- a/pnpm/crates/resolving-npm-resolver/src/trust_checks.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/trust_checks.rs
@@ -17,6 +17,8 @@ use pnpm_config::version_policy::{PackageVersionPolicy, PolicyMatch};
 use pnpm_registry::{Package, PackageVersion};
 use pnpm_resolving_resolver_base::parse_packument_timestamp;
 
+use crate::pick_package::{SkippedTimeCheck, warn_missing_time_once};
+
 /// Rank of supply-chain evidence on a single version. Variants are
 /// declared weakest-first so the derived `Ord` matches `trust_rank`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -90,6 +92,18 @@ pub struct TrustCheckOptions<'a> {
     /// `trust_policy_ignore_after_minutes`. Defaults to wall-clock
     /// `Utc::now`; tests pin it for determinism.
     pub now: Option<DateTime<Utc>>,
+
+    /// The `minimumReleaseAgeIgnoreMissingTime` opt-in, which declares
+    /// that the registry serves no per-version `time` at all. The
+    /// downgrade check orders history by publish date, so a packument
+    /// with no `time` map leaves it nothing to order and the check is
+    /// skipped with a warning rather than aborting the install.
+    ///
+    /// Scoped to the whole map being absent. A `time` map that dates
+    /// other versions but not this one is not a registry that omits the
+    /// field, it is a packument that lost one entry, so that shape keeps
+    /// failing closed however this flag is set.
+    pub ignore_missing_time_field: bool,
 }
 
 /// Reject `version` of `meta` when its trust evidence is weaker
@@ -113,9 +127,24 @@ pub fn fail_if_trust_downgraded(
         }
     }
 
-    // Pull the version's publish time. We treat both "no time map" and
-    // "no entry for this version" as the same `TRUST_CHECK_FAIL` shape
-    // so the verifier surfaces a single "could not be checked" reason.
+    // A packument with no `time` map at all is the shape a registry that
+    // strips the field produces, and is what the opt-in tolerates. A map
+    // that dates other versions but not this one is a gap in the
+    // metadata rather than a registry policy, so it stays a hard failure
+    // below however the flag is set.
+    if meta.time.is_none() {
+        if opts.ignore_missing_time_field {
+            warn_missing_time_once(&meta.name, SkippedTimeCheck::TrustPolicy);
+            return Ok(());
+        }
+        return Err(TrustViolation::TrustCheckFailed {
+            reason: format!(
+                r#"The metadata of {name} is missing the "time" field"#,
+                name = meta.name,
+            ),
+        });
+    }
+
     let published_at =
         meta.published_at(version).ok_or_else(|| TrustViolation::TrustCheckFailed {
             reason: format!(

--- a/pnpm/crates/resolving-npm-resolver/src/trust_checks/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/trust_checks/tests.rs
@@ -388,8 +388,9 @@ mod ignore_missing_time_field {
     };
 
     /// A downgrade candidate (provenance → nothing) whose `time` map is
-    /// absent as a whole, the shape a registry that strips the field
-    /// serves.
+    /// absent as a whole: a registry that strips the field, or one whose
+    /// partial map `Package::drop_incomplete_publish_times` normalized
+    /// away.
     fn time_free_package() -> Package {
         let mut meta = make_package(
             "timeless",
@@ -421,9 +422,9 @@ mod ignore_missing_time_field {
             .expect("the opt-in skips the check on a packument with no time map");
     }
 
-    /// A registry that dates its other versions is not a registry that
-    /// strips `time`, so the gap stays a hard failure no matter how the
-    /// flag is set.
+    /// A packument that dates the versions it lists is saying it does
+    /// not have this one, so the gap stays a hard failure no matter how
+    /// the flag is set.
     #[test]
     fn still_fails_when_the_time_map_omits_the_version() {
         let mut meta = make_package(

--- a/pnpm/crates/resolving-npm-resolver/src/trust_checks/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/trust_checks/tests.rs
@@ -380,6 +380,85 @@ fn undecodable_prior_version_fails_closed() {
     assert!(matches!(err, TrustViolation::TrustCheckFailed { .. }), "got {err:?}");
 }
 
+mod ignore_missing_time_field {
+    use pnpm_registry::Package;
+
+    use super::{
+        Evidence, TrustCheckOptions, TrustViolation, fail_if_trust_downgraded, make_package,
+    };
+
+    /// A downgrade candidate (provenance → nothing) whose `time` map is
+    /// absent as a whole, the shape a registry that strips the field
+    /// serves.
+    fn time_free_package() -> Package {
+        let mut meta = make_package(
+            "timeless",
+            &[
+                ("1.0.0", "2025-01-01T00:00:00.000Z", Evidence::Provenance),
+                ("2.0.0", "2025-02-01T00:00:00.000Z", Evidence::None),
+            ],
+        );
+        meta.time = None;
+        meta
+    }
+
+    #[test]
+    fn fails_when_the_flag_is_off() {
+        let meta = time_free_package();
+        let err = fail_if_trust_downgraded(&meta, "2.0.0", &TrustCheckOptions::default())
+            .expect_err("a time-free packument fails closed without the opt-in");
+        let TrustViolation::TrustCheckFailed { reason } = err else {
+            panic!("expected TrustCheckFailed, got {err:?}");
+        };
+        assert!(reason.contains(r#"missing the "time" field"#), "got reason: {reason}");
+    }
+
+    #[test]
+    fn skips_the_check_when_the_flag_is_on() {
+        let meta = time_free_package();
+        let opts = TrustCheckOptions { ignore_missing_time_field: true, ..Default::default() };
+        fail_if_trust_downgraded(&meta, "2.0.0", &opts)
+            .expect("the opt-in skips the check on a packument with no time map");
+    }
+
+    /// A registry that dates its other versions is not a registry that
+    /// strips `time`, so the gap stays a hard failure no matter how the
+    /// flag is set.
+    #[test]
+    fn still_fails_when_the_time_map_omits_the_version() {
+        let mut meta = make_package(
+            "timeless",
+            &[
+                ("1.0.0", "2025-01-01T00:00:00.000Z", Evidence::Provenance),
+                ("2.0.0", "2025-02-01T00:00:00.000Z", Evidence::None),
+            ],
+        );
+        meta.time.as_mut().expect("fixture builds a time map").remove("2.0.0");
+        let opts = TrustCheckOptions { ignore_missing_time_field: true, ..Default::default() };
+        let err = fail_if_trust_downgraded(&meta, "2.0.0", &opts)
+            .expect_err("a per-version hole is not a registry that omits the field");
+        let TrustViolation::TrustCheckFailed { reason } = err else {
+            panic!("expected TrustCheckFailed, got {err:?}");
+        };
+        assert!(reason.contains("missing time for version 2.0.0"), "got reason: {reason}");
+    }
+
+    #[test]
+    fn still_reports_a_downgrade_when_the_time_map_is_complete() {
+        let meta = make_package(
+            "timeless",
+            &[
+                ("1.0.0", "2025-01-01T00:00:00.000Z", Evidence::Provenance),
+                ("2.0.0", "2025-02-01T00:00:00.000Z", Evidence::None),
+            ],
+        );
+        let opts = TrustCheckOptions { ignore_missing_time_field: true, ..Default::default() };
+        let err = fail_if_trust_downgraded(&meta, "2.0.0", &opts)
+            .expect_err("the opt-in must not blind a check that has the dates it needs");
+        assert!(matches!(err, TrustViolation::TrustDowngrade { .. }), "got {err:?}");
+    }
+}
+
 mod get_trust_evidence {
     use pnpm_registry::PackageVersion;
 

--- a/pnpm11/resolving/npm-resolver/src/createNpmResolutionVerifier.ts
+++ b/pnpm11/resolving/npm-resolver/src/createNpmResolutionVerifier.ts
@@ -58,7 +58,10 @@ export interface CreateNpmResolutionVerifierOptions {
    * behavior for both — the verifier passes the entry with a one-time
    * `globalWarn`, instead of failing closed. Defaults to `false` so
    * the verifier stays stricter than the resolver only when the user
-   * has explicitly opted in to the skip on the resolver side.
+   * has explicitly opted in to the skip on the resolver side. Scoped
+   * to a packument with no usable `time` map: one that dates every
+   * version it lists is saying it never published this pin, which
+   * fails closed either way.
    */
   ignoreMissingTimeField?: boolean
   /**
@@ -369,15 +372,23 @@ async function runAgeCheck (
   const published = await fetchPublishedAt(context, registry, name, version)
   if (!published) {
     // No source — attestation, local mirror, or full metadata —
-    // surfaced a publish timestamp for this version. The resolver's
-    // pickMatchingVersionFinal honors `minimumReleaseAgeIgnoreMissingTime`
-    // for the same shape (some self-hosted registries strip per-version
-    // `time`); the verifier mirrors that so it can't be stricter than
-    // fresh resolution. Without the flag we still fail closed — better
-    // a false reject than silent bypass when the user hasn't opted in.
+    // surfaced a publish timestamp for this version. What
+    // `minimumReleaseAgeIgnoreMissingTime` opts out of is a registry that
+    // cannot date its releases, so the skip is granted only when the
+    // packument carries no usable `time` map at all — the same shape the
+    // resolver's `pickMatchingVersionFinal` warns and skips on, so the
+    // verifier can't be stricter than fresh resolution. A packument that
+    // does date every version it lists is instead telling us this pin is
+    // not one of them (`dropIncompletePublishTimes` leaves no partial maps
+    // for that to be ambiguous), and an unpublished or never-published pin
+    // must fail closed however the flag is set.
     if (ignoreMissingTimeField) {
-      warnMissingTimeFieldOnce(name, 'minimumReleaseAge')
-      return undefined
+      // Already awaited by the lookup above, so this is a cache hit.
+      const timeMap = await fetchFullMetaTime(context, registry, name)
+      if (timeMap == null) {
+        warnMissingTimeFieldOnce(name, 'minimumReleaseAge')
+        return undefined
+      }
     }
     return {
       ok: false,

--- a/pnpm11/resolving/npm-resolver/src/createNpmResolutionVerifier.ts
+++ b/pnpm11/resolving/npm-resolver/src/createNpmResolutionVerifier.ts
@@ -53,12 +53,12 @@ export interface CreateNpmResolutionVerifierOptions {
   /**
    * When the registry's metadata lacks the per-version `time` field
    * (some self-hosted registries strip it), the verifier can't apply
-   * the maturity cutoff. Set this to `true` to mirror the resolver's
-   * `pickMatchingVersionFinal` warn-and-skip behavior — the verifier
-   * passes the entry with a one-time `globalWarn`, instead of failing
-   * closed. Defaults to `false` so the verifier stays stricter than
-   * the resolver only when the user has explicitly opted in to the
-   * skip on the resolver side.
+   * the maturity cutoff, and the trust check has no publish order to
+   * walk. Set this to `true` to mirror the resolver's warn-and-skip
+   * behavior for both — the verifier passes the entry with a one-time
+   * `globalWarn`, instead of failing closed. Defaults to `false` so
+   * the verifier stays stricter than the resolver only when the user
+   * has explicitly opted in to the skip on the resolver side.
    */
   ignoreMissingTimeField?: boolean
   /**
@@ -166,6 +166,7 @@ export function createNpmResolutionVerifier (
   const minimumReleaseAge = opts.minimumReleaseAge ?? 0
   const trustPolicy = opts.trustPolicy
   const trustPolicyIgnoreAfter = opts.trustPolicyIgnoreAfter
+  const ignoreMissingTimeField = opts.ignoreMissingTimeField === true
 
 
   const verify: ResolutionVerifier['verify'] = async (resolution, { name, version, nonSemverVersion, registryName }) => {
@@ -243,7 +244,7 @@ export function createNpmResolutionVerifier (
     if (!ageApplies && !trustApplies) return { ok: true }
 
     if (ageApplies) {
-      const ageViolation = await runAgeCheck(lookupContext, registry, name, version, cutoff, opts.ignoreMissingTimeField === true)
+      const ageViolation = await runAgeCheck(lookupContext, registry, name, version, cutoff, ignoreMissingTimeField)
       if (ageViolation) return ageViolation
     }
 
@@ -251,6 +252,7 @@ export function createNpmResolutionVerifier (
       const trustViolation = await runTrustCheck(lookupContext, registry, name, version, {
         trustPolicyExclude: trustExcludePolicy,
         trustPolicyIgnoreAfter,
+        ignoreMissingTimeField,
       })
       if (trustViolation) return trustViolation
     }
@@ -291,6 +293,7 @@ export function createNpmResolutionVerifier (
       trustPolicy: trustPolicy ?? null,
       trustPolicyExclude: sortedTrustExcludes,
       trustPolicyIgnoreAfter: trustPolicyIgnoreAfter ?? null,
+      minimumReleaseAgeIgnoreMissingTime: ignoreMissingTimeField,
     },
     canTrustPastCheck: (cached) => {
       // The tarball-URL binding is unconditional today; a cached run that
@@ -338,6 +341,14 @@ export function createNpmResolutionVerifier (
       const todayIgnoreAfter = trustPolicyIgnoreAfter ?? null
       if (pastIgnoreAfter !== todayIgnoreAfter) return false
 
+      // Missing-time tolerance: a cached run that failed closed on an
+      // absent `time` field accepted a subset of what today's tolerant
+      // policy accepts, so it stays trustworthy. Turning the tolerance
+      // off invalidates it — entries the past run waved through are the
+      // ones today's policy exists to reject. Older records (no field)
+      // read as intolerant, which is the safe direction.
+      if (cached.minimumReleaseAgeIgnoreMissingTime === true && !ignoreMissingTimeField) return false
+
       return true
     },
   }
@@ -365,7 +376,7 @@ async function runAgeCheck (
     // fresh resolution. Without the flag we still fail closed — better
     // a false reject than silent bypass when the user hasn't opted in.
     if (ignoreMissingTimeField) {
-      warnMissingTimeFieldOnce(name)
+      warnMissingTimeFieldOnce(name, 'minimumReleaseAge')
       return undefined
     }
     return {
@@ -470,6 +481,7 @@ async function runTrustCheck (
   opts: {
     trustPolicyExclude?: PackageVersionPolicy
     trustPolicyIgnoreAfter?: number
+    ignoreMissingTimeField?: boolean
   }
 ): Promise<{ ok: false, code: string, reason: string } | undefined> {
   // A transport failure (auth/network/5xx) propagates the registry's own fetch

--- a/pnpm11/resolving/npm-resolver/src/index.ts
+++ b/pnpm11/resolving/npm-resolver/src/index.ts
@@ -290,6 +290,7 @@ export function createNpmResolver (
     registriesByPrefix,
     namedRegistryNames,
     saveWorkspaceProtocol: opts.saveWorkspaceProtocol,
+    ignoreMissingTimeField: opts.ignoreMissingTimeField,
     peekManifestFromStore,
     warnedHeldBackUpdates: new Set(),
   }
@@ -489,6 +490,12 @@ export interface ResolveFromNpmContext {
   registriesByPrefix: Record<string, string>
   namedRegistryNames: ReadonlySet<string>
   saveWorkspaceProtocol?: boolean | 'rolling'
+  /**
+   * The `minimumReleaseAgeIgnoreMissingTime` opt-in, reaching the trust
+   * check as well as the version pick: both read the same per-version
+   * `time`, so a registry that strips it takes both down together.
+   */
+  ignoreMissingTimeField?: boolean
   peekManifestFromStore?: (opts: {
     id: PkgResolutionId
     integrity: string
@@ -716,7 +723,11 @@ async function resolveNpm (
 
     throw new NoMatchingVersionError({ wantedDependency, packageMeta: meta, registry })
   } else if (opts.trustPolicy === 'no-downgrade') {
-    failIfTrustDowngraded(meta, pickedPackage.version, opts)
+    failIfTrustDowngraded(meta, pickedPackage.version, {
+      trustPolicyExclude: opts.trustPolicyExclude,
+      trustPolicyIgnoreAfter: opts.trustPolicyIgnoreAfter,
+      ignoreMissingTimeField: ctx.ignoreMissingTimeField,
+    })
   }
 
   const latest = latestAllowedByPolicy(meta, opts)

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -201,7 +201,7 @@ function pickMatchingVersionFinal (
     return pickMatchingVersionFast(pickerOpts, spec, meta)
   } catch (err: unknown) {
     if (pickerOpts.ignoreMissingTimeField && isMissingTimeError(err)) {
-      warnMissingTimeFieldOnce(meta.name)
+      warnMissingTimeFieldOnce(meta.name, 'minimumReleaseAge')
       return pickMatchingVersionFast({
         ...pickerOpts,
         publishedBy: undefined,
@@ -834,7 +834,17 @@ function isMissingTimeError (err: unknown): boolean {
 const MAX_WARNED_MISSING_TIME = 1024
 const warnedMissingTimeFor = new Set<string>()
 
-export function warnMissingTimeFieldOnce (pkgName: string): void {
+/**
+ * At most one warning per package, whichever time-dependent check reaches it
+ * first. `minimumReleaseAge` and `trustPolicy` both go dark on the same
+ * missing field, and a workspace full of private packages served by a
+ * registry that strips `time` would otherwise get a wall of warnings saying
+ * the same thing twice per package.
+ */
+export function warnMissingTimeFieldOnce (
+  pkgName: string,
+  skippedCheck: 'minimumReleaseAge' | 'trustPolicy'
+): void {
   if (warnedMissingTimeFor.has(pkgName)) return
   if (warnedMissingTimeFor.size >= MAX_WARNED_MISSING_TIME) {
     // Set preserves insertion order, so the first entry is the oldest.
@@ -842,7 +852,7 @@ export function warnMissingTimeFieldOnce (pkgName: string): void {
     if (oldest != null) warnedMissingTimeFor.delete(oldest)
   }
   warnedMissingTimeFor.add(pkgName)
-  globalWarn(`The metadata of ${pkgName} is missing the "time" field; skipping the minimumReleaseAge check for this package.`)
+  globalWarn(`The metadata of ${pkgName} is missing the "time" field; skipping the ${skippedCheck} check for this package.`)
 }
 
 async function getFileMtime (filePath: string): Promise<Date | null> {

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -835,23 +835,25 @@ const MAX_WARNED_MISSING_TIME = 1024
 const warnedMissingTimeFor = new Set<string>()
 
 /**
- * At most one warning per package, whichever time-dependent check reaches it
- * first. `minimumReleaseAge` and `trustPolicy` both go dark on the same
- * missing field, and a workspace full of private packages served by a
- * registry that strips `time` would otherwise get a wall of warnings saying
- * the same thing twice per package.
+ * At most one warning per package per check. `minimumReleaseAge` and
+ * `trustPolicy` both go dark on the same missing field, so keying by package
+ * alone would let whichever check ran first silence the other and leave the
+ * user told about only one of the two skips.
  */
 export function warnMissingTimeFieldOnce (
   pkgName: string,
   skippedCheck: 'minimumReleaseAge' | 'trustPolicy'
 ): void {
-  if (warnedMissingTimeFor.has(pkgName)) return
+  // A package name cannot contain ':', so the check name prefix cannot
+  // collide with a name that happens to embed it.
+  const key = `${skippedCheck}:${pkgName}`
+  if (warnedMissingTimeFor.has(key)) return
   if (warnedMissingTimeFor.size >= MAX_WARNED_MISSING_TIME) {
     // Set preserves insertion order, so the first entry is the oldest.
     const oldest = warnedMissingTimeFor.values().next().value
     if (oldest != null) warnedMissingTimeFor.delete(oldest)
   }
-  warnedMissingTimeFor.add(pkgName)
+  warnedMissingTimeFor.add(key)
   globalWarn(`The metadata of ${pkgName} is missing the "time" field; skipping the ${skippedCheck} check for this package.`)
 }
 

--- a/pnpm11/resolving/npm-resolver/src/trustChecks.ts
+++ b/pnpm11/resolving/npm-resolver/src/trustChecks.ts
@@ -3,6 +3,7 @@ import type { PackageInRegistry, PackageMeta, PackageMetaWithTime } from '@pnpm/
 import type { PackageVersionPolicy } from '@pnpm/types'
 import semver from 'semver'
 
+import { warnMissingTimeFieldOnce } from './pickPackage.js'
 import { assertMetaHasTime } from './pickPackageFromMeta.js'
 
 type TrustEvidence = 'provenance' | 'trustedPublisher' | 'stagedPublish'
@@ -19,6 +20,19 @@ export function failIfTrustDowngraded (
   opts?: {
     trustPolicyExclude?: PackageVersionPolicy
     trustPolicyIgnoreAfter?: number
+    /**
+     * The `minimumReleaseAgeIgnoreMissingTime` opt-in, which declares that
+     * the registry serves no per-version `time` at all. The downgrade check
+     * orders history by publish date, so a packument with no `time` map
+     * leaves it nothing to order and the check is skipped with a warning
+     * rather than aborting the install.
+     *
+     * Scoped to the whole map being absent. A `time` map that dates other
+     * versions but not this one is not a registry that omits the field, it
+     * is a packument that lost one entry, so that shape keeps failing
+     * closed however this flag is set.
+     */
+    ignoreMissingTimeField?: boolean
   }
 ): void {
   if (opts?.trustPolicyExclude) {
@@ -31,6 +45,10 @@ export function failIfTrustDowngraded (
     }
   }
 
+  if (meta.time == null && opts?.ignoreMissingTimeField) {
+    warnMissingTimeFieldOnce(meta.name, 'trustPolicy')
+    return
+  }
   assertMetaHasTime(meta)
 
   const versionPublishedAt = meta.time[version]

--- a/pnpm11/resolving/npm-resolver/src/trustChecks.ts
+++ b/pnpm11/resolving/npm-resolver/src/trustChecks.ts
@@ -22,15 +22,16 @@ export function failIfTrustDowngraded (
     trustPolicyIgnoreAfter?: number
     /**
      * The `minimumReleaseAgeIgnoreMissingTime` opt-in, which declares that
-     * the registry serves no per-version `time` at all. The downgrade check
-     * orders history by publish date, so a packument with no `time` map
-     * leaves it nothing to order and the check is skipped with a warning
-     * rather than aborting the install.
+     * the registry cannot date its releases. The downgrade check orders
+     * history by publish date, so a packument with no `time` map leaves it
+     * nothing to order and the check is skipped with a warning rather than
+     * aborting the install.
      *
-     * Scoped to the whole map being absent. A `time` map that dates other
-     * versions but not this one is not a registry that omits the field, it
-     * is a packument that lost one entry, so that shape keeps failing
-     * closed however this flag is set.
+     * Scoped to the whole map being absent, which `dropIncompletePublishTimes`
+     * makes the only shape a registry that dates some of its versions can
+     * reach here in. A packument that dates every version it lists is instead
+     * saying it does not have this one, so that shape keeps failing closed
+     * however this flag is set.
      */
     ignoreMissingTimeField?: boolean
   }

--- a/pnpm11/resolving/npm-resolver/test/createNpmResolutionVerifier.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/createNpmResolutionVerifier.test.ts
@@ -321,6 +321,44 @@ test('createNpmResolutionVerifier() ignoreMissingTimeField passes the entry when
   expect(result).toEqual({ ok: true })
 })
 
+test('createNpmResolutionVerifier() ignoreMissingTimeField still rejects a version the registry does not list', async () => {
+  // The opt-in speaks for a registry that cannot date its releases, not for
+  // a pin the registry has never heard of. The packument dates every version
+  // it lists, so the absent timestamp says the version is not there — the
+  // same reading the unpublished-pin case gets without the flag.
+  const meta = {
+    name: 'listed-time-pkg',
+    'dist-tags': { latest: '1.0.0' },
+    versions: {
+      '1.0.0': {
+        name: 'listed-time-pkg',
+        version: '1.0.0',
+        dist: { tarball: 'https://registry.npmjs.org/listed-time-pkg/-/listed-time-pkg-1.0.0.tgz', shasum: 'aa' },
+      },
+    },
+    time: { '1.0.0': '2010-01-01T00:00:00.000Z' },
+    modified: '2010-01-01T00:00:00.000Z',
+  }
+  const pool = getMockAgent().get('https://registry.npmjs.org')
+  pool.intercept({ path: '/listed-time-pkg', method: 'GET' }).reply(200, meta).persist()
+  pool.intercept({ path: '/-/npm/v1/attestations/listed-time-pkg@1.0.1', method: 'GET' }).reply(404, {}).persist()
+
+  const verifier = createNpmResolutionVerifier(makeVerifierOpts({
+    minimumReleaseAge: 1440,
+    ignoreMissingTimeField: true,
+  }))
+  // Registry-style resolution (no explicit tarball URL) so the entry reaches
+  // the age check instead of failing the tarball-URL binding first.
+  const result = await verifier.verify(
+    { integrity: FAKE_INTEGRITY } as unknown as Resolution,
+    { name: 'listed-time-pkg', version: '1.0.1' }
+  )
+  expect(result).toMatchObject({
+    ok: false,
+    code: 'MINIMUM_RELEASE_AGE_VIOLATION',
+  })
+})
+
 const TRUST_TIME_FREE_META = {
   name: 'trust-time-free-pkg',
   'dist-tags': { latest: '2.0.0' },

--- a/pnpm11/resolving/npm-resolver/test/createNpmResolutionVerifier.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/createNpmResolutionVerifier.test.ts
@@ -321,6 +321,134 @@ test('createNpmResolutionVerifier() ignoreMissingTimeField passes the entry when
   expect(result).toEqual({ ok: true })
 })
 
+const TRUST_TIME_FREE_META = {
+  name: 'trust-time-free-pkg',
+  'dist-tags': { latest: '2.0.0' },
+  versions: {
+    '1.0.0': {
+      name: 'trust-time-free-pkg',
+      version: '1.0.0',
+      dist: {
+        tarball: 'https://registry.npmjs.org/trust-time-free-pkg/-/trust-time-free-pkg-1.0.0.tgz',
+        shasum: 'aa',
+        attestations: { provenance: { predicateType: 'https://slsa.dev/provenance/v1' } },
+      },
+    },
+    '2.0.0': {
+      name: 'trust-time-free-pkg',
+      version: '2.0.0',
+      dist: {
+        tarball: 'https://registry.npmjs.org/trust-time-free-pkg/-/trust-time-free-pkg-2.0.0.tgz',
+        shasum: 'bb',
+      },
+    },
+  },
+  modified: '2010-01-01T00:00:00.000Z',
+}
+
+function interceptTrustTimeFreeMeta (): void {
+  getMockAgent().get('https://registry.npmjs.org')
+    .intercept({ path: '/trust-time-free-pkg', method: 'GET' })
+    .reply(200, TRUST_TIME_FREE_META)
+    .persist()
+}
+
+test('createNpmResolutionVerifier() trustPolicy rejects a time-free packument without ignoreMissingTimeField', async () => {
+  interceptTrustTimeFreeMeta()
+
+  const verifier = createNpmResolutionVerifier(makeVerifierOpts({
+    trustPolicy: 'no-downgrade',
+  }))
+  const result = await verifier.verify(
+    makeTarballResolution('trust-time-free-pkg', '2.0.0'),
+    { name: 'trust-time-free-pkg', version: '2.0.0' }
+  )
+  expect(result).toMatchObject({
+    ok: false,
+    code: 'TRUST_DOWNGRADE',
+    reason: expect.stringContaining('missing the "time" field'),
+  })
+})
+
+test('createNpmResolutionVerifier() ignoreMissingTimeField passes the trust check on a time-free packument', async () => {
+  // Same registry deficiency the age check already tolerates under this
+  // opt-in: with no `time` map there is no publish order for the downgrade
+  // walk to read, so the verifier warns and skips rather than locking the
+  // user out of a registry that never serves the field.
+  interceptTrustTimeFreeMeta()
+
+  const verifier = createNpmResolutionVerifier(makeVerifierOpts({
+    trustPolicy: 'no-downgrade',
+    ignoreMissingTimeField: true,
+  }))
+  const result = await verifier.verify(
+    makeTarballResolution('trust-time-free-pkg', '2.0.0'),
+    { name: 'trust-time-free-pkg', version: '2.0.0' }
+  )
+  expect(result).toEqual({ ok: true })
+})
+
+test('createNpmResolutionVerifier() ignoreMissingTimeField still reports a downgrade when the registry serves time', async () => {
+  getMockAgent().get('https://registry.npmjs.org')
+    .intercept({ path: '/dated-pkg', method: 'GET' })
+    .reply(200, {
+      ...TRUST_TIME_FREE_META,
+      name: 'dated-pkg',
+      versions: {
+        '1.0.0': {
+          ...TRUST_TIME_FREE_META.versions['1.0.0'],
+          name: 'dated-pkg',
+          dist: {
+            ...TRUST_TIME_FREE_META.versions['1.0.0'].dist,
+            tarball: 'https://registry.npmjs.org/dated-pkg/-/dated-pkg-1.0.0.tgz',
+          },
+        },
+        '2.0.0': {
+          ...TRUST_TIME_FREE_META.versions['2.0.0'],
+          name: 'dated-pkg',
+          dist: {
+            ...TRUST_TIME_FREE_META.versions['2.0.0'].dist,
+            tarball: 'https://registry.npmjs.org/dated-pkg/-/dated-pkg-2.0.0.tgz',
+          },
+        },
+      },
+      time: {
+        '1.0.0': '2025-01-01T00:00:00.000Z',
+        '2.0.0': '2025-02-01T00:00:00.000Z',
+      },
+    })
+    .persist()
+
+  const verifier = createNpmResolutionVerifier(makeVerifierOpts({
+    trustPolicy: 'no-downgrade',
+    ignoreMissingTimeField: true,
+  }))
+  const result = await verifier.verify(
+    makeTarballResolution('dated-pkg', '2.0.0'),
+    { name: 'dated-pkg', version: '2.0.0' }
+  )
+  expect(result).toMatchObject({
+    ok: false,
+    code: 'TRUST_DOWNGRADE',
+    reason: expect.stringContaining('High-risk trust downgrade'),
+  })
+})
+
+test('createNpmResolutionVerifier() cache identity tracks ignoreMissingTimeField', async () => {
+  const tolerant = createNpmResolutionVerifier(makeVerifierOpts({
+    trustPolicy: 'no-downgrade',
+    ignoreMissingTimeField: true,
+  }))
+  const strict = createNpmResolutionVerifier(makeVerifierOpts({
+    trustPolicy: 'no-downgrade',
+  }))
+
+  // Dropping the tolerance invalidates a run that may have waved entries
+  // through on it; adding the tolerance keeps the stricter run trustworthy.
+  expect(strict.canTrustPastCheck(tolerant.policy)).toBe(false)
+  expect(tolerant.canTrustPastCheck(strict.policy)).toBe(true)
+})
+
 test('createNpmResolutionVerifier() skips file: tarball resolutions', async () => {
   const verifier = createNpmResolutionVerifier(makeVerifierOpts({
     minimumReleaseAge: 1440,

--- a/pnpm11/resolving/npm-resolver/test/index.ts
+++ b/pnpm11/resolving/npm-resolver/test/index.ts
@@ -1673,6 +1673,45 @@ test('preferWorkspacePackages: still consults the registry under trustPolicy=no-
   )
 })
 
+test('resolveFromNpm() fails under trustPolicy=no-downgrade when the registry serves no time field', async () => {
+  getMockAgent().get(registriesByScope.default.replace(/\/$/, ''))
+    .intercept({ path: '/is-positive', method: 'GET' })
+    .reply(200, isPositiveMeta)
+
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir: temporaryDirectory(),
+    registriesByScope,
+  })
+
+  await expect(
+    resolveFromNpm({ alias: 'is-positive', bareSpecifier: '^3.0.0' }, { trustPolicy: 'no-downgrade' })
+  ).rejects.toThrow('The metadata of is-positive is missing the "time" field')
+})
+
+test('resolveFromNpm() skips the trust check when ignoreMissingTimeField is set and the registry serves no time field', async () => {
+  getMockAgent().get(registriesByScope.default.replace(/\/$/, ''))
+    .intercept({ path: '/is-positive', method: 'GET' })
+    .reply(200, isPositiveMeta)
+
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir: temporaryDirectory(),
+    registriesByScope,
+    ignoreMissingTimeField: true,
+  })
+  const resolveResult = await resolveFromNpm({
+    alias: 'is-positive',
+    bareSpecifier: '^3.0.0',
+  }, {
+    trustPolicy: 'no-downgrade',
+  })
+
+  expect(resolveResult).toStrictEqual(
+    expect.objectContaining({ id: 'is-positive@3.1.0' })
+  )
+})
+
 test('preferWorkspacePackages: does not engage for injected workspace packages', async () => {
   getMockAgent().get(registriesByScope.default.replace(/\/$/, ''))
     .intercept({ path: '/is-positive', method: 'GET' })

--- a/pnpm11/resolving/npm-resolver/test/trustChecks.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/trustChecks.test.ts
@@ -792,7 +792,8 @@ describe('failIfTrustDowngraded with ignoreMissingTimeField', () => {
         },
       },
     },
-    // Note: no 'time' field, as served by a registry that strips it
+    // Note: no 'time' field — a registry that strips it, or one whose
+    // partial map `dropIncompletePublishTimes` normalized away.
   }
 
   test('fails with ERR_PNPM_MISSING_TIME when the flag is off', () => {
@@ -808,8 +809,8 @@ describe('failIfTrustDowngraded with ignoreMissingTimeField', () => {
   })
 
   test('still fails when the time map is present but omits the version', () => {
-    // A registry that dates its other versions is not a registry that strips
-    // `time`, so the gap stays a hard failure no matter how the flag is set.
+    // A packument that dates the versions it lists is saying it does not have
+    // this one, so the gap stays a hard failure no matter how the flag is set.
     const meta: PackageMetaWithTime = {
       ...metaWithoutTime,
       time: {

--- a/pnpm11/resolving/npm-resolver/test/trustChecks.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/trustChecks.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, test } from '@jest/globals'
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals'
 import { createPackageVersionPolicy } from '@pnpm/config.version-policy'
+import { type LogBase, streamParser } from '@pnpm/logger'
 import type { PackageInRegistry, PackageMetaWithTime } from '@pnpm/resolving.registry.types'
 
+import { warnMissingTimeFieldOnce } from '../src/pickPackage.js'
 import { failIfTrustDowngraded, getTrustEvidence } from '../src/trustChecks.js'
 
 describe('getTrustEvidence', () => {
@@ -832,5 +834,43 @@ describe('failIfTrustDowngraded with ignoreMissingTimeField', () => {
     expect(() => {
       failIfTrustDowngraded(meta, '2.0.0', { ignoreMissingTimeField: true })
     }).toThrow('High-risk trust downgrade')
+  })
+})
+
+// Both time-dependent checks go dark on the same missing field, so the
+// warning must name each one that was skipped rather than letting whichever
+// ran first stand in for both.
+describe('warnMissingTimeFieldOnce', () => {
+  const collectedWarnings: string[] = []
+
+  function collectWarnings (msg: LogBase & { message?: string }): void {
+    if (msg.level === 'warn' && typeof msg.message === 'string') {
+      collectedWarnings.push(msg.message)
+    }
+  }
+
+  beforeEach(() => {
+    collectedWarnings.length = 0
+    streamParser.on('data', collectWarnings as (msg: LogBase) => void)
+  })
+
+  afterEach(() => {
+    streamParser.removeListener('data', collectWarnings as (msg: LogBase) => void)
+  })
+
+  test('warns once per check for the same package, and no more', async () => {
+    warnMissingTimeFieldOnce('dual-policy-pkg', 'minimumReleaseAge')
+    warnMissingTimeFieldOnce('dual-policy-pkg', 'trustPolicy')
+    warnMissingTimeFieldOnce('dual-policy-pkg', 'minimumReleaseAge')
+    warnMissingTimeFieldOnce('dual-policy-pkg', 'trustPolicy')
+    // The log stream delivers on its own turn of the event loop.
+    await new Promise((resolve) => {
+      setImmediate(resolve)
+    })
+
+    expect(collectedWarnings.filter((message) => message.includes('dual-policy-pkg'))).toStrictEqual([
+      'The metadata of dual-policy-pkg is missing the "time" field; skipping the minimumReleaseAge check for this package.',
+      'The metadata of dual-policy-pkg is missing the "time" field; skipping the trustPolicy check for this package.',
+    ])
   })
 })

--- a/pnpm11/resolving/npm-resolver/test/trustChecks.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/trustChecks.test.ts
@@ -762,3 +762,75 @@ describe('failIfTrustDowngraded with trustPolicyIgnoreAfter', () => {
     }).toThrow('High-risk trust downgrade')
   })
 })
+
+describe('failIfTrustDowngraded with ignoreMissingTimeField', () => {
+  const metaWithoutTime = {
+    name: 'timeless',
+    'dist-tags': { latest: '2.0.0' },
+    versions: {
+      '1.0.0': {
+        name: 'timeless',
+        version: '1.0.0',
+        dist: {
+          shasum: 'abc123',
+          tarball: 'https://registry.example.com/timeless/-/timeless-1.0.0.tgz',
+          attestations: {
+            provenance: {
+              predicateType: 'https://slsa.dev/provenance/v1',
+            },
+          },
+        },
+      },
+      '2.0.0': {
+        name: 'timeless',
+        version: '2.0.0',
+        dist: {
+          shasum: 'def456',
+          tarball: 'https://registry.example.com/timeless/-/timeless-2.0.0.tgz',
+        },
+      },
+    },
+    // Note: no 'time' field, as served by a registry that strips it
+  }
+
+  test('fails with ERR_PNPM_MISSING_TIME when the flag is off', () => {
+    expect(() => {
+      failIfTrustDowngraded(metaWithoutTime, '2.0.0')
+    }).toThrow('The metadata of timeless is missing the "time" field')
+  })
+
+  test('skips the check when the flag is on', () => {
+    expect(() => {
+      failIfTrustDowngraded(metaWithoutTime, '2.0.0', { ignoreMissingTimeField: true })
+    }).not.toThrow()
+  })
+
+  test('still fails when the time map is present but omits the version', () => {
+    // A registry that dates its other versions is not a registry that strips
+    // `time`, so the gap stays a hard failure no matter how the flag is set.
+    const meta: PackageMetaWithTime = {
+      ...metaWithoutTime,
+      time: {
+        '1.0.0': '2025-01-01T00:00:00.000Z',
+      },
+    }
+
+    expect(() => {
+      failIfTrustDowngraded(meta, '2.0.0', { ignoreMissingTimeField: true })
+    }).toThrow('Missing time for version 2.0.0 of timeless in metadata')
+  })
+
+  test('still reports a downgrade when the time map is complete', () => {
+    const meta: PackageMetaWithTime = {
+      ...metaWithoutTime,
+      time: {
+        '1.0.0': '2025-01-01T00:00:00.000Z',
+        '2.0.0': '2025-02-01T00:00:00.000Z',
+      },
+    }
+
+    expect(() => {
+      failIfTrustDowngraded(meta, '2.0.0', { ignoreMissingTimeField: true })
+    }).toThrow('High-risk trust downgrade')
+  })
+})


### PR DESCRIPTION
## Summary

`trustPolicy: no-downgrade` aborts with `ERR_PNPM_MISSING_TIME` on registries that serve no per-version `time` field, even when `minimumReleaseAgeIgnoreMissingTime` is set. Both checks read the same data, so one opt-in should cover both.

`failIfTrustDowngraded` now takes the flag and returns early with the existing warning when the packument carries no `time` map at all. A `time` map that dates other versions but not the installed one still fails closed. The verifier reads the flag from the `ignoreMissingTimeField` option it already accepts, so the frozen-lockfile path does not stay stricter than fresh resolution.

Failing closed on a whole-map absence preserves nothing: `no-downgrade` reads its baseline out of the same document it is judging, so a registry that omits `time` can equally drop `dist.attestations.provenance` and pass. It only pushes users to a `trustPolicyExclude` wildcard, which turns the check off permanently. registry.npmjs.org always returns `time` in a full packument, so installs against it are unaffected.

The flag joins the verifier's cache identity (relaxing free, tightening forces re-verification), and the skip warning now dedups on package *and* check so one skipped check no longer silences the other. pacquet carries the same change with identical scoping.

Not covered here: the website repo still describes `minimumReleaseAgeIgnoreMissingTime` as covering the release-age check only.

Fixes pnpm/pnpm#12446

### Testing

TypeScript: `jest` in `resolving/npm-resolver` (332), `resolving/default-resolver` (21), `store/connection-manager` (15); repo typecheck, `eslint`, `cspell` clean; `pnpm --filter pnpm run compile` builds.

Rust (pinned 1.97.0): `cargo test --locked` for `pnpm-resolving-npm-resolver` (397), `pnpm-lockfile-verification` + `pnpm-deps-restorer` (489), `pnpm-package-manager` (603); clippy `--deny warnings`, `cargo fmt --check`, `cargo doc` clean.

Not run: the CLI e2e suite and the full Rust workspace (`just ready`). The two `trustPolicy` e2e tests resolve from the public registry, whose metadata carries `time`, so neither reaches the changed branch.

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed. The settings description lives in the
  website repo and is called out above.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789761785&installation_model_id=426870&pr_number=14019&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14019&signature=487b96b26b636f43eaa63d33d9b2c5b6723a9ebd0e3cd3a380ff7782d067d2ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Trust-policy checks now honor the configured missing-timestamp tolerance.
  - Resolution can proceed with a warning when registry metadata lacks a complete timestamp map.
  - Missing timestamps for individual versions and detected trust downgrades continue to fail validation.
  - Warnings identify the skipped check and avoid duplicate messages.
  - Cache validation respects the missing-timestamp setting.

- **Tests**
  - Added coverage for trust validation, resolution behavior, warnings, and cache compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

