### PR TITLE
feat(pnpr): backfill hosted revision indexes

### DIFF
--- a/.changeset/pnpr-hosted-revision-backfill.md
+++ b/.changeset/pnpr-hosted-revision-backfill.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/pnpr": minor
+---
+
+Added `pnpr backfill-revisions` to validate and index existing hosted artifacts for integrity-addressed tarball routes.

--- a/pnpr/crates/pnpr/src/lib.rs
+++ b/pnpr/crates/pnpr/src/lib.rs
@@ -16,6 +16,8 @@ mod policy;
 mod publish;
 mod registry;
 mod resolver;
+mod revision;
+mod revision_backfill;
 mod route;
 mod s3;
 mod search;
@@ -42,6 +44,7 @@ pub use policy::{AccessList, AccessToken, Identity, PackageRule, PackageRules};
 pub use registry::{
     ConcreteKind, PackagePattern, Registries, Registry, RegistryConfigError, Resolved,
 };
+pub use revision_backfill::{RevisionBackfillReport, backfill_hosted_revision_refs};
 pub use server::{
     router, router_with_auth, serve, serve_listener, try_router, try_router_with_auth,
 };

--- a/pnpr/crates/pnpr/src/main.rs
+++ b/pnpr/crates/pnpr/src/main.rs
@@ -1,11 +1,17 @@
-use clap::Parser;
-use pnpr::{Config, ConfigSource, LogConfig, LogFormat, RegistryError, default_cache_dir, serve};
+use clap::{Parser, Subcommand};
+use pnpr::{
+    Config, ConfigSource, HostedStoreConfig, LogConfig, LogFormat, RegistryError,
+    backfill_hosted_revision_refs, default_cache_dir, serve,
+};
 use std::{io::IsTerminal, net::SocketAddr, path::PathBuf, time::Duration};
 use tracing_subscriber::EnvFilter;
 
 #[derive(Debug, Parser)]
 #[command(name = "pnpr", version, about = "pnpm-compatible npm registry server")]
 struct Args {
+    #[command(subcommand)]
+    command: Option<Command>,
+
     /// Path to a verdaccio-shaped YAML config (storage, upstreams,
     /// packages, log). When omitted, the global `config.yaml` in
     /// pnpr's config dir (pnpm's config-dir rules, under `pnpr`) is
@@ -66,9 +72,20 @@ struct Args {
     disable_resolver: bool,
 }
 
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Index legacy hosted artifacts for integrity-addressed revision routes.
+    BackfillRevisions {
+        /// Verify and report candidates without changing the hosted store.
+        #[arg(long)]
+        dry_run: bool,
+    },
+}
+
 #[tokio::main]
 async fn main() -> miette::Result<()> {
     let args = Args::parse();
+    let command = args.command;
     let auto_path = Config::auto_config_path();
     // Pass the surface-disable flags into parsing so a CLI-disabled surface
     // skips its parse-time work too (e.g. strict upstream token resolution),
@@ -120,7 +137,35 @@ async fn main() -> miette::Result<()> {
     // enforced that at least one surface stays enabled.
     init_logging(&config.logs);
     log_config_source(&source);
-    serve(config).await.map_err(|err| redacted_report(&err))
+    match command {
+        None => serve(config).await.map_err(|err| redacted_report(&err)),
+        Some(Command::BackfillRevisions { dry_run }) => {
+            if !dry_run && matches!(&config.hosted_store, HostedStoreConfig::Fs) {
+                tracing::warn!("stop the pnpr writer while backfilling a filesystem hosted store");
+            }
+            let report = backfill_hosted_revision_refs(&config, dry_run)
+                .await
+                .map_err(|err| redacted_report(&err))?;
+            tracing::info!(
+                dry_run,
+                stores = report.stores_scanned,
+                packages = report.packages_scanned,
+                versions = report.versions_scanned,
+                indexed = report.indexed,
+                already_indexed = report.already_indexed,
+                skipped = report.skipped,
+                invalid = report.invalid,
+                "hosted revision backfill complete",
+            );
+            if report.invalid > 0 {
+                return Err(miette::miette!(
+                    "hosted revision backfill rejected {} invalid artifact(s)",
+                    report.invalid,
+                ));
+            }
+            Ok(())
+        }
+    }
 }
 
 fn redacted_report(err: &RegistryError) -> miette::Report {

--- a/pnpr/crates/pnpr/src/revision.rs
+++ b/pnpr/crates/pnpr/src/revision.rs
@@ -1,0 +1,99 @@
+use indexmap::IndexMap;
+use pnpm_crypto_hash::{create_hex_hash, integrity_addressed_tarball_path};
+use pnpm_lockfile::TarballRevision;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use ssri::Integrity;
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct HostedOriginalRef {
+    pub(crate) package: String,
+    pub(crate) version: String,
+}
+
+pub(crate) struct HostedOriginalReference {
+    pub(crate) digest: String,
+    pub(crate) ref_id: String,
+    pub(crate) bytes: Vec<u8>,
+}
+
+pub(crate) fn hosted_original_reference(
+    package: &str,
+    version: &str,
+    integrity: &Integrity,
+) -> Option<HostedOriginalReference> {
+    let path = integrity_addressed_tarball_path(integrity)?;
+    let digest = path.strip_prefix("-/tarballs/sha512/")?.to_string();
+    let record = HostedOriginalRef { package: package.to_string(), version: version.to_string() };
+    let bytes = serde_json::to_vec(&record).expect("hosted original reference serializes");
+    let ref_id = create_hex_hash(&format!("{}\0{}", record.package, record.version));
+    Some(HostedOriginalReference { digest, ref_id, bytes })
+}
+
+#[derive(Deserialize)]
+pub(crate) struct HostedRevisionPackument {
+    #[serde(default)]
+    pub(crate) versions: IndexMap<String, HostedRevisionManifest>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct HostedRevisionManifest {
+    #[serde(default)]
+    pub(crate) dist: Option<HostedRevisionDist>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct HostedRevisionDist {
+    #[serde(default)]
+    pub(crate) integrity: Option<String>,
+    #[serde(default)]
+    pub(crate) revision: RevisionField,
+    #[serde(default)]
+    pub(crate) revisions: Vec<HostedRevisionRecord>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct HostedRevisionRecord {
+    #[serde(default)]
+    pub(crate) revision: Value,
+    #[serde(default)]
+    pub(crate) integrity: Option<String>,
+}
+
+#[derive(Default)]
+pub(crate) enum RevisionField {
+    #[default]
+    Missing,
+    Present(Value),
+}
+
+impl<'de> Deserialize<'de> for RevisionField {
+    fn deserialize<Deserializer>(deserializer: Deserializer) -> Result<Self, Deserializer::Error>
+    where
+        Deserializer: serde::Deserializer<'de>,
+    {
+        <Value as Deserialize>::deserialize(deserializer).map(Self::Present)
+    }
+}
+
+pub(crate) fn original_integrity(dist: &HostedRevisionDist) -> Option<Integrity> {
+    let RevisionField::Present(revision) = &dist.revision else {
+        return dist.integrity.as_deref()?.parse().ok();
+    };
+    let selected_revision =
+        revision.as_u64().and_then(|revision| TarballRevision::try_from(revision).ok())?.get();
+    let selected: Vec<_> = dist
+        .revisions
+        .iter()
+        .filter(|record| record.revision.as_u64() == Some(selected_revision))
+        .collect();
+    if selected.len() != 1 || selected[0].integrity.as_deref() != dist.integrity.as_deref() {
+        return None;
+    }
+    let originals: Vec<_> =
+        dist.revisions.iter().filter(|record| record.revision.as_u64() == Some(0)).collect();
+    if originals.len() != 1 {
+        return None;
+    }
+    originals[0].integrity.as_deref()?.parse().ok()
+}

--- a/pnpr/crates/pnpr/src/revision_backfill.rs
+++ b/pnpr/crates/pnpr/src/revision_backfill.rs
@@ -1,0 +1,235 @@
+use crate::{
+    config::Config,
+    error::{RegistryError, Result},
+    package_name::PackageName,
+    revision::{
+        HostedRevisionDist, HostedRevisionPackument, RevisionField, hosted_original_reference,
+        original_integrity,
+    },
+    storage::{HostedRevisionRefWrite, Storage},
+    streaming::{self, MAX_TARBALL_BYTES},
+};
+use futures_util::StreamExt as _;
+use pnpm_crypto_hash::{create_hex_hash_bytes, integrity_addressed_tarball_path};
+use ssri::Integrity;
+use std::collections::BTreeSet;
+
+/// Summary of one hosted-revision backfill run.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct RevisionBackfillReport {
+    pub stores_scanned: usize,
+    pub packages_scanned: usize,
+    pub versions_scanned: usize,
+    pub indexed: usize,
+    pub already_indexed: usize,
+    pub skipped: usize,
+    pub invalid: usize,
+}
+
+/// Validate and index legacy hosted package artifacts for SHA-512 digest routes.
+///
+/// The scan is serial so its memory, file-handle, and object-store request use
+/// stays bounded independently of the size of the hosted repository. Existing
+/// references make the operation idempotent. In dry-run mode every candidate
+/// is still streamed and integrity-checked, but no index is changed. Stop the
+/// pnpr writer while changing a filesystem store; S3 writes use conditional
+/// updates and may run alongside the service.
+pub async fn backfill_hosted_revision_refs(
+    config: &Config,
+    dry_run: bool,
+) -> Result<RevisionBackfillReport> {
+    let storage =
+        Storage::new(&config.hosted_store, config.storage.clone(), config.cache_storage.clone());
+    let mut report = RevisionBackfillReport::default();
+    let mut scanned_orgs = BTreeSet::new();
+    let owner = backfill_owner();
+
+    for (registry, hosted) in &config.hosted {
+        if !scanned_orgs.insert(hosted.org.clone()) {
+            continue;
+        }
+        report.stores_scanned += 1;
+        let hosted_storage = storage.for_hosted(&hosted.org);
+        let packages = hosted_storage.hosted_package_names_for_backfill().await?;
+        for raw_name in packages {
+            report.packages_scanned += 1;
+            let package = match PackageName::parse(&raw_name) {
+                Ok(package) => package,
+                Err(err) => {
+                    report.invalid += 1;
+                    tracing::warn!(%registry, package = %raw_name, error = %err, "hosted revision backfill skipped an invalid package");
+                    continue;
+                }
+            };
+            let Some(bytes) = hosted_storage.read_hosted_packument(&package).await? else {
+                report.invalid += 1;
+                tracing::warn!(%registry, package = %raw_name, "hosted revision backfill found no packument after listing the package");
+                continue;
+            };
+            let packument = match serde_json::from_slice::<HostedRevisionPackument>(&bytes) {
+                Ok(packument) => packument,
+                Err(err) => {
+                    report.invalid += 1;
+                    tracing::warn!(%registry, package = %raw_name, error = %err, "hosted revision backfill skipped an invalid packument");
+                    continue;
+                }
+            };
+            for (version, manifest) in packument.versions {
+                report.versions_scanned += 1;
+                let Some(dist) = manifest.dist else {
+                    report.skipped += 1;
+                    continue;
+                };
+                let integrity = match eligible_original_integrity(&dist) {
+                    OriginalIntegrity::Eligible(integrity) => integrity,
+                    OriginalIntegrity::Unsupported => {
+                        report.skipped += 1;
+                        continue;
+                    }
+                    OriginalIntegrity::Invalid => {
+                        report.invalid += 1;
+                        tracing::warn!(%registry, package = %raw_name, %version, "hosted revision backfill rejected invalid revision metadata");
+                        continue;
+                    }
+                };
+                let reference = hosted_original_reference(package.as_str(), &version, &integrity)
+                    .expect("eligible integrity creates a hosted original reference");
+                let filename = package.tarball_name_for_version(&version);
+                if package.parse_tarball_name(&filename).is_err() {
+                    report.invalid += 1;
+                    tracing::warn!(%registry, package = %raw_name, %version, "hosted revision backfill rejected an invalid version path");
+                    continue;
+                }
+                match verify_hosted_tarball(&hosted_storage, &package, &filename, &integrity)
+                    .await?
+                {
+                    TarballValidation::Valid => {}
+                    TarballValidation::Missing => {
+                        report.invalid += 1;
+                        tracing::warn!(%registry, package = %raw_name, %version, %filename, "hosted revision backfill found no tarball for packument metadata");
+                        continue;
+                    }
+                    TarballValidation::Invalid(reason) => {
+                        report.invalid += 1;
+                        tracing::warn!(%registry, package = %raw_name, %version, %filename, %reason, "hosted revision backfill rejected a tarball");
+                        continue;
+                    }
+                }
+                if hosted_storage
+                    .read_hosted_revision_refs(&reference.digest)
+                    .await?
+                    .iter()
+                    .any(|existing| existing == &reference.bytes)
+                {
+                    report.already_indexed += 1;
+                    continue;
+                }
+                report.indexed += 1;
+                if dry_run {
+                    continue;
+                }
+                match hosted_storage
+                    .write_hosted_revision_ref(
+                        &reference.digest,
+                        &reference.ref_id,
+                        &owner,
+                        &reference.bytes,
+                    )
+                    .await?
+                {
+                    HostedRevisionRefWrite::Committed => {
+                        report.indexed -= 1;
+                        report.already_indexed += 1;
+                    }
+                    HostedRevisionRefWrite::Claimed | HostedRevisionRefWrite::AlreadyClaimed => {
+                        hosted_storage
+                            .commit_hosted_revision_ref(
+                                &reference.digest,
+                                &reference.ref_id,
+                                &owner,
+                            )
+                            .await?;
+                    }
+                }
+            }
+        }
+    }
+    Ok(report)
+}
+
+enum OriginalIntegrity {
+    Eligible(Integrity),
+    Unsupported,
+    Invalid,
+}
+
+fn eligible_original_integrity(dist: &HostedRevisionDist) -> OriginalIntegrity {
+    let integrity = match &dist.revision {
+        RevisionField::Missing => {
+            let Some(raw) = dist.integrity.as_deref() else {
+                return OriginalIntegrity::Unsupported;
+            };
+            match raw.parse() {
+                Ok(integrity) => integrity,
+                Err(_) => return OriginalIntegrity::Invalid,
+            }
+        }
+        RevisionField::Present(_) => match original_integrity(dist) {
+            Some(integrity) => integrity,
+            None => return OriginalIntegrity::Invalid,
+        },
+    };
+    if integrity_addressed_tarball_path(&integrity).is_none() {
+        return OriginalIntegrity::Unsupported;
+    }
+    OriginalIntegrity::Eligible(integrity)
+}
+
+enum TarballValidation {
+    Valid,
+    Missing,
+    Invalid(String),
+}
+
+async fn verify_hosted_tarball(
+    storage: &Storage,
+    package: &PackageName,
+    filename: &str,
+    integrity: &Integrity,
+) -> Result<TarballValidation> {
+    let Some((body, content_length)) = storage.open_hosted_tarball(package, filename).await? else {
+        return Ok(TarballValidation::Missing);
+    };
+    if content_length.is_some_and(|length| length > MAX_TARBALL_BYTES) {
+        return Ok(TarballValidation::Invalid(format!(
+            "tarball exceeds the {MAX_TARBALL_BYTES} byte limit",
+        )));
+    }
+    let mut checker = streaming::integrity_checker(integrity)
+        .map_err(|err| RegistryError::Internal { reason: err.to_string() })?;
+    let mut received = 0_u64;
+    let mut stream = body.into_data_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|err| RegistryError::Io(std::io::Error::other(err)))?;
+        received = received.saturating_add(chunk.len() as u64);
+        if received > MAX_TARBALL_BYTES {
+            return Ok(TarballValidation::Invalid(format!(
+                "tarball exceeds the {MAX_TARBALL_BYTES} byte limit",
+            )));
+        }
+        checker.input(&chunk);
+    }
+    match checker.result() {
+        Ok(_) => Ok(TarballValidation::Valid),
+        Err(err) => Ok(TarballValidation::Invalid(err.to_string())),
+    }
+}
+
+fn backfill_owner() -> String {
+    let mut random = [0_u8; 32];
+    getrandom::fill(&mut random).expect("OS CSPRNG must be available");
+    create_hex_hash_bytes(&random)
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpr/crates/pnpr/src/revision_backfill/tests.rs
+++ b/pnpr/crates/pnpr/src/revision_backfill/tests.rs
@@ -1,0 +1,169 @@
+use super::{RevisionBackfillReport, backfill_hosted_revision_refs};
+use crate::{
+    config::{Config, HostedStoreConfig},
+    package_name::PackageName,
+    storage::{Storage, TarballFinalize},
+};
+use object_store::memory::InMemory;
+use pnpm_crypto_hash::integrity_addressed_tarball_path;
+use serde_json::{Value, json};
+use ssri::{Algorithm, IntegrityOpts};
+use std::{net::SocketAddr, sync::Arc};
+use tempfile::TempDir;
+use tokio::fs;
+
+fn config_in(tmp: &TempDir) -> Config {
+    Config::static_serve(
+        "127.0.0.1:7677".parse::<SocketAddr>().unwrap(),
+        tmp.path().join("storage"),
+    )
+}
+
+fn sri(bytes: &[u8], algorithm: Algorithm) -> String {
+    let mut opts = IntegrityOpts::new().algorithm(algorithm);
+    opts.input(bytes);
+    opts.result().to_string()
+}
+
+async fn seed_version(config: &Config, package: &str, version: &str, dist: Value, tarball: &[u8]) {
+    let storage =
+        Storage::new(&config.hosted_store, config.storage.clone(), config.cache_storage.clone());
+    let package = PackageName::parse(package).unwrap();
+    let packument = serde_json::to_vec(&json!({
+        "name": package.as_str(),
+        "versions": {
+            (version): {
+                "name": package.as_str(),
+                "version": version,
+                "dist": dist,
+            }
+        }
+    }))
+    .unwrap();
+    storage.write_hosted_packument_if_current(&package, &packument, None).await.unwrap();
+    let filename = package.tarball_name_for_version(version);
+    let slot = storage.reserve_hosted_tarball(&package, &filename).await.unwrap();
+    fs::write(&slot.tmp_path, tarball).await.unwrap();
+    assert_eq!(storage.finalize_tarball_slot(slot).await.unwrap(), TarballFinalize::Written);
+}
+
+async fn indexed_refs(config: &Config, integrity: &str) -> Vec<Vec<u8>> {
+    let storage =
+        Storage::new(&config.hosted_store, config.storage.clone(), config.cache_storage.clone());
+    let integrity = integrity.parse().unwrap();
+    let path = integrity_addressed_tarball_path(&integrity).unwrap();
+    let digest = path.strip_prefix("-/tarballs/sha512/").unwrap();
+    storage.read_hosted_revision_refs(digest).await.unwrap()
+}
+
+fn one_indexed() -> RevisionBackfillReport {
+    RevisionBackfillReport {
+        stores_scanned: 1,
+        packages_scanned: 1,
+        versions_scanned: 1,
+        indexed: 1,
+        already_indexed: 0,
+        skipped: 0,
+        invalid: 0,
+    }
+}
+
+#[tokio::test]
+async fn dry_run_verifies_without_writing_and_backfill_is_idempotent() {
+    let tmp = TempDir::new().unwrap();
+    let config = config_in(&tmp);
+    let tarball = b"legacy hosted tarball";
+    let integrity = sri(tarball, Algorithm::Sha512);
+    seed_version(
+        &config,
+        "legacy",
+        "1.0.0",
+        json!({ "integrity": integrity, "tarball": "legacy-1.0.0.tgz" }),
+        tarball,
+    )
+    .await;
+
+    assert_eq!(backfill_hosted_revision_refs(&config, true).await.unwrap(), one_indexed());
+    assert!(indexed_refs(&config, &integrity).await.is_empty());
+    assert_eq!(backfill_hosted_revision_refs(&config, false).await.unwrap(), one_indexed());
+    assert_eq!(indexed_refs(&config, &integrity).await.len(), 1);
+
+    let mut rerun = one_indexed();
+    rerun.indexed = 0;
+    rerun.already_indexed = 1;
+    assert_eq!(backfill_hosted_revision_refs(&config, false).await.unwrap(), rerun);
+}
+
+#[tokio::test]
+async fn backfill_uses_revision_zero_after_a_replacement_is_selected() {
+    let tmp = TempDir::new().unwrap();
+    let config = config_in(&tmp);
+    let original_tarball = b"original hosted tarball";
+    let replacement_tarball = b"replacement tarball";
+    let original = sri(original_tarball, Algorithm::Sha512);
+    let replacement = sri(replacement_tarball, Algorithm::Sha512);
+    seed_version(
+        &config,
+        "patched",
+        "1.0.0",
+        json!({
+            "integrity": replacement,
+            "revision": 1,
+            "tarball": "-/tarballs/sha512/replacement",
+            "revisions": [
+                { "revision": 0, "integrity": original, "manifest": {} },
+                { "revision": 1, "integrity": replacement, "manifest": {} },
+            ],
+        }),
+        original_tarball,
+    )
+    .await;
+
+    assert_eq!(backfill_hosted_revision_refs(&config, false).await.unwrap(), one_indexed());
+    assert_eq!(indexed_refs(&config, &original).await.len(), 1);
+    assert!(indexed_refs(&config, &replacement).await.is_empty());
+}
+
+#[tokio::test]
+async fn backfill_rejects_mismatched_bytes_and_skips_non_sha512_metadata() {
+    let tmp = TempDir::new().unwrap();
+    let config = config_in(&tmp);
+    let expected = b"expected";
+    let integrity = sri(expected, Algorithm::Sha512);
+    seed_version(&config, "tampered", "1.0.0", json!({ "integrity": integrity }), b"different")
+        .await;
+
+    let report = backfill_hosted_revision_refs(&config, false).await.unwrap();
+    assert_eq!(report.invalid, 1);
+    assert_eq!(report.indexed, 0);
+    assert!(indexed_refs(&config, &integrity).await.is_empty());
+
+    let legacy_tmp = TempDir::new().unwrap();
+    let legacy_config = config_in(&legacy_tmp);
+    let tarball = b"sha1 only";
+    seed_version(
+        &legacy_config,
+        "sha1-only",
+        "1.0.0",
+        json!({ "integrity": sri(tarball, Algorithm::Sha1) }),
+        tarball,
+    )
+    .await;
+    let report = backfill_hosted_revision_refs(&legacy_config, false).await.unwrap();
+    assert_eq!(report.skipped, 1);
+    assert_eq!(report.invalid, 0);
+}
+
+#[tokio::test]
+async fn backfill_supports_the_s3_hosted_store() {
+    let tmp = TempDir::new().unwrap();
+    let mut config = config_in(&tmp);
+    config.hosted_store =
+        HostedStoreConfig::S3 { store: Arc::new(InMemory::new()), prefix: "tenant/".to_string() };
+    let tarball = b"legacy s3 tarball";
+    let integrity = sri(tarball, Algorithm::Sha512);
+    seed_version(&config, "legacy-s3", "1.0.0", json!({ "integrity": integrity }), tarball).await;
+
+    assert_eq!(backfill_hosted_revision_refs(&config, false).await.unwrap(), one_indexed());
+    assert_eq!(indexed_refs(&config, &integrity).await.len(), 1);
+}

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -10,6 +10,9 @@ use crate::{
         stream_decode_verify_and_write,
     },
     registry::{ConcreteKind, Registry, Resolved},
+    revision::{
+        HostedOriginalRef, HostedRevisionPackument, hosted_original_reference, original_integrity,
+    },
     storage::{
         HostedPackumentVersion, PACKUMENT_WRITE_RETRIES, PackumentUpdate, PackumentWrite, Storage,
         TarballFinalize,
@@ -36,10 +39,7 @@ use axum::{
 };
 use chrono::Utc;
 use indexmap::IndexMap;
-use pnpm_crypto_hash::{
-    create_hex_hash, integrity_addressed_tarball_integrity, integrity_addressed_tarball_path,
-};
-use pnpm_lockfile::TarballRevision;
+use pnpm_crypto_hash::{integrity_addressed_tarball_integrity, integrity_addressed_tarball_path};
 use serde_json::{Value, json};
 use ssri::Integrity;
 use std::{
@@ -66,17 +66,12 @@ use tracing::Span;
 /// long version histories.
 const ABBREVIATED_CONTENT_TYPE: &str = "application/vnd.npm.install-v1+json";
 
-/// Cap tarballs at 100 MiB while pnpr has to spool them to disk for SRI
-/// verification. This bounds per-request temporary disk usage for
-/// chunked or malicious upstream bodies.
-const MAX_TARBALL_BYTES: u64 = 100 * 1024 * 1024;
-
 /// Cap publish bodies at 100 MiB. The default axum body limit is
 /// 2 MiB, far too small for a real package — npm itself caps publish
 /// at 100 MiB and verdaccio inherits that limit. We apply it via
 /// [`DefaultBodyLimit::max`] on the router rather than on each
 /// route, so future write endpoints inherit the same ceiling.
-const MAX_PUBLISH_BODY_BYTES: usize = MAX_TARBALL_BYTES as usize;
+const MAX_PUBLISH_BODY_BYTES: usize = streaming::MAX_TARBALL_BYTES as usize;
 
 /// Cap adduser/login bodies far below the publish ceiling. The body is a
 /// small couchdb-user JSON document, and login is the one body-accepting
@@ -123,12 +118,6 @@ struct AppInner {
     /// Local OSV index, loaded before the server accepts requests when
     /// `osv.enabled` is set and a mounted surface consults it.
     osv_index: Option<Arc<crate::resolver::OsvIndex>>,
-}
-
-#[derive(serde::Serialize, serde::Deserialize)]
-struct HostedOriginalRef {
-    package: String,
-    version: String,
 }
 
 /// A fixed stripe set bounds lock memory while serializing writers for the
@@ -1878,7 +1867,7 @@ async fn serve_tarball_via_upstream(
             response,
             write,
             &integrity,
-            MAX_TARBALL_BYTES,
+            streaming::MAX_TARBALL_BYTES,
         )
         .await
         {
@@ -1893,7 +1882,12 @@ async fn serve_tarball_via_upstream(
     // `stream_verified_to_cache`). No `Content-Length` is set: the upstream's
     // is attacker-controlled and unverifiable before streaming, so the body is
     // chunked and the client reads to EOF (then re-verifies the integrity).
-    match streaming::stream_verified_to_cache(response, write, &integrity, MAX_TARBALL_BYTES) {
+    match streaming::stream_verified_to_cache(
+        response,
+        write,
+        &integrity,
+        streaming::MAX_TARBALL_BYTES,
+    ) {
         Ok(body) => tarball_response(body, None),
         Err(err) => error_response(&tarball_stream_error(err, &name, &filename)),
     }
@@ -1963,7 +1957,7 @@ async fn serve_upstream_revision_tarball(
             response,
             write,
             integrity,
-            MAX_TARBALL_BYTES,
+            streaming::MAX_TARBALL_BYTES,
         )
         .await
         {
@@ -1978,7 +1972,12 @@ async fn serve_upstream_revision_tarball(
             }
         };
     }
-    match streaming::stream_verified_to_cache(response, write, integrity, MAX_TARBALL_BYTES) {
+    match streaming::stream_verified_to_cache(
+        response,
+        write,
+        integrity,
+        streaming::MAX_TARBALL_BYTES,
+    ) {
         Ok(body) => revision_tarball_response(body, None, digest, integrity),
         Err(err) => {
             error_response(&tarball_stream_error_for_package(err, "registry revision", digest))
@@ -2128,74 +2127,6 @@ async fn open_hosted_revision_tarball(
         Ok(None) => not_found(),
         Err(err) => error_response(&err),
     }
-}
-
-#[derive(serde::Deserialize)]
-struct HostedRevisionPackument {
-    #[serde(default)]
-    versions: IndexMap<String, HostedRevisionManifest>,
-}
-
-#[derive(serde::Deserialize)]
-struct HostedRevisionManifest {
-    #[serde(default)]
-    dist: Option<HostedRevisionDist>,
-}
-
-#[derive(serde::Deserialize)]
-struct HostedRevisionDist {
-    #[serde(default)]
-    integrity: Option<String>,
-    #[serde(default)]
-    revision: RevisionField,
-    #[serde(default)]
-    revisions: Vec<HostedRevisionRecord>,
-}
-
-#[derive(serde::Deserialize)]
-struct HostedRevisionRecord {
-    #[serde(default)]
-    revision: Value,
-    #[serde(default)]
-    integrity: Option<String>,
-}
-
-#[derive(Default)]
-enum RevisionField {
-    #[default]
-    Missing,
-    Present(Value),
-}
-
-impl<'de> serde::Deserialize<'de> for RevisionField {
-    fn deserialize<Deserializer>(deserializer: Deserializer) -> Result<Self, Deserializer::Error>
-    where
-        Deserializer: serde::Deserializer<'de>,
-    {
-        <Value as serde::Deserialize>::deserialize(deserializer).map(Self::Present)
-    }
-}
-
-fn original_integrity(dist: &HostedRevisionDist) -> Option<Integrity> {
-    let RevisionField::Present(revision) = &dist.revision else {
-        return dist.integrity.as_deref()?.parse().ok();
-    };
-    let selected_revision =
-        revision.as_u64().and_then(|revision| TarballRevision::try_from(revision).ok())?.get();
-    let selected: Vec<_> = dist
-        .revisions
-        .iter()
-        .filter(|record| record.revision.as_u64() == Some(selected_revision))
-        .collect();
-    if selected.len() != 1 || selected[0].integrity.as_deref() != dist.integrity.as_deref() {
-        return None;
-    }
-    let originals: Vec<_> =
-        dist.revisions.iter().filter(|record| record.revision.as_u64() == Some(0)).collect();
-    if originals.len() != 1 {
-        return None;
-    }
-    originals[0].integrity.as_deref()?.parse().ok()
 }
 
 /// The response for a cached upstream tarball, or `None` on a cache miss. A
@@ -3466,15 +3397,13 @@ fn staged_hosted_original_ref(
     attachment: &PreparedAttachment,
 ) -> Option<JournaledRevisionRef> {
     let integrity: Integrity = attachment.dist.get("integrity")?.as_str()?.parse().ok()?;
-    let path = integrity_addressed_tarball_path(&integrity)?;
-    let digest = path.strip_prefix("-/tarballs/sha512/")?.to_string();
-    let record = HostedOriginalRef {
-        package: package.as_str().to_string(),
-        version: attachment.version.clone(),
-    };
-    let bytes = serde_json::to_vec(&record).expect("hosted original reference serializes");
-    let ref_id = create_hex_hash(&format!("{}\0{}", record.package, record.version));
-    Some(JournaledRevisionRef { filename: attachment.canonical.clone(), digest, ref_id, bytes })
+    let reference = hosted_original_reference(package.as_str(), &attachment.version, &integrity)?;
+    Some(JournaledRevisionRef {
+        filename: attachment.canonical.clone(),
+        digest: reference.digest,
+        ref_id: reference.ref_id,
+        bytes: reference.bytes,
+    })
 }
 
 /// Make every staged publish visible. The full intent — merged

--- a/pnpr/crates/pnpr/src/server/tests.rs
+++ b/pnpr/crates/pnpr/src/server/tests.rs
@@ -1,7 +1,6 @@
 use super::{
-    ConnectInfo, HostedRevisionDist, HostedRevisionRecord, PeerAddr, RevisionField,
-    artifact_blob_response_body, bearer_credentials, canonical_ip, cidr_contains,
-    cidr_whitelist_allows, is_write_method, original_integrity, router_with_auth,
+    ConnectInfo, PeerAddr, artifact_blob_response_body, bearer_credentials, canonical_ip,
+    cidr_contains, cidr_whitelist_allows, is_write_method, router_with_auth,
     token_timestamp_millis,
 };
 use crate::{
@@ -9,6 +8,7 @@ use crate::{
     config::Config,
     error::{RegistryError, Result},
     policy::{AccessList, PackageRule, PackageRules},
+    revision::{HostedRevisionDist, HostedRevisionRecord, RevisionField, original_integrity},
 };
 use async_trait::async_trait;
 use axum::{

--- a/pnpr/crates/pnpr/src/storage.rs
+++ b/pnpr/crates/pnpr/src/storage.rs
@@ -510,6 +510,13 @@ impl HostedStore {
         }
     }
 
+    async fn list_package_names_for_backfill(&self) -> Result<Vec<String>> {
+        match self {
+            HostedStore::Fs(store) => store.list_package_names_for_backfill().await,
+            HostedStore::S3(store) => store.list_package_names().await,
+        }
+    }
+
     async fn read_revision_refs(&self, digest: &str) -> Result<Vec<Vec<u8>>> {
         match self {
             HostedStore::Fs(store) => store.read_revision_refs(digest).await,
@@ -604,6 +611,10 @@ impl Storage {
     /// indexes hosted/static packages only, never the proxy mirror).
     pub async fn hosted_package_names(&self) -> Result<Vec<String>> {
         self.hosted.list_package_names().await
+    }
+
+    pub(crate) async fn hosted_package_names_for_backfill(&self) -> Result<Vec<String>> {
+        self.hosted.list_package_names_for_backfill().await
     }
 
     pub(crate) async fn read_hosted_revision_refs(&self, digest: &str) -> Result<Vec<Vec<u8>>> {
@@ -1181,6 +1192,40 @@ impl Store {
         Ok(names)
     }
 
+    async fn list_package_names_for_backfill(&self) -> Result<Vec<String>> {
+        let mut names = Vec::new();
+        let mut top = match fs::read_dir(&self.root).await {
+            Ok(entries) => entries,
+            Err(err) if err.kind() == ErrorKind::NotFound => return Ok(names),
+            Err(err) => return Err(err.into()),
+        };
+        while let Some(entry) = top.next_entry().await? {
+            let entry_name = entry.file_name();
+            let name = entry_name.to_string_lossy();
+            if name.starts_with('.') || !entry.file_type().await?.is_dir() {
+                continue;
+            }
+            if is_file_if_present(entry.path().join(PACKUMENT_FILE)).await? {
+                names.push(name.into_owned());
+                continue;
+            }
+            if !name.starts_with('@') {
+                continue;
+            }
+            let mut scoped = fs::read_dir(entry.path()).await?;
+            while let Some(child) = scoped.next_entry().await? {
+                if !child.file_type().await?.is_dir() {
+                    continue;
+                }
+                if is_file_if_present(child.path().join(PACKUMENT_FILE)).await? {
+                    names.push(format!("{name}/{}", child.file_name().to_string_lossy()));
+                }
+            }
+        }
+        names.sort();
+        Ok(names)
+    }
+
     async fn read_revision_refs(&self, digest: &str) -> Result<Vec<Vec<u8>>> {
         let index = self.read_revision_ref_index(digest).await?;
         Ok(index.bodies().map(<[u8]>::to_vec).collect())
@@ -1286,6 +1331,14 @@ impl Store {
             }
         }
         Ok(ids)
+    }
+}
+
+async fn is_file_if_present(path: PathBuf) -> Result<bool> {
+    match fs::metadata(path).await {
+        Ok(metadata) => Ok(metadata.is_file()),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(err.into()),
     }
 }
 

--- a/pnpr/crates/pnpr/src/streaming.rs
+++ b/pnpr/crates/pnpr/src/streaming.rs
@@ -21,6 +21,9 @@ use tokio::{fs::File, io::AsyncReadExt};
 /// multi-MB tarball.
 const READ_CHUNK: usize = 64 * 1024;
 
+/// Maximum tarball size accepted by pnpr's verified streaming paths.
+pub(crate) const MAX_TARBALL_BYTES: u64 = 100 * 1024 * 1024;
+
 pub fn parse_integrity(value: &str) -> Result<Integrity, ssri::Error> {
     let integrity: Integrity = value.parse()?;
     ensure_supported_hash(&integrity)?;

--- a/pnpr/crates/pnpr/src/tests.rs
+++ b/pnpr/crates/pnpr/src/tests.rs
@@ -1,4 +1,5 @@
-use super::{RegistryError, redacted_report};
+use super::{Args, Command, RegistryError, redacted_report};
+use clap::Parser as _;
 
 #[test]
 fn startup_error_report_redacts_dsn_credentials() {
@@ -10,4 +11,14 @@ fn startup_error_report_redacts_dsn_credentials() {
     assert!(report.contains("postgres://redacted@[::1]/pnpr?sslmode=require"));
     assert!(!report.contains("admin"));
     assert!(!report.contains("secret"));
+}
+
+#[test]
+fn parses_revision_backfill_dry_run() {
+    let args =
+        Args::try_parse_from(["pnpr", "--storage", "/tmp/pnpr", "backfill-revisions", "--dry-run"])
+            .unwrap();
+
+    assert!(matches!(args.command, Some(Command::BackfillRevisions { dry_run: true })));
+    assert_eq!(args.storage.as_deref(), Some(std::path::Path::new("/tmp/pnpr")));
 }

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -7,7 +7,8 @@ use futures_util::stream;
 use pnpm_crypto_hash::integrity_addressed_tarball_path;
 use pnpr::{
     AccessList, AuthState, Config, HostedConfig, MaxUsers, PackagePattern, PackageRule,
-    PackageRules, PublicRoute, Registries, Registry, router, router_with_auth,
+    PackageRules, PublicRoute, Registries, Registry, backfill_hosted_revision_refs, router,
+    router_with_auth,
 };
 use serde_json::{Value, json};
 use ssri::{Algorithm, IntegrityOpts};
@@ -3444,6 +3445,60 @@ async fn hosted_original_is_served_by_digest_after_restart_and_through_a_router(
         .unwrap();
     assert_eq!(canonical.status(), StatusCode::OK);
     assert_eq!(body_bytes(canonical.into_body()).await, tarball);
+}
+
+#[tokio::test]
+async fn legacy_hosted_original_is_served_by_digest_after_backfill() {
+    let tmp = TempDir::new().unwrap();
+    let tarball = b"legacy-public-hosted-original";
+    let integrity_text = sha512_integrity(tarball);
+    let integrity = integrity_text.parse().unwrap();
+    let revision_path = integrity_addressed_tarball_path(&integrity).unwrap();
+    let package_dir = tmp.path().join("acme/@acme/widget");
+    std::fs::create_dir_all(&package_dir).unwrap();
+    std::fs::write(package_dir.join("widget-1.0.0.tgz"), tarball).unwrap();
+    std::fs::write(
+        package_dir.join("package.json"),
+        json!({
+            "name": "@acme/widget",
+            "dist-tags": { "latest": "1.0.0" },
+            "versions": { "1.0.0": {
+                "name": "@acme/widget",
+                "version": "1.0.0",
+                "dist": {
+                    "tarball": "http://example.test/@acme/widget/-/widget-1.0.0.tgz",
+                    "integrity": integrity_text,
+                },
+            } },
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
+    config.hosted.clear();
+    config.hosted.insert("acme".to_string(), hosted_with_access("acme", "$all"));
+    config.registries = Registries::new(
+        vec![("acme".to_string(), Registry::Hosted { patterns: vec![] })].into_iter().collect(),
+        Some("acme".to_string()),
+    );
+
+    let before = router(config.clone())
+        .oneshot(Request::get(format!("/{revision_path}")).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(before.status(), StatusCode::NOT_FOUND);
+
+    let report = backfill_hosted_revision_refs(&config, false).await.unwrap();
+    assert_eq!(report.indexed, 1);
+    assert_eq!(report.invalid, 0);
+
+    let after = router(config)
+        .oneshot(Request::get(format!("/{revision_path}")).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(after.status(), StatusCode::OK);
+    assert_eq!(body_bytes(after.into_body()).await, tarball);
 }
 
 #[tokio::test]

--- a/pnpr/npm/pnpr/README.md
+++ b/pnpr/npm/pnpr/README.md
@@ -49,6 +49,29 @@ pnpm config set registry http://127.0.0.1:7677/
 Log level is controlled via the standard `RUST_LOG` environment
 variable (e.g. `RUST_LOG=debug pnpr`).
 
+### Backfill hosted revision indexes
+
+Packages published by current pnpr versions are indexed for immutable SHA-512
+digest routes as part of publication. To index packages already present in a
+hosted filesystem or S3 store, first validate the migration without writing:
+
+```sh
+pnpr -c ./pnpr.yaml backfill-revisions --dry-run
+```
+
+Then run the idempotent backfill:
+
+```sh
+pnpr -c ./pnpr.yaml backfill-revisions
+```
+
+The command streams each eligible tarball through its declared SHA-512
+integrity before adding a reference. It reports unsupported metadata as
+skipped, rejects missing or mismatched artifacts, and bounds each tarball at
+100 MiB. Stop the pnpr writer while backfilling the filesystem backend; S3
+backfills use the same conditional updates as normal publication and may run
+alongside the service.
+
 ## Configuration
 
 `pnpr` uses a [verdaccio](https://verdaccio.org/docs/configuration)-shaped


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Adds `pnpr backfill-revisions` to validate legacy hosted artifacts and populate the digest-reference indexes required by integrity-addressed tarball routes.

The migration streams each eligible tarball through SHA-512 verification with the existing 100 MiB limit, indexes the original artifact after a replacement, supports `--dry-run`, and is idempotent. Filesystem users are warned to stop the pnpr writer during migration; S3 uses conditional writes so it can safely share the store with the service.

Follow-up to https://github.com/pnpm/pnpm/pull/14183 and https://github.com/pnpm/rfcs/pull/19.

## Squash Commit Body

```text
Hosted packages that predate publish-time digest indexing have valid metadata and tarballs but no digest references, so their integrity-addressed tarball routes return 404.

Add an explicit backfill command that enumerates each unique hosted namespace, selects the original revision integrity, streams and verifies eligible tarballs, and writes the existing bounded digest-reference index. Complete canonical SHA-512 artifacts are migrated; unsupported legacy integrity metadata is reported as skipped, while missing, malformed, oversized, or mismatched artifacts are reported as invalid and cause a nonzero exit.

The command supports dry runs and remains idempotent by verifying already indexed artifacts. Filesystem migration warns operators to stop the pnpr writer, while S3 ownership claims use conditional writes for safe concurrent operation. Share revision metadata parsing and reference construction with the publish path so both flows maintain the same index contract.

Follow-up to https://github.com/pnpm/pnpm/pull/14183 and https://github.com/pnpm/rfcs/pull/19.
```

## Checklist

- [x] I checked the referenced RFC and previous pull request and verified that this migration is still needed.
- [x] Added a changeset (`pnpm changeset`) for `@pnpm/pnpr`.
- [x] Added or updated tests.
- [x] Updated the documentation.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790344241&installation_model_id=426870&pr_number=14186&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14186&signature=05f56c137d829f636d6c07d64a0c5ce3b3c977b6d07dabca4bd25b56936d12b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->