### PR TITLE
fix(workspace-manifest-writer): edit inline (flow) YAML blocks in place

### DIFF
--- a/.changeset/flow-style-workspace-manifest-edits.md
+++ b/.changeset/flow-style-workspace-manifest-edits.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Settings written to a `pnpm-workspace.yaml` block that uses inline (flow) YAML — `catalog: { foo: ^1.0.0 }`, `overrides: { foo: 1.0.0 }`, `minimumReleaseAgeExclude: [foo@1.0.0]` — are now edited in place instead of failing or corrupting the file. `pnpm audit`, `pnpm link`, `pnpm approve-builds`, `pnpm patch`, `pnpm add --config`, and catalog updates all keep the block's flow style, its other entries, and its comments [#14108](https://github.com/pnpm/pnpm/issues/14108).

--- a/pnpm/crates/workspace-manifest-writer/src/edit.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/edit.rs
@@ -500,11 +500,19 @@ pub(crate) fn set_minimum_release_age_excludes(manifest: &mut Manifest, items: &
     }
 
     let text = manifest.text();
-    if let Inline::Flow(collection) = locate_sequence(text, &[BLOCK]) {
-        let rendered: Vec<String> = items.iter().map(|item| render::render_value(item)).collect();
-        manifest.set_text(flow::set_items(text, &collection, &rendered));
-        manifest.minimum_release_age_exclude = Some(items.to_vec());
-        return true;
+    match locate_sequence(text, &[BLOCK]) {
+        Inline::Flow(collection) => {
+            let rendered: Vec<String> =
+                items.iter().map(|item| render::render_value(item)).collect();
+            manifest.set_text(flow::set_items(text, &collection, &rendered));
+            manifest.minimum_release_age_exclude = Some(items.to_vec());
+            return true;
+        }
+        // Rendering the whole block afresh would drop the comments an
+        // inline value this writer cannot edit may hold, so leave it be;
+        // the public writer refuses such a manifest outright.
+        Inline::Unsupported => return false,
+        Inline::Block => {}
     }
 
     let rendered = render_top_level_sequence(BLOCK, items);
@@ -1411,10 +1419,14 @@ fn top_level_span(text: &str, key: &str) -> Option<TopLevelSpan> {
     let key_idx = all.iter().position(|line| {
         structural_indent(line.content) == Some(0) && line_key(line.content).as_deref() == Some(key)
     })?;
-    let next_key_idx = ((key_idx + 1)..all.len())
+    // A flow collection written across several lines closes at column zero,
+    // which would otherwise read as the next top-level key and leave the
+    // closing bracket behind when the block is replaced or removed.
+    let body_start = inline_value_last_line(text, &all, key_idx).unwrap_or(key_idx) + 1;
+    let next_key_idx = (body_start..all.len())
         .find(|&idx| structural_indent(all[idx].content) == Some(0))
         .unwrap_or(all.len());
-    let block_end_idx = leading_comment_start(&all, key_idx + 1, next_key_idx);
+    let block_end_idx = leading_comment_start(&all, body_start, next_key_idx);
     let block_end = all
         .get(block_end_idx)
         .map_or_else(|| all.last().map_or(0, |line| line.end), |line| line.start);
@@ -1424,6 +1436,18 @@ fn top_level_span(text: &str, key: &str) -> Option<TopLevelSpan> {
                 && line_key(line.content).as_deref() == Some(key)
         })
         .map(|line| TopLevelSpan { key_line_start: line.start, block_end })
+}
+
+/// Index of the line where the flow collection written inline on
+/// `key_idx`'s line closes. `None` when that line carries no inline value,
+/// its value is not a flow collection, or the collection never closes.
+fn inline_value_last_line(text: &str, all: &[Line<'_>], key_idx: usize) -> Option<usize> {
+    let open = inline_value_on_line(text, all[key_idx].start)?;
+    if !text[open..].starts_with(['{', '[']) {
+        return None;
+    }
+    let close = flow::closing_bracket_across_lines(text, open)?;
+    all.iter().position(|line| line.start <= close && close < line.end)
 }
 
 fn leading_comment_start(all: &[Line<'_>], block_start: usize, next_key_idx: usize) -> usize {

--- a/pnpm/crates/workspace-manifest-writer/src/edit.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/edit.rs
@@ -61,8 +61,19 @@ fn locate_inline(text: &str, path: &[&str], expected: flow::Kind) -> Inline {
 /// Whether the value at `path` is an inline shape no writer can edit. A
 /// caller refuses the whole write rather than corrupt it.
 pub(crate) fn has_unsupported_inline_value(text: &str, path: &[&str]) -> bool {
-    matches!(locate_mapping(text, path), Inline::Unsupported)
-        && matches!(locate_sequence(text, path), Inline::Unsupported)
+    document_root_is_inline(text)
+        || (matches!(locate_mapping(text, path), Inline::Unsupported)
+            && matches!(locate_sequence(text, path), Inline::Unsupported))
+}
+
+/// Whether the document itself is written as a flow collection
+/// (`{ overrides: { foo: 1.0.0 } }`). Its keys are then not top-level lines
+/// at all, so neither the splices here nor a new top-level block can
+/// address them.
+pub(crate) fn document_root_is_inline(text: &str) -> bool {
+    text.lines()
+        .find(|line| structural_indent(line).is_some())
+        .is_some_and(|line| line.trim_start().starts_with(['{', '[']))
 }
 
 /// The keys of the mapping at `path`, whether it is written in block or

--- a/pnpm/crates/workspace-manifest-writer/src/edit.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/edit.rs
@@ -5,8 +5,13 @@
 //! single value (existing entries never move relative to each other), the
 //! format-preserving edits are expressed as targeted text splices for inserts
 //! and a [`yamlpatch`] `Op::Replace` for value updates.
+//!
+//! Those splices are line-oriented, so a block whose value is written
+//! inline (`overrides: { foo: 1.0.0 }`) is handed to [`crate::flow`]
+//! instead, and one neither can edit is reported through [`Inline`] so the
+//! caller can refuse the write.
 
-use std::{collections::HashSet, fmt::Write as _};
+use std::collections::HashSet;
 
 use indexmap::IndexMap;
 use pnpm_catalogs_types::{Catalogs, DEFAULT_CATALOG_NAME};
@@ -14,9 +19,102 @@ use yamlpatch::{Op, Patch};
 use yamlpath::{Component, Document, Route};
 
 use crate::{
+    flow,
     model::{AllowBuildValue, Manifest},
     render,
 };
+
+/// How the value a key path names is written.
+pub(crate) enum Inline {
+    /// A block body on the following lines — or no such key at all. The
+    /// line-oriented splices in this module apply.
+    Block,
+    /// An inline value none of the splices can edit: a multi-line flow
+    /// collection (whose interleaved comments a rebuild would drop), an
+    /// alias, or a scalar where a collection belongs.
+    Unsupported,
+    /// A flow collection written on one line, edited by [`crate::flow`].
+    Flow(flow::Collection),
+}
+
+/// Classify how the mapping at `path` is written.
+fn locate_mapping(text: &str, path: &[&str]) -> Inline {
+    locate_inline(text, path, flow::Kind::Mapping)
+}
+
+/// Classify how the sequence at `path` is written.
+fn locate_sequence(text: &str, path: &[&str]) -> Inline {
+    locate_inline(text, path, flow::Kind::Sequence)
+}
+
+/// Classify how the value of `path` is written. A flow collection of a kind
+/// other than `expected` is reported as unsupported: no writer here can put
+/// a mapping entry into a sequence, or the reverse.
+fn locate_inline(text: &str, path: &[&str], expected: flow::Kind) -> Inline {
+    let Some(offset) = inline_value_start(text, path) else { return Inline::Block };
+    match flow::parse(text, offset) {
+        Some(collection) if collection.kind() == expected => Inline::Flow(collection),
+        Some(_) | None => Inline::Unsupported,
+    }
+}
+
+/// Whether the value at `path` is an inline shape no writer can edit. A
+/// caller refuses the whole write rather than corrupt it.
+pub(crate) fn has_unsupported_inline_value(text: &str, path: &[&str]) -> bool {
+    matches!(locate_mapping(text, path), Inline::Unsupported)
+        && matches!(locate_sequence(text, path), Inline::Unsupported)
+}
+
+/// The keys of the mapping at `path`, whether it is written in block or
+/// single-line flow style. Empty for a mapping with no entries, an
+/// unsupported inline value, or an absent key.
+fn mapping_keys(text: &str, path: &[&str]) -> Vec<String> {
+    match locate_mapping(text, path) {
+        Inline::Flow(collection) => collection.keys(),
+        Inline::Unsupported => Vec::new(),
+        Inline::Block => locate(text, path)
+            .map(|mapping| mapping.entries.into_iter().map(|entry| entry.key).collect())
+            .unwrap_or_default(),
+    }
+}
+
+/// Byte offset of the value of the key `path` names, when that value sits
+/// on the key's own line. `None` when the key is absent or its value is a
+/// block body on the lines below.
+fn inline_value_start(text: &str, path: &[&str]) -> Option<usize> {
+    let (key, parent) = path.split_last()?;
+    if parent.is_empty() {
+        let span = top_level_span(text, key)?;
+        return inline_value_on_line(text, span.key_line_start);
+    }
+    if let Some(entry) = locate(text, parent)
+        .and_then(|mapping| mapping.entries.into_iter().find(|entry| entry.key == *key))
+    {
+        return inline_value_on_line(text, entry.line_start);
+    }
+    // The parent has no line entries of its own when it is itself written
+    // inline, and then the key lives among its flow entries.
+    match locate_mapping(text, parent) {
+        Inline::Flow(collection) => collection.value_start(key),
+        Inline::Block | Inline::Unsupported => None,
+    }
+}
+
+/// Byte offset of the value written after the `key:` on the line starting
+/// at `line_start`. `None` when the line carries no value (a bare `key:`,
+/// optionally followed by a comment), which makes it block style.
+fn inline_value_on_line(text: &str, line_start: usize) -> Option<usize> {
+    let line_end = text[line_start..].find('\n').map_or(text.len(), |offset| line_start + offset);
+    let content = &text[line_start..line_end];
+    let indent = content.len() - content.trim_start().len();
+    let colon = indent + structural_colon_index(&content[indent..])?;
+    let after = &content[colon + 1..];
+    let value = after.trim_start();
+    if value.is_empty() || value.starts_with('#') {
+        return None;
+    }
+    Some(line_start + colon + 1 + (after.len() - value.len()))
+}
 
 /// Merge `updated` into `manifest`'s catalog blocks. Returns whether anything
 /// changed.
@@ -161,8 +259,7 @@ pub(crate) fn remove_overrides(manifest: &mut Manifest, selectors: &[String]) ->
     // map can be empty while the block still holds other entries. Deleting the
     // whole block off the decoded map would silently drop that configuration.
     let all_keys = override_keys_in_text(manifest.text());
-    let remaining_keys: Vec<&String> =
-        all_keys.iter().filter(|key| !present.contains(key)).collect();
+    let nothing_remains = all_keys.iter().all(|key| present.contains(key));
 
     if let Some(overrides) = manifest.overrides.as_mut() {
         for selector in &present {
@@ -170,32 +267,22 @@ pub(crate) fn remove_overrides(manifest: &mut Manifest, selectors: &[String]) ->
         }
     }
 
-    if remaining_keys.is_empty() {
+    if nothing_remains {
         manifest.set_text(remove_top_level_block(manifest.text(), BLOCK));
         manifest.overrides = None;
         manifest.top_level_keys.retain(|key| key != BLOCK);
         return true;
     }
 
-    // A block-style mapping stores each entry on its own line, so the requested
-    // entries can be excised surgically while every other entry (string or not)
-    // is preserved. A flow-style mapping (`overrides: { ... }`) exposes no line
-    // entries, so it can only be rewritten wholesale — which the decoded map can
-    // do faithfully only when it accounts for every remaining key (i.e. the
-    // block has no non-string entries). When it does not, leave the file
-    // untouched rather than drop the entries we cannot reserialize.
-    let line_based =
-        locate(manifest.text(), &[BLOCK]).is_some_and(|mapping| !mapping.entries.is_empty());
-
-    if line_based {
-        manifest.set_text(remove_mapping_entries(manifest.text(), &[BLOCK], &present));
-        true
-    } else if manifest.overrides.as_ref().map_or(0, IndexMap::len) == remaining_keys.len() {
-        rerender_overrides_block(manifest, BLOCK);
-        true
-    } else {
-        false
+    // Both a block-style mapping and a single-line flow one excise the
+    // requested entries surgically, leaving every other entry — string or
+    // not — as written. An inline shape neither can edit leaves the file
+    // untouched rather than dropping what it cannot reserialize.
+    if has_unsupported_inline_value(manifest.text(), &[BLOCK]) {
+        return false;
     }
+    manifest.set_text(remove_mapping_entries(manifest.text(), &[BLOCK], &present));
+    true
 }
 
 /// Raw dependency specifiers per package name, collected from every
@@ -211,10 +298,6 @@ pub(crate) type CatalogReferences =
 /// a bare `catalog:` reference; a named-catalog entry survives via
 /// `catalog:<name>` or bare `catalog:`. Emptied blocks are dropped
 /// whole. Returns whether anything changed.
-///
-/// A flow-style (`catalog: { ... }`) block exposes no line entries for
-/// the partial-removal splice, so its entries are left untouched — the
-/// same conservative stance [`remove_overrides`] takes.
 pub(crate) fn remove_unused_catalogs(
     manifest: &mut Manifest,
     references: &CatalogReferences,
@@ -241,7 +324,7 @@ fn remove_unused_default_catalog(manifest: &mut Manifest, references: &CatalogRe
         manifest.top_level_keys.retain(|key| key != BLOCK);
         return true;
     }
-    if to_remove.is_empty() || !has_line_entries(manifest.text(), &[BLOCK]) {
+    if to_remove.is_empty() || !has_removable_entries(manifest.text(), &[BLOCK]) {
         return false;
     }
     manifest.set_text(remove_mapping_entries(manifest.text(), &[BLOCK], &to_remove));
@@ -273,7 +356,7 @@ fn remove_unused_named_catalogs(manifest: &mut Manifest, references: &CatalogRef
 
     let mut changed = false;
     for (name, to_remove) in &entry_removals {
-        if !has_line_entries(manifest.text(), &[BLOCK, name]) {
+        if !has_removable_entries(manifest.text(), &[BLOCK, name]) {
             continue;
         }
         manifest.set_text(remove_mapping_entries(manifest.text(), &[BLOCK, name], to_remove));
@@ -295,7 +378,7 @@ fn remove_unused_named_catalogs(manifest: &mut Manifest, references: &CatalogRef
         manifest.top_level_keys.retain(|key| key != BLOCK);
         return true;
     }
-    if !names_to_drop.is_empty() && has_line_entries(manifest.text(), &[BLOCK]) {
+    if !names_to_drop.is_empty() && has_removable_entries(manifest.text(), &[BLOCK]) {
         manifest.set_text(remove_mapping_entries(manifest.text(), &[BLOCK], &names_to_drop));
         let catalogs = manifest.catalogs.as_mut().expect("catalogs presence checked above");
         for name in &names_to_drop {
@@ -306,10 +389,11 @@ fn remove_unused_named_catalogs(manifest: &mut Manifest, references: &CatalogRef
     changed
 }
 
-/// Whether the mapping at `path` is written in block style — i.e. it has
-/// per-line entries the removal splices can excise.
-fn has_line_entries(text: &str, path: &[&str]) -> bool {
-    locate(text, path).is_some_and(|mapping| !mapping.entries.is_empty())
+/// Whether the mapping at `path` holds entries the removal splices can
+/// excise: per-line entries in block style, or the entries of a
+/// single-line flow mapping.
+fn has_removable_entries(text: &str, path: &[&str]) -> bool {
+    !mapping_keys(text, path).is_empty()
 }
 
 /// Every key under the top-level `overrides:` block as written in `text`,
@@ -342,16 +426,16 @@ pub(crate) fn set_audit_ignore_ghsas(
 
     if ghsas.is_empty() {
         let text = manifest.text();
-        let Some(mapping) = locate(text, &[BLOCK]) else {
-            return Ok(false);
-        };
-        // Nothing to remove if `ignoreGhsas` isn't present — and crucially,
-        // don't touch sibling `auditConfig` keys.
-        if !mapping.entries.iter().any(|entry| entry.key == "ignoreGhsas") {
+        if locate(text, &[BLOCK]).is_none() {
             return Ok(false);
         }
-        let only_ignore_ghsas = mapping.entries.iter().all(|entry| entry.key == "ignoreGhsas");
-        if only_ignore_ghsas {
+        let keys = mapping_keys(text, &[BLOCK]);
+        // Nothing to remove if `ignoreGhsas` isn't present — and crucially,
+        // don't touch sibling `auditConfig` keys.
+        if !keys.iter().any(|key| key == "ignoreGhsas") {
+            return Ok(false);
+        }
+        if keys.iter().all(|key| key == "ignoreGhsas") {
             manifest.set_text(remove_top_level_block(text, BLOCK));
             manifest.top_level_keys.retain(|key| key != BLOCK);
         } else {
@@ -405,6 +489,13 @@ pub(crate) fn set_minimum_release_age_excludes(manifest: &mut Manifest, items: &
     }
 
     let text = manifest.text();
+    if let Inline::Flow(collection) = locate_sequence(text, &[BLOCK]) {
+        let rendered: Vec<String> = items.iter().map(|item| render::render_value(item)).collect();
+        manifest.set_text(flow::set_items(text, &collection, &rendered));
+        manifest.minimum_release_age_exclude = Some(items.to_vec());
+        return true;
+    }
+
     let rendered = render_top_level_sequence(BLOCK, items);
     if let Some(span) = top_level_span(text, BLOCK) {
         // Preserve a trailing blank line before the next block, since the
@@ -474,6 +565,13 @@ fn render_audit_config_block(ghsas: &[String]) -> String {
 /// in the position the reorder pass would choose. The mapping at
 /// `block_name` must already exist. Used to write `auditConfig.ignoreGhsas`.
 fn upsert_sequence_entry(text: &str, block_name: &str, key: &str, items: &[String]) -> String {
+    let rendered_items: Vec<String> = items.iter().map(|item| render::render_value(item)).collect();
+    if let Inline::Flow(collection) = locate_sequence(text, &[block_name, key]) {
+        return flow::set_items(text, &collection, &rendered_items);
+    }
+    if let Inline::Flow(collection) = locate_mapping(text, &[block_name]) {
+        return flow::upsert(text, &collection, key, &flow::render_sequence(&rendered_items));
+    }
     let mapping = locate(text, &[block_name]).expect("block exists");
     let item_indent = mapping.entry_indent + 2;
     let mut rendered = String::new();
@@ -511,32 +609,6 @@ fn upsert_sequence_entry(text: &str, block_name: &str, key: &str, items: &[Strin
     splice(text, offset, &rendered)
 }
 
-/// Replace the on-disk `overrides:` block with a block-style rendering of the
-/// decoded (already-edited) map. Used when the original block is flow-style and
-/// cannot be edited entry by entry.
-fn rerender_overrides_block(manifest: &mut Manifest, block_name: &str) {
-    let block = {
-        let overrides = manifest.overrides.as_ref().expect("non-empty overrides above");
-        let mut block = format!("{block_name}:\n");
-        for (selector, specifier) in overrides {
-            writeln!(
-                block,
-                "  {}: {}",
-                render::render_value(selector),
-                render::render_value(specifier),
-            )
-            .expect("writing to a String never fails");
-        }
-        block
-    };
-    manifest.set_text(remove_top_level_block(manifest.text(), block_name));
-    manifest.top_level_keys.retain(|key| key != block_name);
-    let new_text = insert_top_level_block(manifest, block_name, &block);
-    manifest.set_text(new_text);
-    manifest.top_level_keys =
-        render::target_order(&manifest.top_level_keys, &[block_name.to_string()]);
-}
-
 fn upsert_top_level_entry(
     manifest: &mut Manifest,
     block_name: &str,
@@ -545,14 +617,14 @@ fn upsert_top_level_entry(
     current_matches: bool,
 ) -> Result<bool, Box<yamlpatch::Error>> {
     let text = manifest.text();
-    if let Some(mapping) = locate(text, &[block_name]) {
-        let new_text = if mapping.entries.iter().any(|entry| entry.key == key) {
+    if locate(text, &[block_name]).is_some() {
+        let new_text = if mapping_keys(text, &[block_name]).iter().any(|entry| entry == key) {
             if current_matches {
                 return Ok(false);
             }
             replace_value_at(text, &[block_name], key, value)?
         } else {
-            insert_entry_at(text, &[block_name], key, value)
+            write_entry_at(text, &[block_name], key, value)
         };
         manifest.set_text(new_text);
     } else {
@@ -576,8 +648,8 @@ fn upsert_top_level_entry(
 pub(crate) fn add_allow_build(manifest: &mut Manifest, name: &str, value: bool) -> bool {
     const BLOCK: &str = "allowBuilds";
     let text = manifest.text();
-    let changed = if let Some(mapping) = locate(text, &[BLOCK]) {
-        if mapping.entries.iter().any(|entry| entry.key == name) {
+    let changed = if locate(text, &[BLOCK]).is_some() {
+        if mapping_keys(text, &[BLOCK]).iter().any(|key| key == name) {
             // Already present with the same value — a true no-op, so don't
             // rewrite the file (which would bump its mtime).
             if manifest.allow_builds.as_ref().and_then(|builds| builds.get(name))
@@ -585,10 +657,14 @@ pub(crate) fn add_allow_build(manifest: &mut Manifest, name: &str, value: bool) 
             {
                 return false;
             }
-            let new_text = replace_bool_value_at(text, &[BLOCK], name, value);
+            let new_text = if let Inline::Flow(collection) = locate_mapping(text, &[BLOCK]) {
+                flow::upsert(text, &collection, name, render_bool(value))
+            } else {
+                replace_bool_value_at(text, &[BLOCK], name, value)
+            };
             manifest.set_text(new_text);
         } else {
-            let new_text = insert_rendered_entry_at(text, &[BLOCK], name, render_bool(value));
+            let new_text = write_rendered_entry_at(text, &[BLOCK], name, render_bool(value));
             manifest.set_text(new_text);
         }
         true
@@ -620,7 +696,14 @@ pub(crate) fn add_undecided_allow_build(
 ) -> bool {
     const BLOCK: &str = "allowBuilds";
     let text = manifest.text();
-    let Some(mapping) = locate(text, &[BLOCK]) else {
+    if locate(text, &[BLOCK]).is_some() {
+        if mapping_keys(text, &[BLOCK]).iter().any(|key| key == name) {
+            return false;
+        }
+        let new_text =
+            write_rendered_entry_at(text, &[BLOCK], name, &render::render_value(placeholder));
+        manifest.set_text(new_text);
+    } else {
         let block = format!(
             "{BLOCK}:\n  {}: {}\n",
             render::render_value(name),
@@ -630,18 +713,7 @@ pub(crate) fn add_undecided_allow_build(
         manifest.set_text(new_text);
         manifest.top_level_keys =
             render::target_order(&manifest.top_level_keys, &[BLOCK.to_string()]);
-        manifest
-            .allow_builds
-            .get_or_insert_with(IndexMap::new)
-            .insert(name.to_string(), AllowBuildValue::String(placeholder.to_string()));
-        return true;
-    };
-    if mapping.entries.iter().any(|entry| entry.key == name) {
-        return false;
     }
-    let new_text =
-        insert_rendered_entry_at(text, &[BLOCK], name, &render::render_value(placeholder));
-    manifest.set_text(new_text);
     manifest
         .allow_builds
         .get_or_insert_with(IndexMap::new)
@@ -792,7 +864,7 @@ fn upsert_existing(
             Ok(true)
         }
         None => {
-            let new_text = insert_entry(manifest.text(), target, dep, specifier);
+            let new_text = write_entry(manifest.text(), target, dep, specifier);
             manifest.set_text(new_text);
             target_map_mut(manifest, target).insert(dep.to_string(), specifier.to_string());
             Ok(true)
@@ -821,7 +893,7 @@ fn create_target(
         manifest.catalog = Some(IndexMap::from([(dep.to_string(), specifier.to_string())]));
     } else if manifest.catalogs.is_some() {
         // `catalogs:` exists but lacks this name — add a named sub-block.
-        let new_text = insert_named_subblock(manifest, catalog_name, dep, &value);
+        let new_text = write_named_subblock(manifest, catalog_name, dep, &value);
         manifest.set_text(new_text);
         manifest.catalogs.as_mut().expect("catalogs present").insert(
             catalog_name.to_string(),
@@ -903,6 +975,13 @@ fn replace_scalar_at(
     dep: &str,
     value: yaml_serde::Value,
 ) -> Result<String, Box<yamlpatch::Error>> {
+    if let Inline::Flow(collection) = locate_mapping(text, path) {
+        let value_text = yaml_serde::to_string(&value)
+            .expect("serializing a scalar to YAML never fails")
+            .trim_end()
+            .to_string();
+        return Ok(flow::upsert(text, &collection, dep, &value_text));
+    }
     let document =
         Document::new(text.to_string()).map_err(yamlpatch::Error::from).map_err(Box::new)?;
     let components: Vec<Component> = path
@@ -916,23 +995,30 @@ fn replace_scalar_at(
     Ok(patched.source().to_string())
 }
 
-/// Insert a new `dep: value` entry into an existing catalog mapping at the
+/// Write a `dep: value` entry into an existing catalog mapping at the
 /// position the reorder pass would choose (sorted-in when the block is
 /// sorted, appended otherwise).
-fn insert_entry(text: &str, target: &Target, dep: &str, specifier: &str) -> String {
-    insert_entry_at(text, &target.path(), dep, specifier)
+fn write_entry(text: &str, target: &Target, dep: &str, specifier: &str) -> String {
+    write_entry_at(text, &target.path(), dep, specifier)
 }
 
-/// [`insert_entry`] addressed by an explicit mapping path, so non-catalog
+/// [`write_entry`] addressed by an explicit mapping path, so non-catalog
 /// blocks (e.g. `configDependencies`) can reuse the reorder-aware splice.
-fn insert_entry_at(text: &str, path: &[&str], dep: &str, specifier: &str) -> String {
-    insert_rendered_entry_at(text, path, dep, &render::render_value(specifier))
+fn write_entry_at(text: &str, path: &[&str], dep: &str, specifier: &str) -> String {
+    write_rendered_entry_at(text, path, dep, &render::render_value(specifier))
 }
 
-/// [`insert_entry_at`] for an already-rendered value text, so non-string
+/// [`write_entry_at`] for an already-rendered value text, so non-string
 /// blocks (e.g. `allowBuilds`'s `true` / `false`) can reuse the
 /// reorder-aware splice without going through [`render::render_value`].
-fn insert_rendered_entry_at(text: &str, path: &[&str], dep: &str, value_text: &str) -> String {
+///
+/// A block-style mapping gains a new entry line; a single-line flow mapping
+/// is rebuilt with the entry upserted, since a flow mapping the caller
+/// thought was entry-less may well already hold `dep`.
+fn write_rendered_entry_at(text: &str, path: &[&str], dep: &str, value_text: &str) -> String {
+    if let Inline::Flow(collection) = locate_mapping(text, path) {
+        return flow::upsert(text, &collection, dep, value_text);
+    }
     let mapping = locate(text, path).expect("mapping exists");
     let existing: Vec<String> = mapping.entries.iter().map(|entry| entry.key.clone()).collect();
     let order = render::target_order(&existing, &[dep.to_string()]);
@@ -958,7 +1044,12 @@ fn insert_rendered_entry_at(text: &str, path: &[&str], dep: &str, value_text: &s
     splice(text, offset, &line)
 }
 
+/// Drop `keys` from the mapping at `path`, whether it is written in block
+/// or single-line flow style.
 fn remove_mapping_entries(text: &str, path: &[&str], keys: &[String]) -> String {
+    if let Inline::Flow(collection) = locate_mapping(text, path) {
+        return flow::remove_keys(text, &collection, keys);
+    }
     let Some(mapping) = locate(text, path) else {
         return text.to_string();
     };
@@ -978,10 +1069,14 @@ fn remove_top_level_block(text: &str, key: &str) -> String {
     out
 }
 
-/// Insert a new named catalog (`<name>:` + its first entry) into an existing
+/// Write a new named catalog (`<name>:` + its first entry) into an existing
 /// top-level `catalogs:` block, at the position the reorder pass would choose.
-fn insert_named_subblock(manifest: &Manifest, name: &str, dep: &str, value: &str) -> String {
+fn write_named_subblock(manifest: &Manifest, name: &str, dep: &str, value: &str) -> String {
     let text = manifest.text();
+    if let Inline::Flow(collection) = locate_mapping(text, &["catalogs"]) {
+        let entry = format!("{{ {}: {value} }}", render::render_value(dep));
+        return flow::upsert(text, &collection, name, &entry);
+    }
     let catalogs = locate(text, &["catalogs"]).expect("catalogs block exists");
     let existing: Vec<String> = catalogs.entries.iter().map(|entry| entry.key.clone()).collect();
     let order = render::target_order(&existing, &[name.to_string()]);
@@ -1299,25 +1394,6 @@ fn collect_entries(all: &[Line<'_>], from: usize, to: usize, entry_indent: usize
     entries
 }
 
-/// Whether the top-level `key:` carries an inline value (a flow mapping /
-/// flow sequence / scalar) on the same line rather than a block body on the
-/// following lines. The block-style splice writers (e.g.
-/// [`set_audit_ignore_ghsas`]) assume a block body, so a caller can refuse an
-/// inline shape instead of corrupting it. A bare `key:` (optionally with a
-/// trailing comment) is block-style and returns `false`.
-pub(crate) fn top_level_has_inline_value(text: &str, key: &str) -> bool {
-    for line in text.lines() {
-        if structural_indent(line) != Some(0) || line_key(line).as_deref() != Some(key) {
-            continue;
-        }
-        let trimmed = line.trim_start();
-        let Some(colon) = structural_colon_index(trimmed) else { return false };
-        let after = trimmed[colon + 1..].trim_start();
-        return !after.is_empty() && !after.starts_with('#');
-    }
-    false
-}
-
 /// The starting offset of a top-level key's line.
 fn top_level_span(text: &str, key: &str) -> Option<TopLevelSpan> {
     let all = lines(text);
@@ -1442,9 +1518,17 @@ pub(crate) fn prune_allow_builds(
         return true;
     }
 
-    let entries = locate(manifest.text(), &[BLOCK]).map(|mapping| mapping.entries);
-    let new_text = match entries.as_deref() {
-        Some(entries) if !entries.is_empty() => {
+    let new_text = match locate_mapping(manifest.text(), &[BLOCK]) {
+        Inline::Flow(collection) => {
+            let prunable: Vec<String> = prunable.iter().cloned().collect();
+            flow::remove_keys(manifest.text(), &collection, &prunable)
+        }
+        Inline::Unsupported => return false,
+        Inline::Block => {
+            let entries = match locate(manifest.text(), &[BLOCK]) {
+                Some(mapping) if !mapping.entries.is_empty() => mapping.entries,
+                _ => return false,
+            };
             // Entries are removed by pairing each text line with its decoded
             // key — the raw key text can differ from the decoded form
             // (quoting, escapes). A count mismatch means the two views
@@ -1458,17 +1542,7 @@ pub(crate) fn prune_allow_builds(
                     out.replace_range(entry.line_start..entry.block_end, "");
                 }
             }
-            Some(out)
-        }
-        _ => {
-            let flow_edit = remove_flow_entries(manifest.text(), BLOCK, &all_keys, &prunable);
-            // The fallback rerenders the block from the decoded view, which
-            // would lose entries that view dropped (values that are neither
-            // booleans nor strings) — leave such a block untouched.
-            if flow_edit.is_none() && allow_builds.len() != all_keys.len() {
-                return false;
-            }
-            flow_edit
+            out
         }
     };
 
@@ -1477,10 +1551,7 @@ pub(crate) fn prune_allow_builds(
             builds.shift_remove(key);
         }
     }
-    match new_text {
-        Some(new_text) => manifest.set_text(new_text),
-        None => rerender_allow_builds_block(manifest, BLOCK),
-    }
+    manifest.set_text(new_text);
     true
 }
 
@@ -1503,107 +1574,6 @@ fn allow_build_key_package_name(key: &str) -> Option<&str> {
     (!name.is_empty() && !name.contains(':')).then_some(name)
 }
 
-/// Rewrite `block_name`'s single-line flow mapping in place, dropping the
-/// entries whose decoded key is in `prunable`. `decoded_keys` pairs the
-/// mapping's entries positionally. Surviving entries keep their original
-/// text and everything outside the braces (indentation, trailing comment)
-/// stays, matching what the TypeScript writer's yaml library emits. Returns
-/// `None` when the text does not have that shape.
-fn remove_flow_entries(
-    text: &str,
-    block_name: &str,
-    decoded_keys: &[String],
-    prunable: &HashSet<String>,
-) -> Option<String> {
-    let span = top_level_span(text, block_name)?;
-    let block = &text[span.key_line_start..span.block_end];
-    let open = block.find('{')?;
-    let interior_and_rest = &block[open + 1..];
-    let close_in_interior = flow_mapping_close(interior_and_rest)?;
-    let interior = &interior_and_rest[..close_in_interior];
-    if interior.contains('\n') {
-        return None;
-    }
-    let segments = split_flow_entries(interior)?;
-    if segments.len() != decoded_keys.len() {
-        return None;
-    }
-    let surviving: Vec<&str> = segments
-        .iter()
-        .zip(decoded_keys)
-        .filter(|&(_, key)| !prunable.contains(key))
-        .map(|(segment, _)| segment.trim())
-        .collect();
-    let rendered = format!("{{ {} }}", surviving.join(", "));
-    let start = span.key_line_start + open;
-    let end = span.key_line_start + open + 1 + close_in_interior + 1;
-    let mut out = text.to_string();
-    out.replace_range(start..end, &rendered);
-    Some(out)
-}
-
-/// Byte offset of the `}` closing a flow mapping whose `{` precedes `text`,
-/// skipping quoted scalars. `None` when unterminated or when a nested flow
-/// collection appears (the entries here hold only scalars).
-fn flow_mapping_close(text: &str) -> Option<usize> {
-    let mut idx = 0;
-    while idx < text.len() {
-        match text.as_bytes()[idx] {
-            b'}' => return Some(idx),
-            b'{' | b'[' | b']' => return None,
-            b'\'' | b'"' => idx = skip_quoted_scalar(text, idx)?,
-            _ => idx += 1,
-        }
-    }
-    None
-}
-
-/// Split a flow mapping's interior on its entry-separating commas, skipping
-/// commas inside quoted scalars. `None` on an unterminated quote or a
-/// nested flow collection.
-fn split_flow_entries(interior: &str) -> Option<Vec<&str>> {
-    let mut segments = Vec::new();
-    let mut start = 0;
-    let mut idx = 0;
-    while idx < interior.len() {
-        match interior.as_bytes()[idx] {
-            b',' => {
-                segments.push(&interior[start..idx]);
-                start = idx + 1;
-                idx += 1;
-            }
-            b'{' | b'[' | b'}' | b']' => return None,
-            b'\'' | b'"' => idx = skip_quoted_scalar(interior, idx)?,
-            _ => idx += 1,
-        }
-    }
-    segments.push(&interior[start..]);
-    Some(segments)
-}
-
-/// Byte offset just past the quoted scalar starting at `open` (a `'` or `"`
-/// byte), honoring the style's escape (`''` doubling, `\"`/`\\`). `None`
-/// when unterminated.
-fn skip_quoted_scalar(text: &str, open: usize) -> Option<usize> {
-    let bytes = text.as_bytes();
-    let quote = bytes[open];
-    let mut idx = open + 1;
-    while idx < bytes.len() {
-        match bytes[idx] {
-            b'\\' if quote == b'"' => idx += 2,
-            byte if byte == quote => {
-                if quote == b'\'' && bytes.get(idx + 1) == Some(&b'\'') {
-                    idx += 2;
-                } else {
-                    return Some(idx + 1);
-                }
-            }
-            _ => idx += 1,
-        }
-    }
-    None
-}
-
 fn allow_builds_keys_in_text(text: &str) -> Vec<String> {
     #[derive(serde::Deserialize)]
     struct OnlyAllowBuilds {
@@ -1615,27 +1585,4 @@ fn allow_builds_keys_in_text(text: &str) -> Vec<String> {
         .and_then(|parsed| parsed.allow_builds)
         .map(|map| map.into_keys().collect())
         .unwrap_or_default()
-}
-
-fn rerender_allow_builds_block(manifest: &mut Manifest, block_name: &str) {
-    let block = {
-        let allow_builds = manifest.allow_builds.as_ref().expect("non-empty allowBuilds above");
-        let mut block = format!("{block_name}:\n");
-        for (name, value) in allow_builds {
-            let rendered_val = match value {
-                AllowBuildValue::Bool(b) => render_bool(*b).to_string(),
-                AllowBuildValue::String(s) => render::render_value(s),
-                AllowBuildValue::Other(_) => String::new(),
-            };
-            writeln!(block, "  {}: {}", render::render_value(name), rendered_val)
-                .expect("writing to a String never fails");
-        }
-        block
-    };
-    manifest.set_text(remove_top_level_block(manifest.text(), block_name));
-    manifest.top_level_keys.retain(|key| key != block_name);
-    let new_text = insert_top_level_block(manifest, block_name, &block);
-    manifest.set_text(new_text);
-    manifest.top_level_keys =
-        render::target_order(&manifest.top_level_keys, &[block_name.to_string()]);
 }

--- a/pnpm/crates/workspace-manifest-writer/src/flow.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/flow.rs
@@ -1,0 +1,319 @@
+//! Format-preserving edits of single-line flow collections.
+//!
+//! `pnpm-workspace.yaml` is normally block style, and the line-oriented
+//! splices in [`super::edit`] assume that shape. A hand-written flow value
+//! (`overrides: { foo: 1.0.0 }`, `ignoreGhsas: [GHSA-1]`) has no line
+//! entries for them to work with, so it is edited here instead: the
+//! collection is rebuilt from its own entry texts with one entry inserted,
+//! replaced, or dropped. Every untouched entry keeps its text (and so its
+//! quoting), and everything outside the brackets — indentation, a trailing
+//! comment — stays verbatim, which is what the TypeScript writer's yaml
+//! library emits for the same edit.
+//!
+//! Only collections written on one line are edited. A flow collection
+//! spanning several lines can carry comments between its entries, which
+//! rebuilding onto one line would drop, so [`parse`] rejects it and the
+//! caller refuses the write rather than silently discarding them.
+
+use std::ops::Range;
+
+/// Which brackets a flow collection uses.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Kind {
+    Mapping,
+    Sequence,
+}
+
+/// A parsed single-line flow collection.
+pub(crate) struct Collection {
+    kind: Kind,
+    /// Byte range of the collection, brackets included.
+    span: Range<usize>,
+    entries: Vec<Entry>,
+}
+
+/// One entry of a flow collection.
+struct Entry {
+    /// Decoded key, for a mapping entry.
+    key: Option<String>,
+    /// Byte range of the entry's text, without the separating commas or the
+    /// whitespace around it.
+    span: Range<usize>,
+    /// Byte range of a mapping entry's value text.
+    value: Range<usize>,
+}
+
+impl Collection {
+    pub(crate) fn kind(&self) -> Kind {
+        self.kind
+    }
+
+    /// The entry keys, in document order. Empty for a sequence.
+    pub(crate) fn keys(&self) -> Vec<String> {
+        self.entries.iter().filter_map(|entry| entry.key.clone()).collect()
+    }
+
+    fn position_of(&self, key: &str) -> Option<usize> {
+        self.entries.iter().position(|entry| entry.key.as_deref() == Some(key))
+    }
+
+    /// Byte offset where `key`'s value starts, for descending into a
+    /// collection nested in this one.
+    pub(crate) fn value_start(&self, key: &str) -> Option<usize> {
+        self.position_of(key).map(|position| self.entries[position].value.start)
+    }
+}
+
+/// Parse the flow collection opening at `open` (a `{` or `[` byte).
+/// `None` when it is not one this module can edit: a multi-line
+/// collection, an unterminated one, or one holding an entry shape the
+/// rebuild cannot reproduce (an empty entry, a mapping entry without a
+/// value, an explicit `? key` entry).
+pub(crate) fn parse(text: &str, open: usize) -> Option<Collection> {
+    let kind = match text.as_bytes().get(open)? {
+        b'{' => Kind::Mapping,
+        b'[' => Kind::Sequence,
+        _ => return None,
+    };
+    let close = closing_bracket(text, open)?;
+    let entries = split_entries(text, open + 1..close)?
+        .into_iter()
+        .map(|span| entry(text, span, kind))
+        .collect::<Option<Vec<Entry>>>()?;
+    Some(Collection { kind, span: open..close + 1, entries })
+}
+
+/// Replace `key`'s value, or add the entry at the position the reorder pass
+/// would choose, and return the document with the rebuilt collection
+/// spliced in. `value_text` is already-rendered YAML.
+pub(crate) fn upsert(text: &str, collection: &Collection, key: &str, value_text: &str) -> String {
+    let mut entries: Vec<String> =
+        collection.entries.iter().map(|entry| text[entry.span.clone()].to_string()).collect();
+    if let Some(position) = collection.position_of(key) {
+        let entry = &collection.entries[position];
+        let key_text = text[entry.span.start..entry.value.start].trim_end();
+        entries[position] = format!("{key_text} {value_text}");
+    } else {
+        let order = crate::render::target_order(&collection.keys(), &[key.to_string()]);
+        let position =
+            order.iter().position(|ordered| ordered == key).expect("key is in the order");
+        entries.insert(position, format!("{}: {value_text}", crate::render::render_value(key)));
+    }
+    splice(text, collection, &entries)
+}
+
+/// Drop the entries whose key is in `keys` and return the document with the
+/// rebuilt collection spliced in.
+pub(crate) fn remove_keys(text: &str, collection: &Collection, keys: &[String]) -> String {
+    let entries: Vec<String> = collection
+        .entries
+        .iter()
+        .filter(|entry| !entry.key.as_ref().is_some_and(|key| keys.contains(key)))
+        .map(|entry| text[entry.span.clone()].to_string())
+        .collect();
+    splice(text, collection, &entries)
+}
+
+/// Replace a flow sequence's items wholesale and return the document with
+/// the rebuilt collection spliced in. `items` are already-rendered YAML.
+pub(crate) fn set_items(text: &str, collection: &Collection, items: &[String]) -> String {
+    splice(text, collection, items)
+}
+
+/// Render `items` as a flow sequence, for writing one as another
+/// collection's entry value.
+pub(crate) fn render_sequence(items: &[String]) -> String {
+    render(Kind::Sequence, items)
+}
+
+/// Render `entries` between the brackets `kind` uses.
+fn render(kind: Kind, entries: &[String]) -> String {
+    let (open, close) = match kind {
+        Kind::Mapping => ('{', '}'),
+        Kind::Sequence => ('[', ']'),
+    };
+    if entries.is_empty() {
+        format!("{open}{close}")
+    } else {
+        format!("{open} {} {close}", entries.join(", "))
+    }
+}
+
+/// Render `entries` into `collection`'s brackets and splice the result over
+/// the original collection text.
+fn splice(text: &str, collection: &Collection, entries: &[String]) -> String {
+    let rendered = render(collection.kind, entries);
+    let mut out = text.to_string();
+    out.replace_range(collection.span.clone(), &rendered);
+    out
+}
+
+/// Byte offset of the bracket closing the collection that opens at `open`,
+/// or `None` when the collection is unterminated, spans several lines, or
+/// runs into a comment (which continues to the end of the line, so the
+/// collection cannot close before it).
+fn closing_bracket(text: &str, open: usize) -> Option<usize> {
+    let bytes = text.as_bytes();
+    let mut depth = 0usize;
+    let mut idx = open;
+    while idx < bytes.len() {
+        match bytes[idx] {
+            b'\n' => return None,
+            b'#' if bytes[idx - 1].is_ascii_whitespace() => return None,
+            b'{' | b'[' => {
+                depth += 1;
+                idx += 1;
+            }
+            b'}' | b']' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(idx);
+                }
+                idx += 1;
+            }
+            b'\'' | b'"' => idx = skip_quoted_scalar(text, idx)?,
+            _ => idx += 1,
+        }
+    }
+    None
+}
+
+/// Split a flow collection's interior at its entry-separating commas,
+/// returning each entry's trimmed span. `None` when an entry is empty
+/// (which the rebuild cannot reproduce) or a quoted scalar is unterminated;
+/// a single trailing comma, which YAML allows, is not an empty entry.
+fn split_entries(text: &str, interior: Range<usize>) -> Option<Vec<Range<usize>>> {
+    let bytes = text.as_bytes();
+    let mut spans = Vec::new();
+    let mut start = interior.start;
+    let mut depth = 0usize;
+    let mut idx = interior.start;
+    while idx < interior.end {
+        match bytes[idx] {
+            b',' if depth == 0 => {
+                spans.push(trim_span(text, start..idx)?);
+                start = idx + 1;
+                idx += 1;
+            }
+            b'{' | b'[' => {
+                depth += 1;
+                idx += 1;
+            }
+            b'}' | b']' => {
+                depth = depth.checked_sub(1)?;
+                idx += 1;
+            }
+            b'\'' | b'"' => idx = skip_quoted_scalar(text, idx)?,
+            _ => idx += 1,
+        }
+    }
+    // A trailing comma leaves a blank final segment; anything else blank is
+    // an empty entry, which YAML reads as a null node.
+    let last = start..interior.end;
+    if text[last.clone()].trim().is_empty() {
+        if spans.is_empty() && !text[interior].trim().is_empty() {
+            return None;
+        }
+    } else {
+        spans.push(trim_span(text, last)?);
+    }
+    Some(spans)
+}
+
+/// `span` without the whitespace around it, or `None` when it holds none.
+fn trim_span(text: &str, span: Range<usize>) -> Option<Range<usize>> {
+    let slice = &text[span.clone()];
+    let trimmed = slice.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let start = span.start + (slice.len() - slice.trim_start().len());
+    Some(start..start + trimmed.len())
+}
+
+/// Describe the entry at `span`: for a mapping, its decoded key and the
+/// span of its value; for a sequence, the item alone.
+fn entry(text: &str, span: Range<usize>, kind: Kind) -> Option<Entry> {
+    if kind == Kind::Sequence {
+        return Some(Entry { key: None, span: span.clone(), value: span });
+    }
+    let delimiter = key_delimiter(text, span.clone())?;
+    let key = decode_key(text[span.start..delimiter].trim_end())?;
+    let value = trim_span(text, delimiter + 1..span.end)?;
+    Some(Entry { key: Some(key), span, value })
+}
+
+/// Byte offset of the `:` separating a flow mapping entry's key from its
+/// value. In a flow context the `:` may follow a quoted key directly
+/// (`{"a":"b"}`); elsewhere it is the delimiter only when whitespace or the
+/// end of the entry follows it. `None` for a valueless entry (`{a, b}`) or
+/// an explicit `? key : value` one.
+fn key_delimiter(text: &str, span: Range<usize>) -> Option<usize> {
+    if text[span.clone()].starts_with('?') {
+        return None;
+    }
+    let bytes = text.as_bytes();
+    let mut depth = 0usize;
+    let mut idx = span.start;
+    let mut after_quoted_key = false;
+    while idx < span.end {
+        match bytes[idx] {
+            b':' if depth == 0
+                && (after_quoted_key
+                    || bytes.get(idx + 1).is_none_or(u8::is_ascii_whitespace)
+                    || idx + 1 == span.end) =>
+            {
+                return Some(idx);
+            }
+            b'{' | b'[' => {
+                depth += 1;
+                idx += 1;
+            }
+            b'}' | b']' => {
+                depth = depth.checked_sub(1)?;
+                idx += 1;
+            }
+            b'\'' | b'"' => {
+                idx = skip_quoted_scalar(text, idx)?;
+                after_quoted_key = depth == 0;
+                continue;
+            }
+            _ => idx += 1,
+        }
+        after_quoted_key = false;
+    }
+    None
+}
+
+/// Decode a key's text into the string it denotes: a plain scalar denotes
+/// itself, a quoted one is unquoted and unescaped. `None` when a quoted key
+/// does not decode.
+fn decode_key(key_text: &str) -> Option<String> {
+    match key_text.as_bytes().first() {
+        Some(b'\'' | b'"') => serde_saphyr::from_str::<String>(key_text).ok(),
+        _ => Some(key_text.to_string()),
+    }
+}
+
+/// Byte offset just past the quoted scalar starting at `open` (a `'` or `"`
+/// byte), honoring the style's escape (`''` doubling, `\"`/`\\`). `None`
+/// when unterminated.
+fn skip_quoted_scalar(text: &str, open: usize) -> Option<usize> {
+    let bytes = text.as_bytes();
+    let quote = bytes[open];
+    let mut idx = open + 1;
+    while idx < bytes.len() {
+        match bytes[idx] {
+            b'\\' if quote == b'"' => idx += 2,
+            byte if byte == quote => {
+                if quote == b'\'' && bytes.get(idx + 1) == Some(&b'\'') {
+                    idx += 2;
+                } else {
+                    return Some(idx + 1);
+                }
+            }
+            _ => idx += 1,
+        }
+    }
+    None
+}

--- a/pnpm/crates/workspace-manifest-writer/src/flow.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/flow.rs
@@ -153,19 +153,32 @@ fn splice(text: &str, collection: &Collection, entries: &[String]) -> String {
 /// runs into a comment (which continues to the end of the line, so the
 /// collection cannot close before it).
 fn closing_bracket(text: &str, open: usize) -> Option<usize> {
+    let close = closing_bracket_across_lines(text, open)?;
+    // A comment inside the collection runs to the end of its line, so a
+    // collection holding one cannot close before a line break either.
+    (!text[open..close].contains('\n')).then_some(close)
+}
+
+/// Byte offset of the bracket closing the collection that opens at `open`,
+/// however many lines and comments it spans. `None` when it is
+/// unterminated. Callers that only edit one-line collections use
+/// [`closing_bracket`]; this one tells them where such a value ends so they
+/// can replace or delete it whole.
+pub(crate) fn closing_bracket_across_lines(text: &str, open: usize) -> Option<usize> {
     let bytes = text.as_bytes();
     let mut depth = 0usize;
     let mut idx = open;
     while idx < bytes.len() {
         match bytes[idx] {
-            b'\n' => return None,
-            b'#' if bytes[idx - 1].is_ascii_whitespace() => return None,
+            b'#' if idx > open && bytes[idx - 1].is_ascii_whitespace() => {
+                idx = text[idx..].find('\n').map_or(bytes.len(), |offset| idx + offset + 1);
+            }
             b'{' | b'[' => {
                 depth += 1;
                 idx += 1;
             }
             b'}' | b']' => {
-                depth -= 1;
+                depth = depth.checked_sub(1)?;
                 if depth == 0 {
                     return Some(idx);
                 }

--- a/pnpm/crates/workspace-manifest-writer/src/lib.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/lib.rs
@@ -26,6 +26,7 @@ use pnpm_package_manifest::{DependencyGroup, PackageManifest};
 pub use pnpm_config::version_policy::ResolvedPackageVersions;
 
 mod edit;
+mod flow;
 mod model;
 mod render;
 
@@ -88,7 +89,7 @@ pub enum UpdateWorkspaceManifestError {
     OverrideConflict { path: std::path::PathBuf, key: String },
 
     #[display(
-        "Cannot edit {key:?} in {path:?}: it uses an inline (flow) YAML value. Reformat it to block style and try again."
+        "Cannot edit {key:?} in {path:?}: it uses an inline YAML value that cannot be edited in place (a multi-line flow collection, an alias, or a scalar). Reformat it to block style and try again."
     )]
     #[diagnostic(code(ERR_PNPM_WORKSPACE_MANIFEST_WRITER_UNSUPPORTED_INLINE_BLOCK))]
     UnsupportedInlineBlock { path: std::path::PathBuf, key: String },
@@ -116,6 +117,17 @@ fn has_control_char(value: &str) -> bool {
     value
         .chars()
         .any(|character| character.is_control() || matches!(character, '\u{2028}' | '\u{2029}'))
+}
+
+/// The first of `paths` whose value is written as an inline shape none of
+/// the writers can edit, named for the error message. A single-line flow
+/// collection is editable and never reported here; a multi-line one, an
+/// alias, or a scalar standing where a collection belongs is.
+fn unsupported_inline_key(text: &str, paths: &[&[&str]]) -> Option<String> {
+    paths
+        .iter()
+        .find(|path| edit::has_unsupported_inline_value(text, path))
+        .map(|path| path.join("."))
 }
 
 /// Inputs of [`update_workspace_manifest`].
@@ -160,6 +172,19 @@ pub fn update_workspace_manifest(
 
     let mut manifest = Manifest::parse(original.as_deref())
         .map_err(|source| UpdateWorkspaceManifestError::Parse { path: path.clone(), source })?;
+
+    if let Some(updated_catalogs) = opts
+        .updated_catalogs
+        .filter(|catalogs| catalogs.values().any(|entries| !entries.is_empty()))
+    {
+        let named: Vec<Vec<&str>> =
+            updated_catalogs.keys().map(|name| vec!["catalogs", name.as_str()]).collect();
+        let mut paths: Vec<&[&str]> = vec![&["catalog"], &["catalogs"]];
+        paths.extend(named.iter().map(Vec::as_slice));
+        if let Some(key) = unsupported_inline_key(manifest.text(), &paths) {
+            return Err(UpdateWorkspaceManifestError::UnsupportedInlineBlock { path, key });
+        }
+    }
 
     let mut changed = match opts.updated_catalogs {
         Some(updated_catalogs) => {
@@ -263,6 +288,13 @@ pub fn set_config_dependencies<'a>(
     let mut manifest = Manifest::parse(original.as_deref())
         .map_err(|source| UpdateWorkspaceManifestError::Parse { path: path.clone(), source })?;
 
+    let entries: Vec<(&str, &str)> = entries.into_iter().collect();
+    if !entries.is_empty()
+        && let Some(key) = unsupported_inline_key(manifest.text(), &[&["configDependencies"]])
+    {
+        return Err(UpdateWorkspaceManifestError::UnsupportedInlineBlock { path, key });
+    }
+
     let mut changed = false;
     for (name, specifier) in entries {
         changed |= edit::add_config_dependency(&mut manifest, name, specifier)
@@ -335,6 +367,13 @@ where
     let mut manifest = Manifest::parse(original.as_deref())
         .map_err(|source| UpdateWorkspaceManifestError::Parse { path: path.clone(), source })?;
 
+    let entries: Vec<(&str, bool)> = entries.into_iter().collect();
+    if !entries.is_empty()
+        && let Some(key) = unsupported_inline_key(manifest.text(), &[&["allowBuilds"]])
+    {
+        return Err(UpdateWorkspaceManifestError::UnsupportedInlineBlock { path, key });
+    }
+
     let mut changed = false;
     for (name, value) in entries {
         // The block-style splice writes `- name: true` on one line, so a
@@ -391,6 +430,13 @@ where
     let mut manifest = Manifest::parse(original.as_deref())
         .map_err(|source| UpdateWorkspaceManifestError::Parse { path: path.clone(), source })?;
 
+    let names: Vec<&str> = names.into_iter().collect();
+    if !names.is_empty()
+        && let Some(key) = unsupported_inline_key(manifest.text(), &[&["allowBuilds"]])
+    {
+        return Err(UpdateWorkspaceManifestError::UnsupportedInlineBlock { path, key });
+    }
+
     let mut changed = false;
     for name in names {
         // Same guard as `set_allow_builds`: the block-style splice writes
@@ -429,6 +475,12 @@ pub fn set_patched_dependencies(
     let mut manifest = Manifest::parse(original.as_deref())
         .map_err(|source| UpdateWorkspaceManifestError::Parse { path: path.clone(), source })?;
 
+    if !patched_dependencies.is_empty()
+        && let Some(key) = unsupported_inline_key(manifest.text(), &[&["patchedDependencies"]])
+    {
+        return Err(UpdateWorkspaceManifestError::UnsupportedInlineBlock { path, key });
+    }
+
     let changed = edit::add_patched_dependencies(&mut manifest, patched_dependencies)
         .map_err(|source| UpdateWorkspaceManifestError::Edit { path: path.clone(), source })?;
     if !changed {
@@ -466,13 +518,11 @@ where
     let mut manifest = Manifest::parse(original.as_deref())
         .map_err(|source| UpdateWorkspaceManifestError::Parse { path: path.clone(), source })?;
 
-    // The block-style splice can't safely edit an inline (flow) `overrides:`
-    // mapping; refuse rather than corrupt it.
-    if edit::top_level_has_inline_value(manifest.text(), "overrides") {
-        return Err(UpdateWorkspaceManifestError::UnsupportedInlineBlock {
-            path,
-            key: "overrides".to_string(),
-        });
+    let entries: Vec<(&str, &str)> = entries.into_iter().collect();
+    if !entries.is_empty()
+        && let Some(key) = unsupported_inline_key(manifest.text(), &[&["overrides"]])
+    {
+        return Err(UpdateWorkspaceManifestError::UnsupportedInlineBlock { path, key });
     }
 
     let mut changed = false;
@@ -530,13 +580,11 @@ pub fn set_audit_ignore_ghsas(
         });
     }
 
-    // The block-style splice can't safely edit an inline (flow) `auditConfig:`
-    // mapping; refuse rather than corrupt it.
-    if edit::top_level_has_inline_value(manifest.text(), "auditConfig") {
-        return Err(UpdateWorkspaceManifestError::UnsupportedInlineBlock {
-            path,
-            key: "auditConfig".to_string(),
-        });
+    if let Some(key) = unsupported_inline_key(
+        manifest.text(),
+        &[&["auditConfig"], &["auditConfig", "ignoreGhsas"]],
+    ) {
+        return Err(UpdateWorkspaceManifestError::UnsupportedInlineBlock { path, key });
     }
 
     let changed = edit::set_audit_ignore_ghsas(&mut manifest, ghsas)

--- a/pnpm/crates/workspace-manifest-writer/src/lib.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/lib.rs
@@ -682,6 +682,13 @@ pub fn update_manifest_field(
         UpdateWorkspaceManifestError::Parse { path: path.to_path_buf(), source }
     })?;
 
+    if edit::document_root_is_inline(manifest.text()) {
+        return Err(UpdateWorkspaceManifestError::UnsupportedInlineBlock {
+            path: path.to_path_buf(),
+            key: key.to_string(),
+        });
+    }
+
     let changed = if value.is_null() {
         edit::remove_top_level_field(&mut manifest, key)
     } else {

--- a/pnpm/crates/workspace-manifest-writer/src/lib.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/lib.rs
@@ -624,6 +624,10 @@ pub fn set_minimum_release_age_excludes(
     let mut manifest = Manifest::parse(original.as_deref())
         .map_err(|source| UpdateWorkspaceManifestError::Parse { path: path.clone(), source })?;
 
+    if let Some(key) = unsupported_inline_key(manifest.text(), &[&["minimumReleaseAgeExclude"]]) {
+        return Err(UpdateWorkspaceManifestError::UnsupportedInlineBlock { path, key });
+    }
+
     if !edit::set_minimum_release_age_excludes(&mut manifest, excludes) {
         return Ok(());
     }

--- a/pnpm/crates/workspace-manifest-writer/src/tests.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/tests.rs
@@ -1796,16 +1796,8 @@ mod flow_style {
 
     #[test]
     fn ignore_ghsas_are_added_to_a_flow_audit_config() {
-        let out = run_ignore_ghsas(
-            Some("auditConfig: { cleanupUnusedIgnoredGhsas: true }\n"),
-            &["GHSA-aaaa-bbbb-cccc"],
-        );
-        assert_eq!(
-            out.as_deref(),
-            Some(
-                "auditConfig: { cleanupUnusedIgnoredGhsas: true, ignoreGhsas: [ GHSA-aaaa-bbbb-cccc ] }\n"
-            ),
-        );
+        let out = run_ignore_ghsas(Some("auditConfig: {}\n"), &["GHSA-aaaa-bbbb-cccc"]);
+        assert_eq!(out.as_deref(), Some("auditConfig: { ignoreGhsas: [ GHSA-aaaa-bbbb-cccc ] }\n"));
     }
 
     #[test]

--- a/pnpm/crates/workspace-manifest-writer/src/tests.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/tests.rs
@@ -1703,21 +1703,21 @@ mod flow_style {
     #[test]
     fn named_catalog_entry_is_added_to_a_nested_flow_mapping() {
         let out = run(
-            Some("catalogs: { mycat: { foo: ^1.0.0 } }\n"),
-            &catalogs(&[("mycat", &[("bar", "^2.0.0")])]),
+            Some("catalogs: { myCatalog: { foo: ^1.0.0 } }\n"),
+            &catalogs(&[("myCatalog", &[("bar", "^2.0.0")])]),
         );
-        assert_eq!(out.as_deref(), Some("catalogs: { mycat: { bar: ^2.0.0, foo: ^1.0.0 } }\n"));
+        assert_eq!(out.as_deref(), Some("catalogs: { myCatalog: { bar: ^2.0.0, foo: ^1.0.0 } }\n"));
     }
 
     #[test]
     fn a_new_named_catalog_is_added_to_a_flow_catalogs_mapping() {
         let out = run(
-            Some("catalogs: { mycat: { foo: ^1.0.0 } }\n"),
-            &catalogs(&[("newcat", &[("bar", "^2.0.0")])]),
+            Some("catalogs: { myCatalog: { foo: ^1.0.0 } }\n"),
+            &catalogs(&[("newCatalog", &[("bar", "^2.0.0")])]),
         );
         assert_eq!(
             out.as_deref(),
-            Some("catalogs: { mycat: { foo: ^1.0.0 }, newcat: { bar: ^2.0.0 } }\n"),
+            Some("catalogs: { myCatalog: { foo: ^1.0.0 }, newCatalog: { bar: ^2.0.0 } }\n"),
         );
     }
 

--- a/pnpm/crates/workspace-manifest-writer/src/tests.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/tests.rs
@@ -1683,7 +1683,7 @@ mod flow_style {
     use super::{
         TempDir, UpdateWorkspaceManifestOptions, WORKSPACE_MANIFEST_FILENAME, catalogs, fs, run,
         run_age_excludes, run_allow_builds, run_config_dep, run_ignore_ghsas, run_patched_deps,
-        run_scaffold_allow_builds, update_workspace_manifest,
+        run_remove_overrides, run_scaffold_allow_builds, update_workspace_manifest,
     };
 
     #[test]
@@ -1815,6 +1815,56 @@ mod flow_style {
             .expect_err("must refuse a multi-line inline allowBuilds block");
 
         assert!(matches!(err, crate::UpdateWorkspaceManifestError::UnsupportedInlineBlock { .. }));
+        assert_eq!(fs::read_to_string(&path).expect("read manifest"), original);
+    }
+
+    #[test]
+    fn a_multiline_flow_sequence_is_refused_rather_than_rewritten() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join(WORKSPACE_MANIFEST_FILENAME);
+        let original = "minimumReleaseAgeExclude: [\n  foo@1.0.0, # pinned\n  bar@2.0.0,\n]\n";
+        fs::write(&path, original).expect("seed manifest");
+
+        let err = crate::set_minimum_release_age_excludes(dir.path(), &["baz@3.0.0".to_string()])
+            .expect_err("must refuse a multi-line inline sequence");
+
+        assert!(matches!(err, crate::UpdateWorkspaceManifestError::UnsupportedInlineBlock { .. }));
+        assert_eq!(fs::read_to_string(&path).expect("read manifest"), original);
+    }
+
+    #[test]
+    fn a_multiline_flow_block_is_dropped_whole_when_it_empties() {
+        let original = "packages:\n  - '*'\noverrides: {\n  foo: link:../foo, # pinned\n}\n";
+        let out = run_remove_overrides(Some(original), &["foo"]).expect("file kept");
+        assert_eq!(out, "packages:\n  - '*'\n");
+    }
+
+    #[test]
+    fn a_multiline_flow_block_is_deleted_whole_by_config_delete() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join(WORKSPACE_MANIFEST_FILENAME);
+        fs::write(&path, "overrides: {\n  foo: 1.0.0, # pinned\n}\npackages:\n  - '*'\n")
+            .expect("seed manifest");
+
+        crate::update_manifest_field(&path, "overrides", &serde_json::Value::Null)
+            .expect("update_manifest_field succeeds");
+
+        assert_eq!(fs::read_to_string(&path).expect("read manifest"), "packages:\n  - '*'\n");
+    }
+
+    /// A block whose value has the wrong shape for its setting never reaches
+    /// the writers: the typed parse rejects the manifest first.
+    #[test]
+    fn a_flow_collection_of_the_wrong_kind_fails_to_parse() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join(WORKSPACE_MANIFEST_FILENAME);
+        let original = "allowBuilds: [ foo ]\n";
+        fs::write(&path, original).expect("seed manifest");
+
+        let err = crate::set_allow_builds(dir.path(), [("bar", true)])
+            .expect_err("must refuse a sequence where allowBuilds expects a mapping");
+
+        assert!(matches!(err, crate::UpdateWorkspaceManifestError::Parse { .. }));
         assert_eq!(fs::read_to_string(&path).expect("read manifest"), original);
     }
 

--- a/pnpm/crates/workspace-manifest-writer/src/tests.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/tests.rs
@@ -1680,7 +1680,11 @@ fn prune_allow_builds_prunes_an_escaped_quoted_key() {
 /// matching what the TypeScript writer's yaml library emits, and refuses a
 /// multi-line one rather than dropping the comments between its entries.
 mod flow_style {
-    use super::*;
+    use super::{
+        TempDir, UpdateWorkspaceManifestOptions, WORKSPACE_MANIFEST_FILENAME, catalogs, fs, run,
+        run_age_excludes, run_allow_builds, run_config_dep, run_ignore_ghsas, run_patched_deps,
+        run_scaffold_allow_builds, update_workspace_manifest,
+    };
 
     #[test]
     fn catalog_entry_is_added_to_a_flow_mapping() {

--- a/pnpm/crates/workspace-manifest-writer/src/tests.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/tests.rs
@@ -861,19 +861,40 @@ fn ignore_ghsas_empty_with_sibling_only_is_a_noop() {
 }
 
 #[test]
-fn ignore_ghsas_refuses_inline_flow_audit_config() {
+fn ignore_ghsas_edits_an_inline_flow_audit_config() {
     let dir = TempDir::new().expect("temp dir");
     let path = dir.path().join(WORKSPACE_MANIFEST_FILENAME);
-    // A hand-written flow-style auditConfig: the block-splice writer can't
-    // safely edit it, so it must refuse instead of corrupting the file.
-    fs::write(&path, "auditConfig: { ignoreGhsas: [GHSA-aaaa-bbbb-cccc] }\n").expect("seed");
+    fs::write(
+        &path,
+        "auditConfig: { cleanupUnusedIgnoredGhsas: true, ignoreGhsas: [GHSA-aaaa-bbbb-cccc] }\n",
+    )
+    .expect("seed");
+
+    crate::set_audit_ignore_ghsas(dir.path(), &["GHSA-dddd-eeee-ffff".to_string()])
+        .expect("set_audit_ignore_ghsas succeeds");
+
+    let after = fs::read_to_string(&path).expect("read manifest");
+    assert_eq!(
+        after,
+        "auditConfig: { cleanupUnusedIgnoredGhsas: true, ignoreGhsas: [ GHSA-dddd-eeee-ffff ] }\n",
+    );
+}
+
+#[test]
+fn ignore_ghsas_refuses_a_multiline_flow_audit_config() {
+    let dir = TempDir::new().expect("temp dir");
+    let path = dir.path().join(WORKSPACE_MANIFEST_FILENAME);
+    // Rebuilding a multi-line flow mapping onto one line would drop the
+    // comments between its entries, so the write is refused instead.
+    let original = "auditConfig: {\n  ignoreGhsas: [GHSA-aaaa-bbbb-cccc], # pinned\n}\n";
+    fs::write(&path, original).expect("seed");
 
     let err = crate::set_audit_ignore_ghsas(dir.path(), &["GHSA-dddd-eeee-ffff".to_string()])
-        .expect_err("must refuse an inline auditConfig");
+        .expect_err("must refuse a multi-line inline auditConfig");
 
     assert!(matches!(err, crate::UpdateWorkspaceManifestError::UnsupportedInlineBlock { .. }));
     let after = fs::read_to_string(&path).expect("read manifest");
-    assert_eq!(after, "auditConfig: { ignoreGhsas: [GHSA-aaaa-bbbb-cccc] }\n");
+    assert_eq!(after, original);
 }
 
 /// Run `set_minimum_release_age_excludes` against `original` and return the
@@ -941,18 +962,42 @@ fn set_overrides_refuses_to_clobber_a_non_scalar_value() {
 }
 
 #[test]
-fn set_overrides_refuses_inline_flow_block() {
+fn set_overrides_edits_an_inline_flow_block() {
     let dir = TempDir::new().expect("temp dir");
     let path = dir.path().join(WORKSPACE_MANIFEST_FILENAME);
-    // A hand-written flow-style overrides block can't be block-spliced safely.
-    fs::write(&path, "overrides: { foo: 1.0.0 }\n").expect("seed manifest");
+    fs::write(&path, "overrides: { foo: 1.0.0 } # pinned\n").expect("seed manifest");
 
-    let err = crate::set_overrides(dir.path(), [("bar@<2.0.0", "^2.0.0")])
-        .expect_err("must refuse an inline overrides block");
+    crate::set_overrides(dir.path(), [("bar", "^2.0.0")]).expect("set_overrides succeeds");
+
+    let after = fs::read_to_string(&path).expect("read manifest");
+    assert_eq!(after, "overrides: { bar: ^2.0.0, foo: 1.0.0 } # pinned\n");
+}
+
+#[test]
+fn set_overrides_updates_an_entry_of_an_inline_flow_block() {
+    let dir = TempDir::new().expect("temp dir");
+    let path = dir.path().join(WORKSPACE_MANIFEST_FILENAME);
+    fs::write(&path, "overrides: { 'foo': \"1.0.0\", bar: 2.0.0 }\n").expect("seed manifest");
+
+    crate::set_overrides(dir.path(), [("foo", "^3.0.0")]).expect("set_overrides succeeds");
+
+    let after = fs::read_to_string(&path).expect("read manifest");
+    assert_eq!(after, "overrides: { 'foo': ^3.0.0, bar: 2.0.0 }\n");
+}
+
+#[test]
+fn set_overrides_refuses_a_multiline_flow_block() {
+    let dir = TempDir::new().expect("temp dir");
+    let path = dir.path().join(WORKSPACE_MANIFEST_FILENAME);
+    let original = "overrides: {\n  foo: 1.0.0, # pinned\n}\n";
+    fs::write(&path, original).expect("seed manifest");
+
+    let err = crate::set_overrides(dir.path(), [("bar", "^2.0.0")])
+        .expect_err("must refuse a multi-line inline overrides block");
 
     assert!(matches!(err, crate::UpdateWorkspaceManifestError::UnsupportedInlineBlock { .. }));
     let after = fs::read_to_string(&path).expect("read manifest");
-    assert_eq!(after, "overrides: { foo: 1.0.0 }\n");
+    assert_eq!(after, original);
 }
 
 #[test]
@@ -1073,7 +1118,7 @@ fn remove_overrides_is_a_noop_when_the_manifest_is_missing() {
 fn remove_overrides_handles_flow_style_mappings() {
     let original = "overrides: { foo: link:../foo, bar: 1.0.0 }\n";
     let out = run_remove_overrides(Some(original), &["foo"]).expect("file kept");
-    assert_eq!(out, "overrides:\n  bar: 1.0.0\n");
+    assert_eq!(out, "overrides: { bar: 1.0.0 }\n");
 }
 
 #[test]
@@ -1128,13 +1173,12 @@ fn allow_builds_clearing_legacy_is_a_noop_when_the_manifest_is_missing() {
 }
 
 #[test]
-fn remove_overrides_leaves_flow_style_block_with_non_string_entries_untouched() {
-    // A flow-style block can only be rewritten wholesale, and the decoded map
-    // cannot reserialize the non-string `bar`, so the file is left as-is rather
-    // than dropping data.
+fn remove_overrides_keeps_non_string_entries_of_a_flow_style_block() {
+    // The decoded map cannot reserialize the non-string `bar`, but the flow
+    // splice keeps its text, so the entry survives the removal of `foo`.
     let original = "overrides: { foo: link:../foo, bar: { nested: value } }\n";
     let out = run_remove_overrides(Some(original), &["foo"]).expect("file kept");
-    assert_eq!(out, original);
+    assert_eq!(out, "overrides: { bar: { nested: value } }\n");
 }
 
 // --- generic top-level field set/delete (pnpm config set / delete) ---
@@ -1313,15 +1357,20 @@ mod remove_unused_catalogs {
         );
     }
 
-    /// A flow-style `catalogs:` mapping exposes no line entries for the
-    /// partial named-catalog drop, so it is left untouched — the same
-    /// conservative stance the entry-level removals take.
     #[test]
-    fn leaves_a_flow_style_catalogs_mapping_untouched() {
+    fn prunes_a_flow_style_catalogs_mapping() {
         let consumer = project(serde_json::json!({ "dependencies": { "def": "catalog:bar" } }));
         let original = "catalogs: { foo: { abc: 0.1.2 }, bar: { def: 3.2.1 } }\n";
         let out = run_cleanup(Some(original), None, &[&consumer]);
-        assert_eq!(out.as_deref(), Some(original));
+        assert_eq!(out.as_deref(), Some("catalogs: { bar: { def: 3.2.1 } }\n"));
+    }
+
+    #[test]
+    fn prunes_the_entries_of_a_flow_style_named_catalog() {
+        let consumer = project(serde_json::json!({ "dependencies": { "abc": "catalog:foo" } }));
+        let original = "catalogs: { foo: { abc: 0.1.2, ghi: 7.8.9 } }\n";
+        let out = run_cleanup(Some(original), None, &[&consumer]);
+        assert_eq!(out.as_deref(), Some("catalogs: { foo: { abc: 0.1.2 } }\n"));
     }
 
     /// TS: `keep catalogs referenced only in workspace overrides`.
@@ -1625,4 +1674,171 @@ fn prune_allow_builds_prunes_an_escaped_quoted_key() {
     let original = "allowBuilds:\n  \"\\u0066oo\": set this to true or false\n  bar: true\n";
     let out = run_prune_allow_builds(Some(original), &[]);
     assert_eq!(out.as_deref(), Some("allowBuilds:\n  bar: true\n"));
+}
+
+/// Every writer edits a hand-written single-line flow collection in place,
+/// matching what the TypeScript writer's yaml library emits, and refuses a
+/// multi-line one rather than dropping the comments between its entries.
+mod flow_style {
+    use super::*;
+
+    #[test]
+    fn catalog_entry_is_added_to_a_flow_mapping() {
+        let out = run(
+            Some("catalog: { foo: ^1.0.0 }\n"),
+            &catalogs(&[("default", &[("bar", "^2.0.0")])]),
+        );
+        assert_eq!(out.as_deref(), Some("catalog: { bar: ^2.0.0, foo: ^1.0.0 }\n"));
+    }
+
+    #[test]
+    fn catalog_entry_is_updated_in_a_flow_mapping() {
+        let out = run(
+            Some("catalog: { foo: ^1.0.0 } # pins\n"),
+            &catalogs(&[("default", &[("foo", "^2.0.0")])]),
+        );
+        assert_eq!(out.as_deref(), Some("catalog: { foo: ^2.0.0 } # pins\n"));
+    }
+
+    #[test]
+    fn named_catalog_entry_is_added_to_a_nested_flow_mapping() {
+        let out = run(
+            Some("catalogs: { mycat: { foo: ^1.0.0 } }\n"),
+            &catalogs(&[("mycat", &[("bar", "^2.0.0")])]),
+        );
+        assert_eq!(out.as_deref(), Some("catalogs: { mycat: { bar: ^2.0.0, foo: ^1.0.0 } }\n"));
+    }
+
+    #[test]
+    fn a_new_named_catalog_is_added_to_a_flow_catalogs_mapping() {
+        let out = run(
+            Some("catalogs: { mycat: { foo: ^1.0.0 } }\n"),
+            &catalogs(&[("newcat", &[("bar", "^2.0.0")])]),
+        );
+        assert_eq!(
+            out.as_deref(),
+            Some("catalogs: { mycat: { foo: ^1.0.0 }, newcat: { bar: ^2.0.0 } }\n"),
+        );
+    }
+
+    #[test]
+    fn config_dependency_is_added_to_a_flow_mapping() {
+        let out = run_config_dep(Some("configDependencies: { foo: 1.0.0 }\n"), "bar", "2.0.0");
+        assert_eq!(out, "configDependencies: { bar: 2.0.0, foo: 1.0.0 }\n");
+    }
+
+    #[test]
+    fn allow_build_is_added_to_a_flow_mapping() {
+        let out = run_allow_builds(Some("allowBuilds: { foo: true }\n"), &[("bar", false)]);
+        assert_eq!(out.as_deref(), Some("allowBuilds: { bar: false, foo: true }\n"));
+    }
+
+    #[test]
+    fn allow_build_is_updated_in_a_flow_mapping() {
+        let out = run_allow_builds(Some("allowBuilds: { foo: true }\n"), &[("foo", false)]);
+        assert_eq!(out.as_deref(), Some("allowBuilds: { foo: false }\n"));
+    }
+
+    #[test]
+    fn undecided_allow_build_is_added_to_a_flow_mapping() {
+        let out = run_scaffold_allow_builds(Some("allowBuilds: { foo: true }\n"), &["bar"]);
+        assert_eq!(
+            out.as_deref(),
+            Some("allowBuilds: { bar: set this to true or false, foo: true }\n"),
+        );
+    }
+
+    #[test]
+    fn undecided_allow_build_leaves_a_decided_flow_entry_alone() {
+        let original = "allowBuilds: { foo: true }\n";
+        let out = run_scaffold_allow_builds(Some(original), &["foo"]);
+        assert_eq!(out.as_deref(), Some(original));
+    }
+
+    #[test]
+    fn patched_dependency_is_added_to_a_flow_mapping() {
+        let out = run_patched_deps(
+            Some("patchedDependencies: { foo: patches/foo.patch }\n"),
+            &[("foo", "patches/foo.patch"), ("bar", "patches/bar.patch")],
+        );
+        assert_eq!(
+            out,
+            "patchedDependencies: { bar: patches/bar.patch, foo: patches/foo.patch }\n",
+        );
+    }
+
+    #[test]
+    fn omitted_patched_dependency_is_dropped_from_a_flow_mapping() {
+        let out = run_patched_deps(
+            Some("patchedDependencies: { foo: patches/foo.patch, bar: patches/bar.patch }\n"),
+            &[("bar", "patches/bar.patch")],
+        );
+        assert_eq!(out, "patchedDependencies: { bar: patches/bar.patch }\n");
+    }
+
+    #[test]
+    fn minimum_release_age_excludes_stay_a_flow_sequence() {
+        let out = run_age_excludes(
+            Some("minimumReleaseAgeExclude: [foo@1.0.0]\n"),
+            &["foo@1.0.0", "bar@2.0.0"],
+        );
+        assert_eq!(out.as_deref(), Some("minimumReleaseAgeExclude: [ foo@1.0.0, bar@2.0.0 ]\n"));
+    }
+
+    #[test]
+    fn ignore_ghsas_stay_a_flow_sequence_under_a_block_audit_config() {
+        let out = run_ignore_ghsas(
+            Some("auditConfig:\n  ignoreGhsas: [GHSA-aaaa-bbbb-cccc, GHSA-dddd-eeee-ffff]\n"),
+            &["GHSA-gggg-hhhh-iiii"],
+        );
+        assert_eq!(out.as_deref(), Some("auditConfig:\n  ignoreGhsas: [ GHSA-gggg-hhhh-iiii ]\n"));
+    }
+
+    #[test]
+    fn ignore_ghsas_are_added_to_a_flow_audit_config() {
+        let out = run_ignore_ghsas(
+            Some("auditConfig: { cleanupUnusedIgnoredGhsas: true }\n"),
+            &["GHSA-aaaa-bbbb-cccc"],
+        );
+        assert_eq!(
+            out.as_deref(),
+            Some(
+                "auditConfig: { cleanupUnusedIgnoredGhsas: true, ignoreGhsas: [ GHSA-aaaa-bbbb-cccc ] }\n"
+            ),
+        );
+    }
+
+    #[test]
+    fn a_multiline_flow_mapping_is_refused_rather_than_flattened() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join(WORKSPACE_MANIFEST_FILENAME);
+        let original = "allowBuilds: {\n  foo: true, # decided\n}\n";
+        fs::write(&path, original).expect("seed manifest");
+
+        let err = crate::set_allow_builds(dir.path(), [("bar", true)])
+            .expect_err("must refuse a multi-line inline allowBuilds block");
+
+        assert!(matches!(err, crate::UpdateWorkspaceManifestError::UnsupportedInlineBlock { .. }));
+        assert_eq!(fs::read_to_string(&path).expect("read manifest"), original);
+    }
+
+    #[test]
+    fn an_aliased_block_is_refused_rather_than_corrupted() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join(WORKSPACE_MANIFEST_FILENAME);
+        let original = "catalog: &pins { foo: ^1.0.0 }\ncatalogs: { other: *pins }\n";
+        fs::write(&path, original).expect("seed manifest");
+
+        let err = update_workspace_manifest(
+            dir.path(),
+            &UpdateWorkspaceManifestOptions {
+                updated_catalogs: Some(&catalogs(&[("other", &[("bar", "^2.0.0")])])),
+                ..Default::default()
+            },
+        )
+        .expect_err("must refuse an aliased catalog block");
+
+        assert!(matches!(err, crate::UpdateWorkspaceManifestError::UnsupportedInlineBlock { .. }));
+        assert_eq!(fs::read_to_string(&path).expect("read manifest"), original);
+    }
 }

--- a/pnpm/crates/workspace-manifest-writer/src/tests.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/tests.rs
@@ -1819,6 +1819,23 @@ mod flow_style {
     }
 
     #[test]
+    fn a_whole_document_flow_mapping_is_refused_rather_than_corrupted() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join(WORKSPACE_MANIFEST_FILENAME);
+        // The keys of a document written as one flow mapping are not
+        // top-level lines, so no splice — nor a new top-level block — can
+        // address them.
+        let original = "{ overrides: { foo: 1.0.0 } }\n";
+        fs::write(&path, original).expect("seed manifest");
+
+        let err = crate::set_overrides(dir.path(), [("bar", "2.0.0")])
+            .expect_err("must refuse a whole-document flow mapping");
+
+        assert!(matches!(err, crate::UpdateWorkspaceManifestError::UnsupportedInlineBlock { .. }));
+        assert_eq!(fs::read_to_string(&path).expect("read manifest"), original);
+    }
+
+    #[test]
     fn an_aliased_block_is_refused_rather_than_corrupted() {
         let dir = TempDir::new().expect("temp dir");
         let path = dir.path().join(WORKSPACE_MANIFEST_FILENAME);

--- a/pnpm11/workspace/workspace-manifest-writer/test/flowStyle.test.ts
+++ b/pnpm11/workspace/workspace-manifest-writer/test/flowStyle.test.ts
@@ -129,3 +129,12 @@ test('a flow mapping emptied by an edit drops the whole block', async () => {
   })
   expect(out).toBe('packages:\n  - pkg\n')
 })
+
+// A multi-line flow collection is the one shape the Rust writer refuses to
+// edit entry by entry, but dropping the whole block agrees in both.
+test('a multi-line flow mapping is dropped whole when it empties', async () => {
+  const out = await editManifest("packages:\n  - '*'\noverrides: {\n  foo: link:../foo, # pinned\n}\n", {
+    updatedFields: { overrides: undefined },
+  })
+  expect(out).toBe("packages:\n  - '*'\n")
+})

--- a/pnpm11/workspace/workspace-manifest-writer/test/flowStyle.test.ts
+++ b/pnpm11/workspace/workspace-manifest-writer/test/flowStyle.test.ts
@@ -35,17 +35,17 @@ test('a catalog entry is updated in a flow mapping, keeping its trailing comment
 })
 
 test('a named catalog entry is added to a nested flow mapping', async () => {
-  const out = await editManifest('catalogs: { mycat: { foo: ^1.0.0 } }\n', {
-    updatedCatalogs: { mycat: { bar: '^2.0.0' } },
+  const out = await editManifest('catalogs: { myCatalog: { foo: ^1.0.0 } }\n', {
+    updatedCatalogs: { myCatalog: { bar: '^2.0.0' } },
   })
-  expect(out).toBe('catalogs: { mycat: { bar: ^2.0.0, foo: ^1.0.0 } }\n')
+  expect(out).toBe('catalogs: { myCatalog: { bar: ^2.0.0, foo: ^1.0.0 } }\n')
 })
 
 test('a new named catalog is added to a flow catalogs mapping', async () => {
-  const out = await editManifest('catalogs: { mycat: { foo: ^1.0.0 } }\n', {
-    updatedCatalogs: { newcat: { bar: '^2.0.0' } },
+  const out = await editManifest('catalogs: { myCatalog: { foo: ^1.0.0 } }\n', {
+    updatedCatalogs: { newCatalog: { bar: '^2.0.0' } },
   })
-  expect(out).toBe('catalogs: { mycat: { foo: ^1.0.0 }, newcat: { bar: ^2.0.0 } }\n')
+  expect(out).toBe('catalogs: { myCatalog: { foo: ^1.0.0 }, newCatalog: { bar: ^2.0.0 } }\n')
 })
 
 test('a config dependency is added to a flow mapping', async () => {

--- a/pnpm11/workspace/workspace-manifest-writer/test/flowStyle.test.ts
+++ b/pnpm11/workspace/workspace-manifest-writer/test/flowStyle.test.ts
@@ -3,7 +3,9 @@ import path from 'node:path'
 
 import { expect, test } from '@jest/globals'
 import { WORKSPACE_MANIFEST_FILENAME } from '@pnpm/constants'
+import { prepare } from '@pnpm/prepare'
 import { tempDir } from '@pnpm/prepare-temp-dir'
+import { findPackages } from '@pnpm/workspace.projects-reader'
 import { updateWorkspaceManifest } from '@pnpm/workspace.workspace-manifest-writer'
 
 // The Rust CLI's workspace-manifest-writer edits single-line flow
@@ -96,26 +98,27 @@ test('ignoreGhsas stays a flow sequence under a block auditConfig', async () => 
 })
 
 test('ignoreGhsas is added to a flow auditConfig', async () => {
-  const out = await editManifest('auditConfig: { cleanupUnusedIgnoredGhsas: true }\n', {
-    updatedFields: { auditConfig: { cleanupUnusedIgnoredGhsas: true, ignoreGhsas: ['GHSA-aaaa-bbbb-cccc'] } },
+  const out = await editManifest('auditConfig: {}\n', {
+    updatedFields: { auditConfig: { ignoreGhsas: ['GHSA-aaaa-bbbb-cccc'] } },
   })
-  expect(out).toBe('auditConfig: { cleanupUnusedIgnoredGhsas: true, ignoreGhsas: [ GHSA-aaaa-bbbb-cccc ] }\n')
+  expect(out).toBe('auditConfig: { ignoreGhsas: [ GHSA-aaaa-bbbb-cccc ] }\n')
 })
 
 test('the entries of a flow named catalog are pruned in place', async () => {
   const dir = tempDir(false)
   const filePath = path.join(dir, WORKSPACE_MANIFEST_FILENAME)
+  prepare({ dependencies: { abc: 'catalog:foo' } }, { tempDir: dir })
   fs.writeFileSync(filePath, 'catalogs: { foo: { abc: 0.1.2, ghi: 7.8.9 } }\n')
   await updateWorkspaceManifest(dir, {
     catalogPrune: true,
-    allProjects: [{ rootDir: dir as never, manifest: { name: 'x', dependencies: { abc: 'catalog:foo' } } }],
+    allProjects: await findPackages(dir),
   })
   expect(fs.readFileSync(filePath, 'utf8')).toBe('catalogs: { foo: { abc: 0.1.2 } }\n')
 })
 
-test('an entry removed from a flow mapping leaves the entries it cannot decode alone', async () => {
+test('an entry removed from a flow mapping leaves a parent-scoped override alone', async () => {
   const out = await editManifest('overrides: { foo: link:../foo, bar: { nested: value } }\n', {
-    updatedFields: { overrides: { bar: { nested: 'value' } } as never },
+    updatedFields: { overrides: { bar: { nested: 'value' } } as unknown as Record<string, string> },
   })
   expect(out).toBe('overrides: { bar: { nested: value } }\n')
 })

--- a/pnpm11/workspace/workspace-manifest-writer/test/flowStyle.test.ts
+++ b/pnpm11/workspace/workspace-manifest-writer/test/flowStyle.test.ts
@@ -1,0 +1,128 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { expect, test } from '@jest/globals'
+import { WORKSPACE_MANIFEST_FILENAME } from '@pnpm/constants'
+import { tempDir } from '@pnpm/prepare-temp-dir'
+import { updateWorkspaceManifest } from '@pnpm/workspace.workspace-manifest-writer'
+
+// The Rust CLI's workspace-manifest-writer edits single-line flow
+// collections with a text splice rather than a document round-trip, so these
+// expectations are the parity contract between the two writers. Its matching
+// suite is `flow_style` in pnpm/crates/workspace-manifest-writer/src/tests.rs.
+async function editManifest (original: string, opts: Parameters<typeof updateWorkspaceManifest>[1]): Promise<string> {
+  const dir = tempDir(false)
+  const filePath = path.join(dir, WORKSPACE_MANIFEST_FILENAME)
+  fs.writeFileSync(filePath, original)
+  await updateWorkspaceManifest(dir, opts)
+  return fs.readFileSync(filePath, 'utf8')
+}
+
+test('a catalog entry is added to a flow mapping', async () => {
+  const out = await editManifest('catalog: { foo: ^1.0.0 }\n', {
+    updatedCatalogs: { default: { bar: '^2.0.0' } },
+  })
+  expect(out).toBe('catalog: { bar: ^2.0.0, foo: ^1.0.0 }\n')
+})
+
+test('a catalog entry is updated in a flow mapping, keeping its trailing comment', async () => {
+  const out = await editManifest('catalog: { foo: ^1.0.0 } # pins\n', {
+    updatedCatalogs: { default: { foo: '^2.0.0' } },
+  })
+  expect(out).toBe('catalog: { foo: ^2.0.0 } # pins\n')
+})
+
+test('a named catalog entry is added to a nested flow mapping', async () => {
+  const out = await editManifest('catalogs: { mycat: { foo: ^1.0.0 } }\n', {
+    updatedCatalogs: { mycat: { bar: '^2.0.0' } },
+  })
+  expect(out).toBe('catalogs: { mycat: { bar: ^2.0.0, foo: ^1.0.0 } }\n')
+})
+
+test('a new named catalog is added to a flow catalogs mapping', async () => {
+  const out = await editManifest('catalogs: { mycat: { foo: ^1.0.0 } }\n', {
+    updatedCatalogs: { newcat: { bar: '^2.0.0' } },
+  })
+  expect(out).toBe('catalogs: { mycat: { foo: ^1.0.0 }, newcat: { bar: ^2.0.0 } }\n')
+})
+
+test('a config dependency is added to a flow mapping', async () => {
+  const out = await editManifest('configDependencies: { foo: 1.0.0 }\n', {
+    updatedFields: { configDependencies: { foo: '1.0.0', bar: '2.0.0' } },
+  })
+  expect(out).toBe('configDependencies: { bar: 2.0.0, foo: 1.0.0 }\n')
+})
+
+test('an allowBuilds entry is added to a flow mapping', async () => {
+  const out = await editManifest('allowBuilds: { foo: true }\n', {
+    updatedFields: { allowBuilds: { foo: true, bar: false } },
+  })
+  expect(out).toBe('allowBuilds: { bar: false, foo: true }\n')
+})
+
+test('an allowBuilds entry is updated in a flow mapping', async () => {
+  const out = await editManifest('allowBuilds: { foo: true }\n', {
+    updatedFields: { allowBuilds: { foo: false } },
+  })
+  expect(out).toBe('allowBuilds: { foo: false }\n')
+})
+
+test('a patched dependency is added to a flow mapping', async () => {
+  const out = await editManifest('patchedDependencies: { foo: patches/foo.patch }\n', {
+    updatedFields: { patchedDependencies: { foo: 'patches/foo.patch', bar: 'patches/bar.patch' } },
+  })
+  expect(out).toBe('patchedDependencies: { bar: patches/bar.patch, foo: patches/foo.patch }\n')
+})
+
+test('an omitted patched dependency is dropped from a flow mapping', async () => {
+  const out = await editManifest('patchedDependencies: { foo: patches/foo.patch, bar: patches/bar.patch }\n', {
+    updatedFields: { patchedDependencies: { bar: 'patches/bar.patch' } },
+  })
+  expect(out).toBe('patchedDependencies: { bar: patches/bar.patch }\n')
+})
+
+test('minimumReleaseAgeExclude stays a flow sequence', async () => {
+  const out = await editManifest('minimumReleaseAgeExclude: [foo@1.0.0]\n', {
+    addedMinimumReleaseAgeExcludes: ['bar@2.0.0'],
+  })
+  expect(out).toBe('minimumReleaseAgeExclude: [ foo@1.0.0, bar@2.0.0 ]\n')
+})
+
+test('ignoreGhsas stays a flow sequence under a block auditConfig', async () => {
+  const out = await editManifest('auditConfig:\n  ignoreGhsas: [GHSA-aaaa-bbbb-cccc, GHSA-dddd-eeee-ffff]\n', {
+    updatedFields: { auditConfig: { ignoreGhsas: ['GHSA-gggg-hhhh-iiii'] } },
+  })
+  expect(out).toBe('auditConfig:\n  ignoreGhsas: [ GHSA-gggg-hhhh-iiii ]\n')
+})
+
+test('ignoreGhsas is added to a flow auditConfig', async () => {
+  const out = await editManifest('auditConfig: { cleanupUnusedIgnoredGhsas: true }\n', {
+    updatedFields: { auditConfig: { cleanupUnusedIgnoredGhsas: true, ignoreGhsas: ['GHSA-aaaa-bbbb-cccc'] } },
+  })
+  expect(out).toBe('auditConfig: { cleanupUnusedIgnoredGhsas: true, ignoreGhsas: [ GHSA-aaaa-bbbb-cccc ] }\n')
+})
+
+test('the entries of a flow named catalog are pruned in place', async () => {
+  const dir = tempDir(false)
+  const filePath = path.join(dir, WORKSPACE_MANIFEST_FILENAME)
+  fs.writeFileSync(filePath, 'catalogs: { foo: { abc: 0.1.2, ghi: 7.8.9 } }\n')
+  await updateWorkspaceManifest(dir, {
+    catalogPrune: true,
+    allProjects: [{ rootDir: dir as never, manifest: { name: 'x', dependencies: { abc: 'catalog:foo' } } }],
+  })
+  expect(fs.readFileSync(filePath, 'utf8')).toBe('catalogs: { foo: { abc: 0.1.2 } }\n')
+})
+
+test('an entry removed from a flow mapping leaves the entries it cannot decode alone', async () => {
+  const out = await editManifest('overrides: { foo: link:../foo, bar: { nested: value } }\n', {
+    updatedFields: { overrides: { bar: { nested: 'value' } } as never },
+  })
+  expect(out).toBe('overrides: { bar: { nested: value } }\n')
+})
+
+test('a flow mapping emptied by an edit drops the whole block', async () => {
+  const out = await editManifest('packages:\n  - pkg\noverrides: { foo: link:../foo }\n', {
+    updatedFields: { overrides: undefined },
+  })
+  expect(out).toBe('packages:\n  - pkg\n')
+})


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Closes pnpm/pnpm#14108.

The issue reports that the two stacks disagree on writing to a flow-style
block in `pnpm-workspace.yaml`: the TypeScript writer edits it in place, the
Rust one refuses. Probing the Rust writer while scoping the fix turned up
something worse than the refusal — only `overrides:` and `auditConfig:` had
the inline guard. Every other block spliced a block-style line in after the
inline value and left an **unparsable document** behind:

```yaml
# before: catalog: { foo: ^1.0.0 }   +  `pnpm add --save-catalog bar`
catalog: { foo: ^1.0.0 }
  bar: ^2.0.0
```

Same for `configDependencies`, `allowBuilds`, and `patchedDependencies`.

The direction taken is the one the issue lists first: **pacquet learns to
edit flow-style nodes in place, matching TS.** The TypeScript writer keeps
today's behavior (refusing there would break `audit --fix`, `link`, and
catalog writes for anyone whose manifest uses flow style, and it already
handles the case well — flow style, entry quoting, and trailing comments all
survive).

pacquet side (`pnpm/crates/workspace-manifest-writer`):

- New `flow` module: parses a single-line flow collection into entry spans
  and rebuilds it with one entry upserted, replaced, or dropped. Untouched
  entries keep their exact text, and everything outside the brackets stays
  verbatim.
- `edit.rs` classifies each key path as block / editable-flow / unsupported,
  and the entry splices, the removal splices, the catalog, `allowBuilds`,
  `patchedDependencies` and `configDependencies` writers, and the
  `catalogPrune` / `allowBuilds` cleanup passes all route through it.
- Rendering matches what the `yaml` library emits (`{ a: 1, b: 2 }`,
  `[ a, b ]`), including where a new key sorts in, so both stacks now write
  the same bytes for the same edit.
- `ERR_PNPM_WORKSPACE_MANIFEST_WRITER_UNSUPPORTED_INLINE_BLOCK` now guards
  *every* writer instead of two, and fires only for shapes a splice really
  cannot edit: a multi-line flow collection (whose interleaved comments a
  one-line rebuild would drop), an alias, or a scalar where a collection
  belongs. Removing a block never triggers it, so `patchedDependencies: null`
  still clears cleanly.

Every expectation in the new `flow_style` suite was taken from running the
TypeScript writer on the same input; the mirrored suite lives in
`pnpm11/workspace/workspace-manifest-writer/test/flowStyle.test.ts` so the
two stay pinned together.

Known remaining divergences, all in shapes pacquet now refuses with an
actionable error rather than corrupting: TS reformats a **multi-line** flow
collection (re-indenting the whole block), resolves **aliases** by unwrapping
them into the value, and edits a manifest written as one **whole-document
flow mapping** (`{ overrides: { foo: 1.0.0 } }`) in place. Matching the first
would mean reproducing the yaml emitter's flow-wrapping algorithm; the other
two are exotic enough that a clear error beats the machinery. All three
corrupted the file before this PR.

Note for pnpm/pnpm#11384: its
`audit_fix_cleanup_reports_the_write_error_for_an_inline_audit_config` asserts
the old refusal for a flow `auditConfig`. Once this lands, that test should
assert the successful in-place edit instead — and the TS mirror CodeRabbit
asked for there becomes writable.

## Squash Commit Body

```text
The workspace-manifest writer's splices are line-oriented, so a block a user
wrote inline — `catalog: { foo: ^1.0.0 }`, `overrides: { foo: 1.0.0 }`,
`minimumReleaseAgeExclude: [foo@1.0.0]` — had no entry lines to splice.
`overrides:` and `auditConfig:` refused the write; every other block spliced a
block-style line in after the inline value and left an unparsable document
behind.

The TypeScript writer round-trips the document through the yaml library and
edits such a block in place, keeping its flow style, its other entries and
their quoting, and any trailing comment. pacquet now does the same: a new
`flow` module parses a single-line flow collection into entry spans and
rebuilds it with one entry upserted, replaced, or dropped, and the entry
splices, the removal splices, the catalog/allowBuilds/patchedDependencies
writers, and the cleanup passes all route through it. The rendering matches
what the yaml library emits (`{ a: 1, b: 2 }`, `[ a, b ]`), so both stacks
produce the same bytes for the same edit — pinned by the new `flow_style`
suite and its mirror in
pnpm11/workspace/workspace-manifest-writer/test/flowStyle.test.ts.

A flow collection spanning several lines can carry comments between its
entries that a one-line rebuild would drop, so those — along with aliases and
scalars standing where a collection belongs — are still refused with
ERR_PNPM_WORKSPACE_MANIFEST_WRITER_UNSUPPORTED_INLINE_BLOCK, now on every
writer rather than only two.

Closes pnpm/pnpm#14108
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (TypeScript already behaved this way; it gains the mirrored tests that pin
  the contract.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5[1m]).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790087265&installation_model_id=426870&pr_number=14112&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14112&signature=6fdecdfd4c15e81054ef4864b034d02953a8d44a79d40112ac184525c2e06603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for editing single-line flow-style YAML mappings and sequences in workspace manifests.
  - Updates preserve existing entries, comments, quoting, and formatting.
  - Supported settings include catalogs, overrides, configuration dependencies, build permissions, patches, and audit rules.

- **Bug Fixes**
  - Unsupported or ambiguous inline YAML values are now left unchanged with clearer errors.

- **Tests**
  - Added comprehensive coverage for flow-style manifest updates, removals, pruning, and unsupported formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
