### PR TITLE
fix(pkg): accept hyphens in dot-notation property paths

### DIFF
--- a/.changeset/pkg-property-paths-accept-hyphens.md
+++ b/.changeset/pkg-property-paths-accept-hyphens.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/object.property-path": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+`pnpm pkg get` and `pnpm pkg set` now accept hyphens inside a dot-notation property path, so `pnpm pkg get dependencies.some-package-name` reads the key instead of failing with `ERR_PNPM_UNEXPECTED_TOKEN_IN_PROPERTY_PATH`. The bracketed and quoted forms already worked and are unchanged.

--- a/pnpm/crates/cli/src/cli_args/pkg/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pkg/tests.rs
@@ -39,6 +39,18 @@ fn test_get_single_key_nested() {
 }
 
 #[test]
+fn test_get_hyphenated_key_nested() {
+    let manifest = json!({
+        "dependencies": {
+            "some-package-name": "0.23.4"
+        }
+    });
+    let result =
+        get_output(&manifest, &["dependencies.some-package-name".to_string()], false).unwrap();
+    assert_eq!(result, "0.23.4");
+}
+
+#[test]
 fn test_get_single_key_object() {
     let manifest = json!({
         "scripts": {
@@ -221,6 +233,20 @@ fn test_set_nested_key() {
     });
     set_object_value_by_property_path(&mut value, "scripts.build", json!("tsc")).unwrap();
     assert_eq!(value["scripts"]["build"], "tsc");
+}
+
+#[test]
+fn test_set_hyphenated_key_nested() {
+    let mut value = json!({
+        "name": "test-pkg"
+    });
+    set_object_value_by_property_path(
+        &mut value,
+        "dependencies.some-package-name",
+        json!("0.23.4"),
+    )
+    .unwrap();
+    assert_eq!(value["dependencies"], json!({ "some-package-name": "0.23.4" }));
 }
 
 #[test]

--- a/pnpm/crates/config/src/property_path.rs
+++ b/pnpm/crates/config/src/property_path.rs
@@ -115,8 +115,9 @@ fn parse_identifier(source: &str) -> Option<(Token, &str)> {
     }
     let mut end = first.len_utf8();
     for (i, c) in chars {
-        // `\w` in JS = [A-Za-z0-9_], plus the hyphen: package names are full of
-        // them, and `npm pkg` accepts `dependencies.foo-bar`.
+        // Mirrors the TypeScript tokenizer's `[\w-]`. Hyphens are in because
+        // package names are full of them and `npm pkg` reads
+        // `dependencies.foo-bar`.
         if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
             end = i + c.len_utf8();
         } else {

--- a/pnpm/crates/config/src/property_path.rs
+++ b/pnpm/crates/config/src/property_path.rs
@@ -115,8 +115,9 @@ fn parse_identifier(source: &str) -> Option<(Token, &str)> {
     }
     let mut end = first.len_utf8();
     for (i, c) in chars {
-        // `\w` in JS = [A-Za-z0-9_]
-        if c.is_ascii_alphanumeric() || c == '_' {
+        // `\w` in JS = [A-Za-z0-9_], plus the hyphen: package names are full of
+        // them, and `npm pkg` accepts `dependencies.foo-bar`.
+        if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
             end = i + c.len_utf8();
         } else {
             break;

--- a/pnpm/crates/config/src/property_path/tests.rs
+++ b/pnpm/crates/config/src/property_path/tests.rs
@@ -40,6 +40,28 @@ fn parses_scoped_package_keys() {
 }
 
 #[test]
+fn parses_hyphenated_keys() {
+    assert_eq!(
+        keys("dependencies.some-package-name"),
+        vec![Segment::Key("dependencies".into()), Segment::Key("some-package-name".into())],
+    );
+    assert_eq!(
+        keys("devDependencies.another-package"),
+        vec![Segment::Key("devDependencies".into()), Segment::Key("another-package".into())],
+    );
+    assert_eq!(
+        keys("a.b-c.d-e"),
+        vec![Segment::Key("a".into()), Segment::Key("b-c".into()), Segment::Key("d-e".into())],
+    );
+    assert_eq!(keys("foo-bar[0]"), vec![Segment::Key("foo-bar".into()), Segment::Index(0.0)]);
+    // The bracketed form already accepted these keys, and still does.
+    assert_eq!(
+        keys(r#"dependencies["some-package-name"]"#),
+        vec![Segment::Key("dependencies".into()), Segment::Key("some-package-name".into())],
+    );
+}
+
+#[test]
 fn parse_errors() {
     assert_eq!(
         parse_property_path("foo..bar"),

--- a/pnpm/crates/config/src/property_path/tests.rs
+++ b/pnpm/crates/config/src/property_path/tests.rs
@@ -68,6 +68,11 @@ fn parse_errors() {
         Err(ParsePropertyPathError::UnexpectedToken { token: ".".into() }),
     );
     assert_eq!(parse_property_path("foo["), Err(ParsePropertyPathError::UnexpectedEndOfInput));
+    // A hyphen still cannot start an identifier.
+    assert_eq!(
+        parse_property_path("dependencies.-foo"),
+        Err(ParsePropertyPathError::UnexpectedToken { token: "-".into() }),
+    );
 }
 
 #[test]

--- a/pnpm11/object/property-path/src/token/Identifier.ts
+++ b/pnpm11/object/property-path/src/token/Identifier.ts
@@ -15,7 +15,9 @@ export const parseIdentifier: Tokenize<Identifier> = source => {
   source = source.slice(1)
   while (source !== '') {
     const char = source[0]
-    if (!/\w/.test(char)) break
+    // Hyphens continue an identifier even though they are not `\w`. Package
+    // names are full of them, and `npm pkg` accepts `dependencies.foo-bar`.
+    if (!/[\w-]/.test(char)) break
     source = source.slice(1)
     content += char
   }

--- a/pnpm11/object/property-path/src/token/Identifier.ts
+++ b/pnpm11/object/property-path/src/token/Identifier.ts
@@ -15,8 +15,8 @@ export const parseIdentifier: Tokenize<Identifier> = source => {
   source = source.slice(1)
   while (source !== '') {
     const char = source[0]
-    // Hyphens continue an identifier even though they are not `\w`. Package
-    // names are full of them, and `npm pkg` accepts `dependencies.foo-bar`.
+    // Hyphens are in because package names are full of them and `npm pkg`
+    // reads `dependencies.foo-bar`.
     if (!/[\w-]/.test(char)) break
     source = source.slice(1)
     content += char

--- a/pnpm11/object/property-path/test/parse.test.ts
+++ b/pnpm11/object/property-path/test/parse.test.ts
@@ -102,6 +102,13 @@ test('invalid property path', () => {
       content: ']',
     },
   } as Partial<UnexpectedTokenError<ExactToken<']'>>>))
+  expect(() => Array.from(parsePropertyPath('dependencies.-foo'))).toThrow(expect.objectContaining({
+    code: 'ERR_PNPM_UNEXPECTED_TOKEN_IN_PROPERTY_PATH',
+    token: {
+      type: 'unexpected',
+      content: '-',
+    },
+  } as Partial<UnexpectedTokenError<UnexpectedToken>>))
   expect(() => Array.from(parsePropertyPath('foo.bar?.baz'))).toThrow(expect.objectContaining({
     code: 'ERR_PNPM_UNEXPECTED_TOKEN_IN_PROPERTY_PATH',
     token: {

--- a/pnpm11/object/property-path/test/parse.test.ts
+++ b/pnpm11/object/property-path/test/parse.test.ts
@@ -29,6 +29,19 @@ test('valid property path', () => {
   expect(Array.from(parsePropertyPath('.a .b .c .d'))).toStrictEqual(['a', 'b', 'c', 'd'])
 })
 
+test('hyphenated keys', () => {
+  expect(Array.from(parsePropertyPath('dependencies.some-package-name')))
+    .toStrictEqual(['dependencies', 'some-package-name'])
+  expect(Array.from(parsePropertyPath('devDependencies.another-package')))
+    .toStrictEqual(['devDependencies', 'another-package'])
+  expect(Array.from(parsePropertyPath('a.b-c.d-e'))).toStrictEqual(['a', 'b-c', 'd-e'])
+  expect(Array.from(parsePropertyPath('foo-bar[0]'))).toStrictEqual(['foo-bar', 0])
+  expect(Array.from(parsePropertyPath('scripts.build-prod'))).toStrictEqual(['scripts', 'build-prod'])
+  // The bracketed and quoted forms already accepted these keys, and still do.
+  expect(Array.from(parsePropertyPath('dependencies["some-package-name"]')))
+    .toStrictEqual(['dependencies', 'some-package-name'])
+})
+
 test('invalid property path', () => {
   expect(() => Array.from(parsePropertyPath('foo.bar.0'))).toThrow(expect.objectContaining({
     code: 'ERR_PNPM_UNEXPECTED_LITERAL_IN_PROPERTY_PATH',

--- a/pnpm11/object/property-path/test/token/Identifier.test.ts
+++ b/pnpm11/object/property-path/test/token/Identifier.test.ts
@@ -62,6 +62,26 @@ test('identifier only', () => {
     type: 'identifier',
     content: '_foo',
   } as Identifier, ''])
+  expect(parseIdentifier('some-package-name')).toStrictEqual([{
+    type: 'identifier',
+    content: 'some-package-name',
+  } as Identifier, ''])
+  expect(parseIdentifier('helloWorld123-456')).toStrictEqual([{
+    type: 'identifier',
+    content: 'helloWorld123-456',
+  } as Identifier, ''])
+  expect(parseIdentifier('_under-score')).toStrictEqual([{
+    type: 'identifier',
+    content: '_under-score',
+  } as Identifier, ''])
+  expect(parseIdentifier('foo--bar')).toStrictEqual([{
+    type: 'identifier',
+    content: 'foo--bar',
+  } as Identifier, ''])
+  expect(parseIdentifier('foo-')).toStrictEqual([{
+    type: 'identifier',
+    content: 'foo-',
+  } as Identifier, ''])
 })
 
 test('identifier and tail', () => {
@@ -73,10 +93,14 @@ test('identifier and tail', () => {
     type: 'identifier',
     content: 'abc',
   } as Identifier, '.def'])
-  expect(parseIdentifier('helloWorld123-456')).toStrictEqual([{
+  expect(parseIdentifier('foo-bar.baz')).toStrictEqual([{
     type: 'identifier',
-    content: 'helloWorld123',
-  } as Identifier, '-456'])
+    content: 'foo-bar',
+  } as Identifier, '.baz'])
+  expect(parseIdentifier('foo-bar[0]')).toStrictEqual([{
+    type: 'identifier',
+    content: 'foo-bar',
+  } as Identifier, '[0]'])
   expect(parseIdentifier('HelloWorld123 456')).toStrictEqual([{
     type: 'identifier',
     content: 'HelloWorld123',

--- a/pnpm11/object/property-path/test/token/Identifier.test.ts
+++ b/pnpm11/object/property-path/test/token/Identifier.test.ts
@@ -5,6 +5,7 @@ import { type Identifier, parseIdentifier } from '../../src/index.js'
 test('not an identifier', () => {
   expect(parseIdentifier('')).toBeUndefined()
   expect(parseIdentifier('-')).toBeUndefined()
+  expect(parseIdentifier('-foo')).toBeUndefined()
   expect(parseIdentifier('+a')).toBeUndefined()
   expect(parseIdentifier('7z')).toBeUndefined()
 })

--- a/pnpm11/pkg-manifest/commands/test/pkg.test.ts
+++ b/pnpm11/pkg-manifest/commands/test/pkg.test.ts
@@ -73,6 +73,16 @@ describe('pkg command', () => {
 
       expect(await handler({ dir: tmpDir }, ['get', 'scripts.build'])).toBe('tsc')
     })
+
+    test('gets a hyphenated key using dot notation', async () => {
+      const manifest = {
+        name: 'test-package',
+        dependencies: { 'some-package-name': '0.23.4' },
+      }
+      fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify(manifest, null, 2))
+
+      expect(await handler({ dir: tmpDir }, ['get', 'dependencies.some-package-name'])).toBe('0.23.4')
+    })
   })
 
   describe('set subcommand', () => {
@@ -92,6 +102,15 @@ describe('pkg command', () => {
       await handler({ dir: tmpDir }, ['set', 'scripts.build=tsc'])
       const updated = JSON.parse(fs.readFileSync(path.join(tmpDir, 'package.json'), 'utf8'))
       expect(updated.scripts.build).toBe('tsc')
+    })
+
+    test('sets a hyphenated key using dot notation', async () => {
+      const manifest = { name: 'test-package' }
+      fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify(manifest, null, 2))
+
+      await handler({ dir: tmpDir }, ['set', 'dependencies.some-package-name=0.23.4'])
+      const updated = JSON.parse(fs.readFileSync(path.join(tmpDir, 'package.json'), 'utf8'))
+      expect(updated.dependencies).toStrictEqual({ 'some-package-name': '0.23.4' })
     })
 
     test('sets multiple key-value pairs', async () => {


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Closes pnpm/pnpm#13163. Both property-path parsers ended an identifier at the first character outside `\w`, so `dependencies.some-package-name` tokenized as `some`, an unexpected `-`, and `package`. A hyphen now continues an identifier, in `pnpm11/object/property-path/src/token/Identifier.ts` and in `pnpm/crates/config/src/property_path.rs` alike. The first character keeps its old rule, so `-foo` is still rejected.

The earlier attempt at this, pnpm/pnpm#13188, was closed by its author with CI green and no review. As far as I can tell nothing was wrong with the approach, so this PR takes the same one, adds the changeset, and corrects the token-level test: `test/token/Identifier.test.ts` asserted that `helloWorld123-456` stops at `helloWorld123`, which is exactly the behaviour being changed.

### What each parser accepts, measured

Rather than reason about npm parity, I ran the same paths through `npm pkg get` (npm 10.9.3 on Node 22.20.0, against a `package.json` holding each key) and through `parsePropertyPath` on both trees. The npm column is command output; the pnpm columns are the parsed segments or the error code.

| property path | `npm pkg get` | pnpm before | pnpm after |
| --- | --- | --- | --- |
| `dependencies.some-package-name` | `"1.0.0"` | `UNEXPECTED_TOKEN` | `["dependencies","some-package-name"]` |
| `dependencies._under-score` | `"5.0.0"` | `UNEXPECTED_TOKEN` | `["dependencies","_under-score"]` |
| `dependencies.UPPER-case` | `"4.0.0"` | `UNEXPECTED_TOKEN` | `["dependencies","UPPER-case"]` |
| `dependencies.@babel/core` | `"7.0.0"` | `UNEXPECTED_TOKEN` | `UNEXPECTED_TOKEN` |
| `dependencies[some-package-name]` | `"1.0.0"` | `UNEXPECTED_IDENTIFIER` | `UNEXPECTED_IDENTIFIER` |
| `dependencies.9lives` | `"6.0.0"` | `UNSUPPORTED_NUMERIC_LITERAL_SUFFIX` | `UNSUPPORTED_NUMERIC_LITERAL_SUFFIX` |
| `dependencies["some-package-name"]` | `{}` | `["dependencies","some-package-name"]` | unchanged |
| `dependencies['some-package-name']` | `{}` | `["dependencies","some-package-name"]` | unchanged |

The first three rows are the issue, and they are what this PR fixes. Rows four to six are further npm divergences that it deliberately leaves alone: closing them means either changing the first-character rule or dropping the identifier grammar for npm's "split on dots and brackets, take the rest literally" model, and both are bigger decisions than a bug fix should make on its own. The scoped-package row is the one I would argue matters most, since `@scope/name` keys fill a real `dependencies` map. Say the word and I will open a separate issue with this table.

The last two rows go the other way: npm treats the quotes as part of the key and returns nothing, while pnpm strips them and resolves. The reporter mentions this too. I left it alone, since matching npm there would break paths that work today.

### One behaviour change beyond `pnpm pkg`

`pnpm config set` shares the parser through `validateSimpleKey`, which short-circuits on strictly kebab-case keys, so `store-dir` never reaches the parser and is unaffected. A key that does not short-circuit, such as `foo-Bar`, does reach it. I drove `config.handler` on both trees:

- before: `ERR_PNPM_UNEXPECTED_TOKEN_IN_PROPERTY_PATH: Unexpected token "-" in property path`
- after: `ERR_PNPM_CONFIG_SET_UNSUPPORTED_YAML_CONFIG_KEY: The key "foo-Bar" isn't supported by the global config.yaml file`

Both reject the key. The second message is the accurate one.

### Verification

All of it in a container, on the toolchains the repository pins.

- `pnpm11/object/property-path`: 41 tests pass across 8 suites
- `pnpm11/pkg-manifest/commands`: 41 tests pass, including two new cases driving `pnpm pkg get` and `pnpm pkg set` end to end. Both fail on the parent commit with the error from the issue.
- `pnpm11/config/commands`: 155 tests pass, the parser's other consumer
- `cargo test -p pnpm-config`: 500 tests pass
- `cargo fmt --all -- --check`, `cargo clippy --all-targets --workspace -- -D warnings`, and `cargo doc` with `RUSTDOCFLAGS="-D warnings"` are clean, as are `eslint` and `cspell` on the touched files
- `pnpm run compile-only`, the first half of the pre-push hook, exits 0. The `eslint` pass inside it reports 7 warnings and 0 errors, all `jest/no-disabled-tests` in files this PR does not touch.

## Squash Commit Body

```text
Both property-path parsers ended an identifier at the first character
outside `\w`, so `dependencies.some-package-name` tokenized as `some`,
an unexpected `-`, and `package`, and `pnpm pkg get` / `pnpm pkg set`
failed with ERR_PNPM_UNEXPECTED_TOKEN_IN_PROPERTY_PATH on a key that
`npm pkg` reads. Hyphens now continue an identifier, in
`pnpm11/object/property-path` and in `pnpm/crates/config` alike.

The first character keeps its old rule, so `-foo` is still rejected, and
the bracketed forms that already accepted these keys are untouched.

`pnpm config set` shares the parser through `validateSimpleKey`, which
short-circuits on strictly kebab-case keys. A key it does not
short-circuit, such as `foo-Bar`, used to fail at the parse step and now
reaches the config validation that has something useful to say about it:
ERR_PNPM_CONFIG_SET_UNSUPPORTED_YAML_CONFIG_KEY. Both reject the key.

Closes pnpm/pnpm#13163
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port.
- [x] Added a changeset for the published packages this touches.
- [x] Added or updated tests.

---

Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14037"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789829728&installation_model_id=426870&pr_number=14037&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14037&signature=2067cd23004ab3e67e00108abeb961b4091de8a5507d8348b63a58997753170d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `pnpm pkg get` and `pnpm pkg set` now support hyphens in dot-notation property paths.
  * Package-style keys such as `some-package-name` can be read and updated, including nested and indexed properties.

* **Bug Fixes**
  * Improved handling of hyphenated property names across dotted, bracketed, and quoted path formats.
  * Invalid paths beginning with a hyphen continue to be rejected with a clear parsing error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->