### PR TITLE
fix(config): enforce CLI options precedence over pnpmfile updateConfig hooks

### DIFF
--- a/.changeset/cli-options-precedence-over-pnpmfile.md
+++ b/.changeset/cli-options-precedence-over-pnpmfile.md
@@ -1,0 +1,6 @@
+---
+"pnpm": patch
+"pacquet": patch
+---
+
+Fixed an issue where `.pnpmfile.mjs` / `.pnpmfile.cjs` `updateConfig` hooks could override explicit CLI flags (such as `--registry`). CLI options now consistently take precedence over pnpmfile config overrides [`pnpm/pnpm#14063`](https://github.com/pnpm/pnpm/issues/14063).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8038,6 +8038,9 @@ importers:
       '@zkochan/rimraf':
         specifier: 'catalog:'
         version: 4.0.0
+      camelcase:
+        specifier: 'catalog:'
+        version: 9.0.0
       chalk:
         specifier: 'catalog:'
         version: 6.0.0

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -320,9 +320,11 @@ impl CliArgs {
                 }
                 if let Some(store_dir) = store_dir.as_deref() {
                     apply_store_dir_override::<Host>(&mut cfg, store_dir, anchor)?;
+                    cfg.cli_settings.insert("storeDir".to_string());
                 }
                 if let Some(state_dir) = state_dir.as_deref() {
                     apply_state_dir_override::<Host>(&mut cfg, state_dir, anchor);
+                    cfg.cli_settings.insert("stateDir".to_string());
                 }
                 // `--recursive` / `--filter` / `--filter-prod` /
                 // `--workspace-root` / `--fail-if-no-match` are CLI-only

--- a/pnpm/crates/cli/src/config_deps.rs
+++ b/pnpm/crates/cli/src/config_deps.rs
@@ -671,6 +671,7 @@ fn reapply_explicit_settings(config: &mut Config) {
                 };
                 if key == "default" {
                     config.registry.clone_from(&normalized);
+                    config.package_manager_bootstrap.registry.clone_from(&normalized);
                 }
                 config.registries_by_scope.insert(key.clone(), normalized.clone());
                 config.package_manager_bootstrap.registries.insert(key.clone(), normalized);

--- a/pnpm/crates/cli/src/config_deps.rs
+++ b/pnpm/crates/cli/src/config_deps.rs
@@ -7,7 +7,7 @@
 //! lockfile. Plugin-hook loading (the `updateConfig` half) is wired in
 //! separately.
 
-use crate::config_overrides::apply_store_dir_override;
+use crate::config_overrides::{apply_registry_override, apply_store_dir_override};
 use miette::{IntoDiagnostic, Result, WrapErr};
 use pnpm_catalogs_config::get_catalogs_from_workspace_manifest;
 use pnpm_config::{Config, Host, PNPM_VERSION, WorkspaceSettings};
@@ -483,10 +483,13 @@ pub async fn prepare_config<Reporter: self::Reporter>(
 /// Config round-trips through [`WorkspaceSettings`], so any settings key a
 /// hook changes is applied back the same way `pnpm-workspace.yaml` is. Only
 /// the keys a hook actually changed are applied, so values resolved from
-/// `.npmrc` or CLI flags that the hooks leave untouched are not clobbered.
-/// The `catalog:`/`catalogs:` blocks — which pacquet models outside
-/// `WorkspaceSettings` — are seeded into the hook input and, when changed,
-/// captured into [`Config::catalogs`] for install and packing commands.
+/// `.npmrc` or the global config that the hooks leave untouched are not
+/// clobbered, and the settings the command line set
+/// ([`Config::cli_settings`]) stay as the command line set them whatever
+/// a hook returns for them. The `catalog:`/`catalogs:` blocks — which
+/// pacquet models outside `WorkspaceSettings` — are seeded into the hook
+/// input and, when changed, captured into [`Config::catalogs`] for install
+/// and packing commands.
 pub async fn run_update_config_hooks<Reporter: self::Reporter>(
     config: &mut Config,
     root_dir: &Path,
@@ -516,6 +519,10 @@ pub async fn run_update_config_hooks<Reporter: self::Reporter>(
         .into_diagnostic()
         .wrap_err("reading catalogs for updateConfig hooks")?;
     if let Some(object) = input.as_object_mut() {
+        // Seed the settings the other config layers set (the global
+        // config, the environment, the command line), which the workspace
+        // manifest alone does not carry, so a hook reads the effective
+        // value rather than the yaml's.
         for (key, val) in &config.explicit_settings {
             object.insert(key.clone(), val.clone());
         }
@@ -580,7 +587,10 @@ pub async fn run_update_config_hooks<Reporter: self::Reporter>(
             .unwrap_or_default(),
     );
 
-    let delta = config_delta(&input, &current);
+    let mut delta = config_delta(&input, &current);
+    if let Some(delta) = delta.as_object_mut() {
+        delta.retain(|key, _| !config.cli_settings.contains(key));
+    }
     if delta.as_object().is_none_or(serde_json::Map::is_empty) {
         return Ok(hooks);
     }
@@ -607,7 +617,9 @@ pub async fn run_update_config_hooks<Reporter: self::Reporter>(
     let delta_settings: WorkspaceSettings = serde_json::from_value(delta)
         .into_diagnostic()
         .wrap_err("deserialize the updateConfig hook result")?;
+    let cli_registries = cli_registries(config);
     delta_settings.apply_to(config, &base_dir);
+    restore_cli_registries(config, cli_registries);
     if let Some(extra_bin_paths) = changed_extra_bin_paths {
         config.extra_bin_paths = extra_bin_paths;
     }
@@ -643,62 +655,45 @@ pub async fn run_update_config_hooks<Reporter: self::Reporter>(
             global_virtual_store_dir_explicit,
         );
     }
-    reapply_explicit_settings(config);
     Ok(hooks)
 }
 
-fn reapply_explicit_settings(config: &mut Config) {
-    if let Some(registry_val) = config.explicit_settings.get("registry").and_then(Value::as_str) {
-        let normalized = if registry_val.ends_with('/') {
-            registry_val.to_string()
-        } else {
-            format!("{registry_val}/")
-        };
-        config.registry.clone_from(&normalized);
-        config.registries_by_scope.insert("default".to_string(), normalized.clone());
-        config.package_manager_bootstrap.registry.clone_from(&normalized);
-        config.package_manager_bootstrap.registries.insert("default".to_string(), normalized);
-    }
-    if let Some(registries_obj) =
-        config.explicit_settings.get("registries").and_then(Value::as_object)
-    {
-        for (key, val) in registries_obj {
-            if let Some(registry_val) = val.as_str() {
-                let normalized = if registry_val.ends_with('/') {
-                    registry_val.to_string()
-                } else {
-                    format!("{registry_val}/")
-                };
-                if key == "default" {
-                    config.registry.clone_from(&normalized);
-                    config.package_manager_bootstrap.registry.clone_from(&normalized);
-                }
-                config.registries_by_scope.insert(key.clone(), normalized.clone());
-                config.package_manager_bootstrap.registries.insert(key.clone(), normalized);
+/// The registry routes the command line set, as `(scope, url)` pairs with
+/// `default` for `--registry`. Read off `config` before the hook delta is
+/// applied: a hook that replaces the `registries` map reroutes these
+/// scopes, and [`restore_cli_registries`] puts the command line's routes
+/// back afterwards.
+fn cli_registries(config: &Config) -> Vec<(String, String)> {
+    config
+        .cli_settings
+        .iter()
+        .filter_map(|key| {
+            if key == "registry" {
+                return Some(("default".to_string(), config.registry.clone()));
             }
-        }
-    }
-    for (key, val) in &config.explicit_settings {
-        if key.starts_with('@')
-            && key.ends_with(":registry")
-            && let Some(registry_val) = val.as_str()
-        {
-            let scope = key[..key.len() - ":registry".len()].to_string();
-            let normalized = if registry_val.ends_with('/') {
-                registry_val.to_string()
-            } else {
-                format!("{registry_val}/")
-            };
-            config.registries_by_scope.insert(scope.clone(), normalized.clone());
-            config.package_manager_bootstrap.registries.insert(scope, normalized);
+            let scope = key.strip_suffix(":registry").filter(|scope| scope.starts_with('@'))?;
+            let url = config.registries_by_scope.get(scope)?;
+            Some((scope.to_string(), url.clone()))
+        })
+        .collect()
+}
+
+fn restore_cli_registries(config: &mut Config, registries: Vec<(String, String)>) {
+    for (scope, url) in registries {
+        if scope == "default" {
+            apply_registry_override(config, &url);
+        } else {
+            config.registries_by_scope.insert(scope.clone(), url.clone());
+            config.package_manager_bootstrap.registries.insert(scope, url);
         }
     }
 }
 
 /// The keys whose value the hooks changed between the serialized input
 /// config and the hooks' output. Applying only these avoids clobbering
-/// config resolved elsewhere (`.npmrc`, CLI flags) that a hook left
-/// untouched.
+/// config resolved elsewhere (`.npmrc`, the global config) that a hook
+/// left untouched; the caller then drops the keys the command line set,
+/// which a hook cannot change at all.
 fn config_delta(input: &Value, output: &Value) -> Value {
     let (Some(input_obj), Some(output_obj)) = (input.as_object(), output.as_object()) else {
         return output.clone();

--- a/pnpm/crates/cli/src/config_deps.rs
+++ b/pnpm/crates/cli/src/config_deps.rs
@@ -516,8 +516,8 @@ pub async fn run_update_config_hooks<Reporter: self::Reporter>(
         .into_diagnostic()
         .wrap_err("reading catalogs for updateConfig hooks")?;
     if let Some(object) = input.as_object_mut() {
-        if let Some(store_dir) = config.explicit_settings.get("storeDir") {
-            object.insert("storeDir".to_string(), store_dir.clone());
+        for (key, val) in &config.explicit_settings {
+            object.insert(key.clone(), val.clone());
         }
         object.insert(
             "catalogs".to_string(),
@@ -643,7 +643,55 @@ pub async fn run_update_config_hooks<Reporter: self::Reporter>(
             global_virtual_store_dir_explicit,
         );
     }
+    reapply_explicit_settings(config);
     Ok(hooks)
+}
+
+fn reapply_explicit_settings(config: &mut Config) {
+    if let Some(registry_val) = config.explicit_settings.get("registry").and_then(Value::as_str) {
+        let normalized = if registry_val.ends_with('/') {
+            registry_val.to_string()
+        } else {
+            format!("{registry_val}/")
+        };
+        config.registry.clone_from(&normalized);
+        config.registries_by_scope.insert("default".to_string(), normalized.clone());
+        config.package_manager_bootstrap.registry.clone_from(&normalized);
+        config.package_manager_bootstrap.registries.insert("default".to_string(), normalized);
+    }
+    if let Some(registries_obj) =
+        config.explicit_settings.get("registries").and_then(Value::as_object)
+    {
+        for (key, val) in registries_obj {
+            if let Some(registry_val) = val.as_str() {
+                let normalized = if registry_val.ends_with('/') {
+                    registry_val.to_string()
+                } else {
+                    format!("{registry_val}/")
+                };
+                if key == "default" {
+                    config.registry.clone_from(&normalized);
+                }
+                config.registries_by_scope.insert(key.clone(), normalized.clone());
+                config.package_manager_bootstrap.registries.insert(key.clone(), normalized);
+            }
+        }
+    }
+    for (key, val) in &config.explicit_settings {
+        if key.starts_with('@')
+            && key.ends_with(":registry")
+            && let Some(registry_val) = val.as_str()
+        {
+            let scope = key[..key.len() - ":registry".len()].to_string();
+            let normalized = if registry_val.ends_with('/') {
+                registry_val.to_string()
+            } else {
+                format!("{registry_val}/")
+            };
+            config.registries_by_scope.insert(scope.clone(), normalized.clone());
+            config.package_manager_bootstrap.registries.insert(scope, normalized);
+        }
+    }
 }
 
 /// The keys whose value the hooks changed between the serialized input

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -2,12 +2,12 @@ use pnpm_config::{
     ColorMode, Config, EnvVar, GLOBAL_LAYOUT_VERSION, GetCurrentDir, GetHomeDir, LinkProbe,
     LinkWorkspacePackages, NodeLinker, PackageImportMethod, PmOnFail, RuntimeOnFail,
     SaveWorkspaceProtocol, TrustPolicy, VerifyDepsBeforeRun, default_state_dir,
-    resolve_child_concurrency,
+    naming_cases::to_camel_case, resolve_child_concurrency,
 };
 use pnpm_fs::lexical_normalize;
 use pnpm_store_dir::StoreDir;
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashSet},
     ffi::{OsStr, OsString},
     path::Path,
 };
@@ -174,6 +174,9 @@ pub struct ConfigOverrides {
     https_proxy: Option<String>,
     http_proxy: Option<String>,
     no_proxy: Option<String>,
+    /// Every kebab-case key [`Self::set`] received, whether or not its
+    /// value parsed, for [`Config::cli_settings`].
+    settings: BTreeSet<String>,
 }
 
 impl ConfigOverrides {
@@ -238,6 +241,7 @@ impl ConfigOverrides {
     }
 
     fn set(&mut self, key: &str, value: &str) {
+        self.settings.insert(key.to_owned());
         match key {
             "allow-unused-patches" => self.allow_unused_patches = parse_bool(value),
             "bail" => self.bail = parse_bool(value),
@@ -435,6 +439,9 @@ impl ConfigOverrides {
     /// `dir` is the canonicalized `--dir`, the fallback base for a
     /// relative path-valued setting outside a workspace.
     pub fn apply(&self, config: &mut Config, dir: &Path) {
+        config.cli_settings.extend(self.settings.iter().map(|key| {
+            if scoped_registry_key(key).is_some() { key.clone() } else { to_camel_case(key) }
+        }));
         config.apply_proxy_cli_overrides(
             self.https_proxy.as_deref(),
             self.http_proxy.as_deref(),
@@ -547,9 +554,6 @@ impl ConfigOverrides {
         for (scope, registry) in &self.registries {
             config.registries_by_scope.insert(scope.clone(), registry.clone());
             config.package_manager_bootstrap.registries.insert(scope.clone(), registry.clone());
-            config
-                .explicit_settings
-                .insert(format!("{scope}:registry"), serde_json::Value::String(registry.clone()));
         }
         if let Some(value) = self.deploy_all_files {
             config.deploy_all_files = value;
@@ -1060,8 +1064,8 @@ pub(crate) fn apply_registry_override(config: &mut Config, registry: &str) {
     config.registry.clone_from(&registry);
     config.registries_by_scope.insert("default".to_string(), registry.clone());
     config.package_manager_bootstrap.registry.clone_from(&registry);
-    config.package_manager_bootstrap.registries.insert("default".to_string(), registry.clone());
-    config.explicit_settings.insert("registry".to_string(), serde_json::Value::String(registry));
+    config.package_manager_bootstrap.registries.insert("default".to_string(), registry);
+    config.cli_settings.insert("registry".to_string());
 }
 
 fn normalize_registry_url(registry: &str) -> String {

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -547,6 +547,9 @@ impl ConfigOverrides {
         for (scope, registry) in &self.registries {
             config.registries_by_scope.insert(scope.clone(), registry.clone());
             config.package_manager_bootstrap.registries.insert(scope.clone(), registry.clone());
+            config
+                .explicit_settings
+                .insert(format!("{scope}:registry"), serde_json::Value::String(registry.clone()));
         }
         if let Some(value) = self.deploy_all_files {
             config.deploy_all_files = value;
@@ -1057,7 +1060,8 @@ pub(crate) fn apply_registry_override(config: &mut Config, registry: &str) {
     config.registry.clone_from(&registry);
     config.registries_by_scope.insert("default".to_string(), registry.clone());
     config.package_manager_bootstrap.registry.clone_from(&registry);
-    config.package_manager_bootstrap.registries.insert("default".to_string(), registry);
+    config.package_manager_bootstrap.registries.insert("default".to_string(), registry.clone());
+    config.explicit_settings.insert("registry".to_string(), serde_json::Value::String(registry));
 }
 
 fn normalize_registry_url(registry: &str) -> String {

--- a/pnpm/crates/cli/tests/suite/config_dependencies.rs
+++ b/pnpm/crates/cli/tests/suite/config_dependencies.rs
@@ -114,8 +114,12 @@ fn update_config_hook_mutates_config_before_install() {
     drop((root, mock_instance));
 }
 
+/// The command line outranks an `updateConfig` hook: the hook's rerouted
+/// default registry and flipped `nodeLinker` both lose to the flags, so
+/// the install still fetches from the mocked registry and lays the
+/// dependency out hoisted.
 #[test]
-fn update_config_hook_cli_registry_option_wins() {
+fn update_config_hook_cannot_override_command_line_settings() {
     let CommandTempCwd { root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();
     let AddMockedRegistry { mock_instance, .. } = npmrc_info;
@@ -128,7 +132,7 @@ fn update_config_hook_cli_registry_option_wins() {
     .expect("write package.json");
     fs::write(
         workspace.join(".pnpmfile.cjs"),
-        "module.exports = { hooks: { updateConfig (config) {\n  config.registries = { default: 'http://127.0.0.1:1/' };\n  return config;\n} } }",
+        "module.exports = { hooks: { updateConfig (config) {\n  config.registries = { default: 'http://127.0.0.1:1/' };\n  config.nodeLinker = 'isolated';\n  return config;\n} } }",
     )
     .expect("write .pnpmfile.cjs");
 
@@ -136,11 +140,51 @@ fn update_config_hook_cli_registry_option_wins() {
         .with_arg("install")
         .with_arg("--registry")
         .with_arg(registry_url.as_str())
+        .with_arg("--config.node-linker=hoisted")
         .assert()
         .success();
 
     let dep = workspace.join("node_modules/@pnpm.e2e/foo");
-    assert!(dep.join("package.json").exists(), "dependency is installed using CLI registry option");
+    assert!(dep.join("package.json").exists(), "dependency is installed from the CLI registry");
+    #[cfg(unix)]
+    assert!(
+        !is_symlink_or_junction(&dep).unwrap(),
+        "--config.node-linker=hoisted outranks the hook's nodeLinker: isolated",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// A `--config.@<scope>:registry` override survives a hook that reroutes
+/// the same scope.
+#[test]
+fn update_config_hook_cannot_override_command_line_scoped_registry() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    let registry_url = mock_instance.url();
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "dependencies": { "@pnpm.e2e/foo": "100.0.0" } }).to_string(),
+    )
+    .expect("write package.json");
+    fs::write(
+        workspace.join(".pnpmfile.cjs"),
+        "module.exports = { hooks: { updateConfig (config) {\n  config.registries = { '@pnpm.e2e': 'http://127.0.0.1:1/' };\n  return config;\n} } }",
+    )
+    .expect("write .pnpmfile.cjs");
+
+    pacquet_at(&workspace)
+        .with_arg("install")
+        .with_arg(format!("--config.@pnpm.e2e:registry={registry_url}"))
+        .assert()
+        .success();
+
+    assert!(
+        workspace.join("node_modules/@pnpm.e2e/foo/package.json").exists(),
+        "dependency is installed from the CLI scoped registry",
+    );
 
     drop((root, mock_instance));
 }
@@ -283,8 +327,10 @@ fn update_config_hook_injects_catalog() {
     drop((root, mock_instance));
 }
 
+/// The hook reads the store the command line chose, and its own
+/// `storeDir` loses to it: the install records the CLI store.
 #[test]
-fn update_config_observes_and_can_replace_the_cli_store_dir() {
+fn update_config_observes_but_cannot_replace_the_cli_store_dir() {
     let CommandTempCwd { root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();
     let AddMockedRegistry { mock_instance, .. } = npmrc_info;
@@ -312,20 +358,19 @@ fn update_config_observes_and_can_replace_the_cli_store_dir() {
     )
     .expect("read .modules.yaml")
     .expect(".modules.yaml exists");
-    let hook_store =
-        dunce::canonicalize(&workspace).expect("canonicalize workspace").join("hook-store/v11");
+    let cli_store =
+        dunce::canonicalize(&workspace).expect("canonicalize workspace").join("cli-store/v11");
     assert_eq!(
         dunce::canonicalize(&modules.store_dir).expect("canonicalize recorded store"),
-        hook_store,
+        cli_store,
     );
     assert_eq!(
         dunce::canonicalize(&modules.virtual_store_dir)
             .expect("canonicalize recorded virtual store"),
-        hook_store.join("links"),
+        cli_store.join("links"),
     );
-    let index_path = hook_store.join("index.db");
-    eprintln!("Checking for hook store index: {}", index_path.display());
-    assert!(index_path.is_file());
+    assert!(cli_store.join("index.db").is_file());
+    assert!(!workspace.join("hook-store").exists(), "the hook's storeDir was not used");
 
     drop((root, mock_instance));
 }

--- a/pnpm/crates/cli/tests/suite/config_dependencies.rs
+++ b/pnpm/crates/cli/tests/suite/config_dependencies.rs
@@ -114,7 +114,6 @@ fn update_config_hook_mutates_config_before_install() {
     drop((root, mock_instance));
 }
 
-/// CLI options (like `--registry`) take precedence over `updateConfig` hook overrides.
 #[test]
 fn update_config_hook_cli_registry_option_wins() {
     let CommandTempCwd { root, workspace, npmrc_info, .. } =

--- a/pnpm/crates/cli/tests/suite/config_dependencies.rs
+++ b/pnpm/crates/cli/tests/suite/config_dependencies.rs
@@ -114,6 +114,38 @@ fn update_config_hook_mutates_config_before_install() {
     drop((root, mock_instance));
 }
 
+/// CLI options (like `--registry`) take precedence over `updateConfig` hook overrides.
+#[test]
+fn update_config_hook_cli_registry_option_wins() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    let registry_url = mock_instance.url();
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "dependencies": { "@pnpm.e2e/foo": "100.0.0" } }).to_string(),
+    )
+    .expect("write package.json");
+    fs::write(
+        workspace.join(".pnpmfile.cjs"),
+        "module.exports = { hooks: { updateConfig (config) {\n  config.registries = { default: 'http://127.0.0.1:1/' };\n  return config;\n} } }",
+    )
+    .expect("write .pnpmfile.cjs");
+
+    pacquet_at(&workspace)
+        .with_arg("install")
+        .with_arg("--registry")
+        .with_arg(registry_url.as_str())
+        .assert()
+        .success();
+
+    let dep = workspace.join("node_modules/@pnpm.e2e/foo");
+    assert!(dep.join("package.json").exists(), "dependency is installed using CLI registry option");
+
+    drop((root, mock_instance));
+}
+
 /// `pacquet add --config <pkg>@<version>` resolves and installs the
 /// package as a configurational dependency, writing the clean specifier
 /// to `pnpm-workspace.yaml` and linking it under `.pnpm-config`.

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -2499,6 +2499,16 @@ pub struct Config {
     /// raw value. The `config` command turns this into the record it prints.
     pub explicit_settings: serde_json::Map<String, serde_json::Value>,
 
+    /// Camel-cased names of the settings the command line set: every
+    /// `--config.<key>` override and bare setting flag, `registry` for
+    /// `--registry`, `storeDir` / `stateDir` for `--store-dir` /
+    /// `--state-dir`. A `--config.@<scope>:registry` override is recorded
+    /// under that `@<scope>:registry` key. Recorded by the CLI as it layers
+    /// the flags onto the loaded config; the `updateConfig` hooks cannot
+    /// change these settings, since the command line outranks every other
+    /// layer.
+    pub cli_settings: BTreeSet<String>,
+
     /// Raw `.npmrc` / `auth.ini` config keys (those for which
     /// [`config_types::is_ini_config_key`] holds: `registry`, `@scope:registry`,
     /// `//host/:_authToken`, `username`, `ca`, ...), post-`${VAR}` substitution

--- a/pnpm/crates/deps-restorer/src/install_package_from_registry/tests.rs
+++ b/pnpm/crates/deps-restorer/src/install_package_from_registry/tests.rs
@@ -231,6 +231,7 @@ fn create_config(
         tls_by_uri: Default::default(),
         package_manager_bootstrap: Default::default(),
         explicit_settings: Default::default(),
+        cli_settings: Default::default(),
         raw_auth_config: Default::default(),
         config_dir: None,
     }

--- a/pnpm11/pnpm/package.json
+++ b/pnpm11/pnpm/package.json
@@ -150,6 +150,7 @@
     "@types/semver": "catalog:",
     "@zkochan/retry": "catalog:",
     "@zkochan/rimraf": "catalog:",
+    "camelcase": "catalog:",
     "chalk": "catalog:",
     "ci-info": "catalog:",
     "cross-spawn": "catalog:",

--- a/pnpm11/pnpm/src/getConfig.ts
+++ b/pnpm11/pnpm/src/getConfig.ts
@@ -144,6 +144,9 @@ function reapplyExplicitCliOptions (config: Config, context: ConfigContext): voi
       if (config.registriesByScope) {
         config.registriesByScope[scope] = normalized
       }
+      if (config.packageManagerRegistries) {
+        config.packageManagerRegistries[scope] = normalized
+      }
       if ((config as Record<string, any>).registries) { // eslint-disable-line @typescript-eslint/no-explicit-any
         (config as Record<string, any>).registries[scope] = normalized // eslint-disable-line @typescript-eslint/no-explicit-any
       }
@@ -151,8 +154,15 @@ function reapplyExplicitCliOptions (config: Config, context: ConfigContext): voi
   }
   if (context.explicitlySetKeys) {
     for (const key of context.explicitlySetKeys) {
-      if (key !== 'registry' && key in cliOptions && cliOptions[key] !== undefined) {
-        (config as unknown as Record<string, unknown>)[key] = cliOptions[key]
+      if (key === 'registry') continue
+      const camelKey = key.replace(/-([a-z])/g, (_, g: string) => g.toUpperCase())
+      const kebabKey = key.replace(/([A-Z])/g, '-$1').toLowerCase()
+      const val = cliOptions[key] ?? cliOptions[camelKey] ?? cliOptions[kebabKey]
+      if (val !== undefined) {
+        (config as unknown as Record<string, unknown>)[key] = val
+        if (key !== camelKey) {
+          (config as unknown as Record<string, unknown>)[camelKey] = val
+        }
       }
     }
   }

--- a/pnpm11/pnpm/src/getConfig.ts
+++ b/pnpm11/pnpm/src/getConfig.ts
@@ -11,6 +11,7 @@ import { logger } from '@pnpm/logger'
 import { createStoreController } from '@pnpm/store.connection-manager'
 import { lexCompare } from '@pnpm/text.ordinal-comparator'
 import type { ConfigDependencies } from '@pnpm/types'
+import camelcase from 'camelcase'
 
 export async function getConfig (
   cliOptions: CliOptions,
@@ -111,65 +112,60 @@ export async function installConfigDepsAndLoadHooks (
     context.finders = finders
     config.pnpmfile = resolvedPnpmfilePaths
     if (context.hooks?.updateConfig) {
+      const cliSettings = pickCliSettings(config, context.cliOptions)
       for (const updateConfig of context.hooks.updateConfig) {
         const updateConfigResult = updateConfig(config)
         config = updateConfigResult instanceof Promise ? await updateConfigResult : updateConfigResult // eslint-disable-line no-await-in-loop
       }
-      reapplyExplicitCliOptions(config, context)
+      restoreCliSettings(config, cliSettings)
     }
   }
   return { config, context }
 }
 
-function reapplyExplicitCliOptions (config: Config, context: ConfigContext): void {
-  const cliOptions = context.cliOptions
-  if (!cliOptions) return
-  if (cliOptions.registry && typeof cliOptions.registry === 'string') {
-    const normalized = normalizeRegistryUrl(cliOptions.registry)
-    config.registry = normalized
-    if (config.registriesByScope) {
-      config.registriesByScope.default = normalized
-    }
-    if (config.packageManagerRegistries) {
-      config.packageManagerRegistries.default = normalized
-    }
-    if ((config as Record<string, any>).registries?.default) { // eslint-disable-line @typescript-eslint/no-explicit-any
-      (config as Record<string, any>).registries.default = normalized // eslint-disable-line @typescript-eslint/no-explicit-any
-    }
-  }
-  for (const [key, value] of Object.entries(cliOptions)) {
-    if (key.startsWith('@') && key.endsWith(':registry') && typeof value === 'string') {
-      const scope = key.slice(0, -':registry'.length)
-      const normalized = normalizeRegistryUrl(value)
-      if (config.registriesByScope) {
-        config.registriesByScope[scope] = normalized
-      }
-      if (config.packageManagerRegistries) {
-        config.packageManagerRegistries[scope] = normalized
-      }
-      if ((config as Record<string, any>).registries) { // eslint-disable-line @typescript-eslint/no-explicit-any
-        (config as Record<string, any>).registries[scope] = normalized // eslint-disable-line @typescript-eslint/no-explicit-any
-      }
-    }
-  }
-  if (context.explicitlySetKeys) {
-    for (const key of context.explicitlySetKeys) {
-      if (key === 'registry') continue
-      const camelKey = key.replace(/-([a-z])/g, (_, g: string) => g.toUpperCase())
-      const kebabKey = key.replace(/([A-Z])/g, '-$1').toLowerCase()
-      const val = cliOptions[key] ?? cliOptions[camelKey] ?? cliOptions[kebabKey]
-      if (val !== undefined) {
-        (config as unknown as Record<string, unknown>)[key] = val
-        if (key !== camelKey) {
-          (config as unknown as Record<string, unknown>)[camelKey] = val
-        }
-      }
-    }
-  }
+/**
+ * The settings the command line set, read off `config` after the config
+ * reader resolved them. The command line outranks every other layer, the
+ * `updateConfig` hooks included, so these go back over whatever the hooks
+ * return. `--registry` and `--@<scope>:registry` are kept as the registry
+ * routes they resolved to, because a hook may replace the whole routing map.
+ */
+interface CliSettings {
+  settings: Map<string, unknown>
+  registriesByScope: Map<string, string>
 }
 
-function normalizeRegistryUrl (url: string): string {
-  return url.endsWith('/') ? url : `${url}/`
+function pickCliSettings (config: Config, cliOptions: Record<string, unknown>): CliSettings {
+  const settings = new Map<string, unknown>()
+  const registriesByScope = new Map<string, string>()
+  for (const [key, value] of Object.entries(cliOptions)) {
+    if (value === undefined) continue
+    if (key.startsWith('@') && key.endsWith(':registry')) {
+      const scope = key.slice(0, -':registry'.length)
+      registriesByScope.set(scope, config.registriesByScope[scope])
+      continue
+    }
+    const setting = camelcase(key, { locale: 'en-US' })
+    if (Object.hasOwn(config, setting)) {
+      settings.set(setting, (config as unknown as Record<string, unknown>)[setting])
+    }
+    if (setting === 'registry') {
+      registriesByScope.set('default', config.registriesByScope.default)
+    }
+  }
+  return { settings, registriesByScope }
+}
+
+function restoreCliSettings (config: Config, { settings, registriesByScope }: CliSettings): void {
+  for (const [setting, value] of settings) {
+    (config as unknown as Record<string, unknown>)[setting] = value
+  }
+  for (const [scope, registry] of registriesByScope) {
+    config.registriesByScope[scope] = registry
+    if (config.packageManagerRegistries) {
+      config.packageManagerRegistries[scope] = registry
+    }
+  }
 }
 
 export function * calcPnpmfilePathsOfPluginDeps (configModulesDir: string, configDependencies: ConfigDependencies): Generator<string> {

--- a/pnpm11/pnpm/src/getConfig.ts
+++ b/pnpm11/pnpm/src/getConfig.ts
@@ -115,9 +115,51 @@ export async function installConfigDepsAndLoadHooks (
         const updateConfigResult = updateConfig(config)
         config = updateConfigResult instanceof Promise ? await updateConfigResult : updateConfigResult // eslint-disable-line no-await-in-loop
       }
+      reapplyExplicitCliOptions(config, context)
     }
   }
   return { config, context }
+}
+
+function reapplyExplicitCliOptions (config: Config, context: ConfigContext): void {
+  const cliOptions = context.cliOptions
+  if (!cliOptions) return
+  if (cliOptions.registry && typeof cliOptions.registry === 'string') {
+    const normalized = normalizeRegistryUrl(cliOptions.registry)
+    config.registry = normalized
+    if (config.registriesByScope) {
+      config.registriesByScope.default = normalized
+    }
+    if (config.packageManagerRegistries) {
+      config.packageManagerRegistries.default = normalized
+    }
+    if ((config as Record<string, any>).registries?.default) { // eslint-disable-line @typescript-eslint/no-explicit-any
+      (config as Record<string, any>).registries.default = normalized // eslint-disable-line @typescript-eslint/no-explicit-any
+    }
+  }
+  for (const [key, value] of Object.entries(cliOptions)) {
+    if (key.startsWith('@') && key.endsWith(':registry') && typeof value === 'string') {
+      const scope = key.slice(0, -':registry'.length)
+      const normalized = normalizeRegistryUrl(value)
+      if (config.registriesByScope) {
+        config.registriesByScope[scope] = normalized
+      }
+      if ((config as Record<string, any>).registries) { // eslint-disable-line @typescript-eslint/no-explicit-any
+        (config as Record<string, any>).registries[scope] = normalized // eslint-disable-line @typescript-eslint/no-explicit-any
+      }
+    }
+  }
+  if (context.explicitlySetKeys) {
+    for (const key of context.explicitlySetKeys) {
+      if (key !== 'registry' && key in cliOptions && cliOptions[key] !== undefined) {
+        (config as unknown as Record<string, unknown>)[key] = cliOptions[key]
+      }
+    }
+  }
+}
+
+function normalizeRegistryUrl (url: string): string {
+  return url.endsWith('/') ? url : `${url}/`
 }
 
 export function * calcPnpmfilePathsOfPluginDeps (configModulesDir: string, configDependencies: ConfigDependencies): Generator<string> {

--- a/pnpm11/pnpm/test/getConfig.test.ts
+++ b/pnpm11/pnpm/test/getConfig.test.ts
@@ -266,6 +266,57 @@ describe('installConfigDepsAndLoadHooks', () => {
     expect(fs.existsSync('pnpmfile-was-loaded')).toBe(true)
   })
 
+  test('the command line outranks the updateConfig hook', async () => {
+    prepare()
+
+    fs.writeFileSync('.pnpmfile.cjs', `
+      module.exports = {
+        hooks: {
+          updateConfig: (config) => ({
+            ...config,
+            registry: 'http://hook.example/',
+            registriesByScope: { default: 'http://hook.example/', '@scoped': 'http://hook.example/' },
+            packageManagerRegistries: { default: 'http://hook.example/' },
+            nodeLinker: 'isolated',
+            storeDir: '/hook/store',
+            minimumReleaseAge: 1440,
+          }),
+        },
+      }
+    `)
+
+    const { config, context } = buildPnpmfileConfig()
+    Object.assign(config, {
+      registry: 'http://cli.example/',
+      registriesByScope: { default: 'http://cli.example/', '@scoped': 'http://cli.example/scoped/', '@yaml': 'http://yaml.example/' },
+      packageManagerRegistries: { default: 'http://cli.example/', '@scoped': 'http://cli.example/scoped/' },
+      nodeLinker: 'hoisted',
+      storeDir: '/resolved/cli/store',
+      minimumReleaseAge: 0,
+    })
+    context.cliOptions = {
+      registry: 'http://cli.example',
+      '@scoped:registry': 'http://cli.example/scoped',
+      'node-linker': 'hoisted',
+      'store-dir': 'store',
+    }
+
+    const { config: updated } = await installConfigDepsAndLoadHooks(config, context)
+
+    expect(updated.registry).toBe('http://cli.example/')
+    expect(updated.registriesByScope).toStrictEqual({
+      default: 'http://cli.example/',
+      '@scoped': 'http://cli.example/scoped/',
+    })
+    expect(updated.packageManagerRegistries).toStrictEqual({
+      default: 'http://cli.example/',
+      '@scoped': 'http://cli.example/scoped/',
+    })
+    expect(updated.nodeLinker).toBe('hoisted')
+    expect(updated.storeDir).toBe('/resolved/cli/store')
+    expect(updated.minimumReleaseAge).toBe(1440)
+  })
+
   function buildPnpmfileConfig (): { config: Config, context: ConfigContext } {
     const { config, context } = buildBaseConfig()
     config.ignorePnpmfile = false
@@ -283,6 +334,7 @@ describe('installConfigDepsAndLoadHooks', () => {
     } as unknown as Config
     const context = {
       rootProjectManifestDir: dir,
+      cliOptions: {},
     } as unknown as ConfigContext
     return { config, context }
   }

--- a/pnpm11/pnpm/test/hooks.ts
+++ b/pnpm11/pnpm/test/hooks.ts
@@ -315,6 +315,28 @@ export const hooks = {
   expect(nodeModulesFiles).toContain('is-positive')
 })
 
+test('CLI scoped registry and multi-word options take precedence over updateConfig hook overrides', async () => {
+  prepare()
+
+  fs.writeFileSync('.pnpmfile.mjs', `
+export const hooks = {
+  updateConfig: (config) => ({
+    ...config,
+    storeDir: '/tmp/pnpm-store-hook-override',
+    registries: {
+      default: 'http://localhost:8080',
+      '@foo': 'http://localhost:8080',
+    },
+  }),
+}`, 'utf8')
+  writeYamlFileSync('pnpm-workspace.yaml', { pnpmfile: ['.pnpmfile.mjs'] })
+
+  await execPnpm(['add', 'is-positive@1.0.0', `--registry=http://localhost:${REGISTRY_MOCK_PORT}/`, `--@foo:registry=http://localhost:${REGISTRY_MOCK_PORT}/`])
+
+  const nodeModulesFiles = fs.readdirSync('node_modules')
+  expect(nodeModulesFiles).toContain('is-positive')
+})
+
 test('loading multiple pnpmfiles', async () => {
   prepare()
 

--- a/pnpm11/pnpm/test/hooks.ts
+++ b/pnpm11/pnpm/test/hooks.ts
@@ -295,46 +295,33 @@ export const hooks = {
   expect(nodeModulesFiles).toContain('is-number')
 })
 
-test('CLI options take precedence over updateConfig hook overrides', async () => {
+test('the command line outranks the updateConfig hook', async () => {
   prepare()
 
   fs.writeFileSync('.pnpmfile.mjs', `
 export const hooks = {
   updateConfig: (config) => ({
     ...config,
-    registries: {
-      default: 'http://localhost:8080',
+    nodeLinker: 'isolated',
+    registriesByScope: {
+      ...config.registriesByScope,
+      default: 'http://localhost:1/',
     },
   }),
 }`, 'utf8')
   writeYamlFileSync('pnpm-workspace.yaml', { pnpmfile: ['.pnpmfile.mjs'] })
 
-  await execPnpm(['add', 'is-positive@1.0.0', `--registry=http://localhost:${REGISTRY_MOCK_PORT}/`])
+  await execPnpm([
+    'add',
+    'is-odd@1.0.0',
+    `--registry=http://localhost:${REGISTRY_MOCK_PORT}/`,
+    '--node-linker=hoisted',
+    '--fetch-retries=0',
+  ])
 
   const nodeModulesFiles = fs.readdirSync('node_modules')
-  expect(nodeModulesFiles).toContain('is-positive')
-})
-
-test('CLI scoped registry and multi-word options take precedence over updateConfig hook overrides', async () => {
-  prepare()
-
-  fs.writeFileSync('.pnpmfile.mjs', `
-export const hooks = {
-  updateConfig: (config) => ({
-    ...config,
-    storeDir: '/tmp/pnpm-store-hook-override',
-    registries: {
-      default: 'http://localhost:8080',
-      '@foo': 'http://localhost:8080',
-    },
-  }),
-}`, 'utf8')
-  writeYamlFileSync('pnpm-workspace.yaml', { pnpmfile: ['.pnpmfile.mjs'] })
-
-  await execPnpm(['add', 'is-positive@1.0.0', `--registry=http://localhost:${REGISTRY_MOCK_PORT}/`, `--@foo:registry=http://localhost:${REGISTRY_MOCK_PORT}/`])
-
-  const nodeModulesFiles = fs.readdirSync('node_modules')
-  expect(nodeModulesFiles).toContain('is-positive')
+  expect(nodeModulesFiles).toContain('is-odd')
+  expect(nodeModulesFiles).toContain('is-number')
 })
 
 test('loading multiple pnpmfiles', async () => {

--- a/pnpm11/pnpm/test/hooks.ts
+++ b/pnpm11/pnpm/test/hooks.ts
@@ -4,7 +4,7 @@ import path from 'node:path'
 import { expect, test } from '@jest/globals'
 import { createHash } from '@pnpm/crypto.hash'
 import { prepare, preparePackages } from '@pnpm/prepare'
-import { getIntegrity } from '@pnpm/testing.registry-mock'
+import { getIntegrity, REGISTRY_MOCK_PORT } from '@pnpm/testing.registry-mock'
 import type { PackageManifest } from '@pnpm/types'
 import { loadJsonFileSync } from 'load-json-file'
 import { writeYamlFileSync } from 'write-yaml-file'
@@ -293,6 +293,26 @@ export const hooks = {
   const nodeModulesFiles = fs.readdirSync('node_modules')
   expect(nodeModulesFiles).toContain('kind-of')
   expect(nodeModulesFiles).toContain('is-number')
+})
+
+test('CLI options take precedence over updateConfig hook overrides', async () => {
+  prepare()
+
+  fs.writeFileSync('.pnpmfile.mjs', `
+export const hooks = {
+  updateConfig: (config) => ({
+    ...config,
+    registries: {
+      default: 'http://localhost:8080',
+    },
+  }),
+}`, 'utf8')
+  writeYamlFileSync('pnpm-workspace.yaml', { pnpmfile: ['.pnpmfile.mjs'] })
+
+  await execPnpm(['add', 'is-positive@1.0.0', `--registry=http://localhost:${REGISTRY_MOCK_PORT}/`])
+
+  const nodeModulesFiles = fs.readdirSync('node_modules')
+  expect(nodeModulesFiles).toContain('is-positive')
 })
 
 test('loading multiple pnpmfiles', async () => {


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Settings given on the command line now outrank a `.pnpmfile.cjs` / `.pnpmfile.mjs` `updateConfig` hook in both the TypeScript CLI and pacquet. Before, a hook that rerouted the default registry silently replaced an explicit `--registry`, and the same held for every other flag.

Fixes pnpm/pnpm#14063

- **pacquet**: `Config::cli_settings` records the settings the command line set (every `--config.<key>` override and bare setting flag, `registry`, `storeDir`, `stateDir`, and `--config.@<scope>:registry`). The `updateConfig` runner drops those keys from the hook delta and puts the CLI registry routes back after a hook that replaced the `registries` map. The hook input is seeded with the explicit settings of every config layer, so a hook reads the effective value rather than the workspace yaml's.
- **TypeScript CLI**: `installConfigDepsAndLoadHooks` snapshots the reader-resolved values of the `cliOptions` keys, plus the registry routes for `--registry` / `--@<scope>:registry`, before the hooks run and restores them afterwards.
- **Behavior change**: a hook can no longer replace `--store-dir` (pacquet had a test asserting that it could; it now asserts the opposite).

## Squash Commit Body

Settings given on the command line now outrank the pnpmfile `updateConfig` hooks in both the TypeScript CLI and pacquet, instead of a hook being able to replace explicit flags such as `--registry`, `--store-dir`, or `--config.<key>` overrides.

Fixes pnpm/pnpm#14063

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Description updated by an agent (Claude Code, claude-fable-5-1).
