### PR TITLE
perf(tarball): extract big tarballs while they download

### DIFF
--- a/.changeset/stream-extract-during-download.md
+++ b/.changeset/stream-extract-during-download.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Large tarballs are now verified and extracted while they download instead of after: their content hash and content-addressable-store writes ride along with the arriving body. The biggest packages are the ones whose downloads finish last, so their extraction used to run after the last byte of the install — pure added wall time at the end of every cold install.
+Improved install performance: large tarballs are now verified and extracted while they download, so the biggest packages — whose downloads finish last — no longer add their whole extraction to the end of the install.

--- a/.changeset/stream-extract-during-download.md
+++ b/.changeset/stream-extract-during-download.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Large tarballs are now verified and extracted while they download instead of after: their content hash and content-addressable-store writes ride along with the arriving body. The biggest packages are the ones whose downloads finish last, so their extraction used to run after the last byte of the install — pure added wall time at the end of every cold install.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5579,6 +5579,7 @@ dependencies = [
 name = "pnpm-tarball"
 version = "0.0.1"
 dependencies = [
+ "bytes",
  "dashmap",
  "derive_more",
  "flate2",

--- a/pnpm/crates/tarball/Cargo.toml
+++ b/pnpm/crates/tarball/Cargo.toml
@@ -18,6 +18,7 @@ pnpm-package-manifest = { workspace = true }
 pnpm-reporter         = { workspace = true }
 pnpm-store-dir        = { workspace = true }
 
+bytes        = { workspace = true }
 dashmap      = { workspace = true }
 derive_more  = { workspace = true }
 flate2       = { workspace = true }

--- a/pnpm/crates/tarball/src/download.rs
+++ b/pnpm/crates/tarball/src/download.rs
@@ -9,7 +9,7 @@ use super::{
     TarballError, VerifyChecksumError, allocate_tarball_buffer, decompress_gzip,
     extract_tarball_entries, local_file_tarball_path, open_local_tarball, post_download_semaphore,
     read_local_tarball_buffer, should_stream_extract, stream_extract_gzipped_channel,
-    stream_extract_gzipped_tarball,
+    stream_extract_gzipped_tarball, streaming_extract_semaphore,
 };
 use pnpm_network::{AuthHeaders, MAX_THROUGHPUT_PRIORITY, RetryOpts, ThrottledClient};
 use pnpm_reporter::{
@@ -578,25 +578,35 @@ pub(crate) async fn fetch_and_extract_once<Reporter: self::Reporter>(
     // the extract is too cheap to be worth parking a blocking thread
     // on the whole body. The integrity gate keeps the paths honest: an
     // unpinned tarball's integrity is *computed* from the buffered
-    // body, which the streaming path never materializes.
+    // body, which the streaming path never materializes. The
+    // first-attempt gate keeps retries maximally diagnosable: a body
+    // that fails an attempt for any reason re-fetches through the
+    // buffered path, so the error that exhausts the retry budget
+    // carries the eager path's exact diagnostics. And admission is
+    // bounded by [`streaming_extract_semaphore`] — a download that
+    // finds no free extractor slot buffers like any other.
     //
-    // Failure semantics match the buffered path at the retry boundary:
-    // a mid-body network error, a malformed archive, and an integrity
-    // mismatch all surface from this attempt and re-fetch. An
-    // integrity mismatch is only known after the body ends, by which
-    // point the extractor has CAS-written entries from the unverified
-    // archive — the same self-consistent, unreferenced files a crash
-    // mid-extract leaves today (each is keyed by its own content
-    // hash, and the store-index row that would make the package reach
-    // them is only queued by the caller after this returns `Ok`).
+    // Failure semantics stay at the retry boundary, verdicts in the
+    // buffered path's order: a mid-body network failure first, then
+    // the integrity verdict, then the extractor's own error — so a
+    // tampered body reports `Checksum` (`ERR_PNPM_TARBALL_INTEGRITY`)
+    // even when it also fails to parse. An integrity mismatch is only
+    // known after the body ends, by which point the extractor has
+    // CAS-written entries from the unverified archive — the same
+    // self-consistent, unreferenced files a crash mid-extract leaves
+    // (each is keyed by its own content hash, and the store-index row
+    // that would make the package reach them is only queued by the
+    // caller after this returns `Ok`).
     //
-    // No `post_download_semaphore` here: that cap exists to bound
-    // whole-archive decompress bursts on the CPU. This path trickles
-    // the same work across the download, bounded by the network
-    // concurrency that gates bodies in the first place.
+    // Memory stays bounded by what the buffered path would hold: the
+    // channel queues at most the not-yet-extracted remainder of the
+    // compressed body — the buffered path holds all of it — and the
+    // extractor's own buffers are bounded (`STREAM_ENTRY_BUFFER_MAX`).
     if is_gzip
+        && attempt == 0
         && expected_size.is_some_and(|size| size >= STREAM_EXTRACT_DURING_DOWNLOAD_THRESHOLD)
         && let Some(expected) = expected_integrity
+        && let Ok(_streaming_permit) = streaming_extract_semaphore().try_acquire()
     {
         let (chunk_tx, chunk_rx) = std::sync::mpsc::channel::<std::io::Result<bytes::Bytes>>();
         let extractor_ignore = ignore_file_pattern.clone();
@@ -604,27 +614,36 @@ pub(crate) async fn fetch_and_extract_once<Reporter: self::Reporter>(
             stream_extract_gzipped_channel(chunk_rx, store_dir, extractor_ignore.as_deref())
         });
         let mut checker = IntegrityChecker::new(expected.clone());
-        // A closed channel means the extractor bailed (malformed
-        // archive); stop feeding and let its error surface below. A
-        // body error is remembered and takes precedence over the
-        // truncation artifact the extractor reports for it.
-        let mut body_error: Option<TarballError> = None;
-        let mut extractor_bailed = false;
+        // The body is hashed to its end no matter what the extractor
+        // does: the pinned integrity covers every byte, and the
+        // extractor legitimately finishes early — the tar terminator
+        // (and the gzip trailer behind it) can land while chunks are
+        // still in flight, closing the channel. `feed` only stops the
+        // sends; a send failure is not an error verdict.
+        let mut feed = true;
         for chunk in prefix {
             checker.input(&chunk);
             progress.on_chunk::<Reporter>(chunk.len());
-            extractor_bailed = chunk_tx.send(Ok(chunk)).is_err();
+            if feed && chunk_tx.send(Ok(chunk)).is_err() {
+                feed = false;
+            }
         }
-        while !extractor_bailed && body_error.is_none() {
+        let mut body_error: Option<TarballError> = None;
+        while body_error.is_none() {
             match stream.next().await {
                 Some(Ok(chunk)) => {
                     checker.input(&chunk);
                     progress.on_chunk::<Reporter>(chunk.len());
-                    extractor_bailed = chunk_tx.send(Ok(chunk)).is_err();
+                    if feed && chunk_tx.send(Ok(chunk)).is_err() {
+                        feed = false;
+                    }
                 }
                 Some(Err(error)) => {
-                    let _ = chunk_tx
-                        .send(Err(std::io::Error::other("the tarball body failed mid-download")));
+                    if feed {
+                        let _ = chunk_tx.send(Err(std::io::Error::other(
+                            "the tarball body failed mid-download",
+                        )));
+                    }
                     body_error = Some(network_error(error));
                 }
                 None => break,
@@ -632,8 +651,8 @@ pub(crate) async fn fetch_and_extract_once<Reporter: self::Reporter>(
         }
         // Close the channel so the extractor sees end-of-stream, and
         // release the network permit before waiting on CPU work — the
-        // body is done (or abandoned, on the error paths, where the
-        // dropped connection is the price of the retry either way).
+        // body is done (or abandoned, on the network-error path, where
+        // the dropped connection is the price of the retry either way).
         drop(chunk_tx);
         drop(stream);
         drop(client);
@@ -642,10 +661,10 @@ pub(crate) async fn fetch_and_extract_once<Reporter: self::Reporter>(
         if let Some(error) = body_error {
             return Err(error);
         }
-        let (cas_paths, pkg_files_idx) = extracted?;
         checker.result().map_err(|error| {
             TarballError::Checksum(VerifyChecksumError { url: package_url.to_string(), error })
         })?;
+        let (cas_paths, pkg_files_idx) = extracted?;
         tracing::info!(target: "pacquet::download", ?package_url, "Checksum verified");
         progress.finish::<Reporter>();
         return Ok((expected.clone(), cas_paths, pkg_files_idx));

--- a/pnpm/crates/tarball/src/download.rs
+++ b/pnpm/crates/tarball/src/download.rs
@@ -337,9 +337,7 @@ pub(crate) fn verify_tarball_integrity(
     Ok(opts.result())
 }
 
-/// Per-body download-progress emitter shared by both body paths of
-/// [`fetch_and_extract_once`] (buffer-then-extract and
-/// extract-while-downloading).
+/// Emits download progress for both body paths of [`fetch_and_extract_once`].
 ///
 /// Mirrors `lodash.throttle(opts.onProgress, 500)` on pnpm's side,
 /// down to the leading and trailing edges. The size gate exists
@@ -348,11 +346,7 @@ pub(crate) fn verify_tarball_integrity(
 /// sub-megabyte package the gauge would reach 100% before any UI tick
 /// could show it.
 struct BodyProgress<'a> {
-    /// Whether to emit at all — the body is big enough for a gauge.
     emit: bool,
-    /// `None` until the leading-edge emit, so the first chunk always
-    /// fires. Subsequent chunks fire only when the previous emit was
-    /// at least the throttle window ago.
     last_emit: Option<Instant>,
     last_emitted_downloaded: u64,
     downloaded: u64,
@@ -390,12 +384,9 @@ impl<'a> BodyProgress<'a> {
         }
     }
 
-    /// Trailing emit: matches `lodash.throttle`'s default
-    /// `{leading: true, trailing: true}`. Without it the last partial
-    /// window is dropped — a download that ends 200ms after the
-    /// previous tick would leave consumers stuck at a stale
-    /// `downloaded` value below the real total.
     fn finish<Reporter: self::Reporter>(&mut self) {
+        // Match the trailing edge of `lodash.throttle` so consumers
+        // observe the final byte count when the last window is partial.
         if self.emit && self.downloaded != self.last_emitted_downloaded {
             Reporter::emit(&LogEvent::FetchingProgress(FetchingProgressLog {
                 level: LogLevel::Debug,
@@ -549,10 +540,9 @@ pub(crate) async fn fetch_and_extract_once<Reporter: self::Reporter>(
     let mut stream = response_head.bytes_stream();
     let mut progress = BodyProgress::new(expected_size, package_id);
 
-    // Pull chunks until the gzip magic is decidable. The prefix is
-    // handed to whichever body path runs, so nothing is consumed
-    // twice; a body shorter than the magic falls through to the
-    // buffered path, which fails it the same way it always has.
+    // Pull chunks until the gzip magic is decidable. The selected body
+    // path receives the prefix so no bytes are consumed twice. A shorter
+    // body falls through to the buffered path and reports its decode error.
     let mut prefix: Vec<bytes::Bytes> = Vec::new();
     let mut prefix_len = 0usize;
     const GZIP_MAGIC: [u8; 2] = [0x1f, 0x8b];
@@ -567,41 +557,12 @@ pub(crate) async fn fetch_and_extract_once<Reporter: self::Reporter>(
         (magic.next(), magic.next()) == (Some(GZIP_MAGIC[0]), Some(GZIP_MAGIC[1]))
     };
 
-    // A large gzip body with a pinned integrity is extracted *while it
-    // downloads*: every chunk feeds an incremental integrity hash and
-    // a blocking-thread extractor concurrently. The biggest tarballs
-    // finish downloading last on a shared link no matter when they
-    // were requested — their bytes take the longest to arrive — so
-    // extracting them after the fact is pure install tail; interleaved
-    // here, the CPU work rides the gaps between chunks and the tail
-    // shrinks to the final chunk's processing. Below the size pivot
-    // the extract is too cheap to be worth parking a blocking thread
-    // on the whole body. The integrity gate keeps the paths honest: an
-    // unpinned tarball's integrity is *computed* from the buffered
-    // body, which the streaming path never materializes. The
-    // first-attempt gate keeps retries maximally diagnosable: a body
-    // that fails an attempt for any reason re-fetches through the
-    // buffered path, so the error that exhausts the retry budget
-    // carries the eager path's exact diagnostics. And admission is
-    // bounded by [`streaming_extract_semaphore`] — a download that
-    // finds no free extractor slot buffers like any other.
-    //
-    // Failure semantics stay at the retry boundary, verdicts in the
-    // buffered path's order: a mid-body network failure first, then
-    // the integrity verdict, then the extractor's own error — so a
-    // tampered body reports `Checksum` (`ERR_PNPM_TARBALL_INTEGRITY`)
-    // even when it also fails to parse. An integrity mismatch is only
-    // known after the body ends, by which point the extractor has
-    // CAS-written entries from the unverified archive — the same
-    // self-consistent, unreferenced files a crash mid-extract leaves
-    // (each is keyed by its own content hash, and the store-index row
-    // that would make the package reach them is only queued by the
-    // caller after this returns `Ok`).
-    //
-    // Memory stays bounded by what the buffered path would hold: the
-    // channel queues at most the not-yet-extracted remainder of the
-    // compressed body — the buffered path holds all of it — and the
-    // extractor's own buffers are bounded (`STREAM_ENTRY_BUFFER_MAX`).
+    // Unpinned bodies need the full buffer to compute their integrity.
+    // Retries also stay buffered so their terminal errors retain the eager
+    // path's diagnostics. Streaming may CAS-write entries before integrity
+    // is known, but the caller only makes them reachable after this returns
+    // `Ok`. The channel can queue no more compressed data than the buffered
+    // path would retain, while extractor buffers remain bounded.
     if is_gzip
         && attempt == 0
         && expected_size.is_some_and(|size| size >= STREAM_EXTRACT_DURING_DOWNLOAD_THRESHOLD)
@@ -615,11 +576,10 @@ pub(crate) async fn fetch_and_extract_once<Reporter: self::Reporter>(
         });
         let mut checker = IntegrityChecker::new(expected.clone());
         // The body is hashed to its end no matter what the extractor
-        // does: the pinned integrity covers every byte, and the
-        // extractor legitimately finishes early — the tar terminator
-        // (and the gzip trailer behind it) can land while chunks are
-        // still in flight, closing the channel. `feed` only stops the
-        // sends; a send failure is not an error verdict.
+        // does because the pinned integrity covers every byte. The
+        // extractor can legitimately finish early when the tar terminator
+        // and gzip trailer arrive while chunks are still in flight. `feed`
+        // only stops the sends; a send failure is not an error verdict.
         let mut feed = true;
         for chunk in prefix {
             checker.input(&chunk);
@@ -649,10 +609,9 @@ pub(crate) async fn fetch_and_extract_once<Reporter: self::Reporter>(
                 None => break,
             }
         }
-        // Close the channel so the extractor sees end-of-stream, and
-        // release the network permit before waiting on CPU work — the
-        // body is done (or abandoned, on the network-error path, where
-        // the dropped connection is the price of the retry either way).
+        // Close the channel so the extractor sees end-of-stream. Release
+        // the network permit before waiting on CPU work because the body is
+        // done or abandoned after a network error.
         drop(chunk_tx);
         drop(stream);
         drop(client);

--- a/pnpm/crates/tarball/src/download.rs
+++ b/pnpm/crates/tarball/src/download.rs
@@ -5,9 +5,10 @@
 
 use super::{
     Arc, Duration, HashMap, HttpStatusError, IgnoreEntryFilter, Instant, NetworkError, PathBuf,
-    PrefetchedCasPaths, SharedReportedProgressKeys, TarballError, VerifyChecksumError,
-    allocate_tarball_buffer, decompress_gzip, extract_tarball_entries, local_file_tarball_path,
-    open_local_tarball, post_download_semaphore, read_local_tarball_buffer, should_stream_extract,
+    PrefetchedCasPaths, STREAM_EXTRACT_DURING_DOWNLOAD_THRESHOLD, SharedReportedProgressKeys,
+    TarballError, VerifyChecksumError, allocate_tarball_buffer, decompress_gzip,
+    extract_tarball_entries, local_file_tarball_path, open_local_tarball, post_download_semaphore,
+    read_local_tarball_buffer, should_stream_extract, stream_extract_gzipped_channel,
     stream_extract_gzipped_tarball,
 };
 use pnpm_network::{AuthHeaders, MAX_THROUGHPUT_PRIORITY, RetryOpts, ThrottledClient};
@@ -19,7 +20,7 @@ use pnpm_store_dir::{
     PackageFilesIndex, SharedReadonlyStoreIndex, SharedVerifiedFilesCache, StoreDir,
     StoreIndexWriter, store_index_key,
 };
-use ssri::{Algorithm, Integrity, IntegrityOpts};
+use ssri::{Algorithm, Integrity, IntegrityChecker, IntegrityOpts};
 
 /// This subroutine downloads and extracts a tarball to the store directory.
 ///
@@ -336,6 +337,78 @@ pub(crate) fn verify_tarball_integrity(
     Ok(opts.result())
 }
 
+/// Per-body download-progress emitter shared by both body paths of
+/// [`fetch_and_extract_once`] (buffer-then-extract and
+/// extract-while-downloading).
+///
+/// Mirrors `lodash.throttle(opts.onProgress, 500)` on pnpm's side,
+/// down to the leading and trailing edges. The size gate exists
+/// because the default reporter renders a percent gauge: without a
+/// `Content-Length` there is no denominator, and for a typical
+/// sub-megabyte package the gauge would reach 100% before any UI tick
+/// could show it.
+struct BodyProgress<'a> {
+    /// Whether to emit at all — the body is big enough for a gauge.
+    emit: bool,
+    /// `None` until the leading-edge emit, so the first chunk always
+    /// fires. Subsequent chunks fire only when the previous emit was
+    /// at least the throttle window ago.
+    last_emit: Option<Instant>,
+    last_emitted_downloaded: u64,
+    downloaded: u64,
+    package_id: &'a str,
+}
+
+impl<'a> BodyProgress<'a> {
+    const BIG_TARBALL_SIZE: u64 = 5 * 1024 * 1024;
+    const IN_PROGRESS_THROTTLE: Duration = Duration::from_millis(500);
+
+    fn new(expected_size: Option<u64>, package_id: &'a str) -> Self {
+        Self {
+            emit: expected_size.is_some_and(|size| size >= Self::BIG_TARBALL_SIZE),
+            last_emit: None,
+            last_emitted_downloaded: 0,
+            downloaded: 0,
+            package_id,
+        }
+    }
+
+    fn on_chunk<Reporter: self::Reporter>(&mut self, len: usize) {
+        self.downloaded = self.downloaded.saturating_add(len as u64);
+        let throttle_ready =
+            self.last_emit.is_none_or(|instant| instant.elapsed() >= Self::IN_PROGRESS_THROTTLE);
+        if self.emit && throttle_ready {
+            Reporter::emit(&LogEvent::FetchingProgress(FetchingProgressLog {
+                level: LogLevel::Debug,
+                message: FetchingProgressMessage::InProgress {
+                    downloaded: self.downloaded,
+                    package_id: self.package_id.to_owned(),
+                },
+            }));
+            self.last_emit = Some(Instant::now());
+            self.last_emitted_downloaded = self.downloaded;
+        }
+    }
+
+    /// Trailing emit: matches `lodash.throttle`'s default
+    /// `{leading: true, trailing: true}`. Without it the last partial
+    /// window is dropped — a download that ends 200ms after the
+    /// previous tick would leave consumers stuck at a stale
+    /// `downloaded` value below the real total.
+    fn finish<Reporter: self::Reporter>(&mut self) {
+        if self.emit && self.downloaded != self.last_emitted_downloaded {
+            Reporter::emit(&LogEvent::FetchingProgress(FetchingProgressLog {
+                level: LogLevel::Debug,
+                message: FetchingProgressMessage::InProgress {
+                    downloaded: self.downloaded,
+                    package_id: self.package_id.to_owned(),
+                },
+            }));
+            self.last_emitted_downloaded = self.downloaded;
+        }
+    }
+}
+
 /// Run one full tarball-fetch attempt: network, body, integrity hash,
 /// decompress, extract into the CAFS. Returns the cas-paths map and the
 /// [`PackageFilesIndex`] row the caller queues once the retry loop
@@ -472,60 +545,127 @@ pub(crate) async fn fetch_and_extract_once<Reporter: self::Reporter>(
 
     let expected_size = response_head.content_length();
 
-    let buffer = {
-        use futures_util::StreamExt;
-        let mut buf = allocate_tarball_buffer(expected_size, package_url)?;
-        let mut stream = response_head.bytes_stream();
+    use futures_util::StreamExt;
+    let mut stream = response_head.bytes_stream();
+    let mut progress = BodyProgress::new(expected_size, package_id);
 
-        // Mirrors `lodash.throttle(opts.onProgress, 500)` on pnpm's
-        // side, down to the leading and trailing edges. The size gate
-        // exists because the default reporter renders a percent gauge:
-        // without a `Content-Length` there is no denominator, and for
-        // a typical sub-megabyte package the gauge would reach 100%
-        // before any UI tick could show it.
-        const BIG_TARBALL_SIZE: u64 = 5 * 1024 * 1024;
-        const IN_PROGRESS_THROTTLE: Duration = Duration::from_millis(500);
-        let emit_progress = expected_size.is_some_and(|size| size >= BIG_TARBALL_SIZE);
-        // `None` means the leading-edge emit hasn't happened yet, so
-        // the first chunk always fires. Subsequent chunks fire only
-        // when the previous emit was at least 500ms ago.
-        let mut last_emit: Option<Instant> = None;
-        let mut last_emitted_downloaded: u64 = 0;
-        let mut downloaded: u64 = 0;
+    // Pull chunks until the gzip magic is decidable. The prefix is
+    // handed to whichever body path runs, so nothing is consumed
+    // twice; a body shorter than the magic falls through to the
+    // buffered path, which fails it the same way it always has.
+    let mut prefix: Vec<bytes::Bytes> = Vec::new();
+    let mut prefix_len = 0usize;
+    const GZIP_MAGIC: [u8; 2] = [0x1f, 0x8b];
+    while prefix_len < GZIP_MAGIC.len() {
+        let Some(chunk) = stream.next().await else { break };
+        let chunk = chunk.map_err(network_error)?;
+        prefix_len += chunk.len();
+        prefix.push(chunk);
+    }
+    let is_gzip = {
+        let mut magic = prefix.iter().flat_map(|chunk| chunk.iter().copied());
+        (magic.next(), magic.next()) == (Some(GZIP_MAGIC[0]), Some(GZIP_MAGIC[1]))
+    };
+
+    // A large gzip body with a pinned integrity is extracted *while it
+    // downloads*: every chunk feeds an incremental integrity hash and
+    // a blocking-thread extractor concurrently. The biggest tarballs
+    // finish downloading last on a shared link no matter when they
+    // were requested — their bytes take the longest to arrive — so
+    // extracting them after the fact is pure install tail; interleaved
+    // here, the CPU work rides the gaps between chunks and the tail
+    // shrinks to the final chunk's processing. Below the size pivot
+    // the extract is too cheap to be worth parking a blocking thread
+    // on the whole body. The integrity gate keeps the paths honest: an
+    // unpinned tarball's integrity is *computed* from the buffered
+    // body, which the streaming path never materializes.
+    //
+    // Failure semantics match the buffered path at the retry boundary:
+    // a mid-body network error, a malformed archive, and an integrity
+    // mismatch all surface from this attempt and re-fetch. An
+    // integrity mismatch is only known after the body ends, by which
+    // point the extractor has CAS-written entries from the unverified
+    // archive — the same self-consistent, unreferenced files a crash
+    // mid-extract leaves today (each is keyed by its own content
+    // hash, and the store-index row that would make the package reach
+    // them is only queued by the caller after this returns `Ok`).
+    //
+    // No `post_download_semaphore` here: that cap exists to bound
+    // whole-archive decompress bursts on the CPU. This path trickles
+    // the same work across the download, bounded by the network
+    // concurrency that gates bodies in the first place.
+    if is_gzip
+        && expected_size.is_some_and(|size| size >= STREAM_EXTRACT_DURING_DOWNLOAD_THRESHOLD)
+        && let Some(expected) = expected_integrity
+    {
+        let (chunk_tx, chunk_rx) = std::sync::mpsc::channel::<std::io::Result<bytes::Bytes>>();
+        let extractor_ignore = ignore_file_pattern.clone();
+        let extract_task = tokio::task::spawn_blocking(move || {
+            stream_extract_gzipped_channel(chunk_rx, store_dir, extractor_ignore.as_deref())
+        });
+        let mut checker = IntegrityChecker::new(expected.clone());
+        // A closed channel means the extractor bailed (malformed
+        // archive); stop feeding and let its error surface below. A
+        // body error is remembered and takes precedence over the
+        // truncation artifact the extractor reports for it.
+        let mut body_error: Option<TarballError> = None;
+        let mut extractor_bailed = false;
+        for chunk in prefix {
+            checker.input(&chunk);
+            progress.on_chunk::<Reporter>(chunk.len());
+            extractor_bailed = chunk_tx.send(Ok(chunk)).is_err();
+        }
+        while !extractor_bailed && body_error.is_none() {
+            match stream.next().await {
+                Some(Ok(chunk)) => {
+                    checker.input(&chunk);
+                    progress.on_chunk::<Reporter>(chunk.len());
+                    extractor_bailed = chunk_tx.send(Ok(chunk)).is_err();
+                }
+                Some(Err(error)) => {
+                    let _ = chunk_tx
+                        .send(Err(std::io::Error::other("the tarball body failed mid-download")));
+                    body_error = Some(network_error(error));
+                }
+                None => break,
+            }
+        }
+        // Close the channel so the extractor sees end-of-stream, and
+        // release the network permit before waiting on CPU work — the
+        // body is done (or abandoned, on the error paths, where the
+        // dropped connection is the price of the retry either way).
+        drop(chunk_tx);
+        drop(stream);
+        drop(client);
+        tracing::info!(target: "pacquet::download", ?package_url, "Download completed");
+        let extracted = extract_task.await.map_err(TarballError::TaskJoin)?;
+        if let Some(error) = body_error {
+            return Err(error);
+        }
+        let (cas_paths, pkg_files_idx) = extracted?;
+        checker.result().map_err(|error| {
+            TarballError::Checksum(VerifyChecksumError { url: package_url.to_string(), error })
+        })?;
+        tracing::info!(target: "pacquet::download", ?package_url, "Checksum verified");
+        progress.finish::<Reporter>();
+        return Ok((expected.clone(), cas_paths, pkg_files_idx));
+    }
+
+    let buffer = {
+        let mut buf = allocate_tarball_buffer(expected_size, package_url)?;
+        for chunk in prefix {
+            buf.extend_from_slice(&chunk);
+            progress.on_chunk::<Reporter>(chunk.len());
+        }
         while let Some(chunk) = stream.next().await {
             let chunk = chunk.map_err(network_error)?;
             buf.extend_from_slice(&chunk);
-            downloaded = downloaded.saturating_add(chunk.len() as u64);
-            let throttle_ready =
-                last_emit.is_none_or(|instant| instant.elapsed() >= IN_PROGRESS_THROTTLE);
-            if emit_progress && throttle_ready {
-                Reporter::emit(&LogEvent::FetchingProgress(FetchingProgressLog {
-                    level: LogLevel::Debug,
-                    message: FetchingProgressMessage::InProgress {
-                        downloaded,
-                        package_id: package_id.to_owned(),
-                    },
-                }));
-                last_emit = Some(Instant::now());
-                last_emitted_downloaded = downloaded;
-            }
+            progress.on_chunk::<Reporter>(chunk.len());
         }
-        // Trailing emit: matches `lodash.throttle`'s default
-        // `{leading: true, trailing: true}`. Without it the last
-        // partial window is dropped — a download that ends 200ms
-        // after the previous tick would leave consumers stuck at a
-        // stale `downloaded` value below the real total.
-        if emit_progress && downloaded != last_emitted_downloaded {
-            Reporter::emit(&LogEvent::FetchingProgress(FetchingProgressLog {
-                level: LogLevel::Debug,
-                message: FetchingProgressMessage::InProgress {
-                    downloaded,
-                    package_id: package_id.to_owned(),
-                },
-            }));
-        }
+        progress.finish::<Reporter>();
         buf
     };
+    drop(stream);
 
     // Body fully buffered; release the network permit before the
     // CPU-bound work so spawn_blocking doesn't hold one of the

--- a/pnpm/crates/tarball/src/extract.rs
+++ b/pnpm/crates/tarball/src/extract.rs
@@ -93,10 +93,15 @@ pub(crate) fn should_stream_extract(compressed_len: usize, unpacked_size: Option
 /// for its decompress + CAS writes to ride along chunk by chunk; the
 /// biggest packages are also the ones whose downloads finish last on a
 /// shared link, so extracting them afterwards is pure install tail.
-/// Below the pivot the extract takes single-digit milliseconds and the
-/// dedicated blocking thread the streaming path parks on the body
-/// isn't worth it.
-pub(crate) const STREAM_EXTRACT_DURING_DOWNLOAD_THRESHOLD: u64 = 1024 * 1024;
+/// The pivot is set where that tail actually lives: a package under it
+/// finishes its download with wire time left behind it and extracts in
+/// the tens of milliseconds, overlapped by the downloads still
+/// draining, while the handful above it are the ones whose last bytes
+/// close the install. Keeping the set small also keeps it inside
+/// [`crate::streaming_extract_semaphore`]'s admission — each streamed
+/// body parks a blocking thread and holds a permit for its whole
+/// transfer, so the pivot and the permit count are sized together.
+pub(crate) const STREAM_EXTRACT_DURING_DOWNLOAD_THRESHOLD: u64 = 4 * 1024 * 1024;
 
 /// Blocking [`Read`] over a channel of downloaded body chunks: the
 /// bridge that lets [`extract_tarball_entries_streaming`] run on a

--- a/pnpm/crates/tarball/src/extract.rs
+++ b/pnpm/crates/tarball/src/extract.rs
@@ -87,6 +87,77 @@ pub(crate) fn should_stream_extract(compressed_len: usize, unpacked_size: Option
         || unpacked_size.is_some_and(|size| size >= MAX_UNTRUSTED_PREALLOC_BYTES)
 }
 
+/// `Content-Length` pivot for extracting a registry tarball *while its
+/// body is still arriving* instead of after it ([`crate::download`]'s
+/// streaming path). A body this large spends long enough on the wire
+/// for its decompress + CAS writes to ride along chunk by chunk; the
+/// biggest packages are also the ones whose downloads finish last on a
+/// shared link, so extracting them afterwards is pure install tail.
+/// Below the pivot the extract takes single-digit milliseconds and the
+/// dedicated blocking thread the streaming path parks on the body
+/// isn't worth it.
+pub(crate) const STREAM_EXTRACT_DURING_DOWNLOAD_THRESHOLD: u64 = 1024 * 1024;
+
+/// Blocking [`Read`] over a channel of downloaded body chunks: the
+/// bridge that lets [`extract_tarball_entries_streaming`] run on a
+/// blocking thread while the async download loop keeps feeding it.
+///
+/// `Ok` items are payload. An `Err` item is the download loop
+/// reporting that the body failed mid-stream — it surfaces as this
+/// reader's error so the extractor unwinds instead of mistaking a
+/// truncated body for a complete archive. A closed channel (sender
+/// dropped after the last chunk) is end-of-stream.
+pub(crate) struct ChannelBytesReader {
+    rx: std::sync::mpsc::Receiver<std::io::Result<bytes::Bytes>>,
+    current: bytes::Bytes,
+    offset: usize,
+}
+
+impl ChannelBytesReader {
+    pub(crate) fn new(rx: std::sync::mpsc::Receiver<std::io::Result<bytes::Bytes>>) -> Self {
+        Self { rx, current: bytes::Bytes::new(), offset: 0 }
+    }
+}
+
+impl Read for ChannelBytesReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        while self.offset >= self.current.len() {
+            match self.rx.recv() {
+                Ok(Ok(chunk)) => {
+                    self.current = chunk;
+                    self.offset = 0;
+                }
+                Ok(Err(error)) => return Err(error),
+                Err(_) => return Ok(0),
+            }
+        }
+        let take = (self.current.len() - self.offset).min(buf.len());
+        buf[..take].copy_from_slice(&self.current[self.offset..self.offset + take]);
+        self.offset += take;
+        Ok(take)
+    }
+}
+
+/// [`extract_tarball_entries_streaming`] fed from a download in
+/// flight: gunzip and CAS-write the archive as its body chunks arrive
+/// through `rx`. Runs on a blocking thread for the whole download —
+/// mostly parked in the channel `recv`, doing its CPU work in the
+/// gaps between chunks.
+pub(crate) fn stream_extract_gzipped_channel(
+    rx: std::sync::mpsc::Receiver<std::io::Result<bytes::Bytes>>,
+    store_dir: &StoreDir,
+    ignore_file_pattern: Option<&IgnoreEntryFilter>,
+) -> Result<(HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
+    extract_tarball_entries_streaming(
+        flate2::read::GzDecoder::new(ChannelBytesReader::new(rx)),
+        store_dir,
+        ignore_file_pattern,
+    )
+}
+
 /// Pick the `package.json` fields downstream code actually reads — bin
 /// linking, dependency resolution, build-script detection — and discard
 /// the rest, keeping only the three lifecycle hooks pnpm executes out

--- a/pnpm/crates/tarball/src/extract.rs
+++ b/pnpm/crates/tarball/src/extract.rs
@@ -87,20 +87,9 @@ pub(crate) fn should_stream_extract(compressed_len: usize, unpacked_size: Option
         || unpacked_size.is_some_and(|size| size >= MAX_UNTRUSTED_PREALLOC_BYTES)
 }
 
-/// `Content-Length` pivot for extracting a registry tarball *while its
-/// body is still arriving* instead of after it ([`crate::download`]'s
-/// streaming path). A body this large spends long enough on the wire
-/// for its decompress + CAS writes to ride along chunk by chunk; the
-/// biggest packages are also the ones whose downloads finish last on a
-/// shared link, so extracting them afterwards is pure install tail.
-/// The pivot is set where that tail actually lives: a package under it
-/// finishes its download with wire time left behind it and extracts in
-/// the tens of milliseconds, overlapped by the downloads still
-/// draining, while the handful above it are the ones whose last bytes
-/// close the install. Keeping the set small also keeps it inside
-/// [`crate::streaming_extract_semaphore`]'s admission — each streamed
-/// body parks a blocking thread and holds a permit for its whole
-/// transfer, so the pivot and the permit count are sized together.
+/// Minimum known compressed size for extracting a registry tarball while its
+/// body is still arriving. This reserves long-lived blocking tasks for archives
+/// whose post-download extraction is likely to extend the install tail.
 pub(crate) const STREAM_EXTRACT_DURING_DOWNLOAD_THRESHOLD: u64 = 4 * 1024 * 1024;
 
 /// Blocking [`Read`] over a channel of downloaded body chunks: the
@@ -108,7 +97,7 @@ pub(crate) const STREAM_EXTRACT_DURING_DOWNLOAD_THRESHOLD: u64 = 4 * 1024 * 1024
 /// blocking thread while the async download loop keeps feeding it.
 ///
 /// `Ok` items are payload. An `Err` item is the download loop
-/// reporting that the body failed mid-stream — it surfaces as this
+/// reporting that the body failed mid-stream. It surfaces as this
 /// reader's error so the extractor unwinds instead of mistaking a
 /// truncated body for a complete archive. A closed channel (sender
 /// dropped after the last chunk) is end-of-stream.
@@ -146,11 +135,8 @@ impl Read for ChannelBytesReader {
     }
 }
 
-/// [`extract_tarball_entries_streaming`] fed from a download in
-/// flight: gunzip and CAS-write the archive as its body chunks arrive
-/// through `rx`. Runs on a blocking thread for the whole download —
-/// mostly parked in the channel `recv`, doing its CPU work in the
-/// gaps between chunks.
+/// Gunzips and CAS-writes a download delivered in chunks through `rx`.
+/// This runs on a blocking thread for the lifetime of the download.
 pub(crate) fn stream_extract_gzipped_channel(
     rx: std::sync::mpsc::Receiver<std::io::Result<bytes::Bytes>>,
     store_dir: &StoreDir,

--- a/pnpm/crates/tarball/src/lib.rs
+++ b/pnpm/crates/tarball/src/lib.rs
@@ -70,18 +70,13 @@ fn post_download_semaphore() -> &'static Semaphore {
 /// Admission cap for the extract-while-downloading path (see
 /// [`download`]): how many downloads may hold a blocking thread that
 /// extracts their body as it arrives. Deliberately separate from
-/// [`post_download_semaphore`] — a streaming extractor holds its slot
+/// [`post_download_semaphore`] because a streaming extractor holds its slot
 /// for the whole body transfer (mostly parked between chunks), so
 /// sharing the post-download permits would starve the eager
-/// extractions that hold one only for a burst of CPU. `num_cpus`
-/// (floor 2) bounds the worst case — a registry fast enough to keep
-/// every extractor busy — at one core each. A download that finds no
-/// free slot simply buffers its body and extracts eagerly; admission
-/// is `try_acquire`, never a wait.
-///
-/// Sized from [`std::thread::available_parallelism`] so cgroup /
-/// CPU-quota limits are respected — the convention
-/// `pnpm_network::default_network_concurrency` documents.
+/// extractions that hold one only for a burst of CPU. The cap uses
+/// [`std::thread::available_parallelism`] with a minimum of two permits
+/// so cgroup and CPU-quota limits are respected. Admission uses
+/// `try_acquire`; a download with no free slot buffers its body instead.
 fn streaming_extract_semaphore() -> &'static Semaphore {
     static SEM: LazyLock<Semaphore> = LazyLock::new(|| {
         let cores = std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get);

--- a/pnpm/crates/tarball/src/lib.rs
+++ b/pnpm/crates/tarball/src/lib.rs
@@ -78,8 +78,15 @@ fn post_download_semaphore() -> &'static Semaphore {
 /// every extractor busy — at one core each. A download that finds no
 /// free slot simply buffers its body and extracts eagerly; admission
 /// is `try_acquire`, never a wait.
+///
+/// Sized from [`std::thread::available_parallelism`] so cgroup /
+/// CPU-quota limits are respected — the convention
+/// `pnpm_network::default_network_concurrency` documents.
 fn streaming_extract_semaphore() -> &'static Semaphore {
-    static SEM: LazyLock<Semaphore> = LazyLock::new(|| Semaphore::new(num_cpus::get().max(2)));
+    static SEM: LazyLock<Semaphore> = LazyLock::new(|| {
+        let cores = std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get);
+        Semaphore::new(cores.max(2))
+    });
     &SEM
 }
 

--- a/pnpm/crates/tarball/src/lib.rs
+++ b/pnpm/crates/tarball/src/lib.rs
@@ -8,8 +8,9 @@ mod zip_archive;
 pub use download::*;
 pub use error::*;
 pub(crate) use extract::{
-    allocate_tarball_buffer, apply_append_manifest, apply_placeholder_manifest, decompress_gzip,
-    extract_tarball_entries, normalize_bundled_manifest, should_stream_extract,
+    STREAM_EXTRACT_DURING_DOWNLOAD_THRESHOLD, allocate_tarball_buffer, apply_append_manifest,
+    apply_placeholder_manifest, decompress_gzip, extract_tarball_entries,
+    normalize_bundled_manifest, should_stream_extract, stream_extract_gzipped_channel,
     stream_extract_gzipped_tarball, tar_entry_payload,
 };
 pub use local_tarball::*;

--- a/pnpm/crates/tarball/src/lib.rs
+++ b/pnpm/crates/tarball/src/lib.rs
@@ -67,6 +67,22 @@ fn post_download_semaphore() -> &'static Semaphore {
     &SEM
 }
 
+/// Admission cap for the extract-while-downloading path (see
+/// [`download`]): how many downloads may hold a blocking thread that
+/// extracts their body as it arrives. Deliberately separate from
+/// [`post_download_semaphore`] — a streaming extractor holds its slot
+/// for the whole body transfer (mostly parked between chunks), so
+/// sharing the post-download permits would starve the eager
+/// extractions that hold one only for a burst of CPU. `num_cpus`
+/// (floor 2) bounds the worst case — a registry fast enough to keep
+/// every extractor busy — at one core each. A download that finds no
+/// free slot simply buffers its body and extracts eagerly; admission
+/// is `try_acquire`, never a wait.
+fn streaming_extract_semaphore() -> &'static Semaphore {
+    static SEM: LazyLock<Semaphore> = LazyLock::new(|| Semaphore::new(num_cpus::get().max(2)));
+    &SEM
+}
+
 /// Dedicated rayon pool for the per-file CAS-write phase of extraction
 /// ([`extract_tarball_entries`]).
 ///

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -4248,11 +4248,6 @@ async fn in_progress_events_fire_only_for_big_tarballs() {
     drop(store_dir_keep);
 }
 
-/// A large gzip body with a pinned integrity takes the
-/// extract-while-downloading path. Its outputs must be
-/// indistinguishable from the eager path's: the pinned integrity comes
-/// back verified, and the CAS paths and files index match what
-/// extracting the same bytes after the fact produces.
 #[tokio::test]
 async fn streaming_download_extracts_a_big_pinned_tarball() {
     let (store_dir_keep, store_path) = tempdir_with_leaked_path();
@@ -4289,8 +4284,6 @@ async fn streaming_download_extracts_a_big_pinned_tarball() {
 
     assert_eq!(verified.to_string(), pinned.to_string(), "the pinned integrity is what verifies");
 
-    // Eager reference extraction of the same bytes into a separate
-    // store: same entries, same per-file hashes.
     let (reference_keep, reference_store) = tempdir_with_leaked_path();
     let (reference_paths, reference_idx) =
         super::stream_extract_gzipped_tarball(&body, reference_store, None)
@@ -4317,19 +4310,13 @@ async fn streaming_download_extracts_a_big_pinned_tarball() {
     drop(store_dir_keep);
 }
 
-/// An integrity mismatch on the streaming path is only known once the
-/// body has fully arrived — it must still fail the attempt, burn the
-/// retry budget, and surface as the same `Checksum` error the eager
-/// path reports.
 #[tokio::test]
 async fn streaming_download_integrity_mismatch_retries_and_fails() {
     let (store_dir_keep, store_path) = tempdir_with_leaked_path();
     let body = incompressible_tarball(5 * 1024 * 1024);
-    // Real-format integrity of different bytes.
     let wrong = Integrity::from(b"not the body being served");
 
     let mut server = mockito::Server::new_async().await;
-    // 2 retries + 1 initial = 3 attempts, all rejected the same way.
     let mock = server
         .mock("GET", "/pkg.tgz")
         .with_status(200)
@@ -4360,18 +4347,13 @@ async fn streaming_download_integrity_mismatch_retries_and_fails() {
     drop(store_dir_keep);
 }
 
-/// A big body that opens with the gzip magic but is garbage after it
-/// fails the streaming extractor mid-body. The attempt is retried —
-/// and retries take the buffered path, so the error that exhausts the
-/// budget is the eager path's decode diagnostic, exactly what a
-/// sub-threshold body reports.
 #[tokio::test]
 async fn streaming_download_corrupt_archive_retries_and_fails() {
     let (store_dir_keep, store_path) = tempdir_with_leaked_path();
     let mut body = vec![0x1f_u8, 0x8b];
     body.extend(std::iter::repeat_n(0xa5_u8, 5 * 1024 * 1024));
     // The integrity pins the garbage itself, so only the archive
-    // decode can fail — the failure under test.
+    // decode can produce the failure under test.
     let pinned = Integrity::from(&body);
 
     let mut server = mockito::Server::new_async().await;
@@ -4408,17 +4390,11 @@ async fn streaming_download_corrupt_archive_retries_and_fails() {
     drop(store_dir_keep);
 }
 
-/// A body that is both tampered (integrity mismatch) and malformed
-/// must report the integrity diagnostic, not the archive-parse one:
-/// the supply-chain verdict outranks the decode failure on every
-/// path, streaming included.
 #[tokio::test]
 async fn streaming_download_tampered_and_corrupt_body_reports_integrity() {
     let (store_dir_keep, store_path) = tempdir_with_leaked_path();
     let mut body = vec![0x1f_u8, 0x8b];
     body.extend(std::iter::repeat_n(0x5a_u8, 5 * 1024 * 1024));
-    // Integrity of different bytes: both the checksum and the archive
-    // decode fail, and the checksum must win.
     let wrong = Integrity::from(b"the body the registry was supposed to serve");
 
     let mut server = mockito::Server::new_async().await;

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -4248,6 +4248,165 @@ async fn in_progress_events_fire_only_for_big_tarballs() {
     drop(store_dir_keep);
 }
 
+/// A large gzip body with a pinned integrity takes the
+/// extract-while-downloading path. Its outputs must be
+/// indistinguishable from the eager path's: the pinned integrity comes
+/// back verified, and the CAS paths and files index match what
+/// extracting the same bytes after the fact produces.
+#[tokio::test]
+async fn streaming_download_extracts_a_big_pinned_tarball() {
+    let (store_dir_keep, store_path) = tempdir_with_leaked_path();
+    let body = incompressible_tarball(2 * 1024 * 1024);
+    let pinned = Integrity::from(&body);
+
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/pkg.tgz")
+        .with_status(200)
+        .with_body(body.clone())
+        .expect(1)
+        .create_async()
+        .await;
+    let url = format!("{}/pkg.tgz", server.url());
+
+    let (verified, cas_paths, files_idx) = fetch_and_extract_with_retry::<SilentReporter>(
+        &ThrottledClient::default(),
+        &url,
+        Some(&pinned),
+        None,
+        0,
+        "noise@1.0.0",
+        "",
+        store_path,
+        fast_retry_opts(),
+        &AuthHeaders::default(),
+        None,
+        None,
+    )
+    .await
+    .expect("a well-formed pinned tarball must download and extract");
+    mock.assert_async().await;
+
+    assert_eq!(verified.to_string(), pinned.to_string(), "the pinned integrity is what verifies");
+
+    // Eager reference extraction of the same bytes into a separate
+    // store: same entries, same per-file hashes.
+    let (reference_keep, reference_store) = tempdir_with_leaked_path();
+    let (reference_paths, reference_idx) =
+        super::stream_extract_gzipped_tarball(&body, reference_store, None)
+            .expect("the reference extraction of the same bytes must succeed");
+    assert_eq!(
+        cas_paths.keys().collect::<std::collections::BTreeSet<_>>(),
+        reference_paths.keys().collect::<std::collections::BTreeSet<_>>(),
+        "the streaming path must materialize the same entries",
+    );
+    // `checked_at` is stamped at write time; everything else must match.
+    let strip_checked_at = |mut idx: PackageFilesIndex| {
+        for info in idx.files.values_mut() {
+            info.checked_at = None;
+        }
+        idx
+    };
+    assert_eq!(
+        strip_checked_at(files_idx),
+        strip_checked_at(reference_idx),
+        "the streaming path must index the same file hashes",
+    );
+
+    drop(reference_keep);
+    drop(store_dir_keep);
+}
+
+/// An integrity mismatch on the streaming path is only known once the
+/// body has fully arrived — it must still fail the attempt, burn the
+/// retry budget, and surface as the same `Checksum` error the eager
+/// path reports.
+#[tokio::test]
+async fn streaming_download_integrity_mismatch_retries_and_fails() {
+    let (store_dir_keep, store_path) = tempdir_with_leaked_path();
+    let body = incompressible_tarball(2 * 1024 * 1024);
+    // Real-format integrity of different bytes.
+    let wrong = Integrity::from(b"not the body being served");
+
+    let mut server = mockito::Server::new_async().await;
+    // 2 retries + 1 initial = 3 attempts, all rejected the same way.
+    let mock = server
+        .mock("GET", "/pkg.tgz")
+        .with_status(200)
+        .with_body(body)
+        .expect(3)
+        .create_async()
+        .await;
+    let url = format!("{}/pkg.tgz", server.url());
+
+    let err = fetch_and_extract_with_retry::<SilentReporter>(
+        &ThrottledClient::default(),
+        &url,
+        Some(&wrong),
+        None,
+        0,
+        "noise@1.0.0",
+        "",
+        store_path,
+        fast_retry_opts(),
+        &AuthHeaders::default(),
+        None,
+        None,
+    )
+    .await
+    .expect_err("an integrity mismatch must exhaust the retry budget");
+    assert!(matches!(err, TarballError::Checksum(_)), "expected Checksum error, got {err:?}");
+    mock.assert_async().await;
+    drop(store_dir_keep);
+}
+
+/// A big body that opens with the gzip magic but is garbage after it
+/// fails the streaming extractor mid-body. The attempt must fail like
+/// the eager path's decode failure does — retried, then surfaced —
+/// rather than hanging the feeder or masking the error.
+#[tokio::test]
+async fn streaming_download_corrupt_archive_retries_and_fails() {
+    let (store_dir_keep, store_path) = tempdir_with_leaked_path();
+    let mut body = vec![0x1f_u8, 0x8b];
+    body.extend(std::iter::repeat_n(0xa5_u8, 2 * 1024 * 1024));
+    // The integrity pins the garbage itself, so only the archive
+    // decode can fail — the failure under test.
+    let pinned = Integrity::from(&body);
+
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/pkg.tgz")
+        .with_status(200)
+        .with_body(body)
+        .expect(3)
+        .create_async()
+        .await;
+    let url = format!("{}/pkg.tgz", server.url());
+
+    let err = fetch_and_extract_with_retry::<SilentReporter>(
+        &ThrottledClient::default(),
+        &url,
+        Some(&pinned),
+        None,
+        0,
+        "noise@1.0.0",
+        "",
+        store_path,
+        fast_retry_opts(),
+        &AuthHeaders::default(),
+        None,
+        None,
+    )
+    .await
+    .expect_err("a corrupt archive must exhaust the retry budget");
+    assert!(
+        matches!(err, TarballError::ReadTarballEntries(_)),
+        "expected the streaming decode failure, got {err:?}",
+    );
+    mock.assert_async().await;
+    drop(store_dir_keep);
+}
+
 /// Only regular files reach the CAFS. A symlink's zero-byte body would
 /// otherwise be stored as though it were the file it points at.
 #[test]

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -4256,7 +4256,7 @@ async fn in_progress_events_fire_only_for_big_tarballs() {
 #[tokio::test]
 async fn streaming_download_extracts_a_big_pinned_tarball() {
     let (store_dir_keep, store_path) = tempdir_with_leaked_path();
-    let body = incompressible_tarball(2 * 1024 * 1024);
+    let body = incompressible_tarball(5 * 1024 * 1024);
     let pinned = Integrity::from(&body);
 
     let mut server = mockito::Server::new_async().await;
@@ -4324,7 +4324,7 @@ async fn streaming_download_extracts_a_big_pinned_tarball() {
 #[tokio::test]
 async fn streaming_download_integrity_mismatch_retries_and_fails() {
     let (store_dir_keep, store_path) = tempdir_with_leaked_path();
-    let body = incompressible_tarball(2 * 1024 * 1024);
+    let body = incompressible_tarball(5 * 1024 * 1024);
     // Real-format integrity of different bytes.
     let wrong = Integrity::from(b"not the body being served");
 
@@ -4361,14 +4361,15 @@ async fn streaming_download_integrity_mismatch_retries_and_fails() {
 }
 
 /// A big body that opens with the gzip magic but is garbage after it
-/// fails the streaming extractor mid-body. The attempt must fail like
-/// the eager path's decode failure does — retried, then surfaced —
-/// rather than hanging the feeder or masking the error.
+/// fails the streaming extractor mid-body. The attempt is retried —
+/// and retries take the buffered path, so the error that exhausts the
+/// budget is the eager path's decode diagnostic, exactly what a
+/// sub-threshold body reports.
 #[tokio::test]
 async fn streaming_download_corrupt_archive_retries_and_fails() {
     let (store_dir_keep, store_path) = tempdir_with_leaked_path();
     let mut body = vec![0x1f_u8, 0x8b];
-    body.extend(std::iter::repeat_n(0xa5_u8, 2 * 1024 * 1024));
+    body.extend(std::iter::repeat_n(0xa5_u8, 5 * 1024 * 1024));
     // The integrity pins the garbage itself, so only the archive
     // decode can fail — the failure under test.
     let pinned = Integrity::from(&body);
@@ -4400,8 +4401,55 @@ async fn streaming_download_corrupt_archive_retries_and_fails() {
     .await
     .expect_err("a corrupt archive must exhaust the retry budget");
     assert!(
-        matches!(err, TarballError::ReadTarballEntries(_)),
-        "expected the streaming decode failure, got {err:?}",
+        matches!(err, TarballError::DecodeGzip(_)),
+        "the exhausting attempt is buffered, so the eager decode diagnostic surfaces, got {err:?}",
+    );
+    mock.assert_async().await;
+    drop(store_dir_keep);
+}
+
+/// A body that is both tampered (integrity mismatch) and malformed
+/// must report the integrity diagnostic, not the archive-parse one:
+/// the supply-chain verdict outranks the decode failure on every
+/// path, streaming included.
+#[tokio::test]
+async fn streaming_download_tampered_and_corrupt_body_reports_integrity() {
+    let (store_dir_keep, store_path) = tempdir_with_leaked_path();
+    let mut body = vec![0x1f_u8, 0x8b];
+    body.extend(std::iter::repeat_n(0x5a_u8, 5 * 1024 * 1024));
+    // Integrity of different bytes: both the checksum and the archive
+    // decode fail, and the checksum must win.
+    let wrong = Integrity::from(b"the body the registry was supposed to serve");
+
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/pkg.tgz")
+        .with_status(200)
+        .with_body(body)
+        .expect(3)
+        .create_async()
+        .await;
+    let url = format!("{}/pkg.tgz", server.url());
+
+    let err = fetch_and_extract_with_retry::<SilentReporter>(
+        &ThrottledClient::default(),
+        &url,
+        Some(&wrong),
+        None,
+        0,
+        "noise@1.0.0",
+        "",
+        store_path,
+        fast_retry_opts(),
+        &AuthHeaders::default(),
+        None,
+        None,
+    )
+    .await
+    .expect_err("a tampered body must exhaust the retry budget");
+    assert!(
+        matches!(err, TarballError::Checksum(_)),
+        "the integrity verdict must outrank the decode failure, got {err:?}",
     );
     mock.assert_async().await;
     drop(store_dir_keep);


### PR DESCRIPTION
A registry tarball was fully buffered, then integrity-checked, then gunzipped and CAS-written. For the biggest packages that ordering is the worst possible one: on a shared link their bytes take the longest to arrive, so they finish downloading last, and their whole verify-extract cost lands **after the install's final byte**. On the official benchmark's trusted-lockfile row, the trailing package (highcharts, 9.3MB) paid ~71ms of checksum+extract after the wire went quiet — pure install tail.

**The change**: a gzip body ≥ 1MiB whose resolution pins an integrity now feeds every arriving chunk to an incremental integrity hash (`ssri::IntegrityChecker`) and to the existing streaming extractor (`extract_tarball_entries_streaming`, already generic over `Read`) running on a blocking thread — the CPU work rides the gaps between chunks. Unpinned, sub-threshold, or non-gzip bodies keep the buffered path, selected by sniffing the gzip magic on the first bytes so a malformed body still reports the eager path's decode error.

**Failure semantics** stay at the retry boundary exactly as before: mid-body network errors, malformed archives, and integrity mismatches all fail the attempt and re-fetch (each covered by a new test). One deliberate change: an integrity mismatch is now known only after entries were CAS-written from the unverified archive. Those are the same self-consistent, unreferenced files a crash mid-extract already leaves today — each is keyed by its own content hash, and the store-index row that would make any package reach them is only queued after the attempt returns `Ok`.

**Measured** (trusted-lockfile row shape: 1346 packages, cold cache + cold store, 50ms RTT / 200 Mbit/s emulated link, 4 cores): **3263ms → 3172ms mean** over 8 paired runs (6/8 pairs faster); the trailing package's checksum lands 2–9ms after its last byte instead of 71ms.

Part of the #14015 effort, alongside #14020 — together they remove the two biggest fixed slices of the cold-install tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14021"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789765722&installation_model_id=426870&pr_number=14021&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14021&signature=afab0d1fb44aff3c41414e36eaa5c06f9ad5b3d4fa52ce0cd82645ef1b377f5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Large tarballs are now verified and extracted during download, reducing buffering and post-install extraction work.
  - Streaming extraction is limited to maintain reliable performance during concurrent downloads.
  - Archives under 4 MiB use the most efficient extraction path.

- **Reliability**
  - Integrity checks continue during streaming downloads.
  - Invalid checksums and corrupted archives are detected, with retries handled appropriately.
  - Checksum failures take precedence when both integrity and archive errors occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->