### PR TITLE
fix(peers): ignoreMissing also suppresses version-mismatch peer issues

### DIFF
--- a/.changeset/ignore-missing-bad-peer.md
+++ b/.changeset/ignore-missing-bad-peer.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/installing.deps-installer": patch
+"@pnpm/deps.inspection.peers-checker": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+Fixed `peerDependencyRules.ignoreMissing` not suppressing peer dependency errors when the peer is found but doesn't satisfy the required version range. Previously `ignoreMissing` only suppressed truly absent peers; it now also covers peers that resolve to a version outside the wanted range for the peer edge it selects.

--- a/.changeset/ignore-missing-bad-peer.md
+++ b/.changeset/ignore-missing-bad-peer.md
@@ -5,4 +5,4 @@
 "pacquet": patch
 ---
 
-Fixed `peerDependencyRules.ignoreMissing` not suppressing peer dependency errors when the peer is found but doesn't satisfy the required version range. Previously `ignoreMissing` only suppressed truly absent peers; it now also covers peers that resolve to a version outside the wanted range for the peer edge it selects.
+`peerDependencyRules.ignoreMissing` now also suppresses peer dependency errors when the peer is found but doesn't satisfy the required version range, not just when it's absent.

--- a/.changeset/ignore-missing-bad-peer.md
+++ b/.changeset/ignore-missing-bad-peer.md
@@ -1,8 +1,8 @@
 ---
-"@pnpm/installing.deps-installer": patch
-"@pnpm/deps.inspection.peers-checker": patch
-"pnpm": patch
-"pacquet": patch
+"@pnpm/installing.deps-installer": minor
+"@pnpm/deps.inspection.peers-checker": minor
+"pnpm": minor
+"pacquet": minor
 ---
 
-`peerDependencyRules.ignoreMissing` now also suppresses peer dependency errors when the peer is found but doesn't satisfy the required version range, not just when it's absent.
+`peerDependencyRules.ignoreMissing` now suppresses every peer dependency issue for a matched peer, including when the peer is present but resolves to a version outside its wanted range. Use `peerDependencyRules.allowAny` to accept any resolved version while still being told about absent peers.

