### PR TITLE
fix: repair TS CI compile and lint after the dependency and Node.js update

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Install pnpm and Node
       uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
       with:
-        runtime: node@26.8.0
+        runtime: node@26.8.1
 
     - name: Install Rust Toolchain
       uses: ./.github/actions/rustup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
             test_chunk: '1'
             test_chunk_total: '1'
             garnet: true
-          - node: '26.8.0'
+          - node: '26.8.1'
             node_major: '26'
             platform: blacksmith-8vcpu-ubuntu-2404
             platform_label: ubuntu

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,7 +271,7 @@ jobs:
       - name: Install pnpm and Node
         uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:
-          runtime: node@26.8.0
+          runtime: node@26.8.1
       - name: Build TypeScript executable artifacts
         run: pn --filter=@pnpm/exe run build-artifacts
 
@@ -425,7 +425,7 @@ jobs:
       - name: Install pnpm and Node
         uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:
-          runtime: node@26.8.0
+          runtime: node@26.8.1
       # Internal workspace packages still publish with the static token. `@pnpm/exe`
       # and `pnpm` use stage-only OIDC. CI stages both packages but cannot approve
       # or publish them; a maintainer does that later with interactive 2FA. Keeping

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test-branch": "pn pretest && pn lint && git remote set-branches --add origin main && git fetch origin main && pn test-pkgs-branch",
     "ci:test-branch": "pn prepare-fixtures && pn test-pkgs-branch",
     "test-pkgs-branch": "pn remove-temp-dir && pn --workspace-concurrency=1 --filter=...[origin/main] --no-sort --if-present .test",
-    "compile-only": "tsgo --build pnpm11/workspace/workspace-manifest-reader pnpm11/workspace/projects-reader && pnx node@runtime:26.8.0 pnpm11/__utils__/scripts/src/typecheck-only.ts && pn -F=pnpm compile",
+    "compile-only": "tsgo --build pnpm11/workspace/workspace-manifest-reader pnpm11/workspace/projects-reader && pnx node@runtime:26.8.1 pnpm11/__utils__/scripts/src/typecheck-only.ts && pn -F=pnpm compile",
     "compile": "pn compile-only && pn update-manifests",
     "build:pnpm": "cargo build --release --bin pnpm",
     "fix:rust": "just fix",
