### PR TITLE
fix(global-virtual-store): give every slot the manifest a dependency's script looks for

### DIFF
--- a/.changeset/gvs-slot-is-not-a-project.md
+++ b/.changeset/gvs-slot-is-not-a-project.md
@@ -1,0 +1,19 @@
+---
+"@pnpm/deps.graph-hasher": patch
+"@pnpm/installing.deps-restorer": patch
+"@pnpm/installing.deps-installer": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+With `virtualStoreType: global`, a dependency's lifecycle scripts run inside the store, where the directory above their `node_modules` is a store slot rather than the project that installed them. A package that reads the manifest there — the convention git-hook installers use to find their consumer — took the install down with an `ENOENT`. Every slot now carries a manifest that declares nothing, so the read resolves and the install proceeds [#13318](https://github.com/pnpm/pnpm/issues/13318).
+
+pnpm does not run a dependency's lifecycle scripts on behalf of the project that installed it, and a shared store makes that plain: one build serves every project that resolves the same dependencies. A package that has to act on your repository — installing git hooks, for example — belongs in a script of your own project, which does run there:
+
+```json
+{
+  "scripts": {
+    "prepare": "simple-git-hooks"
+  }
+}
+```

--- a/cspell.json
+++ b/cspell.json
@@ -130,6 +130,7 @@
     "garply",
     "gcttmf",
     "getattr",
+    "getcwd",
     "ghes",
     "ghsa",
     "ghsas",

--- a/pnpm/crates/cli/tests/suite/global_virtual_store.rs
+++ b/pnpm/crates/cli/tests/suite/global_virtual_store.rs
@@ -1548,12 +1548,16 @@ fn a_lifecycle_script_may_read_the_manifest_above_its_node_modules() {
     );
 
     // What the script read is the slot, and it declares nothing about the
-    // project that installed the package.
+    // project that installed the package. Both sides are resolved before they
+    // are compared: the script derives its path from `process.cwd()`, which is
+    // `getcwd()` and therefore physical, while the harness's temp dir reaches
+    // it through a symlink on macOS.
     let read_from = pkg_in_slot(&slot_dir, "@pnpm.e2e/reads-consumer-manifest")
         .join("read-consumer-manifest-from.txt");
+    let recorded = fs::read_to_string(&read_from).expect("read what the script recorded");
     assert_eq!(
-        fs::read_to_string(&read_from).expect("read what the script recorded"),
-        slot_dir.to_string_lossy(),
+        fs::canonicalize(&recorded).expect("resolve the path the script recorded"),
+        fs::canonicalize(&slot_dir).expect("resolve the slot"),
     );
 
     drop((root, mock_instance));

--- a/pnpm/crates/cli/tests/suite/global_virtual_store.rs
+++ b/pnpm/crates/cli/tests/suite/global_virtual_store.rs
@@ -1516,3 +1516,45 @@ fn virtual_store_type_selects_where_packages_are_materialized() {
         drop((root, mock_instance));
     }
 }
+
+/// A dependency's lifecycle script runs in the store, where the directory above
+/// its `node_modules` is a slot rather than the project that installed it.
+/// Reading the manifest there is how every git-hook installer looks for its
+/// consumer; pnpm does not run a dependency's scripts on a project's behalf,
+/// but the read has to resolve rather than take the install down with it.
+/// <https://github.com/pnpm/pnpm/issues/13318>
+#[test]
+fn a_lifecycle_script_may_read_the_manifest_above_its_node_modules() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { store_dir, mock_instance, .. } = npmrc_info;
+
+    write_manifest(
+        &workspace,
+        &serde_json::json!({ "@pnpm.e2e/reads-consumer-manifest": "1.0.0" }),
+    );
+    set_gvs_workspace_yaml(
+        &workspace,
+        &allow_builds_yaml(&[("@pnpm.e2e/reads-consumer-manifest", true)]),
+    );
+
+    pacquet(&workspace).with_arg("install").assert().success();
+
+    let slot_dir =
+        sole_hash_dir(&pkg_version_dir(&store_dir, "@pnpm.e2e/reads-consumer-manifest", "1.0.0"));
+    assert_eq!(
+        fs::read_to_string(slot_dir.join("package.json")).expect("read the slot manifest"),
+        "{\n  \"private\": true\n}\n",
+    );
+
+    // What the script read is the slot, and it declares nothing about the
+    // project that installed the package.
+    let read_from = pkg_in_slot(&slot_dir, "@pnpm.e2e/reads-consumer-manifest")
+        .join("read-consumer-manifest-from.txt");
+    assert_eq!(
+        fs::read_to_string(&read_from).expect("read what the script recorded"),
+        slot_dir.to_string_lossy(),
+    );
+
+    drop((root, mock_instance));
+}

