### PR TITLE
fix: name the installer wherever self-update cannot replace pnpm

### DIFF
--- a/.changeset/hip-jokes-shave.md
+++ b/.changeset/hip-jokes-shave.md
@@ -1,11 +1,8 @@
 ---
 "@pnpm/tools.plugin-commands-self-updater": patch
 "@pnpm/default-reporter": patch
-"@pnpm/cli-meta": patch
+"@pnpm/cli-meta": minor
 "pnpm": patch
 ---
 
-pnpm no longer tells you to update itself with Corepack or with `pnpm add -g`:
-
-* The update notification now suggests `pnpm self-update`, or the [standalone install script](https://pnpm.io/installation) when pnpm is running under Corepack. It used to suggest `corepack use pnpm@<version>`, or `pnpm add -g pnpm` / `pnpm add -g @pnpm/exe` when pnpm was not installed by the standalone script — but `pnpm add -g` refuses to install pnpm and points at `pnpm self-update` anyway, and `@pnpm/exe` is not published for pnpm v12 or newer, where the unscoped `pnpm` package is itself the native executable.
-* `pnpm self-update` under Corepack now points at the standalone install script too, instead of telling you to update pnpm with Corepack.
+The update notification now suggests `pnpm self-update` when `PNPM_HOME` manages the pnpm in use, and the [standalone install script](https://pnpm.io/installation) otherwise — under Corepack, or when another package manager installed pnpm. `pnpm self-update` under Corepack names the standalone install script too.

--- a/cli/cli-meta/src/index.ts
+++ b/cli/cli-meta/src/index.ts
@@ -52,7 +52,10 @@ export function isExecutedByCorepack (env: NodeJS.ProcessEnv = process.env): boo
 
 /**
  * The command that installs pnpm with the standalone script, as documented at
- * https://pnpm.io/installation.
+ * https://pnpm.io/installation: the PowerShell form for `win32`, the
+ * `curl`-into-`sh` form for every other platform. Reads the platform from
+ * `proc`, defaulting to the host's; always returns a command that can be run
+ * as printed.
  */
 export function standaloneInstallCommand (proc: Process = process): string {
   return proc.platform === 'win32'

--- a/cli/default-reporter/src/reporterForClient/reportUpdateCheck.ts
+++ b/cli/default-reporter/src/reporterForClient/reportUpdateCheck.ts
@@ -47,14 +47,13 @@ function renderUpdateMessage (opts: UpdateMessageOptions): string {
 }
 
 function renderUpdateCommand (opts: UpdateMessageOptions): string {
-  // Under Corepack, `pnpm self-update` refuses to run, and pnpm no longer
-  // points users back at Corepack — it suggests its own installer instead.
-  if (isExecutedByCorepack(opts.env)) {
+  // `pnpm self-update` replaces the pnpm that PNPM_HOME manages. Corepack
+  // refuses it outright, and an install another package manager owns is
+  // resolved from that manager's bin directory rather than pnpm's home, so a
+  // self-update would land beside the executable in use instead of replacing
+  // it. The installer is the command that updates either one.
+  if (isExecutedByCorepack(opts.env) || !opts.env.PNPM_HOME) {
     return standaloneInstallCommand(opts.proc)
   }
-  // `pnpm add -g pnpm` (or `@pnpm/exe`) is refused by the add command itself,
-  // which points at self-update instead. self-update also picks the package
-  // that can actually deliver a working binary for the wanted version — the
-  // unscoped `pnpm` from v12, where `@pnpm/exe` is no longer published.
   return 'pnpm self-update'
 }

--- a/cli/default-reporter/test/__snapshots__/reportingUpdateCheck.ts.snap
+++ b/cli/default-reporter/test/__snapshots__/reportingUpdateCheck.ts.snap
@@ -25,19 +25,7 @@ exports[`print update notification for Corepack on Windows 1`] = `
 "
 `;
 
-exports[`print update notification for the standalone build when pnpm was not installed by the standalone script 1`] = `
-"
-   ╭─────────────────────────────────────────╮
-   │                                         │
-   │   Update available! 10.0.0 → 12.0.0.    │
-   │   Changelog: https://pnpm.io/v/12.0.0   │
-   │    To update, run: pnpm self-update     │
-   │                                         │
-   ╰─────────────────────────────────────────╯
-"
-`;
-
-exports[`print update notification if the latest version is greater than the current 1`] = `
+exports[`print update notification when PNPM_HOME manages the pnpm in use 1`] = `
 "
    ╭─────────────────────────────────────────╮
    │                                         │
@@ -49,14 +37,14 @@ exports[`print update notification if the latest version is greater than the cur
 "
 `;
 
-exports[`print update notification that suggests to use the standalone scripts for the upgrade 1`] = `
+exports[`print update notification when pnpm was installed by another package manager 1`] = `
 "
-   ╭─────────────────────────────────────────╮
-   │                                         │
-   │   Update available! 10.0.0 → 11.0.0.    │
-   │   Changelog: https://pnpm.io/v/11.0.0   │
-   │    To update, run: pnpm self-update     │
-   │                                         │
-   ╰─────────────────────────────────────────╯
+   ╭──────────────────────────────────────────────────────────────────────╮
+   │                                                                      │
+   │                  Update available! 10.0.0 → 11.0.0.                  │
+   │                 Changelog: https://pnpm.io/v/11.0.0                  │
+   │   To update, run: curl -fsSL https://get.pnpm.io/install.sh | sh -   │
+   │                                                                      │
+   ╰──────────────────────────────────────────────────────────────────────╯
 "
 `;

--- a/cli/default-reporter/test/reportingUpdateCheck.ts
+++ b/cli/default-reporter/test/reportingUpdateCheck.ts
@@ -30,12 +30,15 @@ test('does not print update if latest is less than current', async () => {
   expect(output).toEqual(NO_OUTPUT)
 })
 
-test('print update notification if the latest version is greater than the current', async () => {
+test('print update notification when pnpm was installed by another package manager', async () => {
   const output$ = toOutput$({
     context: {
       argv: ['install'],
       config: { recursive: true } as Config,
       env: {},
+      process: {
+        platform: 'linux',
+      } as any, // eslint-disable-line
     },
     streamParser: createStreamParser(),
   })
@@ -77,7 +80,7 @@ test('print update notification for Corepack if the latest version is greater th
   expect(stripAnsi(output)).toMatchSnapshot()
 })
 
-test('print update notification that suggests to use the standalone scripts for the upgrade', async () => {
+test('print update notification when PNPM_HOME manages the pnpm in use', async () => {
   const output$ = toOutput$({
     context: {
       argv: ['install'],
@@ -95,30 +98,6 @@ test('print update notification that suggests to use the standalone scripts for 
   updateCheckLogger.debug({
     currentVersion: '10.0.0',
     latestVersion: '11.0.0',
-  })
-
-  expect.assertions(1)
-
-  const output = await firstValueFrom(output$)
-  expect(stripAnsi(output)).toMatchSnapshot()
-})
-
-test('print update notification for the standalone build when pnpm was not installed by the standalone script', async () => {
-  const output$ = toOutput$({
-    context: {
-      argv: ['install'],
-      config: { recursive: true } as Config,
-      env: {},
-      process: {
-        pkg: true,
-      } as any, // eslint-disable-line
-    },
-    streamParser: createStreamParser(),
-  })
-
-  updateCheckLogger.debug({
-    currentVersion: '10.0.0',
-    latestVersion: '12.0.0',
   })
 
   expect.assertions(1)


### PR DESCRIPTION
## Summary

Follow-up to #14113, from review feedback on its v11/v12 counterpart (#14115).

#14113 left `pnpm self-update` as the suggestion for a pnpm that another package manager installed (no `PNPM_HOME`). That command runs, but it cannot help there: the install is resolved from that manager's bin directory, so `self-update` writes into pnpm's default home — beside the executable in use rather than replacing it — and reports success while the old pnpm keeps announcing the same update.

The notification now names `pnpm self-update` only when `PNPM_HOME` manages the pnpm in use, and the [standalone install script](https://pnpm.io/installation) otherwise, which is already what it does under Corepack.

| `PNPM_HOME` set | under Corepack | suggestion |
| --- | --- | --- |
| yes | no | `pnpm self-update` |
| yes | yes | standalone install script |
| no | either | standalone install script |

The changeset from #14113 is rewritten rather than added to — that release has not gone out yet — and `@pnpm/cli-meta` moves to `minor`, since `standaloneInstallCommand` is a new export.

## Checklist

- [x] Updated the changeset.
- [x] Updated tests — one case per row above, pinned by snapshot.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790104493&installation_model_id=426870&pr_number=14116&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14116&signature=8461af677bec93d9b6eab142c184cb243f5f9919926bf32c22f28aa2caa79a9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->