### PR TITLE
feat: refresh registry revisions through pnpr

### DIFF
--- a/.changeset/pnpr-refreshes-revisions.md
+++ b/.changeset/pnpr-refreshes-revisions.md
@@ -1,0 +1,9 @@
+---
+"@pnpm/installing.deps-installer": minor
+"@pnpm/pnpr.client": minor
+"@pnpm/pnpr": minor
+"pacquet": minor
+"pnpm": minor
+---
+
+Allowed `pnpm update --patches` to refresh registry revisions through a configured pnpr server while retaining locked package versions.

--- a/pnpm/crates/cli/src/cli_args/import.rs
+++ b/pnpm/crates/cli/src/cli_args/import.rs
@@ -45,6 +45,7 @@ impl ImportArgs {
                     skip_runtimes: config.skip_runtimes,
                     frozen_lockfile: false,
                     prefer_frozen_lockfile: false,
+                    update_patches: false,
                     lockfile_only: true,
                     ignore_manifest_check: false,
                     trust_lockfile: false,

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -628,6 +628,7 @@ impl InstallArgs {
                     frozen_lockfile,
                     prefer_frozen_lockfile: prefer_frozen_lockfile
                         .unwrap_or(config.prefer_frozen_lockfile),
+                    update_patches: false,
                     lockfile_only,
                     ignore_manifest_check,
                     trust_lockfile,
@@ -717,6 +718,10 @@ pub(crate) struct PnprLink<'a> {
     /// sending the raw CLI override — keeps a yaml `preferFrozenLockfile:
     /// false` honored on the pnpr path without `--no-prefer-frozen-lockfile`.
     pub(crate) prefer_frozen_lockfile: bool,
+    /// Refresh registry artifacts while retaining every locked package
+    /// version. This disables the exchange-free satisfied-lockfile path and
+    /// is forwarded to `/-/pnpr/v0/resolve`.
+    pub(crate) update_patches: bool,
     /// `--lockfile-only`. Forwarded to `/-/pnpr/v0/resolve` so the server
     /// resolves only — returning the lockfile without fetching files —
     /// after which [`install_via_pnpr`] writes the lockfile and skips
@@ -821,6 +826,15 @@ pub(crate) async fn install_via_pnpr<Reporter: self::Reporter + 'static>(
     Box::pin(install_via_pnpr_inner::<Reporter>(state, pnpr_server, None, link)).await
 }
 
+pub(crate) async fn install_selected_via_pnpr<Reporter: self::Reporter + 'static>(
+    state: &State,
+    pnpr_server: &str,
+    selection: &InstallFamilySelection,
+    link: PnprLink<'_>,
+) -> miette::Result<()> {
+    Box::pin(install_via_pnpr_inner::<Reporter>(state, pnpr_server, Some(selection), link)).await
+}
+
 async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
     state: &State,
     pnpr_server: &str,
@@ -892,6 +906,7 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
     // selection too — every project — and skips the server like any
     // single-project one.
     let satisfied_without_server = !link.frozen_lockfile
+        && !link.update_patches
         && !link.lockfile_only
         && link.prefer_frozen_lockfile
         && !partial_selection
@@ -1164,6 +1179,7 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
         lockfile: previous_wanted.cloned(),
         frozen_lockfile: link.frozen_lockfile,
         prefer_frozen_lockfile: Some(link.prefer_frozen_lockfile),
+        update_patches: link.update_patches,
         ignore_manifest_check: link.ignore_manifest_check,
         trust_lockfile: link.trust_lockfile,
         resolution_mode: state.config.resolution_mode,

