### PR TITLE
fix(deps-resolver): guard the peer diamond check for linked packages

### DIFF
--- a/.changeset/guard-missing-peer-dependencies-in-peer-resolution.md
+++ b/.changeset/guard-missing-peer-dependencies-in-peer-resolution.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-`pnpm deploy --legacy` no longer fails with `Cannot convert undefined or null to object` when the dependency graph contains a package whose resolved manifest carries no `peerDependencies` field.
+Installation no longer fails with `Cannot convert undefined or null to object` when a linked local dependency provides a peer dependency that is also provided by one of its ancestors. This was reachable via `pnpm deploy --legacy`.

--- a/.changeset/guard-missing-peer-dependencies-in-peer-resolution.md
+++ b/.changeset/guard-missing-peer-dependencies-in-peer-resolution.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-resolver": patch
+"pnpm": patch
+---
+
+`pnpm deploy --legacy` no longer fails with `Cannot convert undefined or null to object` when the dependency graph contains a package whose resolved manifest carries no `peerDependencies` field.

--- a/pnpm11/installing/deps-resolver/src/resolvePeers.ts
+++ b/pnpm11/installing/deps-resolver/src/resolvePeers.ts
@@ -549,7 +549,7 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
   if (
     ctx.purePkgs.has(resolvedPackage.pkgIdWithPatchHash) &&
     ctx.depGraph[resolvedPackage.pkgIdWithPatchHash as unknown as DepPath].depth <= node.depth &&
-    Object.keys(resolvedPackage.peerDependencies).length === 0
+    Object.keys(resolvedPackage.peerDependencies ?? {}).length === 0
   ) {
     ctx.pathsByNodeId.set(nodeId, resolvedPackage.pkgIdWithPatchHash as unknown as DepPath)
     ctx.pathsByNodeIdPromises.get(nodeId)!.resolve(resolvedPackage.pkgIdWithPatchHash as unknown as DepPath)
@@ -596,7 +596,7 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
   if (node.lockedPeerContext != null && ctx.resolvedPeerProviderPaths != null) {
     for (const [peerName, previousPeerDepPath] of Object.entries(node.lockedPeerContext)) {
       const peerNodeId = ctx.nodeIdsByPreviousDepPath.get(previousPeerDepPath)
-      const peerDependency = resolvedPackage.peerDependencies[peerName]
+      const peerDependency = resolvedPackage.peerDependencies?.[peerName]
       if (peerNodeId == null || peerDependency == null) continue
       if (ctx.resolvedPeerProviderPaths?.get(peerNodeId) !== previousPeerDepPath) continue
       // Only pin providers that have no peer context of their own. A provider
@@ -675,7 +675,7 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
     parentDepPathsChain: ctx.parentDepPathsChain.includes(resolvedPackage.pkgIdWithPatchHash) ? ctx.parentDepPathsChain : [...ctx.parentDepPathsChain, resolvedPackage.pkgIdWithPatchHash],
   })
 
-  const { resolvedPeers, missingPeers } = Object.keys(resolvedPackage.peerDependencies).length === 0
+  const { resolvedPeers, missingPeers } = Object.keys(resolvedPackage.peerDependencies ?? {}).length === 0
     ? { resolvedPeers: new Map<string, NodeId>(), missingPeers: new Map<string, MissingPeerInfo>() }
     : _resolvePeers({
       currentDepth: node.depth,
@@ -952,7 +952,7 @@ function inheritedParentPkgBreaksPeerDiamond<T extends PartialResolvedPackage> (
   if (parentPkg == null) return false
 
   const conflictingPeers = new Set<string>()
-  for (const peerName of Object.keys(parentPkg.peerDependencies)) {
+  for (const peerName of Object.keys(parentPkg.peerDependencies ?? {})) {
     if (!ctx.allPeerDepNames.has(peerName)) continue
     const inheritedPeer = inheritedContext[peerName]
     const currentPeer = parentPkgs[peerName]

--- a/pnpm11/installing/deps-resolver/src/resolvePeers.ts
+++ b/pnpm11/installing/deps-resolver/src/resolvePeers.ts
@@ -549,7 +549,7 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
   if (
     ctx.purePkgs.has(resolvedPackage.pkgIdWithPatchHash) &&
     ctx.depGraph[resolvedPackage.pkgIdWithPatchHash as unknown as DepPath].depth <= node.depth &&
-    Object.keys(resolvedPackage.peerDependencies ?? {}).length === 0
+    Object.keys(resolvedPackage.peerDependencies).length === 0
   ) {
     ctx.pathsByNodeId.set(nodeId, resolvedPackage.pkgIdWithPatchHash as unknown as DepPath)
     ctx.pathsByNodeIdPromises.get(nodeId)!.resolve(resolvedPackage.pkgIdWithPatchHash as unknown as DepPath)
@@ -596,7 +596,7 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
   if (node.lockedPeerContext != null && ctx.resolvedPeerProviderPaths != null) {
     for (const [peerName, previousPeerDepPath] of Object.entries(node.lockedPeerContext)) {
       const peerNodeId = ctx.nodeIdsByPreviousDepPath.get(previousPeerDepPath)
-      const peerDependency = resolvedPackage.peerDependencies?.[peerName]
+      const peerDependency = resolvedPackage.peerDependencies[peerName]
       if (peerNodeId == null || peerDependency == null) continue
       if (ctx.resolvedPeerProviderPaths?.get(peerNodeId) !== previousPeerDepPath) continue
       // Only pin providers that have no peer context of their own. A provider
@@ -675,7 +675,7 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
     parentDepPathsChain: ctx.parentDepPathsChain.includes(resolvedPackage.pkgIdWithPatchHash) ? ctx.parentDepPathsChain : [...ctx.parentDepPathsChain, resolvedPackage.pkgIdWithPatchHash],
   })
 
-  const { resolvedPeers, missingPeers } = Object.keys(resolvedPackage.peerDependencies ?? {}).length === 0
+  const { resolvedPeers, missingPeers } = Object.keys(resolvedPackage.peerDependencies).length === 0
     ? { resolvedPeers: new Map<string, NodeId>(), missingPeers: new Map<string, MissingPeerInfo>() }
     : _resolvePeers({
       currentDepth: node.depth,

--- a/pnpm11/installing/deps-resolver/test/resolvePeers.ts
+++ b/pnpm11/installing/deps-resolver/test/resolvePeers.ts
@@ -903,34 +903,6 @@ describe('locked peer provider preferences', () => {
     expect(preferred.dependenciesGraph['consumer/1.0.0(peer/2.0.0)' as DepPath]).toBeTruthy()
   })
 
-  // The locked-peer branch reads the consumer's own peer metadata, which resolved package
-  // metadata can omit at runtime.
-  test('a locked peer context on a package without peer metadata resolves without a peer suffix', async () => {
-    const dependenciesTree = createTree()
-    const consumer = dependenciesTree.get(consumerNodeId)!
-    dependenciesTree.set(consumerNodeId, {
-      ...consumer,
-      resolvedPackage: {
-        name: consumerPkg.name,
-        pkgIdWithPatchHash: consumerPkg.pkgIdWithPatchHash,
-        version: consumerPkg.version,
-        id: consumerPkg.id,
-      } as unknown as PartialResolvedPackage,
-    })
-    const resolutionOpts = options(dependenciesTree, new Map([
-      ['peer', currentPeerNodeId],
-      ['retainer', retainerNodeId],
-      ['wrapper', wrapperNodeId],
-    ]))
-    const initial = await resolvePeers(resolutionOpts)
-    const preferred = await resolvePeers({
-      ...resolutionOpts,
-      resolvedPeerProviderPaths: initial.pathsByNodeId,
-    })
-
-    expect(preferred.dependenciesGraph['consumer/1.0.0' as DepPath]).toBeTruthy()
-  })
-
   test('does not replace a newly resolved nested peer provider', async () => {
     const resolutionOpts = options(createTree(currentPeerNodeId), new Map([
       ['retainer', retainerNodeId],
@@ -1519,20 +1491,15 @@ describe('dedupePeers', () => {
     expect(depPaths).not.toContain('plugin/1.0.0(parser/1.0.0(typescript/2.0.0))(typescript/1.0.0)')
   })
 
-  // Resolved package metadata can omit `peerDependencies` at runtime, so peer resolution
-  // treats an absent field as an empty one.
-  test('a peer provider without a peerDependencies field does not break peer resolution', async () => {
-    const ts1Pkg = {
+  // A linked local package is represented by a depth -1 node whose resolved package
+  // carries nothing but a name and a version. Such a node can still shadow a peer
+  // provider that the consumer inherits from an ancestor.
+  test('a linked local package shadowing an inherited peer provider', async () => {
+    const linkedParserNodeId = 'link:../parser' as NodeId
+    const tsPkg = {
       name: 'typescript',
       pkgIdWithPatchHash: 'typescript/1.0.0' as PkgIdWithPatchHash,
       version: '1.0.0',
-      peerDependencies: {} as PeerDependencies,
-      id: '' as PkgResolutionId,
-    }
-    const ts2Pkg = {
-      name: 'typescript',
-      pkgIdWithPatchHash: 'typescript/2.0.0' as PkgIdWithPatchHash,
-      version: '2.0.0',
       peerDependencies: {} as PeerDependencies,
       id: '' as PkgResolutionId,
     }
@@ -1540,8 +1507,9 @@ describe('dedupePeers', () => {
       name: 'parser',
       pkgIdWithPatchHash: 'parser/1.0.0' as PkgIdWithPatchHash,
       version: '1.0.0',
+      peerDependencies: { typescript: { version: '*' } },
       id: '' as PkgResolutionId,
-    } as unknown as PartialResolvedPackage
+    }
     const pluginPkg = {
       name: 'plugin',
       pkgIdWithPatchHash: 'plugin/1.0.0' as PkgIdWithPatchHash,
@@ -1553,13 +1521,6 @@ describe('dedupePeers', () => {
       name: 'umbrella',
       pkgIdWithPatchHash: 'umbrella/1.0.0' as PkgIdWithPatchHash,
       version: '1.0.0',
-      peerDependencies: { typescript: { version: '*' } },
-      id: '' as PkgResolutionId,
-    }
-    const appPkg = {
-      name: 'app',
-      pkgIdWithPatchHash: 'app/1.0.0' as PkgIdWithPatchHash,
-      version: '1.0.0',
       peerDependencies: {} as PeerDependencies,
       id: '' as PkgResolutionId,
     }
@@ -1568,9 +1529,9 @@ describe('dedupePeers', () => {
       projects: [
         {
           directNodeIdsByAlias: new Map([
-            ['typescript', '>typescript/2.0.0>' as NodeId],
+            ['typescript', '>typescript/1.0.0>' as NodeId],
             ['parser', '>parser/1.0.0>' as NodeId],
-            ['app', '>app/1.0.0>' as NodeId],
+            ['umbrella', '>umbrella/1.0.0>' as NodeId],
           ]),
           topParents: [],
           rootDir: '' as ProjectRootDir,
@@ -1579,10 +1540,10 @@ describe('dedupePeers', () => {
       ],
       resolvedImporters: {},
       dependenciesTree: new Map<NodeId, DependenciesTreeNode<PartialResolvedPackage>>([
-        ['>typescript/2.0.0>' as NodeId, {
+        ['>typescript/1.0.0>' as NodeId, {
           children: {},
           installable: true,
-          resolvedPackage: ts2Pkg,
+          resolvedPackage: tsPkg,
           depth: 0,
         }],
         ['>parser/1.0.0>' as NodeId, {
@@ -1591,41 +1552,26 @@ describe('dedupePeers', () => {
           resolvedPackage: parserPkg,
           depth: 0,
         }],
-        ['>app/1.0.0>' as NodeId, {
+        ['>umbrella/1.0.0>' as NodeId, {
           children: {
-            typescript: '>app/1.0.0>typescript/1.0.0>' as NodeId,
-            umbrella: '>app/1.0.0>umbrella/1.0.0>' as NodeId,
-          },
-          installable: true,
-          resolvedPackage: appPkg,
-          depth: 0,
-        }],
-        ['>app/1.0.0>typescript/1.0.0>' as NodeId, {
-          children: {},
-          installable: true,
-          resolvedPackage: ts1Pkg,
-          depth: 1,
-        }],
-        ['>app/1.0.0>umbrella/1.0.0>' as NodeId, {
-          children: {
-            plugin: '>app/1.0.0>umbrella/1.0.0>plugin/1.0.0>' as NodeId,
-            parser: '>app/1.0.0>umbrella/1.0.0>parser/1.0.0>' as NodeId,
+            plugin: '>umbrella/1.0.0>plugin/1.0.0>' as NodeId,
+            parser: linkedParserNodeId,
           },
           installable: true,
           resolvedPackage: umbrellaPkg,
-          depth: 1,
+          depth: 0,
         }],
-        ['>app/1.0.0>umbrella/1.0.0>plugin/1.0.0>' as NodeId, {
+        ['>umbrella/1.0.0>plugin/1.0.0>' as NodeId, {
           children: {},
           installable: true,
           resolvedPackage: pluginPkg,
-          depth: 2,
+          depth: 1,
         }],
-        ['>app/1.0.0>umbrella/1.0.0>parser/1.0.0>' as NodeId, {
+        [linkedParserNodeId, {
           children: {},
           installable: true,
-          resolvedPackage: parserPkg,
-          depth: 2,
+          resolvedPackage: { name: 'parser', version: '1.0.0' },
+          depth: -1,
         }],
       ]),
       virtualStoreDir: '',
@@ -1634,13 +1580,12 @@ describe('dedupePeers', () => {
       peersSuffixMaxLength: 1000,
       workspaceProjectIds: new Set(),
     })
-    // plugin still resolves both of its peers, and the parser without peer metadata
-    // contributes none of its own.
-    const depPaths = Object.keys(dependenciesGraph)
-    expect(depPaths).toContain('plugin/1.0.0(parser/1.0.0)(typescript/1.0.0)')
-    expect(dependenciesGraph['plugin/1.0.0(parser/1.0.0)(typescript/1.0.0)' as DepPath].resolvedPeerNames)
-      .toEqual(new Set(['parser', 'typescript']))
-    expect(depPaths).toContain('parser/1.0.0')
+    expect(Object.keys(dependenciesGraph).sort()).toStrictEqual([
+      'parser/1.0.0(typescript/1.0.0)',
+      'plugin/1.0.0(parser/1.0.0(typescript/1.0.0))(typescript/1.0.0)',
+      'typescript/1.0.0',
+      'umbrella/1.0.0(typescript/1.0.0)',
+    ])
   })
 
   // A cycle re-entry of `a` (a→b→a) resolves against truncated children and must

--- a/pnpm11/installing/deps-resolver/test/resolvePeers.ts
+++ b/pnpm11/installing/deps-resolver/test/resolvePeers.ts
@@ -903,6 +903,34 @@ describe('locked peer provider preferences', () => {
     expect(preferred.dependenciesGraph['consumer/1.0.0(peer/2.0.0)' as DepPath]).toBeTruthy()
   })
 
+  // The locked-peer branch reads the consumer's own peer metadata, which resolved package
+  // metadata can omit at runtime.
+  test('a locked peer context on a package without peer metadata resolves without a peer suffix', async () => {
+    const dependenciesTree = createTree()
+    const consumer = dependenciesTree.get(consumerNodeId)!
+    dependenciesTree.set(consumerNodeId, {
+      ...consumer,
+      resolvedPackage: {
+        name: consumerPkg.name,
+        pkgIdWithPatchHash: consumerPkg.pkgIdWithPatchHash,
+        version: consumerPkg.version,
+        id: consumerPkg.id,
+      } as unknown as PartialResolvedPackage,
+    })
+    const resolutionOpts = options(dependenciesTree, new Map([
+      ['peer', currentPeerNodeId],
+      ['retainer', retainerNodeId],
+      ['wrapper', wrapperNodeId],
+    ]))
+    const initial = await resolvePeers(resolutionOpts)
+    const preferred = await resolvePeers({
+      ...resolutionOpts,
+      resolvedPeerProviderPaths: initial.pathsByNodeId,
+    })
+
+    expect(preferred.dependenciesGraph['consumer/1.0.0' as DepPath]).toBeTruthy()
+  })
+
   test('does not replace a newly resolved nested peer provider', async () => {
     const resolutionOpts = options(createTree(currentPeerNodeId), new Map([
       ['retainer', retainerNodeId],
@@ -1489,6 +1517,130 @@ describe('dedupePeers', () => {
     const depPaths = Object.keys(dependenciesGraph)
     expect(depPaths).toContain('plugin/1.0.0(parser/1.0.0(typescript/1.0.0))(typescript/1.0.0)')
     expect(depPaths).not.toContain('plugin/1.0.0(parser/1.0.0(typescript/2.0.0))(typescript/1.0.0)')
+  })
+
+  // Resolved package metadata can omit `peerDependencies` at runtime, so peer resolution
+  // treats an absent field as an empty one.
+  test('a peer provider without a peerDependencies field does not break peer resolution', async () => {
+    const ts1Pkg = {
+      name: 'typescript',
+      pkgIdWithPatchHash: 'typescript/1.0.0' as PkgIdWithPatchHash,
+      version: '1.0.0',
+      peerDependencies: {} as PeerDependencies,
+      id: '' as PkgResolutionId,
+    }
+    const ts2Pkg = {
+      name: 'typescript',
+      pkgIdWithPatchHash: 'typescript/2.0.0' as PkgIdWithPatchHash,
+      version: '2.0.0',
+      peerDependencies: {} as PeerDependencies,
+      id: '' as PkgResolutionId,
+    }
+    const parserPkg = {
+      name: 'parser',
+      pkgIdWithPatchHash: 'parser/1.0.0' as PkgIdWithPatchHash,
+      version: '1.0.0',
+      id: '' as PkgResolutionId,
+    } as unknown as PartialResolvedPackage
+    const pluginPkg = {
+      name: 'plugin',
+      pkgIdWithPatchHash: 'plugin/1.0.0' as PkgIdWithPatchHash,
+      version: '1.0.0',
+      peerDependencies: { parser: { version: '*' }, typescript: { version: '*' } },
+      id: '' as PkgResolutionId,
+    }
+    const umbrellaPkg = {
+      name: 'umbrella',
+      pkgIdWithPatchHash: 'umbrella/1.0.0' as PkgIdWithPatchHash,
+      version: '1.0.0',
+      peerDependencies: { typescript: { version: '*' } },
+      id: '' as PkgResolutionId,
+    }
+    const appPkg = {
+      name: 'app',
+      pkgIdWithPatchHash: 'app/1.0.0' as PkgIdWithPatchHash,
+      version: '1.0.0',
+      peerDependencies: {} as PeerDependencies,
+      id: '' as PkgResolutionId,
+    }
+    const { dependenciesGraph } = await resolvePeers({
+      allPeerDepNames: new Set(['typescript', 'parser']),
+      projects: [
+        {
+          directNodeIdsByAlias: new Map([
+            ['typescript', '>typescript/2.0.0>' as NodeId],
+            ['parser', '>parser/1.0.0>' as NodeId],
+            ['app', '>app/1.0.0>' as NodeId],
+          ]),
+          topParents: [],
+          rootDir: '' as ProjectRootDir,
+          id: '.',
+        },
+      ],
+      resolvedImporters: {},
+      dependenciesTree: new Map<NodeId, DependenciesTreeNode<PartialResolvedPackage>>([
+        ['>typescript/2.0.0>' as NodeId, {
+          children: {},
+          installable: true,
+          resolvedPackage: ts2Pkg,
+          depth: 0,
+        }],
+        ['>parser/1.0.0>' as NodeId, {
+          children: {},
+          installable: true,
+          resolvedPackage: parserPkg,
+          depth: 0,
+        }],
+        ['>app/1.0.0>' as NodeId, {
+          children: {
+            typescript: '>app/1.0.0>typescript/1.0.0>' as NodeId,
+            umbrella: '>app/1.0.0>umbrella/1.0.0>' as NodeId,
+          },
+          installable: true,
+          resolvedPackage: appPkg,
+          depth: 0,
+        }],
+        ['>app/1.0.0>typescript/1.0.0>' as NodeId, {
+          children: {},
+          installable: true,
+          resolvedPackage: ts1Pkg,
+          depth: 1,
+        }],
+        ['>app/1.0.0>umbrella/1.0.0>' as NodeId, {
+          children: {
+            plugin: '>app/1.0.0>umbrella/1.0.0>plugin/1.0.0>' as NodeId,
+            parser: '>app/1.0.0>umbrella/1.0.0>parser/1.0.0>' as NodeId,
+          },
+          installable: true,
+          resolvedPackage: umbrellaPkg,
+          depth: 1,
+        }],
+        ['>app/1.0.0>umbrella/1.0.0>plugin/1.0.0>' as NodeId, {
+          children: {},
+          installable: true,
+          resolvedPackage: pluginPkg,
+          depth: 2,
+        }],
+        ['>app/1.0.0>umbrella/1.0.0>parser/1.0.0>' as NodeId, {
+          children: {},
+          installable: true,
+          resolvedPackage: parserPkg,
+          depth: 2,
+        }],
+      ]),
+      virtualStoreDir: '',
+      virtualStoreDirMaxLength: 120,
+      lockfileDir: '',
+      peersSuffixMaxLength: 1000,
+      workspaceProjectIds: new Set(),
+    })
+    // plugin still resolves both of its peers, and the parser without peer metadata
+    // contributes none of its own.
+    const depPaths = Object.keys(dependenciesGraph)
+    expect(depPaths).toContain('plugin/1.0.0(parser/1.0.0)(typescript/1.0.0)')
+    expect(dependenciesGraph['plugin/1.0.0(parser/1.0.0)(typescript/1.0.0)' as DepPath].resolvedPeerNames)
+      .toEqual(new Set(['parser', 'typescript']))
+    expect(depPaths).toContain('parser/1.0.0')
   })
 
   // A cycle re-entry of `a` (a→b→a) resolves against truncated children and must


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Peer resolution crashes with `Cannot convert undefined or null to object` when a
linked local dependency (`link:` / `file:`, including every workspace package
under `pnpm deploy --legacy`) provides a peer that is also provided by one of its
ancestors.

A linked local package is stored in the dependencies tree as a `depth: -1` node
whose `resolvedPackage` is only `{ name, version }` — it carries no peer
metadata. `resolvePeersOfNode` returns early for those nodes, but
`inheritedParentPkgBreaksPeerDiamond` reaches one through a
`dependenciesTree.get(...)?.resolvedPackage as T` cast and reads
`peerDependencies` off it. Eight lines below, the same function already guards
the same field on the same kind of node; this makes the parent lookup consistent
with it.

The Rust port needs no change: its `peer_dependencies` is a plain map and the
tree lookup already falls through when the package is absent, so it reaches the
same verdict.

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
`peerDependencies` is only absent on the `depth: -1` arm of
`DependenciesTreeNode`, which represents linked local packages.
`resolvePeersOfNode` returns early for those nodes, so reads inside it are
already safe. The one reachable read is the `as T` cast in
`inheritedParentPkgBreaksPeerDiamond`, which can land on a linked node when the
consumer both inherits a peer provider from an ancestor and has a linked local
package of the same name and version among its own children.

The regression test builds that graph out of a real `depth: -1` node rather than
a hand-forged `PartialResolvedPackage`, and asserts the resolved graph.
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `pnpm deploy --legacy` failures involving linked local dependencies and missing peer-dependency metadata.
  - Peer resolution now safely handles packages without declared peer dependencies.
  - Improved peer resolution when inherited dependencies create nested peer-provider conflicts.

- **Tests**
  - Added regression coverage for linked local packages, missing peer-dependency metadata, and nested peer-resolution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->