### PR TITLE
[pacquet] feat(config): read ignorePnpmfile from configuration and the environment

### DIFF
--- a/.changeset/ignore-pnpmfile-setting.md
+++ b/.changeset/ignore-pnpmfile-setting.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`ignorePnpmfile` can now be set in configuration and read from `PNPM_CONFIG_IGNORE_PNPMFILE`, not only passed as `--ignore-pnpmfile`. A project or a machine can turn pnpmfile hooks off once instead of adding the flag to every command; the flag still applies on top.

--- a/.changeset/ignore-pnpmfile-setting.md
+++ b/.changeset/ignore-pnpmfile-setting.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`ignorePnpmfile` can now be set in configuration and read from `PNPM_CONFIG_IGNORE_PNPMFILE`, not only passed as `--ignore-pnpmfile`. A project or a machine can turn pnpmfile hooks off once instead of adding the flag to every command; the flag still applies on top.
+`ignorePnpmfile` can now be set in `pnpm-workspace.yaml` and read from `PNPM_CONFIG_IGNORE_PNPMFILE`, not only passed as `--ignore-pnpmfile`, so a project or a machine can turn pnpmfile hooks off once instead of adding the flag to every command. The flag still applies on top. As in pnpm, the global `config.yaml` cannot set it: a pnpmfile belongs to the project that ships it.

--- a/pnpm/crates/cli/tests/suite/install.rs
+++ b/pnpm/crates/cli/tests/suite/install.rs
@@ -2183,10 +2183,9 @@ fn an_unmigrated_package_json_pnpm_field_is_not_reported() {
     drop(root);
 }
 
-/// `ignorePnpmfile` is a setting, not only a flag. pnpm lists
-/// `ignore-pnpmfile` among the keys a config file may carry and exposes it
-/// through `PNPM_CONFIG_IGNORE_PNPMFILE`, so a project or a machine can turn
-/// hooks off without every command growing the flag.
+/// `ignorePnpmfile` is a setting, not only a flag: pnpm reads it from
+/// `pnpm-workspace.yaml` and from `PNPM_CONFIG_IGNORE_PNPMFILE`, so a project
+/// or a machine can turn hooks off without every command growing the flag.
 #[test]
 fn ignore_pnpmfile_is_settable_without_the_flag() {
     for source in ["pnpm-workspace.yaml", "PNPM_CONFIG_IGNORE_PNPMFILE"] {
@@ -2203,10 +2202,7 @@ fn ignore_pnpmfile_is_settable_without_the_flag() {
 
         let mut command = pacquet_in(&workspace);
         if source == "pnpm-workspace.yaml" {
-            let path = workspace.join("pnpm-workspace.yaml");
-            let mut yaml = fs::read_to_string(&path).expect("read pnpm-workspace.yaml");
-            yaml.push_str("ignorePnpmfile: true\n");
-            fs::write(&path, yaml).expect("write pnpm-workspace.yaml");
+            append_workspace_setting(&workspace, "ignorePnpmfile: true");
         } else {
             command = command.with_env("PNPM_CONFIG_IGNORE_PNPMFILE", "true");
         }
@@ -2217,15 +2213,98 @@ fn ignore_pnpmfile_is_settable_without_the_flag() {
         // above cannot pass on a fixture whose hook never worked.
         fs::remove_file(workspace.join("pnpm-lock.yaml")).expect("remove pnpm-lock.yaml");
         if source == "pnpm-workspace.yaml" {
-            let path = workspace.join("pnpm-workspace.yaml");
-            let yaml = fs::read_to_string(&path).expect("read pnpm-workspace.yaml");
-            fs::write(&path, yaml.replace("ignorePnpmfile: true\n", "")).expect("rewrite yaml");
+            remove_workspace_setting(&workspace, "ignorePnpmfile");
         }
         pacquet_in(&workspace).with_args(["install", "--lockfile-only"]).assert().success();
         assert!(read_package_hook_applied(&workspace), "{source}: the hook otherwise applies");
 
         drop((root, mock_instance));
     }
+}
+
+/// The global `config.yaml` is not one of the places pnpm reads it from, and it
+/// should not be: a pnpmfile belongs to the project that ships it, so honoring
+/// this globally would drop a repository's hooks on one machine and resolve a
+/// different graph there than everywhere else.
+#[test]
+fn ignore_pnpmfile_in_the_global_config_does_not_disable_hooks() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_read_package_pnpmfile(&workspace);
+    fs::write(
+        workspace.join("package.json"),
+        r#"{"dependencies":{"@pnpm.e2e/pkg-with-1-dep":"100.0.0"}}"#,
+    )
+    .expect("write package.json");
+    let config_home = workspace.join(".config");
+    fs::create_dir_all(config_home.join("pnpm")).expect("create global config dir");
+    fs::write(config_home.join("pnpm/config.yaml"), "ignorePnpmfile: true\n")
+        .expect("write global config");
+
+    pacquet_in(&workspace)
+        .with_env("XDG_CONFIG_HOME", &config_home)
+        .with_args(["install", "--lockfile-only"])
+        .assert()
+        .success();
+    assert!(read_package_hook_applied(&workspace), "the hook still runs");
+
+    drop((root, mock_instance));
+}
+
+/// The flag ORs on top, so it still turns hooks off for a project whose
+/// configuration leaves them on.
+#[test]
+fn the_ignore_pnpmfile_flag_wins_over_a_configured_false() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_read_package_pnpmfile(&workspace);
+    fs::write(
+        workspace.join("package.json"),
+        r#"{"dependencies":{"@pnpm.e2e/pkg-with-1-dep":"100.0.0"}}"#,
+    )
+    .expect("write package.json");
+    append_workspace_setting(&workspace, "ignorePnpmfile: false");
+
+    pacquet_in(&workspace)
+        .with_args(["install", "--lockfile-only", "--ignore-pnpmfile"])
+        .assert()
+        .success();
+    assert!(!read_package_hook_applied(&workspace), "the flag turns the hook off anyway");
+
+    drop((root, mock_instance));
+}
+
+/// Drop every line of the fixture's `pnpm-workspace.yaml` that sets `key`,
+/// leaving the rest of the file as it was.
+fn remove_workspace_setting(workspace: &Path, key: &str) {
+    let path = workspace.join("pnpm-workspace.yaml");
+    let yaml = fs::read_to_string(&path).expect("read pnpm-workspace.yaml");
+    let prefix = format!("{key}:");
+    let kept: String = yaml.lines().filter(|line| !line.trim_start().starts_with(&prefix)).fold(
+        String::new(),
+        |mut kept, line| {
+            let _ = writeln!(kept, "{line}");
+            kept
+        },
+    );
+    fs::write(&path, kept).expect("write pnpm-workspace.yaml");
+}
+
+/// Append one setting to the fixture's `pnpm-workspace.yaml`, starting a line
+/// of its own whether or not the file it is joining ends in a newline.
+fn append_workspace_setting(workspace: &Path, setting: &str) {
+    let path = workspace.join("pnpm-workspace.yaml");
+    let mut yaml = fs::read_to_string(&path).expect("read pnpm-workspace.yaml");
+    if !yaml.is_empty() && !yaml.ends_with('\n') {
+        yaml.push('\n');
+    }
+    yaml.push_str(setting);
+    yaml.push('\n');
+    fs::write(&path, yaml).expect("write pnpm-workspace.yaml");
 }
 
 /// `--ignore-pnpmfile` disables the hooks the workspace pnpmfile

