### PR TITLE
fix(deploy): drop excluded dependency groups from the deployed project

### DIFF
--- a/.changeset/deploy-drops-excluded-direct-deps.md
+++ b/.changeset/deploy-drops-excluded-direct-deps.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/releasing.commands": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+`pnpm deploy --prod` and `pnpm deploy --no-optional` no longer list the excluded dependency groups in the deployed `package.json` and `pnpm-lock.yaml`. The deployed lockfile referenced packages that the deploy left out of its graph, so installing in the deploy directory afterwards created dangling symlinks [#13623](https://github.com/pnpm/pnpm/issues/13623).

--- a/.changeset/dev-only-install-drops-optionals.md
+++ b/.changeset/dev-only-install-drops-optionals.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm install --dev` and `pnpm deploy --dev` no longer install optional dependencies, and `--prod` now takes precedence when combined with `--dev`, matching the TypeScript pnpm CLI.

--- a/cspell.json
+++ b/cspell.json
@@ -44,6 +44,7 @@
     "canva",
     "cerbos",
     "certfile",
+    "chcp",
     "chmods",
     "clonedeep",
     "clonefile",

--- a/pnpm/crates/cli/src/cli_args/deploy.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy.rs
@@ -744,24 +744,36 @@ fn create_deploy_files(
 
     let selected_root = lexical_normalize(&selected.project.root_dir);
     let selected_bases = ResolveBases { file_base: lockfile_dir, link_base: &selected_root };
-    fill_target_dependency_map(
-        &mut target_snapshot.dependencies,
-        input_snapshot.dependencies.as_ref(),
-        &ctx,
-        &selected_bases,
-    )?;
-    fill_target_dependency_map(
-        &mut target_snapshot.dev_dependencies,
-        input_snapshot.dev_dependencies.as_ref(),
-        &ctx,
-        &selected_bases,
-    )?;
-    fill_target_dependency_map(
-        &mut target_snapshot.optional_dependencies,
-        input_snapshot.optional_dependencies.as_ref(),
-        &ctx,
-        &selected_bases,
-    )?;
+    // An excluded group's direct dependencies are left out of both the
+    // deployed manifest and the deployed importer, because the graph prune
+    // below drops the packages they would point at.
+    if dependency_groups.contains(&DependencyGroup::Prod) {
+        fill_target_dependency_map(
+            &mut target_snapshot.dependencies,
+            input_snapshot.dependencies.as_ref(),
+            &ctx,
+            &selected_bases,
+        )?;
+    }
+    if dependency_groups.contains(&DependencyGroup::Dev) {
+        fill_target_dependency_map(
+            &mut target_snapshot.dev_dependencies,
+            input_snapshot.dev_dependencies.as_ref(),
+            &ctx,
+            &selected_bases,
+        )?;
+    }
+    if dependency_groups.contains(&DependencyGroup::Optional) {
+        fill_target_dependency_map(
+            &mut target_snapshot.optional_dependencies,
+            input_snapshot.optional_dependencies.as_ref(),
+            &ctx,
+            &selected_bases,
+        )?;
+    }
+    drop_empty_dependency_map(&mut target_snapshot.dependencies);
+    drop_empty_dependency_map(&mut target_snapshot.dev_dependencies);
+    drop_empty_dependency_map(&mut target_snapshot.optional_dependencies);
 
     let mut packages = HashMap::new();
     if let Some(input_packages) = lockfile.packages.as_ref() {
@@ -892,17 +904,13 @@ fn create_deploy_files(
 
 /// Keep only the dependency graph that the deploy install will materialize.
 ///
-/// The deploy importer and package manifest intentionally retain every direct
-/// dependency group so the generated frozen lockfile still satisfies the
-/// generated manifest. Only the package graph is mode-specific: for example,
-/// `deploy --prod` excludes dev-only and unrelated workspace snapshots from
-/// both the lockfile and the localized virtual store.
+/// The deploy importer already carries just the included dependency groups, so
+/// this walks it in full: `deploy --prod` excludes dev-only and unrelated
+/// workspace snapshots from both the lockfile and the localized virtual store.
 fn prune_deploy_lockfile_graph(lockfile: &mut Lockfile, dependency_groups: &[DependencyGroup]) {
     let Some(snapshots) = lockfile.snapshots.as_ref() else { return };
     let Some(importer) = lockfile.importers.get(Lockfile::ROOT_IMPORTER_KEY) else { return };
 
-    let include_prod = dependency_groups.contains(&DependencyGroup::Prod);
-    let include_dev = dependency_groups.contains(&DependencyGroup::Dev);
     let include_optional = dependency_groups.contains(&DependencyGroup::Optional);
     let mut queue = VecDeque::new();
 
@@ -915,15 +923,9 @@ fn prune_deploy_lockfile_graph(lockfile: &mut Lockfile, dependency_groups: &[Dep
                 }
             }
         };
-        if include_prod {
-            enqueue_importer_map(importer.dependencies.as_ref());
-        }
-        if include_dev {
-            enqueue_importer_map(importer.dev_dependencies.as_ref());
-        }
-        if include_optional {
-            enqueue_importer_map(importer.optional_dependencies.as_ref());
-        }
+        enqueue_importer_map(importer.dependencies.as_ref());
+        enqueue_importer_map(importer.dev_dependencies.as_ref());
+        enqueue_importer_map(importer.optional_dependencies.as_ref());
     }
 
     let mut reachable = HashSet::new();
@@ -964,6 +966,13 @@ fn prune_deploy_lockfile_graph(lockfile: &mut Lockfile, dependency_groups: &[Dep
         if packages.is_empty() {
             lockfile.packages = None;
         }
+    }
+}
+
+/// A lockfile importer records a dependency group only when it has entries.
+fn drop_empty_dependency_map(dependencies: &mut Option<ResolvedDependencyMap>) {
+    if dependencies.as_ref().is_some_and(HashMap::is_empty) {
+        *dependencies = None;
     }
 }
 

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -75,10 +75,15 @@ impl InstallDependencyOptions {
     /// which filters the types of dependencies to install.
     pub(crate) fn dependency_groups(&self) -> impl Iterator<Item = DependencyGroup> {
         let &InstallDependencyOptions { prod, dev, no_optional } = self;
-        let has_both = prod == dev;
-        let has_prod = has_both || prod;
-        let has_dev = has_both || dev;
-        let has_optional = !no_optional;
+        // `--prod` wins over `--dev`, and a dev-only install drops optional
+        // dependencies along with the production ones.
+        let (has_prod, has_dev, has_optional) = if prod {
+            (true, false, !no_optional)
+        } else if dev {
+            (false, true, false)
+        } else {
+            (true, true, !no_optional)
+        };
         std::iter::empty()
             .chain(has_prod.then_some(DependencyGroup::Prod))
             .chain(has_dev.then_some(DependencyGroup::Dev))

--- a/pnpm/crates/cli/src/cli_args/install/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/install/tests.rs
@@ -8,6 +8,8 @@ use pnpm_lockfile::{LockfileResolution, TarballResolution};
 use pnpm_package_manifest::DependencyGroup;
 use pretty_assertions::assert_eq;
 
+/// The full flag matrix, mirroring the TypeScript CLI's prod/dev/optional
+/// resolution in `config/reader/src/index.ts`.
 #[test]
 fn dependency_options_to_dependency_groups() {
     use DependencyGroup::{Dev, Optional, Prod};
@@ -25,7 +27,7 @@ fn dependency_options_to_dependency_groups() {
 
     assert_eq!(
         create_list(InstallDependencyOptions { prod: false, dev: true, no_optional: false }),
-        [Dev, Optional],
+        [Dev],
     );
 
     assert_eq!(
@@ -45,12 +47,12 @@ fn dependency_options_to_dependency_groups() {
 
     assert_eq!(
         create_list(InstallDependencyOptions { prod: true, dev: true, no_optional: false }),
-        [Prod, Dev, Optional],
+        [Prod, Optional],
     );
 
     assert_eq!(
         create_list(InstallDependencyOptions { prod: true, dev: true, no_optional: true }),
-        [Prod, Dev],
+        [Prod],
     );
 }
 

--- a/pnpm/crates/cli/tests/suite/deploy.rs
+++ b/pnpm/crates/cli/tests/suite/deploy.rs
@@ -5,7 +5,12 @@ use pnpm_testing_utils::{
     bin::{AddMockedRegistry, CommandTempCwd},
     fs::is_symlink_or_junction,
 };
-use std::{fmt::Write as _, fs, path::Path, process::Command};
+use std::{
+    fmt::Write as _,
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 #[test]
 fn deploy_from_shared_lockfile_installs_selected_project() {
@@ -275,11 +280,7 @@ fn shared_lockfile_deploy_drops_excluded_direct_dependencies() {
     fs::copy(&npmrc_path, deploy_dir.join(".npmrc")).unwrap();
     fs::remove_dir_all(deploy_dir.join("node_modules")).unwrap();
     pacquet_cmd(&deploy_dir).with_args(["install", "--frozen-lockfile"]).assert().success();
-    let dangling = fs::read_dir(deploy_dir.join("node_modules"))
-        .unwrap()
-        .map(|entry| entry.unwrap().path())
-        .filter(|path| is_symlink_or_junction(path).unwrap() && !path.exists())
-        .collect::<Vec<_>>();
+    let dangling = dangling_links(&deploy_dir.join("node_modules"));
     assert!(
         dangling.is_empty(),
         "installing the deployed lockfile must not create dangling symlinks: {dangling:#?}",
@@ -708,6 +709,25 @@ fn assert_workspace_lockfile_untouched(workspace: &Path, before: &str) {
 
 fn pacquet_cmd(workspace: &Path) -> Command {
     Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
+}
+
+/// Every link under `dir`, at any depth, whose target does not exist.
+fn dangling_links(dir: &Path) -> Vec<PathBuf> {
+    let mut dangling = Vec::new();
+    let mut queue = vec![dir.to_path_buf()];
+    while let Some(current) = queue.pop() {
+        for entry in fs::read_dir(&current).expect("read a deployed directory") {
+            let path = entry.expect("read a deployed entry").path();
+            if is_symlink_or_junction(&path).expect("stat a deployed entry") {
+                if !path.exists() {
+                    dangling.push(path);
+                }
+            } else if path.is_dir() {
+                queue.push(path);
+            }
+        }
+    }
+    dangling
 }
 
 fn deploy_graph_keys(deploy_dir: &Path) -> Vec<String> {

--- a/pnpm/crates/cli/tests/suite/deploy.rs
+++ b/pnpm/crates/cli/tests/suite/deploy.rs
@@ -214,6 +214,80 @@ fn shared_lockfile_deploy_honors_no_optional_in_graph_and_virtual_store() {
     drop((root, mock_instance));
 }
 
+/// A deployed lockfile must never reference a package the graph prune drops:
+/// a later install in the deploy directory would link the missing package and
+/// leave the dangling symlinks of <https://github.com/pnpm/pnpm/issues/13623>.
+#[test]
+fn shared_lockfile_deploy_drops_excluded_direct_dependencies() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { npmrc_path, mock_instance, .. } = npmrc_info;
+    write_workspace(&workspace, true);
+    write_project(
+        &workspace,
+        "app",
+        &serde_json::json!({
+            "name": "app",
+            "version": "1.0.0",
+            "files": ["index.js"],
+            "dependencies": { "@pnpm.e2e/foo": "100.0.0" },
+            "devDependencies": { "@pnpm.e2e/bar": "100.0.0" },
+            "optionalDependencies": { "@pnpm.e2e/qar": "100.0.0" },
+        }),
+    );
+
+    pacquet.with_arg("install").assert().success();
+    // Deploying outside the workspace keeps the follow-up install standalone.
+    let deploy_dir = root.path().join("deploy");
+    pacquet_cmd(&workspace)
+        .with_args(["--filter", "app", "deploy", "--prod", "--no-optional"])
+        .with_arg(&deploy_dir)
+        .assert()
+        .success();
+
+    let deploy_manifest: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(deploy_dir.join("package.json")).unwrap())
+            .unwrap();
+    assert!(
+        deploy_manifest["dependencies"]["@pnpm.e2e/foo"].is_string(),
+        "the production dependency should survive: {deploy_manifest:#}",
+    );
+    for excluded in ["devDependencies", "optionalDependencies"] {
+        assert_eq!(
+            deploy_manifest[excluded],
+            serde_json::json!({}),
+            "the deployed manifest should drop {excluded}: {deploy_manifest:#}",
+        );
+    }
+
+    let deploy_lockfile = Lockfile::load_wanted_from_dir(&deploy_dir).unwrap().unwrap();
+    let importer = deploy_lockfile.importers.get(Lockfile::ROOT_IMPORTER_KEY).unwrap();
+    assert!(importer.dev_dependencies.is_none(), "{:#?}", importer.dev_dependencies);
+    assert!(importer.optional_dependencies.is_none(), "{:#?}", importer.optional_dependencies);
+    let graph_keys = deploy_graph_keys(&deploy_dir);
+    for excluded in ["@pnpm.e2e/bar@", "@pnpm.e2e/qar@"] {
+        assert!(
+            !graph_keys.iter().any(|key| key.contains(excluded)),
+            "the deploy lock graph should exclude {excluded}: {graph_keys:#?}",
+        );
+    }
+
+    fs::copy(&npmrc_path, deploy_dir.join(".npmrc")).unwrap();
+    fs::remove_dir_all(deploy_dir.join("node_modules")).unwrap();
+    pacquet_cmd(&deploy_dir).with_args(["install", "--frozen-lockfile"]).assert().success();
+    let dangling = fs::read_dir(deploy_dir.join("node_modules"))
+        .unwrap()
+        .map(|entry| entry.unwrap().path())
+        .filter(|path| is_symlink_or_junction(path).unwrap() && !path.exists())
+        .collect::<Vec<_>>();
+    assert!(
+        dangling.is_empty(),
+        "installing the deployed lockfile must not create dangling symlinks: {dangling:#?}",
+    );
+
+    drop((root, mock_instance));
+}
+
 #[test]
 fn deploy_from_shared_lockfile_supports_catalog_dependencies() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =

--- a/pnpm/crates/cli/tests/suite/optional_dependencies.rs
+++ b/pnpm/crates/cli/tests/suite/optional_dependencies.rs
@@ -11,6 +11,13 @@ use pnpm_lockfile::{Lockfile, PkgName};
 use pnpm_testing_utils::bin::CommandTempCwd;
 use std::{fs, path::Path};
 
+/// Nothing at `path` at all. `Path::exists` follows links, so it also reports
+/// `false` for a link whose target is missing — an excluded dependency that was
+/// wrongly linked would pass a plain `!exists()` check.
+fn is_absent(path: &Path) -> bool {
+    fs::symlink_metadata(path).is_err()
+}
+
 fn read_wanted_lockfile(workspace: &Path) -> Lockfile {
     let text =
         fs::read_to_string(workspace.join(Lockfile::FILE_NAME)).expect("read pnpm-lock.yaml");
@@ -620,7 +627,7 @@ fn headless_install_include_filtering_excludes_production_group() {
     pacquet_in(&workspace).with_args(["install", "--frozen-lockfile", "--dev"]).assert().success();
 
     assert!(
-        !workspace.join("node_modules/@pnpm.e2e/foo").exists(),
+        is_absent(&workspace.join("node_modules/@pnpm.e2e/foo")),
         "the excluded production dependency must not be linked",
     );
     assert!(
@@ -628,7 +635,7 @@ fn headless_install_include_filtering_excludes_production_group() {
         "the dev dependency must be installed",
     );
     assert!(
-        !workspace.join("node_modules/@pnpm.e2e/qar").exists(),
+        is_absent(&workspace.join("node_modules/@pnpm.e2e/qar")),
         "a dev-only install must not install the optional dependency",
     );
 

--- a/pnpm/crates/cli/tests/suite/optional_dependencies.rs
+++ b/pnpm/crates/cli/tests/suite/optional_dependencies.rs
@@ -9,13 +9,17 @@ use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pnpm_lockfile::{Lockfile, PkgName};
 use pnpm_testing_utils::bin::CommandTempCwd;
-use std::{fs, path::Path};
+use std::{fs, io, path::Path};
 
 /// Nothing at `path` at all. `Path::exists` follows links, so it also reports
 /// `false` for a link whose target is missing — an excluded dependency that was
 /// wrongly linked would pass a plain `!exists()` check.
 fn is_absent(path: &Path) -> bool {
-    fs::symlink_metadata(path).is_err()
+    match fs::symlink_metadata(path) {
+        Ok(_) => false,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => true,
+        Err(error) => panic!("stat {}: {error}", path.display()),
+    }
 }
 
 fn read_wanted_lockfile(workspace: &Path) -> Lockfile {

--- a/pnpm/crates/cli/tests/suite/optional_dependencies.rs
+++ b/pnpm/crates/cli/tests/suite/optional_dependencies.rs
@@ -600,9 +600,9 @@ fn headless_install_without_optional_deps() {
 
 /// TS: `installing only optional deps` (`deps-restorer/test/index.ts:300`).
 /// Upstream drives the programmatic API with `include = { dependencies:
-/// false, devDependencies: false, optionalDependencies: true }`; the
-/// CLI-reachable equivalent is `--dev` (keep dev + optional, drop
-/// production), which exercises the same headless include filtering.
+/// false, devDependencies: false, optionalDependencies: true }`, which no
+/// flag combination reaches. `--dev` is the closest CLI-reachable headless
+/// include filter: it drops the optional group along with the production one.
 #[test]
 fn headless_install_include_filtering_excludes_production_group() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
@@ -628,8 +628,8 @@ fn headless_install_include_filtering_excludes_production_group() {
         "the dev dependency must be installed",
     );
     assert!(
-        workspace.join("node_modules/@pnpm.e2e/qar/package.json").exists(),
-        "the optional dependency must be installed",
+        !workspace.join("node_modules/@pnpm.e2e/qar").exists(),
+        "a dev-only install must not install the optional dependency",
     );
 
     drop((root, npmrc_info)); // cleanup

--- a/pnpm11/pnpm/test/deploy.ts
+++ b/pnpm11/pnpm/test/deploy.ts
@@ -147,6 +147,47 @@ test('deploy with a shared lockfile honors --no-optional in the graph and virtua
   expect(retainedOptionalEdges).toStrictEqual([])
 })
 
