### PR TITLE
perf(install): overlap the store-index teardown with the install tail

### DIFF
--- a/.changeset/overlap-store-index-teardown.md
+++ b/.changeset/overlap-store-index-teardown.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-The store-index writer's teardown no longer extends the install's tail. Closing its SQLite connection runs a WAL checkpoint — around 40ms of pure wait at the end of a cold install of a big project — so the install now starts that close as soon as the last index row is queued and waits for it only after the `.modules.yaml` and lockfile writes it can overlap with.
+Improved install performance: the store-index writer's shutdown now overlaps the install's final lockfile and `.modules.yaml` writes instead of extending the install's tail.

--- a/.changeset/overlap-store-index-teardown.md
+++ b/.changeset/overlap-store-index-teardown.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+The store-index writer's teardown no longer extends the install's tail. Closing its SQLite connection runs a WAL checkpoint — around 40ms of pure wait at the end of a cold install of a big project — so the install now starts that close as soon as the last index row is queued and waits for it only after the `.modules.yaml` and lockfile writes it can overlap with.

--- a/pnpm/crates/deps-restorer/src/install_frozen_lockfile.rs
+++ b/pnpm/crates/deps-restorer/src/install_frozen_lockfile.rs
@@ -41,7 +41,7 @@ use pnpm_patching::{
 };
 use pnpm_reporter::{IgnoredScriptsLog, LogEvent, LogLevel, Reporter, Stage, StageLog};
 use pnpm_resolving_resolver_base::ResolutionVerifier;
-use pnpm_store_dir::StoreIndexWriter;
+use pnpm_store_dir::{StoreIndexError, StoreIndexWriter};
 use pnpm_tarball::{MemCache, SharedReportedProgressKeys};
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
@@ -815,13 +815,16 @@ where
             .map_err(InstallFrozenLockfileError::BuildPhase)?;
 
         // Drop the orchestrator's clone of the writer so the channel
-        // closes once every per-snapshot clone has also been dropped;
-        // then await the task so the final batch flushes before
-        // returning. Swallow any error with `warn!` — the install is
-        // complete and a missed cache write just forces a re-fetch
-        // on the next install.
+        // closes once every per-snapshot clone has also been dropped.
+        // The writer task then flushes its final batch and closes its
+        // `SQLite` connection — and that close runs a WAL checkpoint,
+        // measured at ~40 ms of pure install tail for a cold
+        // 1346-package install. Nothing after this point reads the
+        // index, so the task is handed back to the caller as
+        // [`InstallFrozenLockfileOutput::store_index_teardown`] and
+        // awaited only after the `.modules.yaml` / lockfile writes it
+        // can overlap with.
         drop(store_index_writer);
-        StoreIndexWriter::drain(writer_task, "; some rows may not be persisted").await;
 
         // The injectedDeps payload for `.modules.yaml`: every `file:`
         // snapshot is a materialized copy of an injected workspace
@@ -845,6 +848,7 @@ where
             skipped,
             ignored_builds,
             deferred_builds,
+            store_index_teardown: writer_task,
         })
     }
 }
