### PR TITLE
[pacquet] feat(hooks): support the globalPnpmfile setting

### DIFF
--- a/.changeset/global-pnpmfile.md
+++ b/.changeset/global-pnpmfile.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Added support for the `globalPnpmfile` setting, which names a user-level pnpmfile that runs for every project ahead of the project's own. Like pnpm, it is left out of the lockfile's `pnpmfileChecksum`, so editing it does not decide whether a lockfile is still current. `pnpmfile` and `globalPnpmfile` are now also readable from `PNPM_CONFIG_PNPMFILE` and `PNPM_CONFIG_GLOBAL_PNPMFILE`.

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -379,7 +379,11 @@ impl InstallArgs {
             return false;
         }
         let config_root = config.root_project_manifest_dir(dir).to_path_buf();
-        if !pnpm_hooks::finder::find_pnpmfiles(&config_root, config.pnpmfile.as_deref()).is_empty()
+        if !pnpm_hooks::finder::find_pnpmfiles(
+            &config_root,
+            pnpm_package_manager::pnpmfile_selection(config),
+        )
+        .is_empty()
         {
             return false;
         }
@@ -903,8 +907,11 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
     let pnpmfile_hook = if state.config.ignore_pnpmfile {
         None
     } else {
-        pnpm_hooks::finder::load_pnpmfiles(lockfile_dir, state.config.pnpmfile.as_deref())
-            .map_err(|error| miette::miette!(code = "ERR_PNPM_PNPMFILE_NOT_FOUND", "{error}"))?
+        pnpm_hooks::finder::load_pnpmfiles(
+            lockfile_dir,
+            pnpm_package_manager::pnpmfile_selection(state.config),
+        )
+        .map_err(|error| miette::miette!(code = "ERR_PNPM_PNPMFILE_NOT_FOUND", "{error}"))?
     };
     let prefetch_allowed = match pnpmfile_hook.as_ref() {
         Some(hook) => !hook

--- a/pnpm/crates/cli/src/config_deps.rs
+++ b/pnpm/crates/cli/src/config_deps.rs
@@ -432,7 +432,7 @@ pub fn resolve_pnpmfile_paths(
     if config.ignore_pnpmfile {
         return Ok(Vec::new());
     }
-    finder::validate_configured_pnpmfiles(config.pnpmfile.as_deref())?;
+    finder::validate_configured_pnpmfiles(pnpm_package_manager::pnpmfile_selection(config))?;
     let config_modules_dir = root_dir.join("node_modules").join(".pnpm-config");
     let mut pnpmfiles: Vec<PathBuf> = match config.config_dependencies.as_ref() {
         Some(deps) => finder::calc_pnpmfile_paths_of_plugin_deps(
@@ -441,7 +441,9 @@ pub fn resolve_pnpmfile_paths(
         ),
         None => Vec::new(),
     };
-    for pnpmfile in finder::find_pnpmfiles(root_dir, config.pnpmfile.as_deref()) {
+    for pnpmfile in
+        finder::find_pnpmfiles(root_dir, pnpm_package_manager::pnpmfile_selection(config))
+    {
         if !pnpmfiles.contains(&pnpmfile) {
             pnpmfiles.push(pnpmfile);
         }

--- a/pnpm/crates/cli/tests/suite/install.rs
+++ b/pnpm/crates/cli/tests/suite/install.rs
@@ -2308,17 +2308,99 @@ fn ignore_pnpmfile_skips_the_update_config_hook() {
 /// A workspace pnpmfile whose single `readPackage` hook is observable in
 /// the lockfile: it gives `@pnpm.e2e/pkg-with-1-dep` a dependency the
 /// published package doesn't declare.
-fn write_read_package_pnpmfile(workspace: &Path) {
+/// `globalPnpmfile` names a user-level pnpmfile that runs for projects that
+/// ship none of their own. pnpm loads it ahead of the project's, and exposes
+/// the setting through `PNPM_CONFIG_GLOBAL_PNPMFILE` like every other key in
+/// its schema.
+#[test]
+fn a_global_pnpmfile_runs_for_a_project_without_one() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let global_pnpmfile = root.path().join("global-pnpmfile.cjs");
+    fs::write(&global_pnpmfile, READ_PACKAGE_PNPMFILE).expect("write global pnpmfile");
     fs::write(
-        workspace.join(".pnpmfile.cjs"),
-        r"module.exports = { hooks: { readPackage: (pkg) => {
+        workspace.join("package.json"),
+        r#"{"dependencies":{"@pnpm.e2e/pkg-with-1-dep":"100.0.0"}}"#,
+    )
+    .expect("write package.json");
+    assert!(!workspace.join(".pnpmfile.cjs").exists());
+
+    pacquet_in(&workspace)
+        .with_env("PNPM_CONFIG_GLOBAL_PNPMFILE", &global_pnpmfile)
+        .with_args(["install", "--lockfile-only"])
+        .assert()
+        .success();
+    assert!(
+        read_package_hook_applied(&workspace),
+        "the global pnpmfile's hook injects its dependency",
+    );
+
+    // The same install without the setting resolves the manifest as written,
+    // so the assertion above cannot pass on a fixture that never worked.
+    fs::remove_file(workspace.join("pnpm-lock.yaml")).expect("remove pnpm-lock.yaml");
+    pacquet_in(&workspace).with_args(["install", "--lockfile-only"]).assert().success();
+    assert!(!read_package_hook_applied(&workspace));
+
+    drop((root, mock_instance));
+}
+
+/// The global pnpmfile is excluded from `pnpmfileChecksum`, matching the
+/// `includeInChecksum: false` entry pnpm's `requireHooks` pushes for it.
+/// Editing it must therefore leave the lockfile's checksum alone — the field
+/// answers for the project's pnpmfiles, and claiming otherwise would let a
+/// user-level file silently decide whether a lockfile is still current.
+#[test]
+fn a_global_pnpmfile_stays_out_of_the_pnpmfile_checksum() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let global_pnpmfile = root.path().join("global-pnpmfile.cjs");
+    fs::write(&global_pnpmfile, "module.exports = { hooks: { readPackage: (pkg) => pkg } }")
+        .expect("write global pnpmfile");
+    write_read_package_pnpmfile(&workspace);
+    fs::write(
+        workspace.join("package.json"),
+        r#"{"dependencies":{"@pnpm.e2e/pkg-with-1-dep":"100.0.0"}}"#,
+    )
+    .expect("write package.json");
+
+    let install = || {
+        pacquet_in(&workspace)
+            .with_env("PNPM_CONFIG_GLOBAL_PNPMFILE", &global_pnpmfile)
+            .with_args(["install", "--lockfile-only"])
+            .assert()
+            .success();
+        pnpm_lockfile::Lockfile::load_wanted_from_dir(&workspace)
+            .expect("load wanted lockfile")
+            .expect("wanted lockfile")
+            .pnpmfile_checksum
+    };
+
+    let before = install();
+    assert!(before.is_some(), "the project pnpmfile is checksummed");
+
+    fs::write(
+        &global_pnpmfile,
+        "module.exports = { hooks: { readPackage: (pkg) => { void 0; return pkg } } }",
+    )
+    .expect("rewrite global pnpmfile");
+    assert_eq!(install(), before, "editing the global pnpmfile leaves the checksum alone");
+
+    drop((root, mock_instance));
+}
+
+const READ_PACKAGE_PNPMFILE: &str = r"module.exports = { hooks: { readPackage: (pkg) => {
             if (pkg.name === '@pnpm.e2e/pkg-with-1-dep') {
                 pkg.dependencies['is-positive'] = '1.0.0';
             }
             return pkg;
-        } } }",
-    )
-    .expect("write pnpmfile");
+        } } }";
+
+fn write_read_package_pnpmfile(workspace: &Path) {
+    fs::write(workspace.join(".pnpmfile.cjs"), READ_PACKAGE_PNPMFILE).expect("write pnpmfile");
 }
 
 fn read_package_hook_applied(workspace: &Path) -> bool {

--- a/pnpm/crates/cli/tests/suite/install.rs
+++ b/pnpm/crates/cli/tests/suite/install.rs
@@ -2346,6 +2346,56 @@ fn a_global_pnpmfile_runs_for_a_project_without_one() {
     drop((root, mock_instance));
 }
 
+/// The global pnpmfile loads ahead of the project's, so `readPackage` reaches
+/// it first and the project's hook sees what it returned. Chaining is the whole
+/// point of the order pnpm fixes by pushing the global entry first, and nothing
+/// else in this file would notice if the two swapped.
+#[test]
+fn a_global_pnpmfile_runs_before_the_project_pnpmfile() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let global_pnpmfile = root.path().join("global-pnpmfile.cjs");
+    fs::write(
+        &global_pnpmfile,
+        r"module.exports = { hooks: { readPackage: (pkg) => {
+            pkg.greetedByGlobalPnpmfile = true;
+            return pkg;
+        } } }",
+    )
+    .expect("write global pnpmfile");
+    // Injects only what the global hook already put on the manifest, so the
+    // dependency appears if and only if the global hook ran first.
+    fs::write(
+        workspace.join(".pnpmfile.cjs"),
+        r"module.exports = { hooks: { readPackage: (pkg) => {
+            if (pkg.greetedByGlobalPnpmfile && pkg.name === '@pnpm.e2e/pkg-with-1-dep') {
+                pkg.dependencies['is-positive'] = '1.0.0';
+            }
+            return pkg;
+        } } }",
+    )
+    .expect("write project pnpmfile");
+    fs::write(
+        workspace.join("package.json"),
+        r#"{"dependencies":{"@pnpm.e2e/pkg-with-1-dep":"100.0.0"}}"#,
+    )
+    .expect("write package.json");
+
+    pacquet_in(&workspace)
+        .with_env("PNPM_CONFIG_GLOBAL_PNPMFILE", &global_pnpmfile)
+        .with_args(["install", "--lockfile-only"])
+        .assert()
+        .success();
+    assert!(
+        read_package_hook_applied(&workspace),
+        "the project hook saw the global hook's manifest",
+    );
+
+    drop((root, mock_instance));
+}
+
 /// The global pnpmfile is excluded from `pnpmfileChecksum`, matching the
 /// `includeInChecksum: false` entry pnpm's `requireHooks` pushes for it.
 /// Editing it must therefore leave the lockfile's checksum alone — the field