--- a/pnpm/crates/cli/tests/suite/pnpm_compatibility.rs
+++ b/pnpm/crates/cli/tests/suite/pnpm_compatibility.rs
@@ -233,7 +233,19 @@ fn gvs_paths_only(files: Vec<String>) -> Vec<String> {
     files
         .into_iter()
         .filter(|path| path.starts_with("links/") || path.starts_with("v11/links/"))
+        .filter(|path| !is_slot_manifest(path))
         .collect()
+}
+
+/// The manifest a slot carries to say it is not a project (see
+/// `write_slot_manifest`). It sits directly in the slot, one directory above
+/// the `node_modules` every other slot path goes through — and the `pnpm` this
+/// test compares against is whichever release is on `PATH`, which only writes
+/// it from the version that ships this. The subject here is where the two
+/// stacks address their slots, not which bookkeeping files pnpm keeps in them.
+fn is_slot_manifest(path: &str) -> bool {
+    path.rsplit_once('/')
+        .is_some_and(|(slot, file)| file == "package.json" && !slot.contains("/node_modules"))
 }
 
 /// Run pnpm-then-pacquet against a shared workspace and compare the

--- a/pnpm/crates/deps-restorer/src/create_virtual_dir_by_snapshot.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_dir_by_snapshot.rs
@@ -16,6 +16,7 @@ use pnpm_reporter::{
 use std::{
     collections::HashMap,
     fs, io,
+    io::Write,
     path::{Path, PathBuf},
     sync::atomic::AtomicU8,
 };
@@ -90,6 +91,45 @@ pub struct CreateVirtualDirBySnapshot<'a> {
     pub link_concurrency_probe: Option<&'a tests::LinkConcurrencyProbe>,
 }
 