@@ -888,6 +892,16 @@ pub struct InstallFrozenLockfileOutput {
     /// [`crate::BuildModulesOutput::deferred_builds`]. The caller folds
     /// them into `.modules.yaml.pendingBuilds`.
     pub deferred_builds: Vec<String>,
+    /// The store-index writer task, already winding down: every handle
+    /// was dropped before this output was built, so the task is
+    /// flushing its final batch and closing its `SQLite` connection —
+    /// which runs a WAL checkpoint. Await it via
+    /// [`StoreIndexWriter::drain`] as late as possible so that close
+    /// overlaps the caller's own tail writes instead of extending it.
+    /// (Dropping the handle on an error path is fine too: the task
+    /// keeps running detached, and an interrupted checkpoint is the
+    /// crash case WAL recovery exists for.)
+    pub store_index_teardown: tokio::task::JoinHandle<Result<(), StoreIndexError>>,
 }
 
 impl From<HoistedLinkerError> for InstallFrozenLockfileError {

--- a/pnpm/crates/deps-restorer/src/install_frozen_lockfile.rs
+++ b/pnpm/crates/deps-restorer/src/install_frozen_lockfile.rs
@@ -815,15 +815,12 @@ where
             .map_err(InstallFrozenLockfileError::BuildPhase)?;
 
         // Drop the orchestrator's clone of the writer so the channel
-        // closes once every per-snapshot clone has also been dropped.
-        // The writer task then flushes its final batch and closes its
-        // `SQLite` connection — and that close runs a WAL checkpoint,
-        // measured at ~40 ms of pure install tail for a cold
-        // 1346-package install. Nothing after this point reads the
-        // index, so the task is handed back to the caller as
+        // closes once every per-snapshot clone has also been dropped
+        // and the task starts its final flush and connection close.
+        // Nothing after this point reads the index, so the task is
+        // handed back as
         // [`InstallFrozenLockfileOutput::store_index_teardown`] and
-        // awaited only after the `.modules.yaml` / lockfile writes it
-        // can overlap with.
+        // awaited by the install driver after its own tail writes.
         drop(store_index_writer);
 
         // The injectedDeps payload for `.modules.yaml`: every `file:`
@@ -892,15 +889,12 @@ pub struct InstallFrozenLockfileOutput {
     /// [`crate::BuildModulesOutput::deferred_builds`]. The caller folds
     /// them into `.modules.yaml.pendingBuilds`.
     pub deferred_builds: Vec<String>,
-    /// The store-index writer task, already winding down: every handle
-    /// was dropped before this output was built, so the task is
-    /// flushing its final batch and closing its `SQLite` connection —
-    /// which runs a WAL checkpoint. Await it via
-    /// [`StoreIndexWriter::drain`] as late as possible so that close
-    /// overlaps the caller's own tail writes instead of extending it.
-    /// (Dropping the handle on an error path is fine too: the task
-    /// keeps running detached, and an interrupted checkpoint is the
-    /// crash case WAL recovery exists for.)
+    /// The store-index writer task, already winding down: every writer
+    /// handle was dropped before this output was built. Await it via
+    /// [`StoreIndexWriter::drain`] after any tail writes it can
+    /// overlap with; dropping it instead (error paths) detaches the
+    /// teardown, which is safe. The full rationale lives at the await
+    /// site in the install driver.
     pub store_index_teardown: tokio::task::JoinHandle<Result<(), StoreIndexError>>,
 }
 

--- a/pnpm/crates/package-manager/src/install/materialize.rs
+++ b/pnpm/crates/package-manager/src/install/materialize.rs
@@ -77,11 +77,9 @@ pub(super) struct MaterializationOutput {
     pub(super) install_skipped: crate::SkippedSnapshots,
     pub(super) fresh_lockfile: Option<Lockfile>,
     /// The store-index writer task, already winding down (both install
-    /// paths dropped every writer handle before returning). Its final
-    /// flush and `SQLite` close — a WAL checkpoint, ~40 ms of pure tail
-    /// on a cold install — are still in flight; the caller awaits it
-    /// via [`pnpm_store_dir::StoreIndexWriter::drain`] after the
-    /// `.modules.yaml` / lockfile writes it can overlap with.
+    /// paths dropped every writer handle before returning). The caller
+    /// awaits it after the tail writes it can overlap with — the full
+    /// rationale lives at the await site in `run.rs`.
     pub(super) store_index_teardown: StoreIndexTeardown,
 }
 

--- a/pnpm/crates/package-manager/src/install/materialize.rs
+++ b/pnpm/crates/package-manager/src/install/materialize.rs
@@ -63,6 +63,11 @@ pub(super) struct MaterializationInputs<'a, 'install> {
     pub(super) prefix: &'a str,
 }
 
+/// The store-index writer's wind-down task — see
+/// [`MaterializationOutput::store_index_teardown`].
+pub(super) type StoreIndexTeardown =
+    tokio::task::JoinHandle<Result<(), pnpm_store_dir::StoreIndexError>>;
+
 pub(super) struct MaterializationOutput {
     pub(super) ignored_builds: Vec<String>,
     pub(super) deferred_builds: Vec<String>,
@@ -71,6 +76,13 @@ pub(super) struct MaterializationOutput {
     pub(super) hoisted_locations: BTreeMap<String, Vec<String>>,
     pub(super) install_skipped: crate::SkippedSnapshots,
     pub(super) fresh_lockfile: Option<Lockfile>,
+    /// The store-index writer task, already winding down (both install
+    /// paths dropped every writer handle before returning). Its final
+    /// flush and `SQLite` close — a WAL checkpoint, ~40 ms of pure tail
+    /// on a cold install — are still in flight; the caller awaits it
+    /// via [`pnpm_store_dir::StoreIndexWriter::drain`] after the
+    /// `.modules.yaml` / lockfile writes it can overlap with.
+    pub(super) store_index_teardown: StoreIndexTeardown,
 }
 
 pub(super) async fn materialize<Reporter: self::Reporter + 'static>(
@@ -130,11 +142,18 @@ pub(super) async fn materialize<Reporter: self::Reporter + 'static>(
     let injected_deps: BTreeMap<String, Vec<String>>;
     let effective_node_version =
         config.node_version.clone().or_else(|| node_version_from_engines_runtime(manifest.value()));
-    let (hoisted_dependencies, hoisted_locations, install_skipped, fresh_lockfile): (
+    let (
+        hoisted_dependencies,
+        hoisted_locations,
+        install_skipped,
+        fresh_lockfile,
+        store_index_teardown,
+    ): (
         HoistedDependencies,
         BTreeMap<String, Vec<String>>,
         crate::SkippedSnapshots,
         Option<Lockfile>,
+        StoreIndexTeardown,
     ) = if take_frozen_path {
         let lockfile = lockfile.expect("dispatch verified lockfile is present");
         // pnpm's headless installer announces itself whenever it is
@@ -283,6 +302,7 @@ pub(super) async fn materialize<Reporter: self::Reporter + 'static>(
             frozen_result.hoisted_locations,
             frozen_result.skipped,
             None,
+            frozen_result.store_index_teardown,
         )
     } else {
         // Re-verify the existing lockfile alongside the fresh resolve,
@@ -401,6 +421,7 @@ pub(super) async fn materialize<Reporter: self::Reporter + 'static>(
             fresh_result.hoisted_locations,
             fresh_result.skipped,
             fresh_result.wanted_lockfile,
+            fresh_result.store_index_teardown,
         )
     };
 
@@ -412,5 +433,6 @@ pub(super) async fn materialize<Reporter: self::Reporter + 'static>(
         hoisted_locations,
         install_skipped,
         fresh_lockfile,
+        store_index_teardown,
     })
 }

