### PR TITLE
fix(fs-packlist): anchor `files` entries at the package root

### DIFF
--- a/.changeset/files-field-entries-are-anchored.md
+++ b/.changeset/files-field-entries-are-anchored.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+A package's `files` entries now match from the package root, the way npm reads them. A bare `src` also matched nested directories such as `example/src`, so a dependency installed from git shipped the repository's own example app: 13,324 files where the package publishes 45. The same filter decides what `pnpm pack` and `pnpm publish` put in a tarball and what `pnpm deploy` copies, so those stop carrying the extra files too. Exclusions such as `!**/__tests__` and `!*.map` still match at any depth.

--- a/.changeset/files-field-entries-are-anchored.md
+++ b/.changeset/files-field-entries-are-anchored.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-A package's `files` entries now match from the package root, the way npm reads them. A bare `src` also matched nested directories such as `example/src`, so a dependency installed from git shipped the repository's own example app: 13,324 files where the package publishes 45. The same filter decides what `pnpm pack` and `pnpm publish` put in a tarball and what `pnpm deploy` copies, so those stop carrying the extra files too. Exclusions such as `!**/__tests__` and `!*.map` still match at any depth.
+A package's `files` entries now match only at the package root, the way npm reads them. A bare `src` used to also match nested directories such as `example/src`, so a dependency installed from git could ship the repository's own example app. The same filter decides what `pnpm pack` and `pnpm publish` put in a tarball and what `pnpm deploy` copies, so those stop carrying the extra files too. Exclusions such as `!**/__tests__` and `!*.map` still match at any depth. A package already in the store keeps its old file set until it is fetched again.

--- a/pnpm/crates/cli/tests/suite/deploy.rs
+++ b/pnpm/crates/cli/tests/suite/deploy.rs
@@ -893,6 +893,46 @@ fn write_workspace(workspace: &Path, inject_workspace_packages: bool) {
     );
 }
 
