### PR TITLE
fix(pacquet): stop recording corepack's integrity in the `packageManager` pin

### DIFF
--- a/.changeset/yarn-pin-without-integrity.md
+++ b/.changeset/yarn-pin-without-integrity.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm add yarn@<version>` now records just the resolved version in the `packageManager` field, without corepack's integrity hash. Corepack verifies the release it downloads on its own, so the hash only added a second copy of that information to a field pnpm never verifies.

--- a/pnpm/crates/cli/src/engine_pm/pin.rs
+++ b/pnpm/crates/cli/src/engine_pm/pin.rs
@@ -4,8 +4,8 @@
 //! naming one in `pnpm add` writes the field that declares it instead of a
 //! dependency entry. Which field that is depends on the package manager:
 //! Yarn is started from a project pin by corepack, which reads only the
-//! original `packageManager` field, so a Yarn pin goes there, written the
-//! way `corepack use` writes it. Every other package manager is recorded
+//! original `packageManager` field, so a Yarn pin goes there, as the
+//! exact version that field takes. Every other package manager is recorded
 //! in `devEngines.packageManager`, the field that holds a range and that
 //! pnpm's own package-manager check prefers.
 //!
@@ -46,10 +46,9 @@ pub(crate) fn declared_package_manager(request: &str) -> Option<(PackageManager,
 /// replacing whatever package manager it declared before.
 ///
 /// `reference` is a range for `devEngines.packageManager` and an exact
-/// version — optionally carrying corepack's integrity — for
-/// `packageManager`; [`resolve_project_pin`] produces the right one. A
-/// bare `pnpm add npm` asks for npm without asking for a version, so none
-/// is invented for it.
+/// version for `packageManager`; [`resolve_project_pin`] produces the
+/// right one. A bare `pnpm add npm` asks for npm without asking for a
+/// version, so none is invented for it.
 pub(crate) fn record_package_manager_pin(
     manifest: &mut Map<String, Value>,
     pm: PackageManager,
@@ -97,6 +96,12 @@ fn clear_dev_engines_package_manager(manifest: &mut Map<String, Value>) {
 /// Yarn's field takes an exact version — corepack rejects a range there —
 /// so the request is resolved against the same channel that would install
 /// it. The other package managers keep the range the user asked for.
+///
+/// Only the version is recorded, never corepack's `+<algorithm>.<hash>`
+/// build. Corepack is what installs a release from this pin, and for the
+/// line it fetches from npm it derives that hash from the registry's
+/// signed metadata anyway; recording one here would add a second copy of
+/// it to a field pnpm itself never verifies, for the two to drift apart.
 pub(crate) async fn resolve_project_pin(
     config: &'static Config,
     pm: PackageManager,
@@ -108,44 +113,13 @@ pub(crate) async fn resolve_project_pin(
     let version_spec = version_spec.map(str::trim).filter(|spec| !spec.is_empty());
     let spec = version_spec.unwrap_or("latest");
     let reference = match pm.channel(spec) {
-        Channel::Registry { package } => {
-            let resolved = resolve_release(config, pm, package, spec).await?;
-            let integrity = corepack_integrity(package, resolved.manifest.as_deref());
-            match integrity {
-                Some(integrity) => format!("{}+{integrity}", resolved.version),
-                None => resolved.version,
-            }
-        }
+        Channel::Registry { package } => resolve_release(config, pm, package, spec).await?.version,
         Channel::Binary(BinaryChannel::Bun | BinaryChannel::Yarn) => {
             resolve_yarn_binary_version(config, spec).await?
         }
     };
     Ok(Some(reference))
 }
-
-/// Corepack's `+<algorithm>.<hash>` build for a resolved release, when it
-/// can be known without fetching anything.
-///
-/// Corepack pins the artifact it downloads. For Yarn Classic that artifact
-/// is the npm tarball, so the hash is the integrity the registry already
-/// published and pnpm already has. Yarn Berry is downloaded from
-/// `repo.yarnpkg.com` as a single file instead — not the npm package pnpm
-/// installs — so its hash is not derivable from registry metadata, and a
-/// pin without one is what corepack itself accepts (it then verifies the
-/// release the same way pnpm does, through npm's signature).
-fn corepack_integrity(package: &str, manifest: Option<&Value>) -> Option<String> {
-    if package != YARN_CLASSIC_PACKAGE {
-        return None;
-    }
-    let integrity = manifest?.get("dist")?.get("integrity")?.as_str()?;
-    let integrity: ssri::Integrity = integrity.parse().ok()?;
-    let (algorithm, hex) = integrity.to_hex();
-    (algorithm == ssri::Algorithm::Sha512).then(|| format!("sha512.{hex}"))
-}
-
-/// The npm package Yarn Classic is published as, whose tarball corepack
-/// downloads for the `<2` line.
-const YARN_CLASSIC_PACKAGE: &str = "yarn";
 
 /// Resolve a Yarn line that ships as a platform archive rather than an npm
 /// package. Its releases are listed by `yarnpkg/zpm`, not by a registry.

--- a/pnpm/crates/cli/src/engine_pm/pin/tests.rs
+++ b/pnpm/crates/cli/src/engine_pm/pin/tests.rs
@@ -1,6 +1,4 @@
-use super::{
-    corepack_integrity, declared_package_manager, describe_pin, record_package_manager_pin,
-};
+use super::{declared_package_manager, describe_pin, record_package_manager_pin};
 use crate::engine_pm::channel::PackageManager;
 use serde_json::json;
 
@@ -114,35 +112,6 @@ fn clearing_the_package_manager_keeps_a_dev_engines_runtime() {
             "packageManager": "yarn@4.9.2",
         }),
     );
-}
-
-/// Corepack pins Yarn Classic by the sha512 of the npm tarball, which is
-/// the integrity the registry publishes — the same hash `corepack use`
-/// writes, without downloading anything.
-#[test]
-fn a_yarn_classic_pin_carries_the_integrity_corepack_records() {
-    let manifest = json!({
-        "dist": { "integrity": "sha512-vlN9G+SFrIJKO/A/CmuGZ9zoQAqXNPBUXqk8LMKFVMc+wYRDDKMRQmzcQlvyBMk2C4x/xz2R1L3+dSHOtwSlfQ==" },
-    });
-    assert_eq!(
-        corepack_integrity("yarn", Some(&manifest)).as_deref(),
-        // `node -e 'Buffer.from(<base64>, "base64").toString("hex")'` —
-        // corepack's own conversion of the same integrity.
-        Some(
-            "sha512.be537d1be485ac824a3bf03f0a6b8667dce8400a9734f0545ea93c2cc28554c73ec1844\
-             30ca311426cdc425bf204c9360b8c7fc73d91d4bdfe7521ceb704a57d",
-        ),
-    );
-}
-
-/// Yarn Berry is not downloaded from npm by corepack, so npm's integrity
-/// is not the hash it would verify, and the pin carries none.
-#[test]
-fn a_yarn_berry_pin_carries_no_integrity() {
-    let manifest = json!({ "dist": { "integrity": "sha512-AAAA" } });
-    assert_eq!(corepack_integrity("@yarnpkg/cli-dist", Some(&manifest)), None);
-    assert_eq!(corepack_integrity("yarn", None), None);
-    assert_eq!(corepack_integrity("yarn", Some(&json!({}))), None);
 }
 
 /// A specifier that locates a package to install under the package

--- a/pnpm/crates/cli/tests/suite/package_manager_check.rs
+++ b/pnpm/crates/cli/tests/suite/package_manager_check.rs
@@ -809,10 +809,10 @@ fn a_manifest_that_is_not_an_object_fails_instead_of_panicking() {
 
 /// Yarn is started from a project pin by corepack, which reads only
 /// `packageManager` and only accepts an exact version there — so a Yarn
-/// pin is resolved and written the way `corepack use` writes it, down to
-/// the integrity corepack verifies the Classic tarball with.
+/// pin is resolved to one, and carries nothing else: the release corepack
+/// downloads is corepack's to verify, not pnpm's to pin.
 #[test]
-fn a_yarn_pin_is_recorded_the_way_corepack_writes_it() {
+fn a_yarn_pin_is_recorded_as_the_exact_version_corepack_requires() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
     write_manifest(
         &workspace,
@@ -825,13 +825,11 @@ fn a_yarn_pin_is_recorded_the_way_corepack_writes_it() {
     let manifest: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(workspace.join("package.json")).unwrap()).unwrap();
     let pin = manifest["packageManager"].as_str().expect("a recorded package manager");
-    let (version, integrity) = pin
-        .strip_prefix("yarn@")
-        .and_then(|reference| reference.split_once('+'))
-        .unwrap_or_else(|| panic!("expected an exact version with an integrity, got {pin}"));
-    let version = node_semver::Version::parse(version).expect("an exact version");
+    let reference =
+        pin.strip_prefix("yarn@").unwrap_or_else(|| panic!("expected a Yarn pin, got {pin}"));
+    let version = node_semver::Version::parse(reference).expect("an exact version");
     assert_eq!(version.major, 1, "{pin}");
-    assert!(integrity.starts_with("sha512."), "{pin}");
+    assert!(!reference.contains('+'), "{pin}");
     assert_eq!(manifest.get("devEngines"), None, "{manifest}");
 }
 


### PR DESCRIPTION
## Summary

`pnpm add yarn@<version>` wrote the Yarn Classic pin the way `corepack use` does — the resolved version plus the sha512 of the npm tarball as semver build metadata (`yarn@1.22.22+sha512.…`). This drops the hash and records the version alone.

The hash is not pnpm's to keep. Corepack, not pnpm, installs a release from that pin, and for the line it fetches from npm it derives the same hash from the registry's signed metadata anyway — so a copy in the manifest only gave the same fact a second home, in a field pnpm itself never verifies, for the two to drift apart. The integrity pnpm does verify belongs in the lockfile, which is where pnpm records it.

While removing the helper I also fixed a false claim in its doc comment: it said a Yarn Berry pin without a hash is still verified "through npm's signature". It is not. Corepack back-fills a missing hash, and checks the npm registry signature, only for a package manager whose spec has an npm-typed registry; Yarn `>=2` is fetched from a plain `repo.yarnpkg.com` URL, so that branch never runs. Verified against corepack 0.35.0 with an untrusted `COREPACK_INTEGRITY_KEYS`: a hash-less `pnpm@10.0.0` pin fails signature verification, a hash-less `yarn@4.18.0` pin installs clean.

## Squash Commit Body

```text
`pnpm add yarn@<version>` wrote the Yarn Classic pin the way `corepack use`
does, with the sha512 of the npm tarball as semver build metadata. Drop it
and record the resolved version alone.

