### PR TITLE
fix(pacquet): complete pnp loader integration

### DIFF
--- a/.changeset/pacquet-pnp-execution.md
+++ b/.changeset/pacquet-pnp-execution.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed Plug'n'Play projects to preload `.pnp.cjs` for dependency and project lifecycle scripts, `pnpm run`, and `pnpm exec`. The generated loader now also exposes the public Yarn PnP API surface.

--- a/pnpm/crates/cli/src/cli_args/exec.rs
+++ b/pnpm/crates/cli/src/cli_args/exec.rs
@@ -6,7 +6,10 @@ use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pnpm_config::Config;
 use pnpm_executor::{push_script_arg, select_shell};
-use pnpm_package_manager::{make_node_package_map_option, package_map_path_for_execution};
+use pnpm_package_manager::{
+    make_node_package_map_option, make_node_require_option, package_map_path_for_execution,
+    pnp_path_for_execution,
+};
 use pnpm_workspace::safe_read_project_manifest_only;
 use std::{
     path::Path,
@@ -187,6 +190,9 @@ pub(super) fn spawn_in_dir(
             config.extra_env.get("NODE_OPTIONS").map(String::as_str),
         )
     });
+    if let Some(pnp_path) = pnp_path_for_execution(config, dir) {
+        node_options = Some(make_node_require_option(&pnp_path, node_options.as_deref()));
+    }
     if let Some(package_map_path) = package_map_path_for_execution(config, dir) {
         node_options =
             Some(make_node_package_map_option(&package_map_path, node_options.as_deref()));

--- a/pnpm/crates/cli/src/cli_args/exec.rs
+++ b/pnpm/crates/cli/src/cli_args/exec.rs
@@ -184,12 +184,7 @@ pub(super) fn spawn_in_dir(
     if let Some(name) = read_package_name(dir) {
         cmd.env("PNPM_PACKAGE_NAME", name);
     }
-    let mut node_options = config.node_options.as_deref().map(|node_options| {
-        pnpm_config::esm_node_path_loader::keep_esm_node_path_loader_option(
-            node_options,
-            config.extra_env.get("NODE_OPTIONS").map(String::as_str),
-        )
-    });
+    let mut node_options = configured_node_options(config);
     if let Some(pnp_path) = pnp_path_for_execution(config, dir) {
         node_options = Some(make_node_require_option(&pnp_path, node_options.as_deref()));
     }
@@ -206,6 +201,18 @@ pub(super) fn spawn_in_dir(
     cmd.status().map_err(|source| ExecError::Spawn { command: command[0].clone(), source })
 }
 
+fn configured_node_options(config: &Config) -> Option<String> {
+    match config.node_options.as_deref() {
+        Some(node_options) => {
+            Some(pnpm_config::esm_node_path_loader::keep_esm_node_path_loader_option(
+                node_options,
+                config.extra_env.get("NODE_OPTIONS").map(String::as_str),
+            ))
+        }
+        None => config.extra_env.get("NODE_OPTIONS").cloned(),
+    }
+}
+
 /// Read the `name` field of the project's package manifest, if any.
 ///
 /// Used only to stamp `PNPM_PACKAGE_NAME`; a missing or nameless manifest
@@ -213,3 +220,6 @@ pub(super) fn spawn_in_dir(
 fn read_package_name(dir: &Path) -> Option<String> {
     safe_read_project_manifest_only(dir).ok()??.value().get("name")?.as_str().map(str::to_string)
 }
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/cli_args/exec/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/exec/tests.rs
@@ -1,0 +1,10 @@
+use super::configured_node_options;
+use pnpm_config::Config;
+
+#[test]
+fn configured_node_options_preserves_extra_env_without_a_node_options_setting() {
+    let mut config = Config::default();
+    config.extra_env.insert("NODE_OPTIONS".to_string(), "--trace-warnings".to_string());
+
+    assert_eq!(configured_node_options(&config).as_deref(), Some("--trace-warnings"));
+}

--- a/pnpm/crates/cli/src/cli_args/run.rs
+++ b/pnpm/crates/cli/src/cli_args/run.rs
@@ -5,7 +5,10 @@ use miette::Diagnostic;
 use pnpm_config::Config;
 use pnpm_executor::{RunScript, ScriptsPrependNodePath, run_script};
 use pnpm_injected_deps_syncer::{SyncInjectedDeps, sync_injected_deps};
-use pnpm_package_manager::{make_node_package_map_option, package_map_path_for_execution};
+use pnpm_package_manager::{
+    make_node_package_map_option, make_node_require_option, package_map_path_for_execution,
+    pnp_path_for_execution,
+};
 use pnpm_package_manifest::PackageManifest;
 use pnpm_reporter::LogEvent;
 use pnpm_workspace::{ReadProjectManifestOnlyError, read_project_manifest_only};
@@ -196,6 +199,13 @@ impl RunArgs {
         }
 
         let mut extra_env = config.extra_env_with_node_options();
+        if let Some(pnp_path) = pnp_path_for_execution(config, dir) {
+            let node_options = extra_env.get("NODE_OPTIONS").map(String::as_str);
+            extra_env.insert(
+                "NODE_OPTIONS".to_string(),
+                make_node_require_option(&pnp_path, node_options),
+            );
+        }
         if let Some(package_map_path) = package_map_path_for_execution(config, dir) {
             let node_options = extra_env.get("NODE_OPTIONS").map(String::as_str);
             extra_env.insert(

--- a/pnpm/crates/cli/src/cli_args/run/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/run/recursive.rs
@@ -20,7 +20,10 @@ use derive_more::{Display, Error};
 use indexmap::IndexMap;
 use miette::{Diagnostic, IntoDiagnostic, WrapErr};
 use pnpm_config::Config;
-use pnpm_package_manager::{make_node_package_map_option, package_map_path_for_execution};
+use pnpm_package_manager::{
+    make_node_package_map_option, make_node_require_option, package_map_path_for_execution,
+    pnp_path_for_execution,
+};
 use pnpm_reporter::{LogEvent, LogLevel, ScopeLog};
 use pnpm_workspace::GraphPkg;
 use pnpm_workspace_projects_graph::ProjectGraph;
@@ -154,6 +157,11 @@ pub fn run_recursive(
     // vary per project once; the per-project `RunContext` reuses them.
     let init_cwd = env::current_dir().unwrap_or_else(|_| dir.to_path_buf());
     let mut extra_env: HashMap<String, String> = config.extra_env_with_node_options();
+    if let Some(pnp_path) = pnp_path_for_execution(config, dir) {
+        let node_options = extra_env.get("NODE_OPTIONS").map(String::as_str);
+        extra_env
+            .insert("NODE_OPTIONS".to_string(), make_node_require_option(&pnp_path, node_options));
+    }
     if let Some(package_map_path) = package_map_path_for_execution(config, dir) {
         let node_options = extra_env.get("NODE_OPTIONS").map(String::as_str);
         extra_env.insert(

--- a/pnpm/crates/cli/src/cli_args/run/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/run/recursive.rs
@@ -151,24 +151,11 @@ pub fn run_recursive(
         chunks.iter().flatten().map(|root| (root.clone(), ExecutionStatus::queued())).collect();
     let mut has_command = 0_usize;
 
-    // Lifecycle env reused per project: each recursive script sets up
-    // `node_modules/.bin` on `PATH`, the `npm_*` env, the configured
-    // `script_shell`, and the user-agent. Compute the bits that don't
-    // vary per project once; the per-project `RunContext` reuses them.
+    // Compute the shared lifecycle env once. Each project adds loader
+    // options for its own root before reusing that environment across
+    // the selected pre/main/post stages.
     let init_cwd = env::current_dir().unwrap_or_else(|_| dir.to_path_buf());
-    let mut extra_env: HashMap<String, String> = config.extra_env_with_node_options();
-    if let Some(pnp_path) = pnp_path_for_execution(config, dir) {
-        let node_options = extra_env.get("NODE_OPTIONS").map(String::as_str);
-        extra_env
-            .insert("NODE_OPTIONS".to_string(), make_node_require_option(&pnp_path, node_options));
-    }
-    if let Some(package_map_path) = package_map_path_for_execution(config, dir) {
-        let node_options = extra_env.get("NODE_OPTIONS").map(String::as_str);
-        extra_env.insert(
-            "NODE_OPTIONS".to_string(),
-            make_node_package_map_option(&package_map_path, node_options),
-        );
-    }
+    let extra_env: HashMap<String, String> = config.extra_env_with_node_options();
 
     if args.parallel {
         let roots = chunks.iter().flatten().collect::<Vec<_>>();
@@ -311,6 +298,19 @@ fn run_project(options: RunProjectOptions<'_, '_>) -> miette::Result<ProjectExec
         status.status = Status::Skipped;
         return Ok(ProjectExecution { status, has_command: 0 });
     }
+    let mut extra_env = extra_env.clone();
+    if let Some(pnp_path) = pnp_path_for_execution(config, root) {
+        let node_options = extra_env.get("NODE_OPTIONS").map(String::as_str);
+        extra_env
+            .insert("NODE_OPTIONS".to_string(), make_node_require_option(&pnp_path, node_options));
+    }
+    if let Some(package_map_path) = package_map_path_for_execution(config, root) {
+        let node_options = extra_env.get("NODE_OPTIONS").map(String::as_str);
+        extra_env.insert(
+            "NODE_OPTIONS".to_string(),
+            make_node_package_map_option(&package_map_path, node_options),
+        );
+    }
 
     let mut execution = ProjectExecution { status: ExecutionStatus::queued(), has_command: 0 };
     let mut project_failed = false;
@@ -340,7 +340,7 @@ fn run_project(options: RunProjectOptions<'_, '_>) -> miette::Result<ProjectExec
             dir: root,
             init_cwd,
             config,
-            extra_env,
+            extra_env: &extra_env,
             silent,
             sequential: args.sequential,
         };

--- a/pnpm/crates/cli/tests/suite/install_state.rs
+++ b/pnpm/crates/cli/tests/suite/install_state.rs
@@ -84,7 +84,26 @@ fn pnp_install_without_symlinks_still_writes_modules_manifest_and_bin_directory(
             "--require",
             "./.pnp.cjs",
             "--eval",
-            "const api = require('module').findPnpApi(); const resolved = api.resolveRequest('#x', __filename); if (require(resolved) !== 42) process.exit(1)",
+            r"const assert = require('assert');
+const api = require('pnpapi');
+assert.strictEqual(require('module').findPnpApi(__filename), api);
+assert.strictEqual(api.VERSIONS.std, 3);
+assert.deepStrictEqual(api.getDependencyTreeRoots(), []);
+assert.deepStrictEqual(api.getLocator('alias', ['target', 'reference']), { name: 'target', reference: 'reference' });
+assert.deepStrictEqual(api.findPackageLocator(__filename), api.topLevel);
+assert.strictEqual(api.getPackageInformation(api.topLevel).linkType, 'SOFT');
+const resolved = api.resolveRequest('#x', __filename);
+assert.strictEqual(require(resolved), 42);
+const packageJson = api.resolveRequest('@pnpm.e2e/pkg-with-1-dep/package.json', __filename);
+const locator = api.findPackageLocator(packageJson);
+assert.strictEqual(locator.name, '@pnpm.e2e/pkg-with-1-dep');
+assert.strictEqual(locator.reference, '100.0.0');
+const information = api.getPackageInformation(locator);
+assert(information.packageDependencies instanceof Map);
+assert(information.packagePeers instanceof Set);
+assert.strictEqual(information.linkType, 'HARD');
+assert(api.getAllLocators().some((candidate) => candidate.name === locator.name && candidate.reference === locator.reference));
+assert.strictEqual(api.resolveVirtual(packageJson), null);",
         ])
         .assert()
         .success();
@@ -111,6 +130,154 @@ fn pnp_install_without_symlinks_still_writes_modules_manifest_and_bin_directory(
         .assert()
         .success();
     assert!(workspace.join(".pnp.cjs").exists());
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn pnp_loader_is_preloaded_for_lifecycle_run_and_exec_commands() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "name": "project",
+            "version": "1.0.0",
+            "scripts": {
+                "postinstall": r#"node -e "require('@pnpm.e2e/pkg-with-1-dep'); require('fs').writeFileSync('postinstall-pnp', '')""#,
+                "check-pnp": r#"node -e "require('@pnpm.e2e/pkg-with-1-dep'); require('fs').writeFileSync('run-pnp', '')""#,
+            },
+            "dependencies": {
+                "@pnpm.e2e/pkg-with-1-dep": "100.0.0",
+                "@pnpm.e2e/write-lifecycle-env": "1.0.0",
+            },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    let member_dir = workspace.join("packages/member");
+    fs::create_dir_all(&member_dir).expect("create workspace member");
+    fs::write(
+        member_dir.join("package.json"),
+        serde_json::json!({
+            "name": "member",
+            "version": "1.0.0",
+            "scripts": {
+                "check-pnp": r#"node -e "require('@pnpm.e2e/pkg-with-1-dep'); require('fs').writeFileSync('recursive-run-pnp', '')""#,
+            },
+            "dependencies": {
+                "@pnpm.e2e/pkg-with-1-dep": "100.0.0",
+            },
+        })
+        .to_string(),
+    )
+    .expect("write workspace member package.json");
+    let yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut yaml = fs::read_to_string(&yaml_path).expect("read pnpm-workspace.yaml");
+    yaml.push_str(
+        "packages:\n  - packages/*\nnodeLinker: pnp\nsymlink: false\nnodeOptions: --trace-warnings\nallowBuilds:\n  '@pnpm.e2e/write-lifecycle-env': true\n",
+    );
+    fs::write(&yaml_path, yaml).expect("enable PnP lifecycle scripts");
+
+    pacquet.with_arg("install").assert().success();
+    assert!(
+        workspace.join("postinstall-pnp").exists(),
+        "the project postinstall should resolve its dependency through PnP",
+    );
+
+    let dependency_env_path = workspace.join(
+        "node_modules/.pnpm/@pnpm.e2e+write-lifecycle-env@1.0.0/node_modules/@pnpm.e2e/write-lifecycle-env/env.json",
+    );
+    let dependency_node_options = || {
+        let dependency_env: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(&dependency_env_path)
+                .expect("read dependency lifecycle environment"),
+        )
+        .expect("parse dependency lifecycle environment");
+        dependency_env["NODE_OPTIONS"]
+            .as_str()
+            .expect("dependency lifecycle NODE_OPTIONS")
+            .to_string()
+    };
+    let fresh_node_options = dependency_node_options();
+    eprintln!("FRESH DEPENDENCY NODE_OPTIONS: {fresh_node_options}");
+    assert!(fresh_node_options.contains("--trace-warnings"));
+    assert!(fresh_node_options.contains("--require="));
+    assert!(fresh_node_options.contains(".pnp.cjs"));
+
+    fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
+    fs::remove_file(workspace.join("postinstall-pnp")).expect("remove postinstall marker");
+    Command::cargo_bin("pnpm")
+        .expect("find pnpm binary")
+        .with_current_dir(&workspace)
+        .with_args(["install", "--frozen-lockfile"])
+        .assert()
+        .success();
+    assert!(
+        workspace.join("postinstall-pnp").exists(),
+        "the frozen project postinstall should resolve its dependency through PnP",
+    );
+    let frozen_node_options = dependency_node_options();
+    eprintln!("FROZEN DEPENDENCY NODE_OPTIONS: {frozen_node_options}");
+    assert!(frozen_node_options.contains("--trace-warnings"));
+    assert!(frozen_node_options.contains("--require="));
+    assert!(frozen_node_options.contains(".pnp.cjs"));
+
+    Command::cargo_bin("pnpm")
+        .expect("find pnpm binary")
+        .with_current_dir(&workspace)
+        .with_args(["run", "check-pnp"])
+        .assert()
+        .success();
+    assert!(
+        workspace.join("run-pnp").exists(),
+        "pnpm run should resolve the project dependency through PnP",
+    );
+
+    Command::cargo_bin("pnpm")
+        .expect("find pnpm binary")
+        .with_current_dir(&workspace)
+        .with_args([
+            "exec",
+            "node",
+            "--eval",
+            "require('@pnpm.e2e/pkg-with-1-dep'); require('fs').writeFileSync('exec-pnp', '')",
+        ])
+        .assert()
+        .success();
+    assert!(
+        workspace.join("exec-pnp").exists(),
+        "pnpm exec should resolve the project dependency through PnP",
+    );
+
+    Command::cargo_bin("pnpm")
+        .expect("find pnpm binary")
+        .with_current_dir(&workspace)
+        .with_args(["-r", "run", "check-pnp"])
+        .assert()
+        .success();
+    assert!(
+        member_dir.join("recursive-run-pnp").exists(),
+        "recursive pnpm run should preload the workspace PnP loader",
+    );
+
+    Command::cargo_bin("pnpm")
+        .expect("find pnpm binary")
+        .with_current_dir(&workspace)
+        .with_args([
+            "-r",
+            "exec",
+            "node",
+            "--eval",
+            "require('@pnpm.e2e/pkg-with-1-dep'); require('fs').writeFileSync('recursive-exec-pnp', '')",
+        ])
+        .assert()
+        .success();
+    assert!(
+        member_dir.join("recursive-exec-pnp").exists(),
+        "recursive pnpm exec should preload the workspace PnP loader",
+    );
 
     drop((root, mock_instance));
 }

--- a/pnpm/crates/cli/tests/suite/run_recursive.rs
+++ b/pnpm/crates/cli/tests/suite/run_recursive.rs
@@ -106,6 +106,43 @@ fn recursive_run_executes_script_in_every_project() {
     drop(root);
 }
 
+/// Without a workspace-level loader, recursive run preloads the `.pnp.cjs`
+/// belonging to each selected project rather than resolving once from the
+/// invocation directory.
+#[test]
+fn recursive_run_preloads_each_project_pnp_loader() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let manifest = |name: &str| {
+        json!({
+            "name": name,
+            "version": "1.0.0",
+            "scripts": { "build": "node -e 0" },
+        })
+    };
+    write_workspace(
+        &workspace,
+        &[("project-1", manifest("project-1")), ("project-2", manifest("project-2"))],
+    );
+    for name in ["project-1", "project-2"] {
+        fs::write(
+            workspace.join(name).join(".pnp.cjs"),
+            "require('fs').writeFileSync('pnp-loader-ran.txt', '')",
+        )
+        .expect("write project PnP loader");
+    }
+
+    pacquet.with_args(["-r", "run", "build"]).assert().success();
+
+    for name in ["project-1", "project-2"] {
+        assert!(
+            workspace.join(name).join("pnp-loader-ran.txt").exists(),
+            "{name} should preload its own PnP loader",
+        );
+    }
+
+    drop(root);
+}
+
 #[test]
 fn parallel_before_run_starts_selected_projects_concurrently() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();

--- a/pnpm/crates/deps-restorer/src/install_frozen_lockfile.rs
+++ b/pnpm/crates/deps-restorer/src/install_frozen_lockfile.rs
@@ -178,11 +178,9 @@ where
     /// chain, matching the `nodeLinker === 'hoisted'` branch in
     /// `headlessInstall`.
     ///
-    /// Pacquet's [`NodeLinker::Pnp`] is a config / serde
-    /// placeholder today; an install request with `Pnp` reaches
-    /// the isolated linker in this branch (no `PnP` code path
-    /// exists yet). `nodeLinker: 'pnp'` is out-of-scope and tracked
-    /// separately.
+    /// [`NodeLinker::Pnp`] shares the isolated virtual-store materialization,
+    /// then replaces importer dependency links with the project-level `PnP`
+    /// loader during the link phase.
     pub node_linker: NodeLinker,
 
     /// Install-scoped shared in-flight tarball cache, threaded down to
@@ -772,6 +770,16 @@ where
         };
 
         let mut build_extra_env = config.extra_env_with_node_options();
+        if matches!(node_linker, NodeLinker::Pnp) {
+            let node_options = build_extra_env.get("NODE_OPTIONS").map(String::as_str);
+            build_extra_env.insert(
+                "NODE_OPTIONS".to_string(),
+                crate::make_node_require_option(
+                    &workspace_root.join(crate::PNP_FILENAME),
+                    node_options,
+                ),
+            );
+        }
         if config.node_experimental_package_map && !matches!(node_linker, NodeLinker::Pnp) {
             let package_map_path =
                 config.modules_dir.join(crate::package_map::PACKAGE_MAP_FILENAME);

--- a/pnpm/crates/deps-restorer/src/package_map.rs
+++ b/pnpm/crates/deps-restorer/src/package_map.rs
@@ -378,6 +378,17 @@ pub fn make_node_package_map_option(package_map_path: &Path, node_options: Optio
     parts.join(" ")
 }
 
+pub fn make_node_require_option(module_path: &Path, node_options: Option<&str>) -> String {
+    let node_options =
+        node_options.map(str::to_string).or_else(|| std::env::var("NODE_OPTIONS").ok());
+    let quoted_path = quote_path_if_needed(&module_path.to_string_lossy());
+    let require_option = format!("--require={quoted_path}");
+    match node_options.as_deref().map(str::trim).filter(|options| !options.is_empty()) {
+        Some(node_options) => format!("{node_options} {require_option}"),
+        None => require_option,
+    }
+}
+
 pub fn package_map_path_for_execution(config: &Config, dir: &Path) -> Option<PathBuf> {
     if !config.node_experimental_package_map {
         return None;

--- a/pnpm/crates/deps-restorer/src/package_map/tests.rs
+++ b/pnpm/crates/deps-restorer/src/package_map/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     HoistedPackageMapOptions, PackageMapOptions, absolute_package_url,
     dependencies_graph_to_package_map, link_target_id, lockfile_to_package_map,
-    make_node_package_map_option, to_relative_url,
+    make_node_package_map_option, make_node_require_option, to_relative_url,
 };
 use crate::{DependenciesGraphNode, LockfileToDepGraphResult, VirtualStoreLayout};
 use pnpm_lockfile::{
@@ -377,6 +377,22 @@ fn package_map_node_options_replaces_existing_package_map_option() {
             Some(r#"--experimental-package-map="/quo\"te/old.json" --inspect"#),
         ),
         "--inspect --experimental-package-map=/new/.package-map.json",
+    );
+}
+
+#[test]
+fn pnp_node_options_preserve_existing_options_and_quote_the_loader_path() {
+    assert_eq!(
+        make_node_require_option(Path::new("/repo/.pnp.cjs"), Some("--max-old-space-size=4096")),
+        "--max-old-space-size=4096 --require=/repo/.pnp.cjs",
+    );
+    assert_eq!(
+        make_node_require_option(Path::new("/repo with spaces/.pnp.cjs"), Some("")),
+        r#"--require="/repo with spaces/.pnp.cjs""#,
+    );
+    assert_eq!(
+        make_node_require_option(Path::new(r"C:\repo\.pnp.cjs"), Some("")),
+        r#"--require="C:\\repo\\.pnp.cjs""#,
     );
 }
 

--- a/pnpm/crates/deps-restorer/src/pnp.rs
+++ b/pnpm/crates/deps-restorer/src/pnp.rs
@@ -5,6 +5,9 @@ use pnpm_package_manifest::PackageManifest;
 use std::path::{Path, PathBuf};
 
 pub const PNP_FILENAME: &str = ".pnp.cjs";
+const PNP_LOADER_TEMPLATE: &str = include_str!("pnp_loader.cjs.inc");
+const PACKAGE_REGISTRY_PLACEHOLDER: &str = "__PNPM_PACKAGE_REGISTRY__";
+const MODULES_DIR_PLACEHOLDER: &str = "__PNPM_MODULES_DIR__";
 
 #[derive(Debug, Display, Error)]
 pub enum WritePnpFileError {
@@ -36,92 +39,39 @@ pub fn write_pnp_file(
         .unwrap_or_else(|| config.modules_dir.clone());
     let modules_dir = serde_json::to_string(&modules_dir.to_string_lossy())
         .map_err(WritePnpFileError::Serialize)?;
-    let contents = format!(
-        r"'use strict';
-const Module = require('module');
-const path = require('path');
-const {{ fileURLToPath }} = require('url');
-const registry = {registry}.packages;
-const modulesDir = path.resolve(__dirname, {modules_dir});
-
-function packageLocation(pkg) {{
-  return pkg.url.startsWith('file:') ? fileURLToPath(pkg.url) : path.resolve(modulesDir, pkg.url);
-}}
-
-const locations = Object.entries(registry)
-  .map(([id, pkg]) => [id, packageLocation(pkg)])
-  .sort((a, b) => b[1].length - a[1].length);
-const originalResolveFilename = Module._resolveFilename;
-
-function packageName(request) {{
-  if (!request || request[0] === '.' || request[0] === '#' || path.isAbsolute(request)) return null;
-  if (request[0] !== '@') return request.split('/', 1)[0];
-  const parts = request.split('/');
-  return parts.length > 1 ? `${{parts[0]}}/${{parts[1]}}` : request;
-}}
-
-function issuerPackage(issuer) {{
-  const normalized = path.resolve(issuer || __dirname);
-  return locations.find(([, location]) =>
-    normalized === location || normalized.startsWith(`${{location}}${{path.sep}}`)
-  );
-}}
-
-function moduleForIssuer(issuer) {{
-  const filename = path.resolve(issuer || __filename);
-  const parent = new Module(filename);
-  parent.filename = filename;
-  parent.paths = Module._nodeModulePaths(path.dirname(filename));
-  return parent;
-}}
-
-function resolveToUnqualified(request, issuer) {{
-  const name = packageName(request);
-  if (name === null || request.startsWith('node:') || Module.builtinModules.includes(name)) return null;
-  const owner = issuerPackage(issuer);
-  if (!owner) return null;
-  const dependencyId = registry[owner[0]].dependencies[name];
-  if (dependencyId === undefined || registry[dependencyId] === undefined) {{
-    const error = new Error(`Your application tried to access ${{name}}, but it isn't declared in your dependencies`);
-    error.code = 'MODULE_NOT_FOUND';
-    throw error;
-  }}
-  const subpath = request.slice(name.length);
-  const dependencyLocation = packageLocation(registry[dependencyId]);
-  const unqualified = path.resolve(dependencyLocation, `.${{subpath}}`);
-  if (unqualified !== dependencyLocation && !unqualified.startsWith(`${{dependencyLocation}}${{path.sep}}`)) {{
-    const error = new Error(`Your application tried to access a path outside ${{name}}`);
-    error.code = 'MODULE_NOT_FOUND';
-    throw error;
-  }}
-  return unqualified;
-}}
-
-function resolveRequest(request, issuer, options) {{
-  const unqualified = resolveToUnqualified(request, issuer);
-  const parent = moduleForIssuer(issuer);
-  if (unqualified === null) return originalResolveFilename.call(Module, request, parent, false, options);
-  return originalResolveFilename.call(Module, unqualified, parent, false, options);
-}}
-
-function setup() {{
-  if (Module._resolveFilename.__pnpmPnp) return;
-  const hooked = function(request, parent, isMain, options) {{
-    const issuer = parent && parent.filename ? parent.filename : __filename;
-    const unqualified = resolveToUnqualified(request, issuer);
-    if (unqualified === null) return originalResolveFilename.call(this, request, parent, isMain, options);
-    return originalResolveFilename.call(this, unqualified, parent, isMain, options);
-  }};
-  hooked.__pnpmPnp = true;
-  Module._resolveFilename = hooked;
-  Module.findPnpApi = () => api;
-}}
-
-const api = {{ resolveRequest, resolveToUnqualified, setup }};
-module.exports = api;
-setup();
-",
-    );
+    let contents = render_pnp_loader(&registry, &modules_dir);
     pnpm_fs::ensure_file(&lockfile_dir.join(PNP_FILENAME), contents.as_bytes(), None)
         .map_err(WritePnpFileError::Write)
 }
+
+fn render_pnp_loader(registry: &str, modules_dir: &str) -> String {
+    let (before_registry, after_registry) = PNP_LOADER_TEMPLATE
+        .split_once(PACKAGE_REGISTRY_PLACEHOLDER)
+        .expect("embedded PnP loader has a package registry placeholder");
+    let (between_values, after_modules_dir) = after_registry
+        .split_once(MODULES_DIR_PLACEHOLDER)
+        .expect("embedded PnP loader has a modules directory placeholder");
+    let mut loader =
+        String::with_capacity(PNP_LOADER_TEMPLATE.len() + registry.len() + modules_dir.len());
+    loader.push_str(before_registry);
+    loader.push_str(registry);
+    loader.push_str(between_values);
+    loader.push_str(modules_dir);
+    loader.push_str(after_modules_dir);
+    loader
+}
+
+#[must_use]
+pub fn pnp_path_for_execution(config: &pnpm_config::Config, dir: &Path) -> Option<PathBuf> {
+    let workspace_path = config.workspace_dir.as_ref().map(|dir| dir.join(PNP_FILENAME));
+    if let Some(path) = workspace_path
+        && path.exists()
+    {
+        return Some(path);
+    }
+    let path = dir.join(PNP_FILENAME);
+    path.exists().then_some(path)
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/deps-restorer/src/pnp/tests.rs
+++ b/pnpm/crates/deps-restorer/src/pnp/tests.rs
@@ -1,0 +1,10 @@
+use super::render_pnp_loader;
+
+#[test]
+fn template_markers_inside_values_are_not_replaced() {
+    let loader =
+        render_pnp_loader("registry __PNPM_MODULES_DIR__", "modules __PNPM_PACKAGE_REGISTRY__");
+
+    assert_eq!(loader.matches("registry __PNPM_MODULES_DIR__").count(), 1);
+    assert_eq!(loader.matches("modules __PNPM_PACKAGE_REGISTRY__").count(), 1);
+}

--- a/pnpm/crates/deps-restorer/src/pnp_loader.cjs.inc
+++ b/pnpm/crates/deps-restorer/src/pnp_loader.cjs.inc
@@ -1,0 +1,206 @@
+'use strict'
+
+const Module = require('module')
+const path = require('path')
+const { fileURLToPath } = require('url')
+
+const registry = __PNPM_PACKAGE_REGISTRY__.packages
+const modulesDir = path.resolve(__dirname, __PNPM_MODULES_DIR__)
+const originalResolveFilename = Module._resolveFilename
+const topLevel = { name: null, reference: null }
+
+function packageLocation(pkg) {
+  return pkg.url.startsWith('file:') ? fileURLToPath(pkg.url) : path.resolve(modulesDir, pkg.url)
+}
+
+const locations = Object.entries(registry)
+  .map(([id, pkg]) => [id, packageLocation(pkg)])
+  .sort((a, b) => b[1].length - a[1].length)
+
+const incomingNames = new Map()
+for (const pkg of Object.values(registry)) {
+  for (const [name, id] of Object.entries(pkg.dependencies)) {
+    if (!incomingNames.has(id)) incomingNames.set(id, name)
+  }
+}
+
+function locatorFromPackage(id, pkg) {
+  if (id === '.') return topLevel
+  const selfDependency = Object.entries(pkg.dependencies).find(([, dependencyId]) => dependencyId === id)
+  const name = selfDependency?.[0] ?? incomingNames.get(id) ?? id
+  const prefix = `${name}@`
+  return { name, reference: id.startsWith(prefix) ? id.slice(prefix.length) : id }
+}
+
+function locatorKey(locator) {
+  return JSON.stringify([locator.name, locator.reference])
+}
+
+const locatorById = new Map()
+const idByLocator = new Map()
+for (const [id, pkg] of Object.entries(registry)) {
+  const locator = locatorFromPackage(id, pkg)
+  locatorById.set(id, locator)
+  idByLocator.set(locatorKey(locator), id)
+}
+
+function packageName(request) {
+  if (!request || request[0] === '.' || request[0] === '#' || path.isAbsolute(request)) return null
+  if (request[0] !== '@') return request.split('/', 1)[0]
+  const parts = request.split('/')
+  return parts.length > 1 ? `${parts[0]}/${parts[1]}` : request
+}
+
+function packageIdForLocation(location) {
+  const normalized = path.resolve(location || __dirname)
+  return locations.find(([, packagePath]) =>
+    normalized === packagePath || normalized.startsWith(`${packagePath}${path.sep}`)
+  )?.[0]
+}
+
+function moduleForIssuer(issuer) {
+  const filename = path.resolve(issuer || __filename)
+  const parent = new Module(filename)
+  parent.filename = filename
+  parent.paths = Module._nodeModulePaths(path.dirname(filename))
+  return parent
+}
+
+function nativeResolve(request, issuer, options) {
+  return originalResolveFilename.call(Module, request, moduleForIssuer(issuer), false, options)
+}
+
+function dependencyTarget(alias, dependencyId) {
+  const locator = locatorById.get(dependencyId)
+  if (locator === undefined) return dependencyId
+  if (locator.name === alias) return locator.reference
+  return [locator.name, locator.reference]
+}
+
+function getPackageInformation(locator) {
+  const id = idByLocator.get(locatorKey(locator))
+  if (id === undefined) return null
+  const pkg = registry[id]
+  const location = packageLocation(pkg)
+  const packageDependencies = new Map()
+  for (const [alias, dependencyId] of Object.entries(pkg.dependencies)) {
+    if (id === '.' && dependencyId === id) continue
+    packageDependencies.set(alias, dependencyTarget(alias, dependencyId))
+  }
+  const relativeToModules = path.relative(modulesDir, location)
+  return {
+    packageLocation: location.endsWith(path.sep) ? location : `${location}${path.sep}`,
+    packageDependencies,
+    packagePeers: new Set(),
+    linkType: relativeToModules === '..' || relativeToModules.startsWith(`..${path.sep}`) || path.isAbsolute(relativeToModules)
+      ? 'SOFT'
+      : 'HARD',
+    discardFromLookup: false,
+  }
+}
+
+function findPackageLocator(location) {
+  const id = packageIdForLocation(location)
+  const locator = id === undefined ? undefined : locatorById.get(id)
+  return locator === undefined ? null : { ...locator }
+}
+
+function undeclaredDependencyError(name, issuer) {
+  const error = new Error(`Your application tried to access ${name}, but it isn't declared in your dependencies`)
+  error.code = 'MODULE_NOT_FOUND'
+  error.pnpCode = 'UNDECLARED_DEPENDENCY'
+  error.data = { dependencyName: name, issuer, request: name }
+  return error
+}
+
+function resolveToUnqualified(request, issuer, options = {}) {
+  if (request === 'pnpapi') return __filename
+  const name = packageName(request)
+  if (name === null) {
+    if (request.startsWith('#')) {
+      throw new Error('resolveToUnqualified can not handle private import mappings')
+    }
+    if (path.isAbsolute(request)) return path.normalize(request)
+    if (issuer === null || issuer === undefined) {
+      throw new Error('The resolveToUnqualified function must be called with a valid issuer when the request is relative')
+    }
+    const issuerPath = path.resolve(issuer)
+    const issuerDir = issuer.endsWith(path.sep) ? issuerPath : path.dirname(issuerPath)
+    return path.resolve(issuerDir, request)
+  }
+  if (options.considerBuiltins !== false && (request.startsWith('node:') || Module.builtinModules.includes(name))) {
+    return null
+  }
+  const ownerId = packageIdForLocation(issuer)
+  if (ownerId === undefined) return nativeResolve(request, issuer, options)
+  const dependencyId = registry[ownerId].dependencies[name]
+  if (dependencyId === undefined || registry[dependencyId] === undefined) {
+    throw undeclaredDependencyError(name, issuer)
+  }
+  const subpath = request.slice(name.length)
+  const dependencyLocation = packageLocation(registry[dependencyId])
+  const unqualified = path.resolve(dependencyLocation, `.${subpath}`)
+  if (unqualified !== dependencyLocation && !unqualified.startsWith(`${dependencyLocation}${path.sep}`)) {
+    const error = new Error(`Your application tried to access a path outside ${name}`)
+    error.code = 'MODULE_NOT_FOUND'
+    throw error
+  }
+  return unqualified
+}
+
+function resolveUnqualified(unqualified, options) {
+  return nativeResolve(unqualified, unqualified, options)
+}
+
+function resolveRequest(request, issuer, options = {}) {
+  if (request.startsWith('#')) return nativeResolve(request, issuer, options)
+  const unqualified = resolveToUnqualified(request, issuer, options)
+  if (unqualified === null) return null
+  return resolveUnqualified(unqualified, options)
+}
+
+function getAllLocators() {
+  return [...locatorById.values()]
+    .filter((locator) => locator.name !== null)
+    .map((locator) => ({ ...locator }))
+}
+
+function setup() {
+  if (Module._resolveFilename.__pnpmPnp) return
+  const hooked = function (request, parent, isMain, options) {
+    if (request === 'pnpapi') return __filename
+    const name = packageName(request)
+    if (name === null || request.startsWith('node:') || Module.builtinModules.includes(name)) {
+      return originalResolveFilename.call(this, request, parent, isMain, options)
+    }
+    const issuer = parent?.filename ?? __filename
+    const unqualified = resolveToUnqualified(request, issuer)
+    return originalResolveFilename.call(this, unqualified, parent, isMain, options)
+  }
+  hooked.__pnpmPnp = true
+  Module._resolveFilename = hooked
+  Module.findPnpApi = (lookupSource) => {
+    if (lookupSource === undefined) return api
+    return findPackageLocator(lookupSource) === null ? undefined : api
+  }
+}
+
+const api = {
+  VERSIONS: { std: 3, resolveVirtual: 1, getAllLocators: 1 },
+  topLevel,
+  getLocator: (name, referencish) => Array.isArray(referencish)
+    ? { name: referencish[0], reference: referencish[1] }
+    : { name, reference: referencish },
+  getDependencyTreeRoots: () => [],
+  getAllLocators,
+  getPackageInformation,
+  findPackageLocator,
+  resolveToUnqualified,
+  resolveUnqualified,
+  resolveRequest,
+  resolveVirtual: () => null,
+  setup,
+}
+
+module.exports = api
+setup()

--- a/pnpm/crates/package-manager/src/install/lifecycle.rs
+++ b/pnpm/crates/package-manager/src/install/lifecycle.rs
@@ -161,16 +161,26 @@ pub(super) fn exec_scripts_prepend_node_path(config: &Config) -> ExecScriptsPrep
     }
 }
 
-/// [`Config::extra_env_with_node_options`] plus the `NODE_OPTIONS` entry pointing Node at
-/// `node_modules/.package-map.json` when the user opted into the
-/// experimental package map. pnpm adds it only once it links and builds,
-/// which is why `pnpm:devPreinstall` — running before the file exists —
-/// takes the plain [`Config::extra_env_with_node_options`].
+/// [`Config::extra_env_with_node_options`] plus the `NODE_OPTIONS` entry for
+/// the selected project-level dependency loader. pnpm adds it only once it
+/// links and builds, which is why `pnpm:devPreinstall` — running before the
+/// file exists — takes the plain [`Config::extra_env_with_node_options`].
 pub(super) fn project_lifecycle_extra_env(
     config: &Config,
     node_linker: NodeLinker,
+    workspace_root: &Path,
 ) -> HashMap<String, String> {
     let mut extra_env = config.extra_env_with_node_options();
+    if matches!(node_linker, NodeLinker::Pnp) {
+        let node_options = extra_env.get("NODE_OPTIONS").map(String::as_str);
+        extra_env.insert(
+            "NODE_OPTIONS".to_string(),
+            crate::make_node_require_option(
+                &workspace_root.join(crate::PNP_FILENAME),
+                node_options,
+            ),
+        );
+    }
     if config.node_experimental_package_map && !matches!(node_linker, NodeLinker::Pnp) {
         let package_map_path = config.modules_dir.join(crate::package_map::PACKAGE_MAP_FILENAME);
         let node_options = extra_env.get("NODE_OPTIONS").map(String::as_str);
@@ -244,7 +254,7 @@ pub(super) fn run_projects_lifecycle_scripts<Reporter: self::Reporter>(
 ) -> Result<(), InstallError> {
     let modules_dir_basename = modules_dir_basename(config);
     let scripts_prepend_node_path = exec_scripts_prepend_node_path(config);
-    let extra_env = project_lifecycle_extra_env(config, node_linker);
+    let extra_env = project_lifecycle_extra_env(config, node_linker, workspace_root);
     let max_group_size = project_groups.iter().map(Vec::len).max().unwrap_or(0);
     let link_options = crate::shim_link_options(config, node_linker);
     let run_project =

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1580,7 +1580,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             None => engine_name,
         };
 
-        let build_extra_env = build_extra_env(config, node_linker);
+        let build_extra_env = build_extra_env(config, node_linker, lockfile_dir);
 
         // `CreateVirtualStore` keeps skipped snapshots out of this map, so
         // it holds only what the install put on disk. See
@@ -1806,11 +1806,25 @@ fn pre_resolution_log_fn<Reporter: self::Reporter>(
 /// keeps the output byte-identical to the typed write when the hook makes no
 /// changes. A throwing hook aborts the install.
 /// The environment lifecycle scripts run under: `config.extra_env` plus
-/// the `NODE_OPTIONS` that point Node at the package map.
-fn build_extra_env(config: &Config, node_linker: NodeLinker) -> HashMap<String, String> {
+/// the `NODE_OPTIONS` for the selected project-level dependency loader.
+fn build_extra_env(
+    config: &Config,
+    node_linker: NodeLinker,
+    workspace_root: &Path,
+) -> HashMap<String, String> {
     let mut env = config.extra_env.clone();
     if let Some(node_options) = &config.node_options {
         env.insert("NODE_OPTIONS".to_string(), node_options.clone());
+    }
+    if matches!(node_linker, NodeLinker::Pnp) {
+        let node_options = env.get("NODE_OPTIONS").map(String::as_str);
+        env.insert(
+            "NODE_OPTIONS".to_string(),
+            crate::make_node_require_option(
+                &workspace_root.join(crate::PNP_FILENAME),
+                node_options,
+            ),
+        );
     }
     if config.node_experimental_package_map && !matches!(node_linker, NodeLinker::Pnp) {
         let package_map_path = config.modules_dir.join(crate::package_map::PACKAGE_MAP_FILENAME);


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Complete the Rust CLI Plug'n'Play integration by:

- preloading the workspace `.pnp.cjs` for fresh and frozen dependency builds, project lifecycle scripts, `pnpm run`, recursive runs, `pnpm exec`, and recursive execs;
- preserving existing `NODE_OPTIONS` while adding the loader;
- exposing the Yarn-compatible PnP API used by ecosystem tooling, including `pnpapi`, locator and package-information queries, resolver methods, version metadata, and `Module.findPnpApi`.

The TypeScript CLI already preloads its generated Yarn PnP loader in these paths. This PR ports the missing behavior to pacquet; no TypeScript change is required.

## Squash Commit Body

```text
The Rust CLI generated a minimal .pnp.cjs loader, but it did not preload that loader for lifecycle scripts or explicit run and exec commands. Ecosystem tools could also observe only a small subset of the PnP API.

Append the workspace loader to NODE_OPTIONS across dependency builds, project lifecycle scripts, run, recursive run, exec, and recursive exec. Preserve existing Node options and use the same workspace-first loader lookup as the TypeScript CLI.

Expand the generated loader with locator, package-information, version, and resolver APIs, plus pnpapi and Module.findPnpApi support. Keep generated package data separate from template markers so lockfile-controlled values cannot be interpreted as template substitutions.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14094"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790042625&installation_model_id=426870&pr_number=14094&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14094&signature=2fc9c5fcbe2e5d0d85f8e5d584acb8390a8e1a8b2f1406a2cc45c7f7ff539aef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Plug’n’Play support across installs, lifecycle scripts, `pnpm run`, `pnpm exec`, and recursive commands.
  * Automatically preloads each project’s PnP loader while preserving existing `NODE_OPTIONS`.
  * Generated PnP loaders now expose Yarn-compatible public Plug’n’Play APIs.
  * Improved dependency, alias, virtual package, and subpath resolution.

* **Bug Fixes**
  * Fixed Plug’n’Play script execution for frozen installs and workspace commands.
  * Improved loader path handling, including paths containing spaces and Windows separators.
  * Ensured recursive commands use the correct project-specific PnP loader.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->