### PR TITLE
fix(ci): pass the Mastodon instance and token as action inputs

### DIFF
--- a/.github/workflows/update-latest.yml
+++ b/.github/workflows/update-latest.yml
@@ -262,10 +262,13 @@ jobs:
         id: mastodon
         uses: cbrgm/mastodon-github-action@7fcc3650150fc062d707eeffb50e8f7a2704fd0f # v2.2.3
         with:
+          # The instance and the token are `with:` inputs, not environment
+          # variables: the action turns each input into an argv entry for the
+          # container, and reads nothing from the environment. Supplied any
+          # other way they arrive empty, and posting fails on a URL of "".
+          url: "https://fosstodon.org/"
+          access-token: ${{ secrets.MASTODON_ACCESS_TOKEN }}
           message: |
             pnpm@${{ github.event.inputs.version }} is out!
             https://github.com/pnpm/pnpm/releases/tag/v${{ github.event.inputs.version }}
           visibility: "public"
-        env:
-          MASTODON_URL: "https://fosstodon.org/"
-          MASTODON_ACCESS_TOKEN: ${{ secrets.MASTODON_ACCESS_TOKEN }} # access token


### PR DESCRIPTION
## Summary

`post-to-mastodon` fails on every dispatch of the Tag workflow: 75 failures across
the 76 runs GitHub retains, 2025-07-09 through 2026-08-23 (v11.23.0); the 76th was
skipped. `tag-in-registry` succeeds each time, so releases ship and only the toot is
lost, and the job runs on `workflow_dispatch`, so it never shows up on a PR.

pnpm/pnpm#8008 bumped the action from `@v1` to `@v2`, which reads its instance URL and
token from `with:` inputs rather than the environment. The `env:` block survived the
bump, so the action gets an empty `--url` (full explanation in the squash body below):

```
Error posting status: API call error: Post "/api/v1/statuses": unsupported protocol scheme ""
```

Separate problem, needs a maintainer: `publish-to-winget` fails in the same runs on
`GitHub token is invalid`, an expired `WINGET_TOKEN`.

Verification, since a release workflow cannot be rerun here: for all 157
external-action steps in the 24 workflows, I resolved each action's `action.yml` at
its pinned SHA and asserted every input declared `required: true` is supplied in
`with:`. On `main` that fails naming `url` and `access-token` here (57 satisfied); on
this branch it passes (59). Deleting the job would report 156 steps and 57, so the
counts tell the two apart. Every other step passes on both. zizmor is unchanged.

## Squash Commit Body

```text
The release toot has failed on every dispatch of the Tag workflow since the action
was bumped from v1 to v2 in pnpm/pnpm#8008. v1 read the instance URL and the access
token from the environment; v2 declares them as `url` and `access-token` inputs and
renders each into the container's argv, reading nothing from the environment. The
`env:` block survived the bump, so the action has been invoked with an empty `--url`
ever since and fails with

    Error posting status: API call error: Post "/api/v1/statuses":
    unsupported protocol scheme ""

Move both values into `with:`, which is the form the action documents for v2 and the
form the neighbouring post-to-reddit and publish-to-winget steps use for their
credentials.

The job runs only on workflow_dispatch during a release, so the failure never appears
on a pull request. Of the 76 runs GitHub retains, post-to-mastodon failed in 75
and was skipped in the one remaining.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked
  to it solves it.

<!-- Removed as inapplicable. This is a CI-only change to a release workflow, with
no published-package surface to changeset, port to the Rust CLI, or document. -->

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14161"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790256763&installation_model_id=426870&pr_number=14161&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14161&signature=3ac085b469360f071549e8afa5ee8ce58c727606b97d56fa639a0abf5afb6f9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Mastodon notification configuration to provide the instance URL and access token through supported action inputs.
  * Removed the previous environment-variable configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->