### PR TITLE
fix(release): generate the release description when run as a script

### DIFF
--- a/pnpm11/__utils__/get-release-text/src/main.ts
+++ b/pnpm11/__utils__/get-release-text/src/main.ts
@@ -17,13 +17,6 @@ export const BumpLevels = {
   major: 3,
 } as const
 
-const dirname = path.dirname(fileURLToPath(import.meta.url))
-const repoRoot = path.resolve(dirname, '../../../..')
-
-if (process.argv[1] != null && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
-  await writeReleaseText(repoRoot)
-}
-
 // The sponsors table is shared with the v12 release job, which cats this same
 // fragment onto its RELEASE.md. It is regenerated from pnpm.io's sponsors.json.
 // A missing fragment means someone moved it, not that there are no sponsors —
@@ -113,4 +106,12 @@ export function getChangelogEntry (changelog: string, version: string): Changelo
     content: unified().use(remarkStringify).stringify(ast),
     highestLevel,
   }
+}
+
+// The entry point stays at the bottom: a top-level `await` above a module-level
+// constant runs before that constant is initialized, and the release job only
+// finds out when the description fails to generate.
+if (process.argv[1] != null && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const dirname = path.dirname(fileURLToPath(import.meta.url))
+  await writeReleaseText(process.argv[2] ?? path.resolve(dirname, '../../../..'))
 }

--- a/pnpm11/__utils__/get-release-text/test/main.ts
+++ b/pnpm11/__utils__/get-release-text/test/main.ts
@@ -1,12 +1,18 @@
+import { execFile } from 'node:child_process'
 import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
 
 import { afterEach, beforeEach, expect, test } from '@jest/globals'
 
 import { getChangelogEntry, writeReleaseText } from '../src/main.js'
 
 const SPONSORS_FRAGMENT = '<!-- sponsors -->\n\n## Platinum Sponsors\n\n<!-- sponsors end -->\n'
+
+const execFileAsync = promisify(execFile)
+const scriptPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../src/main.ts')
 
 let workspaceDir: string
 
