### PR TITLE
fix(hoisted): resolve edges declared against a collapsed peer variant

### DIFF
--- a/.changeset/hoisted-collapsed-peer-variant-edges.md
+++ b/.changeset/hoisted-collapsed-peer-variant-edges.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/installing.deps-restorer": patch
+"@pnpm/installing.linking.real-hoist": patch
 "pacquet": patch
 "pnpm": patch
 ---

--- a/.changeset/hoisted-collapsed-peer-variant-edges.md
+++ b/.changeset/hoisted-collapsed-peer-variant-edges.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.deps-restorer": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+Under `nodeLinker: hoisted`, a dependency declared against a peer-resolution variant of a package version is no longer dropped from the installed layout. All variants of a version share one hoisted copy, and edges pointing at any of them now resolve to it, so the depending project keeps the package in its `.package-map.json` and the depending package keeps it in its `node_modules/.bin`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6530,6 +6530,9 @@ importers:
       '@pnpm/error':
         specifier: workspace:*
         version: link:../../../core/error
+      '@pnpm/lockfile.types':
+        specifier: workspace:*
+        version: link:../../../lockfile/types
       '@pnpm/lockfile.utils':
         specifier: workspace:*
         version: link:../../../lockfile/utils

--- a/pnpm/crates/cli/tests/suite/hoisted_node_linker.rs
+++ b/pnpm/crates/cli/tests/suite/hoisted_node_linker.rs
@@ -1064,6 +1064,11 @@ fn a_directory_dependency_is_recopied_under_the_hoisted_linker() {
 /// version. pnpm hoists such variants into a single root copy; nesting
 /// a second, identical copy under the project only costs disk and
 /// install time.
+///
+/// Collapsing the variants leaves only one of the two snapshot keys in
+/// the dep graph, so the package map is asserted too: a project that
+/// declared the *other* variant must still resolve the dependency it
+/// declared, through the one copy at the root.
 #[test]
 fn peer_variants_of_one_version_share_the_root_slot() {
     let fixture = WorkspaceFixture::new();
@@ -1101,6 +1106,20 @@ fn peer_variants_of_one_version_share_the_root_slot() {
         assert!(
             !project.join("node_modules/@pnpm.e2e/abc").exists(),
             "a peer variant of the root version must not nest its own copy: {project:?}",
+        );
+    }
+
+    let package_map: serde_json::Value =
+        serde_json::from_str(&package_map_contents(&fixture.workspace))
+            .expect("parse the package map");
+    for project in ["a", "b"] {
+        let dependency_id = package_map["packages"][format!("../packages/{project}")]
+            ["dependencies"]["@pnpm.e2e/abc"]
+            .as_str()
+            .unwrap_or_else(|| panic!("packages/{project} declares @pnpm.e2e/abc"));
+        assert_eq!(
+            package_map["packages"][dependency_id]["url"], "./@pnpm.e2e/abc",
+            "packages/{project} resolves @pnpm.e2e/abc through the root copy",
         );
     }
 }

--- a/pnpm/crates/cli/tests/suite/hoisted_node_linker.rs
+++ b/pnpm/crates/cli/tests/suite/hoisted_node_linker.rs
@@ -1058,3 +1058,49 @@ fn a_directory_dependency_is_recopied_under_the_hoisted_linker() {
 
     drop((root, mock_instance));
 }
+
+/// Two projects on the same `@pnpm.e2e/abc@1.0.0` but on different
+/// `peer-a` versions give the lockfile two peer variants of one package
+/// version. pnpm hoists such variants into a single root copy; nesting
+/// a second, identical copy under the project only costs disk and
+/// install time.
+#[test]
+fn peer_variants_of_one_version_share_the_root_slot() {
+    let fixture = WorkspaceFixture::new();
+    fixture.append_workspace_yaml("nodeLinker: hoisted\n");
+    let deps_with_peer_a_1_0_0 = [
+        ("@pnpm.e2e/abc", "1.0.0"),
+        ("@pnpm.e2e/peer-a", "1.0.0"),
+        ("@pnpm.e2e/peer-b", "1.0.0"),
+        ("@pnpm.e2e/peer-c", "1.0.0"),
+    ];
+    let deps_with_peer_a_1_0_1 = [
+        ("@pnpm.e2e/abc", "1.0.0"),
+        ("@pnpm.e2e/peer-a", "1.0.1"),
+        ("@pnpm.e2e/peer-b", "1.0.0"),
+        ("@pnpm.e2e/peer-c", "1.0.0"),
+    ];
+    let on_peer_a_1_0_0 = fixture.project(
+        "a",
+        "a",
+        ManifestDeps { prod: &deps_with_peer_a_1_0_0, ..Default::default() },
+    );
+    let on_peer_a_1_0_1 = fixture.project(
+        "b",
+        "b",
+        ManifestDeps { prod: &deps_with_peer_a_1_0_1, ..Default::default() },
+    );
+
+    fixture.run(["install"]);
+
+    assert!(
+        is_real_dir(&fixture.workspace, "node_modules/@pnpm.e2e/abc"),
+        "the shared version holds the root slot",
+    );
+    for project in [&on_peer_a_1_0_0, &on_peer_a_1_0_1] {
+        assert!(
+            !project.join("node_modules/@pnpm.e2e/abc").exists(),
+            "a peer variant of the root version must not nest its own copy: {project:?}",
+        );
+    }
+}

--- a/pnpm/crates/deps-restorer/src/hoisted_dep_graph.rs
+++ b/pnpm/crates/deps-restorer/src/hoisted_dep_graph.rs
@@ -443,7 +443,7 @@ fn build_dep_graph(
                 // don't live in the virtual store.
                 let Some(dep_key) = spec.version.resolved_key(alias) else { continue };
                 if let Some(locations) =
-                    pkg_locations_by_pkg_id.get(&dep_key.without_peer().to_string())
+                    pkg_locations_by_pkg_id.get(&pnpm_real_hoist::pkg_id(&dep_key))
                     && let Some(first) = locations.first()
                 {
                     direct_deps.insert(alias.to_string(), first.clone());
@@ -513,13 +513,12 @@ struct WalkState<'a> {
     /// Records every directory each package landed in, in visit
     /// order. The first entry wins for parent → child wiring.
     ///
-    /// Keyed by the peer-suffix-free package id, not the snapshot
-    /// key: the hoister collapses every peer variant of one package
-    /// version onto a single node (see `real-hoist`'s
-    /// `TreeCache::dep_key_by_pkg_id`), so only the first-seen
-    /// variant's key reaches the walk. Keying — and looking up — by
-    /// the variant-free id is what lets an edge declared against
-    /// any other variant still find that node's directory.
+    /// Keyed by [`pnpm_real_hoist::pkg_id`], not the snapshot key:
+    /// the hoister collapses every peer variant of one package
+    /// version onto a single node, so only the first-seen variant's
+    /// key reaches this walk. Sharing the hoister's own identity
+    /// function is what lets an edge declared against any other
+    /// variant still find that node's directory.
     pkg_locations_by_pkg_id: BTreeMap<String, Vec<PathBuf>>,
     hoisted_locations: BTreeMap<String, Vec<String>>,
     injection_targets_by_dep_path: BTreeMap<String, Vec<PathBuf>>,
@@ -670,7 +669,7 @@ fn walk_deps(
         state.graph.insert(dir.clone(), node);
         state
             .pkg_locations_by_pkg_id
-            .entry(pkg_key.without_peer().to_string())
+            .entry(pnpm_real_hoist::pkg_id(&pkg_key))
             .or_default()
             .push(dir.clone());
 
@@ -784,7 +783,7 @@ fn compute_children(
         let Some(child_key) = dep_ref.resolve(alias_name) else {
             continue;
         };
-        if let Some(locations) = pkg_locations.get(&child_key.without_peer().to_string())
+        if let Some(locations) = pkg_locations.get(&pnpm_real_hoist::pkg_id(&child_key))
             && let Some(first) = locations.first()
         {
             children.insert(alias_name.to_string(), first.clone());

--- a/pnpm/crates/deps-restorer/src/hoisted_dep_graph.rs
+++ b/pnpm/crates/deps-restorer/src/hoisted_dep_graph.rs
@@ -366,7 +366,7 @@ fn build_dep_graph(
         opts,
         skipped: opts.skipped.clone(),
         graph: DependenciesGraph::new(),
-        pkg_locations_by_dep_path: BTreeMap::new(),
+        pkg_locations_by_pkg_id: BTreeMap::new(),
         hoisted_locations: BTreeMap::new(),
         injection_targets_by_dep_path: BTreeMap::new(),
         per_importer_hierarchies: BTreeMap::new(),
@@ -377,18 +377,18 @@ fn build_dep_graph(
     drop(root_deps);
 
     // Pass 2 — fill in each node's `children` map from the
-    // now-complete `pkg_locations_by_dep_path`.
+    // now-complete `pkg_locations_by_pkg_id`.
     //
     // The walk above intentionally leaves `children` empty: every
     // sibling and descendant of a node must have its directory
-    // recorded in `pkg_locations_by_dep_path` before any node
+    // recorded in `pkg_locations_by_pkg_id` before any node
     // resolves its children, so the location index is complete by
     // the time children are computed. The simplest way to preserve
     // that invariant is to insert everything first and resolve
     // children second.
     let WalkState {
         graph,
-        pkg_locations_by_dep_path,
+        pkg_locations_by_pkg_id,
         hoisted_locations,
         injection_targets_by_dep_path,
         skipped,
@@ -398,7 +398,7 @@ fn build_dep_graph(
         ..
     } = state;
     let mut graph = graph;
-    fill_children(&mut graph, &pkg_locations_by_dep_path, lockfile)?;
+    fill_children(&mut graph, &pkg_locations_by_pkg_id, lockfile)?;
 
     // The hoister produced a children order; the directory keys in
     // `root_hierarchy` follow it, and
@@ -415,8 +415,8 @@ fn build_dep_graph(
         .insert(Lockfile::ROOT_IMPORTER_KEY.to_string(), direct_deps_root);
 
     // Per-non-root importer direct deps: iterate each importer's
-    // declared lockfile entries and look up the resolved depPath
-    // in `pkg_locations_by_dep_path`. The first recorded location
+    // declared lockfile entries and look up the resolved snapshot
+    // key in `pkg_locations_by_pkg_id`. The first recorded location
     // wins.
     // We can't read this off the workspace node's tree-children
     // because the hoister moves dedupe-able deps up to root, leaving
@@ -442,8 +442,8 @@ fn build_dep_graph(
                 // `(alias, version)`. `link:` deps are skipped — they
                 // don't live in the virtual store.
                 let Some(dep_key) = spec.version.resolved_key(alias) else { continue };
-                let dep_path = dep_key.to_string();
-                if let Some(locations) = pkg_locations_by_dep_path.get(&dep_path)
+                if let Some(locations) =
+                    pkg_locations_by_pkg_id.get(&dep_key.without_peer().to_string())
                     && let Some(first) = locations.first()
                 {
                     direct_deps.insert(alias.to_string(), first.clone());
@@ -510,9 +510,17 @@ struct WalkState<'a> {
     opts: &'a LockfileToHoistedDepGraphOptions,
     skipped: BTreeSet<String>,
     graph: DependenciesGraph,
-    /// Records every directory each depPath landed in, in visit
+    /// Records every directory each package landed in, in visit
     /// order. The first entry wins for parent → child wiring.
-    pkg_locations_by_dep_path: BTreeMap<String, Vec<PathBuf>>,
+    ///
+    /// Keyed by the peer-suffix-free package id, not the snapshot
+    /// key: the hoister collapses every peer variant of one package
+    /// version onto a single node (see `real-hoist`'s
+    /// `TreeCache::dep_key_by_pkg_id`), so only the first-seen
+    /// variant's key reaches the walk. Keying — and looking up — by
+    /// the variant-free id is what lets an edge declared against
+    /// any other variant still find that node's directory.
+    pkg_locations_by_pkg_id: BTreeMap<String, Vec<PathBuf>>,
     hoisted_locations: BTreeMap<String, Vec<String>>,
     injection_targets_by_dep_path: BTreeMap<String, Vec<PathBuf>>,
     /// Per-non-root-importer hierarchy emitted while walking
@@ -660,7 +668,11 @@ fn walk_deps(
         };
 
         state.graph.insert(dir.clone(), node);
-        state.pkg_locations_by_dep_path.entry(reference.clone()).or_default().push(dir.clone());
+        state
+            .pkg_locations_by_pkg_id
+            .entry(pkg_key.without_peer().to_string())
+            .or_default()
+            .push(dir.clone());
 
         // Directory resolutions are injected workspace packages.
         // Record every dir an injected dep lands in for the
@@ -751,7 +763,7 @@ fn path_relative_to_lockfile_dir(dir: &Path, lockfile_dir: &Path) -> String {
 
 /// Compute the `children: alias → dir` map for a node: look up
 /// every direct (and optional, with `include` always on here) dep
-/// of the snapshot, resolve it to its depPath via
+/// of the snapshot, resolve it to its snapshot key via
 /// `SnapshotDepRef::resolve`, and take the first recorded
 /// location.
 fn compute_children(
@@ -772,8 +784,7 @@ fn compute_children(
         let Some(child_key) = dep_ref.resolve(alias_name) else {
             continue;
         };
-        let child_dep_path = child_key.to_string();
-        if let Some(locations) = pkg_locations.get(&child_dep_path)
+        if let Some(locations) = pkg_locations.get(&child_key.without_peer().to_string())
             && let Some(first) = locations.first()
         {
             children.insert(alias_name.to_string(), first.clone());

--- a/pnpm/crates/deps-restorer/src/hoisted_dep_graph/tests.rs
+++ b/pnpm/crates/deps-restorer/src/hoisted_dep_graph/tests.rs
@@ -1106,3 +1106,67 @@ fn walker_resolves_peered_reference_via_peerless_packages_key() {
     // The peer itself is a plain dep of the root and must be there too.
     assert!(result.graph.contains_key(&lockfile_dir.join("node_modules").join("peer")));
 }
+
+/// The hoister collapses every peer variant of one package version onto
+/// a single node keyed by the first snapshot key it sees, so the graph
+/// holds no entry under the other variants' keys. Edges declared against
+/// one of those — an importer's own dependency, or a sibling package's —
+/// still have to resolve to the copy that node produced.
+#[test]
+fn walker_wires_edges_declared_against_a_collapsed_peer_variant() {
+    let mut root_deps = ResolvedDependencyMap::new();
+    root_deps.insert(pkg_name("b"), resolved_dep("1.0.0(peer@2.0.0)"));
+    root_deps.insert(pkg_name("peer"), resolved_dep("2.0.0"));
+    root_deps.insert(pkg_name("c"), resolved_dep("1.0.0"));
+
+    let mut foo_deps = ResolvedDependencyMap::new();
+    foo_deps.insert(pkg_name("b"), resolved_dep("1.0.0(peer@3.0.0)"));
+
+    let mut packages = HashMap::new();
+    packages.insert(dep_key("b", "1.0.0"), metadata_stub());
+    packages.insert(dep_key("c", "1.0.0"), metadata_stub());
+    packages.insert(dep_key("peer", "2.0.0"), metadata_stub());
+    packages.insert(dep_key("peer", "3.0.0"), metadata_stub());
+
+    let mut snapshots = HashMap::new();
+    for peer_version in ["2.0.0", "3.0.0"] {
+        let mut b_deps = HashMap::new();
+        b_deps.insert(pkg_name("peer"), SnapshotDepRef::Plain(ver_peer(peer_version)));
+        snapshots.insert(
+            dep_key("b", &format!("1.0.0(peer@{peer_version})")),
+            SnapshotEntry { dependencies: Some(b_deps), ..SnapshotEntry::default() },
+        );
+        snapshots.insert(dep_key("peer", peer_version), SnapshotEntry::default());
+    }
+    // `c` depends on the variant the root importer does not declare.
+    let mut c_deps = HashMap::new();
+    c_deps.insert(pkg_name("b"), SnapshotDepRef::Plain(ver_peer("1.0.0(peer@3.0.0)")));
+    snapshots.insert(
+        dep_key("c", "1.0.0"),
+        SnapshotEntry { dependencies: Some(c_deps), ..SnapshotEntry::default() },
+    );
+
+    let lockfile = workspace_lockfile(
+        vec![(Lockfile::ROOT_IMPORTER_KEY, root_deps), ("packages/foo", foo_deps)],
+        packages,
+        snapshots,
+    );
+    let lockfile_dir = PathBuf::from("/repo");
+    let opts = LockfileToHoistedDepGraphOptions {
+        lockfile_dir: lockfile_dir.clone(),
+        ..LockfileToHoistedDepGraphOptions::default()
+    };
+    let result = lockfile_to_hoisted_dep_graph(&lockfile, None, &opts).expect("walker succeeds");
+
+    let modules = lockfile_dir.join("node_modules");
+    assert_eq!(
+        result.direct_dependencies_by_importer_id["packages/foo"].get("b"),
+        Some(&modules.join("b")),
+        "the importer that declared the collapsed variant keeps its direct dependency",
+    );
+    assert_eq!(
+        result.graph[&modules.join("c")].children.get("b"),
+        Some(&modules.join("b")),
+        "a snapshot edge on the collapsed variant resolves to the surviving copy",
+    );
+}

--- a/pnpm/crates/deps-restorer/src/package_map.rs
+++ b/pnpm/crates/deps-restorer/src/package_map.rs
@@ -234,7 +234,7 @@ pub fn dependencies_graph_to_package_map(
     let is_loose = opts.package_map_type == NodePackageMapType::Loose;
     let mut packages = BTreeMap::new();
     let mut package_ids_by_graph_key = BTreeMap::new();
-    let mut package_ids_by_dep_path = BTreeMap::new();
+    let mut package_ids_by_pkg_id = BTreeMap::new();
     let mut package_dirs = is_loose.then(BTreeMap::new);
     let mut loose_index = is_loose.then(PhysicalPackageIndex::default);
     let importer_names = importer_names(opts.lockfile_dir, opts.project_manifests);
@@ -242,9 +242,16 @@ pub fn dependencies_graph_to_package_map(
     for (graph_key, node) in &graph.graph {
         let id = graph_package_id(&node.dir, opts.modules_dir);
         package_ids_by_graph_key.insert(graph_key.clone(), id.clone());
-        package_ids_by_dep_path
-            .entry(node.dep_path.as_str().to_string())
-            .or_insert_with(|| id.clone());
+        // Keyed by the peer-suffix-free package id: the hoister
+        // collapses every peer variant of one package version onto a
+        // single node, so an importer that declared another variant
+        // still has to find this one (see
+        // [`crate::hoisted_dep_graph`]'s `pkg_locations_by_pkg_id`).
+        if let Ok(key) = node.dep_path.as_str().parse::<PackageKey>() {
+            package_ids_by_pkg_id
+                .entry(key.without_peer().to_string())
+                .or_insert_with(|| id.clone());
+        }
         if let Some(loose_index) = loose_index.as_mut()
             && let Some(modules_dir) = get_node_modules_path(&node.dir)
         {
@@ -262,17 +269,17 @@ pub fn dependencies_graph_to_package_map(
         add_hoisted_importer_dependencies(
             &mut dependencies,
             importer.dependencies.as_ref(),
-            &package_ids_by_dep_path,
+            &package_ids_by_pkg_id,
         );
         add_hoisted_importer_dependencies(
             &mut dependencies,
             importer.optional_dependencies.as_ref(),
-            &package_ids_by_dep_path,
+            &package_ids_by_pkg_id,
         );
         add_hoisted_importer_dependencies(
             &mut dependencies,
             importer.dev_dependencies.as_ref(),
-            &package_ids_by_dep_path,
+            &package_ids_by_pkg_id,
         );
         let importer_modules_dir = is_loose.then(|| importer_dir.join("node_modules"));
         add_hoisted_linked_dependencies(
@@ -499,7 +506,7 @@ fn add_physical_snapshot_dependencies(
 fn add_hoisted_importer_dependencies(
     dependencies: &mut BTreeMap<String, String>,
     deps: Option<&pnpm_lockfile::ResolvedDependencyMap>,
-    package_ids_by_dep_path: &BTreeMap<String, String>,
+    package_ids_by_pkg_id: &BTreeMap<String, String>,
 ) {
     let Some(deps) = deps else { return };
     for (alias, spec) in deps {
@@ -507,7 +514,7 @@ fn add_hoisted_importer_dependencies(
             continue;
         }
         if let Some(key) = spec.version.resolved_key(alias)
-            && let Some(id) = package_ids_by_dep_path.get(&key.to_string())
+            && let Some(id) = package_ids_by_pkg_id.get(&key.without_peer().to_string())
         {
             dependencies.insert(alias.to_string(), id.clone());
         }

--- a/pnpm/crates/deps-restorer/src/package_map.rs
+++ b/pnpm/crates/deps-restorer/src/package_map.rs
@@ -242,14 +242,14 @@ pub fn dependencies_graph_to_package_map(
     for (graph_key, node) in &graph.graph {
         let id = graph_package_id(&node.dir, opts.modules_dir);
         package_ids_by_graph_key.insert(graph_key.clone(), id.clone());
-        // Keyed by the peer-suffix-free package id: the hoister
-        // collapses every peer variant of one package version onto a
-        // single node, so an importer that declared another variant
-        // still has to find this one (see
-        // [`crate::hoisted_dep_graph`]'s `pkg_locations_by_pkg_id`).
+        // Keyed by [`pnpm_real_hoist::pkg_id`]: the hoister collapses
+        // every peer variant of one package version onto a single
+        // node, so an importer that declared another variant still has
+        // to find this one (see [`crate::hoisted_dep_graph`]'s
+        // `pkg_locations_by_pkg_id`).
         if let Ok(key) = node.dep_path.as_str().parse::<PackageKey>() {
             package_ids_by_pkg_id
-                .entry(key.without_peer().to_string())
+                .entry(pnpm_real_hoist::pkg_id(&key))
                 .or_insert_with(|| id.clone());
         }
         if let Some(loose_index) = loose_index.as_mut()
@@ -514,7 +514,7 @@ fn add_hoisted_importer_dependencies(
             continue;
         }
         if let Some(key) = spec.version.resolved_key(alias)
-            && let Some(id) = package_ids_by_pkg_id.get(&key.without_peer().to_string())
+            && let Some(id) = package_ids_by_pkg_id.get(&pnpm_real_hoist::pkg_id(&key))
         {
             dependencies.insert(alias.to_string(), id.clone());
         }

--- a/pnpm/crates/real-hoist/src/lib.rs
+++ b/pnpm/crates/real-hoist/src/lib.rs
@@ -396,8 +396,8 @@ pub fn hoist(lockfile: &Lockfile, opts: &HoistOpts) -> Result<HoisterResult, Hoi
 
 /// Conversion-phase caches. `nodes` interns one [`HoisterTree`] per
 /// `(alias, snapshot key)` edge target. `dep_key_by_pkg_id` maps a
-/// peer-suffix-free package id (`name@version`) to the first snapshot
-/// key seen for it: every peer-suffix variant of one package version
+/// package id (see [`pkg_id`]) to the first snapshot key seen for
+/// it: every peer-suffix variant of one package version
 /// gets that first key as its `reference`, so the hoister sees one
 /// locator per version and dedups the variants instead of
 /// conflict-nesting a copy of each. Ports `depPathByPkgId` from pnpm
@@ -527,9 +527,11 @@ fn build_dep_node(
     // matching the TS wrapper, which reads `pkgSnapshot` from the
     // original depPath while stamping `depPathByPkgId.get(id)` as the
     // reference.
-    let pkg_id = dep_key.without_peer().to_string();
-    let reference =
-        cache.dep_key_by_pkg_id.entry(pkg_id).or_insert_with(|| dep_key.clone()).to_string();
+    let reference = cache
+        .dep_key_by_pkg_id
+        .entry(pkg_id(dep_key))
+        .or_insert_with(|| dep_key.clone())
+        .to_string();
     let node = Rc::new(HoisterTree {
         name: alias.to_string(),
         ident_name: dep_key.name.to_string(),
@@ -593,6 +595,24 @@ fn collect_snapshot_deps(
 /// `A-Z a-z 0-9 - _ . ! ~ * ' ( )`. Pacquet workspace importers are
 /// filesystem-relative paths, so the common case is alphanumeric +
 /// `/` + `-` + `_`. Encode `/` (since it would confuse
+/// The identity every peer variant of one package version collapses
+/// onto: the snapshot key with its peer suffix — and the patch hash
+/// that sits alongside it — removed.
+///
+/// The hoister emits a single [`HoisterTree`] node, and so a single
+/// directory, per id: it maps the id to the first snapshot key it sees
+/// for it and stamps that key on every variant. Only that first
+/// variant's key survives as the node's `reference`, so anything
+/// indexing the hoist result by package has to key *and* look up by
+/// this id rather than by the snapshot key an edge declares —
+/// otherwise every edge on a collapsed variant finds nothing and drops
+/// out of the layout. The hoisted dep-graph walker's location map and
+/// the package map both index the result this way.
+#[must_use]
+pub fn pkg_id(dep_key: &PkgNameVerPeer) -> String {
+    dep_key.without_peer().to_string()
+}
+
 /// `node_modules` directory parsing) and pass the rest through; if a
 /// richer set ever shows up the function can switch to a full
 /// encoder without touching call sites.

--- a/pnpm/crates/real-hoist/src/lib.rs
+++ b/pnpm/crates/real-hoist/src/lib.rs
@@ -588,6 +588,28 @@ fn collect_snapshot_deps(
     Ok(())
 }
 
+/// The identity every peer variant of one package version collapses
+/// onto: the snapshot key with its peer suffix — and the patch hash
+/// that sits alongside it — removed.
+///
+/// The hoister maps the id to the first snapshot key it sees for it
+/// and stamps that key on every variant, so only that first key
+/// survives as their shared `reference`. Anything indexing the hoist
+/// result by package therefore has to key *and* look up by this id
+/// rather than by the snapshot key an edge declares — otherwise every
+/// edge on a collapsed variant finds nothing and drops out of the
+/// layout.
+///
+/// One id can still cover several directories: [`HoisterTree`] nodes
+/// are interned per `(alias, snapshot key)`, so an alias exposing a
+/// package under a second name gets a node, and a directory, of its
+/// own. An index over the result holds the list and resolves an edge
+/// to its first entry.
+#[must_use]
+pub fn pkg_id(dep_key: &PkgNameVerPeer) -> String {
+    dep_key.without_peer().to_string()
+}
+
 /// Encode an importer id for use as a child node's `name` (and in
 /// the hoisting-limits locator keys built by
 /// `pnpm_package_manager::get_hoisting_limits`). Matches
@@ -595,24 +617,6 @@ fn collect_snapshot_deps(
 /// `A-Z a-z 0-9 - _ . ! ~ * ' ( )`. Pacquet workspace importers are
 /// filesystem-relative paths, so the common case is alphanumeric +
 /// `/` + `-` + `_`. Encode `/` (since it would confuse
-/// The identity every peer variant of one package version collapses
-/// onto: the snapshot key with its peer suffix — and the patch hash
-/// that sits alongside it — removed.
-///
-/// The hoister emits a single [`HoisterTree`] node, and so a single
-/// directory, per id: it maps the id to the first snapshot key it sees
-/// for it and stamps that key on every variant. Only that first
-/// variant's key survives as the node's `reference`, so anything
-/// indexing the hoist result by package has to key *and* look up by
-/// this id rather than by the snapshot key an edge declares —
-/// otherwise every edge on a collapsed variant finds nothing and drops
-/// out of the layout. The hoisted dep-graph walker's location map and
-/// the package map both index the result this way.
-#[must_use]
-pub fn pkg_id(dep_key: &PkgNameVerPeer) -> String {
-    dep_key.without_peer().to_string()
-}
-
 /// `node_modules` directory parsing) and pass the rest through; if a
 /// richer set ever shows up the function can switch to a full
 /// encoder without touching call sites.

--- a/pnpm11/installing/deps-restorer/src/lockfileToHoistedDepGraph.ts
+++ b/pnpm11/installing/deps-restorer/src/lockfileToHoistedDepGraph.ts
@@ -105,7 +105,7 @@ async function _lockfileToHoistedDepGraph (
     ...opts,
     lockfile,
     graph,
-    pkgLocationsByDepPath: {} as Record<string, string[]>,
+    pkgLocationsByPkgId: {} as Record<string, string[]>,
     injectionTargetsByDepPath: new Map<string, string[]>(),
     hoistedLocations: {} as Record<string, string[]>,
   }
@@ -175,7 +175,16 @@ async function fetchDeps (
   opts: {
     graph: DependenciesGraph
     lockfile: LockfileObject
-    pkgLocationsByDepPath: Record<string, string[]>
+    /**
+     * Every directory a package landed in, in visit order; the first
+     * entry wins for parent → child wiring. Keyed by package id
+     * (`name@version`), not depPath: `toTree` collapses every peer
+     * variant of one version onto the first depPath seen for that id
+     * (its `depPathByPkgId`), so only that depPath reaches this walk.
+     * Keying by the variant-free id is what lets an edge declared
+     * against another variant still find the copy that survived.
+     */
+    pkgLocationsByPkgId: Record<string, string[]>
     injectionTargetsByDepPath: Map<string, string[]>
     hoistedLocations: Record<string, string[]>
   } & LockfileToHoistedDepGraphOptions,
@@ -288,10 +297,11 @@ async function fetchDeps (
       patch: getPatchInfo(opts.patchedDependencies, pkgName, pkgVersion),
       resolution: pkgSnapshot.resolution,
     }
-    if (!opts.pkgLocationsByDepPath[depPath]) {
-      opts.pkgLocationsByDepPath[depPath] = []
+    const pkgId = `${pkgName}@${pkgVersion}`
+    if (!opts.pkgLocationsByPkgId[pkgId]) {
+      opts.pkgLocationsByPkgId[pkgId] = []
     }
-    opts.pkgLocationsByDepPath[depPath].push(dir)
+    opts.pkgLocationsByPkgId[pkgId].push(dir)
     // Track directory deps for injected workspace packages
     if ('directory' in pkgSnapshot.resolution && pkgSnapshot.resolution.directory != null) {
       const locations = opts.injectionTargetsByDepPath.get(depPath)
@@ -306,7 +316,7 @@ async function fetchDeps (
       opts.hoistedLocations[depPath] = []
     }
     opts.hoistedLocations[depPath].push(depLocation)
-    opts.graph[dir].children = getChildren(pkgSnapshot, opts.pkgLocationsByDepPath, opts)
+    opts.graph[dir].children = getChildren(pkgSnapshot, opts.pkgLocationsByPkgId, opts)
   }))
   return depHierarchy
 }
@@ -326,8 +336,8 @@ async function dirHasPackageJsonWithVersion (dir: string, expectedVersion?: stri
 
 function getChildren (
   pkgSnapshot: PackageSnapshot,
-  pkgLocationsByDepPath: Record<string, string[]>,
-  opts: { include: IncludedDependencies }
+  pkgLocationsByPkgId: Record<string, string[]>,
+  opts: { include: IncludedDependencies, lockfile: LockfileObject }
 ): Record<string, string> {
   const allDeps = {
     ...pkgSnapshot.dependencies,
@@ -336,8 +346,13 @@ function getChildren (
   const children: Record<string, string> = {}
   for (const [childName, childRef] of Object.entries(allDeps)) {
     const childDepPath = dp.refToRelative(childRef, childName)
-    if (childDepPath && pkgLocationsByDepPath[childDepPath]) {
-      children[childName] = pkgLocationsByDepPath[childDepPath][0]
+    if (!childDepPath) continue
+    const childSnapshot = opts.lockfile.packages?.[childDepPath]
+    if (!childSnapshot) continue
+    const { name, version } = nameVerFromPkgSnapshot(childDepPath, childSnapshot)
+    const locations = pkgLocationsByPkgId[`${name}@${version}`]
+    if (locations) {
+      children[childName] = locations[0]
     }
   }
   return children

--- a/pnpm11/installing/deps-restorer/src/lockfileToHoistedDepGraph.ts
+++ b/pnpm11/installing/deps-restorer/src/lockfileToHoistedDepGraph.ts
@@ -10,7 +10,7 @@ import type {
 } from '@pnpm/deps.graph-builder'
 import * as dp from '@pnpm/deps.path'
 import { safeJoinModulesDir } from '@pnpm/fs.symlink-dependency'
-import { hoist, type HoisterResult, type HoistingLimits } from '@pnpm/installing.linking.real-hoist'
+import { getHoisterPkgId, hoist, type HoisterResult, type HoistingLimits } from '@pnpm/installing.linking.real-hoist'
 import type { IncludedDependencies } from '@pnpm/installing.modules-yaml'
 import type {
   LockfileObject,
@@ -177,11 +177,11 @@ async function fetchDeps (
     lockfile: LockfileObject
     /**
      * Every directory a package landed in, in visit order; the first
-     * entry wins for parent → child wiring. Keyed by package id
-     * (`name@version`), not depPath: `toTree` collapses every peer
-     * variant of one version onto the first depPath seen for that id
-     * (its `depPathByPkgId`), so only that depPath reaches this walk.
-     * Keying by the variant-free id is what lets an edge declared
+     * entry wins for parent → child wiring. Keyed by
+     * {@link getHoisterPkgId}, not depPath: the hoister collapses
+     * every peer variant of one version onto one node, so only the
+     * first variant's depPath reaches this walk. Sharing the
+     * hoister's own identity function is what lets an edge declared
      * against another variant still find the copy that survived.
      */
     pkgLocationsByPkgId: Record<string, string[]>
@@ -297,7 +297,7 @@ async function fetchDeps (
       patch: getPatchInfo(opts.patchedDependencies, pkgName, pkgVersion),
       resolution: pkgSnapshot.resolution,
     }
-    const pkgId = `${pkgName}@${pkgVersion}`
+    const pkgId = getHoisterPkgId(depPath, pkgSnapshot)
     if (!opts.pkgLocationsByPkgId[pkgId]) {
       opts.pkgLocationsByPkgId[pkgId] = []
     }
@@ -349,8 +349,7 @@ function getChildren (
     if (!childDepPath) continue
     const childSnapshot = opts.lockfile.packages?.[childDepPath]
     if (!childSnapshot) continue
-    const { name, version } = nameVerFromPkgSnapshot(childDepPath, childSnapshot)
-    const locations = pkgLocationsByPkgId[`${name}@${version}`]
+    const locations = pkgLocationsByPkgId[getHoisterPkgId(childDepPath, childSnapshot)]
     if (locations) {
       children[childName] = locations[0]
     }

--- a/pnpm11/installing/deps-restorer/test/lockfileToHoistedDepGraph.test.ts
+++ b/pnpm11/installing/deps-restorer/test/lockfileToHoistedDepGraph.test.ts
@@ -82,3 +82,55 @@ test('lockfileToHoistedDepGraph does not create a file outside node_modules for 
   ).rejects.toThrow(expect.objectContaining({ code: 'ERR_PNPM_INVALID_DEPENDENCY_NAME' }))
   expect(fs.existsSync(escaped)).toBe(false)
 })
+
+// Two peer variants of one version collapse onto a single hoister node
+// keyed by the first depPath seen for the version, so the walk never
+// records a location under the other variant's depPath. An edge declared
+// against that variant — here `c`'s dependency on `b` — still has to
+// resolve to the copy the surviving node produced, or `b` drops out of
+// `c`'s children and off `c`'s `node_modules/.bin`.
+function peerVariantLockfile (): LockfileObject {
+  return {
+    lockfileVersion: '9.0',
+    importers: {
+      '.': {
+        dependencies: {
+          b: '1.0.0(peer@2.0.0)',
+          c: '1.0.0',
+          peer: '2.0.0',
+        },
+        specifiers: { b: '1.0.0', c: '1.0.0', peer: '2.0.0' },
+      },
+    },
+    packages: {
+      'b@1.0.0(peer@2.0.0)': {
+        resolution: { integrity: 'sha512-deadbeef' },
+        dependencies: { peer: '2.0.0' },
+      },
+      'b@1.0.0(peer@3.0.0)': {
+        resolution: { integrity: 'sha512-deadbeef' },
+        dependencies: { peer: '3.0.0' },
+      },
+      'c@1.0.0': {
+        resolution: { integrity: 'sha512-deadbeef' },
+        dependencies: { b: '1.0.0(peer@3.0.0)' },
+      },
+      'peer@2.0.0': { resolution: { integrity: 'sha512-deadbeef' } },
+      'peer@3.0.0': { resolution: { integrity: 'sha512-deadbeef' } },
+    },
+  } as unknown as LockfileObject
+}
+
+test('lockfileToHoistedDepGraph wires an edge declared against a collapsed peer variant', async () => {
+  const dir = tempDir(false)
+  const opts = hoistedOpts(dir)
+  opts.storeController = {
+    fetchPackage: () => ({ filesIndexFile: '' }),
+    getFilesIndexFilePath: () => ({ filesIndexFile: '' }),
+  } as unknown as typeof opts.storeController
+
+  const { graph } = await lockfileToHoistedDepGraph(peerVariantLockfile(), null, opts)
+
+  const modulesDir = path.join(dir, 'node_modules')
+  expect(graph[path.join(modulesDir, 'c')].children.b).toBe(path.join(modulesDir, 'b'))
+})

--- a/pnpm11/installing/deps-restorer/test/lockfileToHoistedDepGraph.test.ts
+++ b/pnpm11/installing/deps-restorer/test/lockfileToHoistedDepGraph.test.ts
@@ -89,6 +89,20 @@ test('lockfileToHoistedDepGraph does not create a file outside node_modules for 
 // against that variant — here `c`'s dependency on `b` — still has to
 // resolve to the copy the surviving node produced, or `b` drops out of
 // `c`'s children and off `c`'s `node_modules/.bin`.
+test('lockfileToHoistedDepGraph wires an edge declared against a collapsed peer variant', async () => {
+  const dir = tempDir(false)
+  const opts = hoistedOpts(dir)
+  opts.storeController = {
+    fetchPackage: () => ({ filesIndexFile: '' }),
+    getFilesIndexFilePath: () => ({ filesIndexFile: '' }),
+  } as unknown as typeof opts.storeController
+
+  const { graph } = await lockfileToHoistedDepGraph(peerVariantLockfile(), null, opts)
+
+  const modulesDir = path.join(dir, 'node_modules')
+  expect(graph[path.join(modulesDir, 'c')].children.b).toBe(path.join(modulesDir, 'b'))
+})
+
 function peerVariantLockfile (): LockfileObject {
   return {
     lockfileVersion: '9.0',
@@ -120,17 +134,3 @@ function peerVariantLockfile (): LockfileObject {
     },
   } as unknown as LockfileObject
 }
-
-test('lockfileToHoistedDepGraph wires an edge declared against a collapsed peer variant', async () => {
-  const dir = tempDir(false)
-  const opts = hoistedOpts(dir)
-  opts.storeController = {
-    fetchPackage: () => ({ filesIndexFile: '' }),
-    getFilesIndexFilePath: () => ({ filesIndexFile: '' }),
-  } as unknown as typeof opts.storeController
-
-  const { graph } = await lockfileToHoistedDepGraph(peerVariantLockfile(), null, opts)
-
-  const modulesDir = path.join(dir, 'node_modules')
-  expect(graph[path.join(modulesDir, 'c')].children.b).toBe(path.join(modulesDir, 'b'))
-})

--- a/pnpm11/installing/linking/real-hoist/package.json
+++ b/pnpm11/installing/linking/real-hoist/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@pnpm/deps.path": "workspace:*",
     "@pnpm/error": "workspace:*",
+    "@pnpm/lockfile.types": "workspace:*",
     "@pnpm/lockfile.utils": "workspace:*",
     "@yarnpkg/nm": "catalog:"
   },

--- a/pnpm11/installing/linking/real-hoist/src/index.ts
+++ b/pnpm11/installing/linking/real-hoist/src/index.ts
@@ -28,14 +28,18 @@ export type { HoisterResult }
  * The identity every peer variant of one package version collapses
  * onto.
  *
- * The hoister emits a single node, and so a single directory, per id:
  * `toTree` maps the id to the first depPath it sees for it and stamps
- * that depPath on every variant as the node's `reference`, so only
+ * that depPath on every variant as their shared `reference`, so only
  * that one depPath survives into the result. Anything indexing the
- * hoist result by package has to key *and* look up by this id rather
- * than by the depPath an edge declares — otherwise every edge on a
- * collapsed variant finds nothing and drops out of the layout.
- * `lockfileToHoistedDepGraph` indexes the result this way.
+ * hoist result by package therefore has to key *and* look up by this
+ * id rather than by the depPath an edge declares — otherwise every
+ * edge on a collapsed variant finds nothing and drops out of the
+ * layout.
+ *
+ * One id can still cover several directories: nodes are interned per
+ * `(alias, depPath)`, so an alias exposing a package under a second
+ * name gets a node, and a directory, of its own. An index over the
+ * result holds the list and resolves an edge to its first entry.
  */
 export function getHoisterPkgId (depPath: string, pkgSnapshot: PackageSnapshot): string {
   const { name, version } = nameVerFromPkgSnapshot(depPath, pkgSnapshot)

--- a/pnpm11/installing/linking/real-hoist/src/index.ts
+++ b/pnpm11/installing/linking/real-hoist/src/index.ts
@@ -1,5 +1,6 @@
 import * as dp from '@pnpm/deps.path'
 import { LockfileMissingDependencyError } from '@pnpm/error'
+import type { PackageSnapshot } from '@pnpm/lockfile.types'
 import {
   type LockfileObject,
   nameVerFromPkgSnapshot,
@@ -22,6 +23,24 @@ import { hoist as _hoist, HoisterDependencyKind, type HoisterResult, type Hoiste
 export type HoistingLimits = 'none' | 'workspaces' | 'dependencies'
 
 export type { HoisterResult }
+
+/**
+ * The identity every peer variant of one package version collapses
+ * onto.
+ *
+ * The hoister emits a single node, and so a single directory, per id:
+ * `toTree` maps the id to the first depPath it sees for it and stamps
+ * that depPath on every variant as the node's `reference`, so only
+ * that one depPath survives into the result. Anything indexing the
+ * hoist result by package has to key *and* look up by this id rather
+ * than by the depPath an edge declares — otherwise every edge on a
+ * collapsed variant finds nothing and drops out of the layout.
+ * `lockfileToHoistedDepGraph` indexes the result this way.
+ */
+export function getHoisterPkgId (depPath: string, pkgSnapshot: PackageSnapshot): string {
+  const { name, version } = nameVerFromPkgSnapshot(depPath, pkgSnapshot)
+  return `${name}@${version}`
+}
 
 /**
  * Translate the user-facing {@link HoistingLimits} mode into the
@@ -165,8 +184,8 @@ function toTree (
       if (!pkgSnapshot) {
         throw new LockfileMissingDependencyError(depPath)
       }
-      const { name: pkgName, version } = nameVerFromPkgSnapshot(depPath, pkgSnapshot)
-      const id = `${pkgName}@${version}`
+      const { name: pkgName } = nameVerFromPkgSnapshot(depPath, pkgSnapshot)
+      const id = getHoisterPkgId(depPath, pkgSnapshot)
       if (!depPathByPkgId.has(id)) {
         depPathByPkgId.set(id, depPath)
       }

--- a/pnpm11/installing/linking/real-hoist/tsconfig.json
+++ b/pnpm11/installing/linking/real-hoist/tsconfig.json
@@ -27,6 +27,9 @@
       "path": "../../../lockfile/fs"
     },
     {
+      "path": "../../../lockfile/types"
+    },
+    {
       "path": "../../../lockfile/utils"
     }
   ]


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

This PR originally ported pnpm's `depPathByPkgId` into pacquet's hoister so that peer variants of one package version share a single directory. That fix landed meanwhile as the second of the three fixes in pnpm/pnpm#14039 (`TreeCache::dep_key_by_pkg_id`), so the implementation here is dropped and the branch rebased onto it. What is left of the original change is its end-to-end regression test, which #14039 covers only at the `real-hoist` unit level.

Rebasing surfaced the follow-on defect that the review on this PR had predicted. The hoister collapses every peer variant of one version onto a single node keyed by the *first* snapshot key it sees for that version, so only that one key reaches the dep-graph walk. But the walk kept indexing package locations by that key and looking them up by the exact key each edge declares, so every edge on another variant missed:

- A workspace project that declared the losing variant lost its entry in `direct_dependencies_by_importer_id` and in `.package-map.json`. Under `nodePackageMapType: standard` that project cannot require a dependency it declares.
- A package that depended on the losing variant lost the child edge, and with it the `node_modules/.bin` link that child provides.

The fix keys the indexes — and the lookups — by the peer-suffix-free package id, which is the identity the hoister collapsed on: `pkg_locations_by_pkg_id` and `package_ids_by_pkg_id` in pacquet, `pkgLocationsByPkgId` in the TypeScript CLI. Each stack derives the id the way its own hoister does (`PkgNameVerPeer::without_peer` in Rust, `nameVerFromPkgSnapshot` in TypeScript).

Reproduced on a workspace where two projects depend on `@pnpm.e2e/abc@1.0.0` but pin different `@pnpm.e2e/peer-a` versions: before the fix, `packages/b`'s package-map entry has no `@pnpm.e2e/abc` at all while `packages/a`'s does.

Both stacks are affected and both are fixed here. Three tests cover it, each verified to fail with the fix reverted:

- `peer_variants_of_one_version_share_the_root_slot` (pacquet e2e) — one root copy, no nested copy, and both projects resolving the dependency through it in the package map.
- `walker_wires_edges_declared_against_a_collapsed_peer_variant` (pacquet unit) — the importer's direct dep and a sibling package's child edge.
- `lockfileToHoistedDepGraph wires an edge declared against a collapsed peer variant` (TypeScript unit).

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
The hoister collapses every peer variant of one package version onto a
single node, keyed by the first snapshot key it sees for that version
(pnpm/pnpm#14039 on the Rust side, `toTree`'s `depPathByPkgId` on the
TypeScript side). Only that one key reaches the dep-graph walk, but the
walk kept indexing locations by it and looking them up by the exact key
each edge declares. Every edge on another variant missed.

A workspace project that declared the losing variant lost its entry in
`direct_dependencies_by_importer_id` and in `.package-map.json`, so
under `nodePackageMapType: standard` it could not require a dependency
it declares. A package that depended on one lost the child edge, and
with it the `node_modules/.bin` link the child provides.

Key the indexes — and the lookups — by the peer-suffix-free package id,
which is the identity the hoister collapsed on: `pkg_locations_by_pkg_id`
and `package_ids_by_pkg_id` in pacquet, `pkgLocationsByPkgId` in the
TypeScript CLI. The two stacks derive the id the way their own hoister
does: `PkgNameVerPeer::without_peer` there, `nameVerFromPkgSnapshot` here.

The hoisted-linker regression test the original version of this PR added
is kept, extended to assert the package map.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed hoisted installations with multiple peer-dependency variants so dependencies consistently resolve to a shared hoisted package.
  - Preserved dependency links, package-map entries, and binary links when peer variants are collapsed.
  - Prevented unnecessary project-local copies and improved resolution for dependencies targeting alternate peer variants.

- **Tests**
  - Added regression coverage for workspace installs and collapsed peer-variant dependency resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->