### PR TITLE
feat(config): report settings unknown to this version of pnpm

### DIFF
--- a/.changeset/config-unknown-settings-warning.md
+++ b/.changeset/config-unknown-settings-warning.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config.reader": minor
+"pnpm": minor
+---
+
+Settings that no supported pnpm version recognizes get their own warning. A key in the global config file that this version of pnpm does not read is no longer reported with advice to move it to a project-level `pnpm-workspace.yaml` (where it would be ignored too); the warning now says the setting is not recognized by this version of pnpm, names the pnpm version that does read it when there is one (for example, `globalShims` is a pnpm v12 setting), and suggests the closest real setting name when the key looks like a typo. Unrecognized and non-camelCase keys in a project's `pnpm-workspace.yaml`, previously ignored silently, are now reported the same way. `pnpm config get <key>` and `pnpm get <key>` no longer print config-load warnings, so a script capturing the value gets the value alone.

--- a/.changeset/pacquet-strict-workspace-settings.md
+++ b/.changeset/pacquet-strict-workspace-settings.md
@@ -1,5 +1,7 @@
 ---
-"pacquet": minor
+"pacquet": major
 ---
 
-Unrecognized settings in a project's `pnpm-workspace.yaml` are now reported instead of being ignored silently. They warn — suggesting the closest real setting name when the key looks like a typo — and fail the command with `ERR_PNPM_UNRECOGNIZED_WORKSPACE_SETTINGS` when the project pins a pnpm version the running pnpm satisfies, since a satisfied pin means the setting cannot be meant for a different pnpm version. The `pnpm config` subcommands never fail on such keys, so a broken file can still be inspected and repaired, and `pnpm config get <key>` prints the value with no warnings at all. Keys the global config file cannot set are likewise split between workspace-only settings (still directed to `pnpm-workspace.yaml`) and settings unknown to this version.
+A project's `pnpm-workspace.yaml` may no longer carry a setting pnpm does not recognize. Such a setting used to be ignored in silence — a misspelled `minimumReleaseAge` dropped the policy it was meant to set, and nothing said so. Now it is reported, suggesting the closest real setting name when the key looks like a typo, and it fails the command with `ERR_PNPM_UNRECOGNIZED_WORKSPACE_SETTINGS` when the project pins a pnpm version the running pnpm satisfies: with the pin honored, the setting cannot be meant for a different pnpm version, so it is a mistake to fix rather than a key to ignore. Everywhere else it is a warning, so a project that has yet to be cleaned up keeps working.
+
+The `pnpm config` subcommands never fail on such a setting, so a broken file can still be inspected and repaired, and `pnpm config get <key>` prints the value with no warnings at all. Keys the global config file cannot set are likewise split between workspace-only settings (still directed to `pnpm-workspace.yaml`) and settings unknown to this version.

--- a/.changeset/pacquet-strict-workspace-settings.md
+++ b/.changeset/pacquet-strict-workspace-settings.md
@@ -1,0 +1,5 @@
+---
+"pacquet": minor
+---
+
+Unrecognized settings in a project's `pnpm-workspace.yaml` are now reported instead of being ignored silently. They warn — suggesting the closest real setting name when the key looks like a typo — and fail the command with `ERR_PNPM_UNRECOGNIZED_WORKSPACE_SETTINGS` when the project pins a pnpm version the running pnpm satisfies, since a satisfied pin means the setting cannot be meant for a different pnpm version. The `pnpm config` subcommands never fail on such keys, so a broken file can still be inspected and repaired, and `pnpm config get <key>` prints the value with no warnings at all. Keys the global config file cannot set are likewise split between workspace-only settings (still directed to `pnpm-workspace.yaml`) and settings unknown to this version.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2539,6 +2539,9 @@ importers:
       ci-info:
         specifier: 'catalog:'
         version: 4.4.0
+      didyoumean2:
+        specifier: 'catalog:'
+        version: 7.0.4
       is-subdir:
         specifier: 'catalog:'
         version: 2.0.0

--- a/pnpm/crates/cli/src/cli_args/config_warnings.rs
+++ b/pnpm/crates/cli/src/cli_args/config_warnings.rs
@@ -6,7 +6,12 @@
 //! captures. Warnings emitted through the reporter stay on stdout; only
 //! config-load warnings belong here.
 
-use pnpm_config::Config;
+use derive_more::{Display, Error};
+use miette::Diagnostic;
+use pnpm_config::{
+    Config, WorkspaceKeyIssues, known_settings::annotate_unknown_setting,
+    naming_cases::to_camel_case, refused_keys::where_refused_key_belongs,
+};
 use pnpm_default_reporter::colors::Colors;
 use pnpm_network::redact_and_sanitize;
 use pnpm_resolving_npm_resolver::BUILTIN_REGISTRIES_BY_PREFIX;
@@ -75,6 +80,82 @@ fn unmatched_registry_options_warning(config: &Config) -> Option<String> {
         r#"The following "registries" entries do not match any configured registry and were ignored: {}. The configured registries are: {configured}."#,
         unmatched.join(", "),
     ))
