### PR TITLE
feat: support negation syntax in allow-build and pre-emptive approve-…

### DIFF
--- a/.changeset/allow-build-negation-support.md
+++ b/.changeset/allow-build-negation-support.md
@@ -1,7 +1,7 @@
 ---
 "@pnpm/building.commands": patch
 "@pnpm/building.policy": minor
-"@pnpm/global.commands": patch
+"@pnpm/global.commands": major
 "@pnpm/installing.commands": patch
 "pnpm": patch
 "pacquet": patch

--- a/.changeset/allow-build-negation-support.md
+++ b/.changeset/allow-build-negation-support.md
@@ -1,8 +1,12 @@
 ---
 "@pnpm/building.commands": patch
+"@pnpm/building.policy": patch
 "@pnpm/installing.commands": patch
 "pnpm": patch
 "pacquet": patch
 ---
 
-Added support for `!<pkg>` negation syntax in `--allow-build` and pre-emptive package arguments in `approve-builds`.
+Build scripts can now be rejected before the package is installed [#14067](https://github.com/pnpm/pnpm/issues/14067):
+
+- `pnpm add --allow-build=!<pkg>` records `<pkg>: false` in `allowBuilds` instead of a `!<pkg>: true` entry that never matched anything.
+- `pnpm approve-builds <pkg>` and `pnpm approve-builds !<pkg>` now record their decision even when no packages are awaiting approval. A package that is not awaiting approval is reported with a warning instead of an error, so a typo is still visible.

--- a/.changeset/allow-build-negation-support.md
+++ b/.changeset/allow-build-negation-support.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/building.commands": patch
+"@pnpm/installing.commands": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+Added support for `!<pkg>` negation syntax in `--allow-build` and pre-emptive package arguments in `approve-builds`.

--- a/.changeset/allow-build-negation-support.md
+++ b/.changeset/allow-build-negation-support.md
@@ -1,6 +1,7 @@
 ---
 "@pnpm/building.commands": patch
 "@pnpm/building.policy": patch
+"@pnpm/global.commands": patch
 "@pnpm/installing.commands": patch
 "pnpm": patch
 "pacquet": patch
@@ -8,5 +9,5 @@
 
 Build scripts can now be rejected before the package is installed [#14067](https://github.com/pnpm/pnpm/issues/14067):
 
-- `pnpm add --allow-build=!<pkg>` records `<pkg>: false` in `allowBuilds` instead of a `!<pkg>: true` entry that never matched anything.
+- `pnpm add --allow-build=!<pkg>` records `<pkg>: false` in `allowBuilds` instead of a `!<pkg>: true` entry that never matched anything. This works for global installs too, where the denial previously never reached the approval prompt.
 - `pnpm approve-builds <pkg>` and `pnpm approve-builds !<pkg>` now record their decision even when no packages are awaiting approval. A package that is not awaiting approval is reported with a warning instead of an error, so a typo is still visible.

--- a/.changeset/allow-build-negation-support.md
+++ b/.changeset/allow-build-negation-support.md
@@ -1,6 +1,6 @@
 ---
 "@pnpm/building.commands": patch
-"@pnpm/building.policy": patch
+"@pnpm/building.policy": minor
 "@pnpm/global.commands": patch
 "@pnpm/installing.commands": patch
 "pnpm": patch
@@ -9,5 +9,5 @@
 
 Build scripts can now be rejected before the package is installed [#14067](https://github.com/pnpm/pnpm/issues/14067):
 
-- `pnpm add --allow-build=!<pkg>` records `<pkg>: false` in `allowBuilds` instead of a `!<pkg>: true` entry that never matched anything. This works for global installs too, where the denial previously never reached the approval prompt.
-- `pnpm approve-builds <pkg>` and `pnpm approve-builds !<pkg>` now record their decision even when no packages are awaiting approval. A package that is not awaiting approval is reported with a warning instead of an error, so a typo is still visible.
+- `pnpm add --allow-build=!<pkg>` records `<pkg>: false` in `allowBuilds`. It used to write a `!<pkg>: true` entry that matched no package. On a global install the denial was dropped altogether, so the post-install prompt offered the build for approval.
+- `pnpm approve-builds <pkg>` and `pnpm approve-builds !<pkg>` record their decision even when no packages are awaiting approval, and report a package that is not awaiting approval with a warning so a typo stays visible. Both cases used to fail the command with an error.

--- a/pnpm/crates/cli/src/cli_args/add.rs
+++ b/pnpm/crates/cli/src/cli_args/add.rs
@@ -18,7 +18,7 @@ use clap::Args;
 use derive_more::{Display, Error};
 use miette::{Context, Diagnostic, IntoDiagnostic};
 use pnpm_config::Config;
-use pnpm_package_manager::Add;
+use pnpm_package_manager::{Add, parse_allow_build_selector};
 use pnpm_package_manifest::DependencyGroup;
 use pnpm_registry::RangeSpecStyle;
 use pnpm_reporter::{LogEvent, LogLevel, PnpmLog, Reporter};
@@ -203,7 +203,8 @@ pub struct AddArgs {
     #[clap(long = "config")]
     pub config: bool,
     /// Package names allowed to run lifecycle (build) scripts during this
-    /// install, appended to `allowBuilds`. May be repeated.
+    /// install, appended to `allowBuilds`. Prefix a name with `!` to deny
+    /// its scripts instead. May be repeated.
     #[clap(long = "allow-build")]
     pub allow_build: Vec<String>,
     /// Dependencies are not downloaded. Only `pnpm-lock.yaml` is updated.
@@ -525,11 +526,13 @@ pub(crate) fn apply_allow_build(
     let mut allow_build_map: Vec<(&str, bool)> = Vec::with_capacity(allow_build.len());
     let mut allowed_only: Vec<&str> = Vec::new();
     for pkg in allow_build {
-        if let Some(stripped) = pkg.strip_prefix('!') {
-            allow_build_map.push((stripped, false));
-        } else {
-            allow_build_map.push((pkg.as_str(), true));
-            allowed_only.push(pkg.as_str());
+        let (name, allowed) = parse_allow_build_selector(pkg);
+        if name.is_empty() {
+            return Err(AllowBuildError::MissingPackage.into());
+        }
+        allow_build_map.push((name, allowed));
+        if allowed {
+            allowed_only.push(name);
         }
     }
     let overlap: Vec<&str> = allowed_only
@@ -586,6 +589,12 @@ pub enum AllowBuildError {
         )
     )]
     OverridingIgnoredBuiltDependencies { dependencies: String },
+
+    #[display(
+        "The --allow-build flag is missing a package name. Please specify the package name(s) that are allowed to run installation scripts."
+    )]
+    #[diagnostic(code(ERR_PNPM_ALLOW_BUILD_MISSING_PACKAGE))]
+    MissingPackage,
 }
 
 /// Add a single package to `state`'s manifest and install it.

--- a/pnpm/crates/cli/src/cli_args/add.rs
+++ b/pnpm/crates/cli/src/cli_args/add.rs
@@ -522,10 +522,19 @@ pub(crate) fn apply_allow_build(
     if allow_build.is_empty() {
         return Ok(());
     }
-    let overlap: Vec<&str> = allow_build
-        .iter()
-        .filter(|pkg| config.allow_builds.get(pkg.as_str()) == Some(&false))
-        .map(String::as_str)
+    let mut allow_build_map: Vec<(&str, bool)> = Vec::with_capacity(allow_build.len());
+    let mut allowed_only: Vec<&str> = Vec::new();
+    for pkg in allow_build {
+        if let Some(stripped) = pkg.strip_prefix('!') {
+            allow_build_map.push((stripped, false));
+        } else {
+            allow_build_map.push((pkg.as_str(), true));
+            allowed_only.push(pkg.as_str());
+        }
+    }
+    let overlap: Vec<&str> = allowed_only
+        .into_iter()
+        .filter(|pkg| config.allow_builds.get(*pkg) == Some(&false))
         .collect();
     if !overlap.is_empty() {
         return Err(AllowBuildError::OverridingIgnoredBuiltDependencies {
@@ -533,10 +542,9 @@ pub(crate) fn apply_allow_build(
         }
         .into());
     }
-    set_allow_builds(settings_dir, allow_build.iter().map(|pkg| (pkg.as_str(), true)))
-        .into_diagnostic()?;
-    for pkg in allow_build {
-        config.allow_builds.insert(pkg.clone(), true);
+    set_allow_builds(settings_dir, allow_build_map.iter().copied()).into_diagnostic()?;
+    for (name, is_allow) in allow_build_map {
+        config.allow_builds.insert(name.to_string(), is_allow);
     }
     Ok(())
 }

--- a/pnpm/crates/cli/src/cli_args/add/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/add/tests.rs
@@ -19,6 +19,20 @@ fn allow_build_merges_into_config_and_persists_to_workspace_yaml() {
 }
 
 #[test]
+fn allow_build_negation_sets_false_in_config_and_workspace_yaml() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let mut config = Config::default();
+    apply_allow_build(&mut config, &["!core-js".to_string()], dir.path())
+        .expect("allow-build negation applies");
+
+    assert_eq!(config.allow_builds.get("core-js"), Some(&false), "disabled for this install");
+
+    let yaml = std::fs::read_to_string(dir.path().join("pnpm-workspace.yaml"))
+        .expect("pnpm-workspace.yaml written");
+    assert!(yaml.contains("core-js"), "allowBuilds entry persisted, got:\n{yaml}");
+}
+
+#[test]
 fn allow_build_rejects_a_package_the_root_disallows() {
     let dir = tempfile::tempdir().expect("temp dir");
     let mut config = Config::default();

--- a/pnpm/crates/cli/src/cli_args/add/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/add/tests.rs
@@ -15,7 +15,7 @@ fn allow_build_merges_into_config_and_persists_to_workspace_yaml() {
 
     let yaml = std::fs::read_to_string(dir.path().join("pnpm-workspace.yaml"))
         .expect("pnpm-workspace.yaml written");
-    assert!(yaml.contains("esbuild"), "allowBuilds entry persisted, got:\n{yaml}");
+    assert!(yaml.contains("esbuild: true"), "allowBuilds entry persisted, got:\n{yaml}");
 }
 
 #[test]
@@ -29,7 +29,26 @@ fn allow_build_negation_sets_false_in_config_and_workspace_yaml() {
 
     let yaml = std::fs::read_to_string(dir.path().join("pnpm-workspace.yaml"))
         .expect("pnpm-workspace.yaml written");
-    assert!(yaml.contains("core-js"), "allowBuilds entry persisted, got:\n{yaml}");
+    assert!(yaml.contains("core-js: false"), "allowBuilds entry persisted, got:\n{yaml}");
+}
+
+#[test]
+fn allow_build_rejects_an_argument_that_names_no_package() {
+    for allow_build in [&["!".to_string()][..], &[String::new()][..]] {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let mut config = Config::default();
+        let err = apply_allow_build(&mut config, allow_build, dir.path())
+            .expect_err("an empty package name is rejected");
+        assert_eq!(
+            err.code().map(|code| code.to_string()).as_deref(),
+            Some("ERR_PNPM_ALLOW_BUILD_MISSING_PACKAGE"),
+        );
+        assert!(config.allow_builds.is_empty());
+        assert!(
+            !dir.path().join("pnpm-workspace.yaml").exists(),
+            "a rejected apply persists nothing",
+        );
+    }
 }
 
 #[test]

--- a/pnpm/crates/cli/src/cli_args/approve_builds.rs
+++ b/pnpm/crates/cli/src/cli_args/approve_builds.rs
@@ -4,7 +4,8 @@ use dialoguer::{Confirm, MultiSelect};
 use miette::{Diagnostic, IntoDiagnostic};
 use pnpm_config::Config;
 use pnpm_modules_yaml::{Host, write_modules_manifest};
-use pnpm_package_manager::allow_build_key_from_ignored_build;
+use pnpm_package_manager::{allow_build_key_from_ignored_build, parse_allow_build_selector};
+use pnpm_reporter::{Reporter, emit_global_warning};
 use pnpm_workspace_manifest_writer::set_allow_builds_clearing_legacy;
 use std::{
     collections::{BTreeMap, HashSet},
@@ -37,6 +38,12 @@ enum ApproveBuildsError {
     #[diagnostic(code(ERR_PNPM_APPROVE_BUILDS_ALL_WITH_ARGS))]
     AllWithArgs,
 
+    #[display(
+        "A package name is missing from the arguments. Please specify the package name(s) to approve (`<pkg>`) or deny (`!<pkg>`)."
+    )]
+    #[diagnostic(code(ERR_PNPM_APPROVE_BUILDS_MISSING_PACKAGE))]
+    MissingPackage,
+
     #[display("The following packages are both approved and denied: {}", _0.join(", "))]
     #[diagnostic(code(ERR_PNPM_APPROVE_BUILDS_CONTRADICTING_ARGS))]
     ContradictingArgs(#[error(not(source))] Vec<String>),
@@ -61,7 +68,7 @@ impl ApproveBuildsArgs {
     /// reflects the just-written `allowBuilds`. `dir` is the canonicalized
     /// `--dir`, the fallback settings target when no `pnpm-workspace.yaml`
     /// is found.
-    pub fn prepare(
+    pub fn prepare<Reporter: self::Reporter>(
         self,
         dir: &Path,
         config: &(dyn Fn() -> miette::Result<&'static mut Config> + Sync),
@@ -75,7 +82,7 @@ impl ApproveBuildsArgs {
             println!("There are no packages awaiting approval");
             return Ok(None);
         }
-        let Some(decision) = self.decide(&pending)? else {
+        let Some(decision) = self.decide::<Reporter>(&pending)? else {
             return Ok(None);
         };
 
@@ -84,17 +91,37 @@ impl ApproveBuildsArgs {
         write_approval_settings(&settings_dir, &decision)?;
         clear_decided_ignored_builds(scan.modules_manifest, &scan.modules_dir, &decision)?;
 
-        if decision.build_packages.is_empty() {
+        // Only a package that was awaiting approval has something to
+        // rebuild. A pre-emptive approval names a package that is not
+        // installed yet, and rebuilding for it would demand a lockfile the
+        // project may not have.
+        let build_packages: Vec<String> =
+            decision.build_packages.into_iter().filter(|name| pending.contains(name)).collect();
+        if build_packages.is_empty() {
             return Ok(None);
         }
-        Ok(Some((state(true)?, decision.build_packages)))
+        Ok(Some((state(true)?, build_packages)))
     }
 
-    pub(crate) fn decide(self, pending: &[String]) -> miette::Result<Option<ApprovalDecision>> {
+    pub(crate) fn decide<Reporter: self::Reporter>(
+        self,
+        pending: &[String],
+    ) -> miette::Result<Option<ApprovalDecision>> {
         self.validate()?;
         let ApproveBuildsArgs { packages, all, global: _ } = self;
 
-        let (approved, denied) = partition_params(&packages, pending)?;
+        let Partition { approved, denied, unknown } = partition_params(&packages, pending);
+        if !unknown.is_empty() {
+            emit_global_warning::<Reporter>(&format!(
+                "The following packages are not awaiting approval: {}",
+                unknown.join(", "),
+            ));
+        }
+        let contradictions: Vec<String> =
+            approved.iter().filter(|pkg| denied.contains(pkg)).cloned().collect();
+        if !contradictions.is_empty() {
+            return Err(ApproveBuildsError::ContradictingArgs(contradictions).into());
+        }
         let build_packages: Vec<String> = if !packages.is_empty() {
             sort_unique(approved.clone())
         } else if all {
@@ -135,6 +162,9 @@ impl ApproveBuildsArgs {
         if self.all && !self.packages.is_empty() {
             return Err(ApproveBuildsError::AllWithArgs.into());
         }
+        if self.packages.iter().any(|param| parse_allow_build_selector(param).0.is_empty()) {
+            return Err(ApproveBuildsError::MissingPackage.into());
+        }
         Ok(())
     }
 }
@@ -150,38 +180,35 @@ pub(crate) fn write_approval_settings(
     .into_diagnostic()
 }
 
+/// The names an `approve-builds` argument list decides, split by verdict.
+///
+/// A name that is not awaiting approval lands in `unknown` as well as in
+/// its verdict: pre-emptive decisions are recorded, but a typo is worth a
+/// warning because it silently allows or denies a package that will never
+/// be installed under that name.
+#[derive(Debug, Default)]
+struct Partition {
+    approved: Vec<String>,
+    denied: Vec<String>,
+    unknown: Vec<String>,
+}
+
 /// Split `params` into approved (`<pkg>`) and denied (`!<pkg>`) names,
-/// validating each is awaiting approval and that none is both.
-fn partition_params(
-    params: &[String],
-    automatically_ignored_builds: &[String],
-) -> Result<(Vec<String>, Vec<String>), ApproveBuildsError> {
-    let mut approved = Vec::new();
-    let mut denied = Vec::new();
-    let mut unknown = Vec::new();
+/// collecting the ones that are not awaiting approval.
+fn partition_params(params: &[String], automatically_ignored_builds: &[String]) -> Partition {
+    let mut partition = Partition::default();
     for param in params {
-        let name = param.strip_prefix('!').unwrap_or(param);
+        let (name, allowed) = parse_allow_build_selector(param);
         if !automatically_ignored_builds.iter().any(|build| build == name) {
-            unknown.push(name.to_string());
+            partition.unknown.push(name.to_string());
         }
-        if param.starts_with('!') {
-            denied.push(name.to_string());
+        if allowed {
+            partition.approved.push(name.to_string());
         } else {
-            approved.push(name.to_string());
+            partition.denied.push(name.to_string());
         }
     }
-    if !unknown.is_empty() {
-        eprintln!(
-            "warning: The following packages are not awaiting approval: {}",
-            unknown.join(", "),
-        );
-    }
-    let contradictions: Vec<String> =
-        approved.iter().filter(|pkg| denied.contains(pkg)).cloned().collect();
-    if !contradictions.is_empty() {
-        return Err(ApproveBuildsError::ContradictingArgs(contradictions));
-    }
-    Ok((approved, denied))
+    partition
 }
 
 /// Show the checkbox prompt and return the chosen package names, or `None`

--- a/pnpm/crates/cli/src/cli_args/approve_builds.rs
+++ b/pnpm/crates/cli/src/cli_args/approve_builds.rs
@@ -37,10 +37,6 @@ enum ApproveBuildsError {
     #[diagnostic(code(ERR_PNPM_APPROVE_BUILDS_ALL_WITH_ARGS))]
     AllWithArgs,
 
-    #[display("The following packages are not awaiting approval: {}", _0.join(", "))]
-    #[diagnostic(code(ERR_PNPM_APPROVE_BUILDS_UNKNOWN_PACKAGES))]
-    UnknownPackages(#[error(not(source))] Vec<String>),
-
     #[display("The following packages are both approved and denied: {}", _0.join(", "))]
     #[diagnostic(code(ERR_PNPM_APPROVE_BUILDS_CONTRADICTING_ARGS))]
     ContradictingArgs(#[error(not(source))] Vec<String>),
@@ -74,10 +70,11 @@ impl ApproveBuildsArgs {
         self.validate()?;
         let initial_config: &Config = config()?;
         let scan = get_automatically_ignored_builds(initial_config)?;
-        let Some(pending) = scan.names.filter(|names| !names.is_empty()) else {
+        let pending = scan.names.unwrap_or_default();
+        if pending.is_empty() && self.packages.is_empty() {
             println!("There are no packages awaiting approval");
             return Ok(None);
-        };
+        }
         let Some(decision) = self.decide(&pending)? else {
             return Ok(None);
         };
@@ -166,14 +163,18 @@ fn partition_params(
         let name = param.strip_prefix('!').unwrap_or(param);
         if !automatically_ignored_builds.iter().any(|build| build == name) {
             unknown.push(name.to_string());
-        } else if param.starts_with('!') {
+        }
+        if param.starts_with('!') {
             denied.push(name.to_string());
         } else {
             approved.push(name.to_string());
         }
     }
     if !unknown.is_empty() {
-        return Err(ApproveBuildsError::UnknownPackages(unknown));
+        eprintln!(
+            "warning: The following packages are not awaiting approval: {}",
+            unknown.join(", "),
+        );
     }
     let contradictions: Vec<String> =
         approved.iter().filter(|pkg| denied.contains(pkg)).cloned().collect();

--- a/pnpm/crates/cli/src/cli_args/approve_builds/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/approve_builds/tests.rs
@@ -16,24 +16,18 @@ fn splits_approved_and_denied() {
     assert_eq!(denied, vec!["bar".to_string()]);
 }
 
-// Ports pnpm's `positional arguments with unknown package throws error`.
 #[test]
-fn rejects_unknown_approved_package() {
-    let err = partition_params(&params(&["nope"]), &pending(&["foo"])).unwrap_err();
-    let ApproveBuildsError::UnknownPackages(names) = err else {
-        panic!("expected UnknownPackages, got {err:?}");
-    };
-    assert_eq!(names, vec!["nope".to_string()]);
+fn accepts_unknown_approved_package() {
+    let (approved, denied) = partition_params(&params(&["nope"]), &pending(&["foo"])).unwrap();
+    assert_eq!(approved, vec!["nope".to_string()]);
+    assert!(denied.is_empty());
 }
 
-// Ports pnpm's `!pkg with unknown package throws error`.
 #[test]
-fn rejects_unknown_denied_package() {
-    let err = partition_params(&params(&["!nope"]), &pending(&["foo"])).unwrap_err();
-    let ApproveBuildsError::UnknownPackages(names) = err else {
-        panic!("expected UnknownPackages, got {err:?}");
-    };
-    assert_eq!(names, vec!["nope".to_string()]);
+fn accepts_unknown_denied_package() {
+    let (approved, denied) = partition_params(&params(&["!nope"]), &pending(&["foo"])).unwrap();
+    assert!(approved.is_empty());
+    assert_eq!(denied, vec!["nope".to_string()]);
 }
 
 // Ports pnpm's `contradictory arguments throw error`.

--- a/pnpm/crates/cli/src/cli_args/approve_builds/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/approve_builds/tests.rs
@@ -1,4 +1,6 @@
-use super::{ApproveBuildsError, partition_params, sort_unique};
+use pnpm_reporter::SilentReporter;
+
+use super::{ApproveBuildsArgs, ApproveBuildsError, partition_params, sort_unique};
 
 fn pending(names: &[&str]) -> Vec<String> {
     names.iter().map(|name| (*name).to_string()).collect()
@@ -8,36 +10,68 @@ fn params(args: &[&str]) -> Vec<String> {
     args.iter().map(|arg| (*arg).to_string()).collect()
 }
 
+fn args(packages: &[&str]) -> ApproveBuildsArgs {
+    ApproveBuildsArgs { packages: params(packages), all: false, global: false }
+}
+
+fn approve_builds_error(report: miette::Report) -> ApproveBuildsError {
+    report.downcast::<ApproveBuildsError>().expect("an approve-builds error")
+}
+
 #[test]
 fn splits_approved_and_denied() {
-    let (approved, denied) =
-        partition_params(&params(&["foo", "!bar"]), &pending(&["foo", "bar"])).unwrap();
-    assert_eq!(approved, vec!["foo".to_string()]);
-    assert_eq!(denied, vec!["bar".to_string()]);
+    let partition = partition_params(&params(&["foo", "!bar"]), &pending(&["foo", "bar"]));
+    assert_eq!(partition.approved, vec!["foo".to_string()]);
+    assert_eq!(partition.denied, vec!["bar".to_string()]);
+    assert!(partition.unknown.is_empty());
 }
 
 #[test]
-fn accepts_unknown_approved_package() {
-    let (approved, denied) = partition_params(&params(&["nope"]), &pending(&["foo"])).unwrap();
-    assert_eq!(approved, vec!["nope".to_string()]);
-    assert!(denied.is_empty());
+fn reports_an_unknown_approved_package_as_pre_emptive() {
+    let partition = partition_params(&params(&["nope"]), &pending(&["foo"]));
+    assert_eq!(partition.approved, vec!["nope".to_string()]);
+    assert!(partition.denied.is_empty());
+    assert_eq!(partition.unknown, vec!["nope".to_string()]);
 }
 
 #[test]
-fn accepts_unknown_denied_package() {
-    let (approved, denied) = partition_params(&params(&["!nope"]), &pending(&["foo"])).unwrap();
-    assert!(approved.is_empty());
-    assert_eq!(denied, vec!["nope".to_string()]);
+fn reports_an_unknown_denied_package_as_pre_emptive() {
+    let partition = partition_params(&params(&["!nope"]), &pending(&["foo"]));
+    assert!(partition.approved.is_empty());
+    assert_eq!(partition.denied, vec!["nope".to_string()]);
+    assert_eq!(partition.unknown, vec!["nope".to_string()]);
 }
 
 // Ports pnpm's `contradictory arguments throw error`.
 #[test]
 fn rejects_contradictory_arguments() {
-    let err = partition_params(&params(&["foo", "!foo"]), &pending(&["foo"])).unwrap_err();
-    let ApproveBuildsError::ContradictingArgs(names) = err else {
-        panic!("expected ContradictingArgs, got {err:?}");
+    let err = args(&["foo", "!foo"])
+        .decide::<SilentReporter>(&pending(&["foo"]))
+        .err()
+        .expect("contradicting arguments are rejected");
+    let ApproveBuildsError::ContradictingArgs(names) = approve_builds_error(err) else {
+        panic!("expected ContradictingArgs");
     };
     assert_eq!(names, vec!["foo".to_string()]);
+}
+
+#[test]
+fn rejects_an_argument_that_names_no_package() {
+    for packages in [&["!"][..], &[""][..], &["foo", "!"][..]] {
+        let err = args(packages).validate().unwrap_err();
+        assert!(
+            matches!(approve_builds_error(err), ApproveBuildsError::MissingPackage),
+            "expected MissingPackage for {packages:?}",
+        );
+    }
+}
+
+#[test]
+fn rejects_positional_arguments_with_all() {
+    let err = ApproveBuildsArgs { packages: params(&["foo"]), all: true, global: false }
+        .validate()
+        .unwrap_err();
+    assert!(matches!(approve_builds_error(err), ApproveBuildsError::AllWithArgs));
 }
 
 #[test]

--- a/pnpm/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_install.rs
@@ -776,8 +776,14 @@ pub(super) fn approve_builds<'a>(
     // The settings/prompt work is synchronous; only the rebuild is async, so
     // the non-`Send` `config` / `state` closures stay out of the awaited
     // future.
-    let Some((rebuild_state, build_packages)) = args.prepare(ctx.dir, ctx.config, ctx.state)?
-    else {
+    let prepared = match ctx.reporter {
+        ReporterType::Default | ReporterType::AppendOnly => {
+            args.prepare::<DefaultReporter>(ctx.dir, ctx.config, ctx.state)
+        }
+        ReporterType::Ndjson => args.prepare::<NdjsonReporter>(ctx.dir, ctx.config, ctx.state),
+        ReporterType::Silent => args.prepare::<SilentReporter>(ctx.dir, ctx.config, ctx.state),
+    };
+    let Some((rebuild_state, build_packages)) = prepared? else {
         return Ok(Box::pin(std::future::ready(Ok(()))));
     };
     let selected =

--- a/pnpm/crates/cli/src/cli_args/global.rs
+++ b/pnpm/crates/cli/src/cli_args/global.rs
@@ -980,12 +980,12 @@ pub async fn approve_global_builds<Reporter: self::Reporter + 'static>(
         }
         groups.push((package.install_dir, scan));
     }
-    if pending.is_empty() {
+    if pending.is_empty() && args.packages.is_empty() {
         println!("There are no packages awaiting approval");
         return Ok(());
     }
     let pending = pending.into_iter().collect::<Vec<_>>();
-    let Some(decision) = args.decide(&pending)? else {
+    let Some(decision) = args.decide::<Reporter>(&pending)? else {
         return Ok(());
     };
 
@@ -1060,7 +1060,7 @@ async fn prompt_approve_global_builds<Reporter: self::Reporter + 'static>(
 
     let args = ApproveBuildsArgs { packages: Vec::new(), all: auto_approve, global: false };
     if let Some((rebuild_state, build_packages)) =
-        args.prepare(global_pkg_dir, &config_fn, &state_fn)?
+        args.prepare::<Reporter>(global_pkg_dir, &config_fn, &state_fn)?
     {
         let selection = crate::cli_args::rebuild::RebuildSelection {
             names: Some(build_packages),

--- a/pnpm/crates/cli/tests/suite/add.rs
+++ b/pnpm/crates/cli/tests/suite/add.rs
@@ -370,8 +370,8 @@ fn add_accepts_dir_allow_build_and_registry_after_the_subcommand() {
     drop((root, mock_instance));
 }
 
-/// `--allow-build=!<pkg>` denies the build instead of recording a literal
-/// `!<pkg>` key that matches nothing.
+/// `--allow-build=!<pkg>` denies the package's build: `allowBuilds` records
+/// `<pkg>: false` and the install script does not run.
 #[test]
 fn add_denies_a_build_with_the_negation_prefix() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =

--- a/pnpm/crates/cli/tests/suite/add.rs
+++ b/pnpm/crates/cli/tests/suite/add.rs
@@ -370,6 +370,44 @@ fn add_accepts_dir_allow_build_and_registry_after_the_subcommand() {
     drop((root, mock_instance));
 }
 
+/// `--allow-build=!<pkg>` denies the build instead of recording a literal
+/// `!<pkg>` key that matches nothing.
+#[test]
+fn add_denies_a_build_with_the_negation_prefix() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    let registry = mock_instance.url();
+
+    pacquet
+        .with_args([
+            "add",
+            "@pnpm.e2e/pre-and-postinstall-scripts-example@1.0.0",
+            "--allow-build=!@pnpm.e2e/pre-and-postinstall-scripts-example",
+        ])
+        .with_arg(format!("--registry={registry}"))
+        .assert()
+        .success();
+
+    let pkg_dir = workspace.join(
+        "node_modules/.pnpm/@pnpm.e2e+pre-and-postinstall-scripts-example@1.0.0\
+         /node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example",
+    );
+    assert!(
+        !pkg_dir.join("generated-by-postinstall.js").exists(),
+        "a denied package must not run its postinstall",
+    );
+
+    let yaml = std::fs::read_to_string(workspace.join("pnpm-workspace.yaml"))
+        .expect("pnpm-workspace.yaml present");
+    assert!(
+        yaml.contains("'@pnpm.e2e/pre-and-postinstall-scripts-example': false"),
+        "the denial should be persisted, got:\n{yaml}",
+    );
+
+    drop((root, mock_instance));
+}
+
 #[test]
 fn should_install_all_dependencies() {
     let (root, workspace, anchor) =

--- a/pnpm/crates/cli/tests/suite/approve_builds.rs
+++ b/pnpm/crates/cli/tests/suite/approve_builds.rs
@@ -292,6 +292,44 @@ fn approve_builds_with_nothing_pending_reports_so() {
     drop(harness);
 }
 
+/// Pre-emptive denial: `!<pkg>` is recorded even when the package is not
+/// installed yet, with a warning that the package is not awaiting approval
+/// so a typo stays visible.
+#[test]
+fn approve_builds_denies_a_package_that_is_not_installed_yet() {
+    let harness = CommandTempCwd::init().add_mocked_registry();
+    let workspace = harness.workspace.clone();
+    fs::write(workspace.join("package.json"), "{}").expect("write package.json");
+    pacquet(&workspace).with_arg("install").assert().success();
+
+    let deny_install = format!("!{INSTALL}");
+    let output =
+        stdout_of(pacquet(&workspace).with_args(["approve-builds", &deny_install]).assert());
+    assert!(
+        output.contains(&format!("The following packages are not awaiting approval: {INSTALL}")),
+        "output: {output}",
+    );
+    assert_eq!(
+        allow_builds(&workspace),
+        std::collections::BTreeMap::from([(INSTALL.to_string(), false)]),
+    );
+
+    drop(harness);
+}
+
+#[test]
+fn approve_builds_rejects_an_argument_that_names_no_package() {
+    let CommandTempCwd { workspace, root, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("package.json"), "{}").expect("write package.json");
+
+    let assert = pacquet(&workspace).with_args(["approve-builds", "!"]).assert().failure();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr).into_owned();
+    assert!(stderr.contains("ERR_PNPM_APPROVE_BUILDS_MISSING_PACKAGE"), "stderr: {stderr}");
+    assert!(!workspace.join("pnpm-workspace.yaml").exists(), "a rejected run persists nothing");
+
+    drop(root);
+}
+
 #[test]
 fn rebuild_reruns_an_approved_build() {
     let (harness, workspace) = install_with_ignored_build();

--- a/pnpm/crates/deps-restorer/src/build_modules.rs
+++ b/pnpm/crates/deps-restorer/src/build_modules.rs
@@ -10,6 +10,7 @@ pub(crate) mod slots;
 
 pub use allow_build_policy::{
     AllowBuildPolicy, allow_build_key_from_ignored_build, normalize_build_dep_path,
+    parse_allow_build_selector,
 };
 pub(crate) use build_one_snapshot::build_one_snapshot;
 pub use slots::parse_name_version_from_key;

--- a/pnpm/crates/deps-restorer/src/build_modules/allow_build_policy.rs
+++ b/pnpm/crates/deps-restorer/src/build_modules/allow_build_policy.rs
@@ -198,6 +198,9 @@ pub fn allow_build_key_from_ignored_build(dep_path: &str) -> String {
 /// The package an `--allow-build` value or an `approve-builds` argument
 /// names, and whether it is allowed to build: a leading `!` denies the
 /// build.
+///
+/// A selector that is empty or only `!` yields an empty name. Callers
+/// reject that rather than persist an empty `allowBuilds` key.
 #[must_use]
 pub fn parse_allow_build_selector(selector: &str) -> (&str, bool) {
     match selector.strip_prefix('!') {

--- a/pnpm/crates/deps-restorer/src/build_modules/allow_build_policy.rs
+++ b/pnpm/crates/deps-restorer/src/build_modules/allow_build_policy.rs
@@ -195,6 +195,17 @@ pub fn allow_build_key_from_ignored_build(dep_path: &str) -> String {
     }
 }
 
+/// The package an `--allow-build` value or an `approve-builds` argument
+/// names, and whether it is allowed to build: a leading `!` denies the
+/// build.
+#[must_use]
+pub fn parse_allow_build_selector(selector: &str) -> (&str, bool) {
+    match selector.strip_prefix('!') {
+        Some(name) => (name, false),
+        None => (selector, true),
+    }
+}
+
 /// Split a peer-suffix-free depPath / pkgId into its `name` and `version`
 /// (with any `(patch_hash=…)` segment stripped) — the half of depPath
 /// parsing that [`allow_build_key_from_ignored_build`] consumes. Returns

--- a/pnpm11/building/commands/src/policy/approveBuilds.ts
+++ b/pnpm11/building/commands/src/policy/approveBuilds.ts
@@ -9,7 +9,7 @@ import { PnpmError } from '@pnpm/error'
 import { scanGlobalPackages } from '@pnpm/global.packages'
 import { install } from '@pnpm/installing.commands'
 import { type Modules, writeModulesManifest } from '@pnpm/installing.modules-yaml'
-import { globalInfo } from '@pnpm/logger'
+import { globalInfo, globalWarn } from '@pnpm/logger'
 import { lexCompare } from '@pnpm/text.ordinal-comparator'
 import { readWorkspaceManifest } from '@pnpm/workspace.workspace-manifest-reader'
 import chalk from 'chalk'
@@ -85,7 +85,7 @@ export async function handler (opts: ApproveBuildsCommandOpts & RebuildCommandOp
   }
   const targets = await getApprovalTargets(opts)
   const automaticallyIgnoredBuilds = sortUniqueStrings(targets.flatMap((target) => target.automaticallyIgnoredBuilds ?? []))
-  if (!automaticallyIgnoredBuilds.length) {
+  if (!automaticallyIgnoredBuilds.length && !params.length) {
     globalInfo('There are no packages awaiting approval')
     return
   }
@@ -96,17 +96,15 @@ export async function handler (opts: ApproveBuildsCommandOpts & RebuildCommandOp
     const name = p.startsWith('!') ? p.slice(1) : p
     if (!automaticallyIgnoredBuilds.includes(name)) {
       unknown.push(name)
-    } else if (p.startsWith('!')) {
+    }
+    if (p.startsWith('!')) {
       denied.push(name)
     } else {
       approved.push(name)
     }
   }
   if (unknown.length) {
-    throw new PnpmError(
-      'APPROVE_BUILDS_UNKNOWN_PACKAGES',
-      `The following packages are not awaiting approval: ${unknown.join(', ')}`
-    )
+    globalWarn(`The following packages are not awaiting approval: ${unknown.join(', ')}`)
   }
   const contradictions = approved.filter((p) => denied.includes(p))
   if (contradictions.length) {

--- a/pnpm11/building/commands/src/policy/approveBuilds.ts
+++ b/pnpm11/building/commands/src/policy/approveBuilds.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 
 import { checkbox, confirm } from '@inquirer/prompts'
-import { allowBuildKeyFromIgnoredBuild } from '@pnpm/building.policy'
+import { allowBuildKeyFromIgnoredBuild, parseAllowBuildSelector } from '@pnpm/building.policy'
 import type { CommandHandlerMap } from '@pnpm/cli.command'
 import type { Config, ConfigContext } from '@pnpm/config.reader'
 import { writeSettings } from '@pnpm/config.writer'
@@ -83,6 +83,12 @@ export async function handler (opts: ApproveBuildsCommandOpts & RebuildCommandOp
       'Cannot use --all with positional arguments'
     )
   }
+  if (params.some((param) => parseAllowBuildSelector(param).name === '')) {
+    throw new PnpmError(
+      'APPROVE_BUILDS_MISSING_PACKAGE',
+      'A package name is missing from the arguments. Please specify the package name(s) to approve (`<pkg>`) or deny (`!<pkg>`).'
+    )
+  }
   const targets = await getApprovalTargets(opts)
   const automaticallyIgnoredBuilds = sortUniqueStrings(targets.flatMap((target) => target.automaticallyIgnoredBuilds ?? []))
   if (!automaticallyIgnoredBuilds.length && !params.length) {
@@ -93,14 +99,14 @@ export async function handler (opts: ApproveBuildsCommandOpts & RebuildCommandOp
   const approved: string[] = []
   const unknown: string[] = []
   for (const p of params) {
-    const name = p.startsWith('!') ? p.slice(1) : p
+    const { name, allowed } = parseAllowBuildSelector(p)
     if (!automaticallyIgnoredBuilds.includes(name)) {
       unknown.push(name)
     }
-    if (p.startsWith('!')) {
-      denied.push(name)
-    } else {
+    if (allowed) {
       approved.push(name)
+    } else {
+      denied.push(name)
     }
   }
   if (unknown.length) {

--- a/pnpm11/building/commands/test/policy/approveBuilds.test.ts
+++ b/pnpm11/building/commands/test/policy/approveBuilds.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import { expect, jest, test } from '@jest/globals'
+import { beforeEach, expect, jest, test } from '@jest/globals'
 import type { ApproveBuildsCommandOpts, RebuildCommandOpts } from '@pnpm/building.commands'
 import { getConfig } from '@pnpm/config.reader'
 import { readModulesManifest } from '@pnpm/installing.modules-yaml'
@@ -31,11 +31,23 @@ jest.unstable_mockModule('@inquirer/prompts', () => {
     select: jest.fn(),
   }
 })
+const actualLogger = await import('@pnpm/logger')
+jest.unstable_mockModule('@pnpm/logger', () => ({
+  ...actualLogger,
+  globalWarn: jest.fn(),
+}))
+
 const { checkbox, confirm } = await import('@inquirer/prompts')
+const { globalWarn } = await import('@pnpm/logger')
 const { approveBuilds } = await import('@pnpm/building.commands')
 
 const mockCheckbox = jest.mocked(checkbox)
 const mockConfirm = jest.mocked(confirm)
+const mockGlobalWarn = jest.mocked(globalWarn)
+
+beforeEach(() => {
+  mockGlobalWarn.mockClear()
+})
 
 const REGISTRY = `http://localhost:${REGISTRY_MOCK_PORT}/`
 const pnpmBin = path.join(import.meta.dirname, '../../../../pnpm/bin/pnpm.mjs')
@@ -335,6 +347,7 @@ test('positional arguments with unknown package updates allowBuilds setting with
 
   await approveBuilds.handler(config, ['@pnpm.e2e/nonexistent-package'], {})
 
+  expect(mockGlobalWarn).toHaveBeenCalledWith('The following packages are not awaiting approval: @pnpm.e2e/nonexistent-package')
   const workspaceManifest = readYamlFileSync<any>(path.resolve('pnpm-workspace.yaml')) // eslint-disable-line
   expect(workspaceManifest.allowBuilds).toStrictEqual({
     '@pnpm.e2e/nonexistent-package': true,
@@ -353,10 +366,48 @@ test('!pkg with unknown package preemptively denies build without error', async 
 
   await approveBuilds.handler(config, ['!@pnpm.e2e/nonexistent-package'], {})
 
+  expect(mockGlobalWarn).toHaveBeenCalledWith('The following packages are not awaiting approval: @pnpm.e2e/nonexistent-package')
   const workspaceManifest = readYamlFileSync<any>(path.resolve('pnpm-workspace.yaml')) // eslint-disable-line
   expect(workspaceManifest.allowBuilds).toStrictEqual({
     '@pnpm.e2e/nonexistent-package': false,
   })
+})
+
+test('!pkg is recorded preemptively when no builds are awaiting approval', async () => {
+  prepare({})
+
+  await execPnpmInstall()
+  const config = await getApproveBuildsConfig()
+
+  await approveBuilds.handler(config, ['!@pnpm.e2e/pre-and-postinstall-scripts-example'], {})
+
+  expect(mockGlobalWarn).toHaveBeenCalledWith('The following packages are not awaiting approval: @pnpm.e2e/pre-and-postinstall-scripts-example')
+  const workspaceManifest = readYamlFileSync<any>(path.resolve('pnpm-workspace.yaml')) // eslint-disable-line
+  expect(workspaceManifest.allowBuilds).toStrictEqual({
+    '@pnpm.e2e/pre-and-postinstall-scripts-example': false,
+  })
+})
+
+test('no arguments and no pending builds writes nothing', async () => {
+  prepare({})
+
+  await execPnpmInstall()
+  const config = await getApproveBuildsConfig()
+
+  await approveBuilds.handler(config, [], {})
+
+  expect(fs.existsSync(path.resolve('pnpm-workspace.yaml'))).toBe(false)
+})
+
+test('an argument that names no package throws an error', async () => {
+  prepare({})
+
+  await execPnpmInstall()
+  const config = await getApproveBuildsConfig()
+
+  await expect(
+    approveBuilds.handler(config, ['!'], {})
+  ).rejects.toThrow('A package name is missing from the arguments')
 })
 
 test('contradictory arguments throw error', async () => {

--- a/pnpm11/building/commands/test/policy/approveBuilds.test.ts
+++ b/pnpm11/building/commands/test/policy/approveBuilds.test.ts
@@ -323,7 +323,7 @@ test('deny-only via !pkg keeps other builds pending', async () => {
   expect(ignoredNames.some((dp) => dp.includes('pre-and-postinstall-scripts-example'))).toBe(true)
 })
 
-test('positional arguments with unknown package throws error', async () => {
+test('positional arguments with unknown package updates allowBuilds setting without error', async () => {
   prepare({
     dependencies: {
       '@pnpm.e2e/pre-and-postinstall-scripts-example': '1.0.0',
@@ -333,12 +333,15 @@ test('positional arguments with unknown package throws error', async () => {
   await execPnpmInstall()
   const config = await getApproveBuildsConfig()
 
-  await expect(
-    approveBuilds.handler(config, ['@pnpm.e2e/nonexistent-package'], {})
-  ).rejects.toThrow('not awaiting approval')
+  await approveBuilds.handler(config, ['@pnpm.e2e/nonexistent-package'], {})
+
+  const workspaceManifest = readYamlFileSync<any>(path.resolve('pnpm-workspace.yaml')) // eslint-disable-line
+  expect(workspaceManifest.allowBuilds).toStrictEqual({
+    '@pnpm.e2e/nonexistent-package': true,
+  })
 })
 
-test('!pkg with unknown package throws error', async () => {
+test('!pkg with unknown package preemptively denies build without error', async () => {
   prepare({
     dependencies: {
       '@pnpm.e2e/pre-and-postinstall-scripts-example': '1.0.0',
@@ -348,9 +351,12 @@ test('!pkg with unknown package throws error', async () => {
   await execPnpmInstall()
   const config = await getApproveBuildsConfig()
 
-  await expect(
-    approveBuilds.handler(config, ['!@pnpm.e2e/nonexistent-package'], {})
-  ).rejects.toThrow('not awaiting approval')
+  await approveBuilds.handler(config, ['!@pnpm.e2e/nonexistent-package'], {})
+
+  const workspaceManifest = readYamlFileSync<any>(path.resolve('pnpm-workspace.yaml')) // eslint-disable-line
+  expect(workspaceManifest.allowBuilds).toStrictEqual({
+    '@pnpm.e2e/nonexistent-package': false,
+  })
 })
 
 test('contradictory arguments throw error', async () => {

--- a/pnpm11/building/policy/src/index.ts
+++ b/pnpm11/building/policy/src/index.ts
@@ -121,6 +121,9 @@ export function packageNameFromAllowBuildKey (key: string): string | undefined {
 /**
  * The package an `--allow-build` value or an `approve-builds` argument names,
  * and whether it is allowed to build: a leading `!` denies the build.
+ *
+ * A selector that is empty or only `!` yields an empty name. Callers reject
+ * that rather than persist an empty `allowBuilds` key.
  */
 export function parseAllowBuildSelector (selector: string): { name: string, allowed: boolean } {
   return selector.startsWith('!')

--- a/pnpm11/building/policy/src/index.ts
+++ b/pnpm11/building/policy/src/index.ts
@@ -118,6 +118,16 @@ export function packageNameFromAllowBuildKey (key: string): string | undefined {
   return name
 }
 
+/**
+ * The package an `--allow-build` value or an `approve-builds` argument names,
+ * and whether it is allowed to build: a leading `!` denies the build.
+ */
+export function parseAllowBuildSelector (selector: string): { name: string, allowed: boolean } {
+  return selector.startsWith('!')
+    ? { name: selector.slice(1), allowed: false }
+    : { name: selector, allowed: true }
+}
+
 function addAllowBuildRule (
   pkg: string,
   target: {

--- a/pnpm11/global/commands/src/globalAdd.ts
+++ b/pnpm11/global/commands/src/globalAdd.ts
@@ -27,7 +27,7 @@ export type GlobalAddOptions = CreateStoreControllerOptions & {
   bin?: string
   globalPkgDir?: string
   registriesByScope: Record<string, string>
-  allowBuild?: string[]
+  /** Already merged with the `--allow-build` selectors by `add`'s handler. */
   allowBuilds?: Record<string, string | boolean>
   saveExact?: boolean
   savePrefix?: string
@@ -45,14 +45,7 @@ export async function handleGlobalAdd (
   const globalBinDir = opts.bin!
   cleanOrphanedInstallDirs(globalDir)
 
-  // Convert allowBuild array to allowBuilds Record (same conversion as add.handler)
-  let allowBuilds = opts.allowBuilds ?? {}
-  if (opts.allowBuild?.length) {
-    allowBuilds = { ...allowBuilds }
-    for (const pkg of opts.allowBuild) {
-      allowBuilds[pkg] = true
-    }
-  }
+  const allowBuilds = opts.allowBuilds ?? {}
 
   // Each space-separated CLI param becomes its own isolated install group.
   // A param containing commas is split into multiple selectors that share a

--- a/pnpm11/installing/commands/src/add.ts
+++ b/pnpm11/installing/commands/src/add.ts
@@ -1,3 +1,4 @@
+import { parseAllowBuildSelector } from '@pnpm/building.policy'
 import type { CommandHandlerMap } from '@pnpm/cli.command'
 import { FILTERING, OPTIONS, UNIVERSAL_OPTIONS } from '@pnpm/cli.common-cli-options-help'
 import { docsUrl } from '@pnpm/cli.utils'
@@ -183,7 +184,7 @@ For options that may be used with `-r`, see "pnpm help recursive"',
           OPTIONS.globalDir,
           ...UNIVERSAL_OPTIONS,
           {
-            description: 'A list of package names that are allowed to run postinstall scripts during installation',
+            description: 'A list of package names that are allowed to run postinstall scripts during installation. Prefix a name with ! to deny its scripts instead',
             name: '--allow-build',
           },
         ],
@@ -273,14 +274,15 @@ export async function handler (
     optionalDependencies: opts.optional !== false,
   }
   if (opts.allowBuild?.length) {
-    if (opts.argv.original.includes('--allow-build')) {
+    const allowBuildSelectors = opts.allowBuild.map(parseAllowBuildSelector)
+    if (opts.argv.original.includes('--allow-build') || allowBuildSelectors.some(({ name }) => name === '')) {
       throw new PnpmError('ALLOW_BUILD_MISSING_PACKAGE', 'The --allow-build flag is missing a package name. Please specify the package name(s) that are allowed to run installation scripts.')
     }
     if (opts.allowBuilds) {
       const disallowedBuilds = Object.entries(opts.allowBuilds)
         .filter(([, value]) => value === false)
         .map(([pkg]) => pkg)
-      const allowedOnly = opts.allowBuild.filter((pkg) => !pkg.startsWith('!'))
+      const allowedOnly = allowBuildSelectors.filter(({ allowed }) => allowed).map(({ name }) => name)
       const overlapDependencies = disallowedBuilds.filter((dep) => allowedOnly.includes(dep))
       if (overlapDependencies.length) {
         throw new PnpmError('OVERRIDING_IGNORED_BUILT_DEPENDENCIES', `The following dependencies are ignored by the root project, but are allowed to be built by the current command: ${overlapDependencies.join(', ')}`, {
@@ -289,10 +291,8 @@ export async function handler (
       }
     }
     const allowBuilds = { ...opts.allowBuilds }
-    for (const pkg of opts.allowBuild) {
-      const isNegated = pkg.startsWith('!')
-      const name = isNegated ? pkg.slice(1) : pkg
-      allowBuilds[name] = !isNegated
+    for (const { name, allowed } of allowBuildSelectors) {
+      allowBuilds[name] = allowed
     }
     if (opts.rootProjectManifestDir) {
       opts.rootProjectManifest = opts.rootProjectManifest ?? {}

--- a/pnpm11/installing/commands/src/add.ts
+++ b/pnpm11/installing/commands/src/add.ts
@@ -280,7 +280,8 @@ export async function handler (
       const disallowedBuilds = Object.entries(opts.allowBuilds)
         .filter(([, value]) => value === false)
         .map(([pkg]) => pkg)
-      const overlapDependencies = disallowedBuilds.filter((dep) => opts.allowBuild?.includes(dep))
+      const allowedOnly = opts.allowBuild.filter((pkg) => !pkg.startsWith('!'))
+      const overlapDependencies = disallowedBuilds.filter((dep) => allowedOnly.includes(dep))
       if (overlapDependencies.length) {
         throw new PnpmError('OVERRIDING_IGNORED_BUILT_DEPENDENCIES', `The following dependencies are ignored by the root project, but are allowed to be built by the current command: ${overlapDependencies.join(', ')}`, {
           hint: 'If you are sure you want to allow those dependencies to run installation scripts, remove them from the allowBuilds list (or change their value to true).',
@@ -289,7 +290,9 @@ export async function handler (
     }
     const allowBuilds = { ...opts.allowBuilds }
     for (const pkg of opts.allowBuild) {
-      allowBuilds[pkg] = true
+      const isNegated = pkg.startsWith('!')
+      const name = isNegated ? pkg.slice(1) : pkg
+      allowBuilds[name] = !isNegated
     }
     if (opts.rootProjectManifestDir) {
       opts.rootProjectManifest = opts.rootProjectManifest ?? {}

--- a/pnpm11/installing/commands/src/add.ts
+++ b/pnpm11/installing/commands/src/add.ts
@@ -253,6 +253,13 @@ export async function handler (
       'If you don\'t want to see this warning anymore, you may set the ignore-workspace-root-check setting to true.'
     )
   }
+  const allowBuildSelectors = opts.allowBuild?.map(parseAllowBuildSelector) ?? []
+  if (
+    allowBuildSelectors.length &&
+    (opts.argv.original.includes('--allow-build') || allowBuildSelectors.some(({ name }) => name === ''))
+  ) {
+    throw new PnpmError('ALLOW_BUILD_MISSING_PACKAGE', 'The --allow-build flag is missing a package name. Please specify the package name(s) that are allowed to run installation scripts.')
+  }
   if (opts.global) {
     if (!opts.bin) {
       throw new PnpmError('NO_GLOBAL_BIN_DIR', 'Unable to find the global bin directory', {
@@ -264,6 +271,7 @@ export async function handler (
     }
     return handleGlobalAdd({
       ...opts,
+      allowBuilds: applyAllowBuildSelectors(opts.allowBuilds, allowBuildSelectors),
       ...createGlobalPolicyCallbacks(opts),
     }, params, commands ?? {})
   }
@@ -273,11 +281,7 @@ export async function handler (
     devDependencies: opts.dev !== false,
     optionalDependencies: opts.optional !== false,
   }
-  if (opts.allowBuild?.length) {
-    const allowBuildSelectors = opts.allowBuild.map(parseAllowBuildSelector)
-    if (opts.argv.original.includes('--allow-build') || allowBuildSelectors.some(({ name }) => name === '')) {
-      throw new PnpmError('ALLOW_BUILD_MISSING_PACKAGE', 'The --allow-build flag is missing a package name. Please specify the package name(s) that are allowed to run installation scripts.')
-    }
+  if (allowBuildSelectors.length) {
     if (opts.allowBuilds) {
       const disallowedBuilds = Object.entries(opts.allowBuilds)
         .filter(([, value]) => value === false)
@@ -290,10 +294,7 @@ export async function handler (
         })
       }
     }
-    const allowBuilds = { ...opts.allowBuilds }
-    for (const { name, allowed } of allowBuildSelectors) {
-      allowBuilds[name] = allowed
-    }
+    const allowBuilds = applyAllowBuildSelectors(opts.allowBuilds, allowBuildSelectors)
     if (opts.rootProjectManifestDir) {
       opts.rootProjectManifest = opts.rootProjectManifest ?? {}
       await writeSettings({
@@ -323,4 +324,15 @@ export async function handler (
     includeDirect: include,
     dryRun: false,
   }, params)
+}
+
+function applyAllowBuildSelectors (
+  allowBuilds: Record<string, boolean | string> | undefined,
+  selectors: Array<ReturnType<typeof parseAllowBuildSelector>>
+): Record<string, boolean | string> {
+  const updated = { ...allowBuilds }
+  for (const { name, allowed } of selectors) {
+    updated[name] = allowed
+  }
+  return updated
 }

--- a/pnpm11/pnpm/test/install/global.ts
+++ b/pnpm11/pnpm/test/install/global.ts
@@ -163,6 +163,30 @@ test('run lifecycle events of global packages in correct working directory', asy
   expect(fs.existsSync(path.join(pkgPath!, 'created-by-postinstall'))).toBeTruthy()
 })
 
+// A denial has to survive the post-install approval prompt: an undecided
+// package is offered for approval, an explicitly denied one is not. The
+// auto-approve env var stands in for a user who approves everything
+// pending, so the build artifact appears only if the `!` was dropped.
+test('global add denies scripts for a package prefixed with ! in --allow-build', async () => {
+  prepare()
+  const global = path.resolve('..', 'global')
+  const pnpmHome = path.join(global, 'pnpm')
+  fs.mkdirSync(pnpmHome, { recursive: true })
+
+  const env = {
+    [PATH_NAME]: `${path.join(pnpmHome, 'bin')}${path.delimiter}${process.env[PATH_NAME]!}`,
+    PNPM_HOME: pnpmHome,
+    XDG_DATA_HOME: global,
+    PNPM_AUTO_APPROVE_BUILDS_FOR_TESTS: '1',
+  }
+
+  await execPnpm(['add', '-g', '--allow-build=!@pnpm.e2e/install-script-example', '@pnpm.e2e/install-script-example@1.0.0'], { env })
+
+  const pkgPath = findGlobalPkg(globalPkgDir(pnpmHome), '@pnpm.e2e/install-script-example')
+  expect(pkgPath).toBeTruthy()
+  expect(fs.existsSync(path.join(pkgPath!, 'generated-by-install.js'))).toBe(false)
+})
+
 // Regression test for https://github.com/pnpm/pnpm/issues/11403.
 //
 // When `pnpm add -g` installs a package whose build is not pre-allowed,

--- a/pnpm11/pnpm/test/install/lifecycleScripts.ts
+++ b/pnpm11/pnpm/test/install/lifecycleScripts.ts
@@ -183,6 +183,18 @@ test('selectively allow scripts in some dependencies by --allow-build flag', asy
   })
 })
 
+test('--allow-build denies scripts for a package prefixed with !', async () => {
+  const project = prepare({})
+  execPnpmSync(['add', '--allow-build=!@pnpm.e2e/install-script-example', '@pnpm.e2e/install-script-example'], { expectSuccess: true })
+
+  expect(fs.existsSync('node_modules/@pnpm.e2e/install-script-example/generated-by-install.js')).toBeFalsy()
+
+  const workspaceManifest = await readWorkspaceManifest(project.dir())
+  expect(workspaceManifest?.allowBuilds).toStrictEqual({
+    '@pnpm.e2e/install-script-example': false,
+  })
+})
+
 test('--allow-build flag keeps the packages already listed in allowBuilds', async () => {
   const project = prepare({})
   writeYamlFileSync('pnpm-workspace.yaml', {
@@ -203,10 +215,12 @@ test('--allow-build flag keeps the packages already listed in allowBuilds', asyn
 
 test('--allow-build flag should specify the package', async () => {
   const project = prepare({})
-  const result = execPnpmSync(['add', '@pnpm.e2e/pre-and-postinstall-scripts-example@1.0.0', '--allow-build'])
+  for (const allowBuild of ['--allow-build', '--allow-build=!']) {
+    const result = execPnpmSync(['add', '@pnpm.e2e/pre-and-postinstall-scripts-example@1.0.0', allowBuild])
 
-  expect(result.status).toBe(1)
-  expect(result.stdout.toString()).toContain('The --allow-build flag is missing a package name. Please specify the package name(s) that are allowed to run installation scripts.')
+    expect(result.status).toBe(1)
+    expect(result.stdout.toString()).toContain('The --allow-build flag is missing a package name. Please specify the package name(s) that are allowed to run installation scripts.')
+  }
 
   expect(fs.existsSync('node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example/generated-by-preinstall.js')).toBeFalsy()
   expect(fs.existsSync('node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example/generated-by-postinstall.js')).toBeFalsy()


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#14067

Makes it possible to reject a package's lifecycle scripts before the package is installed:

1. **`--allow-build` negation.** `pnpm add --allow-build=!<pkg>` records `<pkg>: false` in `allowBuilds`, instead of a literal `!<pkg>: true` entry that never matched anything. Global installs included — `pnpm add -g` used to drop the denial entirely.
2. **Pre-emptive `approve-builds`.** `pnpm approve-builds <pkg>` and `pnpm approve-builds !<pkg>` record their decision even when nothing is awaiting approval. A package that is not awaiting approval is reported with a warning rather than an error, so a typo stays visible.

An argument that names no package (a bare `!`, or an empty value) is rejected: `ALLOW_BUILD_MISSING_PACKAGE` for `--allow-build`, `APPROVE_BUILDS_MISSING_PACKAGE` for `approve-builds`.

Implemented in both the TypeScript CLI (`pnpm11/`) and the Rust CLI (`pnpm/`).

## Squash Commit Body

```text
Closes pnpm/pnpm#14067

Support `!<pkg>` negation syntax in `--allow-build` and pre-emptive package
arguments in `pnpm approve-builds`.

- `pnpm add --allow-build=!<pkg>` sets `allowBuilds[<pkg>]` to `false`
  rather than writing a literal `!<pkg>` key.
- `pnpm approve-builds` processes positional arguments even when no builds
  are awaiting approval, and warns about packages that are not awaiting
  approval instead of erroring out. The warning goes through the reporter,
  so it renders as `[WARN]` and is suppressed by `--reporter=silent`.
- An argument that names no package is rejected before anything is
  persisted, so an empty `allowBuilds` key can no longer be written.
- Global installs honor the negation too: `pnpm add -g` used to drop the
  denial, leaving the package undecided so the post-install approval
  prompt offered the build the user had just rejected.
- A package that was not awaiting approval is not rebuilt: it is not
  installed yet, and the rebuild would demand a lockfile the project may
  not have.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14077"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790007728&installation_model_id=426870&pr_number=14077&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14077&signature=4e3e5403e63f8ba8a955f5858ff0e2d25230ab9d1258e629964b4cf91a2a619f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `!<package>` negation support to `--allow-build` and `approve-builds`.
  - Negated packages are recorded as explicitly denied, including during global installs.
  - `approve-builds` accepts package arguments even when no builds are awaiting approval.
- **Bug Fixes**
  - Unknown packages now generate warnings instead of errors while processing continues.
  - Approval and denial decisions are consistently persisted.
  - Empty package selectors now produce a clear validation error.
  - Denied build scripts no longer run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

