### PR TITLE
fix(update): resolve tag selectors before saving

### DIFF
--- a/.changeset/update-tag-selector-saves-resolved-version.md
+++ b/.changeset/update-tag-selector-saves-resolved-version.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm update <pkg>@<tag>` now saves the version the dist tag resolved to in `package.json`, keeping the range operator the dependency already declared, instead of saving the tag itself. A dependency declared through a `catalog:` reference, a `workspace:` or `npm:` alias, or a path or git specifier keeps its declaration, and one that already tracks a dist tag records the tag asked for [#14092](https://github.com/pnpm/pnpm/issues/14092).

--- a/pnpm/crates/cli/tests/suite/update.rs
+++ b/pnpm/crates/cli/tests/suite/update.rs
@@ -1870,7 +1870,7 @@ fn update_selectors_override_ignore_dependencies() {
     anchor.set_dist_tag(FOO, "100.0.0", "latest");
     anchor.set_dist_tag(BAR, "100.0.0", "latest");
 
-    write_manifest(&workspace, &format!(r#"{{ "{FOO}": "100.0.0", "{BAR}": "100.0.0" }}"#));
+    write_manifest(&workspace, &format!(r#"{{ "{FOO}": "100.0.0", "{BAR}": "^100.0.0" }}"#));
     set_ignore_dependencies(&workspace, &[FOO]);
     pacquet(&workspace, ["install"]).assert().success();
 
@@ -1888,6 +1888,24 @@ fn update_selectors_override_ignore_dependencies() {
     let packages = lockfile_package_keys(&workspace);
     assert!(packages.contains(&format!("{FOO}@100.1.0")), "{packages:?}");
     assert!(packages.contains(&format!("{BAR}@100.1.0")), "{packages:?}");
+    assert_eq!(dep_spec(&workspace, FOO).as_deref(), Some("100.1.0"));
+    assert_eq!(dep_spec(&workspace, BAR).as_deref(), Some("^100.1.0"));
+
+    drop((root, anchor));
+}
+
+#[test]
+fn update_tag_selector_preserves_catalog_reference() {
+    let (root, workspace, anchor) = setup_with_own_registry();
+    anchor.set_dist_tag(FOO, "100.0.0", "latest");
+    set_named_catalog(&workspace, "grp1", &[(FOO, "^100.0.0")]);
+    write_manifest(&workspace, &format!(r#"{{ "{FOO}": "catalog:grp1" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    anchor.set_dist_tag(FOO, "100.1.0", "latest");
+    pacquet(&workspace, ["update", &format!("{FOO}@latest")]).assert().success();
+
+    assert_eq!(dep_spec(&workspace, FOO).as_deref(), Some("catalog:grp1"));
 
     drop((root, anchor));
 }

--- a/pnpm/crates/cli/tests/suite/update.rs
+++ b/pnpm/crates/cli/tests/suite/update.rs
@@ -1894,6 +1894,9 @@ fn update_selectors_override_ignore_dependencies() {
     drop((root, anchor));
 }
 
+/// A `catalog:` entry declares a reference, not a range, so it is not
+/// something a resolved version can replace. The catalog entry keeps
+/// bounding the dependency, and the update moves the lockfile within it.
 #[test]
 fn update_tag_selector_preserves_catalog_reference() {
     let (root, workspace, anchor) = setup_with_own_registry();
@@ -1902,10 +1905,55 @@ fn update_tag_selector_preserves_catalog_reference() {
     write_manifest(&workspace, &format!(r#"{{ "{FOO}": "catalog:grp1" }}"#));
     pacquet(&workspace, ["install"]).assert().success();
 
+    let packages = lockfile_package_keys(&workspace);
+    assert!(packages.contains(&format!("{FOO}@100.0.0")), "{packages:?}");
+
     anchor.set_dist_tag(FOO, "100.1.0", "latest");
     pacquet(&workspace, ["update", &format!("{FOO}@latest")]).assert().success();
 
     assert_eq!(dep_spec(&workspace, FOO).as_deref(), Some("catalog:grp1"));
+    let yaml = read_workspace_yaml(&workspace);
+    assert!(yaml.contains("^100.0.0"), "catalog entry should be untouched: {yaml}");
+    let packages = lockfile_package_keys(&workspace);
+    assert!(packages.contains(&format!("{FOO}@100.1.0")), "{packages:?}");
+    pacquet(&workspace, ["install", "--frozen-lockfile"]).assert().success();
+
+    drop((root, anchor));
+}
+
+/// The selector names the tag to resolve, which need not be the tag the
+/// registry publishes as `latest`, nor the highest published version.
+#[test]
+fn update_tag_selector_resolves_the_named_tag() {
+    let (root, workspace, anchor) = setup_with_own_registry();
+    write_manifest(&workspace, &format!(r#"{{ "{FOO}": "^1.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    anchor.set_dist_tag(FOO, "100.0.0", "canary");
+    pacquet(&workspace, ["update", &format!("{FOO}@canary")]).assert().success();
+
+    assert_eq!(dep_spec(&workspace, FOO).as_deref(), Some("^100.0.0"));
+    let packages = lockfile_package_keys(&workspace);
+    assert!(packages.contains(&format!("{FOO}@100.0.0")), "{packages:?}");
+
+    drop((root, anchor));
+}
+
+/// A manifest that already tracks a dist tag keeps tracking one, so the
+/// selector's tag replaces it rather than being resolved into a range.
+#[test]
+fn update_tag_selector_replaces_a_declared_tag() {
+    let (root, workspace, anchor) = setup_with_own_registry();
+    anchor.set_dist_tag(FOO, "100.1.0", "latest");
+    write_manifest(&workspace, &format!(r#"{{ "{FOO}": "latest" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    anchor.set_dist_tag(FOO, "100.0.0", "canary");
+    pacquet(&workspace, ["update", &format!("{FOO}@canary")]).assert().success();
+
+    assert_eq!(dep_spec(&workspace, FOO).as_deref(), Some("canary"));
+    let packages = lockfile_package_keys(&workspace);
+    assert!(packages.contains(&format!("{FOO}@100.0.0")), "{packages:?}");
 
     drop((root, anchor));
 }

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -959,6 +959,9 @@ async fn prepare_manifest<Reporter: self::Reporter>(
                         .iter()
                         .find(|selector| matcher_one(&selector.pattern).matches(name))
                         .and_then(|selector| selector.version.clone());
+                    let requested_is_tag = requested.as_deref().is_some_and(|specifier| {
+                        get_version_selector_type(specifier) == Some(VersionSelectorType::Tag)
+                    });
                     // A cataloged dependency writes `catalog:` to the manifest, so a version
                     // named on the command line only reaches the lockfile as a preference.
                     if let Some(version) = requested.as_deref() {
@@ -995,6 +998,19 @@ async fn prepare_manifest<Reporter: self::Reporter>(
                                 }));
                                 None
                             }
+                        }
+                    } else if save && requested_is_tag {
+                        if parse_catalog_protocol(previous).is_some() {
+                            None
+                        } else {
+                            latest_specifier(
+                                &rewrite_ctx,
+                                latest_chain,
+                                &mut catalog_ctx,
+                                name,
+                                previous,
+                            )
+                            .await?
                         }
                     } else {
                         if save && requested.is_none() {

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -15,6 +15,7 @@ use crate::{
 use chrono::{DateTime, Utc};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
+use node_semver::Version;
 use pnpm_catalogs_config::{
     InvalidCatalogsConfigurationError, get_catalogs_from_workspace_manifest,
 };
@@ -38,7 +39,10 @@ use pnpm_reporter::{
 };
 use pnpm_resolving_default_resolver::DefaultResolver;
 use pnpm_resolving_deps_resolver::{UpdateDepth, UpdateTargets, VersionLine, real_package_name_of};
-use pnpm_resolving_npm_resolver::{DeclaredSpecifiers, calc_specifier_for_workspace_dep};
+use pnpm_resolving_npm_resolver::{
+    DeclaredSpecifiers, calc_specifier_for_workspace_dep, calc_version_range,
+    infer_range_spec_style,
+};
 use pnpm_resolving_resolver_base::{
     PreferredVersions, ResolveOptions, Resolver, UpdateBehavior, VersionSelectorType,
     WantedDependency, WorkspacePackages, WorkspacePackagesByVersion,
@@ -187,6 +191,17 @@ pub enum UpdateError {
     #[diagnostic(code(ERR_PNPM_PACKAGE_MANAGER_UPDATE_RESOLVE_LATEST))]
     ResolveLatest {
         name: String,
+        #[error(source)]
+        error: pnpm_resolving_resolver_base::ResolveError,
+    },
+
+    /// A resolver failed while resolving the dist tag an explicit
+    /// `<name>@<tag>` update selector named.
+    #[display("Failed to resolve {name}@{tag}: {error}")]
+    #[diagnostic(code(ERR_PNPM_PACKAGE_MANAGER_UPDATE_RESOLVE_TAG))]
+    ResolveTag {
+        name: String,
+        tag: String,
         #[error(source)]
         error: pnpm_resolving_resolver_base::ResolveError,
     },
@@ -959,11 +974,10 @@ async fn prepare_manifest<Reporter: self::Reporter>(
                         .iter()
                         .find(|selector| matcher_one(&selector.pattern).matches(name))
                         .and_then(|selector| selector.version.clone());
-                    let requested_is_tag = requested.as_deref().is_some_and(|specifier| {
-                        get_version_selector_type(specifier) == Some(VersionSelectorType::Tag)
-                    });
-                    // A cataloged dependency writes `catalog:` to the manifest, so a version
-                    // named on the command line only reaches the lockfile as a preference.
+                    // Seeded whatever the manifest ends up recording, so the
+                    // install locks the version that was asked for. A selector
+                    // naming a range or a tag is not a version and seeds
+                    // nothing.
                     if let Some(version) = requested.as_deref() {
                         crate::install_with_fresh_lockfile::prefer_requested_version(
                             &mut preferred_versions_override,
@@ -999,19 +1013,45 @@ async fn prepare_manifest<Reporter: self::Reporter>(
                                 None
                             }
                         }
-                    } else if save && requested_is_tag {
-                        if parse_catalog_protocol(previous).is_some() {
-                            None
-                        } else {
-                            latest_specifier(
-                                &rewrite_ctx,
-                                latest_chain,
-                                &mut catalog_ctx,
-                                name,
-                                previous,
-                            )
-                            .await?
-                        }
+                    } else if save
+                        && let Some(tag) = requested.as_deref().filter(|specifier| {
+                            get_version_selector_type(specifier) == Some(VersionSelectorType::Tag)
+                        })
+                    {
+                        // A dist tag names no version until it is resolved, so
+                        // an entry pinning a version or a range records what the
+                        // tag resolved to, keeping the operator it already pins.
+                        // An entry that already tracks a tag keeps tracking one.
+                        // Anything else — a `catalog:` reference, a `workspace:`
+                        // or `npm:` alias, a path or git dependency — declares
+                        // something no version round-trips, so it stands and the
+                        // selector reaches the install as a preference only.
+                        let rewritten = match get_version_selector_type(previous) {
+                            Some(VersionSelectorType::Version | VersionSelectorType::Range) => {
+                                match tag_version(&rewrite_ctx, latest_chain, name, tag).await? {
+                                    Some(version) => {
+                                        crate::install_with_fresh_lockfile::prefer_requested_version(
+                                            &mut preferred_versions_override,
+                                            name,
+                                            &version.to_string(),
+                                        );
+                                        Some(calc_version_range(
+                                            &version,
+                                            infer_range_spec_style(previous),
+                                            None,
+                                            range_spec_style,
+                                        ))
+                                    }
+                                    None => requested,
+                                }
+                            }
+                            Some(VersionSelectorType::Tag) => requested,
+                            None => None,
+                        };
+                        // A declaration that already says what the selector
+                        // settles on is not a rewrite; recording it would mark
+                        // the manifest dirty and persist it for nothing.
+                        rewritten.filter(|specifier| specifier != previous)
                     } else {
                         if save && requested.is_none() {
                             bump_targets.insert(name.clone());
@@ -1778,6 +1818,42 @@ async fn latest_specifier(
     Ok(resolved
         .and_then(|result| result.normalized_bare_specifier)
         .filter(|specifier| *specifier != effective))
+}
+
+/// The version dist tag `tag` names for `name`, or `None` when no resolver
+/// in the chain claims the dependency.
+///
+/// An explicit `<name>@<tag>` selector asks for the version behind exactly
+/// that tag, so — unlike [`latest_specifier`], which reaches for whichever
+/// of the declared range and the `latest` tag is higher — the tag is the
+/// whole specifier resolved here.
+async fn tag_version(
+    ctx: &LatestRewriteCtx<'_, '_>,
+    chain: &mut Option<LatestResolverChain>,
+    name: &str,
+    tag: &str,
+) -> Result<Option<Version>, UpdateError> {
+    let chain = ensure_latest_resolver_chain(chain, ctx)?;
+    let wanted = WantedDependency {
+        alias: Some(name.to_string()),
+        bare_specifier: Some(tag.to_string()),
+        ..WantedDependency::default()
+    };
+    let manifest_dir =
+        ctx.manifest.path().parent().expect("manifest path always has a parent dir").to_path_buf();
+    let opts = ResolveOptions {
+        project_dir: manifest_dir.clone(),
+        lockfile_dir: manifest_dir,
+        default_tag: Some(tag.to_string()),
+        published_by: chain.published_by,
+        published_by_exclude: chain.published_by_exclude.clone(),
+        dry_run: ctx.lockfile_only,
+        ..ResolveOptions::default()
+    };
+    let resolved = Resolver::resolve(&chain.resolver, &wanted, &opts).await.map_err(|error| {
+        UpdateError::ResolveTag { name: name.to_string(), tag: tag.to_string(), error }
+    })?;
+    Ok(resolved.and_then(|result| result.name_ver).map(|name_ver| name_ver.suffix))
 }
 
 /// The resolvers that can answer "what is the latest for this dependency",


### PR DESCRIPTION
## Summary

`pnpm update <pkg>@<tag>` on pacquet saved the tag itself into `package.json`, so a manifest could declare `latest` while the lockfile held the version behind it. The selector's tag is now resolved and the version behind it is what the manifest records, keeping the range operator the entry already declares — matching the TypeScript CLI.

The tag is resolved **on its own**, not through the `--latest` rewrite: that path takes the higher of the declared range and the `latest` tag, so routing `<pkg>@canary` through it would have recorded whatever `latest` names. The resolved version is also seeded as a resolution preference, so the lockfile locks the version the tag named rather than whatever else the newly recorded range admits.

Only a declaration a version can round-trip is rewritten:

| `package.json` entry | recorded for `update <pkg>@<tag>` |
| --- | --- |
| a range or a pinned version | the version the tag resolved to, with the entry's own operator |
| a dist tag | the tag asked for |
| `catalog:`, `workspace:`, an `npm:` alias, a path or git specifier | unchanged; the selector reaches the install as a preference only |

Closes pnpm/pnpm#14092.

This is a pacquet-only fix — the TypeScript CLI already behaves this way, verified by running the bundle side by side.

### Adjacent behaviour that is deliberately untouched

While checking the `catalog:` case against the TypeScript bundle, two things came up that are **not** changed here, so they don't get lost:

- `update <pkg>@<version>` on a cataloged dependency is governed by `catalogMode`, and both stacks agree: under the default `manual` the version is written directly (the `catalog:` reference is replaced), under `strict` a version outside the catalog range is rejected with `ERR_PNPM_CATALOG_VERSION_MISMATCH`, and under `strict`/`prefer` a covered version keeps the reference.
- The TypeScript CLI treats a cataloged dependency inconsistently between `pnpm update <pkg>@latest` (drops the `catalog:` reference, writes `^<version>`, leaves the catalog entry stale) and `pnpm update --latest` (keeps the reference and bumps the catalog entry, operator preserved). pacquet keeps the reference in both. Worth an issue against the TypeScript side rather than a behaviour change smuggled into this PR.

## Squash Commit Body

```text
An explicit `<name>@<tag>` update selector was saved into package.json
verbatim, so a manifest could declare `latest` while the lockfile held the
version behind it. Resolving through the `--latest` rewrite instead fixed
that only for `latest`: that path merges the declared range with the
`latest` tag, so `update <name>@canary` would have recorded whatever
`latest` names.

The selector's tag is now resolved on its own, and the version behind it
is what package.json records, keeping the range operator the entry already
declares. That version is also seeded as a resolution preference, so the
lockfile locks the tag's version rather than whatever else the recorded
range admits.

Only a declaration a version can round-trip is rewritten. An entry that
already tracks a dist tag keeps tracking one, and a `catalog:` reference,
a `workspace:` or `npm:` alias, and path or git specifiers stand — the
selector reaches those installs as a preference only.

Closes pnpm/pnpm#14092.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (pacquet-only: the TypeScript CLI already behaves this way.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updating dependencies with version ranges now preserves their existing range operators.
  * Dist-tag updates resolve to the appropriate version while preserving declared ranges and tag-based dependencies.
  * Catalog, workspace, alias, path, and Git references remain unchanged during updates.
  * Clear errors are now reported when an explicit dist-tag cannot be resolved.

* **Tests**
  * Added coverage for version ranges, dist-tags, catalog references, and targeted manifest updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->