### PR TITLE
fix(update): key pacquet's update targets by the resolved package name

### DIFF
--- a/.changeset/update-versioned-selector-stays-targeted.md
+++ b/.changeset/update-versioned-selector-stays-targeted.md
@@ -4,4 +4,4 @@
 "pnpm": patch
 ---
 
-`pnpm update <pkg>@<version>` now updates only the selected packages and leaves unrelated dependencies unchanged. A selector that renames the package it installs — `pnpm update <alias>@npm:<pkg>@<version>` — now targets the aliased package rather than the alias.
+`pnpm update <pkg>@<version>` now updates only the selected packages and leaves unrelated dependencies unchanged. A selector that renames the package it installs — `pnpm update <alias>@npm:<pkg>@<version>` or the `jsr:` equivalent — now targets the package the alias installs rather than the alias.

--- a/.changeset/update-versioned-selector-stays-targeted.md
+++ b/.changeset/update-versioned-selector-stays-targeted.md
@@ -1,6 +1,7 @@
 ---
 "@pnpm/installing.commands": patch
+"pacquet": patch
 "pnpm": patch
 ---
 
-`pnpm update <pkg>@<version>` now updates only the selected packages and leaves unrelated dependencies unchanged.
+`pnpm update <pkg>@<version>` now updates only the selected packages and leaves unrelated dependencies unchanged. A selector that renames the package it installs — `pnpm update <alias>@npm:<pkg>@<version>` — now targets the aliased package rather than the alias.

--- a/pnpm/crates/cli/tests/suite/update.rs
+++ b/pnpm/crates/cli/tests/suite/update.rs
@@ -1123,6 +1123,35 @@ fn update_latest_no_save_catalog_bumps_lockfile_only() {
     drop((root, anchor));
 }
 
