### PR TITLE
fix: print trailing newline for audit command

### DIFF
--- a/.changeset/rare-wolves-matter.md
+++ b/.changeset/rare-wolves-matter.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm audit` now prints a trailing newline.

--- a/.changeset/rare-wolves-matter.md
+++ b/.changeset/rare-wolves-matter.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm audit` now prints a trailing newline.
+`pnpm audit` now ends its output with a trailing newline, including the `--json`, `--fix`, and `--ignore` output.

--- a/pnpm/crates/cli/src/cli_args/audit.rs
+++ b/pnpm/crates/cli/src/cli_args/audit.rs
@@ -243,8 +243,7 @@ impl AuditArgs {
                     let _ = std::io::stderr().flush();
                     if self.json {
                         let report = empty_audit_report(lockfile, env_lockfile.as_ref(), include);
-                        print!("{}", render_json_report(&report, audit_level)?);
-                        let _ = std::io::stdout().flush();
+                        print_command_output(&render_json_report(&report, audit_level)?);
                     }
                     return Ok(AuditOutcome::Clean);
                 }
@@ -320,8 +319,7 @@ impl AuditArgs {
                     let output =
                         fix_override(&filtered, &settings_dir, state.config, &publish_infos)
                             .await?;
-                    print!("{output}");
-                    let _ = std::io::stdout().flush();
+                    print_command_output(&output);
                     Ok(AuditOutcome::Clean)
                 }
                 FixMethod::Update => {
@@ -342,8 +340,7 @@ impl AuditArgs {
                         );
                         output.push_str(&note);
                     }
