### PR TITLE
[pacquet] fix(hooks): name the configured pnpmfile that is missing

### DIFF
--- a/.changeset/pnpmfile-not-found.md
+++ b/.changeset/pnpmfile-not-found.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+A path named by the `pnpmfile` setting that is not on disk now fails with `ERR_PNPM_PNPMFILE_NOT_FOUND` and names the file, instead of surfacing as a generic pnpmfile execution failure. Discovery of the default `.pnpmfile.mjs` / `.pnpmfile.cjs` is unaffected: a project that ships neither still installs normally.

--- a/pnpm/crates/cli/src/cli_args/deps_tree_finders.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree_finders.rs
@@ -36,7 +36,8 @@ pub(crate) async fn resolve_finders(
     if find_by.is_empty() {
         return Ok(Vec::new());
     }
-    let pnpmfiles = crate::config_deps::load_before_packing_hooks(config, lockfile_dir);
+    let pnpmfiles = crate::config_deps::load_before_packing_hooks(config, lockfile_dir)
+        .map_err(|error| miette::miette!(code = "ERR_PNPM_PNPMFILE_NOT_FOUND", "{error}"))?;
     let mut finders_by_name: HashMap<String, Arc<dyn PnpmfileHooks>> = HashMap::new();
     for hooks in pnpmfiles {
         let names = hooks

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -900,9 +900,12 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
     let lockfile_dir = link.lockfile_path.and_then(|path| path.parent()).unwrap_or_else(|| {
         state.manifest.path().parent().expect("manifest path always has a parent dir")
     });
-    let pnpmfile_hook = (!state.config.ignore_pnpmfile)
-        .then(|| pnpm_hooks::finder::load_pnpmfiles(lockfile_dir, state.config.pnpmfile.as_deref()))
-        .flatten();
+    let pnpmfile_hook = if state.config.ignore_pnpmfile {
+        None
+    } else {
+        pnpm_hooks::finder::load_pnpmfiles(lockfile_dir, state.config.pnpmfile.as_deref())
+            .map_err(|error| miette::miette!(code = "ERR_PNPM_PNPMFILE_NOT_FOUND", "{error}"))?
+    };
     let prefetch_allowed = match pnpmfile_hook.as_ref() {
         Some(hook) => !hook
             .get_custom_fetchers()

--- a/pnpm/crates/cli/src/cli_args/pack.rs
+++ b/pnpm/crates/cli/src/cli_args/pack.rs
@@ -92,7 +92,9 @@ impl PackArgs {
                 configured_catalogs(config)?,
                 self.out.clone(),
                 self.pack_destination.clone(),
-                crate::config_deps::load_before_packing_hooks(config, pnpmfile_root),
+                crate::config_deps::load_before_packing_hooks(config, pnpmfile_root).map_err(
+                    |error| miette::miette!(code = "ERR_PNPM_PNPMFILE_NOT_FOUND", "{error}"),
+                )?,
             );
             set_injected_changelog(&mut options, config, dir).await?;
             let result = api::<Reporter, Host>(&options)
@@ -142,7 +144,9 @@ impl PackArgs {
         // workspace root); cloning the Arcs into each project shares one
         // worker per pnpmfile instead of re-spawning it per packed project.
         let before_packing_hooks =
-            crate::config_deps::load_before_packing_hooks(config, workspace_root);
+            crate::config_deps::load_before_packing_hooks(config, workspace_root).map_err(
+                |error| miette::miette!(code = "ERR_PNPM_PNPMFILE_NOT_FOUND", "{error}"),
+            )?;
 
         let mut packed: Vec<PackResultJson> = Vec::new();
         for chunk in &chunks {

--- a/pnpm/crates/cli/src/cli_args/publish.rs
+++ b/pnpm/crates/cli/src/cli_args/publish.rs
@@ -297,7 +297,9 @@ impl PublishArgs {
     ) -> miette::Result<PackResult> {
         let pnpmfile_root = config.workspace_dir.as_deref().unwrap_or(dir);
         let before_packing_hooks =
-            crate::config_deps::load_before_packing_hooks(config, pnpmfile_root);
+            crate::config_deps::load_before_packing_hooks(config, pnpmfile_root).map_err(
+                |error| miette::miette!(code = "ERR_PNPM_PNPMFILE_NOT_FOUND", "{error}"),
+            )?;
         let mut options = PackOptions {
             dir: dir.to_path_buf(),
             catalogs: crate::cli_args::catalogs::configured_catalogs(config)?,

--- a/pnpm/crates/cli/src/config_deps.rs
+++ b/pnpm/crates/cli/src/config_deps.rs
@@ -425,11 +425,14 @@ impl EnvInstallerContext {
 /// by the `updateConfig` install hook and the `beforePacking`
 /// pack/publish hook so both apply the same pnpmfile set, matching
 /// pnpm's single loaded hooks object.
-#[must_use]
-pub fn resolve_pnpmfile_paths(config: &Config, root_dir: &Path) -> Vec<PathBuf> {
+pub fn resolve_pnpmfile_paths(
+    config: &Config,
+    root_dir: &Path,
+) -> Result<Vec<PathBuf>, finder::MissingPnpmfileError> {
     if config.ignore_pnpmfile {
-        return Vec::new();
+        return Ok(Vec::new());
     }
+    finder::validate_configured_pnpmfiles(config.pnpmfile.as_deref())?;
     let config_modules_dir = root_dir.join("node_modules").join(".pnpm-config");
     let mut pnpmfiles: Vec<PathBuf> = match config.config_dependencies.as_ref() {
         Some(deps) => finder::calc_pnpmfile_paths_of_plugin_deps(
@@ -443,7 +446,7 @@ pub fn resolve_pnpmfile_paths(config: &Config, root_dir: &Path) -> Vec<PathBuf> 
             pnpmfiles.push(pnpmfile);
         }
     }
-    pnpmfiles
+    Ok(pnpmfiles)
 }
 
 /// Load the pnpmfiles that contribute a `beforePacking` hook for
@@ -451,16 +454,22 @@ pub fn resolve_pnpmfile_paths(config: &Config, root_dir: &Path) -> Vec<PathBuf> 
 /// hook handle per pnpmfile. A recursive pack loads them once and clones
 /// the `Arc`s into each project so a pnpmfile's Node worker is spawned
 /// once, not once per packed project.
-#[must_use]
-pub fn load_before_packing_hooks(config: &Config, root_dir: &Path) -> Vec<Arc<dyn PnpmfileHooks>> {
-    resolve_pnpmfile_paths(config, root_dir).into_iter().map(finder::load_pnpmfile_at).collect()
+pub fn load_before_packing_hooks(
+    config: &Config,
+    root_dir: &Path,
+) -> Result<Vec<Arc<dyn PnpmfileHooks>>, finder::MissingPnpmfileError> {
+    Ok(resolve_pnpmfile_paths(config, root_dir)?
+        .into_iter()
+        .map(finder::load_pnpmfile_at)
+        .collect())
 }
 
 pub async fn run_update_config_hooks<Reporter: self::Reporter>(
     config: &mut Config,
     root_dir: &Path,
 ) -> Result<()> {
-    let pnpmfiles = resolve_pnpmfile_paths(config, root_dir);
+    let pnpmfiles = resolve_pnpmfile_paths(config, root_dir)
+        .map_err(|error| miette::miette!(code = "ERR_PNPM_PNPMFILE_NOT_FOUND", "{error}"))?;
     if pnpmfiles.is_empty() {
         return Ok(());
     }

--- a/pnpm/crates/cli/tests/suite/custom_fetchers.rs
+++ b/pnpm/crates/cli/tests/suite/custom_fetchers.rs
@@ -169,7 +169,7 @@ fn a_configured_pnpmfile_that_is_missing_names_itself() {
     let CommandTempCwd { root: _root, workspace, .. } = CommandTempCwd::init();
     let mut registry = mockito::Server::new();
     let (metadata, original) = mock_fetcher_package(&mut registry, None);
-    configure_fetcher_project(&workspace, &registry.url(), "absent.cjs");
+    configure_fetcher_project(&workspace, &registry.url(), Some("absent.cjs"));
 
     let output = pacquet_at(&workspace).with_arg("install").assert().failure();
     let stderr = String::from_utf8_lossy(&output.get_output().stderr);
@@ -179,31 +179,44 @@ fn a_configured_pnpmfile_that_is_missing_names_itself() {
     drop((metadata, original));
 }
 
-/// The default pnpmfile stays optional: a project that configures nothing and
-/// ships no `.pnpmfile.cjs` installs normally.
+/// Only a configured path is required to exist. With the setting absent the
+/// loader discovers `.pnpmfile.mjs` / `.pnpmfile.cjs`, and finding neither means
+/// the project has no pnpmfile rather than a misconfiguration. An empty list is
+/// configured-but-empty, reaching the same "no hooks" outcome down the other
+/// branch, so both are pinned here.
 #[test]
-fn an_absent_default_pnpmfile_is_not_an_error() {
-    let CommandTempCwd { root: _root, workspace, .. } = CommandTempCwd::init();
-    let mut registry = mockito::Server::new();
-    let tarball = minimal_tarball("fetcher-pkg", "1.0.0");
-    let (metadata, _original) =
-        mock_fetcher_package(&mut registry, Some(&sha512_integrity(&tarball)));
-    let custom = registry.mock("GET", "/original.tgz").with_body(tarball).create();
-    configure_fetcher_project(&workspace, &registry.url(), "[]");
+fn a_project_without_a_pnpmfile_installs() {
+    for pnpmfile in [None, Some("[]")] {
+        let CommandTempCwd { root: _root, workspace, .. } = CommandTempCwd::init();
+        let mut registry = mockito::Server::new();
+        let tarball = minimal_tarball("fetcher-pkg", "1.0.0");
+        let (metadata, _original) =
+            mock_fetcher_package(&mut registry, Some(&sha512_integrity(&tarball)));
+        let archive = registry.mock("GET", "/original.tgz").with_body(tarball).create();
+        configure_fetcher_project(&workspace, &registry.url(), pnpmfile);
+        assert!(!workspace.join(".pnpmfile.mjs").exists());
+        assert!(!workspace.join(".pnpmfile.cjs").exists());
 
-    pacquet_at(&workspace).with_arg("install").assert().success();
-    assert!(workspace.join("node_modules/fetcher-pkg/package.json").is_file());
-    drop((metadata, custom));
+        pacquet_at(&workspace).with_arg("install").assert().success();
+        assert!(
+            workspace.join("node_modules/fetcher-pkg/package.json").is_file(),
+            "pnpmfile: {pnpmfile:?}",
+        );
+        drop((metadata, archive));
+    }
 }
 
-fn configure_fetcher_project(workspace: &Path, registry: &str, pnpmfile: &str) {
+fn configure_fetcher_project(workspace: &Path, registry: &str, pnpmfile: Option<&str>) {
     fs::write(workspace.join(".npmrc"), format!("registry={registry}/\n"))
         .expect("write registry configuration");
+    // `None` leaves the setting out of the file, which is the only way to reach
+    // the discovery branch: `pnpmfile: []` still counts as configured.
+    let pnpmfile = pnpmfile.map_or_else(String::new, |value| format!("pnpmfile: {value}\n"));
     fs::write(
         workspace.join("pnpm-workspace.yaml"),
         format!(
             "registry: {registry}/\nstoreDir: ../store\ncacheDir: ../cache\nenableGlobalVirtualStore: false\n\
-             fetchRetries: 0\npnpmfile: {pnpmfile}\n",
+             fetchRetries: 0\n{pnpmfile}",
         ),
     )
     .expect("write workspace configuration");
@@ -304,7 +317,7 @@ fn configured_fetchers_intercept_fresh_and_frozen_tarball_downloads() {
             .with_status(503)
             .expect(if pinned { 0 } else { 2 })
             .create();
-        configure_fetcher_project(&workspace, &registry.url(), pnpmfile);
+        configure_fetcher_project(&workspace, &registry.url(), Some(pnpmfile));
         fs::write(workspace.join("fixture.tgz"), tarball).expect("write local tarball fixture");
         fs::write(
             workspace.join("tls.key"),
@@ -409,7 +422,7 @@ fn declining_fetcher_rewrites_the_builtin_tarball_url() {
     let (metadata, original) =
         mock_fetcher_package(&mut registry, Some(&sha512_integrity(&tarball)));
     let mirror = registry.mock("GET", "/mirror.tgz").with_body(tarball).expect(1).create();
-    configure_fetcher_project(&workspace, &registry.url(), "configured.cjs");
+    configure_fetcher_project(&workspace, &registry.url(), Some("configured.cjs"));
     fs::write(
         workspace.join("configured.cjs"),
         r"module.exports = { fetchers: [{
@@ -450,7 +463,7 @@ fn a_declining_fetcher_cannot_swap_a_locked_archive_for_a_directory() {
     let tarball = minimal_tarball("fetcher-pkg", "1.0.0");
     let (metadata, original) =
         mock_fetcher_package(&mut registry, Some(&sha512_integrity(&tarball)));
-    configure_fetcher_project(&workspace, &registry.url(), "configured.cjs");
+    configure_fetcher_project(&workspace, &registry.url(), Some("configured.cjs"));
     fs::write(
         workspace.join("configured.cjs"),
         r"module.exports = { fetchers: [{
@@ -524,7 +537,7 @@ fn custom_fetchers_cannot_replace_locked_integrity_or_return_unverified_files() 
             .with_body(tarball)
             .expect(usize::from(name == "modified callback map"))
             .create();
-        configure_fetcher_project(&workspace, &registry.url(), "configured.cjs");
+        configure_fetcher_project(&workspace, &registry.url(), Some("configured.cjs"));
         fs::write(workspace.join("configured.cjs"), fetcher_pnpmfile(&body))
             .expect("write rejecting fetcher");
 

--- a/pnpm/crates/cli/tests/suite/custom_fetchers.rs
+++ b/pnpm/crates/cli/tests/suite/custom_fetchers.rs
@@ -179,6 +179,28 @@ fn a_configured_pnpmfile_that_is_missing_names_itself() {
     drop((metadata, original));
 }
 
+/// A configured path that names no module extension is checked with `.cjs`
+/// appended, the way pnpm's `pnpmFileExistsSync` does. Such a path is present,
+/// so whatever happens next is an execution failure — `require` resolves
+/// `.js`/`.json`/`.node` but not `.cjs` — and reporting it as a missing file
+/// would blame the setting for a pnpmfile that is right there on disk.
+#[test]
+fn an_extensionless_configured_pnpmfile_is_not_reported_as_missing() {
+    let CommandTempCwd { root: _root, workspace, .. } = CommandTempCwd::init();
+    let mut registry = mockito::Server::new();
+    let (metadata, original) = mock_fetcher_package(&mut registry, None);
+    configure_fetcher_project(&workspace, &registry.url(), Some("hooks/custom"));
+    fs::create_dir_all(workspace.join("hooks")).expect("create hooks dir");
+    fs::write(workspace.join("hooks/custom.cjs"), "module.exports = { hooks: {} };\n")
+        .expect("write pnpmfile");
+
+    let output = pacquet_at(&workspace).with_arg("install").assert().failure();
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    assert!(!stderr.contains("ERR_PNPM_PNPMFILE_NOT_FOUND"), "stderr: {stderr}");
+    assert!(stderr.contains("Error during pnpmfile execution"), "stderr: {stderr}");
+    drop((metadata, original));
+}
+
 /// Only a configured path is required to exist. With the setting absent the
 /// loader discovers `.pnpmfile.mjs` / `.pnpmfile.cjs`, and finding neither means
 /// the project has no pnpmfile rather than a misconfiguration. An empty list is

--- a/pnpm/crates/cli/tests/suite/custom_fetchers.rs
+++ b/pnpm/crates/cli/tests/suite/custom_fetchers.rs
@@ -160,6 +160,42 @@ fn ignore_pnpmfile_skips_the_custom_resolver_on_install() {
     drop((root, mock_instance)); // cleanup
 }
 
+/// pnpm's `requireHooks` fails a configured pnpmfile that is not on disk with
+/// `ERR_PNPM_PNPMFILE_NOT_FOUND`; only the default `.pnpmfile.cjs` is optional.
+/// A generic execution failure here would read as a broken pnpmfile rather than
+/// a misconfigured path.
+#[test]
+fn a_configured_pnpmfile_that_is_missing_names_itself() {
+    let CommandTempCwd { root: _root, workspace, .. } = CommandTempCwd::init();
+    let mut registry = mockito::Server::new();
+    let (metadata, original) = mock_fetcher_package(&mut registry, None);
+    configure_fetcher_project(&workspace, &registry.url(), "absent.cjs");
+
+    let output = pacquet_at(&workspace).with_arg("install").assert().failure();
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    assert!(stderr.contains("ERR_PNPM_PNPMFILE_NOT_FOUND"), "stderr: {stderr}");
+    assert!(stderr.contains("is not found"), "stderr: {stderr}");
+    assert!(stderr.contains("absent.cjs"), "stderr: {stderr}");
+    drop((metadata, original));
+}
+
+/// The default pnpmfile stays optional: a project that configures nothing and
+/// ships no `.pnpmfile.cjs` installs normally.
+#[test]
+fn an_absent_default_pnpmfile_is_not_an_error() {
+    let CommandTempCwd { root: _root, workspace, .. } = CommandTempCwd::init();
+    let mut registry = mockito::Server::new();
+    let tarball = minimal_tarball("fetcher-pkg", "1.0.0");
+    let (metadata, _original) =
+        mock_fetcher_package(&mut registry, Some(&sha512_integrity(&tarball)));
+    let custom = registry.mock("GET", "/original.tgz").with_body(tarball).create();
+    configure_fetcher_project(&workspace, &registry.url(), "[]");
+
+    pacquet_at(&workspace).with_arg("install").assert().success();
+    assert!(workspace.join("node_modules/fetcher-pkg/package.json").is_file());
+    drop((metadata, custom));
+}
+
 fn configure_fetcher_project(workspace: &Path, registry: &str, pnpmfile: &str) {
     fs::write(workspace.join(".npmrc"), format!("registry={registry}/\n"))
         .expect("write registry configuration");

--- a/pnpm/crates/hooks/src/finder.rs
+++ b/pnpm/crates/hooks/src/finder.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use async_trait::async_trait;
+use derive_more::{Display, Error};
 use serde_json::Value;
 
 use super::{
@@ -45,18 +46,43 @@ pub fn find_pnpmfiles(root: &Path, configured: Option<&[PathBuf]>) -> Vec<PathBu
     paths
 }
 
-#[must_use]
+/// A pnpmfile named by the `pnpmfile` setting that is not on disk. Discovery of
+/// the default `.pnpmfile.mjs` / `.pnpmfile.cjs` cannot produce this: an absent
+/// default simply means the project has no pnpmfile, while a configured path
+/// that resolves to nothing is a misconfiguration the install has to report.
+#[derive(Debug, Display, Error)]
+#[display("pnpmfile at \"{}\" is not found", path.display())]
+pub struct MissingPnpmfileError {
+    pub path: PathBuf,
+}
+
+/// Report the first path named by the `pnpmfile` setting that is not on disk.
+/// Every loader validates before it hands a path to Node, so a misconfigured
+/// setting is reported the same way whichever hook the command reaches first.
+pub fn validate_configured_pnpmfiles(
+    configured: Option<&[PathBuf]>,
+) -> Result<(), MissingPnpmfileError> {
+    let Some(configured) = configured else { return Ok(()) };
+    match configured.iter().find(|path| !path.is_file()) {
+        Some(missing) => Err(MissingPnpmfileError { path: missing.clone() }),
+        None => Ok(()),
+    }
+}
+
+/// Load every pnpmfile the project runs, in the order the `pnpmfile` setting
+/// lists them. `Ok(None)` means the project has no pnpmfile at all.
 pub fn load_pnpmfiles(
     root: &Path,
     configured: Option<&[PathBuf]>,
-) -> Option<Arc<dyn PnpmfileHooks>> {
-    let mut hooks: Vec<_> =
-        find_pnpmfiles(root, configured).into_iter().map(load_pnpmfile_at).collect();
-    match hooks.len() {
+) -> Result<Option<Arc<dyn PnpmfileHooks>>, MissingPnpmfileError> {
+    let paths = find_pnpmfiles(root, configured);
+    validate_configured_pnpmfiles(configured)?;
+    let mut hooks: Vec<_> = paths.into_iter().map(load_pnpmfile_at).collect();
+    Ok(match hooks.len() {
         0 => None,
         1 => hooks.pop(),
         _ => Some(Arc::new(CombinedPnpmfileHooks { hooks })),
-    }
+    })
 }
 
 struct CombinedPnpmfileHooks {

--- a/pnpm/crates/hooks/src/finder.rs
+++ b/pnpm/crates/hooks/src/finder.rs
@@ -63,10 +63,30 @@ pub fn validate_configured_pnpmfiles(
     configured: Option<&[PathBuf]>,
 ) -> Result<(), MissingPnpmfileError> {
     let Some(configured) = configured else { return Ok(()) };
-    match configured.iter().find(|path| !path.is_file()) {
+    match configured.iter().find(|path| !pnpmfile_exists(path)) {
         Some(missing) => Err(MissingPnpmfileError { path: missing.clone() }),
         None => Ok(()),
     }
+}
+
+/// Whether a configured path names a pnpmfile at all, mirroring pnpm's
+/// `pnpmFileExistsSync`. The question is only "is there something here", not
+/// "will Node load it": a path that exists but fails to evaluate — because the
+/// pnpmfile itself requires a missing module, say — is an execution failure and
+/// must keep reporting as one. Hence a bare existence test rather than
+/// [`Path::is_file`], and the `.cjs` suffix pnpm appends to a path that names
+/// neither module extension itself.
+fn pnpmfile_exists(path: &Path) -> bool {
+    let names_a_module = path
+        .extension()
+        .and_then(std::ffi::OsStr::to_str)
+        .is_some_and(|extension| matches!(extension, "cjs" | "mjs"));
+    if names_a_module {
+        return path.exists();
+    }
+    let mut with_suffix = path.as_os_str().to_owned();
+    with_suffix.push(".cjs");
+    Path::new(&with_suffix).exists()
 }
 
 /// Load every pnpmfile the project runs, in the order the `pnpmfile` setting

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -526,6 +526,11 @@ where
 /// Error type of [`Install`].
 #[derive(Debug, Display, Error, Diagnostic)]
 pub enum InstallError {
+    /// A path named by the `pnpmfile` setting is not on disk. pnpm reports the
+    /// same code and message from `requireHooks`.
+    #[display("{_0}")]
+    #[diagnostic(code(ERR_PNPM_PNPMFILE_NOT_FOUND))]
+    MissingPnpmfile(#[error(not(source))] pnpm_hooks::finder::MissingPnpmfileError),
     #[display(
         "Headless installation requires a pnpm-lock.yaml file, but none was found. Run `pnpm install` without --frozen-lockfile to create one."
     )]

--- a/pnpm/crates/package-manager/src/install/run.rs
+++ b/pnpm/crates/package-manager/src/install/run.rs
@@ -537,13 +537,12 @@ where
         // costs a `stat`. The Node worker only starts if a gate has to
         // ask whether the pnpmfile exports hooks. The handle is handed to
         // the resolve path below so an install spawns at most one.
-        let pnpmfile_hook = pnpmfile_hook_override.or_else(|| {
-            (!config.ignore_pnpmfile)
-                .then(|| {
-                    pnpm_hooks::finder::load_pnpmfiles(&workspace_root, config.pnpmfile.as_deref())
-                })
-                .flatten()
-        });
+        let pnpmfile_hook = match pnpmfile_hook_override {
+            Some(hook) => Some(hook),
+            None if config.ignore_pnpmfile => None,
+            None => pnpm_hooks::finder::load_pnpmfiles(&workspace_root, config.pnpmfile.as_deref())
+                .map_err(InstallError::MissingPnpmfile)?,
+        };
 
         // pnpm's `getContext` runs `readPackage` over every project
         // manifest before anything reads it, so a hook that rewrites a

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -398,6 +398,11 @@ fn full_resolution_required<'a>(
 /// Error type of [`InstallWithFreshLockfile`].
 #[derive(Debug, Display, Error, Diagnostic)]
 pub enum InstallWithFreshLockfileError {
+    /// A path named by the `pnpmfile` setting is not on disk. pnpm reports the
+    /// same code and message from `requireHooks`.
+    #[display("{_0}")]
+    #[diagnostic(code(ERR_PNPM_PNPMFILE_NOT_FOUND))]
+    MissingPnpmfile(#[error(not(source))] pnpm_hooks::finder::MissingPnpmfileError),
     /// The concurrent pre-resolve verification of the existing lockfile
     /// rejected it. The orchestrator maps this back to
     /// `InstallError::LockfileVerification` so the failure keeps the

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolver_setup.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolver_setup.rs
@@ -327,11 +327,12 @@ pub(super) async fn build_resolver_chain<Reporter: pnpm_reporter::Reporter + 'st
         retry_opts: crate::retry_config::retry_opts_from_config(config),
     };
 
-    let pnpmfile_hook = pnpmfile_hook_override.or_else(|| {
-        (!config.ignore_pnpmfile)
-            .then(|| pnpm_hooks::finder::load_pnpmfiles(lockfile_dir, config.pnpmfile.as_deref()))
-            .flatten()
-    });
+    let pnpmfile_hook = match pnpmfile_hook_override {
+        Some(hook) => Some(hook),
+        None if config.ignore_pnpmfile => None,
+        None => pnpm_hooks::finder::load_pnpmfiles(lockfile_dir, config.pnpmfile.as_deref())
+            .map_err(InstallWithFreshLockfileError::MissingPnpmfile)?,
+    };
     let custom_resolvers: Vec<Arc<dyn pnpm_hooks::CustomResolver>> =
         if let Some(ref hook) = pnpmfile_hook {
             hook.get_custom_resolvers().await.map_err(|err| {

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -152,6 +152,11 @@ pub struct Update<'a> {
 /// Error type of [`Update`].
 #[derive(Debug, Display, Error, Diagnostic)]
 pub enum UpdateError {
+    /// A path named by the `pnpmfile` setting is not on disk. pnpm reports the
+    /// same code and message from `requireHooks`.
+    #[display("{_0}")]
+    #[diagnostic(code(ERR_PNPM_PNPMFILE_NOT_FOUND))]
+    MissingPnpmfile(#[error(not(source))] pnpm_hooks::finder::MissingPnpmfileError),
     /// `--latest` was combined with a versioned selector (`foo@2`).
     #[display("Specs are not allowed to be used with --latest ({_0})")]
     #[diagnostic(code(ERR_PNPM_LATEST_WITH_SPEC))]
@@ -295,6 +300,7 @@ impl Update<'_> {
             .map_err(UpdateError::FindWorkspaceDir)?;
         let read_package_hook = (!save && !config.ignore_pnpmfile)
             .then(|| update_read_package_hook::<Reporter>(&workspace_root, config))
+            .transpose()?
             .flatten();
         let mut read_package_hooked_manifest_paths = HashSet::new();
         if let Some((hook, log)) = read_package_hook.as_ref() {
@@ -484,6 +490,7 @@ impl Update<'_> {
         .map_err(UpdateError::FindWorkspaceDir)?;
         let read_package_hook = (!save && !config.ignore_pnpmfile)
             .then(|| update_read_package_hook::<Reporter>(&workspace_root, config))
+            .transpose()?
             .flatten();
         let mut read_package_hooked_manifest_paths = HashSet::new();
         if let Some((hook, log)) = read_package_hook.as_ref() {
@@ -670,11 +677,19 @@ struct SelectedUpdatePreparation {
     any_work: bool,
 }
 
+/// A loaded `readPackage` hook paired with the log sink its `context.log`
+/// calls are forwarded to.
+type ReadPackageHook = (Arc<dyn pnpm_hooks::PnpmfileHooks>, pnpm_hooks::LogFn);
+
 fn update_read_package_hook<Reporter: self::Reporter>(
     workspace_root: &Path,
     config: &Config,
-) -> Option<(Arc<dyn pnpm_hooks::PnpmfileHooks>, pnpm_hooks::LogFn)> {
-    let hook = pnpm_hooks::finder::load_pnpmfiles(workspace_root, config.pnpmfile.as_deref())?;
+) -> Result<Option<ReadPackageHook>, UpdateError> {
+    let Some(hook) = pnpm_hooks::finder::load_pnpmfiles(workspace_root, config.pnpmfile.as_deref())
+        .map_err(UpdateError::MissingPnpmfile)?
+    else {
+        return Ok(None);
+    };
     let log = hook.source_path().map_or_else(
         || Arc::new(|_| {}) as pnpm_hooks::LogFn,
         |from| {
@@ -685,7 +700,7 @@ fn update_read_package_hook<Reporter: self::Reporter>(
             )
         },
     );
-    Some((hook, log))
+    Ok(Some((hook, log)))
 }
 
 async fn apply_read_package_hook_to_update_manifest(


### PR DESCRIPTION
## Summary

A path named by the `pnpmfile` setting that is not on disk was handed to Node and came back as `Cannot find module`, wrapped as `ERR_PNPM_PNPMFILE_FAIL` — the same code a syntactically broken pnpmfile produces, so a typo'd path read as a broken hook. pnpm's `requireHooks` reports `ERR_PNPM_PNPMFILE_NOT_FOUND` with the offending file instead, and treats only the discovered default as optional.

This is a pacquet-side catch-up: the TypeScript CLI already has the behavior (`pnpm11/hooks/pnpmfile/src/requireHooks.ts`), so there is nothing to mirror there.

Follow-up to the review of pnpm/pnpm#14026, where the gap was raised and deferred.

## Squash Commit Body

```text
Validate the paths named by the `pnpmfile` setting before handing any of
them to Node, so a misconfigured path reports ERR_PNPM_PNPMFILE_NOT_FOUND
and names the file rather than surfacing as a pnpmfile execution failure.

The check lives at both loader roots. `updateConfig` resolves pnpmfiles
through `config_deps::resolve_pnpmfile_paths` and runs before the install
loads its own hooks, so validating only `finder::load_pnpmfiles` left
every install still reporting `Cannot find module` — a regression test
caught that the first time round. Sharing one helper between the two
roots turns `resolve_pnpmfile_paths` and `load_before_packing_hooks`
fallible, which is why pack, publish, and the `--find-by` finders appear
in the diff.

Discovery of the default `.pnpmfile.mjs` / `.pnpmfile.cjs` is unchanged
and stays optional: an absent default means the project has no pnpmfile,
which is not an error. pnpm draws the same line with `optional: true` on
the default entry in `requireHooks`.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790025675&installation_model_id=426870&pr_number=14084&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14084&signature=31518b756b1e3e75c1e886b89bd4d12eff895897ca11dc2832e848ff27fcf915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Explicitly configured pnpmfiles that cannot be found now produce a clear `ERR_PNPM_PNPMFILE_NOT_FOUND` error identifying the missing path.
  * Missing pnpmfiles are reported consistently during installation, updates, packing, publishing, and dependency inspection.
  * Extensionless configured pnpmfiles are correctly resolved when the corresponding module file exists.
  * Default pnpmfile discovery remains unchanged when no file is configured.
  * The `ignore_pnpmfile` option continues to skip pnpmfile loading when enabled.
* **Tests**
  * Added regression coverage for missing, omitted, empty, and extensionless pnpmfile configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->