### PR TITLE
feat(stage): approve staged packages interactively with one OTP

### DIFF
--- a/.changeset/stage-approve-interactive.md
+++ b/.changeset/stage-approve-interactive.md
@@ -1,6 +1,8 @@
 ---
 "@pnpm/releasing.commands": minor
 "@pnpm/network.web-auth": minor
+"@pnpm/text.sanitize": minor
+"@pnpm/installing.commands": patch
 "pacquet": minor
 "pnpm": minor
 ---

--- a/.changeset/stage-approve-interactive.md
+++ b/.changeset/stage-approve-interactive.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/releasing.commands": minor
+"@pnpm/network.web-auth": minor
+"pacquet": minor
+"pnpm": minor
+---
+
+`pnpm stage approve` now approves several staged packages at once. Run it without a stage id to pick from the staged versions interactively, or pass a list of stage ids. The whole batch is approved with a single one-time password, and pnpm asks for a new one only once the registry stops accepting it. Inside a workspace, the selected packages are approved in dependency order, and a package whose workspace dependency could not be approved is skipped instead of being published against a dependency that never reached the registry.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -69,18 +69,24 @@ See [#13578](https://github.com/pnpm/pnpm/issues/13578).
 6. After the workflow finishes, approve the staged npm packages. The TypeScript
    pnpm release stages `@pnpm/exe` and then `pnpm`. The Rust pnpm release
    stages its native packages, then its `@pnpm/napi` and `@pnpm/exe` wrappers, and finally
-   `pnpm`. Copy the stage IDs from the completed job's summary and approve each
-   one from a maintainer's machine. Approve all packages in each dependency
-   layer before moving to the next layer, leaving `pnpm` until last:
+   `pnpm`. Approve them from a maintainer's machine, from a checkout of this
+   repository so the staged packages are approved in workspace dependency
+   order:
 
    ```bash
-   pnpm stage approve <stage-id>
+   pnpm stage approve
    ```
 
-   Approval requires interactive 2FA. The npm trusted publishers for `pnpm`,
-   `@pnpm/exe`, `@pnpm/napi`, and their platform packages must allow staged
-   publishing only, so CI can stage a release but cannot approve or publish it
-   directly.
+   The command lists every staged version, approves the ones selected in the
+   picker, and stops before publishing a package whose workspace dependency
+   failed to be approved. Passing the stage IDs from the completed job's
+   summary (`pnpm stage approve <stage-id> ...`) approves that set instead.
+
+   Approval requires interactive 2FA, once for the whole selection — pnpm asks
+   for another one-time password only when the registry stops accepting the
+   one it holds. The npm trusted publishers for `pnpm`, `@pnpm/exe`,
+   `@pnpm/napi`, and their platform packages must allow staged publishing only,
+   so CI can stage a release but cannot approve or publish it directly.
 
 ## Reruns and partial releases
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8430,6 +8430,12 @@ importers:
       '@pnpm/workspace.projects-filter':
         specifier: workspace:*
         version: link:../../workspace/projects-filter
+      '@pnpm/workspace.projects-graph':
+        specifier: workspace:*
+        version: link:../../workspace/projects-graph
+      '@pnpm/workspace.projects-reader':
+        specifier: workspace:*
+        version: link:../../workspace/projects-reader
       '@pnpm/workspace.projects-sorter':
         specifier: workspace:*
         version: link:../../workspace/projects-sorter

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5385,6 +5385,9 @@ importers:
       '@pnpm/text.ordinal-comparator':
         specifier: workspace:*
         version: link:../../text/ordinal-comparator
+      '@pnpm/text.sanitize':
+        specifier: workspace:*
+        version: link:../../text/sanitize
       '@pnpm/types':
         specifier: workspace:*
         version: link:../../core/types
@@ -8424,6 +8427,9 @@ importers:
       '@pnpm/resolving.resolver-base':
         specifier: workspace:*
         version: link:../../resolving/resolver-base
+      '@pnpm/text.sanitize':
+        specifier: workspace:*
+        version: link:../../text/sanitize
       '@pnpm/types':
         specifier: workspace:*
         version: link:../../core/types
@@ -9675,6 +9681,15 @@ importers:
         specifier: 'catalog:'
         version: 30.4.1(supports-color@10.2.2)
       '@pnpm/text.ordinal-comparator':
+        specifier: workspace:*
+        version: 'link:'
+
+  pnpm11/text/sanitize:
+    devDependencies:
+      '@jest/globals':
+        specifier: 'catalog:'
+        version: 30.4.1(supports-color@10.2.2)
+      '@pnpm/text.sanitize':
         specifier: workspace:*
         version: 'link:'
 

--- a/pnpm/crates/cli/src/cli_args/stage.rs
+++ b/pnpm/crates/cli/src/cli_args/stage.rs
@@ -6,6 +6,7 @@
 //! subcommands — `list`, `view`, `approve`, `reject`, `download` — talk to
 //! the registry's `-/stage` API directly.
 
+mod approve;
 mod summarize_tarball;
 
 use std::{collections::HashMap, path::Path, time::Duration};
@@ -18,8 +19,8 @@ use pnpm_network::{
     RetryOpts, ThrottledClient, read_limited_body, redact_url_credentials, send_with_retry,
 };
 use pnpm_network_web_auth::{
-    Host as WebAuthHost, OtpChallenge, OtpError, OtpErrorBody, WebAuthFetchOptions,
-    WebAuthRetryOptions, WithOtpError, with_otp_handling,
+    Host as WebAuthHost, OtpChallenge, OtpError, OtpErrorBody, OtpSession, WebAuthFetchOptions,
+    WebAuthRetryOptions, WithOtpError,
 };
 use pnpm_publish::{Host, PublishSummary, resolve_otp_from_env};
 use pnpm_reporter::{GlobalLog, LogEvent, LogLevel, Reporter};
@@ -180,7 +181,7 @@ impl StageArgs {
             Some("publish") => self.stage_publish::<Reporter>(dir, config, recursive).await,
             Some("list") => self.stage_list(config).await,
             Some("view") => self.stage_view(config).await,
-            Some("approve") => self.stage_approve::<Reporter>(config).await,
+            Some("approve") => approve::stage_approve::<Reporter>(&self, config).await,
             Some("reject") => self.stage_reject::<Reporter>(config).await,
             Some("download") => self.stage_download(dir, config).await,
             None => Err(StageError::SubcommandRequired.into()),
@@ -224,28 +225,7 @@ impl StageArgs {
     async fn stage_list(&self, config: &Config) -> miette::Result<Option<String>> {
         let package_filter = parse_package_filter(self.params.get(1))?;
         let context = self.stage_context(config, package_filter.as_deref())?;
-        let mut items: Vec<Value> = Vec::new();
-        let mut page: usize = 0;
-        loop {
-            let mut url = stage_endpoint_url(&context.registry, "-/stage")?;
-            url.query_pairs_mut()
-                .append_pair("page", &page.to_string())
-                .append_pair("perPage", &PER_PAGE.to_string());
-            if let Some(package) = &package_filter {
-                url.query_pairs_mut().append_pair("package", package);
-            }
-            let response: StageListResponse =
-                stage_json_request(&context, url.as_str(), "list staged packages").await?;
-            let page_len = response.items.len();
-            items.extend(response.items);
-            if items.len() >= response.total || page_len < PER_PAGE {
-                break;
-            }
-            page += 1;
-            if page >= STAGE_LIST_MAX_PAGES {
-                break;
-            }
-        }
+        let items = fetch_stage_items(&context, package_filter.as_deref()).await?;
 
         if self.flags.json {
             return Ok(Some(json_pretty(&Value::Array(items))?));
@@ -272,25 +252,6 @@ impl StageArgs {
             return Ok(Some(json_pretty(&item)?));
         }
         Ok(Some(render_stage_item(&item)))
-    }
-
-    /// `stage approve <stage-id>` — publish the staged version, satisfying an
-    /// OTP / web-auth challenge if the registry raises one.
-    async fn stage_approve<Reporter: self::Reporter>(
-        &self,
-        config: &Config,
-    ) -> miette::Result<Option<String>> {
-        let stage_id = require_stage_id(&self.params, "approve")?;
-        let context = self.stage_context(config, None)?;
-        let url = stage_endpoint_url(&context.registry, &format!("-/stage/{stage_id}/approve"))?;
-        stage_request_with_otp::<Reporter>(
-            &context,
-            reqwest::Method::POST,
-            url.as_str(),
-            &format!("approve staged package {stage_id}"),
-        )
-        .await?;
-        Ok(Some(format!("Staged package {stage_id} approved and published successfully.")))
     }
 
     /// `stage reject <stage-id>` — permanently delete the staged version.
@@ -458,33 +419,47 @@ async fn stage_request_with_otp<Reporter: self::Reporter>(
     url: &str,
     action: &str,
 ) -> miette::Result<()> {
-    with_otp_handling::<WebAuthHost, Reporter, (), StageHttpError, _, _>(
-        context.web_auth_fetch_options.clone(),
-        // A plain `FnMut` returning an `async move` block (not an
-        // `AsyncFnMut`) so the produced future carries an ordinary `Send`
-        // obligation — see `with_otp_handling`'s `Operation` bound.
-        move |challenge_otp: Option<String>| {
-            // The web-auth-provided OTP (a fresh challenge) takes precedence
-            // over any statically configured one.
-            let effective_otp = challenge_otp.or_else(|| context.otp.clone());
-            let method = method.clone();
-            async move {
-                stage_mutation(context, method, url, action, effective_otp.as_deref()).await
+    let mut session = OtpSession::new(context.web_auth_fetch_options.clone());
+    stage_request_in_session::<Reporter>(context, &mut session, method, url, action).await
+}
+
+/// Send one stage mutation through `session`, so a series of mutations
+/// shares a single one-time password. See [`stage_request_with_otp`] for the
+/// standalone form.
+async fn stage_request_in_session<Reporter: self::Reporter>(
+    context: &StageContext,
+    session: &mut OtpSession,
+    method: reqwest::Method,
+    url: &str,
+    action: &str,
+) -> miette::Result<()> {
+    session
+        .run::<WebAuthHost, Reporter, (), StageHttpError, _, _>(
+            // A plain `FnMut` returning an `async move` block (not an
+            // `AsyncFnMut`) so the produced future carries an ordinary `Send`
+            // obligation — see `with_otp_handling`'s `Operation` bound.
+            move |challenge_otp: Option<String>| {
+                // The web-auth-provided OTP (a fresh challenge) takes precedence
+                // over any statically configured one.
+                let effective_otp = challenge_otp.or_else(|| context.otp.clone());
+                let method = method.clone();
+                async move {
+                    stage_mutation(context, method, url, action, effective_otp.as_deref()).await
+                }
+            },
+        )
+        .await
+        .map_err(|error| match error {
+            // Unwrap the operation's own failure so the user sees the registry
+            // error once, not re-narrated through the OTP wrapper.
+            WithOtpError::Operation(StageHttpError::Registry(registry_error)) => {
+                miette::Report::new(registry_error)
             }
-        },
-    )
-    .await
-    .map_err(|error| match error {
-        // Unwrap the operation's own failure so the user sees the registry
-        // error once, not re-narrated through the OTP wrapper.
-        WithOtpError::Operation(StageHttpError::Registry(registry_error)) => {
-            miette::Report::new(registry_error)
-        }
-        WithOtpError::Operation(StageHttpError::Request(request_error)) => {
-            miette::Report::new(*request_error)
-        }
-        other => miette::Report::new(other),
-    })
+            WithOtpError::Operation(StageHttpError::Request(request_error)) => {
+                miette::Report::new(*request_error)
+            }
+            other => miette::Report::new(other),
+        })
 }
 
 /// Perform a single stage mutation request and classify the response.
@@ -522,6 +497,37 @@ async fn stage_mutation(
         &status_text,
         &body_display_string(&body),
     )))
+}
+
+/// Every staged version the registry reports, optionally narrowed to one
+/// package name.
+async fn fetch_stage_items(
+    context: &StageContext,
+    package_filter: Option<&str>,
+) -> miette::Result<Vec<Value>> {
+    let mut items: Vec<Value> = Vec::new();
+    let mut page: usize = 0;
+    loop {
+        let mut url = stage_endpoint_url(&context.registry, "-/stage")?;
+        url.query_pairs_mut()
+            .append_pair("page", &page.to_string())
+            .append_pair("perPage", &PER_PAGE.to_string());
+        if let Some(package) = package_filter {
+            url.query_pairs_mut().append_pair("package", package);
+        }
+        let response: StageListResponse =
+            stage_json_request(context, url.as_str(), "list staged packages").await?;
+        let page_len = response.items.len();
+        items.extend(response.items);
+        if items.len() >= response.total || page_len < PER_PAGE {
+            break;
+        }
+        page += 1;
+        if page >= STAGE_LIST_MAX_PAGES {
+            break;
+        }
+    }
+    Ok(items)
 }
 
 /// GET a `-/stage` endpoint and parse its JSON body.
@@ -763,6 +769,13 @@ fn render_tarball_summary(summary: &PublishSummary) -> String {
         integrity = summary.integrity,
         entry_count = summary.entry_count,
     )
+}
+
+fn global_info<Reporter: self::Reporter>(message: &str) {
+    Reporter::emit(&LogEvent::Global(GlobalLog {
+        level: LogLevel::Info,
+        message: message.to_owned(),
+    }));
 }
 
 fn global_warn<Reporter: self::Reporter>(message: &str) {

--- a/pnpm/crates/cli/src/cli_args/stage.rs
+++ b/pnpm/crates/cli/src/cli_args/stage.rs
@@ -381,9 +381,9 @@ struct StageContext {
     web_auth_fetch_options: WebAuthFetchOptions,
 }
 
-/// An HTTP-level failure of a stage mutation, handed to
-/// [`with_otp_handling`]. Only the [`Otp`](Self::Otp) arm is a challenge it
-/// acts on; the rest propagate.
+/// An HTTP-level failure of a stage mutation, handed to the
+/// [`OtpSession`]. Only the [`Otp`](Self::Otp) arm is a challenge it acts on;
+/// the rest propagate.
 #[derive(Debug, Display, Error, Diagnostic)]
 enum StageHttpError {
     #[display("the registry requested a one-time password")]

--- a/pnpm/crates/cli/src/cli_args/stage.rs
+++ b/pnpm/crates/cli/src/cli_args/stage.rs
@@ -142,6 +142,10 @@ pub enum StageError {
 pub struct StageRegistryError {
     #[error(not(source))]
     message: String,
+    /// The response status, kept so a caller can tell "no such staged
+    /// version" apart from a failure that applies to every request.
+    #[error(not(source))]
+    pub status: u16,
 }
 
 impl StageRegistryError {
@@ -157,7 +161,7 @@ impl StageRegistryError {
         } else {
             format!("Failed to {action} (status {status_display}): {trimmed}")
         };
-        StageRegistryError { message }
+        StageRegistryError { message, status }
     }
 }
 

--- a/pnpm/crates/cli/src/cli_args/stage/approve.rs
+++ b/pnpm/crates/cli/src/cli_args/stage/approve.rs
@@ -1,10 +1,9 @@
 //! `pnpm stage approve` — publish staged versions, chosen interactively
 //! when none are named.
 //!
-//! A batch of versions is approved through a single
-//! [`OtpSession`](pnpm_network_web_auth::OtpSession), so one proof of
-//! presence covers all of them, and in workspace dependency order, so a
-//! package reaches the registry only after the workspace packages it
+//! A batch of versions is approved through a single [`OtpSession`], so one
+//! proof of presence covers all of them, and in workspace dependency order,
+//! so a package reaches the registry only after the workspace packages it
 //! depends on.
 
 use std::{

--- a/pnpm/crates/cli/src/cli_args/stage/approve.rs
+++ b/pnpm/crates/cli/src/cli_args/stage/approve.rs
@@ -28,6 +28,7 @@ use super::{
 use crate::cli_args::{
     changelog::published_name,
     recursive::{discover_workspace_projects, sort_projects},
+    sanitize::sanitize_inline,
 };
 
 /// `pnpm stage approve` with no `<stage-id>` outside an interactive
@@ -41,19 +42,6 @@ use crate::cli_args::{
     )
 )]
 struct StageApproveIdRequired;
-
-/// Not every staged version of an approval batch reached the registry. The
-/// per-version outcome is already reported; this carries the count and the
-/// failing exit status.
-#[derive(Debug, Display, Error, Diagnostic)]
-#[display("Approved {approved} of {total} staged packages.")]
-#[diagnostic(code(ERR_PNPM_STAGE_APPROVE_INCOMPLETE))]
-struct StageApprovalsIncomplete {
-    #[error(not(source))]
-    approved: usize,
-    #[error(not(source))]
-    total: usize,
-}
 
 /// One staged version, as much of it as the registry's `-/stage` listing
 /// reported.
@@ -81,15 +69,20 @@ impl StageApprovalItem {
         }
     }
 
+    /// Reads one entry of the registry's `-/stage` listing. The entry is
+    /// registry-controlled input that ends up in a terminal prompt the user
+    /// picks releases from, so its id has to be the same UUID the other
+    /// subcommands accept, and its text is stripped of the control characters
+    /// that could redraw the prompt around a selection.
     fn from_value(item: &Value) -> Option<Self> {
         let string_field = |field: &str| {
             item.get(field)
                 .and_then(Value::as_str)
+                .map(|value| sanitize_inline(value).into_owned())
                 .filter(|value| !value.is_empty())
-                .map(str::to_owned)
         };
         Some(StageApprovalItem {
-            id: string_field("id")?,
+            id: string_field("id").filter(|id| is_uuid(id))?,
             package_name: string_field("packageName"),
             version: string_field("version"),
             tag: string_field("tag"),
@@ -184,10 +177,16 @@ pub(super) async fn stage_approve<Reporter: self::Reporter>(
 
 /// The `<stage-id>` arguments of `pnpm stage approve`, each validated as a
 /// UUID. An empty list asks for interactive selection.
+///
+/// A staged version repeated on the command line is one approval: sending the
+/// second request would either fail against the release the first one
+/// published, or count the same package twice.
 fn parse_stage_ids(params: &[String]) -> Result<Vec<String>, StageError> {
+    let mut seen = HashSet::new();
     params
         .iter()
         .skip(1)
+        .filter(|stage_id| seen.insert((*stage_id).clone()))
         .map(
             |stage_id| {
                 if is_uuid(stage_id) {
@@ -277,7 +276,14 @@ async fn approve_staged_packages<Reporter: self::Reporter>(
         }
     }
     if approved < items.len() {
-        return Err(StageApprovalsIncomplete { approved, total: items.len() }.into());
+        // pnpm prints this summary and exits 1. A command here either returns
+        // output or an error, never both, so print it the way the dispatcher
+        // prints a command's output and exit with the failing status.
+        #[expect(clippy::exit, reason = "an incomplete approval batch exits 1, mirroring pnpm")]
+        {
+            println!("Approved {approved} of {}.", render_package_count(items.len()));
+            std::process::exit(1);
+        }
     }
     Ok(Some(format!("Approved {} successfully.", render_package_count(approved))))
 }

--- a/pnpm/crates/cli/src/cli_args/stage/approve.rs
+++ b/pnpm/crates/cli/src/cli_args/stage/approve.rs
@@ -23,7 +23,7 @@ use serde_json::Value;
 
 use super::{
     StageArgs, StageContext, StageError, fetch_stage_items, global_info, global_warn, is_uuid,
-    stage_endpoint_url, stage_request_in_session,
+    stage_endpoint_url, stage_json_request, stage_request_in_session,
 };
 use crate::cli_args::{
     changelog::published_name,
@@ -212,30 +212,43 @@ async fn approval_items(context: &StageContext) -> miette::Result<Vec<StageAppro
         .collect())
 }
 
-/// The staged versions the given ids identify. Stage ids are hexadecimal, so
-/// the lookup ignores their spelling: an id the listing carries in another
-/// casing still resolves to the package name the approval order and the
-/// dependency blocking are keyed on. An id the registry does not list at all
-/// is kept as is, so approving it fails on the registry's own error rather
-/// than on a guess about why it is missing.
+/// The staged versions the given ids identify, each read from the registry's
+/// entry for that id rather than from the full staged listing, which a busy
+/// registry can page far beyond what the batch needs.
+///
+/// A version the registry does not describe is kept as its bare id, so
+/// approving it fails on the registry's own error rather than on a guess
+/// about why it is missing; it also carries no package name, so it is
+/// approved outside the workspace order.
 async fn resolve_approval_items(
     context: &StageContext,
     stage_ids: &[String],
 ) -> miette::Result<Vec<StageApprovalItem>> {
-    let listed: HashMap<String, StageApprovalItem> = approval_items(context)
-        .await?
-        .into_iter()
-        .map(|item| (item.id.to_lowercase(), item))
-        .collect();
-    Ok(stage_ids
-        .iter()
-        .map(|stage_id| {
-            listed
-                .get(&stage_id.to_lowercase())
-                .cloned()
-                .unwrap_or_else(|| StageApprovalItem::from_id(stage_id))
-        })
-        .collect())
+    let mut items = Vec::with_capacity(stage_ids.len());
+    for stage_id in stage_ids {
+        let url = stage_endpoint_url(&context.registry, &format!("-/stage/{stage_id}"))?;
+        let action = format!("view staged package {stage_id}");
+        let described: Option<Value> =
+            stage_json_request(context, url.as_str(), &action).await.ok();
+        items.push(
+            described
+                .as_ref()
+                .and_then(|item| StageApprovalItem::from_value(&with_id(item, stage_id)))
+                .unwrap_or_else(|| StageApprovalItem::from_id(stage_id)),
+        );
+    }
+    Ok(items)
+}
+
+/// The registry's description of a staged version, keyed by the id the
+/// command line named it with: the id in the body is the registry's own
+/// spelling, and hexadecimal ids are the same id in any casing.
+fn with_id(item: &Value, stage_id: &str) -> Value {
+    let mut item = item.clone();
+    if let Some(object) = item.as_object_mut() {
+        object.insert("id".to_owned(), Value::String(stage_id.to_owned()));
+    }
+    item
 }
 
 /// Show the checkbox prompt; an interrupted prompt selects nothing.

--- a/pnpm/crates/cli/src/cli_args/stage/approve.rs
+++ b/pnpm/crates/cli/src/cli_args/stage/approve.rs
@@ -81,8 +81,11 @@ impl StageApprovalItem {
                 .map(|value| sanitize_inline(value).into_owned())
                 .filter(|value| !value.is_empty())
         };
+        // The id is validated before sanitizing: stripping a formatting
+        // character out of it must not be what makes it a UUID.
+        let id = item.get("id").and_then(Value::as_str).filter(|id| is_uuid(id))?.to_owned();
         Some(StageApprovalItem {
-            id: string_field("id").filter(|id| is_uuid(id))?,
+            id,
             package_name: string_field("packageName"),
             version: string_field("version"),
             tag: string_field("tag"),
@@ -180,13 +183,15 @@ pub(super) async fn stage_approve<Reporter: self::Reporter>(
 ///
 /// A staged version repeated on the command line is one approval: sending the
 /// second request would either fail against the release the first one
-/// published, or count the same package twice.
+/// published, or count the same package twice. Stage ids are hexadecimal, so
+/// the same id in two spellings is the same id; the first spelling is the one
+/// that reaches the registry.
 fn parse_stage_ids(params: &[String]) -> Result<Vec<String>, StageError> {
     let mut seen = HashSet::new();
     params
         .iter()
         .skip(1)
-        .filter(|stage_id| seen.insert((*stage_id).clone()))
+        .filter(|stage_id| seen.insert(stage_id.to_lowercase()))
         .map(
             |stage_id| {
                 if is_uuid(stage_id) {

--- a/pnpm/crates/cli/src/cli_args/stage/approve.rs
+++ b/pnpm/crates/cli/src/cli_args/stage/approve.rs
@@ -212,19 +212,28 @@ async fn approval_items(context: &StageContext) -> miette::Result<Vec<StageAppro
         .collect())
 }
 
-/// The staged versions the given ids identify. An id the registry does not
-/// list is kept as is, so approving it fails on the registry's own error
-/// rather than on a guess about why it is missing.
+/// The staged versions the given ids identify. Stage ids are hexadecimal, so
+/// the lookup ignores their spelling: an id the listing carries in another
+/// casing still resolves to the package name the approval order and the
+/// dependency blocking are keyed on. An id the registry does not list at all
+/// is kept as is, so approving it fails on the registry's own error rather
+/// than on a guess about why it is missing.
 async fn resolve_approval_items(
     context: &StageContext,
     stage_ids: &[String],
 ) -> miette::Result<Vec<StageApprovalItem>> {
-    let listed: HashMap<String, StageApprovalItem> =
-        approval_items(context).await?.into_iter().map(|item| (item.id.clone(), item)).collect();
+    let listed: HashMap<String, StageApprovalItem> = approval_items(context)
+        .await?
+        .into_iter()
+        .map(|item| (item.id.to_lowercase(), item))
+        .collect();
     Ok(stage_ids
         .iter()
         .map(|stage_id| {
-            listed.get(stage_id).cloned().unwrap_or_else(|| StageApprovalItem::from_id(stage_id))
+            listed
+                .get(&stage_id.to_lowercase())
+                .cloned()
+                .unwrap_or_else(|| StageApprovalItem::from_id(stage_id))
         })
         .collect())
 }

--- a/pnpm/crates/cli/src/cli_args/stage/approve.rs
+++ b/pnpm/crates/cli/src/cli_args/stage/approve.rs
@@ -1,0 +1,415 @@
+//! `pnpm stage approve` — publish staged versions, chosen interactively
+//! when none are named.
+//!
+//! A batch of versions is approved through a single
+//! [`OtpSession`](pnpm_network_web_auth::OtpSession), so one proof of
+//! presence covers all of them, and in workspace dependency order, so a
+//! package reaches the registry only after the workspace packages it
+//! depends on.
+
+use std::{
+    collections::{HashMap, HashSet},
+    path::Path,
+};
+
+use derive_more::{Display, Error};
+use dialoguer::MultiSelect;
+use miette::{Diagnostic, IntoDiagnostic};
+use pnpm_config::{Config, LinkWorkspacePackages};
+use pnpm_network_web_auth::{Host as WebAuthHost, OtpSession, StdinIsTty, StdoutIsTty};
+use pnpm_reporter::Reporter;
+use pnpm_workspace::GraphPkg;
+use pnpm_workspace_projects_graph::{CreateProjectsGraphOptions, create_projects_graph};
+use serde_json::Value;
+
+use super::{
+    StageArgs, StageContext, StageError, fetch_stage_items, global_info, global_warn, is_uuid,
+    stage_endpoint_url, stage_request_in_session,
+};
+use crate::cli_args::{
+    changelog::published_name,
+    recursive::{discover_workspace_projects, sort_projects},
+};
+
+/// `pnpm stage approve` with no `<stage-id>` outside an interactive
+/// terminal, where the staged versions cannot be chosen.
+#[derive(Debug, Display, Error, Diagnostic)]
+#[display(r#"Missing required <stage-id> for "pnpm stage approve""#)]
+#[diagnostic(
+    code(ERR_PNPM_STAGE_ID_REQUIRED),
+    help(
+        r#"Run "pnpm stage approve" in an interactive terminal to choose from the staged packages, or pass the stage ids to approve."#
+    )
+)]
+struct StageApproveIdRequired;
+
+/// Not every staged version of an approval batch reached the registry. The
+/// per-version outcome is already reported; this carries the count and the
+/// failing exit status.
+#[derive(Debug, Display, Error, Diagnostic)]
+#[display("Approved {approved} of {total} staged packages.")]
+#[diagnostic(code(ERR_PNPM_STAGE_APPROVE_INCOMPLETE))]
+struct StageApprovalsIncomplete {
+    #[error(not(source))]
+    approved: usize,
+    #[error(not(source))]
+    total: usize,
+}
+
+/// One staged version, as much of it as the registry's `-/stage` listing
+/// reported.
+#[derive(Debug, Clone)]
+struct StageApprovalItem {
+    id: String,
+    package_name: Option<String>,
+    version: Option<String>,
+    tag: Option<String>,
+    created_at: Option<String>,
+    actor: Option<String>,
+}
+
+impl StageApprovalItem {
+    /// A staged version named on the command line, before the registry
+    /// listing filled in what it publishes.
+    fn from_id(id: &str) -> Self {
+        StageApprovalItem {
+            id: id.to_owned(),
+            package_name: None,
+            version: None,
+            tag: None,
+            created_at: None,
+            actor: None,
+        }
+    }
+
+    fn from_value(item: &Value) -> Option<Self> {
+        let string_field = |field: &str| {
+            item.get(field)
+                .and_then(Value::as_str)
+                .filter(|value| !value.is_empty())
+                .map(str::to_owned)
+        };
+        Some(StageApprovalItem {
+            id: string_field("id")?,
+            package_name: string_field("packageName"),
+            version: string_field("version"),
+            tag: string_field("tag"),
+            created_at: string_field("createdAt"),
+            actor: string_field("actor"),
+        })
+    }
+
+    /// How progress lines name this staged version.
+    fn label(&self) -> String {
+        match (&self.package_name, &self.version) {
+            (Some(package_name), Some(version)) => format!("{package_name}@{version}"),
+            (Some(package_name), None) => package_name.clone(),
+            (None, _) => self.id.clone(),
+        }
+    }
+
+    /// How error messages name this staged version: the label plus the id
+    /// the other `stage` subcommands address it by.
+    fn reference(&self) -> String {
+        match self.package_name {
+            Some(_) => format!("{} ({})", self.label(), self.id),
+            None => self.id.clone(),
+        }
+    }
+
+    /// How the interactive picker names this staged version.
+    fn choice(&self) -> String {
+        let details: Vec<String> = [
+            self.tag.clone(),
+            self.created_at.as_ref().map(|created_at| format!("staged {created_at}")),
+            self.actor.as_ref().map(|actor| format!("by {actor}")),
+        ]
+        .into_iter()
+        .flatten()
+        .collect();
+        if details.is_empty() {
+            self.label()
+        } else {
+            format!("{} ({})", self.label(), details.join(", "))
+        }
+    }
+}
+
+/// Where each workspace package sits in the order its siblings have to be
+/// published in, keyed by the name the package publishes under — the only
+/// name a staged version carries.
+struct WorkspaceApprovalOrder {
+    /// Index of the topological chunk a package belongs to. A package only
+    /// ever depends on packages in lower-indexed chunks, so approving in
+    /// ascending index order publishes every dependency before its
+    /// dependents.
+    chunk_index_by_package_name: HashMap<String, usize>,
+    /// The workspace siblings a package directly depends on.
+    dependency_names_by_package_name: HashMap<String, Vec<String>>,
+}
+
+pub(super) async fn stage_approve<Reporter: self::Reporter>(
+    args: &StageArgs,
+    config: &Config,
+) -> miette::Result<Option<String>> {
+    let context = args.stage_context(config, None)?;
+    let stage_ids = parse_stage_ids(&args.params)?;
+    if let [stage_id] = stage_ids.as_slice() {
+        let mut session = OtpSession::new(context.web_auth_fetch_options.clone());
+        approve_staged_package::<Reporter>(
+            &context,
+            &mut session,
+            &StageApprovalItem::from_id(stage_id),
+        )
+        .await?;
+        return Ok(Some(format!("Staged package {stage_id} approved and published successfully.")));
+    }
+    let items = if stage_ids.is_empty() {
+        if !WebAuthHost::stdin_is_tty() || !WebAuthHost::stdout_is_tty() {
+            return Err(StageApproveIdRequired.into());
+        }
+        let staged = approval_items(&context).await?;
+        if staged.is_empty() {
+            return Ok(Some("There are no staged packages awaiting approval.".to_owned()));
+        }
+        let selected = prompt_for_staged_packages(&staged)?;
+        if selected.is_empty() {
+            return Ok(Some("No staged packages were selected.".to_owned()));
+        }
+        selected
+    } else {
+        resolve_approval_items(&context, &stage_ids).await?
+    };
+    approve_staged_packages::<Reporter>(&context, config, items).await
+}
+
+/// The `<stage-id>` arguments of `pnpm stage approve`, each validated as a
+/// UUID. An empty list asks for interactive selection.
+fn parse_stage_ids(params: &[String]) -> Result<Vec<String>, StageError> {
+    params
+        .iter()
+        .skip(1)
+        .map(
+            |stage_id| {
+                if is_uuid(stage_id) {
+                    Ok(stage_id.clone())
+                } else {
+                    Err(StageError::InvalidStageId)
+                }
+            },
+        )
+        .collect()
+}
+
+async fn approval_items(context: &StageContext) -> miette::Result<Vec<StageApprovalItem>> {
+    Ok(fetch_stage_items(context, None)
+        .await?
+        .iter()
+        .filter_map(StageApprovalItem::from_value)
+        .collect())
+}
+
+/// The staged versions the given ids identify. An id the registry does not
+/// list is kept as is, so approving it fails on the registry's own error
+/// rather than on a guess about why it is missing.
+async fn resolve_approval_items(
+    context: &StageContext,
+    stage_ids: &[String],
+) -> miette::Result<Vec<StageApprovalItem>> {
+    let listed: HashMap<String, StageApprovalItem> =
+        approval_items(context).await?.into_iter().map(|item| (item.id.clone(), item)).collect();
+    Ok(stage_ids
+        .iter()
+        .map(|stage_id| {
+            listed.get(stage_id).cloned().unwrap_or_else(|| StageApprovalItem::from_id(stage_id))
+        })
+        .collect())
+}
+
+/// Show the checkbox prompt; an interrupted prompt selects nothing.
+fn prompt_for_staged_packages(
+    staged: &[StageApprovalItem],
+) -> miette::Result<Vec<StageApprovalItem>> {
+    let choices: Vec<String> = staged.iter().map(StageApprovalItem::choice).collect();
+    let selected = MultiSelect::new()
+        .with_prompt(
+            "Choose which staged packages to approve (<space> to select, <enter> to confirm)",
+        )
+        .items(&choices)
+        .interact_opt()
+        .into_diagnostic()?;
+    Ok(selected.unwrap_or_default().into_iter().map(|index| staged[index].clone()).collect())
+}
+
+async fn approve_staged_packages<Reporter: self::Reporter>(
+    context: &StageContext,
+    config: &Config,
+    items: Vec<StageApprovalItem>,
+) -> miette::Result<Option<String>> {
+    let order = read_workspace_approval_order(config)?;
+    let items = sort_items_for_approval(items, order.as_ref());
+    let mut session = OtpSession::new(context.web_auth_fetch_options.clone());
+    let mut unpublished_package_names: HashSet<String> = HashSet::new();
+    let mut approved = 0_usize;
+    for item in &items {
+        let blockers = unavailable_dependencies(item, &unpublished_package_names, order.as_ref());
+        if !blockers.is_empty() {
+            record_unpublished(item, &mut unpublished_package_names);
+            global_warn::<Reporter>(&format!(
+                "Skipped {}, as it depends on {}, which could not be approved",
+                item.label(),
+                blockers.join(", "),
+            ));
+            continue;
+        }
+        match approve_staged_package::<Reporter>(context, &mut session, item).await {
+            Ok(()) => {
+                approved += 1;
+                global_info::<Reporter>(&format!("Approved {}", item.label()));
+            }
+            // Only the registry's verdict on one staged version is
+            // survivable. An authentication failure or a broken connection
+            // applies to every remaining version too, so it aborts the batch.
+            Err(error) if is_stage_registry_error(&error) => {
+                record_unpublished(item, &mut unpublished_package_names);
+                global_warn::<Reporter>(&format!("{error}"));
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    if approved < items.len() {
+        return Err(StageApprovalsIncomplete { approved, total: items.len() }.into());
+    }
+    Ok(Some(format!("Approved {} successfully.", render_package_count(approved))))
+}
+
+async fn approve_staged_package<Reporter: self::Reporter>(
+    context: &StageContext,
+    session: &mut OtpSession,
+    item: &StageApprovalItem,
+) -> miette::Result<()> {
+    let url = stage_endpoint_url(&context.registry, &format!("-/stage/{}/approve", item.id))?;
+    let action = format!("approve staged package {}", item.reference());
+    stage_request_in_session::<Reporter>(
+        context,
+        session,
+        reqwest::Method::POST,
+        url.as_str(),
+        &action,
+    )
+    .await
+}
+
+fn is_stage_registry_error(error: &miette::Report) -> bool {
+    error.code().is_some_and(|code| code.to_string() == "ERR_PNPM_STAGE_REGISTRY_ERROR")
+}
+
+fn record_unpublished(item: &StageApprovalItem, unpublished_package_names: &mut HashSet<String>) {
+    if let Some(package_name) = &item.package_name {
+        unpublished_package_names.insert(package_name.clone());
+    }
+}
+
+/// Reads the workspace the command runs in and derives the order its
+/// packages have to be approved in.
+///
+/// Returns `None` outside a workspace, where nothing is known about how the
+/// staged versions relate and the selection order is kept as is.
+fn read_workspace_approval_order(
+    config: &Config,
+) -> miette::Result<Option<WorkspaceApprovalOrder>> {
+    let Some(workspace_dir) = config.workspace_dir.clone() else {
+        return Ok(None);
+    };
+    let (projects, _patterns) = discover_workspace_projects(&workspace_dir, config)?;
+    let graph = create_projects_graph(
+        projects.iter().map(|project| GraphPkg { project }).collect(),
+        &CreateProjectsGraphOptions {
+            link_workspace_packages: Some(
+                config.link_workspace_packages != LinkWorkspacePackages::Off,
+            ),
+            ..CreateProjectsGraphOptions::default()
+        },
+    )
+    .graph;
+    let published_name_by_root_dir: HashMap<&Path, String> = graph
+        .iter()
+        .filter_map(|(root_dir, node)| {
+            let manifest = node.package.project.manifest.value();
+            let name = published_name(manifest)
+                .or_else(|| manifest.get("name")?.as_str())
+                .filter(|name| !name.is_empty())?;
+            Some((root_dir.as_path(), name.to_owned()))
+        })
+        .collect();
+    let mut chunk_index_by_package_name = HashMap::new();
+    let mut dependency_names_by_package_name = HashMap::new();
+    for (chunk_index, chunk) in sort_projects(&graph, None).into_iter().enumerate() {
+        for root_dir in chunk {
+            let Some(package_name) = published_name_by_root_dir.get(root_dir.as_path()) else {
+                continue;
+            };
+            chunk_index_by_package_name.insert(package_name.clone(), chunk_index);
+            let dependencies: Vec<String> = graph[&root_dir]
+                .dependencies
+                .iter()
+                .filter_map(|dependency| {
+                    published_name_by_root_dir.get(dependency.as_path()).cloned()
+                })
+                .collect();
+            dependency_names_by_package_name.insert(package_name.clone(), dependencies);
+        }
+    }
+    Ok(Some(WorkspaceApprovalOrder {
+        chunk_index_by_package_name,
+        dependency_names_by_package_name,
+    }))
+}
+
+/// Orders staged versions so that a workspace package is approved after the
+/// workspace packages it depends on. Staged versions of packages outside the
+/// workspace keep their original relative order, after the workspace ones.
+fn sort_items_for_approval(
+    mut items: Vec<StageApprovalItem>,
+    order: Option<&WorkspaceApprovalOrder>,
+) -> Vec<StageApprovalItem> {
+    items.sort_by_key(|item| chunk_index_of(item, order));
+    items
+}
+
+/// The packages in `unpublished_package_names` that `item` depends on, and
+/// that therefore will not be on the registry by the time `item` would be
+/// approved.
+fn unavailable_dependencies(
+    item: &StageApprovalItem,
+    unpublished_package_names: &HashSet<String>,
+    order: Option<&WorkspaceApprovalOrder>,
+) -> Vec<String> {
+    let Some((order, package_name)) = order.zip(item.package_name.as_deref()) else {
+        return Vec::new();
+    };
+    order
+        .dependency_names_by_package_name
+        .get(package_name)
+        .into_iter()
+        .flatten()
+        .filter(|dependency| unpublished_package_names.contains(*dependency))
+        .cloned()
+        .collect()
+}
+
+fn chunk_index_of(item: &StageApprovalItem, order: Option<&WorkspaceApprovalOrder>) -> usize {
+    order
+        .zip(item.package_name.as_deref())
+        .and_then(|(order, package_name)| {
+            order.chunk_index_by_package_name.get(package_name).copied()
+        })
+        .unwrap_or(usize::MAX)
+}
+
+fn render_package_count(count: usize) -> String {
+    format!("{count} staged package{}", if count == 1 { "" } else { "s" })
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/cli_args/stage/approve.rs
+++ b/pnpm/crates/cli/src/cli_args/stage/approve.rs
@@ -17,13 +17,14 @@ use miette::{Diagnostic, IntoDiagnostic};
 use pnpm_config::{Config, LinkWorkspacePackages};
 use pnpm_network_web_auth::{Host as WebAuthHost, OtpSession, StdinIsTty, StdoutIsTty};
 use pnpm_reporter::Reporter;
+use pnpm_resolving_parse_wanted_dependency::is_valid_old_npm_package_name;
 use pnpm_workspace::GraphPkg;
 use pnpm_workspace_projects_graph::{CreateProjectsGraphOptions, create_projects_graph};
 use serde_json::Value;
 
 use super::{
-    StageArgs, StageContext, StageError, fetch_stage_items, global_info, global_warn, is_uuid,
-    stage_endpoint_url, stage_json_request, stage_request_in_session,
+    StageArgs, StageContext, StageError, StageRegistryError, fetch_stage_items, global_info,
+    global_warn, is_uuid, stage_endpoint_url, stage_json_request, stage_request_in_session,
 };
 use crate::cli_args::{
     changelog::published_name,
@@ -69,11 +70,12 @@ impl StageApprovalItem {
         }
     }
 
-    /// Reads one entry of the registry's `-/stage` listing. The entry is
+    /// Reads one staged version the registry described. The entry is
     /// registry-controlled input that ends up in a terminal prompt the user
-    /// picks releases from, so its id has to be the same UUID the other
-    /// subcommands accept, and its text is stripped of the control characters
-    /// that could redraw the prompt around a selection.
+    /// picks releases from, so every field is taken as it came and checked
+    /// rather than repaired; the fields that are only displayed are stripped
+    /// of the control characters that could redraw the prompt around a
+    /// selection.
     fn from_value(item: &Value) -> Option<Self> {
         let string_field = |field: &str| {
             item.get(field)
@@ -81,12 +83,20 @@ impl StageApprovalItem {
                 .map(|value| sanitize_inline(value).into_owned())
                 .filter(|value| !value.is_empty())
         };
-        // The id is validated before sanitizing: stripping a formatting
-        // character out of it must not be what makes it a UUID.
+        // The id and the package name are validated as they came: removing a
+        // hidden character must never be what makes a value valid. A name
+        // that fails carries no workspace identity, so the version is
+        // approved outside the workspace order rather than under the name it
+        // resembles. A valid name is URL-safe, so it is also safe to display.
         let id = item.get("id").and_then(Value::as_str).filter(|id| is_uuid(id))?.to_owned();
+        let package_name = item
+            .get("packageName")
+            .and_then(Value::as_str)
+            .filter(|name| is_valid_old_npm_package_name(name))
+            .map(str::to_owned);
         Some(StageApprovalItem {
             id,
-            package_name: string_field("packageName"),
+            package_name,
             version: string_field("version"),
             tag: string_field("tag"),
             created_at: string_field("createdAt"),
@@ -229,7 +239,15 @@ async fn resolve_approval_items(
         let url = stage_endpoint_url(&context.registry, &format!("-/stage/{stage_id}"))?;
         let action = format!("view staged package {stage_id}");
         let described: Option<Value> =
-            stage_json_request(context, url.as_str(), &action).await.ok();
+            match stage_json_request(context, url.as_str(), &action).await {
+                Ok(described) => Some(described),
+                // Only the registry answering "no such staged version" is
+                // survivable here. An authentication failure or a broken
+                // connection applies to every id in the batch, so it aborts
+                // before anything is approved.
+                Err(error) if is_missing_stage_error(&error) => None,
+                Err(error) => return Err(error),
+            };
         items.push(
             described
                 .as_ref()
@@ -334,6 +352,10 @@ async fn approve_staged_package<Reporter: self::Reporter>(
 
 fn is_stage_registry_error(error: &miette::Report) -> bool {
     error.code().is_some_and(|code| code.to_string() == "ERR_PNPM_STAGE_REGISTRY_ERROR")
+}
+
+fn is_missing_stage_error(error: &miette::Report) -> bool {
+    error.downcast_ref::<StageRegistryError>().is_some_and(|error| error.status == 404)
 }
 
 fn record_unpublished(item: &StageApprovalItem, unpublished_package_names: &mut HashSet<String>) {

--- a/pnpm/crates/cli/src/cli_args/stage/approve/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/stage/approve/tests.rs
@@ -1,0 +1,136 @@
+use super::*;
+
+fn item(id: &str, package_name: Option<&str>, version: Option<&str>) -> StageApprovalItem {
+    StageApprovalItem {
+        id: id.to_owned(),
+        package_name: package_name.map(str::to_owned),
+        version: version.map(str::to_owned),
+        tag: None,
+        created_at: None,
+        actor: None,
+    }
+}
+
+fn order(chunks: &[&[&str]], dependencies: &[(&str, &[&str])]) -> WorkspaceApprovalOrder {
+    WorkspaceApprovalOrder {
+        chunk_index_by_package_name: chunks
+            .iter()
+            .enumerate()
+            .flat_map(|(chunk_index, chunk)| {
+                chunk.iter().map(move |name| ((*name).to_owned(), chunk_index))
+            })
+            .collect(),
+        dependency_names_by_package_name: dependencies
+            .iter()
+            .map(|(name, deps)| {
+                ((*name).to_owned(), deps.iter().map(|dep| (*dep).to_owned()).collect())
+            })
+            .collect(),
+    }
+}
+
+#[test]
+fn workspace_dependencies_are_approved_before_their_dependents() {
+    let items = vec![
+        item("id-dependent", Some("dependent"), Some("1.0.0")),
+        item("id-dependency", Some("dependency"), Some("1.0.0")),
+    ];
+    let order = order(&[&["dependency"], &["dependent"]], &[("dependent", &["dependency"])]);
+    let sorted = sort_items_for_approval(items, Some(&order));
+    assert_eq!(
+        sorted.iter().map(|item| item.id.as_str()).collect::<Vec<_>>(),
+        ["id-dependency", "id-dependent"],
+    );
+}
+
+#[test]
+fn packages_outside_the_workspace_keep_their_order_after_the_workspace_ones() {
+    let items = vec![
+        item("id-external", Some("external"), Some("1.0.0")),
+        item("id-unlisted", None, None),
+        item("id-dependency", Some("dependency"), Some("1.0.0")),
+    ];
+    let order = order(&[&["dependency"]], &[]);
+    let sorted = sort_items_for_approval(items, Some(&order));
+    assert_eq!(
+        sorted.iter().map(|item| item.id.as_str()).collect::<Vec<_>>(),
+        ["id-dependency", "id-external", "id-unlisted"],
+    );
+}
+
+#[test]
+fn selection_order_is_kept_outside_a_workspace() {
+    let items = vec![
+        item("id-dependent", Some("dependent"), Some("1.0.0")),
+        item("id-dependency", Some("dependency"), Some("1.0.0")),
+    ];
+    let sorted = sort_items_for_approval(items, None);
+    assert_eq!(
+        sorted.iter().map(|item| item.id.as_str()).collect::<Vec<_>>(),
+        ["id-dependent", "id-dependency"],
+    );
+}
+
+#[test]
+fn a_dependent_of_an_unpublished_package_is_blocked() {
+    let order = order(&[&["dependency"], &["dependent"]], &[("dependent", &["dependency"])]);
+    let unpublished: HashSet<String> = std::iter::once("dependency".to_owned()).collect();
+    assert_eq!(
+        unavailable_dependencies(
+            &item("id", Some("dependent"), Some("1.0.0")),
+            &unpublished,
+            Some(&order)
+        ),
+        ["dependency"],
+    );
+    assert!(
+        unavailable_dependencies(
+            &item("id", Some("dependency"), Some("1.0.0")),
+            &unpublished,
+            Some(&order),
+        )
+        .is_empty()
+    );
+}
+
+#[test]
+fn nothing_is_blocked_without_workspace_knowledge() {
+    let unpublished: HashSet<String> = std::iter::once("dependency".to_owned()).collect();
+    assert!(
+        unavailable_dependencies(&item("id", Some("dependent"), Some("1.0.0")), &unpublished, None)
+            .is_empty()
+    );
+}
+
+#[test]
+fn stage_ids_are_validated_as_uuids() {
+    let params = vec![
+        "approve".to_owned(),
+        "1de6f3db-2ed9-4d72-b3dd-8f0e2b474a2f".to_owned(),
+        "2b8f1c14-4a0d-4a4a-9a2e-6c5a2f0a1b33".to_owned(),
+    ];
+    assert_eq!(parse_stage_ids(&params).unwrap(), params[1..]);
+    assert!(parse_stage_ids(&["approve".to_owned()]).unwrap().is_empty());
+    assert!(matches!(
+        parse_stage_ids(&["approve".to_owned(), "not-a-uuid".to_owned()]),
+        Err(StageError::InvalidStageId),
+    ));
+}
+
+#[test]
+fn a_staged_version_is_named_by_its_package_and_falls_back_to_its_id() {
+    let named = item("1de6f3db-2ed9-4d72-b3dd-8f0e2b474a2f", Some("foo"), Some("1.0.0"));
+    assert_eq!(named.label(), "foo@1.0.0");
+    assert_eq!(named.reference(), "foo@1.0.0 (1de6f3db-2ed9-4d72-b3dd-8f0e2b474a2f)");
+    let unlisted = item("1de6f3db-2ed9-4d72-b3dd-8f0e2b474a2f", None, None);
+    assert_eq!(unlisted.label(), "1de6f3db-2ed9-4d72-b3dd-8f0e2b474a2f");
+    assert_eq!(unlisted.reference(), "1de6f3db-2ed9-4d72-b3dd-8f0e2b474a2f");
+}
+
+#[test]
+fn the_picker_shows_the_tag_and_who_staged_it() {
+    let mut staged = item("id", Some("foo"), Some("1.0.0"));
+    staged.tag = Some("next".to_owned());
+    staged.actor = Some("zkochan".to_owned());
+    assert_eq!(staged.choice(), "foo@1.0.0 (next, by zkochan)");
+}

--- a/pnpm/crates/cli/src/cli_args/stage/approve/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/stage/approve/tests.rs
@@ -127,12 +127,12 @@ fn stage_ids_are_validated_as_uuids() {
 }
 
 #[test]
-fn a_repeated_stage_id_is_approved_once() {
+fn a_repeated_stage_id_is_approved_once_whatever_its_spelling() {
     let params = vec![
         "approve".to_owned(),
         "1de6f3db-2ed9-4d72-b3dd-8f0e2b474a2f".to_owned(),
         "2b8f1c14-4a0d-4a4a-9a2e-6c5a2f0a1b33".to_owned(),
-        "1de6f3db-2ed9-4d72-b3dd-8f0e2b474a2f".to_owned(),
+        "1DE6F3DB-2ED9-4D72-B3DD-8F0E2B474A2F".to_owned(),
     ];
     assert_eq!(parse_stage_ids(&params).unwrap(), params[1..3]);
 }
@@ -165,6 +165,15 @@ fn a_listed_staged_version_without_a_uuid_id_is_dropped() {
     assert!(
         StageApprovalItem::from_value(&json!({
             "id": "../../../-/npm/v1/tokens",
+            "packageName": "foo",
+            "version": "1.0.0",
+        }))
+        .is_none(),
+    );
+    // Sanitizing the id must not be what turns it into a UUID.
+    assert!(
+        StageApprovalItem::from_value(&json!({
+            "id": "1de6f3db-2ed9-4d72-b3dd-8f0e2b474a2f\u{202e}",
             "packageName": "foo",
             "version": "1.0.0",
         }))

--- a/pnpm/crates/cli/src/cli_args/stage/approve/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/stage/approve/tests.rs
@@ -2,6 +2,8 @@ use std::collections::HashSet;
 
 use pretty_assertions::assert_eq;
 
+use serde_json::json;
+
 use super::{
     StageApprovalItem, StageError, WorkspaceApprovalOrder, parse_stage_ids,
     sort_items_for_approval, unavailable_dependencies,
@@ -125,6 +127,17 @@ fn stage_ids_are_validated_as_uuids() {
 }
 
 #[test]
+fn a_repeated_stage_id_is_approved_once() {
+    let params = vec![
+        "approve".to_owned(),
+        "1de6f3db-2ed9-4d72-b3dd-8f0e2b474a2f".to_owned(),
+        "2b8f1c14-4a0d-4a4a-9a2e-6c5a2f0a1b33".to_owned(),
+        "1de6f3db-2ed9-4d72-b3dd-8f0e2b474a2f".to_owned(),
+    ];
+    assert_eq!(parse_stage_ids(&params).unwrap(), params[1..3]);
+}
+
+#[test]
 fn a_staged_version_is_named_by_its_package_and_falls_back_to_its_id() {
     let named = item("1de6f3db-2ed9-4d72-b3dd-8f0e2b474a2f", Some("foo"), Some("1.0.0"));
     assert_eq!(named.label(), "foo@1.0.0");
@@ -132,6 +145,31 @@ fn a_staged_version_is_named_by_its_package_and_falls_back_to_its_id() {
     let unlisted = item("1de6f3db-2ed9-4d72-b3dd-8f0e2b474a2f", None, None);
     assert_eq!(unlisted.label(), "1de6f3db-2ed9-4d72-b3dd-8f0e2b474a2f");
     assert_eq!(unlisted.reference(), "1de6f3db-2ed9-4d72-b3dd-8f0e2b474a2f");
+}
+
+#[test]
+fn a_listed_staged_version_is_stripped_of_terminal_control_characters() {
+    let listed = StageApprovalItem::from_value(&json!({
+        "id": "1de6f3db-2ed9-4d72-b3dd-8f0e2b474a2f",
+        "packageName": "foo\u{1b}[2K\u{1b}[G",
+        "version": "1.0.0",
+        "actor": "zkochan\u{202e}",
+    }))
+    .expect("a staged version");
+    assert_eq!(listed.label(), "foo[2K[G@1.0.0");
+    assert_eq!(listed.choice(), "foo[2K[G@1.0.0 (by zkochan)");
+}
+
+#[test]
+fn a_listed_staged_version_without_a_uuid_id_is_dropped() {
+    assert!(
+        StageApprovalItem::from_value(&json!({
+            "id": "../../../-/npm/v1/tokens",
+            "packageName": "foo",
+            "version": "1.0.0",
+        }))
+        .is_none(),
+    );
 }
 
 #[test]

--- a/pnpm/crates/cli/src/cli_args/stage/approve/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/stage/approve/tests.rs
@@ -148,20 +148,34 @@ fn a_staged_version_is_named_by_its_package_and_falls_back_to_its_id() {
 }
 
 #[test]
-fn a_listed_staged_version_is_stripped_of_terminal_control_characters() {
-    let listed = StageApprovalItem::from_value(&json!({
+fn a_described_staged_version_is_stripped_of_terminal_control_characters() {
+    let described = StageApprovalItem::from_value(&json!({
         "id": "1de6f3db-2ed9-4d72-b3dd-8f0e2b474a2f",
-        "packageName": "foo\u{1b}[2K\u{1b}[G",
-        "version": "1.0.0",
+        "packageName": "foo",
+        "version": "1.0.0\u{1b}[2K",
         "actor": "zkochan\u{202e}",
     }))
     .expect("a staged version");
-    assert_eq!(listed.label(), "foo[2K[G@1.0.0");
-    assert_eq!(listed.choice(), "foo[2K[G@1.0.0 (by zkochan)");
+    assert_eq!(described.label(), "foo@1.0.0[2K");
+    assert_eq!(described.choice(), "foo@1.0.0[2K (by zkochan)");
+}
+
+/// A name only npm would reject carries no workspace identity: sanitizing it
+/// must not be what makes it match a workspace package.
+#[test]
+fn a_described_staged_version_with_an_invalid_package_name_carries_no_name() {
+    let described = StageApprovalItem::from_value(&json!({
+        "id": "1de6f3db-2ed9-4d72-b3dd-8f0e2b474a2f",
+        "packageName": "@scope/dependency\u{202e}",
+        "version": "1.0.0",
+    }))
+    .expect("a staged version");
+    assert_eq!(described.package_name, None);
+    assert_eq!(described.label(), "1de6f3db-2ed9-4d72-b3dd-8f0e2b474a2f");
 }
 
 #[test]
-fn a_listed_staged_version_without_a_uuid_id_is_dropped() {
+fn a_described_staged_version_without_a_uuid_id_is_dropped() {
     assert!(
         StageApprovalItem::from_value(&json!({
             "id": "../../../-/npm/v1/tokens",

--- a/pnpm/crates/cli/src/cli_args/stage/approve/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/stage/approve/tests.rs
@@ -1,4 +1,11 @@
-use super::*;
+use std::collections::HashSet;
+
+use pretty_assertions::assert_eq;
+
+use super::{
+    StageApprovalItem, StageError, WorkspaceApprovalOrder, parse_stage_ids,
+    sort_items_for_approval, unavailable_dependencies,
+};
 
 fn item(id: &str, package_name: Option<&str>, version: Option<&str>) -> StageApprovalItem {
     StageApprovalItem {
@@ -89,7 +96,7 @@ fn a_dependent_of_an_unpublished_package_is_blocked() {
             &unpublished,
             Some(&order),
         )
-        .is_empty()
+        .is_empty(),
     );
 }
 
@@ -98,7 +105,7 @@ fn nothing_is_blocked_without_workspace_knowledge() {
     let unpublished: HashSet<String> = std::iter::once("dependency".to_owned()).collect();
     assert!(
         unavailable_dependencies(&item("id", Some("dependent"), Some("1.0.0")), &unpublished, None)
-            .is_empty()
+            .is_empty(),
     );
 }
 

--- a/pnpm/crates/cli/tests/suite/stage.rs
+++ b/pnpm/crates/cli/tests/suite/stage.rs
@@ -333,9 +333,18 @@ fn approve_skips_a_staged_package_whose_workspace_dependency_could_not_be_approv
     let dependent_mock =
         server.mock("POST", format!("/-/stage/{STAGE_ID}/approve").as_str()).expect(0).create();
 
+    // The dependent's id is given in another casing than the listing carries,
+    // so this also covers the listing lookup the approval order depends on.
     let output = stage(
         dir.path(),
-        &["approve", STAGE_ID, SECOND_STAGE_ID, "--otp", "123456", "--reporter=silent"],
+        &[
+            "approve",
+            &STAGE_ID.to_uppercase(),
+            SECOND_STAGE_ID,
+            "--otp",
+            "123456",
+            "--reporter=silent",
+        ],
     );
 
     list_mock.assert();

--- a/pnpm/crates/cli/tests/suite/stage.rs
+++ b/pnpm/crates/cli/tests/suite/stage.rs
@@ -21,6 +21,7 @@ use std::{
 };
 
 const STAGE_ID: &str = "1de6f3db-2ed9-4d72-b3dd-8f0e2b474a2f";
+const SECOND_STAGE_ID: &str = "2b8f1c14-4a0d-4a4a-9a2e-6c5a2f0a1b33";
 
 fn pacquet(workspace: &Path) -> Command {
     Command::cargo_bin("pnpm")
@@ -211,6 +212,163 @@ fn approve_and_reject_send_the_configured_otp_and_stage_headers() {
         stdout.contains(&format!("Staged package {STAGE_ID} has been rejected.")),
         "stdout: {stdout}",
     );
+}
+
+/// A staged version of `package_name`, as the `-/stage` listing reports it.
+fn staged_item_of(stage_id: &str, package_name: &str) -> Value {
+    json!({
+        "id": stage_id,
+        "packageName": package_name,
+        "version": "1.0.0",
+        "tag": "latest",
+        "createdAt": "2026-03-16T09:00:00.000Z",
+        "actor": "user",
+        "actorType": "user",
+    })
+}
+
+#[test]
+fn approve_shares_one_one_time_password_across_a_batch() {
+    let dir = tempfile::tempdir().expect("workspace");
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    write_registry_config(dir.path(), &registry);
+    let list_mock = server
+        .mock("GET", "/-/stage")
+        .match_query(Matcher::Any)
+        .with_body(
+            json!({
+                "items": [
+                    staged_item_of(STAGE_ID, "@scope/first"),
+                    staged_item_of(SECOND_STAGE_ID, "@scope/second"),
+                ],
+                "total": 2,
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create();
+    let approve_mocks: Vec<mockito::Mock> = [STAGE_ID, SECOND_STAGE_ID]
+        .into_iter()
+        .map(|stage_id| {
+            server
+                .mock("POST", format!("/-/stage/{stage_id}/approve").as_str())
+                .match_header("npm-otp", "123456")
+                .with_status(201)
+                .with_body(r#"{"ok":true}"#)
+                .expect(1)
+                .create()
+        })
+        .collect();
+
+    let output = stage(
+        dir.path(),
+        &["approve", STAGE_ID, SECOND_STAGE_ID, "--otp", "123456", "--reporter=silent"],
+    );
+
+    list_mock.assert();
+    for mock in &approve_mocks {
+        mock.assert();
+    }
+    assert_success(&output);
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "Approved 2 staged packages successfully.\n",
+    );
+}
+
+/// A workspace whose `@scope/dependent` package depends on its
+/// `@scope/dependency` package.
+fn write_workspace_with_dependency(dir: &Path, registry: &str) {
+    write_registry_config(dir, registry);
+    fs::write(dir.join("pnpm-workspace.yaml"), "packages:\n  - packages/*\n")
+        .expect("write pnpm-workspace.yaml");
+    for (location, manifest) in [
+        ("dependency", json!({ "name": "@scope/dependency", "version": "1.0.0" })),
+        (
+            "dependent",
+            json!({
+                "name": "@scope/dependent",
+                "version": "1.0.0",
+                "dependencies": { "@scope/dependency": "workspace:*" },
+            }),
+        ),
+    ] {
+        let package_dir = dir.join("packages").join(location);
+        fs::create_dir_all(&package_dir).expect("create the package directory");
+        fs::write(package_dir.join("package.json"), manifest.to_string())
+            .expect("write package.json");
+    }
+}
+
+/// The dependency is approved first, so a dependency that never reaches the
+/// registry keeps its dependent from being published against it.
+#[test]
+fn approve_skips_a_staged_package_whose_workspace_dependency_could_not_be_approved() {
+    let dir = tempfile::tempdir().expect("workspace");
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    write_workspace_with_dependency(dir.path(), &registry);
+    let list_mock = server
+        .mock("GET", "/-/stage")
+        .match_query(Matcher::Any)
+        .with_body(
+            json!({
+                "items": [
+                    staged_item_of(STAGE_ID, "@scope/dependent"),
+                    staged_item_of(SECOND_STAGE_ID, "@scope/dependency"),
+                ],
+                "total": 2,
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create();
+    let dependency_mock = server
+        .mock("POST", format!("/-/stage/{SECOND_STAGE_ID}/approve").as_str())
+        .with_status(409)
+        .with_body(r#"{"error":"version already exists"}"#)
+        .expect_at_least(1)
+        .create();
+    let dependent_mock =
+        server.mock("POST", format!("/-/stage/{STAGE_ID}/approve").as_str()).expect(0).create();
+
+    let output = stage(
+        dir.path(),
+        &["approve", STAGE_ID, SECOND_STAGE_ID, "--otp", "123456", "--reporter=silent"],
+    );
+
+    list_mock.assert();
+    dependency_mock.assert();
+    dependent_mock.assert();
+    assert_failure_with_code(&output, "ERR_PNPM_STAGE_APPROVE_INCOMPLETE");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Approved 0 of 2 staged packages."), "stderr: {stderr}");
+}
+
+#[test]
+fn approve_without_a_stage_id_requires_an_interactive_terminal() {
+    let dir = tempfile::tempdir().expect("workspace");
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    write_registry_config(dir.path(), &registry);
+    let mock = server.mock("GET", Matcher::Any).expect(0).create();
+
+    // The spawned binary has no TTY, so the staged packages cannot be chosen.
+    let output = stage(dir.path(), &["approve"]);
+
+    mock.assert();
+    assert_failure_with_code(&output, "ERR_PNPM_STAGE_ID_REQUIRED");
+}
+
+#[test]
+fn approve_rejects_a_stage_id_that_is_not_a_uuid() {
+    let dir = tempfile::tempdir().expect("workspace");
+    write_registry_config(dir.path(), "http://localhost:4873/");
+
+    let output = stage(dir.path(), &["approve", STAGE_ID, "not-a-uuid"]);
+
+    assert_failure_with_code(&output, "ERR_PNPM_INVALID_STAGE_ID");
 }
 
 #[test]

--- a/pnpm/crates/cli/tests/suite/stage.rs
+++ b/pnpm/crates/cli/tests/suite/stage.rs
@@ -341,9 +341,35 @@ fn approve_skips_a_staged_package_whose_workspace_dependency_could_not_be_approv
     list_mock.assert();
     dependency_mock.assert();
     dependent_mock.assert();
-    assert_failure_with_code(&output, "ERR_PNPM_STAGE_APPROVE_INCOMPLETE");
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("Approved 0 of 2 staged packages."), "stderr: {stderr}");
+    assert!(!output.status.success(), "an incomplete approval batch must exit non-zero");
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "Approved 0 of 2 staged packages.\n");
+}
+
+#[test]
+fn approve_sends_one_request_for_a_repeated_stage_id() {
+    let dir = tempfile::tempdir().expect("workspace");
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    write_registry_config(dir.path(), &registry);
+    let list_mock = server.mock("GET", "/-/stage").match_query(Matcher::Any).expect(0).create();
+    let approve_mock = server
+        .mock("POST", format!("/-/stage/{STAGE_ID}/approve").as_str())
+        .match_header("npm-otp", "123456")
+        .with_status(201)
+        .with_body(r#"{"ok":true}"#)
+        .expect(1)
+        .create();
+
+    let output =
+        stage(dir.path(), &["approve", STAGE_ID, STAGE_ID, "--otp", "123456", "--reporter=silent"]);
+
+    list_mock.assert();
+    approve_mock.assert();
+    assert_success(&output);
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        format!("Staged package {STAGE_ID} approved and published successfully.\n"),
+    );
 }
 
 #[test]

--- a/pnpm/crates/cli/tests/suite/stage.rs
+++ b/pnpm/crates/cli/tests/suite/stage.rs
@@ -233,21 +233,17 @@ fn approve_shares_one_one_time_password_across_a_batch() {
     let mut server = mockito::Server::new();
     let registry = format!("{}/", server.url());
     write_registry_config(dir.path(), &registry);
-    let list_mock = server
-        .mock("GET", "/-/stage")
-        .match_query(Matcher::Any)
-        .with_body(
-            json!({
-                "items": [
-                    staged_item_of(STAGE_ID, "@scope/first"),
-                    staged_item_of(SECOND_STAGE_ID, "@scope/second"),
-                ],
-                "total": 2,
+    let described_mocks: Vec<mockito::Mock> =
+        [(STAGE_ID, "@scope/first"), (SECOND_STAGE_ID, "@scope/second")]
+            .into_iter()
+            .map(|(stage_id, package_name)| {
+                server
+                    .mock("GET", format!("/-/stage/{stage_id}").as_str())
+                    .with_body(staged_item_of(stage_id, package_name).to_string())
+                    .expect(1)
+                    .create()
             })
-            .to_string(),
-        )
-        .expect(1)
-        .create();
+            .collect();
     let approve_mocks: Vec<mockito::Mock> = [STAGE_ID, SECOND_STAGE_ID]
         .into_iter()
         .map(|stage_id| {
@@ -266,8 +262,7 @@ fn approve_shares_one_one_time_password_across_a_batch() {
         &["approve", STAGE_ID, SECOND_STAGE_ID, "--otp", "123456", "--reporter=silent"],
     );
 
-    list_mock.assert();
-    for mock in &approve_mocks {
+    for mock in described_mocks.iter().chain(&approve_mocks) {
         mock.assert();
     }
     assert_success(&output);
@@ -309,21 +304,17 @@ fn approve_skips_a_staged_package_whose_workspace_dependency_could_not_be_approv
     let mut server = mockito::Server::new();
     let registry = format!("{}/", server.url());
     write_workspace_with_dependency(dir.path(), &registry);
-    let list_mock = server
-        .mock("GET", "/-/stage")
-        .match_query(Matcher::Any)
-        .with_body(
-            json!({
-                "items": [
-                    staged_item_of(STAGE_ID, "@scope/dependent"),
-                    staged_item_of(SECOND_STAGE_ID, "@scope/dependency"),
-                ],
-                "total": 2,
+    let described_mocks: Vec<mockito::Mock> =
+        [(STAGE_ID, "@scope/dependent"), (SECOND_STAGE_ID, "@scope/dependency")]
+            .into_iter()
+            .map(|(stage_id, package_name)| {
+                server
+                    .mock("GET", format!("/-/stage/{stage_id}").as_str())
+                    .with_body(staged_item_of(stage_id, package_name).to_string())
+                    .expect(1)
+                    .create()
             })
-            .to_string(),
-        )
-        .expect(1)
-        .create();
+            .collect();
     let dependency_mock = server
         .mock("POST", format!("/-/stage/{SECOND_STAGE_ID}/approve").as_str())
         .with_status(409)
@@ -333,21 +324,14 @@ fn approve_skips_a_staged_package_whose_workspace_dependency_could_not_be_approv
     let dependent_mock =
         server.mock("POST", format!("/-/stage/{STAGE_ID}/approve").as_str()).expect(0).create();
 
-    // The dependent's id is given in another casing than the listing carries,
-    // so this also covers the listing lookup the approval order depends on.
     let output = stage(
         dir.path(),
-        &[
-            "approve",
-            &STAGE_ID.to_uppercase(),
-            SECOND_STAGE_ID,
-            "--otp",
-            "123456",
-            "--reporter=silent",
-        ],
+        &["approve", STAGE_ID, SECOND_STAGE_ID, "--otp", "123456", "--reporter=silent"],
     );
 
-    list_mock.assert();
+    for mock in &described_mocks {
+        mock.assert();
+    }
     dependency_mock.assert();
     dependent_mock.assert();
     assert!(!output.status.success(), "an incomplete approval batch must exit non-zero");
@@ -360,7 +344,7 @@ fn approve_sends_one_request_for_a_repeated_stage_id() {
     let mut server = mockito::Server::new();
     let registry = format!("{}/", server.url());
     write_registry_config(dir.path(), &registry);
-    let list_mock = server.mock("GET", "/-/stage").match_query(Matcher::Any).expect(0).create();
+    let read_mock = server.mock("GET", Matcher::Any).expect(0).create();
     let approve_mock = server
         .mock("POST", format!("/-/stage/{STAGE_ID}/approve").as_str())
         .match_header("npm-otp", "123456")
@@ -372,7 +356,7 @@ fn approve_sends_one_request_for_a_repeated_stage_id() {
     let output =
         stage(dir.path(), &["approve", STAGE_ID, STAGE_ID, "--otp", "123456", "--reporter=silent"]);
 
-    list_mock.assert();
+    read_mock.assert();
     approve_mock.assert();
     assert_success(&output);
     assert_eq!(

--- a/pnpm/crates/network-web-auth/src/lib.rs
+++ b/pnpm/crates/network-web-auth/src/lib.rs
@@ -44,5 +44,5 @@ pub use prompt_browser_open::prompt_browser_open;
 pub use web_auth_timeout_error::WebAuthTimeoutError;
 pub use with_otp_handling::{
     OtpChallenge, OtpError, OtpErrorBody, OtpNonInteractiveError, OtpSecondChallengeError,
-    SyntheticOtpError, WithOtpError, with_otp_handling,
+    OtpSession, SyntheticOtpError, WithOtpError, with_otp_handling,
 };

--- a/pnpm/crates/network-web-auth/src/with_otp_handling.rs
+++ b/pnpm/crates/network-web-auth/src/with_otp_handling.rs
@@ -199,6 +199,130 @@ pub enum WithOtpError<Error: Diagnostic + 'static> {
     Prompt(PromptError),
 }
 
+/// OTP challenge handling shared across a series of operations.
+///
+/// The first operation runs without a one-time password (the caller may
+/// still send a configured `--otp`); the password a challenge yields is
+/// kept and passed to every later operation, so a batch of operations
+/// costs one proof of presence instead of one per operation. When a kept
+/// password stops being accepted — a classic OTP expires within a minute —
+/// the challenge that follows obtains a new one and the operation that
+/// triggered it is retried with it.
+#[derive(Debug, Clone)]
+pub struct OtpSession {
+    fetch_options: WebAuthFetchOptions,
+    otp: Option<String>,
+}
+
+impl OtpSession {
+    #[must_use]
+    pub fn new(fetch_options: WebAuthFetchOptions) -> Self {
+        OtpSession { fetch_options, otp: None }
+    }
+
+    /// Run `operation` with the one-time password this session holds,
+    /// obtaining one on demand. See [`with_otp_handling`] for the
+    /// single-operation form and for the `Operation` bound's rationale.
+    pub async fn run<Sys, Reporter, Token, Error, Operation, Fut>(
+        &mut self,
+        mut operation: Operation,
+    ) -> Result<Token, WithOtpError<Error>>
+    where
+        Sys: Clock
+            + Sleep
+            + WebAuthFetch
+            + StdinIsTty
+            + StdoutIsTty
+            + EnterKeyListener
+            + OpenUrl
+            + PromptOtp,
+        Reporter: self::Reporter,
+        Error: OtpError + Diagnostic + 'static,
+        Operation: FnMut(Option<String>) -> Fut,
+        Fut: Future<Output = Result<Token, Error>>,
+    {
+        let error = match operation(self.otp.clone()).await {
+            Ok(value) => return Ok(value),
+            Err(error) => error,
+        };
+
+        let Some(challenge) = error.as_otp_challenge() else {
+            return Err(WithOtpError::Operation(error));
+        };
+
+        let Some(otp) =
+            resolve_otp_challenge::<Sys, Reporter, Error>(challenge, self.fetch_options.clone())
+                .await?
+        else {
+            return Err(WithOtpError::Operation(error));
+        };
+        self.otp = Some(otp.clone());
+
+        match operation(Some(otp)).await {
+            Ok(value) => Ok(value),
+            Err(retry_error) if retry_error.as_otp_challenge().is_some() => {
+                Err(WithOtpError::SecondChallenge(OtpSecondChallengeError))
+            }
+            Err(retry_error) => Err(WithOtpError::Operation(retry_error)),
+        }
+    }
+}
+
+/// Satisfy an OTP challenge, either through the web-based authentication
+/// flow (when the challenge carries both `authUrl` and `doneUrl`) or by
+/// prompting for a classic one-time password. `Ok(None)` means the user
+/// supplied none, which leaves the challenge unsatisfied.
+async fn resolve_otp_challenge<Sys, Reporter, Error>(
+    challenge: OtpChallenge,
+    fetch_options: WebAuthFetchOptions,
+) -> Result<Option<String>, WithOtpError<Error>>
+where
+    Sys: Clock
+        + Sleep
+        + WebAuthFetch
+        + StdinIsTty
+        + StdoutIsTty
+        + EnterKeyListener
+        + OpenUrl
+        + PromptOtp,
+    Reporter: self::Reporter,
+    Error: Diagnostic + 'static,
+{
+    if !Sys::stdin_is_tty() || !Sys::stdout_is_tty() {
+        return Err(WithOtpError::NonInteractive(OtpNonInteractiveError::new(challenge.body)));
+    }
+
+    let web_auth_urls = match &challenge.body {
+        Some(OtpErrorBody { auth_url: Some(auth_url), done_url: Some(done_url) }) => {
+            canonical_http_url(auth_url).zip(canonical_http_url(done_url))
+        }
+        _ => None,
+    };
+
+    match web_auth_urls {
+        Some((auth_url, done_url)) => {
+            global_info::<Reporter>(format_auth_url_message::<Reporter>(&auth_url).to_string());
+            let poll = poll_for_web_auth_token::<Sys>(WebAuthTokenPollParams {
+                done_url,
+                fetch_options,
+                timeout_ms: None,
+            });
+            prompt_browser_open::<Sys, Reporter, _, _>(&auth_url, poll)
+                .await
+                .map(Some)
+                .map_err(WithOtpError::Timeout)
+        }
+        None => {
+            match Sys::input("This operation requires a one-time password.\nEnter OTP:").await {
+                Ok(value) => Ok(value.filter(|otp| !otp.is_empty())),
+                // The user aborted the prompt: leave the challenge unsatisfied.
+                Err(PromptError::Cancelled) => Ok(None),
+                Err(other) => Err(WithOtpError::Prompt(other)),
+            }
+        }
+    }
+}
+
 /// Run `operation`, transparently satisfying an OTP challenge if it raises
 /// one.
 ///
@@ -207,9 +331,12 @@ pub enum WithOtpError<Error: Diagnostic + 'static> {
 /// `authUrl` and `doneUrl`) or prompts for a classic OTP, then retries the
 /// operation once with the obtained one-time password. Any non-OTP error,
 /// or an OTP challenge with no usable code, propagates unchanged.
+///
+/// Use [`OtpSession`] instead when several operations authenticate against
+/// the same registry in one run, so they share one one-time password.
 pub async fn with_otp_handling<Sys, Reporter, Token, Error, Operation, Fut>(
     fetch_options: WebAuthFetchOptions,
-    mut operation: Operation,
+    operation: Operation,
 ) -> Result<Token, WithOtpError<Error>>
 where
     Sys: Clock
@@ -232,58 +359,7 @@ where
     Operation: FnMut(Option<String>) -> Fut,
     Fut: Future<Output = Result<Token, Error>>,
 {
-    let error = match operation(None).await {
-        Ok(value) => return Ok(value),
-        Err(error) => error,
-    };
-
-    let Some(challenge) = error.as_otp_challenge() else {
-        return Err(WithOtpError::Operation(error));
-    };
-
-    if !Sys::stdin_is_tty() || !Sys::stdout_is_tty() {
-        return Err(WithOtpError::NonInteractive(OtpNonInteractiveError::new(challenge.body)));
-    }
-
-    let web_auth_urls = match &challenge.body {
-        Some(OtpErrorBody { auth_url: Some(auth_url), done_url: Some(done_url) }) => {
-            canonical_http_url(auth_url).zip(canonical_http_url(done_url))
-        }
-        _ => None,
-    };
-
-    let otp = match web_auth_urls {
-        Some((auth_url, done_url)) => {
-            global_info::<Reporter>(format_auth_url_message::<Reporter>(&auth_url).to_string());
-            let poll = poll_for_web_auth_token::<Sys>(WebAuthTokenPollParams {
-                done_url,
-                fetch_options,
-                timeout_ms: None,
-            });
-            prompt_browser_open::<Sys, Reporter, _, _>(&auth_url, poll)
-                .await
-                .map(Some)
-                .map_err(WithOtpError::Timeout)?
-        }
-        None => {
-            match Sys::input("This operation requires a one-time password.\nEnter OTP:").await {
-                Ok(value) => value.filter(|otp| !otp.is_empty()),
-                // The user aborted the prompt: re-throw the original challenge.
-                Err(PromptError::Cancelled) => return Err(WithOtpError::Operation(error)),
-                Err(other) => return Err(WithOtpError::Prompt(other)),
-            }
-        }
-    };
-
-    let Some(otp) = otp else {
-        return Err(WithOtpError::Operation(error));
-    };
-
-    match operation(Some(otp)).await {
-        Ok(value) => Ok(value),
-        Err(retry_error) if retry_error.as_otp_challenge().is_some() => {
-            Err(WithOtpError::SecondChallenge(OtpSecondChallengeError))
-        }
-        Err(retry_error) => Err(WithOtpError::Operation(retry_error)),
-    }
+    OtpSession::new(fetch_options)
+        .run::<Sys, Reporter, Token, Error, Operation, Fut>(operation)
+        .await
 }

--- a/pnpm/crates/network-web-auth/tests/with_otp_handling.rs
+++ b/pnpm/crates/network-web-auth/tests/with_otp_handling.rs
@@ -1,7 +1,11 @@
-use std::{cell::Cell, rc::Rc};
+use std::{
+    cell::{Cell, RefCell},
+    rc::Rc,
+};
 
 use pnpm_network_web_auth::{
-    OtpError, OtpErrorBody, SyntheticOtpError, WebAuthFetchOptions, WithOtpError, with_otp_handling,
+    OtpError, OtpErrorBody, OtpSession, SyntheticOtpError, WebAuthFetchOptions, WithOtpError,
+    with_otp_handling,
 };
 use pnpm_network_web_auth_testing::{
     FakeOtpError, InputResponse, SleepBehavior, ok_202, ok_token, ok_truncated, web_auth_body,
@@ -646,5 +650,92 @@ fn from_unknown_body_returns_empty_body_when_no_auth_url_or_done_url() {
     assert_eq!(
         error.as_otp_challenge().expect("a challenge").body,
         Some(OtpErrorBody { auth_url: None, done_url: None }),
+    );
+}
+
+/// The future one call of [`otp_gated_operation`] returns.
+type OtpGatedFuture = std::pin::Pin<Box<dyn Future<Output = Result<String, FakeOtpError>>>>;
+
+/// An operation that succeeds only when it is given `accepted`, recording
+/// every one-time password it was called with.
+fn otp_gated_operation(
+    accepted: &Rc<RefCell<String>>,
+    seen: &Rc<RefCell<Vec<Option<String>>>>,
+) -> impl FnMut(Option<String>) -> OtpGatedFuture {
+    let accepted = Rc::clone(accepted);
+    let seen = Rc::clone(seen);
+    move |otp| {
+        let accepted = Rc::clone(&accepted);
+        let seen = Rc::clone(&seen);
+        Box::pin(async move {
+            seen.borrow_mut().push(otp.clone());
+            if otp.as_deref() == Some(accepted.borrow().as_str()) {
+                Ok("ok".to_owned())
+            } else {
+                Err(FakeOtpError::Otp { body: None })
+            }
+        })
+    }
+}
+
+#[tokio::test]
+async fn session_reuses_the_obtained_otp_across_later_operations() {
+    web_auth_fake!(FakeHost, UnexpectedReporter, set_input);
+    reset();
+    set_input(InputResponse::Value(Some("654321".to_owned())));
+    let accepted = Rc::new(RefCell::new("654321".to_owned()));
+    let seen = Rc::new(RefCell::new(Vec::new()));
+    let mut session = OtpSession::new(WebAuthFetchOptions::default());
+
+    for _ in 0..2 {
+        let result = session
+            .run::<FakeHost, UnexpectedReporter, String, FakeOtpError, _, _>(otp_gated_operation(
+                &accepted, &seen,
+            ))
+            .await
+            .expect("a result");
+        assert_eq!(result, "ok");
+    }
+
+    assert_eq!(
+        seen.borrow().as_slice(),
+        [None, Some("654321".to_owned()), Some("654321".to_owned())],
+    );
+}
+
+#[tokio::test]
+async fn session_obtains_a_new_otp_once_the_registry_stops_accepting_the_held_one() {
+    web_auth_fake!(FakeHost, UnexpectedReporter, set_input);
+    reset();
+    set_input(InputResponse::Value(Some("first-otp".to_owned())));
+    let accepted = Rc::new(RefCell::new("first-otp".to_owned()));
+    let seen = Rc::new(RefCell::new(Vec::new()));
+    let mut session = OtpSession::new(WebAuthFetchOptions::default());
+
+    session
+        .run::<FakeHost, UnexpectedReporter, String, FakeOtpError, _, _>(otp_gated_operation(
+            &accepted, &seen,
+        ))
+        .await
+        .expect("a result");
+
+    // The password expires right after the operation it was obtained for.
+    *accepted.borrow_mut() = "second-otp".to_owned();
+    set_input(InputResponse::Value(Some("second-otp".to_owned())));
+    session
+        .run::<FakeHost, UnexpectedReporter, String, FakeOtpError, _, _>(otp_gated_operation(
+            &accepted, &seen,
+        ))
+        .await
+        .expect("a result");
+
+    assert_eq!(
+        seen.borrow().as_slice(),
+        [
+            None,
+            Some("first-otp".to_owned()),
+            Some("first-otp".to_owned()),
+            Some("second-otp".to_owned()),
+        ],
     );
 }

--- a/pnpm11/installing/commands/package.json
+++ b/pnpm11/installing/commands/package.json
@@ -79,6 +79,7 @@
     "@pnpm/store.connection-manager": "workspace:*",
     "@pnpm/store.controller": "workspace:*",
     "@pnpm/text.ordinal-comparator": "workspace:*",
+    "@pnpm/text.sanitize": "workspace:*",
     "@pnpm/types": "workspace:*",
     "@pnpm/workspace.project-manifest-reader": "workspace:*",
     "@pnpm/workspace.project-manifest-writer": "workspace:*",

--- a/pnpm11/installing/commands/src/update/getUpdateChoices.ts
+++ b/pnpm11/installing/commands/src/update/getUpdateChoices.ts
@@ -1,6 +1,7 @@
 import { colorizeSemverDiff } from '@pnpm/colorize-semver-diff'
 import type { OutdatedPackage } from '@pnpm/deps.inspection.outdated'
 import { semverDiff } from '@pnpm/semver-diff'
+import { sanitizeInline } from '@pnpm/text.sanitize'
 import { getBorderCharacters, table } from '@zkochan/table'
 import { and, groupBy, isEmpty, pickBy, pluck } from 'ramda'
 import stringWidth from 'string-width'
@@ -102,7 +103,7 @@ export function getUpdateChoices (outdatedPkgsOfProjects: UpdateChoiceDependency
         name: outdatedPkg.name,
         message: renderedTable[i],
         value: outdatedPkg.name,
-        short: sanitizeUpdateChoiceText(outdatedPkg.name),
+        short: sanitizeInline(outdatedPkg.name),
       }
     })
 
@@ -130,7 +131,7 @@ function buildPkgChoice (outdatedPkg: UpdateChoiceDependency, workspacesEnabled:
   const label = outdatedPkg.packageName
 
   const raw: string[] = [
-    sanitizeUpdateChoiceText(label),
+    sanitizeInline(label),
     outdatedPkg.current ?? '',
     '❯',
     // Not sanitized: `colorizeSemverDiff` puts the highlighting escapes
@@ -138,23 +139,14 @@ function buildPkgChoice (outdatedPkg: UpdateChoiceDependency, workspacesEnabled:
     nextVersion,
   ]
   if (workspacesEnabled) {
-    raw.push(Array.from(workspaces ?? []).map(sanitizeUpdateChoiceText).join(', '))
+    raw.push(Array.from(workspaces ?? []).map(sanitizeInline).join(', '))
   }
-  raw.push(sanitizeUpdateChoiceText(getPkgUrl(outdatedPkg)))
+  raw.push(sanitizeInline(getPkgUrl(outdatedPkg)))
 
   return {
     raw,
     name: outdatedPkg.packageName,
   }
-}
-
-/**
- * Strip control and formatting characters from text that goes into a
- * single-line table cell.
- */
-export function sanitizeUpdateChoiceText (text: string): string {
-  // eslint-disable-next-line no-control-regex
-  return text.replace(/[\u0000-\u001F\u007F-\u009F\u00AD\u0600-\u0605\u061C\u06DD\u070F\u0890\u0891\u08E2\u180E\u200B-\u200F\u202A-\u202E\u2060-\u2064\u2066-\u206F\uFEFF\uFFF9-\uFFFB\u{110BD}\u{110CD}\u{13430}-\u{1343F}\u{1BCA0}-\u{1BCA3}\u{1D173}-\u{1D17A}\u{E0001}\u{E0020}-\u{E007F}]/gu, '')
 }
 
 function getPkgUrl (pkg: OutdatedPackage): string {

--- a/pnpm11/installing/commands/src/update/index.ts
+++ b/pnpm11/installing/commands/src/update/index.ts
@@ -18,6 +18,7 @@ import { handleGlobalUpdate } from '@pnpm/global.commands'
 import { scanGlobalPackages } from '@pnpm/global.packages'
 import type { UpdateMatchingFunction } from '@pnpm/installing.deps-installer'
 import { globalInfo } from '@pnpm/logger'
+import { sanitizeInline } from '@pnpm/text.sanitize'
 import type { IncludedDependencies, PackageVulnerabilityAudit, ProjectRootDir } from '@pnpm/types'
 import chalk from 'chalk'
 import { pick, unnest } from 'ramda'
@@ -28,7 +29,7 @@ import { createVulnerabilityUpdateMatching, installDeps } from '../installDeps.j
 import { createUpdateMatching, expandUpdateSelectorsForMatching, parseUpdateParam } from '../recursive.js'
 import { createGlobalPolicyCallbacks } from '../resolutionPolicyManifest.js'
 import { captureUpdateChangesetContext, generateUpdateChangeset } from './generateUpdateChangeset.js'
-import { getUpdateChoices, sanitizeUpdateChoiceText } from './getUpdateChoices.js'
+import { getUpdateChoices } from './getUpdateChoices.js'
 export function rcOptionsTypes (): Record<string, unknown> {
   return pick([
     'cache-dir',
@@ -263,7 +264,7 @@ async function selectGlobalPackageGroups (
       name: outdated
         .map(({ alias, current, wanted, latestManifest }) =>
           [alias, current ?? 'missing', '→', opts.latest ? latestManifest?.version ?? wanted : wanted]
-            .map(sanitizeUpdateChoiceText)
+            .map(sanitizeInline)
             .join(' ')
         )
         .join(', '),

--- a/pnpm11/installing/commands/tsconfig.json
+++ b/pnpm11/installing/commands/tsconfig.json
@@ -157,6 +157,9 @@
       "path": "../../text/ordinal-comparator"
     },
     {
+      "path": "../../text/sanitize"
+    },
+    {
       "path": "../../worker"
     },
     {

--- a/pnpm11/network/web-auth/src/index.ts
+++ b/pnpm11/network/web-auth/src/index.ts
@@ -19,6 +19,7 @@ export {
 export { WebAuthTimeoutError } from './WebAuthTimeoutError.js'
 export {
   canonicalHttpUrl,
+  createOtpSession,
   isOtpError,
   type OtpContext,
   type OtpEnquirer,
@@ -26,6 +27,8 @@ export {
   OtpNonInteractiveError,
   type OtpProcess,
   OtpSecondChallengeError,
+  type OtpSession,
+  type OtpSessionParams,
   SyntheticOtpError,
   withOtpHandling,
 } from './withOtpHandling.js'

--- a/pnpm11/network/web-auth/src/withOtpHandling.ts
+++ b/pnpm11/network/web-auth/src/withOtpHandling.ts
@@ -53,6 +53,60 @@ export interface OtpHandlingParams<T> {
   operation: (otp?: string) => Promise<T>
 }
 
+export interface OtpSessionParams {
+  context: OtpContext
+  fetchOptions: WebAuthFetchOptions
+}
+
+export interface OtpSession {
+  /**
+   * Runs `operation` with the one-time password this session holds, obtaining
+   * one on demand.
+   *
+   * The first operation runs without a password (the caller may still send a
+   * configured `--otp`); the password obtained from a challenge is kept and
+   * passed to every later operation, so a batch of operations costs one
+   * authentication instead of one per operation. When a kept password stops
+   * being accepted — a classic OTP expires within a minute — the challenge it
+   * triggers obtains a new one and the operation is retried with it.
+   */
+  run: <T>(operation: (otp?: string) => Promise<T>) => Promise<T>
+}
+
+/**
+ * Creates an {@link OtpSession}: OTP challenge handling shared across a series
+ * of operations.
+ *
+ * @throws {@link OtpNonInteractiveError} if OTP is required but the terminal is not interactive.
+ * @throws {@link OtpSecondChallengeError} if the registry challenges an operation again right after
+ *   a freshly obtained one-time password was submitted for it.
+ */
+export function createOtpSession ({ context, fetchOptions }: OtpSessionParams): OtpSession {
+  let sessionOtp: string | undefined
+  return {
+    async run<T> (operation: (otp?: string) => Promise<T>): Promise<T> {
+      let error: unknown
+      try {
+        return await operation(sessionOtp)
+      } catch (err: unknown) {
+        if (!isOtpError(err)) throw err
+        error = err
+      }
+      const otp = await resolveOtpChallenge(context, fetchOptions, error as OtpError)
+      if (otp == null) throw error
+      sessionOtp = otp
+      try {
+        return await operation(otp)
+      } catch (retryError) {
+        if (isOtpError(retryError)) {
+          throw new OtpSecondChallengeError()
+        }
+        throw retryError
+      }
+    },
+  }
+}
+
 /**
  * Wraps an operation with OTP (one-time password) challenge handling.
  *
@@ -61,6 +115,9 @@ export interface OtpHandlingParams<T> {
  *    `authUrl` and `doneUrl`.
  * 2. Falls back to prompting the user for a classic OTP code.
  * 3. Retries the operation with the obtained OTP.
+ *
+ * Use {@link createOtpSession} instead when several operations authenticate
+ * against the same registry in one run, so they share one one-time password.
  *
  * @throws {@link OtpNonInteractiveError} if OTP is required but the terminal is not interactive.
  * @throws {@link OtpSecondChallengeError} if the registry requests OTP a second time after one was submitted.
@@ -73,67 +130,53 @@ export async function withOtpHandling<T> ({
   fetchOptions,
   operation,
 }: OtpHandlingParams<T>): Promise<T> {
-  const {
-    enquirer,
-    globalInfo,
-    globalWarn,
-    process,
-  } = context
+  return createOtpSession({ context, fetchOptions }).run(operation)
+}
 
-  try {
-    return await operation()
-  } catch (error) {
-    if (!isOtpError(error)) throw error
-    if (!process.stdin.isTTY || !process.stdout.isTTY) {
-      throw new OtpNonInteractiveError(error.body)
-    }
-
-    let otp: string | undefined
-
-    const authUrl = canonicalHttpUrl(error.body?.authUrl)
-    const doneUrl = canonicalHttpUrl(error.body?.doneUrl)
-    if (authUrl != null && doneUrl != null) {
-      globalInfo(formatAuthUrlMessage(authUrl, globalWarn))
-      const pollPromise = pollForWebAuthToken({
-        context,
-        doneUrl,
-        fetchOptions,
-      })
-      otp = await promptBrowserOpen({
-        authUrl,
-        context,
-        pollPromise,
-      })
-    } else {
-      let otpValue: string | undefined
-      try {
-        otpValue = await enquirer.input({
-          message: 'This operation requires a one-time password.\nEnter OTP:',
-        })
-      } catch (err: unknown) {
-        if (err instanceof Error && err.name === 'ExitPromptError') {
-          throw error
-        }
-        throw err
-      }
-
-      otp = otpValue || undefined
-    }
-
-    if (otp != null) {
-      try {
-        return await operation(otp)
-      } catch (retryError) {
-        if (isOtpError(retryError)) {
-          throw new OtpSecondChallengeError()
-        }
-
-        throw retryError
-      }
-    }
-
-    throw error
+/**
+ * Satisfies an OTP challenge, either through the web-based authentication flow
+ * (when the challenge carries both `authUrl` and `doneUrl`) or by prompting for
+ * a classic one-time password.
+ *
+ * @returns the one-time password, or `undefined` when the user supplied none.
+ */
+async function resolveOtpChallenge (
+  context: OtpContext,
+  fetchOptions: WebAuthFetchOptions,
+  error: OtpError
+): Promise<string | undefined> {
+  const { enquirer, globalInfo, globalWarn, process } = context
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    throw new OtpNonInteractiveError(error.body)
   }
+
+  const authUrl = canonicalHttpUrl(error.body?.authUrl)
+  const doneUrl = canonicalHttpUrl(error.body?.doneUrl)
+  if (authUrl != null && doneUrl != null) {
+    globalInfo(formatAuthUrlMessage(authUrl, globalWarn))
+    const pollPromise = pollForWebAuthToken({
+      context,
+      doneUrl,
+      fetchOptions,
+    })
+    return promptBrowserOpen({
+      authUrl,
+      context,
+      pollPromise,
+    })
+  }
+
+  let otp: string | undefined
+  try {
+    otp = await enquirer.input({
+      message: 'This operation requires a one-time password.\nEnter OTP:',
+    })
+  } catch (err: unknown) {
+    // The user aborted the prompt: re-throw the original challenge.
+    if (err instanceof Error && err.name === 'ExitPromptError') return undefined
+    throw err
+  }
+  return otp || undefined
 }
 
 /**

--- a/pnpm11/network/web-auth/test/withOtpHandling.test.ts
+++ b/pnpm11/network/web-auth/test/withOtpHandling.test.ts
@@ -521,9 +521,9 @@ describe('createOtpSession', () => {
     const input = jest.fn(async () => '123456')
     const context = createOtpMockContext({ enquirer: { input } })
     const session = createOtpSession({ context, fetchOptions })
-    const seenOtps: Array<string | undefined> = []
+    const sentPasswords: Array<string | undefined> = []
     const operation = async (otp?: string): Promise<string> => {
-      seenOtps.push(otp)
+      sentPasswords.push(otp)
       if (otp !== '123456') throw new SyntheticOtpError(undefined)
       return 'published'
     }
@@ -531,19 +531,19 @@ describe('createOtpSession', () => {
     await expect(session.run(operation)).resolves.toBe('published')
     await expect(session.run(operation)).resolves.toBe('published')
 
-    expect(seenOtps).toEqual([undefined, '123456', '123456'])
+    expect(sentPasswords).toEqual([undefined, '123456', '123456'])
     expect(input).toHaveBeenCalledTimes(1)
   })
 
   it('asks for a new one-time password once the registry stops accepting the one it holds', async () => {
-    const otps = ['first-otp', 'second-otp']
-    const input = jest.fn(async () => otps.shift())
+    const passwords = ['first-otp', 'second-otp']
+    const input = jest.fn(async () => passwords.shift())
     const context = createOtpMockContext({ enquirer: { input } })
     const session = createOtpSession({ context, fetchOptions })
-    const seenOtps: Array<string | undefined> = []
+    const sentPasswords: Array<string | undefined> = []
     let acceptedOtp = 'first-otp'
     const operation = async (otp?: string): Promise<string> => {
-      seenOtps.push(otp)
+      sentPasswords.push(otp)
       if (otp !== acceptedOtp) throw new SyntheticOtpError(undefined)
       // The password expires right after the operation it was obtained for.
       acceptedOtp = 'second-otp'
@@ -553,7 +553,7 @@ describe('createOtpSession', () => {
     await expect(session.run(operation)).resolves.toBe('published')
     await expect(session.run(operation)).resolves.toBe('published')
 
-    expect(seenOtps).toEqual([undefined, 'first-otp', 'first-otp', 'second-otp'])
+    expect(sentPasswords).toEqual([undefined, 'first-otp', 'first-otp', 'second-otp'])
     expect(input).toHaveBeenCalledTimes(2)
   })
 

--- a/pnpm11/network/web-auth/test/withOtpHandling.test.ts
+++ b/pnpm11/network/web-auth/test/withOtpHandling.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, jest } from '@jest/globals'
 import {
+  createOtpSession,
   type OtpContext,
   OtpNonInteractiveError,
   OtpSecondChallengeError,
@@ -512,5 +513,55 @@ describe('SyntheticOtpError.fromUnknownBody', () => {
   it('returns empty body when body has no authUrl or doneUrl', () => {
     const err = SyntheticOtpError.fromUnknownBody(unexpectedWarn, { something: 'else' })
     expect(err.body).toEqual({})
+  })
+})
+
+describe('createOtpSession', () => {
+  it('reuses the one-time password it obtained across later operations', async () => {
+    const input = jest.fn(async () => '123456')
+    const context = createOtpMockContext({ enquirer: { input } })
+    const session = createOtpSession({ context, fetchOptions })
+    const seenOtps: Array<string | undefined> = []
+    const operation = async (otp?: string): Promise<string> => {
+      seenOtps.push(otp)
+      if (otp !== '123456') throw new SyntheticOtpError(undefined)
+      return 'published'
+    }
+
+    await expect(session.run(operation)).resolves.toBe('published')
+    await expect(session.run(operation)).resolves.toBe('published')
+
+    expect(seenOtps).toEqual([undefined, '123456', '123456'])
+    expect(input).toHaveBeenCalledTimes(1)
+  })
+
+  it('asks for a new one-time password once the registry stops accepting the one it holds', async () => {
+    const otps = ['first-otp', 'second-otp']
+    const input = jest.fn(async () => otps.shift())
+    const context = createOtpMockContext({ enquirer: { input } })
+    const session = createOtpSession({ context, fetchOptions })
+    const seenOtps: Array<string | undefined> = []
+    let acceptedOtp = 'first-otp'
+    const operation = async (otp?: string): Promise<string> => {
+      seenOtps.push(otp)
+      if (otp !== acceptedOtp) throw new SyntheticOtpError(undefined)
+      // The password expires right after the operation it was obtained for.
+      acceptedOtp = 'second-otp'
+      return 'published'
+    }
+
+    await expect(session.run(operation)).resolves.toBe('published')
+    await expect(session.run(operation)).resolves.toBe('published')
+
+    expect(seenOtps).toEqual([undefined, 'first-otp', 'first-otp', 'second-otp'])
+    expect(input).toHaveBeenCalledTimes(2)
+  })
+
+  it('throws OtpSecondChallengeError when a freshly obtained password is challenged again', async () => {
+    const context = createOtpMockContext()
+    const session = createOtpSession({ context, fetchOptions })
+    await expect(session.run(async () => {
+      throw new SyntheticOtpError(undefined)
+    })).rejects.toThrow(OtpSecondChallengeError)
   })
 })

--- a/pnpm11/releasing/commands/package.json
+++ b/pnpm11/releasing/commands/package.json
@@ -67,6 +67,8 @@
     "@pnpm/resolving.resolver-base": "workspace:*",
     "@pnpm/types": "workspace:*",
     "@pnpm/workspace.projects-filter": "workspace:*",
+    "@pnpm/workspace.projects-graph": "workspace:*",
+    "@pnpm/workspace.projects-reader": "workspace:*",
     "@pnpm/workspace.projects-sorter": "workspace:*",
     "@pnpm/workspace.workspace-manifest-writer": "workspace:*",
     "@types/normalize-path": "catalog:",

--- a/pnpm11/releasing/commands/package.json
+++ b/pnpm11/releasing/commands/package.json
@@ -65,6 +65,7 @@
     "@pnpm/resolving.npm-resolver": "workspace:*",
     "@pnpm/resolving.registry.types": "workspace:*",
     "@pnpm/resolving.resolver-base": "workspace:*",
+    "@pnpm/text.sanitize": "workspace:*",
     "@pnpm/types": "workspace:*",
     "@pnpm/workspace.projects-filter": "workspace:*",
     "@pnpm/workspace.projects-graph": "workspace:*",

--- a/pnpm11/releasing/commands/src/stage/approvalOrder.ts
+++ b/pnpm11/releasing/commands/src/stage/approvalOrder.ts
@@ -4,7 +4,7 @@ import { findWorkspaceProjectsNoCheck } from '@pnpm/workspace.projects-reader'
 import { sortProjects } from '@pnpm/workspace.projects-sorter'
 
 import { publishedName } from '../publishedNames.js'
-import type { StageItem, StageOptions } from './types.js'
+import type { ApprovalItem, StageOptions } from './types.js'
 
 /**
  * Where each workspace package sits in the order its siblings have to be
@@ -65,7 +65,7 @@ export async function readWorkspaceApprovalOrder (opts: StageOptions): Promise<W
  * workspace packages it depends on. Staged versions of packages outside the
  * workspace keep their original relative order, after the workspace ones.
  */
-export function sortStageItemsForApproval (items: StageItem[], order?: WorkspaceApprovalOrder): StageItem[] {
+export function sortStageItemsForApproval (items: ApprovalItem[], order?: WorkspaceApprovalOrder): ApprovalItem[] {
   return items
     .map((item, index) => ({ item, index, chunkIndex: chunkIndexOf(item, order) }))
     .sort((left, right) => left.chunkIndex - right.chunkIndex || left.index - right.index)
@@ -77,7 +77,7 @@ export function sortStageItemsForApproval (items: StageItem[], order?: Workspace
  * therefore will not be on the registry by the time `item` would be approved.
  */
 export function unavailableDependencies (
-  item: StageItem,
+  item: ApprovalItem,
   unpublishedPackageNames: Set<string>,
   order?: WorkspaceApprovalOrder
 ): string[] {
@@ -86,7 +86,7 @@ export function unavailableDependencies (
     .filter((dependencyName) => unpublishedPackageNames.has(dependencyName))
 }
 
-function chunkIndexOf (item: StageItem, order?: WorkspaceApprovalOrder): number {
+function chunkIndexOf (item: ApprovalItem, order?: WorkspaceApprovalOrder): number {
   const chunkIndex = item.packageName ? order?.chunkIndexByPackageName.get(item.packageName) : undefined
   return chunkIndex ?? Number.MAX_SAFE_INTEGER
 }

--- a/pnpm11/releasing/commands/src/stage/approvalOrder.ts
+++ b/pnpm11/releasing/commands/src/stage/approvalOrder.ts
@@ -1,0 +1,92 @@
+import type { ProjectRootDir } from '@pnpm/types'
+import { createProjectsGraph } from '@pnpm/workspace.projects-graph'
+import { findWorkspaceProjectsNoCheck } from '@pnpm/workspace.projects-reader'
+import { sortProjects } from '@pnpm/workspace.projects-sorter'
+
+import { publishedName } from '../publishedNames.js'
+import type { StageItem, StageOptions } from './types.js'
+
+/**
+ * Where each workspace package sits in the order its siblings have to be
+ * published in, keyed by the name the package publishes under — the only name
+ * a staged version carries.
+ */
+export interface WorkspaceApprovalOrder {
+  /**
+   * Index of the topological chunk a package belongs to. A package only ever
+   * depends on packages in lower-indexed chunks, so approving in ascending
+   * index order publishes every dependency before its dependents.
+   */
+  chunkIndexByPackageName: Map<string, number>
+  /** The workspace siblings a package directly depends on. */
+  dependencyNamesByPackageName: Map<string, string[]>
+}
+
+/**
+ * Reads the workspace the command runs in and derives the order its packages
+ * have to be approved in.
+ *
+ * Returns `undefined` outside a workspace, where nothing is known about how
+ * the staged versions relate and the selection order is kept as is.
+ */
+export async function readWorkspaceApprovalOrder (opts: StageOptions): Promise<WorkspaceApprovalOrder | undefined> {
+  if (!opts.workspaceDir) return undefined
+  const projects = await findWorkspaceProjectsNoCheck(opts.workspaceDir, {
+    patterns: opts.workspacePackagePatterns,
+  })
+  const { graph } = createProjectsGraph(projects, {
+    linkWorkspacePackages: Boolean(opts.linkWorkspacePackages),
+  })
+  const publishedNameByRootDir = new Map<ProjectRootDir, string>()
+  for (const rootDir of Object.keys(graph) as ProjectRootDir[]) {
+    const name = publishedName(graph[rootDir].package.manifest)
+    if (name) publishedNameByRootDir.set(rootDir, name)
+  }
+  const chunkIndexByPackageName = new Map<string, number>()
+  const dependencyNamesByPackageName = new Map<string, string[]>()
+  sortProjects(graph).forEach((chunk, chunkIndex) => {
+    for (const rootDir of chunk) {
+      const name = publishedNameByRootDir.get(rootDir)
+      if (!name) continue
+      chunkIndexByPackageName.set(name, chunkIndex)
+      dependencyNamesByPackageName.set(
+        name,
+        graph[rootDir].dependencies
+          .map((dependencyRootDir) => publishedNameByRootDir.get(dependencyRootDir))
+          .filter((dependencyName) => dependencyName != null)
+      )
+    }
+  })
+  return { chunkIndexByPackageName, dependencyNamesByPackageName }
+}
+
+/**
+ * Orders staged versions so that a workspace package is approved after the
+ * workspace packages it depends on. Staged versions of packages outside the
+ * workspace keep their original relative order, after the workspace ones.
+ */
+export function sortStageItemsForApproval (items: StageItem[], order?: WorkspaceApprovalOrder): StageItem[] {
+  return items
+    .map((item, index) => ({ item, index, chunkIndex: chunkIndexOf(item, order) }))
+    .sort((left, right) => left.chunkIndex - right.chunkIndex || left.index - right.index)
+    .map(({ item }) => item)
+}
+
+/**
+ * The packages in `unpublishedPackageNames` that `item` depends on, and that
+ * therefore will not be on the registry by the time `item` would be approved.
+ */
+export function unavailableDependencies (
+  item: StageItem,
+  unpublishedPackageNames: Set<string>,
+  order?: WorkspaceApprovalOrder
+): string[] {
+  if (!order || !item.packageName) return []
+  return (order.dependencyNamesByPackageName.get(item.packageName) ?? [])
+    .filter((dependencyName) => unpublishedPackageNames.has(dependencyName))
+}
+
+function chunkIndexOf (item: StageItem, order?: WorkspaceApprovalOrder): number {
+  const chunkIndex = item.packageName ? order?.chunkIndexByPackageName.get(item.packageName) : undefined
+  return chunkIndex ?? Number.MAX_SAFE_INTEGER
+}

--- a/pnpm11/releasing/commands/src/stage/approve.ts
+++ b/pnpm11/releasing/commands/src/stage/approve.ts
@@ -14,8 +14,8 @@ import {
 import { createStageContext, type StageContext } from './context.js'
 import { fetchStageItems } from './items.js'
 import { parseStageIds, UUID_REGEX } from './parsing.js'
-import { createStageOtpSession, type StageOtpSession } from './request.js'
-import type { StageItem, StageOptions } from './types.js'
+import { createStageOtpSession, stageJsonRequest, type StageOtpSession } from './request.js'
+import type { ApprovalItem, StageItem, StageOptions } from './types.js'
 
 export type StageApproveResult = string | { output: string, exitCode: number }
 
@@ -32,7 +32,7 @@ export async function stageApprove (opts: StageOptions, params: string[]): Promi
   const context = createStageContext(opts)
   if (params.length === 0) {
     requireInteractiveSelection()
-    const stagedPackages = (await fetchStageItems(context)).filter(hasStageId)
+    const stagedPackages = (await fetchStageItems(context)).map(toApprovalItem).filter((item) => item != null)
     if (stagedPackages.length === 0) return 'There are no staged packages awaiting approval.'
     const selected = await promptForStagedPackages(stagedPackages)
     if (selected.length === 0) return 'No staged packages were selected.'
@@ -65,12 +65,32 @@ function dedupeStageIds (stageIds: string[]): string[] {
 }
 
 /**
- * A staged version the registry reported can only be approved through the id
- * the other subcommands address it by — the same UUID the command line
- * accepts, not an arbitrary string the registry puts in the listing.
+ * Reads one staged version the registry reported.
+ *
+ * The entry is registry-controlled input that ends up in a terminal prompt the
+ * user picks releases from, and whose package name is matched against the
+ * workspace to order the approvals, so its id has to be the same UUID the
+ * other subcommands address a staged version by — checked before sanitizing,
+ * so that stripping a formatting character cannot be what makes it one — and
+ * its text is stripped of the control characters that could redraw the prompt
+ * around a selection or hide a name from the workspace match.
  */
-function hasStageId (item: StageItem): item is StageItem & { id: string } {
-  return typeof item.id === 'string' && UUID_REGEX.test(item.id)
+function toApprovalItem (item: StageItem): ApprovalItem | undefined {
+  if (typeof item.id !== 'string' || !UUID_REGEX.test(item.id)) return undefined
+  return {
+    id: item.id,
+    packageName: sanitizedField(item.packageName),
+    version: sanitizedField(item.version),
+    tag: sanitizedField(item.tag),
+    createdAt: sanitizedField(item.createdAt),
+    actor: sanitizedField(item.actor),
+  }
+}
+
+function sanitizedField (value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const sanitized = sanitizeInline(value)
+  return sanitized === '' ? undefined : sanitized
 }
 
 function requireInteractiveSelection (): void {
@@ -81,7 +101,7 @@ function requireInteractiveSelection (): void {
 }
 
 /** Shows the checkbox prompt; an interrupted prompt selects nothing. */
-async function promptForStagedPackages (stagedPackages: StageItem[]): Promise<StageItem[]> {
+async function promptForStagedPackages (stagedPackages: ApprovalItem[]): Promise<ApprovalItem[]> {
   try {
     return await checkbox({
       choices: stagedPackages.map((item) => ({
@@ -108,23 +128,34 @@ async function promptForStagedPackages (stagedPackages: StageItem[]): Promise<St
 }
 
 /**
- * The staged versions the given ids identify. Stage ids are hexadecimal, so
- * the lookup ignores their spelling: an id the listing carries in another
- * casing still resolves to the package name the approval order and the
- * dependency blocking are keyed on. An id the registry does not list at all is
- * kept as is, so approving it fails on the registry's own error rather than on
- * a guess about why it is missing.
+ * The staged versions the given ids identify, each read from the registry's
+ * entry for that id rather than from the full staged listing, which a busy
+ * registry can page far beyond what the batch needs.
+ *
+ * A version the registry does not describe is kept as its bare id, so
+ * approving it fails on the registry's own error rather than on a guess about
+ * why it is missing; it also carries no package name, so it is approved
+ * outside the workspace order.
  */
-async function resolveStageItems (context: StageContext, stageIds: string[]): Promise<StageItem[]> {
-  const listedItems = (await fetchStageItems(context)).filter(hasStageId)
-  const itemsByStageId = new Map(listedItems.map((item) => [item.id.toLowerCase(), item]))
-  return stageIds.map((stageId) => itemsByStageId.get(stageId.toLowerCase()) ?? { id: stageId })
+async function resolveStageItems (context: StageContext, stageIds: string[]): Promise<ApprovalItem[]> {
+  return Promise.all(stageIds.map(async (stageId) => {
+    let item: StageItem
+    try {
+      item = await stageJsonRequest<StageItem>(context, {
+        url: new URL(`-/stage/${stageId}`, context.registry).href,
+        action: `view staged package ${stageId}`,
+      })
+    } catch {
+      return { id: stageId }
+    }
+    return toApprovalItem({ ...item, id: stageId }) ?? { id: stageId }
+  }))
 }
 
 async function approveStagedPackages (
   context: StageContext,
   opts: StageOptions,
-  items: StageItem[]
+  items: ApprovalItem[]
 ): Promise<StageApproveResult> {
   const order = await readWorkspaceApprovalOrder(opts)
   const sortedItems = sortStageItemsForApproval(items, order)
@@ -162,7 +193,7 @@ async function approveStagedPackages (
   }
 }
 
-async function approveStagedPackage (context: StageContext, item: StageItem, session: StageOtpSession): Promise<void> {
+async function approveStagedPackage (context: StageContext, item: ApprovalItem, session: StageOtpSession): Promise<void> {
   await session.request({
     url: new URL(`-/stage/${item.id}/approve`, context.registry).href,
     init: { method: 'POST' },
@@ -174,35 +205,23 @@ function isStageRegistryError (err: unknown): err is Error {
   return util.types.isNativeError(err) && (err as PnpmError).code === 'ERR_PNPM_STAGE_REGISTRY_ERROR'
 }
 
-/**
- * How the interactive picker names a staged version.
- *
- * The fields come from the registry and end up in a prompt the user picks
- * releases from, so {@link renderRegistryText} keeps them from redrawing it.
- */
-function renderStageItemChoice (item: StageItem): string {
+/** How the interactive picker names a staged version. */
+function renderStageItemChoice (item: ApprovalItem): string {
   const details = [item.tag, item.createdAt && `staged ${item.createdAt}`, item.actor && `by ${item.actor}`]
     .filter((detail): detail is string => detail != null && detail !== '')
-    .map((detail) => renderRegistryText(detail))
   return details.length > 0
     ? `${renderStageItemLabel(item)} (${details.join(', ')})`
     : renderStageItemLabel(item)
 }
 
-function renderStageItemLabel (item: StageItem): string {
-  if (!item.packageName) return item.id ?? '<unknown staged package>'
-  const packageName = renderRegistryText(item.packageName)
-  return item.version ? `${packageName}@${renderRegistryText(item.version)}` : packageName
-}
-
-/** Registry-provided text, stripped of what could rewrite the terminal. */
-function renderRegistryText (text: string): string {
-  return sanitizeInline(text)
+function renderStageItemLabel (item: ApprovalItem): string {
+  if (!item.packageName) return item.id
+  return item.version ? `${item.packageName}@${item.version}` : item.packageName
 }
 
 /** The label an error message identifies a staged version by. */
-function renderStageItemReference (item: StageItem): string {
-  return item.packageName ? `${renderStageItemLabel(item)} (${item.id})` : item.id ?? '<unknown staged package>'
+function renderStageItemReference (item: ApprovalItem): string {
+  return item.packageName ? `${renderStageItemLabel(item)} (${item.id})` : item.id
 }
 
 function renderPackageCount (count: number): string {

--- a/pnpm11/releasing/commands/src/stage/approve.ts
+++ b/pnpm11/releasing/commands/src/stage/approve.ts
@@ -1,15 +1,170 @@
-import { createStageContext } from './context.js'
-import { requireStageId } from './parsing.js'
-import { stageRequestWithOtp } from './request.js'
-import type { StageOptions } from './types.js'
+import util from 'node:util'
 
-export async function stageApprove (opts: StageOptions, params: string[]): Promise<string> {
-  const stageId = requireStageId(params, 'approve')
+import { checkbox } from '@inquirer/prompts'
+import { PnpmError } from '@pnpm/error'
+import { globalInfo, globalWarn } from '@pnpm/logger'
+import chalk from 'chalk'
+
+import {
+  readWorkspaceApprovalOrder,
+  sortStageItemsForApproval,
+  unavailableDependencies,
+} from './approvalOrder.js'
+import { createStageContext, type StageContext } from './context.js'
+import { fetchStageItems } from './items.js'
+import { parseStageIds, requireStageId } from './parsing.js'
+import { createStageOtpSession, type StageOtpSession } from './request.js'
+import type { StageItem, StageOptions } from './types.js'
+
+export type StageApproveResult = string | { output: string, exitCode: number }
+
+/**
+ * `pnpm stage approve [<stage-id> ...]` — publish staged versions, choosing
+ * them interactively when none are named.
+ *
+ * Several versions are approved through a single {@link StageOtpSession}, so
+ * one proof of presence covers the whole batch, and in workspace dependency
+ * order, so a package reaches the registry only after the workspace packages
+ * it depends on.
+ */
+export async function stageApprove (opts: StageOptions, params: string[]): Promise<StageApproveResult> {
   const context = createStageContext(opts)
-  await stageRequestWithOtp(context, {
-    url: new URL(`-/stage/${stageId}/approve`, context.registry).href,
-    init: { method: 'POST' },
-    action: `approve staged package ${stageId}`,
+  if (params.length === 1) {
+    const stageId = requireStageId(params, 'approve')
+    await approveStagedPackage(context, { id: stageId }, createStageOtpSession(context))
+    return `Staged package ${stageId} approved and published successfully.`
+  }
+  if (params.length === 0) {
+    requireInteractiveSelection()
+    const stagedPackages = (await fetchStageItems(context)).filter(isApprovable)
+    if (stagedPackages.length === 0) return 'There are no staged packages awaiting approval.'
+    const selected = await promptForStagedPackages(stagedPackages)
+    if (selected.length === 0) return 'No staged packages were selected.'
+    return approveStagedPackages(context, opts, selected)
+  }
+  return approveStagedPackages(context, opts, await resolveStageItems(context, parseStageIds(params, 'approve')))
+}
+
+/** A staged version the registry reported without an id cannot be approved. */
+function isApprovable (item: StageItem): boolean {
+  return typeof item.id === 'string' && item.id !== ''
+}
+
+function requireInteractiveSelection (): void {
+  if (process.stdin.isTTY && process.stdout.isTTY) return
+  throw new PnpmError('STAGE_ID_REQUIRED', 'Missing required <stage-id> for "pnpm stage approve"', {
+    hint: 'Run "pnpm stage approve" in an interactive terminal to choose from the staged packages, or pass the stage ids to approve.',
   })
-  return `Staged package ${stageId} approved and published successfully.`
+}
+
+/** Shows the checkbox prompt; an interrupted prompt selects nothing. */
+async function promptForStagedPackages (stagedPackages: StageItem[]): Promise<StageItem[]> {
+  try {
+    return await checkbox({
+      choices: stagedPackages.map((item) => ({
+        name: renderStageItemChoice(item),
+        value: item,
+      })),
+      message: 'Choose which staged packages to approve ' +
+        `(Press ${chalk.cyan('<space>')} to select, ` +
+        `${chalk.cyan('<a>')} to toggle all, ` +
+        `${chalk.cyan('<i>')} to invert selection)`,
+      required: false,
+      theme: {
+        icon: { checked: '●', unchecked: '○', cursor: '❯' },
+        style: {
+          highlight: chalk.bgBlack.whiteBright,
+        },
+        keybindings: ['vim'],
+      },
+    })
+  } catch (err: unknown) {
+    if (util.types.isNativeError(err) && err.name === 'ExitPromptError') return []
+    throw err
+  }
+}
+
+/**
+ * The staged versions the given ids identify. An id the registry does not list
+ * is kept as is, so approving it fails on the registry's own error rather than
+ * on a guess about why it is missing.
+ */
+async function resolveStageItems (context: StageContext, stageIds: string[]): Promise<StageItem[]> {
+  const itemsById = new Map((await fetchStageItems(context)).map((item) => [item.id, item]))
+  return stageIds.map((stageId) => itemsById.get(stageId) ?? { id: stageId })
+}
+
+async function approveStagedPackages (
+  context: StageContext,
+  opts: StageOptions,
+  items: StageItem[]
+): Promise<StageApproveResult> {
+  const order = await readWorkspaceApprovalOrder(opts)
+  const sortedItems = sortStageItemsForApproval(items, order)
+  const session = createStageOtpSession(context)
+  const unpublishedPackageNames = new Set<string>()
+  let approvedCount = 0
+  for (const item of sortedItems) {
+    const label = renderStageItemLabel(item)
+    const blockers = unavailableDependencies(item, unpublishedPackageNames, order)
+    if (blockers.length > 0) {
+      if (item.packageName) unpublishedPackageNames.add(item.packageName)
+      globalWarn(`Skipped ${label}, as it depends on ${blockers.join(', ')}, which could not be approved`)
+      continue
+    }
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      await approveStagedPackage(context, item, session)
+      approvedCount++
+      globalInfo(`Approved ${label}`)
+    } catch (err: unknown) {
+      // Only the registry's verdict on one staged version is survivable. An
+      // authentication failure or a broken connection applies to every
+      // remaining version too, so it aborts the batch.
+      if (!isStageRegistryError(err)) throw err
+      if (item.packageName) unpublishedPackageNames.add(item.packageName)
+      globalWarn(err.message)
+    }
+  }
+  const failedCount = sortedItems.length - approvedCount
+  return {
+    output: failedCount === 0
+      ? `Approved ${renderPackageCount(approvedCount)} successfully.`
+      : `Approved ${approvedCount} of ${renderPackageCount(sortedItems.length)}.`,
+    exitCode: failedCount === 0 ? 0 : 1,
+  }
+}
+
+async function approveStagedPackage (context: StageContext, item: StageItem, session: StageOtpSession): Promise<void> {
+  await session.request({
+    url: new URL(`-/stage/${item.id}/approve`, context.registry).href,
+    init: { method: 'POST' },
+    action: `approve staged package ${renderStageItemReference(item)}`,
+  })
+}
+
+function isStageRegistryError (err: unknown): err is Error {
+  return util.types.isNativeError(err) && (err as PnpmError).code === 'ERR_PNPM_STAGE_REGISTRY_ERROR'
+}
+
+function renderStageItemChoice (item: StageItem): string {
+  const details = [item.tag, item.createdAt && `staged ${item.createdAt}`, item.actor && `by ${item.actor}`]
+    .filter((detail) => detail != null && detail !== '')
+  return details.length > 0
+    ? `${renderStageItemLabel(item)} (${details.join(', ')})`
+    : renderStageItemLabel(item)
+}
+
+function renderStageItemLabel (item: StageItem): string {
+  if (!item.packageName) return item.id ?? '<unknown staged package>'
+  return item.version ? `${item.packageName}@${item.version}` : item.packageName
+}
+
+/** The label an error message identifies a staged version by. */
+function renderStageItemReference (item: StageItem): string {
+  return item.packageName ? `${renderStageItemLabel(item)} (${item.id})` : item.id ?? '<unknown staged package>'
+}
+
+function renderPackageCount (count: number): string {
+  return `${count} staged package${count === 1 ? '' : 's'}`
 }

--- a/pnpm11/releasing/commands/src/stage/approve.ts
+++ b/pnpm11/releasing/commands/src/stage/approve.ts
@@ -36,7 +36,7 @@ export async function stageApprove (opts: StageOptions, params: string[]): Promi
   }
   if (params.length === 0) {
     requireInteractiveSelection()
-    const stagedPackages = (await fetchStageItems(context)).filter(isApprovable)
+    const stagedPackages = (await fetchStageItems(context)).filter(hasStageId)
     if (stagedPackages.length === 0) return 'There are no staged packages awaiting approval.'
     const selected = await promptForStagedPackages(stagedPackages)
     if (selected.length === 0) return 'No staged packages were selected.'
@@ -46,7 +46,7 @@ export async function stageApprove (opts: StageOptions, params: string[]): Promi
 }
 
 /** A staged version the registry reported without an id cannot be approved. */
-function isApprovable (item: StageItem): boolean {
+function hasStageId (item: StageItem): boolean {
   return typeof item.id === 'string' && item.id !== ''
 }
 

--- a/pnpm11/releasing/commands/src/stage/approve.ts
+++ b/pnpm11/releasing/commands/src/stage/approve.ts
@@ -5,6 +5,7 @@ import { PnpmError } from '@pnpm/error'
 import { globalInfo, globalWarn } from '@pnpm/logger'
 import { sanitizeInline } from '@pnpm/text.sanitize'
 import chalk from 'chalk'
+import validateNpmPackageName from 'validate-npm-package-name'
 
 import {
   readWorkspaceApprovalOrder,
@@ -12,6 +13,7 @@ import {
   unavailableDependencies,
 } from './approvalOrder.js'
 import { createStageContext, type StageContext } from './context.js'
+import type { StageRegistryError } from './errors.js'
 import { fetchStageItems } from './items.js'
 import { parseStageIds, UUID_REGEX } from './parsing.js'
 import { createStageOtpSession, stageJsonRequest, type StageOtpSession } from './request.js'
@@ -68,23 +70,37 @@ function dedupeStageIds (stageIds: string[]): string[] {
  * Reads one staged version the registry reported.
  *
  * The entry is registry-controlled input that ends up in a terminal prompt the
- * user picks releases from, and whose package name is matched against the
- * workspace to order the approvals, so its id has to be the same UUID the
- * other subcommands address a staged version by — checked before sanitizing,
- * so that stripping a formatting character cannot be what makes it one — and
- * its text is stripped of the control characters that could redraw the prompt
- * around a selection or hide a name from the workspace match.
+ * user picks releases from, so every field is taken as it came and checked
+ * rather than repaired:
+ *
+ * - the id has to be the same UUID the other subcommands address a staged
+ *   version by, and the package name a name npm would accept — both checked
+ *   before anything is stripped, so that removing a hidden character can
+ *   never be what makes a value valid. A name that fails carries no workspace
+ *   identity, so the version is approved outside the workspace order rather
+ *   than under the name it resembles;
+ * - the remaining fields are shown and nothing more, so they are stripped of
+ *   the control characters that could redraw the prompt around a selection.
  */
 function toApprovalItem (item: StageItem): ApprovalItem | undefined {
   if (typeof item.id !== 'string' || !UUID_REGEX.test(item.id)) return undefined
   return {
     id: item.id,
-    packageName: sanitizedField(item.packageName),
+    packageName: validPackageName(item.packageName),
     version: sanitizedField(item.version),
     tag: sanitizedField(item.tag),
     createdAt: sanitizedField(item.createdAt),
     actor: sanitizedField(item.actor),
   }
+}
+
+/**
+ * The name a staged version publishes under, if the registry named it the way
+ * npm would. A valid name is URL-safe, so it is also safe to display as it is.
+ */
+function validPackageName (value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  return validateNpmPackageName(value).validForOldPackages ? value : undefined
 }
 
 function sanitizedField (value: unknown): string | undefined {
@@ -145,7 +161,11 @@ async function resolveStageItems (context: StageContext, stageIds: string[]): Pr
         url: new URL(`-/stage/${stageId}`, context.registry).href,
         action: `view staged package ${stageId}`,
       })
-    } catch {
+    } catch (err: unknown) {
+      // Only the registry answering "no such staged version" is survivable
+      // here. An authentication failure or a broken connection applies to
+      // every id in the batch, so it aborts before anything is approved.
+      if (!isMissingStageError(err)) throw err
       return { id: stageId }
     }
     return toApprovalItem({ ...item, id: stageId }) ?? { id: stageId }
@@ -203,6 +223,10 @@ async function approveStagedPackage (context: StageContext, item: ApprovalItem, 
 
 function isStageRegistryError (err: unknown): err is Error {
   return util.types.isNativeError(err) && (err as PnpmError).code === 'ERR_PNPM_STAGE_REGISTRY_ERROR'
+}
+
+function isMissingStageError (err: unknown): boolean {
+  return isStageRegistryError(err) && (err as StageRegistryError).status === 404
 }
 
 /** How the interactive picker names a staged version. */

--- a/pnpm11/releasing/commands/src/stage/approve.ts
+++ b/pnpm11/releasing/commands/src/stage/approve.ts
@@ -1,8 +1,9 @@
 import util from 'node:util'
 
 import { checkbox } from '@inquirer/prompts'
-import { PnpmError, redactAndSanitize } from '@pnpm/error'
+import { PnpmError } from '@pnpm/error'
 import { globalInfo, globalWarn } from '@pnpm/logger'
+import { sanitizeInline } from '@pnpm/text.sanitize'
 import chalk from 'chalk'
 
 import {
@@ -37,16 +38,30 @@ export async function stageApprove (opts: StageOptions, params: string[]): Promi
     if (selected.length === 0) return 'No staged packages were selected.'
     return approveStagedPackages(context, opts, selected)
   }
-  // A staged version repeated on the command line is one approval: sending the
-  // second request would either fail against the release the first one
-  // published, or count the same package twice.
-  const stageIds = [...new Set(parseStageIds(params, 'approve'))]
+  const stageIds = dedupeStageIds(parseStageIds(params, 'approve'))
   if (stageIds.length === 1) {
     const [stageId] = stageIds
     await approveStagedPackage(context, { id: stageId }, createStageOtpSession(context))
     return `Staged package ${stageId} approved and published successfully.`
   }
   return approveStagedPackages(context, opts, await resolveStageItems(context, stageIds))
+}
+
+/**
+ * A staged version repeated on the command line is one approval: sending the
+ * second request would either fail against the release the first one
+ * published, or count the same package twice. Stage ids are hexadecimal, so
+ * the same id in two spellings is the same id; the first spelling is the one
+ * that reaches the registry.
+ */
+function dedupeStageIds (stageIds: string[]): string[] {
+  const seen = new Set<string>()
+  return stageIds.filter((stageId) => {
+    const key = stageId.toLowerCase()
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
 }
 
 /**
@@ -178,7 +193,7 @@ function renderStageItemLabel (item: StageItem): string {
 
 /** Registry-provided text, stripped of what could rewrite the terminal. */
 function renderRegistryText (text: string): string {
-  return redactAndSanitize(text)
+  return sanitizeInline(text)
 }
 
 /** The label an error message identifies a staged version by. */

--- a/pnpm11/releasing/commands/src/stage/approve.ts
+++ b/pnpm11/releasing/commands/src/stage/approve.ts
@@ -69,7 +69,7 @@ function dedupeStageIds (stageIds: string[]): string[] {
  * the other subcommands address it by — the same UUID the command line
  * accepts, not an arbitrary string the registry puts in the listing.
  */
-function hasStageId (item: StageItem): boolean {
+function hasStageId (item: StageItem): item is StageItem & { id: string } {
   return typeof item.id === 'string' && UUID_REGEX.test(item.id)
 }
 
@@ -108,13 +108,17 @@ async function promptForStagedPackages (stagedPackages: StageItem[]): Promise<St
 }
 
 /**
- * The staged versions the given ids identify. An id the registry does not list
- * is kept as is, so approving it fails on the registry's own error rather than
- * on a guess about why it is missing.
+ * The staged versions the given ids identify. Stage ids are hexadecimal, so
+ * the lookup ignores their spelling: an id the listing carries in another
+ * casing still resolves to the package name the approval order and the
+ * dependency blocking are keyed on. An id the registry does not list at all is
+ * kept as is, so approving it fails on the registry's own error rather than on
+ * a guess about why it is missing.
  */
 async function resolveStageItems (context: StageContext, stageIds: string[]): Promise<StageItem[]> {
-  const itemsById = new Map((await fetchStageItems(context)).map((item) => [item.id, item]))
-  return stageIds.map((stageId) => itemsById.get(stageId) ?? { id: stageId })
+  const listedItems = (await fetchStageItems(context)).filter(hasStageId)
+  const itemsByStageId = new Map(listedItems.map((item) => [item.id.toLowerCase(), item]))
+  return stageIds.map((stageId) => itemsByStageId.get(stageId.toLowerCase()) ?? { id: stageId })
 }
 
 async function approveStagedPackages (

--- a/pnpm11/releasing/commands/src/stage/approve.ts
+++ b/pnpm11/releasing/commands/src/stage/approve.ts
@@ -1,7 +1,7 @@
 import util from 'node:util'
 
 import { checkbox } from '@inquirer/prompts'
-import { PnpmError } from '@pnpm/error'
+import { PnpmError, redactAndSanitize } from '@pnpm/error'
 import { globalInfo, globalWarn } from '@pnpm/logger'
 import chalk from 'chalk'
 
@@ -12,7 +12,7 @@ import {
 } from './approvalOrder.js'
 import { createStageContext, type StageContext } from './context.js'
 import { fetchStageItems } from './items.js'
-import { parseStageIds, requireStageId } from './parsing.js'
+import { parseStageIds, UUID_REGEX } from './parsing.js'
 import { createStageOtpSession, type StageOtpSession } from './request.js'
 import type { StageItem, StageOptions } from './types.js'
 
@@ -29,11 +29,6 @@ export type StageApproveResult = string | { output: string, exitCode: number }
  */
 export async function stageApprove (opts: StageOptions, params: string[]): Promise<StageApproveResult> {
   const context = createStageContext(opts)
-  if (params.length === 1) {
-    const stageId = requireStageId(params, 'approve')
-    await approveStagedPackage(context, { id: stageId }, createStageOtpSession(context))
-    return `Staged package ${stageId} approved and published successfully.`
-  }
   if (params.length === 0) {
     requireInteractiveSelection()
     const stagedPackages = (await fetchStageItems(context)).filter(hasStageId)
@@ -42,12 +37,25 @@ export async function stageApprove (opts: StageOptions, params: string[]): Promi
     if (selected.length === 0) return 'No staged packages were selected.'
     return approveStagedPackages(context, opts, selected)
   }
-  return approveStagedPackages(context, opts, await resolveStageItems(context, parseStageIds(params, 'approve')))
+  // A staged version repeated on the command line is one approval: sending the
+  // second request would either fail against the release the first one
+  // published, or count the same package twice.
+  const stageIds = [...new Set(parseStageIds(params, 'approve'))]
+  if (stageIds.length === 1) {
+    const [stageId] = stageIds
+    await approveStagedPackage(context, { id: stageId }, createStageOtpSession(context))
+    return `Staged package ${stageId} approved and published successfully.`
+  }
+  return approveStagedPackages(context, opts, await resolveStageItems(context, stageIds))
 }
 
-/** A staged version the registry reported without an id cannot be approved. */
+/**
+ * A staged version the registry reported can only be approved through the id
+ * the other subcommands address it by — the same UUID the command line
+ * accepts, not an arbitrary string the registry puts in the listing.
+ */
 function hasStageId (item: StageItem): boolean {
-  return typeof item.id === 'string' && item.id !== ''
+  return typeof item.id === 'string' && UUID_REGEX.test(item.id)
 }
 
 function requireInteractiveSelection (): void {
@@ -147,9 +155,16 @@ function isStageRegistryError (err: unknown): err is Error {
   return util.types.isNativeError(err) && (err as PnpmError).code === 'ERR_PNPM_STAGE_REGISTRY_ERROR'
 }
 
+/**
+ * How the interactive picker names a staged version.
+ *
+ * The fields come from the registry and end up in a prompt the user picks
+ * releases from, so {@link renderRegistryText} keeps them from redrawing it.
+ */
 function renderStageItemChoice (item: StageItem): string {
   const details = [item.tag, item.createdAt && `staged ${item.createdAt}`, item.actor && `by ${item.actor}`]
-    .filter((detail) => detail != null && detail !== '')
+    .filter((detail): detail is string => detail != null && detail !== '')
+    .map((detail) => renderRegistryText(detail))
   return details.length > 0
     ? `${renderStageItemLabel(item)} (${details.join(', ')})`
     : renderStageItemLabel(item)
@@ -157,7 +172,13 @@ function renderStageItemChoice (item: StageItem): string {
 
 function renderStageItemLabel (item: StageItem): string {
   if (!item.packageName) return item.id ?? '<unknown staged package>'
-  return item.version ? `${item.packageName}@${item.version}` : item.packageName
+  const packageName = renderRegistryText(item.packageName)
+  return item.version ? `${packageName}@${renderRegistryText(item.version)}` : packageName
+}
+
+/** Registry-provided text, stripped of what could rewrite the terminal. */
+function renderRegistryText (text: string): string {
+  return redactAndSanitize(text)
 }
 
 /** The label an error message identifies a staged version by. */

--- a/pnpm11/releasing/commands/src/stage/help.ts
+++ b/pnpm11/releasing/commands/src/stage/help.ts
@@ -22,7 +22,7 @@ export function help (): string {
             name: 'view',
           },
           {
-            description: 'Approve a staged package, publishing it to the npm registry.',
+            description: 'Approve staged packages, publishing them to the npm registry. Run without arguments to choose them interactively.',
             name: 'approve',
           },
           {
@@ -59,7 +59,7 @@ export function help (): string {
             name: '--dry-run',
           },
           {
-            description: 'One-time password for approve and reject.',
+            description: 'One-time password for approve and reject. One password covers a whole batch of approvals; pnpm asks for a new one when the registry stops accepting it.',
             name: '--otp',
           },
           {
@@ -76,7 +76,7 @@ export function help (): string {
       'pnpm stage publish [<tarball>|<dir>] [--tag <tag>] [--access <public|restricted>] [options]',
       'pnpm stage list [<package-spec>]',
       'pnpm stage view <stage-id>',
-      'pnpm stage approve <stage-id>',
+      'pnpm stage approve [<stage-id> ...]',
       'pnpm stage reject <stage-id>',
       'pnpm stage download <stage-id>',
     ],

--- a/pnpm11/releasing/commands/src/stage/items.ts
+++ b/pnpm11/releasing/commands/src/stage/items.ts
@@ -1,0 +1,32 @@
+import type { StageContext } from './context.js'
+import { stageJsonRequest } from './request.js'
+import type { StageItem, StageListResponse } from './types.js'
+
+const PER_PAGE = 100
+// Fail-safe bound on the pagination loop, so a registry that keeps answering
+// full pages with an inflated `total` cannot drive it forever.
+const MAX_PAGES = 1000
+
+/**
+ * Every staged version the registry reports, optionally narrowed to one
+ * package name.
+ */
+export async function fetchStageItems (context: StageContext, packageFilter?: string): Promise<StageItem[]> {
+  const items: StageItem[] = []
+  let page = 0
+  while (true) {
+    const url = new URL('-/stage', context.registry)
+    url.searchParams.set('page', page.toString())
+    url.searchParams.set('perPage', PER_PAGE.toString())
+    if (packageFilter) {
+      url.searchParams.set('package', packageFilter)
+    }
+    // eslint-disable-next-line no-await-in-loop
+    const res = await stageJsonRequest<StageListResponse>(context, { url: url.href, action: 'list staged packages' })
+    items.push(...res.items)
+    if (items.length >= res.total || res.items.length < PER_PAGE) break
+    page++
+    if (page >= MAX_PAGES) break
+  }
+  return items
+}

--- a/pnpm11/releasing/commands/src/stage/list.ts
+++ b/pnpm11/releasing/commands/src/stage/list.ts
@@ -1,36 +1,16 @@
 import { PnpmError } from '@pnpm/error'
 
 import { createStageContext } from './context.js'
+import { fetchStageItems } from './items.js'
 import { parseStagePackageSpec } from './parsing.js'
 import { renderStageItem } from './rendering.js'
-import { stageJsonRequest } from './request.js'
-import type { StageItem, StageListResponse, StageOptions } from './types.js'
-
-const PER_PAGE = 100
-// Fail-safe bound on the pagination loop, so a registry that keeps answering
-// full pages with an inflated `total` cannot drive it forever.
-const MAX_PAGES = 1000
+import type { StageOptions } from './types.js'
 
 export async function stageList (opts: StageOptions, params: string[]): Promise<string> {
   const packageFilter = parsePackageFilter(params[0])
 
   const context = createStageContext(opts, packageFilter)
-  const items: StageItem[] = []
-  let page = 0
-  while (true) {
-    const url = new URL('-/stage', context.registry)
-    url.searchParams.set('page', page.toString())
-    url.searchParams.set('perPage', PER_PAGE.toString())
-    if (packageFilter) {
-      url.searchParams.set('package', packageFilter)
-    }
-    // eslint-disable-next-line no-await-in-loop
-    const res = await stageJsonRequest<StageListResponse>(context, { url: url.href, action: 'list staged packages' })
-    items.push(...res.items)
-    if (items.length >= res.total || res.items.length < PER_PAGE) break
-    page++
-    if (page >= MAX_PAGES) break
-  }
+  const items = await fetchStageItems(context, packageFilter)
 
   if (opts.json) return JSON.stringify(items, null, 2)
   if (items.length === 0) {

--- a/pnpm11/releasing/commands/src/stage/parsing.ts
+++ b/pnpm11/releasing/commands/src/stage/parsing.ts
@@ -3,7 +3,7 @@ import npa from '@pnpm/npm-package-arg'
 
 import type { StageSubcommand } from './types.js'
 
-const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+export const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 export function parseStagePackageSpec (rawSpec: string): { name: string, rawSpec: string } {
   let spec: ReturnType<typeof npa>

--- a/pnpm11/releasing/commands/src/stage/parsing.ts
+++ b/pnpm11/releasing/commands/src/stage/parsing.ts
@@ -18,6 +18,15 @@ export function parseStagePackageSpec (rawSpec: string): { name: string, rawSpec
   return { name: spec.name, rawSpec: spec.rawSpec }
 }
 
+/**
+ * Validates every stage id in `params`. An empty `params` yields an empty
+ * array — the caller decides whether that is an error or a request for
+ * interactive selection.
+ */
+export function parseStageIds (params: string[], subcommand: StageSubcommand): string[] {
+  return params.map((stageId) => requireStageId([stageId], subcommand))
+}
+
 export function requireStageId (params: string[], subcommand: StageSubcommand): string {
   if (!params[0]) {
     throw new PnpmError('STAGE_ID_REQUIRED', `Missing required <stage-id> for "pnpm stage ${subcommand}"`)

--- a/pnpm11/releasing/commands/src/stage/request.ts
+++ b/pnpm11/releasing/commands/src/stage/request.ts
@@ -1,5 +1,5 @@
 import { globalWarn } from '@pnpm/logger'
-import { SyntheticOtpError, type WebAuthFetchOptions, withOtpHandling } from '@pnpm/network.web-auth'
+import { createOtpSession, SyntheticOtpError, type WebAuthFetchOptions } from '@pnpm/network.web-auth'
 
 import { createPublishContext } from '../publish/publishPackedPkg.js'
 import type { StageContext } from './context.js'
@@ -31,26 +31,39 @@ export async function stageJsonRequest<T> (
   return await response.json() as T
 }
 
+export interface StageOtpSession {
+  request: (params: { url: string, init: StageRequestInit, action: string }) => Promise<Response>
+}
+
 /**
- * Wraps {@link stageRequest} with OTP / web-auth handling. The first attempt
- * carries any user-configured `--otp`; if the registry responds with an OTP
- * challenge, `withOtpHandling` drives the browser-based authentication flow
- * and retries the operation with the resulting token.
+ * A series of stage mutations sharing one one-time password: the first request
+ * carries any user-configured `--otp`, and the password obtained from a
+ * registry challenge is reused by every later request until the registry stops
+ * accepting it, at which point the next challenge obtains a fresh one.
+ */
+export function createStageOtpSession (context: StageContext): StageOtpSession {
+  const session = createOtpSession({
+    context: createPublishContext(context.opts),
+    fetchOptions: createWebAuthFetchOptions(context.opts),
+  })
+  return {
+    request: async (params) => session.run(async (otp) => stageRequest(context, {
+      url: params.url,
+      action: params.action,
+      init: params.init,
+      otp: otp ?? getConfiguredOtp(context.opts),
+    })),
+  }
+}
+
+/**
+ * Sends a single stage mutation with OTP / web-auth handling.
  */
 export async function stageRequestWithOtp (
   context: StageContext,
   params: { url: string, init: StageRequestInit, action: string }
 ): Promise<Response> {
-  return withOtpHandling({
-    context: createPublishContext(context.opts),
-    fetchOptions: createWebAuthFetchOptions(context.opts),
-    operation: async (otp) => stageRequest(context, {
-      url: params.url,
-      action: params.action,
-      init: params.init,
-      otp: otp ?? getConfiguredOtp(context.opts),
-    }),
-  })
+  return createStageOtpSession(context).request(params)
 }
 
 export async function stageRequest (context: StageContext, params: StageRequestParams): Promise<Response> {

--- a/pnpm11/releasing/commands/src/stage/types.ts
+++ b/pnpm11/releasing/commands/src/stage/types.ts
@@ -1,3 +1,5 @@
+import type { Config } from '@pnpm/config.reader'
+
 import * as publishCommand from '../publish/publish.js'
 
 export const STAGE_SUBCOMMANDS = ['publish', 'list', 'view', 'approve', 'reject', 'download'] as const
@@ -11,7 +13,9 @@ export type StageSubcommand = typeof STAGE_SUBCOMMANDS[number]
  * subcommands need only a subset (registry/auth/fetch/retry settings),
  * but accepting the full set keeps a single type across the dispatcher.
  */
-export type StageOptions = Parameters<typeof publishCommand.publish>[0] & {
+export type StageOptions = Parameters<typeof publishCommand.publish>[0]
+& Partial<Pick<Config, 'linkWorkspacePackages' | 'workspacePackagePatterns'>>
+& {
   cliOptions?: Record<string, unknown>
   json?: boolean
   otp?: string

--- a/pnpm11/releasing/commands/src/stage/types.ts
+++ b/pnpm11/releasing/commands/src/stage/types.ts
@@ -40,6 +40,20 @@ export interface StageItem {
   [key: string]: unknown
 }
 
+/**
+ * One staged version as `pnpm stage approve` works with it: the fields it
+ * displays and orders by, validated and sanitized out of the registry's
+ * {@link StageItem}.
+ */
+export interface ApprovalItem {
+  id: string
+  packageName?: string
+  version?: string
+  tag?: string
+  createdAt?: string
+  actor?: string
+}
+
 export interface StageListResponse {
   items: StageItem[]
   total: number

--- a/pnpm11/releasing/commands/test/stage.test.ts
+++ b/pnpm11/releasing/commands/test/stage.test.ts
@@ -245,12 +245,14 @@ describe('stage command against the registry mock', () => {
         doneUrl: 'https://registry.example.com/-/v1/done?authId=test-auth-id',
       },
     }))
+    const restoreTty = forceNonInteractiveTty()
     try {
       await expect(stage.handler({
         ...stageOpts(registry.url),
         argv: { original: ['stage'] },
       }, ['approve', STAGE_ID])).rejects.toMatchObject({ code: 'ERR_PNPM_OTP_NON_INTERACTIVE' })
     } finally {
+      restoreTty()
       await registry.close()
     }
   })
@@ -529,13 +531,62 @@ describe('stage command against the registry mock', () => {
     }
   })
 
+  test('stage approve sends one request for a repeated stage id', async () => {
+    const seen: string[] = []
+    const registry = await createRegistry((request) => {
+      const stageId = approvedStageId(request)
+      if (stageId) {
+        seen.push(stageId)
+        return { status: 201, body: { ok: true } }
+      }
+      return { status: 404, body: { error: 'not found' } }
+    })
+    try {
+      const result = await stage.handler({
+        ...stageOpts(registry.url),
+        cliOptions: { otp: '123456' },
+        otp: '123456',
+      }, ['approve', STAGE_ID, STAGE_ID])
+      expect(result).toBe(`Staged package ${STAGE_ID} approved and published successfully.`)
+      expect(seen).toEqual([STAGE_ID])
+      expect(registry.requests.filter(({ url }) => url.pathname === '/-/stage')).toHaveLength(0)
+    } finally {
+      await registry.close()
+    }
+  })
+
   test('stage approve without a stage id requires an interactive terminal', async () => {
     const registry = await createRegistry(() => ({ status: 500, body: { error: 'nothing should be requested' } }))
+    const restoreTty = forceNonInteractiveTty()
     try {
       await expect(stage.handler(stageOpts(registry.url), ['approve']))
         .rejects.toMatchObject({ code: 'ERR_PNPM_STAGE_ID_REQUIRED' })
       expect(registry.requests).toHaveLength(0)
     } finally {
+      restoreTty()
+      await registry.close()
+    }
+  })
+
+  test('stage approve does not offer a staged version the registry listed without a stage id', async () => {
+    const registry = await createRegistry((request) => {
+      if (request.method === 'GET' && request.url.pathname === '/-/stage') {
+        return {
+          status: 200,
+          body: {
+            items: [{ id: '../../../-/npm/v1/tokens', packageName: '@pnpmtest/spoofed', version: '1.0.0' }],
+            total: 1,
+          },
+        }
+      }
+      return { status: 404, body: { error: 'not found' } }
+    })
+    const restoreTty = forceInteractiveTty()
+    try {
+      await expect(stage.handler(stageOpts(registry.url), ['approve']))
+        .resolves.toBe('There are no staged packages awaiting approval.')
+    } finally {
+      restoreTty()
       await registry.close()
     }
   })
@@ -686,10 +737,23 @@ function headerValue (value: http.IncomingHttpHeaders[string]): string | undefin
 }
 
 function forceInteractiveTty (): () => void {
+  return overrideTty(true)
+}
+
+function forceNonInteractiveTty (): () => void {
+  return overrideTty(false)
+}
+
+/**
+ * Pins both terminal streams to `isTTY`, so a test exercises the interactive
+ * or the non-interactive path whether or not the suite itself runs on a
+ * terminal. Returns the restore function.
+ */
+function overrideTty (isTTY: boolean): () => void {
   const originalStdin = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY')
   const originalStdout = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
-  Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
-  Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
+  Object.defineProperty(process.stdin, 'isTTY', { value: isTTY, configurable: true })
+  Object.defineProperty(process.stdout, 'isTTY', { value: isTTY, configurable: true })
   return () => {
     if (originalStdin) {
       Object.defineProperty(process.stdin, 'isTTY', originalStdin)

--- a/pnpm11/releasing/commands/test/stage.test.ts
+++ b/pnpm11/releasing/commands/test/stage.test.ts
@@ -563,6 +563,70 @@ describe('stage command against the registry mock', () => {
     }
   })
 
+  test('stage approve aborts the batch when a staged version cannot be read', async () => {
+    const approveAttempts: string[] = []
+    const registry = await createRegistry((request) => {
+      if (describedStageId(request)) {
+        return { status: 401, body: { error: 'unauthorized' } }
+      }
+      const stageId = approvedStageId(request)
+      if (stageId) {
+        approveAttempts.push(stageId)
+        return { status: 201, body: { ok: true } }
+      }
+      return { status: 404, body: { error: 'not found' } }
+    })
+    try {
+      await expect(stage.handler({
+        ...stageOpts(registry.url),
+        cliOptions: { otp: '123456' },
+        otp: '123456',
+      }, ['approve', STAGE_ID, SECOND_STAGE_ID])).rejects.toMatchObject({ code: 'ERR_PNPM_STAGE_REGISTRY_ERROR' })
+      expect(approveAttempts).toHaveLength(0)
+    } finally {
+      await registry.close()
+    }
+  })
+
+  test('stage approve treats a package name the registry made up as no name at all', async () => {
+    const items = [
+      { id: STAGE_ID, packageName: '@pnpmtest/stage-dependent', version: '1.0.0' },
+      // The dependency's name only looks like the workspace package's.
+      { id: SECOND_STAGE_ID, packageName: '@pnpmtest/stage-dependency\u202E', version: '1.0.0' },
+    ]
+    const workspaceDir = prepareWorkspaceWithDependency()
+    const approved: string[] = []
+    const registry = await createRegistry((request) => {
+      const describedStageIdOfRequest = describedStageId(request)
+      if (describedStageIdOfRequest) {
+        const item = items.find(({ id }) => id === describedStageIdOfRequest)
+        return item ? { status: 200, body: item } : { status: 404, body: { error: 'not found' } }
+      }
+      const stageId = approvedStageId(request)
+      if (stageId) {
+        approved.push(stageId)
+        return { status: 201, body: { ok: true } }
+      }
+      return { status: 404, body: { error: 'not found' } }
+    })
+    try {
+      const result = await stage.handler({
+        ...stageOpts(registry.url),
+        cliOptions: { otp: '123456' },
+        dir: workspaceDir,
+        otp: '123456',
+        workspaceDir,
+        workspacePackagePatterns: ['packages/*'],
+      }, ['approve', STAGE_ID, SECOND_STAGE_ID])
+      expect(result).toStrictEqual({ exitCode: 0, output: 'Approved 2 staged packages successfully.' })
+      // Without a workspace identity it sorts after the workspace packages
+      // instead of ahead of the dependent it resembles.
+      expect(approved).toEqual([STAGE_ID, SECOND_STAGE_ID])
+    } finally {
+      await registry.close()
+    }
+  })
+
   test('stage approve without a stage id requires an interactive terminal', async () => {
     const registry = await createRegistry(() => ({ status: 500, body: { error: 'nothing should be requested' } }))
     const restoreTty = forceNonInteractiveTty()

--- a/pnpm11/releasing/commands/test/stage.test.ts
+++ b/pnpm11/releasing/commands/test/stage.test.ts
@@ -392,8 +392,10 @@ describe('stage command against the registry mock', () => {
     let baseUrl = ''
     let acceptedOtp = 'otp-1'
     const registry = await createRegistry((request) => {
-      if (request.method === 'GET' && request.url.pathname === '/-/stage') {
-        return { status: 200, body: { items, total: items.length } }
+      const describedStageIdOfRequest = describedStageId(request)
+      if (describedStageIdOfRequest) {
+        const item = items.find(({ id }) => id === describedStageIdOfRequest)
+        return item ? { status: 200, body: item } : { status: 404, body: { error: 'not found' } }
       }
       if (request.method === 'GET' && request.url.pathname === '/-/v1/done') {
         return { status: 200, body: { token: acceptedOtp } }
@@ -440,8 +442,10 @@ describe('stage command against the registry mock', () => {
       { id: SECOND_STAGE_ID, packageName: '@pnpmtest/stage-passing', version: '1.0.0' },
     ]
     const registry = await createRegistry((request) => {
-      if (request.method === 'GET' && request.url.pathname === '/-/stage') {
-        return { status: 200, body: { items, total: items.length } }
+      const describedStageIdOfRequest = describedStageId(request)
+      if (describedStageIdOfRequest) {
+        const item = items.find(({ id }) => id === describedStageIdOfRequest)
+        return item ? { status: 200, body: item } : { status: 404, body: { error: 'not found' } }
       }
       const stageId = approvedStageId(request)
       if (stageId === STAGE_ID) return { status: 409, body: { error: 'version already exists' } }
@@ -468,8 +472,10 @@ describe('stage command against the registry mock', () => {
     ]
     const approved: string[] = []
     const registry = await createRegistry((request) => {
-      if (request.method === 'GET' && request.url.pathname === '/-/stage') {
-        return { status: 200, body: { items, total: items.length } }
+      const describedStageIdOfRequest = describedStageId(request)
+      if (describedStageIdOfRequest) {
+        const item = items.find(({ id }) => id === describedStageIdOfRequest)
+        return item ? { status: 200, body: item } : { status: 404, body: { error: 'not found' } }
       }
       const stageId = approvedStageId(request)
       if (stageId) {
@@ -486,7 +492,7 @@ describe('stage command against the registry mock', () => {
         otp: '123456',
         workspaceDir,
         workspacePackagePatterns: ['packages/*'],
-      }, ['approve', STAGE_ID.toUpperCase(), SECOND_STAGE_ID])
+      }, ['approve', STAGE_ID, SECOND_STAGE_ID])
       expect(result).toStrictEqual({ exitCode: 0, output: 'Approved 2 staged packages successfully.' })
       expect(approved).toEqual([SECOND_STAGE_ID, STAGE_ID])
     } finally {
@@ -502,8 +508,10 @@ describe('stage command against the registry mock', () => {
     ]
     const approveAttempts: string[] = []
     const registry = await createRegistry((request) => {
-      if (request.method === 'GET' && request.url.pathname === '/-/stage') {
-        return { status: 200, body: { items, total: items.length } }
+      const describedStageIdOfRequest = describedStageId(request)
+      if (describedStageIdOfRequest) {
+        const item = items.find(({ id }) => id === describedStageIdOfRequest)
+        return item ? { status: 200, body: item } : { status: 404, body: { error: 'not found' } }
       }
       const stageId = approvedStageId(request)
       if (stageId) {
@@ -549,7 +557,7 @@ describe('stage command against the registry mock', () => {
       }, ['approve', STAGE_ID, STAGE_ID.toUpperCase()])
       expect(result).toBe(`Staged package ${STAGE_ID} approved and published successfully.`)
       expect(seen).toEqual([STAGE_ID])
-      expect(registry.requests.filter(({ url }) => url.pathname === '/-/stage')).toHaveLength(0)
+      expect(registry.requests.filter(({ method }) => method === 'GET')).toHaveLength(0)
     } finally {
       await registry.close()
     }
@@ -631,6 +639,16 @@ describe('stage command against the registry mock', () => {
     }
   })
 })
+
+/**
+ * The stage id a `GET /-/stage/<id>` request describes, as `stage approve`
+ * reads a named staged version's metadata.
+ */
+function describedStageId (request: RegistryRequest): string | undefined {
+  if (request.method !== 'GET') return undefined
+  const match = /^\/-\/stage\/([^/]+)$/.exec(request.url.pathname)
+  return match?.[1]
+}
 
 function approvedStageId (request: RegistryRequest): string | undefined {
   if (request.method !== 'POST') return undefined

--- a/pnpm11/releasing/commands/test/stage.test.ts
+++ b/pnpm11/releasing/commands/test/stage.test.ts
@@ -486,7 +486,7 @@ describe('stage command against the registry mock', () => {
         otp: '123456',
         workspaceDir,
         workspacePackagePatterns: ['packages/*'],
-      }, ['approve', STAGE_ID, SECOND_STAGE_ID])
+      }, ['approve', STAGE_ID.toUpperCase(), SECOND_STAGE_ID])
       expect(result).toStrictEqual({ exitCode: 0, output: 'Approved 2 staged packages successfully.' })
       expect(approved).toEqual([SECOND_STAGE_ID, STAGE_ID])
     } finally {

--- a/pnpm11/releasing/commands/test/stage.test.ts
+++ b/pnpm11/releasing/commands/test/stage.test.ts
@@ -531,7 +531,7 @@ describe('stage command against the registry mock', () => {
     }
   })
 
-  test('stage approve sends one request for a repeated stage id', async () => {
+  test('stage approve sends one request for a repeated stage id, whatever its spelling', async () => {
     const seen: string[] = []
     const registry = await createRegistry((request) => {
       const stageId = approvedStageId(request)
@@ -546,7 +546,7 @@ describe('stage command against the registry mock', () => {
         ...stageOpts(registry.url),
         cliOptions: { otp: '123456' },
         otp: '123456',
-      }, ['approve', STAGE_ID, STAGE_ID])
+      }, ['approve', STAGE_ID, STAGE_ID.toUpperCase()])
       expect(result).toBe(`Staged package ${STAGE_ID} approved and published successfully.`)
       expect(seen).toEqual([STAGE_ID])
       expect(registry.requests.filter(({ url }) => url.pathname === '/-/stage')).toHaveLength(0)

--- a/pnpm11/releasing/commands/test/stage.test.ts
+++ b/pnpm11/releasing/commands/test/stage.test.ts
@@ -3,7 +3,7 @@ import http from 'node:http'
 import path from 'node:path'
 
 import { describe, expect, test } from '@jest/globals'
-import { prepare } from '@pnpm/prepare'
+import { prepare, preparePackages, tempDir } from '@pnpm/prepare'
 import { stage } from '@pnpm/releasing.commands'
 import { REGISTRY_URL } from '@pnpm/testing.command-defaults'
 import { getRegistryMockToken, REGISTRY_MOCK_CREDENTIALS, REGISTRY_MOCK_PORT } from '@pnpm/testing.registry-mock'
@@ -13,6 +13,8 @@ import { temporaryDirectory } from 'tempy'
 import { DEFAULT_OPTS } from './publish/utils/index.js'
 
 const STAGE_ID = '1de6f3db-2ed9-4d72-b3dd-8f0e2b474a2f'
+const SECOND_STAGE_ID = '2b8f1c14-4a0d-4a4a-9a2e-6c5a2f0a1b33'
+const THIRD_STAGE_ID = '3c7e9d25-5b1e-4b5b-8b3f-7d6b3a1b2c44'
 
 interface RegistryRequest {
   body: Buffer
@@ -378,6 +380,183 @@ describe('stage command against the registry mock', () => {
     }
   })
 
+  test('stage approve reuses one one-time password across the batch and asks for a new one when it expires', async () => {
+    const items = [
+      { id: STAGE_ID, packageName: '@pnpmtest/stage-batch-a', version: '1.0.0' },
+      { id: SECOND_STAGE_ID, packageName: '@pnpmtest/stage-batch-b', version: '1.0.0' },
+      { id: THIRD_STAGE_ID, packageName: '@pnpmtest/stage-batch-c', version: '1.0.0' },
+    ]
+    const otpsByStageId = new Map<string, Array<string | undefined>>()
+    let baseUrl = ''
+    let acceptedOtp = 'otp-1'
+    const registry = await createRegistry((request) => {
+      if (request.method === 'GET' && request.url.pathname === '/-/stage') {
+        return { status: 200, body: { items, total: items.length } }
+      }
+      if (request.method === 'GET' && request.url.pathname === '/-/v1/done') {
+        return { status: 200, body: { token: acceptedOtp } }
+      }
+      const stageId = approvedStageId(request)
+      if (stageId) {
+        const otp = headerValue(request.headers['npm-otp'])
+        otpsByStageId.set(stageId, [...otpsByStageId.get(stageId) ?? [], otp])
+        if (otp === acceptedOtp) {
+          // The password the first approval obtained expires right after it,
+          // so the second approval has to obtain a new one.
+          if (stageId === STAGE_ID) acceptedOtp = 'otp-2'
+          return { status: 201, body: { ok: true } }
+        }
+        return {
+          status: 401,
+          body: {
+            authUrl: 'http://example.invalid/auth-redirect',
+            doneUrl: new URL('/-/v1/done?authId=test', baseUrl).href,
+          },
+        }
+      }
+      return { status: 404, body: { error: 'not found' } }
+    })
+    baseUrl = registry.url
+    const restoreTty = forceInteractiveTty()
+    try {
+      const result = await stage.handler({
+        ...stageOpts(registry.url),
+      }, ['approve', STAGE_ID, SECOND_STAGE_ID, THIRD_STAGE_ID])
+      expect(result).toStrictEqual({ exitCode: 0, output: 'Approved 3 staged packages successfully.' })
+      expect(otpsByStageId.get(STAGE_ID)).toEqual([undefined, 'otp-1'])
+      expect(otpsByStageId.get(SECOND_STAGE_ID)).toEqual(['otp-1', 'otp-2'])
+      expect(otpsByStageId.get(THIRD_STAGE_ID)).toEqual(['otp-2'])
+    } finally {
+      restoreTty()
+      await registry.close()
+    }
+  }, 30000)
+
+  test('stage approve keeps going after a staged package is rejected by the registry', async () => {
+    const items = [
+      { id: STAGE_ID, packageName: '@pnpmtest/stage-failing', version: '1.0.0' },
+      { id: SECOND_STAGE_ID, packageName: '@pnpmtest/stage-passing', version: '1.0.0' },
+    ]
+    const registry = await createRegistry((request) => {
+      if (request.method === 'GET' && request.url.pathname === '/-/stage') {
+        return { status: 200, body: { items, total: items.length } }
+      }
+      const stageId = approvedStageId(request)
+      if (stageId === STAGE_ID) return { status: 409, body: { error: 'version already exists' } }
+      if (stageId === SECOND_STAGE_ID) return { status: 201, body: { ok: true } }
+      return { status: 404, body: { error: 'not found' } }
+    })
+    try {
+      const result = await stage.handler({
+        ...stageOpts(registry.url),
+        cliOptions: { otp: '123456' },
+        otp: '123456',
+      }, ['approve', STAGE_ID, SECOND_STAGE_ID])
+      expect(result).toStrictEqual({ exitCode: 1, output: 'Approved 1 of 2 staged packages.' })
+    } finally {
+      await registry.close()
+    }
+  })
+
+  test('stage approve publishes workspace dependencies before their dependents', async () => {
+    const workspaceDir = prepareWorkspaceWithDependency()
+    const items = [
+      { id: STAGE_ID, packageName: '@pnpmtest/stage-dependent', version: '1.0.0' },
+      { id: SECOND_STAGE_ID, packageName: '@pnpmtest/stage-dependency', version: '1.0.0' },
+    ]
+    const approved: string[] = []
+    const registry = await createRegistry((request) => {
+      if (request.method === 'GET' && request.url.pathname === '/-/stage') {
+        return { status: 200, body: { items, total: items.length } }
+      }
+      const stageId = approvedStageId(request)
+      if (stageId) {
+        approved.push(stageId)
+        return { status: 201, body: { ok: true } }
+      }
+      return { status: 404, body: { error: 'not found' } }
+    })
+    try {
+      const result = await stage.handler({
+        ...stageOpts(registry.url),
+        cliOptions: { otp: '123456' },
+        dir: workspaceDir,
+        otp: '123456',
+        workspaceDir,
+        workspacePackagePatterns: ['packages/*'],
+      }, ['approve', STAGE_ID, SECOND_STAGE_ID])
+      expect(result).toStrictEqual({ exitCode: 0, output: 'Approved 2 staged packages successfully.' })
+      expect(approved).toEqual([SECOND_STAGE_ID, STAGE_ID])
+    } finally {
+      await registry.close()
+    }
+  })
+
+  test('stage approve skips a staged package whose workspace dependency could not be approved', async () => {
+    const workspaceDir = prepareWorkspaceWithDependency()
+    const items = [
+      { id: STAGE_ID, packageName: '@pnpmtest/stage-dependent', version: '1.0.0' },
+      { id: SECOND_STAGE_ID, packageName: '@pnpmtest/stage-dependency', version: '1.0.0' },
+    ]
+    const approveAttempts: string[] = []
+    const registry = await createRegistry((request) => {
+      if (request.method === 'GET' && request.url.pathname === '/-/stage') {
+        return { status: 200, body: { items, total: items.length } }
+      }
+      const stageId = approvedStageId(request)
+      if (stageId) {
+        approveAttempts.push(stageId)
+        return { status: 409, body: { error: 'version already exists' } }
+      }
+      return { status: 404, body: { error: 'not found' } }
+    })
+    try {
+      const result = await stage.handler({
+        ...stageOpts(registry.url),
+        cliOptions: { otp: '123456' },
+        dir: workspaceDir,
+        otp: '123456',
+        workspaceDir,
+        workspacePackagePatterns: ['packages/*'],
+      }, ['approve', STAGE_ID, SECOND_STAGE_ID])
+      expect(result).toStrictEqual({ exitCode: 1, output: 'Approved 0 of 2 staged packages.' })
+      // The dependency is attempted (and retried by the registry client); the
+      // dependent is never sent, as its dependency never reached the registry.
+      expect(approveAttempts).not.toContain(STAGE_ID)
+      expect(approveAttempts).toContain(SECOND_STAGE_ID)
+    } finally {
+      await registry.close()
+    }
+  })
+
+  test('stage approve without a stage id requires an interactive terminal', async () => {
+    const registry = await createRegistry(() => ({ status: 500, body: { error: 'nothing should be requested' } }))
+    try {
+      await expect(stage.handler(stageOpts(registry.url), ['approve']))
+        .rejects.toMatchObject({ code: 'ERR_PNPM_STAGE_ID_REQUIRED' })
+      expect(registry.requests).toHaveLength(0)
+    } finally {
+      await registry.close()
+    }
+  })
+
+  test('stage approve without a stage id reports an empty staging area instead of prompting', async () => {
+    const registry = await createRegistry((request) => {
+      if (request.method === 'GET' && request.url.pathname === '/-/stage') {
+        return { status: 200, body: { items: [], total: 0 } }
+      }
+      return { status: 404, body: { error: 'not found' } }
+    })
+    const restoreTty = forceInteractiveTty()
+    try {
+      await expect(stage.handler(stageOpts(registry.url), ['approve']))
+        .resolves.toBe('There are no staged packages awaiting approval.')
+    } finally {
+      restoreTty()
+      await registry.close()
+    }
+  })
+
   test('stage publish --dry-run reports that packages would be staged', async () => {
     const pkgName = '@scope/stage-publish-dry-run'
     prepare({ name: pkgName, version: '1.0.0' })
@@ -401,6 +580,35 @@ describe('stage command against the registry mock', () => {
     }
   })
 })
+
+function approvedStageId (request: RegistryRequest): string | undefined {
+  if (request.method !== 'POST') return undefined
+  const match = /^\/-\/stage\/([^/]+)\/approve$/.exec(request.url.pathname)
+  return match?.[1]
+}
+
+/**
+ * A workspace whose `@pnpmtest/stage-dependent` package depends on its
+ * `@pnpmtest/stage-dependency` package. Returns the workspace root.
+ */
+function prepareWorkspaceWithDependency (): string {
+  const workspaceDir = tempDir()
+  preparePackages([
+    {
+      location: 'packages/dependency',
+      package: { name: '@pnpmtest/stage-dependency', version: '1.0.0' },
+    },
+    {
+      location: 'packages/dependent',
+      package: {
+        name: '@pnpmtest/stage-dependent',
+        version: '1.0.0',
+        dependencies: { '@pnpmtest/stage-dependency': 'workspace:*' },
+      },
+    },
+  ], { tempDir: path.join(workspaceDir, 'project') })
+  return workspaceDir
+}
 
 function configByUri (): Record<string, Record<string, { authToken: string }>> {
   return {

--- a/pnpm11/releasing/commands/test/stage.test.ts
+++ b/pnpm11/releasing/commands/test/stage.test.ts
@@ -386,7 +386,7 @@ describe('stage command against the registry mock', () => {
       { id: SECOND_STAGE_ID, packageName: '@pnpmtest/stage-batch-b', version: '1.0.0' },
       { id: THIRD_STAGE_ID, packageName: '@pnpmtest/stage-batch-c', version: '1.0.0' },
     ]
-    const otpsByStageId = new Map<string, Array<string | undefined>>()
+    const passwordsByStageId = new Map<string, Array<string | undefined>>()
     let baseUrl = ''
     let acceptedOtp = 'otp-1'
     const registry = await createRegistry((request) => {
@@ -399,7 +399,7 @@ describe('stage command against the registry mock', () => {
       const stageId = approvedStageId(request)
       if (stageId) {
         const otp = headerValue(request.headers['npm-otp'])
-        otpsByStageId.set(stageId, [...otpsByStageId.get(stageId) ?? [], otp])
+        passwordsByStageId.set(stageId, [...passwordsByStageId.get(stageId) ?? [], otp])
         if (otp === acceptedOtp) {
           // The password the first approval obtained expires right after it,
           // so the second approval has to obtain a new one.
@@ -423,9 +423,9 @@ describe('stage command against the registry mock', () => {
         ...stageOpts(registry.url),
       }, ['approve', STAGE_ID, SECOND_STAGE_ID, THIRD_STAGE_ID])
       expect(result).toStrictEqual({ exitCode: 0, output: 'Approved 3 staged packages successfully.' })
-      expect(otpsByStageId.get(STAGE_ID)).toEqual([undefined, 'otp-1'])
-      expect(otpsByStageId.get(SECOND_STAGE_ID)).toEqual(['otp-1', 'otp-2'])
-      expect(otpsByStageId.get(THIRD_STAGE_ID)).toEqual(['otp-2'])
+      expect(passwordsByStageId.get(STAGE_ID)).toEqual([undefined, 'otp-1'])
+      expect(passwordsByStageId.get(SECOND_STAGE_ID)).toEqual(['otp-1', 'otp-2'])
+      expect(passwordsByStageId.get(THIRD_STAGE_ID)).toEqual(['otp-2'])
     } finally {
       restoreTty()
       await registry.close()

--- a/pnpm11/releasing/commands/tsconfig.json
+++ b/pnpm11/releasing/commands/tsconfig.json
@@ -130,6 +130,12 @@
       "path": "../../workspace/projects-filter"
     },
     {
+      "path": "../../workspace/projects-graph"
+    },
+    {
+      "path": "../../workspace/projects-reader"
+    },
+    {
       "path": "../../workspace/projects-sorter"
     },
     {

--- a/pnpm11/releasing/commands/tsconfig.json
+++ b/pnpm11/releasing/commands/tsconfig.json
@@ -127,6 +127,9 @@
       "path": "../../testing/registry-mock"
     },
     {
+      "path": "../../text/sanitize"
+    },
+    {
       "path": "../../workspace/projects-filter"
     },
     {

--- a/pnpm11/text/sanitize/README.md
+++ b/pnpm11/text/sanitize/README.md
@@ -1,0 +1,3 @@
+# @pnpm/text.sanitize
+
+> Strips control and formatting characters from text that reaches the terminal

--- a/pnpm11/text/sanitize/package.json
+++ b/pnpm11/text/sanitize/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@pnpm/text.sanitize",
+  "version": "1100.0.0",
+  "description": "Strips control and formatting characters from text that reaches the terminal",
+  "keywords": [
+    "pnpm",
+    "pnpm11",
+    "sanitize"
+  ],
+  "license": "MIT",
+  "funding": "https://opencollective.com/pnpm",
+  "repository": "https://github.com/pnpm/pnpm/tree/main/pnpm11/text/sanitize",
+  "homepage": "https://github.com/pnpm/pnpm/tree/main/pnpm11/text/sanitize#readme",
+  "bugs": {
+    "url": "https://github.com/pnpm/pnpm/issues"
+  },
+  "type": "module",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "exports": {
+    ".": "./lib/index.js"
+  },
+  "files": [
+    "lib",
+    "!*.map"
+  ],
+  "scripts": {
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "test": "pn compile && pn .test",
+    "prepublishOnly": "tsgo --build",
+    "compile": "tsgo --build && pn lint --fix",
+    ".test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169\" jest"
+  },
+  "devDependencies": {
+    "@jest/globals": "catalog:",
+    "@pnpm/text.sanitize": "workspace:*"
+  },
+  "engines": {
+    "node": ">=22.13"
+  },
+  "jest": {
+    "preset": "@pnpm/jest-config"
+  }
+}

--- a/pnpm11/text/sanitize/src/index.ts
+++ b/pnpm11/text/sanitize/src/index.ts
@@ -1,0 +1,23 @@
+/**
+ * The control and formatting characters {@link sanitizeInline} strips: C0/C1
+ * controls, soft hyphens, bidi overrides, zero-width joiners, variation
+ * selectors, and the other invisible formatting characters.
+ */
+// eslint-disable-next-line no-control-regex
+const CONTROL_AND_FORMAT_CHARACTERS = /[\u0000-\u001F\u007F-\u009F\u00AD\u0600-\u0605\u061C\u06DD\u070F\u0890\u0891\u08E2\u180E\u200B-\u200F\u202A-\u202E\u2060-\u2064\u2066-\u206F\uFEFF\uFFF9-\uFFFB\u{110BD}\u{110CD}\u{13430}-\u{1343F}\u{1BCA0}-\u{1BCA3}\u{1D173}-\u{1D17A}\u{E0001}\u{E0020}-\u{E007F}]/gu
+
+/**
+ * Strips control and formatting characters from text embedded in a
+ * single-line field that reaches the terminal.
+ *
+ * Registry- and store-derived strings (package names, versions, tags,
+ * usernames) can carry escape sequences, bidi overrides, or zero-width
+ * joiners that make rendered output misrepresent what is installed or
+ * published, so every such string is filtered before it is printed.
+ *
+ * The TypeScript counterpart of the Rust `pnpm-text-sanitize` crate's
+ * `sanitize_inline`; the two strip the same characters.
+ */
+export function sanitizeInline (text: string): string {
+  return text.replace(CONTROL_AND_FORMAT_CHARACTERS, '')
+}

--- a/pnpm11/text/sanitize/src/index.ts
+++ b/pnpm11/text/sanitize/src/index.ts
@@ -1,7 +1,12 @@
 /**
  * The control and formatting characters {@link sanitizeInline} strips: C0/C1
- * controls, soft hyphens, bidi overrides, zero-width joiners, variation
- * selectors, and the other invisible formatting characters.
+ * controls, soft hyphens, bidi overrides and isolates, zero-width joiners,
+ * and the other invisible formatting characters that can make a rendered
+ * line read as something else.
+ *
+ * Variation selectors are deliberately absent: they change how the character
+ * before them is drawn rather than where the rest of the line goes, and they
+ * are part of the emoji a package description may legitimately carry.
  */
 // eslint-disable-next-line no-control-regex
 const CONTROL_AND_FORMAT_CHARACTERS = /[\u0000-\u001F\u007F-\u009F\u00AD\u0600-\u0605\u061C\u06DD\u070F\u0890\u0891\u08E2\u180E\u200B-\u200F\u202A-\u202E\u2060-\u2064\u2066-\u206F\uFEFF\uFFF9-\uFFFB\u{110BD}\u{110CD}\u{13430}-\u{1343F}\u{1BCA0}-\u{1BCA3}\u{1D173}-\u{1D17A}\u{E0001}\u{E0020}-\u{E007F}]/gu

--- a/pnpm11/text/sanitize/test/index.test.ts
+++ b/pnpm11/text/sanitize/test/index.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@jest/globals'
+import { sanitizeInline } from '@pnpm/text.sanitize'
+
+test('sanitizeInline strips escape sequences', () => {
+  expect(sanitizeInline('foo\u001B[2K\u001B[G')).toBe('foo[2K[G')
+})
+
+test('sanitizeInline strips invisible formatting characters', () => {
+  expect(sanitizeInline('foo\u202Ebar')).toBe('foobar')
+  expect(sanitizeInline('foo\u200Bbar\uFEFF')).toBe('foobar')
+})
+
+test('sanitizeInline strips line breaks and tabs', () => {
+  expect(sanitizeInline('a\nb\tc')).toBe('abc')
+})
+
+test('sanitizeInline leaves text without control characters untouched', () => {
+  expect(sanitizeInline('@scope/foo@1.0.0')).toBe('@scope/foo@1.0.0')
+})

--- a/pnpm11/text/sanitize/test/tsconfig.json
+++ b/pnpm11/text/sanitize/test/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "../node_modules/.test.lib",
+    "rootDir": "..",
+    "isolatedModules": true
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/pnpm11/text/sanitize/tsconfig.json
+++ b/pnpm11/text/sanitize/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@pnpm/tsconfig",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "include": [
+    "src/**/*.ts",
+    "../../__typings__/**/*.d.ts"
+  ],
+  "references": []
+}

--- a/pnpm11/text/sanitize/tsconfig.lint.json
+++ b/pnpm11/text/sanitize/tsconfig.lint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "../../__typings__/**/*.d.ts"
+  ]
+}


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

`pnpm stage approve` accepted exactly one stage id and wrapped every request in
its own `withOtpHandling`, so approving a release meant one invocation and one
proof of presence per package, in an order the releaser had to work out by
hand.

It now approves a whole set at once:

- **`pnpm stage approve` with no stage id** lists the staged versions and offers
  them in a checkbox prompt. Passing ids (`pnpm stage approve <stage-id> ...`)
  approves that set instead; the single-id form behaves exactly as before.
  Without a TTY and without ids the command still fails with
  `ERR_PNPM_STAGE_ID_REQUIRED`, now with a hint.
- **One one-time password covers the batch.** A new `OtpSession` in the web-auth
  package keeps the password a challenge yielded and passes it to every later
  request, obtaining a new one only once the registry stops accepting it — a
  classic TOTP expires within a minute, which is exactly what a whole-workspace
  approval runs into. `withOtpHandling` is now the single-operation form of that
  session, so `publish` and `stage reject` behave as before.
- **Workspace dependency order.** Run from a workspace, the selection is sorted
  through the workspace dependency graph, so a package is approved after the
  workspace packages it depends on. A package whose workspace dependency could
  not be approved is skipped rather than published against a dependency that
  never reached the registry.
- **Partial failures.** The registry's verdict on one staged version (409, 404,
  …) leaves the rest of the batch running and ends with a non-zero exit; an
  authentication failure or a broken connection aborts the batch.

The staged listing decides what a maintainer publishes, so every field it
carries is checked rather than repaired: the id has to be the UUID the other
subcommands address a staged version by, and the package name — which the
workspace order and the dependency blocking key on — a name npm would accept,
both validated before anything is stripped. A version whose name fails is
approved outside the workspace order rather than under the name it resembles.
The fields that are only displayed (`version`, `tag`, `createdAt`, `actor`) are
stripped of terminal control characters through the new `@pnpm/text.sanitize`,
the counterpart of the `pnpm-text-sanitize` crate pacquet uses, which also
replaces the copy of that character set `update --interactive` carried.

`RELEASING.md` step 6 now uses the picker instead of one `stage approve` call
per package.

Both stacks implement this, down to the partial-batch output and exit code.

## Squash Commit Body

```text
`pnpm stage approve` accepted exactly one stage id and wrapped each request in
its own `withOtpHandling`, so releasing a workspace meant one invocation and one
proof of presence per package, in an order the releaser had to work out by hand.

It now takes a list of stage ids, and with none it lists the staged versions and
offers them in a checkbox prompt (the non-interactive case keeps failing with
STAGE_ID_REQUIRED, now with a hint).

The batch runs through a new `OtpSession` in the web-auth package: it keeps the
one-time password a challenge yielded and passes it to every later request,
re-prompting only once the registry stops accepting it — a classic TOTP expires
within a minute, which is exactly the case a whole-workspace approval hits.
`withOtpHandling` is now the single-operation form of that session, so publish
and reject behave as before.

Inside a workspace the selection is sorted through the workspace dependency
graph (the same sequencer the recursive commands use), keyed on the name each
project publishes under, since that is the only name a staged version carries. A
package whose workspace dependency could not be approved is skipped rather than
published against a dependency that never reached the registry. A registry
verdict on one version leaves the rest of the batch running and ends with a
non-zero exit; an authentication failure or a broken connection aborts it.

The registry's description of a staged version decides what a maintainer
publishes, so its id and package name are validated as they came — a hidden
character can neither be stripped into a valid value nor keep a name from
matching a workspace package — and the display-only fields are stripped of the
control characters that could redraw the picker around a selection. The shared
`@pnpm/text.sanitize` package holds that character set for both the staged
picker and `update --interactive`, mirroring the `pnpm-text-sanitize` crate.

Both stacks implement this, down to the partial-batch summary and exit code —
pacquet has no output-with-exit-code channel, so it prints the summary the way
the dispatcher prints command output and exits 1.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5).