+// A deployed lockfile must never reference a package the graph filter drops:
+// a later install in the deploy directory would link the missing package and
+// leave the dangling symlinks of https://github.com/pnpm/pnpm/issues/13623.
+test('deploy with a shared lockfile drops excluded direct dependency groups', async () => {
+  preparePackages([
+    { location: '.', package: { name: 'root', version: '0.0.0', private: true } },
+    {
+      location: 'packages/app',
+      package: {
+        name: 'app',
+        version: '1.0.0',
+        dependencies: { '@pnpm.e2e/foo': '100.0.0' },
+        devDependencies: { '@pnpm.e2e/bar': '100.0.0' },
+        optionalDependencies: { '@pnpm.e2e/qar': '100.0.0' },
+      },
+    },
+  ])
+
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    packages: ['packages/*'],
+    injectWorkspacePackages: true,
+  })
+
+  await execPnpm(['install'])
+
+  const deployDir = path.resolve('deploy')
+  await execPnpm(['--filter=app', 'deploy', '--prod', '--no-optional', deployDir])
+
+  const deployManifest = loadJsonFileSync<Record<string, unknown>>(path.join(deployDir, 'package.json'))
+  expect(deployManifest.dependencies).toStrictEqual({ '@pnpm.e2e/foo': '100.0.0' })
+  expect(deployManifest.devDependencies).toStrictEqual({})
+  expect(deployManifest.optionalDependencies).toStrictEqual({})
+
+  const deployLockfile = readYamlFileSync<LockfileFile>(path.join(deployDir, 'pnpm-lock.yaml'))
+  const importer = deployLockfile.importers!['.']
+  expect(importer.devDependencies ?? {}).toStrictEqual({})
+  expect(importer.optionalDependencies ?? {}).toStrictEqual({})
+  const graphKeys = Object.keys(deployLockfile.packages ?? {})
+  expect(graphKeys.filter(key => key.startsWith('@pnpm.e2e/bar@') || key.startsWith('@pnpm.e2e/qar@'))).toStrictEqual([])
+})
+
 // `pacquet` is fetched from the real npm registry — registry-mock doesn't
 // carry it (or its platform-specific binary sub-packages), so this test
 // requires the public registry to be reachable. Matches the pattern in

