### PR TITLE
fix(cli): install workspace root under filters

### DIFF
--- a/.changeset/filtered-installs-include-root.md
+++ b/.changeset/filtered-installs-include-root.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Fixed filtered `install`, `add`, `update`, and `remove` commands to install the workspace root alongside the selected projects [pnpm/pnpm#13397](https://github.com/pnpm/pnpm/issues/13397).
+Fixed filtered `install`, `add`, `update`, and `remove` commands in shared-lockfile workspaces to install the workspace root alongside the selected projects [pnpm/pnpm#13397](https://github.com/pnpm/pnpm/issues/13397).

--- a/.changeset/filtered-installs-include-root.md
+++ b/.changeset/filtered-installs-include-root.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed filtered `install`, `add`, `update`, and `remove` commands to install the workspace root alongside the selected projects [pnpm/pnpm#13397](https://github.com/pnpm/pnpm/issues/13397).

--- a/pnpm/crates/cli/src/cli_args/add.rs
+++ b/pnpm/crates/cli/src/cli_args/add.rs
@@ -375,6 +375,7 @@ impl AddArgs {
             ordered_groups,
             ordered_dirs,
             selected_dirs,
+            install_dirs,
             active_manifest_is_standin,
         } = selection;
         let lockfile_path = state.lockfile_path();
@@ -404,6 +405,7 @@ impl AddArgs {
             &ordered_groups,
             &ordered_dirs,
             selected_dirs.as_ref(),
+            install_dirs.as_ref(),
             active_manifest_is_standin,
         )
         .await

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -693,6 +693,7 @@ fn workspace_install_selection(
         ordered_groups: &selection.ordered_groups,
         ordered_dirs: &selection.ordered_dirs,
         selected_dirs: selection.selected_dirs.as_ref(),
+        install_dirs: selection.install_dirs.as_ref(),
         active_manifest_is_standin: selection.active_manifest_is_standin,
     }
 }
@@ -862,7 +863,7 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
             })
             .collect();
         let selected_importer_ids = selection
