### PR TITLE
fix: enforce git prepare approvals on store reuse

### DIFF
--- a/.changeset/tough-flies-approve.md
+++ b/.changeset/tough-flies-approve.md
@@ -1,0 +1,14 @@
+---
+'@pnpm/exec.prepare-package': patch
+'@pnpm/fetching.fetcher-base': patch
+'@pnpm/fetching.git-fetcher': patch
+'@pnpm/fetching.tarball-fetcher': patch
+'@pnpm/installing.package-requester': patch
+'@pnpm/store.cafs': patch
+'@pnpm/store.cafs-types': patch
+'@pnpm/worker': patch
+'pacquet': patch
+'pnpm': patch
+---
+
+Enforce `allowBuilds` when a prepared git dependency is reused from the shared store, and use the lockfile's canonical git resolution ID in approval suggestions.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6622,6 +6622,9 @@ importers:
       '@pnpm/error':
         specifier: workspace:*
         version: link:../../core/error
+      '@pnpm/exec.prepare-package':
+        specifier: workspace:*
+        version: link:../../exec/prepare-package
       '@pnpm/fetching.fetcher-base':
         specifier: workspace:*
         version: link:../../fetching/fetcher-base

--- a/pnpm/crates/cli/tests/suite/git_hosted_install.rs
+++ b/pnpm/crates/cli/tests/suite/git_hosted_install.rs
@@ -473,6 +473,51 @@ fn run_prepare_script_for_git_hosted_dependencies() {
 }
 
 #[test]
+fn prepared_git_package_in_shared_store_still_requires_project_approval() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let repo = GitRepoFixture::init(root.path(), "shared-prepare");
+    repo.write_file(
+        "package.json",
+        r#"{"name":"shared-prepare","version":"1.0.0","files":["package.json","prepare.txt"],"scripts":{"prepare":"node -e \"require('fs').writeFileSync('prepare.txt', 'prepared')\""}}"#,
+    );
+    let commit = repo.commit("init");
+    let spec = repo.git_url_at(&commit);
+    write_dependencies(&workspace, &[("shared-prepare", &spec)]);
+    allow_builds(&workspace, &[&format!("shared-prepare@{spec}")]);
+
+    pacquet.with_arg("install").assert().success();
+    assert!(workspace.join("node_modules/shared-prepare/prepare.txt").exists());
+
+    let workspace_b = root.path().join("workspace-b");
+    fs::create_dir(&workspace_b).expect("create second workspace");
+    fs::copy(workspace.join(".npmrc"), workspace_b.join(".npmrc"))
+        .expect("copy shared-store npmrc");
+    fs::copy(workspace.join("pnpm-workspace.yaml"), workspace_b.join("pnpm-workspace.yaml"))
+        .expect("copy shared-store workspace config");
+    let workspace_b_yaml = fs::read_to_string(workspace_b.join("pnpm-workspace.yaml"))
+        .expect("read second workspace config");
+    let (workspace_b_yaml, _) = workspace_b_yaml
+        .split_once("allowBuilds:")
+        .expect("the first workspace has an allowBuilds block");
+    fs::write(workspace_b.join("pnpm-workspace.yaml"), workspace_b_yaml)
+        .expect("remove build approval from second workspace");
+    write_dependencies(&workspace_b, &[("shared-prepare", &spec)]);
+
+    let output =
+        pnpm_at(&workspace_b).with_arg("install").output().expect("install from warm store");
+    dbg!(&output);
+    assert!(!output.status.success(), "the unapproved warm-store install unexpectedly succeeded");
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED"),
+        "stderr did not report the build-policy failure",
+    );
+    assert!(!workspace_b.join("node_modules/shared-prepare/prepare.txt").exists());
+
+    drop((root, npmrc_info));
+}
+
+#[test]
 fn type_git_dependency_reuses_side_effects_on_warm_install() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();

--- a/pnpm/crates/cli/tests/suite/git_hosted_install.rs
+++ b/pnpm/crates/cli/tests/suite/git_hosted_install.rs
@@ -514,6 +514,35 @@ fn prepared_git_package_in_shared_store_still_requires_project_approval() {
     );
     assert!(!workspace_b.join("node_modules/shared-prepare/prepare.txt").exists());
 
+    let store_dir = pnpm_store_dir::StoreDir::from(npmrc_info.store_dir.clone());
+    let store_index_key = pnpm_store_dir::git_hosted_store_index_key(&spec, true);
+    let store_index = pnpm_store_dir::StoreIndex::open_in(&store_dir).expect("open store index");
+    let mut legacy_index = store_index
+        .get(&store_index_key)
+        .expect("read store index")
+        .expect("prepared git package is indexed");
+    assert_eq!(legacy_index.requires_prepare, Some(true));
+    legacy_index.requires_prepare = None;
+    store_index.set(&store_index_key, &legacy_index).expect("write legacy store index row");
+
+    let workspace_c = root.path().join("workspace-c");
+    fs::create_dir(&workspace_c).expect("create third workspace");
+    fs::copy(workspace.join(".npmrc"), workspace_c.join(".npmrc"))
+        .expect("copy shared-store npmrc");
+    fs::write(workspace_c.join("pnpm-workspace.yaml"), workspace_b_yaml)
+        .expect("write workspace config without build approval");
+    write_dependencies(&workspace_c, &[("shared-prepare", &spec)]);
+
+    let output =
+        pnpm_at(&workspace_c).with_arg("install").output().expect("install from legacy store");
+    dbg!(&output);
+    assert!(!output.status.success(), "the unapproved legacy-store install unexpectedly succeeded");
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED"),
+        "stderr did not report the build-policy failure",
+    );
+    assert!(!workspace_c.join("node_modules/shared-prepare/prepare.txt").exists());
+
     drop((root, npmrc_info));
 }
 

