### PR TITLE
fix(pacquet): link a manifest-less root-component member from its snapshot, not the whole root

### DIFF
--- a/.changeset/root-component-siblings-from-snapshot.md
+++ b/.changeset/root-component-siblings-from-snapshot.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Under `nodeLinker: isolated`, a Bit root-component member whose materialized slot carries no `package.json` now gets its sibling symlinks from its own lockfile snapshot instead of gaining a link to every other member of the root. On a Bit workspace the all-member fallback cost one symlink per (member, member) pair — hundreds of thousands of inodes on a large workspace — while the snapshot declares the same edges exactly. The all-member fallback remains only for a member with neither a manifest nor a snapshot.

--- a/.changeset/root-component-siblings-from-snapshot.md
+++ b/.changeset/root-component-siblings-from-snapshot.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Under `nodeLinker: isolated`, a Bit root-component member whose materialized slot carries no `package.json` now gets its sibling symlinks from its own lockfile snapshot instead of gaining a link to every other member of the root. On a Bit workspace the all-member fallback cost one symlink per (member, member) pair — hundreds of thousands of inodes on a large workspace — while the snapshot declares the same edges exactly. The all-member fallback remains only for a member with neither a manifest nor a snapshot.
+Under `nodeLinker: isolated`, a Bit root-component member whose materialized copy carries no `package.json` now receives sibling symlinks for the dependencies its own lockfile snapshot declares, instead of a symlink to every other member of the root. The all-member fallback remains only when no snapshot exists.

--- a/pnpm/crates/deps-restorer/src/link_root_component_members.rs
+++ b/pnpm/crates/deps-restorer/src/link_root_component_members.rs
@@ -240,7 +240,14 @@ fn link_declared_siblings(
                 .into_iter()
                 .flatten()
                 .flatten()
-                .filter_map(|(alias, _)| by_name.get(alias.to_string().as_str()).copied())
+                .filter_map(|(alias, dep_ref)| {
+                    let sibling = by_name.get(alias.to_string().as_str()).copied()?;
+                    // Only an edge that resolves to this sibling's own
+                    // peer-variant slot: a registry, `link:`, or
+                    // other-variant reference that merely shares the
+                    // alias is not this member.
+                    (dep_ref.resolve(alias).as_ref() == Some(&sibling.key)).then_some(sibling)
+                })
                 .collect(),
             (None, None) => members.iter().collect(),
         };

