### PR TITLE
perf(release): build the NAPI addon on its own runners

### DIFF
--- a/.github/actions/rust-release-target/action.yml
+++ b/.github/actions/rust-release-target/action.yml
@@ -1,0 +1,83 @@
+name: Rust release target
+
+description: Prepare a runner to cross-build one Rust release target
+
+inputs:
+  target:
+    description: Rust target triple to cross-build for
+    required: true
+  version:
+    description: Version the release tag names, asserted against the committed sources
+    required: true
+
+runs:
+  using: composite
+
+  steps:
+    - name: Install cross
+      uses: taiki-e/install-action@6cd13508893c0e7eab5f273c2575d3859bd7229a # v2.86.6
+      with:
+        tool: cross
+
+    - name: Install clang-cl for Windows ARM64
+      if: ${{ inputs.target == 'aarch64-pc-windows-msvc' }}
+      shell: pwsh
+      # The values exported below are read off the Visual Studio installation
+      # this step just made and out of `vcvarsall`; nothing here is
+      # attacker-reachable. zizmor flags the writes because a composite action
+      # cannot see who calls it, and the only caller is a release job that runs
+      # on a maintainer-signed tag.
+      run: | # zizmor: ignore[github-env]
+        $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+        $installPath = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationPath
+        & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe" modify --installPath "$installPath" --add Microsoft.VisualStudio.Component.VC.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --quiet --norestart
+        if ($LASTEXITCODE -ne 0) { throw "Visual Studio installer exited with $LASTEXITCODE" }
+        $llvmDir = Join-Path $installPath 'VC\Tools\Llvm'
+        $deadline = (Get-Date).AddMinutes(5)
+        $installerRunning = $true
+        $clangCl = $null
+        do {
+          $installerRunning = @(Get-Process -Name 'vs_installer', 'vs_setup', 'setup' -ErrorAction SilentlyContinue).Count -gt 0
+          $clangCl = Join-Path $llvmDir 'x64\bin\clang-cl.exe'
+          if (-not (Test-Path -LiteralPath $clangCl)) { $clangCl = $null }
+          if ($installerRunning -or $null -eq $clangCl) { Start-Sleep -Seconds 5 }
+        } while (($installerRunning -or $null -eq $clangCl) -and (Get-Date) -lt $deadline)
+        if ($installerRunning) { throw 'Visual Studio installer did not finish within five minutes' }
+        if ($null -eq $clangCl) { throw "clang-cl was not installed under $llvmDir" }
+        & $clangCl --version
+        $clangDir = Split-Path -Parent $clangCl
+        $clang = Join-Path $clangDir 'clang.exe'
+        if (-not (Test-Path -LiteralPath $clang)) { throw "clang was not installed under $clangDir" }
+        & $clang --version
+        "CC_aarch64_pc_windows_msvc=$clangCl" >> $env:GITHUB_ENV
+        "CXX_aarch64_pc_windows_msvc=$clangCl" >> $env:GITHUB_ENV
+        $clangDir >> $env:GITHUB_PATH
+        $vcvarsall = Join-Path $installPath 'VC\Auxiliary\Build\vcvarsall.bat'
+        $targetEnvironment = cmd.exe /c "`"$vcvarsall`" amd64_arm64 > nul && set"
+        if ($LASTEXITCODE -ne 0) { throw "vcvarsall exited with $LASTEXITCODE" }
+        if (-not ($targetEnvironment -match '(?i)^LIB=.*\\arm64')) { throw 'vcvarsall did not configure ARM64 libraries' }
+        foreach ($line in $targetEnvironment) {
+          if ($line -match '^(INCLUDE|LIB|LIBPATH|PATH)=(.*)$') {
+            "$($matches[1])=$($matches[2])" >> $env:GITHUB_ENV
+          }
+        }
+
+    # No build cache: GitHub Actions caches are writable by any workflow on
+    # the default branch, so restoring one here would let a poisoned cache
+    # entry inject code into the published, attested release binaries.
+    - name: Add Rust Target
+      shell: bash
+      env:
+        TARGET: ${{ inputs.target }}
+      run: rustup target add "$TARGET"
+
+    - name: Verify the committed version
+      # `pacquet --version` and the default User-Agent read the PNPM_VERSION
+      # constant, which `pnpm bump` keeps in sync with the npm wrapper's
+      # version. Verify instead of patching so the binaries are reproducible
+      # from the tagged sources.
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        grep -F "PNPM_VERSION: &str = \"$VERSION\"" pnpm/crates/config/src/defaults.rs

--- a/.github/actions/rust-release-target/action.yml
+++ b/.github/actions/rust-release-target/action.yml
@@ -30,12 +30,19 @@ runs:
       run: | # zizmor: ignore[github-env]
         $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
         $installPath = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationPath
-        & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe" modify --installPath "$installPath" --add Microsoft.VisualStudio.Component.VC.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --quiet --norestart
-        if ($LASTEXITCODE -ne 0) { throw "Visual Studio installer exited with $LASTEXITCODE" }
+        & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe" modify --installPath "$installPath" --add Microsoft.VisualStudio.Component.VC.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --quiet --norestart --wait
+        # `--wait` is what makes $LASTEXITCODE report the install rather than
+        # just the launch. 3010 is the installer's "succeeded, wants a
+        # reboot"; `--norestart` is why it wants one, and the components are
+        # usable without it.
+        if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne 3010) { throw "Visual Studio installer exited with $LASTEXITCODE" }
         $llvmDir = Join-Path $installPath 'VC\Tools\Llvm'
         $deadline = (Get-Date).AddMinutes(5)
         $installerRunning = $true
         $clangCl = $null
+        # `--wait` above should have left nothing running, but the installer
+        # spawns work in processes it does not always account for, so poll for
+        # a quiet installer and a real clang-cl before trusting the toolchain.
         do {
           $installerRunning = @(Get-Process -Name 'vs_installer', 'vs_setup', 'setup' -ErrorAction SilentlyContinue).Count -gt 0
           $clangCl = Join-Path $llvmDir 'x64\bin\clang-cl.exe'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -553,12 +553,12 @@ jobs:
           path: node-gyp-payload.tar.gz
 
   # The CLI binary and the NAPI addon are built by two matrices on separate
-  # runners rather than back to back on one. They are compiled under different
-  # Cargo profiles (`release` and `napi-release`, which differ for the reason
-  # documented on those profiles), so Cargo keeps them in separate target
-  # directories and they share not one compiled dependency. Building both in
-  # one job paid for the whole dependency graph twice in series, which put the
-  # slowest leg — win32-arm64 — at ~17 minutes instead of ~11.
+  # runners. They are compiled under different Cargo profiles (`release` and
+  # `napi-release`, which differ for the reason documented on those profiles),
+  # so Cargo keeps them in separate target directories and they share no
+  # compiled dependency: sharing a runner would only make one leg walk the
+  # whole dependency graph twice in series, and the release waits on its
+  # slowest leg.
   build-rust:
     needs:
       - plan
@@ -771,7 +771,10 @@ jobs:
           # Downloaded by the same `binaries-rust-*` pattern the CLI archives
           # are, so both land in one directory for the jobs downstream.
           name: binaries-rust-napi-${{ matrix.code-target }}
-          path: "*.node"
+          # Named exactly, not globbed: the artifact must carry the one file
+          # the step above attested and nothing else that happens to be in the
+          # workspace root.
+          path: pnpm-napi.${{ matrix.code-target }}.node
 
   verify-rust-artifacts:
     name: Verify pnpm (Rust) npm artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -552,6 +552,13 @@ jobs:
           name: node-gyp-payload
           path: node-gyp-payload.tar.gz
 
+  # The CLI binary and the NAPI addon are built by two matrices on separate
+  # runners rather than back to back on one. They are compiled under different
+  # Cargo profiles (`release` and `napi-release`, which differ for the reason
+  # documented on those profiles), so Cargo keeps them in separate target
+  # directories and they share not one compiled dependency. Building both in
+  # one job paid for the whole dependency graph twice in series, which put the
+  # slowest leg — win32-arm64 — at ~17 minutes instead of ~11.
   build-rust:
     needs:
       - plan
@@ -603,98 +610,14 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install cross
-        uses: taiki-e/install-action@6cd13508893c0e7eab5f273c2575d3859bd7229a # v2.86.6
+      - name: Prepare the release target
+        uses: ./.github/actions/rust-release-target
         with:
-          tool: cross
-
-      - name: Install clang-cl for Windows ARM64
-        if: matrix.target == 'aarch64-pc-windows-msvc'
-        shell: pwsh
-        run: |
-          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-          $installPath = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationPath
-          & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe" modify --installPath "$installPath" --add Microsoft.VisualStudio.Component.VC.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --quiet --norestart
-          if ($LASTEXITCODE -ne 0) { throw "Visual Studio installer exited with $LASTEXITCODE" }
-          $llvmDir = Join-Path $installPath 'VC\Tools\Llvm'
-          $deadline = (Get-Date).AddMinutes(5)
-          $installerRunning = $true
-          $clangCl = $null
-          do {
-            $installerRunning = @(Get-Process -Name 'vs_installer', 'vs_setup', 'setup' -ErrorAction SilentlyContinue).Count -gt 0
-            $clangCl = Join-Path $llvmDir 'x64\bin\clang-cl.exe'
-            if (-not (Test-Path -LiteralPath $clangCl)) { $clangCl = $null }
-            if ($installerRunning -or $null -eq $clangCl) { Start-Sleep -Seconds 5 }
-          } while (($installerRunning -or $null -eq $clangCl) -and (Get-Date) -lt $deadline)
-          if ($installerRunning) { throw 'Visual Studio installer did not finish within five minutes' }
-          if ($null -eq $clangCl) { throw "clang-cl was not installed under $llvmDir" }
-          & $clangCl --version
-          $clangDir = Split-Path -Parent $clangCl
-          $clang = Join-Path $clangDir 'clang.exe'
-          if (-not (Test-Path -LiteralPath $clang)) { throw "clang was not installed under $clangDir" }
-          & $clang --version
-          "CC_aarch64_pc_windows_msvc=$clangCl" >> $env:GITHUB_ENV
-          "CXX_aarch64_pc_windows_msvc=$clangCl" >> $env:GITHUB_ENV
-          $clangDir >> $env:GITHUB_PATH
-          $vcvarsall = Join-Path $installPath 'VC\Auxiliary\Build\vcvarsall.bat'
-          $targetEnvironment = cmd.exe /c "`"$vcvarsall`" amd64_arm64 > nul && set"
-          if ($LASTEXITCODE -ne 0) { throw "vcvarsall exited with $LASTEXITCODE" }
-          if (-not ($targetEnvironment -match '(?i)^LIB=.*\\arm64')) { throw 'vcvarsall did not configure ARM64 libraries' }
-          foreach ($line in $targetEnvironment) {
-            if ($line -match '^(INCLUDE|LIB|LIBPATH|PATH)=(.*)$') {
-              "$($matches[1])=$($matches[2])" >> $env:GITHUB_ENV
-            }
-          }
-
-      # No build cache: GitHub Actions caches are writable by any workflow on
-      # the default branch, so restoring one here would let a poisoned cache
-      # entry inject code into the published, attested release binaries.
-      - name: Add Rust Target
-        run: rustup target add ${{ matrix.target }}
-
-      - name: Verify the committed version
-        # `pacquet --version` and the default User-Agent read the PNPM_VERSION
-        # constant, which `pnpm bump` keeps in sync with the npm wrapper's
-        # version. Verify instead of patching so the binary is reproducible
-        # from the tagged sources.
-        shell: bash
-        env:
-          VERSION: ${{ needs.plan.outputs.rust_version }}
-        run: |
-          grep -F "PNPM_VERSION: &str = \"$VERSION\"" pnpm/crates/config/src/defaults.rs
+          target: ${{ matrix.target }}
+          version: ${{ needs.plan.outputs.rust_version }}
 
       - name: Build with cross
         run: cross build --locked -p pnpm-cli --bin pnpm --release --target=${{ matrix.target }}