-            .selected_dirs
+            .install_dirs
             .iter()
             .map(|project_dir| {
                 pnpm_workspace::importer_id_from_root_dir(importer_root, project_dir)

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -39,6 +39,7 @@ pub(crate) struct InstallFamilySelection {
     pub(crate) ordered_groups: Vec<Vec<PathBuf>>,
     pub(crate) ordered_dirs: Vec<PathBuf>,
     pub(crate) selected_dirs: Arc<HashSet<PathBuf>>,
+    pub(crate) install_dirs: Arc<HashSet<PathBuf>>,
     pub(crate) active_manifest_is_standin: bool,
 }
 
@@ -172,7 +173,8 @@ pub(crate) fn select_workspace_projects(
             vec![selection.selected.keys().cloned().collect()]
         };
         let ordered_dirs = ordered_groups.iter().flatten().cloned().collect();
-        let selected_dirs = Arc::new(selection.selected.keys().cloned().collect());
+        let selected_dirs: Arc<HashSet<PathBuf>> =
+            Arc::new(selection.selected.keys().cloned().collect());
         (ordered_groups, ordered_dirs, selected_dirs)
     };
 
@@ -185,6 +187,14 @@ pub(crate) fn select_workspace_projects(
         && !projects
             .iter()
             .any(|project| pnpm_fs::lexical_normalize(&project.root_dir) == normalized_active_dir);
+    let normalized_workspace_root = pnpm_fs::lexical_normalize(&workspace_root);
+    let mut install_dirs = selected_dirs.as_ref().clone();
+    if let Some(workspace_root_project) = projects
+        .iter()
+        .find(|project| pnpm_fs::lexical_normalize(&project.root_dir) == normalized_workspace_root)
+    {
+        install_dirs.insert(workspace_root_project.root_dir.clone());
+    }
 
     Ok(Some(InstallFamilySelection {
         workspace_root,
@@ -192,6 +202,7 @@ pub(crate) fn select_workspace_projects(
         ordered_groups,
         ordered_dirs,
         selected_dirs,
+        install_dirs: Arc::new(install_dirs),
         active_manifest_is_standin,
     }))
 }

--- a/pnpm/crates/cli/src/cli_args/rebuild.rs
+++ b/pnpm/crates/cli/src/cli_args/rebuild.rs
@@ -237,6 +237,7 @@ pub(crate) async fn run_rebuild<Reporter: self::Reporter + 'static>(
                         ordered_groups: &selection.ordered_groups,
                         ordered_dirs: &selection.ordered_dirs,
                         selected_dirs: selection.selected_dirs.as_ref(),
+                        install_dirs: selection.selected_dirs.as_ref(),
                         active_manifest_is_standin: selection.active_manifest_is_standin,
                     },
                     rebuild,

--- a/pnpm/crates/cli/src/cli_args/remove.rs
+++ b/pnpm/crates/cli/src/cli_args/remove.rs
@@ -99,6 +99,7 @@ impl RemoveArgs {
             ordered_groups,
             ordered_dirs,
             selected_dirs,
+            install_dirs,
             active_manifest_is_standin,
         } = selection;
         let lockfile_path = state.lockfile_path();
@@ -126,6 +127,7 @@ impl RemoveArgs {
             &ordered_groups,
             &ordered_dirs,
             selected_dirs.as_ref(),
+            install_dirs.as_ref(),
             active_manifest_is_standin,
         )
         .await

--- a/pnpm/crates/cli/src/cli_args/update.rs
+++ b/pnpm/crates/cli/src/cli_args/update.rs
@@ -354,6 +354,7 @@ impl UpdateArgs {
             ordered_groups,
             ordered_dirs,
             selected_dirs,
+            install_dirs,
             active_manifest_is_standin,
         } = selection;
 
@@ -383,6 +384,7 @@ impl UpdateArgs {
                 &ordered_groups,
                 &ordered_dirs,
                 selected_dirs.as_ref(),
+                install_dirs.as_ref(),
                 active_manifest_is_standin,
             )
             .await

--- a/pnpm/crates/cli/tests/suite/install_filters.rs
+++ b/pnpm/crates/cli/tests/suite/install_filters.rs
@@ -238,6 +238,110 @@ fn filtered_remove_mutates_only_selected_importers() {
     assert_stage_once(&records);
 }
 
+fn workspace_with_installable_root(
+    selected_deps: ManifestDeps<'_>,
+) -> (WorkspaceFixture, std::path::PathBuf, std::path::PathBuf, Vec<u8>) {
+    let fixture = WorkspaceFixture::new();
+    fixture.write_root_manifest(
+        "workspace-root",
+        ManifestDeps { prod: &[(HELLO, "1.0.0")], ..Default::default() },
+    );
+    let selected = fixture.project("selected", "selected", selected_deps);
+    let unselected = fixture.project(
+        "unselected",
+        "unselected",
+        ManifestDeps { prod: &[(DEP, "100.0.0")], ..Default::default() },
+    );
+    let root_manifest = fs::read(fixture.workspace.join("package.json")).expect("read manifest");
+    (fixture, selected, unselected, root_manifest)
+}
+
+fn assert_root_and_selected_are_materialized(
+    fixture: &WorkspaceFixture,
+    selected: &Path,
+    unselected: &Path,
+    selected_dependency: &str,
+) {
+    assert!(has_link(&fixture.workspace, HELLO), "workspace root dependency must be linked");
+    assert!(has_link(selected, selected_dependency), "selected dependency must be linked");
+    assert!(
+        !unselected.join("node_modules").exists(),
+        "unselected project must not be materialized",
+    );
+    assert_eq!(
+        importer_ids(&fixture.current()),
+        BTreeSet::from([".".to_string(), "packages/selected".to_string()]),
+    );
+}
+
+#[test]
+fn filtered_install_materializes_the_workspace_root() {
+    let (fixture, selected, unselected, root_manifest) =
+        workspace_with_installable_root(ManifestDeps {
+            prod: &[(PARENT, "100.0.0")],
+            ..Default::default()
+        });
+
+    fixture.run(["--filter", "selected", "install"]);
+
+    assert_root_and_selected_are_materialized(&fixture, &selected, &unselected, PARENT);
+    assert_eq!(
+        fs::read(fixture.workspace.join("package.json")).expect("read manifest"),
+        root_manifest,
+    );
+}
+
+#[test]
+fn filtered_add_materializes_the_workspace_root_without_mutating_it() {
+    let (fixture, selected, unselected, root_manifest) =
+        workspace_with_installable_root(ManifestDeps::default());
+
+    fixture.run(["--filter", "selected", "add", PARENT]);
+
+    assert_root_and_selected_are_materialized(&fixture, &selected, &unselected, PARENT);
+    assert_eq!(dependency_spec(&selected, "dependencies", PARENT).as_deref(), Some("^100.1.0"));
+    assert_eq!(
+        fs::read(fixture.workspace.join("package.json")).expect("read manifest"),
+        root_manifest,
+    );
+}
+
+#[test]
+fn filtered_update_materializes_the_workspace_root_without_mutating_it() {
+    let (fixture, selected, unselected, root_manifest) =
+        workspace_with_installable_root(ManifestDeps {
+            prod: &[(DEP, "100.0.0")],
+            ..Default::default()
+        });
+
+    fixture.run(["--filter", "selected", "update", DEP, "--latest"]);
+
+    assert_root_and_selected_are_materialized(&fixture, &selected, &unselected, DEP);
+    assert_eq!(dependency_spec(&selected, "dependencies", DEP).as_deref(), Some("101.0.0"));
+    assert_eq!(
+        fs::read(fixture.workspace.join("package.json")).expect("read manifest"),
+        root_manifest,
+    );
+}
+
+#[test]
+fn filtered_remove_materializes_the_workspace_root_without_mutating_it() {
+    let (fixture, selected, unselected, root_manifest) =
+        workspace_with_installable_root(ManifestDeps {
+            prod: &[(HELLO, "1.0.0"), (PARENT, "100.0.0")],
+            ..Default::default()
+        });
+
+    fixture.run(["--filter", "selected", "remove", HELLO]);
+
+    assert_root_and_selected_are_materialized(&fixture, &selected, &unselected, PARENT);
+    assert_eq!(dependency_spec(&selected, "dependencies", HELLO), None);
+    assert_eq!(
+        fs::read(fixture.workspace.join("package.json")).expect("read manifest"),
+        root_manifest,
+    );
+}
+
 #[test]
 fn filtered_update_from_selected_child_uses_discovered_manifest_as_source_of_truth() {
     let fixture = WorkspaceFixture::new();

--- a/pnpm/crates/cli/tests/suite/lifecycle_scripts.rs
+++ b/pnpm/crates/cli/tests/suite/lifecycle_scripts.rs
@@ -2187,6 +2187,17 @@ mod project_scripts_in_a_workspace {
         drop((root, anchor));
     }
 
+    #[test]
+    fn filtered_bare_update_runs_the_selected_member_and_workspace_root() {
+        let (root, workspace, anchor) = installed_workspace(&["a", "b"]);
+
+        pacquet(&workspace, ["--filter", "a", "update"]).assert().success();
+
+        assert_ran(&workspace, &["root", "a"], &["root", "a", "b"]);
+
+        drop((root, anchor));
+    }
+
     /// Run at the workspace root, an update mutates the root alone: the
     /// members are materialized from the lockfile but run no scripts.
     #[test]

--- a/pnpm/crates/cli/tests/suite/patch.rs
+++ b/pnpm/crates/cli/tests/suite/patch.rs
@@ -1555,9 +1555,9 @@ fn unused_patch_warns_when_allow_unused_patches_is_set() {
     drop((root, mock_instance));
 }
 
-/// pnpm only verifies patch usage when every workspace importer was part
-/// of the resolution, so a filtered install must not fail on an unused
-/// patch.
+/// pnpm only verifies patch usage when the original project selection
+/// covers the workspace, so adding the workspace root to a filtered
+/// install must not make an unused patch fail.
 #[test]
 fn unused_patch_is_not_checked_on_a_filtered_install() {
     let CommandTempCwd { root, workspace, npmrc_info, .. } =

--- a/pnpm/crates/cli/tests/suite/patch.rs
+++ b/pnpm/crates/cli/tests/suite/patch.rs
@@ -1493,6 +1493,51 @@ fn setup_configured_patch_with_allow_unused(
     (root, workspace, npmrc_info)
 }
 
+fn setup_filtered_patch_workspace() -> (TempDir, std::path::PathBuf, AddMockedRegistry) {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    fs::write(workspace.join("package.json"), serde_json::json!({}).to_string())
+        .expect("write root package.json");
+    let project = workspace.join("packages").join("pkg-a");
+    fs::create_dir_all(&project).expect("create pkg-a dir");
+    fs::write(
+        project.join("package.json"),
+        serde_json::json!({
+            "name": "pkg-a",
+            "dependencies": {
+                "is-positive": "1.0.0",
+            },
+        })
+        .to_string(),
+    )
+    .expect("write pkg-a package.json");
+    fs::create_dir_all(workspace.join("patches")).expect("create patches dir");
+    fs::write(workspace.join("patches").join("is-positive@1.0.0.patch"), IS_POSITIVE_PATCH)
+        .expect("write patch file");
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    if !workspace_yaml.ends_with('\n') {
+        workspace_yaml.push('\n');
+    }
+    workspace_yaml.push_str(concat!(
+        "packages:\n",
+        "  - 'packages/*'\n",
+        "patchedDependencies:\n",
+        "  is-positive@1.0.0: patches/is-positive@1.0.0.patch\n",
+    ));
+    fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
+    (root, workspace, npmrc_info)
+}
+
+fn append_unused_filtered_patch(workspace: &Path) {
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    workspace_yaml.push_str("  is-negative@1.0.0: patches/is-positive@1.0.0.patch\n");
+    fs::write(workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
+}
+
 #[test]
 fn unused_patch_fails_with_err_pnpm_unused_patch() {
     let (root, workspace, npmrc_info) = setup_configured_patch_with_allow_unused(
@@ -1555,45 +1600,12 @@ fn unused_patch_warns_when_allow_unused_patches_is_set() {
     drop((root, mock_instance));
 }
 
-/// pnpm only verifies patch usage when the original project selection
-/// covers the workspace, so adding the workspace root to a filtered
-/// install must not make an unused patch fail.
+/// pnpm skips patch usage validation when a first filtered install's
+/// previous wanted lockfile does not cover every resolved importer.
 #[test]
 fn unused_patch_is_not_checked_on_a_filtered_install() {
-    let CommandTempCwd { root, workspace, npmrc_info, .. } =
-        CommandTempCwd::init().add_mocked_registry();
-    fs::write(workspace.join("package.json"), serde_json::json!({}).to_string())
-        .expect("write root package.json");
-    let project = workspace.join("packages").join("pkg-a");
-    fs::create_dir_all(&project).expect("create pkg-a dir");
-    fs::write(
-        project.join("package.json"),
-        serde_json::json!({
-            "name": "pkg-a",
-            "dependencies": {
-                "is-positive": "1.0.0",
-            },
-        })
-        .to_string(),
-    )
-    .expect("write pkg-a package.json");
-    fs::create_dir_all(workspace.join("patches")).expect("create patches dir");
-    fs::write(workspace.join("patches").join("is-positive@1.0.0.patch"), IS_POSITIVE_PATCH)
-        .expect("write patch file");
-    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
-    let mut workspace_yaml =
-        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
-    if !workspace_yaml.ends_with('\n') {
-        workspace_yaml.push('\n');
-    }
-    workspace_yaml.push_str(concat!(
-        "packages:\n",
-        "  - 'packages/*'\n",
-        "patchedDependencies:\n",
-        "  is-positive@1.0.0: patches/is-positive@1.0.0.patch\n",
-        "  is-negative@1.0.0: patches/is-positive@1.0.0.patch\n",
-    ));
-    fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
+    let (root, workspace, npmrc_info) = setup_filtered_patch_workspace();
+    append_unused_filtered_patch(&workspace);
     let AddMockedRegistry { mock_instance, .. } = npmrc_info;
 
     let output =
@@ -1604,6 +1616,29 @@ fn unused_patch_is_not_checked_on_a_filtered_install() {
     assert!(
         !stderr.contains("ERR_PNPM_UNUSED_PATCH"),
         "filtered install should not run the unused-patch check: {stderr}",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// A filtered selection augmented with the workspace root covers every
+/// importer once the previous wanted lockfile does too, so pnpm validates
+/// unused patches.
+#[test]
+fn unused_patch_is_checked_for_a_complete_root_augmented_filtered_install() {
+    let (root, workspace, npmrc_info) = setup_filtered_patch_workspace();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    pacquet(&workspace, ["install"]).assert().success();
+    append_unused_filtered_patch(&workspace);
+
+    let output =
+        pacquet(&workspace, ["install", "--filter", "pkg-a"]).output().expect("run install");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "complete filtered install should fail: {stderr}");
+    assert!(
+        stderr.contains("ERR_PNPM_UNUSED_PATCH"),
+        "complete filtered install should run the unused-patch check: {stderr}",
     );
 
     drop((root, mock_instance));

--- a/pnpm/crates/cli/tests/suite/pnpr_install.rs
+++ b/pnpm/crates/cli/tests/suite/pnpr_install.rs
@@ -783,6 +783,7 @@ fn assert_filtered_workspace_pnpr(lockfile_only: bool) {
         .to_string(),
     )
     .expect("add workspace root dependency");
+    let root_manifest = fs::read(workspace.join("package.json")).expect("read root manifest");
     replace_workspace_dependency(&workspace, "selected", (WORKSPACE_HELLO, "1.0.0"));
     replace_workspace_dependency(&workspace, "unselected", (WORKSPACE_HELLO_PARENT, "1.0.0"));
     let unselected_manifest =
@@ -813,6 +814,10 @@ fn assert_filtered_workspace_pnpr(lockfile_only: bool) {
     assert!(workspace_snapshot_entries(&after, WORKSPACE_HELLO_PARENT).is_empty());
     assert_eq!(workspace_importer_version(&after, "packages/selected", WORKSPACE_HELLO), "1.0.0");
     assert_eq!(workspace_importer_version(&after, ".", WORKSPACE_ROOT_DEP), "1.0.0");
+    assert_eq!(
+        fs::read(workspace.join("package.json")).expect("read root manifest"),
+        root_manifest,
+    );
 
     if lockfile_only {
         assert!(!workspace.join("node_modules").exists());

--- a/pnpm/crates/cli/tests/suite/pnpr_install.rs
+++ b/pnpm/crates/cli/tests/suite/pnpr_install.rs
@@ -757,7 +757,6 @@ fn assert_filtered_workspace_pnpr(lockfile_only: bool) {
             "name": "workspace-root",
             "version": "1.0.0",
             "private": true,
-            "dependencies": { WORKSPACE_ROOT_DEP: "1.0.0" },
         })
         .to_string(),
     )
@@ -773,6 +772,17 @@ fn assert_filtered_workspace_pnpr(lockfile_only: bool) {
     let prior_unselected = workspace_importer(&before, "packages/unselected").clone();
     let prior_parent = workspace_snapshot_entries(&before, WORKSPACE_PARENT);
     let prior_child = workspace_snapshot_entries(&before, WORKSPACE_DEP);
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "name": "workspace-root",
+            "version": "1.0.0",
+            "private": true,
+            "dependencies": { WORKSPACE_ROOT_DEP: "1.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("add workspace root dependency");
     replace_workspace_dependency(&workspace, "selected", (WORKSPACE_HELLO, "1.0.0"));
     replace_workspace_dependency(&workspace, "unselected", (WORKSPACE_HELLO_PARENT, "1.0.0"));
     let unselected_manifest =

--- a/pnpm/crates/cli/tests/suite/pnpr_install.rs
+++ b/pnpm/crates/cli/tests/suite/pnpr_install.rs
@@ -484,6 +484,7 @@ const WORKSPACE_DEP: &str = "@pnpm.e2e/dep-of-pkg-with-1-dep";
 const WORKSPACE_HELLO: &str = "@pnpm.e2e/hello-world-js-bin";
 const WORKSPACE_HELLO_PARENT: &str = "@pnpm.e2e/hello-world-js-bin-parent";
 const WORKSPACE_PARENT: &str = "@pnpm.e2e/pkg-with-1-dep";
+const WORKSPACE_ROOT_DEP: &str = "@foo/no-deps";
 const MISSING_PEERS_PARENT: &str = "@pnpm.e2e/abc-parent-with-missing-peers";
 
 fn configure_workspace(workspace: &Path) {
@@ -750,6 +751,17 @@ fn assert_filtered_workspace_pnpr(lockfile_only: bool) {
         CommandTempCwd::init().add_mocked_registry();
     let AddMockedRegistry { npmrc_path, store_dir, mock_instance, .. } = npmrc_info;
     configure_workspace(&workspace);
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "name": "workspace-root",
+            "version": "1.0.0",
+            "private": true,
+            "dependencies": { WORKSPACE_ROOT_DEP: "1.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write workspace root manifest");
     write_workspace_project(&workspace, "selected", "selected", (WORKSPACE_HELLO, "0.0.0"));
     write_workspace_project(&workspace, "unselected", "unselected", (WORKSPACE_PARENT, "100.0.0"));
     pacquet_at(&workspace)
@@ -790,12 +802,17 @@ fn assert_filtered_workspace_pnpr(lockfile_only: bool) {
     assert_eq!(workspace_snapshot_entries(&after, WORKSPACE_DEP), prior_child);
     assert!(workspace_snapshot_entries(&after, WORKSPACE_HELLO_PARENT).is_empty());
     assert_eq!(workspace_importer_version(&after, "packages/selected", WORKSPACE_HELLO), "1.0.0");
-    assert!(!after.importers.contains_key("."));
+    assert_eq!(workspace_importer_version(&after, ".", WORKSPACE_ROOT_DEP), "1.0.0");
 
     if lockfile_only {
         assert!(!workspace.join("node_modules").exists());
         assert!(!store_dir.join("v11/index.db").exists());
     } else {
+        assert!(
+            is_symlink_or_junction(&workspace.join("node_modules").join(WORKSPACE_ROOT_DEP))
+                .unwrap_or(false),
+            "workspace root dependency must be linked",
+        );
         assert!(workspace_has_link(&workspace, "selected", WORKSPACE_HELLO));
         assert!(!workspace.join("packages/unselected/node_modules").exists());
         assert!(workspace_slot(&workspace, WORKSPACE_HELLO, "1.0.0").exists());
@@ -805,7 +822,7 @@ fn assert_filtered_workspace_pnpr(lockfile_only: bool) {
         let current = read_workspace_current_lockfile(&workspace);
         assert_eq!(
             current.importers.keys().cloned().collect::<std::collections::BTreeSet<_>>(),
-            std::collections::BTreeSet::from(["packages/selected".to_string()]),
+            std::collections::BTreeSet::from([".".to_string(), "packages/selected".to_string()]),
         );
     }
 
@@ -813,12 +830,12 @@ fn assert_filtered_workspace_pnpr(lockfile_only: bool) {
 }
 
 #[test]
-fn filtered_workspace_install_via_pnpr_materializes_only_selected_closure() {
+fn filtered_workspace_install_via_pnpr_materializes_the_root_and_selected_closure() {
     assert_filtered_workspace_pnpr(false);
 }
 
 #[test]
-fn filtered_workspace_pnpr_lockfile_only_merges_prior_wanted_without_root_importer() {
+fn filtered_workspace_pnpr_lockfile_only_merges_the_root_and_selected_importers() {
     assert_filtered_workspace_pnpr(true);
 }
 

--- a/pnpm/crates/package-manager/src/add.rs
+++ b/pnpm/crates/package-manager/src/add.rs
@@ -345,6 +345,7 @@ where
         ordered_groups: &[Vec<PathBuf>],
         ordered_dirs: &[PathBuf],
         selected_dirs: &HashSet<PathBuf>,
+        install_dirs: &HashSet<PathBuf>,
         active_manifest_is_standin: bool,
     ) -> Result<(), AddError> {
         let Add {
@@ -478,6 +479,7 @@ where
                 ordered_groups,
                 ordered_dirs,
                 selected_dirs,
+                install_dirs,
                 active_manifest_is_standin,
             }),
         )

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -230,7 +230,12 @@ pub struct WorkspaceInstallSelection<'a> {
     pub all_projects: &'a [pnpm_workspace::Project],
     pub ordered_groups: &'a [Vec<PathBuf>],
     pub ordered_dirs: &'a [PathBuf],
+    /// Projects chosen by the original filter. Manifest mutations stay
+    /// scoped to these projects.
     pub selected_dirs: &'a HashSet<PathBuf>,
+    /// Importers to materialize: [`Self::selected_dirs`] plus an omitted
+    /// workspace root that pnpm treats as a full-install importer.
+    pub install_dirs: &'a HashSet<PathBuf>,
     pub active_manifest_is_standin: bool,
 }
 

--- a/pnpm/crates/package-manager/src/install/run.rs
+++ b/pnpm/crates/package-manager/src/install/run.rs
@@ -300,6 +300,15 @@ where
             ),
             None => build_project_manifests_list(manifest, workspace_projects),
         };
+        let install_importer_ids = selection.as_ref().map(|selection| {
+            selection
+                .install_dirs
+                .iter()
+                .map(|project_dir| {
+                    pnpm_workspace::importer_id_from_root_dir(&workspace_root, project_dir)
+                })
+                .collect::<HashSet<_>>()
+        });
         let selected_importer_ids = selection.as_ref().map(|selection| {
             selection
                 .selected_dirs
@@ -318,7 +327,7 @@ where
         let filtered_install = selected_importer_ids
             .as_ref()
             .is_some_and(|selected_importer_ids| selected_importer_ids != &real_importer_ids);
-        let requested_importer_ids = if filtered_install { selected_importer_ids } else { None };
+        let requested_importer_ids = if filtered_install { install_importer_ids } else { None };
         // Only an install that covers a whole workspace sees the complete
         // project list, so only it may conclude that an importer the
         // lockfile records belongs to a project that is gone. This is
@@ -634,7 +643,7 @@ where
             Some(selection) => selected_manifest_freshness_inputs(
                 &workspace_root,
                 &project_manifests,
-                selection.selected_dirs,
+                selection.install_dirs,
             ),
             None => project_manifests
                 .iter()

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1110,12 +1110,21 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         .await
         .map_err(InstallWithFreshLockfileError::MinimumReleaseAge)?;
         // Only in the fresh-lockfile path — frozen lockfile trusts recorded
-        // patches. Skipped for a filtered install (`--filter`), matching
-        // pnpm's importer-count gate. An omitted workspace root may still be
-        // added to the resolution, but that does not broaden the original
-        // project selection for workspace-wide validation.
+        // patches. pnpm's importer-count gate admits an unfiltered run, or a
+        // filtered run whose root-augmented selection and previous wanted
+        // lockfile both cover the complete workspace. A first filtered
+        // install has no complete previous lockfile and skips this check.
+        let verify_patch_usage = match selected_importer_ids {
+            None => true,
+            Some(selected_importer_ids) => {
+                !is_partial_workspace_selection(real_importer_ids, Some(selected_importer_ids))
+                    && wanted_lockfile.is_some_and(|wanted_lockfile| {
+                        wanted_lockfile.importers.len() == selected_importer_ids.len()
+                    })
+            }
+        };
         if let Some(ref deps) = patched_dependencies
-            && selected_importer_ids.is_none()
+            && verify_patch_usage
         {
             match pnpm_patching::verify_patches(
                 deps,

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1111,10 +1111,11 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         .map_err(InstallWithFreshLockfileError::MinimumReleaseAge)?;
         // Only in the fresh-lockfile path — frozen lockfile trusts recorded
         // patches. Skipped for a filtered install (`--filter`), matching
-        // pnpm's importer-count gate: pnpm only verifies patches when every
-        // workspace importer was part of the resolution.
+        // pnpm's importer-count gate. An omitted workspace root may still be
+        // added to the resolution, but that does not broaden the original
+        // project selection for workspace-wide validation.
         if let Some(ref deps) = patched_dependencies
-            && !is_partial_workspace_selection(real_importer_ids, selected_importer_ids)
+            && selected_importer_ids.is_none()
         {
             match pnpm_patching::verify_patches(
                 deps,

--- a/pnpm/crates/package-manager/src/remove.rs
+++ b/pnpm/crates/package-manager/src/remove.rs
@@ -173,6 +173,7 @@ impl Remove<'_> {
         ordered_groups: &[Vec<std::path::PathBuf>],
         ordered_dirs: &[std::path::PathBuf],
         selected_dirs: &HashSet<std::path::PathBuf>,
+        install_dirs: &HashSet<std::path::PathBuf>,
         active_manifest_is_standin: bool,
     ) -> Result<(), RemoveError> {
         let Remove {
@@ -245,6 +246,7 @@ impl Remove<'_> {
             ordered_groups,
             ordered_dirs,
             selected_dirs,
+            install_dirs,
             active_manifest_is_standin,
         })
         .await

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -483,6 +483,7 @@ impl Update<'_> {
         ordered_groups: &[Vec<PathBuf>],
         ordered_dirs: &[PathBuf],
         selected_dirs: &HashSet<PathBuf>,
+        install_dirs: &HashSet<PathBuf>,
         active_manifest_is_standin: bool,
     ) -> Result<(), UpdateError> {
         let Update {
@@ -624,6 +625,7 @@ impl Update<'_> {
             ordered_groups,
             ordered_dirs,
             selected_dirs,
+            install_dirs,
             active_manifest_is_standin,
         };
         match lockfile_specifier_project_manifests {


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Closes pnpm/pnpm#13397.

Filtered `install`, `add`, `update`, and `remove` commands in shared-lockfile workspaces in the Rust CLI now materialize the workspace root alongside filtered projects while keeping manifest mutations scoped to the original selection. The same root importer is included in pnpr requests and workspace-root lifecycle scripts.

The TypeScript CLI already implements this behavior by adding the workspace root as an install-only mutation, so no TypeScript source change is needed. Regression coverage includes all four install-family commands, pnpr install and lockfile-only paths, lifecycle execution, and filtered unused-patch validation.

## Squash Commit Body

```text
Keep manifest-mutation selection separate from importer materialization selection.
Filtered shared-lockfile install-family commands now install the workspace root without mutating its
manifest. Preserve filtered validation and cleanup semantics while including the root
in lifecycle execution and pnpr requests.

Closes pnpm/pnpm#13397.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790254490&installation_model_id=426870&pr_number=14158&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14158&signature=19fb4dbc1c57324f411a6af2d1c072e573a84d8fb443468df38ba51c4a12d3de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Filtered `install`, `add`, `update`, and `remove` commands now install the workspace root when it has an installable manifest.
  * Unselected workspace projects remain untouched.
  * Workspace lifecycle scripts run for both the selected project and workspace root.
  * Patch validation now correctly handles filtered installations, including unused patches.

* **Tests**
  * Added coverage for root dependency linking, importer tracking, lifecycle scripts, and patch validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->