### PR TITLE
refactor(pnpr): dispatch the hosted store through a trait

### DIFF
--- a/pnpr/crates/pnpr/src/s3.rs
+++ b/pnpr/crates/pnpr/src/s3.rs
@@ -17,11 +17,13 @@ use crate::{
     error::{RegistryError, Result},
     package_name::PackageName,
     storage::{
-        HOSTED_REVISION_REF_INDEX_FILE, HOSTED_REVISION_REFS_DIR, HostedRevisionRefIndex,
-        HostedRevisionRefWrite, STAGED_DIR, staged_id_of_meta_object,
-        wait_after_packument_write_conflict,
+        HOSTED_REVISION_REF_INDEX_FILE, HOSTED_REVISION_REFS_DIR, HostedBackend,
+        HostedPackumentForUpdate, HostedPackumentVersion, HostedRevisionRefIndex,
+        HostedRevisionRefWrite, PackumentWrite, STAGED_DIR, TarballFinalize,
+        staged_id_of_meta_object, wait_after_packument_write_conflict,
     },
 };
+use async_trait::async_trait;
 use axum::body::Body;
 use futures_util::StreamExt;
 use object_store::{
@@ -135,6 +137,9 @@ pub struct S3Store {
     /// when the final home is a bucket; a subdirectory of the
     /// proxy-cache root doubles as scratch.
     staging_dir: PathBuf,
+    /// The proxy-cache root `staging_dir` sits under. The publish journal
+    /// lives here, beside the staged tmp files it rolls forward.
+    cache_root: PathBuf,
 }
 
 #[derive(Debug)]
@@ -149,12 +154,8 @@ pub(crate) struct S3PackumentForUpdate {
 const STAGING_SUBDIR: &str = "pnpr-hosted-staging";
 
 impl S3Store {
-    #[expect(
-        clippy::needless_pass_by_value,
-        reason = "constructor; cache_root seeds staging_dir without threading &Path through storage::new and its construction sites"
-    )]
     pub fn new(store: Arc<dyn ObjectStore>, prefix: String, cache_root: PathBuf) -> Self {
-        Self { store, prefix, staging_dir: cache_root.join(STAGING_SUBDIR) }
+        Self { store, prefix, staging_dir: cache_root.join(STAGING_SUBDIR), cache_root }
     }
 
     /// A view of this store with `segment` appended to the key prefix, giving a
@@ -170,12 +171,14 @@ impl S3Store {
                 store: Arc::clone(&self.store),
                 prefix: self.prefix.clone(),
                 staging_dir: self.staging_dir.clone(),
+                cache_root: self.cache_root.clone(),
             };
         }
         Self {
             store: Arc::clone(&self.store),
             prefix: format!("{}{segment}/", self.prefix),
             staging_dir: self.staging_dir.clone(),
+            cache_root: self.cache_root.clone(),
         }
     }
 
