### PR TITLE
fix(hoisted): build the previous graph without fetching packages

### DIFF
--- a/.changeset/hoisted-install-refetches-skipped-optionals.md
+++ b/.changeset/hoisted-install-refetches-skipped-optionals.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-restorer": patch
+"pnpm": patch
+---
+
+`pnpm install --node-linker=hoisted` no longer downloads every optional dependency it reports as skipped when `node_modules` already exists. The downloads also kept running after pnpm printed `Done`, since nothing waited on them [#14139](https://github.com/pnpm/pnpm/issues/14139).

--- a/.changeset/hoisted-install-refetches-skipped-optionals.md
+++ b/.changeset/hoisted-install-refetches-skipped-optionals.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-`pnpm install --node-linker=hoisted` no longer downloads every optional dependency it reports as skipped when `node_modules` already exists. The downloads also kept running after pnpm printed `Done`, since nothing waited on them [#14139](https://github.com/pnpm/pnpm/issues/14139).
+`pnpm install --node-linker=hoisted` no longer downloads every optional dependency it reports as skipped when `node_modules` already exists. Those downloads also continued after pnpm printed `Done` [#14139](https://github.com/pnpm/pnpm/issues/14139).

--- a/pnpm11/installing/deps-restorer/src/lockfileToHoistedDepGraph.ts
+++ b/pnpm11/installing/deps-restorer/src/lockfileToHoistedDepGraph.ts
@@ -78,8 +78,8 @@ export async function lockfileToHoistedDepGraph (
   if (currentLockfile?.packages != null) {
     prevGraph = (await _lockfileToHoistedDepGraph(currentLockfile, {
       ...opts,
-      dirsOnly: true,
       force: true,
+      skipFetching: true,
       skipped: new Set(),
     })).graph
   } else {
@@ -91,9 +91,22 @@ export async function lockfileToHoistedDepGraph (
   }
 }
 
+interface SkipFetchingOption {
+  /**
+   * When true, never reach the store: the graph is built without
+   * `fetching` and `filesIndexFile`. Set for the previous graph, whose
+   * only consumer diffs its keys against the new graph's to find
+   * directories to remove. That walk runs with `force: true` and an
+   * empty skip list, so it visits packages an earlier install skipped
+   * and never downloaded; fetching them would download tarballs that
+   * are then discarded.
+   */
+  skipFetching?: boolean
+}
+
 async function _lockfileToHoistedDepGraph (
   lockfile: LockfileObject,
-  opts: LockfileToHoistedDepGraphOptions & { dirsOnly?: boolean }
+  opts: LockfileToHoistedDepGraphOptions & SkipFetchingOption
 ): Promise<Omit<LockfileToDepGraphResult, 'prevGraph'>> {
   const tree = hoist(lockfile, {
     hoistingLimits: opts.hoistingLimits,
@@ -188,16 +201,7 @@ async function fetchDeps (
     pkgLocationsByPkgId: Record<string, string[]>
     injectionTargetsByDepPath: Map<string, string[]>
     hoistedLocations: Record<string, string[]>
-    /**
-     * Build the graph from directory names alone, without reaching the
-     * store. Set for the previous graph, whose only consumer diffs its
-     * keys against the new graph's to find directories to remove: its
-     * `force: true` walk visits packages an earlier install skipped and
-     * never downloaded, so fetching them would download tarballs that
-     * are then discarded.
-     */
-    dirsOnly?: boolean
-  } & LockfileToHoistedDepGraphOptions,
+  } & LockfileToHoistedDepGraphOptions & SkipFetchingOption,
   modules: string,
   deps: Set<HoisterResult>
 ): Promise<DepHierarchy> {
@@ -250,7 +254,7 @@ async function fetchDeps (
     const dir = safeJoinModulesDir(modules, dep.name)
     const depLocation = path.relative(opts.lockfileDir, dir)
     let fetchResponse!: ReturnType<FetchPackageToStoreFunction>
-    if (opts.dirsOnly) {
+    if (opts.skipFetching) {
       fetchResponse = {} as unknown as ReturnType<FetchPackageToStoreFunction>
     } else {
       // We check for the existence of the package inside node_modules.

--- a/pnpm11/installing/deps-restorer/src/lockfileToHoistedDepGraph.ts
+++ b/pnpm11/installing/deps-restorer/src/lockfileToHoistedDepGraph.ts
@@ -78,6 +78,7 @@ export async function lockfileToHoistedDepGraph (
   if (currentLockfile?.packages != null) {
     prevGraph = (await _lockfileToHoistedDepGraph(currentLockfile, {
       ...opts,
+      dirsOnly: true,
       force: true,
       skipped: new Set(),
     })).graph
@@ -92,7 +93,7 @@ export async function lockfileToHoistedDepGraph (
 
 async function _lockfileToHoistedDepGraph (
   lockfile: LockfileObject,
-  opts: LockfileToHoistedDepGraphOptions
+  opts: LockfileToHoistedDepGraphOptions & { dirsOnly?: boolean }
 ): Promise<Omit<LockfileToDepGraphResult, 'prevGraph'>> {
   const tree = hoist(lockfile, {
     hoistingLimits: opts.hoistingLimits,
@@ -187,6 +188,15 @@ async function fetchDeps (
     pkgLocationsByPkgId: Record<string, string[]>
     injectionTargetsByDepPath: Map<string, string[]>
     hoistedLocations: Record<string, string[]>
+    /**
+     * Build the graph from directory names alone, without reaching the
+     * store. Set for the previous graph, whose only consumer diffs its
+     * keys against the new graph's to find directories to remove: its
+     * `force: true` walk visits packages an earlier install skipped and
+     * never downloaded, so fetching them would download tarballs that
+     * are then discarded.
+     */
+    dirsOnly?: boolean
   } & LockfileToHoistedDepGraphOptions,
   modules: string,
   deps: Set<HoisterResult>
@@ -239,44 +249,47 @@ async function fetchDeps (
 
     const dir = safeJoinModulesDir(modules, dep.name)
     const depLocation = path.relative(opts.lockfileDir, dir)
-    const resolution = pkgSnapshotToResolution(depPath, pkgSnapshot, pickRegistryContext(opts))
     let fetchResponse!: ReturnType<FetchPackageToStoreFunction>
-    // We check for the existence of the package inside node_modules.
-    // It will only be missing if the user manually removed it.
-    // That shouldn't normally happen but Bit CLI does remove node_modules in component directories:
-    // https://github.com/teambit/bit/blob/5e1eed7cd122813ad5ea124df956ee89d661d770/scopes/dependencies/dependency-resolver/dependency-installer.ts#L169
-    //
-    // We also verify that the package that is present has the expected version.
-    // This check is required because there is no guarantee the modules manifest and current lockfile were
-    // successfully saved after node_modules was changed during installation.
-    const skipFetch = opts.currentHoistedLocations?.[depPath]?.includes(depLocation) &&
-      await dirHasPackageJsonWithVersion(path.join(opts.lockfileDir, depLocation), pkgVersion)
-    const pkgResolution = {
-      id: packageId,
-      resolution,
-      name: pkgName,
-      version: pkgVersion,
-    }
-    if (skipFetch) {
-      const { filesIndexFile } = opts.storeController.getFilesIndexFilePath({
-        ignoreScripts: opts.ignoreScripts,
-        pkg: pkgResolution,
-      })
-      fetchResponse = { filesIndexFile } as unknown as ReturnType<FetchPackageToStoreFunction>
+    if (opts.dirsOnly) {
+      fetchResponse = {} as unknown as ReturnType<FetchPackageToStoreFunction>
     } else {
-      try {
-        fetchResponse = opts.storeController.fetchPackage({
-          allowBuild: opts.allowBuild,
-          force: false,
-          lockfileDir: opts.lockfileDir,
+      // We check for the existence of the package inside node_modules.
+      // It will only be missing if the user manually removed it.
+      // That shouldn't normally happen but Bit CLI does remove node_modules in component directories:
+      // https://github.com/teambit/bit/blob/5e1eed7cd122813ad5ea124df956ee89d661d770/scopes/dependencies/dependency-resolver/dependency-installer.ts#L169
+      //
+      // We also verify that the package that is present has the expected version.
+      // This check is required because there is no guarantee the modules manifest and current lockfile were
+      // successfully saved after node_modules was changed during installation.
+      const skipFetch = opts.currentHoistedLocations?.[depPath]?.includes(depLocation) &&
+        await dirHasPackageJsonWithVersion(path.join(opts.lockfileDir, depLocation), pkgVersion)
+      const pkgResolution = {
+        id: packageId,
+        resolution: pkgSnapshotToResolution(depPath, pkgSnapshot, pickRegistryContext(opts)),
+        name: pkgName,
+        version: pkgVersion,
+      }
+      if (skipFetch) {
+        const { filesIndexFile } = opts.storeController.getFilesIndexFilePath({
           ignoreScripts: opts.ignoreScripts,
           pkg: pkgResolution,
-          supportedArchitectures: opts.supportedArchitectures,
-        }) as unknown as ReturnType<FetchPackageToStoreFunction>
-        if (fetchResponse instanceof Promise) fetchResponse = await fetchResponse
-      } catch (err: unknown) {
-        if (pkgSnapshot.optional) return
-        throw err
+        })
+        fetchResponse = { filesIndexFile } as unknown as ReturnType<FetchPackageToStoreFunction>
+      } else {
+        try {
+          fetchResponse = opts.storeController.fetchPackage({
+            allowBuild: opts.allowBuild,
+            force: false,
+            lockfileDir: opts.lockfileDir,
+            ignoreScripts: opts.ignoreScripts,
+            pkg: pkgResolution,
+            supportedArchitectures: opts.supportedArchitectures,
+          }) as unknown as ReturnType<FetchPackageToStoreFunction>
+          if (fetchResponse instanceof Promise) fetchResponse = await fetchResponse
+        } catch (err: unknown) {
+          if (pkgSnapshot.optional) return
+          throw err
+        }
       }
     }
     opts.graph[dir] = {

--- a/pnpm11/installing/deps-restorer/src/lockfileToHoistedDepGraph.ts
+++ b/pnpm11/installing/deps-restorer/src/lockfileToHoistedDepGraph.ts
@@ -93,13 +93,9 @@ export async function lockfileToHoistedDepGraph (
 
 interface SkipFetchingOption {
   /**
-   * When true, never reach the store: the graph is built without
-   * `fetching` and `filesIndexFile`. Set for the previous graph, whose
-   * only consumer diffs its keys against the new graph's to find
-   * directories to remove. That walk runs with `force: true` and an
-   * empty skip list, so it visits packages an earlier install skipped
-   * and never downloaded; fetching them would download tarballs that
-   * are then discarded.
+   * Build the graph without reaching the store. The previous graph is
+   * only diffed by directory name, and its forced walk visits packages
+   * the earlier install skipped and never downloaded.
    */
   skipFetching?: boolean
 }

--- a/pnpm11/installing/deps-restorer/test/lockfileToHoistedDepGraph.test.ts
+++ b/pnpm11/installing/deps-restorer/test/lockfileToHoistedDepGraph.test.ts
@@ -161,51 +161,6 @@ test('lockfileToHoistedDepGraph keeps file-dep peer variants apart', async () =>
   })
 })
 
-// The previous graph is only diffed by directory name, and its walk runs
-// with `force: true` and an empty skip list so it also names directories
-// an earlier install could have left behind. Reaching the store from
-// there downloads every optional dependency that install skipped.
-test('lockfileToHoistedDepGraph does not fetch anything for the previous graph', async () => {
-  const dir = tempDir(false)
-  const opts = hoistedOpts(dir)
-  const fetchedDepPaths: string[] = []
-  opts.skipped = new Set(['opt@1.0.0'])
-  opts.storeController = {
-    fetchPackage: ({ pkg }: { pkg: { id: string } }) => {
-      fetchedDepPaths.push(pkg.id)
-      return { filesIndexFile: '' }
-    },
-    getFilesIndexFilePath: () => ({ filesIndexFile: '' }),
-  } as unknown as typeof opts.storeController
-
-  const lockfile = skippedOptionalLockfile()
-  const { prevGraph } = await lockfileToHoistedDepGraph(lockfile, lockfile, opts)
-
-  expect(fetchedDepPaths).toStrictEqual(['a@1.0.0'])
-  const modulesDir = path.join(dir, 'node_modules')
-  expect(Object.keys(prevGraph!).sort()).toStrictEqual([
-    path.join(modulesDir, 'a'),
-    path.join(modulesDir, 'opt'),
-  ])
-})
-
-function skippedOptionalLockfile (): LockfileObject {
-  return {
-    lockfileVersion: '9.0',
-    importers: {
-      '.': {
-        dependencies: { a: '1.0.0' },
-        optionalDependencies: { opt: '1.0.0' },
-        specifiers: { a: '1.0.0', opt: '1.0.0' },
-      },
-    },
-    packages: {
-      'a@1.0.0': { resolution: { integrity: 'sha512-deadbeef' } },
-      'opt@1.0.0': { resolution: { integrity: 'sha512-deadbeef' }, optional: true },
-    },
-  } as unknown as LockfileObject
-}
-
 function fileVariantLockfile (): LockfileObject {
   const importer = (peerVersion: string) => ({
     dependencies: {
@@ -230,6 +185,51 @@ function fileVariantLockfile (): LockfileObject {
       'comp@file:comp(peer@2.0.0)': compVariant('2.0.0'),
       'peer@1.0.0': { resolution: { integrity: 'sha512-deadbeef' } },
       'peer@2.0.0': { resolution: { integrity: 'sha512-deadbeef' } },
+    },
+  } as unknown as LockfileObject
+}
+
+// The previous graph is only diffed by directory name, and its walk runs
+// with `force: true` and an empty skip list so it also names directories
+// an earlier install could have left behind. Reaching the store from
+// there downloads every optional dependency that install skipped.
+test('lockfileToHoistedDepGraph does not fetch anything for the previous graph', async () => {
+  const dir = tempDir(false)
+  const opts = hoistedOpts(dir)
+  const fetchedPkgIds: string[] = []
+  opts.skipped = new Set(['opt@1.0.0'])
+  opts.storeController = {
+    fetchPackage: ({ pkg }: { pkg: { id: string } }) => {
+      fetchedPkgIds.push(pkg.id)
+      return { filesIndexFile: '' }
+    },
+    getFilesIndexFilePath: () => ({ filesIndexFile: '' }),
+  } as unknown as typeof opts.storeController
+
+  const lockfile = skippedOptionalLockfile()
+  const { prevGraph } = await lockfileToHoistedDepGraph(lockfile, lockfile, opts)
+
+  expect(fetchedPkgIds).toStrictEqual(['a@1.0.0'])
+  const modulesDir = path.join(dir, 'node_modules')
+  expect(Object.keys(prevGraph!).sort()).toStrictEqual([
+    path.join(modulesDir, 'a'),
+    path.join(modulesDir, 'opt'),
+  ])
+})
+
+function skippedOptionalLockfile (): LockfileObject {
+  return {
+    lockfileVersion: '9.0',
+    importers: {
+      '.': {
+        dependencies: { a: '1.0.0' },
+        optionalDependencies: { opt: '1.0.0' },
+        specifiers: { a: '1.0.0', opt: '1.0.0' },
+      },
+    },
+    packages: {
+      'a@1.0.0': { resolution: { integrity: 'sha512-deadbeef' } },
+      'opt@1.0.0': { resolution: { integrity: 'sha512-deadbeef' }, optional: true },
     },
   } as unknown as LockfileObject
 }

--- a/pnpm11/installing/deps-restorer/test/lockfileToHoistedDepGraph.test.ts
+++ b/pnpm11/installing/deps-restorer/test/lockfileToHoistedDepGraph.test.ts
@@ -161,6 +161,51 @@ test('lockfileToHoistedDepGraph keeps file-dep peer variants apart', async () =>
   })
 })
 
+// The previous graph is only diffed by directory name, and its walk runs
+// with `force: true` and an empty skip list so it also names directories
+// an earlier install could have left behind. Reaching the store from
+// there downloads every optional dependency that install skipped.
+test('lockfileToHoistedDepGraph does not fetch anything for the previous graph', async () => {
+  const dir = tempDir(false)
+  const opts = hoistedOpts(dir)
+  const fetchedDepPaths: string[] = []
+  opts.skipped = new Set(['opt@1.0.0'])
+  opts.storeController = {
+    fetchPackage: ({ pkg }: { pkg: { id: string } }) => {
+      fetchedDepPaths.push(pkg.id)
+      return { filesIndexFile: '' }
+    },
+    getFilesIndexFilePath: () => ({ filesIndexFile: '' }),
+  } as unknown as typeof opts.storeController
+
+  const lockfile = skippedOptionalLockfile()
+  const { prevGraph } = await lockfileToHoistedDepGraph(lockfile, lockfile, opts)
+
+  expect(fetchedDepPaths).toStrictEqual(['a@1.0.0'])
+  const modulesDir = path.join(dir, 'node_modules')
+  expect(Object.keys(prevGraph!).sort()).toStrictEqual([
+    path.join(modulesDir, 'a'),
+    path.join(modulesDir, 'opt'),
+  ])
+})
+
+function skippedOptionalLockfile (): LockfileObject {
+  return {
+    lockfileVersion: '9.0',
+    importers: {
+      '.': {
+        dependencies: { a: '1.0.0' },
+        optionalDependencies: { opt: '1.0.0' },
+        specifiers: { a: '1.0.0', opt: '1.0.0' },
+      },
+    },
+    packages: {
+      'a@1.0.0': { resolution: { integrity: 'sha512-deadbeef' } },
+      'opt@1.0.0': { resolution: { integrity: 'sha512-deadbeef' }, optional: true },
+    },
+  } as unknown as LockfileObject
+}
+
 function fileVariantLockfile (): LockfileObject {
   const importer = (peerVersion: string) => ({
     dependencies: {

--- a/pnpm11/installing/deps-restorer/test/lockfileToHoistedDepGraph.test.ts
+++ b/pnpm11/installing/deps-restorer/test/lockfileToHoistedDepGraph.test.ts
@@ -189,10 +189,6 @@ function fileVariantLockfile (): LockfileObject {
   } as unknown as LockfileObject
 }
 
-// The previous graph is only diffed by directory name, and its walk runs
-// with `force: true` and an empty skip list so it also names directories
-// an earlier install could have left behind. Reaching the store from
-// there downloads every optional dependency that install skipped.
 test('lockfileToHoistedDepGraph does not fetch anything for the previous graph', async () => {
   const dir = tempDir(false)
   const opts = hoistedOpts(dir)


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

With `--node-linker=hoisted` and an existing `node_modules`, `lockfileToHoistedDepGraph` replays the current lockfile a second time to find the directories the previous install left on disk. That replay runs with `force: true` and an empty skip list, so it reaches every optional dependency the install just reported as skipped and sends each one to `storeController.fetchPackage()`. Nothing awaits those promises, so the downloads outlive the `Done` line. The reporter measured 25 needless tarballs on a one-dependency project and 436 MB on a real one.

The replay's only consumer diffs `Object.keys(prevGraph)` against the new graph to pick directories to remove, so it needs directory names and nothing else. It now walks with `skipFetching` so it stays away from the store controller, leaving `force: true` and its inclusiveness untouched.

The pacquet graph walker also builds a forced `prev_graph`, but it performs no store I/O. Package fetching is driven independently from the current install graph, so the previous-graph walk cannot trigger this bug and needs no matching change.

Fixes pnpm/pnpm#14139

## Squash Commit Body

```text
lockfileToHoistedDepGraph replays the current lockfile with `force: true`
and an empty skip list to collect the directories the previous install
left on disk. `force: true` bypasses the installability guard in
fetchDeps, and the local skipFetch fast path only triggers for packages
currentHoistedLocations already places, which a skipped optional
dependency never is. Every one of them therefore reached
storeController.fetchPackage(), and because the replay's promises are
never awaited the downloads continued past "Done".

linkHoistedModules only reads Object.keys(prevGraph), so the replay
needs directory names and nothing else. Give fetchDeps a skipFetching option
that stubs the fetch response instead of calling the store controller,
and pass it when building prevGraph.

Routing the replay through the existing skipFetch branch would not do:
that branch still calls getFilesIndexFilePath, which throws
NO_RESOLUTION_MATCHED for a variations resolution carrying no variant
for the current platform.

Closes pnpm/pnpm#14139
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790193200&installation_model_id=426870&pr_number=14141&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14141&signature=68141725e1ec78f42b01a1d9319edc37a0ed27af4d7dbf7e3c11d5e55e652ed9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hoisted installs no longer download skipped optional dependencies when `node_modules` already exists.
  * Dependency downloads now finish before pnpm reports that installation is complete.
  * Existing package directories are recognized correctly during installation, helping avoid unnecessary downloads.

* **Tests**
  * Added coverage to verify skipped optional packages are not fetched during hoisted installation and existing package directories are handled correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
