### PR TITLE
feat(napi): honor ignorePackageManifest and pnpmHomeDir

### DIFF
--- a/.changeset/napi-fetch-shape-and-pnpm-home-dir.md
+++ b/.changeset/napi-fetch-shape-and-pnpm-home-dir.md
@@ -1,6 +1,5 @@
 ---
 "@pnpm/napi": minor
-"pacquet": minor
 ---
 
 `@pnpm/napi`'s `install` now honors the last two install options it accepted without acting on them:

--- a/.changeset/napi-fetch-shape-and-pnpm-home-dir.md
+++ b/.changeset/napi-fetch-shape-and-pnpm-home-dir.md
@@ -1,0 +1,9 @@
+---
+"@pnpm/napi": minor
+"pacquet": minor
+---
+
+`@pnpm/napi`'s `install` now honors the last two install options it accepted without acting on them:
+
+- `ignorePackageManifest: true` installs from `pnpm-lock.yaml` alone, ignoring the project manifests — pnpm's `pnpm fetch` semantics. Every importer the lockfile records is imported into the virtual store, and no post-import linking is performed: no importer symlinks, no `.bin` entries, no hoisting, and no project lifecycle scripts. It previously only skipped the manifest ↔ lockfile freshness check and otherwise linked a full `node_modules`.
+- `pnpmHomeDir` now places the default store at `<pnpmHomeDir>/store`, with the same same-volume fallback pnpm applies. An explicit `storeDir` — passed alongside it or set by a config source — still wins. It was previously ignored.

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -3006,6 +3006,20 @@ impl Config {
         );
     }
 
+    /// Resolve the default store location relative to an explicit pnpm home
+    /// directory instead of the ambient one — the programmatic counterpart
+    /// of the `pnpmHomeDir` input of pnpm's `getStorePath`. The store lands
+    /// at `<pnpm_home_dir>/store/<version>` when `start_dir` can hardlink
+    /// into that volume, with the same mount-point fallback as the ambient
+    /// default. Callers apply it only when no config source set `storeDir`.
+    pub fn resolve_store_dir_from_home<Sys>(&mut self, pnpm_home_dir: &Path, start_dir: &Path)
+    where
+        Sys: GetHomeDir + LinkProbe,
+    {
+        self.store_dir = StoreDir::new(pnpm_home_dir.join("store"));
+        self.resolve_default_store_dir::<Sys>(start_dir);
+    }
+
     fn resolve_default_store_dir<Sys: GetHomeDir + LinkProbe>(&mut self, start_dir: &Path) {
         let Some(home_dir) = Sys::home_dir() else {
             return;

--- a/pnpm/crates/napi/src/config.rs
+++ b/pnpm/crates/napi/src/config.rs
@@ -52,11 +52,26 @@ pub struct ConfigOverlay {
     pub registries: Option<BTreeMap<String, String>>,
     pub proxy: Option<ProxyConfig>,
     pub tls: Option<TlsConfig>,
+    /// `pnpmHomeDir` — the home directory the default store location is
+    /// resolved under when no config source sets `storeDir` (mirrors the
+    /// `pnpmHomeDir` input of pnpm's `getStorePath`). An explicit
+    /// [`Self::store_dir`] or a cascade-configured `storeDir` wins.
+    pub pnpm_home_dir: Option<PathBuf>,
     pub node_linker: Option<NodeLinker>,
     /// `linkWorkspacePackages` — whether a bare-semver dependency may resolve
     /// to a workspace package by name. `Off` (the default) matches only
     /// `workspace:`-prefixed ranges.
     pub link_workspace_packages: Option<LinkWorkspacePackages>,
+    /// `virtualStoreOnly` — populate the virtual store but perform no
+    /// post-import linking (importer symlinks, `.bin` entries, hoisting,
+    /// project lifecycle scripts). The binding sets it for
+    /// `ignorePackageManifest` installs — pnpm `fetch` semantics.
+    pub virtual_store_only: Option<bool>,
+    /// `enableModulesDir` — pnpm's setting for suppressing the
+    /// `node_modules` directory. The binding forces it on for
+    /// `ignorePackageManifest` installs, which need `node_modules/.pnpm`
+    /// even when an ambient config source disables the modules dir.
+    pub enable_modules_dir: Option<bool>,
     pub package_import_method: Option<PackageImportMethod>,
     pub virtual_store_dir_max_length: Option<u64>,
     pub enable_global_virtual_store: Option<bool>,
@@ -260,6 +275,10 @@ fn build_config(dir: &Path, overlay: &ConfigOverlay) -> Result<Config, LoadWorks
     let mut config = Config::default().current::<Host>(dir)?;
     if let Some(store_dir) = &overlay.store_dir {
         config.store_dir = StoreDir::new(store_dir.clone());
+    } else if let Some(pnpm_home_dir) = &overlay.pnpm_home_dir
+        && !config.explicit_settings.contains_key("storeDir")
+    {
+        config.resolve_store_dir_from_home::<Host>(pnpm_home_dir, dir);
     }
     if let Some(cache_dir) = &overlay.cache_dir {
         config.cache_dir.clone_from(cache_dir);
@@ -287,6 +306,12 @@ fn build_config(dir: &Path, overlay: &ConfigOverlay) -> Result<Config, LoadWorks
     }
     if let Some(link_workspace_packages) = overlay.link_workspace_packages {
         config.link_workspace_packages = link_workspace_packages;
+    }
+    if let Some(value) = overlay.virtual_store_only {
+        config.virtual_store_only = value;
+    }
+    if let Some(value) = overlay.enable_modules_dir {
+        config.enable_modules_dir = value;
     }
     if let Some(method) = overlay.package_import_method {
         config.package_import_method = method;
@@ -444,10 +469,17 @@ fn build_config(dir: &Path, overlay: &ConfigOverlay) -> Result<Config, LoadWorks
             &overlay_default_registry(overlay),
         )));
     }