+/// `deploy` copies a project through the directory fetcher's packlist
+/// mode, which reads the `files` field. Those entries name paths from
+/// the package root, so a project that keeps an example app under
+/// `example/src` deploys its own `src` and leaves the example behind.
+#[test]
+fn deployed_files_field_does_not_match_at_depth() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    write_workspace(&workspace, true);
+    write_project(
+        &workspace,
+        "packs-its-own-src",
+        &serde_json::json!({
+            "name": "packs-its-own-src",
+            "version": "1.0.0",
+            "main": "src/index.js",
+            "files": ["src"],
+        }),
+    );
+    let project = workspace.join("packages/packs-its-own-src");
+    for path in ["src/index.js", "example/src/App.js"] {
+        let file = project.join(path);
+        fs::create_dir_all(file.parent().unwrap()).unwrap();
+        fs::write(file, "").unwrap();
+    }
+
+    pacquet.with_arg("install").assert().success();
+    pacquet_cmd(&workspace)
+        .with_args(["--filter", "packs-its-own-src", "deploy", "deploy"])
+        .assert()
+        .success();
+
+    let deploy_dir = workspace.join("deploy");
+    assert!(deploy_dir.join("src/index.js").exists(), "the published src is deployed");
+    assert!(!deploy_dir.join("example").exists(), "the example app is not deployed");
+
+    drop((root, mock_instance));
+}
+
 fn write_reachability_workspace(workspace: &Path) {
     write_workspace(workspace, true);
     write_project(

--- a/pnpm/crates/cli/tests/suite/deploy.rs
+++ b/pnpm/crates/cli/tests/suite/deploy.rs
@@ -894,9 +894,8 @@ fn write_workspace(workspace: &Path, inject_workspace_packages: bool) {
 }
 
 /// `deploy` copies a project through the directory fetcher's packlist
-/// mode, which reads the `files` field. Those entries name paths from
-/// the package root, so a project that keeps an example app under
-/// `example/src` deploys its own `src` and leaves the example behind.
+/// mode, so the project's `files` field is what decides the deployed
+/// file set.
 #[test]
 fn deployed_files_field_does_not_match_at_depth() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =

--- a/pnpm/crates/cli/tests/suite/git_hosted_install.rs
+++ b/pnpm/crates/cli/tests/suite/git_hosted_install.rs
@@ -920,3 +920,30 @@ fn a_git_dependency_is_prepared_with_the_package_manager_it_pins() {
 
     drop((root, npmrc_info));
 }
+
+/// A git dependency is packed by pnpm rather than by its publisher, so
+/// the `files` field decides what lands in `node_modules`. Its entries
+/// name paths from the package root: a repository that keeps an example
+/// app under `example/src` publishes its own `src`, not both.
+#[test]
+fn files_field_of_a_git_dependency_does_not_match_at_depth() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let repo = GitRepoFixture::init(root.path(), "packs-its-own-src");
+    repo.write_file(
+        "package.json",
+        r#"{"name":"packs-its-own-src","version":"1.0.0","main":"src/index.js","files":["src"]}"#,
+    );
+    repo.write_file("src/index.js", "module.exports = true\n");
+    repo.write_file("example/src/App.js", "module.exports = 'example'\n");
+    let commit = repo.commit("init");
+    write_dependencies(&workspace, &[("packs-its-own-src", &repo.git_url_at(&commit))]);
+
+    pacquet.with_args(["install", "--ignore-scripts"]).assert().success();
+
+    let installed = workspace.join("node_modules/packs-its-own-src");
+    assert!(installed.join("src/index.js").is_file(), "the published src ships");
+    assert!(!installed.join("example").exists(), "the repository's example app is not published");
+
+    drop((root, npmrc_info));
+}

--- a/pnpm/crates/cli/tests/suite/git_hosted_install.rs
+++ b/pnpm/crates/cli/tests/suite/git_hosted_install.rs
@@ -922,9 +922,7 @@ fn a_git_dependency_is_prepared_with_the_package_manager_it_pins() {
 }
 
 /// A git dependency is packed by pnpm rather than by its publisher, so
-/// the `files` field decides what lands in `node_modules`. Its entries
-/// name paths from the package root: a repository that keeps an example
-/// app under `example/src` publishes its own `src`, not both.
+/// its `files` field is what decides the installed file set.
 #[test]
 fn files_field_of_a_git_dependency_does_not_match_at_depth() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =

--- a/pnpm/crates/fs-packlist/src/lib.rs
+++ b/pnpm/crates/fs-packlist/src/lib.rs
@@ -501,10 +501,11 @@ fn build_files_matcher(pkg_dir: &Path, entries: &[Value]) -> Option<Gitignore> {
     let mut added = 0;
     for entry in entries {
         let Some(raw) = entry.as_str() else { continue };
-        let pattern = anchor_files_entry(&normalize_field_path(raw));
-        if pattern.is_empty() {
+        let normalized = normalize_field_path(raw);
+        if normalized.is_empty() {
             continue;
         }
+        let pattern = anchor_files_entry(&normalized);
         if let Err(error) = builder.add_line(None, &pattern) {
             tracing::debug!(
                 target: "pacquet::fs_packlist",
@@ -532,15 +533,12 @@ fn build_files_matcher(pkg_dir: &Path, entries: &[Value]) -> Option<Gitignore> {
     }
 }
 
-/// Anchor a `files` entry at the package root, the way npm reads it: a
-/// bare `src` publishes the root `src` directory, not every directory
-/// named `src` in the tree. The matcher is rooted at the package
-/// directory, so the leading slash is what binds the pattern to it.
-///
-/// Exclusions keep gitignore's depth semantics: `npm pack --dry-run`
-/// drops `lib/index.js.map` for `files: ["lib", "!*.map"]`.
+/// Anchor a [`normalize_field_path`]-ed `files` entry at the package
+/// root — the matcher is rooted there, so the leading slash is what
+/// binds the pattern to it. An exclusion is left unanchored, matching
+/// how npm-packlist hands a negated entry to `ignore-walk`.
 fn anchor_files_entry(pattern: &str) -> String {
-    if pattern.is_empty() || pattern.starts_with('!') || pattern.starts_with('/') {
+    if pattern.starts_with('!') {
         return pattern.to_string();
     }
     format!("/{pattern}")

--- a/pnpm/crates/fs-packlist/src/lib.rs
+++ b/pnpm/crates/fs-packlist/src/lib.rs
@@ -501,7 +501,7 @@ fn build_files_matcher(pkg_dir: &Path, entries: &[Value]) -> Option<Gitignore> {
     let mut added = 0;
     for entry in entries {
         let Some(raw) = entry.as_str() else { continue };
-        let pattern = normalize_field_path(raw);
+        let pattern = anchor_files_entry(&normalize_field_path(raw));
         if pattern.is_empty() {
             continue;
         }
@@ -530,6 +530,20 @@ fn build_files_matcher(pkg_dir: &Path, entries: &[Value]) -> Option<Gitignore> {
             None
         }
     }
+}
+
+/// Anchor a `files` entry at the package root, the way npm reads it: a
+/// bare `src` publishes the root `src` directory, not every directory
+/// named `src` in the tree. The matcher is rooted at the package
+/// directory, so the leading slash is what binds the pattern to it.
+///
+/// Exclusions keep gitignore's depth semantics: `npm pack --dry-run`
+/// drops `lib/index.js.map` for `files: ["lib", "!*.map"]`.
+fn anchor_files_entry(pattern: &str) -> String {
+    if pattern.is_empty() || pattern.starts_with('!') || pattern.starts_with('/') {
+        return pattern.to_string();
+    }
+    format!("/{pattern}")
 }
 
 /// `true` when `rel` matches the `files`-field allowlist. The matcher

--- a/pnpm/crates/fs-packlist/src/tests.rs
+++ b/pnpm/crates/fs-packlist/src/tests.rs
@@ -766,9 +766,6 @@ fn always_excluded_dir_segments_only_match_vcs() {
 
 #[test]
 fn files_field_bare_basename_is_root_only() {
-    // `npm pack --dry-run` on `files: ["cli"]` publishes the root `cli`
-    // and leaves `bin/cli` and `lib/cli/index.js` out: every entry is
-    // anchored at the package root.
     let dir = tempdir().unwrap();
     let root = dir.path();
     touch(root, "package.json");
@@ -1110,6 +1107,26 @@ fn files_field_keeps_explicitly_deep_patterns() {
         "name": "x",
         "version": "0.0.0",
         "files": ["lib", "!**/__tests__"],
+    });
+    let mut out = packlist(root, &manifest).unwrap();
+    out.sort();
+
+    assert_eq!(out, vec!["lib/index.js".to_string(), "package.json".into()]);
+}
+
+#[test]
+fn files_field_exclusions_are_not_anchored() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "package.json");
+    touch(root, "lib/index.js");
+    touch(root, "lib/index.js.map");
+    touch(root, "lib/nested/deep.js.map");
+
+    let manifest = json!({
+        "name": "x",
+        "version": "0.0.0",
+        "files": ["lib", "!*.map"],
     });
     let mut out = packlist(root, &manifest).unwrap();
     out.sort();

--- a/pnpm/crates/fs-packlist/src/tests.rs
+++ b/pnpm/crates/fs-packlist/src/tests.rs
@@ -765,12 +765,10 @@ fn always_excluded_dir_segments_only_match_vcs() {
 }
 
 #[test]
-fn files_field_bare_basename_matches_at_depth() {
-    // npm-packlist treats `files: ["cli"]` as an unanchored gitignore
-    // pattern, so it matches both root-level `cli` and a nested
-    // `bin/cli`. The `Gitignore::matched` call already handles this
-    // because gitignore patterns without a leading slash are
-    // unanchored.
+fn files_field_bare_basename_is_root_only() {
+    // `npm pack --dry-run` on `files: ["cli"]` publishes the root `cli`
+    // and leaves `bin/cli` and `lib/cli/index.js` out: every entry is
+    // anchored at the package root.
     let dir = tempdir().unwrap();
     let root = dir.path();
     touch(root, "package.json");
@@ -783,14 +781,10 @@ fn files_field_bare_basename_matches_at_depth() {
         "version": "0.0.0",
         "files": ["cli"],
     });
-    let out = packlist(root, &manifest).unwrap();
+    let mut out = packlist(root, &manifest).unwrap();
+    out.sort();
 
-    assert!(out.contains(&"cli".to_string()), "root-level cli: {out:?}");
-    assert!(out.contains(&"bin/cli".to_string()), "nested cli matches at depth: {out:?}");
-    assert!(
-        out.contains(&"lib/cli/index.js".to_string()),
-        "files entry matching a directory also includes its contents: {out:?}",
-    );
+    assert_eq!(out, vec!["cli".to_string(), "package.json".into()]);
 }
 
 #[test]
@@ -1077,4 +1071,48 @@ fn files_field_overrides_gitignore_with_npmignore_coexisting() {
         !out.contains(&"src/index.ts".to_string()),
         "files not in the `files` allowlist must be excluded: {out:?}",
     );
+}
+
+#[test]
+fn files_field_entries_are_anchored_to_the_package_root() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "package.json");
+    touch(root, "src/index.js");
+    touch(root, "android/src/Main.java");
+    touch(root, "example/src/App.tsx");
+    touch(root, "example/android/app/src/main/AndroidManifest.xml");
+
+    let manifest = json!({
+        "name": "x",
+        "version": "0.0.0",
+        "files": ["src", "android/src"],
+    });
+    let mut out = packlist(root, &manifest).unwrap();
+    out.sort();
+
+    assert_eq!(
+        out,
+        vec!["android/src/Main.java".to_string(), "package.json".into(), "src/index.js".into(),],
+    );
+}
+
+#[test]
+fn files_field_keeps_explicitly_deep_patterns() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "package.json");
+    touch(root, "lib/index.js");
+    touch(root, "lib/__tests__/index.test.js");
+    touch(root, "lib/nested/__tests__/deep.test.js");
+
+    let manifest = json!({
+        "name": "x",
+        "version": "0.0.0",
+        "files": ["lib", "!**/__tests__"],
+    });
+    let mut out = packlist(root, &manifest).unwrap();
+    out.sort();
+
+    assert_eq!(out, vec!["lib/index.js".to_string(), "package.json".into()]);
 }

--- a/pnpm/crates/pack/src/tests.rs
+++ b/pnpm/crates/pack/src/tests.rs
@@ -325,6 +325,20 @@ fn files_field_restricts_the_tarball_contents() {
 }
 
 #[test]
+fn files_field_entries_do_not_match_at_depth() {
+    let (dir, opts) = fixture(&json!({
+        "name": "foo",
+        "version": "1.0.0",
+        "files": ["src"],
+    }));
+    touch(dir.path(), "src/index.js", "x\n");
+    touch(dir.path(), "example/src/App.js", "x\n");
+
+    let result = api::<SilentReporter, Host>(&opts).unwrap();
+    assert_eq!(result.contents, vec!["package.json".to_string(), "src/index.js".into()]);
+}
+
+#[test]
 fn missing_name_is_rejected() {
     let (_dir, opts) = fixture(&json!({ "version": "1.0.0" }));
     assert!(matches!(api::<SilentReporter, Host>(&opts), Err(PackError::PackageNameNotFound)));


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

A package's `files` field names what to publish, as paths from the package root. Each entry was compiled into a gitignore pattern and matched with `matched_path_or_any_parents`, and a gitignore pattern without a leading slash matches at any depth. So `src` selected the root `src` directory *and* every nested directory named `src`.

The filter only runs for packages pnpm packs itself, which means git and GitHub-URL dependencies, `pnpm pack` and `pnpm publish`. Installing `react-native-mmkv` from its repository shows it ([repro](https://github.com/arthur-fontaine/pnpm12-hoisted-mode-repros/tree/main/repro-gitdep-files-unanchored)): `files` lists `android/src`, `cpp`, `src`, `lib/commonjs` and friends, and pnpm 12.0.0-rc.7 installs 51 files including the repository's own example app, where pnpm 10 installs 33 and no `example/`.

npm's behaviour is the specification here, so Claude measured it rather than reasoning about it. `npm pack --dry-run --json`:

- `files: ["src", "android/src", "cli"]` over a tree holding `example/src`, `example/android/app/src`, `bin/cli` and `lib/cli` publishes only the root `src`, the root `android/src` and the root `cli`.
- `files: ["*.md"]` publishes `README.md` and leaves `docs/guide.md` out.
- `files: ["lib", "!*.map"]` drops `lib/index.js.map`, and `!**/__tests__` reaches `lib/nested/__tests__`.

So positive entries anchor at the package root and exclusions keep gitignore's depth semantics. `anchor_files_entry` prefixes a positive entry with `/` and leaves anything starting with `!` alone.

Every command that packs a package itself goes through this one matcher, so all of them are fixed together: installing a git or GitHub-URL dependency, `pnpm pack`, `pnpm publish`, `pnpm deploy`, and injected or `file:` directory dependencies. Publishing is where it shows most plainly — for `files: ["src", "cli"]` over a tree holding `example/src` and `lib/cli`, npm and pnpm 10 pack `package.json`, `src/index.js` and `cli`, pnpm 12.0.0-rc.7 adds `example/src/App.js` and `lib/cli/index.js`, and this branch matches npm again. Registry installs are unaffected, since those tarballs arrive already packed.

`files_field_bare_basename_matches_at_depth` asserted the opposite for a bare entry, on the premise that npm-packlist treats `files` entries as unanchored. The npm runs above are the ground truth it was measured against, so it now asserts root-only and is renamed `files_field_bare_basename_is_root_only`. Two tests are new: one for anchoring in `fs-packlist`, one end to end installing a local git repository whose `files` says `src` while the repository also has `example/src`. Both fail on `main`.

Measured on a React Native monorepo: one forked native module installed 13,324 files instead of the 45 it publishes, because its `example/ios/Pods` matched the `ios` entry. Note that the file set is decided when pnpm packs the repository into the store, so a store that already holds the unfiltered package keeps serving it until that entry is refetched.

pacquet-only. The TypeScript CLI packs through npm-packlist, which anchors already.

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
A `files` entry was compiled into a gitignore pattern as written, and a
gitignore pattern without a leading slash matches at any depth. So `src`
published the root `src` directory *and* every nested directory named
`src`. For a package pnpm packs itself — a git or GitHub-URL dependency —
that pulled the repository's own example app into `node_modules`: one
React Native monorepo installed 13,324 files where the package publishes
45. The same matcher decides what `pnpm pack` and `pnpm publish` put in a
tarball and what `pnpm deploy` copies, so those shipped the extra files
too.

`npm pack --dry-run` on `files: ["cli"]` publishes the root `cli` and
leaves `bin/cli` and `lib/cli/index.js` out, and on `files: ["*.md"]`
leaves `docs/guide.md` out. Anchor each entry the same way. Exclusions
keep gitignore's depth semantics: npm drops `lib/index.js.map` for
`files: ["lib", "!*.map"]`, and `!**/__tests__` reaches a nested match.

`files_field_bare_basename_matches_at_depth` asserted the opposite for a
bare entry, on a premise that was never measured. `npm pack --dry-run`
contradicts it, so the test now asserts root-only.
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] I checked ~the referenced issue~ and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14036"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789825536&installation_model_id=426870&pr_number=14036&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14036&signature=ae6ae3840c8f4a06aa9d324961a8d76c4b97e909ab7c61b83c1116b3cbb287eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected package file selection so `files` entries match only paths at the package root.
  * Prevented unrelated nested examples and same-named directories from being included in installed packages, publish archives, or deployment outputs.
  * Preserved support for recursive exclusions and explicitly deep glob patterns.

* **Tests**
  * Added regression coverage for git-based installs, publishing, deployment, and package file selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->