### PR TITLE
fix(package-manager): let a filtered no-op install short-circuit

### DIFF
--- a/.changeset/filtered-no-op-install-fast-path.md
+++ b/.changeset/filtered-no-op-install-fast-path.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+A `pnpm install --filter <selector>` run that has nothing to do now reports "Already up to date" without entering the install pipeline, the same way an unfiltered `pnpm install` already did [#14033](https://github.com/pnpm/pnpm/issues/14033).

--- a/pnpm/crates/cli/tests/suite/install_filters.rs
+++ b/pnpm/crates/cli/tests/suite/install_filters.rs
@@ -42,6 +42,13 @@ fn assert_stage_once(records: &[Value]) {
     assert_eq!(importing_started_count(records), 1, "one install pipeline must import once");
 }
 
+fn reports_up_to_date(records: &[Value]) -> bool {
+    records.iter().any(|record| {
+        record.get("name").and_then(Value::as_str) == Some("pnpm")
+            && record.get("message").and_then(Value::as_str) == Some("Already up to date")
+    })
+}
+
 #[test]
 fn full_recursive_install_keeps_the_unfiltered_up_to_date_path() {
     let fixture = WorkspaceFixture::new();
@@ -64,10 +71,35 @@ fn full_recursive_install_keeps_the_unfiltered_up_to_date_path() {
 
     assert_eq!(fs::read(lockfile_path).expect("read lockfile"), before);
     assert_eq!(importing_started_count(&records), 0, "a full selection must not relink");
-    assert!(records.iter().any(|record| {
-        record.get("name").and_then(Value::as_str) == Some("pnpm")
-            && record.get("message").and_then(Value::as_str) == Some("Already up to date")
-    }));
+    assert!(reports_up_to_date(&records));
+}
+
+/// A `--filter`ed install with nothing to do short-circuits like the
+/// unfiltered one: the fast path validates the whole workspace, and the
+/// full install that preceded it materialized every project.
+#[test]
+fn filtered_install_takes_the_up_to_date_path_after_a_full_install() {
+    let fixture = WorkspaceFixture::new();
+    fixture.project(
+        "selected",
+        "selected",
+        ManifestDeps { prod: &[(HELLO, "1.0.0")], ..Default::default() },
+    );
+    fixture.project(
+        "unselected",
+        "unselected",
+        ManifestDeps { prod: &[(PARENT, "100.0.0")], ..Default::default() },
+    );
+    fixture.run(["install"]);
+    let lockfile_path = fixture.workspace.join("pnpm-lock.yaml");
+    let before = fs::read(&lockfile_path).expect("read lockfile");
+
+    let records = fixture.run(["--filter", "selected", "install"]);
+
+    assert!(reports_up_to_date(&records));
+    assert_eq!(importing_started_count(&records), 0, "a no-op selection must not relink");
+    assert_eq!(fs::read(&lockfile_path).expect("read lockfile"), before);
+    assert!(!fixture.state().filtered_install, "the short-circuit narrowed nothing");
 }
 
 #[test]
@@ -694,6 +726,10 @@ fn filtered_prod_install_preserves_shallow_workspace_link_targets() {
 #[test]
 fn filtered_install_keeps_full_cleanup_for_shared_layout_drift() {
     let fixture = WorkspaceFixture::new();
+    // The drift lives in `.modules.yaml`, which the repeat-install fast
+    // path never reads; this test is about what the pipeline cleans up
+    // once it runs, so keep the pipeline in play.
+    fixture.append_workspace_yaml("optimisticRepeatInstall: false\n");
     let selected = fixture.project(
         "selected",
         "selected",

--- a/pnpm/crates/package-manager/src/install/run.rs
+++ b/pnpm/crates/package-manager/src/install/run.rs
@@ -304,9 +304,14 @@ where
         // excluded through its seed policy: a compatible bump leaves
         // the manifest byte-identical, which the check would likewise
         // read as up to date and skip the registry re-resolution.
+        //
+        // A `--filter` narrowing does not disqualify the run: the check
+        // validates the whole workspace (`project_manifests` covers every
+        // project even when only a subset is selected), and it refuses a
+        // workspace state a filtered install wrote, so "nothing changed"
+        // still means every selected project is materialized.
         let optimistic_decision = mutation.is_full_install()
             && matches!(update_seed_policy, UpdateSeedPolicy::KeepAll)
-            && !filtered_install
             && !frozen_lockfile
             && !config.force
             && !disable_optimistic_repeat_install

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
@@ -185,6 +185,16 @@ pub(crate) fn check_optimistic_repeat_install_ignoring(
         return Decision::Skipped { reason: "no workspace state on disk" };
     };
 
+    // A filtered install refreshes `lastValidatedTimestamp` while
+    // materializing only the projects it selected, so its state cannot
+    // prove anything about the rest of the workspace: an unselected
+    // project's manifest edit is already older than the recorded
+    // timestamp. Every install must re-validate once against a state a
+    // filtered install wrote — pnpm's `ignoreFilteredInstallCache`.
+    if state.filtered_install {
+        return Decision::Skipped { reason: "the previous install was filtered" };
+    }
+
     if first_lockfile_requiring_conflict_safe_install(check, state.last_validated_timestamp)
         .is_some()
     {

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
@@ -228,6 +228,30 @@ fn returns_up_to_date_when_state_and_manifests_agree() {
     assert_eq!(decision, Decision::UpToDate);
 }
 
+/// A filtered install refreshes `lastValidatedTimestamp` while leaving
+/// the projects it did not select untouched, so its state cannot prove
+/// the workspace is current: the next install re-validates for real.
+#[test]
+fn returns_skipped_when_the_previous_install_was_filtered() {
+    let (dir, config, manifest) =
+        setup_fresh_install(pnpm_config::NodeLinker::Isolated, "root", "1.0.0", "");
+    let mut state = load_workspace_state(dir.path()).expect("read state").expect("state on disk");
+    state.filtered_install = true;
+    update_workspace_state(dir.path(), &state).expect("write workspace state");
+
+    let decision = check(
+        dir.path(),
+        config,
+        pnpm_config::NodeLinker::Isolated,
+        &[(dir.path().to_path_buf(), &manifest)],
+    );
+
+    assert!(
+        matches!(decision, Decision::Skipped { reason } if reason.contains("previous install was filtered")),
+        "unexpected decision: {decision:?}",
+    );
+}
+
 /// A `file:` dependency must never short-circuit: nothing the fast
 /// path stats covers the dependency's *contents*, so the full install
 /// path has to run and refetch it.


### PR DESCRIPTION
## Summary

`pnpm install --filter <selector>` never reached the repeat-install fast path, so a filtered no-op install paid for the full resolve/verify pipeline while the unfiltered one short-circuited. On the reporter's 12,838-project monorepo that is 30.5s vs 9.2s; the TypeScript CLI short-circuits both.

`Install::run_inner` gated the fast path on `!filtered_install`. That gate was aimed at the wrong thing: `project_manifests` already covers *every* workspace project when a selection is present (`build_selected_project_manifests_list` maps the full project list), so the freshness comparison is workspace-wide either way.

What the selection really changes is the *previous* run. A filtered install refreshes `lastValidatedTimestamp` while materializing only what it selected, so an unselected project's manifest edit ends up older than the recorded timestamp and the mtime walk cannot see it. So the caller-side gate is dropped and `check_optimistic_repeat_install` refuses the recorded state instead: it skips whenever the workspace state was written by a filtered install. That is exactly pnpm's `ignoreFilteredInstallCache`, which `installDeps` passes on every optimistic-repeat check.

pacquet-only: the TypeScript CLI already behaves this way (`deps/status/src/checkDepsStatus.ts` runs against `allProjects` and bails on `workspaceState.filteredInstall`), so there is nothing to mirror.

One existing test needed adjusting. `filtered_install_keeps_full_cleanup_for_shared_layout_drift` puts its drift in `.modules.yaml`, which no repeat-install fast path reads — in either stack, an unfiltered `pnpm install` after a `layoutVersion` bump already reports "Already up to date" (TS checks `layoutVersion` in `deps-installer`'s `checkCompatibility`, well past `checkDepsStatus`). The test was passing only because filtered installs were excluded from the fast path, so it now sets `optimisticRepeatInstall: false` and keeps testing the cleanup it is named for.

Closes pnpm/pnpm#14033

## Squash Commit Body

```text
`pacquet install --filter <selector>` never reached the repeat-install
fast path: `Install::run_inner` gated it on `!filtered_install`, so a
narrowed run paid for the full resolve/verify pipeline even when nothing
had changed. On a large workspace that is the difference between a 9s
and a 30s no-op.

The narrowing is not what the check reasons about. `project_manifests`
already covers every workspace project when a selection is present
(`build_selected_project_manifests_list` maps the full project list),
so the freshness comparison is workspace-wide either way. What the
selection does change is the *previous* run: a filtered install
refreshes `lastValidatedTimestamp` while materializing only what it
selected, so an unselected project's manifest edit ends up older than
the recorded timestamp and the mtime walk cannot see it.

So drop the caller-side gate and refuse the recorded state instead:
`check_optimistic_repeat_install` now skips whenever the workspace state
was written by a filtered install, which is pnpm's
`ignoreFilteredInstallCache`. The TypeScript CLI already behaves this
way, so this is a pacquet-only fix.

`filtered_install_keeps_full_cleanup_for_shared_layout_drift` relied on
filtered installs always running the pipeline: its drift lives in
`.modules.yaml`, which no repeat-install fast path reads in either stack
(an unfiltered install already short-circuits past a `layoutVersion`
bump). It now opts out of the fast path so it keeps testing the cleanup
it is named for.

Closes pnpm/pnpm#14033
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Filtered no-op installs now immediately report “Already up to date.”
  * Repeat installs can use a faster path when all selected projects are already current.

* **Bug Fixes**
  * Prevented filtered-install state from incorrectly triggering optimistic repeat-install behavior.
  * Filtered installs now avoid unnecessary relinking and lockfile updates when no changes are needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->