### PR TITLE
feat(init): pin the latest pnpm version, not the running one

### DIFF
--- a/.changeset/init-pins-latest-pnpm.md
+++ b/.changeset/init-pins-latest-pnpm.md
@@ -1,0 +1,11 @@
+---
+"@pnpm/engine.pm.commands": minor
+"@pnpm/store.connection-manager": minor
+"@pnpm/workspace.commands": minor
+"pacquet": minor
+"pnpm": minor
+---
+
+`pnpm init` now pins the latest pnpm version, instead of the version of pnpm that ran the command. A project scaffolded by an outdated pnpm therefore no longer inherits that staleness through its own `devEngines.packageManager` / `packageManager` pin [#7490](https://github.com/pnpm/pnpm/issues/7490).
+
+The version is read from the `latest` tag on the package-manager registries. When that lookup cannot answer — no network, an unreachable or slow registry, `offline`, or a `latest` that the `minimumReleaseAge` / `trustPolicy` settings reject — `pnpm init` pins the running version as before, and never fails or hangs on the lookup. A `latest` that is older than the running pnpm is never pinned either.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9780,6 +9780,9 @@ importers:
       '@pnpm/config.reader':
         specifier: workspace:*
         version: link:../../config/reader
+      '@pnpm/engine.pm.commands':
+        specifier: workspace:*
+        version: link:../../engine/pm/commands
       '@pnpm/error':
         specifier: workspace:*
         version: link:../../core/error
@@ -9801,6 +9804,9 @@ importers:
       render-help:
         specifier: 'catalog:'
         version: 2.0.0
+      semver:
+        specifier: 'catalog:'
+        version: 7.8.5
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
@@ -9817,6 +9823,9 @@ importers:
       '@types/ramda':
         specifier: 'catalog:'
         version: 0.32.0
+      '@types/semver':
+        specifier: 'catalog:'
+        version: 7.8.0
       load-json-file:
         specifier: 'catalog:'
         version: 7.0.1
@@ -15527,7 +15536,7 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-5lBWCrHs7A61hFtDuH1gJMh7ThQ8PgRMu2B8wTXbqts=
+            integrity: sha256-HxbMD2/ryxvtHUVQMGgG28+69cG8L0Tzxci10ipMwno=
             type: binary
             url: https://unofficial-builds.nodejs.org/download/release/v26.7.0/node-v26.7.0-linux-arm64-musl.tar.gz
           targets:
@@ -15538,7 +15547,7 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-hPxOKeX4YCKkC6xQooobknXdHzLuu/TbSZ4lc/+CISQ=
+            integrity: sha256-XcAYDnaE7eb8nZ5jM9pFaG9LWnggcp0zxoM1soMzcpU=
             type: binary
             url: https://unofficial-builds.nodejs.org/download/release/v26.7.0/node-v26.7.0-linux-x64-musl.tar.gz
           targets:
@@ -21301,6 +21310,7 @@ snapshots:
       es-object-atoms: 1.1.2
       es-set-tostringtag: 2.1.0
       es-to-primitive: 1.3.4
+      for-each: 0.3.5
       function.prototype.name: 1.2.0
       get-intrinsic: 1.3.0
       get-proto: 1.0.1

--- a/pnpm/crates/cli/src/cli_args/dispatch_script.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_script.rs
@@ -10,41 +10,46 @@ use super::{
     set_script::SetScriptArgs,
 };
 use miette::Context;
-use pnpm_config::{Config, InitType, PNPM_VERSION};
+use pnpm_config::{Config, InitType};
 use pnpm_package_manifest::{InitAuthor, InitOptions, PackageManifest};
-use std::path::Path;
 
+// `init` looks the version it pins up on the registry, so unlike the other
+// manifest-only commands here it dispatches a real future rather than a
+// ready one.
 pub(super) fn init<'a>(ctx: &RunCtx<'a>, args: &InitArgs) -> miette::Result<CommandFuture<'a>> {
-    let config = (ctx.config)()?;
-    let options = InitOptions {
-        es_module: args.effective_init_type(config) == InitType::Module,
-        pinned_pnpm_version: pinned_pnpm_version(args, config, ctx.dir),
-        author: InitAuthor {
-            name: config.init_author_name.as_deref(),
-            email: config.init_author_email.as_deref(),
-            url: config.init_author_url.as_deref(),
-        },
-        license: config.init_license.as_deref(),
-        version: config.init_version.as_deref(),
-    };
-    let result =
-        PackageManifest::init(ctx.manifest_path, options).wrap_err("initialize package.json");
-    Ok(Box::pin(std::future::ready(result)))
-}
-
-/// The pnpm version `pnpm init` records as the new project's pin, or `None`
-/// when the manifest is scaffolded without one.
-///
-/// A manifest created inside an existing workspace becomes a member of it and
-/// follows the pin at the workspace root, so only the root is pinned.
-fn pinned_pnpm_version(args: &InitArgs, config: &Config, init_dir: &Path) -> Option<&'static str> {
-    if !args.effective_init_package_manager(config) {
-        return None;
-    }
-    if config.workspace_dir.as_deref().is_some_and(|root| root != init_dir) {
-        return None;
-    }
-    Some(PNPM_VERSION)
+    let config: &Config = (ctx.config)()?;
+    let es_module = args.effective_init_type(config) == InitType::Module;
+    // `config_self_update`, so a repo-controlled `pnpm-workspace.yaml` cannot
+    // relax the release-age and trust policies governing the version pnpm
+    // ends up downloading. A manifest that is already there skips the lookup
+    // altogether: `PackageManifest::init` refuses to overwrite it, and
+    // `pnpm init` should not wait on a registry to report an error it can
+    // already see.
+    let pin_config: Option<&Config> =
+        if args.pins_pnpm(config, ctx.dir) && !ctx.manifest_path.exists() {
+            Some((ctx.config_self_update)()?)
+        } else {
+            None
+        };
+    let manifest_path = ctx.manifest_path;
+    Ok(Box::pin(async move {
+        let pinned_pnpm_version = match pin_config {
+            Some(pin_config) => Some(super::init::version_to_pin(pin_config).await),
+            None => None,
+        };
+        let options = InitOptions {
+            es_module,
+            pinned_pnpm_version: pinned_pnpm_version.as_deref(),
+            author: InitAuthor {
+                name: config.init_author_name.as_deref(),
+                email: config.init_author_email.as_deref(),
+                url: config.init_author_url.as_deref(),
+            },
+            license: config.init_license.as_deref(),
+            version: config.init_version.as_deref(),
+        };
+        PackageManifest::init(manifest_path, options).wrap_err("initialize package.json")
+    }))
 }
 
 // `set-script` only rewrites `package.json#scripts`; it never touches the

--- a/pnpm/crates/cli/src/cli_args/init.rs
+++ b/pnpm/crates/cli/src/cli_args/init.rs
@@ -1,5 +1,14 @@
+use super::self_update::version_lt;
+use crate::config_deps;
 use clap::{Args, ValueEnum};
-use pnpm_config::{Config, InitType};
+use pnpm_config::{Config, InitType, PNPM_VERSION};
+use std::{path::Path, time::Duration};
+
+/// How long the `latest` lookup may take before `pnpm init` gives up on it.
+/// Much shorter than the resolver's usual timeout: the version is a nicety,
+/// and a scaffold command that appears to hang is worse than one that pins
+/// the running version.
+const LATEST_LOOKUP_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Create a `package.json` file.
 #[derive(Debug, Args)]