-
-      - name: Build NAPI addon with cross
-        # musl targets enable `crt-static` by default, but a `cdylib` (the
-        # `.node` addon) can't be produced with a statically linked CRT. Disable
-        # it so the addon builds as a shared object that dynamically links musl
-        # libc at load time (this is what napi-rs does for musl prebuilds). The
-        # CLI binary keeps `crt-static` — it's built in the separate step above,
-        # so it stays fully static for portability across musl distros.
-        #
-        # Set RUSTFLAGS only for musl: an empty RUSTFLAGS is not a no-op — Cargo
-        # treats it as an override that discards any `rustflags` from
-        # `.cargo/config.toml`, so we leave it unset on every other target.
-        shell: bash
-        env:
-          TARGET: ${{ matrix.target }}
-        run: |
-          if [[ "$TARGET" == *musl* ]]; then
-            export RUSTFLAGS="-C target-feature=-crt-static"
-          fi
-          cross build --locked -p pnpm-napi --profile napi-release --target="$TARGET"
-
-      - name: Prepare NAPI addon
-        shell: bash
-        run: |
-          case "${{ runner.os }}" in
-            Windows) source="target/${{ matrix.target }}/napi-release/pnpm_napi.dll" ;;
-            macOS) source="target/${{ matrix.target }}/napi-release/libpnpm_napi.dylib" ;;
-            *) source="target/${{ matrix.target }}/napi-release/libpnpm_napi.so" ;;
-          esac
-          cp "$source" "pnpm-napi.${{ matrix.code-target }}.node"
 
       - name: Download node-gyp payload
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -735,9 +658,7 @@ jobs:
       - name: Attest build provenance
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
-          subject-path: |
-            pnpm-${{ matrix.code-target }}.*
-            pnpm-napi.${{ matrix.code-target }}.node
+          subject-path: pnpm-${{ matrix.code-target }}.*
 
       - name: Upload Binary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -747,7 +668,110 @@ jobs:
           path: |
             *.zip
             *.tar.gz
