### PR TITLE
feat(config): support the lockfileDir setting in the Rust CLI

### DIFF
--- a/.changeset/pacquet-lockfile-dir.md
+++ b/.changeset/pacquet-lockfile-dir.md
@@ -1,0 +1,5 @@
+---
+"pacquet": minor
+---
+
+Added support for the `lockfileDir` setting and its `--lockfile-dir <dir>` flag on `pnpm install`, `add`, `update`, and `remove`. `pnpm-lock.yaml`, the root `node_modules` holding the virtual store, and the config dependencies now live in the given directory, each project is recorded under its path relative to it, and every project keeps its own `node_modules` of symlinks — so several projects can share one lockfile [#12042](https://github.com/pnpm/pnpm/issues/12042).

--- a/pnpm/crates/cli/src/cli_args.rs
+++ b/pnpm/crates/cli/src/cli_args.rs
@@ -38,6 +38,7 @@ pub(crate) mod legacy_pnpm_field;
 pub mod licenses;
 pub mod link;
 pub mod list;
+pub mod lockfile_dir;
 pub mod login;
 pub mod logout;
 pub mod outdated;

--- a/pnpm/crates/cli/src/cli_args/add.rs
+++ b/pnpm/crates/cli/src/cli_args/add.rs
@@ -1,8 +1,8 @@
 use crate::{
     State,
     cli_args::{
-        install::resolve_bool_override, pipelines::InstallFamilySelection,
-        supported_architectures::SupportedArchitecturesArgs,
+        install::resolve_bool_override, lockfile_dir::LockfileDirArg,
+        pipelines::InstallFamilySelection, supported_architectures::SupportedArchitecturesArgs,
     },
     config_deps,
     engine_pm::{
@@ -152,6 +152,8 @@ pub struct AddArgs {
     /// Dependencies are not downloaded. Only `pnpm-lock.yaml` is updated.
     #[clap(long = "lockfile-only")]
     pub lockfile_only: bool,
+    #[clap(flatten)]
+    pub lockfile_dir: LockfileDirArg,
     /// The directory with links to the store (default is `node_modules/.pnpm`).
     /// All direct and indirect dependencies of the project are linked into this directory
     #[clap(long = "virtual-store-dir", default_value = "node_modules/.pnpm")]

--- a/pnpm/crates/cli/src/cli_args/cat_index.rs
+++ b/pnpm/crates/cli/src/cli_args/cat_index.rs
@@ -77,10 +77,7 @@ impl CatIndexArgs {
 }
 
 fn lockfile_dir(config: &Config, dir: &Path) -> PathBuf {
-    match &config.workspace_dir {
-        Some(workspace_dir) => workspace_dir.clone(),
-        None => dir.to_path_buf(),
-    }
+    config.lockfile_dir_for(dir).to_path_buf()
 }
 
 fn lockfile_store_index_keys(

--- a/pnpm/crates/cli/src/cli_args/deploy.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy.rs
@@ -169,7 +169,7 @@ impl DeployArgs {
         }
 
         let force_legacy = self.legacy || config.force_legacy_deploy;
-        if config.shared_workspace_lockfile && !force_legacy && !config.inject_workspace_packages {
+        if config.shares_one_lockfile() && !force_legacy && !config.inject_workspace_packages {
             return Err(DeployError::NonInjectedWorkspace.into());
         }
 
@@ -191,7 +191,7 @@ impl DeployArgs {
             !config.deploy_all_files,
         )?;
 
-        if config.shared_workspace_lockfile && !force_legacy {
+        if config.shares_one_lockfile() && !force_legacy {
             match Box::pin(self.deploy_from_shared_lockfile::<ReporterT>(
                 config,
                 workspace_dir,
@@ -203,7 +203,7 @@ impl DeployArgs {
                 SharedDeployOutcome::Deployed => return Ok(()),
                 SharedDeployOutcome::Fallback(warning) => warn::<ReporterT>(&deploy_dir, warning),
             }
-        } else if config.shared_workspace_lockfile && force_legacy {
+        } else if config.shares_one_lockfile() && force_legacy {
             warn::<ReporterT>(
                 &deploy_dir,
                 "Shared workspace lockfile detected but configuration forces legacy deploy implementation.",

--- a/pnpm/crates/cli/src/cli_args/deploy.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy.rs
@@ -236,6 +236,19 @@ impl DeployArgs {
         // it, belong to the lockfile dir — which `lockfileDir` can move
         // away from the workspace this deploy selected its project from.
         let lockfile_dir = config.lockfile_dir_for(workspace_dir);
+        // Every path this deploy resolves is a lockfile-relative importer
+        // id joined onto that dir, and none of them may escape it. A pin
+        // that does not contain the workspace makes each project's id
+        // climb out (`../packages/app`), so the shared path cannot
+        // describe this layout at all: hand it to the legacy installer,
+        // which resolves the deployed manifest on its own.
+        if !same_path(workspace_dir, lockfile_dir) && !is_ancestor_path(lockfile_dir, workspace_dir)
+        {
+            return Ok(SharedDeployOutcome::Fallback(format!(
+                "The lockfile at {} is outside the workspace, so its importer paths cannot be deployed. Falling back to installing without it.",
+                lockfile_dir.display(),
+            )));
+        }
         let Some(lockfile) = Lockfile::load_wanted_from_dir(lockfile_dir)
             .map_err(miette::Report::new)
             .wrap_err("read shared lockfile")?

--- a/pnpm/crates/cli/src/cli_args/deploy.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy.rs
@@ -232,7 +232,11 @@ impl DeployArgs {
         if !config.inject_workspace_packages {
             return Err(DeployError::NonInjectedWorkspace.into());
         }
-        let Some(lockfile) = Lockfile::load_wanted_from_dir(workspace_dir)
+        // The shared lockfile, and the importer ids naming the projects in
+        // it, belong to the lockfile dir — which `lockfileDir` can move
+        // away from the workspace this deploy selected its project from.
+        let lockfile_dir = config.lockfile_dir_for(workspace_dir);
+        let Some(lockfile) = Lockfile::load_wanted_from_dir(lockfile_dir)
             .map_err(miette::Report::new)
             .wrap_err("read shared lockfile")?
         else {
@@ -242,14 +246,14 @@ impl DeployArgs {
             ));
         };
 
-        let project_id = importer_id_from_root_dir(workspace_dir, &selected.project.root_dir);
+        let project_id = importer_id_from_root_dir(lockfile_dir, &selected.project.root_dir);
         let dependency_groups =
             self.install_args.dependency_options.dependency_groups().collect::<Vec<_>>();
         let deploy_files = create_deploy_files(
             &lockfile,
             selected,
             &project_id,
-            workspace_dir,
+            lockfile_dir,
             deploy_dir,
             config,
             &dependency_groups,
@@ -395,6 +399,11 @@ fn create_deploy_install_config(
     let mut deploy_config = base_config.clone();
     deploy_config.modules_dir = deploy_dir.join("node_modules");
     deploy_config.virtual_store_dir = deploy_dir.join("node_modules/.pnpm");
+    // The deploy directory owns the lockfile this install runs against —
+    // the generated one for a shared deploy, its own resolution for the
+    // legacy path. A `lockfileDir` pinning the *source* workspace's
+    // lockfile must not redirect either.
+    deploy_config.lockfile_dir = None;
     deploy_config.global_virtual_store_dir = deploy_config.virtual_store_dir.clone();
     deploy_config.enable_global_virtual_store = false;
     deploy_config.pnpr_server = None;

--- a/pnpm/crates/cli/src/cli_args/deploy.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy.rs
@@ -245,7 +245,7 @@ impl DeployArgs {
         if !same_path(workspace_dir, lockfile_dir) && !is_ancestor_path(lockfile_dir, workspace_dir)
         {
             return Ok(SharedDeployOutcome::Fallback(format!(
-                "The lockfile at {} is outside the workspace, so its importer paths cannot be deployed. Falling back to installing without it.",
+                "The lockfile at {} does not contain the workspace, so its importer paths cannot be deployed. Falling back to installing without it.",
                 lockfile_dir.display(),
             )));
         }

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -133,6 +133,7 @@ impl CliArgs {
         {
             return false;
         }
+        install_args.lockfile_dir.apply_to(&mut config, &dir);
         self.configure_reporter();
         let emit = reporter_emit(self.effective_reporter());
         let finished = install_args.finished_via_up_to_date_fast_path(&dir, &config, emit);

--- a/pnpm/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_install.rs
@@ -36,6 +36,7 @@ use pnpm_reporter::{NdjsonReporter, SilentReporter};
 pub(super) fn add<'a>(ctx: &RunCtx<'a>, args: AddArgs) -> miette::Result<CommandFuture<'a>> {
     if args.global {
         let config = (ctx.global_config)()?;
+        args.lockfile_dir.apply_to_global(config)?;
         args.apply_cli_config(config);
         let dir = ctx.dir;
         return Ok(match ctx.reporter {
@@ -56,11 +57,16 @@ pub(super) fn add<'a>(ctx: &RunCtx<'a>, args: AddArgs) -> miette::Result<Command
     let config = ctx.config;
     Ok(Box::pin(async move {
         let cfg = config()?;
+        args.lockfile_dir.apply_to(cfg, dir);
         args.apply_cli_config(cfg);
         let (config_root, package_manager_to_sync) =
             derive_config_root_and_package_manager_to_sync(cfg, dir, reporter)
                 .wrap_err("derive workspace root and package manager policy")?;
-        apply_allow_build(cfg, &args.allow_build, &config_root)?;
+        // `allowBuilds` is persisted to `pnpm-workspace.yaml`, which stays
+        // at the workspace root even when `lockfileDir` moved the config
+        // root elsewhere.
+        let allow_build_root = cfg.workspace_dir.clone().unwrap_or_else(|| config_root.clone());
+        apply_allow_build(cfg, &args.allow_build, &allow_build_root)?;
         let pipeline = AddPipeline {
             args,
             cfg,
@@ -85,6 +91,7 @@ pub(super) fn add<'a>(ctx: &RunCtx<'a>, args: AddArgs) -> miette::Result<Command
 pub(super) fn update<'a>(ctx: &RunCtx<'a>, args: UpdateArgs) -> miette::Result<CommandFuture<'a>> {
     if args.global {
         let config = (ctx.global_config)()?;
+        args.lockfile_dir.apply_to_global(config)?;
         args.apply_cli_config(config);
         return Ok(match ctx.reporter {
             ReporterType::Default | ReporterType::AppendOnly => {
@@ -101,6 +108,7 @@ pub(super) fn update<'a>(ctx: &RunCtx<'a>, args: UpdateArgs) -> miette::Result<C
     let config = ctx.config;
     Ok(Box::pin(async move {
         let cfg = config()?;
+        args.lockfile_dir.apply_to(cfg, dir);
         args.apply_cli_config(cfg);
         let (config_root, package_manager_to_sync) =
             derive_config_root_and_package_manager_to_sync(cfg, dir, reporter)
@@ -127,7 +135,9 @@ pub(super) fn update<'a>(ctx: &RunCtx<'a>, args: UpdateArgs) -> miette::Result<C
 
 pub(super) fn remove<'a>(ctx: &RunCtx<'a>, args: RemoveArgs) -> miette::Result<CommandFuture<'a>> {
     if args.global {
-        global::handle_global_remove((ctx.global_config)()?, &args.package_names)?;
+        let config = (ctx.global_config)()?;
+        args.lockfile_dir.apply_to_global(config)?;
+        global::handle_global_remove(config, &args.package_names)?;
         return Ok(Box::pin(std::future::ready(Ok(()))));
     }
     let dir = ctx.dir;
@@ -137,6 +147,7 @@ pub(super) fn remove<'a>(ctx: &RunCtx<'a>, args: RemoveArgs) -> miette::Result<C
     let config = ctx.config;
     Ok(Box::pin(async move {
         let cfg = config()?;
+        args.lockfile_dir.apply_to(cfg, dir);
         let (config_root, package_manager_to_sync) =
             derive_config_root_and_package_manager_to_sync(cfg, dir, reporter)
                 .wrap_err("derive workspace root and package manager policy")?;
@@ -184,6 +195,7 @@ pub(super) fn install<'a>(
             // mutable through `Config::leak`'s
             // `&'static mut Config` return.
             let cfg = config()?;
+            args.lockfile_dir.apply_to(cfg, dir);
             apply_install_cli_config(cfg, &args);
             let frozen_lockfile = args.effective_frozen_lockfile(cfg);
             let require_lockfile = frozen_lockfile;

--- a/pnpm/crates/cli/src/cli_args/dlx.rs
+++ b/pnpm/crates/cli/src/cli_args/dlx.rs
@@ -367,6 +367,9 @@ async fn install_into_cache<Reporter: self::Reporter + 'static>(
     // rather than `None`, which walks up from the cache dir and can
     // adopt a stray `pnpm-workspace.yaml` above it (pnpm/pnpm#13697).
     config.workspace_dir = Some(prepare_dir.to_path_buf());
+    // Same reasoning for a pinned `lockfileDir`: it names the caller's
+    // lockfile, which the throwaway install must not touch.
+    config.lockfile_dir = None;
     // The caller's patches never apply to the throwaway install (pnpm's
     // dlx installs the package unpatched too). Their paths are relative
     // to the caller's workspace root, which the anchor above replaced, so

--- a/pnpm/crates/cli/src/cli_args/global.rs
+++ b/pnpm/crates/cli/src/cli_args/global.rs
@@ -488,8 +488,11 @@ async fn run_group_install<Reporter: self::Reporter + 'static>(
     cfg.enable_global_virtual_store = false;
     // Persist a `pnpm-lock.yaml` in the group's install dir (pnpm sets
     // `lockfileDir = installDir`). `outdated -g` / `update -g` read these
-    // pins to determine the currently-installed versions.
+    // pins to determine the currently-installed versions. A `lockfileDir`
+    // the environment set cannot redirect it — pnpm deletes the setting
+    // under `--global`.
     cfg.lockfile = true;
+    cfg.lockfile_dir = None;
     // Pin the group's workspace root to its own install dir (pnpm's
     // `rootProjectManifestDir: installDir`, `workspaceDir: undefined`). The
     // install dir sits *under* the global packages dir, which carries a

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -779,22 +779,24 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
     } else {
         None
     };
+    // Importer ids name projects relative to the lockfile, which
+    // `lockfileDir` can pin somewhere other than the workspace the
+    // selection was resolved in. The server request, the merge below, and
+    // the lockfile on disk all have to agree on them.
     let selection_importer_ids = selection.map(|selection| {
+        let importer_root = state.config.lockfile_dir_for(&selection.workspace_root);
         let real_importer_ids = selection
             .projects
             .iter()
             .map(|project| {
-                pnpm_workspace::importer_id_from_root_dir(
-                    &selection.workspace_root,
-                    &project.root_dir,
-                )
+                pnpm_workspace::importer_id_from_root_dir(importer_root, &project.root_dir)
             })
             .collect();
         let selected_importer_ids = selection
             .selected_dirs
             .iter()
             .map(|project_dir| {
-                pnpm_workspace::importer_id_from_root_dir(&selection.workspace_root, project_dir)
+                pnpm_workspace::importer_id_from_root_dir(importer_root, project_dir)
             })
             .collect();
         (real_importer_ids, selected_importer_ids)
@@ -1144,7 +1146,8 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
         selection_importer_ids.as_ref().or(full_workspace_importer_ids.as_ref()),
         selection
             .map(|selection| selection.workspace_root.as_path())
-            .or(state.config.workspace_dir.as_deref()),
+            .or(state.config.workspace_dir.as_deref())
+            .map(|root| state.config.lockfile_dir_for(root)),
     ) {
         outcome.lockfile = merge_filtered_wanted_lockfile(
             previous_wanted,
@@ -1282,14 +1285,20 @@ fn resolve_projects_for_pnpr(
     use_state_lockfile: bool,
 ) -> miette::Result<Vec<ResolveProject>> {
     if let Some(selection) = selection {
-        return Ok(resolve_workspace_projects(&selection.workspace_root, &selection.projects));
+        return Ok(resolve_workspace_projects(
+            state.config.lockfile_dir_for(&selection.workspace_root),
+            &selection.projects,
+        ));
     }
     if use_state_lockfile
         && state.config.shares_one_lockfile()
         && let Some(workspace_root) = state.config.workspace_dir.as_deref()
     {
         let (projects, _) = discover_workspace_projects(workspace_root)?;
-        return Ok(resolve_workspace_projects(workspace_root, &projects));
+        return Ok(resolve_workspace_projects(
+            state.config.lockfile_dir_for(workspace_root),
+            &projects,
+        ));
     }
     Ok(vec![resolve_project(".".to_string(), &state.manifest)])
 }

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -1,7 +1,7 @@
 use crate::{
     State,
     cli_args::{
-        legacy_pnpm_field::warn_ignored_pnpm_manifest_fields_in,
+        legacy_pnpm_field::warn_ignored_pnpm_manifest_fields_in, lockfile_dir::LockfileDirArg,
         override_version_references::warn_deprecated_override_version_references,
         pipelines::InstallFamilySelection, recursive::discover_workspace_projects,
         supported_architectures::SupportedArchitecturesArgs,
@@ -115,6 +115,9 @@ pub struct InstallArgs {
     /// `node_modules`.
     #[clap(long = "lockfile-only")]
     pub lockfile_only: bool,
+
+    #[clap(flatten)]
+    pub lockfile_dir: LockfileDirArg,
 
     /// Show what an install would change without writing anything to disk.
     #[clap(long = "dry-run")]
@@ -271,6 +274,7 @@ impl InstallArgs {
             frozen_lockfile: false,
             no_frozen_lockfile: true,
             lockfile_only: false,
+            lockfile_dir: LockfileDirArg::default(),
             dry_run: false,
             force: false,
             prefer_frozen_lockfile: false,
@@ -342,7 +346,7 @@ impl InstallArgs {
         if config.config_dependencies.as_ref().is_some_and(|deps| !deps.is_empty()) {
             return false;
         }
-        let config_root = config.workspace_dir.clone().unwrap_or_else(|| dir.to_path_buf());
+        let config_root = config.root_project_manifest_dir(dir).to_path_buf();
         if pnpm_hooks::finder::find_pnpmfile(&config_root).is_some() {
             return false;
         }
@@ -450,6 +454,10 @@ impl InstallArgs {
             frozen_lockfile: _,
             no_frozen_lockfile: _,
             lockfile_only,
+            // Pinned onto `config` in the dispatch (`dispatch_install.rs`)
+            // before the state is built, so the install reads it from
+            // `config`, not from here.
+            lockfile_dir: _,
             dry_run,
             // Resolved against config by `apply_install_cli_config` in
             // the dispatch, like `ignore_scripts` below.

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -340,7 +340,7 @@ impl InstallArgs {
         // project; a single-dir up-to-date probe can't speak for the
         // sibling projects, so the loop (whose per-project engine runs
         // each have their own optimistic short-circuit) must always run.
-        if !config.shared_workspace_lockfile && config.workspace_dir.is_some() {
+        if !config.shares_one_lockfile() && config.workspace_dir.is_some() {
             return false;
         }
         if config.config_dependencies.as_ref().is_some_and(|deps| !deps.is_empty()) {
@@ -805,7 +805,7 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
     let projects = resolve_projects_for_pnpr(state, selection, link.use_state_lockfile)?;
     let full_workspace_importer_ids = (selection.is_none()
         && link.use_state_lockfile
-        && state.config.shared_workspace_lockfile
+        && state.config.shares_one_lockfile()
         && state.config.workspace_dir.is_some())
     .then(|| {
         let importer_ids: std::collections::HashSet<_> =
@@ -1285,7 +1285,7 @@ fn resolve_projects_for_pnpr(
         return Ok(resolve_workspace_projects(&selection.workspace_root, &selection.projects));
     }
     if use_state_lockfile
-        && state.config.shared_workspace_lockfile
+        && state.config.shares_one_lockfile()
         && let Some(workspace_root) = state.config.workspace_dir.as_deref()
     {
         let (projects, _) = discover_workspace_projects(workspace_root)?;

--- a/pnpm/crates/cli/src/cli_args/list.rs
+++ b/pnpm/crates/cli/src/cli_args/list.rs
@@ -207,7 +207,7 @@ impl ListArgs {
 
         let always_print_root_package = self.depth == RecursionLimit::ProjectsOnly;
 
-        if config.shared_workspace_lockfile {
+        if config.shares_one_lockfile() {
             return self
                 .render_projects(
                     config,

--- a/pnpm/crates/cli/src/cli_args/list.rs
+++ b/pnpm/crates/cli/src/cli_args/list.rs
@@ -213,7 +213,7 @@ impl ListArgs {
                     config,
                     &project_dirs,
                     &self.packages,
-                    &workspace_root,
+                    config.lockfile_dir_for(&workspace_root),
                     always_print_root_package,
                 )
                 .await;
@@ -379,15 +379,9 @@ fn global_report_as(report_as: ReportAs) -> ListReportAs {
     }
 }
 
-/// The directory the lockfile is read from for a non-recursive `list`:
-/// the workspace root under a shared workspace lockfile, the project
-/// itself otherwise.
+/// The directory the lockfile is read from for a non-recursive `list`.
 pub(crate) fn local_lockfile_dir(config: &Config, dir: &Path) -> PathBuf {
-    if config.shared_workspace_lockfile {
-        config.workspace_dir.clone().unwrap_or_else(|| dir.to_path_buf())
-    } else {
-        dir.to_path_buf()
-    }
+    config.lockfile_dir_for(dir).to_path_buf()
 }
 
 /// Print command output the way the TypeScript CLI does: nothing for an

--- a/pnpm/crates/cli/src/cli_args/lockfile_dir.rs
+++ b/pnpm/crates/cli/src/cli_args/lockfile_dir.rs
@@ -1,5 +1,11 @@
 //! `--lockfile-dir`, the install-family flag that pins where
 //! `pnpm-lock.yaml` is created.
+//!
+//! [`LockfileDirArg`] is flattened into every install-family command that
+//! accepts the flag and applied to the loaded [`Config`] through
+//! [`LockfileDirArg::apply_to`] before the state is built, so the whole
+//! install — the lockfile, the root `node_modules`, the virtual store, and
+//! the importer ids — is anchored at the pinned directory.
 
 use clap::Args;
 use derive_more::{Display, Error};
@@ -7,12 +13,9 @@ use miette::Diagnostic;
 use pnpm_config::Config;
 use std::path::{Path, PathBuf};
 
-/// The `--lockfile-dir <dir>` option, flattened into every install-family
-/// command that accepts it. Applied to the loaded [`Config`] through
-/// [`LockfileDirArg::apply_to`] before the state is built, so the whole
-/// install — the lockfile, the root `node_modules`, the virtual store, and
-/// the importer ids — is anchored at the pinned directory.
-#[derive(Debug, Clone, Default, Args)]
+// Doc comments on a clap-derived type reach `--help`, so the contract
+// lives in the module doc above rather than in intra-doc links here.
+#[derive(Debug, Default, Clone, Args)]
 pub struct LockfileDirArg {
     /// The directory in which `pnpm-lock.yaml` is created. Several
     /// projects may share a single lockfile.

--- a/pnpm/crates/cli/src/cli_args/lockfile_dir.rs
+++ b/pnpm/crates/cli/src/cli_args/lockfile_dir.rs
@@ -1,0 +1,52 @@
+//! `--lockfile-dir`, the install-family flag that pins where
+//! `pnpm-lock.yaml` is created.
+
+use clap::Args;
+use derive_more::{Display, Error};
+use miette::Diagnostic;
+use pnpm_config::Config;
+use std::path::{Path, PathBuf};
+
+/// The `--lockfile-dir <dir>` option, flattened into every install-family
+/// command that accepts it. Applied to the loaded [`Config`] through
+/// [`LockfileDirArg::apply_to`] before the state is built, so the whole
+/// install — the lockfile, the root `node_modules`, the virtual store, and
+/// the importer ids — is anchored at the pinned directory.
+#[derive(Debug, Clone, Default, Args)]
+pub struct LockfileDirArg {
+    /// The directory in which `pnpm-lock.yaml` is created. Several
+    /// projects may share a single lockfile.
+    #[clap(long = "lockfile-dir", value_name = "dir")]
+    pub lockfile_dir: Option<PathBuf>,
+}
+
+/// A global install owns a lockfile under its own group directory, so
+/// there is nothing for `--lockfile-dir` to point at. Mirrors pnpm's
+/// `CONFIG_CONFLICT_LOCKFILE_DIR_WITH_GLOBAL`.
+#[derive(Debug, Display, Error, Diagnostic)]
+#[display(r#"Configuration conflict. "lockfile-dir" may not be used with "global""#)]
+#[diagnostic(code(ERR_PNPM_CONFIG_CONFLICT_LOCKFILE_DIR_WITH_GLOBAL))]
+pub struct LockfileDirWithGlobal;
+
+impl LockfileDirArg {
+    /// Pin `config`'s lockfile directory, resolving a relative flag value
+    /// against `dir` — the canonicalized `--dir`, which is what pnpm
+    /// resolves its own `lockfileDir` against.
+    pub(crate) fn apply_to(&self, config: &mut Config, dir: &Path) {
+        if let Some(lockfile_dir) = self.lockfile_dir.as_deref() {
+            config.pin_lockfile_dir(&dir.join(lockfile_dir));
+        }
+    }
+
+    /// The `--global` counterpart of [`Self::apply_to`]: the flag is an
+    /// error there, and a `lockfileDir` that reached the config from
+    /// another source is dropped — pnpm deletes the setting rather than
+    /// erroring when the CLI did not ask for it.
+    pub(crate) fn apply_to_global(&self, config: &mut Config) -> Result<(), LockfileDirWithGlobal> {
+        if self.lockfile_dir.is_some() {
+            return Err(LockfileDirWithGlobal);
+        }
+        config.lockfile_dir = None;
+        Ok(())
+    }
+}

--- a/pnpm/crates/cli/src/cli_args/outdated.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated.rs
@@ -593,6 +593,9 @@ impl OutdatedArgs {
         let config = state.config;
         let workspace_root =
             config.workspace_dir.clone().unwrap_or_else(|| state.lockfile_dir().to_path_buf());
+        // The lockfile the importer ids name may sit somewhere else than
+        // the workspace the projects are discovered in — `lockfileDir`.
+        let lockfile_root = state.lockfile_dir().to_path_buf();
         let (projects, _) = discover_workspace_projects(&workspace_root)?;
         let prefix = state.manifest.path().parent().unwrap_or_else(|| state.manifest.path());
         let selection =
@@ -644,14 +647,14 @@ impl OutdatedArgs {
                 let (lockfile, importer_id) = if config.shared_workspace_lockfile {
                     (
                         shared_lockfile,
-                        pnpm_workspace::importer_id_from_root_dir(&workspace_root, project_dir),
+                        pnpm_workspace::importer_id_from_root_dir(&lockfile_root, project_dir),
                     )
                 } else {
                     (project_lockfile.as_ref(), Lockfile::ROOT_IMPORTER_KEY.to_string())
                 };
                 let Some(lockfile) = lockfile else {
                     let lockfile_dir = if config.shared_workspace_lockfile {
-                        workspace_root.as_path()
+                        lockfile_root.as_path()
                     } else {
                         project_dir.as_path()
                     };
@@ -748,6 +751,7 @@ impl OutdatedArgs {
         let mut isolated_config = config.clone();
         isolated_config.workspace_dir = None;
         isolated_config.shared_workspace_lockfile = false;
+        isolated_config.lockfile_dir = None;
         // A group's lockfile is written unconditionally (`run_group_install`
         // forces it) because it is where the installed versions are recorded,
         // so reading it back must not depend on the caller's `lockfile`

--- a/pnpm/crates/cli/src/cli_args/outdated.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated.rs
@@ -611,7 +611,7 @@ impl OutdatedArgs {
             include_deprecated: true,
         };
 
-        let shared_lockfile = if config.shared_workspace_lockfile {
+        let shared_lockfile = if config.shares_one_lockfile() {
             state
                 .lockfile
                 .get()
@@ -634,7 +634,7 @@ impl OutdatedArgs {
             if !has_any_dependency {
                 continue;
             }
-            let project_lockfile = if config.shared_workspace_lockfile {
+            let project_lockfile = if config.shares_one_lockfile() {
                 None
             } else {
                 Lockfile::load_wanted_from_dir(project_dir).into_diagnostic()?
@@ -644,7 +644,7 @@ impl OutdatedArgs {
         let run = OutdatedRun::new(config)?;
         let project_queries =
             project_inputs.iter().map(|(project_dir, project, project_lockfile)| async {
-                let (lockfile, importer_id) = if config.shared_workspace_lockfile {
+                let (lockfile, importer_id) = if config.shares_one_lockfile() {
                     (
                         shared_lockfile,
                         pnpm_workspace::importer_id_from_root_dir(&lockfile_root, project_dir),
@@ -653,7 +653,7 @@ impl OutdatedArgs {
                     (project_lockfile.as_ref(), Lockfile::ROOT_IMPORTER_KEY.to_string())
                 };
                 let Some(lockfile) = lockfile else {
-                    let lockfile_dir = if config.shared_workspace_lockfile {
+                    let lockfile_dir = if config.shares_one_lockfile() {
                         lockfile_root.as_path()
                     } else {
                         project_dir.as_path()

--- a/pnpm/crates/cli/src/cli_args/peers.rs
+++ b/pnpm/crates/cli/src/cli_args/peers.rs
@@ -98,11 +98,7 @@ impl PeersArgs {
             }
         }
 
-        let lockfile_dir = if config.shared_workspace_lockfile {
-            config.workspace_dir.as_deref().unwrap_or(dir)
-        } else {
-            dir
-        };
+        let lockfile_dir = config.lockfile_dir_for(dir);
         let project_dirs = if recursive {
             let workspace_root = config.workspace_dir.as_deref().unwrap_or(dir);
             let (projects, _) = discover_workspace_projects(workspace_root)?;

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -164,7 +164,7 @@ pub(crate) fn select_workspace_projects(
 
 /// Build the project-anchored `State` for one project of a
 /// `sharedWorkspaceLockfile: false` workspace: clone `cfg`, re-anchor its
-/// output paths under `project_dir` via [`anchor_dedicated_project_config`],
+/// output paths under `project_dir` via [`Config::anchor_lockfile_paths`],
 /// and initialize the state. The clone is leaked because [`State::init`] needs
 /// a `&'static Config`; see [`run_dedicated_lockfile_workspace_install`] for
 /// why the bounded leak is acceptable.
@@ -174,7 +174,7 @@ fn init_dedicated_project_state(
     require_lockfile: bool,
 ) -> miette::Result<State> {
     let mut project_config = cfg.clone();
-    anchor_dedicated_project_config(&mut project_config, project_dir);
+    project_config.anchor_lockfile_paths(project_dir);
     let project_config = Config::leak(project_config);
     State::init(project_dir.join("package.json"), project_config, require_lockfile)
         .wrap_err_with(|| format!("initialize the state for {}", project_dir.display()))
@@ -354,7 +354,7 @@ impl AddPipeline {
                         .parent()
                         .expect("manifest path always has a parent dir")
                         .to_path_buf();
-                    anchor_dedicated_project_config(cfg, &manifest_dir);
+                    cfg.anchor_lockfile_paths(&manifest_dir);
                 }
                 let cfg: &'static Config = cfg;
                 let state =
@@ -428,7 +428,7 @@ impl UpdatePipeline {
                 .parent()
                 .expect("manifest path always has a parent dir")
                 .to_path_buf();
-            anchor_dedicated_project_config(cfg, &manifest_dir);
+            cfg.anchor_lockfile_paths(&manifest_dir);
         }
         let generate_changeset = if args.changeset {
             true
@@ -538,7 +538,7 @@ impl RemovePipeline {
                         .parent()
                         .expect("manifest path always has a parent dir")
                         .to_path_buf();
-                    anchor_dedicated_project_config(cfg, &manifest_dir);
+                    cfg.anchor_lockfile_paths(&manifest_dir);
                 }
                 let cfg: &'static Config = cfg;
                 let state =
@@ -577,36 +577,6 @@ impl DeployPipeline {
         config_deps::run_update_config_hooks::<Reporter>(cfg, &config_root).await?;
         let cfg: &'static Config = cfg;
         Box::pin(args.run::<Reporter>(cfg, dir_ref)).await
-    }
-}
-
-/// Re-anchor the per-project output paths for dedicated per-project
-/// lockfiles (`sharedWorkspaceLockfile: false`): `node_modules` and the
-/// virtual store live under the project, mirroring pnpm, which resolves
-/// them against `lockfileDir` — the project dir in dedicated mode. An
-/// explicit `virtualStoreDir` setting re-resolves against the project
-/// (its raw value is recovered from [`Config::explicit_settings`]);
-/// the default stays `<modules_dir>/.pnpm`. Global-virtual-store
-/// installs keep their store-anchored `virtual_store_dir`.
-pub(crate) fn anchor_dedicated_project_config(config: &mut Config, project_dir: &Path) {
-    // Both re-anchored paths resolve the *raw* setting (recovered from
-    // [`Config::explicit_settings`]) against the project dir, so a
-    // multi-component or absolute value keeps its full shape —
-    // `Path::join` keeps an absolute setting absolute.
-    config.modules_dir =
-        match config.explicit_settings.get("modulesDir").and_then(serde_json::Value::as_str) {
-            Some(raw) => project_dir.join(raw),
-            None => project_dir.join("node_modules"),
-        };
-    if !config.enable_global_virtual_store {
-        config.virtual_store_dir = match config
-            .explicit_settings
-            .get("virtualStoreDir")
-            .and_then(serde_json::Value::as_str)
-        {
-            Some(raw) => project_dir.join(raw),
-            None => config.modules_dir.join(".pnpm"),
-        };
     }
 }
 
@@ -653,7 +623,7 @@ pub(crate) fn derive_config_root_and_package_manager_to_sync(
     dir_ref: &Path,
     reporter: ReporterType,
 ) -> miette::Result<(PathBuf, Option<PackageManagerToSync>)> {
-    let config_root = cfg.workspace_dir.clone().unwrap_or_else(|| dir_ref.to_path_buf());
+    let config_root = cfg.root_project_manifest_dir(dir_ref).to_path_buf();
     let root_manifest = read_manifest_json(&config_root.join("package.json"))
         .wrap_err("read package manager policy")?;
     // pnpm warns from config-reading, so the notice lands ahead of any

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -87,7 +87,7 @@ fn select_install_family_plan<Reporter: self::Reporter>(
         total: Some(selection.projects.len()),
         workspace_prefix: Some(selection.workspace_root.to_string_lossy().into_owned()),
     }));
-    if !cfg.shared_workspace_lockfile {
+    if !cfg.shares_one_lockfile() {
         let mut project_dirs: Vec<PathBuf> = selection.selected_dirs.iter().cloned().collect();
         project_dirs.sort();
         return Ok(InstallFamilyPlan::PerProject(project_dirs));
@@ -248,7 +248,7 @@ impl InstallPipeline {
                 Box::pin(args.run_selected::<Reporter>(state, *selection)).await
             }
             InstallFamilyPlan::Single => {
-                if !cfg.shared_workspace_lockfile
+                if !cfg.shares_one_lockfile()
                     && let Some(workspace_dir) = cfg.workspace_dir.clone()
                 {
                     let cfg: &'static Config = cfg;
@@ -347,7 +347,7 @@ impl AddPipeline {
                 // `--config` targets the workspace's configuration
                 // dependencies, which stay workspace-anchored.
                 if config_dependencies.is_none()
-                    && !cfg.shared_workspace_lockfile
+                    && !cfg.shares_one_lockfile()
                     && cfg.workspace_dir.is_some()
                 {
                     let manifest_dir = manifest_path
@@ -421,7 +421,7 @@ impl UpdatePipeline {
         // mutates only the active project, whose outputs anchor at the
         // project dir.
         if matches!(plan, InstallFamilyPlan::Single)
-            && !cfg.shared_workspace_lockfile
+            && !cfg.shares_one_lockfile()
             && cfg.workspace_dir.is_some()
         {
             let manifest_dir = manifest_path
@@ -533,7 +533,7 @@ impl RemovePipeline {
                 // Dedicated per-project lockfiles: the non-recursive command
                 // mutates only the active project, whose outputs anchor at the
                 // project dir.
-                if !cfg.shared_workspace_lockfile && cfg.workspace_dir.is_some() {
+                if !cfg.shares_one_lockfile() && cfg.workspace_dir.is_some() {
                     let manifest_dir = manifest_path
                         .parent()
                         .expect("manifest path always has a parent dir")

--- a/pnpm/crates/cli/src/cli_args/rebuild.rs
+++ b/pnpm/crates/cli/src/cli_args/rebuild.rs
@@ -56,7 +56,7 @@ impl RebuildArgs {
         {
             return Ok(());
         }
-        if !cfg.shared_workspace_lockfile
+        if !cfg.shares_one_lockfile()
             && let Some(workspace_selection) = workspace_selection
         {
             let base_config = cfg.clone();

--- a/pnpm/crates/cli/src/cli_args/rebuild.rs
+++ b/pnpm/crates/cli/src/cli_args/rebuild.rs
@@ -15,9 +15,7 @@ use std::{
 
 use crate::{
     State,
-    cli_args::pipelines::{
-        InstallFamilySelection, anchor_dedicated_project_config, select_workspace_projects,
-    },
+    cli_args::pipelines::{InstallFamilySelection, select_workspace_projects},
 };
 
 /// `pacquet rebuild` — re-run the lifecycle scripts of installed
@@ -70,7 +68,7 @@ impl RebuildArgs {
                     let rebuilds = batch.iter().cloned().map(|project_dir| {
                         let args = self.clone();
                         let mut project_config = base_config.clone();
-                        anchor_dedicated_project_config(&mut project_config, &project_dir);
+                        project_config.anchor_lockfile_paths(&project_dir);
                         async move {
                             let project_config = Config::leak(project_config);
                             let state =

--- a/pnpm/crates/cli/src/cli_args/remove.rs
+++ b/pnpm/crates/cli/src/cli_args/remove.rs
@@ -1,4 +1,7 @@
-use crate::{State, cli_args::pipelines::InstallFamilySelection};
+use crate::{
+    State,
+    cli_args::{lockfile_dir::LockfileDirArg, pipelines::InstallFamilySelection},
+};
 use clap::Args;
 use miette::Context;
 use pnpm_package_manager::Remove;
@@ -46,6 +49,8 @@ pub struct RemoveArgs {
     /// and `pnpm-lock.yaml` are updated.
     #[clap(long = "lockfile-only")]
     pub lockfile_only: bool,
+    #[clap(flatten)]
+    pub lockfile_dir: LockfileDirArg,
     /// Remove the package from the global packages directory and unlink its
     /// bins.
     #[clap(short = 'g', long)]

--- a/pnpm/crates/cli/src/cli_args/sbom.rs
+++ b/pnpm/crates/cli/src/cli_args/sbom.rs
@@ -805,7 +805,7 @@ fn missing_importers(selected: &HashSet<String>, lockfile_ids: &[String]) -> Vec
 
 impl SbomArgs {
     pub async fn run(self, state: State) -> miette::Result<()> {
-        if !state.config.shared_workspace_lockfile
+        if !state.config.shares_one_lockfile()
             && (state.config.recursive || self.split || selectors_narrow_the_run(state.config))
         {
             return Err(

--- a/pnpm/crates/cli/src/cli_args/update.rs
+++ b/pnpm/crates/cli/src/cli_args/update.rs
@@ -1,7 +1,7 @@
 use crate::{
     State,
     cli_args::{
-        pipelines::InstallFamilySelection, recursive,
+        lockfile_dir::LockfileDirArg, pipelines::InstallFamilySelection, recursive,
         supported_architectures::SupportedArchitecturesArgs,
         update_interactive::InteractiveUpdateOptions,
     },
@@ -100,6 +100,9 @@ pub struct UpdateArgs {
     /// Dependencies are not downloaded; only `pnpm-lock.yaml` is updated.
     #[clap(long = "lockfile-only")]
     pub lockfile_only: bool,
+
+    #[clap(flatten)]
+    pub lockfile_dir: LockfileDirArg,
 
     /// Show outdated dependencies and select which ones to update.
     #[clap(short = 'i', long)]

--- a/pnpm/crates/cli/src/cli_args/update_interactive.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive.rs
@@ -58,6 +58,7 @@ pub(crate) async fn select_global_package_groups(
     let mut config = base_config.clone();
     config.workspace_dir = None;
     config.shared_workspace_lockfile = false;
+    config.lockfile_dir = None;
     // A group's lockfile is written unconditionally (`run_group_install`
     // forces it) because it is where the installed versions are recorded, so
     // reading it back must not depend on the caller's `lockfile` setting.

--- a/pnpm/crates/cli/src/state.rs
+++ b/pnpm/crates/cli/src/state.rs
@@ -69,14 +69,12 @@ impl State {
     ) -> Result<Self, InitStateError> {
         let should_load = config.lockfile || require_lockfile;
         let lockfile = if should_load {
-            let manifest_dir =
-                manifest_path.parent().expect("manifest path always has a parent dir");
-            if config.shared_workspace_lockfile {
-                config.workspace_dir.clone().unwrap_or_else(|| manifest_dir.to_path_buf())
-            } else {
-                manifest_dir.to_path_buf()
-            }
-            .pipe(LazyLockfile::deferred)
+            manifest_path
+                .parent()
+                .expect("manifest path always has a parent dir")
+                .pipe(|manifest_dir| config.lockfile_dir_for(manifest_dir))
+                .to_path_buf()
+                .pipe(LazyLockfile::deferred)
         } else {
             LazyLockfile::disabled()
         };
@@ -110,12 +108,7 @@ impl State {
     }
 
     pub fn lockfile_dir(&self) -> &Path {
-        let manifest_dir = self.project_dir();
-        if self.config.shared_workspace_lockfile {
-            self.config.workspace_dir.as_deref().unwrap_or(manifest_dir)
-        } else {
-            manifest_dir
-        }
+        self.config.lockfile_dir_for(self.project_dir())
     }
 
     pub fn lockfile_path(&self) -> PathBuf {

--- a/pnpm/crates/cli/tests/suite/deploy.rs
+++ b/pnpm/crates/cli/tests/suite/deploy.rs
@@ -140,6 +140,43 @@ fn deploy_from_shared_lockfile_follows_a_pinned_lockfile_dir() {
     drop((root, mock_instance));
 }
 
+/// A pin that does not contain the workspace gives every project an
+/// importer id that climbs out of the lockfile dir, and deploy resolves
+/// each of them by joining onto that dir — paths it refuses on principle.
+/// The shared path cannot describe the layout, so it hands over to the
+/// legacy installer rather than failing the command.
+#[test]
+fn deploy_falls_back_when_the_pinned_lockfile_dir_is_outside_the_workspace() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    write_reachability_workspace(&workspace);
+    fs::create_dir_all(root.path().join("side")).unwrap();
+    let mut workspace_yaml = fs::read_to_string(workspace.join("pnpm-workspace.yaml")).unwrap();
+    workspace_yaml.push_str("lockfileDir: ../side\n");
+    fs::write(workspace.join("pnpm-workspace.yaml"), workspace_yaml).unwrap();
+
+    pacquet.with_arg("install").assert().success();
+
+    let output = pacquet_cmd(&workspace)
+        .with_args(["--filter", "app", "deploy", "--prod", "deploy"])
+        .output()
+        .expect("spawn pacquet deploy");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "deploy must fall back, not fail:\n{stdout}\n{stderr}");
+    assert!(
+        stdout.contains("is outside the workspace, so its importer paths cannot be deployed"),
+        "the fallback must say why the shared lockfile was unusable:\n{stdout}",
+    );
+    assert!(
+        is_symlink_or_junction(&workspace.join("deploy/node_modules/lib")).unwrap(),
+        "the legacy deploy still links the prod workspace dependency",
+    );
+
+    drop((root, mock_instance));
+}
+
 #[test]
 fn production_deploy_does_not_require_dev_only_workspace_sources() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =

--- a/pnpm/crates/cli/tests/suite/deploy.rs
+++ b/pnpm/crates/cli/tests/suite/deploy.rs
@@ -1,3 +1,5 @@
+use crate::_utils::append_workspace_yaml_key;
+
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pnpm_lockfile::Lockfile;
@@ -106,9 +108,7 @@ fn deploy_from_shared_lockfile_follows_a_pinned_lockfile_dir() {
         CommandTempCwd::init().add_mocked_registry();
     let AddMockedRegistry { mock_instance, .. } = npmrc_info;
     write_reachability_workspace(&workspace);
-    let mut workspace_yaml = fs::read_to_string(workspace.join("pnpm-workspace.yaml")).unwrap();
-    workspace_yaml.push_str("lockfileDir: ..\n");
-    fs::write(workspace.join("pnpm-workspace.yaml"), workspace_yaml).unwrap();
+    append_workspace_yaml_key(&workspace, "lockfileDir", "..");
 
     pacquet.with_arg("install").assert().success();
     assert!(
@@ -146,15 +146,13 @@ fn deploy_from_shared_lockfile_follows_a_pinned_lockfile_dir() {
 /// The shared path cannot describe the layout, so it hands over to the
 /// legacy installer rather than failing the command.
 #[test]
-fn deploy_falls_back_when_the_pinned_lockfile_dir_is_outside_the_workspace() {
+fn deploy_falls_back_when_the_pinned_lockfile_dir_does_not_contain_the_workspace() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();
     let AddMockedRegistry { mock_instance, .. } = npmrc_info;
     write_reachability_workspace(&workspace);
     fs::create_dir_all(root.path().join("side")).unwrap();
-    let mut workspace_yaml = fs::read_to_string(workspace.join("pnpm-workspace.yaml")).unwrap();
-    workspace_yaml.push_str("lockfileDir: ../side\n");
-    fs::write(workspace.join("pnpm-workspace.yaml"), workspace_yaml).unwrap();
+    append_workspace_yaml_key(&workspace, "lockfileDir", "../side");
 
     pacquet.with_arg("install").assert().success();
 
@@ -166,7 +164,7 @@ fn deploy_falls_back_when_the_pinned_lockfile_dir_is_outside_the_workspace() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(output.status.success(), "deploy must fall back, not fail:\n{stdout}\n{stderr}");
     assert!(
-        stdout.contains("is outside the workspace, so its importer paths cannot be deployed"),
+        stdout.contains("does not contain the workspace, so its importer paths cannot be deployed"),
         "the fallback must say why the shared lockfile was unusable:\n{stdout}",
     );
     assert!(

--- a/pnpm/crates/cli/tests/suite/deploy.rs
+++ b/pnpm/crates/cli/tests/suite/deploy.rs
@@ -95,6 +95,51 @@ fn deploy_from_shared_lockfile_installs_selected_project() {
     drop((root, mock_instance));
 }
 
+/// A pinned `lockfileDir` moves the shared lockfile `deploy` reads and
+/// the importer id naming the selected project in it. Reading either from
+/// the workspace root instead drops the deploy to its "shared lockfile not
+/// found" fallback, which installs the project without a lockfile and can
+/// resolve versions the workspace never pinned.
+#[test]
+fn deploy_from_shared_lockfile_follows_a_pinned_lockfile_dir() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    write_reachability_workspace(&workspace);
+    let mut workspace_yaml = fs::read_to_string(workspace.join("pnpm-workspace.yaml")).unwrap();
+    workspace_yaml.push_str("lockfileDir: ..\n");
+    fs::write(workspace.join("pnpm-workspace.yaml"), workspace_yaml).unwrap();
+
+    pacquet.with_arg("install").assert().success();
+    assert!(
+        root.path().join("pnpm-lock.yaml").is_file(),
+        "the install must have written the lockfile at the pin",
+    );
+
+    let output = pacquet_cmd(&workspace)
+        .with_args(["--filter", "app", "deploy", "--prod", "deploy"])
+        .output()
+        .expect("spawn pacquet deploy");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success(), "deploy must succeed:\n{stdout}");
+    assert!(
+        !stdout.contains("Shared lockfile not found"),
+        "deploy must find the lockfile at the pin:\n{stdout}",
+    );
+
+    let deploy_dir = workspace.join("deploy");
+    assert!(
+        deploy_dir.join("pnpm-lock.yaml").is_file(),
+        "the deployed project gets its own lockfile, not the pinned one",
+    );
+    assert!(
+        is_symlink_or_junction(&deploy_dir.join("node_modules/lib")).unwrap(),
+        "the prod workspace dependency must be linked into the deploy dir",
+    );
+
+    drop((root, mock_instance));
+}
+
 #[test]
 fn production_deploy_does_not_require_dev_only_workspace_sources() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =

--- a/pnpm/crates/cli/tests/suite/lockfile_dir.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_dir.rs
@@ -261,8 +261,8 @@ fn a_pin_overrides_dedicated_per_project_lockfiles() {
     let lockfile_dir = root.path();
     assert_eq!(importer_ids(lockfile_dir), ["workspace", "workspace/packages/a"]);
     assert!(
-        !package_dir.join("pnpm-lock.yaml").exists(),
-        "the pin replaces the per-project lockfiles",
+        !package_dir.join("pnpm-lock.yaml").exists() && !workspace.join("pnpm-lock.yaml").exists(),
+        "the pin replaces the per-project lockfiles and leaves none at the workspace root",
     );
     assert!(
         package_dir.join("node_modules/is-positive/package.json").is_file(),

--- a/pnpm/crates/cli/tests/suite/lockfile_dir.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_dir.rs
@@ -252,7 +252,7 @@ fn a_pin_overrides_dedicated_per_project_lockfiles() {
     .expect("write the package manifest");
     fs::write(workspace.join("package.json"), r#"{"name":"root","version":"1.0.0"}"#)
         .expect("write the root manifest");
-    append_workspace_yaml_key(&workspace, "packages", "\n  - packages/*");
+    append_workspace_yaml_key(&workspace, "packages", "['packages/*']");
     append_workspace_yaml_key(&workspace, "sharedWorkspaceLockfile", false);
     append_workspace_yaml_key(&workspace, "lockfileDir", "..");
 

--- a/pnpm/crates/cli/tests/suite/lockfile_dir.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_dir.rs
@@ -5,21 +5,33 @@
 //! and the importer ids, which become the paths from the pin down to each
 //! project. Every project keeps its own `node_modules` of symlinks.
 
-use crate::_utils::append_workspace_yaml_key;
+use crate::_utils::{append_workspace_yaml_key, pacquet_in};
 
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pnpm_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
+use serde_json::json;
 use std::{fs, path::Path, process::Command};
 
-/// The `importers:` keys of the lockfile at `lockfile_dir`.
+/// Whether an install reported the project as already up to date. Read
+/// off the NDJSON stream (which the reporter writes to stderr) because
+/// the default reporter only prints a message whose prefix is the current
+/// directory, and a pinned `lockfileDir` is by definition somewhere else.
+fn reported_up_to_date(ndjson: &str) -> bool {
+    ndjson.lines().any(|line| line.contains(r#""message":"Already up to date""#))
+}
+
+/// The `importers:` keys of the lockfile at `lockfile_dir`, sorted —
+/// the parsed map is a `HashMap`, so only the serialized file is ordered.
 fn importer_ids(lockfile_dir: &Path) -> Vec<String> {
-    pnpm_lockfile::Lockfile::load_wanted_from_dir(lockfile_dir)
+    let mut ids: Vec<String> = pnpm_lockfile::Lockfile::load_wanted_from_dir(lockfile_dir)
         .expect("load pnpm-lock.yaml")
         .expect("pnpm-lock.yaml exists at the pinned lockfile dir")
         .importers
         .into_keys()
-        .collect()
+        .collect();
+    ids.sort_unstable();
+    ids
 }
 
 /// `--lockfile-dir` puts `pnpm-lock.yaml` and the virtual store in a
@@ -117,4 +129,145 @@ fn lockfile_dir_conflicts_with_global() {
     );
 
     drop((root, mock_instance));
+}
+
+/// Adopting `lockfileDir` after an install without it must not let the
+/// repeat-install short-circuit answer for the old layout: the state and
+/// lockfile the previous install left at the workspace root say "up to
+/// date", but nothing has been written at the pin yet.
+#[test]
+fn adopting_lockfile_dir_re_installs_at_the_pin() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "name": "project",
+            "version": "1.0.0",
+            "dependencies": { "is-positive": "1.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    pacquet.with_arg("install").assert().success();
+    assert!(workspace.join("pnpm-lock.yaml").is_file(), "the first install writes in place");
+
+    append_workspace_yaml_key(&workspace, "lockfileDir", "..");
+    let output = pacquet_in(&workspace)
+        .with_args(["install", "--reporter=ndjson"])
+        .output()
+        .expect("spawn pacquet install");
+    let ndjson = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "the re-anchored install must succeed:\n{ndjson}");
+    assert!(
+        !reported_up_to_date(&ndjson),
+        "the pin has no lockfile yet, so the install cannot report up to date:\n{ndjson}",
+    );
+
+    let lockfile_dir = root.path();
+    assert_eq!(importer_ids(lockfile_dir), ["workspace"]);
+    assert!(
+        lockfile_dir.join("node_modules/.pnpm/is-positive@1.0.0").is_dir(),
+        "the virtual store must be materialized under the pin",
+    );
+
+    drop(mock_instance);
+}
+
+/// A repeat install against a pinned lockfile reads the state the
+/// previous one wrote at the pin, so it short-circuits — and the
+/// `verifyDepsBeforeRun` gate reads the same state, so `pnpm run` finds
+/// the dependencies current instead of reinstalling before every script.
+#[cfg(unix)]
+#[test]
+fn a_pinned_install_is_current_for_repeat_installs_and_for_run() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let marker = workspace.join("marker.txt");
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "name": "project",
+            "version": "1.0.0",
+            "dependencies": { "is-positive": "1.0.0" },
+            "scripts": { "hello": format!(r#"touch "{}""#, marker.display()) },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    append_workspace_yaml_key(&workspace, "lockfileDir", "..");
+
+    pacquet.with_arg("install").assert().success();
+
+    let output = pacquet_in(&workspace)
+        .with_args(["install", "--reporter=ndjson"])
+        .output()
+        .expect("spawn pacquet install");
+    let ndjson = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "the repeat install must succeed:\n{ndjson}");
+    assert!(
+        reported_up_to_date(&ndjson),
+        "the repeat install must short-circuit on the state written at the pin:\n{ndjson}",
+    );
+
+    let output =
+        pacquet_in(&workspace).with_args(["run", "hello"]).output().expect("spawn pacquet run");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success(), "the script must run:\n{stdout}");
+    assert!(marker.is_file(), "the script must have run:\n{stdout}");
+    assert!(
+        !stdout.contains("Cannot check whether dependencies are outdated"),
+        "the gate must find the state the pinned install wrote:\n{stdout}",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// `sharedWorkspaceLockfile: false` asks for a lockfile per project, but
+/// an explicit `lockfileDir` names the one directory they all share, so
+/// the pin wins — as it does in pnpm, whose recursive dispatch routes any
+/// run with a `lockfileDir` through its shared-lockfile branch.
+#[test]
+fn a_pin_overrides_dedicated_per_project_lockfiles() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let package_dir = workspace.join("packages/a");
+    fs::create_dir_all(&package_dir).expect("create the workspace package dir");
+    fs::write(
+        package_dir.join("package.json"),
+        json!({
+            "name": "a",
+            "version": "1.0.0",
+            "dependencies": { "is-positive": "1.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write the package manifest");
+    fs::write(workspace.join("package.json"), r#"{"name":"root","version":"1.0.0"}"#)
+        .expect("write the root manifest");
+    append_workspace_yaml_key(&workspace, "packages", "\n  - packages/*");
+    append_workspace_yaml_key(&workspace, "sharedWorkspaceLockfile", false);
+    append_workspace_yaml_key(&workspace, "lockfileDir", "..");
+
+    pacquet.with_arg("install").assert().success();
+
+    let lockfile_dir = root.path();
+    assert_eq!(importer_ids(lockfile_dir), ["workspace", "workspace/packages/a"]);
+    assert!(
+        !package_dir.join("pnpm-lock.yaml").exists(),
+        "the pin replaces the per-project lockfiles",
+    );
+    assert!(
+        package_dir.join("node_modules/is-positive/package.json").is_file(),
+        "the workspace package still links its dependency",
+    );
+
+    drop(mock_instance);
 }

--- a/pnpm/crates/cli/tests/suite/lockfile_dir.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_dir.rs
@@ -1,0 +1,120 @@
+//! The `lockfileDir` setting and its `--lockfile-dir` flag.
+//!
+//! Pinning the lockfile directory moves the whole shared layout with it:
+//! `pnpm-lock.yaml`, the root `node_modules` holding the virtual store,
+//! and the importer ids, which become the paths from the pin down to each
+//! project. Every project keeps its own `node_modules` of symlinks.
+
+use crate::_utils::append_workspace_yaml_key;
+
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pnpm_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
+use std::{fs, path::Path, process::Command};
+
+/// The `importers:` keys of the lockfile at `lockfile_dir`.
+fn importer_ids(lockfile_dir: &Path) -> Vec<String> {
+    pnpm_lockfile::Lockfile::load_wanted_from_dir(lockfile_dir)
+        .expect("load pnpm-lock.yaml")
+        .expect("pnpm-lock.yaml exists at the pinned lockfile dir")
+        .importers
+        .into_keys()
+        .collect()
+}
+
+/// `--lockfile-dir` puts `pnpm-lock.yaml` and the virtual store in a
+/// directory above the project, and names the project by its path from
+/// there. The project still gets its own `node_modules` with the
+/// dependency linked in. Ports pnpm's "install with external lockfile
+/// directory".
+#[test]
+fn external_lockfile_dir_holds_the_lockfile_and_the_virtual_store() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let lockfile_dir = workspace.join("nested");
+    let project_dir = lockfile_dir.join("project");
+    fs::create_dir_all(&project_dir).expect("create the project dir");
+    fs::write(project_dir.join("package.json"), r#"{"name":"project","version":"1.0.0"}"#)
+        .expect("write package.json");
+
+    Command::cargo_bin("pnpm")
+        .expect("find the pnpm binary")
+        .with_current_dir(&project_dir)
+        .with_args(["install", "is-positive@1.0.0", "--lockfile-dir", ".."])
+        .assert()
+        .success();
+
+    assert_eq!(importer_ids(&lockfile_dir), ["project"]);
+    assert!(
+        !workspace.join("pnpm-lock.yaml").exists(),
+        "no lockfile may be written at the workspace root the pin moved away from",
+    );
+    assert!(
+        lockfile_dir.join("node_modules/.pnpm/is-positive@1.0.0").is_dir(),
+        "the virtual store must live under the pinned lockfile dir",
+    );
+    assert!(
+        project_dir.join("node_modules/is-positive/package.json").is_file(),
+        "the project keeps its own node_modules of symlinks into the virtual store",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// The `lockfileDir` setting is read from `pnpm-workspace.yaml` and
+/// resolved against it, so a workspace can keep its lockfile one level up
+/// without passing a flag on every command.
+#[test]
+fn lockfile_dir_setting_is_read_from_the_workspace_manifest() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(workspace.join("package.json"), r#"{"name":"project","version":"1.0.0"}"#)
+        .expect("write package.json");
+    append_workspace_yaml_key(&workspace, "lockfileDir", "..");
+
+    pacquet.with_args(["install", "is-positive@1.0.0"]).assert().success();
+
+    let lockfile_dir = root.path();
+    assert_eq!(importer_ids(lockfile_dir), ["workspace"]);
+    assert!(
+        !workspace.join("pnpm-lock.yaml").exists(),
+        "no lockfile may be written at the workspace root the setting moved away from",
+    );
+    assert!(
+        lockfile_dir.join("node_modules/.pnpm/is-positive@1.0.0").is_dir(),
+        "the virtual store must live under the configured lockfile dir",
+    );
+    assert!(
+        workspace.join("node_modules/is-positive/package.json").is_file(),
+        "the project keeps its own node_modules of symlinks into the virtual store",
+    );
+
+    drop(mock_instance);
+}
+
+/// A global install owns the lockfile in its own group directory, so
+/// pnpm refuses to let `--lockfile-dir` redirect it.
+#[test]
+fn lockfile_dir_conflicts_with_global() {
+    let CommandTempCwd { pacquet, root, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let output = pacquet
+        .with_args(["add", "--global", "is-positive@1.0.0", "--lockfile-dir", "."])
+        .output()
+        .expect("spawn pacquet add");
+
+    let stderr = String::from_utf8(output.stderr).expect("stderr is UTF-8");
+    assert!(!output.status.success(), "the conflicting flags must fail the command:\n{stderr}");
+    assert!(
+        stderr.contains("ERR_PNPM_CONFIG_CONFLICT_LOCKFILE_DIR_WITH_GLOBAL"),
+        "the error must carry pnpm's code:\n{stderr}",
+    );
+
+    drop((root, mock_instance));
+}

--- a/pnpm/crates/cli/tests/suite/main.rs
+++ b/pnpm/crates/cli/tests/suite/main.rs
@@ -62,6 +62,7 @@ mod lifecycle_scripts;
 mod link;
 mod list;
 mod local_tarball_dependency;
+mod lockfile_dir;
 mod lockfile_only;
 mod lockfile_resolution_reuse;
 mod lockfile_verification;

--- a/pnpm/crates/cli/tests/suite/pnpr_install.rs
+++ b/pnpm/crates/cli/tests/suite/pnpr_install.rs
@@ -645,10 +645,7 @@ fn workspace_install_via_pnpr_names_importers_relative_to_a_pinned_lockfile_dir(
         CommandTempCwd::init().add_mocked_registry();
     let AddMockedRegistry { npmrc_path, mock_instance, .. } = npmrc_info;
     configure_workspace(&workspace);
-    let path = workspace.join("pnpm-workspace.yaml");
-    let mut yaml = fs::read_to_string(&path).expect("read pnpm-workspace.yaml");
-    yaml.push_str("lockfileDir: ..\n");
-    fs::write(&path, yaml).expect("write pnpm-workspace.yaml");
+    crate::_utils::append_workspace_yaml_key(&workspace, "lockfileDir", "..");
     write_workspace_project(&workspace, "app", "app", (WORKSPACE_HELLO, "1.0.0"));
     let (pnpr_url, token) = start_pnpr(&mock_instance.url());
     configure_pnpr_auth(&npmrc_path, &pnpr_url, &token);

--- a/pnpm/crates/cli/tests/suite/pnpr_install.rs
+++ b/pnpm/crates/cli/tests/suite/pnpr_install.rs
@@ -635,6 +635,40 @@ fn workspace_install_via_pnpr_resolves_catalog_references() {
     drop((root, mock_instance));
 }
 
+/// The importer ids the server request carries, and the ones the
+/// filtered-lockfile merge keys on, are relative to the lockfile — which
+/// `lockfileDir` can pin outside the workspace. Deriving them from the
+/// workspace root instead leaves the two sides naming different projects.
+#[test]
+fn workspace_install_via_pnpr_names_importers_relative_to_a_pinned_lockfile_dir() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { npmrc_path, mock_instance, .. } = npmrc_info;
+    configure_workspace(&workspace);
+    let path = workspace.join("pnpm-workspace.yaml");
+    let mut yaml = fs::read_to_string(&path).expect("read pnpm-workspace.yaml");
+    yaml.push_str("lockfileDir: ..\n");
+    fs::write(&path, yaml).expect("write pnpm-workspace.yaml");
+    write_workspace_project(&workspace, "app", "app", (WORKSPACE_HELLO, "1.0.0"));
+    let (pnpr_url, token) = start_pnpr(&mock_instance.url());
+    configure_pnpr_auth(&npmrc_path, &pnpr_url, &token);
+
+    pacquet_at(&workspace)
+        .with_env("PNPM_CONFIG_REGISTRY", mock_instance.url())
+        .with_args(["install", "--pnpr-server", &pnpr_url])
+        .assert()
+        .success();
+
+    let wanted = read_workspace_lockfile(root.path());
+    assert_eq!(
+        wanted.importers.keys().cloned().collect::<std::collections::BTreeSet<_>>(),
+        std::collections::BTreeSet::from(["workspace/packages/app".to_string()]),
+    );
+    assert!(workspace_has_link(&workspace, "app", WORKSPACE_HELLO));
+
+    drop(mock_instance);
+}
+
 #[test]
 fn standard_workspace_install_via_pnpr_from_root_resolves_every_real_importer() {
     assert_standard_workspace_pnpr_from(None);

--- a/pnpm/crates/config/src/env_overlay.rs
+++ b/pnpm/crates/config/src/env_overlay.rs
@@ -157,6 +157,7 @@ impl WorkspaceSettings {
         json_field!(virtual_store_dir_max_length, "VIRTUAL_STORE_DIR_MAX_LENGTH");
         json_field!(peers_suffix_max_length, "PEERS_SUFFIX_MAX_LENGTH");
         json_field!(lockfile, "LOCKFILE");
+        string_field!(lockfile_dir, "LOCKFILE_DIR");
         json_field!(prefer_frozen_lockfile, "PREFER_FROZEN_LOCKFILE");
         json_field!(prefer_symlinked_executables, "PREFER_SYMLINKED_EXECUTABLES");
         json_field!(frozen_lockfile, "FROZEN_LOCKFILE");

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -1090,6 +1090,17 @@ pub struct Config {
     #[default = true]
     pub lockfile: bool,
 
+    /// Where `pnpm-lock.yaml` is read and written, when the user pins it
+    /// with the `lockfileDir` setting (or `--lockfile-dir`). Several
+    /// projects may share one lockfile this way. Absolute once
+    /// [`Config::current`] has resolved it; `None` means "derive it",
+    /// which [`Config::lockfile_dir_for`] does.
+    ///
+    /// Every path anchored on the lockfile — the root `node_modules`, the
+    /// virtual store, and the importer ids — follows it, so setting it
+    /// goes through [`Config::pin_lockfile_dir`].
+    pub lockfile_dir: Option<PathBuf>,
+
     /// When set to true and the available pnpm-lock.yaml satisfies the package.json dependencies
     /// directive, a headless installation is performed. A headless installation skips all
     /// dependency resolution as it does not need to modify the lockfile.
@@ -2513,6 +2524,83 @@ impl Config {
             };
     }
 
+    /// The directory owning the `pnpm-lock.yaml` that covers
+    /// `project_dir`: the pinned [`lockfile_dir`], else the workspace root
+    /// when the workspace shares one lockfile, else the project itself.
+    ///
+    /// Mirrors pnpm's `lockfileDir ?? dir`, whose config reader has
+    /// already defaulted `lockfileDir` to `workspaceDir` for a shared
+    /// workspace lockfile.
+    ///
+    /// [`lockfile_dir`]: Self::lockfile_dir
+    #[must_use]
+    pub fn lockfile_dir_for<'a>(&'a self, project_dir: &'a Path) -> &'a Path {
+        self.lockfile_dir.as_deref().unwrap_or_else(|| {
+            if self.shared_workspace_lockfile {
+                self.workspace_dir.as_deref().unwrap_or(project_dir)
+            } else {
+                project_dir
+            }
+        })
+    }
+
+    /// pnpm's `rootProjectManifestDir`: where the root `package.json`,
+    /// the config dependencies (`node_modules/.pnpm-config`), and the
+    /// pnpmfile a command reads live — `lockfileDir ?? workspaceDir ??
+    /// dir`.
+    ///
+    /// Not the directory settings are *written* back to: `pnpm-workspace.yaml`
+    /// stays at [`workspace_dir`] when there is one.
+    ///
+    /// [`workspace_dir`]: Self::workspace_dir
+    #[must_use]
+    pub fn root_project_manifest_dir<'a>(&'a self, dir: &'a Path) -> &'a Path {
+        self.lockfile_dir.as_deref().or(self.workspace_dir.as_deref()).unwrap_or(dir)
+    }
+
+    /// Pin [`lockfile_dir`] to `dir` and re-anchor the paths that follow
+    /// the lockfile with it.
+    ///
+    /// `dir` is normalized first: importer ids are a lexical path diff
+    /// against it, so an unnormalized `<workspace>/..` would not name the
+    /// project it points at.
+    ///
+    /// [`lockfile_dir`]: Self::lockfile_dir
+    pub fn pin_lockfile_dir(&mut self, dir: &Path) {
+        let dir = pnpm_fs::lexical_normalize(dir);
+        self.anchor_lockfile_paths(&dir);
+        self.lockfile_dir = Some(dir);
+    }
+
+    /// Re-anchor the paths pnpm resolves against `lockfileDir` — the root
+    /// `node_modules` and the virtual store — onto `dir`.
+    ///
+    /// An explicitly configured `modulesDir` / `virtualStoreDir` keeps its
+    /// raw value (recovered from [`explicit_settings`]) and is re-resolved
+    /// against `dir`, so a multi-component or absolute setting keeps its
+    /// full shape — [`Path::join`] leaves an absolute value absolute.
+    /// Global-virtual-store installs keep their store-anchored
+    /// `virtual_store_dir`.
+    ///
+    /// [`explicit_settings`]: Self::explicit_settings
+    pub fn anchor_lockfile_paths(&mut self, dir: &Path) {
+        self.modules_dir =
+            match self.explicit_settings.get("modulesDir").and_then(serde_json::Value::as_str) {
+                Some(raw) => dir.join(raw),
+                None => dir.join("node_modules"),
+            };
+        if !self.enable_global_virtual_store {
+            self.virtual_store_dir = match self
+                .explicit_settings
+                .get("virtualStoreDir")
+                .and_then(serde_json::Value::as_str)
+            {
+                Some(raw) => dir.join(raw),
+                None => self.modules_dir.join(".pnpm"),
+            };
+        }
+    }
+
     /// [`Config::extra_env`] with the `nodeOptions` setting applied as
     /// `NODE_OPTIONS`, preserving the ESM `NODE_PATH` loader flag the
     /// `extra_env` carries under a global virtual store.
@@ -3109,6 +3197,15 @@ impl Config {
             self.registries_by_scope.insert("default".to_string(), normalized.clone());
             self.package_manager_bootstrap.registry.clone_from(&normalized);
             self.package_manager_bootstrap.registries.insert("default".to_string(), normalized);
+        }
+
+        // A pinned `lockfileDir` moves the root `node_modules` and the
+        // virtual store with it. Applied after every source has had its
+        // say so the anchor uses the final value, and before the
+        // global-virtual-store derivation, which may re-point
+        // `virtual_store_dir` at the store.
+        if let Some(lockfile_dir) = self.lockfile_dir.clone() {
+            self.anchor_lockfile_paths(&lockfile_dir);
         }
 
         // Build the per-URI auth-header lookup. Credentials were already

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -2544,6 +2544,19 @@ impl Config {
         })
     }
 
+    /// Whether one `pnpm-lock.yaml` covers every project the command
+    /// touches. The `sharedWorkspaceLockfile` setting, which an explicit
+    /// [`lockfile_dir`] overrides: pinning the lockfile to one directory
+    /// *is* the shared layout, and pnpm's recursive dispatch routes such
+    /// a run through its shared-lockfile branch whatever the setting
+    /// says.
+    ///
+    /// [`lockfile_dir`]: Self::lockfile_dir
+    #[must_use]
+    pub fn shares_one_lockfile(&self) -> bool {
+        self.lockfile_dir.is_some() || self.shared_workspace_lockfile
+    }
+
     /// pnpm's `rootProjectManifestDir`: where the root `package.json`,
     /// the config dependencies (`node_modules/.pnpm-config`), and the
     /// pnpmfile a command reads live — `lockfileDir ?? workspaceDir ??

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -3270,6 +3270,70 @@ pub fn virtual_store_dir_max_length_env_var_overrides_yaml() {
     );
 }
 
+/// `lockfileDir` moves the paths pnpm resolves against it: the root
+/// `node_modules` and the virtual store follow the pin, and the config
+/// root the install reads its root manifest and pnpmfile from becomes the
+/// pin rather than the workspace root.
+#[test]
+pub fn lockfile_dir_from_workspace_yaml_moves_the_paths_anchored_on_it() {
+    let tmp = tempdir().unwrap();
+    let workspace = tmp.path().join("workspace");
+    fs::create_dir(&workspace).expect("create the workspace dir");
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        "lockfileDir: ..
+",
+    )
+    .expect("write to pnpm-workspace.yaml");
+
+    let config = Config::new().current::<HostNoHome>(&workspace).expect("yaml is valid");
+
+    assert_eq!(config.lockfile_dir.as_deref(), Some(tmp.path()));
+    assert_eq!(config.lockfile_dir_for(&workspace), tmp.path());
+    assert_eq!(config.root_project_manifest_dir(&workspace), tmp.path());
+    assert_eq!(config.modules_dir, tmp.path().join("node_modules"));
+    assert_eq!(config.virtual_store_dir, tmp.path().join("node_modules").join(".pnpm"));
+}
+
+/// `PNPM_CONFIG_LOCKFILE_DIR` overrides the yaml setting, and a relative
+/// value resolves against the directory the config was loaded for.
+#[test]
+pub fn lockfile_dir_env_var_overrides_yaml() {
+    let tmp = tempdir().unwrap();
+    fs::write(
+        tmp.path().join("pnpm-workspace.yaml"),
+        "lockfileDir: from-yaml
+",
+    )
+    .expect("write to pnpm-workspace.yaml");
+
+    struct HostWithLockfileDirEnv;
+    impl EnvVar for HostWithLockfileDirEnv {
+        fn var(name: &str) -> Option<String> {
+            if name == "PNPM_CONFIG_LOCKFILE_DIR" {
+                return Some("from-env".to_owned());
+            }
+            safe_host_var(name)
+        }
+    }
+    impl EnvVarOs for HostWithLockfileDirEnv {
+        fn var_os(_: &str) -> Option<OsString> {
+            None
+        }
+    }
+    impl GetHomeDir for HostWithLockfileDirEnv {
+        fn home_dir() -> Option<PathBuf> {
+            None
+        }
+    }
+    inert_link_probe!(HostWithLockfileDirEnv);
+    host_current_dir!(HostWithLockfileDirEnv);
+
+    let config = Config::new().current::<HostWithLockfileDirEnv>(tmp.path()).expect("loads");
+    assert_eq!(config.lockfile_dir.as_deref(), Some(tmp.path().join("from-env").as_path()));
+    assert_eq!(config.modules_dir, tmp.path().join("from-env").join("node_modules"));
+}
+
 #[test]
 pub fn package_map_settings_load_from_workspace_yaml() {
     let tmp = tempdir().unwrap();

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -207,6 +207,10 @@ pub struct WorkspaceSettings {
     pub virtual_store_dir_max_length: Option<u64>,
     pub peers_suffix_max_length: Option<u64>,
     pub lockfile: Option<bool>,
+    /// `lockfileDir` from `pnpm-workspace.yaml` or the global
+    /// `config.yaml`. Resolved against the workspace dir like the other
+    /// path-valued fields. See [`Config::lockfile_dir`].
+    pub lockfile_dir: Option<String>,
     pub prefer_frozen_lockfile: Option<bool>,
 
     /// `frozenLockfile` from `pnpm-workspace.yaml`. Unset by default:
@@ -1372,6 +1376,7 @@ impl WorkspaceSettings {
         substitute_optional_string::<Sys>(&mut self.global_virtual_store_dir);
         substitute_optional_string::<Sys>(&mut self.user_agent);
         substitute_optional_string::<Sys>(&mut self.npmrc_auth_file);
+        substitute_optional_string::<Sys>(&mut self.lockfile_dir);
         substitute_optional_string::<Sys>(&mut self.patches_dir);
         substitute_optional_string::<Sys>(&mut self.cache_dir);
         substitute_optional_inner_string::<Sys>(&mut self.script_shell);
@@ -1523,6 +1528,12 @@ impl WorkspaceSettings {
         }
         if let Some(v) = self.global_virtual_store_dir {
             config.global_virtual_store_dir = resolve(base_dir, &v);
+        }
+        // Last of the path-valued settings: pinning the lockfile dir
+        // re-resolves `modulesDir` / `virtualStoreDir` against it, so it
+        // must see whatever this layer just set.
+        if let Some(v) = self.lockfile_dir {
+            config.pin_lockfile_dir(&resolve(base_dir, &v));
         }
         if let Some(v) = self.store_dir {
             config.store_dir = StoreDir::from(resolve(base_dir, &v));

--- a/pnpm/crates/deps-restorer/src/install_package_from_registry/tests.rs
+++ b/pnpm/crates/deps-restorer/src/install_package_from_registry/tests.rs
@@ -61,6 +61,7 @@ fn create_config(
         virtual_store_dir_max_length: pnpm_config::default_virtual_store_dir_max_length(),
         peers_suffix_max_length: pnpm_config::default_peers_suffix_max_length(),
         lockfile: false,
+        lockfile_dir: None,
         prefer_frozen_lockfile: false,
         frozen_lockfile: None,
         optimistic_repeat_install: false,

--- a/pnpm/crates/package-manager/src/add.rs
+++ b/pnpm/crates/package-manager/src/add.rs
@@ -42,7 +42,7 @@ use pnpm_workspace_range_resolver::resolve_workspace_range;
 use pnpm_workspace_spec::WorkspaceSpec;
 use std::{
     collections::{BTreeMap, HashSet},
-    path::{Path, PathBuf},
+    path::PathBuf,
     sync::Arc,
 };
 
@@ -249,7 +249,7 @@ where
                 manifest.path().parent().expect("manifest path always has a parent dir");
             BTreeMap::from([(
                 pnpm_workspace::importer_id_from_root_dir(
-                    importer_id_root(config, manifest_dir),
+                    config.lockfile_dir_for(manifest_dir),
                     manifest_dir,
                 ),
                 ImporterUpdateSeedPolicy::DropOnly(dropped_pins),
@@ -390,7 +390,7 @@ where
         // Scoped per importer: a project that wasn't selected keeps its pins, so its
         // resolutions stand even when it declares the same package directly.
         let manifest_dir = manifest.path().parent().expect("manifest path always has a parent dir");
-        let importer_root = importer_id_root(config, manifest_dir);
+        let importer_root = config.lockfile_dir_for(manifest_dir);
         let mut seed_policies = BTreeMap::new();
         let mut preferred_versions_override = PreferredVersions::new();
         for &index in &selected_indices {
@@ -481,18 +481,6 @@ where
         post_install_prune(config, Some(&prepared.workspace_dir), manifest)
             .map_err(AddError::WriteWorkspaceManifest)?;
         Ok(())
-    }
-}
-
-/// The directory importer ids are relative to: the lockfile's own directory,
-/// which is the workspace root only while one lockfile is shared. A seed
-/// policy keyed against anything else names no importer and silently does
-/// nothing. Mirrors the root [`Install`] resolves against.
-fn importer_id_root<'a>(config: &'a Config, manifest_dir: &'a Path) -> &'a Path {
-    if config.shared_workspace_lockfile {
-        config.workspace_dir.as_deref().unwrap_or(manifest_dir)
-    } else {
-        manifest_dir
     }
 }
 

--- a/pnpm/crates/package-manager/src/catalog_cleanup.rs
+++ b/pnpm/crates/package-manager/src/catalog_cleanup.rs
@@ -124,27 +124,29 @@ fn derive_workspace_dir(
 ///
 /// The pass may only drop an entry it can prove nothing resolves, so it
 /// needs a lockfile covering every project `minimumReleaseAgeExclude`
-/// governs — only a workspace-shared one does. Under dedicated
-/// per-project lockfiles (`sharedWorkspaceLockfile: false`, pnpm's
-/// `lockfileDir = sharedWorkspaceLockfile ? workspaceDir : projectDir`)
-/// every entry a sibling project needs would look unresolved, so the pass
-/// no-ops. It also no-ops when the setting is off, when lockfile
-/// persistence is disabled (`lockfile: false` — the on-disk lockfile
-/// would be stale), and when no lockfile exists, mirroring the
-/// `all_projects` guard of the catalog cleanup.
+/// governs — only a shared one does. Under dedicated per-project
+/// lockfiles (`sharedWorkspaceLockfile: false` with no `lockfileDir`
+/// pinning them back together) every entry a sibling project needs would
+/// look unresolved, so the pass no-ops. It also no-ops when the setting
+/// is off, when lockfile persistence is disabled (`lockfile: false` — the
+/// on-disk lockfile would be stale), and when no lockfile exists,
+/// mirroring the `all_projects` guard of the catalog cleanup.
 pub(crate) fn post_install_prune(
     config: &Config,
     workspace_dir: Option<&Path>,
     current_manifest: &PackageManifest,
 ) -> Result<(), WriteWorkspaceCatalogsError> {
-    if !config.lockfile || !config.shared_workspace_lockfile {
+    if !config.lockfile || !config.shares_one_lockfile() {
         return Ok(());
     }
     let workspace_dir = match workspace_dir {
         Some(dir) => dir.to_path_buf(),
         None => derive_workspace_dir(current_manifest)?,
     };
-    let Some(lockfile) = Lockfile::load_wanted_from_dir(&workspace_dir)
+    // The entries live in the workspace's `pnpm-workspace.yaml`; the
+    // lockfile that proves what still resolves sits wherever
+    // `lockfileDir` put it.
+    let Some(lockfile) = Lockfile::load_wanted_from_dir(config.lockfile_dir_for(&workspace_dir))
         .map_err(WriteWorkspaceCatalogsError::LoadLockfile)?
     else {
         return Ok(());

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -89,7 +89,7 @@ use prepare_modules_state::{
 use workspace_state::{
     ProjectScriptsInputs, build_project_manifests_list, build_root_importer_project_manifests_list,
     build_selected_project_manifests_list, configured_or_discovered_workspace_dir,
-    projects_running_own_scripts, selected_manifest_freshness_inputs,
+    lockfile_root_for, projects_running_own_scripts, selected_manifest_freshness_inputs,
 };
 pub use workspace_state::{
     UpToDateFastPathCheck, UpToDateWorkspace, build_workspace_packages_map,

--- a/pnpm/crates/package-manager/src/install/lockfile_freshness.rs
+++ b/pnpm/crates/package-manager/src/install/lockfile_freshness.rs
@@ -55,7 +55,13 @@ pub async fn wanted_lockfile_satisfies_workspace(
     let Ok(workspace_dir_opt) = configured_or_discovered_workspace_dir(config, manifest_dir) else {
         return false;
     };
-    let workspace_root = workspace_dir_opt.unwrap_or_else(|| manifest_dir.to_path_buf());
+    let workspace_root = workspace_dir_opt.clone().unwrap_or_else(|| manifest_dir.to_path_buf());
+    // The importer ids below name projects relative to the directory the
+    // lockfile sits in, which `lockfileDir` can move away from the
+    // workspace root — deriving them from the workspace instead would
+    // classify every importer the lockfile records as missing.
+    let lockfile_root =
+        super::lockfile_root_for(config, workspace_dir_opt.as_deref(), manifest_dir);
     if !config.ignore_pnpmfile && pnpm_hooks::finder::find_pnpmfile(&workspace_root).is_some() {
         return false;
     }
@@ -71,7 +77,7 @@ pub async fn wanted_lockfile_satisfies_workspace(
     let manifest_freshness_inputs: Vec<(String, &PackageManifest)> = project_manifests
         .iter()
         .map(|(project_dir, manifest)| {
-            (pnpm_workspace::importer_id_from_root_dir(&workspace_root, project_dir), *manifest)
+            (pnpm_workspace::importer_id_from_root_dir(&lockfile_root, project_dir), *manifest)
         })
         .collect();
     check_lockfile_freshness(

--- a/pnpm/crates/package-manager/src/install/lockfile_freshness.rs
+++ b/pnpm/crates/package-manager/src/install/lockfile_freshness.rs
@@ -67,8 +67,7 @@ pub async fn wanted_lockfile_satisfies_workspace(
     else {
         return false;
     };
-    let project_manifests =
-        build_project_manifests_list(&workspace_root, manifest, workspace_projects.as_deref());
+    let project_manifests = build_project_manifests_list(manifest, workspace_projects.as_deref());
     let manifest_freshness_inputs: Vec<(String, &PackageManifest)> = project_manifests
         .iter()
         .map(|(project_dir, manifest)| {

--- a/pnpm/crates/package-manager/src/install/run.rs
+++ b/pnpm/crates/package-manager/src/install/run.rs
@@ -242,9 +242,13 @@ where
         // headless install should always go through the dispatch so a
         // `NoLockfile` or `OutdatedLockfile` error still fires when
         // the lockfile is missing or stale.
+
+        // A pinned `lockfileDir` decouples the lockfile root from the
+        // active project, so the manifest can no longer stand in for it —
+        // its importer id is the path from the pin down to the project.
         let manifest_is_root_importer = root_manifest_as_workspace_root
             || workspace_projects_are_overridden
-            || !config.shared_workspace_lockfile;
+            || (!config.shared_workspace_lockfile && config.lockfile_dir.is_none());
         let project_manifests = match selection.as_ref() {
             Some(selection) => build_selected_project_manifests_list(
                 manifest,
@@ -259,7 +263,7 @@ where
                 // `workspace:` resolver, never the importer list.
                 config.shared_workspace_lockfile.then_some(workspace_projects).flatten(),
             ),
-            None => build_project_manifests_list(&workspace_root, manifest, workspace_projects),
+            None => build_project_manifests_list(manifest, workspace_projects),
         };
         // Only an unfiltered install of a whole workspace sees the complete
         // project list, so only it may conclude that an importer the

--- a/pnpm/crates/package-manager/src/install/run.rs
+++ b/pnpm/crates/package-manager/src/install/run.rs
@@ -219,7 +219,7 @@ where
         // `remove`, ...) targets the project it was run in and reports the
         // single-project shape, with no `total`, exactly as pnpm's
         // non-recursive `scopeLogger` call does.
-        if selection.is_none() && config.shared_workspace_lockfile {
+        if selection.is_none() && config.shares_one_lockfile() {
             let workspace_wide = mutation.is_full_install().then_some(workspace_projects).flatten();
             Reporter::emit(&LogEvent::Scope(ScopeLog {
                 level: LogLevel::Debug,
@@ -243,12 +243,9 @@ where
         // `NoLockfile` or `OutdatedLockfile` error still fires when
         // the lockfile is missing or stale.
 
-        // A pinned `lockfileDir` decouples the lockfile root from the
-        // active project, so the manifest can no longer stand in for it —
-        // its importer id is the path from the pin down to the project.
         let manifest_is_root_importer = root_manifest_as_workspace_root
             || workspace_projects_are_overridden
-            || (!config.shared_workspace_lockfile && config.lockfile_dir.is_none());
+            || !config.shares_one_lockfile();
         let project_manifests = match selection.as_ref() {
             Some(selection) => build_selected_project_manifests_list(
                 manifest,
@@ -261,7 +258,7 @@ where
                 // Dedicated per-project lockfiles record a single "."
                 // importer per project; sibling projects only feed the
                 // `workspace:` resolver, never the importer list.
-                config.shared_workspace_lockfile.then_some(workspace_projects).flatten(),
+                config.shares_one_lockfile().then_some(workspace_projects).flatten(),
             ),
             None => build_project_manifests_list(manifest, workspace_projects),
         };
@@ -278,7 +275,7 @@ where
             && mutation.is_full_install()
             && workspace_projects.is_some()
             && !workspace_projects_are_overridden
-            && config.shared_workspace_lockfile;
+            && config.shares_one_lockfile();
         let selected_importer_ids = selection.as_ref().map(|selection| {
             selection
                 .selected_dirs

--- a/pnpm/crates/package-manager/src/install/workspace_state.rs
+++ b/pnpm/crates/package-manager/src/install/workspace_state.rs
@@ -70,15 +70,14 @@ pub fn install_already_up_to_date(check: &UpToDateFastPathCheck<'_>) -> Option<U
     let workspace_projects =
         load_workspace_projects(&workspace_root, workspace_manifest.as_ref()).ok()?;
     let project_manifests = build_project_manifests_list(manifest, workspace_projects.as_deref());
-    // Match the install pipeline's lockfile source: shared workspaces
-    // read the root lockfile, while per-project workspaces read the
-    // active project's lockfile.
+    // The lockfile the install wrote sits at its `lockfileDir`, which
+    // both `sharedWorkspaceLockfile: false` and an explicit pin move away
+    // from the discovered workspace root. The workspace *state* keeps its
+    // own root, which only a pin moves — `state_root` below.
+    let lockfile_root = lockfile_root_for(config, workspace_dir_opt.as_deref(), manifest_dir);
+    let state_root = config.lockfile_dir.clone().unwrap_or_else(|| workspace_root.clone());
     let lockfile = if config.lockfile {
-        LazyLockfile::deferred(if config.shared_workspace_lockfile {
-            workspace_root.clone()
-        } else {
-            manifest_dir.to_path_buf()
-        })
+        LazyLockfile::deferred(lockfile_root.clone())
     } else {
         LazyLockfile::disabled()
     };
@@ -103,7 +102,7 @@ pub fn install_already_up_to_date(check: &UpToDateFastPathCheck<'_>) -> Option<U
         }
     }
     let up_to_date = check_optimistic_repeat_install(&OptimisticRepeatInstallCheck {
-        workspace_root: &workspace_root,
+        workspace_root: &state_root,
         config,
         node_linker: *node_linker,
         included,
@@ -118,20 +117,12 @@ pub fn install_already_up_to_date(check: &UpToDateFastPathCheck<'_>) -> Option<U
     }
     if gvs_build_markers_may_require_recovery(config) {
         let wanted = lockfile.get().ok().flatten()?;
-        // `workspace_root` above is the workspace-state root, which stays the
-        // discovered workspace dir even under `sharedWorkspaceLockfile: false`.
-        // The slot lookup needs the lockfile dir instead — `run_inner`'s
-        // `lockfileDir = sharedWorkspaceLockfile ? workspaceDir : projectDir` —
-        // or this fast path would probe a directory dep's slot under a project
-        // that does not own it and miss the marker it is looking for.
-        let lockfile_dir =
-            if config.shared_workspace_lockfile { workspace_root.as_path() } else { manifest_dir };
-        if gvs_build_marker_present(wanted, config, lockfile_dir) {
+        if gvs_build_marker_present(wanted, config, &lockfile_root) {
             return None;
         }
     }
     Some(UpToDateWorkspace {
-        root: workspace_root,
+        root: state_root,
         project_count: workspace_projects.as_ref().map(Vec::len),
     })
 }
@@ -183,11 +174,14 @@ pub fn check_deps_status_before_run_at(
         },
         None => None,
     };
+    // A pinned `lockfileDir` is where the install left the state and the
+    // lockfile; the root manifest above stays where the workspace put it.
+    let lockfile_root = config.lockfile_dir.clone().unwrap_or_else(|| workspace_root.clone());
     // pnpm reports "cannot check" straight from the missing workspace
     // state, before any project discovery — a fresh project (the common
     // out-of-sync case) must not pay for the workspace-projects walk
     // only to reach the same verdict inside the check.
-    let Ok(Some(workspace_state)) = pnpm_workspace_state::load_workspace_state(&workspace_root)
+    let Ok(Some(workspace_state)) = pnpm_workspace_state::load_workspace_state(&lockfile_root)
     else {
         return cannot_check();
     };
@@ -206,13 +200,13 @@ pub fn check_deps_status_before_run_at(
     let project_manifests =
         build_project_manifests_list(&root_manifest, workspace_projects.as_deref());
     let lockfile = if config.lockfile {
-        LazyLockfile::deferred(workspace_root.clone())
+        LazyLockfile::deferred(lockfile_root.clone())
     } else {
         LazyLockfile::disabled()
     };
     Some(crate::check_deps_status_before_run(
         &OptimisticRepeatInstallCheck {
-            workspace_root: &workspace_root,
+            workspace_root: &lockfile_root,
             config,
             node_linker: config.node_linker,
             supported_architectures: config.supported_architectures.as_ref(),
@@ -463,6 +457,22 @@ pub(crate) fn lockfile_root_dir(
     }
     Ok(configured_or_discovered_workspace_dir(config, manifest_dir)?
         .unwrap_or_else(|| manifest_dir.to_path_buf()))
+}
+
+/// [`lockfile_root_dir`] for a caller that has already resolved the
+/// workspace dir, so the ancestor walk is not repeated.
+pub(super) fn lockfile_root_for(
+    config: &Config,
+    workspace_dir: Option<&Path>,
+    manifest_dir: &Path,
+) -> PathBuf {
+    if let Some(lockfile_dir) = config.lockfile_dir.clone() {
+        return lockfile_dir;
+    }
+    if !config.shared_workspace_lockfile {
+        return manifest_dir.to_path_buf();
+    }
+    workspace_dir.map_or_else(|| manifest_dir.to_path_buf(), Path::to_path_buf)
 }
 
 /// Build the `name → version → WorkspacePackage` lookup the npm

--- a/pnpm/crates/package-manager/src/install/workspace_state.rs
+++ b/pnpm/crates/package-manager/src/install/workspace_state.rs
@@ -69,8 +69,7 @@ pub fn install_already_up_to_date(check: &UpToDateFastPathCheck<'_>) -> Option<U
     };
     let workspace_projects =
         load_workspace_projects(&workspace_root, workspace_manifest.as_ref()).ok()?;
-    let project_manifests =
-        build_project_manifests_list(&workspace_root, manifest, workspace_projects.as_deref());
+    let project_manifests = build_project_manifests_list(manifest, workspace_projects.as_deref());
     // Match the install pipeline's lockfile source: shared workspaces
     // read the root lockfile, while per-project workspaces read the
     // active project's lockfile.
@@ -204,11 +203,8 @@ pub fn check_deps_status_before_run_at(
     else {
         return cannot_check();
     };
-    let project_manifests = build_project_manifests_list(
-        &workspace_root,
-        &root_manifest,
-        workspace_projects.as_deref(),
-    );
+    let project_manifests =
+        build_project_manifests_list(&root_manifest, workspace_projects.as_deref());
     let lockfile = if config.lockfile {
         LazyLockfile::deferred(workspace_root.clone())
     } else {
@@ -238,14 +234,13 @@ pub fn check_deps_status_before_run_at(
 }
 
 pub(super) fn build_project_manifests_list<'a>(
-    workspace_root: &std::path::Path,
     root_manifest: &'a PackageManifest,
     workspace_projects: Option<&'a [pnpm_workspace::Project]>,
 ) -> Vec<(std::path::PathBuf, &'a PackageManifest)> {
-    let Some(projects) = workspace_projects else {
-        return vec![(workspace_root.to_path_buf(), root_manifest)];
-    };
     let active_dir = root_manifest.path().parent().expect("manifest path always has a parent dir");
+    let Some(projects) = workspace_projects else {
+        return vec![(active_dir.to_path_buf(), root_manifest)];
+    };
     let active_dir_matcher = ProjectDirMatcher::new(active_dir);
     let mut active_project_was_discovered = false;
     let mut list = projects
@@ -445,10 +440,13 @@ pub(crate) fn configured_or_discovered_workspace_dir(
 
 /// The directory `pnpm-lock.yaml` lives in, which is what importer ids,
 /// reporter prefixes and the workspace-state file are all named relative
-/// to. Dedicated per-project lockfiles (`sharedWorkspaceLockfile: false`)
-/// anchor it at the active project rather than the workspace root,
-/// mirroring pnpm's `lockfileDir = sharedWorkspaceLockfile ? workspaceDir
-/// : projectDir`.
+/// to. A pinned `lockfileDir` wins outright; otherwise dedicated
+/// per-project lockfiles (`sharedWorkspaceLockfile: false`) anchor it at
+/// the active project rather than the workspace root, mirroring pnpm's
+/// `lockfileDir ?? (sharedWorkspaceLockfile ? workspaceDir : projectDir)`.
+///
+/// Unlike [`Config::lockfile_dir_for`], this also *discovers* the
+/// workspace root when the config carries none.
 ///
 /// Every caller that names something by importer id has to derive it the
 /// same way the install does, or the two disagree about which importer an
@@ -457,6 +455,9 @@ pub(crate) fn lockfile_root_dir(
     config: &Config,
     manifest_dir: &Path,
 ) -> Result<PathBuf, pnpm_workspace::FindWorkspaceDirError> {
+    if let Some(lockfile_dir) = config.lockfile_dir.clone() {
+        return Ok(lockfile_dir);
+    }
     if !config.shared_workspace_lockfile {
         return Ok(manifest_dir.to_path_buf());
     }

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/conflict_markers.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/conflict_markers.rs
@@ -21,7 +21,7 @@ pub(crate) fn first_lockfile_requiring_conflict_safe_install(
     {
         return Some((shared_lockfile, failure));
     }
-    if check.config.shared_workspace_lockfile {
+    if check.config.shares_one_lockfile() {
         return None;
     }
     for (root_dir, _) in check.project_manifests {


### PR DESCRIPTION
## Summary

Implements the `lockfileDir` setting in the Rust CLI — one of the open items on
the installation-settings parity list, pnpm/pnpm#12042. The key was already in
pacquet's `types` registry (so `pnpm config get lockfile-dir` worked and it was
never reported as unknown), but nothing read it: a project that pinned its
lockfile location silently got the default layout.

`Config::lockfile_dir` is now the pinned directory, read from
`pnpm-workspace.yaml`, the global `config.yaml`, `PNPM_CONFIG_LOCKFILE_DIR`, and
`--lockfile-dir <dir>` on `install`, `add`, `update`, and `remove` — the same
sources and the same command set the TypeScript CLI accepts it on. Pinning it
re-anchors everything pnpm resolves against `lockfileDir`:

- `pnpm-lock.yaml` is read and written there;
- the root `node_modules` and the virtual store move with it (an explicit
  `modulesDir` / `virtualStoreDir` is re-resolved against the pin, keeping the
  raw setting's shape);
- config dependencies (`node_modules/.pnpm-config`), the root manifest, and the
  pnpmfile are read from it — pnpm's `rootProjectManifestDir`;
- importer ids become each project's path relative to the pin, and every project
  keeps its own `node_modules` of symlinks.

`--lockfile-dir` together with `--global` fails with
`ERR_PNPM_CONFIG_CONFLICT_LOCKFILE_DIR_WITH_GLOBAL`, matching pnpm's
`CONFIG_CONFLICT_LOCKFILE_DIR_WITH_GLOBAL`; the isolated configs the global,
`dlx`, and `outdated -g` paths derive drop the setting, as pnpm's reader does
under `--global`.

An explicit `lockfileDir` also wins over `sharedWorkspaceLockfile: false`:
pinning the lockfile to one directory *is* the shared layout, and pnpm's
recursive dispatch routes any run carrying a `lockfileDir` through its
shared-lockfile branch whatever the setting says. That question is
`Config::shares_one_lockfile`, and every "is there one lockfile for all of
this?" decision now asks it instead of reading the setting.

Two derivations that were spelled out in several places collapse into one each:
`Config::lockfile_dir_for` (`State`, `peers`, `cat-index`, `list`, `outdated`,
and `add`'s private `importer_id_root`) and `lockfile_root_for` inside the
installer, so the commands cannot drift on which importer an entry belongs to.
The install-time freshness paths — the repeat-install short-circuit, the
`verifyDepsBeforeRun` gate, and the lockfile-freshness check — go through the
latter; they previously derived from the discovered workspace root, which under
a pin let the short-circuit answer for a lockfile the install does not use.
Note the workspace *state* keeps its own root: `sharedWorkspaceLockfile: false`
records it at the workspace root even though each project owns its lockfile.

One behavior changes for configurations that do **not** set `lockfileDir`, an
alignment with the TypeScript CLI: `pnpm cat-index` and `pnpm list` now read the
project's own lockfile under `sharedWorkspaceLockfile: false` instead of the
workspace root's.

This is a Rust-only change: the TypeScript CLI already implements `lockfileDir`,
and this PR ports its behavior rather than changing it. The e2e test
`external_lockfile_dir_holds_the_lockfile_and_the_virtual_store` is a port of
pnpm's own `install with external lockfile directory`
(`pnpm11/pnpm/test/install/misc.ts`).

Related to pnpm/pnpm#12042.

## Squash Commit Body

```text
pacquet accepted `lockfileDir` as a known config key but read it nowhere, so a
project that pins its lockfile location silently got the default layout.
Implement it across the install family, mirroring the TypeScript CLI, which
already has it.

`Config::lockfile_dir` is the pinned directory, read from `pnpm-workspace.yaml`,
the global `config.yaml`, `PNPM_CONFIG_LOCKFILE_DIR`, and `--lockfile-dir <dir>`
on `install`, `add`, `update`, and `remove`. Pinning it re-anchors everything
pnpm resolves against `lockfileDir`: the root `node_modules`, the virtual store,
the config dependencies and the pnpmfile, and the importer ids, which become
each project's path relative to the pin. `--lockfile-dir` with `--global` fails
with `ERR_PNPM_CONFIG_CONFLICT_LOCKFILE_DIR_WITH_GLOBAL`, and the isolated
configs the global, dlx, and `outdated -g` paths derive drop the setting,
matching pnpm.

An explicit pin also wins over `sharedWorkspaceLockfile: false` — pinning the
lockfile to one directory is the shared layout, and pnpm's recursive dispatch
routes any run carrying a `lockfileDir` through its shared-lockfile branch
whatever the setting says. `Config::shares_one_lockfile` is that question, and
every "is there one lockfile" decision asks it instead of reading the setting.

Three derivations that were duplicated across commands collapse into one each:
`Config::lockfile_dir_for`, `Config::root_project_manifest_dir` (pnpm's
`rootProjectManifestDir`), and the installer's `lockfile_root_for`. The
install-time freshness paths go through the last of these rather than the
discovered workspace root, which under a pin let the repeat-install
short-circuit answer for a lockfile the install does not use.

Related to pnpm/pnpm#12042.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5[1m]).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `lockfileDir` configuration and the `--lockfile-dir <dir>` option for install, add, update, and remove commands.
  - Supports workspace configuration, environment variables, relative paths, and workspace operations.
  - Relocates shared lockfiles and virtual stores while preserving project-specific `node_modules` links.

- **Bug Fixes**
  - Prevented incompatible use with global operations.
  - Isolated global and temporary package operations from inherited lockfile directory settings.
  - Improved deployment handling when the configured lockfile directory does not contain the workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->