The hash is not pnpm's to keep. Corepack is what installs a release from
this pin, and for the line it fetches from npm it derives the same hash
from the registry's signed metadata anyway — so a copy in the manifest
only gave the same fact a second home, in a field pnpm itself never
verifies, for the two to drift apart. Integrity that pnpm does verify
belongs in the lockfile, which is where pnpm records it.

The doc comment on the removed helper also claimed that a Yarn Berry pin
without a hash is still verified "through npm's signature". It is not:
corepack derives a missing hash, and checks the npm registry signature,
only for a package manager whose spec has an npm-typed registry, and
Yarn `>=2` is fetched from a plain `repo.yarnpkg.com` URL.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  *(Rust-only: the TypeScript CLI has no package-manager pin path — it writes
  `packageManager` from `pnpm init` and `pnpm self-update` only, and never with
  a hash. Nothing to port.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790208935&installation_model_id=426870&pr_number=14146&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14146&signature=ac0b87554d5fabf80cc8ea8395548d440f81871b196ed7a7b10cdb993b3283fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Yarn version pinning now records only the exact version in `packageManager`.
  * Removed automatic Corepack integrity hash suffixes from recorded Yarn versions.
  * Updated package manager validation to recognize the simplified Yarn pin format.

* **Documentation**
  * Clarified that Yarn pins contain an exact version and never include Corepack build or integrity metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->