### PR TITLE
fix(cli): keep verifier install output off stdout

### DIFF
--- a/.changeset/calm-pandas-report.md
+++ b/.changeset/calm-pandas-report.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed dependency-verification install logs corrupting `pnpm exec` output and ignoring `--silent` [pnpm/pnpm#14197](https://github.com/pnpm/pnpm/issues/14197).

--- a/pnpm/crates/cli/src/cli_args/clean.rs
+++ b/pnpm/crates/cli/src/cli_args/clean.rs
@@ -1,6 +1,4 @@
-use super::{
-    dispatch::RunCtx, recursive::discover_workspace_projects, reporter::ReporterType, run::RunArgs,
-};
+use super::{dispatch::RunCtx, recursive::discover_workspace_projects, run::RunArgs};
 use derive_more::{Display, Error};
 use miette::{Context, Diagnostic, IntoDiagnostic};
 use pnpm_config::Config;
@@ -63,7 +61,7 @@ impl CleanArgs {
                 parallel: false,
                 sequential: false,
             }
-            .run(ctx.dir, config, matches!(ctx.reporter, ReporterType::Silent));
+            .run(ctx.dir, config, ctx.reporter);
         }
         // Inside a workspace subdirectory, a `<command_name>` script at the
         // workspace root must be run from the root rather than shadowed by

--- a/pnpm/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_install.rs
@@ -319,14 +319,9 @@ pub(super) fn install_test<'a>(
         run_args.sort = cfg.sort;
         run_args.reverse = cfg.reverse;
         if recursive {
-            run_args.run_recursive(
-                cfg,
-                dir,
-                reporter_emit(reporter),
-                matches!(reporter, ReporterType::Ndjson | ReporterType::Silent),
-            )?;
+            run_args.run_recursive(cfg, dir, reporter)?;
         } else {
-            run_args.run(dir, cfg, matches!(reporter, ReporterType::Silent))?;
+            run_args.run(dir, cfg, reporter)?;
         }
 
         Ok(())

--- a/pnpm/crates/cli/src/cli_args/dispatch_script.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_script.rs
@@ -131,9 +131,10 @@ pub(super) fn exec<'a>(ctx: &RunCtx<'a>, args: ExecArgs) -> miette::Result<Comma
     if ctx.recursive {
         let dir = ctx.dir;
         let emit = reporter_emit(ctx.reporter);
-        Ok(Box::pin(async move { args.run_recursive(config, dir, emit).await }))
+        let silent = matches!(ctx.reporter, ReporterType::Silent);
+        Ok(Box::pin(async move { args.run_recursive(config, dir, emit, silent).await }))
     } else {
-        args.run(ctx.dir, config)?;
+        args.run(ctx.dir, config, matches!(ctx.reporter, ReporterType::Silent))?;
         Ok(Box::pin(std::future::ready(Ok(()))))
     }
 }

--- a/pnpm/crates/cli/src/cli_args/dispatch_script.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_script.rs
@@ -3,7 +3,6 @@ use super::{
     exec::ExecArgs,
     init::InitArgs,
     pkg::PkgArgs,
-    reporter::{ReporterType, reporter_emit},
     restart::RestartArgs,
     run::RunArgs,
     script_shortcut::ScriptShortcutArgs,
@@ -83,14 +82,9 @@ pub(super) fn run<'a>(ctx: &RunCtx<'a>, args: RunArgs) -> miette::Result<Command
     let config = (ctx.config)()?;
     let args = with_recursive_run_options(ctx, args, config);
     if ctx.recursive {
-        args.run_recursive(
-            config,
-            ctx.dir,
-            reporter_emit(ctx.reporter),
-            matches!(ctx.reporter, ReporterType::Ndjson | ReporterType::Silent),
-        )?;
+        args.run_recursive(config, ctx.dir, ctx.reporter)?;
     } else {
-        args.run(ctx.dir, config, matches!(ctx.reporter, ReporterType::Silent))?;
+        args.run(ctx.dir, config, ctx.reporter)?;
     }
     Ok(Box::pin(std::future::ready(Ok(()))))
 }
@@ -113,14 +107,9 @@ pub(super) fn fallback<'a>(
     let config = (ctx.config)()?;
     let args = with_recursive_run_options(ctx, args, config);
     if ctx.recursive {
-        args.run_recursive(
-            config,
-            ctx.dir,
-            reporter_emit(ctx.reporter),
-            matches!(ctx.reporter, ReporterType::Ndjson | ReporterType::Silent),
-        )?;
+        args.run_recursive(config, ctx.dir, ctx.reporter)?;
     } else {
-        args.run_fallback(ctx.dir, config, matches!(ctx.reporter, ReporterType::Silent))?;
+        args.run_fallback(ctx.dir, config, ctx.reporter)?;
     }
     Ok(Box::pin(std::future::ready(Ok(()))))
 }
