### PR TITLE
feat(pacquet): add slow fetch warnings

### DIFF
--- a/.changeset/slow-fetch-warnings.md
+++ b/.changeset/slow-fetch-warnings.md
@@ -1,0 +1,6 @@
+---
+"pacquet": minor
+"@pnpm/napi": minor
+---
+
+Added `fetchWarnTimeoutMs` and `fetchMinSpeedKiBps` to the Rust pnpm CLI and its N-API bindings. Slow registry metadata requests and tarball downloads now emit the same warnings as pnpm 11 [pnpm/pnpm#12042](https://github.com/pnpm/pnpm/issues/12042).

--- a/.changeset/slow-fetch-warnings.md
+++ b/.changeset/slow-fetch-warnings.md
@@ -1,6 +1,10 @@
 ---
 "pacquet": minor
 "@pnpm/napi": minor
+"@pnpm/error": patch
+"@pnpm/resolving.npm-resolver": patch
+"@pnpm/fetching.tarball-fetcher": patch
+"pnpm": patch
 ---
 
-Added `fetchWarnTimeoutMs` and `fetchMinSpeedKiBps` to the Rust pnpm CLI and its N-API bindings. Slow registry metadata requests and tarball downloads now emit the same warnings as pnpm 11 [pnpm/pnpm#12042](https://github.com/pnpm/pnpm/issues/12042).
+Added `fetchWarnTimeoutMs` and `fetchMinSpeedKiBps` to the Rust pnpm CLI and its N-API bindings. Slow registry metadata requests and tarball downloads now emit pnpm-compatible warnings without exposing URL credentials, query parameters, fragments, or control characters [pnpm/pnpm#12042](https://github.com/pnpm/pnpm/issues/12042).

--- a/pnpm/crates/cli/src/cli_args/access.rs
+++ b/pnpm/crates/cli/src/cli_args/access.rs
@@ -4,8 +4,8 @@ use futures_util::StreamExt as _;
 use miette::{Context, Diagnostic, IntoDiagnostic};
 use pnpm_config::Config;
 use pnpm_network::{
-    NetworkSettings, RedirectGuard, RetryOpts, ThrottledClient, encode_uri_component,
-    redact_and_sanitize, send_with_retry,
+    RedirectGuard, RetryOpts, ThrottledClient, encode_uri_component, redact_and_sanitize,
+    send_with_retry,
 };
 use reqwest::{Response, StatusCode};
 use std::{collections::HashMap, sync::Arc, time::Duration};
@@ -800,11 +800,7 @@ fn build_http_client(
         &config.proxy,
         &config.tls,
         &config.tls_by_uri,
-        &NetworkSettings {
-            network_concurrency: config.network_concurrency,
-            fetch_timeout: Duration::from_millis(config.fetch_timeout),
-            user_agent: config.user_agent.clone(),
-        },
+        &config.network_settings(),
         redirect_guard,
     )
     .into_diagnostic()

--- a/pnpm/crates/cli/src/cli_args/deprecate.rs
+++ b/pnpm/crates/cli/src/cli_args/deprecate.rs
@@ -5,8 +5,8 @@ use miette::{Context, Diagnostic, IntoDiagnostic};
 use node_semver::Range;
 use pnpm_config::Config;
 use pnpm_network::{
-    NetworkSettings, RetryOpts, ThrottledClient, encode_uri_component, read_limited_body,
-    redact_url_credentials, retry_async, send_with_retry,
+    RetryOpts, ThrottledClient, encode_uri_component, read_limited_body, redact_url_credentials,
+    retry_async, send_with_retry,
 };
 use pnpm_resolving_npm_resolver::pick_registry_for_package;
 use pnpm_resolving_parse_wanted_dependency::parse_wanted_dependency;
@@ -475,11 +475,7 @@ pub(crate) fn build_http_client(config: &Config) -> miette::Result<ThrottledClie
         &config.proxy,
         &config.tls,
         &config.tls_by_uri,
-        &NetworkSettings {
-            network_concurrency: config.network_concurrency,
-            fetch_timeout: Duration::from_millis(config.fetch_timeout),
-            user_agent: config.user_agent.clone(),
-        },
+        &config.network_settings(),
     )
     .into_diagnostic()
     .wrap_err("create the network client for deprecate")

--- a/pnpm/crates/cli/src/cli_args/dist_tag.rs
+++ b/pnpm/crates/cli/src/cli_args/dist_tag.rs
@@ -5,8 +5,8 @@ use miette::{Context, Diagnostic, IntoDiagnostic};
 use node_semver::Version;
 use pnpm_config::Config;
 use pnpm_network::{
-    NetworkSettings, RetryOpts, ThrottledClient, encode_uri_component, read_limited_body,
-    redact_url_credentials, retry_async, send_with_retry,
+    RetryOpts, ThrottledClient, encode_uri_component, read_limited_body, redact_url_credentials,
+    retry_async, send_with_retry,
 };
 use pnpm_resolving_npm_resolver::pick_registry_for_package;
 use pnpm_resolving_parse_wanted_dependency::parse_wanted_dependency;
@@ -544,11 +544,7 @@ fn build_http_client(config: &Config) -> miette::Result<ThrottledClient> {
         &config.proxy,
         &config.tls,
         &config.tls_by_uri,
-        &NetworkSettings {
-            network_concurrency: config.network_concurrency,
-            fetch_timeout: Duration::from_millis(config.fetch_timeout),
-            user_agent: config.user_agent.clone(),
-        },
+        &config.network_settings(),
     )
     .into_diagnostic()
     .wrap_err("create the network client for dist-tag")

--- a/pnpm/crates/cli/src/cli_args/docs.rs
+++ b/pnpm/crates/cli/src/cli_args/docs.rs
@@ -1,7 +1,7 @@
 use clap::Args;
 use miette::{Context, IntoDiagnostic};
 use pnpm_config::Config;
-use pnpm_network::{NetworkSettings, RetryOpts, ThrottledClient};
+use pnpm_network::{RetryOpts, ThrottledClient};
 use pnpm_package_manifest::PackageManifest;
 use pnpm_resolving_npm_resolver::{
     FetchFullMetadataOptions, FetchFullMetadataOutcome, fetch_full_metadata,
@@ -29,15 +29,10 @@ impl DocsArgs {
             &config.proxy,
             &config.tls,
             &config.tls_by_uri,
-            &NetworkSettings {
-                network_concurrency: config.network_concurrency,
-                fetch_timeout: std::time::Duration::from_millis(config.fetch_timeout),
-                user_agent: config.user_agent.clone(),
-            },
+            &config.network_settings(),
         )
         .into_diagnostic()
         .wrap_err("create the network client for docs")?;
-
         let registries: std::collections::HashMap<String, String> =
             config.resolved_registries().into_iter().collect();
         let registry = pick_registry_for_package(&registries, resolved_name, Some(bare));

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -229,6 +229,15 @@ pub struct InstallArgs {
     #[clap(long = "fetch-timeout")]
     pub fetch_timeout: Option<u64>,
 
+    /// Warn when a registry metadata request takes longer than this many
+    /// milliseconds.
+    #[clap(long = "fetch-warn-timeout-ms")]
+    pub fetch_warn_timeout_ms: Option<u64>,
+
+    /// Warn when a tarball download's average speed is below this many KiB/s.
+    #[clap(long = "fetch-min-speed-ki-bps")]
+    pub fetch_min_speed_ki_bps: Option<u64>,
+
     /// `User-Agent` header to send on registry requests.
     #[clap(long = "user-agent")]
     pub user_agent: Option<String>,
@@ -293,6 +302,8 @@ impl InstallArgs {
             update_checksums: false,
             network_concurrency: None,
             fetch_timeout: None,
+            fetch_warn_timeout_ms: None,
+            fetch_min_speed_ki_bps: None,
             user_agent: None,
             pnpr_server: None,
         }
@@ -429,6 +440,7 @@ impl InstallArgs {
         state: State,
         selection: Option<InstallFamilySelection>,
     ) -> miette::Result<()> {
+        state.http_client.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
         let frozen_lockfile = match self.configured_frozen_lockfile(state.config) {
             Some(value) => value,
             None if state.config.ci
@@ -479,6 +491,8 @@ impl InstallArgs {
             update_checksums,
             network_concurrency: _,
             fetch_timeout: _,
+            fetch_warn_timeout_ms: _,
+            fetch_min_speed_ki_bps: _,
             user_agent: _,
             // Read from `config.pnpr_server` (the CLI flag was already
             // merged in by the dispatch in `cli_args.rs`), not from here.

--- a/pnpm/crates/cli/src/cli_args/install/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/install/tests.rs
@@ -147,6 +147,21 @@ fn frozen_store_flag_parses() {
     assert!(parsed.args.frozen_store, "flag present → true");
 }
 
+#[test]
+fn slow_fetch_warning_flags_parse() {
+    let parsed = InstallArgsHarness::try_parse_from([
+        "pacquet-test",
+        "--fetch-warn-timeout-ms",
+        "2500",
+        "--fetch-min-speed-ki-bps",
+        "125",
+    ])
+    .expect("slow-fetch warning flags parse");
+
+    assert_eq!(parsed.args.fetch_warn_timeout_ms, Some(2_500));
+    assert_eq!(parsed.args.fetch_min_speed_ki_bps, Some(125));
+}
+
 /// `NodeLinkerArg::into_config` maps every variant 1:1 to the
 /// canonical `pnpm_config::NodeLinker` enum. Tied to the
 /// `ValueEnum` derive's kebab-case rename — if a future variant

--- a/pnpm/crates/cli/src/cli_args/login.rs
+++ b/pnpm/crates/cli/src/cli_args/login.rs
@@ -3,14 +3,14 @@
 //! `pnpm-auth-commands`; this module is the thin CLI adapter that resolves
 //! config into [`LoginOptions`].
 
-use std::{path::Path, time::Duration};
+use std::path::Path;
 
 use clap::Args;
 use derive_more::{Display, Error};
 use miette::{Diagnostic, IntoDiagnostic};
 use pnpm_auth_commands::login::{Host as AuthHost, LoginHost, LoginOptions, login};
 use pnpm_config::Config;
-use pnpm_network::{NetworkSettings, ThrottledClient};
+use pnpm_network::ThrottledClient;
 use pnpm_reporter::Reporter;
 
 /// Log in to an npm registry.
@@ -63,11 +63,7 @@ impl LoginArgs {
             &config.proxy,
             &config.tls,
             &config.tls_by_uri,
-            &NetworkSettings {
-                network_concurrency: config.network_concurrency,
-                fetch_timeout: Duration::from_millis(config.fetch_timeout),
-                user_agent: config.user_agent.clone(),
-            },
+            &config.network_settings(),
         )
         .into_diagnostic()?;
 

--- a/pnpm/crates/cli/src/cli_args/logout.rs
+++ b/pnpm/crates/cli/src/cli_args/logout.rs
@@ -10,7 +10,7 @@ use derive_more::{Display, Error};
 use miette::{Diagnostic, IntoDiagnostic};
 use pnpm_auth_commands::logout::{Host as AuthHost, LogoutOptions, logout};
 use pnpm_config::Config;
-use pnpm_network::{NetworkSettings, RetryOpts, ThrottledClient};
+use pnpm_network::{RetryOpts, ThrottledClient};
 use pnpm_reporter::Reporter;
 
 /// Log out of an npm registry.
@@ -46,11 +46,7 @@ impl LogoutArgs {
             &config.proxy,
             &config.tls,
             &config.tls_by_uri,
-            &NetworkSettings {
-                network_concurrency: config.network_concurrency,
-                fetch_timeout: Duration::from_millis(config.fetch_timeout),
-                user_agent: config.user_agent.clone(),
-            },
+            &config.network_settings(),
         )
         .into_diagnostic()?;
 

--- a/pnpm/crates/cli/src/cli_args/owner.rs
+++ b/pnpm/crates/cli/src/cli_args/owner.rs
@@ -3,8 +3,8 @@ use derive_more::{Display, Error};
 use miette::{Diagnostic, IntoDiagnostic, WrapErr};
 use pnpm_config::Config;
 use pnpm_network::{
-    NetworkSettings, RedirectGuard, RetryOpts, ThrottledClient, encode_package_name,
-    encode_uri_component, read_limited_body, redact_url_credentials, send_with_retry,
+    RedirectGuard, RetryOpts, ThrottledClient, encode_package_name, encode_uri_component,
+    read_limited_body, redact_url_credentials, send_with_retry,
 };
 use pnpm_resolving_npm_resolver::pick_registry_for_package;
 use reqwest::Response;
@@ -287,11 +287,7 @@ fn build_http_client(
         &config.proxy,
         &config.tls,
         &config.tls_by_uri,
-        &NetworkSettings {
-            network_concurrency: config.network_concurrency,
-            fetch_timeout: Duration::from_millis(config.fetch_timeout),
-            user_agent: config.user_agent.clone(),
-        },
+        &config.network_settings(),
         redirect_guard,
     )
     .into_diagnostic()

--- a/pnpm/crates/cli/src/cli_args/pack_app.rs
+++ b/pnpm/crates/cli/src/cli_args/pack_app.rs
@@ -22,7 +22,6 @@ use std::{
     fs,
     path::{Component, Path, PathBuf},
     process::Command,
-    time::Duration,
 };
 
 use clap::Args;
@@ -32,7 +31,7 @@ use pnpm_config::{Config, Host};
 use pnpm_engine_runtime_node_resolver::{
     get_node_mirror, parse_node_specifier, resolve_node_version,
 };
-use pnpm_network::{NetworkSettings, ThrottledClient};
+use pnpm_network::ThrottledClient;
 use pnpm_package_manifest::parse_manifest;
 use serde_json::Value;
 
@@ -627,11 +626,7 @@ fn build_http_client(config: &Config) -> miette::Result<ThrottledClient> {
         &config.proxy,
         &config.tls,
         &config.tls_by_uri,
-        &NetworkSettings {
-            network_concurrency: config.network_concurrency,
-            fetch_timeout: Duration::from_millis(config.fetch_timeout),
-            user_agent: config.user_agent.clone(),
-        },
+        &config.network_settings(),
     )
     .into_diagnostic()
     .wrap_err("create the network client for pack-app")

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -684,6 +684,12 @@ pub(crate) fn apply_install_cli_config(cfg: &mut Config, args: &InstallArgs) {
     if let Some(fetch_timeout) = args.fetch_timeout {
         cfg.fetch_timeout = fetch_timeout;
     }
+    if let Some(fetch_warn_timeout_ms) = args.fetch_warn_timeout_ms {
+        cfg.fetch_warn_timeout_ms = fetch_warn_timeout_ms;
+    }
+    if let Some(fetch_min_speed_ki_bps) = args.fetch_min_speed_ki_bps {
+        cfg.fetch_min_speed_ki_bps = fetch_min_speed_ki_bps;
+    }
     if let Some(user_agent) = args.user_agent.clone() {
         cfg.user_agent = user_agent;
     }

--- a/pnpm/crates/cli/src/cli_args/registry_client.rs
+++ b/pnpm/crates/cli/src/cli_args/registry_client.rs
@@ -1,7 +1,6 @@
 use miette::{Context, IntoDiagnostic};
 use pnpm_config::Config;
-use pnpm_network::{NetworkSettings, ThrottledClient};
-use std::time::Duration;
+use pnpm_network::ThrottledClient;
 
 /// Build the network client a one-off registry query (`whoami`, `ping`, ...)
 /// makes its request through, from the same proxy / TLS / timeout config as
@@ -11,11 +10,7 @@ pub fn build_registry_client(config: &Config) -> miette::Result<ThrottledClient>
         &config.proxy,
         &config.tls,
         &config.tls_by_uri,
-        &NetworkSettings {
-            network_concurrency: config.network_concurrency,
-            fetch_timeout: Duration::from_millis(config.fetch_timeout),
-            user_agent: config.user_agent.clone(),
-        },
+        &config.network_settings(),
     )
     .into_diagnostic()
     .wrap_err("create the network client for the registry request")

--- a/pnpm/crates/cli/src/cli_args/repo.rs
+++ b/pnpm/crates/cli/src/cli_args/repo.rs
@@ -4,7 +4,7 @@ use clap::Args;
 use derive_more::{Display, Error};
 use miette::{Context, Diagnostic, IntoDiagnostic};
 use pnpm_config::Config;
-use pnpm_network::{NetworkSettings, RetryOpts, ThrottledClient};
+use pnpm_network::{RetryOpts, ThrottledClient};
 use pnpm_package_manifest::{PackageManifest, PackageManifestError};
 use pnpm_reporter::{LogEvent, LogLevel, PnpmLog, Reporter};
 use pnpm_resolving_npm_resolver::{
@@ -32,15 +32,10 @@ impl RepoArgs {
             &config.proxy,
             &config.tls,
             &config.tls_by_uri,
-            &NetworkSettings {
-                network_concurrency: config.network_concurrency,
-                fetch_timeout: Duration::from_millis(config.fetch_timeout),
-                user_agent: config.user_agent.clone(),
-            },
+            &config.network_settings(),
         )
         .into_diagnostic()
         .wrap_err("create the network client for repo")?;
-
         let registries: HashMap<String, String> =
             config.resolved_registries().into_iter().collect();
 

--- a/pnpm/crates/cli/src/cli_args/self_update/verify_engine.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/verify_engine.rs
@@ -23,8 +23,7 @@ use pnpm_config::Config;
 use pnpm_graph_hasher::{host_arch, host_libc, host_platform};
 use pnpm_lockfile::{EnvLockfile, PackageKey, SnapshotDepRef, SpecifierAndResolution};
 use pnpm_network::{
-    NetworkSettings, RetryOpts, ThrottledClient, encode_package_name, redact_and_sanitize,
-    send_with_retry,
+    RetryOpts, ThrottledClient, encode_package_name, redact_and_sanitize, send_with_retry,
 };
 use serde::Deserialize;
 use std::{collections::BTreeMap, time::Duration};
@@ -702,11 +701,7 @@ fn build_client(config: &Config) -> Result<ThrottledClient, SelfUpdateError> {
         &bootstrap.proxy,
         &bootstrap.tls,
         &bootstrap.tls_by_uri,
-        &NetworkSettings {
-            network_concurrency: config.network_concurrency,
-            fetch_timeout: Duration::from_millis(config.fetch_timeout),
-            user_agent: config.user_agent.clone(),
-        },
+        &config.network_settings(),
     )
     .map_err(|error| SelfUpdateError::EngineIdentityUnverifiable {
         message: format!("could not build the network client to verify the pnpm release: {error}"),

--- a/pnpm/crates/cli/src/cli_args/team.rs
+++ b/pnpm/crates/cli/src/cli_args/team.rs
@@ -5,8 +5,8 @@ use futures_util::StreamExt as _;
 use miette::{Diagnostic, IntoDiagnostic, WrapErr};
 use pnpm_config::Config;
 use pnpm_network::{
-    NetworkSettings, RedirectGuard, RetryOpts, ThrottledClient, encode_uri_component,
-    redact_url_credentials, send_with_retry,
+    RedirectGuard, RetryOpts, ThrottledClient, encode_uri_component, redact_url_credentials,
+    send_with_retry,
 };
 use pnpm_resolving_npm_resolver::pick_registry_for_package;
 use reqwest::Response;
@@ -614,11 +614,7 @@ fn build_http_client(
         &config.proxy,
         &config.tls,
         &config.tls_by_uri,
-        &NetworkSettings {
-            network_concurrency: config.network_concurrency,
-            fetch_timeout: Duration::from_millis(config.fetch_timeout),
-            user_agent: config.user_agent.clone(),
-        },
+        &config.network_settings(),
         redirect_guard,
     )
     .into_diagnostic()

--- a/pnpm/crates/cli/src/cli_args/update.rs
+++ b/pnpm/crates/cli/src/cli_args/update.rs
@@ -273,6 +273,7 @@ impl UpdateArgs {
         mut state: State,
         selection: InstallFamilySelection,
     ) -> miette::Result<()> {
+        state.http_client.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
         let workspace_packages = self
             .check_workspace_option(state.config.workspace_dir.as_deref())?
             .and_then(|_| build_workspace_packages_map(Some(&selection.projects)));

--- a/pnpm/crates/cli/src/cli_args/update.rs
+++ b/pnpm/crates/cli/src/cli_args/update.rs
@@ -157,6 +157,7 @@ impl UpdateArgs {
         self,
         mut state: State,
     ) -> miette::Result<()> {
+        state.http_client.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
         let workspace_packages = self
             .check_workspace_option(state.config.workspace_dir.as_deref())?
             .map(|workspace_root| {

--- a/pnpm/crates/cli/src/cli_args/view.rs
+++ b/pnpm/crates/cli/src/cli_args/view.rs
@@ -14,7 +14,7 @@ use derive_more::{Display, Error};
 use miette::{Context, Diagnostic, IntoDiagnostic};
 use owo_colors::{OwoColorize, Stream, Style};
 use pnpm_config::Config;
-use pnpm_network::{NetworkSettings, RetryOpts, ThrottledClient};
+use pnpm_network::{RetryOpts, ThrottledClient};
 use pnpm_resolving_npm_resolver::{
     FetchFullMetadataOptions, FetchFullMetadataOutcome, PickPackageFromMetaOptions,
     fetch_full_metadata, parse_bare_specifier, pick_package_from_meta, pick_registry_for_package,
@@ -177,15 +177,10 @@ async fn fetch_package_info(
         &config.proxy,
         &config.tls,
         &config.tls_by_uri,
-        &NetworkSettings {
-            network_concurrency: config.network_concurrency,
-            fetch_timeout: std::time::Duration::from_millis(config.fetch_timeout),
-            user_agent: config.user_agent.clone(),
-        },
+        &config.network_settings(),
     )
     .into_diagnostic()
     .wrap_err("create the network client for view")?;
-
     let outcome = fetch_full_metadata(
         &spec.name,
         &FetchFullMetadataOptions {

--- a/pnpm/crates/cli/src/config_deps.rs
+++ b/pnpm/crates/cli/src/config_deps.rs
@@ -17,7 +17,7 @@ use pnpm_env_installer::{
 };
 use pnpm_graph_hasher::{detect_node_version, host_arch, host_libc, host_platform};
 use pnpm_hooks::{HookContext, LogFn, PnpmfileHooks, finder};
-use pnpm_network::{NetworkSettings, RetryOpts, ThrottledClient};
+use pnpm_network::{RetryOpts, ThrottledClient};
 use pnpm_reporter::{HookLog, LogEvent, LogLevel, Reporter};
 use pnpm_resolving_npm_resolver::{
     InMemoryPackageMetaCache, NpmResolver, shared_packument_fetch_locker,
@@ -266,6 +266,7 @@ async fn resolve_and_install<Reporter: self::Reporter>(
     frozen_lockfile: bool,
 ) -> Result<()> {
     let context = EnvInstallerContext::new(config)?;
+    context.http_client.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
     let options = context.options(root_dir, frozen_lockfile);
 
     resolve_and_install_config_deps::<Reporter>(config_dependencies, &context.resolver, &options)
@@ -327,19 +328,10 @@ impl EnvInstallerContext {
         auth_headers: Arc<pnpm_network::AuthHeaders>,
     ) -> Result<Self> {
         let http_client = Arc::new(
-            ThrottledClient::for_installs(
-                proxy,
-                tls,
-                tls_by_uri,
-                &NetworkSettings {
-                    network_concurrency: config.network_concurrency,
-                    fetch_timeout: Duration::from_millis(config.fetch_timeout),
-                    user_agent: config.user_agent.clone(),
-                },
-            )
-            .into_diagnostic()
-            .wrap_err("create the network client for env-installer dependencies")?
-            .with_max_sockets_per_host(config.max_sockets),
+            ThrottledClient::for_installs(proxy, tls, tls_by_uri, &config.network_settings())
+                .into_diagnostic()
+                .wrap_err("create the network client for env-installer dependencies")?
+                .with_max_sockets_per_host(config.max_sockets),
         );
 
         let registries: HashMap<String, String> = registries.into_iter().collect();

--- a/pnpm/crates/cli/src/engine_pm/pin.rs
+++ b/pnpm/crates/cli/src/engine_pm/pin.rs
@@ -158,11 +158,7 @@ async fn resolve_yarn_binary_version(
         &bootstrap.proxy,
         &bootstrap.tls,
         &bootstrap.tls_by_uri,
-        &pnpm_network::NetworkSettings {
-            network_concurrency: config.network_concurrency,
-            fetch_timeout: std::time::Duration::from_millis(config.fetch_timeout),
-            user_agent: config.user_agent.clone(),
-        },
+        &config.network_settings(),
     )
     .into_diagnostic()
     .wrap_err("build the network client to resolve the Yarn release")?;

--- a/pnpm/crates/cli/src/state.rs
+++ b/pnpm/crates/cli/src/state.rs
@@ -3,7 +3,7 @@ use miette::Diagnostic;
 use pipe_trait::Pipe;
 use pnpm_config::Config;
 use pnpm_lockfile::LazyLockfile;
-use pnpm_network::{ForInstallsError, NetworkSettings, ThrottledClient};
+use pnpm_network::{ForInstallsError, ThrottledClient};
 use pnpm_package_manager::ResolvedPackages;
 use pnpm_package_manifest::{PackageManifest, PackageManifestError};
 use pnpm_tarball::MemCache;
@@ -89,11 +89,7 @@ impl State {
                     &config.proxy,
                     &config.tls,
                     &config.tls_by_uri,
-                    &NetworkSettings {
-                        network_concurrency: config.network_concurrency,
-                        fetch_timeout: std::time::Duration::from_millis(config.fetch_timeout),
-                        user_agent: config.user_agent.clone(),
-                    },
+                    &config.network_settings(),
                 )
                 .map_err(InitStateError::Network)?
                 .with_max_sockets_per_host(config.max_sockets),

--- a/pnpm/crates/config/src/defaults.rs
+++ b/pnpm/crates/config/src/defaults.rs
@@ -300,6 +300,14 @@ pub fn default_fetch_timeout() -> u64 {
     pnpm_network::DEFAULT_FETCH_TIMEOUT_MS
 }
 
+pub fn default_fetch_warn_timeout_ms() -> u64 {
+    pnpm_network::DEFAULT_FETCH_WARN_TIMEOUT_MS
+}
+
+pub fn default_fetch_min_speed_ki_bps() -> u64 {
+    pnpm_network::DEFAULT_FETCH_MIN_SPEED_KI_BPS
+}
+
 /// Default `User-Agent`, in the format
 /// `${name}/${version} npm/? node/${nodeVersion} ${platform} ${arch}`.
 /// The `name/version` segment is `pnpm/<version>`. There is no embedded

--- a/pnpm/crates/config/src/defaults.rs
+++ b/pnpm/crates/config/src/defaults.rs
@@ -300,10 +300,16 @@ pub fn default_fetch_timeout() -> u64 {
     pnpm_network::DEFAULT_FETCH_TIMEOUT_MS
 }
 
+/// Returns the shared `fetchWarnTimeoutMs` default in milliseconds.
+///
+/// See [`pnpm_network::DEFAULT_FETCH_WARN_TIMEOUT_MS`].
 pub fn default_fetch_warn_timeout_ms() -> u64 {
     pnpm_network::DEFAULT_FETCH_WARN_TIMEOUT_MS
 }
 
+/// Returns the shared `fetchMinSpeedKiBps` default in KiB/s.
+///
+/// See [`pnpm_network::DEFAULT_FETCH_MIN_SPEED_KI_BPS`].
 pub fn default_fetch_min_speed_ki_bps() -> u64 {
     pnpm_network::DEFAULT_FETCH_MIN_SPEED_KI_BPS
 }

--- a/pnpm/crates/config/src/env_overlay.rs
+++ b/pnpm/crates/config/src/env_overlay.rs
@@ -208,6 +208,8 @@ impl WorkspaceSettings {
         json_field!(network_concurrency, "NETWORK_CONCURRENCY");
         json_field!(max_sockets, "MAX_SOCKETS");
         json_field!(fetch_timeout, "FETCH_TIMEOUT");
+        json_field!(fetch_warn_timeout_ms, "FETCH_WARN_TIMEOUT_MS");
+        json_field!(fetch_min_speed_ki_bps, "FETCH_MIN_SPEED_KI_BPS");
         string_field!(user_agent, "USER_AGENT");
         json_field!(patched_dependencies, "PATCHED_DEPENDENCIES");
         string_field!(patches_dir, "PATCHES_DIR");

--- a/pnpm/crates/config/src/env_overlay/tests.rs
+++ b/pnpm/crates/config/src/env_overlay/tests.rs
@@ -134,6 +134,8 @@ fn network_settings_parse_from_env() {
             match name {
                 "PNPM_CONFIG_NETWORK_CONCURRENCY" => Some("12".to_owned()),
                 "PNPM_CONFIG_FETCH_TIMEOUT" => Some("90000".to_owned()),
+                "PNPM_CONFIG_FETCH_WARN_TIMEOUT_MS" => Some("15000".to_owned()),
+                "PNPM_CONFIG_FETCH_MIN_SPEED_KI_BPS" => Some("75".to_owned()),
                 "PNPM_CONFIG_USER_AGENT" => Some("custom-ua/1.0".to_owned()),
                 _ => None,
             }
@@ -142,6 +144,8 @@ fn network_settings_parse_from_env() {
     let settings = WorkspaceSettings::from_pnpm_config_env::<EnvNetwork>();
     assert_eq!(settings.network_concurrency, Some(12));
     assert_eq!(settings.fetch_timeout, Some(90_000));
+    assert_eq!(settings.fetch_warn_timeout_ms, Some(15_000));
+    assert_eq!(settings.fetch_min_speed_ki_bps, Some(75));
     assert_eq!(settings.user_agent.as_deref(), Some("custom-ua/1.0"));
 }
 

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -49,11 +49,11 @@ pub use crate::defaults::{
     is_unsafe_perm_posix, resolve_child_concurrency,
 };
 use crate::defaults::{
-    default_child_concurrency, default_enable_global_virtual_store, default_fetch_retries,
-    default_fetch_retry_factor, default_fetch_retry_maxtimeout, default_fetch_retry_mintimeout,
-    default_fetch_timeout, default_hoist_pattern, default_modules_cache_max_age,
-    default_modules_dir, default_public_hoist_pattern, default_store_dir, default_user_agent,
-    default_virtual_store_dir,
+    default_child_concurrency, default_enable_global_virtual_store, default_fetch_min_speed_ki_bps,
+    default_fetch_retries, default_fetch_retry_factor, default_fetch_retry_maxtimeout,
+    default_fetch_retry_mintimeout, default_fetch_timeout, default_fetch_warn_timeout_ms,
+    default_hoist_pattern, default_modules_cache_max_age, default_modules_dir,
+    default_public_hoist_pattern, default_store_dir, default_user_agent, default_virtual_store_dir,
 };
 pub use workspace_yaml::{
     AllowBuild, AuditSettings, GLOBAL_CONFIG_YAML_FILENAME, LoadWorkspaceYamlError,
@@ -1555,6 +1555,18 @@ pub struct Config {
     #[default(_code = "default_fetch_timeout()")]
     pub fetch_timeout: u64,
 
+    /// Successful registry metadata requests slower than this threshold emit
+    /// a warning. The `fetchWarnTimeoutMs` setting, in milliseconds (default
+    /// `10000`, or 10 s).
+    #[default(_code = "default_fetch_warn_timeout_ms()")]
+    pub fetch_warn_timeout_ms: u64,
+
+    /// Minimum expected average tarball download speed in KiB/s. A download
+    /// lasting more than one second warns when its average falls below this
+    /// value. The `fetchMinSpeedKiBps` setting (default `50`).
+    #[default(_code = "default_fetch_min_speed_ki_bps()")]
+    pub fetch_min_speed_ki_bps: u64,
+
     /// Value of the `User-Agent` header sent on every registry request.
     /// The `userAgent` setting; the default is the
     /// `pnpm/<version> npm/? node/? <platform> <arch>` format (built by
@@ -2196,6 +2208,18 @@ impl Config {
     #[must_use]
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// The resolved settings used to construct an install HTTP client.
+    #[must_use]
+    pub fn network_settings(&self) -> pnpm_network::NetworkSettings {
+        pnpm_network::NetworkSettings {
+            network_concurrency: self.network_concurrency,
+            fetch_timeout: std::time::Duration::from_millis(self.fetch_timeout),
+            fetch_warn_timeout: std::time::Duration::from_millis(self.fetch_warn_timeout_ms),
+            fetch_min_speed_ki_bps: self.fetch_min_speed_ki_bps,
+            user_agent: self.user_agent.clone(),
+        }
     }
 
     /// The registries this config declares, in the shape the `registries`

--- a/pnpm/crates/config/src/pnpm_default_parity.rs
+++ b/pnpm/crates/config/src/pnpm_default_parity.rs
@@ -69,8 +69,6 @@ const NOT_PORTED: &[&str] = &[
     "color",
     "disallow-workspace-cycles",
     "embed-readme",
-    "fetch-min-speed-ki-bps",
-    "fetch-warn-timeout-ms",
     "git-branch-lockfile",
     "ignore-workspace-cycles",
     "ignore-workspace-root-check",
@@ -168,6 +166,8 @@ fn mapped_rows(cfg: &Config) -> Vec<(&'static str, Scalar)> {
         ("fetch-retry-maxtimeout", Int(cfg.fetch_retry_maxtimeout as i64)),
         ("fetch-retry-mintimeout", Int(cfg.fetch_retry_mintimeout as i64)),
         ("fetch-timeout", Int(cfg.fetch_timeout as i64)),
+        ("fetch-warn-timeout-ms", Int(cfg.fetch_warn_timeout_ms as i64)),
+        ("fetch-min-speed-ki-bps", Int(cfg.fetch_min_speed_ki_bps as i64)),
         ("frozen-store", Bool(cfg.frozen_store)),
         (
             "minimum-release-age",

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -304,6 +304,8 @@ pub fn network_settings_defaults_match_pnpm() {
     let value = Config::new();
     assert_eq!(value.network_concurrency, pnpm_network::default_network_concurrency());
     assert_eq!(value.fetch_timeout, 60_000);
+    assert_eq!(value.fetch_warn_timeout_ms, 10_000);
+    assert_eq!(value.fetch_min_speed_ki_bps, 50);
     assert!(value.user_agent.starts_with("pnpm/"), "user-agent: {:?}", value.user_agent);
     assert_eq!(value.npmrc_auth_file, None);
 }

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -311,6 +311,23 @@ pub fn network_settings_defaults_match_pnpm() {
 }
 
 #[test]
+pub fn network_settings_maps_custom_config_values() {
+    let mut config = Config::new();
+    config.network_concurrency = 8;
+    config.fetch_timeout = 120_000;
+    config.fetch_warn_timeout_ms = 2_345;
+    config.fetch_min_speed_ki_bps = 12;
+    config.user_agent = "pnpm-test".to_string();
+
+    let settings = config.network_settings();
+    assert_eq!(settings.network_concurrency, 8);
+    assert_eq!(settings.fetch_timeout, std::time::Duration::from_mins(2));
+    assert_eq!(settings.fetch_warn_timeout, std::time::Duration::from_millis(2_345));
+    assert_eq!(settings.fetch_min_speed_ki_bps, 12);
+    assert_eq!(settings.user_agent, "pnpm-test");
+}
+
+#[test]
 pub fn npmrc_auth_file_override_supplies_auth() {
     let project = tempdir().expect("project tempdir");
     let auth = tempdir().expect("auth tempdir");

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -313,6 +313,8 @@ pub struct WorkspaceSettings {
     /// [`Config::max_sockets`]. Default unset (no per-origin cap).
     pub max_sockets: Option<usize>,
     pub fetch_timeout: Option<u64>,
+    pub fetch_warn_timeout_ms: Option<u64>,
+    pub fetch_min_speed_ki_bps: Option<u64>,
     pub user_agent: Option<String>,
     /// `npmrcAuthFile` is read only from the global `config.yaml`
     /// (consumed by [`crate::Config::current`] to choose the user-level
@@ -1444,7 +1446,8 @@ impl WorkspaceSettings {
             side_effects_cache, side_effects_cache_readonly,
             fetch_retries, fetch_retry_factor,
             fetch_retry_mintimeout, fetch_retry_maxtimeout,
-            network_concurrency, fetch_timeout, user_agent,
+            network_concurrency, fetch_timeout,
+            fetch_warn_timeout_ms, fetch_min_speed_ki_bps, user_agent,
             enable_global_virtual_store,
             virtual_store_only, enable_modules_dir,
             git_shallow_hosts,

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -313,7 +313,11 @@ pub struct WorkspaceSettings {
     /// [`Config::max_sockets`]. Default unset (no per-origin cap).
     pub max_sockets: Option<usize>,
     pub fetch_timeout: Option<u64>,
+    /// The `fetchWarnTimeoutMs` YAML value in milliseconds. [`None`] leaves
+    /// [`Config::fetch_warn_timeout_ms`] unchanged.
     pub fetch_warn_timeout_ms: Option<u64>,
+    /// The `fetchMinSpeedKiBps` YAML value in KiB/s. [`None`] leaves
+    /// [`Config::fetch_min_speed_ki_bps`] unchanged.
     pub fetch_min_speed_ki_bps: Option<u64>,
     pub user_agent: Option<String>,
     /// `npmrcAuthFile` is read only from the global `config.yaml`

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -337,7 +337,7 @@ fn parses_git_checks_from_yaml_and_applies() {
     assert!(!config.git_checks);
 }
 
-/// `networkConcurrency` / `fetchTimeout` / `userAgent` parse from
+/// Network settings parse from
 /// `pnpm-workspace.yaml` as camelCase keys and `apply_to` pushes them
 /// onto the `Config`, matching pnpm.
 #[test]
@@ -345,17 +345,23 @@ fn parses_network_settings_from_yaml_and_applies() {
     let yaml = r"
 networkConcurrency: 8
 fetchTimeout: 120000
+fetchWarnTimeoutMs: 20000
+fetchMinSpeedKiBps: 100
 userAgent: my-agent/2.0
 ";
     let settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
     assert_eq!(settings.network_concurrency, Some(8));
     assert_eq!(settings.fetch_timeout, Some(120_000));
+    assert_eq!(settings.fetch_warn_timeout_ms, Some(20_000));
+    assert_eq!(settings.fetch_min_speed_ki_bps, Some(100));
     assert_eq!(settings.user_agent.as_deref(), Some("my-agent/2.0"));
 
     let mut config = Config::new();
     settings.apply_to(&mut config, Path::new("/irrelevant"));
     assert_eq!(config.network_concurrency, 8);
     assert_eq!(config.fetch_timeout, 120_000);
+    assert_eq!(config.fetch_warn_timeout_ms, 20_000);
+    assert_eq!(config.fetch_min_speed_ki_bps, 100);
     assert_eq!(config.user_agent, "my-agent/2.0");
 }
 

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -337,9 +337,6 @@ fn parses_git_checks_from_yaml_and_applies() {
     assert!(!config.git_checks);
 }
 
-/// Network settings parse from
-/// `pnpm-workspace.yaml` as camelCase keys and `apply_to` pushes them
-/// onto the `Config`, matching pnpm.
 #[test]
 fn parses_network_settings_from_yaml_and_applies() {
     let yaml = r"

--- a/pnpm/crates/deps-restorer/src/install_package_from_registry/tests.rs
+++ b/pnpm/crates/deps-restorer/src/install_package_from_registry/tests.rs
@@ -112,6 +112,8 @@ fn create_config(
         network_concurrency: pnpm_network::default_network_concurrency(),
         max_sockets: None,
         fetch_timeout: 60_000,
+        fetch_warn_timeout_ms: 10_000,
+        fetch_min_speed_ki_bps: 50,
         user_agent: "pnpm".to_string(),
         npmrc_auth_file: None,
         workspace_dir: None,

--- a/pnpm/crates/napi/src/config.rs
+++ b/pnpm/crates/napi/src/config.rs
@@ -94,6 +94,8 @@ pub struct ConfigOverlay {
     pub fetch_retry_mintimeout: Option<u64>,
     pub fetch_retry_maxtimeout: Option<u64>,
     pub fetch_timeout: Option<u64>,
+    pub fetch_warn_timeout_ms: Option<u64>,
+    pub fetch_min_speed_ki_bps: Option<u64>,
     pub user_agent: Option<String>,
     /// When `false` (the embedder default), an install that blocks dependency
     /// build scripts reports them via `depsRequiringBuild` instead of failing
@@ -383,6 +385,12 @@ fn build_config(dir: &Path, overlay: &ConfigOverlay) -> Result<Config, LoadWorks
     }
     if let Some(value) = overlay.fetch_timeout {
         config.fetch_timeout = value;
+    }
+    if let Some(value) = overlay.fetch_warn_timeout_ms {
+        config.fetch_warn_timeout_ms = value;
+    }
+    if let Some(value) = overlay.fetch_min_speed_ki_bps {
+        config.fetch_min_speed_ki_bps = value;
     }
     if let Some(user_agent) = &overlay.user_agent {
         config.user_agent.clone_from(user_agent);

--- a/pnpm/crates/napi/src/config.rs
+++ b/pnpm/crates/napi/src/config.rs
@@ -94,7 +94,11 @@ pub struct ConfigOverlay {
     pub fetch_retry_mintimeout: Option<u64>,
     pub fetch_retry_maxtimeout: Option<u64>,
     pub fetch_timeout: Option<u64>,
+    /// Slow metadata-request threshold in milliseconds. [`None`] keeps the
+    /// value resolved by [`Config::current`].
     pub fetch_warn_timeout_ms: Option<u64>,
+    /// Minimum average tarball speed in KiB/s. [`None`] keeps the value
+    /// resolved by [`Config::current`].
     pub fetch_min_speed_ki_bps: Option<u64>,
     pub user_agent: Option<String>,
     /// When `false` (the embedder default), an install that blocks dependency

--- a/pnpm/crates/napi/src/install.rs
+++ b/pnpm/crates/napi/src/install.rs
@@ -131,7 +131,11 @@ pub struct InstallOptions {
     pub fetch_retry_mintimeout: Option<u32>,
     pub fetch_retry_maxtimeout: Option<u32>,
     pub fetch_timeout: Option<u32>,
+    /// Slow metadata-request threshold in milliseconds. When set, this takes
+    /// precedence over the same field in `networkConfig`.
     pub fetch_warn_timeout_ms: Option<u32>,
+    /// Minimum average tarball speed in KiB/s. When set, this takes precedence
+    /// over the same field in `networkConfig`.
     pub fetch_min_speed_ki_bps: Option<u32>,
     pub user_agent: Option<String>,
     /// Fail the install with `ERR_PNPM_IGNORED_BUILDS` when a dependency build
@@ -183,7 +187,11 @@ pub struct NetworkConfigInput {
     pub fetch_retry_mintimeout: Option<u32>,
     pub fetch_retry_maxtimeout: Option<u32>,
     pub fetch_timeout: Option<u32>,
+    /// Slow metadata-request threshold in milliseconds. Used when the
+    /// corresponding top-level install option is omitted.
     pub fetch_warn_timeout_ms: Option<u32>,
+    /// Minimum average tarball speed in KiB/s. Used when the corresponding
+    /// top-level install option is omitted.
     pub fetch_min_speed_ki_bps: Option<u32>,
     pub user_agent: Option<String>,
 }

--- a/pnpm/crates/napi/src/install.rs
+++ b/pnpm/crates/napi/src/install.rs
@@ -25,7 +25,7 @@ use indexmap::IndexMap;
 use napi_derive::napi;
 use pnpm_hooks::PnpmfileHooks;
 use pnpm_lockfile::{LazyLockfile, Lockfile, MaybeLazyLockfile};
-use pnpm_network::{NetworkSettings, NoProxySetting, ProxyConfig, ThrottledClient, TlsConfig};
+use pnpm_network::{NoProxySetting, ProxyConfig, ThrottledClient, TlsConfig};
 use pnpm_package_manager::{
     DepsRequiringBuildSink, Install, ProjectMutation, RebuildOptions, ResolvedPackages,
     UpdateSeedPolicy,
@@ -131,6 +131,8 @@ pub struct InstallOptions {
     pub fetch_retry_mintimeout: Option<u32>,
     pub fetch_retry_maxtimeout: Option<u32>,
     pub fetch_timeout: Option<u32>,
+    pub fetch_warn_timeout_ms: Option<u32>,
+    pub fetch_min_speed_ki_bps: Option<u32>,
     pub user_agent: Option<String>,
     /// Fail the install with `ERR_PNPM_IGNORED_BUILDS` when a dependency build
     /// script is blocked. Defaults to `false` — the install instead reports the
@@ -181,6 +183,8 @@ pub struct NetworkConfigInput {
     pub fetch_retry_mintimeout: Option<u32>,
     pub fetch_retry_maxtimeout: Option<u32>,
     pub fetch_timeout: Option<u32>,
+    pub fetch_warn_timeout_ms: Option<u32>,
+    pub fetch_min_speed_ki_bps: Option<u32>,
     pub user_agent: Option<String>,
 }
 
@@ -384,11 +388,7 @@ fn run_install_inner(
             &config.proxy,
             &config.tls,
             &config.tls_by_uri,
-            &NetworkSettings {
-                network_concurrency: config.network_concurrency,
-                fetch_timeout: std::time::Duration::from_millis(config.fetch_timeout),
-                user_agent: config.user_agent.clone(),
-            },
+            &config.network_settings(),
         )
         .map_err(|error| to_napi_error(&error))?
         .with_max_sockets_per_host(config.max_sockets),
@@ -665,6 +665,14 @@ fn build_overlay(options: &InstallOptions) -> napi::Result<ConfigOverlay> {
         fetch_timeout: options
             .fetch_timeout
             .or_else(|| network_config.and_then(|config| config.fetch_timeout))
+            .map(u64::from),
+        fetch_warn_timeout_ms: options
+            .fetch_warn_timeout_ms
+            .or_else(|| network_config.and_then(|config| config.fetch_warn_timeout_ms))
+            .map(u64::from),
+        fetch_min_speed_ki_bps: options
+            .fetch_min_speed_ki_bps
+            .or_else(|| network_config.and_then(|config| config.fetch_min_speed_ki_bps))
             .map(u64::from),
         user_agent: options
             .user_agent

--- a/pnpm/crates/napi/src/install/tests.rs
+++ b/pnpm/crates/napi/src/install/tests.rs
@@ -114,6 +114,22 @@ fn build_overlay_maps_supported_install_options() {
 }
 
 #[test]
+fn top_level_fetch_warning_options_override_network_config() {
+    let mut options = install_options();
+    options.fetch_warn_timeout_ms = Some(1_234);
+    options.fetch_min_speed_ki_bps = Some(12);
+    options.network_config = Some(NetworkConfigInput {
+        fetch_warn_timeout_ms: Some(5_678),
+        fetch_min_speed_ki_bps: Some(56),
+        ..network_config()
+    });
+
+    let overlay = build_overlay(&options).expect("overlay");
+    assert_eq!(overlay.fetch_warn_timeout_ms, Some(1_234));
+    assert_eq!(overlay.fetch_min_speed_ki_bps, Some(12));
+}
+
+#[test]
 fn resolved_config_applies_trust_lockfile() {
     let dir = tempfile::tempdir().expect("tempdir");
 

--- a/pnpm/crates/napi/src/install/tests.rs
+++ b/pnpm/crates/napi/src/install/tests.rs
@@ -67,6 +67,8 @@ fn build_overlay_maps_supported_install_options() {
         fetch_retry_mintimeout: Some(10),
         fetch_retry_maxtimeout: Some(20),
         fetch_timeout: Some(30),
+        fetch_warn_timeout_ms: Some(40),
+        fetch_min_speed_ki_bps: Some(50),
         user_agent: Some("pnpm-test".to_string()),
     });
     options.proxy_config = Some(ProxyConfigInput {
@@ -93,6 +95,8 @@ fn build_overlay_maps_supported_install_options() {
     assert_eq!(overlay.fetch_retry_mintimeout, Some(10));
     assert_eq!(overlay.fetch_retry_maxtimeout, Some(20));
     assert_eq!(overlay.fetch_timeout, Some(30));
+    assert_eq!(overlay.fetch_warn_timeout_ms, Some(40));
+    assert_eq!(overlay.fetch_min_speed_ki_bps, Some(50));
     assert_eq!(overlay.user_agent, Some("pnpm-test".to_string()));
     let proxy = overlay.proxy.expect("proxy");
     assert_eq!(proxy.http_proxy, Some("http://proxy.test".to_string()));
@@ -628,6 +632,8 @@ fn install_options() -> InstallOptions {
         fetch_retry_mintimeout: None,
         fetch_retry_maxtimeout: None,
         fetch_timeout: None,
+        fetch_warn_timeout_ms: None,
+        fetch_min_speed_ki_bps: None,
         user_agent: None,
         strict_dep_builds: None,
         return_list_of_deps_requiring_build: None,
@@ -653,6 +659,8 @@ fn network_config() -> NetworkConfigInput {
         fetch_retry_mintimeout: None,
         fetch_retry_maxtimeout: None,
         fetch_timeout: None,
+        fetch_warn_timeout_ms: None,
+        fetch_min_speed_ki_bps: None,
         user_agent: None,
     }
 }

--- a/pnpm/crates/napi/src/read_config.rs
+++ b/pnpm/crates/napi/src/read_config.rs
@@ -72,6 +72,8 @@ pub struct ResolvedConfig {
     pub fetch_retry_mintimeout: u32,
     pub fetch_retry_maxtimeout: u32,
     pub fetch_timeout: u32,
+    pub fetch_warn_timeout_ms: u32,
+    pub fetch_min_speed_ki_bps: u32,
     /// The explicitly configured user agent, when the cascade set one.
     /// The engine's own computed default is omitted — an embedder that
     /// passes nothing back to `install` gets that same default.
@@ -167,6 +169,8 @@ fn project_config(config: &pnpm_config::Config) -> ResolvedConfig {
         fetch_retry_mintimeout: u32::try_from(config.fetch_retry_mintimeout).unwrap_or(u32::MAX),
         fetch_retry_maxtimeout: u32::try_from(config.fetch_retry_maxtimeout).unwrap_or(u32::MAX),
         fetch_timeout: u32::try_from(config.fetch_timeout).unwrap_or(u32::MAX),
+        fetch_warn_timeout_ms: u32::try_from(config.fetch_warn_timeout_ms).unwrap_or(u32::MAX),
+        fetch_min_speed_ki_bps: u32::try_from(config.fetch_min_speed_ki_bps).unwrap_or(u32::MAX),
         user_agent: config
             .explicit_settings
             .contains_key("userAgent")

--- a/pnpm/crates/napi/src/read_config/tests.rs
+++ b/pnpm/crates/napi/src/read_config/tests.rs
@@ -177,14 +177,21 @@ fn read_config_resolves_the_project_npmrc_cascade() {
 #[test]
 fn read_config_reports_explicitly_set_workspace_settings() {
     let dir = tempfile::tempdir().expect("tempdir");
-    std::fs::write(dir.path().join("pnpm-workspace.yaml"), "fetchRetries: 7\n")
-        .expect("write pnpm-workspace.yaml");
+    std::fs::write(
+        dir.path().join("pnpm-workspace.yaml"),
+        "fetchRetries: 7\nfetchWarnTimeoutMs: 2345\nfetchMinSpeedKiBps: 12\n",
+    )
+    .expect("write pnpm-workspace.yaml");
 
     let resolved =
         super::read_config(super::ReadConfigOptions { dir: dir.path().display().to_string() })
             .expect("read config");
 
     assert_eq!(resolved.fetch_retries, 7);
+    assert_eq!(resolved.fetch_warn_timeout_ms, 2_345);
+    assert_eq!(resolved.fetch_min_speed_ki_bps, 12);
     assert!(resolved.explicit_settings.contains(&"fetchRetries".to_string()));
+    assert!(resolved.explicit_settings.contains(&"fetchWarnTimeoutMs".to_string()));
+    assert!(resolved.explicit_settings.contains(&"fetchMinSpeedKiBps".to_string()));
     assert!(!resolved.explicit_settings.contains(&"fetchTimeout".to_string()));
 }

--- a/pnpm/crates/napi/src/resolve.rs
+++ b/pnpm/crates/napi/src/resolve.rs
@@ -35,7 +35,7 @@ use pnpm_engine_pm_yarn_resolver::YarnResolver;
 use pnpm_engine_runtime_bun_resolver::BunResolver;
 use pnpm_engine_runtime_deno_resolver::DenoResolver;
 use pnpm_engine_runtime_node_resolver::NodeResolver;
-use pnpm_network::{NetworkSettings, RetryOpts, ThrottledClient};
+use pnpm_network::{RetryOpts, ThrottledClient};
 use pnpm_resolving_default_resolver::DefaultResolver;
 use pnpm_resolving_git_resolver::{GitResolver, RealGitProbe, RealGitRunner};
 use pnpm_resolving_local_resolver::{LocalPathResolver, LocalResolverContext, LocalSchemeResolver};
@@ -49,6 +49,7 @@ use pnpm_resolving_tarball_resolver::TarballResolver;
 use crate::{
     config::{ConfigOverlay, resolve_config},
     error::to_napi_error,
+    reporter_bridge::NodeBridgeReporter,
 };
 
 /// The `(alias, bareSpecifier)` a resolve is requested for. Mirrors
@@ -125,14 +126,11 @@ fn run_resolve_blocking(
             &config.proxy,
             &config.tls,
             &config.tls_by_uri,
-            &NetworkSettings {
-                network_concurrency: config.network_concurrency,
-                fetch_timeout: std::time::Duration::from_millis(config.fetch_timeout),
-                user_agent: config.user_agent.clone(),
-            },
+            &config.network_settings(),
         )
         .map_err(|error| to_napi_error(&error))?,
     );
+    http_client.set_warning_handler(pnpm_reporter::emit_global_warning::<NodeBridgeReporter>);
 
     let full_metadata = options.full_metadata.unwrap_or(false);
     // `filter_metadata` stays off even under `full_metadata`, unlike the

--- a/pnpm/crates/network/src/auth.rs
+++ b/pnpm/crates/network/src/auth.rs
@@ -818,19 +818,30 @@ pub fn redact_url_credentials(text: &str) -> String {
 /// output.
 #[must_use]
 pub fn redact_and_sanitize(text: &str) -> String {
-    let sanitized: String = text.chars().filter(|character| !character.is_control()).collect();
+    let sanitized = sanitize_control_characters(text);
     redact_url_credentials(&sanitized)
 }
 
 /// Make a URL safe for user-visible output without exposing credentials,
 /// query parameters, fragments, or terminal control characters.
+/// Malformed URLs are replaced entirely because their authority cannot be
+/// redacted reliably.
 #[must_use]
 pub fn redact_url_for_display(url: &str) -> String {
-    let mut display = redact_and_sanitize(url);
-    if let Some(end) = display.find(['?', '#']) {
-        display.truncate(end);
+    let sanitized = sanitize_control_characters(url);
+    let Ok(mut display) = reqwest::Url::parse(&sanitized) else {
+        return "[hidden]".to_string();
+    };
+    if display.set_username("").is_err() || display.set_password(None).is_err() {
+        return "[hidden]".to_string();
     }
-    display
+    display.set_query(None);
+    display.set_fragment(None);
+    display.to_string()
+}
+
+fn sanitize_control_characters(text: &str) -> String {
+    text.chars().filter(|character| !character.is_control()).collect()
 }
 
 /// [`redact_and_sanitize`] for text whose line breaks are worth keeping, such

--- a/pnpm/crates/network/src/auth.rs
+++ b/pnpm/crates/network/src/auth.rs
@@ -822,6 +822,17 @@ pub fn redact_and_sanitize(text: &str) -> String {
     redact_url_credentials(&sanitized)
 }
 
+/// Make a URL safe for user-visible output without exposing credentials,
+/// query parameters, fragments, or terminal control characters.
+#[must_use]
+pub fn redact_url_for_display(url: &str) -> String {
+    let mut display = redact_and_sanitize(url);
+    if let Some(end) = display.find(['?', '#']) {
+        display.truncate(end);
+    }
+    display
+}
+
 /// [`redact_and_sanitize`] for text whose line breaks are worth keeping, such
 /// as a subprocess's multi-line stderr.
 ///

--- a/pnpm/crates/network/src/auth/tests.rs
+++ b/pnpm/crates/network/src/auth/tests.rs
@@ -242,6 +242,8 @@ fn redact_url_for_display_strips_secrets_and_control_chars() {
     );
     assert_eq!(redact_url_for_display("https://host/pkg#secret"), "https://host/pkg");
     assert_eq!(redact_url_for_display("https://host/pkg"), "https://host/pkg");
+    assert_eq!(redact_url_for_display("https://user:pa?ss@host/pkg"), "[hidden]");
+    assert_eq!(redact_url_for_display("https://user:pa#ss@host/pkg"), "[hidden]");
 }
 
 #[test]

--- a/pnpm/crates/network/src/auth/tests.rs
+++ b/pnpm/crates/network/src/auth/tests.rs
@@ -1,6 +1,7 @@
 use super::{
     AuthHeaders, DEFAULT_REGISTRY_SCOPE, UpstreamRouteHook, base64_encode, hide_auth_information,
     nerf_dart, redact_and_sanitize, redact_and_sanitize_multiline, redact_url_credentials,
+    redact_url_for_display,
 };
 use crate::TokenHelperOutput;
 use pretty_assertions::assert_eq;
@@ -231,6 +232,16 @@ fn redact_and_sanitize_strips_credentials_and_control_chars() {
     // A control character inside the userinfo must not break the redaction:
     // controls are stripped first, then credentials are redacted.
     assert_eq!(redact_and_sanitize("https://user:pass\r@host/x"), "https://host/x");
+}
+
+#[test]
+fn redact_url_for_display_strips_secrets_and_control_chars() {
+    assert_eq!(
+        redact_url_for_display("https://user:pass@host/pkg?token=secret#fragment\u{1b}"),
+        "https://host/pkg",
+    );
+    assert_eq!(redact_url_for_display("https://host/pkg#secret"), "https://host/pkg");
+    assert_eq!(redact_url_for_display("https://host/pkg"), "https://host/pkg");
 }
 
 #[test]

--- a/pnpm/crates/network/src/lib.rs
+++ b/pnpm/crates/network/src/lib.rs
@@ -92,8 +92,17 @@ pub const MAX_THROUGHPUT_PRIORITY: u64 = BACKGROUND - 1;
 /// `default_fetch_timeout`.
 pub const DEFAULT_FETCH_TIMEOUT_MS: u64 = 60_000;
 
+/// Default slow-metadata-request warning threshold in milliseconds: the
+/// `fetchWarnTimeoutMs` default of `10000`.
+pub const DEFAULT_FETCH_WARN_TIMEOUT_MS: u64 = 10_000;
+
+/// Default minimum average tarball download speed in KiB/s: the
+/// `fetchMinSpeedKiBps` default of `50`.
+pub const DEFAULT_FETCH_MIN_SPEED_KI_BPS: u64 = 50;
+
 /// Tunable network knobs threaded into the install client: the
-/// `networkConcurrency`, `fetchTimeout`, and `userAgent` settings.
+/// `networkConcurrency`, `fetchTimeout`, `fetchWarnTimeoutMs`,
+/// `fetchMinSpeedKiBps`, and `userAgent` settings.
 /// `pnpm-config` owns their defaults and override sources
 /// (`pnpm-workspace.yaml`, `PNPM_CONFIG_*`, CLI flags) and hands the
 /// resolved values here.
@@ -108,6 +117,14 @@ pub struct NetworkSettings {
     /// Default: [`DEFAULT_FETCH_TIMEOUT_MS`].
     pub fetch_timeout: Duration,
 
+    /// Successful metadata requests slower than this emit a warning.
+    /// Default: [`DEFAULT_FETCH_WARN_TIMEOUT_MS`].
+    pub fetch_warn_timeout: Duration,
+
+    /// Successful tarball downloads whose average speed falls below this
+    /// value emit a warning. Default: [`DEFAULT_FETCH_MIN_SPEED_KI_BPS`].
+    pub fetch_min_speed_ki_bps: u64,
+
     /// Value of the `User-Agent` header sent on every request.
     /// Default: [`DEFAULT_USER_AGENT`].
     pub user_agent: String,
@@ -118,6 +135,8 @@ impl Default for NetworkSettings {
         NetworkSettings {
             network_concurrency: default_network_concurrency(),
             fetch_timeout: Duration::from_millis(DEFAULT_FETCH_TIMEOUT_MS),
+            fetch_warn_timeout: Duration::from_millis(DEFAULT_FETCH_WARN_TIMEOUT_MS),
+            fetch_min_speed_ki_bps: DEFAULT_FETCH_MIN_SPEED_KI_BPS,
             user_agent: DEFAULT_USER_AGENT.to_string(),
         }
     }
@@ -164,6 +183,9 @@ pub struct ThrottledClient {
     /// default) leaves the per-origin socket count bounded only by
     /// `semaphore`; see [`HostSocketLimit`].
     host_socket_limit: Option<HostSocketLimit>,
+    fetch_warn_timeout: Duration,
+    fetch_min_speed_ki_bps: u64,
+    warning_handler: std::sync::RwLock<fn(&str)>,
 }
 
 /// Per-origin concurrent-connection cap, mirroring undici's `connections`
@@ -246,6 +268,27 @@ impl Deref for ThrottledClientGuard<'_> {
 }
 
 impl ThrottledClient {
+    /// Replace the sink used by successful slow-fetch warnings.
+    pub fn set_warning_handler(&self, handler: fn(&str)) {
+        *self.warning_handler.write().expect("warning-handler lock poisoned") = handler;
+    }
+
+    /// Emit a successful slow-fetch warning through the configured sink.
+    pub fn warn(&self, message: &str) {
+        let handler = *self.warning_handler.read().expect("warning-handler lock poisoned");
+        handler(message);
+    }
+
+    /// The `fetchWarnTimeoutMs` threshold configured for this client.
+    pub fn fetch_warn_timeout(&self) -> Duration {
+        self.fetch_warn_timeout
+    }
+
+    /// The `fetchMinSpeedKiBps` threshold configured for this client.
+    pub fn fetch_min_speed_ki_bps(&self) -> u64 {
+        self.fetch_min_speed_ki_bps
+    }
+
     /// Acquire a permit and return a guard granting access to the
     /// underlying [`Client`]. The permit is released when the guard
     /// is dropped, so callers control how long the request "counts"
@@ -485,6 +528,9 @@ impl ThrottledClient {
             per_registry: per_registry_clients,
             routing: per_registry.clone(),
             host_socket_limit: None,
+            fetch_warn_timeout: settings.fetch_warn_timeout,
+            fetch_min_speed_ki_bps: settings.fetch_min_speed_ki_bps,
+            warning_handler: std::sync::RwLock::new(ignore_warning),
         })
     }
 
@@ -502,6 +548,9 @@ impl ThrottledClient {
             per_registry: HashMap::new(),
             routing: PerRegistryTls::default(),
             host_socket_limit: None,
+            fetch_warn_timeout: Duration::from_millis(DEFAULT_FETCH_WARN_TIMEOUT_MS),
+            fetch_min_speed_ki_bps: DEFAULT_FETCH_MIN_SPEED_KI_BPS,
+            warning_handler: std::sync::RwLock::new(ignore_warning),
         }
     }
 
@@ -557,6 +606,8 @@ impl ThrottledClient {
         ThrottledClientGuard { _permit: permit, _host_permit: host_permit, client }
     }
 }
+
+fn ignore_warning(_: &str) {}
 
 /// Shared builder with the install-time defaults
 /// ([`ThrottledClient::new_for_installs`] documents the why behind each

--- a/pnpm/crates/network/src/lib.rs
+++ b/pnpm/crates/network/src/lib.rs
@@ -11,7 +11,7 @@ mod token_helper;
 pub use auth::{
     AuthHeaders, AuthHeadersByScope, DEFAULT_REGISTRY_SCOPE, MetadataCacheScope, UpstreamRouteHook,
     base64_encode, hide_auth_information, nerf_dart, normalize_auth_key, redact_and_sanitize,
-    redact_and_sanitize_multiline, redact_url_credentials,
+    redact_and_sanitize_multiline, redact_url_credentials, redact_url_for_display,
 };
 pub use limited_body::{LimitedBody, read_limited_body};
 pub use token_helper::{TokenHelperOutput, TokenHelperRunner};

--- a/pnpm/crates/network/src/tests.rs
+++ b/pnpm/crates/network/src/tests.rs
@@ -1017,12 +1017,14 @@ fn for_installs_with_pkcs1_client_key_builds() {
 
 #[test]
 fn for_installs_honors_custom_network_settings() {
-    // A custom concurrency / timeout / user-agent must thread through
+    // Custom concurrency, timeout, warning thresholds, and user-agent must thread through
     // without error — the settings reach the semaphore and the reqwest
     // builder rather than being ignored.
     let settings = NetworkSettings {
         network_concurrency: 4,
         fetch_timeout: std::time::Duration::from_secs(5),
+        fetch_warn_timeout: std::time::Duration::from_secs(2),
+        fetch_min_speed_ki_bps: 75,
         user_agent: "pnpm/9.9.9 npm/? node/? darwin arm64".to_string(),
     };
     let client = ThrottledClient::for_installs(
@@ -1033,6 +1035,8 @@ fn for_installs_honors_custom_network_settings() {
     )
     .expect("custom network settings build");
     assert_eq!(client.semaphore.available_permits(), 4);
+    assert_eq!(client.fetch_warn_timeout(), std::time::Duration::from_secs(2));
+    assert_eq!(client.fetch_min_speed_ki_bps(), 75);
 }
 
 #[test]

--- a/pnpm/crates/package-manager/src/add.rs
+++ b/pnpm/crates/package-manager/src/add.rs
@@ -362,6 +362,8 @@ where
             supported_architectures,
             lockfile_only,
         } = self;
+        http_client.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
+        http_client_arc.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
         let dependency_groups: Option<Vec<DependencyGroup>> =
             dependency_groups.map(|groups| groups.into_iter().collect());
         let selected_indices = selected_project_indices(projects, ordered_dirs, selected_dirs);

--- a/pnpm/crates/package-manager/src/add.rs
+++ b/pnpm/crates/package-manager/src/add.rs
@@ -191,6 +191,8 @@ where
             supported_architectures,
             lockfile_only,
         } = self;
+        http_client.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
+        http_client_arc.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
         let dependency_groups: Option<Vec<DependencyGroup>> =
             dependency_groups.map(|groups| groups.into_iter().collect());
 

--- a/pnpm/crates/package-manager/src/install/run.rs
+++ b/pnpm/crates/package-manager/src/install/run.rs
@@ -74,6 +74,8 @@ where
             pnpmfile_hook_override,
             workspace_projects_override,
         } = self;
+        http_client.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
+        http_client_arc.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
         let can_prompt = prompt_eligibility_override
             .unwrap_or_else(|| !is_ci::cached() && std::io::stdin().is_terminal());
         let peer_issues_sink_is_none = peer_issues_sink.is_none();

--- a/pnpm/crates/package-manager/src/patch.rs
+++ b/pnpm/crates/package-manager/src/patch.rs
@@ -188,6 +188,7 @@ impl WritePackageForPatch<'_> {
             target,
             dest,
         } = self;
+        http_client.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
         let metadata = current_lockfile
             .packages
             .as_ref()

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -467,6 +467,8 @@ impl Update<'_> {
             lockfile_only,
             resolution_observer,
         } = self;
+        http_client.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
+        http_client_arc.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
 
         crate::minimum_release_age::ensure_strict_minimum_release_age_can_save(config, save)
             .map_err(UpdateError::MinimumReleaseAge)?;

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -283,6 +283,8 @@ impl Update<'_> {
             lockfile_only,
             resolution_observer,
         } = self;
+        http_client.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
+        http_client_arc.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
 
         crate::minimum_release_age::ensure_strict_minimum_release_age_can_save(config, save)
             .map_err(UpdateError::MinimumReleaseAge)?;

--- a/pnpm/crates/reporter/src/lib.rs
+++ b/pnpm/crates/reporter/src/lib.rs
@@ -933,6 +933,14 @@ pub trait Reporter: Send + Sync + 'static {
     fn emit(event: &LogEvent);
 }
 
+/// Adapt a [`Reporter`] into the warning callback used by the network client.
+pub fn emit_global_warning<Sink: Reporter>(message: &str) {
+    Sink::emit(&LogEvent::Global(GlobalLog {
+        level: LogLevel::Warn,
+        message: message.to_string(),
+    }));
+}
+
 /// `--reporter=silent`: every event is dropped.
 pub struct SilentReporter;
 

--- a/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata.rs
@@ -18,8 +18,8 @@
 //! demands it.
 
 use pnpm_network::{
-    AuthHeaders, RetryOpts, ThrottledClient, ThrottledClientGuard, redact_url_credentials,
-    retry_async, send_with_retry_at_priority,
+    AuthHeaders, RetryOpts, ThrottledClient, ThrottledClientGuard, redact_and_sanitize,
+    redact_url_credentials, retry_async, send_with_retry_at_priority,
 };
 use pnpm_registry::Package;
 use reqwest::{Response, StatusCode, header};
@@ -279,7 +279,7 @@ pub async fn fetch_full_metadata(
 pub(crate) fn warn_if_request_is_slow(http_client: &ThrottledClient, elapsed: Duration, url: &str) {
     let elapsed_ms = elapsed.as_millis();
     if elapsed_ms > http_client.fetch_warn_timeout().as_millis() {
-        http_client.warn(&format!("Request took {elapsed_ms}ms: {url}"));
+        http_client.warn(&format!("Request took {elapsed_ms}ms: {}", redact_and_sanitize(url)));
     }
 }
 

--- a/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata.rs
@@ -18,8 +18,8 @@
 //! demands it.
 
 use pnpm_network::{
-    AuthHeaders, RetryOpts, ThrottledClient, ThrottledClientGuard, redact_and_sanitize,
-    redact_url_credentials, retry_async, send_with_retry_at_priority,
+    AuthHeaders, RetryOpts, ThrottledClient, ThrottledClientGuard, redact_url_credentials,
+    redact_url_for_display, retry_async, send_with_retry_at_priority,
 };
 use pnpm_registry::Package;
 use reqwest::{Response, StatusCode, header};
@@ -279,7 +279,7 @@ pub async fn fetch_full_metadata(
 pub(crate) fn warn_if_request_is_slow(http_client: &ThrottledClient, elapsed: Duration, url: &str) {
     let elapsed_ms = elapsed.as_millis();
     if elapsed_ms > http_client.fetch_warn_timeout().as_millis() {
-        http_client.warn(&format!("Request took {elapsed_ms}ms: {}", redact_and_sanitize(url)));
+        http_client.warn(&format!("Request took {elapsed_ms}ms: {}", redact_url_for_display(url)));
     }
 }
 

--- a/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata.rs
@@ -23,6 +23,7 @@ use pnpm_network::{
 };
 use pnpm_registry::Package;
 use reqwest::{Response, StatusCode, header};
+use std::time::{Duration, Instant};
 
 use crate::{FetchMetadataError, mirror::clear_meta, registry_url::to_registry_url};
 
@@ -219,6 +220,7 @@ pub async fn fetch_full_metadata(
     let url = to_registry_url(opts.registry, pkg_name);
     let accept = if opts.full_metadata { ACCEPT_FULL_DOC } else { ACCEPT_ABBREVIATED_DOC };
     retry_async(&url, opts.retry_opts, FetchMetadataError::is_body_retryable, || async {
+        let started_at = Instant::now();
         let (client, response) = send_metadata_request(&MetadataRequestOptions {
             pkg_name,
             url: &url,
@@ -251,21 +253,34 @@ pub async fn fetch_full_metadata(
         // `fetch_full_metadata_cached` for the cold-install numbers).
         drop(client);
         let task_url = url.clone();
-        let meta = tokio::task::spawn_blocking(move || -> Result<Package, FetchMetadataError> {
-            let mut meta = serde_json::from_str::<Package>(&raw_body).map_err(|error| {
-                FetchMetadataError::Decode { url: redact_url_credentials(&task_url), error }
-            })?;
-            meta.drop_incomplete_publish_times();
-            Ok(if normalize_to_abbreviated { normalize_abbreviated_meta(meta) } else { meta })
-        })
+        let (meta, elapsed) = tokio::task::spawn_blocking(
+            move || -> Result<(Package, Duration), FetchMetadataError> {
+                let mut meta = serde_json::from_str::<Package>(&raw_body).map_err(|error| {
+                    FetchMetadataError::Decode { url: redact_url_credentials(&task_url), error }
+                })?;
+                meta.drop_incomplete_publish_times();
+                let elapsed = started_at.elapsed();
+                let meta =
+                    if normalize_to_abbreviated { normalize_abbreviated_meta(meta) } else { meta };
+                Ok((meta, elapsed))
+            },
+        )
         .await
         .map_err(|error| FetchMetadataError::ParseTask {
             url: redact_url_credentials(&url),
             error,
         })??;
+        warn_if_request_is_slow(opts.http_client, elapsed, &url);
         Ok(FetchFullMetadataOutcome::Modified(Box::new(meta)))
     })
     .await
+}
+
+pub(crate) fn warn_if_request_is_slow(http_client: &ThrottledClient, elapsed: Duration, url: &str) {
+    let elapsed_ms = elapsed.as_millis();
+    if elapsed_ms > http_client.fetch_warn_timeout().as_millis() {
+        http_client.warn(&format!("Request took {elapsed_ms}ms: {url}"));
+    }
 }
 
 /// Strip a packument served for an **abbreviated** request down to the

--- a/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata/tests.rs
@@ -1,10 +1,39 @@
 use pnpm_network::{AuthHeaders, RetryOpts, ThrottledClient};
-use std::time::Duration;
+use std::{sync::Mutex, time::Duration};
 
 use super::{
     ABBREVIATED_META_CONTENT_TYPE, ACCEPT_ABBREVIATED_DOC, FetchFullMetadataOptions,
-    FetchFullMetadataOutcome, fetch_full_metadata,
+    FetchFullMetadataOutcome, fetch_full_metadata, warn_if_request_is_slow,
 };
+
+static WARNINGS: Mutex<Vec<String>> = Mutex::new(Vec::new());
+
+fn record_warning(message: &str) {
+    WARNINGS.lock().expect("warning recorder lock poisoned").push(message.to_string());
+}
+
+#[test]
+fn warns_when_metadata_request_exceeds_configured_timeout() {
+    let http_client = ThrottledClient::default();
+    http_client.set_warning_handler(record_warning);
+    WARNINGS.lock().expect("warning recorder lock poisoned").clear();
+
+    warn_if_request_is_slow(
+        &http_client,
+        Duration::from_millis(10_001),
+        "https://registry.example.test/pkg",
+    );
+    warn_if_request_is_slow(
+        &http_client,
+        Duration::from_secs(10),
+        "https://registry.example.test/not-slow",
+    );
+
+    assert_eq!(
+        *WARNINGS.lock().expect("warning recorder lock poisoned"),
+        ["Request took 10001ms: https://registry.example.test/pkg"],
+    );
+}
 
 /// The two constants repeat the media type as separate literals (Rust
 /// cannot build one string const from another without a macro), so

--- a/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata/tests.rs
@@ -20,7 +20,7 @@ fn warns_when_metadata_request_exceeds_configured_timeout() {
     warn_if_request_is_slow(
         &http_client,
         Duration::from_millis(10_001),
-        "https://user:pass@registry.example.test/pkg\u{1b}",
+        "https://user:pass@registry.example.test/pkg?token=secret#fragment\u{1b}",
     );
     warn_if_request_is_slow(
         &http_client,

--- a/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata/tests.rs
@@ -21,7 +21,7 @@ fn warns_when_metadata_request_exceeds_configured_timeout() {
     warn_if_request_is_slow(
         &http_client,
         Duration::from_millis(10_001),
-        "https://registry.example.test/pkg",
+        "https://user:pass@registry.example.test/pkg\u{1b}",
     );
     warn_if_request_is_slow(
         &http_client,

--- a/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata/tests.rs
@@ -1,19 +1,18 @@
 use pnpm_network::{AuthHeaders, RetryOpts, ThrottledClient};
-use std::{sync::Mutex, time::Duration};
+use std::time::Duration;
 
 use super::{
     ABBREVIATED_META_CONTENT_TYPE, ACCEPT_ABBREVIATED_DOC, FetchFullMetadataOptions,
     FetchFullMetadataOutcome, fetch_full_metadata, warn_if_request_is_slow,
 };
 
-static WARNINGS: Mutex<Vec<String>> = Mutex::new(Vec::new());
-
-fn record_warning(message: &str) {
-    WARNINGS.lock().expect("warning recorder lock poisoned").push(message.to_string());
-}
-
 #[test]
 fn warns_when_metadata_request_exceeds_configured_timeout() {
+    static WARNINGS: std::sync::Mutex<Vec<String>> = std::sync::Mutex::new(Vec::new());
+    fn record_warning(message: &str) {
+        WARNINGS.lock().expect("warning recorder lock poisoned").push(message.to_string());
+    }
+
     let http_client = ThrottledClient::default();
     http_client.set_warning_handler(record_warning);
     WARNINGS.lock().expect("warning recorder lock poisoned").clear();

--- a/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
@@ -16,6 +16,7 @@
 use std::{
     path::{Path, PathBuf},
     sync::atomic::{AtomicBool, Ordering},
+    time::{Duration, Instant},
 };
 
 use pipe_trait::Pipe;
@@ -31,6 +32,7 @@ use crate::{
     fetch_full_metadata::{
         ACCEPT_ABBREVIATED_DOC, ACCEPT_FULL_DOC, MetadataRequestOptions,
         is_abbreviated_content_type, normalize_abbreviated_meta, send_metadata_request,
+        warn_if_request_is_slow,
     },
     mirror::{
         ABBREVIATED_META_DIR, FULL_FILTERED_META_DIR, FULL_META_DIR, clear_meta,
@@ -132,6 +134,7 @@ pub async fn fetch_full_metadata_cached(
     // outlive the attempt that discovered the loss: re-validating against a
     // mirror already known to be gone would 304 into the same dead end.
     retry_async(&url, opts.retry_opts, FetchMetadataError::is_body_retryable, || async {
+        let started_at = Instant::now();
         let request = MetadataRequestOptions {
             pkg_name,
             url: &url,
@@ -189,47 +192,30 @@ pub async fn fetch_full_metadata_cached(
         // throughput.
         let task_url = url.clone();
         let task_mirror_path = mirror_path.clone();
-        let meta = tokio::task::spawn_blocking(move || -> Result<Package, FetchMetadataError> {
-            let mut meta: Package = serde_json::from_str(&raw_body).map_err(|error| {
-                FetchMetadataError::Decode { url: redact_url_credentials(&task_url), error }
-            })?;
-            meta.drop_incomplete_publish_times();
-            if normalize_to_abbreviated {
-                meta = normalize_abbreviated_meta(meta);
-            }
-            if should_filter_metadata {
-                meta = clear_meta(&meta).map_err(|error| FetchMetadataError::FilterMetadata {
-                    url: redact_url_credentials(&task_url),
-                    error: error.into_inner(),
+        let (meta, elapsed) = tokio::task::spawn_blocking(
+            move || -> Result<(Package, Duration), FetchMetadataError> {
+                let mut meta: Package = serde_json::from_str(&raw_body).map_err(|error| {
+                    FetchMetadataError::Decode { url: redact_url_credentials(&task_url), error }
                 })?;
-            }
-
-            if let Some(path) = task_mirror_path.as_deref() {
-                // A filtered full response is written in pnpm's NDJSON
-                // shape. Other responses keep pacquet's indexed mirror
-                // layout for lazy version hydration.
+                meta.drop_incomplete_publish_times();
+                let elapsed = started_at.elapsed();
+                if normalize_to_abbreviated {
+                    meta = normalize_abbreviated_meta(meta);
+                }
                 if should_filter_metadata {
-                    if let Err(error) = save_meta_ndjson(path, &meta, etag.as_deref()) {
-                        tracing::debug!(
-                            target: "pnpm_resolving_npm_resolver::cache",
-                            ?error,
-                            path = %path.display(),
-                            "could not persist mirror; bypassing cache write",
-                        );
-                    }
-                } else {
-                    match save_meta_indexed(path, &meta, etag.as_deref()) {
-                        // Serve the just-persisted mirror instead of the
-                        // response body: its version fragments read from
-                        // the file on demand, so the multi-megabyte body
-                        // drops here instead of living in the packument
-                        // cache for the rest of the install.
-                        Ok(()) => {
-                            if let Some(saved) = load_meta(path) {
-                                return Ok(saved);
-                            }
-                        }
-                        Err(error) => {
+                    meta =
+                        clear_meta(&meta).map_err(|error| FetchMetadataError::FilterMetadata {
+                            url: redact_url_credentials(&task_url),
+                            error: error.into_inner(),
+                        })?;
+                }
+
+                if let Some(path) = task_mirror_path.as_deref() {
+                    // A filtered full response is written in pnpm's NDJSON
+                    // shape. Other responses keep pacquet's indexed mirror
+                    // layout for lazy version hydration.
+                    if should_filter_metadata {
+                        if let Err(error) = save_meta_ndjson(path, &meta, etag.as_deref()) {
                             tracing::debug!(
                                 target: "pnpm_resolving_npm_resolver::cache",
                                 ?error,
@@ -237,17 +223,39 @@ pub async fn fetch_full_metadata_cached(
                                 "could not persist mirror; bypassing cache write",
                             );
                         }
+                    } else {
+                        match save_meta_indexed(path, &meta, etag.as_deref()) {
+                            // Serve the just-persisted mirror instead of the
+                            // response body: its version fragments read from
+                            // the file on demand, so the multi-megabyte body
+                            // drops here instead of living in the packument
+                            // cache for the rest of the install.
+                            Ok(()) => {
+                                if let Some(saved) = load_meta(path) {
+                                    return Ok((saved, elapsed));
+                                }
+                            }
+                            Err(error) => {
+                                tracing::debug!(
+                                    target: "pnpm_resolving_npm_resolver::cache",
+                                    ?error,
+                                    path = %path.display(),
+                                    "could not persist mirror; bypassing cache write",
+                                );
+                            }
+                        }
                     }
                 }
-            }
-            Ok(meta)
-        })
+                Ok((meta, elapsed))
+            },
+        )
         .await
         .map_err(|error| FetchMetadataError::ParseTask {
             url: redact_url_credentials(&url),
             error,
         })??;
 
+        warn_if_request_is_slow(opts.http_client, elapsed, &url);
         meta.pipe(Ok)
     })
     .await

--- a/pnpm/crates/tarball/src/download.rs
+++ b/pnpm/crates/tarball/src/download.rs
@@ -12,7 +12,7 @@ use super::{
     stream_extract_gzipped_tarball, streaming_extract_semaphore,
 };
 use pnpm_network::{
-    AuthHeaders, MAX_THROUGHPUT_PRIORITY, RetryOpts, ThrottledClient, redact_and_sanitize,
+    AuthHeaders, MAX_THROUGHPUT_PRIORITY, RetryOpts, ThrottledClient, redact_url_for_display,
 };
 use pnpm_reporter::{
     FetchingProgressLog, FetchingProgressMessage, LogEvent, LogLevel, ProgressLog, ProgressMessage,
@@ -446,7 +446,7 @@ pub(crate) fn slow_download_warning(
     let size_ki_b = downloaded / 1_024;
     Some(format!(
         "Tarball download average speed {avg_ki_bps} KiB/s (size {size_ki_b} KiB) is below {fetch_min_speed_ki_bps} KiB/s: {} (GET)",
-        redact_and_sanitize(package_url),
+        redact_url_for_display(package_url),
     ))
 }
 

--- a/pnpm/crates/tarball/src/download.rs
+++ b/pnpm/crates/tarball/src/download.rs
@@ -11,7 +11,9 @@ use super::{
     read_local_tarball_buffer, should_stream_extract, stream_extract_gzipped_channel,
     stream_extract_gzipped_tarball, streaming_extract_semaphore,
 };
-use pnpm_network::{AuthHeaders, MAX_THROUGHPUT_PRIORITY, RetryOpts, ThrottledClient};
+use pnpm_network::{
+    AuthHeaders, MAX_THROUGHPUT_PRIORITY, RetryOpts, ThrottledClient, redact_and_sanitize,
+};
 use pnpm_reporter::{
     FetchingProgressLog, FetchingProgressMessage, LogEvent, LogLevel, ProgressLog, ProgressMessage,
     Reporter, RequestRetryError, RequestRetryLog,
@@ -443,7 +445,8 @@ pub(crate) fn slow_download_warning(
     }
     let size_ki_b = downloaded / 1_024;
     Some(format!(
-        "Tarball download average speed {avg_ki_bps} KiB/s (size {size_ki_b} KiB) is below {fetch_min_speed_ki_bps} KiB/s: {package_url} (GET)",
+        "Tarball download average speed {avg_ki_bps} KiB/s (size {size_ki_b} KiB) is below {fetch_min_speed_ki_bps} KiB/s: {} (GET)",
+        redact_and_sanitize(package_url),
     ))
 }
 

--- a/pnpm/crates/tarball/src/download.rs
+++ b/pnpm/crates/tarball/src/download.rs
@@ -360,6 +360,7 @@ pub(crate) fn verify_tarball_integrity(
 /// could show it.
 struct BodyProgress<'a> {
     emit: bool,
+    started_at: Instant,
     last_emit: Option<Instant>,
     last_emitted_downloaded: u64,
     downloaded: u64,
@@ -373,6 +374,7 @@ impl<'a> BodyProgress<'a> {
     fn new(expected_size: Option<u64>, package_id: &'a str) -> Self {
         Self {
             emit: expected_size.is_some_and(|size| size >= Self::BIG_TARBALL_SIZE),
+            started_at: Instant::now(),
             last_emit: None,
             last_emitted_downloaded: 0,
             downloaded: 0,
@@ -411,6 +413,38 @@ impl<'a> BodyProgress<'a> {
             self.last_emitted_downloaded = self.downloaded;
         }
     }
+
+    fn warn_if_slow(&self, http_client: &ThrottledClient, package_url: &str) {
+        if let Some(message) = slow_download_warning(
+            self.downloaded,
+            self.started_at.elapsed(),
+            http_client.fetch_min_speed_ki_bps(),
+            package_url,
+        ) {
+            http_client.warn(&message);
+        }
+    }
+}
+
+pub(crate) fn slow_download_warning(
+    downloaded: u64,
+    elapsed: Duration,
+    fetch_min_speed_ki_bps: u64,
+    package_url: &str,
+) -> Option<String> {
+    let elapsed_ms = elapsed.as_millis();
+    if downloaded == 0 || elapsed_ms <= 1_000 {
+        return None;
+    }
+    let avg_ki_bps =
+        u128::from(downloaded).saturating_mul(1_000) / elapsed_ms.saturating_mul(1_024);
+    if avg_ki_bps >= u128::from(fetch_min_speed_ki_bps) {
+        return None;
+    }
+    let size_ki_b = downloaded / 1_024;
+    Some(format!(
+        "Tarball download average speed {avg_ki_bps} KiB/s (size {size_ki_b} KiB) is below {fetch_min_speed_ki_bps} KiB/s: {package_url} (GET)",
+    ))
 }
 
 /// Run one full tarball-fetch attempt: network, body, integrity hash,
@@ -622,6 +656,9 @@ pub(crate) async fn fetch_and_extract_once<Reporter: self::Reporter>(
                 None => break,
             }
         }
+        if body_error.is_none() {
+            progress.warn_if_slow(http_client, package_url);
+        }
         // Close the channel so the extractor sees end-of-stream. Release
         // the network permit before waiting on CPU work because the body is
         // done or abandoned after a network error.
@@ -653,6 +690,7 @@ pub(crate) async fn fetch_and_extract_once<Reporter: self::Reporter>(
             buf.extend_from_slice(&chunk);
             progress.on_chunk::<Reporter>(chunk.len());
         }
+        progress.warn_if_slow(http_client, package_url);
         progress.finish::<Reporter>();
         buf
     };

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -48,7 +48,7 @@ fn formats_warning_for_slow_tarball_download() {
             40 * 1024,
             Duration::from_millis(2_001),
             50,
-            "https://user:pass@registry.example.test/pkg.tgz\u{1b}",
+            "https://user:pass@registry.example.test/pkg.tgz?token=secret#fragment\u{1b}",
         ),
         Some(
             "Tarball download average speed 19 KiB/s (size 40 KiB) is below 50 KiB/s: https://registry.example.test/pkg.tgz (GET)"

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -2,7 +2,8 @@ use super::{
     FetchTarballForResolution, MAX_UNTRUSTED_PREALLOC_BYTES, MemCache, RetryOpts,
     SharedReportedProgressKeys,
     download::{
-        DownloadTarballToStore, download_priority, fetch_and_extract_with_retry, is_transient_error,
+        DownloadTarballToStore, download_priority, fetch_and_extract_with_retry,
+        is_transient_error, slow_download_warning,
     },
     error::{HttpStatusError, NetworkError, TarballError, VerifyChecksumError},
     extract::{
@@ -38,6 +39,39 @@ use tempfile::{TempDir, tempdir};
 
 fn integrity(integrity_str: &str) -> Integrity {
     integrity_str.parse().expect("parse integrity string")
+}
+
+#[test]
+fn formats_warning_for_slow_tarball_download() {
+    assert_eq!(
+        slow_download_warning(
+            40 * 1024,
+            Duration::from_millis(2_001),
+            50,
+            "https://registry.example.test/pkg.tgz",
+        ),
+        Some(
+            "Tarball download average speed 19 KiB/s (size 40 KiB) is below 50 KiB/s: https://registry.example.test/pkg.tgz (GET)"
+                .to_string(),
+        ),
+    );
+}
+
+#[test]
+fn does_not_warn_for_short_or_fast_tarball_download() {
+    assert_eq!(
+        slow_download_warning(1, Duration::from_secs(1), 50, "https://example.test/pkg.tgz"),
+        None,
+    );
+    assert_eq!(
+        slow_download_warning(
+            100 * 1024,
+            Duration::from_secs(2),
+            50,
+            "https://example.test/pkg.tgz",
+        ),
+        None,
+    );
 }
 
 #[test]

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -48,7 +48,7 @@ fn formats_warning_for_slow_tarball_download() {
             40 * 1024,
             Duration::from_millis(2_001),
             50,
-            "https://registry.example.test/pkg.tgz",
+            "https://user:pass@registry.example.test/pkg.tgz\u{1b}",
         ),
         Some(
             "Tarball download average speed 19 KiB/s (size 40 KiB) is below 50 KiB/s: https://registry.example.test/pkg.tgz (GET)"

--- a/pnpm/npm/napi/index.d.ts
+++ b/pnpm/npm/napi/index.d.ts
@@ -65,6 +65,8 @@ export interface NetworkConfig {
   fetchRetryMintimeout?: number
   fetchRetryMaxtimeout?: number
   fetchTimeout?: number
+  fetchWarnTimeoutMs?: number
+  fetchMinSpeedKiBps?: number
   userAgent?: string
 }
 
@@ -423,6 +425,8 @@ export interface ResolvedConfig {
   fetchRetryMintimeout: number
   fetchRetryMaxtimeout: number
   fetchTimeout: number
+  fetchWarnTimeoutMs: number
+  fetchMinSpeedKiBps: number
   /**
    * The explicitly configured user agent, when the cascade set one. The
    * engine's own computed default is omitted — an embedder that passes

--- a/pnpm/npm/napi/index.d.ts
+++ b/pnpm/npm/napi/index.d.ts
@@ -119,6 +119,10 @@ export interface InstallOptions extends SharedEngineOptions {
   dir: string
   projects: NodeApiProject[]
   storeDir?: string
+  /** Slow metadata-request warning threshold in milliseconds. Overrides `networkConfig`. */
+  fetchWarnTimeoutMs?: number
+  /** Minimum average tarball download speed in KiB/s. Overrides `networkConfig`. */
+  fetchMinSpeedKiBps?: number
   nodeLinker?: 'hoisted' | 'isolated'
   /**
    * pnpm's `linkWorkspacePackages`. When `true`/`'deep'`, a bare-semver

--- a/pnpm11/bins/linker/test/index.ts
+++ b/pnpm11/bins/linker/test/index.ts
@@ -171,7 +171,7 @@ test('linkBins() deletes a PowerShell shim left by an older install of the pnpm 
     expect(bins).toContain(binName)
     expect(bins).not.toContain(`${binName}.ps1`)
     if (IS_WINDOWS) {
-      expect(bins).toContain(`${binName}.cmd`)
+      expect(bins).toContain(`${binName}${CMD_EXTENSION}`)
     }
   }
 

--- a/pnpm11/core/error/src/index.ts
+++ b/pnpm11/core/error/src/index.ts
@@ -113,27 +113,27 @@ export function redactAndSanitize (text: string): string {
   // userinfo (`user:pass\r@host`) would otherwise split the authority across
   // the redaction scan, and removing it afterwards would rejoin the
   // credentials into the output.
-  let sanitized = ''
-  for (const char of text) {
-    const code = char.codePointAt(0)!
-    if (code <= 0x1f || (code >= 0x7f && code <= 0x9f)) continue
-    sanitized += char
-  }
-  return redactUrlCredentials(sanitized)
+  return redactUrlCredentials(sanitizeControlCharacters(text))
 }
 
 /**
  * Make a URL safe for user-visible output without exposing credentials,
- * query parameters, fragments, or terminal control characters.
+ * query parameters, fragments, or terminal control characters. Malformed
+ * URLs are replaced entirely because their authority cannot be redacted
+ * reliably.
  */
 export function redactUrlForDisplay (url: string): string {
-  const display = redactAndSanitize(url)
-  const queryStart = display.indexOf('?')
-  const fragmentStart = display.indexOf('#')
-  const end = [queryStart, fragmentStart]
-    .filter(index => index !== -1)
-    .reduce((first, index) => Math.min(first, index), display.length)
-  return display.slice(0, end)
+  let display: URL
+  try {
+    display = new URL(sanitizeControlCharacters(url))
+  } catch {
+    return '[hidden]'
+  }
+  display.username = ''
+  display.password = ''
+  display.search = ''
+  display.hash = ''
+  return display.href
 }
 
 /**
@@ -158,6 +158,16 @@ function isSchemeTailChar (code: number): boolean {
 
 function isAsciiWhitespace (code: number): boolean {
   return code === 0x20 || code === 0x09 || code === 0x0a || code === 0x0b || code === 0x0c || code === 0x0d
+}
+
+function sanitizeControlCharacters (text: string): string {
+  let sanitized = ''
+  for (const char of text) {
+    const code = char.codePointAt(0)!
+    if (code <= 0x1f || (code >= 0x7f && code <= 0x9f)) continue
+    sanitized += char
+  }
+  return sanitized
 }
 
 function hideAuthInformation (authHeaderValue: string): string {

--- a/pnpm11/core/error/src/index.ts
+++ b/pnpm11/core/error/src/index.ts
@@ -123,6 +123,20 @@ export function redactAndSanitize (text: string): string {
 }
 
 /**
+ * Make a URL safe for user-visible output without exposing credentials,
+ * query parameters, fragments, or terminal control characters.
+ */
+export function redactUrlForDisplay (url: string): string {
+  const display = redactAndSanitize(url)
+  const queryStart = display.indexOf('?')
+  const fragmentStart = display.indexOf('#')
+  const end = [queryStart, fragmentStart]
+    .filter(index => index !== -1)
+    .reduce((first, index) => Math.min(first, index), display.length)
+  return display.slice(0, end)
+}
+
+/**
  * {@link redactAndSanitize} for text whose line breaks are worth keeping, such
  * as a subprocess's multi-line stderr.
  *

--- a/pnpm11/core/error/test/index.ts
+++ b/pnpm11/core/error/test/index.ts
@@ -104,6 +104,8 @@ test('redactUrlForDisplay strips URL secrets and control characters', () => {
     .toBe('https://host/pkg')
   expect(redactUrlForDisplay('https://host/pkg#secret')).toBe('https://host/pkg')
   expect(redactUrlForDisplay('https://host/pkg')).toBe('https://host/pkg')
+  expect(redactUrlForDisplay('https://user:pa?ss@host/pkg')).toBe('[hidden]')
+  expect(redactUrlForDisplay('https://user:pa#ss@host/pkg')).toBe('[hidden]')
 })
 
 test('redactAndSanitizeMultiline', () => {

--- a/pnpm11/core/error/test/index.ts
+++ b/pnpm11/core/error/test/index.ts
@@ -1,5 +1,12 @@
 import { expect, test } from '@jest/globals'
-import { FetchError, PnpmError, redactAndSanitize, redactAndSanitizeMultiline, redactUrlCredentials } from '@pnpm/error'
+import {
+  FetchError,
+  PnpmError,
+  redactAndSanitize,
+  redactAndSanitizeMultiline,
+  redactUrlCredentials,
+  redactUrlForDisplay,
+} from '@pnpm/error'
 
 test('PnpmError exposes cause when provided', () => {
   const cause = new Error('original failure')
@@ -90,6 +97,13 @@ test('redactAndSanitize', () => {
   // A control character inside the userinfo must not break the redaction:
   // controls are stripped first, then credentials are redacted.
   expect(redactAndSanitize('https://user:pass\r@host/x')).toBe('https://host/x')
+})
+
+test('redactUrlForDisplay strips URL secrets and control characters', () => {
+  expect(redactUrlForDisplay('https://user:pass@host/pkg?token=secret#fragment\u001b'))
+    .toBe('https://host/pkg')
+  expect(redactUrlForDisplay('https://host/pkg#secret')).toBe('https://host/pkg')
+  expect(redactUrlForDisplay('https://host/pkg')).toBe('https://host/pkg')
 })
 
 test('redactAndSanitizeMultiline', () => {

--- a/pnpm11/fetching/tarball-fetcher/src/remoteTarballFetcher.ts
+++ b/pnpm11/fetching/tarball-fetcher/src/remoteTarballFetcher.ts
@@ -2,7 +2,7 @@ import type { IncomingMessage } from 'node:http'
 import util from 'node:util'
 
 import { requestRetryLogger } from '@pnpm/core-loggers'
-import { FetchError } from '@pnpm/error'
+import { FetchError, redactUrlForDisplay } from '@pnpm/error'
 import type { FetchOptions, FetchResult } from '@pnpm/fetching.fetcher-base'
 import type { FetchFromRegistry, GetAuthHeader } from '@pnpm/fetching.types'
 import { globalWarn } from '@pnpm/logger'
@@ -197,7 +197,7 @@ export function createDownloader (
         const avgKiBps = Math.floor((downloaded / elapsedSec) / 1024)
         if (downloaded > 0 && elapsedSec > 1 && avgKiBps < fetchMinSpeedKiBps) {
           const sizeKb = Math.floor(downloaded / 1024)
-          globalWarn(`Tarball download average speed ${avgKiBps} KiB/s (size ${sizeKb} KiB) is below ${fetchMinSpeedKiBps} KiB/s: ${url} (GET)`)
+          globalWarn(`Tarball download average speed ${avgKiBps} KiB/s (size ${sizeKb} KiB) is below ${fetchMinSpeedKiBps} KiB/s: ${redactUrlForDisplay(url)} (GET)`)
         }
       } catch (err: unknown) {
         const error = util.types.isNativeError(err) ? err : new Error(String(err), { cause: err })

--- a/pnpm11/resolving/npm-resolver/src/fetch.ts
+++ b/pnpm11/resolving/npm-resolver/src/fetch.ts
@@ -8,6 +8,7 @@ import {
   type FetchErrorResponse,
   PnpmError,
   redactUrlCredentials,
+  redactUrlForDisplay,
 } from '@pnpm/error'
 import type { FetchFromRegistry, RetryTimeoutOptions } from '@pnpm/fetching.types'
 import { globalWarn } from '@pnpm/logger'
@@ -219,7 +220,7 @@ export async function fetchMetadataFromFromRegistry (
         // Check if request took longer than expected
         const elapsedMs = Date.now() - startTime
         if (elapsedMs > fetchOpts.fetchWarnTimeoutMs) {
-          globalWarn(`Request took ${elapsedMs}ms: ${uri}`)
+          globalWarn(`Request took ${elapsedMs}ms: ${redactUrlForDisplay(uri)}`)
         }
         resolve({
           ...normalizeAbbreviatedResponse({ fullMetadata, meta, jsonText, response }),


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Ports pnpm 11's `fetchWarnTimeoutMs` and `fetchMinSpeedKiBps` settings to the
Rust CLI and N-API bindings.

- Threads both settings through workspace YAML, environment variables, install
  flags, N-API options, and resolved config output.
- Warns after successful slow registry metadata requests and low-average-speed
  tarball downloads, using pnpm-compatible boundaries and messages.
- Routes warnings through the active CLI or N-API reporter and covers defaults,
  config sources, option plumbing, and warning formatting with tests.
- Sanitizes slow-fetch warning URLs in both implementations before reporter
  output, removing credentials, query parameters, fragments, and control characters.

The TypeScript CLI already supports both settings; this PR supplies the Rust
side of the parity change and hardens slow-fetch warning URLs in both stacks.

Related to pnpm/pnpm#12042.

## Squash Commit Body

```text
Port `fetchWarnTimeoutMs` and `fetchMinSpeedKiBps` through pacquet's workspace
YAML, environment, CLI install flags, and N-API configuration surfaces. Keep
the two thresholds alongside the other settings used to construct the shared
HTTP client so every install-family path receives the resolved values.

Measure successful registry metadata requests through body parsing and emit a
warning only when the configured timeout is exceeded. Measure complete tarball
bodies and warn when a download lasting more than one second falls below the
configured average KiB/s threshold. Match pnpm 11's comparison boundaries and
message formats, and route the warnings through the selected reporter. Strip
credentials, query parameters, fragments, and control characters from the URL
text in both implementations before it reaches reporter output.

The TypeScript CLI already implements both settings, so this completes the Rust
side of the parity work.

Related to pnpm/pnpm#12042.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Codex, gpt-5.6-sol).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790008191&installation_model_id=426870&pr_number=14078&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14078&signature=0b759980044588562dad33ffc4f70ff986590c98ac5e2f77c7b50eab71e14ab7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added warnings for slow registry metadata requests and downloads below the configured average speed.
  * Added `fetchWarnTimeoutMs` and `fetchMinSpeedKiBps` settings through CLI options, environment variables, workspace YAML, and the N-API.
  * Resolved configuration reports both settings, with defaults of 10 seconds and 50 KiB/s.
* **Security**
  * Slow-fetch warnings redact credentials, query parameters, fragments, and control characters from displayed URLs.
* **Tests**
  * Added coverage for configuration parsing and slow-fetch warning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->