### PR TITLE
fix(jest-config): update pnpr config path

### DIFF
--- a/pnpm11/__utils__/jest-config/with-registry/globalSetup.js
+++ b/pnpm11/__utils__/jest-config/with-registry/globalSetup.js
@@ -99,7 +99,7 @@ export default async () => {
 }
 
 function writeTestConfig (storage) {
-  const source = path.join(REPO_ROOT, 'pnpr', 'crates', 'pnpr', 'config.yaml')
+  const source = path.join(REPO_ROOT, 'pnpr', 'crates', 'config', 'config.yaml')
   const bundled = readFileSync(source, 'utf8')
   const configured = bundled.replace('max_users: -1', 'max_users: 100')
   if (configured === bundled) {


### PR DESCRIPTION
## Summary

Update the Jest registry setup to read pnpr's bundled configuration from the `pnpr-config` crate after the file moved from `pnpr/crates/pnpr` to `pnpr/crates/config`.

This fixes the TS CI test shards that failed during Jest global setup with `ENOENT`, including the [Node.js 24 Linux job](https://github.com/pnpm/pnpm/actions/runs/33020954311/job/98352442004). This is test infrastructure only, so no changeset or Rust CLI parity change is needed.

## Squash Commit Body

```text
The pnpr-config extraction moved the bundled registry configuration from pnpr/crates/pnpr to pnpr/crates/config, but the Jest registry setup still read the old location. Point the setup at the new canonical path so registry-backed TypeScript tests can start pnpr again.
```

## Checklist

- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790377966&installation_model_id=426870&pr_number=14208&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14208&signature=0b33e3908e4866f656572c41866b0e92a5f0b176a3daaf6e5f3ad94ca976b726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the test configuration to use the correct registry configuration path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->