### PR TITLE
fix(cli): keep the verify-deps install's report off exec's stdout

### DIFF
--- a/.changeset/exec-stdout-stays-the-commands.md
+++ b/.changeset/exec-stdout-stays-the-commands.md
@@ -1,5 +1,0 @@
----
-"pacquet": patch
----
-
-The install that `verifyDepsBeforeRun` spawns before `pnpm run` / `pnpm exec` now reports to stderr, so lines such as `Scope: all 56 workspace projects` no longer land in the middle of the executed command's stdout and break a pipe into `jq` [#14197](https://github.com/pnpm/pnpm/issues/14197). A silent `pnpm exec` also passes its reporter down to that install now, so `--silent` suppresses it.

--- a/.changeset/exec-stdout-stays-the-commands.md
+++ b/.changeset/exec-stdout-stays-the-commands.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+The install that `verifyDepsBeforeRun` spawns before `pnpm run` / `pnpm exec` now reports to stderr, so lines such as `Scope: all 56 workspace projects` no longer land in the middle of the executed command's stdout and break a pipe into `jq` [#14197](https://github.com/pnpm/pnpm/issues/14197). A silent `pnpm exec` also passes its reporter down to that install now, so `--silent` suppresses it.

--- a/.changeset/keep-exec-stdout-for-the-command.md
+++ b/.changeset/keep-exec-stdout-for-the-command.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-The install that `verifyDepsBeforeRun` spawns before `pnpm run` / `pnpm exec` now reports to stderr, so lines such as `Scope: all 56 workspace projects` no longer land in the middle of the executed command's stdout and break a pipe into `jq` [#14197](https://github.com/pnpm/pnpm/issues/14197). `pnpm exec --silent` now suppresses that install's output too.
+The install that `verifyDepsBeforeRun` spawns before `pnpm run` / `pnpm exec` now reports to stderr, so lines such as `Scope: all 56 workspace projects` no longer land in the middle of the executed command's stdout and break a pipe into `jq` [#14197](https://github.com/pnpm/pnpm/issues/14197). `pnpm exec --silent` and `pnpm --silent -r run` now suppress that install's output too.

--- a/.changeset/keep-exec-stdout-for-the-command.md
+++ b/.changeset/keep-exec-stdout-for-the-command.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+The install that `verifyDepsBeforeRun` spawns before `pnpm run` / `pnpm exec` now reports to stderr, so lines such as `Scope: all 56 workspace projects` no longer land in the middle of the executed command's stdout and break a pipe into `jq` [#14197](https://github.com/pnpm/pnpm/issues/14197). `pnpm exec --silent` now suppresses that install's output too.

--- a/pnpm/crates/cli/src/cli_args/dispatch_script.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_script.rs
@@ -128,12 +128,13 @@ pub(super) fn fallback<'a>(
 pub(super) fn exec<'a>(ctx: &RunCtx<'a>, args: ExecArgs) -> miette::Result<CommandFuture<'a>> {
     let config: &'static Config = (ctx.config)()?;
     let args = with_recursive_exec_options(ctx, args, config);
+    let silent = matches!(ctx.reporter, ReporterType::Silent);
     if ctx.recursive {
         let dir = ctx.dir;
         let emit = reporter_emit(ctx.reporter);
-        Ok(Box::pin(async move { args.run_recursive(config, dir, emit).await }))
+        Ok(Box::pin(async move { args.run_recursive(config, dir, emit, silent).await }))
     } else {
-        args.run(ctx.dir, config)?;
+        args.run(ctx.dir, config, silent)?;
         Ok(Box::pin(std::future::ready(Ok(()))))
     }
 }

