### PR TITLE
fix(release): keep the Rust CLI's bundled bins packable

### DIFF
--- a/pnpm/npm/pnpm/scripts/bundle-node-gyp.mjs
+++ b/pnpm/npm/pnpm/scripts/bundle-node-gyp.mjs
@@ -28,6 +28,7 @@ import { execFileSync } from 'node:child_process'
 import console from 'node:console'
 import fs from 'node:fs'
 import path from 'node:path'
+import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 
 const PNPM_ROOT = path.resolve(fileURLToPath(import.meta.url), '../..')
@@ -52,7 +53,17 @@ function deployNodeGyp () {
     '--prod',
     'deploy',
     DEPLOY_DIR,
-  ], { cwd: REPO_ROOT, stdio: 'inherit' })
+  ], {
+    cwd: REPO_ROOT,
+    stdio: 'inherit',
+    // The hoisted node linker turns preferSymlinkedExecutables on, which makes
+    // node_modules/.bin a directory of symlinks — and a symlink cannot travel
+    // inside an npm tarball, so every bin would silently disappear from the
+    // published dist/node_modules/.bin. Shell shims survive packing. Passed
+    // through the environment rather than as `--config.` because the release-
+    // pinned pnpm ignores that flag for this setting.
+    env: { ...process.env, pnpm_config_prefer_symlinked_executables: 'false' },
+  })
 
   const nmPrune = path.join(PNPM_ROOT, 'node_modules', '.bin', 'nm-prune')
   execFileSync(nmPrune, ['--force'], { cwd: DEPLOY_DIR, stdio: 'inherit' })
@@ -108,6 +119,22 @@ function verifyPayload () {
       `The dist/ payload is incomplete; missing:\n${missing.map((file) => `  ${file}`).join('\n')}`
     )
   }
+  // A symlink never reaches a consumer: `pnpm pack` drops it from the tarball
+  // without a warning, so it would leave the same hole as a missing file.
+  const symlinks = findSymlinks(DIST_DIR)
+  if (symlinks.length > 0) {
+    throw new Error(
+      `The dist/ payload contains symlinks, which npm tarballs cannot carry:\n${symlinks.map((file) => `  ${file}`).join('\n')}`
+    )
+  }
+}
+
+function findSymlinks (dir) {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = path.join(dir, entry.name)
+    if (entry.isSymbolicLink()) return [fullPath]
+    return entry.isDirectory() ? findSymlinks(fullPath) : []
+  })
 }
 
 deployNodeGyp()


### PR DESCRIPTION
## Summary

Follow-up to pnpm/pnpm#14135, which fixed the same bug on the TypeScript side only.
The Rust CLI's release run failed in **Verify pnpm (Rust) npm artifacts** with:

```
tar: package/dist/node_modules/.bin/get-pnpm: Not found in archive
```

`pnpm/npm/pnpm/scripts/bundle-node-gyp.mjs` builds that package's bundled
`dist/node_modules` with `pnpm deploy --config.node-linker=hoisted`, exactly like the
TypeScript CLI's bundler. The hoisted linker turns `preferSymlinkedExecutables` on, so
`dist/node_modules/.bin` became a directory of symlinks instead of shell shims — and an
npm tarball cannot carry a symlink, so all five bins (`get-pnpm`, `node-gyp`,
`node-which`, `nopt`, `semver`) silently vanished from the packed `pnpm` tarball. The
verification step stats the payload through the symlink, still sees a file, and demands
it in the tarball; the publish job never ran.

Reproduced locally against the released `pnpm@12.0.0-rc.9` binary — the pin that first
carried pnpm/pnpm#14044 — using the script's own deploy command: without the fix,
`get-pnpm -> ../get-pnpm/bin/get-pnpm.js`; with it, a 1.5 KB shim.

`verifyPayload` already refuses to ship an incomplete `dist/` payload, so it now also
rejects a symlink anywhere under `dist/`: packing drops one without a warning, which
leaves exactly the hole that function exists to catch. Verified by flipping the setting
back on — the script aborts and names the five symlinks.

The setting is passed through `pnpm_config_prefer_symlinked_executables` rather than
`--config.prefer-symlinked-executables=false`, because the release-pinned rc.9 drops
the latter: `--config.<key>` is a curated allowlist in `ConfigOverrides` and this key is
not on it, so the hoisted derivation overwrites it. The env var is honoured by both
stacks, so this works with the currently pinned toolchain and needs no new release.
Worth a separate issue: the Rust CLI should accept
`--config.prefer-symlinked-executables` like the TypeScript CLI does.

No user-visible change: the published tarball goes back to the contents it had before
12.0.0-rc.10, and nothing resolves through `dist/node_modules/.bin` anyway
(`dist/node-gyp-bin/node-gyp` calls `../node_modules/node-gyp/bin/node-gyp.js`
directly, and the Corepack entry point loads `dist/node_modules/get-pnpm/lib/index.js`).
Hence no changeset.

## Squash Commit Body

```text
The Rust CLI's `dist/node_modules` is deployed the same way as the TypeScript CLI's,
so the hoisted linker symlinked its bins too and `dist/node_modules/.bin/get-pnpm`
went missing from the `pnpm` tarball:

    tar: package/dist/node_modules/.bin/get-pnpm: Not found in archive

Pin the setting off for that deploy as well, and teach `verifyPayload` to reject a
symlink anywhere in `dist/` — packing drops one silently, which leaves exactly the
hole that function exists to catch.

Completes pnpm/pnpm#14135, which fixed only the TypeScript CLI's bundler.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port,
  or the description notes what still needs porting. — the TypeScript half landed in
  pnpm/pnpm#14135; this is the Rust half.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package.
  — not needed: the published tarball is restored to its pre-12.0.0-rc.10 contents.
- [x] Added or updated tests. — the bundler's own payload check now covers this class,
  alongside the release workflow's artifact verification that caught it.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790174977&installation_model_id=426870&pr_number=14136&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14136&signature=8df177f43c3c3be4b21e5573e36cc1f7a707f4ec64801f5d5c3328cf0b424ed2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package creation to ensure executable tools remain usable after installation.
  * Added validation to prevent symbolic links from being included in distributable package archives.
  * Packaging now reports any unexpected symbolic links before release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->