### PR TITLE
fix(tarball): bound the memory an untrusted archive decode can claim

### DIFF
--- a/.changeset/bounded-archive-decoding.md
+++ b/.changeset/bounded-archive-decoding.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+pnpm now decodes package archives using a bounded amount of memory, whatever an archive or a registry claims about its size. A gzipped tarball that inflates past what a whole-archive decode may hold is extracted as a stream instead, a response body that keeps arriving is extracted while it downloads rather than accumulated in full, and a zip entry is read only as far as the size its archive records. No archive is refused for being large — everything that installed before still installs.

--- a/pnpm/crates/tarball/src/download.rs
+++ b/pnpm/crates/tarball/src/download.rs
@@ -4,13 +4,14 @@
 //! events the reporter renders during a fetch.
 
 use super::{
-    Arc, Duration, HashMap, HttpStatusError, IgnoreEntryFilter, Instant, NetworkError, PathBuf,
-    PrefetchedCasPaths, STREAM_EXTRACT_DURING_DOWNLOAD_THRESHOLD, SharedReportedProgressKeys,
-    TarballError, VerifyChecksumError, allocate_tarball_buffer, decompress_gzip,
-    extract_tarball_entries, local_file_tarball_path, open_local_tarball, post_download_semaphore,
-    read_local_tarball_buffer, should_stream_extract, stream_extract_gzipped_channel,
-    stream_extract_gzipped_tarball, streaming_extract_semaphore,
+    Arc, Duration, GZIP_MAGIC, HashMap, HttpStatusError, IgnoreEntryFilter, Instant, NetworkError,
+    PathBuf, PrefetchedCasPaths, STREAM_EXTRACT_COMPRESSED_THRESHOLD,
+    STREAM_EXTRACT_DURING_DOWNLOAD_THRESHOLD, SharedReportedProgressKeys, TarballError,
+    VerifyChecksumError, allocate_tarball_buffer, body_chunk_channel, extract_gzipped_tarball,
+    local_file_tarball_path, non_gzip_body_error, open_local_tarball, post_download_semaphore,
+    read_local_tarball_buffer, stream_extract_gzipped_channel, streaming_extract_semaphore,
 };
+use futures_util::{Stream, StreamExt};
 use pnpm_network::{
     AuthHeaders, MAX_THROUGHPUT_PRIORITY, RetryOpts, ThrottledClient, redact_url_for_display,
 };
@@ -309,23 +310,12 @@ pub(crate) async fn extract_tarball_buffer(
                 expected_integrity,
                 package_url_owned,
             )?;
-            // A large archive is extracted by streaming the gzip
-            // decode straight into the tar walk, so the only
-            // whole-archive allocation alive during extraction is the
-            // compressed body — the eager path would hold the
-            // decompressed archive (typically several times larger)
-            // next to it.
-            let (cas_paths, pkg_files_idx) =
-                if should_stream_extract(buffer.len(), package_unpacked_size) {
-                    stream_extract_gzipped_tarball(
-                        &buffer,
-                        store_dir,
-                        ignore_file_pattern.as_deref(),
-                    )?
-                } else {
-                    let tar_data = decompress_gzip(&buffer, package_unpacked_size)?;
-                    extract_tarball_entries(&tar_data, store_dir, ignore_file_pattern.as_deref())?
-                };
+            let (cas_paths, pkg_files_idx) = extract_gzipped_tarball(
+                &buffer,
+                package_unpacked_size,
+                store_dir,
+                ignore_file_pattern.as_deref(),
+            )?;
             Ok((integrity, cas_paths, pkg_files_idx))
         },
     )
@@ -352,6 +342,152 @@ pub(crate) fn verify_tarball_integrity(
     let mut opts = IntegrityOpts::new().algorithm(Algorithm::Sha512);
     opts.input(buffer);
     Ok(opts.result())
+}
+
+/// Hashes a tarball body chunk by chunk as it arrives: verifying the
+/// pinned integrity when the resolution carries one, computing a fresh
+/// sha512 when it does not.
+///
+/// Same two outcomes [`verify_tarball_integrity`] produces over a fully
+/// buffered body. Doing it incrementally is what lets a body be
+/// extracted while it downloads without the whole of it being held to
+/// hash at the end.
+enum BodyHasher {
+    Pinned { expected: Integrity, checker: IntegrityChecker },
+    Computed(IntegrityOpts),
+}
+
+impl BodyHasher {
+    fn new(expected_integrity: Option<&Integrity>) -> Self {
+        match expected_integrity {
+            Some(expected) => BodyHasher::Pinned {
+                expected: expected.clone(),
+                checker: IntegrityChecker::new(expected.clone()),
+            },
+            None => BodyHasher::Computed(IntegrityOpts::new().algorithm(Algorithm::Sha512)),
+        }
+    }
+
+    fn input(&mut self, bytes: &[u8]) {
+        match self {
+            BodyHasher::Pinned { checker, .. } => checker.input(bytes),
+            BodyHasher::Computed(opts) => opts.input(bytes),
+        }
+    }
+
+    fn finish(self, package_url: &str) -> Result<Integrity, TarballError> {
+        match self {
+            BodyHasher::Pinned { expected, checker } => {
+                checker.result().map(|_| expected).map_err(|error| {
+                    TarballError::Checksum(VerifyChecksumError {
+                        url: package_url.to_string(),
+                        error,
+                    })
+                })
+            }
+            BodyHasher::Computed(opts) => Ok(opts.result()),
+        }
+    }
+}
+
+/// Extract a gzipped tarball body into the CAFS while it is still
+/// arriving, hashing every byte on its way past.
+///
+/// The extractor runs on a blocking thread fed through a channel, so
+/// what is held in memory is the queued chunks plus the extractor's own
+/// bounded batch — never the archive. That is the property the callers
+/// want: [`fetch_and_extract_once`] takes this path up front for a body
+/// whose advertised size already says it is large, and falls back to it
+/// for one that turns out to be large while it buffers.
+///
+/// `seed` is the part of the body already pulled off the socket; the
+/// caller has reported it to `progress` and has not hashed it.
+/// `network_permit` is dropped once the body is done, before the wait
+/// on the extractor's CPU work.
+///
+/// Entries reach the CAFS before the body is verified. Only returning
+/// `Ok` makes them reachable, and a caller that gets an error treats
+/// the fetch as failed, so a tampered body's entries stay orphaned in
+/// the content-addressed store rather than being installed.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the parameters are the independent pieces of one in-flight download; a struct would only move the same fields into a wrapper"
+)]
+async fn extract_body_while_downloading<Reporter, Body, Guard>(
+    seed: Vec<bytes::Bytes>,
+    mut stream: Body,
+    mut hasher: BodyHasher,
+    progress: &mut BodyProgress<'_>,
+    network_permit: Guard,
+    http_client: &ThrottledClient,
+    package_url: &str,
+    store_dir: &'static StoreDir,
+    ignore_file_pattern: Option<Arc<IgnoreEntryFilter>>,
+) -> Result<(Integrity, HashMap<String, PathBuf>, PackageFilesIndex), TarballError>
+where
+    Reporter: self::Reporter,
+    Body: Stream<Item = reqwest::Result<bytes::Bytes>> + Unpin,
+{
+    let network_error =
+        |error| TarballError::FetchTarball(NetworkError { url: package_url.to_string(), error });
+
+    let (chunk_tx, chunk_rx) = body_chunk_channel();
+    let extractor_ignore = ignore_file_pattern.clone();
+    let extract_task = tokio::task::spawn_blocking(move || {
+        stream_extract_gzipped_channel(chunk_rx, store_dir, extractor_ignore.as_deref())
+    });
+    // The body is hashed to its end no matter what the extractor does
+    // because the integrity verdict covers every byte. The extractor
+    // can legitimately finish early when the tar terminator and gzip
+    // trailer arrive while chunks are still in flight. `feed` only
+    // stops the sends; a send failure is not an error verdict.
+    let mut feed = true;
+    for chunk in seed {
+        hasher.input(&chunk);
+        if feed && chunk_tx.send(Ok(chunk)).await.is_err() {
+            feed = false;
+        }
+    }
+    let mut body_error: Option<TarballError> = None;
+    while body_error.is_none() {
+        match stream.next().await {
+            Some(Ok(chunk)) => {
+                hasher.input(&chunk);
+                progress.on_chunk::<Reporter>(chunk.len());
+                if feed && chunk_tx.send(Ok(chunk)).await.is_err() {
+                    feed = false;
+                }
+            }
+            Some(Err(error)) => {
+                if feed {
+                    let _ = chunk_tx
+                        .send(Err(std::io::Error::other("the tarball body failed mid-download")))
+                        .await;
+                }
+                body_error = Some(network_error(error));
+            }
+            None => break,
+        }
+    }
+    if body_error.is_none() {
+        progress.warn_if_slow(http_client, package_url);
+    }
+    // Close the channel so the extractor sees end-of-stream. Release
+    // the network permit before waiting on CPU work because the body is
+    // done or abandoned after a network error.
+    drop(chunk_tx);
+    drop(stream);
+    drop(network_permit);
+    tracing::info!(target: "pacquet::download", ?package_url, "Download completed");
+    let extracted = extract_task.await.map_err(TarballError::TaskJoin)?;
+    if let Some(error) = body_error {
+        return Err(error);
+    }
+    let integrity = hasher.finish(package_url)?;
+    let (cas_paths, pkg_files_idx) = extracted?;
+    tracing::info!(target: "pacquet::download", ?package_url, "Checksum verified");
+    progress.finish::<Reporter>();
+    Ok((integrity, cas_paths, pkg_files_idx))
 }
 
 /// Emits download progress for both body paths of [`fetch_and_extract_once`].
