### PR TITLE
fix(deploy): support linked workspace packages

### DIFF
--- a/.changeset/deploy-linked-workspaces.md
+++ b/.changeset/deploy-linked-workspaces.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/releasing.commands": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+`pnpm deploy` now creates its dedicated lockfile from linked workspace dependencies when `injectWorkspacePackages` is disabled. Docker builds can use native, frozen-lockfile deploys without changing how workspace packages are linked during local installs or enabling the legacy deploy implementation.

--- a/.changeset/deploy-linked-workspaces.md
+++ b/.changeset/deploy-linked-workspaces.md
@@ -4,4 +4,4 @@
 "pacquet": patch
 ---
 
-`pnpm deploy` can create self-contained deployments from linked workspace dependencies when `injectWorkspacePackages` is disabled.
+`pnpm deploy` now supports workspaces that keep `injectWorkspacePackages` disabled. Instead of failing with `ERR_PNPM_DEPLOY_NONINJECTED_WORKSPACE`, the deploy lockfile rewrites the linked workspace dependencies to `file:` dependencies that are materialized inside the deploy directory [#9386](https://github.com/pnpm/pnpm/issues/9386).

--- a/.changeset/deploy-linked-workspaces.md
+++ b/.changeset/deploy-linked-workspaces.md
@@ -4,4 +4,4 @@
 "pacquet": patch
 ---
 
-`pnpm deploy` now creates its dedicated lockfile from linked workspace dependencies when `injectWorkspacePackages` is disabled. Docker builds can use native, frozen-lockfile deploys without changing how workspace packages are linked during local installs or enabling the legacy deploy implementation.
+`pnpm deploy` can create self-contained deployments from linked workspace dependencies when `injectWorkspacePackages` is disabled.

--- a/pnpm/crates/cli/src/cli_args/deploy.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy.rs
@@ -87,17 +87,6 @@ enum DeployError {
     #[diagnostic(code(ERR_PNPM_INVALID_DEPLOY_TARGET))]
     UnsafeDeployTarget { deploy_dir: PathBuf, reason: &'static str },
 
-    #[display(
-        r#"By default, starting from pnpm v10, we only deploy from workspaces that have "inject-workspace-packages=true" set"#
-    )]
-    #[diagnostic(
-        code(ERR_PNPM_DEPLOY_NONINJECTED_WORKSPACE),
-        help(
-            r#"If you want to deploy without using injected dependencies, run "pnpm deploy" with the "--legacy" flag or set "force-legacy-deploy" to true"#
-        )
-    )]
-    NonInjectedWorkspace,
-
     #[display("The selected project is missing from pnpm-lock.yaml: {project_id}")]
     #[diagnostic(code(ERR_PNPM_CANNOT_DEPLOY))]
     MissingImporter { project_id: String },
@@ -170,10 +159,6 @@ impl DeployArgs {
         }
 
         let force_legacy = self.legacy || config.force_legacy_deploy;
-        if config.shares_one_lockfile() && !force_legacy && !config.inject_workspace_packages {
-            return Err(DeployError::NonInjectedWorkspace.into());
-        }
-
         let deploy_dir = resolve_target_dir(dir, &self.target_dirs[0]);
         // Deploy's `--force` (declared on the flattened `InstallArgs`)
         // does double duty: besides the install-side force semantics it
