### PR TITLE
fix(config): classify confirmModulesPurge across pnpm versions

### DIFF
--- a/.changeset/confirm-modules-purge-setting.md
+++ b/.changeset/confirm-modules-purge-setting.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config.reader": patch
+"pnpm": patch
+---
+
+Fixed a warning that incorrectly reported `confirmModulesPurge` as unrecognized when it was set in `pnpm-workspace.yaml`.

--- a/.changeset/confirm-modules-purge-setting.md
+++ b/.changeset/confirm-modules-purge-setting.md
@@ -1,6 +1,7 @@
 ---
 "@pnpm/config.reader": patch
+"pacquet": patch
 "pnpm": patch
 ---
 
-Fixed a warning that incorrectly reported `confirmModulesPurge` as unrecognized when it was set in `pnpm-workspace.yaml`.
+Fixed pnpm v11 incorrectly reporting `confirmModulesPurge` as unrecognized when set in `pnpm-workspace.yaml`. The Rust CLI now identifies the unsupported option as a pnpm v11 setting instead of suggesting an unrelated setting.

--- a/pnpm/crates/config/src/known_settings.rs
+++ b/pnpm/crates/config/src/known_settings.rs
@@ -103,6 +103,8 @@ const UNTYPED_WORKSPACE_SETTING_KEYS: &[&str] = &[
     "onlyBuiltDependenciesFile",
 ];
 
+const SETTINGS_OF_OTHER_PNPM_VERSIONS: &[(&str, &str)] = &[("confirmModulesPurge", "pnpm v11")];
+
 /// The camelCase field names of [`WorkspaceSettings`], read off its serde
 /// serialization so the set cannot drift from the struct.
 fn settings_field_keys() -> &'static HashSet<String> {
@@ -155,6 +157,11 @@ pub fn is_known_setting_key(key: &str) -> bool {
 #[must_use]
 pub fn annotate_unknown_setting(key: &str) -> String {
     let camel = to_camel_case(key);
+    if let Some((_, version)) =
+        SETTINGS_OF_OTHER_PNPM_VERSIONS.iter().find(|(setting, _)| *setting == camel)
+    {
+        return format!(r#""{key}" (a {version} setting)"#);
+    }
     match did_you_mean(&camel, known_setting_keys_sorted().iter().map(String::as_str)) {
         Some(suggestion) => format!(r#""{key}" (did you mean "{suggestion}"?)"#),
         None => format!(r#""{key}""#),

--- a/pnpm/crates/config/src/known_settings/tests.rs
+++ b/pnpm/crates/config/src/known_settings/tests.rs
@@ -38,6 +38,14 @@ fn annotates_a_typo_with_the_closest_setting() {
 }
 
 #[test]
+fn annotates_a_setting_from_another_pnpm_version() {
+    assert_eq!(
+        annotate_unknown_setting("confirmModulesPurge"),
+        r#""confirmModulesPurge" (a pnpm v11 setting)"#,
+    );
+}
+
+#[test]
 fn annotates_an_unmatchable_key_bare() {
     assert_eq!(annotate_unknown_setting("zzzXqjWv"), r#""zzzXqjWv""#);
 }

--- a/pnpm11/config/reader/src/unknownSettings.ts
+++ b/pnpm11/config/reader/src/unknownSettings.ts
@@ -96,11 +96,12 @@ const CONFIG_ONLY_SETTING_KEYS = [
 ] as const satisfies ReadonlyArray<keyof ConfigWithDeprecatedSettings>
 
 /**
- * Recognized keys that have no field on {@link WorkspaceManifest} or
- * {@link ConfigWithDeprecatedSettings}: the legacy build policies
- * `pnpm approve-builds` migrates into `allowBuilds`, and `executionEnv`.
+ * Recognized workspace keys that have no field on {@link WorkspaceManifest}
+ * or {@link ConfigWithDeprecatedSettings}: install-only settings and the
+ * legacy build policies `pnpm approve-builds` migrates into `allowBuilds`.
  */
 const UNTYPED_WORKSPACE_SETTING_KEYS = [
+  'confirmModulesPurge',
   'executionEnv',
   'ignoredBuiltDependencies',
   'neverBuiltDependencies',

--- a/pnpm11/config/reader/src/unknownSettings.ts
+++ b/pnpm11/config/reader/src/unknownSettings.ts
@@ -95,11 +95,6 @@ const CONFIG_ONLY_SETTING_KEYS = [
   'workspacePrefix',
 ] as const satisfies ReadonlyArray<keyof ConfigWithDeprecatedSettings>
 
-/**
- * Recognized workspace keys that have no field on {@link WorkspaceManifest}
- * or {@link ConfigWithDeprecatedSettings}: install-only settings and the
- * legacy build policies `pnpm approve-builds` migrates into `allowBuilds`.
- */
 const UNTYPED_WORKSPACE_SETTING_KEYS = [
   'confirmModulesPurge',
   'executionEnv',

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -1000,6 +1000,21 @@ describe("a project's pnpm-workspace.yaml cannot redirect where pnpm reads and w
     expect((config as unknown as Record<string, unknown>)['zzzNotASettingZzz']).toBe(true)
   })
 
+  test('confirmModulesPurge is recognized in pnpm-workspace.yaml', async () => {
+    prepareEmpty()
+
+    writeYamlFileSync('pnpm-workspace.yaml', { confirmModulesPurge: false })
+
+    const { config, warnings } = await getConfig({
+      cliOptions: {},
+      packageManager: { name: 'pnpm', version: '1.0.0' },
+      workspaceDir: process.cwd(),
+    })
+
+    expect((config as unknown as Record<string, unknown>)['confirmModulesPurge']).toBe(false)
+    expect(warnings).not.toContainEqual(expect.stringContaining('confirmModulesPurge'))
+  })
+
   test('a null-valued key sets nothing, so it is not reported', async () => {
     prepareEmpty()
 


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Fixes pnpm/pnpm#14125.

- Registers `confirmModulesPurge` as a recognized untyped pnpm v11 workspace setting, matching the value already consumed by the install command.
- Adds a v11 regression test that verifies the setting remains available to install and produces no unknown-setting warning.
- Keeps pacquet's warning because its install flow does not implement `confirmModulesPurge`, but identifies the key as a pnpm v11 setting instead of suggesting the unrelated `enableModulesDir` setting.
- Audits the typed config/workspace keys and command-only options; no other missing pnpm v11 workspace setting was found.

The remaining behavior port for `confirmModulesPurge` in pacquet is outside this bug fix. The canonical settings documentation is maintained in `pnpm/pnpm.io`, so no in-repository settings reference is changed here.

## Squash Commit Body

```text
The pnpm v11 workspace-setting validator classified confirmModulesPurge as unknown because this install-only option intentionally sits outside Config and WorkspaceManifest. Register it in the explicit untyped workspace-setting list so pnpm v11 no longer warns that the working setting was ignored.

Pacquet does not implement confirmModulesPurge, so it should continue warning that the key is ignored. Record the key in pacquet's cross-version setting table so its diagnostic names pnpm v11 instead of suggesting enableModulesDir.

Closes pnpm/pnpm#14125.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an incorrect warning indicating that `confirmModulesPurge` was an unrecognized workspace setting.
  * The setting is now correctly read from `pnpm-workspace.yaml`.
  * Settings introduced in a different pnpm version now provide clearer version-specific guidance when encountered.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->