### PR TITLE
fix: validate unused patches during incremental installs

### DIFF
--- a/.changeset/fuzzy-carpets-smile.md
+++ b/.changeset/fuzzy-carpets-smile.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-resolver": patch
+"pnpm": patch
+---
+
+Fixed `ERR_PNPM_UNUSED_PATCH` validation during incremental installs [pnpm/pnpm#13692](https://github.com/pnpm/pnpm/issues/13692).

--- a/pnpm11/installing/deps-installer/test/install/patch.ts
+++ b/pnpm11/installing/deps-installer/test/install/patch.ts
@@ -4,13 +4,14 @@ import path from 'node:path'
 import { afterAll, expect, jest, test } from '@jest/globals'
 import { ENGINE_NAME, WANTED_LOCKFILE } from '@pnpm/constants'
 import { createHexHashFromFile } from '@pnpm/crypto.hash'
-import { install } from '@pnpm/installing.deps-installer'
+import { install, type MutatedProject, mutateModules } from '@pnpm/installing.deps-installer'
 import type { LockfileFile } from '@pnpm/lockfile.types'
-import { prepareEmpty } from '@pnpm/prepare'
+import { prepareEmpty, preparePackages } from '@pnpm/prepare'
 import type { PackageFilesIndex } from '@pnpm/store.cafs'
 import { StoreIndex, storeIndexKey } from '@pnpm/store.index'
 import { fixtures } from '@pnpm/test-fixtures'
 import { getIntegrity } from '@pnpm/testing.registry-mock'
+import type { ProjectRootDir } from '@pnpm/types'
 import { rimrafSync } from '@zkochan/rimraf'
 import { readYamlFileSync } from 'read-yaml-file'
 
@@ -320,6 +321,68 @@ test('an incremental install recognizes a patch in an untouched locked subtree',
 
   const patchFileHash = await createHexHashFromFile(patchPath)
   expect(project.readLockfile().snapshots[`is-positive@1.0.0(patch_hash=${patchFileHash})`]).toBeTruthy()
+})
+
+test('an incremental workspace install recognizes a patch used by an unchanged non-root importer', async () => {
+  const project1Manifest = {
+    name: 'project-1',
+    version: '1.0.0',
+    dependencies: {
+      'is-positive': '1.0.0',
+    },
+  }
+  const project2Manifest = {
+    name: 'project-2',
+    version: '1.0.0',
+  }
+  const projects = preparePackages([
+    { location: 'project-1', package: project1Manifest },
+    { location: 'project-2', package: project2Manifest },
+  ])
+  const project1Root = path.resolve('project-1') as ProjectRootDir
+  const project2Root = path.resolve('project-2') as ProjectRootDir
+  const importers: MutatedProject[] = [
+    { mutation: 'install', rootDir: project1Root },
+    { mutation: 'install', rootDir: project2Root },
+  ]
+  const patchPath = path.join(f.find('patch-pkg'), 'is-positive@1.0.0.patch')
+  const patchedDependencies = {
+    'is-positive@1.0.0': patchPath,
+  }
+  const opts = testDefaults({
+    allProjects: [
+      { buildIndex: 0, manifest: project1Manifest, rootDir: project1Root },
+      { buildIndex: 0, manifest: project2Manifest, rootDir: project2Root },
+    ],
+    patchedDependencies,
+  })
+  await mutateModules(importers, opts)
+
+  const updatedProject2Manifest = {
+    ...project2Manifest,
+    dependencies: {
+      '@pnpm.e2e/pkg-with-1-dep': '100.0.0',
+    },
+  }
+  projects['project-2'].writePackageJson(updatedProject2Manifest)
+  const requestedPackages: string[] = []
+  const requestPackage = opts.storeController.requestPackage
+  opts.storeController.requestPackage = async (wantedDependency, requestOptions) => {
+    requestedPackages.push(wantedDependency.alias!)
+    return requestPackage(wantedDependency, requestOptions)
+  }
+  await mutateModules(importers, {
+    ...opts,
+    allProjects: [
+      { buildIndex: 0, manifest: project1Manifest, rootDir: project1Root },
+      { buildIndex: 0, manifest: updatedProject2Manifest, rootDir: project2Root },
+    ],
+  })
+
+  expect(requestedPackages).toContain('@pnpm.e2e/pkg-with-1-dep')
+  const patchFileHash = await createHexHashFromFile(patchPath)
+  const lockfile = readYamlFileSync<LockfileFile>(WANTED_LOCKFILE)
+  expect(lockfile.snapshots?.[`is-positive@1.0.0(patch_hash=${patchFileHash})`]).toBeTruthy()
 })
 
 test('the patched package is updated if the patch is modified', async () => {

--- a/pnpm11/installing/deps-installer/test/install/patch.ts
+++ b/pnpm11/installing/deps-installer/test/install/patch.ts
@@ -268,6 +268,60 @@ test('patch package throws an exception if not all patches are applied', async (
   ).rejects.toThrow('The following patches were not used: is-negative@1.0.0')
 })
 
+test('patch package throws an exception for an unused patch during an incremental install', async () => {
+  prepareEmpty()
+  const patchPath = path.join(f.find('patch-pkg'), 'is-positive@1.0.0.patch')
+  const manifest = {
+    dependencies: {
+      'is-positive': '1.0.0',
+    },
+  }
+  const opts = testDefaults({
+    fastUnpack: false,
+    sideEffectsCacheRead: true,
+    sideEffectsCacheWrite: true,
+  }, {}, {}, { packageImportMethod: 'hardlink' })
+  await install(manifest, opts)
+
+  await expect(install(manifest, {
+    ...opts,
+    patchedDependencies: {
+      'is-negative@1.0.0': patchPath,
+    },
+  })).rejects.toThrow('The following patches were not used: is-negative@1.0.0')
+})
+
+test('an incremental install recognizes a patch in an untouched locked subtree', async () => {
+  const project = prepareEmpty()
+  const patchPath = path.join(f.find('patch-pkg'), 'is-positive@1.0.0.patch')
+  const opts = testDefaults({
+    fastUnpack: false,
+    sideEffectsCacheRead: true,
+    sideEffectsCacheWrite: true,
+    patchedDependencies: {
+      'is-positive@1.0.0': patchPath,
+    },
+    overrides: {
+      'is-positive': '1.0.0',
+    },
+  }, {}, {}, { packageImportMethod: 'hardlink' })
+  await install({
+    dependencies: {
+      'is-not-positive': '1.0.0',
+    },
+  }, opts)
+
+  await install({
+    dependencies: {
+      'is-negative': '1.0.0',
+      'is-not-positive': '1.0.0',
+    },
+  }, opts)
+
+  const patchFileHash = await createHexHashFromFile(patchPath)
+  expect(project.readLockfile().snapshots[`is-positive@1.0.0(patch_hash=${patchFileHash})`]).toBeTruthy()
+})
+
 test('the patched package is updated if the patch is modified', async () => {
   prepareEmpty()
   f.copy('patch-pkg', 'patches')

--- a/pnpm11/installing/deps-resolver/src/index.ts
+++ b/pnpm11/installing/deps-resolver/src/index.ts
@@ -6,14 +6,15 @@ import {
   packageManifestLogger,
 } from '@pnpm/core-loggers'
 import { findRuntimeNodeVersion, iterateHashedGraphNodes } from '@pnpm/deps.graph-hasher'
-import { isRuntimeDepPath } from '@pnpm/deps.path'
+import { isRuntimeDepPath, parse as parseDepPath } from '@pnpm/deps.path'
 import { PnpmError } from '@pnpm/error'
 import { safeJoinModulesDir } from '@pnpm/fs.symlink-dependency'
 import type {
   LockfileObject,
   ProjectSnapshot,
 } from '@pnpm/lockfile.types'
-import { verifyPatches } from '@pnpm/patching.config'
+import { nameVerFromPkgSnapshot } from '@pnpm/lockfile.utils'
+import { getPatchInfo, type PatchGroupRecord, verifyPatches } from '@pnpm/patching.config'
 import { safeReadPackageJsonFromDir } from '@pnpm/pkg-manifest.reader'
 import {
   getAllDependenciesFromManifest,
@@ -291,17 +292,6 @@ export async function resolveDependencies (
     })
     : initiallyResolvedPeers
 
-  if (
-    opts.patchedDependencies &&
-    Object.keys(opts.wantedLockfile.importers).length === importers.length
-  ) {
-    verifyPatches({
-      patchedDependencies: opts.patchedDependencies,
-      appliedPatches: getAppliedPatchKeys(dependenciesGraph),
-      allowUnusedPatches: opts.allowUnusedPatches,
-    })
-  }
-
   const preserveDedupedWorkspaceLinks = Boolean(opts.dedupeInjectedDeps)
   const linkedDependenciesByProjectId: Record<string, LinkedDependency[]> = {}
   await Promise.all(projectsToResolve.map(async (project, index) => {
@@ -460,6 +450,17 @@ export async function resolveDependencies (
     Object.values(resolvedImporters).flatMap(({ directDependencies }) => directDependencies),
     updatedCatalogs)
 
+  if (
+    opts.patchedDependencies &&
+    Object.keys(opts.wantedLockfile.importers).length === importers.length
+  ) {
+    verifyPatches({
+      patchedDependencies: opts.patchedDependencies,
+      appliedPatches: getAppliedPatchKeys(newLockfile, opts.patchedDependencies),
+      allowUnusedPatches: opts.allowUnusedPatches,
+    })
+  }
+
   // waiting till package requests are finished
   async function waitTillAllFetchingsFinish (): Promise<void> {
     await Promise.all(Object.values(resolvedPkgsById).map(async ({ fetching }) => {
@@ -490,10 +491,19 @@ function treeHasLockedPeerContexts (dependenciesTree: DependenciesTree<ResolvedP
   return false
 }
 
-function getAppliedPatchKeys (dependenciesGraph: DependenciesGraph): Set<string> {
+function getAppliedPatchKeys (
+  lockfile: LockfileObject,
+  patchedDependencies: PatchGroupRecord
+): Set<string> {
   const appliedPatchKeys = new Set<string>()
-  for (const pkg of Object.values(dependenciesGraph)) {
-    if (pkg.patch?.key != null) appliedPatchKeys.add(pkg.patch.key)
+  for (const [depPath, pkgSnapshot] of Object.entries(lockfile.packages ?? {})) {
+    if (!depPath.includes('(patch_hash=')) continue
+    const { patchHash } = parseDepPath(depPath)
+    if (patchHash == null) continue
+    const { name, version } = nameVerFromPkgSnapshot(depPath, pkgSnapshot)
+    if (version == null) continue
+    const patch = getPatchInfo(patchedDependencies, name, version)
+    if (patch != null && patchHash === `(patch_hash=${patch.hash})`) appliedPatchKeys.add(patch.key)
   }
   return appliedPatchKeys
 }

--- a/pnpm11/installing/deps-resolver/src/index.ts
+++ b/pnpm11/installing/deps-resolver/src/index.ts
@@ -175,7 +175,6 @@ export async function resolveDependencies (
     resolvedImporters,
     resolvedPkgsById,
     wantedToBeSkippedPackageIds,
-    appliedPatches,
     time,
     allPeerDepNames,
     resolutionPolicyViolations,
@@ -209,19 +208,6 @@ export async function resolveDependencies (
   }
 
   opts.storeController.clearResolutionCache()
-
-  // We only check whether patches were applied in cases when the whole lockfile was reanalyzed.
-  if (
-    opts.patchedDependencies &&
-    (opts.forceFullResolution || !Object.keys(opts.wantedLockfile.packages ?? {})?.length) &&
-    Object.keys(opts.wantedLockfile.importers).length === importers.length
-  ) {
-    verifyPatches({
-      patchedDependencies: opts.patchedDependencies,
-      appliedPatches,
-      allowUnusedPatches: opts.allowUnusedPatches,
-    })
-  }
 
   const projectsToLink = await Promise.all<ProjectToLink>(projectsToResolve.map(async (project) => {
     const resolvedImporter = resolvedImporters[project.id]
@@ -304,6 +290,17 @@ export async function resolveDependencies (
       resolvedPeerProviderPaths: initiallyResolvedPeers.pathsByNodeId,
     })
     : initiallyResolvedPeers
+
+  if (
+    opts.patchedDependencies &&
+    Object.keys(opts.wantedLockfile.importers).length === importers.length
+  ) {
+    verifyPatches({
+      patchedDependencies: opts.patchedDependencies,
+      appliedPatches: getAppliedPatchKeys(dependenciesGraph),
+      allowUnusedPatches: opts.allowUnusedPatches,
+    })
+  }
 
   const preserveDedupedWorkspaceLinks = Boolean(opts.dedupeInjectedDeps)
   const linkedDependenciesByProjectId: Record<string, LinkedDependency[]> = {}
@@ -491,6 +488,14 @@ function treeHasLockedPeerContexts (dependenciesTree: DependenciesTree<ResolvedP
     if (node.lockedPeerContext != null) return true
   }
   return false
+}
+
+function getAppliedPatchKeys (dependenciesGraph: DependenciesGraph): Set<string> {
+  const appliedPatchKeys = new Set<string>()
+  for (const pkg of Object.values(dependenciesGraph)) {
+    if (pkg.patch?.key != null) appliedPatchKeys.add(pkg.patch.key)
+  }
+  return appliedPatchKeys
 }
 
 function addDirectDependenciesToLockfile (

--- a/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
+++ b/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
@@ -24,7 +24,7 @@ import {
 } from '@pnpm/lockfile.utils'
 import { logger } from '@pnpm/logger'
 import { getPatchInfo, type PatchGroupRecord } from '@pnpm/patching.config'
-import type { PatchInfo } from '@pnpm/patching.types'
+import type { ExtendedPatchInfo, PatchInfo } from '@pnpm/patching.types'
 import { safeReadPackageJsonFromDir } from '@pnpm/pkg-manifest.reader'
 import { convertEnginesRuntimeToDependencies } from '@pnpm/pkg-manifest.utils'
 import { parseBareSpecifier } from '@pnpm/resolving.npm-resolver'
@@ -157,7 +157,6 @@ export interface ResolutionContext extends RegistryContext {
   autoInstallPeersFromHighestMatch: boolean
   allowedDeprecatedVersions: AllowedDeprecatedVersions
   allPreferredVersions?: PreferredVersions
-  appliedPatches: Set<string>
   updatedSet: Set<string>
   catalogResolver: CatalogResolver
   defaultTag: string
@@ -315,7 +314,7 @@ export interface ResolvedPackage {
   optionalDependencies: Set<string>
   hasBin: boolean
   hasBundledDependencies: boolean
-  patch?: PatchInfo
+  patch?: PatchInfo & { key?: string }
   prepare: boolean
   pkgIdWithPatchHash: PkgIdWithPatchHash
   requiresBuild?: boolean
@@ -2104,7 +2103,6 @@ async function resolveDependency (
     let pkgIdWithPatchHash = (pkgResponse.body.id.startsWith(`${pkg.name}@`) ? pkgResponse.body.id : `${pkg.name}@${pkgResponse.body.id}`) as PkgIdWithPatchHash
     const patch = getPatchInfo(ctx.patchedDependencies, pkg.name, pkg.version)
     if (patch) {
-      ctx.appliedPatches.add(patch.key)
       pkgIdWithPatchHash = `${pkgIdWithPatchHash}(patch_hash=${patch.hash})` as PkgIdWithPatchHash
     }
 
@@ -2378,7 +2376,7 @@ function getResolvedPackage (
     force: boolean
     hasBin: boolean
     parentImporterId: string
-    patch?: PatchInfo
+    patch?: ExtendedPatchInfo
     pkg: PackageManifest
     pkgResponse: PackageResponse
     prepare: boolean

--- a/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
+++ b/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
@@ -24,7 +24,7 @@ import {
 } from '@pnpm/lockfile.utils'
 import { logger } from '@pnpm/logger'
 import { getPatchInfo, type PatchGroupRecord } from '@pnpm/patching.config'
-import type { ExtendedPatchInfo, PatchInfo } from '@pnpm/patching.types'
+import type { PatchInfo } from '@pnpm/patching.types'
 import { safeReadPackageJsonFromDir } from '@pnpm/pkg-manifest.reader'
 import { convertEnginesRuntimeToDependencies } from '@pnpm/pkg-manifest.utils'
 import { parseBareSpecifier } from '@pnpm/resolving.npm-resolver'
@@ -314,7 +314,7 @@ export interface ResolvedPackage {
   optionalDependencies: Set<string>
   hasBin: boolean
   hasBundledDependencies: boolean
-  patch?: PatchInfo & { key?: string }
+  patch?: PatchInfo
   prepare: boolean
   pkgIdWithPatchHash: PkgIdWithPatchHash
   requiresBuild?: boolean
@@ -2376,7 +2376,7 @@ function getResolvedPackage (
     force: boolean
     hasBin: boolean
     parentImporterId: string
-    patch?: ExtendedPatchInfo
+    patch?: PatchInfo
     pkg: PackageManifest
     pkgResponse: PackageResponse
     prepare: boolean

--- a/pnpm11/installing/deps-resolver/src/resolveDependencyTree.ts
+++ b/pnpm11/installing/deps-resolver/src/resolveDependencyTree.ts
@@ -152,7 +152,6 @@ export interface ResolveDependencyTreeResult {
   resolvedImporters: ResolvedImporters
   resolvedPkgsById: ResolvedPkgsById
   wantedToBeSkippedPackageIds: Set<string>
-  appliedPatches: Set<string>
   time?: Record<string, string>
   /**
    * Policy violations collected inline during resolution — the
@@ -213,7 +212,6 @@ export async function resolveDependencyTree<T> (
     virtualStoreDir: opts.virtualStoreDir,
     virtualStoreDirMaxLength: opts.virtualStoreDirMaxLength,
     wantedLockfile: opts.wantedLockfile,
-    appliedPatches: new Set<string>(),
     updatedSet: new Set<string>(),
     workspacePackages: opts.workspacePackages,
     missingPeersOfChildrenByPkgId: {},
@@ -358,7 +356,6 @@ export async function resolveDependencyTree<T> (
     resolvedImporters,
     resolvedPkgsById: ctx.resolvedPkgsById,
     wantedToBeSkippedPackageIds,
-    appliedPatches: ctx.appliedPatches,
     time,
     allPeerDepNames: ctx.allPeerDepNames,
     resolutionPolicyViolations: ctx.resolutionPolicyViolations,


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#13692 by validating configured patches against the final pruned lockfile graph during every full-workspace resolution, including incremental installs.

The final lockfile is the authoritative set of reachable packages and retains patches used by untouched dependencies and unchanged workspace importers. The existing partial-workspace importer-count exception remains unchanged.

Pacquet already performs unused-patch validation on incremental installs, so no Rust source change is needed; this PR brings the TypeScript CLI into parity.

## Squash Commit Body

```text
Derive applied patch keys from the final pruned lockfile graph. This lets reused lockfile subtrees and unchanged workspace importers count toward validation on full-workspace resolutions.

Closes pnpm/pnpm#13692
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved incremental installation validation for unused patches.
  - Ensured patches applied within unchanged dependency subtrees remain recognized and recorded in the lockfile.
  - Patch validation now runs consistently during incremental installs, preventing missed errors and preserving expected patched dependencies.

- **Tests**
  - Added workspace coverage for unused patch errors and patches applied to locked dependency subtrees.
  - Verified that dependency changes in one workspace do not invalidate recognized patches elsewhere.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->