--- a/pnpm11/pnpm/test/deploy.ts
+++ b/pnpm11/pnpm/test/deploy.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 
 import { expect, test } from '@jest/globals'
 import type { LockfileFile } from '@pnpm/lockfile.types'
-import { preparePackages } from '@pnpm/prepare'
+import { preparePackages, tempDir } from '@pnpm/prepare'
 import { loadJsonFileSync } from 'load-json-file'
 import { readYamlFileSync } from 'read-yaml-file'
 import { writeYamlFileSync } from 'write-yaml-file'
@@ -172,7 +172,9 @@ test('deploy with a shared lockfile drops excluded direct dependency groups', as
 
   await execPnpm(['install'])
 
-  const deployDir = path.resolve('deploy')
+  // Deploying outside the workspace keeps the follow-up install standalone.
+  const workspaceDir = process.cwd()
+  const deployDir = path.join(tempDir(false), 'deploy')
   await execPnpm(['--filter=app', 'deploy', '--prod', '--no-optional', deployDir])
 
   const deployManifest = loadJsonFileSync<Record<string, unknown>>(path.join(deployDir, 'package.json'))
@@ -186,6 +188,18 @@ test('deploy with a shared lockfile drops excluded direct dependency groups', as
   expect(importer.optionalDependencies ?? {}).toStrictEqual({})
   const graphKeys = Object.keys(deployLockfile.packages ?? {})
   expect(graphKeys.filter(key => key.startsWith('@pnpm.e2e/bar@') || key.startsWith('@pnpm.e2e/qar@'))).toStrictEqual([])
+
+  const nodeModulesDir = path.join(deployDir, 'node_modules')
+  fs.rmSync(nodeModulesDir, { recursive: true })
+  process.chdir(deployDir)
+  try {
+    await execPnpm(['install', '--frozen-lockfile'])
+  } finally {
+    process.chdir(workspaceDir)
+  }
+  const dangling = fs.readdirSync(nodeModulesDir, { recursive: true, encoding: 'utf8' })
+    .filter(entry => !fs.existsSync(path.join(nodeModulesDir, entry)))
+  expect(dangling).toStrictEqual([])
 })
 
 // `pacquet` is fetched from the real npm registry — registry-mock doesn't

