### PR TITLE
fix(pm): drop the statically detected phantom compat entries

### DIFF
--- a/.changeset/drop-static-analysis-compat-entries.md
+++ b/.changeset/drop-static-analysis-compat-entries.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+The built-in compatibility database no longer adds dependencies that were detected by static analysis of published packages. Those entries named packages that are only imported for their types, so installing them was at best unnecessary and at worst broke the dependent: `@typescript-eslint/types` gained a `typescript` dependency resolved to the newest release, which put TypeScript 7 under older `@typescript-eslint` versions and made ESLint fail with "Cannot read properties of undefined (reading 'Intrinsic')". The database keeps its `@yarnpkg/extensions` entries and pnpm's own curated ones.

--- a/pnpm/crates/package-manager/src/compat_package_extensions.rs
+++ b/pnpm/crates/package-manager/src/compat_package_extensions.rs
@@ -33,9 +33,8 @@ use pnpm_config::{PackageExtension, PeerDependencyMeta};
 use std::{collections::BTreeMap, sync::LazyLock};
 
 // `pnpm_compat_package_extensions.json` holds pnpm-specific entries not in
-// `@yarnpkg/extensions`: the original three from the TypeScript CLI's
-// `pnpmCompatPackageExtensions`, plus phantom-dependency findings detected
-// by static analysis of published npm packages.
+// `@yarnpkg/extensions`. It must stay identical to the TypeScript CLI's
+// `pnpmCompatPackageExtensions`.
 static COMPAT_PACKAGE_EXTENSIONS: LazyLock<IndexMap<String, PackageExtension>> =
     LazyLock::new(|| {
         let mut extensions = IndexMap::new();

--- a/pnpm/crates/package-manager/src/compat_package_extensions/tests.rs
+++ b/pnpm/crates/package-manager/src/compat_package_extensions/tests.rs
@@ -25,53 +25,18 @@ fn includes_pnpm_specific_compat_entries() {
     );
 }
 
-/// Verify the phantom-dependency entries detected by static analysis of
-/// the top-500 most-downloaded npm packages. Each entry declares a
-/// dependency the package imports but doesn't declare in its package.json -
-/// a phantom that resolves under npm's flat layout but breaks under a
-/// strict resolver. Only phantoms that are installable packages belong
-/// here: a type-only import satisfied by a `@types/*` package (like
-/// eslint's `estree`) names no npm package at all, and an entry for it
-/// makes every fresh resolve of the extended package fail with a 404.
+/// Compat entries must not inject `estree` — no such npm package exists,
+/// the import that names it is type-only and satisfied by `@types/estree` —
+/// nor a single-instance runtime like `typescript`, `react`, or `eslint`,
+/// where a second copy in the graph breaks the tools that load it.
 #[test]
-fn includes_phantom_dependency_entries() {
-    let assert_dep = |selector: &str, target: &str| {
-        let entry = COMPAT_PACKAGE_EXTENSIONS
-            .get(selector)
-            .unwrap_or_else(|| panic!("phantom entry {selector} missing"));
-        let dep = entry
-            .dependencies
-            .as_ref()
-            .and_then(|deps| deps.get(target))
-            .unwrap_or_else(|| panic!("phantom target {target} missing from {selector}"));
-        assert_eq!(dep, "*");
-    };
-
-    assert_dep("@eslint/core@*", "json-schema");
-    assert_dep("@eslint/eslintrc@*", "eslint");
-    assert_dep("@jest/types@*", "istanbul-lib-coverage");
-    assert_dep("@jest/types@*", "istanbul-reports");
-    assert_dep("@jest/types@*", "yargs");
-    assert_dep("@types/babel__core@*", "@babel/generator");
-    assert_dep("@types/babel__core@*", "@babel/template");
-    assert_dep("@types/babel__core@*", "@babel/traverse");
-    assert_dep("@types/react-dom@*", "react");
-    assert_dep("@types/yargs@*", "yargs-parser");
-    assert_dep("@typescript-eslint/types@*", "typescript");
-    assert_dep("es-abstract@*", "for-each");
-}
-
-/// The phantom findings must never name a target that is not an
-/// installable npm package. `estree` is a type-only import whose types
-/// live in `@types/estree` — there is no runtime package behind it, so
-/// an entry targeting it makes every fresh resolve of the extended
-/// package fail with a 404.
-#[test]
-fn phantom_entries_never_target_estree() {
-    for (selector, extension) in COMPAT_PACKAGE_EXTENSIONS.iter() {
-        assert!(
-            extension.dependencies.as_ref().is_none_or(|deps| !deps.contains_key("estree")),
-            "{selector} must not depend on the nonexistent estree package",
-        );
+fn compat_entries_never_inject_type_only_or_singleton_packages() {
+    for target in ["estree", "typescript", "react", "eslint"] {
+        for (selector, extension) in COMPAT_PACKAGE_EXTENSIONS.iter() {
+            assert!(
+                extension.dependencies.as_ref().is_none_or(|deps| !deps.contains_key(target)),
+                "{selector} must not inject a {target} dependency",
+            );
+        }
     }
 }

--- a/pnpm/crates/package-manager/src/pnpm_compat_package_extensions.json
+++ b/pnpm/crates/package-manager/src/pnpm_compat_package_extensions.json
@@ -8,32 +8,6 @@
     }
   ],
   [
-    "@eslint/core@*",
-    {
-      "dependencies": {
-        "json-schema": "*"
-      }
-    }
-  ],
-  [
-    "@eslint/eslintrc@*",
-    {
-      "dependencies": {
-        "eslint": "*"
-      }
-    }
-  ],
-  [
-    "@jest/types@*",
-    {
-      "dependencies": {
-        "istanbul-lib-coverage": "*",
-        "istanbul-reports": "*",
-        "yargs": "*"
-      }
-    }
-  ],
-  [
     "@nuxt/vite-builder@>=4.0.0 <4.5.0",
     {
       "dependencies": {
@@ -46,48 +20,6 @@
     {
       "dependencies": {
         "unplugin": "^3.3.0"
-      }
-    }
-  ],
-  [
-    "@types/babel__core@*",
-    {
-      "dependencies": {
-        "@babel/generator": "*",
-        "@babel/template": "*",
-        "@babel/traverse": "*"
-      }
-    }
-  ],
-  [
-    "@types/react-dom@*",
-    {
-      "dependencies": {
-        "react": "*"
-      }
-    }
-  ],
-  [
-    "@types/yargs@*",
-    {
-      "dependencies": {
-        "yargs-parser": "*"
-      }
-    }
-  ],
-  [
-    "@typescript-eslint/types@*",
-    {
-      "dependencies": {
-        "typescript": "*"
-      }
-    }
-  ],
-  [
-    "es-abstract@*",
-    {
-      "dependencies": {
-        "for-each": "*"
       }
     }
   ]


### PR DESCRIPTION
## Summary

`pnpm/pnpm#13970` did two things: it synced `compat_package_extensions.json` to the
latest `@yarnpkg/extensions`, and it added ten dependency additions found by
static analysis of published packages to `pnpm_compat_package_extensions.json`.
This PR keeps the first half and drops the second.

The analysis counted **type-only** imports, which name no runtime dependency.
Two of the ten targeted `estree`, which is not a package on the registry at all,
and had to be reverted in `pnpm/pnpm#13981` because every fresh resolve of `eslint`
404'd. The remaining eight are the same mistake in a form that resolves: they
name packages the extended package needs only to type-check, usually through an
already-declared `@types/*` counterpart.

Installing them is at best dead weight — every `@jest/types` install pulled in
`yargs` and `istanbul-reports`, which `@jest/types` only references from a
`.d.ts` via its declared `@types/yargs` and `@types/istanbul-reports`. At worst
it breaks the dependent, because each target was requested as `*` and so
resolved to the newest release:

| Entry | Problem |
| --- | --- |
| `@typescript-eslint/types@* → typescript` | `@typescript-eslint/types` declares no dependencies; its only reference to typescript is `import type { Program } from 'typescript'` in `dist/parser-options.d.ts`. The injected node put TypeScript 7 under `@typescript-eslint` 6, where `ts-api-utils@1` fails with `Cannot read properties of undefined (reading 'Intrinsic')`. |
| `@eslint/eslintrc@* → eslint` | Installs a second, latest-major ESLint underneath eslintrc. Duplicate ESLint instances break plugin and config loading. |
| `@types/react-dom@* → react` | Type-only, and React is the canonical single-instance runtime; `*` pulls the newest major under old react-dom types. |
| `@eslint/core@* → json-schema` | Wrong package: the types come from `@types/json-schema`. |
| `@jest/types@* → istanbul-lib-coverage, istanbul-reports, yargs` | All three are declared as their `@types/*` counterparts already. |
| `@types/yargs@* → yargs-parser`, `@types/babel__core@* → @babel/*` | Type-only imports inside `@types` packages. |
| `es-abstract@* → for-each` | The one genuine runtime phantom of the batch (`2025/EncodeForRegExpEscape.js` does `require('for-each')`). Dropped with the rest so the file returns to a curated state; it can come back as its own verified entry landing in both stacks. |

This restores `pnpm_compat_package_extensions.json` to the three curated entries,
which makes it identical to the TypeScript CLI's `pnpmCompatPackageExtensions`
again — the ten additions had landed in pacquet only, so the two stacks had
silently diverged.

The `@yarnpkg/extensions` sync is kept: the synced file matches
`@yarnpkg/extensions@2.0.7` selector-for-selector, which is exactly the version
the TypeScript CLI installs. Reverting it would re-stale pacquet's vendored copy
at 150 of 159 entries and reintroduce a divergence.

Reported for `teambit/bit`, where `bit sign` started failing after Bit moved from
`@pnpm/napi` rc.5 to rc.7.

Related to pnpm/pnpm#13970, pnpm/pnpm#13981.

## Squash Commit Body

```text
The compatibility database gained ten dependency additions found by
static analysis of published packages (pnpm/pnpm#13970). The analysis
counted type-only imports, which name no runtime dependency: two of the
ten targeted `estree`, a package that does not exist on the registry
(pnpm/pnpm#13981), and the rest name packages the extended package needs
only to type-check, usually through an already-declared `@types/*`
counterpart.

Installing them is at best dead weight - every `@jest/types` install
pulled in yargs and istanbul-reports - and at worst breaks the
dependent, because each target was requested as `*` and resolved to the
newest release. `@typescript-eslint/types` gained a `typescript`
dependency, putting TypeScript 7 under `@typescript-eslint` 6, where
`ts-api-utils` fails with "Cannot read properties of undefined (reading
'Intrinsic')". `@eslint/eslintrc` gained an `eslint` dependency and
`@types/react-dom` a `react` one, each duplicating a runtime whose
consumers assume a single instance.

Restores `pnpm_compat_package_extensions.json` to the three curated
entries, matching the TypeScript CLI's `pnpmCompatPackageExtensions`
again, and keeps the `@yarnpkg/extensions` sync from the same commit -
that half tracks upstream's curated database and matches the
`@yarnpkg/extensions` version the TypeScript CLI installs. A test pins
that no entry may inject `estree` or a single-instance runtime.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (The dropped entries only ever existed in the Rust port; removing them is
  what restores parity.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790161298&installation_model_id=426870&pr_number=14128&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14128&signature=451477db475a550acf3b3d2418c0e416f0914c00b3ac8c1e8defe27f48a51cdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated package compatibility handling by removing outdated automatically generated compatibility entries.
  * Reduced unsupported dependency injection for common TypeScript, ESLint, React, Jest, and Babel packages.
  * Dependency resolution now relies on curated compatibility data, improving accuracy while exposing genuine incompatibilities such as TypeScript 7 with older ESLint tooling.

* **Documentation**
  * Added release documentation describing the compatibility-data changes and their potential dependency-resolution impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->