--- a/pnpm/crates/package-manager/src/install/run.rs
+++ b/pnpm/crates/package-manager/src/install/run.rs
@@ -956,6 +956,7 @@ where
             hoisted_locations,
             install_skipped,
             fresh_lockfile,
+            store_index_teardown,
         } = materialize::<Reporter>(MaterializationInputs {
             tarball_mem_cache,
             resolved_packages,
@@ -1046,7 +1047,22 @@ where
             catalogs,
             verified_file_integrity_baseline,
         })
-        .await
+        .await?;
+
+        // Only now wait out the store-index writer's teardown — its
+        // final flush and the WAL checkpoint `SQLite` runs when the
+        // connection closes (~40 ms of otherwise pure tail on a cold
+        // install) have been overlapping every write above since the
+        // install paths dropped their writer handles. An error path
+        // that returned before this point dropped the handle instead,
+        // detaching the task: an interrupted checkpoint is exactly the
+        // crash case WAL recovery exists for.
+        pnpm_store_dir::StoreIndexWriter::drain(
+            store_index_teardown,
+            "; some rows may not be persisted",
+        )
+        .await;
+        Ok(())
     }
 }
 

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1663,11 +1663,10 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             .map_err(InstallWithFreshLockfileError::BuildPhase)?;
 
         // Drop the orchestration's writer handle so the channel closes
-        // once the build phase's side-effects-cache rows are queued.
-        // The task's final flush and `SQLite` close (a WAL checkpoint,
-        // ~40 ms of pure tail on a cold install) then overlap the
-        // lockfile save below and the caller's `.modules.yaml` writes —
-        // it is returned as `store_index_teardown` and awaited last.
+        // once the build phase's side-effects-cache rows are queued and
+        // the task starts winding down. It is returned as
+        // `store_index_teardown` and awaited by the install driver
+        // after the tail writes it overlaps.
         drop(store_index_writer);
 
         let injected_deps = crate::collect_injected_deps(

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -687,6 +687,13 @@ pub struct InstallWithFreshLockfileResult {
     /// Installability-skipped optional snapshots. The outer install
     /// writer persists these into `.modules.yaml.skipped`.
     pub skipped: SkippedSnapshots,
+    /// The store-index writer task, already winding down — see
+    /// [`pnpm_deps_restorer::InstallFrozenLockfileOutput::store_index_teardown`]:
+    /// every handle was dropped, the task is flushing its final batch
+    /// and closing its `SQLite` connection (a WAL checkpoint). Await it
+    /// via [`pnpm_store_dir::StoreIndexWriter::drain`] as late as
+    /// possible so the close overlaps the caller's tail writes.
+    pub store_index_teardown: tokio::task::JoinHandle<Result<(), pnpm_store_dir::StoreIndexError>>,
 }
 
 impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
@@ -1655,15 +1662,13 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             )
             .map_err(InstallWithFreshLockfileError::BuildPhase)?;
 
