### PR TITLE
fix(workspace): keep settings-only workspaces root-scoped

### DIFF
--- a/.changeset/root-only-workspace-discovery.md
+++ b/.changeset/root-only-workspace-discovery.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/cli.commands": patch
+"@pnpm/deps.status": patch
+"@pnpm/workspace.projects-filter": patch
+"pnpm": patch
+---
+
+Fixed workspace discovery for `pnpm-workspace.yaml` files without a `packages` field so commands only consider the workspace root instead of recursively scanning nested projects [#14047](https://github.com/pnpm/pnpm/issues/14047).

--- a/pnpm11/cli/commands/src/completion/complete.ts
+++ b/pnpm11/cli/commands/src/completion/complete.ts
@@ -36,7 +36,7 @@ export async function complete (
       const workspaceDir = await findWorkspaceDir(process.cwd()) ?? process.cwd()
       const workspaceManifest = await readWorkspaceManifest(workspaceDir)
       const allProjects = await findWorkspaceProjects(workspaceDir, {
-        patterns: workspaceManifest?.packages ?? ['.'],
+        patterns: workspaceManifest == null ? undefined : workspaceManifest.packages ?? ['.'],
         supportedArchitectures: {
           os: ['current'],
           cpu: ['current'],

--- a/pnpm11/cli/commands/src/completion/complete.ts
+++ b/pnpm11/cli/commands/src/completion/complete.ts
@@ -36,7 +36,7 @@ export async function complete (
       const workspaceDir = await findWorkspaceDir(process.cwd()) ?? process.cwd()
       const workspaceManifest = await readWorkspaceManifest(workspaceDir)
       const allProjects = await findWorkspaceProjects(workspaceDir, {
-        patterns: workspaceManifest?.packages,
+        patterns: workspaceManifest?.packages ?? ['.'],
         supportedArchitectures: {
           os: ['current'],
           cpu: ['current'],

--- a/pnpm11/cli/commands/test/completion/complete.test.ts
+++ b/pnpm11/cli/commands/test/completion/complete.test.ts
@@ -1,3 +1,7 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
 import { expect, test } from '@jest/globals'
 
 import { complete } from '../../src/completion/complete.js'
@@ -28,6 +32,43 @@ test('complete an option value', async () => {
     { name: 'fast' },
     { name: 'fewer-dependencies' },
   ])
+})
+
+test('complete workspace packages from the root when the workspace manifest has no packages field', async () => {
+  const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-completion-'))
+  const initialCwd = process.cwd()
+  try {
+    await fs.mkdir(path.join(workspaceDir, 'nested'), { recursive: true })
+    await Promise.all([
+      fs.writeFile(path.join(workspaceDir, 'package.json'), JSON.stringify({ name: 'root' })),
+      fs.writeFile(path.join(workspaceDir, 'pnpm-workspace.yaml'), 'minimumReleaseAge: 0\n'),
+      fs.writeFile(path.join(workspaceDir, 'nested/package.json'), JSON.stringify({ name: 'nested' })),
+    ])
+    process.chdir(workspaceDir)
+
+    const completions = await complete(
+      {
+        cliOptionsTypesByCommandName: {},
+        completionByCommandName: {},
+        initialCompletion: () => [],
+        shorthandsByCommandName: {},
+        universalOptionsTypes: {},
+        universalShorthands: {},
+      },
+      {
+        cmd: 'run',
+        currentTypedWordType: 'value',
+        lastOption: '--filter',
+        options: {},
+        params: [],
+      }
+    )
+
+    expect(completions).toStrictEqual([{ name: 'root' }])
+  } finally {
+    process.chdir(initialCwd)
+    await fs.rm(workspaceDir, { recursive: true, force: true })
+  }
 })
 
 test('complete a command', async () => {

--- a/pnpm11/cli/commands/test/completion/complete.test.ts
+++ b/pnpm11/cli/commands/test/completion/complete.test.ts
@@ -71,6 +71,42 @@ test('complete workspace packages from the root when the workspace manifest has 
   }
 })
 
+test('complete nested packages when there is no workspace manifest', async () => {
+  const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-completion-'))
+  const initialCwd = process.cwd()
+  try {
+    await fs.mkdir(path.join(workspaceDir, 'nested'), { recursive: true })
+    await Promise.all([
+      fs.writeFile(path.join(workspaceDir, 'package.json'), JSON.stringify({ name: 'root' })),
+      fs.writeFile(path.join(workspaceDir, 'nested/package.json'), JSON.stringify({ name: 'nested' })),
+    ])
+    process.chdir(workspaceDir)
+
+    const completions = await complete(
+      {
+        cliOptionsTypesByCommandName: {},
+        completionByCommandName: {},
+        initialCompletion: () => [],
+        shorthandsByCommandName: {},
+        universalOptionsTypes: {},
+        universalShorthands: {},
+      },
+      {
+        cmd: 'run',
+        currentTypedWordType: 'value',
+        lastOption: '--filter',
+        options: {},
+        params: [],
+      }
+    )
+
+    expect(completions).toStrictEqual([{ name: 'root' }, { name: 'nested' }])
+  } finally {
+    process.chdir(initialCwd)
+    await fs.rm(workspaceDir, { recursive: true, force: true })
+  }
+})
+
 test('complete a command', async () => {
   const ctx = {
     cliOptionsTypesByCommandName: {

--- a/pnpm11/deps/status/src/checkDepsStatus.ts
+++ b/pnpm11/deps/status/src/checkDepsStatus.ts
@@ -503,7 +503,7 @@ async function _checkDepsStatus (opts: CheckDepsStatusOptions, workspaceState: W
     const workspaceManifest = await readWorkspaceManifest(workspaceRoot)
     if (workspaceManifest ?? workspaceDir) {
       const allProjects = await findWorkspaceProjectsNoCheck(rootProjectManifestDir, {
-        patterns: workspaceManifest?.packages,
+        patterns: workspaceManifest?.packages ?? ['.'],
       })
       return checkDepsStatus({
         ...opts,

--- a/pnpm11/deps/status/src/checkDepsStatus.ts
+++ b/pnpm11/deps/status/src/checkDepsStatus.ts
@@ -503,7 +503,7 @@ async function _checkDepsStatus (opts: CheckDepsStatusOptions, workspaceState: W
     const workspaceManifest = await readWorkspaceManifest(workspaceRoot)
     if (workspaceManifest ?? workspaceDir) {
       const allProjects = await findWorkspaceProjectsNoCheck(rootProjectManifestDir, {
-        patterns: workspaceManifest?.packages ?? ['.'],
+        patterns: workspaceManifest == null ? undefined : workspaceManifest.packages ?? ['.'],
       })
       return checkDepsStatus({
         ...opts,

--- a/pnpm11/deps/status/test/checkDepsStatus.test.ts
+++ b/pnpm11/deps/status/test/checkDepsStatus.test.ts
@@ -1711,35 +1711,69 @@ describe('checkDepsStatus - missing workspace state', () => {
 })
 
 describe('checkDepsStatus - workspace discovery', () => {
+  const settings = {
+    excludeLinksFromLockfile: false,
+    linkWorkspacePackages: true,
+    preferWorkspacePackages: true,
+  }
+
   beforeEach(() => {
     jest.resetModules()
     jest.clearAllMocks()
   })
 
   it('uses the workspace root when the workspace manifest has no packages field', async () => {
-    const settings = {
-      excludeLinksFromLockfile: false,
-      linkWorkspacePackages: true,
-      preferWorkspacePackages: true,
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-deps-status-'))
+    try {
+      await fs.writeFile(path.join(workspaceDir, 'pnpm-workspace.yaml'), 'minimumReleaseAge: 0\n')
+      jest.mocked(loadWorkspaceState).mockReturnValue({
+        lastValidatedTimestamp: Date.now(),
+        pnpmfiles: [],
+        settings,
+        projects: {},
+        filteredInstall: false,
+      })
+      jest.mocked(findWorkspaceProjectsNoCheck).mockRejectedValueOnce(new Error('stop after workspace discovery'))
+
+      await checkDepsStatus({
+        workspaceDir,
+        rootProjectManifestDir: workspaceDir,
+        pnpmfile: [],
+        ...settings,
+      })
+
+      expect(findWorkspaceProjectsNoCheck).toHaveBeenCalledWith(workspaceDir, {
+        patterns: ['.'],
+      })
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true })
     }
-    jest.mocked(loadWorkspaceState).mockReturnValue({
-      lastValidatedTimestamp: Date.now(),
-      pnpmfiles: [],
-      settings,
-      projects: {},
-      filteredInstall: false,
-    })
-    jest.mocked(findWorkspaceProjectsNoCheck).mockRejectedValueOnce(new Error('stop after workspace discovery'))
+  })
 
-    await checkDepsStatus({
-      workspaceDir: '/workspace',
-      rootProjectManifestDir: '/workspace',
-      pnpmfile: [],
-      ...settings,
-    })
+  it('preserves recursive discovery when there is no workspace manifest', async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-deps-status-'))
+    try {
+      jest.mocked(loadWorkspaceState).mockReturnValue({
+        lastValidatedTimestamp: Date.now(),
+        pnpmfiles: [],
+        settings,
+        projects: {},
+        filteredInstall: false,
+      })
+      jest.mocked(findWorkspaceProjectsNoCheck).mockRejectedValueOnce(new Error('stop after workspace discovery'))
 
-    expect(findWorkspaceProjectsNoCheck).toHaveBeenCalledWith('/workspace', {
-      patterns: ['.'],
-    })
+      await checkDepsStatus({
+        workspaceDir,
+        rootProjectManifestDir: workspaceDir,
+        pnpmfile: [],
+        ...settings,
+      })
+
+      expect(findWorkspaceProjectsNoCheck).toHaveBeenCalledWith(workspaceDir, {
+        patterns: undefined,
+      })
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true })
+    }
   })
 })

--- a/pnpm11/deps/status/test/checkDepsStatus.test.ts
+++ b/pnpm11/deps/status/test/checkDepsStatus.test.ts
@@ -17,6 +17,13 @@ import type { WorkspaceState } from '@pnpm/workspace.state'
   }))
 }
 {
+  const original = await import('@pnpm/workspace.projects-reader')
+  jest.unstable_mockModule('@pnpm/workspace.projects-reader', () => ({
+    ...original,
+    findWorkspaceProjectsNoCheck: jest.fn(original.findWorkspaceProjectsNoCheck),
+  }))
+}
+{
   const original = await import('../lib/safeStat.js')
   jest.unstable_mockModule('../lib/safeStat', () => ({
     ...original,
@@ -42,6 +49,7 @@ import type { WorkspaceState } from '@pnpm/workspace.state'
 }
 
 const { checkDepsStatus } = await import('@pnpm/deps.status')
+const { findWorkspaceProjectsNoCheck } = await import('@pnpm/workspace.projects-reader')
 const { loadWorkspaceState } = await import('@pnpm/workspace.state')
 const lockfileFs = await import('@pnpm/lockfile.fs')
 const fsUtils = await import('../lib/safeStat.js')
@@ -1699,5 +1707,39 @@ describe('checkDepsStatus - missing workspace state', () => {
 
     expect(result.upToDate).toBe(false)
     expect(result.issue).toBe('Cannot check whether dependencies are outdated')
+  })
+})
+
+describe('checkDepsStatus - workspace discovery', () => {
+  beforeEach(() => {
+    jest.resetModules()
+    jest.clearAllMocks()
+  })
+
+  it('uses the workspace root when the workspace manifest has no packages field', async () => {
+    const settings = {
+      excludeLinksFromLockfile: false,
+      linkWorkspacePackages: true,
+      preferWorkspacePackages: true,
+    }
+    jest.mocked(loadWorkspaceState).mockReturnValue({
+      lastValidatedTimestamp: Date.now(),
+      pnpmfiles: [],
+      settings,
+      projects: {},
+      filteredInstall: false,
+    })
+    jest.mocked(findWorkspaceProjectsNoCheck).mockRejectedValueOnce(new Error('stop after workspace discovery'))
+
+    await checkDepsStatus({
+      workspaceDir: '/workspace',
+      rootProjectManifestDir: '/workspace',
+      pnpmfile: [],
+      ...settings,
+    })
+
+    expect(findWorkspaceProjectsNoCheck).toHaveBeenCalledWith('/workspace', {
+      patterns: ['.'],
+    })
   })
 })

--- a/pnpm11/workspace/projects-filter/src/filterProjectsFromDir.ts
+++ b/pnpm11/workspace/projects-filter/src/filterProjectsFromDir.ts
@@ -16,7 +16,7 @@ export async function filterProjectsBySelectorObjectsFromDir (
 ): Promise<ReadProjectsResult> {
   const workspaceManifest = await readWorkspaceManifest(workspaceDir)
   const allProjects = await findWorkspaceProjects(workspaceDir, {
-    patterns: workspaceManifest?.packages ?? ['.'],
+    patterns: workspaceManifest == null ? undefined : workspaceManifest.packages ?? ['.'],
     engineStrict: opts?.engineStrict,
     supportedArchitectures: opts?.supportedArchitectures ?? {
       os: ['current'],

--- a/pnpm11/workspace/projects-filter/src/filterProjectsFromDir.ts
+++ b/pnpm11/workspace/projects-filter/src/filterProjectsFromDir.ts
@@ -16,7 +16,7 @@ export async function filterProjectsBySelectorObjectsFromDir (
 ): Promise<ReadProjectsResult> {
   const workspaceManifest = await readWorkspaceManifest(workspaceDir)
   const allProjects = await findWorkspaceProjects(workspaceDir, {
-    patterns: workspaceManifest?.packages,
+    patterns: workspaceManifest?.packages ?? ['.'],
     engineStrict: opts?.engineStrict,
     supportedArchitectures: opts?.supportedArchitectures ?? {
       os: ['current'],

--- a/pnpm11/workspace/projects-filter/test/filterProjectsFromDir.test.ts
+++ b/pnpm11/workspace/projects-filter/test/filterProjectsFromDir.test.ts
@@ -1,0 +1,24 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import { expect, test } from '@jest/globals'
+import { filterProjectsBySelectorObjectsFromDir } from '@pnpm/workspace.projects-filter'
+
+test('does not discover nested projects when the workspace manifest has no packages field', async () => {
+  const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-workspace-filter-'))
+  try {
+    await fs.mkdir(path.join(workspaceDir, 'nested'), { recursive: true })
+    await Promise.all([
+      fs.writeFile(path.join(workspaceDir, 'package.json'), JSON.stringify({ name: 'root' })),
+      fs.writeFile(path.join(workspaceDir, 'pnpm-workspace.yaml'), 'minimumReleaseAge: 0\n'),
+      fs.writeFile(path.join(workspaceDir, 'nested/package.json'), JSON.stringify({ name: 'nested' })),
+    ])
+
+    const result = await filterProjectsBySelectorObjectsFromDir(workspaceDir, [])
+
+    expect(result.allProjects.map(({ manifest }) => manifest.name)).toStrictEqual(['root'])
+  } finally {
+    await fs.rm(workspaceDir, { recursive: true, force: true })
+  }
+})

--- a/pnpm11/workspace/projects-filter/test/filterProjectsFromDir.test.ts
+++ b/pnpm11/workspace/projects-filter/test/filterProjectsFromDir.test.ts
@@ -22,3 +22,20 @@ test('does not discover nested projects when the workspace manifest has no packa
     await fs.rm(workspaceDir, { recursive: true, force: true })
   }
 })
+
+test('discovers nested projects when there is no workspace manifest', async () => {
+  const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-workspace-filter-'))
+  try {
+    await fs.mkdir(path.join(workspaceDir, 'nested'), { recursive: true })
+    await Promise.all([
+      fs.writeFile(path.join(workspaceDir, 'package.json'), JSON.stringify({ name: 'root' })),
+      fs.writeFile(path.join(workspaceDir, 'nested/package.json'), JSON.stringify({ name: 'nested' })),
+    ])
+
+    const result = await filterProjectsBySelectorObjectsFromDir(workspaceDir, [])
+
+    expect(result.allProjects.map(({ manifest }) => manifest.name)).toStrictEqual(['root', 'nested'])
+  } finally {
+    await fs.rm(workspaceDir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#14047.

When `pnpm-workspace.yaml` exists without a `packages` field, configuration treats the workspace as root-only (`['.']`). Three workspace discovery call sites bypassed that configured default and passed `undefined`, which activated the projects reader's recursive `['.', '**']` fallback.

This change applies the same root-only fallback in dependency status checks, workspace filtering, and `--filter` completion only when a workspace manifest exists. When no workspace manifest exists, these call sites continue passing `undefined`, preserving the projects reader's recursive default.

The Rust `pnpm/` port already passes the configured `workspace_package_patterns`, including its root-only default, so no Rust change is required.

## Squash Commit Body

```text
Keep settings-only workspace manifests scoped to the root package when checking dependency status, filtering projects, and completing --filter values.

These call sites previously passed an undefined package pattern to the projects reader, activating its recursive default even though config had already defined settings-only workspaces as root-only. Preserve the projects reader default for other callers and apply the root-only fallback only at the three manifest-aware boundaries.

Fixes pnpm/pnpm#14047.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789914028&installation_model_id=426870&pr_number=14059&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14059&signature=b5ff237be401f41e8f5b624103112c709234047acfe8b418e8df6f19de0878f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace manifests without a `packages` field now treat the workspace root as the only project.
  * Nested projects are no longer discovered unintentionally in root-only workspaces.
  * Workspace package completion and dependency checks now correctly recognize root-only configurations.
  * Workspaces without a manifest continue to discover nested projects as expected.

* **Tests**
  * Added coverage for workspace discovery, filtering, dependency checks, and package completion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