--- a/pnpm11/releasing/commands/src/deploy/createDeployFiles.ts
+++ b/pnpm11/releasing/commands/src/deploy/createDeployFiles.ts
@@ -106,6 +106,10 @@ export function createDeployFiles ({
   }
 
   for (const field of DEPENDENCIES_FIELD) {
+    // An excluded group's direct dependencies are left out of both the
+    // deployed manifest and the deployed importer, because the graph filter
+    // below drops the packages they would point at.
+    if (!include[field]) continue
     const targetDependencies = targetSnapshot[field] ?? {}
     const targetSpecifiers = targetSnapshot.specifiers
     const inputDependencies = inputSnapshot[field] ?? {}
@@ -197,9 +201,9 @@ function filterDeployPackageSnapshots (
     }
   }
 
-  if (include.dependencies) enqueue(importer.dependencies)
-  if (include.devDependencies) enqueue(importer.devDependencies)
-  if (include.optionalDependencies) enqueue(importer.optionalDependencies)
+  enqueue(importer.dependencies)
+  enqueue(importer.devDependencies)
+  enqueue(importer.optionalDependencies)
 
   const reachable = new Set<DepPath>()
   let head = 0

--- a/pnpm11/releasing/commands/test/deploy/createDeployFiles.test.ts
+++ b/pnpm11/releasing/commands/test/deploy/createDeployFiles.test.ts
@@ -132,3 +132,73 @@ test('createDeployFiles drops optional edges of retained packages when optional 
   expect(withoutOptional.packages?.[optionalDepPath]).toBeUndefined()
   expect(withoutOptional.packages?.[keptDepPath].optionalDependencies).toBeUndefined()
 })