+/// The manifest every global virtual store slot carries, and what it is for.
+///
+/// A dependency's lifecycle scripts run in `<slot>/node_modules/<name>`. A
+/// package that wants to know which project installed it reads the manifest
+/// above that `node_modules` — the convention every git-hook installer
+/// follows. In a project's own virtual store it finds the project; a slot is
+/// shared by every project that resolves the same dependencies, so there is no
+/// project there to find, and pnpm does not run a dependency's scripts on any
+/// project's behalf. The read still has to resolve, or a package that merely
+/// *looks* takes the install down with it
+/// ([pnpm/pnpm#13318](https://github.com/pnpm/pnpm/issues/13318)) — so the slot
+/// answers with a manifest that declares nothing.
+///
+/// Byte-identical to what the TypeScript CLI writes
+/// (`writeVirtualStoreSlotManifest`), since both fill the same store.
+const VIRTUAL_STORE_SLOT_MANIFEST: &str = "{\n  \"private\": true\n}\n";
+
+/// Write [`VIRTUAL_STORE_SLOT_MANIFEST`] into a slot, once.
+///
+/// Concurrent installs materialize the same slot, so losing the race is
+/// success — every writer has the same bytes. A failure is not worth failing an
+/// install over either: the manifest only keeps a package that looks for its
+/// consumer from crashing, and the install it would abort is the one that
+/// still has every other reason to succeed.
+fn write_slot_manifest(slot_dir: &Path) {
+    let path = slot_dir.join("package.json");
+    match fs::OpenOptions::new().write(true).create_new(true).open(&path) {
+        Ok(mut file) => {
+            if let Err(error) = file.write_all(VIRTUAL_STORE_SLOT_MANIFEST.as_bytes()) {
+                tracing::warn!(target: "pnpm::store", ?error, path = %path.display(), "could not write the virtual store slot manifest");
+            }
+        }
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+        Err(error) => {
+            tracing::warn!(target: "pnpm::store", ?error, path = %path.display(), "could not write the virtual store slot manifest");
+        }
+    }
+}
+
 /// Error type of [`CreateVirtualDirBySnapshot`].
 #[derive(Debug, Display, Error, Diagnostic)]
 pub enum CreateVirtualDirError {
@@ -148,13 +188,17 @@ impl CreateVirtualDirBySnapshot<'_> {
         let _link_concurrency_guard =
             link_concurrency_probe.map(tests::LinkConcurrencyProbe::enter);
 
-        let virtual_node_modules_dir = layout.slot_dir(package_key).join("node_modules");
+        let slot_dir = layout.slot_dir(package_key);
+        let virtual_node_modules_dir = slot_dir.join("node_modules");
         fs::create_dir_all(&virtual_node_modules_dir).map_err(|error| {
             CreateVirtualDirError::CreateNodeModulesDir {
                 dir: virtual_node_modules_dir.clone(),
                 error,
             }
         })?;
+        if layout.enable_global_virtual_store() {
+            write_slot_manifest(&slot_dir);
+        }
 
         let save_path =
             safe_join_modules_dir(&virtual_node_modules_dir, &package_key.name.to_string())

--- a/pnpm11/deps/graph-hasher/src/index.ts
+++ b/pnpm11/deps/graph-hasher/src/index.ts
@@ -1,4 +1,6 @@
+import { promises as fs } from 'node:fs'
 import path from 'node:path'
+import util from 'node:util'
 
 import { hashObject, hashObjectWithoutSorting } from '@pnpm/crypto.object-hasher'
 import { getPkgIdWithPatchHash, refToRelative } from '@pnpm/deps.path'
@@ -323,6 +325,40 @@ export function calcGlobalVirtualStorePathWithSubdeps (
   const depsHash = hashObject({ id: fullPkgId, deps: childHashes })
   const hexDigest = hashObjectWithoutSorting({ engine: null, deps: depsHash }, { encoding: 'hex' })
   return formatGlobalVirtualStorePath(name, version, hexDigest)
+}
+
+/**
+ * The manifest every global virtual store slot carries, and what it is for.
+ *
+ * A dependency's lifecycle scripts run in `<slot>/node_modules/<name>`. A
+ * package that wants to know which project installed it reads the manifest
+ * above that `node_modules` — the convention every git-hook installer follows.
+ * In a project's own virtual store it finds the project; a slot is shared by
+ * every project that resolves the same dependencies, so there is no project
+ * there to find, and pnpm does not run a dependency's scripts on any project's
+ * behalf. The read still has to resolve, or a package that merely *looks*
+ * takes the install down with it (pnpm/pnpm#13318) — so the slot answers with
+ * a manifest that declares nothing.
+ *
+ * Byte-identical to what the Rust CLI writes (`create_virtual_dir_by_snapshot`),
+ * since both fill the same store.
+ */
+const VIRTUAL_STORE_SLOT_MANIFEST = `{
+  "private": true
+}
+`
+
+/**
+ * Write {@link VIRTUAL_STORE_SLOT_MANIFEST} into a slot, once. Concurrent
+ * installs materialize the same slot, so losing the race is success — every
+ * writer has the same bytes.
+ */
+export async function writeVirtualStoreSlotManifest (slotDir: string): Promise<void> {
+  try {
+    await fs.writeFile(path.join(slotDir, 'package.json'), VIRTUAL_STORE_SLOT_MANIFEST, { flag: 'wx' })
+  } catch (err: unknown) {
+    if (!util.types.isNativeError(err) || !('code' in err) || err.code !== 'EEXIST') throw err
+  }
 }
 
 // Use @/ prefix for unscoped packages to maintain uniform 4-level directory depth

--- a/pnpm11/installing/deps-installer/src/install/link.ts
+++ b/pnpm11/installing/deps-installer/src/install/link.ts
@@ -6,7 +6,7 @@ import {
   stageLogger,
   statsLogger,
 } from '@pnpm/core-loggers'
-import { calcDepState, type DepsStateCache, findRuntimeNodeVersion } from '@pnpm/deps.graph-hasher'
+import { calcDepState, type DepsStateCache, findRuntimeNodeVersion, writeVirtualStoreSlotManifest } from '@pnpm/deps.graph-hasher'
 import { readModulesDir } from '@pnpm/fs.read-modules-dir'
 import { symlinkDependency } from '@pnpm/fs.symlink-dependency'
 import type {
@@ -434,7 +434,14 @@ async function linkNewPackages (
 
   const newPkgs = props<DepPath, DependenciesGraphNode>(newDepPaths, depGraph)
 
-  await Promise.all(newPkgs.map(async (depNode) => fs.mkdir(depNode.modules, { recursive: true })))
+  await Promise.all(newPkgs.map(async (depNode) => {
+    await fs.mkdir(depNode.modules, { recursive: true })
+    // A slot is not a project, and a dependency's lifecycle scripts run one
+    // directory below it — see `writeVirtualStoreSlotManifest`.
+    if (opts.enableGlobalVirtualStore) {
+      await writeVirtualStoreSlotManifest(path.dirname(depNode.modules))
+    }
+  }))
   await Promise.all([
     !opts.symlink
       ? Promise.resolve()

--- a/pnpm11/installing/deps-installer/test/install/globalVirtualStore.ts
+++ b/pnpm11/installing/deps-installer/test/install/globalVirtualStore.ts
@@ -822,7 +822,9 @@ test('a lifecycle script that reads the manifest above its node_modules does not
   expect(JSON.parse(fs.readFileSync(path.join(slotDir, 'package.json'), 'utf8'))).toStrictEqual({ private: true })
 
   // What the script read is the slot, and it declares nothing about the
-  // project that installed the package.
+  // project that installed the package. Both sides are resolved before they
+  // are compared: the script derives its path from `process.cwd()`, which is
+  // `getcwd()` and therefore physical, while the test's own path need not be.
   const readFrom = path.join(slotDir, 'node_modules/@pnpm.e2e/reads-consumer-manifest/read-consumer-manifest-from.txt')
-  expect(fs.readFileSync(readFrom, 'utf8')).toBe(slotDir)
+  expect(fs.realpathSync(fs.readFileSync(readFrom, 'utf8'))).toBe(fs.realpathSync(slotDir))
 })

--- a/pnpm11/installing/deps-installer/test/install/globalVirtualStore.ts
+++ b/pnpm11/installing/deps-installer/test/install/globalVirtualStore.ts
@@ -793,3 +793,36 @@ test('virtualStoreOnly suppresses hoisting even with explicit hoistPattern', asy
   // No importer-level symlinks
   expect(fs.existsSync(path.resolve('node_modules/@pnpm.e2e/pkg-with-1-dep'))).toBeFalsy()
 })
+
+// A dependency's lifecycle script runs in the store, where the directory above
+// its `node_modules` is a slot rather than the project that installed it.
+// Reading the manifest there is how every git-hook installer looks for its
+// consumer; pnpm does not run a dependency's scripts on a project's behalf, but
+// the read has to resolve rather than take the install down with it.
+// https://github.com/pnpm/pnpm/issues/13318
+test('a lifecycle script that reads the manifest above its node_modules does not fail the install', async () => {
+  prepareEmpty()
+  const globalVirtualStoreDir = path.resolve('links')
+  const manifest = {
+    dependencies: {
+      '@pnpm.e2e/reads-consumer-manifest': '1.0.0',
+    },
+  }
+  await install(manifest, testDefaults({
+    enableGlobalVirtualStore: true,
+    virtualStoreDir: globalVirtualStoreDir,
+    fastUnpack: false,
+    allowBuilds: { '@pnpm.e2e/reads-consumer-manifest': true },
+  }))
+
+  const versionDir = path.join(globalVirtualStoreDir, '@pnpm.e2e/reads-consumer-manifest/1.0.0')
+  const hashes = fs.readdirSync(versionDir)
+  expect(hashes).toHaveLength(1)
+  const slotDir = path.join(versionDir, hashes[0])
+  expect(JSON.parse(fs.readFileSync(path.join(slotDir, 'package.json'), 'utf8'))).toStrictEqual({ private: true })
+
+  // What the script read is the slot, and it declares nothing about the
+  // project that installed the package.
+  const readFrom = path.join(slotDir, 'node_modules/@pnpm.e2e/reads-consumer-manifest/read-consumer-manifest-from.txt')
+  expect(fs.readFileSync(readFrom, 'utf8')).toBe(slotDir)
+})

--- a/pnpm11/installing/deps-restorer/src/index.ts
+++ b/pnpm11/installing/deps-restorer/src/index.ts
@@ -22,7 +22,7 @@ import {
   lockfileToDepGraph,
   type LockfileToDepGraphOptions,
 } from '@pnpm/deps.graph-builder'
-import { calcDepState, type DepsStateCache, findRuntimeNodeVersion } from '@pnpm/deps.graph-hasher'
+import { calcDepState, type DepsStateCache, findRuntimeNodeVersion, writeVirtualStoreSlotManifest } from '@pnpm/deps.graph-hasher'
 import * as dp from '@pnpm/deps.path'
 import { PnpmError } from '@pnpm/error'
 import {
@@ -470,7 +470,14 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
   } else if (opts.enableModulesDir !== false || opts.enableGlobalVirtualStore) {
     if (!skipGvsInternalLinking) {
       if (opts.enableModulesDir !== false) {
-        await Promise.all(depNodes.map(async (depNode) => fs.mkdir(depNode.modules, { recursive: true })))
+        await Promise.all(depNodes.map(async (depNode) => {
+          await fs.mkdir(depNode.modules, { recursive: true })
+          // A slot is not a project, and a dependency's lifecycle scripts run
+          // one directory below it — see `writeVirtualStoreSlotManifest`.
+          if (opts.enableGlobalVirtualStore) {
+            await writeVirtualStoreSlotManifest(path.dirname(depNode.modules))
+          }
+        }))
       }
       await Promise.all([
         opts.symlink === false || opts.enableModulesDir === false

--- a/pnpr/.fixtures/packages/@pnpm.e2e/reads-consumer-manifest/1.0.0/README.md
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/reads-consumer-manifest/1.0.0/README.md
@@ -1,0 +1,8 @@
+# @pnpm.e2e/reads-consumer-manifest
+
+A package whose `postinstall` reads the `package.json` of the directory above
+the `node_modules` that holds it — the convention every git-hook installer uses
+to find the project that installed it.
+
+It exists to pin that this read does not crash an install, whatever pnpm's
+virtual store layout is. See https://github.com/pnpm/pnpm/issues/13318.

--- a/pnpr/.fixtures/packages/@pnpm.e2e/reads-consumer-manifest/1.0.0/package.json
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/reads-consumer-manifest/1.0.0/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@pnpm.e2e/reads-consumer-manifest",
+  "version": "1.0.0",
+  "description": "A package whose postinstall reads the manifest of the project it assumes installed it",
+  "scripts": {
+    "postinstall": "node read-consumer-manifest"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pnpm/pnpm/tree/master/test/packages/reads-consumer-manifest"
+  }
+}

--- a/pnpr/.fixtures/packages/@pnpm.e2e/reads-consumer-manifest/1.0.0/read-consumer-manifest.js
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/reads-consumer-manifest/1.0.0/read-consumer-manifest.js
@@ -1,0 +1,19 @@
+'use strict'
+// The convention a git-hook installer follows to find the project that
+// installed it: walk out of its own directory to the `node_modules` holding
+// it, and read the manifest of whatever sits above that. Nothing promises a
+// manifest is there, and this package does not care what it says — it only
+// has to be readable, which is what pnpm/pnpm#13318 was about.
+const fs = require('fs')
+const path = require('path')
+
+let dir = process.cwd()
+while (path.basename(path.dirname(dir)) !== 'node_modules') {
+  const parent = path.dirname(dir)
+  if (parent === dir) throw new Error('no node_modules above ' + process.cwd())
+  dir = parent
+}
+const assumedProjectDir = path.dirname(path.dirname(dir))
+
+fs.statSync(path.join(assumedProjectDir, 'package.json'))
+fs.writeFileSync('read-consumer-manifest-from.txt', assumedProjectDir, 'utf8')


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#13318.

With `virtualStoreType: global`, a dependency's lifecycle scripts run in
`<store>/v11/links/<scope>/<name>/<version>/<hash>/node_modules/<name>`. A package that
wants to know which project installed it reads the manifest above that `node_modules` —
the convention every git-hook installer follows. In a project's own virtual store it finds
the project; in the store there is nothing there, and `simple-git-hooks` died on the
`ENOENT` and took the install down with it. That is what blocks vite's cold install.

Every slot now carries a manifest of its own — `{"private": true}` — so the read resolves
and the install proceeds.

**What this deliberately does not do:** make the script find a project. pnpm does not run a
dependency's lifecycle scripts on behalf of the project that installed it, and a shared
store makes that plain — one build serves every project that resolves the same
dependencies, so there is no single consumer to point at. `process.cwd()` is `getcwd()`, so
no symlink or environment variable could produce one either; only moving the package into
the consuming project would, which would mean giving up the sharing the setting exists for.
A package that has to act on your repository belongs in a script of your own project, which
does run there:

```json
{ "scripts": { "prepare": "simple-git-hooks" } }
```

So under `virtualStoreType: global` a git-hook installer's `postinstall` now does nothing
instead of crashing. Note that pnpm 12 already behaves this way on the project-scoped
layout: a warm store imports the package as built and never re-runs its scripts, so the
second project onwards has never had its hooks installed.

Both stacks write the same bytes, since both fill the same store. The one place that
compares the two — `pnpm_compatibility` — filters the file out, because the `pnpm` it
compares against is whichever release is on `PATH` and only the one shipping this writes it.

Not included: the project-scoped layout has the same shape one level down
(`node_modules/.pnpm/<flat>/` is not a project either), so a package doing this naive walk
crashes there too unless it special-cases `.pnpm` the way `simple-git-hooks` does. Worth
its own change if we want the two layouts to answer alike.

## Squash Commit Body

```text
A dependency's lifecycle scripts run in `<slot>/node_modules/<name>` when
the global virtual store is on. A package that wants to know which
project installed it reads the manifest above that `node_modules` — what
every git-hook installer does — and a slot had nothing there, so a
package that merely looked took the install down with an ENOENT
(`simple-git-hooks`, blocking vite's cold install).

Give every slot a manifest that declares nothing, so the read resolves.
Not a project for the script to find: pnpm does not run a dependency's
scripts on behalf of the project that installed it, and a slot is shared
by every project that resolves the same dependencies, so there is no
single consumer to name. A package that has to act on the repository
belongs in a script of the project itself, which runs there.

Both stacks write the same bytes, since both fill the same store.

Closes pnpm/pnpm#13318
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Global virtual-store dependency lifecycle scripts can reliably read a private project manifest without causing installation failures.
  - Manifest creation is safe during concurrent installs and tolerates expected filesystem races.
  - Compatibility checks now correctly account for slot-level manifests.

- **Documentation**
  - Clarified that repository-specific setup actions, such as Git hook installation, should run from the consuming project’s preparation script.

- **Tests**
  - Added coverage verifying manifest access across global virtual-store layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->