### PR TITLE
fix(cli): accept and honor --lockfile-only on pnpm dedupe

### DIFF
--- a/.changeset/dedupe-lockfile-only.md
+++ b/.changeset/dedupe-lockfile-only.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm dedupe` accepts the `pnpm install` options that pnpm documents for it — `--lockfile-only`, `--ignore-scripts`, `--offline`, and `--prefer-offline` — instead of rejecting them with `unexpected argument`. Without `--lockfile-only`, `pnpm dedupe` now also updates `node_modules`, as an install does [#14107](https://github.com/pnpm/pnpm/issues/14107).

--- a/pnpm/crates/cli/src/cli_args/dedupe.rs
+++ b/pnpm/crates/cli/src/cli_args/dedupe.rs
@@ -165,13 +165,12 @@ impl DedupeArgs {
             resolved_packages,
             supported_architectures: config.supported_architectures.clone(),
             node_linker: config.node_linker,
-            // `--check` reports what dedupe would change, so it never
-            // materializes `node_modules` either way.
             lockfile_only: self.lockfile_only || self.check,
             dry_run: false,
-            // `--check` must leave the working tree untouched: the lockfile
-            // guard restores `pnpm-lock.yaml`, and this gate keeps loose
-            // minimumReleaseAge picks out of `pnpm-workspace.yaml`.
+            // `--check` must leave the working tree untouched: `lockfile_only`
+            // above keeps `node_modules` out of it, the lockfile guard restores
+            // `pnpm-lock.yaml`, and this gate keeps loose minimumReleaseAge
+            // picks out of `pnpm-workspace.yaml`.
             persist_policy_excludes: !self.check,
             update_seed_policy: pnpm_package_manager::UpdateSeedPolicy::KeepAllResolveAll,
             preferred_versions_override: None,

--- a/pnpm/crates/cli/src/cli_args/dedupe.rs
+++ b/pnpm/crates/cli/src/cli_args/dedupe.rs
@@ -12,6 +12,7 @@ use crate::{
         deps_tree::render::{
             TreeNode, blue_bright_underline, gray, green, plain, red, render_archy,
         },
+        install::resolve_bool_override,
         peers::peer_issues_warrant_warning,
     },
 };
@@ -37,8 +38,46 @@ use tempfile::NamedTempFile;
 
 #[derive(Debug, Args)]
 pub struct DedupeArgs {
+    /// Check if running dedupe would result in changes without installing
+    /// packages or editing the lockfile. Exits with a non-zero status code
+    /// if changes are possible.
     #[clap(long)]
     pub check: bool,
+
+    /// Only update `pnpm-lock.yaml`. Don't download packages or write
+    /// `node_modules`.
+    #[clap(long = "lockfile-only")]
+    pub lockfile_only: bool,
+
+    /// Don't run lifecycle scripts of the project or its dependencies.
+    /// Packages are still installed; only their build scripts are skipped,
+    /// and the install won't fail because of it.
+    #[clap(long = "ignore-scripts", overrides_with = "no_ignore_scripts")]
+    pub ignore_scripts: bool,
+
+    /// Run lifecycle scripts even when the configuration disables them.
+    #[clap(long = "no-ignore-scripts", overrides_with = "ignore_scripts")]
+    pub no_ignore_scripts: bool,
+
+    /// Fail on a cache miss instead of fetching from the registry, using
+    /// only packages already in the store.
+    #[clap(long, overrides_with = "no_offline")]
+    pub offline: bool,
+
+    /// Allow network fetches even when the configuration enables offline
+    /// mode.
+    #[clap(long = "no-offline", overrides_with = "offline")]
+    pub no_offline: bool,
+
+    /// Prefer packages already in the cache over the network, even past
+    /// their freshness window.
+    #[clap(long, overrides_with = "no_prefer_offline")]
+    pub prefer_offline: bool,
+
+    /// Don't prefer cached packages even when the configuration enables
+    /// it.
+    #[clap(long = "no-prefer-offline", overrides_with = "prefer_offline")]
+    pub no_prefer_offline: bool,
 
     /// Disable pnpm hooks defined in `.pnpmfile.cjs`, including the
     /// pnpmfiles of config dependencies.
@@ -49,6 +88,17 @@ pub struct DedupeArgs {
 impl DedupeArgs {
     pub(crate) fn apply_cli_config(&self, config: &mut Config) {
         config.ignore_pnpmfile = self.ignore_pnpmfile || config.ignore_pnpmfile;
+        config.ignore_scripts = resolve_bool_override(
+            self.ignore_scripts,
+            self.no_ignore_scripts,
+            config.ignore_scripts,
+        );
+        config.offline = resolve_bool_override(self.offline, self.no_offline, config.offline);
+        config.prefer_offline = resolve_bool_override(
+            self.prefer_offline,
+            self.no_prefer_offline,
+            config.prefer_offline,
+        );
     }
 
     /// Run the deduplication install pipeline. In `--check` mode the method
@@ -115,7 +165,9 @@ impl DedupeArgs {
             resolved_packages,
             supported_architectures: config.supported_architectures.clone(),
             node_linker: config.node_linker,
-            lockfile_only: true,
+            // `--check` reports what dedupe would change, so it never
+            // materializes `node_modules` either way.
+            lockfile_only: self.lockfile_only || self.check,
             dry_run: false,
             // `--check` must leave the working tree untouched: the lockfile
             // guard restores `pnpm-lock.yaml`, and this gate keeps loose

--- a/pnpm/crates/cli/src/cli_args/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/tests.rs
@@ -954,6 +954,49 @@ fn every_command_pnpm_takes_ignore_pnpmfile_on_takes_it() {
     }
 }
 
+/// The `dedupe` options pnpm documents beyond `--check`. `dedupe` takes
+/// `pnpm install`'s rc options, so Renovate's `pnpm dedupe
+/// --lockfile-only` has to parse.
+#[test]
+fn dedupe_takes_the_install_options_pnpm_documents_for_it() {
+    let args = dedupe_args(&[
+        "pacquet",
+        "dedupe",
+        "--lockfile-only",
+        "--ignore-scripts",
+        "--offline",
+        "--prefer-offline",
+    ]);
+    assert!(args.lockfile_only);
+    assert!(args.ignore_scripts);
+    assert!(args.offline);
+    assert!(args.prefer_offline);
+
+    let mut config = pnpm_config::Config::default();
+    args.apply_cli_config(&mut config);
+    assert!(config.ignore_scripts);
+    assert!(config.offline);
+    assert!(config.prefer_offline);
+
+    let negated = dedupe_args(&[
+        "pacquet",
+        "dedupe",
+        "--no-ignore-scripts",
+        "--no-offline",
+        "--no-prefer-offline",
+    ]);
+    let mut config = pnpm_config::Config {
+        ignore_scripts: true,
+        offline: true,
+        prefer_offline: true,
+        ..pnpm_config::Config::default()
+    };
+    negated.apply_cli_config(&mut config);
+    assert!(!config.ignore_scripts, "the CLI negation turns a yaml `true` back off");
+    assert!(!config.offline);
+    assert!(!config.prefer_offline);
+}
+
 #[test]
 fn dedupe_ignore_pnpmfile_flag_applies_to_config() {
     let mut config = pnpm_config::Config::default();

--- a/pnpm/crates/cli/src/cli_args/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/tests.rs
@@ -954,9 +954,7 @@ fn every_command_pnpm_takes_ignore_pnpmfile_on_takes_it() {
     }
 }
 