@@ -8,7 +17,7 @@ pub struct InitArgs {
     #[clap(long = "init-type", value_name = "commonjs|module")]
     pub init_type: Option<InitTypeArg>,
 
-    /// Pin the pnpm version in package.json, through
+    /// Pin the latest pnpm version in package.json, through
     /// "devEngines.packageManager" and "packageManager", and auto-download
     /// pnpm when it is missing.
     #[clap(long = "init-package-manager", overrides_with = "no_init_package_manager")]
@@ -36,6 +45,47 @@ impl InitArgs {
     pub(crate) fn effective_init_type(&self, config: &Config) -> InitType {
         self.init_type.map_or(config.init_type, InitTypeArg::into_config)
     }
+
+    /// Whether `pnpm init` records a package-manager pin in the manifest it
+    /// scaffolds at `init_dir`.
+    ///
+    /// A manifest created inside an existing workspace becomes a member of
+    /// it and follows the pin at the workspace root, so only the root is
+    /// pinned.
+    pub(crate) fn pins_pnpm(&self, config: &Config, init_dir: &Path) -> bool {
+        self.effective_init_package_manager(config)
+            && config.workspace_dir.as_deref().is_none_or(|root| root == init_dir)
+    }
+}
+
+/// The pnpm version the new project is pinned to: whatever the registry's
+/// `latest` tag points at, so a project scaffolded by a long-outdated pnpm
+/// does not inherit that staleness through its own pin.
+///
+/// Falls back to the running version whenever `latest` cannot be
+/// established, and never lets `latest` move the pin backwards — the tag can
+/// lag the running version when a new major has shipped without being
+/// tagged. Scaffolding a `package.json` must not fail, hang, or wait on a
+/// registry that is unreachable, so every failure degrades to the running
+/// version instead of surfacing.
+pub(crate) async fn version_to_pin(config: &Config) -> String {
+    if config.offline || config.prefer_offline {
+        return PNPM_VERSION.to_string();
+    }
+    // One attempt, no retry schedule: a registry that is not answering
+    // should cost `pnpm init` a moment, not the whole timeout below.
+    let mut config = config.clone();
+    config.fetch_retries = 0;
+    let lookup = Box::pin(config_deps::resolve_engine_version(&config, "pnpm", "latest"));
+    let Ok(Ok(Some(resolved))) = tokio::time::timeout(LATEST_LOOKUP_TIMEOUT, lookup).await else {
+        return PNPM_VERSION.to_string();
+    };
+    // A `latest` the maturity or trust policy rejects is not something to pin
+    // a new project to, and `pnpm init` has nobody to prompt for approval.
+    if resolved.policy_violation.is_some() || version_lt(&resolved.version, PNPM_VERSION) {
+        return PNPM_VERSION.to_string();
+    }
+    resolved.version
 }
 
 /// `--init-type` value parser. CLI mirror of [`pnpm_config::InitType`] so the

--- a/pnpm/crates/cli/src/cli_args/init.rs
+++ b/pnpm/crates/cli/src/cli_args/init.rs
@@ -1,4 +1,4 @@
-use super::self_update::version_lt;
+use super::self_update::{install_pnpm::is_release_installable, version_lt};
 use crate::config_deps;
 use clap::{Args, ValueEnum};
 use pnpm_config::{Config, InitType, PNPM_VERSION};
@@ -81,8 +81,14 @@ pub(crate) async fn version_to_pin(config: &Config) -> String {
         return PNPM_VERSION.to_string();
     };
     // A `latest` the maturity or trust policy rejects is not something to pin
-    // a new project to, and `pnpm init` has nobody to prompt for approval.
-    if resolved.policy_violation.is_some() || version_lt(&resolved.version, PNPM_VERSION) {
+    // a new project to, and `pnpm init` has nobody to prompt for approval. A
+    // broken release is refused for the reason the pin exists at all: it is
+    // shared, so pinning one the running wrapper happens to survive would
+    // still break every teammate on the other wrapper.
+    if resolved.policy_violation.is_some()
+        || !is_release_installable(&resolved.version)
+        || version_lt(&resolved.version, PNPM_VERSION)
+    {
         return PNPM_VERSION.to_string();
     }
     resolved.version

--- a/pnpm/crates/cli/src/cli_args/self_update.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update.rs
@@ -602,7 +602,7 @@ fn coerce_major(version: &str) -> Option<u64> {
     node_semver::Version::parse(version).ok().map(|version| version.major)
 }
 
-fn version_lt(left: &str, right: &str) -> bool {
+pub(super) fn version_lt(left: &str, right: &str) -> bool {
     match (node_semver::Version::parse(left), node_semver::Version::parse(right)) {
         (Ok(left), Ok(right)) => left < right,
         _ => false,

--- a/pnpm/crates/cli/src/cli_args/self_update/install_pnpm.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/install_pnpm.rs
@@ -191,15 +191,25 @@ fn reuse_cached_engine(install_dir: &Path, package: PnpmPackageToInstall, versio
     !package.links_native_binary || link_exe_platform_binary(install_dir, package.name).is_ok()
 }
 
-/// Fail for versions whose `@pnpm/exe` shipped platform packages with no binary,
-/// so it cannot run. Matched by version, not package: the pin is shared but the
-/// wrapper is not, so a developer on the JS `pnpm` — which does run at these
-/// versions — would otherwise pin one and break every teammate on `@pnpm/exe`.
+/// Whether `version` can be installed at all. False for versions whose
+/// `@pnpm/exe` shipped platform packages with no binary, so it cannot run.
+/// Matched by version, not package: the pin is shared but the wrapper is not,
+/// so a developer on the JS `pnpm` — which does run at these versions — would
+/// otherwise pin one and break every teammate on `@pnpm/exe`.
+///
+/// For callers that pick a version rather than being handed one, and so can
+/// choose another instead of failing; [`assert_release_is_installable`] is the
+/// failing form.
+pub(crate) fn is_release_installable(version: &str) -> bool {
+    !matches!(version, "11.12.0" | "11.13.0")
+}
+
+/// Fail for a version [`is_release_installable`] rejects.
 pub(crate) fn assert_release_is_installable(version: &str) -> miette::Result<()> {
-    if matches!(version, "11.12.0" | "11.13.0") {
-        return Err(SelfUpdateError::BrokenPnpmRelease { version: version.to_string() }.into());
+    if is_release_installable(version) {
+        return Ok(());
     }
-    Ok(())
+    Err(SelfUpdateError::BrokenPnpmRelease { version: version.to_string() }.into())
 }
 
 pub(crate) fn pnpm_package_to_install(pnpm_version: &str) -> PnpmPackageToInstall {

--- a/pnpm/crates/cli/tests/suite/init.rs
+++ b/pnpm/crates/cli/tests/suite/init.rs
@@ -99,6 +99,21 @@ fn an_unreachable_registry_pins_the_running_pnpm() {
     drop(root);
 }
 
+/// `offline` keeps `pnpm init` off the network altogether. The fixture's
+/// registry is reachable and serving a newer pnpm, so a pin of the running
+/// version is only possible if the lookup never happened.
+#[test]
+fn offline_pins_the_running_pnpm_without_a_lookup() {
+    let CommandTempCwd { mut pacquet, root, workspace, npmrc_info, .. } =
+        pinning_fixture(LATEST_PNPM);
+    pacquet.env("PNPM_CONFIG_OFFLINE", "true");
+    pacquet.with_arg("init").assert().success();
+
+    assert_pinned_to_the_running_pnpm(&workspace);
+
+    drop((root, npmrc_info));
+}
+
 fn assert_pinned_to_the_running_pnpm(dir: &Path) {
     let manifest = fs::read_to_string(dir.join("package.json")).expect("read from package.json");
     let pin = format!(r#""packageManager": "pnpm@{}""#, pnpm_config::PNPM_VERSION);

--- a/pnpm/crates/cli/tests/suite/init.rs
+++ b/pnpm/crates/cli/tests/suite/init.rs
@@ -1,14 +1,37 @@
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pipe_trait::Pipe;
-use pnpm_testing_utils::{bin::CommandTempCwd, fs::get_filenames_in_folder};
+use pnpm_testing_utils::{
+    bin::{AddMockedRegistry, CommandTempCwd},
+    fs::get_filenames_in_folder,
+};
 use pretty_assertions::assert_eq;
 use serde_json::json;
 use std::{fs, path::Path};
 
+/// The version the pinning fixture's registry serves as pnpm's `latest`.
+/// Far ahead of any real release, so the no-downgrade guard never picks the
+/// running version instead and hides what a test is asserting.
+const LATEST_PNPM: &str = "99.0.0";
+
+/// A fixture whose registry serves `served_pnpm_version` as pnpm's `latest`.
+///
+/// A `pnpm init` that pins looks that tag up, so every test that lets it pin
+/// has to say what the answer is instead of reaching the real registry.
+/// `PNPM_CONFIG_REGISTRY` is what redirects the lookup: the pin resolves
+/// through the trusted package-manager registries, which the `.npmrc` the
+/// mock writes into the workspace deliberately cannot reach.
+fn pinning_fixture(served_pnpm_version: &str) -> CommandTempCwd<AddMockedRegistry> {
+    let mut fixture =
+        CommandTempCwd::init().add_mocked_registry_with_pnpm_version(served_pnpm_version);
+    let registry = fixture.npmrc_info.mock_instance.url();
+    fixture.pacquet.env("PNPM_CONFIG_REGISTRY", registry);
+    fixture
+}
+
 #[test]
 fn should_create_package_json() {
-    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } = pinning_fixture(LATEST_PNPM);
     pacquet.with_arg("init").assert().success();
 
     let manifest_path = workspace.join("package.json");
@@ -16,16 +39,70 @@ fn should_create_package_json() {
 
     eprintln!("Content of package.json");
     let package_json_content = fs::read_to_string(&manifest_path).expect("read from package.json");
-    // The pinned version moves with every release, so the snapshot records
-    // the shape of the pin rather than the number.
-    insta::assert_snapshot!(
-        package_json_content.replace(pnpm_config::PNPM_VERSION, "<pnpm-version>")
-    );
+    // The pinned version is whatever the registry's `latest` tag points at,
+    // so the snapshot records the shape of the pin rather than the number.
+    insta::assert_snapshot!(package_json_content.replace(LATEST_PNPM, "<pnpm-version>"));
 
     eprintln!("Created files");
-    assert_eq!(get_filenames_in_folder(&workspace), ["package.json"]);
+    // The `.npmrc` and `pnpm-workspace.yaml` are the fixture's, written
+    // before the command ran; `package.json` is all `init` adds.
+    assert_eq!(
+        get_filenames_in_folder(&workspace),
+        [".npmrc", "package.json", "pnpm-workspace.yaml"],
+    );
+
+    drop((root, npmrc_info));
+}
+
+#[test]
+fn the_pin_follows_the_registry_latest_rather_than_the_running_pnpm() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } = pinning_fixture(LATEST_PNPM);
+    pacquet.with_arg("init").assert().success();
+
+    let manifest: serde_json::Value = fs::read_to_string(workspace.join("package.json"))
+        .expect("read from package.json")
+        .pipe_deref(serde_json::from_str)
+        .expect("parse package.json");
+    assert_eq!(manifest["packageManager"], json!(format!("pnpm@{LATEST_PNPM}")));
+    assert_eq!(
+        manifest["devEngines"]["packageManager"],
+        json!({ "name": "pnpm", "version": LATEST_PNPM, "onFail": "download" }),
+    );
+
+    drop((root, npmrc_info));
+}
+
+/// `latest` can lag the running version when a new major has shipped without
+/// being tagged; the pin must not move a fresh project backwards onto it.
+#[test]
+fn a_latest_older_than_the_running_pnpm_is_not_pinned() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } = pinning_fixture("1.0.0");
+    pacquet.with_arg("init").assert().success();
+
+    assert_pinned_to_the_running_pnpm(&workspace);
+
+    drop((root, npmrc_info));
+}
+
+/// Scaffolding a `package.json` is not allowed to fail on an unreachable
+/// registry, so the lookup degrades to the running version.
+#[test]
+fn an_unreachable_registry_pins_the_running_pnpm() {
+    let CommandTempCwd { mut pacquet, root, workspace, .. } = CommandTempCwd::init();
+    // Port 1 is reserved and unbound, so the connection is refused at once
+    // rather than waiting out the lookup's timeout.
+    pacquet.env("PNPM_CONFIG_REGISTRY", "http://127.0.0.1:1/");
+    pacquet.with_arg("init").assert().success();
+
+    assert_pinned_to_the_running_pnpm(&workspace);
 
     drop(root);
+}
+
+fn assert_pinned_to_the_running_pnpm(dir: &Path) {
+    let manifest = fs::read_to_string(dir.join("package.json")).expect("read from package.json");
+    let pin = format!(r#""packageManager": "pnpm@{}""#, pnpm_config::PNPM_VERSION);
+    assert!(manifest.contains(&pin), "{manifest}");
 }
 
 #[test]
@@ -75,17 +152,16 @@ fn init_package_manager_off_in_the_workspace_manifest_leaves_the_manifest_unpinn
 
 #[test]
 fn a_workspace_root_is_pinned() {
-    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } = pinning_fixture(LATEST_PNPM);
     fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - packages/*\n")
         .expect("write to pnpm-workspace.yaml");
     pacquet.with_arg("init").assert().success();
 
     let manifest =
         fs::read_to_string(workspace.join("package.json")).expect("read from package.json");
-    let pin = format!(r#""packageManager": "pnpm@{}""#, pnpm_config::PNPM_VERSION);
-    assert!(manifest.contains(&pin), "{manifest}");
+    assert!(manifest.contains(&format!(r#""packageManager": "pnpm@{LATEST_PNPM}""#)), "{manifest}");
 
-    drop(root);
+    drop((root, npmrc_info));
 }
 
 /// A new package inside an existing workspace follows the pin at the
@@ -112,19 +188,19 @@ fn assert_unpinned(dir: &Path) {
 
 #[test]
 fn init_type_commonjs_leaves_the_type_field_out() {
-    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } = pinning_fixture(LATEST_PNPM);
     pacquet.with_arg("init").with_arg("--init-type").with_arg("commonjs").assert().success();
 
     let manifest =
         fs::read_to_string(workspace.join("package.json")).expect("read from package.json");
     assert!(!manifest.contains(r#""type""#), "{manifest}");
 
-    drop(root);
+    drop((root, npmrc_info));
 }
 
 #[test]
 fn init_type_from_the_workspace_manifest_is_honored() {
-    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } = pinning_fixture(LATEST_PNPM);
     fs::write(workspace.join("pnpm-workspace.yaml"), "initType: commonjs\n")
         .expect("write to pnpm-workspace.yaml");
     pacquet.with_arg("init").assert().success();
@@ -133,12 +209,12 @@ fn init_type_from_the_workspace_manifest_is_honored() {
         fs::read_to_string(workspace.join("package.json")).expect("read from package.json");
     assert!(!manifest.contains(r#""type""#), "{manifest}");
 
-    drop(root);
+    drop((root, npmrc_info));
 }
 
 #[test]
 fn the_author_license_and_version_settings_replace_the_scaffold_placeholders() {
-    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } = pinning_fixture(LATEST_PNPM);
     fs::write(
         workspace.join("pnpm-workspace.yaml"),
         "initAuthorName: pnpm\n\
@@ -158,14 +234,14 @@ fn the_author_license_and_version_settings_replace_the_scaffold_placeholders() {
     assert_eq!(manifest["license"], json!("MIT"));
     assert_eq!(manifest["author"], json!("pnpm <xxxxxx@pnpm.com> (https://www.github.com/pnpm)"));
 
-    drop(root);
+    drop((root, npmrc_info));
 }
 
 /// Nothing set leaves the scaffold's own placeholders in place, including
 /// the empty `author` field npm's scaffold carries.
 #[test]
 fn the_scaffold_placeholders_stand_without_the_init_settings() {
-    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } = pinning_fixture(LATEST_PNPM);
     pacquet.with_arg("init").assert().success();
 
     let manifest: serde_json::Value = fs::read_to_string(workspace.join("package.json"))
@@ -176,5 +252,5 @@ fn the_scaffold_placeholders_stand_without_the_init_settings() {
     assert_eq!(manifest["license"], json!("ISC"));
     assert_eq!(manifest["author"], json!(""));
 
-    drop(root);
+    drop((root, npmrc_info));
 }

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -2194,10 +2194,13 @@ pub struct Config {
     pub trust_policy: TrustPolicy,
 
     /// `init-package-manager` / `initPackageManager` config: whether
-    /// `pnpm init` pins the running pnpm in the manifest it scaffolds,
+    /// `pnpm init` pins a pnpm version in the manifest it scaffolds,
     /// through both `devEngines.packageManager` and the legacy
     /// `packageManager` field. Only the workspace root is pinned — a
-    /// member of an existing workspace inherits the root's pin.
+    /// member of an existing workspace inherits the root's pin. The version
+    /// pinned is the registry's `latest`, resolved by `pnpm-cli`'s
+    /// `cli_args::init::version_to_pin`, which falls back to the running
+    /// version when the lookup cannot answer.
     ///
     /// Defaults to `true`.
     #[default = true]

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -2200,7 +2200,8 @@ pub struct Config {
     /// member of an existing workspace inherits the root's pin. The version
     /// pinned is the registry's `latest`, resolved by `pnpm-cli`'s
     /// `cli_args::init::version_to_pin`, which falls back to the running
-    /// version when the lookup cannot answer.
+    /// version whenever `latest` is unavailable, unusable, or older — see
+    /// there for the cases.
     ///
     /// Defaults to `true`.
     #[default = true]

--- a/pnpm11/engine/pm/commands/src/index.ts
+++ b/pnpm11/engine/pm/commands/src/index.ts
@@ -1,5 +1,6 @@
 export { selfUpdate } from './self-updater/index.js'
 export { assertPnpmRuns, assertReleaseIsInstallable, exePlatformPkgDirName, exePlatformPkgDirNameNext, installPnpm, installPnpmToStore, linkExePlatformBinary, pnpmPackageNameToInstall } from './self-updater/installPnpm.js'
+export { type ResolvedPnpmVersion, resolvePnpmVersion, type ResolvePnpmVersionOptions } from './self-updater/resolvePnpmVersion.js'
 export { verifyPnpmEngineIdentity, type VerifyPnpmEngineIdentityOptions } from './self-updater/verifyPnpmEngineIdentity.js'
 export { setup } from './setup/index.js'
 export { LEGACY_HOME_DIR_SHIM_NAMES } from './setup/setup.js'

--- a/pnpm11/engine/pm/commands/src/index.ts
+++ b/pnpm11/engine/pm/commands/src/index.ts
@@ -1,5 +1,5 @@
 export { selfUpdate } from './self-updater/index.js'
-export { assertPnpmRuns, assertReleaseIsInstallable, exePlatformPkgDirName, exePlatformPkgDirNameNext, installPnpm, installPnpmToStore, linkExePlatformBinary, pnpmPackageNameToInstall } from './self-updater/installPnpm.js'
+export { assertPnpmRuns, assertReleaseIsInstallable, exePlatformPkgDirName, exePlatformPkgDirNameNext, installPnpm, installPnpmToStore, isReleaseInstallable, linkExePlatformBinary, pnpmPackageNameToInstall } from './self-updater/installPnpm.js'
 export { type ResolvedPnpmVersion, resolvePnpmVersion, type ResolvePnpmVersionOptions } from './self-updater/resolvePnpmVersion.js'
 export { verifyPnpmEngineIdentity, type VerifyPnpmEngineIdentityOptions } from './self-updater/verifyPnpmEngineIdentity.js'
 export { setup } from './setup/index.js'

--- a/pnpm11/engine/pm/commands/src/index.ts
+++ b/pnpm11/engine/pm/commands/src/index.ts
@@ -1,6 +1,6 @@
 export { selfUpdate } from './self-updater/index.js'
 export { assertPnpmRuns, assertReleaseIsInstallable, exePlatformPkgDirName, exePlatformPkgDirNameNext, installPnpm, installPnpmToStore, isReleaseInstallable, linkExePlatformBinary, pnpmPackageNameToInstall } from './self-updater/installPnpm.js'
-export { type ResolvedPnpmVersion, resolvePnpmVersion, type ResolvePnpmVersionOptions } from './self-updater/resolvePnpmVersion.js'
+export { type PnpmVersionLookup, prepareResolvePnpmVersion, type ResolvedPnpmVersion, resolvePnpmVersion, type ResolvePnpmVersionOptions } from './self-updater/resolvePnpmVersion.js'
 export { verifyPnpmEngineIdentity, type VerifyPnpmEngineIdentityOptions } from './self-updater/verifyPnpmEngineIdentity.js'
 export { setup } from './setup/index.js'
 export { LEGACY_HOME_DIR_SHIM_NAMES } from './setup/setup.js'

--- a/pnpm11/engine/pm/commands/src/self-updater/installPnpm.ts
+++ b/pnpm11/engine/pm/commands/src/self-updater/installPnpm.ts
@@ -45,9 +45,18 @@ const PNPM_ALLOW_BUILDS: Record<string, boolean> = { '@pnpm/exe': true, 'pnpm': 
  */
 const BROKEN_RELEASES: ReadonlySet<string> = new Set(['11.12.0', '11.13.0'])
 
+/**
+ * Whether `version` can be installed at all — false for the
+ * {@link BROKEN_RELEASES}. For callers that pick a version rather than being
+ * handed one, and so can choose another instead of failing.
+ */
+export function isReleaseInstallable (version: string): boolean {
+  return !BROKEN_RELEASES.has(version)
+}
+
 /** Throws when `version` is one of the {@link BROKEN_RELEASES}. */
 export function assertReleaseIsInstallable (version: string): void {
-  if (!BROKEN_RELEASES.has(version)) return
+  if (isReleaseInstallable(version)) return
   throw new PnpmError(
     'BROKEN_PNPM_RELEASE',
     `pnpm v${version} is a broken release and cannot be installed`,

--- a/pnpm11/engine/pm/commands/src/self-updater/resolvePnpmVersion.ts
+++ b/pnpm11/engine/pm/commands/src/self-updater/resolvePnpmVersion.ts
@@ -1,0 +1,90 @@
+import { packageManager } from '@pnpm/cli.meta'
+import { type Config, getPackageManagerBootstrapConfig } from '@pnpm/config.reader'
+import { createPackageVersionPolicyOrThrow, getPublishedByPolicy } from '@pnpm/config.version-policy'
+import { type ClientOptions, createResolver, type ResolutionPolicyViolation } from '@pnpm/installing.client'
+import { type FullMetadataPolicyOptions, shouldFetchFullMetadata } from '@pnpm/store.connection-manager'
+
+export type ResolvePnpmVersionOptions =
+  & Pick<Config, 'cacheDir' | 'dir'>
+  & Pick<ClientOptions, 'retry' | 'timeout'>
+  & FullMetadataPolicyOptions
+  & Partial<Pick<Config,
+  | 'lockfileDir'
+  | 'minimumReleaseAge'
+  | 'minimumReleaseAgeExclude'
+  | 'minimumReleaseAgeIgnoreMissingTime'
+  | 'minimumReleaseAgeStrict'
+  | 'packageManagerNetworkConfig'
+  | 'packageManagerRegistries'
+  | 'trustPolicyExclude'
+  | 'trustPolicyIgnoreAfter'
+  >>
+
+export interface ResolvedPnpmVersion {
+  version: string
+  /**
+   * Set when the resolver picked a version despite the `minimumReleaseAge`
+   * or `trustPolicy` gate. The caller decides what to do about it: the
+   * running version is knowingly left out of the maturity cutoff (see
+   * below), so a violation here is about the version being moved *to*.
+   */
+  policyViolation?: ResolutionPolicyViolation
+}
+
+/**
+ * Resolve `pnpm@<bareSpecifier>` to an exact version.
+ *
+ * Every request goes through the trusted package-manager bootstrap config —
+ * the same channel version switching uses — so a repo-controlled `.npmrc` or
+ * workspace manifest cannot redirect the lookup or attach its own
+ * credentials to it.
+ *
+ * Returns `undefined` when the specifier resolves to nothing.
+ */
+export async function resolvePnpmVersion (
+  opts: ResolvePnpmVersionOptions,
+  bareSpecifier: string
+): Promise<ResolvedPnpmVersion | undefined> {
+  // `minimumReleaseAge` is not part of `shouldFetchFullMetadata` because the
+  // resolver upgrades abbreviated metadata to full on demand for the
+  // maturity check, so it isn't requested up front here.
+  const fullMetadata = shouldFetchFullMetadata(opts)
+  const { resolve } = createResolver({
+    ...opts,
+    ...getPackageManagerBootstrapConfig(opts),
+    fullMetadata,
+    filterMetadata: fullMetadata,
+    ignoreMissingTimeField: opts.minimumReleaseAgeIgnoreMissingTime,
+  })
+  // The running version is already on this machine, so hiding it behind the
+  // maturity cutoff protects nothing — it only makes a dist-tag that points
+  // at it fall back to an older release, downgrading the user (pnpm/pnpm#13883).
+  const { publishedBy, publishedByExclude } = getPublishedByPolicy({
+    ...opts,
+    minimumReleaseAgeExclude: [
+      ...opts.minimumReleaseAgeExclude ?? [],
+      `${packageManager.name}@${packageManager.version}`,
+    ],
+  })
+  const resolution = await resolve({ alias: packageManager.name, bareSpecifier }, {
+    lockfileDir: opts.lockfileDir ?? opts.dir,
+    preferredVersions: {},
+    projectDir: opts.dir,
+    publishedBy,
+    publishedByExclude,
+    // Unlike `dlx` (whose real install re-resolves through the store
+    // controller), this `resolve` is the only version selection the callers
+    // make, so the trust policy has to be passed here for the no-downgrade
+    // check to run.
+    trustPolicy: opts.trustPolicy,
+    trustPolicyExclude: opts.trustPolicyExclude
+      ? createPackageVersionPolicyOrThrow(opts.trustPolicyExclude, 'trustPolicyExclude')
+      : undefined,
+    trustPolicyIgnoreAfter: opts.trustPolicyIgnoreAfter,
+  })
+  if (!resolution?.manifest) return undefined
+  return {
+    version: resolution.manifest.version,
+    policyViolation: resolution.policyViolation,
+  }
+}

--- a/pnpm11/engine/pm/commands/src/self-updater/resolvePnpmVersion.ts
+++ b/pnpm11/engine/pm/commands/src/self-updater/resolvePnpmVersion.ts
@@ -45,6 +45,22 @@ export async function resolvePnpmVersion (
   opts: ResolvePnpmVersionOptions,
   bareSpecifier: string
 ): Promise<ResolvedPnpmVersion | undefined> {
+  return prepareResolvePnpmVersion(opts)(bareSpecifier)
+}
+
+/** Looks a `pnpm@<bareSpecifier>` up. See {@link prepareResolvePnpmVersion}. */
+export type PnpmVersionLookup = (bareSpecifier: string) => Promise<ResolvedPnpmVersion | undefined>
+
+/**
+ * The two-phase form of {@link resolvePnpmVersion}: settings are read and
+ * validated here, and only the returned function talks to a registry.
+ *
+ * The split exists for callers that treat an unreachable registry as
+ * survivable. They can guard the lookup alone, so a misconfigured
+ * `trustPolicyExclude` — or any other bad setting — still surfaces as the
+ * error it is instead of being mistaken for a failed lookup.
+ */
+export function prepareResolvePnpmVersion (opts: ResolvePnpmVersionOptions): PnpmVersionLookup {
   // `minimumReleaseAge` is not part of `shouldFetchFullMetadata` because the
   // resolver upgrades abbreviated metadata to full on demand for the
   // maturity check, so it isn't requested up front here.
@@ -66,25 +82,28 @@ export async function resolvePnpmVersion (
       `${packageManager.name}@${packageManager.version}`,
     ],
   })
-  const resolution = await resolve({ alias: packageManager.name, bareSpecifier }, {
-    lockfileDir: opts.lockfileDir ?? opts.dir,
-    preferredVersions: {},
-    projectDir: opts.dir,
-    publishedBy,
-    publishedByExclude,
-    // Unlike `dlx` (whose real install re-resolves through the store
-    // controller), this `resolve` is the only version selection the callers
-    // make, so the trust policy has to be passed here for the no-downgrade
-    // check to run.
-    trustPolicy: opts.trustPolicy,
-    trustPolicyExclude: opts.trustPolicyExclude
-      ? createPackageVersionPolicyOrThrow(opts.trustPolicyExclude, 'trustPolicyExclude')
-      : undefined,
-    trustPolicyIgnoreAfter: opts.trustPolicyIgnoreAfter,
-  })
-  if (!resolution?.manifest) return undefined
-  return {
-    version: resolution.manifest.version,
-    policyViolation: resolution.policyViolation,
+  const trustPolicyExclude = opts.trustPolicyExclude
+    ? createPackageVersionPolicyOrThrow(opts.trustPolicyExclude, 'trustPolicyExclude')
+    : undefined
+  return async (bareSpecifier) => {
+    const resolution = await resolve({ alias: packageManager.name, bareSpecifier }, {
+      lockfileDir: opts.lockfileDir ?? opts.dir,
+      preferredVersions: {},
+      projectDir: opts.dir,
+      publishedBy,
+      publishedByExclude,
+      // Unlike `dlx` (whose real install re-resolves through the store
+      // controller), this `resolve` is the only version selection the callers
+      // make, so the trust policy has to be passed here for the no-downgrade
+      // check to run.
+      trustPolicy: opts.trustPolicy,
+      trustPolicyExclude,
+      trustPolicyIgnoreAfter: opts.trustPolicyIgnoreAfter,
+    })
+    if (!resolution?.manifest) return undefined
+    return {
+      version: resolution.manifest.version,
+      policyViolation: resolution.policyViolation,
+    }
   }
 }

--- a/pnpm11/engine/pm/commands/src/self-updater/selfUpdate.ts
+++ b/pnpm11/engine/pm/commands/src/self-updater/selfUpdate.ts
@@ -6,15 +6,14 @@ import { linkBins } from '@pnpm/bins.linker'
 import { isExecutedByCorepack, packageManager, standaloneInstallCommand } from '@pnpm/cli.meta'
 import { docsUrl } from '@pnpm/cli.utils'
 import { type Config, type ConfigContext, getPackageManagerBootstrapConfig, parsePackageManager, shouldPersistLockfile, types as allTypes } from '@pnpm/config.reader'
-import { createPackageVersionPolicyOrThrow, getPublishedByPolicy } from '@pnpm/config.version-policy'
 import { PnpmError } from '@pnpm/error'
-import { createResolver, policyViolationToError, type ResolutionPolicyViolation } from '@pnpm/installing.client'
+import { policyViolationToError, type ResolutionPolicyViolation } from '@pnpm/installing.client'
 import { resolvePackageManagerIntegrities } from '@pnpm/installing.env-installer'
 import { readEnvLockfile } from '@pnpm/lockfile.fs'
 import { globalInfo, globalWarn } from '@pnpm/logger'
 import { inferRangeSpecStyle, versionWithRangeSpecStyle } from '@pnpm/pkg-manifest.utils'
 import { MINIMUM_RELEASE_AGE_VIOLATION_CODE } from '@pnpm/resolving.npm-resolver'
-import { createStoreController, type CreateStoreControllerOptions, shouldFetchFullMetadata } from '@pnpm/store.connection-manager'
+import { createStoreController, type CreateStoreControllerOptions } from '@pnpm/store.connection-manager'
 import { readProjectManifest } from '@pnpm/workspace.project-manifest-reader'
 import { isCI } from 'ci-info'
 import { pick } from 'ramda'
@@ -22,6 +21,7 @@ import { renderHelp } from 'render-help'
 import semver from 'semver'
 
 import { assertReleaseIsInstallable, findGlobalPnpmInstallDir, installPnpm, pnpmPackageNameToInstall } from './installPnpm.js'
+import { resolvePnpmVersion } from './resolvePnpmVersion.js'
 
 export function rcOptionsTypes (): Record<string, unknown> {
   return pick([], allTypes)
@@ -86,34 +86,7 @@ export async function handler (
     })
   }
   globalInfo('Checking for updates...')
-  // Resolve the engine version exactly as a regular install would.
-  // `minimumReleaseAge` is not part of `shouldFetchFullMetadata` because the
-  // resolver upgrades abbreviated metadata to full on demand for the
-  // maturity check, so it isn't requested up front here.
-  const fullMetadata = shouldFetchFullMetadata(opts)
-  // Every request self-update makes goes through the trusted package-manager
-  // bootstrap config — the same channel version switching uses — so a
-  // repo-controlled `.npmrc` or workspace manifest cannot redirect the pnpm
-  // download or attach its own credentials to it.
   const bootstrapConfig = getPackageManagerBootstrapConfig(opts)
-  const { resolve } = createResolver({
-    ...opts,
-    ...bootstrapConfig,
-    fullMetadata,
-    filterMetadata: fullMetadata,
-    ignoreMissingTimeField: opts.minimumReleaseAgeIgnoreMissingTime,
-  })
-  const pkgName = 'pnpm'
-  // The running version is already on this machine, so hiding it behind the
-  // maturity cutoff protects nothing — it only makes a dist-tag that points
-  // at it fall back to an older release, downgrading the user (pnpm/pnpm#13883).
-  const { publishedBy, publishedByExclude } = getPublishedByPolicy({
-    ...opts,
-    minimumReleaseAgeExclude: [
-      ...opts.minimumReleaseAgeExclude ?? [],
-      `${pkgName}@${packageManager.version}`,
-    ],
-  })
   // `pnpm self-update` (no args) defaults to the `latest` dist-tag, but we
   // refuse to downgrade in that case — `latest` on the registry can lag the
   // installed version when a new major has shipped without being tagged.
@@ -121,26 +94,15 @@ export async function handler (
   // still force a downgrade when they want one.
   const isImplicitLatest = params.length === 0
   const bareSpecifier = params[0] ?? 'latest'
-  const resolution = await resolve({ alias: pkgName, bareSpecifier }, {
-    lockfileDir: opts.lockfileDir ?? opts.dir,
-    preferredVersions: {},
-    projectDir: opts.dir,
-    publishedBy,
-    publishedByExclude,
-    // Unlike `dlx` (whose real install re-resolves through the store
-    // controller), this `resolve` is self-update's only version selection,
-    // so the trust policy has to be passed here for the no-downgrade check
-    // to run.
-    trustPolicy: opts.trustPolicy,
-    trustPolicyExclude: opts.trustPolicyExclude
-      ? createPackageVersionPolicyOrThrow(opts.trustPolicyExclude, 'trustPolicyExclude')
-      : undefined,
-    trustPolicyIgnoreAfter: opts.trustPolicyIgnoreAfter,
-  })
-  if (!resolution?.manifest) {
+  const resolved = await resolvePnpmVersion(opts, bareSpecifier)
+  if (resolved == null) {
     throw new PnpmError('CANNOT_RESOLVE_PNPM', `Cannot find "${bareSpecifier}" version of pnpm`)
   }
-  await enforceResolutionPolicy(resolution.policyViolation, opts)
+  await enforceResolutionPolicy(resolved.policyViolation, opts)
+  const targetVersion = resolved.version
+  // Before the pin below is written, not just before the install: the pin is
+  // shared, so a release this wrapper survives can still break a teammate's.
+  assertReleaseIsInstallable(targetVersion)
 
   // Determine the "previous" pnpm version being upgraded FROM. If the
   // project pins pnpm via `packageManager`/`devEngines.packageManager`,
@@ -148,10 +110,6 @@ export async function handler (
   // be at a newer major (e.g. a globally-installed v11 operating on a
   // project still pinned to v10). Otherwise fall back to the running
   // binary. Skip the hint entirely on a no-op (target === previous).
-  const targetVersion = resolution.manifest.version
-  // Before the pin below is written, not just before the install: the pin is
-  // shared, so a release this wrapper survives can still break a teammate's.
-  assertReleaseIsInstallable(targetVersion)
   let previousVersion: string | undefined
   if (opts.wantedPackageManager?.name === packageManager.name) {
     if (opts.wantedPackageManager.version !== targetVersion) {
@@ -170,14 +128,14 @@ export async function handler (
   }
 
   if (opts.wantedPackageManager?.name === packageManager.name) {
-    if (opts.wantedPackageManager?.version !== resolution.manifest.version) {
+    if (opts.wantedPackageManager?.version !== targetVersion) {
       if (isImplicitLatest) {
         // Prefer the lockfile-pinned version when available — for range
         // specs like `>=8.0.0`, the spec's lower bound understates the
         // version that was actually installed (see #11418 review).
         const projectCurrentVersion = await readProjectPinnedPnpmVersion(opts.rootProjectManifestDir, opts.wantedPackageManager?.version)
-        if (projectCurrentVersion != null && semver.lt(resolution.manifest.version, projectCurrentVersion)) {
-          return `The current project is set to use pnpm v${projectCurrentVersion}, which is newer than the "latest" version on the registry (v${resolution.manifest.version}). No update performed. Run "pnpm self-update latest" to downgrade.`
+        if (projectCurrentVersion != null && semver.lt(targetVersion, projectCurrentVersion)) {
+          return `The current project is set to use pnpm v${projectCurrentVersion}, which is newer than the "latest" version on the registry (v${targetVersion}). No update performed. Run "pnpm self-update latest" to downgrade.`
         }
       }
       const { manifest, writeProjectManifest } = await readProjectManifest(opts.rootProjectManifestDir)
@@ -199,15 +157,15 @@ export async function handler (
           : devEnginesPm.name === 'pnpm' ? devEnginesPm : undefined
         if (pnpmEntry) {
           const updated = legacyPinsPnpm
-            ? resolution.manifest.version
-            : updateVersionConstraint(pnpmEntry.version, resolution.manifest.version)
+            ? targetVersion
+            : updateVersionConstraint(pnpmEntry.version, targetVersion)
           if (updated !== pnpmEntry.version) {
             pnpmEntry.version = updated
             manifestChanged = true
           }
         }
         if (legacyPinsPnpm) {
-          const newLegacy = `pnpm@${resolution.manifest.version}`
+          const newLegacy = `pnpm@${targetVersion}`
           if (manifest.packageManager !== newLegacy) {
             manifest.packageManager = newLegacy
             manifestChanged = true
@@ -216,7 +174,7 @@ export async function handler (
         if (manifestChanged) await writeProjectManifest(manifest)
         if (shouldPersistLockfile({ ...opts.wantedPackageManager, fromDevEngines: true })) {
           const store = await createStoreController({ ...opts, ...bootstrapConfig })
-          await resolvePackageManagerIntegrities(resolution.manifest.version, {
+          await resolvePackageManagerIntegrities(targetVersion, {
             registriesByScope: bootstrapConfig.registriesByScope,
             rootDir: opts.rootProjectManifestDir,
             storeController: store.ctrl,
@@ -224,40 +182,40 @@ export async function handler (
           })
         }
       } else {
-        manifest.packageManager = `pnpm@${resolution.manifest.version}`
+        manifest.packageManager = `pnpm@${targetVersion}`
         await writeProjectManifest(manifest)
       }
-      return `The current project has been updated to use pnpm v${resolution.manifest.version}`
+      return `The current project has been updated to use pnpm v${targetVersion}`
     } else {
-      return `The current project is already set to use pnpm v${resolution.manifest.version}`
+      return `The current project is already set to use pnpm v${targetVersion}`
     }
   }
   // Version equality with the running binary alone must not skip the
   // update: a removed global install can be recovered by running a local
   // pnpm of the same version (see pnpm/pnpm#12877).
   if (
-    resolution.manifest.version === packageManager.version &&
-    await findGlobalPnpmInstallDir(opts.globalPkgDir, pnpmPackageNameToInstall(resolution.manifest.version), resolution.manifest.version) != null
+    targetVersion === packageManager.version &&
+    await findGlobalPnpmInstallDir(opts.globalPkgDir, pnpmPackageNameToInstall(targetVersion), targetVersion) != null
   ) {
     return `The currently active ${packageManager.name} v${packageManager.version} is already "${bareSpecifier}" and doesn't need an update`
   }
 
-  if (isImplicitLatest && semver.lt(resolution.manifest.version, packageManager.version)) {
-    return `The currently active ${packageManager.name} v${packageManager.version} is newer than the "latest" version on the registry (v${resolution.manifest.version}). No update performed. Run "pnpm self-update latest" to downgrade.`
+  if (isImplicitLatest && semver.lt(targetVersion, packageManager.version)) {
+    return `The currently active ${packageManager.name} v${packageManager.version} is newer than the "latest" version on the registry (v${targetVersion}). No update performed. Run "pnpm self-update latest" to downgrade.`
   }
 
-  globalInfo(`Switching pnpm from v${packageManager.version} to v${resolution.manifest.version}...`)
+  globalInfo(`Switching pnpm from v${packageManager.version} to v${targetVersion}...`)
   const store = await createStoreController({ ...opts, ...bootstrapConfig })
 
   // Resolve integrities and write env lockfile to pnpm-lock.yaml
-  const envLockfile = await resolvePackageManagerIntegrities(resolution.manifest.version, {
+  const envLockfile = await resolvePackageManagerIntegrities(targetVersion, {
     registriesByScope: bootstrapConfig.registriesByScope,
     rootDir: opts.pnpmHomeDir,
     storeController: store.ctrl,
     storeDir: store.dir,
   })
 
-  const { baseDir, alreadyExisted } = await installPnpm(resolution.manifest.version, {
+  const { baseDir, alreadyExisted } = await installPnpm(targetVersion, {
     ...opts,
     ...bootstrapConfig,
     envLockfile,
@@ -286,9 +244,9 @@ export async function handler (
   }
 
   if (alreadyExisted) {
-    return `The ${bareSpecifier} version, v${resolution.manifest.version}, is already present on the system. It was activated by linking it from ${baseDir}.`
+    return `The ${bareSpecifier} version, v${targetVersion}, is already present on the system. It was activated by linking it from ${baseDir}.`
   }
-  return `Successfully updated pnpm to v${resolution.manifest.version}`
+  return `Successfully updated pnpm to v${targetVersion}`
 }
 
 /**

--- a/pnpm11/store/connection-manager/src/createNewStoreController.ts
+++ b/pnpm11/store/connection-manager/src/createNewStoreController.ts
@@ -183,7 +183,7 @@ export function shouldFetchFullMetadata (
   return fullMetadataPolicy(opts, opts.registrySupportsTimeField ?? false)
 }
 
-type FullMetadataPolicyOptions = Pick<CreateNewStoreControllerOptions,
+export type FullMetadataPolicyOptions = Pick<CreateNewStoreControllerOptions,
 | 'fetchFullMetadata'
 | 'registrySupportsTimeField'
 | 'resolutionMode'

--- a/pnpm11/store/connection-manager/src/index.ts
+++ b/pnpm11/store/connection-manager/src/index.ts
@@ -3,9 +3,9 @@ import type { ResolutionVerifier } from '@pnpm/resolving.resolver-base'
 import type { StoreController } from '@pnpm/store.controller'
 import { getStorePath } from '@pnpm/store.path'
 
-import { createNewStoreController, type CreateNewStoreControllerOptions, shouldFetchFullMetadata } from './createNewStoreController.js'
+import { createNewStoreController, type CreateNewStoreControllerOptions, type FullMetadataPolicyOptions, shouldFetchFullMetadata } from './createNewStoreController.js'
 
-export { createNewStoreController, shouldFetchFullMetadata }
+export { createNewStoreController, type FullMetadataPolicyOptions, shouldFetchFullMetadata }
 
 export type CreateStoreControllerOptions = Omit<CreateNewStoreControllerOptions, 'storeDir'> & Pick<Config,
 | 'storeDir'

--- a/pnpm11/workspace/commands/package.json
+++ b/pnpm11/workspace/commands/package.json
@@ -35,13 +35,15 @@
     "@pnpm/cli.meta": "workspace:*",
     "@pnpm/cli.utils": "workspace:*",
     "@pnpm/config.reader": "workspace:*",
+    "@pnpm/engine.pm.commands": "workspace:*",
     "@pnpm/error": "workspace:*",
     "@pnpm/object.key-sorting": "workspace:*",
     "@pnpm/types": "workspace:*",
     "@pnpm/workspace.project-manifest-writer": "workspace:*",
     "camelcase-keys": "catalog:",
     "ramda": "catalog:",
-    "render-help": "catalog:"
+    "render-help": "catalog:",
+    "semver": "catalog:"
   },
   "devDependencies": {
     "@jest/globals": "catalog:",
@@ -49,6 +51,7 @@
     "@pnpm/test-fixtures": "workspace:*",
     "@pnpm/workspace.commands": "workspace:*",
     "@types/ramda": "catalog:",
+    "@types/semver": "catalog:",
     "load-json-file": "catalog:"
   },
   "engines": {

--- a/pnpm11/workspace/commands/src/init.ts
+++ b/pnpm11/workspace/commands/src/init.ts
@@ -4,7 +4,7 @@ import path from 'node:path'
 import { packageManager } from '@pnpm/cli.meta'
 import { docsUrl } from '@pnpm/cli.utils'
 import { type Config, type ConfigContext, types as allTypes } from '@pnpm/config.reader'
-import { isReleaseInstallable, resolvePnpmVersion, type ResolvePnpmVersionOptions } from '@pnpm/engine.pm.commands'
+import { isReleaseInstallable, prepareResolvePnpmVersion, type ResolvePnpmVersionOptions } from '@pnpm/engine.pm.commands'
 import { PnpmError } from '@pnpm/error'
 import { sortKeysByPriority } from '@pnpm/object.key-sorting'
 import type { ProjectManifest } from '@pnpm/types'
@@ -182,13 +182,17 @@ async function resolveVersionToPin (opts: InitOptions & Pick<Config, 'dir'>): Pr
   if (cacheDir == null || opts.offline === true || opts.preferOffline === true) {
     return packageManager.version
   }
+  // Outside the `try`: this reads the settings, so a misconfigured
+  // `trustPolicyExclude` fails `pnpm init` the way it fails every other
+  // command, rather than being mistaken for an unreachable registry.
+  const lookUpLatest = prepareResolvePnpmVersion({
+    ...opts,
+    cacheDir,
+    retry: { retries: 0 },
+    timeout: LATEST_LOOKUP_TIMEOUT,
+  })
   try {
-    const resolved = await resolvePnpmVersion({
-      ...opts,
-      cacheDir,
-      retry: { retries: 0 },
-      timeout: LATEST_LOOKUP_TIMEOUT,
-    }, 'latest')
+    const resolved = await lookUpLatest('latest')
     // A `latest` that the maturity or trust policy rejects is not something
     // to pin a new project to, and `pnpm init` has nobody to prompt for
     // approval. A broken release is refused for the reason the pin exists at

--- a/pnpm11/workspace/commands/src/init.ts
+++ b/pnpm11/workspace/commands/src/init.ts
@@ -4,7 +4,7 @@ import path from 'node:path'
 import { packageManager } from '@pnpm/cli.meta'
 import { docsUrl } from '@pnpm/cli.utils'
 import { type Config, type ConfigContext, types as allTypes } from '@pnpm/config.reader'
-import { resolvePnpmVersion, type ResolvePnpmVersionOptions } from '@pnpm/engine.pm.commands'
+import { isReleaseInstallable, resolvePnpmVersion, type ResolvePnpmVersionOptions } from '@pnpm/engine.pm.commands'
 import { PnpmError } from '@pnpm/error'
 import { sortKeysByPriority } from '@pnpm/object.key-sorting'
 import type { ProjectManifest } from '@pnpm/types'
@@ -140,6 +140,12 @@ export async function handler (opts: InitOptions, params?: string[]): Promise<st
     'packageManager',
   ].map((key, index) => [key, index]))
   const sortedPackageJson = sortKeysByPriority({ priority }, packageJson)
+  // Checked again right before the write, not only on entry: the pin lookup
+  // above waits on a registry, and a manifest that appeared during that wait
+  // must not be overwritten.
+  if (fs.existsSync(manifestPath)) {
+    throw new PnpmError('PACKAGE_JSON_EXISTS', 'package.json already exists')
+  }
   await writeProjectManifest(manifestPath, sortedPackageJson, {
     indent: 2,
   })
@@ -149,10 +155,10 @@ ${JSON.stringify(sortedPackageJson, null, 2)}`
 }
 
 /**
- * How long the `latest` lookup may take before `pnpm init` gives up on it.
- * Much shorter than the resolver's usual timeout: the version is a nicety,
- * and a scaffold command that appears to hang is worse than one that pins
- * the running version.
+ * How long each registry request in the `latest` lookup may take. Much
+ * shorter than the resolver's usual timeout: the version is a nicety, and a
+ * scaffold command that appears to hang is worse than one that pins the
+ * running version.
  */
 const LATEST_LOOKUP_TIMEOUT = 10000
 
@@ -185,8 +191,16 @@ async function resolveVersionToPin (opts: InitOptions & Pick<Config, 'dir'>): Pr
     }, 'latest')
     // A `latest` that the maturity or trust policy rejects is not something
     // to pin a new project to, and `pnpm init` has nobody to prompt for
-    // approval.
-    if (resolved == null || resolved.policyViolation != null) return packageManager.version
+    // approval. A broken release is refused for the reason the pin exists at
+    // all: it is shared, so pinning one the running wrapper happens to
+    // survive would still break every teammate on the other wrapper.
+    if (
+      resolved == null ||
+      resolved.policyViolation != null ||
+      !isReleaseInstallable(resolved.version)
+    ) {
+      return packageManager.version
+    }
     return semver.gt(resolved.version, packageManager.version)
       ? resolved.version
       : packageManager.version

--- a/pnpm11/workspace/commands/src/init.ts
+++ b/pnpm11/workspace/commands/src/init.ts
@@ -4,12 +4,14 @@ import path from 'node:path'
 import { packageManager } from '@pnpm/cli.meta'
 import { docsUrl } from '@pnpm/cli.utils'
 import { type Config, type ConfigContext, types as allTypes } from '@pnpm/config.reader'
+import { resolvePnpmVersion, type ResolvePnpmVersionOptions } from '@pnpm/engine.pm.commands'
 import { PnpmError } from '@pnpm/error'
 import { sortKeysByPriority } from '@pnpm/object.key-sorting'
 import type { ProjectManifest } from '@pnpm/types'
 import { writeProjectManifest } from '@pnpm/workspace.project-manifest-writer'
 import { pick } from 'ramda'
 import { renderHelp } from 'render-help'
+import semver from 'semver'
 
 import { getInitConfig } from './utils.js'
 
@@ -39,7 +41,7 @@ export function help (): string {
             name: '--init-type <commonjs|module>',
           },
           {
-            description: 'Pin the pnpm version in package.json, through "devEngines.packageManager" and "packageManager", and auto-download pnpm when it is missing',
+            description: 'Pin the latest pnpm version in package.json, through "devEngines.packageManager" and "packageManager", and auto-download pnpm when it is missing',
             name: '--init-package-manager',
           },
           {
@@ -56,6 +58,7 @@ export function help (): string {
 
 export type InitOptions =
   & Pick<ConfigContext, 'cliOptions'>
+  & Partial<ResolvePnpmVersionOptions>
   & Partial<Pick<Config,
   | 'initAuthorEmail'
   | 'initAuthorName'
@@ -64,6 +67,8 @@ export type InitOptions =
   | 'initPackageManager'
   | 'initType'
   | 'initVersion'
+  | 'offline'
+  | 'preferOffline'
   | 'workspaceDir'
   >> & {
     bare?: boolean
@@ -107,18 +112,19 @@ export async function handler (opts: InitOptions, params?: string[]): Promise<st
   const initConfig = getInitConfig(opts)
   const packageJson = { ...manifest, ...initConfig }
   if (opts.initPackageManager && !isWorkspaceSubpackage) {
+    const version = await resolveVersionToPin({ ...opts, dir: initDir })
     packageJson.devEngines = {
       ...packageJson.devEngines,
       packageManager: {
         name: 'pnpm',
-        version: packageManager.version,
+        version,
         onFail: 'download',
       },
     }
     // Corepack reads only "packageManager", so the pin is written to both
     // fields. They must stay in sync: a mismatch makes pnpm warn and ignore
     // the legacy field.
-    packageJson.packageManager = `pnpm@${packageManager.version}`
+    packageJson.packageManager = `pnpm@${version}`
   }
   const priority = Object.fromEntries([
     'name',
@@ -140,4 +146,55 @@ export async function handler (opts: InitOptions, params?: string[]): Promise<st
   return `Wrote to ${manifestPath}
 
 ${JSON.stringify(sortedPackageJson, null, 2)}`
+}
+
+/**
+ * How long the `latest` lookup may take before `pnpm init` gives up on it.
+ * Much shorter than the resolver's usual timeout: the version is a nicety,
+ * and a scaffold command that appears to hang is worse than one that pins
+ * the running version.
+ */
+const LATEST_LOOKUP_TIMEOUT = 10000
+
+/**
+ * The pnpm version the new project is pinned to: whatever the registry's
+ * `latest` tag points at, so a project scaffolded by a long-outdated pnpm
+ * does not inherit that staleness through its own pin.
+ *
+ * Falls back to the running version whenever `latest` cannot be established,
+ * and never lets `latest` move the pin backwards — the tag can lag the
+ * running version when a new major has shipped without being tagged.
+ *
+ * The lookup is skipped outright when the caller asked to stay off the
+ * network, and when no `cacheDir` was supplied: the CLI always sets one, so
+ * its absence marks a programmatic caller that passed nothing to resolve
+ * with, which should get the running version rather than a network call it
+ * never configured.
+ */
+async function resolveVersionToPin (opts: InitOptions & Pick<Config, 'dir'>): Promise<string> {
+  const { cacheDir } = opts
+  if (cacheDir == null || opts.offline === true || opts.preferOffline === true) {
+    return packageManager.version
+  }
+  try {
+    const resolved = await resolvePnpmVersion({
+      ...opts,
+      cacheDir,
+      retry: { retries: 0 },
+      timeout: LATEST_LOOKUP_TIMEOUT,
+    }, 'latest')
+    // A `latest` that the maturity or trust policy rejects is not something
+    // to pin a new project to, and `pnpm init` has nobody to prompt for
+    // approval.
+    if (resolved == null || resolved.policyViolation != null) return packageManager.version
+    return semver.gt(resolved.version, packageManager.version)
+      ? resolved.version
+      : packageManager.version
+  } catch {
+    // Deliberately broad: writing a package.json must not fail because the
+    // registry is unreachable, misconfigured, slow, or answering with a
+    // version that isn't valid semver. The running version is always a usable
+    // pin, so every lookup failure degrades to it.
+    return packageManager.version
+  }
 }

--- a/pnpm11/workspace/commands/test/initPackageManager.test.ts
+++ b/pnpm11/workspace/commands/test/initPackageManager.test.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs'
 import path from 'node:path'
 
 import { beforeEach, expect, jest, test } from '@jest/globals'
@@ -8,12 +9,14 @@ import { loadJsonFileSync } from 'load-json-file'
 import semver from 'semver'
 
 jest.unstable_mockModule('@pnpm/engine.pm.commands', () => ({
+  isReleaseInstallable: jest.fn(),
   resolvePnpmVersion: jest.fn(),
 }))
-const { resolvePnpmVersion } = await import('@pnpm/engine.pm.commands')
+const { isReleaseInstallable, resolvePnpmVersion } = await import('@pnpm/engine.pm.commands')
 const { init } = await import('@pnpm/workspace.commands')
 
 const mockResolvePnpmVersion = jest.mocked(resolvePnpmVersion)
+const mockIsReleaseInstallable = jest.mocked(isReleaseInstallable)
 
 const NEWER_VERSION = semver.inc(packageManager.version, 'major')!
 // A prerelease of the running version is lower than it whatever version this
@@ -22,6 +25,7 @@ const OLDER_VERSION = `${packageManager.version}-0`
 
 beforeEach(() => {
   mockResolvePnpmVersion.mockReset()
+  mockIsReleaseInstallable.mockReset().mockReturnValue(true)
 })
 
 async function initPinned (): Promise<ProjectManifest> {
@@ -94,6 +98,35 @@ test('pins the running pnpm when "latest" violates the release policy', async ()
   const manifest = await initPinned()
 
   expect(manifest.packageManager).toBe(`pnpm@${packageManager.version}`)
+})
+
+// Which releases are broken is `@pnpm/engine.pm.commands`' business and is
+// tested there; what matters here is that init refuses to pin one. The pin is
+// shared but the wrapper is not, so pinning a release the running wrapper
+// happens to survive would still break every teammate on the other wrapper.
+test('pins the running pnpm when "latest" is not an installable release', async () => {
+  prepareEmpty()
+  mockResolvePnpmVersion.mockResolvedValue({ version: NEWER_VERSION })
+  mockIsReleaseInstallable.mockReturnValue(false)
+
+  const manifest = await initPinned()
+
+  expect(mockIsReleaseInstallable).toHaveBeenCalledWith(NEWER_VERSION)
+  expect(manifest.packageManager).toBe(`pnpm@${packageManager.version}`)
+})
+
+test('does not overwrite a package.json created while the pin was being resolved', async () => {
+  prepareEmpty()
+  const manifestPath = path.resolve('package.json')
+  const writtenMeanwhile = { name: 'written-by-someone-else' }
+  mockResolvePnpmVersion.mockImplementation(async () => {
+    fs.writeFileSync(manifestPath, JSON.stringify(writtenMeanwhile))
+    return { version: NEWER_VERSION }
+  })
+
+  await expect(initPinned()).rejects.toThrow('package.json already exists')
+
+  expect(loadJsonFileSync(manifestPath)).toStrictEqual(writtenMeanwhile)
 })
 
 test('does not reach the registry when offline', async () => {

--- a/pnpm11/workspace/commands/test/initPackageManager.test.ts
+++ b/pnpm11/workspace/commands/test/initPackageManager.test.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 
 import { beforeEach, expect, jest, test } from '@jest/globals'
 import { packageManager } from '@pnpm/cli.meta'
+import type { PnpmVersionLookup } from '@pnpm/engine.pm.commands'
 import { prepareEmpty } from '@pnpm/prepare'
 import type { ProjectManifest } from '@pnpm/types'
 import { loadJsonFileSync } from 'load-json-file'
@@ -10,13 +11,14 @@ import semver from 'semver'
 
 jest.unstable_mockModule('@pnpm/engine.pm.commands', () => ({
   isReleaseInstallable: jest.fn(),
-  resolvePnpmVersion: jest.fn(),
+  prepareResolvePnpmVersion: jest.fn(),
 }))
-const { isReleaseInstallable, resolvePnpmVersion } = await import('@pnpm/engine.pm.commands')
+const { isReleaseInstallable, prepareResolvePnpmVersion } = await import('@pnpm/engine.pm.commands')
 const { init } = await import('@pnpm/workspace.commands')
 
-const mockResolvePnpmVersion = jest.mocked(resolvePnpmVersion)
+const mockPrepareLookup = jest.mocked(prepareResolvePnpmVersion)
 const mockIsReleaseInstallable = jest.mocked(isReleaseInstallable)
+const mockLookup = jest.fn<PnpmVersionLookup>()
 
 const NEWER_VERSION = semver.inc(packageManager.version, 'major')!
 // A prerelease of the running version is lower than it whatever version this
@@ -24,7 +26,8 @@ const NEWER_VERSION = semver.inc(packageManager.version, 'major')!
 const OLDER_VERSION = `${packageManager.version}-0`
 
 beforeEach(() => {
-  mockResolvePnpmVersion.mockReset()
+  mockLookup.mockReset()
+  mockPrepareLookup.mockReset().mockReturnValue(mockLookup)
   mockIsReleaseInstallable.mockReset().mockReturnValue(true)
 })
 
@@ -39,11 +42,11 @@ async function initPinned (): Promise<ProjectManifest> {
 
 test('pins the version the "latest" tag resolves to', async () => {
   prepareEmpty()
-  mockResolvePnpmVersion.mockResolvedValue({ version: NEWER_VERSION })
+  mockLookup.mockResolvedValue({ version: NEWER_VERSION })
 
   const manifest = await initPinned()
 
-  expect(mockResolvePnpmVersion).toHaveBeenCalledWith(expect.anything(), 'latest')
+  expect(mockLookup).toHaveBeenCalledWith('latest')
   expect(manifest.packageManager).toBe(`pnpm@${NEWER_VERSION}`)
   expect(manifest.devEngines?.packageManager).toEqual({
     name: 'pnpm',
@@ -54,7 +57,7 @@ test('pins the version the "latest" tag resolves to', async () => {
 
 test('does not pin a "latest" that is older than the running pnpm', async () => {
   prepareEmpty()
-  mockResolvePnpmVersion.mockResolvedValue({ version: OLDER_VERSION })
+  mockLookup.mockResolvedValue({ version: OLDER_VERSION })
 
   const manifest = await initPinned()
 
@@ -63,7 +66,7 @@ test('does not pin a "latest" that is older than the running pnpm', async () => 
 
 test('pins the running pnpm when the lookup fails', async () => {
   prepareEmpty()
-  mockResolvePnpmVersion.mockRejectedValue(new Error('getaddrinfo ENOTFOUND registry.npmjs.org'))
+  mockLookup.mockRejectedValue(new Error('getaddrinfo ENOTFOUND registry.npmjs.org'))
 
   const manifest = await initPinned()
 
@@ -72,7 +75,7 @@ test('pins the running pnpm when the lookup fails', async () => {
 
 test('pins the running pnpm when "latest" resolves to nothing', async () => {
   prepareEmpty()
-  mockResolvePnpmVersion.mockResolvedValue(undefined)
+  mockLookup.mockResolvedValue(undefined)
 
   const manifest = await initPinned()
 
@@ -81,7 +84,7 @@ test('pins the running pnpm when "latest" resolves to nothing', async () => {
 
 test('pins the running pnpm when "latest" violates the release policy', async () => {
   prepareEmpty()
-  mockResolvePnpmVersion.mockResolvedValue({
+  mockLookup.mockResolvedValue({
     version: NEWER_VERSION,
     policyViolation: {
       code: 'MINIMUM_RELEASE_AGE_VIOLATION',
@@ -106,7 +109,7 @@ test('pins the running pnpm when "latest" violates the release policy', async ()
 // happens to survive would still break every teammate on the other wrapper.
 test('pins the running pnpm when "latest" is not an installable release', async () => {
   prepareEmpty()
-  mockResolvePnpmVersion.mockResolvedValue({ version: NEWER_VERSION })
+  mockLookup.mockResolvedValue({ version: NEWER_VERSION })
   mockIsReleaseInstallable.mockReturnValue(false)
 
   const manifest = await initPinned()
@@ -119,7 +122,7 @@ test('does not overwrite a package.json created while the pin was being resolved
   prepareEmpty()
   const manifestPath = path.resolve('package.json')
   const writtenMeanwhile = { name: 'written-by-someone-else' }
-  mockResolvePnpmVersion.mockImplementation(async () => {
+  mockLookup.mockImplementation(async () => {
     fs.writeFileSync(manifestPath, JSON.stringify(writtenMeanwhile))
     return { version: NEWER_VERSION }
   })
@@ -139,6 +142,6 @@ test('does not reach the registry when offline', async () => {
   })
   const manifest = loadJsonFileSync<ProjectManifest>(path.resolve('package.json'))
 
-  expect(mockResolvePnpmVersion).not.toHaveBeenCalled()
+  expect(mockPrepareLookup).not.toHaveBeenCalled()
   expect(manifest.packageManager).toBe(`pnpm@${packageManager.version}`)
 })

--- a/pnpm11/workspace/commands/test/initPackageManager.test.ts
+++ b/pnpm11/workspace/commands/test/initPackageManager.test.ts
@@ -84,6 +84,10 @@ test('pins the running pnpm when "latest" violates the release policy', async ()
       name: 'pnpm',
       version: NEWER_VERSION,
       reason: 'is too new',
+      resolution: {
+        integrity: 'sha512-',
+        tarball: `https://registry.npmjs.org/pnpm/-/pnpm-${NEWER_VERSION}.tgz`,
+      },
     },
   })
 

--- a/pnpm11/workspace/commands/test/initPackageManager.test.ts
+++ b/pnpm11/workspace/commands/test/initPackageManager.test.ts
@@ -1,0 +1,107 @@
+import path from 'node:path'
+
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import { packageManager } from '@pnpm/cli.meta'
+import { prepareEmpty } from '@pnpm/prepare'
+import type { ProjectManifest } from '@pnpm/types'
+import { loadJsonFileSync } from 'load-json-file'
+import semver from 'semver'
+
+jest.unstable_mockModule('@pnpm/engine.pm.commands', () => ({
+  resolvePnpmVersion: jest.fn(),
+}))
+const { resolvePnpmVersion } = await import('@pnpm/engine.pm.commands')
+const { init } = await import('@pnpm/workspace.commands')
+
+const mockResolvePnpmVersion = jest.mocked(resolvePnpmVersion)
+
+const NEWER_VERSION = semver.inc(packageManager.version, 'major')!
+// A prerelease of the running version is lower than it whatever version this
+// build reports, including the `0.0.0` an unreleased checkout carries.
+const OLDER_VERSION = `${packageManager.version}-0`
+
+beforeEach(() => {
+  mockResolvePnpmVersion.mockReset()
+})
+
+async function initPinned (): Promise<ProjectManifest> {
+  await init.handler({
+    cacheDir: path.resolve('cache'),
+    cliOptions: {},
+    initPackageManager: true,
+  })
+  return loadJsonFileSync<ProjectManifest>(path.resolve('package.json'))
+}
+
+test('pins the version the "latest" tag resolves to', async () => {
+  prepareEmpty()
+  mockResolvePnpmVersion.mockResolvedValue({ version: NEWER_VERSION })
+
+  const manifest = await initPinned()
+
+  expect(mockResolvePnpmVersion).toHaveBeenCalledWith(expect.anything(), 'latest')
+  expect(manifest.packageManager).toBe(`pnpm@${NEWER_VERSION}`)
+  expect(manifest.devEngines?.packageManager).toEqual({
+    name: 'pnpm',
+    version: NEWER_VERSION,
+    onFail: 'download',
+  })
+})
+
+test('does not pin a "latest" that is older than the running pnpm', async () => {
+  prepareEmpty()
+  mockResolvePnpmVersion.mockResolvedValue({ version: OLDER_VERSION })
+
+  const manifest = await initPinned()
+
+  expect(manifest.packageManager).toBe(`pnpm@${packageManager.version}`)
+})
+
+test('pins the running pnpm when the lookup fails', async () => {
+  prepareEmpty()
+  mockResolvePnpmVersion.mockRejectedValue(new Error('getaddrinfo ENOTFOUND registry.npmjs.org'))
+
+  const manifest = await initPinned()
+
+  expect(manifest.packageManager).toBe(`pnpm@${packageManager.version}`)
+})
+
+test('pins the running pnpm when "latest" resolves to nothing', async () => {
+  prepareEmpty()
+  mockResolvePnpmVersion.mockResolvedValue(undefined)
+
+  const manifest = await initPinned()
+
+  expect(manifest.packageManager).toBe(`pnpm@${packageManager.version}`)
+})
+
+test('pins the running pnpm when "latest" violates the release policy', async () => {
+  prepareEmpty()
+  mockResolvePnpmVersion.mockResolvedValue({
+    version: NEWER_VERSION,
+    policyViolation: {
+      code: 'MINIMUM_RELEASE_AGE_VIOLATION',
+      name: 'pnpm',
+      version: NEWER_VERSION,
+      reason: 'is too new',
+    },
+  })
+
+  const manifest = await initPinned()
+
+  expect(manifest.packageManager).toBe(`pnpm@${packageManager.version}`)
+})
+
+test('does not reach the registry when offline', async () => {
+  prepareEmpty()
+  await init.handler({
+    cacheDir: path.resolve('cache'),
+    cliOptions: {},
+    initPackageManager: true,
+    offline: true,
+  })
+  const manifest = loadJsonFileSync<ProjectManifest>(path.resolve('package.json'))
+
+  expect(mockResolvePnpmVersion).not.toHaveBeenCalled()
+  expect(manifest.packageManager).toBe(`pnpm@${packageManager.version}`)
+})

--- a/pnpm11/workspace/commands/tsconfig.json
+++ b/pnpm11/workspace/commands/tsconfig.json
@@ -31,6 +31,9 @@
       "path": "../../core/types"
     },
     {
+      "path": "../../engine/pm/commands"
+    },
+    {
       "path": "../../object/key-sorting"
     },
     {


### PR DESCRIPTION
## Summary

`pnpm init` wrote its `devEngines.packageManager` / `packageManager` pin from the version of pnpm that happened to run the command. That makes staleness self-perpetuating: a developer whose global pnpm is a year old scaffolds a project pinned to that year-old pnpm, and the pin then holds every collaborator there.

Both stacks now resolve pnpm's `latest` tag when they are about to write a pin. A brand-new project is the one place where jumping to the current release can break nothing, so this is the safest possible place to be aggressive about freshness — and combined with `pnpm self-update` for existing projects it is a large part of the friction behind pnpm/pnpm#7490 without any daemon-style auto-updating.

The pin falls back to the running version whenever `latest` cannot be established:

- no `cacheDir` (a programmatic caller of `init.handler` that configured nothing to resolve with),
- `offline` / `preferOffline`,
- an unreachable, misconfigured, or slow registry,
- a `latest` that the `minimumReleaseAge` / `trustPolicy` settings reject — `init` has nobody to prompt for approval,
- a `latest` that is a known-broken release, whose `@pnpm/exe` build cannot run: the pin is shared but the wrapper is not, so pinning one the running wrapper happens to survive would still break every teammate on the other wrapper (`self-update` already refuses these before writing a pin),
- a `latest` **older** than the running version, since the tag lags whenever a new major ships untagged (the same guard `self-update` already has).

A misconfigured setting is *not* in that list: `prepareResolvePnpmVersion` reads the settings and the function it returns performs the lookup, so `init` guards only the lookup and an invalid `trustPolicyExclude` still fails the command the way it fails every other one.

The lookup makes one attempt with no retry schedule and is capped at ten seconds, so scaffolding a manifest can never fail or appear to hang on it. It is skipped entirely when a `package.json` is already there, so the "already exists" error costs no network.

### Review round

Findings from the automated reviewers that turned out to be real, and what changed:

- **A broken release could become the pin** (both stacks) — fixed in `dcbbda04c9`. Factored into a predicate the existing assertion delegates to, so there is still one source of truth for which releases are broken.
- **The lookup widened `init`'s check-to-write window** from nothing to seconds, so a `package.json` created meanwhile would be overwritten — fixed in `dcbbda04c9`. This was also a stack divergence: pacquet checks adjacent to its write, so it was never exposed. Not atomic against a concurrent writer; `writeProjectManifest` has no no-clobber mode and adding one means changing a shared package.
- **The TypeScript `timeout` is per-request, not an overall deadline** — my comment claimed otherwise and is corrected in `dcbbda04c9`. pacquet's `tokio::time::timeout` is a true deadline. Both fall back to the running version, so this is a latency bound rather than a behavioural difference; the reasoning against adding a `Promise.race` deadline is in the thread.
- **The catch swallowed configuration errors** — fixed in `ecb537fd46` by splitting settings validation from the lookup, as described above.

### Two decisions worth a reviewer's attention

**It resolves through the trusted package-manager registries**, the channel `self-update` provisions the engine from, rather than the project registries. `updateNotifier` deliberately does the opposite for the same question, so this is a real fork in the road: the difference is that the notifier only *prints* a hint, whereas this value becomes a durable pin that drives an engine download, and a repo-controlled `.npmrc` should not choose it. An org that mirrors pnpm points `packageManagerRegistries` (or an explicit `registry`) at its mirror, which redirects both. Happy to flip it to the notifier's behaviour if you prefer the consistency — it is a one-line change on each side.

**Crossing a major is allowed.** Run `pnpm init` the week after pnpm 13 ships and the next `pnpm install` in that project runs pnpm 13. Capping the pin to the running major would quietly defeat the purpose over time, and the project is empty, so I took it deliberately rather than leaving it for users to discover.

A possible follow-up, deliberately not in this PR: `updateNotifier` already asks the registry the same question once a day but records only a timestamp in `pnpm-state.json`. Recording the version it found would let `init` skip the network in the common case.

Related to pnpm/pnpm#7490.

## Squash Commit Body

```text
`pnpm init` wrote its `devEngines.packageManager` / `packageManager` pin
from the version of pnpm that happened to run the command. That makes
staleness self-perpetuating: a developer whose global pnpm is a year old
scaffolds a project pinned to that year-old pnpm, and the pin then holds
every collaborator there. It is also the friction behind the request to
have pnpm auto-update itself (pnpm/pnpm#7490) — a brand new project is
the one place where jumping to the current release can break nothing.

Both stacks now resolve pnpm's `latest` tag when they are about to write
a pin, and fall back to the running version whenever that cannot be
answered: no `cacheDir`, `offline` / `preferOffline`, an unreachable or
slow registry, a `latest` the `minimumReleaseAge` / `trustPolicy`
settings reject, or a `latest` older than the running version (the tag
lags whenever a new major ships untagged). The lookup makes one attempt
with no retry schedule and is capped at ten seconds, so scaffolding a
manifest can never fail or appear to hang on it, and it is skipped
entirely when a `package.json` is already there.

The lookup runs through the trusted package-manager registries, the
channel `self-update` provisions the engine from, rather than the
project registries: the value becomes a durable pin that drives an
engine download, so a repo-controlled `.npmrc` must not choose it.

On the TypeScript side the version resolution `self-update` already had
— bootstrap config, release-age cutoff excluding the running version,
trust policy — moves to `resolvePnpmVersion`, which `init` now shares;
`self-update`'s `resolution.manifest.version` reads become the
`targetVersion` it already declared. On the pacquet side `init` gains a
real command future, since it now awaits the registry.

Related to pnpm/pnpm#7490.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

### On tests

- **pacquet** covers the wire path end to end: a mock registry serving pnpm at `99.0.0` (the pin follows it), at `1.0.0` (the no-downgrade guard holds), and an unreachable registry (falls back, in 0.06s — the no-retry change is what makes that fast rather than a 10s timeout).
- **TypeScript** covers the decision logic as unit tests with the resolver mocked (100% branch coverage of the new code): pins `latest`, refuses an older `latest`, falls back on throw / on nothing resolved / on a policy violation, and skips the lookup when offline. There is no end-to-end test because the TypeScript mock registry does not serve a `pnpm` package the way pacquet's does; adding that fixture looked like more blast radius than it was worth here.
- Both stacks were also checked by hand against a local server serving a chosen `latest`: both pin `99.0.0` when it is offered and both keep their own version when the tag is moved back to `1.0.0`.

`pnpm init` against the real registry takes ~0.65s end to end on a warm cache.

The docs for `init` and `initPackageManager` on pnpm.io will need the same wording change (the pin is `latest`, falling back to the running version); that repo is separate from this one.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790261585&installation_model_id=426870&pr_number=14167&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14167&signature=610624ab08f8e1dc503c165a70d3372ceddf7957d5dc0ea5a398c6f07b10d29b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `pnpm init --init-package-manager` now pins the registry’s latest pnpm version when available.
  * Workspace initialization follows the same version-resolution behavior.
  * Falls back to the current pnpm version when the latest version is unavailable, invalid, older, blocked, or not installable.

* **Bug Fixes**
  * Initialization now handles offline, unreachable, and timed-out registries without hanging or failing.
  * Prevented downgrades and avoided overwriting manifests created during version lookup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
