### PR TITLE
perf(pacquet): skip redundant bin relinking

### DIFF
--- a/.changeset/skip-redundant-bin-relinks.md
+++ b/.changeset/skip-redundant-bin-relinks.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Reduced install time with `--ignore-scripts` by skipping redundant bin relinking when dependency builds and public hoist work are absent.

--- a/pnpm/crates/deps-restorer/src/install_frozen_lockfile/build_phase.rs
+++ b/pnpm/crates/deps-restorer/src/install_frozen_lockfile/build_phase.rs
@@ -207,6 +207,7 @@ pub fn run_build_phase<Reporter: self::Reporter>(
         && rebuild.is_none()
         && patches.as_ref().is_none_or(HashMap::is_empty)
         && (!config.side_effects_cache_read() || side_effects_maps_by_snapshot.is_empty());
+    let build_modules_ran = !can_defer_without_build_modules;
     let build_output = if can_defer_without_build_modules {
         let newly_deferred = materialized_snapshots
             .iter()
@@ -277,10 +278,18 @@ pub fn run_build_phase<Reporter: self::Reporter>(
     // Post-`BuildModules` per-importer top-level bin link
     // (pnpm/pacquet#342). Resolves direct-over-hoisted precedence and
     // shims lifecycle-script-created bins that didn't exist at extract
-    // time. Idempotent for unchanged shims. Runs after `buildModules`.
+    // time. When no build ran, the link phase already handled direct
+    // bins; only the root's public-hoist candidates still need this pass.
     let modules_dir_basename: &OsStr =
         config.modules_dir.file_name().unwrap_or_else(|| OsStr::new("node_modules"));
     for (importer_id, importer_snapshot) in importers {
+        if !needs_top_level_bin_link(
+            importer_id,
+            build_modules_ran,
+            publicly_hoisted_for_post_build,
+        ) {
+            continue;
+        }
         let project_dir = importer_root_dir(top_level_bin_root, importer_id);
         let modules_dir = project_dir.join(modules_dir_basename);
         // Same filter the symlink phase used so the post-build pass sees
@@ -305,4 +314,13 @@ pub fn run_build_phase<Reporter: self::Reporter>(
     }
 
     Ok(build_output)
+}
+
+fn needs_top_level_bin_link(
+    importer_id: &str,
+    build_modules_ran: bool,
+    publicly_hoisted: &[String],
+) -> bool {
+    build_modules_ran
+        || (importer_id == Lockfile::ROOT_IMPORTER_KEY && !publicly_hoisted.is_empty())
 }

--- a/pnpm/crates/deps-restorer/src/install_frozen_lockfile/build_phase/tests.rs
+++ b/pnpm/crates/deps-restorer/src/install_frozen_lockfile/build_phase/tests.rs
@@ -1,6 +1,7 @@
 use super::{
-    AllowBuildPolicy, AtomicU8, BuildPhaseInputs, Config, DependencyGroup, HashMap, PackageKey,
-    ProjectSnapshot, SkippedSnapshots, StoreIndexWriter, VirtualStoreLayout, run_build_phase,
+    AllowBuildPolicy, AtomicU8, BuildPhaseInputs, Config, DependencyGroup, HashMap, Lockfile,
+    PackageKey, ProjectSnapshot, SkippedSnapshots, StoreIndexWriter, VirtualStoreLayout,
+    needs_top_level_bin_link, run_build_phase,
 };
 use pnpm_reporter::SilentReporter;
 use tempfile::tempdir;
@@ -58,4 +59,14 @@ async fn ignored_scripts_fast_path_defers_only_materialized_snapshots() {
     assert_eq!(output.deferred_builds, [materialized.to_string()]);
     drop(store_index_writer);
     writer_task.await.expect("join writer task").expect("drain writer task");
+}
+
+#[test]
+fn top_level_bin_link_only_runs_when_post_materialization_work_can_change_bins() {
+    let public_hoisted = ["public-cli".to_string()];
+
+    assert!(!needs_top_level_bin_link(Lockfile::ROOT_IMPORTER_KEY, false, &[]));
+    assert!(needs_top_level_bin_link(Lockfile::ROOT_IMPORTER_KEY, false, &public_hoisted));
+    assert!(!needs_top_level_bin_link("packages/app", false, &public_hoisted));
+    assert!(needs_top_level_bin_link("packages/app", true, &[]));
 }

--- a/pnpm/crates/deps-restorer/src/linking.rs
+++ b/pnpm/crates/deps-restorer/src/linking.rs
@@ -21,6 +21,7 @@ use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pnpm_config::{Config, NodeLinker};
 use pnpm_lockfile::{Lockfile, PackageKey, PackageMetadata, ProjectSnapshot, SnapshotEntry};
+use pnpm_modules_yaml::HoistKind;
 use pnpm_package_manifest::{DependencyGroup, PackageManifest};
 use pnpm_reporter::{LogEvent, LogLevel, Reporter, StatsLog, StatsMessage};
 use std::{
@@ -215,6 +216,9 @@ pub fn run_link_phase<Reporter: self::Reporter>(
     let public_hoist_targets: Option<BTreeMap<String, PathBuf>> = pre_hoist
         .as_ref()
         .map(|plan| collect_public_hoist_targets(&plan.result, &plan.graph, layout, &plan.skipped));
+    let has_publicly_hoisted_workspace_package = pre_hoist.as_ref().is_some_and(|plan| {
+        includes_publicly_hoisted_workspace_package(&plan.result.hoisted_workspace_aliases)
+    });
 
     // Reconcile before linking: stale direct-dep links and
     // orphaned hoist links must vacate their slots so the relink +
@@ -478,7 +482,7 @@ pub fn run_link_phase<Reporter: self::Reporter>(
     // is what shims a publicly-hoisted *workspace package*'s bin: those
     // are recorded in the hoist result's `hoisted_workspace_aliases`,
     // which the post-build top-level link never sees.
-    {
+    if has_publicly_hoisted_workspace_package {
         let modules_basename = config.modules_dir.file_name().map_or_else(
             || std::ffi::OsString::from("node_modules"),
             std::ffi::OsStr::to_os_string,
@@ -504,3 +508,12 @@ pub fn run_link_phase<Reporter: self::Reporter>(
         publicly_hoisted_for_post_build,
     })
 }
+
+fn includes_publicly_hoisted_workspace_package(
+    hoisted_workspace_aliases: &[(String, HoistKind, PathBuf)],
+) -> bool {
+    hoisted_workspace_aliases.iter().any(|(_, kind, _)| *kind == HoistKind::Public)
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/deps-restorer/src/linking/tests.rs
+++ b/pnpm/crates/deps-restorer/src/linking/tests.rs
@@ -1,0 +1,11 @@
+use super::{HoistKind, PathBuf, includes_publicly_hoisted_workspace_package};
+
+#[test]
+fn detects_publicly_hoisted_workspace_packages() {
+    let private = ("private".to_string(), HoistKind::Private, PathBuf::from("packages/private"));
+    let public = ("public".to_string(), HoistKind::Public, PathBuf::from("packages/public"));
+
+    assert!(!includes_publicly_hoisted_workspace_package(&[]));
+    assert!(!includes_publicly_hoisted_workspace_package(std::slice::from_ref(&private)));
+    assert!(includes_publicly_hoisted_workspace_package(&[private, public]));
+}


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

- Skip the isolated link phase's project-bin re-walk unless it added a publicly hoisted workspace package.
- When `--ignore-scripts` bypasses dependency builds, skip the post-build direct-bin relink unless the root has public-hoist bin candidates. Preserve the full relink after real builds so lifecycle-created bins are still discovered.
- Add focused routing tests and retain the end-to-end public-workspace-hoist coverage.

This is a pacquet-internal pipeline optimization related to pnpm/pnpm#14015 and pnpm/pnpm#14022. The TypeScript implementation already performs its corresponding bin link once after dependency builds, so it does not need a matching change.

Paired local A/B benchmark of the tracked update scenario (8 pairs, 4 cores, 50 ms registry RTT, 200 Mbit/s):

| | Merge base | This PR | Change |
|---|---:|---:|---:|
| Mean | 747.8 ms | 734.3 ms | -13.5 ms (-1.8%) |
| Median | 751.0 ms | 732.5 ms | -18.5 ms (-2.5%) |

Head was faster in 6 of 8 pairs.

Validation:

- `just ready` — 8,452 tests passed, plus workspace checks and Clippy.
- `cargo test -p pnpm-cli publicly_hoisted_workspace_package` — both public-workspace-hoist bin tests passed.

## Squash Commit Body

```text
Avoid two bin-linking scans whose prerequisites are absent on the common
ignore-scripts update path. The link phase now re-walks project bins only when
it placed a publicly hoisted workspace package, and the build phase relinks
top-level bins only after a real dependency build or for root public-hoist bin
candidates.

Keep full relinking after lifecycle builds so package.json changes made by
scripts are still observed, and retain the public-workspace-hoist path that is
the sole source of those workspace bin shims.

Related to pnpm/pnpm#14015 and pnpm/pnpm#14022.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14038"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789831008&installation_model_id=426870&pr_number=14038&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14038&signature=5a81f17d5b71cc975faa958bdd7fb946e59b5d4b15c29985ac6b2b12ad520662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced install time when scripts are ignored by skipping unnecessary binary relinking.
  * Avoided redundant post-build and trusted-importer linking when no changes require it.
  * Preserved required linking for publicly hoisted packages and other affected dependencies.

* **Bug Fixes**
  * Ensured binary links are refreshed when dependency builds or public hoisting may change executable locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->