### PR TITLE
feat(cli): implement flagged pacquet parity gaps

### DIFF
--- a/.changeset/bright-pandas-approve.md
+++ b/.changeset/bright-pandas-approve.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/building.commands": minor
+"pnpm": minor
+"pacquet": minor
+---
+
+Added global build approvals [pnpm/pnpm#14101](https://github.com/pnpm/pnpm/issues/14101).

--- a/.changeset/calm-ravens-outdated.md
+++ b/.changeset/calm-ravens-outdated.md
@@ -1,0 +1,5 @@
+---
+"pacquet": minor
+---
+
+Added recursive global outdated checks [pnpm/pnpm#14101](https://github.com/pnpm/pnpm/issues/14101).

--- a/.changeset/fuzzy-tigers-concurrency.md
+++ b/.changeset/fuzzy-tigers-concurrency.md
@@ -1,0 +1,5 @@
+---
+"pacquet": minor
+---
+
+Added bounded workspace concurrency for recursive run and exec commands [pnpm/pnpm#14101](https://github.com/pnpm/pnpm/issues/14101).

--- a/.changeset/quick-wolves-publish.md
+++ b/.changeset/quick-wolves-publish.md
@@ -1,7 +1,5 @@
 ---
-"@pnpm/building.commands": minor
-"pnpm": minor
 "pacquet": minor
 ---
 
-Added batch workspace publishing, global build approvals, recursive global outdated checks, bounded workspace run/exec concurrency, and SBOM generation with per-project lockfiles [pnpm/pnpm#14101](https://github.com/pnpm/pnpm/issues/14101).
+Added batch workspace publishing [pnpm/pnpm#14101](https://github.com/pnpm/pnpm/issues/14101).

--- a/.changeset/quick-wolves-publish.md
+++ b/.changeset/quick-wolves-publish.md
@@ -1,5 +1,7 @@
 ---
+"@pnpm/releasing.commands": patch
+"pnpm": patch
 "pacquet": minor
 ---
 
-Added batch workspace publishing [pnpm/pnpm#14101](https://github.com/pnpm/pnpm/issues/14101).
+Added batch workspace publishing to the Rust CLI. Batch publishing now accepts a scope-specific credential when it applies to every package in the request, and fails before publishing when packages targeting one registry resolve to different credentials [pnpm/pnpm#14101](https://github.com/pnpm/pnpm/issues/14101).

--- a/.changeset/quick-wolves-publish.md
+++ b/.changeset/quick-wolves-publish.md
@@ -4,4 +4,4 @@
 "pacquet": minor
 ---
 
-Added batch workspace publishing to the Rust CLI. Batch publishing accepts a common scope-specific credential, rejects mismatched credentials before publishing, and runs post-publish scripts after each completed registry group [pnpm/pnpm#14101](https://github.com/pnpm/pnpm/issues/14101).
+Batch workspace publishing accepts a shared scope-specific credential, rejects mismatched credentials for a registry before publishing, and runs the `publish` and `postpublish` scripts after each completed registry group [pnpm/pnpm#14101](https://github.com/pnpm/pnpm/issues/14101).

--- a/.changeset/quick-wolves-publish.md
+++ b/.changeset/quick-wolves-publish.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/building.commands": minor
+"pnpm": minor
+"pacquet": minor
+---
+
+Added batch workspace publishing, global build approvals, recursive global outdated checks, bounded workspace run/exec concurrency, and SBOM generation with per-project lockfiles [pnpm/pnpm#14101](https://github.com/pnpm/pnpm/issues/14101).

--- a/.changeset/quick-wolves-publish.md
+++ b/.changeset/quick-wolves-publish.md
@@ -4,4 +4,4 @@
 "pacquet": minor
 ---
 
-Added batch workspace publishing to the Rust CLI. Batch publishing now accepts a scope-specific credential when it applies to every package in the request, and fails before publishing when packages targeting one registry resolve to different credentials [pnpm/pnpm#14101](https://github.com/pnpm/pnpm/issues/14101).
+Added batch workspace publishing to the Rust CLI. Batch publishing accepts a common scope-specific credential, rejects mismatched credentials before publishing, and runs post-publish scripts after each completed registry group [pnpm/pnpm#14101](https://github.com/pnpm/pnpm/issues/14101).

--- a/.changeset/tidy-otters-sbom.md
+++ b/.changeset/tidy-otters-sbom.md
@@ -1,0 +1,5 @@
+---
+"pacquet": minor
+---
+
+Added filtered and split SBOM generation with per-project lockfiles [pnpm/pnpm#14101](https://github.com/pnpm/pnpm/issues/14101).

--- a/.changeset/tidy-otters-sbom.md
+++ b/.changeset/tidy-otters-sbom.md
@@ -2,4 +2,4 @@
 "pacquet": minor
 ---
 
-Added filtered and split SBOM generation with per-project lockfiles [pnpm/pnpm#14101](https://github.com/pnpm/pnpm/issues/14101).
+Added filtered and split SBOM generation with per-project lockfiles, including reachable workspace projects and incomplete-graph validation [pnpm/pnpm#14101](https://github.com/pnpm/pnpm/issues/14101).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1730,6 +1730,9 @@ importers:
       '@pnpm/workspace.projects-sorter':
         specifier: workspace:*
         version: link:../../workspace/projects-sorter
+      '@pnpm/workspace.workspace-manifest-reader':
+        specifier: workspace:*
+        version: link:../../workspace/workspace-manifest-reader
       chalk:
         specifier: 'catalog:'
         version: 6.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1706,6 +1706,9 @@ importers:
       '@pnpm/error':
         specifier: workspace:*
         version: link:../../core/error
+      '@pnpm/global.packages':
+        specifier: workspace:*
+        version: link:../../global/packages
       '@pnpm/installing.commands':
         specifier: workspace:*
         version: link:../../installing/commands
@@ -1730,6 +1733,9 @@ importers:
       chalk:
         specifier: 'catalog:'
         version: 6.0.0
+      is-subdir:
+        specifier: 'catalog:'
+        version: 2.0.0
       p-limit:
         specifier: 'catalog:'
         version: 7.3.1

--- a/pnpm/crates/cli/Cargo.toml
+++ b/pnpm/crates/cli/Cargo.toml
@@ -99,7 +99,7 @@ ssri                 = { workspace = true }
 tabled               = { workspace = true }
 tar                  = { workspace = true }
 tempfile             = { workspace = true }
-tokio                = { workspace = true }
+tokio                = { workspace = true, features = ["process"] }
 tracing              = { workspace = true }
 url                  = { workspace = true }
 which                = { workspace = true }

--- a/pnpm/crates/cli/src/cli_args/approve_builds.rs
+++ b/pnpm/crates/cli/src/cli_args/approve_builds.rs
@@ -24,7 +24,7 @@ pub struct ApproveBuildsArgs {
     #[clap(long)]
     pub all: bool,
 
-    /// Approve builds for globally installed packages (not supported yet).
+    /// Approve builds for globally installed packages.
     #[clap(short = 'g', long)]
     pub global: bool,
 }
@@ -33,15 +33,6 @@ pub struct ApproveBuildsArgs {
 /// `ERR_PNPM_APPROVE_BUILDS_*` set.
 #[derive(Debug, Display, Error, Diagnostic)]
 enum ApproveBuildsError {
-    #[display(r#""approve-builds" is not supported with global packages"#)]
-    #[diagnostic(
-        code(ERR_PNPM_APPROVE_BUILDS_NOT_SUPPORTED_WITH_GLOBAL),
-        help(
-            r#"Use --allow-build when installing globally, e.g. "pnpm add -g --allow-build=<pkg> <pkg>". pnpm will also prompt to allow builds interactively during global install."#
-        )
-    )]
-    NotSupportedWithGlobal,
-
     #[display("Cannot use --all with positional arguments")]
     #[diagnostic(code(ERR_PNPM_APPROVE_BUILDS_ALL_WITH_ARGS))]
     AllWithArgs,
@@ -53,6 +44,12 @@ enum ApproveBuildsError {
     #[display("The following packages are both approved and denied: {}", _0.join(", "))]
     #[diagnostic(code(ERR_PNPM_APPROVE_BUILDS_CONTRADICTING_ARGS))]
     ContradictingArgs(#[error(not(source))] Vec<String>),
+}
+
+pub(crate) struct ApprovalDecision {
+    pub(crate) build_packages: Vec<String>,
+    decisions: BTreeMap<String, bool>,
+    clear_all: bool,
 }
 
 impl ApproveBuildsArgs {
@@ -74,47 +71,47 @@ impl ApproveBuildsArgs {
         config: &(dyn Fn() -> miette::Result<&'static mut Config> + Sync),
         state: &(dyn Fn(bool) -> miette::Result<State> + Sync),
     ) -> miette::Result<Option<(State, Vec<String>)>> {
-        let ApproveBuildsArgs { packages, all, global } = self;
-
-        if global {
-            return Err(ApproveBuildsError::NotSupportedWithGlobal.into());
-        }
-        if all && !packages.is_empty() {
-            return Err(ApproveBuildsError::AllWithArgs.into());
-        }
-
+        self.validate()?;
         let initial_config: &Config = config()?;
         let scan = get_automatically_ignored_builds(initial_config)?;
         let Some(pending) = scan.names.filter(|names| !names.is_empty()) else {
             println!("There are no packages awaiting approval");
             return Ok(None);
         };
+        let Some(decision) = self.decide(&pending)? else {
+            return Ok(None);
+        };
 
-        let (approved, denied) = partition_params(&packages, &pending)?;
+        let settings_dir =
+            initial_config.workspace_dir.clone().unwrap_or_else(|| dir.to_path_buf());
+        write_approval_settings(&settings_dir, &decision)?;
+        clear_decided_ignored_builds(scan.modules_manifest, &scan.modules_dir, &decision)?;
 
-        // The packages to build: explicit approvals, every pending package
-        // under `--all`, or the interactive selection otherwise.
+        if decision.build_packages.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some((state(true)?, decision.build_packages)))
+    }
+
+    pub(crate) fn decide(self, pending: &[String]) -> miette::Result<Option<ApprovalDecision>> {
+        self.validate()?;
+        let ApproveBuildsArgs { packages, all, global: _ } = self;
+
+        let (approved, denied) = partition_params(&packages, pending)?;
         let build_packages: Vec<String> = if !packages.is_empty() {
             sort_unique(approved.clone())
         } else if all {
-            sort_unique(pending.clone())
+            sort_unique(pending.to_owned())
         } else {
-            let Some(selected) = prompt_for_builds(&pending)? else {
-                // The prompt was interrupted (Esc / Ctrl-C); leave
-                // everything untouched, matching pnpm's `ExitPromptError`
-                // early exit.
+            let Some(selected) = prompt_for_builds(pending)? else {
                 return Ok(None);
             };
             selected
         };
 
-        // The `allowBuilds` entries to write: each decided package mapped to
-        // `true` (build) or `false` (skip). In interactive / `--all` mode
-        // every pending package is decided, so unselected ones are recorded
-        // as `false`.
         let mut decisions: BTreeMap<String, bool> = BTreeMap::new();
         if packages.is_empty() {
-            for pkg in &pending {
+            for pkg in pending {
                 decisions.insert(pkg.clone(), build_packages.contains(pkg));
             }
         } else {
@@ -134,29 +131,26 @@ impl ApproveBuildsArgs {
             }
         }
 
-        let settings_dir =
-            initial_config.workspace_dir.clone().unwrap_or_else(|| dir.to_path_buf());
-        set_allow_builds_clearing_legacy(
-            &settings_dir,
-            decisions.iter().map(|(pkg, &value)| (pkg.as_str(), value)),
-        )
-        .into_diagnostic()?;
-
-        clear_decided_ignored_builds(
-            scan.modules_manifest,
-            &scan.modules_dir,
-            &packages,
-            &approved,
-            &denied,
-        )?;
-
-        if build_packages.is_empty() {
-            return Ok(None);
-        }
-        // Build state from a freshly loaded config so the rebuild's
-        // allow-build policy reflects the `allowBuilds` just written.
-        Ok(Some((state(true)?, build_packages)))
+        Ok(Some(ApprovalDecision { build_packages, decisions, clear_all: packages.is_empty() }))
     }
+
+    pub(crate) fn validate(&self) -> miette::Result<()> {
+        if self.all && !self.packages.is_empty() {
+            return Err(ApproveBuildsError::AllWithArgs.into());
+        }
+        Ok(())
+    }
+}
+
+pub(crate) fn write_approval_settings(
+    settings_dir: &Path,
+    decision: &ApprovalDecision,
+) -> miette::Result<()> {
+    set_allow_builds_clearing_legacy(
+        settings_dir,
+        decision.decisions.iter().map(|(pkg, &value)| (pkg.as_str(), value)),
+    )
+    .into_diagnostic()
 }
 
 /// Split `params` into approved (`<pkg>`) and denied (`!<pkg>`) names,
@@ -225,12 +219,10 @@ fn confirm_builds(build_packages: &[String]) -> miette::Result<bool> {
 /// later `ignored-builds` / install no longer reports them. With positional
 /// arguments only the decided (approved + denied) packages are removed,
 /// preserving the still-pending ones; otherwise every entry is cleared.
-fn clear_decided_ignored_builds(
+pub(crate) fn clear_decided_ignored_builds(
     modules_manifest: Option<pnpm_modules_yaml::Modules>,
     modules_dir: &Path,
-    params: &[String],
-    approved: &[String],
-    denied: &[String],
+    decision: &ApprovalDecision,
 ) -> miette::Result<()> {
     let Some(mut modules) = modules_manifest else {
         return Ok(());
@@ -238,11 +230,10 @@ fn clear_decided_ignored_builds(
     if modules.ignored_builds.is_none() {
         return Ok(());
     }
-    if params.is_empty() {
+    if decision.clear_all {
         modules.ignored_builds = None;
     } else {
-        let decided: HashSet<&str> =
-            approved.iter().chain(denied.iter()).map(String::as_str).collect();
+        let decided: HashSet<&str> = decision.decisions.keys().map(String::as_str).collect();
         if let Some(ignored) = modules.ignored_builds.as_mut() {
             ignored.retain(|dep_path| {
                 !decided.contains(allow_build_key_from_ignored_build(dep_path.as_str()).as_str())

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -511,6 +511,7 @@ impl CliArgs {
         if matches!(
             self.command,
             CliCommand::Run(_)
+                | CliCommand::Exec(_)
                 | CliCommand::External(_)
                 | CliCommand::Test(_)
                 | CliCommand::Start(_)

--- a/pnpm/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_install.rs
@@ -706,6 +706,20 @@ pub(super) fn approve_builds<'a>(
     ctx: &RunCtx<'a>,
     args: ApproveBuildsArgs,
 ) -> miette::Result<CommandFuture<'a>> {
+    if args.global {
+        let config = (ctx.global_config)()?;
+        return Ok(match ctx.reporter {
+            ReporterType::Default | ReporterType::AppendOnly => {
+                Box::pin(global::approve_global_builds::<DefaultReporter>(config, args))
+            }
+            ReporterType::Ndjson => {
+                Box::pin(global::approve_global_builds::<NdjsonReporter>(config, args))
+            }
+            ReporterType::Silent => {
+                Box::pin(global::approve_global_builds::<SilentReporter>(config, args))
+            }
+        });
+    }
     // The settings/prompt work is synchronous; only the rebuild is async, so
     // the non-`Send` `config` / `state` closures stay out of the awaited
     // future.

--- a/pnpm/crates/cli/src/cli_args/dispatch_script.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_script.rs
@@ -114,14 +114,16 @@ pub(super) fn fallback<'a>(
 }
 
 pub(super) fn exec<'a>(ctx: &RunCtx<'a>, args: ExecArgs) -> miette::Result<CommandFuture<'a>> {
-    let config = (ctx.config)()?;
+    let config: &'static Config = (ctx.config)()?;
     let args = with_recursive_exec_options(ctx, args, config);
     if ctx.recursive {
-        args.run_recursive(config, ctx.dir, reporter_emit(ctx.reporter))?;
+        let dir = ctx.dir;
+        let emit = reporter_emit(ctx.reporter);
+        Ok(Box::pin(async move { args.run_recursive(config, dir, emit).await }))
     } else {
         args.run(ctx.dir, config)?;
+        Ok(Box::pin(std::future::ready(Ok(()))))
     }
-    Ok(Box::pin(std::future::ready(Ok(()))))
 }
 
 fn with_recursive_run_options(ctx: &RunCtx<'_>, mut args: RunArgs, config: &Config) -> RunArgs {

--- a/pnpm/crates/cli/src/cli_args/dispatch_script.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_script.rs
@@ -141,6 +141,7 @@ fn with_recursive_exec_options(ctx: &RunCtx<'_>, mut args: ExecArgs, config: &Co
     args.no_bail = !config.bail;
     args.sort = config.sort;
     args.reverse = config.reverse;
+    args.parallel = ctx.recursive_parallel;
     args
 }
 

--- a/pnpm/crates/cli/src/cli_args/exec.rs
+++ b/pnpm/crates/cli/src/cli_args/exec.rs
@@ -186,9 +186,11 @@ pub(super) async fn spawn_async_in_dir(
     shell_mode: bool,
     output: ScriptOutput<'_>,
 ) -> Result<ExitStatus, ExecError> {
-    let mut cmd = command_in_dir(command, dir, config, shell_mode)?;
+    let cmd = command_in_dir(command, dir, config, shell_mode)?;
+    let mut cmd = tokio::process::Command::from(cmd);
+    cmd.kill_on_drop(true);
     let ScriptOutput::Streamed { dep_path, emit } = output else {
-        return tokio::process::Command::from(cmd)
+        return cmd
             .status()
             .await
             .map_err(|source| ExecError::Spawn { command: command[0].clone(), source });
@@ -196,9 +198,8 @@ pub(super) async fn spawn_async_in_dir(
     let wd = dir.to_string_lossy();
     let streamed = StreamedScript { dep_path, stage: EXEC_STAGE, wd: &wd, emit };
     cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
-    let mut child = tokio::process::Command::from(cmd)
-        .spawn()
-        .map_err(|source| ExecError::Spawn { command: command[0].clone(), source })?;
+    let mut child =
+        cmd.spawn().map_err(|source| ExecError::Spawn { command: command[0].clone(), source })?;
     let status = streamed
         .pump_async(&mut child)
         .await

--- a/pnpm/crates/cli/src/cli_args/exec.rs
+++ b/pnpm/crates/cli/src/cli_args/exec.rs
@@ -114,14 +114,14 @@ impl ExecArgs {
     /// Execute the command across the `--filter`-selected workspace
     /// projects, in topological order. The recursive counterpart of
     /// [`Self::run`], selected when the global `-r` / `--recursive` flag is set.
-    pub fn run_recursive(
+    pub async fn run_recursive(
         &self,
         config: &Config,
         dir: &Path,
         emit: fn(&LogEvent),
     ) -> miette::Result<()> {
         super::verify_deps::verify_deps_before_run(dir, config, false)?;
-        recursive::exec_recursive(self, config, dir, emit)
+        recursive::exec_recursive(self, config, dir, emit).await
     }
 }
 
@@ -159,6 +159,60 @@ pub(super) fn spawn_in_dir(
     shell_mode: bool,
     output: ScriptOutput<'_>,
 ) -> Result<ExitStatus, ExecError> {
+    let mut cmd = command_in_dir(command, dir, config, shell_mode)?;
+    let ScriptOutput::Streamed { dep_path, emit } = output else {
+        return cmd
+            .status()
+            .map_err(|source| ExecError::Spawn { command: command[0].clone(), source });
+    };
+    let wd = dir.to_string_lossy();
+    let streamed = StreamedScript { dep_path, stage: EXEC_STAGE, wd: &wd, emit };
+    let mut child = cmd
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|source| ExecError::Spawn { command: command[0].clone(), source })?;
+    let status = streamed
+        .pump(&mut child)
+        .map_err(|source| ExecError::Spawn { command: command[0].clone(), source })?;
+    streamed.finished(status.code().unwrap_or(-1));
+    Ok(status)
+}
+
+pub(super) async fn spawn_async_in_dir(
+    command: &[String],
+    dir: &Path,
+    config: &Config,
+    shell_mode: bool,
+    output: ScriptOutput<'_>,
+) -> Result<ExitStatus, ExecError> {
+    let mut cmd = command_in_dir(command, dir, config, shell_mode)?;
+    let ScriptOutput::Streamed { dep_path, emit } = output else {
+        return tokio::process::Command::from(cmd)
+            .status()
+            .await
+            .map_err(|source| ExecError::Spawn { command: command[0].clone(), source });
+    };
+    let wd = dir.to_string_lossy();
+    let streamed = StreamedScript { dep_path, stage: EXEC_STAGE, wd: &wd, emit };
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let mut child = tokio::process::Command::from(cmd)
+        .spawn()
+        .map_err(|source| ExecError::Spawn { command: command[0].clone(), source })?;
+    let status = streamed
+        .pump_async(&mut child)
+        .await
+        .map_err(|source| ExecError::Spawn { command: command[0].clone(), source })?;
+    streamed.finished(status.code().unwrap_or(-1));
+    Ok(status)
+}
+
+fn command_in_dir(
+    command: &[String],
+    dir: &Path,
+    config: &Config,
+    shell_mode: bool,
+) -> Result<Command, ExecError> {
     // Prepend `./node_modules/.bin` (resolved against the project
     // directory) and then the `extraBinPaths`.
     let mut prepend = Vec::with_capacity(1 + config.extra_bin_paths.len());
@@ -218,25 +272,7 @@ pub(super) fn spawn_in_dir(
         cmd.env("NODE_OPTIONS", node_options);
     }
 
-    let ScriptOutput::Streamed { dep_path, emit } = output else {
-        return cmd
-            .status()
-            .map_err(|source| ExecError::Spawn { command: command[0].clone(), source });
-    };
-    // pnpm labels an exec'd command with a `(exec)` stage rather than a
-    // script name, since there is no script.
-    let wd = dir.to_string_lossy();
-    let streamed = StreamedScript { dep_path, stage: EXEC_STAGE, wd: &wd, emit };
-    let mut child = cmd
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(|source| ExecError::Spawn { command: command[0].clone(), source })?;
-    let status = streamed
-        .pump(&mut child)
-        .map_err(|source| ExecError::Spawn { command: command[0].clone(), source })?;
-    streamed.finished(status.code().unwrap_or(-1));
-    Ok(status)
+    Ok(cmd)
 }
 
 /// The `stage` pnpm stamps on the lifecycle events of an exec'd command.

--- a/pnpm/crates/cli/src/cli_args/exec.rs
+++ b/pnpm/crates/cli/src/cli_args/exec.rs
@@ -54,6 +54,10 @@ pub struct ExecArgs {
     /// Reverse the project order of a recursive exec.
     #[clap(skip = true)]
     pub reverse: bool,
+
+    /// Run every selected project concurrently, without a concurrency cap.
+    #[clap(skip = true)]
+    pub parallel: bool,
 }
 
 /// Errors from `pacquet exec`.

--- a/pnpm/crates/cli/src/cli_args/exec/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/exec/recursive.rs
@@ -11,7 +11,9 @@
 //! reversed under `--reverse`, and run with `workspaceConcurrency` operations
 //! in flight within each dependency-independent chunk.
 
-use super::{ExecArgs, prepare_command, read_package_name, spawn_in_dir};
+use super::{
+    ExecArgs, ExecError, prepare_command, read_package_name, spawn_async_in_dir, spawn_in_dir,
+};
 use crate::cli_args::recursive::{
     AutoExcludeRoot, ExecutionStatus, Status, count_failures, discover_workspace_projects,
     get_resumed_package_chunks, run_workspace_chunk, select_recursive_projects,
@@ -63,7 +65,7 @@ struct ProjectExecution {
 /// workspace root (and the directory the summary is written to) is
 /// `config.workspace_dir`, falling back to `dir` when no
 /// `pnpm-workspace.yaml` exists.
-pub fn exec_recursive(
+pub async fn exec_recursive(
     args: &ExecArgs,
     config: &Config,
     dir: &Path,
@@ -120,45 +122,35 @@ pub fn exec_recursive(
         chunks.iter().flatten().map(|root| (root.clone(), ExecutionStatus::queued())).collect();
 
     for chunk in &chunks {
-        let workspace_concurrency =
-            if args.parallel { u32::MAX } else { config.workspace_concurrency };
-        let concurrency = usize::try_from(workspace_concurrency).unwrap_or(usize::MAX).max(1);
+        let concurrency = if args.parallel {
+            chunk.len().max(1)
+        } else {
+            usize::try_from(config.workspace_concurrency).unwrap_or(usize::MAX).max(1)
+        };
         let batch_size = if bail { concurrency } else { chunk.len().max(1) };
         for batch in chunk.chunks(batch_size) {
             for root in batch {
                 result[root].status = Status::Running;
             }
-            let executions = run_workspace_chunk(batch, workspace_concurrency, |root| {
-                let start = Instant::now();
-                let dep_path = show_prefix.then(|| {
-                    read_package_name(root).unwrap_or_else(|| {
-                        pathdiff::diff_paths(root, dir)
-                            .unwrap_or_else(|| root.to_path_buf())
-                            .to_string_lossy()
-                            .into_owned()
-                    })
-                });
-                let output = match &dep_path {
-                    Some(dep_path) => ScriptOutput::Streamed { dep_path, emit },
-                    None => ScriptOutput::Inherit,
-                };
-                // A spawn / resolution error (e.g. command not found) is a
-                // per-project failure rather than a hard error: the error is
-                // recorded and the loop bails or continues like any other
-                // non-zero result.
-                let outcome = spawn_in_dir(&command, root, config, args.shell_mode, output);
-                let duration = start.elapsed().as_secs_f64() * 1e3;
-
-                let message = match outcome {
-                    Ok(status) if status.success() => None,
-                    Ok(status) => Some(format!(
-                        "command failed with exit code {}",
-                        status.code().unwrap_or(1),
-                    )),
-                    Err(error) => Some(error.to_string()),
-                };
-                ProjectExecution { duration, message }
-            })?;
+            let executions = if args.parallel {
+                futures_util::future::join_all(batch.iter().map(|root| async {
+                    let start = Instant::now();
+                    let dep_path = project_dep_path(root, dir, show_prefix);
+                    let output = project_output(dep_path.as_deref(), emit);
+                    let outcome =
+                        spawn_async_in_dir(&command, root, config, args.shell_mode, output).await;
+                    project_execution(start, outcome)
+                }))
+                .await
+            } else {
+                run_workspace_chunk(batch, config.workspace_concurrency, |root| {
+                    let start = Instant::now();
+                    let dep_path = project_dep_path(root, dir, show_prefix);
+                    let output = project_output(dep_path.as_deref(), emit);
+                    let outcome = spawn_in_dir(&command, root, config, args.shell_mode, output);
+                    project_execution(start, outcome)
+                })?
+            };
             let mut first_failure = None;
             for (root, execution) in batch.iter().zip(executions) {
                 let prefix = root.to_string_lossy().into_owned();
@@ -194,4 +186,35 @@ pub fn exec_recursive(
         return Err(RecursiveExecError::RecursiveFail { count: failures }.into());
     }
     Ok(())
+}
+
+fn project_dep_path(root: &Path, dir: &Path, show_prefix: bool) -> Option<String> {
+    show_prefix.then(|| {
+        read_package_name(root).unwrap_or_else(|| {
+            pathdiff::diff_paths(root, dir)
+                .unwrap_or_else(|| root.to_path_buf())
+                .to_string_lossy()
+                .into_owned()
+        })
+    })
+}
+
+fn project_output(dep_path: Option<&str>, emit: fn(&LogEvent)) -> ScriptOutput<'_> {
+    match dep_path {
+        Some(dep_path) => ScriptOutput::Streamed { dep_path, emit },
+        None => ScriptOutput::Inherit,
+    }
+}
+
+fn project_execution(
+    start: Instant,
+    outcome: Result<std::process::ExitStatus, ExecError>,
+) -> ProjectExecution {
+    let duration = start.elapsed().as_secs_f64() * 1e3;
+    let message = match outcome {
+        Ok(status) if status.success() => None,
+        Ok(status) => Some(format!("command failed with exit code {}", status.code().unwrap_or(1))),
+        Err(error) => Some(error.to_string()),
+    };
+    ProjectExecution { duration, message }
 }

--- a/pnpm/crates/cli/src/cli_args/exec/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/exec/recursive.rs
@@ -8,15 +8,14 @@
 //! include and exclude selectors) narrow the selected set via
 //! [`select_recursive_projects`]; the selection is then sorted
 //! topologically by default, or kept in workspace order under `--no-sort`,
-//! reversed under `--reverse`, and run sequentially.
-//! `--workspace-concurrency` parallelism is not ported yet, matching the
-//! recursive `run` runner.
+//! reversed under `--reverse`, and run with `workspaceConcurrency` operations
+//! in flight within each dependency-independent chunk.
 
 use super::{ExecArgs, prepare_command, read_package_name, spawn_in_dir};
 use crate::cli_args::recursive::{
     AutoExcludeRoot, ExecutionStatus, Status, count_failures, discover_workspace_projects,
-    get_resumed_package_chunks, select_recursive_projects, sort_filtered_projects,
-    write_recursive_summary,
+    get_resumed_package_chunks, run_workspace_chunk, select_recursive_projects,
+    sort_filtered_projects, write_recursive_summary,
 };
 use derive_more::{Display, Error};
 use indexmap::IndexMap;
@@ -52,6 +51,11 @@ pub enum RecursiveExecError {
         #[error(not(source))]
         prefix: String,
     },
+}
+
+struct ProjectExecution {
+    duration: f64,
+    message: Option<String>,
 }
 
 /// Run `args.command` across the `--filter`-selected workspace projects,
@@ -99,7 +103,9 @@ pub fn exec_recursive(
             &selection.prod_only_selected,
         )
     } else {
-        graph.keys().cloned().map(|root| vec![root]).collect()
+        let mut roots = graph.keys().cloned().collect::<Vec<_>>();
+        roots.sort_unstable();
+        vec![roots]
     };
     if args.reverse {
         chunks.reverse();
@@ -113,52 +119,63 @@ pub fn exec_recursive(
         chunks.iter().flatten().map(|root| (root.clone(), ExecutionStatus::queued())).collect();
 
     for chunk in &chunks {
-        for root in chunk {
-            result[root].status = Status::Running;
-            let start = Instant::now();
-            // pnpm names the package, falling back to the project's
-            // path relative to the working directory.
-            let dep_path = show_prefix.then(|| {
-                read_package_name(root).unwrap_or_else(|| {
-                    pathdiff::diff_paths(root, dir)
-                        .unwrap_or_else(|| root.clone())
-                        .to_string_lossy()
-                        .into_owned()
-                })
-            });
-            let output = match &dep_path {
-                Some(dep_path) => ScriptOutput::Streamed { dep_path, emit },
-                None => ScriptOutput::Inherit,
-            };
-            // A spawn / resolution error (e.g. command not found) is a
-            // per-project failure rather than a hard error: the error is
-            // recorded and the loop bails or continues like any other
-            // non-zero result.
-            let outcome = spawn_in_dir(&command, root, config, args.shell_mode, output);
-            let duration = start.elapsed().as_secs_f64() * 1e3;
+        let workspace_concurrency =
+            if args.parallel { u32::MAX } else { config.workspace_concurrency };
+        let concurrency = usize::try_from(workspace_concurrency).unwrap_or(usize::MAX).max(1);
+        let batch_size = if bail { concurrency } else { chunk.len().max(1) };
+        for batch in chunk.chunks(batch_size) {
+            for root in batch {
+                result[root].status = Status::Running;
+            }
+            let executions = run_workspace_chunk(batch, workspace_concurrency, |root| {
+                let start = Instant::now();
+                let dep_path = show_prefix.then(|| {
+                    read_package_name(root).unwrap_or_else(|| {
+                        pathdiff::diff_paths(root, dir)
+                            .unwrap_or_else(|| root.to_path_buf())
+                            .to_string_lossy()
+                            .into_owned()
+                    })
+                });
+                let output = match &dep_path {
+                    Some(dep_path) => ScriptOutput::Streamed { dep_path, emit },
+                    None => ScriptOutput::Inherit,
+                };
+                // A spawn / resolution error (e.g. command not found) is a
+                // per-project failure rather than a hard error: the error is
+                // recorded and the loop bails or continues like any other
+                // non-zero result.
+                let outcome = spawn_in_dir(&command, root, config, args.shell_mode, output);
+                let duration = start.elapsed().as_secs_f64() * 1e3;
 
-            let message = match outcome {
-                Ok(status) if status.success() => None,
-                Ok(status) => {
-                    Some(format!("command failed with exit code {}", status.code().unwrap_or(1)))
-                }
-                Err(error) => Some(error.to_string()),
-            };
-
-            let prefix = root.to_string_lossy().into_owned();
-            let entry = &mut result[root];
-            entry.duration = Some(duration);
-            match message {
-                None => entry.status = Status::Passed,
-                Some(message) => {
-                    entry.status = Status::Failure;
-                    entry.message = Some(message);
-                    entry.prefix = Some(prefix.clone());
-                    if bail {
-                        if args.report_summary {
-                            write_recursive_summary(workspace_root, &result)?;
+                let message = match outcome {
+                    Ok(status) if status.success() => None,
+                    Ok(status) => Some(format!(
+                        "command failed with exit code {}",
+                        status.code().unwrap_or(1),
+                    )),
+                    Err(error) => Some(error.to_string()),
+                };
+                ProjectExecution { duration, message }
+            })?;
+            for (root, execution) in batch.iter().zip(executions) {
+                let prefix = root.to_string_lossy().into_owned();
+                let entry = &mut result[root];
+                entry.duration = Some(execution.duration);
+                match execution.message {
+                    None => entry.status = Status::Passed,
+                    Some(message) => {
+                        entry.status = Status::Failure;
+                        entry.message = Some(message);
+                        entry.prefix = Some(prefix.clone());
+                        if bail {
+                            if args.report_summary {
+                                write_recursive_summary(workspace_root, &result)?;
+                            }
+                            return Err(
+                                RecursiveExecError::RecursiveExecFirstFail { prefix }.into()
+                            );
                         }
-                        return Err(RecursiveExecError::RecursiveExecFirstFail { prefix }.into());
                     }
                 }
             }

--- a/pnpm/crates/cli/src/cli_args/exec/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/exec/recursive.rs
@@ -103,15 +103,16 @@ pub fn exec_recursive(
             &selection.prod_only_selected,
         )
     } else {
-        let mut roots = graph.keys().cloned().collect::<Vec<_>>();
-        roots.sort_unstable();
-        vec![roots]
+        graph.keys().cloned().map(|root| vec![root]).collect()
     };
     if args.reverse {
         chunks.reverse();
     }
     if let Some(resume_from) = &args.resume_from {
         chunks = get_resumed_package_chunks(resume_from, chunks, graph)?;
+    }
+    if !args.sort {
+        chunks = vec![chunks.into_iter().flatten().collect()];
     }
 
     let bail = !args.no_bail;
@@ -158,6 +159,7 @@ pub fn exec_recursive(
                 };
                 ProjectExecution { duration, message }
             })?;
+            let mut first_failure = None;
             for (root, execution) in batch.iter().zip(executions) {
                 let prefix = root.to_string_lossy().into_owned();
                 let entry = &mut result[root];
@@ -168,16 +170,17 @@ pub fn exec_recursive(
                         entry.status = Status::Failure;
                         entry.message = Some(message);
                         entry.prefix = Some(prefix.clone());
-                        if bail {
-                            if args.report_summary {
-                                write_recursive_summary(workspace_root, &result)?;
-                            }
-                            return Err(
-                                RecursiveExecError::RecursiveExecFirstFail { prefix }.into()
-                            );
+                        if first_failure.is_none() {
+                            first_failure = Some(prefix);
                         }
                     }
                 }
+            }
+            if bail && let Some(prefix) = first_failure {
+                if args.report_summary {
+                    write_recursive_summary(workspace_root, &result)?;
+                }
+                return Err(RecursiveExecError::RecursiveExecFirstFail { prefix }.into());
             }
         }
     }

--- a/pnpm/crates/cli/src/cli_args/global.rs
+++ b/pnpm/crates/cli/src/cli_args/global.rs
@@ -16,9 +16,11 @@ use crate::{
     State,
     cli_args::{
         add::{add_packages, apply_allow_build},
-        approve_builds::ApproveBuildsArgs,
+        approve_builds::{
+            ApproveBuildsArgs, clear_decided_ignored_builds, write_approval_settings,
+        },
         global_bin_lock::acquire_global_bin_lock,
-        ignored_builds::get_automatically_ignored_builds,
+        ignored_builds::{IgnoredBuildsScan, get_automatically_ignored_builds},
         rebuild::run_rebuild,
         shim::{
             record_package_manager_shims, virtual_shim_bins_to_restore, virtual_shim_owner,
@@ -744,6 +746,40 @@ async fn run_group_install<Reporter: self::Reporter + 'static>(
         .into_diagnostic()
         .wrap_err("create global install dir")?;
 
+    let mut cfg =
+        global_group_config(base_config, &install_dir, global_pkg_dir, supported_architectures)?;
+    apply_allow_build(&mut cfg, allow_build, global_pkg_dir)?;
+
+    let config: &'static Config = Config::leak(cfg);
+
+    let manifest_path = install_dir.join("package.json");
+    let selectors = selectors
+        .iter()
+        .map(|selector| infer_local_package_alias(selector))
+        .collect::<miette::Result<Vec<_>>>()?;
+    let state = State::init(manifest_path, config, false)
+        .wrap_err("initialize the global install state")?;
+    add_packages::<Reporter, _>(
+        state,
+        &selectors,
+        range_spec_style,
+        None,
+        false,
+        config.supported_architectures.clone(),
+        Some([DependencyGroup::Prod]),
+    )
+    .await?;
+
+    prompt_approve_global_builds::<Reporter>(config, &install_dir, global_pkg_dir).await?;
+    Ok((install_dir, config))
+}
+
+fn global_group_config(
+    base_config: &Config,
+    install_dir: &Path,
+    global_pkg_dir: &Path,
+    supported_architectures: Option<SupportedArchitectures>,
+) -> miette::Result<Config> {
     let mut cfg = base_config.clone();
     cfg.modules_dir = install_dir.join("node_modules");
     cfg.virtual_store_dir = install_dir.join("node_modules").join(".pnpm");
@@ -765,7 +801,7 @@ async fn run_group_install<Reporter: self::Reporter + 'static>(
     // that file as the workspace, and then fail trying to enumerate its
     // non-existent root project. Anchoring here keeps the group install an
     // isolated single project.
-    cfg.workspace_dir = Some(install_dir.clone());
+    cfg.workspace_dir = Some(install_dir.to_path_buf());
     cfg.supported_architectures = supported_architectures;
 
     // A global install is isolated from the caller's project, so it must
@@ -809,37 +845,87 @@ async fn run_group_install<Reporter: self::Reporter + 'static>(
             cfg.dangerously_allow_all_builds = allow_all;
         }
     }
-    // `pnpm add -g --allow-build=<pkg>` opts the named packages into their
-    // build scripts for this global install and persists them to the
-    // global `allowBuilds`, on top of the settings just loaded.
-    apply_allow_build(&mut cfg, allow_build, global_pkg_dir)?;
     // Don't fail the install when a dependency's build is ignored; the
     // global approval prompt (run after the install) records the ignored
     // builds and prompts rather than erroring under `strictDepBuilds`.
     cfg.strict_dep_builds = false;
 
-    let config: &'static Config = Config::leak(cfg);
+    Ok(cfg)
+}
 
-    let manifest_path = install_dir.join("package.json");
-    let selectors = selectors
-        .iter()
-        .map(|selector| infer_local_package_alias(selector))
-        .collect::<miette::Result<Vec<_>>>()?;
-    let state = State::init(manifest_path, config, false)
-        .wrap_err("initialize the global install state")?;
-    add_packages::<Reporter, _>(
-        state,
-        &selectors,
-        range_spec_style,
-        None,
-        false,
-        config.supported_architectures.clone(),
-        Some([DependencyGroup::Prod]),
-    )
-    .await?;
+pub async fn approve_global_builds<Reporter: self::Reporter + 'static>(
+    base_config: &'static Config,
+    args: ApproveBuildsArgs,
+) -> miette::Result<()> {
+    args.validate()?;
+    let global_pkg_dir = base_config.global_pkg_dir.as_ref().ok_or(GlobalError::NoGlobalBinDir)?;
+    let packages =
+        scan_global_packages(global_pkg_dir).into_diagnostic().wrap_err("scan global packages")?;
+    let mut groups: Vec<(PathBuf, IgnoredBuildsScan)> = Vec::new();
+    let mut pending = BTreeSet::new();
+    let canonical_global_pkg_dir = (!packages.is_empty())
+        .then(|| dunce::canonicalize(global_pkg_dir))
+        .transpose()
+        .into_diagnostic()
+        .wrap_err("resolve the global packages directory")?;
+    for package in packages {
+        if canonical_global_pkg_dir
+            .as_ref()
+            .is_some_and(|root| !is_subdir(root, &package.install_dir))
+        {
+            continue;
+        }
+        let config = global_group_config(
+            base_config,
+            &package.install_dir,
+            global_pkg_dir,
+            base_config.supported_architectures.clone(),
+        )?;
+        let scan = get_automatically_ignored_builds(&config)?;
+        if let Some(names) = &scan.names {
+            pending.extend(names.iter().cloned());
+        }
+        groups.push((package.install_dir, scan));
+    }
+    if pending.is_empty() {
+        println!("There are no packages awaiting approval");
+        return Ok(());
+    }
+    let pending = pending.into_iter().collect::<Vec<_>>();
+    let Some(decision) = args.decide(&pending)? else {
+        return Ok(());
+    };
 
-    prompt_approve_global_builds::<Reporter>(config, &install_dir, global_pkg_dir).await?;
-    Ok((install_dir, config))
+    write_approval_settings(global_pkg_dir, &decision)?;
+    let mut rebuild_groups = Vec::new();
+    for (install_dir, scan) in groups {
+        let build_packages: Vec<String> = decision
+            .build_packages
+            .iter()
+            .filter(|name| scan.names.as_ref().is_some_and(|names| names.contains(name)))
+            .cloned()
+            .collect();
+        clear_decided_ignored_builds(scan.modules_manifest, &scan.modules_dir, &decision)?;
+        if !build_packages.is_empty() {
+            rebuild_groups.push((install_dir, build_packages));
+        }
+    }
+    for (install_dir, build_packages) in rebuild_groups {
+        let config = Config::leak(global_group_config(
+            base_config,
+            &install_dir,
+            global_pkg_dir,
+            base_config.supported_architectures.clone(),
+        )?);
+        let state = State::init(install_dir.join("package.json"), config, true)
+            .wrap_err("initialize the global approve-builds state")?;
+        let selection = crate::cli_args::rebuild::RebuildSelection {
+            names: Some(build_packages),
+            projects: Vec::new(),
+        };
+        run_rebuild::<Reporter>(&state, selection, None).await?;
+    }
+    Ok(())
 }
 
 /// Run the interactive build-approval flow against the just-installed

--- a/pnpm/crates/cli/src/cli_args/outdated.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated.rs
@@ -737,9 +737,6 @@ impl OutdatedArgs {
     /// treating each install dir's `package.json` as a project, and report
     /// the aggregate.
     pub async fn run_global(self, config: &'static Config) -> miette::Result<OutdatedOutcome> {
-        if config.recursive {
-            return Err(miette::miette!("`pnpm outdated --recursive` is not supported yet."));
-        }
         let global_pkg_dir = config.global_pkg_dir.clone().ok_or_else(|| {
             miette::miette!(
                 code = "ERR_PNPM_NO_GLOBAL_BIN_DIR",

--- a/pnpm/crates/cli/src/cli_args/publish.rs
+++ b/pnpm/crates/cli/src/cli_args/publish.rs
@@ -5,10 +5,8 @@
 //! onto its options, runs the git checks and publish-lifecycle scripts, and
 //! packs the project before handing the tarball off.
 //!
-//! `--recursive` (workspace publishing) lives in
-//! [`recursive`]; `--batch` (a single batched request to a pnpr-style
-//! registry) is accepted for surface parity but not yet ported — it errors
-//! rather than silently doing nothing.
+//! `--recursive` (workspace publishing), including pnpr's batch endpoint,
+//! lives in [`recursive`].
 
 mod recursive;
 
@@ -119,6 +117,28 @@ pub struct PublishFlags {
 pub(super) enum PublishedPackages {
     Single(Box<PublishSummary>),
     Recursive(Vec<PublishSummary>),
+}
+
+struct PackedDirectory {
+    project_dir: std::path::PathBuf,
+    source_manifest: Value,
+    published_manifest: Value,
+    tarball_data: Vec<u8>,
+    tarball_path: String,
+    contents: Vec<String>,
+    unpacked_size: u64,
+}
+
+impl PackedDirectory {
+    fn packed_pkg(&self) -> PackedPkg<'_> {
+        PackedPkg {
+            published_manifest: &self.published_manifest,
+            tarball_data: &self.tarball_data,
+            tarball_path: &self.tarball_path,
+            contents: &self.contents,
+            unpacked_size: self.unpacked_size,
+        }
+    }
 }
 
 impl PublishedPackages {
@@ -241,6 +261,19 @@ impl PublishArgs {
         opts: &PublishPackedPkgOptions,
         network: &PublishNetwork<'_>,
     ) -> miette::Result<PublishSummary> {
+        let packed = self.pack_directory::<Reporter>(project_dir, config).await?;
+        let summary =
+            publish_packed_pkg::<Host, Reporter>(&packed.packed_pkg(), opts, network).await?;
+
+        self.run_post_publish_scripts::<Reporter>(&packed, config)?;
+        Ok(summary)
+    }
+
+    async fn pack_directory<Reporter: self::Reporter>(
+        &self,
+        project_dir: &Path,
+        config: &Config,
+    ) -> miette::Result<PackedDirectory> {
         let manifest = pnpm_package_manifest::safe_read_package_json_from_dir(project_dir)
             .into_diagnostic()
             .wrap_err("read package.json")?
@@ -267,30 +300,33 @@ impl PublishArgs {
         let tarball_data = std::fs::read(&pack_result.tarball_path)
             .into_diagnostic()
             .wrap_err("read packed tarball")?;
-
-        let summary = publish_packed_pkg::<Host, Reporter>(
-            &PackedPkg {
-                published_manifest: &pack_result.published_manifest,
-                tarball_data: &tarball_data,
-                tarball_path: &pack_result.tarball_path,
-                contents: &pack_result.contents,
-                unpacked_size: pack_result.unpacked_size,
-            },
-            opts,
-            network,
-        )
-        .await?;
         drop(pack_destination);
 
+        Ok(PackedDirectory {
+            project_dir: project_dir.to_path_buf(),
+            source_manifest: manifest,
+            published_manifest: pack_result.published_manifest,
+            tarball_data,
+            tarball_path: pack_result.tarball_path,
+            contents: pack_result.contents,
+            unpacked_size: pack_result.unpacked_size,
+        })
+    }
+
+    fn run_post_publish_scripts<Reporter: self::Reporter>(
+        &self,
+        packed: &PackedDirectory,
+        config: &Config,
+    ) -> miette::Result<()> {
         if !self.should_ignore_scripts(config) {
             run_publish_scripts::<Reporter>(
-                project_dir,
+                &packed.project_dir,
                 config,
-                &manifest,
+                &packed.source_manifest,
                 &["publish", "postpublish"],
             )?;
         }
-        Ok(summary)
+        Ok(())
     }
 
     /// Whether to skip every publish-related lifecycle script. `--ignore-scripts`

--- a/pnpm/crates/cli/src/cli_args/publish/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/publish/recursive.rs
@@ -126,11 +126,18 @@ impl PublishArgs {
                 }
             }
             let packages = packed.iter().map(|package| package.packed_pkg()).collect::<Vec<_>>();
-            let published =
-                batch_publish_packed_pkgs::<Reporter>(&packages, &opts, &network).await?;
-            for package in &packed {
-                self.run_post_publish_scripts::<Reporter>(package, config)?;
-            }
+            let published = batch_publish_packed_pkgs::<Reporter, _, miette::Report>(
+                &packages,
+                &opts,
+                &network,
+                |package_indexes| {
+                    for &package_index in package_indexes {
+                        self.run_post_publish_scripts::<Reporter>(&packed[package_index], config)?;
+                    }
+                    Ok(())
+                },
+            )
+            .await?;
             if self.flags.report_summary {
                 write_publish_summary(workspace_root, &published)?;
             }

--- a/pnpm/crates/cli/src/cli_args/publish/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/publish/recursive.rs
@@ -16,7 +16,8 @@ use pipe_trait::Pipe;
 use pnpm_config::Config;
 use pnpm_network::{RetryOpts, ThrottledClient};
 use pnpm_publish::{
-    Host, PublishNetwork, PublishSummary, find_registry_info, resolve_otp_from_env,
+    Host, PublishNetwork, PublishSummary, batch_publish_packed_pkgs, find_registry_info,
+    resolve_otp_from_env, validate_batch_publish_options,
 };
 use pnpm_reporter::{LogEvent, LogLevel, PnpmLog, Reporter};
 use pnpm_resolving_npm_resolver::{
@@ -44,13 +45,6 @@ impl PublishArgs {
         config: &Config,
         stage: bool,
     ) -> miette::Result<Vec<PublishSummary>> {
-        if self.flags.batch {
-            return Err(miette::miette!(
-                help = "Publish without --batch.",
-                "Batch publishing (--batch) is not yet supported",
-            ));
-        }
-
         let workspace_root = config.workspace_dir.as_deref().unwrap_or(dir);
         // `publish` is not in pnpm's root-auto-exclusion command set
         // (`run` / `exec` / `add` / `test`), so the workspace root stays in the
@@ -72,6 +66,9 @@ impl PublishArgs {
         let network = PublishNetwork { client: &http_client, auth_headers: &config.auth_headers };
         let otp = resolve_otp_from_env::<Host>(self.flags.otp.clone());
         let opts = self.publish_options(config, otp, stage);
+        if self.flags.batch {
+            validate_batch_publish_options(&opts)?;
+        }
         let retry_opts = retry_opts_from_config(config);
 
         // Filter the selected graph: keep only packages that have a name and
@@ -121,6 +118,24 @@ impl PublishArgs {
             selection.prod_all.as_ref(),
             &selection.prod_only_selected,
         );
+        if self.flags.batch {
+            let mut packed = Vec::with_capacity(to_publish.len());
+            for root in chunks.iter().flatten() {
+                if to_publish.contains(root) {
+                    packed.push(self.pack_directory::<Reporter>(root, config).await?);
+                }
+            }
+            let packages = packed.iter().map(|package| package.packed_pkg()).collect::<Vec<_>>();
+            let published =
+                batch_publish_packed_pkgs::<Reporter>(&packages, &opts, &network).await?;
+            for package in &packed {
+                self.run_post_publish_scripts::<Reporter>(package, config)?;
+            }
+            if self.flags.report_summary {
+                write_publish_summary(workspace_root, &published)?;
+            }
+            return Ok(published);
+        }
         for chunk in chunks {
             for root in chunk {
                 if !to_publish.contains(&root) {

--- a/pnpm/crates/cli/src/cli_args/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/recursive.rs
@@ -27,6 +27,10 @@ use serde::Serialize;
 use std::{
     collections::{HashMap, HashSet},
     path::{Path, PathBuf},
+    sync::{
+        Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
 };
 
 /// `Cannot find package {resume_from}` — raised by both recursive `run`
@@ -39,24 +43,6 @@ use std::{
 pub struct ResumeFromNotFound {
     #[error(not(source))]
     pub resume_from: String,
-}
-
-/// `{operation} with `sharedWorkspaceLockfile=false` is not supported yet.`
-///
-/// Every workspace-aware command reads and rewrites one shared
-/// `pnpm-lock.yaml`; the per-project lockfiles that
-/// `sharedWorkspaceLockfile=false` produces have no reader here yet. pnpm
-/// itself supports the combination, so this is a known gap rather than a
-/// rejected configuration — it fails loudly instead of silently installing
-/// something other than what was asked for.
-#[derive(Debug, Display, Error, Diagnostic)]
-#[display("{operation} with `sharedWorkspaceLockfile=false` is not supported yet.")]
-#[diagnostic(code(ERR_PNPM_RECURSIVE_SHARED_LOCKFILE_UNSUPPORTED))]
-pub struct RecursiveSharedLockfileUnsupported {
-    /// The user-facing description of what was attempted, e.g.
-    /// ``Recursive and filtered `pnpm why` ``.
-    #[error(not(source))]
-    pub operation: String,
 }
 
 /// Diagnostic code of [`NoMatchingProjects`]. pnpm has no error code for
@@ -74,12 +60,6 @@ pub const NO_MATCHING_PROJECTS_CODE: &str = "ERR_PNPM_NO_MATCHING_PROJECTS";
 pub struct NoMatchingProjects {
     #[error(not(source))]
     pub message: String,
-}
-
-impl RecursiveSharedLockfileUnsupported {
-    pub fn new(operation: impl Into<String>) -> Self {
-        RecursiveSharedLockfileUnsupported { operation: operation.into() }
-    }
 }
 
 /// Sort the `--filter`-selected workspace projects into topologically
@@ -475,6 +455,55 @@ pub fn selected_importer_ids(
         .keys()
         .map(|project_dir| importer_id_from_root_dir(lockfile_dir, project_dir))
         .collect()
+}
+
+/// Run one dependency-independent workspace chunk with at most
+/// `workspace_concurrency` operations in flight, preserving input order in
+/// the returned results.
+pub fn run_workspace_chunk<Output, Operation>(
+    roots: &[PathBuf],
+    workspace_concurrency: u32,
+    operation: Operation,
+) -> miette::Result<Vec<Output>>
+where
+    Output: Send,
+    Operation: Fn(&Path) -> Output + Sync,
+{
+    if roots.is_empty() {
+        return Ok(Vec::new());
+    }
+    let concurrency =
+        usize::try_from(workspace_concurrency).unwrap_or(usize::MAX).max(1).min(roots.len());
+    let next = AtomicUsize::new(0);
+    let outputs = Mutex::new((0..roots.len()).map(|_| None).collect::<Vec<Option<Output>>>());
+    std::thread::scope(|scope| -> miette::Result<()> {
+        let handles = (0..concurrency)
+            .map(|_| {
+                std::thread::Builder::new()
+                    .spawn_scoped(scope, || {
+                        loop {
+                            let index = next.fetch_add(1, Ordering::Relaxed);
+                            let Some(root) = roots.get(index) else { break };
+                            let output = operation(root);
+                            outputs.lock().expect("workspace output lock is not poisoned")[index] =
+                                Some(output);
+                        }
+                    })
+                    .into_diagnostic()
+                    .wrap_err("failed to start workspace task runner")
+            })
+            .collect::<miette::Result<Vec<_>>>()?;
+        for handle in handles {
+            handle.join().unwrap_or_else(|panic| std::panic::resume_unwind(panic));
+        }
+        Ok(())
+    })?;
+    Ok(outputs
+        .into_inner()
+        .expect("workspace output lock is not poisoned")
+        .into_iter()
+        .map(|output| output.expect("every workspace operation produced an output"))
+        .collect())
 }
 
 /// Build the workspace [`ProjectGraph`] from `projects` under `options`.

--- a/pnpm/crates/cli/src/cli_args/run.rs
+++ b/pnpm/crates/cli/src/cli_args/run.rs
@@ -278,6 +278,7 @@ fn exec_fallback(
         no_bail: false,
         sort: true,
         reverse: false,
+        parallel: false,
     }
     .run(dir, config)
 }

--- a/pnpm/crates/cli/src/cli_args/run/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/run/recursive.rs
@@ -140,15 +140,16 @@ pub fn run_recursive(
             &selection.prod_only_selected,
         )
     } else {
-        let mut roots = graph.keys().cloned().collect::<Vec<_>>();
-        roots.sort_unstable();
-        vec![roots]
+        graph.keys().cloned().map(|root| vec![root]).collect()
     };
     if args.reverse {
         chunks.reverse();
     }
     if let Some(resume_from) = &args.resume_from {
         chunks = get_resumed_package_chunks(resume_from, chunks, graph)?;
+    }
+    if !args.sort {
+        chunks = vec![chunks.into_iter().flatten().collect()];
     }
 
     // Compiled once for the whole run, not per project.
@@ -235,20 +236,21 @@ pub fn run_recursive(
                             emit,
                         })
                     })?;
+                let mut first_failure = None;
                 for (root, execution) in batch.iter().zip(executions) {
                     let execution = execution?;
                     has_command += execution.has_command;
                     let failed = execution.status.status == Status::Failure;
                     result.insert(root.clone(), execution.status);
-                    if bail && failed {
-                        if args.report_summary {
-                            write_recursive_summary(workspace_root, &result)?;
-                        }
-                        return Err(RecursiveRunError::RecursiveRunFirstFail {
-                            prefix: root.to_string_lossy().into_owned(),
-                        }
-                        .into());
+                    if failed && first_failure.is_none() {
+                        first_failure = Some(root.to_string_lossy().into_owned());
                     }
+                }
+                if bail && let Some(prefix) = first_failure {
+                    if args.report_summary {
+                        write_recursive_summary(workspace_root, &result)?;
+                    }
+                    return Err(RecursiveRunError::RecursiveRunFirstFail { prefix }.into());
                 }
             }
         }

--- a/pnpm/crates/cli/src/cli_args/run/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/run/recursive.rs
@@ -6,16 +6,16 @@
 //! [`select_recursive_projects`]; the selection is then sorted
 //! topologically by default, or kept in workspace order under `--no-sort`,
 //! and reversed under `--reverse`. `--parallel` starts every selected
-//! project concurrently; bounded `--workspace-concurrency` parallelism is
-//! not supported yet.
+//! project concurrently; otherwise `workspaceConcurrency` bounds the work
+//! within each dependency-independent chunk.
 //! The main-dispatch auto-exclusion of the workspace root is applied via
 //! [`AutoExcludeRoot::Enabled`].
 
 use super::{RunArgs, RunContext, ScriptSelector, render_project_commands, run_stages};
 use crate::cli_args::recursive::{
     AutoExcludeRoot, ExecutionStatus, Status, count_failures, discover_workspace_projects,
-    get_resumed_package_chunks, select_recursive_projects, sort_filtered_projects,
-    write_recursive_summary,
+    get_resumed_package_chunks, run_workspace_chunk, select_recursive_projects,
+    sort_filtered_projects, write_recursive_summary,
 };
 use derive_more::{Display, Error};
 use indexmap::IndexMap;
@@ -140,7 +140,9 @@ pub fn run_recursive(
             &selection.prod_only_selected,
         )
     } else {
-        graph.keys().cloned().map(|root| vec![root]).collect()
+        let mut roots = graph.keys().cloned().collect::<Vec<_>>();
+        roots.sort_unstable();
+        vec![roots]
     };
     if args.reverse {
         chunks.reverse();
@@ -214,30 +216,39 @@ pub fn run_recursive(
         }
     } else {
         for chunk in &chunks {
-            for root in chunk {
-                let execution = run_project(RunProjectOptions {
-                    root,
-                    graph,
-                    selector: &selector,
-                    args,
-                    init_cwd: &init_cwd,
-                    config,
-                    extra_env: &extra_env,
-                    bail,
-                    silent,
-                    emit,
-                })?;
-                has_command += execution.has_command;
-                let failed = execution.status.status == Status::Failure;
-                result.insert(root.clone(), execution.status);
-                if bail && failed {
-                    if args.report_summary {
-                        write_recursive_summary(workspace_root, &result)?;
+            let concurrency =
+                usize::try_from(config.workspace_concurrency).unwrap_or(usize::MAX).max(1);
+            let batch_size = if bail { concurrency } else { chunk.len().max(1) };
+            for batch in chunk.chunks(batch_size) {
+                let executions =
+                    run_workspace_chunk(batch, config.workspace_concurrency, |root| {
+                        run_project(RunProjectOptions {
+                            root,
+                            graph,
+                            selector: &selector,
+                            args,
+                            init_cwd: &init_cwd,
+                            config,
+                            extra_env: &extra_env,
+                            bail,
+                            silent,
+                            emit,
+                        })
+                    })?;
+                for (root, execution) in batch.iter().zip(executions) {
+                    let execution = execution?;
+                    has_command += execution.has_command;
+                    let failed = execution.status.status == Status::Failure;
+                    result.insert(root.clone(), execution.status);
+                    if bail && failed {
+                        if args.report_summary {
+                            write_recursive_summary(workspace_root, &result)?;
+                        }
+                        return Err(RecursiveRunError::RecursiveRunFirstFail {
+                            prefix: root.to_string_lossy().into_owned(),
+                        }
+                        .into());
                     }
-                    return Err(RecursiveRunError::RecursiveRunFirstFail {
-                        prefix: root.to_string_lossy().into_owned(),
-                    }
-                    .into());
                 }
             }
         }

--- a/pnpm/crates/cli/src/cli_args/sbom.rs
+++ b/pnpm/crates/cli/src/cli_args/sbom.rs
@@ -905,7 +905,7 @@ fn selected_and_reachable_project_dirs(
 fn merged_dedicated_lockfile_state(mut state: State) -> miette::Result<(State, Vec<PathBuf>)> {
     let project_dir = state.project_dir();
     let workspace_root = state.config.workspace_dir.as_deref().unwrap_or(project_dir);
-    let (projects, _) = discover_workspace_projects(workspace_root)?;
+    let (projects, _) = discover_workspace_projects(workspace_root, state.config)?;
     let selection =
         select_recursive_projects(&projects, state.config, project_dir, AutoExcludeRoot::Disabled)?;
 

--- a/pnpm/crates/cli/src/cli_args/sbom.rs
+++ b/pnpm/crates/cli/src/cli_args/sbom.rs
@@ -852,6 +852,35 @@ where
     Ok(())
 }
 
+fn extend_dedicated_snapshots(
+    current: &mut HashMap<PackageKey, SnapshotEntry>,
+    incoming: HashMap<PackageKey, SnapshotEntry>,
+    selected_dir: &Path,
+) -> miette::Result<()> {
+    for (key, mut value) in incoming {
+        match current.entry(key) {
+            Entry::Vacant(entry) => {
+                entry.insert(value);
+            }
+            Entry::Occupied(mut entry) => {
+                let incoming_optional = value.optional;
+                value.optional = entry.get().optional;
+                if entry.get() != &value {
+                    let key = entry.key();
+                    let selected_dir = selected_dir.display();
+                    return Err(miette::miette!(
+                        code = "ERR_PNPM_SBOM_CONFLICTING_LOCKFILE_ENTRIES",
+                        "Cannot combine dedicated workspace lockfiles because {} contains a different snapshot entry for {key}",
+                        selected_dir,
+                    ));
+                }
+                entry.get_mut().optional &= incoming_optional;
+            }
+        }
+    }
+    Ok(())
+}
+
 fn extend_dedicated_lockfile(
     current: &mut Lockfile,
     incoming: Lockfile,
@@ -872,10 +901,9 @@ fn extend_dedicated_lockfile(
         )?;
     }
     if let Some(snapshots) = incoming.snapshots {
-        extend_dedicated_lockfile_map(
+        extend_dedicated_snapshots(
             current.snapshots.get_or_insert_default(),
             snapshots,
-            "snapshot",
             selected_dir,
         )?;
     }

--- a/pnpm/crates/cli/src/cli_args/sbom.rs
+++ b/pnpm/crates/cli/src/cli_args/sbom.rs
@@ -18,7 +18,7 @@ use indexmap::IndexMap;
 use pnpm_config::Config;
 use pnpm_lockfile::{
     LazyLockfile, Lockfile, LockfileResolution, PackageKey, PackageMetadata, PkgName,
-    PkgNameVerPeer, SnapshotEntry, merge_lockfile_changes,
+    PkgNameVerPeer, SnapshotEntry,
 };
 use pnpm_package_is_installable::{
     InstallabilityOptions, WantedPlatformRef, platform_is_supported_with_inference,
@@ -26,7 +26,9 @@ use pnpm_package_is_installable::{
 use pnpm_package_manager::{importer_root_dir, validate_importer_id};
 use pnpm_package_manifest::{extract_author, extract_homepage, safe_read_package_json_from_dir};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{HashMap, HashSet, hash_map::Entry},
+    fmt::Display,
+    hash::Hash,
     io::Write,
     path::{Path, PathBuf},
 };
@@ -820,6 +822,86 @@ fn missing_importers(selected: &HashSet<String>, lockfile_ids: &[String]) -> Vec
     missing
 }
 
+fn extend_dedicated_lockfile_map<Key, Value>(
+    current: &mut HashMap<Key, Value>,
+    incoming: HashMap<Key, Value>,
+    entry_kind: &str,
+    selected_dir: &Path,
+) -> miette::Result<()>
+where
+    Key: Display + Eq + Hash,
+    Value: PartialEq,
+{
+    for (key, value) in incoming {
+        match current.entry(key) {
+            Entry::Vacant(entry) => {
+                entry.insert(value);
+            }
+            Entry::Occupied(entry) if entry.get() != &value => {
+                let key = entry.key();
+                let selected_dir = selected_dir.display();
+                return Err(miette::miette!(
+                    code = "ERR_PNPM_SBOM_CONFLICTING_LOCKFILE_ENTRIES",
+                    "Cannot combine dedicated workspace lockfiles because {} contains a different {entry_kind} entry for {key}",
+                    selected_dir,
+                ));
+            }
+            Entry::Occupied(_) => {}
+        }
+    }
+    Ok(())
+}
+
+fn extend_dedicated_lockfile(
+    current: &mut Lockfile,
+    incoming: Lockfile,
+    selected_dir: &Path,
+) -> miette::Result<()> {
+    extend_dedicated_lockfile_map(
+        &mut current.importers,
+        incoming.importers,
+        "importer",
+        selected_dir,
+    )?;
+    if let Some(packages) = incoming.packages {
+        extend_dedicated_lockfile_map(
+            current.packages.get_or_insert_default(),
+            packages,
+            "package",
+            selected_dir,
+        )?;
+    }
+    if let Some(snapshots) = incoming.snapshots {
+        extend_dedicated_lockfile_map(
+            current.snapshots.get_or_insert_default(),
+            snapshots,
+            "snapshot",
+            selected_dir,
+        )?;
+    }
+    Ok(())
+}
+
+fn selected_and_reachable_project_dirs(
+    selection: &crate::cli_args::recursive::RecursiveSelection<'_>,
+) -> Vec<PathBuf> {
+    let graph = selection.full_graph();
+    let mut project_dirs: Vec<PathBuf> = selection.selected.keys().cloned().collect();
+    let mut seen: HashSet<PathBuf> = project_dirs.iter().cloned().collect();
+    let mut index = 0;
+    while let Some(project_dir) = project_dirs.get(index) {
+        if let Some(project) = graph.get(project_dir) {
+            for dependency_dir in &project.dependencies {
+                if seen.insert(dependency_dir.clone()) {
+                    project_dirs.push(dependency_dir.clone());
+                }
+            }
+        }
+        index += 1;
+    }
+    project_dirs
+}
+
 fn merged_dedicated_lockfile_state(mut state: State) -> miette::Result<(State, Vec<PathBuf>)> {
     let project_dir = state.project_dir();
     let workspace_root = state.config.workspace_dir.as_deref().unwrap_or(project_dir);
@@ -828,14 +910,15 @@ fn merged_dedicated_lockfile_state(mut state: State) -> miette::Result<(State, V
         select_recursive_projects(&projects, state.config, project_dir, AutoExcludeRoot::Disabled)?;
 
     let mut merged: Option<Lockfile> = None;
-    let mut virtual_store_dirs = Vec::with_capacity(selection.selected.len());
-    for selected_dir in selection.selected.keys() {
+    let project_dirs = selected_and_reachable_project_dirs(&selection);
+    let mut virtual_store_dirs = Vec::with_capacity(project_dirs.len());
+    for selected_dir in project_dirs {
         let mut project_config = state.config.clone();
-        project_config.anchor_lockfile_paths(selected_dir);
+        project_config.anchor_lockfile_paths(&selected_dir);
         virtual_store_dirs.push(project_config.effective_virtual_store_dir().to_path_buf());
 
         let Some(mut lockfile) =
-            Lockfile::load_wanted(selected_dir, &state.config.wanted_lockfile_selection())
+            Lockfile::load_wanted(&selected_dir, &state.config.wanted_lockfile_selection())
                 .map_err(miette::Report::new)?
         else {
             continue;
@@ -845,16 +928,17 @@ fn merged_dedicated_lockfile_state(mut state: State) -> miette::Result<(State, V
             .into_iter()
             .map(|(importer_id, importer)| {
                 validate_importer_id(&importer_id).map_err(miette::Report::new)?;
-                let importer_dir = importer_root_dir(selected_dir, &importer_id);
+                let importer_dir = importer_root_dir(&selected_dir, &importer_id);
                 let workspace_id =
                     pnpm_workspace::importer_id_from_root_dir(workspace_root, &importer_dir);
                 Ok((workspace_id, importer))
             })
             .collect::<miette::Result<_>>()?;
-        merged = Some(match merged {
-            Some(current) => merge_lockfile_changes(&current, &lockfile),
-            None => lockfile,
-        });
+        if let Some(current) = &mut merged {
+            extend_dedicated_lockfile(current, lockfile, &selected_dir)?;
+        } else {
+            merged = Some(lockfile);
+        }
     }
 
     virtual_store_dirs.sort_unstable();

--- a/pnpm/crates/cli/src/cli_args/sbom.rs
+++ b/pnpm/crates/cli/src/cli_args/sbom.rs
@@ -822,6 +822,16 @@ fn missing_importers(selected: &HashSet<String>, lockfile_ids: &[String]) -> Vec
     missing
 }
 
+fn missing_importers_error(missing: &[String], project_kind: &str) -> miette::Report {
+    let plural = if missing.len() == 1 { "" } else { "s" };
+    let names = missing.join(", ");
+    let lockfile_name = pnpm_lockfile::Lockfile::FILE_NAME;
+    miette::miette!(
+        code = "ERR_PNPM_SBOM_MISSING_IMPORTERS",
+        r#"{lockfile_name} has no entry for the {project_kind} workspace project{plural}: {names}. Run "pnpm install" to update it."#,
+    )
+}
+
 fn extend_dedicated_lockfile_map<Key, Value>(
     current: &mut HashMap<Key, Value>,
     incoming: HashMap<Key, Value>,
@@ -939,14 +949,18 @@ fn merged_dedicated_lockfile_state(mut state: State) -> miette::Result<(State, V
 
     let mut merged: Option<Lockfile> = None;
     let project_dirs = selected_and_reachable_project_dirs(&selection);
+    let required_importer_ids: HashSet<String> = project_dirs
+        .iter()
+        .map(|project_dir| pnpm_workspace::importer_id_from_root_dir(workspace_root, project_dir))
+        .collect();
     let mut virtual_store_dirs = Vec::with_capacity(project_dirs.len());
-    for selected_dir in project_dirs {
+    for selected_dir in &project_dirs {
         let mut project_config = state.config.clone();
-        project_config.anchor_lockfile_paths(&selected_dir);
+        project_config.anchor_lockfile_paths(selected_dir);
         virtual_store_dirs.push(project_config.effective_virtual_store_dir().to_path_buf());
 
         let Some(mut lockfile) =
-            Lockfile::load_wanted(&selected_dir, &state.config.wanted_lockfile_selection())
+            Lockfile::load_wanted(selected_dir, &state.config.wanted_lockfile_selection())
                 .map_err(miette::Report::new)?
         else {
             continue;
@@ -956,16 +970,24 @@ fn merged_dedicated_lockfile_state(mut state: State) -> miette::Result<(State, V
             .into_iter()
             .map(|(importer_id, importer)| {
                 validate_importer_id(&importer_id).map_err(miette::Report::new)?;
-                let importer_dir = importer_root_dir(&selected_dir, &importer_id);
+                let importer_dir = importer_root_dir(selected_dir, &importer_id);
                 let workspace_id =
                     pnpm_workspace::importer_id_from_root_dir(workspace_root, &importer_dir);
                 Ok((workspace_id, importer))
             })
             .collect::<miette::Result<_>>()?;
         if let Some(current) = &mut merged {
-            extend_dedicated_lockfile(current, lockfile, &selected_dir)?;
+            extend_dedicated_lockfile(current, lockfile, selected_dir)?;
         } else {
             merged = Some(lockfile);
+        }
+    }
+
+    if let Some(lockfile) = &merged {
+        let importer_ids: Vec<String> = lockfile.importers.keys().cloned().collect();
+        let missing = missing_importers(&required_importer_ids, &importer_ids);
+        if !missing.is_empty() {
+            return Err(missing_importers_error(&missing, "selected or reachable"));
         }
     }
 
@@ -1049,13 +1071,7 @@ impl SbomArgs {
                 Vec::new()
             };
             if !missing.is_empty() {
-                let plural = if missing.len() == 1 { "" } else { "s" };
-                let names = missing.join(", ");
-                let lockfile_name = pnpm_lockfile::Lockfile::FILE_NAME;
-                return Err(miette::miette!(
-                    code = "ERR_PNPM_SBOM_MISSING_IMPORTERS",
-                    r#"{lockfile_name} has no entry for the selected project{plural}: {names}. Run "pnpm install" to update it."#,
-                ));
+                return Err(missing_importers_error(&missing, "selected"));
             }
             // Intersecting rather than mapping the selection keeps the
             // lockfile order established above.

--- a/pnpm/crates/cli/src/cli_args/sbom.rs
+++ b/pnpm/crates/cli/src/cli_args/sbom.rs
@@ -8,9 +8,8 @@ use crate::{
     cli_args::{
         install::resolve_bool_override,
         recursive::{
-            AutoExcludeRoot, RecursiveSharedLockfileUnsupported, discover_workspace_projects,
-            no_projects_matched_message, notice_workspace_dir, select_recursive_projects,
-            selected_importer_ids,
+            AutoExcludeRoot, discover_workspace_projects, no_projects_matched_message,
+            notice_workspace_dir, select_recursive_projects, selected_importer_ids,
         },
     },
 };
@@ -18,7 +17,8 @@ use clap::Args;
 use indexmap::IndexMap;
 use pnpm_config::Config;
 use pnpm_lockfile::{
-    LockfileResolution, PackageKey, PackageMetadata, PkgName, PkgNameVerPeer, SnapshotEntry,
+    LazyLockfile, Lockfile, LockfileResolution, PackageKey, PackageMetadata, PkgName,
+    PkgNameVerPeer, SnapshotEntry, merge_lockfile_changes,
 };
 use pnpm_package_is_installable::{
     InstallabilityOptions, WantedPlatformRef, platform_is_supported_with_inference,
@@ -147,7 +147,7 @@ struct WalkContext<'a> {
     packages: Option<&'a HashMap<PackageKey, PackageMetadata>>,
     dep_types: &'a HashMap<PackageKey, DepType>,
     default_registry: &'a str,
-    virtual_store_dir: Option<PathBuf>,
+    virtual_store_dirs: &'a [PathBuf],
     virtual_store_dir_max_length: usize,
     include_optional_transitive: bool,
     installability: InstallabilityOptions<'a>,
@@ -404,6 +404,7 @@ fn collect_components(
     exclude_peers: bool,
     lockfile_only: bool,
     filter_importer_ids: Option<&[&str]>,
+    virtual_store_dirs_override: Option<&[PathBuf]>,
 ) -> miette::Result<SbomResult> {
     let lockfile = state
         .lockfile
@@ -459,15 +460,19 @@ fn collect_components(
 
     let dep_types = detect_dep_types(lockfile, include.optional_dependencies);
 
-    let virtual_store_dir =
-        (!lockfile_only).then(|| state.config.effective_virtual_store_dir().to_path_buf());
+    let default_virtual_store_dirs = [state.config.effective_virtual_store_dir().to_path_buf()];
+    let virtual_store_dirs = if lockfile_only {
+        &[][..]
+    } else {
+        virtual_store_dirs_override.unwrap_or(&default_virtual_store_dirs)
+    };
 
     let ctx = WalkContext {
         snapshots: lockfile.snapshots.as_ref(),
         packages: lockfile.packages.as_ref(),
         dep_types: &dep_types,
         default_registry: &state.config.registry,
-        virtual_store_dir,
+        virtual_store_dirs,
         virtual_store_dir_max_length: state.config.virtual_store_dir_max_length as usize,
         include_optional_transitive: include.optional_dependencies,
         installability: InstallabilityOptions {
@@ -654,22 +659,24 @@ fn read_pkg_metadata_from_store(
         repository: None,
         bugs_url: None,
     };
-    let Some(ref vs_dir) = ctx.virtual_store_dir else {
-        return empty;
-    };
     let store_name = key.to_virtual_store_name(ctx.virtual_store_dir_max_length);
-    let pkg_dir = vs_dir.join(&store_name).join("node_modules").join(pkg_name);
-    let Ok(Some(manifest)) = safe_read_package_json_from_dir(&pkg_dir) else {
-        return empty;
-    };
-    PkgMetadata {
-        license: manifest.get("license").and_then(|v| v.as_str()).map(ToString::to_string),
-        description: manifest.get("description").and_then(|v| v.as_str()).map(ToString::to_string),
-        author: extract_author(&manifest),
-        homepage: extract_homepage(&manifest),
-        repository: extract_repository(&manifest),
-        bugs_url: extract_bugs_url(&manifest),
+    for virtual_store_dir in ctx.virtual_store_dirs {
+        let pkg_dir = virtual_store_dir.join(&store_name).join("node_modules").join(pkg_name);
+        if let Ok(Some(manifest)) = safe_read_package_json_from_dir(&pkg_dir) {
+            return PkgMetadata {
+                license: manifest.get("license").and_then(|v| v.as_str()).map(ToString::to_string),
+                description: manifest
+                    .get("description")
+                    .and_then(|v| v.as_str())
+                    .map(ToString::to_string),
+                author: extract_author(&manifest),
+                homepage: extract_homepage(&manifest),
+                repository: extract_repository(&manifest),
+                bugs_url: extract_bugs_url(&manifest),
+            };
+        }
     }
+    empty
 }
 
 /// Whether `package` is an optional dependency that pnpm would not install on
@@ -717,9 +724,9 @@ fn walk_snapshot(
             .and_then(|meta| meta.version.clone())
             .unwrap_or_else(|| key.suffix.version().to_string());
 
-        // `virtual_store_dir` is `None` under --lockfile-only, which describes
+        // `virtual_store_dirs` is empty under --lockfile-only, which describes
         // the whole lockfile graph, platform-independently.
-        if ctx.virtual_store_dir.is_some()
+        if !ctx.virtual_store_dirs.is_empty()
             && platform_incompatible_optional(
                 &key.name.bare,
                 ctx.snapshots.is_some_and(|snapshots| {
@@ -813,15 +820,62 @@ fn missing_importers(selected: &HashSet<String>, lockfile_ids: &[String]) -> Vec
     missing
 }
 
+fn merged_dedicated_lockfile_state(mut state: State) -> miette::Result<(State, Vec<PathBuf>)> {
+    let project_dir = state.project_dir();
+    let workspace_root = state.config.workspace_dir.as_deref().unwrap_or(project_dir);
+    let (projects, _) = discover_workspace_projects(workspace_root)?;
+    let selection =
+        select_recursive_projects(&projects, state.config, project_dir, AutoExcludeRoot::Disabled)?;
+
+    let mut merged: Option<Lockfile> = None;
+    let mut virtual_store_dirs = Vec::with_capacity(selection.selected.len());
+    for selected_dir in selection.selected.keys() {
+        let mut project_config = state.config.clone();
+        project_config.anchor_lockfile_paths(selected_dir);
+        virtual_store_dirs.push(project_config.effective_virtual_store_dir().to_path_buf());
+
+        let Some(mut lockfile) =
+            Lockfile::load_wanted(selected_dir, &state.config.wanted_lockfile_selection())
+                .map_err(miette::Report::new)?
+        else {
+            continue;
+        };
+        let importers = std::mem::take(&mut lockfile.importers);
+        lockfile.importers = importers
+            .into_iter()
+            .map(|(importer_id, importer)| {
+                validate_importer_id(&importer_id).map_err(miette::Report::new)?;
+                let importer_dir = importer_root_dir(selected_dir, &importer_id);
+                let workspace_id =
+                    pnpm_workspace::importer_id_from_root_dir(workspace_root, &importer_dir);
+                Ok((workspace_id, importer))
+            })
+            .collect::<miette::Result<_>>()?;
+        merged = Some(match merged {
+            Some(current) => merge_lockfile_changes(&current, &lockfile),
+            None => lockfile,
+        });
+    }
+
+    virtual_store_dirs.sort_unstable();
+    virtual_store_dirs.dedup();
+    let mut config = state.config.clone();
+    config.lockfile_dir = Some(workspace_root.to_path_buf());
+    state.config = Config::leak(config);
+    state.lockfile = LazyLockfile::preloaded(merged);
+    Ok((state, virtual_store_dirs))
+}
+
 impl SbomArgs {
     pub async fn run(self, state: State) -> miette::Result<()> {
-        if !state.config.shares_one_lockfile()
+        let (state, virtual_store_dirs) = if !state.config.shares_one_lockfile()
             && (state.config.recursive || self.split || selectors_narrow_the_run(state.config))
         {
-            return Err(
-                RecursiveSharedLockfileUnsupported::new("Filtered and split `pnpm sbom`").into()
-            );
-        }
+            let (state, virtual_store_dirs) = merged_dedicated_lockfile_state(state)?;
+            (state, Some(virtual_store_dirs))
+        } else {
+            (state, None)
+        };
         if let Some(ref spec_ver) = self.spec_version {
             if self.format != SbomFormat::CycloneDx {
                 return Err(miette::miette!(
@@ -925,6 +979,7 @@ impl SbomArgs {
                     self.exclude_peers,
                     self.lockfile_only,
                     Some(&filter),
+                    virtual_store_dirs.as_deref(),
                 )?;
                 if result.root_name == "unknown" {
                     continue;
@@ -983,7 +1038,8 @@ impl SbomArgs {
             }
             let _ = stdout.flush();
         } else {
-            let filter_ids: Option<Vec<&str>> = (importer_ids.len() < all_count)
+            let filter_ids: Option<Vec<&str>> = (selectors_narrow_the_run(state.config)
+                || importer_ids.len() < all_count)
                 .then(|| importer_ids.iter().map(String::as_str).collect());
             let result = collect_components(
                 &state,
@@ -992,6 +1048,7 @@ impl SbomArgs {
                 self.exclude_peers,
                 self.lockfile_only,
                 filter_ids.as_deref(),
+                virtual_store_dirs.as_deref(),
             )?;
 
             let output = match self.format {

--- a/pnpm/crates/cli/src/cli_args/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/tests.rs
@@ -297,6 +297,16 @@ fn parallel_before_run_is_a_recursive_unsorted_run_option() {
 }
 
 #[test]
+fn parallel_before_exec_is_a_recursive_unsorted_exec_option() {
+    let mut parsed = CliArgs::try_parse_from(["pacquet", "--parallel", "exec", "echo"])
+        .expect("parses --parallel before exec");
+    parsed.validate_command_scoped_global_options().expect("exec accepts --parallel");
+    parsed.apply_parallel_run_options();
+    assert!(parsed.recursive);
+    assert!(parsed.no_sort);
+}
+
+#[test]
 fn parallel_after_run_script_is_forwarded_to_the_script() {
     let parsed = CliArgs::try_parse_from(["pacquet", "run", "build", "--parallel"])
         .expect("parses --parallel as a script argument");

--- a/pnpm/crates/cli/tests/suite/approve_builds.rs
+++ b/pnpm/crates/cli/tests/suite/approve_builds.rs
@@ -542,33 +542,6 @@ fn approve_builds_all_with_args_is_rejected() {
 
     drop(root);
 }
-
-/// Both spellings reach the same rejection. `-g` used to stop in the
-/// argument parser instead (pnpm/pnpm#13310), which the long form alone
-/// could not have caught.
-#[test]
-fn approve_builds_global_is_rejected() {
-    for global in ["--global", "-g"] {
-        let CommandTempCwd { workspace, root, .. } = CommandTempCwd::init();
-        fs::write(workspace.join("package.json"), "{}").expect("write package.json");
-
-        let assert = pacquet(&workspace).with_args(["approve-builds", global]).assert().failure();
-        let stderr = String::from_utf8_lossy(&assert.get_output().stderr).into_owned();
-        // Code and message both: the code alone would not catch the two
-        // spellings drifting to different user-facing text.
-        assert!(
-            stderr.contains("ERR_PNPM_APPROVE_BUILDS_NOT_SUPPORTED_WITH_GLOBAL"),
-            "{global} stderr: {stderr}",
-        );
-        assert!(
-            stderr.contains(r#""approve-builds" is not supported with global packages"#),
-            "{global} stderr: {stderr}",
-        );
-
-        drop(root);
-    }
-}
-
 /// `--ignore-workspace` disowns the workspace manifest, so the install
 /// must not write the `allowBuilds` scaffold into one.
 #[test]

--- a/pnpm/crates/cli/tests/suite/exec_recursive.rs
+++ b/pnpm/crates/cli/tests/suite/exec_recursive.rs
@@ -110,6 +110,31 @@ fn recursive_exec_respects_workspace_concurrency() {
 }
 
 #[test]
+fn recursive_exec_no_sort_reverse_and_resume_transform_workspace_order() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(&workspace, &["z-first", "m-middle", "a-last"]);
+
+    pacquet
+        .with_args([
+            "--workspace-concurrency=1",
+            "--no-sort",
+            "--reverse",
+            "--resume-from=m-middle",
+            "-r",
+            "exec",
+            "-c",
+            r#"echo "$(basename "$PWD")" >> ../order.log"#,
+        ])
+        .assert()
+        .success();
+
+    let order = fs::read_to_string(workspace.join("order.log")).expect("read order log");
+    assert_eq!(order, "m-middle\na-last\n");
+
+    drop(root);
+}
+
+#[test]
 fn parallel_recursive_exec_has_no_workspace_concurrency_cap() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
     write_workspace(&workspace, &["project-1", "project-2", "project-3"]);
@@ -287,6 +312,31 @@ fn recursive_exec_report_summary_records_every_package_status() {
     let statuses = summary_statuses(&workspace);
     assert_eq!(statuses.get("project-1").map(String::as_str), Some("passed"));
     assert_eq!(statuses.get("project-2").map(String::as_str), Some("passed"));
+
+    drop(root);
+}
+
+#[test]
+fn recursive_exec_bail_summary_records_every_completed_batch_result() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(&workspace, &["fails", "passes"]);
+
+    pacquet
+        .with_args([
+            "--workspace-concurrency=2",
+            "--no-sort",
+            "--report-summary",
+            "-r",
+            "exec",
+            "-c",
+            r#"if [ "$(basename "$PWD")" = fails ]; then exit 1; fi"#,
+        ])
+        .assert()
+        .failure();
+
+    let statuses = summary_statuses(&workspace);
+    assert_eq!(statuses.get("fails").map(String::as_str), Some("failure"));
+    assert_eq!(statuses.get("passes").map(String::as_str), Some("passed"));
 
     drop(root);
 }

--- a/pnpm/crates/cli/tests/suite/exec_recursive.rs
+++ b/pnpm/crates/cli/tests/suite/exec_recursive.rs
@@ -46,6 +46,23 @@ fn summary_statuses(workspace: &Path) -> HashMap<String, String> {
         .collect()
 }
 
+fn write_concurrency_probe(workspace: &Path) {
+    fs::write(
+        workspace.join("track-concurrency.sh"),
+        r#"marker=../active-$(basename "$PWD")
+mkdir "$marker"
+sleep 0.2
+set -- ../active-*
+[ -e "$1" ] || set --
+[ "$#" -ge 2 ] && touch ../saw-parallel
+[ "$#" -gt 2 ] && touch ../exceeded-concurrency
+sleep 0.2
+rmdir "$marker"
+"#,
+    )
+    .expect("write concurrency probe");
+}
+
 /// `pacquet -r exec <command>` runs the command once in every workspace
 /// project, each with cwd == its own package root — a relative `touch`
 /// lands a marker inside each package directory.
@@ -68,6 +85,42 @@ fn recursive_exec_runs_command_in_every_project() {
             "{name} should have run the command in its own directory",
         );
     }
+
+    drop(root);
+}
+
+#[test]
+fn recursive_exec_respects_workspace_concurrency() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(&workspace, &["project-1", "project-2", "project-3"]);
+    write_concurrency_probe(&workspace);
+
+    pacquet
+        .with_args(["--workspace-concurrency=2", "-r", "exec", "sh", "../track-concurrency.sh"])
+        .assert()
+        .success();
+
+    assert!(workspace.join("saw-parallel").exists(), "two commands should overlap");
+    assert!(
+        !workspace.join("exceeded-concurrency").exists(),
+        "no more than two commands should overlap",
+    );
+
+    drop(root);
+}
+
+#[test]
+fn parallel_recursive_exec_has_no_workspace_concurrency_cap() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(&workspace, &["project-1", "project-2", "project-3"]);
+    write_concurrency_probe(&workspace);
+
+    pacquet.with_args(["--parallel", "exec", "sh", "../track-concurrency.sh"]).assert().success();
+
+    assert!(
+        workspace.join("exceeded-concurrency").exists(),
+        "--parallel should start all three commands together",
+    );
 
     drop(root);
 }
@@ -265,14 +318,15 @@ fn recursive_exec_no_bail_runs_all_then_fails() {
     drop(root);
 }
 
-/// Without `--no-bail`, execution stops at the first failing project, so
-/// at least one project never runs.
+/// With one workspace task in flight, execution stops at the first failing
+/// project, so at least one project never runs.
 #[test]
 fn recursive_exec_bail_stops_at_first_failure() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
     write_workspace(&workspace, &["project-1", "project-2", "project-3"]);
 
     let output = pacquet
+        .with_arg("--workspace-concurrency=1")
         .with_arg("-r")
         .with_arg("exec")
         .with_arg("-c")

--- a/pnpm/crates/cli/tests/suite/global.rs
+++ b/pnpm/crates/cli/tests/suite/global.rs
@@ -656,6 +656,53 @@ fn global_add_persists_build_approvals_to_the_global_packages_dir() {
     drop(root);
 }
 
+#[cfg(unix)]
+#[test]
+fn approve_builds_global_approves_every_install_group() {
+    use assert_cmd::assert::OutputAssertExt;
+
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let pnpm_home = root.path().join("pnpm-home");
+    let global_pkg_dir = pnpm_home.join("global").join("v11");
+    prepare_global_home(&pnpm_home, &npmrc_info);
+
+    for package in [
+        "@pnpm.e2e/install-script-example@1.0.0",
+        "@pnpm.e2e/pre-and-postinstall-scripts-example@1.0.0",
+    ] {
+        global_command(&workspace, &pnpm_home).with_args(["add", "-g", package]).assert().success();
+    }
+
+    let install_script =
+        pnpm_global::find_global_package(&global_pkg_dir, "@pnpm.e2e/install-script-example")
+            .expect("scan global packages")
+            .expect("find install-script group")
+            .install_dir
+            .join("node_modules/@pnpm.e2e/install-script-example/generated-by-install.js");
+    let postinstall = pnpm_global::find_global_package(
+        &global_pkg_dir,
+        "@pnpm.e2e/pre-and-postinstall-scripts-example",
+    )
+    .expect("scan global packages")
+    .expect("find pre-and-postinstall group")
+    .install_dir
+    .join("node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example/generated-by-postinstall.js");
+    assert!(!install_script.exists());
+    assert!(!postinstall.exists());
+
+    global_command(&workspace, &pnpm_home)
+        .with_args(["approve-builds", "-g", "--all"])
+        .assert()
+        .success();
+
+    assert!(install_script.exists(), "first install group should be rebuilt");
+    assert!(postinstall.exists(), "second install group should be rebuilt");
+
+    drop(npmrc_info);
+    drop(root);
+}
+
 /// A global install must ignore the `pnpm-workspace.yaml` of global
 /// settings (`allowBuilds`, `catalog`, ...) that lives in the global packages
 /// directory: the per-group install dir sits under it, so an install that
@@ -775,7 +822,7 @@ fn global_add_ignores_caller_project_npmrc_registry() {
 
 #[cfg(unix)]
 #[test]
-fn global_outdated_reads_each_global_install_lockfile() {
+fn recursive_global_outdated_reads_each_global_install_lockfile() {
     use assert_cmd::assert::OutputAssertExt;
 
     let CommandTempCwd { root, workspace, npmrc_info, .. } =
@@ -805,6 +852,7 @@ fn global_outdated_reads_each_global_install_lockfile() {
     let output = global_command(&workspace, &pnpm_home)
         .with_arg("outdated")
         .with_arg("-g")
+        .with_arg("-r")
         .with_arg("--format")
         .with_arg("json")
         .output()

--- a/pnpm/crates/cli/tests/suite/publish_recursive.rs
+++ b/pnpm/crates/cli/tests/suite/publish_recursive.rs
@@ -1,7 +1,7 @@
 //! Recursive-publish integration tests. The no-registry tests exercise the
 //! `publish --recursive` dispatch, `--filter` selection, the private-package
-//! skip, the empty-selection no-op, the `--report-summary` output, and the
-//! unsupported `--batch` gap. The registry tests drive the real binary against
+//! skip, the empty-selection no-op, the `--report-summary` output, and batch
+//! publishing. The registry tests drive the real binary against
 //! a `mockito` registry (pnpr's `TestRegistry` is proxy-mode and rejects
 //! path-less publishes) to cover the actual publish loop: the not-yet-published
 //! probe, the per-package `PUT`, `--force`, and the summary / `--json` shapes —
@@ -145,26 +145,61 @@ fn recursive_publish_json_prints_empty_array_when_nothing_published() {
     drop(root);
 }
 
-/// `--batch` is accepted for surface parity but not yet ported, so a recursive
-/// batch publish fails fast with an explicit message rather than silently
-/// publishing per-package.
+/// `--batch` packs every selected package and sends their publish documents to
+/// pnpr's endpoint in one request instead of falling back to per-package PUTs.
 #[test]
-fn recursive_publish_batch_is_unsupported() {
+fn recursive_publish_batches_selected_packages() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
-    write_workspace(&workspace, &[("project-1", private_pkg("project-1"))]);
+    let mut server = mockito::Server::new();
+    write_workspace(
+        &workspace,
+        &[("project-1", public_pkg("project-1")), ("project-2", public_pkg("project-2"))],
+    );
+    write_registry_npmrc(&workspace, &format!("{}/", server.url()));
+    let batch = server
+        .mock("PUT", "/-/pnpm/v1/publish")
+        .match_body(Matcher::PartialJson(serde_json::json!({
+            "packages": [
+                { "name": "project-1" },
+                { "name": "project-2" },
+            ],
+        })))
+        .with_status(201)
+        .with_body(r#"{"ok":true}"#)
+        .expect(1)
+        .create();
+    let individual =
+        server.mock("PUT", Matcher::Regex(r"^/project-[12]$".to_string())).expect(0).create();
 
-    let assert = pacquet
+    clear_ci(pacquet)
         .with_arg("-r")
         .with_arg("publish")
         .with_arg("--batch")
+        .with_arg("--force")
         .with_arg("--no-git-checks")
         .assert()
+        .success();
+    batch.assert();
+    individual.assert();
+
+    drop(root);
+}
+
+#[test]
+fn recursive_batch_publish_reports_an_unsupported_registry() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    write_workspace(&workspace, &[("project-1", public_pkg("project-1"))]);
+    write_registry_npmrc(&workspace, &format!("{}/", server.url()));
+    let batch = server.mock("PUT", "/-/pnpm/v1/publish").with_status(404).expect(1).create();
+
+    let assert = clear_ci(pacquet)
+        .with_args(["-r", "publish", "--batch", "--force", "--no-git-checks"])
+        .assert()
         .failure();
-    let stderr = assert.get_output().stderr.pipe_as_ref(String::from_utf8_lossy);
-    assert!(
-        stderr.contains("Batch publishing (--batch) is not yet supported"),
-        "expected the batch-unsupported message, got: {stderr}",
-    );
+    batch.assert();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(stderr.contains("ERR_PNPM_BATCH_PUBLISH_UNSUPPORTED"), "stderr: {stderr}");
 
     drop(root);
 }

--- a/pnpm/crates/cli/tests/suite/publish_recursive.rs
+++ b/pnpm/crates/cli/tests/suite/publish_recursive.rs
@@ -186,6 +186,74 @@ fn recursive_publish_batches_selected_packages() {
 }
 
 #[test]
+fn recursive_batch_publish_runs_completed_group_postpublish_scripts_before_a_later_failure() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let mut first_registry = mockito::Server::new();
+    let mut second_registry = mockito::Server::new();
+    write_workspace(
+        &workspace,
+        &[
+            (
+                "project-1",
+                json!({
+                    "name": "project-1",
+                    "version": "1.0.0",
+                    "publishConfig": { "registry": format!("{}/", first_registry.url()) },
+                    "scripts": {
+                        "postpublish": r#"node -e "require('fs').writeFileSync('post-published', '')""#,
+                    },
+                }),
+            ),
+            (
+                "project-2",
+                json!({
+                    "name": "project-2",
+                    "version": "1.0.0",
+                    "dependencies": { "project-1": "1.0.0" },
+                    "publishConfig": { "registry": format!("{}/", second_registry.url()) },
+                    "scripts": {
+                        "postpublish": r#"node -e "require('fs').writeFileSync('post-published', '')""#,
+                    },
+                }),
+            ),
+        ],
+    );
+    let workspace_manifest =
+        fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("read workspace manifest");
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        format!("{workspace_manifest}linkWorkspacePackages: true\n"),
+    )
+    .expect("enable workspace linking");
+    write_registry_npmrc(&workspace, &format!("{}/", first_registry.url()));
+    let first_batch = first_registry
+        .mock("PUT", "/-/pnpm/v1/publish")
+        .with_status(201)
+        .with_body(r#"{"ok":true}"#)
+        .expect(1)
+        .create();
+    let second_batch = second_registry
+        .mock("PUT", "/-/pnpm/v1/publish")
+        .with_status(500)
+        .with_body(r#"{"error":"publish failed"}"#)
+        .expect(1)
+        .create();
+
+    let assert = clear_ci(pacquet)
+        .with_args(["-r", "publish", "--batch", "--force", "--no-git-checks"])
+        .assert()
+        .failure();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(first_batch.matched(), "the first registry was not published: {stderr}");
+    first_batch.assert();
+    second_batch.assert();
+    assert!(workspace.join("project-1/post-published").exists());
+    assert!(!workspace.join("project-2/post-published").exists());
+
+    drop(root);
+}
+
+#[test]
 fn recursive_batch_publish_rejects_mixed_credentials_for_one_registry() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
     let mut server = mockito::Server::new();

--- a/pnpm/crates/cli/tests/suite/publish_recursive.rs
+++ b/pnpm/crates/cli/tests/suite/publish_recursive.rs
@@ -186,6 +186,40 @@ fn recursive_publish_batches_selected_packages() {
 }
 
 #[test]
+fn recursive_batch_publish_uses_registry_auth_for_mixed_scopes() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    write_workspace(
+        &workspace,
+        &[("project-1", public_pkg("@scope/project-1")), ("project-2", public_pkg("project-2"))],
+    );
+    let registry = format!("{}/", server.url());
+    let host = registry.strip_prefix("http://").unwrap_or(&registry);
+    fs::write(
+        workspace.join(".npmrc"),
+        format!(
+            "registry={registry}\n//{host}:_authToken=registry-token\n//{host}:@scope:_authToken=scoped-token\n",
+        ),
+    )
+    .expect("write .npmrc");
+    let batch = server
+        .mock("PUT", "/-/pnpm/v1/publish")
+        .match_header("authorization", "Bearer registry-token")
+        .with_status(201)
+        .with_body(r#"{"ok":true}"#)
+        .expect(1)
+        .create();
+
+    clear_ci(pacquet)
+        .with_args(["-r", "publish", "--batch", "--force", "--no-git-checks"])
+        .assert()
+        .success();
+    batch.assert();
+
+    drop(root);
+}
+
+#[test]
 fn recursive_batch_publish_reports_an_unsupported_registry() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
     let mut server = mockito::Server::new();

--- a/pnpm/crates/cli/tests/suite/publish_recursive.rs
+++ b/pnpm/crates/cli/tests/suite/publish_recursive.rs
@@ -186,7 +186,7 @@ fn recursive_publish_batches_selected_packages() {
 }
 
 #[test]
-fn recursive_batch_publish_uses_registry_auth_for_mixed_scopes() {
+fn recursive_batch_publish_rejects_mixed_credentials_for_one_registry() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
     let mut server = mockito::Server::new();
     write_workspace(
@@ -202,9 +202,40 @@ fn recursive_batch_publish_uses_registry_auth_for_mixed_scopes() {
         ),
     )
     .expect("write .npmrc");
+    let batch = server.mock("PUT", "/-/pnpm/v1/publish").expect(0).create();
+
+    let assert = clear_ci(pacquet)
+        .with_args(["-r", "publish", "--batch", "--force", "--no-git-checks"])
+        .assert()
+        .failure();
+    batch.assert();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(stderr.contains("ERR_PNPM_BATCH_PUBLISH_CONFLICTING_CREDENTIALS"), "stderr: {stderr}");
+
+    drop(root);
+}
+
+#[test]
+fn recursive_batch_publish_accepts_one_scope_credential_for_every_package() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    write_workspace(
+        &workspace,
+        &[
+            ("project-1", public_pkg("@scope/project-1")),
+            ("project-2", public_pkg("@scope/project-2")),
+        ],
+    );
+    let registry = format!("{}/", server.url());
+    let host = registry.strip_prefix("http://").unwrap_or(&registry);
+    fs::write(
+        workspace.join(".npmrc"),
+        format!("registry={registry}\n//{host}:@scope:_authToken=scoped-token\n"),
+    )
+    .expect("write .npmrc");
     let batch = server
         .mock("PUT", "/-/pnpm/v1/publish")
-        .match_header("authorization", "Bearer registry-token")
+        .match_header("authorization", "Bearer scoped-token")
         .with_status(201)
         .with_body(r#"{"ok":true}"#)
         .expect(1)

--- a/pnpm/crates/cli/tests/suite/run_recursive.rs
+++ b/pnpm/crates/cli/tests/suite/run_recursive.rs
@@ -76,6 +76,23 @@ fn build_appends_run_order(name: &str) -> Value {
     })
 }
 
+fn write_concurrency_probe(workspace: &Path) {
+    fs::write(
+        workspace.join("track-concurrency.sh"),
+        r#"marker=../active-$(basename "$PWD")
+mkdir "$marker"
+sleep 0.2
+set -- ../active-*
+[ -e "$1" ] || set --
+[ "$#" -ge 2 ] && touch ../saw-parallel
+[ "$#" -gt 2 ] && touch ../exceeded-concurrency
+sleep 0.2
+rmdir "$marker"
+"#,
+    )
+    .expect("write concurrency probe");
+}
+
 /// `pacquet -r run <script>` runs the script in every workspace project,
 /// in topological order derived from the workspace dependency graph.
 #[test]
@@ -101,6 +118,37 @@ fn recursive_run_executes_script_in_every_project() {
     assert!(
         !workspace.join("ran.txt").exists(),
         "scripts must run from each package root, not the workspace root",
+    );
+
+    drop(root);
+}
+
+#[test]
+fn recursive_run_respects_workspace_concurrency() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let manifest = |name: &str| {
+        json!({
+            "name": name,
+            "version": "1.0.0",
+            "scripts": { "build": "sh ../track-concurrency.sh" },
+        })
+    };
+    write_workspace(
+        &workspace,
+        &[
+            ("project-1", manifest("project-1")),
+            ("project-2", manifest("project-2")),
+            ("project-3", manifest("project-3")),
+        ],
+    );
+    write_concurrency_probe(&workspace);
+
+    pacquet.with_args(["--workspace-concurrency=2", "-r", "run", "build"]).assert().success();
+
+    assert!(workspace.join("saw-parallel").exists(), "two scripts should overlap");
+    assert!(
+        !workspace.join("exceeded-concurrency").exists(),
+        "no more than two scripts should overlap",
     );
 
     drop(root);
@@ -1013,6 +1061,7 @@ fn recursive_run_mixed_filter_runs_prod_selected_before_regular() {
     );
 
     pacquet
+        .with_arg("--workspace-concurrency=1")
         .with_arg("-r")
         .with_arg("--filter")
         .with_arg("alpha")
@@ -1078,6 +1127,7 @@ fn recursive_run_no_sort_uses_workspace_order() {
     );
 
     pacquet
+        .with_arg("--workspace-concurrency=1")
         .with_arg("--no-sort")
         .with_arg("-r")
         .with_arg("run")
@@ -1112,7 +1162,7 @@ fn recursive_run_reads_sort_from_workspace_config() {
     fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - app\n  - lib\nsort: false\n")
         .expect("write workspace settings");
 
-    pacquet.with_args(["-r", "run", "build"]).assert().success();
+    pacquet.with_args(["--workspace-concurrency=1", "-r", "run", "build"]).assert().success();
 
     let order = fs::read_to_string(workspace.join("order.log")).expect("read order log");
     assert_eq!(order, "app\nlib\n");
@@ -1334,6 +1384,7 @@ fn recursive_run_bail_writes_summary_then_stops_at_first_failure() {
     );
 
     let output = pacquet
+        .with_arg("--workspace-concurrency=1")
         .with_arg("-r")
         .with_arg("run")
         .with_arg("--report-summary")

--- a/pnpm/crates/cli/tests/suite/run_recursive.rs
+++ b/pnpm/crates/cli/tests/suite/run_recursive.rs
@@ -1114,21 +1114,23 @@ fn recursive_run_no_sort_uses_workspace_order() {
         &workspace,
         &[
             (
-                "app",
+                "z-app",
                 json!({
-                    "name": "app",
+                    "name": "z-app",
                     "version": "1.0.0",
-                    "scripts": { "build": "echo app >> ../order.log" },
-                    "dependencies": { "lib": "workspace:*" },
+                    "scripts": { "build": "echo z-app >> ../order.log" },
+                    "dependencies": { "a-lib": "workspace:*" },
                 }),
             ),
-            ("lib", build_appends_run_order("lib")),
+            ("a-lib", build_appends_run_order("a-lib")),
         ],
     );
 
     pacquet
         .with_arg("--workspace-concurrency=1")
         .with_arg("--no-sort")
+        .with_arg("--filter-prod=z-app")
+        .with_arg("--filter=a-lib")
         .with_arg("-r")
         .with_arg("run")
         .with_arg("build")
@@ -1136,7 +1138,38 @@ fn recursive_run_no_sort_uses_workspace_order() {
         .success();
 
     let order = fs::read_to_string(workspace.join("order.log")).expect("read order log");
-    assert_eq!(order, "app\nlib\n");
+    assert_eq!(order, "z-app\na-lib\n");
+
+    drop(root);
+}
+
+#[test]
+fn recursive_run_no_sort_reverse_and_resume_transform_workspace_order() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(
+        &workspace,
+        &[
+            ("z-first", build_appends_run_order("z-first")),
+            ("m-middle", build_appends_run_order("m-middle")),
+            ("a-last", build_appends_run_order("a-last")),
+        ],
+    );
+
+    pacquet
+        .with_args([
+            "--workspace-concurrency=1",
+            "--no-sort",
+            "--reverse",
+            "--resume-from=m-middle",
+            "-r",
+            "run",
+            "build",
+        ])
+        .assert()
+        .success();
+
+    let order = fs::read_to_string(workspace.join("order.log")).expect("read order log");
+    assert_eq!(order, "m-middle\na-last\n");
 
     drop(root);
 }
@@ -1323,6 +1356,34 @@ fn recursive_run_report_summary_records_every_package_status() {
     for (name, status) in expected {
         assert_eq!(statuses.get(name).map(String::as_str), Some(status), "status of {name}");
     }
+
+    drop(root);
+}
+
+#[test]
+fn recursive_run_bail_summary_records_every_completed_batch_result() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let manifest = |name: &str, body: &str| json!({ "name": name, "version": "1.0.0", "scripts": { "build": body } });
+    write_workspace(
+        &workspace,
+        &[("fails", manifest("fails", "exit 1")), ("passes", manifest("passes", "true"))],
+    );
+
+    pacquet
+        .with_args([
+            "--workspace-concurrency=2",
+            "--no-sort",
+            "--report-summary",
+            "-r",
+            "run",
+            "build",
+        ])
+        .assert()
+        .failure();
+
+    let statuses = summary_statuses(&workspace);
+    assert_eq!(statuses.get("fails").map(String::as_str), Some("failure"));
+    assert_eq!(statuses.get("passes").map(String::as_str), Some("passed"));
 
     drop(root);
 }

--- a/pnpm/crates/cli/tests/suite/sbom.rs
+++ b/pnpm/crates/cli/tests/suite/sbom.rs
@@ -1,7 +1,7 @@
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pnpm_testing_utils::command_env::CommandTestExt;
-use std::{ffi::OsStr, fs, path::Path, process::Command};
+use std::{collections::HashSet, ffi::OsStr, fs, path::Path, process::Command};
 use tempfile::TempDir;
 
 fn copy_fixture(name: &str) -> TempDir {
@@ -179,6 +179,119 @@ fn split_and_filtered_sbom_read_per_project_workspace_lockfiles() {
             .any(|component| component["name"] == "is-positive"),
         "filtered SBOM should include dependencies from the selected project's lockfile",
     );
+}
+
+#[test]
+fn sbom_rejects_conflicting_entries_from_dedicated_lockfiles() {
+    let tmp = copy_fixture("simple-sbom");
+    let lockfile =
+        fs::read_to_string(tmp.path().join("pnpm-lock.yaml")).expect("read fixture lockfile");
+    for name in ["project-a", "project-b"] {
+        let project_dir = tmp.path().join("packages").join(name);
+        fs::create_dir_all(&project_dir).expect("create project dir");
+        fs::write(
+            project_dir.join("package.json"),
+            serde_json::json!({
+                "name": name,
+                "version": "1.0.0",
+                "dependencies": { "is-positive": "3.1.0" },
+            })
+            .to_string(),
+        )
+        .expect("write project manifest");
+        let project_lockfile = if name == "project-b" {
+            lockfile.replace(&["sha512-8N", "D1"].concat(), "sha512-different")
+        } else {
+            lockfile.clone()
+        };
+        fs::write(project_dir.join("pnpm-lock.yaml"), project_lockfile)
+            .expect("write project lockfile");
+    }
+    fs::remove_file(tmp.path().join("package.json")).expect("remove root manifest");
+    fs::remove_file(tmp.path().join("pnpm-lock.yaml")).expect("remove shared lockfile");
+    fs::write(
+        tmp.path().join("pnpm-workspace.yaml"),
+        "packages:\n  - packages/*\nsharedWorkspaceLockfile: false\n",
+    )
+    .expect("write workspace manifest");
+
+    let output =
+        pacquet(tmp.path(), ["sbom", "--sbom-format", "cyclonedx", "--lockfile-only", "--split"])
+            .output()
+            .expect("run split pacquet sbom");
+
+    assert!(!output.status.success(), "conflicting lockfile entries must fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("ERR_PNPM_SBOM_CONFLICTING_LOCKFILE_ENTRIES"), "stderr: {stderr}");
+    assert!(stderr.contains("is-positive@3.1.0"), "stderr: {stderr}");
+}
+
+#[test]
+fn filtered_sbom_reads_reachable_workspace_project_lockfiles() {
+    let tmp = copy_fixture("simple-sbom");
+    let dependency_lockfile =
+        fs::read_to_string(tmp.path().join("pnpm-lock.yaml")).expect("read fixture lockfile");
+    let project_a = tmp.path().join("packages/project-a");
+    let project_b = tmp.path().join("packages/project-b");
+    fs::create_dir_all(&project_a).expect("create project-a");
+    fs::create_dir_all(&project_b).expect("create project-b");
+    fs::write(
+        project_a.join("package.json"),
+        serde_json::json!({
+            "name": "project-a",
+            "version": "1.0.0",
+            "dependencies": { "project-b": "workspace:*" },
+        })
+        .to_string(),
+    )
+    .expect("write project-a manifest");
+    fs::write(
+        project_b.join("package.json"),
+        serde_json::json!({
+            "name": "project-b",
+            "version": "1.0.0",
+            "dependencies": { "is-positive": "3.1.0" },
+        })
+        .to_string(),
+    )
+    .expect("write project-b manifest");
+    fs::write(
+        project_a.join("pnpm-lock.yaml"),
+        "lockfileVersion: '9.0'\nimporters:\n  .:\n    dependencies:\n      project-b:\n        specifier: workspace:*\n        version: link:../project-b\n",
+    )
+    .expect("write project-a lockfile");
+    fs::write(project_b.join("pnpm-lock.yaml"), dependency_lockfile)
+        .expect("write project-b lockfile");
+    fs::remove_file(tmp.path().join("package.json")).expect("remove root manifest");
+    fs::remove_file(tmp.path().join("pnpm-lock.yaml")).expect("remove shared lockfile");
+    fs::write(
+        tmp.path().join("pnpm-workspace.yaml"),
+        "packages:\n  - packages/*\nsharedWorkspaceLockfile: false\n",
+    )
+    .expect("write workspace manifest");
+
+    let output = pacquet(
+        tmp.path(),
+        ["sbom", "--sbom-format", "cyclonedx", "--lockfile-only", "--filter", "project-a"],
+    )
+    .output()
+    .expect("run filtered pacquet sbom");
+
+    assert!(
+        output.status.success(),
+        "filtered SBOM failed: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let sbom: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("parse filtered SBOM");
+    let component_names: HashSet<&str> = sbom["components"]
+        .as_array()
+        .expect("components array")
+        .iter()
+        .filter_map(|component| component["name"].as_str())
+        .collect();
+    assert!(component_names.contains("project-b"));
+    assert!(component_names.contains("is-positive"));
 }
 
 #[test]

--- a/pnpm/crates/cli/tests/suite/sbom.rs
+++ b/pnpm/crates/cli/tests/suite/sbom.rs
@@ -103,22 +103,81 @@ fn sbom_missing_format_fails() {
 }
 
 #[test]
-fn split_sbom_rejects_per_project_workspace_lockfiles() {
+fn split_and_filtered_sbom_read_per_project_workspace_lockfiles() {
     let tmp = copy_fixture("simple-sbom");
-    fs::write(tmp.path().join("pnpm-workspace.yaml"), "sharedWorkspaceLockfile: false\n")
-        .expect("write workspace manifest");
+    let lockfile = fs::read(tmp.path().join("pnpm-lock.yaml")).expect("read fixture lockfile");
+    for name in ["project-a", "project-b"] {
+        let project_dir = tmp.path().join("packages").join(name);
+        fs::create_dir_all(&project_dir).expect("create project dir");
+        fs::write(
+            project_dir.join("package.json"),
+            serde_json::json!({
+                "name": name,
+                "version": "1.0.0",
+                "dependencies": { "is-positive": "3.1.0" },
+            })
+            .to_string(),
+        )
+        .expect("write project manifest");
+        fs::write(project_dir.join("pnpm-lock.yaml"), &lockfile).expect("write project lockfile");
+    }
+    fs::remove_file(tmp.path().join("package.json")).expect("remove root manifest");
+    fs::remove_file(tmp.path().join("pnpm-lock.yaml")).expect("remove shared lockfile");
+    fs::write(
+        tmp.path().join("pnpm-workspace.yaml"),
+        "packages:\n  - packages/*\nsharedWorkspaceLockfile: false\n",
+    )
+    .expect("write workspace manifest");
 
-    let output =
+    let split =
         pacquet(tmp.path(), ["sbom", "--sbom-format", "cyclonedx", "--lockfile-only", "--split"])
             .output()
             .expect("run split pacquet sbom");
-
-    assert!(!output.status.success());
-    let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("ERR_PNPM_RECURSIVE_SHARED_LOCKFILE_UNSUPPORTED")
-            && stderr.contains("sharedWorkspaceLockfile=false"),
-        "stderr: {stderr}",
+        split.status.success(),
+        "split SBOM failed: {}",
+        String::from_utf8_lossy(&split.stderr),
+    );
+    let mut names = String::from_utf8(split.stdout)
+        .expect("split stdout is UTF-8")
+        .lines()
+        .map(|line| {
+            let sbom: serde_json::Value = serde_json::from_str(line).expect("parse NDJSON line");
+            assert!(
+                sbom["components"]
+                    .as_array()
+                    .expect("components array")
+                    .iter()
+                    .any(|component| component["name"] == "is-positive"),
+                "split SBOM should include dependencies from its project lockfile",
+            );
+            sbom["metadata"]["component"]["name"].as_str().expect("root component name").to_string()
+        })
+        .collect::<Vec<_>>();
+    names.sort_unstable();
+    assert_eq!(names, ["project-a", "project-b"]);
+
+    let filtered = pacquet(
+        tmp.path(),
+        ["sbom", "--sbom-format", "cyclonedx", "--lockfile-only", "--filter", "project-a"],
+    )
+    .output()
+    .expect("run filtered pacquet sbom");
+    assert!(
+        filtered.status.success(),
+        "filtered SBOM failed: {}",
+        String::from_utf8_lossy(&filtered.stderr),
+    );
+    let sbom: serde_json::Value =
+        serde_json::from_slice(&filtered.stdout).expect("parse filtered SBOM");
+    assert_eq!(sbom["metadata"]["component"]["name"], "project-a");
+    assert!(
+        sbom["components"]
+            .as_array()
+            .expect("components array")
+            .iter()
+            .any(|component| component["name"] == "is-positive"),
+        "filtered SBOM should include dependencies from the selected project's lockfile",
     );
 }
 

--- a/pnpm/crates/cli/tests/suite/sbom.rs
+++ b/pnpm/crates/cli/tests/suite/sbom.rs
@@ -223,7 +223,8 @@ fn sbom_rejects_conflicting_entries_from_dedicated_lockfiles() {
     assert!(!output.status.success(), "conflicting lockfile entries must fail");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("ERR_PNPM_SBOM_CONFLICTING_LOCKFILE_ENTRIES"), "stderr: {stderr}");
-    assert!(stderr.contains("is-positive@3.1.0"), "stderr: {stderr}");
+    let compact_stderr: String = stderr.replace('│', "").split_whitespace().collect();
+    assert!(compact_stderr.contains("is-positive@3.1.0"), "stderr: {stderr}");
 }
 
 #[test]
@@ -231,6 +232,10 @@ fn sbom_merges_snapshot_optionality_from_dedicated_lockfiles() {
     let tmp = copy_fixture("simple-sbom");
     let lockfile =
         fs::read_to_string(tmp.path().join("pnpm-lock.yaml")).expect("read fixture lockfile");
+    let lockfile = lockfile.replace(
+        "    engines: {node: '>=0.10.0'}",
+        "    engines: {node: '>=0.10.0'}\n    os: [unsupported-test-os]",
+    );
     for name in ["project-a", "project-b"] {
         let project_dir = tmp.path().join("packages").join(name);
         fs::create_dir_all(&project_dir).expect("create project dir");
@@ -245,10 +250,12 @@ fn sbom_merges_snapshot_optionality_from_dedicated_lockfiles() {
         )
         .expect("write project manifest");
         let project_lockfile = if name == "project-b" {
-            lockfile.replace(
+            let project_lockfile = lockfile.replace(
                 "  is-positive@3.1.0:\n    dev: false",
                 "  is-positive@3.1.0:\n    optional: true\n    dev: false",
-            )
+            );
+            assert_ne!(project_lockfile, lockfile, "mark project-b's snapshot as optional");
+            project_lockfile
         } else {
             lockfile.clone()
         };
@@ -263,20 +270,31 @@ fn sbom_merges_snapshot_optionality_from_dedicated_lockfiles() {
     )
     .expect("write workspace manifest");
 
-    let output =
-        pacquet(tmp.path(), ["sbom", "--sbom-format", "cyclonedx", "--lockfile-only", "--split"])
-            .output()
-            .expect("run split pacquet sbom");
+    let output = pacquet(tmp.path(), ["sbom", "--sbom-format", "cyclonedx", "--split"])
+        .output()
+        .expect("run split pacquet sbom");
 
     assert!(
         output.status.success(),
         "derived snapshot optionality should merge: {}",
         String::from_utf8_lossy(&output.stderr),
     );
+    let sboms: Vec<serde_json::Value> = String::from_utf8(output.stdout)
+        .expect("SBOM output is UTF-8")
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("parse split CycloneDX output"))
+        .collect();
+    assert_eq!(sboms.len(), 2);
+    for sbom in sboms {
+        let components = sbom["components"].as_array().expect("components array");
+        assert!(
+            components.iter().any(|component| component["name"] == "is-positive"),
+            "a required platform-incompatible snapshot must remain in the SBOM",
+        );
+    }
 }
 
-#[test]
-fn filtered_sbom_reads_reachable_workspace_project_lockfiles() {
+fn dedicated_workspace_with_reachable_project() -> TempDir {
     let tmp = copy_fixture("simple-sbom");
     let dependency_lockfile =
         fs::read_to_string(tmp.path().join("pnpm-lock.yaml")).expect("read fixture lockfile");
@@ -319,6 +337,13 @@ fn filtered_sbom_reads_reachable_workspace_project_lockfiles() {
     )
     .expect("write workspace manifest");
 
+    tmp
+}
+
+#[test]
+fn filtered_sbom_reads_reachable_workspace_project_lockfiles() {
+    let tmp = dedicated_workspace_with_reachable_project();
+
     let output = pacquet(
         tmp.path(),
         ["sbom", "--sbom-format", "cyclonedx", "--lockfile-only", "--filter", "project-a"],
@@ -341,6 +366,25 @@ fn filtered_sbom_reads_reachable_workspace_project_lockfiles() {
         .collect();
     assert!(component_names.contains("project-b"));
     assert!(component_names.contains("is-positive"));
+}
+
+#[test]
+fn filtered_sbom_rejects_a_reachable_project_without_a_dedicated_lockfile() {
+    let tmp = dedicated_workspace_with_reachable_project();
+    fs::remove_file(tmp.path().join("packages/project-b/pnpm-lock.yaml"))
+        .expect("remove reachable project lockfile");
+
+    let output = pacquet(
+        tmp.path(),
+        ["sbom", "--sbom-format", "cyclonedx", "--lockfile-only", "--filter", "project-a"],
+    )
+    .output()
+    .expect("run filtered pacquet sbom");
+
+    assert!(!output.status.success(), "an incomplete workspace graph must fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("ERR_PNPM_SBOM_MISSING_IMPORTERS"), "stderr: {stderr}");
+    assert!(stderr.contains("packages/project-b"), "stderr: {stderr}");
 }
 
 #[test]

--- a/pnpm/crates/cli/tests/suite/sbom.rs
+++ b/pnpm/crates/cli/tests/suite/sbom.rs
@@ -227,6 +227,55 @@ fn sbom_rejects_conflicting_entries_from_dedicated_lockfiles() {
 }
 
 #[test]
+fn sbom_merges_snapshot_optionality_from_dedicated_lockfiles() {
+    let tmp = copy_fixture("simple-sbom");
+    let lockfile =
+        fs::read_to_string(tmp.path().join("pnpm-lock.yaml")).expect("read fixture lockfile");
+    for name in ["project-a", "project-b"] {
+        let project_dir = tmp.path().join("packages").join(name);
+        fs::create_dir_all(&project_dir).expect("create project dir");
+        fs::write(
+            project_dir.join("package.json"),
+            serde_json::json!({
+                "name": name,
+                "version": "1.0.0",
+                "dependencies": { "is-positive": "3.1.0" },
+            })
+            .to_string(),
+        )
+        .expect("write project manifest");
+        let project_lockfile = if name == "project-b" {
+            lockfile.replace(
+                "  is-positive@3.1.0:\n    dev: false",
+                "  is-positive@3.1.0:\n    optional: true\n    dev: false",
+            )
+        } else {
+            lockfile.clone()
+        };
+        fs::write(project_dir.join("pnpm-lock.yaml"), project_lockfile)
+            .expect("write project lockfile");
+    }
+    fs::remove_file(tmp.path().join("package.json")).expect("remove root manifest");
+    fs::remove_file(tmp.path().join("pnpm-lock.yaml")).expect("remove shared lockfile");
+    fs::write(
+        tmp.path().join("pnpm-workspace.yaml"),
+        "packages:\n  - packages/*\nsharedWorkspaceLockfile: false\n",
+    )
+    .expect("write workspace manifest");
+
+    let output =
+        pacquet(tmp.path(), ["sbom", "--sbom-format", "cyclonedx", "--lockfile-only", "--split"])
+            .output()
+            .expect("run split pacquet sbom");
+
+    assert!(
+        output.status.success(),
+        "derived snapshot optionality should merge: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
 fn filtered_sbom_reads_reachable_workspace_project_lockfiles() {
     let tmp = copy_fixture("simple-sbom");
     let dependency_lockfile =

--- a/pnpm/crates/executor/Cargo.toml
+++ b/pnpm/crates/executor/Cargo.toml
@@ -18,7 +18,7 @@ deno_task_shell = { workspace = true }
 derive_more     = { workspace = true }
 miette          = { workspace = true }
 serde_json      = { workspace = true }
-tokio           = { workspace = true }
+tokio           = { workspace = true, features = ["process"] }
 tracing         = { workspace = true }
 
 [dev-dependencies]

--- a/pnpm/crates/executor/src/lifecycle.rs
+++ b/pnpm/crates/executor/src/lifecycle.rs
@@ -20,6 +20,7 @@ use std::{
     process::{Child, Command, ExitStatus, Stdio},
     thread,
 };
+use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader as AsyncBufReader};
 
 /// Error from running lifecycle scripts.
 #[derive(Debug, Display, Error, Diagnostic)]
@@ -540,6 +541,26 @@ impl StreamedScript<'_> {
         status
     }
 
+    /// Asynchronously drain a tokio child's piped stdout and stderr into
+    /// lifecycle events, then wait for it.
+    pub async fn pump_async(&self, child: &mut tokio::process::Child) -> io::Result<ExitStatus> {
+        let stdout = child.stdout.take();
+        let stderr = child.stderr.take();
+        let stdout_pump = async {
+            if let Some(stream) = stdout {
+                self.pump_async_stream(stream, LifecycleStdio::Stdout).await;
+            }
+        };
+        let stderr_pump = async {
+            if let Some(stream) = stderr {
+                self.pump_async_stream(stream, LifecycleStdio::Stderr).await;
+            }
+        };
+        let child_wait = child.wait();
+        let (status, (), ()) = tokio::join!(child_wait, stdout_pump, stderr_pump);
+        status
+    }
+
     /// Spawn a thread that reads `reader` line-by-line and republishes
     /// each line.
     ///
@@ -572,15 +593,32 @@ impl StreamedScript<'_> {
                     // non-zero exit code if the child failed over it.
                     Err(_) => break,
                 }
-                if line.last() == Some(&b'\n') {
-                    line.pop();
-                    if line.last() == Some(&b'\r') {
-                        line.pop();
-                    }
-                }
-                target.emit_line(stdio, String::from_utf8_lossy(&line).into_owned());
+                target.emit_bytes_line(stdio, &mut line);
             }
         })
+    }
+
+    async fn pump_async_stream(&self, reader: impl AsyncRead + Unpin, stdio: LifecycleStdio) {
+        let mut reader = AsyncBufReader::new(reader);
+        let mut line = Vec::new();
+        loop {
+            line.clear();
+            match reader.read_until(b'\n', &mut line).await {
+                Ok(0) => break,
+                Ok(_) => self.emit_bytes_line(stdio, &mut line),
+                Err(_) => break,
+            }
+        }
+    }
+
+    fn emit_bytes_line(&self, stdio: LifecycleStdio, line: &mut Vec<u8>) {
+        if line.last() == Some(&b'\n') {
+            line.pop();
+            if line.last() == Some(&b'\r') {
+                line.pop();
+            }
+        }
+        self.emit_line(stdio, String::from_utf8_lossy(line).into_owned());
     }
 
     /// Republish one line of the script's output.

--- a/pnpm/crates/publish/src/batch_publish.rs
+++ b/pnpm/crates/publish/src/batch_publish.rs
@@ -103,7 +103,16 @@ where
         }
     }
 
-    for group in groups {
+    let authorizations = if opts.dry_run {
+        vec![None; groups.len()]
+    } else {
+        groups
+            .iter()
+            .map(|group| batch_authorization(group, network))
+            .collect::<Result<Vec<_>, _>>()?
+    };
+
+    for (group, authorization) in groups.into_iter().zip(authorizations) {
         let registry = registry_for_display(&group.registry);
         for &summary_index in &group.summary_indexes {
             global_info::<Reporter>(&format!("📦 {} → {registry}", summaries[summary_index].id));
@@ -117,7 +126,6 @@ where
         }
 
         let put_url = join_registry(&group.registry, BATCH_PUBLISH_ENDPOINT)?;
-        let authorization = network.auth_headers.for_url(group.registry.as_str());
         let body = bytes::Bytes::from(
             serde_json::to_vec(&serde_json::json!({ "packages": group.documents }))
                 .expect("serialize batch publish documents"),
@@ -154,6 +162,25 @@ where
     Ok(summaries)
 }
 
+fn batch_authorization(
+    group: &BatchGroup,
+    network: &PublishNetwork<'_>,
+) -> Result<Option<String>, BatchPublishError> {
+    let mut package_names = group.package_names.iter();
+    let authorization = package_names.next().and_then(|name| {
+        network.auth_headers.for_url_with_package(group.registry.as_str(), Some(name))
+    });
+    if package_names.any(|name| {
+        network.auth_headers.for_url_with_package(group.registry.as_str(), Some(name))
+            != authorization
+    }) {
+        return Err(BatchPublishError::ConflictingCredentials {
+            registry: registry_for_display(&group.registry),
+        });
+    }
+    Ok(authorization)
+}
+
 /// Failures specific to batch publishing.
 #[derive(Debug, derive_more::Display, derive_more::Error, Diagnostic)]
 pub enum BatchPublishError {
@@ -169,6 +196,20 @@ pub enum BatchPublishError {
         )
     )]
     Provenance,
+
+    #[display(
+        "Packages targeting {registry} resolve to different authentication credentials and cannot be published in one batch"
+    )]
+    #[diagnostic(
+        code(ERR_PNPM_BATCH_PUBLISH_CONFLICTING_CREDENTIALS),
+        help(
+            "Configure one credential that can publish every package targeting this registry, or publish without --batch."
+        )
+    )]
+    ConflictingCredentials {
+        #[error(not(source))]
+        registry: String,
+    },
 
     #[display(
         "The registry at {registry} does not support publishing multiple packages in a single request"

--- a/pnpm/crates/publish/src/batch_publish.rs
+++ b/pnpm/crates/publish/src/batch_publish.rs
@@ -43,14 +43,19 @@ pub fn validate_batch_publish_options(
     Ok(())
 }
 
-/// Publish every packed package in one request per target registry.
-pub async fn batch_publish_packed_pkgs<Reporter>(
+/// Publish every packed package in one request per target registry, calling
+/// `on_group_complete` with the input indexes after each completed registry
+/// group (including dry-run groups).
+pub async fn batch_publish_packed_pkgs<Reporter, OnGroupComplete, Error>(
     packages: &[PackedPkg<'_>],
     opts: &PublishPackedPkgOptions,
     network: &PublishNetwork<'_>,
-) -> Result<Vec<PublishSummary>, BatchPublishError>
+    mut on_group_complete: OnGroupComplete,
+) -> Result<Vec<PublishSummary>, Error>
 where
     Reporter: self::Reporter,
+    OnGroupComplete: FnMut(&[usize]) -> Result<(), Error>,
+    Error: From<BatchPublishError>,
 {
     validate_batch_publish_options(opts)?;
 
@@ -68,7 +73,8 @@ where
             &opts.default_registry,
             &opts.scoped_registries,
             publish_config_registry,
-        )?;
+        )
+        .map_err(BatchPublishError::from)?;
         let summary = create_publish_summary(
             &PackedPkgInfo {
                 published_manifest: manifest,
@@ -85,7 +91,8 @@ where
             resolve_access(opts.access, manifest),
             &opts.tag,
             &DistHashes { integrity: &summary.integrity, shasum: &summary.shasum },
-        )?;
+        )
+        .map_err(BatchPublishError::from)?;
         let summary_index = summaries.len();
         summaries.push(summary);
 
@@ -122,41 +129,44 @@ where
                 "Skip publishing {} package(s) to {registry} (dry run)",
                 group.documents.len(),
             ));
-            continue;
-        }
-
-        let put_url = join_registry(&group.registry, BATCH_PUBLISH_ENDPOINT)?;
-        let body = bytes::Bytes::from(
-            serde_json::to_vec(&serde_json::json!({ "packages": group.documents }))
-                .expect("serialize batch publish documents"),
-        );
-        let response = publish_with_otp_handling::<WebAuthHost, Reporter>(
-            network.client,
-            &put_url,
-            authorization.as_deref(),
-            "publish",
-            body,
-            opts.otp.as_deref(),
-            false,
-            web_auth_fetch_options(&opts.http),
-        )
-        .await?;
-        if !response.ok {
-            if matches!(response.status, 404 | 405) {
-                return Err(BatchPublishError::Unsupported { registry });
+        } else {
+            let put_url = join_registry(&group.registry, BATCH_PUBLISH_ENDPOINT)
+                .map_err(BatchPublishError::from)?;
+            let body = bytes::Bytes::from(
+                serde_json::to_vec(&serde_json::json!({ "packages": group.documents }))
+                    .expect("serialize batch publish documents"),
+            );
+            let response = publish_with_otp_handling::<WebAuthHost, Reporter>(
+                network.client,
+                &put_url,
+                authorization.as_deref(),
+                "publish",
+                body,
+                opts.otp.as_deref(),
+                false,
+                web_auth_fetch_options(&opts.http),
+            )
+            .await
+            .map_err(BatchPublishError::from)?;
+            if !response.ok {
+                if matches!(response.status, 404 | 405) {
+                    return Err(BatchPublishError::Unsupported { registry }.into());
+                }
+                return Err(BatchPublishError::Failed(FailedToPublishError::new_batch(
+                    group.package_names.len(),
+                    &registry,
+                    response.status,
+                    response.status_text,
+                    response.body,
+                ))
+                .into());
             }
-            return Err(BatchPublishError::Failed(FailedToPublishError::new_batch(
-                group.package_names.len(),
-                &registry,
-                response.status,
-                response.status_text,
-                response.body,
-            )));
+            global_info::<Reporter>(&format!(
+                "✅ Published {} package(s) to {registry} in a single request",
+                group.summary_indexes.len(),
+            ));
         }
-        global_info::<Reporter>(&format!(
-            "✅ Published {} package(s) to {registry} in a single request",
-            group.summary_indexes.len(),
-        ));
+        on_group_complete(&group.summary_indexes)?;
     }
 
     Ok(summaries)

--- a/pnpm/crates/publish/src/batch_publish.rs
+++ b/pnpm/crates/publish/src/batch_publish.rs
@@ -117,10 +117,7 @@ where
         }
 
         let put_url = join_registry(&group.registry, BATCH_PUBLISH_ENDPOINT)?;
-        let authorization = network.auth_headers.for_url_with_package(
-            group.registry.as_str(),
-            group.package_names.first().map(String::as_str),
-        );
+        let authorization = network.auth_headers.for_url(group.registry.as_str());
         let body = bytes::Bytes::from(
             serde_json::to_vec(&serde_json::json!({ "packages": group.documents }))
                 .expect("serialize batch publish documents"),

--- a/pnpm/crates/publish/src/batch_publish.rs
+++ b/pnpm/crates/publish/src/batch_publish.rs
@@ -1,0 +1,223 @@
+//! Publish several packed packages through pnpr's atomic batch endpoint.
+
+use pnpm_diagnostics::miette::{self, Diagnostic};
+use pnpm_network_web_auth::{Host as WebAuthHost, WithOtpError};
+use pnpm_reporter::Reporter;
+use serde_json::Value;
+
+use crate::{
+    failed_to_publish_error::FailedToPublishError,
+    global_log::{global_info, global_warn},
+    publish_options::{
+        PublishUnsupportedRegistryProtocolError, find_registry_info, resolve_access,
+    },
+    publish_packed_pkg::{
+        DistHashes, PackedPkg, PublishHttpError, PublishNetwork, PublishPackedPkgError,
+        PublishPackedPkgOptions, build_publish_document, join_registry, publish_with_otp_handling,
+        registry_for_display, web_auth_fetch_options,
+    },
+    publish_summary::{PackedPkgInfo, PublishSummary, create_publish_summary},
+    registry_config_keys::NormalizedRegistryUrl,
+};
+
+const BATCH_PUBLISH_ENDPOINT: &str = "-/pnpm/v1/publish";
+
+struct BatchGroup {
+    registry: NormalizedRegistryUrl,
+    package_names: Vec<String>,
+    summary_indexes: Vec<usize>,
+    documents: Vec<Value>,
+}
+
+/// Reject publish modes whose per-package artifacts cannot be represented by
+/// one batch request.
+pub fn validate_batch_publish_options(
+    opts: &PublishPackedPkgOptions,
+) -> Result<(), BatchPublishError> {
+    if opts.stage {
+        return Err(BatchPublishError::Stage);
+    }
+    if opts.provenance == Some(true) {
+        return Err(BatchPublishError::Provenance);
+    }
+    Ok(())
+}
+
+/// Publish every packed package in one request per target registry.
+pub async fn batch_publish_packed_pkgs<Reporter>(
+    packages: &[PackedPkg<'_>],
+    opts: &PublishPackedPkgOptions,
+    network: &PublishNetwork<'_>,
+) -> Result<Vec<PublishSummary>, BatchPublishError>
+where
+    Reporter: self::Reporter,
+{
+    validate_batch_publish_options(opts)?;
+
+    let mut summaries = Vec::with_capacity(packages.len());
+    let mut groups: Vec<BatchGroup> = Vec::new();
+    for package in packages {
+        let manifest = package.published_manifest;
+        let name = manifest.get("name").and_then(Value::as_str).unwrap_or_default();
+        let publish_config_registry = manifest
+            .get("publishConfig")
+            .and_then(|config| config.get("registry"))
+            .and_then(Value::as_str);
+        let registry = find_registry_info(
+            name,
+            &opts.default_registry,
+            &opts.scoped_registries,
+            publish_config_registry,
+        )?;
+        let summary = create_publish_summary(
+            &PackedPkgInfo {
+                published_manifest: manifest,
+                tarball_path: package.tarball_path,
+                contents: package.contents,
+                unpacked_size: package.unpacked_size,
+            },
+            package.tarball_data,
+        );
+        let document = build_publish_document(
+            manifest,
+            package.tarball_data,
+            &registry,
+            resolve_access(opts.access, manifest),
+            &opts.tag,
+            &DistHashes { integrity: &summary.integrity, shasum: &summary.shasum },
+        )?;
+        let summary_index = summaries.len();
+        summaries.push(summary);
+
+        if let Some(group) = groups.iter_mut().find(|group| group.registry == registry) {
+            group.package_names.push(name.to_string());
+            group.summary_indexes.push(summary_index);
+            group.documents.push(document);
+        } else {
+            groups.push(BatchGroup {
+                registry,
+                package_names: vec![name.to_string()],
+                summary_indexes: vec![summary_index],
+                documents: vec![document],
+            });
+        }
+    }
+
+    for group in groups {
+        let registry = registry_for_display(&group.registry);
+        for &summary_index in &group.summary_indexes {
+            global_info::<Reporter>(&format!("📦 {} → {registry}", summaries[summary_index].id));
+        }
+        if opts.dry_run {
+            global_warn::<Reporter>(&format!(
+                "Skip publishing {} package(s) to {registry} (dry run)",
+                group.documents.len(),
+            ));
+            continue;
+        }
+
+        let put_url = join_registry(&group.registry, BATCH_PUBLISH_ENDPOINT)?;
+        let authorization = network.auth_headers.for_url_with_package(
+            group.registry.as_str(),
+            group.package_names.first().map(String::as_str),
+        );
+        let body = bytes::Bytes::from(
+            serde_json::to_vec(&serde_json::json!({ "packages": group.documents }))
+                .expect("serialize batch publish documents"),
+        );
+        let response = publish_with_otp_handling::<WebAuthHost, Reporter>(
+            network.client,
+            &put_url,
+            authorization.as_deref(),
+            "publish",
+            body,
+            opts.otp.as_deref(),
+            false,
+            web_auth_fetch_options(&opts.http),
+        )
+        .await?;
+        if !response.ok {
+            if matches!(response.status, 404 | 405) {
+                return Err(BatchPublishError::Unsupported { registry });
+            }
+            return Err(BatchPublishError::Failed(FailedToPublishError::new_batch(
+                group.package_names.len(),
+                &registry,
+                response.status,
+                response.status_text,
+                response.body,
+            )));
+        }
+        global_info::<Reporter>(&format!(
+            "✅ Published {} package(s) to {registry} in a single request",
+            group.summary_indexes.len(),
+        ));
+    }
+
+    Ok(summaries)
+}
+
+/// Failures specific to batch publishing.
+#[derive(Debug, derive_more::Display, derive_more::Error, Diagnostic)]
+pub enum BatchPublishError {
+    #[display("Staged publishing cannot be combined with --batch")]
+    #[diagnostic(code(ERR_PNPM_BATCH_PUBLISH_NO_STAGE))]
+    Stage,
+
+    #[display("Provenance statements cannot be generated when publishing with --batch")]
+    #[diagnostic(
+        code(ERR_PNPM_BATCH_PUBLISH_NO_PROVENANCE),
+        help(
+            "Provenance is bound to a single package, but --batch sends many packages in one request. Publish without --batch to attach provenance."
+        )
+    )]
+    Provenance,
+
+    #[display(
+        "The registry at {registry} does not support publishing multiple packages in a single request"
+    )]
+    #[diagnostic(
+        code(ERR_PNPM_BATCH_PUBLISH_UNSUPPORTED),
+        help(
+            r#"Retry without the --batch flag, or publish to a registry that implements "PUT /-/pnpm/v1/publish" (for example, pnpr)."#
+        )
+    )]
+    Unsupported {
+        #[error(not(source))]
+        registry: String,
+    },
+
+    #[display("{_0}")]
+    #[diagnostic(transparent)]
+    Registry(PublishUnsupportedRegistryProtocolError),
+
+    #[display("{_0}")]
+    #[diagnostic(transparent)]
+    Package(PublishPackedPkgError),
+
+    #[display("{_0}")]
+    #[diagnostic(transparent)]
+    Otp(WithOtpError<PublishHttpError>),
+
+    #[display("{_0}")]
+    #[diagnostic(transparent)]
+    Failed(FailedToPublishError),
+}
+
+impl From<PublishUnsupportedRegistryProtocolError> for BatchPublishError {
+    fn from(error: PublishUnsupportedRegistryProtocolError) -> Self {
+        BatchPublishError::Registry(error)
+    }
+}
+
+impl From<PublishPackedPkgError> for BatchPublishError {
+    fn from(error: PublishPackedPkgError) -> Self {
+        BatchPublishError::Package(error)
+    }
+}
+
+impl From<WithOtpError<PublishHttpError>> for BatchPublishError {
+    fn from(error: WithOtpError<PublishHttpError>) -> Self {
+        BatchPublishError::Otp(error)
+    }
+}

--- a/pnpm/crates/publish/src/failed_to_publish_error.rs
+++ b/pnpm/crates/publish/src/failed_to_publish_error.rs
@@ -25,6 +25,27 @@ impl FailedToPublishError {
     /// a single-line body appended inline.
     #[must_use]
     pub fn new(name: &str, version: &str, status: u16, status_text: String, text: String) -> Self {
+        Self::from_response(&format!("package {name}@{version}"), status, status_text, text)
+    }
+
+    /// Build the error for one rejected batch request.
+    #[must_use]
+    pub fn new_batch(
+        package_count: usize,
+        registry: &str,
+        status: u16,
+        status_text: String,
+        text: String,
+    ) -> Self {
+        Self::from_response(
+            &format!("{package_count} packages to {registry}"),
+            status,
+            status_text,
+            text,
+        )
+    }
+
+    fn from_response(subject: &str, status: u16, status_text: String, text: String) -> Self {
         let status_display = if status_text.is_empty() {
             status.to_string()
         } else {
@@ -32,8 +53,7 @@ impl FailedToPublishError {
         };
 
         let trimmed = text.trim();
-        let mut message =
-            format!("Failed to publish package {name}@{version} (status {status_display})");
+        let mut message = format!("Failed to publish {subject} (status {status_display})");
         if trimmed.contains('\n') {
             message.push_str("\nDetails:\n");
             for line in text.trim_end().split('\n') {

--- a/pnpm/crates/publish/src/lib.rs
+++ b/pnpm/crates/publish/src/lib.rs
@@ -1,6 +1,7 @@
 //! Publish a package to an npm registry — pnpm's `publish` command,
 //! implemented in Rust.
 
+mod batch_publish;
 mod capabilities;
 mod display_error;
 mod execute_token_helper;
@@ -16,6 +17,9 @@ mod publish_packed_pkg;
 mod publish_summary;
 mod registry_config_keys;
 
+pub use batch_publish::{
+    BatchPublishError, batch_publish_packed_pkgs, validate_batch_publish_options,
+};
 pub use capabilities::{
     Clock, CommandOutput, ConfirmPrompt, EnvVar, Host, OidcFetch, OidcFetchError, OidcMethod,
     OidcRequest, OidcResponse, RunCommand,

--- a/pnpm/crates/publish/src/publish_packed_pkg.rs
+++ b/pnpm/crates/publish/src/publish_packed_pkg.rs
@@ -185,11 +185,11 @@ where
 
 /// One completed publish response.
 #[derive(Debug)]
-struct PublishResponse {
-    ok: bool,
-    status: u16,
-    status_text: String,
-    body: String,
+pub(crate) struct PublishResponse {
+    pub(crate) ok: bool,
+    pub(crate) status: u16,
+    pub(crate) status_text: String,
+    pub(crate) body: String,
     stage_id: Option<String>,
 }
 
@@ -231,7 +231,7 @@ impl OtpError for PublishHttpError {
     clippy::too_many_arguments,
     reason = "a single registry request legitimately needs the URL, auth, command, body, OTP, stage flag and retry options"
 )]
-async fn publish_with_otp_handling<Sys, Reporter>(
+pub(crate) async fn publish_with_otp_handling<Sys, Reporter>(
     client: &ThrottledClient,
     put_url: &str,
     authorization: Option<&str>,
@@ -364,7 +364,7 @@ fn stage_id_from_body(body: &str) -> Option<String> {
         .and_then(|json| json.get("stageId")?.as_str().map(str::to_owned))
 }
 
-fn web_auth_fetch_options(http: &OidcHttpOptions) -> WebAuthFetchOptions {
+pub(crate) fn web_auth_fetch_options(http: &OidcHttpOptions) -> WebAuthFetchOptions {
     WebAuthFetchOptions {
         timeout: http.fetch_timeout,
         retry: Some(WebAuthRetryOptions {
@@ -379,16 +379,16 @@ fn web_auth_fetch_options(http: &OidcHttpOptions) -> WebAuthFetchOptions {
 
 /// The tarball digests written into the document's `dist`, already computed by
 /// [`create_publish_summary`] so the tarball is not hashed twice.
-struct DistHashes<'a> {
+pub(crate) struct DistHashes<'a> {
     /// SRI SHA-512 (`sha512-...`).
-    integrity: &'a str,
+    pub(crate) integrity: &'a str,
     /// Lowercase hex SHA-1.
-    shasum: &'a str,
+    pub(crate) shasum: &'a str,
 }
 
 /// Build the npm publish document — the JSON body sent as the whole
 /// `PUT /:pkg` request.
-fn build_publish_document(
+pub(crate) fn build_publish_document(
     manifest: &Value,
     tarball_data: &[u8],
     registry: &NormalizedRegistryUrl,
@@ -462,7 +462,7 @@ fn build_publish_document(
 }
 
 /// Resolve `path` against the registry the way `new URL(path, registry)` does.
-fn join_registry(
+pub(crate) fn join_registry(
     registry: &NormalizedRegistryUrl,
     path: &str,
 ) -> Result<String, PublishPackedPkgError> {
@@ -477,7 +477,7 @@ fn join_registry(
 /// A typed entry point over [`redact_url_credentials`] for the
 /// `NormalizedRegistryUrl` log site; the unsanitized URL is still used for the
 /// request and auth-header lookup.
-fn registry_for_display(registry: &NormalizedRegistryUrl) -> String {
+pub(crate) fn registry_for_display(registry: &NormalizedRegistryUrl) -> String {
     redact_url_credentials(registry.as_str())
 }
 

--- a/pnpm11/building/commands/package.json
+++ b/pnpm11/building/commands/package.json
@@ -42,6 +42,7 @@
     "@pnpm/config.writer": "workspace:*",
     "@pnpm/deps.path": "workspace:*",
     "@pnpm/error": "workspace:*",
+    "@pnpm/global.packages": "workspace:*",
     "@pnpm/installing.commands": "workspace:*",
     "@pnpm/installing.modules-yaml": "workspace:*",
     "@pnpm/prepare-temp-dir": "workspace:*",
@@ -50,6 +51,7 @@
     "@pnpm/types": "workspace:*",
     "@pnpm/workspace.projects-sorter": "workspace:*",
     "chalk": "catalog:",
+    "is-subdir": "catalog:",
     "p-limit": "catalog:",
     "ramda": "catalog:",
     "render-help": "catalog:"

--- a/pnpm11/building/commands/package.json
+++ b/pnpm11/building/commands/package.json
@@ -50,6 +50,7 @@
     "@pnpm/text.ordinal-comparator": "workspace:*",
     "@pnpm/types": "workspace:*",
     "@pnpm/workspace.projects-sorter": "workspace:*",
+    "@pnpm/workspace.workspace-manifest-reader": "workspace:*",
     "chalk": "catalog:",
     "is-subdir": "catalog:",
     "p-limit": "catalog:",

--- a/pnpm11/building/commands/src/policy/approveBuilds.ts
+++ b/pnpm11/building/commands/src/policy/approveBuilds.ts
@@ -1,20 +1,24 @@
+import fs from 'node:fs'
+
 import { checkbox, confirm } from '@inquirer/prompts'
 import { allowBuildKeyFromIgnoredBuild } from '@pnpm/building.policy'
 import type { CommandHandlerMap } from '@pnpm/cli.command'
 import type { Config, ConfigContext } from '@pnpm/config.reader'
 import { writeSettings } from '@pnpm/config.writer'
 import { PnpmError } from '@pnpm/error'
+import { scanGlobalPackages } from '@pnpm/global.packages'
 import { install } from '@pnpm/installing.commands'
 import { type Modules, writeModulesManifest } from '@pnpm/installing.modules-yaml'
 import { globalInfo } from '@pnpm/logger'
 import { lexCompare } from '@pnpm/text.ordinal-comparator'
 import chalk from 'chalk'
+import { isSubdir } from 'is-subdir'
 import { renderHelp } from 'render-help'
 
 import { rebuild, type RebuildCommandOpts } from '../build/index.js'
 import { getAutomaticallyIgnoredBuilds } from './getAutomaticallyIgnoredBuilds.js'
 
-export type ApproveBuildsCommandOpts = Pick<Config, 'modulesDir' | 'dir' | 'allowBuilds' | 'enableGlobalVirtualStore'> & Pick<ConfigContext, 'rootProjectManifest' | 'rootProjectManifestDir'> & {
+export type ApproveBuildsCommandOpts = Pick<Config, 'modulesDir' | 'dir' | 'allowBuilds' | 'enableGlobalVirtualStore' | 'globalPkgDir'> & Pick<ConfigContext, 'rootProjectManifest' | 'rootProjectManifestDir'> & {
   all?: boolean
   global?: boolean
   /**
@@ -49,6 +53,11 @@ export function help (): string {
             description: 'Approve all pending dependencies without interactive prompts',
             name: '--all',
           },
+          {
+            description: 'Approve builds for globally installed packages',
+            name: '--global',
+            shortAlias: '-g',
+          },
         ],
       },
     ],
@@ -67,28 +76,15 @@ export function rcOptionsTypes (): Record<string, unknown> {
 }
 
 export async function handler (opts: ApproveBuildsCommandOpts & RebuildCommandOpts, params: string[] = [], commands?: CommandHandlerMap): Promise<void> {
-  if (opts.global) {
-    throw new PnpmError(
-      'APPROVE_BUILDS_NOT_SUPPORTED_WITH_GLOBAL',
-      '"approve-builds" is not supported with global packages',
-      {
-        hint: 'Use --allow-build when installing globally, e.g. "pnpm add -g --allow-build=<pkg> <pkg>". ' +
-          'pnpm will also prompt to allow builds interactively during global install.',
-      }
-    )
-  }
   if (opts.all && params.length) {
     throw new PnpmError(
       'APPROVE_BUILDS_ALL_WITH_ARGS',
       'Cannot use --all with positional arguments'
     )
   }
-  const {
-    automaticallyIgnoredBuilds,
-    modulesDir,
-    modulesManifest,
-  } = await getAutomaticallyIgnoredBuilds(opts)
-  if (!automaticallyIgnoredBuilds?.length) {
+  const targets = await getApprovalTargets(opts)
+  const automaticallyIgnoredBuilds = sortUniqueStrings(targets.flatMap((target) => target.automaticallyIgnoredBuilds ?? []))
+  if (!automaticallyIgnoredBuilds.length) {
     globalInfo('There are no packages awaiting approval')
     return
   }
@@ -191,42 +187,75 @@ export async function handler (opts: ApproveBuildsCommandOpts & RebuildCommandOp
   }
   await writeSettings({
     ...opts,
-    workspaceDir: opts.settingsDir ?? opts.workspaceDir ?? opts.rootProjectManifestDir,
+    workspaceDir: opts.settingsDir ?? (opts.global ? opts.globalPkgDir : opts.workspaceDir ?? opts.rootProjectManifestDir),
     updatedSettings: { allowBuilds },
     deletedLegacyKeys: LEGACY_BUILD_SETTINGS,
   })
-  if (modulesManifest?.ignoredBuilds) {
-    if (params.length) {
-      const decided = new Set([...approved, ...denied])
-      for (const depPath of Array.from(modulesManifest.ignoredBuilds)) {
-        const name = allowBuildKeyFromIgnoredBuild(depPath)
-        if (decided.has(name)) {
+  const decided = new Set([...approved, ...denied])
+  await Promise.all(targets.map(async ({ modulesDir, modulesManifest }) => {
+    if (!modulesManifest?.ignoredBuilds) return
+    if (!params.length) {
+      delete modulesManifest.ignoredBuilds
+    } else {
+      for (const depPath of modulesManifest.ignoredBuilds) {
+        if (decided.has(allowBuildKeyFromIgnoredBuild(depPath))) {
           modulesManifest.ignoredBuilds.delete(depPath)
         }
       }
-      if (!modulesManifest.ignoredBuilds.size) {
-        delete modulesManifest.ignoredBuilds
-      }
-    } else {
-      delete modulesManifest.ignoredBuilds
+      if (!modulesManifest.ignoredBuilds.size) delete modulesManifest.ignoredBuilds
     }
     await writeModulesManifest(modulesDir, modulesManifest as Modules)
-  }
-  if (buildPackages.length) {
-    if (opts.enableGlobalVirtualStore) {
+  }))
+  await Promise.all(targets.map(async (target) => {
+    const targetBuildPackages = buildPackages.filter((name) => target.automaticallyIgnoredBuilds?.includes(name))
+    if (!targetBuildPackages.length) return
+    if (target.opts.enableGlobalVirtualStore) {
       await install.handler({
-        ...opts,
+        ...target.opts,
         allowBuilds,
         frozenLockfile: true,
         optimisticRepeatInstall: false,
       } as any, [], commands) // eslint-disable-line @typescript-eslint/no-explicit-any
       return
     }
-    return rebuild.handler({
-      ...opts,
+    await rebuild.handler({
+      ...target.opts,
       allowBuilds,
-    }, buildPackages)
+    }, targetBuildPackages)
+  }))
+}
+
+interface ApprovalTarget {
+  automaticallyIgnoredBuilds: string[] | null
+  modulesDir: string
+  modulesManifest: Modules | null
+  opts: ApproveBuildsCommandOpts & RebuildCommandOpts
+}
+
+async function getApprovalTargets (opts: ApproveBuildsCommandOpts & RebuildCommandOpts): Promise<ApprovalTarget[]> {
+  if (!opts.global) {
+    return [{ ...await getAutomaticallyIgnoredBuilds(opts), opts }]
   }
+  const scannedGroups = scanGlobalPackages(opts.globalPkgDir)
+  if (!scannedGroups.length) return []
+  const globalPkgDir = fs.realpathSync(opts.globalPkgDir)
+  const groups = scannedGroups.filter(({ installDir }) => isSubdir(globalPkgDir, installDir))
+  return Promise.all(groups.map(async ({ installDir }) => {
+    const groupOpts = {
+      ...opts,
+      allProjects: undefined,
+      dir: installDir,
+      global: false,
+      lockfileDir: installDir,
+      modulesDir: undefined,
+      rootProjectManifest: undefined,
+      rootProjectManifestDir: installDir,
+      selectedProjectsGraph: undefined,
+      workspaceDir: undefined,
+      workspacePackagePatterns: undefined,
+    } as ApproveBuildsCommandOpts & RebuildCommandOpts
+    return { ...await getAutomaticallyIgnoredBuilds(groupOpts), opts: groupOpts }
+  }))
 }
 
 function sortUniqueStrings (array: string[]): string[] {

--- a/pnpm11/building/commands/src/policy/approveBuilds.ts
+++ b/pnpm11/building/commands/src/policy/approveBuilds.ts
@@ -11,6 +11,7 @@ import { install } from '@pnpm/installing.commands'
 import { type Modules, writeModulesManifest } from '@pnpm/installing.modules-yaml'
 import { globalInfo } from '@pnpm/logger'
 import { lexCompare } from '@pnpm/text.ordinal-comparator'
+import { readWorkspaceManifest } from '@pnpm/workspace.workspace-manifest-reader'
 import chalk from 'chalk'
 import { isSubdir } from 'is-subdir'
 import { renderHelp } from 'render-help'
@@ -147,7 +148,10 @@ export async function handler (opts: ApproveBuildsCommandOpts & RebuildCommandOp
       throw err
     }
   }
-  const allowBuilds: Record<string, boolean | string> = { ...opts.allowBuilds }
+  const existingAllowBuilds = opts.global
+    ? (await readWorkspaceManifest(opts.globalPkgDir))?.allowBuilds
+    : opts.allowBuilds
+  const allowBuilds: Record<string, boolean | string> = { ...existingAllowBuilds }
   if (params.length) {
     for (const pkg of approved) {
       allowBuilds[pkg] = true

--- a/pnpm11/building/commands/tsconfig.json
+++ b/pnpm11/building/commands/tsconfig.json
@@ -91,6 +91,9 @@
       "path": "../../workspace/projects-sorter"
     },
     {
+      "path": "../../workspace/workspace-manifest-reader"
+    },
+    {
       "path": "../after-install"
     },
     {

--- a/pnpm11/building/commands/tsconfig.json
+++ b/pnpm11/building/commands/tsconfig.json
@@ -58,6 +58,9 @@
       "path": "../../deps/path"
     },
     {
+      "path": "../../global/packages"
+    },
+    {
       "path": "../../installing/commands"
     },
     {

--- a/pnpm11/pnpm/test/install/global.ts
+++ b/pnpm11/pnpm/test/install/global.ts
@@ -238,10 +238,16 @@ test('approve-builds -g approves pending builds in every global install group', 
 
   expect(fs.existsSync(path.join(installScriptPkg, 'generated-by-install.js'))).toBe(true)
   expect(fs.existsSync(path.join(preAndPostinstallPkg, 'generated-by-postinstall.js'))).toBe(true)
-  expect(readYamlFileSync<any>(globalWorkspaceManifestPath).allowBuilds).toMatchObject({ // eslint-disable-line
+  const localWorkspaceManifest = readYamlFileSync<{ allowBuilds?: Record<string, boolean> }>('pnpm-workspace.yaml')
+  expect(localWorkspaceManifest.allowBuilds).toMatchObject({
+    'caller-project-policy': true,
+  })
+  expect(localWorkspaceManifest.allowBuilds).not.toHaveProperty('existing-global-policy')
+  const globalWorkspaceManifest = readYamlFileSync<{ allowBuilds?: Record<string, boolean> }>(globalWorkspaceManifestPath)
+  expect(globalWorkspaceManifest.allowBuilds).toMatchObject({
     'existing-global-policy': false,
   })
-  expect(readYamlFileSync<any>(globalWorkspaceManifestPath).allowBuilds).not.toHaveProperty('caller-project-policy') // eslint-disable-line
+  expect(globalWorkspaceManifest.allowBuilds).not.toHaveProperty('caller-project-policy')
 })
 
 // CONTEXT: dangerously-allow-all-builds has been removed from rc files, as a result, this test no longer applies

--- a/pnpm11/pnpm/test/install/global.ts
+++ b/pnpm11/pnpm/test/install/global.ts
@@ -206,6 +206,31 @@ test('approve-builds during global add does not produce a doubled modules path',
   expect(fs.existsSync(path.join(pkgPath!, 'generated-by-install.js'))).toBe(true)
 })
 
+test('approve-builds -g approves pending builds in every global install group', async () => {
+  prepare()
+  const global = path.resolve('..', 'global')
+  const pnpmHome = path.join(global, 'pnpm')
+  fs.mkdirSync(pnpmHome, { recursive: true })
+
+  const env = {
+    [PATH_NAME]: `${path.join(pnpmHome, 'bin')}${path.delimiter}${process.env[PATH_NAME]!}`,
+    PNPM_HOME: pnpmHome,
+    XDG_DATA_HOME: global,
+  }
+  await execPnpm(['add', '-g', '@pnpm.e2e/install-script-example@1.0.0'], { env })
+  await execPnpm(['add', '-g', '@pnpm.e2e/pre-and-postinstall-scripts-example@1.0.0'], { env })
+
+  const installScriptPkg = findGlobalPkg(globalPkgDir(pnpmHome), '@pnpm.e2e/install-script-example')!
+  const preAndPostinstallPkg = findGlobalPkg(globalPkgDir(pnpmHome), '@pnpm.e2e/pre-and-postinstall-scripts-example')!
+  expect(fs.existsSync(path.join(installScriptPkg, 'generated-by-install.js'))).toBe(false)
+  expect(fs.existsSync(path.join(preAndPostinstallPkg, 'generated-by-postinstall.js'))).toBe(false)
+
+  await execPnpm(['approve-builds', '-g', '--all'], { env })
+
+  expect(fs.existsSync(path.join(installScriptPkg, 'generated-by-install.js'))).toBe(true)
+  expect(fs.existsSync(path.join(preAndPostinstallPkg, 'generated-by-postinstall.js'))).toBe(true)
+})
+
 // CONTEXT: dangerously-allow-all-builds has been removed from rc files, as a result, this test no longer applies
 // TODO: Maybe we should create a yaml config file specifically for `--global`? After all, this test is to serve such use-cases
 test.skip('dangerously-allow-all-builds=true in global config', async () => {

--- a/pnpm11/pnpm/test/install/global.ts
+++ b/pnpm11/pnpm/test/install/global.ts
@@ -208,6 +208,10 @@ test('approve-builds during global add does not produce a doubled modules path',
 
 test('approve-builds -g approves pending builds in every global install group', async () => {
   prepare()
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    packages: [],
+    allowBuilds: { 'caller-project-policy': true },
+  })
   const global = path.resolve('..', 'global')
   const pnpmHome = path.join(global, 'pnpm')
   fs.mkdirSync(pnpmHome, { recursive: true })
@@ -225,10 +229,19 @@ test('approve-builds -g approves pending builds in every global install group', 
   expect(fs.existsSync(path.join(installScriptPkg, 'generated-by-install.js'))).toBe(false)
   expect(fs.existsSync(path.join(preAndPostinstallPkg, 'generated-by-postinstall.js'))).toBe(false)
 
+  const globalWorkspaceManifestPath = path.join(globalPkgDir(pnpmHome), 'pnpm-workspace.yaml')
+  writeYamlFileSync(globalWorkspaceManifestPath, {
+    allowBuilds: { 'existing-global-policy': false },
+  })
+
   await execPnpm(['approve-builds', '-g', '--all'], { env })
 
   expect(fs.existsSync(path.join(installScriptPkg, 'generated-by-install.js'))).toBe(true)
   expect(fs.existsSync(path.join(preAndPostinstallPkg, 'generated-by-postinstall.js'))).toBe(true)
+  expect(readYamlFileSync<any>(globalWorkspaceManifestPath).allowBuilds).toMatchObject({ // eslint-disable-line
+    'existing-global-policy': false,
+  })
+  expect(readYamlFileSync<any>(globalWorkspaceManifestPath).allowBuilds).not.toHaveProperty('caller-project-policy') // eslint-disable-line
 })
 
 // CONTEXT: dangerously-allow-all-builds has been removed from rc files, as a result, this test no longer applies

--- a/pnpm11/releasing/commands/src/publish/batchPublish.ts
+++ b/pnpm11/releasing/commands/src/publish/batchPublish.ts
@@ -8,7 +8,7 @@ import type { RunLifecycleHookOptions } from '@pnpm/exec.lifecycle'
 import { globalInfo, globalWarn } from '@pnpm/logger'
 import { type WebAuthFetchOptions, withOtpHandling } from '@pnpm/network.web-auth'
 import type { ExportedManifest } from '@pnpm/releasing.exportable-manifest'
-import type { Project } from '@pnpm/types'
+import { type Creds, DEFAULT_REGISTRY_SCOPE, type Project } from '@pnpm/types'
 import { rimraf } from '@zkochan/rimraf'
 import npmFetch from 'npm-registry-fetch'
 import { realpathMissing } from 'realpath-missing'
@@ -39,6 +39,10 @@ interface PackedPkg {
   summary: PublishSummary
 }
 
+type GroupedPackedPkg = PackedPkg & {
+  credentials: Creds | undefined
+}
+
 /**
  * Publish all {@link pkgs} by sending a single `PUT /-/pnpm/v1/publish` request per target
  * registry, instead of one request per package. The endpoint is not part of the standard npm
@@ -61,7 +65,7 @@ export async function batchPublishPackages (pkgs: Project[], opts: BatchPublishO
       hint: 'Provenance is bound to a single package, but --batch sends many packages in one request. Publish without --batch to attach provenance.',
     })
   }
-  const packedByRegistry = new Map<string, PackedPkg[]>()
+  const packedByRegistry = new Map<string, GroupedPackedPkg[]>()
   const packedPkgs: PackedPkg[] = []
   for (const project of pkgs) {
     // eslint-disable-next-line no-await-in-loop
@@ -69,14 +73,24 @@ export async function batchPublishPackages (pkgs: Project[], opts: BatchPublishO
     const publishConfigRegistry = typeof packedPkg.publishedManifest.publishConfig?.registry === 'string'
       ? packedPkg.publishedManifest.publishConfig.registry
       : undefined
-    const { registry } = findRegistryInfo(packedPkg.publishedManifest, opts, publishConfigRegistry)
+    const { config, registry } = findRegistryInfo(packedPkg.publishedManifest, opts, publishConfigRegistry)
     let group = packedByRegistry.get(registry!)
     if (!group) {
       group = []
       packedByRegistry.set(registry!, group)
     }
-    group.push(packedPkg)
+    group.push({
+      ...packedPkg,
+      credentials: config?.[DEFAULT_REGISTRY_SCOPE],
+    })
     packedPkgs.push(packedPkg)
+  }
+  const publishOptionsByRegistry = new Map<string, Awaited<ReturnType<typeof createPublishOptions>>>()
+  if (!opts.dryRun) {
+    for (const [registry, group] of packedByRegistry.entries()) {
+      // eslint-disable-next-line no-await-in-loop
+      publishOptionsByRegistry.set(registry, await createBatchPublishOptions(registry, group, opts))
+    }
   }
   for (const [registry, group] of packedByRegistry.entries()) {
     for (const { summary } of group) {
@@ -86,8 +100,12 @@ export async function batchPublishPackages (pkgs: Project[], opts: BatchPublishO
       globalWarn(`Skip publishing ${group.length} package(s) to ${registry} (dry run)`)
       continue
     }
+    const publishOptions = publishOptionsByRegistry.get(registry)
+    if (publishOptions == null) {
+      throw new Error(`Missing precomputed publish options for ${registry}`)
+    }
     // eslint-disable-next-line no-await-in-loop
-    await multiPublishToRegistry(registry, group, opts)
+    await multiPublishToRegistry({ registry, group, opts, publishOptions })
     globalInfo(`✅ Published ${group.length} package(s) to ${registry} in a single request`)
   }
   if (!opts.ignoreScripts) {
@@ -97,6 +115,32 @@ export async function batchPublishPackages (pkgs: Project[], opts: BatchPublishO
     }
   }
   return packedPkgs.map(({ summary }) => summary)
+}
+
+async function createBatchPublishOptions (
+  registry: string,
+  group: GroupedPackedPkg[],
+  opts: BatchPublishOptions
+): Promise<Awaited<ReturnType<typeof createPublishOptions>>> {
+  const [first, ...rest] = group
+  if (rest.some(({ credentials }) => !sameCredentials(first.credentials, credentials))) {
+    throw new PnpmError(
+      'BATCH_PUBLISH_CONFLICTING_CREDENTIALS',
+      `Packages targeting ${registry} resolve to different authentication credentials and cannot be published in one batch`,
+      {
+        hint: 'Configure one credential that can publish every package targeting this registry, or publish without --batch.',
+      }
+    )
+  }
+  return createPublishOptions(first.publishedManifest, opts, { oidc: false })
+}
+
+function sameCredentials (left: Creds | undefined, right: Creds | undefined): boolean {
+  return left?.authToken === right?.authToken &&
+    left?.basicAuth?.username === right?.basicAuth?.username &&
+    left?.basicAuth?.password === right?.basicAuth?.password &&
+    left?.tokenHelper?.length === right?.tokenHelper?.length &&
+    left?.tokenHelper?.every((part, index) => part === right?.tokenHelper?.[index]) !== false
 }
 
 async function packPkgForBatch (project: Project, opts: BatchPublishOptions): Promise<PackedPkg> {
@@ -138,10 +182,17 @@ async function lifecycleOpts (pkgRoot: string, opts: BatchPublishOptions): Promi
   }
 }
 
-async function multiPublishToRegistry (registry: string, group: PackedPkg[], opts: BatchPublishOptions): Promise<void> {
-  // A package-scoped OIDC token cannot authorize a request that publishes many packages, so the
-  // OIDC exchange is skipped and only statically configured credentials are used.
-  const publishOptions = await createPublishOptions(group[0].publishedManifest, opts, { oidc: false })
+async function multiPublishToRegistry ({
+  registry,
+  group,
+  opts,
+  publishOptions,
+}: {
+  registry: string
+  group: GroupedPackedPkg[]
+  opts: BatchPublishOptions
+  publishOptions: Awaited<ReturnType<typeof createPublishOptions>>
+}): Promise<void> {
   const body = {
     packages: group.map((packedPkg) => createPublishDocument(packedPkg, registry, opts)),
   }

--- a/pnpm11/releasing/commands/src/publish/batchPublish.ts
+++ b/pnpm11/releasing/commands/src/publish/batchPublish.ts
@@ -8,7 +8,7 @@ import type { RunLifecycleHookOptions } from '@pnpm/exec.lifecycle'
 import { globalInfo, globalWarn } from '@pnpm/logger'
 import { type WebAuthFetchOptions, withOtpHandling } from '@pnpm/network.web-auth'
 import type { ExportedManifest } from '@pnpm/releasing.exportable-manifest'
-import { type Creds, DEFAULT_REGISTRY_SCOPE, type Project } from '@pnpm/types'
+import type { Project } from '@pnpm/types'
 import { rimraf } from '@zkochan/rimraf'
 import npmFetch from 'npm-registry-fetch'
 import { realpathMissing } from 'realpath-missing'
@@ -39,10 +39,6 @@ interface PackedPkg {
   summary: PublishSummary
 }
 
-type GroupedPackedPkg = PackedPkg & {
-  credentials: Creds | undefined
-}
-
 /**
  * Publish all {@link pkgs} by sending a single `PUT /-/pnpm/v1/publish` request per target
  * registry, instead of one request per package. The endpoint is not part of the standard npm
@@ -65,7 +61,7 @@ export async function batchPublishPackages (pkgs: Project[], opts: BatchPublishO
       hint: 'Provenance is bound to a single package, but --batch sends many packages in one request. Publish without --batch to attach provenance.',
     })
   }
-  const packedByRegistry = new Map<string, GroupedPackedPkg[]>()
+  const packedByRegistry = new Map<string, PackedPkg[]>()
   const packedPkgs: PackedPkg[] = []
   for (const project of pkgs) {
     // eslint-disable-next-line no-await-in-loop
@@ -73,16 +69,13 @@ export async function batchPublishPackages (pkgs: Project[], opts: BatchPublishO
     const publishConfigRegistry = typeof packedPkg.publishedManifest.publishConfig?.registry === 'string'
       ? packedPkg.publishedManifest.publishConfig.registry
       : undefined
-    const { config, registry } = findRegistryInfo(packedPkg.publishedManifest, opts, publishConfigRegistry)
+    const { registry } = findRegistryInfo(packedPkg.publishedManifest, opts, publishConfigRegistry)
     let group = packedByRegistry.get(registry!)
     if (!group) {
       group = []
       packedByRegistry.set(registry!, group)
     }
-    group.push({
-      ...packedPkg,
-      credentials: config?.[DEFAULT_REGISTRY_SCOPE],
-    })
+    group.push(packedPkg)
     packedPkgs.push(packedPkg)
   }
   const publishOptionsByRegistry = new Map<string, Awaited<ReturnType<typeof createPublishOptions>>>()
@@ -119,11 +112,11 @@ export async function batchPublishPackages (pkgs: Project[], opts: BatchPublishO
 
 async function createBatchPublishOptions (
   registry: string,
-  group: GroupedPackedPkg[],
+  group: PackedPkg[],
   opts: BatchPublishOptions
 ): Promise<Awaited<ReturnType<typeof createPublishOptions>>> {
-  const [first, ...rest] = group
-  if (rest.some(({ credentials }) => !sameCredentials(first.credentials, credentials))) {
+  const [first, ...rest] = await Promise.all(group.map(async ({ publishedManifest }) => createPublishOptions(publishedManifest, opts, { oidc: false })))
+  if (rest.some((publishOptions) => !sameCredentials(first, publishOptions))) {
     throw new PnpmError(
       'BATCH_PUBLISH_CONFLICTING_CREDENTIALS',
       `Packages targeting ${registry} resolve to different authentication credentials and cannot be published in one batch`,
@@ -132,15 +125,16 @@ async function createBatchPublishOptions (
       }
     )
   }
-  return createPublishOptions(first.publishedManifest, opts, { oidc: false })
+  return first
 }
 
-function sameCredentials (left: Creds | undefined, right: Creds | undefined): boolean {
-  return left?.authToken === right?.authToken &&
-    left?.basicAuth?.username === right?.basicAuth?.username &&
-    left?.basicAuth?.password === right?.basicAuth?.password &&
-    left?.tokenHelper?.length === right?.tokenHelper?.length &&
-    left?.tokenHelper?.every((part, index) => part === right?.tokenHelper?.[index]) !== false
+function sameCredentials (
+  left: Awaited<ReturnType<typeof createPublishOptions>>,
+  right: Awaited<ReturnType<typeof createPublishOptions>>
+): boolean {
+  return left.token === right.token &&
+    left.username === right.username &&
+    left.password === right.password
 }
 
 async function packPkgForBatch (project: Project, opts: BatchPublishOptions): Promise<PackedPkg> {
@@ -189,7 +183,7 @@ async function multiPublishToRegistry ({
   publishOptions,
 }: {
   registry: string
-  group: GroupedPackedPkg[]
+  group: PackedPkg[]
   opts: BatchPublishOptions
   publishOptions: Awaited<ReturnType<typeof createPublishOptions>>
 }): Promise<void> {

--- a/pnpm11/releasing/commands/src/publish/batchPublish.ts
+++ b/pnpm11/releasing/commands/src/publish/batchPublish.ts
@@ -98,20 +98,20 @@ export async function batchPublishPackages (pkgs: Project[], opts: BatchPublishO
     }
     if (opts.dryRun) {
       globalWarn(`Skip publishing ${group.length} package(s) to ${registry} (dry run)`)
-      continue
-    }
-    const publishOptions = publishOptionsByRegistry.get(registry)
-    if (publishOptions == null) {
-      throw new Error(`Missing precomputed publish options for ${registry}`)
-    }
-    // eslint-disable-next-line no-await-in-loop
-    await multiPublishToRegistry({ registry, group, opts, publishOptions })
-    globalInfo(`✅ Published ${group.length} package(s) to ${registry} in a single request`)
-  }
-  if (!opts.ignoreScripts) {
-    for (const { project } of packedPkgs) {
+    } else {
+      const publishOptions = publishOptionsByRegistry.get(registry)
+      if (publishOptions == null) {
+        throw new Error(`Missing precomputed publish options for ${registry}`)
+      }
       // eslint-disable-next-line no-await-in-loop
-      await runScriptsIfPresent(await lifecycleOpts(project.rootDir, opts), ['publish', 'postpublish'], project.manifest)
+      await multiPublishToRegistry({ registry, group, opts, publishOptions })
+      globalInfo(`✅ Published ${group.length} package(s) to ${registry} in a single request`)
+    }
+    if (!opts.ignoreScripts) {
+      for (const { project } of group) {
+        // eslint-disable-next-line no-await-in-loop
+        await runScriptsIfPresent(await lifecycleOpts(project.rootDir, opts), ['publish', 'postpublish'], project.manifest)
+      }
     }
   }
   return packedPkgs.map(({ summary }) => summary)

--- a/pnpm11/releasing/commands/test/publish/batchPublish.test.ts
+++ b/pnpm11/releasing/commands/test/publish/batchPublish.test.ts
@@ -1,6 +1,8 @@
 import { createHash } from 'node:crypto'
+import fs from 'node:fs'
 import http from 'node:http'
 import type { AddressInfo } from 'node:net'
+import path from 'node:path'
 
 import { afterEach, beforeEach, expect, test } from '@jest/globals'
 import { preparePackages } from '@pnpm/prepare'
@@ -150,6 +152,46 @@ test('batch publish sends all packages in a single batch publish request', async
   expect(dist.integrity).toBe(`sha512-${createHash('sha512').update(tarballData).digest('base64')}`)
   expect(dist.shasum).toBe(createHash('sha1').update(tarballData).digest('hex'))
   expect(dist.tarball).toBe(`${registry.url}@pnpmtest/batch-pkg-1/-/@pnpmtest/batch-pkg-1-1.0.0.tgz`)
+})
+
+test('batch publish runs completed group postpublish scripts before a later registry fails', async () => {
+  const failingRegistry = await createRegistryStub()
+  try {
+    failingRegistry.multiPublishStatusCode = 500
+    preparePackages([
+      {
+        name: 'batch-postpublish-first',
+        version: '1.0.0',
+        publishConfig: { registry: registry.url },
+        scripts: {
+          postpublish: 'node -e "require(\'fs\').writeFileSync(\'post-published\', \'\')"',
+        },
+      },
+      {
+        name: 'batch-postpublish-second',
+        version: '1.0.0',
+        dependencies: { 'batch-postpublish-first': '1.0.0' },
+        publishConfig: { registry: failingRegistry.url },
+        scripts: {
+          postpublish: 'node -e "require(\'fs\').writeFileSync(\'post-published\', \'\')"',
+        },
+      },
+    ])
+    const workspaceDir = process.cwd()
+
+    await expect(publish.handler({
+      ...batchPublishOpts(),
+      ...await filterProjectsBySelectorObjectsFromDir(workspaceDir, [], { linkWorkspacePackages: true }),
+      force: true,
+    }, [])).rejects.toBeDefined()
+
+    expect(registry.received.filter(({ url }) => url === '/-/pnpm/v1/publish')).toHaveLength(1)
+    expect(failingRegistry.received.filter(({ url }) => url === '/-/pnpm/v1/publish').length).toBeGreaterThan(0)
+    expect(fs.existsSync(path.join(workspaceDir, 'batch-postpublish-first', 'post-published'))).toBe(true)
+    expect(fs.existsSync(path.join(workspaceDir, 'batch-postpublish-second', 'post-published'))).toBe(false)
+  } finally {
+    await failingRegistry.close()
+  }
 })
 
 test('batch publish accepts one scope credential for every package', async () => {

--- a/pnpm11/releasing/commands/test/publish/batchPublish.test.ts
+++ b/pnpm11/releasing/commands/test/publish/batchPublish.test.ts
@@ -221,6 +221,40 @@ test('batch publish accepts one scope credential for every package', async () =>
   expect(publishRequests[0].headers.authorization).toBe('Bearer scope-token')
 })
 
+test('batch publish accepts equivalent credentials configured differently', async () => {
+  preparePackages([
+    {
+      name: '@scope/batch-pkg-1',
+      version: '1.0.0',
+    },
+    {
+      name: 'batch-pkg-2',
+      version: '1.0.0',
+    },
+  ])
+  const tokenHelper = path.join(
+    import.meta.dirname,
+    'utils',
+    process.platform === 'win32' ? 'tokenHelperBasic.bat' : 'tokenHelperBasic.js'
+  )
+  fs.chmodSync(tokenHelper, 0o755)
+
+  await publish.handler({
+    ...batchPublishOpts(),
+    ...await filterProjectsBySelectorObjectsFromDir(process.cwd(), []),
+    configByUri: {
+      [registry.url.replace(/^http:/, '')]: {
+        '@': { authToken: getRegistryMockToken() },
+        '@scope': { tokenHelper: [tokenHelper] },
+      },
+    },
+  }, [])
+
+  const publishRequests = registry.received.filter(({ url }) => url === '/-/pnpm/v1/publish')
+  expect(publishRequests).toHaveLength(1)
+  expect(publishRequests[0].headers.authorization).toBe(`Bearer ${getRegistryMockToken()}`)
+})
+
 test('batch publish rejects different credentials for one registry before publishing', async () => {
   preparePackages([
     {

--- a/pnpm11/releasing/commands/test/publish/batchPublish.test.ts
+++ b/pnpm11/releasing/commands/test/publish/batchPublish.test.ts
@@ -152,6 +152,59 @@ test('batch publish sends all packages in a single batch publish request', async
   expect(dist.tarball).toBe(`${registry.url}@pnpmtest/batch-pkg-1/-/@pnpmtest/batch-pkg-1-1.0.0.tgz`)
 })
 
+test('batch publish accepts one scope credential for every package', async () => {
+  preparePackages([
+    {
+      name: '@scope/batch-pkg-1',
+      version: '1.0.0',
+    },
+    {
+      name: '@scope/batch-pkg-2',
+      version: '1.0.0',
+    },
+  ])
+
+  await publish.handler({
+    ...batchPublishOpts(),
+    ...await filterProjectsBySelectorObjectsFromDir(process.cwd(), []),
+    configByUri: {
+      [registry.url.replace(/^http:/, '')]: {
+        '@scope': { authToken: 'scope-token' },
+      },
+    },
+  }, [])
+
+  const publishRequests = registry.received.filter(({ url }) => url === '/-/pnpm/v1/publish')
+  expect(publishRequests).toHaveLength(1)
+  expect(publishRequests[0].headers.authorization).toBe('Bearer scope-token')
+})
+
+test('batch publish rejects different credentials for one registry before publishing', async () => {
+  preparePackages([
+    {
+      name: '@scope/batch-pkg-1',
+      version: '1.0.0',
+    },
+    {
+      name: 'batch-pkg-2',
+      version: '1.0.0',
+    },
+  ])
+
+  await expect(publish.handler({
+    ...batchPublishOpts(),
+    ...await filterProjectsBySelectorObjectsFromDir(process.cwd(), []),
+    configByUri: {
+      [registry.url.replace(/^http:/, '')]: {
+        '@': { authToken: 'registry-token' },
+        '@scope': { authToken: 'scope-token' },
+      },
+    },
+  }, [])).rejects.toMatchObject({ code: 'ERR_PNPM_BATCH_PUBLISH_CONFLICTING_CREDENTIALS' })
+
+  expect(registry.received.filter(({ url }) => url === '/-/pnpm/v1/publish')).toHaveLength(0)
+})
+
 test('batch publish sends configured OTP on the first publish request', async () => {
   preparePackages([
     {


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Implements section 3 ("Gaps pacquet already flags in-source") of pnpm/pnpm#14101. The PRs linked from that issue cover sections 1 and 2; none covers these five gaps.

- `pnpm publish -r --batch` now packs every selected project before publishing and sends one pnpr batch request per target registry, with the same publish documents, static authentication, OTP flow, dry-run behavior, lifecycle ordering, and unsupported-registry diagnostic as the TypeScript CLI.
- `pnpm outdated -g -r` now uses the existing global outdated implementation instead of rejecting recursion.
- `pnpm approve-builds -g` scans every global install group, records one global build policy, clears the decided pending entries, and rebuilds the matching groups. The TypeScript CLI had the same rejection despite already recommending this command, so both stacks are updated; symlinked group targets are confined to the global packages directory.
- Recursive `run` and `exec` now honor bounded `workspaceConcurrency` within dependency-independent chunks. `--parallel exec` follows the TypeScript CLI's unlimited-concurrency shorthand.
- Filtered and split `pnpm sbom` runs under `sharedWorkspaceLockfile=false` merge the selected projects' dedicated lockfiles in memory, rebase their importer IDs to the workspace, and read metadata from each selected virtual store.

Related to pnpm/pnpm#14101.

## Squash Commit Body

```text
Implement the five parity gaps tracked in section 3 of pnpm/pnpm#14101.

Recursive batch publish now packs all eligible projects before sending
anything, groups the standard npm publish documents by registry, and uses
pnpr's atomic batch endpoint once per group. It reuses the existing publish
document, authentication, OTP, lifecycle, and summary paths so single and
batch publishing cannot drift. Staging and provenance remain incompatible
with a multi-package request and fail with explicit diagnostics.

Global outdated accepts the recursive spelling already handled by the
TypeScript CLI. Global approve-builds aggregates pending packages across all
install groups, writes one policy under the global packages directory, clears
the corresponding group manifests, and rebuilds each affected group. Since
the TypeScript implementation rejected the same command, this behavior lands
in both stacks; canonical path checks prevent a tampered group symlink from
redirecting approval or rebuild work outside the global package root.

Recursive run and exec share a bounded worker pool per topological chunk,
preserve result ordering, and stop scheduling later batches after a failure
when bail is enabled. Parallel exec removes the cap, matching pnpm's
--parallel shorthand.

SBOM generation with dedicated project lockfiles constructs a synthetic
in-memory workspace lockfile for the selected projects. Importer paths are
validated and rebased to workspace-relative IDs, package and snapshot graphs
are merged, and metadata lookup searches the selected projects' virtual
stores. This supports both filtered output and split output without changing
the on-disk lockfiles.

Related to pnpm/pnpm#14101.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed. (`approve-builds --global` is now
  listed in CLI help; the remaining TypeScript surfaces were already documented.)

---
Written by an agent (Codex, GPT-5.6).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790079385&installation_model_id=426870&pr_number=14106&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14106&signature=5774871c3d85dbca96d6cf04d9cde204f063d25f3eb5be3a308215f46ab788a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added batch publishing for workspace packages with registry grouping, OTP support, dry-run reporting, and credential validation.
  * Added global build approval via `approve-builds --global` and `--all`.
  * Added bounded concurrent recursive `run` and `exec` execution with `--parallel`.
  * Added split, filtered, and project-specific SBOM generation.
  * Added configurable streaming, aggregate output, reporter prefixes, stderr routing, and workspace selection.
  * Added post-publish script execution after successful registry-group publishing.

* **Bug Fixes**
  * Improved global package installation, shim restoration, cleanup, and failure reporting.
  * Expanded support for global outdated checks and recursive workspace operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->