### PR TITLE
fix: include sponsors in v12 release descriptions

### DIFF
--- a/.github/release-sponsors.md
+++ b/.github/release-sponsors.md
@@ -1,0 +1,115 @@
+<!-- sponsors -->
+
+## Platinum Sponsors
+
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="middle">
+        <a href="https://bit.cloud/?utm_source=pnpm&utm_medium=release_notes" target="_blank" rel="noopener noreferrer"><img src="https://pnpm.io/img/users/bit.svg" width="80" alt="Bit"></a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://openai.com/?utm_source=pnpm&utm_medium=release_notes" target="_blank" rel="noopener noreferrer">
+          <picture>
+            <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/openai_dark.svg" />
+            <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/openai_light.svg" />
+            <img src="https://pnpm.io/img/users/openai_dark.svg" width="160" alt="OpenAI" />
+          </picture>
+        </a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://notion.com/?utm_source=pnpm&utm_medium=release_notes" target="_blank" rel="noopener noreferrer">
+          <picture>
+            <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/notion.svg" />
+            <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/notion_light.svg" />
+            <img src="https://pnpm.io/img/users/notion.svg" width="80" alt="Notion" />
+          </picture>
+        </a>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## Gold Sponsors
+
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="middle">
+        <a href="https://sanity.io/?utm_source=pnpm&utm_medium=release_notes" target="_blank" rel="noopener noreferrer">
+          <picture>
+            <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/sanity.svg" />
+            <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/sanity_light.svg" />
+            <img src="https://pnpm.io/img/users/sanity.svg" width="120" alt="Sanity" />
+          </picture>
+        </a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://discord.com/?utm_source=pnpm&utm_medium=release_notes" target="_blank" rel="noopener noreferrer">
+          <picture>
+            <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/discord.svg" />
+            <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/discord_light.svg" />
+            <img src="https://pnpm.io/img/users/discord.svg" width="220" alt="Discord" />
+          </picture>
+        </a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://vite.dev/?utm_source=pnpm&utm_medium=release_notes" target="_blank" rel="noopener noreferrer"><img src="https://pnpm.io/img/users/vitejs.svg" width="42" alt="Vite"></a>
+      </td>
+    </tr>
+    <tr>
+      <td align="center" valign="middle">
+        <a href="https://serpapi.com/?utm_source=pnpm&utm_medium=release_notes" target="_blank" rel="noopener noreferrer">
+          <picture>
+            <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/serpapi_dark.svg" />
+            <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/serpapi_light.svg" />
+            <img src="https://pnpm.io/img/users/serpapi_dark.svg" width="160" alt="SerpApi" />
+          </picture>
+        </a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://coderabbit.ai/?utm_source=pnpm&utm_medium=release_notes" target="_blank" rel="noopener noreferrer">
+          <picture>
+            <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/coderabbit.svg" />
+            <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/coderabbit_light.svg" />
+            <img src="https://pnpm.io/img/users/coderabbit.svg" width="220" alt="CodeRabbit" />
+          </picture>
+        </a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://stackblitz.com/?utm_source=pnpm&utm_medium=release_notes" target="_blank" rel="noopener noreferrer">
+          <picture>
+            <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/stackblitz.svg" />
+            <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/stackblitz_light.svg" />
+            <img src="https://pnpm.io/img/users/stackblitz.svg" width="190" alt="Stackblitz" />
+          </picture>
+        </a>
+      </td>
+    </tr>
+    <tr>
+      <td align="center" valign="middle">
+        <a href="https://workleap.com/?utm_source=pnpm&utm_medium=release_notes" target="_blank" rel="noopener noreferrer">
+          <picture>
+            <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/workleap.svg" />
+            <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/workleap_light.svg" />
+            <img src="https://pnpm.io/img/users/workleap.svg" width="190" alt="Workleap" />
+          </picture>
+        </a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://nx.dev/?utm_source=pnpm&utm_medium=release_notes" target="_blank" rel="noopener noreferrer">
+          <picture>
+            <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/nx.svg" />
+            <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/nx_light.svg" />
+            <img src="https://pnpm.io/img/users/nx.svg" width="50" alt="Nx" />
+          </picture>
+        </a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://latitude.so/?utm_source=pnpm&utm_medium=release_notes" target="_blank" rel="noopener noreferrer"><img src="https://pnpm.io/img/users/latitude.svg" width="160" alt="Latitude"></a>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- sponsors end -->

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1018,6 +1018,12 @@ jobs:
         # under the release title. A missing changelog only warns: the draft is
         # still worth having for its artifacts, and a maintainer can fill in
         # the description before publishing.
