### PR TITLE
chore: enable `minimumReleaseAgeExcludePrune` & `catalogPrune`

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -386,10 +386,9 @@ catalog:
   write-yaml-file: ^6.0.0
   yaml: ^2.9.0
   yaml-tag: 1.1.0
-
 catalogMode: strict
 
-cleanupUnusedCatalogs: true
+catalogPrune: true
 
 enableGlobalVirtualStore: true
 
@@ -406,24 +405,17 @@ minimumReleaseAge: 1440 # At least a day
 
 minimumReleaseAgeExclude:
   - '@pnpm/*'
-  - '@rushstack/worker-pool@0.7.18'
   - '@zkochan/*'
   - better-path-resolve
-  - body-parser@2.2.1
   - can-link
   - can-write-to-dir
   - cmd-extension
   - comver-to-semver
   - dir-is-case-sensitive
-  - esbuild@0.28.1
   - '@esbuild/*'
-  - express@4.22.1
   - glob@11.1.0
-  - handlebars@4.7.9
   - is-inner-link
   - is-subdir
-  - jws@3.2.3
-  - lodash@4.17.23
   - make-empty-dir
   - normalize-registry-url
   - parse-npm-tarball-url@5.0.0
@@ -432,9 +424,7 @@ minimumReleaseAgeExclude:
   - pnpm
   - preferred-pm
   - promise-share
-  - qs@6.14.2 || 6.15.2
   - read-ini-file
-  - read-json5-file
   - read-yaml-file
   - realpath-missing
   - rename-overwrite
@@ -445,15 +435,14 @@ minimumReleaseAgeExclude:
   - safe-execa
   - safe-promise-defer
   - symlink-dir
-  - tar@7.5.10
   - which-pm
-  - which-pm-runs
   - write-ini-file
   - write-json5-file
   - write-yaml-file
-  - tmp@0.2.6
   - http-proxy-middleware@3.0.7
-  - get-pnpm@0.0.2 || 0.0.3
+  - get-pnpm@0.0.3
+
+minimumReleaseAgeExcludePrune: true
 
 nodeVersion: 22.13.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -386,6 +386,7 @@ catalog:
   write-yaml-file: ^6.0.0
   yaml: ^2.9.0
   yaml-tag: 1.1.0
+
 catalogMode: strict
 
 catalogPrune: true


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary
https://github.com/pnpm/pnpm/releases/tag/v11.22.0
<!-- Describe what this PR changes and why, for reviewers. Link any related
issues here (Closes pnpm/pnpm#123, Fixes pnpm/pnpm#456, or Related to
pnpm/pnpm#123 for a partial fix). -->

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
Explain what changed and why. Reference issues here too (Closes pnpm/pnpm#123).
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [ ] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [ ] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [ ] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [ ] Added or updated tests.
- [ ] Updated the documentation if needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14066"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789959658&installation_model_id=426870&pr_number=14066&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14066&signature=324b84a3d319bdcbcd40860c3b114b6cca9bd07ccde4424791bf4fed1f93b69c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package workspace maintenance settings.
  * Improved automatic cleanup of unused package catalog entries and outdated release-age exceptions.
  * Refined package compatibility exceptions to retain required entries while removing obsolete ones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->