### PR TITLE
fix(deps-status): treat an unrecorded enableGlobalVirtualStore as false

### DIFF
--- a/.changeset/deps-status-implicit-global-virtual-store.md
+++ b/.changeset/deps-status-implicit-global-virtual-store.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/deps.status": patch
+"pnpm": patch
+---
+
+`pnpm run` no longer reinstalls dependencies when a `node_modules` installed outside CI is used with `CI=true`, or the other way around. An install that never configured `enableGlobalVirtualStore` records no value for it, while `CI=true` resolves the same setting to `false`, and the two were compared as different values.

--- a/.changeset/deps-status-implicit-global-virtual-store.md
+++ b/.changeset/deps-status-implicit-global-virtual-store.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-`pnpm run` no longer reinstalls dependencies when a `node_modules` installed outside CI is used with `CI=true`, or the other way around. An install that never configured `enableGlobalVirtualStore` records no value for it, while `CI=true` resolves the same setting to `false`, and the two were compared as different values.
+`pnpm run` no longer reinstalls dependencies when a `node_modules` directory installed outside CI is used with `CI=true`, or the other way around.

--- a/pnpm11/deps/status/src/checkDepsStatus.ts
+++ b/pnpm11/deps/status/src/checkDepsStatus.ts
@@ -231,12 +231,9 @@ async function _checkDepsStatus (opts: CheckDepsStatusOptions, workspaceState: W
     ignoredSettings.add('catalogs')
     for (const settingName of WORKSPACE_STATE_SETTING_KEYS) {
       if (ignoredSettings.has(settingName as keyof WorkspaceStateSettings)) continue
-      const storedValue = settingName === 'allowBuilds'
-        ? workspaceState.settings[settingName] ?? {}
-        : workspaceState.settings[settingName as keyof WorkspaceStateSettings]
-      const currentValue = settingName === 'allowBuilds'
-        ? opts.allowBuilds ?? {}
-        : opts[settingName as keyof WorkspaceStateSettings]
+      const settingKey = settingName as keyof WorkspaceStateSettings
+      const storedValue = normalizeUnsetSetting(settingKey, workspaceState.settings[settingKey])
+      const currentValue = normalizeUnsetSetting(settingKey, opts[settingKey])
       if (!equals(storedValue, currentValue)) {
         return {
           upToDate: false,
@@ -638,6 +635,30 @@ interface AssertWantedLockfileUpToDateContext {
   getWorkspacePackages: () => WorkspacePackages | undefined
   rootDir: string
   patchedDependencies?: Record<string, string>
+}
+
+/**
+ * Settings whose unset form means exactly what a concrete value means.
+ *
+ * The workspace state only records settings that were configured, so a
+ * setting left at its default has no key in the state file. The resolved
+ * config, on the other hand, may carry the value the default resolves to:
+ * `@pnpm/config.reader` writes `enableGlobalVirtualStore: false` when `ci`
+ * is set, and reading `allowBuilds` yields `{}`. Comparing the two forms
+ * raw reports a change where nothing changed — a `pnpm install` outside CI
+ * followed by a `pnpm run` under `CI=true` (or the reverse) reinstalls from
+ * scratch on every switch.
+ *
+ * pacquet normalizes the same two settings before comparing, in
+ * `enable_global_virtual_store_match` and `allow_builds_match`.
+ */
+const SETTING_UNSET_EQUIVALENTS: Partial<Record<keyof WorkspaceStateSettings, unknown>> = {
+  allowBuilds: {},
+  enableGlobalVirtualStore: false,
+}
+
+function normalizeUnsetSetting (settingName: keyof WorkspaceStateSettings, value: unknown): unknown {
+  return value ?? SETTING_UNSET_EQUIVALENTS[settingName]
 }
 
 interface AssertWantedLockfileUpToDateOptions {

--- a/pnpm11/deps/status/test/checkDepsStatus.test.ts
+++ b/pnpm11/deps/status/test/checkDepsStatus.test.ts
@@ -319,6 +319,68 @@ describe('checkDepsStatus - settings change detection', () => {
     expect(result.upToDate).toBe(false)
     expect(result.issue).toBe('The value of the enableGlobalVirtualStore setting has changed')
   })
+
+  it('does not report a change when an unrecorded enableGlobalVirtualStore meets the false CI resolves it to', async () => {
+    // An install outside CI leaves the setting unset, so the state file has no
+    // key for it. Under `CI=true`, config resolution fills in the `false` the
+    // setting already defaulted to. Both mean "global virtual store off".
+    const lastValidatedTimestamp = Date.now() - 10_000
+    const mockWorkspaceState: WorkspaceState = {
+      lastValidatedTimestamp,
+      pnpmfiles: [],
+      settings: {
+        excludeLinksFromLockfile: false,
+        linkWorkspacePackages: true,
+        preferWorkspacePackages: true,
+      },
+      projects: {},
+      filteredInstall: false,
+    }
+
+    jest.mocked(loadWorkspaceState).mockReturnValue(mockWorkspaceState)
+
+    const opts: CheckDepsStatusOptions = {
+      rootProjectManifest: {},
+      rootProjectManifestDir: '/project',
+      pnpmfile: [],
+      ...mockWorkspaceState.settings,
+      enableGlobalVirtualStore: false,
+    }
+    const result = await checkDepsStatus(opts)
+
+    expect(result.issue).not.toBe('The value of the enableGlobalVirtualStore setting has changed')
+  })
+
+  it('does not report a change when a state file recorded enableGlobalVirtualStore: false and the setting is now unset', async () => {
+    // The reverse direction: the CI install records `false`, and the next run
+    // outside CI resolves the setting to `undefined`.
+    const lastValidatedTimestamp = Date.now() - 10_000
+    const mockWorkspaceState: WorkspaceState = {
+      lastValidatedTimestamp,
+      pnpmfiles: [],
+      settings: {
+        excludeLinksFromLockfile: false,
+        linkWorkspacePackages: true,
+        preferWorkspacePackages: true,
+        enableGlobalVirtualStore: false,
+      },
+      projects: {},
+      filteredInstall: false,
+    }
+
+    jest.mocked(loadWorkspaceState).mockReturnValue(mockWorkspaceState)
+
+    const opts: CheckDepsStatusOptions = {
+      rootProjectManifest: {},
+      rootProjectManifestDir: '/project',
+      pnpmfile: [],
+      ...mockWorkspaceState.settings,
+      enableGlobalVirtualStore: undefined,
+    }
+    const result = await checkDepsStatus(opts)
+
+    expect(result.issue).not.toBe('The value of the enableGlobalVirtualStore setting has changed')
+  })
 })
 
 describe('checkDepsStatus - pnpmfile modification', () => {


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#12337.

`verifyDepsBeforeRun` runs a full `pnpm install` before every `pnpm run` whenever a `node_modules` installed outside CI is used with `CI=true`, and again in the reverse direction.

The workspace state records only the settings that were configured, so an install that never set `enableGlobalVirtualStore` writes no key for it. Config resolution does set it, to `false`, whenever `ci` is on (*"Using a global virtual store in CI makes little sense"*). The settings loop in `checkDepsStatus` compared the two forms raw, so `undefined !== false` became `The value of the enableGlobalVirtualStore setting has changed`.

Both forms mean the same thing: the setting has no default coercion anywhere, and every read site treats a missing value as off.

The hard failure in the report is a dev container that bakes `node_modules` into the image (the build has no `CI` env) and runs as a non-root user with `CI=true`. The spurious auto-install cannot delete the root-owned directory:

```
Recreating /app/node_modules
[EACCES] EACCES: permission denied, rmdir '/app/node_modules/.bin'
[ERROR] Command failed with exit code 243: pnpm install
```

Rebuilding does not help, because a non-CI install can never record the key.

## The fix

The loop already normalized one setting whose unset form is meaningful — `allowBuilds ?? {}`. This turns that into a small map and adds `enableGlobalVirtualStore: false` to it, so both sides of the comparison go through the same normalization.

A real `true`/`false` flip still reports drift, and so does a legacy state file that predates the key when the setting is turned **on** — both pinned by tests that were already there.

## Parity

**No pacquet-side change is needed: the Rust port already does this.** `enable_global_virtual_store_match` normalizes both forms, and its doc comment records the gap this PR closes:

> `enableGlobalVirtualStore` has no `?? default` coercion on pnpm's read side, but its `undefined` default and an explicit `false` both mean "global virtual store off". pnpm omits the key for the former and records `false` only when CI forces it; pacquet omits both.

So a state file written by pacquet already round-tripped; one written by pnpm did not.

## Verification

- `@pnpm/deps.status`: **63/63 pass**.
- Revert-checked: with `checkDepsStatus.ts` restored to `main` and the tests kept, **exactly the two new tests fail** and the other 61 pass.
- The two pre-existing `enableGlobalVirtualStore` tests (`true → false`, and `absent → true`) still pass unchanged — the normalization does not swallow a genuine flip.
- `tsgo --build`, `eslint` and `cspell` clean on the changed files.

Tested on Windows with `pnpm@11` for the workspace install: pnpm 12 cannot install this repository without Windows Developer Mode, because it creates real symlinks (`os error 1314`) for the global store, the project virtual store and `--node-linker=hoisted` alike. Happy to file that separately if it is not already known.

## Squash Commit Body

```text
The workspace state records only the settings that were configured, so an
install that never set `enableGlobalVirtualStore` writes no key for it.
Config resolution does set it, to `false`, whenever `ci` is on. The
settings comparison in `checkDepsStatus` compared the two forms raw,
reported "The value of the enableGlobalVirtualStore setting has changed",
and `verifyDepsBeforeRun` reinstalled from scratch — on every switch
between a CI and a non-CI environment, in both directions. A dev
container that bakes `node_modules` into the image and runs as a non-root
user with `CI=true` cannot survive that install: it fails with EACCES
trying to delete the root-owned directory.

Normalize a setting's unset form to the value it means before comparing,
next to the `allowBuilds ?? {}` case that already did exactly this. A
real `true`/`false` flip still reports drift, and so does the legacy
state file that predates the key when the setting is turned on.

pacquet already normalizes both settings this way, in
`enable_global_virtual_store_match` and `allow_builds_match`, and its doc
comment records that pnpm's read side lacks the coercion. This brings the
TypeScript CLI up to the Rust port rather than changing shared behavior,
so no pacquet-side change is needed.

Closes pnpm/pnpm#12337
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it. (The issue has no linked PRs at all.)
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (TypeScript-only: pacquet already has the behaviour — see Parity above.)
- [x] Added a changeset (`pnpm changeset`).
- [x] Added or updated tests.
- [x] Updated the documentation if needed. (No user-facing setting changed.)

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14123"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790149975&installation_model_id=426870&pr_number=14123&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14123&signature=eaacd5946a14dfd9c4a1d55ad2e76fd5595f5c6b47524949c7c1cf4c0d908e27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented equivalent unset and `false` dependency settings from being incorrectly reported as configuration changes.
  * Fixed unnecessary dependency reinstalls during `pnpm run` when installation and execution differ in CI status.

* **Tests**
  * Added coverage for dependency-setting comparisons involving unset and `false` values.

* **Documentation**
  * Documented the patch-level fixes for dependency status checks and command execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->