+/// A versioned `npm:` selector targets the package the alias installs, not
+/// the alias it is written at: update targets are keyed by the resolved
+/// package name, so keying them by the alias leaves the pin in place.
+#[test]
+fn update_npm_alias_selector_targets_the_aliased_package() {
+    let (root, workspace, anchor) = setup();
+
+    // Pin the aliased package at 100.0.0 through a direct exact entry,
+    // then drop the entry so the alias is the only thing holding it — its
+    // ^100.0.0 range a fresh resolve answers with 100.1.0.
+    write_manifest(
+        &workspace,
+        &format!(r#"{{ "dep-alias": "npm:{DEP}@^100.0.0", "{DEP}": "100.0.0" }}"#),
+    );
+    pacquet(&workspace, ["install"]).assert().success();
+    assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.0.0"));
+    write_manifest(&workspace, &format!(r#"{{ "dep-alias": "npm:{DEP}@^100.0.0" }}"#));
+
+    pacquet(&workspace, ["update", &format!("dep-alias@npm:{DEP}@^100.0.0")]).assert().success();
+
+    eprintln!("virtual store contents: {:?}", list_virtual_store(&workspace));
+    assert!(
+        virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.1.0"),
+        "the selector should have withheld the aliased package's pin",
+    );
+
+    drop((root, anchor));
+}
+
 /// The alias name does not exist in the mock registry.
 #[test]
 fn update_latest_npm_alias_resolves_aliased_package() {

--- a/pnpm/crates/cli/tests/suite/update_jsr.rs
+++ b/pnpm/crates/cli/tests/suite/update_jsr.rs
@@ -133,3 +133,37 @@ fn update_latest_bumps_an_aliased_jsr_dependency() {
 
     drop((root, anchor));
 }
+
+/// A versioned `jsr:` selector targets the npm package the alias installs
+/// (`@jsr/<scope>__<name>`), not the alias it is written at. Update targets
+/// are keyed by the resolved package name, so keying them by the alias
+/// leaves the locked resolution in place.
+#[test]
+fn update_jsr_alias_selector_targets_the_aliased_package() {
+    let (root, workspace, anchor) = setup();
+
+    // Pin the aliased package at 1.0.0 through an exact entry naming the
+    // npm package the alias installs, then drop that entry so the alias is
+    // the only thing holding it — its ^1.0.0 range a fresh resolve answers
+    // with 1.1.0.
+    write_manifest(
+        &workspace,
+        r#"{ "bar-from-jsr": "jsr:@pnpm-e2e/bar@^1.0.0", "@jsr/pnpm-e2e__bar": "1.0.0" }"#,
+    );
+    pacquet(&workspace, ["install"]).assert().success();
+    assert_eq!(
+        lockfile_entry(&workspace, "bar-from-jsr"),
+        Some(("jsr:@pnpm-e2e/bar@^1.0.0".to_string(), "@jsr/pnpm-e2e__bar@1.0.0".to_string())),
+    );
+    write_manifest(&workspace, r#"{ "bar-from-jsr": "jsr:@pnpm-e2e/bar@^1.0.0" }"#);
+
+    pacquet(&workspace, ["update", "bar-from-jsr@jsr:@pnpm-e2e/bar@^1.0.0"]).assert().success();
+
+    assert_eq!(
+        lockfile_entry(&workspace, "bar-from-jsr"),
+        Some(("jsr:@pnpm-e2e/bar@^1.0.0".to_string(), "@jsr/pnpm-e2e__bar@1.1.0".to_string())),
+        "the selector should have withheld the aliased package's pin",
+    );
+
+    drop((root, anchor));
+}

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -37,7 +37,7 @@ use pnpm_reporter::{
     LogEvent, LogLevel, PackageManifestLog, PackageManifestMessage, PnpmLog, Reporter,
 };
 use pnpm_resolving_default_resolver::DefaultResolver;
-use pnpm_resolving_deps_resolver::UpdateDepth;
+use pnpm_resolving_deps_resolver::{UpdateDepth, real_package_name_of};
 use pnpm_resolving_npm_resolver::{
     DeclaredSpecifiers, InMemoryPackageMetaCache, NpmResolver, calc_specifier_for_workspace_dep,
     merge_named_registries, shared_packument_fetch_locker, shared_picked_manifest_cache,
@@ -977,7 +977,7 @@ async fn prepare_manifest<Reporter: self::Reporter>(
                         requested
                     }
                 };
-                drop_names.insert(name.clone());
+                drop_names.insert(update_target_name(&selectors, name));
                 if let Some(specifier) = rewrite {
                     rewrites.push((name.clone(), *group, specifier));
                 }
@@ -1395,6 +1395,23 @@ fn judge_against_kept_range(requested: &str, kept: &str) -> KeptRangeVerdict {
         return KeptRangeVerdict::Undecided;
     };
     if requested.satisfies(&kept) { KeptRangeVerdict::Admitted } else { KeptRangeVerdict::Excluded }
+}
+
+/// The name an update target for `matched` is keyed by. A manifest keys a
+/// dependency by its alias, but the resolver matches update targets — and
+/// [`UpdateSeedPolicy::DropOnly`] keys them — by the package name the edge
+/// resolves under, which an `npm:` or `jsr:` selector states separately from
+/// the alias. Falls back to the alias, which is the name for every other
+/// selector shape.
+fn update_target_name(selectors: &[ParsedSelector], matched: &str) -> String {
+    selectors
+        .iter()
+        .filter(|selector| matcher_one(&selector.pattern).matches(matched))
+        .filter_map(|selector| {
+            real_package_name_of(Some(matched), Some(selector.version.as_deref()?))
+        })
+        .find(|name| name.as_ref() != matched)
+        .map_or_else(|| matched.to_string(), std::borrow::Cow::into_owned)
 }
 
 /// Compile a single pattern into a matcher. Used to map a matched direct

--- a/pnpm/crates/package-manager/src/update/tests.rs
+++ b/pnpm/crates/package-manager/src/update/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     KeptRangeVerdict, apply_bumped_manifest_specs, is_workspace_local_path_specifier,
     judge_against_kept_range, parse_update_param, persist_selected_manifests,
-    prepare_selected_manifests, selected_project_indices,
+    prepare_selected_manifests, selected_project_indices, update_target_name,
 };
 use pnpm_config::{CatalogMode, Config};
 use pnpm_network::ThrottledClient;
@@ -59,6 +59,38 @@ fn negated_unscoped_pattern_without_version() {
     let parsed = parse_update_param("!foo");
     assert_eq!(parsed.pattern, "!foo");
     assert_eq!(parsed.version, None);
+}
+
+#[test]
+fn an_npm_alias_selector_targets_the_aliased_package_name() {
+    let selectors = vec![parse_update_param("alias@npm:@scope/real@^1.0.0")];
+    assert_eq!(update_target_name(&selectors, "alias"), "@scope/real");
+}
+
+#[test]
+fn a_versioned_selector_without_an_alias_targets_the_name_it_names() {
+    let selectors = vec![parse_update_param("foo@^1.0.0")];
+    assert_eq!(update_target_name(&selectors, "foo"), "foo");
+}
+
+#[test]
+fn an_npm_selector_carrying_only_a_range_keeps_the_alias() {
+    let selectors = vec![parse_update_param("foo@npm:^1.0.0")];
+    assert_eq!(update_target_name(&selectors, "foo"), "foo");
+}
+
+#[test]
+fn a_bare_selector_targets_the_name_it_names() {
+    let selectors = vec![parse_update_param("foo")];
+    assert_eq!(update_target_name(&selectors, "foo"), "foo");
+}
+
+#[test]
+fn a_wildcard_selector_does_not_shadow_an_alias_selector_that_also_matches() {
+    let selectors =
+        vec![parse_update_param("*"), parse_update_param("alias@npm:@scope/real@^1.0.0")];
+    assert_eq!(update_target_name(&selectors, "alias"), "@scope/real");
+    assert_eq!(update_target_name(&selectors, "other"), "other");
 }
 
 #[test]

--- a/pnpm/crates/package-manager/src/update/tests.rs
+++ b/pnpm/crates/package-manager/src/update/tests.rs
@@ -68,6 +68,12 @@ fn an_npm_alias_selector_targets_the_aliased_package_name() {
 }
 
 #[test]
+fn a_jsr_alias_selector_targets_the_npm_package_name_it_installs() {
+    let selectors = vec![parse_update_param("bar-from-jsr@jsr:@pnpm-e2e/bar@^1.0.0")];
+    assert_eq!(update_target_name(&selectors, "bar-from-jsr"), "@jsr/pnpm-e2e__bar");
+}
+
+#[test]
 fn a_versioned_selector_without_an_alias_targets_the_name_it_names() {
     let selectors = vec![parse_update_param("foo@^1.0.0")];
     assert_eq!(update_target_name(&selectors, "foo"), "foo");

--- a/pnpm/crates/resolving-deps-resolver/src/lib.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/lib.rs
@@ -95,7 +95,7 @@ pub use resolve_dependency_tree::{
     Deprecation, DeprecationLogFn, ManifestHook, ResolveDependencyTreeError,
     ResolveDependencyTreeOptions, SkippedOptionalDependency, SkippedOptionalDependencyParent,
     SkippedOptionalLogFn, TreeCtx, UpdateDepth, UpdateReuseScope, WorkspaceTreeCtx, extend_tree,
-    resolve_dependency_tree,
+    real_package_name_of, resolve_dependency_tree,
 };
 pub use resolve_importer::{
     ResolveImporterError, ResolveImporterOptions, ResolveImporterResult, resolve_importer,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -30,6 +30,7 @@ mod workspace_ctx;
 #[cfg(test)]
 mod test_support;
 
+pub use reuse::real_package_name_of;
 pub use tree_ctx::TreeCtx;
 pub use workspace_ctx::WorkspaceTreeCtx;
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/reuse.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/reuse.rs
@@ -372,7 +372,7 @@ pub(crate) fn unwrap_package_name<'a>(
 ///
 /// `None` when no name can be recovered; the caller reads that as "not
 /// a targeted update", since update targets are keyed by package name.
-pub(super) fn real_package_name_of<'edge>(
+pub fn real_package_name_of<'edge>(
     alias: Option<&'edge str>,
     bare_specifier: Option<&'edge str>,
 ) -> Option<Cow<'edge, str>> {


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Follow-up to pnpm/pnpm#13826, which landed the TypeScript half of this fix while the Rust half was still being verified. This is the pacquet port; nothing else changed.

`pacquet update <alias>@npm:<pkg>@<range>` left the aliased package on its locked resolution. Matched direct dependencies go into `drop_names` under their **manifest key**, which for an aliased dependency is the alias — but `is_update_target` matches `real_package_name_of(..)` and `subtree_fully_reusable` matches `key.name`, both of which are the **resolved** package name. So an aliased package never matched its own drop entry, its pin was never withheld, and the update was a no-op.

`update_target_name` derives the drop name from the selector that claimed the dependency, so an `npm:` (or `jsr:`) selector contributes the package it actually installs. It skips a selector whose derived name is just the alias again, so an earlier `*` cannot shadow a later `<alias>@npm:<pkg>` — the `requested` lookup beside it takes the first match and would otherwise miss the expansion.

`real_package_name_of` is promoted to the resolver crate's public API rather than reimplemented. It is the function the reuse matching already keys on, and it carries the `npm:<range>`-keeps-the-alias and `jsr:` cases that a second parser would have to duplicate.

This also amends the changeset still pending from pnpm/pnpm#13826 so it names `pacquet` and describes the alias behavior, instead of adding a second changeset for the same user-visible change.

Related to pnpm/pnpm#13825.

### Verification

- `update_npm_alias_selector_targets_the_aliased_package` pins the aliased package at `100.0.0` through a direct exact entry, drops that entry so only the alias holds it, then runs the selector and asserts it moves to `100.1.0`. Verified to fail without the fix, with its own message (`the selector should have withheld the aliased package's pin`).
- Five unit tests cover the name derivation: npm alias, plain versioned selector, `npm:` carrying only a range, bare selector, and the wildcard-shadowing case.
- `update` CLI suite 79/79, `update::tests` 26/26, `clippy -D warnings` and a cold `cargo doc --document-private-items` both clean.

### Known residual gap

A **bare** alias selector — `pnpm update <alias>` with no version — still misses the aliased package, in both stacks. The selector alone carries no `npm:` spec, so neither stack can map the alias to its real name without consulting the manifest. Pre-existing and out of scope here.

## Squash Commit Body

```text
`pacquet update <alias>@npm:<pkg>@<range>` left the aliased package on its
pin: the matched direct dependencies went into `drop_names` under their
manifest key, which is the alias, while `is_update_target` matches
`real_package_name_of(..)` and `subtree_fully_reusable` matches `key.name`
— both the resolved package name. An aliased package therefore never
matched its own drop entry and kept its seeded resolution.

`update_target_name` derives the name from the selector that claimed the
dependency, so an `npm:` (or `jsr:`) selector contributes the package it
installs. It skips a selector whose derived name is just the alias again,
so an earlier `*` cannot shadow a later `<alias>@npm:<pkg>` — the
`requested` lookup beside it takes the first match and would have missed
the expansion.

`real_package_name_of` is promoted to the resolver crate's public API
rather than reimplemented: it is the function the reuse matching already
keys on, and it carries the `npm:<range>`-keeps-the-alias and `jsr:`
cases a second parser would have to repeat.

The changeset pending from pnpm/pnpm#13826 is amended to name `pacquet`
and describe the alias behavior, rather than adding a second changeset
for the same user-visible change.

Test: `update_npm_alias_selector_targets_the_aliased_package` pins the
aliased package through a direct exact entry, drops the entry so only the
alias holds it, and asserts the selector moves it — verified to fail
without the fix. Five unit tests cover the name derivation.

Follow-up to pnpm/pnpm#13826. Related to pnpm/pnpm#13825.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. _(The TypeScript half landed in pnpm/pnpm#13826; this is the Rust half.)_
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed. _(No user-facing CLI change — the behavior now matches what the docs already describe.)_

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14040"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789846099&installation_model_id=426870&pr_number=14040&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14040&signature=07f8fd5e5e658ab86482a35663e7a0ed297c9a1ce63a3b76d47ae9d7ef266ac8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed updates for aliased package selectors so versioned `npm:` and `jsr:` dependencies update the underlying package correctly.
  * Preserved expected behavior for bare, range-based, and wildcard alias selectors.

* **Tests**
  * Added coverage for aliased dependency updates and selector matching scenarios.

* **Documentation**
  * Updated release notes to document targeted updates for aliased package selectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->