### PR TITLE
perf(pacquet): scope post-resolve work to changed packages

### DIFF
--- a/.changeset/faster-pacquet-post-resolve.md
+++ b/.changeset/faster-pacquet-post-resolve.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Reduced warm update overhead by limiting virtual-store bin linking and ignored-script build bookkeeping to packages materialized by the current install.

--- a/pnpm/crates/deps-restorer/src/build_modules.rs
+++ b/pnpm/crates/deps-restorer/src/build_modules.rs
@@ -559,7 +559,7 @@ impl BuildModules<'_> {
             ignored_builds.into_inner().unwrap_or_else(std::sync::PoisonError::into_inner);
         Ok(BuildModulesOutput {
             ignored_builds: ignored_builds.into_iter().collect(),
-            deferred_builds: deferred_builds(&requires_build_map, ignore_scripts),
+            deferred_builds: deferred_builds(requires_build_map.iter(), ignore_scripts),
         })
     }
 }
@@ -567,18 +567,18 @@ impl BuildModules<'_> {
 /// The snapshots `--ignore-scripts` kept from building, sorted for a
 /// stable `.modules.yaml`.
 ///
-/// Every `requires_build` snapshot qualifies, not just the ones this
-/// install newly materialized: a build stays owed until something
-/// actually runs it, and only `pnpm rebuild` clears the record.
-fn deferred_builds(
-    requires_build_map: &HashMap<PackageKey, bool>,
+/// The caller supplies the snapshots in scope. Normal build-module runs
+/// pass every snapshot they inspected; the `ignoreScripts`
+/// fast path passes only entries newly materialized by this install.
+pub(crate) fn deferred_builds<'a>(
+    requires_build: impl IntoIterator<Item = (&'a PackageKey, &'a bool)>,
     ignore_scripts: bool,
 ) -> Vec<String> {
     if !ignore_scripts {
         return Vec::new();
     }
-    let mut deferred: Vec<String> = requires_build_map
-        .iter()
+    let mut deferred: Vec<String> = requires_build
+        .into_iter()
         .filter(|&(_, &requires_build)| requires_build)
         .map(|(key, _)| key.to_string())
         .collect();

--- a/pnpm/crates/deps-restorer/src/build_modules/tests.rs
+++ b/pnpm/crates/deps-restorer/src/build_modules/tests.rs
@@ -1,6 +1,7 @@
 use super::{
     BuildModules,
     allow_build_policy::{AllowBuildPolicy, allow_build_key_from_ignored_build},
+    deferred_builds,
     slots::{is_contained_descendant, parse_name_version_from_key},
 };
 // Only the `#[cfg(unix)]` rebuild-selection test uses this; importing it
@@ -33,6 +34,18 @@ use tempfile::tempdir;
 /// to it through the side-effects re-materialization path; tests don't
 /// assert on it, so one shared static is enough.
 static TEST_LOGGED_METHODS: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
+
+#[test]
+fn deferred_builds_uses_only_the_supplied_snapshots() {
+    let first = key("first", "1.0.0");
+    let second = key("second", "1.0.0");
+    let requires_build = HashMap::from([(first.clone(), true), (second, true)]);
+
+    assert_eq!(
+        deferred_builds(requires_build.iter().filter(|(key, _)| *key == &first), true),
+        [first.to_string()],
+    );
+}
 
 /// Build an [`AllowBuildPolicy`] from a list of `(spec, allowed)`
 /// pairs, mirroring how `pnpm-workspace.yaml`'s `allowBuilds` map

--- a/pnpm/crates/deps-restorer/src/create_virtual_store.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store.rs
@@ -101,6 +101,11 @@ pub struct CreateVirtualStoreOutput {
     pub package_manifests: PackageManifests,
     pub side_effects_maps_by_snapshot: SideEffectsMapsBySnapshot,
     pub requires_build_by_snapshot: RequiresBuildBySnapshot,
+    /// Snapshot keys whose package directories this run materialized.
+    /// The build phase uses this list to record only newly deferred
+    /// builds under `ignoreScripts`; earlier debt is retained from
+    /// `.modules.yaml` by the install orchestrator.
+    pub materialized_snapshots: Vec<PackageKey>,
     pub fetch_failed: HashSet<PackageKey>,
     /// Per-package CAS index, populated only when
     /// [`CreateVirtualStore::node_linker`] is
@@ -288,6 +293,7 @@ impl CreateVirtualStore<'_> {
                 package_manifests: PackageManifests::new(),
                 side_effects_maps_by_snapshot: SideEffectsMapsBySnapshot::new(),
                 requires_build_by_snapshot: RequiresBuildBySnapshot::new(),
+                materialized_snapshots: Vec::new(),
                 fetch_failed: HashSet::new(),
                 cas_paths_by_pkg_id: is_hoisted.then(CasPathsByPkgId::new),
             });