@@ -130,11 +119,10 @@ pub(super) fn exec<'a>(ctx: &RunCtx<'a>, args: ExecArgs) -> miette::Result<Comma
     let args = with_recursive_exec_options(ctx, args, config);
     if ctx.recursive {
         let dir = ctx.dir;
-        let emit = reporter_emit(ctx.reporter);
-        let silent = matches!(ctx.reporter, ReporterType::Silent);
-        Ok(Box::pin(async move { args.run_recursive(config, dir, emit, silent).await }))
+        let reporter = ctx.reporter;
+        Ok(Box::pin(async move { args.run_recursive(config, dir, reporter).await }))
     } else {
-        args.run(ctx.dir, config, matches!(ctx.reporter, ReporterType::Silent))?;
+        args.run(ctx.dir, config, ctx.reporter)?;
         Ok(Box::pin(std::future::ready(Ok(()))))
     }
 }
@@ -174,13 +162,7 @@ pub(super) fn stop<'a>(
     if ctx.recursive {
         run(ctx, args.into_run_args("stop", ctx.if_present))
     } else {
-        args.run(
-            "stop",
-            ctx.if_present,
-            ctx.dir,
-            (ctx.config)()?,
-            matches!(ctx.reporter, ReporterType::Silent),
-        )?;
+        args.run("stop", ctx.if_present, ctx.dir, (ctx.config)()?, ctx.reporter)?;
         Ok(Box::pin(std::future::ready(Ok(()))))
     }
 }
@@ -190,6 +172,6 @@ pub(super) fn restart<'a>(
     mut args: RestartArgs,
 ) -> miette::Result<CommandFuture<'a>> {
     args.if_present |= ctx.if_present;
-    args.run(ctx.dir, (ctx.config)()?, matches!(ctx.reporter, ReporterType::Silent))?;
+    args.run(ctx.dir, (ctx.config)()?, ctx.reporter)?;
     Ok(Box::pin(std::future::ready(Ok(()))))
 }

--- a/pnpm/crates/cli/src/cli_args/exec.rs
+++ b/pnpm/crates/cli/src/cli_args/exec.rs
@@ -10,12 +10,13 @@ use pnpm_package_manager::{
     make_node_package_map_option, make_node_require_option, package_map_path_for_execution,
     pnp_path_for_execution,
 };
-use pnpm_reporter::LogEvent;
 use pnpm_workspace::safe_read_project_manifest_only;
 use std::{
     path::Path,
     process::{Command, ExitStatus, Stdio},
 };
+
+use super::reporter::{ReporterType, reporter_emit};
 
 /// Run a shell command in the context of a project.
 ///