+        #
+        # The sponsors table is appended from a checked-in fragment, the same
+        # one the v11 release text carries inline. It is regenerated from
+        # pnpm.io's sponsors.json, so a missing file means someone moved it,
+        # not that there are no sponsors — warn rather than fail, since the
+        # sponsors table is not worth losing a release over.
         env:
           VERSION: ${{ needs.plan.outputs.rust_version }}
         run: |
@@ -1027,6 +1033,13 @@ jobs:
           else
             echo "::warning::No pending changelog at ${changelog}; drafting the release with an empty description"
             : > RELEASE.md
+          fi
+          sponsors=".github/release-sponsors.md"
+          if [ -f "$sponsors" ]; then
+            printf '\n' >> RELEASE.md
+            cat "$sponsors" >> RELEASE.md
+          else
+            echo "::warning::No sponsors fragment at ${sponsors}; drafting the release without the sponsors table"
           fi
 
       - name: Release

--- a/pnpm11/__utils__/get-release-text/src/main.ts
+++ b/pnpm11/__utils__/get-release-text/src/main.ts
@@ -24,6 +24,23 @@ if (process.argv[1] != null && path.resolve(process.argv[1]) === fileURLToPath(i
   await writeReleaseText(repoRoot)
 }
 
+// The sponsors table is shared with the v12 release job, which cats this same
+// fragment onto its RELEASE.md. It is regenerated from pnpm.io's sponsors.json.
+// A missing fragment means someone moved it, not that there are no sponsors —
+// warn rather than throw, since the workflow falls back to a diagnostic
+// description when this script fails, and no sponsors beats no release notes.
+const SPONSORS_FRAGMENT = '.github/release-sponsors.md'
+
+async function readSponsors (workspaceDir: string): Promise<string> {
+  try {
+    return await fs.readFile(path.join(workspaceDir, SPONSORS_FRAGMENT), 'utf8')
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err
+    console.warn(`::warning::No sponsors fragment at ${SPONSORS_FRAGMENT}; writing the release description without the sponsors table`)
+    return ''
+  }
+}
+
 export async function writeReleaseText (workspaceDir: string): Promise<void> {
   const pnpmDir = path.join(workspaceDir, 'pnpm11/pnpm')
   const pnpm = JSON.parse(await fs.readFile(path.join(pnpmDir, 'package.json'), 'utf8'))
@@ -32,9 +49,11 @@ export async function writeReleaseText (workspaceDir: string): Promise<void> {
     throw new PnpmError('MISSING_CHANGELOG', `No pending changelog found for pnpm ${pnpm.version}`)
   }
   const release = getChangelogEntry(changelog, pnpm.version)
+  const sponsors = await readSponsors(workspaceDir)
+  const content = sponsors === '' ? release.content : `${release.content}\n${sponsors}`
   const releasePath = path.join(workspaceDir, 'RELEASE.md')
   const temporaryPath = `${releasePath}.${process.pid}.tmp`
-  await fs.writeFile(temporaryPath, release.content)
+  await fs.writeFile(temporaryPath, content)
   await fs.rename(temporaryPath, releasePath)
 }
 
@@ -91,124 +110,7 @@ export function getChangelogEntry (changelog: string, version: string): Changelo
     endIndex
   )
   return {
-    content: `${unified().use(remarkStringify).stringify(ast)}
-
-<!-- sponsors -->
-
-## Platinum Sponsors
-
-<table>
-  <tbody>
-    <tr>
-      <td align="center" valign="middle">
-        <a href="https://bit.cloud/?utm_source=pnpm&utm_medium=release_notes" target="_blank" rel="noopener noreferrer"><img src="https://pnpm.io/img/users/bit.svg" width="80" alt="Bit"></a>
-      </td>
-      <td align="center" valign="middle">
-        <a href="https://openai.com/?utm_source=pnpm&utm_medium=release_notes" target="_blank" rel="noopener noreferrer">
-          <picture>
-            <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/openai_dark.svg" />
-            <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/openai_light.svg" />
-            <img src="https://pnpm.io/img/users/openai_dark.svg" width="160" alt="OpenAI" />
-          </picture>
-        </a>
-      </td>
-      <td align="center" valign="middle">
-        <a href="https://notion.com/?utm_source=pnpm&utm_medium=release_notes" target="_blank" rel="noopener noreferrer">
-          <picture>
-            <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/notion.svg" />
-            <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/notion_light.svg" />
-            <img src="https://pnpm.io/img/users/notion.svg" width="80" alt="Notion" />
-          </picture>
-        </a>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-## Gold Sponsors
-
-<table>
-  <tbody>
-    <tr>
-      <td align="center" valign="middle">
-        <a href="https://sanity.io/?utm_source=pnpm&utm_medium=release_notes" target="_blank" rel="noopener noreferrer">
-          <picture>
-            <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/sanity.svg" />
-            <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/sanity_light.svg" />
-            <img src="https://pnpm.io/img/users/sanity.svg" width="120" alt="Sanity" />
-          </picture>
-        </a>
-      </td>
-      <td align="center" valign="middle">
-        <a href="https://discord.com/?utm_source=pnpm&utm_medium=release_notes" target="_blank" rel="noopener noreferrer">
-          <picture>
-            <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/discord.svg" />
-            <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/discord_light.svg" />
-            <img src="https://pnpm.io/img/users/discord.svg" width="220" alt="Discord" />
-          </picture>
-        </a>
-      </td>
-      <td align="center" valign="middle">
-        <a href="https://vite.dev/?utm_source=pnpm&utm_medium=release_notes" target="_blank" rel="noopener noreferrer"><img src="https://pnpm.io/img/users/vitejs.svg" width="42" alt="Vite"></a>
-      </td>
-    </tr>
-    <tr>
-      <td align="center" valign="middle">
-        <a href="https://serpapi.com/?utm_source=pnpm&utm_medium=release_notes" target="_blank" rel="noopener noreferrer">
-          <picture>
-            <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/serpapi_dark.svg" />
-            <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/serpapi_light.svg" />
-            <img src="https://pnpm.io/img/users/serpapi_dark.svg" width="160" alt="SerpApi" />
-          </picture>
-        </a>
-      </td>
-      <td align="center" valign="middle">
-        <a href="https://coderabbit.ai/?utm_source=pnpm&utm_medium=release_notes" target="_blank" rel="noopener noreferrer">
-          <picture>
-            <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/coderabbit.svg" />
-            <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/coderabbit_light.svg" />
-            <img src="https://pnpm.io/img/users/coderabbit.svg" width="220" alt="CodeRabbit" />
-          </picture>
-        </a>
-      </td>
-      <td align="center" valign="middle">
-        <a href="https://stackblitz.com/?utm_source=pnpm&utm_medium=release_notes" target="_blank" rel="noopener noreferrer">
-          <picture>
-            <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/stackblitz.svg" />
-            <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/stackblitz_light.svg" />
-            <img src="https://pnpm.io/img/users/stackblitz.svg" width="190" alt="Stackblitz" />
-          </picture>
-        </a>
-      </td>
-    </tr>
-    <tr>
-      <td align="center" valign="middle">
-        <a href="https://workleap.com/?utm_source=pnpm&utm_medium=release_notes" target="_blank" rel="noopener noreferrer">
-          <picture>
-            <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/workleap.svg" />
-            <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/workleap_light.svg" />
-            <img src="https://pnpm.io/img/users/workleap.svg" width="190" alt="Workleap" />
-          </picture>
-        </a>
-      </td>
-      <td align="center" valign="middle">
-        <a href="https://nx.dev/?utm_source=pnpm&utm_medium=release_notes" target="_blank" rel="noopener noreferrer">
-          <picture>
-            <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/nx.svg" />
-            <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/nx_light.svg" />
-            <img src="https://pnpm.io/img/users/nx.svg" width="50" alt="Nx" />
-          </picture>
-        </a>
-      </td>
-      <td align="center" valign="middle">
-        <a href="https://latitude.so/?utm_source=pnpm&utm_medium=release_notes" target="_blank" rel="noopener noreferrer"><img src="https://pnpm.io/img/users/latitude.svg" width="160" alt="Latitude"></a>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-<!-- sponsors end -->
-`,
+    content: unified().use(remarkStringify).stringify(ast),
     highestLevel,
   }
 }