@@ -69,7 +69,7 @@
     },
     "runtime": {
       "name": "node",
-      "version": "26.8.0",
+      "version": "26.8.1",
       "onFail": "download"
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -961,8 +961,8 @@ importers:
         specifier: 'catalog:'
         version: 6.0.0
       node:
-        specifier: runtime:26.8.0
-        version: runtime:26.8.0
+        specifier: runtime:26.8.1
+        version: runtime:26.8.1
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -15472,7 +15472,7 @@ packages:
     resolution: {integrity: sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==}
     engines: {node: '>=18'}
 
-  node@runtime:26.8.0:
+  node@runtime:26.8.1:
     resolution:
       type: variations
       variants:
@@ -15480,9 +15480,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-N3A8NdesvgqaFemfvCvu0vRre7m8qjUhupllq9UCcFU=
+            integrity: sha256-LU0HWYDdrNqgWeJ+wfHFU6TdQmIr2edB4eTDSBcwFAM=
             type: binary
-            url: https://nodejs.org/download/release/v26.8.0/node-v26.8.0-aix-ppc64.tar.gz
+            url: https://nodejs.org/download/release/v26.8.1/node-v26.8.1-aix-ppc64.tar.gz
           targets:
             - cpu: ppc64
               os: aix
@@ -15490,9 +15490,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-1lFvBnpDPNl5sn39sLrYjOl/R74ztxPQTINhsVAvGcY=
+            integrity: sha256-bld/0Nnbd224IwZinkQanazkFnAmIq690XHJ36pB9NI=
             type: binary
-            url: https://nodejs.org/download/release/v26.8.0/node-v26.8.0-darwin-arm64.tar.gz
+            url: https://nodejs.org/download/release/v26.8.1/node-v26.8.1-darwin-arm64.tar.gz
           targets:
             - cpu: arm64
               os: darwin
@@ -15500,9 +15500,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-WOCGbjtDVcHjFA/cDBsbKlVhb05aN/2hISPpgRSgUTg=
+            integrity: sha256-/pxtv5yOG0RDgD114qIDZuQg2uZQx0fbsRayKXV1G68=
             type: binary
-            url: https://nodejs.org/download/release/v26.8.0/node-v26.8.0-darwin-x64.tar.gz
+            url: https://nodejs.org/download/release/v26.8.1/node-v26.8.1-darwin-x64.tar.gz
           targets:
             - cpu: x64
               os: darwin
@@ -15510,9 +15510,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-w1jkyb1M0aRSH6KuFAyIY3o2efw+mc0apryh7FEx8T8=
+            integrity: sha256-1flzzpdeS9A+bCA4Jg9+kgFhWqjh7ik8cvjcwqbZ/ds=
             type: binary
-            url: https://nodejs.org/download/release/v26.8.0/node-v26.8.0-linux-arm64.tar.gz
+            url: https://nodejs.org/download/release/v26.8.1/node-v26.8.1-linux-arm64.tar.gz
           targets:
             - cpu: arm64
               os: linux
@@ -15520,9 +15520,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-4BDZ9iVixDAp/HmUEaOiHknIjLLFT0/TVslLL5QWOpE=
+            integrity: sha256-otDRIQjis89WkbFgVLG2xdhH0wbm8I1m/cY2PpmMejk=
             type: binary
-            url: https://nodejs.org/download/release/v26.8.0/node-v26.8.0-linux-ppc64le.tar.gz
+            url: https://nodejs.org/download/release/v26.8.1/node-v26.8.1-linux-ppc64le.tar.gz
           targets:
             - cpu: ppc64le
               os: linux
@@ -15530,9 +15530,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-AH7wYFitYCQXqmiC/L0w0+rOD2/6u6PY+Nfgi5ttx0s=
+            integrity: sha256-72un7U4iqWAp1ppcq5GvjnnlwUPI1jPECYOATcrJgi8=
             type: binary
-            url: https://nodejs.org/download/release/v26.8.0/node-v26.8.0-linux-s390x.tar.gz
+            url: https://nodejs.org/download/release/v26.8.1/node-v26.8.1-linux-s390x.tar.gz
           targets:
             - cpu: s390x
               os: linux
@@ -15540,9 +15540,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-EO0GA1UjgzIOGd4wHI3sVHQuLIT1unmLUkpA1JSFC5s=
+            integrity: sha256-erg+reDp7r2bo1IxuI0iWuXHKrVWlaPXqWEVocRe2Vw=
             type: binary
-            url: https://nodejs.org/download/release/v26.8.0/node-v26.8.0-linux-x64-musl.tar.gz
+            url: https://nodejs.org/download/release/v26.8.1/node-v26.8.1-linux-x64-musl.tar.gz
           targets:
             - cpu: x64
               os: linux
@@ -15551,9 +15551,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-Mvzcji4sxU+81sjMlspb0ucAGawjAAy9bMxWY94RGzM=
+            integrity: sha256-srdmYPpN7U4LKkHuPAxlHNUuqBcOrZHrrB4UesPVVkM=
             type: binary
-            url: https://nodejs.org/download/release/v26.8.0/node-v26.8.0-linux-x64.tar.gz
+            url: https://nodejs.org/download/release/v26.8.1/node-v26.8.1-linux-x64.tar.gz
           targets:
             - cpu: x64
               os: linux
@@ -15561,10 +15561,10 @@ packages:
             archive: zip
             bin:
               node: node.exe
-            integrity: sha256-MQIhW+l1gm46YJXpVfB3ZQsYYWJFW09Z7eHPijUcK/I=
-            prefix: node-v26.8.0-win-arm64
+            integrity: sha256-CdYgBaqdyo/Nm9zoGW9ap4Pu44GNWvdAietylxA8AtQ=
+            prefix: node-v26.8.1-win-arm64
             type: binary
-            url: https://nodejs.org/download/release/v26.8.0/node-v26.8.0-win-arm64.zip
+            url: https://nodejs.org/download/release/v26.8.1/node-v26.8.1-win-arm64.zip
           targets:
             - cpu: arm64
               os: win32
@@ -15572,10 +15572,10 @@ packages:
             archive: zip
             bin:
               node: node.exe
-            integrity: sha256-onxiAIDNTaK9BFj9fb4cQLrvZ8wowPC/IaIp2GevfAA=
-            prefix: node-v26.8.0-win-x64
+            integrity: sha256-V2k9jpPRsE57feRqylPs1j6XVk5z3jamhCjX/wjYNYc=
+            prefix: node-v26.8.1-win-x64
             type: binary
-            url: https://nodejs.org/download/release/v26.8.0/node-v26.8.0-win-x64.zip
+            url: https://nodejs.org/download/release/v26.8.1/node-v26.8.1-win-x64.zip
           targets:
             - cpu: x64
               os: win32
@@ -15583,9 +15583,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-7FbXUv4wFDagTO8JPLVdRn3Hu8LB8u9q/28jRn0Fj+o=
+            integrity: sha256-D+eK/etKTSc7FKu9S5RsdyiFxYmUydI7HIrgpZovilM=
             type: binary
-            url: https://unofficial-builds.nodejs.org/download/release/v26.8.0/node-v26.8.0-linux-arm64-musl.tar.gz
+            url: https://unofficial-builds.nodejs.org/download/release/v26.8.1/node-v26.8.1-linux-arm64-musl.tar.gz
           targets:
             - cpu: arm64
               os: linux
@@ -15594,14 +15594,14 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-t5aYVWS+awM/OnxJ8njnkQVfLWaXpdPfavldPas+is0=
+            integrity: sha256-ExNaaiEG+dER+ptIyIAe0RmtQ+fh0A3hfXepxEiZqto=
             type: binary
-            url: https://unofficial-builds.nodejs.org/download/release/v26.8.0/node-v26.8.0-linux-x64-musl.tar.gz
+            url: https://unofficial-builds.nodejs.org/download/release/v26.8.1/node-v26.8.1-linux-x64-musl.tar.gz
           targets:
             - cpu: x64
               os: linux
               libc: musl
-    version: 26.8.0
+    version: 26.8.1
     hasBin: true
 
   nopt@1.0.10:
@@ -21357,6 +21357,7 @@ snapshots:
       es-object-atoms: 1.1.2
       es-set-tostringtag: 2.1.0
       es-to-primitive: 1.3.4
+      for-each: 0.3.5
       function.prototype.name: 1.2.0
       get-intrinsic: 1.3.0
       get-proto: 1.0.1
@@ -23583,7 +23584,7 @@ snapshots:
 
   node-releases@2.0.53: {}
 
-  node@runtime:26.8.0: {}
+  node@runtime:26.8.1: {}
 
   nopt@1.0.10:
     dependencies:

--- a/pnpm11/releasing/commands/src/publish/extractManifestFromPacked.ts
+++ b/pnpm11/releasing/commands/src/publish/extractManifestFromPacked.ts
@@ -97,8 +97,8 @@ async function extractEntriesFromPacked (tarballPath: TarballPath, wantReadme: b
       }
 
       const chunks: Buffer[] = []
-      stream.on('data', (chunk: Buffer) => {
-        chunks.push(chunk)
+      stream.on('data', (chunk) => {
+        chunks.push(chunk as Buffer)
       })
 
       stream.once('end', () => {

--- a/pnpm11/releasing/commands/src/publish/previousChangelog.ts
+++ b/pnpm11/releasing/commands/src/publish/previousChangelog.ts
@@ -197,7 +197,7 @@ async function extractTarballEntry (tarballData: Buffer, entryName: string): Pro
         return
       }
       const chunks: Buffer[] = []
-      stream.on('data', (chunk: Buffer) => chunks.push(Buffer.from(chunk)))
+      stream.on('data', (chunk) => chunks.push(Buffer.from(chunk as Uint8Array)))
       stream.on('error', () => resolve(undefined))
       stream.on('end', () => {
         contents = Buffer.concat(chunks).toString('utf8')

--- a/pnpm11/releasing/commands/src/tarball/summarizeTarball.ts
+++ b/pnpm11/releasing/commands/src/tarball/summarizeTarball.ts
@@ -47,7 +47,7 @@ export async function summarizeTarball (tarballData: Buffer): Promise<PublishSum
         }
       }
       if (header.name === 'package/package.json') {
-        stream.on('data', (chunk: Buffer) => chunks.push(Buffer.from(chunk)))
+        stream.on('data', (chunk) => chunks.push(Buffer.from(chunk as Uint8Array)))
       }
       stream.on('error', reject)
       stream.on('end', () => {

--- a/pnpm11/releasing/commands/test/publish/registryChangelog.ts
+++ b/pnpm11/releasing/commands/test/publish/registryChangelog.ts
@@ -61,7 +61,7 @@ async function fetchPublishedChangelog (version: string): Promise<string | undef
         return
       }
       const chunks: Buffer[] = []
-      stream.on('data', (chunk: Buffer) => chunks.push(Buffer.from(chunk)))
+      stream.on('data', (chunk) => chunks.push(Buffer.from(chunk as Uint8Array)))
       stream.on('error', reject)
       stream.on('end', () => {
         changelog = Buffer.concat(chunks).toString('utf8')

--- a/pnpm11/releasing/commands/test/stage.test.ts
+++ b/pnpm11/releasing/commands/test/stage.test.ts
@@ -801,7 +801,7 @@ function createPackageTarball (manifest: { name: string, version: string }): Pro
   return new Promise((resolve, reject) => {
     const pack = tar.pack()
     const chunks: Buffer[] = []
-    pack.on('data', (chunk: Buffer) => chunks.push(Buffer.from(chunk)))
+    pack.on('data', (chunk) => chunks.push(Buffer.from(chunk as Uint8Array)))
     pack.on('error', reject)
     pack.on('end', () => resolve(Buffer.concat(chunks)))
     pack.entry({ name: 'package/package.json' }, JSON.stringify(manifest), (err?: Error | null) => {


### PR DESCRIPTION
## Summary

Fixes the `TS CI / Compile & Lint` failure on `main` introduced by the dependency and Node.js update in pnpm/pnpm#14205 ([failing run](https://github.com/pnpm/pnpm/actions/runs/33019057949/job/98344675709)). Two independent breakages:

1. **Compile:** streamx 2.28.1 now types the `data` event payload as `unknown`, so the five tar-stream `data` handlers in `@pnpm/releasing.commands` that annotated the chunk as `Buffer` stopped typechecking (TS2345). The handlers now accept the chunk as `unknown` and cast at the use site; tar-stream emits Buffers at runtime, so emitted code is unchanged.
2. **Lint (and native builds):** the Node.js v26.8.0 binaries published on nodejs.org self-report as `26.8.0-alpha.0.0.0` — a botched release that Node.js corrected with v26.8.1 one day later. The prerelease-looking version made cspell's engine guard reject the runtime (`Unsupported NodeJS version (26.8.0-alpha.0.0.0); >=20.18 is required`), which would fail the Lint step next, and made node-gyp derive a nonexistent `v26.8.0-alpha.0.0.0` headers URL (the fuse-native 404 visible in the same run). The runtime is bumped to 26.8.1 everywhere it is pinned (root `devEngines`, `compile-only` script, CI test matrix, benchmark and release workflows).

Verified locally: `pn compile-only` and `pn lint` both pass, and the downloaded 26.8.1 runtime self-reports `v26.8.1`.

## Squash Commit Body

```text
The dependency update (pnpm/pnpm#14205) broke TS CI / Compile & Lint in
two independent ways.

streamx 2.28.1 declares the 'data' event payload as unknown, so the five
tar-stream data handlers in the releasing commands that annotated the
chunk as Buffer no longer typechecked. They now take the chunk as
unknown and cast at the use site; tar-stream emits Buffers at runtime,
so the emitted JavaScript is unchanged.

The Node.js v26.8.0 binaries on nodejs.org were built with a bogus
version string and self-report as 26.8.0-alpha.0.0.0 (Node.js shipped
26.8.1 the next day to correct it). That prerelease-looking version made
cspell's engine guard reject the runtime during lint and made node-gyp
request a nonexistent v26.8.0-alpha.0.0.0 headers tarball for native
builds. The pinned runtime is bumped to 26.8.1 in the root devEngines,
the compile-only script, the CI test matrix, and the benchmark and
release workflows.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. *(Repo
  tooling and type-only fixes — nothing user-visible to port.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. *(Not needed: the casts do not change the emitted JavaScript, and
  the runtime pin is repo tooling.)*

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790375875&installation_model_id=426870&pr_number=14206&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14206&signature=49fcadcc963dcfc6482512bbc199627b60321ba1cb3ace3726ae03d6113ddc66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s Node.js runtime to version 26.8.1 across development, testing, benchmarking, and release workflows.

* **Refactor**
  * Improved compatibility with stream data typing while preserving existing tarball and changelog processing behavior.

* **Tests**
  * Updated stream handling in release-related tests to align with current data formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->