### PR TITLE
fix(pacquet): decouple shared nodes so hoisting decides per parent path

### DIFF
--- a/.changeset/hoisted-shared-node-keeps-conflicting-deps.md
+++ b/.changeset/hoisted-shared-node-keeps-conflicting-deps.md
@@ -2,4 +2,8 @@
 "pacquet": patch
 ---
 
-`node-linker=hoisted` installs no longer produce a broken layout when a version-conflicted package is depended on by several packages. Its conflicting transitive dependencies were nested under only one of the dependents, so requiring them through any of the other dependents resolved the wrong (root-hoisted) version — for example an ESM `parse-entities@4` resolving `character-entities-legacy@1` instead of `@3`, which crashes with `ERR_IMPORT_ATTRIBUTE_MISSING` on Node.js 22.
+`node-linker=hoisted` installs no longer produce broken layouts on graphs with version conflicts. Three hoister fixes, aligning with `@yarnpkg/nm` (which the TypeScript CLI delegates to):
+
+- A version-conflicted package depended on by several packages kept its conflicting transitive dependencies under only one of the dependents, so requiring them through any other dependent resolved the wrong (root-hoisted) version — for example an ESM `parse-entities@4` resolving `character-entities-legacy` v1 instead of v3, which crashes with `ERR_IMPORT_ATTRIBUTE_MISSING` on Node.js 22. Hoist decisions are now made per parent path on decoupled copies (ports upstream's `decoupleGraphNode`).
+- Peer-resolution variants of one package version now collapse onto a single copy (ports pnpm v11's `depPathByPkgId` mapping) instead of conflict-nesting a copy under every dependent — on peer-variant-heavy graphs (such as `bit`'s) the old behavior also made the per-path walk explode.
+- Hoisting no longer shadows names a subtree resolves through an ancestor directory: a candidate is refused when a nearer ancestor holds a different version of its name (upstream's "filled by parent" scan) or when the hoist root's subtree already resolves that name from above (upstream's `usedDependencies` gate).

--- a/.changeset/hoisted-shared-node-keeps-conflicting-deps.md
+++ b/.changeset/hoisted-shared-node-keeps-conflicting-deps.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`node-linker=hoisted` installs no longer produce a broken layout when a version-conflicted package is depended on by several packages. Its conflicting transitive dependencies were nested under only one of the dependents, so requiring them through any of the other dependents resolved the wrong (root-hoisted) version — for example an ESM `parse-entities@4` resolving `character-entities-legacy@1` instead of `@3`, which crashes with `ERR_IMPORT_ATTRIBUTE_MISSING` on Node.js 22.

--- a/pnpm/crates/real-hoist/src/lib.rs
+++ b/pnpm/crates/real-hoist/src/lib.rs
@@ -158,6 +158,14 @@ pub struct HoisterResult {
     /// [ts-HoisterTree]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L16-L19
     pub peer_names: BTreeSet<String>,
     pub dependencies: RefCell<IndexSet<RcByPtr<HoisterResult>>>,
+    /// Names of dependencies that the hoist pass removed from this
+    /// node (hoisted to a root or dedup'd against a root's copy),
+    /// mapped to the removed node. Requires at this position resolve
+    /// them through an ancestor directory, so a later nested-root
+    /// pass must not shadow these names with a different version
+    /// (see [`get_used_dependencies`]). Ports upstream's
+    /// `hoistedDependencies`.
+    hoisted_dependencies: RefCell<HashMap<String, Rc<HoisterResult>>>,
     /// Whether this node is a single-parent copy that the hoist
     /// algorithm may mutate. The converter builds a DAG in which a
     /// package reachable through several parents is one shared node;
@@ -298,12 +306,12 @@ impl<Inner> From<Rc<Inner>> for RcByPtr<Inner> {
 /// workspace trees, and `ExternalSoftLink` descendants — are
 /// documented on the private `nm_hoist` driver.
 pub fn hoist(lockfile: &Lockfile, opts: &HoistOpts) -> Result<HoisterResult, HoistError> {
-    let mut nodes: HashMap<String, Rc<HoisterTree>> = HashMap::new();
+    let mut cache = TreeCache::default();
 
     let mut root_children: IndexSet<RcByPtr<HoisterTree>> = IndexSet::new();
 
     if let Some(root) = lockfile.importers.get(Lockfile::ROOT_IMPORTER_KEY) {
-        collect_importer_deps(root, lockfile, opts, &mut nodes, &mut root_children)?;
+        collect_importer_deps(root, lockfile, opts, &mut cache, &mut root_children)?;
     }
 
     // `externalDependencies` are added as `link:` placeholders at
@@ -349,7 +357,7 @@ pub fn hoist(lockfile: &Lockfile, opts: &HoistOpts) -> Result<HoisterResult, Hoi
 
     for (importer_id, importer) in non_root {
         let mut importer_children: IndexSet<RcByPtr<HoisterTree>> = IndexSet::new();
-        collect_importer_deps(importer, lockfile, opts, &mut nodes, &mut importer_children)?;
+        collect_importer_deps(importer, lockfile, opts, &mut cache, &mut importer_children)?;
         let importer_node = Rc::new(HoisterTree {
             name: percent_encode_path(importer_id),
             ident_name: percent_encode_path(importer_id),
@@ -386,11 +394,27 @@ pub fn hoist(lockfile: &Lockfile, opts: &HoistOpts) -> Result<HoisterResult, Hoi
     Ok(result)
 }
 
+/// Conversion-phase caches. `nodes` interns one [`HoisterTree`] per
+/// `(alias, snapshot key)` edge target. `dep_key_by_pkg_id` maps a
+/// peer-suffix-free package id (`name@version`) to the first snapshot
+/// key seen for it: every peer-suffix variant of one package version
+/// gets that first key as its `reference`, so the hoister sees one
+/// locator per version and dedups the variants instead of
+/// conflict-nesting a copy of each. Ports `depPathByPkgId` from pnpm
+/// v11's `@pnpm/real-hoist` wrapper — without the collapse, a
+/// peer-variant-heavy lockfile turns the per-path hoist walk into a
+/// combinatorial explosion of nested conflict copies.
+#[derive(Default)]
+struct TreeCache {
+    nodes: HashMap<String, Rc<HoisterTree>>,
+    dep_key_by_pkg_id: HashMap<String, PkgNameVerPeer>,
+}
+
 fn collect_importer_deps(
     importer: &ProjectSnapshot,
     lockfile: &Lockfile,
     opts: &HoistOpts,
-    nodes: &mut HashMap<String, Rc<HoisterTree>>,
+    cache: &mut TreeCache,
     out: &mut IndexSet<RcByPtr<HoisterTree>>,
 ) -> Result<(), HoistError> {
     // Merge `dependencies + devDependencies + optionalDependencies`
@@ -427,7 +451,7 @@ fn collect_importer_deps(
         let Some(dep_key) = spec.version.resolved_key(alias) else {
             continue;
         };
-        let Some(node) = build_dep_node(alias, &dep_key, optional, lockfile, opts, nodes)? else {
+        let Some(node) = build_dep_node(alias, &dep_key, optional, lockfile, opts, cache)? else {
             continue;
         };
         out.insert(RcByPtr(node));
@@ -447,14 +471,14 @@ fn build_dep_node(
     optional: bool,
     lockfile: &Lockfile,
     opts: &HoistOpts,
-    nodes: &mut HashMap<String, Rc<HoisterTree>>,
+    cache: &mut TreeCache,
 ) -> Result<Option<Rc<HoisterTree>>, HoistError> {
     // Cache key is `<alias>:<dep_key>` — two different aliases
     // pointing at the same package are intentionally different nodes
     // (the node's `name` field differs), so they shouldn't share a
     // cache slot.
     let cache_key = format!("{alias}:{dep_key}");
-    if let Some(existing) = nodes.get(&cache_key) {
+    if let Some(existing) = cache.nodes.get(&cache_key) {
         return Ok(Some(Rc::clone(existing)));
     }
 
@@ -496,19 +520,29 @@ fn build_dep_node(
     // outer call returns the cell holds the populated set, and the
     // shared-by-identity invariant the hoister algorithm relies on
     // survives.
+    // The reference is the *canonical* snapshot key for this package
+    // version — the first-seen peer-suffix variant — not necessarily
+    // `dep_key` itself (see [`TreeCache::dep_key_by_pkg_id`]). The
+    // node's own children still come from `dep_key`'s snapshot,
+    // matching the TS wrapper, which reads `pkgSnapshot` from the
+    // original depPath while stamping `depPathByPkgId.get(id)` as the
+    // reference.
+    let pkg_id = dep_key.without_peer().to_string();
+    let reference =
+        cache.dep_key_by_pkg_id.entry(pkg_id).or_insert_with(|| dep_key.clone()).to_string();
     let node = Rc::new(HoisterTree {
         name: alias.to_string(),
         ident_name: dep_key.name.to_string(),
-        reference: dep_key.to_string(),
+        reference,
         peer_names,
         dependency_kind: HoisterDependencyKind::Regular,
         hoist_priority: 0,
         dependencies: RefCell::new(IndexSet::new()),
     });
-    nodes.insert(cache_key, Rc::clone(&node));
+    cache.nodes.insert(cache_key, Rc::clone(&node));
 
     let mut children: IndexSet<RcByPtr<HoisterTree>> = IndexSet::new();
-    collect_snapshot_deps(snapshot, lockfile, opts, nodes, &mut children)?;
+    collect_snapshot_deps(snapshot, lockfile, opts, cache, &mut children)?;
     *node.dependencies.borrow_mut() = children;
     Ok(Some(node))
 }
@@ -517,7 +551,7 @@ fn collect_snapshot_deps(
     snapshot: &SnapshotEntry,
     lockfile: &Lockfile,
     opts: &HoistOpts,
-    nodes: &mut HashMap<String, Rc<HoisterTree>>,
+    cache: &mut TreeCache,
     out: &mut IndexSet<RcByPtr<HoisterTree>>,
 ) -> Result<(), HoistError> {
     let mut merged: HashMap<&PkgName, (&pnpm_lockfile::SnapshotDepRef, bool)> = HashMap::new();
@@ -544,7 +578,7 @@ fn collect_snapshot_deps(
         let Some(dep_key) = dep_ref.resolve(alias) else {
             continue;
         };
-        let Some(node) = build_dep_node(alias, &dep_key, optional, lockfile, opts, nodes)? else {
+        let Some(node) = build_dep_node(alias, &dep_key, optional, lockfile, opts, cache)? else {
             continue;
         };
         out.insert(RcByPtr(node));
@@ -628,7 +662,7 @@ fn nm_hoist(tree: &HoisterTree, opts: &HoistOpts) -> HoisterResult {
     // construction — mutating its children can't leak anywhere.
     root.decoupled.set(true);
     let mut path_locators = HashSet::from([node_locator(&root)]);
-    hoist_to(&root, opts, &mut path_locators);
+    hoist_to(&root, opts, &mut path_locators, true);
     // Returning an owned `HoisterResult` (rather than
     // `Rc<HoisterResult>`) keeps the wrapper's post-hoist
     // `external_dependencies` filter from mutating the shared graph.
@@ -654,8 +688,20 @@ fn nm_hoist(tree: &HoisterTree, opts: &HoistOpts) -> HoisterResult {
 /// while walking, so the call here is a cheap no-op safety net.
 ///
 /// [hoist-to]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L309
-fn hoist_to(root: &Rc<HoisterResult>, opts: &HoistOpts, path_locators: &mut HashSet<String>) {
-    hoist_into_root(root, &node_locator(root), opts);
+fn hoist_to(
+    root: &Rc<HoisterResult>,
+    opts: &HoistOpts,
+    path_locators: &mut HashSet<String>,
+    is_top_root: bool,
+) {
+    // Names this root's subtree already resolves from ancestor
+    // directories (their providers were hoisted away earlier). A
+    // candidate must not take such a name slot with a different
+    // version. The top `.` root has nothing above it, so its map is
+    // empty — matching upstream, which passes an empty map when
+    // `tree == rootNode`.
+    let used = if is_top_root { HashMap::new() } else { get_used_dependencies(root) };
+    hoist_into_root(root, &node_locator(root), opts, &used);
 
     let children: Vec<RcByPtr<HoisterResult>> =
         root.dependencies.borrow().iter().cloned().collect();
@@ -668,9 +714,41 @@ fn hoist_to(root: &Rc<HoisterResult>, opts: &HoistOpts, path_locators: &mut Hash
             continue;
         }
         let child = decouple_child(root, &child);
-        hoist_to(&child.0, opts, path_locators);
+        hoist_to(&child.0, opts, path_locators, false);
         path_locators.remove(&locator);
     }
+}
+
+/// Collects the dependencies that `root`'s subtree resolves through
+/// ancestor directories: every name recorded in a subtree node's
+/// `hoisted_dependencies` (the provider was hoisted above this root
+/// earlier, so requires at that position reach it via parent
+/// lookup). Hoisting a *different* version of such a name onto
+/// `root` would shadow those resolutions, so [`hoist_into_root`]
+/// refuses candidates that collide with this map. Ports upstream's
+/// [`getZeroRoundUsedDependencies`][zero-round] — the variant yarn
+/// always uses, since its `hoist()` hardcodes
+/// `fastLookupPossible: true`.
+///
+/// [zero-round]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L161
+fn get_used_dependencies(root: &Rc<HoisterResult>) -> HashMap<String, Rc<HoisterResult>> {
+    let mut used: HashMap<String, Rc<HoisterResult>> = HashMap::new();
+    let mut seen: HashSet<*const HoisterResult> = HashSet::new();
+    let mut pending: Vec<Rc<HoisterResult>> = vec![Rc::clone(root)];
+    while let Some(node) = pending.pop() {
+        if !seen.insert(Rc::as_ptr(&node)) {
+            continue;
+        }
+        for (name, dep) in node.hoisted_dependencies.borrow().iter() {
+            used.insert(name.clone(), Rc::clone(dep));
+        }
+        for dep in node.dependencies.borrow().iter() {
+            if !node.peer_names.contains(&dep.0.name) {
+                pending.push(Rc::clone(&dep.0));
+            }
+        }
+    }
+    used
 }
 
 /// The node's locator: `ident@reference`, unique per package
@@ -678,6 +756,38 @@ fn hoist_to(root: &Rc<HoisterResult>, opts: &HoistOpts, path_locators: &mut Hash
 /// of the [`HoistingLimits`] keys and upstream's `node.locator`.
 fn node_locator(node: &HoisterResult) -> String {
     format!("{}@{}", node.ident_name, node_ident(node))
+}
+
+/// Whether two nodes are the same package *version*, ignoring the
+/// peer-resolution suffix — upstream's `ident` equality (its
+/// `makeIdent` strips the virtual segment the way this drops the
+/// `(...)` suffix). Peer-suffix variants of one version compare
+/// equal: they merge in a hoisted layout, so they never shadow each
+/// other.
+fn same_ident(left: &HoisterResult, right: &HoisterResult) -> bool {
+    fn ident_of(node: &HoisterResult) -> String {
+        let references = node.references.borrow();
+        let reference = references.iter().next().map_or("", String::as_str);
+        match reference.find('(') {
+            Some(idx) => reference[..idx].to_string(),
+            None => reference.to_string(),
+        }
+    }
+    left.ident_name == right.ident_name && ident_of(left) == ident_of(right)
+}
+
+/// Whether an ancestor strictly below the root carries a different
+/// package version under `candidate`'s name (see
+/// [`AbsorbDecision::PathShadow`]). `path[0]` is the hoist root —
+/// its slot is judged by the root-index decision, not here.
+fn path_shadowed(candidate: &HoisterResult, path: &[Rc<HoisterResult>]) -> bool {
+    path.iter().skip(1).any(|ancestor| {
+        ancestor
+            .dependencies
+            .borrow()
+            .iter()
+            .any(|dep| dep.0.name == candidate.name && !same_ident(&dep.0, candidate))
+    })
 }
 
 /// Whether two nodes are the same package — equal locators — without
@@ -713,6 +823,7 @@ fn decouple_child(
         references: RefCell::new(child.0.references.borrow().clone()),
         peer_names: child.0.peer_names.clone(),
         dependencies: RefCell::new(child.0.dependencies.borrow().clone()),
+        hoisted_dependencies: RefCell::new(child.0.hoisted_dependencies.borrow().clone()),
         decoupled: Cell::new(true),
     }));
     let mut deps = parent.dependencies.borrow_mut();
@@ -762,6 +873,26 @@ enum AbsorbDecision {
     /// [peer-shadow-root]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L414
     /// [peer-path]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L454-L479
     PeerShadow,
+    /// An ancestor strictly below the root holds a *different*
+    /// package version under the candidate's name. Hoisting (or
+    /// dedup-removing) the candidate would make this subtree resolve
+    /// the name to that nearer, conflicting copy instead, so the
+    /// candidate stays nested. Ports the "filled by parent" scan in
+    /// upstream's [`getNodeHoistInfo`][filled] (which vetoes
+    /// `isNameAvailable` after the root-slot check).
+    ///
+    /// [filled]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L500-L516
+    PathShadow,
+    /// The subtree of the current hoist root resolves this name
+    /// through an ancestor directory (a provider hoisted above the
+    /// root earlier — see [`get_used_dependencies`]), and the
+    /// candidate is a different version. Taking the root's name slot
+    /// would shadow those resolutions, so the candidate stays
+    /// nested. Ports the `usedDependencies` gate in upstream's
+    /// [`getNodeHoistInfo`][used-gate].
+    ///
+    /// [used-gate]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L492-L497
+    UsedShadow,
     /// The candidate sits beneath a hoisting border — its parent (or
     /// a higher ancestor) has a name listed in
     /// `opts.hoisting_limits` for the root locator. A bordered node's
@@ -785,6 +916,8 @@ struct HoistCtx<'a> {
     root: &'a Rc<HoisterResult>,
     border_names: &'a BTreeSet<String>,
     hoist_ident_map: &'a HashMap<String, VecDeque<String>>,
+    /// See [`get_used_dependencies`]; empty for the top `.` root.
+    used: &'a HashMap<String, Rc<HoisterResult>>,
 }
 
 /// Walk the result tree and hoist every eligible descendant of
@@ -819,7 +952,12 @@ struct HoistCtx<'a> {
 /// [`decouple_child`]), so a package reachable through several
 /// parents gets an independent hoist decision per path, exactly like
 /// upstream's per-path work tree.
-fn hoist_into_root(root: &Rc<HoisterResult>, root_locator: &str, opts: &HoistOpts) {
+fn hoist_into_root(
+    root: &Rc<HoisterResult>,
+    root_locator: &str,
+    opts: &HoistOpts,
+    used: &HashMap<String, Rc<HoisterResult>>,
+) {
     let mut root_index: HashMap<String, RcByPtr<HoisterResult>> =
         root.dependencies.borrow().iter().map(|dep| (dep.0.name.clone(), dep.clone())).collect();
 
@@ -843,7 +981,7 @@ fn hoist_into_root(root: &Rc<HoisterResult>, root_locator: &str, opts: &HoistOpt
         opts.hoisting_limits.get(root_locator).unwrap_or(&empty_set);
 
     loop {
-        let ctx = HoistCtx { root, border_names, hoist_ident_map: &hoist_ident_map };
+        let ctx = HoistCtx { root, border_names, hoist_ident_map: &hoist_ident_map, used };
         let changed = hoist_subtree(root, &[], &ctx, &mut root_index, false);
 
         // Per-pass ident shift: a name with more than one candidate
@@ -1025,7 +1163,7 @@ fn hoist_subtree(
     root_index: &mut HashMap<String, RcByPtr<HoisterResult>>,
     under_border: bool,
 ) -> bool {
-    let &HoistCtx { root, border_names, hoist_ident_map } = ctx;
+    let &HoistCtx { root, border_names, hoist_ident_map, used } = ctx;
     let mut changed_in_subtree = false;
 
     // A node whose name is in `border_names` is a hoisting border:
@@ -1093,6 +1231,30 @@ fn hoist_subtree(
             }
         };
 
+        // Used-dependency refusal: the root's subtree already
+        // resolves this name from an ancestor directory; a different
+        // version must not take the root's slot (and a same-version
+        // dedup stays allowed — it resolves identically).
+        if matches!(decision, AbsorbDecision::Free | AbsorbDecision::SameNode)
+            && used.get(&child.0.name).is_some_and(|provider| !same_ident(provider, &child.0))
+        {
+            decision = AbsorbDecision::UsedShadow;
+        }
+
+        // "Filled by parent" refusal: when a nearer ancestor's
+        // node_modules already carries a different version of this
+        // name, both hoisting and dedup-removal are wrong — either
+        // way the requires at this position would start resolving to
+        // the nearer, conflicting copy. Applies to `SameNode` too:
+        // even if the root already holds this exact package, the
+        // shadow between here and the root means this position needs
+        // its own nested copy.
+        if matches!(decision, AbsorbDecision::Free | AbsorbDecision::SameNode)
+            && path_shadowed(&child.0, &path_for_children)
+        {
+            decision = AbsorbDecision::PathShadow;
+        }
+
         // Peer-aware refusal layered on top of the basic
         // free / dedup / conflict decision. `Conflict` already
         // leaves the candidate in place and `SameNode` dedups
@@ -1119,6 +1281,9 @@ fn hoist_subtree(
             match decision {
                 AbsorbDecision::Free => {
                     node.dependencies.borrow_mut().shift_remove(&child);
+                    node.hoisted_dependencies
+                        .borrow_mut()
+                        .insert(child.0.name.clone(), Rc::clone(&child.0));
                     root.dependencies.borrow_mut().insert(child.clone());
                     root_index.insert(child.0.name.clone(), child.clone());
                     changed_in_subtree = true;
@@ -1134,11 +1299,16 @@ fn hoist_subtree(
                     // walked as a root child every round), so there
                     // is nothing to descend into.
                     node.dependencies.borrow_mut().shift_remove(&child);
+                    node.hoisted_dependencies
+                        .borrow_mut()
+                        .insert(child.0.name.clone(), Rc::clone(&child.0));
                     changed_in_subtree = true;
                     continue;
                 }
                 AbsorbDecision::Conflict
                 | AbsorbDecision::PeerShadow
+                | AbsorbDecision::PathShadow
+                | AbsorbDecision::UsedShadow
                 | AbsorbDecision::Border
                 | AbsorbDecision::Defer => {
                     // Stays at the current parent, so the child's
@@ -1289,6 +1459,7 @@ fn convert(tree: &HoisterTree, context: &mut ConvertContext) -> Rc<HoisterResult
         references: RefCell::new(refs),
         peer_names: tree.peer_names.clone(),
         dependencies: RefCell::new(IndexSet::new()),
+        hoisted_dependencies: RefCell::new(HashMap::new()),
         decoupled: Cell::new(false),
     });
     context.result_by_tree.insert(ptr, Rc::clone(&node));

--- a/pnpm/crates/real-hoist/src/lib.rs
+++ b/pnpm/crates/real-hoist/src/lib.rs
@@ -680,6 +680,14 @@ fn node_locator(node: &HoisterResult) -> String {
     format!("{}@{}", node.ident_name, node_ident(node))
 }
 
+/// Whether two nodes are the same package — equal locators — without
+/// building the locator strings. Decoupled copies of one package
+/// compare equal; different versions under one name do not.
+fn same_locator(a: &HoisterResult, b: &HoisterResult) -> bool {
+    a.ident_name == b.ident_name
+        && a.references.borrow().iter().next() == b.references.borrow().iter().next()
+}
+
 /// Return a single-parent copy of `child` that is safe to mutate on
 /// the current path, replacing `parent`'s edge with it (in place, so
 /// sibling order is preserved). A node already decoupled has exactly
@@ -709,12 +717,8 @@ fn decouple_child(
     }));
     let mut deps = parent.dependencies.borrow_mut();
     let index = deps.get_index_of(child).expect("decoupled edge exists in its parent");
-    let replaced: IndexSet<RcByPtr<HoisterResult>> = deps
-        .iter()
-        .enumerate()
-        .map(|(dep_index, dep)| if dep_index == index { clone.clone() } else { dep.clone() })
-        .collect();
-    *deps = replaced;
+    deps.shift_remove_index(index);
+    deps.shift_insert(index, clone.clone());
     clone
 }
 
@@ -1049,8 +1053,6 @@ fn hoist_subtree(
     // nested.
     let mut path_for_children: Vec<Rc<HoisterResult>> = ancestor_path.to_vec();
     path_for_children.push(Rc::clone(node));
-    let path_locators: Vec<String> =
-        path_for_children.iter().map(|ancestor| node_locator(ancestor)).collect();
 
     for child in children {
         // Cycle (or self-reference) edge: a package with this
@@ -1062,8 +1064,7 @@ fn hoist_subtree(
         // / `aliasedLocatorPath` guards); pacquet removes them
         // outright because its layout walkers require the result to
         // be a DAG. `node` is decoupled, so the cut is per-path.
-        let child_locator = node_locator(&child.0);
-        if path_locators.contains(&child_locator) {
+        if path_for_children.iter().any(|ancestor| same_locator(ancestor, &child.0)) {
             node.dependencies.borrow_mut().shift_remove(&child);
             changed_in_subtree = true;
             continue;
@@ -1080,9 +1081,7 @@ fn hoist_subtree(
             match root_index.get(&child.0.name) {
                 None if is_preferred_ident(&child.0, hoist_ident_map) => AbsorbDecision::Free,
                 None => AbsorbDecision::Defer,
-                Some(existing) if node_locator(&existing.0) == child_locator => {
-                    AbsorbDecision::SameNode
-                }
+                Some(existing) if same_locator(&existing.0, &child.0) => AbsorbDecision::SameNode,
                 Some(_) => AbsorbDecision::Conflict,
             }
         };
@@ -1227,7 +1226,7 @@ fn would_shadow_peer(
                 // distinct allocations) against root's current
                 // slot for the same name.
                 match root_index.get(peer_name) {
-                    Some(at_root) if node_locator(&at_root.0) == node_locator(&provider) => {
+                    Some(at_root) if same_locator(&at_root.0, &provider) => {
                         // Root already carries this exact
                         // provider — promoting the candidate
                         // doesn't change resolution. Move to

--- a/pnpm/crates/real-hoist/src/lib.rs
+++ b/pnpm/crates/real-hoist/src/lib.rs
@@ -1055,16 +1055,23 @@ fn hoist_subtree(
     path_for_children.push(Rc::clone(node));
 
     for child in children {
-        // Cycle (or self-reference) edge: a package with this
-        // locator already materializes as an ancestor of this
-        // position, so requiring it here resolves to that ancestor
-        // — the edge carries no additional layout and would send
-        // the walkers into unbounded recursion. Cut it. Upstream
-        // skips descending into such edges (its `rootNodePathLocators`
-        // / `aliasedLocatorPath` guards); pacquet removes them
-        // outright because its layout walkers require the result to
-        // be a DAG. `node` is decoupled, so the cut is per-path.
-        if path_for_children.iter().any(|ancestor| same_locator(ancestor, &child.0)) {
+        // Cycle (or self-reference) edge: a package with this alias
+        // *and* locator already materializes as an ancestor of this
+        // position, so requiring the alias here resolves to that
+        // ancestor — the edge carries no additional layout and would
+        // send the walkers into unbounded recursion. Cut it. The
+        // alias name must match too: an edge exposing the same
+        // package under a *different* alias is the only
+        // `node_modules/<alias>` entry for that name and stays, just
+        // like upstream, whose `aliasedLocatorPath` guard compares
+        // `name@locator`. Upstream merely skips descending into
+        // cycle edges; pacquet removes them outright because its
+        // layout walkers require the result to be a DAG. `node` is
+        // decoupled, so the cut is per-path.
+        if path_for_children
+            .iter()
+            .any(|ancestor| ancestor.name == child.0.name && same_locator(ancestor, &child.0))
+        {
             node.dependencies.borrow_mut().shift_remove(&child);
             changed_in_subtree = true;
             continue;

--- a/pnpm/crates/real-hoist/src/lib.rs
+++ b/pnpm/crates/real-hoist/src/lib.rs
@@ -683,9 +683,9 @@ fn node_locator(node: &HoisterResult) -> String {
 /// Whether two nodes are the same package — equal locators — without
 /// building the locator strings. Decoupled copies of one package
 /// compare equal; different versions under one name do not.
-fn same_locator(a: &HoisterResult, b: &HoisterResult) -> bool {
-    a.ident_name == b.ident_name
-        && a.references.borrow().iter().next() == b.references.borrow().iter().next()
+fn same_locator(left: &HoisterResult, right: &HoisterResult) -> bool {
+    left.ident_name == right.ident_name
+        && left.references.borrow().iter().next() == right.references.borrow().iter().next()
 }
 
 /// Return a single-parent copy of `child` that is safe to mutate on

--- a/pnpm/crates/real-hoist/src/lib.rs
+++ b/pnpm/crates/real-hoist/src/lib.rs
@@ -42,7 +42,7 @@ use indexmap::{IndexMap, IndexSet};
 use miette::Diagnostic;
 use pnpm_lockfile::{Lockfile, PkgName, PkgNameVerPeer, ProjectSnapshot, SnapshotEntry};
 use std::{
-    cell::RefCell,
+    cell::{Cell, RefCell},
     collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque},
     fmt::Write as _,
     rc::Rc,
@@ -158,6 +158,17 @@ pub struct HoisterResult {
     /// [ts-HoisterTree]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L16-L19
     pub peer_names: BTreeSet<String>,
     pub dependencies: RefCell<IndexSet<RcByPtr<HoisterResult>>>,
+    /// Whether this node is a single-parent copy that the hoist
+    /// algorithm may mutate. The converter builds a DAG in which a
+    /// package reachable through several parents is one shared node;
+    /// hoisting decisions are per parent path, so before a shared
+    /// node's children are touched the node is cloned for the path
+    /// being worked on (see [`decouple_child`]). Ports the
+    /// `decoupled` flag consumed by upstream's
+    /// [`decoupleGraphNode`][decouple].
+    ///
+    /// [decouple]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L670
+    decoupled: Cell<bool>,
 }
 
 /// Per-importer hoisting borders. Outer key is the importer locator
@@ -613,12 +624,11 @@ pub fn percent_encode_path(text: &str) -> String {
 fn nm_hoist(tree: &HoisterTree, opts: &HoistOpts) -> HoisterResult {
     let mut context = ConvertContext::default();
     let root = convert(tree, &mut context);
-    let root_locator = context
-        .locator_by_result
-        .get(&Rc::as_ptr(&root))
-        .expect("every converted result has its input locator");
-    hoist_into_root(&root, root_locator, opts);
-    hoist_nested_roots(&root, opts, &context.locator_by_result);
+    // The `.` root has no parents, so it is decoupled by
+    // construction — mutating its children can't leak anywhere.
+    root.decoupled.set(true);
+    let mut path_locators = HashSet::from([node_locator(&root)]);
+    hoist_to(&root, opts, &mut path_locators);
     // Returning an owned `HoisterResult` (rather than
     // `Rc<HoisterResult>`) keeps the wrapper's post-hoist
     // `external_dependencies` filter from mutating the shared graph.
@@ -628,24 +638,84 @@ fn nm_hoist(tree: &HoisterTree, opts: &HoistOpts) -> HoisterResult {
     (*root).clone()
 }
 
-fn hoist_nested_roots(
-    root: &Rc<HoisterResult>,
-    opts: &HoistOpts,
-    locator_by_result: &HashMap<*const HoisterResult, String>,
-) {
-    let mut visited = HashSet::from([Rc::as_ptr(root)]);
-    let mut pending: Vec<Rc<HoisterResult>> =
-        root.dependencies.borrow().iter().map(|child| Rc::clone(&child.0)).collect();
-    while let Some(node) = pending.pop() {
-        if !visited.insert(Rc::as_ptr(&node)) {
+/// Hoist eligible descendants onto `root`, then recurse into every
+/// child that stayed (a conflict-nested loser, a border, …) using it
+/// as the next hoist root, so its own subtree flattens onto it.
+/// `path_locators` carries the locators of every root on the current
+/// recursion path; a child whose locator is already on it is a cycle
+/// through the roots and is not descended into. Mirrors upstream's
+/// `hoistTo` recursion (its `rootNodePathLocators` guard included) at
+/// [hoist.ts:309][hoist-to].
+///
+/// Children are decoupled before they become roots: a hoist root's
+/// dependency set is mutated (descendants are inserted), which is
+/// only safe on a single-parent copy. In practice
+/// [`hoist_subtree`] has already decoupled every remaining child
+/// while walking, so the call here is a cheap no-op safety net.
+///
+/// [hoist-to]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L309
+fn hoist_to(root: &Rc<HoisterResult>, opts: &HoistOpts, path_locators: &mut HashSet<String>) {
+    hoist_into_root(root, &node_locator(root), opts);
+
+    let children: Vec<RcByPtr<HoisterResult>> =
+        root.dependencies.borrow().iter().cloned().collect();
+    for child in children {
+        if root.peer_names.contains(&child.0.name) {
             continue;
         }
-        let locator = locator_by_result
-            .get(&Rc::as_ptr(&node))
-            .expect("every converted result has its input locator");
-        hoist_into_root(&node, locator, opts);
-        pending.extend(node.dependencies.borrow().iter().map(|child| Rc::clone(&child.0)));
+        let locator = node_locator(&child.0);
+        if !path_locators.insert(locator.clone()) {
+            continue;
+        }
+        let child = decouple_child(root, &child);
+        hoist_to(&child.0, opts, path_locators);
+        path_locators.remove(&locator);
     }
+}
+
+/// The node's locator: `ident@reference`, unique per package
+/// identity and stable across decoupled copies. Matches the format
+/// of the [`HoistingLimits`] keys and upstream's `node.locator`.
+fn node_locator(node: &HoisterResult) -> String {
+    format!("{}@{}", node.ident_name, node_ident(node))
+}
+
+/// Return a single-parent copy of `child` that is safe to mutate on
+/// the current path, replacing `parent`'s edge with it (in place, so
+/// sibling order is preserved). A node already decoupled has exactly
+/// one parent and is returned as is. Ports upstream's
+/// [`decoupleGraphNode`][decouple]: the clone shares the grandchild
+/// `Rc`s — those are decoupled in turn if and when the walk reaches
+/// them — so only the mutated spine of the graph is ever copied.
+///
+/// `parent` must itself be decoupled: replacing the edge mutates its
+/// dependency set.
+///
+/// [decouple]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L670
+fn decouple_child(
+    parent: &Rc<HoisterResult>,
+    child: &RcByPtr<HoisterResult>,
+) -> RcByPtr<HoisterResult> {
+    if child.0.decoupled.get() {
+        return child.clone();
+    }
+    let clone = RcByPtr(Rc::new(HoisterResult {
+        name: child.0.name.clone(),
+        ident_name: child.0.ident_name.clone(),
+        references: RefCell::new(child.0.references.borrow().clone()),
+        peer_names: child.0.peer_names.clone(),
+        dependencies: RefCell::new(child.0.dependencies.borrow().clone()),
+        decoupled: Cell::new(true),
+    }));
+    let mut deps = parent.dependencies.borrow_mut();
+    let index = deps.get_index_of(child).expect("decoupled edge exists in its parent");
+    let replaced: IndexSet<RcByPtr<HoisterResult>> = deps
+        .iter()
+        .enumerate()
+        .map(|(dep_index, dep)| if dep_index == index { clone.clone() } else { dep.clone() })
+        .collect();
+    *deps = replaced;
+    clone
 }
 
 /// Outcome of the per-child hoist decision at the root.
@@ -664,12 +734,17 @@ enum AbsorbDecision {
     ///
     /// [prefer-gate]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L387
     Defer,
-    /// Root already holds *this exact `Rc`* (the same node was
-    /// reachable through another parent path and got hoisted
-    /// earlier). The duplicate reference in the current parent
-    /// just needs to be removed.
+    /// Root already holds a node with this locator (the same
+    /// package was reachable through another parent path — possibly
+    /// as a decoupled copy — and got hoisted earlier). The duplicate
+    /// edge in the current parent just needs to be removed; the
+    /// root's copy represents the subtree from here on. Mirrors
+    /// upstream's same-locator merge in `hoistGraph` at
+    /// [hoist.ts:521][merge].
+    ///
+    /// [merge]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L521
     SameNode,
-    /// Root's name slot is taken by a different `Rc` — a version
+    /// Root's name slot is taken by a different locator — a version
     /// conflict. The child stays under its current parent.
     Conflict,
     /// Hoisting would shadow a peer dependency one of the
@@ -700,7 +775,7 @@ enum AbsorbDecision {
 /// one [`hoist_into_root`] pass: the hoisting root, the active
 /// border-name set, and the per-name preferred-ident map. Bundled
 /// into one struct so the recursive walker stays under the argument
-/// limit; only `root_index`, `visited`, and the per-node position
+/// limit; only `root_index` and the per-node position
 /// (`node`, `ancestor_path`, `under_border`) vary per call.
 struct HoistCtx<'a> {
     root: &'a Rc<HoisterResult>,
@@ -734,13 +809,12 @@ struct HoistCtx<'a> {
 /// `do { hoistGraph(); } while (anotherRoundNeeded)` shape, just
 /// with the DFS-by-round simplification described above.
 ///
-/// For a DAG where the same node is reachable through multiple
-/// paths, only the first-arrived path is consulted; upstream's
-/// `cloneTree` produces a strict tree (per-path duplication) and
-/// gets a per-path peer decision for free, but pacquet preserves
-/// DAG sharing and accepts a more conservative ruling in the
-/// rare cross-path mismatch cases. The cost is layouts that are
-/// sometimes more nested than pnpm's, never less.
+/// The converter's result is a DAG (one shared node per package),
+/// but the walk mutates only decoupled — single-parent — copies:
+/// every edge the DFS crosses is decoupled first (see
+/// [`decouple_child`]), so a package reachable through several
+/// parents gets an independent hoist decision per path, exactly like
+/// upstream's per-path work tree.
 fn hoist_into_root(root: &Rc<HoisterResult>, root_locator: &str, opts: &HoistOpts) {
     let mut root_index: HashMap<String, RcByPtr<HoisterResult>> =
         root.dependencies.borrow().iter().map(|dep| (dep.0.name.clone(), dep.clone())).collect();
@@ -765,9 +839,8 @@ fn hoist_into_root(root: &Rc<HoisterResult>, root_locator: &str, opts: &HoistOpt
         opts.hoisting_limits.get(root_locator).unwrap_or(&empty_set);
 
     loop {
-        let mut visited: HashSet<*const HoisterResult> = HashSet::new();
         let ctx = HoistCtx { root, border_names, hoist_ident_map: &hoist_ident_map };
-        let changed = hoist_subtree(root, &[], &ctx, &mut root_index, &mut visited, false);
+        let changed = hoist_subtree(root, &[], &ctx, &mut root_index, false);
 
         // Per-pass ident shift: a name with more than one candidate
         // ident whose preferred ident still hasn't reached the root
@@ -932,19 +1005,23 @@ fn is_preferred_ident(
 /// Returns whether this subtree moved at least one node in the
 /// current round — the outer multi-round loop uses that to
 /// decide whether another round can unlock further hoists.
+///
+/// `node` must be decoupled — the walk mutates its dependency set.
+/// The recursion keeps that invariant: every child is decoupled
+/// (relative to its post-decision parent) before it is descended
+/// into, so a package shared by several parents is walked — and
+/// decided — once per path, on that path's own copy. The walk tree
+/// therefore has the shape of the final materialized layout, and
+/// termination follows from the cycle cut below: no locator repeats
+/// on a path, so paths (and the walk) are finite.
 fn hoist_subtree(
     node: &Rc<HoisterResult>,
     ancestor_path: &[Rc<HoisterResult>],
     ctx: &HoistCtx<'_>,
     root_index: &mut HashMap<String, RcByPtr<HoisterResult>>,
-    visited: &mut HashSet<*const HoisterResult>,
     under_border: bool,
 ) -> bool {
     let &HoistCtx { root, border_names, hoist_ident_map } = ctx;
-    let root_ptr = Rc::as_ptr(root);
-    if !visited.insert(Rc::as_ptr(node)) {
-        return false;
-    }
     let mut changed_in_subtree = false;
 
     // A node whose name is in `border_names` is a hoisting border:
@@ -966,16 +1043,29 @@ fn hoist_subtree(
     let is_root = Rc::ptr_eq(node, root);
 
     // Path from root down to and including `node` — i.e. the
-    // ancestor path for `node`'s direct children. Used both for
-    // peer-shadow checks (children) and as the starting point
+    // ancestor path for `node`'s direct children. Used for the
+    // peer-shadow checks, the cycle cut, and as the starting point
     // for the path passed into recursion when a child stays
     // nested.
     let mut path_for_children: Vec<Rc<HoisterResult>> = ancestor_path.to_vec();
     path_for_children.push(Rc::clone(node));
+    let path_locators: Vec<String> =
+        path_for_children.iter().map(|ancestor| node_locator(ancestor)).collect();
 
     for child in children {
-        if Rc::as_ptr(&child.0) == root_ptr {
-            // Back-edge to root via a cycle. Nothing to hoist.
+        // Cycle (or self-reference) edge: a package with this
+        // locator already materializes as an ancestor of this
+        // position, so requiring it here resolves to that ancestor
+        // — the edge carries no additional layout and would send
+        // the walkers into unbounded recursion. Cut it. Upstream
+        // skips descending into such edges (its `rootNodePathLocators`
+        // / `aliasedLocatorPath` guards); pacquet removes them
+        // outright because its layout walkers require the result to
+        // be a DAG. `node` is decoupled, so the cut is per-path.
+        let child_locator = node_locator(&child.0);
+        if path_locators.contains(&child_locator) {
+            node.dependencies.borrow_mut().shift_remove(&child);
+            changed_in_subtree = true;
             continue;
         }
 
@@ -990,7 +1080,9 @@ fn hoist_subtree(
             match root_index.get(&child.0.name) {
                 None if is_preferred_ident(&child.0, hoist_ident_map) => AbsorbDecision::Free,
                 None => AbsorbDecision::Defer,
-                Some(existing) if Rc::ptr_eq(&existing.0, &child.0) => AbsorbDecision::SameNode,
+                Some(existing) if node_locator(&existing.0) == child_locator => {
+                    AbsorbDecision::SameNode
+                }
                 Some(_) => AbsorbDecision::Conflict,
             }
         };
@@ -998,7 +1090,7 @@ fn hoist_subtree(
         // Peer-aware refusal layered on top of the basic
         // free / dedup / conflict decision. `Conflict` already
         // leaves the candidate in place and `SameNode` dedups
-        // an already-hoisted shared `Rc`, so the peer check
+        // an already-hoisted package, so the peer check
         // only matters when we'd otherwise hoist.
         if matches!(decision, AbsorbDecision::Free)
             && would_shadow_peer(&child.0, &path_for_children, root, root_index)
@@ -1029,13 +1121,15 @@ fn hoist_subtree(
                     vec![Rc::clone(root)]
                 }
                 AbsorbDecision::SameNode => {
-                    // The shared `Rc` is already at root; strip
-                    // the duplicate reference at this parent so
-                    // the deeper copy disappears. Child's actual
-                    // ancestor path is `[root]`.
+                    // A copy of this package is already at root;
+                    // strip the duplicate edge at this parent so the
+                    // deeper copy disappears. The root's copy
+                    // represents the subtree from here on (it is
+                    // walked as a root child every round), so there
+                    // is nothing to descend into.
                     node.dependencies.borrow_mut().shift_remove(&child);
                     changed_in_subtree = true;
-                    vec![Rc::clone(root)]
+                    continue;
                 }
                 AbsorbDecision::Conflict
                 | AbsorbDecision::PeerShadow
@@ -1051,14 +1145,20 @@ fn hoist_subtree(
             }
         };
 
-        let child_changed = hoist_subtree(
-            &child.0,
-            &child_recursion_path,
-            ctx,
-            root_index,
-            visited,
-            children_blocked,
-        );
+        // Decouple before descending: the recursion mutates the
+        // child's dependency set, which must not leak into other
+        // paths that share the child. The child's current parent is
+        // the last element of its recursion path — root for a
+        // just-moved (or root-direct) child, `node` otherwise.
+        let parent =
+            child_recursion_path.last().expect("the recursion path ends at the child's parent");
+        let child = decouple_child(parent, &child);
+        if Rc::ptr_eq(parent, root) {
+            root_index.insert(child.0.name.clone(), child.clone());
+        }
+
+        let child_changed =
+            hoist_subtree(&child.0, &child_recursion_path, ctx, root_index, children_blocked);
         changed_in_subtree |= child_changed;
     }
     changed_in_subtree
@@ -1086,16 +1186,10 @@ fn hoist_subtree(
 ///   would silently re-resolve its peer to the wrong package, so
 ///   we leave it nested.
 ///
-/// Differs from upstream's check in one DAG case: upstream's
-/// [`cloneTree`][clone] duplicates the work tree into a strict
-/// tree per parent path, so each visit has a unique ancestor
-/// chain. Pacquet preserves the DAG, and the DFS records only
-/// the path it actually used to reach the candidate; if the same
-/// candidate could be reached via a peer-compatible alternative
-/// path, we still refuse to hoist. The result is at most
-/// over-nested layouts, never under-nested ones.
-///
-/// [clone]: https://github.com/yarnpkg/berry/blob/4287909fa6a0a1ec976a55776bff606864b31990/packages/yarnpkg-nm/sources/hoist.ts#L670
+/// The ancestor chain is per-path by construction: the DFS
+/// decouples every node it descends into (see [`decouple_child`]),
+/// so a package shared by several parents gets a fresh peer ruling
+/// on each path, matching upstream's per-path work tree.
 fn would_shadow_peer(
     candidate: &HoisterResult,
     ancestor_path: &[Rc<HoisterResult>],
@@ -1128,10 +1222,12 @@ fn would_shadow_peer(
 
             if let Some(provider) = provider_rc {
                 // Found a concrete provider in the ancestor
-                // chain. Compare its identity against root's
-                // current slot for the same name.
+                // chain. Compare its locator (identity is too
+                // strict — decoupled copies of one package are
+                // distinct allocations) against root's current
+                // slot for the same name.
                 match root_index.get(peer_name) {
-                    Some(at_root) if Rc::ptr_eq(&at_root.0, &provider) => {
+                    Some(at_root) if node_locator(&at_root.0) == node_locator(&provider) => {
                         // Root already carries this exact
                         // provider — promoting the candidate
                         // doesn't change resolution. Move to
@@ -1167,7 +1263,6 @@ fn would_shadow_peer(
 #[derive(Default)]
 struct ConvertContext {
     result_by_tree: HashMap<*const HoisterTree, Rc<HoisterResult>>,
-    locator_by_result: HashMap<*const HoisterResult, String>,
 }
 
 fn convert(tree: &HoisterTree, context: &mut ConvertContext) -> Rc<HoisterResult> {
@@ -1188,11 +1283,9 @@ fn convert(tree: &HoisterTree, context: &mut ConvertContext) -> Rc<HoisterResult
         references: RefCell::new(refs),
         peer_names: tree.peer_names.clone(),
         dependencies: RefCell::new(IndexSet::new()),
+        decoupled: Cell::new(false),
     });
     context.result_by_tree.insert(ptr, Rc::clone(&node));
-    context
-        .locator_by_result
-        .insert(Rc::as_ptr(&node), format!("{}@{}", tree.ident_name, tree.reference));
 
     // Collect the children before recursing so we can drop the
     // `Ref<'_, IndexSet<...>>` borrow on `tree.dependencies`. The

--- a/pnpm/crates/real-hoist/src/lib.rs
+++ b/pnpm/crates/real-hoist/src/lib.rs
@@ -639,7 +639,7 @@ fn nm_hoist(tree: &HoisterTree, opts: &HoistOpts) -> HoisterResult {
 }
 
 /// Hoist eligible descendants onto `root`, then recurse into every
-/// child that stayed (a conflict-nested loser, a border, …) using it
+/// child that stayed (a conflict-nested loser, a border, ...) using it
 /// as the next hoist root, so its own subtree flattens onto it.
 /// `path_locators` carries the locators of every root on the current
 /// recursion path; a child whose locator is already on it is a cycle

--- a/pnpm/crates/real-hoist/src/tests.rs
+++ b/pnpm/crates/real-hoist/src/tests.rs
@@ -1180,6 +1180,68 @@ fn conflict_nested_shared_cycle_is_cut() {
     }
 }
 
+/// An npm-alias edge that exposes the same underlying package as an
+/// ancestor under a *different* alias is not a cycle: it is the only
+/// `node_modules/<alias>` entry for its name, so cutting it would
+/// break `require('<alias>')`. Only an edge repeating an ancestor's
+/// alias *and* locator is cut, mirroring upstream's
+/// `aliasedLocatorPath` guard (which compares `name@locator`).
+/// Regression shape: `b@1` exposes itself under the alias `c`
+/// (`"c": "npm:b@1.0.0"`).
+#[test]
+fn self_alias_keeps_its_entry_and_only_the_alias_repeat_is_cut() {
+    let mut importers = HashMap::new();
+    let mut root_deps = ResolvedDependencyMap::new();
+    root_deps.insert(pkg_name("b"), resolved_dep("1.0.0"));
+    importers.insert(
+        Lockfile::ROOT_IMPORTER_KEY.to_string(),
+        ProjectSnapshot { dependencies: Some(root_deps), ..ProjectSnapshot::default() },
+    );
+
+    let mut snapshots = HashMap::new();
+    let mut b_deps = HashMap::new();
+    b_deps.insert(pkg_name("c"), SnapshotDepRef::Alias(dep_key("b", "1.0.0")));
+    snapshots.insert(
+        dep_key("b", "1.0.0"),
+        SnapshotEntry { dependencies: Some(b_deps), ..SnapshotEntry::default() },
+    );
+
+    let lockfile = Lockfile {
+        lockfile_version: lockfile_version(),
+        settings: None,
+        catalogs: None,
+        overrides: None,
+        package_extensions_checksum: None,
+        pnpmfile_checksum: None,
+        ignored_optional_dependencies: None,
+        patched_dependencies: None,
+        importers,
+        packages: None,
+        snapshots: Some(snapshots),
+        time: None,
+    };
+
+    let result = hoist(&lockfile, &HoistOpts::default()).expect("self-alias hoist should succeed");
+    let root_children = result.dependencies.borrow();
+    let mut names: Vec<&str> = root_children.iter().map(|dep| dep.0.name.as_str()).collect();
+    names.sort_unstable();
+    assert_eq!(
+        names,
+        ["b", "c"],
+        "the alias keeps its own node_modules entry instead of being cut as a cycle",
+    );
+
+    // The alias copy's own self-alias edge repeats both the alias
+    // name and the locator, so that one *is* cut — the result must
+    // not retain the cycle.
+    for child in root_children.iter() {
+        assert!(
+            child.0.dependencies.borrow().is_empty(),
+            "the alias-repeat back-edge is cut: {child:#?}",
+        );
+    }
+}
+
 #[test]
 fn self_dependency_does_not_loop() {
     let mut importers = HashMap::new();

--- a/pnpm/crates/real-hoist/src/tests.rs
+++ b/pnpm/crates/real-hoist/src/tests.rs
@@ -996,6 +996,192 @@ fn nested_hoist_uses_the_nested_root_locator() {
     assert_eq!(b_names, ["c"], "the workspace's b border keeps c below b");
 }
 
+/// A conflict-nested node shared by several parents must keep its own
+/// conflicting dependencies reachable from *every* parent. The nested
+/// hoist pass must not steal a child out of the shared node into one
+/// parent's subtree: the other parents' materialized copies would then
+/// resolve the name to the root's (wrong-version) slot.
+///
+/// Regression shape (from `@teambit/bit`'s lockfile): root holds `b@1`
+/// and `d@1`; `c1` and `c2` share one `b@2` node whose dependency `d@2`
+/// conflicts with the root's `d@1`.
+#[test]
+fn nested_hoist_keeps_conflicting_dep_reachable_from_every_parent_of_a_shared_node() {
+    let mut importers = HashMap::new();
+    let mut root_deps = ResolvedDependencyMap::new();
+    root_deps.insert(pkg_name("b"), resolved_dep("1.0.0"));
+    root_deps.insert(pkg_name("d"), resolved_dep("1.0.0"));
+    root_deps.insert(pkg_name("c1"), resolved_dep("1.0.0"));
+    root_deps.insert(pkg_name("c2"), resolved_dep("1.0.0"));
+    importers.insert(
+        Lockfile::ROOT_IMPORTER_KEY.to_string(),
+        ProjectSnapshot { dependencies: Some(root_deps), ..ProjectSnapshot::default() },
+    );
+
+    let mut snapshots = HashMap::new();
+    for parent in ["c1", "c2"] {
+        let mut parent_deps = HashMap::new();
+        parent_deps.insert(pkg_name("b"), SnapshotDepRef::Plain(ver_peer("2.0.0")));
+        snapshots.insert(
+            dep_key(parent, "1.0.0"),
+            SnapshotEntry { dependencies: Some(parent_deps), ..SnapshotEntry::default() },
+        );
+    }
+    let mut b_two_deps = HashMap::new();
+    b_two_deps.insert(pkg_name("d"), SnapshotDepRef::Plain(ver_peer("2.0.0")));
+    snapshots.insert(
+        dep_key("b", "2.0.0"),
+        SnapshotEntry { dependencies: Some(b_two_deps), ..SnapshotEntry::default() },
+    );
+    snapshots.insert(dep_key("b", "1.0.0"), SnapshotEntry::default());
+    snapshots.insert(dep_key("d", "1.0.0"), SnapshotEntry::default());
+    snapshots.insert(dep_key("d", "2.0.0"), SnapshotEntry::default());
+
+    let lockfile = Lockfile {
+        lockfile_version: lockfile_version(),
+        settings: None,
+        catalogs: None,
+        overrides: None,
+        package_extensions_checksum: None,
+        pnpmfile_checksum: None,
+        ignored_optional_dependencies: None,
+        patched_dependencies: None,
+        importers,
+        packages: None,
+        snapshots: Some(snapshots),
+        time: None,
+    };
+
+    let result = hoist(&lockfile, &HoistOpts::default()).expect("hoist should succeed");
+    let root_children = result.dependencies.borrow();
+    let mut names: Vec<&str> = root_children.iter().map(|dep| dep.0.name.as_str()).collect();
+    names.sort_unstable();
+    assert_eq!(names, ["b", "c1", "c2", "d"], "root keeps its direct b@1 and d@1");
+
+    let mut b_under_parents: Vec<Rc<HoisterResult>> = Vec::new();
+    for parent_name in ["c1", "c2"] {
+        let parent =
+            Rc::clone(&root_children.iter().find(|dep| dep.0.name == parent_name).unwrap().0);
+        let parent_kids = parent.dependencies.borrow();
+        let nested_b = Rc::clone(
+            &parent_kids
+                .iter()
+                .find(|dep| dep.0.name == "b")
+                .unwrap_or_else(|| panic!("{parent_name} keeps its conflicting b@2: {parent:#?}"))
+                .0,
+        );
+        assert!(nested_b.references.borrow().contains("b@2.0.0"));
+
+        // `d@2` must resolve from this parent's copy of `b@2`: either
+        // nested under `b@2` itself or as a sibling inside the parent.
+        let d_under_b = nested_b
+            .dependencies
+            .borrow()
+            .iter()
+            .any(|dep| dep.0.name == "d" && dep.0.references.borrow().contains("d@2.0.0"));
+        let d_under_parent = parent_kids
+            .iter()
+            .any(|dep| dep.0.name == "d" && dep.0.references.borrow().contains("d@2.0.0"));
+        assert!(
+            d_under_b || d_under_parent,
+            "d@2 is unreachable from {parent_name}'s subtree, so its b@2 would \
+             resolve d to the root's d@1: {parent:#?}"
+        );
+        b_under_parents.push(nested_b);
+    }
+    // The copies are per-path (decoupled), never one shared
+    // allocation — a shared node would let one parent's hoisting
+    // steal the other's subtree.
+    assert!(
+        !Rc::ptr_eq(&b_under_parents[0], &b_under_parents[1]),
+        "each parent gets its own decoupled b@2 copy"
+    );
+}
+
+/// A cycle inside a conflict-nested shared cluster must still be cut.
+/// The shared-chain guard refuses the moves that used to dissolve such
+/// cycles, so the nested pass cuts the back-edge instead — a cycle
+/// that survives into the result sends the layout walkers into
+/// unbounded recursion.
+#[test]
+fn conflict_nested_shared_cycle_is_cut() {
+    let mut importers = HashMap::new();
+    let mut root_deps = ResolvedDependencyMap::new();
+    root_deps.insert(pkg_name("x"), resolved_dep("1.0.0"));
+    root_deps.insert(pkg_name("y"), resolved_dep("1.0.0"));
+    root_deps.insert(pkg_name("c1"), resolved_dep("1.0.0"));
+    root_deps.insert(pkg_name("c2"), resolved_dep("1.0.0"));
+    importers.insert(
+        Lockfile::ROOT_IMPORTER_KEY.to_string(),
+        ProjectSnapshot { dependencies: Some(root_deps), ..ProjectSnapshot::default() },
+    );
+
+    let mut snapshots = HashMap::new();
+    for parent in ["c1", "c2"] {
+        let mut parent_deps = HashMap::new();
+        parent_deps.insert(pkg_name("x"), SnapshotDepRef::Plain(ver_peer("2.0.0")));
+        snapshots.insert(
+            dep_key(parent, "1.0.0"),
+            SnapshotEntry { dependencies: Some(parent_deps), ..SnapshotEntry::default() },
+        );
+    }
+    let mut x_two_deps = HashMap::new();
+    x_two_deps.insert(pkg_name("y"), SnapshotDepRef::Plain(ver_peer("2.0.0")));
+    snapshots.insert(
+        dep_key("x", "2.0.0"),
+        SnapshotEntry { dependencies: Some(x_two_deps), ..SnapshotEntry::default() },
+    );
+    let mut y_two_deps = HashMap::new();
+    y_two_deps.insert(pkg_name("x"), SnapshotDepRef::Plain(ver_peer("2.0.0")));
+    snapshots.insert(
+        dep_key("y", "2.0.0"),
+        SnapshotEntry { dependencies: Some(y_two_deps), ..SnapshotEntry::default() },
+    );
+    snapshots.insert(dep_key("x", "1.0.0"), SnapshotEntry::default());
+    snapshots.insert(dep_key("y", "1.0.0"), SnapshotEntry::default());
+
+    let lockfile = Lockfile {
+        lockfile_version: lockfile_version(),
+        settings: None,
+        catalogs: None,
+        overrides: None,
+        package_extensions_checksum: None,
+        pnpmfile_checksum: None,
+        ignored_optional_dependencies: None,
+        patched_dependencies: None,
+        importers,
+        packages: None,
+        snapshots: Some(snapshots),
+        time: None,
+    };
+
+    let result = hoist(&lockfile, &HoistOpts::default()).expect("cyclic hoist should succeed");
+
+    // Walk every path; a node reappearing on its own ancestor path
+    // means a cycle survived.
+    fn assert_acyclic(node: &Rc<HoisterResult>, path: &mut Vec<*const HoisterResult>) {
+        assert!(
+            !path.contains(&Rc::as_ptr(node)),
+            "cycle in hoister output through {}@{:?}",
+            node.name,
+            node.references.borrow()
+        );
+        path.push(Rc::as_ptr(node));
+        let children: Vec<Rc<HoisterResult>> =
+            node.dependencies.borrow().iter().map(|dep| Rc::clone(&dep.0)).collect();
+        for child in children {
+            assert_acyclic(&child, path);
+        }
+        path.pop();
+    }
+    let root_children: Vec<Rc<HoisterResult>> =
+        result.dependencies.borrow().iter().map(|dep| Rc::clone(&dep.0)).collect();
+    let mut path = Vec::new();
+    for child in &root_children {
+        assert_acyclic(child, &mut path);
+    }
+}
+
 #[test]
 fn self_dependency_does_not_loop() {
     let mut importers = HashMap::new();
@@ -1186,6 +1372,7 @@ fn result_node(
         references: RefCell::new(BTreeSet::from([reference.to_string()])),
         peer_names: peer_names.iter().map(|&peer| peer.to_string()).collect(),
         dependencies: RefCell::new(dependencies.into_iter().map(RcByPtr).collect::<IndexSet<_>>()),
+        decoupled: std::cell::Cell::new(false),
     })
 }
 

--- a/pnpm/crates/real-hoist/src/tests.rs
+++ b/pnpm/crates/real-hoist/src/tests.rs
@@ -1098,11 +1098,9 @@ fn nested_hoist_keeps_conflicting_dep_reachable_from_every_parent_of_a_shared_no
     );
 }
 
-/// A cycle inside a conflict-nested shared cluster must still be cut.
-/// The shared-chain guard refuses the moves that used to dissolve such
-/// cycles, so the nested pass cuts the back-edge instead — a cycle
-/// that survives into the result sends the layout walkers into
-/// unbounded recursion.
+/// A cycle inside a conflict-nested shared cluster must be cut by the
+/// locator path guard in `hoist_subtree` — a cycle that survives into
+/// the result sends the layout walkers into unbounded recursion.
 #[test]
 fn conflict_nested_shared_cycle_is_cut() {
     let mut importers = HashMap::new();

--- a/pnpm/crates/real-hoist/src/tests.rs
+++ b/pnpm/crates/real-hoist/src/tests.rs
@@ -1085,7 +1085,7 @@ fn nested_hoist_keeps_conflicting_dep_reachable_from_every_parent_of_a_shared_no
         assert!(
             d_under_b || d_under_parent,
             "d@2 is unreachable from {parent_name}'s subtree, so its b@2 would \
-             resolve d to the root's d@1: {parent:#?}"
+             resolve d to the root's d@1: {parent:#?}",
         );
         b_under_parents.push(nested_b);
     }
@@ -1094,7 +1094,7 @@ fn nested_hoist_keeps_conflicting_dep_reachable_from_every_parent_of_a_shared_no
     // steal the other's subtree.
     assert!(
         !Rc::ptr_eq(&b_under_parents[0], &b_under_parents[1]),
-        "each parent gets its own decoupled b@2 copy"
+        "each parent gets its own decoupled b@2 copy",
     );
 }
 
@@ -1164,7 +1164,7 @@ fn conflict_nested_shared_cycle_is_cut() {
             !path.contains(&Rc::as_ptr(node)),
             "cycle in hoister output through {}@{:?}",
             node.name,
-            node.references.borrow()
+            node.references.borrow(),
         );
         path.push(Rc::as_ptr(node));
         let children: Vec<Rc<HoisterResult>> =

--- a/pnpm/crates/real-hoist/src/tests.rs
+++ b/pnpm/crates/real-hoist/src/tests.rs
@@ -1242,6 +1242,171 @@ fn self_alias_keeps_its_entry_and_only_the_alias_repeat_is_cut() {
     }
 }
 
+/// Peer-suffix variants of one package version collapse onto the
+/// first-seen variant (the ported `depPathByPkgId` mapping): the
+/// hoister sees a single locator, so the variants dedup at the root
+/// instead of conflict-nesting a copy under every dependent. Keeping
+/// them distinct made peer-variant-heavy lockfiles (e.g.
+/// `@teambit/bit`'s) explode the per-path walk.
+#[test]
+fn peer_suffix_variants_collapse_to_one_hoisted_copy() {
+    let mut importers = HashMap::new();
+    let mut root_deps = ResolvedDependencyMap::new();
+    root_deps.insert(pkg_name("c1"), resolved_dep("1.0.0"));
+    root_deps.insert(pkg_name("c2"), resolved_dep("1.0.0"));
+    importers.insert(
+        Lockfile::ROOT_IMPORTER_KEY.to_string(),
+        ProjectSnapshot { dependencies: Some(root_deps), ..ProjectSnapshot::default() },
+    );
+
+    let mut snapshots = HashMap::new();
+    let mut c1_deps = HashMap::new();
+    c1_deps.insert(pkg_name("x"), SnapshotDepRef::Plain(ver_peer("1.0.0(p@1.0.0)")));
+    snapshots.insert(
+        dep_key("c1", "1.0.0"),
+        SnapshotEntry { dependencies: Some(c1_deps), ..SnapshotEntry::default() },
+    );
+    let mut c2_deps = HashMap::new();
+    c2_deps.insert(pkg_name("x"), SnapshotDepRef::Plain(ver_peer("1.0.0(p@2.0.0)")));
+    snapshots.insert(
+        dep_key("c2", "1.0.0"),
+        SnapshotEntry { dependencies: Some(c2_deps), ..SnapshotEntry::default() },
+    );
+    snapshots.insert(dep_key("x", "1.0.0(p@1.0.0)"), SnapshotEntry::default());
+    snapshots.insert(dep_key("x", "1.0.0(p@2.0.0)"), SnapshotEntry::default());
+
+    let lockfile = Lockfile { importers, snapshots: Some(snapshots), ..empty_lockfile() };
+
+    let result = hoist(&lockfile, &HoistOpts::default()).expect("variant hoist should succeed");
+    let root_children = result.dependencies.borrow();
+    let mut names: Vec<&str> = root_children.iter().map(|dep| dep.0.name.as_str()).collect();
+    names.sort_unstable();
+    assert_eq!(names, ["c1", "c2", "x"], "one hoisted x, no nested variant copies");
+    for parent in ["c1", "c2"] {
+        let parent = &root_children.iter().find(|dep| dep.0.name == parent).unwrap().0;
+        assert!(
+            parent.dependencies.borrow().is_empty(),
+            "the variant edge dedups against the root copy: {parent:#?}",
+        );
+    }
+    let hoisted_x = &root_children.iter().find(|dep| dep.0.name == "x").unwrap().0;
+    assert!(
+        hoisted_x.references.borrow().contains("x@1.0.0(p@1.0.0)"),
+        "the first-seen variant is the canonical reference: {hoisted_x:#?}",
+    );
+}
+
+/// A nearer ancestor holding a different version of a name blocks
+/// both hoisting and same-node dedup for that name (upstream's
+/// "filled by parent" scan): removing the edge would make this
+/// position resolve the ancestor's conflicting copy.
+#[test]
+fn ancestor_conflict_blocks_dedup_against_the_root_copy() {
+    let mut importers = HashMap::new();
+    let mut root_deps = ResolvedDependencyMap::new();
+    root_deps.insert(pkg_name("a"), resolved_dep("1.0.0"));
+    root_deps.insert(pkg_name("x"), resolved_dep("1.0.0"));
+    root_deps.insert(pkg_name("b"), resolved_dep("2.0.0"));
+    importers.insert(
+        Lockfile::ROOT_IMPORTER_KEY.to_string(),
+        ProjectSnapshot { dependencies: Some(root_deps), ..ProjectSnapshot::default() },
+    );
+
+    let mut snapshots = HashMap::new();
+    let mut a_deps = HashMap::new();
+    a_deps.insert(pkg_name("x"), SnapshotDepRef::Plain(ver_peer("2.0.0")));
+    a_deps.insert(pkg_name("b"), SnapshotDepRef::Plain(ver_peer("1.0.0")));
+    snapshots.insert(
+        dep_key("a", "1.0.0"),
+        SnapshotEntry { dependencies: Some(a_deps), ..SnapshotEntry::default() },
+    );
+    let mut b_one_deps = HashMap::new();
+    b_one_deps.insert(pkg_name("x"), SnapshotDepRef::Plain(ver_peer("1.0.0")));
+    snapshots.insert(
+        dep_key("b", "1.0.0"),
+        SnapshotEntry { dependencies: Some(b_one_deps), ..SnapshotEntry::default() },
+    );
+    snapshots.insert(dep_key("b", "2.0.0"), SnapshotEntry::default());
+    snapshots.insert(dep_key("x", "1.0.0"), SnapshotEntry::default());
+    snapshots.insert(dep_key("x", "2.0.0"), SnapshotEntry::default());
+
+    let lockfile = Lockfile { importers, snapshots: Some(snapshots), ..empty_lockfile() };
+
+    let result = hoist(&lockfile, &HoistOpts::default()).expect("hoist should succeed");
+    let root_children = result.dependencies.borrow();
+    let node_a = &root_children.iter().find(|dep| dep.0.name == "a").unwrap().0;
+    let a_kids = node_a.dependencies.borrow();
+    let b_nested = &a_kids.iter().find(|dep| dep.0.name == "b").expect("b@1 nests under a").0;
+    let b_kids = b_nested.dependencies.borrow();
+    let x_kept = b_kids
+        .iter()
+        .find(|dep| dep.0.name == "x")
+        .unwrap_or_else(|| panic!("b@1 keeps its own x@1 below a's conflicting x@2: {node_a:#?}"));
+    assert!(x_kept.0.references.borrow().contains("x@1.0.0"));
+}
+
+/// A nested hoist root must not take a name slot that its subtree
+/// already resolves through an ancestor directory (upstream's
+/// `usedDependencies` gate). Regression shape (from `express` in
+/// `@teambit/bit`'s lockfile): `send`'s `ms@2` dedup'd against the
+/// root, then the nested pass hoisted `debug`'s conflicting `ms@1`
+/// onto `express`, shadowing `send`'s resolution.
+#[test]
+fn nested_root_does_not_shadow_names_its_subtree_uses_from_above() {
+    let mut importers = HashMap::new();
+    let mut root_deps = ResolvedDependencyMap::new();
+    root_deps.insert(pkg_name("e"), resolved_dep("1.0.0"));
+    root_deps.insert(pkg_name("m"), resolved_dep("2.0.0"));
+    root_deps.insert(pkg_name("s"), resolved_dep("2.0.0"));
+    root_deps.insert(pkg_name("d"), resolved_dep("2.0.0"));
+    importers.insert(
+        Lockfile::ROOT_IMPORTER_KEY.to_string(),
+        ProjectSnapshot { dependencies: Some(root_deps), ..ProjectSnapshot::default() },
+    );
+
+    let mut snapshots = HashMap::new();
+    let mut e_deps = HashMap::new();
+    e_deps.insert(pkg_name("d"), SnapshotDepRef::Plain(ver_peer("1.0.0")));
+    e_deps.insert(pkg_name("s"), SnapshotDepRef::Plain(ver_peer("1.0.0")));
+    snapshots.insert(
+        dep_key("e", "1.0.0"),
+        SnapshotEntry { dependencies: Some(e_deps), ..SnapshotEntry::default() },
+    );
+    let mut d_one_deps = HashMap::new();
+    d_one_deps.insert(pkg_name("m"), SnapshotDepRef::Plain(ver_peer("1.0.0")));
+    snapshots.insert(
+        dep_key("d", "1.0.0"),
+        SnapshotEntry { dependencies: Some(d_one_deps), ..SnapshotEntry::default() },
+    );
+    let mut s_one_deps = HashMap::new();
+    s_one_deps.insert(pkg_name("m"), SnapshotDepRef::Plain(ver_peer("2.0.0")));
+    snapshots.insert(
+        dep_key("s", "1.0.0"),
+        SnapshotEntry { dependencies: Some(s_one_deps), ..SnapshotEntry::default() },
+    );
+    for leaf in [("m", "1.0.0"), ("m", "2.0.0"), ("s", "2.0.0"), ("d", "2.0.0")] {
+        snapshots.insert(dep_key(leaf.0, leaf.1), SnapshotEntry::default());
+    }
+
+    let lockfile = Lockfile { importers, snapshots: Some(snapshots), ..empty_lockfile() };
+
+    let result = hoist(&lockfile, &HoistOpts::default()).expect("hoist should succeed");
+    let root_children = result.dependencies.borrow();
+    let node_e = &root_children.iter().find(|dep| dep.0.name == "e").unwrap().0;
+    let e_kids = node_e.dependencies.borrow();
+    assert!(
+        !e_kids.iter().any(|dep| dep.0.name == "m"),
+        "m@1 must not hoist onto e - s@1's requires resolve m through the root: {node_e:#?}",
+    );
+    let d_nested = &e_kids.iter().find(|dep| dep.0.name == "d").expect("d@1 nests under e").0;
+    let m_kept = d_nested
+        .dependencies
+        .borrow()
+        .iter()
+        .any(|dep| dep.0.name == "m" && dep.0.references.borrow().contains("m@1.0.0"));
+    assert!(m_kept, "d@1 keeps its own m@1 nested: {d_nested:#?}");
+}
+
 #[test]
 fn self_dependency_does_not_loop() {
     let mut importers = HashMap::new();
@@ -1432,6 +1597,7 @@ fn result_node(
         references: RefCell::new(BTreeSet::from([reference.to_string()])),
         peer_names: peer_names.iter().map(|&peer| peer.to_string()).collect(),
         dependencies: RefCell::new(dependencies.into_iter().map(RcByPtr).collect::<IndexSet<_>>()),
+        hoisted_dependencies: RefCell::new(std::collections::HashMap::new()),
         decoupled: std::cell::Cell::new(false),
     })
 }


### PR DESCRIPTION
With `node-linker=hoisted`, pacquet's hoister produced broken layouts on graphs with version conflicts. Validated against `@teambit/bit@2.0.82`'s published lockfile by checking the resolution of every (position, dependency) pair of the hoisted tree: **185 wrong resolutions on `main`, 0 with this PR** (plus one inherent ambiguity where two peer-variants of one package version pin different dependency versions due to lockfile drift — the TS CLI merges variants the same way). One real-world symptom: bit's own CI crashing with `ERR_IMPORT_ATTRIBUTE_MISSING` because a conflict-nested ESM `execa` resolved the root's CommonJS `npm-run-path@4` instead of its own `@5`.

### The fixes (all ports of `@yarnpkg/nm` behavior, which the TypeScript CLI delegates to)

1. **Per-path decisions on decoupled copies** (`decoupleGraphNode`): a version-conflicted package shared by several dependents kept its conflicting transitive deps under only one of them; requiring them through any other dependent resolved the wrong root-hoisted version (e.g. `parse-entities@4` → `character-entities-legacy` v1 instead of v3). Shared DAG nodes are now cloned into single-parent copies before mutation, so every parent path gets its own hoist and peer ruling. Same-node dedup and peer-shadow checks compare locators instead of `Rc` identity; cycle edges are cut per path via an aliased-locator guard (`name` + locator, mirroring `aliasedLocatorPath` — an alias edge exposing the same package under a different name is kept).
2. **Peer-variant collapse** (pnpm v11 wrapper's `depPathByPkgId`): peer-resolution variants of one package version now map to the first-seen snapshot key, so the hoister sees one locator per version and dedups the variants. Keeping distinct variant locators both nested wrong copies *and* made the per-path walk explode combinatorially — on bit's lockfile the hoister ran out of memory (2 GB in under 3 s before OOM; 37 MB / 100 ms after).
3. **Shadow gates** (`getNodeHoistInfo`'s "filled by parent" scan and `usedDependencies` gate, in the zero-round variant yarn always uses since it hardcodes `fastLookupPossible: true`): hoisting or dedup is refused when a nearer ancestor holds a different version of the candidate's name, or when the hoist root's subtree already resolves that name through an ancestor directory. Requires `hoisted_dependencies` bookkeeping (each node records what the hoist pass removed from it).

### Verification

- New regression tests for every mechanism: shared-node conflicting deps, cycle cutting, alias-repeat cycles, peer-variant collapse, ancestor-conflict dedup veto, nested-root used-dependency veto (each verified to fail without its fix).
- All `real-hoist` (31), `deps-restorer` (425), and hoisted-node-linker CLI suite (44) tests pass; fmt/clippy/rustdoc/dylint clean.
- End-to-end: the `parse-entities` fixture resolves correctly from every dependent, and replaying bvm's install of `@teambit/bit@2.0.82` (its published lockfile, `nodeLinker: hoisted`) with the fixed binary produces a layout with zero wrong resolutions, where `main` produces 185.

TS-side is unaffected: it uses yarn's hoister plus the `depPathByPkgId` mapping, which already behave this way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)