-            *.node
+
+  build-rust-napi:
+    # Deliberately not waiting on build-node-gyp-payload: the addon ships no
+    # node-gyp, so these legs start as soon as the release is planned.
+    needs: plan
+    if: needs.plan.outputs.rust == 'true' && !inputs.verify_ts_release
+    permissions:
+      contents: read
+      id-token: write # needed for actions/attest-build-provenance
+      attestations: write
+    strategy:
+      matrix:
+        # Every target build-rust above packages a CLI binary for also needs
+        # an addon — `pnpm/npm/napi/scripts/generate-packages.mjs` fails on a
+        # missing one — so keep the two matrices in sync.
+        include:
+          - os: blacksmith-8vcpu-windows-2025
+            target: x86_64-pc-windows-msvc
+            code-target: win32-x64
+
+          - os: blacksmith-8vcpu-windows-2025
+            target: aarch64-pc-windows-msvc
+            code-target: win32-arm64
+
+          - os: blacksmith-8vcpu-ubuntu-2404
+            target: x86_64-unknown-linux-gnu
+            code-target: linux-x64
+
+          - os: blacksmith-8vcpu-ubuntu-2404
+            target: aarch64-unknown-linux-gnu
+            code-target: linux-arm64
+
+          - os: blacksmith-8vcpu-ubuntu-2404
+            target: x86_64-unknown-linux-musl
+            code-target: linux-x64-musl
+
+          - os: blacksmith-8vcpu-ubuntu-2404
+            target: aarch64-unknown-linux-musl
+            code-target: linux-arm64-musl
+
+          - os: blacksmith-12vcpu-macos-latest
+            target: x86_64-apple-darwin
+            code-target: darwin-x64
+
+          - os: blacksmith-12vcpu-macos-latest
+            target: aarch64-apple-darwin
+            code-target: darwin-arm64
+
+    name: Package @pnpm/napi ${{ matrix.code-target }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Prepare the release target
+        uses: ./.github/actions/rust-release-target
+        with:
+          target: ${{ matrix.target }}
+          version: ${{ needs.plan.outputs.rust_version }}
+
+      - name: Build NAPI addon with cross
+        # musl targets enable `crt-static` by default, but a `cdylib` (the
+        # `.node` addon) can't be produced with a statically linked CRT. Disable
+        # it so the addon builds as a shared object that dynamically links musl
+        # libc at load time (this is what napi-rs does for musl prebuilds). The
+        # CLI binary keeps `crt-static` — build-rust builds it untouched, so it
+        # stays fully static for portability across musl distros.
+        #
+        # Set RUSTFLAGS only for musl: an empty RUSTFLAGS is not a no-op — Cargo
+        # treats it as an override that discards any `rustflags` from
+        # `.cargo/config.toml`, so we leave it unset on every other target.
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          if [[ "$TARGET" == *musl* ]]; then
+            export RUSTFLAGS="-C target-feature=-crt-static"
+          fi
+          cross build --locked -p pnpm-napi --profile napi-release --target="$TARGET"
+
+      - name: Prepare NAPI addon
+        shell: bash
+        run: |
+          case "${{ runner.os }}" in
+            Windows) source="target/${{ matrix.target }}/napi-release/pnpm_napi.dll" ;;
+            macOS) source="target/${{ matrix.target }}/napi-release/libpnpm_napi.dylib" ;;
+            *) source="target/${{ matrix.target }}/napi-release/libpnpm_napi.so" ;;
+          esac
+          cp "$source" "pnpm-napi.${{ matrix.code-target }}.node"
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: pnpm-napi.${{ matrix.code-target }}.node
+
+      - name: Upload NAPI addon
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          if-no-files-found: error
+          # Downloaded by the same `binaries-rust-*` pattern the CLI archives
+          # are, so both land in one directory for the jobs downstream.
+          name: binaries-rust-napi-${{ matrix.code-target }}
+          path: "*.node"
 
   verify-rust-artifacts:
     name: Verify pnpm (Rust) npm artifacts