--- a/pnpm/crates/deps-restorer/src/link_root_component_members.rs
+++ b/pnpm/crates/deps-restorer/src/link_root_component_members.rs
@@ -2,7 +2,8 @@ use crate::{SkippedSnapshots, SymlinkPackageError, VirtualStoreLayout, symlink_p
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pnpm_lockfile::{
-    ImporterDepVersion, PackageKey, PkgName, ProjectSnapshot, ResolvedDependencySpec, VersionPart,
+    ImporterDepVersion, PackageKey, PkgName, ProjectSnapshot, ResolvedDependencySpec,
+    SnapshotEntry, VersionPart,
 };
 use pnpm_package_manifest::{DependencyGroup, PackageManifest, PackageManifestError};
 use std::{
@@ -39,10 +40,13 @@ pub const HOISTING_LIMITS_WORKSPACES: &str = "workspaces";
 ///
 /// This restores exactly the edges the isolated linker creates for an
 /// ordinary dependency: for each member it symlinks the siblings that
-/// member *declares in its own manifest* into its slot `node_modules/`.
-/// It mirrors pnpm — each package's slot holds only its own declared
-/// children, and a transitive sibling resolves through the chain
-/// (`comp3 → comp2 → comp1`) rather than an all-to-all clique.
+/// member declares into its slot `node_modules/` — read from the
+/// slot's own `package.json` when one is materialized, else from the
+/// member's lockfile snapshot, else (with neither source) linking the
+/// whole root as a last resort. It mirrors pnpm — each package's slot
+/// holds only its own declared children, and a transitive sibling
+/// resolves through the chain (`comp3 → comp2 → comp1`) rather than
+/// an all-to-all clique.
 ///
 /// ## Why this is safe
 /// It fires only for importers whose manifest declares
@@ -57,6 +61,7 @@ pub const HOISTING_LIMITS_WORKSPACES: &str = "workspaces";
 pub fn link_root_component_members(
     layout: &VirtualStoreLayout,
     importers: &HashMap<String, ProjectSnapshot>,
+    snapshots: Option<&HashMap<PackageKey, SnapshotEntry>>,
     root_component_importers: &HashSet<String>,
     dependency_groups: &[DependencyGroup],
     skipped: &SkippedSnapshots,
@@ -72,7 +77,7 @@ pub fn link_root_component_members(
             continue;
         }
         let members = collect_injected_members(layout, importer, dependency_groups, skipped);
-        link_declared_siblings(&members)?;
+        link_declared_siblings(&members, snapshots)?;
     }
 
     Ok(())
@@ -84,6 +89,9 @@ struct Member {
     /// `@scope/name` — the name siblings import this member as, and the
     /// directory name under `node_modules/`.
     name: String,
+    /// The member's snapshot key (its exact peer variant), for looking
+    /// up the sibling edges the lockfile declares for this copy.
+    key: PackageKey,
     /// `<slot>/node_modules` — where this member's dependency symlinks
     /// live, and where sibling symlinks get added.
     slot_modules_dir: PathBuf,
@@ -133,7 +141,7 @@ fn collect_injected_members(
             }
             let slot_modules_dir = layout.slot_dir(&key).join("node_modules");
             let package_dir = slot_modules_dir.join(&dir_name);
-            members.push(Member { name: dir_name, slot_modules_dir, package_dir });
+            members.push(Member { name: dir_name, key, slot_modules_dir, package_dir });
         }
     }
     members
@@ -171,27 +179,32 @@ fn injected_member_key(
 /// Symlink each member's sibling dependencies into its slot
 /// `node_modules/`.
 ///
-/// A member's manifest is the source of truth for which siblings it
-/// depends on — it survives `excludeLinksFromLockfile` /
-/// `dedupeInjectedDeps`, where the lockfile edges do not. Only the
-/// `dependencies` / `optionalDependencies` / `peerDependencies` a
-/// member declares are linked, and only when the named package is
-/// itself a member of this same root (its peer-resolved slot), matching
-/// the isolated linker's per-package child linking.
+/// Only the siblings a member declares are linked, and only when the
+/// named package is itself a member of this same root (its
+/// peer-resolved slot), matching the isolated linker's per-package
+/// child linking. The declared set comes from the best source
+/// available for the member:
 ///
-/// A Bit workspace component carries no `package.json` in its source
-/// directory (its manifest lives only in memory on the Bit side, and
-/// Bit's read-package hooks strip sibling edges from it before it ever
-/// reaches the engine), so the materialized slot has no manifest to
-/// read. For such a member the declared-edge information is simply
-/// unavailable — fall back to linking **every** other member of this
-/// root into its slot. The clique is safe: member names are unique
-/// within one root's peer context, the links are additive (an entry the
-/// member already resolves for itself is never overwritten), and a
-/// member only ever `require`s what it actually depends on, so surplus
-/// links are inert. A manifest that exists but cannot be parsed is
-/// still a hard error.
-fn link_declared_siblings(members: &[Member]) -> Result<(), LinkRootComponentMembersError> {
+/// 1. The slot's `package.json`, when the materialized copy carries
+///    one — it survives `excludeLinksFromLockfile` /
+///    `dedupeInjectedDeps`, where lockfile edges may not.
+/// 2. The member's own lockfile snapshot (its exact peer-variant key),
+///    when the slot has no manifest — a Bit workspace component
+///    carries no `package.json` in its source directory (its manifest
+///    lives only in memory on the Bit side), but its snapshot still
+///    declares the sibling `file:` edges of this copy.
+/// 3. Every other member of the root, when neither exists. The clique
+///    is safe — member names are unique within one root's peer
+///    context, the links are additive, and a member only ever
+///    `require`s what it actually depends on, so surplus links are
+///    inert — but at a Bit-workspace scale it costs one symlink per
+///    (member, member) pair, which is why the snapshot is preferred.
+///
+/// A manifest that exists but cannot be parsed is still a hard error.
+fn link_declared_siblings(
+    members: &[Member],
+    snapshots: Option<&HashMap<PackageKey, SnapshotEntry>>,
+) -> Result<(), LinkRootComponentMembersError> {
     // Within one root importer each member name is unique (one peer
     // context per root), so a declared name identifies at most one
     // sibling slot.
@@ -202,8 +215,6 @@ fn link_declared_siblings(members: &[Member]) -> Result<(), LinkRootComponentMem
         let manifest_path = host.package_dir.join("package.json");
         let manifest = match PackageManifest::from_path(manifest_path.clone()) {
             Ok(manifest) => Some(manifest),
-            // No manifest on disk — the Bit-workspace shape. Link the
-            // whole root clique instead (see the doc comment above).
             Err(PackageManifestError::NoImporterManifestFound(_)) => None,
             Err(source) => {
                 return Err(LinkRootComponentMembersError::ReadManifest {
@@ -213,8 +224,9 @@ fn link_declared_siblings(members: &[Member]) -> Result<(), LinkRootComponentMem
                 });
             }
         };
-        let siblings: Vec<&Member> = match &manifest {
-            Some(manifest) => manifest
+        let snapshot = || snapshots.and_then(|snapshots| snapshots.get(&host.key));
+        let siblings: Vec<&Member> = match (&manifest, snapshot()) {
+            (Some(manifest), _) => manifest
                 .dependencies([
                     DependencyGroup::Prod,
                     DependencyGroup::Optional,
@@ -224,7 +236,13 @@ fn link_declared_siblings(members: &[Member]) -> Result<(), LinkRootComponentMem
                 // package dir already lives in its slot.
                 .filter_map(|(dep_name, _)| by_name.get(dep_name).copied())
                 .collect(),
-            None => members.iter().collect(),
+            (None, Some(snapshot)) => [&snapshot.dependencies, &snapshot.optional_dependencies]
+                .into_iter()
+                .flatten()
+                .flatten()
+                .filter_map(|(alias, _)| by_name.get(alias.to_string().as_str()).copied())
+                .collect(),
+            (None, None) => members.iter().collect(),
         };
         for sibling in siblings {
             if sibling.name == host.name {

--- a/pnpm/crates/deps-restorer/src/link_root_component_members/tests.rs
+++ b/pnpm/crates/deps-restorer/src/link_root_component_members/tests.rs
@@ -332,7 +332,20 @@ fn member_without_manifest_links_snapshot_declared_siblings() {
     snapshots.insert(
         snapshot_key("@scope/a", "a"),
         SnapshotEntry {
-            dependencies: Some(std::iter::once(sibling_edge("@scope/b", "b")).collect()),
+            dependencies: Some(
+                [
+                    sibling_edge("@scope/b", "b"),
+                    // A registry reference whose alias collides with the
+                    // member name `@scope/c` — it resolves to a different
+                    // key than c's slot, so it must not be linked as c.
+                    (
+                        "@scope/c".parse::<PkgName>().unwrap(),
+                        SnapshotDepRef::Plain("2.0.0".parse().unwrap()),
+                    ),
+                ]
+                .into_iter()
+                .collect(),
+            ),
             ..SnapshotEntry::default()
         },
     );
@@ -359,21 +372,19 @@ fn member_without_manifest_links_snapshot_declared_siblings() {
     let b_slot = &slots["@scope/b"];
     let c_slot = &slots["@scope/c"];
 
-    // `a` links its snapshot-declared sibling `b`, and nothing else.
     assert!(
         is_symlink_or_junction(&a_slot.join("@scope/b")).unwrap(),
         "a must link its snapshot-declared sibling b",
     );
     assert!(
         !a_slot.join("@scope/c").exists(),
-        "a must not gain the clique — c is not declared in a's snapshot",
+        "a must link neither the clique nor a registry ref that shares a member's alias",
     );
     assert_eq!(
         fs::canonicalize(a_slot.join("@scope/b")).unwrap(),
         fs::canonicalize(b_slot.join("@scope/b")).unwrap(),
     );
 
-    // `b` links `c`, not `a`; `c` links nothing.
     assert!(is_symlink_or_junction(&b_slot.join("@scope/c")).unwrap());
     assert!(!b_slot.join("@scope/a").exists());
     assert!(!c_slot.join("@scope/a").exists());

--- a/pnpm/crates/deps-restorer/src/link_root_component_members/tests.rs
+++ b/pnpm/crates/deps-restorer/src/link_root_component_members/tests.rs
@@ -2,7 +2,7 @@ use super::{HOISTING_LIMITS_WORKSPACES, injected_member_key, link_root_component
 use crate::{SkippedSnapshots, VirtualStoreLayout};
 use pnpm_lockfile::{
     ImporterDepVersion, PackageKey, PkgName, ProjectSnapshot, ResolvedDependencyMap,
-    ResolvedDependencySpec,
+    ResolvedDependencySpec, SnapshotDepRef, SnapshotEntry,
 };
 use pnpm_package_manifest::DependencyGroup;
 use pnpm_testing_utils::fs::is_symlink_or_junction;
@@ -150,6 +150,7 @@ fn injected_members_link_declared_siblings() {
     link_root_component_members(
         &layout,
         &importers,
+        None,
         &id_set(&[importer_id.as_str()]),
         &[DependencyGroup::Prod],
         &SkippedSnapshots::default(),
@@ -210,12 +211,12 @@ fn injected_members_link_declared_siblings() {
     drop(dir);
 }
 
-/// A member whose slot has no `package.json` — a Bit workspace
-/// component, whose manifest exists only in memory on the Bit side —
-/// falls back to linking every other member of the root into its slot.
-/// Members that DO have a manifest keep the declared-only behavior.
+/// A member with no slot `package.json` and no lockfile snapshot to
+/// consult falls back to linking every other member of the root into
+/// its slot. Members that DO have a manifest keep the declared-only
+/// behavior.
 #[test]
-fn member_without_manifest_links_all_root_siblings() {
+fn member_without_manifest_or_snapshot_links_all_root_siblings() {
     let dir = tempdir().unwrap();
     let layout = VirtualStoreLayout::legacy(dir.path().join("vs"), 120);
 
@@ -244,6 +245,7 @@ fn member_without_manifest_links_all_root_siblings() {
     link_root_component_members(
         &layout,
         &importers,
+        None,
         &id_set(&[importer_id.as_str()]),
         &[DependencyGroup::Prod],
         &SkippedSnapshots::default(),
@@ -275,6 +277,111 @@ fn member_without_manifest_links_all_root_siblings() {
     drop(dir);
 }
 
+/// A member with no slot `package.json` whose lockfile snapshot is
+/// available gets only the siblings that snapshot declares — not the
+/// all-to-all clique. This is the Bit-workspace shape at scale: the
+/// snapshot of the member's exact peer variant carries its sibling
+/// `file:` edges, so the clique (one symlink per member pair) is never
+/// needed when the lockfile is present.
+#[test]
+fn member_without_manifest_links_snapshot_declared_siblings() {
+    let dir = tempdir().unwrap();
+    let layout = VirtualStoreLayout::legacy(dir.path().join("vs"), 120);
+
+    // None of the members carries a manifest; a declares b (in the
+    // lockfile), b declares c, c declares nothing.
+    let slots: HashMap<&str, std::path::PathBuf> =
+        [("@scope/a", "a"), ("@scope/b", "b"), ("@scope/c", "c")]
+            .into_iter()
+            .map(|(name, payload)| {
+                let slot = member_slot_modules_dir(&layout, name, payload);
+                fs::create_dir_all(slot.join(name)).unwrap();
+                fs::write(slot.join(name).join("index.js"), "").unwrap();
+                (name, slot)
+            })
+            .collect();
+
+    let mut deps = ResolvedDependencyMap::new();
+    for (name, payload) in [("@scope/a", "a"), ("@scope/b", "b"), ("@scope/c", "c")] {
+        deps.insert(name.parse().unwrap(), file_member(name, payload));
+    }
+
+    let importer_id = "node_modules/.bit_roots/root".to_string();
+    let mut importers = HashMap::new();
+    importers.insert(
+        importer_id.clone(),
+        ProjectSnapshot { dependencies: Some(deps), ..ProjectSnapshot::default() },
+    );
+
+    let snapshot_key = |name: &str, payload: &str| {
+        PackageKey::new(
+            name.parse::<PkgName>().unwrap(),
+            format!("file:{payload}").parse().unwrap(),
+        )
+    };
+    // A sibling edge as the lockfile records it: alias name mapped to a
+    // bare `file:` version ref (the `Plain` shape a scoped `file:` dep
+    // takes when its value carries no leading package name).
+    let sibling_edge = |name: &str, payload: &str| {
+        (
+            name.parse::<PkgName>().unwrap(),
+            SnapshotDepRef::Plain(format!("file:{payload}").parse().unwrap()),
+        )
+    };
+    let mut snapshots = HashMap::new();
+    snapshots.insert(
+        snapshot_key("@scope/a", "a"),
+        SnapshotEntry {
+            dependencies: Some(std::iter::once(sibling_edge("@scope/b", "b")).collect()),
+            ..SnapshotEntry::default()
+        },
+    );
+    snapshots.insert(
+        snapshot_key("@scope/b", "b"),
+        SnapshotEntry {
+            dependencies: Some(std::iter::once(sibling_edge("@scope/c", "c")).collect()),
+            ..SnapshotEntry::default()
+        },
+    );
+    snapshots.insert(snapshot_key("@scope/c", "c"), SnapshotEntry::default());
+
+    link_root_component_members(
+        &layout,
+        &importers,
+        Some(&snapshots),
+        &id_set(&[importer_id.as_str()]),
+        &[DependencyGroup::Prod],
+        &SkippedSnapshots::default(),
+    )
+    .expect("linking should succeed");
+
+    let a_slot = &slots["@scope/a"];
+    let b_slot = &slots["@scope/b"];
+    let c_slot = &slots["@scope/c"];
+
+    // `a` links its snapshot-declared sibling `b`, and nothing else.
+    assert!(
+        is_symlink_or_junction(&a_slot.join("@scope/b")).unwrap(),
+        "a must link its snapshot-declared sibling b",
+    );
+    assert!(
+        !a_slot.join("@scope/c").exists(),
+        "a must not gain the clique — c is not declared in a's snapshot",
+    );
+    assert_eq!(
+        fs::canonicalize(a_slot.join("@scope/b")).unwrap(),
+        fs::canonicalize(b_slot.join("@scope/b")).unwrap(),
+    );
+
+    // `b` links `c`, not `a`; `c` links nothing.
+    assert!(is_symlink_or_junction(&b_slot.join("@scope/c")).unwrap());
+    assert!(!b_slot.join("@scope/a").exists());
+    assert!(!c_slot.join("@scope/a").exists());
+    assert!(!c_slot.join("@scope/b").exists());
+
+    drop(dir);
+}
+
 /// A slot `package.json` that exists but cannot be parsed is still a
 /// hard error — only a *missing* manifest triggers the clique fallback.
 #[test]
@@ -299,6 +406,7 @@ fn malformed_member_manifest_still_errors() {
     let result = link_root_component_members(
         &layout,
         &importers,
+        None,
         &id_set(&[importer_id.as_str()]),
         &[DependencyGroup::Prod],
         &SkippedSnapshots::default(),
@@ -344,6 +452,7 @@ fn non_root_component_importer_is_untouched() {
     link_root_component_members(
         &layout,
         &importers,
+        None,
         &id_set(&[]),
         &[DependencyGroup::Prod],
         &SkippedSnapshots::default(),
@@ -394,6 +503,7 @@ fn existing_member_dependency_is_not_clobbered() {
     link_root_component_members(
         &layout,
         &importers,
+        None,
         &id_set(&[importer_id.as_str()]),
         &[DependencyGroup::Prod],
         &SkippedSnapshots::default(),
@@ -425,6 +535,7 @@ fn empty_root_component_set_is_a_no_op() {
     let result = link_root_component_members(
         &layout,
         &importers,
+        None,
         &id_set(&[]),
         &[DependencyGroup::Prod],
         &SkippedSnapshots::default(),

--- a/pnpm/crates/deps-restorer/src/linking.rs
+++ b/pnpm/crates/deps-restorer/src/linking.rs
@@ -289,6 +289,7 @@ pub fn run_link_phase<Reporter: self::Reporter>(
         link_root_component_members(
             layout,
             importers,
+            snapshots,
             root_component_importers,
             dependency_groups,
             skipped,


### PR DESCRIPTION
The sibling-linking pass for Bit root components (`link_root_component_members`) falls back to linking **every other member of the root** into a member's slot when the materialized copy carries no `package.json`. A Bit workspace component never carries one at engine link time — Bit writes a manifest into the copy only during its own post-install compile, and that manifest is stripped of sibling edges anyway — so on a real Bit workspace every injected member gets the all-member fallback: one symlink per (member, member) pair per peer context.

### Measured on teambit/bit's own workspace

- **270,840** `@teambit/*` symlinks under `node_modules/.pnpm/`, all inside the **812** injected-component slots
- a `@teambit/compositions` variant slot carries **359** sibling links where its lockfile snapshot declares **42** — the other 317 are the fallback
- the inode cost is paid on every install and every CI cache restore; on teambit/bit's CI the persisted `node_modules` tree grew 2.9 GB / 207k symlinks → 3.8 GB / 356k symlinks across the pnpm v12 migration, and per-node workspace attach time went 0.8 → 2.7 min on all 40 e2e nodes

### The fix

A member's own lockfile snapshot — keyed by its exact peer variant — declares precisely the sibling `file:` edges of that copy. A manifest-less member now links those. The source order is: slot `package.json` → member snapshot → all members of the root (only when neither exists; the reachability guarantee is unchanged).

`link_root_component_members` takes the lockfile's `snapshots` map (the link phase already holds it), and `Member` carries its snapshot key.

### Verification

- New regression test `member_without_manifest_links_snapshot_declared_siblings` — fails under the all-member fallback, passes with the fix; the fallback test is retitled to the neither-source case it still covers; all 433 `pnpm-deps-restorer` tests pass
- `cargo fmt`, `clippy --all-targets` and `cargo doc` clean
- End to end with teambit/bit's isolated-linker root-components e2e suite against an engine built from this branch: **15 passing**, and each member slot holds exactly its declared chain — `comp2 → comp1`, `comp3 → comp2`, `comp4 → comp2`, 4 sibling links total. The same suite on the released rc.10 binary also passes but materializes **20** sibling links on the same fixture, including edges no member declares.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790194319&installation_model_id=426870&pr_number=14142&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14142&signature=1568a1dd725ea5d9226f505b7eb8cc747d6e79c2b1415a45b373cdf62ec67b43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency linking for root component members when `package.json` is unavailable.
  * Uses lockfile information to link only the appropriate sibling dependencies.
  * Prevents incorrect links when registry references conflict with member names.
  * Preserves fallback behavior when both manifest and lockfile details are unavailable.
  * Maintains clear handling for malformed manifests and existing linking scenarios.
  * Added coverage for snapshot-based and fallback linking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->