### PR TITLE
feat(config): show the settings pnpm acts on via config get/list

### DIFF
--- a/.changeset/config-get-resolved-registries.md
+++ b/.changeset/config-get-resolved-registries.md
@@ -1,0 +1,12 @@
+---
+"@pnpm/config.normalize-registries": minor
+"@pnpm/config.reader": minor
+"@pnpm/config.commands": minor
+"pnpm": minor
+"pacquet": minor
+---
+
+`pnpm config get` and `pnpm config list` now show the settings pnpm acts on under their documented names:
+
+- `registries` shows the registries pnpm resolves from, merged across every source (`.npmrc`, `pnpm-workspace.yaml`, the global config, CLI flags), in the shape the setting is written in: keyed by registry URL, with the default registry declared as the bare `@` scope. Previously `pnpm config get registries` printed `undefined`.
+- `update` and `audit` show the effective sections, whichever spelling set them. The deprecated internal spellings (`updateConfig`, `auditConfig`, `auditLevel`) are no longer listed.

--- a/.changeset/config-get-resolved-registries.md
+++ b/.changeset/config-get-resolved-registries.md
@@ -8,5 +8,5 @@
 
 `pnpm config get` and `pnpm config list` now show the settings pnpm acts on under their documented names:
 
-- `registries` shows the registries pnpm resolves from, merged across every source (`.npmrc`, `pnpm-workspace.yaml`, the global config, CLI flags), in the shape the setting is written in: keyed by registry URL, with the default registry declared as the bare `@` scope. Previously `pnpm config get registries` printed `undefined`.
+- `registries` shows the registries pnpm resolves from, merged across every source (`.npmrc`, `pnpm-workspace.yaml`, the global config, CLI flags), in the shape the setting is written in: keyed by registry URL, with the default registry declared as the bare `@` scope. Built-in routes are included — the `@jsr` scope and the `npmjs` and `gh` prefixes — unless pointed elsewhere. Previously `pnpm config get registries` printed `undefined`.
 - `update` and `audit` show the effective sections, whichever spelling set them. The deprecated internal spellings (`updateConfig`, `auditConfig`, `auditLevel`) are no longer listed.

--- a/.changeset/config-get-resolved-registries.md
+++ b/.changeset/config-get-resolved-registries.md
@@ -10,3 +10,5 @@
 
 - `registries` shows the registries pnpm resolves from, merged across every source (`.npmrc`, `pnpm-workspace.yaml`, the global config, CLI flags), in the shape the setting is written in: keyed by registry URL, with the default registry declared as the bare `@` scope. Built-in routes are included — the `@jsr` scope and the `npmjs` and `gh` prefixes — unless pointed elsewhere. Previously `pnpm config get registries` printed `undefined`.
 - `update` and `audit` show the effective sections, whichever spelling set them. The deprecated internal spellings (`updateConfig`, `auditConfig`, `auditLevel`) are no longer listed.
+- `catalogs` shows the complete resolved catalog set — the singular `catalog` block is its `default` entry — whichever spelling declared it.
+- The `registry` and `@scope:registry` entries show the merged routes rather than raw `.npmrc` values, so they always agree with the `registries` view.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2278,6 +2278,9 @@ importers:
       '@pnpm/cli.utils':
         specifier: workspace:*
         version: link:../../cli/utils
+      '@pnpm/config.normalize-registries':
+        specifier: workspace:*
+        version: link:../normalize-registries
       '@pnpm/config.reader':
         specifier: workspace:*
         version: link:../reader

--- a/pnpm/crates/cli/src/cli_args/config.rs
+++ b/pnpm/crates/cli/src/cli_args/config.rs
@@ -19,7 +19,8 @@ use derive_more::{Display, Error};
 use indexmap::IndexMap;
 use miette::Diagnostic;
 use pnpm_config::{
-    Config, GLOBAL_CONFIG_YAML_FILENAME, WORKSPACE_MANIFEST_FILENAME, config_types, naming_cases,
+    Config, DEFAULT_JSR_REGISTRY, GLOBAL_CONFIG_YAML_FILENAME, WORKSPACE_MANIFEST_FILENAME,
+    config_types, naming_cases,
     property_path::{self, Segment},
     protected_settings,
 };
@@ -477,6 +478,35 @@ fn config_get(config: &Config, flags: ConfigFlags, key: &str) -> Result<String, 
     Ok(display_config(&value, flags.json))
 }
 
+/// pnpm resolves relative patch paths against the workspace root when it
+/// reads the setting, so its record shows the resolved paths; pacquet keeps
+/// them as written and resolves lazily — mirror the resolved display.
+fn absolutize_patch_paths(result: &mut Map<String, Value>, config: &Config) {
+    let Some(workspace_dir) = &config.workspace_dir else { return };
+    let Some(Value::Object(patched)) = result.get_mut("patchedDependencies") else { return };
+    for value in patched.values_mut() {
+        if let Value::String(path) = value
+            && !Path::new(path.as_str()).is_absolute()
+        {
+            *value =
+                Value::String(workspace_dir.join(path.as_str()).to_string_lossy().into_owned());
+        }
+    }
+}
+
+/// The singular `catalog` block is the `default` catalog, so when the record
+/// carries a `catalogs` map it is shown merged, the way the resolver reads it.
+fn merge_default_catalog(result: &mut Map<String, Value>) {
+    let Some(Value::Object(named)) = result.get("catalogs") else { return };
+    let Some(default) = result.get("catalog") else { return };
+    let mut merged = Map::new();
+    merged.insert("default".to_string(), default.clone());
+    for (name, catalog) in named {
+        merged.insert(name.clone(), catalog.clone());
+    }
+    result.insert("catalogs".to_string(), Value::Object(merged));
+}
+
 /// `configList`: the full config record as pretty JSON. Port of `configList`.
 fn config_list(config: &Config) -> String {
     serde_json::to_string_pretty(&Value::Object(config_to_record(config)))
@@ -493,6 +523,10 @@ fn lookup_config(config: &Config, key: &str, is_scoped: bool) -> Option<Value> {
             // resolvers/publish use (pnpm/pnpm#11492).
             if let Some(merged) = config.registries_by_scope.get(scope) {
                 return Some(Value::String(merged.clone()));
+            }
+            // The built-in `@jsr` route, which pnpm merges into its scope map.
+            if scope == "@jsr" && !config.raw_auth_config.contains_key(key) {
+                return Some(Value::String(DEFAULT_JSR_REGISTRY.to_string()));
             }
         }
         return Some(auth_value(config, key));
@@ -517,6 +551,11 @@ fn lookup_config(config: &Config, key: &str, is_scoped: bool) -> Option<Value> {
         }
         if let Some(value) = config.raw_auth_config.get(&kebab) {
             return Some(Value::String(value.clone()));
+        }
+        // npm-conf seeds `registry` into pnpm's raw auth config, so pnpm
+        // answers the built-in default rather than `undefined`.
+        if kebab == "registry" {
+            return Some(Value::String(pnpm_config::default_registry()));
         }
         return Some(Value::Null);
     }
