### PR TITLE
fix(package-manager): keep hoisted repeat installs a no-op

### DIFF
--- a/.changeset/hoisted-repeat-install-is-a-noop.md
+++ b/.changeset/hoisted-repeat-install-is-a-noop.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+A repeat `pnpm install` with `nodeLinker: hoisted` is a no-op again when a workspace package declares the dependencies [#14001](https://github.com/pnpm/pnpm/issues/14001). The hoisted linker installs them into the root `node_modules`, but the up-to-date check previously looked under each package's own `node_modules` and reinstalled the whole tree every time. A hoisted install also no longer reports the packages it just wrote as broken.

--- a/pnpm/crates/cli/tests/suite/hoisted_node_linker.rs
+++ b/pnpm/crates/cli/tests/suite/hoisted_node_linker.rs
@@ -616,6 +616,10 @@ fn a_nested_copy_is_removed_once_its_version_wins_the_root_slot() {
     fs::create_dir_all(stale.parent().expect("scope dir")).expect("create the scope dir");
     std::os::unix::fs::symlink(fixture.workspace.join("node_modules").join(SCRIPTS), &stale)
         .expect("plant a stale link");
+    // The repeat-install short-circuit would report the unchanged
+    // workspace up to date without ever reaching the linker.
+    fs::remove_file(fixture.workspace.join("node_modules/.pnpm-workspace-state-v1.json"))
+        .expect("remove the workspace state");
     fixture.run(["install"]);
 
     assert!(!stale.exists(), "a stale project-local link must not survive a reinstall");

--- a/pnpm/crates/cli/tests/suite/repeat_install.rs
+++ b/pnpm/crates/cli/tests/suite/repeat_install.rs
@@ -360,3 +360,98 @@ fn a_directory_dependency_is_recopied_when_its_source_changes() {
 
     drop((root, mock_instance));
 }
+
+/// A workspace whose only dependency (`@pnpm.e2e/pkg-with-1-dep`, one
+/// subdep) is declared by the member, installed with
+/// `nodeLinker: hoisted`. Returns the path of a file inside the hoisted
+/// subdep, whose inode tells a repeat install that re-imported the tree
+/// from one that left it alone.
+fn install_hoisted_workspace_member(
+    pacquet: std::process::Command,
+    workspace: &Path,
+) -> std::path::PathBuf {
+    let workspace_yaml = workspace.join("pnpm-workspace.yaml");
+    let mut yaml = fs::read_to_string(&workspace_yaml).expect("read pnpm-workspace.yaml");
+    yaml.push_str("nodeLinker: hoisted\npackages:\n  - member\n");
+    fs::write(&workspace_yaml, yaml).expect("write pnpm-workspace.yaml");
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "name": "ws-root", "private": true }).to_string(),
+    )
+    .expect("write the root package.json");
+    fs::create_dir_all(workspace.join("member")).expect("mkdir member");
+    fs::write(
+        workspace.join("member/package.json"),
+        serde_json::json!({
+            "name": "member",
+            "version": "1.0.0",
+            "dependencies": { "@pnpm.e2e/pkg-with-1-dep": "100.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write the member package.json");
+
+    pacquet.with_arg("install").assert().success();
+
+    assert!(
+        !workspace.join("member/node_modules").exists(),
+        "hoisted keeps the member's registry deps in the root node_modules",
+    );
+    workspace.join("node_modules/@pnpm.e2e/dep-of-pkg-with-1-dep/package.json")
+}
+
+/// pnpm/pnpm#14001: under `nodeLinker: hoisted` every project's
+/// dependencies are installed into the *root* modules directory, so a
+/// member's own `node_modules` is normally absent. The workspace-state
+/// fast path must check the root directory for every project instead of
+/// reading that absence as a project that was never installed.
+#[test]
+fn repeat_hoisted_install_with_workspace_member_deps_is_up_to_date() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let hoisted_manifest = install_hoisted_workspace_member(pacquet, &workspace);
+    let inode_before = fs::metadata(&hoisted_manifest).expect("stat the hoisted dep").ino();
+
+    let second = pacquet_in(&workspace).with_arg("install").assert().success();
+    let second_output = String::from_utf8_lossy(&second.get_output().stdout).into_owned();
+    assert!(
+        second_output.contains("Already up to date"),
+        "the repeat install must short-circuit: {second_output}",
+    );
+    assert_eq!(
+        fs::metadata(&hoisted_manifest).expect("stat the hoisted dep").ino(),
+        inode_before,
+        "the second install must re-import nothing",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// A hoisted install writes no virtual-store slot, so the pipeline must
+/// not probe one: it reported every package of the tree it had just
+/// written as broken (pnpm/pnpm#14001). Dropping the workspace-state
+/// file gets this install past the repeat-install short-circuit and into
+/// the pipeline.
+#[test]
+fn repeat_hoisted_install_reports_nothing_broken() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let hoisted_manifest = install_hoisted_workspace_member(pacquet, &workspace);
+    fs::remove_file(workspace.join("node_modules/.pnpm-workspace-state-v1.json"))
+        .expect("remove the workspace state");
+
+    let second =
+        pacquet_in(&workspace).with_args(["install", "--reporter=ndjson"]).assert().success();
+    let second_events = String::from_utf8_lossy(&second.get_output().stderr).into_owned();
+    assert!(
+        !second_events.contains("pnpm:_broken_node_modules"),
+        "a hoisted tree has no virtual-store slots to report broken: {second_events}",
+    );
+    assert!(hoisted_manifest.is_file(), "the hoisted dep must still be in place");
+
+    drop((root, mock_instance));
+}

--- a/pnpm/crates/deps-restorer/src/create_virtual_store.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store.rs
@@ -396,6 +396,7 @@ impl CreateVirtualStore<'_> {
             allow_build_policy,
             skipped,
             link_dependencies: !is_hoisted && config.symlink,
+            is_hoisted,
             include_optional_dependencies,
             ignore_scripts: config.ignore_scripts,
             runtime_platform_selector: &runtime_platform_selector,

--- a/pnpm/crates/deps-restorer/src/create_virtual_store/snapshot_plan.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store/snapshot_plan.rs
@@ -31,6 +31,7 @@ pub(super) struct SnapshotPlanInputs<'a> {
     /// Snapshots the installability pass ruled out on this host.
     pub skipped: &'a SkippedSnapshots,
     pub link_dependencies: bool,
+    pub is_hoisted: bool,
     pub include_optional_dependencies: bool,
     pub ignore_scripts: bool,
     pub runtime_platform_selector: &'a PlatformSelector,
@@ -70,6 +71,7 @@ pub(super) fn plan_snapshots<'a, Reporter: self::Reporter>(
         allow_build_policy,
         skipped,
         link_dependencies,
+        is_hoisted,
         include_optional_dependencies,
         ignore_scripts,
         runtime_platform_selector,
@@ -92,6 +94,11 @@ pub(super) fn plan_snapshots<'a, Reporter: self::Reporter>(
         // converting the slot into a rebuild on every run.
         .try_fold(Vec::new(), |mut entries, (snapshot_key, snapshot)| {
             let current_slot_matches = (|| -> Result<bool, CreateVirtualStoreError> {
+                // The hoisted linker writes no virtual-store slot, so
+                // this probe cannot judge it (pnpm/pnpm#14001).
+                if is_hoisted {
+                    return Ok(false);
+                }
                 let Some(current_snapshots) = current_snapshots else { return Ok(false) };
                 let Some(current_snapshot) = current_snapshots.get(snapshot_key) else {
                     return Ok(false);

--- a/pnpm/crates/deps-restorer/src/create_virtual_store/snapshot_plan.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store/snapshot_plan.rs
@@ -160,15 +160,17 @@ pub(super) fn plan_snapshots<'a, Reporter: self::Reporter>(
             }
             Ok::<_, CreateVirtualStoreError>(entries)
         })?;
-    marker_rebuilds.extend(
-        snapshot_entries
-            .iter()
-            .filter(|(snapshot_key, _, _)| !marker_probe_keys.contains(*snapshot_key))
-            .filter(|(snapshot_key, _, _)| {
-                gvs_slot_needs_rebuild(layout, allow_build_policy, snapshot_key)
-            })
-            .map(|(snapshot_key, _, _)| (*snapshot_key).clone()),
-    );
+    if !is_hoisted {
+        marker_rebuilds.extend(
+            snapshot_entries
+                .iter()
+                .filter(|(snapshot_key, _, _)| !marker_probe_keys.contains(*snapshot_key))
+                .filter(|(snapshot_key, _, _)| {
+                    gvs_slot_needs_rebuild(layout, allow_build_policy, snapshot_key)
+                })
+                .map(|(snapshot_key, _, _)| (*snapshot_key).clone()),
+        );
+    }
 
     // A parallel `Vec` rather than a filter later: the partition's
     // manifest and side-effects loop has to see the full snapshot set,

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
@@ -502,6 +502,8 @@ fn first_project_missing_modules_dir(
     node_linker: NodeLinker,
     project_manifests: &[(PathBuf, &PackageManifest)],
 ) -> Option<String> {
+    let root_modules_dir_exists = config.modules_dir.exists();
+
     project_manifests.iter().find_map(|(root_dir, manifest)| {
         if !manifest_has_runtime_deps(manifest) {
             return None;
@@ -510,27 +512,21 @@ fn first_project_missing_modules_dir(
         // their own `<root>/node_modules`. Matches the isolated-linker
         // default — `config.modules_dir` is `<workspace_root>/node_modules`
         // unless the user overrode it explicitly.
-        let modules_dir = match node_linker {
-            NodeLinker::Hoisted => {
-                // Every project's dependencies land in the root modules
-                // directory, so that is what each one is checked against.
-                config.modules_dir.clone()
-            }
+        let modules_dir_exists = match node_linker {
+            NodeLinker::Hoisted => root_modules_dir_exists,
             NodeLinker::Isolated | NodeLinker::Pnp => {
                 if *root_dir == workspace_dir_of(config, root_dir) {
-                    config.modules_dir.clone()
+                    root_modules_dir_exists
                 } else {
-                    root_dir.join("node_modules")
+                    root_dir.join("node_modules").exists()
                 }
             }
         };
-        if modules_dir.exists() {
-            return None;
-        }
-        Some(
+
+        (!modules_dir_exists).then(|| {
             manifest_string_field(manifest, "name")
-                .unwrap_or_else(|| root_dir.to_string_lossy().into_owned()),
-        )
+                .unwrap_or_else(|| root_dir.to_string_lossy().into_owned())
+        })
     })
 }
 

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
@@ -241,7 +241,7 @@ pub(crate) fn check_optimistic_repeat_install_ignoring(
     // overrides yet, so check the install-time `config.modules_dir`
     // for the root + `<project_root>/node_modules` for siblings,
     // matching the `isolated`-linker default.
-    if !modules_dirs_present(config, project_manifests) {
+    if !modules_dirs_present(config, node_linker, project_manifests) {
         return Decision::Skipped {
             reason: "project has dependencies but no node_modules directory",
         };
@@ -488,9 +488,10 @@ fn project_structure_matches(
 
 fn modules_dirs_present(
     config: &Config,
+    node_linker: NodeLinker,
     project_manifests: &[(PathBuf, &PackageManifest)],
 ) -> bool {
-    first_project_missing_modules_dir(config, project_manifests).is_none()
+    first_project_missing_modules_dir(config, node_linker, project_manifests).is_none()
 }
 
 /// The id (`name` field, falling back to the root dir) of the first
@@ -498,6 +499,7 @@ fn modules_dirs_present(
 /// `None` when every project with dependencies has one.
 fn first_project_missing_modules_dir(
     config: &Config,
+    node_linker: NodeLinker,
     project_manifests: &[(PathBuf, &PackageManifest)],
 ) -> Option<String> {
     project_manifests.iter().find_map(|(root_dir, manifest)| {
@@ -508,10 +510,19 @@ fn first_project_missing_modules_dir(
         // their own `<root>/node_modules`. Matches the isolated-linker
         // default — `config.modules_dir` is `<workspace_root>/node_modules`
         // unless the user overrode it explicitly.
-        let modules_dir = if *root_dir == workspace_dir_of(config, root_dir) {
-            config.modules_dir.clone()
-        } else {
-            root_dir.join("node_modules")
+        let modules_dir = match node_linker {
+            NodeLinker::Hoisted => {
+                // Every project's dependencies land in the root modules
+                // directory, so that is what each one is checked against.
+                config.modules_dir.clone()
+            }
+            NodeLinker::Isolated | NodeLinker::Pnp => {
+                if *root_dir == workspace_dir_of(config, root_dir) {
+                    config.modules_dir.clone()
+                } else {
+                    root_dir.join("node_modules")
+                }
+            }
         };
         if modules_dir.exists() {
             return None;

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/deps_status.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/deps_status.rs
@@ -101,7 +101,7 @@ pub fn check_deps_status_before_run(
     // A filtered install legitimately leaves unselected projects
     // without a modules directory.
     if !state.filtered_install
-        && let Some(id) = first_project_missing_modules_dir(config, project_manifests)
+        && let Some(id) = first_project_missing_modules_dir(config, node_linker, project_manifests)
     {
         return outdated(format!(
             "Workspace package {id} has dependencies but does not have a modules directory",


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#14001.

Under `nodeLinker: hoisted`, a repeat `pnpm install` re-imported the whole dependency tree instead of reporting the workspace up to date, and logged `pnpm:_broken_node_modules` for every package it had just written. Both need a workspace package to declare the dependencies, which is why the plain single-project hoisted tests never caught them.

Two independent causes, both rooted in the same assumption — that a project's dependencies live under that project.

The workspace-state fast path stat'ed each project's own `node_modules`. Under hoisting a member's directory holds nothing but workspace links and usually does not exist at all, so the check read the absence as a project that was never installed and fell through to the full pipeline. It now stats the root modules directory for every project, the way `checkDepsStatus` does through `statModulesDir` (`pnpm11/deps/status/src/checkDepsStatus.ts:307`).

The snapshot plan then probed an isolated-style virtual-store slot for every snapshot, and a hoisted install writes none. Every package of the freshly written tree came back missing, hence the broken-modules log line. The probe was also wrong in the other direction: a slot left behind by an earlier isolated install let the plan skip a snapshot whose CAS paths the hoisted linker still needed. `is_hoisted` now short-circuits it.

The hoisted no-op short-circuit inside the pipeline is deliberately left alone. It probes registry deps under each importer, so it never fires for a workspace package's dependencies, and the pipeline keeps removing stale project-local copies — which the extended `hoisted_node_linker` test pins down.

Three tests cover this. `repeat_hoisted_install_with_workspace_member_deps_is_up_to_date` asserts the second install prints "Already up to date" and leaves the hoisted subdep's inode untouched; `repeat_hoisted_install_reports_nothing_broken` drops the workspace-state file to force the pipeline and asserts no `pnpm:_broken_node_modules` event; and `a_nested_copy_is_removed_once_its_version_wins_the_root_slot` now drops that file too, so the stale-link half of it reaches the linker at all instead of short-circuiting.

pacquet-only: the TypeScript CLI already special-cases the hoisted linker in `statModulesDir`, and its headless hoisted path rematerializes without probing virtual-store slots, so there is nothing to mirror.

## Squash Commit Body

```text
Under `nodeLinker: hoisted` every project's dependencies are installed
into the root modules directory, so a workspace package's own
`node_modules` holds nothing but workspace links and is usually absent.
The workspace-state fast path stat'ed each project's own directory, read
that absence as a project that was never installed, and fell through to
the pipeline, which re-imported the whole tree on every install. Stat the
root modules directory for every project instead, the way pnpm's
`checkDepsStatus` does through `statModulesDir`.

The snapshot plan also probed an isolated-style virtual-store slot for
every snapshot under the hoisted linker, which writes none: it logged
`pnpm:_broken_node_modules` for each package of the tree it had just
written, and a stale slot from an earlier isolated install could skip a
snapshot the hoisted linker still needs CAS paths for.

The hoisted no-op short-circuit inside the pipeline stays as it is — it
probes registry deps under each importer, so it does not fire for a
workspace package's dependencies, and the pipeline keeps removing stale
project-local copies. pnpm behaves the same way: its headless hoisted
path always rematerializes.

Closes pnpm/pnpm#14001
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789810727&installation_model_id=426870&pr_number=14029&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14029&signature=7bb00cf969d72a82378a01a6cf417602fbd82c5a5fc32ae7c10cfa88489b5e78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Repeated installs using the hoisted node linker now correctly complete as no-ops when dependencies are already installed.
  - Prevented valid hoisted workspace dependencies from being incorrectly reported as broken.
  - Improved reinstall handling when workspace state information is unavailable or bypassed.

- **Tests**
  - Added coverage for hoisted workspace repeat-install scenarios and stale dependency cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->