--- a/pnpm/crates/deps-restorer/src/build_modules/tests.rs
+++ b/pnpm/crates/deps-restorer/src/build_modules/tests.rs
@@ -1760,6 +1760,7 @@ async fn write_path_populates_side_effects_row() {
     let base_row = PackageFilesIndex {
         manifest: None,
         requires_build: Some(true),
+        requires_prepare: None,
         algo: HASH_ALGORITHM.to_string(),
         files: base_files,
         side_effects: None,
@@ -1901,6 +1902,7 @@ async fn write_path_disabled_skips_upload() {
     let base_row = PackageFilesIndex {
         manifest: None,
         requires_build: Some(true),
+        requires_prepare: None,
         algo: HASH_ALGORITHM.to_string(),
         files: HashMap::new(),
         side_effects: None,
@@ -2141,6 +2143,7 @@ async fn upload_error_does_not_interrupt_install() {
     let base_row = PackageFilesIndex {
         manifest: None,
         requires_build: Some(true),
+        requires_prepare: None,
         algo: HASH_ALGORITHM.to_string(),
         files: HashMap::new(),
         side_effects: None,
@@ -2351,6 +2354,7 @@ async fn write_path_cache_key_includes_patch_hash() {
     let base_row = PackageFilesIndex {
         manifest: None,
         requires_build: Some(true),
+        requires_prepare: None,
         algo: HASH_ALGORITHM.to_string(),
         files: base_files,
         side_effects: None,

--- a/pnpm/crates/deps-restorer/src/create_virtual_store.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store.rs
@@ -910,7 +910,9 @@ fn enforce_cached_git_prepare_policy(
     allow_build_policy: &crate::AllowBuildPolicy,
     ignore_scripts: bool,
 ) -> Result<(), CreateVirtualStoreError> {
-    if ignore_scripts {
+    if ignore_scripts
+        || !packages.values().any(|metadata| is_git_hosted_resolution(&metadata.resolution))
+    {
         return Ok(());
     }
     for (snapshot_key, _snapshot, cache_key) in snapshots {
@@ -923,12 +925,7 @@ fn enforce_cached_git_prepare_policy(
                 metadata_key: metadata_key.to_string(),
             }
         })?;
-        let is_git_hosted = match &metadata.resolution {
-            LockfileResolution::Git(_) => true,
-            LockfileResolution::Tarball(tarball) => tarball.is_git_hosted(),
-            _ => false,
-        };
-        if !is_git_hosted {
+        if !is_git_hosted_resolution(&metadata.resolution) {
             continue;
         }
         if prefetch.requires_prepare.get(key) == Some(&false) {
@@ -969,6 +966,14 @@ fn enforce_cached_git_prepare_policy(
         })?;
     }
     Ok(())
+}
+
+fn is_git_hosted_resolution(resolution: &LockfileResolution) -> bool {
+    match resolution {
+        LockfileResolution::Git(_) => true,
+        LockfileResolution::Tarball(tarball) => tarball.is_git_hosted(),
+        _ => false,
+    }
 }
 
 fn requires_build_from_cas_paths(cas_paths: &HashMap<String, PathBuf>) -> bool {

--- a/pnpm/crates/deps-restorer/src/create_virtual_store.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store.rs
@@ -412,6 +412,7 @@ impl CreateVirtualStore<'_> {
             survivors: mut snapshot_entries,
             skipped_entries,
             marker_rebuilds,
+            has_git_hosted_survivor,
         } = snapshot_plan::plan_snapshots::<Reporter>(&snapshot_plan::SnapshotPlanInputs {
             snapshots,
             packages,
@@ -473,6 +474,7 @@ impl CreateVirtualStore<'_> {
             &prefetch,
             allow_build_policy,
             config.ignore_scripts,
+            has_git_hosted_survivor,
         )?;
         let partition::Partition {
             warm,
@@ -909,10 +911,9 @@ fn enforce_cached_git_prepare_policy(
     prefetch: &PrefetchResult,
     allow_build_policy: &crate::AllowBuildPolicy,
     ignore_scripts: bool,
+    has_git_hosted_survivor: bool,
 ) -> Result<(), CreateVirtualStoreError> {
-    if ignore_scripts
-        || !packages.values().any(|metadata| is_git_hosted_resolution(&metadata.resolution))
-    {
+    if ignore_scripts || !has_git_hosted_survivor {
         return Ok(());
     }
     for (snapshot_key, _snapshot, cache_key) in snapshots {
@@ -1261,7 +1262,7 @@ fn snapshot_cache_key(
     packages: &HashMap<PackageKey, PackageMetadata>,
     ignore_scripts: bool,
     runtime_platform_selector: &PlatformSelector,
-) -> Result<Option<String>, CreateVirtualStoreError> {
+) -> Result<SnapshotCacheKey, CreateVirtualStoreError> {
     let metadata_key = snapshot_key.without_peer();
     let metadata = packages.get(&metadata_key).ok_or_else(|| {
         CreateVirtualStoreError::MissingPackageMetadata {
@@ -1280,7 +1281,7 @@ fn snapshot_cache_key(
             // skip that refusal — pnpm likewise asserts fetchability
             // before it consults the store.
             if t.integrity.is_none() && !unverified_fetch_is_allowed(&t.tarball) {
-                return Ok(None);
+                return Ok(SnapshotCacheKey { value: None, is_git_hosted: false });
             }
             // Git-hosted tarballs land in the CAS via
             // `pnpm_git_fetcher::GitHostedTarballFetcher`, which
@@ -1292,11 +1293,19 @@ fn snapshot_cache_key(
             // `built` tracks `!ignore_scripts` in lock-step with the
             // dispatcher's write key, so the prefetch and the write
             // address the same slot.
-            Ok(store_index_key_for_resolution(&metadata.resolution, &pkg_id, !ignore_scripts))
+            Ok(SnapshotCacheKey {
+                value: store_index_key_for_resolution(
+                    &metadata.resolution,
+                    &pkg_id,
+                    !ignore_scripts,
+                ),
+                is_git_hosted: t.is_git_hosted(),
+            })
         }
-        LockfileResolution::Registry(r) => {
-            Ok(Some(store_index_key(&r.integrity.to_string(), &pkg_id)))
-        }
+        LockfileResolution::Registry(r) => Ok(SnapshotCacheKey {
+            value: Some(store_index_key(&r.integrity.to_string(), &pkg_id)),
+            is_git_hosted: false,
+        }),
         LockfileResolution::Directory(_) => {
             // Directory resolutions are injected workspace deps and
             // bypass the CAFS entirely (the directory-fetcher returns
@@ -1307,7 +1316,7 @@ fn snapshot_cache_key(
             // changed since the last install). Returning `Ok(None)`
             // routes the snapshot
             // through the cold path which runs the fetcher.
-            Ok(None)
+            Ok(SnapshotCacheKey { value: None, is_git_hosted: false })
         }
         LockfileResolution::Git(_) => {
             // `Git` resolutions land in CAS via
@@ -1320,7 +1329,14 @@ fn snapshot_cache_key(
             // whether the snapshot is already in `index.db`. `built`
             // tracks `!ignore_scripts` to match the dispatcher's
             // write key.
-            Ok(store_index_key_for_resolution(&metadata.resolution, &pkg_id, !ignore_scripts))
+            Ok(SnapshotCacheKey {
+                value: store_index_key_for_resolution(
+                    &metadata.resolution,
+                    &pkg_id,
+                    !ignore_scripts,
+                ),
+                is_git_hosted: true,
+            })
         }
         // Runtime artifacts (Node.js / Bun / Deno): the per-archive
         // integrity is the warm-cache key, same shape as the
@@ -1329,9 +1345,10 @@ fn snapshot_cache_key(
         // path's variant selector + binary fetcher writes the row
         // under this key when it succeeds, so a re-install hits
         // here instead of cold-fetching the runtime archive again.
-        LockfileResolution::Binary(binary) => {
-            Ok(Some(store_index_key(&binary.integrity.to_string(), &pkg_id)))
-        }
+        LockfileResolution::Binary(binary) => Ok(SnapshotCacheKey {
+            value: Some(store_index_key(&binary.integrity.to_string(), &pkg_id)),
+            is_git_hosted: false,
+        }),
         // `Variations` is a meta-shape: its integrity lives on the
         // *picked* variant, not the wrapper. Run the same host-
         // matching selector the cold path runs so the warm key
@@ -1345,26 +1362,32 @@ fn snapshot_cache_key(
             let Some(variant) =
                 select_platform_variant(&variations.variants, runtime_platform_selector)
             else {
-                return Ok(None);
+                return Ok(SnapshotCacheKey { value: None, is_git_hosted: false });
             };
             match &variant.resolution {
-                LockfileResolution::Binary(binary) => {
-                    Ok(Some(store_index_key(&binary.integrity.to_string(), &pkg_id)))
-                }
+                LockfileResolution::Binary(binary) => Ok(SnapshotCacheKey {
+                    value: Some(store_index_key(&binary.integrity.to_string(), &pkg_id)),
+                    is_git_hosted: false,
+                }),
                 // Non-`Binary` variant (corrupt lockfile, or a
                 // future shape pacquet doesn't recognise). The
                 // cold path raises the typed
                 // `VariantHasNonBinaryResolution` error; we just
                 // skip the warm key.
-                _ => Ok(None),
+                _ => Ok(SnapshotCacheKey { value: None, is_git_hosted: false }),
             }
         }
         // Custom resolutions have no built-in warm-cache key — the
         // cold path consults the pnpmfile custom fetchers, and the
         // delegated resolution (unknowable here) determines the row
         // that gets written.
-        LockfileResolution::Custom(_) => Ok(None),
+        LockfileResolution::Custom(_) => Ok(SnapshotCacheKey { value: None, is_git_hosted: false }),
     }
+}
+
+struct SnapshotCacheKey {
+    value: Option<String>,
+    is_git_hosted: bool,
 }
 
 /// Two snapshots agree on dependency wiring when both their

--- a/pnpm/crates/deps-restorer/src/create_virtual_store.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store.rs
@@ -10,6 +10,7 @@ use futures_util::{StreamExt, stream::FuturesUnordered};
 use miette::Diagnostic;
 use pnpm_config::{Config, NodeLinker, PackageImportMethod};
 use pnpm_deps_path::get_pkg_id_with_patch_hash;
+use pnpm_git_fetcher::{GitFetcherError, assert_package_build_allowed};
 use pnpm_lockfile::{
     LockfileResolution, PackageKey, PackageMetadata, PkgIdWithPatchHash, PkgName, PkgNameVerPeer,
     PlatformSelector, SnapshotEntry, select_platform_variant,
@@ -25,8 +26,9 @@ use pnpm_store_dir::{
     SharedReadonlyStoreIndex, SharedVerifiedFilesCache, StoreIndex, StoreIndexWriter,
     store_index_key,
 };
-use pnpm_tarball::{MemCache, SharedReportedProgressKeys, prefetch_cas_paths};
+use pnpm_tarball::{MemCache, PrefetchResult, SharedReportedProgressKeys, prefetch_cas_paths};
 use std::{
+    borrow::Cow,
     collections::{HashMap, HashSet},
     fs,
     path::{Path, PathBuf},
@@ -407,7 +409,7 @@ impl CreateVirtualStore<'_> {
         // doesn't redo identical SELECT + integrity-check work for
         // every peer variant.
         let snapshot_plan::SnapshotPlan {
-            survivors: snapshot_entries,
+            survivors: mut snapshot_entries,
             skipped_entries,
             marker_rebuilds,
         } = snapshot_plan::plan_snapshots::<Reporter>(&snapshot_plan::SnapshotPlanInputs {
@@ -465,6 +467,13 @@ impl CreateVirtualStore<'_> {
             SharedVerifiedFilesCache::clone(&verified_files_cache),
         )
         .await;
+        enforce_cached_git_prepare_policy(
+            &mut snapshot_entries,
+            packages,
+            &prefetch,
+            allow_build_policy,
+            config.ignore_scripts,
+        )?;
         let partition::Partition {
             warm,
             cold,
@@ -892,6 +901,74 @@ fn removed_child_aliases(
         }
     }
     removed
+}
+
+fn enforce_cached_git_prepare_policy(
+    snapshots: &mut [SnapshotWithCacheKey<'_>],
+    packages: &HashMap<PackageKey, PackageMetadata>,
+    prefetch: &PrefetchResult,
+    allow_build_policy: &crate::AllowBuildPolicy,
+    ignore_scripts: bool,
+) -> Result<(), CreateVirtualStoreError> {
+    if ignore_scripts {
+        return Ok(());
+    }
+    for (snapshot_key, _snapshot, cache_key) in snapshots {
+        let Some(key) = cache_key.as_deref() else { continue };
+        let Some(cas_paths) = prefetch.cas_paths.get(key) else { continue };
+        let metadata_key = snapshot_key.without_peer();
+        let metadata = packages.get(&metadata_key).ok_or_else(|| {
+            CreateVirtualStoreError::MissingPackageMetadata {
+                snapshot_key: snapshot_key.to_string(),
+                metadata_key: metadata_key.to_string(),
+            }
+        })?;
+        let is_git_hosted = match &metadata.resolution {
+            LockfileResolution::Git(_) => true,
+            LockfileResolution::Tarball(tarball) => tarball.is_git_hosted(),
+            _ => false,
+        };
+        if !is_git_hosted {
+            continue;
+        }
+        if prefetch.requires_prepare.get(key) == Some(&false) {
+            continue;
+        }
+        let manifest = if let Some(manifest) = prefetch.manifests.get(key) {
+            Cow::Borrowed(manifest.as_ref())
+        } else {
+            let Some(package_json) = cas_paths.get("package.json") else {
+                *cache_key = None;
+                continue;
+            };
+            let Ok(contents) = fs::read_to_string(package_json) else {
+                *cache_key = None;
+                continue;
+            };
+            let Ok(manifest) = parse_manifest(&contents) else {
+                *cache_key = None;
+                continue;
+            };
+            Cow::Owned(manifest)
+        };
+        let package_id = metadata_key.pkg_id();
+        let name = manifest.get("name").and_then(serde_json::Value::as_str).unwrap_or("");
+        let dep_path = format!("{name}@{package_id}");
+        if allow_build_policy.check(&dep_path) == Some(true) {
+            continue;
+        }
+        if !prefetch.requires_prepare.contains_key(key) {
+            *cache_key = None;
+            continue;
+        }
+        let allow_build = |dep_path: &str| allow_build_policy.check(dep_path).unwrap_or(false);
+        assert_package_build_allowed(&allow_build, &package_id, &manifest).map_err(|error| {
+            CreateVirtualStoreError::InstallPackageBySnapshot(
+                InstallPackageBySnapshotError::GitFetch(GitFetcherError::Prepare(error)),
+            )
+        })?;
+    }
+    Ok(())
 }
 
 fn requires_build_from_cas_paths(cas_paths: &HashMap<String, PathBuf>) -> bool {

--- a/pnpm/crates/deps-restorer/src/create_virtual_store/snapshot_plan.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store/snapshot_plan.rs
@@ -48,6 +48,7 @@ pub(super) struct SnapshotPlan<'a> {
     /// approved build scripts.
     pub skipped_entries: Vec<SnapshotWithCacheKey<'a>>,
     pub marker_rebuilds: HashSet<PackageKey>,
+    pub has_git_hosted_survivor: bool,
 }
 
 /// Partition the lockfile's snapshots into what this install must do
@@ -84,6 +85,7 @@ pub(super) fn plan_snapshots<'a, Reporter: self::Reporter>(
     // current-lockfile skip keeps its store-index rows.
     let mut marker_probe_keys = HashSet::new();
     let mut marker_rebuilds = HashSet::new();
+    let mut has_git_hosted_survivor = false;
     let snapshot_entries = snapshots
         .iter()
         // Reason 1: installability skip. Drop entirely.
@@ -156,7 +158,8 @@ pub(super) fn plan_snapshots<'a, Reporter: self::Reporter>(
                     ignore_scripts,
                     runtime_platform_selector,
                 )?;
-                entries.push((snapshot_key, snapshot, cache_key));
+                has_git_hosted_survivor |= cache_key.is_git_hosted;
+                entries.push((snapshot_key, snapshot, cache_key.value));
             }
             Ok::<_, CreateVirtualStoreError>(entries)
         })?;
@@ -195,11 +198,16 @@ pub(super) fn plan_snapshots<'a, Reporter: self::Reporter>(
                 runtime_platform_selector,
             )
             .ok()
-            .flatten();
+            .and_then(|cache_key| cache_key.value);
             (snapshot_key, snapshot, cache_key)
         })
         .collect();
-    Ok(SnapshotPlan { survivors: snapshot_entries, skipped_entries, marker_rebuilds })
+    Ok(SnapshotPlan {
+        survivors: snapshot_entries,
+        skipped_entries,
+        marker_rebuilds,
+        has_git_hosted_survivor,
+    })
 }
 
 fn optional_children_match(

--- a/pnpm/crates/deps-restorer/src/create_virtual_store/tests.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store/tests.rs
@@ -272,6 +272,7 @@ async fn shared_store_context_materializes_a_warm_package() {
             &PackageFilesIndex {
                 manifest: None,
                 requires_build: Some(false),
+                requires_prepare: None,
                 algo: "sha512".to_string(),
                 files,
                 side_effects: None,

--- a/pnpm/crates/deps-restorer/src/create_virtual_store/tests.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store/tests.rs
@@ -694,10 +694,11 @@ fn snapshot_cache_key_for_git_resolution_uses_git_hosted_key() {
     let received = snapshot_cache_key(&pkg, &packages, false, &host_platform_selector())
         .expect("snapshot_cache_key must not error");
     assert_eq!(
-        received,
+        received.value,
         Some(format!("{pkg}\tbuilt")),
         "git resolutions must route through gitHostedStoreIndexKey",
     );
+    assert!(received.is_git_hosted);
 }
 
 #[test]
@@ -708,10 +709,11 @@ fn snapshot_cache_key_for_git_hosted_tarball_uses_git_hosted_key() {
     let received = snapshot_cache_key(&pkg, &packages, false, &host_platform_selector())
         .expect("snapshot_cache_key must not error");
     assert_eq!(
-        received,
+        received.value,
         Some(format!("{pkg}\tbuilt")),
         "git-hosted tarball resolutions must route through gitHostedStoreIndexKey",
     );
+    assert!(received.is_git_hosted);
 }
 
 /// A plain remote tarball with no `integrity` is refused when the
@@ -726,7 +728,8 @@ fn snapshot_cache_key_for_a_refused_tarball_is_absent() {
 
     let received = snapshot_cache_key(&pkg, &packages, false, &host_platform_selector())
         .expect("snapshot_cache_key must not error");
-    assert_eq!(received, None, "a tarball the fetch path refuses must not warm-hit");
+    assert_eq!(received.value, None, "a tarball the fetch path refuses must not warm-hit");
+    assert!(!received.is_git_hosted);
 }
 
 fn tarball_metadata_without_integrity() -> PackageMetadata {

--- a/pnpm/crates/git-fetcher/src/fetcher.rs
+++ b/pnpm/crates/git-fetcher/src/fetcher.rs
@@ -187,6 +187,7 @@ impl GitFetcher<'_> {
                 PackageFilesIndex {
                     manifest: None,
                     requires_build: Some(should_be_built),
+                    requires_prepare: Some(should_be_built),
                     algo: "sha512".to_string(),
                     files: files_index,
                     side_effects: None,

--- a/pnpm/crates/git-fetcher/src/lib.rs
+++ b/pnpm/crates/git-fetcher/src/lib.rs
@@ -30,5 +30,7 @@ pub use fetcher::{
 };
 pub use pnpm_fs_packlist::{PacklistError, packlist};
 pub use preferred_pm::{PreferredPm, WantedPm, detect_preferred_pm, detect_wanted_pm};
-pub use prepare_package::{PreparePackageOptions, PreparedPackage, prepare_package};
+pub use prepare_package::{
+    PreparePackageOptions, PreparedPackage, assert_package_build_allowed, prepare_package,
+};
 pub use tarball_fetcher::GitHostedTarballFetcher;

--- a/pnpm/crates/git-fetcher/src/prepare_package.rs
+++ b/pnpm/crates/git-fetcher/src/prepare_package.rs
@@ -321,7 +321,6 @@ fn probe_host(wanted: &WantedPm) -> bool {
     })
 }
 
-/// Reject a git package preparation that is not allowed by project policy.
 pub fn assert_package_build_allowed(
     allow_build: AllowBuildRef<'_>,
     pkg_resolution_id: &str,

--- a/pnpm/crates/git-fetcher/src/prepare_package.rs
+++ b/pnpm/crates/git-fetcher/src/prepare_package.rs
@@ -104,24 +104,10 @@ pub fn prepare_package<Reporter: self::Reporter>(
         return Ok(PreparedPackage { pkg_dir, should_be_built: true });
     }
 
-    // `allowBuild` check before any spawn. A dep path that isn't
-    // allowed throws ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED. The manifest comes
-    // from the fetched artifact itself, so its version only feeds the
-    // error message; the synthesized dep path is the gated identity.
-    // Resolution ids of git and tarball artifacts are never
-    // semver-shaped, so the policy derives an untrusted package
-    // identity from it and name-only rules can't approve the build.
+    assert_package_build_allowed(opts.allow_build.as_ref(), opts.pkg_resolution_id, &manifest)?;
+
     let name = manifest.get("name").and_then(Value::as_str).unwrap_or("");
     let version = manifest.get("version").and_then(Value::as_str).unwrap_or("");
-    let allow_build_dep_path = format!("{name}@{}", opts.pkg_resolution_id);
-    if !(opts.allow_build)(&allow_build_dep_path) {
-        return Err(PreparePackageError::NotAllowed {
-            name: name.to_string(),
-            version: version.to_string(),
-            dep_path: redact_and_sanitize(&allow_build_dep_path),
-        });
-    }
-
     let wanted_pm = detect_wanted_pm(git_root_dir, Some(&manifest));
     let pm = wanted_pm.pm;
     let dep_path = format!("{name}@{version}");
@@ -332,6 +318,25 @@ fn probe_host(wanted: &WantedPm) -> bool {
                 .map(str::trim)
                 .and_then(|version| node_semver::Version::parse(version).ok())
                 .is_some_and(|version| version.satisfies(wanted_range))
+    })
+}
+
+/// Reject a git package preparation that is not allowed by project policy.
+pub fn assert_package_build_allowed(
+    allow_build: AllowBuildRef<'_>,
+    pkg_resolution_id: &str,
+    manifest: &Value,
+) -> Result<(), PreparePackageError> {
+    let name = manifest.get("name").and_then(Value::as_str).unwrap_or("");
+    let version = manifest.get("version").and_then(Value::as_str).unwrap_or("");
+    let allow_build_dep_path = format!("{name}@{pkg_resolution_id}");
+    if allow_build(&allow_build_dep_path) {
+        return Ok(());
+    }
+    Err(PreparePackageError::NotAllowed {
+        name: name.to_string(),
+        version: version.to_string(),
+        dep_path: redact_and_sanitize(&allow_build_dep_path),
     })
 }
 

--- a/pnpm/crates/git-fetcher/src/tarball_fetcher.rs
+++ b/pnpm/crates/git-fetcher/src/tarball_fetcher.rs
@@ -173,6 +173,7 @@ impl GitHostedTarballFetcher<'_> {
                     PackageFilesIndex {
                         manifest: None,
                         requires_build: Some(false),
+                        requires_prepare: Some(false),
                         algo: "sha512".to_string(),
                         files: files_index,
                         side_effects: None,
@@ -207,6 +208,7 @@ impl GitHostedTarballFetcher<'_> {
                 PackageFilesIndex {
                     manifest: None,
                     requires_build: Some(should_be_built),
+                    requires_prepare: Some(should_be_built),
                     algo: "sha512".to_string(),
                     files: files_index,
                     side_effects: None,

--- a/pnpm/crates/package-manager/src/tarball_prefetch/tests.rs
+++ b/pnpm/crates/package-manager/src/tarball_prefetch/tests.rs
@@ -17,6 +17,7 @@ fn sample_index() -> PackageFilesIndex {
     PackageFilesIndex {
         manifest: None,
         requires_build: Some(false),
+        requires_prepare: None,
         algo: "sha512".to_string(),
         files,
         side_effects: None,

--- a/pnpm/crates/store-dir/src/check_pkg_files_integrity/tests.rs
+++ b/pnpm/crates/store-dir/src/check_pkg_files_integrity/tests.rs
@@ -38,6 +38,7 @@ fn index_with(algo: &str, info: Vec<(&str, CafsFileInfo)>) -> PackageFilesIndex 
     PackageFilesIndex {
         manifest: None,
         requires_build: None,
+        requires_prepare: None,
         algo: algo.to_string(),
         files: info.into_iter().map(|(k, v)| (k.to_string(), v)).collect(),
         side_effects: None,
@@ -390,6 +391,7 @@ fn side_effects_overlay_adds_and_drops_correctly() {
     let entry = PackageFilesIndex {
         manifest: None,
         requires_build: None,
+        requires_prepare: None,
         algo: "sha512".into(),
         files: HashMap::from([
             ("a.js".to_string(), info(&base_digest, 4, 0o644, None)),
@@ -419,6 +421,7 @@ fn side_effects_overlay_added_shadows_base_on_collision() {
     let entry = PackageFilesIndex {
         manifest: None,
         requires_build: None,
+        requires_prepare: None,
         algo: "sha512".into(),
         files: HashMap::from([("collide.js".to_string(), info(&base_digest, 4, 0o644, None))]),
         side_effects: Some(side_effects),
@@ -468,6 +471,7 @@ fn side_effects_overlay_malformed_added_digest_drops_cache_key_entry() {
     let entry = PackageFilesIndex {
         manifest: None,
         requires_build: None,
+        requires_prepare: None,
         algo: "sha512".into(),
         files: HashMap::from([("base.js".to_string(), info(&base_digest, 4, 0o644, None))]),
         side_effects: Some(side_effects),
@@ -517,6 +521,7 @@ fn side_effects_overlay_unsafe_added_path_drops_cache_key_entry() {
     let entry = PackageFilesIndex {
         manifest: None,
         requires_build: None,
+        requires_prepare: None,
         algo: "sha512".into(),
         files: HashMap::from([("base.js".to_string(), info(&base_digest, 4, 0o644, None))]),
         side_effects: Some(side_effects),
@@ -554,6 +559,7 @@ fn side_effects_overlay_keys_are_independent() {
     let entry = PackageFilesIndex {
         manifest: None,
         requires_build: None,
+        requires_prepare: None,
         algo: "sha512".into(),
         files: HashMap::from([("base.js".to_string(), info(&base_digest, 4, 0o644, None))]),
         side_effects: Some(side_effects),
@@ -573,6 +579,7 @@ fn index_with_one_file(path: &str, content: &[u8]) -> PackageFilesIndex {
     PackageFilesIndex {
         manifest: None,
         requires_build: None,
+        requires_prepare: None,
         algo: "sha512".to_string(),
         files: HashMap::from([(
             path.to_string(),

--- a/pnpm/crates/store-dir/src/msgpackr_records.rs
+++ b/pnpm/crates/store-dir/src/msgpackr_records.rs
@@ -615,7 +615,7 @@ fn write_str(writer: &mut Vec<u8>, text: &str) {
 /// ## Optional-field handling
 ///
 /// - **`PackageFilesIndex`**: `algo` and `files` are always emitted;
-///   `requires_build`, `manifest`, and `side_effects` are included
+///   `requires_build`, `requires_prepare`, `manifest`, and `side_effects` are included
 ///   in the record schema only when `Some`. The `manifest`
 ///   ([`serde_json::Value`]) is encoded recursively, with every
 ///   nested JSON object record-encoded so a pnpm reader sees them as
@@ -739,14 +739,17 @@ fn encode_pkg_files_index_value(
     state: &mut EncodeState,
     idx: &PackageFilesIndex,
 ) -> Result<(), EncodeError> {
-    // Field order `[algo, requiresBuild?, manifest?, files, sideEffects?]`.
+    // Field order `[algo, requiresBuild?, requiresPrepare?, manifest?, files, sideEffects?]`.
     // Optional fields are omitted from the schema when `None`, matching
     // msgpackr's field-omit-when-absent shape so a pnpm reader sees the
     // same JS object regardless of whether pacquet or pnpm wrote the row.
-    let mut fields: Vec<&str> = Vec::with_capacity(5);
+    let mut fields: Vec<&str> = Vec::with_capacity(6);
     fields.push("algo");
     if idx.requires_build.is_some() {
         fields.push("requiresBuild");
+    }
+    if idx.requires_prepare.is_some() {
+        fields.push("requiresPrepare");
     }
     if idx.manifest.is_some() {
         fields.push("manifest");
@@ -762,6 +765,9 @@ fn encode_pkg_files_index_value(
     write_str(writer, &idx.algo);
     if let Some(rb) = idx.requires_build {
         write_bool(writer, rb);
+    }
+    if let Some(rp) = idx.requires_prepare {
+        write_bool(writer, rp);
     }
     if let Some(manifest) = &idx.manifest {
         encode_json_value(writer, state, manifest)?;

--- a/pnpm/crates/store-dir/src/msgpackr_records/tests.rs
+++ b/pnpm/crates/store-dir/src/msgpackr_records/tests.rs
@@ -140,6 +140,7 @@ fn round_trips_plain_msgpack_through_transcoder() {
     let original = PackageFilesIndex {
         manifest: None,
         requires_build: Some(false),
+        requires_prepare: None,
         algo: "sha512".to_string(),
         files,
         side_effects: None,
@@ -275,6 +276,7 @@ fn encode_emits_record_header_for_top_level_struct() {
     let idx = PackageFilesIndex {
         manifest: None,
         requires_build: None,
+        requires_prepare: None,
         algo: "sha512".to_string(),
         files: HashMap::new(),
         side_effects: None,
@@ -290,6 +292,7 @@ fn encode_roundtrips_single_file() {
     let original = PackageFilesIndex {
         manifest: None,
         requires_build: None,
+        requires_prepare: None,
         algo: "sha512".to_string(),
         files,
         side_effects: None,
@@ -306,6 +309,7 @@ fn encode_roundtrips_many_files_sharing_one_slot() {
     let original = PackageFilesIndex {
         manifest: None,
         requires_build: None,
+        requires_prepare: None,
         algo: "sha512".to_string(),
         files,
         side_effects: None,
@@ -334,6 +338,7 @@ fn encode_handles_fixint_in_slot_range_safely() {
     let original = PackageFilesIndex {
         manifest: None,
         requires_build: None,
+        requires_prepare: None,
         algo: "sha512".to_string(),
         files,
         side_effects: None,
@@ -348,6 +353,7 @@ fn encode_omits_checked_at_when_none() {
     let original = PackageFilesIndex {
         manifest: None,
         requires_build: None,
+        requires_prepare: None,
         algo: "sha512".to_string(),
         files,
         side_effects: None,
@@ -370,6 +376,7 @@ fn encode_allocates_separate_slots_for_distinct_cafs_shapes() {
     let original = PackageFilesIndex {
         manifest: None,
         requires_build: None,
+        requires_prepare: None,
         algo: "sha512".to_string(),
         files,
         side_effects: None,
@@ -389,12 +396,27 @@ fn encode_requires_build_when_set() {
     let original = PackageFilesIndex {
         manifest: None,
         requires_build: Some(true),
+        requires_prepare: None,
         algo: "sha512".to_string(),
         files: HashMap::new(),
         side_effects: None,
     };
     let roundtripped = roundtrip(&original);
     assert_eq!(roundtripped.requires_build, Some(true));
+}
+
+#[test]
+fn encode_requires_prepare_when_set() {
+    let original = PackageFilesIndex {
+        manifest: None,
+        requires_build: Some(true),
+        requires_prepare: Some(true),
+        algo: "sha512".to_string(),
+        files: HashMap::new(),
+        side_effects: None,
+    };
+    let roundtripped = roundtrip(&original);
+    assert_eq!(roundtripped.requires_prepare, Some(true));
 }
 
 #[test]
@@ -412,6 +434,7 @@ fn encode_outer_field_order_matches_msgpackr() {
     let idx = PackageFilesIndex {
         manifest: None,
         requires_build: Some(true),
+        requires_prepare: None,
         algo: "sha512".to_string(),
         files,
         side_effects: None,
@@ -440,6 +463,7 @@ fn encode_omits_requires_build_when_none() {
     let idx = PackageFilesIndex {
         manifest: None,
         requires_build: None,
+        requires_prepare: None,
         algo: "sha512".to_string(),
         files: HashMap::new(),
         side_effects: None,
@@ -466,6 +490,7 @@ fn encode_side_effects_roundtrip() {
     let original = PackageFilesIndex {
         manifest: None,
         requires_build: None,
+        requires_prepare: None,
         algo: "sha512".to_string(),
         files,
         side_effects: Some(side_effects),
@@ -482,6 +507,7 @@ fn encode_side_effects_with_only_added_omits_deleted_field() {
     let original = PackageFilesIndex {
         manifest: None,
         requires_build: None,
+        requires_prepare: None,
         algo: "sha512".to_string(),
         files: HashMap::new(),
         side_effects: Some(side_effects),
@@ -508,6 +534,7 @@ fn encode_allocates_separate_slots_for_distinct_side_effects_shapes() {
     let original = PackageFilesIndex {
         manifest: None,
         requires_build: None,
+        requires_prepare: None,
         algo: "sha512".to_string(),
         files: HashMap::new(),
         side_effects: Some(side_effects),
@@ -551,6 +578,7 @@ fn encode_roundtrips_simple_manifest() {
     let original = PackageFilesIndex {
         manifest: Some(manifest),
         requires_build: None,
+        requires_prepare: None,
         algo: "sha512".to_string(),
         files: HashMap::new(),
         side_effects: None,
@@ -576,6 +604,7 @@ fn encode_record_encodes_nested_objects_in_manifest() {
     let idx = PackageFilesIndex {
         manifest: Some(manifest),
         requires_build: None,
+        requires_prepare: None,
         algo: "sha512".to_string(),
         files: HashMap::new(),
         side_effects: None,
@@ -607,6 +636,7 @@ fn encode_shares_slot_for_same_shaped_nested_objects() {
     let idx = PackageFilesIndex {
         manifest: Some(manifest),
         requires_build: None,
+        requires_prepare: None,
         algo: "sha512".to_string(),
         files: HashMap::new(),
         side_effects: None,
@@ -644,6 +674,7 @@ fn encode_roundtrips_all_json_value_kinds() {
     let idx = PackageFilesIndex {
         manifest: Some(manifest),
         requires_build: None,
+        requires_prepare: None,
         algo: "sha512".to_string(),
         files: HashMap::new(),
         side_effects: None,
@@ -661,6 +692,7 @@ fn encode_roundtrips_manifest_with_other_fields() {
     let original = PackageFilesIndex {
         manifest: Some(serde_json::json!({ "name": "x", "bin": "cli.js" })),
         requires_build: Some(true),
+        requires_prepare: None,
         algo: "sha512".to_string(),
         files,
         side_effects: None,

--- a/pnpm/crates/store-dir/src/store_index.rs
+++ b/pnpm/crates/store-dir/src/store_index.rs
@@ -1010,6 +1010,10 @@ pub struct PackageFilesIndex {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub requires_build: Option<bool>,
 
+    /// Whether fetching the git package required running preparation scripts.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requires_prepare: Option<bool>,
+
     /// The digest algorithm used for every `files.*.digest` entry, e.g. `sha512`.
     pub algo: String,
 

--- a/pnpm/crates/store-dir/src/store_index/tests.rs
+++ b/pnpm/crates/store-dir/src/store_index/tests.rs
@@ -48,6 +48,7 @@ fn sample_index() -> PackageFilesIndex {
     PackageFilesIndex {
         manifest: None,
         requires_build: Some(false),
+        requires_prepare: None,
         algo: "sha512".to_string(),
         files,
         side_effects: None,

--- a/pnpm/crates/store-dir/tests/verify_writer_race.rs
+++ b/pnpm/crates/store-dir/tests/verify_writer_race.rs
@@ -76,6 +76,7 @@ fn make_index(filename: &str, content: &[u8]) -> PackageFilesIndex {
     PackageFilesIndex {
         manifest: None,
         requires_build: None,
+        requires_prepare: None,
         algo: "sha512".to_string(),
         files,
         side_effects: None,

--- a/pnpm/crates/tarball/src/extract.rs
+++ b/pnpm/crates/tarball/src/extract.rs
@@ -499,6 +499,7 @@ fn assemble_extract_output(
     let pkg_files_idx = PackageFilesIndex {
         manifest,
         requires_build: Some(requires_build),
+        requires_prepare: None,
         algo: "sha512".to_string(),
         files,
         side_effects: None,

--- a/pnpm/crates/tarball/src/prefetch.rs
+++ b/pnpm/crates/tarball/src/prefetch.rs
@@ -60,8 +60,16 @@ pub type PrefetchedSideEffectsMaps =
 /// pnpm's worker fallback when `pkgFilesIndex.requiresBuild` is absent.
 pub type PrefetchedRequiresBuild = HashMap<String, bool>;
 
-pub(crate) type DecodedPrefetchRow =
-    (String, Option<Arc<serde_json::Value>>, Option<bool>, pnpm_store_dir::VerifyResult);
+/// `requiresPrepare` flags present in git package store-index rows.
+pub type PrefetchedRequiresPrepare = HashMap<String, bool>;
+
+pub(crate) type DecodedPrefetchRow = (
+    String,
+    Option<Arc<serde_json::Value>>,
+    Option<bool>,
+    Option<bool>,
+    pnpm_store_dir::VerifyResult,
+);
 
 /// Output of [`prefetch_cas_paths`]: the warm-cache filesystem map
 /// plus any bundled manifests and side-effects overlays recovered
@@ -75,6 +83,7 @@ pub struct PrefetchResult {
     pub manifests: PrefetchedManifests,
     pub side_effects_maps: PrefetchedSideEffectsMaps,
     pub requires_build: PrefetchedRequiresBuild,
+    pub requires_prepare: PrefetchedRequiresPrepare,
 }
 
 /// Resolve the whole install's warm-cache lookups up front, returning a
@@ -151,6 +160,7 @@ pub async fn prefetch_cas_paths(
                     return None;
                 }
                 let stored_requires_build = entry.requires_build;
+                let stored_requires_prepare = entry.requires_prepare;
                 let manifest = entry.manifest.take().map(Arc::new);
                 let verify_result = if verify_store_integrity {
                     pnpm_store_dir::check_pkg_files_integrity(
@@ -161,7 +171,13 @@ pub async fn prefetch_cas_paths(
                 } else {
                     pnpm_store_dir::build_file_maps_from_index(store_dir, entry)
                 };
-                Some((cache_key, manifest, stored_requires_build, verify_result))
+                Some((
+                    cache_key,
+                    manifest,
+                    stored_requires_build,
+                    stored_requires_prepare,
+                    verify_result,
+                ))
             })
             .collect();
 
@@ -169,7 +185,10 @@ pub async fn prefetch_cas_paths(
         let mut manifests = HashMap::new();
         let mut side_effects_maps = HashMap::new();
         let mut requires_build = HashMap::with_capacity(decoded.len());
-        for (cache_key, manifest, stored_requires_build, verify_result) in decoded {
+        let mut requires_prepare = HashMap::new();
+        for (cache_key, manifest, stored_requires_build, stored_requires_prepare, verify_result) in
+            decoded
+        {
             if verify_result.passed {
                 let calculated_requires_build = stored_requires_build.unwrap_or_else(|| {
                     manifest.as_deref().is_some_and(manifest_requires_build)
@@ -184,10 +203,19 @@ pub async fn prefetch_cas_paths(
                     side_effects_maps.insert(cache_key.clone(), Arc::new(maps));
                 }
                 requires_build.insert(cache_key.clone(), calculated_requires_build);
+                if let Some(requires_prepare_value) = stored_requires_prepare {
+                    requires_prepare.insert(cache_key.clone(), requires_prepare_value);
+                }
                 cas_paths.insert(cache_key, Arc::new(verify_result.files_map));
             }
         }
-        PrefetchResult { cas_paths, manifests, side_effects_maps, requires_build }
+        PrefetchResult {
+            cas_paths,
+            manifests,
+            side_effects_maps,
+            requires_build,
+            requires_prepare,
+        }
     })
     .await;
     result.unwrap_or_else(|error| {

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -421,6 +421,7 @@ async fn reuses_cached_cas_paths_when_index_entry_is_live() {
     let entry = PackageFilesIndex {
         manifest: None,
         requires_build: Some(false),
+        requires_prepare: None,
         algo: "sha512".to_string(),
         files,
         side_effects: None,
@@ -574,6 +575,7 @@ async fn prefetch_cas_paths_returns_hits_for_live_index_rows() {
     let entry = PackageFilesIndex {
         manifest: None,
         requires_build: Some(false),
+        requires_prepare: Some(true),
         algo: "sha512".to_string(),
         files,
         side_effects: None,
@@ -594,6 +596,7 @@ async fn prefetch_cas_paths_returns_hits_for_live_index_rows() {
     let map = prefetched.cas_paths.get(&index_key).expect("hit");
     assert_eq!(map.get("package.json"), Some(&pkg_json_path));
     assert_eq!(prefetched.requires_build.get(&index_key), Some(&false));
+    assert_eq!(prefetched.requires_prepare.get(&index_key), Some(&true));
     drop(store_dir);
 }
 
@@ -623,6 +626,7 @@ async fn prefetch_cas_paths_recomputes_requires_build_for_legacy_rows() {
     let entry = PackageFilesIndex {
         manifest: Some(serde_json::from_slice(manifest_bytes).unwrap()),
         requires_build: None,
+        requires_prepare: None,
         algo: "sha512".to_string(),
         files,
         side_effects: None,
@@ -676,6 +680,7 @@ async fn prefetch_cas_paths_omits_failed_integrity_entries() {
     let entry = PackageFilesIndex {
         manifest: None,
         requires_build: Some(false),
+        requires_prepare: None,
         algo: "sha512".to_string(),
         files,
         side_effects: None,
@@ -736,6 +741,7 @@ async fn prefetch_cas_paths_skips_filesystem_checks_when_verify_disabled() {
     let entry = PackageFilesIndex {
         manifest: None,
         requires_build: Some(false),
+        requires_prepare: None,
         algo: "sha512".to_string(),
         files,
         side_effects: None,
@@ -788,6 +794,7 @@ async fn falls_through_when_cafs_file_missing() {
     let entry = PackageFilesIndex {
         manifest: None,
         requires_build: None,
+        requires_prepare: None,
         algo: "sha512".to_string(),
         files,
         side_effects: None,
@@ -840,6 +847,7 @@ fn seed_row_holding_another_package(store_path: &StoreDir, index_key: &str) {
     let entry = PackageFilesIndex {
         manifest: Some(serde_json::json!({ "name": "other-package", "version": "9.9.9" })),
         requires_build: None,
+        requires_prepare: None,
         algo: "sha512".to_string(),
         files,
         side_effects: None,
@@ -996,6 +1004,7 @@ async fn falls_through_when_digest_is_malformed() {
     let entry = PackageFilesIndex {
         manifest: None,
         requires_build: None,
+        requires_prepare: None,
         algo: "sha512".to_string(),
         files,
         side_effects: None,
@@ -1064,6 +1073,7 @@ async fn falls_through_when_cafs_path_is_a_directory() {
     let entry = PackageFilesIndex {
         manifest: None,
         requires_build: None,
+        requires_prepare: None,
         algo: "sha512".to_string(),
         files,
         side_effects: None,
@@ -1142,6 +1152,7 @@ async fn falls_through_when_cafs_path_is_a_symlink() {
     let entry = PackageFilesIndex {
         manifest: None,
         requires_build: None,
+        requires_prepare: None,
         algo: "sha512".to_string(),
         files,
         side_effects: None,

--- a/pnpm/crates/tarball/src/zip_archive.rs
+++ b/pnpm/crates/tarball/src/zip_archive.rs
@@ -50,6 +50,7 @@ pub(crate) fn extract_zip_entries(
     let mut pkg_files_idx = PackageFilesIndex {
         manifest: None,
         requires_build: None,
+        requires_prepare: None,
         algo: "sha512".to_string(),
         files: HashMap::with_capacity(entry_count),
         side_effects: None,

--- a/pnpm11/exec/prepare-package/src/index.ts
+++ b/pnpm11/exec/prepare-package/src/index.ts
@@ -32,23 +32,7 @@ export async function preparePackage (opts: PreparePackageOptions, gitRootDir: s
   const manifest = await safeReadPackageJsonFromDir(pkgDir)
   if (manifest?.scripts == null || !packageShouldBeBuilt(manifest, pkgDir)) return { shouldBeBuilt: false, pkgDir }
   if (opts.ignoreScripts) return { shouldBeBuilt: true, pkgDir }
-  // Check if the package is allowed to run build scripts
-  // If allowBuild is undefined or returns false, block the build.
-  // The depPath is synthesized from the resolution id rather than read from
-  // a lockfile; resolution ids of git and tarball artifacts are never
-  // semver-shaped, so the policy derives an untrusted package identity.
-  const depPath = `${manifest.name}@${opts.pkgResolutionId}` as DepPath
-  if (!opts.allowBuild?.(depPath)) {
-    throw new PnpmError(
-      'GIT_DEP_PREPARE_NOT_ALLOWED',
-      `The git-hosted package "${manifest.name}@${manifest.version}" needs to execute build scripts but is not in the "allowBuilds" allowlist.`,
-      {
-        hint: `Add the package to "allowBuilds" in your project's pnpm-workspace.yaml to allow it to run scripts. For example:
-allowBuilds:
-  ${depPath}: true`,
-      }
-    )
-  }
+  assertPackageBuildIsAllowed(opts, manifest)
   const pm = (await preferredPM(gitRootDir))?.name ?? 'npm'
   const execOpts: RunLifecycleHookOptions = {
     depPath: `${manifest.name}@${manifest.version}`,
@@ -82,6 +66,24 @@ allowBuilds:
   }
   await rimraf(path.join(pkgDir, 'node_modules'))
   return { shouldBeBuilt: true, pkgDir }
+}
+
+export function assertPackageBuildIsAllowed (
+  opts: Pick<PreparePackageOptions, 'allowBuild' | 'pkgResolutionId'>,
+  manifest: Partial<PackageManifest>
+): void {
+  const depPath = `${manifest.name}@${opts.pkgResolutionId}` as DepPath
+  if (!opts.allowBuild?.(depPath)) {
+    throw new PnpmError(
+      'GIT_DEP_PREPARE_NOT_ALLOWED',
+      `The git-hosted package "${manifest.name}@${manifest.version}" needs to execute build scripts but is not in the "allowBuilds" allowlist.`,
+      {
+        hint: `Add the package to "allowBuilds" in your project's pnpm-workspace.yaml to allow it to run scripts. For example:
+allowBuilds:
+  ${depPath}: true`,
+      }
+    )
+  }
 }
 
 function packageShouldBeBuilt (manifest: PackageManifest, pkgDir: string): boolean {

--- a/pnpm11/fetching/fetcher-base/src/index.ts
+++ b/pnpm11/fetching/fetcher-base/src/index.ts
@@ -16,6 +16,7 @@ export interface FetchOptions {
   allowBuild?: AllowBuild
   filesIndexFile: string
   lockfileDir: string
+  pkgResolutionId?: string
   onStart?: (totalSize: number | null, attempt: number) => void
   onProgress?: (downloaded: number) => void
   readManifest?: boolean
@@ -47,6 +48,7 @@ export interface FetchResult {
   manifest?: BundledManifest
   filesMap: FilesMap
   requiresBuild: boolean
+  requiresPrepare?: boolean
   integrity?: string
 }
 
@@ -54,6 +56,7 @@ export interface GitFetcherOptions {
   allowBuild?: AllowBuild
   readManifest?: boolean
   filesIndexFile: string
+  pkgResolutionId?: string
   pkg?: PkgNameVersion
 }
 
@@ -61,6 +64,7 @@ export interface GitFetcherResult {
   filesMap: FilesMap
   manifest?: BundledManifest
   requiresBuild: boolean
+  requiresPrepare?: boolean
 }
 
 export type GitFetcher = FetchFunction<GitResolution, GitFetcherOptions, GitFetcherResult>

--- a/pnpm11/fetching/git-fetcher/src/index.ts
+++ b/pnpm11/fetching/git-fetcher/src/index.ts
@@ -49,15 +49,17 @@ export function createGitFetcher (createOpts: CreateGitFetcherOptions): { git: G
       throw new PnpmError('GIT_CHECKOUT_FAILED', `received commit ${receivedCommit.trim()} does not match expected value ${resolution.commit}`)
     }
     let pkgDir: string
+    let requiresPrepare: boolean
     try {
       const prepareResult = await preparePackage({
         allowBuild: opts.allowBuild,
         ignoreScripts: createOpts.ignoreScripts,
-        pkgResolutionId: createGitHostedPkgId(resolution),
+        pkgResolutionId: opts.pkgResolutionId ?? createGitHostedPkgId(resolution),
         unsafePerm: createOpts.unsafePerm,
         userAgent: createOpts.userAgent,
       }, tempLocation, resolution.path ?? '')
       pkgDir = prepareResult.pkgDir
+      requiresPrepare = prepareResult.shouldBeBuilt
       if (ignoreScripts && prepareResult.shouldBeBuilt) {
         globalWarn(`The git-hosted package fetched from "${resolution.repo}" has to be built but the build scripts were ignored.`)
       }
@@ -78,6 +80,7 @@ export function createGitFetcher (createOpts: CreateGitFetcherOptions): { git: G
       dir: pkgDir,
       files,
       filesIndexFile: opts.filesIndexFile,
+      requiresPrepare,
       readManifest: opts.readManifest,
       pkg: opts.pkg,
     })

--- a/pnpm11/fetching/git-fetcher/test/index.ts
+++ b/pnpm11/fetching/git-fetcher/test/index.ts
@@ -141,7 +141,8 @@ test('fetch a package from Git that has a prepare script', async () => {
   const fetch = createGitFetcher({
     storeIndex: createStoreIndex(storeDir),
   }).git
-  const { filesMap } = await fetch(
+  const pkgResolutionId = 'git+https://github.com/pnpm/test-git-fetch.git#8b333f12d5357f4f25a654c305c826294cb073bf&path:packages/test-git-fetch'
+  const { filesMap, requiresPrepare } = await fetch(
     createCafsStore(storeDir),
     {
       commit: '8b333f12d5357f4f25a654c305c826294cb073bf',
@@ -149,11 +150,13 @@ test('fetch a package from Git that has a prepare script', async () => {
       type: 'git',
     },
     {
-      allowBuild: (depPath) => depPath.startsWith('test-git-fetch@'),
+      allowBuild: (depPath) => depPath === `test-git-fetch@${pkgResolutionId}`,
       filesIndexFile: path.join(storeDir, 'index.json'),
+      pkgResolutionId,
     }
   )
   expect(filesMap.has('dist/index.js')).toBeTruthy()
+  expect(requiresPrepare).toBe(true)
 })
 
 // Test case for https://github.com/pnpm/pnpm/issues/1866

--- a/pnpm11/fetching/tarball-fetcher/src/gitHostedTarballFetcher.ts
+++ b/pnpm11/fetching/tarball-fetcher/src/gitHostedTarballFetcher.ts
@@ -42,6 +42,7 @@ export function createGitHostedTarballFetcher (fetchRemoteTarball: FetchFunction
         filesMap: prepareResult.filesMap,
         manifest: prepareResult.manifest ?? manifest,
         requiresBuild,
+        requiresPrepare: prepareResult.requiresPrepare,
         // Propagate the raw tarball integrity so the lockfile pins it and
         // future installs detect a tampered tarball from the git host.
         integrity,
@@ -60,6 +61,7 @@ interface PrepareGitHostedPkgResult {
   filesMap: FilesMap
   manifest?: BundledManifest
   ignoredBuild: boolean
+  requiresPrepare: boolean
 }
 
 async function prepareGitHostedPkg (
@@ -83,20 +85,22 @@ async function prepareGitHostedPkg (
   const { shouldBeBuilt, pkgDir } = await preparePackage({
     ...opts,
     allowBuild: fetcherOpts.allowBuild,
-    pkgResolutionId: createGitHostedTarballPkgResolutionId(resolution),
+    pkgResolutionId: fetcherOpts.pkgResolutionId ?? createGitHostedTarballPkgResolutionId(resolution),
   }, tempLocation, resolution.path ?? '')
   const files = await packlist(pkgDir)
   const { storeIndex } = opts
   if (!resolution.path && files.length === filesMap.size) {
     if (!shouldBeBuilt) {
-      const data = storeIndex.get(rawFilesIndexFile)
+      const data = storeIndex.get(rawFilesIndexFile) as { requiresPrepare?: boolean } | undefined
       if (data) {
+        data.requiresPrepare = false
         storeIndex.set(filesIndexFile, data)
         storeIndex.delete(rawFilesIndexFile)
       }
       return {
         filesMap,
         ignoredBuild: false,
+        requiresPrepare: false,
       }
     }
     if (opts.ignoreScripts) {
@@ -104,6 +108,7 @@ async function prepareGitHostedPkg (
       return {
         filesMap,
         ignoredBuild: true,
+        requiresPrepare: true,
       }
     }
   }
@@ -120,8 +125,10 @@ async function prepareGitHostedPkg (
       filesIndexFile,
       pkg: fetcherOpts.pkg,
       readManifest: fetcherOpts.readManifest,
+      requiresPrepare: shouldBeBuilt,
     }),
     ignoredBuild: Boolean(opts.ignoreScripts),
+    requiresPrepare: shouldBeBuilt,
   }
 }
 

--- a/pnpm11/fetching/tarball-fetcher/test/fetch.ts
+++ b/pnpm11/fetching/tarball-fetcher/test/fetch.ts
@@ -782,7 +782,7 @@ test('do not build the package when scripts are ignored', async () => {
       retries: 1,
     },
   })
-  const { filesMap } = await fetch.gitHostedTarball(cafs, resolution, {
+  const { filesMap, requiresPrepare } = await fetch.gitHostedTarball(cafs, resolution, {
     filesIndexFile,
     lockfileDir: process.cwd(),
     pkg,
@@ -790,6 +790,7 @@ test('do not build the package when scripts are ignored', async () => {
 
   expect(filesMap.has('package.json')).toBeTruthy()
   expect(filesMap.has('prepare.txt')).toBeFalsy()
+  expect(requiresPrepare).toBe(true)
   expect(globalWarn).toHaveBeenCalledWith(`The git-hosted package fetched from "${tarball}" has to be built but the build scripts were ignored.`)
 })
 

--- a/pnpm11/installing/deps-installer/test/install/lifecycleScripts.ts
+++ b/pnpm11/installing/deps-installer/test/install/lifecycleScripts.ts
@@ -13,6 +13,8 @@ import {
 } from '@pnpm/installing.deps-installer'
 import { streamParser } from '@pnpm/logger'
 import { prepareEmpty, preparePackages } from '@pnpm/prepare'
+import type { PackageFilesIndex } from '@pnpm/store.cafs'
+import { gitHostedStoreIndexKey, StoreIndex } from '@pnpm/store.index'
 import { createTestIpcServer } from '@pnpm/test-ipc-server'
 import { REGISTRY_MOCK_PORT } from '@pnpm/testing.registry-mock'
 import type { ProjectRootDir } from '@pnpm/types'
@@ -359,6 +361,71 @@ test('run prepare script for git-hosted dependencies allowed by repository', asy
     'install',
     'postinstall',
   ])
+})
+
+test('git-hosted packages prepared in a shared store still require project approval', async () => {
+  preparePackages([
+    { location: 'project-a', package: { name: 'project-a' } },
+    { location: 'project-b', package: { name: 'project-b' } },
+    { location: 'project-c', package: { name: 'project-c' } },
+  ])
+  const gitDependency = await createGitPreparePackage()
+  const manifest = {
+    dependencies: {
+      'test-git-fetch': gitDependency,
+    },
+  }
+  const projectA = path.resolve('project-a') as ProjectRootDir
+  const projectB = path.resolve('project-b') as ProjectRootDir
+  const projectC = path.resolve('project-c') as ProjectRootDir
+  const opts = testDefaults({
+    fastUnpack: false,
+    allowBuilds: { [`test-git-fetch@${gitDependency}`]: true },
+    lockfileDir: projectA,
+  })
+
+  await mutateModulesInSingleProject({ manifest, mutation: 'install', rootDir: projectA }, opts)
+
+  fs.rmSync(path.join(projectA, 'node_modules'), { force: true, recursive: true })
+  await expect(mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: projectA,
+  }, {
+    ...opts,
+    allowBuilds: {},
+  })).rejects.toThrow('needs to execute build scripts but is not in the "allowBuilds" allowlist')
+  expect(fs.existsSync(path.join(projectA, 'node_modules/test-git-fetch/output.json'))).toBeFalsy()
+
+  await expect(mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: projectB,
+  }, {
+    ...opts,
+    allowBuilds: {},
+    lockfileDir: projectB,
+  })).rejects.toThrow('needs to execute build scripts but is not in the "allowBuilds" allowlist')
+  expect(fs.existsSync(path.join(projectB, 'node_modules/test-git-fetch/output.json'))).toBeFalsy()
+
+  const storeIndex = new StoreIndex(opts.storeDir)
+  const storeIndexKey = gitHostedStoreIndexKey(gitDependency, { built: true })
+  const legacyIndex = storeIndex.get(storeIndexKey) as PackageFilesIndex
+  expect(legacyIndex.requiresPrepare).toBe(true)
+  delete legacyIndex.requiresPrepare
+  storeIndex.set(storeIndexKey, legacyIndex)
+  storeIndex.close()
+
+  await expect(mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: projectC,
+  }, {
+    ...opts,
+    allowBuilds: {},
+    lockfileDir: projectC,
+  })).rejects.toThrow('needs to execute build scripts but is not in the "allowBuilds" allowlist')
+  expect(fs.existsSync(path.join(projectC, 'node_modules/test-git-fetch/output.json'))).toBeFalsy()
 })
 
 async function createGitPreparePackage (): Promise<string> {

--- a/pnpm11/installing/package-requester/package.json
+++ b/pnpm11/installing/package-requester/package.json
@@ -38,6 +38,7 @@
     "@pnpm/core-loggers": "workspace:*",
     "@pnpm/deps.path": "workspace:*",
     "@pnpm/error": "workspace:*",
+    "@pnpm/exec.prepare-package": "workspace:*",
     "@pnpm/fetching.fetcher-base": "workspace:*",
     "@pnpm/fetching.pick-fetcher": "workspace:*",
     "@pnpm/fs.graceful-fs": "workspace:*",

--- a/pnpm11/installing/package-requester/src/packageRequester.ts
+++ b/pnpm11/installing/package-requester/src/packageRequester.ts
@@ -5,6 +5,7 @@ import { packageIsInstallable } from '@pnpm/config.package-is-installable'
 import { fetchingProgressLogger, progressLogger } from '@pnpm/core-loggers'
 import { depPathToFilename } from '@pnpm/deps.path'
 import { PnpmError } from '@pnpm/error'
+import { assertPackageBuildIsAllowed } from '@pnpm/exec.prepare-package'
 import type {
   DirectoryFetcherResult,
   Fetchers,
@@ -45,7 +46,7 @@ import type {
   WantedDependency,
 } from '@pnpm/store.controller-types'
 import { pickStoreIndexKey } from '@pnpm/store.index'
-import type { DependencyManifest, SupportedArchitectures } from '@pnpm/types'
+import type { DependencyManifest, DepPath, SupportedArchitectures } from '@pnpm/types'
 import {
   calcMaxWorkers,
   readPkgFromCafs as _readPkgFromCafs,
@@ -465,13 +466,20 @@ function fetchToStore (
     opts.fetchRawManifest = true
   }
 
-  if (!ctx.fetchingLocker.has(opts.pkg.id)) {
+  const resolutionKind = classifyResolution(opts.pkg.resolution)
+  const fetchingKey = resolutionKind === 'git' || resolutionKind === 'gitHostedTarball'
+    ? `${opts.lockfileDir}\0${opts.pkg.id}`
+    : opts.pkg.id
+  const reusingPolicySensitiveFetch = ctx.fetchingLocker.has(fetchingKey) &&
+    (resolutionKind === 'git' || resolutionKind === 'gitHostedTarball')
+
+  if (!ctx.fetchingLocker.has(fetchingKey)) {
     const fetching = pDefer<PkgRequestFetchResult>()
     const { filesIndexFile, target, resolution } = getFilesIndexFilePath(ctx, opts)
 
     doFetchToStore(filesIndexFile, fetching, target, resolution)
 
-    ctx.fetchingLocker.set(opts.pkg.id, {
+    ctx.fetchingLocker.set(fetchingKey, {
       fetching: removeKeyOnFail(fetching.promise),
       filesIndexFile,
       fetchRawManifest: opts.fetchRawManifest,
@@ -497,13 +505,13 @@ function fetchToStore (
         return
       }
 
-      const tmp = ctx.fetchingLocker.get(opts.pkg.id)
+      const tmp = ctx.fetchingLocker.get(fetchingKey)
 
       // If fetching failed then it was removed from the cache.
       // It is OK. In that case there is no need to update it.
       if (tmp == null) return
 
-      ctx.fetchingLocker.set(opts.pkg.id, {
+      ctx.fetchingLocker.set(fetchingKey, {
         ...tmp,
         fetching: Promise.resolve({
           ...cache,
@@ -515,11 +523,11 @@ function fetchToStore (
       })
     })
       .catch(() => {
-        ctx.fetchingLocker.delete(opts.pkg.id)
+        ctx.fetchingLocker.delete(fetchingKey)
       })
   }
 
-  const result = ctx.fetchingLocker.get(opts.pkg.id)!
+  const result = ctx.fetchingLocker.get(fetchingKey)!
 
   if (opts.fetchRawManifest && !result.fetchRawManifest) {
     result.fetching = removeKeyOnFail(
@@ -537,8 +545,24 @@ function fetchToStore (
     result.fetchRawManifest = true
   }
 
+  const fetching = reusingPolicySensitiveFetch
+    ? removeKeyOnFail(result.fetching.then(async (cached) => {
+      if (await cachedPackageCanBeReused({
+        allowBuild: opts.allowBuild,
+        bundledManifest: cached.bundledManifest,
+        filesMap: cached.files.filesMap,
+        ignoreScripts: opts.ignoreScripts,
+        pkgResolutionId: opts.pkg.id,
+        requiresPrepare: cached.files.requiresPrepare,
+        resolutionKind,
+      })) return cached
+      ctx.fetchingLocker.delete(fetchingKey)
+      return fetchToStore(ctx, opts).fetching()
+    }))
+    : result.fetching
+
   return {
-    fetching: pShare(result.fetching),
+    fetching: pShare(fetching),
     filesIndexFile: result.filesIndexFile,
   }
 
@@ -546,7 +570,7 @@ function fetchToStore (
     try {
       return await p
     } catch (err: any) { // eslint-disable-line
-      ctx.fetchingLocker.delete(opts.pkg.id)
+      ctx.fetchingLocker.delete(fetchingKey)
       if (opts.onFetchError) {
         throw opts.onFetchError(err)
       }
@@ -584,14 +608,22 @@ function fetchToStore (
           readManifest: opts.fetchRawManifest,
           expectedPkg: opts.pkg,
         })
-        if (verified) {
+        if (verified && await cachedPackageCanBeReused({
+          allowBuild: opts.allowBuild,
+          bundledManifest,
+          filesMap: files.filesMap,
+          ignoreScripts: opts.ignoreScripts,
+          pkgResolutionId: opts.pkg.id,
+          requiresPrepare: files.requiresPrepare,
+          resolutionKind,
+        })) {
           fetching.resolve({
             files,
             bundledManifest,
           })
           return
         }
-        refetchingStoredPackage = (files?.filesMap) != null
+        refetchingStoredPackage = !verified && (files?.filesMap) != null
       }
 
       if (refetchingStoredPackage) {
@@ -617,6 +649,7 @@ function fetchToStore (
           allowBuild: opts.allowBuild,
           filesIndexFile,
           lockfileDir: opts.lockfileDir,
+          pkgResolutionId: opts.pkg.id,
           readManifest: opts.fetchRawManifest,
           onProgress: (downloaded) => {
             fetchingProgressLogger.debug({
@@ -653,6 +686,7 @@ function fetchToStore (
           filesMap: fetchedPackage.filesMap,
           packageImportMethod: (fetchedPackage as DirectoryFetcherResult).packageImportMethod,
           requiresBuild: fetchedPackage.requiresBuild,
+          requiresPrepare: fetchedPackage.requiresPrepare,
         },
         bundledManifest: fetchedPackage.manifest,
         integrity,
@@ -661,6 +695,30 @@ function fetchToStore (
       fetching.reject(err)
     }
   }
+}
+
+async function cachedPackageCanBeReused (opts: {
+  allowBuild?: FetchPackageToStoreOptions['allowBuild']
+  bundledManifest?: BundledManifest
+  filesMap: Map<string, string>
+  ignoreScripts?: boolean
+  pkgResolutionId: string
+  requiresPrepare?: boolean
+  resolutionKind: ReturnType<typeof classifyResolution>
+}): Promise<boolean> {
+  if (opts.ignoreScripts || (opts.resolutionKind !== 'git' && opts.resolutionKind !== 'gitHostedTarball')) return true
+  if (opts.requiresPrepare === false) return true
+  const pkgJsonPath = opts.filesMap.get('package.json')
+  const manifest = opts.bundledManifest ?? (pkgJsonPath == null ? undefined : await readBundledManifest(pkgJsonPath))
+  if (manifest == null) return false
+  const depPath = `${manifest.name}@${opts.pkgResolutionId}` as DepPath
+  if (opts.allowBuild?.(depPath)) return true
+  if (opts.requiresPrepare == null) return false
+  assertPackageBuildIsAllowed({
+    allowBuild: opts.allowBuild,
+    pkgResolutionId: opts.pkgResolutionId,
+  }, manifest)
+  return false
 }
 
 async function readBundledManifest (pkgJsonPath: string): Promise<BundledManifest | undefined> {

--- a/pnpm11/installing/package-requester/src/packageRequester.ts
+++ b/pnpm11/installing/package-requester/src/packageRequester.ts
@@ -556,7 +556,9 @@ function fetchToStore (
         requiresPrepare: cached.files.requiresPrepare,
         resolutionKind,
       })) return cached
-      ctx.fetchingLocker.delete(fetchingKey)
+      if (ctx.fetchingLocker.get(fetchingKey) === result) {
+        ctx.fetchingLocker.delete(fetchingKey)
+      }
       return fetchToStore(ctx, opts).fetching()
     }))
     : result.fetching

--- a/pnpm11/installing/package-requester/test/index.ts
+++ b/pnpm11/installing/package-requester/test/index.ts
@@ -741,6 +741,57 @@ test('fetchPackageToStore() concurrency check', async () => {
   expect(ino1).toBe(ino2)
 })
 
+test('fetchPackageToStore() coalesces concurrent refetches of a legacy git cache entry', async () => {
+  const storeDir = temporaryDirectory()
+  const cafs = createCafsStore(storeDir)
+  let gitFetchCalls = 0
+  const packageRequester = createPackageRequester({
+    resolve,
+    fetchers: {
+      ...fetchers,
+      git: async () => {
+        gitFetchCalls++
+        return {
+          filesMap: new Map(),
+          manifest: {
+            name: 'legacy-git-package',
+            version: '1.0.0',
+          },
+          requiresBuild: false,
+          requiresPrepare: gitFetchCalls === 1 ? undefined : false,
+        }
+      },
+    },
+    cafs,
+    networkConcurrency: 2,
+    storeDir,
+    verifyStoreIntegrity: true,
+    virtualStoreDirMaxLength: 120,
+  })
+  const lockfileDir = temporaryDirectory()
+  const pkg = {
+    name: 'legacy-git-package',
+    version: '1.0.0',
+    id: 'git+https://example.com/legacy-git-package.git#0123456789012345678901234567890123456789' as PkgResolutionId,
+    resolution: {
+      type: 'git' as const,
+      repo: 'https://example.com/legacy-git-package.git',
+      commit: '0123456789012345678901234567890123456789',
+    },
+  }
+  const fetch = () => packageRequester.fetchPackageToStore({
+    allowBuild: () => false,
+    force: false,
+    lockfileDir,
+    pkg,
+  }).fetching()
+
+  await fetch()
+  await Promise.all([fetch(), fetch()])
+
+  expect(gitFetchCalls).toBe(2)
+})
+
 test('fetchPackageToStore() does not cache errors', async () => {
   const agent = await setupMockAgent()
   const mockPool = agent.get(registry)

--- a/pnpm11/installing/package-requester/tsconfig.json
+++ b/pnpm11/installing/package-requester/tsconfig.json
@@ -31,6 +31,9 @@
       "path": "../../deps/path"
     },
     {
+      "path": "../../exec/prepare-package"
+    },
+    {
       "path": "../../fetching/fetcher-base"
     },
     {

--- a/pnpm11/store/cafs-types/src/index.ts
+++ b/pnpm11/store/cafs-types/src/index.ts
@@ -27,6 +27,8 @@ export interface PackageFilesResponse {
   // Pre-calculated file location maps for side effects, avoiding recalculation during import
   sideEffectsMaps?: Map<string, { added?: FilesMap, deleted?: string[] }>
   requiresBuild: boolean
+  /** Whether preparing a git package required lifecycle scripts before these files were stored. */
+  requiresPrepare?: boolean
 }
 
 export interface ImportPackageOpts {

--- a/pnpm11/store/cafs/src/checkPkgFilesIntegrity.ts
+++ b/pnpm11/store/cafs/src/checkPkgFilesIntegrity.ts
@@ -53,6 +53,8 @@ export interface VerifyResult {
 export interface PackageFilesIndex {
   manifest?: BundledManifest
   requiresBuild?: boolean
+  /** Whether preparing a git package required lifecycle scripts before these files were stored. */
+  requiresPrepare?: boolean
   algo: string
   files: PackageFiles
   sideEffects?: SideEffects

--- a/pnpm11/worker/src/index.ts
+++ b/pnpm11/worker/src/index.ts
@@ -119,10 +119,11 @@ interface AddFilesResult {
   filesMap: FilesMap
   manifest?: BundledManifest
   requiresBuild: boolean
+  requiresPrepare?: boolean
   integrity?: string
 }
 
-type AddFilesFromDirOptions = Pick<AddDirToStoreMessage, 'storeDir' | 'dir' | 'filesIndexFile' | 'sideEffectsCacheKey' | 'readManifest' | 'pkg' | 'files' | 'appendManifest' | 'includeNodeModules'> & {
+type AddFilesFromDirOptions = Pick<AddDirToStoreMessage, 'storeDir' | 'dir' | 'filesIndexFile' | 'sideEffectsCacheKey' | 'readManifest' | 'pkg' | 'files' | 'appendManifest' | 'includeNodeModules' | 'requiresPrepare'> & {
   storeIndex: StoreIndex
 }
 
@@ -164,6 +165,7 @@ export async function addFilesFromDir (opts: AddFilesFromDirOptions): Promise<Ad
       appendManifest: opts.appendManifest,
       files: opts.files,
       includeNodeModules: opts.includeNodeModules,
+      requiresPrepare: opts.requiresPrepare,
     })
   })
 }

--- a/pnpm11/worker/src/start.ts
+++ b/pnpm11/worker/src/start.ts
@@ -162,6 +162,7 @@ async function handleMessage (
               sideEffectsMaps: verifyResult.sideEffectsMaps,
               resolvedFrom: 'store',
               requiresBuild,
+              requiresPrepare: pkgFilesIndex.requiresPrepare,
             },
           },
         })
@@ -284,6 +285,7 @@ interface AddFilesFromDirResult {
     filesMap: FilesMap
     manifest?: BundledManifest
     requiresBuild: boolean
+    requiresPrepare?: boolean
   }
   indexWrites?: IndexWrite[]
 }
@@ -323,6 +325,7 @@ function addFilesFromDir (
     files,
     filesIndexFile,
     includeNodeModules,
+    requiresPrepare,
     sideEffectsCacheKey,
     storeDir,
   }: AddDirToStoreMessage
@@ -345,6 +348,7 @@ function addFilesFromDir (
   const { filesIntegrity, filesMap } = processFilesIndex(filesIndex)
   const bundledManifest = manifest != null ? normalizeBundledManifest(manifest) : undefined
   let requiresBuild: boolean
+  let storedRequiresPrepare = requiresPrepare
   let indexWrites: IndexWrite[] | undefined
   if (sideEffectsCacheKey) {
     const existingFilesIndex = getStoreIndex(storeDir).get(filesIndexFile) as PackageFilesIndex | undefined
@@ -375,18 +379,20 @@ function addFilesFromDir (
     } else {
       requiresBuild = existingFilesIndex.requiresBuild
     }
+    storedRequiresPrepare = existingFilesIndex.requiresPrepare
     indexWrites = [{ key: filesIndexFile, buffer: packToShared(existingFilesIndex) }]
   } else {
     requiresBuild = pkgRequiresBuild(bundledManifest, filesIntegrity)
     const pkgFilesIndex: PackageFilesIndex = {
       requiresBuild,
+      requiresPrepare,
       manifest: bundledManifest,
       algo: HASH_ALGORITHM,
       files: filesIntegrity,
     }
     indexWrites = [{ key: filesIndexFile, buffer: packToShared(pkgFilesIndex) }]
   }
-  return { status: 'success', value: { filesMap, manifest: bundledManifest, requiresBuild }, indexWrites }
+  return { status: 'success', value: { filesMap, manifest: bundledManifest, requiresBuild, requiresPrepare: storedRequiresPrepare }, indexWrites }
 }
 
 function addManifestToCafs (cafs: CafsFunctions, filesIndex: FilesIndex, manifest: DependencyManifest): void {
@@ -507,4 +513,3 @@ function symlinkAllModules (opts: SymlinkAllModulesMessage): { status: 'success'
   }
   return { status: 'success' }
 }
-

--- a/pnpm11/worker/src/types.ts
+++ b/pnpm11/worker/src/types.ts
@@ -62,6 +62,7 @@ export interface AddDirToStoreMessage {
   appendManifest?: DependencyManifest
   files?: string[]
   includeNodeModules?: boolean
+  requiresPrepare?: boolean
 }
 
 export interface ReadPkgFromCafsMessage {

--- a/pnpm11/worker/test/addFilesFromDir.test.ts
+++ b/pnpm11/worker/test/addFilesFromDir.test.ts
@@ -4,11 +4,34 @@ import path from 'node:path'
 
 import { afterAll, expect, test } from '@jest/globals'
 import { PnpmError } from '@pnpm/error'
-import type { StoreIndex } from '@pnpm/store.index'
+import type { PackageFilesIndex } from '@pnpm/store.cafs'
+import { StoreIndex } from '@pnpm/store.index'
 
 import { addFilesFromDir, finishWorkers } from '../lib/index.js'
 
 afterAll(() => finishWorkers())
+
+test('addFilesFromDir() records whether git preparation was required', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-worker-test-'))
+  const dir = path.join(tmp, 'pkg')
+  fs.mkdirSync(dir)
+  fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: 'prepared-pkg', version: '1.0.0' }))
+  const storeDir = path.join(tmp, 'store')
+  const filesIndexFile = 'prepared-pkg'
+  const storeIndex = new StoreIndex(storeDir)
+
+  const result = await addFilesFromDir({
+    storeDir,
+    dir,
+    filesIndexFile,
+    requiresPrepare: true,
+    storeIndex,
+  })
+
+  expect(result.requiresPrepare).toBe(true)
+  expect((storeIndex.get(filesIndexFile) as PackageFilesIndex).requiresPrepare).toBe(true)
+  storeIndex.close()
+})
 
 test('addFilesFromDir() rejects when committing the index writes throws (e.g. a read-only store index)', async () => {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-worker-test-'))


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Fixes pnpm/pnpm#13965.

- Record whether a git dependency required preparation in the shared store index, and enforce the consuming project's `allowBuilds` policy before pnpm or pacquet reuses prepared files.
- Treat legacy store rows without the marker conservatively: an explicitly approved package may be reused, while an unapproved package is fetched through the policy-gated cold path.
- Revalidate long-lived in-process git fetch results against the current project policy, and pass the lockfile's canonical resolution ID to git fetchers so approval suggestions match the lockfile exactly.
- Keep the TypeScript CLI and Rust CLI interoperable by reading and writing the same optional store-index field.

Validation includes the full TypeScript/Rust pre-push hook, pacquet’s 9,125-test readiness suite, all 28 package-requester tests, and focused shared-store, fetcher, worker, and store-format regressions.

## Squash Commit Body

```text
Git preparation was gated only while fetching a package. Once an approved project placed prepared files in the shared store, a different project could link those files without consulting its own allowBuilds policy.

Persist whether preparation was required in each git package's store-index row and check the active project policy before warm-store reuse. Legacy rows without the marker are reused only with explicit approval; otherwise they go through the existing cold fetch and preparation gate. Revalidate in-process git fetch results as well so a long-lived store controller cannot carry approval across policy changes.

Pass the canonical lockfile resolution ID into both git fetch paths so the allowBuilds identity and suggested key stay byte-for-byte exact. Mirror the marker and warm-reuse gate in pacquet using the shared msgpackr-compatible store format.

Closes pnpm/pnpm#13965.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790255865&installation_model_id=426870&pr_number=14160&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14160&signature=c73663564ead2c983a04b1577ebd55be3d56ec3b8c15a4eb70d419b2307222f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Git-hosted packages now retain preparation requirements when reused from shared stores.
  * Build-script approval checks use consistent dependency identifiers.
* **Bug Fixes**
  * Reusing prepared Git dependencies without project approval is now blocked consistently.
  * Cached packages are refetched or rejected when required preparation approval is missing.
  * Legacy cache entries are handled safely when preparation metadata is unavailable.
  * Approval suggestions now display consistent dependency identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->