### PR TITLE
revert: "chore(release): stop publishing `@pnpm/exe` from v12 (#14121)"

### DIFF
--- a/.changeset/stop-publishing-pnpm-exe.md
+++ b/.changeset/stop-publishing-pnpm-exe.md
@@ -1,5 +1,0 @@
----
-"pacquet": patch
----
-
-`@pnpm/exe` is no longer published from pnpm v12. It existed to run pnpm without a Node.js runtime; the `pnpm` package is now itself the native executable, so install `pnpm` instead. An existing `@pnpm/exe` install needs no action — `pnpm self-update` moves it onto `pnpm` when it upgrades to v12.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -793,10 +793,11 @@ jobs:
           done
 
       - name: Restore node-gyp payload
-        # The dist/ payload the wrapper ships, so install scripts that shell
+        # The dist/ payload both wrappers ship, so install scripts that shell
         # out to node-gyp build out of the box. Taken from the artifact rather
         # than rebuilt, so the npm packages and the GitHub release archives
-        # carry the same bytes.
+        # carry the same bytes. Must land before the packages are generated:
+        # the `@pnpm/exe` wrapper copies dist/ too.
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: node-gyp-payload
@@ -822,7 +823,7 @@ jobs:
         run: |
           set -euo pipefail
           release_tarballs=$(mktemp -d)
