### PR TITLE
fix(package-manager): stop purging node_modules on an unreadable .modules.yaml

### DIFF
--- a/.changeset/modules-yaml-unreadable-no-purge.md
+++ b/.changeset/modules-yaml-unreadable-no-purge.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+An unreadable `node_modules/.modules.yaml` no longer makes `pnpm install` delete `node_modules` and relink every package on each run. The unparsable state file is now reported as an error instead [#14062](https://github.com/pnpm/pnpm/issues/14062).

--- a/cspell.json
+++ b/cspell.json
@@ -44,6 +44,7 @@
     "canva",
     "cerbos",
     "certfile",
+    "chcp",
     "chmods",
     "clonedeep",
     "clonefile",

--- a/pnpm/crates/cli/tests/suite/install_state.rs
+++ b/pnpm/crates/cli/tests/suite/install_state.rs
@@ -166,6 +166,49 @@ fn public_hoist_uses_the_project_root_when_the_lockfile_is_external() {
     drop((root, mock_instance));
 }
 
+/// A `.modules.yaml` the reader cannot parse must fail the install
+/// rather than read as layout drift: the drift path purges
+/// `node_modules` and relinks the whole tree on every run, taking the
+/// user's own entries with it (<https://github.com/pnpm/pnpm/issues/14062>).
+#[test]
+fn unreadable_modules_manifest_fails_the_install_without_purging_node_modules() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join("package.json"),
+        r#"{"dependencies":{"@pnpm.e2e/hello-world-js-bin":"1.0.0"}}"#,
+    )
+    .expect("write manifest");
+    pacquet.with_arg("install").assert().success();
+
+    let modules_dir = workspace.join("node_modules");
+    let vendored = modules_dir.join("vendored");
+    fs::create_dir(&vendored).expect("create a directory pnpm does not manage");
+    fs::write(modules_dir.join(".modules.yaml"), "not: [valid").expect("corrupt modules manifest");
+
+    let output = Command::cargo_bin("pnpm")
+        .expect("find pnpm binary")
+        .with_current_dir(&workspace)
+        .with_args(["install", "--frozen-lockfile"])
+        .output()
+        .expect("run pnpm install");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "an unparsable .modules.yaml must fail the install");
+    assert!(
+        stderr.contains("ERR_PNPM_MODULES_YAML_PARSE_YAML") && stderr.contains(".modules.yaml"),
+        "the install must report the unparsable modules manifest:\n{stderr}",
+    );
+    assert!(vendored.is_dir(), "the failed install must not purge node_modules:\n{stderr}");
+    assert!(
+        modules_dir.join("@pnpm.e2e/hello-world-js-bin/package.json").exists(),
+        "the failed install must leave the materialized tree alone:\n{stderr}",
+    );
+
+    drop((root, mock_instance));
+}
+
 /// TS: `the modules cache is pruned when it expires and headless install
 /// is used` (`deps-installer/test/install/modulesCache.ts:52`).
 #[test]

--- a/pnpm/crates/modules-yaml/src/lib.rs
+++ b/pnpm/crates/modules-yaml/src/lib.rs
@@ -328,20 +328,25 @@ impl TryFrom<u32> for LayoutVersion {
     }
 }
 
-/// Read `layoutVersion`, reporting a version this build does not support
-/// as `None` — the same "layout predates this pnpm" signal a missing
-/// field carries, which the caller reacts to by rebuilding
-/// `node_modules`. Rejecting it at parse time instead would make the
-/// whole manifest unreadable, and an unreadable manifest fails the
-/// install. pnpm reads any number here too and defers the decision to
+/// Read `layoutVersion`, reporting any number that is not the version
+/// this build supports as `None` — the same "layout predates this pnpm"
+/// signal a missing field carries, which the caller reacts to by
+/// rebuilding `node_modules`. Rejecting it at parse time instead would
+/// make the whole manifest unreadable, and an unreadable manifest fails
+/// the install. pnpm reads any number here too and defers the decision to
 /// its own compatibility check.