--- a/pnpm11/__utils__/get-release-text/test/main.ts
+++ b/pnpm11/__utils__/get-release-text/test/main.ts
@@ -30,6 +30,42 @@ test('writes the pending registry changelog section', async () => {
   expect(release).toContain('Fixed the release notes.')
 })
 
+test('appends the shared sponsors fragment', async () => {
+  const pnpmDir = path.join(workspaceDir, 'pnpm11/pnpm')
+  await fs.mkdir(pnpmDir, { recursive: true })
+  await fs.writeFile(path.join(pnpmDir, 'package.json'), JSON.stringify({ name: 'pnpm', version: '11.13.1' }))
+  const pendingDir = path.join(workspaceDir, '.changeset/changelogs')
+  await fs.mkdir(pendingDir, { recursive: true })
+  await fs.writeFile(path.join(pendingDir, 'pnpm@11.13.1.md'), '## 11.13.1\n\n### Patch Changes\n\n- Fixed the release notes.\n')
+  const githubDir = path.join(workspaceDir, '.github')
+  await fs.mkdir(githubDir, { recursive: true })
+  await fs.writeFile(path.join(githubDir, 'release-sponsors.md'), '<!-- sponsors -->\n\n## Platinum Sponsors\n\n<!-- sponsors end -->\n')
+
+  await writeReleaseText(workspaceDir)
+
+  const release = await fs.readFile(path.join(workspaceDir, 'RELEASE.md'), 'utf8')
+  expect(release).toContain('Fixed the release notes.')
+  expect(release).toContain('## Platinum Sponsors')
+  // the changelog stays above the table, separated by a blank line
+  expect(release.indexOf('Fixed the release notes.')).toBeLessThan(release.indexOf('## Platinum Sponsors'))
+  expect(release).toContain('\n\n<!-- sponsors -->')
+})
+
+test('writes the release description when the sponsors fragment is missing', async () => {
+  const pnpmDir = path.join(workspaceDir, 'pnpm11/pnpm')
+  await fs.mkdir(pnpmDir, { recursive: true })
+  await fs.writeFile(path.join(pnpmDir, 'package.json'), JSON.stringify({ name: 'pnpm', version: '11.13.1' }))
+  const pendingDir = path.join(workspaceDir, '.changeset/changelogs')
+  await fs.mkdir(pendingDir, { recursive: true })
+  await fs.writeFile(path.join(pendingDir, 'pnpm@11.13.1.md'), '## 11.13.1\n\n### Patch Changes\n\n- Fixed the release notes.\n')
+
+  await writeReleaseText(workspaceDir)
+
+  const release = await fs.readFile(path.join(workspaceDir, 'RELEASE.md'), 'utf8')
+  expect(release).toContain('Fixed the release notes.')
+  expect(release).not.toContain('<!-- sponsors -->')
+})
+
 test('reports a missing changelog for the released version', async () => {
   const pnpmDir = path.join(workspaceDir, 'pnpm11/pnpm')
   await fs.mkdir(pnpmDir, { recursive: true })

--- a/pnpm11/__utils__/get-release-text/test/main.ts
+++ b/pnpm11/__utils__/get-release-text/test/main.ts
@@ -6,6 +6,8 @@ import { afterEach, beforeEach, expect, test } from '@jest/globals'
 
 import { getChangelogEntry, writeReleaseText } from '../src/main.js'
 
+const SPONSORS_FRAGMENT = '<!-- sponsors -->\n\n## Platinum Sponsors\n\n<!-- sponsors end -->\n'
+
 let workspaceDir: string
 
 beforeEach(async () => {
@@ -30,7 +32,7 @@ test('writes the pending registry changelog section', async () => {
   expect(release).toContain('Fixed the release notes.')
 })
 
-test('appends the shared sponsors fragment', async () => {
+test('appends the shared sponsors fragment exactly once', async () => {
   const pnpmDir = path.join(workspaceDir, 'pnpm11/pnpm')
   await fs.mkdir(pnpmDir, { recursive: true })
   await fs.writeFile(path.join(pnpmDir, 'package.json'), JSON.stringify({ name: 'pnpm', version: '11.13.1' }))
@@ -39,15 +41,17 @@ test('appends the shared sponsors fragment', async () => {
   await fs.writeFile(path.join(pendingDir, 'pnpm@11.13.1.md'), '## 11.13.1\n\n### Patch Changes\n\n- Fixed the release notes.\n')
   const githubDir = path.join(workspaceDir, '.github')
   await fs.mkdir(githubDir, { recursive: true })
-  await fs.writeFile(path.join(githubDir, 'release-sponsors.md'), '<!-- sponsors -->\n\n## Platinum Sponsors\n\n<!-- sponsors end -->\n')
+  await fs.writeFile(path.join(githubDir, 'release-sponsors.md'), SPONSORS_FRAGMENT)
 
   await writeReleaseText(workspaceDir)
 
   const release = await fs.readFile(path.join(workspaceDir, 'RELEASE.md'), 'utf8')
   expect(release).toContain('Fixed the release notes.')
-  expect(release).toContain('## Platinum Sponsors')
-  // the changelog stays above the table, separated by a blank line
-  expect(release.indexOf('Fixed the release notes.')).toBeLessThan(release.indexOf('## Platinum Sponsors'))
+  // the fragment is the tail of the description, appended once and only once —
+  // a second append, or markup left behind in getChangelogEntry, fails here
+  expect(release.match(/<!-- sponsors -->/g)).toHaveLength(1)
+  expect(release.endsWith(`\n${SPONSORS_FRAGMENT}`)).toBe(true)
+  // separated from the changelog by a blank line
   expect(release).toContain('\n\n<!-- sponsors -->')
 })
 


### PR DESCRIPTION
v12 release pages don't show sponsors. v11's description comes from `pn make-release-description`, which appended the sponsors tables inline; the Rust release job builds its description by dumping the pending changelog and nothing else, so sponsors never made it in.

## What this does

**Commit 1** — adds `.github/release-sponsors.md`, a checked-in fragment holding the platinum and gold tables with `utm_medium=release_notes` attribution, and cats it onto `RELEASE.md` in the Rust release job.

**Commit 2** — points `make-release-description` at the same fragment. It carried its own copy of the tables, 109 lines of HTML that had to be regenerated in lockstep with the READMEs; with v12 reading a fragment there was no reason for v11 to keep its own. `getChangelogEntry` goes back to returning just the changelog section and `writeReleaseText` appends the fragment.

Net: −119 / +57 in the util, and one source of truth for the tables.

## Missing-fragment behaviour

Both paths warn and produce the description without the table, matching how a missing changelog is already handled in the v12 job. Throwing in the v11 util would be actively worse: the workflow replaces a failed `make-release-description` with a diagnostic "release notes unavailable" body, so a missing sponsors table would cost the release its actual notes.

## Why a fragment rather than sharing the generator

`make-release-description` lives in the `pnpm11` TypeScript workspace; the Rust job has no reason to install and build that workspace to render a static table. Extracting the block from the root README instead would have been simpler, but that copy carries `utm_medium=readme`, which would misattribute release-page clicks in sponsors' analytics.

## Verified

- `tsgo --build`, `eslint`, and `jest` all pass on the util — 5 tests, including two new ones covering the fragment being appended and the fragment being absent.
- Simulated the v12 shell step against a fixture changelog; output matches the v11 shape — changelog body, blank line, `<!-- sponsors -->`, then the tables.
- `release.yml` still parses (15 jobs).

## Follow-ups

- The fragment is kept in sync by pnpm.io's `scripts/generate-sponsors.mjs`; retargeted in pnpm/pnpm.io#901.
- `pnpr` builds its description the same way and also has no sponsors. Left alone — say the word if it should carry them too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release notes now include Platinum and Gold sponsor sections.
  * Sponsor links include tracking information, and logos support light and dark display modes with accessible descriptions.
  * Sponsor content is automatically appended to release descriptions when available.

* **Bug Fixes**
  * Release generation now continues successfully when sponsor information is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->