+
+test('createDeployFiles drops excluded direct dependency groups from the importer and the manifest', () => {
+  const lockfileDir = path.resolve('workspace')
+  const deployDir = path.join(lockfileDir, 'out')
+  const projectId = '.' as ProjectId
+  const prodDepPath = 'prod@1.0.0' as DepPath
+  const devDepPath = 'dev@1.0.0' as DepPath
+  const optionalDepPath = 'opt@1.0.0' as DepPath
+  const lockfile: LockfileObject = {
+    lockfileVersion: '9.0',
+    settings: {
+      autoInstallPeers: true,
+      excludeLinksFromLockfile: false,
+    },
+    importers: {
+      [projectId]: {
+        specifiers: { prod: '1.0.0', dev: '1.0.0', opt: '1.0.0' },
+        dependencies: { prod: '1.0.0' },
+        devDependencies: { dev: '1.0.0' },
+        optionalDependencies: { opt: '1.0.0' },
+      },
+    },
+    packages: {
+      [prodDepPath]: { resolution: { integrity: 'sha512-prod' }, version: '1.0.0' },
+      [devDepPath]: { resolution: { integrity: 'sha512-dev' }, version: '1.0.0' },
+      [optionalDepPath]: { resolution: { integrity: 'sha512-opt' }, version: '1.0.0' },
+    },
+  }
+  const commonOpts = {
+    allProjects: [{
+      rootDirRealPath: lockfileDir as ProjectRootDirRealPath,
+      manifest: { name: 'app', version: '1.0.0' },
+    }],
+    deployDir,
+    lockfile,
+    lockfileDir,
+    selectedProjectManifest: {
+      name: 'app',
+      version: '1.0.0',
+      dependencies: { prod: '1.0.0' },
+      devDependencies: { dev: '1.0.0' },
+      optionalDependencies: { opt: '1.0.0' },
+    },
+    projectId,
+    rootProjectManifestDir: lockfileDir,
+  }
+
+  const all = createDeployFiles({
+    ...commonOpts,
+    include: { dependencies: true, devDependencies: true, optionalDependencies: true },
+  })
+  expect(all.lockfile.importers[projectId].devDependencies).toStrictEqual({ dev: '1.0.0' })
+  expect(all.lockfile.importers[projectId].optionalDependencies).toStrictEqual({ opt: '1.0.0' })
+  expect(all.manifest.devDependencies).toStrictEqual({ dev: '1.0.0' })
+  expect(all.manifest.optionalDependencies).toStrictEqual({ opt: '1.0.0' })
+
+  const prodOnly = createDeployFiles({
+    ...commonOpts,
+    include: { dependencies: true, devDependencies: false, optionalDependencies: false },
+  })
+  expect(prodOnly.lockfile.importers[projectId].dependencies).toStrictEqual({ prod: '1.0.0' })
+  expect(prodOnly.lockfile.importers[projectId].devDependencies).toStrictEqual({})
+  expect(prodOnly.lockfile.importers[projectId].optionalDependencies).toStrictEqual({})
+  expect(prodOnly.lockfile.importers[projectId].specifiers).toStrictEqual({ prod: '1.0.0' })
+  expect(prodOnly.manifest.devDependencies).toStrictEqual({})
+  expect(prodOnly.manifest.optionalDependencies).toStrictEqual({})
+  expect(prodOnly.lockfile.packages?.[prodDepPath]).toBeDefined()
+  expect(prodOnly.lockfile.packages?.[devDepPath]).toBeUndefined()
+  expect(prodOnly.lockfile.packages?.[optionalDepPath]).toBeUndefined()
+})