+///
+/// The number is read as `f64` because that is the one JSON numeric type,
+/// so `5` and `5.0` are the same version to pnpm and must be here too.
 fn deserialize_layout_version<'de, Deser>(
     deserializer: Deser,
 ) -> Result<Option<LayoutVersion>, Deser::Error>
 where
     Deser: serde::Deserializer<'de>,
 {
-    Ok(Option::<u32>::deserialize(deserializer)?
+    Ok(Option::<f64>::deserialize(deserializer)?
+        .filter(|found| found.fract() == 0.0)
+        .and_then(|found| u32::try_from(found as i64).ok())
         .and_then(|found| LayoutVersion::try_from(found).ok()))
 }
 

--- a/pnpm/crates/modules-yaml/src/lib.rs
+++ b/pnpm/crates/modules-yaml/src/lib.rs
@@ -148,7 +148,11 @@ pub struct Modules {
     #[serde(default)]
     pub included: IncludedDependencies,
 
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_layout_version",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub layout_version: Option<LayoutVersion>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -226,7 +230,7 @@ pub struct ModulesLayout {
     pub hoist_pattern: Option<Vec<String>>,
     #[serde(default)]
     pub included: IncludedDependencies,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_layout_version")]
     pub layout_version: Option<LayoutVersion>,
     #[serde(default)]
     pub node_linker: Option<NodeLinker>,
@@ -285,12 +289,13 @@ pub enum NodeLinker {
 
 /// Pinned identifier for the `node_modules` layout pacquet emits.
 ///
-/// The unit type carries no data: its existence is the value. It serializes
-/// as the integer `5` and deserializes only when the on-disk value is
-/// exactly `5`. Any other version causes a deserialization error, the
-/// breaking-change reaction to a missing or mismatched `layoutVersion`.
-/// Wrapping this in [`Option`] on [`Modules`] distinguishes "missing"
-/// (legacy, breaking change) from "present and matching".
+/// The unit type carries no data: its existence is the value. It
+/// serializes as the integer `5` and converts from `u32` only when the
+/// on-disk value is exactly `5`. On [`Modules`] and [`ModulesLayout`] it
+/// is wrapped in an [`Option`] whose `None` means "not the layout this
+/// build emits" — a missing field and an unsupported version read alike,
+/// so an old layout rebuilds `node_modules` instead of making the whole
+/// manifest unreadable.
 ///
 /// The `#[serde(try_from = "u32", into = "u32")]` proxy lets us reuse
 /// serde's number deserializer, while the [`TryFrom`] impl owns the
@@ -321,6 +326,23 @@ impl TryFrom<u32> for LayoutVersion {
             Err(UnsupportedLayoutVersionError { found: value })
         }
     }
+}
+
+/// Read `layoutVersion`, reporting a version this build does not support
+/// as `None` — the same "layout predates this pnpm" signal a missing
+/// field carries, which the caller reacts to by rebuilding
+/// `node_modules`. Rejecting it at parse time instead would make the
+/// whole manifest unreadable, and an unreadable manifest fails the
+/// install. pnpm reads any number here too and defers the decision to
+/// its own compatibility check.
+fn deserialize_layout_version<'de, Deser>(
+    deserializer: Deser,
+) -> Result<Option<LayoutVersion>, Deser::Error>
+where
+    Deser: serde::Deserializer<'de>,
+{
+    Ok(Option::<u32>::deserialize(deserializer)?
+        .and_then(|found| LayoutVersion::try_from(found).ok()))
 }
 
 /// Returned by [`LayoutVersion::try_from`] when the on-disk `layoutVersion`

--- a/pnpm/crates/modules-yaml/tests/fakes.rs
+++ b/pnpm/crates/modules-yaml/tests/fakes.rs
@@ -9,8 +9,8 @@
 use chrono::{TimeZone, Utc};
 use pipe_trait::Pipe;
 use pnpm_modules_yaml::{
-    Clock, DepPath, FsCreateDirAll, FsReadToString, FsWrite, Modules, read_modules_manifest,
-    write_modules_manifest,
+    Clock, DepPath, FsCreateDirAll, FsReadToString, FsWrite, Modules, read_modules_layout,
+    read_modules_manifest, write_modules_manifest,
 };
 use pretty_assertions::assert_eq;
 use std::{path::Path, time::SystemTime};