--- a/pnpm/crates/cli/src/cli_args/exec.rs
+++ b/pnpm/crates/cli/src/cli_args/exec.rs
@@ -99,9 +99,9 @@ impl ExecArgs {
     /// On a non-zero child exit code this terminates the process with the
     /// same code via [`std::process::exit`], matching pnpm's exec, which
     /// returns `{ exitCode }` and lets the CLI exit with it.
-    pub fn run(self, dir: &Path, config: &Config) -> miette::Result<()> {
+    pub fn run(self, dir: &Path, config: &Config, silent: bool) -> miette::Result<()> {
         let command = prepare_command(self.command)?;
-        super::verify_deps::verify_deps_before_run(dir, config, false)?;
+        super::verify_deps::verify_deps_before_run(dir, config, silent)?;
         let status = spawn_in_dir(&command, dir, config, self.shell_mode, ScriptOutput::Inherit)?;
         if !status.success() {
             // Propagate the child's exit code. A signal-terminated child
@@ -119,8 +119,9 @@ impl ExecArgs {
         config: &Config,
         dir: &Path,
         emit: fn(&LogEvent),
+        silent: bool,
     ) -> miette::Result<()> {
-        super::verify_deps::verify_deps_before_run(dir, config, false)?;
+        super::verify_deps::verify_deps_before_run(dir, config, silent)?;
         recursive::exec_recursive(self, config, dir, emit).await
     }
 }

--- a/pnpm/crates/cli/src/cli_args/exec.rs
+++ b/pnpm/crates/cli/src/cli_args/exec.rs
@@ -99,6 +99,9 @@ impl ExecArgs {
     /// On a non-zero child exit code this terminates the process with the
     /// same code via [`std::process::exit`], matching pnpm's exec, which
     /// returns `{ exitCode }` and lets the CLI exit with it.
+    ///
+    /// `silent` reaches the verify-deps gate, so a silent `exec` also
+    /// silences the install the gate may spawn.
     pub fn run(self, dir: &Path, config: &Config, silent: bool) -> miette::Result<()> {
         let command = prepare_command(self.command)?;
         super::verify_deps::verify_deps_before_run(dir, config, silent)?;

--- a/pnpm/crates/cli/src/cli_args/run.rs
+++ b/pnpm/crates/cli/src/cli_args/run.rs
@@ -174,7 +174,7 @@ impl RunArgs {
             Err(ReadProjectManifestOnlyError::NoImporterManifestFound { .. })
                 if fallback_to_exec =>
             {
-                return exec_fallback(script_name, args, dir, config);
+                return exec_fallback(script_name, args, dir, config, silent);
             }
             Err(err) => return Err(RunError::Manifest(err).into()),
         };
@@ -193,7 +193,7 @@ impl RunArgs {
                 return Ok(());
             }
             if fallback_to_exec {
-                return exec_fallback(script_name, args, dir, config);
+                return exec_fallback(script_name, args, dir, config, silent);
             }
             return Err(RunError::NoScript {
                 script: script_name.clone(),
@@ -259,7 +259,7 @@ impl RunArgs {
         emit: fn(&LogEvent),
         silent: bool,
     ) -> miette::Result<()> {
-        super::verify_deps::verify_deps_before_run(dir, config, false)?;
+        super::verify_deps::verify_deps_before_run(dir, config, silent)?;
         recursive::run_recursive(self, config, dir, emit, silent)
     }
 }
@@ -269,6 +269,7 @@ fn exec_fallback(
     args: &[String],
     dir: &Path,
     config: &Config,
+    silent: bool,
 ) -> miette::Result<()> {
     ExecArgs {
         command: RunArgs::script(script_name, args.iter().cloned()),
@@ -280,7 +281,7 @@ fn exec_fallback(
         reverse: false,
         parallel: false,
     }
-    .run(dir, config)
+    .run(dir, config, silent)
 }
 
 /// Shared inputs for running a script, threaded through

--- a/pnpm/crates/cli/src/cli_args/verify_deps.rs
+++ b/pnpm/crates/cli/src/cli_args/verify_deps.rs
@@ -90,12 +90,12 @@ pub(crate) fn verify_deps_before_run(
 
 /// Re-run the kind of install the workspace state recorded, in-place
 /// and with inherited stdio, the way pnpm's `runDepsStatusCheck` spawns
-/// `pnpm install` through `runPnpmCli`. `--use-stderr` keeps its
-/// reporter off the inherited stdout, which belongs to the script or
-/// command the gate is about to run. The spawned install never
+/// `pnpm install` through `runPnpmCli`. The spawned install never
 /// re-enters this gate: only `run` / `exec` consult it. Its up-to-date
 /// shortcuts are bypassed because the pre-run check has already decided
-/// that an install is required.
+/// that an install is required. `--use-stderr` keeps its reporter off
+/// the inherited stdout, which belongs to the script or command the gate
+/// is about to run.
 #[expect(clippy::exit, reason = "a failed spawned install must preserve the child exit code")]
 fn spawn_install(dir: &Path, install_args: &[String], silent: bool) -> miette::Result<()> {
     let exe = std::env::current_exe().into_diagnostic()?;

--- a/pnpm/crates/cli/src/cli_args/verify_deps.rs
+++ b/pnpm/crates/cli/src/cli_args/verify_deps.rs
@@ -90,7 +90,9 @@ pub(crate) fn verify_deps_before_run(
 
 /// Re-run the kind of install the workspace state recorded, in-place
 /// and with inherited stdio, the way pnpm's `runDepsStatusCheck` spawns
-/// `pnpm install` through `runPnpmCli`. The spawned install never
+/// `pnpm install` through `runPnpmCli`. `--use-stderr` keeps its
+/// reporter off the inherited stdout, which belongs to the script or
+/// command the gate is about to run. The spawned install never
 /// re-enters this gate: only `run` / `exec` consult it. Its up-to-date
 /// shortcuts are bypassed because the pre-run check has already decided
 /// that an install is required.
@@ -99,7 +101,7 @@ fn spawn_install(dir: &Path, install_args: &[String], silent: bool) -> miette::R
     let exe = std::env::current_exe().into_diagnostic()?;
     let mut command = Command::new(exe);
     command
-        .args(["install", "--verify-deps-before-run-install"])
+        .args(["install", "--verify-deps-before-run-install", "--use-stderr"])
         .args(install_args)
         .current_dir(dir);
     if silent {

--- a/pnpm/crates/cli/tests/suite/verify_deps_before_run.rs
+++ b/pnpm/crates/cli/tests/suite/verify_deps_before_run.rs
@@ -43,6 +43,42 @@ fn write_manifest_with_dependency_groups(
         .expect("write package.json");
 }
 
+/// A two-project workspace whose projects each print a JSON line from a
+/// `hello` script, for the recursive gate scenarios.
+fn write_recursive_workspace(workspace: &Path) {
+    fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - project-1\n  - project-2\n")
+        .expect("write pnpm-workspace.yaml");
+    fs::write(
+        workspace.join("package.json"),
+        json!({ "name": "verify-deps-workspace", "version": "0.0.0" }).to_string(),
+    )
+    .expect("write the root package.json");
+    for name in ["project-1", "project-2"] {
+        let dir = workspace.join(name);
+        fs::create_dir_all(&dir).expect("create the project directory");
+        fs::write(
+            dir.join("package.json"),
+            json!({
+                "name": name,
+                "version": "0.0.0",
+                "scripts": { "hello": r#"echo '{"ok":true}'"# },
+            })
+            .to_string(),
+        )
+        .expect("write the project package.json");
+    }
+}
+
+/// Sorted so a test does not depend on the order two concurrent projects
+/// finish in.
+fn sorted_lines(stdout: &[u8]) -> Vec<String> {
+    let stdout = String::from_utf8_lossy(stdout);
+    eprintln!("STDOUT:\n{stdout}\n");
+    let mut lines = stdout.trim().lines().map(str::to_string).collect::<Vec<_>>();
+    lines.sort();
+    lines
+}
+
 /// The default action is `install` (pnpm's
 /// `'verify-deps-before-run': 'install'`): a fresh project's first
 /// `run` spawns an install before executing the script.
@@ -514,32 +550,6 @@ fn a_silent_exec_silences_the_spawned_install() {
     drop(root);
 }
 
-/// A two-project workspace whose projects each print a JSON line from a
-/// `hello` script, for the recursive gate scenarios.
-fn write_recursive_workspace(workspace: &Path) {
-    fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - project-1\n  - project-2\n")
-        .expect("write pnpm-workspace.yaml");
-    fs::write(
-        workspace.join("package.json"),
-        json!({ "name": "verify-deps-workspace", "version": "0.0.0" }).to_string(),
-    )
-    .expect("write the root package.json");
-    for name in ["project-1", "project-2"] {
-        let dir = workspace.join(name);
-        fs::create_dir_all(&dir).expect("create the project directory");
-        fs::write(
-            dir.join("package.json"),
-            json!({
-                "name": name,
-                "version": "0.0.0",
-                "scripts": { "hello": r#"echo '{"ok":true}'"# },
-            })
-            .to_string(),
-        )
-        .expect("write the project package.json");
-    }
-}
-
 /// The recursive `exec` path routes the gate's install the same way the
 /// single-project one does.
 #[cfg(unix)]
@@ -553,19 +563,33 @@ fn a_recursive_exec_keeps_the_spawned_install_off_stdout() {
         .output()
         .expect("spawn pacquet exec");
     assert!(output.status.success(), "exec must succeed after the spawned install");
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert_eq!(stdout, "{\"ok\":true}\n{\"ok\":true}\n", "only the command may write to stdout");
+    assert_eq!(
+        sorted_lines(&output.stdout),
+        [r#"{"ok":true}"#, r#"{"ok":true}"#],
+        "only the command may write to stdout",
+    );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("Done in"), "the spawned install must report on stderr:\n{stderr}");
 
-    let output = pacquet_in(&workspace)
+    drop(root);
+}
+
+/// A silent recursive `exec` silences the install the gate spawns, the
+/// way the single-project one does.
+#[cfg(unix)]
+#[test]
+fn a_silent_recursive_exec_silences_the_spawned_install() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_recursive_workspace(&workspace);
+
+    let output = pacquet
         .with_args(["--silent", "-r", "exec", "sh", "-c", "echo done"])
         .output()
         .expect("spawn pacquet exec");
-    assert!(output.status.success(), "a silent exec must succeed too");
-    assert_eq!(String::from_utf8_lossy(&output.stdout), "done\ndone\n");
+    assert!(output.status.success(), "exec must succeed after the spawned install");
+    assert_eq!(sorted_lines(&output.stdout), ["done", "done"]);
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.is_empty(), "a silent recursive exec must report nothing:\n{stderr}");
+    assert!(stderr.is_empty(), "the spawned install must report nothing:\n{stderr}");
 
     drop(root);
 }
@@ -580,22 +604,31 @@ fn a_recursive_run_keeps_the_spawned_install_off_stdout() {
 
     let output = pacquet.with_args(["-r", "run", "hello"]).output().expect("spawn pacquet run");
     assert!(output.status.success(), "run must succeed after the spawned install");
-    let stdout = String::from_utf8_lossy(&output.stdout);
     assert_eq!(
-        stdout, "Scope: 2 of 3 workspace projects\n{\"ok\":true}\n{\"ok\":true}\n",
+        sorted_lines(&output.stdout),
+        ["Scope: 2 of 3 workspace projects", r#"{"ok":true}"#, r#"{"ok":true}"#],
         "stdout carries the scripts and `run`'s own scope line, nothing from the install",
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("Done in"), "the spawned install must report on stderr:\n{stderr}");
 
-    let output = pacquet_in(&workspace)
-        .with_args(["--silent", "-r", "run", "hello"])
-        .output()
-        .expect("spawn pacquet run");
-    assert!(output.status.success(), "a silent run must succeed too");
-    assert_eq!(String::from_utf8_lossy(&output.stdout), "{\"ok\":true}\n{\"ok\":true}\n");
+    drop(root);
+}
+
+/// A silent recursive `run` silences the install the gate spawns, and
+/// drops `run`'s own scope line with it.
+#[cfg(unix)]
+#[test]
+fn a_silent_recursive_run_silences_the_spawned_install() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_recursive_workspace(&workspace);
+
+    let output =
+        pacquet.with_args(["--silent", "-r", "run", "hello"]).output().expect("spawn pacquet run");
+    assert!(output.status.success(), "run must succeed after the spawned install");
+    assert_eq!(sorted_lines(&output.stdout), [r#"{"ok":true}"#, r#"{"ok":true}"#]);
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.is_empty(), "a silent recursive run must report nothing:\n{stderr}");
+    assert!(stderr.is_empty(), "the spawned install must report nothing:\n{stderr}");
 
     drop(root);
 }

--- a/pnpm/crates/cli/tests/suite/verify_deps_before_run.rs
+++ b/pnpm/crates/cli/tests/suite/verify_deps_before_run.rs
@@ -581,7 +581,10 @@ fn a_recursive_run_keeps_the_spawned_install_off_stdout() {
     let output = pacquet.with_args(["-r", "run", "hello"]).output().expect("spawn pacquet run");
     assert!(output.status.success(), "run must succeed after the spawned install");
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(!stdout.contains("Done in"), "the spawned install must not write to stdout:\n{stdout}");
+    assert_eq!(
+        stdout, "Scope: 2 of 3 workspace projects\n{\"ok\":true}\n{\"ok\":true}\n",
+        "stdout carries the scripts and `run`'s own scope line, nothing from the install",
+    );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("Done in"), "the spawned install must report on stderr:\n{stderr}");
 

--- a/pnpm/crates/cli/tests/suite/verify_deps_before_run.rs
+++ b/pnpm/crates/cli/tests/suite/verify_deps_before_run.rs
@@ -513,3 +513,86 @@ fn a_silent_exec_silences_the_spawned_install() {
 
     drop(root);
 }
+
+/// A two-project workspace whose projects each print a JSON line from a
+/// `hello` script, for the recursive gate scenarios.
+fn write_recursive_workspace(workspace: &Path) {
+    fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - project-1\n  - project-2\n")
+        .expect("write pnpm-workspace.yaml");
+    fs::write(
+        workspace.join("package.json"),
+        json!({ "name": "verify-deps-workspace", "version": "0.0.0" }).to_string(),
+    )
+    .expect("write the root package.json");
+    for name in ["project-1", "project-2"] {
+        let dir = workspace.join(name);
+        fs::create_dir_all(&dir).expect("create the project directory");
+        fs::write(
+            dir.join("package.json"),
+            json!({
+                "name": name,
+                "version": "0.0.0",
+                "scripts": { "hello": r#"echo '{"ok":true}'"# },
+            })
+            .to_string(),
+        )
+        .expect("write the project package.json");
+    }
+}
+
+/// The recursive `exec` path routes the gate's install the same way the
+/// single-project one does.
+#[cfg(unix)]
+#[test]
+fn a_recursive_exec_keeps_the_spawned_install_off_stdout() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_recursive_workspace(&workspace);
+
+    let output = pacquet
+        .with_args(["-r", "exec", "sh", "-c", r#"echo '{"ok":true}'"#])
+        .output()
+        .expect("spawn pacquet exec");
+    assert!(output.status.success(), "exec must succeed after the spawned install");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(stdout, "{\"ok\":true}\n{\"ok\":true}\n", "only the command may write to stdout");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Done in"), "the spawned install must report on stderr:\n{stderr}");
+
+    let output = pacquet_in(&workspace)
+        .with_args(["--silent", "-r", "exec", "sh", "-c", "echo done"])
+        .output()
+        .expect("spawn pacquet exec");
+    assert!(output.status.success(), "a silent exec must succeed too");
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "done\ndone\n");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.is_empty(), "a silent recursive exec must report nothing:\n{stderr}");
+
+    drop(root);
+}
+
+/// The recursive `run` path passes its reporter down to the gate as
+/// well, which the single-project one already did.
+#[cfg(unix)]
+#[test]
+fn a_recursive_run_keeps_the_spawned_install_off_stdout() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_recursive_workspace(&workspace);
+
+    let output = pacquet.with_args(["-r", "run", "hello"]).output().expect("spawn pacquet run");
+    assert!(output.status.success(), "run must succeed after the spawned install");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.contains("Done in"), "the spawned install must not write to stdout:\n{stdout}");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Done in"), "the spawned install must report on stderr:\n{stderr}");
+
+    let output = pacquet_in(&workspace)
+        .with_args(["--silent", "-r", "run", "hello"])
+        .output()
+        .expect("spawn pacquet run");
+    assert!(output.status.success(), "a silent run must succeed too");
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "{\"ok\":true}\n{\"ok\":true}\n");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.is_empty(), "a silent recursive run must report nothing:\n{stderr}");
+
+    drop(root);
+}

--- a/pnpm/crates/cli/tests/suite/verify_deps_before_run.rs
+++ b/pnpm/crates/cli/tests/suite/verify_deps_before_run.rs
@@ -154,25 +154,25 @@ fn dedupe_peers_lockfile_regeneration_installs_before_running_the_script() {
         .with_args(["run", "hello"])
         .output()
         .expect("run script after lockfile regeneration");
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    eprintln!("STDOUT:\n{stdout}\n");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    eprintln!("STDERR:\n{stderr}\n");
     assert!(output.status.success(), "the script must run successfully");
     assert!(
-        stdout.contains("Lockfile is up to date, resolution step is skipped"),
-        "the verifier install must reuse the regenerated lockfile:\n{stdout}",
+        stderr.contains("Lockfile is up to date, resolution step is skipped"),
+        "the verifier install must reuse the regenerated lockfile:\n{stderr}",
     );
-    let policy_verdict = stdout
+    let policy_verdict = stderr
         .find("Lockfile passes supply-chain policies")
         .expect("the verifier must report its lockfile policy verdict");
-    let frozen_install = stdout
+    let frozen_install = stderr
         .find("Lockfile is up to date, resolution step is skipped")
         .expect("the verifier must report the frozen install");
-    let up_to_date = stdout
+    let up_to_date = stderr
         .find("Already up to date")
         .expect("the verifier must report that no packages changed");
     assert!(
         policy_verdict < frozen_install && frozen_install < up_to_date,
-        "the verifier messages must match pnpm's order:\n{stdout}",
+        "the verifier messages must match pnpm's order:\n{stderr}",
     );
     assert_eq!(
         fs::read_to_string(workspace.join("pnpm-lock.yaml"))
@@ -469,6 +469,47 @@ fn exec_runs_the_gate_too() {
         .with_args(["--config.verify-deps-before-run=error", "exec", "true"])
         .assert()
         .success();
+
+    drop(root);
+}
+
+/// The install the gate spawns writes its report to stderr, so `exec`
+/// hands stdout to the executed command alone and machine-readable
+/// output survives a pipe
+/// ([pnpm/pnpm#14197](https://github.com/pnpm/pnpm/issues/14197)).
+#[cfg(unix)]
+#[test]
+fn the_spawned_install_keeps_exec_stdout_for_the_command() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_manifest(&workspace, &workspace.join("marker.txt"));
+
+    let output = pacquet
+        .with_args(["exec", "sh", "-c", r#"echo '{"ok":true}'"#])
+        .output()
+        .expect("spawn pacquet exec");
+    assert!(output.status.success(), "exec must succeed after the spawned install");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(stdout, "{\"ok\":true}\n", "the spawned install must not write to stdout");
+
+    drop(root);
+}
+
+/// A silent `exec` passes its reporter down to the install the gate
+/// spawns, so nothing is reported at all.
+#[cfg(unix)]
+#[test]
+fn a_silent_exec_silences_the_spawned_install() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_manifest(&workspace, &workspace.join("marker.txt"));
+
+    let output = pacquet
+        .with_args(["--silent", "exec", "sh", "-c", "echo done"])
+        .output()
+        .expect("spawn pacquet exec");
+    assert!(output.status.success(), "exec must succeed after the spawned install");
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "done\n");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.is_empty(), "the spawned install must report nothing:\n{stderr}");
 
     drop(root);
 }


### PR DESCRIPTION
## Summary

Running `pnpm exec <bin> --json | jq` from a workspace member printed `Scope: all N workspace projects` ahead of the command's own output, which broke the pipe. The lines come from the install `verifyDepsBeforeRun` spawns when `node_modules` is out of sync: `spawn_install` re-execs `pnpm install` with fully inherited stdio, so that install's reporter writes to the same stdout the executed command writes to. That is also why it only showed up on a fresh CI checkout and not on a machine whose `node_modules` was already current.

The spawned install now gets `--use-stderr`, so its report goes to stderr and stdout stays the command's alone. `exec` also passes the real silent flag into the gate instead of a hardcoded `false`, so `--silent` / `--reporter=silent` suppresses the install too; `run`'s recursive path had the same hardcoded `false` and now threads it as well.

On the porting question: the TypeScript CLI spawns the same install through `runPnpmCli`, which also uses `stdio: 'inherit'` and never passes `--use-stderr`, so the stdout leak exists there too and still needs porting. It does forward the reporter (`--reporter=${reporter}`), so the `--silent` half is already correct on that side. I left `pnpm11/` alone here because moving the auto-install's output to stderr shifts behavior in a stable release and turns over three existing e2e assertions, which felt like it deserves its own PR rather than riding along with a v12 regression fix. Happy to add it here if you would rather have both in one go.

Fixes pnpm/pnpm#14197

## Squash Commit Body

```text
The verify-deps-before-run gate re-execs `pnpm install` with inherited
stdio, so the install's reporter output (`Scope: ...`, `Done in ...`)
was interleaved with the stdout of the script or command the gate was
about to run. Piping `pnpm exec <bin> --json` into a JSON parser failed
because of it.

Pass `--use-stderr` to the spawned install so its report goes to stderr,
and thread the caller's silent flag into `verify_deps_before_run` from
`exec` (both the single-project and recursive paths) and from `run`'s
recursive path, which all passed a hardcoded `false` and so ignored
`--silent`.

The TypeScript `runPnpmCli` spawns the same install with inherited stdio
and no `--use-stderr`, so that side still needs the matching change.

Closes pnpm/pnpm#14197
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [ ] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dependency installation output during `pnpm run` and `pnpm exec` now goes to stderr, keeping command stdout clean for pipelines.
  * `--silent` consistently suppresses dependency installation output, including recursive commands.
  * Improved reliability for recursive `run` and `exec` commands when dependencies are installed automatically.

* **Documentation**
  * Added release notes describing the updated output behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->