@@ -588,16 +724,13 @@ pub(crate) async fn fetch_and_extract_once<Reporter: self::Reporter>(
 
     let expected_size = response_head.content_length();
 
-    use futures_util::StreamExt;
     let mut stream = response_head.bytes_stream();
     let mut progress = BodyProgress::new(expected_size, package_id);
 
     // Pull chunks until the gzip magic is decidable. The selected body
-    // path receives the prefix so no bytes are consumed twice. A shorter
-    // body falls through to the buffered path and reports its decode error.
+    // path receives the prefix so no bytes are consumed twice.
     let mut prefix: Vec<bytes::Bytes> = Vec::new();
     let mut prefix_len = 0usize;
-    const GZIP_MAGIC: [u8; 2] = [0x1f, 0x8b];
     while prefix_len < GZIP_MAGIC.len() {
         let Some(chunk) = stream.next().await else { break };
         let chunk = chunk.map_err(network_error)?;
@@ -608,84 +741,41 @@ pub(crate) async fn fetch_and_extract_once<Reporter: self::Reporter>(
         let mut magic = prefix.iter().flat_map(|chunk| chunk.iter().copied());
         (magic.next(), magic.next()) == (Some(GZIP_MAGIC[0]), Some(GZIP_MAGIC[1]))
     };
-
-    // Unpinned bodies need the full buffer to compute their integrity.
-    // Retries also stay buffered so their terminal errors retain the eager
-    // path's diagnostics. Streaming may CAS-write entries before integrity
-    // is known, but the caller only makes them reachable after this returns
-    // `Ok`. The channel can queue no more compressed data than the buffered
-    // path would retain, while extractor buffers remain bounded.
+    // Take the streaming extractor up front when the advertised size
+    // already says the archive is large. Retries stay buffered so their
+    // terminal errors retain the whole-archive decode's diagnostics.
     if is_gzip
         && attempt == 0
         && expected_size.is_some_and(|size| size >= STREAM_EXTRACT_DURING_DOWNLOAD_THRESHOLD)
-        && let Some(expected) = expected_integrity
         && let Ok(_streaming_permit) = streaming_extract_semaphore().try_acquire()
     {
-        let (chunk_tx, chunk_rx) = std::sync::mpsc::channel::<std::io::Result<bytes::Bytes>>();
-        let extractor_ignore = ignore_file_pattern.clone();
-        let extract_task = tokio::task::spawn_blocking(move || {
-            stream_extract_gzipped_channel(chunk_rx, store_dir, extractor_ignore.as_deref())
-        });
-        let mut checker = IntegrityChecker::new(expected.clone());
-        // The body is hashed to its end no matter what the extractor
-        // does because the pinned integrity covers every byte. The
-        // extractor can legitimately finish early when the tar terminator
-        // and gzip trailer arrive while chunks are still in flight. `feed`
-        // only stops the sends; a send failure is not an error verdict.
-        let mut feed = true;
-        for chunk in prefix {
-            checker.input(&chunk);
+        for chunk in &prefix {
             progress.on_chunk::<Reporter>(chunk.len());
-            if feed && chunk_tx.send(Ok(chunk)).is_err() {
-                feed = false;
-            }
         }
-        let mut body_error: Option<TarballError> = None;
-        while body_error.is_none() {
-            match stream.next().await {
-                Some(Ok(chunk)) => {
-                    checker.input(&chunk);
-                    progress.on_chunk::<Reporter>(chunk.len());
-                    if feed && chunk_tx.send(Ok(chunk)).is_err() {
-                        feed = false;
-                    }
-                }
-                Some(Err(error)) => {
-                    if feed {
-                        let _ = chunk_tx.send(Err(std::io::Error::other(
-                            "the tarball body failed mid-download",
-                        )));
-                    }
-                    body_error = Some(network_error(error));
-                }
-                None => break,
-            }
-        }
-        if body_error.is_none() {
-            progress.warn_if_slow(http_client, package_url);
-        }
-        // Close the channel so the extractor sees end-of-stream. Release
-        // the network permit before waiting on CPU work because the body is
-        // done or abandoned after a network error.
-        drop(chunk_tx);
-        drop(stream);
-        drop(client);
-        tracing::info!(target: "pacquet::download", ?package_url, "Download completed");
-        let extracted = extract_task.await.map_err(TarballError::TaskJoin)?;
-        if let Some(error) = body_error {
-            return Err(error);
-        }
-        checker.result().map_err(|error| {
-            TarballError::Checksum(VerifyChecksumError { url: package_url.to_string(), error })
-        })?;
-        let (cas_paths, pkg_files_idx) = extracted?;
-        tracing::info!(target: "pacquet::download", ?package_url, "Checksum verified");
-        progress.finish::<Reporter>();
-        return Ok((expected.clone(), cas_paths, pkg_files_idx));
+        return extract_body_while_downloading::<Reporter, _, _>(
+            prefix,
+            stream,
+            BodyHasher::new(expected_integrity),
+            &mut progress,
+            client,
+            http_client,
+            package_url,
+            store_dir,
+            ignore_file_pattern,
+        )
+        .await;
     }
 
     let buffer = {
-        let mut buf = allocate_tarball_buffer(expected_size, package_url)?;
+        // Pre-size from the advertised length, but only as far as this
+        // path will ever fill: past the threshold below the body is
+        // handed to the streaming extractor, so reserving for a larger
+        // advertised size would be reserving for bytes that never land
+        // here — and would let a server's claim, rather than its body,
+        // decide the size of an allocation.
+        let reserve =
+            expected_size.map(|size| size.min(STREAM_EXTRACT_COMPRESSED_THRESHOLD as u64));
+        let mut buf = allocate_tarball_buffer(reserve, package_url)?;
         for chunk in prefix {
             buf.extend_from_slice(&chunk);
             progress.on_chunk::<Reporter>(chunk.len());
@@ -694,6 +784,54 @@ pub(crate) async fn fetch_and_extract_once<Reporter: self::Reporter>(
             let chunk = chunk.map_err(network_error)?;
             buf.extend_from_slice(&chunk);
             progress.on_chunk::<Reporter>(chunk.len());
+            // Nothing above bounds how much body a server may send: a
+            // chunked response advertises no length at all, and an
+            // advertised one is a claim like any other. Once the body
+            // has grown to the size at which it would be extracted as a
+            // stream anyway, stop accumulating it.
+            if buf.len() < STREAM_EXTRACT_COMPRESSED_THRESHOLD {
+                continue;
+            }
+            if is_gzip {
+                // Extract from here on. The archive is decoded in full
+                // either way, so no download is refused for being large.
+                //
+                // The buffer's capacity has doubled past what arrived;
+                // hand the extractor the bytes, not the headroom.
+                buf.shrink_to_fit();
+                let _streaming_permit = streaming_extract_semaphore()
+                    .acquire()
+                    .await
+                    .expect("streaming-extract semaphore shouldn't be closed this soon");
+                return extract_body_while_downloading::<Reporter, _, _>(
+                    vec![bytes::Bytes::from(buf)],
+                    stream,
+                    BodyHasher::new(expected_integrity),
+                    &mut progress,
+                    client,
+                    http_client,
+                    package_url,
+                    store_dir,
+                    ignore_file_pattern,
+                )
+                .await;
+            }
+            // A body that does not start with the gzip magic fails at
+            // the decoder however much of it arrives, so the rest is
+            // read and dropped rather than kept. It still has to be
+            // read: when the resolution pins an integrity, a body that
+            // does not hash to it is a tampered or stale download, and
+            // saying so outranks saying it did not decode.
+            let mut hasher = BodyHasher::new(expected_integrity);
+            hasher.input(&buf);
+            drop(buf);
+            while let Some(chunk) = stream.next().await {
+                let chunk = chunk.map_err(network_error)?;
+                hasher.input(&chunk);
+                progress.on_chunk::<Reporter>(chunk.len());
+            }
+            hasher.finish(package_url)?;
+            return Err(non_gzip_body_error(prefix_len));
         }
         progress.warn_if_slow(http_client, package_url);
         progress.finish::<Reporter>();

--- a/pnpm/crates/tarball/src/extract.rs
+++ b/pnpm/crates/tarball/src/extract.rs
@@ -13,7 +13,7 @@ use pnpm_store_dir::{
 };
 use tar::Archive;
 use tracing::instrument;
-use zune_inflate::{DeflateDecoder, DeflateOptions};
+use zune_inflate::{DeflateDecoder, DeflateOptions, errors::DecodeErrorStatus};
 
 /// Build the buffer the tarball body streams into, pre-sized from the
 /// response's `Content-Length` where possible.
@@ -40,19 +40,41 @@ pub(crate) fn allocate_tarball_buffer(
     Ok(buf)
 }
 
-/// Bound a registry-supplied `dist.unpackedSize` before it reaches
-/// zune-inflate, which reserves the hint as an infallible zero-filled
-/// `vec![0; hint]` and aborts the process if that allocation fails.
+/// Bound an untrusted unpacked-size claim — the registry's
+/// `dist.unpackedSize` or the archive's own gzip trailer — before it
+/// reaches zune-inflate, which reserves the hint as an infallible
+/// zero-filled `vec![0; hint]` and aborts the process if that
+/// allocation fails.
 pub(crate) fn bounded_gzip_size_hint(unpacked_size: Option<usize>) -> Option<usize> {
     unpacked_size.map(|size| size.min(MAX_UNTRUSTED_PREALLOC_BYTES))
 }
 
+/// Decompress a whole gzipped archive into one contiguous buffer,
+/// refusing to inflate past [`MAX_UNTRUSTED_PREALLOC_BYTES`].
+///
+/// The ceiling is the same one [`should_stream_extract`] pivots on, so
+/// the two agree on how large an archive the eager path may hold — the
+/// difference being that this one measures the archive instead of
+/// trusting a hint about it. Both signals [`should_stream_extract`] has
+/// can be wrong: `dist.unpackedSize` is attacker-controlled, and the
+/// compressed length says nothing about the ratio. Integrity
+/// verification is no help either, since a gzip bomb is a legitimately
+/// published package whose hash matches. Without the ceiling the only
+/// bound is `zune-inflate`'s own 1 GiB default, which every
+/// concurrently extracting task may claim (see
+/// [`crate::post_download_semaphore`]).
+///
+/// Exceeding it is not a refusal: callers answer
+/// [`is_eager_decode_limit_exceeded`] by re-running the archive through
+/// a streaming decoder, which decodes it in full.
 #[instrument(skip(gz_data), fields(gz_data_len = gz_data.len()))]
 pub(crate) fn decompress_gzip(
     gz_data: &[u8],
     unpacked_size: Option<usize>,
 ) -> Result<Vec<u8>, TarballError> {
-    let mut options = DeflateOptions::default().set_confirm_checksum(false);
+    let mut options = DeflateOptions::default()
+        .set_confirm_checksum(false)
+        .set_limit(MAX_UNTRUSTED_PREALLOC_BYTES);
 
     if let Some(size) = bounded_gzip_size_hint(unpacked_size) {
         options = options.set_size_hint(size);
@@ -62,6 +84,105 @@ pub(crate) fn decompress_gzip(
         .decode_gzip()
         .map_err(TarballError::DecodeGzip)
 }
+
+/// Whether `error` is [`decompress_gzip`] reporting that the archive
+/// inflated past its ceiling, the one decode failure that says nothing
+/// about the archive being malformed.
+pub(crate) fn is_eager_decode_limit_exceeded(error: &TarballError) -> bool {
+    matches!(
+        error,
+        TarballError::DecodeGzip(decode) if matches!(decode.error, DecodeErrorStatus::OutputLimitExceeded(..)),
+    )
+}
+
+/// Extract a fully buffered gzipped tarball into the CAFS through
+/// whichever of the two extractors suits its size.
+///
+/// Eager extraction buys zero-copy payload slices and one big parallel
+/// write phase, and holds the whole decompressed archive to do it —
+/// multiplied across every extraction running concurrently. It is
+/// therefore taken only while the archive is small:
+/// [`should_stream_extract`] routes on the size signals available
+/// before decoding, and [`decompress_gzip`]'s ceiling catches an
+/// archive that only turns out to be large once it inflates.
+///
+/// No archive is refused for its size. Both outcomes route to
+/// [`stream_extract_gzipped_tarball`], which decodes the same bytes
+/// with the same results in bounded memory.
+pub(crate) fn extract_gzipped_tarball(
+    gz_data: &[u8],
+    unpacked_size: Option<usize>,
+    store_dir: &StoreDir,
+    ignore_file_pattern: Option<&IgnoreEntryFilter>,
+) -> Result<(HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
+    // Route on the larger of the two claims about the unpacked size.
+    // Neither is trustworthy, and taking the larger is the conservative
+    // reading: a registry hint that under-reports cannot hide a trailer
+    // that does not, or the other way round.
+    let unpacked_size = unpacked_size.max(gzip_isize_hint(gz_data));
+    if should_stream_extract(gz_data.len(), unpacked_size) {
+        return stream_extract_gzipped_tarball(gz_data, store_dir, ignore_file_pattern);
+    }
+    match decompress_gzip(gz_data, unpacked_size) {
+        Ok(tar_data) => extract_tarball_entries(&tar_data, store_dir, ignore_file_pattern),
+        Err(error) if is_eager_decode_limit_exceeded(&error) => {
+            tracing::debug!(
+                target: "pacquet::download",
+                gz_data_len = gz_data.len(),
+                "archive inflated past the eager decode ceiling; extracting it as a stream",
+            );
+            stream_extract_gzipped_tarball(gz_data, store_dir, ignore_file_pattern)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+/// The uncompressed size a gzip stream records in its own trailer.
+///
+/// The last four bytes of a gzip member are ISIZE: what it decodes to,
+/// modulo 2^32. It is the archive's own claim and no more trustworthy
+/// than the registry's `dist.unpackedSize` — but it is available where
+/// that one often is not (a lockfile records no unpacked size, so a
+/// frozen install has nothing else), and routing on it means an honest
+/// archive that inflates past the eager ceiling is streamed on the
+/// first pass instead of being decoded twice. A dishonest one is still
+/// caught by [`decompress_gzip`]'s ceiling.
+///
+/// `None` unless the buffer opens with a deflate member header — the
+/// same three bytes the decoder itself checks first. A body that will
+/// fail at the decoder anyway keeps taking the path whose diagnostic
+/// says so, rather than being routed by four bytes of whatever it
+/// happens to end with.
+pub(crate) fn gzip_isize_hint(gz_data: &[u8]) -> Option<usize> {
+    if !gz_data.starts_with(&GZIP_MAGIC) || gz_data.get(GZIP_MAGIC.len()) != Some(&GZIP_CM_DEFLATE)
+    {
+        return None;
+    }
+    let trailer: [u8; 4] = gz_data.get(gz_data.len().checked_sub(4)?..)?.try_into().ok()?;
+    usize::try_from(u32::from_le_bytes(trailer)).ok()
+}
+
+/// The decode error a body whose first bytes are not gzip will produce,
+/// raised from those bytes alone so a response that cannot be an
+/// archive is never buffered in full. `decode_gzip` rejects on the
+/// magic number, so the verdict does not depend on how much of the body
+/// has arrived.
+pub(crate) fn non_gzip_body_error(prefix_len: usize) -> TarballError {
+    let status = if prefix_len < GZIP_MAGIC.len() {
+        DecodeErrorStatus::InsufficientData
+    } else {
+        DecodeErrorStatus::CorruptData
+    };
+    TarballError::DecodeGzip(zune_inflate::errors::InflateDecodeErrors::new_with_error(status))
+}
+
+/// First bytes of every gzip member, and all a reader needs to tell an
+/// archive from whatever else a server might answer with.
+pub(crate) const GZIP_MAGIC: [u8; 2] = [0x1f, 0x8b];
+
+/// Compression method byte following [`GZIP_MAGIC`]. Deflate is the
+/// only method npm archives use and the only one the decoder accepts.
+const GZIP_CM_DEFLATE: u8 = 8;
 
 /// Compressed-size pivot for [`should_stream_extract`]. The compressed
 /// length is the one exact size we hold in hand; npm tarballs
@@ -77,11 +198,13 @@ pub(crate) const STREAM_EXTRACT_COMPRESSED_THRESHOLD: usize = 16 * 1024 * 1024;
 /// The eager path materializes the entire decompressed archive as one
 /// contiguous buffer, which for a large package multiplies across every
 /// concurrently extracting task. Stream once either signal says the
-/// archive is large: the exact compressed length, or the registry's
-/// `dist.unpackedSize` hint. The hint is attacker-controlled, but here
-/// it only picks between two correct extraction paths — a lying value
-/// costs at most the wrong path's performance profile, never
-/// correctness or unbounded memory.
+/// archive is large: the exact compressed length, or an unpacked-size
+/// claim ([`crate::extract_gzipped_tarball`] takes the larger of the
+/// registry's `dist.unpackedSize` and the gzip trailer's). A claim is
+/// attacker-controlled, but here it only picks between two correct
+/// extraction paths — a lying value costs at most the wrong path's
+/// performance profile, and [`decompress_gzip`]'s ceiling keeps even
+/// that path's memory bounded.
 pub(crate) fn should_stream_extract(compressed_len: usize, unpacked_size: Option<usize>) -> bool {
     compressed_len >= STREAM_EXTRACT_COMPRESSED_THRESHOLD
         || unpacked_size.is_some_and(|size| size >= MAX_UNTRUSTED_PREALLOC_BYTES)
@@ -92,23 +215,49 @@ pub(crate) fn should_stream_extract(compressed_len: usize, unpacked_size: Option
 /// whose post-download extraction is likely to extend the install tail.
 pub(crate) const STREAM_EXTRACT_DURING_DOWNLOAD_THRESHOLD: u64 = 4 * 1024 * 1024;
 
+/// Body chunks in flight between the download loop and the extractor.
+///
+/// The queue is what keeps the two decoupled — the extractor is
+/// normally far faster than the network, and a few chunks of slack stop
+/// a momentary stall on either side from costing throughput. It is
+/// bounded because the alternative is a queue that grows to whatever a
+/// server sends faster than the extractor can consume it, which would
+/// hand back the unbounded buffer this path exists to avoid. Reaching
+/// the bound applies backpressure to the download rather than failing
+/// it.
+pub(crate) const STREAM_CHANNEL_CHUNKS: usize = 64;
+
+/// Sender half of the queue [`ChannelBytesReader`] drains.
+///
+/// `Ok` items are payload. An `Err` item is the download loop reporting
+/// that the body failed mid-stream; it surfaces as the reader's error
+/// so the extractor unwinds instead of mistaking a truncated body for a
+/// complete archive.
+pub(crate) type BodyChunkSender = tokio::sync::mpsc::Sender<std::io::Result<bytes::Bytes>>;
+
+/// Receiver half of [`BodyChunkSender`].
+pub(crate) type BodyChunkReceiver = tokio::sync::mpsc::Receiver<std::io::Result<bytes::Bytes>>;
+
+/// Allocate the bounded queue joining an async download loop to a
+/// blocking extractor.
+pub(crate) fn body_chunk_channel() -> (BodyChunkSender, BodyChunkReceiver) {
+    tokio::sync::mpsc::channel(STREAM_CHANNEL_CHUNKS)
+}
+
 /// Blocking [`Read`] over a channel of downloaded body chunks: the
 /// bridge that lets [`extract_tarball_entries_streaming`] run on a
 /// blocking thread while the async download loop keeps feeding it.
 ///
-/// `Ok` items are payload. An `Err` item is the download loop
-/// reporting that the body failed mid-stream. It surfaces as this
-/// reader's error so the extractor unwinds instead of mistaking a
-/// truncated body for a complete archive. A closed channel (sender
-/// dropped after the last chunk) is end-of-stream.
+/// A closed channel (sender dropped after the last chunk) is
+/// end-of-stream.
 pub(crate) struct ChannelBytesReader {
-    rx: std::sync::mpsc::Receiver<std::io::Result<bytes::Bytes>>,
+    rx: BodyChunkReceiver,
     current: bytes::Bytes,
     offset: usize,
 }
 
 impl ChannelBytesReader {
-    pub(crate) fn new(rx: std::sync::mpsc::Receiver<std::io::Result<bytes::Bytes>>) -> Self {
+    pub(crate) fn new(rx: BodyChunkReceiver) -> Self {
         Self { rx, current: bytes::Bytes::new(), offset: 0 }
     }
 }
@@ -119,13 +268,16 @@ impl Read for ChannelBytesReader {
             return Ok(0);
         }
         while self.offset >= self.current.len() {
-            match self.rx.recv() {
-                Ok(Ok(chunk)) => {
+            // Only ever reached from the blocking thread the extractor
+            // runs on, which is where `blocking_recv` belongs; it
+            // panics inside an async context.
+            match self.rx.blocking_recv() {
+                Some(Ok(chunk)) => {
                     self.current = chunk;
                     self.offset = 0;
                 }
-                Ok(Err(error)) => return Err(error),
-                Err(_) => return Ok(0),
+                Some(Err(error)) => return Err(error),
+                None => return Ok(0),
             }
         }
         let take = (self.current.len() - self.offset).min(buf.len());
@@ -138,7 +290,7 @@ impl Read for ChannelBytesReader {
 /// Gunzips and CAS-writes a download delivered in chunks through `rx`.
 /// This runs on a blocking thread for the lifetime of the download.
 pub(crate) fn stream_extract_gzipped_channel(
-    rx: std::sync::mpsc::Receiver<std::io::Result<bytes::Bytes>>,
+    rx: BodyChunkReceiver,
     store_dir: &StoreDir,
     ignore_file_pattern: Option<&IgnoreEntryFilter>,
 ) -> Result<(HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
@@ -583,6 +735,26 @@ fn clean_archive_entry_path(raw: &str) -> Result<String, TarballError> {
 /// beyond which the archive is rejected as hostile.
 pub(crate) const STREAM_ENTRY_BUFFER_MAX: u64 = 4 * 1024 * 1024;
 
+/// Reject a `package.json` entry that claims more than
+/// [`MAX_UNTRUSTED_PREALLOC_BYTES`].
+///
+/// A manifest has to reach memory to be parsed — the bundled manifest
+/// and its build-script detection both come from its bytes — so a
+/// reader that otherwise holds only a bounded window has to draw the
+/// line somewhere, and silently skipping the parse would record wrong
+/// build metadata instead. Real manifests are a few KB; one past the
+/// cap exists only in a hostile archive, so failing loudly is the
+/// honest outcome.
+pub(crate) fn oversized_manifest_error(file_size: u64) -> TarballError {
+    TarballError::ReadTarballEntries(std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        format!(
+            "tar entry package.json is {file_size} bytes, which exceeds the \
+             {MAX_UNTRUSTED_PREALLOC_BYTES}-byte manifest limit",
+        ),
+    ))
+}
+
 /// Byte budget for one batch of buffered entries on the streaming
 /// extraction path. A batch flushes to [`write_pending_files`] once it
 /// holds this much payload, so peak memory stays bounded by the budget
@@ -670,24 +842,10 @@ pub(crate) fn extract_tarball_entries_streaming(
             file_build_hooks = true;
         }
 
-        // `package.json` must be buffered — the bundled manifest and
-        // its build-script detection are parsed from bytes, exactly as
-        // on the eager path — so its size is hard-capped instead:
-        // buffering an unbounded manifest would defeat this path's
-        // bounded-memory guarantee, and silently skipping the parse
-        // would record wrong build metadata. A manifest beyond the cap
-        // exists only in a hostile archive (real ones are a few KB), so
-        // failing loudly is the honest outcome. A tar entry's payload
-        // can never exceed its header size, so the pre-read check is
-        // sufficient.
+        // A tar entry's payload can never exceed its header size, so
+        // the pre-read check is sufficient.
         if cleaned_entry_path == "package.json" && file_size > MAX_UNTRUSTED_PREALLOC_BYTES as u64 {
-            return Err(TarballError::ReadTarballEntries(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!(
-                    "tar entry package.json is {file_size} bytes, which exceeds the \
-                     {MAX_UNTRUSTED_PREALLOC_BYTES}-byte manifest limit",
-                ),
-            )));
+            return Err(oversized_manifest_error(file_size));
         }
         let buffer_entry =
             file_size <= STREAM_ENTRY_BUFFER_MAX || cleaned_entry_path == "package.json";

--- a/pnpm/crates/tarball/src/lib.rs
+++ b/pnpm/crates/tarball/src/lib.rs
@@ -8,10 +8,11 @@ mod zip_archive;
 pub use download::*;
 pub use error::*;
 pub(crate) use extract::{
+    GZIP_MAGIC, STREAM_ENTRY_BUFFER_MAX, STREAM_EXTRACT_COMPRESSED_THRESHOLD,
     STREAM_EXTRACT_DURING_DOWNLOAD_THRESHOLD, allocate_tarball_buffer, apply_append_manifest,
-    apply_placeholder_manifest, decompress_gzip, extract_tarball_entries,
-    normalize_bundled_manifest, should_stream_extract, stream_extract_gzipped_channel,
-    stream_extract_gzipped_tarball, tar_entry_payload,
+    apply_placeholder_manifest, body_chunk_channel, decompress_gzip, extract_gzipped_tarball,
+    is_eager_decode_limit_exceeded, non_gzip_body_error, normalize_bundled_manifest,
+    oversized_manifest_error, stream_extract_gzipped_channel, tar_entry_payload,
 };
 pub use local_tarball::*;
 pub use prefetch::*;
@@ -86,7 +87,7 @@ fn streaming_extract_semaphore() -> &'static Semaphore {
 }
 
 /// Dedicated rayon pool for the per-file CAS-write phase of extraction
-/// ([`extract_tarball_entries`]).
+/// ([`crate::extract::extract_tarball_entries`]).
 ///
 /// Separate from the global pool because the install overlaps
 /// extraction with linking, and the linker runs on the global pool:

--- a/pnpm/crates/tarball/src/local_tarball.rs
+++ b/pnpm/crates/tarball/src/local_tarball.rs
@@ -4,9 +4,10 @@
 //! local archive without going through the store.
 
 use super::{
-    Component, Cursor, HashMap, Path, PathBuf, TarballError, allocate_tarball_buffer,
-    decompress_gzip, io, normalize_bundled_manifest, post_download_semaphore, tar_entry_payload,
-    verify_tarball_integrity,
+    Component, Cursor, HashMap, MAX_UNTRUSTED_PREALLOC_BYTES, Path, PathBuf, Read, TarballError,
+    allocate_tarball_buffer, decompress_gzip, io, is_eager_decode_limit_exceeded,
+    normalize_bundled_manifest, oversized_manifest_error, post_download_semaphore,
+    tar_entry_payload, verify_tarball_integrity,
 };
 use pnpm_package_manifest::parse_manifest_bytes;
 use ssri::Integrity;
@@ -207,12 +208,30 @@ pub async fn read_local_tarball_metadata(
         .expect("post-download semaphore shouldn't be closed this soon");
     tokio::task::spawn_blocking(move || {
         let integrity = verify_tarball_integrity(&buffer, None, package_url)?;
-        let tar_data = decompress_gzip(&buffer, None)?;
-        let (manifest, has_manifest_entry) = read_bundled_manifest(&tar_data, &tarball_path)?;
+        let (manifest, has_manifest_entry) =
+            read_bundled_manifest_from_archive(&buffer, &tarball_path)?;
         Ok(LocalTarballMetadata { integrity, manifest, has_manifest_entry })
     })
     .await
     .map_err(TarballError::TaskJoin)?
+}
+
+/// Read the root `package.json` out of a gzipped archive, decoding it
+/// whole while it is small enough for [`decompress_gzip`] and streaming
+/// it past that. See [`crate::extract::extract_gzipped_tarball`] for
+/// why the whole-archive decode has a ceiling and why reaching it is
+/// not a refusal.
+pub(crate) fn read_bundled_manifest_from_archive(
+    gz_data: &[u8],
+    tarball_path: &str,
+) -> Result<(Option<serde_json::Value>, bool), TarballError> {
+    match decompress_gzip(gz_data, None) {
+        Ok(tar_data) => read_bundled_manifest(&tar_data, tarball_path),
+        Err(error) if is_eager_decode_limit_exceeded(&error) => {
+            read_bundled_manifest_streaming(flate2::read::GzDecoder::new(gz_data), tarball_path)
+        }
+        Err(error) => Err(error),
+    }
 }
 
 /// Read the root `package.json` out of a decompressed tar stream,
@@ -242,18 +261,64 @@ pub(crate) fn read_bundled_manifest(
             continue;
         }
         let path = entry.path().map_err(TarballError::ReadTarballEntries)?;
-        let mut components = path.components().skip(1);
-        if components.next() != Some(Component::Normal("package.json".as_ref()))
-            || components.next().is_some()
-        {
+        if !is_root_manifest_entry_path(&path) {
             continue;
         }
-        drop(components);
+        drop(path);
         // Only the surviving entry is parsed, so a malformed duplicate
         // that a later one supersedes can't fail the read.
         payload = Some(tar_entry_payload(tar_data, &entry)?);
     }
     let Some(payload) = payload else { return Ok((None, false)) };
+    finish_bundled_manifest(payload, tarball_path)
+}
+
+/// [`read_bundled_manifest`] over a tar stream that is not held in
+/// memory: only the manifest entry itself is buffered, so the archive's
+/// size no longer bounds this read.
+fn read_bundled_manifest_streaming(
+    reader: impl Read,
+    tarball_path: &str,
+) -> Result<(Option<serde_json::Value>, bool), TarballError> {
+    let mut archive = Archive::new(reader);
+    let mut payload: Option<Vec<u8>> = None;
+    for entry in archive.entries().map_err(TarballError::ReadTarballEntries)? {
+        let mut entry = entry.map_err(TarballError::ReadTarballEntries)?;
+        if !entry.header().entry_type().is_file() {
+            continue;
+        }
+        let is_manifest = {
+            let path = entry.path().map_err(TarballError::ReadTarballEntries)?;
+            is_root_manifest_entry_path(&path)
+        };
+        if !is_manifest {
+            continue;
+        }
+        let file_size = entry.header().size().map_err(TarballError::ReadTarballEntries)?;
+        if file_size > MAX_UNTRUSTED_PREALLOC_BYTES as u64 {
+            return Err(oversized_manifest_error(file_size));
+        }
+        let mut data = Vec::with_capacity(file_size as usize);
+        entry.read_to_end(&mut data).map_err(TarballError::ReadTarballEntries)?;
+        payload = Some(data);
+    }
+    let Some(payload) = payload else { return Ok((None, false)) };
+    finish_bundled_manifest(&payload, tarball_path)
+}
+
+/// Whether an archive entry is the package's own `package.json` — the
+/// one directly inside the top-level directory every published tarball
+/// wraps its payload in, not a `package.json` shipped in a subdirectory.
+fn is_root_manifest_entry_path(path: &Path) -> bool {
+    let mut components = path.components().skip(1);
+    components.next() == Some(Component::Normal("package.json".as_ref()))
+        && components.next().is_none()
+}
+
+fn finish_bundled_manifest(
+    payload: &[u8],
+    tarball_path: &str,
+) -> Result<(Option<serde_json::Value>, bool), TarballError> {
     let parsed = parse_manifest_bytes(payload).map_err(|source| {
         TarballError::ParseBundledManifest { tarball: tarball_path.to_string(), source }
     })?;

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -9,7 +9,8 @@ use super::{
     extract::{
         STREAM_ENTRY_BUFFER_MAX, STREAM_EXTRACT_COMPRESSED_THRESHOLD, allocate_tarball_buffer,
         apply_append_manifest, apply_placeholder_manifest, bounded_gzip_size_hint, decompress_gzip,
-        extract_tarball_entries, normalize_bundled_manifest, should_stream_extract,
+        extract_gzipped_tarball, extract_tarball_entries, gzip_isize_hint,
+        is_eager_decode_limit_exceeded, normalize_bundled_manifest, should_stream_extract,
         stream_extract_gzipped_tarball,
     },
     local_tarball::{
@@ -17,7 +18,7 @@ use super::{
         read_local_tarball_buffer, read_local_tarball_metadata,
     },
     prefetch::{PrefetchedCasPaths, prefetch_cas_paths},
-    zip_archive::extract_zip_entries,
+    zip_archive::{extract_zip_entries, write_zip_entry_to_cas},
 };
 use pipe_trait::Pipe;
 use pnpm_network::{AuthHeaders, MAX_THROUGHPUT_PRIORITY, ThrottledClient, UNPRIORITIZED};
@@ -30,7 +31,7 @@ use pretty_assertions::assert_eq;
 use ssri::Integrity;
 use std::{
     collections::HashMap,
-    io::{Cursor, ErrorKind},
+    io::{Cursor, ErrorKind, Read},
     path::{Path, PathBuf},
     sync::Arc,
     time::Duration,
@@ -1380,6 +1381,123 @@ fn extract_tarball_reads_a_manifest_that_starts_with_a_utf8_bom() {
     drop(tempdir);
 }
 
+/// Build a gzipped tar that inflates to more than
+/// [`MAX_UNTRUSTED_PREALLOC_BYTES`] from a compressed body small enough
+/// that [`should_stream_extract`] sees nothing suspicious about it — the
+/// gzip bomb the eager decode ceiling exists for.
+///
+/// `generated` entries are `(path, size)` pairs of filler produced
+/// straight into the encoder, so the archive only ever exists
+/// compressed; `verbatim` entries carry their own bytes.
+fn gzip_bomb_tarball(generated: &[(&str, u64)], verbatim: &[(&str, &[u8])]) -> Vec<u8> {
+    fn header(size: u64) -> tar::Header {
+        let mut header = tar::Header::new_gnu();
+        header.set_size(size);
+        header.set_mode(0o644);
+        header.set_entry_type(tar::EntryType::Regular);
+        header.set_cksum();
+        header
+    }
+
+    let encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+    let mut builder = tar::Builder::new(encoder);
+    for &(path, size) in generated {
+        builder
+            .append_data(&mut header(size), path, std::io::repeat(b'a').take(size))
+            .expect("append generated entry");
+    }
+    for &(path, bytes) in verbatim {
+        builder
+            .append_data(&mut header(bytes.len() as u64), path, bytes)
+            .expect("append verbatim entry");
+    }
+    builder.into_inner().expect("finish tar").finish().expect("finish gzip")
+}
+
+/// Nothing an archive says about itself bounds what it decodes to:
+/// `dist.unpackedSize` is the publisher's claim and the compressed
+/// length says nothing about the ratio, so the eager decode measures the
+/// archive itself and stops at the ceiling.
+#[test]
+fn decompress_gzip_stops_at_the_eager_ceiling() {
+    let bomb =
+        gzip_bomb_tarball(&[("package/bomb.bin", MAX_UNTRUSTED_PREALLOC_BYTES as u64 + 1)], &[]);
+    assert!(
+        !should_stream_extract(bomb.len(), None),
+        "the compressed body must look small enough to route to the eager path",
+    );
+
+    let err = decompress_gzip(&bomb, None).expect_err("the archive must not inflate past the cap");
+    assert!(is_eager_decode_limit_exceeded(&err), "expected an output-limit refusal, got {err:?}");
+    assert!(is_transient_error(&err), "a decode failure must remain retryable");
+}
+
+/// A lockfile records no unpacked size, so on a frozen install the
+/// archive's own gzip trailer is the only claim about it there is — and
+/// a good enough one to route a large archive straight to the streaming
+/// extractor instead of discovering its size by decoding it twice.
+#[test]
+fn gzip_isize_hint_routes_a_large_archive_before_it_is_decoded() {
+    let bomb =
+        gzip_bomb_tarball(&[("package/bomb.bin", MAX_UNTRUSTED_PREALLOC_BYTES as u64 + 1)], &[]);
+    let hint = gzip_isize_hint(&bomb).expect("a gzip stream carries an unpacked size");
+    assert!(
+        hint > MAX_UNTRUSTED_PREALLOC_BYTES,
+        "the trailer must report the archive's real size, got {hint}",
+    );
+    assert!(should_stream_extract(bomb.len(), Some(hint)));
+
+    assert_eq!(gzip_isize_hint(b"not a gzip stream at all"), None);
+    // Faked magic over garbage: the trailer of a body that cannot decode
+    // is not a size, and reading it as one would route the body away
+    // from the path whose error says it is not a gzip stream.
+    let mut faked = vec![0x1f_u8, 0x8b];
+    faked.extend(std::iter::repeat_n(0xa5_u8, 64));
+    assert_eq!(gzip_isize_hint(&faked), None);
+}
+
+/// Reaching the eager decode ceiling refuses no package: an archive that
+/// under-reports its unpacked size takes the eager path, exceeds the
+/// ceiling, and is extracted in full by the streaming extractor, which
+/// holds a bounded window of it rather than the whole thing.
+#[test]
+fn extract_gzipped_tarball_streams_an_archive_past_the_eager_ceiling() {
+    let (tempdir, store_path) = tempdir_with_leaked_path();
+
+    let payload_size = MAX_UNTRUSTED_PREALLOC_BYTES as u64 + 1;
+    let mut bomb = gzip_bomb_tarball(
+        &[("package/bomb.bin", payload_size), ("package/tail.txt", 3)],
+        &[("package/package.json", br#"{"name":"bomb"}"#)],
+    );
+    // Rewrite the trailer's unpacked size so nothing warns the router
+    // ahead of the decode — the shape a bomb takes once the trailer is
+    // a signal.
+    let trailer = bomb.len() - 4;
+    bomb[trailer..].copy_from_slice(&1024_u32.to_le_bytes());
+    assert!(
+        !should_stream_extract(bomb.len(), gzip_isize_hint(&bomb)),
+        "the fixture must look small enough to route to the eager path",
+    );
+
+    let (cas_paths, pkg_files_idx) = extract_gzipped_tarball(&bomb, None, store_path, None)
+        .expect("an archive past the eager ceiling must still extract");
+
+    dbg!(cas_paths.keys().collect::<Vec<_>>());
+    assert_eq!(pkg_files_idx.files["bomb.bin"].size, payload_size);
+    assert_eq!(
+        std::fs::metadata(&cas_paths["bomb.bin"]).expect("stat the streamed entry").len(),
+        payload_size,
+        "the oversized entry must land in the CAS in full",
+    );
+    assert_eq!(
+        std::fs::read(&cas_paths["tail.txt"]).expect("read the trailing entry"),
+        b"aaa",
+        "entries after the oversized one must still be extracted",
+    );
+
+    drop(tempdir);
+}
+
 #[test]
 fn should_stream_extract_pivots_on_compressed_size_and_unpacked_hint() {
     assert!(!should_stream_extract(0, None));
@@ -1928,6 +2046,31 @@ async fn read_local_tarball_metadata_reads_integrity_and_bundled_manifest() {
     let manifest = metadata.manifest.expect("bundled manifest");
     assert_eq!(manifest.get("name").and_then(serde_json::Value::as_str), Some("@fastify/error"));
     assert_eq!(manifest.get("version").and_then(serde_json::Value::as_str), Some("3.3.0"));
+}
+
+/// A `file:` tarball is read to learn the name and version its
+/// specifier does not carry, so the eager decode ceiling must not turn
+/// a large local archive into an unresolvable dependency: past the
+/// ceiling the manifest is found by streaming instead.
+#[tokio::test]
+async fn read_local_tarball_metadata_reads_a_manifest_past_the_eager_ceiling() {
+    let local_dir = tempdir().unwrap();
+    let tarball_path = local_dir.path().join("pkg.tgz");
+
+    let archive = gzip_bomb_tarball(
+        &[("package/payload.bin", MAX_UNTRUSTED_PREALLOC_BYTES as u64 + 1)],
+        &[("package/package.json", br#"{"name":"huge","version":"1.0.0"}"#)],
+    );
+    std::fs::write(&tarball_path, &archive).unwrap();
+
+    let metadata = read_local_tarball_metadata(&tarball_path)
+        .await
+        .expect("an archive past the eager ceiling must still resolve");
+
+    let manifest = metadata.manifest.expect("bundled manifest");
+    assert_eq!(manifest.get("name").and_then(serde_json::Value::as_str), Some("huge"));
+    assert_eq!(manifest.get("version").and_then(serde_json::Value::as_str), Some("1.0.0"));
+    assert!(metadata.has_manifest_entry);
 }
 
 /// The manifest is the package's only source of identity here, so an
@@ -3898,6 +4041,94 @@ fn extract_zip_normalizes_dot_segments_in_entry_paths() {
     drop(tempdir);
 }
 
+/// A source that keeps producing bytes, counting how many were taken
+/// from it. `cap` is a safety net for the very regression under test: a
+/// caller that forgets to bound its read gets an error instead of an
+/// endless loop, and the byte count says what happened.
+struct EndlessReader {
+    bytes_read: u64,
+    cap: u64,
+}
+
+impl Read for EndlessReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if self.bytes_read >= self.cap {
+            return Err(std::io::Error::other("test reader ran past its safety cap"));
+        }
+        let take = buf.len().min(usize::try_from(self.cap - self.bytes_read).unwrap_or(usize::MAX));
+        buf[..take].fill(b'x');
+        self.bytes_read += take as u64;
+        Ok(take)
+    }
+}
+
+/// A zip entry's decompressed size is a claim in the central directory,
+/// not a limit the deflate stream behind it respects. An entry that
+/// keeps producing bytes past what it declared is the zip bomb: it must
+/// be rejected, and the read must stop rather than following the stream
+/// to wherever it ends — on the buffered and the direct-to-store branch
+/// alike.
+#[test]
+fn write_zip_entry_to_cas_stops_reading_an_entry_longer_than_it_claims() {
+    let (tempdir, store_path) = tempdir_with_leaked_path();
+
+    for declared_size in [16, STREAM_ENTRY_BUFFER_MAX + 1] {
+        let mut liar = EndlessReader { bytes_read: 0, cap: declared_size * 8 };
+        let err = write_zip_entry_to_cas(
+            &mut liar,
+            declared_size,
+            "https://example.test/bomb.zip",
+            "big.bin",
+            store_path,
+            false,
+        )
+        .expect_err("an entry that outruns its declared size must be rejected");
+        assert!(
+            matches!(err, TarballError::ReadZipEntries { .. }),
+            "expected ReadZipEntries for declared_size {declared_size}, got {err:?}",
+        );
+        assert!(
+            liar.bytes_read <= declared_size + 1,
+            "the read must stop just past the declared {declared_size} bytes, took {}",
+            liar.bytes_read,
+        );
+    }
+
+    drop(tempdir);
+}
+
+/// The counterpart of the rejection above: a truthful entry past the
+/// buffering ceiling streams into the CAS in full, so bounding the read
+/// costs a runtime archive's biggest member nothing.
+#[test]
+fn write_zip_entry_to_cas_streams_a_truthful_oversized_entry() {
+    let (tempdir, store_path) = tempdir_with_leaked_path();
+
+    let declared_size = STREAM_ENTRY_BUFFER_MAX + 1;
+    let mut payload = std::io::repeat(b'x').take(declared_size);
+    let (file_path, _, size) = write_zip_entry_to_cas(
+        &mut payload,
+        declared_size,
+        "https://example.test/runtime.zip",
+        "bin/node",
+        store_path,
+        true,
+    )
+    .expect("an oversized entry must stream into the store");
+
+    assert_eq!(size, declared_size);
+    assert_eq!(
+        std::fs::metadata(&file_path).expect("stat the streamed entry").len(),
+        declared_size,
+    );
+    assert!(
+        file_path.to_string_lossy().ends_with("-exec"),
+        "executable entries must keep the -exec CAS suffix on the streaming branch",
+    );
+
+    drop(tempdir);
+}
+
 /// `offline: true` short-circuits the fetcher before any network
 /// request when the package isn't in the local store. Mocks a server
 /// with `.expect(0)` so the assertion fires *only* if the fetcher
@@ -4516,7 +4747,7 @@ async fn streaming_download_extracts_a_big_pinned_tarball() {
 
     let (reference_keep, reference_store) = tempdir_with_leaked_path();
     let (reference_paths, reference_idx) =
-        super::stream_extract_gzipped_tarball(&body, reference_store, None)
+        stream_extract_gzipped_tarball(&body, reference_store, None)
             .expect("the reference extraction of the same bytes must succeed");
     assert_eq!(
         cas_paths.keys().collect::<std::collections::BTreeSet<_>>(),
@@ -4537,6 +4768,115 @@ async fn streaming_download_extracts_a_big_pinned_tarball() {
     );
 
     drop(reference_keep);
+    drop(store_dir_keep);
+}
+
+/// A chunked response advertises no length, so nothing decides up front
+/// that its body is large — the buffered path has to notice while it
+/// runs. Past the point where the archive would be extracted as a stream
+/// anyway, it is, and the download completes as it would have with a
+/// `Content-Length`.
+#[tokio::test]
+async fn chunked_download_extracts_a_body_past_the_buffering_threshold() {
+    let (store_dir_keep, store_path) = tempdir_with_leaked_path();
+    let body = incompressible_tarball(STREAM_EXTRACT_COMPRESSED_THRESHOLD);
+    assert!(
+        body.len() > STREAM_EXTRACT_COMPRESSED_THRESHOLD,
+        "the body must outgrow the buffering threshold to exercise the handover",
+    );
+    let pinned = Integrity::from(&body);
+
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/pkg.tgz")
+        .with_status(200)
+        .with_chunked_body(move |writer| writer.write_all(&body))
+        .expect(1)
+        .create_async()
+        .await;
+    let url = format!("{}/pkg.tgz", server.url());
+
+    let (verified, cas_paths, _) = fetch_and_extract_with_retry::<SilentReporter>(
+        &ThrottledClient::default(),
+        &url,
+        Some(&pinned),
+        None,
+        0,
+        "noise@1.0.0",
+        "",
+        store_path,
+        fast_retry_opts(),
+        &AuthHeaders::default(),
+        None,
+        None,
+    )
+    .await
+    .expect("a chunked body must download and extract");
+    mock.assert_async().await;
+
+    assert_eq!(verified.to_string(), pinned.to_string());
+    assert!(cas_paths.contains_key("noise.bin"), "got {:?}", cas_paths.keys().collect::<Vec<_>>());
+    drop(store_dir_keep);
+}
+
+/// A body that never was an archive still has to be read to its end
+/// before it can be judged: whether it hashes to the pinned integrity is
+/// what decides between "someone tampered with this download" and "this
+/// package is not a gzip stream". Dropping the bytes instead of keeping
+/// them must not change which of the two is reported.
+#[tokio::test]
+async fn oversized_non_gzip_body_reports_the_integrity_verdict_first() {
+    let (store_dir_keep, store_path) = tempdir_with_leaked_path();
+    let body = vec![b'n'; STREAM_EXTRACT_COMPRESSED_THRESHOLD + (1 << 16)];
+    let matching = Integrity::from(&body);
+    let wrong = Integrity::from(b"the body the registry was supposed to serve");
+
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/pkg.tgz")
+        .with_status(200)
+        .with_body(body)
+        .expect(6)
+        .create_async()
+        .await;
+    let url = format!("{}/pkg.tgz", server.url());
+
+    async fn fetch_err(
+        url: &str,
+        pinned: &Integrity,
+        store_path: &'static StoreDir,
+    ) -> TarballError {
+        fetch_and_extract_with_retry::<SilentReporter>(
+            &ThrottledClient::default(),
+            url,
+            Some(pinned),
+            None,
+            0,
+            "noise@1.0.0",
+            "",
+            store_path,
+            fast_retry_opts(),
+            &AuthHeaders::default(),
+            None,
+            None,
+        )
+        .await
+        .expect_err("a body that is not an archive must fail")
+    }
+
+    let err = fetch_err(&url, &wrong, store_path).await;
+    assert!(
+        matches!(err, TarballError::Checksum(_)),
+        "a body that does not hash to the pinned integrity must report that, got {err:?}",
+    );
+
+    let err = fetch_err(&url, &matching, store_path).await;
+    assert!(
+        matches!(err, TarballError::DecodeGzip(_)),
+        "a body that hashes correctly but is not gzip must report the decode failure, got {err:?}",
+    );
+
+    mock.assert_async().await;
     drop(store_dir_keep);
 }
 

--- a/pnpm/crates/tarball/src/zip_archive.rs
+++ b/pnpm/crates/tarball/src/zip_archive.rs
@@ -6,7 +6,7 @@
 
 use super::{
     Arc, Component, Cursor, Duration, HashMap, HttpStatusError, IgnoreEntryFilter, Instant,
-    MAX_UNTRUSTED_PREALLOC_BYTES, NetworkError, PathBuf, PrefetchedCasPaths, Read, TarballError,
+    NetworkError, PathBuf, PrefetchedCasPaths, Read, STREAM_ENTRY_BUFFER_MAX, TarballError,
     UNIX_EPOCH, VerifyChecksumError, allocate_tarball_buffer, apply_append_manifest,
     apply_placeholder_manifest, emit_progress_found_in_store, is_transient_error,
     load_cached_cas_paths, post_download_semaphore, tarball_error_to_request_retry,
@@ -18,8 +18,8 @@ use pnpm_reporter::{
     Reporter, RequestRetryLog,
 };
 use pnpm_store_dir::{
-    CafsFileInfo, PackageFilesIndex, SharedReadonlyStoreIndex, SharedVerifiedFilesCache, StoreDir,
-    StoreIndexWriter, store_index_key,
+    CafsFileInfo, FileHash, PackageFilesIndex, SharedReadonlyStoreIndex, SharedVerifiedFilesCache,
+    StoreDir, StoreIndexWriter, WriteCasFileFromReaderError, store_index_key,
 };
 use ssri::Integrity;
 
@@ -140,22 +140,6 @@ pub(crate) fn extract_zip_entries(
             continue;
         }
 
-        let prealloc_hint = entry.size().min(MAX_UNTRUSTED_PREALLOC_BYTES as u64) as usize;
-        let mut buffer = Vec::new();
-        buffer.try_reserve(prealloc_hint).map_err(|err| TarballError::ReadZipEntries {
-            url: package_url.to_string(),
-            entry_path: cleaned.clone(),
-            source: std::io::Error::new(
-                std::io::ErrorKind::OutOfMemory,
-                format!("failed to reserve {prealloc_hint} bytes for zip entry: {err}"),
-            ),
-        })?;
-        entry.read_to_end(&mut buffer).map_err(|source| TarballError::ReadZipEntries {
-            url: package_url.to_string(),
-            entry_path: cleaned.clone(),
-            source,
-        })?;
-
         // Central-directory record carries a Unix mode only when
         // the archive was built by a Unix tool; Windows-built
         // archives omit it. Fall back to `0o644` so the executable
@@ -165,12 +149,17 @@ pub(crate) fn extract_zip_entries(
         // `add_files_from_dir.rs` enforces for tar / on-disk imports.
         let file_mode = entry.unix_mode().unwrap_or(0o644) & 0o777;
         let file_is_executable = file_mode::is_executable(file_mode);
+        let declared_size = entry.size();
 
-        let (file_path, file_hash) = store_dir
-            .write_cas_file(&buffer, file_is_executable)
-            .map_err(TarballError::WriteCasFile)?;
+        let (file_path, file_hash, file_size) = write_zip_entry_to_cas(
+            &mut entry,
+            declared_size,
+            package_url,
+            &cleaned,
+            store_dir,
+            file_is_executable,
+        )?;
 
-        let file_size = u64::try_from(buffer.len()).unwrap_or(u64::MAX);
         let checked_at =
             UNIX_EPOCH.elapsed().ok().and_then(|elapsed| u64::try_from(elapsed.as_millis()).ok());
         let file_attrs = CafsFileInfo {
@@ -189,6 +178,77 @@ pub(crate) fn extract_zip_entries(
     }
 
     Ok((cas_paths, pkg_files_idx))
+}
+
+/// Hash one zip entry into the content-addressed store, holding it in
+/// memory only while it is small.
+///
+/// Nothing in a zip archive bounds an entry's decompressed size:
+/// `uncompressed_size` in the central directory is a claim, and the
+/// deflate stream behind it keeps producing bytes for as long as it
+/// likes — a tar entry, by contrast, is raw bytes the header's size
+/// field genuinely delimits. Both branches below therefore read through
+/// a [`Read::take`] of the claim and reject an entry whose payload
+/// outruns it, rather than growing to whatever it decodes to.
+///
+/// Entries above [`STREAM_ENTRY_BUFFER_MAX`] go straight into the store
+/// with an incremental hash, the same shape
+/// [`crate::extract::extract_tarball_entries_streaming`] gives a large
+/// tar entry, so a runtime archive's biggest member never has to fit in
+/// memory.
+///
+/// Returns the CAS path, the content hash, and the entry's size.
+pub(crate) fn write_zip_entry_to_cas(
+    entry: &mut impl Read,
+    declared_size: u64,
+    package_url: &str,
+    entry_path: &str,
+    store_dir: &StoreDir,
+    executable: bool,
+) -> Result<(PathBuf, FileHash, u64), TarballError> {
+    let read_error = |source| TarballError::ReadZipEntries {
+        url: package_url.to_string(),
+        entry_path: entry_path.to_string(),
+        source,
+    };
+    // One byte past the claim is all it takes to tell a truthful entry
+    // from one whose payload keeps going.
+    let mut bounded = entry.take(declared_size.saturating_add(1));
+
+    if declared_size > STREAM_ENTRY_BUFFER_MAX {
+        // `Some(declared_size)` makes the store writer reject a stream
+        // that runs short or long before anything is committed to a
+        // content-addressed path.
+        return store_dir
+            .write_cas_file_from_reader(&mut bounded, executable, Some(declared_size))
+            .map_err(|error| match error {
+                WriteCasFileFromReaderError::Read(error) => read_error(error),
+                WriteCasFileFromReaderError::Write(error) => TarballError::WriteCasFile(error),
+            });
+    }
+
+    let prealloc = declared_size as usize;
+    let mut buffer = Vec::new();
+    buffer.try_reserve(prealloc).map_err(|err| {
+        read_error(std::io::Error::new(
+            std::io::ErrorKind::OutOfMemory,
+            format!("failed to reserve {prealloc} bytes for zip entry: {err}"),
+        ))
+    })?;
+    bounded.read_to_end(&mut buffer).map_err(read_error)?;
+    if buffer.len() as u64 != declared_size {
+        return Err(read_error(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "zip entry decompressed to {} bytes where its central-directory record claims {declared_size}",
+                buffer.len(),
+            ),
+        )));
+    }
+
+    let (file_path, file_hash) =
+        store_dir.write_cas_file(&buffer, executable).map_err(TarballError::WriteCasFile)?;
+    Ok((file_path, file_hash, declared_size))
 }
 
 /// Run one full zip-archive fetch attempt: hit the network, drain the


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#13656, which asked for a decision before a patch: whether the unbounded allocation paths in `pacquet-tarball` are a pnpm weakness at all, what ceiling a fix would impose, and what happens to a real package that exceeds it.

**The decision: bound how much is held at once, never how much may be installed.** Every path below is answered by extracting the archive as a stream instead of refusing it, so there is no ceiling on package size, no new error a user can hit, and no divergence to mirror — a package that installed before still installs.

That framing also settles the "is this an advisory" question. It is not. The TypeScript CLI has the same exposure or worse on all three of the issue's paths:

| path | TypeScript pnpm CLI | pacquet before | pacquet after |
| --- | --- | --- | --- |
| gzip decode | `gunzipSync(tarballBuffer)` over the whole archive, no `maxOutputLength` (`store/cafs/src/addFilesFromTarball.ts:30`) | zune-inflate's 1 GiB default, times every concurrent extraction | 64 MiB, then streamed |
| response body | accumulated into one `SharedArrayBuffer`; the chunked branch has no length to check against (`fetching/tarball-fetcher/src/remoteTarballFetcher.ts:181`) | accumulated with no ceiling | handed to the streaming extractor at 16 MiB |
| zip entry | `adm-zip` reads the whole zip, then inflates each entry into memory (`fetching/binary-fetcher/src/index.ts:185`) | `read_to_end` on a deflate stream nothing bounds | read to the declared size; streamed above 4 MiB |

Integrity verification is not a defence on any of them: a gzip bomb published to npm is a legitimate package whose hash matches its lockfile entry. Neither is `dist.unpackedSize` — it is the publisher's claim, and on a frozen install there is none at all, because a lockfile records no unpacked size.

### What changed

- **Whole-archive gzip decode** stops at `MAX_UNTRUSTED_PREALLOC_BYTES` (64 MiB), the same ceiling `should_stream_extract` already routes on. Reaching it is not an error: the archive is re-run through the streaming extractor and decoded in full. `read_local_tarball_metadata` gets the same fallback, so a large `file:` tarball still resolves.
- **Response bodies** are handed to the streaming extractor once the buffer reaches the size at which the archive would be extracted as a stream anyway. That covers a chunked response (no advertised length at all — how `codeload.github.com` serves git-hosted archives), a body that outruns the length it advertised, and a retry. The buffer is also pre-sized only as far as it can fill, so an advertised `Content-Length` no longer sizes an allocation it will never occupy. A body that is not a gzip stream is drained and dropped rather than accumulated — but still hashed, so a pinned integrity keeps producing the verdict that outranks the decode failure.
- **The queue between the download loop and the extractor** is now bounded. This one is not in the issue; I hit it writing the fix. An unbounded channel between an async producer and a blocking consumer holds whatever a server sends faster than the extractor consumes it — which would have handed back the very buffer the streaming path exists to avoid. It was only ever bounded because the alternative path held the whole body too. A bounded `tokio` channel with a blocking receive on the extractor's thread applies backpressure to the download instead.
- **Zip entries** are read only as far as the size the central directory records, and one above the entry-buffer ceiling streams straight into the store. Nothing in a zip bounds an entry's decompressed size on its own; a tar entry is different, because its header size genuinely delimits raw bytes.
- **Routing now reads the gzip trailer's unpacked size.** This is what keeps the ceiling from costing anything: `ISIZE` is available exactly where `dist.unpackedSize` is not, so a large archive goes to the streaming extractor on the first pass instead of being decoded twice to discover how large it was. It is read only behind a well-formed deflate header, so a corrupt body keeps reporting the decode error rather than being routed by four bytes of whatever it happens to end with.

### Benchmark

The issue asked for a before/after on a large real lockfile. Here it is, from the Pacquet Integrated-Benchmark on this PR — the 1356-snapshot `alotta-modules` fixture, both revisions built and run in the same job on the same runner:

| scenario | `pacquet@main` | `pacquet@HEAD` |
| --- | --- | --- |
| fresh restore, cold cache + cold store | 2.567 s ± 0.127 | 2.570 s ± 0.097 |
| fresh install, cold cache + cold store | 2.928 s ± 0.112 | 2.998 s ± 0.076 |
| fresh restore, hot cache + hot store | 372.3 ms ± 24.7 | 354.0 ms ± 20.2 |
| repeat install, hot cache + hot store | 14.5 ms ± 2.4 | 11.9 ms ± 1.6 |
| repeat install, cold cache + hot store | 12.2 ms ± 2.6 | 12.9 ms ± 2.1 |

Flat. The cold-cache restore — the scenario the issue named, and the one that actually downloads and extracts all 1356 snapshots — moves by 0.1%, well inside its own error bars, and every other scenario overlaps too.

That is the expected result, and the reason is the whole design of the ceiling. On the hot path this adds a four-byte read of the gzip trailer per archive, one `usize` comparison per body chunk, and a `Take` per zip entry. The ceiling itself would cost a second decode for any archive inflating past 64 MiB — which on a frozen install used to mean *any* such archive, since a lockfile carries no unpacked size to route on. Routing on the trailer is what avoids that: an honest large archive is streamed on the first pass, and only one that lies about its own size pays twice.

**On the two red checks that reference benchmarks**, both are environmental rather than caused by this change; the measurements are in [this comment](#issuecomment-5412109787) and the one below it:

- The **micro-benchmark** comment reports `tarball/download_dependency` at 1.39×. Re-run on one idle machine against `main`, it is 2.3055 ms here versus 2.3284 ms on main — marginally faster. Its fixture is a 4 KB tarball, orders of magnitude below every threshold this PR adds.
- The **Bencher Report** alerts on the two `repeat-install` scenarios, which short-circuit an up-to-date tree and never download or extract anything. Its baselines are 6.35 / 6.54 ms, but `main` measured 14.5 / 12.2 ms *in this same job* — above the 7.85 / 7.62 ms boundaries it flagged this branch for. The controlled in-run comparison has this branch faster on one and level on the other.

### What is deliberately still unbounded

- A zip archive's own body must be fully buffered — the central directory is at the end, so `ZipArchive::new` cannot start without all of it.
- A truthful, genuinely huge zip entry streams to disk. Bounded RAM, unbounded disk, which is what npm does too.
- Retries of a body under the handover threshold stay buffered, so their terminal errors keep the whole-archive decode's diagnostics.

### Parity

Nothing here is user-visible, so there is nothing to mirror in the TypeScript CLI for behavioural parity. Giving the TypeScript stack the same memory property is a real and separate piece of work: `parseTarball` is an index-only scan over one contiguous decompressed buffer and `addFilesFromTarball` hands out zero-copy `subarray` views of it, so bounding it means replacing that design, not adding a limit. Tracked in pnpm/pnpm#14164.

One error-code detail worth flagging: a non-gzip response body larger than 16 MiB previously surfaced `ERR_PNPM_TARBALL_IO_ERROR` (it was routed to the streaming extractor by its compressed size and failed in the tar reader) and now surfaces `ERR_PNPM_TARBALL_DECODE_GZIP`, which is what the same body under 16 MiB already reported. Both are retryable, so retry behaviour is unchanged; the inconsistency is simply gone.

### Testing

Eight new tests in `pnpm/crates/tarball/src/tests.rs`, each verified to fail when the code it covers is broken: the decode ceiling firing, the streaming fallback extracting an archive that under-reports its trailer, the trailer routing a large archive before any decode, a `file:` tarball past the ceiling still resolving, a zip entry's read stopping just past its declared size (asserted on the byte count, not just the rejection), a truthful oversized zip entry streaming in full, a chunked body past the handover threshold, and the integrity verdict still outranking the decode failure on an oversized non-gzip body.

## Squash Commit Body

```text
Four decode paths grew to whatever the archive or the server produced,
and nothing upstream of them bounded it. The lockfile's integrity does
not: a gzip bomb is a legitimately published package whose hash matches.
The registry's `dist.unpackedSize` does not either — it is the
publisher's claim, and on a frozen install there is none at all, since a
lockfile records no unpacked size.

- The whole-archive gzip decode now stops at `MAX_UNTRUSTED_PREALLOC_BYTES`,
  the same ceiling `should_stream_extract` routes on, instead of relying
  on zune-inflate's 1 GiB default that every concurrent extraction may
  claim. Reaching it is not a refusal: the archive is re-run through the
  streaming extractor and decoded in full. `read_local_tarball_metadata`
  gets the same fallback, so a large `file:` tarball still resolves.
- A response body that keeps arriving is handed to the streaming
  extractor once it reaches the size at which it would be extracted as a
  stream anyway, so a chunked response — which advertises no length —
  and a body that outruns the length it advertised both stop growing the
  buffer. The buffer is also pre-sized only as far as it can fill, so an
  advertised `Content-Length` no longer decides the size of an
  allocation it will never occupy. A body that is not a gzip stream is
  drained and dropped rather than accumulated, after being hashed, so a
  pinned integrity still produces the verdict that outranks the decode
  failure.
- The queue joining the download loop to the streaming extractor is
  bounded. An unbounded channel between an async producer and a blocking
  consumer holds whatever a server sends faster than the extractor
  consumes it, which would hand back the very buffer this path exists to
  avoid; it was only ever bounded by the buffered alternative holding
  the whole body too. A bounded tokio channel with a blocking receive on
  the extractor's thread applies backpressure to the download instead.
- A zip entry is read only as far as the size its central directory
  records, and one above the entry buffer ceiling streams straight into
  the store. Nothing in a zip bounds an entry's decompressed size on its
  own — unlike a tar entry, whose header size genuinely delimits it.

No archive is refused for being large, so nothing that installed before
stops installing. Routing now consults the gzip trailer's unpacked size,
which the frozen-install path had no equivalent of, so a large archive
goes to the streaming extractor on the first pass rather than being
decoded twice to discover how large it was. It is read only behind a
well-formed deflate header, so a corrupt body keeps reporting the decode
error rather than being routed by four bytes of whatever it ends with.

One error code moves: a non-gzip response body larger than 16 MiB
reported `ERR_PNPM_TARBALL_IO_ERROR`, having been routed to the
streaming extractor by its compressed size and failed in the tar reader,
and now reports `ERR_PNPM_TARBALL_DECODE_GZIP` — what the same body
under 16 MiB already reported. Both are retryable, so retry behavior is
unchanged.

The TypeScript CLI has the same exposure on all three of the issue's
paths — it buffers the whole body, `gunzipSync`es the whole archive, and
inflates each zip entry through adm-zip, with no ceiling anywhere.
Bounding pacquet's decode changes no observable behavior, so there is
nothing to mirror for parity; giving the TypeScript stack the same
property means replacing `parseTarball`'s index-scan-over-one-buffer
design, and is tracked separately.

Closes pnpm/pnpm#13656
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).