@@ -172,6 +172,16 @@ fn read_reports_an_incompatible_layout_version_as_no_layout() {
         .expect("manifest exists");
     dbg!(&manifest.layout_version);
     assert_eq!(manifest.layout_version, None);
+
+    // `ModulesLayout` carries its own copy of the field, and it is the
+    // one the install's drift check reads.
+    let layout = "/dev/null/unused"
+        .pipe(Path::new)
+        .pipe(read_modules_layout::<LegacyVersion>)
+        .expect("read layout")
+        .expect("layout exists");
+    dbg!(&layout.layout_version);
+    assert_eq!(layout.layout_version, None);
 }
 
 /// `ignoredBuilds` deserializes into an [`IndexSet`]: the on-disk array

--- a/pnpm/crates/modules-yaml/tests/fakes.rs
+++ b/pnpm/crates/modules-yaml/tests/fakes.rs
@@ -170,7 +170,6 @@ fn read_reports_an_incompatible_layout_version_as_no_layout() {
         .pipe(read_modules_manifest::<LegacyVersion>)
         .expect("read manifest")
         .expect("manifest exists");
-    dbg!(&manifest.layout_version);
     assert_eq!(manifest.layout_version, None);
 
     // `ModulesLayout` carries its own copy of the field, and it is the
@@ -180,7 +179,6 @@ fn read_reports_an_incompatible_layout_version_as_no_layout() {
         .pipe(read_modules_layout::<LegacyVersion>)
         .expect("read layout")
         .expect("layout exists");
-    dbg!(&layout.layout_version);
     assert_eq!(layout.layout_version, None);
 }
 

--- a/pnpm/crates/modules-yaml/tests/fakes.rs
+++ b/pnpm/crates/modules-yaml/tests/fakes.rs
@@ -144,13 +144,13 @@ fn write_propagates_write_error() {
     assert!(matches!(err, pnpm_modules_yaml::WriteModulesError::WriteFile { .. }));
 }
 
-/// `LayoutVersion` is a unit type pinned to `5`. A manifest whose
-/// `layoutVersion` is any other number must fail at parse time. This is
-/// stricter than pnpm, which accepts any number at read time and defers
-/// the decision to a later compatibility check; the end-to-end behavior
-/// matches because both code paths reject incompatible manifests.
+/// `LayoutVersion` is a unit type pinned to `5`, and a manifest naming
+/// any other layout reads as `None` — the same signal a missing
+/// `layoutVersion` carries, which the install reacts to by rebuilding
+/// `node_modules`. Rejecting the whole manifest instead would fail the
+/// install, since an unreadable state file is an error.
 #[test]
-fn read_rejects_incompatible_layout_version() {
+fn read_reports_an_incompatible_layout_version_as_no_layout() {
     use std::io;
 
     struct LegacyVersion;
@@ -161,16 +161,17 @@ fn read_rejects_incompatible_layout_version() {
     }
     impl Clock for LegacyVersion {
         fn now() -> SystemTime {
-            unreachable!("clock must not be called when layout version is rejected");
+            SystemTime::UNIX_EPOCH
         }
     }
 
-    let err = "/dev/null/unused"
+    let manifest = "/dev/null/unused"
         .pipe(Path::new)
         .pipe(read_modules_manifest::<LegacyVersion>)
-        .expect_err("expected error");
-    eprintln!("error: {err}");
-    assert!(matches!(err, pnpm_modules_yaml::ReadModulesError::ParseYaml { .. }));
+        .expect("read manifest")
+        .expect("manifest exists");
+    dbg!(&manifest.layout_version);
+    assert_eq!(manifest.layout_version, None);
 }
 
 /// `ignoredBuilds` deserializes into an [`IndexSet`]: the on-disk array

--- a/pnpm/crates/modules-yaml/tests/index.rs
+++ b/pnpm/crates/modules-yaml/tests/index.rs
@@ -7,7 +7,8 @@
 use indexmap::IndexMap;
 use pipe_trait::Pipe;
 use pnpm_modules_yaml::{
-    HoistKind, Host, Modules, read_modules_layout, read_modules_manifest, write_modules_manifest,
+    HoistKind, Host, LayoutVersion, Modules, read_modules_layout, read_modules_manifest,
+    write_modules_manifest,
 };
 use pretty_assertions::assert_eq;
 use serde_json::{Value, json};
@@ -248,6 +249,37 @@ fn yaml_fallback_keeps_depth_budget() {
     ] {
         let error = result.expect_err("excessive depth must be rejected");
         assert!(error.to_string().to_lowercase().contains("depth"), "{error}");
+    }
+}
+
+/// A `layoutVersion` naming a layout this build does not emit reads as
+/// `None` through both readers — the install rebuilds `node_modules`
+/// rather than failing on a manifest it could otherwise read. `5.0` is
+/// the same number as `5` in JSON, so it is the same version here.
+#[test]
+fn incompatible_layout_versions_read_as_no_layout_version() {
+    let temp_dir = tempfile::tempdir().expect("create temporary directory");
+    let modules_dir = temp_dir.path();
+    for (recorded, expected) in [
+        (json!(5), Some(LayoutVersion)),
+        (json!(5.0), Some(LayoutVersion)),
+        (json!(4), None),
+        (json!(-1), None),
+        (json!(1e9), None),
+    ] {
+        eprintln!("CASE: layoutVersion {recorded}");
+        fs::write(
+            modules_dir.join(".modules.yaml"),
+            json!({ "layoutVersion": recorded }).to_string(),
+        )
+        .expect("write manifest");
+        let manifest = read_modules_manifest::<Host>(modules_dir)
+            .expect("read manifest")
+            .expect("manifest exists");
+        assert_eq!(manifest.layout_version, expected);
+        let layout =
+            read_modules_layout::<Host>(modules_dir).expect("read layout").expect("layout exists");
+        assert_eq!(layout.layout_version, expected);
     }
 }
 

--- a/pnpm/crates/modules-yaml/tests/index.rs
+++ b/pnpm/crates/modules-yaml/tests/index.rs
@@ -265,7 +265,8 @@ fn incompatible_layout_versions_read_as_no_layout_version() {
         (json!(5.0), Some(LayoutVersion)),
         (json!(4), None),
         (json!(-1), None),
-        (json!(1e9), None),
+        (json!(5.5), None),
+        (json!(4_294_967_296.0), None),
     ] {
         eprintln!("CASE: layoutVersion {recorded}");
         fs::write(

--- a/pnpm/crates/package-manager/src/install/prepare_modules_state.rs
+++ b/pnpm/crates/package-manager/src/install/prepare_modules_state.rs
@@ -76,30 +76,30 @@ pub(super) async fn prepare_modules_state<'install, Reporter: self::Reporter + '
     } = inputs;
     // A no-op still refreshes workspace state so `verifyDepsBeforeRun`
     // does not treat the materialized tree as stale.
-    let modules_manifest_res = if !resolve_only || take_frozen_path {
+    // An unreadable state file fails the install rather than being read
+    // as layout drift. Treating it as drift would purge `node_modules`
+    // — including whatever the user put there themselves — and silently
+    // relink the whole tree on every run, which is how a manifest the
+    // reader could not parse surfaced as an endless re-link
+    // (<https://github.com/pnpm/pnpm/issues/14062>). The TypeScript CLI's
+    // `readModulesManifest` rethrows everything but `ENOENT` for the same
+    // reason.
+    let old_modules = if !resolve_only || take_frozen_path {
         pnpm_modules_yaml::read_modules_layout::<Host>(&config.modules_dir)
+            .map_err(InstallError::ReadModules)?
     } else {
-        Ok(None)
+        None
     };
-    let read_failed = modules_manifest_res.is_err();
-    if let Err(err) = &modules_manifest_res {
-        tracing::warn!(
-            target: "pacquet::install",
-            ?err,
-            "failed to read .modules.yaml; treating as an inconsistent node_modules directory",
-        );
-    }
-    let old_modules = modules_manifest_res.ok().flatten();
     let modules_manifest = old_modules.as_ref();
     // A filtered install rewrites `.modules.yaml` from the selected
     // projects' state merged over the previous file's, so losing the
     // previous contents would drop every unselected project's entries.
-    // An unreadable *layout* is already handled as an inconsistent
-    // `node_modules` — the purge rebuilds everything and the merge is
-    // skipped — but a file whose layout parses while some later field
-    // does not would otherwise merge against `None` and silently prune
-    // those entries, so that case fails instead.
-    let previous_modules_metadata = if !resolve_only && !read_failed {
+    // A file whose layout parses while some later field does not would
+    // otherwise merge against `None` and silently prune those entries, so
+    // that case fails instead.
+    let previous_modules_metadata = if resolve_only {
+        None
+    } else {
         match pnpm_modules_yaml::read_modules_manifest::<Host>(&config.modules_dir) {
             Ok(modules) => modules,
             // A filtered install merges the unselected importers'
@@ -116,23 +116,20 @@ pub(super) async fn prepare_modules_state<'install, Reporter: self::Reporter + '
                 None
             }
         }
-    } else {
-        None
     };
     // The purge keys off *layout* drift only, not `included`: an
     // included (`--prod`<->full) change is handled by relinking, so it
     // must not wipe the user's `node_modules` contents. See
     // [`modules_layout_consistent_with`].
-    let is_inconsistent = read_failed
-        || match &modules_manifest {
-            Some(modules) => !modules_layout_consistent_with(modules, config, node_linker),
-            // Treat existence-check errors conservatively as inconsistent.
-            None => config
-                .modules_dir
-                .join(pnpm_modules_yaml::MODULES_FILENAME)
-                .try_exists()
-                .unwrap_or(true),
-        };
+    let is_inconsistent = match &modules_manifest {
+        Some(modules) => !modules_layout_consistent_with(modules, config, node_linker),
+        // Treat existence-check errors conservatively as inconsistent.
+        None => config
+            .modules_dir
+            .join(pnpm_modules_yaml::MODULES_FILENAME)
+            .try_exists()
+            .unwrap_or(true),
+    };
 
     if !resolve_only && is_inconsistent {
         // A plain install may recreate the drifted modules dir;

--- a/pnpm/crates/package-manager/src/install/prepare_modules_state.rs
+++ b/pnpm/crates/package-manager/src/install/prepare_modules_state.rs
@@ -76,12 +76,11 @@ pub(super) async fn prepare_modules_state<'install, Reporter: self::Reporter + '
     } = inputs;
     // A no-op still refreshes workspace state so `verifyDepsBeforeRun`
     // does not treat the materialized tree as stale.
-    // An unreadable state file fails the install rather than being read
-    // as layout drift. Treating it as drift would purge `node_modules`
-    // — including whatever the user put there themselves — and silently
-    // relink the whole tree on every run, which is how a manifest the
-    // reader could not parse surfaced as an endless re-link
-    // (<https://github.com/pnpm/pnpm/issues/14062>). The TypeScript CLI's
+    // An unreadable state file fails the install rather than reading as
+    // layout drift: the drift path purges `node_modules` — the entries
+    // the user keeps there included — and relinks the whole tree, and it
+    // would do so on every run, because the manifest it rewrites is no
+    // more readable than the one it replaced. The TypeScript CLI's
     // `readModulesManifest` rethrows everything but `ENOENT` for the same
     // reason.
     let old_modules = if !resolve_only || take_frozen_path {

--- a/pnpm11/installing/modules-yaml/test/index.ts
+++ b/pnpm11/installing/modules-yaml/test/index.ts
@@ -133,6 +133,14 @@ test('readModulesManifest does not fail on empty file', async () => {
   expect(modulesYaml).toBeUndefined()
 })
 
+test('readModulesManifest() rejects a manifest it cannot parse', async () => {
+  // Callers must not mistake an unreadable state file for a missing one:
+  // that reads as layout drift and purges node_modules on every install.
+  const modulesDir = temporaryDirectory()
+  fs.writeFileSync(path.join(modulesDir, '.modules.yaml'), 'not: [valid')
+  await expect(readModulesManifest(modulesDir)).rejects.toThrow()
+})
+
 test('writeModulesManifest() drops the registries a pnpm 11 file recorded', async () => {
   // The registries a project resolves from are read from its config, so a
   // recorded copy is stale the moment the config changes.


### PR DESCRIPTION
## Summary

Related to pnpm/pnpm#14062.

The re-linking in pnpm/pnpm#14062 is a symptom; the root cause was already fixed after `12.0.0-rc.8` was cut. The reporter's `node_modules/.modules.yaml` has one `hoistedDependencies` key of 1030 characters (only the full four-dependency graph produces one that long, which is why every reduced repro is clean). `rc.8` read that JSON file through a YAML parser, which rejects a simple key over 1024 characters, so `read_modules_layout` returned an error on every run. pnpm/pnpm#13885 (`1e5732cb30`, unreleased) parses the manifest as JSON first, so the manifest is readable again. I reproduced the manifest with the reporter's `package.json` and confirmed both halves: the YAML parser fails at column 1037 of that file, and the JSON parser accepts it.

What this PR fixes is what turned an unreadable state file into that symptom. `prepare_modules_state` treated *any* read failure as layout drift, and the drift path deletes everything in `node_modules` — including entries pnpm does not manage — and relinks the tree from scratch, with a `pnpm:_broken_node_modules` event per package and nothing on stderr to say why. Because the rewritten manifest keeps the same long key, it repeated on every install. Verified on `rc.8`'s behavior locally: a hand-corrupted `.modules.yaml` silently removed a directory I had put in `node_modules` myself and relinked all 584 packages.

An unreadable state file now fails the install with `ERR_PNPM_MODULES_YAML_PARSE_YAML`, naming the file, which is what the TypeScript CLI already does — its `readModulesManifest` rethrows everything but `ENOENT`.

That change alone would have broken the older-layout case, because pacquet encoded "unsupported `layoutVersion`" *as* a deserialization error, and relied on the same swallow-and-purge path to rebuild the directory. `layoutVersion` is now read leniently: a version this build does not support reads as `None`, the same signal a missing field carries, so an old `node_modules` still rebuilds. This also removes a documented divergence — pnpm accepts any number there and leaves the decision to its own compatibility check.

Tests: a CLI e2e test that an unparsable `.modules.yaml` fails the install and leaves `node_modules` intact (verified to fail without the fix), the updated `modules-yaml` layout-version test, and a TypeScript unit test pinning the `readModulesManifest` behavior this brings pacquet in line with.

The commit on top of the fix adds `chcp` to `cspell.json`: the changeset for pnpm/pnpm#13998 on `main` names that Windows command and fails the spell check in the pre-push hook.

## Squash Commit Body

```text
A `.modules.yaml` the reader could not parse was treated as layout drift,
so every install deleted the whole `node_modules` directory — the user's
own entries included — and relinked the tree from scratch, emitting one
`pnpm:_broken_node_modules` event per package with nothing on stderr to
explain it. That is how a manifest key longer than YAML's simple-key
limit (fixed in pnpm/pnpm#13885) surfaced as an endless re-link in
pnpm/pnpm#14062.

Fail the install on an unreadable state file instead, matching the
TypeScript CLI's `readModulesManifest`, which rethrows everything but
`ENOENT`.

An unsupported `layoutVersion` no longer travels as a parse error: it now
reads as "no layout version", the same signal a missing field carries, so
a `node_modules` from an older layout still rebuilds rather than failing
the install. pnpm reads any number there too and leaves the decision to
its own compatibility check.

Also adds `chcp` to the spell-check dictionary: the changeset for
pnpm/pnpm#13998 names that Windows command and fails the pre-push hook.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. (The
  TypeScript CLI already behaves this way; this brings pacquet in line and
  adds a test pinning the TypeScript side.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5[1m]).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14073"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789999190&installation_model_id=426870&pr_number=14073&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14073&signature=4de67345af41937426d339f673296d532aec835bb0be468c206b6e0cf47e9d66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - `pnpm install` now reports an error when `node_modules/.modules.yaml` is unreadable or malformed.
  - Existing `node_modules` contents are preserved instead of being automatically deleted and relinked.
  - Supported numeric layout versions, including values such as `5.0`, are handled correctly; unsupported, fractional, or out-of-range versions are safely rejected.

- **Tests**
  - Added coverage for malformed manifests, frozen installs, layout-version handling, and preservation of existing package contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->