### PR TITLE
fix(cli): respect minimum release age

### DIFF
--- a/.changeset/outdated-respects-release-age.md
+++ b/.changeset/outdated-respects-release-age.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `pnpm outdated` and `pnpm update --interactive` offering versions blocked by `minimumReleaseAge` [pnpm/pnpm#14004](https://github.com/pnpm/pnpm/issues/14004).

--- a/pnpm/crates/cli/src/cli_args/outdated.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated.rs
@@ -29,7 +29,9 @@ use miette::IntoDiagnostic;
 use node_semver::Version;
 use owo_colors::{OwoColorize, Stream};
 use pnpm_catalogs_protocol_parser::parse_catalog_protocol;
-use pnpm_catalogs_resolver::{CatalogResolutionResult, WantedDependency, resolve_from_catalog};
+use pnpm_catalogs_resolver::{
+    CatalogResolutionResult, WantedDependency as CatalogWantedDependency, resolve_from_catalog,
+};
 use pnpm_catalogs_types::Catalogs;
 use pnpm_config::{
     Config,
@@ -37,34 +39,38 @@ use pnpm_config::{
 };
 use pnpm_lockfile::Lockfile;
 use pnpm_network::ThrottledClient;
+use pnpm_package_manager::{PickPolicy, create_configured_npm_resolver};
 use pnpm_package_manifest::{DependencyGroup, PackageManifest};
-use pnpm_registry::{Package, PackageVersion, RegistryError};
 use pnpm_reporter::Reporter;
-use pnpm_resolving_npm_resolver::pick_registry_for_package;
-use std::{
-    borrow::Cow,
-    collections::HashMap,
-    io::Write,
-    path::PathBuf,
-    sync::{Arc, Mutex},
+use pnpm_resolving_npm_resolver::{InMemoryPackageMetaCache, NpmResolver};
+use pnpm_resolving_resolver_base::{
+    LatestQuery, ResolveOptions, Resolver, WantedDependency as ResolverWantedDependency,
 };
-use tokio::sync::OnceCell;
-
-type PackumentCache = Mutex<HashMap<(String, String), Arc<OnceCell<Arc<Package>>>>>;
+use std::{borrow::Cow, collections::HashMap, io::Write, path::PathBuf, sync::Arc};
 
 /// State shared by every importer inspected in one `outdated` (or
-/// `update --interactive`) run: the packument memo, so a dependency
-/// several workspace projects share is fetched once, and the catalogs
-/// their `catalog:` specifiers dereference against.
+/// `update --interactive`) run: one resolver and metadata cache, so a
+/// dependency several workspace projects share is fetched once, plus the
+/// catalogs their `catalog:` specifiers dereference against.
 pub(crate) struct OutdatedRun {
-    packument_cache: PackumentCache,
+    resolver: NpmResolver<InMemoryPackageMetaCache>,
+    resolve_options: ResolveOptions,
     catalogs: Catalogs,
 }
 
 impl OutdatedRun {
-    pub(crate) fn new(config: &Config) -> miette::Result<Self> {
+    pub(crate) fn new(config: &Config, http_client: Arc<ThrottledClient>) -> miette::Result<Self> {
+        let policy = PickPolicy::from_config(config).map_err(miette::Report::new)?;
+        let resolver = create_configured_npm_resolver(config, http_client, &policy)
+            .map_err(miette::Report::new)?;
         Ok(Self {
-            packument_cache: PackumentCache::default(),
+            resolver,
+            resolve_options: ResolveOptions {
+                default_tag: Some("latest".to_string()),
+                published_by: policy.published_by,
+                published_by_exclude: policy.published_by_exclude,
+                ..ResolveOptions::default()
+            },
             catalogs: configured_catalogs(config)?,
         })
     }
@@ -157,7 +163,7 @@ pub async fn collect_outdated(
     manifest: &PackageManifest,
     lockfile: Option<&Lockfile>,
     config: &Config,
-    http_client: &ThrottledClient,
+    http_client: &Arc<ThrottledClient>,
     query: &OutdatedQuery<'_>,
 ) -> miette::Result<Vec<OutdatedPackage>> {
     collect_outdated_for_importer(
@@ -176,17 +182,15 @@ pub(crate) async fn collect_outdated_for_importer(
     lockfile: Option<&Lockfile>,
     importer_id: &str,
     config: &Config,
-    http_client: &ThrottledClient,
+    http_client: &Arc<ThrottledClient>,
     query: &OutdatedQuery<'_>,
 ) -> miette::Result<Vec<OutdatedPackage>> {
     collect_outdated_for_importer_in_run(
         manifest,
         lockfile,
         importer_id,
-        config,
-        http_client,
         query,
-        &OutdatedRun::new(config)?,
+        &OutdatedRun::new(config, Arc::clone(http_client))?,
     )
     .await
 }
@@ -195,8 +199,6 @@ pub(crate) async fn collect_outdated_for_importer_in_run(
     manifest: &PackageManifest,
     lockfile: Option<&Lockfile>,
     importer_id: &str,
-    config: &Config,
-    http_client: &ThrottledClient,
     query: &OutdatedQuery<'_>,
     run: &OutdatedRun,
 ) -> miette::Result<Vec<OutdatedPackage>> {
@@ -238,45 +240,66 @@ pub(crate) async fn collect_outdated_for_importer_in_run(
         })
         .map(|(alias, group, bare_specifier, current)| async move {
             let bare_specifier = dereference_catalog(&run.catalogs, alias, bare_specifier)?;
-            let (package_name, range) =
-                PackageManifest::resolve_registry_dependency(alias, &bare_specifier);
-            let registries: HashMap<String, String> =
-                config.resolved_registries().into_iter().collect();
-            let registry =
-                pick_registry_for_package(&registries, package_name, Some(&bare_specifier));
-            let package = fetch_package_cached(
-                &run.packument_cache,
-                package_name,
-                http_client,
-                &registry,
-                &config.auth_headers,
-            )
-            .await
-            .map_err(|error| {
-                let reason = pnpm_network::redact_url_credentials(&error.to_string());
-                miette::miette!(
-                    code = "ERR_PNPM_OUTDATED_REGISTRY_ERROR",
-                    r#"Failed to fetch metadata for "{package_name}": {reason}"#,
+            let resolved_package_name =
+                PackageManifest::resolve_registry_dependency(alias, &bare_specifier).0.to_string();
+            let latest = run
+                .resolver
+                .resolve_latest(
+                    &LatestQuery {
+                        wanted_dependency: ResolverWantedDependency {
+                            alias: Some(alias.to_string()),
+                            bare_specifier: Some(bare_specifier.into_owned()),
+                            optional: Some(group == DependencyGroup::Optional),
+                            ..ResolverWantedDependency::default()
+                        },
+                        compatible: matches!(query.target_version, TargetVersion::WithinRange),
+                    },
+                    &run.resolve_options,
                 )
-            })?;
-            let Some(target) = resolve_target(&package, range, query.target_version) else {
+                .await
+                .map_err(|error| {
+                    let reason = pnpm_network::redact_url_credentials(&error.to_string());
+                    miette::miette!(
+                        code = "ERR_PNPM_OUTDATED_REGISTRY_ERROR",
+                        r#"Failed to fetch metadata for "{resolved_package_name}": {reason}"#,
+                    )
+                })?;
+            let Some(target_manifest) = latest.and_then(|latest| latest.latest_manifest) else {
                 return Ok(None);
             };
-            let deprecated = target.deprecated.clone();
-            let is_newer = target.version > current;
+            let Some(target) = target_manifest
+                .get("version")
+                .and_then(serde_json::Value::as_str)
+                .and_then(|version| version.parse::<Version>().ok())
+            else {
+                return Ok(None);
+            };
+            let deprecated = target_manifest
+                .get("deprecated")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string);
+            let is_newer = target > current;
             if !(is_newer || (query.include_deprecated && deprecated.is_some())) {
                 return Ok(None);
             }
+            let package_name = target_manifest
+                .get("name")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or(&resolved_package_name)
+                .to_string();
             Ok(Some(OutdatedPackage {
                 alias: alias.to_string(),
-                package_name: package_name.to_string(),
+                package_name,
                 belongs_to: group,
                 wanted: current.clone(),
                 current,
-                target: target.version.clone(),
+                target,
                 github_action: false,
                 deprecated,
-                homepage: package.homepage.clone(),
+                homepage: target_manifest
+                    .get("homepage")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string),
                 workspace: Some(workspace.clone()),
             }))
         });
@@ -303,60 +326,16 @@ fn dereference_catalog<'a>(
     if parse_catalog_protocol(bare_specifier).is_none() {
         return Ok(Cow::Borrowed(bare_specifier));
     }
-    let wanted =
-        WantedDependency { alias: alias.to_string(), bare_specifier: bare_specifier.to_string() };
+    let wanted = CatalogWantedDependency {
+        alias: alias.to_string(),
+        bare_specifier: bare_specifier.to_string(),
+    };
     match resolve_from_catalog(catalogs, &wanted) {
         CatalogResolutionResult::Found(found) => Ok(Cow::Owned(found.resolution.specifier)),
         CatalogResolutionResult::Misconfiguration(misconfiguration) => {
             Err(miette::Report::new(misconfiguration.error))
         }
         CatalogResolutionResult::Unused => Ok(Cow::Borrowed(bare_specifier)),
-    }
-}
-
-async fn fetch_package_cached(
-    cache: &PackumentCache,
-    package_name: &str,
-    http_client: &ThrottledClient,
-    registry: &str,
-    auth_headers: &pnpm_network::AuthHeaders,
-) -> Result<Arc<Package>, RegistryError> {
-    let key = (registry.to_string(), package_name.to_string());
-    let entry = {
-        let mut cache = cache.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-        Arc::clone(cache.entry(key).or_default())
-    };
-    let package = entry
-        .get_or_try_init(|| async {
-            Package::fetch_from_registry(package_name, http_client, registry, auth_headers)
-                .await
-                .map(Arc::new)
-        })
-        .await?;
-    Ok(Arc::clone(package))
-}
-
-/// Resolve the [`TargetVersion`] to a concrete published version, or
-/// `None` when the registry has no matching version (no `latest` tag, no
-/// in-range version, or a non-semver range).
-fn resolve_target(
-    package: &Package,
-    range: &str,
-    target_version: TargetVersion,
-) -> Option<std::sync::Arc<PackageVersion>> {
-    match target_version {
-        TargetVersion::Latest => {
-            let tag = package.dist_tag("latest")?;
-            package.versions.get(tag)
-        }
-        TargetVersion::WithinRange => {
-            // `pinned_version` parses the range with `.unwrap()`, so guard
-            // non-semver specifiers (`workspace:`, `link:`, git URLs) that
-            // a lockfile-pinned semver `current` would not have screened
-            // out on its own.
-            range.parse::<node_semver::Range>().ok()?;
-            package.pinned_version(range)
-        }
     }
 }
 
@@ -641,7 +620,7 @@ impl OutdatedArgs {
             };
             project_inputs.push((project_dir, project, project_lockfile));
         }
-        let run = OutdatedRun::new(config)?;
+        let run = OutdatedRun::new(config, Arc::clone(&state.http_client))?;
         let project_queries =
             project_inputs.iter().map(|(project_dir, project, project_lockfile)| async {
                 let (lockfile, importer_id) = if config.shares_one_lockfile() {
@@ -664,8 +643,6 @@ impl OutdatedArgs {
                     &project.manifest,
                     Some(lockfile),
                     &importer_id,
-                    config,
-                    &state.http_client,
                     &query,
                     &run,
                 )

--- a/pnpm/crates/cli/src/cli_args/outdated/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated/tests.rs
@@ -1,12 +1,10 @@
 use super::{
     Change, DependentProject, OutdatedDependencyOptions, OutdatedInWorkspace, OutdatedPackage,
-    PackumentCache, classify, current_versions_from_importer, fetch_package_cached,
-    render_dependents, render_json, render_latest, render_recursive_json, sort_outdated,
+    classify, current_versions_from_importer, render_dependents, render_json, render_latest,
+    render_recursive_json, sort_outdated,
 };
 use node_semver::Version;
-use pnpm_config::Config;
 use pnpm_lockfile::Lockfile;
-use pnpm_network::ThrottledClient;
 use pnpm_package_manifest::DependencyGroup;
 use std::{collections::HashMap, path::PathBuf};
 use text_block_macros::text_block;
@@ -271,104 +269,4 @@ fn recursive_json_replaces_invalid_utf8_in_locations() {
     let value: serde_json::Value =
         serde_json::from_str(&render_recursive_json(&[entry], false)).expect("valid JSON");
     assert_eq!(value["foo"]["dependentPackages"][0]["location"], "packages/�-app");
-}
-
-#[tokio::test]
-async fn packument_cache_deduplicates_concurrent_fetches() {
-    let mut server = mockito::Server::new_async().await;
-    let package = server
-        .mock("GET", "/foo")
-        .with_status(200)
-        .with_header("content-type", "application/json")
-        .with_body(r#"{ "name": "foo", "dist-tags": {}, "versions": {} }"#)
-        .expect(1)
-        .create_async()
-        .await;
-    let registry = format!("{}/", server.url());
-    let config = Config::new();
-    let client = ThrottledClient::default();
-    let cache = PackumentCache::default();
-    let first_fetch = fetch_package_cached(&cache, "foo", &client, &registry, &config.auth_headers);
-    let second_fetch =
-        fetch_package_cached(&cache, "foo", &client, &registry, &config.auth_headers);
-
-    let (first, second) = tokio::join!(first_fetch, second_fetch);
-
-    assert_eq!(first.expect("first fetch").name, "foo");
-    assert_eq!(second.expect("second fetch").name, "foo");
-    package.assert_async().await;
-}
-
-#[tokio::test]
-async fn packument_cache_does_not_memoize_failures() {
-    let mut server = mockito::Server::new_async().await;
-    let failed_request = server
-        .mock("GET", "/foo")
-        .with_status(500)
-        .with_body("not package metadata")
-        .expect(1)
-        .create_async()
-        .await;
-    let registry = format!("{}/", server.url());
-    let config = Config::new();
-    let client = ThrottledClient::default();
-    let cache = PackumentCache::default();
-
-    assert!(
-        fetch_package_cached(&cache, "foo", &client, &registry, &config.auth_headers)
-            .await
-            .is_err(),
-    );
-    failed_request.assert_async().await;
-    failed_request.remove_async().await;
-
-    let successful_request = server
-        .mock("GET", "/foo")
-        .with_status(200)
-        .with_header("content-type", "application/json")
-        .with_body(r#"{ "name": "foo", "dist-tags": {}, "versions": {} }"#)
-        .expect(1)
-        .create_async()
-        .await;
-
-    let package = fetch_package_cached(&cache, "foo", &client, &registry, &config.auth_headers)
-        .await
-        .expect("retry package fetch");
-    assert_eq!(package.name, "foo");
-    successful_request.assert_async().await;
-}
-
-#[tokio::test]
-async fn packument_cache_recovers_from_poisoning() {
-    let mut server = mockito::Server::new_async().await;
-    let package = server
-        .mock("GET", "/foo")
-        .with_status(200)
-        .with_header("content-type", "application/json")
-        .with_body(r#"{ "name": "foo", "dist-tags": {}, "versions": {} }"#)
-        .expect(1)
-        .create_async()
-        .await;
-    let registry = format!("{}/", server.url());
-    let config = Config::new();
-    let client = ThrottledClient::default();
-    let cache = PackumentCache::default();
-
-    std::thread::scope(|scope| {
-        assert!(
-            scope
-                .spawn(|| {
-                    let _guard = cache.lock().expect("lock packument cache");
-                    panic!("poison packument cache");
-                })
-                .join()
-                .is_err(),
-        );
-    });
-
-    let fetched = fetch_package_cached(&cache, "foo", &client, &registry, &config.auth_headers)
-        .await
-        .expect("fetch package after cache poisoning");
-    assert_eq!(fetched.name, "foo");
-    package.assert_async().await;
 }

--- a/pnpm/crates/cli/src/cli_args/update_interactive.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive.rs
@@ -34,7 +34,7 @@ use pnpm_lockfile::Lockfile;
 use pnpm_network::ThrottledClient;
 use pnpm_package_manifest::{DependencyGroup, PackageManifest};
 use pnpm_reporter::Reporter;
-use std::{collections::HashSet, path::Path};
+use std::{collections::HashSet, path::Path, sync::Arc};
 
 struct InteractiveUpdateProject<'a> {
     manifest: &'a PackageManifest,
@@ -165,7 +165,7 @@ pub(crate) async fn select_packages<Reporter: self::Reporter>(
     lockfile: Option<&Lockfile>,
     importer_id: &str,
     config: &Config,
-    http_client: &ThrottledClient,
+    http_client: &Arc<ThrottledClient>,
     options: InteractiveUpdateOptions<'_>,
 ) -> miette::Result<Option<Vec<String>>> {
     let projects = [InteractiveUpdateProject { manifest, importer_id: importer_id.to_string() }];
@@ -195,7 +195,7 @@ pub(crate) async fn select_packages_for_projects<Reporter: self::Reporter>(
     selection: &InstallFamilySelection,
     lockfile: Option<&Lockfile>,
     config: &Config,
-    http_client: &ThrottledClient,
+    http_client: &Arc<ThrottledClient>,
     options: InteractiveUpdateOptions<'_>,
 ) -> miette::Result<Option<Vec<String>>> {
     let projects = selection
@@ -250,7 +250,7 @@ async fn collect_choices(
     projects: &[InteractiveUpdateProject<'_>],
     lockfile: Option<&Lockfile>,
     config: &Config,
-    http_client: &ThrottledClient,
+    http_client: &Arc<ThrottledClient>,
     latest: bool,
     include_direct: &[DependencyGroup],
 ) -> miette::Result<Vec<OutdatedPackage>> {
@@ -261,14 +261,12 @@ async fn collect_choices(
         match_names: None,
         include_deprecated: false,
     };
-    let run = OutdatedRun::new(config)?;
+    let run = OutdatedRun::new(config, Arc::clone(http_client))?;
     let choices = futures_util::future::join_all(projects.iter().map(|project| {
         collect_outdated_for_importer_in_run(
             project.manifest,
             lockfile,
             &project.importer_id,
-            config,
-            http_client,
             &query,
             &run,
         )

--- a/pnpm/crates/cli/src/cli_args/update_interactive/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive/tests.rs
@@ -12,6 +12,53 @@ const TEST_INTEGRITY: &str = "sha512-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 const RELEASE_AGE_METADATA_REQUESTS: usize = 2;
 
 #[tokio::test]
+async fn interactive_choices_respect_minimum_release_age() {
+    let temp = tempfile::tempdir().expect("create temporary workspace");
+    let manifest = manifest_with_dependency(temp.path(), "packages/a", "foo");
+    let lockfile: Lockfile = serde_saphyr::from_str(
+        r"
+lockfileVersion: '9.0'
+importers:
+  packages/a:
+    dependencies:
+      foo:
+        specifier: ^1.0.0
+        version: 1.0.0
+",
+    )
+    .expect("parse workspace lockfile");
+    let mut server = mockito::Server::new_async().await;
+    let registry = format!("{}/", server.url());
+    let foo_mock = server
+        .mock("GET", "/foo")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(package_body_with_publish_times("foo", &registry))
+        .create_async()
+        .await;
+    let mut config = Config::new();
+    config.registry = registry;
+    config.minimum_release_age = Some(60);
+    let projects =
+        [InteractiveUpdateProject { manifest: &manifest, importer_id: "packages/a".to_string() }];
+
+    let choices = collect_choices(
+        &projects,
+        Some(&lockfile),
+        &config,
+        &Arc::new(ThrottledClient::default()),
+        true,
+        &[DependencyGroup::Prod],
+    )
+    .await
+    .expect("collect interactive choices");
+
+    assert_eq!(choices.len(), 1);
+    assert_eq!(choices[0].target.to_string(), "1.0.1");
+    foo_mock.assert_async().await;
+}
+
+#[tokio::test]
 async fn collects_choices_from_each_selected_workspace_importer() {
     let temp = tempfile::tempdir().expect("create temporary workspace");
     let foo = manifest_with_dependency(temp.path(), "packages/a", "foo");
@@ -333,6 +380,25 @@ fn package_body(name: &str, registry: &str) -> String {
         },
     })
     .to_string()
+}
+
+fn package_body_with_publish_times(name: &str, registry: &str) -> String {
+    let mut body: serde_json::Value =
+        serde_json::from_str(&package_body(name, registry)).expect("parse package body");
+    body["versions"]["1.0.1"] = json!({
+        "name": name,
+        "version": "1.0.1",
+        "dist": {
+            "integrity": TEST_INTEGRITY,
+            "tarball": format!("{registry}{name}/-/{name}-1.0.1.tgz"),
+        },
+    });
+    body["time"] = json!({
+        "1.0.0": "2020-01-01T00:00:00.000Z",
+        "1.0.1": "2020-02-01T00:00:00.000Z",
+        "1.1.0": "2999-01-01T00:00:00.000Z",
+    });
+    body.to_string()
 }
 
 mod selection {

--- a/pnpm/crates/cli/src/cli_args/update_interactive/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive/tests.rs
@@ -4,8 +4,12 @@ use pnpm_lockfile::Lockfile;
 use pnpm_network::ThrottledClient;
 use pnpm_package_manifest::{DependencyGroup, PackageManifest};
 use serde_json::json;
+use std::sync::Arc;
 
 const TEST_INTEGRITY: &str = "sha512-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa==";
+/// The default release-age policy fetches abbreviated metadata, then upgrades
+/// it to full metadata when this test fixture omits publish times.
+const RELEASE_AGE_METADATA_REQUESTS: usize = 2;
 
 #[tokio::test]
 async fn collects_choices_from_each_selected_workspace_importer() {
@@ -36,7 +40,7 @@ importers:
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(package_body("foo", &registry))
-        .expect(1)
+        .expect(RELEASE_AGE_METADATA_REQUESTS)
         .create_async()
         .await;
     let bar_mock = server
@@ -44,7 +48,7 @@ importers:
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(package_body("bar", &registry))
-        .expect(1)
+        .expect(RELEASE_AGE_METADATA_REQUESTS)
         .create_async()
         .await;
     let mut config = Config::new();
@@ -58,7 +62,7 @@ importers:
         &projects,
         Some(&lockfile),
         &config,
-        &ThrottledClient::default(),
+        &Arc::new(ThrottledClient::default()),
         false,
         &[DependencyGroup::Prod],
     )
@@ -109,7 +113,7 @@ importers:
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(package_body("foo", &registry))
-        .expect(1)
+        .expect(RELEASE_AGE_METADATA_REQUESTS)
         .create_async()
         .await;
     let mut config = Config::new();
@@ -123,7 +127,7 @@ importers:
         &projects,
         Some(&lockfile),
         &config,
-        &ThrottledClient::default(),
+        &Arc::new(ThrottledClient::default()),
         false,
         &[DependencyGroup::Prod],
     )
@@ -169,7 +173,7 @@ importers:
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(package_body("foo", &registry))
-        .expect(1)
+        .expect(RELEASE_AGE_METADATA_REQUESTS)
         .create_async()
         .await;
     let mut config = Config::new();
@@ -183,7 +187,7 @@ importers:
         &projects,
         Some(&lockfile),
         &config,
-        &ThrottledClient::default(),
+        &Arc::new(ThrottledClient::default()),
         false,
         &[DependencyGroup::Prod],
     )
@@ -232,7 +236,7 @@ importers:
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(package_body("foo", &registry))
-            .expect(1)
+            .expect(RELEASE_AGE_METADATA_REQUESTS)
             .create_async()
             .await;
         let mut config = Config::new();
@@ -246,7 +250,7 @@ importers:
             &projects,
             Some(&lockfile),
             &config,
-            &ThrottledClient::default(),
+            &Arc::new(ThrottledClient::default()),
             false,
             &[DependencyGroup::Prod],
         )

--- a/pnpm/crates/cli/tests/suite/outdated.rs
+++ b/pnpm/crates/cli/tests/suite/outdated.rs
@@ -1,4 +1,7 @@
-use crate::_utils::append_workspace_yaml_key;
+use crate::_utils::{
+    append_workspace_yaml_key, bravo_dep_mature_up_to_1_0_1_minimum_release_age,
+    set_minimum_release_age,
+};
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pnpm_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
@@ -8,6 +11,7 @@ use tempfile::TempDir;
 const DEP: &str = "@pnpm.e2e/dep-of-pkg-with-1-dep";
 const FOO: &str = "@pnpm.e2e/foo";
 const DEPRECATED: &str = "@pnpm.e2e/deprecated";
+const BRAVO_DEP: &str = "@pnpm.e2e/bravo-dep";
 
 fn setup() -> (TempDir, std::path::PathBuf, AddMockedRegistry) {
     let CommandTempCwd { root, workspace, npmrc_info, .. } =
@@ -144,6 +148,24 @@ fn outdated_up_to_date_exits_zero() {
     assert_eq!(output.status.code(), Some(0), "up-to-date deps should exit 0");
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(!stdout.contains(DEP), "no outdated dep should be reported: {stdout}");
+
+    drop((root, anchor));
+}
+
+/// Covers <https://github.com/pnpm/pnpm/issues/14004>: versions blocked by
+/// `minimumReleaseAge` must not be offered by `outdated` or interactive update.
+#[test]
+fn outdated_respects_minimum_release_age() {
+    let (root, workspace, anchor) = setup();
+
+    write_manifest(&workspace, &format!(r#"{{ "{BRAVO_DEP}": "1.0.1" }}"#));
+    set_minimum_release_age(&workspace, bravo_dep_mature_up_to_1_0_1_minimum_release_age());
+    pacquet(&workspace, ["install"]).assert().success();
+
+    let output = pacquet(&workspace, ["outdated"]).output().expect("run pacquet outdated");
+    assert_eq!(output.status.code(), Some(0), "immature releases should not be offered");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.contains(BRAVO_DEP), "report should omit immature releases: {stdout}");
 
     drop((root, anchor));
 }

--- a/pnpm/crates/cli/tests/suite/outdated.rs
+++ b/pnpm/crates/cli/tests/suite/outdated.rs
@@ -152,16 +152,25 @@ fn outdated_up_to_date_exits_zero() {
     drop((root, anchor));
 }
 
-/// Covers <https://github.com/pnpm/pnpm/issues/14004>: versions blocked by
-/// `minimumReleaseAge` must not be offered by `outdated` or interactive update.
+/// Covers <https://github.com/pnpm/pnpm/issues/14004>: `outdated` must offer
+/// mature releases without offering newer versions blocked by `minimumReleaseAge`.
 #[test]
 fn outdated_respects_minimum_release_age() {
     let (root, workspace, anchor) = setup();
 
-    write_manifest(&workspace, &format!(r#"{{ "{BRAVO_DEP}": "1.0.1" }}"#));
+    write_manifest(&workspace, &format!(r#"{{ "{BRAVO_DEP}": "1.0.0" }}"#));
     set_minimum_release_age(&workspace, bravo_dep_mature_up_to_1_0_1_minimum_release_age());
     pacquet(&workspace, ["install"]).assert().success();
 
+    let output = pacquet(&workspace, ["outdated"]).output().expect("run pacquet outdated");
+    assert_eq!(output.status.code(), Some(1), "the mature release should be offered");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains(BRAVO_DEP), "report should include the package: {stdout}");
+    assert!(stdout.contains("1.0.1"), "report should offer the mature release: {stdout}");
+    assert!(!stdout.contains("1.1.0"), "report should omit the immature release: {stdout}");
+
+    write_manifest(&workspace, &format!(r#"{{ "{BRAVO_DEP}": "1.0.1" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
     let output = pacquet(&workspace, ["outdated"]).output().expect("run pacquet outdated");
     assert_eq!(output.status.code(), Some(0), "immature releases should not be offered");
     let stdout = String::from_utf8_lossy(&output.stdout);

--- a/pnpm/crates/package-manager/src/lib.rs
+++ b/pnpm/crates/package-manager/src/lib.rs
@@ -60,6 +60,7 @@ pub use pnpm_patching::{
 pub use prefetching_resolver::*;
 pub use remove::*;
 pub use resolution_observer::*;
+pub use resolution_policy::{PickPolicy, create_configured_npm_resolver};
 pub use resolve_latest::ResolveLatestError;
 pub use tarball_prefetch::*;
 pub use update::*;

--- a/pnpm/crates/package-manager/src/resolution_policy.rs
+++ b/pnpm/crates/package-manager/src/resolution_policy.rs
@@ -1,8 +1,6 @@
 //! The config-derived version-pick policy shared by the install resolver
-//! chain and the `pacquet add`/`update` pre-resolutions, so both pick
-//! byte-identical versions (an `add foo@^1` pins the manifest to the same
-//! version the install locks, `minimumReleaseAge` and `resolutionMode`
-//! included).
+//! chain and command-level registry lookups, so they pick byte-identical
+//! versions (`minimumReleaseAge` and `resolutionMode` included).
 
 use crate::retry_config::retry_opts_from_config;
 use chrono::{DateTime, Utc};
@@ -12,13 +10,16 @@ use pnpm_config::{
 };
 use pnpm_network::ThrottledClient;
 use pnpm_resolving_npm_resolver::{
-    InMemoryPackageMetaCache, PackumentFetchLocker, PickPackageContext,
+    InMemoryPackageMetaCache, MergeNamedRegistriesError, NpmResolver, PackumentFetchLocker,
+    PickPackageContext, merge_named_registries, shared_packument_fetch_locker,
+    shared_picked_manifest_cache,
 };
+use std::sync::Arc;
 
-/// The version-pick knobs derived purely from [`Config`]. Computed once and
-/// fed to both the resolver chain and the `add` pre-resolution so a single
-/// definition can't drift between them.
-pub(crate) struct PickPolicy {
+/// The version-pick knobs derived purely from [`Config`]. Computed once per
+/// command so every lookup in that run shares the same cutoff and metadata
+/// policy.
+pub struct PickPolicy {
     /// `resolutionMode: time-based`.
     pub time_based: bool,
     /// `resolutionMode` picks the lowest satisfying direct version.
@@ -45,14 +46,10 @@ impl PickPolicy {
     /// `minimumReleaseAge` cutoff. Errors only when
     /// `minimumReleaseAgeExclude` contains an invalid rule.
     ///
-    /// The cutoff is anchored to "now" at the moment of the call. When
-    /// `minimumReleaseAge` is set (off by default) and two derivations run
-    /// at slightly different instants — e.g. `pacquet add`'s explicit-spec
-    /// pre-resolution and its follow-up install — a version published in
-    /// that sub-second window could in theory flip eligibility. To pin both
-    /// to the same instant, derive once via [`Self::from_config_at`] and
-    /// share the `now`.
-    pub(crate) fn from_config(config: &Config) -> Result<Self, VersionPolicyError> {
+    /// The cutoff is anchored to "now" at the moment of the call. Share the
+    /// returned policy across an operation so every lookup uses the same
+    /// cutoff instant.
+    pub fn from_config(config: &Config) -> Result<Self, VersionPolicyError> {
         Self::from_config_at(config, chrono::Utc::now())
     }
 
@@ -106,6 +103,34 @@ impl PickPolicy {
             published_by_exclude,
         })
     }
+}
+
+/// Construct the npm resolver used by config-driven, command-level version
+/// lookups with the same registry, cache, and metadata settings as an install.
+pub fn create_configured_npm_resolver(
+    config: &Config,
+    http_client: Arc<ThrottledClient>,
+    policy: &PickPolicy,
+) -> Result<NpmResolver<InMemoryPackageMetaCache>, MergeNamedRegistriesError> {
+    let registries_by_prefix =
+        merge_named_registries(&config.registries_by_prefix.clone().into_iter().collect())?;
+    Ok(NpmResolver {
+        registries: config.resolved_registries().into_iter().collect(),
+        registries_by_prefix,
+        http_client,
+        auth_headers: Arc::clone(&config.auth_headers),
+        meta_cache: Arc::<InMemoryPackageMetaCache>::default(),
+        fetch_locker: shared_packument_fetch_locker(),
+        picked_manifest_cache: shared_picked_manifest_cache(),
+        cache_dir: Some(config.cache_dir.clone()),
+        offline: config.offline,
+        prefer_offline: config.prefer_offline,
+        ignore_missing_time_field: config.minimum_release_age_ignore_missing_time,
+        full_metadata: policy.full_metadata,
+        needs_full_metadata_for: Some(Arc::clone(&policy.needs_full_metadata_for)),
+        filter_metadata: config.requires_filtered_full_metadata(),
+        retry_opts: retry_opts_from_config(config),
+    })
 }
 
 /// Build the [`PickPackageContext`] shared by every config-driven pick in a

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -9,7 +9,7 @@ use crate::{
     decide_catalog, emit_initial_package_manifest,
     manifest_spec_bumps::ManifestSpecBumps,
     package_manifest_prefix,
-    resolution_policy::PickPolicy,
+    resolution_policy::{PickPolicy, create_configured_npm_resolver},
     selected_project_indices,
 };
 use chrono::{DateTime, Utc};
@@ -38,10 +38,7 @@ use pnpm_reporter::{
 };
 use pnpm_resolving_default_resolver::DefaultResolver;
 use pnpm_resolving_deps_resolver::{UpdateDepth, UpdateTargets, VersionLine, real_package_name_of};
-use pnpm_resolving_npm_resolver::{
-    DeclaredSpecifiers, InMemoryPackageMetaCache, NpmResolver, calc_specifier_for_workspace_dep,
-    merge_named_registries, shared_packument_fetch_locker, shared_picked_manifest_cache,
-};
+use pnpm_resolving_npm_resolver::{DeclaredSpecifiers, calc_specifier_for_workspace_dep};
 use pnpm_resolving_resolver_base::{
     PreferredVersions, ResolveOptions, Resolver, UpdateBehavior, VersionSelectorType,
     WantedDependency, WorkspacePackages, WorkspacePackagesByVersion,
@@ -1677,26 +1674,10 @@ fn ensure_latest_resolver_chain<'chain>(
         let policy =
             PickPolicy::from_config_with_extra_excludes(ctx.config, extra_excludes.as_deref())
                 .map_err(UpdateError::MinimumReleaseAgeExclude)?;
-        let registries_by_prefix =
-            merge_named_registries(&ctx.config.registries_by_prefix.clone().into_iter().collect())
-                .map_err(UpdateError::InvalidNamedRegistry)?;
-        let npm_resolver: Arc<dyn Resolver> = Arc::new(NpmResolver {
-            registries: ctx.config.resolved_registries().into_iter().collect(),
-            registries_by_prefix,
-            http_client: Arc::clone(ctx.http_client_arc),
-            auth_headers: Arc::clone(&ctx.config.auth_headers),
-            meta_cache: Arc::<InMemoryPackageMetaCache>::default(),
-            fetch_locker: shared_packument_fetch_locker(),
-            picked_manifest_cache: shared_picked_manifest_cache(),
-            cache_dir: Some(ctx.config.cache_dir.clone()),
-            offline: ctx.config.offline,
-            prefer_offline: ctx.config.prefer_offline,
-            ignore_missing_time_field: ctx.config.minimum_release_age_ignore_missing_time,
-            full_metadata: policy.full_metadata,
-            needs_full_metadata_for: Some(Arc::clone(&policy.needs_full_metadata_for)),
-            filter_metadata: ctx.config.requires_filtered_full_metadata(),
-            retry_opts: crate::retry_config::retry_opts_from_config(ctx.config),
-        });
+        let npm_resolver: Arc<dyn Resolver> = Arc::new(
+            create_configured_npm_resolver(ctx.config, Arc::clone(ctx.http_client_arc), &policy)
+                .map_err(UpdateError::InvalidNamedRegistry)?,
+        );
         let mut node_resolver = NodeResolver::new(Arc::clone(ctx.http_client_arc));
         node_resolver.node_download_mirrors.clone_from(&ctx.config.node_download_mirrors);
         node_resolver.offline = ctx.config.offline;


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#14004.

Pacquet's outdated and interactive-update collector read the registry's raw `latest` dist-tag even when `minimumReleaseAge` blocked that version. This made `pnpm update --interactive --latest` offer updates that normal resolution then rejected, so selected updates made no manifest or lockfile changes.

Route outdated and interactive-update lookups through pacquet's config-aware npm resolver so they only offer actionable, mature versions. The TypeScript CLI already applies this policy, so no TypeScript change is needed.

## Squash Commit Body

```text
Pacquet's outdated collector bypassed the version-pick policy and read the registry's raw latest version. With the v12 default minimumReleaseAge, interactive update could therefore offer same-day releases that the update resolver would reject, leaving the manifest and lockfile unchanged.

Reuse the configured npm resolver for outdated and interactive-update lookups, and share its construction with update's latest-version path so registry and metadata policy settings cannot drift.

Fixes pnpm/pnpm#14004.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Codex, gpt-5.6-sol).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790031591&installation_model_id=426870&pr_number=14087&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14087&signature=37808ea37b62894afa479130e2a4ceb75ec596bf6b9ce3ea359e5af5d32fab3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `pnpm outdated` now excludes package versions that have not reached the configured `minimumReleaseAge`.
  * Interactive updates no longer offer releases blocked by the minimum release age setting.
  * Outdated package information now follows configured registry and resolution rules for more consistent results.
* **Improvements**
  * Targeted updates now preserve requested version ranges, including aliased packages.
  * Update checks provide more reliable results across projects and configured package sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->