--- a/pnpm11/releasing/commands/test/deploy/shared-lockfile.test.ts
+++ b/pnpm11/releasing/commands/test/deploy/shared-lockfile.test.ts
@@ -151,6 +151,10 @@ test('deploy with a shared lockfile after full install', async () => {
     files: ['index.js'],
     optionalDependencies: {},
   }
+  const expectedProdDeployManifest = {
+    ...expectedDeployManifest,
+    devDependencies: {},
+  }
 
   // deploy prod only
   {
@@ -175,7 +179,7 @@ test('deploy with a shared lockfile after full install', async () => {
     project.hasNot('is-negative')
     project.hasNot('project-4')
     project.hasNot('project-5')
-    expect(readPackageJson('deploy')).toStrictEqual(expectedDeployManifest)
+    expect(readPackageJson('deploy')).toStrictEqual(expectedProdDeployManifest)
     expect(fs.existsSync('deploy/pnpm-lock.yaml')).toBeTruthy()
     expect(fs.existsSync('deploy/index.js')).toBeTruthy()
     expect(fs.existsSync('deploy/test.js')).toBeFalsy()
@@ -513,16 +517,6 @@ test('deploy with a shared lockfile and --prod filter should not fail even if de
           specifier: expect.stringMatching(/^prod-1@file:/),
         },
       },
-      devDependencies: {
-        'dev-0': {
-          version: expect.stringMatching(/^dev-0@file:/),
-          specifier: expect.stringMatching(/^dev-0@file:/),
-        },
-        'is-negative': {
-          version: '1.0.0',
-          specifier: '1.0.0',
-        },
-      },
     },
   })
 