@@ -757,6 +781,7 @@ jobs:
     needs:
       - plan
       - build-rust
+      - build-rust-napi
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -900,6 +925,7 @@ jobs:
     needs:
       - plan
       - build-rust
+      - build-rust-napi
       - verify-rust-artifacts
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -981,6 +1007,7 @@ jobs:
     needs:
       - plan
       - build-rust
+      - build-rust-napi
       - publish-rust
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

The Rust release built the CLI binary and the NAPI addon back to back in one matrix leg per target. The two are compiled under different Cargo profiles — `release` for the CLI, `napi-release` for the addon (which must keep `panic = "unwind"`) — so Cargo gives them separate target directories and they share not one compiled dependency. Every leg paid for the whole dependency graph twice, in series.

This splits the addon into its own `build-rust-napi` matrix over the same eight targets. Per-leg build time measured on the `v12.0.0-rc.9` release run:

| target | CLI build | addon build | leg total |
| --- | --- | --- | --- |
| win32-arm64 | 508s | 369s | **17m09s** |
| win32-x64 | 495s | 363s | 15m06s |
| darwin-arm64 | 477s | 241s | 12m30s |
| darwin-x64 | 461s | 235s | 12m10s |
| linux-\* | 322–351s | 217–238s | ~10m |

The stage is bounded by its slowest leg, so taking the addon out of `win32-arm64` moves the critical path from ~17 to ~11 minutes, and the whole release run from ~25m30s to roughly 19 minutes. The addon legs run alongside and gate nothing.