@@ -2379,15 +2429,27 @@ fn a_global_pnpmfile_stays_out_of_the_pnpmfile_checksum() {
             .pnpmfile_checksum
     };
 
-    let before = install();
-    assert!(before.is_some(), "the project pnpmfile is checksummed");
+    let with_global = install();
+    assert!(with_global.is_some(), "the project pnpmfile is checksummed");
 
     fs::write(
         &global_pnpmfile,
         "module.exports = { hooks: { readPackage: (pkg) => { void 0; return pkg } } }",
     )
     .expect("rewrite global pnpmfile");
-    assert_eq!(install(), before, "editing the global pnpmfile leaves the checksum alone");
+    assert_eq!(install(), with_global, "editing the global pnpmfile leaves the checksum alone");
+
+    // The value itself has to match what the project alone records, not merely
+    // stay stable: `pnpmfileChecksum` is shared with pnpm, so a project that
+    // happens to have a global pnpmfile must not hash to something pnpm would
+    // disagree with.
+    fs::remove_file(workspace.join("pnpm-lock.yaml")).expect("remove pnpm-lock.yaml");
+    pacquet_in(&workspace).with_args(["install", "--lockfile-only"]).assert().success();
+    let without_global = pnpm_lockfile::Lockfile::load_wanted_from_dir(&workspace)
+        .expect("load wanted lockfile")
+        .expect("wanted lockfile")
+        .pnpmfile_checksum;
+    assert_eq!(with_global, without_global, "a global pnpmfile does not alter the recorded value");
 
     drop((root, mock_instance));
 }

