### PR TITLE
docs: warn against installing pnpm with Corepack

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,7 @@ The repository holds two implementations of the same package manager: the TypeSc
 
 ### JavaScript and TypeScript CLI
 
+1. Install pnpm using one of the [official installation methods](https://pnpm.io/installation). **Do not use Corepack.** The scripts in this repository invoke pnpm through the `pn` and `pnx` aliases, which the official installation methods create. Corepack only provides the `pnpm` and `pnpx` commands, so with a Corepack-managed pnpm the build fails with errors like `pn: Permission denied` ([pnpm/pnpm#12448](https://github.com/pnpm/pnpm/issues/12448)).
 1. Run `pnpm install` in the root of the repository to install all dependencies.
 1. Run `pnpm add ./pnpm/dev -g` to make pnpm from the repository available in the command line via the `pd` command.
 1. Run `pnpm run compile` to create an initial build of pnpm from the source in the repository.


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Adds a prerequisite step to the "JavaScript and TypeScript CLI" setup section of `CONTRIBUTING.md`: install pnpm via one of the [official installation methods](https://pnpm.io/installation) and do not use Corepack.

The repository's scripts invoke pnpm through the `pn`/`pnx` aliases, which the official installers create but Corepack does not (it only shims `pnpm` and `pnpx`), so a Corepack-managed setup fails with confusing errors like `pn: Permission denied` when running `pnpm run compile`. Related to pnpm/pnpm#12448.

## Squash Commit Body

```text
The repository's scripts invoke pnpm through the pn and pnx aliases,
which the official installation methods create but Corepack does not,
so a Corepack-managed pnpm fails with errors like "pn: Permission
denied". Document that contributors must install pnpm via an official
installation method, not Corepack.

Related to https://github.com/pnpm/pnpm/issues/12448
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790254778&installation_model_id=426870&pr_number=14159&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14159&signature=88df1b9d7c1d4ac5038c6fa9d9f5d868792358bcd13f6d1eed46539e599e2e85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI setup instructions to recommend installing pnpm through official methods.
  * Clarified that Corepack should not be used.
  * Documented required `pn` and `pnx` command aliases for repository scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->