### PR TITLE
refactor(pnpr): render errors through IntoResponse

### DIFF
--- a/pnpr/crates/pnpr/src/error.rs
+++ b/pnpr/crates/pnpr/src/error.rs
@@ -1,4 +1,7 @@
-use axum::http::StatusCode;
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
 use derive_more::{Display, Error, From};
 
 #[derive(Debug, Display, Error, From)]
@@ -111,6 +114,13 @@ pub enum RegistryError {
         #[error(not(source))]
         reason: String,
     },
+
+    /// Nothing is served at the addressed route: an unknown package,
+    /// registry, or revision, or a private one masked as absent so the
+    /// 404 cannot be used to probe for its existence. Carries no detail
+    /// for that reason.
+    #[display("Not Found")]
+    NotFound,
 
     /// A publish targeted a `name@version` that is already hosted.
     /// Published versions are immutable; npm and verdaccio both answer a
@@ -263,6 +273,7 @@ impl RegistryError {
             RegistryError::InvalidPackageName { .. } => "invalid_package_name",
             RegistryError::InvalidTarballName { .. } => "invalid_tarball_name",
             RegistryError::InvalidConfig { .. } => "invalid_config",
+            RegistryError::NotFound => "not_found",
             RegistryError::Unauthenticated { .. } => "unauthenticated",
             RegistryError::Forbidden { .. } => "forbidden",
             RegistryError::TeamsConfigManaged { .. } => "teams_config_managed",
@@ -351,6 +362,7 @@ impl RegistryError {
             | RegistryError::PackumentWriteConflict { .. }
             | RegistryError::RevisionReferenceLimit { .. }
             | RegistryError::RevisionReferenceWriteConflict { .. } => StatusCode::CONFLICT,
+            RegistryError::NotFound => StatusCode::NOT_FOUND,
             RegistryError::Unauthenticated { .. } => StatusCode::UNAUTHORIZED,
             RegistryError::Forbidden { .. } => StatusCode::FORBIDDEN,
             RegistryError::TeamsConfigManaged { .. } => StatusCode::FORBIDDEN,
@@ -579,6 +591,32 @@ fn is_sensitive_query_key(key: &str) -> bool {
             | "accesstoken"
             | "apikey",
     )
+}
+
+/// Render the error as the response the client receives, logging it on the way
+/// out at a severity that matches the status: server faults are `error`, the
+/// statuses an unauthorized or probing client provokes routinely
+/// (401 / 403 / 404) are `debug`, and the rest are `warn`. The `error` branch
+/// logs [`Self::log_message`] because every variant that can embed a request
+/// URL — and so a credential — is a server fault; the client sees only
+/// [`Self::public_message`] either way.
+impl IntoResponse for RegistryError {
+    fn into_response(self) -> Response {
+        let status = self.status_code();
+        let error_kind = self.log_kind();
+        if status.is_server_error() {
+            let err = self.log_message();
+            tracing::error!(%err, %error_kind, %status, "request failed");
+        } else if matches!(
+            status,
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN | StatusCode::NOT_FOUND,
+        ) {
+            tracing::debug!(err = %self, %error_kind, %status, "request failed");
+        } else {
+            tracing::warn!(err = %self, %error_kind, %status, "request failed");
+        }
+        (status, self.public_message()).into_response()
+    }
 }
 
 pub type Result<Value, Error = RegistryError> = std::result::Result<Value, Error>;

--- a/pnpr/crates/pnpr/src/error.rs
+++ b/pnpr/crates/pnpr/src/error.rs
@@ -593,13 +593,10 @@ fn is_sensitive_query_key(key: &str) -> bool {
     )
 }
 
-/// Render the error as the response the client receives, logging it on the way
-/// out at a severity that matches the status: server faults are `error`, the
-/// statuses an unauthorized or probing client provokes routinely
-/// (401 / 403 / 404) are `debug`, and the rest are `warn`. The `error` branch
-/// logs [`Self::log_message`] because every variant that can embed a request
-/// URL — and so a credential — is a server fault; the client sees only
-/// [`Self::public_message`] either way.
+/// Only server faults need [`Self::log_message`]'s redaction: every variant
+/// that can embed a request URL — and so a credential — is one. The 401 / 403 /
+/// 404 tier drops to `debug` so a probing or unauthorized client cannot flood
+/// the log with warnings.
 impl IntoResponse for RegistryError {
     fn into_response(self) -> Response {
         let status = self.status_code();

--- a/pnpr/crates/pnpr/src/error/tests.rs
+++ b/pnpr/crates/pnpr/src/error/tests.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use axum::http::StatusCode;
+use axum::{body::to_bytes, http::StatusCode, response::IntoResponse};
 use tokio::net::TcpListener;
 
 use super::RegistryError;
@@ -185,4 +185,14 @@ fn is_transient_upstream_error_only_for_availability_failures() {
     // A non-upstream error is never a transient availability failure.
     let config_error = RegistryError::InvalidConfig { reason: "x".to_string() };
     assert!(!config_error.is_transient_upstream_error());
+}
+
+/// Every masked-existence path answers through this variant, so its rendering
+/// is a wire contract: a bare `404 Not Found` that leaks nothing about why.
+#[tokio::test]
+async fn not_found_renders_as_a_bare_404() {
+    let response = RegistryError::NotFound.into_response();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(body.as_ref(), b"Not Found");
 }

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -580,7 +580,7 @@ async fn serve_registry_version_manifest(
 ) -> Response {
     let name = match PackageName::parse(raw_name) {
         Ok(n) => n,
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     };
     let resolved_source = resolve_registry_source(state, registry, name.as_str());
     let bytes = match &resolved_source {
@@ -590,12 +590,12 @@ async fn serve_registry_version_manifest(
             if let Err(err) =
                 authorize(state, identity, &resolved_source, name.as_str(), Action::Access)
             {
-                return error_response(&err);
+                return err.into_response();
             }
             match load_upstream_packument_for(state, identity, source, &name).await {
                 Ok(Some(bytes)) => bytes,
                 Ok(None) => return not_found(),
-                Err(response) => return *response,
+                Err(err) => return err.into_response(),
             }
         }
         RegistrySource::Hosted(source) => {
@@ -603,19 +603,19 @@ async fn serve_registry_version_manifest(
             // an explicit-rule 401/403 — see `serve_registry_packument`.
             let org = match hosted_read_namespace(state, identity, source, name.as_str()) {
                 Ok(org) => org,
-                Err(response) => return *response,
+                Err(err) => return err.into_response(),
             };
             match state.inner.storage.for_hosted(&org).read_hosted_packument(&name).await {
                 Ok(Some(bytes)) => bytes,
                 Ok(None) => return not_found(),
-                Err(err) => return error_response(&err),
+                Err(err) => return err.into_response(),
             }
         }
         RegistrySource::Unclaimed | RegistrySource::NotFound => return not_found(),
     };
     let packument: Value = match serde_json::from_slice(&bytes) {
         Ok(v) => v,
-        Err(err) => return error_response(&RegistryError::Json(err)),
+        Err(err) => return RegistryError::Json(err).into_response(),
     };
     if let Some(osv_index) = state.inner.osv_index.as_ref() {
         let resolved = resolve_version_or_tag(&packument, version_or_tag);
@@ -642,7 +642,7 @@ async fn serve_registry_version_manifest(
     };
     match serde_json::to_vec(&manifest) {
         Ok(body) => packument_bytes_response(body, "application/json", None),
-        Err(err) => error_response(&RegistryError::Json(err)),
+        Err(err) => RegistryError::Json(err).into_response(),
     }
 }
 
@@ -665,9 +665,9 @@ fn authorized_upstream<'a>(
     state: &'a AppState,
     identity: &Identity,
     upstream: &str,
-) -> Result<&'a Upstream, Box<Response>> {
+) -> Result<&'a Upstream, RegistryError> {
     let Some(config) = state.inner.config.upstreams.get(upstream) else {
-        return Err(Box::new(not_found()));
+        return Err(RegistryError::NotFound);
     };
     // A private upstream registry gates by its `access:` list; a public registry
     // (no access) is reachable by anyone at its `/~<name>/` URL, its upstream
@@ -677,28 +677,28 @@ fn authorized_upstream<'a>(
     {
         let user = require_caller(identity, "upstream access")
             .unwrap_or_else(|_| "<anonymous>".to_string());
-        return Err(Box::new(error_response(&RegistryError::Forbidden {
+        return Err(RegistryError::Forbidden {
             user,
             action: "access",
             resource: format!("upstream {upstream:?}"),
-        })));
+        });
     }
-    state.inner.upstreams.get(upstream).ok_or_else(|| Box::new(not_found()))
+    state.inner.upstreams.get(upstream).ok_or_else(|| RegistryError::NotFound)
 }
 
 fn authorized_revision_upstream<'a>(
     state: &'a AppState,
     identity: &Identity,
     registry: &str,
-) -> Result<&'a Upstream, Box<Response>> {
+) -> Result<&'a Upstream, RegistryError> {
     if !matches!(state.inner.config.registries.get(registry), Some(Registry::Upstream { .. })) {
-        return Err(Box::new(not_found()));
+        return Err(RegistryError::NotFound);
     }
     let Some(config) = state.inner.config.upstreams.get(registry) else {
-        return Err(Box::new(not_found()));
+        return Err(RegistryError::NotFound);
     };
     if config.rules.refines_access() {
-        return Err(Box::new(not_found()));
+        return Err(RegistryError::NotFound);
     }
     authorized_upstream(state, identity, registry)
 }
