### PR TITLE
fix(audit): accept bare --fix and honor saveExact/savePrefix in overrides

### DIFF
--- a/.changeset/audit-fix-bare-flag-and-save-exact.md
+++ b/.changeset/audit-fix-bare-flag-and-save-exact.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/deps.compliance.commands": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+Fixed `pnpm audit --fix` failing with `ERR_PNPM_INVALID_FIX_OPTION` when used without a value [#13261](https://github.com/pnpm/pnpm/issues/13261). Fixed `pnpm audit --fix=override` ignoring the `saveExact` and `savePrefix` settings when writing vulnerability overrides [#11523](https://github.com/pnpm/pnpm/issues/11523).

--- a/.changeset/audit-fix-bare-flag-and-save-exact.md
+++ b/.changeset/audit-fix-bare-flag-and-save-exact.md
@@ -4,4 +4,4 @@
 "pacquet": patch
 ---
 
-Fixed `pnpm audit --fix` failing with `ERR_PNPM_INVALID_FIX_OPTION` when used without a value [#13261](https://github.com/pnpm/pnpm/issues/13261). Fixed `pnpm audit --fix=override` ignoring the `saveExact` and `savePrefix` settings when writing vulnerability overrides [#11523](https://github.com/pnpm/pnpm/issues/11523).
+Fixed `pnpm audit --fix` failing with `ERR_PNPM_INVALID_FIX_OPTION` when used without a value, including when another flag follows it, as in `pnpm audit --fix --json` [#13261](https://github.com/pnpm/pnpm/issues/13261). Fixed `pnpm audit --fix=override` ignoring the `saveExact` and `savePrefix` settings when writing vulnerability overrides [#11523](https://github.com/pnpm/pnpm/issues/11523).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2934,6 +2934,9 @@ importers:
       '@pnpm/object.key-sorting':
         specifier: workspace:*
         version: link:../../../object/key-sorting
+      '@pnpm/pkg-manifest.utils':
+        specifier: workspace:*
+        version: link:../../../pkg-manifest/utils
       '@pnpm/store.path':
         specifier: workspace:*
         version: link:../../../store/path
@@ -21476,6 +21479,7 @@ snapshots:
       es-object-atoms: 1.1.2
       es-set-tostringtag: 2.1.0
       es-to-primitive: 1.3.4
+      for-each: 0.3.5
       function.prototype.name: 1.2.0
       get-intrinsic: 1.3.0
       get-proto: 1.0.1

--- a/pnpm/crates/cli/src/cli_args/audit.rs
+++ b/pnpm/crates/cli/src/cli_args/audit.rs
@@ -17,6 +17,7 @@ use pnpm_lockfile::{
 use pnpm_network::{RetryOpts, encode_package_name, send_with_retry};
 use pnpm_package_manager::{ResolutionObserver, ResolvedPackageHint, Update};
 use pnpm_package_manifest::DependencyGroup;
+use pnpm_registry::RangeSpecStyle;
 use pnpm_reporter::Reporter;
 use pnpm_resolving_resolver_base::{
     PackageVersionGuard, PackageVersionGuardDecision, PackageVersionGuardFuture,
@@ -58,7 +59,8 @@ pub(crate) use request::{
     lockfile_to_audit_request, root_included,
 };
 pub(crate) use version_ranges::{
-    caret_range_for_patched, infer_patched_versions, satisfies_including_prerelease, satisfies_safe,
+    caret_range_for_patched, infer_patched_versions, patched_range_for_style,
+    satisfies_including_prerelease, satisfies_safe,
 };
 
 mod signatures;

--- a/pnpm/crates/cli/src/cli_args/audit/fix.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/fix.rs
@@ -3,11 +3,11 @@
 use super::{
     Arc, AuditAdvisory, AuditError, AuditReport, BTreeMap, Config, ConfigAuditLevel, DateTime,
     DependencyGroup, Deserialize, HashMap, HashSet, IntoDiagnostic, Lockfile, MultiSelect,
-    PackageVersionGuard, Range, Reporter, ResolutionObserver, State, Update, Utc, Version, blue,
-    caret_range_for_patched, color_severity, encode_package_name, green, normalize_ghsa_id,
-    normalize_registry, parse_packument_timestamp, red, redact_url_userinfo,
-    retry_opts_from_config, satisfies_including_prerelease, send_with_retry, severity_name,
-    severity_number,
+    PackageVersionGuard, Range, RangeSpecStyle, Reporter, ResolutionObserver, State, Update, Utc,
+    Version, blue, caret_range_for_patched, color_severity, encode_package_name, green,
+    normalize_ghsa_id, normalize_registry, parse_packument_timestamp, patched_range_for_style, red,
+    redact_url_userinfo, retry_opts_from_config, satisfies_including_prerelease, send_with_retry,
+    severity_name, severity_number,
 };
 
 /// Filter `report`'s advisories down to the set both fix methods and the
@@ -78,17 +78,19 @@ pub(crate) fn prune_ignored_ghsas(
     PruneIgnoredGhsasResult { pruned, retained }
 }
 
-/// Build the `name@vulnerable_versions → ^patched` override map from the
-/// fixable advisories (those with an inferred patched range). Keyed by a
+/// Build the `name@vulnerable_versions → patched-range` override map from the
+/// fixable advisories (those with an inferred patched range), saving each
+/// minimum patched version in the style of `range_spec_style`. Keyed by a
 /// `BTreeMap` so the output is sorted, mirroring pnpm's `sortDirectKeys`.
 pub(crate) fn create_overrides(
     advisories: &BTreeMap<String, AuditAdvisory>,
+    range_spec_style: RangeSpecStyle,
 ) -> BTreeMap<String, String> {
     let mut overrides = BTreeMap::new();
     for advisory in advisories.values() {
         let Some(patched) = advisory.patched_versions.as_deref() else { continue };
         let key = format!("{}@{}", advisory.module_name, advisory.vulnerable_versions);
-        overrides.insert(key, caret_range_for_patched(patched));
+        overrides.insert(key, patched_range_for_style(patched, range_spec_style));
     }
     overrides
 }
@@ -103,7 +105,10 @@ pub(crate) async fn fix_override(
     config: &Config,
     publish_infos: &HashMap<String, Option<PackumentPublishInfo>>,
 ) -> miette::Result<String> {
-    let overrides = create_overrides(advisories);
+    let overrides = create_overrides(
+        advisories,
+        RangeSpecStyle::from_save_options(config.save_exact, config.save_prefix.as_deref()),
+    );
     if overrides.is_empty() {
         return Ok("No fixes were made".to_string());
     }

--- a/pnpm/crates/cli/src/cli_args/audit/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/tests.rs
@@ -18,6 +18,7 @@ use super::{
 };
 use chrono::{DateTime, Utc};
 use pnpm_lockfile::{EnvLockfile, Lockfile, SnapshotEntry, SpecifierAndResolution};
+use pnpm_registry::RangeSpecStyle;
 use std::{collections::HashSet, fmt::Write as _};
 
 fn parse_lockfile(yaml: &str) -> Lockfile {
@@ -1147,7 +1148,7 @@ fn create_overrides_sorts_and_skips_unfixable() {
         ),
     ]);
 
-    let overrides = create_overrides(&advisories);
+    let overrides = create_overrides(&advisories, RangeSpecStyle::Major);
 
     assert_eq!(
         overrides.into_iter().collect::<Vec<_>>(),
@@ -1156,6 +1157,20 @@ fn create_overrides_sorts_and_skips_unfixable() {
             ("zoo@<2.0.0".to_string(), "^2.0.0".to_string()),
         ],
     );
+}
+
+#[test]
+fn create_overrides_respects_save_style() {
+    let advisories = BTreeMap::from([(
+        "1".to_string(),
+        fix_advisory(1, "axios", "<=0.18.0", Some(">=0.18.1"), ConfigAuditLevel::High, "GHSA-a"),
+    )]);
+
+    let exact = create_overrides(&advisories, RangeSpecStyle::from_save_options(true, None));
+    assert_eq!(exact["axios@<=0.18.0"], "0.18.1");
+
+    let tilde = create_overrides(&advisories, RangeSpecStyle::from_save_options(false, Some("~")));
+    assert_eq!(tilde["axios@<=0.18.0"], "~0.18.1");
 }
 
 #[test]

--- a/pnpm/crates/cli/src/cli_args/audit/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/tests.rs
@@ -1171,6 +1171,12 @@ fn create_overrides_respects_save_style() {
 
     let tilde = create_overrides(&advisories, RangeSpecStyle::from_save_options(false, Some("~")));
     assert_eq!(tilde["axios@<=0.18.0"], "~0.18.1");
+
+    let equals = create_overrides(&advisories, RangeSpecStyle::from_save_options(false, Some("=")));
+    assert_eq!(equals["axios@<=0.18.0"], "=0.18.1");
+
+    let bare = create_overrides(&advisories, RangeSpecStyle::from_save_options(false, Some("")));
+    assert_eq!(bare["axios@<=0.18.0"], "0.18.1");
 }
 
 #[test]

--- a/pnpm/crates/cli/src/cli_args/audit/version_ranges.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/version_ranges.rs
@@ -1,6 +1,6 @@
 //! Semver questions the audit asks of advisory ranges.
 
-use super::{Range, Version};
+use super::{Range, RangeSpecStyle, Version};
 
 pub(crate) fn satisfies_safe(version: &str, range: &str) -> bool {
     let Ok(version) = version.parse::<Version>() else { return false };
@@ -73,14 +73,19 @@ pub(crate) fn last_upper_bound(input: &str) -> Option<(&str, &str)> {
     matches!(operator, "<" | "<=").then_some((operator, last))
 }
 
-/// The minimum patched version with a caret, mirroring pnpm's
-/// `caretRangeForPatched`: `^X.Y.Z` keeps the resolver within the same major
-/// the user pinned to, where a bare `>=X.Y.Z` could silently promote a dep to
-/// a later breaking major. `patched` is always pacquet's inferred `>=V` form,
-/// so its minimum is the version after `>=`.
-pub(crate) fn caret_range_for_patched(patched: &str) -> String {
+/// The minimum patched version saved with the operator of `style`, mirroring
+/// pnpm's `patchedRangeForStyle`: `^X.Y.Z` (the default) keeps the resolver
+/// within the same major the user pinned to, where a bare `>=X.Y.Z` could
+/// silently promote a dep to a later breaking major. `patched` is always
+/// pacquet's inferred `>=V` form, so its minimum is the version after `>=`.
+pub(crate) fn patched_range_for_style(patched: &str, style: RangeSpecStyle) -> String {
     patched
         .strip_prefix(">=")
         .and_then(|version| version.trim().parse::<Version>().ok())
-        .map_or_else(|| patched.to_string(), |version| format!("^{version}"))
+        .map_or_else(|| patched.to_string(), |version| format!("{}{version}", style.range_prefix()))
+}
+
+/// [`patched_range_for_style`] at pnpm's default caret style.
+pub(crate) fn caret_range_for_patched(patched: &str) -> String {
+    patched_range_for_style(patched, RangeSpecStyle::Major)
 }

--- a/pnpm/crates/cli/tests/suite/audit.rs
+++ b/pnpm/crates/cli/tests/suite/audit.rs
@@ -757,6 +757,29 @@ fn audit_fix_override_writes_overrides_to_workspace_manifest() {
 }
 
 #[test]
+fn audit_fix_override_writes_overrides_in_the_configured_save_style() {
+    let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
+    let mut registry = mockito::Server::new();
+    let mock = audit_mock(
+        &mut registry,
+        &advisory_response("vulnerable", 123, "high", "<2.0.0", "test", "GHSA-test-1111-2222"),
+    )
+    .create();
+    write_audit_workspace(&workspace, &registry.url(), "savePrefix: '~'\n");
+
+    let output = pacquet.arg("audit").arg("--fix").output().expect("run pacquet audit --fix");
+
+    assert_success(&output);
+    let manifest =
+        fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("read workspace manifest");
+    assert!(
+        manifest.contains("vulnerable@<2.0.0: ~2.0.0"),
+        "manifest should hold the tilde override:\n{manifest}",
+    );
+    mock.assert();
+}
+
+#[test]
 fn audit_fix_override_writes_minimum_release_age_excludes_when_configured() {
     let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
     let mut registry = mockito::Server::new();

--- a/pnpm11/deps/compliance/commands/package.json
+++ b/pnpm11/deps/compliance/commands/package.json
@@ -60,6 +60,7 @@
     "@pnpm/network.fetch": "workspace:*",
     "@pnpm/npm-package-arg": "catalog:",
     "@pnpm/object.key-sorting": "workspace:*",
+    "@pnpm/pkg-manifest.utils": "workspace:*",
     "@pnpm/store.path": "workspace:*",
     "@pnpm/text.sanitize": "workspace:*",
     "@pnpm/types": "workspace:*",

--- a/pnpm11/deps/compliance/commands/src/audit/audit.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/audit.ts
@@ -164,7 +164,7 @@ export function help (): string {
 export type { PublishTimesFetcher } from './publishTimes.js'
 
 export type AuditOptions = Pick<UniversalOptions, 'dir'> & {
-  fix?: boolean | 'override' | 'update'
+  fix?: boolean | 'override' | 'update' | 'true'
   ignoreRegistryErrors?: boolean
   interactive?: boolean
   json?: boolean
@@ -264,12 +264,16 @@ export async function handler (opts: AuditOptions, params: string[] = []): Promi
   // is requested at most once.
   const getPublishTimes = createPublishTimesFetcher(opts)
   await correctInferredPatchedVersions(auditReport.advisories, getPublishTimes)
+  const { fix: fixOption } = opts
   let fixMethod: 'update' | 'override' | undefined
-  if (opts.fix === 'update' || opts.fix === 'override') {
-    fixMethod = opts.fix
-  } else if (opts.fix === true || (opts.interactive && !opts.fix)) {
+  if (fixOption === 'update' || fixOption === 'override') {
+    fixMethod = fixOption
+  } else if (fixOption === true || fixOption === 'true' || (opts.interactive && !fixOption)) {
+    // A bare `--fix` arrives as the string 'true': with the [String, Boolean]
+    // rc-option spec, nopt's String validation runs first and coerces the
+    // flag's implicit value.
     fixMethod = DEFAULT_FIX_METHOD
-  } else if (!opts.fix) {
+  } else if (!fixOption) {
     fixMethod = undefined
   } else {
     throw new PnpmError('INVALID_FIX_OPTION', `Invalid value for --fix: ${opts.fix as string}. Should be one of "override" or "update"`)

--- a/pnpm11/deps/compliance/commands/src/audit/audit.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/audit.ts
@@ -63,9 +63,11 @@ export function rcOptionsTypes (): Record<string, unknown> {
       'registry',
     ], allTypes),
     'audit-level': ['info', 'low', 'moderate', 'high', 'critical'],
-    // For fix, use String instead of a list of allowed string values.
-    // Otherwise, an unexpected value will get coerced to true because of the Boolean type.
-    fix: [String, Boolean],
+    // A plain String, not a list of allowed values and not paired with
+    // Boolean: a list coerces an unexpected value to true, and Boolean makes
+    // nopt swallow the next `--flag` as the fix method. A bare `--fix` then
+    // arrives as the empty string.
+    fix: String,
     'ignore-registry-errors': Boolean,
     ignore: [String, Array],
     'ignore-unfixable': Boolean,
@@ -164,7 +166,12 @@ export function help (): string {
 export type { PublishTimesFetcher } from './publishTimes.js'
 
 export type AuditOptions = Pick<UniversalOptions, 'dir'> & {
-  fix?: boolean | 'override' | 'update' | 'true'
+  /**
+   * The `--fix` value as the CLI hands it over: nopt types the option as a
+   * string, so `--fix` with no method arrives as `''` and `--fix=<method>`
+   * as the raw method name, valid or not. An rc file may still set a boolean.
+   */
+  fix?: boolean | string
   ignoreRegistryErrors?: boolean
   interactive?: boolean
   json?: boolean
@@ -268,15 +275,12 @@ export async function handler (opts: AuditOptions, params: string[] = []): Promi
   let fixMethod: 'update' | 'override' | undefined
   if (fixOption === 'update' || fixOption === 'override') {
     fixMethod = fixOption
-  } else if (fixOption === true || fixOption === 'true' || (opts.interactive && !fixOption)) {
-    // A bare `--fix` arrives as the string 'true': with the [String, Boolean]
-    // rc-option spec, nopt's String validation runs first and coerces the
-    // flag's implicit value.
+  } else if (isFixWithoutMethod(fixOption) || (opts.interactive && !fixOption)) {
     fixMethod = DEFAULT_FIX_METHOD
   } else if (!fixOption) {
     fixMethod = undefined
   } else {
-    throw new PnpmError('INVALID_FIX_OPTION', `Invalid value for --fix: ${opts.fix as string}. Should be one of "override" or "update"`)
+    throw new PnpmError('INVALID_FIX_OPTION', `Invalid value for --fix: ${fixOption}. Should be one of "override" or "update"`)
   }
   if (fixMethod != null) {
     if (opts.auditIgnorePrune && opts.auditConfig?.ignoreGhsas?.length) {
@@ -435,6 +439,15 @@ ${newIgnores.join('\n')}`,
     exitCode: output ? 1 : 0,
     output: `${output}${reportSummary(auditReport.metadata.vulnerabilities, totalVulnerabilityCount, ignoredVulnerabilities)}`,
   }
+}
+
+/**
+ * Whether `--fix` was passed without a fix method, in which case
+ * {@link DEFAULT_FIX_METHOD} applies. The CLI spells that as the empty
+ * string; an rc file spells it as a boolean or its string form.
+ */
+function isFixWithoutMethod (fix: AuditOptions['fix']): boolean {
+  return fix === '' || fix === true || fix === 'true'
 }
 
 function reportSummary (vulnerabilities: AuditVulnerabilityCounts, totalVulnerabilityCount: number, ignoredVulnerabilities: IgnoredAuditVulnerabilityCounts): string {

--- a/pnpm11/deps/compliance/commands/src/audit/fix.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/fix.ts
@@ -2,6 +2,8 @@ import { mergePackageVersionSpecs } from '@pnpm/config.version-policy'
 import { writeSettings } from '@pnpm/config.writer'
 import { type AuditAdvisory, type AuditReport, normalizeGhsaId } from '@pnpm/deps.compliance.audit'
 import { sortDirectKeys } from '@pnpm/object.key-sorting'
+import { getRangeSpecStyle, versionWithRangeSpecStyle } from '@pnpm/pkg-manifest.utils'
+import type { RangeSpecStyle } from '@pnpm/types'
 import semver from 'semver'
 
 import type { AuditOptions } from './audit.js'
@@ -14,7 +16,10 @@ export interface FixResult {
 
 export async function fix (auditReport: AuditReport, opts: AuditOptions): Promise<FixResult> {
   const fixableAdvisories = getFixableAdvisories(Object.values(auditReport.advisories), opts.auditConfig?.ignoreGhsas)
-  const vulnOverrides = createOverrides(fixableAdvisories)
+  const vulnOverrides = createOverrides(fixableAdvisories, {
+    saveExact: opts.saveExact,
+    savePrefix: opts.savePrefix,
+  })
   if (Object.values(vulnOverrides).length === 0) return { vulnOverrides, addedAgeExcludes: [] }
   const addedAgeExcludes = opts.minimumReleaseAge
     ? await createMinimumReleaseAgeExcludes(fixableAdvisories, {
@@ -44,22 +49,30 @@ function getFixableAdvisories (advisories: AuditAdvisory[], ignoreGhsas?: string
   return advisories.filter(({ patched_versions: patchedVersions }) => patchedVersions != null)
 }
 
-function createOverrides (advisories: AuditAdvisory[]): Record<string, string> {
+function createOverrides (
+  advisories: AuditAdvisory[],
+  saveStyle: { saveExact?: boolean, savePrefix?: string }
+): Record<string, string> {
+  const rangeSpecStyle = getRangeSpecStyle(saveStyle)
   const entries: Array<[string, string]> = []
   for (const advisory of advisories) {
     if (!advisory.patched_versions) continue
-    entries.push([`${advisory.module_name}@${advisory.vulnerable_versions}`, caretRangeForPatched(advisory.patched_versions)])
+    entries.push([`${advisory.module_name}@${advisory.vulnerable_versions}`, patchedRangeForStyle(advisory.patched_versions, rangeSpecStyle)])
   }
   return sortDirectKeys(Object.fromEntries(entries))
 }
 
-// Use the minimum patched version with a caret so pnpm stays within the
-// same major as the fix. `>=X.Y.Z` alone can silently promote a dep to a
-// later breaking major; `^X.Y.Z` still satisfies the patch while
-// preserving the major the user originally pinned to.
+// Use the minimum patched version so pnpm stays within the same major as the
+// fix. `>=X.Y.Z` alone can silently promote a dep to a later breaking major;
+// a caret still satisfies the patch while preserving the major the user
+// originally pinned to.
 export function caretRangeForPatched (patchedRange: string): string {
+  return patchedRangeForStyle(patchedRange, 'major')
+}
+
+function patchedRangeForStyle (patchedRange: string, rangeSpecStyle: RangeSpecStyle): string {
   const min = semver.minVersion(patchedRange)
-  return min ? `^${min.version}` : patchedRange
+  return min ? versionWithRangeSpecStyle(min.version, rangeSpecStyle) : patchedRange
 }
 
 export interface CreateMinimumReleaseAgeExcludesOptions {

--- a/pnpm11/deps/compliance/commands/src/audit/fix.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/fix.ts
@@ -64,7 +64,8 @@ export function caretRangeForPatched (patchedRange: string): string {
  * The minimum patched version saved with the operator of `rangeSpecStyle`.
  * The default `^X.Y.Z` keeps the resolver within the major the user pinned
  * to, where the advisory's own `>=X.Y.Z` could silently promote a dep to a
- * later breaking major.
+ * later breaking major. A `patchedRange` with no parseable minimum is
+ * returned unchanged, so an advisory pins whatever the registry sent.
  */
 function patchedRangeForStyle (patchedRange: string, rangeSpecStyle: RangeSpecStyle): string {
   const min = semver.minVersion(patchedRange)

--- a/pnpm11/deps/compliance/commands/src/audit/fix.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/fix.ts
@@ -16,10 +16,7 @@ export interface FixResult {
 
 export async function fix (auditReport: AuditReport, opts: AuditOptions): Promise<FixResult> {
   const fixableAdvisories = getFixableAdvisories(Object.values(auditReport.advisories), opts.auditConfig?.ignoreGhsas)
-  const vulnOverrides = createOverrides(fixableAdvisories, {
-    saveExact: opts.saveExact,
-    savePrefix: opts.savePrefix,
-  })
+  const vulnOverrides = createOverrides(fixableAdvisories, getRangeSpecStyle(opts))
   if (Object.values(vulnOverrides).length === 0) return { vulnOverrides, addedAgeExcludes: [] }
   const addedAgeExcludes = opts.minimumReleaseAge
     ? await createMinimumReleaseAgeExcludes(fixableAdvisories, {
@@ -49,11 +46,7 @@ function getFixableAdvisories (advisories: AuditAdvisory[], ignoreGhsas?: string
   return advisories.filter(({ patched_versions: patchedVersions }) => patchedVersions != null)
 }
 
-function createOverrides (
-  advisories: AuditAdvisory[],
-  saveStyle: { saveExact?: boolean, savePrefix?: string }
-): Record<string, string> {
-  const rangeSpecStyle = getRangeSpecStyle(saveStyle)
+function createOverrides (advisories: AuditAdvisory[], rangeSpecStyle: RangeSpecStyle): Record<string, string> {
   const entries: Array<[string, string]> = []
   for (const advisory of advisories) {
     if (!advisory.patched_versions) continue
@@ -62,14 +55,17 @@ function createOverrides (
   return sortDirectKeys(Object.fromEntries(entries))
 }
 
-// Use the minimum patched version so pnpm stays within the same major as the
-// fix. `>=X.Y.Z` alone can silently promote a dep to a later breaking major;
-// a caret still satisfies the patch while preserving the major the user
-// originally pinned to.
+/** {@link patchedRangeForStyle} at pnpm's default caret style. */
 export function caretRangeForPatched (patchedRange: string): string {
   return patchedRangeForStyle(patchedRange, 'major')
 }
 
+/**
+ * The minimum patched version saved with the operator of `rangeSpecStyle`.
+ * The default `^X.Y.Z` keeps the resolver within the major the user pinned
+ * to, where the advisory's own `>=X.Y.Z` could silently promote a dep to a
+ * later breaking major.
+ */
 function patchedRangeForStyle (patchedRange: string, rangeSpecStyle: RangeSpecStyle): string {
   const min = semver.minVersion(patchedRange)
   return min ? versionWithRangeSpecStyle(min.version, rangeSpecStyle) : patchedRange

--- a/pnpm11/deps/compliance/commands/test/audit/fix.ts
+++ b/pnpm11/deps/compliance/commands/test/audit/fix.ts
@@ -1,4 +1,4 @@
-import { existsSync as fsExistsSync, readFileSync, writeFileSync } from 'node:fs'
+import fs, { existsSync as fsExistsSync } from 'node:fs'
 import path from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, test } from '@jest/globals'
@@ -294,7 +294,7 @@ test('audit.ignorePrune removes ignored GHSAs that are no longer in the report',
 
   // The preceding comment and the trailing same-line comment attached to
   // the removed entry must both go with it.
-  const rawContent = readFileSync(path.join(tmp, 'pnpm-workspace.yaml'), 'utf8')
+  const rawContent = fs.readFileSync(path.join(tmp, 'pnpm-workspace.yaml'), 'utf8')
   expect(rawContent).not.toContain('Expired GHSA')
   expect(rawContent).not.toContain('trailing comment')
 
@@ -424,7 +424,7 @@ test('audit.ignorePrune removes all entries when none are relevant', async () =>
 
 test('audit.ignorePrune edits an inline (flow-style) auditConfig in place', async () => {
   const tmp = f.prepare('has-vulnerabilities-with-ignored-ghsas')
-  writeFileSync(
+  fs.writeFileSync(
     path.join(tmp, 'pnpm-workspace.yaml'),
     'packages:\n  - \'.\'\nsharedWorkspaceLockfile: false\nauditConfig: { ignoreGhsas: [GHSA-42xw-2xvc-qx8m, GHSA-xxxx-xxxx-xxxx] }\n'
   )
@@ -452,7 +452,7 @@ test('audit.ignorePrune edits an inline (flow-style) auditConfig in place', asyn
 
   // The retained GHSA is edited in place inside the flow-style block, rather
   // than the whole auditConfig being reformatted into block style.
-  const rawContent = readFileSync(path.join(tmp, 'pnpm-workspace.yaml'), 'utf8')
+  const rawContent = fs.readFileSync(path.join(tmp, 'pnpm-workspace.yaml'), 'utf8')
   expect(rawContent).toContain(
     'auditConfig: { ignoreGhsas: [ GHSA-42xw-2xvc-qx8m ] }'
   )
@@ -463,7 +463,7 @@ test('audit.ignorePrune edits an inline (flow-style) auditConfig in place', asyn
 
 test('audit.ignorePrune updates the canonical audit.ignore list', async () => {
   const tmp = f.prepare('has-vulnerabilities-with-ignored-ghsas')
-  writeFileSync(
+  fs.writeFileSync(
     path.join(tmp, 'pnpm-workspace.yaml'),
     'packages:\n  - \'.\'\nsharedWorkspaceLockfile: false\naudit:\n  ignorePrune: true\n  ignore:\n    - GHSA-42xw-2xvc-qx8m\n    - GHSA-xxxx-xxxx-xxxx\n'
   )

--- a/pnpm11/deps/compliance/commands/test/audit/fix.ts
+++ b/pnpm11/deps/compliance/commands/test/audit/fix.ts
@@ -529,21 +529,23 @@ test('audit.ignorePrune sanitizes the removed ids in the log message', async () 
   expect(collectedInfos.every((message) => !message.includes('\u001b'))).toBe(true)
 })
 
-test('a bare --fix arriving as the string "true" still applies the default fix method', async () => {
+test.each([
+  ['the empty string the CLI parser delivers', ''],
+  ['a boolean from an rc file', true],
+  ['the string form of that boolean', 'true'],
+])('a --fix without a method applies the default fix method: %s', async (_label, fix) => {
   const tmp = f.prepare('has-vulnerabilities')
 
   getMockAgent().get(AUDIT_REGISTRY.replace(/\/$/, ''))
     .intercept({ path: '/-/npm/v1/security/advisories/bulk', method: 'POST' })
     .reply(200, responses.ALL_VULN_RESP)
 
-  // The rc-option spec for --fix is [String, Boolean], so the CLI parser
-  // delivers a bare --fix as the string 'true'.
   const { exitCode, output } = await audit.handler({
     ...AUDIT_REGISTRY_OPTS,
     auditLevel: 'moderate',
     dir: tmp,
     rootProjectManifestDir: tmp,
-    fix: 'true',
+    fix,
   })
 
   expect(exitCode).toBe(0)
@@ -565,9 +567,7 @@ test('an invalid --fix value is rejected', async () => {
     auditLevel: 'moderate',
     dir: tmp,
     rootProjectManifestDir: tmp,
-    // The CLI parser delivers --fix values as strings before validation, so
-    // the options type cannot represent this input.
-    fix: 'bogus' as unknown as 'update',
+    fix: 'bogus',
   })).rejects.toMatchObject({ code: 'ERR_PNPM_INVALID_FIX_OPTION' })
 })
 

--- a/pnpm11/deps/compliance/commands/test/audit/fix.ts
+++ b/pnpm11/deps/compliance/commands/test/audit/fix.ts
@@ -1,4 +1,4 @@
-import fs, { existsSync as fsExistsSync } from 'node:fs'
+import { existsSync as fsExistsSync, readFileSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, test } from '@jest/globals'
@@ -294,7 +294,7 @@ test('audit.ignorePrune removes ignored GHSAs that are no longer in the report',
 
   // The preceding comment and the trailing same-line comment attached to
   // the removed entry must both go with it.
-  const rawContent = fs.readFileSync(path.join(tmp, 'pnpm-workspace.yaml'), 'utf8')
+  const rawContent = readFileSync(path.join(tmp, 'pnpm-workspace.yaml'), 'utf8')
   expect(rawContent).not.toContain('Expired GHSA')
   expect(rawContent).not.toContain('trailing comment')
 
@@ -424,7 +424,7 @@ test('audit.ignorePrune removes all entries when none are relevant', async () =>
 
 test('audit.ignorePrune edits an inline (flow-style) auditConfig in place', async () => {
   const tmp = f.prepare('has-vulnerabilities-with-ignored-ghsas')
-  fs.writeFileSync(
+  writeFileSync(
     path.join(tmp, 'pnpm-workspace.yaml'),
     'packages:\n  - \'.\'\nsharedWorkspaceLockfile: false\nauditConfig: { ignoreGhsas: [GHSA-42xw-2xvc-qx8m, GHSA-xxxx-xxxx-xxxx] }\n'
   )
@@ -452,7 +452,7 @@ test('audit.ignorePrune edits an inline (flow-style) auditConfig in place', asyn
 
   // The retained GHSA is edited in place inside the flow-style block, rather
   // than the whole auditConfig being reformatted into block style.
-  const rawContent = fs.readFileSync(path.join(tmp, 'pnpm-workspace.yaml'), 'utf8')
+  const rawContent = readFileSync(path.join(tmp, 'pnpm-workspace.yaml'), 'utf8')
   expect(rawContent).toContain(
     'auditConfig: { ignoreGhsas: [ GHSA-42xw-2xvc-qx8m ] }'
   )
@@ -463,7 +463,7 @@ test('audit.ignorePrune edits an inline (flow-style) auditConfig in place', asyn
 
 test('audit.ignorePrune updates the canonical audit.ignore list', async () => {
   const tmp = f.prepare('has-vulnerabilities-with-ignored-ghsas')
-  fs.writeFileSync(
+  writeFileSync(
     path.join(tmp, 'pnpm-workspace.yaml'),
     'packages:\n  - \'.\'\nsharedWorkspaceLockfile: false\naudit:\n  ignorePrune: true\n  ignore:\n    - GHSA-42xw-2xvc-qx8m\n    - GHSA-xxxx-xxxx-xxxx\n'
   )

--- a/pnpm11/deps/compliance/commands/test/audit/fix.ts
+++ b/pnpm11/deps/compliance/commands/test/audit/fix.ts
@@ -529,6 +529,136 @@ test('audit.ignorePrune sanitizes the removed ids in the log message', async () 
   expect(collectedInfos.every((message) => !message.includes('\u001b'))).toBe(true)
 })
 
+test('a bare --fix arriving as the string "true" still applies the default fix method', async () => {
+  const tmp = f.prepare('has-vulnerabilities')
+
+  getMockAgent().get(AUDIT_REGISTRY.replace(/\/$/, ''))
+    .intercept({ path: '/-/npm/v1/security/advisories/bulk', method: 'POST' })
+    .reply(200, responses.ALL_VULN_RESP)
+
+  // The rc-option spec for --fix is [String, Boolean], so the CLI parser
+  // delivers a bare --fix as the string 'true'.
+  const { exitCode, output } = await audit.handler({
+    ...AUDIT_REGISTRY_OPTS,
+    auditLevel: 'moderate',
+    dir: tmp,
+    rootProjectManifestDir: tmp,
+    fix: 'true',
+  })
+
+  expect(exitCode).toBe(0)
+  expect(output).toMatch(/Run "pnpm install"/)
+
+  const manifest = readYamlFileSync<{ overrides?: Record<string, string> }>(path.join(tmp, 'pnpm-workspace.yaml'))
+  expect(manifest.overrides?.['axios@<=0.18.0']).toBe('^0.18.1')
+})
+
+test('an invalid --fix value is rejected', async () => {
+  const tmp = f.prepare('has-vulnerabilities')
+
+  getMockAgent().get(AUDIT_REGISTRY.replace(/\/$/, ''))
+    .intercept({ path: '/-/npm/v1/security/advisories/bulk', method: 'POST' })
+    .reply(200, responses.NO_VULN_RESP)
+
+  await expect(audit.handler({
+    ...AUDIT_REGISTRY_OPTS,
+    auditLevel: 'moderate',
+    dir: tmp,
+    rootProjectManifestDir: tmp,
+    // The CLI parser delivers --fix values as strings before validation, so
+    // the options type cannot represent this input.
+    fix: 'bogus' as unknown as 'update',
+  })).rejects.toMatchObject({ code: 'ERR_PNPM_INVALID_FIX_OPTION' })
+})
+
+test('saveExact saves the override as an exact version', async () => {
+  const tmp = f.prepare('has-vulnerabilities')
+
+  getMockAgent().get(AUDIT_REGISTRY.replace(/\/$/, ''))
+    .intercept({ path: '/-/npm/v1/security/advisories/bulk', method: 'POST' })
+    .reply(200, responses.ALL_VULN_RESP)
+
+  const { exitCode } = await audit.handler({
+    ...AUDIT_REGISTRY_OPTS,
+    auditLevel: 'moderate',
+    dir: tmp,
+    rootProjectManifestDir: tmp,
+    fix: true,
+    saveExact: true,
+  })
+
+  expect(exitCode).toBe(0)
+
+  const manifest = readYamlFileSync<{ overrides?: Record<string, string> }>(path.join(tmp, 'pnpm-workspace.yaml'))
+  expect(manifest.overrides?.['axios@<=0.18.0']).toBe('0.18.1')
+})
+
+test('savePrefix ~ saves the override as a tilde range', async () => {
+  const tmp = f.prepare('has-vulnerabilities')
+
+  getMockAgent().get(AUDIT_REGISTRY.replace(/\/$/, ''))
+    .intercept({ path: '/-/npm/v1/security/advisories/bulk', method: 'POST' })
+    .reply(200, responses.ALL_VULN_RESP)
+
+  const { exitCode } = await audit.handler({
+    ...AUDIT_REGISTRY_OPTS,
+    auditLevel: 'moderate',
+    dir: tmp,
+    rootProjectManifestDir: tmp,
+    fix: true,
+    savePrefix: '~',
+  })
+
+  expect(exitCode).toBe(0)
+
+  const manifest = readYamlFileSync<{ overrides?: Record<string, string> }>(path.join(tmp, 'pnpm-workspace.yaml'))
+  expect(manifest.overrides?.['axios@<=0.18.0']).toBe('~0.18.1')
+})
+
+test('savePrefix = saves the override as an exact = range', async () => {
+  const tmp = f.prepare('has-vulnerabilities')
+
+  getMockAgent().get(AUDIT_REGISTRY.replace(/\/$/, ''))
+    .intercept({ path: '/-/npm/v1/security/advisories/bulk', method: 'POST' })
+    .reply(200, responses.ALL_VULN_RESP)
+
+  const { exitCode } = await audit.handler({
+    ...AUDIT_REGISTRY_OPTS,
+    auditLevel: 'moderate',
+    dir: tmp,
+    rootProjectManifestDir: tmp,
+    fix: true,
+    savePrefix: '=',
+  })
+
+  expect(exitCode).toBe(0)
+
+  const manifest = readYamlFileSync<{ overrides?: Record<string, string> }>(path.join(tmp, 'pnpm-workspace.yaml'))
+  expect(manifest.overrides?.['axios@<=0.18.0']).toBe('=0.18.1')
+})
+
+test('savePrefix "" saves the override as an exact version', async () => {
+  const tmp = f.prepare('has-vulnerabilities')
+
+  getMockAgent().get(AUDIT_REGISTRY.replace(/\/$/, ''))
+    .intercept({ path: '/-/npm/v1/security/advisories/bulk', method: 'POST' })
+    .reply(200, responses.ALL_VULN_RESP)
+
+  const { exitCode } = await audit.handler({
+    ...AUDIT_REGISTRY_OPTS,
+    auditLevel: 'moderate',
+    dir: tmp,
+    rootProjectManifestDir: tmp,
+    fix: true,
+    savePrefix: '',
+  })
+
+  expect(exitCode).toBe(0)
+
+  const manifest = readYamlFileSync<{ overrides?: Record<string, string> }>(path.join(tmp, 'pnpm-workspace.yaml'))
+  expect(manifest.overrides?.['axios@<=0.18.0']).toBe('0.18.1')
+})
+
 function advisory (moduleName: string, vulnerableVersions: string, patchedVersions?: string): AuditAdvisory {
   return {
     findings: [],

--- a/pnpm11/deps/compliance/commands/tsconfig.json
+++ b/pnpm11/deps/compliance/commands/tsconfig.json
@@ -80,6 +80,9 @@
       "path": "../../../pkg-manifest/reader"
     },
     {
+      "path": "../../../pkg-manifest/utils"
+    },
+    {
       "path": "../../../store/path"
     },
     {

--- a/pnpm11/pnpm/test/parseCliArgs.test.ts
+++ b/pnpm11/pnpm/test/parseCliArgs.test.ts
@@ -11,3 +11,8 @@ test('the "issues" alias resolves to the "bugs" command', async () => {
   const { cmd } = await parseCliArgs(['issues', 'is-positive'])
   expect(cmd).toBe('bugs')
 })
+
+test('a bare --fix reaches the audit command handler as the string "true"', async () => {
+  const { options } = await parseCliArgs(['audit', '--fix'])
+  expect(options.fix).toBe('true')
+})

--- a/pnpm11/pnpm/test/parseCliArgs.test.ts
+++ b/pnpm11/pnpm/test/parseCliArgs.test.ts
@@ -12,7 +12,13 @@ test('the "issues" alias resolves to the "bugs" command', async () => {
   expect(cmd).toBe('bugs')
 })
 
-test('a bare --fix reaches the audit command handler as the string "true"', async () => {
+test('a bare --fix reaches the audit command handler as an empty string', async () => {
   const { options } = await parseCliArgs(['audit', '--fix'])
-  expect(options.fix).toBe('true')
+  expect(options.fix).toBe('')
+})
+
+test('a bare --fix does not consume the flag that follows it', async () => {
+  const { options } = await parseCliArgs(['audit', '--fix', '--json'])
+  expect(options.fix).toBe('')
+  expect(options.json).toBe(true)
 })


### PR DESCRIPTION
## Summary

Two fixes to `pnpm audit --fix`:

1. `pnpm audit --fix` (without a value) failed with `ERR_PNPM_INVALID_FIX_OPTION`.
   The `fix` rc-option was typed `[String, Boolean]`, which makes nopt take the
   token *after* `--fix` as its value even when that token is another flag — so
   the failure was not limited to the bare flag at the end of the command line:

   | invocation | old `fix` value | result |
   | --- | --- | --- |
   | `pnpm audit --fix` | `'true'` | rejected |
   | `pnpm audit --fix --json` | `'--json'` | rejected, **and `--json` silently dropped** |
   | `pnpm audit --fix --interactive` | `'--interactive'` | rejected, `--interactive` dropped |
   | `pnpm audit --fix --save-exact` | `'--save-exact'` | rejected, `--save-exact` dropped |

   The option is now typed as a plain `String`. nopt then leaves a following
   `--flag` alone and delivers a methodless `--fix` as the empty string, which
   selects the default fix method (`override`) — restoring the pnpm 10 behavior
   where `audit --fix` writes vulnerability overrides. Invalid values
   (`--fix=bogus`) are still rejected. Closes pnpm/pnpm#13261.

   The Rust port already had this right (clap's `default_missing_value = "override"`
   plus its refusal to read a `-`-prefixed token as a value), so this half is a
   TypeScript-only parity fix.

2. `pnpm audit --fix=override` wrote overrides with a hardcoded caret, ignoring
   the `saveExact` and `savePrefix` settings. Overrides are now formatted with
   the same range-style rules as other manifest edits, in both stacks.
   Closes pnpm/pnpm#11523.

`AuditOptions.fix` is widened to `boolean | string`: the CLI hands the command
whatever the user typed, valid or not, which no literal union can describe.

### Tests

- Handler-level regression tests in `test/audit/fix.ts` covering a methodless
  `--fix` (empty string, boolean, and its string form), an invalid value, and
  `saveExact` / `savePrefix` of `~`, `=` and `""`.
- A CLI-parse boundary test in `pnpm11/pnpm/test/parseCliArgs.test.ts` asserting
  that a bare `--fix` parses to `''` and does **not** consume the flag after it.
- Rust: unit tests for `create_overrides` at each range style, plus an e2e test
  (`audit_fix_override_writes_overrides_in_the_configured_save_style`) that runs
  the real binary against a workspace with `savePrefix: '~'`, covering the
  settings-to-override wiring the unit tests bypass.

### Known gaps (not addressed here)

- The interactive picker's "Patched" column still renders a caret regardless of
  `savePrefix`. It is shared with `--fix update`, which writes no overrides and
  preserves each manifest entry's existing style, so threading the save style
  through would make that preview less accurate.
- `pnpm audit --no-fix` still errors (nopt delivers the string `'false'`).
  pacquet rejects `--no-fix` outright, so both stacks error today.
- `pnpm audit --save-exact` works in the TypeScript CLI (audit inherits
  `update`'s rc options) but not in pacquet, where neither `save-exact` nor
  `save-prefix` is in `BARE_SETTING_FLAGS`.

## Squash Commit Body

```text
`pnpm audit --fix` failed with ERR_PNPM_INVALID_FIX_OPTION when the flag
was passed without a method. The `fix` rc-option was typed
[String, Boolean], which makes nopt take the token after `--fix` as its
value even when that token is another flag, so `pnpm audit --fix --json`
failed too and silently dropped `--json`. Typing the option as a plain
String leaves a following `--flag` alone and delivers a methodless
`--fix` as the empty string, which selects the default fix method
(override) and restores the pnpm 10 behavior.

`pnpm audit --fix=override` wrote overrides with a hardcoded version
format, ignoring the `saveExact` and `savePrefix` settings. Overrides
are now written using the same formatting rules as other manifest edits.

Closes pnpm/pnpm#13261, pnpm/pnpm#11523
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5[1m]).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm audit --fix` when used without a value.
  * Continued rejecting invalid `--fix` values with clear errors.
  * Audit vulnerability overrides now respect exact-version and custom save-prefix settings, including `~`, `=`, and empty prefixes.
  * Preserved default caret-based override behavior when no save style is configured.
  * Improved consistency when applying vulnerability fixes across supported audit workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->