+}
+
+/// Settings in a project's `pnpm-workspace.yaml` that this version of pnpm
+/// does not recognize, raised instead of a warning when the project pins a
+/// pnpm the running pnpm satisfies: with the pin honored, the keys cannot be
+/// meant for a different pnpm version, so they are a typo or a removed
+/// setting the project must fix.
+#[derive(Debug, Display, Error, Diagnostic)]
+#[display(
+    "The following settings in pnpm-workspace.yaml are not recognized by this version of pnpm: {keys}."
+)]
+#[diagnostic(
+    code(ERR_PNPM_UNRECOGNIZED_WORKSPACE_SETTINGS),
+    help(
+        "The project pins pnpm to a version the running pnpm satisfies, so these settings cannot be meant for a different pnpm version. Remove them from pnpm-workspace.yaml or fix their spelling."
+    )
+)]
+pub(crate) struct UnrecognizedWorkspaceSettingsError {
+    keys: String,
+}
+
+/// Report the problem keys of the project's `pnpm-workspace.yaml`, in pnpm's
+/// order (refused, unrecognized, kebab-case). Unrecognized keys are a
+/// warning, or — when `strict` (the running pnpm is the version the project
+/// pins) — the error above, raised after the other warnings are out.
+pub(crate) fn report_workspace_key_issues(
+    issues: &WorkspaceKeyIssues,
+    strict: bool,
+) -> Result<(), UnrecognizedWorkspaceSettingsError> {
+    if !issues.refused.is_empty() {
+        emit_config_warning(&refused_workspace_keys_warning(&issues.refused));
+    }
+    let unrecognized = annotate_unknown_settings(&issues.unrecognized);
+    if let Some(unrecognized) = unrecognized.as_deref()
+        && !strict
+    {
+        emit_config_warning(&format!(
+            "The following settings in pnpm-workspace.yaml are not recognized by this version of pnpm and were ignored: {unrecognized}.",
+        ));
+    }
+    if !issues.non_camel_case.is_empty() {
+        emit_config_warning(&non_camel_case_workspace_keys_warning(&issues.non_camel_case));
+    }
+    match unrecognized {
+        Some(keys) if strict => Err(UnrecognizedWorkspaceSettingsError { keys }),
+        _ => Ok(()),
+    }
+}
+
+fn refused_workspace_keys_warning(keys: &[String]) -> String {
+    let keys = keys
+        .iter()
+        .map(|key| format!(r#""{key}" ({})"#, where_refused_key_belongs(&to_camel_case(key))))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "The following settings cannot be set in a project's pnpm-workspace.yaml and were ignored: {keys}.",
+    )
+}
+
+fn annotate_unknown_settings(keys: &[String]) -> Option<String> {
+    if keys.is_empty() {
+        return None;
+    }
+    Some(keys.iter().map(|key| annotate_unknown_setting(key)).collect::<Vec<_>>().join(", "))
+}
+
+fn non_camel_case_workspace_keys_warning(keys: &[String]) -> String {
+    let keys = keys
+        .iter()
+        .map(|key| format!(r#""{key}" (use "{}")"#, to_camel_case(key)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "The following settings in pnpm-workspace.yaml were ignored because they are not written in camelCase: {keys}.",
+    )
 }
 
 #[cfg(test)]

--- a/pnpm/crates/cli/src/cli_args/config_warnings.rs
+++ b/pnpm/crates/cli/src/cli_args/config_warnings.rs
@@ -132,7 +132,8 @@ pub(crate) fn report_workspace_key_issues(
 fn refused_workspace_keys_warning(keys: &[String]) -> String {
     let keys = keys
         .iter()
-        .map(|key| format!(r#""{key}" ({})"#, where_refused_key_belongs(&to_camel_case(key))))
+        .map(|key| redact_and_sanitize(key))
+        .map(|key| format!(r#""{key}" ({})"#, where_refused_key_belongs(&to_camel_case(&key))))
         .collect::<Vec<_>>()
         .join(", ");
     format!(
@@ -144,13 +145,19 @@ fn annotate_unknown_settings(keys: &[String]) -> Option<String> {
     if keys.is_empty() {
         return None;
     }
-    Some(keys.iter().map(|key| annotate_unknown_setting(key)).collect::<Vec<_>>().join(", "))
+    Some(
+        keys.iter()
+            .map(|key| annotate_unknown_setting(&redact_and_sanitize(key)))
+            .collect::<Vec<_>>()
+            .join(", "),
+    )
 }
 
 fn non_camel_case_workspace_keys_warning(keys: &[String]) -> String {
     let keys = keys
         .iter()
-        .map(|key| format!(r#""{key}" (use "{}")"#, to_camel_case(key)))
+        .map(|key| redact_and_sanitize(key))
+        .map(|key| format!(r#""{key}" (use "{}")"#, to_camel_case(&key)))
         .collect::<Vec<_>>()
         .join(", ");
     format!(

--- a/pnpm/crates/cli/src/cli_args/config_warnings/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/config_warnings/tests.rs
@@ -76,3 +76,53 @@ fn redacts_credentials_in_the_warning() {
     assert!(!received.contains("ci-user-6e42"), "the username must not be echoed: {received}");
     assert!(received.contains("npm.example.com"), "the host is still named: {received}");
 }
+
+mod workspace_key_issues {
+    use super::super::{
+        non_camel_case_workspace_keys_warning, refused_workspace_keys_warning,
+        report_workspace_key_issues,
+    };
+    use pnpm_config::WorkspaceKeyIssues;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn refused_keys_name_where_each_belongs() {
+        assert_eq!(
+            refused_workspace_keys_warning(&["configDir".to_string(), "bin".to_string()]),
+            "The following settings cannot be set in a project's pnpm-workspace.yaml and were \
+             ignored: \"configDir\" (This is not a pnpm setting), \"bin\" (Set it for the machine \
+             instead: pnpm config set --global global-bin-dir).",
+        );
+    }
+
+    #[test]
+    fn non_camel_case_keys_name_the_spelling_that_works() {
+        assert_eq!(
+            non_camel_case_workspace_keys_warning(&["store-dir".to_string()]),
+            "The following settings in pnpm-workspace.yaml were ignored because they are not \
+             written in camelCase: \"store-dir\" (use \"storeDir\").",
+        );
+    }
+
+    #[test]
+    fn unrecognized_keys_error_only_when_strict() {
+        let issues = WorkspaceKeyIssues {
+            unrecognized: vec!["minimumReleaseAg".to_string()],
+            ..WorkspaceKeyIssues::default()
+        };
+        report_workspace_key_issues(&issues, false).expect("a warning, not an error");
+        let error =
+            report_workspace_key_issues(&issues, true).expect_err("strict must fail").to_string();
+        assert_eq!(
+            error,
+            "The following settings in pnpm-workspace.yaml are not recognized by this version of \
+             pnpm: \"minimumReleaseAg\" (did you mean \"minimumReleaseAge\"?).",
+        );
+    }
+
+    #[test]
+    fn a_clean_file_reports_nothing_even_when_strict() {
+        report_workspace_key_issues(&WorkspaceKeyIssues::default(), true)
+            .expect("nothing to report");
+    }
+}

--- a/pnpm/crates/cli/src/cli_args/pre_command.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command.rs
@@ -23,6 +23,7 @@ use super::{
     with::{PackageManagerCheck, spawn_pnpm},
 };
 use crate::{
+    cli_args::config_warnings::report_workspace_key_issues,
     config_deps,
     config_overrides::ConfigOverrides,
     engine_pm::{
@@ -65,6 +66,7 @@ pub(crate) fn pre_command_plan(
             check_runtimes: true,
             syncs_env_lockfile_in_pipeline: syncs_env_lockfile_in_pipeline(&args.command),
             emit: reporter_emit(args.reporter),
+            key_issues: key_issue_reporting(&args.command),
         },
         config_overrides,
         SwitchProcessState::current(),
@@ -88,6 +90,9 @@ pub(crate) fn pre_command_plan_for_version_flag(
             // would record the pin.
             syncs_env_lockfile_in_pipeline: false,
             emit: DefaultReporter::emit,
+            // Printing the version must work in a project whose
+            // `pnpm-workspace.yaml` is broken, like the runtime checks above.
+            key_issues: KeyIssueReporting::WarnOnly,
         },
         config_overrides,
         SwitchProcessState::current(),
@@ -204,9 +209,14 @@ fn pre_command_plan_from_input(
     let root_dir = config.workspace_dir.clone().unwrap_or_else(|| dir.clone());
     let manifest = read_manifest_json(&root_dir.join("package.json"))?;
 
+    let wanted_pm = manifest.as_ref().and_then(wanted_package_manager);
+    let running_matches_pin = wanted_pm.as_ref().is_some_and(|pm| {
+        pm.name == "pnpm"
+            && pm.version.as_deref().is_some_and(|version| version_satisfies(PNPM_VERSION, version))
+    });
     let mut package_manager_to_sync = None;
     if let Some(root_manifest) = manifest.as_ref()
-        && let Some(pm) = wanted_package_manager(root_manifest)
+        && let Some(pm) = wanted_pm
     {
         let on_fail = effective_on_fail(&config, &pm);
         let switch_wanted = pm.name == "pnpm" && on_fail == PmOnFail::Download;
@@ -253,6 +263,14 @@ fn pre_command_plan_from_input(
                 )?;
             }
         }
+    }
+
+    if input.key_issues != KeyIssueReporting::Skip {
+        // A `--global` invocation does not act on the project, so a satisfied
+        // pin does not harden its unrecognized-key report into an error.
+        let strict =
+            input.key_issues == KeyIssueReporting::Enforce && running_matches_pin && !input.global;
+        report_workspace_key_issues(&config.workspace_key_issues, strict)?;
     }
 
     if input.check_runtimes
@@ -529,6 +547,33 @@ struct PreCommandInput {
     check_runtimes: bool,
     syncs_env_lockfile_in_pipeline: bool,
     emit: fn(&LogEvent),
+    key_issues: KeyIssueReporting,
+}
+
+/// What to do about the problem keys of the project's `pnpm-workspace.yaml`
+/// (see [`report_workspace_key_issues`]), decided per invocation.
+#[derive(Clone, Copy, PartialEq)]
+enum KeyIssueReporting {
+    /// `pnpm config get <key>` prints one value for a script to capture, so
+    /// config-load warnings stay off it entirely, as pnpm keeps them off.
+    Skip,
+    /// The other `pnpm config` subcommands are how a user inspects and
+    /// repairs the config, so they must keep working on a broken file:
+    /// unrecognized keys warn even under a satisfied pin.
+    WarnOnly,
+    /// Unrecognized keys warn, or fail the command when the running pnpm is
+    /// the version the project pins (no version-skew excuse remains).
+    Enforce,
+}
+
+fn key_issue_reporting(command: &CliCommand) -> KeyIssueReporting {
+    match command {
+        CliCommand::Config(args) => match &args.command {
+            ConfigSubcommand::Get(get) if get.key.is_some() => KeyIssueReporting::Skip,
+            _ => KeyIssueReporting::WarnOnly,
+        },
+        _ => KeyIssueReporting::Enforce,
+    }
 }
 
 /// The install-family commands that sync `packageManagerDependencies` from

--- a/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    PackageManagerToSync, PreCommandInput, PreCommandPlan, SwitchInput, SwitchProcessState,
-    SwitchSource, pre_command_plan_from_input, switch_target,
+    KeyIssueReporting, PackageManagerToSync, PreCommandInput, PreCommandPlan, SwitchInput,
+    SwitchProcessState, SwitchSource, pre_command_plan_from_input, switch_target,
 };
 use crate::config_overrides::ConfigOverrides;
 use pnpm_config::{Config, PNPM_VERSION, PmOnFail};
@@ -354,6 +354,7 @@ fn pre_command_input(dir: &Path) -> PreCommandInput {
         check_runtimes: true,
         syncs_env_lockfile_in_pipeline: false,
         emit: SilentReporter::emit,
+        key_issues: KeyIssueReporting::Enforce,
     }
 }
 

--- a/pnpm/crates/cli/tests/suite/main.rs
+++ b/pnpm/crates/cli/tests/suite/main.rs
@@ -125,3 +125,4 @@ mod whoami;
 mod why;
 mod with;
 mod workspace_install;
+mod workspace_settings_check;

--- a/pnpm/crates/cli/tests/suite/workspace_settings_check.rs
+++ b/pnpm/crates/cli/tests/suite/workspace_settings_check.rs
@@ -57,8 +57,7 @@ fn a_kebab_case_spelling_of_a_known_setting_warns() {
     );
 }
 
-/// `pnpm config get <key>` prints one value for a script to capture, so even
-/// a pinned project with a broken `pnpm-workspace.yaml` answers it silently.
+/// Single-key reads are consumed by scripts, so nothing may join the value.
 #[test]
 fn config_get_of_one_key_stays_quiet_and_succeeds() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
@@ -74,8 +73,7 @@ fn config_get_of_one_key_stays_quiet_and_succeeds() {
     assert!(!stderr.contains("not recognized"), "expected no unrecognized report; got:\n{stderr}");
 }
 
-/// The other `pnpm config` subcommands are how a user inspects and repairs
-/// the config, so a satisfied pin downgrades the error back to a warning.
+/// A broken config file must stay inspectable and repairable.
 #[test]
 fn config_list_warns_but_succeeds_under_a_satisfied_pin() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
@@ -89,6 +87,54 @@ fn config_list_warns_but_succeeds_under_a_satisfied_pin() {
         &stderr(&output),
         r#"[WARN] The following settings in pnpm-workspace.yaml are not recognized by this version of pnpm and were ignored: "minimumReleaseAg" (did you mean "minimumReleaseAge"?)."#,
     );
+}
+
+/// A `--global` command does not act on the project, so the project's pin
+/// does not harden the report into an error.
+#[test]
+fn a_global_command_warns_under_a_satisfied_pin() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace_yaml(&workspace, "minimumReleaseAg: 100\n");
+    write_package_manager_pin(&workspace);
+
+    let global_bin = root.path().join("pnpm-home");
+    fs::create_dir_all(&global_bin).expect("create the global bin dir");
+    let mut pacquet = pacquet;
+    pacquet.env("PATH", prepend_to_path(&global_bin));
+    let output = run_with_switch_disabled(pacquet, root.path(), &["list", "--global"]);
+
+    assert_success(&output);
+    assert_contains(
+        &stderr(&output),
+        r#"[WARN] The following settings in pnpm-workspace.yaml are not recognized by this version of pnpm and were ignored: "minimumReleaseAg" (did you mean "minimumReleaseAge"?)."#,
+    );
+}
+
+/// A key carrying terminal escapes reaches stderr and any CI log, so the
+/// report must not let it move the cursor or repaint the screen.
+#[test]
+fn a_key_with_control_characters_is_sanitized() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_plain_manifest(&workspace);
+    write_workspace_yaml(&workspace, "\"nope\\e[31mRED\\r\": 1\npackages:\n  - .\n");
+
+    let output = run(pacquet, root.path(), &["install", "--lockfile-only"]);
+
+    assert_success(&output);
+    let stderr = stderr(&output);
+    assert_contains(&stderr, "not recognized by this version of pnpm");
+    assert!(!stderr.contains('\u{1b}'), "an escape reached the output: {stderr:?}");
+    assert!(!stderr.contains('\r'), "a carriage return reached the output: {stderr:?}");
+}
+
+/// `pnpm list --global` refuses to run when the global bin directory is not
+/// on `PATH`, which is about the environment rather than this file.
+fn prepend_to_path(dir: &Path) -> std::ffi::OsString {
+    let mut entries = vec![dir.to_path_buf()];
+    if let Some(path) = std::env::var_os("PATH") {
+        entries.extend(std::env::split_paths(&path));
+    }
+    std::env::join_paths(entries).expect("join PATH entries")
 }
 
 fn write_plain_manifest(workspace: &Path) {

--- a/pnpm/crates/cli/tests/suite/workspace_settings_check.rs
+++ b/pnpm/crates/cli/tests/suite/workspace_settings_check.rs
@@ -1,0 +1,176 @@
+//! Reporting of `pnpm-workspace.yaml` keys that set nothing: unrecognized
+//! settings warn, harden into an error when the running pnpm is the version
+//! the project pins, and stay off `pnpm config get <key>` entirely.
+
+use pnpm_testing_utils::bin::CommandTempCwd;
+use std::{
+    fs,
+    path::Path,
+    process::{Command, Output},
+};
+
+#[test]
+fn an_unrecognized_workspace_setting_warns_without_a_pin() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_plain_manifest(&workspace);
+    write_workspace_yaml(&workspace, "minimumReleaseAg: 100\npackages:\n  - .\n");
+
+    let output = run(pacquet, root.path(), &["install", "--lockfile-only"]);
+
+    assert_success(&output);
+    assert_contains(
+        &stderr(&output),
+        r#"[WARN] The following settings in pnpm-workspace.yaml are not recognized by this version of pnpm and were ignored: "minimumReleaseAg" (did you mean "minimumReleaseAge"?)."#,
+    );
+}
+
+#[test]
+fn an_unrecognized_workspace_setting_fails_when_the_running_pnpm_is_the_pinned_version() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace_yaml(&workspace, "minimumReleaseAg: 100\npackages:\n  - .\n");
+    write_package_manager_pin(&workspace);
+
+    let output =
+        run(pacquet, root.path(), &["install", "--lockfile-only", "--config.pm-on-fail=error"]);
+
+    assert_failure(&output);
+    let stderr = stderr(&output);
+    assert_contains(&stderr, "ERR_PNPM_UNRECOGNIZED_WORKSPACE_SETTINGS");
+    assert_contains(
+        &stderr,
+        r#"The following settings in pnpm-workspace.yaml are not recognized by this version of pnpm: "minimumReleaseAg" (did you mean "minimumReleaseAge"?)."#,
+    );
+}
+
+#[test]
+fn a_kebab_case_spelling_of_a_known_setting_warns() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_plain_manifest(&workspace);
+    write_workspace_yaml(&workspace, "store-dir: some-store\npackages:\n  - .\n");
+
+    let output = run(pacquet, root.path(), &["install", "--lockfile-only"]);
+
+    assert_success(&output);
+    assert_contains(
+        &stderr(&output),
+        r#"[WARN] The following settings in pnpm-workspace.yaml were ignored because they are not written in camelCase: "store-dir" (use "storeDir")."#,
+    );
+}
+
+/// `pnpm config get <key>` prints one value for a script to capture, so even
+/// a pinned project with a broken `pnpm-workspace.yaml` answers it silently.
+#[test]
+fn config_get_of_one_key_stays_quiet_and_succeeds() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace_yaml(&workspace, "minimumReleaseAg: 100\nnodeLinker: hoisted\n");
+    write_package_manager_pin(&workspace);
+
+    let output = run_with_switch_disabled(pacquet, root.path(), &["config", "get", "node-linker"]);
+
+    assert_success(&output);
+    assert_contains(&stdout(&output), "hoisted");
+    let stderr = stderr(&output);
+    assert!(!stderr.contains("[WARN]"), "expected no config warning; got:\n{stderr}");
+    assert!(!stderr.contains("not recognized"), "expected no unrecognized report; got:\n{stderr}");
+}
+
+/// The other `pnpm config` subcommands are how a user inspects and repairs
+/// the config, so a satisfied pin downgrades the error back to a warning.
+#[test]
+fn config_list_warns_but_succeeds_under_a_satisfied_pin() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace_yaml(&workspace, "minimumReleaseAg: 100\n");
+    write_package_manager_pin(&workspace);
+
+    let output = run_with_switch_disabled(pacquet, root.path(), &["config", "list"]);
+
+    assert_success(&output);
+    assert_contains(
+        &stderr(&output),
+        r#"[WARN] The following settings in pnpm-workspace.yaml are not recognized by this version of pnpm and were ignored: "minimumReleaseAg" (did you mean "minimumReleaseAge"?)."#,
+    );
+}
+
+fn write_plain_manifest(workspace: &Path) {
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "name": "plain", "version": "1.0.0", "private": true }).to_string(),
+    )
+    .expect("write package.json");
+}
+
+fn write_workspace_yaml(workspace: &Path, contents: &str) {
+    fs::write(workspace.join("pnpm-workspace.yaml"), contents).expect("write pnpm-workspace.yaml");
+}
+
+/// Pin the running pnpm version itself, with `pm-on-fail` left to each test:
+/// the check must pass while the strictness decision sees a satisfied pin.
+fn write_package_manager_pin(workspace: &Path) {
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "name": "pinned",
+            "version": "1.0.0",
+            "private": true,
+            "packageManager": format!("pnpm@{}", pnpm_config::PNPM_VERSION),
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+}
+
+fn run(command: Command, root: &Path, args: &[&str]) -> Output {
+    let mut command = command;
+    command.env("PNPM_HOME", root.join("pnpm-home"));
+    command.env("HOME", root);
+    command.env("XDG_CONFIG_HOME", root.join("xdg-config"));
+    command.args(args).output().expect("run pacquet")
+}
+
+/// A pinned project would otherwise resolve the pin's env-lockfile entry,
+/// which needs a registry; turning version management off keeps the test
+/// hermetic while the pin stays visible to the strictness decision.
+fn run_with_switch_disabled(mut command: Command, root: &Path, args: &[&str]) -> Output {
+    command.env("PNPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS", "false");
+    run(command, root, args)
+}
+
+fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "command should succeed\nstdout:\n{}\nstderr:\n{}",
+        stdout(output),
+        stderr(output),
+    );
+}
+
+fn assert_failure(output: &Output) {
+    assert!(
+        !output.status.success(),
+        "command should fail\nstdout:\n{}\nstderr:\n{}",
+        stdout(output),
+        stderr(output),
+    );
+}
+
+fn assert_contains(text: &str, expected: &str) {
+    assert!(
+        unwrap_diagnostic(text).contains(&unwrap_diagnostic(expected)),
+        "expected {expected:?} in:\n{text}",
+    );
+}
+
+/// miette hard-wraps a diagnostic to the terminal width and prefixes the
+/// continuation lines with `│`, so an expected message only matches after
+/// both sides are flattened to single-spaced text.
+fn unwrap_diagnostic(text: &str) -> String {
+    text.replace('│', " ").split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}

--- a/pnpm/crates/config/src/known_settings.rs
+++ b/pnpm/crates/config/src/known_settings.rs
@@ -149,6 +149,9 @@ pub fn is_known_setting_key(key: &str) -> bool {
 
 /// Render an unrecognized key for a warning or error, appending the closest
 /// known setting name when one is close enough to look like a typo.
+///
+/// `key` must already be sanitized for display: it comes from a config file a
+/// repository may control, and the rendering reaches a terminal or a CI log.
 #[must_use]
 pub fn annotate_unknown_setting(key: &str) -> String {
     let camel = to_camel_case(key);

--- a/pnpm/crates/config/src/known_settings.rs
+++ b/pnpm/crates/config/src/known_settings.rs
@@ -1,0 +1,202 @@
+//! Which keys name a setting some supported pnpm reads, and the suggestion
+//! for a key that names none.
+//!
+//! Mirrors `unknownSettings.ts` in pnpm's `config.reader`: the lists below
+//! are copies of its lists, so the two stacks agree on which keys get the
+//! "not recognized by this version of pnpm" treatment. The pacquet-only
+//! settings (e.g. `globalShims`) enter through [`WorkspaceSettings`]'s own
+//! field names instead.
+
+use crate::{
+    WorkspaceSettings,
+    config_types::is_type_key,
+    naming_cases::{to_camel_case, to_kebab_case},
+};
+use std::{collections::HashSet, sync::OnceLock};
+
+/// A YAML-language-server schema association, not a setting; tools put it in
+/// config files pnpm reads, so it must not trip the unknown-setting warnings.
+pub const SCHEMA_DIRECTIVE_KEY: &str = "$schema";
+
+/// Mirror of the same-named list in `unknownSettings.ts`.
+const TYPED_WORKSPACE_MANIFEST_KEYS: &[&str] = &[
+    "allowBuilds",
+    "allowUnusedPatches",
+    "allowedDeprecatedVersions",
+    "audit",
+    "auditConfig",
+    "catalog",
+    "catalogs",
+    "configDependencies",
+    "enableGlobalVirtualStore",
+    "httpProxy",
+    "httpsProxy",
+    "ignoredOptionalDependencies",
+    "namedRegistries",
+    "nodeDownloadMirrors",
+    "noProxy",
+    "npmrcAuthFile",
+    "overrides",
+    "packageExtensions",
+    "packages",
+    "patchedDependencies",
+    "peerDependencyRules",
+    "pnprServer",
+    "registries",
+    "requiredScripts",
+    "supportedArchitectures",
+    "update",
+    "updateConfig",
+    "versioning",
+    "virtualStoreType",
+];
+
+/// Mirror of the same-named list in `unknownSettings.ts`: settings whose only
+/// spelling in pnpm is a camelCase config field, plus pnpm's reader-derived
+/// fields.
+const CONFIG_ONLY_SETTING_KEYS: &[&str] = &[
+    "allowNew",
+    "authConfig",
+    "autoConfirmAllPrompts",
+    "bin",
+    "catalogPrune",
+    "cleanupUnusedCatalogs",
+    "configByUri",
+    "enablePnp",
+    "extraBinPaths",
+    "extraEnv",
+    "globalPkgDir",
+    "globalPrefix",
+    "ignoreCurrentSpecifiers",
+    "maxSockets",
+    "minimumReleaseAgeExcludePrune",
+    "packageConfigs",
+    "packageManagerNetworkConfig",
+    "packageManagerRegistries",
+    "pending",
+    "pnpmExecPath",
+    "pnpmHomeDir",
+    "recursive",
+    "registriesByPrefix",
+    "registriesByScope",
+    "registryOptionsByUrl",
+    "reverse",
+    "sideEffectsCacheRead",
+    "sideEffectsCacheWrite",
+    "tryLoadDefaultPnpmfile",
+    "useGitBranchLockfile",
+    "useLockfile",
+    "useRunningStoreServer",
+    "useStoreServer",
+    "userConfig",
+    "workspaceDir",
+    "workspacePackagePatterns",
+    "workspacePrefix",
+];
+
+/// Mirror of the same-named list in `unknownSettings.ts`.
+const UNTYPED_WORKSPACE_SETTING_KEYS: &[&str] = &[
+    "executionEnv",
+    "ignoredBuiltDependencies",
+    "neverBuiltDependencies",
+    "onlyBuiltDependencies",
+    "onlyBuiltDependenciesFile",
+];
+
+/// The camelCase field names of [`WorkspaceSettings`], read off its serde
+/// serialization so the set cannot drift from the struct.
+fn settings_field_keys() -> &'static HashSet<String> {
+    static SET: OnceLock<HashSet<String>> = OnceLock::new();
+    SET.get_or_init(|| match serde_json::to_value(WorkspaceSettings::default()) {
+        Ok(serde_json::Value::Object(fields)) => fields.into_iter().map(|(key, _)| key).collect(),
+        _ => HashSet::new(),
+    })
+}
+
+fn known_setting_keys() -> &'static HashSet<String> {
+    static SET: OnceLock<HashSet<String>> = OnceLock::new();
+    SET.get_or_init(|| {
+        TYPED_WORKSPACE_MANIFEST_KEYS
+            .iter()
+            .chain(CONFIG_ONLY_SETTING_KEYS)
+            .chain(UNTYPED_WORKSPACE_SETTING_KEYS)
+            .map(|key| (*key).to_string())
+            .chain(settings_field_keys().iter().cloned())
+            .collect()
+    })
+}
+
+/// The same corpus in a stable order, so the suggestion picked among
+/// equally-close candidates does not vary run to run.
+fn known_setting_keys_sorted() -> &'static Vec<String> {
+    static LIST: OnceLock<Vec<String>> = OnceLock::new();
+    LIST.get_or_init(|| {
+        let mut keys: Vec<String> = known_setting_keys().iter().cloned().collect();
+        keys.sort_unstable();
+        keys
+    })
+}
+
+/// Whether `key`, given in either camelCase or kebab-case, names a setting
+/// some supported pnpm reads from at least one config source. A key failing
+/// this check is a typo or belongs to a pnpm version this repository does not
+/// know, so it gets the "not recognized by this version of pnpm" warning
+/// instead of advice to move it to another config file.
+#[must_use]
+pub fn is_known_setting_key(key: &str) -> bool {
+    known_setting_keys().contains(to_camel_case(key).as_str()) || is_type_key(&to_kebab_case(key))
+}
+
+/// Render an unrecognized key for a warning or error, appending the closest
+/// known setting name when one is close enough to look like a typo.
+#[must_use]
+pub fn annotate_unknown_setting(key: &str) -> String {
+    let camel = to_camel_case(key);
+    match did_you_mean(&camel, known_setting_keys_sorted().iter().map(String::as_str)) {
+        Some(suggestion) => format!(r#""{key}" (did you mean "{suggestion}"?)"#),
+        None => format!(r#""{key}""#),
+    }
+}
+
+/// The candidate most similar to `input`, if any clears the similarity
+/// threshold `didyoumean2` (pnpm's suggester) applies by default:
+/// `1 - distance / max_len >= 0.4`, compared case-insensitively.
+fn did_you_mean<'a>(input: &str, candidates: impl IntoIterator<Item = &'a str>) -> Option<&'a str> {
+    let input_lower = input.to_lowercase();
+    let mut best: Option<(&str, f64)> = None;
+    for candidate in candidates {
+        let candidate_lower = candidate.to_lowercase();
+        let input_chars: Vec<char> = input_lower.chars().collect();
+        let candidate_chars: Vec<char> = candidate_lower.chars().collect();
+        let max_len = input_chars.len().max(candidate_chars.len());
+        if max_len == 0 {
+            continue;
+        }
+        let distance = levenshtein(&input_chars, &candidate_chars);
+        #[expect(clippy::cast_precision_loss, reason = "setting names are far shorter than 2^52")]
+        let similarity = 1.0 - distance as f64 / max_len as f64;
+        if similarity >= 0.4 && best.is_none_or(|(_, best_similarity)| similarity > best_similarity)
+        {
+            best = Some((candidate, similarity));
+        }
+    }
+    best.map(|(candidate, _)| candidate)
+}
+
+fn levenshtein(left: &[char], right: &[char]) -> usize {
+    let mut previous_row: Vec<usize> = (0..=right.len()).collect();
+    for (row, left_char) in left.iter().enumerate() {
+        let mut current_row = vec![row + 1];
+        for (column, right_char) in right.iter().enumerate() {
+            let substitution = previous_row[column] + usize::from(left_char != right_char);
+            let insertion = current_row[column] + 1;
+            let deletion = previous_row[column + 1] + 1;
+            current_row.push(substitution.min(insertion).min(deletion));
+        }
+        previous_row = current_row;
+    }
+    previous_row[right.len()]
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/config/src/known_settings.rs
+++ b/pnpm/crates/config/src/known_settings.rs
@@ -165,17 +165,24 @@ pub fn annotate_unknown_setting(key: &str) -> String {
 /// threshold `didyoumean2` (pnpm's suggester) applies by default:
 /// `1 - distance / max_len >= 0.4`, compared case-insensitively.
 fn did_you_mean<'a>(input: &str, candidates: impl IntoIterator<Item = &'a str>) -> Option<&'a str> {
-    let input_lower = input.to_lowercase();
+    let input_chars: Vec<char> = input.to_lowercase().chars().collect();
+    let mut candidate_chars = Vec::new();
+    let mut rows = LevenshteinRows::default();
     let mut best: Option<(&str, f64)> = None;
     for candidate in candidates {
-        let candidate_lower = candidate.to_lowercase();
-        let input_chars: Vec<char> = input_lower.chars().collect();
-        let candidate_chars: Vec<char> = candidate_lower.chars().collect();
+        candidate_chars.clear();
+        candidate_chars.extend(candidate.chars().flat_map(char::to_lowercase));
         let max_len = input_chars.len().max(candidate_chars.len());
         if max_len == 0 {
             continue;
         }
-        let distance = levenshtein(&input_chars, &candidate_chars);
+        // The distance is at least the length difference, so a candidate whose
+        // length alone puts it past the threshold cannot clear it, and the
+        // matrix does not have to be filled to find that out.
+        if input_chars.len().abs_diff(candidate_chars.len()) > max_len * 3 / 5 {
+            continue;
+        }
+        let distance = rows.levenshtein(&input_chars, &candidate_chars);
         #[expect(clippy::cast_precision_loss, reason = "setting names are far shorter than 2^52")]
         let similarity = 1.0 - distance as f64 / max_len as f64;
         if similarity >= 0.4 && best.is_none_or(|(_, best_similarity)| similarity > best_similarity)
@@ -186,19 +193,32 @@ fn did_you_mean<'a>(input: &str, candidates: impl IntoIterator<Item = &'a str>) 
     best.map(|(candidate, _)| candidate)
 }
 