@@ -913,13 +913,11 @@ async fn load_upstream_packument_for(
     identity: &Identity,
     upstream: &str,
     name: &PackageName,
-) -> Result<Option<Vec<u8>>, Box<Response>> {
+) -> Result<Option<Vec<u8>>, RegistryError> {
     let namespace = upstream_cache_namespace(state, upstream);
     let upstream = authorized_upstream(state, identity, upstream)?;
     let ttl = upstream.maxage().unwrap_or(state.inner.config.packument_ttl);
-    load_upstream_packument(state, &namespace, upstream, name, ttl)
-        .await
-        .map_err(|err| Box::new(error_response(&err)))
+    load_upstream_packument(state, &namespace, upstream, name, ttl).await
 }
 
 /// Load a package's packument bytes through the addressed `/~<name>/` (or,
@@ -933,7 +931,7 @@ async fn load_packument_for_read(
     identity: &Identity,
     registry: Option<&str>,
     name: &PackageName,
-) -> Result<Option<Vec<u8>>, Box<Response>> {
+) -> Result<Option<Vec<u8>>, RegistryError> {
     let target = match registry {
         Some(registry) => registry.to_string(),
         None => match default_registry_target(state) {
@@ -949,26 +947,16 @@ async fn load_packument_for_read(
     let resolved_source = resolve_registry_source(state, &target, name.as_str());
     match &resolved_source {
         RegistrySource::Upstream(source) => {
-            if let Err(err) =
-                authorize(state, identity, &resolved_source, name.as_str(), Action::Access)
-            {
-                return Err(Box::new(error_response(&err)));
-            }
+            authorize(state, identity, &resolved_source, name.as_str(), Action::Access)?;
             load_upstream_packument_for(state, identity, source, name).await
         }
         RegistrySource::Hosted(source) => {
             let org = match hosted_gate(state, identity, source, name.as_str()) {
                 HostedGate::Allowed(org) => org,
                 HostedGate::MaskNotFound => return Ok(None),
-                HostedGate::Denied(err) => return Err(Box::new(error_response(&err))),
+                HostedGate::Denied(err) => return Err(err),
             };
-            state
-                .inner
-                .storage
-                .for_hosted(&org)
-                .read_hosted_packument(name)
-                .await
-                .map_err(|err| Box::new(error_response(&err)))
+            state.inner.storage.for_hosted(&org).read_hosted_packument(name).await
         }
         RegistrySource::Unclaimed | RegistrySource::NotFound => Ok(None),
     }
@@ -986,7 +974,7 @@ async fn serve_packument_via_upstream(
     let bytes = match load_upstream_packument_for(state, identity, upstream, name).await {
         Ok(Some(bytes)) => bytes,
         Ok(None) => return not_found(),
-        Err(response) => return *response,
+        Err(err) => return err.into_response(),
     };
     match packument_response(
         name,
@@ -997,7 +985,7 @@ async fn serve_packument_via_upstream(
         wants_abbreviated(headers),
     ) {
         Ok(response) => response,
-        Err(err) => error_response(&err),
+        Err(err) => err.into_response(),
     }
 }
 
@@ -1016,7 +1004,7 @@ async fn serve_tarball_via_upstream(
 ) -> Response {
     let name = match PackageName::parse(raw_name) {
         Ok(n) => n,
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     };
     // A canonical `<basename>-<version>.tgz` (or the scoped wire form) is
     // normalized as usual. A non-canonical basename preserved verbatim from
@@ -1029,7 +1017,7 @@ async fn serve_tarball_via_upstream(
         Ok((canonical, version)) => (canonical, Some(version)),
         Err(err) => {
             if !crate::package_name::is_safe_path_segment(filename) {
-                return error_response(&err);
+                return err.into_response();
             }
             (filename.to_string(), None)
         }
@@ -1037,7 +1025,7 @@ async fn serve_tarball_via_upstream(
     let namespace = upstream_cache_namespace(state, upstream);
     let upstream = match authorized_upstream(state, identity, upstream) {
         Ok(upstream) => upstream,
-        Err(response) => return *response,
+        Err(err) => return err.into_response(),
     };
     // Pre-check OSV on the filename-derived version (when the name is
     // canonical) to fail fast; the authoritative check against the
@@ -1045,7 +1033,7 @@ async fn serve_tarball_via_upstream(
     if let Some(version) = &parsed_version
         && let Err(err) = ensure_osv_allowed(state, &name, version)
     {
-        return error_response(&err);
+        return err.into_response();
     }
     let ttl = upstream.maxage().unwrap_or(state.inner.config.packument_ttl);
     // Serve a cached hit before touching the packument: a cached entry was
@@ -1081,18 +1069,18 @@ async fn serve_tarball_via_upstream(
     {
         Ok(Some(bytes)) => bytes,
         Ok(None) => return not_found(),
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     };
     let TarballDist { version, integrity } =
         match expected_tarball_dist(&packument, &name, &filename) {
             Ok(Some(dist)) => dist,
             Ok(None) => return not_found(),
-            Err(err) => return error_response(&err),
+            Err(err) => return err.into_response(),
         };
     if parsed_version.as_deref() != Some(version.as_str())
         && let Err(err) = ensure_osv_allowed(state, &name, &version)
     {
-        return error_response(&err);
+        return err.into_response();
     }
     if upstream.caches()
         && state.inner.osv_index.is_some()
@@ -1110,12 +1098,12 @@ async fn serve_tarball_via_upstream(
     {
         Ok(FetchOutcome::Ok(response)) => response,
         Ok(FetchOutcome::NotFound) => return not_found(),
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     };
     let write =
         match state.inner.storage.open_upstream_tarball_tmp(&namespace, &name, &filename).await {
             Ok(write) => write,
-            Err(err) => return error_response(&err),
+            Err(err) => return err.into_response(),
         };
     if !upstream.caches() {
         // Fetch-through: verify and stream from the temp file, then remove it,
@@ -1131,7 +1119,7 @@ async fn serve_tarball_via_upstream(
             Ok((file, len, tmp_path)) => {
                 tarball_response(streaming::stream_file_and_remove(file, tmp_path), Some(len))
             }
-            Err(err) => error_response(&tarball_stream_error(err, &name, &filename)),
+            Err(err) => tarball_stream_error(err, &name, &filename).into_response(),
         };
     }
     // Stream the download to the client while teeing it into the namespaced
@@ -1141,7 +1129,7 @@ async fn serve_tarball_via_upstream(
     // chunked and the client reads to EOF (then re-verifies the integrity).
     match streaming::stream_verified_to_cache(response, write, &integrity, MAX_TARBALL_BYTES) {
         Ok(body) => tarball_response(body, None),
-        Err(err) => error_response(&tarball_stream_error(err, &name, &filename)),
+        Err(err) => tarball_stream_error(err, &name, &filename).into_response(),
     }
 }
 
@@ -1175,7 +1163,7 @@ async fn serve_upstream_revision_tarball(
 ) -> Response {
     let upstream = match authorized_revision_upstream(state, identity, registry) {
         Ok(upstream) => upstream,
-        Err(response) => return *response,
+        Err(err) => return err.into_response(),
     };
     let namespace = upstream_cache_namespace(state, registry);
     if upstream.caches() {
@@ -1197,12 +1185,12 @@ async fn serve_upstream_revision_tarball(
     let response = match upstream.fetch_revision_tarball_response(digest).await {
         Ok(FetchOutcome::Ok(response)) => response,
         Ok(FetchOutcome::NotFound) => return not_found(),
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     };
     let write =
         match state.inner.storage.open_upstream_revision_tarball_tmp(&namespace, digest).await {
             Ok(write) => write,
-            Err(err) => return error_response(&err),
+            Err(err) => return err.into_response(),
         };
     if !upstream.caches() {
         return match streaming::download_verified_to_temp(
@@ -1220,14 +1208,14 @@ async fn serve_upstream_revision_tarball(
                 integrity,
             ),
             Err(err) => {
-                error_response(&tarball_stream_error_for_package(err, "registry revision", digest))
+                tarball_stream_error_for_package(err, "registry revision", digest).into_response()
             }
         };
     }
     match streaming::stream_verified_to_cache(response, write, integrity, MAX_TARBALL_BYTES) {
         Ok(body) => revision_tarball_response(body, None, digest, integrity),
         Err(err) => {
-            error_response(&tarball_stream_error_for_package(err, "registry revision", digest))
+            tarball_stream_error_for_package(err, "registry revision", digest).into_response()
         }
     }
 }
@@ -1253,16 +1241,16 @@ async fn serve_hosted_revision_tarball(
         let storage = state.inner.storage.for_hosted(&hosted.org);
         let refs = match hosted_revision_refs(&storage, digest).await {
             Ok(refs) => refs,
-            Err(err) => return private_no_cache(error_response(&err)),
+            Err(err) => return private_no_cache(err.into_response()),
         };
         for original in refs {
             let package = match PackageName::parse(&original.package) {
                 Ok(package) => package,
-                Err(err) => return private_no_cache(error_response(&err)),
+                Err(err) => return private_no_cache(err.into_response()),
             };
             let filename = package.tarball_name_for_version(&original.version);
             if let Err(err) = package.canonicalize_tarball_name(&filename) {
-                return private_no_cache(error_response(&err));
+                return private_no_cache(err.into_response());
             }
             if !matches!(
                 resolve_registry_source(state, registry, package.as_str()),
@@ -1276,7 +1264,7 @@ async fn serve_hosted_revision_tarball(
             match hosted_original_is_current(&storage, &package, &original.version, digest).await {
                 Ok(true) => {}
                 Ok(false) => continue,
-                Err(err) => return private_no_cache(error_response(&err)),
+                Err(err) => return private_no_cache(err.into_response()),
             }
             if let Err(err) = ensure_osv_allowed(state, &package, &original.version) {
                 policy_error.get_or_insert(err);
@@ -1311,7 +1299,7 @@ async fn serve_hosted_revision_tarball(
         }
     }
     if let Some(err) = policy_error {
-        return private_no_cache(error_response(&err));
+        return private_no_cache(err.into_response());
     }
     private_no_cache(not_found())
 }
@@ -1372,7 +1360,7 @@ async fn open_hosted_revision_tarball(
     match storage.open_hosted_tarball(package, &filename).await {
         Ok(Some((body, len))) => revision_tarball_response(body, len, digest, integrity),
         Ok(None) => not_found(),
-        Err(err) => error_response(&err),
+        Err(err) => err.into_response(),
     }
 }
 
@@ -1587,7 +1575,7 @@ async fn serve_registry_packument(
 ) -> Response {
     let name = match PackageName::parse(raw_name) {
         Ok(n) => n,
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     };
     // `tarball_base` is the URL the *client* addressed (the path-less host or a
     // `/~<name>/`), not the resolved source's `/~<source>/`. The served
@@ -1604,7 +1592,7 @@ async fn serve_registry_packument(
             if let Err(err) =
                 authorize(state, identity, &resolved_source, name.as_str(), Action::Access)
             {
-                return error_response(&err);
+                return err.into_response();
             }
             let revision_registry = revision_source_registry(state, registry, source);
             serve_packument_via_upstream(
@@ -1640,7 +1628,7 @@ async fn serve_registry_tarball(
 ) -> Response {
     let name = match PackageName::parse(raw_name) {
         Ok(n) => n,
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     };
     let resolved_source = resolve_registry_source(state, registry, name.as_str());
     match &resolved_source {
@@ -1649,7 +1637,7 @@ async fn serve_registry_tarball(
             if let Err(err) =
                 authorize(state, identity, &resolved_source, name.as_str(), Action::Access)
             {
-                return error_response(&err);
+                return err.into_response();
             }
             serve_tarball_via_upstream(state, identity, source, name.as_str(), filename).await
         }
@@ -1720,11 +1708,11 @@ fn hosted_read_namespace(
     identity: &Identity,
     source: &str,
     package: &str,
-) -> Result<String, Box<Response>> {
+) -> Result<String, RegistryError> {
     match hosted_gate(state, identity, source, package) {
         HostedGate::Allowed(org) => Ok(org),
-        HostedGate::MaskNotFound => Err(Box::new(not_found())),
-        HostedGate::Denied(err) => Err(Box::new(error_response(&err))),
+        HostedGate::MaskNotFound => Err(RegistryError::NotFound),
+        HostedGate::Denied(err) => Err(err),
     }
 }
 
@@ -1738,7 +1726,7 @@ async fn serve_hosted_packument(
 ) -> Response {
     let org = match hosted_read_namespace(state, identity, source, name.as_str()) {
         Ok(org) => org,
-        Err(response) => return *response,
+        Err(err) => return err.into_response(),
     };
     // A hosted org has no upstream fallback: a package it does not host is a
     // definitive not-found. Reads come from the org's own storage namespace.
@@ -1752,10 +1740,10 @@ async fn serve_hosted_packument(
             wants_abbreviated(headers),
         ) {
             Ok(response) => response,
-            Err(err) => error_response(&err),
+            Err(err) => err.into_response(),
         },
         Ok(None) => not_found(),
-        Err(err) => error_response(&err),
+        Err(err) => err.into_response(),
     }
 }
 
@@ -1768,21 +1756,21 @@ async fn serve_hosted_tarball(
 ) -> Response {
     let org = match hosted_read_namespace(state, identity, source, name.as_str()) {
         Ok(org) => org,
-        Err(response) => return *response,
+        Err(err) => return err.into_response(),
     };
     let (filename, name_version) = match name.parse_tarball_name(filename) {
         Ok(parsed) => parsed,
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     };
     if let Err(err) = ensure_osv_allowed(state, name, &name_version) {
-        return error_response(&err);
+        return err.into_response();
     }
     match state.inner.storage.for_hosted(&org).open_hosted_tarball(name, &filename).await {
         Ok(Some((body, len))) => tarball_response(body, len),
         Ok(None) => not_found(),
         Err(err) => {
             tracing::warn!(?err, package = %name.as_str(), %filename, "hosted tarball open failed");
-            error_response(&err)
+            err.into_response()
         }
     }
 }
@@ -1952,27 +1940,27 @@ async fn add_user(state: &AppState, name: &str, body: &[u8]) -> Response {
     // (`%2F` → `/`, `%40` → `@`, etc.), so we use `name` verbatim.
     let body: Value = match serde_json::from_slice(body) {
         Ok(v) => v,
-        Err(err) => return error_response(&RegistryError::Json(err)),
+        Err(err) => return RegistryError::Json(err).into_response(),
     };
     let body_name = body.get("name").and_then(Value::as_str).unwrap_or("");
     if body_name != name {
-        return error_response(&RegistryError::BadRequest {
+        return RegistryError::BadRequest {
             reason: format!("username in URL ({name:?}) does not match body ({body_name:?})"),
-        });
+        }
+        .into_response();
     }
     let Some(password) = body.get("password").and_then(Value::as_str) else {
-        return error_response(&RegistryError::BadRequest {
-            reason: "missing password".to_string(),
-        });
+        return RegistryError::BadRequest { reason: "missing password".to_string() }
+            .into_response();
     };
 
     let (outcome, username) = match state.inner.auth.users.add_or_login(name, password).await {
         Ok(o) => o,
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     };
     let token = match state.inner.auth.tokens.issue(&username).await {
         Ok(t) => t,
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     };
     let ok_msg = match outcome {
         UpsertOutcome::Created => format!("user '{username}' created"),
@@ -1997,7 +1985,7 @@ async fn add_user(state: &AppState, name: &str, body: &[u8]) -> Response {
 fn serve_whoami(identity: &Identity) -> Response {
     let username = match require_caller(identity, "user identity") {
         Ok(username) => username,
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     };
     json_response(StatusCode::OK, &json!({ "username": username }))
 }
@@ -2010,7 +1998,7 @@ fn serve_whoami(identity: &Identity) -> Response {
 fn serve_profile(identity: &Identity) -> Response {
     let username = match require_caller(identity, "user profile") {
         Ok(username) => username,
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     };
     json_response(
         StatusCode::OK,
@@ -2034,11 +2022,11 @@ fn serve_profile(identity: &Identity) -> Response {
 async fn list_tokens(state: &AppState, identity: &Identity) -> Response {
     let username = match require_caller(identity, "token list") {
         Ok(username) => username,
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     };
     let tokens = match state.inner.auth.tokens.list_for_user(&username).await {
         Ok(tokens) => tokens,
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     };
     let objects: Vec<Value> =
         tokens.into_iter().map(|(key, record)| token_response_object(&key, &record)).collect();
@@ -2053,23 +2041,22 @@ async fn list_tokens(state: &AppState, identity: &Identity) -> Response {
 async fn revoke_token_by_key(state: &AppState, identity: &Identity, key: &str) -> Response {
     let username = match require_caller(identity, "token revocation") {
         Ok(username) => username,
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     };
     match state.inner.auth.tokens.find_by_key(key).await {
-        Ok(Some(record)) if record.username != username => {
-            error_response(&RegistryError::Forbidden {
-                user: username,
-                action: "revoke",
-                resource: "this token".to_string(),
-            })
+        Ok(Some(record)) if record.username != username => RegistryError::Forbidden {
+            user: username,
+            action: "revoke",
+            resource: "this token".to_string(),
         }
+        .into_response(),
         Ok(Some(_)) => match state.inner.auth.tokens.revoke_by_key(key).await {
             Ok(Some(_)) => json_response(StatusCode::OK, &json!({ "ok": "token revoked" })),
             Ok(None) => not_found(),
-            Err(err) => error_response(&err),
+            Err(err) => err.into_response(),
         },
         Ok(None) => not_found(),
-        Err(err) => error_response(&err),
+        Err(err) => err.into_response(),
     }
 }
 
@@ -2081,24 +2068,25 @@ async fn revoke_token_by_key(state: &AppState, identity: &Identity, key: &str) -
 async fn logout(state: &AppState, identity: &Identity, raw_token: &str) -> Response {
     let username = match require_caller(identity, "logout") {
         Ok(username) => username,
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     };
     let target_owner = match state.inner.auth.tokens.lookup(raw_token).await {
         Ok(Some(owner)) => owner,
         Ok(None) => return not_found(),
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     };
     if target_owner != username {
-        return error_response(&RegistryError::Forbidden {
+        return RegistryError::Forbidden {
             user: username,
             action: "revoke",
             resource: "this token".to_string(),
-        });
+        }
+        .into_response();
     }
     match state.inner.auth.tokens.revoke_by_raw(raw_token).await {
         Ok(Some(_)) => json_response(StatusCode::OK, &json!({ "ok": true })),
         Ok(None) => not_found(),
-        Err(err) => error_response(&err),
+        Err(err) => err.into_response(),
     }
 }
 
@@ -2156,10 +2144,11 @@ async fn require_resolver_caller(
 ) -> Response {
     match caller_username(&state, request.headers()).await {
         Ok(Some(_username)) => next.run(request).await,
-        Ok(None) => error_response(&RegistryError::Unauthenticated {
-            resource: "dependency resolution".to_string(),
-        }),
-        Err(error) => error_response(&error),
+        Ok(None) => {
+            RegistryError::Unauthenticated { resource: "dependency resolution".to_string() }
+                .into_response()
+        }
+        Err(error) => error.into_response(),
     }
 }
 
@@ -2290,7 +2279,7 @@ async fn serve_search(
         };
         match crate::search::run_local_search(&storage, &text, size - objects.len(), keep).await {
             Ok(mut entries) => objects.append(&mut entries),
-            Err(err) => return error_response(&err),
+            Err(err) => return err.into_response(),
         }
     }
     result(objects)
@@ -2336,27 +2325,27 @@ fn team_registry<'a>(
     identity: &Identity,
     registry: Option<&str>,
     scope: &str,
-) -> Result<&'a HostedConfig, Box<Response>> {
+) -> Result<&'a HostedConfig, RegistryError> {
     let scope = scope.strip_prefix('@').unwrap_or(scope);
     if scope.is_empty() {
-        return Err(Box::new(not_found()));
+        return Err(RegistryError::NotFound);
     }
     let target = match registry {
         Some(registry) => registry.to_string(),
         None => match default_registry_target(state) {
             Some(target) => target,
-            None => return Err(Box::new(not_found())),
+            None => return Err(RegistryError::NotFound),
         },
     };
     let probe = format!("@{scope}/-");
     let RegistrySource::Hosted(source) = resolve_registry_source(state, &target, &probe) else {
-        return Err(Box::new(not_found()));
+        return Err(RegistryError::NotFound);
     };
     let Some(hosted) = state.inner.config.hosted.get(&source) else {
-        return Err(Box::new(not_found()));
+        return Err(RegistryError::NotFound);
     };
     if !hosted.rules.default_access().allows(identity) {
-        return Err(Box::new(not_found()));
+        return Err(RegistryError::NotFound);
     }
     Ok(hosted)
 }
@@ -2372,7 +2361,7 @@ fn get_org_teams(
 ) -> Response {
     let hosted = match team_registry(state, identity, registry, scope) {
         Ok(hosted) => hosted,
-        Err(response) => return *response,
+        Err(err) => return err.into_response(),
     };
     let teams: Vec<Value> = hosted.teams.keys().map(|name| json!({ "name": name })).collect();
     (StatusCode::OK, axum::Json(Value::Array(teams))).into_response()
@@ -2390,7 +2379,7 @@ fn get_team_members(
 ) -> Response {
     let hosted = match team_registry(state, identity, registry, scope) {
         Ok(hosted) => hosted,
-        Err(response) => return *response,
+        Err(err) => return err.into_response(),
     };
     let Some(members) = hosted.teams.get(team) else {
         return not_found();
@@ -2413,9 +2402,9 @@ fn reject_team_mutation(
     action: &'static str,
 ) -> Response {
     if let Err(response) = team_registry(state, identity, registry, scope) {
-        return *response;
+        return response.into_response();
     }
-    error_response(&RegistryError::TeamsConfigManaged { action })
+    RegistryError::TeamsConfigManaged { action }.into_response()
 }
 
 // --------------------------------------------------------------------
@@ -2433,14 +2422,12 @@ fn resolve_write_target(
     identity: &Identity,
     registry: Option<&str>,
     name: &PackageName,
-) -> Result<WriteTarget, Box<Response>> {
+) -> Result<WriteTarget, RegistryError> {
     match resolve_publish_target(state, identity, registry, name.as_str()) {
         PublishTarget::Hosted { source, org } => Ok(WriteTarget { source, org }),
-        PublishTarget::Reject(reason) => {
-            Err(Box::new(error_response(&RegistryError::BadRequest { reason })))
-        }
+        PublishTarget::Reject(reason) => Err(RegistryError::BadRequest { reason }),
         PublishTarget::Denied(response) => Err(response),
-        PublishTarget::NotFound => Err(Box::new(not_found())),
+        PublishTarget::NotFound => Err(RegistryError::NotFound),
     }
 }
 
@@ -2675,21 +2662,7 @@ fn revision_tarball_response(
 }
 
 fn not_found() -> Response {
-    (StatusCode::NOT_FOUND, "Not Found").into_response()
-}
-
-fn error_response(err: &RegistryError) -> Response {
-    let status = err.status_code();
-    let error_kind = err.log_kind();
-    if status.is_server_error() {
-        let err = err.log_message();
-        tracing::error!(%err, %error_kind, %status, "request failed");
-    } else if status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN {
-        tracing::debug!(%err, %error_kind, %status, "request failed");
-    } else {
-        tracing::warn!(%err, %error_kind, %status, "request failed");
-    }
-    (status, err.public_message()).into_response()
+    RegistryError::NotFound.into_response()
 }
 
 async fn serve_ping(State(_state): State<AppState>) -> Response {
@@ -2761,11 +2734,11 @@ async fn serve_publish_artifact(
 ) -> Response {
     let username = match require_caller(&identity, "shared artifact publication") {
         Ok(username) => username,
-        Err(err) => return private_no_cache(error_response(&err)),
+        Err(err) => return private_no_cache(err.into_response()),
     };
     let request = match crate::shared_artifacts::parse_publish(&body) {
         Ok(request) => request,
-        Err(err) => return private_no_cache(error_response(&err)),
+        Err(err) => return private_no_cache(err.into_response()),
     };
     private_no_cache(
         match crate::shared_artifacts::publish(
@@ -2777,7 +2750,7 @@ async fn serve_publish_artifact(
         {
             Ok(true) => StatusCode::CREATED.into_response(),
             Ok(false) => StatusCode::OK.into_response(),
-            Err(err) => error_response(&err),
+            Err(err) => err.into_response(),
         },
     )
 }
@@ -2789,14 +2762,14 @@ async fn serve_resolve_artifacts(
 ) -> Response {
     let username = match require_caller(&identity, "shared artifact lookup") {
         Ok(username) => username,
-        Err(err) => return private_no_cache(error_response(&err)),
+        Err(err) => return private_no_cache(err.into_response()),
     };
     private_no_cache(
         match crate::shared_artifacts::resolve(&state.inner.config.cache_storage, &username, &body)
             .await
         {
             Ok(response) => (StatusCode::OK, axum::Json(response)).into_response(),
-            Err(err) => error_response(&err),
+            Err(err) => err.into_response(),
         },
     )
 }
@@ -2808,7 +2781,7 @@ async fn serve_artifact_blob(
 ) -> Response {
     let username = match require_caller(&identity, "shared artifact blob") {
         Ok(username) => username,
-        Err(err) => return private_no_cache(error_response(&err)),
+        Err(err) => return private_no_cache(err.into_response()),
     };
     let permit = Arc::clone(&state.inner.artifact_blob_verifications)
         .acquire_owned()
@@ -2826,7 +2799,7 @@ async fn serve_artifact_blob(
             .body(artifact_blob_response_body(file, permit))
             .expect("static artifact blob response always builds"),
         Ok(None) => private_no_cache(StatusCode::NOT_FOUND.into_response()),
-        Err(err) => private_no_cache(error_response(&err)),
+        Err(err) => private_no_cache(err.into_response()),
     }
 }
 

--- a/pnpr/crates/pnpr/src/server/authentication.rs
+++ b/pnpr/crates/pnpr/src/server/authentication.rs
@@ -7,7 +7,7 @@ use axum::{
     extract::{ConnectInfo, FromRequestParts, Request, State},
     http::{Method, request::Parts},
     middleware::Next,
-    response::Response,
+    response::{IntoResponse, Response},
 };
 
 use crate::{
@@ -16,7 +16,7 @@ use crate::{
     policy::{Identity, PackageRules},
 };
 
-use super::{AppState, PeerAddr, RegistrySource, error_response, single_authorization_header};
+use super::{AppState, PeerAddr, RegistrySource, single_authorization_header};
 
 /// What the caller is trying to do with a package. Drives which
 /// rule from the access policy applies.
@@ -56,9 +56,8 @@ impl<RouterState: Send + Sync> FromRequestParts<RouterState> for AuthedCaller {
         // The middleware runs on every route, so the context is always
         // present; a miss means a wiring bug, surfaced as a 5xx.
         parts.extensions.get::<AuthedCaller>().cloned().ok_or_else(|| {
-            error_response(&RegistryError::Internal {
-                reason: "authentication middleware did not run".to_string(),
-            })
+            RegistryError::Internal { reason: "authentication middleware did not run".to_string() }
+                .into_response()
         })
     }
 }
@@ -86,14 +85,14 @@ pub(super) async fn authenticate(
     // `extensions_mut` call.
     let header = match single_authorization_header(request.headers()) {
         Ok(header) => header.map(str::to_owned),
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     };
     let method = request.method().clone();
     let peer = request.extensions().get::<ConnectInfo<PeerAddr>>().map(|info| info.0.0);
 
     let identity = match resolve_caller(&state, header.as_deref(), &method, peer).await {
         Ok(identity) => identity,
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     };
     request.extensions_mut().insert(AuthedCaller(identity));
     next.run(request).await

--- a/pnpr/crates/pnpr/src/server/package_mutation.rs
+++ b/pnpr/crates/pnpr/src/server/package_mutation.rs
@@ -1,7 +1,7 @@
 use axum::{
     body::Body,
     http::{StatusCode, header},
-    response::Response,
+    response::{IntoResponse, Response},
 };
 use serde_json::{Value, json};
 
@@ -15,8 +15,8 @@ use crate::{
 };
 
 use super::{
-    Action, AppState, RegistrySource, authorize, error_response, filter_osv_vulnerable_dist_tags,
-    hosted_storage, load_packument_for_read, not_found, resolve_write_target,
+    Action, AppState, RegistrySource, authorize, filter_osv_vulnerable_dist_tags, hosted_storage,
+    load_packument_for_read, not_found, resolve_write_target,
 };
 
 /// `PUT /:pkg/-rev/:rev` (path-less) or `PUT /~<name>/:pkg/-rev/:rev` —
@@ -37,23 +37,23 @@ pub(super) async fn update_packument(
 ) -> Response {
     let name = match PackageName::parse(raw_name) {
         Ok(n) => n,
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     };
     let target = match resolve_write_target(state, identity, registry, &name) {
         Ok(target) => target,
-        Err(response) => return *response,
+        Err(err) => return err.into_response(),
     };
     let source = RegistrySource::Hosted(target.source.clone());
     for action in [Action::Publish, Action::Unpublish] {
         if let Err(err) = authorize(state, identity, &source, name.as_str(), action) {
-            return error_response(&err);
+            return err.into_response();
         }
     }
     let org = target.org;
     let storage = hosted_storage(state, Some(&org));
     let mut packument: Value = match serde_json::from_slice(body) {
         Ok(v) => v,
-        Err(err) => return error_response(&RegistryError::Json(err)),
+        Err(err) => return RegistryError::Json(err).into_response(),
     };
     // The write destination is the URL package name; a mismatched body name
     // would otherwise land under the URL package and persist an inconsistent
@@ -61,12 +61,13 @@ pub(super) async fn update_packument(
     if let Some(body_name) = packument.get("name").and_then(Value::as_str)
         && body_name != name.as_str()
     {
-        return error_response(&RegistryError::BadRequest {
+        return RegistryError::BadRequest {
             reason: format!(
                 "packument name {body_name:?} does not match the URL package {:?}",
                 name.as_str(),
             ),
-        });
+        }
+        .into_response();
     }
     if let Some(obj) = packument.as_object_mut() {
         obj.remove("_attachments");
@@ -80,25 +81,26 @@ pub(super) async fn update_packument(
     let hosted_packument = match storage.read_hosted_packument_for_update(&name).await {
         Ok(Some(packument)) => packument,
         Ok(None) => {
-            return error_response(&RegistryError::BadRequest {
+            return RegistryError::BadRequest {
                 reason: format!(
                     "cannot update {:?}: it has no published packument to unpublish from",
                     name.as_str(),
                 ),
-            });
+            }
+            .into_response();
         }
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     };
     let hosted: Value = match serde_json::from_slice(&hosted_packument.bytes) {
         Ok(value) => value,
-        Err(err) => return error_response(&RegistryError::Json(err)),
+        Err(err) => return RegistryError::Json(err).into_response(),
     };
     if let Some(err) = enforce_published_version_immutability(&hosted, &name, &mut packument) {
-        return error_response(&err);
+        return err.into_response();
     }
     let bytes = match serde_json::to_vec_pretty(&packument) {
         Ok(b) => b,
-        Err(err) => return error_response(&RegistryError::Json(err)),
+        Err(err) => return RegistryError::Json(err).into_response(),
     };
     match storage
         .write_hosted_packument_if_current(&name, &bytes, Some(&hosted_packument.version))
@@ -106,11 +108,10 @@ pub(super) async fn update_packument(
     {
         Ok(PackumentWrite::Written) => {}
         Ok(PackumentWrite::Conflict) => {
-            return error_response(&RegistryError::PackumentWriteConflict {
-                package: name.as_str().to_string(),
-            });
+            return RegistryError::PackumentWriteConflict { package: name.as_str().to_string() }
+                .into_response();
         }
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     }
     let body = json!({ "ok": true });
     let bytes = serde_json::to_vec(&body).expect("static-shape JSON serializes");
@@ -267,11 +268,11 @@ pub(super) async fn delete_package(
 ) -> Response {
     let name = match PackageName::parse(raw_name) {
         Ok(n) => n,
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     };
     let target = match resolve_write_target(state, identity, registry, &name) {
         Ok(target) => target,
-        Err(response) => return *response,
+        Err(err) => return err.into_response(),
     };
     if let Err(err) = authorize(
         state,
@@ -280,14 +281,14 @@ pub(super) async fn delete_package(
         name.as_str(),
         Action::Unpublish,
     ) {
-        return error_response(&err);
+        return err.into_response();
     }
     let org = target.org;
     // Serialize against same-package publishers so a delete can't race a
     // stage-and-commit and remove the package mid-write.
     let _packument_guard = state.inner.package_locks.lock(name.as_str()).await;
     if let Err(err) = hosted_storage(state, Some(&org)).remove_package(&name).await {
-        return error_response(&err);
+        return err.into_response();
     }
     let body = json!({ "ok": true });
     let bytes = serde_json::to_vec(&body).expect("static-shape JSON serializes");
@@ -312,15 +313,15 @@ pub(super) async fn delete_tarball(
 ) -> Response {
     let name = match PackageName::parse(raw_name) {
         Ok(n) => n,
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     };
     let canonical = match name.canonicalize_tarball_name(filename) {
         Ok(c) => c,
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     };
     let target = match resolve_write_target(state, identity, registry, &name) {
         Ok(target) => target,
-        Err(response) => return *response,
+        Err(err) => return err.into_response(),
     };
     if let Err(err) = authorize(
         state,
@@ -329,14 +330,14 @@ pub(super) async fn delete_tarball(
         name.as_str(),
         Action::Unpublish,
     ) {
-        return error_response(&err);
+        return err.into_response();
     }
     let org = target.org;
     // Serialize against same-package publishers so a delete can't race a
     // stage-and-commit and remove a tarball mid-write.
     let _packument_guard = state.inner.package_locks.lock(name.as_str()).await;
     if let Err(err) = hosted_storage(state, Some(&org)).remove_tarball(&name, &canonical).await {
-        return error_response(&err);
+        return err.into_response();
     }
     let body = json!({ "ok": true });
     let bytes = serde_json::to_vec(&body).expect("static-shape JSON serializes");
@@ -358,16 +359,16 @@ pub(super) async fn get_dist_tags(
 ) -> Response {
     let name = match PackageName::parse(raw_name) {
         Ok(n) => n,
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     };
     let bytes = match load_packument_for_read(state, identity, registry, &name).await {
         Ok(Some(bytes)) => bytes,
         Ok(None) => return not_found(),
-        Err(response) => return *response,
+        Err(err) => return err.into_response(),
     };
     let packument: Value = match serde_json::from_slice(&bytes) {
         Ok(v) => v,
-        Err(err) => return error_response(&RegistryError::Json(err)),
+        Err(err) => return RegistryError::Json(err).into_response(),
     };
     let mut tags = packument.get("dist-tags").cloned().unwrap_or_else(|| json!({}));
     filter_osv_vulnerable_dist_tags(&mut tags, &packument, &name, state.inner.osv_index.as_ref());
@@ -436,14 +437,14 @@ where
 {
     let name = match PackageName::parse(raw_name) {
         Ok(n) => n,
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     };
     // A dist-tag change is a write, so it routes to a hosted namespace like
     // a publish — a name routed to an upstream is rejected — and the
     // resolved registry's `publish` rule gates it.
     let target = match resolve_write_target(state, identity, registry, &name) {
         Ok(target) => target,
-        Err(response) => return *response,
+        Err(err) => return err.into_response(),
     };
     if let Err(err) = authorize(
         state,
@@ -452,7 +453,7 @@ where
         name.as_str(),
         Action::Publish,
     ) {
-        return error_response(&err);
+        return err.into_response();
     }
     let org = target.org;
     let storage = hosted_storage(state, Some(&org));
@@ -501,7 +502,7 @@ where
     match outcome {
         Ok(PackumentUpdate::Written) => {}
         Ok(PackumentUpdate::NotFound) => return not_found(),
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     }
     let body = json!({ "ok": true });
     let bytes = serde_json::to_vec(&body).expect("static-shape JSON serializes");

--- a/pnpr/crates/pnpr/src/server/publishing.rs
+++ b/pnpr/crates/pnpr/src/server/publishing.rs
@@ -4,7 +4,7 @@ use axum::{
     body::Body,
     extract::State,
     http::{StatusCode, header},
-    response::Response,
+    response::{IntoResponse, Response},
 };
 use pnpm_crypto_hash::{create_hex_hash, integrity_addressed_tarball_path};
 use serde_json::{Value, json};
@@ -25,8 +25,8 @@ use crate::{
 
 use super::{
     Action, AppState, AuthedCaller, HostedGate, HostedOriginalRef, RegistrySource, WriteTarget,
-    authorize, authorized_upstream, default_registry_target, error_response, hosted_gate,
-    hosted_storage, resolve_registry_source, resolve_write_target,
+    authorize, authorized_upstream, default_registry_target, hosted_gate, hosted_storage,
+    resolve_registry_source, resolve_write_target,
 };
 
 /// Where a publish of `package` writes, given an optional explicit `/~<name>/`.
@@ -40,7 +40,7 @@ pub(super) enum PublishTarget {
     /// The resolved upstream registry denies this caller; answer with the
     /// same response its reads give (a 403), before any rejection that would
     /// narrate routing config.
-    Denied(Box<Response>),
+    Denied(RegistryError),
     /// The addressed registry or route does not exist (or the path-less base has
     /// no default target).
     NotFound,
@@ -77,7 +77,7 @@ pub(super) fn resolve_publish_target(
             match hosted_gate(state, identity, &registry, package) {
                 HostedGate::Allowed(org) => PublishTarget::Hosted { source: registry, org },
                 HostedGate::MaskNotFound => PublishTarget::NotFound,
-                HostedGate::Denied(err) => PublishTarget::Denied(Box::new(error_response(&err))),
+                HostedGate::Denied(err) => PublishTarget::Denied(err),
             }
         }
         // A write can never land on an upstream — but the upstream's `access:`
@@ -153,12 +153,12 @@ pub(super) async fn publish_package(
 ) -> Response {
     let name = match PackageName::parse(raw_name) {
         Ok(n) => n,
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     };
 
     let incoming: Value = match serde_json::from_slice(&body) {
         Ok(v) => v,
-        Err(err) => return error_response(&RegistryError::Json(err)),
+        Err(err) => return RegistryError::Json(err).into_response(),
     };
 
     // Reject a publish whose body name disagrees with the URL.
@@ -167,13 +167,14 @@ pub(super) async fn publish_package(
     // package.json with another package's manifest.
     let body_name = incoming.get("name").and_then(Value::as_str);
     if body_name.is_some_and(|body_name| body_name != name.as_str()) {
-        return error_response(&RegistryError::BadRequest {
+        return RegistryError::BadRequest {
             reason: format!(
                 "package in URL ({:?}) does not match body ({:?})",
                 name.as_str(),
                 body_name.unwrap_or(""),
             ),
-        });
+        }
+        .into_response();
     }
 
     // Routing, masking, and the publish rule all run inside
@@ -182,7 +183,7 @@ pub(super) async fn publish_package(
     let (validated, target) =
         match validate_publish_doc(state, identity, registry, name, incoming).await {
             Ok(validated) => validated,
-            Err(response) => return *response,
+            Err(err) => return err.into_response(),
         };
 
     // Serialize the read-merge-write against other writers of this same
@@ -193,10 +194,10 @@ pub(super) async fn publish_package(
 
     let staged = match stage_publish(state, validated, &now_iso(), Some(&target.org)).await {
         Ok(staged) => staged,
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     };
     if let Err(err) = commit_publishes(state, vec![staged]).await {
-        return error_response(&err);
+        return err.into_response();
     }
     publish_created_response()
 }
@@ -220,35 +221,35 @@ pub(super) async fn serve_batch_publish(
 ) -> Response {
     let incoming: Value = match serde_json::from_slice(&body) {
         Ok(v) => v,
-        Err(err) => return error_response(&RegistryError::Json(err)),
+        Err(err) => return RegistryError::Json(err).into_response(),
     };
     let Value::Object(mut incoming) = incoming else {
-        return error_response(&RegistryError::BadRequest {
-            reason: "body must be a JSON object".to_string(),
-        });
+        return RegistryError::BadRequest { reason: "body must be a JSON object".to_string() }
+            .into_response();
     };
     let Some(Value::Array(docs)) = incoming.remove("packages") else {
-        return error_response(&RegistryError::BadRequest {
+        return RegistryError::BadRequest {
             reason: "body must have a `packages` array".to_string(),
-        });
+        }
+        .into_response();
     };
     if docs.is_empty() {
-        return error_response(&RegistryError::BadRequest {
-            reason: "`packages` must not be empty".to_string(),
-        });
+        return RegistryError::BadRequest { reason: "`packages` must not be empty".to_string() }
+            .into_response();
     }
 
     let mut validated = Vec::with_capacity(docs.len());
     let mut seen_names = std::collections::BTreeSet::new();
     for doc in docs {
         let Some(doc_name) = doc.get("name").and_then(Value::as_str) else {
-            return error_response(&RegistryError::BadRequest {
+            return RegistryError::BadRequest {
                 reason: "every entry in `packages` must have a string `name`".to_string(),
-            });
+            }
+            .into_response();
         };
         let name = match PackageName::parse(doc_name) {
             Ok(name) => name,
-            Err(err) => return error_response(&err),
+            Err(err) => return err.into_response(),
         };
         // One packument read-merge-write per package: with the same
         // package twice in a batch, the second entry's merge would
@@ -256,16 +257,17 @@ pub(super) async fn serve_batch_publish(
         // multiple versions of one package as several `versions`
         // entries in a single document instead.
         if !seen_names.insert(name.as_str().to_string()) {
-            return error_response(&RegistryError::BadRequest {
+            return RegistryError::BadRequest {
                 reason: format!("duplicate package {:?} in `packages`", name.as_str()),
-            });
+            }
+            .into_response();
         }
         // The batch endpoint is path-less, so each package routes via the
         // default target; validation resolves that route and checks the
         // resolved hosted registry's publish rule per document.
         match validate_publish_doc(&state, &identity, None, name, doc).await {
             Ok(doc) => validated.push(doc),
-            Err(response) => return *response,
+            Err(err) => return err.into_response(),
         }
     }
 
@@ -286,12 +288,12 @@ pub(super) async fn serve_batch_publish(
                 for stage in staged {
                     cleanup_tmp_slots(stage.slots).await;
                 }
-                return error_response(&err);
+                return err.into_response();
             }
         }
     }
     if let Err(err) = commit_publishes(&state, staged).await {
-        return error_response(&err);
+        return err.into_response();
     }
     publish_created_response()
 }
@@ -327,8 +329,8 @@ pub(super) async fn validate_publish_doc(
     identity: &Identity,
     registry: Option<&str>,
     name: PackageName,
-    incoming: Value,
-) -> Result<(ValidatedPublish, WriteTarget), Box<Response>> {
+    mut incoming: Value,
+) -> Result<(ValidatedPublish, WriteTarget), RegistryError> {
     // Route the write to its hosted registry first (masking a denied caller
     // as not-found, rejecting an upstream target), then check that
     // registry's `publish` rule for this package — so routing failures
@@ -340,22 +342,8 @@ pub(super) async fn validate_publish_doc(
         &RegistrySource::Hosted(target.source.clone()),
         name.as_str(),
         Action::Publish,
-    )
-    .map_err(|err| Box::new(error_response(&err)))?;
+    )?;
 
-    let (validated, target) = validate_publish_attachments(name, incoming, target)
-        .map_err(|err| Box::new(error_response(&err)))?;
-    Ok((validated, target))
-}
-
-/// The attachment half of [`validate_publish_doc`], split out so the
-/// routing/authorization half above can use `?` on `Box<Response>` while
-/// this half keeps plain [`RegistryError`]s.
-fn validate_publish_attachments(
-    name: PackageName,
-    mut incoming: Value,
-    target: WriteTarget,
-) -> Result<(ValidatedPublish, WriteTarget), RegistryError> {
     let attachments = extract_attachments(&mut incoming)?;
 
     // Resolve each attachment's canonical disk filename + matching

--- a/pnpr/crates/pnpr/src/server/staged.rs
+++ b/pnpr/crates/pnpr/src/server/staged.rs
@@ -18,7 +18,7 @@ use axum::{
     body::Body,
     extract::{OriginalUri, Path, State},
     http::{StatusCode, header},
-    response::Response,
+    response::{IntoResponse, Response},
 };
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use serde::{Deserialize, Serialize};
@@ -26,8 +26,8 @@ use serde_json::{Value, json};
 
 use super::{
     Action, AppState, AuthedCaller, Identity, RegistrySource, authorize, commit_publishes,
-    error_response, is_tilde_prefix, json_response, not_found, private_no_cache,
-    resolve_write_target, stage_publish, validate_publish_doc,
+    is_tilde_prefix, json_response, not_found, private_no_cache, resolve_write_target,
+    stage_publish, validate_publish_doc,
 };
 use crate::{
     error::RegistryError,
@@ -262,21 +262,22 @@ async fn serve_staged_publish(
 ) -> Response {
     let name = match PackageName::parse(raw_name) {
         Ok(name) => name,
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     };
     let incoming: Value = match serde_json::from_slice(body) {
         Ok(value) => value,
-        Err(err) => return error_response(&RegistryError::Json(err)),
+        Err(err) => return RegistryError::Json(err).into_response(),
     };
     let body_name = incoming.get("name").and_then(Value::as_str);
     if body_name.is_some_and(|body_name| body_name != name.as_str()) {
-        return error_response(&RegistryError::BadRequest {
+        return RegistryError::BadRequest {
             reason: format!(
                 "package in URL ({:?}) does not match body ({:?})",
                 name.as_str(),
                 body_name.unwrap_or(""),
             ),
-        });
+        }
+        .into_response();
     }
 
     // The same routing + `publish`-rule + attachment validation a direct
@@ -285,7 +286,7 @@ async fn serve_staged_publish(
     let (validated, _target) =
         match validate_publish_doc(state, identity, registry, name, incoming).await {
             Ok(validated) => validated,
-            Err(response) => return *response,
+            Err(err) => return err.into_response(),
         };
 
     let (version, dist) = validated.prepared.first().map_or((None, Value::Null), |attachment| {
@@ -318,12 +319,12 @@ async fn serve_staged_publish(
     // Body first, metadata last: a record whose metadata exists always has
     // its body. On a metadata failure the body is cleaned up best-effort.
     if let Err(err) = state.inner.storage.write_staged_body(&stage_id, body).await {
-        return error_response(&err);
+        return err.into_response();
     }
     let meta_bytes = serde_json::to_vec(&record).expect("a staged record serializes");
     if let Err(err) = state.inner.storage.write_staged_meta(&stage_id, &meta_bytes).await {
         let _ = state.inner.storage.remove_staged(&stage_id).await;
-        return error_response(&err);
+        return err.into_response();
     }
     json_response(StatusCode::CREATED, &json!({ "ok": true, "stageId": stage_id }))
 }
@@ -340,7 +341,7 @@ async fn serve_staged_list(
     let per_page = query.per_page.clamp(1, MAX_PER_PAGE);
     let ids = match state.inner.storage.list_staged_ids().await {
         Ok(ids) => ids,
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     };
     let mut records: Vec<StagedRecord> = Vec::new();
     for stage_id in ids {
@@ -388,7 +389,7 @@ async fn serve_staged_view(
 ) -> Response {
     let record = match load_authorized_record(state, identity, registry, stage_id).await {
         Ok(record) => record,
-        Err(response) => return *response,
+        Err(err) => return err.into_response(),
     };
     json_response(StatusCode::OK, &record.metadata())
 }
@@ -402,14 +403,14 @@ async fn serve_staged_reject(
     stage_id: &str,
 ) -> Response {
     if let Err(response) = load_authorized_record(state, identity, registry, stage_id).await {
-        return *response;
+        return response.into_response();
     }
     match state.inner.storage.remove_staged(stage_id).await {
         Ok(_) => Response::builder()
             .status(StatusCode::NO_CONTENT)
             .body(Body::empty())
             .expect("static-shape response always builds"),
-        Err(err) => error_response(&err),
+        Err(err) => err.into_response(),
     }
 }
 
@@ -423,24 +424,25 @@ async fn serve_staged_approve(
 ) -> Response {
     let record = match load_authorized_record(state, identity, registry, stage_id).await {
         Ok(record) => record,
-        Err(response) => return *response,
+        Err(err) => return err.into_response(),
     };
     let body = match state.inner.storage.read_staged_body(stage_id).await {
         Ok(Some(body)) => body,
         Ok(None) => {
-            return error_response(&RegistryError::Io(std::io::Error::other(format!(
+            return RegistryError::Io(std::io::Error::other(format!(
                 "staged publish {stage_id} has no stored body",
-            ))));
+            )))
+            .into_response();
         }
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     };
     let incoming: Value = match serde_json::from_slice(&body) {
         Ok(value) => value,
-        Err(err) => return error_response(&RegistryError::Json(err)),
+        Err(err) => return RegistryError::Json(err).into_response(),
     };
     let name = match PackageName::parse(&record.package_name) {
         Ok(name) => name,
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     };
     // Re-validate against the registry state of *now*: rules may have
     // changed since staging, and the version may have been published in
@@ -450,16 +452,16 @@ async fn serve_staged_approve(
             .await
         {
             Ok(validated) => validated,
-            Err(response) => return *response,
+            Err(err) => return err.into_response(),
         };
 
     let _packument_guard = state.inner.package_locks.lock(validated.name.as_str()).await;
     let staged = match stage_publish(state, validated, &now_iso(), Some(&target.org)).await {
         Ok(staged) => staged,
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     };
     if let Err(err) = commit_publishes(state, vec![staged]).await {
-        return error_response(&err);
+        return err.into_response();
     }
     if let Err(err) = state.inner.storage.remove_staged(stage_id).await {
         // The publish is already committed and visible; a failed record
@@ -478,20 +480,20 @@ async fn serve_staged_tarball(
     stage_id: &str,
 ) -> Response {
     if let Err(response) = load_authorized_record(state, identity, registry, stage_id).await {
-        return *response;
+        return response.into_response();
     }
     let body = match state.inner.storage.read_staged_body(stage_id).await {
         Ok(Some(body)) => body,
         Ok(None) => return not_found(),
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     };
     let mut incoming: Value = match serde_json::from_slice(&body) {
         Ok(value) => value,
-        Err(err) => return error_response(&RegistryError::Json(err)),
+        Err(err) => return RegistryError::Json(err).into_response(),
     };
     let attachments = match extract_attachments(&mut incoming) {
         Ok(attachments) => attachments,
-        Err(err) => return error_response(&err),
+        Err(err) => return err.into_response(),
     };
     let Some(attachment) = attachments.into_iter().next() else {
         return not_found();
@@ -499,10 +501,11 @@ async fn serve_staged_tarball(
     let bytes = match BASE64.decode(attachment.data.as_bytes()) {
         Ok(bytes) => bytes,
         Err(err) => {
-            return error_response(&RegistryError::InvalidAttachment {
+            return RegistryError::InvalidAttachment {
                 filename: attachment.filename,
                 reason: format!("invalid base64 data: {err}"),
-            });
+            }
+            .into_response();
         }
     };
     Response::builder()
@@ -525,14 +528,14 @@ async fn load_authorized_record(
     identity: &Identity,
     registry: Option<&str>,
     stage_id: &str,
-) -> Result<StagedRecord, Box<Response>> {
+) -> Result<StagedRecord, RegistryError> {
     let record = match read_staged_record(state, stage_id).await {
         Ok(Some(record)) => record,
-        Ok(None) => return Err(Box::new(not_found())),
-        Err(err) => return Err(Box::new(error_response(&err))),
+        Ok(None) => return Err(RegistryError::NotFound),
+        Err(err) => return Err(err),
     };
     if record.registry.as_deref() != registry {
-        return Err(Box::new(not_found()));
+        return Err(RegistryError::NotFound);
     }
     authorize_staged(state, identity, &record).await?;
     Ok(record)
@@ -544,9 +547,8 @@ async fn authorize_staged(
     state: &AppState,
     identity: &Identity,
     record: &StagedRecord,
-) -> Result<(), Box<Response>> {
-    let name =
-        PackageName::parse(&record.package_name).map_err(|err| Box::new(error_response(&err)))?;
+) -> Result<(), RegistryError> {
+    let name = PackageName::parse(&record.package_name)?;
     let target = resolve_write_target(state, identity, record.registry.as_deref(), &name)?;
     authorize(
         state,
@@ -555,7 +557,6 @@ async fn authorize_staged(
         name.as_str(),
         Action::Publish,
     )
-    .map_err(|err| Box::new(error_response(&err)))
 }
 
 async fn read_staged_record(


### PR DESCRIPTION
## Summary

First item from the pnpr refactor plan in pnpm/pnpm#14191.

`RegistryError` had no `NotFound` variant, so every path that answers a bare
404 built the response itself via a `not_found()` helper. That one gap forced
twelve helpers to carry HTTP responses as their error type —
`Result<T, Box<Response>>` — and pushed 27 `Box::new(error_response(&err))`
wraps onto their callers. It also split `validate_publish_doc` in two, purely
so the routing half could `?` on `Box<Response>` while the attachment half kept
a plain `RegistryError`; the split is documented in the source as existing for
exactly that reason.

This adds the variant and moves response rendering into
`impl IntoResponse for RegistryError`, absorbing the tracing that the free
`error_response` function did. Then:

- all twelve `Box<Response>` signatures become `Result<T, RegistryError>`
- the 27 wraps become plain `?`
- 120 `error_response(&err)` call sites become `err.into_response()`
- `error_response` is deleted
- the two publish-validation halves rejoin into one function

No wire change: `NotFound` renders as the same bare `404 Not Found` the helper
emitted, and `not_found()` now builds it from the variant so there is one
source of truth. A new test pins that rendering, since every masked-existence
path depends on it.

One deliberate behavior delta: 404s now log at `debug`, alongside 401 and 403.
That is below the default level, and the statuses a probing client provokes
routinely are not worth a `warn` line each.

The full pnpr suite passes at 711 tests (710 existing, unchanged, plus the new
one).

## Squash Commit Body

```text
RegistryError had no NotFound variant, so every path answering a bare 404
built the response itself. That forced twelve helpers to carry HTTP
responses as their error type — Result<T, Box<Response>> — and pushed 27
Box::new(error_response(&err)) wraps onto their callers. It also split
validate_publish_doc in two, purely so the routing half could `?` on
Box<Response> while the attachment half kept a plain RegistryError.

Add the variant and move response rendering into
impl IntoResponse for RegistryError, which absorbs the tracing that the
free error_response function did. Every Box<Response> signature becomes
Result<T, RegistryError>, the wraps become plain `?`, 120 error_response
call sites become err.into_response(), error_response is deleted, and the
two publish-validation halves rejoin.

NotFound renders as the bare 404 Not Found the old helper emitted, so the
wire is unchanged; not_found() now builds it from the variant to keep one
source of truth, and a new test pins the rendering. 404s newly log at
debug, alongside 401 and 403 — below the default level, and the statuses a
probing client provokes routinely are not worth a warn each.

Related to pnpm/pnpm#14191.
```

## Checklist

- [x] Added or updated tests. — `not_found_renders_as_a_bare_404` pins the
  wire contract the whole change rests on; the rest is covered by the existing
  suite, which passes unchanged.

---
Written by an agent (Claude Code, claude-opus-5[1m]).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790348504&installation_model_id=426870&pr_number=14192&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14192&signature=d50fb321118c2d88f6e9f5c2e19937dbeff9810d4c1910cd5269a50b1cbd5a71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added standardized HTTP error responses across registry operations.
  * Missing resources now return HTTP 404 with a clear “Not Found” message.
  * Error responses are consistently logged according to their severity.

* **Bug Fixes**
  * Improved error handling for authentication, publishing, package management, staged workflows, searches, and artifact operations.
  * Preserved existing validation behavior and response formats while making failures more consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->