@@ -267,8 +270,7 @@ impl S3Store {
         tmp_path: &Path,
         name: &PackageName,
         filename: &str,
-    ) -> Result<crate::storage::TarballFinalize> {
-        use crate::storage::TarballFinalize;
+    ) -> Result<TarballFinalize> {
         let bytes = fs::read(tmp_path).await?;
         let key = self.tarball_key(name, filename);
         // Create-only. A published version's tarball is immutable, so an object
@@ -566,3 +568,129 @@ impl S3Store {
 
 #[cfg(test)]
 mod tests;
+
+/// The S3-compatible object-store backend. Packument writes are
+/// compare-and-set on the object's version, so concurrent publishers on
+/// separate nodes cannot lose each other's writes, and a tarball is promoted
+/// by upload rather than rename.
+#[async_trait]
+impl HostedBackend for S3Store {
+    async fn read_packument(&self, name: &PackageName) -> Result<Option<Vec<u8>>> {
+        S3Store::read_packument(self, name).await
+    }
+
+    async fn read_packument_for_update(
+        &self,
+        name: &PackageName,
+    ) -> Result<Option<HostedPackumentForUpdate>> {
+        Ok(S3Store::read_packument_for_update(self, name).await?.map(|packument| {
+            HostedPackumentForUpdate {
+                bytes: packument.bytes,
+                version: HostedPackumentVersion::ObjectVersion(packument.version),
+            }
+        }))
+    }
+
+    async fn write_packument_if_current(
+        &self,
+        name: &PackageName,
+        bytes: &[u8],
+        version: Option<&HostedPackumentVersion>,
+    ) -> Result<PackumentWrite> {
+        let version = match version {
+            Some(HostedPackumentVersion::ObjectVersion(version)) => Some(version),
+            Some(HostedPackumentVersion::Unversioned) | None => None,
+        };
+        if S3Store::write_packument_if_current(self, name, bytes, version).await? {
+            Ok(PackumentWrite::Written)
+        } else {
+            Ok(PackumentWrite::Conflict)
+        }
+    }
+
+    async fn open_tarball(
+        &self,
+        name: &PackageName,
+        filename: &str,
+    ) -> Result<Option<(Body, Option<u64>)>> {
+        S3Store::open_tarball(self, name, filename).await
+    }
+
+    async fn reserve_tarball_tmp(&self, name: &PackageName, filename: &str) -> Result<PathBuf> {
+        self.staging_tmp_path(name, filename).await
+    }
+
+    async fn finalize_tarball(
+        &self,
+        tmp_path: &Path,
+        name: &PackageName,
+        filename: &str,
+    ) -> Result<TarballFinalize> {
+        let outcome = self.upload_tarball(tmp_path, name, filename).await?;
+        // Keep the staged tmp on a Conflict so journal roll-forward can
+        // re-detect it and exclude the version whose bytes we don't own;
+        // once the object is ours there is nothing left to promote.
+        if outcome != TarballFinalize::Conflict {
+            let _ = fs::remove_file(tmp_path).await;
+        }
+        Ok(outcome)
+    }
+
+    async fn remove_tarball(&self, name: &PackageName, filename: &str) -> Result<bool> {
+        S3Store::remove_tarball(self, name, filename).await
+    }
+
+    async fn remove_package(&self, name: &PackageName) -> Result<bool> {
+        S3Store::remove_package(self, name).await
+    }
+
+    async fn list_package_names(&self) -> Result<Vec<String>> {
+        S3Store::list_package_names(self).await
+    }
+
+    async fn read_revision_refs(&self, digest: &str) -> Result<Vec<Vec<u8>>> {
+        S3Store::read_revision_refs(self, digest).await
+    }
+
+    async fn write_revision_ref(
+        &self,
+        digest: &str,
+        ref_id: &str,
+        owner: &str,
+        bytes: &[u8],
+    ) -> Result<HostedRevisionRefWrite> {
+        S3Store::write_revision_ref(self, digest, ref_id, owner, bytes).await
+    }
+
+    async fn remove_revision_ref(&self, digest: &str, ref_id: &str, owner: &str) -> Result<()> {
+        S3Store::remove_revision_ref(self, digest, ref_id, owner).await
+    }
+
+    async fn commit_revision_ref(&self, digest: &str, ref_id: &str, owner: &str) -> Result<()> {
+        S3Store::commit_revision_ref(self, digest, ref_id, owner).await
+    }
+
+    fn namespaced(&self, segment: &str) -> Arc<dyn HostedBackend> {
+        Arc::new(S3Store::namespaced(self, segment))
+    }
+
+    fn local_scratch_root(&self) -> &Path {
+        &self.cache_root
+    }
+
+    async fn read_staged(&self, object: &str) -> Result<Option<Vec<u8>>> {
+        S3Store::read_staged(self, object).await
+    }
+
+    async fn write_staged(&self, object: &str, bytes: &[u8]) -> Result<()> {
+        S3Store::write_staged(self, object, bytes).await
+    }
+
+    async fn remove_staged(&self, object: &str) -> Result<bool> {
+        S3Store::remove_staged(self, object).await
+    }
+
+    async fn list_staged_ids(&self) -> Result<Vec<String>> {
+        S3Store::list_staged_ids(self).await
+    }
+}

--- a/pnpr/crates/pnpr/src/s3/tests.rs
+++ b/pnpr/crates/pnpr/src/s3/tests.rs
@@ -34,8 +34,8 @@ async fn collect(body: Body) -> Vec<u8> {
 
 /// Stage a tarball through the same path the publish flow uses: write
 /// the decoded bytes to the reserved local tmp file, then upload.
-/// (Cleaning up the staging file is the `HostedStore` wrapper's job,
-/// not the adapter's, so it stays behind here.)
+/// (Cleaning up the staging file belongs to the `HostedBackend` impl, not
+/// to `upload_tarball`, so it stays behind here.)
 async fn upload(store: &S3Store, name: &PackageName, filename: &str, bytes: &[u8]) {
     let tmp = store.staging_tmp_path(name, filename).await.expect("reserve staging path");
     tokio::fs::write(&tmp, bytes).await.expect("write staging file");

--- a/pnpr/crates/pnpr/src/storage.rs
+++ b/pnpr/crates/pnpr/src/storage.rs
@@ -5,8 +5,8 @@ use crate::{
     s3::S3Store,
     streaming,
 };
+use async_trait::async_trait;
 use axum::body::Body;
-use object_store::UpdateVersion;
 use pnpm_crypto_hash::integrity_addressed_tarball_integrity;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -22,6 +22,12 @@ use std::{
 use tokio::{
     fs,
     io::{AsyncSeekExt, AsyncWriteExt},
+};
+
+mod backend;
+
+pub(crate) use self::backend::{
+    HostedBackend, HostedPackumentForUpdate, HostedPackumentVersion, TarballFinalize,
 };
 
 const PACKUMENT_FILE: &str = "package.json";
@@ -333,29 +339,8 @@ pub enum CachedPackument {
 /// in static mode.
 #[derive(Debug, Clone)]
 pub struct Storage {
-    hosted: HostedStore,
+    hosted: Arc<dyn HostedBackend>,
     cached: Store,
-}
-
-/// The hosted store's pluggable backend: a local directory or an
-/// S3-compatible bucket. The disposable `cached` store is always
-/// local, so only the hosted side varies.
-#[derive(Debug, Clone)]
-enum HostedStore {
-    Fs(Store),
-    S3(S3Store),
-}
-
-#[derive(Debug)]
-pub(crate) struct HostedPackumentForUpdate {
-    pub(crate) bytes: Vec<u8>,
-    pub(crate) version: HostedPackumentVersion,
-}
-
-#[derive(Debug)]
-pub(crate) enum HostedPackumentVersion {
-    Fs,
-    S3(UpdateVersion),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -373,74 +358,33 @@ pub(crate) enum PackumentUpdate {
     NotFound,
 }
 
-/// Outcome of promoting a staged tarball into the hosted store.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum TarballFinalize {
-    /// The tarball was promoted: created on S3, or renamed into place on the
-    /// single-node FS backend, which owns its store exclusively.
-    Written,
-    /// An object with byte-identical content already occupied the key, so
-    /// promotion was a no-op. Safe — the published artifact is exactly ours.
-    AlreadyIdentical,
-    /// A *different* object already occupies the key: a concurrent publisher
-    /// won this version's tarball. A published version's tarball is immutable,
-    /// so the caller must not overwrite it and should surface a write conflict
-    /// rather than advertise an integrity that no longer matches the bytes.
-    Conflict,
-}
-
-impl HostedStore {
+/// The single-node filesystem backend. It owns its directory tree
+/// exclusively, so a packument write needs no compare-and-set and a tarball
+/// is promoted by rename.
+#[async_trait]
+impl HostedBackend for Store {
     async fn read_packument(&self, name: &PackageName) -> Result<Option<Vec<u8>>> {
-        match self {
-            HostedStore::Fs(store) => store.read_packument_any_age(name).await,
-            HostedStore::S3(store) => store.read_packument(name).await,
-        }
+        Store::read_packument_any_age(self, name).await
     }
 
     async fn read_packument_for_update(
         &self,
         name: &PackageName,
     ) -> Result<Option<HostedPackumentForUpdate>> {
-        match self {
-            HostedStore::Fs(store) => Ok(store.read_packument_any_age(name).await?.map(|bytes| {
-                HostedPackumentForUpdate { bytes, version: HostedPackumentVersion::Fs }
-            })),
-            HostedStore::S3(store) => {
-                Ok(store.read_packument_for_update(name).await?.map(|packument| {
-                    HostedPackumentForUpdate {
-                        bytes: packument.bytes,
-                        version: HostedPackumentVersion::S3(packument.version),
-                    }
-                }))
-            }
-        }
+        Ok(Store::read_packument_any_age(self, name).await?.map(|bytes| HostedPackumentForUpdate {
+            bytes,
+            version: HostedPackumentVersion::Unversioned,
+        }))
     }
 
-    /// FS has no hosted packument CAS and always returns `Written`.
-    /// `Conflict` is only returned by the S3 object-version path.
     async fn write_packument_if_current(
         &self,
         name: &PackageName,
         bytes: &[u8],
-        version: Option<&HostedPackumentVersion>,
+        _version: Option<&HostedPackumentVersion>,
     ) -> Result<PackumentWrite> {
-        match self {
-            HostedStore::Fs(store) => {
-                store.write_packument(name, bytes).await?;
-                Ok(PackumentWrite::Written)
-            }
-            HostedStore::S3(store) => {
-                let version = match version {
-                    Some(HostedPackumentVersion::S3(version)) => Some(version),
-                    Some(HostedPackumentVersion::Fs) | None => None,
-                };
-                if store.write_packument_if_current(name, bytes, version).await? {
-                    Ok(PackumentWrite::Written)
-                } else {
-                    Ok(PackumentWrite::Conflict)
-                }
-            }
-        }
+        Store::write_packument(self, name, bytes).await?;
+        Ok(PackumentWrite::Written)
     }
 
     async fn open_tarball(
@@ -448,21 +392,13 @@ impl HostedStore {
         name: &PackageName,
         filename: &str,
     ) -> Result<Option<(Body, Option<u64>)>> {
-        match self {
-            HostedStore::Fs(store) => Ok(store
-                .open_tarball(name, filename)
-                .await?
-                .map(|(file, len)| (streaming::stream_file(file), Some(len)))),
-            HostedStore::S3(store) => store.open_tarball(name, filename).await,
-        }
+        Ok(Store::open_tarball(self, name, filename)
+            .await?
+            .map(|(file, len)| (streaming::stream_file(file), Some(len))))
     }
 
-    /// Reserve the local staging path the publish flow decodes into.
     async fn reserve_tarball_tmp(&self, name: &PackageName, filename: &str) -> Result<PathBuf> {
-        match self {
-            HostedStore::Fs(store) => store.reserve_tarball_tmp(name, filename).await,
-            HostedStore::S3(store) => store.staging_tmp_path(name, filename).await,
-        }
+        Store::reserve_tarball_tmp(self, name, filename).await
     }
 
     async fn finalize_tarball(
@@ -471,50 +407,24 @@ impl HostedStore {
         name: &PackageName,
         filename: &str,
     ) -> Result<TarballFinalize> {
-        match self {
-            HostedStore::Fs(store) => {
-                store.finalize_tarball(tmp_path, name, filename).await?;
-                Ok(TarballFinalize::Written)
-            }
-            HostedStore::S3(store) => {
-                let outcome = store.upload_tarball(tmp_path, name, filename).await?;
-                // Keep the staged tmp on a Conflict so journal roll-forward can
-                // re-detect it and exclude the version whose bytes we don't own;
-                // once the object is ours there is nothing left to promote.
-                if outcome != TarballFinalize::Conflict {
-                    let _ = fs::remove_file(tmp_path).await;
-                }
-                Ok(outcome)
-            }
-        }
+        Store::finalize_tarball(self, tmp_path, name, filename).await?;
+        Ok(TarballFinalize::Written)
     }
 
     async fn remove_tarball(&self, name: &PackageName, filename: &str) -> Result<bool> {
-        match self {
-            HostedStore::Fs(store) => store.remove_tarball(name, filename).await,
-            HostedStore::S3(store) => store.remove_tarball(name, filename).await,
-        }
+        Store::remove_tarball(self, name, filename).await
     }
 
     async fn remove_package(&self, name: &PackageName) -> Result<bool> {
-        match self {
-            HostedStore::Fs(store) => store.remove_package(name).await,
-            HostedStore::S3(store) => store.remove_package(name).await,
-        }
+        Store::remove_package(self, name).await
     }
 
     async fn list_package_names(&self) -> Result<Vec<String>> {
-        match self {
-            HostedStore::Fs(store) => store.list_package_names().await,
-            HostedStore::S3(store) => store.list_package_names().await,
-        }
+        Store::list_package_names(self).await
     }
 
     async fn read_revision_refs(&self, digest: &str) -> Result<Vec<Vec<u8>>> {
-        match self {
-            HostedStore::Fs(store) => store.read_revision_refs(digest).await,
-            HostedStore::S3(store) => store.read_revision_refs(digest).await,
-        }
+        Store::read_revision_refs(self, digest).await
     }
 
     async fn write_revision_ref(
@@ -524,62 +434,39 @@ impl HostedStore {
         owner: &str,
         bytes: &[u8],
     ) -> Result<HostedRevisionRefWrite> {
-        match self {
-            HostedStore::Fs(store) => store.write_revision_ref(digest, ref_id, owner, bytes).await,
-            HostedStore::S3(store) => store.write_revision_ref(digest, ref_id, owner, bytes).await,
-        }
+        Store::write_revision_ref(self, digest, ref_id, owner, bytes).await
     }
 
     async fn remove_revision_ref(&self, digest: &str, ref_id: &str, owner: &str) -> Result<()> {
-        match self {
-            HostedStore::Fs(store) => store.remove_revision_ref(digest, ref_id, owner).await,
-            HostedStore::S3(store) => store.remove_revision_ref(digest, ref_id, owner).await,
-        }
+        Store::remove_revision_ref(self, digest, ref_id, owner).await
     }
 
     async fn commit_revision_ref(&self, digest: &str, ref_id: &str, owner: &str) -> Result<()> {
-        match self {
-            HostedStore::Fs(store) => store.commit_revision_ref(digest, ref_id, owner).await,
-            HostedStore::S3(store) => store.commit_revision_ref(digest, ref_id, owner).await,
-        }
+        Store::commit_revision_ref(self, digest, ref_id, owner).await
     }
 
-    /// A view rooted under `segment`, giving a hosted registry its own
-    /// storage namespace so two orgs hosting the same `name@version` never
-    /// collide on disk (or on object keys).
-    fn namespaced(&self, segment: &str) -> HostedStore {
-        match self {
-            HostedStore::Fs(store) => HostedStore::Fs(store.namespaced(segment)),
-            HostedStore::S3(store) => HostedStore::S3(store.namespaced(segment)),
-        }
+    fn namespaced(&self, segment: &str) -> Arc<dyn HostedBackend> {
+        Arc::new(Store::namespaced(self, segment))
+    }
+
+    fn local_scratch_root(&self) -> &Path {
+        &self.root
     }
 
     async fn read_staged(&self, object: &str) -> Result<Option<Vec<u8>>> {
-        match self {
-            HostedStore::Fs(store) => store.read_staged(object).await,
-            HostedStore::S3(store) => store.read_staged(object).await,
-        }
+        Store::read_staged(self, object).await
     }
 
     async fn write_staged(&self, object: &str, bytes: &[u8]) -> Result<()> {
-        match self {
-            HostedStore::Fs(store) => store.write_staged(object, bytes).await,
-            HostedStore::S3(store) => store.write_staged(object, bytes).await,
-        }
+        Store::write_staged(self, object, bytes).await
     }
 
     async fn remove_staged(&self, object: &str) -> Result<bool> {
-        match self {
-            HostedStore::Fs(store) => store.remove_staged(object).await,
-            HostedStore::S3(store) => store.remove_staged(object).await,
-        }
+        Store::remove_staged(self, object).await
     }
 
     async fn list_staged_ids(&self) -> Result<Vec<String>> {
-        match self {
-            HostedStore::Fs(store) => store.list_staged_ids().await,
-            HostedStore::S3(store) => store.list_staged_ids().await,
-        }
+        Store::list_staged_ids(self).await
     }
 }
 
@@ -591,10 +478,10 @@ impl Storage {
     /// S3 backend's local staging scratch.
     pub fn new(hosted: &HostedStoreConfig, storage: PathBuf, cache_storage: PathBuf) -> Self {
         let cached = Store::new(cache_storage.clone());
-        let hosted = match hosted {
-            HostedStoreConfig::Fs => HostedStore::Fs(Store::new(storage)),
+        let hosted: Arc<dyn HostedBackend> = match hosted {
+            HostedStoreConfig::Fs => Arc::new(Store::new(storage)),
             HostedStoreConfig::S3 { store, prefix } => {
-                HostedStore::S3(S3Store::new(Arc::clone(store), prefix.clone(), cache_storage))
+                Arc::new(S3Store::new(Arc::clone(store), prefix.clone(), cache_storage))
             }
         };
         Self { hosted, cached }
@@ -878,10 +765,7 @@ impl Storage {
     /// root on the fs backend, the cache scratch on the S3 backend
     /// (whose staging paths live there too).
     pub fn publish_journal(&self) -> crate::journal::PublishJournal {
-        let root = match &self.hosted {
-            HostedStore::Fs(store) => &store.root,
-            HostedStore::S3(_) => &self.cached.root,
-        };
+        let root = self.hosted.local_scratch_root();
         crate::journal::PublishJournal::new(root.join(crate::journal::JOURNAL_DIR))
     }
 

--- a/pnpr/crates/pnpr/src/storage/backend.rs
+++ b/pnpr/crates/pnpr/src/storage/backend.rs
@@ -1,0 +1,136 @@
+use crate::{
+    error::Result,
+    package_name::PackageName,
+    storage::{HostedRevisionRefWrite, PackumentWrite},
+};
+use async_trait::async_trait;
+use axum::body::Body;
+use object_store::UpdateVersion;
+use std::{
+    fmt::Debug,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+/// The pluggable store behind a hosted registry: a local directory, an
+/// S3-compatible bucket, or anything else that can hold packuments,
+/// tarballs, revision references, and staged publishes.
+///
+/// Only the hosted side is pluggable. The disposable proxy cache is always
+/// local, because its contents are re-fetchable and its value is being fast.
+///
+/// Implementations own the differences the rest of the registry should not
+/// see: whether writes are compare-and-set, whether a tarball is promoted by
+/// rename or by upload, and how a namespace maps onto paths or key prefixes.
+#[async_trait]
+pub(crate) trait HostedBackend: Debug + Send + Sync {
+    async fn read_packument(&self, name: &PackageName) -> Result<Option<Vec<u8>>>;
+
+    /// Read a packument together with the token [`Self::write_packument_if_current`]
+    /// needs to detect a concurrent writer.
+    async fn read_packument_for_update(
+        &self,
+        name: &PackageName,
+    ) -> Result<Option<HostedPackumentForUpdate>>;
+
+    /// Write only if the stored packument is still at `version`. A backend
+    /// without compare-and-set reports [`PackumentWrite::Written`]
+    /// unconditionally — it serializes writers by another means.
+    async fn write_packument_if_current(
+        &self,
+        name: &PackageName,
+        bytes: &[u8],
+        version: Option<&HostedPackumentVersion>,
+    ) -> Result<PackumentWrite>;
+
+    async fn open_tarball(
+        &self,
+        name: &PackageName,
+        filename: &str,
+    ) -> Result<Option<(Body, Option<u64>)>>;
+
+    /// Reserve the local staging path the publish flow decodes into. Always
+    /// local: the bytes are verified on the way in, before the backend sees
+    /// them.
+    async fn reserve_tarball_tmp(&self, name: &PackageName, filename: &str) -> Result<PathBuf>;
+
+    /// Promote a staged tarball to its final home, consuming the tmp file
+    /// unless the outcome is [`TarballFinalize::Conflict`] — those bytes stay
+    /// put so journal roll-forward can re-detect them.
+    async fn finalize_tarball(
+        &self,
+        tmp_path: &Path,
+        name: &PackageName,
+        filename: &str,
+    ) -> Result<TarballFinalize>;
+
+    async fn remove_tarball(&self, name: &PackageName, filename: &str) -> Result<bool>;
+
+    async fn remove_package(&self, name: &PackageName) -> Result<bool>;
+
+    async fn list_package_names(&self) -> Result<Vec<String>>;
+
+    async fn read_revision_refs(&self, digest: &str) -> Result<Vec<Vec<u8>>>;
+
+    async fn write_revision_ref(
+        &self,
+        digest: &str,
+        ref_id: &str,
+        owner: &str,
+        bytes: &[u8],
+    ) -> Result<HostedRevisionRefWrite>;
+
+    async fn remove_revision_ref(&self, digest: &str, ref_id: &str, owner: &str) -> Result<()>;
+
+    async fn commit_revision_ref(&self, digest: &str, ref_id: &str, owner: &str) -> Result<()>;
+
+    /// A view rooted under `segment`, giving a hosted registry its own
+    /// namespace so two orgs hosting the same `name@version` never collide.
+    fn namespaced(&self, segment: &str) -> Arc<dyn HostedBackend>;
+
+    /// The local directory this backend stages tarballs in, and with them the
+    /// commit journal that rolls a staged publish forward after a crash. Local
+    /// even when the final home is a bucket: the decode/verify step writes
+    /// through `std::fs` and needs a real path.
+    fn local_scratch_root(&self) -> &Path;
+
+    async fn read_staged(&self, object: &str) -> Result<Option<Vec<u8>>>;
+
+    async fn write_staged(&self, object: &str, bytes: &[u8]) -> Result<()>;
+
+    async fn remove_staged(&self, object: &str) -> Result<bool>;
+
+    async fn list_staged_ids(&self) -> Result<Vec<String>>;
+}
+
+#[derive(Debug)]
+pub(crate) struct HostedPackumentForUpdate {
+    pub(crate) bytes: Vec<u8>,
+    pub(crate) version: HostedPackumentVersion,
+}
+
+/// What a backend needs to recognize the packument it handed out, so a
+/// read-modify-write can refuse to clobber a concurrent publisher.
+#[derive(Debug)]
+pub(crate) enum HostedPackumentVersion {
+    /// The backend offers no compare-and-set. It is single-writer by
+    /// construction, so there is nothing to compare against.
+    Unversioned,
+    ObjectVersion(UpdateVersion),
+}
+
+/// Outcome of promoting a staged tarball into the hosted store.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TarballFinalize {
+    /// The tarball was promoted: created on S3, or renamed into place on the
+    /// single-node FS backend, which owns its store exclusively.
+    Written,
+    /// An object with byte-identical content already occupied the key, so
+    /// promotion was a no-op. Safe — the published artifact is exactly ours.
+    AlreadyIdentical,
+    /// A *different* object already occupies the key: a concurrent publisher
+    /// won this version's tarball. A published version's tarball is immutable,
+    /// so the caller must not overwrite it and should surface a write conflict
+    /// rather than advertise an integrity that no longer matches the bytes.
+    Conflict,
+}


### PR DESCRIPTION
## Summary

Second item from the pnpr refactor plan in pnpm/pnpm#14191.

The hosted store was a two-variant enum, `HostedStore::{Fs, S3}`, whose impl
block was **193 lines of pure dispatch** — 36 `match { Fs => …, S3 => … }` arms
across 18 methods — for a choice nothing above `Storage` ever needs to see.
Adding a third backend (GCS and Azure are both already supported by the
`object_store` crate we depend on) meant editing all eighteen.

This replaces it with a `HostedBackend` trait implemented by the filesystem
`Store` and by `S3Store`, held as `Arc<dyn HostedBackend>`. That is exactly the
shape the auth layer already uses for `UserBackend` and `TokenBackend`, so this
makes the two consistent rather than introducing a new pattern.

Each impl now owns the adaptation the dispatch arms used to hold: the fs side
wraps its file handle into a stream and reports an unconditional `Written`; the
S3 side maps its object version onto the CAS token and keeps the staged tmp file
when promotion conflicts.

**Two things stop naming the backend.**

- `HostedPackumentVersion::Fs` becomes `Unversioned`. Callers branch on whether
  a store offers compare-and-set, not on which store it is.
- `publish_journal` picked its root by matching on the variant. That is now
  `local_scratch_root` on the trait, so `S3Store` carries the cache root it
  already derived `staging_dir` from. **The journal path is unchanged on both
  backends** — deliberately, since moving it would strand the crash-recovery
  roll-forward of an existing deployment.

The trait and the types in its signatures live in a new `storage::backend`, so
what a backend must provide is stated in one place instead of being implied by
an enum's arms.

Also drops a now-unfulfilled `#[expect(clippy::needless_pass_by_value)]` on
`S3Store::new`, whose stated reason no longer holds once `cache_root` is stored.

Net: `storage.rs` loses 174 lines, and there are now **zero** matches on the
backend kind anywhere in the crate. The full pnpr suite passes unchanged at 711
tests.

## Squash Commit Body

```text
The hosted store was a two-variant enum whose impl block was 193 lines of
match { Fs => …, S3 => … } across 36 arms — a hand-rolled vtable for a
choice the rest of the registry never needs to see. Adding a third backend
meant editing eighteen methods.

Replace it with a HostedBackend trait, implemented by the filesystem Store
and by S3Store, held as Arc<dyn HostedBackend>. This is the shape the auth
layer already uses for UserBackend and TokenBackend, so it makes the two
consistent rather than introducing a pattern.

Each impl now owns the adaptation the dispatch used to hold: the fs side
wraps its file handle into a stream and reports an unconditional Written,
the S3 side maps its object version onto the CAS token and keeps the staged
tmp file on a conflict.

Two things stop naming the backend. HostedPackumentVersion::Fs becomes
Unversioned — it describes a store with no compare-and-set, which is what
callers actually branch on. And publish_journal picked its root by matching
on the variant; that becomes local_scratch_root, so S3Store now carries the
cache root it already derived staging_dir from. The journal path is
unchanged on both backends.

The trait and the types in its signatures live in storage::backend, so what
a backend must provide is stated in one place instead of being implied by an
enum's arms.

Related to pnpm/pnpm#14191.
```

## Checklist

- [x] Added or updated tests. — behaviour-preserving; covered by the existing
  711-test suite (including the S3 backend tests), which passes unchanged.

---
Written by an agent (Claude Code, claude-opus-5[1m]).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790365986&installation_model_id=426870&pr_number=14195&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14195&signature=01d8938bad8f00d8e762eb225924662bcc7780e3a771e464f7664368c1c1f099"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for hosted registry storage across multiple backend types, including S3.
  * Added safer handling for staged tarball publishing, including duplicate and conflicting uploads.
  * Added support for namespaced hosted storage and recovery of staged publications.
* **Refactor**
  * Unified hosted storage operations behind a common backend abstraction, improving consistency across storage implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->