### PR TITLE
fix(cli): accept the universal --loglevel flag

### DIFF
--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -51,7 +51,7 @@ use super::{
     rebuild::RebuildArgs,
     remove::RemoveArgs,
     repo::RepoArgs,
-    reporter::ReporterType,
+    reporter::{LogLevelSetting, ReporterType},
     restart::RestartArgs,
     root::RootArgs,
     run::RunArgs,
@@ -172,6 +172,12 @@ pub struct CliArgs {
     )]
     pub reporter: ReporterType,
 
+    /// What level of logs to print. Mirrors pnpm's universal `--loglevel`
+    /// option: `silent` selects the silent reporter over any `--reporter`
+    /// choice; the other levels cap the default reporter's output.
+    #[clap(long, value_enum, global = true)]
+    pub loglevel: Option<LogLevelSetting>,
+
     /// Select which workspace projects to run on. Repeat to add more.
     /// Each selector can be a name pattern (`@scope/*`), a path (`./pkg`),
     /// a dependency query (`foo...`), an exclusion (`!bar`), a directory
@@ -237,6 +243,16 @@ fn parse_store_dir(value: &str) -> Result<PathBuf, std::convert::Infallible> {
 }
 
 impl CliArgs {
+    /// The reporter the command should drive: `--loglevel silent` forces
+    /// the silent reporter over any `--reporter` choice, mirroring the
+    /// reporter selection in pnpm 11's `main.ts`.
+    pub(crate) fn effective_reporter(&self) -> ReporterType {
+        if self.loglevel == Some(LogLevelSetting::Silent) {
+            return ReporterType::Silent;
+        }
+        self.reporter
+    }
+
     pub fn validate_command_scoped_global_options(&self) -> Result<(), clap::Error> {
         if self.resume_from.is_some() {
             self.validate_run_scoped_global_option("--resume-from")?;

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -1,7 +1,7 @@
 use super::{
     cli_command::{CliArgs, CliCommand},
     dispatch_install, dispatch_query, dispatch_script,
-    reporter::{ReporterType, configure_default_reporter, reporter_emit},
+    reporter::{ReporterType, configure_default_reporter, configure_max_log_level, reporter_emit},
 };
 use crate::{
     State,
@@ -67,7 +67,7 @@ impl CliArgs {
     pub fn configure_reporter(&self) {
         let dir = dunce::canonicalize(&self.dir).unwrap_or_else(|_| self.dir.clone());
         configure_default_reporter(
-            self.reporter,
+            self.effective_reporter(),
             &dir,
             self.command.default_reporter_summary_scope(),
             self.command.reports_scope(self.recursive),
@@ -75,6 +75,7 @@ impl CliArgs {
             self.recursive,
             self.command.uses_stderr_reporter(),
         );
+        configure_max_log_level(self.loglevel);
     }
 
     pub fn run_completion_if_requested(&self) -> miette::Result<bool> {
@@ -133,7 +134,7 @@ impl CliArgs {
             return false;
         }
         self.configure_reporter();
-        let emit = reporter_emit(self.reporter);
+        let emit = reporter_emit(self.effective_reporter());
         let finished = install_args.finished_via_up_to_date_fast_path(&dir, &config, emit);
         if finished {
             // The fast path returns from `main` before `run` reaches its
@@ -159,6 +160,7 @@ impl CliArgs {
         }
         self.configure_reporter();
 
+        let reporter = self.effective_reporter();
         // `version` short-circuits in `main`, never reaching dispatch.
         let CliArgs {
             command,
@@ -170,7 +172,8 @@ impl CliArgs {
             http_proxy,
             no_proxy,
             recursive,
-            reporter,
+            reporter: _,
+            loglevel: _,
             filter,
             filter_prod,
             workspace_root,

--- a/pnpm/crates/cli/src/cli_args/reporter.rs
+++ b/pnpm/crates/cli/src/cli_args/reporter.rs
@@ -1,5 +1,5 @@
 use clap::ValueEnum;
-use pnpm_default_reporter::{DefaultReporter, SummaryScope};
+use pnpm_default_reporter::{DefaultReporter, MaxLogLevel, SummaryScope};
 use pnpm_reporter::{LogEvent, NdjsonReporter, Reporter, SilentReporter};
 use std::path::Path;
 
@@ -18,6 +18,32 @@ pub enum ReporterType {
     Ndjson,
     /// No progress output.
     Silent,
+}
+
+/// Accepted values of pnpm's universal `--loglevel` option.
+///
+/// `silent` selects the silent reporter outright (see
+/// [`super::cli_command::CliArgs::effective_reporter`]); the other values
+/// become the default reporter's [`MaxLogLevel`] ceiling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum LogLevelSetting {
+    Silent,
+    Error,
+    Warn,
+    Info,
+    Debug,
+}
+
+impl LogLevelSetting {
+    fn as_max_log_level(self) -> Option<MaxLogLevel> {
+        match self {
+            LogLevelSetting::Silent => None,
+            LogLevelSetting::Error => Some(MaxLogLevel::Error),
+            LogLevelSetting::Warn => Some(MaxLogLevel::Warn),
+            LogLevelSetting::Info => Some(MaxLogLevel::Info),
+            LogLevelSetting::Debug => Some(MaxLogLevel::Debug),
+        }
+    }
 }
 
 /// Resolve a [`ReporterType`] to the monomorphized `emit` of its sink, for
@@ -52,5 +78,15 @@ pub(crate) fn configure_default_reporter(
     pnpm_default_reporter::set_is_recursive(is_recursive);
     if matches!(reporter, ReporterType::AppendOnly) {
         pnpm_default_reporter::force_append_only();
+    }
+}
+
+/// Seed the default reporter's verbosity ceiling from the `--loglevel`
+/// value. `silent` and an absent flag leave the [`MaxLogLevel::Info`]
+/// default in place — `silent` never reaches the default reporter (see
+/// [`super::cli_command::CliArgs::effective_reporter`]).
+pub(crate) fn configure_max_log_level(loglevel: Option<LogLevelSetting>) {
+    if let Some(level) = loglevel.and_then(LogLevelSetting::as_max_log_level) {
+        pnpm_default_reporter::set_max_log_level(level);
     }
 }

--- a/pnpm/crates/cli/src/cli_args/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/tests.rs
@@ -9,6 +9,7 @@ use super::{
         current_source_pnpm_version, package_manager_to_sync, parse_package_manager,
         read_manifest_json,
     },
+    reporter::{LogLevelSetting, ReporterType},
     unlink::UnlinkArgs,
 };
 use clap::Parser;
@@ -141,6 +142,64 @@ fn recursive_flag_is_global_and_parses_either_side_of_subcommand() {
         .expect("parses install --recursive");
     assert!(after.recursive, "`install --recursive` → recursive");
     assert!(matches!(after.command, CliCommand::Install(_)));
+}
+
+#[test]
+fn loglevel_is_global_and_parses_on_either_side_of_the_subcommand() {
+    for argv in [
+        ["pacquet", "--loglevel", "error", "install"].as_slice(),
+        ["pacquet", "install", "--loglevel=error"].as_slice(),
+    ] {
+        let parsed = CliArgs::try_parse_from(argv).expect("parses global --loglevel");
+        assert_eq!(parsed.loglevel, Some(LogLevelSetting::Error));
+    }
+}
+
+/// The exact invocation electron-builder's node-module collector runs;
+/// rejecting it breaks Electron packaging
+/// ([pnpm/pnpm#14024](https://github.com/pnpm/pnpm/issues/14024)).
+#[test]
+fn list_accepts_the_electron_builder_collector_invocation() {
+    let parsed = CliArgs::try_parse_from([
+        "pacquet",
+        "list",
+        "--prod",
+        "--json",
+        "--depth",
+        "Infinity",
+        "--loglevel",
+        "error",
+    ])
+    .expect("parses the electron-builder `pnpm list` invocation");
+    assert!(matches!(parsed.command, CliCommand::List(_)));
+    assert_eq!(parsed.loglevel, Some(LogLevelSetting::Error));
+}
+
+#[test]
+fn loglevel_silent_forces_the_silent_reporter_over_the_reporter_flag() {
+    let parsed = CliArgs::try_parse_from([
+        "pacquet",
+        "--reporter",
+        "append-only",
+        "--loglevel",
+        "silent",
+        "install",
+    ])
+    .expect("parses --reporter with --loglevel silent");
+    assert!(matches!(parsed.effective_reporter(), ReporterType::Silent));
+}
+
+#[test]
+fn non_silent_loglevels_keep_the_selected_reporter() {
+    let parsed =
+        CliArgs::try_parse_from(["pacquet", "--loglevel", "warn", "install"]).expect("parses");
+    assert!(matches!(parsed.effective_reporter(), ReporterType::Default));
+}
+
+#[test]
+fn loglevel_rejects_unknown_values() {
+    CliArgs::try_parse_from(["pacquet", "install", "--loglevel", "verbose"])
+        .expect_err("unknown loglevel value must be rejected");
 }
 
 #[test]

--- a/pnpm/crates/cli/src/shorthands.rs
+++ b/pnpm/crates/cli/src/shorthands.rs
@@ -11,8 +11,11 @@
 //!
 //! Only the universal shorthands whose expansion targets exist in pacquet
 //! are handled here. The loglevel family (`-d`, `-q`, `--quiet`,
-//! `--verbose`, ...) expands to `--loglevel=<level>`, which pacquet has
-//! not grown yet.
+//! `--verbose`, ...) is still not expanded: pacquet accepts `--loglevel`
+//! itself now, but some of the family's expansions (`--loglevel=verbose`,
+//! `--loglevel=silly`) are npm level names that pnpm's own `loglevel`
+//! setting rejects, and nopt only soft-drops them upstream — mapping that
+//! quirk is left for when the family lands.
 
 use crate::flag_relocation::{ArgTable, find_positional, token_width};
 use clap::Command;

--- a/pnpm/crates/cli/tests/suite/list.rs
+++ b/pnpm/crates/cli/tests/suite/list.rs
@@ -943,3 +943,35 @@ fn list_in_long_format_appends_manifest_details() {
     let ll_output = run_ok(&workspace, &["ll"]);
     assert_eq!(ll_output, output);
 }
+
+/// The exact flags electron-builder's node-module collector passes to
+/// `pnpm list`; the CLI rejecting `--loglevel` breaks Electron packaging
+/// ([pnpm/pnpm#14024](https://github.com/pnpm/pnpm/issues/14024)).
+#[test]
+fn list_accepts_the_global_loglevel_flag() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    fs::write(
+        workspace.join("package.json"),
+        json!({ "name": "app", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write package.json");
+
+    let output = pacquet
+        .with_arg("list")
+        .with_arg("--prod")
+        .with_arg("--json")
+        .with_arg("--depth")
+        .with_arg("Infinity")
+        .with_arg("--loglevel")
+        .with_arg("error")
+        .output()
+        .expect("spawn pacquet list");
+
+    assert!(
+        output.status.success(),
+        "list with --loglevel should succeed:\n{}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    drop(root);
+}

--- a/pnpm/crates/default-reporter/src/lib.rs
+++ b/pnpm/crates/default-reporter/src/lib.rs
@@ -40,6 +40,20 @@ static SUMMARY_SCOPE: OnceLock<SummaryScope> = OnceLock::new();
 static REPORTS_SCOPE: OnceLock<bool> = OnceLock::new();
 static HIDE_ADDED_PKGS_PROGRESS: OnceLock<bool> = OnceLock::new();
 static IS_RECURSIVE: OnceLock<bool> = OnceLock::new();
+static MAX_LOG_LEVEL: OnceLock<MaxLogLevel> = OnceLock::new();
+
+/// Verbosity ceiling for the rendered output, from pnpm's `--loglevel`
+/// setting. Mirrors `LOG_LEVEL_NUMBER` in `@pnpm/cli.default-reporter`
+/// (`error` = 0 ... `debug` = 3): a stream renders when its own tier is at
+/// or below the ceiling, so the derived order makes `Error` the quietest
+/// and `Debug` the loudest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum MaxLogLevel {
+    Error,
+    Warn,
+    Info,
+    Debug,
+}
 
 /// Which prefixes contribute to the packages-diff summary.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -111,6 +125,13 @@ pub fn set_hide_added_pkgs_progress(hide_added_pkgs_progress: bool) {
 /// configured value is retained.
 pub fn set_is_recursive(is_recursive: bool) {
     let _ = IS_RECURSIVE.set(is_recursive);
+}
+
+/// Configure the verbosity ceiling, backing pnpm's `--loglevel` option.
+/// Call once before the first event; ignored if already set. Defaults to
+/// [`MaxLogLevel::Info`], pnpm's fallback when no `loglevel` is given.
+pub fn set_max_log_level(level: MaxLogLevel) {
+    let _ = MAX_LOG_LEVEL.set(level);
 }
 
 fn cwd() -> String {
@@ -186,6 +207,7 @@ impl Sink {
                 reports_scope: REPORTS_SCOPE.get().copied().unwrap_or(false),
                 hide_added_pkgs_progress: HIDE_ADDED_PKGS_PROGRESS.get().copied().unwrap_or(false),
                 is_recursive: IS_RECURSIVE.get().copied().unwrap_or(false),
+                max_log_level: MAX_LOG_LEVEL.get().copied().unwrap_or(MaxLogLevel::Info),
                 ..state::ReporterOptions::default()
             },
         );

--- a/pnpm/crates/default-reporter/src/state.rs
+++ b/pnpm/crates/default-reporter/src/state.rs
@@ -457,9 +457,12 @@ impl ReporterState {
     /// streams (progress, stats, lifecycle, summary, `Done in ...`) need
     /// `info`, and the `pnpm` / `pnpm:global` misc streams filter per
     /// message level in [`Self::on_pnpm`], so errors always pass.
+    /// Dedupe-check issues always pass too — upstream reports them as an
+    /// error-level log (`ERR_PNPM_DEDUPE_CHECK_ISSUES` in
+    /// `reportError.ts`).
     fn level_permits(&self, event: &LogEvent) -> bool {
         match event {
-            LogEvent::Pnpm(_) | LogEvent::Global(_) => true,
+            LogEvent::Pnpm(_) | LogEvent::Global(_) | LogEvent::DedupeCheck(_) => true,
             LogEvent::RequestRetry(_) | LogEvent::Deprecation(_) => {
                 self.max_log_level >= MaxLogLevel::Warn
             }
@@ -1178,7 +1181,9 @@ impl ReporterState {
 
     fn on_pnpm(&mut self, level: LogLevel, message: &str, prefix: &str) {
         match level {
-            LogLevel::Debug => {}
+            LogLevel::Debug if self.max_log_level >= MaxLogLevel::Debug => {
+                self.push_block(message.to_string());
+            }
             LogLevel::Warn if self.max_log_level >= MaxLogLevel::Warn => {
                 self.push_warning(message);
             }
@@ -1192,7 +1197,7 @@ impl ReporterState {
                     }
                 }
             }
-            LogLevel::Warn | LogLevel::Info => {}
+            LogLevel::Debug | LogLevel::Warn | LogLevel::Info => {}
         }
     }
 

--- a/pnpm/crates/default-reporter/src/state.rs
+++ b/pnpm/crates/default-reporter/src/state.rs
@@ -22,7 +22,7 @@ use pnpm_reporter::{
 use serde_json::Value;
 
 use crate::{
-    SummaryScope,
+    MaxLogLevel, SummaryScope,
     colors::Colors,
     format::{
         contains_path, cut_line, format_prefix, format_prefix_no_trim, highlight_last_folder,
@@ -58,6 +58,8 @@ pub struct ReporterOptions {
     pub reports_scope: bool,
     /// Whether direct dependency warnings use workspace-relative prefixes.
     pub is_recursive: bool,
+    /// Verbosity ceiling from pnpm's `--loglevel` setting.
+    pub max_log_level: MaxLogLevel,
 }
 
 impl Default for ReporterOptions {
@@ -69,6 +71,7 @@ impl Default for ReporterOptions {
             summary_scope: SummaryScope::CurrentPrefix,
             reports_scope: false,
             is_recursive: false,
+            max_log_level: MaxLogLevel::Info,
         }
     }
 }
@@ -243,6 +246,7 @@ pub struct ReporterState {
     append_only: bool,
     hide_added_pkgs_progress: bool,
     hide_progress_prefix: bool,
+    max_log_level: MaxLogLevel,
     frame: Frame,
     last_frame: Option<String>,
 
@@ -342,6 +346,7 @@ impl ReporterState {
             summary_scope,
             reports_scope,
             is_recursive,
+            max_log_level,
         } = options;
         let mut diff = HashMap::new();
         for kind in SUMMARY_ORDER {
@@ -354,6 +359,7 @@ impl ReporterState {
             append_only,
             hide_added_pkgs_progress,
             hide_progress_prefix,
+            max_log_level,
             frame: Frame::new(append_only),
             last_frame: None,
             progress: HashMap::new(),
@@ -390,6 +396,9 @@ impl ReporterState {
     }
 
     pub fn handle(&mut self, event: &LogEvent) -> Output {
+        if !self.level_permits(event) {
+            return Output::None;
+        }
         if matches!(event, LogEvent::Summary(_) | LogEvent::ExecutionTime(_)) {
             self.flush_pending_lockfile_message();
         }
@@ -440,6 +449,22 @@ impl ReporterState {
             self.flush_pending_lockfile_message();
         }
         self.finish()
+    }
+
+    /// Which events render at the configured `--loglevel`, mirroring the
+    /// tiers in `@pnpm/cli.default-reporter`'s `reporterForClient`: the
+    /// request-retry and deprecation streams need `warn`, the visual
+    /// streams (progress, stats, lifecycle, summary, `Done in ...`) need
+    /// `info`, and the `pnpm` / `pnpm:global` misc streams filter per
+    /// message level in [`Self::on_pnpm`], so errors always pass.
+    fn level_permits(&self, event: &LogEvent) -> bool {
+        match event {
+            LogEvent::Pnpm(_) | LogEvent::Global(_) => true,
+            LogEvent::RequestRetry(_) | LogEvent::Deprecation(_) => {
+                self.max_log_level >= MaxLogLevel::Warn
+            }
+            _ => self.max_log_level >= MaxLogLevel::Info,
+        }
     }
 
     fn finish(&mut self) -> Output {
@@ -1154,9 +1179,11 @@ impl ReporterState {
     fn on_pnpm(&mut self, level: LogLevel, message: &str, prefix: &str) {
         match level {
             LogLevel::Debug => {}
-            LogLevel::Warn => self.push_warning(message),
+            LogLevel::Warn if self.max_log_level >= MaxLogLevel::Warn => {
+                self.push_warning(message);
+            }
             LogLevel::Error => self.push_block(message.to_string()),
-            LogLevel::Info => {
+            LogLevel::Info if self.max_log_level >= MaxLogLevel::Info => {
                 if prefix.is_empty() || prefix == self.cwd {
                     if message == "Lockfile is up to date, resolution step is skipped" {
                         self.pending_lockfile_message = Some(message.to_string());
@@ -1165,6 +1192,7 @@ impl ReporterState {
                     }
                 }
             }
+            LogLevel::Warn | LogLevel::Info => {}
         }
     }
 

--- a/pnpm/crates/default-reporter/tests/render.rs
+++ b/pnpm/crates/default-reporter/tests/render.rs
@@ -948,27 +948,30 @@ fn debug_messages_stay_hidden_at_the_default_loglevel() {
 
 /// Dedupe-check issues are an error-level log upstream
 /// (`ERR_PNPM_DEDUPE_CHECK_ISSUES` in `reportError.ts`), so they render
-/// even at the `error` ceiling.
+/// at every ceiling, including `error`.
 #[test]
-fn loglevel_error_still_renders_dedupe_check_issues() {
-    let mut reporter = state_with_options(ReporterOptions {
-        max_log_level: MaxLogLevel::Error,
-        ..ReporterOptions::default()
-    });
-    let frame = render(
-        &mut reporter,
-        vec![LogEvent::DedupeCheck(DedupeCheckLog {
-            level: LogLevel::Error,
-            message: "dedupe check issues".to_string(),
-            err: PnpmErrorLog {
-                code: "ERR_PNPM_DEDUPE_CHECK_ISSUES".to_string(),
+fn dedupe_check_issues_render_at_every_loglevel_ceiling() {
+    for max_log_level in
+        [MaxLogLevel::Error, MaxLogLevel::Warn, MaxLogLevel::Info, MaxLogLevel::Debug]
+    {
+        let mut reporter =
+            state_with_options(ReporterOptions { max_log_level, ..ReporterOptions::default() });
+        let frame = render(
+            &mut reporter,
+            vec![LogEvent::DedupeCheck(DedupeCheckLog {
+                level: LogLevel::Error,
                 message: "dedupe check issues".to_string(),
-            },
-            dedupe_check_issues: serde_json::Value::Null,
-            rendered: "resolution changes".to_string(),
-        })],
-    );
-    assert_eq!(frame, "\nresolution changes");
+                err: PnpmErrorLog {
+                    code: "ERR_PNPM_DEDUPE_CHECK_ISSUES".to_string(),
+                    message: "dedupe check issues".to_string(),
+                },
+                dedupe_check_issues: serde_json::Value::Null,
+                rendered: "resolution changes".to_string(),
+            })],
+        );
+        println!("ceiling: {max_log_level:?}");
+        assert_eq!(frame, "\nresolution changes");
+    }
 }
 
 #[test]

--- a/pnpm/crates/default-reporter/tests/render.rs
+++ b/pnpm/crates/default-reporter/tests/render.rs
@@ -4,7 +4,7 @@
 //! plain-text assertions and on for the ANSI-specific ones.
 
 use pnpm_default_reporter::{
-    SummaryScope,
+    MaxLogLevel, SummaryScope,
     colors::Colors,
     format::pretty_bytes,
     state::{Output, ReporterOptions, ReporterState},
@@ -890,6 +890,58 @@ fn full_install_frame_orders_blocks_like_pnpm() {
          Progress: resolved 1, reused 1, downloaded 0, added 1, done\n\
          Done in 1.2s using pnpm v0.0.1",
     );
+}
+
+fn pnpm_log(level: LogLevel, message: &str) -> LogEvent {
+    LogEvent::Pnpm(PnpmLog { level, message: message.to_string(), prefix: CWD.to_string() })
+}
+
+#[test]
+fn loglevel_error_suppresses_warnings_and_the_visual_streams() {
+    let mut reporter = state_with_options(ReporterOptions {
+        max_log_level: MaxLogLevel::Error,
+        ..ReporterOptions::default()
+    });
+    let frame = render(
+        &mut reporter,
+        vec![
+            pnpm_log(LogLevel::Warn, "deprecated package"),
+            pnpm_log(LogLevel::Info, "Already up to date"),
+            progress("resolved"),
+            LogEvent::ExecutionTime(ExecutionTimeLog {
+                level: LogLevel::Debug,
+                started_at: 0,
+                ended_at: 1200,
+            }),
+        ],
+    );
+    assert_eq!(frame, "");
+}
+
+#[test]
+fn loglevel_error_still_renders_errors() {
+    let mut reporter = state_with_options(ReporterOptions {
+        max_log_level: MaxLogLevel::Error,
+        ..ReporterOptions::default()
+    });
+    let frame = render(&mut reporter, vec![pnpm_log(LogLevel::Error, "ERR_PNPM_FETCH_404")]);
+    assert_eq!(frame, "ERR_PNPM_FETCH_404");
+}
+
+#[test]
+fn loglevel_warn_renders_warnings_but_not_info() {
+    let mut reporter = state_with_options(ReporterOptions {
+        max_log_level: MaxLogLevel::Warn,
+        ..ReporterOptions::default()
+    });
+    let frame = render(
+        &mut reporter,
+        vec![
+            pnpm_log(LogLevel::Info, "Already up to date"),
+            pnpm_log(LogLevel::Warn, "deprecated package"),
+        ],
+    );
+    assert_eq!(frame, "[WARN] deprecated package");
 }
 
 #[test]

--- a/pnpm/crates/default-reporter/tests/render.rs
+++ b/pnpm/crates/default-reporter/tests/render.rs
@@ -10,13 +10,14 @@ use pnpm_default_reporter::{
     state::{Output, ReporterOptions, ReporterState},
 };
 use pnpm_reporter::{
-    AddedRoot, ContextLog, DependencyType, DeprecationLog, ExecutionTimeLog, FetchingProgressLog,
-    FetchingProgressMessage, GlobalLog, HookLog, LifecycleLog, LifecycleMessage, LifecycleStdio,
-    LockfileVerificationLog, LockfileVerificationMessage, LogEvent, LogLevel, PackageImportMethod,
-    PackageImportMethodLog, PackageManifestLog, PackageManifestMessage, PnpmLog, ProgressLog,
-    ProgressMessage, RootLog, RootMessage, ScopeLog, SkippedOptionalDependencyLog,
-    SkippedOptionalPackage, SkippedOptionalParent, SkippedOptionalReason, Stage, StageLog,
-    StatsLog, StatsMessage, SummaryLog,
+    AddedRoot, ContextLog, DedupeCheckLog, DependencyType, DeprecationLog, ExecutionTimeLog,
+    FetchingProgressLog, FetchingProgressMessage, GlobalLog, HookLog, LifecycleLog,
+    LifecycleMessage, LifecycleStdio, LockfileVerificationLog, LockfileVerificationMessage,
+    LogEvent, LogLevel, PackageImportMethod, PackageImportMethodLog, PackageManifestLog,
+    PackageManifestMessage, PnpmErrorLog, PnpmLog, ProgressLog, ProgressMessage, RootLog,
+    RootMessage, ScopeLog, SkippedOptionalDependencyLog, SkippedOptionalPackage,
+    SkippedOptionalParent, SkippedOptionalReason, Stage, StageLog, StatsLog, StatsMessage,
+    SummaryLog,
 };
 
 const CWD: &str = "/repo";
@@ -926,6 +927,48 @@ fn loglevel_error_still_renders_errors() {
     });
     let frame = render(&mut reporter, vec![pnpm_log(LogLevel::Error, "ERR_PNPM_FETCH_404")]);
     assert_eq!(frame, "ERR_PNPM_FETCH_404");
+}
+
+#[test]
+fn loglevel_debug_renders_debug_messages() {
+    let mut reporter = state_with_options(ReporterOptions {
+        max_log_level: MaxLogLevel::Debug,
+        ..ReporterOptions::default()
+    });
+    let frame = render(&mut reporter, vec![pnpm_log(LogLevel::Debug, "resolution details")]);
+    assert_eq!(frame, "resolution details");
+}
+
+#[test]
+fn debug_messages_stay_hidden_at_the_default_loglevel() {
+    let mut reporter = state(false);
+    let frame = render(&mut reporter, vec![pnpm_log(LogLevel::Debug, "resolution details")]);
+    assert_eq!(frame, "");
+}
+
+/// Dedupe-check issues are an error-level log upstream
+/// (`ERR_PNPM_DEDUPE_CHECK_ISSUES` in `reportError.ts`), so they render
+/// even at the `error` ceiling.
+#[test]
+fn loglevel_error_still_renders_dedupe_check_issues() {
+    let mut reporter = state_with_options(ReporterOptions {
+        max_log_level: MaxLogLevel::Error,
+        ..ReporterOptions::default()
+    });
+    let frame = render(
+        &mut reporter,
+        vec![LogEvent::DedupeCheck(DedupeCheckLog {
+            level: LogLevel::Error,
+            message: "dedupe check issues".to_string(),
+            err: PnpmErrorLog {
+                code: "ERR_PNPM_DEDUPE_CHECK_ISSUES".to_string(),
+                message: "dedupe check issues".to_string(),
+            },
+            dedupe_check_issues: serde_json::Value::Null,
+            rendered: "resolution changes".to_string(),
+        })],
+    );
+    assert_eq!(frame, "\nresolution changes");
 }
 
 #[test]


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

pnpm 12 rejected the universal `--loglevel` flag outright (`error: unexpected argument '--loglevel' found`), while pnpm 11 accepts it on every command. This broke electron-builder: its node-module collector runs `pnpm list --prod --json --depth Infinity --loglevel error`, so every Electron packaging job on pnpm 12 fails with exit code 2.

This PR adds `--loglevel <silent|error|warn|info|debug>` as a global clap flag with pnpm 11 semantics:

- `silent` selects the silent reporter over any `--reporter` choice, mirroring the reporter selection in pnpm 11's `main.ts`.
- The other levels become a verbosity ceiling (`MaxLogLevel`, carried in the default reporter's `ReporterOptions`) that mirrors `LOG_LEVEL_NUMBER` in `@pnpm/cli.default-reporter`: request retries and deprecations render at `warn` and up, the visual streams (progress, stats, lifecycle, summary, `Done in ...`) render at `info` and up, and the `pnpm` / `pnpm:global` misc streams filter per message level, so errors always render.
- The stale note in `shorthands.rs` that said pacquet "has not grown" `--loglevel` is updated; the loglevel shorthand family (`-d`, `-q`, `--quiet`, `--verbose`, ...) stays unexpanded because some of its expansions (`verbose`, `silly`) are npm level names that pnpm's own `loglevel` setting rejects, and nopt only soft-drops them upstream.

Not in scope: the `loglevel` key from `.npmrc` / `pnpm-workspace.yaml` is still not consumed for reporter selection (same as the `reporter` config key today), because the reporter is configured before the lazily-loaded config exists. That can be a follow-up.

Closes [pnpm/pnpm#14024](https://github.com/pnpm/pnpm/issues/14024).

## Squash Commit Body

```text
pnpm 12 rejected --loglevel outright (clap: "unexpected argument"),
while pnpm 11 accepts it on every command. This broke electron-builder,
whose node-module collector runs
`pnpm list --prod --json --depth Infinity --loglevel error`.

Accept --loglevel as a global flag with pnpm 11 semantics:

- `silent` selects the silent reporter over any --reporter choice,
  mirroring the reporter selection in pnpm 11's main.ts.
- The other levels become a verbosity ceiling in the default reporter,
  mirroring LOG_LEVEL_NUMBER in `@pnpm/cli.default-reporter`: request
  retries and deprecations need warn, the visual streams need info, and
  the pnpm / pnpm:global misc streams filter per message level, so
  errors always render.

Closes pnpm/pnpm#14024.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (pnpm 11 already supports `--loglevel`; this PR brings the Rust CLI to
  parity, so the change is Rust-only.)
- [x] Added or updated tests. (Clap parse tests including the exact
  electron-builder invocation, default-reporter level-gating render tests,
  and an end-to-end test that spawns the binary with `--loglevel error`.)

<!-- Changeset: not applicable — no published TypeScript package changes.
Documentation: not needed — `--loglevel` is already documented for pnpm. -->

---
Written by an agent (Claude Code, claude-fable-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global `--loglevel` option supporting silent, error, warning, informational, and debug output.
  * Log-level settings now control displayed messages while preserving errors.
  * Silent mode overrides other reporter settings.
  * `list` commands support the global `--loglevel error` option.

* **Bug Fixes**
  * Improved reporter consistency across command execution paths.

* **Documentation**
  * Clarified that log-level shorthand expansion is not currently supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->