@@ -534,10 +528,7 @@ test('deploy with a shared lockfile and --prod filter should not fail even if de
     dependencies: {
       'prod-1': expect.stringMatching(/^prod-1@file:/),
     },
-    devDependencies: {
-      'dev-0': expect.stringMatching(/^dev-0@file:/),
-      'is-negative': '1.0.0',
-    },
+    devDependencies: {},
     optionalDependencies: {},
   })
 


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#13623.

The dangling symlinks the issue reports directly no longer reproduce — pnpm/pnpm#13641 fixed the snapshot half of the problem — but the same defect is still there one level up.

A shared-lockfile deploy prunes the package graph to the included dependency groups, yet it fills **every** direct dependency group into the deployed `package.json` and into the deployed lockfile's importer. The deployed lockfile therefore references packages it does not define, and the next install in the deploy directory trips over that. The two stacks fail differently:

```console
$ pnpm --filter app deploy /tmp/deployment --prod --no-optional
$ cd /tmp/deployment && pnpm install --frozen-lockfile

# pacquet: installs, and silently links what the lockfile never defined
$ file node_modules/sharp
node_modules/sharp: broken symbolic link to .pnpm/sharp@0.35.3/node_modules/sharp

# TypeScript CLI: refuses the install
[ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY] Broken lockfile: no entry for 'sharp@0.35.3' in pnpm-lock.yaml
```

`--prod` has the same hole for `devDependencies`, and the existing `#8778` test showed how bad it can get: its deployed lockfile pointed at `dev-0@file:…`, a workspace project that had been deleted before the deploy.

The fix is to fill only the included groups, so the deployed manifest, the deployed importer, and the deployed package graph agree. Both stacks change identically (`create_deploy_files` in pacquet, `createDeployFiles` in the TypeScript CLI), and the graph walk no longer needs its own `include` gating for the importer maps.

One parity nit rides along: pacquet wrote an emptied group as `devDependencies: {}` in the deploy importer, while the TypeScript lockfile writer omits an empty dependency map. Before this PR that difference only showed up occasionally; afterwards every `--prod` deploy would hit it, so pacquet now drops the empty map too and the two stacks emit byte-identical deploy lockfiles for the same input.

