### PR TITLE
fix(install): accept a package-manager entry pnpm does not install from

### DIFF
--- a/.changeset/tolerate-a-foreign-package-manager-entry.md
+++ b/.changeset/tolerate-a-foreign-package-manager-entry.md
@@ -1,0 +1,6 @@
+---
+"pacquet": patch
+"pnpm": patch
+---
+
+`pnpm install --frozen-lockfile` no longer fails with `ERR_PNPM_FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE` when `pnpm-lock.yaml` records the pinned pnpm version alongside an engine package the running pnpm does not install it from — the block a pnpm older than 11.20.0 writes for a pnpm 12 pin. An entry pinning any other version is still refused, and a writable install still rewrites the block [#14124](https://github.com/pnpm/pnpm/issues/14124).

--- a/.changeset/tolerate-a-foreign-package-manager-entry.md
+++ b/.changeset/tolerate-a-foreign-package-manager-entry.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-`pnpm install --frozen-lockfile` no longer fails with `ERR_PNPM_FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE` when `pnpm-lock.yaml` records the pinned pnpm version alongside an engine package the running pnpm does not install it from — the block a pnpm older than 11.20.0 writes for a pnpm 12 pin. An entry pinning any other version is still refused, and a writable install still rewrites the block [#14124](https://github.com/pnpm/pnpm/issues/14124).
+`pnpm install --frozen-lockfile` no longer fails when `pnpm-lock.yaml` records the pinned pnpm version alongside an engine package the running pnpm does not install it from. An entry pinning another version is still refused, and a plain install rewrites the block [#14124](https://github.com/pnpm/pnpm/issues/14124).

--- a/pnpm/crates/env-installer/src/resolve_package_manager_integrities.rs
+++ b/pnpm/crates/env-installer/src/resolve_package_manager_integrities.rs
@@ -53,6 +53,14 @@ pub async fn resolve_package_manager_integrities(
     }
     let repair_in_memory = force_resync && opts.frozen_lockfile;
     if opts.frozen_lockfile && !force_resync {
+        if pins_wanted_package_manager(
+            &env_lockfile,
+            wanted_specifier,
+            version,
+            package_manager_deps,
+        ) {
+            return Ok(env_lockfile);
+        }
         return Err(ConfigDepError::FrozenLockfileOutdated {
             message: r#"Cannot update packageManagerDependencies with "frozen-lockfile" because the lockfile is not up to date"#.to_string(),
         });
@@ -164,27 +172,59 @@ pub fn is_package_manager_resolved(
     )
 }
 
+/// Whether the env lockfile already records what this pnpm would write for
+/// `pnpm_version`: the pinned packages, and nothing besides them.
 fn is_package_manager_resolved_with_deps(
     env_lockfile: &EnvLockfile,
     wanted_specifier: &str,
     pnpm_version: &str,
     package_manager_deps: &[&str],
 ) -> bool {
-    let Some(pm_deps) = env_lockfile
+    recorded_package_manager_deps(env_lockfile)
+        .is_some_and(|pm_deps| pm_deps.len() == package_manager_deps.len())
+        && pins_wanted_package_manager(
+            env_lockfile,
+            wanted_specifier,
+            pnpm_version,
+            package_manager_deps,
+        )
+}
+
+/// Whether the env lockfile pins the package manager the manifest asks for,
+/// even when it records more packages than this pnpm installs it from.
+///
+/// A pnpm below 11.20.0 pins `@pnpm/exe` beside `pnpm` for a v12 version,
+/// because that is the set its own major is installed from. Such an entry
+/// pins the wanted version through the same integrity and cannot change
+/// which pnpm runs, so a frozen lockfile accepts it instead of failing a
+/// project whose lockfile a teammate's older pnpm last wrote. An entry
+/// pinning any other version is a lockfile that disagrees with the manifest,
+/// which is what the flag is for, and a writable install still rewrites the
+/// block to the packages this pnpm installs from.
+fn pins_wanted_package_manager(
+    env_lockfile: &EnvLockfile,
+    wanted_specifier: &str,
+    pnpm_version: &str,
+    package_manager_deps: &[&str],
+) -> bool {
+    let Some(pm_deps) = recorded_package_manager_deps(env_lockfile) else {
+        return false;
+    };
+    package_manager_deps.iter().all(|name| pm_deps.contains_key(*name))
+        && pm_deps.iter().all(|(name, dep)| {
+            dep.specifier == wanted_specifier
+                && dep.version == pnpm_version
+                && package_manager_entry_exists(env_lockfile, name, &dep.version)
+        })
+}
+
+fn recorded_package_manager_deps(
+    env_lockfile: &EnvLockfile,
+) -> Option<&std::collections::BTreeMap<String, SpecifierAndResolution>> {
+    env_lockfile
         .importers
         .get(EnvLockfile::ROOT_IMPORTER_KEY)
         .and_then(|importer| importer.package_manager_dependencies.as_ref())
-    else {
-        return false;
-    };
-    pm_deps.len() == package_manager_deps.len()
-        && package_manager_deps.iter().all(|name| {
-            pm_deps.get(*name).is_some_and(|dep| {
-                dep.specifier == wanted_specifier
-                    && dep.version == pnpm_version
-                    && package_manager_entry_exists(env_lockfile, name, &dep.version)
-            })
-        })
 }
 
 /// The packages the env lockfile pins for `pnpm_version`.

--- a/pnpm/crates/env-installer/src/resolve_package_manager_integrities.rs
+++ b/pnpm/crates/env-installer/src/resolve_package_manager_integrities.rs
@@ -53,12 +53,7 @@ pub async fn resolve_package_manager_integrities(
     }
     let repair_in_memory = force_resync && opts.frozen_lockfile;
     if opts.frozen_lockfile && !force_resync {
-        if pins_wanted_package_manager(
-            &env_lockfile,
-            wanted_specifier,
-            version,
-            package_manager_deps,
-        ) {
+        if pins_wanted_package_manager(&env_lockfile, version, package_manager_deps) {
             return Ok(env_lockfile);
         }
         return Err(ConfigDepError::FrozenLockfileOutdated {
@@ -173,21 +168,18 @@ pub fn is_package_manager_resolved(
 }
 
 /// Whether the env lockfile already records what this pnpm would write for
-/// `pnpm_version`: the pinned packages, and nothing besides them.
+/// `pnpm_version`: the pinned packages under the specifier they were pinned
+/// from, and nothing besides them.
 fn is_package_manager_resolved_with_deps(
     env_lockfile: &EnvLockfile,
     wanted_specifier: &str,
     pnpm_version: &str,
     package_manager_deps: &[&str],
 ) -> bool {
-    recorded_package_manager_deps(env_lockfile)
-        .is_some_and(|pm_deps| pm_deps.len() == package_manager_deps.len())
-        && pins_wanted_package_manager(
-            env_lockfile,
-            wanted_specifier,
-            pnpm_version,
-            package_manager_deps,
-        )
+    recorded_package_manager_deps(env_lockfile).is_some_and(|pm_deps| {
+        pm_deps.len() == package_manager_deps.len()
+            && pm_deps.values().all(|dep| dep.specifier == wanted_specifier)
+    }) && pins_wanted_package_manager(env_lockfile, pnpm_version, package_manager_deps)
 }
 
 /// Whether the env lockfile pins the package manager the manifest asks for,
@@ -198,12 +190,12 @@ fn is_package_manager_resolved_with_deps(
 /// pins the wanted version through the same integrity and cannot change
 /// which pnpm runs, so a frozen lockfile accepts it instead of failing a
 /// project whose lockfile a teammate's older pnpm last wrote. An entry
-/// pinning any other version is a lockfile that disagrees with the manifest,
-/// which is what the flag is for, and a writable install still rewrites the
-/// block to the packages this pnpm installs from.
+/// pinning any other version, or one the lockfile carries no package to
+/// install from, is a lockfile that disagrees with the manifest, which is
+/// what the flag is for, and a writable install still rewrites the block to
+/// the packages this pnpm installs from.
 fn pins_wanted_package_manager(
     env_lockfile: &EnvLockfile,
-    wanted_specifier: &str,
     pnpm_version: &str,
     package_manager_deps: &[&str],
 ) -> bool {
@@ -212,8 +204,7 @@ fn pins_wanted_package_manager(
     };
     package_manager_deps.iter().all(|name| pm_deps.contains_key(*name))
         && pm_deps.iter().all(|(name, dep)| {
-            dep.specifier == wanted_specifier
-                && dep.version == pnpm_version
+            dep.version == pnpm_version
                 && package_manager_entry_exists(env_lockfile, name, &dep.version)
         })
 }

--- a/pnpm/crates/env-installer/src/tests.rs
+++ b/pnpm/crates/env-installer/src/tests.rs
@@ -549,6 +549,134 @@ async fn force_resync_under_frozen_lockfile_resolves_without_writing() {
     assert_eq!(std::fs::read_to_string(&lockfile_path).unwrap(), before);
 }
 
+/// A pnpm below 11.20.0 pins `@pnpm/exe` beside `pnpm` for a v12 version.
+/// The entry pins the wanted version and cannot change which pnpm runs, so a
+/// frozen lockfile accepts the block a teammate's older pnpm left behind,
+/// and a writable install rewrites it to the packages this pnpm installs
+/// from.
+#[tokio::test]
+async fn frozen_lockfile_accepts_an_engine_package_it_does_not_install_from() {
+    let harness = harness();
+    let root = TempDir::new().unwrap();
+    let fixtures = || {
+        FixtureResolver::new()
+            .package(serde_json::json!({
+                "name": "pnpm",
+                "version": "12.0.0",
+                "bin": "bin/pnpm.cjs",
+            }))
+            .package(serde_json::json!({
+                "name": "@pnpm/exe",
+                "version": "12.0.0",
+                "bin": "pnpm",
+            }))
+    };
+    // The set an older pnpm records for a v12 pin.
+    resolve_package_manager_integrities(
+        &["pnpm", "@pnpm/exe"],
+        "^12.0.0",
+        "12.0.0",
+        &fixtures(),
+        &options(&harness, root.path(), false),
+        false,
+    )
+    .await
+    .unwrap();
+    let lockfile_path = root.path().join("pnpm-lock.yaml");
+    let before = std::fs::read_to_string(&lockfile_path).unwrap();
+
+    resolve_package_manager_integrities(
+        pnpm_engine_packages("12.0.0"),
+        "^12.0.0",
+        "12.0.0",
+        &fixtures(),
+        &options(&harness, root.path(), true),
+        false,
+    )
+    .await
+    .expect("the block pins the wanted version, so there is nothing to update");
+    assert_eq!(std::fs::read_to_string(&lockfile_path).unwrap(), before);
+
+    let env = resolve_package_manager_integrities(
+        pnpm_engine_packages("12.0.0"),
+        "^12.0.0",
+        "12.0.0",
+        &fixtures(),
+        &options(&harness, root.path(), false),
+        false,
+    )
+    .await
+    .unwrap();
+
+    let recorded: Vec<&str> = env.importers[EnvLockfile::ROOT_IMPORTER_KEY]
+        .package_manager_dependencies
+        .as_ref()
+        .expect("recorded package manager dependencies")
+        .keys()
+        .map(String::as_str)
+        .collect();
+    assert_eq!(recorded, ["pnpm"], "a writable install records what it installs from");
+}
+
+/// The tolerance is for a package pinned at the wanted version. One pinning
+/// anything else is a block that disagrees with the manifest.
+#[tokio::test]
+async fn frozen_lockfile_rejects_an_engine_package_pinned_at_another_version() {
+    let harness = harness();
+    let root = TempDir::new().unwrap();
+    let resolver = FixtureResolver::new()
+        .package(serde_json::json!({
+            "name": "pnpm",
+            "version": "12.0.0",
+            "bin": "bin/pnpm.cjs",
+        }))
+        .package(serde_json::json!({
+            "name": "@pnpm/exe",
+            "version": "12.0.0",
+            "bin": "pnpm",
+        }));
+    resolve_package_manager_integrities(
+        &["pnpm", "@pnpm/exe"],
+        "^12.0.0",
+        "12.0.0",
+        &resolver,
+        &options(&harness, root.path(), false),
+        false,
+    )
+    .await
+    .unwrap();
+    let mut env_lockfile = EnvLockfile::read(root.path()).unwrap().expect("env lockfile written");
+    env_lockfile
+        .root_importer_mut()
+        .package_manager_dependencies
+        .as_mut()
+        .expect("recorded package manager dependencies")
+        .insert(
+            "@pnpm/exe".to_string(),
+            SpecifierAndResolution {
+                specifier: "^12.0.0".to_string(),
+                version: "11.23.0".to_string(),
+            },
+        );
+    env_lockfile.write(root.path()).unwrap();
+    let lockfile_path = root.path().join("pnpm-lock.yaml");
+    let before = std::fs::read_to_string(&lockfile_path).unwrap();
+
+    let error = resolve_package_manager_integrities(
+        pnpm_engine_packages("12.0.0"),
+        "^12.0.0",
+        "12.0.0",
+        &resolver,
+        &options(&harness, root.path(), true),
+        false,
+    )
+    .await
+    .expect_err("an entry pinning another version is an outdated lockfile");
+
+    assert!(matches!(error, ConfigDepError::FrozenLockfileOutdated { .. }), "{error:?}");
+    assert_eq!(std::fs::read_to_string(&lockfile_path).unwrap(), before);
+}
+
 /// Entries that do not record the pinned version are the case
 /// `--frozen-lockfile` exists for: recording them would take the lockfile
 /// out of sync with the manifest, so the command fails instead, and the

--- a/pnpm11/installing/env-installer/src/resolvePackageManagerIntegrities.ts
+++ b/pnpm11/installing/env-installer/src/resolvePackageManagerIntegrities.ts
@@ -37,19 +37,40 @@ export interface ResolvePackageManagerIntegritiesOpts {
 }
 
 /**
- * Checks if the wanted pnpm version integrities are already fully resolved in the env lockfile.
+ * Whether the env lockfile already records what this pnpm writes for
+ * `pnpmVersion`: the pinned packages, and nothing besides them.
  */
 export function isPackageManagerResolved (
   envLockfile: EnvLockfile | undefined,
   pnpmVersion: string
 ): boolean {
-  if (!envLockfile) return false
-
-  const pmDeps = envLockfile.importers['.'].packageManagerDependencies
+  const pmDeps = envLockfile?.importers['.'].packageManagerDependencies
   if (pmDeps == null) return false
-  const wantedDeps = packageManagerDeps(pnpmVersion)
-  return Object.keys(pmDeps).length === wantedDeps.length &&
-    wantedDeps.every((name) => pmDeps[name]?.version === pnpmVersion)
+  return Object.keys(pmDeps).length === packageManagerDeps(pnpmVersion).length &&
+    pinsWantedPackageManager(envLockfile, pnpmVersion)
+}
+
+/**
+ * Whether the env lockfile pins the package manager the manifest asks for,
+ * even when it records more packages than this pnpm installs it from.
+ *
+ * A pnpm below 11.20.0 pins `@pnpm/exe` beside `pnpm` for a v12 version,
+ * because that is the set its own major is installed from. Such an entry pins
+ * the wanted version through the same integrity and cannot change which pnpm
+ * runs, so a frozen lockfile accepts it instead of failing a project whose
+ * lockfile a teammate's older pnpm last wrote. An entry pinning any other
+ * version is a lockfile that disagrees with the manifest, which is what the
+ * flag is for, and a writable install still rewrites the block to the
+ * packages this pnpm installs from.
+ */
+export function pinsWantedPackageManager (
+  envLockfile: EnvLockfile | undefined,
+  pnpmVersion: string
+): boolean {
+  const pmDeps = envLockfile?.importers['.'].packageManagerDependencies
+  if (pmDeps == null) return false
+  return packageManagerDeps(pnpmVersion).every((name) => pmDeps[name] != null) &&
+    Object.values(pmDeps).every((dep) => dep.version === pnpmVersion)
 }
 
 /**
@@ -92,6 +113,9 @@ export async function resolvePackageManagerIntegrities (
   }
 
   if (save && opts.frozenLockfile) {
+    if (pinsWantedPackageManager(envLockfile, pnpmVersion)) {
+      return envLockfile
+    }
     throw new PnpmError('FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE', 'Cannot update packageManagerDependencies with "frozen-lockfile" because the lockfile is not up to date')
   }
 

--- a/pnpm11/installing/env-installer/src/resolvePackageManagerIntegrities.ts
+++ b/pnpm11/installing/env-installer/src/resolvePackageManagerIntegrities.ts
@@ -1,4 +1,4 @@
-import { parseRegistryQualifiedVersion } from '@pnpm/deps.path'
+import { parseRegistryQualifiedVersion, refToRelative, removeSuffix } from '@pnpm/deps.path'
 import { PnpmError } from '@pnpm/error'
 import { convertToLockfileFile, createEnvLockfile, readEnvLockfile } from '@pnpm/lockfile.fs'
 import { pruneSharedLockfile } from '@pnpm/lockfile.pruner'
@@ -37,17 +37,19 @@ export interface ResolvePackageManagerIntegritiesOpts {
 }
 
 /**
- * Whether the env lockfile already records what this pnpm writes for
- * `pnpmVersion`: the pinned packages, and nothing besides them.
+ * Checks if the wanted pnpm version integrities are already fully resolved in the env lockfile.
  */
 export function isPackageManagerResolved (
   envLockfile: EnvLockfile | undefined,
   pnpmVersion: string
 ): boolean {
-  const pmDeps = envLockfile?.importers['.'].packageManagerDependencies
+  if (!envLockfile) return false
+
+  const pmDeps = envLockfile.importers['.'].packageManagerDependencies
   if (pmDeps == null) return false
-  return Object.keys(pmDeps).length === packageManagerDeps(pnpmVersion).length &&
-    pinsWantedPackageManager(envLockfile, pnpmVersion)
+  const wantedDeps = packageManagerDeps(pnpmVersion)
+  return Object.keys(pmDeps).length === wantedDeps.length &&
+    wantedDeps.every((name) => pmDeps[name]?.version === pnpmVersion)
 }
 
 /**
@@ -59,18 +61,31 @@ export function isPackageManagerResolved (
  * the wanted version through the same integrity and cannot change which pnpm
  * runs, so a frozen lockfile accepts it instead of failing a project whose
  * lockfile a teammate's older pnpm last wrote. An entry pinning any other
- * version is a lockfile that disagrees with the manifest, which is what the
- * flag is for, and a writable install still rewrites the block to the
- * packages this pnpm installs from.
+ * version, or one the lockfile carries no package to install from, is a
+ * lockfile that disagrees with the manifest, which is what the flag is for,
+ * and a writable install still rewrites the block to the packages this pnpm
+ * installs from.
  */
 export function pinsWantedPackageManager (
   envLockfile: EnvLockfile | undefined,
   pnpmVersion: string
 ): boolean {
-  const pmDeps = envLockfile?.importers['.'].packageManagerDependencies
+  if (!envLockfile) return false
+
+  const pmDeps = envLockfile.importers['.'].packageManagerDependencies
   if (pmDeps == null) return false
   return packageManagerDeps(pnpmVersion).every((name) => pmDeps[name] != null) &&
-    Object.values(pmDeps).every((dep) => dep.version === pnpmVersion)
+    Object.entries(pmDeps).every(([name, dep]) =>
+      dep.version === pnpmVersion && isRecordedForInstall(envLockfile, name, dep.version)
+    )
+}
+
+/** Whether the lockfile carries the records the bootstrap installs `name@version` from. */
+function isRecordedForInstall (envLockfile: EnvLockfile, name: string, version: string): boolean {
+  const depPath = refToRelative(version, name)
+  return depPath != null &&
+    envLockfile.packages[removeSuffix(depPath)] != null &&
+    envLockfile.snapshots[depPath] != null
 }
 
 /**

--- a/pnpm11/installing/env-installer/test/resolvePackageManagerIntegrities.test.ts
+++ b/pnpm11/installing/env-installer/test/resolvePackageManagerIntegrities.test.ts
@@ -119,6 +119,44 @@ test('a lockfile that pins another version is not updated under frozenLockfile',
   })
 })
 
+// https://github.com/pnpm/pnpm/issues/14124: a pnpm below 11.20.0 pins
+// `@pnpm/exe` beside `pnpm` for a v12 version. The entry pins the wanted
+// version and cannot change which pnpm runs, so a frozen install accepts the
+// block a teammate's older pnpm left behind instead of failing on it.
+test('an entry for a package the running pnpm does not install from is accepted under frozenLockfile', async () => {
+  resolveManifestDependencies.mockClear()
+
+  const result = await resolvePackageManagerIntegrities('12.0.0', {
+    envLockfile: envLockfile({ 'pnpm': '12.0.0', '@pnpm/exe': '12.0.0' }),
+    registriesByScope: { default: 'https://mirror.example.com/' },
+    rootDir: '/repo',
+    storeController: {} as never,
+    storeDir: '/store',
+    frozenLockfile: true,
+  })
+
+  expect(result.importers['.'].packageManagerDependencies).toEqual({
+    'pnpm': { specifier: '12.0.0', version: '12.0.0' },
+    '@pnpm/exe': { specifier: '12.0.0', version: '12.0.0' },
+  })
+  expect(resolveManifestDependencies).not.toHaveBeenCalled()
+})
+
+test('an entry pinning another version is still refused under frozenLockfile', async () => {
+  await expect(
+    resolvePackageManagerIntegrities('12.0.0', {
+      envLockfile: envLockfile({ 'pnpm': '12.0.0', '@pnpm/exe': '11.23.0' }),
+      registriesByScope: { default: 'https://mirror.example.com/' },
+      rootDir: '/repo',
+      storeController: {} as never,
+      storeDir: '/store',
+      frozenLockfile: true,
+    })
+  ).rejects.toMatchObject({
+    code: 'ERR_PNPM_FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE',
+  })
+})
+
 // A resolution that is never saved cannot take the lockfile out of sync with
 // the manifest, so `--frozen-lockfile` has nothing to refuse. This is how a
 // legacy `packageManager` pin below v12 switches versions.

--- a/pnpm11/installing/env-installer/test/resolvePackageManagerIntegrities.test.ts
+++ b/pnpm11/installing/env-installer/test/resolvePackageManagerIntegrities.test.ts
@@ -142,6 +142,25 @@ test('an entry for a package the running pnpm does not install from is accepted 
   expect(resolveManifestDependencies).not.toHaveBeenCalled()
 })
 
+test('an entry the lockfile carries no package for is refused under frozenLockfile', async () => {
+  const withoutRecords = envLockfile({ 'pnpm': '12.0.0', '@pnpm/exe': '12.0.0' })
+  withoutRecords.packages = {}
+  withoutRecords.snapshots = {}
+
+  await expect(
+    resolvePackageManagerIntegrities('12.0.0', {
+      envLockfile: withoutRecords,
+      registriesByScope: { default: 'https://mirror.example.com/' },
+      rootDir: '/repo',
+      storeController: {} as never,
+      storeDir: '/store',
+      frozenLockfile: true,
+    })
+  ).rejects.toMatchObject({
+    code: 'ERR_PNPM_FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE',
+  })
+})
+
 test('an entry pinning another version is still refused under frozenLockfile', async () => {
   await expect(
     resolvePackageManagerIntegrities('12.0.0', {
@@ -190,17 +209,20 @@ test('an in-memory resolution is performed under frozenLockfile', async () => {
 })
 
 function envLockfile (packageManagerDependencies: Record<string, string>): EnvLockfile {
+  const pinned = Object.entries(packageManagerDependencies)
   return {
     lockfileVersion: '9.0',
     importers: {
       '.': {
         configDependencies: {},
         packageManagerDependencies: Object.fromEntries(
-          Object.entries(packageManagerDependencies).map(([name, version]) => [name, { specifier: version, version }])
+          pinned.map(([name, version]) => [name, { specifier: version, version }])
         ),
       },
     },
-    packages: {},
-    snapshots: {},
+    packages: Object.fromEntries(
+      pinned.map(([name, version]) => [`${name}@${version}`, { resolution: { integrity: `sha512-${name}` } }])
+    ),
+    snapshots: Object.fromEntries(pinned.map(([name, version]) => [`${name}@${version}`, {}])),
   } as unknown as EnvLockfile
 }


### PR DESCRIPTION
## Summary

A pnpm below 11.20.0 pins `@pnpm/exe` beside `pnpm` for a **v12** version, because that is the set its own major is installed from — pnpm/pnpm#13599 is where pnpm learned that v12 publishes the executable as the unscoped package alone. A project pinning pnpm 12 whose lockfile such a pnpm last wrote therefore carries an entry every newer pnpm rejects, and `--frozen-lockfile` fails on it from either side of the disagreement while a plain install rewrites the block and hides it again. Measured on `main`, with published binaries:

| lockfile written by | `pnpm i --frozen-lockfile` under | before |
|---|---|---|
| 11.23 (`pnpm` only) | 11.18 | fails — 11.18 rewrites the block despite the flag, the pinned v12 then rejects it |
| 11.18 (`pnpm` + `@pnpm/exe`) | 11.23 | fails on its own check |
| 11.18 (`pnpm` + `@pnpm/exe`) | pnpm 12 | fails |

That entry pins the wanted version through the same integrity and cannot change which pnpm runs. The frozen refusal now accepts a block that records every package this pnpm installs from, whatever else it records; an entry pinning **another** version is a lockfile that disagrees with the manifest and is still refused. The predicate that drives the *write* keeps the exact-set rule, so a writable install still rewrites the block to the packages this pnpm installs from:

```
$ pnpm i --frozen-lockfile     # block carries the extra @pnpm/exe entry
Lockfile is up to date, resolution step is skipped     # lockfile byte-identical
$ pnpm i
Done in 80ms using pnpm v12.0.0-rc.9                   # block back to `pnpm` alone
```

**The trade:** `--frozen-lockfile` no longer guarantees that block is byte-stable against a later plain install. It is deliberate — the tolerated difference is an engine package pinned at the version the manifest asks for, which cannot change what gets installed — and it is what makes a mixed-version team survive the v12 transition without a lockfile the two halves keep fighting over.

Follows pnpm/pnpm#14129; related to pnpm/pnpm#14124, where this bit the reporter.

## Squash Commit Body

```text
A pnpm below 11.20.0 pins `@pnpm/exe` beside `pnpm` for a v12 version, because
that is the set its own major is installed from — pnpm/pnpm#13599 is where pnpm
learned that v12 publishes the executable as the unscoped package alone. A
project pinning pnpm 12 whose lockfile such a pnpm last wrote therefore carries
an entry every newer pnpm rejects, and `--frozen-lockfile` fails on it from
either side of the disagreement while a plain install rewrites the block and
hides it again. The two versions take turns.

That entry pins the wanted version through the same integrity and cannot change
which pnpm runs, so the frozen refusal now accepts a block that records every
package this pnpm installs from, whatever else it records. An entry pinning
another version is a lockfile that disagrees with the manifest and is still
refused. The predicate that drives the write keeps the exact-set rule, so a
writable install still rewrites the block to the packages this pnpm installs
from — the trade is that `--frozen-lockfile` no longer guarantees that block is
byte-stable against a later plain install.

Related to pnpm/pnpm#14124.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790168537&installation_model_id=426870&pr_number=14132&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14132&signature=8a7a4c45457095af9b8ec0474d298667cfcf23890bc033b82cbff2e387add8e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Frozen installs now tolerate legacy pnpm lockfile entries containing additional package-manager dependencies when versions match.
  * Frozen installs reject missing or mismatched lockfile records and package-manager versions without modifying the lockfile.
  * Writable installs record only the package-manager dependencies actually used.

* **Tests**
  * Added coverage for matching and mismatched versions, legacy entries, stale lockfiles, and frozen-install behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->