### PR TITLE
fix(pacquet): hard-fail dedupe on unmet peers when strictPeerDependencies is set

### DIFF
--- a/.changeset/dedupe-strict-peer-dependencies.md
+++ b/.changeset/dedupe-strict-peer-dependencies.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm dedupe` in the Rust engine now fails with `ERR_PNPM_PEER_DEP_ISSUES` when `strictPeerDependencies` is set and unresolved peer dependency issues remain after deduplication, matching the TypeScript CLI [#14099](https://github.com/pnpm/pnpm/issues/14099). Previously it only ever printed a warning, regardless of the setting.

--- a/pnpm/crates/cli/src/cli_args/dedupe.rs
+++ b/pnpm/crates/cli/src/cli_args/dedupe.rs
@@ -313,17 +313,15 @@ fn render_peer_dependency_issues_error(issues: &PeerIssuesReport) -> String {
     let mut hints = Vec::new();
     if issues.has_missing_peer {
         hints.push(
-            "hint: To auto-install peer dependencies, add the following to \"pnpm-workspace.yaml\" in your project root:\n\n  autoInstallPeers: true"
-                .to_string(),
+            "hint: To auto-install peer dependencies, add the following to \"pnpm-workspace.yaml\" in your project root:\n\n  autoInstallPeers: true",
         );
     }
     hints.push(
-        "hint: To disable failing on peer dependency issues, add the following to pnpm-workspace.yaml in your project root:\n\n  strictPeerDependencies: false"
-            .to_string(),
+        "hint: To disable failing on peer dependency issues, add the following to pnpm-workspace.yaml in your project root:\n\n  strictPeerDependencies: false",
     );
     let hints = hints.join("\n");
-    let body =
-        if issues.rendered.is_empty() { hints } else { format!("{}\n{hints}", issues.rendered) };
+    let rendered = issues.render();
+    let body = if rendered.is_empty() { hints } else { format!("{rendered}\n{hints}") };
     format!("[ERR_PNPM_PEER_DEP_ISSUES] Unmet peer dependencies\n\n{body}\n")
 }
 

--- a/pnpm/crates/cli/src/cli_args/dedupe.rs
+++ b/pnpm/crates/cli/src/cli_args/dedupe.rs
@@ -13,7 +13,10 @@ use crate::{
             TreeNode, blue_bright_underline, gray, green, plain, red, render_archy,
         },
         install::resolve_bool_override,
-        peers::peer_issues_warrant_warning,
+        peers::{
+            IssuesByProjects, peer_dependency_issues_exist, peer_dependency_issues_for_lockfile,
+            render_peer_issues,
+        },
     },
 };
 use clap::Args;
@@ -203,15 +206,23 @@ impl DedupeArgs {
         let deduped = parse_snapshot(current.as_deref(), lockfile_path);
 
         let lockfile_dir = lockfile_path.parent().unwrap_or_else(|| Path::new("."));
-        if let Some(deduped) = &deduped
-            && peer_issues_warrant_warning(deduped, lockfile_dir, &config.peer_dependency_rules)
-        {
-            Reporter::emit(&LogEvent::Global(GlobalLog {
-                level: LogLevel::Warn,
-                message:
-                    r#"Issues with peer dependencies found. Run "pnpm peers check" to list them."#
+        if let Some(deduped) = &deduped {
+            let peer_issues = peer_dependency_issues_for_lockfile(
+                deduped,
+                lockfile_dir,
+                &config.peer_dependency_rules,
+            );
+            if peer_dependency_issues_exist(&peer_issues) {
+                if config.strict_peer_dependencies {
+                    emit_peer_dependency_issues_error::<Reporter>(&peer_issues);
+                    return Err(DedupeError::PeerDependencyIssues.into());
+                }
+                Reporter::emit(&LogEvent::Global(GlobalLog {
+                    level: LogLevel::Warn,
+                    message: r#"Issues with peer dependencies found. Run "pnpm peers check" to list them."#
                         .to_string(),
-            }));
+                }));
+            }
         }
 
         if self.check {
@@ -239,6 +250,9 @@ enum DedupeError {
     #[display("Dedupe --check found changes to the lockfile")]
     #[diagnostic(code(ERR_PNPM_DEDUPE_CHECK_ISSUES))]
     CheckIssues,
+    #[display("Unmet peer dependencies")]
+    #[diagnostic(code(ERR_PNPM_PEER_DEP_ISSUES))]
+    PeerDependencyIssues,
 }
 
 struct DedupeResolutionReporter<Reporter> {
@@ -292,6 +306,17 @@ fn reusable_skipped_package_id(
     Ok(package_metadata_is_installable(package_key, metadata, installability_host)
         .into_diagnostic()?
         .then(|| package_key.pkg_id()))
+}
+
+fn emit_peer_dependency_issues_error<Reporter: self::Reporter>(issues: &IssuesByProjects) {
+    let message = "Unmet peer dependencies".to_string();
+    Reporter::emit(&LogEvent::Global(GlobalLog {
+        level: LogLevel::Error,
+        message: format!(
+            "[ERR_PNPM_PEER_DEP_ISSUES] {message}\n\n{}\nhint: To disable failing on peer dependency issues, add the following to pnpm-workspace.yaml in your project root:\n\n  strictPeerDependencies: false\n",
+            render_peer_issues(issues),
+        ),
+    }));
 }
 
 fn emit_dedupe_check_error<Reporter: self::Reporter>(diff: &LockfileDiff) {

--- a/pnpm/crates/cli/src/cli_args/dedupe.rs
+++ b/pnpm/crates/cli/src/cli_args/dedupe.rs
@@ -13,10 +13,7 @@ use crate::{
             TreeNode, blue_bright_underline, gray, green, plain, red, render_archy,
         },
         install::resolve_bool_override,
-        peers::{
-            IssuesByProjects, peer_dependency_issues_exist, peer_dependency_issues_for_lockfile,
-            render_peer_issues,
-        },
+        peers::{PeerIssuesReport, peer_issues_for_lockfile},
     },
 };
 use clap::Args;
@@ -206,23 +203,20 @@ impl DedupeArgs {
         let deduped = parse_snapshot(current.as_deref(), lockfile_path);
 
         let lockfile_dir = lockfile_path.parent().unwrap_or_else(|| Path::new("."));
-        if let Some(deduped) = &deduped {
-            let peer_issues = peer_dependency_issues_for_lockfile(
-                deduped,
-                lockfile_dir,
-                &config.peer_dependency_rules,
-            );
-            if peer_dependency_issues_exist(&peer_issues) {
-                if config.strict_peer_dependencies {
-                    emit_peer_dependency_issues_error::<Reporter>(&peer_issues);
-                    return Err(DedupeError::PeerDependencyIssues.into());
-                }
-                Reporter::emit(&LogEvent::Global(GlobalLog {
-                    level: LogLevel::Warn,
-                    message: r#"Issues with peer dependencies found. Run "pnpm peers check" to list them."#
-                        .to_string(),
-                }));
+        if let Some(deduped) = &deduped
+            && let Some(peer_issues) =
+                peer_issues_for_lockfile(deduped, lockfile_dir, &config.peer_dependency_rules)
+        {
+            if config.strict_peer_dependencies {
+                emit_peer_dependency_issues_error::<Reporter>(&peer_issues);
+                return Err(DedupeError::PeerDependencyIssues.into());
             }
+            Reporter::emit(&LogEvent::Global(GlobalLog {
+                level: LogLevel::Warn,
+                message:
+                    r#"Issues with peer dependencies found. Run "pnpm peers check" to list them."#
+                        .to_string(),
+            }));
         }
 
         if self.check {
@@ -308,15 +302,29 @@ fn reusable_skipped_package_id(
         .then(|| package_key.pkg_id()))
 }
 
-fn emit_peer_dependency_issues_error<Reporter: self::Reporter>(issues: &IssuesByProjects) {
-    let message = "Unmet peer dependencies".to_string();
+fn emit_peer_dependency_issues_error<Reporter: self::Reporter>(issues: &PeerIssuesReport) {
     Reporter::emit(&LogEvent::Global(GlobalLog {
         level: LogLevel::Error,
-        message: format!(
-            "[ERR_PNPM_PEER_DEP_ISSUES] {message}\n\n{}\nhint: To disable failing on peer dependency issues, add the following to pnpm-workspace.yaml in your project root:\n\n  strictPeerDependencies: false\n",
-            render_peer_issues(issues),
-        ),
+        message: render_peer_dependency_issues_error(issues),
     }));
+}
+
+fn render_peer_dependency_issues_error(issues: &PeerIssuesReport) -> String {
+    let mut hints = Vec::new();
+    if issues.has_missing_peer {
+        hints.push(
+            "hint: To auto-install peer dependencies, add the following to \"pnpm-workspace.yaml\" in your project root:\n\n  autoInstallPeers: true"
+                .to_string(),
+        );
+    }
+    hints.push(
+        "hint: To disable failing on peer dependency issues, add the following to pnpm-workspace.yaml in your project root:\n\n  strictPeerDependencies: false"
+            .to_string(),
+    );
+    let hints = hints.join("\n");
+    let body =
+        if issues.rendered.is_empty() { hints } else { format!("{}\n{hints}", issues.rendered) };
+    format!("[ERR_PNPM_PEER_DEP_ISSUES] Unmet peer dependencies\n\n{body}\n")
 }
 
 fn emit_dedupe_check_error<Reporter: self::Reporter>(diff: &LockfileDiff) {

--- a/pnpm/crates/cli/src/cli_args/peers.rs
+++ b/pnpm/crates/cli/src/cli_args/peers.rs
@@ -47,14 +47,14 @@ struct BadPeerIssue {
 }
 
 #[derive(Debug, Clone, Serialize)]
-struct PeerIssues {
+pub(crate) struct PeerIssues {
     bad: BTreeMap<String, Vec<BadPeerIssue>>,
     missing: BTreeMap<String, Vec<MissingPeerIssue>>,
     conflicts: Vec<String>,
     intersections: BTreeMap<String, String>,
 }
 
-type IssuesByProjects = BTreeMap<String, PeerIssues>;
+pub(crate) type IssuesByProjects = BTreeMap<String, PeerIssues>;
 
 #[derive(Debug, Args)]
 pub struct PeersArgs {
@@ -152,24 +152,28 @@ impl PeersArgs {
     }
 }
 
-/// Whether an install over `lockfile` should point the user at
-/// `pnpm peers check`. Mirrors pnpm's install-time gate: a bad peer, or a
-/// missing peer that at least one parent requires non-optionally, once
-/// `peerDependencyRules` have been applied.
+/// The same issue set `pnpm peers check` reports, filtered by
+/// `peerDependencyRules`, for an install's already-written lockfile.
 ///
 /// Every importer the lockfile records is checked, since an install writes
 /// them all — no workspace scan needed to name them.
-pub(crate) fn peer_issues_warrant_warning(
+pub(crate) fn peer_dependency_issues_for_lockfile(
     lockfile: &Lockfile,
     lockfile_dir: &std::path::Path,
     rules: &PeerDependencyRules,
-) -> bool {
+) -> IssuesByProjects {
     let mut importer_ids: Vec<String> = lockfile.importers.keys().cloned().collect();
     importer_ids.sort();
-    let issues = filter_peer_issues(
+    filter_peer_issues(
         check_peer_dependencies_of_importers(lockfile, lockfile_dir, &importer_ids),
         rules,
-    );
+    )
+}
+
+/// Whether `issues` is worth acting on: a bad peer, or a missing peer that
+/// at least one parent requires non-optionally. Mirrors pnpm's install-time
+/// gate.
+pub(crate) fn peer_dependency_issues_exist(issues: &IssuesByProjects) -> bool {
     issues.values().any(|project_issues| {
         !project_issues.bad.is_empty()
             || project_issues
@@ -1074,7 +1078,7 @@ fn parse_allowed_versions(
     (match_all, by_parent)
 }
 
-fn render_peer_issues(issues_by_projects: &IssuesByProjects) -> String {
+pub(crate) fn render_peer_issues(issues_by_projects: &IssuesByProjects) -> String {
     let mut sections: Vec<String> = Vec::new();
 
     for project_issues in issues_by_projects.values() {

--- a/pnpm/crates/cli/src/cli_args/peers.rs
+++ b/pnpm/crates/cli/src/cli_args/peers.rs
@@ -156,8 +156,17 @@ impl PeersArgs {
 /// acting on: a bad peer, or a missing peer that at least one parent
 /// requires non-optionally. Mirrors pnpm's install-time gate.
 pub(crate) struct PeerIssuesReport {
-    pub(crate) rendered: String,
+    issues: IssuesByProjects,
     pub(crate) has_missing_peer: bool,
+}
+
+impl PeerIssuesReport {
+    /// The listing `pnpm peers check` prints for the same issues. Empty
+    /// when every issue is one that listing leaves out — a missing peer no
+    /// parent conflicts over, say — so callers must handle an empty body.
+    pub(crate) fn render(&self) -> String {
+        render_peer_issues(&self.issues)
+    }
 }
 
 /// The same issue set `pnpm peers check` reports, filtered by
@@ -180,7 +189,7 @@ pub(crate) fn peer_issues_for_lockfile(
     });
     let has_issues =
         has_missing_peer || issues.values().any(|project_issues| !project_issues.bad.is_empty());
-    has_issues.then(|| PeerIssuesReport { rendered: render_peer_issues(&issues), has_missing_peer })
+    has_issues.then_some(PeerIssuesReport { issues, has_missing_peer })
 }
 
 fn check_peer_dependencies_from_lockfile(

--- a/pnpm/crates/cli/src/cli_args/peers.rs
+++ b/pnpm/crates/cli/src/cli_args/peers.rs
@@ -47,14 +47,14 @@ struct BadPeerIssue {
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub(crate) struct PeerIssues {
+struct PeerIssues {
     bad: BTreeMap<String, Vec<BadPeerIssue>>,
     missing: BTreeMap<String, Vec<MissingPeerIssue>>,
     conflicts: Vec<String>,
     intersections: BTreeMap<String, String>,
 }
 
-pub(crate) type IssuesByProjects = BTreeMap<String, PeerIssues>;
+type IssuesByProjects = BTreeMap<String, PeerIssues>;
 
 #[derive(Debug, Args)]
 pub struct PeersArgs {
@@ -152,35 +152,35 @@ impl PeersArgs {
     }
 }
 
+/// [`peer_issues_for_lockfile`]'s result when the lockfile has issues worth
+/// acting on: a bad peer, or a missing peer that at least one parent
+/// requires non-optionally. Mirrors pnpm's install-time gate.
+pub(crate) struct PeerIssuesReport {
+    pub(crate) rendered: String,
+    pub(crate) has_missing_peer: bool,
+}
+
 /// The same issue set `pnpm peers check` reports, filtered by
-/// `peerDependencyRules`, for an install's already-written lockfile.
+/// `peerDependencyRules`, for every importer the lockfile records.
 ///
-/// Every importer the lockfile records is checked, since an install writes
-/// them all — no workspace scan needed to name them.
-pub(crate) fn peer_dependency_issues_for_lockfile(
+/// Returns `None` when there is nothing worth acting on.
+pub(crate) fn peer_issues_for_lockfile(
     lockfile: &Lockfile,
     lockfile_dir: &std::path::Path,
     rules: &PeerDependencyRules,
-) -> IssuesByProjects {
+) -> Option<PeerIssuesReport> {
     let mut importer_ids: Vec<String> = lockfile.importers.keys().cloned().collect();
     importer_ids.sort();
-    filter_peer_issues(
+    let issues = filter_peer_issues(
         check_peer_dependencies_of_importers(lockfile, lockfile_dir, &importer_ids),
         rules,
-    )
-}
-
-/// Whether `issues` is worth acting on: a bad peer, or a missing peer that
-/// at least one parent requires non-optionally. Mirrors pnpm's install-time
-/// gate.
-pub(crate) fn peer_dependency_issues_exist(issues: &IssuesByProjects) -> bool {
-    issues.values().any(|project_issues| {
-        !project_issues.bad.is_empty()
-            || project_issues
-                .missing
-                .values()
-                .any(|entries| entries.iter().any(|entry| !entry.optional))
-    })
+    );
+    let has_missing_peer = issues.values().any(|project_issues| {
+        project_issues.missing.values().any(|entries| entries.iter().any(|entry| !entry.optional))
+    });
+    let has_issues =
+        has_missing_peer || issues.values().any(|project_issues| !project_issues.bad.is_empty());
+    has_issues.then(|| PeerIssuesReport { rendered: render_peer_issues(&issues), has_missing_peer })
 }
 
 fn check_peer_dependencies_from_lockfile(
@@ -1078,7 +1078,7 @@ fn parse_allowed_versions(
     (match_all, by_parent)
 }
 
-pub(crate) fn render_peer_issues(issues_by_projects: &IssuesByProjects) -> String {
+fn render_peer_issues(issues_by_projects: &IssuesByProjects) -> String {
     let mut sections: Vec<String> = Vec::new();
 
     for project_issues in issues_by_projects.values() {

--- a/pnpm/crates/cli/src/lib.rs
+++ b/pnpm/crates/cli/src/lib.rs
@@ -53,7 +53,9 @@ fn is_reported_error(error: &miette::Report) -> bool {
     error.code().is_some_and(|code| {
         matches!(
             code.to_string().as_str(),
-            "ERR_PNPM_DEDUPE_CHECK_ISSUES" | cli_args::recursive::NO_MATCHING_PROJECTS_CODE,
+            "ERR_PNPM_DEDUPE_CHECK_ISSUES"
+                | "ERR_PNPM_PEER_DEP_ISSUES"
+                | cli_args::recursive::NO_MATCHING_PROJECTS_CODE,
         )
     })
 }

--- a/pnpm/crates/cli/tests/suite/dedupe.rs
+++ b/pnpm/crates/cli/tests/suite/dedupe.rs
@@ -268,6 +268,8 @@ fn dedupe_fails_on_peer_dependency_issues_when_strict() {
     let stdout = String::from_utf8(output.stdout).expect("stdout is UTF-8");
     assert!(stdout.contains("ERR_PNPM_PEER_DEP_ISSUES"), "stdout:\n{stdout}");
     assert!(stdout.contains("Unmet peer dependencies"), "stdout:\n{stdout}");
+    assert!(stdout.contains("@pnpm.e2e/foo"), "stdout:\n{stdout}");
+    assert!(stdout.contains("Wanted:"), "stdout:\n{stdout}");
     assert!(stdout.contains("strictPeerDependencies: false"), "stdout:\n{stdout}");
 
     let lockfile_path = workspace.join("pnpm-lock.yaml");

--- a/pnpm/crates/cli/tests/suite/dedupe.rs
+++ b/pnpm/crates/cli/tests/suite/dedupe.rs
@@ -271,9 +271,47 @@ fn dedupe_fails_on_peer_dependency_issues_when_strict() {
     assert!(stdout.contains("@pnpm.e2e/foo"), "stdout:\n{stdout}");
     assert!(stdout.contains("Wanted:"), "stdout:\n{stdout}");
     assert!(stdout.contains("strictPeerDependencies: false"), "stdout:\n{stdout}");
+    assert!(!stdout.contains("autoInstallPeers: true"), "stdout:\n{stdout}");
 
     let lockfile_path = workspace.join("pnpm-lock.yaml");
     assert!(lockfile_path.exists(), "dedupe still writes the lockfile before failing");
+
+    drop((root, mock_instance));
+}
+
+/// A peer nothing installed at all also earns the `autoInstallPeers` hint,
+/// which the bad-peer failure above leaves out.
+#[test]
+fn dedupe_strict_failure_hints_at_auto_install_peers_for_a_missing_peer() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        "strictPeerDependencies: true\nautoInstallPeers: false\n",
+    )
+    .expect("write pnpm-workspace.yaml");
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/has-foo100-peer": "1.0.0",
+            },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    let output = pacquet.with_arg("dedupe").output().expect("run pnpm dedupe");
+    assert!(
+        !output.status.success(),
+        "dedupe must fail when strictPeerDependencies is true: {output:?}",
+    );
+    let stdout = String::from_utf8(output.stdout).expect("stdout is UTF-8");
+    assert!(stdout.contains("missing peer"), "stdout:\n{stdout}");
+    assert!(stdout.contains("autoInstallPeers: true"), "stdout:\n{stdout}");
+    assert!(stdout.contains("strictPeerDependencies: false"), "stdout:\n{stdout}");
 
     drop((root, mock_instance));
 }

--- a/pnpm/crates/cli/tests/suite/dedupe.rs
+++ b/pnpm/crates/cli/tests/suite/dedupe.rs
@@ -237,6 +237,45 @@ fn dedupe_warns_about_peer_dependency_issues() {
     drop((root, mock_instance));
 }
 
+/// `strictPeerDependencies: true` turns the same peer-dependency issues
+/// `dedupe_warns_about_peer_dependency_issues` only warns about into a hard
+/// failure, matching the TypeScript CLI's `ERR_PNPM_PEER_DEP_ISSUES`.
+#[test]
+fn dedupe_fails_on_peer_dependency_issues_when_strict() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(workspace.join("pnpm-workspace.yaml"), "strictPeerDependencies: true\n")
+        .expect("write pnpm-workspace.yaml");
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/has-foo100-peer": "1.0.0",
+                "@pnpm.e2e/foo": "2.0.0",
+            },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    let output = pacquet.with_arg("dedupe").output().expect("run pnpm dedupe");
+    assert!(
+        !output.status.success(),
+        "dedupe must fail when strictPeerDependencies is true: {output:?}",
+    );
+    let stdout = String::from_utf8(output.stdout).expect("stdout is UTF-8");
+    assert!(stdout.contains("ERR_PNPM_PEER_DEP_ISSUES"), "stdout:\n{stdout}");
+    assert!(stdout.contains("Unmet peer dependencies"), "stdout:\n{stdout}");
+    assert!(stdout.contains("strictPeerDependencies: false"), "stdout:\n{stdout}");
+
+    let lockfile_path = workspace.join("pnpm-lock.yaml");
+    assert!(lockfile_path.exists(), "dedupe still writes the lockfile before failing");
+
+    drop((root, mock_instance));
+}
+
 /// A `--check` run that would rewrite the lockfile reports what it would
 /// change, under pnpm's `ERR_PNPM_DEDUPE_CHECK_ISSUES`.
 #[test]

--- a/pnpm/crates/cli/tests/suite/dedupe.rs
+++ b/pnpm/crates/cli/tests/suite/dedupe.rs
@@ -238,8 +238,8 @@ fn dedupe_warns_about_peer_dependency_issues() {
 }
 
 /// `strictPeerDependencies: true` turns the same peer-dependency issues
-/// `dedupe_warns_about_peer_dependency_issues` only warns about into a hard
-/// failure, matching the TypeScript CLI's `ERR_PNPM_PEER_DEP_ISSUES`.
+/// [`dedupe_warns_about_peer_dependency_issues`] only warns about into a
+/// hard failure, matching the TypeScript CLI's `ERR_PNPM_PEER_DEP_ISSUES`.
 #[test]
 fn dedupe_fails_on_peer_dependency_issues_when_strict() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

pacquet's `pnpm dedupe` never hard-failed on peer dependency issues: `Install.peer_issues_sink` in `dedupe.rs` was hardcoded to `None`, and the only post-install handling was a `Warn` log gated on `peer_issues_warrant_warning`. `config.strict_peer_dependencies` was never read, so the command could not fail regardless of the setting. The TypeScript CLI's `dedupe` runs through the shared install pipeline's `reportPeerDependencyIssues`, which throws `ERR_PNPM_PEER_DEP_ISSUES` when `strictPeerDependencies` is true and issues remain.

`dedupe.rs` now checks `config.strict_peer_dependencies` against the same filtered issue set `pnpm peers check` computes (`peers.rs`'s `check_peer_dependencies_of_importers` / `filter_peer_issues`, now exposed as `peer_dependency_issues_for_lockfile`), and fails with `ERR_PNPM_PEER_DEP_ISSUES` instead of only warning, mirroring the existing `--check`/`DedupeError` pattern in the same file.

This is a pacquet-only fix. The maintainer triage on the issue confirmed the TypeScript CLI already hard-fails correctly and that the same `peer_issues_sink: None` gap in `install.rs`/`add.rs`/`update.rs` is broader than this issue's scope.

Fixes pnpm/pnpm#14099.

## Squash Commit Body

```text
pacquet's dedupe never hard-failed on peer dependency issues: Install.peer_issues_sink
in dedupe.rs was hardcoded to None, and the only post-install handling was a Warn log.
config.strict_peer_dependencies was never read, so the command could not fail regardless
of the setting, unlike the TypeScript CLI's dedupe, which throws ERR_PNPM_PEER_DEP_ISSUES
via reportPeerDependencyIssues.

dedupe.rs now checks strict_peer_dependencies against the same filtered peer issue set
pnpm peers check computes, and fails with ERR_PNPM_PEER_DEP_ISSUES instead of only
warning, reusing the existing --check/DedupeError pattern in the same file.

Fixes pnpm/pnpm#14099.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790074916&installation_model_id=426870&pr_number=14102&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14102&signature=7fea70f446cfc6195eb5fc809afa28f3c32b3a6b891f30aacc216f59f1dc0692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `pnpm dedupe` now fails with `ERR_PNPM_PEER_DEP_ISSUES` when strict peer dependency issues remain unresolved.
  * Error output includes detailed peer dependency information and guidance, including suggestions for missing peers and strict-mode configuration.
  * In non-strict mode, existing warning behavior is preserved.
  * The lockfile is still written before the command reports failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->