-/// The `dedupe` options pnpm documents beyond `--check`. `dedupe` takes
-/// `pnpm install`'s rc options, so Renovate's `pnpm dedupe
-/// --lockfile-only` has to parse.
+/// <https://github.com/pnpm/pnpm/issues/14107>
 #[test]
 fn dedupe_takes_the_install_options_pnpm_documents_for_it() {
     let args = dedupe_args(&[

--- a/pnpm/crates/cli/tests/suite/dedupe.rs
+++ b/pnpm/crates/cli/tests/suite/dedupe.rs
@@ -34,8 +34,6 @@ fn dedupe_writes_lockfile() {
     drop((root, mock_instance));
 }
 
-/// `pnpm dedupe` is an install, so it rewrites `node_modules` too —
-/// `--lockfile-only` is what narrows it to the lockfile.
 #[test]
 fn dedupe_materializes_node_modules_unless_lockfile_only() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
@@ -94,7 +92,6 @@ fn dedupe_check_does_not_materialize_nor_write_lockfile() {
     )
     .expect("write package.json");
 
-    // Create a lockfile first, without materializing node_modules
     pacquet.with_args(["dedupe", "--lockfile-only"]).assert().success();
 
     // Recreate a pacquet command for the --check invocation

--- a/pnpm/crates/cli/tests/suite/dedupe.rs
+++ b/pnpm/crates/cli/tests/suite/dedupe.rs
@@ -34,6 +34,48 @@ fn dedupe_writes_lockfile() {
     drop((root, mock_instance));
 }
 
+/// `pnpm dedupe` is an install, so it rewrites `node_modules` too —
+/// `--lockfile-only` is what narrows it to the lockfile.
+#[test]
+fn dedupe_materializes_node_modules_unless_lockfile_only() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pkg-with-1-dep": "100.0.0",
+            },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    pacquet.with_args(["dedupe", "--lockfile-only"]).assert().success();
+
+    assert!(
+        workspace.join("pnpm-lock.yaml").exists(),
+        "dedupe --lockfile-only must write pnpm-lock.yaml",
+    );
+    assert!(
+        !workspace.join("node_modules").exists(),
+        "dedupe --lockfile-only must not create node_modules",
+    );
+
+    let pacquet =
+        Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(&workspace);
+    pacquet.with_arg("dedupe").assert().success();
+
+    assert!(
+        workspace.join("node_modules/@pnpm.e2e/pkg-with-1-dep").exists(),
+        "dedupe must link the dependency into node_modules",
+    );
+
+    drop((root, mock_instance));
+}
+
 #[test]
 fn dedupe_check_does_not_materialize_nor_write_lockfile() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
@@ -52,8 +94,8 @@ fn dedupe_check_does_not_materialize_nor_write_lockfile() {
     )
     .expect("write package.json");
 
-    // Create a lockfile first by running dedupe
-    pacquet.with_arg("dedupe").assert().success();
+    // Create a lockfile first, without materializing node_modules
+    pacquet.with_args(["dedupe", "--lockfile-only"]).assert().success();
 
     // Recreate a pacquet command for the --check invocation
     let pacquet_check =


### PR DESCRIPTION
## Summary

`pnpm dedupe --lockfile-only` failed with `error: unexpected argument '--lockfile-only' found`, which breaks Renovate's dependency-update runs since renovatebot/renovate#42024 started passing the flag. `DedupeArgs` declared only `--check` and `--ignore-pnpmfile`, while pnpm's `dedupe` takes `pnpm install`'s rc options (everything except `--frozen-lockfile`).

This PR declares the options pnpm's `dedupe --help` documents beyond `--check` — `--lockfile-only`, `--ignore-scripts`, `--offline`, `--prefer-offline` — each of which also gets its generated `--no-` negation.

It also makes `--lockfile-only` mean something. The install `dedupe` builds hardcoded `lockfileOnly: true`, so `pnpm dedupe` never materialized `node_modules`. pnpm's `dedupe` is a full install and does — verified against the bundled v11 CLI:

```
$ node pnpm11/pnpm/dist/pnpm.mjs dedupe
...
dependencies:
+ is-positive 3.1.0
$ ls
node_modules  package.json  pnpm-lock.yaml
```

The flag now drives that field, with `--check` still forcing the lockfile-only path so a check leaves the working tree untouched.

TypeScript side: nothing to port. `DedupeCommandOptions extends InstallCommandOptions`, so the v11 CLI already accepts `--lockfile-only` and already installs `node_modules`. This is a pacquet-only fix, same class as the already-closed pnpm/pnpm#13808 (`--ignore-pnpmfile`).

Closes pnpm/pnpm#14107

## Squash Commit Body

```text
`pnpm dedupe` declared only `--check` and `--ignore-pnpmfile`, so clap
rejected `pnpm dedupe --lockfile-only` with "unexpected argument". pnpm's
`dedupe` takes `pnpm install`'s rc options, and Renovate now passes
`--lockfile-only` on its dependency-update runs, which fails the whole
update.

Declare the options pnpm documents for `dedupe` beyond `--check`:
`--lockfile-only`, `--ignore-scripts`, `--offline`, and
`--prefer-offline` (each with the generated `--no-` negation).

The install `dedupe` builds hardcoded `lockfileOnly: true`, so it never
materialized `node_modules` — pnpm's `dedupe` is a full install and does.
The flag now drives that field, with `--check` still forcing the
lockfile-only path so a check leaves the working tree untouched.

Closes pnpm/pnpm#14107
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5[1m]).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790083729&installation_model_id=426870&pr_number=14110&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14110&signature=4c8bf63831836bbe0b8a20fb1b9d3d4810708d779be171f6b3cb542ff8f181bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `pnpm dedupe` now supports `--lockfile-only`, `--ignore-scripts`, `--offline`, and `--prefer-offline`, including their negated forms.
  * By default, deduplication now updates both the lockfile and installed dependencies.
  * Use `--lockfile-only` to update only the lockfile without modifying `node_modules`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->