### PR TITLE
fix(npm-resolver): drop build metadata from an exact version spec

### DIFF
--- a/.changeset/exact-version-build-metadata-resolves.md
+++ b/.changeset/exact-version-build-metadata-resolves.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+A dependency pinned to an exact version carrying semver build metadata (`"@parcel/codeframe": "2.0.0-canary.1718+d8408010f"`) installs again instead of failing with `ERR_PNPM_NO_MATCHING_VERSION` [#14096](https://github.com/pnpm/pnpm/issues/14096). npm drops build metadata when it publishes a version, so the metadata is dropped from the version that is looked up too, as npm and pnpm v11 do.

--- a/.changeset/exact-version-build-metadata-resolves.md
+++ b/.changeset/exact-version-build-metadata-resolves.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-A dependency pinned to an exact version carrying semver build metadata (`"@parcel/codeframe": "2.0.0-canary.1718+d8408010f"`) installs again instead of failing with `ERR_PNPM_NO_MATCHING_VERSION` [#14096](https://github.com/pnpm/pnpm/issues/14096). npm drops build metadata when it publishes a version, so the metadata is dropped from the version that is looked up too, as npm and pnpm v11 do.
+A dependency pinned to an exact version carrying semver build metadata (`"@parcel/codeframe": "2.0.0-canary.1718+d8408010f"`) installs again instead of failing with `ERR_PNPM_NO_MATCHING_VERSION` [#14096](https://github.com/pnpm/pnpm/issues/14096). npm strips build metadata when it publishes a version, so pnpm strips it from the version it looks up, matching npm and pnpm v11.

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -247,6 +247,86 @@ async fn exact_version_with_build_metadata_resolves_to_the_published_version() {
     assert_eq!(result.resolved_via, "npm-registry");
 }
 
+/// [`PACKAGE_BODY`] plus a published prerelease version, so the
+/// build-metadata-stripping regression test below can exercise the
+/// prerelease branch end-to-end: [`PACKAGE_BODY`] alone has no published
+/// prerelease, so a regression confined to that branch could pass
+/// [`exact_version_with_build_metadata_resolves_to_the_published_version`]
+/// above unnoticed.
+const PACKAGE_BODY_WITH_PRERELEASE: &str = r#"{
+    "name": "acme",
+    "dist-tags": { "latest": "1.1.0" },
+    "modified": "2025-01-15T12:00:00.000Z",
+    "time": {
+        "1.0.0": "2024-01-10T08:30:00.000Z",
+        "1.0.0-canary.1": "2024-01-05T08:30:00.000Z",
+        "1.1.0": "2024-12-10T08:30:00.000Z"
+    },
+    "versions": {
+        "1.0.0": {
+            "name": "acme",
+            "version": "1.0.0",
+            "dist": {
+                "integrity": "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+                "shasum": "0000000000000000000000000000000000000000",
+                "tarball": "https://registry/acme-1.0.0.tgz"
+            }
+        },
+        "1.0.0-canary.1": {
+            "name": "acme",
+            "version": "1.0.0-canary.1",
+            "dist": {
+                "integrity": "sha512-EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE==",
+                "shasum": "4444444444444444444444444444444444444444",
+                "tarball": "https://registry/acme-1.0.0-canary.1.tgz"
+            }
+        },
+        "1.1.0": {
+            "name": "acme",
+            "version": "1.1.0",
+            "dist": {
+                "integrity": "sha512-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB==",
+                "shasum": "1111111111111111111111111111111111111111",
+                "tarball": "https://registry/acme-1.1.0.tgz"
+            }
+        }
+    }
+}"#;
+
+#[tokio::test]
+async fn exact_prerelease_version_with_build_metadata_resolves_to_the_published_version() {
+    // Regression test for pnpm/pnpm#14096.
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_body(PACKAGE_BODY_WITH_PRERELEASE)
+        .create_async()
+        .await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    let prerelease_wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("1.0.0-canary.1+build1".to_string()),
+        ..WantedDependency::default()
+    };
+    let result =
+        resolver.resolve(&prerelease_wanted, &ResolveOptions::default()).await.unwrap().unwrap();
+    assert_eq!(result.id.as_str(), "acme@1.0.0-canary.1");
+    assert_eq!(result.resolved_via, "npm-registry");
+
+    let stable_wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("1.0.0+build1".to_string()),
+        ..WantedDependency::default()
+    };
+    let result =
+        resolver.resolve(&stable_wanted, &ResolveOptions::default()).await.unwrap().unwrap();
+    assert_eq!(result.id.as_str(), "acme@1.0.0");
+    assert_eq!(result.resolved_via, "npm-registry");
+}
+
 #[tokio::test]
 async fn package_version_guard_excludes_rejected_versions_and_repicks() {
     let mut server = mockito::Server::new_async().await;

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -32,10 +32,20 @@ const PACKAGE_BODY: &str = r#"{
     "dist-tags": { "latest": "1.1.0" },
     "modified": "2025-01-15T12:00:00.000Z",
     "time": {
+        "1.0.0-canary.1": "2024-01-05T08:30:00.000Z",
         "1.0.0": "2024-01-10T08:30:00.000Z",
         "1.1.0": "2024-12-10T08:30:00.000Z"
     },
     "versions": {
+        "1.0.0-canary.1": {
+            "name": "acme",
+            "version": "1.0.0-canary.1",
+            "dist": {
+                "integrity": "sha512-EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE==",
+                "shasum": "4444444444444444444444444444444444444444",
+                "tarball": "https://registry/acme-1.0.0-canary.1.tgz"
+            }
+        },
         "1.0.0": {
             "name": "acme",
             "version": "1.0.0",
@@ -228,103 +238,30 @@ async fn empty_specifier_resolves_to_the_max_published_version() {
     assert_eq!(result.resolved_via, "npm-registry");
 }
 
+/// Regression test for pnpm/pnpm#14096: npm strips build metadata when
+/// it publishes a version, so a selector carrying it must still resolve
+/// to the published version — for a prerelease as much as for a stable
+/// release.
 #[tokio::test]
 async fn exact_version_with_build_metadata_resolves_to_the_published_version() {
-    // Regression test for pnpm/pnpm#14096.
     let mut server = mockito::Server::new_async().await;
     let _mock =
         server.mock("GET", "/acme").with_status(200).with_body(PACKAGE_BODY).create_async().await;
     let registry = format!("{}/", server.url());
     let (resolver, _tempdir) = build_resolver(&registry);
 
-    let wanted = WantedDependency {
-        alias: Some("acme".to_string()),
-        bare_specifier: Some("1.0.0+build1".to_string()),
-        ..WantedDependency::default()
-    };
-    let result = resolver.resolve(&wanted, &ResolveOptions::default()).await.unwrap().unwrap();
-    assert_eq!(result.id.as_str(), "acme@1.0.0");
-    assert_eq!(result.resolved_via, "npm-registry");
-}
-
-/// [`PACKAGE_BODY`] plus a published prerelease version, so the
-/// build-metadata-stripping regression test below can exercise the
-/// prerelease branch end-to-end: [`PACKAGE_BODY`] alone has no published
-/// prerelease, so a regression confined to that branch could pass
-/// [`exact_version_with_build_metadata_resolves_to_the_published_version`]
-/// above unnoticed.
-const PACKAGE_BODY_WITH_PRERELEASE: &str = r#"{
-    "name": "acme",
-    "dist-tags": { "latest": "1.1.0" },
-    "modified": "2025-01-15T12:00:00.000Z",
-    "time": {
-        "1.0.0": "2024-01-10T08:30:00.000Z",
-        "1.0.0-canary.1": "2024-01-05T08:30:00.000Z",
-        "1.1.0": "2024-12-10T08:30:00.000Z"
-    },
-    "versions": {
-        "1.0.0": {
-            "name": "acme",
-            "version": "1.0.0",
-            "dist": {
-                "integrity": "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
-                "shasum": "0000000000000000000000000000000000000000",
-                "tarball": "https://registry/acme-1.0.0.tgz"
-            }
-        },
-        "1.0.0-canary.1": {
-            "name": "acme",
-            "version": "1.0.0-canary.1",
-            "dist": {
-                "integrity": "sha512-EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE==",
-                "shasum": "4444444444444444444444444444444444444444",
-                "tarball": "https://registry/acme-1.0.0-canary.1.tgz"
-            }
-        },
-        "1.1.0": {
-            "name": "acme",
-            "version": "1.1.0",
-            "dist": {
-                "integrity": "sha512-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB==",
-                "shasum": "1111111111111111111111111111111111111111",
-                "tarball": "https://registry/acme-1.1.0.tgz"
-            }
-        }
+    for (bare_specifier, expected_id) in
+        [("1.0.0+build1", "acme@1.0.0"), ("1.0.0-canary.1+build1", "acme@1.0.0-canary.1")]
+    {
+        let wanted = WantedDependency {
+            alias: Some("acme".to_string()),
+            bare_specifier: Some(bare_specifier.to_string()),
+            ..WantedDependency::default()
+        };
+        let result = resolver.resolve(&wanted, &ResolveOptions::default()).await.unwrap().unwrap();
+        assert_eq!(result.id.as_str(), expected_id, "for {bare_specifier:?}");
+        assert_eq!(result.resolved_via, "npm-registry", "for {bare_specifier:?}");
     }
-}"#;
-
-#[tokio::test]
-async fn exact_prerelease_version_with_build_metadata_resolves_to_the_published_version() {
-    // Regression test for pnpm/pnpm#14096.
-    let mut server = mockito::Server::new_async().await;
-    let _mock = server
-        .mock("GET", "/acme")
-        .with_status(200)
-        .with_body(PACKAGE_BODY_WITH_PRERELEASE)
-        .create_async()
-        .await;
-    let registry = format!("{}/", server.url());
-    let (resolver, _tempdir) = build_resolver(&registry);
-
-    let prerelease_wanted = WantedDependency {
-        alias: Some("acme".to_string()),
-        bare_specifier: Some("1.0.0-canary.1+build1".to_string()),
-        ..WantedDependency::default()
-    };
-    let result =
-        resolver.resolve(&prerelease_wanted, &ResolveOptions::default()).await.unwrap().unwrap();
-    assert_eq!(result.id.as_str(), "acme@1.0.0-canary.1");
-    assert_eq!(result.resolved_via, "npm-registry");
-
-    let stable_wanted = WantedDependency {
-        alias: Some("acme".to_string()),
-        bare_specifier: Some("1.0.0+build1".to_string()),
-        ..WantedDependency::default()
-    };
-    let result =
-        resolver.resolve(&stable_wanted, &ResolveOptions::default()).await.unwrap().unwrap();
-    assert_eq!(result.id.as_str(), "acme@1.0.0");
-    assert_eq!(result.resolved_via, "npm-registry");
 }
 
 #[tokio::test]

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -229,6 +229,25 @@ async fn empty_specifier_resolves_to_the_max_published_version() {
 }
 
 #[tokio::test]
+async fn exact_version_with_build_metadata_resolves_to_the_published_version() {
+    // Regression test for pnpm/pnpm#14096.
+    let mut server = mockito::Server::new_async().await;
+    let _mock =
+        server.mock("GET", "/acme").with_status(200).with_body(PACKAGE_BODY).create_async().await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("1.0.0+build1".to_string()),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, &ResolveOptions::default()).await.unwrap().unwrap();
+    assert_eq!(result.id.as_str(), "acme@1.0.0");
+    assert_eq!(result.resolved_via, "npm-registry");
+}
+
+#[tokio::test]
 async fn package_version_guard_excludes_rejected_versions_and_repicks() {
     let mut server = mockito::Server::new_async().await;
     let _mock =

--- a/pnpm/crates/resolving-npm-resolver/src/parse_bare_specifier.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/parse_bare_specifier.rs
@@ -274,9 +274,11 @@ pub fn parse_named_registry_specifier_to_registry_package_spec(
 
 /// Discriminate between an exact version, a semver range, and a
 /// dist-tag, returning the normalized form alongside the discriminator:
-/// version first, range second, tag last. Returns `None` only when the
-/// selector contains characters that `encodeURIComponent` would escape
-/// (i.e. not a valid npm tag).
+/// version first, range second, tag last. An exact version normalizes
+/// without its build metadata, since npm strips build metadata off a
+/// version when it publishes it. Returns `None` only when the selector
+/// contains characters that `encodeURIComponent` would escape (i.e. not
+/// a valid npm tag).
 pub(crate) fn get_version_selector_type(selector: &str) -> Option<VersionSelectorMatch> {
     if is_any_version_range(selector) {
         return Some(VersionSelectorMatch {
@@ -284,7 +286,8 @@ pub(crate) fn get_version_selector_type(selector: &str) -> Option<VersionSelecto
             normalized: ANY_VERSION_RANGE.to_string(),
         });
     }
-    if let Ok(version) = Version::parse(selector) {
+    if let Ok(mut version) = Version::parse(selector) {
+        version.build.clear();
         return Some(VersionSelectorMatch {
             spec_type: RegistryPackageSpecType::Version,
             normalized: version.to_string(),

--- a/pnpm/crates/resolving-npm-resolver/src/parse_bare_specifier/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/parse_bare_specifier/tests.rs
@@ -23,6 +23,21 @@ fn version_selector_classified_as_version() {
 }
 
 #[test]
+fn version_selector_drops_build_metadata() {
+    // pnpm/pnpm#14096: `@parcel/codeframe` is published as
+    // `2.0.0-canary.1718`, but dependents declare it as
+    // `2.0.0-canary.1718+d8408010f`.
+    for (selector, expected) in
+        [("1.0.0+build1", "1.0.0"), ("1.0.0-canary.1+build1", "1.0.0-canary.1")]
+    {
+        let spec = parse_bare_specifier(selector, Some("foo"), DEFAULT_TAG, REGISTRY)
+            .unwrap_or_else(|| panic!("expected a spec for {selector:?}"));
+        assert_eq!(spec.fetch_spec, expected, "for {selector:?}");
+        assert_eq!(spec.spec_type, RegistryPackageSpecType::Version, "for {selector:?}");
+    }
+}
+
+#[test]
 fn range_selector_classified_as_range() {
     let spec = parse_bare_specifier("^1.0.0", Some("foo"), DEFAULT_TAG, REGISTRY).unwrap();
     assert_eq!(spec.name, "foo");


### PR DESCRIPTION
## Summary

A dependency pinned to a bare exact version that carries semver build metadata, such as `"@parcel/codeframe": "2.0.0-canary.1718+d8408010f"`, failed with `ERR_PNPM_NO_MATCHING_VERSION`. `get_version_selector_type` normalized the exact version through `node_semver::Version`'s `Display`, which keeps the `+d8408010f` part, and that string is used as a literal key into the packument's `versions` map. npm strips build metadata when it publishes a version, so the key never matched. Clearing the build identifiers before formatting makes the lookup hit the published version, which is what `semver.valid()` gives the TypeScript CLI. Ranges were never affected, they go through the range branch and range satisfaction already ignores build metadata.

Fixes pnpm/pnpm#14096

## Squash Commit Body

```text
get_version_selector_type normalized an exact version selector with
node_semver::Version::to_string(), whose Display impl writes the build
identifiers back out. pick_package_from_meta uses that normalized string
as a literal key into the packument's versions map, and npm strips build
metadata off a version when it publishes it, so a selector like
1.0.0+build1 could never match and the resolver reported
ERR_PNPM_NO_MATCHING_VERSION.

The build identifiers are now cleared before the version is formatted,
matching semver.valid() / SemVer.version in the version-selector-type
package the TypeScript CLI uses, which excludes build metadata from its
normalized form. Range and dist-tag selectors take other branches and are
untouched.

Closes pnpm/pnpm#14096
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  The TypeScript CLI needs no change: `version-selector-type` already
  normalizes `1.0.0+build1` to `1.0.0`, so this is Rust-only and the
  changeset targets `pacquet`.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14097"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790071337&installation_model_id=426870&pr_number=14097&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14097&signature=5c2752e09b0e3dda87b76671f401d5360bff29514dc251b83dd4d230c83aa92b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Exact package versions containing semver build metadata, such as `1.0.0+build1`, now install successfully.
  * Build metadata is normalized during version resolution, matching npm behavior.
  * Prerelease versions with build metadata are also handled correctly.
  * Package resolution now works consistently for published versions that include build metadata in the requested version.
* **Tests**
  * Added coverage to verify resolution for exact and prerelease versions with build metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->