@@ -99,9 +100,9 @@ impl ExecArgs {
     /// On a non-zero child exit code this terminates the process with the
     /// same code via [`std::process::exit`], matching pnpm's exec, which
     /// returns `{ exitCode }` and lets the CLI exit with it.
-    pub fn run(self, dir: &Path, config: &Config, silent: bool) -> miette::Result<()> {
+    pub fn run(self, dir: &Path, config: &Config, reporter: ReporterType) -> miette::Result<()> {
         let command = prepare_command(self.command)?;
-        super::verify_deps::verify_deps_before_run(dir, config, silent)?;
+        super::verify_deps::verify_deps_before_run(dir, config, reporter)?;
         let status = spawn_in_dir(&command, dir, config, self.shell_mode, ScriptOutput::Inherit)?;
         if !status.success() {
             // Propagate the child's exit code. A signal-terminated child
@@ -118,11 +119,10 @@ impl ExecArgs {
         &self,
         config: &Config,
         dir: &Path,
-        emit: fn(&LogEvent),
-        silent: bool,
+        reporter: ReporterType,
     ) -> miette::Result<()> {
-        super::verify_deps::verify_deps_before_run(dir, config, silent)?;
-        recursive::exec_recursive(self, config, dir, emit).await
+        super::verify_deps::verify_deps_before_run(dir, config, reporter)?;
+        recursive::exec_recursive(self, config, dir, reporter_emit(reporter)).await
     }
 }
 

--- a/pnpm/crates/cli/src/cli_args/exec.rs
+++ b/pnpm/crates/cli/src/cli_args/exec.rs
@@ -99,9 +99,9 @@ impl ExecArgs {
     /// On a non-zero child exit code this terminates the process with the
     /// same code via [`std::process::exit`], matching pnpm's exec, which
     /// returns `{ exitCode }` and lets the CLI exit with it.
-    pub fn run(self, dir: &Path, config: &Config) -> miette::Result<()> {
+    pub fn run(self, dir: &Path, config: &Config, silent: bool) -> miette::Result<()> {
         let command = prepare_command(self.command)?;
-        super::verify_deps::verify_deps_before_run(dir, config, false)?;
+        super::verify_deps::verify_deps_before_run(dir, config, silent)?;
         let status = spawn_in_dir(&command, dir, config, self.shell_mode, ScriptOutput::Inherit)?;
         if !status.success() {
             // Propagate the child's exit code. A signal-terminated child
@@ -119,8 +119,9 @@ impl ExecArgs {
         config: &Config,
         dir: &Path,
         emit: fn(&LogEvent),
+        silent: bool,
     ) -> miette::Result<()> {
-        super::verify_deps::verify_deps_before_run(dir, config, false)?;
+        super::verify_deps::verify_deps_before_run(dir, config, silent)?;
         recursive::exec_recursive(self, config, dir, emit).await
     }
 }

--- a/pnpm/crates/cli/src/cli_args/restart.rs
+++ b/pnpm/crates/cli/src/cli_args/restart.rs
@@ -1,6 +1,6 @@
 use clap::Args;
 
-use super::run::RunArgs;
+use super::{reporter::ReporterType, run::RunArgs};
 
 /// Restarts a package. Runs a package's "stop", "restart", and "start"
 /// scripts, and associated pre- and post- scripts.
@@ -20,7 +20,7 @@ impl RestartArgs {
         self,
         dir: &std::path::Path,
         config: &pnpm_config::Config,
-        silent: bool,
+        reporter: ReporterType,
     ) -> miette::Result<()> {
         let RestartArgs { args, if_present } = self;
 
@@ -36,7 +36,7 @@ impl RestartArgs {
                 parallel: false,
                 sequential: false,
             }
-            .run(dir, config, silent)?;
+            .run(dir, config, reporter)?;
         }
 
         Ok(())

--- a/pnpm/crates/cli/src/cli_args/restart/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/restart/tests.rs
@@ -4,6 +4,7 @@
 #![cfg(unix)]
 
 use super::RestartArgs;
+use crate::cli_args::reporter::ReporterType;
 use serde_json::json;
 use tempfile::TempDir;
 
@@ -32,7 +33,7 @@ fn restart_runs_stop_restart_start_in_order() {
     );
     let config = test_config();
     RestartArgs { args: vec![], if_present: false }
-        .run(dir, &config, true)
+        .run(dir, &config, ReporterType::Silent)
         .expect("restart should succeed");
     let content = std::fs::read_to_string(&log_file).expect("read log file");
     let lines: Vec<&str> = content.lines().map(str::trim).filter(|line| !line.is_empty()).collect();
@@ -52,7 +53,7 @@ fn restart_with_if_present_skips_missing_stop_and_restart() {
     );
     let config = test_config();
     RestartArgs { args: vec![], if_present: true }
-        .run(dir, &config, true)
+        .run(dir, &config, ReporterType::Silent)
         .expect("--if-present should skip missing stop/restart");
 }
 
@@ -84,7 +85,7 @@ fn restart_passes_args_to_each_script() {
     std::fs::write(dir.join("package.json"), manifest.to_string()).expect("write package.json");
     let config = test_config();
     RestartArgs { args: vec!["myarg".to_string()], if_present: false }
-        .run(dir, &config, true)
+        .run(dir, &config, ReporterType::Silent)
         .expect("restart should succeed");
     let content = std::fs::read_to_string(&log_file).expect("read log file");
     let lines: Vec<&str> = content.lines().map(str::trim).filter(|line| !line.is_empty()).collect();

--- a/pnpm/crates/cli/src/cli_args/run.rs
+++ b/pnpm/crates/cli/src/cli_args/run.rs
@@ -1,4 +1,7 @@
-use super::exec::ExecArgs;
+use super::{
+    exec::ExecArgs,
+    reporter::{ReporterType, reporter_emit},
+};
 use clap::Args;
 use derive_more::{Display, Error};
 use miette::Diagnostic;
@@ -10,7 +13,6 @@ use pnpm_package_manager::{
     pnp_path_for_execution,
 };
 use pnpm_package_manifest::PackageManifest;
-use pnpm_reporter::LogEvent;
 use pnpm_workspace::{ReadProjectManifestOnlyError, read_project_manifest_only};
 use regex::Regex;
 use serde_json::Value;
@@ -144,25 +146,31 @@ impl RunArgs {
     /// The `resume_from` / `report_summary` / `no_bail` fields are only
     /// meaningful for the recursive path (see [`Self::run_recursive`])
     /// and are ignored here.
-    pub fn run(self, dir: &Path, config: &Config, silent: bool) -> miette::Result<()> {
-        self.run_inner(dir, config, silent, false)
+    pub fn run(self, dir: &Path, config: &Config, reporter: ReporterType) -> miette::Result<()> {
+        self.run_inner(dir, config, reporter, false)
     }
 
-    pub fn run_fallback(self, dir: &Path, config: &Config, silent: bool) -> miette::Result<()> {
-        self.run_inner(dir, config, silent, true)
+    pub fn run_fallback(
+        self,
+        dir: &Path,
+        config: &Config,
+        reporter: ReporterType,
+    ) -> miette::Result<()> {
+        self.run_inner(dir, config, reporter, true)
     }
 
     fn run_inner(
         self,
         dir: &Path,
         config: &Config,
-        silent: bool,
+        reporter: ReporterType,
         fallback_to_exec: bool,
     ) -> miette::Result<()> {
         // Before the manifest is read, so a mistyped command in a
         // directory without a project skips the check instead of
         // spawning a doomed install (see check_deps_status_before_run_at).
-        super::verify_deps::verify_deps_before_run(dir, config, silent)?;
+        super::verify_deps::verify_deps_before_run(dir, config, reporter)?;
+        let silent = matches!(reporter, ReporterType::Silent);
         let RunArgs { script, if_present, sequential, .. } = self;
         let Some((script_name, args)) = script.split_first() else {
             let manifest = read_project_manifest_only(dir).map_err(RunError::Manifest)?;
@@ -174,7 +182,7 @@ impl RunArgs {
             Err(ReadProjectManifestOnlyError::NoImporterManifestFound { .. })
                 if fallback_to_exec =>
             {
-                return exec_fallback(script_name, args, dir, config, silent);
+                return exec_fallback(script_name, args, dir, config, reporter);
             }
             Err(err) => return Err(RunError::Manifest(err).into()),
         };
@@ -193,7 +201,7 @@ impl RunArgs {
                 return Ok(());
             }
             if fallback_to_exec {
-                return exec_fallback(script_name, args, dir, config, silent);
+                return exec_fallback(script_name, args, dir, config, reporter);
             }
             return Err(RunError::NoScript {
                 script: script_name.clone(),
@@ -256,11 +264,16 @@ impl RunArgs {
         &self,
         config: &Config,
         dir: &Path,
-        emit: fn(&LogEvent),
-        silent: bool,
+        reporter: ReporterType,
     ) -> miette::Result<()> {
-        super::verify_deps::verify_deps_before_run(dir, config, silent)?;
-        recursive::run_recursive(self, config, dir, emit, silent)
+        super::verify_deps::verify_deps_before_run(dir, config, reporter)?;
+        recursive::run_recursive(
+            self,
+            config,
+            dir,
+            reporter_emit(reporter),
+            matches!(reporter, ReporterType::Ndjson | ReporterType::Silent),
+        )
     }
 }
 
@@ -269,7 +282,7 @@ fn exec_fallback(
     args: &[String],
     dir: &Path,
     config: &Config,
-    silent: bool,
+    reporter: ReporterType,
 ) -> miette::Result<()> {
     ExecArgs {
         command: RunArgs::script(script_name, args.iter().cloned()),
@@ -281,7 +294,7 @@ fn exec_fallback(
         reverse: false,
         parallel: false,
     }
-    .run(dir, config, silent)
+    .run(dir, config, reporter)
 }
 
 /// Shared inputs for running a script, threaded through

--- a/pnpm/crates/cli/src/cli_args/run.rs
+++ b/pnpm/crates/cli/src/cli_args/run.rs
@@ -174,7 +174,7 @@ impl RunArgs {
             Err(ReadProjectManifestOnlyError::NoImporterManifestFound { .. })
                 if fallback_to_exec =>
             {
-                return exec_fallback(script_name, args, dir, config);
+                return exec_fallback(script_name, args, dir, config, silent);
             }
             Err(err) => return Err(RunError::Manifest(err).into()),
         };
@@ -193,7 +193,7 @@ impl RunArgs {
                 return Ok(());
             }
             if fallback_to_exec {
-                return exec_fallback(script_name, args, dir, config);
+                return exec_fallback(script_name, args, dir, config, silent);
             }
             return Err(RunError::NoScript {
                 script: script_name.clone(),
@@ -259,7 +259,7 @@ impl RunArgs {
         emit: fn(&LogEvent),
         silent: bool,
     ) -> miette::Result<()> {
-        super::verify_deps::verify_deps_before_run(dir, config, false)?;
+        super::verify_deps::verify_deps_before_run(dir, config, silent)?;
         recursive::run_recursive(self, config, dir, emit, silent)
     }
 }
@@ -269,6 +269,7 @@ fn exec_fallback(
     args: &[String],
     dir: &Path,
     config: &Config,
+    silent: bool,
 ) -> miette::Result<()> {
     ExecArgs {
         command: RunArgs::script(script_name, args.iter().cloned()),
@@ -280,7 +281,7 @@ fn exec_fallback(
         reverse: false,
         parallel: false,
     }
-    .run(dir, config)
+    .run(dir, config, silent)
 }
 
 /// Shared inputs for running a script, threaded through

--- a/pnpm/crates/cli/src/cli_args/script_shortcut.rs
+++ b/pnpm/crates/cli/src/cli_args/script_shortcut.rs
@@ -1,4 +1,4 @@
-use super::run::RunArgs;
+use super::{reporter::ReporterType, run::RunArgs};
 use clap::Args;
 
 /// The arguments of a command that stands for one named script —
@@ -39,9 +39,9 @@ impl ScriptShortcutArgs {
         if_present: bool,
         dir: &std::path::Path,
         config: &pnpm_config::Config,
-        silent: bool,
+        reporter: ReporterType,
     ) -> miette::Result<()> {
-        self.into_run_args(script_name, if_present).run(dir, config, silent)
+        self.into_run_args(script_name, if_present).run(dir, config, reporter)
     }
 }
 

--- a/pnpm/crates/cli/src/cli_args/script_shortcut/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/script_shortcut/tests.rs
@@ -4,6 +4,7 @@
 #![cfg(unix)]
 
 use super::ScriptShortcutArgs;
+use crate::cli_args::reporter::ReporterType;
 use serde_json::json;
 use tempfile::TempDir;
 
@@ -30,7 +31,7 @@ fn stop_runs_declared_script() {
     );
     let config = test_config();
     ScriptShortcutArgs { args: vec![] }
-        .run("stop", false, dir, &config, true)
+        .run("stop", false, dir, &config, ReporterType::Silent)
         .expect("stop should succeed");
     assert!(marker.exists(), "stop script should have run");
 }
@@ -43,7 +44,7 @@ fn stop_with_if_present_skips_missing_script() {
     setup_project(dir, &json!({}));
     let config = test_config();
     ScriptShortcutArgs { args: vec![] }
-        .run("stop", true, dir, &config, true)
+        .run("stop", true, dir, &config, ReporterType::Silent)
         .expect("--if-present should succeed when script is missing");
 }
 
@@ -54,7 +55,8 @@ fn stop_fails_on_missing_script_without_if_present() {
     let dir = tmp.path();
     setup_project(dir, &json!({}));
     let config = test_config();
-    let res = ScriptShortcutArgs { args: vec![] }.run("stop", false, dir, &config, true);
+    let res =
+        ScriptShortcutArgs { args: vec![] }.run("stop", false, dir, &config, ReporterType::Silent);
     assert!(res.is_err(), "should fail because script is missing");
 }
 

--- a/pnpm/crates/cli/src/cli_args/verify_deps.rs
+++ b/pnpm/crates/cli/src/cli_args/verify_deps.rs
@@ -90,16 +90,17 @@ pub(crate) fn verify_deps_before_run(
 
 /// Re-run the kind of install the workspace state recorded, in-place
 /// and with inherited stdio, the way pnpm's `runDepsStatusCheck` spawns
-/// `pnpm install` through `runPnpmCli`. The spawned install never
-/// re-enters this gate: only `run` / `exec` consult it. Its up-to-date
-/// shortcuts are bypassed because the pre-run check has already decided
-/// that an install is required.
+/// `pnpm install` through `runPnpmCli`. Reporter output goes to stderr so
+/// the command being run owns stdout. The spawned install never re-enters
+/// this gate: only `run` / `exec` consult it. Its up-to-date shortcuts are
+/// bypassed because the pre-run check has already decided that an install
+/// is required.
 #[expect(clippy::exit, reason = "a failed spawned install must preserve the child exit code")]
 fn spawn_install(dir: &Path, install_args: &[String], silent: bool) -> miette::Result<()> {
     let exe = std::env::current_exe().into_diagnostic()?;
     let mut command = Command::new(exe);
     command
-        .args(["install", "--verify-deps-before-run-install"])
+        .args(["install", "--verify-deps-before-run-install", "--use-stderr"])
         .args(install_args)
         .current_dir(dir);
     if silent {

--- a/pnpm/crates/cli/src/cli_args/verify_deps.rs
+++ b/pnpm/crates/cli/src/cli_args/verify_deps.rs
@@ -17,6 +17,8 @@ use pnpm_config::{Config, VerifyDepsBeforeRun};
 use pnpm_default_reporter::colors::Colors;
 use pnpm_package_manager::{RunDepsStatus, check_deps_status_before_run_at};
 
+use super::reporter::ReporterType;
+
 #[derive(Debug, Display, Error, Diagnostic)]
 enum VerifyDepsError {
     #[display("{issue}")]
@@ -40,7 +42,7 @@ enum VerifyDepsError {
 pub(crate) fn verify_deps_before_run(
     dir: &Path,
     config: &Config,
-    silent: bool,
+    reporter: ReporterType,
 ) -> miette::Result<()> {
     if !config.verify_deps_before_run.is_enabled() {
         return Ok(());
@@ -51,13 +53,16 @@ pub(crate) fn verify_deps_before_run(
     let (issue, install_args) = match status {
         RunDepsStatus::UpToDate => return Ok(()),
         RunDepsStatus::SkippedPnp => {
-            warn(silent, "verify-deps-before-run does not work with node-linker=pnp");
+            warn(
+                matches!(reporter, ReporterType::Silent),
+                "verify-deps-before-run does not work with node-linker=pnp",
+            );
             return Ok(());
         }
         RunDepsStatus::Outdated { issue, install_args } => (issue, install_args),
     };
     match config.verify_deps_before_run {
-        VerifyDepsBeforeRun::Install => spawn_install(dir, &install_args, silent),
+        VerifyDepsBeforeRun::Install => spawn_install(dir, &install_args, reporter),
         VerifyDepsBeforeRun::Prompt => {
             if !std::io::stdin().is_terminal() {
                 return Err(VerifyDepsError::CannotPrompt { issue }.into());
@@ -70,7 +75,7 @@ pub(crate) fn verify_deps_before_run(
                 "Your \"node_modules\" directory is out of sync with the \"pnpm-lock.yaml\" file. This can lead to issues during scripts execution.\n\nWould you like to run \"pnpm {command}\" to update your \"node_modules\"?",
             );
             match Confirm::new().with_prompt(message).default(true).interact() {
-                Ok(true) => spawn_install(dir, &install_args, silent),
+                Ok(true) => spawn_install(dir, &install_args, reporter),
                 Ok(false) => Ok(()),
                 // The prompt was interrupted (Esc / Ctrl-C); exit like
                 // pnpm's ExitPromptError handler.
@@ -79,7 +84,10 @@ pub(crate) fn verify_deps_before_run(
         }
         VerifyDepsBeforeRun::Error => Err(VerifyDepsError::OutOfSync { issue }.into()),
         VerifyDepsBeforeRun::Warn => {
-            warn(silent, &format!("Your node_modules are out of sync with your lockfile. {issue}"));
+            warn(
+                matches!(reporter, ReporterType::Silent),
+                &format!("Your node_modules are out of sync with your lockfile. {issue}"),
+            );
             Ok(())
         }
         // `true` runs the check without acting on the verdict; `false`
@@ -91,20 +99,33 @@ pub(crate) fn verify_deps_before_run(
 /// Re-run the kind of install the workspace state recorded, in-place
 /// and with inherited stdio, the way pnpm's `runDepsStatusCheck` spawns
 /// `pnpm install` through `runPnpmCli`. Reporter output goes to stderr so
-/// the command being run owns stdout. The spawned install never re-enters
-/// this gate: only `run` / `exec` consult it. Its up-to-date shortcuts are
-/// bypassed because the pre-run check has already decided that an install
-/// is required.
+/// the command being run owns stdout, in the format selected by the parent.
+/// The spawned install never re-enters this gate: only `run` / `exec` consult
+/// it. Its up-to-date shortcuts are bypassed because the pre-run check has
+/// already decided that an install is required.
 #[expect(clippy::exit, reason = "a failed spawned install must preserve the child exit code")]
-fn spawn_install(dir: &Path, install_args: &[String], silent: bool) -> miette::Result<()> {
+fn spawn_install(
+    dir: &Path,
+    install_args: &[String],
+    reporter: ReporterType,
+) -> miette::Result<()> {
     let exe = std::env::current_exe().into_diagnostic()?;
     let mut command = Command::new(exe);
     command
         .args(["install", "--verify-deps-before-run-install", "--use-stderr"])
         .args(install_args)
         .current_dir(dir);
-    if silent {
-        command.arg("--reporter=silent");
+    match reporter {
+        ReporterType::Default => {}
+        ReporterType::AppendOnly => {
+            command.arg("--reporter=append-only");
+        }
+        ReporterType::Ndjson => {
+            command.arg("--reporter=ndjson");
+        }
+        ReporterType::Silent => {
+            command.arg("--reporter=silent");
+        }
     }
     let status = command.status().into_diagnostic()?;
     if !status.success() {

--- a/pnpm/crates/cli/tests/suite/verify_deps_before_run.rs
+++ b/pnpm/crates/cli/tests/suite/verify_deps_before_run.rs
@@ -154,25 +154,25 @@ fn dedupe_peers_lockfile_regeneration_installs_before_running_the_script() {
         .with_args(["run", "hello"])
         .output()
         .expect("run script after lockfile regeneration");
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    eprintln!("STDOUT:\n{stdout}\n");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    eprintln!("STDERR:\n{stderr}\n");
     assert!(output.status.success(), "the script must run successfully");
     assert!(
-        stdout.contains("Lockfile is up to date, resolution step is skipped"),
-        "the verifier install must reuse the regenerated lockfile:\n{stdout}",
+        stderr.contains("Lockfile is up to date, resolution step is skipped"),
+        "the verifier install must reuse the regenerated lockfile:\n{stderr}",
     );
-    let policy_verdict = stdout
+    let policy_verdict = stderr
         .find("Lockfile passes supply-chain policies")
         .expect("the verifier must report its lockfile policy verdict");
-    let frozen_install = stdout
+    let frozen_install = stderr
         .find("Lockfile is up to date, resolution step is skipped")
         .expect("the verifier must report the frozen install");
-    let up_to_date = stdout
+    let up_to_date = stderr
         .find("Already up to date")
         .expect("the verifier must report that no packages changed");
     assert!(
         policy_verdict < frozen_install && frozen_install < up_to_date,
-        "the verifier messages must match pnpm's order:\n{stdout}",
+        "the verifier messages must match pnpm's order:\n{stderr}",
     );
     assert_eq!(
         fs::read_to_string(workspace.join("pnpm-lock.yaml"))
@@ -469,6 +469,119 @@ fn exec_runs_the_gate_too() {
         .with_args(["--config.verify-deps-before-run=error", "exec", "true"])
         .assert()
         .success();
+
+    drop(root);
+}
+
+#[test]
+fn exec_keeps_verifier_output_out_of_child_stdout() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    fs::write(
+        workspace.join("package.json"),
+        json!({ "name": "workspace-root", "version": "0.0.0" }).to_string(),
+    )
+    .expect("write root package.json");
+    fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - packages/*\n")
+        .expect("write pnpm-workspace.yaml");
+    let project = workspace.join("packages/project");
+    fs::create_dir_all(&project).expect("create workspace project");
+    write_manifest(&project, &project.join("marker.txt"));
+
+    let output = pacquet_in(&project)
+        .with_args([
+            "exec",
+            "node",
+            "-e",
+            r#"process.stdout.write(JSON.stringify({workspace:"test"}))"#,
+        ])
+        .output()
+        .expect("spawn pacquet exec");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    eprintln!("STDOUT:\n{stdout}\n\nSTDERR:\n{stderr}\n");
+    assert!(output.status.success(), "exec failed");
+    assert_eq!(stdout, r#"{"workspace":"test"}"#);
+    assert!(
+        stderr.contains("Scope: all 2 workspace projects") && stderr.contains("Done in"),
+        "the verifier install must report on stderr:\n{stderr}",
+    );
+
+    drop(root);
+}
+
+#[test]
+fn silent_exec_suppresses_verifier_output() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_manifest(&workspace, &workspace.join("marker.txt"));
+
+    let output = pacquet
+        .with_args([
+            "exec",
+            "--silent",
+            "node",
+            "-e",
+            r#"process.stdout.write(JSON.stringify({workspace:"test"}))"#,
+        ])
+        .output()
+        .expect("spawn silent pacquet exec");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    eprintln!("STDOUT:\n{stdout}\n\nSTDERR:\n{stderr}\n");
+    assert!(output.status.success(), "silent exec failed");
+    assert_eq!(stdout, r#"{"workspace":"test"}"#);
+    assert_eq!(stderr, "");
+
+    drop(root);
+}
+
+#[test]
+fn silent_recursive_exec_suppresses_verifier_output() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_manifest(&workspace, &workspace.join("marker.txt"));
+    fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - .\n")
+        .expect("write pnpm-workspace.yaml");
+
+    let output = pacquet
+        .with_args([
+            "--silent",
+            "--recursive",
+            "exec",
+            "node",
+            "-e",
+            r#"process.stdout.write(JSON.stringify({workspace:"test"}))"#,
+        ])
+        .output()
+        .expect("spawn silent recursive pacquet exec");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    eprintln!("STDOUT:\n{stdout}\n\nSTDERR:\n{stderr}\n");
+    assert!(output.status.success(), "silent recursive exec failed");
+    assert_eq!(stdout, r#"{"workspace":"test"}"#);
+    assert_eq!(stderr, "");
+
+    drop(root);
+}
+
+#[test]
+#[cfg_attr(not(unix), ignore = "the fixture script uses the POSIX `touch` command")]
+fn silent_recursive_run_suppresses_verifier_output() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let marker = workspace.join("marker.txt");
+    write_manifest(&workspace, &marker);
+    fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - .\n")
+        .expect("write pnpm-workspace.yaml");
+
+    let output = pacquet
+        .with_args(["--silent", "--recursive", "run", "hello"])
+        .output()
+        .expect("spawn silent recursive pacquet run");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    eprintln!("STDOUT:\n{stdout}\n\nSTDERR:\n{stderr}\n");
+    assert!(output.status.success(), "silent recursive run failed");
+    assert_eq!(stdout, "");
+    assert_eq!(stderr, "");
+    assert!(marker.exists(), "the script must run after the verifier install");
 
     drop(root);
 }

--- a/pnpm/crates/cli/tests/suite/verify_deps_before_run.rs
+++ b/pnpm/crates/cli/tests/suite/verify_deps_before_run.rs
@@ -510,6 +510,35 @@ fn exec_keeps_verifier_output_out_of_child_stdout() {
 }
 
 #[test]
+fn ndjson_exec_keeps_verifier_output_machine_readable() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_manifest(&workspace, &workspace.join("marker.txt"));
+
+    let output = pacquet
+        .with_args([
+            "--reporter=ndjson",
+            "exec",
+            "node",
+            "-e",
+            r#"process.stdout.write(JSON.stringify({workspace:"test"}))"#,
+        ])
+        .output()
+        .expect("spawn ndjson pacquet exec");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    eprintln!("STDOUT:\n{stdout}\n\nSTDERR:\n{stderr}\n");
+    assert!(output.status.success(), "ndjson exec failed");
+    assert_eq!(stdout, r#"{"workspace":"test"}"#);
+    assert!(!stderr.is_empty(), "the verifier install must report NDJSON events");
+    for line in stderr.lines() {
+        serde_json::from_str::<serde_json::Value>(line)
+            .unwrap_or_else(|err| panic!("invalid NDJSON line {line:?}: {err}"));
+    }
+
+    drop(root);
+}
+
+#[test]
 fn silent_exec_suppresses_verifier_output() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
     write_manifest(&workspace, &workspace.join("marker.txt"));


### PR DESCRIPTION
## Summary

- Route dependency-verification install reporter output to stderr so `pnpm exec` preserves machine-readable child stdout.
- Preserve the effective default, append-only, NDJSON, or silent reporter through dependency verification in single-project and recursive execution paths.
- Cover the reported workspace scope leak, machine-readable NDJSON diagnostics, and silent execution paths end to end.
- Add a patch changeset for `pacquet`.

Fixes pnpm/pnpm#14197.

This is a Rust-only parity correction. The frozen TypeScript pnpm 11 CLI does not reproduce the regression; it was introduced in the pacquet v12 implementation.

## Squash Commit Body

```text
Route the dependency-verification install reporter to stderr so commands retain ownership of stdout. Preserve the effective reporter format through single-project and recursive execution paths.

Add end-to-end coverage for the workspace scope leak, NDJSON diagnostics, and every affected silent execution path.

Fixes pnpm/pnpm#14197.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790369770&installation_model_id=426870&pr_number=14200&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14200&signature=8e431ca1e50b8bbab0f5fdd2b9e83f01b436b2eb14922cda5a76a1b344b42df6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dependency-verification messages appearing in `pnpm exec` command output.
  * Preserved child command output while directing verification and installation messages to stderr.
  * Made `--silent` consistently suppress verification output for regular and recursive `exec` and `run` commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->