@@ -68,6 +74,22 @@ test('writes the release description when the sponsors fragment is missing', asy
   const release = await fs.readFile(path.join(workspaceDir, 'RELEASE.md'), 'utf8')
   expect(release).toContain('Fixed the release notes.')
   expect(release).not.toContain('<!-- sponsors -->')
+})
+
+test('writes the release description when run as a script', async () => {
+  const pnpmDir = path.join(workspaceDir, 'pnpm11/pnpm')
+  await fs.mkdir(pnpmDir, { recursive: true })
+  await fs.writeFile(path.join(pnpmDir, 'package.json'), JSON.stringify({ name: 'pnpm', version: '11.13.1' }))
+  const pendingDir = path.join(workspaceDir, '.changeset/changelogs')
+  await fs.mkdir(pendingDir, { recursive: true })
+  await fs.writeFile(path.join(pendingDir, 'pnpm@11.13.1.md'), '## 11.13.1\n\n### Patch Changes\n\n- Fixed the release notes.\n')
+
+  // the release job runs the module, it doesn't import it; only this path
+  // evaluates the top-level entry point
+  await execFileAsync(process.execPath, [scriptPath, workspaceDir])
+
+  const release = await fs.readFile(path.join(workspaceDir, 'RELEASE.md'), 'utf8')
+  expect(release).toContain('Fixed the release notes.')
 })
 
 test('reports a missing changelog for the released version', async () => {

--- a/pnpm11/__utils__/get-release-text/test/main.ts
+++ b/pnpm11/__utils__/get-release-text/test/main.ts
@@ -13,6 +13,9 @@ const SPONSORS_FRAGMENT = '<!-- sponsors -->\n\n## Platinum Sponsors\n\n<!-- spo
 
 const execFileAsync = promisify(execFile)
 const scriptPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../src/main.ts')
+// Node strips types on its own from v23.6; the older versions the test matrix
+// still covers need the flag to load the TypeScript entry point at all.
+const stripTypes = parseInt(process.versions.node, 10) < 23 ? ['--experimental-strip-types'] : []
 
 let workspaceDir: string
 
@@ -86,7 +89,7 @@ test('writes the release description when run as a script', async () => {
 
   // the release job runs the module, it doesn't import it; only this path
   // evaluates the top-level entry point
-  await execFileAsync(process.execPath, [scriptPath, workspaceDir])
+  await execFileAsync(process.execPath, [...stripTypes, scriptPath, workspaceDir])
 
   const release = await fs.readFile(path.join(workspaceDir, 'RELEASE.md'), 'utf8')
   expect(release).toContain('Fixed the release notes.')

--- a/pnpm11/__utils__/get-release-text/test/main.ts
+++ b/pnpm11/__utils__/get-release-text/test/main.ts
@@ -15,7 +15,8 @@ const execFileAsync = promisify(execFile)
 const scriptPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../src/main.ts')
 // Node strips types on its own from v23.6; the older versions the test matrix
 // still covers need the flag to load the TypeScript entry point at all.
-const stripTypes = parseInt(process.versions.node, 10) < 23 ? ['--experimental-strip-types'] : []
+const [nodeMajor, nodeMinor] = process.versions.node.split('.').map(Number)
+const stripTypes = nodeMajor < 23 || (nodeMajor === 23 && nodeMinor < 6) ? ['--experimental-strip-types'] : []
 
 let workspaceDir: string
 


### PR DESCRIPTION
## Summary

The v11.24.0 release page shows "Release notes unavailable" instead of the changelog.

`pn make-release-description` crashed in [the release run](https://github.com/pnpm/pnpm/actions/runs/32739049201), so the workflow fell back to its diagnostic description:

```
ReferenceError: Cannot access 'SPONSORS_FRAGMENT' before initialization
    at readSponsors (.../get-release-text/src/main.ts:36:54)
    at writeReleaseText (.../get-release-text/src/main.ts:52:26)
```

`get-release-text/src/main.ts` ran its top-level `await writeReleaseText(repoRoot)` near the top of the module, above the `const SPONSORS_FRAGMENT` that `readSponsors` reads. Function declarations hoist, `const` bindings do not, so the entry point executed while the constant was still in its temporal dead zone. The regression came in with the shared sponsors fragment (pnpm/pnpm#14118), which added the first module-level constant below that entry point.

Every existing test passed because tests `import` the module, and importing leaves the direct-invocation branch unevaluated. Only `node src/main.ts` — what the release job runs — reaches it.

The entry point now sits at the bottom of the module, past every module-level binding, and a new test spawns the script the way the release job does. It takes an optional workspace directory so that test can point it at a fixture instead of the repository. Verified locally: the new test fails on `main` with the exact CI `ReferenceError` and passes with the fix.

The v11.24.0 draft release still has to have its notes regenerated by hand; this only prevents the next release from hitting the same failure.

## Squash Commit Body

```text
`pn make-release-description` crashed with "Cannot access 'SPONSORS_FRAGMENT'
before initialization", so pnpm 11.24.0's release notes fell back to the
workflow's diagnostic description.

The script's top-level `await writeReleaseText(repoRoot)` sat above the
`SPONSORS_FRAGMENT` constant it ends up reading. Function declarations hoist,
`const` bindings do not: the entry point ran while the constant was still in
its temporal dead zone. The test suite never saw it because tests import the
module, which leaves the direct-invocation branch unevaluated.

Moves the entry point to the bottom of the module, past every module-level
binding, and covers the script path with a test that spawns it the way the
release job does. The entry point takes an optional workspace directory so
that test can point it at a fixture instead of the repository.
```

## Checklist

- [x] Added or updated tests.
- [x] Release tooling for the TypeScript CLI only — the v12 release job builds its description in the workflow itself, so there is nothing to port to `pnpm/`.
- [x] No changeset: `@pnpm/get-release-text` is a private workspace package and no published package changes.

---
Written by an agent (Claude Code, claude-opus-5[1m]).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790176686&installation_model_id=426870&pr_number=14137&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14137&signature=6b3efc12a46accebf51f96d95499414889818282a691e88f83d1c58e0029caaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The release-text tool can run as a standalone command.
  * Added support for specifying a workspace directory when generating release text, with the repository root used by default.

* **Tests**
  * Improved test execution across supported Node.js versions, including older versions that require TypeScript support flags.
  * Added verification for generated output from pending changelog content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->