@@ -417,6 +423,8 @@ impl CreateVirtualStore<'_> {
             ignore_scripts: config.ignore_scripts,
             runtime_platform_selector: &runtime_platform_selector,
         })?;
+        let materialized_snapshots =
+            snapshot_entries.iter().map(|(snapshot_key, _, _)| (*snapshot_key).clone()).collect();
 
         // `pnpm:stats added` fires one event per project once the
         // orchestrator has decided how many packages will land in the
@@ -835,6 +843,7 @@ impl CreateVirtualStore<'_> {
             package_manifests,
             side_effects_maps_by_snapshot,
             requires_build_by_snapshot,
+            materialized_snapshots,
             fetch_failed,
             cas_paths_by_pkg_id,
         })

--- a/pnpm/crates/deps-restorer/src/create_virtual_store/tests.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store/tests.rs
@@ -9,7 +9,7 @@ use pnpm_lockfile::{
 };
 use pnpm_reporter::{LogEvent, ProgressMessage, Reporter, SilentReporter};
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fs,
     sync::{Arc, Mutex, atomic::AtomicU8},
 };
@@ -210,6 +210,10 @@ async fn cold_batch_links_slots_in_parallel() {
     let cold_b = key("cold-b", "1.0.0");
     assert_eq!(output.requires_build_by_snapshot.get(&cold_a), Some(&true));
     assert_eq!(output.requires_build_by_snapshot.get(&cold_b), Some(&false));
+    assert_eq!(
+        output.materialized_snapshots.into_iter().collect::<HashSet<_>>(),
+        HashSet::from([cold_a, cold_b, key("cold-c", "1.0.0"), key("cold-d", "1.0.0"),]),
+    );
 }
 
 const DUMMY_SHA512: &str = "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==";