--- a/pnpm/crates/cli/tests/suite/install.rs
+++ b/pnpm/crates/cli/tests/suite/install.rs
@@ -2183,6 +2183,51 @@ fn an_unmigrated_package_json_pnpm_field_is_not_reported() {
     drop(root);
 }
 
+/// `ignorePnpmfile` is a setting, not only a flag. pnpm lists
+/// `ignore-pnpmfile` among the keys a config file may carry and exposes it
+/// through `PNPM_CONFIG_IGNORE_PNPMFILE`, so a project or a machine can turn
+/// hooks off without every command growing the flag.
+#[test]
+fn ignore_pnpmfile_is_settable_without_the_flag() {
+    for source in ["pnpm-workspace.yaml", "PNPM_CONFIG_IGNORE_PNPMFILE"] {
+        let CommandTempCwd { root, workspace, npmrc_info, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+        write_read_package_pnpmfile(&workspace);
+        fs::write(
+            workspace.join("package.json"),
+            r#"{"dependencies":{"@pnpm.e2e/pkg-with-1-dep":"100.0.0"}}"#,
+        )
+        .expect("write package.json");
+
+        let mut command = pacquet_in(&workspace);
+        if source == "pnpm-workspace.yaml" {
+            let path = workspace.join("pnpm-workspace.yaml");
+            let mut yaml = fs::read_to_string(&path).expect("read pnpm-workspace.yaml");
+            yaml.push_str("ignorePnpmfile: true\n");
+            fs::write(&path, yaml).expect("write pnpm-workspace.yaml");
+        } else {
+            command = command.with_env("PNPM_CONFIG_IGNORE_PNPMFILE", "true");
+        }
+        command.with_args(["install", "--lockfile-only"]).assert().success();
+        assert!(!read_package_hook_applied(&workspace), "{source}: the pnpmfile's hook is skipped");
+
+        // Resolve the same project with the setting absent, so the assertion
+        // above cannot pass on a fixture whose hook never worked.
+        fs::remove_file(workspace.join("pnpm-lock.yaml")).expect("remove pnpm-lock.yaml");
+        if source == "pnpm-workspace.yaml" {
+            let path = workspace.join("pnpm-workspace.yaml");
+            let yaml = fs::read_to_string(&path).expect("read pnpm-workspace.yaml");
+            fs::write(&path, yaml.replace("ignorePnpmfile: true\n", "")).expect("rewrite yaml");
+        }
+        pacquet_in(&workspace).with_args(["install", "--lockfile-only"]).assert().success();
+        assert!(read_package_hook_applied(&workspace), "{source}: the hook otherwise applies");
+
+        drop((root, mock_instance));
+    }
+}
+
 /// `--ignore-pnpmfile` disables the hooks the workspace pnpmfile
 /// exports, so an install that passes it resolves the manifest as
 /// written and drops what a `readPackage` hook injected.
@@ -2348,7 +2393,7 @@ fn a_global_pnpmfile_runs_for_a_project_without_one() {
 
 /// The global pnpmfile loads ahead of the project's, so `readPackage` reaches
 /// it first and the project's hook sees what it returned. Chaining is the whole
-/// point of the order pnpm fixes by pushing the global entry first, and nothing
+/// point of the order pnpm pins by pushing the global entry first, and nothing
 /// else in this file would notice if the two swapped.
 #[test]
 fn a_global_pnpmfile_runs_before_the_project_pnpmfile() {
@@ -2418,6 +2463,9 @@ fn a_global_pnpmfile_stays_out_of_the_pnpmfile_checksum() {
     .expect("write package.json");
 
     let install = || {
+        // Each measurement resolves from scratch. Reading back a lockfile an
+        // up-to-date check declined to rewrite would compare a value to itself.
+        drop(fs::remove_file(workspace.join("pnpm-lock.yaml")));
         pacquet_in(&workspace)
             .with_env("PNPM_CONFIG_GLOBAL_PNPMFILE", &global_pnpmfile)
             .with_args(["install", "--lockfile-only"])

--- a/pnpm/crates/config/src/env_overlay.rs
+++ b/pnpm/crates/config/src/env_overlay.rs
@@ -137,6 +137,7 @@ impl WorkspaceSettings {
         }
 
         json_field!(ci, "CI");
+        json_field!(ignore_pnpmfile, "IGNORE_PNPMFILE");
         json_field!(hoist, "HOIST");
         tri_array_field!(hoist_pattern, "HOIST_PATTERN");
         tri_array_field!(public_hoist_pattern, "PUBLIC_HOIST_PATTERN");

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -1725,14 +1725,13 @@ pub struct Config {
     /// when set, leaving `ignoredBuilds` empty. Default `false`.
     pub ignore_scripts: bool,
 
-    /// `--ignore-pnpmfile`. When `true`, no pnpmfile hooks run: neither
-    /// the workspace-root `.pnpmfile.{cjs,mjs}` nor the pnpmfiles of
-    /// config-dependency plugins are loaded, so `readPackage`,
-    /// `updateConfig`, `afterAllResolved`, custom resolvers and custom
-    /// fetchers are all skipped. A CLI-only boolean: pnpm excludes
-    /// `ignore-pnpmfile` from its config-file keys, so the yaml / env
-    /// overlay never populates it — the CLI layer sets it from the flag.
-    /// Default `false`.
+    /// `ignorePnpmfile` (`--ignore-pnpmfile`). When `true`, no pnpmfile hooks
+    /// run: neither the pnpmfiles the project configures or ships nor those of
+    /// config-dependency plugins are loaded, so `readPackage`, `updateConfig`,
+    /// `afterAllResolved`, custom resolvers and custom fetchers are all
+    /// skipped. Settable from configuration and the environment as well as the
+    /// flag, which ORs on top — pnpm carries `ignore-pnpmfile` in both its
+    /// config-file keys and its schema. Default `false`.
     pub ignore_pnpmfile: bool,
 
     /// `gitChecks` (`--no-git-checks`). When `true` (the default),

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -431,9 +431,11 @@ pub struct WorkspaceSettings {
     /// CLI flag ORs on top of this. Default `false`.
     pub ignore_scripts: Option<bool>,
 
-    /// `ignorePnpmfile`. When `true`, no pnpmfile hooks run. See
-    /// [`Config::ignore_pnpmfile`]. The `--ignore-pnpmfile` CLI flag ORs on
-    /// top of this. Default `false`.
+    /// `ignorePnpmfile` from `pnpm-workspace.yaml`. When `true`, no pnpmfile
+    /// hooks run. See [`Config::ignore_pnpmfile`]. The `--ignore-pnpmfile` CLI
+    /// flag ORs on top of this. Cleared by
+    /// [`Self::clear_workspace_only_fields`], so the global `config.yaml`
+    /// cannot set it. Default `false`.
     pub ignore_pnpmfile: Option<bool>,
 
     /// `gitChecks` from `pnpm-workspace.yaml`. When `false`, `pnpm publish`
@@ -1182,6 +1184,11 @@ impl WorkspaceSettings {
         self.versioning = None;
         self.packages = None;
         self.catalog = None;
+        // A pnpmfile belongs to the project that ships it, and pnpm reads
+        // `ignorePnpmfile` from `pnpm-workspace.yaml` and the environment but
+        // not from here. Honoring it globally would silently drop a
+        // repository's hooks on one machine and resolve a different graph.
+        self.ignore_pnpmfile = None;
         self.catalogs = None;
         self.only_built_dependencies = None;
         self.never_built_dependencies = None;

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -431,6 +431,11 @@ pub struct WorkspaceSettings {
     /// CLI flag ORs on top of this. Default `false`.
     pub ignore_scripts: Option<bool>,
 
+    /// `ignorePnpmfile`. When `true`, no pnpmfile hooks run. See
+    /// [`Config::ignore_pnpmfile`]. The `--ignore-pnpmfile` CLI flag ORs on
+    /// top of this. Default `false`.
+    pub ignore_pnpmfile: Option<bool>,
+
     /// `gitChecks` from `pnpm-workspace.yaml`. When `false`, `pnpm publish`
     /// skips its git working-tree checks. See [`Config::git_checks`]. The
     /// `--no-git-checks` CLI flag forces it off on top of this. Default
@@ -1653,6 +1658,9 @@ impl WorkspaceSettings {
         }
         if let Some(v) = self.ignore_scripts {
             config.ignore_scripts = v;
+        }
+        if let Some(v) = self.ignore_pnpmfile {
+            config.ignore_pnpmfile = v;
         }
         if let Some(v) = self.git_checks {
             config.git_checks = v;


### PR DESCRIPTION
## Summary

`ignorePnpmfile` was reachable only as `--ignore-pnpmfile`, so a project or a machine that wanted pnpmfile hooks off had to add the flag to every command. pnpm lists `ignore-pnpmfile` among the keys a config file may carry (`pnpmConfigFileKeys`) and exposes `PNPM_CONFIG_IGNORE_PNPMFILE` like every key in its schema. Both now work here, and the flag still ORs on top so it wins over a configured `false`.

The `Config::ignore_pnpmfile` doc comment claimed the opposite — that pnpm excludes the key from its config-file keys and only the CLI layer ever sets it — so it described a gap in this implementation as though it were the contract. Corrected.

Closes the last open piece of the pnpmfile item in pnpm/pnpm#12042. TypeScript already has all of this, so there is nothing to mirror there.

Also folds in two review notes that arrived on pnpm/pnpm#14085 shortly after it merged, both in the same test file.

## Squash Commit Body

```text
`--ignore-pnpmfile` was the only way to turn pnpmfile hooks off. pnpm
lists `ignore-pnpmfile` among the keys a config file may carry and
exposes `PNPM_CONFIG_IGNORE_PNPMFILE` like every key in its schema; both
now work here, with the flag still ORing on top.

The doc comment claimed the opposite — that pnpm excludes the key from
its config-file keys and only the CLI layer sets it. `pnpmConfigFileKeys`
carries it, so the comment described a limitation of this implementation
as though it were the contract.

Two review notes from pnpm/pnpm#14085 ride along: each checksum
measurement now resolves from scratch, since reading back a lockfile an
up-to-date check declined to rewrite would compare a value to itself, and
a comment saying the order pnpm "fixes" now says "pins".

Part of pnpm/pnpm#12042.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14088"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790032938&installation_model_id=426870&pr_number=14088&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14088&signature=afeb200f0cd8418e525a31a5bff961fee8fd849570e6fee3a0d963647b4c5588"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring `ignorePnpmfile` in `pnpm-workspace.yaml`.
  - Added support for the `PNPM_CONFIG_IGNORE_PNPMFILE` environment variable.
  - Existing `--ignore-pnpmfile` command-line support remains available and can override configuration.

- **Bug Fixes**
  - Invalid or empty environment variable values are safely ignored.
  - Global configuration no longer controls this workspace-only setting.
  - Configuration now consistently disables pnpmfile hooks when enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->