+    // An overlay hoist pattern must not undo the empty-pattern derivation a
+    // `virtualStoreOnly` install records in `.modules.yaml`, so re-derive
+    // after every pattern-touching field above has been applied.
+    config.apply_virtual_store_only_derivation();
     // Overlay fields may invalidate the path derived by `Config::current`.
     if let Some(global_virtual_store_dir) = &overlay.global_virtual_store_dir {
         config.global_virtual_store_dir.clone_from(global_virtual_store_dir);
-    } else if overlay.enable_global_virtual_store.is_some() || overlay.store_dir.is_some() {
+    } else if overlay.enable_global_virtual_store.is_some()
+        || overlay.store_dir.is_some()
+        || overlay.pnpm_home_dir.is_some()
+    {
         let virtual_store_dir_explicit = config.explicit_settings.contains_key("virtualStoreDir");
         let global_virtual_store_dir_explicit =
             config.explicit_settings.contains_key("globalVirtualStoreDir");

--- a/pnpm/crates/napi/src/install.rs
+++ b/pnpm/crates/napi/src/install.rs
@@ -691,12 +691,15 @@ fn build_overlay(options: &InstallOptions, fetch_shaped: bool) -> napi::Result<C
         inject_workspace_packages: options.inject_workspace_packages,
         prefer_offline: options.prefer_offline,
         offline: options.offline,
+        // Both of these installs are defined in terms of the lockfile, so an
+        // ambient `lockfile: false` must not disable it underneath them.
         // `enableModulesDir: false` writes the lockfile while skipping
         // `node_modules`, so it runs through the lockfile-only path — which
-        // requires the lockfile to be enabled. Force it on for that case so an
-        // ambient `lockfile: false` can't turn the install into an opaque
-        // `ERR_PNPM_CONFIG_CONFLICT_LOCKFILE_ONLY_WITH_NO_LOCKFILE`.
-        lockfile: (options.enable_modules_dir == Some(false)).then_some(true),
+        // requires the lockfile to be enabled, or the install fails with an
+        // opaque `ERR_PNPM_CONFIG_CONFLICT_LOCKFILE_ONLY_WITH_NO_LOCKFILE`. A
+        // fetch-shaped install reads the lockfile as its only input, and
+        // would fail with `ERR_PNPM_NO_LOCKFILE`.
+        lockfile: (fetch_shaped || options.enable_modules_dir == Some(false)).then_some(true),
         prefer_frozen_lockfile: options.prefer_frozen_lockfile,
         dedupe_peer_dependents: options.dedupe_peer_dependents,
         dedupe_peers: options.dedupe_peers,

--- a/pnpm/crates/napi/src/install.rs
+++ b/pnpm/crates/napi/src/install.rs
@@ -113,6 +113,9 @@ pub struct InstallOptions {
     pub inject_workspace_packages: Option<bool>,
     pub hoist_workspace_packages: Option<bool>,
     pub enable_modules_dir: Option<bool>,
+    /// Install from the lockfile alone, ignoring the project manifests —
+    /// pnpm's `pnpm fetch` semantics: the frozen path, no post-import
+    /// linking, and no project lifecycle scripts.
     pub ignore_package_manifest: Option<bool>,
     pub node_version: Option<String>,
     pub engine_strict: Option<bool>,
@@ -163,6 +166,9 @@ pub struct InstallOptions {
     /// engine pins to the `registry` / `registries.default` passed alongside
     /// it, never to a registry the project's own `.npmrc` names.
     pub auth_header_by_uri: Option<HashMap<String, String>>,
+    /// The pnpm home directory the default store location is resolved under
+    /// when no `storeDir` is configured (`<pnpmHomeDir>/store`, with pnpm's
+    /// same-volume fallback).
     pub pnpm_home_dir: Option<String>,
     /// Render pnpm's own terminal output for this call. Omitted, the call
     /// prints nothing and the embedder renders the `onLog` event stream
@@ -406,8 +412,21 @@ fn run_install_inner(
         })?;
     let workspace_projects_override = build_workspace_projects_override(&options.projects);
 
+    // `ignorePackageManifest` is pnpm's "install from the lockfile, ignore the
+    // project manifests" mode — the shape the `pnpm fetch` handler passes in
+    // both stacks. The install takes the frozen path against the lockfile
+    // alone (the manifest ↔ lockfile freshness gate is skipped via
+    // `ignore_manifest_check`), and `virtualStoreOnly` — forced in
+    // `build_overlay` — suppresses all post-import linking: importer symlinks,
+    // `.bin` entries, hoisting, and project lifecycle scripts. Confined to the
+    // install path: a rebuild runs against an already-materialized
+    // `node_modules` and must keep its own frozen shape even when the caller
+    // reuses install options that carry the flag.
+    let ignore_package_manifest =
+        matches!(mode, EngineMode::Install(_)) && options.ignore_package_manifest == Some(true);
+
     reject_unsupported_install_options(options)?;
-    let overlay = build_overlay(options)?;
+    let overlay = build_overlay(options, ignore_package_manifest)?;
     let config = resolve_config(&dir, &overlay).map_err(|error| to_napi_error(&error))?;
 
     let manifest = PackageManifest::from_value(dir.join("package.json"), root_manifest_value);
@@ -444,16 +463,13 @@ fn run_install_inner(
     // API compatibility only. Mirrors `pnpm_package_manager::Update`, which
     // forces `prefer_frozen_lockfile: false` and a non-frozen path so the
     // re-resolution is not short-circuited by the auto-frozen / repeat-install
-    // fast paths.
-    let update_requested = matches!(mode, EngineMode::Install(_)) && options.update == Some(true);
+    // fast paths. `ignorePackageManifest` contradicts an update — it installs
+    // exactly what the lockfile records — and wins, matching pnpm, where it
+    // forces the headless path.
+    let update_requested = matches!(mode, EngineMode::Install(_))
+        && options.update == Some(true)
+        && !ignore_package_manifest;
 
-    // `ignorePackageManifest` maps to pacquet's `ignore_manifest_check`: the
-    // per-importer `package.json` ↔ `pnpm-lock.yaml` freshness gate is skipped,
-    // so the install proceeds from the lockfile even when the in-memory
-    // manifest disagrees with it. pnpm additionally skips the project-level
-    // linking phase (its `pnpm fetch` semantics); pacquet still links direct
-    // dependencies. The difference is immaterial to the programmatic consumers
-    // that pass this option — a fuller native port is tracked in NAPI.md.
     let ignore_manifest_check = options.ignore_package_manifest == Some(true);
 
     // `enableModulesDir: false` ("do not create a `node_modules` directory") is
@@ -463,14 +479,22 @@ fn run_install_inner(
     // already-materialized `node_modules`, so it must never take the
     // lockfile-only short-circuit (which would make it silently do nothing) even
     // when the caller reuses install options that disable the modules dir.
+    // `ignorePackageManifest` overrides both: it materializes the virtual
+    // store from the lockfile, which the lockfile-only short-circuit would
+    // skip entirely (the TS fetch handler forces `enableModulesDir: true` for
+    // the same reason).
     let lockfile_only = matches!(mode, EngineMode::Install(_))
+        && !ignore_package_manifest
         && (options.lockfile_only.unwrap_or(false) || options.enable_modules_dir == Some(false));
 
     // A rebuild takes the frozen path against the already-materialized
     // `node_modules`, and re-runs dependency build scripts rather than the
     // root project's own lifecycle scripts.
     let frozen_lockfile = match &mode {
-        EngineMode::Install(_) => !update_requested && options.frozen_lockfile.unwrap_or(false),
+        EngineMode::Install(_) => {
+            ignore_package_manifest
+                || (!update_requested && options.frozen_lockfile.unwrap_or(false))
+        }
         EngineMode::Rebuild(_) => true,
         // Peer issues need a full fresh resolve — never frozen.
         EngineMode::PeerIssues(_) => false,
@@ -482,7 +506,10 @@ fn run_install_inner(
     };
     let update_seed_policy =
         if update_requested { UpdateSeedPolicy::drop_all() } else { UpdateSeedPolicy::KeepAll };
-    let mutation = if matches!(mode, EngineMode::Install(_)) {
+    // An `ignorePackageManifest` install materializes what the lockfile
+    // records without installing any project's manifest — `NoInstall`, the
+    // mutation both stacks' fetch handlers use.
+    let mutation = if matches!(mode, EngineMode::Install(_)) && !ignore_package_manifest {
         ProjectMutation::InstallWorkspace
     } else {
         ProjectMutation::NoInstall
@@ -589,11 +616,18 @@ fn build_workspace_projects_override(
     )
 }
 
-fn build_overlay(options: &InstallOptions) -> napi::Result<ConfigOverlay> {
+/// Map the install options onto the config overlay. `fetch_shaped` is the
+/// resolved `ignorePackageManifest` decision (see [`run_install_inner`]):
+/// it forces `virtualStoreOnly` on and the modules dir back on, the same
+/// two settings the `pnpm fetch` handlers pin in both stacks.
+fn build_overlay(options: &InstallOptions, fetch_shaped: bool) -> napi::Result<ConfigOverlay> {
     let network_config = options.network_config.as_ref();
     Ok(ConfigOverlay {
         store_dir: options.store_dir.as_ref().map(PathBuf::from),
         cache_dir: options.cache_dir.as_ref().map(PathBuf::from),
+        pnpm_home_dir: options.pnpm_home_dir.as_ref().map(PathBuf::from),
+        virtual_store_only: fetch_shaped.then_some(true),
+        enable_modules_dir: fetch_shaped.then_some(true),
         registry: None,
         registries: options.registries.as_ref().map(|map| map.clone().into_iter().collect()),
         proxy: options.proxy_config.as_ref().map(build_proxy_config).transpose()?,

--- a/pnpm/crates/napi/src/install/tests.rs
+++ b/pnpm/crates/napi/src/install/tests.rs
@@ -357,6 +357,50 @@ fn ignore_package_manifest_populates_the_virtual_store_without_linking() {
     assert!(!modules_dir.join(".bin").exists(), "a fetch-shaped install links no top-level bins");
 }
 
+/// A fetch-shaped install reads the lockfile by definition, so an ambient
+/// `lockfile: false` must not disable it — that would leave the mode with
+/// nothing to materialize from and fail with `ERR_PNPM_NO_LOCKFILE`.
+#[test]
+fn ignore_package_manifest_survives_an_ambient_lockfile_false() {
+    let registry = TestRegistry::start();
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let project_dir = temp_dir.path().join("project");
+    std::fs::create_dir_all(&project_dir).expect("create project dir");
+    std::fs::write(project_dir.join("package.json"), "{}\n").expect("write package.json");
+
+    let project_dir_string = project_dir.to_string_lossy().into_owned();
+    let mut options = install_options();
+    options.dir = project_dir_string.clone();
+    options.projects = vec![NodeApiProject {
+        root_dir: project_dir_string,
+        manifest: serde_json::json!({
+            "dependencies": { "@pnpm.e2e/hello-world-js-bin": "1.0.0" }
+        }),
+        dependency_manifest: None,
+    }];
+    options.store_dir = Some(temp_dir.path().join("store").to_string_lossy().into_owned());
+    options.registries = Some(HashMap::from([("default".to_string(), registry.url())]));
+
+    options.lockfile_only = Some(true);
+    run_install_inner(&options, None, EngineMode::Install(None)).expect("seed the lockfile");
+    options.lockfile_only = None;
+
+    std::fs::write(project_dir.join("pnpm-workspace.yaml"), "lockfile: false\n")
+        .expect("write workspace yaml");
+
+    options.ignore_package_manifest = Some(true);
+    run_install_inner(&options, None, EngineMode::Install(None))
+        .expect("a fetch-shaped install must read the lockfile despite `lockfile: false`");
+
+    let fetched: Vec<String> = std::fs::read_dir(project_dir.join("node_modules/.pnpm"))
+        .expect("read the virtual store")
+        .map(|entry| entry.expect("virtual store entry").file_name().to_string_lossy().into_owned())
+        .filter(|name| name.starts_with("@pnpm.e2e+hello-world-js-bin"))
+        .collect();
+    dbg!(&fetched);
+    assert_eq!(fetched.len(), 1, "the recorded dependency must still be imported");
+}
+
 /// The fetch shape covers every importer the lockfile records, not just the
 /// ones the caller named — pnpm's `initialImporterIds` under
 /// `ignorePackageManifest`. Here the caller passes only the workspace root

--- a/pnpm/crates/napi/src/install/tests.rs
+++ b/pnpm/crates/napi/src/install/tests.rs
@@ -357,6 +357,67 @@ fn ignore_package_manifest_populates_the_virtual_store_without_linking() {
     assert!(!modules_dir.join(".bin").exists(), "a fetch-shaped install links no top-level bins");
 }
 
+/// The fetch shape covers every importer the lockfile records, not just the
+/// ones the caller named — pnpm's `initialImporterIds` under
+/// `ignorePackageManifest`. Here the caller passes only the workspace root
+/// while the dependency belongs to a member project.
+#[test]
+fn ignore_package_manifest_fetches_importers_the_caller_did_not_pass() {
+    let registry = TestRegistry::start();
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let root_dir = temp_dir.path().join("workspace");
+    let member_dir = root_dir.join("packages/member");
+    std::fs::create_dir_all(&member_dir).expect("create member dir");
+    std::fs::write(root_dir.join("package.json"), "{}\n").expect("write root package.json");
+    std::fs::write(member_dir.join("package.json"), "{}\n").expect("write member package.json");
+    std::fs::write(root_dir.join("pnpm-workspace.yaml"), "packages:\n  - packages/*\n")
+        .expect("write workspace yaml");
+
+    let root_dir_string = root_dir.to_string_lossy().into_owned();
+    let member_dir_string = member_dir.to_string_lossy().into_owned();
+    let mut options = install_options();
+    options.dir = root_dir_string.clone();
+    options.projects = vec![
+        NodeApiProject {
+            root_dir: root_dir_string,
+            manifest: serde_json::json!({ "name": "root" }),
+            dependency_manifest: None,
+        },
+        NodeApiProject {
+            root_dir: member_dir_string,
+            manifest: serde_json::json!({
+                "name": "member",
+                "dependencies": { "@pnpm.e2e/hello-world-js-bin": "1.0.0" }
+            }),
+            dependency_manifest: None,
+        },
+    ];
+    options.store_dir = Some(temp_dir.path().join("store").to_string_lossy().into_owned());
+    options.registries = Some(HashMap::from([("default".to_string(), registry.url())]));
+
+    options.lockfile_only = Some(true);
+    run_install_inner(&options, None, EngineMode::Install(None)).expect("seed the lockfile");
+    options.lockfile_only = None;
+
+    // Drop the member importer from the call entirely: its dependency must
+    // still be fetched, because the lockfile records it.
+    options.projects.truncate(1);
+    options.ignore_package_manifest = Some(true);
+    run_install_inner(&options, None, EngineMode::Install(None)).expect("fetch-shaped install");
+
+    let fetched: Vec<String> = std::fs::read_dir(root_dir.join("node_modules/.pnpm"))
+        .expect("read the virtual store")
+        .map(|entry| entry.expect("virtual store entry").file_name().to_string_lossy().into_owned())
+        .filter(|name| name.starts_with("@pnpm.e2e+hello-world-js-bin"))
+        .collect();
+    dbg!(&fetched);
+    assert_eq!(fetched.len(), 1, "the unnamed importer's dependency must still be fetched");
+    assert!(
+        !member_dir.join("node_modules/@pnpm.e2e/hello-world-js-bin").exists(),
+        "a fetch-shaped install links no importer symlinks",
+    );
+}
+
 #[test]
 fn repeat_install_uses_changed_in_memory_manifest() {
     let registry = TestRegistry::start();

--- a/pnpm/crates/napi/src/install/tests.rs
+++ b/pnpm/crates/napi/src/install/tests.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use pnpm_network::NoProxySetting;
+use pnpm_store_dir::STORE_VERSION;
 use pnpm_testing_utils::registry::TestRegistry;
 
 use super::{
@@ -77,7 +78,7 @@ fn build_overlay_maps_supported_install_options() {
         no_proxy: Some(serde_json::json!("localhost,127.0.0.1")),
     });
 
-    let overlay = build_overlay(&options).expect("overlay");
+    let overlay = build_overlay(&options, false).expect("overlay");
     assert_eq!(overlay.external_dependencies.unwrap().len(), 1);
     assert_eq!(overlay.exclude_links_from_lockfile, Some(true));
     assert_eq!(overlay.inject_workspace_packages, Some(true));
@@ -124,7 +125,7 @@ fn top_level_fetch_warning_options_override_network_config() {
         ..network_config()
     });
 
-    let overlay = build_overlay(&options).expect("overlay");
+    let overlay = build_overlay(&options, false).expect("overlay");
     assert_eq!(overlay.fetch_warn_timeout_ms, Some(1_234));
     assert_eq!(overlay.fetch_min_speed_ki_bps, Some(12));
 }
@@ -136,7 +137,7 @@ fn resolved_config_applies_trust_lockfile() {
     for (trust_lockfile, expected) in [(Some(false), false), (Some(true), true), (None, false)] {
         let mut options = install_options();
         options.trust_lockfile = trust_lockfile;
-        let overlay = build_overlay(&options).expect("overlay");
+        let overlay = build_overlay(&options, false).expect("overlay");
         assert_eq!(resolve_config(dir.path(), &overlay).expect("config").trust_lockfile, expected);
     }
 }
@@ -150,7 +151,7 @@ fn resolved_config_applies_allow_unused_patches() {
     {
         let mut options = install_options();
         options.allow_unused_patches = allow_unused_patches;
-        let overlay = build_overlay(&options).expect("overlay");
+        let overlay = build_overlay(&options, false).expect("overlay");
         assert_eq!(
             resolve_config(dir.path(), &overlay).expect("config").allow_unused_patches,
             expected,
@@ -165,25 +166,25 @@ fn build_overlay_parses_link_workspace_packages() {
     let mut options = install_options();
     options.link_workspace_packages = Some(serde_json::json!("deep"));
     assert_eq!(
-        build_overlay(&options).expect("overlay").link_workspace_packages,
+        build_overlay(&options, false).expect("overlay").link_workspace_packages,
         Some(LinkWorkspacePackages::Deep),
     );
 
     options.link_workspace_packages = Some(serde_json::json!(true));
     assert_eq!(
-        build_overlay(&options).expect("overlay").link_workspace_packages,
+        build_overlay(&options, false).expect("overlay").link_workspace_packages,
         Some(LinkWorkspacePackages::DirectOnly),
     );
 
     options.link_workspace_packages = Some(serde_json::json!(false));
     assert_eq!(
-        build_overlay(&options).expect("overlay").link_workspace_packages,
+        build_overlay(&options, false).expect("overlay").link_workspace_packages,
         Some(LinkWorkspacePackages::Off),
     );
 
     // Anything other than a boolean or "deep" is rejected.
     options.link_workspace_packages = Some(serde_json::json!("shallow"));
-    assert!(build_overlay(&options).is_err());
+    assert!(build_overlay(&options, false).is_err());
 }
 
 #[test]
@@ -234,7 +235,126 @@ fn newly_supported_install_options_are_accepted() {
     options.pnpm_home_dir = Some("/home/user/.local/share/pnpm".to_string());
     options.network_config = Some(NetworkConfigInput { max_sockets: Some(20), ..network_config() });
     assert!(reject_unsupported_install_options(&options).is_ok());
-    assert_eq!(build_overlay(&options).expect("overlay").max_sockets, Some(20));
+    assert_eq!(build_overlay(&options, false).expect("overlay").max_sockets, Some(20));
+}
+
+/// `ignorePackageManifest` carries pnpm's `pnpm fetch` shape into the
+/// overlay: post-import linking off, and the modules dir forced back on so
+/// an ambient `enableModulesDir: false` cannot leave the virtual store with
+/// nowhere to go.
+#[test]
+fn ignore_package_manifest_pins_the_fetch_shaped_config() {
+    let mut options = install_options();
+    options.ignore_package_manifest = Some(true);
+    options.enable_modules_dir = Some(false);
+
+    let overlay = build_overlay(&options, true).expect("overlay");
+
+    assert_eq!(overlay.virtual_store_only, Some(true));
+    assert_eq!(overlay.enable_modules_dir, Some(true));
+}
+
+/// `pnpmHomeDir` resolves the default store under that home, and an
+/// explicit `storeDir` still wins.
+#[test]
+fn pnpm_home_dir_places_the_default_store_under_that_home() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let home_dir = temp_dir.path().join("pnpm-home");
+    let project_dir = temp_dir.path().join("project");
+    std::fs::create_dir_all(&home_dir).expect("create home dir");
+    std::fs::create_dir_all(&project_dir).expect("create project dir");
+
+    let mut options = install_options();
+    options.pnpm_home_dir = Some(home_dir.to_string_lossy().into_owned());
+    let overlay = build_overlay(&options, false).expect("overlay");
+    let config = resolve_config(&project_dir, &overlay).expect("config");
+    assert_eq!(config.store_dir.root(), home_dir.join("store").join(STORE_VERSION));
+
+    let store_dir = temp_dir.path().join("explicit-store");
+    options.store_dir = Some(store_dir.to_string_lossy().into_owned());
+    let overlay = build_overlay(&options, false).expect("overlay");
+    let config = resolve_config(&project_dir, &overlay).expect("config");
+    assert_eq!(config.store_dir.root(), store_dir.join(STORE_VERSION));
+}
+
+/// A `storeDir` a config source set explicitly outranks `pnpmHomeDir`,
+/// which only supplies the *default* store location.
+#[test]
+fn a_configured_store_dir_outranks_pnpm_home_dir() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let home_dir = temp_dir.path().join("pnpm-home");
+    let configured_store = temp_dir.path().join("configured-store");
+    let project_dir = temp_dir.path().join("project");
+    std::fs::create_dir_all(&home_dir).expect("create home dir");
+    std::fs::create_dir_all(&project_dir).expect("create project dir");
+    std::fs::write(
+        project_dir.join("pnpm-workspace.yaml"),
+        format!("storeDir: {}\n", configured_store.display()),
+    )
+    .expect("write workspace yaml");
+
+    let mut options = install_options();
+    options.pnpm_home_dir = Some(home_dir.to_string_lossy().into_owned());
+    let overlay = build_overlay(&options, false).expect("overlay");
+    let config = resolve_config(&project_dir, &overlay).expect("config");
+
+    assert_eq!(config.store_dir.root(), configured_store.join(STORE_VERSION));
+}
+
+/// The `pnpm fetch` shape: every importer the lockfile records is imported
+/// into the virtual store, and nothing is linked out of it — no importer
+/// symlink for a direct dependency, and no top-level `.bin` entry. The
+/// in-memory manifests are ignored entirely, so an empty one still fetches
+/// the whole recorded graph.
+#[test]
+fn ignore_package_manifest_populates_the_virtual_store_without_linking() {
+    let registry = TestRegistry::start();
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let project_dir = temp_dir.path().join("project");
+    std::fs::create_dir_all(&project_dir).expect("create project dir");
+    std::fs::write(project_dir.join("package.json"), "{}\n").expect("write package.json");
+
+    let project_dir_string = project_dir.to_string_lossy().into_owned();
+    let mut options = install_options();
+    options.dir = project_dir_string.clone();
+    options.projects = vec![NodeApiProject {
+        root_dir: project_dir_string,
+        manifest: serde_json::json!({
+            "dependencies": { "@pnpm.e2e/hello-world-js-bin": "1.0.0" }
+        }),
+        dependency_manifest: None,
+    }];
+    options.store_dir = Some(temp_dir.path().join("store").to_string_lossy().into_owned());
+    options.registries = Some(HashMap::from([("default".to_string(), registry.url())]));
+
+    // Seed the lockfile with an ordinary install, then throw the linked
+    // `node_modules` away so the fetch-shaped run starts from the lockfile
+    // alone.
+    options.lockfile_only = Some(true);
+    run_install_inner(&options, None, EngineMode::Install(None)).expect("seed the lockfile");
+    assert!(project_dir.join("pnpm-lock.yaml").exists(), "the seed run must write a lockfile");
+    options.lockfile_only = None;
+
+    // An empty manifest proves the run reads the lockfile, not the manifest.
+    options.projects[0].manifest = serde_json::json!({});
+    options.ignore_package_manifest = Some(true);
+    run_install_inner(&options, None, EngineMode::Install(None)).expect("fetch-shaped install");
+
+    let modules_dir = project_dir.join("node_modules");
+    let virtual_store = modules_dir.join(".pnpm");
+    let fetched: Vec<String> = std::fs::read_dir(&virtual_store)
+        .expect("read the virtual store")
+        .map(|entry| entry.expect("virtual store entry").file_name().to_string_lossy().into_owned())
+        .filter(|name| name.starts_with("@pnpm.e2e+hello-world-js-bin"))
+        .collect();
+    dbg!(&fetched);
+    assert_eq!(fetched.len(), 1, "the recorded dependency must be imported into the virtual store");
+
+    assert!(
+        !modules_dir.join("@pnpm.e2e/hello-world-js-bin").exists(),
+        "a fetch-shaped install links no importer symlinks",
+    );
+    assert!(!modules_dir.join(".bin").exists(), "a fetch-shaped install links no top-level bins");
 }
 
 #[test]

--- a/pnpm/npm/napi/index.d.ts
+++ b/pnpm/npm/napi/index.d.ts
@@ -212,12 +212,20 @@ export interface InstallOptions extends SharedEngineOptions {
    */
   enableModulesDir?: boolean
   /**
-   * Install from the lockfile without gating on the `package.json` ↔
-   * `pnpm-lock.yaml` freshness check, so an in-memory manifest that disagrees
-   * with the lockfile does not block the install.
+   * Install from the lockfile alone, ignoring the project manifests —
+   * pnpm's `pnpm fetch` semantics. The resolution step and the
+   * `package.json` ↔ `pnpm-lock.yaml` freshness check are skipped, every
+   * importer the lockfile records is imported into the virtual store, and
+   * no post-import linking is performed: no importer symlinks, no `.bin`
+   * entries, no hoisting, no project lifecycle scripts.
    */
   ignorePackageManifest?: boolean
-  /** pnpm home directory. Accepted for compatibility; unused for project installs. */
+  /**
+   * The pnpm home directory the default store location is resolved under
+   * when no `storeDir` is configured (`<pnpmHomeDir>/store`, with pnpm's
+   * same-volume fallback). An explicit `storeDir` — passed here or set by
+   * a config source — wins.
+   */
   pnpmHomeDir?: string
   /**
    * Fail with `ERR_PNPM_IGNORED_BUILDS` when a dependency build script is

--- a/pnpm/plans/NAPI.md
+++ b/pnpm/plans/NAPI.md
@@ -337,12 +337,16 @@ Dropped from consumers: `@pnpm/installing.deps-installer`, `@pnpm/installing.cli
     the global `networkConcurrency` semaphore stays the outer bound.
   - `enableModulesDir: false` → pacquet's lockfile-only path (resolve + write
     lockfile, materialize no `node_modules`).
-  - `ignorePackageManifest` → pacquet's existing `ignore_manifest_check` (skip
-    the manifest↔lockfile freshness gate). pnpm additionally skips the
-    project-level linking phase (`pnpm fetch` semantics); a fuller native port
-    of that is a follow-up.
-  - `pnpmHomeDir` → accepted and ignored; only global flows consult it and the
-    binding drives project installs.
+  - `ignorePackageManifest` → the full `pnpm fetch` shape: the frozen path
+    against the lockfile alone (`ignore_manifest_check` skips the
+    manifest↔lockfile freshness gate), `virtual_store_only` (no importer
+    symlinks, `.bin` entries, hoisting, or project lifecycle scripts), a
+    forced-on modules dir, and `ProjectMutation::NoInstall` — the same
+    settings both stacks' fetch handlers pin.
+  - `pnpmHomeDir` → the home directory the default store location resolves
+    under when no `storeDir` is configured
+    (`Config::resolve_store_dir_from_home`, pnpm's `getStorePath`
+    semantics). An explicit or cascade-configured `storeDir` wins.
 
 - **`install` remaining work** (additive; core pipeline + hook + multi-importer
   + build approval above are proven):


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#12823. Follow-up to pnpm/pnpm#12826, which wired through
every install option the `@pnpm/napi` binding used to reject and left two
accepted-but-inert:

**`ignorePackageManifest`** was mapped only onto pacquet's
`ignore_manifest_check` — the `package.json` ↔ `pnpm-lock.yaml` freshness
gate was skipped, but the install otherwise linked a full `node_modules`
and ran project lifecycle scripts. It now carries pnpm's whole `pnpm fetch`
shape, matching what `installing/commands/src/fetch.ts` and pacquet's own
`FetchArgs` pin:

- the frozen path against the lockfile alone (`frozen_lockfile: true`),
- `virtualStoreOnly` — no importer symlinks, no `.bin` entries, no
  hoisting, no project lifecycle scripts,
- `enableModulesDir: true` forced back on, so an ambient
  `enableModulesDir: false` can't leave the virtual store nowhere to go
  (the TypeScript handler forces the same, with the same comment),
- `ProjectMutation::NoInstall`.

It also takes precedence over two options it contradicts: `update` (which
would re-resolve what the lockfile already pins — pnpm likewise lets
`ignorePackageManifest` force the headless path) and the `lockfileOnly` /
`enableModulesDir: false` short-circuit (which would skip the very
materialization this mode exists to perform).

**`pnpmHomeDir`** was accepted and dropped. It now places the default store
at `<pnpmHomeDir>/store` through a new `Config::resolve_store_dir_from_home`,
mirroring the `pnpmHomeDir` input of pnpm's `getStorePath` in
`store/path/src/index.ts` — including the same-volume probe and the
`<mountpoint>/.pnpm-store` fallback, since it reuses the existing
`resolve_default_store_dir`. An explicit `storeDir` — passed alongside it or
set by any config source — still wins.

No TypeScript-side change: the TS engine already implements both options,
and this is the Rust binding catching up to it. The changeset therefore
targets `@pnpm/napi` alone — the Rust CLI's own behavior is unchanged, and it
bumps in lockstep anyway through the `versioning.fixed` group.

### Review follow-ups

Both of CodeRabbit's findings were real and are fixed in 7e0fadde07:

- An ambient `lockfile: false` made a fetch-shaped install fail with
  `ERR_PNPM_NO_LOCKFILE`, since `LazyLockfile::disabled()` left it nothing to
  materialize from. The overlay now forces the lockfile on for it, next to the
  `enableModulesDir: false` case that already needed the same treatment.
  Reproduced first, and pinned by a new test.
- Dropped `pacquet` from the changeset (see above).

### Verification

Six new tests in `pnpm/crates/napi/src/install/tests.rs`, the behavioral
ones regression-verified by temporarily breaking the implementation and
confirming they fail:

- `ignore_package_manifest_populates_the_virtual_store_without_linking` —
  seeds a lockfile, then runs with an *empty* in-memory manifest and asserts
  the recorded dependency lands in `node_modules/.pnpm` while no importer
  symlink and no top-level `.bin` are created. (Reverting the
  `virtualStoreOnly` forcing makes it fail on the symlink assertion.)
- `ignore_package_manifest_fetches_importers_the_caller_did_not_pass` —
  the fetch shape covers every importer the *lockfile* records, not just the
  ones the caller passed (pnpm's `initialImporterIds` under
  `ignorePackageManifest`). The caller hands over only the workspace root and
  the member project's dependency is still fetched.
- `ignore_package_manifest_survives_an_ambient_lockfile_false` — a
  fetch-shaped install reads the lockfile as its only input, so an ambient
  `lockfile: false` must not disable it out from under the mode.
- `ignore_package_manifest_pins_the_fetch_shaped_config`
- `pnpm_home_dir_places_the_default_store_under_that_home` — and that an
  explicit `storeDir` outranks it. (Dropping the `pnpmHomeDir` handling makes
  it resolve to the ambient home instead.)
- `a_configured_store_dir_outranks_pnpm_home_dir` — a `storeDir` in
  `pnpm-workspace.yaml` wins.

Full suites green locally: `pnpm-napi` + `pnpm-config` (637), plus
`pnpm-package-manager` / `pnpm-deps-restorer` / `pnpm-store-dir` (1216) and
the `pnpm-cli` fetch/store e2e modules (123). `cargo fmt`, `clippy
--all-targets -D warnings`, `cargo doc` with `RUSTDOCFLAGS=-D warnings`,
`taplo`, and `cargo dylint` (rebuilt from scratch) all pass.

## Squash Commit Body

```text
Close the last two install options the `@pnpm/napi` binding accepted without
acting on (Closes pnpm/pnpm#12823, follow-up to pnpm/pnpm#12826).

ignorePackageManifest now carries pnpm's full `pnpm fetch` shape rather than
only skipping the manifest/lockfile freshness gate: the frozen path against
the lockfile alone, virtualStoreOnly (no importer symlinks, .bin entries,
hoisting, or project lifecycle scripts), a forced-on modules dir so an
ambient enableModulesDir:false cannot leave the virtual store nowhere to go,
and ProjectMutation::NoInstall. It outranks both update (which would
re-resolve what the lockfile already pins) and the lockfile-only
short-circuit (which would skip the materialization the mode exists to
perform) — the same precedence the TypeScript handler applies.

pnpmHomeDir now places the default store at <pnpmHomeDir>/store via a new
Config::resolve_store_dir_from_home, mirroring the pnpmHomeDir input of
pnpm's getStorePath including the same-volume probe and the mountpoint
fallback. An explicit storeDir, passed alongside it or set by a config
source, still wins.

The TypeScript engine already implements both options; this is the Rust
binding reaching parity with it, so there is no TS-side counterpart.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (Rust-only: the TypeScript engine already has both options — this brings
  the binding up to it.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed. (`pnpm/npm/napi/index.d.ts` and
  `pnpm/plans/NAPI.md`.)

---
Written by an agent (Claude Code, claude-fable-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `pnpm fetch`-style installation through `ignorePackageManifest`, populating the virtual store without linking dependencies, binaries, or running lifecycle scripts.
  * Fetch-mode installs now process every importer recorded in the lockfile.
  * Added support for deriving the default store location from `pnpmHomeDir`, while preserving explicit store directory precedence.

* **Documentation**
  * Documented fetch-mode installation behavior and store directory resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->