--- a/pnpm/crates/cli/src/cli_args/update.rs
+++ b/pnpm/crates/cli/src/cli_args/update.rs
@@ -194,8 +194,7 @@ impl UpdateArgs {
         let workspace_root = self.check_workspace_option(state.config.workspace_dir.as_deref())?;
         let include_direct = self.dependency_options.include_direct();
         let update_actions = self.should_update_github_actions(state.config, &include_direct);
-        if self.patches
-            && !update_actions
+        if self.can_delegate_patch_refresh(update_actions)
             && let Some(pnpr_server) = state.config.pnpr_server.as_deref()
         {
             let lockfile_path = state.lockfile_path();
@@ -325,8 +324,7 @@ impl UpdateArgs {
         let workspace_root = self.check_workspace_option(state.config.workspace_dir.as_deref())?;
         let include_direct = self.dependency_options.include_direct();
         let update_actions = self.should_update_github_actions(state.config, &include_direct);
-        if self.patches
-            && !update_actions
+        if self.can_delegate_patch_refresh(update_actions)
             && let Some(pnpr_server) = state.config.pnpr_server.as_deref()
         {
             let lockfile_path = state.lockfile_path();
@@ -515,6 +513,10 @@ impl UpdateArgs {
             return Err(PatchesWithSelectorError.into());
         }
         Ok(())
+    }
+
+    fn can_delegate_patch_refresh(&self, update_actions: bool) -> bool {
+        self.patches && self.depth.is_none() && !update_actions
     }
 
     fn pnpr_patch_link<'path>(

--- a/pnpm/crates/cli/src/cli_args/update.rs
+++ b/pnpm/crates/cli/src/cli_args/update.rs
@@ -13,7 +13,7 @@ use clap::Args;
 use derive_more::{Display, Error};
 use miette::{Context, Diagnostic};
 use pnpm_config::Config;
-use pnpm_package_manager::{Update, build_workspace_packages_map};
+use pnpm_package_manager::{Update, build_workspace_packages_map, included_direct_groups};
 use pnpm_package_manifest::DependencyGroup;
 use pnpm_registry::RangeSpecStyle;
 use pnpm_reporter::Reporter;
@@ -148,6 +148,10 @@ pub struct UpdateArgs {
     #[clap(long = "ignore-pnpmfile")]
     pub ignore_pnpmfile: bool,
 
+    /// URL of a pnpr server to offload revision refresh resolution to.
+    #[clap(long = "pnpr-server")]
+    pub pnpr_server: Option<String>,
+
     #[clap(skip)]
     pub(crate) prompt: UpdatePrompt,
 }
@@ -176,6 +180,9 @@ struct PatchesWithSelectorError;
 impl UpdateArgs {
     pub(crate) fn apply_cli_config(&self, config: &mut Config) {
         config.ignore_pnpmfile = self.ignore_pnpmfile || config.ignore_pnpmfile;
+        if let Some(pnpr_server) = self.pnpr_server.clone() {
+            config.pnpr_server = Some(pnpr_server);
+        }
     }
 
     pub async fn run<Reporter: self::Reporter + 'static>(
@@ -184,8 +191,22 @@ impl UpdateArgs {
     ) -> miette::Result<()> {
         self.check_patches_options()?;
         state.http_client.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
-        let workspace_packages = self
-            .check_workspace_option(state.config.workspace_dir.as_deref())?
+        let workspace_root = self.check_workspace_option(state.config.workspace_dir.as_deref())?;
+        let include_direct = self.dependency_options.include_direct();
+        let update_actions = self.should_update_github_actions(state.config, &include_direct);
+        if self.patches
+            && !update_actions
+            && let Some(pnpr_server) = state.config.pnpr_server.as_deref()
+        {
+            let lockfile_path = state.lockfile_path();
+            return super::install::install_via_pnpr::<Reporter>(
+                &state,
+                pnpr_server,
+                self.pnpr_patch_link(&state, &lockfile_path),
+            )
+            .await;
+        }
+        let workspace_packages = workspace_root
             .map(|workspace_root| {
                 recursive::discover_workspace_projects(workspace_root, state.config)
                     .map(|(projects, _)| build_workspace_packages_map(Some(&projects)))
@@ -195,8 +216,6 @@ impl UpdateArgs {
 
         let actions_root =
             state.config.workspace_dir.clone().unwrap_or_else(|| manifest_root(&state.manifest));
-        let include_direct = self.dependency_options.include_direct();
-        let update_actions = self.should_update_github_actions(state.config, &include_direct);
         let action_matcher =
             if update_actions { github_actions::selector_matcher(&self.packages) } else { None };
         let package_selectors = filter_package_selectors(&self.packages, update_actions);
@@ -303,13 +322,26 @@ impl UpdateArgs {
     ) -> miette::Result<()> {
         self.check_patches_options()?;
         state.http_client.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
-        let workspace_packages = self
-            .check_workspace_option(state.config.workspace_dir.as_deref())?
-            .and_then(|_| build_workspace_packages_map(Some(&selection.projects)));
-
-        let actions_root = selection.workspace_root.clone();
+        let workspace_root = self.check_workspace_option(state.config.workspace_dir.as_deref())?;
         let include_direct = self.dependency_options.include_direct();
         let update_actions = self.should_update_github_actions(state.config, &include_direct);
+        if self.patches
+            && !update_actions
+            && let Some(pnpr_server) = state.config.pnpr_server.as_deref()
+        {
+            let lockfile_path = state.lockfile_path();
+            return super::install::install_selected_via_pnpr::<Reporter>(
+                &state,
+                pnpr_server,
+                &selection,
+                self.pnpr_patch_link(&state, &lockfile_path),
+            )
+            .await;
+        }
+        let workspace_packages =
+            workspace_root.and_then(|_| build_workspace_packages_map(Some(&selection.projects)));
+
+        let actions_root = selection.workspace_root.clone();
         let action_matcher =
             if update_actions { github_actions::selector_matcher(&self.packages) } else { None };
         let package_selectors = filter_package_selectors(&self.packages, update_actions);
@@ -483,6 +515,29 @@ impl UpdateArgs {
             return Err(PatchesWithSelectorError.into());
         }
         Ok(())
+    }
+
+    fn pnpr_patch_link<'path>(
+        &self,
+        state: &State,
+        lockfile_path: &'path Path,
+    ) -> super::install::PnprLink<'path> {
+        super::install::PnprLink {
+            dependency_groups: included_direct_groups(state.config.optional).collect(),
+            supported_architectures: self
+                .supported_architectures
+                .apply_to(state.config.supported_architectures.clone()),
+            node_linker: state.config.node_linker,
+            skip_runtimes: state.config.skip_runtimes,
+            frozen_lockfile: false,
+            prefer_frozen_lockfile: false,
+            update_patches: true,
+            lockfile_only: self.lockfile_only,
+            ignore_manifest_check: false,
+            trust_lockfile: state.config.trust_lockfile,
+            lockfile_path: Some(lockfile_path),
+            use_state_lockfile: true,
+        }
     }
 
     fn should_update_github_actions(

--- a/pnpm/crates/cli/src/cli_args/update.rs
+++ b/pnpm/crates/cli/src/cli_args/update.rs
@@ -194,7 +194,7 @@ impl UpdateArgs {
         let workspace_root = self.check_workspace_option(state.config.workspace_dir.as_deref())?;
         let include_direct = self.dependency_options.include_direct();
         let update_actions = self.should_update_github_actions(state.config, &include_direct);
-        if self.can_delegate_patch_refresh(update_actions)
+        if self.can_delegate_patch_refresh(update_actions, &include_direct)
             && let Some(pnpr_server) = state.config.pnpr_server.as_deref()
         {
             let lockfile_path = state.lockfile_path();
@@ -324,7 +324,7 @@ impl UpdateArgs {
         let workspace_root = self.check_workspace_option(state.config.workspace_dir.as_deref())?;
         let include_direct = self.dependency_options.include_direct();
         let update_actions = self.should_update_github_actions(state.config, &include_direct);
-        if self.can_delegate_patch_refresh(update_actions)
+        if self.can_delegate_patch_refresh(update_actions, &include_direct)
             && let Some(pnpr_server) = state.config.pnpr_server.as_deref()
         {
             let lockfile_path = state.lockfile_path();
@@ -515,8 +515,17 @@ impl UpdateArgs {
         Ok(())
     }
 
-    fn can_delegate_patch_refresh(&self, update_actions: bool) -> bool {
-        self.patches && self.depth.is_none() && !update_actions
+    fn can_delegate_patch_refresh(
+        &self,
+        update_actions: bool,
+        include_direct: &[DependencyGroup],
+    ) -> bool {
+        let all_dependency_groups =
+            [DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional];
+        self.patches
+            && self.depth.is_none()
+            && !update_actions
+            && all_dependency_groups.iter().all(|group| include_direct.contains(group))
     }
 
     fn pnpr_patch_link<'path>(

--- a/pnpm/crates/cli/src/cli_args/update/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/update/tests.rs
@@ -161,8 +161,14 @@ fn patches_is_a_selectorless_update_mode() {
 }
 
 #[test]
-fn patch_refresh_with_a_depth_limit_stays_on_the_client() {
-    assert!(update_args(&["--patches"]).can_delegate_patch_refresh(false));
-    assert!(!update_args(&["--patches", "--depth", "0"]).can_delegate_patch_refresh(false));
-    assert!(!update_args(&["--patches"]).can_delegate_patch_refresh(true));
+fn constrained_patch_refresh_stays_on_the_client() {
+    let all_groups = vec![DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional];
+    let prod_only = vec![DependencyGroup::Prod];
+
+    assert!(update_args(&["--patches"]).can_delegate_patch_refresh(false, &all_groups));
+    assert!(
+        !update_args(&["--patches", "--depth", "0"]).can_delegate_patch_refresh(false, &all_groups),
+    );
+    assert!(!update_args(&["--patches"]).can_delegate_patch_refresh(true, &all_groups));
+    assert!(!update_args(&["--patches"]).can_delegate_patch_refresh(false, &prod_only));
 }

--- a/pnpm/crates/cli/src/cli_args/update/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/update/tests.rs
@@ -159,3 +159,10 @@ fn patches_is_a_selectorless_update_mode() {
         );
     }
 }
+
+#[test]
+fn patch_refresh_with_a_depth_limit_stays_on_the_client() {
+    assert!(update_args(&["--patches"]).can_delegate_patch_refresh(false));
+    assert!(!update_args(&["--patches", "--depth", "0"]).can_delegate_patch_refresh(false));
+    assert!(!update_args(&["--patches"]).can_delegate_patch_refresh(true));
+}

--- a/pnpm/crates/cli/src/cli_args/update/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/update/tests.rs
@@ -131,6 +131,15 @@ fn ignore_pnpmfile_flag_applies_to_config() {
 }
 
 #[test]
+fn pnpr_server_flag_applies_to_config() {
+    let mut config = Config::default();
+
+    update_args(&["--pnpr-server", "https://pnpr.example.test/"]).apply_cli_config(&mut config);
+
+    assert_eq!(config.pnpr_server.as_deref(), Some("https://pnpr.example.test/"));
+}
+
+#[test]
 fn patches_is_a_selectorless_update_mode() {
     let patches = update_args(&["--patches"]);
     assert!(patches.patches);

--- a/pnpm/crates/cli/tests/suite/pnpr_install.rs
+++ b/pnpm/crates/cli/tests/suite/pnpr_install.rs
@@ -328,6 +328,81 @@ fn update_patches_refreshes_a_pnpr_revision_without_changing_the_version() {
 }
 
 #[test]
+fn update_patches_refreshes_a_revision_through_the_pnpr_resolver() {
+    let first_tarball = revision_fixture_tarball_with_value("revision one");
+    let second_tarball = revision_fixture_tarball_with_value("revision two");
+    let mut upstream = mockito::Server::new();
+    let (first_integrity, first_packument) = revision_packument(&upstream, &first_tarball, 1, &[]);
+    let first_path = integrity_addressed_tarball_path(&first_integrity).unwrap();
+    let first_packument_mock = upstream
+        .mock("GET", "/revision-pkg")
+        .with_body(first_packument.to_string())
+        .expect_at_least(1)
+        .create();
+    let first_tarball_mock = upstream
+        .mock("GET", format!("/{first_path}").as_str())
+        .with_body(&first_tarball)
+        .expect(1)
+        .create();
+    let (pnpr_url, token) = start_pnpr(&upstream.url());
+
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { npmrc_path, mock_instance, .. } = npmrc_info;
+    configure_pnpr_auth(&npmrc_path, &pnpr_url, &token);
+    let manifest = serde_json::json!({ "dependencies": { "revision-pkg": "^1.0.0" } });
+    fs::write(workspace.join("package.json"), manifest.to_string()).expect("write package.json");
+
+    pacquet
+        .with_env("PNPM_CONFIG_REGISTRY", upstream.url())
+        .with_args(["install", "--pnpr-server", &pnpr_url])
+        .assert()
+        .success();
+    first_packument_mock.assert();
+    first_tarball_mock.assert();
+    first_packument_mock.remove();
+
+    let (second_integrity, second_packument) =
+        revision_packument(&upstream, &second_tarball, 2, &[(&first_integrity, 1)]);
+    let second_path = integrity_addressed_tarball_path(&second_integrity).unwrap();
+    let second_packument_mock = upstream
+        .mock("GET", "/revision-pkg")
+        .with_body(second_packument.to_string())
+        .expect_at_least(1)
+        .create();
+    let second_tarball_mock = upstream
+        .mock("GET", format!("/{second_path}").as_str())
+        .with_body(&second_tarball)
+        .expect(1)
+        .create();
+
+    pacquet_at(&workspace)
+        .with_env("PNPM_CONFIG_REGISTRY", upstream.url())
+        .with_args(["update", "--patches", "--pnpr-server", &pnpr_url])
+        .assert()
+        .success();
+
+    second_packument_mock.assert();
+    second_tarball_mock.assert();
+    let refreshed = fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read lockfile");
+    assert!(refreshed.contains("revision: 2"), "{refreshed}");
+    assert!(!refreshed.contains("revision: 1"), "{refreshed}");
+    assert!(refreshed.contains("revision-pkg@1.0.0"), "{refreshed}");
+    let saved_manifest: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(workspace.join("package.json")).expect("read package.json"),
+    )
+    .expect("parse package.json");
+    assert_eq!(saved_manifest, manifest);
+    assert_eq!(
+        fs::read_to_string(workspace.join("node_modules/revision-pkg/index.js"))
+            .expect("read installed source"),
+        "module.exports = 'revision two'\n",
+    );
+
+    drop((root, mock_instance));
+}
+
+#[test]
 fn install_via_pnpr_links_node_modules() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();

--- a/pnpm/crates/package-manager/src/lib.rs
+++ b/pnpm/crates/package-manager/src/lib.rs
@@ -86,7 +86,7 @@ pub(crate) const DIRECT_GROUPS: [pnpm_package_manifest::DependencyGroup; 3] = [
     pnpm_package_manifest::DependencyGroup::Optional,
 ];
 
-pub(crate) fn included_direct_groups(
+pub fn included_direct_groups(
     include_optional: bool,
 ) -> impl Iterator<Item = pnpm_package_manifest::DependencyGroup> {
     DIRECT_GROUPS.into_iter().filter(move |group| {

--- a/pnpm/crates/pnpr-client/src/lib.rs
+++ b/pnpm/crates/pnpr-client/src/lib.rs
@@ -98,6 +98,9 @@ pub struct ResolveOptions {
     /// `preferFrozenLockfile`. `Some(false)` forces the server to
     /// re-resolve; `None` lets it default to reuse.
     pub prefer_frozen_lockfile: Option<bool>,
+    /// Refresh registry artifacts while retaining every locked package
+    /// version.
+    pub update_patches: bool,
     /// `ignoreManifestCheck`: skip the manifest ↔ lockfile freshness
     /// comparison during the frozen resolve.
     pub ignore_manifest_check: bool,
@@ -154,6 +157,7 @@ pub struct ResolveProjectsOptions {
     pub lockfile: Option<Lockfile>,
     pub frozen_lockfile: bool,
     pub prefer_frozen_lockfile: Option<bool>,
+    pub update_patches: bool,
     pub ignore_manifest_check: bool,
     pub trust_lockfile: bool,
     /// See [`ResolveOptions::resolution_mode`].
@@ -191,6 +195,7 @@ impl From<ResolveOptions> for ResolveProjectsOptions {
             lockfile: opts.lockfile,
             frozen_lockfile: opts.frozen_lockfile,
             prefer_frozen_lockfile: opts.prefer_frozen_lockfile,
+            update_patches: opts.update_patches,
             ignore_manifest_check: opts.ignore_manifest_check,
             trust_lockfile: opts.trust_lockfile,
             resolution_mode: opts.resolution_mode,
@@ -500,6 +505,7 @@ impl PnprClient {
             "lockfile": opts.lockfile,
             "frozenLockfile": opts.frozen_lockfile,
             "preferFrozenLockfile": opts.prefer_frozen_lockfile,
+            "updatePatches": opts.update_patches,
             "ignoreManifestCheck": opts.ignore_manifest_check,
             "trustLockfile": opts.trust_lockfile,
             "resolutionMode": opts.resolution_mode,

--- a/pnpm/crates/pnpr-client/src/tests.rs
+++ b/pnpm/crates/pnpr-client/src/tests.rs
@@ -42,6 +42,7 @@ async fn the_resolve_request_carries_the_catalogs_and_the_whole_policy() {
             "trustPolicyExclude": ["legacy-pkg"],
             "trustPolicyIgnoreAfter": 43200,
             "trustLockfile": true,
+            "updatePatches": true,
         })))
         .with_header(PROJECT_TRANSFORMS_HEADER, PROJECT_TRANSFORMS_VERSION)
         .with_body(format!("{}\n", json!({ "type": "done", "lockfile": response_lockfile })))
@@ -168,6 +169,7 @@ fn resolve_projects_options() -> ResolveProjectsOptions {
         lockfile: None,
         frozen_lockfile: false,
         prefer_frozen_lockfile: None,
+        update_patches: true,
         ignore_manifest_check: false,
         trust_lockfile: true,
         resolution_mode: ResolutionMode::TimeBased,

--- a/pnpm/crates/pnpr-client/tests/integration.rs
+++ b/pnpm/crates/pnpr-client/tests/integration.rs
@@ -220,6 +220,7 @@ fn options(
         lockfile: None,
         frozen_lockfile: false,
         prefer_frozen_lockfile: None,
+        update_patches: false,
         ignore_manifest_check: false,
         trust_lockfile: false,
         resolution_mode: pnpm_config::ResolutionMode::default(),

--- a/pnpm/crates/resolving-npm-resolver/src/named_registry_resolver.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/named_registry_resolver.rs
@@ -264,7 +264,7 @@ impl<Cache: PackageMetaCache + 'static> NamedRegistryResolver<Cache> {
                 include_latest_tag: opts.update == UpdateBehavior::Latest,
                 dry_run: opts.dry_run,
                 optional,
-                update_checksums: opts.update_checksums,
+                update_checksums: opts.update_checksums || opts.update == UpdateBehavior::Patches,
                 trust_policy: opts.trust_policy,
                 package_version_guard: opts.package_version_guard.as_ref(),
             },

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -472,7 +472,7 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
                 include_latest_tag: opts.update == UpdateBehavior::Latest,
                 dry_run: opts.dry_run,
                 optional,
-                update_checksums: opts.update_checksums,
+                update_checksums: opts.update_checksums || opts.update == UpdateBehavior::Patches,
                 trust_policy: opts.trust_policy,
                 package_version_guard: opts.package_version_guard.as_ref(),
             },

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -1070,6 +1070,45 @@ async fn revision_refresh_does_not_replace_a_registry_resolution_with_a_workspac
 }
 
 #[tokio::test]
+async fn revision_refresh_revalidates_a_warm_packument_without_update_checksums() {
+    let mut server = mockito::Server::new_async().await;
+    let first_mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_body(PACKAGE_BODY)
+        .expect(1)
+        .create_async()
+        .await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("1.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+
+    resolver.resolve(&wanted, &ResolveOptions::default()).await.unwrap();
+    first_mock.assert_async().await;
+    first_mock.remove_async().await;
+
+    let refresh_mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_body(PACKAGE_BODY)
+        .expect(1)
+        .create_async()
+        .await;
+    let opts = ResolveOptions {
+        update: UpdateBehavior::Patches,
+        update_checksums: false,
+        ..ResolveOptions::default()
+    };
+    resolver.resolve(&wanted, &opts).await.unwrap();
+
+    refresh_mock.assert_async().await;
+}
+
+#[tokio::test]
 async fn workspace_shadows_registry_when_name_and_version_match() {
     let mut server = mockito::Server::new_async().await;
     let _mock = server

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -369,7 +369,7 @@ export async function mutateModules (
   // (pnpm remove), and complete-project revision refreshes. Mutations that
   // need other client-side update behavior still fall through to the normal
   // flow.
-  if (opts.pnprServer && canUsePnprForMutations(projects, opts.allProjects)) {
+  if (opts.pnprServer && canUsePnprForMutations(projects, opts)) {
     const pnprResult = await mutateModulesViaPnpr(projects, opts)
     if (pnprResult) {
       // This path materializes packages of its own, so it verifies the
@@ -2782,13 +2782,17 @@ function getProjectsWithTargetDirs<T extends { id: ProjectId }> (
  */
 function canUsePnprForMutations (
   projects: MutatedProject[],
-  allProjects: MutateModulesOptions['allProjects']
+  opts: Pick<MutateModulesOptions, 'allProjects' | 'depth'>
 ): boolean {
   if (projects.length === 0) return false
   const refreshesRevisions = projects.some(project =>
     (project.mutation === 'install' || project.mutation === 'installSome') && project.updatePatches === true
   )
   if (refreshesRevisions) {
+    if (opts.depth !== Infinity && projects.some(project =>
+      project.mutation !== 'uninstallSome' && project.update === true
+    )) return false
+    const { allProjects } = opts
     if (allProjects == null || projects.length !== allProjects.length) return false
     const mutatedRootDirs = new Set(projects.map(project => project.rootDir))
     if (!allProjects.every(project => mutatedRootDirs.has(project.rootDir))) return false

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -211,7 +211,7 @@ export async function install (
 
   // When a pnpr server is configured, use server-side resolution
   // instead of the normal resolution flow.
-  if (opts.pnprServer) {
+  if (opts.pnprServer && canUsePnprForInstall(opts)) {
     return installViaPnprServer(manifest, rootDir, opts)
   }
 
@@ -2782,15 +2782,16 @@ function getProjectsWithTargetDirs<T extends { id: ProjectId }> (
  */
 function canUsePnprForMutations (
   projects: MutatedProject[],
-  opts: Pick<MutateModulesOptions, 'allProjects' | 'depth'>
+  opts: Pick<MutateModulesOptions, 'allProjects' | 'depth' | 'includeDirect'>
 ): boolean {
   if (projects.length === 0) return false
   const refreshesRevisions = projects.some(project =>
     (project.mutation === 'install' || project.mutation === 'installSome') && project.updatePatches === true
   )
   if (refreshesRevisions) {
-    if (opts.depth !== Infinity && projects.some(project =>
-      project.mutation !== 'uninstallSome' && project.update === true
+    if (projects.some(project =>
+      project.mutation !== 'uninstallSome' &&
+      !canUsePnprForPatchRefresh(opts, project.update)
     )) return false
     const { allProjects } = opts
     if (allProjects == null || projects.length !== allProjects.length) return false
@@ -2809,6 +2810,26 @@ function canUsePnprForMutations (
     const m = p as InstallDepsMutation | InstallSomeDepsMutation
     return !m.update && !m.updateToLatest && m.updateMatching == null
   })
+}
+
+function canUsePnprForInstall (opts: Opts): boolean {
+  if (opts.updatePatches) {
+    return !opts.updateToLatest &&
+      opts.updateMatching == null &&
+      canUsePnprForPatchRefresh(opts, opts.update)
+  }
+  return !opts.update && !opts.updateToLatest && opts.updateMatching == null
+}
+
+function canUsePnprForPatchRefresh (
+  opts: Pick<InstallOptions, 'depth' | 'includeDirect'>,
+  update: boolean | undefined
+): boolean {
+  if (update !== true) return true
+  return opts.depth === Infinity &&
+    opts.includeDirect?.dependencies !== false &&
+    opts.includeDirect?.devDependencies !== false &&
+    opts.includeDirect?.optionalDependencies !== false
 }
 
 interface PnprNewDep {

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -211,7 +211,7 @@ export async function install (
 
   // When a pnpr server is configured, use server-side resolution
   // instead of the normal resolution flow.
-  if (opts.pnprServer && !opts.updatePatches) {
+  if (opts.pnprServer) {
     return installViaPnprServer(manifest, rootDir, opts)
   }
 
@@ -365,10 +365,11 @@ export async function mutateModules (
   const verifiedFileIntegrityBaseline = verifiedFileIntegritySnapshot()
 
   // When a pnpr server is configured, use server-side resolution. The pnpr server
-  // path supports `install`, `installSome` (pnpm add), and `uninstallSome`
-  // (pnpm remove). Mutations that need full client-side resolution (update
-  // flags) still fall through to the normal flow.
-  if (opts.pnprServer && canUsePnprForMutations(projects)) {
+  // path supports `install`, `installSome` (pnpm add), `uninstallSome`
+  // (pnpm remove), and complete-project revision refreshes. Mutations that
+  // need other client-side update behavior still fall through to the normal
+  // flow.
+  if (opts.pnprServer && canUsePnprForMutations(projects, opts.allProjects)) {
     const pnprResult = await mutateModulesViaPnpr(projects, opts)
     if (pnprResult) {
       // This path materializes packages of its own, so it verifies the
@@ -2775,17 +2776,34 @@ function getProjectsWithTargetDirs<T extends { id: ProjectId }> (
 /**
  * Whether the pnpr server path can handle this batch of mutations. The pnpr server flow
  * supports installing the manifest as-is (`install`), adding new deps
- * (`installSome`), and removing deps (`uninstallSome`). It cannot model the
- * client-side update-flag behavior (`update`/`updateMatching`/`updateToLatest`)
- * yet, so those still go through the normal client-side resolver.
+ * (`installSome`), removing deps (`uninstallSome`), and refreshing registry
+ * revisions for a complete project set. Other client-side update behavior
+ * (`update`/`updateMatching`/`updateToLatest`) still uses the local resolver.
  */
-function canUsePnprForMutations (projects: MutatedProject[]): boolean {
+function canUsePnprForMutations (
+  projects: MutatedProject[],
+  allProjects: MutateModulesOptions['allProjects']
+): boolean {
   if (projects.length === 0) return false
+  const refreshesRevisions = projects.some(project =>
+    (project.mutation === 'install' || project.mutation === 'installSome') && project.updatePatches === true
+  )
+  if (refreshesRevisions) {
+    if (allProjects == null || projects.length !== allProjects.length) return false
+    const mutatedRootDirs = new Set(projects.map(project => project.rootDir))
+    if (!allProjects.every(project => mutatedRootDirs.has(project.rootDir))) return false
+    return projects.every(project =>
+      project.mutation === 'install' &&
+      project.updatePatches === true &&
+      !project.updateToLatest &&
+      project.updateMatching == null
+    )
+  }
   return projects.every((p) => {
     if (p.mutation === 'uninstallSome') return true
     if (p.mutation !== 'install' && p.mutation !== 'installSome') return false
     const m = p as InstallDepsMutation | InstallSomeDepsMutation
-    return !m.update && !m.updatePatches && !m.updateToLatest && m.updateMatching == null
+    return !m.update && !m.updateToLatest && m.updateMatching == null
   })
 }
 
@@ -2992,7 +3010,12 @@ async function mutateModulesViaPnpr (
   const result = await installViaPnprServer(
     pnprProjects[0].manifest,
     pnprProjects[0].rootDir,
-    opts,
+    {
+      ...opts,
+      updatePatches: projects.every(project =>
+        project.mutation === 'install' && project.updatePatches === true
+      ),
+    },
     pnprProjects.map((p) => ({ rootDir: p.rootDir, manifest: p.manifest }))
   )
 
@@ -3127,6 +3150,7 @@ async function installViaPnprServer (
       // lockfile it promises to leave alone.
       frozenLockfile: opts.frozenLockfile === true || (opts.frozenLockfileIfExists === true && existingLockfile != null),
       preferFrozenLockfile: opts.preferFrozenLockfile,
+      updatePatches: opts.updatePatches,
       lockfile: existingLockfile ?? undefined,
     })
 

--- a/pnpm11/installing/deps-installer/test/install/pnprWorkspaceMetadata.ts
+++ b/pnpm11/installing/deps-installer/test/install/pnprWorkspaceMetadata.ts
@@ -235,7 +235,7 @@ test('pnpr runs under trustPolicy instead of refusing the install', async () => 
   expect(resolveViaPnprServer).toHaveBeenCalledTimes(1)
 })
 
-test('updatePatches uses client-side resolution instead of silently delegating to pnpr', async () => {
+test('updatePatches is delegated to pnpr', async () => {
   const workspaceRoot = prepareEmpty().dir()
   const rootDir = workspaceRoot as ProjectRootDir
   const manifest: ProjectManifest = { name: 'app', version: '1.2.3' }
@@ -243,15 +243,36 @@ test('updatePatches uses client-side resolution instead of silently delegating t
 
   await install(manifest, { ...options, updatePatches: true })
 
-  expect(resolveViaPnprServer).not.toHaveBeenCalled()
+  expect(resolveViaPnprServer).toHaveBeenCalledWith(expect.objectContaining({
+    updatePatches: true,
+  }))
 })
 
-test('an updatePatches mutation uses client-side resolution instead of silently delegating to pnpr', async () => {
+test('a complete updatePatches mutation is delegated to pnpr', async () => {
   const workspaceRoot = prepareEmpty().dir()
   const rootDir = workspaceRoot as ProjectRootDir
   const manifest: ProjectManifest = { name: 'app', version: '1.2.3' }
   const options = createOptions(workspaceRoot, rootDir, {
     allProjects: [{ buildIndex: 0, manifest, rootDir }],
+  })
+
+  await mutateModules([{ mutation: 'install', rootDir, updatePatches: true }], options)
+
+  expect(resolveViaPnprServer).toHaveBeenCalledWith(expect.objectContaining({
+    updatePatches: true,
+  }))
+})
+
+test('a partial updatePatches mutation stays on the client', async () => {
+  const workspaceRoot = prepareEmpty().dir()
+  const rootDir = workspaceRoot as ProjectRootDir
+  const otherRootDir = path.join(workspaceRoot, 'other') as ProjectRootDir
+  const manifest: ProjectManifest = { name: 'app', version: '1.2.3' }
+  const options = createOptions(workspaceRoot, rootDir, {
+    allProjects: [
+      { buildIndex: 0, manifest, rootDir },
+      { buildIndex: 1, manifest: { name: 'other', version: '1.0.0' }, rootDir: otherRootDir },
+    ],
   })
 
   await mutateModules([{ mutation: 'install', rootDir, updatePatches: true }], options)

--- a/pnpm11/installing/deps-installer/test/install/pnprWorkspaceMetadata.ts
+++ b/pnpm11/installing/deps-installer/test/install/pnprWorkspaceMetadata.ts
@@ -263,6 +263,20 @@ test('a complete updatePatches mutation is delegated to pnpr', async () => {
   }))
 })
 
+test('an updatePatches mutation with a depth limit stays on the client', async () => {
+  const workspaceRoot = prepareEmpty().dir()
+  const rootDir = workspaceRoot as ProjectRootDir
+  const manifest: ProjectManifest = { name: 'app', version: '1.2.3' }
+  const options = createOptions(workspaceRoot, rootDir, {
+    allProjects: [{ buildIndex: 0, manifest, rootDir }],
+    depth: 0,
+  })
+
+  await mutateModules([{ mutation: 'install', rootDir, update: true, updatePatches: true }], options)
+
+  expect(resolveViaPnprServer).not.toHaveBeenCalled()
+})
+
 test('a partial updatePatches mutation stays on the client', async () => {
   const workspaceRoot = prepareEmpty().dir()
   const rootDir = workspaceRoot as ProjectRootDir

--- a/pnpm11/installing/deps-installer/test/install/pnprWorkspaceMetadata.ts
+++ b/pnpm11/installing/deps-installer/test/install/pnprWorkspaceMetadata.ts
@@ -241,7 +241,12 @@ test('updatePatches is delegated to pnpr', async () => {
   const manifest: ProjectManifest = { name: 'app', version: '1.2.3' }
   const options = createOptions(workspaceRoot, rootDir)
 
-  await install(manifest, { ...options, updatePatches: true })
+  await install(manifest, {
+    ...options,
+    depth: Infinity,
+    update: true,
+    updatePatches: true,
+  })
 
   expect(resolveViaPnprServer).toHaveBeenCalledWith(expect.objectContaining({
     updatePatches: true,
@@ -263,16 +268,43 @@ test('a complete updatePatches mutation is delegated to pnpr', async () => {
   }))
 })
 
-test('an updatePatches mutation with a depth limit stays on the client', async () => {
+test('an updatePatches install with a depth limit stays on the client', async () => {
+  const workspaceRoot = prepareEmpty().dir()
+  const rootDir = workspaceRoot as ProjectRootDir
+  const manifest: ProjectManifest = { name: 'app', version: '1.2.3' }
+  const options = createOptions(workspaceRoot, rootDir)
+
+  await install(manifest, { ...options, depth: 0, update: true, updatePatches: true })
+
+  expect(resolveViaPnprServer).not.toHaveBeenCalled()
+})
+
+test('an updatePatches mutation with filtered dependency groups stays on the client', async () => {
   const workspaceRoot = prepareEmpty().dir()
   const rootDir = workspaceRoot as ProjectRootDir
   const manifest: ProjectManifest = { name: 'app', version: '1.2.3' }
   const options = createOptions(workspaceRoot, rootDir, {
     allProjects: [{ buildIndex: 0, manifest, rootDir }],
-    depth: 0,
+    depth: Infinity,
+    includeDirect: {
+      dependencies: true,
+      devDependencies: false,
+      optionalDependencies: false,
+    },
   })
 
   await mutateModules([{ mutation: 'install', rootDir, update: true, updatePatches: true }], options)
+
+  expect(resolveViaPnprServer).not.toHaveBeenCalled()
+})
+
+test('unsupported direct update modes stay on the client', async () => {
+  const workspaceRoot = prepareEmpty().dir()
+  const rootDir = workspaceRoot as ProjectRootDir
+  const manifest: ProjectManifest = { name: 'app', version: '1.2.3' }
+  const options = createOptions(workspaceRoot, rootDir)
+
+  await install(manifest, { ...options, update: true })
 
   expect(resolveViaPnprServer).not.toHaveBeenCalled()
 })

--- a/pnpr/client/src/resolveViaPnprServer.ts
+++ b/pnpr/client/src/resolveViaPnprServer.ts
@@ -116,6 +116,8 @@ export interface ResolveViaPnprServerOptions {
    */
   frozenLockfile?: boolean
   preferFrozenLockfile?: boolean
+  /** Refresh registry artifacts while retaining every locked package version. */
+  updatePatches?: boolean
   /**
    * Existing lockfile for incremental resolution, in the on-disk format
    * the wire protocol carries. The caller reads it with
@@ -190,6 +192,7 @@ export async function resolveViaPnprServer (
     trustLockfile: opts.trustLockfile,
     frozenLockfile: opts.frozenLockfile,
     preferFrozenLockfile: opts.preferFrozenLockfile,
+    updatePatches: opts.updatePatches,
     // Sent as-is: `opts.lockfile` is already the on-disk format the wire
     // protocol carries (split `packages`/`snapshots`, `{ specifier, version }`
     // importer deps).

--- a/pnpr/client/test/resolveViaPnprServer.test.ts
+++ b/pnpr/client/test/resolveViaPnprServer.test.ts
@@ -11,6 +11,7 @@ interface CapturedResolveRequest {
   patchedDependencies?: Record<string, string>
   packageExtensions?: Record<string, unknown>
   allowUnusedPatches?: boolean
+  updatePatches?: boolean
 }
 
 const resolverSettingNames = ['autoInstallPeers', 'dedupePeers', 'excludeLinksFromLockfile'] as const
@@ -141,6 +142,18 @@ test.each([
     code: 'ERR_PNPM_PNPR_TRANSFORM_METADATA_MISMATCH',
     message: expect.stringContaining('returned packageExtensionsChecksum that does not match the request'),
   })
+})
+
+test.each([true, false])('serializes updatePatches %s', async (updatePatches) => {
+  const request = await captureResolveRequest({ dependencies: {}, updatePatches })
+
+  expect(request).toMatchObject({ updatePatches })
+})
+
+test('omits updatePatches when the caller has none', async () => {
+  const request = await captureResolveRequest({ dependencies: {} })
+
+  expect(Object.hasOwn(request, 'updatePatches')).toBe(false)
 })
 
 async function captureResolveRequest (

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -798,6 +798,12 @@ fn lru_resolution_candidate(
 }
 
 fn resolution_cache_key(config: &PacquetConfig, request: &ResolveRequest) -> Option<String> {
+    // A revision refresh is an explicit request for current upstream state.
+    // Serving or storing it in the whole-resolution cache would make the next
+    // refresh repeat an old registry selection until the cache TTL expires.
+    if request.update_patches {
+        return None;
+    }
     let projects: Vec<serde_json::Value> = request
         .projects_normalized()
         .into_iter()

--- a/pnpr/crates/pnpr/src/resolver/protocol.rs
+++ b/pnpr/crates/pnpr/src/resolver/protocol.rs
@@ -124,6 +124,10 @@ pub struct ResolveRequest {
     /// when the lockfile is up to date. `None` defaults to reuse.
     #[serde(default)]
     pub prefer_frozen_lockfile: Option<bool>,
+    /// Refresh registry artifacts while retaining every locked package
+    /// version. Omitted by older clients and false for ordinary resolves.
+    #[serde(default)]
+    pub update_patches: bool,
     /// `ignoreManifestCheck`: skip the manifest ↔ lockfile freshness
     /// comparison during the frozen resolve.
     #[serde(default)]

--- a/pnpr/crates/pnpr/src/resolver/resolve.rs
+++ b/pnpr/crates/pnpr/src/resolver/resolve.rs
@@ -200,17 +200,20 @@ pub async fn resolve(
             DependencyGroup::Optional,
         ],
         frozen_lockfile,
-        // Default to reuse so unchanged entries keep their pins; the
-        // client's `--no-prefer-frozen-lockfile` (`Some(false)`) forces
-        // a fresh re-resolve.
-        prefer_frozen_lockfile: request.prefer_frozen_lockfile.or(Some(true)),
+        // Default to reuse so unchanged entries keep their pins; a revision
+        // refresh always re-resolves the pinned registry versions.
+        prefer_frozen_lockfile: if request.update_patches {
+            Some(false)
+        } else {
+            request.prefer_frozen_lockfile.or(Some(true))
+        },
         ignore_manifest_check: request.ignore_manifest_check,
         skip_runtimes: false,
         // The lockfile was already verified under the client's policy
         // (in `handle_resolve`) before we get here, so the install path
         // must not re-verify it.
         trust_lockfile: true,
-        update_checksums: false,
+        update_checksums: request.update_patches,
         mutation: ProjectMutation::InstallWorkspace,
         installs_only: true,
         supported_architectures: None,
@@ -218,7 +221,11 @@ pub async fn resolve(
         lockfile_only: true,
         dry_run: false,
         persist_policy_excludes: false,
-        update_seed_policy: pnpm_package_manager::UpdateSeedPolicy::KeepAll,
+        update_seed_policy: if request.update_patches {
+            pnpm_package_manager::UpdateSeedPolicy::RefreshRevisions
+        } else {
+            pnpm_package_manager::UpdateSeedPolicy::KeepAll
+        },
         preferred_versions_override: None,
         // Resolve as the caller (forwarded credentials) without baking
         // per-user auth into the interned `&'static Config`.
@@ -253,7 +260,10 @@ pub async fn resolve(
 /// checks prove the server's lockfile-only resolve would return it
 /// unchanged.
 pub fn fresh_frozen_input_lockfile(config: &Config, request: &ResolveRequest) -> Option<Lockfile> {
-    if !request.frozen_lockfile || request.prefer_frozen_lockfile == Some(false) {
+    if request.update_patches
+        || !request.frozen_lockfile
+        || request.prefer_frozen_lockfile == Some(false)
+    {
         return None;
     }
     if request.overrides.as_ref().is_some_and(|value| match value {

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -327,6 +327,35 @@ fn resolution_cache_key_changes_with_project_transforms() {
 }
 
 #[test]
+fn revision_refresh_bypasses_the_resolution_cache() {
+    let ordinary = ResolveRequest {
+        dependencies: Some(deps(&[("foo", "1.0.0")])),
+        ..ResolveRequest::default()
+    };
+    let refresh = ResolveRequest {
+        dependencies: ordinary.dependencies.clone(),
+        update_patches: true,
+        ..ResolveRequest::default()
+    };
+
+    assert!(resolution_cache_key(&config(), &ordinary).is_some());
+    assert!(resolution_cache_key(&config(), &refresh).is_none());
+}
+
+#[test]
+fn update_patches_defaults_to_false_for_older_clients() {
+    let request = serde_json::from_value::<ResolveRequest>(serde_json::json!({}))
+        .expect("legacy request parses");
+    let refresh = serde_json::from_value::<ResolveRequest>(serde_json::json!({
+        "updatePatches": true
+    }))
+    .expect("refresh request parses");
+
+    assert!(!request.update_patches);
+    assert!(refresh.update_patches);
+}
+
+#[test]
 fn resolution_cache_key_hashes_input_lockfile_stably() {
     let first_lockfile: Lockfile = serde_saphyr::from_str(
         "lockfileVersion: '9.0'


### PR DESCRIPTION
## Summary

- Forward revision-refresh intent through the TypeScript and Rust pnpr clients so `pnpm update --patches` can use a configured pnpr resolver.
- Resolve against the client's existing `registry` and `registries` declarations while retaining locked versions.
- Bypass pnpr's whole-resolution cache and force registry metadata revalidation for every explicit refresh.
- Reuse the Rust CLI's pnpr workspace merge, prefetch, and frozen-materialization path; keep partial TypeScript workspace refreshes on the local resolver.
- Add protocol, delegation, cache, resolver, CLI-option, and end-to-end coverage, including replacement of installed revision content.

Follow-up to https://github.com/pnpm/pnpm/pull/14175 and related to https://github.com/pnpm/rfcs/pull/19.

## Squash Commit Body

```text
Allow revision-only updates to delegate dependency resolution to pnpr.

Carry updatePatches across both pnpr clients and map it server-side to pacquet's RefreshRevisions seed policy. Explicit refreshes bypass frozen reuse and pnpr's whole-resolution cache, while the registry resolver revalidates metadata even when its in-memory or disk cache is warm.

Route both pnpm implementations through their existing pnpr install and materialization paths. The Rust update command accepts --pnpr-server, and partial TypeScript workspace refreshes continue locally so unselected importers are not refreshed.

Follow-up to https://github.com/pnpm/pnpm/pull/14175.
Related to https://github.com/pnpm/rfcs/pull/19.
```

## Checklist

- [x] I checked the referenced RFC and previous PR and verified that neither already implements pnpr-side revision refreshes.
- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port.
- [x] Added a changeset covering the affected TypeScript packages, `pnpm`, `pacquet`, and `@pnpm/pnpr`.
- [x] Added or updated tests.
- [x] Updated the Rust CLI help for the new update-command option; no standalone documentation change is needed.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790295787&installation_model_id=426870&pr_number=14180&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14180&signature=8e4598f59d89e8d55db080b5aecb0a087981df6e83804a5e8f6e96c4bb82d767"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for refreshing registry package revisions with `pnpm update --patches` through a configured pnpr server.
  - Package versions remain locked while newer revisions, checksums, and artifacts are retrieved.
  - Supports regular projects and complete workspace updates.
  - Preserves and validates patch and package-extension metadata during resolution.

- **Bug Fixes**
  - Patch updates now bypass stale resolution data and revalidate cached package metadata.
  - Partial workspace updates and unsupported configurations continue using local resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->