### PR TITLE
fix(fetch): link virtual-store bins so dependency build scripts resolve siblings

### DIFF
--- a/.changeset/fetch-command-options-declare-allow-builds.md
+++ b/.changeset/fetch-command-options-declare-allow-builds.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.commands": patch
+"pnpm": patch
+---
+
+The options type of the `fetch` command now declares `allowBuilds`, a setting its handler already forwarded to the installer. Type-level only — what `pnpm fetch` does is unchanged.

--- a/.changeset/fetch-links-virtual-store-bins.md
+++ b/.changeset/fetch-links-virtual-store-bins.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm fetch` now links each virtual-store package's dependency bins, so a dependency's lifecycle script can invoke a sibling dependency's bin. Previously a `postinstall` calling one — as `unrs-resolver` does with `napi-postinstall` — failed with `command not found` in the Docker "fetcher stage" shape (a lockfile with no project manifest), while `pnpm install` against the same lockfile succeeded [#14174](https://github.com/pnpm/pnpm/issues/14174).

--- a/pnpm/crates/cli/tests/suite/fetch.rs
+++ b/pnpm/crates/cli/tests/suite/fetch.rs
@@ -209,3 +209,55 @@ fn fetch_under_pnp_does_not_write_the_loader() {
 
     drop((root, mock_instance, store_dir));
 }
+
+/// A dependency's lifecycle script resolves a sibling dependency's bin
+/// through the per-slot `node_modules/.bin` the virtual store carries.
+/// `fetch` runs those scripts, so it has to write those links even
+/// though it materializes nothing importer-facing
+/// ([pnpm/pnpm#14174](https://github.com/pnpm/pnpm/issues/14174)).
+///
+/// `@pnpm.e2e/pre-and-postinstall-scripts-example`'s postinstall opens
+/// with `hello-world-js-bin`, the bin of its own dependency, and only
+/// then writes its marker file.
+#[test]
+fn fetch_runs_a_build_script_that_calls_a_sibling_dependency_bin() {
+    const BUILT_DEP: &str = "@pnpm.e2e/pre-and-postinstall-scripts-example";
+
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let workspace_manifest = workspace.join("pnpm-workspace.yaml");
+    let yaml = fs::read_to_string(&workspace_manifest).expect("read pnpm-workspace.yaml");
+    let yaml = format!("{yaml}allowBuilds:\n  '{BUILT_DEP}': true\n");
+    fs::write(&workspace_manifest, yaml).expect("write pnpm-workspace.yaml");
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "dependencies": { BUILT_DEP: "1.0.0" } }).to_string(),
+    )
+    .expect("write package.json");
+    pacquet_at(&workspace).with_args(["install", "--lockfile-only"]).assert().success();
+
+    // The Docker "fetcher stage" shape the report used: the lockfile and
+    // the workspace manifest, with no project manifest to import from.
+    fs::remove_file(workspace.join("package.json")).expect("remove package.json");
+
+    pacquet_at(&workspace).with_arg("fetch").assert().success();
+
+    let pkg_dir = workspace
+        .join("node_modules/.pnpm")
+        .join(format!("{}@1.0.0", BUILT_DEP.replace('/', "+")))
+        .join("node_modules")
+        .join(BUILT_DEP);
+    assert!(
+        pkg_dir.join("node_modules/.bin/hello-world-js-bin").exists(),
+        "fetch must link the built package's dependency bins next to it",
+    );
+    assert!(
+        pkg_dir.join("generated-by-postinstall.js").exists(),
+        "the postinstall script must have run to completion",
+    );
+
+    drop((root, mock_instance));
+}

--- a/pnpm/crates/deps-restorer/src/install_frozen_lockfile/build_phase.rs
+++ b/pnpm/crates/deps-restorer/src/install_frozen_lockfile/build_phase.rs
@@ -268,9 +268,10 @@ pub fn run_build_phase<Reporter: self::Reporter>(
         strict_dep_builds: config.strict_dep_builds,
     }));
 
-    // `virtual_store_only` links no bins at all, so there is nothing for
-    // the pass below to re-resolve. Dependency *build* scripts still ran
-    // above — only the linking stops, matching `pnpm fetch`.
+    // `virtual_store_only` links no importer bins, so there is nothing
+    // for the pass below to re-resolve. Dependency *build* scripts still
+    // ran above — only the importer-facing linking stops, matching
+    // `pnpm fetch`.
     if config.virtual_store_only {
         return Ok(build_output);
     }

--- a/pnpm/crates/deps-restorer/src/linking.rs
+++ b/pnpm/crates/deps-restorer/src/linking.rs
@@ -135,7 +135,44 @@ pub struct LinkPhaseOutput {
     pub hoisted_dependencies: crate::HoistedDependencies,
     pub hoisted_locations: BTreeMap<String, Vec<String>>,
     pub hoisted_pkg_roots_by_key: Option<HashMap<PackageKey, Vec<PathBuf>>>,
+    /// Publicly-hoisted aliases carrying bins. Public hoist promotes a
+    /// transitive dep to `<root>/node_modules/<alias>`, whose bin then
+    /// competes for the same `<root>/node_modules/.bin` slot as a root
+    /// direct dep's; per pnpm/pacquet#342 the direct dep must win. The
+    /// post-`BuildModules` top-level bin link takes both candidate lists
+    /// so `pick_winner`'s [`BinOrigin`] tier settles it in one call.
+    ///
+    /// [`BinOrigin`]: pnpm_cmd_shim::BinOrigin
     pub publicly_hoisted_for_post_build: Vec<String>,
+}
+
+impl LinkPhaseOutput {
+    /// The result of a run that materialized nothing.
+    fn empty() -> Self {
+        LinkPhaseOutput {
+            hoisted_dependencies: crate::HoistedDependencies::new(),
+            hoisted_locations: BTreeMap::new(),
+            hoisted_pkg_roots_by_key: None,
+            publicly_hoisted_for_post_build: Vec::new(),
+        }
+    }
+}
+
+/// What [`write_hoist_links`] put on disk.
+struct HoistLinks {
+    hoisted_dependencies: crate::HoistedDependencies,
+    /// See [`LinkPhaseOutput::publicly_hoisted_for_post_build`].
+    publicly_hoisted_with_bins: Vec<String>,
+}
+
+impl HoistLinks {
+    /// The result of a run with no hoist plan to write.
+    fn none() -> Self {
+        HoistLinks {
+            hoisted_dependencies: crate::HoistedDependencies::new(),
+            publicly_hoisted_with_bins: Vec::new(),
+        }
+    }
 }
 
 /// Reconcile what the previous install left behind, then materialize
@@ -192,12 +229,10 @@ pub fn run_link_phase<Reporter: self::Reporter>(
     let hoisted_workspace_packages = config
         .hoist_workspace_packages
         .then(|| workspace_packages_for_hoist(workspace_root, project_manifests));
-    // Planned here, ahead of `SymlinkDirectDependencies`, so that pass's
-    // dedupe map can see publicly-hoisted aliases: the on-disk hoist runs
-    // *after* it, and without the plan the map holds only root's direct
-    // deps — leaving a non-root importer's dep that public-hoist would
-    // land at root un-deduped. The plan is threaded to the hoist pass
-    // below so the traversal runs once.
+    // Planned before the links are written, not with them: an importer's
+    // dep that public-hoist lands at root has to be in
+    // `SymlinkDirectDependencies`'s dedupe map, and `write_hoist_links`
+    // reuses the plan rather than walking a second time.
     let pre_hoist = compute_hoist_plan(
         config,
         snapshots,
@@ -212,16 +247,17 @@ pub fn run_link_phase<Reporter: self::Reporter>(
         .as_ref()
         .map(|plan| collect_public_hoist_targets(&plan.result, &plan.graph, layout, &plan.skipped));
 
-    // Reconcile before linking: stale direct-dep links and orphaned
-    // hoist links must vacate their slots so the relink + rehoist below
-    // can claim them. Excluded under the hoisted linker, whose
-    // previous-graph diff removes orphans and emits the `pnpm:stats`
-    // `removed` event itself (see [`crate::link_hoisted_modules()`]) —
-    // so every install carries exactly one, pairing the `added` emitted
-    // in `CreateVirtualStore`. Excluded under `virtual_store_only` too:
-    // it creates no importer or hoist links, so it has neither anything
-    // to reconcile nor anything to link.
-    if !is_hoisted && !config.virtual_store_only {
+    // `nodeLinker: hoisted` writes no virtual store — `CreateVirtualStore`
+    // skipped the slots — so there is nothing to link into or out of.
+    let has_virtual_store = !is_hoisted;
+    let links_importer_tree = has_virtual_store && !config.virtual_store_only;
+
+    // Reconcile first, so stale direct-dep and orphaned hoist links
+    // vacate the slots the relink + rehoist below claim. The hoisted
+    // linker reconciles and emits this `removed` event itself (see
+    // [`crate::link_hoisted_modules()`]), keeping it one per install —
+    // the pair of the `added` emitted in `CreateVirtualStore`.
+    if links_importer_tree {
         let removed_count = match current_lockfile {
             Some(current) => crate::PruneStaleModules {
                 config,
@@ -270,14 +306,7 @@ pub fn run_link_phase<Reporter: self::Reporter>(
         .map_err(LinkPhaseError::LinkRootComponentMembers)?;
     }
 
-    if !is_hoisted {
-        // Link the bins of each virtual-store slot's children into the
-        // slot's own `node_modules/.bin`, before `importing_done` so
-        // reporters see the import phase close only once every link is
-        // in place. Skipped under `nodeLinker: hoisted`, which has no
-        // virtual store to link into and whose linker below runs its own
-        // per-`node_modules` bin pass while walking the hierarchy.
-        //
+    if has_virtual_store {
         // Unlike every other pass here this one also runs under
         // `virtual_store_only`: the links it writes live inside the
         // virtual store, and the build phase — which `pnpm fetch` still
@@ -295,27 +324,12 @@ pub fn run_link_phase<Reporter: self::Reporter>(
         .map_err(LinkPhaseError::LinkVirtualStoreBins)?;
     }
 
-    // Nothing below this point runs under `virtual_store_only`: it
-    // materializes the importer-visible tree and the sidecars that
-    // describe it, and the hoist pass writes into `config.modules_dir`
-    // — a project this mode is meant to leave alone.
+    // Everything below writes into the project that `virtual_store_only`
+    // exists to leave alone.
     if config.virtual_store_only {
-        return Ok(LinkPhaseOutput {
-            hoisted_dependencies: crate::HoistedDependencies::new(),
-            hoisted_locations: BTreeMap::new(),
-            hoisted_pkg_roots_by_key: None,
-            publicly_hoisted_for_post_build: Vec::new(),
-        });
+        return Ok(LinkPhaseOutput::empty());
     }
 
-    // Hoisted-linker materialization: replaces the
-    // [`crate::SymlinkDirectDependencies`] + [`crate::LinkVirtualStoreBins`]
-    // pair above when `nodeLinker: hoisted` is in effect. The dep-graph
-    // walker computes per-package directories (with conflict-aware
-    // nesting) and the linker imports CAS files into them from
-    // [`CreateVirtualStoreOutput::cas_paths_by_pkg_id`], populated above
-    // with `node_linker = Hoisted`. Both outputs stay empty for the
-    // isolated linker — see [`HoistedLinkerOutput`] for what they carry.
     let HoistedLinkerOutput { hoisted_locations, hoisted_pkg_roots_by_key } = if is_hoisted {
         run_hoisted_linker::<Reporter>(
             HoistedLinkerInputs {
@@ -342,50 +356,9 @@ pub fn run_link_phase<Reporter: self::Reporter>(
         HoistedLinkerOutput::default()
     };
 
-    // Public-hoist promotes a transitive dep's alias to
-    // `<root>/node_modules/<alias>`, where its bin competes for the same
-    // `<root>/node_modules/.bin` slot as a root direct dep's. Per
-    // pnpm/pacquet#342 the direct dep must win, so the aliases are stashed
-    // here for the post-`BuildModules` top-level bin link, which takes
-    // both candidate lists and lets `pick_winner`'s [`BinOrigin`] tier
-    // settle it in one call. Empty when nothing was publicly hoisted.
-    let mut publicly_hoisted_for_post_build: Vec<String> = Vec::new();
-    // Write the plan to disk: shamefully-hoist + private hoist into the
-    // virtual store, plus the per-side bin shims. `pre_hoist` is `None`
-    // under the hoisted linker, which materialized the tree itself and
-    // has no virtual store to point hoist symlinks at.
-    let hoisted_dependencies = if let Some(plan) = pre_hoist {
-        let HoistPlan { graph, result, skipped: hoist_skipped, .. } = plan;
-        // `virtual_store_dir` stays project-local even with GVS enabled
-        // — the shared root is routed through `global_virtual_store_dir`
-        // instead (see [`Config::apply_global_virtual_store_derivation`])
-        // — so the private-hoist target is always
-        // `<root>/node_modules/.pnpm/node_modules`. Only the symlink
-        // *target* under the slot dir is GVS-aware, which `layout`
-        // resolves.
-        let private_dir = config.virtual_store_dir.join("node_modules");
-        let public_dir = config.modules_dir.clone();
-        symlink_hoisted_dependencies(
-            &result.hoisted_dependencies_by_node_id,
-            &result.hoisted_workspace_aliases,
-            &graph,
-            layout,
-            &private_dir,
-            &public_dir,
-            &hoist_skipped,
-        )
-        .map_err(LinkPhaseError::HoistSymlink)?;
-        // Private-side bins → `<vs>/node_modules/.bin`.
-        link_direct_dep_bins_resolved(
-            &private_dir,
-            &crate::resolve_hoisted_bin_deps(layout, &result.hoisted_aliases_with_bins),
-            link_options,
-        )
-        .map_err(LinkPhaseError::HoistLinkBins)?;
-        publicly_hoisted_for_post_build = result.publicly_hoisted_aliases_with_bins;
-        result.hoisted_dependencies
-    } else {
-        crate::HoistedDependencies::new()
+    let HoistLinks { hoisted_dependencies, publicly_hoisted_with_bins } = match pre_hoist {
+        Some(plan) => write_hoist_links(plan, config, layout, link_options)?,
+        None => HoistLinks::none(),
     };
 
     if crate::should_write_package_map(config, node_linker) {
@@ -405,30 +378,90 @@ pub fn run_link_phase<Reporter: self::Reporter>(
         crate::write_pnp_file(sidecar_lockfile, workspace_root, config, layout, project_manifests)
             .map_err(LinkPhaseError::WritePnpFile)?;
     }
-    // `SymlinkDirectDependencies` already linked direct-dep bins, but
-    // hoisting runs after it. Re-walking each importer's `node_modules`
-    // is what shims a publicly-hoisted *workspace package*'s bin: those
-    // are recorded in the hoist result's `hoisted_workspace_aliases`,
-    // which the post-build top-level link never sees.
-    {
-        let modules_basename = config.modules_dir.file_name().map_or_else(
-            || std::ffi::OsString::from("node_modules"),
-            std::ffi::OsStr::to_os_string,
-        );
-        for importer_id in trusted_importer_ids {
-            let modules_dir =
-                crate::symlink_direct_dependencies::importer_root_dir(symlink_root, importer_id)
-                    .join(&modules_basename);
-            let bins_dir = modules_dir.join(".bin");
-            pnpm_cmd_shim::link_bins::<pnpm_cmd_shim::Host>(&modules_dir, &bins_dir, link_options)
-                .map_err(LinkPhaseError::LinkBins)?;
-        }
-    }
+    relink_importer_bins_after_hoisting(
+        &config.modules_dir,
+        symlink_root,
+        trusted_importer_ids,
+        link_options,
+    )?;
 
     Ok(LinkPhaseOutput {
         hoisted_dependencies,
         hoisted_locations,
         hoisted_pkg_roots_by_key,
-        publicly_hoisted_for_post_build,
+        publicly_hoisted_for_post_build: publicly_hoisted_with_bins,
     })
+}
+
+/// Symlink the hoist plan's aliases into the private
+/// (`<virtual_store>/node_modules`) and public (`<root>/node_modules`)
+/// targets, then shim the private side's bins.
+///
+/// Enabling the global virtual store does not move the private target:
+/// pacquet leaves `virtual_store_dir` at its project-local (or
+/// yaml-pinned) value and routes the shared root through
+/// `global_virtual_store_dir` instead — see
+/// [`Config::apply_global_virtual_store_derivation`]. Only the symlink
+/// *target* under the slot dir is GVS-aware, which `layout` resolves.
+fn write_hoist_links(
+    plan: HoistPlan,
+    config: &Config,
+    layout: &VirtualStoreLayout,
+    link_options: &LinkBinsOptions,
+) -> Result<HoistLinks, LinkPhaseError> {
+    let HoistPlan { graph, result, skipped, .. } = plan;
+    let private_hoist_dir = config.virtual_store_dir.join("node_modules");
+    let public_hoist_dir = config.modules_dir.clone();
+    symlink_hoisted_dependencies(
+        &result.hoisted_dependencies_by_node_id,
+        &result.hoisted_workspace_aliases,
+        &graph,
+        layout,
+        &private_hoist_dir,
+        &public_hoist_dir,
+        &skipped,
+    )
+    .map_err(LinkPhaseError::HoistSymlink)?;
+    link_direct_dep_bins_resolved(
+        &private_hoist_dir,
+        &crate::resolve_hoisted_bin_deps(layout, &result.hoisted_aliases_with_bins),
+        link_options,
+    )
+    .map_err(LinkPhaseError::HoistLinkBins)?;
+    Ok(HoistLinks {
+        hoisted_dependencies: result.hoisted_dependencies,
+        publicly_hoisted_with_bins: result.publicly_hoisted_aliases_with_bins,
+    })
+}
+
+/// Re-walk each trusted importer's `node_modules` and shim what it now
+/// holds.
+///
+/// [`SymlinkDirectDependencies`] already linked the direct-dep bins, but
+/// hoisting runs after it, so this pass is what shims a publicly-hoisted
+/// *workspace package*'s bin — those live in the hoist result's
+/// `hoisted_workspace_aliases`, which the post-build top-level bin link
+/// never sees.
+fn relink_importer_bins_after_hoisting(
+    modules_dir: &Path,
+    symlink_root: &Path,
+    trusted_importer_ids: &std::collections::HashSet<String>,
+    link_options: &LinkBinsOptions,
+) -> Result<(), LinkPhaseError> {
+    let modules_basename = modules_dir
+        .file_name()
+        .map_or_else(|| std::ffi::OsString::from("node_modules"), std::ffi::OsStr::to_os_string);
+    for importer_id in trusted_importer_ids {
+        let importer_modules_dir =
+            crate::symlink_direct_dependencies::importer_root_dir(symlink_root, importer_id)
+                .join(&modules_basename);
+        let bins_dir = importer_modules_dir.join(".bin");
+        pnpm_cmd_shim::link_bins::<pnpm_cmd_shim::Host>(
+            &importer_modules_dir,
+            &bins_dir,
+            link_options,
+        )
+        .map_err(LinkPhaseError::LinkBins)?;
+    }
+    Ok(())
 }

--- a/pnpm/crates/deps-restorer/src/linking.rs
+++ b/pnpm/crates/deps-restorer/src/linking.rs
@@ -153,9 +153,9 @@ pub struct LinkPhaseOutput {
 /// `.modules.yaml` observe the same skip set this phase acted on.
 ///
 /// Returns what the build phase and the caller's `.modules.yaml` writer
-/// need — see [`LinkPhaseOutput`]. Under `virtual_store_only` nothing
-/// below the reconciliation runs and every output is empty: that mode
-/// populates the store without touching the project.
+/// need — see [`LinkPhaseOutput`]. Under `virtual_store_only` only the
+/// per-slot bin pass runs and every output is empty: that mode
+/// populates the virtual store without touching the project.
 pub fn run_link_phase<Reporter: self::Reporter>(
     inputs: LinkPhaseInputs<'_>,
     skipped: &mut SkippedSnapshots,
@@ -225,23 +225,10 @@ pub fn run_link_phase<Reporter: self::Reporter>(
     // [`crate::link_hoisted_modules()`]); on the isolated linker
     // the event fires here, so every install carries exactly one,
     // pairing the `added` emitted in `CreateVirtualStore`.
-    // Nothing below this point runs under `virtual_store_only`: it
-    // creates no importer or hoist links, so it has neither anything to
-    // reconcile nor anything to link. Returning here rather than gating
-    // each pass keeps that a single decision — and keeps the hoist pass,
-    // which writes into `config.modules_dir`, from touching a project
-    // this mode is meant to leave alone.
-    if config.virtual_store_only {
-        return Ok(LinkPhaseOutput {
-            hoisted_dependencies: crate::HoistedDependencies::new(),
-            hoisted_locations: BTreeMap::new(),
-            hoisted_pkg_roots_by_key: None,
-            publicly_hoisted_for_post_build: Vec::new(),
-        });
-    }
-
-    //
-    if !is_hoisted {
+    // `virtual_store_only` is excluded as well: it creates no importer
+    // or hoist links, so it has neither anything to reconcile nor
+    // anything to link.
+    if !is_hoisted && !config.virtual_store_only {
         let removed_count = match current_lockfile {
             Some(current) => crate::PruneStaleModules {
                 config,
@@ -260,9 +247,7 @@ pub fn run_link_phase<Reporter: self::Reporter>(
             level: LogLevel::Debug,
             message: StatsMessage::Removed { prefix: requester.to_owned(), removed: removed_count },
         }));
-    }
 
-    if !is_hoisted {
         SymlinkDirectDependencies {
             config,
             layout,
@@ -295,7 +280,9 @@ pub fn run_link_phase<Reporter: self::Reporter>(
             skipped,
         )
         .map_err(LinkPhaseError::LinkRootComponentMembers)?;
+    }
 
+    if !is_hoisted {
         // Link the bins of each virtual-store slot's children into the
         // slot's own `node_modules/.bin`.
         // Done before `importing_done` so reporters see the import phase
@@ -304,15 +291,20 @@ pub fn run_link_phase<Reporter: self::Reporter>(
         // lets the linker hit `pkgFilesIndex.manifest` directly instead
         // of re-reading every child's `package.json` from disk.
         //
-        // Both passes are gated by `!is_hoisted`: under
-        // `nodeLinker: hoisted` there is no virtual store
-        // (`CreateVirtualStore` skipped slot writes), and the
-        // bin links go into `<parent>/node_modules/.bin` for
+        // This pass and [`SymlinkDirectDependencies`] above are both
+        // gated by `!is_hoisted`: under `nodeLinker: hoisted` there is
+        // no virtual store (`CreateVirtualStore` skipped slot writes),
+        // and the bin links go into `<parent>/node_modules/.bin` for
         // every hoist location instead. The hoisted linker
         // ([`crate::link_hoisted_modules()`], called below) does
         // its own per-`node_modules` bin pass while walking the
         // hierarchy, routing both link phases through the hoisted
         // linker.
+        //
+        // Unlike every other pass here this one also runs under
+        // `virtual_store_only`: the links it writes live inside the
+        // virtual store, and the build phase — which `pnpm fetch` still
+        // runs — resolves a dependency's sibling bin through them.
         LinkVirtualStoreBins {
             layout,
             snapshots,
@@ -324,6 +316,19 @@ pub fn run_link_phase<Reporter: self::Reporter>(
         }
         .run()
         .map_err(LinkPhaseError::LinkVirtualStoreBins)?;
+    }
+
+    // Nothing below this point runs under `virtual_store_only`: it
+    // materializes the importer-visible tree and the sidecars that
+    // describe it, and the hoist pass writes into `config.modules_dir`
+    // — a project this mode is meant to leave alone.
+    if config.virtual_store_only {
+        return Ok(LinkPhaseOutput {
+            hoisted_dependencies: crate::HoistedDependencies::new(),
+            hoisted_locations: BTreeMap::new(),
+            hoisted_pkg_roots_by_key: None,
+            publicly_hoisted_for_post_build: Vec::new(),
+        });
     }
 
     // Hoisted-linker materialization. Replaces the isolated

--- a/pnpm/crates/deps-restorer/src/linking.rs
+++ b/pnpm/crates/deps-restorer/src/linking.rs
@@ -84,11 +84,9 @@ impl From<HoistedLinkerError> for LinkPhaseError {
 
 /// Everything the link phase reads.
 ///
-/// Both install paths supply this, and the fields that differ between
-/// them are inputs rather than branches: [`Self::symlink_root`],
-/// [`Self::trusted_importer_ids`], [`Self::root_component_importers`]
-/// and [`Self::sidecar_lockfile`] each carry a per-path value whose
-/// reason is documented on the field.
+/// Both install paths supply this. What differs between them is carried
+/// as a field value rather than a branch inside the phase; each such
+/// field documents its per-path value.
 pub struct LinkPhaseInputs<'a> {
     pub config: &'static Config,
     pub layout: &'a VirtualStoreLayout,
@@ -113,8 +111,7 @@ pub struct LinkPhaseInputs<'a> {
     /// Lockfile dir, for the sidecars and the hoisted walker.
     pub workspace_root: &'a Path,
     /// Importer ids allowed to live outside the lockfile dir (Bit's
-    /// capsule installs). Derived differently per path, so it is an
-    /// input rather than something this module recomputes.
+    /// capsule installs).
     pub trusted_importer_ids: &'a std::collections::HashSet<String>,
     /// Importers declaring `installConfig.hoistingLimits: "workspaces"`.
     pub root_component_importers: &'a std::collections::HashSet<String>,
@@ -190,19 +187,17 @@ pub fn run_link_phase<Reporter: self::Reporter>(
         logged_methods,
     } = inputs;
 
-    // Pre-compute the hoist plan so the dedupe pass inside
-    // `SymlinkDirectDependencies` can fold publicly-hoisted aliases
-    // into root's target map — pacquet runs hoist *after*
-    // `SymlinkDirectDependencies`, so without this the dedupe map
-    // only sees root's direct deps and a non-root importer's
-    // direct dep that would land at root via public-hoist stays
-    // un-deduped. The full `HoistResult` is also threaded to the
-    // on-disk hoist pass below so the traversal isn't run twice.
-    // `hoist-workspace-packages`: named non-root projects become
-    // hoist candidates whose links point at the project dirs.
+    // `hoistWorkspacePackages`: named non-root projects become hoist
+    // candidates whose links point at the project dirs.
     let hoisted_workspace_packages = config
         .hoist_workspace_packages
         .then(|| workspace_packages_for_hoist(workspace_root, project_manifests));
+    // Planned here, ahead of `SymlinkDirectDependencies`, so that pass's
+    // dedupe map can see publicly-hoisted aliases: the on-disk hoist runs
+    // *after* it, and without the plan the map holds only root's direct
+    // deps — leaving a non-root importer's dep that public-hoist would
+    // land at root un-deduped. The plan is threaded to the hoist pass
+    // below so the traversal runs once.
     let pre_hoist = compute_hoist_plan(
         config,
         snapshots,
@@ -217,17 +212,15 @@ pub fn run_link_phase<Reporter: self::Reporter>(
         .as_ref()
         .map(|plan| collect_public_hoist_targets(&plan.result, &plan.graph, layout, &plan.skipped));
 
-    // Reconcile before linking: stale direct-dep links and
-    // orphaned hoist links must vacate their slots so the relink +
-    // rehoist below can claim them. The hoisted linker is excluded
-    // — its previous-graph diff removes orphans and emits the
-    // `pnpm:stats` `removed` event itself (see
-    // [`crate::link_hoisted_modules()`]); on the isolated linker
-    // the event fires here, so every install carries exactly one,
-    // pairing the `added` emitted in `CreateVirtualStore`.
-    // `virtual_store_only` is excluded as well: it creates no importer
-    // or hoist links, so it has neither anything to reconcile nor
-    // anything to link.
+    // Reconcile before linking: stale direct-dep links and orphaned
+    // hoist links must vacate their slots so the relink + rehoist below
+    // can claim them. Excluded under the hoisted linker, whose
+    // previous-graph diff removes orphans and emits the `pnpm:stats`
+    // `removed` event itself (see [`crate::link_hoisted_modules()`]) —
+    // so every install carries exactly one, pairing the `added` emitted
+    // in `CreateVirtualStore`. Excluded under `virtual_store_only` too:
+    // it creates no importer or hoist links, so it has neither anything
+    // to reconcile nor anything to link.
     if !is_hoisted && !config.virtual_store_only {
         let removed_count = match current_lockfile {
             Some(current) => crate::PruneStaleModules {
@@ -264,13 +257,8 @@ pub fn run_link_phase<Reporter: self::Reporter>(
         .run::<Reporter>()
         .map_err(LinkPhaseError::SymlinkDirectDependencies)?;
 
-        // Bit "root components": make each root's injected members
-        // mutually reachable. Gated on
-        // `installConfig.hoistingLimits: "workspaces"`, so it is a
-        // no-op for every non-Bit install. See
-        // [`link_root_component_members`]. `project_manifests` keys
-        // are project directories; map each back to its lockfile
-        // importer id so the set lines up with `importers`.
+        // Bit "root components" — a no-op unless an importer declared
+        // `installConfig.hoistingLimits: "workspaces"`.
         link_root_component_members(
             layout,
             importers,
@@ -284,22 +272,11 @@ pub fn run_link_phase<Reporter: self::Reporter>(
 
     if !is_hoisted {
         // Link the bins of each virtual-store slot's children into the
-        // slot's own `node_modules/.bin`.
-        // Done before `importing_done` so reporters see the import phase
-        // close only after every link (including per-slot bins) is in
-        // place. The manifest map threaded from `CreateVirtualStore`
-        // lets the linker hit `pkgFilesIndex.manifest` directly instead
-        // of re-reading every child's `package.json` from disk.
-        //
-        // This pass and [`SymlinkDirectDependencies`] above are both
-        // gated by `!is_hoisted`: under `nodeLinker: hoisted` there is
-        // no virtual store (`CreateVirtualStore` skipped slot writes),
-        // and the bin links go into `<parent>/node_modules/.bin` for
-        // every hoist location instead. The hoisted linker
-        // ([`crate::link_hoisted_modules()`], called below) does
-        // its own per-`node_modules` bin pass while walking the
-        // hierarchy, routing both link phases through the hoisted
-        // linker.
+        // slot's own `node_modules/.bin`, before `importing_done` so
+        // reporters see the import phase close only once every link is
+        // in place. Skipped under `nodeLinker: hoisted`, which has no
+        // virtual store to link into and whose linker below runs its own
+        // per-`node_modules` bin pass while walking the hierarchy.
         //
         // Unlike every other pass here this one also runs under
         // `virtual_store_only`: the links it writes live inside the
@@ -331,33 +308,14 @@ pub fn run_link_phase<Reporter: self::Reporter>(
         });
     }
 
-    // Hoisted-linker materialization. Replaces the isolated
-    // [`crate::SymlinkDirectDependencies`] +
-    // [`crate::LinkVirtualStoreBins`] pair when
-    // `nodeLinker: hoisted` is in effect: the dep-graph walker
-    // computes per-package directories (with conflict-aware
-    // nesting), and the linker imports CAS files into those
-    // directories from
-    // [`CreateVirtualStoreOutput::cas_paths_by_pkg_id`] which
-    // was populated above with `node_linker = Hoisted`.
-    //
-    // `hoisted_locations` is the per-depPath list of
-    // lockfile-relative directories the walker emits. Threaded
-    // through [`InstallFrozenLockfileOutput`] so
-    // [`crate::Install::run`] can persist it into
-    // `.modules.yaml.hoisted_locations` (rebuild reads it back
-    // and surfaces `MISSING_HOISTED_LOCATIONS` if it's gone).
-    //
-    // `pkg_roots_by_key` is a per-snapshot override for
-    // `BuildModules`'s `pkgRoot` lookup. Populated from the
-    // walker's [`crate::DependenciesGraphNode::dir`] values so
-    // the build phase can `cd` into the on-disk hoisted
-    // directory instead of computing a virtual-store slot path
-    // that doesn't exist under hoisted. `None` (and an empty
-    // `hoisted_locations`) for the isolated linker. See
-    // [`crate::BuildModules::pkg_roots_by_key`] for why a snapshot
-    // can map to more than one directory and which writes have to
-    // reach all of them.
+    // Hoisted-linker materialization: replaces the
+    // [`crate::SymlinkDirectDependencies`] + [`crate::LinkVirtualStoreBins`]
+    // pair above when `nodeLinker: hoisted` is in effect. The dep-graph
+    // walker computes per-package directories (with conflict-aware
+    // nesting) and the linker imports CAS files into them from
+    // [`CreateVirtualStoreOutput::cas_paths_by_pkg_id`], populated above
+    // with `node_linker = Hoisted`. Both outputs stay empty for the
+    // isolated linker — see [`HoistedLinkerOutput`] for what they carry.
     let HoistedLinkerOutput { hoisted_locations, hoisted_pkg_roots_by_key } = if is_hoisted {
         run_hoisted_linker::<Reporter>(
             HoistedLinkerInputs {
@@ -384,52 +342,27 @@ pub fn run_link_phase<Reporter: self::Reporter>(
         HoistedLinkerOutput::default()
     };
 
-    // Hoist transitive deps into `<virtual_store>/node_modules`
-    // (private hoist) and/or `<root>/node_modules` (public hoist).
-    //
-    // The guard is `hoistPattern != null || publicHoistPattern != null`
-    // — `Some(empty)` is a valid disabled state for one side but
-    // not the other, so the guard checks `is_some()` on the field
-    // (not `Vec` length). With pacquet's defaults both sides are
-    // `Some(non-empty)`, so the pass runs by default.
-    // Stashed across the hoist pass for the post-`BuildModules`
-    // top-level bin link. Isolated-linker public-hoist promotes
-    // a transitive dep alias to `<root>/node_modules/<alias>`
-    // where it competes for the same `<root>/node_modules/.bin`
-    // slot as the root importer's direct deps. Per
-    // pnpm/pacquet#342 the direct dep's bin must win. The post-build pass below
-    // takes both direct + hoisted candidate lists so
-    // `pnpm_cmd_shim::pick_winner` (private)'s [`BinOrigin`] tier
-    // resolves the conflict in one call. Empty means there's
-    // no public-hoist (no patterns set, hoisted linker, or
-    // `Some(empty)`-vs-`None` short-circuit).
+    // Public-hoist promotes a transitive dep's alias to
+    // `<root>/node_modules/<alias>`, where its bin competes for the same
+    // `<root>/node_modules/.bin` slot as a root direct dep's. Per
+    // pnpm/pacquet#342 the direct dep must win, so the aliases are stashed
+    // here for the post-`BuildModules` top-level bin link, which takes
+    // both candidate lists and lets `pick_winner`'s [`BinOrigin`] tier
+    // settle it in one call. Empty when nothing was publicly hoisted.
     let mut publicly_hoisted_for_post_build: Vec<String> = Vec::new();
-    // Isolated-linker hoist pass: shamefully-hoist + private
-    // hoist into the virtual store. Skipped under hoisted —
-    // the hoisted linker materialized the project tree above
-    // and there's no virtual store to point hoist symlinks at,
-    // so no new isolated-hoist results are produced when no
-    // `hoistPattern` / `publicHoistPattern` is configured.
-    //
-    // The traversal itself ran upthread (`pre_hoist`) so the dedupe
-    // pass in `SymlinkDirectDependencies` could see public-hoist
-    // targets; here we consume the same plan to write the
-    // symlinks on disk and emit the per-side bin shims.
+    // Write the plan to disk: shamefully-hoist + private hoist into the
+    // virtual store, plus the per-side bin shims. `pre_hoist` is `None`
+    // under the hoisted linker, which materialized the tree itself and
+    // has no virtual store to point hoist symlinks at.
     let hoisted_dependencies = if let Some(plan) = pre_hoist {
         let HoistPlan { graph, result, skipped: hoist_skipped, .. } = plan;
-        // Public-hoist target is the project's root
-        // `node_modules` (= `config.modules_dir`).
-        // Private-hoist target is the project-local
-        // `<root>/node_modules/.pnpm/node_modules` —
-        // pacquet's `config.virtual_store_dir` always
-        // resolves there even with GVS enabled: pacquet keeps
-        // `virtual_store_dir` project-local and
-        // routes the GVS-shared root through
-        // `global_virtual_store_dir` instead — see
-        // [`Config::apply_global_virtual_store_derivation`].
-        // The symlink *target* (under the slot dir)
-        // does need to be GVS-aware, which the
-        // `VirtualStoreLayout` handle below provides.
+        // `virtual_store_dir` stays project-local even with GVS enabled
+        // — the shared root is routed through `global_virtual_store_dir`
+        // instead (see [`Config::apply_global_virtual_store_derivation`])
+        // — so the private-hoist target is always
+        // `<root>/node_modules/.pnpm/node_modules`. Only the symlink
+        // *target* under the slot dir is GVS-aware, which `layout`
+        // resolves.
         let private_dir = config.virtual_store_dir.join("node_modules");
         let public_dir = config.modules_dir.clone();
         symlink_hoisted_dependencies(
@@ -443,20 +376,12 @@ pub fn run_link_phase<Reporter: self::Reporter>(
         )
         .map_err(LinkPhaseError::HoistSymlink)?;
         // Private-side bins → `<vs>/node_modules/.bin`.
-        // Reuses the rayon-parallel `link_direct_dep_bins`
-        // shape (read each location's `package.json`, fan out
-        // to `link_bins_of_packages`).
         link_direct_dep_bins_resolved(
             &private_dir,
             &crate::resolve_hoisted_bin_deps(layout, &result.hoisted_aliases_with_bins),
             link_options,
         )
         .map_err(LinkPhaseError::HoistLinkBins)?;
-        // Stash the public-hoist alias list for the
-        // post-`BuildModules` top-level bin link, which re-links
-        // with the [`BinOrigin`] tier so a direct dep's bin wins
-        // outright over a publicly-hoisted bin with a lexically
-        // smaller name. The re-link runs after `buildModules`.
         publicly_hoisted_for_post_build = result.publicly_hoisted_aliases_with_bins;
         result.hoisted_dependencies
     } else {

--- a/pnpm11/installing/commands/src/fetch.ts
+++ b/pnpm11/installing/commands/src/fetch.ts
@@ -46,7 +46,7 @@ export function help (): string {
   })
 }
 
-type FetchCommandOptions = Pick<Config, 'production' | 'dev' | 'enableGlobalVirtualStore' | 'patchedDependencies'> & Pick<ConfigContext, 'rootProjectManifest' | 'rootProjectManifestDir'> & CreateStoreControllerOptions
+type FetchCommandOptions = Pick<Config, 'production' | 'dev' | 'allowBuilds' | 'enableGlobalVirtualStore' | 'patchedDependencies'> & Pick<ConfigContext, 'rootProjectManifest' | 'rootProjectManifestDir'> & CreateStoreControllerOptions
 
 export async function handler (opts: FetchCommandOptions): Promise<void> {
   const store = await createStoreController(opts)

--- a/pnpm11/installing/commands/test/fetch.ts
+++ b/pnpm11/installing/commands/test/fetch.ts
@@ -329,3 +329,39 @@ test('fetch applies patches to dependencies when patchedDependencies key is bare
   const patchedIndexJsAfterFetch = fs.readFileSync(path.join(virtualStoreDir, consoleLogDirs[0], 'node_modules/@pnpm.e2e/console-log/index.js'), 'utf8')
   expect(patchedIndexJsAfterFetch).toContain('FIRST LINE')
 })
+
+// Regression test for https://github.com/pnpm/pnpm/issues/14174
+// A dependency's lifecycle script resolves a sibling dependency's bin
+// through the `node_modules/.bin` linked next to it in the virtual store.
+// fetch runs those scripts, so it has to write those links even though it
+// materializes nothing importer-facing.
+test('fetch runs a build script that calls a dependency bin', async () => {
+  const project = prepare({
+    dependencies: { '@pnpm.e2e/pre-and-postinstall-scripts-example': '1.0.0' },
+  })
+  const storeDir = path.resolve('store')
+
+  await install.handler({
+    ...DEFAULT_OPTIONS,
+    cacheDir: path.resolve('cache'),
+    dir: process.cwd(),
+    linkWorkspacePackages: true,
+    lockfileOnly: true,
+    storeDir,
+  })
+
+  // The Docker "fetcher stage" shape: the lockfile with no project manifest.
+  rimrafSync(path.resolve(project.dir(), './package.json'))
+
+  await fetch.handler({
+    ...DEFAULT_OPTIONS,
+    allowBuilds: { '@pnpm.e2e/pre-and-postinstall-scripts-example': true },
+    cacheDir: path.resolve('cache'),
+    dir: process.cwd(),
+    storeDir,
+  })
+
+  const pkgDir = path.resolve(project.dir(), 'node_modules/.pnpm/@pnpm.e2e+pre-and-postinstall-scripts-example@1.0.0/node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example')
+  expect(fs.existsSync(path.join(pkgDir, 'node_modules/.bin/hello-world-js-bin'))).toBeTruthy()
+  expect(fs.existsSync(path.join(pkgDir, 'generated-by-postinstall.js'))).toBeTruthy()
+})


### PR DESCRIPTION
## Summary

`pnpm fetch` in 12.0.0-rc.11 failed any dependency `postinstall` that invokes a
sibling dependency's bin — the reporter hit it with `unrs-resolver` calling
`napi-postinstall`, which killed every Docker multi-stage build whose fetcher
stage touches oxlint/eslint tooling:

```
sh: napi-postinstall: command not found
× fetching dependencies
╰─▶ unrs-resolver@1.11.1 postinstall: … exited with exit status: 127
```

`pnpm install --frozen-lockfile` against the same lockfile succeeded.

In the Rust CLI, `run_link_phase` returned early under `virtual_store_only`
(which `pnpm fetch` sets) *before* reaching `LinkVirtualStoreBins`, while
`run_build_phase` still ran dependency lifecycle scripts under that mode. The
scripts therefore ran with no `node_modules/.bin` for
`pnpm_executor::extend_path`'s ancestor walk to find.

The per-slot bin pass now runs under `virtual_store_only` too: its links live
inside the virtual store, which is exactly what that mode materializes. Only
the importer-facing passes — prune, direct-dependency symlinks, root
components, hoisting, and the module-resolution sidecars — stay skipped, so
`fetch` still leaves the project untouched.

The TypeScript CLI is unaffected: its `buildModules` links a dep node's bins
itself right before running that node's scripts, which is why pnpm 11.11.0
worked. It gets the matching regression test only (plus the one-word
`allowBuilds` widening on `FetchCommandOptions` that the test needs to compile).

Closes pnpm/pnpm#14174

### Second commit: comment cleanup in `linking.rs`

`linking.rs` was 38% comment lines, and touching it for this fix surfaced how
much of that prose the code and the callees' own docs already carried — a call
site restating `HoistedLinkerOutput`'s field docs, a rationale duplicated at
both the declaration and the assignment, two comments sitting above the wrong
binding, and one sentence describing a mapping the call site does not perform.
The second commit removes those. Gate and ordering rationale stays: why a pass
is skipped under `nodeLinker: hoisted` or `virtualStoreOnly`, why
reconciliation precedes relinking, why the hoist plan is computed before
`SymlinkDirectDependencies`. Comment lines 192 → 117, code lines unchanged at
301 — stripping comments from both revisions yields identical files.

## Squash Commit Body

```text
`run_link_phase` returned early under `virtual_store_only` before reaching
`LinkVirtualStoreBins`, while `run_build_phase` still ran dependency
lifecycle scripts under that mode. A `postinstall` that invokes a sibling
dependency's bin — `unrs-resolver` calling `napi-postinstall`, for
instance — therefore died with `command not found` (exit 127) under
`pnpm fetch`, because `pnpm_executor::extend_path`'s ancestor-`.bin` walk
had no `.bin` to find. `pnpm install --frozen-lockfile` against the same
lockfile worked: it does not set `virtual_store_only`.

The per-slot bin pass now runs under `virtual_store_only` too. Its links
live inside the virtual store, which is exactly what that mode
materializes; only the importer-facing passes (prune, direct-dependency
symlinks, root components, hoisting, sidecars) stay skipped.

The TypeScript CLI is unaffected — its `buildModules` links a dep node's
bins itself right before running the node's scripts — so it gets the
matching regression test only, plus the `allowBuilds` widening that test
needs on `FetchCommandOptions`.

Closes pnpm/pnpm#14174
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - `pnpm fetch` now links dependency binaries in the virtual store, allowing permitted lifecycle scripts to invoke sibling commands.
  - Fixed failures in manifest-less, lockfile-only fetch workflows, including Docker build stages.
  - Fetch operations now honor configured build permissions.

- **Tests**
  - Added regression coverage confirming build scripts run successfully and generated binaries and files are available during fetch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->