### PR TITLE
fix(release): keep the bundled bins packable

### DIFF
--- a/pnpm11/pnpm/bundle-deps.ts
+++ b/pnpm11/pnpm/bundle-deps.ts
@@ -98,7 +98,17 @@ function createDistNodeModules () {
     'deploy',
     DEPLOY_DIR
   ].join(' ')
-  execSync(pnpmDeploy, { cwd: WORKSPACE_DIR, stdio: 'inherit' })
+  execSync(pnpmDeploy, {
+    cwd: WORKSPACE_DIR,
+    stdio: 'inherit',
+    // The hoisted node linker turns preferSymlinkedExecutables on, which makes
+    // node_modules/.bin a directory of symlinks — and a symlink cannot travel
+    // inside an npm tarball, so every bin would silently disappear from the
+    // published dist/node_modules/.bin. Shell shims survive packing. Passed
+    // through the environment rather than as `--config.` because the release-
+    // pinned pnpm ignores that flag for this setting.
+    env: { ...process.env, pnpm_config_prefer_symlinked_executables: 'false' },
+  })
 
   cleanupNodeModules(DEPLOY_DIR)
 


### PR DESCRIPTION
## Summary

The 11.24.0 release run failed in **Verify TypeScript pnpm release artifacts** with:

```
tar: package/dist/node_modules/.bin/node-gyp: Not found in archive
```

`dist/node_modules` is built by `pnpm deploy --config.node-linker=hoisted`, and the
hoisted linker turns `preferSymlinkedExecutables` on — so `dist/node_modules/.bin`
became a directory of symlinks instead of shell shims. No packer puts a symlink in an
npm tarball (verified with the pnpm 11 bundle, pnpm 12, and npm), so the four bins
there — `node-gyp`, `node-which`, `nopt`, `semver` — silently vanished from the packed
`pnpm` and `@pnpm/exe` tarballs. The verification step stats the payload through the
symlink, still sees a file, and demands it in the tarball; the publish job never ran.

This surfaced now because the `packageManager` pin moved to `pnpm@12.0.0-rc.9`, the
first rc containing `feat(pacquet): support preferSymlinkedExecutables`
(pnpm/pnpm#14044). Reproduced locally with the released rc.9 binary: rc.7 writes 1.5 KB
shim files, rc.9 writes `node-gyp -> ../node-gyp/bin/node-gyp.js`. It is not a pacquet
regression — the TypeScript CLI has always symlinked bins under the hoisted linker, so
rc.9 removed a divergence and exposed a latent problem in the bundling script.

Forcing `preferSymlinkedExecutables: false` for that one deploy restores the layout
`@pnpm/exe@11.23.0` and every release before it shipped.

The setting is passed through `pnpm_config_prefer_symlinked_executables` rather than
`--config.prefer-symlinked-executables=false`, because the release-pinned rc.9 drops
the latter: `--config.<key>` is a curated allowlist in `ConfigOverrides` and this key
is not on it, so the hoisted derivation overwrites it. The env var is honoured by both
stacks (verified against the pnpm 11 bundle and the rc.9 binary), so the fix works with
the currently pinned toolchain and needs no new pacquet release. Worth a separate issue: the
Rust CLI should accept `--config.prefer-symlinked-executables` like the TypeScript CLI
does.

No user-visible change: the published tarballs go back to exactly the contents they had
before 11.24.0, and nothing in the bundle resolves node-gyp through
`dist/node_modules/.bin` anyway (`dist/node-gyp-bin/node-gyp` calls
`../node_modules/node-gyp/bin/node-gyp.js` directly). Hence no changeset.

## Squash Commit Body

```text
`dist/node_modules` is built by a `pnpm deploy --config.node-linker=hoisted`, and the
hoisted linker turns `preferSymlinkedExecutables` on, so `dist/node_modules/.bin`
became a directory of symlinks. An npm tarball cannot carry a symlink, so those bins
were dropped from the packed `pnpm` and `@pnpm/exe` tarballs and the release
workflow's artifact verification failed:

    tar: package/dist/node_modules/.bin/node-gyp: Not found in archive

Force the deploy to write shell shims, which pack fine, restoring the layout every
release before 11.24.0 shipped.

The setting travels through `pnpm_config_prefer_symlinked_executables` because the
release-pinned pnpm 12.0.0-rc.9 does not honour `--config.prefer-symlinked-executables`
for this key.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port,
  or the description notes what still needs porting. — release tooling for the
  TypeScript CLI only; nothing to port.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package.
  — not needed: the published tarballs are restored to their pre-11.24.0 contents.
- [x] Added or updated tests. — covered by the release workflow's own artifact
  verification, which is what caught this.

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed packaging of command-line executables so they remain available after publishing.
  * Ensured bundled dependencies include compatible executable shims instead of links that could be lost during archive creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->