-        // Drop the orchestration's writer handle so the channel closes,
-        // then wait for the final batch flush — now including any
-        // side-effects-cache rows the build phase queued. Errors are
-        // downgraded to `warn!` (see `create_virtual_store.rs`): the
-        // install is complete and a missed cache write just forces a
-        // re-fetch on the next install.
+        // Drop the orchestration's writer handle so the channel closes
+        // once the build phase's side-effects-cache rows are queued.
+        // The task's final flush and `SQLite` close (a WAL checkpoint,
+        // ~40 ms of pure tail on a cold install) then overlap the
+        // lockfile save below and the caller's `.modules.yaml` writes —
+        // it is returned as `store_index_teardown` and awaited last.
         drop(store_index_writer);
-        pnpm_store_dir::StoreIndexWriter::drain(writer_task, "; some rows may not be persisted")
-            .await;
 
         let injected_deps = crate::collect_injected_deps(
             &layout,
@@ -1703,6 +1708,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             ignored_builds,
             deferred_builds,
             skipped,
+            store_index_teardown: writer_task,
         })
     }
 }
@@ -1938,9 +1944,9 @@ async fn finish_lockfile_only<Reporter: self::Reporter>(
     };
 
     // Close the writer cleanly even though no rows were written,
-    // mirroring the drain at the tail of the materializing path.
+    // mirroring the materializing path: drop closes the channel, the
+    // caller awaits the returned task after its own tail writes.
     drop(store_index_writer);
-    pnpm_store_dir::StoreIndexWriter::drain(writer_task, " during a lockfile-only install").await;
 
     Reporter::emit(&LogEvent::Stage(StageLog {
         level: LogLevel::Debug,
@@ -1956,6 +1962,7 @@ async fn finish_lockfile_only<Reporter: self::Reporter>(
         ignored_builds: Vec::new(),
         deferred_builds: Vec::new(),
         skipped: SkippedSnapshots::new(),
+        store_index_teardown: writer_task,
     })
 }
 


### PR DESCRIPTION
Closing the store-index writer's SQLite connection runs a WAL checkpoint, and both install paths awaited that close inline — after the last byte of the install had already landed, making it pure install tail.

**Measured** (alotta-files fixture, 1346 packages, cold cache + cold store, trusted lockfile, 50ms RTT / 200 Mbit/s emulated link, 4 cores): the final `StoreIndexWriter::drain` blocked the install for **39–46 ms** — after every row had long been committed. The wait is the checkpoint SQLite runs when the last connection closes (verified by timing `drop(conn)` directly: `close_ms: 46`). The rest of the writer's work is negligible — the whole install's batched flushes total ~3 ms.

Two designs were measured and rejected before this one:

- `SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE`: skips the cost entirely, but breaks `open_immutable` consumers — an immutable open ignores the WAL, so a store whose last writer never checkpointed would look empty on a read-only filesystem (two existing store-dir tests catch exactly this).
- Incremental passive checkpoints from the writer thread (every 256 rows): the close-time cost barely moved (46 → 34 ms) — it is dominated by a fixed fsync/unlink floor, not by WAL volume — while adding five mid-install checkpoints.

So the fix moves the *wait*, not the work: the writer handles are dropped at the same points as before (the flush and close start just as early), but the `JoinHandle` now rides the install outputs up to the top-level install driver, which awaits it only after the `.modules.yaml` and lockfile writes the close can overlap with. Paired A/B on the benchmark row above: **−30 ms mean wall** (6/8 pairs faster); the win should be larger on CI runners where fsync is slower.

An error path that returns before the final await just drops the handle: the teardown finishes detached, and an interrupted checkpoint is the crash case WAL recovery exists for.

Part of the #14015 effort (official-benchmark trusted-lockfile row: pnpm 3.4s vs bun 3.0s over a 2.8s bandwidth floor — the gap is entirely lead-in + tail, and this removes a fixed slice of the tail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789762618&installation_model_id=426870&pr_number=14020&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14020&signature=e10d5782eb4d71d7213b7e22b56c6c019c8b454a5ab1f5be92d2f2c48a3d6224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved installation speed by overlapping final metadata writes with store-index shutdown.
  * Reduced unnecessary waiting during frozen-lockfile, fresh-lockfile, and lockfile-only installations.
* **Reliability**
  * Installations now complete only after final store-index flushing and closure finish.
  * Cleanup errors are handled without interrupting otherwise successful installations.
* **Documentation**
  * Added release documentation describing the updated installation shutdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->