### PR TITLE
feat(pacquet): support remaining install env vars

### DIFF
--- a/.changeset/pacquet-install-env-coverage.md
+++ b/.changeset/pacquet-install-env-coverage.md
@@ -1,0 +1,5 @@
+---
+"pacquet": minor
+---
+
+Added `PNPM_CONFIG_VIRTUAL_STORE_ONLY` and `PNPM_CONFIG_ENABLE_MODULES_DIR` support to the Rust pnpm CLI.

--- a/pnpm/crates/config/src/env_overlay.rs
+++ b/pnpm/crates/config/src/env_overlay.rs
@@ -151,6 +151,8 @@ impl WorkspaceSettings {
         string_field!(virtual_store_dir, "VIRTUAL_STORE_DIR");
         enum_field!(virtual_store_type, "VIRTUAL_STORE_TYPE", VirtualStoreType);
         json_field!(enable_global_virtual_store, "ENABLE_GLOBAL_VIRTUAL_STORE");
+        json_field!(virtual_store_only, "VIRTUAL_STORE_ONLY");
+        json_field!(enable_modules_dir, "ENABLE_MODULES_DIR");
         json_field!(global_shims, "GLOBAL_SHIMS");
         string_field!(global_virtual_store_dir, "GLOBAL_VIRTUAL_STORE_DIR");
         enum_field!(package_import_method, "PACKAGE_IMPORT_METHOD", PackageImportMethod);

--- a/pnpm/crates/config/src/env_overlay/tests.rs
+++ b/pnpm/crates/config/src/env_overlay/tests.rs
@@ -17,6 +17,23 @@ fn bool_env_var_only_accepts_lowercase_true_false() {
     assert_eq!(settings.enable_global_virtual_store, None);
 }
 
+#[test]
+fn materialization_settings_read_from_the_environment() {
+    struct EnvMaterialization;
+    impl EnvVar for EnvMaterialization {
+        fn var(name: &str) -> Option<String> {
+            match name {
+                "PNPM_CONFIG_VIRTUAL_STORE_ONLY" => Some("true".to_owned()),
+                "PNPM_CONFIG_ENABLE_MODULES_DIR" => Some("false".to_owned()),
+                _ => None,
+            }
+        }
+    }
+    let settings = WorkspaceSettings::from_pnpm_config_env::<EnvMaterialization>();
+    assert_eq!(settings.virtual_store_only, Some(true));
+    assert_eq!(settings.enable_modules_dir, Some(false));
+}
+
 /// An exported-but-empty `PNPM_CONFIG_STORE_DIR=` shouldn't clobber
 /// the configured store path.
 #[test]

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -2923,6 +2923,45 @@ pub fn pnpm_config_env_var_overrides_workspace_yaml() {
 }
 
 #[test]
+pub fn materialization_env_vars_override_workspace_yaml() {
+    let tmp = tempdir().unwrap();
+    fs::write(
+        tmp.path().join("pnpm-workspace.yaml"),
+        "virtualStoreOnly: false\nenableModulesDir: true\n",
+    )
+    .expect("write to pnpm-workspace.yaml");
+
+    struct HostWithMaterializationEnv;
+    impl EnvVar for HostWithMaterializationEnv {
+        fn var(name: &str) -> Option<String> {
+            match name {
+                "PNPM_CONFIG_VIRTUAL_STORE_ONLY" => Some("true".to_owned()),
+                "PNPM_CONFIG_ENABLE_MODULES_DIR" => Some("false".to_owned()),
+                _ => safe_host_var(name),
+            }
+        }
+    }
+    impl EnvVarOs for HostWithMaterializationEnv {
+        fn var_os(_: &str) -> Option<OsString> {
+            None
+        }
+    }
+    impl GetHomeDir for HostWithMaterializationEnv {
+        fn home_dir() -> Option<PathBuf> {
+            None
+        }
+    }
+    inert_link_probe!(HostWithMaterializationEnv);
+    host_current_dir!(HostWithMaterializationEnv);
+
+    let config = Config::new().current::<HostWithMaterializationEnv>(tmp.path()).expect("loads");
+    assert!(config.virtual_store_only);
+    assert!(!config.enable_modules_dir);
+    assert_eq!(config.hoist_pattern, Some(vec![]));
+    assert_eq!(config.public_hoist_pattern, Some(vec![]));
+}
+
+#[test]
 pub fn self_update_config_ignores_a_workspace_manifest_that_raises_the_cutoff() {
     let tmp = tempdir().unwrap();
     fs::write(


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Complete the **Env-var coverage** section of pnpm/pnpm#12042 by wiring `PNPM_CONFIG_VIRTUAL_STORE_ONLY` and `PNPM_CONFIG_ENABLE_MODULES_DIR` into pacquet's schema-wide environment overlay. Both values override `pnpm-workspace.yaml` and receive the same post-processing as values read from YAML.

The third setting listed there, `PNPM_CONFIG_NPMRC_AUTH_FILE`, was re-audited and is already implemented through the auth-file bootstrap path, including uppercase and lowercase lookup, precedence, relative-path, and credential-loading tests. This PR leaves that specialized path intact instead of duplicating it in the general overlay.

The TypeScript CLI already exposes all three variables through `parseEnvVars`, so no matching TypeScript change is needed.

Related to pnpm/pnpm#12042.

## Squash Commit Body

```text
Expose virtualStoreOnly and enableModulesDir through pacquet's PNPM_CONFIG environment overlay so CI and other callers can override committed workspace settings.

Keep npmrcAuthFile on its existing early bootstrap path, which already supports PNPM_CONFIG_NPMRC_AUTH_FILE and must select the auth file before the rest of configuration is loaded.

Related to pnpm/pnpm#12042.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Codex, gpt-5.6-sol).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14086"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790029496&installation_model_id=426870&pr_number=14086&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14086&signature=4a8ef3d94e35dc410fbcd4fc28d9dc58453832457dd31742dc3f76c123f4506b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring virtual-store-only mode through `PNPM_CONFIG_VIRTUAL_STORE_ONLY`.
  * Added support for enabling or disabling the modules directory through `PNPM_CONFIG_ENABLE_MODULES_DIR`.
  * Environment variable settings now override conflicting workspace configuration values.

* **Tests**
  * Added coverage for environment-based configuration parsing and precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->