@@ -331,6 +335,7 @@ async fn shared_store_context_materializes_a_warm_package() {
     writer_task.await.expect("join store-index writer").expect("flush store-index writer");
 
     assert_eq!(output.requires_build_by_snapshot.get(&package_key), Some(&false));
+    assert_eq!(output.materialized_snapshots.as_slice(), std::slice::from_ref(&package_key));
     let installed_body = layout
         .slot_dir(&package_key)
         .join("node_modules")

--- a/pnpm/crates/deps-restorer/src/install_frozen_lockfile.rs
+++ b/pnpm/crates/deps-restorer/src/install_frozen_lockfile.rs
@@ -648,6 +648,7 @@ where
             package_manifests,
             side_effects_maps_by_snapshot,
             requires_build_by_snapshot,
+            materialized_snapshots,
             fetch_failed,
             cas_paths_by_pkg_id,
         } = {
@@ -726,6 +727,9 @@ where
                 lockfile,
                 current_lockfile,
                 snapshots,
+                materialized_snapshots: rebuild
+                    .is_none()
+                    .then_some(materialized_snapshots.as_slice()),
                 packages,
                 importers,
                 project_manifests,
@@ -802,6 +806,7 @@ where
                 allow_build_policy: &allow_build_policy,
                 side_effects_maps_by_snapshot: &side_effects_maps_by_snapshot,
                 requires_build_by_snapshot: &requires_build_by_snapshot,
+                materialized_snapshots: &materialized_snapshots,
                 engine_name: engine_name.as_deref(),
                 extra_env: &build_extra_env,
                 store_index_writer: &store_index_writer,

--- a/pnpm/crates/deps-restorer/src/install_frozen_lockfile/build_phase.rs
+++ b/pnpm/crates/deps-restorer/src/install_frozen_lockfile/build_phase.rs
@@ -121,6 +121,10 @@ pub struct BuildPhaseInputs<'a> {
     pub allow_build_policy: &'a AllowBuildPolicy,
     pub side_effects_maps_by_snapshot: &'a crate::SideEffectsMapsBySnapshot,
     pub requires_build_by_snapshot: &'a crate::RequiresBuildBySnapshot,
+    /// Snapshot keys materialized by this install. Under
+    /// `ignoreScripts`, only these can add new `pendingBuilds`; the
+    /// install orchestrator separately carries forward existing entries.
+    pub materialized_snapshots: &'a [PackageKey],
     pub engine_name: Option<&'a str>,
     pub extra_env: &'a HashMap<String, String>,
     pub store_index_writer: &'a Arc<StoreIndexWriter>,
@@ -167,6 +171,7 @@ pub fn run_build_phase<Reporter: self::Reporter>(
         allow_build_policy,
         side_effects_maps_by_snapshot,
         requires_build_by_snapshot,
+        materialized_snapshots,
         engine_name,
         extra_env,
         store_index_writer,
@@ -195,39 +200,54 @@ pub fn run_build_phase<Reporter: self::Reporter>(
     // Under isolated, the directories live under the virtual-store slot
     // layout; under hoisted, they live at the project-tree paths the
     // walker assigned — threaded in via `pkg_roots_by_key`.
-    let build_output = BuildModules {
-        layout,
-        modules_dir: &config.modules_dir,
-        lockfile_dir: workspace_root,
-        snapshots,
-        packages,
-        importers,
-        allow_build_policy,
-        side_effects_maps_by_snapshot: Some(side_effects_maps_by_snapshot),
-        requires_build_by_snapshot: Some(requires_build_by_snapshot),
-        engine_name,
-        side_effects_cache: config.side_effects_cache_read(),
-        side_effects_cache_write: config.side_effects_cache_write(),
-        store_dir: Some(&config.store_dir),
-        store_index_writer: Some(store_index_writer),
-        patches: patches.as_ref(),
-        scripts_prepend_node_path,
-        script_shell: config.script_shell.as_deref().map(Path::new),
-        extra_env,
-        user_agent: &config.user_agent,
-        unsafe_perm: config.unsafe_perm,
-        child_concurrency: config.child_concurrency,
-        skipped,
-        pkg_roots_by_key: hoisted_pkg_roots_by_key,
-        gather_ancestor_bin_paths: is_hoisted,
-        frozen_store: config.frozen_store,
-        ignore_scripts: config.ignore_scripts,
-        import_method: config.package_import_method,
-        logged_methods,
-        rebuild,
-    }
-    .run::<Reporter>()
-    .map_err(BuildPhaseError::BuildModules)?;
+    let can_defer_without_build_modules = config.ignore_scripts
+        && rebuild.is_none()
+        && patches.as_ref().is_none_or(HashMap::is_empty)
+        && (!config.side_effects_cache_read() || side_effects_maps_by_snapshot.is_empty());
+    let build_output = if can_defer_without_build_modules {
+        let newly_deferred = materialized_snapshots
+            .iter()
+            .filter(|snapshot_key| !skipped.contains(snapshot_key))
+            .filter_map(|snapshot_key| requires_build_by_snapshot.get_key_value(snapshot_key));
+        crate::BuildModulesOutput {
+            ignored_builds: Vec::new(),
+            deferred_builds: crate::build_modules::deferred_builds(newly_deferred, true),
+        }
+    } else {
+        BuildModules {
+            layout,
+            modules_dir: &config.modules_dir,
+            lockfile_dir: workspace_root,
+            snapshots,
+            packages,
+            importers,
+            allow_build_policy,
+            side_effects_maps_by_snapshot: Some(side_effects_maps_by_snapshot),
+            requires_build_by_snapshot: Some(requires_build_by_snapshot),
+            engine_name,
+            side_effects_cache: config.side_effects_cache_read(),
+            side_effects_cache_write: config.side_effects_cache_write(),
+            store_dir: Some(&config.store_dir),
+            store_index_writer: Some(store_index_writer),
+            patches: patches.as_ref(),
+            scripts_prepend_node_path,
+            script_shell: config.script_shell.as_deref().map(Path::new),
+            extra_env,
+            user_agent: &config.user_agent,
+            unsafe_perm: config.unsafe_perm,
+            child_concurrency: config.child_concurrency,
+            skipped,
+            pkg_roots_by_key: hoisted_pkg_roots_by_key,
+            gather_ancestor_bin_paths: is_hoisted,
+            frozen_store: config.frozen_store,
+            ignore_scripts: config.ignore_scripts,
+            import_method: config.package_import_method,
+            logged_methods,
+            rebuild,
+        }
+        .run::<Reporter>()
+        .map_err(BuildPhaseError::BuildModules)?
+    };
 
     // Always emit the `pnpm:ignored-scripts` event with the package
     // names, unconditionally, so structured / NDJSON consumers always

--- a/pnpm/crates/deps-restorer/src/install_frozen_lockfile/build_phase.rs
+++ b/pnpm/crates/deps-restorer/src/install_frozen_lockfile/build_phase.rs
@@ -10,6 +10,9 @@ use super::{
     link_top_level_bins,
 };
 
+#[cfg(test)]
+mod tests;
+
 /// Error type of [`run_build_phase`] and [`resolve_snapshot_patches`].
 ///
 /// Each variant is `#[diagnostic(transparent)]` so the surfaced

--- a/pnpm/crates/deps-restorer/src/install_frozen_lockfile/build_phase/tests.rs
+++ b/pnpm/crates/deps-restorer/src/install_frozen_lockfile/build_phase/tests.rs
@@ -1,0 +1,61 @@
+use super::{
+    AllowBuildPolicy, AtomicU8, BuildPhaseInputs, Config, DependencyGroup, HashMap, PackageKey,
+    ProjectSnapshot, SkippedSnapshots, StoreIndexWriter, VirtualStoreLayout, run_build_phase,
+};
+use pnpm_reporter::SilentReporter;
+use tempfile::tempdir;
+
+#[tokio::test]
+async fn ignored_scripts_fast_path_defers_only_materialized_snapshots() {
+    let materialized = "materialized@1.0.0".parse::<PackageKey>().expect("parse package key");
+    let unrelated = "unrelated@1.0.0".parse::<PackageKey>().expect("parse package key");
+    let requires_build_by_snapshot =
+        HashMap::from([(materialized.clone(), true), (unrelated, true)]);
+    let materialized_snapshots = [materialized.clone()];
+
+    let temp_dir = tempdir().expect("create temp dir");
+    let mut config = Config::new();
+    config.ignore_scripts = true;
+    config.virtual_store_only = true;
+    let config = config.leak();
+    let layout = VirtualStoreLayout::legacy(temp_dir.path(), 120);
+    let importers = HashMap::<String, ProjectSnapshot>::new();
+    let dependency_groups = Vec::<DependencyGroup>::new();
+    let side_effects_maps_by_snapshot = HashMap::new();
+    let allow_build_policy = AllowBuildPolicy::default();
+    let extra_env = HashMap::new();
+    let skipped = SkippedSnapshots::default();
+    let logged_methods = AtomicU8::new(0);
+    let (store_index_writer, writer_task) = StoreIndexWriter::spawn_disabled();
+
+    let output = run_build_phase::<SilentReporter>(&BuildPhaseInputs {
+        config,
+        workspace_root: temp_dir.path(),
+        top_level_bin_root: temp_dir.path(),
+        layout: &layout,
+        snapshots: None,
+        packages: None,
+        importers: &importers,
+        dependency_groups: &dependency_groups,
+        patch_groups: None,
+        allow_build_policy: &allow_build_policy,
+        side_effects_maps_by_snapshot: &side_effects_maps_by_snapshot,
+        requires_build_by_snapshot: &requires_build_by_snapshot,
+        materialized_snapshots: &materialized_snapshots,
+        engine_name: None,
+        extra_env: &extra_env,
+        store_index_writer: &store_index_writer,
+        skipped: &skipped,
+        hoisted_pkg_roots_by_key: None,
+        is_hoisted: false,
+        publicly_hoisted_for_post_build: &[],
+        logged_methods: &logged_methods,
+        rebuild: None,
+        extra_node_paths: &[],
+    })
+    .expect("build phase succeeds");
+
+    assert_eq!(output.deferred_builds, [materialized.to_string()]);
+    drop(store_index_writer);
+    writer_task.await.expect("join writer task").expect("drain writer task");
+}

--- a/pnpm/crates/deps-restorer/src/link_bins.rs
+++ b/pnpm/crates/deps-restorer/src/link_bins.rs
@@ -320,6 +320,10 @@ pub struct LinkVirtualStoreBins<'a> {
     /// each slot's children from its `dependencies` /
     /// `optionalDependencies` lists without touching the filesystem.
     pub snapshots: Option<&'a HashMap<PackageKey, SnapshotEntry>>,
+    /// When present, limit the lockfile-driven pass to these slots.
+    /// Install paths pass the snapshots materialized in the current run;
+    /// rebuild and filesystem-discovery callers leave it unrestricted.
+    pub selected_snapshots: Option<&'a [PackageKey]>,
     /// Lockfile `packages:` section, indexed by `PkgNameVerPeer`
     /// (without peer suffix). Used to filter children by
     /// `hasBin == true` *before* any per-child IO.
@@ -372,6 +376,7 @@ impl LinkVirtualStoreBins<'_> {
         let LinkVirtualStoreBins {
             layout,
             snapshots,
+            selected_snapshots,
             packages,
             package_manifests,
             skipped,
@@ -383,6 +388,7 @@ impl LinkVirtualStoreBins<'_> {
             run_lockfile_driven::<Sys>(
                 layout,
                 snapshots,
+                selected_snapshots,
                 BinSlotSets { has_bin: has_bin_set.as_ref(), bundling: &bundling_set },
                 package_manifests,
                 skipped,
@@ -479,6 +485,7 @@ struct BinSlotSets<'a> {
 fn run_lockfile_driven<Sys>(
     layout: &crate::VirtualStoreLayout,
     snapshots: &HashMap<PackageKey, SnapshotEntry>,
+    selected_snapshots: Option<&[PackageKey]>,
     sets: BinSlotSets<'_>,
     package_manifests: &PackageManifests,
     skipped: &SkippedSnapshots,
@@ -517,8 +524,15 @@ where
     // `<slot>/node_modules/<alias>` (returning `None` harmlessly but
     // wasting work) or — worse — create a `<slot>/.../node_modules/.bin`
     // directory under a slot that doesn't exist on disk.
-    let slot_entries: Vec<(&PackageKey, &SnapshotEntry)> =
-        snapshots.iter().filter(|(slot_key, _)| !skipped.contains(slot_key)).collect();
+    let selected_snapshots: Option<HashSet<&PackageKey>> =
+        selected_snapshots.map(|keys| keys.iter().collect());
+    let slot_entries: Vec<(&PackageKey, &SnapshotEntry)> = snapshots
+        .iter()
+        .filter(|(slot_key, _)| {
+            !skipped.contains(slot_key)
+                && selected_snapshots.as_ref().is_none_or(|keys| keys.contains(slot_key))
+        })
+        .collect();
     slot_entries.par_iter().try_for_each(|(slot_key, snapshot)| {
         let children = snapshot
             .dependencies

--- a/pnpm/crates/deps-restorer/src/link_bins/tests.rs
+++ b/pnpm/crates/deps-restorer/src/link_bins/tests.rs
@@ -6,7 +6,7 @@ use pnpm_cmd_shim::is_shim_pointing_at;
 use pnpm_lockfile::{
     BinaryArchive, BinaryResolution, BinarySpec, DirectoryResolution, LockfileResolution,
     PackageKey, PackageMetadata, PlatformAssetResolution, PlatformAssetTarget, RegistryResolution,
-    VariationsResolution,
+    SnapshotEntry, VariationsResolution,
 };
 use serde_json::json;
 use std::{
@@ -53,6 +53,7 @@ fn writes_child_bins_into_slot_own_package_node_modules() {
             pnpm_config::default_virtual_store_dir_max_length() as usize,
         ),
         snapshots: None,
+        selected_snapshots: None,
         packages: None,
         package_manifests: &HashMap::default(),
         skipped: &SkippedSnapshots::default(),
@@ -106,6 +107,7 @@ fn skips_slot_own_package_when_walking_children() {
             pnpm_config::default_virtual_store_dir_max_length() as usize,
         ),
         snapshots: None,
+        selected_snapshots: None,
         packages: None,
         package_manifests: &HashMap::default(),
         skipped: &SkippedSnapshots::default(),
@@ -135,6 +137,7 @@ fn link_virtual_store_bins_no_op_when_dir_missing() {
             pnpm_config::default_virtual_store_dir_max_length() as usize,
         ),
         snapshots: None,
+        selected_snapshots: None,
         packages: None,
         package_manifests: &HashMap::default(),
         skipped: &SkippedSnapshots::default(),
@@ -177,6 +180,7 @@ fn link_virtual_store_bins_handles_scoped_slot_name() {
             pnpm_config::default_virtual_store_dir_max_length() as usize,
         ),
         snapshots: None,
+        selected_snapshots: None,
         packages: None,
         package_manifests: &HashMap::default(),
         skipped: &SkippedSnapshots::default(),
@@ -231,6 +235,7 @@ fn link_virtual_store_bins_handles_peer_resolved_slot_name() {
             pnpm_config::default_virtual_store_dir_max_length() as usize,
         ),
         snapshots: None,
+        selected_snapshots: None,
         packages: None,
         package_manifests: &HashMap::default(),
         skipped: &SkippedSnapshots::default(),
@@ -285,6 +290,7 @@ fn link_virtual_store_bins_handles_unscoped_name_with_plus() {
             pnpm_config::default_virtual_store_dir_max_length() as usize,
         ),
         snapshots: None,
+        selected_snapshots: None,
         packages: None,
         package_manifests: &HashMap::default(),
         skipped: &SkippedSnapshots::default(),
@@ -314,6 +320,7 @@ fn link_virtual_store_bins_skips_slot_without_node_modules() {
             pnpm_config::default_virtual_store_dir_max_length() as usize,
         ),
         snapshots: None,
+        selected_snapshots: None,
         packages: None,
         package_manifests: &HashMap::default(),
         skipped: &SkippedSnapshots::default(),
@@ -345,6 +352,7 @@ fn link_virtual_store_bins_skips_slot_without_own_package_dir() {
             pnpm_config::default_virtual_store_dir_max_length() as usize,
         ),
         snapshots: None,
+        selected_snapshots: None,
         packages: None,
         package_manifests: &HashMap::default(),
         skipped: &SkippedSnapshots::default(),
@@ -352,6 +360,74 @@ fn link_virtual_store_bins_skips_slot_without_own_package_dir() {
     }
     .run()
     .expect("missing own-package dir is skipped silently");
+}
+
+#[test]
+fn lockfile_driven_linking_only_visits_selected_snapshots() {
+    let tmp = tempdir().unwrap();
+    let virtual_dir = tmp.path().join(".pacquet");
+    let layout = VirtualStoreLayout::legacy(
+        virtual_dir,
+        pnpm_config::default_virtual_store_dir_max_length() as usize,
+    );
+    let selected: PackageKey = "selected@1.0.0".parse().expect("parse selected key");
+    let unchanged: PackageKey = "unchanged@1.0.0".parse().expect("parse unchanged key");
+    let snapshots = HashMap::from([
+        (selected.clone(), SnapshotEntry::default()),
+        (unchanged.clone(), SnapshotEntry::default()),
+    ]);
+    let packages = HashMap::from([
+        (
+            selected.clone(),
+            metadata_with_resolution(
+                LockfileResolution::Directory(DirectoryResolution { directory: "selected".into() }),
+                Some(true),
+            ),
+        ),
+        (
+            unchanged.clone(),
+            metadata_with_resolution(
+                LockfileResolution::Directory(DirectoryResolution {
+                    directory: "unchanged".into(),
+                }),
+                Some(true),
+            ),
+        ),
+    ]);
+    for key in [&selected, &unchanged] {
+        let package_dir = layout.slot_dir(key).join("node_modules").join(key.name.to_string());
+        create_dir_all(&package_dir).unwrap();
+        write_file(
+            package_dir.join("package.json"),
+            json!({ "name": key.name.to_string(), "bin": "cli.js" }).to_string(),
+        )
+        .unwrap();
+        write_file(package_dir.join("cli.js"), "#!/usr/bin/env node\n").unwrap();
+    }
+    let selected_snapshots = [selected.clone()];
+
+    LinkVirtualStoreBins {
+        layout: &layout,
+        snapshots: Some(&snapshots),
+        selected_snapshots: Some(&selected_snapshots),
+        packages: Some(&packages),
+        package_manifests: &HashMap::default(),
+        skipped: &SkippedSnapshots::default(),
+        extra_node_paths: &[],
+    }
+    .run()
+    .unwrap();
+
+    let bin_path = |key: &PackageKey| {
+        layout
+            .slot_dir(key)
+            .join("node_modules")
+            .join(key.name.to_string())
+            .join("node_modules/.bin")
+            .join(key.name.bare.as_str())
+    };
+    assert!(bin_path(&selected).exists());
+    assert!(!bin_path(&unchanged).exists());
 }
 
 /// [`link_direct_dep_bins`] walks the project's `node_modules/<dep>`
@@ -500,6 +576,7 @@ fn link_virtual_store_bins_propagates_read_error_via_di() {
             pnpm_config::default_virtual_store_dir_max_length() as usize,
         ),
         snapshots: None,
+        selected_snapshots: None,
         packages: None,
         package_manifests: &HashMap::default(),
         skipped: &SkippedSnapshots::default(),

--- a/pnpm/crates/deps-restorer/src/linking.rs
+++ b/pnpm/crates/deps-restorer/src/linking.rs
@@ -94,6 +94,9 @@ pub struct LinkPhaseInputs<'a> {
     pub lockfile: &'a Lockfile,
     pub current_lockfile: Option<&'a Lockfile>,
     pub snapshots: Option<&'a HashMap<PackageKey, SnapshotEntry>>,
+    /// Restricts per-slot bin linking to this install's materialized
+    /// snapshots. `None` keeps rebuild's all-slot behavior.
+    pub materialized_snapshots: Option<&'a [PackageKey]>,
     pub packages: Option<&'a HashMap<PackageKey, PackageMetadata>>,
     pub importers: &'a HashMap<String, ProjectSnapshot>,
     pub project_manifests: &'a [(PathBuf, &'a PackageManifest)],
@@ -166,6 +169,7 @@ pub fn run_link_phase<Reporter: self::Reporter>(
         lockfile,
         current_lockfile,
         snapshots,
+        materialized_snapshots,
         packages,
         importers,
         project_manifests,
@@ -310,6 +314,7 @@ pub fn run_link_phase<Reporter: self::Reporter>(
         LinkVirtualStoreBins {
             layout,
             snapshots,
+            selected_snapshots: materialized_snapshots,
             packages,
             package_manifests,
             skipped,

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1403,6 +1403,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             // `requiresBuild` decision per snapshot.
             side_effects_maps_by_snapshot,
             requires_build_by_snapshot,
+            materialized_snapshots,
             // Optional snapshots whose fetch was swallowed. Folded into
             // the live skip set below so the symlink, bin-link, and build
             // phases observe them as absent — matching the frozen path
@@ -1521,6 +1522,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
                 lockfile: materialization_lockfile,
                 current_lockfile,
                 snapshots: materialization_lockfile.snapshots.as_ref(),
+                materialized_snapshots: Some(&materialized_snapshots),
                 packages: materialization_lockfile.packages.as_ref(),
                 importers: &materialization_lockfile.importers,
                 project_manifests: &project_manifests_for_link,
@@ -1600,6 +1602,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
                     allow_build_policy: &allow_build_policy,
                     side_effects_maps_by_snapshot: &side_effects_maps_by_snapshot,
                     requires_build_by_snapshot: &requires_build_by_snapshot,
+                    materialized_snapshots: &materialized_snapshots,
                     engine_name: engine_name.as_deref(),
                     extra_env: &build_extra_env,
                     store_index_writer: &store_index_writer,


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

- Track which snapshots the current install materialized and restrict virtual-store bin linking to those snapshots.
- Under `--ignore-scripts`, record pending builds directly from that set when no patches or side-effects-cache overlay require the full build graph.
- Preserve pending-build debt from earlier installs, side-effects-cache handling, and rebuild's all-snapshot behavior.
- Add focused coverage for selected bin snapshots, materialized output, and pending-build bookkeeping.

This is a bounded follow-up to pnpm/pnpm#14022. It reduces post-resolve work without introducing resolver finality or streamed materialization. The equivalent TypeScript paths already scope this work to `newDepPaths`; this is an internal pacquet performance change with no user-visible parity work required.

In an alternating six-run A/B of the update benchmark at 4 cores, 50 ms RTT, and 200 Mbit/s, the median improved from 758.1 ms on `main` to 744.8 ms on this branch (1.75%); the mean improved from 774.0 ms to 752.0 ms (2.84%).

## Squash Commit Body

```text
Restrict virtual-store bin linking to snapshots materialized by the current
install.

When lifecycle scripts are ignored and no patch or side-effects-cache overlay
requires the dependency graph, record pending builds directly from those
snapshots. Preserve pending-build debt from earlier installs and keep rebuild
operating on every snapshot.

This is a bounded post-resolve pipeline improvement related to pnpm/pnpm#14022.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789825310&installation_model_id=426870&pr_number=14035&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14035&signature=64da17d1de85821f2d349e5b6f7baf407e3737b2956699b741933c0412bdc925"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced warm-install overhead by processing only packages materialized during the current install.
  * Limited virtual-store binary linking to newly materialized packages when applicable.
  * Reduced unnecessary build bookkeeping when lifecycle scripts are ignored.
* **Bug Fixes**
  * Improved handling of deferred builds during partial and warm installations.
  * Preserved existing behavior for full installs and rebuild scenarios.
* **Tests**
  * Added coverage confirming selective materialization, linking, and deferred-build behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->