Nothing downstream needed changing: the new job uploads to `binaries-rust-napi-<code-target>`, which the `binaries-rust-*` download pattern that the verify, publish and draft-release jobs already use picks up and merges into the same directory. It also drops the `build-node-gyp-payload` dependency, since only the CLI archives ship `dist/`.

The toolchain prelude the two jobs share — installing `cross`, the clang-cl/ARM64 Visual Studio components, the rustup target, and the guard that the committed `PNPM_VERSION` matches the tag — moves into a `rust-release-target` composite action instead of being duplicated.

**One thing worth a reviewer's eye:** zizmor reports `github-env` (high) against that composite action's writes to `GITHUB_ENV`/`GITHUB_PATH`. It is a false positive of the move — the same script in `release.yml` was not flagged, because there zizmor can see the workflow only triggers on tag pushes, whereas a composite action cannot see who calls it. The values come from the Visual Studio installation the step just made and from `vcvarsall`, and the only caller is a release job running on a maintainer-signed tag. It is suppressed on that step with that justification. Verified with `zizmor 1.29.0`: `.github/workflows/release.yml` and the new action both report no findings.

Not verifiable end to end before merge — the workflow only runs on a version tag. The YAML and job graph were validated locally; the first release after this lands is the real test, and a failure is resumable by rerunning the tag (the `plan` job skips what is already published).

