### PR TITLE
docs(package-manager): document configured resolver

### DIFF
--- a/pnpm/crates/package-manager/src/resolution_policy.rs
+++ b/pnpm/crates/package-manager/src/resolution_policy.rs
@@ -105,8 +105,15 @@ impl PickPolicy {
     }
 }
 
-/// Construct the npm resolver used by config-driven, command-level version
-/// lookups with the same registry, cache, and metadata settings as an install.
+/// Constructs the npm resolver used by config-driven, command-level version
+/// lookups with the same registry, authentication, cache, network, and metadata
+/// settings as an install. The supplied [`PickPolicy`] keeps version selection
+/// aligned with the install operation that derived it.
+///
+/// # Errors
+///
+/// Returns an error when the configured named-registry prefixes cannot be
+/// merged into an unambiguous resolver map.
 pub fn create_configured_npm_resolver(
     config: &Config,
     http_client: Arc<ThrottledClient>,


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Follow-up to pnpm/pnpm#14087. Documents the configuration, resolution-policy,
and named-registry error guarantees of the newly public configured npm resolver
factory.

This is a Rust-only API documentation change. TypeScript parity and a changeset
are not applicable because runtime behavior and published user-facing
documentation are unchanged.

## Squash Commit Body

```text
Document which install settings and version-selection policy the configured npm
resolver factory preserves, together with its named-registry error contract.

This follows up on review feedback from pnpm/pnpm#14087.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Updated the documentation if needed.

---
Written by an agent (Codex, gpt-5.6-sol).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790033162&installation_model_id=426870&pr_number=14089&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14089&signature=566e19aedd07875b46e405744926328f7aa961fa05ea448cd0f05d594c82af9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified resolver configuration behavior, including shared registry, authentication, cache, network, and metadata settings.
  * Documented alignment with install version selection and explained the conditions that can cause merge errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->