### PR TITLE
fix(audit): don't treat peer-satisfaction edges as real dependency edges

### DIFF
--- a/.changeset/fix-audit-peer-satisfaction-edges.md
+++ b/.changeset/fix-audit-peer-satisfaction-edges.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/deps.compliance.audit": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+Fixed `pnpm audit --prod`/`--dev` incorrectly reporting (and misclassifying) a package that only entered the resolved dependency graph because it was the concrete package chosen to satisfy another package's peer dependency, when that concrete package itself came from an excluded dependency type — for example, an optional peer satisfied by a devDependency, still reported under `--prod` [https://github.com/pnpm/pnpm/issues/13605](https://github.com/pnpm/pnpm/issues/13605).

--- a/pnpm/crates/cli/src/cli_args/audit.rs
+++ b/pnpm/crates/cli/src/cli_args/audit.rs
@@ -8,8 +8,9 @@ use node_semver::{Range, Version};
 use owo_colors::{OwoColorize, Stream};
 use pnpm_config::{AuditLevel as ConfigAuditLevel, Config};
 use pnpm_lockfile::{
-    EnvLockfile, ImporterDepVersion, Lockfile, PackageKey, PkgName, ResolvedDependencyMap,
-    SnapshotDepRef, SnapshotEntry, SpecifierAndResolution, pick_registry_for_package,
+    EnvLockfile, ImporterDepVersion, Lockfile, PackageKey, PackageMetadata, PkgName,
+    ResolvedDependencyMap, SnapshotDepRef, SnapshotEntry, SpecifierAndResolution,
+    pick_registry_for_package,
 };
 use pnpm_network::{RetryOpts, encode_package_name, send_with_retry};
 use pnpm_package_manager::{ResolutionObserver, ResolvedPackageHint, Update};
@@ -50,8 +51,8 @@ pub(crate) use report::{
 };
 pub(crate) use request::{
     AuditGraph, AuditIndexRequest, DepClass, DepKind, Edge, GraphImporter, Include,
-    append_snapshot_edges, classify_graph, empty_snapshots, env_roots, importer_roots,
-    lockfile_to_audit_request, root_included,
+    append_snapshot_edges, classify_graph, empty_packages, empty_snapshots, env_roots,
+    importer_roots, lockfile_to_audit_request, root_included,
 };
 pub(crate) use version_ranges::{
     caret_range_for_patched, infer_patched_versions, satisfies_including_prerelease, satisfies_safe,
@@ -477,8 +478,10 @@ fn retry_opts_from_config(config: &Config) -> RetryOpts {
 
 impl<'a> AuditGraph<'a> {
     fn main(lockfile: &'a Lockfile) -> Self {
-        let empty = empty_snapshots();
-        let snapshots = lockfile.snapshots.as_ref().unwrap_or(empty);
+        let empty_snaps = empty_snapshots();
+        let snapshots = lockfile.snapshots.as_ref().unwrap_or(empty_snaps);
+        let empty_pkgs = empty_packages();
+        let packages = lockfile.packages.as_ref().unwrap_or(empty_pkgs);
         let importers = lockfile
             .importers
             .iter()
@@ -487,7 +490,7 @@ impl<'a> AuditGraph<'a> {
                 roots: importer_roots(importer),
             })
             .collect();
-        Self { importers, snapshots }
+        Self { importers, snapshots, packages }
     }
 
     fn env(env_lockfile: &'a EnvLockfile) -> Self {
@@ -514,15 +517,21 @@ impl<'a> AuditGraph<'a> {
                 }
             }
         }
-        Self { importers, snapshots: &env_lockfile.snapshots }
+        Self { importers, snapshots: &env_lockfile.snapshots, packages: &env_lockfile.packages }
     }
 
     fn children(&self, key: &PackageKey, include_optional_edges: bool) -> Vec<Edge> {
         let Some(snapshot) = self.snapshots.get(key) else { return Vec::new() };
+        let peer_dependencies =
+            self.packages.get(&key.without_peer()).and_then(|pkg| pkg.peer_dependencies.as_ref());
         let mut children = Vec::new();
-        append_snapshot_edges(&mut children, snapshot.dependencies.as_ref());
+        append_snapshot_edges(&mut children, snapshot.dependencies.as_ref(), peer_dependencies);
         if include_optional_edges {
-            append_snapshot_edges(&mut children, snapshot.optional_dependencies.as_ref());
+            append_snapshot_edges(
+                &mut children,
+                snapshot.optional_dependencies.as_ref(),
+                peer_dependencies,
+            );
         }
         children
     }

--- a/pnpm/crates/cli/src/cli_args/audit/request.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/request.rs
@@ -1,8 +1,9 @@
 //! Turning a lockfile into the dependency graph the registry audits.
 
 use super::{
-    BTreeMap, EnvLockfile, HashMap, HashSet, ImporterDepVersion, Lockfile, PackageKey, PkgName,
-    ResolvedDependencyMap, SnapshotDepRef, SnapshotEntry, SpecifierAndResolution, package_version,
+    BTreeMap, EnvLockfile, HashMap, HashSet, ImporterDepVersion, Lockfile, PackageKey,
+    PackageMetadata, PkgName, ResolvedDependencyMap, SnapshotDepRef, SnapshotEntry,
+    SpecifierAndResolution, package_version,
 };
 
 #[derive(Debug, Default)]
@@ -43,12 +44,20 @@ pub(crate) struct GraphImporter {
 pub(crate) struct AuditGraph<'a> {
     pub(crate) importers: Vec<GraphImporter>,
     pub(crate) snapshots: &'a HashMap<PackageKey, SnapshotEntry>,
+    pub(crate) packages: &'a HashMap<PackageKey, PackageMetadata>,
 }
 
 pub(crate) fn empty_snapshots() -> &'static HashMap<PackageKey, SnapshotEntry> {
     use std::sync::OnceLock;
 
     static EMPTY: OnceLock<HashMap<PackageKey, SnapshotEntry>> = OnceLock::new();
+    EMPTY.get_or_init(HashMap::new)
+}
+
+pub(crate) fn empty_packages() -> &'static HashMap<PackageKey, PackageMetadata> {
+    use std::sync::OnceLock;
+
+    static EMPTY: OnceLock<HashMap<PackageKey, PackageMetadata>> = OnceLock::new();
     EMPTY.get_or_init(HashMap::new)
 }
 