@@ -230,9 +215,6 @@ impl DeployArgs {
         selected: &SelectedProject,
         deploy_dir: &Path,
     ) -> miette::Result<SharedDeployOutcome> {
-        if !config.inject_workspace_packages {
-            return Err(DeployError::NonInjectedWorkspace.into());
-        }
         // The shared lockfile, and the importer ids naming the projects in
         // it, belong to the lockfile dir — which `lockfileDir` can move
         // away from the workspace this deploy selected its project from.

--- a/pnpm/crates/cli/tests/suite/deploy.rs
+++ b/pnpm/crates/cli/tests/suite/deploy.rs
@@ -476,22 +476,30 @@ fn deploy_refuses_non_empty_target_without_force() {
 }
 
 #[test]
-fn shared_lockfile_deploy_refuses_non_injected_workspace_before_target_mutation() {
+fn shared_lockfile_deploy_supports_non_injected_workspace() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();
     let AddMockedRegistry { mock_instance, .. } = npmrc_info;
     write_workspace(&workspace, false);
 
-    let output = pacquet
-        .with_args(["--filter", "app", "deploy", "deploy"])
-        .output()
-        .expect("run pacquet deploy");
-    assert!(!output.status.success());
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("inject-workspace-packages=true"), "unexpected stderr:\n{stderr}");
+    pacquet.with_arg("install").assert().success();
+    let deploy_dir = root.path().join("deploy");
+    pacquet_cmd(&workspace)
+        .with_args(["--filter", "app", "deploy", "--prod"])
+        .with_arg(&deploy_dir)
+        .assert()
+        .success();
+
     assert!(
-        !workspace.join("deploy").exists(),
-        "non-injected shared-lockfile deploy must fail before creating the target",
+        is_symlink_or_junction(&deploy_dir.join("node_modules/lib")).unwrap(),
+        "the linked workspace dependency should be materialized in the deploy directory",
+    );
+
+    fs::remove_dir_all(deploy_dir.join("node_modules")).unwrap();
+    pacquet_cmd(&deploy_dir).with_args(["install", "--frozen-lockfile"]).assert().success();
+    assert!(
+        deploy_dir.join("node_modules/lib/index.js").is_file(),
+        "the dedicated deploy lockfile should restore the workspace dependency on frozen reinstall",
     );
 
     drop((root, mock_instance));

--- a/pnpm/crates/cli/tests/suite/deploy.rs
+++ b/pnpm/crates/cli/tests/suite/deploy.rs
@@ -2,7 +2,7 @@ use crate::_utils::append_workspace_yaml_key;
 
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
-use pnpm_lockfile::Lockfile;
+use pnpm_lockfile::{Lockfile, PkgName};
 use pnpm_testing_utils::{
     bin::{AddMockedRegistry, CommandTempCwd},
     fs::is_symlink_or_junction,
@@ -490,16 +490,30 @@ fn shared_lockfile_deploy_supports_non_injected_workspace() {
         .assert()
         .success();
 
+    let lib_link = deploy_dir.join("node_modules/lib");
     assert!(
-        is_symlink_or_junction(&deploy_dir.join("node_modules/lib")).unwrap(),
+        is_symlink_or_junction(&lib_link).unwrap(),
         "the linked workspace dependency should be materialized in the deploy directory",
     );
 
-    fs::remove_dir_all(deploy_dir.join("node_modules")).unwrap();
-    pacquet_cmd(&deploy_dir).with_args(["install", "--frozen-lockfile"]).assert().success();
+    let deploy_lockfile = Lockfile::load_wanted_from_dir(&deploy_dir).unwrap().unwrap();
+    let importer = deploy_lockfile.importers.get(Lockfile::ROOT_IMPORTER_KEY).unwrap();
+    let dependencies = importer.dependencies.as_ref().expect("deploy importer dependencies");
+    let lib_name: PkgName = "lib".parse().unwrap();
+    let lib_version =
+        dependencies.get(&lib_name).expect("deployed lib dependency").version.to_string();
     assert!(
-        deploy_dir.join("node_modules/lib/index.js").is_file(),
-        "the dedicated deploy lockfile should restore the workspace dependency on frozen reinstall",
+        lib_version.starts_with("lib@file:"),
+        "the dedicated deploy lockfile should rewrite the linked workspace dependency: {lib_version}",
+    );
+
+    let deploy_dir_real = fs::canonicalize(&deploy_dir).unwrap();
+    let lib_real = fs::canonicalize(&lib_link).unwrap();
+    assert!(
+        lib_real.starts_with(&deploy_dir_real),
+        "the deployed workspace dependency should stay inside {}: {}",
+        deploy_dir_real.display(),
+        lib_real.display(),
     );
 
     drop((root, mock_instance));

--- a/pnpm/crates/cli/tests/suite/deploy.rs
+++ b/pnpm/crates/cli/tests/suite/deploy.rs
@@ -502,7 +502,13 @@ fn shared_lockfile_deploy_supports_non_injected_workspace() {
     );
 
     pacquet.with_arg("install").assert().success();
-    let deploy_dir = root.path().join("deploy");
+    // The deployed lockfile stores the workspace sources as paths relative to
+    // the target this deploy is handed, while the reinstall below resolves
+    // them from the target's canonical path. Deploy to the canonical path so
+    // the two agree: a target reached through a symlink that changes the
+    // path's depth resolves those entries somewhere else entirely, which is
+    // its own defect and not what this test is about.
+    let deploy_dir = fs::canonicalize(root.path()).unwrap().join("deploy");
     pacquet_cmd(&workspace)
         .with_args(["--filter", "app", "deploy", "--prod"])
         .with_arg(&deploy_dir)
@@ -526,12 +532,11 @@ fn shared_lockfile_deploy_supports_non_injected_workspace() {
         "the dedicated deploy lockfile should rewrite the linked workspace dependency: {lib_version}",
     );
 
-    let deploy_dir_real = fs::canonicalize(&deploy_dir).unwrap();
     let lib_real = fs::canonicalize(&lib_link).unwrap();
     assert!(
-        lib_real.starts_with(&deploy_dir_real),
+        lib_real.starts_with(&deploy_dir),
         "the deployed workspace dependency should stay inside {}: {}",
-        deploy_dir_real.display(),
+        deploy_dir.display(),
         lib_real.display(),
     );
 
@@ -539,9 +544,9 @@ fn shared_lockfile_deploy_supports_non_injected_workspace() {
     assert!(lib_modules.join("@pnpm.e2e/foo").exists());
     let nested_real = fs::canonicalize(lib_modules.join("nested")).unwrap();
     assert!(
-        nested_real.starts_with(&deploy_dir_real),
+        nested_real.starts_with(&deploy_dir),
         "a transitively linked workspace dependency should stay inside {}: {}",
-        deploy_dir_real.display(),
+        deploy_dir.display(),
         nested_real.display(),
     );
 

--- a/pnpm/crates/cli/tests/suite/deploy.rs
+++ b/pnpm/crates/cli/tests/suite/deploy.rs
@@ -479,8 +479,27 @@ fn deploy_refuses_non_empty_target_without_force() {
 fn shared_lockfile_deploy_supports_non_injected_workspace() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();
-    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    let AddMockedRegistry { npmrc_path, mock_instance, .. } = npmrc_info;
     write_workspace(&workspace, false);
+    write_project(
+        &workspace,
+        "lib",
+        &serde_json::json!({
+            "name": "lib",
+            "version": "1.0.0",
+            "files": ["index.js"],
+            "dependencies": { "nested": "workspace:*", "@pnpm.e2e/foo": "100.0.0" },
+        }),
+    );
+    write_project(
+        &workspace,
+        "nested",
+        &serde_json::json!({
+            "name": "nested",
+            "version": "1.0.0",
+            "files": ["index.js"],
+        }),
+    );
 
     pacquet.with_arg("install").assert().success();
     let deploy_dir = root.path().join("deploy");
@@ -514,6 +533,26 @@ fn shared_lockfile_deploy_supports_non_injected_workspace() {
         "the deployed workspace dependency should stay inside {}: {}",
         deploy_dir_real.display(),
         lib_real.display(),
+    );
+
+    let lib_modules = lib_real.parent().expect("the deployed lib's node_modules");
+    assert!(lib_modules.join("@pnpm.e2e/foo").exists());
+    let nested_real = fs::canonicalize(lib_modules.join("nested")).unwrap();
+    assert!(
+        nested_real.starts_with(&deploy_dir_real),
+        "a transitively linked workspace dependency should stay inside {}: {}",
+        deploy_dir_real.display(),
+        nested_real.display(),
+    );
+
+    fs::copy(&npmrc_path, deploy_dir.join(".npmrc")).unwrap();
+    fs::remove_dir_all(deploy_dir.join("node_modules")).unwrap();
+    pacquet_cmd(&deploy_dir).with_args(["install", "--frozen-lockfile"]).assert().success();
+    assert!(deploy_dir.join("node_modules/lib/index.js").is_file());
+    let dangling = dangling_links(&deploy_dir.join("node_modules"));
+    assert!(
+        dangling.is_empty(),
+        "installing the deployed lockfile must not create dangling symlinks: {dangling:#?}",
     );
 
     drop((root, mock_instance));

--- a/pnpm11/releasing/commands/src/deploy/deploy.ts
+++ b/pnpm11/releasing/commands/src/deploy/deploy.ts
@@ -351,11 +351,6 @@ async function deployFromSharedLockfile (
   },
   deployDir: string
 ): Promise<string | undefined> {
-  if (!opts.injectWorkspacePackages) {
-    throw new PnpmError('DEPLOY_NONINJECTED_WORKSPACE', 'By default, starting from pnpm v10, we only deploy from workspaces that have "inject-workspace-packages=true" set', {
-      hint: 'If you want to deploy without using injected dependencies, run "pnpm deploy" with the "--legacy" flag or set "force-legacy-deploy" to true',
-    })
-  }
   const {
     allProjects,
     lockfileDir,

--- a/pnpm11/releasing/commands/test/deploy/deploy.test.ts
+++ b/pnpm11/releasing/commands/test/deploy/deploy.test.ts
@@ -165,6 +165,62 @@ test('legacy deploy injects workspace dependencies that the shared lockfile link
   )
 })
 
+test('native deploy creates a dedicated lockfile from linked workspace dependencies', async () => {
+  preparePackages([
+    {
+      location: '.',
+      package: {
+        name: 'root',
+        version: '1.0.0',
+        private: true,
+      },
+    },
+    {
+      name: 'project-1',
+      version: '1.0.0',
+      dependencies: {
+        'project-2': 'workspace:*',
+      },
+    },
+    {
+      name: 'project-2',
+      version: '1.0.0',
+    },
+  ])
+
+  const { allProjects, selectedProjectsGraph } = await filterProjectsBySelectorObjectsFromDir(process.cwd(), [{ namePattern: 'project-1' }])
+
+  await install.handler({
+    ...DEFAULT_OPTS,
+    allProjects,
+    dir: process.cwd(),
+    injectWorkspacePackages: false,
+    lockfileDir: process.cwd(),
+    sharedWorkspaceLockfile: true,
+    workspaceDir: process.cwd(),
+  })
+  expect(assertProject(process.cwd()).readLockfile().importers['project-1'].dependencies!['project-2'].version).toBe('link:../project-2')
+
+  await deploy.handler({
+    ...DEFAULT_OPTS,
+    allProjects,
+    dir: process.cwd(),
+    injectWorkspacePackages: false,
+    production: true,
+    recursive: true,
+    selectedProjectsGraph,
+    sharedWorkspaceLockfile: true,
+    lockfileDir: process.cwd(),
+    workspaceDir: process.cwd(),
+  }, ['deploy'])
+
+  const deployDir = path.resolve('deploy')
+  expect(assertProject(deployDir).readLockfile().importers['.'].dependencies!['project-2'].version).toMatch(/^project-2@file:/)
+  const deployedDependencyDir = fs.realpathSync(path.join(deployDir, 'node_modules/project-2'))
+  expect(deployedDependencyDir.startsWith(`${path.join(deployDir, 'node_modules/.pnpm')}${path.sep}`)).toBeTruthy()
+  expect(deployedDependencyDir.endsWith(path.join('node_modules', 'project-2'))).toBeTruthy()
+})
+
 test('deploy in workspace with shared-workspace-lockfile=false', async () => {
   preparePackages([
     {

--- a/pnpm11/releasing/commands/test/deploy/deploy.test.ts
+++ b/pnpm11/releasing/commands/test/deploy/deploy.test.ts
@@ -185,6 +185,14 @@ test('native deploy creates a dedicated lockfile from linked workspace dependenc
     {
       name: 'project-2',
       version: '1.0.0',
+      dependencies: {
+        'project-3': 'workspace:*',
+        'is-positive': '1.0.0',
+      },
+    },
+    {
+      name: 'project-3',
+      version: '1.0.0',
     },
   ])
 
@@ -215,10 +223,32 @@ test('native deploy creates a dedicated lockfile from linked workspace dependenc
   }, ['deploy'])
 
   const deployDir = path.resolve('deploy')
+  const virtualStoreDir = `${path.join(deployDir, 'node_modules/.pnpm')}${path.sep}`
   expect(assertProject(deployDir).readLockfile().importers['.'].dependencies!['project-2'].version).toMatch(/^project-2@file:/)
-  const deployedDependencyDir = fs.realpathSync(path.join(deployDir, 'node_modules/project-2'))
-  expect(deployedDependencyDir.startsWith(`${path.join(deployDir, 'node_modules/.pnpm')}${path.sep}`)).toBeTruthy()
-  expect(deployedDependencyDir.endsWith(path.join('node_modules', 'project-2'))).toBeTruthy()
+  expectDeployedWorkspaceDependencies()
+
+  fs.rmSync(path.join(deployDir, 'node_modules'), { recursive: true })
+  await install.handler({
+    ...DEFAULT_OPTS,
+    dir: deployDir,
+    frozenLockfile: true,
+    injectWorkspacePackages: false,
+    lockfileDir: deployDir,
+    production: true,
+    rootProjectManifestDir: deployDir,
+    rootProjectManifest: JSON.parse(fs.readFileSync(path.join(deployDir, 'package.json'), 'utf8')),
+  })
+  expectDeployedWorkspaceDependencies()
+
+  function expectDeployedWorkspaceDependencies (): void {
+    const deployedDependencyDir = fs.realpathSync(path.join(deployDir, 'node_modules/project-2'))
+    expect(deployedDependencyDir.startsWith(virtualStoreDir)).toBeTruthy()
+    expect(deployedDependencyDir.endsWith(path.join('node_modules', 'project-2'))).toBeTruthy()
+    const deployedDependencyModulesDir = path.dirname(deployedDependencyDir)
+    expect(fs.existsSync(path.join(deployedDependencyModulesDir, 'is-positive'))).toBeTruthy()
+    const deployedTransitiveDir = fs.realpathSync(path.join(deployedDependencyModulesDir, 'project-3'))
+    expect(deployedTransitiveDir.startsWith(virtualStoreDir)).toBeTruthy()
+  }
 })
 
 test('deploy in workspace with shared-workspace-lockfile=false', async () => {


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

<!-- Describe what this PR changes and why, for reviewers. Link any related
issues here (Closes pnpm/pnpm#123, Fixes pnpm/pnpm#456, or Related to
pnpm/pnpm#123 for a partial fix). -->

Related to pnpm/pnpm#9386 — this approach does not fix it; see the closing comment.

`pnpm deploy` creates a standalone copy of a workspace project and its production dependencies.

When `injectWorkspacePackages` is disabled, the workspace lockfile records dependencies between workspace packages as `link:` references.
Those references point back into the source workspace and cannot remain unchanged in a standalone deployment.

The native deploy lockfile converter already handles these references.
When native deploy creates the dedicated deploy lockfile, the converter changes both `link:` and `file:` workspace references into deployable `file:` dependencies.
Native deploy then materializes those dependencies inside the deployment directory.

Before this change, native deploy rejected shared workspace lockfiles when `injectWorkspacePackages` was disabled.
The command fails before the existing `link:` conversion can run.
Users must either enable workspace injection for the whole workspace or use legacy deploy.

This PR removes that early rejection from both the TypeScript CLI and the Rust CLI.
Native deploy can now use its existing conversion path for linked workspace dependencies.

Nothing changes in the source workspace.
Local installs can continue using `link:` references, while the dedicated deploy lockfile remains self-contained.
Docker builds can use native deploy without enabling workspace injection or legacy deploy.

The regression tests verify that:

- The source workspace lockfile contains a linked workspace dependency.
- Native deploy succeeds with `injectWorkspacePackages` disabled.
- The dedicated deploy lockfile contains a deployable `file:` dependency.
- The resolved workspace dependency stays inside the deployment directory.
- A workspace package reached only through another linked workspace package, and that package's own registry dependency, also stay inside the deployment directory.
- A frozen install of the dedicated deploy lockfile restores the linked workspace dependency and leaves no dangling symlinks.

### Validation

- The TypeScript deploy suite passed with 15 tests and one existing platform-specific skip.
- The updated Rust tests passed in the macOS and Ubuntu CI jobs.
- The relevant TypeScript compilation passed.
- Rust Clippy, documentation, Dylint, formatting, and spellcheck passed in CI.
- The pre-push TypeScript compile, build, lint, spellcheck, and metadata checks passed.
- The changeset spellcheck passed.

No Docker daemon was used for validation.
The tests invoke native deploy directly and verify that the deployed dependency stays inside the target directory.
This PR adds no Docker-specific behavior.

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
Native deploy creates a dedicated lockfile for the selected project.
The lockfile must not retain links that point back into the source workspace.

The deploy lockfile converter already handles both link: and file: workspace references.
It turns them into file dependencies that can be installed inside the deployment directory.

An early validation check rejected shared workspace lockfiles whenever injectWorkspacePackages was disabled.
The command therefore failed before the converter could process linked workspace dependencies.
Users had to enable workspace injection or use legacy deploy even though native deploy already supported the required conversion.

Remove the early validation check from both CLI implementations.
Keep local installation settings, dependency conversion, production pruning, frozen-lockfile behavior, and legacy deploy behavior unchanged.

Add matching TypeScript and Rust regression tests.
The tests start with a linked workspace dependency, run native deploy, and verify that the dedicated lockfile rewrites it to a file dependency and the resolved package remains inside the deployment directory.
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

Co-Authored with the help of GPT-5.6 SOL

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790341896&installation_model_id=426870&pr_number=14185&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14185&signature=dde9e68d10f6d12a9929b58e33282f316cc65752ae5d3c1c9510e6eb684944de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `pnpm deploy` now supports linked workspace dependencies when workspace package injection is disabled.
  * Deploy lockfiles rewrite linked workspace references as deployable `file:` dependencies.
  * Native deployments, including Docker builds, work without changing local workspace linking.
  * Linked dependencies remain self-contained within the deployment directory.
  * Deployments can be reinstalled from the generated frozen lockfile.

* **Tests**
  * Added regression coverage for native deployments using linked workspace dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

