### PR TITLE
fix(install): stop --frozen-lockfile rejecting a package-manager pin it agrees with

### DIFF
--- a/.changeset/corepack-build-in-a-dev-engines-pin.md
+++ b/.changeset/corepack-build-in-a-dev-engines-pin.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Ignore the `+<algorithm>.<hash>` build corepack appends when it is written into a `devEngines.packageManager` version. The hash identifies corepack's download rather than a pnpm release, so the version resolved for it never carried one: the lockfile entry could never match its own pin, and `pnpm install --frozen-lockfile` failed with `ERR_PNPM_FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE` on a lockfile that a plain install rewrote identically on every run [#14124](https://github.com/pnpm/pnpm/issues/14124).
+A `+<algorithm>.<hash>` build in a `devEngines.packageManager` version no longer makes `pnpm install --frozen-lockfile` fail with `ERR_PNPM_FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE` on a lockfile a plain install kept rewriting identically [#14124](https://github.com/pnpm/pnpm/issues/14124).

--- a/.changeset/corepack-build-in-a-dev-engines-pin.md
+++ b/.changeset/corepack-build-in-a-dev-engines-pin.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Ignore the `+<algorithm>.<hash>` build corepack appends when it is written into a `devEngines.packageManager` version. The hash identifies corepack's download rather than a pnpm release, so the version resolved for it never carried one: the lockfile entry could never match its own pin, and `pnpm install --frozen-lockfile` failed with `ERR_PNPM_FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE` on a lockfile that a plain install rewrote identically on every run [#14124](https://github.com/pnpm/pnpm/issues/14124).

--- a/.changeset/frozen-lockfile-package-manager-repair.md
+++ b/.changeset/frozen-lockfile-package-manager-repair.md
@@ -1,0 +1,6 @@
+---
+"pacquet": patch
+"pnpm": patch
+---
+
+Don't fail `--frozen-lockfile` when the pinned pnpm version recorded in `pnpm-lock.yaml` has to be re-resolved only because an earlier pnpm wrote its resolutions with tarball URLs. Those entries already record the version the manifest pins, so they are now re-resolved in memory and the lockfile is left untouched, instead of failing with `ERR_PNPM_FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE` [#14124](https://github.com/pnpm/pnpm/issues/14124).

--- a/.changeset/frozen-lockfile-package-manager-repair.md
+++ b/.changeset/frozen-lockfile-package-manager-repair.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-Don't fail `--frozen-lockfile` when the pinned pnpm version recorded in `pnpm-lock.yaml` has to be re-resolved only because an earlier pnpm wrote its resolutions with tarball URLs. Those entries already record the version the manifest pins, so they are now re-resolved in memory and the lockfile is left untouched, instead of failing with `ERR_PNPM_FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE` [#14124](https://github.com/pnpm/pnpm/issues/14124).
+`pnpm install --frozen-lockfile` no longer fails with `ERR_PNPM_FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE` when the pinned pnpm version recorded in `pnpm-lock.yaml` has to be re-resolved before it can be installed. It runs the pnpm version the lockfile pins and leaves the lockfile unchanged [#14124](https://github.com/pnpm/pnpm/issues/14124).

--- a/.changeset/record-package-manager-pin-on-fast-path.md
+++ b/.changeset/record-package-manager-pin-on-fast-path.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Record the pnpm version a project pins even when the install has nothing else to do. Adding a `devEngines.packageManager` (or `packageManager`) pin to a project whose dependencies are already installed left `packageManagerDependencies` unwritten, so `pnpm install --frozen-lockfile` failed with `ERR_PNPM_FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE` while a plain `pnpm install` kept reporting "Already up to date" without fixing it [#14124](https://github.com/pnpm/pnpm/issues/14124).
+Record the pnpm version a project pins even when the install has nothing else to do. Adding a `devEngines.packageManager` (or `packageManager`) pin to a project whose dependencies are already installed left `packageManagerDependencies` unwritten, so `pnpm install --frozen-lockfile` failed with `ERR_PNPM_FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE` while a plain `pnpm install` reported "Already up to date" without recording it [#14124](https://github.com/pnpm/pnpm/issues/14124).

--- a/.changeset/record-package-manager-pin-on-fast-path.md
+++ b/.changeset/record-package-manager-pin-on-fast-path.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Record the pnpm version a project pins even when the install has nothing else to do. Adding a `devEngines.packageManager` (or `packageManager`) pin to a project whose dependencies are already installed left `packageManagerDependencies` unwritten, so `pnpm install --frozen-lockfile` failed with `ERR_PNPM_FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE` while a plain `pnpm install` kept reporting "Already up to date" without fixing it [#14124](https://github.com/pnpm/pnpm/issues/14124).

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -3,7 +3,8 @@ use crate::{
     cli_args::{
         legacy_pnpm_field::warn_ignored_pnpm_manifest_fields_in, lockfile_dir::LockfileDirArg,
         override_version_references::warn_deprecated_override_version_references,
-        pipelines::InstallFamilySelection, recursive::discover_workspace_projects,
+        package_manager::package_manager_needs_recording, pipelines::InstallFamilySelection,
+        recursive::discover_workspace_projects,
         supported_architectures::SupportedArchitecturesArgs,
     },
 };
@@ -387,6 +388,9 @@ impl InstallArgs {
             return false;
         }
         let config_root = config.root_project_manifest_dir(dir).to_path_buf();
+        if package_manager_needs_recording(&config_root, config.pm_on_fail) {
+            return false;
+        }
         if !pnpm_hooks::finder::find_pnpmfiles(
             &config_root,
             pnpm_package_manager::pnpmfile_selection(config),

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -388,9 +388,6 @@ impl InstallArgs {
             return false;
         }
         let config_root = config.root_project_manifest_dir(dir).to_path_buf();
-        if package_manager_needs_recording(&config_root, config.pm_on_fail) {
-            return false;
-        }
         if !pnpm_hooks::finder::find_pnpmfiles(
             &config_root,
             pnpm_package_manager::pnpmfile_selection(config),
@@ -406,6 +403,14 @@ impl InstallArgs {
         let Ok(manifest) = pnpm_package_manifest::PackageManifest::from_path(manifest_path) else {
             return false;
         };
+        // The pin reaches the lockfile from the install pipeline, which this
+        // short-circuit returns before. This manifest is the root one unless
+        // a workspace or `lockfileDir` put the root elsewhere, in which case
+        // the check reads that one.
+        let root_manifest = (config_root == dir).then(|| manifest.value());
+        if package_manager_needs_recording(&config_root, config.pm_on_fail, root_manifest) {
+            return false;
+        }
         let node_linker = self.node_linker.map_or(config.node_linker, NodeLinkerArg::into_config);
         let Some(up_to_date) = install_already_up_to_date(&UpToDateFastPathCheck {
             config,

--- a/pnpm/crates/cli/src/cli_args/package_manager.rs
+++ b/pnpm/crates/cli/src/cli_args/package_manager.rs
@@ -68,13 +68,27 @@ pub(crate) fn package_manager_to_sync(
 /// reporting success while leaving every `--frozen-lockfile` run failing on
 /// the unwritten entry.
 ///
+/// `root_manifest` is that manifest when the caller already holds it, so a
+/// fast path does not read the same file twice.
+///
 /// A manifest that cannot be read answers `false`: the full install path
 /// reports that, and a fast path is not where it should surface.
-pub(crate) fn package_manager_needs_recording(root_dir: &Path, on_fail: Option<PmOnFail>) -> bool {
-    let Ok(Some(manifest)) = read_manifest_json(&root_dir.join("package.json")) else {
-        return false;
+pub(crate) fn package_manager_needs_recording(
+    root_dir: &Path,
+    on_fail: Option<PmOnFail>,
+    root_manifest: Option<&Value>,
+) -> bool {
+    let read;
+    let manifest = if let Some(manifest) = root_manifest {
+        manifest
+    } else {
+        let Ok(Some(manifest)) = read_manifest_json(&root_dir.join("package.json")) else {
+            return false;
+        };
+        read = manifest;
+        &read
     };
-    let Some(package_manager) = package_manager_to_sync(&manifest, root_dir, on_fail) else {
+    let Some(package_manager) = package_manager_to_sync(manifest, root_dir, on_fail) else {
         return false;
     };
     !EnvLockfile::read(root_dir).ok().flatten().is_some_and(|env_lockfile| {

--- a/pnpm/crates/cli/src/cli_args/package_manager.rs
+++ b/pnpm/crates/cli/src/cli_args/package_manager.rs
@@ -1,5 +1,7 @@
 use miette::IntoDiagnostic;
 use pnpm_config::PmOnFail;
+use pnpm_env_installer::is_package_manager_resolved;
+use pnpm_lockfile::EnvLockfile;
 use pnpm_package_manifest::{
     package_manager_spec::{
         dev_engines_package_managers, is_version_request, split_spec, version_without_build,
@@ -57,6 +59,31 @@ pub(crate) fn package_manager_to_sync(
     exact_version(wanted_version)
         .filter(|version| version_satisfies(version, wanted_version))
         .map(|version| PackageManagerToSync { specifier: wanted_version.to_string(), version })
+}
+
+/// Whether the pnpm version the manifest at `root_dir` pins still has to be
+/// recorded in the env lockfile there. The install family records it from
+/// its own pipeline, so an install that short-circuits before the pipeline
+/// has to give up its fast path — a plain install would otherwise keep
+/// reporting success while leaving every `--frozen-lockfile` run failing on
+/// the unwritten entry.
+///
+/// A manifest that cannot be read answers `false`: the full install path
+/// reports that, and a fast path is not where it should surface.
+pub(crate) fn package_manager_needs_recording(root_dir: &Path, on_fail: Option<PmOnFail>) -> bool {
+    let Ok(Some(manifest)) = read_manifest_json(&root_dir.join("package.json")) else {
+        return false;
+    };
+    let Some(package_manager) = package_manager_to_sync(&manifest, root_dir, on_fail) else {
+        return false;
+    };
+    !EnvLockfile::read(root_dir).ok().flatten().is_some_and(|env_lockfile| {
+        is_package_manager_resolved(
+            &env_lockfile,
+            &package_manager.specifier,
+            &package_manager.version,
+        )
+    })
 }
 
 pub(crate) fn read_manifest_json(path: &Path) -> miette::Result<Option<Value>> {
@@ -149,9 +176,16 @@ fn pnpm_version_from(root_dir: &Path) -> Option<String> {
     value.get("version").and_then(Value::as_str).map(ToString::to_string)
 }
 
+/// The one version `version` pins, or `None` when it pins a range, a
+/// dist-tag, or nothing at all.
+///
+/// The `+<algorithm>.<hash>` build corepack records the artifact it
+/// downloaded with is dropped: it names corepack's download, not a pnpm
+/// release, so the registry resolves the version without it and a lockfile
+/// entry that kept it would never match the version recorded beside it.
 pub(crate) fn exact_version(version: &str) -> Option<String> {
     let parsed = node_semver::Version::parse(version).ok()?;
-    (parsed.to_string() == version).then(|| version.to_string())
+    (parsed.to_string() == version).then(|| version_without_build(version).to_string())
 }
 
 pub(crate) fn version_satisfies(version: &str, wanted_range: &str) -> bool {
@@ -176,3 +210,6 @@ pub(crate) fn version_satisfies(version: &str, wanted_range: &str) -> bool {
     };
     base.satisfies(&range)
 }
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/cli_args/package_manager/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/package_manager/tests.rs
@@ -1,0 +1,40 @@
+use super::{package_manager_to_sync, wanted_package_manager};
+use pnpm_config::PNPM_VERSION;
+use std::path::Path;
+
+fn dev_engines_manifest(version: &str) -> serde_json::Value {
+    serde_json::json!({
+        "devEngines": {
+            "packageManager": { "name": "pnpm", "version": version, "onFail": "download" },
+        },
+    })
+}
+
+/// Corepack writes the artifact it downloaded as a build on the version it
+/// pins. The resolved version never carries it, so a pin that kept it would
+/// record a version no later run recognizes: every install would rewrite the
+/// same entry, and every `--frozen-lockfile` run would reject it.
+#[test]
+fn a_corepack_build_is_not_part_of_the_pinned_version() {
+    let manifest = dev_engines_manifest(&format!("{PNPM_VERSION}+sha512.0123456789abcdef"));
+
+    let pin = format!("{PNPM_VERSION}+sha512.0123456789abcdef");
+
+    let sync = package_manager_to_sync(&manifest, Path::new("."), None).expect("an entry to sync");
+
+    assert_eq!(sync.version, PNPM_VERSION);
+    // The specifier records the pin as the manifest writes it, the way the
+    // TypeScript CLI does — both stacks write the same lockfile.
+    assert_eq!(sync.specifier, pin);
+}
+
+/// A range is not a version, and its `+` (if any) is not corepack's.
+#[test]
+fn a_range_pin_is_left_as_written() {
+    let manifest = dev_engines_manifest(">=9.1.0 <9.1.2");
+
+    let pm = wanted_package_manager(&manifest).expect("a pinned package manager");
+
+    assert_eq!(pm.version.as_deref(), Some(">=9.1.0 <9.1.2"));
+    assert!(package_manager_to_sync(&manifest, Path::new("."), None).is_none());
+}

--- a/pnpm/crates/cli/src/cli_args/pre_command.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command.rs
@@ -152,10 +152,12 @@ async fn execute_switch(plan: SwitchPlan, child_argv: &[OsString]) -> miette::Re
                 .await?
                 .ok_or_else(|| miette::miette!(r#"Cannot resolve pnpm version for "{}""#, spec))?;
             if resolved.version == PNPM_VERSION {
-                if force_resync {
+                if force_resync && !frozen_lockfile {
                     // No switch to perform, but the recorded entries are
                     // invalid — heal them now or every later invocation
-                    // re-resolves over the network.
+                    // re-resolves over the network. A frozen lockfile cannot
+                    // be written, and nothing is installed here, so the
+                    // repair waits for a run that may write.
                     config_deps::sync_package_manager_dependencies(
                         config,
                         &env_root,

--- a/pnpm/crates/cli/src/cli_args/pre_command.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command.rs
@@ -147,11 +147,19 @@ async fn execute_switch(plan: SwitchPlan, child_argv: &[OsString]) -> miette::Re
             .await?;
             (version, bin_dir)
         }
-        SwitchSource::Resolve { env_root, frozen_lockfile, force_resync } => {
-            let resolved = config_deps::resolve_engine_version(config, "pnpm", &spec)
-                .await?
-                .ok_or_else(|| miette::miette!(r#"Cannot resolve pnpm version for "{}""#, spec))?;
-            if resolved.version == PNPM_VERSION {
+        SwitchSource::Resolve { env_root, frozen_lockfile, force_resync, locked_version } => {
+            let version = match locked_version.filter(|_| frozen_lockfile) {
+                Some(locked) => locked,
+                None => {
+                    config_deps::resolve_engine_version(config, "pnpm", &spec)
+                        .await?
+                        .ok_or_else(|| {
+                            miette::miette!(r#"Cannot resolve pnpm version for "{}""#, spec)
+                        })?
+                        .version
+                }
+            };
+            if version == PNPM_VERSION {
                 if force_resync && !frozen_lockfile {
                     // No switch to perform, but the recorded entries are
                     // invalid — heal them now or every later invocation
@@ -162,7 +170,7 @@ async fn execute_switch(plan: SwitchPlan, child_argv: &[OsString]) -> miette::Re
                         config,
                         &env_root,
                         &spec,
-                        &resolved.version,
+                        &version,
                         frozen_lockfile,
                         true,
                     )
@@ -170,18 +178,18 @@ async fn execute_switch(plan: SwitchPlan, child_argv: &[OsString]) -> miette::Re
                 }
                 return Ok(false);
             }
-            assert_release_is_installable(&resolved.version)?;
+            assert_release_is_installable(&version)?;
             let bin_dir = Box::pin(install_engine_to_store::<SilentReporter>(
                 config,
                 PackageManager::Pnpm,
                 &env_root,
                 &spec,
-                &resolved.version,
+                &version,
                 frozen_lockfile,
                 force_resync,
             ))
             .await?;
-            (resolved.version, bin_dir)
+            (version, bin_dir)
         }
     };
 
@@ -705,6 +713,7 @@ fn switch_target(
                 env_root: root_dir.to_path_buf(),
                 frozen_lockfile,
                 force_resync: true,
+                locked_version: Some(version),
             },
         }));
     }
@@ -724,7 +733,12 @@ fn switch_target(
     };
     Ok(Some(SwitchTarget {
         spec,
-        source: SwitchSource::Resolve { env_root, frozen_lockfile, force_resync: false },
+        source: SwitchSource::Resolve {
+            env_root,
+            frozen_lockfile,
+            force_resync: false,
+            locked_version: None,
+        },
     }))
 }
 
@@ -1004,6 +1018,11 @@ enum SwitchSource {
         /// entries failed the bootstrap validation, so the resync heals the
         /// env lockfile instead of no-op'ing on the invalid entries.
         force_resync: bool,
+        /// The version those invalid entries record. A frozen lockfile
+        /// cannot record a fresh pick, so the repair re-resolves this
+        /// version rather than the range around it — the switch then runs
+        /// the pnpm the lockfile pins, which is what the flag is for.
+        locked_version: Option<String>,
     },
 }
 

--- a/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
@@ -461,12 +461,17 @@ fn switch_target_discards_package_manager_lockfile_resolution_with_non_integrity
     let target =
         switch_target(&Config::default(), root.path(), false).expect("target").expect("switch");
 
-    let SwitchSource::Resolve { env_root, frozen_lockfile: false, force_resync: true } =
-        target.source
+    let SwitchSource::Resolve {
+        env_root,
+        frozen_lockfile: false,
+        force_resync: true,
+        locked_version,
+    } = target.source
     else {
         panic!("expected a forced re-resolve, got {:?}", target.source);
     };
     assert_eq!(env_root, root.path());
+    assert_eq!(locked_version.as_deref(), Some("9.3.0"));
 }
 
 #[test]
@@ -478,12 +483,17 @@ fn switch_target_discards_package_manager_lockfile_dependency_with_non_registry_
     let target =
         switch_target(&Config::default(), root.path(), false).expect("target").expect("switch");
 
-    let SwitchSource::Resolve { env_root, frozen_lockfile: false, force_resync: true } =
-        target.source
+    let SwitchSource::Resolve {
+        env_root,
+        frozen_lockfile: false,
+        force_resync: true,
+        locked_version,
+    } = target.source
     else {
         panic!("expected a forced re-resolve, got {:?}", target.source);
     };
     assert_eq!(env_root, root.path());
+    assert_eq!(locked_version.as_deref(), Some("9.3.0"));
 }
 
 #[test]
@@ -496,8 +506,12 @@ fn switch_target_reresolves_when_locked_version_no_longer_satisfies_range() {
         switch_target(&Config::default(), root.path(), false).expect("target").expect("switch");
 
     assert_eq!(target.spec, ">=9.1.2 <9.1.4");
-    let SwitchSource::Resolve { env_root, frozen_lockfile: false, force_resync: false } =
-        target.source
+    let SwitchSource::Resolve {
+        env_root,
+        frozen_lockfile: false,
+        force_resync: false,
+        locked_version: None,
+    } = target.source
     else {
         panic!("expected resolve target");
     };
@@ -518,8 +532,12 @@ fn switch_target_uses_global_env_for_legacy_package_manager_field() {
     .expect("target")
     .expect("switch");
 
-    let SwitchSource::Resolve { env_root, frozen_lockfile: false, force_resync: false } =
-        target.source
+    let SwitchSource::Resolve {
+        env_root,
+        frozen_lockfile: false,
+        force_resync: false,
+        locked_version: None,
+    } = target.source
     else {
         panic!("expected resolve target");
     };
@@ -555,8 +573,12 @@ fn switch_target_refuses_to_record_a_persisting_pin_under_frozen_lockfile() {
     let target =
         switch_target(&Config::default(), root.path(), true).expect("target").expect("switch");
 
-    let SwitchSource::Resolve { env_root, frozen_lockfile: true, force_resync: false } =
-        target.source
+    let SwitchSource::Resolve {
+        env_root,
+        frozen_lockfile: true,
+        force_resync: false,
+        locked_version: None,
+    } = target.source
     else {
         panic!("expected a frozen resolve target, got {:?}", target.source);
     };
@@ -577,8 +599,12 @@ fn switch_target_leaves_the_global_env_writable_under_frozen_lockfile() {
     .expect("target")
     .expect("switch");
 
-    let SwitchSource::Resolve { env_root, frozen_lockfile: false, force_resync: false } =
-        target.source
+    let SwitchSource::Resolve {
+        env_root,
+        frozen_lockfile: false,
+        force_resync: false,
+        locked_version: None,
+    } = target.source
     else {
         panic!("expected an unfrozen resolve target, got {:?}", target.source);
     };

--- a/pnpm/crates/cli/src/config_deps.rs
+++ b/pnpm/crates/cli/src/config_deps.rs
@@ -17,6 +17,7 @@ use pnpm_env_installer::{
 };
 use pnpm_graph_hasher::{detect_node_version, host_arch, host_libc, host_platform};
 use pnpm_hooks::{HookContext, LogFn, PnpmfileHooks, finder};
+use pnpm_lockfile::EnvLockfile;
 use pnpm_network::{RetryOpts, ThrottledClient};
 use pnpm_reporter::{HookLog, LogEvent, LogLevel, Reporter};
 use pnpm_resolving_npm_resolver::{
@@ -63,7 +64,7 @@ pub async fn sync_package_manager_dependencies(
     pnpm_version: &str,
     frozen_lockfile: bool,
     force_resync: bool,
-) -> Result<()> {
+) -> Result<EnvLockfile> {
     sync_engine_dependencies(
         config,
         root_dir,
@@ -78,7 +79,8 @@ pub async fn sync_package_manager_dependencies(
 
 /// Resolve the packages a package manager is installed from into the env
 /// lockfile at `root_dir`, so its bytes are pinned by integrity before any
-/// of them are downloaded or executed.
+/// of them are downloaded or executed. Returns that env lockfile, which the
+/// engine installer reads the closure from.
 pub async fn sync_engine_dependencies(
     config: &Config,
     root_dir: &Path,
@@ -87,7 +89,7 @@ pub async fn sync_engine_dependencies(
     version: &str,
     frozen_lockfile: bool,
     force_resync: bool,
-) -> Result<()> {
+) -> Result<EnvLockfile> {
     let context = EnvInstallerContext::for_package_manager(config)?;
     let options = context.options(root_dir, frozen_lockfile);
     resolve_package_manager_integrities(

--- a/pnpm/crates/cli/src/engine_pm/install.rs
+++ b/pnpm/crates/cli/src/engine_pm/install.rs
@@ -50,11 +50,12 @@ use crate::{
 /// `env_root` is where the engine's env lockfile (its resolved package
 /// closure) is written, under the pnpm home directory. `spec` is the
 /// user's bare specifier (a version, range, or dist-tag) and `version` the
-/// exact version it resolved to. `force_resync` discards recorded
-/// `packageManagerDependencies` and re-resolves them even when they look
-/// up to date. `frozen_lockfile` refuses that write instead of performing
-/// it; only a caller whose `env_root` is the project itself passes it,
-/// since a global env lockfile is not what `--frozen-lockfile` freezes.
+/// exact version it resolved to. `force_resync` and `frozen_lockfile` are
+/// the [`resolve_package_manager_integrities`] flags of the same name; only
+/// a caller whose `env_root` is the project itself passes the latter, since
+/// a global env lockfile is not what `--frozen-lockfile` freezes.
+///
+/// [`resolve_package_manager_integrities`]: pnpm_env_installer::resolve_package_manager_integrities
 pub(crate) async fn install_engine_to_store<Reporter: self::Reporter + 'static>(
     config: &'static Config,
     pm: PackageManager,
@@ -83,13 +84,7 @@ pub(crate) async fn install_engine_to_store<Reporter: self::Reporter + 'static>(
             frozen_lockfile,
             force_resync,
         )
-        .await?;
-        EnvLockfile::read(env_root)
-            .map_err(miette::Report::new)
-            .wrap_err("read the package-manager env lockfile")?
-            .ok_or_else(|| {
-                miette::miette!("the package-manager env lockfile is missing after resolution")
-            })?
+        .await?
     };
     install_engine_from_env::<Reporter>(config, pm, &env, version).await
 }

--- a/pnpm/crates/cli/tests/suite/package_manager_check.rs
+++ b/pnpm/crates/cli/tests/suite/package_manager_check.rs
@@ -1,7 +1,8 @@
 //! Ports `pnpm11/pnpm/test/packageManagerCheck.test.ts`.
 
+use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
-use pnpm_testing_utils::bin::CommandTempCwd;
+use pnpm_testing_utils::{bin::CommandTempCwd, command_env::CommandTestExt};
 use std::{
     fs,
     path::Path,
@@ -206,6 +207,42 @@ fn a_command_outside_the_install_family_records_the_pinned_package_manager() {
     pacquet.env("PNPM_CONFIG_REGISTRY", npmrc_info.mock_instance.url());
 
     let output = run(pacquet, root.path(), &EXEC_NODE_VERSION);
+
+    assert_success(&output);
+    let lockfile =
+        fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read the written lockfile");
+    assert_contains(&lockfile, "packageManagerDependencies:");
+    assert_contains(&lockfile, &format!("pnpm@{}", pnpm_config::PNPM_VERSION));
+    drop((root, npmrc_info));
+}
+
+/// Adding a pnpm pin to a project whose dependencies are already installed
+/// must still record it. The up-to-date fast path returns before the install
+/// pipeline that writes the entry, so a plain install kept reporting success
+/// while every `--frozen-lockfile` run failed on the entry it never wrote.
+#[test]
+fn adding_a_pin_to_an_up_to_date_project_records_the_package_manager() {
+    let CommandTempCwd { mut pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry_with_pnpm_version(pnpm_config::PNPM_VERSION);
+    write_manifest(
+        &workspace,
+        &serde_json::json!({ "dependencies": { "@pnpm.e2e/foo": "100.0.0" } }),
+    );
+    pacquet.env("PNPM_CONFIG_REGISTRY", npmrc_info.mock_instance.url());
+    assert_success(&run(pacquet, root.path(), &["install"]));
+
+    write_manifest(
+        &workspace,
+        &serde_json::json!({
+            "dependencies": { "@pnpm.e2e/foo": "100.0.0" },
+            "devEngines": {
+                "packageManager": { "name": "pnpm", "version": pnpm_config::PNPM_VERSION },
+            },
+        }),
+    );
+    let mut pinned = pacquet_at(&workspace);
+    pinned.env("PNPM_CONFIG_REGISTRY", npmrc_info.mock_instance.url());
+    let output = run(pinned, root.path(), &["install"]);
 
     assert_success(&output);
     let lockfile =
@@ -555,6 +592,15 @@ fn a_failing_runtime_check_does_not_block_the_version_output() {
 /// checks; the dependency verification it would otherwise run is unrelated.
 const EXEC_NODE_VERSION: [&str; 4] =
     ["--config.verify-deps-before-run=false", "exec", "node", "--version"];
+
+/// A second command for a test that runs pacquet twice; the first one
+/// [`CommandTempCwd::init`] hands out is consumed by [`run`].
+fn pacquet_at(workspace: &Path) -> Command {
+    Command::cargo_bin("pnpm")
+        .expect("find the pnpm binary")
+        .with_current_dir(workspace)
+        .without_ambient_pnpm_config()
+}
 
 fn run(command: Command, root: &Path, args: &[&str]) -> Output {
     let mut command = command;

--- a/pnpm/crates/env-installer/src/resolve_package_manager_integrities.rs
+++ b/pnpm/crates/env-installer/src/resolve_package_manager_integrities.rs
@@ -4,7 +4,7 @@ use crate::{
     options::ConfigDepsInstallOptions,
     prune::prune_env_lockfile,
     resolve_optional_subdeps::resolution_has_integrity,
-    verify_env_lockfile::write_verified_env_lockfile,
+    verify_env_lockfile::{verify_env_lockfile, write_verified_env_lockfile},
 };
 use pnpm_lockfile::{
     EnvLockfile, LockfileResolution, PackageKey, PkgName, PkgVerPeer, RegistryResolution,
@@ -18,12 +18,18 @@ const PACKAGE_MANAGER_DEPS_PNPM_ONLY: [&str; 1] = ["pnpm"];
 const PNPM_EXE_INTRODUCED: (u64, u64, u64) = (6, 17, 1);
 
 /// Resolve the closure of `package_manager_deps` — the packages a package
-/// manager is installed from — at `version`, and record it in the env
-/// lockfile at `opts.root_dir`.
+/// manager is installed from — at `version`, record it in the env lockfile
+/// at `opts.root_dir`, and return that lockfile.
 ///
 /// `force_resync` skips the recorded-entries fast path, so entries that look
 /// up to date but are invalid (e.g. resolutions carrying tarball URLs
-/// written by an earlier pnpm) are discarded and re-resolved.
+/// written by an earlier pnpm) are discarded and re-resolved. Such entries
+/// already record the version the manifest pins — only pnpm's own reading of
+/// them is at stake — so under `opts.frozen_lockfile` the re-resolution
+/// happens in memory and the lockfile is left untouched, rather than failing
+/// a command the manifest and the lockfile agree on. Entries that do not
+/// record the pinned version are the case `--frozen-lockfile` exists for and
+/// still fail.
 pub async fn resolve_package_manager_integrities(
     package_manager_deps: &[&str],
     wanted_specifier: &str,
@@ -31,7 +37,7 @@ pub async fn resolve_package_manager_integrities(
     resolver: &dyn Resolver,
     opts: &ConfigDepsInstallOptions<'_>,
     force_resync: bool,
-) -> Result<(), ConfigDepError> {
+) -> Result<EnvLockfile, ConfigDepError> {
     let mut env_lockfile = EnvLockfile::read(opts.root_dir)
         .map_err(ConfigDepError::ReadLockfile)?
         .unwrap_or_else(EnvLockfile::create);
@@ -43,9 +49,10 @@ pub async fn resolve_package_manager_integrities(
             package_manager_deps,
         )
     {
-        return Ok(());
+        return Ok(env_lockfile);
     }
-    if opts.frozen_lockfile {
+    let repair_in_memory = force_resync && opts.frozen_lockfile;
+    if opts.frozen_lockfile && !force_resync {
         return Err(ConfigDepError::FrozenLockfileOutdated {
             message: r#"Cannot update packageManagerDependencies with "frozen-lockfile" because the lockfile is not up to date"#.to_string(),
         });
@@ -112,7 +119,12 @@ pub async fn resolve_package_manager_integrities(
     }
 
     prune_env_lockfile(&mut env_lockfile);
-    write_verified_env_lockfile(&env_lockfile, opts.root_dir)
+    if repair_in_memory {
+        verify_env_lockfile(&env_lockfile)?;
+    } else {
+        write_verified_env_lockfile(&env_lockfile, opts.root_dir)?;
+    }
+    Ok(env_lockfile)
 }
 
 /// Rewrite a registry tarball resolution to integrity-only form, dropping

--- a/pnpm/crates/env-installer/src/tests.rs
+++ b/pnpm/crates/env-installer/src/tests.rs
@@ -488,6 +488,87 @@ async fn force_resync_overwrites_recorded_package_manager_entries() {
     assert!(matches!(&env.packages[&key].resolution, LockfileResolution::Registry(_)));
 }
 
+/// The entries a forced resync repairs already record the pinned version,
+/// so `--frozen-lockfile` re-resolves them in memory: the caller gets usable
+/// entries and the lockfile on disk keeps the bytes it had.
+#[tokio::test]
+async fn force_resync_under_frozen_lockfile_resolves_without_writing() {
+    let harness = harness();
+    let root = TempDir::new().unwrap();
+    let recorded = FixtureResolver::new().package(serde_json::json!({
+        "name": "pnpm",
+        "version": "12.0.0",
+        "bin": "bin/pnpm.cjs",
+    }));
+    resolve_package_manager_integrities(
+        pnpm_engine_packages("12.0.0"),
+        "^12.0.0",
+        "12.0.0",
+        &recorded,
+        &options(&harness, root.path(), false),
+        false,
+    )
+    .await
+    .unwrap();
+    let lockfile_path = root.path().join("pnpm-lock.yaml");
+    let before = std::fs::read_to_string(&lockfile_path).unwrap();
+
+    // A resync that would add an entry, under a frozen lockfile.
+    let repaired = FixtureResolver::new()
+        .package(serde_json::json!({
+            "name": "pnpm",
+            "version": "12.0.0",
+            "bin": "bin/pnpm.cjs",
+            "optionalDependencies": { "@pnpm/exe.linux-x64": "12.0.0" },
+        }))
+        .package(serde_json::json!({
+            "name": "@pnpm/exe.linux-x64",
+            "version": "12.0.0",
+        }));
+    let env = resolve_package_manager_integrities(
+        pnpm_engine_packages("12.0.0"),
+        "^12.0.0",
+        "12.0.0",
+        &repaired,
+        &options(&harness, root.path(), true),
+        true,
+    )
+    .await
+    .expect("a forced resync is a repair, not a lockfile update");
+
+    let platform_key: PackageKey = "@pnpm/exe.linux-x64@12.0.0".parse().unwrap();
+    assert!(env.packages.contains_key(&platform_key), "the caller gets the repaired closure");
+    assert_eq!(std::fs::read_to_string(&lockfile_path).unwrap(), before);
+}
+
+/// Entries that do not record the pinned version are the case
+/// `--frozen-lockfile` exists for: recording them would take the lockfile
+/// out of sync with the manifest, so the command fails instead.
+#[tokio::test]
+async fn frozen_lockfile_rejects_outdated_package_manager_entries() {
+    let harness = harness();
+    let root = TempDir::new().unwrap();
+    let resolver = FixtureResolver::new().package(serde_json::json!({
+        "name": "pnpm",
+        "version": "12.0.0",
+        "bin": "bin/pnpm.cjs",
+    }));
+
+    let error = resolve_package_manager_integrities(
+        pnpm_engine_packages("12.0.0"),
+        "^12.0.0",
+        "12.0.0",
+        &resolver,
+        &options(&harness, root.path(), true),
+        false,
+    )
+    .await
+    .expect_err("a missing entry has to be recorded, which a frozen lockfile forbids");
+
+    assert!(matches!(error, ConfigDepError::FrozenLockfileOutdated { .. }), "{error:?}");
+    assert!(!root.path().join("pnpm-lock.yaml").exists());
+}
+
 #[tokio::test]
 async fn resolves_package_manager_dependencies_without_exe_from_v12() {
     let harness = harness();

--- a/pnpm/crates/env-installer/src/tests.rs
+++ b/pnpm/crates/env-installer/src/tests.rs
@@ -538,35 +538,78 @@ async fn force_resync_under_frozen_lockfile_resolves_without_writing() {
 
     let platform_key: PackageKey = "@pnpm/exe.linux-x64@12.0.0".parse().unwrap();
     assert!(env.packages.contains_key(&platform_key), "the caller gets the repaired closure");
+    for (key, metadata) in &env.packages {
+        assert!(
+            matches!(&metadata.resolution, LockfileResolution::Registry(resolution)
+                if !resolution.integrity.to_string().is_empty()),
+            "the bootstrap only reads integrity-only registry resolutions, {key} has {:?}",
+            metadata.resolution,
+        );
+    }
     assert_eq!(std::fs::read_to_string(&lockfile_path).unwrap(), before);
 }
 
 /// Entries that do not record the pinned version are the case
 /// `--frozen-lockfile` exists for: recording them would take the lockfile
-/// out of sync with the manifest, so the command fails instead.
+/// out of sync with the manifest, so the command fails instead, and the
+/// lockfile it refused to update keeps the bytes it had.
 #[tokio::test]
 async fn frozen_lockfile_rejects_outdated_package_manager_entries() {
     let harness = harness();
     let root = TempDir::new().unwrap();
-    let resolver = FixtureResolver::new().package(serde_json::json!({
-        "name": "pnpm",
-        "version": "12.0.0",
-        "bin": "bin/pnpm.cjs",
-    }));
-
-    let error = resolve_package_manager_integrities(
+    let resolver = || {
+        FixtureResolver::new().package(serde_json::json!({
+            "name": "pnpm",
+            "version": "12.0.0",
+            "bin": "bin/pnpm.cjs",
+        }))
+    };
+    let outdated = resolve_package_manager_integrities(
         pnpm_engine_packages("12.0.0"),
         "^12.0.0",
         "12.0.0",
-        &resolver,
+        &resolver(),
         &options(&harness, root.path(), true),
         false,
     )
     .await
     .expect_err("a missing entry has to be recorded, which a frozen lockfile forbids");
 
-    assert!(matches!(error, ConfigDepError::FrozenLockfileOutdated { .. }), "{error:?}");
+    assert!(matches!(outdated, ConfigDepError::FrozenLockfileOutdated { .. }), "{outdated:?}");
     assert!(!root.path().join("pnpm-lock.yaml").exists());
+
+    // The same refusal once a lockfile exists: an entry recorded for another
+    // version is what a bumped pin leaves behind.
+    resolve_package_manager_integrities(
+        pnpm_engine_packages("12.0.0"),
+        "^12.0.0",
+        "12.0.0",
+        &resolver(),
+        &options(&harness, root.path(), false),
+        false,
+    )
+    .await
+    .unwrap();
+    let lockfile_path = root.path().join("pnpm-lock.yaml");
+    let before = std::fs::read_to_string(&lockfile_path).unwrap();
+
+    let stale = resolve_package_manager_integrities(
+        pnpm_engine_packages("13.0.0"),
+        "^13.0.0",
+        "13.0.0",
+        &FixtureResolver::new().package(serde_json::json!({
+            "name": "pnpm",
+            "version": "13.0.0",
+            "bin": "bin/pnpm.cjs",
+        })),
+        &options(&harness, root.path(), true),
+        false,
+    )
+    .await
+    .expect_err("the recorded entry pins another version");
+
+    assert!(matches!(stale, ConfigDepError::FrozenLockfileOutdated { .. }), "{stale:?}");
+    assert_eq!(std::fs::read_to_string(&lockfile_path).unwrap(), before);
 }
 
 #[tokio::test]

--- a/pnpm11/pnpm/src/switchCliVersion.ts
+++ b/pnpm11/pnpm/src/switchCliVersion.ts
@@ -104,17 +104,18 @@ export async function switchCliVersion (config: Config, context: ConfigContext):
       ) {
         throw err
       }
-      // The persisted entries don't satisfy the current bootstrap rules — e.g.
-      // an earlier pnpm recorded resolutions carrying tarball URLs. Rather than
-      // refusing to run, discard them and resolve afresh through the trusted
-      // bootstrap registries, which yields entries in the accepted shape.
+      // The persisted entries do not satisfy the bootstrap rules — a
+      // resolution carrying a tarball URL, say. Rather than refusing to run,
+      // discard them and resolve afresh through the trusted bootstrap
+      // registries, which yields entries in the accepted shape.
       //
-      // Those entries already record the version the manifest pins, so a
-      // frozen lockfile has nothing to reject here: the re-resolution stays in
-      // memory and the lockfile keeps the shape it had.
+      // They already record a version that satisfies the pin, so a frozen
+      // lockfile has nothing to reject: the repair resolves that version
+      // rather than the range around it, keeps the result in memory, and
+      // leaves the lockfile as it is.
       delete envLockfile.importers['.'].packageManagerDependencies
       storeToUse ??= await createStoreController({ ...config, ...context, ...packageManagerConfig })
-      envLockfile = await resolvePackageManagerIntegrities(pm.version, {
+      envLockfile = await resolvePackageManagerIntegrities(config.frozenLockfile ? pmVersion : pm.version, {
         envLockfile,
         registriesByScope: packageManagerConfig.registriesByScope,
         rootDir: context.rootProjectManifestDir,

--- a/pnpm11/pnpm/src/switchCliVersion.ts
+++ b/pnpm11/pnpm/src/switchCliVersion.ts
@@ -108,6 +108,10 @@ export async function switchCliVersion (config: Config, context: ConfigContext):
       // an earlier pnpm recorded resolutions carrying tarball URLs. Rather than
       // refusing to run, discard them and resolve afresh through the trusted
       // bootstrap registries, which yields entries in the accepted shape.
+      //
+      // Those entries already record the version the manifest pins, so a
+      // frozen lockfile has nothing to reject here: the re-resolution stays in
+      // memory and the lockfile keeps the shape it had.
       delete envLockfile.importers['.'].packageManagerDependencies
       storeToUse ??= await createStoreController({ ...config, ...context, ...packageManagerConfig })
       envLockfile = await resolvePackageManagerIntegrities(pm.version, {
@@ -116,8 +120,7 @@ export async function switchCliVersion (config: Config, context: ConfigContext):
         rootDir: context.rootProjectManifestDir,
         storeController: storeToUse.ctrl,
         storeDir: storeToUse.dir,
-        save: persistLockfile,
-        frozenLockfile: config.frozenLockfile,
+        save: persistLockfile && !config.frozenLockfile,
       })
       pmVersion = envLockfile.importers['.'].packageManagerDependencies?.['pnpm']?.version
       if (!pmVersion) {

--- a/pnpm11/pnpm/test/switchingVersions.test.ts
+++ b/pnpm11/pnpm/test/switchingVersions.test.ts
@@ -231,6 +231,40 @@ test('devEngines.packageManager is not re-resolved under --frozen-lockfile', asy
   expect(fs.readFileSync('pnpm-lock.yaml', 'utf8')).toBe(lockfile)
 })
 
+// https://github.com/pnpm/pnpm/issues/14124: entries an earlier pnpm recorded
+// with tarball URLs are discarded and re-resolved before the bootstrap reads
+// them. That repair re-records the version the manifest already pins, so a
+// frozen lockfile has nothing to reject — it used to fail the command.
+test('devEngines.packageManager entries with a tarball resolution are repaired under --frozen-lockfile', async () => {
+  prepare()
+  const pnpmHome = path.resolve('pnpm')
+  const env = { PNPM_HOME: pnpmHome }
+
+  writeJsonFileSync('package.json', {
+    devEngines: {
+      packageManager: {
+        name: 'pnpm',
+        version: '>=9.1.0 <9.1.2',
+        onFail: 'download',
+      },
+    },
+  })
+  expect(execPnpmSync(['help'], { env }).stdout.toString()).toContain('Version 9.1.1')
+
+  // The shape an earlier pnpm wrote, which the bootstrap refuses to read.
+  const lockfile = fs.readFileSync('pnpm-lock.yaml', 'utf8').replace(
+    /resolution: \{integrity: ([^}]+)\}/,
+    'resolution: {integrity: $1, tarball: https://registry.npmjs.org/pnpm/-/pnpm-9.1.1.tgz}'
+  )
+  fs.writeFileSync('pnpm-lock.yaml', lockfile)
+  writeYamlFileSync('pnpm-workspace.yaml', { frozenLockfile: true })
+
+  const { stdout } = execPnpmSync(['help'], { env })
+
+  expect(stdout.toString()).toContain('Version 9.1.1')
+  expect(fs.readFileSync('pnpm-lock.yaml', 'utf8')).toBe(lockfile)
+})
+
 test('devEngines.packageManager without onFail=download does not switch version', async () => {
   prepare()
   const pnpmHome = path.resolve('pnpm')

--- a/pnpm11/pnpm/test/switchingVersions.test.ts
+++ b/pnpm11/pnpm/test/switchingVersions.test.ts
@@ -231,10 +231,11 @@ test('devEngines.packageManager is not re-resolved under --frozen-lockfile', asy
   expect(fs.readFileSync('pnpm-lock.yaml', 'utf8')).toBe(lockfile)
 })
 
-// https://github.com/pnpm/pnpm/issues/14124: entries an earlier pnpm recorded
-// with tarball URLs are discarded and re-resolved before the bootstrap reads
-// them. That repair re-records the version the manifest already pins, so a
-// frozen lockfile has nothing to reject — it used to fail the command.
+// https://github.com/pnpm/pnpm/issues/14124: entries whose resolutions the
+// bootstrap refuses to read are discarded and resolved afresh. The repair
+// records the version the lockfile already pins, so a frozen lockfile has
+// nothing to reject: the command runs that pnpm and the lockfile is left as
+// it is.
 test('devEngines.packageManager entries with a tarball resolution are repaired under --frozen-lockfile', async () => {
   prepare()
   const pnpmHome = path.resolve('pnpm')
@@ -251,12 +252,28 @@ test('devEngines.packageManager entries with a tarball resolution are repaired u
   })
   expect(execPnpmSync(['help'], { env }).stdout.toString()).toContain('Version 9.1.1')
 
-  // The shape an earlier pnpm wrote, which the bootstrap refuses to read.
-  const lockfile = fs.readFileSync('pnpm-lock.yaml', 'utf8').replace(
-    /resolution: \{integrity: ([^}]+)\}/,
-    'resolution: {integrity: $1, tarball: https://registry.npmjs.org/pnpm/-/pnpm-9.1.1.tgz}'
-  )
+  // A resolution carrying a tarball URL: the bootstrap accepts integrity-only
+  // resolutions, so this one sends the pin through the repair.
+  const seeded = fs.readFileSync('pnpm-lock.yaml', 'utf8')
+  const resolutionEnd = seeded.indexOf('}', seeded.indexOf('resolution: {integrity: '))
+  const lockfile = [
+    seeded.slice(0, resolutionEnd),
+    ', tarball: https://registry.npmjs.org/pnpm/-/pnpm-9.1.1.tgz',
+    seeded.slice(resolutionEnd),
+  ].join('')
   fs.writeFileSync('pnpm-lock.yaml', lockfile)
+  // A range the locked 9.1.1 still satisfies, and which 9.1.3 satisfies too:
+  // a repair that resolved the range instead of the locked version would
+  // switch to 9.1.3 without recording it.
+  writeJsonFileSync('package.json', {
+    devEngines: {
+      packageManager: {
+        name: 'pnpm',
+        version: '>=9.1.0 <9.1.4',
+        onFail: 'download',
+      },
+    },
+  })
   writeYamlFileSync('pnpm-workspace.yaml', { frozenLockfile: true })
 
   const { stdout } = execPnpmSync(['help'], { env })


### PR DESCRIPTION
## Summary

Three ways `pnpm install --frozen-lockfile` failed with `ERR_PNPM_FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE` on a lockfile that agrees with the manifest, while a plain `pnpm install` kept reporting success and never repaired the state. Each is reproducible on `main`; each is now covered by a regression test.

**1. The bootstrap repair was treated as a lockfile update (both stacks).** Entries whose resolutions the bootstrap refuses to read — a resolution carrying a tarball URL, the shape recorded before pnpm/pnpm#13728 — are discarded and re-resolved before the pinned pnpm is installed. That repair went through the same save path as a genuine update, so `--frozen-lockfile` failed it even though the recorded version and the manifest pin agree. It now resolves in memory and leaves the lockfile byte-identical. `install_engine_to_store` takes the resolved lockfile straight from the resolver instead of re-reading the one it just wrote.

The repair also resolved the manifest's *range* afresh, so a project pinning a range could switch to whatever the registry offers now while the lockfile kept pinning something else. Under a frozen lockfile it now re-resolves the version the lockfile records, so the command runs the pnpm the lockfile pins.

**2. A corepack build in a `devEngines.packageManager` version (Rust only).** `12.0.0-rc.9+sha512.…` was taken as the version to record, but the registry resolves that spec without the build, so the recorded `version` never equalled the pin it was written from: every plain install rewrote the entry byte-for-byte and every frozen install rejected it. The build is now dropped where the pinned version is read, as the `packageManager` field already does; the `specifier` still records the pin as the manifest writes it, which is what the TypeScript CLI writes.

**3. The up-to-date fast path never recorded the pin (Rust only).** It returns before the install pipeline, which is where the install family records the pin (the pre-command block defers to it). Adding a pin to a project whose dependencies are already installed therefore never reached the lockfile:

```
$ pnpm install            # "Already up to date" — pin not recorded
$ pnpm install --frozen-lockfile
Error: ERR_PNPM_FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE
```

The fast path now gives way when the pin still has to be recorded, and stays a fast path once it is. The TypeScript CLI records it from its pre-command block on every command, so (2) and (3) are Rust-only divergences from it.

Entries that do **not** record the pinned version — pnpm/pnpm#14009, the case the flag exists for — still fail, and its regression tests still pass.

Related to pnpm/pnpm#14124. The reporter's trace is this failure shape; I have asked for their lockfile to confirm which of these three (or a fourth) they hit, and will follow up on the issue either way.

## Squash Commit Body

```text
Three ways a project's `packageManagerDependencies` entry could be rejected by
`--frozen-lockfile` while agreeing with the manifest, each leaving a plain
install reporting success without repairing anything.

A bootstrap repair — entries whose resolutions the bootstrap refuses to read
are discarded and re-resolved before the pinned pnpm is installed — went
through the same save path as a genuine update. It now resolves in memory
under a frozen lockfile and leaves the lockfile untouched, and re-resolves the
version the lockfile records rather than the range around it, so the command
runs the pnpm the lockfile pins. `resolve_package_manager_integrities` returns
the env lockfile it resolved, which `install_engine_to_store` installs from
instead of re-reading the one it just wrote, and the switch plan carries the
locked version. `switchCliVersion` does the same on the TypeScript side by
dropping `save` and passing the locked `pmVersion`.

`exact_version` kept the `+<algorithm>.<hash>` build corepack appends. A
`devEngines.packageManager` version carrying one was recorded as the version
to look for, but the registry resolves that spec without the build, so the
recorded `version` never equalled it: the entry was rewritten byte-for-byte on
every install and rejected on every frozen one. The build is now dropped where
the pinned version is read, as `parse_package_manager` already does for the
`packageManager` field; the `specifier` still records the pin as the manifest
writes it, which is what the TypeScript CLI writes.

The up-to-date fast path returns before the install pipeline, which is where
the install family records the pin — the pre-command block defers to it. A pin
added to a project whose dependencies are already installed therefore never
reached the lockfile. The fast path now gives way when the pin still has to be
recorded, and stays a fast path once it is.

The TypeScript CLI records the pin from its pre-command block and compares
versions with semver, so the last two divergences are Rust-only.

Related to pnpm/pnpm#14124.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Frozen-lockfile installs now repair matching package-manager resolutions in memory without modifying the lockfile.
  - Repairs use the exact version recorded in the lockfile; incompatible pins remain rejected.
  - Corepack build metadata is ignored when matching versions.
  - Package-manager pins are recorded even when dependencies are already up to date.

- **Tests**
  - Added coverage for recovery, lockfile preservation, version handling, and fast-path metadata recording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->