### PR TITLE
fix(lockfile): keep bundledDependencies and the libc shape on a reused package entry

### DIFF
--- a/.changeset/lockfile-rewrite-keeps-bundled-dependencies.md
+++ b/.changeset/lockfile-rewrite-keeps-bundled-dependencies.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Rewriting `pnpm-lock.yaml` no longer deletes `bundledDependencies` from package entries whose resolution was reused, so bumping one dependency no longer strips the field from every unrelated entry that carries it [#14153](https://github.com/pnpm/pnpm/issues/14153).
+`bundledDependencies` is no longer dropped from `pnpm-lock.yaml` when an install rewrites it. Bumping a single dependency stripped the field from every unrelated entry that carried it, and a `libc` recorded as a plain string was rewritten as a list [#14153](https://github.com/pnpm/pnpm/issues/14153).

--- a/.changeset/lockfile-rewrite-keeps-bundled-dependencies.md
+++ b/.changeset/lockfile-rewrite-keeps-bundled-dependencies.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Rewriting `pnpm-lock.yaml` no longer deletes `bundledDependencies` from package entries whose resolution was reused, so bumping one dependency no longer strips the field from every unrelated entry that carries it [#14153](https://github.com/pnpm/pnpm/issues/14153).

--- a/pnpm/crates/cli/tests/suite/bundled_dependencies.rs
+++ b/pnpm/crates/cli/tests/suite/bundled_dependencies.rs
@@ -147,6 +147,24 @@ fn bundle_dependencies_false_is_not_recorded() {
     drop((root, npmrc_info)); // cleanup
 }
 
+#[test]
+fn bundled_dependencies_survive_a_lockfile_rewrite() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+
+    pacquet.with_args(["add", "@pnpm.e2e/pkg-with-bundled-dependencies@1.0.0"]).assert().success();
+    pacquet_in(&workspace).with_args(["add", "@pnpm.e2e/foo@100.0.0"]).assert().success();
+
+    let lockfile = read_wanted_lockfile(&workspace);
+    assert_eq!(
+        package(&lockfile, "@pnpm.e2e/pkg-with-bundled-dependencies@1.0.0").bundled_dependencies,
+        Some(BundledDependencies::Names(vec!["@pnpm.e2e/hello-world-js-bin".to_string()])),
+        "an entry whose resolution was reused keeps its recorded bundled dependencies",
+    );
+
+    drop((root, npmrc_info)); // cleanup
+}
+
 /// A linked bin means something different per platform: Unix has the
 /// executable bit on the extensionless shim, while Windows has no such bit and
 /// instead relies on the `.cmd` / `.ps1` launchers written next to it. Assert

--- a/pnpm/crates/cli/tests/suite/bundled_dependencies.rs
+++ b/pnpm/crates/cli/tests/suite/bundled_dependencies.rs
@@ -153,6 +153,9 @@ fn bundled_dependencies_survive_a_lockfile_rewrite() {
         CommandTempCwd::init().add_mocked_registry();
 
     pacquet.with_args(["add", "@pnpm.e2e/pkg-with-bundled-dependencies@1.0.0"]).assert().success();
+
+    // Adding an unrelated package rewrites the lockfile while the first
+    // entry's resolution is reused rather than resolved again.
     pacquet_in(&workspace).with_args(["add", "@pnpm.e2e/foo@100.0.0"]).assert().success();
 
     let lockfile = read_wanted_lockfile(&workspace);

--- a/pnpm/crates/resolving-deps-resolver/src/lockfile_reuse.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/lockfile_reuse.rs
@@ -6,8 +6,9 @@
 use node_semver::{Range, Version};
 use pnpm_lockfile::{
     BundledDependencies, Lockfile, LockfileResolution, PkgName, PkgNameVer, PkgNameVerPeer,
-    ProjectSnapshot, RegistryContext, ResolvedDependencySpec, SnapshotEntry, TarballResolution,
-    TarballUrlOptions, npm_tarball_url, pick_registry_for_package, registry_server_type,
+    ProjectSnapshot, RegistryContext, ResolvedDependencySpec, SnapshotEntry, StringOrList,
+    TarballResolution, TarballUrlOptions, npm_tarball_url, pick_registry_for_package,
+    registry_server_type,
 };
 use pnpm_resolving_parse_wanted_dependency::git_specifiers_are_equivalent;
 use pnpm_resolving_resolver_base::{CurrentPkg, PkgResolutionId, ResolveResult};
@@ -288,9 +289,11 @@ pub(crate) fn synthesize_reused_result(
 }
 
 /// Reconstruct the minimal manifest fragment downstream consumers read
-/// off a reused [`ResolveResult`]. Carries the peer / platform metadata
-/// the lockfile records; omits `dependencies` because a reused node's
-/// children come from the snapshot graph, not the manifest.
+/// off a reused [`ResolveResult`]. Carries the peer / platform /
+/// packaging metadata the lockfile records, in the shape it recorded it,
+/// so a rewrite re-emits the entry unchanged; omits `dependencies`
+/// because a reused node's children come from the snapshot graph, not
+/// the manifest.
 fn synthesize_manifest(
     name: &PkgName,
     version: Option<&str>,
@@ -334,7 +337,11 @@ fn synthesize_manifest(
         manifest.insert("os".to_string(), string_array(os));
     }
     if let Some(libc) = metadata.libc.as_ref() {
-        manifest.insert("libc".to_string(), string_array(libc));
+        let value = match libc {
+            StringOrList::String(single) => Value::String(single.clone()),
+            StringOrList::List(names) => string_array(names),
+        };
+        manifest.insert("libc".to_string(), value);
     }
     if let Some(deprecated) = metadata.deprecated.as_ref() {
         manifest.insert("deprecated".to_string(), Value::String(deprecated.clone()));

--- a/pnpm/crates/resolving-deps-resolver/src/lockfile_reuse.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/lockfile_reuse.rs
@@ -5,9 +5,9 @@
 
 use node_semver::{Range, Version};
 use pnpm_lockfile::{
-    Lockfile, LockfileResolution, PkgName, PkgNameVer, PkgNameVerPeer, ProjectSnapshot,
-    RegistryContext, ResolvedDependencySpec, SnapshotEntry, TarballResolution, TarballUrlOptions,
-    npm_tarball_url, pick_registry_for_package, registry_server_type,
+    BundledDependencies, Lockfile, LockfileResolution, PkgName, PkgNameVer, PkgNameVerPeer,
+    ProjectSnapshot, RegistryContext, ResolvedDependencySpec, SnapshotEntry, TarballResolution,
+    TarballUrlOptions, npm_tarball_url, pick_registry_for_package, registry_server_type,
 };
 use pnpm_resolving_parse_wanted_dependency::git_specifiers_are_equivalent;
 use pnpm_resolving_resolver_base::{CurrentPkg, PkgResolutionId, ResolveResult};
@@ -338,6 +338,13 @@ fn synthesize_manifest(
     }
     if let Some(deprecated) = metadata.deprecated.as_ref() {
         manifest.insert("deprecated".to_string(), Value::String(deprecated.clone()));
+    }
+    if let Some(bundled) = metadata.bundled_dependencies.as_ref() {
+        let value = match bundled {
+            BundledDependencies::Boolean(bundles_all) => Value::Bool(*bundles_all),
+            BundledDependencies::Names(names) => string_array(names),
+        };
+        manifest.insert("bundledDependencies".to_string(), value);
     }
     // `has_bin: Some(true)` round-trips as a truthy `bin` so the
     // bundled-manifest bin linker sees a non-empty bin set; the exact

--- a/pnpm/crates/resolving-deps-resolver/src/lockfile_reuse/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/lockfile_reuse/tests.rs
@@ -7,9 +7,9 @@ fn registry_context(registries: HashMap<String, String>) -> pnpm_lockfile::Regis
 }
 
 use pnpm_lockfile::{
-    ComVer, GitResolution, ImporterDepVersion, Lockfile, LockfileResolution, LockfileVersion,
-    PackageMetadata, PkgName, PkgNameVerPeer, PkgVerPeer, ProjectSnapshot, RegistryResolution,
-    ResolvedDependencySpec, TarballResolution,
+    BundledDependencies, ComVer, GitResolution, ImporterDepVersion, Lockfile, LockfileResolution,
+    LockfileVersion, PackageMetadata, PkgName, PkgNameVerPeer, PkgVerPeer, ProjectSnapshot,
+    RegistryResolution, ResolvedDependencySpec, TarballResolution,
 };
 
 use super::{reusable_importer_dep, synthesize_reused_result};
@@ -175,6 +175,40 @@ fn synthesized_manifest_carries_deprecated_metadata() {
     assert_eq!(
         manifest.get("deprecated").and_then(serde_json::Value::as_str),
         Some("use String.prototype.padStart()"),
+    );
+}
+
+#[test]
+fn synthesized_manifest_carries_bundled_dependencies() {
+    let key: PkgNameVerPeer = "pkg-with-bundled-deps@1.0.0".parse().expect("parse key");
+    let mut metadata = registry_metadata();
+    metadata.bundled_dependencies = Some(BundledDependencies::Names(vec!["napi-wasm".to_string()]));
+    let mut lockfile = empty_lockfile();
+    lockfile.packages = Some(HashMap::from([(key.clone(), metadata)]));
+
+    let result = synthesize_reused_result(&lockfile, &key, "pkg-with-bundled-deps")
+        .expect("registry dep is reusable");
+    let manifest = result.manifest.expect("synthesized manifest");
+    assert_eq!(
+        BundledDependencies::from_manifest(Some(&manifest)),
+        Some(BundledDependencies::Names(vec!["napi-wasm".to_string()])),
+    );
+}
+
+#[test]
+fn synthesized_manifest_carries_the_boolean_bundled_dependencies_form() {
+    let key: PkgNameVerPeer = "pkg-bundling-everything@1.0.0".parse().expect("parse key");
+    let mut metadata = registry_metadata();
+    metadata.bundled_dependencies = Some(BundledDependencies::Boolean(true));
+    let mut lockfile = empty_lockfile();
+    lockfile.packages = Some(HashMap::from([(key.clone(), metadata)]));
+
+    let result = synthesize_reused_result(&lockfile, &key, "pkg-bundling-everything")
+        .expect("registry dep is reusable");
+    let manifest = result.manifest.expect("synthesized manifest");
+    assert_eq!(
+        BundledDependencies::from_manifest(Some(&manifest)),
+        Some(BundledDependencies::Boolean(true)),
     );
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/lockfile_reuse/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/lockfile_reuse/tests.rs
@@ -9,7 +9,7 @@ fn registry_context(registries: HashMap<String, String>) -> pnpm_lockfile::Regis
 use pnpm_lockfile::{
     BundledDependencies, ComVer, GitResolution, ImporterDepVersion, Lockfile, LockfileResolution,
     LockfileVersion, PackageMetadata, PkgName, PkgNameVerPeer, PkgVerPeer, ProjectSnapshot,
-    RegistryResolution, ResolvedDependencySpec, TarballResolution,
+    RegistryResolution, ResolvedDependencySpec, StringOrList, TarballResolution,
 };
 
 use super::{reusable_importer_dep, synthesize_reused_result};
@@ -189,10 +189,7 @@ fn synthesized_manifest_carries_bundled_dependencies() {
     let result = synthesize_reused_result(&lockfile, &key, "pkg-with-bundled-deps")
         .expect("registry dep is reusable");
     let manifest = result.manifest.expect("synthesized manifest");
-    assert_eq!(
-        BundledDependencies::from_manifest(Some(&manifest)),
-        Some(BundledDependencies::Names(vec!["napi-wasm".to_string()])),
-    );
+    assert_eq!(manifest.get("bundledDependencies"), Some(&serde_json::json!(["napi-wasm"])));
 }
 
 #[test]
@@ -206,10 +203,21 @@ fn synthesized_manifest_carries_the_boolean_bundled_dependencies_form() {
     let result = synthesize_reused_result(&lockfile, &key, "pkg-bundling-everything")
         .expect("registry dep is reusable");
     let manifest = result.manifest.expect("synthesized manifest");
-    assert_eq!(
-        BundledDependencies::from_manifest(Some(&manifest)),
-        Some(BundledDependencies::Boolean(true)),
-    );
+    assert_eq!(manifest.get("bundledDependencies"), Some(&serde_json::Value::Bool(true)));
+}
+
+#[test]
+fn synthesized_manifest_keeps_the_scalar_libc_form() {
+    let key: PkgNameVerPeer = "pkg-with-scalar-libc@1.0.0".parse().expect("parse key");
+    let mut metadata = registry_metadata();
+    metadata.libc = Some(StringOrList::String("musl".to_string()));
+    let mut lockfile = empty_lockfile();
+    lockfile.packages = Some(HashMap::from([(key.clone(), metadata)]));
+
+    let result = synthesize_reused_result(&lockfile, &key, "pkg-with-scalar-libc")
+        .expect("registry dep is reusable");
+    let manifest = result.manifest.expect("synthesized manifest");
+    assert_eq!(manifest.get("libc"), Some(&serde_json::Value::String("musl".to_string())));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

When the resolver reuses a locked resolution, `synthesize_manifest` rebuilds the package's manifest from its `packages:` entry, but it never carried `bundledDependencies` over. The lockfile writer reads that field off the synthesized manifest, so every reused entry lost it — bumping one dependency stripped `bundledDependencies` from all 9 entries carrying it in the reproduction, none of them related to the change. Synthesizing the field back, in both its list and boolean form, makes a reused entry round-trip. The TypeScript CLI already keeps the field through the pick list in `lockfile/fs/src/lockfileFormatConverters.ts`, so this is Rust-only.

The same function also flattened `libc` through a `&[String]` helper, so an entry recorded as `libc: musl` came back as `libc: [musl]` on any rewrite. `StringOrList` exists precisely to keep that distinction, so it now keeps the scalar form too.

The `prepare` half of the report does not hold up: the TypeScript CLI drops that field too. It is absent from `LockfilePackageInfo` and from the same pick list, so a `prepare: true` marker is read into memory and then dropped on the next write there as well. Preserving it in the Rust CLI alone would be a divergence, so I left it out. Happy to do both stacks in a follow-up if you want the field kept.

Fixes pnpm/pnpm#14153

## Squash Commit Body

```text
`synthesize_manifest` in the lockfile reuse gate rebuilds a manifest fragment
from a reused `packages:` entry, carrying peerDependencies, engines, cpu, os,
libc, deprecated and bin. bundledDependencies was missing, so
`BundledDependencies::from_manifest` in `build_package_metadata` found nothing
and the rewritten entry dropped the field. Any lockfile rewrite that reused a
resolution therefore deleted bundledDependencies from unrelated entries.

Both recorded shapes are synthesized back: the name list as a JSON array and
`true` as a JSON boolean, which is what `from_manifest` reads on the fresh
resolve path.

libc had a narrower case of the same bug. It was synthesized through
`string_array`, which takes `&[String]` and so reached StringOrList::String
through its Deref, always emitting an array; the writer then read that back as
a list. An entry recorded as `libc: musl` was rewritten as `libc: [musl]`. It
is now matched on and the scalar form is preserved.

The issue also reports that `prepare` is dropped. The TypeScript CLI drops it
as well — it is not a field of LockfilePackageInfo and not in the pick list of
convertToLockfileFile — so preserving it here alone would break parity, and it
is left for a change that covers both stacks.

Closes pnpm/pnpm#14153
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved `bundledDependencies` metadata when rewriting the lockfile.
  * Prevented unrelated package entries from losing bundled dependency information when another dependency is added or updated.
  * Preserved the original format of `libc` metadata, including plain-string values.

* **Tests**
  * Added regression coverage for named and boolean bundled dependency metadata.
  * Added coverage ensuring scalar `libc` values remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->