-                    print!("{output}");
-                    let _ = std::io::stdout().flush();
+                    print_command_output(&output);
                     Ok(if remaining.is_empty() {
                         AuditOutcome::Clean
                     } else {
@@ -361,8 +358,7 @@ impl AuditArgs {
                 &self.ignore,
                 self.ignore_unfixable,
             )?;
-            print!("{output}");
-            let _ = std::io::stdout().flush();
+            print_command_output(&output);
             return Ok(AuditOutcome::Clean);
         }
 
@@ -374,8 +370,7 @@ impl AuditArgs {
         } else {
             render_text_report(&report, audit_level, total_vulnerability_count, &ignored)
         };
-        print!("{output}");
-        let _ = std::io::stdout().flush();
+        print_command_output(&output);
 
         Ok(
             if report
@@ -452,8 +447,7 @@ impl AuditArgs {
         } else {
             signatures::render_signature_verification_result(&result)
         };
-        print!("{output}");
-        let _ = std::io::stdout().flush();
+        print_command_output(&output);
 
         Ok(if result.invalid.is_empty() && result.missing.is_empty() {
             AuditOutcome::Clean
@@ -517,6 +511,21 @@ async fn audit(
             body: sanitize_response_body(&raw_body),
         }),
     }
+}
+
+/// Write one command result to stdout, appending the newline it lacks. Mirrors
+/// pnpm's CLI, which terminates every command's output the same way and writes
+/// nothing when a command produced none.
+fn print_command_output(output: &str) {
+    if output.is_empty() {
+        return;
+    }
+    if output.ends_with('\n') {
+        print!("{output}");
+    } else {
+        println!("{output}");
+    }
+    let _ = std::io::stdout().flush();
 }
 
 fn retry_opts_from_config(config: &Config) -> RetryOpts {

--- a/pnpm/crates/cli/src/cli_args/audit/render.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/render.rs
@@ -116,7 +116,7 @@ pub(crate) fn report_summary(
         .collect::<Vec<_>>()
         .join(" | ");
     format!(
-        "{} vulnerabilities found\nSeverity: {severities}\n",
+        "{} vulnerabilities found\nSeverity: {severities}",
         red(&total_vulnerability_count.to_string()),
     )
 }

--- a/pnpm/crates/cli/src/cli_args/audit/render.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/render.rs
@@ -116,7 +116,7 @@ pub(crate) fn report_summary(
         .collect::<Vec<_>>()
         .join(" | ");
     format!(
-        "{} vulnerabilities found\nSeverity: {severities}",
+        "{} vulnerabilities found\nSeverity: {severities}\n",
         red(&total_vulnerability_count.to_string()),
     )
 }

--- a/pnpm/crates/cli/tests/suite/audit.rs
+++ b/pnpm/crates/cli/tests/suite/audit.rs
@@ -41,6 +41,7 @@ fn audit_json_posts_bulk_request_and_exits_on_vulnerability() {
 
     assert_eq!(output.status.code(), Some(1), "vulnerability should produce exit code 1");
     let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.ends_with('\n'), "JSON report should end with a newline:\n{stdout}");
     let report: serde_json::Value = serde_json::from_str(&stdout).expect("audit JSON output");
     assert_eq!(report["advisories"]["123"]["title"], "test vulnerability");
     assert_eq!(report["advisories"]["123"]["module_name"], "vulnerable");
@@ -554,8 +555,9 @@ fn audit_signatures_json_reports_counts() {
         .expect("run audit signatures");
 
     assert_success(&output);
-    let report: serde_json::Value =
-        serde_json::from_str(&stdout(&output)).expect("signatures JSON");
+    let out = stdout(&output);
+    assert!(out.ends_with('\n'), "signatures JSON should end with a newline:\n{out}");
+    let report: serde_json::Value = serde_json::from_str(&out).expect("signatures JSON");
     assert_eq!(report["audited"], 1);
     assert_eq!(report["verified"], 1);
     assert_eq!(report["invalid"].as_array().expect("invalid array").len(), 0);
@@ -746,7 +748,9 @@ fn audit_fix_override_writes_overrides_to_workspace_manifest() {
     let output = pacquet.arg("audit").arg("--fix").output().expect("run pacquet audit --fix");
 
     assert_success(&output);
-    assert!(stdout(&output).contains("overrides were added to pnpm-workspace.yaml"));
+    let out = stdout(&output);
+    assert!(out.contains("overrides were added to pnpm-workspace.yaml"), "{out}");
+    assert!(out.ends_with('\n'), "fix output should end with a newline:\n{out}");
     let manifest =
         fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("read workspace manifest");
     assert!(
@@ -947,7 +951,7 @@ fn audit_fix_override_with_no_fixable_vulnerabilities_makes_no_changes() {
     let output = pacquet.arg("audit").arg("--fix").output().expect("run pacquet audit --fix");
 
     assert_success(&output);
-    assert_eq!(stdout(&output), "No fixes were made");
+    assert_eq!(stdout(&output), "No fixes were made\n");
     mock.assert();
 }
 
@@ -1239,8 +1243,7 @@ fn audit_ignore_writes_ghsa_to_audit_config() {
         .expect("run pacquet audit --ignore");
 
     assert_success(&output);
-    assert!(stdout(&output).contains("1 new vulnerabilities were ignored"));
-    assert!(stdout(&output).contains("GHSA-test-1111-2222"));
+    assert_eq!(stdout(&output), "1 new vulnerabilities were ignored:\nGHSA-test-1111-2222\n");
     let manifest =
         fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("read workspace manifest");
     assert!(

--- a/pnpm/crates/cli/tests/suite/audit.rs
+++ b/pnpm/crates/cli/tests/suite/audit.rs
@@ -116,7 +116,7 @@ fn audit_exits_zero_when_every_vulnerability_is_below_audit_level() {
         pacquet.arg("audit").arg("--audit-level").arg("high").output().expect("run pacquet audit");
 
     assert_success(&output);
-    assert_eq!(stdout(&output), "1 vulnerabilities found\nSeverity: 1 moderate");
+    assert_eq!(stdout(&output), "1 vulnerabilities found\nSeverity: 1 moderate\n");
     mock.assert();
 }
 
@@ -500,7 +500,7 @@ fn audit_defaults_to_low_and_ignores_info_for_exit_code() {
     let output = pacquet.arg("audit").output().expect("run pacquet audit");
 
     assert_success(&output);
-    assert_eq!(stdout(&output), "1 vulnerabilities found\nSeverity: 1 info");
+    assert_eq!(stdout(&output), "1 vulnerabilities found\nSeverity: 1 info\n");
     mock.assert();
 }
 


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

<!-- Describe what this PR changes and why, for reviewers. Link any related
issues here (Closes pnpm/pnpm#123, Fixes pnpm/pnpm#456, or Related to
pnpm/pnpm#123 for a partial fix). -->
Pacquet is not printing a trailing newline for `pnpm audit`.
Not printing a trailing newline can cause rendering issues in some shells, and a trailing
newline ensure that the output buffer is flushed.
The TS version already prints a trailing newline, so this PR makes the Rust version consistent with that.

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
pnpm's CLI appends a newline to any non-empty command output that lacks
one before writing it (pnpm11/pnpm/src/main.ts). pacquet has no such
step, so audit's `--json`, `signatures --json`, `--fix` and `--ignore`
output all ended without a newline.

Route audit's stdout writes through a single print_command_output helper
that mirrors that normalization, instead of hard-coding the newline into
report_summary, which only covered the plain text report.
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790261978&installation_model_id=426870&pr_number=14168&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14168&signature=a65408320e7e70202044a51c2ced241ca5811aeba93ceb93b1a1f190a6f25cbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated `pnpm audit` output to consistently end with a trailing newline.
  * Applied consistent formatting across text, JSON, signatures, fix, and ignore-related audit results.
  * Preserved clean output behavior when no report content is available.

* **Tests**
  * Expanded audit coverage to verify newline-terminated output across supported report types and commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
