### PR TITLE
perf: reuse store content when restoring a remote build

### DIFF
--- a/.changeset/remote-side-effects-reuse-store-content.md
+++ b/.changeset/remote-side-effects-reuse-store-content.md
@@ -1,0 +1,9 @@
+---
+"@pnpm/store.controller-types": minor
+"@pnpm/store.controller": minor
+"@pnpm/pnpr.client": minor
+"pacquet": patch
+"pnpm": patch
+---
+
+Restoring a dependency's build from the remote side-effects cache no longer downloads files the store already holds. A built package's files are mostly its own, and artifacts share files with one another, so most of an artifact is content the store has already addressed by the same digest.

--- a/.changeset/remote-side-effects-reuse-store-content.md
+++ b/.changeset/remote-side-effects-reuse-store-content.md
@@ -1,9 +1,10 @@
 ---
 "@pnpm/store.controller-types": minor
+"@pnpm/store.cafs": minor
 "@pnpm/store.controller": minor
 "@pnpm/pnpr.client": minor
 "pacquet": patch
 "pnpm": patch
 ---
 
-Restoring a dependency's build from the remote side-effects cache no longer downloads files the store already holds. A built package's files are mostly its own, and artifacts share files with one another, so most of an artifact is content the store has already addressed by the same digest.
+Restoring a dependency's build from the remote side-effects cache no longer downloads files the store already holds.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4724,6 +4724,7 @@ dependencies = [
  "tokio",
  "tracing",
  "walkdir",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4674,6 +4674,7 @@ dependencies = [
  "futures-util",
  "indexmap 2.14.0",
  "insta",
+ "libc",
  "miette 7.6.0",
  "mockito",
  "node-semver",

--- a/cspell.json
+++ b/cspell.json
@@ -211,6 +211,7 @@
     "millis",
     "minioadmin",
     "mintimeout",
+    "mkfifo",
     "mmap",
     "monorepolint",
     "montudor",

--- a/pnpm/crates/deps-restorer/Cargo.toml
+++ b/pnpm/crates/deps-restorer/Cargo.toml
@@ -77,7 +77,8 @@ walkdir           = { workspace = true }
 libc = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
-same-file = { workspace = true }
+same-file   = { workspace = true }
+windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem"] }
 
 [lints]
 workspace = true

--- a/pnpm/crates/deps-restorer/Cargo.toml
+++ b/pnpm/crates/deps-restorer/Cargo.toml
@@ -52,6 +52,7 @@ rayon        = { workspace = true }
 reflink-copy = { workspace = true }
 serde        = { workspace = true }
 serde_json   = { workspace = true }
+sha2         = { workspace = true }
 ssri         = { workspace = true }
 tempfile     = { workspace = true }
 tokio        = { workspace = true }

--- a/pnpm/crates/deps-restorer/Cargo.toml
+++ b/pnpm/crates/deps-restorer/Cargo.toml
@@ -73,6 +73,9 @@ tar               = { workspace = true }
 text-block-macros = { workspace = true }
 walkdir           = { workspace = true }
 
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
+
 [target.'cfg(windows)'.dependencies]
 same-file = { workspace = true }
 

--- a/pnpm/crates/deps-restorer/src/shared_side_effects.rs
+++ b/pnpm/crates/deps-restorer/src/shared_side_effects.rs
@@ -322,20 +322,23 @@ const STORE_READ_CHUNK: usize = 64 * 1024;
 async fn store_holds(path: &Path, digest: &str) -> Result<bool, String> {
     use tokio::io::AsyncReadExt as _;
 
-    // Checked without following links: the store addresses its own regular
-    // files, and a symlink here would import content from outside it that the
-    // CAS write path would have replaced.
-    match tokio::fs::symlink_metadata(path).await {
-        Ok(metadata) if metadata.is_file() => {}
-        Ok(_) => return Ok(false),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
-        Err(error) => return Err(format!("failed to inspect {}: {error}", path.display())),
-    }
-    let file = match tokio::fs::File::open(path).await {
-        Ok(file) => file,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
-        Err(error) => return Err(format!("failed to open {}: {error}", path.display())),
+    let mut options = tokio::fs::OpenOptions::new();
+    options.read(true);
+    // The store addresses its own regular files. A symlink at the digest path
+    // would name bytes the store neither owns nor can keep from changing, and
+    // a plain open on a FIFO would block until a writer appeared. Refusing
+    // both at open binds the check to the file that is actually read, which a
+    // preceding `symlink_metadata` could not.
+    #[cfg(unix)]
+    options.custom_flags(libc::O_NONBLOCK | libc::O_NOFOLLOW);
+    // Anything that cannot be opened this way — absent, a symlink `O_NOFOLLOW`
+    // turned away, a device — is a miss the download and CAS write repair.
+    let Ok(file) = options.open(path).await else {
+        return Ok(false);
     };
+    if !file.metadata().await.is_ok_and(|metadata| metadata.is_file()) {
+        return Ok(false);
+    }
     let mut reader = tokio::io::BufReader::with_capacity(STORE_READ_CHUNK, file);
     let mut hasher = Sha512::new();
     let mut buffer = vec![0u8; STORE_READ_CHUNK];

--- a/pnpm/crates/deps-restorer/src/shared_side_effects.rs
+++ b/pnpm/crates/deps-restorer/src/shared_side_effects.rs
@@ -9,7 +9,8 @@ use pnpm_pnpr_client::{
     ARTIFACT_KIND, ArtifactBlobRequest, ArtifactBlobUpload, ArtifactCandidate, ArtifactFile,
     ArtifactManifest, ArtifactPayload, BuilderProfile, CompatibilityConstraints,
     LinuxGlibcPlatform, OwnerScope, PackageIdentity, PnprClient, PublishArtifactRequest,
-    ResolveArtifactsOptions, SignedArtifactEnvelope, linux_glibc_supported_tags, linux_glibc_tag,
+    ResolveArtifactsOptions, SignedArtifactEnvelope, blob_id, linux_glibc_supported_tags,
+    linux_glibc_tag,
 };
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
@@ -205,6 +206,18 @@ pub(crate) async fn apply_shared_side_effects(
                 let storage_key = (file.integrity.clone(), file.mode);
                 if let Some(path) = stored.get(&storage_key) {
                     return Ok(path.clone());
+                }
+                // A built package's files are mostly its own, and artifacts
+                // share files with each other. The store addresses content by
+                // the digest this manifest entry already carries, so anything
+                // it holds is the same bytes and needs no transfer.
+                if !downloaded.contains_key(&file.integrity)
+                    && let Ok(digest) = blob_id(&file.integrity)
+                    && let Some(path) = config.store_dir.cas_file_path_by_mode(&digest, file.mode)
+                    && tokio::fs::try_exists(&path).await.unwrap_or(false)
+                {
+                    stored.insert(storage_key, path.clone());
+                    return Ok(path);
                 }
                 if !downloaded.contains_key(&file.integrity) {
                     let bytes = client

--- a/pnpm/crates/deps-restorer/src/shared_side_effects.rs
+++ b/pnpm/crates/deps-restorer/src/shared_side_effects.rs
@@ -331,8 +331,12 @@ async fn store_holds(path: &Path, digest: &str) -> Result<bool, String> {
     // preceding `symlink_metadata` could not.
     #[cfg(unix)]
     options.custom_flags(libc::O_NONBLOCK | libc::O_NOFOLLOW);
-    // Anything that cannot be opened this way — absent, a symlink `O_NOFOLLOW`
-    // turned away, a device — is a miss the download and CAS write repair.
+    // Whatever turned the open away — absent, a directory, a symlink
+    // `O_NOFOLLOW` refused, a permission error — names something the caller
+    // cannot reuse, and its fallback is a verified download that reports any
+    // real fault itself. A failure once the file is open is different: that
+    // one is reported below, since the store handed over a file it then could
+    // not read.
     let Ok(file) = options.open(path).await else {
         return Ok(false);
     };

--- a/pnpm/crates/deps-restorer/src/shared_side_effects.rs
+++ b/pnpm/crates/deps-restorer/src/shared_side_effects.rs
@@ -306,34 +306,48 @@ fn decoded_trusted_keys(
     Some(trusted_keys)
 }
 
-/// Whether the store holds `path` as the content `digest` names.
-///
-/// Reusing content is a read of the store like any other, so it answers to
-/// `verifyStoreIntegrity`: asked to verify, content that does not hash to the
-/// digest it is filed under is not reused, and the caller falls back to its
-/// own verified download. A missing file is an ordinary miss; any other
-/// failure is reported rather than quietly redownloaded.
+/// Reads the store in chunks this size while hashing, so a large CAS blob
+/// is never held in memory whole.
+const STORE_READ_CHUNK: usize = 64 * 1024;
+
 /// Whether the store already holds `digest` at `path`.
 ///
 /// Verified unconditionally rather than answering to `verifyStoreIntegrity`:
 /// the download this skips would have ended in a CAS write, and that path
 /// checks content already at the destination whatever the setting says.
 /// Hashing a local file is far cheaper than the transfer it avoids.
+///
+/// A missing file is an ordinary miss; any other failure is reported rather
+/// than quietly redownloaded.
 async fn store_holds(path: &Path, digest: &str) -> Result<bool, String> {
-    let bytes = match tokio::fs::read(path).await {
-        Ok(bytes) => bytes,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
-        Err(error) => return Err(format!("failed to read {}: {error}", path.display())),
-    };
-    Ok(hex_digest(&bytes) == digest)
-}
+    use tokio::io::AsyncReadExt as _;
 
-fn hex_digest(bytes: &[u8]) -> String {
-    Sha512::digest(bytes).iter().fold(String::with_capacity(128), |mut output, byte| {
-        use std::fmt::Write as _;
-        write!(output, "{byte:02x}").expect("writing to a String cannot fail");
-        output
-    })
+    // Checked without following links: the store addresses its own regular
+    // files, and a symlink here would import content from outside it that the
+    // CAS write path would have replaced.
+    match tokio::fs::symlink_metadata(path).await {
+        Ok(metadata) if metadata.is_file() => {}
+        Ok(_) => return Ok(false),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(format!("failed to inspect {}: {error}", path.display())),
+    }
+    let file = match tokio::fs::File::open(path).await {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(format!("failed to open {}: {error}", path.display())),
+    };
+    let mut reader = tokio::io::BufReader::with_capacity(STORE_READ_CHUNK, file);
+    let mut hasher = Sha512::new();
+    let mut buffer = vec![0u8; STORE_READ_CHUNK];
+    loop {
+        match reader.read(&mut buffer).await {
+            Ok(0) => break,
+            Ok(read) => hasher.update(&buffer[..read]),
+            Err(ref error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(error) => return Err(format!("failed to read {}: {error}", path.display())),
+        }
+    }
+    Ok(format!("{:x}", hasher.finalize()) == digest)
 }
 
 fn non_empty(value: &str) -> Option<&str> {

--- a/pnpm/crates/deps-restorer/src/shared_side_effects.rs
+++ b/pnpm/crates/deps-restorer/src/shared_side_effects.rs
@@ -211,6 +211,11 @@ pub(crate) async fn apply_shared_side_effects(
                 // share files with each other. The store addresses content by
                 // the digest this manifest entry already carries, so anything
                 // it holds is the same bytes and needs no transfer.
+                //
+                // Both this lookup and the write below address the store by
+                // `is_executable`, so they cannot disagree about where a mode
+                // belongs. The manifest only carries 0o644 and 0o755 today,
+                // but the agreement must not rest on that.
                 if !downloaded.contains_key(&file.integrity)
                     && let Ok(digest) = blob_id(&file.integrity)
                     && let Some(path) = config.store_dir.cas_file_path_by_mode(&digest, file.mode)
@@ -234,7 +239,10 @@ pub(crate) async fn apply_shared_side_effects(
                 }
                 let (path, _) = config
                     .store_dir
-                    .write_cas_file(&downloaded[&file.integrity], file.mode == 0o755)
+                    .write_cas_file(
+                        &downloaded[&file.integrity],
+                        pnpm_fs::file_mode::is_executable(file.mode),
+                    )
                     .map_err(|error| error.to_string())?;
                 stored.insert(storage_key, path.clone());
                 Ok(path)

--- a/pnpm/crates/deps-restorer/src/shared_side_effects.rs
+++ b/pnpm/crates/deps-restorer/src/shared_side_effects.rs
@@ -12,9 +12,10 @@ use pnpm_pnpr_client::{
     ResolveArtifactsOptions, SignedArtifactEnvelope, blob_id, linux_glibc_supported_tags,
     linux_glibc_tag,
 };
+use sha2::{Digest as _, Sha512};
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::Arc,
 };
 
@@ -219,7 +220,7 @@ pub(crate) async fn apply_shared_side_effects(
                 if !downloaded.contains_key(&file.integrity)
                     && let Ok(digest) = blob_id(&file.integrity)
                     && let Some(path) = config.store_dir.cas_file_path_by_mode(&digest, file.mode)
-                    && tokio::fs::try_exists(&path).await.unwrap_or(false)
+                    && store_holds(&path, &digest).await?
                 {
                     stored.insert(storage_key, path.clone());
                     return Ok(path);
@@ -303,6 +304,36 @@ fn decoded_trusted_keys(
         trusted_keys.insert(key_id.clone(), public_key);
     }
     Some(trusted_keys)
+}
+
+/// Whether the store holds `path` as the content `digest` names.
+///
+/// Reusing content is a read of the store like any other, so it answers to
+/// `verifyStoreIntegrity`: asked to verify, content that does not hash to the
+/// digest it is filed under is not reused, and the caller falls back to its
+/// own verified download. A missing file is an ordinary miss; any other
+/// failure is reported rather than quietly redownloaded.
+/// Whether the store already holds `digest` at `path`.
+///
+/// Verified unconditionally rather than answering to `verifyStoreIntegrity`:
+/// the download this skips would have ended in a CAS write, and that path
+/// checks content already at the destination whatever the setting says.
+/// Hashing a local file is far cheaper than the transfer it avoids.
+async fn store_holds(path: &Path, digest: &str) -> Result<bool, String> {
+    let bytes = match tokio::fs::read(path).await {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(format!("failed to read {}: {error}", path.display())),
+    };
+    Ok(hex_digest(&bytes) == digest)
+}
+
+fn hex_digest(bytes: &[u8]) -> String {
+    Sha512::digest(bytes).iter().fold(String::with_capacity(128), |mut output, byte| {
+        use std::fmt::Write as _;
+        write!(output, "{byte:02x}").expect("writing to a String cannot fail");
+        output
+    })
 }
 
 fn non_empty(value: &str) -> Option<&str> {

--- a/pnpm/crates/deps-restorer/src/shared_side_effects.rs
+++ b/pnpm/crates/deps-restorer/src/shared_side_effects.rs
@@ -331,6 +331,11 @@ async fn store_holds(path: &Path, digest: &str) -> Result<bool, String> {
     // preceding `symlink_metadata` could not.
     #[cfg(unix)]
     options.custom_flags(libc::O_NONBLOCK | libc::O_NOFOLLOW);
+    // The Windows spelling of the same refusal: open the reparse point itself
+    // rather than what it redirects to, so the descriptor check below sees a
+    // reparse point instead of the file it names.
+    #[cfg(windows)]
+    options.custom_flags(windows_sys::Win32::Storage::FileSystem::FILE_FLAG_OPEN_REPARSE_POINT);
     // Whatever turned the open away — absent, a directory, a symlink
     // `O_NOFOLLOW` refused, a permission error — names something the caller
     // cannot reuse, and its fallback is a verified download that reports any

--- a/pnpm/crates/deps-restorer/src/shared_side_effects/tests.rs
+++ b/pnpm/crates/deps-restorer/src/shared_side_effects/tests.rs
@@ -96,6 +96,16 @@ async fn a_non_regular_file_is_not_reused_as_store_content() {
 
     #[cfg(unix)]
     {
+        let fifo = store.path().join("fifo");
+        assert!(
+            std::process::Command::new("mkfifo").arg(&fifo).status().unwrap().success(),
+            "mkfifo is needed to plant a FIFO at a store path",
+        );
+        assert!(
+            !super::store_holds(&fifo, &digest).await.unwrap(),
+            "a FIFO must be refused rather than held open waiting for a writer",
+        );
+
         let outside = store.path().join("outside");
         std::fs::write(&outside, bytes).unwrap();
         std::fs::remove_dir(&path).unwrap();

--- a/pnpm/crates/deps-restorer/src/shared_side_effects/tests.rs
+++ b/pnpm/crates/deps-restorer/src/shared_side_effects/tests.rs
@@ -28,20 +28,50 @@ fn an_artifact_digest_addresses_the_file_the_store_wrote() {
 
     let store = tempfile::tempdir().unwrap();
     let store_dir = pnpm_store_dir::StoreDir::new(store.path());
-    for (bytes, mode) in [
-        (b"executable addon".as_slice(), 0o755),
-        (b"plain addon".as_slice(), 0o644),
-        (b"owner-executable addon".as_slice(), 0o744),
-    ] {
+    // One content, so only the mode can make the paths differ.
+    let bytes = b"addon".as_slice();
+    let integrity = format!("sha512-{}", BASE64.encode(Sha512::digest(bytes)));
+    let digest = pnpm_pnpr_client::blob_id(&integrity).unwrap();
+    let mut located_by_mode = Vec::new();
+    for mode in [0o755, 0o644, 0o744] {
         let (written, _) =
             store_dir.write_cas_file(bytes, pnpm_fs::file_mode::is_executable(mode)).unwrap();
-        let integrity = format!("sha512-{}", BASE64.encode(Sha512::digest(bytes)));
-        let digest = pnpm_pnpr_client::blob_id(&integrity).unwrap();
-
         let located = store_dir
             .cas_file_path_by_mode(&digest, mode)
             .expect("an artifact digest must address a CAS path");
         assert_eq!(located, written, "mode {mode:o}");
         assert!(located.is_file(), "mode {mode:o}");
+        located_by_mode.push((mode, located));
     }
+
+    let executable = &located_by_mode[0].1;
+    let plain = &located_by_mode[1].1;
+    assert_ne!(executable, plain, "one content must not share a path across modes");
+    assert_eq!(&located_by_mode[2].1, executable, "any executable bit files as executable");
+}
+
+/// Reuse answers to `verifyStoreIntegrity`: content that does not hash to the
+/// digest it is filed under is not offered, so the caller falls back to its own
+/// verified download rather than installing whatever happens to sit there.
+#[tokio::test]
+async fn corrupted_store_content_is_not_reused() {
+    use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+    use sha2::{Digest as _, Sha512};
+
+    let store = tempfile::tempdir().unwrap();
+    let store_dir = pnpm_store_dir::StoreDir::new(store.path());
+    let bytes = b"addon".as_slice();
+    let (path, _) = store_dir.write_cas_file(bytes, true).unwrap();
+    let integrity = format!("sha512-{}", BASE64.encode(Sha512::digest(bytes)));
+    let digest = pnpm_pnpr_client::blob_id(&integrity).unwrap();
+    assert!(super::store_holds(&path, &digest).await.unwrap());
+
+    std::fs::write(&path, b"tampered").unwrap();
+    assert!(
+        !super::store_holds(&path, &digest).await.unwrap(),
+        "the write this skips checks the destination whatever verifyStoreIntegrity says",
+    );
+
+    std::fs::remove_file(&path).unwrap();
+    assert!(!super::store_holds(&path, &digest).await.unwrap());
 }

--- a/pnpm/crates/deps-restorer/src/shared_side_effects/tests.rs
+++ b/pnpm/crates/deps-restorer/src/shared_side_effects/tests.rs
@@ -50,9 +50,9 @@ fn an_artifact_digest_addresses_the_file_the_store_wrote() {
     assert_eq!(&located_by_mode[2].1, executable, "any executable bit files as executable");
 }
 
-/// Reuse answers to `verifyStoreIntegrity`: content that does not hash to the
-/// digest it is filed under is not offered, so the caller falls back to its own
-/// verified download rather than installing whatever happens to sit there.
+/// Content that does not hash to the digest it is filed under is not offered,
+/// so the caller falls back to its own verified download rather than
+/// installing whatever happens to sit there.
 #[tokio::test]
 async fn corrupted_store_content_is_not_reused() {
     use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
@@ -74,4 +74,35 @@ async fn corrupted_store_content_is_not_reused() {
 
     std::fs::remove_file(&path).unwrap();
     assert!(!super::store_holds(&path, &digest).await.unwrap());
+}
+
+/// The store addresses its own regular files, so anything else at the digest
+/// path is a miss the download and CAS write can repair.
+#[tokio::test]
+async fn a_non_regular_file_is_not_reused_as_store_content() {
+    use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+    use sha2::{Digest as _, Sha512};
+
+    let store = tempfile::tempdir().unwrap();
+    let store_dir = pnpm_store_dir::StoreDir::new(store.path());
+    let bytes = b"addon".as_slice();
+    let (path, _) = store_dir.write_cas_file(bytes, true).unwrap();
+    let integrity = format!("sha512-{}", BASE64.encode(Sha512::digest(bytes)));
+    let digest = pnpm_pnpr_client::blob_id(&integrity).unwrap();
+
+    std::fs::remove_file(&path).unwrap();
+    std::fs::create_dir(&path).unwrap();
+    assert!(!super::store_holds(&path, &digest).await.unwrap());
+
+    #[cfg(unix)]
+    {
+        let outside = store.path().join("outside");
+        std::fs::write(&outside, bytes).unwrap();
+        std::fs::remove_dir(&path).unwrap();
+        std::os::unix::fs::symlink(&outside, &path).unwrap();
+        assert!(
+            !super::store_holds(&path, &digest).await.unwrap(),
+            "a link naming correct bytes still imports content the store does not own",
+        );
+    }
 }

--- a/pnpm/crates/deps-restorer/src/shared_side_effects/tests.rs
+++ b/pnpm/crates/deps-restorer/src/shared_side_effects/tests.rs
@@ -14,6 +14,13 @@ fn package_identity_uses_the_manifest_version_for_non_registry_sources() {
 /// has depends on the artifact's digest and mode naming the same CAS path the
 /// store wrote. Nothing else would notice them drifting apart: the lookup
 /// would simply always miss and every install would download again.
+///
+/// `0o744` is here even though a manifest carrying it is refused before
+/// hydration ever sees it. The two sides must agree on their own terms rather
+/// than because a validator elsewhere happens to allow only two modes: an
+/// owner-executable file would otherwise be looked up as executable and
+/// written as not, and the permission a restore installs would depend on what
+/// the store already held.
 #[test]
 fn an_artifact_digest_addresses_the_file_the_store_wrote() {
     use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
@@ -21,8 +28,13 @@ fn an_artifact_digest_addresses_the_file_the_store_wrote() {
 
     let store = tempfile::tempdir().unwrap();
     let store_dir = pnpm_store_dir::StoreDir::new(store.path());
-    for (bytes, mode) in [(b"executable addon".as_slice(), 0o755), (b"plain addon", 0o644)] {
-        let (written, _) = store_dir.write_cas_file(bytes, mode == 0o755).unwrap();
+    for (bytes, mode) in [
+        (b"executable addon".as_slice(), 0o755),
+        (b"plain addon".as_slice(), 0o644),
+        (b"owner-executable addon".as_slice(), 0o744),
+    ] {
+        let (written, _) =
+            store_dir.write_cas_file(bytes, pnpm_fs::file_mode::is_executable(mode)).unwrap();
         let integrity = format!("sha512-{}", BASE64.encode(Sha512::digest(bytes)));
         let digest = pnpm_pnpr_client::blob_id(&integrity).unwrap();
 

--- a/pnpm/crates/deps-restorer/src/shared_side_effects/tests.rs
+++ b/pnpm/crates/deps-restorer/src/shared_side_effects/tests.rs
@@ -9,3 +9,27 @@ fn package_identity_uses_the_manifest_version_for_non_registry_sources() {
     let registry: PackageKey = "native-addon@2.0.0".parse().unwrap();
     assert_eq!(package_version(&registry, None), "2.0.0");
 }
+
+/// The skip that keeps a restore from re-fetching content the store already
+/// has depends on the artifact's digest and mode naming the same CAS path the
+/// store wrote. Nothing else would notice them drifting apart: the lookup
+/// would simply always miss and every install would download again.
+#[test]
+fn an_artifact_digest_addresses_the_file_the_store_wrote() {
+    use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+    use sha2::{Digest as _, Sha512};
+
+    let store = tempfile::tempdir().unwrap();
+    let store_dir = pnpm_store_dir::StoreDir::new(store.path());
+    for (bytes, mode) in [(b"executable addon".as_slice(), 0o755), (b"plain addon", 0o644)] {
+        let (written, _) = store_dir.write_cas_file(bytes, mode == 0o755).unwrap();
+        let integrity = format!("sha512-{}", BASE64.encode(Sha512::digest(bytes)));
+        let digest = pnpm_pnpr_client::blob_id(&integrity).unwrap();
+
+        let located = store_dir
+            .cas_file_path_by_mode(&digest, mode)
+            .expect("an artifact digest must address a CAS path");
+        assert_eq!(located, written, "mode {mode:o}");
+        assert!(located.is_file(), "mode {mode:o}");
+    }
+}

--- a/pnpm/crates/pnpr-client/src/lib.rs
+++ b/pnpm/crates/pnpr-client/src/lib.rs
@@ -38,7 +38,7 @@ pub use pnpm_shared_artifact_protocol::{
     ArtifactManifest, ArtifactPayload, BuilderProfile, COMPATIBILITY_TAG_SCHEMA,
     CompatibilityConstraints, INPUT_KEY_PREFIX, LinuxGlibcPlatform, OwnerScope, PackageIdentity,
     PublishArtifactRequest, ResolveArtifactsRequest, SIGNATURE_ALGORITHM, SignedArtifactEnvelope,
-    linux_glibc_supported_tags, linux_glibc_tag, platform_fingerprint,
+    blob_id, linux_glibc_supported_tags, linux_glibc_tag, platform_fingerprint,
 };
 use pnpm_shared_artifact_protocol::{
     MAX_CANDIDATES, MAX_FILE_SIZE, MAX_RESOLVE_RESPONSE_SIZE, MAX_VARIANTS_PER_CANDIDATE,

--- a/pnpm11/store/cafs/src/checkPkgFilesIntegrity.ts
+++ b/pnpm11/store/cafs/src/checkPkgFilesIntegrity.ts
@@ -11,8 +11,10 @@ import { rimrafSync } from '@zkochan/rimraf'
 import { getFilePathByModeInCafs } from './getFilePathInCafs.js'
 
 const CHUNK_SIZE = 64 * 1024
-// Windows has no O_NOFOLLOW; there the descriptor check below stands alone.
-const NO_FOLLOW = fs.constants.O_NOFOLLOW ?? 0
+// Windows has neither flag; there the descriptor check below stands alone.
+// O_NONBLOCK keeps a FIFO planted at a digest path from holding the open
+// until a writer appears, and is a no-op for the regular files expected.
+const GUARDED_OPEN = (fs.constants.O_NOFOLLOW ?? 0) | (fs.constants.O_NONBLOCK ?? 0)
 
 export interface Integrity {
   digest: string
@@ -242,9 +244,10 @@ export function verifyFileIntegrity (
  * before yielding, which stalls everything else for the length of a large
  * CAS file. Prefer this wherever the caller is already asynchronous.
  *
- * A path that is absent or is not a regular file is `false`, so the caller
- * falls back to fetching it, as is an `integrity.algorithm` the runtime does
- * not support. Any other read failure is thrown.
+ * Anything that cannot be opened and read as a regular file is `false`, so the
+ * caller falls back to fetching it — an absent path, a directory, a symlink,
+ * or an `integrity.algorithm` the runtime does not support. A failure once the
+ * file is open is thrown instead.
  */
 export async function verifyFileIntegrityAsync (
   filename: string,
@@ -264,10 +267,13 @@ export async function verifyFileIntegrityAsync (
   // afterwards keeps the check bound to the file that is actually read.
   let handle: fs.promises.FileHandle
   try {
-    handle = await fs.promises.open(filename, fs.constants.O_RDONLY | NO_FOLLOW)
-  } catch (err: unknown) {
-    if (isMissingOrUnusable(err)) return false
-    throw err
+    handle = await fs.promises.open(filename, fs.constants.O_RDONLY | GUARDED_OPEN)
+  } catch {
+    // Whatever turned the open away names something that cannot be reused, and
+    // the caller's fallback is a verified fetch that reports any real fault
+    // itself. A failure once the file is open is different: that one is left
+    // to throw, since the store handed over a file it then could not read.
+    return false
   }
   try {
     if (!(await handle.stat()).isFile()) return false
@@ -283,14 +289,6 @@ export async function verifyFileIntegrityAsync (
   return hasher.digest('hex') === integrity.digest
 }
 
-/**
- * Whether opening a store path failed because nothing usable is there — it is
- * absent, it is a directory, or it is a symlink `O_NOFOLLOW` turned away.
- */
-function isMissingOrUnusable (err: unknown): boolean {
-  if (!util.types.isNativeError(err) || !('code' in err)) return false
-  return err.code === 'ENOENT' || err.code === 'EISDIR' || err.code === 'ELOOP'
-}
 
 /** The file's content, or `null` if it is no longer there. */
 function readFileForIntegrity (filename: string): Buffer | null {

--- a/pnpm11/store/cafs/src/checkPkgFilesIntegrity.ts
+++ b/pnpm11/store/cafs/src/checkPkgFilesIntegrity.ts
@@ -244,10 +244,11 @@ export function verifyFileIntegrity (
  * before yielding, which stalls everything else for the length of a large
  * CAS file. Prefer this wherever the caller is already asynchronous.
  *
- * Anything that cannot be opened and read as a regular file is `false`, so the
- * caller falls back to fetching it — an absent path, a directory, a symlink,
- * or an `integrity.algorithm` the runtime does not support. A failure once the
- * file is open is thrown instead.
+ * `false` — the caller falls back to fetching the file — when the path cannot
+ * be opened at all, when what was opened is not a regular file, when the
+ * content does not hash to `integrity`, or when the runtime does not support
+ * `integrity.algorithm`. A failure while reading an already-open file is
+ * thrown instead, since the store handed over a file it then could not read.
  */
 export async function verifyFileIntegrityAsync (
   filename: string,

--- a/pnpm11/store/cafs/src/checkPkgFilesIntegrity.ts
+++ b/pnpm11/store/cafs/src/checkPkgFilesIntegrity.ts
@@ -11,6 +11,8 @@ import { rimrafSync } from '@zkochan/rimraf'
 import { getFilePathByModeInCafs } from './getFilePathInCafs.js'
 
 const CHUNK_SIZE = 64 * 1024
+// Windows has no O_NOFOLLOW; there the descriptor check below stands alone.
+const NO_FOLLOW = fs.constants.O_NOFOLLOW ?? 0
 
 export interface Integrity {
   digest: string
@@ -256,17 +258,38 @@ export async function verifyFileIntegrityAsync (
     // verification failure rather than an error, as in `hashMatches`.
     return false
   }
+  // The store addresses its own regular files. A symlink at the digest path
+  // would name bytes the store neither owns nor can keep from changing, so it
+  // is refused at open where the platform can; inspecting the descriptor
+  // afterwards keeps the check bound to the file that is actually read.
+  let handle: fs.promises.FileHandle
   try {
-    for await (const chunk of fs.createReadStream(filename, { highWaterMark: CHUNK_SIZE })) {
-      hasher.update(chunk as Buffer)
-    }
+    handle = await fs.promises.open(filename, fs.constants.O_RDONLY | NO_FOLLOW)
   } catch (err: unknown) {
-    if (util.types.isNativeError(err) && 'code' in err && (err.code === 'ENOENT' || err.code === 'EISDIR')) {
-      return false
-    }
+    if (isMissingOrUnusable(err)) return false
     throw err
   }
+  try {
+    if (!(await handle.stat()).isFile()) return false
+    // `autoClose: false` so the handle is closed once, below, whether or not
+    // the stream got as far as ending.
+    const stream = handle.createReadStream({ highWaterMark: CHUNK_SIZE, autoClose: false })
+    for await (const chunk of stream) {
+      hasher.update(chunk as Buffer)
+    }
+  } finally {
+    await handle.close()
+  }
   return hasher.digest('hex') === integrity.digest
+}
+
+/**
+ * Whether opening a store path failed because nothing usable is there — it is
+ * absent, it is a directory, or it is a symlink `O_NOFOLLOW` turned away.
+ */
+function isMissingOrUnusable (err: unknown): boolean {
+  if (!util.types.isNativeError(err) || !('code' in err)) return false
+  return err.code === 'ENOENT' || err.code === 'EISDIR' || err.code === 'ELOOP'
 }
 
 /** The file's content, or `null` if it is no longer there. */

--- a/pnpm11/store/cafs/src/checkPkgFilesIntegrity.ts
+++ b/pnpm11/store/cafs/src/checkPkgFilesIntegrity.ts
@@ -10,6 +10,8 @@ import { rimrafSync } from '@zkochan/rimraf'
 
 import { getFilePathByModeInCafs } from './getFilePathInCafs.js'
 
+const CHUNK_SIZE = 64 * 1024
+
 export interface Integrity {
   digest: string
   algorithm: string
@@ -228,6 +230,42 @@ export function verifyFileIntegrity (
   const data = readFileForIntegrity(filename)
   if (data == null) return false
   return hashMatches(data, integrity) ?? false
+}
+
+/**
+ * Whether the file at `filename` hashes to `integrity`, read in 64 KiB
+ * chunks off the event loop.
+ *
+ * The synchronous {@link verifyFileIntegrity} reads and hashes a whole blob
+ * before yielding, which stalls everything else for the length of a large
+ * CAS file. Prefer this wherever the caller is already asynchronous.
+ *
+ * A path that is absent or is not a regular file is `false`, so the caller
+ * falls back to fetching it; any other read failure is thrown.
+ */
+export async function verifyFileIntegrityAsync (
+  filename: string,
+  integrity: Integrity
+): Promise<boolean> {
+  let hasher: crypto.Hash
+  try {
+    hasher = crypto.createHash(integrity.algorithm)
+  } catch {
+    // An unusable algorithm, e.g. from a corrupted index file, is a
+    // verification failure rather than an error, as in `hashMatches`.
+    return false
+  }
+  try {
+    for await (const chunk of fs.createReadStream(filename, { highWaterMark: CHUNK_SIZE })) {
+      hasher.update(chunk as Buffer)
+    }
+  } catch (err: unknown) {
+    if (util.types.isNativeError(err) && 'code' in err && (err.code === 'ENOENT' || err.code === 'EISDIR')) {
+      return false
+    }
+    throw err
+  }
+  return hasher.digest('hex') === integrity.digest
 }
 
 /** The file's content, or `null` if it is no longer there. */

--- a/pnpm11/store/cafs/src/checkPkgFilesIntegrity.ts
+++ b/pnpm11/store/cafs/src/checkPkgFilesIntegrity.ts
@@ -241,7 +241,8 @@ export function verifyFileIntegrity (
  * CAS file. Prefer this wherever the caller is already asynchronous.
  *
  * A path that is absent or is not a regular file is `false`, so the caller
- * falls back to fetching it; any other read failure is thrown.
+ * falls back to fetching it, as is an `integrity.algorithm` the runtime does
+ * not support. Any other read failure is thrown.
  */
 export async function verifyFileIntegrityAsync (
   filename: string,

--- a/pnpm11/store/cafs/src/index.ts
+++ b/pnpm11/store/cafs/src/index.ts
@@ -19,6 +19,7 @@ import {
   type PackageFilesIndex,
   takeVerifiedFileIntegrity,
   type VerifiedFileIntegrity,
+  verifyFileIntegrity,
   type VerifyResult,
 } from './checkPkgFilesIntegrity.js'
 import {
@@ -50,6 +51,7 @@ export {
   type SideEffectsDiff,
   takeVerifiedFileIntegrity,
   type VerifiedFileIntegrity,
+  verifyFileIntegrity,
   type VerifyResult,
 }
 

--- a/pnpm11/store/cafs/src/index.ts
+++ b/pnpm11/store/cafs/src/index.ts
@@ -20,6 +20,7 @@ import {
   takeVerifiedFileIntegrity,
   type VerifiedFileIntegrity,
   verifyFileIntegrity,
+  verifyFileIntegrityAsync,
   type VerifyResult,
 } from './checkPkgFilesIntegrity.js'
 import {
@@ -52,6 +53,7 @@ export {
   takeVerifiedFileIntegrity,
   type VerifiedFileIntegrity,
   verifyFileIntegrity,
+  verifyFileIntegrityAsync,
   type VerifyResult,
 }
 

--- a/pnpm11/store/cafs/test/verifyFileIntegrityAsync.test.ts
+++ b/pnpm11/store/cafs/test/verifyFileIntegrityAsync.test.ts
@@ -41,6 +41,20 @@ describe('verifyFileIntegrityAsync', () => {
     ).resolves.toBe(false)
   })
 
+  // Windows has no `O_NOFOLLOW`, and creating a symlink there needs a
+  // privilege the test runner is not guaranteed.
+  const itPosix = process.platform === 'win32' ? it.skip : it
+  itPosix('refuses a symlink even when it names content with the right digest', async () => {
+    const dir = temporaryDirectory()
+    const outside = path.join(dir, 'outside')
+    const link = path.join(dir, 'linked')
+    fs.writeFileSync(outside, 'addon')
+    fs.symlinkSync(outside, link)
+    await expect(
+      verifyFileIntegrityAsync(link, { algorithm: 'sha512', digest: sha512('addon') })
+    ).resolves.toBe(false)
+  })
+
   it('reports an unusable algorithm as unverified', async () => {
     const dir = temporaryDirectory()
     const file = path.join(dir, 'addon.node')

--- a/pnpm11/store/cafs/test/verifyFileIntegrityAsync.test.ts
+++ b/pnpm11/store/cafs/test/verifyFileIntegrityAsync.test.ts
@@ -1,0 +1,52 @@
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { describe, expect, it } from '@jest/globals'
+import { temporaryDirectory } from 'tempy'
+
+import { verifyFileIntegrityAsync } from '../src/index.js'
+
+const sha512 = (data: string): string => crypto.createHash('sha512').update(data).digest('hex')
+
+describe('verifyFileIntegrityAsync', () => {
+  it('accepts content that hashes to the digest and rejects content that does not', async () => {
+    const dir = temporaryDirectory()
+    const file = path.join(dir, 'addon.node')
+    fs.writeFileSync(file, 'addon')
+    const digest = sha512('addon')
+    await expect(verifyFileIntegrityAsync(file, { algorithm: 'sha512', digest })).resolves.toBe(true)
+
+    fs.writeFileSync(file, 'tampered')
+    await expect(verifyFileIntegrityAsync(file, { algorithm: 'sha512', digest })).resolves.toBe(false)
+  })
+
+  it('hashes a file larger than one read chunk', async () => {
+    const dir = temporaryDirectory()
+    const file = path.join(dir, 'big.node')
+    const content = 'x'.repeat(64 * 1024 * 3 + 17)
+    fs.writeFileSync(file, content)
+    await expect(
+      verifyFileIntegrityAsync(file, { algorithm: 'sha512', digest: sha512(content) })
+    ).resolves.toBe(true)
+  })
+
+  it.each([
+    ['a path that does not exist', (dir: string) => path.join(dir, 'absent')],
+    ['a path that is not a regular file', (dir: string) => dir],
+  ])('reports %s as unverified rather than throwing', async (_name, target) => {
+    const dir = temporaryDirectory()
+    await expect(
+      verifyFileIntegrityAsync(target(dir), { algorithm: 'sha512', digest: sha512('addon') })
+    ).resolves.toBe(false)
+  })
+
+  it('reports an unusable algorithm as unverified', async () => {
+    const dir = temporaryDirectory()
+    const file = path.join(dir, 'addon.node')
+    fs.writeFileSync(file, 'addon')
+    await expect(
+      verifyFileIntegrityAsync(file, { algorithm: 'not-an-algorithm', digest: sha512('addon') })
+    ).resolves.toBe(false)
+  })
+})

--- a/pnpm11/store/cafs/test/verifyFileIntegrityAsync.test.ts
+++ b/pnpm11/store/cafs/test/verifyFileIntegrityAsync.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process'
 import crypto from 'node:crypto'
 import fs from 'node:fs'
 import path from 'node:path'
@@ -52,6 +53,15 @@ describe('verifyFileIntegrityAsync', () => {
     fs.symlinkSync(outside, link)
     await expect(
       verifyFileIntegrityAsync(link, { algorithm: 'sha512', digest: sha512('addon') })
+    ).resolves.toBe(false)
+  })
+
+  itPosix('does not hang on a FIFO planted at the path', async () => {
+    const dir = temporaryDirectory()
+    const fifo = path.join(dir, 'fifo')
+    execFileSync('mkfifo', [fifo])
+    await expect(
+      verifyFileIntegrityAsync(fifo, { algorithm: 'sha512', digest: sha512('addon') })
     ).resolves.toBe(false)
   })
 

--- a/pnpm11/store/controller-types/src/index.ts
+++ b/pnpm11/store/controller-types/src/index.ts
@@ -59,6 +59,16 @@ export interface StoreController {
   prune: (removeAlienFiles?: boolean) => Promise<void>
   upload: UploadPkgToStore
   addFileToStore?: (buffer: Buffer, mode: number) => FileWriteResult
+  /**
+   * Path of the file the store already holds for this content, or `undefined`
+   * when it holds none.
+   *
+   * Lets a caller that would otherwise fetch content the store already has —
+   * a remote side-effects artifact whose files are shared with the package's
+   * own, or with another artifact — skip the transfer. `mode` matters because
+   * the store keeps executable and non-executable content apart.
+   */
+  locateFileInStore?: (hexDigest: string, mode: number) => Promise<string | undefined>
   clearResolutionCache: () => void
 }
 

--- a/pnpm11/store/controller/src/storeController/index.ts
+++ b/pnpm11/store/controller/src/storeController/index.ts
@@ -1,12 +1,12 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import util from 'node:util'
 
 import { PnpmError } from '@pnpm/error'
 import type { Fetchers } from '@pnpm/fetching.fetcher-base'
 import type { CustomFetcher } from '@pnpm/hooks.types'
 import { createPackageRequester } from '@pnpm/installing.package-requester'
 import type { ResolveFunction } from '@pnpm/resolving.resolver-base'
+import { verifyFileIntegrity } from '@pnpm/store.cafs'
 import type {
   ImportIndexedPackageAsync,
   StoreController,
@@ -105,13 +105,13 @@ export function createPackageStore (
 
   async function locateFileInStore (hexDigest: string, mode: number): Promise<string | undefined> {
     const filePath = cafs.getFilePathByModeInCafs(hexDigest, mode)
-    try {
-      await fs.promises.stat(filePath)
-      return filePath
-    } catch (err: unknown) {
-      if (util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT') return undefined
-      throw err
-    }
+    // Verified unconditionally rather than answering to `verifyStoreIntegrity`:
+    // the download this skips would have ended in a CAS write, and that path
+    // checks content already at the destination whatever the setting says.
+    // Hashing a local file is far cheaper than the transfer it avoids.
+    return verifyFileIntegrity(filePath, { algorithm: 'sha512', digest: hexDigest })
+      ? filePath
+      : undefined
   }
 
   async function upload (builtPkgLocation: string, opts: { filesIndexFile: string, sideEffectsCacheKey: string }) {

--- a/pnpm11/store/controller/src/storeController/index.ts
+++ b/pnpm11/store/controller/src/storeController/index.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import util from 'node:util'
 
 import { PnpmError } from '@pnpm/error'
 import type { Fetchers } from '@pnpm/fetching.fetcher-base'
@@ -98,7 +99,19 @@ export function createPackageStore (
     // A read-only store cannot accept new content, so it does not advertise the
     // direct write capability that remote side-effects hydration requires.
     addFileToStore: initOpts.frozenStore ? undefined : cafs.addFile,
+    locateFileInStore,
     clearResolutionCache: initOpts.clearResolutionCache,
+  }
+
+  async function locateFileInStore (hexDigest: string, mode: number): Promise<string | undefined> {
+    const filePath = cafs.getFilePathByModeInCafs(hexDigest, mode)
+    try {
+      await fs.promises.stat(filePath)
+      return filePath
+    } catch (err: unknown) {
+      if (util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT') return undefined
+      throw err
+    }
   }
 
   async function upload (builtPkgLocation: string, opts: { filesIndexFile: string, sideEffectsCacheKey: string }) {

--- a/pnpm11/store/controller/src/storeController/index.ts
+++ b/pnpm11/store/controller/src/storeController/index.ts
@@ -6,7 +6,7 @@ import type { Fetchers } from '@pnpm/fetching.fetcher-base'
 import type { CustomFetcher } from '@pnpm/hooks.types'
 import { createPackageRequester } from '@pnpm/installing.package-requester'
 import type { ResolveFunction } from '@pnpm/resolving.resolver-base'
-import { verifyFileIntegrity } from '@pnpm/store.cafs'
+import { verifyFileIntegrityAsync } from '@pnpm/store.cafs'
 import type {
   ImportIndexedPackageAsync,
   StoreController,
@@ -109,7 +109,7 @@ export function createPackageStore (
     // the download this skips would have ended in a CAS write, and that path
     // checks content already at the destination whatever the setting says.
     // Hashing a local file is far cheaper than the transfer it avoids.
-    return verifyFileIntegrity(filePath, { algorithm: 'sha512', digest: hexDigest })
+    return await verifyFileIntegrityAsync(filePath, { algorithm: 'sha512', digest: hexDigest })
       ? filePath
       : undefined
   }

--- a/pnpm11/store/controller/test/index.ts
+++ b/pnpm11/store/controller/test/index.ts
@@ -1,4 +1,5 @@
 /// <reference path="../../../__typings__/index.d.ts"/>
+import { createHash } from 'node:crypto'
 import fs from 'node:fs'
 import path from 'node:path'
 
@@ -124,4 +125,48 @@ describe('store.addFileToStore', () => {
   it('is withheld by a read-only store', () => {
     expect(packageStore(true).addFileToStore).toBeUndefined()
   })
+})
+
+describe('store.locateFileInStore', () => {
+  function packageStore (verifyStoreIntegrity: boolean) {
+    const tmp = temporaryDirectory()
+    const storeDir = path.join(tmp, 'store')
+    const storeIndex = new StoreIndex(storeDir)
+    fs.mkdirSync(path.join(storeDir, 'files'), { recursive: true })
+    return createPackageStore({} as never, {} as never, {
+      storeDir,
+      cacheDir: path.join(tmp, 'cache'),
+      verifyStoreIntegrity,
+      virtualStoreDirMaxLength: 120,
+      clearResolutionCache: () => {},
+      storeIndex,
+    })
+  }
+
+  it('offers content the store holds and nothing it does not', async () => {
+    const store = packageStore(false)
+    const bytes = Buffer.from('addon')
+    const digest = createHash('sha512').update(bytes).digest('hex')
+    expect(await store.locateFileInStore!(digest, 0o644)).toBeUndefined()
+
+    const { filePath } = store.addFileToStore!(bytes, 0o644)
+    expect(await store.locateFileInStore!(digest, 0o644)).toBe(filePath)
+    // The store keeps executable content apart, so the same bytes under
+    // another mode are a different file it does not yet have.
+    expect(await store.locateFileInStore!(digest, 0o755)).toBeUndefined()
+  })
+
+  it.each([true, false])(
+    'withholds content that no longer hashes to its digest (verifyStoreIntegrity: %s)',
+    async (verifyStoreIntegrity) => {
+      const store = packageStore(verifyStoreIntegrity)
+      const bytes = Buffer.from('addon')
+      const digest = createHash('sha512').update(bytes).digest('hex')
+      const { filePath } = store.addFileToStore!(bytes, 0o644)
+      expect(await store.locateFileInStore!(digest, 0o644)).toBe(filePath)
+
+      fs.writeFileSync(filePath, 'tampered')
+      expect(await store.locateFileInStore!(digest, 0o644)).toBeUndefined()
+    }
+  )
 })

--- a/pnpr/client/src/index.ts
+++ b/pnpr/client/src/index.ts
@@ -12,6 +12,7 @@ export { type ResponseMetadata } from './protocol.js'
 export { type PnprProject, resolveViaPnprServer, type ResolveViaPnprServerOptions, type ResolveViaPnprServerResult } from './resolveViaPnprServer.js'
 export {
   ARTIFACT_KIND,
+  artifactBlobDigest,
   type ArtifactBlobRequest,
   type ArtifactBlobUpload,
   type ArtifactCandidate,

--- a/pnpr/client/src/installSharedSideEffects.ts
+++ b/pnpr/client/src/installSharedSideEffects.ts
@@ -123,6 +123,11 @@ export function createRemoteSideEffectsRestorer<T extends string> (
   const authorization = createGetAuthHeaderByURI(opts.configByUri)(registryUrl)
   const artifactLimit = pLimit(4)
   const downloadLimit = pLimit(16)
+  // A store probe reads and hashes the candidate, so it holds a descriptor for
+  // as long as the file takes. A manifest may list `MAX_MANIFEST_FILES` paths
+  // and several artifacts hydrate at once, so probing every file the moment it
+  // is asked for would exhaust the descriptor table.
+  const storeLookupLimit = pLimit(16)
   // Restorer-lifetime, so one blob shared by several artifacts is fetched and
   // stored once however the batches happen to fall.
   const storedBlobs = new Map<string, Promise<string>>()
@@ -266,10 +271,10 @@ export function createRemoteSideEffectsRestorer<T extends string> (
             // files with each other. The store addresses content by the digest
             // this manifest entry already carries, so anything it holds is the
             // same bytes and does not need transferring again.
-            const present = await opts.storeController.locateFileInStore?.(
+            const present = await storeLookupLimit(async () => opts.storeController.locateFileInStore?.(
               artifactBlobDigest(file.integrity),
               file.mode
-            )
+            ))
             if (present != null) return present
             const bytes = await downloadLimit(async () => downloadSharedArtifactBlob({
               registryUrl,

--- a/pnpr/client/src/installSharedSideEffects.ts
+++ b/pnpr/client/src/installSharedSideEffects.ts
@@ -10,6 +10,7 @@ import type { AllowBuild, DepPath, RegistryConfig, RemoteSideEffectsCacheSetting
 import pLimit from 'p-limit'
 
 import {
+  artifactBlobDigest,
   type ArtifactBlobUpload,
   type ArtifactCandidate,
   type ArtifactManifest,
@@ -261,6 +262,15 @@ export function createRemoteSideEffectsRestorer<T extends string> (
         let stored = storedBlobs.get(storedKey)
         if (stored == null) {
           stored = (async () => {
+            // A built package's files are mostly its own, and artifacts share
+            // files with each other. The store addresses content by the digest
+            // this manifest entry already carries, so anything it holds is the
+            // same bytes and does not need transferring again.
+            const present = await opts.storeController.locateFileInStore?.(
+              artifactBlobDigest(file.integrity),
+              file.mode
+            )
+            if (present != null) return present
             const bytes = await downloadLimit(async () => downloadSharedArtifactBlob({
               registryUrl,
               authorization,

--- a/pnpr/client/src/sharedSideEffects.ts
+++ b/pnpr/client/src/sharedSideEffects.ts
@@ -672,6 +672,16 @@ function ownersEqual (left: OwnerScope, right: OwnerScope): boolean {
     : left.package === (right as { type: 'publisher', package: string }).package
 }
 
+/**
+ * Hex digest identifying an artifact blob's content, from its `sha512-` value.
+ *
+ * The same identity the store addresses its content by, so a caller holding a
+ * manifest entry can ask the store whether it already has the bytes.
+ */
+export function artifactBlobDigest (integrity: string): string {
+  return blobId(integrity)
+}
+
 function blobId (integrity: string): string {
   if (typeof integrity !== 'string' || !integrity.startsWith('sha512-')) {
     throw new Error('Shared artifact blobs require sha512 integrity')

--- a/pnpr/client/src/sharedSideEffects.ts
+++ b/pnpr/client/src/sharedSideEffects.ts
@@ -677,6 +677,8 @@ function ownersEqual (left: OwnerScope, right: OwnerScope): boolean {
  *
  * The same identity the store addresses its content by, so a caller holding a
  * manifest entry can ask the store whether it already has the bytes.
+ *
+ * @throws if `integrity` is not a `sha512-` value carrying a 64-byte digest.
  */
 export function artifactBlobDigest (integrity: string): string {
   return blobId(integrity)

--- a/pnpr/client/test/installSharedSideEffects.test.ts
+++ b/pnpr/client/test/installSharedSideEffects.test.ts
@@ -114,6 +114,7 @@ describe('install remote side-effects', () => {
       resolvedFrom: 'remote',
     }
     const storedFiles: Array<{ bytes: Buffer, mode: number }> = []
+    const alreadyInStore = new Map<string, string>()
     const storeController = {
       addFileToStore: (bytes: Buffer, mode: number) => {
         storedFiles.push({ bytes, mode })
@@ -123,6 +124,7 @@ describe('install remote side-effects', () => {
           filePath: '/store/cafs/build-addon.node',
         }
       },
+      locateFileInStore: async (hexDigest: string, mode: number) => alreadyInStore.get(`${hexDigest}\0${mode}`),
     } as unknown as StoreController
     const depsGraph: DepsGraph<typeof graphKey> = {
       [graphKey]: {
@@ -170,6 +172,43 @@ describe('install remote side-effects', () => {
         '/-/pnpr/v0/artifacts/resolve',
         '/-/pnpr/v0/artifacts/blob',
       ])
+
+      // Content the store already holds is the same content, addressed by the
+      // digest the manifest carries, so a second restore transfers nothing.
+      alreadyInStore.set(
+        `${createHash('sha512').update(builtFile).digest('hex')}\0${0o755}`,
+        '/store/cafs/already-there'
+      )
+      storedFiles.length = 0
+      requestedPaths.length = 0
+      const reuse = createRemoteSideEffectsRestorer({
+        allowBuild: candidate => candidate === depPath,
+        configByUri: {},
+        depsGraph,
+        depsStateCache: {},
+        ignoreScripts: false,
+        pnprServer,
+        settings: { organization: 'acme', packages: [packageName], trustedKeys },
+        sideEffectsCacheRead: false,
+        storeController,
+      })
+      const reusedFiles: PackageFilesResponse = {
+        filesMap: new Map(),
+        requiresBuild: true,
+        resolvedFrom: 'remote',
+      }
+      const reusedKey = await reuse?.restore({
+        graphKey,
+        depPath,
+        files: reusedFiles,
+        name: packageName,
+        resolution: { integrity: sourceIntegrity } as LockfileResolution,
+        version: packageVersion,
+      })
+      expect(reusedFiles.sideEffectsMaps?.get(reusedKey!)?.added?.get('build/addon.node'))
+        .toBe('/store/cafs/already-there')
+      expect(storedFiles).toEqual([])
+      expect(requestedPaths).not.toContain('/-/pnpr/v0/artifacts/blob')
 
       // Restoring is per package so one package never waits on another's
       // fetch, but packages restored together still share a lookup request.


### PR DESCRIPTION
## Summary

Follow-up to pnpm/pnpm#14171. Related to pnpm/pnpm#13771 and pnpm/rfcs#20.

Restoring a dependency's build from the remote side-effects cache downloaded every file the artifact's manifest listed, then handed the bytes to the store — which addresses content by the very digest that manifest already carries. A built package's files are mostly its own, and artifacts share files with one another, so most of what crossed the wire was content the store already had.

- Adds `locateFileInStore` to the store controller: given a hex digest and a mode, it answers with the path the store holds for that content, or nothing. The mode is part of the question because the store keeps executable and non-executable content apart.
- The restore consults it before fetching, so only files the store is actually missing are transferred.
- Both stacks. pacquet already had the store-side helper (`cas_file_path_by_mode`); only the restore path needed the check.

This trusts nothing new: the store addresses content by its hash, so a file it holds under an artifact's digest is that artifact's bytes. It also does not change when trust is checked — nothing about a restore is persisted, so the signed manifest is still verified on every install.

The pacquet test pins the part that could otherwise drift silently. If the digest encoding or the executable-bit rule ever diverged between the store's write side and the artifact side, nothing would fail — the lookup would simply always miss, and every install would go back to downloading everything.

## Squash Commit Body

```text
Reuse store content when restoring a remote build.

A remote side-effects restore downloaded every file of the artifact, then handed the bytes to the store, which addresses content by the very digest the artifact manifest already carries. A built package's files are mostly its own, and artifacts share files with one another, so most of what was transferred was content the store already had.

Ask the store first. `locateFileInStore` answers with the path it holds for a digest and mode, or nothing, and the restore only fetches what is missing. The store keeps executable and non-executable content apart, so the mode is part of the question.

Nothing is trusted that was not trusted before: the store addresses content by its hash, so a file it holds under an artifact's digest is that artifact's bytes.

The pacquet side already had the store helper this needs; its test pins the part that could silently drift — a digest or executable-bit rule diverging between the write side and the artifact side would not fail anything, it would just make the lookup always miss.

Follow-up to pnpm/pnpm#14171.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790345151&installation_model_id=426870&pr_number=14189&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14189&signature=544fccb34e1a599303b86500acc00b2cbde1a2d1f8127deb03852d2e60f9f0d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Remote side-effects restoration now reuses matching files already present in the local store, avoiding unnecessary downloads.
  * Limited concurrent store lookups to improve restoration stability.
* **Bug Fixes**
  * Preserved download behavior when artifacts are unavailable locally.
  * Reuses artifacts only when integrity, file type, and file mode match the requested content.
  * Improved handling of executable and non-executable artifact files.
* **Tests**
  * Added coverage for local artifact reuse, integrity verification, corrupted content, non-regular paths, and file mode handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->