-          for package in pnpm/npm/pacquet-* pnpm/npm/napi.* pnpm/npm/napi pnpm/npm/pnpm; do
+          for package in pnpm/npm/pacquet-* pnpm/npm/napi.* pnpm/npm/napi pnpm/npm/pnpm-exe pnpm/npm/pnpm; do
             package_tarballs="$release_tarballs/${package//\//_}"
             mkdir "$package_tarballs"
             (
@@ -945,9 +946,9 @@ jobs:
           node pnpm/npm/napi/scripts/generate-packages.mjs
 
       # Every generated package uses stage-only OIDC. CI stages the native
-      # packages, the `@pnpm/napi` wrapper, and `pnpm`, then finishes without
-      # publishing any of them. A maintainer approves those layers later with
-      # interactive 2FA in the same dependency order. The `pnpm` wrapper is
+      # packages, `@pnpm/napi` / `@pnpm/exe` wrappers, and `pnpm`, then finishes
+      # without publishing any of them. A maintainer approves those layers later
+      # with interactive 2FA in the same dependency order. The `pnpm` wrapper is
       # approved last because the plan job uses it as the "release completed"
       # gate. The build dirs `pacquet-*` publish as `@pnpm/exe.<target>`.
       - name: Stage Rust native packages (OIDC)
@@ -963,7 +964,7 @@ jobs:
         run: >-
           .github/scripts/npm-staged-publication.sh stage
           'Rust wrapper packages' "$TAG"
-          pnpm/npm/napi
+          pnpm/npm/napi pnpm/npm/pnpm-exe
       - name: Stage Rust pnpm package (OIDC)
         env:
           TAG: ${{ needs.plan.outputs.rust_tag }}

--- a/.github/workflows/update-latest.yml
+++ b/.github/workflows/update-latest.yml
@@ -124,16 +124,8 @@ jobs:
 
         # Both wrappers are exercised: self-update reinstalls the package it is
         # running from, so `pnpm` and `@pnpm/exe` resolve different published
-        # manifests and a broken one surfaces on only that wrapper. The gate is
-        # on the starting version, not the promoted one — `@pnpm/exe` is
-        # published up to v11 only, so a v12 starting point has just the one
-        # wrapper, while upgrading a v11 `@pnpm/exe` onto a v12 release is a
-        # path this must still cover.
-        packages=(pnpm)
-        if [ "${FROM%%.*}" -lt 12 ]; then
-          packages+=(@pnpm/exe)
-        fi
-        for package in "${packages[@]}"; do
+        # manifests and a broken one surfaces on only that wrapper.
+        for package in pnpm @pnpm/exe; do
           work=$(mktemp -d)
           # Isolate the whole pnpm environment so the upgrade resolves and
           # installs for real instead of reusing a warm store or global dir.
@@ -145,16 +137,13 @@ jobs:
           mkdir -p "$work/from"
           printf '{"name":"pnpm-upgrade-check","version":"0.0.0","private":true}\n' >"$work/from/package.json"
           # `--allow-build` is what makes this install the starting point rather
-          # than a fake one: pnpm blocks dependency build scripts by default,
-          # and the preinstall of whichever wrapper carries the native binary
-          # (`@pnpm/exe` up to v11, `pnpm` itself from v12) is what swaps its
-          # placeholder bin for the real native. Without it every run reproduces
-          # the exact breakage this gate exists to catch (the placeholder
-          # surviving) and blames the release.
+          # than a fake one: pnpm blocks dependency build scripts by default, and
+          # `@pnpm/exe`'s setup.js is what swaps its placeholder bin for the real
+          # native. Without it every run reproduces the exact breakage this gate
+          # exists to catch (the placeholder surviving) and blames the release.
           pn add "${package}@${FROM}" \
             --dir "$work/from" \
             --allow-build=@pnpm/exe \
-            --allow-build=pnpm \
             --registry="$REGISTRY"
           # Drive through the bin shim rather than a path into the package: the
           # entry point differs by major (pnpm.cjs in v10, pnpm.mjs in v11) and
@@ -178,9 +167,9 @@ jobs:
             upgraded="$PNPM_HOME/pnpm"
           fi
           # Run the upgraded binary rather than trust self-update's exit code:
-          # the wrapper's preinstall leaves its placeholder bin in place when
-          # the platform package ships no native, so that failure is invisible
-          # until the binary is actually invoked.
+          # `@pnpm/exe`'s preinstall leaves its placeholder bin in place when the
+          # platform package ships no native, so that failure is invisible until
+          # the binary is actually invoked.
           test "$("$upgraded" --version)" = "$VERSION"
 
           # Hand the rest of the gate to the release itself, so what is gated is
@@ -230,19 +219,12 @@ jobs:
         pn config set "//registry.npmjs.org/:_authToken" "${NPM_TOKEN}"
 
         MAJOR="${VERSION%%.*}"
-        # `@pnpm/exe` is only published up to v11; from v12 the `pnpm` package
-        # is itself the native executable, so there is nothing to tag under
-        # that name.
-        packages=(pnpm)
-        if [ "$MAJOR" -lt 12 ]; then
-          packages+=(@pnpm/exe)
+        pn dist-tag add "pnpm@${VERSION}" "latest-${MAJOR}" --registry="$REGISTRY"
+        pn dist-tag add "@pnpm/exe@${VERSION}" "latest-${MAJOR}" --registry="$REGISTRY"
+        if [ "$TAG" != "latest-${MAJOR}" ]; then
+          pn dist-tag add "pnpm@${VERSION}" "${TAG}" --registry="$REGISTRY"
+          pn dist-tag add "@pnpm/exe@${VERSION}" "${TAG}" --registry="$REGISTRY"
         fi
-        for package in "${packages[@]}"; do
-          pn dist-tag add "${package}@${VERSION}" "latest-${MAJOR}" --registry="$REGISTRY"
-          if [ "$TAG" != "latest-${MAJOR}" ]; then
-            pn dist-tag add "${package}@${VERSION}" "${TAG}" --registry="$REGISTRY"
-          fi
-        done
 
   publish-to-winget:
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,7 +216,7 @@ Added a new setting `blockExoticSubdeps` that prevents the resolution of exotic 
 
 The Rust products are released through the same native flow. Their npm wrapper packages are workspace packages with committed versions, so a user-visible change to a Rust product needs a changeset too, targeting:
 
-- `pacquet` — the Rust pnpm CLI (published to npm as `pnpm` under its `next-<major>` dist-tag; named `pacquet` in-repo so its name can't collide with the TypeScript CLI). `@pnpm/napi` is a `versioning.fixed` group with it and bumps with it automatically.
+- `pacquet` — the Rust pnpm CLI (published to npm as `pnpm` and `@pnpm/exe` under its `next-<major>` dist-tag; named `pacquet` in-repo so its name can't collide with the TypeScript CLI). `@pnpm/napi` is a `versioning.fixed` group with it and bumps with it automatically.
 - `@pnpm/napi` — the Node.js addon bindings for the Rust engine.
 - `@pnpm/pnpr` — the pnpr registry server (published as `@pnpm/pnpr` and its platform packages, plus the `ghcr.io/pnpm/pnpr` Docker image).
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -68,7 +68,7 @@ See [#13578](https://github.com/pnpm/pnpm/issues/13578).
 
 6. After the workflow finishes, approve the staged npm packages. The TypeScript
    pnpm release stages `@pnpm/exe` and then `pnpm`. The Rust pnpm release
-   stages its native packages, then its `@pnpm/napi` wrapper, and finally
+   stages its native packages, then its `@pnpm/napi` and `@pnpm/exe` wrappers, and finally
    `pnpm`. Copy the stage IDs from the completed job's summary and approve each
    one from a maintainer's machine. Approve all packages in each dependency
    layer before moving to the next layer, leaving `pnpm` until last:

--- a/pnpm/crates/cli/src/cli_args/self_update/install_pnpm.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/install_pnpm.rs
@@ -24,8 +24,8 @@ use std::{
 
 use super::SelfUpdateError;
 
-/// From v12 the unscoped `pnpm` package is itself the native engine and
-/// `@pnpm/exe` is no longer published, so v12+ installs converge on `pnpm`.
+/// From v12 the unscoped `pnpm` package is itself the native engine
+/// (equal content to `@pnpm/exe`), so v12+ installs converge on `pnpm`.
 pub(crate) const PNPM_PACKAGE_NAME: &str = "pnpm";
 pub(crate) const PNPM_EXE_PACKAGE_NAME: &str = "@pnpm/exe";
 

--- a/pnpm/crates/default-reporter/src/state.rs
+++ b/pnpm/crates/default-reporter/src/state.rs
@@ -1588,8 +1588,9 @@ fn detect_install_source() -> PnpmInstallSource {
 /// user is running.
 ///
 /// pnpm names `@pnpm/exe` in the last case when it is running as a single
-/// executable. From v12 the native binary is published only as `pnpm`, so
-/// it always names `pnpm`.
+/// executable. The native binary is published under both `pnpm` and
+/// `@pnpm/exe` and carries no marker telling the two apart, and a global
+/// install of either replaces the other, so it always names `pnpm`.
 fn update_command(source: PnpmInstallSource, latest_version: &str) -> String {
     match source {
         PnpmInstallSource::Corepack => format!("corepack use pnpm@{latest_version}"),

--- a/pnpm/npm/pnpm/scripts/generate-packages.mjs
+++ b/pnpm/npm/pnpm/scripts/generate-packages.mjs
@@ -1,13 +1,14 @@
 // Adapted from Rome (https://github.com/rome/tools/blob/392d188a49/npm/rome/scripts/generate-packages.mjs).
 //
-// Generates the per-platform `@pnpm/exe.<target>` native packages.
+// Generates the per-platform `@pnpm/exe.<target>` native packages and the
+// `@pnpm/exe` wrapper (an equal-content copy of the committed wrapper).
 //
 // The committed wrapper is the private workspace package `pacquet` (so its
 // name can't collide with the TypeScript CLI package `pnpm`, which the
 // meta-updater and pnpm's own name-keyed resolution key on); this script
 // rewrites it into the publishable `pnpm` manifest.
 
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import * as fs from "node:fs";
 
@@ -15,16 +16,34 @@ import * as fs from "node:fs";
 // `pnpm-<codeTarget>` archives and extracts the binaries under these names.
 const EXTRACTED_BIN_NAME = "pnpm";
 // Prefix of the generated native package dirs. Kept distinct from `pnpm` so
-// the release workflow can address them separately from the `pnpm/npm/pnpm`
-// wrapper dir they sit beside.
+// the dirs can't be caught by the `pnpm/npm/pnpm*` glob the release
+// workflow publishes the wrapper packages with.
 const PACKAGE_DIR_PREFIX = "pacquet";
 // Binary file name inside each native package; `installPnpm`'s
 // `linkExePlatformBinary` hardcodes `pnpm`, so both must agree.
 const NATIVE_BIN_FILE = "pnpm";
+const EXE_WRAPPER_NAME = "@pnpm/exe";
+const EXE_WRAPPER_DIR = "pnpm-exe";
 // Ships with every package that carries the native binary, wrapper or not:
 // the BSD 2-Clause code the engine is derived from asks for its notice in the
 // materials accompanying a binary distribution.
 const NOTICES_FILE = "THIRD-PARTY-NOTICES.md";
+// Files shared verbatim by both wrappers: the root-level bins + preinstall +
+// the Corepack entry points + README + the third-party notices. Both wrappers
+// publish the same `files` list, so anything named there has to be copied here
+// too.
+const WRAPPER_FILES = [
+  "pnpm",
+  "pn",
+  "pnpx",
+  "pnx",
+  "install.js",
+  "native-binary.mjs",
+  "bin/pnpm.mjs",
+  "bin/pnpx.mjs",
+  "README.md",
+  NOTICES_FILE,
+];
 
 const PNPM_ROOT = resolve(fileURLToPath(import.meta.url), "../..");
 const PACKAGES_ROOT = resolve(PNPM_ROOT, "..");
@@ -112,6 +131,48 @@ function patchPnpmWrapperManifest() {
   fs.writeFileSync(MANIFEST_PATH, JSON.stringify(rootManifest));
 }
 
+// Generate the `@pnpm/exe` wrapper as a copy of the `pnpm` wrapper with only the
+// name + repo.directory changed. Must run after `patchPnpmWrapperManifest` so the
+// copied manifest already carries the version and optionalDependencies.
+function generateExeWrapper() {
+  const exeRoot = resolve(PACKAGES_ROOT, EXE_WRAPPER_DIR);
+  fs.rmSync(exeRoot, { recursive: true, force: true });
+  fs.mkdirSync(exeRoot, { recursive: true });
+
+  // Copy instead of symlinking so the tarball is self-contained for publish.
+  for (const file of WRAPPER_FILES) {
+    fs.mkdirSync(dirname(resolve(exeRoot, file)), { recursive: true });
+    fs.copyFileSync(resolve(PNPM_ROOT, file), resolve(exeRoot, file));
+    fs.chmodSync(resolve(exeRoot, file), fs.statSync(resolve(PNPM_ROOT, file)).mode);
+  }
+
+  // Both wrappers place the native binary next to themselves, so both need
+  // their own copy of the node-gyp payload for it to be found at
+  // `<exe dir>/dist`. Built by scripts/bundle-node-gyp.mjs; absent when
+  // generating packages without having run it.
+  const distRoot = resolve(PNPM_ROOT, "dist");
+  if (fs.existsSync(distRoot)) {
+    fs.cpSync(distRoot, resolve(exeRoot, "dist"), { recursive: true });
+  }
+
+  const baseManifest = JSON.parse(fs.readFileSync(MANIFEST_PATH, "utf-8"));
+  // The wrapper states its own name outright, so it must not inherit the base
+  // manifest's `publishConfig.name` rename — that would publish it as `pnpm`.
+  const { name: _renamedTo, ...publishConfig } = baseManifest.publishConfig ?? {};
+  const exeManifest = {
+    ...baseManifest,
+    name: EXE_WRAPPER_NAME,
+    repository: { ...baseManifest.repository, directory: `pnpm/npm/${EXE_WRAPPER_DIR}` },
+  };
+  if (Object.keys(publishConfig).length > 0) {
+    exeManifest.publishConfig = publishConfig;
+  } else {
+    delete exeManifest.publishConfig;
+  }
+  console.log(`Create wrapper ${exeRoot}`);
+  fs.writeFileSync(resolve(exeRoot, "package.json"), JSON.stringify(exeManifest));
+}
+
 // `@pnpm/exe.<target>` is the convention `installPnpm`'s relinker already
 // anticipates (`exePlatformPkgDirNameNext`), so a switch to v12 needs no special
 // case.
@@ -135,3 +196,4 @@ for (const target of TARGETS) {
 }
 
 patchPnpmWrapperManifest();
+generateExeWrapper();

--- a/pnpm11/engine/pm/commands/src/self-updater/installPnpm.ts
+++ b/pnpm11/engine/pm/commands/src/self-updater/installPnpm.ts
@@ -59,10 +59,9 @@ export function assertReleaseIsInstallable (version: string): void {
 
 /**
  * Package name to install for a switch to `pnpmVersion`. From v12 the unscoped
- * `pnpm` is itself the native exe and `@pnpm/exe` is no longer published, so
- * v12+ always converges on `pnpm`, even from a SEA `@pnpm/exe` build. Earlier
- * majors keep `pnpm` (JS) and `@pnpm/exe` (SEA) distinct, preserving the
- * running identity.
+ * `pnpm` is itself the native exe (equal content to `@pnpm/exe`), so v12+ always
+ * converges on `pnpm`, even from a SEA `@pnpm/exe` build. Earlier majors keep
+ * `pnpm` (JS) and `@pnpm/exe` (SEA) distinct, preserving the running identity.
  */
 export function pnpmPackageNameToInstall (pnpmVersion: string): string {
   const parsed = semver.parse(pnpmVersion, { loose: true })


### PR DESCRIPTION
This reverts commit afb4071811747883b646c2f1a92654fc5d214ff1.

Let's postpone `@pnpm/exe` deprecation to v13 otherwise some older version of pnpm will fail on `pnpm self-update`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790169544&installation_model_id=426870&pr_number=14133&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14133&signature=213a3321ac7722c9d7c868879219efd2f5ced01ce45d550d5407416bad200b31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Releases now provide both the `pnpm` package and the `@pnpm/exe` package, offering equivalent native command-line functionality.
  * Package generation includes the appropriate executable wrapper and native payload.

* **Bug Fixes**
  * Upgrades and release tagging now consistently support both package names across supported versions.

* **Documentation**
  * Updated installation, self-update, and release guidance to reflect the available package options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->