### PR TITLE
fix: stop pointing users at Corepack for pnpm updates

### DIFF
--- a/.changeset/tidy-pianos-tap.md
+++ b/.changeset/tidy-pianos-tap.md
@@ -1,0 +1,12 @@
+---
+"@pnpm/engine.pm.commands": patch
+"@pnpm/cli.default-reporter": patch
+"@pnpm/cli.meta": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+pnpm no longer tells you to update itself with Corepack or with `pnpm add -g`:
+
+* The update notification now suggests `pnpm self-update`, or the [standalone install script](https://pnpm.io/installation) when pnpm is running under Corepack. It used to suggest `corepack use pnpm@<version>`, or `pnpm add -g pnpm` when pnpm was not installed by the standalone script — but `pnpm add -g` refuses to install pnpm and points at `pnpm self-update` anyway.
+* `pnpm self-update` under Corepack now points at the standalone install script too, instead of telling you to update pnpm with Corepack.

--- a/.changeset/tidy-pianos-tap.md
+++ b/.changeset/tidy-pianos-tap.md
@@ -1,12 +1,9 @@
 ---
 "@pnpm/engine.pm.commands": patch
 "@pnpm/cli.default-reporter": patch
-"@pnpm/cli.meta": patch
+"@pnpm/cli.meta": minor
 "pnpm": patch
 "pacquet": patch
 ---
 
-pnpm no longer tells you to update itself with Corepack or with `pnpm add -g`:
-
-* The update notification now suggests `pnpm self-update`, or the [standalone install script](https://pnpm.io/installation) when pnpm is running under Corepack. It used to suggest `corepack use pnpm@<version>`, or `pnpm add -g pnpm` when pnpm was not installed by the standalone script — but `pnpm add -g` refuses to install pnpm and points at `pnpm self-update` anyway.
-* `pnpm self-update` under Corepack now points at the standalone install script too, instead of telling you to update pnpm with Corepack.
+The update notification now suggests `pnpm self-update` when `PNPM_HOME` manages the pnpm in use, and the [standalone install script](https://pnpm.io/installation) otherwise — under Corepack, or when another package manager installed pnpm. `pnpm self-update` under Corepack names the standalone install script too.

--- a/pnpm/crates/cli/src/cli_args/self_update.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update.rs
@@ -17,6 +17,7 @@ use derive_more::{Display, Error};
 use miette::{Context, Diagnostic, IntoDiagnostic};
 use pnpm_cmd_shim::{Host as CmdShimHost, LinkBinsOptions, link_bins_of_packages_with_excludes};
 use pnpm_config::{Config, PNPM_VERSION};
+use pnpm_default_reporter::state::standalone_install_command;
 use pnpm_env_installer::pnpm_engine_packages;
 use pnpm_fs::force_symlink_dir;
 use pnpm_global::{
@@ -49,9 +50,12 @@ fn major_upgrade_hint(target_major: u64) -> Option<&'static str> {
 /// `ERR_PNPM_PNPM_...`.
 #[derive(Debug, Display, Error, Diagnostic)]
 pub(crate) enum SelfUpdateError {
-    #[display("You should update pnpm with corepack")]
-    #[diagnostic(code(ERR_PNPM_CANT_SELF_UPDATE_IN_COREPACK))]
-    CantSelfUpdateInCorepack,
+    #[display("pnpm cannot update itself when it is executed by Corepack")]
+    #[diagnostic(
+        code(ERR_PNPM_CANT_SELF_UPDATE_IN_COREPACK),
+        help("Install pnpm with the standalone script instead: {install_command}")
+    )]
+    CantSelfUpdateInCorepack { install_command: &'static str },
 
     #[display(r#"Cannot find "{specifier}" version of pnpm"#)]
     #[diagnostic(code(ERR_PNPM_CANNOT_RESOLVE_PNPM))]
@@ -170,7 +174,10 @@ fn enforce_resolution_policy(
 /// `.npmrc` / workspace config can't mask the corepack refusal.
 pub(crate) fn reject_if_corepack() -> miette::Result<()> {
     if is_executed_by_corepack() {
-        return Err(SelfUpdateError::CantSelfUpdateInCorepack.into());
+        return Err(SelfUpdateError::CantSelfUpdateInCorepack {
+            install_command: standalone_install_command(),
+        }
+        .into());
     }
     Ok(())
 }

--- a/pnpm/crates/cli/src/cli_args/self_update.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update.rs
@@ -16,8 +16,7 @@ use clap::Args;
 use derive_more::{Display, Error};
 use miette::{Context, Diagnostic, IntoDiagnostic};
 use pnpm_cmd_shim::{Host as CmdShimHost, LinkBinsOptions, link_bins_of_packages_with_excludes};
-use pnpm_config::{Config, PNPM_VERSION};
-use pnpm_default_reporter::state::standalone_install_command;
+use pnpm_config::{Config, PNPM_VERSION, standalone_install_command};
 use pnpm_env_installer::pnpm_engine_packages;
 use pnpm_fs::force_symlink_dir;
 use pnpm_global::{

--- a/pnpm/crates/config/src/defaults.rs
+++ b/pnpm/crates/config/src/defaults.rs
@@ -329,6 +329,26 @@ pub fn default_fetch_retry_maxtimeout() -> u64 {
 /// the release workflow verifies the two match before building.
 pub const PNPM_VERSION: &str = "12.0.0-rc.8";
 
+/// The command that installs pnpm with the standalone script, as documented
+/// at <https://pnpm.io/installation>: the PowerShell form on Windows, the
+/// `curl`-into-`sh` form everywhere else. Both the update notification and
+/// `self-update` name it, so it is defined once here.
+#[must_use]
+pub fn standalone_install_command() -> &'static str {
+    install_command_for(cfg!(windows))
+}
+
+/// [`standalone_install_command`] with the host check as an argument, so both
+/// commands are reachable from a test on either platform.
+#[must_use]
+pub fn install_command_for(windows: bool) -> &'static str {
+    if windows {
+        "Invoke-WebRequest https://get.pnpm.io/install.ps1 -UseBasicParsing | Invoke-Expression"
+    } else {
+        "curl -fsSL https://get.pnpm.io/install.sh | sh -"
+    }
+}
+
 pub fn default_fetch_timeout() -> u64 {
     pnpm_network::DEFAULT_FETCH_TIMEOUT_MS
 }

--- a/pnpm/crates/config/src/defaults/tests.rs
+++ b/pnpm/crates/config/src/defaults/tests.rs
@@ -2,8 +2,8 @@ use super::{
     PNPM_VERSION, default_cache_dir, default_child_concurrency,
     default_child_concurrency_with_parallelism, default_config_dir, default_fetch_timeout,
     default_store_dir, default_unsafe_perm, default_user_agent, default_workspace_concurrency,
-    is_unsafe_perm_posix, resolve_child_concurrency, resolve_child_concurrency_with_parallelism,
-    resolve_configured_state_dir,
+    install_command_for, is_unsafe_perm_posix, resolve_child_concurrency,
+    resolve_child_concurrency_with_parallelism, resolve_configured_state_dir,
 };
 use crate::api::{EnvVar, GetCurrentDir, GetHomeDir};
 use pnpm_store_dir::{STORE_VERSION, StoreDir};
@@ -401,4 +401,16 @@ fn user_agent_default_matches_pnpm_format() {
     let tail: Vec<&str> = ua[prefix.len()..].split(' ').collect();
     assert_eq!(tail.len(), 2, "expected `<platform> <arch>` tail, got {ua:?}");
     assert!(tail.iter().all(|token| !token.is_empty()), "platform/arch must be non-empty: {ua:?}");
+}
+
+/// Both forms are asserted here rather than through
+/// `standalone_install_command`, whose branch a single-platform test run
+/// cannot cover.
+#[test]
+fn the_install_command_matches_the_host_shell() {
+    assert_eq!(
+        install_command_for(true),
+        "Invoke-WebRequest https://get.pnpm.io/install.ps1 -UseBasicParsing | Invoke-Expression"
+    );
+    assert_eq!(install_command_for(false), "curl -fsSL https://get.pnpm.io/install.sh | sh -");
 }

--- a/pnpm/crates/config/src/defaults/tests.rs
+++ b/pnpm/crates/config/src/defaults/tests.rs
@@ -410,7 +410,7 @@ fn user_agent_default_matches_pnpm_format() {
 fn the_install_command_matches_the_host_shell() {
     assert_eq!(
         install_command_for(true),
-        "Invoke-WebRequest https://get.pnpm.io/install.ps1 -UseBasicParsing | Invoke-Expression"
+        "Invoke-WebRequest https://get.pnpm.io/install.ps1 -UseBasicParsing | Invoke-Expression",
     );
     assert_eq!(install_command_for(false), "curl -fsSL https://get.pnpm.io/install.sh | sh -");
 }

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -47,7 +47,8 @@ pub use crate::defaults::{
     available_parallelism, default_cache_dir, default_config_dir, default_git_shallow_hosts,
     default_peers_suffix_max_length, default_pnpm_home_dir, default_registry, default_state_dir,
     default_unsafe_perm, default_virtual_store_dir_max_length, default_workspace_concurrency,
-    is_unsafe_perm_posix, resolve_child_concurrency, resolve_configured_state_dir,
+    install_command_for, is_unsafe_perm_posix, resolve_child_concurrency,
+    resolve_configured_state_dir, standalone_install_command,
 };
 use crate::defaults::{
     default_child_concurrency, default_enable_global_virtual_store, default_fetch_min_speed_ki_bps,

--- a/pnpm/crates/default-reporter/src/state.rs
+++ b/pnpm/crates/default-reporter/src/state.rs
@@ -22,6 +22,7 @@ use pnpm_reporter::{
 use serde_json::Value;
 
 use pnpm_config::matcher::{Matcher, create_matcher};
+use pnpm_config::standalone_install_command;
 
 use crate::{
     MaxLogLevel, SummaryScope,
@@ -1584,30 +1585,17 @@ fn detect_install_source() -> PnpmInstallSource {
 
 /// pnpm's `renderUpdateCommand`: the command that updates the pnpm the
 /// user is running.
-///
-/// `pnpm add -g pnpm` is not named here even though pnpm was installed by
-/// another package manager: `pnpm add -g` refuses to install pnpm and points
-/// at `self-update` itself, which works wherever `PNPM_HOME` resolves to.
-/// Corepack is the one case self-update cannot serve, and pnpm points at its
-/// own installer there rather than back at Corepack.
 fn update_command(source: PnpmInstallSource) -> String {
     match source {
-        PnpmInstallSource::Corepack => standalone_install_command().to_string(),
-        PnpmInstallSource::PnpmHome | PnpmInstallSource::Elsewhere => {
-            "pnpm self-update".to_string()
+        PnpmInstallSource::PnpmHome => "pnpm self-update".to_string(),
+        // `self-update` replaces the pnpm that `PNPM_HOME` manages. Corepack
+        // refuses it outright, and an install another package manager owns is
+        // resolved from that manager's bin directory rather than pnpm's home,
+        // so a self-update would land beside the executable in use instead of
+        // replacing it. The installer is the command that updates either one.
+        PnpmInstallSource::Corepack | PnpmInstallSource::Elsewhere => {
+            standalone_install_command().to_string()
         }
-    }
-}
-
-/// The command that installs pnpm with the standalone script, as documented
-/// at <https://pnpm.io/installation>. Shared with `self-update`, which names
-/// it when it refuses to run under Corepack.
-#[must_use]
-pub fn standalone_install_command() -> &'static str {
-    if cfg!(windows) {
-        "Invoke-WebRequest https://get.pnpm.io/install.ps1 -UseBasicParsing | Invoke-Expression"
-    } else {
-        "curl -fsSL https://get.pnpm.io/install.sh | sh -"
     }
 }
 

--- a/pnpm/crates/default-reporter/src/state.rs
+++ b/pnpm/crates/default-reporter/src/state.rs
@@ -1214,9 +1214,7 @@ impl ReporterState {
             latest = self.colors.green(&log.latest_version),
             changelog = self.colors.magenta("Changelog:"),
             version = log.latest_version,
-            command = self
-                .colors
-                .magenta(&update_command(detect_install_source(), &log.latest_version)),
+            command = self.colors.magenta(&update_command(detect_install_source())),
         ));
     }
 
@@ -1587,15 +1585,29 @@ fn detect_install_source() -> PnpmInstallSource {
 /// pnpm's `renderUpdateCommand`: the command that updates the pnpm the
 /// user is running.
 ///
-/// pnpm names `@pnpm/exe` in the last case when it is running as a single
-/// executable. The native binary is published under both `pnpm` and
-/// `@pnpm/exe` and carries no marker telling the two apart, and a global
-/// install of either replaces the other, so it always names `pnpm`.
-fn update_command(source: PnpmInstallSource, latest_version: &str) -> String {
+/// `pnpm add -g pnpm` is not named here even though pnpm was installed by
+/// another package manager: `pnpm add -g` refuses to install pnpm and points
+/// at `self-update` itself, which works wherever `PNPM_HOME` resolves to.
+/// Corepack is the one case self-update cannot serve, and pnpm points at its
+/// own installer there rather than back at Corepack.
+fn update_command(source: PnpmInstallSource) -> String {
     match source {
-        PnpmInstallSource::Corepack => format!("corepack use pnpm@{latest_version}"),
-        PnpmInstallSource::PnpmHome => "pnpm self-update".to_string(),
-        PnpmInstallSource::Elsewhere => "pnpm add -g pnpm".to_string(),
+        PnpmInstallSource::Corepack => standalone_install_command().to_string(),
+        PnpmInstallSource::PnpmHome | PnpmInstallSource::Elsewhere => {
+            "pnpm self-update".to_string()
+        }
+    }
+}
+
+/// The command that installs pnpm with the standalone script, as documented
+/// at <https://pnpm.io/installation>. Shared with `self-update`, which names
+/// it when it refuses to run under Corepack.
+#[must_use]
+pub fn standalone_install_command() -> &'static str {
+    if cfg!(windows) {
+        "Invoke-WebRequest https://get.pnpm.io/install.ps1 -UseBasicParsing | Invoke-Expression"
+    } else {
+        "curl -fsSL https://get.pnpm.io/install.sh | sh -"
     }
 }
 

--- a/pnpm/crates/default-reporter/src/state.rs
+++ b/pnpm/crates/default-reporter/src/state.rs
@@ -21,8 +21,10 @@ use pnpm_reporter::{
 };
 use serde_json::Value;
 
-use pnpm_config::matcher::{Matcher, create_matcher};
-use pnpm_config::standalone_install_command;
+use pnpm_config::{
+    matcher::{Matcher, create_matcher},
+    standalone_install_command,
+};
 
 use crate::{
     MaxLogLevel, SummaryScope,

--- a/pnpm/crates/default-reporter/src/state/tests.rs
+++ b/pnpm/crates/default-reporter/src/state/tests.rs
@@ -32,21 +32,10 @@ fn clamps_a_future_timestamp_to_zero() {
     assert_eq!(cached_verdict(Some("2026-07-25T12:00:05.000Z"), now), "verified 0ms ago");
 }
 
-/// Corepack is the only source `self-update` cannot serve, and it is
-/// pointed at pnpm's own installer rather than back at Corepack.
+/// `self-update` is named only where it can replace the executable in use.
 #[test]
-fn only_corepack_is_told_to_install_pnpm_another_way() {
-    assert_eq!(update_command(PnpmInstallSource::Corepack), standalone_install_command());
+fn only_a_pnpm_home_install_is_told_to_self_update() {
     assert_eq!(update_command(PnpmInstallSource::PnpmHome), "pnpm self-update");
-    assert_eq!(update_command(PnpmInstallSource::Elsewhere), "pnpm self-update");
-}
-
-#[test]
-fn the_standalone_install_command_matches_the_host_shell() {
-    let command = standalone_install_command();
-    if cfg!(windows) {
-        assert!(command.contains("install.ps1"), "command: {command}");
-    } else {
-        assert!(command.contains("install.sh"), "command: {command}");
-    }
+    assert_eq!(update_command(PnpmInstallSource::Corepack), standalone_install_command());
+    assert_eq!(update_command(PnpmInstallSource::Elsewhere), standalone_install_command());
 }

--- a/pnpm/crates/default-reporter/src/state/tests.rs
+++ b/pnpm/crates/default-reporter/src/state/tests.rs
@@ -1,4 +1,4 @@
-use super::{PnpmInstallSource, cached_verdict, update_command};
+use super::{PnpmInstallSource, cached_verdict, standalone_install_command, update_command};
 use chrono::{DateTime, Utc};
 use pretty_assertions::assert_eq;
 
@@ -32,9 +32,21 @@ fn clamps_a_future_timestamp_to_zero() {
     assert_eq!(cached_verdict(Some("2026-07-25T12:00:05.000Z"), now), "verified 0ms ago");
 }
 
+/// Corepack is the only source `self-update` cannot serve, and it is
+/// pointed at pnpm's own installer rather than back at Corepack.
 #[test]
-fn each_way_of_installing_pnpm_gets_its_own_update_command() {
-    assert_eq!(update_command(PnpmInstallSource::Corepack, "12.0.0"), "corepack use pnpm@12.0.0");
-    assert_eq!(update_command(PnpmInstallSource::PnpmHome, "12.0.0"), "pnpm self-update");
-    assert_eq!(update_command(PnpmInstallSource::Elsewhere, "12.0.0"), "pnpm add -g pnpm");
+fn only_corepack_is_told_to_install_pnpm_another_way() {
+    assert_eq!(update_command(PnpmInstallSource::Corepack), standalone_install_command());
+    assert_eq!(update_command(PnpmInstallSource::PnpmHome), "pnpm self-update");
+    assert_eq!(update_command(PnpmInstallSource::Elsewhere), "pnpm self-update");
+}
+
+#[test]
+fn the_standalone_install_command_matches_the_host_shell() {
+    let command = standalone_install_command();
+    if cfg!(windows) {
+        assert!(command.contains("install.ps1"), "command: {command}");
+    } else {
+        assert!(command.contains("install.sh"), "command: {command}");
+    }
 }

--- a/pnpm11/cli/default-reporter/src/reporterForClient/reportUpdateCheck.ts
+++ b/pnpm11/cli/default-reporter/src/reporterForClient/reportUpdateCheck.ts
@@ -1,4 +1,4 @@
-import { detectIfCurrentPkgIsExecutable, isExecutedByCorepack } from '@pnpm/cli.meta'
+import { isExecutedByCorepack, standaloneInstallCommand } from '@pnpm/cli.meta'
 import type { UpdateCheckLog } from '@pnpm/core-loggers'
 import boxen from 'boxen'
 import chalk from 'chalk'
@@ -15,9 +15,8 @@ export function reportUpdateCheck (log$: Rx.Observable<UpdateCheckLog>, opts: {
     filter((log) => semver.gt(log.latestVersion, log.currentVersion)),
     map((log) => {
       const updateMessage = renderUpdateMessage({
-        currentPkgIsExecutable: detectIfCurrentPkgIsExecutable(opts.process),
-        latestVersion: log.latestVersion,
         env: opts.env,
+        platform: opts.process.platform,
       })
       return Rx.of({
         msg: boxen(`\
@@ -38,9 +37,8 @@ ${updateMessage}`,
 }
 
 interface UpdateMessageOptions {
-  currentPkgIsExecutable: boolean
   env: NodeJS.ProcessEnv
-  latestVersion: string
+  platform: NodeJS.Platform
 }
 
 function renderUpdateMessage (opts: UpdateMessageOptions): string {
@@ -49,12 +47,14 @@ function renderUpdateMessage (opts: UpdateMessageOptions): string {
 }
 
 function renderUpdateCommand (opts: UpdateMessageOptions): string {
+  // Under Corepack, `pnpm self-update` refuses to run, and pnpm no longer
+  // points users back at Corepack — it suggests its own installer instead.
   if (isExecutedByCorepack(opts.env)) {
-    return `corepack use pnpm@${opts.latestVersion}`
+    return standaloneInstallCommand(opts.platform)
   }
-  if (opts.env.PNPM_HOME) {
-    return 'pnpm self-update'
-  }
-  const pkgName = opts.currentPkgIsExecutable ? '@pnpm/exe' : 'pnpm'
-  return `pnpm add -g ${pkgName}`
+  // `pnpm add -g pnpm` (or `@pnpm/exe`) is refused by the add command itself,
+  // which points at self-update instead. self-update also picks the package
+  // that can actually deliver a working binary for the wanted version — the
+  // unscoped `pnpm` from v12, where `@pnpm/exe` is no longer published.
+  return 'pnpm self-update'
 }

--- a/pnpm11/cli/default-reporter/src/reporterForClient/reportUpdateCheck.ts
+++ b/pnpm11/cli/default-reporter/src/reporterForClient/reportUpdateCheck.ts
@@ -47,14 +47,13 @@ function renderUpdateMessage (opts: UpdateMessageOptions): string {
 }
 
 function renderUpdateCommand (opts: UpdateMessageOptions): string {
-  // Under Corepack, `pnpm self-update` refuses to run, and pnpm no longer
-  // points users back at Corepack — it suggests its own installer instead.
-  if (isExecutedByCorepack(opts.env)) {
+  // `pnpm self-update` replaces the pnpm that PNPM_HOME manages. Corepack
+  // refuses it outright, and an install another package manager owns is
+  // resolved from that manager's bin directory rather than pnpm's home, so a
+  // self-update would land beside the executable in use instead of replacing
+  // it. The installer is the command that updates either one.
+  if (isExecutedByCorepack(opts.env) || !opts.env.PNPM_HOME) {
     return standaloneInstallCommand(opts.platform)
   }
-  // `pnpm add -g pnpm` (or `@pnpm/exe`) is refused by the add command itself,
-  // which points at self-update instead. self-update also picks the package
-  // that can actually deliver a working binary for the wanted version — the
-  // unscoped `pnpm` from v12, where `@pnpm/exe` is no longer published.
   return 'pnpm self-update'
 }

--- a/pnpm11/cli/default-reporter/test/__snapshots__/reportingUpdateCheck.ts.snap
+++ b/pnpm11/cli/default-reporter/test/__snapshots__/reportingUpdateCheck.ts.snap
@@ -2,13 +2,26 @@
 
 exports[`print update notification for Corepack if the latest version is greater than the current 1`] = `
 "
-   ╭──────────────────────────────────────────────╮
-   │                                              │
-   │      Update available! 10.0.0 → 11.0.0.      │
-   │     Changelog: https://pnpm.io/v/11.0.0      │
-   │   To update, run: corepack use pnpm@11.0.0   │
-   │                                              │
-   ╰──────────────────────────────────────────────╯
+   ╭──────────────────────────────────────────────────────────────────────╮
+   │                                                                      │
+   │                  Update available! 10.0.0 → 11.0.0.                  │
+   │                 Changelog: https://pnpm.io/v/11.0.0                  │
+   │   To update, run: curl -fsSL https://get.pnpm.io/install.sh | sh -   │
+   │                                                                      │
+   ╰──────────────────────────────────────────────────────────────────────╯
+"
+`;
+
+exports[`print update notification for Corepack on Windows 1`] = `
+"
+   ╭────────────────────────────────────────────────────────────────────────╮
+   │                                                                        │
+   │                   Update available! 10.0.0 → 11.0.0.                   │
+   │                  Changelog: https://pnpm.io/v/11.0.0                   │
+   │   To update, run: Invoke-WebRequest https://get.pnpm.io/install.ps1    │
+   │                 -UseBasicParsing | Invoke-Expression                   │
+   │                                                                        │
+   ╰────────────────────────────────────────────────────────────────────────╯
 "
 `;
 
@@ -18,7 +31,7 @@ exports[`print update notification if the latest version is greater than the cur
    │                                         │
    │   Update available! 10.0.0 → 11.0.0.    │
    │   Changelog: https://pnpm.io/v/11.0.0   │
-   │    To update, run: pnpm add -g pnpm     │
+   │    To update, run: pnpm self-update     │
    │                                         │
    ╰─────────────────────────────────────────╯
 "
@@ -30,6 +43,18 @@ exports[`print update notification that suggests to use the standalone scripts f
    │                                         │
    │   Update available! 10.0.0 → 11.0.0.    │
    │   Changelog: https://pnpm.io/v/11.0.0   │
+   │    To update, run: pnpm self-update     │
+   │                                         │
+   ╰─────────────────────────────────────────╯
+"
+`;
+
+exports[`print update notification when pnpm was not installed by the standalone script 1`] = `
+"
+   ╭─────────────────────────────────────────╮
+   │                                         │
+   │   Update available! 10.0.0 → 12.0.0.    │
+   │   Changelog: https://pnpm.io/v/12.0.0   │
    │    To update, run: pnpm self-update     │
    │                                         │
    ╰─────────────────────────────────────────╯

--- a/pnpm11/cli/default-reporter/test/__snapshots__/reportingUpdateCheck.ts.snap
+++ b/pnpm11/cli/default-reporter/test/__snapshots__/reportingUpdateCheck.ts.snap
@@ -25,7 +25,7 @@ exports[`print update notification for Corepack on Windows 1`] = `
 "
 `;
 
-exports[`print update notification if the latest version is greater than the current 1`] = `
+exports[`print update notification when PNPM_HOME manages the pnpm in use 1`] = `
 "
    ╭─────────────────────────────────────────╮
    │                                         │
@@ -37,26 +37,14 @@ exports[`print update notification if the latest version is greater than the cur
 "
 `;
 
-exports[`print update notification that suggests to use the standalone scripts for the upgrade 1`] = `
+exports[`print update notification when pnpm was installed by another package manager 1`] = `
 "
-   ╭─────────────────────────────────────────╮
-   │                                         │
-   │   Update available! 10.0.0 → 11.0.0.    │
-   │   Changelog: https://pnpm.io/v/11.0.0   │
-   │    To update, run: pnpm self-update     │
-   │                                         │
-   ╰─────────────────────────────────────────╯
-"
-`;
-
-exports[`print update notification when pnpm was not installed by the standalone script 1`] = `
-"
-   ╭─────────────────────────────────────────╮
-   │                                         │
-   │   Update available! 10.0.0 → 12.0.0.    │
-   │   Changelog: https://pnpm.io/v/12.0.0   │
-   │    To update, run: pnpm self-update     │
-   │                                         │
-   ╰─────────────────────────────────────────╯
+   ╭──────────────────────────────────────────────────────────────────────╮
+   │                                                                      │
+   │                  Update available! 10.0.0 → 11.0.0.                  │
+   │                 Changelog: https://pnpm.io/v/11.0.0                  │
+   │   To update, run: curl -fsSL https://get.pnpm.io/install.sh | sh -   │
+   │                                                                      │
+   ╰──────────────────────────────────────────────────────────────────────╯
 "
 `;

--- a/pnpm11/cli/default-reporter/test/reportingUpdateCheck.ts
+++ b/pnpm11/cli/default-reporter/test/reportingUpdateCheck.ts
@@ -62,6 +62,9 @@ test('print update notification for Corepack if the latest version is greater th
       env: {
         COREPACK_ROOT: '/usr/bin/corepack',
       },
+      process: {
+        platform: 'linux',
+      } as any, // eslint-disable-line
     },
     streamParser: createStreamParser(),
   })
@@ -95,6 +98,56 @@ test('print update notification that suggests to use the standalone scripts for 
   updateCheckLogger.debug({
     currentVersion: '10.0.0',
     latestVersion: '11.0.0',
+  })
+
+  expect.assertions(1)
+
+  const output = await firstValueFrom(output$)
+  expect(stripAnsi(output)).toMatchSnapshot()
+})
+
+test('print update notification for Corepack on Windows', async () => {
+  const output$ = toOutput$({
+    context: {
+      argv: ['install'],
+      config: { recursive: true } as ReporterPnpmConfig,
+      env: {
+        COREPACK_ROOT: 'C:\\corepack',
+      },
+      process: {
+        platform: 'win32',
+      } as any, // eslint-disable-line
+    },
+    streamParser: createStreamParser(),
+  })
+
+  updateCheckLogger.debug({
+    currentVersion: '10.0.0',
+    latestVersion: '11.0.0',
+  })
+
+  expect.assertions(1)
+
+  const output = await firstValueFrom(output$)
+  expect(stripAnsi(output)).toMatchSnapshot()
+})
+
+test('print update notification when pnpm was not installed by the standalone script', async () => {
+  const output$ = toOutput$({
+    context: {
+      argv: ['install'],
+      config: { recursive: true } as ReporterPnpmConfig,
+      env: {},
+      process: {
+        platform: 'linux',
+      } as any, // eslint-disable-line
+    },
+    streamParser: createStreamParser(),
+  })
+
+  updateCheckLogger.debug({
+    currentVersion: '10.0.0',
+    latestVersion: '12.0.0',
   })
 
   expect.assertions(1)

--- a/pnpm11/cli/default-reporter/test/reportingUpdateCheck.ts
+++ b/pnpm11/cli/default-reporter/test/reportingUpdateCheck.ts
@@ -33,12 +33,15 @@ test('does not print update if latest is less than current', async () => {
   expect(output).toEqual(NO_OUTPUT)
 })
 
-test('print update notification if the latest version is greater than the current', async () => {
+test('print update notification when pnpm was installed by another package manager', async () => {
   const output$ = toOutput$({
     context: {
       argv: ['install'],
       config: { recursive: true } as ReporterPnpmConfig,
       env: {},
+      process: {
+        platform: 'linux',
+      } as any, // eslint-disable-line
     },
     streamParser: createStreamParser(),
   })
@@ -80,7 +83,7 @@ test('print update notification for Corepack if the latest version is greater th
   expect(stripAnsi(output)).toMatchSnapshot()
 })
 
-test('print update notification that suggests to use the standalone scripts for the upgrade', async () => {
+test('print update notification when PNPM_HOME manages the pnpm in use', async () => {
   const output$ = toOutput$({
     context: {
       argv: ['install'],
@@ -124,30 +127,6 @@ test('print update notification for Corepack on Windows', async () => {
   updateCheckLogger.debug({
     currentVersion: '10.0.0',
     latestVersion: '11.0.0',
-  })
-
-  expect.assertions(1)
-
-  const output = await firstValueFrom(output$)
-  expect(stripAnsi(output)).toMatchSnapshot()
-})
-
-test('print update notification when pnpm was not installed by the standalone script', async () => {
-  const output$ = toOutput$({
-    context: {
-      argv: ['install'],
-      config: { recursive: true } as ReporterPnpmConfig,
-      env: {},
-      process: {
-        platform: 'linux',
-      } as any, // eslint-disable-line
-    },
-    streamParser: createStreamParser(),
-  })
-
-  updateCheckLogger.debug({
-    currentVersion: '10.0.0',
-    latestVersion: '12.0.0',
   })
 
   expect.assertions(1)

--- a/pnpm11/cli/meta/src/index.ts
+++ b/pnpm11/cli/meta/src/index.ts
@@ -34,6 +34,16 @@ export function isExecutedByCorepack (env: NodeJS.ProcessEnv = process.env): boo
   return env.COREPACK_ROOT != null
 }
 
+/**
+ * The command that installs pnpm with the standalone script, as documented at
+ * https://pnpm.io/installation.
+ */
+export function standaloneInstallCommand (platform: NodeJS.Platform = process.platform): string {
+  return platform === 'win32'
+    ? 'Invoke-WebRequest https://get.pnpm.io/install.ps1 -UseBasicParsing | Invoke-Expression'
+    : 'curl -fsSL https://get.pnpm.io/install.sh | sh -'
+}
+
 export function getCurrentPackageName (): string {
   return detectIfCurrentPkgIsExecutable() ? '@pnpm/exe' : 'pnpm'
 }

--- a/pnpm11/cli/meta/src/index.ts
+++ b/pnpm11/cli/meta/src/index.ts
@@ -36,7 +36,9 @@ export function isExecutedByCorepack (env: NodeJS.ProcessEnv = process.env): boo
 
 /**
  * The command that installs pnpm with the standalone script, as documented at
- * https://pnpm.io/installation.
+ * https://pnpm.io/installation: the PowerShell form for `win32`, the
+ * `curl`-into-`sh` form for every other `platform`. Defaults to the host's
+ * platform; always returns a command that can be run as printed.
  */
 export function standaloneInstallCommand (platform: NodeJS.Platform = process.platform): string {
   return platform === 'win32'

--- a/pnpm11/engine/pm/commands/src/self-updater/selfUpdate.ts
+++ b/pnpm11/engine/pm/commands/src/self-updater/selfUpdate.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 
 import { confirm } from '@inquirer/prompts'
 import { linkBins } from '@pnpm/bins.linker'
-import { isExecutedByCorepack, packageManager } from '@pnpm/cli.meta'
+import { isExecutedByCorepack, packageManager, standaloneInstallCommand } from '@pnpm/cli.meta'
 import { docsUrl } from '@pnpm/cli.utils'
 import { type Config, type ConfigContext, getPackageManagerBootstrapConfig, parsePackageManager, shouldPersistLockfile, types as allTypes } from '@pnpm/config.reader'
 import { createPackageVersionPolicyOrThrow, getPublishedByPolicy } from '@pnpm/config.version-policy'
@@ -81,7 +81,9 @@ export async function handler (
   params: string[]
 ): Promise<undefined | string> {
   if (isExecutedByCorepack()) {
-    throw new PnpmError('CANT_SELF_UPDATE_IN_COREPACK', 'You should update pnpm with corepack')
+    throw new PnpmError('CANT_SELF_UPDATE_IN_COREPACK', 'pnpm cannot update itself when it is executed by Corepack', {
+      hint: `Install pnpm with the standalone script instead: ${standaloneInstallCommand()}`,
+    })
   }
   globalInfo('Checking for updates...')
   // Resolve the engine version exactly as a regular install would.


### PR DESCRIPTION
## Summary

The v11 CLI and the Rust engine, matching #14113 (merged) plus its follow-up #14116.

Two places told users to update pnpm with Corepack:

- The **update notification** printed `corepack use pnpm@<version>` when pnpm ran under Corepack. It now prints pnpm's [standalone install script](https://pnpm.io/installation) — `curl -fsSL https://get.pnpm.io/install.sh | sh -`, or the `Invoke-WebRequest` form on Windows.
- **`pnpm self-update`** refused under Corepack with *"You should update pnpm with corepack"*. It now says it cannot update itself under Corepack, and names the standalone install script as the hint.

The notification also stopped naming `pnpm add -g pnpm`, which `add` refuses outright (`ERR_PNPM_GLOBAL_PNPM_INSTALL` in the TypeScript CLI, `GlobalError::GlobalPnpmInstall` in the Rust one). `pnpm self-update` is named only where it can replace the executable in use — an install another package manager owns is resolved from that manager's bin directory, so a self-update would land beside it and report success while the old pnpm keeps announcing the update:

| `PNPM_HOME` set | under Corepack | suggestion |
| --- | --- | --- |
| yes | no | `pnpm self-update` |
| yes | yes | standalone install script |
| no | either | standalone install script |

The command has one definition per stack — `standaloneInstallCommand` in `@pnpm/cli.meta`, `standalone_install_command` in `pnpm-config` (beside `PNPM_VERSION`) — shared by the notification and the self-update refusal so the two cannot drift.

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port.
- [x] Added a changeset.
- [x] Added or updated tests — one case per row above in both stacks, plus a `pnpm-config` test that pins both installer commands in full, so a run on either platform covers both.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated pnpm update notifications to recommend `pnpm self-update` for installations managed through `PNPM_HOME`.
  * Corepack and other installation types now receive clear standalone installer instructions.
  * Installation guidance automatically uses the appropriate command for Windows or other platforms.
  * Improved self-update error messages with actionable alternatives when Corepack cannot perform the update.
  * Standardized update guidance across supported pnpm interfaces for a more consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->