-fn levenshtein(left: &[char], right: &[char]) -> usize {
-    let mut previous_row: Vec<usize> = (0..=right.len()).collect();
-    for (row, left_char) in left.iter().enumerate() {
-        let mut current_row = vec![row + 1];
-        for (column, right_char) in right.iter().enumerate() {
-            let substitution = previous_row[column] + usize::from(left_char != right_char);
-            let insertion = current_row[column] + 1;
-            let deletion = previous_row[column + 1] + 1;
-            current_row.push(substitution.min(insertion).min(deletion));
+/// The two rows a Levenshtein pass needs, kept across the candidates so the
+/// suggestion for one key allocates a bounded number of times rather than
+/// twice per candidate.
+#[derive(Default)]
+struct LevenshteinRows {
+    previous: Vec<usize>,
+    current: Vec<usize>,
+}
+
+impl LevenshteinRows {
+    fn levenshtein(&mut self, left: &[char], right: &[char]) -> usize {
+        self.previous.clear();
+        self.previous.extend(0..=right.len());
+        for (row, left_char) in left.iter().enumerate() {
+            self.current.clear();
+            self.current.push(row + 1);
+            for (column, right_char) in right.iter().enumerate() {
+                let substitution = self.previous[column] + usize::from(left_char != right_char);
+                let insertion = self.current[column] + 1;
+                let deletion = self.previous[column + 1] + 1;
+                self.current.push(substitution.min(insertion).min(deletion));
+            }
+            std::mem::swap(&mut self.previous, &mut self.current);
         }
-        previous_row = current_row;
+        self.previous[right.len()]
     }
-    previous_row[right.len()]
 }
 
 #[cfg(test)]

--- a/pnpm/crates/config/src/known_settings/tests.rs
+++ b/pnpm/crates/config/src/known_settings/tests.rs
@@ -1,0 +1,43 @@
+use super::{annotate_unknown_setting, is_known_setting_key};
+
+#[test]
+fn recognizes_type_keys_in_both_spellings() {
+    assert!(is_known_setting_key("minimumReleaseAge"));
+    assert!(is_known_setting_key("minimum-release-age"));
+    assert!(is_known_setting_key("nodeLinker"));
+}
+
+#[test]
+fn recognizes_structured_and_config_only_keys() {
+    assert!(is_known_setting_key("packages"));
+    assert!(is_known_setting_key("catalogs"));
+    assert!(is_known_setting_key("overrides"));
+    assert!(is_known_setting_key("catalogPrune"));
+    assert!(is_known_setting_key("executionEnv"));
+}
+
+/// `globalShims` has no entry in the mirrored pnpm lists; it must enter
+/// through the [`crate::WorkspaceSettings`] field names.
+#[test]
+fn recognizes_pacquet_only_settings_via_the_struct_fields() {
+    assert!(is_known_setting_key("globalShims"));
+}
+
+#[test]
+fn rejects_typos_and_inventions() {
+    assert!(!is_known_setting_key("minimumReleaseAg"));
+    assert!(!is_known_setting_key("zzzNotASettingZzz"));
+}
+
+#[test]
+fn annotates_a_typo_with_the_closest_setting() {
+    assert_eq!(
+        annotate_unknown_setting("minimumReleaseAg"),
+        r#""minimumReleaseAg" (did you mean "minimumReleaseAge"?)"#,
+    );
+}
+
+#[test]
+fn annotates_an_unmatchable_key_bare() {
+    assert_eq!(annotate_unknown_setting("zzzXqjWv"), r#""zzzXqjWv""#);
+}

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -4,6 +4,7 @@ mod defaults;
 mod env_overlay;
 pub mod esm_node_path_loader;
 mod global_bin_check;
+pub mod known_settings;
 pub mod matcher;
 pub mod naming_cases;
 mod npmrc_auth;
@@ -57,7 +58,7 @@ use crate::defaults::{
 pub use workspace_yaml::{
     AllowBuild, AuditSettings, GLOBAL_CONFIG_YAML_FILENAME, LoadWorkspaceYamlError,
     PackageExtension, PeerDependencyMeta, PeerDependencyRules, UpdateConfig, UpdateSettings,
-    WORKSPACE_MANIFEST_FILENAME, WorkspaceSettings, decided_allow_builds,
+    WORKSPACE_MANIFEST_FILENAME, WorkspaceKeyIssues, WorkspaceSettings, decided_allow_builds,
     registries::{self, RegistryDeclaration, RegistryEntry, RegistryLookups},
     workspace_root_or,
 };
@@ -832,6 +833,11 @@ pub struct Config {
     /// configuration.
     #[default(_code = "default_ci::<Host>(is_ci::cached)")]
     pub ci: bool,
+
+    /// The problem keys of the project's own `pnpm-workspace.yaml` (see
+    /// [`WorkspaceKeyIssues`]), for the CLI to report. Empty when there is no
+    /// workspace manifest or it is clean.
+    pub workspace_key_issues: WorkspaceKeyIssues,
 
     /// When true, all dependencies are hoisted to `node_modules/.pnpm/node_modules`.
     /// This makes unlisted dependencies accessible to all packages inside `node_modules`.
@@ -2716,10 +2722,11 @@ impl Config {
             let yaml_path = env_dir.join(WORKSPACE_MANIFEST_FILENAME);
             match fs::read_to_string(&yaml_path) {
                 Ok(text) => {
-                    let settings: WorkspaceSettings =
+                    let mut settings: WorkspaceSettings =
                         serde_saphyr::from_str(&text).map_err(Box::new).map_err(|source| {
                             LoadWorkspaceYamlError::ParseYaml { path: yaml_path, source }
                         })?;
+                    settings.collect_key_issues(&text);
                     Some((env_dir, Some(settings)))
                 }
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => Some((env_dir, None)),
@@ -2987,6 +2994,7 @@ impl Config {
                 if for_self_update {
                     settings.clear_self_update_policy();
                 }
+                self.workspace_key_issues = settings.key_issues.clone();
                 collect_explicit_settings(&mut self.explicit_settings, &settings);
                 settings.apply_to(&mut self, &base_dir);
                 // `overrides` reaches `Config` only from the workspace

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -3591,6 +3591,51 @@ pub fn global_config_yaml_keys_settable_nowhere_are_reported_with_their_route() 
     );
 }
 
+/// A key that names no setting of any supported pnpm gets the
+/// "not recognized by this version" warning — with the closest real setting
+/// when the key looks like a typo of one — instead of the move-to-workspace
+/// advice, which would send the user to a file that ignores it too.
+#[test]
+pub fn global_config_yaml_unrecognized_keys_are_reported_with_a_suggestion() {
+    let config_dir = tempdir().expect("config tempdir");
+    let config_file = config_dir.path().join("config.yaml");
+    fs::write(&config_file, "minimumReleaseAg: 100\nzzzNotASettingZzz: true\n")
+        .expect("write global config.yaml");
+
+    let warnings = capture_warnings(|| {
+        WorkspaceSettings::load_global(config_dir.path())
+            .expect("load global config.yaml")
+            .expect("global config.yaml is present");
+    });
+
+    assert_eq!(
+        warnings,
+        [format!(
+            r#"The following settings in the global config file ("{}") are not recognized by this version of pnpm and were ignored: "minimumReleaseAg" (did you mean "minimumReleaseAge"?), "zzzNotASettingZzz"."#,
+            config_file.display(),
+        )],
+    );
+}
+
+/// A `$schema` key is an editor's schema association, not a setting.
+#[test]
+pub fn global_config_yaml_schema_directive_is_silent() {
+    let config_dir = tempdir().expect("config tempdir");
+    fs::write(
+        config_dir.path().join("config.yaml"),
+        "$schema: https://json.schemastore.org/pnpm-workspace.json\n",
+    )
+    .expect("write global config.yaml");
+
+    let warnings = capture_warnings(|| {
+        WorkspaceSettings::load_global(config_dir.path())
+            .expect("load global config.yaml")
+            .expect("global config.yaml is present");
+    });
+
+    assert_eq!(warnings, Vec::<String>::new());
+}
+
 /// A dropped key pnpm honors in this file gets no warning; the rationale
 /// lives on `warn_about_dropped_keys`.
 #[test]
@@ -3617,7 +3662,7 @@ pub fn global_config_yaml_null_key_is_silent_and_the_warnings_are_ordered() {
     let config_file = config_dir.path().join("config.yaml");
     fs::write(
         &config_file,
-        "scriptShell: null\nstore-dir: /kebab-store\nconfigDir: /elsewhere\nnodeLinker: hoisted\n",
+        "scriptShell: null\nstore-dir: /kebab-store\nzzzNotASettingZzz: true\nconfigDir: /elsewhere\nnodeLinker: hoisted\n",
     )
     .expect("write global config.yaml");
 
@@ -3632,6 +3677,10 @@ pub fn global_config_yaml_null_key_is_silent_and_the_warnings_are_ordered() {
         [
             format!(
                 r#"The following settings cannot be set in the global config file ("{}") and were ignored: "nodeLinker". Move them to a project-level pnpm-workspace.yaml. To share these settings across projects, use config dependencies: https://pnpm.io/11.x/config-dependencies"#,
+                config_file.display(),
+            ),
+            format!(
+                r#"The following settings in the global config file ("{}") are not recognized by this version of pnpm and were ignored: "zzzNotASettingZzz"."#,
                 config_file.display(),
             ),
             format!(

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -5,6 +5,7 @@ use crate::{
     VirtualStoreType,
     api::EnvVar,
     config_types::is_config_file_key,
+    known_settings::{SCHEMA_DIRECTIVE_KEY, annotate_unknown_setting, is_known_setting_key},
     naming_cases::{is_camel_case, to_camel_case, to_kebab_case},
     proxy_keys::{ProxyKeys, ProxyValue},
     refused_keys::{is_refused_by_a_project_manifest, where_refused_key_belongs},
@@ -687,6 +688,31 @@ pub struct WorkspaceSettings {
     /// `peerDependencyRules` from `pnpm-workspace.yaml`. See
     /// [`PeerDependencyRules`].
     pub peer_dependency_rules: Option<PeerDependencyRules>,
+
+    /// The problem keys [`Self::collect_key_issues`] found in the file this
+    /// was parsed from. Not a setting: carried here so the CLI can report
+    /// them at the point where it knows how severe they are (see the
+    /// warnings/error in `pnpm-cli`'s `config_warnings`).
+    #[serde(skip)]
+    pub key_issues: WorkspaceKeyIssues,
+}
+
+/// The keys of a project's `pnpm-workspace.yaml` that set nothing, bucketed
+/// by why: refused values a project may not contribute, keys naming no
+/// setting any supported pnpm reads, and kebab-case spellings of keys pnpm
+/// only reads in camelCase.
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct WorkspaceKeyIssues {
+    pub refused: Vec<String>,
+    pub unrecognized: Vec<String>,
+    pub non_camel_case: Vec<String>,
+}
+
+impl WorkspaceKeyIssues {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.refused.is_empty() && self.unrecognized.is_empty() && self.non_camel_case.is_empty()
+    }
 }
 
 /// `audit` entry: settings that tune `pnpm audit`. Supersedes the
@@ -1006,9 +1032,13 @@ impl WorkspaceSettings {
         };
 
         let mut movable = Vec::new();
+        let mut unrecognized = Vec::new();
         let mut nowhere = Vec::new();
         let mut kebab_case = Vec::new();
         for key in document.iter().filter(|(_, value)| value.is_some()).map(|(key, _)| key) {
+            if key == SCHEMA_DIRECTIVE_KEY {
+                continue;
+            }
             if matches!(kept.get(key), Some(value) if !value.is_null()) {
                 continue;
             }
@@ -1018,8 +1048,10 @@ impl WorkspaceSettings {
                         r#""{key}" ({})"#,
                         where_refused_key_belongs(&to_camel_case(key)),
                     ));
-                } else {
+                } else if is_known_setting_key(key) {
                     movable.push(format!(r#""{key}""#));
+                } else {
+                    unrecognized.push(annotate_unknown_setting(key));
                 }
             } else if !is_camel_case(key) {
                 kebab_case.push(format!(r#""{key}" (use "{}")"#, to_camel_case(key)));
@@ -1032,6 +1064,13 @@ impl WorkspaceSettings {
             tracing::warn!(
                 target: "pacquet::config",
                 r#"The following settings cannot be set in the global config file ("{path}") and were ignored: {movable}. Move them to a project-level pnpm-workspace.yaml. To share these settings across projects, use config dependencies: https://pnpm.io/11.x/config-dependencies"#,
+            );
+        }
+        if !unrecognized.is_empty() {
+            let unrecognized = unrecognized.join(", ");
+            tracing::warn!(
+                target: "pacquet::config",
+                r#"The following settings in the global config file ("{path}") are not recognized by this version of pnpm and were ignored: {unrecognized}."#,
             );
         }
         if !nowhere.is_empty() {
@@ -1161,12 +1200,40 @@ impl WorkspaceSettings {
             Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
             Err(source) => return Err(LoadWorkspaceYamlError::ReadFile { path, source }),
         };
-        let settings: WorkspaceSettings = text
+        let mut settings: WorkspaceSettings = text
             .pipe_as_ref(serde_saphyr::from_str)
             .map_err(Box::new)
             .map_err(|source| LoadWorkspaceYamlError::ParseYaml { path, source })?;
         settings.validate_registries()?;
+        settings.collect_key_issues(&text);
         Ok(Some(settings))
+    }
+
+    /// Bucket the file's keys that set nothing into [`Self::key_issues`],
+    /// under the project-file rules: refused values, keys naming no setting
+    /// any supported pnpm reads, and kebab-case spellings of known settings.
+    /// Reporting is the caller's job — how severe an unrecognized key is
+    /// depends on whether the running pnpm is the project's pinned version,
+    /// which only the CLI layer knows.
+    pub fn collect_key_issues(&mut self, text: &str) {
+        let Ok(document) = serde_saphyr::from_str::<IndexMap<String, Option<IgnoredAny>>>(text)
+        else {
+            return;
+        };
+        let mut issues = WorkspaceKeyIssues::default();
+        for key in document.iter().filter(|(_, value)| value.is_some()).map(|(key, _)| key) {
+            if key == SCHEMA_DIRECTIVE_KEY {
+                continue;
+            }
+            if is_refused_by_a_project_manifest(key) {
+                issues.refused.push(key.clone());
+            } else if !is_known_setting_key(key) {
+                issues.unrecognized.push(key.clone());
+            } else if !is_camel_case(key) {
+                issues.non_camel_case.push(key.clone());
+            }
+        }
+        self.key_issues = issues;
     }
 
     /// Walk up from `start_dir` looking for a readable `pnpm-workspace.yaml`.

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -1248,25 +1248,44 @@ impl WorkspaceSettings {
     /// would report, answered without parsing the file a second time.
     ///
     /// Serde keeps no record of the keys it dropped, so collecting them means
-    /// re-reading the document — which costs as much as the parse that produced
-    /// the settings, on every command, to find nothing in the overwhelmingly
-    /// common case of a file that is simply correct. Every top-level key begins a
-    /// line, so a line walk answers "is there anything to look at" first.
+    /// re-reading the document — which costs as much as the parse that
+    /// produced the settings, on every command, to find nothing in the
+    /// overwhelmingly common case of a file that is simply correct.
     ///
-    /// A line this cannot classify counts as one to look at, so the answer errs
-    /// only towards doing the work, never towards missing a key.
+    /// The top-level keys are the least indented lines of the document, since
+    /// everything a key nests under it is indented further; the root mapping
+    /// may itself be indented, so what marks a top-level key is the smallest
+    /// indentation the file uses rather than column zero. A line this cannot
+    /// measure or classify counts as one to look at, so the answer errs only
+    /// towards re-reading, never towards missing a key.
     fn may_have_key_issues(text: &str) -> bool {
-        text.lines().any(|line| {
-            if line.is_empty() || line.starts_with([' ', '\t', '#']) {
-                return false;
+        let content_lines = text.lines().filter(|line| {
+            let trimmed = line.trim_start();
+            !trimmed.is_empty() && !trimmed.starts_with('#')
+        });
+        let mut root_indent = usize::MAX;
+        for line in content_lines.clone() {
+            let indent = line.len() - line.trim_start().len();
+            // YAML forbids a tab as indentation, so a file that uses one is
+            // not worth measuring against.
+            if line[..indent].bytes().any(|byte| byte != b' ') {
+                return true;
             }
-            let Some((key, _)) = line.split_once(':') else { return true };
-            let key = key.trim_end();
-            key != SCHEMA_DIRECTIVE_KEY
-                && (!is_camel_case(key)
-                    || !is_known_setting_key(key)
-                    || is_refused_by_a_project_manifest(key))
-        })
+            root_indent = root_indent.min(indent);
+        }
+        if root_indent == usize::MAX {
+            return false;
+        }
+        content_lines.filter(|line| line.len() - line.trim_start().len() == root_indent).any(
+            |line| {
+                let Some((key, _)) = line.trim_start().split_once(':') else { return true };
+                let key = key.trim_end();
+                key != SCHEMA_DIRECTIVE_KEY
+                    && (!is_camel_case(key)
+                        || !is_known_setting_key(key)
+                        || is_refused_by_a_project_manifest(key))
+            },
+        )
     }
 
     /// Walk up from `start_dir` looking for a readable `pnpm-workspace.yaml`.

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -1042,6 +1042,11 @@ impl WorkspaceSettings {
             if matches!(kept.get(key), Some(value) if !value.is_null()) {
                 continue;
             }
+            // The key comes from a file the machine's user controls, but the
+            // same rendering serves the project file, so it is sanitized here
+            // too rather than only where it must be.
+            let key = redact_and_sanitize(key);
+            let key = key.as_str();
             if !is_config_file_key(&to_kebab_case(key)) {
                 if is_refused_by_a_project_manifest(key) {
                     nowhere.push(format!(

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -1221,6 +1221,9 @@ impl WorkspaceSettings {
     /// depends on whether the running pnpm is the project's pinned version,
     /// which only the CLI layer knows.
     pub fn collect_key_issues(&mut self, text: &str) {
+        if !Self::may_have_key_issues(text) {
+            return;
+        }
         let Ok(document) = serde_saphyr::from_str::<IndexMap<String, Option<IgnoredAny>>>(text)
         else {
             return;
@@ -1239,6 +1242,31 @@ impl WorkspaceSettings {
             }
         }
         self.key_issues = issues;
+    }
+
+    /// Whether `text` may carry a key [`WorkspaceSettings::collect_key_issues`]
+    /// would report, answered without parsing the file a second time.
+    ///
+    /// Serde keeps no record of the keys it dropped, so collecting them means
+    /// re-reading the document — which costs as much as the parse that produced
+    /// the settings, on every command, to find nothing in the overwhelmingly
+    /// common case of a file that is simply correct. Every top-level key begins a
+    /// line, so a line walk answers "is there anything to look at" first.
+    ///
+    /// A line this cannot classify counts as one to look at, so the answer errs
+    /// only towards doing the work, never towards missing a key.
+    fn may_have_key_issues(text: &str) -> bool {
+        text.lines().any(|line| {
+            if line.is_empty() || line.starts_with([' ', '\t', '#']) {
+                return false;
+            }
+            let Some((key, _)) = line.split_once(':') else { return true };
+            let key = key.trim_end();
+            key != SCHEMA_DIRECTIVE_KEY
+                && (!is_camel_case(key)
+                    || !is_known_setting_key(key)
+                    || is_refused_by_a_project_manifest(key))
+        })
     }
 
     /// Walk up from `start_dir` looking for a readable `pnpm-workspace.yaml`.

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -2502,3 +2502,36 @@ fn no_filtered_mirror_without_a_reason_for_full_metadata() {
     config.resolution_mode = ResolutionMode::TimeBased;
     assert!(config.requires_filtered_full_metadata());
 }
+
+/// The scan that decides whether the file is worth re-reading must never
+/// answer "nothing here" for a key there is something to say about, so a
+/// top-level key written in a shape it cannot classify still gets collected.
+#[test]
+fn load_at_collects_issues_from_a_key_it_cannot_scan() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join(WORKSPACE_MANIFEST_FILENAME), "{zzzNotASettingZzz: 1}\n").unwrap();
+
+    let settings = WorkspaceSettings::load_at(dir.path())
+        .expect("load pnpm-workspace.yaml")
+        .expect("pnpm-workspace.yaml is present");
+
+    assert_eq!(settings.key_issues.unrecognized, ["zzzNotASettingZzz"]);
+}
+
+/// A `$schema` line is what an editor adds to an otherwise correct file, so
+/// it must not be what makes every command re-read it.
+#[test]
+fn load_at_collects_no_issues_from_a_clean_file_carrying_a_schema_line() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join(WORKSPACE_MANIFEST_FILENAME),
+        "$schema: https://json.schemastore.org/pnpm-workspace.json\nnodeLinker: hoisted\n",
+    )
+    .unwrap();
+
+    let settings = WorkspaceSettings::load_at(dir.path())
+        .expect("load pnpm-workspace.yaml")
+        .expect("pnpm-workspace.yaml is present");
+
+    assert!(settings.key_issues.is_empty(), "unexpected issues: {:?}", settings.key_issues);
+}

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -131,6 +131,48 @@ packages:
 }
 
 #[test]
+fn load_at_buckets_the_problem_keys() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join(WORKSPACE_MANIFEST_FILENAME),
+        concat!(
+            "$schema: https://json.schemastore.org/pnpm-workspace.json\n",
+            "configDir: /elsewhere\n",
+            "minimumReleaseAg: 100\n",
+            "store-dir: /some-store\n",
+            "nodeLinker: hoisted\n",
+            "globalShims:\n  node: true\n",
+            "packages:\n  - apps/*\n",
+        ),
+    )
+    .unwrap();
+
+    let settings = WorkspaceSettings::load_at(dir.path())
+        .expect("load pnpm-workspace.yaml")
+        .expect("pnpm-workspace.yaml is present");
+
+    assert_eq!(settings.key_issues.refused, ["configDir"]);
+    assert_eq!(settings.key_issues.unrecognized, ["minimumReleaseAg"]);
+    assert_eq!(settings.key_issues.non_camel_case, ["store-dir"]);
+}
+
+#[test]
+fn load_at_collects_no_issues_from_a_clean_file() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join(WORKSPACE_MANIFEST_FILENAME),
+        "nodeLinker: hoisted\npackages:\n  - apps/*\ncatalog:\n  react: ^18\n",
+    )
+    .unwrap();
+
+    let settings = WorkspaceSettings::load_at(dir.path())
+        .expect("load pnpm-workspace.yaml")
+        .expect("pnpm-workspace.yaml is present");
+
+    assert!(settings.key_issues.is_empty(), "unexpected issues: {:?}", settings.key_issues);
+}
+
+#[test]
 fn apply_overrides_npmrc_defaults() {
     let yaml = r"
 storeDir: /absolute/store

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -2535,3 +2535,53 @@ fn load_at_collects_no_issues_from_a_clean_file_carrying_a_schema_line() {
 
     assert!(settings.key_issues.is_empty(), "unexpected issues: {:?}", settings.key_issues);
 }
+
+/// A root mapping may itself be indented, and the whole file is then more
+/// indented than column zero without a single key being nested.
+#[test]
+fn load_at_collects_issues_from_an_indented_root_mapping() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join(WORKSPACE_MANIFEST_FILENAME),
+        "  zzzNotASettingZzz: 1\n  nodeLinker: hoisted\n",
+    )
+    .unwrap();
+
+    let settings = WorkspaceSettings::load_at(dir.path())
+        .expect("load pnpm-workspace.yaml")
+        .expect("pnpm-workspace.yaml is present");
+
+    assert_eq!(settings.key_issues.unrecognized, ["zzzNotASettingZzz"]);
+}
+
+/// Indentation is not measurable where a tab stands in for it, so such a file
+/// is read rather than judged by its shape.
+#[test]
+fn load_at_collects_issues_from_a_tab_indented_file() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join(WORKSPACE_MANIFEST_FILENAME), "\tzzzNotASettingZzz: 1\n").unwrap();
+
+    let settings = WorkspaceSettings::load_at(dir.path())
+        .expect("load pnpm-workspace.yaml")
+        .expect("pnpm-workspace.yaml is present");
+
+    assert_eq!(settings.key_issues.unrecognized, ["zzzNotASettingZzz"]);
+}
+
+/// A nested key is not a setting of this file, so a catalog naming a package
+/// after nothing pnpm knows is not something to report.
+#[test]
+fn load_at_ignores_keys_nested_under_a_setting() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join(WORKSPACE_MANIFEST_FILENAME),
+        "catalog:\n  zzzNotASettingZzz: ^1\noverrides:\n  alsoNotASetting: 2\n",
+    )
+    .unwrap();
+
+    let settings = WorkspaceSettings::load_at(dir.path())
+        .expect("load pnpm-workspace.yaml")
+        .expect("pnpm-workspace.yaml is present");
+
+    assert!(settings.key_issues.is_empty(), "unexpected issues: {:?}", settings.key_issues);
+}

--- a/pnpm/crates/deps-restorer/src/install_package_from_registry/tests.rs
+++ b/pnpm/crates/deps-restorer/src/install_package_from_registry/tests.rs
@@ -32,6 +32,7 @@ fn create_config(
 ) -> Config {
     Config {
         ci: false,
+        workspace_key_issues: Default::default(),
         versioning: Default::default(),
         hoist: false,
         hoist_pattern: None,

--- a/pnpm11/config/reader/package.json
+++ b/pnpm11/config/reader/package.json
@@ -53,6 +53,7 @@
     "camelcase-keys": "catalog:",
     "can-write-to-dir": "catalog:",
     "ci-info": "catalog:",
+    "didyoumean2": "catalog:",
     "is-subdir": "catalog:",
     "is-windows": "catalog:",
     "lodash.kebabcase": "catalog:",

--- a/pnpm11/config/reader/src/index.ts
+++ b/pnpm11/config/reader/src/index.ts
@@ -333,14 +333,18 @@ export async function getConfig (opts: {
     // The gate below is kebab-based, but only camelCase keys are picked up later.
     const kebabKeys: string[] = []
     for (const key in globalYamlConfig) {
-      // An explicit null sets nothing, so it is not reported.
-      if (key === SCHEMA_DIRECTIVE_KEY || globalYamlConfig[key as keyof typeof globalYamlConfig] == null) {
+      // A key set to null is dropped like any other the file may not set, but
+      // it is not reported: it chose nothing, so there is nothing to correct.
+      // A null a setting accepts (`httpProxy`, `pnprServer`, ...) is a value
+      // like any other and passes through both branches untouched.
+      const setsNothing = globalYamlConfig[key as keyof typeof globalYamlConfig] == null
+      if (key === SCHEMA_DIRECTIVE_KEY) {
         delete globalYamlConfig[key as keyof typeof globalYamlConfig]
       } else if (!isConfigFileKey(kebabCase(key))) {
-        ignoredKeys.push(key)
+        if (!setsNothing) ignoredKeys.push(key)
         delete globalYamlConfig[key as keyof typeof globalYamlConfig]
       } else if (!isCamelCase(key)) {
-        kebabKeys.push(key)
+        if (!setsNothing) kebabKeys.push(key)
         delete globalYamlConfig[key as keyof typeof globalYamlConfig]
       }
     }

--- a/pnpm11/config/reader/src/index.ts
+++ b/pnpm11/config/reader/src/index.ts
@@ -53,6 +53,7 @@ import {
 import { quoteAndJoin } from './quoteAndJoin.js'
 import { transformPathKeys } from './transformPath.js'
 import { types } from './types.js'
+import { isKnownSettingKey, quoteAndAnnotateUnknown } from './unknownSettings.js'
 export { types }
 
 export { getDefaultWorkspaceConcurrency, getWorkspaceConcurrency } from './concurrency.js'
@@ -81,6 +82,12 @@ export type { Config, ConfigContext, ProjectConfig, UniversalOptions, VerifyDeps
 
 export { type ConfigFileKey, isConfigFileKey } from './configFileKey.js'
 export { isIniConfigKey, isNpmrcReadableKey } from './localConfig.js'
+
+/**
+ * A YAML-language-server schema association, not a setting; tools put it in
+ * config files pnpm reads, so it must not trip the unknown-setting warnings.
+ */
+const SCHEMA_DIRECTIVE_KEY = '$schema'
 
 type CamelToKebabCase<S extends string> = S extends `${infer T}${infer U}`
   ? `${T extends Lowercase<T> ? '' : '-'}${Lowercase<T>}${CamelToKebabCase<U>}`
@@ -326,7 +333,9 @@ export async function getConfig (opts: {
     // The gate below is kebab-based, but only camelCase keys are picked up later.
     const kebabKeys: string[] = []
     for (const key in globalYamlConfig) {
-      if (!isConfigFileKey(kebabCase(key))) {
+      if (key === SCHEMA_DIRECTIVE_KEY) {
+        delete globalYamlConfig[key as keyof typeof globalYamlConfig]
+      } else if (!isConfigFileKey(kebabCase(key))) {
         ignoredKeys.push(key)
         delete globalYamlConfig[key as keyof typeof globalYamlConfig]
       } else if (!isCamelCase(key)) {
@@ -336,10 +345,14 @@ export async function getConfig (opts: {
     }
     if (ignoredKeys.length > 0 || kebabKeys.length > 0) {
       const globalYamlConfigPath = getGlobalConfigPath(configDir)
-      const movable = ignoredKeys.filter((key) => !isRefusedByAProjectManifest(key))
+      const movable = ignoredKeys.filter((key) => !isRefusedByAProjectManifest(key) && isKnownSettingKey(key))
+      const unrecognized = ignoredKeys.filter((key) => !isRefusedByAProjectManifest(key) && !isKnownSettingKey(key))
       const nowhere = ignoredKeys.filter(isRefusedByAProjectManifest)
       if (movable.length > 0) {
         warnings.push(`The following settings cannot be set in the global config file ("${globalYamlConfigPath}") and were ignored: ${quoteAndJoin(movable)}. Move them to a project-level pnpm-workspace.yaml. To share these settings across projects, use config dependencies: https://pnpm.io/11.x/config-dependencies`)
+      }
+      if (unrecognized.length > 0) {
+        warnings.push(`The following settings in the global config file ("${globalYamlConfigPath}") are not recognized by this version of pnpm and were ignored: ${quoteAndAnnotateUnknown(unrecognized)}.`)
       }
       if (nowhere.length > 0) {
         warnings.push(`The following settings cannot be set in the global config file ("${globalYamlConfigPath}") and were ignored: ${quoteAndExplain(nowhere)}.`)
@@ -494,9 +507,28 @@ export async function getConfig (opts: {
 
       pnpmConfig.workspacePackagePatterns = cliOptions['workspace-packages'] as string[] ?? workspaceManifest?.packages ?? ['.']
       if (workspaceManifest) {
-        const ignoredKeys = Object.keys(workspaceManifest).filter(isRefusedByAProjectManifest)
-        if (ignoredKeys.length > 0) {
-          warnings.push(`The following settings cannot be set in a project's pnpm-workspace.yaml and were ignored: ${quoteAndExplain(ignoredKeys)}.`)
+        const refusedKeys: string[] = []
+        const unrecognizedKeys: string[] = []
+        const kebabKeys: string[] = []
+        for (const key of Object.keys(workspaceManifest)) {
+          if (key === SCHEMA_DIRECTIVE_KEY) continue
+          if (isRefusedByAProjectManifest(key)) {
+            refusedKeys.push(key)
+          } else if (!isKnownSettingKey(key)) {
+            unrecognizedKeys.push(key)
+            delete workspaceManifest[key as keyof typeof workspaceManifest]
+          } else if (!isCamelCase(key)) {
+            kebabKeys.push(key)
+          }
+        }
+        if (refusedKeys.length > 0) {
+          warnings.push(`The following settings cannot be set in a project's pnpm-workspace.yaml and were ignored: ${quoteAndExplain(refusedKeys)}.`)
+        }
+        if (unrecognizedKeys.length > 0) {
+          warnings.push(`The following settings in pnpm-workspace.yaml are not recognized by this version of pnpm and were ignored: ${quoteAndAnnotateUnknown(unrecognizedKeys)}.`)
+        }
+        if (kebabKeys.length > 0) {
+          warnings.push(`The following settings in pnpm-workspace.yaml were ignored because they are not written in camelCase: ${kebabKeys.map(k => `"${k}" (use "${camelcase(k)}")`).join(', ')}.`)
         }
         addSettingsFromWorkspaceManifestToConfig(pnpmConfig, {
           configFromCliOpts,

--- a/pnpm11/config/reader/src/index.ts
+++ b/pnpm11/config/reader/src/index.ts
@@ -333,7 +333,8 @@ export async function getConfig (opts: {
     // The gate below is kebab-based, but only camelCase keys are picked up later.
     const kebabKeys: string[] = []
     for (const key in globalYamlConfig) {
-      if (key === SCHEMA_DIRECTIVE_KEY) {
+      // An explicit null sets nothing, so it is not reported.
+      if (key === SCHEMA_DIRECTIVE_KEY || globalYamlConfig[key as keyof typeof globalYamlConfig] == null) {
         delete globalYamlConfig[key as keyof typeof globalYamlConfig]
       } else if (!isConfigFileKey(kebabCase(key))) {
         ignoredKeys.push(key)
@@ -349,7 +350,7 @@ export async function getConfig (opts: {
       const unrecognized = ignoredKeys.filter((key) => !isRefusedByAProjectManifest(key) && !isKnownSettingKey(key))
       const nowhere = ignoredKeys.filter(isRefusedByAProjectManifest)
       if (movable.length > 0) {
-        warnings.push(`The following settings cannot be set in the global config file ("${globalYamlConfigPath}") and were ignored: ${quoteAndJoin(movable)}. Move them to a project-level pnpm-workspace.yaml. To share these settings across projects, use config dependencies: https://pnpm.io/11.x/config-dependencies`)
+        warnings.push(`The following settings cannot be set in the global config file ("${globalYamlConfigPath}") and were ignored: ${quoteAndJoin(movable.map(redactAndSanitize))}. Move them to a project-level pnpm-workspace.yaml. To share these settings across projects, use config dependencies: https://pnpm.io/11.x/config-dependencies`)
       }
       if (unrecognized.length > 0) {
         warnings.push(`The following settings in the global config file ("${globalYamlConfigPath}") are not recognized by this version of pnpm and were ignored: ${quoteAndAnnotateUnknown(unrecognized)}.`)
@@ -358,7 +359,7 @@ export async function getConfig (opts: {
         warnings.push(`The following settings cannot be set in the global config file ("${globalYamlConfigPath}") and were ignored: ${quoteAndExplain(nowhere)}.`)
       }
       if (kebabKeys.length > 0) {
-        warnings.push(`The following settings in the global config file ("${globalYamlConfigPath}") were ignored because they are not written in camelCase: ${kebabKeys.map(k => `"${k}" (use "${camelcase(k)}")`).join(', ')}.`)
+        warnings.push(`The following settings in the global config file ("${globalYamlConfigPath}") were ignored because they are not written in camelCase: ${quoteAndSuggestCamelCase(kebabKeys)}.`)
       }
     }
     addSettingsFromWorkspaceManifestToConfig(pnpmConfig, {
@@ -510,13 +511,16 @@ export async function getConfig (opts: {
         const refusedKeys: string[] = []
         const unrecognizedKeys: string[] = []
         const kebabKeys: string[] = []
-        for (const key of Object.keys(workspaceManifest)) {
-          if (key === SCHEMA_DIRECTIVE_KEY) continue
+        for (const [key, value] of Object.entries(workspaceManifest)) {
+          // An unrecognized key is only reported, never dropped: this file's
+          // unknown camelCase keys reach the config record, which
+          // `pnpm config list` prints, and taking that away is the breaking
+          // change v12 makes rather than v11.
+          if (key === SCHEMA_DIRECTIVE_KEY || value == null) continue
           if (isRefusedByAProjectManifest(key)) {
             refusedKeys.push(key)
           } else if (!isKnownSettingKey(key)) {
             unrecognizedKeys.push(key)
-            delete workspaceManifest[key as keyof typeof workspaceManifest]
           } else if (!isCamelCase(key)) {
             kebabKeys.push(key)
           }
@@ -528,7 +532,7 @@ export async function getConfig (opts: {
           warnings.push(`The following settings in pnpm-workspace.yaml are not recognized by this version of pnpm and were ignored: ${quoteAndAnnotateUnknown(unrecognizedKeys)}.`)
         }
         if (kebabKeys.length > 0) {
-          warnings.push(`The following settings in pnpm-workspace.yaml were ignored because they are not written in camelCase: ${kebabKeys.map(k => `"${k}" (use "${camelcase(k)}")`).join(', ')}.`)
+          warnings.push(`The following settings in pnpm-workspace.yaml were ignored because they are not written in camelCase: ${quoteAndSuggestCamelCase(kebabKeys)}.`)
         }
         addSettingsFromWorkspaceManifestToConfig(pnpmConfig, {
           configFromCliOpts,
@@ -1376,11 +1380,20 @@ export function whereRefusedKeyBelongs (camelKey: string): string {
 }
 
 function quoteRefusedKey (key: string): string {
-  return `"${key}" (${whereRefusedKeyBelongs(camelcase(key, { locale: 'en-US' }))})`
+  const sanitized = redactAndSanitize(key)
+  return `"${sanitized}" (${whereRefusedKeyBelongs(camelcase(sanitized, { locale: 'en-US' }))})`
 }
 
 function quoteAndExplain (keys: string[]): string {
   return keys.map(quoteRefusedKey).join(', ')
+}
+
+/** Renders keys pnpm only reads in camelCase, naming the spelling that works. */
+function quoteAndSuggestCamelCase (keys: string[]): string {
+  return keys.map((key) => {
+    const sanitized = redactAndSanitize(key)
+    return `"${sanitized}" (use "${camelcase(sanitized, { locale: 'en-US' })}")`
+  }).join(', ')
 }
 
 function addSettingsFromWorkspaceManifestToConfig (pnpmConfig: Config & ConfigContext, {

--- a/pnpm11/config/reader/src/unknownSettings.ts
+++ b/pnpm11/config/reader/src/unknownSettings.ts
@@ -1,0 +1,162 @@
+import type { WorkspaceManifest } from '@pnpm/workspace.workspace-manifest-reader'
+import camelcase from 'camelcase'
+import didYouMean, { ReturnTypeEnums } from 'didyoumean2'
+
+import type { ConfigWithDeprecatedSettings } from './Config.js'
+import { types } from './types.js'
+
+/**
+ * The structured settings of `pnpm-workspace.yaml`, which have no entry in
+ * {@link types} because they never come in through a CLI flag.
+ */
+const TYPED_WORKSPACE_MANIFEST_KEYS = [
+  'allowBuilds',
+  'allowUnusedPatches',
+  'allowedDeprecatedVersions',
+  'audit',
+  'auditConfig',
+  'catalog',
+  'catalogs',
+  'configDependencies',
+  'enableGlobalVirtualStore',
+  'httpProxy',
+  'httpsProxy',
+  'ignoredOptionalDependencies',
+  'namedRegistries',
+  'nodeDownloadMirrors',
+  'noProxy',
+  'npmrcAuthFile',
+  'overrides',
+  'packageExtensions',
+  'packages',
+  'patchedDependencies',
+  'peerDependencyRules',
+  'pnprServer',
+  'registries',
+  'requiredScripts',
+  'supportedArchitectures',
+  'update',
+  'updateConfig',
+  'versioning',
+  'virtualStoreType',
+] as const satisfies ReadonlyArray<keyof WorkspaceManifest>
+
+type ProofTypedWorkspaceManifestKeysAreExhaustive =
+  (_: Record<typeof TYPED_WORKSPACE_MANIFEST_KEYS[number], unknown>) => Record<keyof WorkspaceManifest, unknown>
+
+const _proofTypedWorkspaceManifestKeysAreExhaustive: ProofTypedWorkspaceManifestKeysAreExhaustive = (x) => x
+
+/**
+ * The {@link ConfigWithDeprecatedSettings} fields that neither {@link types}
+ * nor {@link TYPED_WORKSPACE_MANIFEST_KEYS} carries — settings whose only
+ * spelling is a camelCase config field (e.g. `catalogPrune`), and the reader's
+ * own derived fields. {@link ProofKnownSettingKeysCoverConfig} forces a new
+ * config field to be added here, so a setting introduced later cannot start
+ * out being reported as unrecognized.
+ */
+const CONFIG_ONLY_SETTING_KEYS = [
+  'allowNew',
+  'authConfig',
+  'autoConfirmAllPrompts',
+  'bin',
+  'catalogPrune',
+  'cleanupUnusedCatalogs',
+  'configByUri',
+  'enablePnp',
+  'extraBinPaths',
+  'extraEnv',
+  'globalPkgDir',
+  'globalPrefix',
+  'ignoreCurrentSpecifiers',
+  'maxSockets',
+  'minimumReleaseAgeExcludePrune',
+  'packageConfigs',
+  'packageManagerNetworkConfig',
+  'packageManagerRegistries',
+  'pending',
+  'pnpmExecPath',
+  'pnpmHomeDir',
+  'recursive',
+  'registriesByPrefix',
+  'registriesByScope',
+  'registryOptionsByUrl',
+  'reverse',
+  'sideEffectsCacheRead',
+  'sideEffectsCacheWrite',
+  'tryLoadDefaultPnpmfile',
+  'useGitBranchLockfile',
+  'useLockfile',
+  'useRunningStoreServer',
+  'useStoreServer',
+  'userConfig',
+  'workspaceDir',
+  'workspacePackagePatterns',
+  'workspacePrefix',
+] as const satisfies ReadonlyArray<keyof ConfigWithDeprecatedSettings>
+
+/**
+ * Recognized keys that have no field on {@link WorkspaceManifest} or
+ * {@link ConfigWithDeprecatedSettings}: the legacy build policies
+ * `pnpm approve-builds` migrates into `allowBuilds`, and `executionEnv`.
+ */
+const UNTYPED_WORKSPACE_SETTING_KEYS = [
+  'executionEnv',
+  'ignoredBuiltDependencies',
+  'neverBuiltDependencies',
+  'onlyBuiltDependencies',
+  'onlyBuiltDependenciesFile',
+]
+
+type KebabToCamelCase<S extends string> = S extends `${infer A}-${infer B}`
+  ? `${A}${Capitalize<KebabToCamelCase<B>>}`
+  : S
+
+type KnownSettingKey =
+  | KebabToCamelCase<keyof typeof types & string>
+  | typeof TYPED_WORKSPACE_MANIFEST_KEYS[number]
+  | typeof CONFIG_ONLY_SETTING_KEYS[number]
+
+type ProofKnownSettingKeysCoverConfig =
+  (_: Record<KnownSettingKey, unknown>) => Record<keyof ConfigWithDeprecatedSettings, unknown>
+
+const _proofKnownSettingKeysCoverConfig: ProofKnownSettingKeysCoverConfig = (x) => x
+
+const KNOWN_SETTING_KEYS: ReadonlySet<string> = new Set([
+  ...TYPED_WORKSPACE_MANIFEST_KEYS,
+  ...CONFIG_ONLY_SETTING_KEYS,
+  ...UNTYPED_WORKSPACE_SETTING_KEYS,
+  ...Object.keys(types).map((key) => camelcase(key, { locale: 'en-US' })),
+])
+
+/**
+ * Whether {@link key}, given in either camelCase or kebab-case, names a
+ * setting this version of pnpm reads from at least one config source. A key
+ * failing this check is a typo or belongs to a different pnpm version, so it
+ * gets {@link quoteAndAnnotateUnknown}'s warning instead of advice to move it
+ * to another config file.
+ */
+export function isKnownSettingKey (key: string): boolean {
+  return KNOWN_SETTING_KEYS.has(camelcase(key, { locale: 'en-US' }))
+}
+
+/**
+ * Settings recognized by other supported pnpm release lines but not by this
+ * one, so the warning can name the version that reads the key instead of
+ * guessing at a typo. Maintained by hand: the lines are developed together in
+ * this repository, so a line-exclusive setting is known at build time.
+ */
+const SETTINGS_OF_OTHER_PNPM_VERSIONS: Record<string, string> = {
+  globalShims: 'pnpm v12',
+}
+
+const KNOWN_SETTING_KEYS_LIST = [...KNOWN_SETTING_KEYS]
+
+export function quoteAndAnnotateUnknown (keys: string[]): string {
+  return keys.map((key) => {
+    const camelKey = camelcase(key, { locale: 'en-US' })
+    const otherVersion = SETTINGS_OF_OTHER_PNPM_VERSIONS[camelKey]
+    if (otherVersion) return `"${key}" (a ${otherVersion} setting)`
+    const suggestion = didYouMean(camelKey, KNOWN_SETTING_KEYS_LIST, { returnType: ReturnTypeEnums.FIRST_CLOSEST_MATCH })
+    return suggestion ? `"${key}" (did you mean "${suggestion}"?)` : `"${key}"`
+  }).join(', ')
+}

--- a/pnpm11/config/reader/src/unknownSettings.ts
+++ b/pnpm11/config/reader/src/unknownSettings.ts
@@ -1,3 +1,4 @@
+import { redactAndSanitize } from '@pnpm/error'
 import type { WorkspaceManifest } from '@pnpm/workspace.workspace-manifest-reader'
 import camelcase from 'camelcase'
 import didYouMean, { ReturnTypeEnums } from 'didyoumean2'
@@ -151,12 +152,18 @@ const SETTINGS_OF_OTHER_PNPM_VERSIONS: Record<string, string> = {
 
 const KNOWN_SETTING_KEYS_LIST = [...KNOWN_SETTING_KEYS]
 
+/**
+ * Renders unrecognized keys for a warning. The key comes from a config file a
+ * repository may control, so it is sanitized before it reaches a terminal or a
+ * CI log; the suggestion is one of pnpm's own setting names.
+ */
 export function quoteAndAnnotateUnknown (keys: string[]): string {
   return keys.map((key) => {
-    const camelKey = camelcase(key, { locale: 'en-US' })
+    const sanitized = redactAndSanitize(key)
+    const camelKey = camelcase(sanitized, { locale: 'en-US' })
     const otherVersion = SETTINGS_OF_OTHER_PNPM_VERSIONS[camelKey]
-    if (otherVersion) return `"${key}" (a ${otherVersion} setting)`
+    if (otherVersion) return `"${sanitized}" (a ${otherVersion} setting)`
     const suggestion = didYouMean(camelKey, KNOWN_SETTING_KEYS_LIST, { returnType: ReturnTypeEnums.FIRST_CLOSEST_MATCH })
-    return suggestion ? `"${key}" (did you mean "${suggestion}"?)` : `"${key}"`
+    return suggestion ? `"${sanitized}" (did you mean "${suggestion}"?)` : `"${sanitized}"`
   }).join(', ')
 }

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -891,6 +891,40 @@ describe("a project's pnpm-workspace.yaml cannot redirect where pnpm reads and w
     expect(warnings).not.toContainEqual(expect.stringContaining('store-dir'))
   })
 
+  // `pnprServer` is typed `[null, String]`, so a null is a value the setting
+  // takes, not an absent one. Asserted through `explicitlySetKeys` because the
+  // merge is what the null has to survive; what each setting then does with it
+  // is its own business.
+  test('a null a setting accepts still reaches the config', async () => {
+    prepareEmpty()
+
+    const xdgConfigHome = process.cwd()
+    const configDir = path.join(xdgConfigHome, 'pnpm')
+    fs.mkdirSync(configDir, { recursive: true })
+    writeYamlFileSync(path.join(configDir, 'config.yaml'), { pnprServer: null })
+
+    const previousXdgConfigHome = process.env.XDG_CONFIG_HOME
+    process.env.XDG_CONFIG_HOME = xdgConfigHome
+    let context: { explicitlySetKeys: Set<string> }
+    let warnings: string[]
+    try {
+      ;({ context, warnings } = await getConfig({
+        cliOptions: {},
+        packageManager: { name: 'pnpm', version: '1.0.0' },
+        workspaceDir: process.cwd(),
+      }))
+    } finally {
+      if (previousXdgConfigHome == null) {
+        delete process.env.XDG_CONFIG_HOME
+      } else {
+        process.env.XDG_CONFIG_HOME = previousXdgConfigHome
+      }
+    }
+
+    expect(context.explicitlySetKeys.has('pnprServer')).toBe(true)
+    expect(warnings).not.toContainEqual(expect.stringContaining('pnprServer'))
+  })
+
   test('a key carrying terminal escapes is sanitized before it is reported', async () => {
     prepareEmpty()
 

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -843,6 +843,50 @@ describe("a project's pnpm-workspace.yaml cannot redirect where pnpm reads and w
     expect(warnings).toContainEqual(expect.stringContaining('This is not a pnpm setting'))
   })
 
+  test('a setting unknown to this version of pnpm in pnpm-workspace.yaml is reported', async () => {
+    prepareEmpty()
+
+    writeYamlFileSync('pnpm-workspace.yaml', {
+      $schema: 'https://json.schemastore.org/pnpm-workspace.json',
+      globalShims: { node: true },
+      minimumReleaseAg: 100,
+      zzzNotASettingZzz: true,
+      nodeLinker: 'hoisted',
+      packages: ['packages/*'],
+      overrides: { foo: '1.0.0' },
+    })
+
+    const { config, warnings } = await getConfig({
+      cliOptions: {},
+      packageManager: { name: 'pnpm', version: '1.0.0' },
+      workspaceDir: process.cwd(),
+    })
+
+    const unrecognized = warnings.find((warning) => warning.includes('in pnpm-workspace.yaml are not recognized by this version of pnpm'))
+    expect(unrecognized).toContain('"globalShims" (a pnpm v12 setting)')
+    expect(unrecognized).toContain('"minimumReleaseAg" (did you mean "minimumReleaseAge"?)')
+    expect(unrecognized).toContain('"zzzNotASettingZzz"')
+    expect(unrecognized).not.toContain('"nodeLinker"')
+    expect(unrecognized).not.toContain('"packages"')
+    expect(unrecognized).not.toContain('"overrides"')
+    expect(unrecognized).not.toContain('$schema')
+    expect((config as unknown as Record<string, unknown>)['zzzNotASettingZzz']).toBeUndefined()
+  })
+
+  test('a kebab-case spelling of a known setting in pnpm-workspace.yaml is reported', async () => {
+    prepareEmpty()
+
+    writeYamlFileSync('pnpm-workspace.yaml', { 'store-dir': '/tmp/some-store' })
+
+    const { warnings } = await getConfig({
+      cliOptions: {},
+      packageManager: { name: 'pnpm', version: '1.0.0' },
+      workspaceDir: process.cwd(),
+    })
+
+    expect(warnings).toContainEqual(expect.stringContaining('in pnpm-workspace.yaml were ignored because they are not written in camelCase: "store-dir" (use "storeDir")'))
+  })
+
   test('auth and the bootstrap download routes stay out of the manifest', async () => {
     prepareEmpty()
 
@@ -942,6 +986,44 @@ describe("a project's pnpm-workspace.yaml cannot redirect where pnpm reads and w
     for (const warning of aboutConfigDir) {
       expect(warning).not.toContain('Move them to a project-level pnpm-workspace.yaml')
     }
+  })
+
+  test('the global config file distinguishes settings unknown to this version from workspace-only ones', async () => {
+    prepareEmpty()
+
+    const xdgConfigHome = process.cwd()
+    const configDir = path.join(xdgConfigHome, 'pnpm')
+    fs.mkdirSync(configDir, { recursive: true })
+    writeYamlFileSync(path.join(configDir, 'config.yaml'), {
+      globalShims: { node: true },
+      minimumReleaseAg: 100,
+      nodeLinker: 'hoisted',
+      bail: false,
+    })
+
+    const previousXdgConfigHome = process.env.XDG_CONFIG_HOME
+    process.env.XDG_CONFIG_HOME = xdgConfigHome
+    let warnings: string[]
+    try {
+      ;({ warnings } = await getConfig({
+        cliOptions: {},
+        packageManager: { name: 'pnpm', version: '1.0.0' },
+        workspaceDir: process.cwd(),
+      }))
+    } finally {
+      if (previousXdgConfigHome == null) {
+        delete process.env.XDG_CONFIG_HOME
+      } else {
+        process.env.XDG_CONFIG_HOME = previousXdgConfigHome
+      }
+    }
+
+    const unrecognized = warnings.find((warning) => warning.includes('in the global config file') && warning.includes('are not recognized by this version of pnpm'))
+    expect(unrecognized).toContain('"globalShims" (a pnpm v12 setting)')
+    expect(unrecognized).toContain('"minimumReleaseAg" (did you mean "minimumReleaseAge"?)')
+    const movable = warnings.find((warning) => warning.includes('Move them to a project-level pnpm-workspace.yaml'))
+    expect(movable).toContain('"nodeLinker"')
+    expect(movable).not.toContain('"globalShims"')
   })
 
   // The global config file's own contents are filtered before the merge, but

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -870,7 +870,42 @@ describe("a project's pnpm-workspace.yaml cannot redirect where pnpm reads and w
     expect(unrecognized).not.toContain('"packages"')
     expect(unrecognized).not.toContain('"overrides"')
     expect(unrecognized).not.toContain('$schema')
-    expect((config as unknown as Record<string, unknown>)['zzzNotASettingZzz']).toBeUndefined()
+    // Reported, not dropped: `pnpm config list` still prints this file's
+    // unknown camelCase keys, which `test/config/list.ts` pins.
+    expect((config as unknown as Record<string, unknown>)['zzzNotASettingZzz']).toBe(true)
+  })
+
+  test('a null-valued key sets nothing, so it is not reported', async () => {
+    prepareEmpty()
+
+    writeYamlFileSync('pnpm-workspace.yaml', { zzzNotASettingZzz: null, configDir: null, 'store-dir': null })
+
+    const { warnings } = await getConfig({
+      cliOptions: {},
+      packageManager: { name: 'pnpm', version: '1.0.0' },
+      workspaceDir: process.cwd(),
+    })
+
+    expect(warnings).not.toContainEqual(expect.stringContaining('zzzNotASettingZzz'))
+    expect(warnings).not.toContainEqual(expect.stringContaining('configDir'))
+    expect(warnings).not.toContainEqual(expect.stringContaining('store-dir'))
+  })
+
+  test('a key carrying terminal escapes is sanitized before it is reported', async () => {
+    prepareEmpty()
+
+    writeYamlFileSync('pnpm-workspace.yaml', { 'nope\u001b[31mRED\r': true })
+
+    const { warnings } = await getConfig({
+      cliOptions: {},
+      packageManager: { name: 'pnpm', version: '1.0.0' },
+      workspaceDir: process.cwd(),
+    })
+
+    const unrecognized = warnings.find((warning) => warning.includes('are not recognized by this version of pnpm'))
+    expect(unrecognized).toContain('nope[31mRED')
+    expect(unrecognized).not.toContain('\u001b')
+    expect(unrecognized).not.toContain('\r')
   })
 
   test('a kebab-case spelling of a known setting in pnpm-workspace.yaml is reported', async () => {

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -880,7 +880,7 @@ describe("a project's pnpm-workspace.yaml cannot redirect where pnpm reads and w
 
     writeYamlFileSync('pnpm-workspace.yaml', { zzzNotASettingZzz: null, configDir: null, 'store-dir': null })
 
-    const { warnings } = await getConfig({
+    const { config, warnings } = await getConfig({
       cliOptions: {},
       packageManager: { name: 'pnpm', version: '1.0.0' },
       workspaceDir: process.cwd(),
@@ -889,6 +889,10 @@ describe("a project's pnpm-workspace.yaml cannot redirect where pnpm reads and w
     expect(warnings).not.toContainEqual(expect.stringContaining('zzzNotASettingZzz'))
     expect(warnings).not.toContainEqual(expect.stringContaining('configDir'))
     expect(warnings).not.toContainEqual(expect.stringContaining('store-dir'))
+    // Reporting decides nothing about what reaches the config: the null is
+    // retained here exactly as a non-null unknown key is.
+    expect(Object.hasOwn(config, 'zzzNotASettingZzz')).toBe(true)
+    expect((config as unknown as Record<string, unknown>)['zzzNotASettingZzz']).toBeNull()
   })
 
   // `pnprServer` is typed `[null, String]`, so a null is a value the setting

--- a/pnpm11/pnpm/src/getConfig.test.ts
+++ b/pnpm11/pnpm/src/getConfig.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from '@jest/globals'
+
+import { isSingleSettingRead } from './getConfig.js'
+
+test.each([
+  ['config', ['get', 'registries'], true],
+  ['config', ['get'], false],
+  ['config', ['list'], false],
+  ['config', ['set', 'store-dir', '/tmp/store'], false],
+  ['get', ['registries'], true],
+  ['get', [], false],
+  ['install', [], false],
+  [null, [], false],
+] as Array<[string | null, string[], boolean]>)('isSingleSettingRead(%p, %p) → %p', (cmd, cliParams, expected) => {
+  expect(isSingleSettingRead(cmd, cliParams)).toBe(expected)
+})

--- a/pnpm11/pnpm/src/getConfig.ts
+++ b/pnpm11/pnpm/src/getConfig.ts
@@ -20,6 +20,7 @@ export async function getConfig (
     workspaceDir: string | undefined
     onlyInheritDlxSettingsFromLocal?: boolean
     forSelfUpdate?: boolean
+    printWarnings?: boolean
   }
 ): Promise<{ config: Config, context: ConfigContext }> {
   const { config, context, warnings } = await _getConfig({
@@ -37,11 +38,22 @@ export async function getConfig (
     delete config.reporter // This is a silly workaround because @pnpm/installing.deps-installer expects a function as opts.reporter
   }
 
-  if (warnings.length > 0) {
+  if (opts.printWarnings !== false && warnings.length > 0) {
     console.warn(warnings.map((warning) => formatWarn(warning)).join('\n'))
   }
 
   return { config, context }
+}
+
+/**
+ * Whether the invocation prints one setting's value (`pnpm config get <key>`
+ * or `pnpm get <key>`). Such reads are consumed by scripts, so config-load
+ * warnings stay off them; the keyless list forms keep the warnings, being how
+ * a user inspects the config.
+ */
+export function isSingleSettingRead (cmd: string | null, cliParams: string[]): boolean {
+  if (cmd === 'config') return cliParams[0] === 'get' && cliParams.length > 1
+  return cmd === 'get' && cliParams.length > 0
 }
 
 export async function installConfigDepsAndLoadHooks (

--- a/pnpm11/pnpm/src/main.ts
+++ b/pnpm11/pnpm/src/main.ts
@@ -28,7 +28,7 @@ import { checkForUpdates } from './checkForUpdates.js'
 import { checkSudo } from './checkSudo.js'
 import { NOT_IMPLEMENTED_COMMAND_SET, overridableByScriptCommands, pnpmCmds, recursiveByDefaultCommands, skipPackageManagerCheckForCommand } from './cmd/index.js'
 import { formatUnknownOptionsError } from './formatError.js'
-import { getConfig, installConfigDepsAndLoadHooks } from './getConfig.js'
+import { getConfig, installConfigDepsAndLoadHooks, isSingleSettingRead } from './getConfig.js'
 import type { ParsedCliArgsWithBuiltIn } from './parseCliArgs.js'
 import { parseCliArgs } from './parseCliArgs.js'
 import { initReporter, type ReporterType } from './reporter/index.js'
@@ -113,6 +113,7 @@ export async function main (inputArgv: string[]): Promise<void> {
       workspaceDir,
       onlyInheritDlxSettingsFromLocal: isDlxOrCreateCommand,
       forSelfUpdate: cmd === 'self-update',
+      printWarnings: !isSingleSettingRead(cmd, cliParams),
     }) as { config: typeof config, context: ConfigContext })
     if (cmd !== 'setup' && !shouldSkipPmHandling(cmd, cliParams)) {
       if (context.wantedPackageManager != null) {

--- a/pnpm11/pnpm/test/config/get.ts
+++ b/pnpm11/pnpm/test/config/get.ts
@@ -305,3 +305,20 @@ test('the path from "config get globalconfig" is the file that pnpm actually rea
 
   expect(configGet('dlx-cache-max-age')).toBe('4321')
 })
+
+test('a single-setting read prints no configuration warnings, but "config list" still does', () => {
+  prepare()
+  writeYamlFileSync('pnpm-workspace.yaml', { minimumReleaseAg: 100, dlxCacheMaxAge: 4321 })
+
+  const unrecognized = 'are not recognized by this version of pnpm'
+
+  const get = execPnpmSync(['config', 'get', 'dlx-cache-max-age'], { expectSuccess: true })
+  expect(get.stdout.toString().trim()).toBe('4321')
+  expect(get.stderr.toString()).not.toContain(unrecognized)
+
+  const getAlias = execPnpmSync(['get', 'dlx-cache-max-age'], { expectSuccess: true })
+  expect(getAlias.stderr.toString()).not.toContain(unrecognized)
+
+  const list = execPnpmSync(['config', 'list'], { expectSuccess: true })
+  expect(list.stderr.toString()).toContain(`${unrecognized} and were ignored: "minimumReleaseAg" (did you mean "minimumReleaseAge"?)`)
+})


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

`pnpm config get registries` (v11) warned that `globalShims` "cannot be set in the global config file … Move them to a project-level pnpm-workspace.yaml" — misleading twice over: `globalShims` is a valid **pnpm v12** setting that belongs exactly where it is, and moving it to a project file would change nothing in v11 either. This PR fixes that warning and the surrounding gaps in both stacks:

- **Unknown-key classification.** Keys the running version does not read are now split from workspace-only settings. Workspace-only settings keep the move-to-`pnpm-workspace.yaml` advice; keys unknown to this version get a new warning: *"…are not recognized by this version of pnpm and were ignored"*, annotated per key with the release line that reads it (`"globalShims" (a pnpm v12 setting)` in the TypeScript CLI) or a did-you-mean suggestion for typos (`"minimumReleaseAg" (did you mean "minimumReleaseAge"?)`).
- **Project-file validation.** Unrecognized and non-camelCase keys in a project's `pnpm-workspace.yaml` were previously ignored in complete silence — a typo'd `minimumReleaseAgeExclude` silently dropped a security setting. v11 now warns about them, and **only warns**: the keys still reach the config record, so `pnpm config list` keeps printing them (`pnpm11/pnpm/test/config/list.ts` pins that as behaviour whose removal is breaking, which makes it v12's to change, not v11's). pacquet (v12) goes further: when the project pins a pnpm the running pnpm satisfies, an unrecognized key fails the command with `ERR_PNPM_UNRECOGNIZED_WORKSPACE_SETTINGS` — with the pin honored, the key cannot be meant for a different pnpm version. `pnpm config` subcommands never hard-fail (a broken file must stay inspectable/repairable), `--global` invocations only warn, and enforcement runs after the pm-switch decision so a delegating pnpm never judges the file with the wrong version's key set.
- **Sanitized key output.** Config keys come from files a repository controls and are printed to a terminal and any CI log, so every key a warning names is sanitized in both stacks — including the keys the pre-existing global-config warnings name, which interpolated them verbatim before this PR.
- **Null-valued keys are silent.** An explicit `null` sets nothing, so it is not reported. pacquet already skipped those; the TypeScript reader did not, so the two stacks disagreed on the same file.
- **Quiet single-key reads.** `pnpm config get <key>` / `pnpm get <key>` no longer print config-load warnings in either stack — they are consumed by scripts; the keyless list forms keep the warnings.
- **Robust known-key sets.** The TypeScript known-key list is proven exhaustive against `Config` at compile time (a newly added setting cannot start out reported as unknown); pacquet derives its set from the `WorkspaceSettings` serde fields plus mirrored lists. `$schema` (editor schema association) is exempt everywhere. The Rust did-you-mean helper is hand-rolled (~30 lines) rather than a new `strsim` dependency, per the no-new-deps rule.

**Known divergence, pre-existing:** pacquet's `WorkspaceSettings` drops unknown keys at deserialization, so `pnpm config list` never showed them there, while the TypeScript CLI passes them through. This PR does not change either side; v12 is where taking the pass-through away belongs, and its strict error covers the pinned case already.

Follow-ups not included: pacquet's global-config warnings still go through `tracing::warn!` (invisible without `TRACE`) — routing them through the stderr `[WARN]` channel is a pre-existing parity gap; pnpm.io docs for the new error code.

## Squash Commit Body

```text
The global config file's unknown-key warning claimed every dropped key
could be moved to a project-level pnpm-workspace.yaml. For a key this
version of pnpm does not read at all — a typo, or a setting of another
release line sharing the file, like pnpm v12's globalShims — that
advice was wrong twice over: the project file ignores the key too, and
for a cross-version setting the right action is to change nothing.

Both stacks now classify dropped keys against the union of every known
setting name and report unrecognized ones with their own message,
naming the release line that reads the key or the closest real setting
name when the key looks like a typo. Unrecognized and non-camelCase
keys in a project's pnpm-workspace.yaml, previously ignored in
silence, get the same report; in the TypeScript CLI the known-key set
is proven exhaustive against the Config type at compile time, so a
newly added setting cannot start out reported as unknown.

pacquet hardens the project-file report into
ERR_PNPM_UNRECOGNIZED_WORKSPACE_SETTINGS when the project pins a pnpm
the running pnpm satisfies: with the pin honored, no version-skew
excuse remains, so the key is a mistake the project must fix. The
pnpm config subcommands never hard-fail (a broken file must stay
inspectable and repairable), a satisfied pin behind --global only
warns, and the enforcement runs after the pm-switch decision so a
delegating pnpm never judges the file with the wrong version's key
set.

pnpm config get <key> (and pnpm get <key>) no longer prints
config-load warnings in either stack: single-key reads are consumed by
scripts, and the noise on every read is the complaint that started
this change.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed. (pnpm.io follow-up: document
  `ERR_PNPM_UNRECOGNIZED_WORKSPACE_SETTINGS` and the v12 strictness.)

---
Written by an agent (Claude Code, claude-fable-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearer warnings for unknown, misspelled, kebab-case, and unsupported settings.
  - Suggestions are provided for settings that closely match recognized keys.
  - Strict validation can stop commands when unrecognized workspace settings are found.
  - `$schema` directives are accepted without warnings.

- **Bug Fixes**
  - `pnpm config get` and `pnpm get` no longer display unrelated configuration warnings.
  - Global and workspace-only settings are distinguished more accurately.
  - Configuration warnings safely sanitize unusual characters, and explicit `null` values are ignored.
  - Global commands avoid unnecessary warnings when the configured package-manager version is satisfied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->