@@ -589,14 +628,51 @@ fn plain_string(value: &Value) -> String {
 /// `configToRecord`: build the camelCase record shown by `list` / `get` — the
 /// explicitly-set settings, then the raw auth keys (original casing), then
 /// `userAgent` — sorted by key and with protected settings censored.
+/// `registries` is always present and holds the resolved view: the registries
+/// the CLI resolves from, merged across every source, in place of the raw
+/// `registries` / `namedRegistries` values a single source set.
 fn config_to_record(config: &Config) -> Map<String, Value> {
     let mut result: Map<String, Value> = Map::new();
     for (key, value) in &config.explicit_settings {
         result.insert(key.clone(), value.clone());
     }
+    result.remove("namedRegistries");
+    result.insert(
+        "registries".to_string(),
+        serde_json::to_value(config.resolved_registry_declarations())
+            .expect("serializing registry declarations to JSON never fails"),
+    );
+    // Likewise the raw `update` / `audit` sections and their deprecated
+    // spellings: the record shows the settings the CLI acts on, re-joined
+    // under the documented names.
+    for key in ["update", "updateConfig", "audit", "auditConfig", "auditLevel"] {
+        result.remove(key);
+    }
+    if let Some(update) = config.resolved_update_settings() {
+        result.insert(
+            "update".to_string(),
+            serde_json::to_value(update).expect("serializing update settings to JSON never fails"),
+        );
+    }
+    if let Some(audit) = config.resolved_audit_settings() {
+        result.insert(
+            "audit".to_string(),
+            serde_json::to_value(audit).expect("serializing audit settings to JSON never fails"),
+        );
+    }
+    merge_default_catalog(&mut result);
+    absolutize_patch_paths(&mut result, config);
     for (key, value) in &config.raw_auth_config {
         result.entry(key.clone()).or_insert_with(|| Value::String(value.clone()));
     }
+    // npm-conf seeds these two into pnpm's raw auth config, so its record
+    // always carries them.
+    result
+        .entry("registry".to_string())
+        .or_insert_with(|| Value::String(pnpm_config::default_registry()));
+    result
+        .entry("@jsr:registry".to_string())
+        .or_insert_with(|| Value::String(DEFAULT_JSR_REGISTRY.to_string()));
     if !config.user_agent.is_empty() {
         result.insert("userAgent".to_string(), Value::String(config.user_agent.clone()));
     }

--- a/pnpm/crates/cli/src/cli_args/config.rs
+++ b/pnpm/crates/cli/src/cli_args/config.rs
@@ -494,17 +494,29 @@ fn absolutize_patch_paths(result: &mut Map<String, Value>, config: &Config) {
     }
 }
 
-/// The singular `catalog` block is the `default` catalog, so when the record
-/// carries a `catalogs` map it is shown merged, the way the resolver reads it.
+/// `catalogs` shows the complete resolved catalog set — the singular
+/// `catalog` block is its `default` entry, listed first — whichever spelling
+/// declared it.
 fn merge_default_catalog(result: &mut Map<String, Value>) {
-    let Some(Value::Object(named)) = result.get("catalogs") else { return };
-    let Some(default) = result.get("catalog") else { return };
+    let named = match result.get("catalogs") {
+        Some(Value::Object(named)) => named.clone(),
+        _ => Map::new(),
+    };
+    let default = result.get("catalog").or_else(|| named.get("default")).cloned();
     let mut merged = Map::new();
-    merged.insert("default".to_string(), default.clone());
-    for (name, catalog) in named {
-        merged.insert(name.clone(), catalog.clone());
+    if let Some(default) = default {
+        merged.insert("default".to_string(), default);
     }
-    result.insert("catalogs".to_string(), Value::Object(merged));
+    for (name, catalog) in named {
+        if name != "default" {
+            merged.insert(name, catalog);
+        }
+    }
+    if merged.is_empty() {
+        result.remove("catalogs");
+    } else {
+        result.insert("catalogs".to_string(), Value::Object(merged));
+    }
 }
 
 /// `configList`: the full config record as pretty JSON. Port of `configList`.
@@ -544,6 +556,12 @@ fn lookup_config(config: &Config, key: &str, is_scoped: bool) -> Option<Value> {
     } else {
         key.to_string()
     };
+    // The merged default is what resolvers use, so `registry` answers the
+    // same URL the resolved `registries` view declares as the bare `@`
+    // scope — a raw `.npmrc` value would contradict it.
+    if kebab == "registry" {
+        return Some(Value::String(config.registry.clone()));
+    }
     if config_types::is_type_key(&kebab) {
         let camel = naming_cases::to_camel_case(&kebab);
         if let Some(value) = config.explicit_settings.get(&camel) {
@@ -551,11 +569,6 @@ fn lookup_config(config: &Config, key: &str, is_scoped: bool) -> Option<Value> {
         }
         if let Some(value) = config.raw_auth_config.get(&kebab) {
             return Some(Value::String(value.clone()));
-        }
-        // npm-conf seeds `registry` into pnpm's raw auth config, so pnpm
-        // answers the built-in default rather than `undefined`.
-        if kebab == "registry" {
-            return Some(Value::String(pnpm_config::default_registry()));
         }
         return Some(Value::Null);
     }
@@ -665,11 +678,15 @@ fn config_to_record(config: &Config) -> Map<String, Value> {
     for (key, value) in &config.raw_auth_config {
         result.entry(key.clone()).or_insert_with(|| Value::String(value.clone()));
     }
-    // npm-conf seeds these two into pnpm's raw auth config, so its record
-    // always carries them.
-    result
-        .entry("registry".to_string())
-        .or_insert_with(|| Value::String(pnpm_config::default_registry()));
+    // The `registry` / `@scope:registry` rows show the merged routes — the
+    // values `config get` answers — so a raw `.npmrc` row cannot contradict
+    // the resolved `registries` view.
+    result.insert("registry".to_string(), Value::String(config.registry.clone()));
+    for (scope, url) in &config.registries_by_scope {
+        if scope != "default" {
+            result.insert(format!("{scope}:registry"), Value::String(url.clone()));
+        }
+    }
     result
         .entry("@jsr:registry".to_string())
         .or_insert_with(|| Value::String(DEFAULT_JSR_REGISTRY.to_string()));

--- a/pnpm/crates/cli/src/cli_args/config.rs
+++ b/pnpm/crates/cli/src/cli_args/config.rs
@@ -498,8 +498,8 @@ fn absolutize_patch_paths(result: &mut Map<String, Value>, config: &Config) {
 /// `catalog` block is its `default` entry, listed first — whichever spelling
 /// declared it.
 fn merge_default_catalog(result: &mut Map<String, Value>) {
-    let named = match result.get("catalogs") {
-        Some(Value::Object(named)) => named.clone(),
+    let named = match result.remove("catalogs") {
+        Some(Value::Object(named)) => named,
         _ => Map::new(),
     };
     let default = result.get("catalog").or_else(|| named.get("default")).cloned();
@@ -512,9 +512,7 @@ fn merge_default_catalog(result: &mut Map<String, Value>) {
             merged.insert(name, catalog);
         }
     }
-    if merged.is_empty() {
-        result.remove("catalogs");
-    } else {
+    if !merged.is_empty() {
         result.insert("catalogs".to_string(), Value::Object(merged));
     }
 }

--- a/pnpm/crates/cli/src/cli_args/config/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/config/tests.rs
@@ -599,7 +599,10 @@ fn get_registries_returns_resolved_declarations() {
         )
         .unwrap(),
         json!({
+            "https://npm.jsr.io/": { "scopes": ["@jsr"] },
+            "https://npm.pkg.github.com/": { "prefix": "gh" },
             "https://registry.example.com/": { "scopes": ["@"] },
+            "https://registry.npmjs.org/": { "prefix": "npmjs" },
             "https://work.example.com/": {
                 "serverType": "artifactory",
                 "scopes": ["@corp"],
@@ -626,7 +629,10 @@ fn list_rejoins_registry_lookups_under_registries() {
     assert_eq!(
         listed["registries"],
         json!({
+            "https://npm.jsr.io/": { "scopes": ["@jsr"] },
+            "https://npm.pkg.github.com/": { "prefix": "gh" },
             "https://registry.example.com/": { "scopes": ["@"] },
+            "https://registry.npmjs.org/": { "prefix": "npmjs" },
             "https://work.example.com/": { "prefix": "work" },
         }),
     );

--- a/pnpm/crates/cli/src/cli_args/config/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/config/tests.rs
@@ -554,6 +554,154 @@ fn get_scoped_registry_from_auth_and_merged() {
     );
 }
 
+/// npm-conf seeds `registry` and `@jsr:registry` into pnpm's raw auth
+/// config, so pnpm answers the built-in defaults rather than `undefined`.
+#[test]
+fn get_registry_and_jsr_fall_back_to_the_builtin_defaults() {
+    let config = config_for_get(&[], &[]);
+    assert_eq!(
+        config_get(&config, flags(false, None, false), "registry").unwrap(),
+        "https://registry.npmjs.org/",
+    );
+    assert_eq!(
+        config_get(&config, flags(false, None, false), "@jsr:registry").unwrap(),
+        "https://npm.jsr.io/",
+    );
+
+    let listed: Value = serde_json::from_str(&config_list(&config)).unwrap();
+    assert_eq!(listed["registry"], json!("https://registry.npmjs.org/"));
+    assert_eq!(listed["@jsr:registry"], json!("https://npm.jsr.io/"));
+
+    // A raw `.npmrc` value wins over the built-in default.
+    let overridden = config_for_get(&[], &[("registry", "https://from-npmrc.example.com/")]);
+    assert_eq!(
+        config_get(&overridden, flags(false, None, false), "registry").unwrap(),
+        "https://from-npmrc.example.com/",
+    );
+}
+
+#[test]
+fn get_registries_returns_resolved_declarations() {
+    let mut config = config_for_get(&[], &[]);
+    config.registry = "https://registry.example.com/".to_string();
+    config.registries_by_scope.insert("@corp".to_string(), "https://work.example.com/".to_string());
+    config.registries_by_prefix.insert("work".to_string(), "https://work.example.com/".to_string());
+    config.registry_options_by_url.insert(
+        "https://work.example.com/".to_string(),
+        pnpm_lockfile::RegistryOptions {
+            server_type: Some(pnpm_lockfile::RegistryServerType::Artifactory),
+            ..Default::default()
+        },
+    );
+    assert_eq!(
+        serde_json::from_str::<Value>(
+            &config_get(&config, flags(false, None, false), "registries").unwrap()
+        )
+        .unwrap(),
+        json!({
+            "https://registry.example.com/": { "scopes": ["@"] },
+            "https://work.example.com/": {
+                "serverType": "artifactory",
+                "scopes": ["@corp"],
+                "prefix": "work",
+            },
+        }),
+    );
+}
+
+/// The record shows the resolved registries view in place of the raw
+/// `registries` / `namedRegistries` values a source set.
+#[test]
+fn list_rejoins_registry_lookups_under_registries() {
+    let mut config = config_for_get(
+        &[
+            ("registries", json!({ "default": "https://registry.example.com/" })),
+            ("namedRegistries", json!({ "work": "https://work.example.com/" })),
+        ],
+        &[],
+    );
+    config.registry = "https://registry.example.com/".to_string();
+    config.registries_by_prefix.insert("work".to_string(), "https://work.example.com/".to_string());
+    let listed: Value = serde_json::from_str(&config_list(&config)).unwrap();
+    assert_eq!(
+        listed["registries"],
+        json!({
+            "https://registry.example.com/": { "scopes": ["@"] },
+            "https://work.example.com/": { "prefix": "work" },
+        }),
+    );
+    assert_eq!(listed.get("namedRegistries"), None);
+}
+
+#[test]
+fn get_update_and_audit_return_resolved_settings() {
+    let mut config = config_for_get(
+        &[
+            ("update", json!({ "ignoreDeps": ["webpack"], "changeset": true })),
+            ("updateConfig", json!({ "ignoreDependencies": ["webpack"] })),
+            ("auditConfig", json!({ "ignoreGhsas": ["GHSA-xxxx-yyyy-zzzz"] })),
+            ("auditLevel", json!("high")),
+        ],
+        &[],
+    );
+    config.update_config.ignore_dependencies = Some(vec!["webpack".to_string()]);
+    config.update_config.changeset = Some(true);
+    config.audit_level = Some(pnpm_config::AuditLevel::High);
+    config.audit_config.ignore_ghsas = vec!["GHSA-xxxx-yyyy-zzzz".to_string()];
+
+    assert_eq!(
+        serde_json::from_str::<Value>(
+            &config_get(&config, flags(false, None, false), "update").unwrap()
+        )
+        .unwrap(),
+        json!({ "ignoreDeps": ["webpack"], "changeset": true }),
+    );
+    assert_eq!(
+        serde_json::from_str::<Value>(
+            &config_get(&config, flags(false, None, false), "audit").unwrap()
+        )
+        .unwrap(),
+        json!({ "level": "high", "ignore": ["GHSA-xxxx-yyyy-zzzz"] }),
+    );
+
+    // The deprecated internal spellings are no longer part of the record;
+    // `audit-level` still answers because it is a `types` key.
+    for deprecated_key in ["updateConfig", "auditConfig"] {
+        assert_eq!(
+            config_get(&config, flags(false, None, false), deprecated_key).unwrap(),
+            "undefined",
+            "{deprecated_key}",
+        );
+    }
+    assert_eq!(config_get(&config, flags(false, None, false), "audit-level").unwrap(), "high");
+    let listed: Value = serde_json::from_str(&config_list(&config)).unwrap();
+    assert_eq!(listed.get("auditLevel"), None);
+}
+
+#[test]
+fn list_merges_the_default_catalog_into_catalogs() {
+    let config = config_for_get(
+        &[
+            ("packages", json!(["."])),
+            ("catalog", json!({ "react": "^19.0.0" })),
+            ("catalogs", json!({ "react17": { "react": "^17.0.0" } })),
+            ("onlyBuiltDependencies", json!(["esbuild"])),
+        ],
+        &[],
+    );
+    let listed: Value = serde_json::from_str(&config_list(&config)).unwrap();
+    assert_eq!(listed["packages"], json!(["."]));
+    assert_eq!(listed["catalog"], json!({ "react": "^19.0.0" }));
+    assert_eq!(
+        listed["catalogs"],
+        json!({
+            "default": { "react": "^19.0.0" },
+            "react17": { "react": "^17.0.0" },
+        }),
+    );
+    assert_eq!(listed["onlyBuiltDependencies"], json!(["esbuild"]));
+}
+
 #[test]
 fn get_globalconfig_path() {
     let config = config_for_get(&[], &[]);

--- a/pnpm/crates/cli/src/cli_args/config/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/config/tests.rs
@@ -554,10 +554,10 @@ fn get_scoped_registry_from_auth_and_merged() {
     );
 }
 
-/// npm-conf seeds `registry` and `@jsr:registry` into pnpm's raw auth
-/// config, so pnpm answers the built-in defaults rather than `undefined`.
+/// `registry` and `@jsr:registry` answer the merged routes — the built-in
+/// defaults when nothing routes them elsewhere — rather than `undefined`.
 #[test]
-fn get_registry_and_jsr_fall_back_to_the_builtin_defaults() {
+fn get_registry_and_jsr_answer_the_merged_routes() {
     let config = config_for_get(&[], &[]);
     assert_eq!(
         config_get(&config, flags(false, None, false), "registry").unwrap(),
@@ -572,12 +572,17 @@ fn get_registry_and_jsr_fall_back_to_the_builtin_defaults() {
     assert_eq!(listed["registry"], json!("https://registry.npmjs.org/"));
     assert_eq!(listed["@jsr:registry"], json!("https://npm.jsr.io/"));
 
-    // A raw `.npmrc` value wins over the built-in default.
-    let overridden = config_for_get(&[], &[("registry", "https://from-npmrc.example.com/")]);
+    // The resolved default — wherever it was routed from — wins over a raw
+    // `.npmrc` row, so `get` and `list` cannot contradict the `registries`
+    // view.
+    let mut routed = config_for_get(&[], &[("registry", "https://from-npmrc.example.com/")]);
+    routed.registry = "https://from-workspace-yaml.example.com/".to_string();
     assert_eq!(
-        config_get(&overridden, flags(false, None, false), "registry").unwrap(),
-        "https://from-npmrc.example.com/",
+        config_get(&routed, flags(false, None, false), "registry").unwrap(),
+        "https://from-workspace-yaml.example.com/",
     );
+    let listed: Value = serde_json::from_str(&config_list(&routed)).unwrap();
+    assert_eq!(listed["registry"], json!("https://from-workspace-yaml.example.com/"));
 }
 
 #[test]
@@ -610,6 +615,11 @@ fn get_registries_returns_resolved_declarations() {
             },
         }),
     );
+
+    // The npm-compat rows agree with the resolved view.
+    let listed: Value = serde_json::from_str(&config_list(&config)).unwrap();
+    assert_eq!(listed["registry"], json!("https://registry.example.com/"));
+    assert_eq!(listed["@corp:registry"], json!("https://work.example.com/"));
 }
 
 /// The record shows the resolved registries view in place of the raw
@@ -706,6 +716,23 @@ fn list_merges_the_default_catalog_into_catalogs() {
         }),
     );
     assert_eq!(listed["onlyBuiltDependencies"], json!(["esbuild"]));
+}
+
+/// The resolved `catalogs` view answers whichever spelling declared a
+/// catalog: the singular `catalog` block alone still shows up as `default`.
+#[test]
+fn catalogs_resolve_from_the_singular_catalog_alone() {
+    let config = config_for_get(&[("catalog", json!({ "react": "^19.0.0" }))], &[]);
+    assert_eq!(
+        serde_json::from_str::<Value>(
+            &config_get(&config, flags(false, None, false), "catalogs").unwrap()
+        )
+        .unwrap(),
+        json!({ "default": { "react": "^19.0.0" } }),
+    );
+
+    let empty = config_for_get(&[], &[]);
+    assert_eq!(config_get(&empty, flags(false, None, false), "catalogs").unwrap(), "undefined");
 }
 
 #[test]

--- a/pnpm/crates/config/src/defaults.rs
+++ b/pnpm/crates/config/src/defaults.rs
@@ -228,6 +228,10 @@ pub fn default_registry() -> String {
     "https://registry.npmjs.org/".to_string()
 }
 
+/// The registry the built-in `@jsr` scope routes to when the user has not
+/// pointed it elsewhere.
+pub const DEFAULT_JSR_REGISTRY: &str = "https://npm.jsr.io/";
+
 pub fn default_modules_cache_max_age() -> u64 {
     10080
 }

--- a/pnpm/crates/config/src/defaults.rs
+++ b/pnpm/crates/config/src/defaults.rs
@@ -232,6 +232,23 @@ pub fn default_registry() -> String {
 /// pointed it elsewhere.
 pub const DEFAULT_JSR_REGISTRY: &str = "https://npm.jsr.io/";
 
+/// Built-in named-registry aliases the resolver recognizes
+/// out of the box.
+///
+/// `npmjs` is here so a dependency can be pinned to the public
+/// registry even when `registry` points somewhere else, such as an
+/// internal proxy. The `npm` prefix cannot serve that purpose: it is
+/// reserved for the alias protocol (`npm:<name>@<range>`), which
+/// resolves through the default registry.
+///
+/// These URLs are also the prefixes the npm verifier's
+/// `named_registry_tarball_prefixes` matches a recorded tarball URL
+/// against, so an org that proxies
+/// npmjs should point `npmjs` at their proxy to keep verification
+/// going there rather than to the public host.
+pub const BUILTIN_REGISTRIES_BY_PREFIX: &[(&str, &str)] =
+    &[("gh", "https://npm.pkg.github.com/"), ("npmjs", "https://registry.npmjs.org/")];
+
 pub fn default_modules_cache_max_age() -> u64 {
     10080
 }

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -41,8 +41,8 @@ use std::{
 };
 
 pub use crate::defaults::{
-    DEFAULT_JSR_REGISTRY, GLOBAL_LAYOUT_VERSION, PNPM_VERSION, available_parallelism,
-    default_cache_dir, default_config_dir, default_git_shallow_hosts,
+    BUILTIN_REGISTRIES_BY_PREFIX, DEFAULT_JSR_REGISTRY, GLOBAL_LAYOUT_VERSION, PNPM_VERSION,
+    available_parallelism, default_cache_dir, default_config_dir, default_git_shallow_hosts,
     default_peers_suffix_max_length, default_pnpm_home_dir, default_registry, default_state_dir,
     default_unsafe_perm, default_virtual_store_dir_max_length, default_workspace_concurrency,
     is_unsafe_perm_posix, resolve_child_concurrency,
@@ -2170,11 +2170,24 @@ impl Config {
     /// The registries this config resolves from, merged across every source,
     /// in the shape the `registries` setting is written in — the view
     /// `pnpm config get registries` prints. Unlike
-    /// [`Self::registry_declarations`], the default registry is declared too,
-    /// as the bare `@` scope.
+    /// [`Self::registry_declarations`], nothing is omitted: the default
+    /// registry is declared as the bare `@` scope, and the built-in routes —
+    /// the `@jsr` scope and the [`BUILTIN_REGISTRIES_BY_PREFIX`] prefixes —
+    /// are declared too, unless the user pointed them elsewhere.
     #[must_use]
     pub fn resolved_registry_declarations(&self) -> BTreeMap<String, RegistryDeclaration> {
-        registries::to_resolved_declarations(&self.registry_lookups(Some(self.registry.clone())))
+        let mut lookups = self.registry_lookups(Some(self.registry.clone()));
+        lookups
+            .registries_by_scope
+            .entry("@jsr".to_string())
+            .or_insert_with(|| DEFAULT_JSR_REGISTRY.to_string());
+        for (prefix, registry) in BUILTIN_REGISTRIES_BY_PREFIX {
+            lookups
+                .registries_by_prefix
+                .entry((*prefix).to_string())
+                .or_insert_with(|| (*registry).to_string());
+        }
+        registries::to_resolved_declarations(&lookups)
     }
 
     fn registry_lookups(&self, default_registry: Option<String>) -> RegistryLookups {

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -41,11 +41,11 @@ use std::{
 };
 
 pub use crate::defaults::{
-    GLOBAL_LAYOUT_VERSION, PNPM_VERSION, available_parallelism, default_cache_dir,
-    default_config_dir, default_git_shallow_hosts, default_peers_suffix_max_length,
-    default_pnpm_home_dir, default_registry, default_state_dir, default_unsafe_perm,
-    default_virtual_store_dir_max_length, default_workspace_concurrency, is_unsafe_perm_posix,
-    resolve_child_concurrency,
+    DEFAULT_JSR_REGISTRY, GLOBAL_LAYOUT_VERSION, PNPM_VERSION, available_parallelism,
+    default_cache_dir, default_config_dir, default_git_shallow_hosts,
+    default_peers_suffix_max_length, default_pnpm_home_dir, default_registry, default_state_dir,
+    default_unsafe_perm, default_virtual_store_dir_max_length, default_workspace_concurrency,
+    is_unsafe_perm_posix, resolve_child_concurrency,
 };
 use crate::defaults::{
     default_child_concurrency, default_enable_global_virtual_store, default_fetch_retries,
@@ -2164,12 +2164,54 @@ impl Config {
     /// own `registry` field.
     #[must_use]
     pub fn registry_declarations(&self) -> BTreeMap<String, RegistryDeclaration> {
-        registries::to_declarations(&RegistryLookups {
+        registries::to_declarations(&self.registry_lookups(None))
+    }
+
+    /// The registries this config resolves from, merged across every source,
+    /// in the shape the `registries` setting is written in — the view
+    /// `pnpm config get registries` prints. Unlike
+    /// [`Self::registry_declarations`], the default registry is declared too,
+    /// as the bare `@` scope.
+    #[must_use]
+    pub fn resolved_registry_declarations(&self) -> BTreeMap<String, RegistryDeclaration> {
+        registries::to_resolved_declarations(&self.registry_lookups(Some(self.registry.clone())))
+    }
+
+    fn registry_lookups(&self, default_registry: Option<String>) -> RegistryLookups {
+        RegistryLookups {
             registries_by_scope: self.registries_by_scope.clone(),
-            default_registry: None,
+            default_registry,
             registries_by_prefix: self.registries_by_prefix.clone(),
             registry_options_by_url: self.registry_options_by_url.clone(),
-        })
+        }
+    }
+
+    /// The `update` settings the CLI acts on, re-joined from
+    /// [`Self::update_config`] — the view `pnpm config get update` prints.
+    /// `None` when nothing is set.
+    #[must_use]
+    pub fn resolved_update_settings(&self) -> Option<UpdateSettings> {
+        let update = UpdateSettings {
+            ignore_deps: self.update_config.ignore_dependencies.clone(),
+            changeset: self.update_config.changeset,
+            github_actions: self.update_config.github_actions,
+            github_actions_server: self.update_config.github_actions_server.clone(),
+        };
+        (update != UpdateSettings::default()).then_some(update)
+    }
+
+    /// The `audit` settings the CLI acts on, re-joined from
+    /// [`Self::audit_level`] and [`Self::audit_config`] — the view
+    /// `pnpm config get audit` prints. An empty ignore list reads as unset.
+    /// `None` when nothing is set.
+    #[must_use]
+    pub fn resolved_audit_settings(&self) -> Option<AuditSettings> {
+        let audit = AuditSettings {
+            level: self.audit_level,
+            ignore: (!self.audit_config.ignore_ghsas.is_empty())
+                .then(|| self.audit_config.ignore_ghsas.clone()),
+        };
+        (audit != AuditSettings::default()).then_some(audit)
     }
 
     /// Overlay the CLI's proxy flags onto the merged keys and re-resolve.
@@ -3137,6 +3179,12 @@ fn collect_explicit_settings(
             "enableGlobalVirtualStore".to_string(),
             serde_json::Value::Bool(virtual_store_type.is_global()),
         );
+    }
+    // `audit.level` supersedes the deprecated `auditLevel` spelling; mirror it
+    // there so `config get audit-level` answers the way pnpm does.
+    if let Some(level) = settings.audit.as_ref().and_then(|audit| audit.level) {
+        let Ok(level) = serde_json::to_value(level) else { return };
+        target.insert("auditLevel".to_string(), level);
     }
 }
 

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -2150,6 +2150,25 @@ pub fn explicit_settings_report_the_spelling_that_won() {
     }
 }
 
+/// `audit.level` supersedes the deprecated `auditLevel` spelling, and
+/// `pnpm config get audit-level` reads the explicit-settings record — so the
+/// record has to carry the level under the deprecated name too, whichever
+/// spelling the file was written in.
+#[test]
+pub fn explicit_settings_mirror_audit_level_from_the_audit_section() {
+    for yaml in ["audit:\n  level: high\n", "audit:\n  level: high\nauditLevel: low\n"] {
+        let tmp = tempdir().unwrap();
+        fs::write(tmp.path().join("pnpm-workspace.yaml"), yaml)
+            .expect("write to pnpm-workspace.yaml");
+        let config = Config::new().current::<HostNoHome>(tmp.path()).expect("yaml is valid");
+        assert_eq!(
+            config.explicit_settings.get("auditLevel").and_then(serde_json::Value::as_str),
+            Some("high"),
+            "yaml: {yaml}",
+        );
+    }
+}
+
 #[test]
 pub fn gvs_disabled_keeps_project_local_virtual_store() {
     let tmp = tempdir().unwrap();

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -146,9 +146,10 @@ pub fn decided_allow_builds(allow_builds: HashMap<String, AllowBuild>) -> HashMa
 /// (or the hard-coded default).
 ///
 /// See <https://pnpm.io/settings> for the canonical key list.
-/// Non-config keys in a real pnpm-workspace.yaml (`packages`, `catalog`,
-/// `catalogs`, `onlyBuiltDependencies`, `allowBuilds`, ...) are silently
-/// ignored — serde drops them since the struct doesn't use
+/// Workspace-structural keys (`packages`, `catalog`, `catalogs`, the build
+/// allowlists) are carried only for `pnpm config get` / `list` — see
+/// [`Self::packages`]. Anything else that is not a field is silently
+/// ignored — serde drops it since the struct doesn't use
 /// `deny_unknown_fields`.
 ///
 /// pnpm v11 also reads `patchedDependencies` (and the other install
@@ -358,6 +359,23 @@ pub struct WorkspaceSettings {
     /// pnpm 10+ moved `allowBuilds` out of `package.json#pnpm` into
     /// `pnpm-workspace.yaml` alongside other install settings.
     pub allow_builds: Option<HashMap<String, AllowBuild>>,
+
+    /// The workspace-structural keys of `pnpm-workspace.yaml`, carried so
+    /// `pnpm config get` / `pnpm config list` can show them. Installs read
+    /// them from the workspace-manifest layer, not from [`Config`], so
+    /// [`Self::apply_to`] leaves them alone and the global `config.yaml`
+    /// refuses them.
+    pub packages: Option<Vec<String>>,
+    /// See [`Self::packages`].
+    pub catalog: Option<IndexMap<String, String>>,
+    /// See [`Self::packages`].
+    pub catalogs: Option<IndexMap<String, IndexMap<String, String>>>,
+    /// See [`Self::packages`].
+    pub only_built_dependencies: Option<Vec<String>>,
+    /// See [`Self::packages`].
+    pub never_built_dependencies: Option<Vec<String>>,
+    /// See [`Self::packages`].
+    pub ignored_built_dependencies: Option<Vec<String>>,
 
     /// Bypass the [`allow_builds`] gate entirely — every package may
     /// run lifecycle scripts. Same `pnpm-workspace.yaml` migration
@@ -1078,6 +1096,12 @@ impl WorkspaceSettings {
             }
         }
         self.versioning = None;
+        self.packages = None;
+        self.catalog = None;
+        self.catalogs = None;
+        self.only_built_dependencies = None;
+        self.never_built_dependencies = None;
+        self.ignored_built_dependencies = None;
         self.hoist = None;
         self.hoist_pattern = None;
         self.public_hoist_pattern = None;

--- a/pnpm/crates/config/src/workspace_yaml/registries.rs
+++ b/pnpm/crates/config/src/workspace_yaml/registries.rs
@@ -60,18 +60,18 @@ pub enum RegistryEntry {
 #[derive(Debug, Default, Clone, PartialEq, serde::Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RegistryDeclaration {
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub server_type: Option<RegistryServerType>,
     /// See [`RegistryOptions::supports_time_field`].
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub supports_time_field: Option<bool>,
     /// The scopes routed here, `@`-prefixed. A bare `@` is the scope-less
     /// default registry, the one the `registry` setting names.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scopes: Option<Vec<String>>,
     /// The bare-specifier prefix this registry answers to, as in
     /// `"foo": "work:^1.0.0"`.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub prefix: Option<String>,
     #[serde(flatten)]
     pub unknown: BTreeMap<String, serde_json::Value>,
@@ -311,6 +311,25 @@ pub fn to_declarations(lookups: &RegistryLookups) -> BTreeMap<String, RegistryDe
         let declaration = declarations.entry(registry.clone()).or_default();
         declaration.server_type = options.server_type;
         declaration.supports_time_field = options.supports_time_field;
+    }
+    declarations
+}
+
+/// [`to_declarations`] plus the default registry declared as the bare `@`
+/// scope — the resolved view `pnpm config get registries` prints, where
+/// nothing travels separately.
+#[must_use]
+pub fn to_resolved_declarations(
+    lookups: &RegistryLookups,
+) -> BTreeMap<String, RegistryDeclaration> {
+    let mut declarations = to_declarations(lookups);
+    if let Some(default_registry) = &lookups.default_registry {
+        declarations
+            .entry(default_registry.clone())
+            .or_default()
+            .scopes
+            .get_or_insert_with(Vec::new)
+            .insert(0, DEFAULT_REGISTRY_SCOPE.to_string());
     }
     declarations
 }

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -172,6 +172,45 @@ fn scope_survives_workspace_only_field_clearing() {
     assert_eq!(settings.scope.as_deref(), Some("@from-global"));
 }
 
+/// The workspace-structural keys are parsed so `pnpm config get` / `list`
+/// can show them, but only from the workspace yaml: the global `config.yaml`
+/// refuses them.
+#[test]
+fn structural_keys_are_parsed_and_are_workspace_only() {
+    let yaml = "
+packages: ['.']
+catalog:
+  react: ^19.0.0
+catalogs:
+  react17:
+    react: ^17.0.0
+onlyBuiltDependencies: [esbuild]
+neverBuiltDependencies: [fsevents]
+ignoredBuiltDependencies: [core-js]
+";
+    let mut settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
+    assert_eq!(settings.packages.as_deref(), Some(&[".".to_owned()][..]));
+    assert_eq!(
+        settings.catalog.as_ref().and_then(|c| c.get("react")).map(String::as_str),
+        Some("^19.0.0")
+    );
+    assert_eq!(
+        settings
+            .catalogs
+            .as_ref()
+            .and_then(|c| c.get("react17"))
+            .and_then(|c| c.get("react"))
+            .map(String::as_str),
+        Some("^17.0.0"),
+    );
+    assert_eq!(settings.only_built_dependencies.as_deref(), Some(&["esbuild".to_owned()][..]));
+    assert_eq!(settings.never_built_dependencies.as_deref(), Some(&["fsevents".to_owned()][..]));
+    assert_eq!(settings.ignored_built_dependencies.as_deref(), Some(&["core-js".to_owned()][..]));
+
+    settings.clear_workspace_only_fields();
+    assert_eq!(settings, WorkspaceSettings::default());
+}
+
 #[test]
 fn apply_scope_overrides_an_earlier_layer() {
     // The workspace yaml is applied over the global `config.yaml`, so the
@@ -2262,6 +2301,25 @@ fn rebuilds_the_declarations_from_the_lookups() {
     );
     // The default registry travels as the request's own `registry` field.
     assert!(!declarations.contains_key("https://registry.npmjs.org/"), "{declarations:?}");
+}
+
+/// The resolved view declares every route, so the default registry appears as
+/// the bare `@` scope — first in the scope list it shares with real scopes.
+#[test]
+fn resolved_declarations_declare_the_default_registry_as_the_bare_scope() {
+    let mut config = Config::new();
+    config.registry = "https://npm.corp.example/".to_owned();
+    config.registries_by_scope =
+        BTreeMap::from([("@acme".to_owned(), "https://npm.corp.example/".to_owned())]);
+
+    let declarations = config.resolved_registry_declarations();
+    assert_eq!(
+        declarations.get("https://npm.corp.example/"),
+        Some(&RegistryDeclaration {
+            scopes: Some(vec!["@".to_owned(), "@acme".to_owned()]),
+            ..RegistryDeclaration::default()
+        }),
+    );
 }
 
 /// A declaration map survives the round trip through the lookups it is split

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -2303,20 +2303,47 @@ fn rebuilds_the_declarations_from_the_lookups() {
     assert!(!declarations.contains_key("https://registry.npmjs.org/"), "{declarations:?}");
 }
 
-/// The resolved view declares every route, so the default registry appears as
-/// the bare `@` scope — first in the scope list it shares with real scopes.
+/// The resolved view declares every route: the default registry appears as
+/// the bare `@` scope — first in the scope list it shares with real scopes —
+/// and the built-in `@jsr` scope and `gh` / `npmjs` prefixes are declared
+/// unless the user pointed them elsewhere.
 #[test]
-fn resolved_declarations_declare_the_default_registry_as_the_bare_scope() {
+fn resolved_declarations_declare_every_route() {
     let mut config = Config::new();
     config.registry = "https://npm.corp.example/".to_owned();
     config.registries_by_scope =
         BTreeMap::from([("@acme".to_owned(), "https://npm.corp.example/".to_owned())]);
+    config.registries_by_prefix =
+        BTreeMap::from([("gh".to_owned(), "https://github.corp.example/".to_owned())]);
 
     let declarations = config.resolved_registry_declarations();
     assert_eq!(
         declarations.get("https://npm.corp.example/"),
         Some(&RegistryDeclaration {
             scopes: Some(vec!["@".to_owned(), "@acme".to_owned()]),
+            ..RegistryDeclaration::default()
+        }),
+    );
+    assert_eq!(
+        declarations.get("https://npm.jsr.io/"),
+        Some(&RegistryDeclaration {
+            scopes: Some(vec!["@jsr".to_owned()]),
+            ..RegistryDeclaration::default()
+        }),
+    );
+    // The user's `gh` route wins over the built-in of the same name.
+    assert_eq!(
+        declarations.get("https://github.corp.example/"),
+        Some(&RegistryDeclaration {
+            prefix: Some("gh".to_owned()),
+            ..RegistryDeclaration::default()
+        }),
+    );
+    assert_eq!(declarations.get("https://npm.pkg.github.com/"), None);
+    assert_eq!(
+        declarations.get("https://registry.npmjs.org/"),
+        Some(&RegistryDeclaration {
+            prefix: Some("npmjs".to_owned()),
             ..RegistryDeclaration::default()
         }),
     );

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -192,7 +192,7 @@ ignoredBuiltDependencies: [core-js]
     assert_eq!(settings.packages.as_deref(), Some(&[".".to_owned()][..]));
     assert_eq!(
         settings.catalog.as_ref().and_then(|c| c.get("react")).map(String::as_str),
-        Some("^19.0.0")
+        Some("^19.0.0"),
     );
     assert_eq!(
         settings

--- a/pnpm/crates/resolving-npm-resolver/src/named_registry.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/named_registry.rs
@@ -15,22 +15,7 @@ use miette::Diagnostic;
 pub use pnpm_lockfile::pick_registry_for_package;
 use reqwest::Url;
 
-/// Built-in named-registry aliases the resolver recognizes
-/// out of the box.
-///
-/// `npmjs` is here so a dependency can be pinned to the public
-/// registry even when `registry` points somewhere else, such as an
-/// internal proxy. The `npm` prefix cannot serve that purpose: it is
-/// reserved for the alias protocol (`npm:<name>@<range>`), which
-/// resolves through the default registry.
-///
-/// These URLs are also the prefixes
-/// [`named_registry_tarball_prefixes`] matches a recorded tarball URL
-/// against, so an org that proxies
-/// npmjs should point `npmjs` at their proxy to keep verification
-/// going there rather than to the public host.
-pub const BUILTIN_REGISTRIES_BY_PREFIX: &[(&str, &str)] =
-    &[("gh", "https://npm.pkg.github.com/"), ("npmjs", "https://registry.npmjs.org/")];
+pub use pnpm_config::BUILTIN_REGISTRIES_BY_PREFIX;
 
 /// Failure from [`merge_named_registries`], surfaced with the
 /// `ERR_PNPM_INVALID_NAMED_REGISTRY_URL` code.

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -27,7 +27,9 @@ use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
 use chrono::{DateTime, Utc};
 use node_semver::Version;
-use pnpm_config::{NeedsFullMetadataFor, TrustPolicy, version_policy::PackageVersionPolicy};
+use pnpm_config::{
+    DEFAULT_JSR_REGISTRY, NeedsFullMetadataFor, TrustPolicy, version_policy::PackageVersionPolicy,
+};
 use pnpm_lockfile::{LockfileResolution, PkgName, PkgNameVer, TarballResolution};
 use pnpm_network::{AuthHeaders, RetryOpts, ThrottledClient, redact_and_sanitize};
 use pnpm_registry::{Package, PackageDistribution, PackageVersion, RangeSpecStyle};
@@ -56,12 +58,6 @@ use crate::{
     trust_checks::{TrustCheckOptions, fail_if_trust_downgraded},
     violation_codes::MINIMUM_RELEASE_AGE_VIOLATION_CODE,
 };
-
-/// Default `@jsr` registry URL. The `registries` map always populates
-/// `@jsr`, so the dispatcher can read it unconditionally; this constant
-/// is the fallback for pacquet callers that haven't routed the `@jsr`
-/// entry through their `registries` map yet.
-const DEFAULT_JSR_REGISTRY: &str = "https://npm.jsr.io/";
 
 /// Provenance tag for [`ResolveResult::resolved_via`] when the picker
 /// drove a JSR-prefixed specifier through the `@jsr` registry.

--- a/pnpm11/config/commands/package.json
+++ b/pnpm11/config/commands/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@pnpm/cli.utils": "workspace:*",
+    "@pnpm/config.normalize-registries": "workspace:*",
     "@pnpm/config.reader": "workspace:*",
     "@pnpm/constants": "workspace:*",
     "@pnpm/error": "workspace:*",

--- a/pnpm11/config/commands/src/configGet.ts
+++ b/pnpm11/config/commands/src/configGet.ts
@@ -39,6 +39,12 @@ function lookupConfig (opts: ConfigCommandOptions, key: string, isScopedKey: boo
     return { value: getGlobalConfigPath(opts.configDir) }
   }
   const kebabKey = isCamelCase(key) ? kebabCase(key) : key
+  // The merged map is what resolvers use, so `registry` answers the same
+  // default the resolved `registries` view declares as the bare `@` scope —
+  // a raw `.npmrc` value would contradict it.
+  if (kebabKey === 'registry') {
+    return { value: opts._config.registriesByScope?.default ?? opts.authConfig.registry }
+  }
   // Resolve typed keys from Config — check explicitly set values first,
   // then fall back to authConfig (for keys like registry set in .npmrc)
   if (Object.hasOwn(types, kebabKey)) {

--- a/pnpm11/config/commands/src/configToRecord.ts
+++ b/pnpm11/config/commands/src/configToRecord.ts
@@ -1,18 +1,26 @@
-import { type Config, types } from '@pnpm/config.reader'
+import { pickRegistryContext, toResolvedRegistryDeclarations } from '@pnpm/config.normalize-registries'
+import { type Config, toAuditSettings, toUpdateSettings, types } from '@pnpm/config.reader'
 import { sortDirectKeys } from '@pnpm/object.key-sorting'
 import camelcase from 'camelcase'
 
 import { censorProtectedSettings } from './protectedSettings.js'
 
-// Auth-related Config fields that are internal objects, not user settings.
+// Config fields that are internal objects or internal spellings, not user
+// settings: the three lookups the `registries` setting is split into and the
+// deprecated `update` / `audit` spellings are shown re-joined under the
+// documented setting names instead.
 const NON_SETTING_CONFIG_KEYS = new Set([
   'authConfig', 'configByUri',
+  'registriesByScope', 'registriesByPrefix', 'registryOptionsByUrl',
+  'updateConfig', 'auditConfig', 'auditLevel',
 ])
 
 /**
  * Convert a Config object to a camelCase record for display.
  * Only includes explicitly set values (from CLI, env vars, or workspace yaml),
- * not default values. Auth/registry keys from authConfig are always included.
+ * not default values. Auth/registry keys from authConfig are always included,
+ * and so is `registries` — the registries the CLI resolves from, merged
+ * across every source.
  *
  * Accepts a clean Config object (without ConfigContext fields mixed in),
  * so no INTERNAL_CONFIG_KEYS exclusion list is needed.
@@ -22,7 +30,7 @@ export function configToRecord (config: Config, explicitlySetKeys: Set<string>):
   // Add typed settings (only explicitly set ones if tracking is available)
   for (const kebabKey of Object.keys(types)) {
     const camelKey = camelcase(kebabKey, { locale: 'en-US' })
-    if (!explicitlySetKeys.has(camelKey)) continue
+    if (!explicitlySetKeys.has(camelKey) || NON_SETTING_CONFIG_KEYS.has(camelKey)) continue
     const value = (config as unknown as Record<string, unknown>)[camelKey]
     if (value !== undefined) {
       result[camelKey] = value
@@ -44,6 +52,15 @@ export function configToRecord (config: Config, explicitlySetKeys: Set<string>):
   // Always include user-agent for debugging connectivity issues
   if (config.userAgent) {
     result.userAgent = config.userAgent
+  }
+  result.registries = toResolvedRegistryDeclarations(pickRegistryContext(config))
+  const update = toUpdateSettings(config.updateConfig)
+  if (update != null) {
+    result.update = update
+  }
+  const audit = toAuditSettings(config)
+  if (audit != null) {
+    result.audit = audit
   }
   return censorProtectedSettings(sortDirectKeys(result))
 }

--- a/pnpm11/config/commands/src/configToRecord.ts
+++ b/pnpm11/config/commands/src/configToRecord.ts
@@ -5,14 +5,15 @@ import camelcase from 'camelcase'
 
 import { censorProtectedSettings } from './protectedSettings.js'
 
-// Config fields that are internal objects or internal spellings, not user
-// settings: the three lookups the `registries` setting is split into and the
-// deprecated `update` / `audit` spellings are shown re-joined under the
-// documented setting names instead.
+// Config fields the record does not copy verbatim: internal objects, the
+// lookups and spellings the `registries` / `update` / `audit` settings are
+// split into (shown re-joined under the documented names instead), and
+// `catalogs`, which is re-added below as the resolved catalog set.
 const NON_SETTING_CONFIG_KEYS = new Set([
   'authConfig', 'configByUri',
   'registriesByScope', 'registriesByPrefix', 'registryOptionsByUrl',
   'updateConfig', 'auditConfig', 'auditLevel',
+  'catalogs',
 ])
 
 /**
@@ -49,6 +50,12 @@ export function configToRecord (config: Config, explicitlySetKeys: Set<string>):
       result[key] = value
     }
   }
+  // The `registry` / `@scope:registry` rows show the merged routes — the
+  // values `config get` answers — so a raw `.npmrc` row cannot contradict
+  // the resolved `registries` view.
+  for (const [scope, url] of Object.entries(config.registriesByScope ?? {})) {
+    result[scope === 'default' ? 'registry' : `${scope}:registry`] = url
+  }
   // Always include user-agent for debugging connectivity issues
   if (config.userAgent) {
     result.userAgent = config.userAgent
@@ -61,6 +68,11 @@ export function configToRecord (config: Config, explicitlySetKeys: Set<string>):
   const audit = toAuditSettings(config)
   if (audit != null) {
     result.audit = audit
+  }
+  // `catalogs` shows the complete resolved catalog set — the singular
+  // `catalog` block is its `default` entry — whichever spelling declared it.
+  if (config.catalogs != null && Object.values(config.catalogs).some((catalog) => catalog != null)) {
+    result.catalogs = config.catalogs
   }
   return censorProtectedSettings(sortDirectKeys(result))
 }

--- a/pnpm11/config/commands/test/configGet.test.ts
+++ b/pnpm11/config/commands/test/configGet.test.ts
@@ -257,6 +257,102 @@ test('config get with scoped registry returns the merged value from pnpm-workspa
   expect(getOutputString(getResult)).toBe('https://from-workspace-yaml.example.com/')
 })
 
+test('config get registries returns the registries the CLI resolves from', async () => {
+  const getResult = await config.handler(createConfigCommandOpts({
+    dir: process.cwd(),
+    cliOptions: {},
+    configDir: process.cwd(),
+    global: false,
+    authConfig: {},
+    registriesByScope: {
+      default: 'https://registry.example.com/',
+      '@jsr': 'https://npm.jsr.io/',
+      '@corp': 'https://work.example.com/',
+    },
+    registriesByPrefix: {
+      work: 'https://work.example.com/',
+    },
+    registryOptionsByUrl: {
+      'https://work.example.com/': { serverType: 'artifactory' },
+    },
+  }), ['get', 'registries'])
+
+  expect(JSON.parse(getOutputString(getResult))).toStrictEqual({
+    'https://registry.example.com/': { scopes: ['@'] },
+    'https://work.example.com/': {
+      serverType: 'artifactory',
+      scopes: ['@corp'],
+      prefix: 'work',
+    },
+  })
+})
+
+test('config list re-joins the registry lookups under `registries`', async () => {
+  const listResult = await config.handler(createConfigCommandOpts({
+    dir: process.cwd(),
+    cliOptions: {},
+    configDir: process.cwd(),
+    global: false,
+    authConfig: {},
+    registriesByScope: {
+      default: 'https://registry.example.com/',
+    },
+    registryOptionsByUrl: {
+      'https://registry.example.com/': { supportsTimeField: true },
+    },
+  }), ['list'])
+
+  const record = JSON.parse(getOutputString(listResult))
+  expect(record.registries).toStrictEqual({
+    'https://registry.example.com/': {
+      supportsTimeField: true,
+      scopes: ['@'],
+    },
+  })
+  expect(record).not.toHaveProperty('registriesByScope')
+  expect(record).not.toHaveProperty('registryOptionsByUrl')
+})
+
+test('config get update and audit return the settings the CLI acts on, under the documented names', async () => {
+  const baseOpts = {
+    dir: process.cwd(),
+    cliOptions: {},
+    configDir: process.cwd(),
+    global: false,
+    authConfig: {},
+    updateConfig: {
+      ignoreDependencies: ['webpack'],
+      changeset: true,
+    },
+    auditConfig: {
+      ignoreGhsas: ['GHSA-xxxx-yyyy-zzzz'],
+    },
+    auditLevel: 'high',
+  }
+
+  const updateResult = await config.handler(createConfigCommandOpts(baseOpts), ['get', 'update'])
+  expect(JSON.parse(getOutputString(updateResult))).toStrictEqual({
+    ignoreDeps: ['webpack'],
+    changeset: true,
+  })
+
+  const auditResult = await config.handler(createConfigCommandOpts(baseOpts), ['get', 'audit'])
+  expect(JSON.parse(getOutputString(auditResult))).toStrictEqual({
+    level: 'high',
+    ignore: ['GHSA-xxxx-yyyy-zzzz'],
+  })
+
+  // The deprecated internal spellings are no longer part of the record.
+  const deprecatedResults = await Promise.all(['updateConfig', 'auditConfig'].map(
+    async (deprecatedKey) => config.handler(createConfigCommandOpts(baseOpts), ['get', deprecatedKey])
+  ))
+  for (const result of deprecatedResults) {
+    expect(getOutputString(result)).toBe('undefined')
+  }
+  const listResult = await config.handler(createConfigCommandOpts(baseOpts), ['list'])
+  expect(JSON.parse(getOutputString(listResult))).not.toHaveProperty('auditLevel')
+})
+
 test('config get with scoped registry key that does not exist', async () => {
   const getResult = await config.handler(createConfigCommandOpts({
     dir: process.cwd(),

--- a/pnpm11/config/commands/test/configGet.test.ts
+++ b/pnpm11/config/commands/test/configGet.test.ts
@@ -317,6 +317,78 @@ test('config list re-joins the registry lookups under `registries`', async () =>
   })
   expect(record).not.toHaveProperty('registriesByScope')
   expect(record).not.toHaveProperty('registryOptionsByUrl')
+  // The npm-compat row agrees with the resolved view.
+  expect(record.registry).toBe('https://registry.example.com/')
+})
+
+test('config get registry and @jsr:registry answer the merged routes', async () => {
+  const baseOpts = {
+    dir: process.cwd(),
+    cliOptions: {},
+    configDir: process.cwd(),
+    global: false,
+    authConfig: {
+      registry: 'https://from-npmrc.example.com/',
+    },
+    registriesByScope: {
+      default: 'https://from-workspace-yaml.example.com/',
+      '@jsr': 'https://npm.jsr.io/',
+    },
+  }
+
+  // The resolved default — wherever it was routed from — wins over a raw
+  // `.npmrc` row, so `get` and `list` cannot contradict the `registries`
+  // view.
+  const registryResult = await config.handler(createConfigCommandOpts(baseOpts), ['get', 'registry'])
+  expect(getOutputString(registryResult)).toBe('https://from-workspace-yaml.example.com/')
+  const jsrResult = await config.handler(createConfigCommandOpts(baseOpts), ['get', '@jsr:registry'])
+  expect(getOutputString(jsrResult)).toBe('https://npm.jsr.io/')
+  const listResult = await config.handler(createConfigCommandOpts(baseOpts), ['list'])
+  const record = JSON.parse(getOutputString(listResult))
+  expect(record.registry).toBe('https://from-workspace-yaml.example.com/')
+  expect(record['@jsr:registry']).toBe('https://npm.jsr.io/')
+})
+
+test('config get audit-level still answers the deprecated types key', async () => {
+  const getResult = await config.handler(createConfigCommandOpts({
+    dir: process.cwd(),
+    cliOptions: {},
+    configDir: process.cwd(),
+    global: false,
+    authConfig: {},
+    auditLevel: 'high',
+  }), ['get', 'audit-level'])
+  expect(getOutputString(getResult)).toBe('high')
+})
+
+test('config get catalogs prints the resolved catalog set, whichever spelling declared it', async () => {
+  // The reader merges the singular `catalog` block into `catalogs` as its
+  // `default` entry; the record shows that merged set, named catalogs
+  // preserved.
+  const getResult = await config.handler(createConfigCommandOpts({
+    dir: process.cwd(),
+    cliOptions: {},
+    configDir: process.cwd(),
+    global: false,
+    authConfig: {},
+    catalog: { react: '^19.0.0' },
+    catalogs: { default: { react: '^19.0.0' }, react17: { react: '^17.0.0' } },
+  }), ['get', 'catalogs'])
+  expect(JSON.parse(getOutputString(getResult))).toStrictEqual({
+    default: { react: '^19.0.0' },
+    react17: { react: '^17.0.0' },
+  })
+
+  // A catalogs map holding no catalog reads as unset.
+  const emptyResult = await config.handler(createConfigCommandOpts({
+    dir: process.cwd(),
+    cliOptions: {},
+    configDir: process.cwd(),
+    global: false,
+    authConfig: {},
+    catalogs: { default: undefined },
+  }), ['get', 'catalogs'])
+  expect(getOutputString(emptyResult)).toBe('undefined')
 })
 
 test('config get update and audit return the settings the CLI acts on, under the documented names', async () => {

--- a/pnpm11/config/commands/test/configGet.test.ts
+++ b/pnpm11/config/commands/test/configGet.test.ts
@@ -278,7 +278,10 @@ test('config get registries returns the registries the CLI resolves from', async
   }), ['get', 'registries'])
 
   expect(JSON.parse(getOutputString(getResult))).toStrictEqual({
+    'https://npm.jsr.io/': { scopes: ['@jsr'] },
+    'https://npm.pkg.github.com/': { prefix: 'gh' },
     'https://registry.example.com/': { scopes: ['@'] },
+    'https://registry.npmjs.org/': { prefix: 'npmjs' },
     'https://work.example.com/': {
       serverType: 'artifactory',
       scopes: ['@corp'],
@@ -304,10 +307,13 @@ test('config list re-joins the registry lookups under `registries`', async () =>
 
   const record = JSON.parse(getOutputString(listResult))
   expect(record.registries).toStrictEqual({
+    'https://npm.jsr.io/': { scopes: ['@jsr'] },
+    'https://npm.pkg.github.com/': { prefix: 'gh' },
     'https://registry.example.com/': {
       supportsTimeField: true,
       scopes: ['@'],
     },
+    'https://registry.npmjs.org/': { prefix: 'npmjs' },
   })
   expect(record).not.toHaveProperty('registriesByScope')
   expect(record).not.toHaveProperty('registryOptionsByUrl')

--- a/pnpm11/config/commands/tsconfig.json
+++ b/pnpm11/config/commands/tsconfig.json
@@ -37,6 +37,9 @@
       "path": "../../workspace/workspace-manifest-writer"
     },
     {
+      "path": "../normalize-registries"
+    },
+    {
       "path": "../reader"
     }
   ]

--- a/pnpm11/config/normalize-registries/src/index.ts
+++ b/pnpm11/config/normalize-registries/src/index.ts
@@ -1,5 +1,5 @@
 import { BUILTIN_REGISTRIES_BY_PREFIX } from '@pnpm/constants'
-import type { RegistriesByPrefix, RegistriesByScope, RegistryContext, RegistryDeclaration, RegistryServerType } from '@pnpm/types'
+import { DEFAULT_REGISTRY_SCOPE, type RegistriesByPrefix, type RegistriesByScope, type RegistryContext, type RegistryDeclaration, type RegistryServerType } from '@pnpm/types'
 import normalizeRegistryUrl from 'normalize-registry-url'
 import { map as mapValues } from 'ramda'
 
@@ -86,6 +86,40 @@ export function toRegistryDeclarations (context: Partial<RegistryContext>): Reco
     if (options.supportsTimeField != null) declarationFor(registry).supportsTimeField = options.supportsTimeField
   }
   return declarations
+}
+
+/**
+ * The registries the CLI resolves from, merged across every source, in the
+ * shape the `registries` setting is written in — the view `pnpm config get
+ * registries` prints.
+ *
+ * On top of {@link toRegistryDeclarations}, the default registry is declared
+ * too, as the bare `@` scope. Registry keys, declaration fields, and scope
+ * lists come out in one canonical order so both CLI implementations print
+ * identical JSON.
+ */
+export function toResolvedRegistryDeclarations (context: Partial<RegistryContext>): Record<string, RegistryDeclaration> {
+  const declarations = toRegistryDeclarations(context)
+  const defaultRegistry = context.registriesByScope?.default
+  if (defaultRegistry != null) {
+    const declaration = declarations[defaultRegistry] ??= {}
+    declaration.scopes = [DEFAULT_REGISTRY_SCOPE, ...declaration.scopes ?? []]
+  }
+  return sortRegistryDeclarations(declarations)
+}
+
+function sortRegistryDeclarations (declarations: Record<string, RegistryDeclaration>): Record<string, RegistryDeclaration> {
+  const sorted: Record<string, RegistryDeclaration> = {}
+  for (const registry of Object.keys(declarations).sort()) {
+    const { serverType, supportsTimeField, scopes, prefix } = declarations[registry]
+    sorted[registry] = {
+      ...(serverType != null ? { serverType } : {}),
+      ...(supportsTimeField != null ? { supportsTimeField } : {}),
+      ...(scopes != null ? { scopes: [...scopes].sort() } : {}),
+      ...(prefix != null ? { prefix } : {}),
+    }
+  }
+  return sorted
 }
 
 /**

--- a/pnpm11/config/normalize-registries/src/index.ts
+++ b/pnpm11/config/normalize-registries/src/index.ts
@@ -1,5 +1,5 @@
 import { BUILTIN_REGISTRIES_BY_PREFIX } from '@pnpm/constants'
-import { DEFAULT_REGISTRY_SCOPE, type RegistriesByPrefix, type RegistriesByScope, type RegistryContext, type RegistryDeclaration, type RegistryServerType } from '@pnpm/types'
+import { DEFAULT_REGISTRY_SCOPE, type RegistriesByPrefix, type RegistriesByScope, type RegistryContext, type RegistryDeclaration, type RegistryOptions, type RegistryServerType } from '@pnpm/types'
 import normalizeRegistryUrl from 'normalize-registry-url'
 import { map as mapValues } from 'ramda'
 
@@ -71,21 +71,13 @@ export function pickRegistryContext (source: RegistryContext): RegistryContext {
  * the requests that never resolve a JSR package.
  */
 export function toRegistryDeclarations (context: Partial<RegistryContext>): Record<string, RegistryDeclaration> {
-  const declarations: Record<string, RegistryDeclaration> = {}
-  const declarationFor = (registry: string): RegistryDeclaration => (declarations[registry] ??= {})
-  for (const [scope, registry] of Object.entries(context.registriesByScope ?? {})) {
-    if (scope === 'default' || DEFAULT_REGISTRIES_BY_SCOPE[scope] === registry) continue
-    const declaration = declarationFor(registry)
-    declaration.scopes = [...declaration.scopes ?? [], scope]
-  }
-  for (const [prefix, registry] of Object.entries(context.registriesByPrefix ?? {})) {
-    declarationFor(registry).prefix = prefix
-  }
-  for (const [registry, options] of Object.entries(context.registryOptionsByUrl ?? {})) {
-    if (options.serverType != null) declarationFor(registry).serverType = options.serverType
-    if (options.supportsTimeField != null) declarationFor(registry).supportsTimeField = options.supportsTimeField
-  }
-  return declarations
+  const scopeRoutes = Object.entries(context.registriesByScope ?? {}).filter(
+    ([scope, registry]) => scope !== 'default' && DEFAULT_REGISTRIES_BY_SCOPE[scope] !== registry
+  )
+  return buildRegistryDeclarations({
+    ...context,
+    registriesByScope: Object.fromEntries(scopeRoutes),
+  })
 }
 
 /**
@@ -93,19 +85,50 @@ export function toRegistryDeclarations (context: Partial<RegistryContext>): Reco
  * shape the `registries` setting is written in — the view `pnpm config get
  * registries` prints.
  *
- * On top of {@link toRegistryDeclarations}, the default registry is declared
- * too, as the bare `@` scope. Registry keys, declaration fields, and scope
- * lists come out in one canonical order so both CLI implementations print
- * identical JSON.
+ * Unlike {@link toRegistryDeclarations}, nothing is omitted: the default
+ * registry is declared as the bare `@` scope, and the built-in routes — the
+ * `@jsr` scope and the `npmjs` / `gh` prefixes — are declared too, because
+ * this view answers "where does this install resolve from", not "what did
+ * the user write". Registry keys, declaration fields, and scope lists come
+ * out in one canonical order so both CLI implementations print identical
+ * JSON.
  */
 export function toResolvedRegistryDeclarations (context: Partial<RegistryContext>): Record<string, RegistryDeclaration> {
-  const declarations = toRegistryDeclarations(context)
-  const defaultRegistry = context.registriesByScope?.default
-  if (defaultRegistry != null) {
-    const declaration = declarations[defaultRegistry] ??= {}
-    declaration.scopes = [DEFAULT_REGISTRY_SCOPE, ...declaration.scopes ?? []]
+  return sortRegistryDeclarations(buildRegistryDeclarations({
+    ...context,
+    registriesByScope: { ...DEFAULT_REGISTRIES_BY_SCOPE, ...context.registriesByScope },
+    registriesByPrefix: { ...BUILTIN_REGISTRIES_BY_PREFIX, ...context.registriesByPrefix },
+  }))
+}
+
+/** {@link RegistryContext} with the scope map allowed to omit `default`. */
+interface RegistryRoutes {
+  registriesByScope?: Record<string, string>
+  registriesByPrefix?: Record<string, string>
+  registryOptionsByUrl?: Record<string, RegistryOptions>
+}
+
+/**
+ * A registry's `prefix` field holds one name, so when several prefixes route
+ * to the same URL the alphabetically last one is shown — sorted here rather
+ * than left to insertion order, so both CLI implementations pick the same
+ * one.
+ */
+function buildRegistryDeclarations (context: RegistryRoutes): Record<string, RegistryDeclaration> {
+  const declarations: Record<string, RegistryDeclaration> = {}
+  const declarationFor = (registry: string): RegistryDeclaration => (declarations[registry] ??= {})
+  for (const [scope, registry] of Object.entries(context.registriesByScope ?? {})) {
+    const declaration = declarationFor(registry)
+    declaration.scopes = [...declaration.scopes ?? [], scope === 'default' ? DEFAULT_REGISTRY_SCOPE : scope]
   }
-  return sortRegistryDeclarations(declarations)
+  for (const [prefix, registry] of Object.entries(context.registriesByPrefix ?? {}).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))) {
+    declarationFor(registry).prefix = prefix
+  }
+  for (const [registry, options] of Object.entries(context.registryOptionsByUrl ?? {})) {
+    if (options.serverType != null) declarationFor(registry).serverType = options.serverType
+    if (options.supportsTimeField != null) declarationFor(registry).supportsTimeField = options.supportsTimeField
+  }
+  return declarations
 }
 
 function sortRegistryDeclarations (declarations: Record<string, RegistryDeclaration>): Record<string, RegistryDeclaration> {

--- a/pnpm11/config/normalize-registries/test/toResolvedRegistryDeclarations.test.ts
+++ b/pnpm11/config/normalize-registries/test/toResolvedRegistryDeclarations.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from '@jest/globals'
+import { toResolvedRegistryDeclarations } from '@pnpm/config.normalize-registries'
+
+test('toResolvedRegistryDeclarations() declares the default registry as the bare @ scope', () => {
+  expect(toResolvedRegistryDeclarations({
+    registriesByScope: { default: 'https://registry.npmjs.org/' },
+  })).toStrictEqual({
+    'https://registry.npmjs.org/': { scopes: ['@'] },
+  })
+})
+
+test('toResolvedRegistryDeclarations() merges the default route into the registry entry it belongs to', () => {
+  expect(toResolvedRegistryDeclarations({
+    registriesByScope: {
+      default: 'https://npm.corp.example/',
+      '@acme': 'https://npm.corp.example/',
+    },
+    registriesByPrefix: { work: 'https://npm.corp.example/' },
+    registryOptionsByUrl: { 'https://npm.corp.example/': { serverType: 'artifactory' } },
+  })).toStrictEqual({
+    'https://npm.corp.example/': {
+      serverType: 'artifactory',
+      scopes: ['@', '@acme'],
+      prefix: 'work',
+    },
+  })
+})
+
+test('toResolvedRegistryDeclarations() still omits a built-in route the user did not point elsewhere', () => {
+  expect(toResolvedRegistryDeclarations({
+    registriesByScope: {
+      default: 'https://registry.npmjs.org/',
+      '@jsr': 'https://npm.jsr.io/',
+    },
+  })).toStrictEqual({
+    'https://registry.npmjs.org/': { scopes: ['@'] },
+  })
+})
+
+test('toResolvedRegistryDeclarations() emits keys, fields, and scopes in canonical order', () => {
+  // Both CLI implementations print this view as JSON, so its ordering is part
+  // of the shared contract: registry URLs and scope lists lexicographic,
+  // fields as the setting documents them.
+  const resolved = toResolvedRegistryDeclarations({
+    registriesByScope: {
+      '@other': 'https://npm.other.example/',
+      '@acme': 'https://npm.corp.example/',
+      default: 'https://npm.corp.example/',
+    },
+    registriesByPrefix: { work: 'https://npm.corp.example/' },
+    registryOptionsByUrl: { 'https://npm.corp.example/': { supportsTimeField: true, serverType: 'artifactory' } },
+  })
+  expect(Object.keys(resolved)).toStrictEqual(['https://npm.corp.example/', 'https://npm.other.example/'])
+  expect(Object.keys(resolved['https://npm.corp.example/'])).toStrictEqual(['serverType', 'supportsTimeField', 'scopes', 'prefix'])
+  expect(resolved['https://npm.corp.example/'].scopes).toStrictEqual(['@', '@acme'])
+})

--- a/pnpm11/config/normalize-registries/test/toResolvedRegistryDeclarations.test.ts
+++ b/pnpm11/config/normalize-registries/test/toResolvedRegistryDeclarations.test.ts
@@ -1,56 +1,78 @@
 import { expect, test } from '@jest/globals'
 import { toResolvedRegistryDeclarations } from '@pnpm/config.normalize-registries'
 
-test('toResolvedRegistryDeclarations() declares the default registry as the bare @ scope', () => {
-  expect(toResolvedRegistryDeclarations({
-    registriesByScope: { default: 'https://registry.npmjs.org/' },
-  })).toStrictEqual({
-    'https://registry.npmjs.org/': { scopes: ['@'] },
+test('toResolvedRegistryDeclarations() declares the built-in routes on a default setup', () => {
+  expect(toResolvedRegistryDeclarations({})).toStrictEqual({
+    'https://npm.jsr.io/': { scopes: ['@jsr'] },
+    'https://npm.pkg.github.com/': { prefix: 'gh' },
+    'https://registry.npmjs.org/': { scopes: ['@'], prefix: 'npmjs' },
   })
 })
 
-test('toResolvedRegistryDeclarations() merges the default route into the registry entry it belongs to', () => {
+test('toResolvedRegistryDeclarations() declares the default registry as the bare @ scope', () => {
+  expect(toResolvedRegistryDeclarations({
+    registriesByScope: { default: 'https://npm.corp.example/' },
+  })).toStrictEqual({
+    'https://npm.corp.example/': { scopes: ['@'] },
+    'https://npm.jsr.io/': { scopes: ['@jsr'] },
+    'https://npm.pkg.github.com/': { prefix: 'gh' },
+    'https://registry.npmjs.org/': { prefix: 'npmjs' },
+  })
+})
+
+test('toResolvedRegistryDeclarations() merges every route into the registry entry it belongs to', () => {
   expect(toResolvedRegistryDeclarations({
     registriesByScope: {
       default: 'https://npm.corp.example/',
+      '@jsr': 'https://jsr.corp.example/',
       '@acme': 'https://npm.corp.example/',
     },
     registriesByPrefix: { work: 'https://npm.corp.example/' },
     registryOptionsByUrl: { 'https://npm.corp.example/': { serverType: 'artifactory' } },
   })).toStrictEqual({
+    'https://jsr.corp.example/': { scopes: ['@jsr'] },
     'https://npm.corp.example/': {
       serverType: 'artifactory',
       scopes: ['@', '@acme'],
       prefix: 'work',
     },
+    'https://npm.pkg.github.com/': { prefix: 'gh' },
+    'https://registry.npmjs.org/': { prefix: 'npmjs' },
   })
 })
 
-test('toResolvedRegistryDeclarations() still omits a built-in route the user did not point elsewhere', () => {
+test('toResolvedRegistryDeclarations() lets a user prefix win over the built-in of the same name', () => {
   expect(toResolvedRegistryDeclarations({
-    registriesByScope: {
-      default: 'https://registry.npmjs.org/',
-      '@jsr': 'https://npm.jsr.io/',
-    },
+    registriesByPrefix: { gh: 'https://github.corp.example/' },
   })).toStrictEqual({
-    'https://registry.npmjs.org/': { scopes: ['@'] },
+    'https://github.corp.example/': { prefix: 'gh' },
+    'https://npm.jsr.io/': { scopes: ['@jsr'] },
+    'https://registry.npmjs.org/': { scopes: ['@'], prefix: 'npmjs' },
   })
 })
 
 test('toResolvedRegistryDeclarations() emits keys, fields, and scopes in canonical order', () => {
   // Both CLI implementations print this view as JSON, so its ordering is part
   // of the shared contract: registry URLs and scope lists lexicographic,
-  // fields as the setting documents them.
+  // fields as the setting documents them, and the alphabetically last of the
+  // prefixes routed to one URL.
   const resolved = toResolvedRegistryDeclarations({
     registriesByScope: {
       '@other': 'https://npm.other.example/',
       '@acme': 'https://npm.corp.example/',
       default: 'https://npm.corp.example/',
     },
-    registriesByPrefix: { work: 'https://npm.corp.example/' },
+    registriesByPrefix: { work: 'https://npm.corp.example/', corp: 'https://npm.corp.example/' },
     registryOptionsByUrl: { 'https://npm.corp.example/': { supportsTimeField: true, serverType: 'artifactory' } },
   })
-  expect(Object.keys(resolved)).toStrictEqual(['https://npm.corp.example/', 'https://npm.other.example/'])
+  expect(Object.keys(resolved)).toStrictEqual([
+    'https://npm.corp.example/',
+    'https://npm.jsr.io/',
+    'https://npm.other.example/',
+    'https://npm.pkg.github.com/',
+    'https://registry.npmjs.org/',
+  ])
   expect(Object.keys(resolved['https://npm.corp.example/'])).toStrictEqual(['serverType', 'supportsTimeField', 'scopes', 'prefix'])
   expect(resolved['https://npm.corp.example/'].scopes).toStrictEqual(['@', '@acme'])
+  expect(resolved['https://npm.corp.example/'].prefix).toBe('work')
 })

--- a/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
+++ b/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
@@ -5,6 +5,9 @@ import { PnpmError, redactAndSanitize } from '@pnpm/error'
 import { globalWarn } from '@pnpm/logger'
 import {
   type AllowedDeprecatedVersions,
+  type AuditConfig,
+  type AuditLevel,
+  type AuditSettings,
   DEFAULT_REGISTRY_SCOPE,
   type PackageExtension,
   type PeerDependencyRules,
@@ -13,6 +16,7 @@ import {
   type RegistryDeclaration,
   type RegistryOptions,
   type SupportedArchitectures,
+  type UpdateSettings,
   type VirtualStoreType,
 } from '@pnpm/types'
 import normalizeRegistryUrl from 'normalize-registry-url'
@@ -347,6 +351,38 @@ function translateAuditSettings (pnpmSettings: PnpmSettings, settings: OptionsFr
     }
     ;(settings as { auditLevel?: string }).auditLevel = audit.level
   }
+}
+
+/**
+ * The `update` settings the CLI acts on, re-joined from the internal
+ * `updateConfig` shape {@link translateUpdateSettings} splits the section
+ * into — the view `pnpm config get update` prints. `undefined` when nothing
+ * is set.
+ */
+export function toUpdateSettings (updateConfig: OptionsFromRootManifest['updateConfig']): UpdateSettings | undefined {
+  if (updateConfig == null) return undefined
+  const update: UpdateSettings = {
+    ...(updateConfig.ignoreDependencies != null ? { ignoreDeps: updateConfig.ignoreDependencies } : {}),
+    ...(updateConfig.changeset != null ? { changeset: updateConfig.changeset } : {}),
+    ...(updateConfig.githubActions != null ? { githubActions: updateConfig.githubActions } : {}),
+    ...(updateConfig.githubActionsServer != null ? { githubActionsServer: updateConfig.githubActionsServer } : {}),
+  }
+  return Object.keys(update).length > 0 ? update : undefined
+}
+
+/**
+ * The `audit` settings the CLI acts on, re-joined from the internal
+ * `auditConfig` / `auditLevel` pair {@link translateAuditSettings} splits the
+ * section into — the view `pnpm config get audit` prints. An empty ignore
+ * list reads as unset. `undefined` when nothing is set.
+ */
+export function toAuditSettings ({ auditConfig, auditLevel }: { auditConfig?: AuditConfig, auditLevel?: AuditLevel }): AuditSettings | undefined {
+  const ignore = auditConfig?.ignoreGhsas
+  const audit: AuditSettings = {
+    ...(auditLevel != null ? { level: auditLevel } : {}),
+    ...(ignore != null && ignore.length > 0 ? { ignore } : {}),
+  }
+  return Object.keys(audit).length > 0 ? audit : undefined
 }
 
 /**

--- a/pnpm11/config/reader/src/index.ts
+++ b/pnpm11/config/reader/src/index.ts
@@ -58,7 +58,7 @@ export { types }
 export { getDefaultWorkspaceConcurrency, getWorkspaceConcurrency } from './concurrency.js'
 export { getGlobalConfigPath } from './dirs.js'
 export { getDefaultCreds, getNetworkConfigs, type NetworkConfigs } from './getNetworkConfigs.js'
-export { getOptionsFromPnpmSettings, type OptionsFromRootManifest } from './getOptionsFromRootManifest.js'
+export { getOptionsFromPnpmSettings, type OptionsFromRootManifest, toAuditSettings, toUpdateSettings } from './getOptionsFromRootManifest.js'
 export {
   getPackageManagerBootstrapConfig,
   getPackageManagerRegistries,

--- a/pnpm11/pnpm/test/config/list.ts
+++ b/pnpm11/pnpm/test/config/list.ts
@@ -32,8 +32,10 @@ test('pnpm config list reads npm options but ignores other settings from .npmrc'
   expect(list).toMatchObject({
     '//my-org.registry.example.com:username': '(protected)',
     '//my-org.registry.example.com:_authToken': '(protected)',
-    '@my-org:registry': 'https://my-org.registry.example.com',
-    '@jsr:registry': 'https://not-actually-jsr.example.com',
+    // The registry rows show the merged routes, normalized the way the
+    // resolvers read them.
+    '@my-org:registry': 'https://my-org.registry.example.com/',
+    '@jsr:registry': 'https://not-actually-jsr.example.com/',
   } as Partial<Config>)
   expect(list).not.toHaveProperty(['dlx-cache-max-age'])
   expect(list).not.toHaveProperty(['dlxCacheMaxAge'])


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

`pnpm config get registries` printed `undefined`: the config reader splits the setting into internal lookups (`registriesByScope`, `registriesByPrefix`, `registryOptionsByUrl`) and deletes the raw key, so the documented name had no readable value. The same translate-and-delete pattern hid `update` and `audit` — only their *deprecated* spellings (`updateConfig`, `auditConfig`, `auditLevel`) answered — and a systematic comparison of the two stacks' config records surfaced a dozen more keys where pacquet and the TypeScript CLI disagreed.

After this PR, both CLIs answer the documented setting names with the values they actually act on, and print byte-identical JSON:

- **`registries`** shows the resolved view, merged across every source (`.npmrc`, `pnpm-workspace.yaml`, global config, CLI flags), keyed by registry URL with the default registry declared as the bare `@` scope. Built-in routes are declared too — the `` `@jsr` `` scope and the `npmjs` / `gh` prefixes — unless the user pointed them elsewhere, so the view answers "where does this install resolve from", not "what did the user write". Works for `config get registries`, `config list`, and property paths (`config get "registries['https://work.example.com/'].serverType"`). The internal lookups leave the record.
- **`update` / `audit`** show the effective sections, whichever spelling set them, and the deprecated spellings leave the record. `config get audit-level` still answers in both stacks (it is a `types` key).
- **Pacquet record holes filled:** `packages`, `catalog`, `catalogs` (shown merged, with the singular `catalog` block as its `default` entry — matching the TypeScript CLI exactly), `onlyBuiltDependencies`, `neverBuiltDependencies`, `ignoredBuiltDependencies`.
- **Pacquet built-in defaults:** `config get registry` and `` config get `@jsr:registry` `` answered `undefined` where the TypeScript CLI answers the built-in defaults; `patchedDependencies` displayed as-written paths where the TypeScript CLI shows workspace-resolved ones. All aligned.
- **Wire parity fix:** `RegistryDeclaration` now skips absent fields when serializing, so pacquet's pnpr requests stop sending `null`s the TypeScript CLI's requests omit.

Verified by diffing full `config list` records and per-key `config get` output between the freshly built TS bundle and pacquet binary, on loaded and empty workspaces: the only remaining differences are the `userAgent` version strings.

Known accepted micro-divergence (cosmetic): on Windows pacquet's absolutized patch paths may keep forward slashes where Node normalizes them.

`BUILTIN_REGISTRIES_BY_PREFIX` and the built-in JSR registry URL moved from `pnpm-resolving-npm-resolver` into `pnpm-config` so the config record and the resolver consult one constant; the resolver re-exports them, keeping existing import paths working.

## Squash Commit Body

```text
`pnpm config get registries` printed `undefined`: the reader splits the
setting into internal lookups and deletes the raw key. The same
translate-and-delete pattern hid `update` and `audit`, whose deprecated
internal spellings were the only readable names, and pacquet's config
record diverged from the TypeScript CLI on a dozen keys.

Both CLIs now answer the documented names with the settings they act
on, and print byte-identical JSON:

- `registries`: the resolved view, merged across every source, keyed by
  registry URL with the default registry as the bare `@` scope and the
  built-in routes (the `@jsr` scope, the `npmjs` / `gh` prefixes)
  declared unless pointed elsewhere. Built on the existing pnpr-request
  rebuilder (`toRegistryDeclarations` / `registries::to_declarations`),
  with a canonical key/field/scope order. The internal lookups
  (`registriesByScope`, `registriesByPrefix`, `registryOptionsByUrl`)
  leave the record. `BUILTIN_REGISTRIES_BY_PREFIX` and the JSR default
  moved from the npm resolver into `pnpm-config` so both layers consult
  one constant.
- `update` / `audit`: re-joined from `updateConfig` and
  `auditConfig`/`auditLevel`, whichever spelling set them; the
  deprecated spellings leave the record. Pacquet mirrors `audit.level`
  into its explicit `auditLevel` entry so `config get audit-level`
  answers the way the TypeScript CLI does.
- Pacquet record holes: `packages`, `catalog`, `catalogs` (shown merged,
  with the singular `catalog` block as its `default` entry),
  `onlyBuiltDependencies`, `neverBuiltDependencies`, and
  `ignoredBuiltDependencies` are now carried by `WorkspaceSettings` for
  display only; the global config.yaml refuses them via the existing
  workspace-only clearing.
- Pacquet answered `undefined` for `registry` and `@jsr:registry` where
  the TypeScript CLI answers the built-in defaults; the JSR default
  registry moved from the npm resolver into `pnpm-config` so both
  consult one constant. `patchedDependencies` now displays
  workspace-resolved paths, matching the TypeScript record.
- `RegistryDeclaration` serialization skips absent fields, so pacquet's
  pnpr requests stop sending nulls the TypeScript CLI's requests omit.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14043"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789860927&installation_model_id=426870&pr_number=14043&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14043&signature=fb3cbdd3349be257b9ec9d471abca17a845a140403d7cfd121e08cb45d8ab2b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `config get` and `config list` now display resolved default, scoped, built-in, and JSR registry settings.
  - Configuration output includes user-facing `update` and `audit` sections.
  - Workspace catalog and build-dependency settings are represented accurately, including merged catalog values.
  - Registry declarations and configuration fields use consistent, deterministic ordering.

- **Bug Fixes**
  - Deprecated internal configuration names are omitted from command output.
  - Empty catalog configurations are omitted, and singular catalogs resolve as default entries.
  - Registry URLs are normalized consistently with trailing slashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->