### PR TITLE
docs: add Notion as a platinum sponsor

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,6 @@ To quote the [Rush](https://rushjs.io/) team:
           </picture>
         </a>
       </td>
-    </tr>
-    <tr>
       <td align="center" valign="middle">
         <a href="https://notion.com/?utm_source=pnpm&utm_medium=readme" target="_blank" rel="noopener noreferrer">
           <picture>

--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ To quote the [Rush](https://rushjs.io/) team:
         </a>
       </td>
     </tr>
+    <tr>
+      <td align="center" valign="middle">
+        <a href="https://notion.com/?utm_source=pnpm&utm_medium=readme" target="_blank" rel="noopener noreferrer">
+          <picture>
+            <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/notion.svg" />
+            <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/notion_light.svg" />
+            <img src="https://pnpm.io/img/users/notion.svg" width="80" alt="Notion" />
+          </picture>
+        </a>
+      </td>
+    </tr>
   </tbody>
 </table>
 
@@ -131,6 +142,9 @@ To quote the [Rush](https://rushjs.io/) team:
             <img src="https://pnpm.io/img/users/nx.svg" width="50" alt="Nx" />
           </picture>
         </a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://latitude.so/?utm_source=pnpm&utm_medium=readme" target="_blank" rel="noopener noreferrer"><img src="https://pnpm.io/img/users/latitude.svg" width="160" alt="Latitude"></a>
       </td>
     </tr>
   </tbody>

--- a/pnpm/npm/pnpm/README.md
+++ b/pnpm/npm/pnpm/README.md
@@ -52,6 +52,17 @@ To quote the [Rush](https://rushjs.io/) team:
         </a>
       </td>
     </tr>
+    <tr>
+      <td align="center" valign="middle">
+        <a href="https://notion.com/?utm_source=pnpm&utm_medium=readme" target="_blank" rel="noopener noreferrer">
+          <picture>
+            <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/notion.svg" />
+            <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/notion_light.svg" />
+            <img src="https://pnpm.io/img/users/notion.svg" width="80" alt="Notion" />
+          </picture>
+        </a>
+      </td>
+    </tr>
   </tbody>
 </table>
 
@@ -129,6 +140,9 @@ To quote the [Rush](https://rushjs.io/) team:
             <img src="https://pnpm.io/img/users/nx.svg" width="50" alt="Nx" />
           </picture>
         </a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://latitude.so/?utm_source=pnpm&utm_medium=readme" target="_blank" rel="noopener noreferrer"><img src="https://pnpm.io/img/users/latitude.svg" width="160" alt="Latitude"></a>
       </td>
     </tr>
   </tbody>

--- a/pnpm/npm/pnpm/README.md
+++ b/pnpm/npm/pnpm/README.md
@@ -51,8 +51,6 @@ To quote the [Rush](https://rushjs.io/) team:
           </picture>
         </a>
       </td>
-    </tr>
-    <tr>
       <td align="center" valign="middle">
         <a href="https://notion.com/?utm_source=pnpm&utm_medium=readme" target="_blank" rel="noopener noreferrer">
           <picture>

--- a/pnpm11/__utils__/get-release-text/src/main.ts
+++ b/pnpm11/__utils__/get-release-text/src/main.ts
@@ -103,8 +103,6 @@ export function getChangelogEntry (changelog: string, version: string): Changelo
       <td align="center" valign="middle">
         <a href="https://bit.cloud/?utm_source=pnpm&utm_medium=release_notes" target="_blank" rel="noopener noreferrer"><img src="https://pnpm.io/img/users/bit.svg" width="80" alt="Bit"></a>
       </td>
-    </tr>
-    <tr>
       <td align="center" valign="middle">
         <a href="https://openai.com/?utm_source=pnpm&utm_medium=release_notes" target="_blank" rel="noopener noreferrer">
           <picture>
@@ -114,8 +112,6 @@ export function getChangelogEntry (changelog: string, version: string): Changelo
           </picture>
         </a>
       </td>
-    </tr>
-    <tr>
       <td align="center" valign="middle">
         <a href="https://notion.com/?utm_source=pnpm&utm_medium=release_notes" target="_blank" rel="noopener noreferrer">
           <picture>

--- a/pnpm11/__utils__/get-release-text/src/main.ts
+++ b/pnpm11/__utils__/get-release-text/src/main.ts
@@ -115,6 +115,17 @@ export function getChangelogEntry (changelog: string, version: string): Changelo
         </a>
       </td>
     </tr>
+    <tr>
+      <td align="center" valign="middle">
+        <a href="https://notion.com/?utm_source=pnpm&utm_medium=release_notes" target="_blank" rel="noopener noreferrer">
+          <picture>
+            <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/notion.svg" />
+            <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/notion_light.svg" />
+            <img src="https://pnpm.io/img/users/notion.svg" width="80" alt="Notion" />
+          </picture>
+        </a>
+      </td>
+    </tr>
   </tbody>
 </table>
 
@@ -192,6 +203,9 @@ export function getChangelogEntry (changelog: string, version: string): Changelo
             <img src="https://pnpm.io/img/users/nx.svg" width="50" alt="Nx" />
           </picture>
         </a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://latitude.so/?utm_source=pnpm&utm_medium=release_notes" target="_blank" rel="noopener noreferrer"><img src="https://pnpm.io/img/users/latitude.svg" width="160" alt="Latitude"></a>
       </td>
     </tr>
   </tbody>

--- a/pnpm11/pnpm/README.md
+++ b/pnpm11/pnpm/README.md
@@ -52,6 +52,17 @@ To quote the [Rush](https://rushjs.io/) team:
         </a>
       </td>
     </tr>
+    <tr>
+      <td align="center" valign="middle">
+        <a href="https://notion.com/?utm_source=pnpm&utm_medium=readme" target="_blank" rel="noopener noreferrer">
+          <picture>
+            <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/notion.svg" />
+            <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/notion_light.svg" />
+            <img src="https://pnpm.io/img/users/notion.svg" width="80" alt="Notion" />
+          </picture>
+        </a>
+      </td>
+    </tr>
   </tbody>
 </table>
 
@@ -129,6 +140,9 @@ To quote the [Rush](https://rushjs.io/) team:
             <img src="https://pnpm.io/img/users/nx.svg" width="50" alt="Nx" />
           </picture>
         </a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://latitude.so/?utm_source=pnpm&utm_medium=readme" target="_blank" rel="noopener noreferrer"><img src="https://pnpm.io/img/users/latitude.svg" width="160" alt="Latitude"></a>
       </td>
     </tr>
   </tbody>

--- a/pnpm11/pnpm/README.md
+++ b/pnpm11/pnpm/README.md
@@ -51,8 +51,6 @@ To quote the [Rush](https://rushjs.io/) team:
           </picture>
         </a>
       </td>
-    </tr>
-    <tr>
       <td align="center" valign="middle">
         <a href="https://notion.com/?utm_source=pnpm&utm_medium=readme" target="_blank" rel="noopener noreferrer">
           <picture>


### PR DESCRIPTION
Notion is now a platinum sponsor. Regenerated the sponsor tables from pnpm.io's `sponsors.json` with `scripts/generate-sponsors.mjs`.

**Depends on** pnpm/pnpm.io#899 — the `<picture>` element references `notion_light.svg`, which needs to be deployed to pnpm.io before this merges, or the dark-theme source 404s. The base `notion.svg` is already live (pnpm/pnpm.io#898).

Files touched, all four carrying `<!-- sponsors -->` markers:

- `README.md`
- `pnpm/npm/pnpm/README.md`
- `pnpm11/pnpm/README.md`
- `pnpm11/__utils__/get-release-text/src/main.ts`

Two things worth noting:

- The diff also adds **Latitude** to the gold tier. It was added to the website a while back but never propagated here, so the regeneration picks it up.
- `scripts/generate-sponsors.mjs` in pnpm.io still points at the pre-restructure paths (`pnpm/README.md` and `__utils__/get-release-text/src/main.ts`). It updates the root `README.md` fine but errors out on the rest, so I generated the other three with a locally corrected copy. Worth fixing that script separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14117"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790111651&installation_model_id=426870&pr_number=14117&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14117&signature=135728253fd89cd3c483c9626167ab215055dd749aecfe6fc19b51a79425a1f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added Notion to the Platinum Sponsors section.
  - Added Latitude to the Gold Sponsors section.
  - Included sponsor links and light/dark images for improved display across themes and screen sizes.
  - Updated sponsor table formatting so Platinum sponsors appear together in a consistent row.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->