**Behavior change worth calling out:** a `pnpm deploy --prod` artifact's `package.json` now has `"devDependencies": {}` instead of the source project's dev dependencies (likewise `optionalDependencies` under `--no-optional`). That is what makes the artifact self-consistent — the packages were never deployed in the first place. Two TypeScript deploy tests that pinned the old shape are updated.

### Follow-up commits from review

- **`--dev` parity** (raised by Greptile, verified): pacquet's `--dev` kept optional dependencies and `--prod --dev` kept all three groups, while the TypeScript CLI resolves the three flags together — `--prod` wins over `--dev`, and a dev-only install clears `optional`. `pnpm install --dev` therefore installed an optional dependency that pnpm skips, and after the deploy fix above the divergence would have reached `pnpm deploy --dev`'s artifact too. Now resolved the same way in both stacks; the full flag matrix matches:

  | | `--dev` | `--prod` | `--prod --dev` | `--no-optional` | *(none)* |
  |---|---|---|---|---|---|
  | before | dev + optional | prod + optional | all three | prod + dev | all three |
  | after / TS CLI | dev | prod + optional | prod + optional | prod + dev | all three |

  One ported test, `headless_install_include_filtering_excludes_production_group`, asserted the old behavior; its upstream counterpart drives the programmatic API with an optional-only `include` that no flag combination reaches, so its `--dev` mapping was wrong.

- **Frozen reinstall in the regression tests** (raised by CodeRabbit): both stacks' deploy tests now deploy outside the workspace, wipe the deployed `node_modules`, run a frozen install there, and assert that no link at any depth has a missing target. Verified against `main`'s deploy code that this step fails in both stacks — pacquet by dangling, the TypeScript CLI by refusing the install.

- **`cspell.json`** (flagged by Qodo as out of scope): the changeset from pnpm/pnpm#13998 uses the word `chcp`, which fails the spellcheck the `pre-push` hook runs, so no branch off `main` can be pushed without it. Kept as its own commit; happy to split it out if you'd rather.

### Verification

Reproduced the issue's scenario with locally built binaries of both stacks, before and after: deploy, then `pnpm install --frozen-lockfile` in the deploy directory, then `find -xtype l`. Zero dangling links afterwards, and the deployed manifest and importer now match byte for byte between pacquet and the TypeScript CLI. Full pacquet suite (2754 tests) green; `@pnpm/releasing.commands` deploy tests (28) and `pnpm/test/deploy.ts` green.

### Noted, not fixed here

Two pre-existing gaps this work surfaced but does not touch:

1. A frozen install against a lockfile whose importer references an undefined package makes pacquet create dangling symlinks, where the TypeScript CLI raises `ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY`. Deploy no longer produces such a lockfile, but a hand-edited or badly merged one still can.
2. `--no-optional` drops a package's optional edge even when that package stays installed via a non-optional path. Identical in both stacks, and present in pnpm 11.

## Squash Commit Body

```text
A shared-lockfile deploy prunes the package graph to the included dependency
groups but kept every direct dependency in the deployed package.json and in the
deployed lockfile's importer. The deployed lockfile therefore referenced
packages it did not define, and the next install in the deploy directory tripped
over that: pacquet linked the missing packages and left dangling symlinks, while
the TypeScript CLI refused the install with ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY.
A --prod deploy of a project whose dev workspace dependency no longer exists
pointed the importer at a missing directory the same way.

Fill only the included groups into the deploy importer, in pacquet's
create_deploy_files and in the TypeScript CLI's createDeployFiles, so the
manifest, the importer, and the package graph agree. The graph walk no longer
needs its own include gating for the importer maps; the snapshot-level optional
handling from pnpm/pnpm#13641 stays as it is.

Also drop an emptied group from pacquet's deploy importer instead of writing it
as `{}` — the TypeScript lockfile writer omits an empty dependency map, so the
two stacks were producing different deploy lockfiles for the same input.

Resolve pacquet's --prod/--dev/--no-optional flags the way the TypeScript CLI
does: --prod wins over --dev, and a dev-only install drops optional dependencies
along with the production ones. Without it `pnpm install --dev` installed an
optional dependency pnpm skips, and the deploy change above would have carried
that divergence into `pnpm deploy --dev`'s manifest and lockfile.

Closes pnpm/pnpm#13623
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `pnpm install --dev` and `pnpm deploy --dev` now omit optional dependencies.
  - When combined, `--prod` takes precedence over `--dev`.
  - Production deployments exclude development and optional dependencies from manifests and lockfiles.

- **Bug Fixes**
  - Improved dependency filtering during installs and deployments.
  - Prevented dangling symlinks during subsequent frozen-lockfile installations.
  - Corrected handling of excluded dependency groups in deployed packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->