--- a/pnpm/crates/config/src/env_overlay.rs
+++ b/pnpm/crates/config/src/env_overlay.rs
@@ -224,6 +224,8 @@ impl WorkspaceSettings {
         string_field!(user_agent, "USER_AGENT");
         json_field!(patched_dependencies, "PATCHED_DEPENDENCIES");
         string_field!(patches_dir, "PATCHES_DIR");
+        string_field!(global_pnpmfile, "GLOBAL_PNPMFILE");
+        enum_field!(pnpmfile, "PNPMFILE", crate::PnpmfileSetting);
         json_field!(allow_builds, "ALLOW_BUILDS");
         json_field!(dangerously_allow_all_builds, "DANGEROUSLY_ALLOW_ALL_BUILDS");
         json_field!(strict_dep_builds, "STRICT_DEP_BUILDS");

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -1673,6 +1673,12 @@ pub struct Config {
     /// discovers the default `.pnpmfile.mjs` or `.pnpmfile.cjs`.
     pub pnpmfile: Option<Vec<PathBuf>>,
 
+    /// `globalPnpmfile`. Loaded ahead of every project pnpmfile and left out
+    /// of `pnpmfileChecksum`, matching the entry pnpm's `requireHooks` pushes
+    /// first with `includeInChecksum: false`. A user-level file the lockfile
+    /// therefore cannot vouch for.
+    pub global_pnpmfile: Option<PathBuf>,
+
     /// `allowUnusedPatches` from `pnpm-workspace.yaml`. When `true`,
     /// configured patches that don't match any installed dependency
     /// produce a warning instead of failing the install with

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -369,6 +369,11 @@ pub struct WorkspaceSettings {
 
     pub pnpmfile: Option<PnpmfileSetting>,
 
+    /// `globalPnpmfile`. Unlike [`Self::pnpmfile`] this survives
+    /// [`Self::clear_workspace_only_fields`]: pnpm lists `global-pnpmfile`
+    /// among the keys its global `config.yaml` accepts.
+    pub global_pnpmfile: Option<String>,
+
     /// `allowUnusedPatches` from `pnpm-workspace.yaml`. Default `false`.
     pub allow_unused_patches: Option<bool>,
 
@@ -1618,6 +1623,9 @@ impl WorkspaceSettings {
         }
         if let Some(v) = self.patches_dir {
             config.patches_dir = Some(v);
+        }
+        if let Some(path) = self.global_pnpmfile {
+            config.global_pnpmfile = Some(pnpm_fs::lexical_normalize(&base_dir.join(path)));
         }
         if let Some(pnpmfile) = self.pnpmfile {
             let paths = match pnpmfile {

--- a/pnpm/crates/deps-restorer/src/install_package_from_registry/tests.rs
+++ b/pnpm/crates/deps-restorer/src/install_package_from_registry/tests.rs
@@ -129,6 +129,7 @@ fn create_config(
         patched_dependencies: None,
         patches_dir: None,
         pnpmfile: None,
+        global_pnpmfile: None,
         allow_unused_patches: false,
         config_dependencies: None,
         allow_builds: Default::default(),

--- a/pnpm/crates/hooks/src/finder.rs
+++ b/pnpm/crates/hooks/src/finder.rs
@@ -31,16 +31,28 @@ pub fn load_pnpmfile(root: &Path) -> Option<Arc<dyn PnpmfileHooks>> {
     Some(Arc::new(super::node_runtime::NodeJsHooks::new(file)))
 }
 
-#[must_use]
-pub fn find_pnpmfiles(root: &Path, configured: Option<&[PathBuf]>) -> Vec<PathBuf> {
-    let Some(configured) = configured else {
-        return find_pnpmfile(root).into_iter().collect();
-    };
+/// Which pnpmfiles an install runs, before any of them is read.
+///
+/// `global` is the user-level `globalPnpmfile`. It loads ahead of the project's
+/// own and stays out of `pnpmfileChecksum`, so nothing that trusts the checksum
+/// may treat it as accounted for — the same split pnpm's `requireHooks` makes
+/// with `includeInChecksum: false`.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct PnpmfileSelection<'a> {
+    pub configured: Option<&'a [PathBuf]>,
+    pub global: Option<&'a Path>,
+}
 
-    let mut paths = Vec::with_capacity(configured.len());
-    for path in configured {
-        if !paths.contains(path) {
-            paths.push(path.clone());
+#[must_use]
+pub fn find_pnpmfiles(root: &Path, selection: PnpmfileSelection<'_>) -> Vec<PathBuf> {
+    let mut paths: Vec<PathBuf> = selection.global.map(Path::to_path_buf).into_iter().collect();
+    let project = match selection.configured {
+        Some(configured) => configured.to_vec(),
+        None => find_pnpmfile(root).into_iter().collect(),
+    };
+    for path in project {
+        if !paths.contains(&path) {
+            paths.push(path);
         }
     }
     paths
@@ -60,11 +72,16 @@ pub struct MissingPnpmfileError {
 /// Every loader validates before it hands a path to Node, so a misconfigured
 /// setting is reported the same way whichever hook the command reaches first.
 pub fn validate_configured_pnpmfiles(
-    configured: Option<&[PathBuf]>,
+    selection: PnpmfileSelection<'_>,
 ) -> Result<(), MissingPnpmfileError> {
-    let Some(configured) = configured else { return Ok(()) };
-    match configured.iter().find(|path| !pnpmfile_exists(path)) {
-        Some(missing) => Err(MissingPnpmfileError { path: missing.clone() }),
+    // Discovery is the only source that may come back empty without complaint,
+    // so both explicitly named sources are checked and the default is not.
+    let mut named = selection
+        .global
+        .into_iter()
+        .chain(selection.configured.unwrap_or(&[]).iter().map(PathBuf::as_path));
+    match named.find(|path| !pnpmfile_exists(path)) {
+        Some(missing) => Err(MissingPnpmfileError { path: missing.to_path_buf() }),
         None => Ok(()),
     }
 }
@@ -93,20 +110,26 @@ fn pnpmfile_exists(path: &Path) -> bool {
 /// lists them. `Ok(None)` means the project has no pnpmfile at all.
 pub fn load_pnpmfiles(
     root: &Path,
-    configured: Option<&[PathBuf]>,
+    selection: PnpmfileSelection<'_>,
 ) -> Result<Option<Arc<dyn PnpmfileHooks>>, MissingPnpmfileError> {
-    let paths = find_pnpmfiles(root, configured);
-    validate_configured_pnpmfiles(configured)?;
-    let mut hooks: Vec<_> = paths.into_iter().map(load_pnpmfile_at).collect();
-    Ok(match hooks.len() {
-        0 => None,
-        1 => hooks.pop(),
-        _ => Some(Arc::new(CombinedPnpmfileHooks { hooks })),
+    let paths = find_pnpmfiles(root, selection);
+    validate_configured_pnpmfiles(selection)?;
+    let checksum_skips = usize::from(selection.global.is_some());
+    let hooks: Vec<_> = paths.into_iter().map(load_pnpmfile_at).collect();
+    Ok(match (hooks.len(), checksum_skips) {
+        (0, _) => None,
+        // A lone project pnpmfile answers for its own checksum. Anything else
+        // has to go through the wrapper, including a lone global one: its hash
+        // must not become the project's.
+        (1, 0) => hooks.into_iter().next(),
+        _ => Some(Arc::new(CombinedPnpmfileHooks { hooks, checksum_skips })),
     })
 }
 
 struct CombinedPnpmfileHooks {
     hooks: Vec<Arc<dyn PnpmfileHooks>>,
+    /// How many leading entries of [`Self::hooks`] the checksum leaves out.
+    checksum_skips: usize,
 }
 
 #[async_trait]
@@ -162,8 +185,10 @@ impl PnpmfileHooks for CombinedPnpmfileHooks {
             return None;
         }
 
-        let mut paths: Vec<&Path> =
-            self.hooks.iter().filter_map(|hook| hook.source_path()).collect();
+        let mut paths: Vec<&Path> = self.hooks[self.checksum_skips..]
+            .iter()
+            .filter_map(|hook| hook.source_path())
+            .collect();
         paths.sort_unstable();
         let hashes: Option<Vec<String>> = paths
             .into_iter()

--- a/pnpm/crates/hooks/src/finder.rs
+++ b/pnpm/crates/hooks/src/finder.rs
@@ -195,7 +195,15 @@ impl PnpmfileHooks for CombinedPnpmfileHooks {
             .map(|path| pnpm_crypto_hash::create_hash_from_file(path).ok())
             .collect();
         let hashes = hashes?;
-        Some(pnpm_crypto_hash::create_hash(&hashes.join(",")))
+        Some(match hashes.as_slice() {
+            // `createHashFromMultipleFiles` answers with the file's own hash
+            // when the set holds exactly one, rather than hashing a list of
+            // one hash. Excluding the global pnpmfile can leave a single
+            // project file behind, so the shortcut is reachable here and the
+            // two implementations have to agree on the value they record.
+            [only] => only.clone(),
+            _ => pnpm_crypto_hash::create_hash(&hashes.join(",")),
+        })
     }
 
     async fn get_custom_resolvers(&self) -> Result<Vec<Arc<dyn CustomResolver>>, HookError> {

--- a/pnpm/crates/package-manager/src/install/lockfile_freshness.rs
+++ b/pnpm/crates/package-manager/src/install/lockfile_freshness.rs
@@ -63,7 +63,7 @@ pub async fn wanted_lockfile_satisfies_workspace(
     let lockfile_root =
         super::lockfile_root_for(config, workspace_dir_opt.as_deref(), manifest_dir);
     if !config.ignore_pnpmfile
-        && !pnpm_hooks::finder::find_pnpmfiles(&workspace_root, config.pnpmfile.as_deref())
+        && !pnpm_hooks::finder::find_pnpmfiles(&workspace_root, crate::pnpmfile_selection(config))
             .is_empty()
     {
         return false;

--- a/pnpm/crates/package-manager/src/install/run.rs
+++ b/pnpm/crates/package-manager/src/install/run.rs
@@ -540,8 +540,11 @@ where
         let pnpmfile_hook = match pnpmfile_hook_override {
             Some(hook) => Some(hook),
             None if config.ignore_pnpmfile => None,
-            None => pnpm_hooks::finder::load_pnpmfiles(&workspace_root, config.pnpmfile.as_deref())
-                .map_err(InstallError::MissingPnpmfile)?,
+            None => pnpm_hooks::finder::load_pnpmfiles(
+                &workspace_root,
+                crate::pnpmfile_selection(config),
+            )
+            .map_err(InstallError::MissingPnpmfile)?,
         };
 
         // pnpm's `getContext` runs `readPackage` over every project

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolver_setup.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolver_setup.rs
@@ -330,7 +330,7 @@ pub(super) async fn build_resolver_chain<Reporter: pnpm_reporter::Reporter + 'st
     let pnpmfile_hook = match pnpmfile_hook_override {
         Some(hook) => Some(hook),
         None if config.ignore_pnpmfile => None,
-        None => pnpm_hooks::finder::load_pnpmfiles(lockfile_dir, config.pnpmfile.as_deref())
+        None => pnpm_hooks::finder::load_pnpmfiles(lockfile_dir, crate::pnpmfile_selection(config))
             .map_err(InstallWithFreshLockfileError::MissingPnpmfile)?,
     };
     let custom_resolvers: Vec<Arc<dyn pnpm_hooks::CustomResolver>> =

--- a/pnpm/crates/package-manager/src/lib.rs
+++ b/pnpm/crates/package-manager/src/lib.rs
@@ -101,3 +101,15 @@ pub(crate) fn emit_initial_package_manifest<Reporter: pnpm_reporter::Reporter>(
 
 #[cfg(test)]
 mod tests;
+
+/// The pnpmfiles an install runs, as configured. Every entry point that loads
+/// hooks or asks whether any exist reads the same pair of settings.
+#[must_use]
+pub fn pnpmfile_selection(
+    config: &pnpm_config::Config,
+) -> pnpm_hooks::finder::PnpmfileSelection<'_> {
+    pnpm_hooks::finder::PnpmfileSelection {
+        configured: config.pnpmfile.as_deref(),
+        global: config.global_pnpmfile.as_deref(),
+    }
+}

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
@@ -608,7 +608,7 @@ pub(crate) fn current_pnpmfiles(workspace_root: &Path, config: &Config) -> Vec<S
     if config.ignore_pnpmfile {
         return Vec::new();
     }
-    pnpm_hooks::finder::find_pnpmfiles(workspace_root, config.pnpmfile.as_deref())
+    pnpm_hooks::finder::find_pnpmfiles(workspace_root, crate::pnpmfile_selection(config))
         .into_iter()
         .map(|path| path.to_string_lossy().into_owned())
         .collect()

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -685,8 +685,9 @@ fn update_read_package_hook<Reporter: self::Reporter>(
     workspace_root: &Path,
     config: &Config,
 ) -> Result<Option<ReadPackageHook>, UpdateError> {
-    let Some(hook) = pnpm_hooks::finder::load_pnpmfiles(workspace_root, config.pnpmfile.as_deref())
-        .map_err(UpdateError::MissingPnpmfile)?
+    let Some(hook) =
+        pnpm_hooks::finder::load_pnpmfiles(workspace_root, crate::pnpmfile_selection(config))
+            .map_err(UpdateError::MissingPnpmfile)?
     else {
         return Ok(None);
     };


### PR DESCRIPTION
## Summary

Adds the `globalPnpmfile` setting: a user-level pnpmfile that runs for every project, loaded ahead of the project's own. pnpm has carried `global-pnpmfile` in its config schema all along and loads it in `requireHooks`; pacquet had no way to name one.

It is deliberately left out of the lockfile's `pnpmfileChecksum`, matching the entry pnpm pushes with `includeInChecksum: false`. The field answers for the pnpmfiles a project ships — a lockfile that folded in a file living in the user's config directory would go stale for reasons the repository cannot see.

`pnpmfile` and `globalPnpmfile` are now also readable from `PNPM_CONFIG_PNPMFILE` and `PNPM_CONFIG_GLOBAL_PNPMFILE`, since pnpm's `parseEnvVars` exposes every key in its schema.

Part of pnpm/pnpm#12042. TypeScript already has all of this, so there is nothing to mirror there.

Still open on that checklist item after this: `ignorePnpmfile` from the global config file / `PNPM_CONFIG_IGNORE_PNPMFILE`, which stays CLI-only here.

## Squash Commit Body

```text
A user-level pnpmfile that runs for every project, loaded ahead of the
project's own.

It is deliberately outside `pnpmfileChecksum`. That field answers for the
pnpmfiles a project ships, and a lockfile that folded in a file living in
the user's config directory would go stale for reasons the repository
cannot see. This is the split pnpm draws by pushing the entry with
`includeInChecksum: false`, and it is why a lone global pnpmfile still
goes through the combining wrapper rather than answering for the checksum
itself.

`PnpmfileSelection` carries the two settings together so every site that
loads hooks, or only asks whether any exist, reads the same pair — the
freshness checks included, which is what keeps a global pnpmfile from
letting an install take the frozen fast path and skip its hooks.

`pnpmfile` and `globalPnpmfile` are read from the environment too, as
pnpm's `parseEnvVars` exposes every key in its schema.

Part of pnpm/pnpm#12042.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14085"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790029151&installation_model_id=426870&pr_number=14085&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14085&signature=16685cf974a72097fbb57190cc2aaf21b70882db2ce18aebcc7a8e42a01b1853"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a global pnpmfile alongside project pnpmfiles.
  * Added configuration through workspace settings and environment variables.
  * Global pnpmfiles load before project pnpmfiles and are excluded from project lockfile checksum calculations.

* **Bug Fixes**
  * Improved pnpmfile discovery, validation, and loading across installation and update workflows.
  * Prevented global pnpmfile changes from unnecessarily invalidating project state.

* **Tests**
  * Added end-to-end coverage for global pnpmfile behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->