### PR TITLE
fix(config): stop `pnpm config delete` leaving a trailing blank line

### DIFF
--- a/.changeset/config-delete-last-setting-blank-line.md
+++ b/.changeset/config-delete-last-setting-blank-line.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm config delete` no longer leaves a blank line at the end of `pnpm-workspace.yaml` when it removes the last setting in the file. Because that blank line stayed behind, a later `pnpm config set` separated its new setting from it and the file ended up with two blank lines before the added setting.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -391,8 +391,6 @@ catalogMode: strict
 
 catalogPrune: true
 
-enableGlobalVirtualStore: true
-
 enablePrePostScripts: false
 
 engineStrict: false
@@ -568,3 +566,6 @@ update:
     - undici
     - validate-npm-package-name
     - write-file-atomic
+
+
+virtualStoreType: global

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -567,5 +567,4 @@ update:
     - validate-npm-package-name
     - write-file-atomic
 
-
 virtualStoreType: global

--- a/pnpm/crates/workspace-manifest-writer/src/edit.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/edit.rs
@@ -1130,8 +1130,9 @@ fn remove_top_level_block(text: &str, key: &str) -> String {
     // document has no such successor: its separator is the blank line
     // *before* it, which has to go too, or the file is left ending in a
     // blank line that the next insert would then separate from again.
-    let preceding = &text[..span.key_line_start];
-    let start = if span.block_end == text.len() && !has_kept_chomping_scalar(preceding) {
+    let start = if span.block_end == text.len()
+        && !blanks_belong_to_kept_scalar(text, span.key_line_start)
+    {
         blank_run_start(text, span.key_line_start)
     } else {
         span.key_line_start
@@ -1141,20 +1142,48 @@ fn remove_top_level_block(text: &str, key: &str) -> String {
     out
 }
 
-/// Whether `text` opens a block scalar with keep chomping (`|+`, `>+`, and
-/// their explicit-indent spellings). Such a scalar's value ends *with* the
-/// blank lines that follow it, so a blank line after one is content rather
-/// than a separator and must survive a neighbouring block's removal. The
-/// test is deliberately loose — a false positive only forgoes tidying a
-/// separator away.
-fn has_kept_chomping_scalar(text: &str) -> bool {
-    text.lines().any(|line| {
-        let header = line.trim_end();
-        header.ends_with('+')
-            && header
-                .trim_end_matches(|char: char| char == '+' || char.is_ascii_digit())
-                .ends_with(['|', '>'])
-    })
+/// Whether the blank lines that end at `line_start` are the tail of a
+/// keep-chomped block scalar rather than a separator. Such a scalar keeps
+/// the blank lines that follow it *as its value*, so dropping them would
+/// rewrite a setting the caller never asked to touch.
+///
+/// The blanks belong to the scalar when the last content line above them
+/// sits inside one: either it is the header itself (an otherwise empty
+/// scalar) or the nearest less-indented line above it is.
+fn blanks_belong_to_kept_scalar(text: &str, line_start: usize) -> bool {
+    let all = lines(&text[..line_start]);
+    let Some(last) = all.iter().rposition(|line| !line.content.trim().is_empty()) else {
+        return false;
+    };
+    if is_kept_chomping_header(all[last].content) {
+        return true;
+    }
+    let body_indent = indent_width(all[last].content);
+    all[..last]
+        .iter()
+        .rev()
+        .filter(|line| !line.content.trim().is_empty())
+        .find(|line| indent_width(line.content) < body_indent)
+        .is_some_and(|line| is_kept_chomping_header(line.content))
+}
+
+/// Whether `content` opens a block scalar that keeps its trailing line
+/// breaks: a `|` or `>` header carrying a `+`, in either order relative to
+/// an explicit indentation digit (`|+`, `>+2`, `|2+`), with or without a
+/// trailing comment.
+fn is_kept_chomping_header(content: &str) -> bool {
+    let Some((_, indicators)) = content.rsplit_once(['|', '>']) else {
+        return false;
+    };
+    let indicators = indicators.split('#').next().unwrap_or_default().trim();
+    indicators.contains('+') && indicators.chars().all(|char| char == '+' || char.is_ascii_digit())
+}
+
+/// Leading-space count of `content`, whatever the line holds — unlike
+/// [`structural_indent`], which reads a comment or a blank as unindented.
+/// Block scalar bodies can hold both.
+fn indent_width(content: &str) -> usize {
+    content.len() - content.trim_start().len()
 }
 
 /// Start of the run of blank lines immediately preceding `line_start`, or

--- a/pnpm/crates/workspace-manifest-writer/src/edit.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/edit.rs
@@ -1200,7 +1200,14 @@ fn line_value(line: &str) -> Option<&str> {
             }
         } else {
             match char {
-                '\'' | '"' => quote = Some(char),
+                // A quote only opens a scalar at the start of a token: the
+                // apostrophe in a plain key like `it's` is part of the key.
+                '\'' | '"'
+                    if index == 0
+                        || line[..index].ends_with([' ', '\t', ':', '-', '[', '{', ',']) =>
+                {
+                    quote = Some(char);
+                }
                 '#' if index == 0 || line[..index].ends_with([' ', '\t']) => return None,
                 ':' => {
                     let value = &line[index + 1..];
@@ -1217,8 +1224,16 @@ fn line_value(line: &str) -> Option<&str> {
 
 /// Whether `value` is a block scalar header carrying a `+`, in either order
 /// relative to an explicit indentation digit (`|+`, `>+2`, `|2+`), with or
-/// without a trailing comment.
+/// without a trailing comment. Any anchor and tag properties in front of the
+/// header (`&notes |+`, `!!str >+`) are skipped.
 fn opens_kept_chomping_scalar(value: &str) -> bool {
+    let mut value = value.trim_start();
+    while value.starts_with(['&', '!']) {
+        let Some((_, rest)) = value.split_once([' ', '\t']) else {
+            return false;
+        };
+        value = rest.trim_start();
+    }
     let Some(indicators) = value.strip_prefix(['|', '>']) else {
         return false;
     };

--- a/pnpm/crates/workspace-manifest-writer/src/edit.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/edit.rs
@@ -1130,7 +1130,8 @@ fn remove_top_level_block(text: &str, key: &str) -> String {
     // document has no such successor: its separator is the blank line
     // *before* it, which has to go too, or the file is left ending in a
     // blank line that the next insert would then separate from again.
-    let start = if span.block_end == text.len() {
+    let preceding = &text[..span.key_line_start];
+    let start = if span.block_end == text.len() && !has_kept_chomping_scalar(preceding) {
         blank_run_start(text, span.key_line_start)
     } else {
         span.key_line_start
@@ -1138,6 +1139,22 @@ fn remove_top_level_block(text: &str, key: &str) -> String {
     let mut out = text.to_string();
     out.replace_range(start..span.block_end, "");
     out
+}
+
+/// Whether `text` opens a block scalar with keep chomping (`|+`, `>+`, and
+/// their explicit-indent spellings). Such a scalar's value ends *with* the
+/// blank lines that follow it, so a blank line after one is content rather
+/// than a separator and must survive a neighbouring block's removal. The
+/// test is deliberately loose — a false positive only forgoes tidying a
+/// separator away.
+fn has_kept_chomping_scalar(text: &str) -> bool {
+    text.lines().any(|line| {
+        let header = line.trim_end();
+        header.ends_with('+')
+            && header
+                .trim_end_matches(|char: char| char == '+' || char.is_ascii_digit())
+                .ends_with(['|', '>'])
+    })
 }
 
 /// Start of the run of blank lines immediately preceding `line_start`, or
@@ -1217,7 +1234,7 @@ fn insert_top_level_block(manifest: &Manifest, new_key: &str, block_text: &str) 
         if !out.is_empty() && !out.ends_with('\n') {
             out.push('\n');
         }
-        if blank_style && !out.is_empty() && !out.ends_with("\n\n") {
+        if blank_style && !out.is_empty() && !ends_with_blank_line(&out) {
             out.push('\n');
         }
         out.push_str(block_text);
@@ -1554,6 +1571,13 @@ pub(crate) fn uses_blank_line_style(text: &str, top_level_keys: &[String]) -> bo
         }
     }
     non_first > 0 && non_first == non_first_with_blank
+}
+
+/// Whether `text`'s final line is blank, by the same trimmed-content test
+/// [`blank_run_start`] and [`has_blank_before`] use — so a whitespace-only
+/// separator counts as one too.
+fn ends_with_blank_line(text: &str) -> bool {
+    lines(text).last().is_some_and(|line| line.content.trim().is_empty())
 }
 
 /// Whether a blank line precedes the key at `idx`, looking past the key's own

--- a/pnpm/crates/workspace-manifest-writer/src/edit.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/edit.rs
@@ -1195,6 +1195,9 @@ fn line_value(line: &str) -> Option<&str> {
         } else if let Some(open) = quote {
             match char {
                 '\\' if open == '"' => escaped = true,
+                // A doubled quote inside a single-quoted scalar is one
+                // escaped quote, not the end of the scalar.
+                '\'' if open == '\'' && line[index + 1..].starts_with('\'') => escaped = true,
                 _ if char == open => quote = None,
                 _ => {}
             }

--- a/pnpm/crates/workspace-manifest-writer/src/edit.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/edit.rs
@@ -1125,9 +1125,32 @@ fn remove_top_level_block(text: &str, key: &str) -> String {
     let Some(span) = top_level_span(text, key) else {
         return text.to_string();
     };
+    // The span runs up to the next top-level key, so it carries the blank
+    // line that separates this block from that one. The last block in a
+    // document has no such successor: its separator is the blank line
+    // *before* it, which has to go too, or the file is left ending in a
+    // blank line that the next insert would then separate from again.
+    let start = if span.block_end == text.len() {
+        blank_run_start(text, span.key_line_start)
+    } else {
+        span.key_line_start
+    };
     let mut out = text.to_string();
-    out.replace_range(span.key_line_start..span.block_end, "");
+    out.replace_range(start..span.block_end, "");
     out
+}
+
+/// Start of the run of blank lines immediately preceding `line_start`, or
+/// `line_start` itself when the preceding line is not blank.
+fn blank_run_start(text: &str, line_start: usize) -> usize {
+    let mut start = line_start;
+    for line in lines(&text[..line_start]).iter().rev() {
+        if !line.content.trim().is_empty() {
+            break;
+        }
+        start = line.start;
+    }
+    start
 }
 
 /// Write a new named catalog (`<name>:` + its first entry) into an existing
@@ -1170,7 +1193,7 @@ fn insert_top_level_block(manifest: &Manifest, new_key: &str, block_text: &str) 
     let order = render::target_order(&manifest.top_level_keys, &[new_key.to_string()]);
     let position =
         order.iter().position(|key| key == new_key).expect("new key is in the merged order");
-    let blank_style = uses_blank_line_style(text, &manifest.top_level_keys);
+    let blank_style = manifest.blank_line_style;
 
     if position == 0 {
         // New key sorts to the front: prepend the block. Under blank-line
@@ -1194,7 +1217,7 @@ fn insert_top_level_block(manifest: &Manifest, new_key: &str, block_text: &str) 
         if !out.is_empty() && !out.ends_with('\n') {
             out.push('\n');
         }
-        if blank_style && !out.is_empty() {
+        if blank_style && !out.is_empty() && !out.ends_with("\n\n") {
             out.push('\n');
         }
         out.push_str(block_text);
@@ -1509,7 +1532,9 @@ fn is_comment_line(content: &str) -> bool {
 }
 
 /// Whether every original non-first top-level key has a blank line before it.
-fn uses_blank_line_style(text: &str, top_level_keys: &[String]) -> bool {
+/// Judged once, on the document as parsed: an edit that drops a key must not
+/// change how the surviving blocks are separated.
+pub(crate) fn uses_blank_line_style(text: &str, top_level_keys: &[String]) -> bool {
     if top_level_keys.len() < 2 {
         return false;
     }

--- a/pnpm/crates/workspace-manifest-writer/src/edit.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/edit.rs
@@ -1171,19 +1171,32 @@ fn blanks_belong_to_kept_scalar(text: &str, line_start: usize) -> bool {
     false
 }
 
-/// Whether `content` opens a block scalar that keeps its trailing line
-/// breaks: a `|` or `>` header carrying a `+`, in either order relative to
-/// an explicit indentation digit (`|+`, `>+2`, `|2+`), with or without a
-/// trailing comment. Only the value position counts — a `|+` inside an
-/// ordinary scalar, or inside the header's own comment, is text.
+/// Whether `content` declares a block scalar that keeps its trailing line
+/// breaks. Only the value position counts — a `|+` inside an ordinary
+/// scalar, or inside the header's own comment, is text. A quoted key may
+/// itself hold `: `, so which colon delimits the value is not decidable
+/// from one line; every candidate is tried, and any of them opening a kept
+/// scalar counts. That errs towards leaving a separator in place, which is
+/// the harmless direction.
 fn is_kept_chomping_header(content: &str) -> bool {
-    let mut value = content.trim_start();
-    while let Some(item) = value.strip_prefix("- ") {
-        value = item.trim_start();
+    let mut line = content.trim_start();
+    while let Some(item) = line.strip_prefix("- ") {
+        line = item.trim_start();
     }
-    if let Some(delimiter) = structural_colon_index(value) {
-        value = value[delimiter + 1..].trim_start();
-    }
+    opens_kept_chomping_scalar(line)
+        || line
+            .match_indices(':')
+            .filter(|(index, _)| {
+                let rest = &line[index + 1..];
+                rest.is_empty() || rest.starts_with([' ', '\t'])
+            })
+            .any(|(index, _)| opens_kept_chomping_scalar(line[index + 1..].trim_start()))
+}
+
+/// Whether `value` is a block scalar header carrying a `+`, in either order
+/// relative to an explicit indentation digit (`|+`, `>+2`, `|2+`), with or
+/// without a trailing comment.
+fn opens_kept_chomping_scalar(value: &str) -> bool {
     let Some(indicators) = value.strip_prefix(['|', '>']) else {
         return false;
     };

--- a/pnpm/crates/workspace-manifest-writer/src/edit.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/edit.rs
@@ -1173,24 +1173,46 @@ fn blanks_belong_to_kept_scalar(text: &str, line_start: usize) -> bool {
 
 /// Whether `content` declares a block scalar that keeps its trailing line
 /// breaks. Only the value position counts — a `|+` inside an ordinary
-/// scalar, or inside the header's own comment, is text. A quoted key may
-/// itself hold `: `, so which colon delimits the value is not decidable
-/// from one line; every candidate is tried, and any of them opening a kept
-/// scalar counts. That errs towards leaving a separator in place, which is
-/// the harmless direction.
+/// scalar, inside a comment, or inside a quoted key is text.
 fn is_kept_chomping_header(content: &str) -> bool {
     let mut line = content.trim_start();
     while let Some(item) = line.strip_prefix("- ") {
         line = item.trim_start();
     }
-    opens_kept_chomping_scalar(line)
-        || line
-            .match_indices(':')
-            .filter(|(index, _)| {
-                let rest = &line[index + 1..];
-                rest.is_empty() || rest.starts_with([' ', '\t'])
-            })
-            .any(|(index, _)| opens_kept_chomping_scalar(line[index + 1..].trim_start()))
+    opens_kept_chomping_scalar(line) || line_value(line).is_some_and(opens_kept_chomping_scalar)
+}
+
+/// The value of a `key: value` line, or `None` when the line declares none.
+/// The delimiter is the first `:` that ends the line or is followed by
+/// whitespace *outside* a quoted scalar and before any comment, so neither a
+/// quoted key holding `: ` nor a comment holding one is mistaken for it.
+fn line_value(line: &str) -> Option<&str> {
+    let mut quote = None;
+    let mut escaped = false;
+    for (index, char) in line.char_indices() {
+        if escaped {
+            escaped = false;
+        } else if let Some(open) = quote {
+            match char {
+                '\\' if open == '"' => escaped = true,
+                _ if char == open => quote = None,
+                _ => {}
+            }
+        } else {
+            match char {
+                '\'' | '"' => quote = Some(char),
+                '#' if index == 0 || line[..index].ends_with([' ', '\t']) => return None,
+                ':' => {
+                    let value = &line[index + 1..];
+                    if value.is_empty() || value.starts_with([' ', '\t']) {
+                        return Some(value.trim_start());
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    None
 }
 
 /// Whether `value` is a block scalar header carrying a `+`, in either order

--- a/pnpm/crates/workspace-manifest-writer/src/edit.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/edit.rs
@@ -1147,35 +1147,47 @@ fn remove_top_level_block(text: &str, key: &str) -> String {
 /// the blank lines that follow it *as its value*, so dropping them would
 /// rewrite a setting the caller never asked to touch.
 ///
-/// The blanks belong to the scalar when the last content line above them
-/// sits inside one: either it is the header itself (an otherwise empty
-/// scalar) or the nearest less-indented line above it is.
+/// The blanks belong to the scalar when the content above them climbs out to
+/// a keep-chomping header: walking up, each line that is less indented than
+/// everything seen so far either is that header or becomes the new bar to
+/// clear. A top-level line that is not a header ends the search — a scalar's
+/// body is always indented past its own key.
 fn blanks_belong_to_kept_scalar(text: &str, line_start: usize) -> bool {
     let all = lines(&text[..line_start]);
-    let Some(last) = all.iter().rposition(|line| !line.content.trim().is_empty()) else {
-        return false;
-    };
-    if is_kept_chomping_header(all[last].content) {
-        return true;
+    let mut enclosing_indent = usize::MAX;
+    for line in all.iter().rev().filter(|line| !line.content.trim().is_empty()) {
+        let indent = indent_width(line.content);
+        if indent >= enclosing_indent {
+            continue;
+        }
+        if is_kept_chomping_header(line.content) {
+            return true;
+        }
+        if indent == 0 {
+            return false;
+        }
+        enclosing_indent = indent;
     }
-    let body_indent = indent_width(all[last].content);
-    all[..last]
-        .iter()
-        .rev()
-        .filter(|line| !line.content.trim().is_empty())
-        .find(|line| indent_width(line.content) < body_indent)
-        .is_some_and(|line| is_kept_chomping_header(line.content))
+    false
 }
 
 /// Whether `content` opens a block scalar that keeps its trailing line
 /// breaks: a `|` or `>` header carrying a `+`, in either order relative to
 /// an explicit indentation digit (`|+`, `>+2`, `|2+`), with or without a
-/// trailing comment.
+/// trailing comment. Only the value position counts — a `|+` inside an
+/// ordinary scalar, or inside the header's own comment, is text.
 fn is_kept_chomping_header(content: &str) -> bool {
-    let Some((_, indicators)) = content.rsplit_once(['|', '>']) else {
+    let mut value = content.trim_start();
+    while let Some(item) = value.strip_prefix("- ") {
+        value = item.trim_start();
+    }
+    if let Some(delimiter) = structural_colon_index(value) {
+        value = value[delimiter + 1..].trim_start();
+    }
+    let Some(indicators) = value.strip_prefix(['|', '>']) else {
         return false;
     };
-    let indicators = indicators.split('#').next().unwrap_or_default().trim();
+    let indicators = indicators.split_whitespace().next().unwrap_or_default();
     indicators.contains('+') && indicators.chars().all(|char| char == '+' || char.is_ascii_digit())
 }
 

--- a/pnpm/crates/workspace-manifest-writer/src/model.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/model.rs
@@ -13,6 +13,10 @@ use std::collections::HashSet;
 pub(crate) struct Manifest {
     text: String,
     pub(crate) top_level_keys: Vec<String>,
+    /// Whether the document separates its top-level blocks with blank lines,
+    /// as judged by [`crate::edit::uses_blank_line_style`] on the original
+    /// text. New blocks are inserted in the same style.
+    pub(crate) blank_line_style: bool,
     /// `catalog:` shorthand for the default catalog.
     pub(crate) catalog: Option<IndexMap<String, String>>,
     /// `catalogs:` map of named catalogs (may include `default`).
@@ -127,6 +131,7 @@ impl Manifest {
             return Ok(Manifest {
                 text,
                 top_level_keys: Vec::new(),
+                blank_line_style: false,
                 catalog: None,
                 catalogs: None,
                 config_dependencies: None,
@@ -142,7 +147,9 @@ impl Manifest {
 
         let top: Option<IndexMap<String, serde::de::IgnoredAny>> =
             serde_saphyr::from_str(&text).map_err(Box::new)?;
-        let top_level_keys = top.map(|map| map.into_keys().collect()).unwrap_or_default();
+        let top_level_keys: Vec<String> =
+            top.map(|map| map.into_keys().collect()).unwrap_or_default();
+        let blank_line_style = crate::edit::uses_blank_line_style(&text, &top_level_keys);
 
         let data: CatalogData = serde_saphyr::from_str(&text).map_err(Box::new)?;
         let config_dependencies = data.config_dependencies.map(|entries| {
@@ -183,6 +190,7 @@ impl Manifest {
         Ok(Manifest {
             text,
             top_level_keys,
+            blank_line_style,
             catalog: data.catalog,
             catalogs: data.catalogs,
             config_dependencies,

--- a/pnpm/crates/workspace-manifest-writer/src/tests.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/tests.rs
@@ -1264,13 +1264,23 @@ fn delete_last_field_leaves_no_trailing_blank_line() {
 
 #[test]
 fn delete_last_field_keeps_a_kept_chomped_block_scalars_trailing_blank() {
+    for header in ["|+", ">+", "|+2", "|2+", "|2+ # keep the breaks"] {
+        let original = format!("notes: {header}\n  foo\n\nvirtualStoreDir: .pnpm\n");
+        let out = run_update_field(Some(&original), "virtualStoreDir", &serde_json::Value::Null)
+            .expect("file kept");
+        assert_eq!(out, format!("notes: {header}\n  foo\n\n"), "header {header}");
+    }
+}
+
+#[test]
+fn delete_last_field_drops_a_separator_below_an_unrelated_kept_chomped_scalar() {
     let out = run_update_field(
-        Some("notes: |+\n  foo\n\nvirtualStoreDir: .pnpm\n"),
+        Some("notes: |+\n  foo\n\nstoreDir: ~/store\n\nvirtualStoreDir: .pnpm\n"),
         "virtualStoreDir",
         &serde_json::Value::Null,
     )
     .expect("file kept");
-    assert_eq!(out, "notes: |+\n  foo\n\n");
+    assert_eq!(out, "notes: |+\n  foo\n\nstoreDir: ~/store\n");
 }
 
 #[test]

--- a/pnpm/crates/workspace-manifest-writer/src/tests.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/tests.rs
@@ -1305,13 +1305,12 @@ fn delete_last_field_keeps_the_blank_of_a_scalar_under_a_quoted_key() {
 
 #[test]
 fn delete_last_field_keeps_the_blank_of_a_scalar_under_an_apostrophe_key() {
-    let out = run_update_field(
-        Some("it's: |+\n  foo\n\nvirtualStoreDir: .pnpm\n"),
-        "virtualStoreDir",
-        &serde_json::Value::Null,
-    )
-    .expect("file kept");
-    assert_eq!(out, "it's: |+\n  foo\n\n");
+    for key in ["it's", "'it''s: title'"] {
+        let original = format!("{key}: |+\n  foo\n\nvirtualStoreDir: .pnpm\n");
+        let out = run_update_field(Some(&original), "virtualStoreDir", &serde_json::Value::Null)
+            .expect("file kept");
+        assert_eq!(out, format!("{key}: |+\n  foo\n\n"), "key {key}");
+    }
 }
 
 #[test]

--- a/pnpm/crates/workspace-manifest-writer/src/tests.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/tests.rs
@@ -1295,6 +1295,16 @@ fn delete_last_field_keeps_the_blank_of_a_scalar_under_a_quoted_key() {
 }
 
 #[test]
+fn delete_last_field_drops_a_separator_below_a_header_written_in_a_comment() {
+    for line in ["notes: text # detail: |+", "notes: text\n# detail: |+"] {
+        let original = format!("{line}\n\nvirtualStoreDir: .pnpm\n");
+        let out = run_update_field(Some(&original), "virtualStoreDir", &serde_json::Value::Null)
+            .expect("file kept");
+        assert_eq!(out, format!("{line}\n"), "line {line}");
+    }
+}
+
+#[test]
 fn delete_last_field_drops_a_separator_below_a_quoted_scalar_holding_a_header() {
     let out = run_update_field(
         Some("notes: \"foo |+ #\"\n\nvirtualStoreDir: .pnpm\n"),

--- a/pnpm/crates/workspace-manifest-writer/src/tests.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/tests.rs
@@ -589,7 +589,7 @@ fn patched_dependency_removes_empty_last_block() {
     let original = "packages:\n  - '*'\n\npatchedDependencies:\n  is-positive@1.0.0: patches/is-positive@1.0.0.patch\n";
     let out = run_patched_deps(Some(original), &[]);
 
-    assert_eq!(out, "packages:\n  - '*'\n\n");
+    assert_eq!(out, "packages:\n  - '*'\n");
 }
 
 #[test]
@@ -1249,6 +1249,54 @@ fn delete_last_field_removes_file() {
         &serde_json::Value::Null,
     );
     assert_eq!(out, None);
+}
+
+#[test]
+fn delete_last_field_leaves_no_trailing_blank_line() {
+    let out = run_update_field(
+        Some("cacheDir: ~/cache\n\nvirtualStoreDir: .pnpm\n"),
+        "virtualStoreDir",
+        &serde_json::Value::Null,
+    )
+    .expect("file kept");
+    assert_eq!(out, "cacheDir: ~/cache\n");
+}
+
+#[test]
+fn setting_a_field_after_deleting_the_last_one_keeps_a_single_blank_line() {
+    let dir = TempDir::new().expect("temp dir");
+    let path = dir.path().join(WORKSPACE_MANIFEST_FILENAME);
+    let original = "cacheDir: ~/cache\n\nstoreDir: ~/store\n";
+    fs::write(&path, original).expect("seed manifest");
+    let with_field = format!("{original}\nvirtualStoreDir: .pnpm\n");
+
+    for value in [serde_json::json!(".pnpm"), serde_json::Value::Null, serde_json::json!(".pnpm")] {
+        crate::update_manifest_field(&path, "virtualStoreDir", &value).expect("update succeeds");
+    }
+
+    assert_eq!(fs::read_to_string(&path).expect("file kept"), with_field);
+}
+
+#[test]
+fn changing_the_value_of_the_last_field_keeps_its_single_blank_line() {
+    let out = run_update_field(
+        Some("cacheDir: ~/cache\n\nstoreDir: ~/store\n"),
+        "storeDir",
+        &serde_json::json!("~/other"),
+    )
+    .expect("file written");
+    assert_eq!(out, "cacheDir: ~/cache\n\nstoreDir: ~/other\n");
+}
+
+#[test]
+fn a_manifest_already_ending_in_a_blank_line_gains_no_second_one() {
+    let out = run_update_field(
+        Some("cacheDir: ~/cache\n\nstoreDir: ~/store\n\n"),
+        "virtualStoreDir",
+        &serde_json::json!(".pnpm"),
+    )
+    .expect("file written");
+    assert_eq!(out, "cacheDir: ~/cache\n\nstoreDir: ~/store\n\nvirtualStoreDir: .pnpm\n");
 }
 
 #[test]

--- a/pnpm/crates/workspace-manifest-writer/src/tests.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/tests.rs
@@ -1264,12 +1264,34 @@ fn delete_last_field_leaves_no_trailing_blank_line() {
 
 #[test]
 fn delete_last_field_keeps_a_kept_chomped_block_scalars_trailing_blank() {
-    for header in ["|+", ">+", "|+2", "|2+", "|2+ # keep the breaks"] {
+    for header in ["|+", ">+", "|+2", "|2+", "|2+ # keep the breaks", "|+ # retain > blanks"] {
         let original = format!("notes: {header}\n  foo\n\nvirtualStoreDir: .pnpm\n");
         let out = run_update_field(Some(&original), "virtualStoreDir", &serde_json::Value::Null)
             .expect("file kept");
         assert_eq!(out, format!("notes: {header}\n  foo\n\n"), "header {header}");
     }
+}
+
+#[test]
+fn delete_last_field_keeps_the_blank_below_a_deeper_indented_scalar_line() {
+    let out = run_update_field(
+        Some("notes: |+\n  foo\n    bar\n\nvirtualStoreDir: .pnpm\n"),
+        "virtualStoreDir",
+        &serde_json::Value::Null,
+    )
+    .expect("file kept");
+    assert_eq!(out, "notes: |+\n  foo\n    bar\n\n");
+}
+
+#[test]
+fn delete_last_field_drops_a_separator_below_a_quoted_scalar_holding_a_header() {
+    let out = run_update_field(
+        Some("notes: \"foo |+ #\"\n\nvirtualStoreDir: .pnpm\n"),
+        "virtualStoreDir",
+        &serde_json::Value::Null,
+    )
+    .expect("file kept");
+    assert_eq!(out, "notes: \"foo |+ #\"\n");
 }
 
 #[test]

--- a/pnpm/crates/workspace-manifest-writer/src/tests.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/tests.rs
@@ -1264,7 +1264,16 @@ fn delete_last_field_leaves_no_trailing_blank_line() {
 
 #[test]
 fn delete_last_field_keeps_a_kept_chomped_block_scalars_trailing_blank() {
-    for header in ["|+", ">+", "|+2", "|2+", "|2+ # keep the breaks", "|+ # retain > blanks"] {
+    for header in [
+        "|+",
+        ">+",
+        "|+2",
+        "|2+",
+        "|2+ # keep the breaks",
+        "|+ # retain > blanks",
+        "&notes |+",
+        "!!str >+",
+    ] {
         let original = format!("notes: {header}\n  foo\n\nvirtualStoreDir: .pnpm\n");
         let out = run_update_field(Some(&original), "virtualStoreDir", &serde_json::Value::Null)
             .expect("file kept");
@@ -1292,6 +1301,17 @@ fn delete_last_field_keeps_the_blank_of_a_scalar_under_a_quoted_key() {
     )
     .expect("file kept");
     assert_eq!(out, "\"notes: title\": |+\n  foo\n\n");
+}
+
+#[test]
+fn delete_last_field_keeps_the_blank_of_a_scalar_under_an_apostrophe_key() {
+    let out = run_update_field(
+        Some("it's: |+\n  foo\n\nvirtualStoreDir: .pnpm\n"),
+        "virtualStoreDir",
+        &serde_json::Value::Null,
+    )
+    .expect("file kept");
+    assert_eq!(out, "it's: |+\n  foo\n\n");
 }
 
 #[test]

--- a/pnpm/crates/workspace-manifest-writer/src/tests.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/tests.rs
@@ -1263,6 +1263,17 @@ fn delete_last_field_leaves_no_trailing_blank_line() {
 }
 
 #[test]
+fn delete_last_field_keeps_a_kept_chomped_block_scalars_trailing_blank() {
+    let out = run_update_field(
+        Some("notes: |+\n  foo\n\nvirtualStoreDir: .pnpm\n"),
+        "virtualStoreDir",
+        &serde_json::Value::Null,
+    )
+    .expect("file kept");
+    assert_eq!(out, "notes: |+\n  foo\n\n");
+}
+
+#[test]
 fn setting_a_field_after_deleting_the_last_one_keeps_a_single_blank_line() {
     let dir = TempDir::new().expect("temp dir");
     let path = dir.path().join(WORKSPACE_MANIFEST_FILENAME);
@@ -1297,6 +1308,17 @@ fn a_manifest_already_ending_in_a_blank_line_gains_no_second_one() {
     )
     .expect("file written");
     assert_eq!(out, "cacheDir: ~/cache\n\nstoreDir: ~/store\n\nvirtualStoreDir: .pnpm\n");
+}
+
+#[test]
+fn a_manifest_ending_in_a_whitespace_only_line_gains_no_second_blank() {
+    let out = run_update_field(
+        Some("cacheDir: ~/cache\n\nstoreDir: ~/store\n  \n"),
+        "virtualStoreDir",
+        &serde_json::json!(".pnpm"),
+    )
+    .expect("file written");
+    assert_eq!(out, "cacheDir: ~/cache\n\nstoreDir: ~/store\n  \nvirtualStoreDir: .pnpm\n");
 }
 
 #[test]

--- a/pnpm/crates/workspace-manifest-writer/src/tests.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/tests.rs
@@ -1284,6 +1284,17 @@ fn delete_last_field_keeps_the_blank_below_a_deeper_indented_scalar_line() {
 }
 
 #[test]
+fn delete_last_field_keeps_the_blank_of_a_scalar_under_a_quoted_key() {
+    let out = run_update_field(
+        Some("\"notes: title\": |+\n  foo\n\nvirtualStoreDir: .pnpm\n"),
+        "virtualStoreDir",
+        &serde_json::Value::Null,
+    )
+    .expect("file kept");
+    assert_eq!(out, "\"notes: title\": |+\n  foo\n\n");
+}
+
+#[test]
 fn delete_last_field_drops_a_separator_below_a_quoted_scalar_holding_a_header() {
     let out = run_update_field(
         Some("notes: \"foo |+ #\"\n\nvirtualStoreDir: .pnpm\n"),


### PR DESCRIPTION
## Summary

`pnpm config delete` of the **last** setting in `pnpm-workspace.yaml` left behind the blank line that had separated it from its predecessor, so the file ended in a blank line. A later `pnpm config set` then added its own separator on top of that, and the new setting landed after **two** blank lines:

```console
$ pnpm config set    virtualStoreType global --location=project   # ...write-file-atomic ⏎ ⏎ virtualStoreType: global
$ pnpm config delete virtualStoreType        --location=project   # ...write-file-atomic ⏎ ⏎   ← blank left at EOF
$ pnpm config set    virtualStoreType global --location=project   # ...write-file-atomic ⏎ ⏎ ⏎ virtualStoreType: global
```

The TypeScript writer already gets this right, so this is a pacquet-only parity fix. The last commit of this branch is where the bug produced a stray blank line in this repository's own `pnpm-workspace.yaml`; that line is removed here too.

## Squash Commit Body

```text
A top-level block's span reaches the next top-level key, so it carries that
block's trailing blank separator. The last block in a document has no such
successor: its separator is the blank line before it. Take that one instead
when the removal runs to the end of the document, and skip the separator on
insert when the text already ends in a blank line.

Judge the document's blank-line style once, at parse time, rather than
re-deriving it from the mutated text. `config set` on an already-present
last key removes and reinserts that key, and the style probe then saw a
document one key short of the original, concluded its blocks were not
blank-line separated, and glued the rewritten setting to its predecessor.
The TypeScript writer likewise judges the style from the original key list.

Also renames this repo's own `enableGlobalVirtualStore: true` to the
`virtualStoreType: global` spelling, and drops the stray blank line the bug
left behind when that setting was rewritten.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (TypeScript already behaves correctly — verified against `pnpm11`'s bundle —
  so no TS-side change is needed.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `pnpm config delete` leaving an unwanted trailing blank line when removing the final setting from `pnpm-workspace.yaml`.
  - Preserved existing blank-line formatting when adding, updating, or removing workspace settings.
  - Prevented duplicate blank lines and obsolete separators when editing workspace settings.
  - Improved handling of multiline, quoted, tagged, and anchored YAML values during configuration updates.

- **Chores**
  - Updated the workspace configuration to use the current global virtual store setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->