### PR TITLE
fix(release): count only installer processes the release step started

### DIFF
--- a/.github/actions/rust-release-target/action.yml
+++ b/.github/actions/rust-release-target/action.yml
@@ -37,6 +37,9 @@ runs:
         # so PowerShell returns before the install starts and $LASTEXITCODE
         # would still describe the launch. The poll below is what confirms
         # the components landed.
+        # Snapshot first: an installer already running for some other reason
+        # would otherwise pass for the one launched below.
+        $installerPidsBefore = @(Get-Process -Name 'vs_installer', 'vs_setup', 'setup' -ErrorAction SilentlyContinue).Id
         & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe" modify --installPath "$installPath" --add Microsoft.VisualStudio.Component.VC.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --quiet --norestart
         $llvmDir = Join-Path $installPath 'VC\Tools\Llvm'
         $deadline = (Get-Date).AddMinutes(5)
@@ -47,8 +50,9 @@ runs:
         # processes it does not always account for, so poll for a quiet
         # installer and a real clang-cl before trusting the toolchain.
         do {
-          $installerRunning = @(Get-Process -Name 'vs_installer', 'vs_setup', 'setup' -ErrorAction SilentlyContinue).Count -gt 0
-          $installerSeen = $installerSeen -or $installerRunning
+          $installerPids = @(Get-Process -Name 'vs_installer', 'vs_setup', 'setup' -ErrorAction SilentlyContinue).Id
+          $installerRunning = $installerPids.Count -gt 0
+          $installerSeen = $installerSeen -or @($installerPids | Where-Object { $installerPidsBefore -notcontains $_ }).Count -gt 0
           $clangCl = Join-Path $llvmDir 'x64\bin\clang-cl.exe'
           if (-not (Test-Path -LiteralPath $clangCl)) { $clangCl = $null }
           if ($installerRunning -or $null -eq $clangCl) { Start-Sleep -Seconds 5 }


### PR DESCRIPTION
## Summary

Follow-up to pnpm/pnpm#14144, which merged while CodeRabbit's second pass was still running. This carries the one finding from that pass.

pnpm/pnpm#14144 added `$installerSeen` so that a missing clang-cl reports whether an install ever started — the difference between a rejected `modify` command line (what took out the `12.0.0-rc.11` release) and an install that ran and left the component out. But it watched for any Visual Studio installer process by name, so one already running for an unrelated reason would pass for the one the step launches, and the run would fall back to the generic `clang-cl was not installed` message the flag exists to sharpen.

This snapshots the matching process ids before the launch and counts only ids that appear afterwards.

Diagnostics only: the poll's exit conditions and every `throw` are unchanged, so no run that passes today starts failing, and none that fails today starts passing.

## Squash Commit Body

```text
The check that separates a rejected modify command line from an install
that ran and skipped a component watched for any Visual Studio installer
process by name. One already running for an unrelated reason would pass
for the one this step launches, putting the run back on the generic
"clang-cl was not installed" error it is meant to sharpen.

Snapshot the matching process ids before the launch and count only ones
that appear afterwards.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <!-- Release CI only; no product code on either side. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
  <!-- No published package changes; workflow-only. -->

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790203710&installation_model_id=426870&pr_number=14145&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14145&signature=fa4a85ac4804a4d8424834fe1c3330bfd03770d2749e7bd53ca1773124bf4fc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows ARM64 toolchain installation detection.
  * Prevented unrelated existing installer processes from being mistaken for the newly launched installation.
  * Increased reliability of release setup on Windows ARM64.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->