## Squash Commit Body

```text
The Rust release built the CLI binary and the NAPI addon back to back in
one matrix leg per target. The two are compiled under different Cargo
profiles — `release` for the CLI, `napi-release` for the addon, which
must keep `panic = "unwind"` so a panic reaching the FFI boundary becomes
a JS exception instead of aborting the host node process. Different
profile means a different target directory, so the two builds shared not
one compiled dependency: every leg paid for the whole graph twice, in
series.

Split the addon into its own `build-rust-napi` matrix over the same eight
targets. Measured on the 12.0.0-rc.9 release run, per-leg build time was:

  target             CLI     addon    leg
  win32-arm64        508s    369s     17m09s
  win32-x64          495s    363s     15m06s
  darwin-arm64       477s    241s     12m30s
  darwin-x64         461s    235s     12m10s
  linux-*        322-351s  217-238s   ~10m

The stage is bounded by its slowest leg, so dropping the addon out of
win32-arm64 takes the critical path from ~17 to ~11 minutes and the whole
release run from ~25m30s to roughly 19 minutes. The addon legs run
alongside and gate nothing.

Downstream needs no changes: the new job uploads to
`binaries-rust-napi-<code-target>`, which the `binaries-rust-*` download
pattern the verify, publish and draft-release jobs already use picks up
and merges into the same directory. It is also free of the node-gyp
payload dependency, since only the CLI archives ship `dist/`.

The toolchain prelude the two jobs share — installing cross, the
clang-cl/ARM64 Visual Studio components, the rustup target, and the guard
that the committed PNPM_VERSION matches the tag — moves into a
`rust-release-target` composite action rather than being duplicated.
zizmor flags that action's writes to GITHUB_ENV/GITHUB_PATH because a
composite action cannot see who calls it; the values come from the
Visual Studio install and `vcvarsall`, and the only caller is a release
job running on a maintainer-signed tag, so the audit is suppressed on
that step with that justification.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <!-- Release CI only; no CLI surface on either side. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
  <!-- No published package changes: this touches only release CI. -->
- [x] Added or updated tests.
  <!-- Not testable outside a tagged release run; validated with zizmor and a YAML/job-graph check. -->
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790176836&installation_model_id=426870&pr_number=14138&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14138&signature=a49af675c7ad9de149aa6a60a25536651ed17218946b312f20e87f79d79fda1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for building and releasing platform-specific native addons independently from the Rust CLI.
  * Added cross-build support for Windows ARM64 releases.
  * Release artifacts now include separately verified CLI binaries and native addons.

* **Improvements**
  * Release publishing is performed in parallel where possible, helping streamline delivery.
  * Added validation to ensure published packages match the intended release version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->