### PR TITLE
feat(pacquet): deprecate pnpmfile filterLog

### DIFF
--- a/.changeset/pnpmfile-filter-log.md
+++ b/.changeset/pnpmfile-filter-log.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Deprecated the pnpmfile `filterLog` hook in pnpm v12. The Rust CLI ignores it with a warning instead of adding a Node.js round trip for every log message.
+Deprecated the pnpmfile `filterLog` hook in pnpm v12. The Rust CLI ignores it and emits a warning.

--- a/.changeset/pnpmfile-filter-log.md
+++ b/.changeset/pnpmfile-filter-log.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Deprecated the pnpmfile `filterLog` hook in pnpm v12. The Rust CLI ignores it with a warning instead of adding a Node.js round trip for every log message.

--- a/pnpm/crates/cli/src/config_deps.rs
+++ b/pnpm/crates/cli/src/config_deps.rs
@@ -19,7 +19,7 @@ use pnpm_graph_hasher::{detect_node_version, host_arch, host_libc, host_platform
 use pnpm_hooks::{HookContext, LogFn, PnpmfileHooks, finder};
 use pnpm_lockfile::EnvLockfile;
 use pnpm_network::{RetryOpts, ThrottledClient};
-use pnpm_reporter::{HookLog, LogEvent, LogLevel, Reporter};
+use pnpm_reporter::{HookLog, LogEvent, LogLevel, PnpmLog, Reporter};
 use pnpm_resolving_npm_resolver::{
     InMemoryPackageMetaCache, NpmResolver, shared_packument_fetch_locker,
     shared_picked_manifest_cache,
@@ -520,6 +520,7 @@ pub async fn run_update_config_hooks<Reporter: self::Reporter>(
 
     let prefix = root_dir.to_string_lossy().into_owned();
     let mut current = input.clone();
+    let mut has_filter_log = false;
     for pnpmfile in &pnpmfiles {
         let hooks = finder::load_pnpmfile_at(pnpmfile.clone());
         let ctx = HookContext { log: hook_logger::<Reporter>(pnpmfile, &prefix), dir: None };
@@ -530,6 +531,15 @@ pub async fn run_update_config_hooks<Reporter: self::Reporter>(
             .wrap_err_with(|| {
             format!("running updateConfig hook from {}", pnpmfile.display())
         })?;
+        has_filter_log |= hooks.has_filter_log().await;
+    }
+    if has_filter_log {
+        Reporter::emit(&LogEvent::Pnpm(PnpmLog {
+            level: LogLevel::Warn,
+            message: "The pnpmfile filterLog hook is deprecated and is not supported by pnpm v12. Remove it from the pnpmfile."
+                .to_string(),
+            prefix: prefix.clone(),
+        }));
     }
 
     // Adopt the hook output's catalogs wholesale into `Config::catalogs`

--- a/pnpm/crates/cli/tests/suite/hooks.rs
+++ b/pnpm/crates/cli/tests/suite/hooks.rs
@@ -1,0 +1,24 @@
+use crate::_utils::pacquet_in;
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pnpm_testing_utils::bin::CommandTempCwd;
+use std::fs;
+
+#[test]
+fn filter_log_is_ignored_with_a_warning() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("package.json"), "{}").expect("write package.json");
+    fs::write(
+        workspace.join(".pnpmfile.cjs"),
+        "module.exports = { hooks: { filterLog: () => false } }",
+    )
+    .expect("write filterLog hook");
+    fs::write(workspace.join("pnpm-lock.yaml"), "not: [valid").expect("write broken lockfile");
+
+    let output = pacquet_in(&workspace).with_arg("install").assert().success();
+    let stdout = String::from_utf8_lossy(&output.get_output().stdout);
+    assert!(stdout.contains("filterLog hook is deprecated"), "STDOUT:\n{stdout}");
+    assert!(stdout.contains("Ignoring broken lockfile"), "STDOUT:\n{stdout}");
+
+    drop(root);
+}

--- a/pnpm/crates/cli/tests/suite/main.rs
+++ b/pnpm/crates/cli/tests/suite/main.rs
@@ -52,6 +52,7 @@ mod global_shims;
 mod global_virtual_store;
 mod hoist;
 mod hoisted_node_linker;
+mod hooks;
 mod ignore_workspace;
 mod import;
 mod init;

--- a/pnpm/crates/hooks/src/lib.rs
+++ b/pnpm/crates/hooks/src/lib.rs
@@ -149,6 +149,11 @@ pub trait PnpmfileHooks: Send + Sync {
     /// `filterLog` hook: determines if a log message should be emitted.
     async fn filter_log(&self, log: Value, ctx: HookContext) -> bool;
 
+    /// Whether this pnpmfile exports a callable `filterLog` hook.
+    async fn has_filter_log(&self) -> bool {
+        false
+    }
+
     /// Compute the `pnpmfileChecksum` recorded in `pnpm-lock.yaml`, or
     /// `None` when this hook set defines no `hooks` object.
     ///

--- a/pnpm/crates/hooks/src/node_runtime.rs
+++ b/pnpm/crates/hooks/src/node_runtime.rs
@@ -322,6 +322,13 @@ impl crate::PnpmfileHooks for NodeJsHooks {
         }
     }
 
+    async fn has_filter_log(&self) -> bool {
+        match self.worker().await {
+            Ok(worker) => worker.has_filter_log().await,
+            Err(_) => false,
+        }
+    }
+
     async fn calculate_pnpmfile_checksum(&self) -> Option<String> {
         // Gate on the loaded module exporting `hooks`, mirroring pnpm's
         // `entries.some(entry => entry.hooks != null)`. The checksum

--- a/pnpm/crates/hooks/src/worker.rs
+++ b/pnpm/crates/hooks/src/worker.rs
@@ -214,6 +214,20 @@ impl NodeWorker {
             .unwrap_or(false)
     }
 
+    /// Whether the loaded pnpmfile exports a callable `filterLog` hook.
+    pub async fn has_filter_log(&self) -> bool {
+        self.request(
+            "hasFilterLog",
+            serde_json::json!({ "query": "hasFilterLog" }),
+            Arc::new(|_| {}),
+        )
+        .await
+        .ok()
+        .as_ref()
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    }
+
     /// Call `method` on the custom resolver at `index` in the pnpmfile's
     /// `resolvers` array, forwarding any `context.log(...)` to `log`.
     pub async fn call_resolver(
@@ -458,6 +472,10 @@ async function handle(req) {{
   await ensureLoaded();
   if (loadErr !== null) {{ send({{ err: loadErr }}); return; }}
   if (req.query === 'hasHooks') {{ send({{ ok: mod != null && mod.hooks != null }}); return; }}
+  if (req.query === 'hasFilterLog') {{
+    send({{ ok: mod != null && mod.hooks != null && typeof mod.hooks.filterLog === 'function' }});
+    return;
+  }}
   try {{
     const fn = mod && mod.hooks && mod.hooks[req.hook];
     const context = {{ log: (m) => send({{ log: String(m) }}) }};

--- a/pnpm/crates/hooks/tests/node_hooks.rs
+++ b/pnpm/crates/hooks/tests/node_hooks.rs
@@ -205,6 +205,8 @@ function filterLog(log) {
 
     let hooks = pnpm_hooks::node_runtime::NodeJsHooks::new(pnpmfile_path);
 
+    assert!(hooks.has_filter_log().await);
+
     let debug_log = serde_json::json!({
         "level": "debug",
         "message": "test debug"
@@ -595,6 +597,7 @@ async fn update_config_without_hook_returns_config_unchanged() {
     let config = serde_json::json!({ "registry": "https://r/" });
     let updated = hooks.update_config(config.clone(), noop_context()).await.expect("ok");
 
+    assert!(!hooks.has_filter_log().await);
     assert_eq!(updated, config, "a pnpmfile without updateConfig leaves config unchanged");
 }
 


### PR DESCRIPTION
## Summary

- Closes pnpm/pnpm#12118 by settling the final unfinished pnpmfile-hook item.
- Detects a callable `filterLog` export during the existing pnpmfile setup and warns once that pnpm v12 ignores it.
- Keeps pnpm 11 behavior unchanged and deliberately does not port filtering to the Rust reporter, where each eligible log would require a synchronous Node.js IPC round trip.
- Adds capability and end-to-end coverage proving the warning appears and the hook does not suppress output.

## Squash Commit Body

```text
The Rust v12 CLI would have to cross the persistent Node worker IPC boundary
for every eligible reportable event to implement filterLog. That cost is a bad
fit for the reporter hot path.

Detect a callable filterLog export once while the pnpmfile worker is already
active, warn that v12 ignores the deprecated hook, and leave emitted logs
unchanged.

Closes pnpm/pnpm#12118.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790254016&installation_model_id=426870&pr_number=14157&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14157&signature=867dd37941bcdd7dc288d5ae6ef79dcb77ad2f7c92c1b70d0227e1f63892750b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deprecated `filterLog` hooks are now ignored by the CLI instead of being invoked for log messages.
  * A warning is displayed when a pnpmfile uses the deprecated hook.
  * Installation continues successfully while clearly reporting related lockfile issues.

* **Tests**
  * Added coverage for detecting, warning about, and ignoring `filterLog` hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->