--- a/pnpm/crates/cli/src/cli_args/peers.rs
+++ b/pnpm/crates/cli/src/cli_args/peers.rs
@@ -982,7 +982,9 @@ fn filter_peer_issues(
         }
 
         for (peer_name, peer_issues) in &project_issues.bad {
-            if allow_any_matcher_rule.matches(peer_name) {
+            if allow_any_matcher_rule.matches(peer_name)
+                || ignore_missing_matcher.matches(peer_name)
+            {
                 continue;
             }
             let remaining: Vec<BadPeerIssue> = peer_issues

--- a/pnpm/crates/cli/src/cli_args/peers/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/peers/tests.rs
@@ -286,6 +286,48 @@ fn test_filter_peer_issues_allow_any() {
 }
 
 #[test]
+fn test_filter_peer_issues_ignore_missing_also_suppresses_bad() {
+    let mut issues: IssuesByProjects = BTreeMap::new();
+    let mut peer = PeerIssues {
+        bad: BTreeMap::new(),
+        missing: BTreeMap::new(),
+        conflicts: Vec::new(),
+        intersections: BTreeMap::new(),
+    };
+    peer.bad.insert(
+        "react".to_string(),
+        vec![BadPeerIssue {
+            parents: vec![ParentPkg { name: "foo".to_string(), version: "1.0.0".to_string() }],
+            optional: false,
+            wanted_range: "^18.0.0".to_string(),
+            found_version: "17.0.0".to_string(),
+            resolved_from: Vec::new(),
+        }],
+    );
+    peer.bad.insert(
+        "vue".to_string(),
+        vec![BadPeerIssue {
+            parents: vec![ParentPkg { name: "bar".to_string(), version: "1.0.0".to_string() }],
+            optional: false,
+            wanted_range: "^3.0.0".to_string(),
+            found_version: "2.0.0".to_string(),
+            resolved_from: Vec::new(),
+        }],
+    );
+    issues.insert("project".to_string(), peer);
+    let filtered = filter_peer_issues(
+        issues,
+        &PeerDependencyRules {
+            ignore_missing: Some(vec!["react".to_string()]),
+            allow_any: None,
+            allowed_versions: None,
+        },
+    );
+    assert!(!filtered["project"].bad.contains_key("react"));
+    assert!(filtered["project"].bad.contains_key("vue"));
+}
+
+#[test]
 fn test_filter_peer_issues_allowed_versions() {
     let mut issues: IssuesByProjects = BTreeMap::new();
     let mut peer = PeerIssues {

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -830,9 +830,10 @@ pub struct UpdateConfig {
 /// peer-dependency issues.
 ///
 /// - `ignoreMissing` / `allowAny` are glob/negation pattern lists
-///   (matched against the peer package name). `ignoreMissing` suppresses
-///   issues for a matched peer whether it's absent or resolves to a
-///   version outside its wanted range.
+///   (matched against the peer package name). `ignoreMissing` never
+///   reports a matched peer, whether it's absent or resolves to a version
+///   outside its wanted range; `allowAny` only accepts whatever version a
+///   matched peer resolved to, and still reports it when absent.
 /// - `allowedVersions` maps a peer selector (`name`, or the override
 ///   form `parent>name` / `parent@range>name`) to an extra semver range
 ///   that should be accepted.

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -830,7 +830,9 @@ pub struct UpdateConfig {
 /// peer-dependency issues.
 ///
 /// - `ignoreMissing` / `allowAny` are glob/negation pattern lists
-///   (matched against the peer package name).
+///   (matched against the peer package name). `ignoreMissing` suppresses
+///   issues for a matched peer whether it's absent or resolves to a
+///   version outside its wanted range.
 /// - `allowedVersions` maps a peer selector (`name`, or the override
 ///   form `parent>name` / `parent@range>name`) to an extra semver range
 ///   that should be accepted.

--- a/pnpm11/core/types/src/package.ts
+++ b/pnpm11/core/types/src/package.ts
@@ -154,10 +154,14 @@ export type PackageExtension = Pick<BaseManifest, 'dependencies' | 'optionalDepe
 
 export interface PeerDependencyRules {
   /**
-   * Peer name patterns for which pnpm should not report peer dependency issues,
-   * whether the peer is absent or resolves to a version outside its wanted range.
+   * Peer name patterns whose issues are never reported, whether the peer is
+   * absent or resolves to a version outside its wanted range.
    */
   ignoreMissing?: string[]
+  /**
+   * Peer name patterns whose resolved version is accepted whatever range the
+   * dependent asks for. Unlike `ignoreMissing`, an absent peer is still reported.
+   */
   allowAny?: string[]
   allowedVersions?: Record<string, string>
 }

--- a/pnpm11/core/types/src/package.ts
+++ b/pnpm11/core/types/src/package.ts
@@ -153,6 +153,10 @@ export interface DependencyManifest extends BaseManifest {
 export type PackageExtension = Pick<BaseManifest, 'dependencies' | 'optionalDependencies' | 'peerDependencies' | 'peerDependenciesMeta'>
 
 export interface PeerDependencyRules {
+  /**
+   * Peer name patterns for which pnpm should not report peer dependency issues,
+   * whether the peer is absent or resolves to a version outside its wanted range.
+   */
   ignoreMissing?: string[]
   allowAny?: string[]
   allowedVersions?: Record<string, string>

--- a/pnpm11/deps/inspection/peers-checker/src/checkPeerDependencies.ts
+++ b/pnpm11/deps/inspection/peers-checker/src/checkPeerDependencies.ts
@@ -164,7 +164,7 @@ function filterPeerDependencyIssues (
     }
 
     for (const [peerName, issues] of Object.entries(bad)) {
-      if (allowAnyMatcher(peerName)) continue
+      if (allowAnyMatcher(peerName) || ignoreMissingMatcher(peerName)) continue
       const remaining = issues.filter(
         (issue) => {
           if (allowedVersionsMatchAll[peerName]?.some(

--- a/pnpm11/deps/inspection/peers-checker/test/__fixtures__/with-unmet-peers-multiple/package.json
+++ b/pnpm11/deps/inspection/peers-checker/test/__fixtures__/with-unmet-peers-multiple/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "with-unmet-peers-multiple",
+  "version": "1.0.0",
+  "dependencies": {
+    "needs-react-18": "1.0.0",
+    "needs-vue-3": "1.0.0",
+    "react": "17.0.0",
+    "vue": "2.0.0"
+  }
+}

--- a/pnpm11/deps/inspection/peers-checker/test/__fixtures__/with-unmet-peers-multiple/pnpm-lock.yaml
+++ b/pnpm11/deps/inspection/peers-checker/test/__fixtures__/with-unmet-peers-multiple/pnpm-lock.yaml
@@ -1,0 +1,55 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: false
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      needs-react-18:
+        specifier: 1.0.0
+        version: 1.0.0(react@17.0.0)
+      needs-vue-3:
+        specifier: 1.0.0
+        version: 1.0.0(vue@2.0.0)
+      react:
+        specifier: 17.0.0
+        version: 17.0.0
+      vue:
+        specifier: 2.0.0
+        version: 2.0.0
+
+packages:
+
+  needs-react-18@1.0.0:
+    resolution: {integrity: sha512-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa==}
+    peerDependencies:
+      react: ^18.0.0
+
+  needs-vue-3@1.0.0:
+    resolution: {integrity: sha512-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb==}
+    peerDependencies:
+      vue: ^3.0.0
+
+  react@17.0.0:
+    resolution: {integrity: sha512-RcdM0Qe4NK6Hfm+7+fOv0WTLO02H8LFu8Aa3dWtfI3G5QFxedoR9NBsDXm7Z+y0LHGQ3gJ+w3JkdNZyDrWOA==}
+    engines: {node: '>=0.10.0'}
+
+  vue@2.0.0:
+    resolution: {integrity: sha512-cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc==}
+
+snapshots:
+
+  needs-react-18@1.0.0(react@17.0.0):
+    dependencies:
+      react: 17.0.0
+
+  needs-vue-3@1.0.0(vue@2.0.0):
+    dependencies:
+      vue: 2.0.0
+
+  react@17.0.0: {}
+
+  vue@2.0.0: {}

--- a/pnpm11/deps/inspection/peers-checker/test/checkPeerDependencies.test.ts
+++ b/pnpm11/deps/inspection/peers-checker/test/checkPeerDependencies.test.ts
@@ -99,6 +99,20 @@ test('respects peerDependencyRules.ignoreMissing', async () => {
   expect(Object.keys(projectIssues.missing)).toHaveLength(0)
 })
 
+test('peerDependencyRules.ignoreMissing also suppresses bad (version-mismatch) peer issues', async () => {
+  const fixture = f.find('with-unmet-peers')
+  const issues = await checkPeerDependencies([fixture], {
+    lockfileDir: fixture,
+    checkWantedLockfileOnly: true,
+    peerDependencyRules: {
+      ignoreMissing: ['react'],
+    },
+  })
+
+  const projectIssues = issues['.']
+  expect(Object.keys(projectIssues.bad)).toHaveLength(0)
+})
+
 test('detects conflicting missing peer dependencies', async () => {
   const fixture = f.find('with-conflicting-peers')
   const issues = await checkPeerDependencies([fixture], {

--- a/pnpm11/deps/inspection/peers-checker/test/checkPeerDependencies.test.ts
+++ b/pnpm11/deps/inspection/peers-checker/test/checkPeerDependencies.test.ts
@@ -99,8 +99,8 @@ test('respects peerDependencyRules.ignoreMissing', async () => {
   expect(Object.keys(projectIssues.missing)).toHaveLength(0)
 })
 
-test('peerDependencyRules.ignoreMissing also suppresses bad (version-mismatch) peer issues', async () => {
-  const fixture = f.find('with-unmet-peers')
+test('peerDependencyRules.ignoreMissing suppresses bad (version-mismatch) peer issues it matches, but not unrelated ones', async () => {
+  const fixture = f.find('with-unmet-peers-multiple')
   const issues = await checkPeerDependencies([fixture], {
     lockfileDir: fixture,
     checkWantedLockfileOnly: true,
@@ -110,7 +110,8 @@ test('peerDependencyRules.ignoreMissing also suppresses bad (version-mismatch) p
   })
 
   const projectIssues = issues['.']
-  expect(Object.keys(projectIssues.bad)).toHaveLength(0)
+  expect(projectIssues.bad).not.toHaveProperty('react')
+  expect(projectIssues.bad).toHaveProperty('vue')
 })
 
 test('detects conflicting missing peer dependencies', async () => {

--- a/pnpm11/installing/deps-installer/src/install/reportPeerDependencyIssues.ts
+++ b/pnpm11/installing/deps-installer/src/install/reportPeerDependencyIssues.ts
@@ -52,7 +52,7 @@ export function filterPeerDependencyIssues (
       newPeerDependencyIssuesByProjects[projectId].missing[peerName] = issues
     }
     for (const [peerName, issues] of Object.entries(bad)) {
-      if (allowAnyMatcher(peerName)) continue
+      if (allowAnyMatcher(peerName) || ignoreMissingMatcher(peerName)) continue
       const filteredIssues: BadPeerDependencyIssue[] = []
       for (const issue of issues) {
         if (allowedVersionsMatchAll[peerName]?.some((range) => semver.satisfies(issue.foundVersion, range))) continue

--- a/pnpm11/installing/deps-installer/test/filterPeerDependencyIssues.test.ts
+++ b/pnpm11/installing/deps-installer/test/filterPeerDependencyIssues.test.ts
@@ -101,6 +101,69 @@ test('filterPeerDependencyIssues() allow any version', () => {
   })
 })
 
+test('filterPeerDependencyIssues() ignoreMissing also suppresses bad (version-mismatch) peer issues', () => {
+  expect(filterPeerDependencyIssues({
+    '.': {
+      missing: {},
+      bad: {
+        bbb: [
+          {
+            parents: [
+              {
+                name: 'xxx',
+                version: '1.0.0',
+              }],
+
+            foundVersion: '2.0.0',
+            resolvedFrom: [],
+            optional: false,
+            wantedRange: '^1.0.0',
+          }],
+
+        ccc: [
+          {
+            parents: [
+              {
+                name: 'yyy',
+                version: '1.0.0',
+              }],
+
+            foundVersion: '2.0.0',
+            resolvedFrom: [],
+            optional: false,
+            wantedRange: '^1.0.0',
+          }],
+
+      },
+      conflicts: [],
+      intersections: {},
+    },
+  }, {
+    ignoreMissing: ['bbb'],
+  })).toStrictEqual({
+    '.': {
+      bad: {
+        ccc: [
+          {
+            parents: [
+              {
+                name: 'yyy',
+                version: '1.0.0',
+              }],
+
+            foundVersion: '2.0.0',
+            resolvedFrom: [],
+            optional: false,
+            wantedRange: '^1.0.0',
+          }],
+      },
+      conflicts: [],
+      intersections: {},
+      missing: {},
+    },
+  })
+})
+
 test('filterPeerDependencyIssues() allowed versions', () => {
   expect(filterPeerDependencyIssues({
     '.': {


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

`peerDependencyRules.ignoreMissing` only suppressed peer dependency issues
for peers that were *fully absent* from the resolved graph. A peer that
resolves to *some* version which fails its declared semver range is
classified as a "bad" issue (as opposed to "missing"), and only
`allowAny`/`allowedVersions` filtered that bucket — `ignoreMissing` had no
effect on it.

`pnpm dedupe` surfaces this reliably because it always forces a full peer
re-resolution, while `pnpm install` on an up-to-date lockfile skips
resolution entirely and never computes peer issues in the first place. That
asymmetry is what made `dedupe` fail while `install` silently passed on the
same project.

Fixed by also checking the `ignoreMissing` matcher when filtering "bad"
issues, in all three places that implement this filter: the TypeScript
`reportPeerDependencyIssues` (used by `install`/`dedupe`), the TypeScript
`checkPeerDependencies` (used by `pnpm peers`), and pacquet's
`filter_peer_issues` (used by both `pnpm peers` and `dedupe`'s peer
warning). Also added a doc comment on `PeerDependencyRules.ignoreMissing`
in both stacks noting the widened coverage.

Note: while verifying this, I found the reproduction's exact selector
(`ignoreMissing: ['react-inspector>react']`) uses `parent>peer` edge syntax
that `ignoreMissing` doesn't actually support — it only matches plain peer
name globs (that scoped syntax is `allowedVersions`-only). I confirmed the
underlying "bad vs missing" bug independently with the correct syntax
(`ignoreMissing: ['react']`), reproducing the failure pre-fix and the fix
resolving it post-fix against the built CLI bundle.

Separately, out of scope here: pacquet's `dedupe` never hard-fails on peer
issues regardless of `strictPeerDependencies` — it only emits a warning
(`peer_issues_sink: None` in `dedupe.rs`), unlike the TypeScript CLI's
`reportPeerDependencyIssues`, which throws. That's a pre-existing parity
gap unrelated to this fix. Happy to file a tracking issue for it if
maintainers agree it's worth a follow-up.

Closes pnpm/pnpm#9657.

## Squash Commit Body

```text
peerDependencyRules.ignoreMissing only filtered peers that were fully
absent from the resolved dependency graph. A peer that resolves to some
version failing its declared semver range is classified as a "bad" issue
(distinct from "missing"), and only allowAny/allowedVersions filtered that
bucket.

pnpm dedupe surfaces this reliably because it always forces a full peer
re-resolution, while pnpm install on an up-to-date lockfile skips
resolution entirely and never computes peer issues at all - that's why
dedupe failed while install silently passed on the same project.

Also check the ignoreMissing matcher when filtering bad issues, mirrored
across reportPeerDependencyIssues.ts (install/dedupe), checkPeerDependencies.ts
(pnpm peers), and pacquet's filter_peer_issues (pnpm peers and dedupe's
warning). Documented the widened ignoreMissing coverage on
PeerDependencyRules in both stacks.

Closes pnpm/pnpm#9657.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-sonnet-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14028"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789782088&installation_model_id=426870&pr_number=14028&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14028&signature=2eb2fec0249dbbe950002f38d7e88c8d14cd43fc45c93d12ba97d9afe0b764f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated `peerDependencyRules.ignoreMissing` to suppress warnings for missing peers and peers resolved outside the requested version range.
  * Preserved reporting for unrelated peer dependency issues.
  * Ensured `allowAny` continues accepting resolved versions while reporting absent peers.

* **Documentation**
  * Clarified how `ignoreMissing` and `allowAny` patterns affect peer dependency checks.

* **Tests**
  * Added regression coverage for version mismatches, missing peers, and unrelated peer issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->