@@ -83,12 +92,33 @@ pub(crate) fn env_roots(deps: &BTreeMap<String, SpecifierAndResolution>) -> Vec<
         .collect()
 }
 
+/// Appends `deps`' edges, skipping a peer-satisfaction edge — an entry
+/// whose alias is also one of `peer_dependencies` (the snapshot's own
+/// package's declared peers, looked up by the caller via the peer-stripped
+/// key since peer declarations live on the `packages:` entry, not the
+/// `snapshots:` entry). That entry doesn't exist because the package
+/// depends on it; it exists because that's the concrete package pnpm's peer
+/// resolution picked to satisfy the peer. Peer resolution only ever picks a
+/// package that's independently present via a genuine (non-peer) edge
+/// somewhere in the whole workspace tree, so a peer-satisfaction edge never
+/// needs to contribute reachability or appear as an install path — if the
+/// satisfying package is really available, it's already reachable via its
+/// own genuine edge; if it isn't (e.g. it's only a devDependency and
+/// `--prod` excludes devDependencies), the peer edge shouldn't make it
+/// "available" either. Without this, `pnpm audit --prod` would report a
+/// package that only exists in the resolved graph because an excluded
+/// dependency type (typically a devDependency) happened to satisfy another
+/// package's optional peer.
 pub(crate) fn append_snapshot_edges(
     children: &mut Vec<Edge>,
     deps: Option<&HashMap<PkgName, SnapshotDepRef>>,
+    peer_dependencies: Option<&HashMap<String, String>>,
 ) {
     let Some(deps) = deps else { return };
     for (name, dep_ref) in deps {
+        if peer_dependencies.is_some_and(|peers| peers.contains_key(&name.to_string())) {
+            continue;
+        }
         if let Some(key) = dep_ref.resolve(name) {
             children.push(Edge { key });
         }

--- a/pnpm/crates/cli/src/cli_args/audit/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/tests.rs
@@ -161,6 +161,182 @@ fn lockfile_to_audit_request_respects_prod_and_no_optional() {
 }
 
 #[test]
+fn lockfile_to_audit_request_excludes_package_only_present_via_optional_peer_satisfied_by_excluded_dev_dependency()
+ {
+    // <https://github.com/pnpm/pnpm/issues/13605> — hookform (a prod
+    // dependency) declares an optional peer on valibot; valibot is only
+    // otherwise present as a devDependency. Peer resolution mixes all
+    // dependency types, so the lockfile bakes valibot into hookform's
+    // snapshot regardless of --prod. A real --prod-only resolve would never
+    // have seen valibot to satisfy the peer with, so `pnpm audit --prod`
+    // must not report it at all.
+    let lockfile = parse_lockfile(
+        "
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      hookform:
+        specifier: '^1.0.0'
+        version: '1.0.0(valibot@1.2.0)'
+    devDependencies:
+      valibot:
+        specifier: '^1.2.0'
+        version: '1.2.0'
+
+packages:
+
+  hookform@1.0.0:
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    peerDependencies:
+      valibot: ^1.0.0
+    peerDependenciesMeta:
+      valibot:
+        optional: true
+
+  valibot@1.2.0:
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+
+snapshots:
+
+  hookform@1.0.0(valibot@1.2.0):
+    optionalDependencies:
+      valibot: 1.2.0
+
+  valibot@1.2.0: {}
+",
+    );
+
+    let full = lockfile_to_audit_request(&lockfile, None, all_dependencies());
+    assert_eq!(full.request["hookform"], vec!["1.0.0"]);
+    assert_eq!(full.request["valibot"], vec!["1.2.0"]);
+
+    let prod_only = lockfile_to_audit_request(
+        &lockfile,
+        None,
+        Include { dependencies: true, dev_dependencies: false, optional_dependencies: true },
+    );
+    assert_eq!(prod_only.request["hookform"], vec!["1.0.0"]);
+    assert!(!prod_only.request.contains_key("valibot"));
+}
+
+#[test]
+fn lockfile_to_audit_request_excludes_package_only_present_via_required_peer_satisfied_by_excluded_dev_dependency()
+ {
+    // Same bug class as the optional-peer test above, but for a required
+    // peer — a required-peer satisfaction edge lands in `dependencies`, not
+    // `optionalDependencies`, but is still keyed by the parent's own
+    // peerDependencies, so the fix (skip any alias present in
+    // peer_dependencies) covers this without extra logic.
+    let lockfile = parse_lockfile(
+        "
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      needs-react:
+        specifier: '^1.0.0'
+        version: '1.0.0(react@18.0.0)'
+    devDependencies:
+      react:
+        specifier: '^18.0.0'
+        version: '18.0.0'
+
+packages:
+
+  needs-react@1.0.0:
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    peerDependencies:
+      react: ^18.0.0
+
+  react@18.0.0:
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+
+snapshots:
+
+  needs-react@1.0.0(react@18.0.0):
+    dependencies:
+      react: 18.0.0
+
+  react@18.0.0: {}
+",
+    );
+
+    let prod_only = lockfile_to_audit_request(
+        &lockfile,
+        None,
+        Include { dependencies: true, dev_dependencies: false, optional_dependencies: true },
+    );
+    assert_eq!(prod_only.request["needs-react"], vec!["1.0.0"]);
+    assert!(!prod_only.request.contains_key("react"));
+}
+
+#[test]
+fn lockfile_to_audit_request_excludes_package_only_present_via_required_peer_satisfied_by_excluded_prod_dependency_dev_mirror()
+ {
+    // Required-peer mirror of the --prod test above, for --dev (include:
+    // {dependencies: false, optional_dependencies: false}). Unlike an
+    // optional-peer edge (which lives in optionalDependencies and is always
+    // gated by include.optional_dependencies), a required-peer edge lives in
+    // `dependencies`, which was followed unconditionally regardless of
+    // `include` before the fix — so, unlike the optional case, this
+    // scenario does exercise the fix under --dev.
+    let lockfile = parse_lockfile(
+        "
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      ui-lib:
+        specifier: '^2.0.0'
+        version: '2.0.0'
+    devDependencies:
+      needs-ui-lib:
+        specifier: '^1.0.0'
+        version: '1.0.0(ui-lib@2.0.0)'
+
+packages:
+
+  needs-ui-lib@1.0.0:
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    peerDependencies:
+      ui-lib: ^2.0.0
+
+  ui-lib@2.0.0:
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+
+snapshots:
+
+  needs-ui-lib@1.0.0(ui-lib@2.0.0):
+    dependencies:
+      ui-lib: 2.0.0
+
+  ui-lib@2.0.0: {}
+",
+    );
+
+    // ui-lib is a genuine prod dependency (independent of the peer edge), so
+    // it must still be reported under the default/full include.
+    let full = lockfile_to_audit_request(&lockfile, None, all_dependencies());
+    assert_eq!(full.request["needs-ui-lib"], vec!["1.0.0"]);
+    assert_eq!(full.request["ui-lib"], vec!["2.0.0"]);
+
+    let dev_only = lockfile_to_audit_request(
+        &lockfile,
+        None,
+        Include { dependencies: false, dev_dependencies: true, optional_dependencies: false },
+    );
+    assert_eq!(dev_only.request["needs-ui-lib"], vec!["1.0.0"]);
+    assert!(!dev_only.request.contains_key("ui-lib"));
+}
+
+#[test]
 fn lockfile_to_audit_request_accepts_absent_env_lockfile() {
     let lockfile = parse_lockfile(
         "
@@ -481,6 +657,67 @@ snapshots:
         Include { dependencies: true, dev_dependencies: false, optional_dependencies: true },
     );
     assert!(path_info(&prod_only, "shared-pkg", "1.0.0").optional);
+}
+
+#[test]
+fn build_audit_path_index_classifies_peer_satisfied_by_dev_dependency_as_dev_not_optional() {
+    // Same shape as the lockfile_to_audit_request "excludes ... optional
+    // peer ..." test above. Path building never follows the
+    // peer-satisfaction edge either — a peer-satisfaction edge isn't a real
+    // install path any more than it's real reachability — so valibot's only
+    // path is its own devDependency root, and it must be dev: true,
+    // optional: false: it's a real devDependency, not something reachable
+    // only through an optional edge.
+    let lockfile = parse_lockfile(
+        "
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      hookform:
+        specifier: '^1.0.0'
+        version: '1.0.0(valibot@1.2.0)'
+    devDependencies:
+      valibot:
+        specifier: '^1.2.0'
+        version: '1.2.0'
+
+packages:
+
+  hookform@1.0.0:
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    peerDependencies:
+      valibot: ^1.0.0
+    peerDependenciesMeta:
+      valibot:
+        optional: true
+
+  valibot@1.2.0:
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+
+snapshots:
+
+  hookform@1.0.0(valibot@1.2.0):
+    optionalDependencies:
+      valibot: 1.2.0
+
+  valibot@1.2.0: {}
+",
+    );
+
+    let index = build_audit_path_index(
+        &lockfile,
+        None,
+        &vulnerable_names(&["valibot"]),
+        all_dependencies(),
+    );
+
+    let info = path_info(&index, "valibot", "1.2.0");
+    assert_eq!(info.paths, vec![".>valibot"]);
+    assert!(info.dev);
+    assert!(!info.optional);
 }
 
 #[test]

--- a/pnpm11/deps/compliance/audit/src/index.ts
+++ b/pnpm11/deps/compliance/audit/src/index.ts
@@ -1,6 +1,5 @@
 import { PnpmError } from '@pnpm/error'
 import type { GetAuthHeader } from '@pnpm/fetching.types'
-import { detectDepTypes } from '@pnpm/lockfile.detect-dep-types'
 import type { EnvLockfile, LockfileObject } from '@pnpm/lockfile.types'
 import { type DispatcherOptions, fetchWithDispatcher, type RetryTimeoutOptions } from '@pnpm/network.fetch'
 import type { DependenciesField } from '@pnpm/types'
@@ -11,6 +10,8 @@ import {
   type AuditPathIndex,
   buildAuditPathIndex,
   collectOptionalOnlyDepPaths,
+  collectReachableDepPaths,
+  detectAuditDepTypes,
   lockfileToAuditRequest,
   type PathInfo,
 } from './lockfileToAuditIndex.js'
@@ -47,9 +48,10 @@ export async function audit (
     timeout?: number
   }
 ): Promise<AuditReport> {
-  const depTypes = detectDepTypes(lockfile)
-  const optionalOnly = collectOptionalOnlyDepPaths(lockfile, opts.include)
-  const auditRequest = lockfileToAuditRequest(lockfile, { envLockfile: opts.envLockfile, include: opts.include, depTypes, optionalOnly })
+  const depTypes = detectAuditDepTypes(lockfile)
+  const reachable = collectReachableDepPaths(lockfile, opts.include)
+  const optionalOnly = collectOptionalOnlyDepPaths(lockfile, opts.include, reachable)
+  const auditRequest = lockfileToAuditRequest(lockfile, { envLockfile: opts.envLockfile, include: opts.include, depTypes, optionalOnly, reachable })
   const registry = opts.registry.endsWith('/') ? opts.registry : `${opts.registry}/`
   const auditUrl = `${registry}-/npm/v1/security/advisories/bulk`
   const authHeaderValue = getAuthHeader(registry)

--- a/pnpm11/deps/compliance/audit/src/lockfileToAuditIndex.ts
+++ b/pnpm11/deps/compliance/audit/src/lockfileToAuditIndex.ts
@@ -1,7 +1,7 @@
 import * as dp from '@pnpm/deps.path'
-import { DepType, type DepTypes, detectDepTypes } from '@pnpm/lockfile.detect-dep-types'
+import { DepType, type DepTypes } from '@pnpm/lockfile.detect-dep-types'
 import { convertToLockfileObject } from '@pnpm/lockfile.fs'
-import type { EnvLockfile, LockfileObject, ResolvedDependencies } from '@pnpm/lockfile.types'
+import type { EnvLockfile, LockfileObject, PackageSnapshot, ResolvedDependencies } from '@pnpm/lockfile.types'
 import { nameVerFromPkgSnapshot } from '@pnpm/lockfile.utils'
 import { lockfileWalkerGroupImporterSteps, type LockfileWalkerStep } from '@pnpm/lockfile.walker'
 import type { DependenciesField, DepPath, ProjectId } from '@pnpm/types'
@@ -37,6 +37,10 @@ export interface AuditIndexOptions {
   // Pre-computed optional-only depPaths for the main lockfile. Shared between
   // lockfileToAuditRequest and buildAuditPathIndex when both are called.
   optionalOnly?: Set<DepPath>
+  // Pre-computed reachable depPaths for the main lockfile (collectReachableDepPaths).
+  // Shared with callers that already computed it (e.g. via collectOptionalOnlyDepPaths)
+  // so lockfileToAuditRequest doesn't walk the lockfile a second time.
+  reachable?: Set<DepPath>
 }
 
 export function lockfileToAuditRequest (
@@ -45,8 +49,9 @@ export function lockfileToAuditRequest (
 ): AuditIndexRequest {
   const importerIds = Object.keys(lockfile.importers) as ProjectId[]
   const importerWalkers = lockfileWalkerGroupImporterSteps(lockfile, importerIds, { include: opts.include })
-  const depTypes = opts.depTypes ?? detectDepTypes(lockfile)
-  const optionalOnly = opts.optionalOnly ?? collectOptionalOnlyDepPaths(lockfile, opts.include)
+  const depTypes = opts.depTypes ?? detectAuditDepTypes(lockfile)
+  const reachable = opts.reachable ?? collectReachableDepPaths(lockfile, opts.include)
+  const optionalOnly = opts.optionalOnly ?? collectOptionalOnlyDepPaths(lockfile, opts.include, reachable)
 
   // Use null-prototype objects for records keyed by package names so a
   // hostile or unusual package name (e.g. "__proto__") cannot pollute the
@@ -98,7 +103,7 @@ export function lockfileToAuditRequest (
   // explicit frame stack stands in for recursion (registering each dependency
   // before descending, preserving pre-order) so a deep dependency chain from an
   // untrusted lockfile cannot overflow the call stack.
-  const makeVisitor = (graphDepTypes: DepTypes, graphOptionalOnly: Set<DepPath>) => {
+  const makeVisitor = (graphDepTypes: DepTypes, graphOptionalOnly: Set<DepPath>, graphReachable: Set<DepPath>) => {
     return (rootStep: LockfileWalkerStep): void => {
       const stack: Array<{ dependencies: LockfileWalkerStep['dependencies'], next: number }> = [{ dependencies: rootStep.dependencies, next: 0 }]
       while (stack.length > 0) {
@@ -109,7 +114,12 @@ export function lockfileToAuditRequest (
         }
         const { depPath, pkgSnapshot, next } = frame.dependencies[frame.next++]
         const { name, version } = nameVerFromPkgSnapshot(depPath, pkgSnapshot)
-        if (version) {
+        // `@pnpm/lockfile.walker` follows every optionalDependencies edge
+        // unconditionally once inside the graph, including ones that only
+        // exist because they satisfy a peer of the parent — so it can visit
+        // a depPath that graphReachable (which excludes peer-satisfaction
+        // edges) correctly determined wouldn't be present under opts.include.
+        if (version && graphReachable.has(depPath)) {
           registerOccurrence({
             name,
             version,
@@ -122,15 +132,16 @@ export function lockfileToAuditRequest (
     }
   }
 
-  const visitMain = makeVisitor(depTypes, optionalOnly)
+  const visitMain = makeVisitor(depTypes, optionalOnly, reachable)
   for (const importerWalker of importerWalkers) {
     visitMain(importerWalker.step)
   }
   if (opts.envLockfile) {
     const envLockfileObject = envLockfileToLockfileObject(opts.envLockfile)
-    const envDepTypes = detectDepTypes(envLockfileObject)
-    const envOptionalOnly = collectOptionalOnlyDepPaths(envLockfileObject, opts.include)
-    const visitEnv = makeVisitor(envDepTypes, envOptionalOnly)
+    const envDepTypes = detectAuditDepTypes(envLockfileObject)
+    const envReachable = collectReachableDepPaths(envLockfileObject, opts.include)
+    const envOptionalOnly = collectOptionalOnlyDepPaths(envLockfileObject, opts.include, envReachable)
+    const visitEnv = makeVisitor(envDepTypes, envOptionalOnly, envReachable)
     for (const { step } of lockfileWalkerGroupImporterSteps(envLockfileObject, Object.keys(envLockfileObject.importers) as ProjectId[], { include: opts.include })) {
       visitEnv(step)
     }
@@ -147,8 +158,8 @@ export function buildAuditPathIndex (
   // Null-prototype record keyed by package name to avoid prototype pollution
   // from registry-supplied or lockfile-supplied names.
   const paths: AuditPathIndex = Object.create(null)
-  const depTypes = opts.depTypes ?? detectDepTypes(lockfile)
-  const optionalOnly = opts.optionalOnly ?? collectOptionalOnlyDepPaths(lockfile, opts.include)
+  const depTypes = opts.depTypes ?? detectAuditDepTypes(lockfile)
+  const optionalOnly = opts.optionalOnly ?? collectOptionalOnlyDepPaths(lockfile, opts.include, opts.reachable)
 
   walkForPaths({
     lockfile,
@@ -166,7 +177,7 @@ export function buildAuditPathIndex (
       lockfile: envLockfileObject,
       vulnerableNames,
       paths,
-      depTypes: detectDepTypes(envLockfileObject),
+      depTypes: detectAuditDepTypes(envLockfileObject),
       optionalOnly: collectOptionalOnlyDepPaths(envLockfileObject, opts.include),
       include: opts.include,
       importerSegmentOf: (importerId) => importerId,
@@ -229,11 +240,7 @@ function walkForPaths (ctx: WalkForPathsCtx): void {
         optionalOnly.has(edge.depPath))
     }
     if (allReachableVulnerabilitiesSaturated(paths, reachable, depTypes, optionalOnly)) return
-    const children: Array<{ name: string, depPath: DepPath }> = []
-    appendNamedDepPaths(children, pkgSnapshot.dependencies ?? {})
-    if (includeOptDeps) {
-      appendNamedDepPaths(children, pkgSnapshot.optionalDependencies ?? {})
-    }
+    const children = snapshotChildren(pkgSnapshot, includeOptDeps)
     inTrail.add(edge.depPath)
     stack.push({ depPath: edge.depPath, trail, children, next: 0 })
   }
@@ -313,21 +320,16 @@ function createReachableVulnerabilitiesGetter (
       sccStack.push(edge.depPath)
       onStack.add(edge.depPath)
 
-      // Derive children from this single read rather than via a helper that would
-      // read the snapshot again.
       const pkgSnapshot = packages[edge.depPath]
       const own = new Set<string>()
-      const children: Array<{ name: string, depPath: DepPath }> = []
+      let children: Array<{ name: string, depPath: DepPath }> = []
       if (pkgSnapshot != null) {
         const { name, version } = nameVerFromPkgSnapshot(edge.depPath, pkgSnapshot)
         const resolvedName = name ?? edge.name
         if (version && vulnerableNames.has(resolvedName)) {
           own.add(vulnerabilityKey(resolvedName, version, edge.depPath))
         }
-        appendNamedDepPaths(children, pkgSnapshot.dependencies ?? {})
-        if (includeOptDeps) {
-          appendNamedDepPaths(children, pkgSnapshot.optionalDependencies ?? {})
-        }
+        children = snapshotChildren(pkgSnapshot, includeOptDeps)
       }
       partial.set(edge.depPath, own)
       work.push({ edge, own, children, next: 0 })
@@ -473,6 +475,74 @@ function appendNamedDepPaths (target: Array<{ name: string, depPath: DepPath }>,
   }
 }
 
+// A snapshot's children for graph-walking purposes: its dependencies, plus
+// optionalDependencies when includeOptDeps, excluding peer-satisfaction
+// edges (see isPeerSatisfactionAlias's doc comment for why).
+function snapshotChildren (pkgSnapshot: PackageSnapshot, includeOptDeps: boolean): Array<{ name: string, depPath: DepPath }> {
+  const children: Array<{ name: string, depPath: DepPath }> = []
+  appendNonPeerNamedDepPaths(children, pkgSnapshot, pkgSnapshot.dependencies ?? {})
+  if (includeOptDeps) {
+    appendNonPeerNamedDepPaths(children, pkgSnapshot, pkgSnapshot.optionalDependencies ?? {})
+  }
+  return children
+}
+
+// Like appendNamedDepPaths, but skips a peer-satisfaction edge.
+function appendNonPeerNamedDepPaths (target: Array<{ name: string, depPath: DepPath }>, snapshot: PackageSnapshot, deps: ResolvedDependencies): void {
+  for (const [alias, ref] of Object.entries(deps)) {
+    if (isPeerSatisfactionAlias(snapshot, alias)) continue
+    const depPath = dp.refToRelative(ref, alias)
+    if (depPath != null) target.push({ name: alias, depPath })
+  }
+}
+
+// True when `alias` is one of `snapshot`'s own declared `peerDependencies` —
+// i.e. the corresponding `dependencies`/`optionalDependencies` entry doesn't
+// exist because the package depends on it, but because that's the concrete
+// package pnpm's peer resolution picked to satisfy the peer. Every graph walk
+// in this file that enumerates a snapshot's children treats such an entry as
+// a non-edge: peer resolution only ever picks a package that's independently
+// present via a genuine (non-peer) edge somewhere in the whole workspace
+// tree, so the peer-satisfaction edge itself never needs to contribute
+// reachability or appear as an install path — if the satisfying package is
+// really available under the current `include`, it's already reachable via
+// its own genuine edge; if it isn't (e.g. it's only a devDependency and
+// `include.devDependencies` is false), the peer edge shouldn't make it
+// "available" either. Without this, `pnpm audit --prod` would report a
+// package that only exists in the resolved graph because an excluded
+// dependency type (typically a devDependency) happened to satisfy another
+// package's optional peer.
+function isPeerSatisfactionAlias (snapshot: PackageSnapshot, alias: string): boolean {
+  // Object.hasOwn rather than `in`: a lockfile is untrusted input, and `in`
+  // also matches inherited Object.prototype property names (`constructor`,
+  // `toString`, `valueOf`, ...), some of which are syntactically valid
+  // package names — `in` would treat a plain dependency edge named
+  // `constructor` as a peer-satisfaction edge even with no such peer
+  // declared.
+  return snapshot.peerDependencies != null && Object.hasOwn(snapshot.peerDependencies, alias)
+}
+
+// Returns every depPath reachable from the importers' roots under `include`
+// (peer-satisfaction edges excluded — see isPeerSatisfactionAlias).
+export function collectReachableDepPaths (
+  lockfile: LockfileObject,
+  include?: AuditIndexOptions['include']
+): Set<DepPath> {
+  const includeDeps = include?.dependencies !== false
+  const includeDevDeps = include?.devDependencies !== false
+  const includeOptDeps = include?.optionalDependencies !== false
+  const reachable = new Set<DepPath>()
+  for (const importer of Object.values(lockfile.importers)) {
+    const roots = [
+      ...(includeDeps ? resolvedDepsToDepPaths(importer.dependencies ?? {}) : []),
+      ...(includeDevDeps ? resolvedDepsToDepPaths(importer.devDependencies ?? {}) : []),
+      ...(includeOptDeps ? resolvedDepsToDepPaths(importer.optionalDependencies ?? {}) : []),
+    ]
+    walkReachable(lockfile, roots, reachable, includeOptDeps)
+  }
+  return reachable
+}
+
 // Returns the set of depPaths that are reachable only through optional edges
 // (i.e. they would be absent from the install set if optionalDependencies were
 // not included). Matches the AuditMetadata.optionalDependencies semantic.
@@ -484,32 +554,61 @@ function appendNamedDepPaths (target: Array<{ name: string, depPath: DepPath }>,
 // Root selection honours the caller's `include` flags, so running
 // `pnpm audit --prod` doesn't let dev-only subgraphs flip a package out of
 // "optional-only" classification.
+//
+// Accepts an optional pre-computed `reachable` (collectReachableDepPaths(lockfile,
+// include)) for callers that already have one, to avoid walking the lockfile twice.
 export function collectOptionalOnlyDepPaths (
   lockfile: LockfileObject,
-  include?: AuditIndexOptions['include']
+  include?: AuditIndexOptions['include'],
+  reachable?: Set<DepPath>
 ): Set<DepPath> {
   const includeDeps = include?.dependencies !== false
   const includeDevDeps = include?.devDependencies !== false
-  const includeOptDeps = include?.optionalDependencies !== false
   const withoutOptional = new Set<DepPath>()
-  const withOptional = new Set<DepPath>()
   for (const importer of Object.values(lockfile.importers)) {
     const nonOptionalRoots = [
       ...(includeDeps ? resolvedDepsToDepPaths(importer.dependencies ?? {}) : []),
       ...(includeDevDeps ? resolvedDepsToDepPaths(importer.devDependencies ?? {}) : []),
     ]
-    const allRoots = [
-      ...nonOptionalRoots,
-      ...(includeOptDeps ? resolvedDepsToDepPaths(importer.optionalDependencies ?? {}) : []),
-    ]
     walkReachable(lockfile, nonOptionalRoots, withoutOptional, false)
-    walkReachable(lockfile, allRoots, withOptional, includeOptDeps)
   }
+  const withOptional = reachable ?? collectReachableDepPaths(lockfile, include)
   const result = new Set<DepPath>()
   for (const depPath of withOptional) {
     if (!withoutOptional.has(depPath)) result.add(depPath)
   }
   return result
+}
+
+// Computes the same DepType.DevOnly/DevAndProd/ProdOnly classification as
+// `@pnpm/lockfile.detect-dep-types`'s detectDepTypes, but locally — that
+// package is also consumed by `pnpm list`/`pnpm why`/the license-scanner/sbom
+// and has no way to exclude peer-satisfaction edges without widening its
+// contract for all of those. Peer-satisfaction edges are excluded per
+// collectReachableDepPaths's doc comment above. Intentionally not
+// parameterized by the caller's `include`, matching detectDepTypes's own
+// contract: this reports a fixed "would this survive without
+// devDependencies" property of the dependency, independent of what the
+// current `pnpm audit` invocation's own `--prod`/`--dev` flags select.
+export function detectAuditDepTypes (lockfile: LockfileObject): DepTypes {
+  const devReachable = new Set<DepPath>()
+  const prodReachable = new Set<DepPath>()
+  for (const importer of Object.values(lockfile.importers)) {
+    walkReachable(lockfile, resolvedDepsToDepPaths(importer.devDependencies ?? {}), devReachable, true)
+    const prodRoots = [
+      ...resolvedDepsToDepPaths(importer.dependencies ?? {}),
+      ...resolvedDepsToDepPaths(importer.optionalDependencies ?? {}),
+    ]
+    walkReachable(lockfile, prodRoots, prodReachable, true)
+  }
+  const dev: DepTypes = {}
+  for (const depPath of devReachable) {
+    dev[depPath] = prodReachable.has(depPath) ? DepType.DevAndProd : DepType.DevOnly
+  }
+  for (const depPath of prodReachable) {
+    if (!devReachable.has(depPath)) dev[depPath] = DepType.ProdOnly
+  }
+  return dev
 }
 
 // Explicit stack rather than recursion: a lockfile is untrusted input, and a
@@ -525,11 +624,20 @@ function walkReachable (lockfile: LockfileObject, depPaths: DepPath[], seen: Set
     seen.add(depPath)
     const snapshot = packages[depPath]
     if (!snapshot) continue
-    for (const child of resolvedDepsToDepPaths(snapshot.dependencies ?? {})) stack.push(child)
+    for (const child of resolvedNonPeerDepPaths(snapshot, snapshot.dependencies ?? {})) stack.push(child)
     if (includeOptionalEdges) {
-      for (const child of resolvedDepsToDepPaths(snapshot.optionalDependencies ?? {})) stack.push(child)
+      for (const child of resolvedNonPeerDepPaths(snapshot, snapshot.optionalDependencies ?? {})) stack.push(child)
     }
   }
+}
+
+// Like resolvedDepsToDepPaths, but skips a peer-satisfaction edge (see
+// isPeerSatisfactionAlias).
+function resolvedNonPeerDepPaths (snapshot: PackageSnapshot, deps: ResolvedDependencies): DepPath[] {
+  return Object.entries(deps)
+    .filter(([alias]) => !isPeerSatisfactionAlias(snapshot, alias))
+    .map(([alias, ref]) => dp.refToRelative(ref, alias))
+    .filter((depPath): depPath is DepPath => depPath !== null)
 }
 
 function resolvedDepsToDepPaths (deps: ResolvedDependencies): DepPath[] {

--- a/pnpm11/deps/compliance/audit/test/index.ts
+++ b/pnpm11/deps/compliance/audit/test/index.ts
@@ -30,6 +30,32 @@ describe('audit', () => {
     expect(result.devDependencies).toBe(0)
   })
 
+  test('lockfileToAuditRequest() does not treat a dependency named after an Object.prototype property as a peer-satisfaction edge', () => {
+    // Peer-satisfaction detection must check own properties only. Checking
+    // via `in` would match inherited Object.prototype names — `constructor`
+    // is both one of them and a syntactically valid npm package name — and
+    // wrongly exclude this real, non-peer dependency from every reachable
+    // set even though `foo` declares no peerDependencies at all.
+    const result = lockfileToAuditRequest({
+      importers: {
+        ['.' as ProjectId]: {
+          dependencies: { foo: '1.0.0' },
+          specifiers: { foo: '^1.0.0' },
+        },
+      },
+      lockfileVersion: LOCKFILE_VERSION,
+      packages: {
+        ['constructor@1.0.0' as DepPath]: { resolution: { integrity: 'constructor-integrity' } },
+        ['foo@1.0.0' as DepPath]: {
+          dependencies: { constructor: '1.0.0' },
+          resolution: { integrity: 'foo-integrity' },
+        },
+      },
+    }, {})
+
+    expect(result.request).toEqual({ foo: ['1.0.0'], constructor: ['1.0.0'] })
+  })
+
   test('buildAuditPathIndex() records install paths for vulnerable packages', () => {
     const lockfile = {
       importers: {
@@ -186,6 +212,191 @@ describe('audit', () => {
     // With devDependencies excluded the only remaining way to reach shared-pkg
     // is through opt-root, so the dep becomes optional-only.
     expect(prodOnly['shared-pkg']!.get('1.0.0')!.optional).toBe(true)
+  })
+
+  test('lockfileToAuditRequest() excludes a package only present because it satisfied a prod dependency\'s optional peer via an excluded devDependency', () => {
+    // https://github.com/pnpm/pnpm/issues/13605 — hookform (a prod dependency)
+    // declares an optional peer on valibot; valibot is only otherwise present
+    // as a devDependency. Peer resolution mixes all dependency types, so the
+    // lockfile bakes valibot into hookform's snapshot regardless of --prod.
+    // A real --prod-only resolve would never have seen valibot to satisfy the
+    // peer with, so `pnpm audit --prod` must not report it at all.
+    const lockfile = {
+      importers: {
+        ['.' as ProjectId]: {
+          dependencies: { hookform: '1.0.0(valibot@1.2.0)' },
+          devDependencies: { valibot: '1.2.0' },
+          specifiers: { hookform: '^1.0.0', valibot: '^1.2.0' },
+        },
+      },
+      lockfileVersion: LOCKFILE_VERSION,
+      packages: {
+        ['hookform@1.0.0(valibot@1.2.0)' as DepPath]: {
+          optionalDependencies: { valibot: '1.2.0' },
+          peerDependencies: { valibot: '^1.0.0' },
+          peerDependenciesMeta: { valibot: { optional: true as const } },
+          resolution: { integrity: 'hookform-integrity' },
+        },
+        ['valibot@1.2.0' as DepPath]: { resolution: { integrity: 'valibot-integrity' } },
+      },
+    }
+
+    const full = lockfileToAuditRequest(lockfile, {})
+    expect(full.request).toEqual({ hookform: ['1.0.0'], valibot: ['1.2.0'] })
+
+    const prodOnly = lockfileToAuditRequest(lockfile, {
+      include: { dependencies: true, devDependencies: false, optionalDependencies: true },
+    })
+    expect(prodOnly.request).toEqual({ hookform: ['1.0.0'] })
+    expect(prodOnly.request).not.toHaveProperty('valibot')
+  })
+
+  test('buildAuditPathIndex() classifies a peer-satisfied-by-devDependency package as dev, not optional', () => {
+    // Same shape as the lockfileToAuditRequest test above. Path building never
+    // follows the peer-satisfaction edge either — a peer-satisfaction edge
+    // isn't a real install path any more than it's real reachability — so
+    // valibot's only path is its own devDependency root, and it must be
+    // dev: true, optional: false: it's a real devDependency, not something
+    // reachable only through an optional edge.
+    const lockfile = {
+      importers: {
+        ['.' as ProjectId]: {
+          dependencies: { hookform: '1.0.0(valibot@1.2.0)' },
+          devDependencies: { valibot: '1.2.0' },
+          specifiers: { hookform: '^1.0.0', valibot: '^1.2.0' },
+        },
+      },
+      lockfileVersion: LOCKFILE_VERSION,
+      packages: {
+        ['hookform@1.0.0(valibot@1.2.0)' as DepPath]: {
+          optionalDependencies: { valibot: '1.2.0' },
+          peerDependencies: { valibot: '^1.0.0' },
+          peerDependenciesMeta: { valibot: { optional: true as const } },
+          resolution: { integrity: 'hookform-integrity' },
+        },
+        ['valibot@1.2.0' as DepPath]: { resolution: { integrity: 'valibot-integrity' } },
+      },
+    }
+    const result = buildAuditPathIndex(lockfile, new Set(['valibot']), {})
+
+    expect(result['valibot']!.get('1.2.0')).toEqual({
+      paths: ['.>valibot'],
+      dev: true,
+      optional: false,
+    })
+  })
+
+  test('lockfileToAuditRequest() excludes a package only present because it satisfied a devDependency\'s optional peer via an excluded prod dependency (--dev mirror)', () => {
+    // Mirror of the --prod case above, for --dev (include: {dependencies:
+    // false, optionalDependencies: false}). dev-tool (a devDependency)
+    // declares an optional peer on helper-lib, which is only otherwise
+    // present as a prod dependency. --dev must not report helper-lib. Note
+    // this specific scenario (an *optional* peer) doesn't discriminate the
+    // fix on its own — --dev already excludes all optionalDependencies edges
+    // globally, so it was correctly excluded before the fix too. The
+    // required-peer --dev test below does discriminate, since a required
+    // peer's satisfaction edge lands in `dependencies`, which was always
+    // followed unconditionally regardless of `include`.
+    const lockfile = {
+      importers: {
+        ['.' as ProjectId]: {
+          dependencies: { 'helper-lib': '1.0.0' },
+          devDependencies: { 'dev-tool': '1.0.0(helper-lib@1.0.0)' },
+          specifiers: { 'dev-tool': '^1.0.0', 'helper-lib': '^1.0.0' },
+        },
+      },
+      lockfileVersion: LOCKFILE_VERSION,
+      packages: {
+        ['dev-tool@1.0.0(helper-lib@1.0.0)' as DepPath]: {
+          optionalDependencies: { 'helper-lib': '1.0.0' },
+          peerDependencies: { 'helper-lib': '^1.0.0' },
+          peerDependenciesMeta: { 'helper-lib': { optional: true as const } },
+          resolution: { integrity: 'dev-tool-integrity' },
+        },
+        ['helper-lib@1.0.0' as DepPath]: { resolution: { integrity: 'helper-lib-integrity' } },
+      },
+    }
+
+    // helper-lib is a genuine prod dependency (independent of the peer edge),
+    // so it must still be reported under the default/full include.
+    const full = lockfileToAuditRequest(lockfile, {})
+    expect(full.request).toEqual({ 'dev-tool': ['1.0.0'], 'helper-lib': ['1.0.0'] })
+
+    const devOnly = lockfileToAuditRequest(lockfile, {
+      include: { dependencies: false, devDependencies: true, optionalDependencies: false },
+    })
+    expect(devOnly.request).toEqual({ 'dev-tool': ['1.0.0'] })
+    expect(devOnly.request).not.toHaveProperty('helper-lib')
+  })
+
+  test('lockfileToAuditRequest() excludes a package only present because it satisfied a required (non-optional) peer via an excluded devDependency', () => {
+    // Same bug class as the optional-peer case, but for a required peer —
+    // required-peer satisfaction edges land in `dependencies`, not
+    // `optionalDependencies`, but are still keyed by the parent's own
+    // peerDependencies, so the fix (skip any alias present in
+    // peerDependencies) covers this without extra logic.
+    const lockfile = {
+      importers: {
+        ['.' as ProjectId]: {
+          dependencies: { 'needs-react': '1.0.0(react@18.0.0)' },
+          devDependencies: { react: '18.0.0' },
+          specifiers: { 'needs-react': '^1.0.0', react: '^18.0.0' },
+        },
+      },
+      lockfileVersion: LOCKFILE_VERSION,
+      packages: {
+        ['needs-react@1.0.0(react@18.0.0)' as DepPath]: {
+          dependencies: { react: '18.0.0' },
+          peerDependencies: { react: '^18.0.0' },
+          resolution: { integrity: 'needs-react-integrity' },
+        },
+        ['react@18.0.0' as DepPath]: { resolution: { integrity: 'react-integrity' } },
+      },
+    }
+
+    const prodOnly = lockfileToAuditRequest(lockfile, {
+      include: { dependencies: true, devDependencies: false, optionalDependencies: true },
+    })
+    expect(prodOnly.request).toEqual({ 'needs-react': ['1.0.0'] })
+    expect(prodOnly.request).not.toHaveProperty('react')
+  })
+
+  test('lockfileToAuditRequest() excludes a package only present because it satisfied a devDependency\'s required peer via an excluded prod dependency (--dev mirror)', () => {
+    // Required-peer mirror of the --dev optional-peer test above. Unlike an
+    // optional-peer edge (which lives in optionalDependencies and was always
+    // gated by include.optionalDependencies), a required-peer edge lives in
+    // `dependencies`, which the walker followed unconditionally regardless of
+    // `include` — so, unlike the optional case, this scenario does exercise
+    // the fix under --dev.
+    const lockfile = {
+      importers: {
+        ['.' as ProjectId]: {
+          dependencies: { 'ui-lib': '2.0.0' },
+          devDependencies: { 'needs-ui-lib': '1.0.0(ui-lib@2.0.0)' },
+          specifiers: { 'needs-ui-lib': '^1.0.0', 'ui-lib': '^2.0.0' },
+        },
+      },
+      lockfileVersion: LOCKFILE_VERSION,
+      packages: {
+        ['needs-ui-lib@1.0.0(ui-lib@2.0.0)' as DepPath]: {
+          dependencies: { 'ui-lib': '2.0.0' },
+          peerDependencies: { 'ui-lib': '^2.0.0' },
+          resolution: { integrity: 'needs-ui-lib-integrity' },
+        },
+        ['ui-lib@2.0.0' as DepPath]: { resolution: { integrity: 'ui-lib-integrity' } },
+      },
+    }
+
+    // ui-lib is a genuine prod dependency (independent of the peer edge), so
+    // it must still be reported under the default/full include.
+    const full = lockfileToAuditRequest(lockfile, {})
+    expect(full.request).toEqual({ 'needs-ui-lib': ['1.0.0'], 'ui-lib': ['2.0.0'] })
+
+    const devOnly = lockfileToAuditRequest(lockfile, {
+      include: { dependencies: false, devDependencies: true, optionalDependencies: false },
+    })
+    expect(devOnly.request).toEqual({ 'needs-ui-lib': ['1.0.0'] })
+    expect(devOnly.request).not.toHaveProperty('ui-lib')
   })
 
   test('buildAuditPathIndex() flags findings reached only through optional edges', () => {


### PR DESCRIPTION
## Summary

`pnpm audit --prod`/`--dev` reported (and misclassified) a package that only entered the resolved dependency graph because it was the concrete package pnpm's peer resolution picked to satisfy another package's peer dependency, when that concrete package itself came from an excluded dependency type — e.g. an optional peer satisfied by a devDependency, still reported under `--prod`.

Peer resolution mixes all dependency types and bakes the result into the lockfile regardless of `--prod`/`--dev`, but pnpm's resolver only ever picks a peer's concrete package from one that's independently present via a genuine, non-peer edge somewhere in the workspace tree — so a peer-satisfaction edge is never the sole reason a package is reachable. Skipping such edges when walking the graph for audit classification and inclusion fixes both stacks, without touching the lockfile format, peer resolution, or install/deploy pruning.

Fixes pnpm/pnpm#13605

## Squash Commit Body

```text
fix(audit): don't treat peer-satisfaction edges as real dependency edges

`pnpm audit --prod`/`--dev` reported (and misclassified) a package that
only entered the resolved graph because it was the concrete package
pnpm's peer resolution picked to satisfy another package's peer
dependency, when that concrete package itself came from an excluded
dependency type — e.g. an optional peer satisfied by a devDependency,
still reported under `--prod`.

Peer resolution mixes all dependency types and bakes the result into
the lockfile regardless of `--prod`/`--dev`, but pnpm's resolver only
ever picks a peer's concrete package from one that's independently
present via a genuine, non-peer edge somewhere in the workspace tree —
so a peer-satisfaction edge is never the sole reason a package is
reachable. Skipping such edges when walking the graph for audit
classification and inclusion fixes both stacks without touching the
lockfile format, peer resolution, or install/deploy pruning.

Fixes pnpm/pnpm#13605
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-sonnet-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14027"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789778286&installation_model_id=426870&pr_number=14027&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14027&signature=0aac17f5e6ea84801c4101bca10c0926ad9c475be3adb32f8508d242b7f9b300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audit dependency classification when peer dependencies are satisfied by excluded production or development packages.
  * Prevented peer-satisfaction paths from incorrectly including packages in audit results.
  * Corrected production, development, optional, and direct dependency reporting.
  * Preserved valid dependencies with names matching common object properties.
  * Improved consistency when determining which packages are reachable during auditing.

* **Tests**
  * Added regression coverage for peer dependency filtering, reachability, and audit path classification across dependency scopes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->