### PR TITLE
fix(release): drop the unsupported `--wait` from the Visual Studio installer call

### DIFF
--- a/.github/actions/rust-release-target/action.yml
+++ b/.github/actions/rust-release-target/action.yml
@@ -41,17 +41,22 @@ runs:
         $llvmDir = Join-Path $installPath 'VC\Tools\Llvm'
         $deadline = (Get-Date).AddMinutes(5)
         $installerRunning = $true
+        $installerSeen = $false
         $clangCl = $null
         # The launch above is asynchronous and the installer spawns work in
         # processes it does not always account for, so poll for a quiet
         # installer and a real clang-cl before trusting the toolchain.
         do {
           $installerRunning = @(Get-Process -Name 'vs_installer', 'vs_setup', 'setup' -ErrorAction SilentlyContinue).Count -gt 0
+          $installerSeen = $installerSeen -or $installerRunning
           $clangCl = Join-Path $llvmDir 'x64\bin\clang-cl.exe'
           if (-not (Test-Path -LiteralPath $clangCl)) { $clangCl = $null }
           if ($installerRunning -or $null -eq $clangCl) { Start-Sleep -Seconds 5 }
         } while (($installerRunning -or $null -eq $clangCl) -and (Get-Date) -lt $deadline)
         if ($installerRunning) { throw 'Visual Studio installer did not finish within five minutes' }
+        # Never having seen the installer run separates a rejected command line
+        # from an install that ran and left the component out.
+        if ($null -eq $clangCl -and -not $installerSeen) { throw "no install ever started; the installer rejected the modify command line above, and clang-cl is absent from $llvmDir" }
         if ($null -eq $clangCl) { throw "clang-cl was not installed under $llvmDir" }
         & $clangCl --version
         $clangDir = Split-Path -Parent $clangCl

--- a/.github/actions/rust-release-target/action.yml
+++ b/.github/actions/rust-release-target/action.yml
@@ -30,19 +30,21 @@ runs:
       run: | # zizmor: ignore[github-env]
         $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
         $installPath = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationPath
-        & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe" modify --installPath "$installPath" --add Microsoft.VisualStudio.Component.VC.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --quiet --norestart --wait
-        # `--wait` is what makes $LASTEXITCODE report the install rather than
-        # just the launch. 3010 is the installer's "succeeded, wants a
-        # reboot"; `--norestart` is why it wants one, and the components are
-        # usable without it.
-        if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne 3010) { throw "Visual Studio installer exited with $LASTEXITCODE" }
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($installPath)) { throw "vswhere found no Visual Studio installation (exit $LASTEXITCODE)" }
+        # `--wait` is not an option here: it is accepted by the bootstrapper
+        # only, and the installer rejects the whole command line when it is
+        # passed. Nor would it help — `setup.exe` is a GUI-subsystem process,
+        # so PowerShell returns before the install starts and $LASTEXITCODE
+        # would still describe the launch. The poll below is what confirms
+        # the components landed.
+        & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe" modify --installPath "$installPath" --add Microsoft.VisualStudio.Component.VC.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --quiet --norestart
         $llvmDir = Join-Path $installPath 'VC\Tools\Llvm'
         $deadline = (Get-Date).AddMinutes(5)
         $installerRunning = $true
         $clangCl = $null
-        # `--wait` above should have left nothing running, but the installer
-        # spawns work in processes it does not always account for, so poll for
-        # a quiet installer and a real clang-cl before trusting the toolchain.
+        # The launch above is asynchronous and the installer spawns work in
+        # processes it does not always account for, so poll for a quiet
+        # installer and a real clang-cl before trusting the toolchain.
         do {
           $installerRunning = @(Get-Process -Name 'vs_installer', 'vs_setup', 'setup' -ErrorAction SilentlyContinue).Count -gt 0
           $clangCl = Join-Path $llvmDir 'x64\bin\clang-cl.exe'


### PR DESCRIPTION
## Summary

The `12.0.0-rc.11` release run failed on both `win32-arm64` legs — `Package pnpm (Rust) win32-arm64` and `Package @pnpm/napi win32-arm64` — with:

```
clang-cl was not installed under C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\Llvm
```

Everything else that showed red in that run was cancelled by fail-fast.

The cause is the `--wait` flag that pnpm/pnpm#14138 added to the `setup.exe modify` call when the toolchain prelude moved into the `rust-release-target` composite action. Microsoft documents `--wait` as bootstrapper-only:

> The `--wait` parameter can only be passed into the bootstrapper; the installer (setup.exe) doesn't support it.

We call the installer (`C:\Program Files (x86)\Microsoft Visual Studio\Installer\setup.exe`), so it rejected the command line and installed nothing. The log timings confirm it: the step body starts at `22:24:34.0` and throws at `22:29:34.7` — the call returned in under a second, and the poll then burned its full five-minute deadline without ever seeing an installer process. It also threw the `clang-cl` branch rather than the "installer did not finish" branch, so nothing was running at any point.

The exit-code guard could not catch it: `setup.exe` is a GUI-subsystem binary, so PowerShell's call operator does not wait for it and never sets `$LASTEXITCODE` from it — the value tested was still `vswhere`'s `0`.

This PR drops `--wait`, restoring the launch-and-poll shape that shipped `rc.9` and `rc.10`, and moves the exit-code check onto `vswhere`, where the variable actually means something. The poll loop is left as the sole confirmation that the components landed, which is what it was written for.

The matrix split from pnpm/pnpm#14138 itself is fine and is kept — it only doubled the number of legs running the affected step.

Verified against the run logs of `rc.9`/`rc.10` (same script without `--wait`, clang installed in ~105s) and `rc.11` (first run with `--wait`, both arm64 legs failed deterministically). A re-run of the release would not have helped.

## Squash Commit Body

```text
The 12.0.0-rc.11 release failed on both win32-arm64 legs with "clang-cl
was not installed under ...\VC\Tools\Llvm", five minutes after the
Visual Studio installer was asked to add the LLVM and ARM64 components.

`--wait` had been added to that `setup.exe modify` call. Microsoft
documents it as bootstrapper-only: "The --wait parameter can only be
passed into the bootstrapper; the installer (setup.exe) doesn't support
it." We invoke the installer at
`C:\Program Files (x86)\Microsoft Visual Studio\Installer\setup.exe`, so
it rejected the command line and installed nothing. The logs show the
call returning in under a second and no installer process alive for the
whole polling window.

The exit-code check could not catch that. `setup.exe` is a
GUI-subsystem binary, so PowerShell's call operator does not wait for it
and never sets $LASTEXITCODE from it — the value tested was still
vswhere's. Check vswhere's own result instead, where the variable
actually means something, and leave the poll loop as the sole
confirmation that the components landed, which is what it was written
for.

Regressed in pnpm/pnpm#14138; the split into separate CLI and NAPI
matrices is unaffected, it only doubled the number of legs running the
step.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <!-- Release CI only; no product code on either side. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
  <!-- No published package changes; workflow-only. -->

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790203042&installation_model_id=426870&pr_number=14144&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14144&signature=f3ee9851d4f6bf7b57b095588219549972378e70d9c6cbafecfeb396d32a0772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows ARM64 Visual Studio setup reliability.
  * Installation progress is monitored until the required compiler tools become available.
  * Added clearer diagnostics when the Visual Studio modification request is rejected before installation begins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->