### PR TITLE
refactor: remove unused linked aliases set

### DIFF
--- a/.changeset/calm-tools-link.md
+++ b/.changeset/calm-tools-link.md
@@ -1,6 +1,0 @@
----
-"@pnpm/installing.deps-resolver": patch
-"pnpm": patch
----
-
-Removed unnecessary work while partitioning linked dependencies.

--- a/.changeset/calm-tools-link.md
+++ b/.changeset/calm-tools-link.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-resolver": patch
+"pnpm": patch
+---
+
+Removed unnecessary work while partitioning linked dependencies.

--- a/pnpm11/installing/deps-resolver/src/toResolveImporter.ts
+++ b/pnpm11/installing/deps-resolver/src/toResolveImporter.ts
@@ -107,7 +107,6 @@ async function partitionLinkedPackages (
   }
 ): Promise<WantedDependency[]> {
   const nonLinkedDependencies: WantedDependency[] = []
-  const linkedAliases = new Set<string>()
   await Promise.all(dependencies.map(async (dependency) => {
     if (
       !dependency.alias ||
@@ -134,7 +133,6 @@ async function partitionLinkedPackages (
         prefix: opts.projectDir,
       })
     }
-    linkedAliases.add(dependency.alias)
   }))
   return nonLinkedDependencies
 }


### PR DESCRIPTION
## Summary

- Remove the local `linkedAliases` Set from `partitionLinkedPackages`.
- The Set has no reads: it was allocated once per call and populated once per linked dependency without affecting the returned dependencies.
- This is an internal TypeScript refactor with no user-visible behavior change, so no Rust parity change is needed.

## Squash Commit Body

```text
Remove the unused linkedAliases Set from partitionLinkedPackages. It was allocated and populated for linked dependencies but never read, so it added work without affecting the returned non-linked dependencies.
```

## Validation

- `pnpm --filter @pnpm/installing.deps-resolver test` (17 suites, 178 tests)
- `pnpm --filter @pnpm/installing.deps-installer exec jest test/install/excludeLinksFromLockfile.ts --runInBand` (1 suite, 7 tests)
- Repository pre-push type checks, CLI build, spelling, metadata, TypeScript lint, Rust formatting, Clippy, and documentation checks
- `pnpm change status`

## Checklist

- [x] Added a changeset for `@pnpm/installing.deps-resolver` and `pnpm`.

Written by an agent (Codex, GPT-5.6)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14032"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789816212&installation_model_id=426870&pr_number=14032&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14032&signature=e3d12990cf7ec2a534e5c92d39514bc9ada95bbf6ca2584c498ccfce7b1a36c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Reduced unnecessary processing when resolving linked dependencies.
  - Dependency partitioning and related logging continue to work as expected.

- **Release**
  - Patch releases prepared for the dependency resolver and pnpm packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->