### PR TITLE
refactor(pnpr): keep the parsed config free of a live object store

### DIFF
--- a/pnpr/crates/config/src/lib.rs
+++ b/pnpr/crates/config/src/lib.rs
@@ -310,14 +310,9 @@ impl fmt::Debug for S3Settings {
 impl S3Settings {
     /// The configured key prefix, normalized to either `""` or a value
     /// ending in `/` so it can be string-concatenated onto object keys.
+    #[must_use]
     pub fn normalized_prefix(&self) -> String {
-        match self.prefix.as_deref().map(str::trim).filter(|text| !text.is_empty()) {
-            None => String::new(),
-            Some(prefix) => {
-                let trimmed = prefix.trim_matches('/');
-                if trimmed.is_empty() { String::new() } else { format!("{trimmed}/") }
-            }
-        }
+        normalize_key_prefix(self.prefix.as_deref())
     }
 }
 
@@ -363,10 +358,24 @@ fn s3_builder(settings: &S3Settings) -> AmazonS3Builder {
     builder.with_allow_http(settings.allow_http.unwrap_or(false))
 }
 
+/// A key prefix normalized to either `""` or a value ending in `/`, so the
+/// store can concatenate it onto an object key. Every prefix reaching a store
+/// goes through this — a raw `packages` would otherwise key `packagesfoo/…`.
+#[must_use]
+pub fn normalize_key_prefix(prefix: Option<&str>) -> String {
+    match prefix.map(str::trim).filter(|text| !text.is_empty()) {
+        None => String::new(),
+        Some(prefix) => {
+            let trimmed = prefix.trim_matches('/');
+            if trimmed.is_empty() { String::new() } else { format!("{trimmed}/") }
+        }
+    }
+}
+
 /// The resolved hosted-store backend. Like [`BackendConfig`], this carries
-/// settings rather than a live client: opening an object store can fail on
-/// credentials or an unreachable endpoint, and parsing a config file is not
-/// the place to find that out. `Storage::new` opens it.
+/// settings rather than a live client, so a parsed config stays plain data —
+/// nothing here holds a constructed `ObjectStore` that a reader has to reason
+/// about the lifetime of. `Storage::new` builds the client.
 #[derive(Debug, Clone)]
 pub enum HostedStoreConfig {
     /// Local directory — [`Config::storage`].
@@ -375,7 +384,8 @@ pub enum HostedStoreConfig {
     S3(S3Settings),
     /// A caller-supplied object store. Parsing never produces this variant —
     /// it is how an embedder brings its own [`ObjectStore`]: a provider pnpr
-    /// has no settings shape for, or an in-memory one under test.
+    /// has no settings shape for, or an in-memory one under test. `prefix` is
+    /// normalized on the way in, so a raw `packages` works.
     ObjectStore { store: Arc<dyn ObjectStore>, prefix: String },
 }
 

--- a/pnpr/crates/config/src/lib.rs
+++ b/pnpr/crates/config/src/lib.rs
@@ -363,16 +363,20 @@ fn s3_builder(settings: &S3Settings) -> AmazonS3Builder {
     builder.with_allow_http(settings.allow_http.unwrap_or(false))
 }
 
-/// The resolved hosted-store backend. The object-store client is built
-/// once at config-load time (the fallible step), so constructing the
-/// storage layer from it is infallible.
+/// The resolved hosted-store backend. Like [`BackendConfig`], this carries
+/// settings rather than a live client: opening an object store can fail on
+/// credentials or an unreachable endpoint, and parsing a config file is not
+/// the place to find that out. `Storage::new` opens it.
 #[derive(Debug, Clone)]
 pub enum HostedStoreConfig {
     /// Local directory — [`Config::storage`].
     Fs,
-    /// S3-compatible bucket. `prefix` is normalized to `""` or a
-    /// `.../`-terminated key prefix.
-    S3 { store: Arc<dyn ObjectStore>, prefix: String },
+    /// S3-compatible bucket, as declared by the YAML `s3:` block.
+    S3(S3Settings),
+    /// A caller-supplied object store. Parsing never produces this variant —
+    /// it is how an embedder brings its own [`ObjectStore`]: a provider pnpr
+    /// has no settings shape for, or an in-memory one under test.
+    ObjectStore { store: Arc<dyn ObjectStore>, prefix: String },
 }
 
 /// The resolved record-store backend for auth (users + tokens). Unlike
@@ -1490,9 +1494,7 @@ impl Config {
             .as_deref()
             .map_or_else(|| default_cache_dir(&storage), |raw| resolve_relative(raw, base_dir));
         let hosted_store = match &file.s3 {
-            Some(s3) => {
-                HostedStoreConfig::S3 { store: build_s3_store(s3)?, prefix: s3.normalized_prefix() }
-            }
+            Some(s3) => HostedStoreConfig::S3(s3.clone()),
             None => HostedStoreConfig::Fs,
         };
         let backend = build_backend_config(file.backend, base_dir)?;

--- a/pnpr/crates/config/src/tests.rs
+++ b/pnpr/crates/config/src/tests.rs
@@ -521,8 +521,8 @@ upstreams: {}
 ";
     let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
     match config.hosted_store {
-        HostedStoreConfig::S3 { prefix, .. } => assert_eq!(prefix, "packages/"),
-        HostedStoreConfig::Fs => panic!("expected an S3 hosted store, got Fs"),
+        HostedStoreConfig::S3(settings) => assert_eq!(settings.normalized_prefix(), "packages/"),
+        other => panic!("expected an S3 hosted store, got {other:?}"),
     }
 }
 
@@ -2422,4 +2422,28 @@ fn s3_settings_debug_redacts_credentials_inside_the_endpoint() {
     let rendered = format!("{settings:?}");
     assert!(!rendered.contains("hunter2"), "endpoint userinfo leaked: {rendered}");
     assert!(rendered.contains("minio.corp.example"), "host should still render: {rendered}");
+}
+
+/// Parsing a config file must not open an S3 client. A bucket the operator
+/// cannot reach is a startup problem for whatever wants the store, not a
+/// syntax error in their YAML — and `Config::from_yaml_str` has no business
+/// making network decisions.
+#[test]
+fn an_s3_block_parses_without_opening_the_store() {
+    let yaml = "\
+storage: /var/lib/pnpr
+s3:
+  bucket: packages
+  endpoint: http://127.0.0.1:1
+  accessKeyId: nope
+  secretAccessKey: nope
+upstreams: {}
+";
+    let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None)
+        .expect("an unreachable endpoint is not a parse error");
+
+    match config.hosted_store {
+        HostedStoreConfig::S3(settings) => assert_eq!(settings.bucket, "packages"),
+        other => panic!("expected the parsed S3 settings, got {other:?}"),
+    }
 }

--- a/pnpr/crates/config/src/tests.rs
+++ b/pnpr/crates/config/src/tests.rs
@@ -1,7 +1,8 @@
 use super::{
     BackendConfig, Config, ConfigSource, DEFAULT_CONFIG_YAML, FeatureOverrides, HostedStoreConfig,
     Interval, LogFormat, LogLevel, S3Settings, Teams, UpstreamAuthFile, UpstreamConfig,
-    UpstreamConfigFile, config_file_in, parse_interval, resolve_relative, resolve_upstream_config,
+    UpstreamConfigFile, config_file_in, normalize_key_prefix, parse_interval, resolve_relative,
+    resolve_upstream_config,
     upstream::{TokenEnv, UpstreamAuthType},
 };
 use indexmap::IndexMap;
@@ -2424,26 +2425,18 @@ fn s3_settings_debug_redacts_credentials_inside_the_endpoint() {
     assert!(rendered.contains("minio.corp.example"), "host should still render: {rendered}");
 }
 
-/// Parsing a config file must not open an S3 client. A bucket the operator
-/// cannot reach is a startup problem for whatever wants the store, not a
-/// syntax error in their YAML — and `Config::from_yaml_str` has no business
-/// making network decisions.
+/// Every prefix reaching a store goes through this, including the one an
+/// embedder hands to `HostedStoreConfig::ObjectStore`. A raw `packages` must
+/// come back `/`-terminated: the store concatenates it onto the package name,
+/// so without one it would key `packagesfoo/...`.
 #[test]
-fn an_s3_block_parses_without_opening_the_store() {
-    let yaml = "\
-storage: /var/lib/pnpr
-s3:
-  bucket: packages
-  endpoint: http://127.0.0.1:1
-  accessKeyId: nope
-  secretAccessKey: nope
-upstreams: {}
-";
-    let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None)
-        .expect("an unreachable endpoint is not a parse error");
+fn a_key_prefix_is_normalized_to_empty_or_slash_terminated() {
+    assert_eq!(normalize_key_prefix(Some("packages")), "packages/");
+    assert_eq!(normalize_key_prefix(Some("/packages/")), "packages/");
+    assert_eq!(normalize_key_prefix(Some("  packages  ")), "packages/");
 
-    match config.hosted_store {
-        HostedStoreConfig::S3(settings) => assert_eq!(settings.bucket, "packages"),
-        other => panic!("expected the parsed S3 settings, got {other:?}"),
-    }
+    assert_eq!(normalize_key_prefix(None), "");
+    assert_eq!(normalize_key_prefix(Some("")), "");
+    assert_eq!(normalize_key_prefix(Some("   ")), "");
+    assert_eq!(normalize_key_prefix(Some("/")), "");
 }

--- a/pnpr/crates/pnpr/src/lib.rs
+++ b/pnpr/crates/pnpr/src/lib.rs
@@ -18,8 +18,8 @@ pub use pnpr_config::{
     AccessSpec, AuthConfig, BackendConfig, Config, ConfigSource, DEFAULT_CONFIG_YAML,
     FeatureOverrides, HostedConfig, HostedStoreConfig, HtpasswdConfig, LibsqlSettings, LogConfig,
     LogFormat, LogLevel, MaxUsers, OsvConfig, PackageAccess, PublicRoute, RegistryFeature,
-    ResolverFeature, RoutePolicy, SqlBackendSettings, Teams, TokensConfig, UpstreamConfig,
-    default_cache_dir,
+    ResolverFeature, RoutePolicy, S3Settings, SqlBackendSettings, Teams, TokensConfig,
+    UpstreamConfig, default_cache_dir,
 };
 pub use pnpr_error::{RegistryError, Result};
 pub use pnpr_policy::{AccessList, AccessToken, Identity, PackageRule, PackageRules};

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -224,7 +224,7 @@ pub fn try_router_with_auth(mut config: Config, auth: AuthState) -> pnpr_error::
     config.ensure_a_feature_is_enabled()?;
     config.ensure_valid_registry_graph()?;
     let osv_index = load_active_osv_index(&config)?;
-    Ok(router_with_auth_and_osv(config, auth, osv_index))
+    router_with_auth_and_osv(config, auth, osv_index)
 }
 
 /// Load the OSV index only for surfaces that actually consult it. With
@@ -285,7 +285,7 @@ pub async fn serve(mut config: Config) -> pnpr_error::Result<()> {
     let app = router_with_auth_and_osv(config, auth, osv_index);
     let listener = NodelayTcpListener(tokio::net::TcpListener::bind(listen).await?);
     tracing::info!(%listen, "pnpr listening");
-    axum::serve(listener, app.into_make_service_with_connect_info::<PeerAddr>())
+    axum::serve(listener, app?.into_make_service_with_connect_info::<PeerAddr>())
         .with_graceful_shutdown(shutdown_signal())
         .await?;
     Ok(())
@@ -327,7 +327,7 @@ pub async fn serve_listener(
     tracing::info!(%listen, "pnpr listening");
     axum::serve(
         NodelayTcpListener(listener),
-        app.into_make_service_with_connect_info::<PeerAddr>(),
+        app?.into_make_service_with_connect_info::<PeerAddr>(),
     )
     .with_graceful_shutdown(shutdown_signal())
     .await?;

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -198,9 +198,9 @@ pub fn router(config: Config) -> Router {
 }
 
 /// Fallible counterpart to [`router`]: surfaces an invalid config, an
-/// unloadable OSV database (when `osv.enabled`), and a hosted object store
-/// that will not open as errors instead of panicking, for embedders that
-/// build the router directly rather than via [`serve`].
+/// unloadable OSV database (when `osv.enabled`), and hosted-store settings
+/// that don't build a client as errors instead of panicking, for embedders
+/// that build the router directly rather than via [`serve`].
 pub fn try_router(config: Config) -> pnpr_error::Result<Router> {
     let max_users = config.auth.htpasswd.max_users;
     try_router_with_auth(config, AuthState::in_memory_with_max_users(max_users))
@@ -211,12 +211,11 @@ pub fn try_router(config: Config) -> pnpr_error::Result<Router> {
 /// tests that want to override the bcrypt cost or pre-seed users.
 ///
 /// Panics if the config is invalid, an enabled OSV database can't load, or
-/// the hosted object store can't be opened — the last of which needs
-/// reachable credentials, so it is a real possibility at startup. Call
+/// the hosted object store's settings don't build a client. Call
 /// [`try_router_with_auth`] to handle these as recoverable errors.
 pub fn router_with_auth(config: Config, auth: AuthState) -> Router {
     try_router_with_auth(config, auth)
-        .expect("pnpr config must be valid, and any enabled OSV database and the hosted object store must open, before building the router")
+        .expect("pnpr config must be valid, and any enabled OSV database and hosted-store client must build, before building the router")
 }
 
 /// Fallible counterpart to [`router_with_auth`].
@@ -285,10 +284,13 @@ pub async fn serve(mut config: Config) -> pnpr_error::Result<()> {
     let osv_index = load_active_osv_index(&config)?;
     let auth = load_startup_auth(&config).await?;
     let listen = config.listen;
-    let app = router_with_auth_and_osv(config, auth, osv_index);
+    // Build the router before taking the port: it can fail, and a failure
+    // should not leave a bound socket behind or put a `pnpr listening` line
+    // immediately above the error saying it is not.
+    let app = router_with_auth_and_osv(config, auth, osv_index)?;
     let listener = NodelayTcpListener(tokio::net::TcpListener::bind(listen).await?);
     tracing::info!(%listen, "pnpr listening");
-    axum::serve(listener, app?.into_make_service_with_connect_info::<PeerAddr>())
+    axum::serve(listener, app.into_make_service_with_connect_info::<PeerAddr>())
         .with_graceful_shutdown(shutdown_signal())
         .await?;
     Ok(())
@@ -326,11 +328,11 @@ pub async fn serve_listener(
     // would silently fall back to in-memory auth and ignore a persisted
     // htpasswd / SQLite store or a configured `backend:`.
     let auth = load_startup_auth(&config).await?;
-    let app = router_with_auth_and_osv(config, auth, osv_index);
+    let app = router_with_auth_and_osv(config, auth, osv_index)?;
     tracing::info!(%listen, "pnpr listening");
     axum::serve(
         NodelayTcpListener(listener),
-        app?.into_make_service_with_connect_info::<PeerAddr>(),
+        app.into_make_service_with_connect_info::<PeerAddr>(),
     )
     .with_graceful_shutdown(shutdown_signal())
     .await?;

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -197,9 +197,10 @@ pub fn router(config: Config) -> Router {
     router_with_auth(config, AuthState::in_memory_with_max_users(max_users))
 }
 
-/// Fallible counterpart to [`router`]: surfaces a missing/invalid OSV
-/// database (when `osv.enabled`) as an error instead of panicking, for
-/// embedders that build the router directly rather than via [`serve`].
+/// Fallible counterpart to [`router`]: surfaces an invalid config, an
+/// unloadable OSV database (when `osv.enabled`), and a hosted object store
+/// that will not open as errors instead of panicking, for embedders that
+/// build the router directly rather than via [`serve`].
 pub fn try_router(config: Config) -> pnpr_error::Result<Router> {
     let max_users = config.auth.htpasswd.max_users;
     try_router_with_auth(config, AuthState::in_memory_with_max_users(max_users))
@@ -209,11 +210,13 @@ pub fn try_router(config: Config) -> pnpr_error::Result<Router> {
 /// by [`serve`] to wire the persistent file-backed stores, and by
 /// tests that want to override the bcrypt cost or pre-seed users.
 ///
-/// Panics if `osv.enabled` is set but the database can't load; call
-/// [`try_router_with_auth`] to handle that as a recoverable error.
+/// Panics if the config is invalid, an enabled OSV database can't load, or
+/// the hosted object store can't be opened — the last of which needs
+/// reachable credentials, so it is a real possibility at startup. Call
+/// [`try_router_with_auth`] to handle these as recoverable errors.
 pub fn router_with_auth(config: Config, auth: AuthState) -> Router {
     try_router_with_auth(config, auth)
-        .expect("pnpr config must be valid and any enabled OSV database must load before building the router")
+        .expect("pnpr config must be valid, and any enabled OSV database and the hosted object store must open, before building the router")
 }
 
 /// Fallible counterpart to [`router_with_auth`].

--- a/pnpr/crates/pnpr/src/server/routing.rs
+++ b/pnpr/crates/pnpr/src/server/routing.rs
@@ -46,9 +46,9 @@ pub(super) fn router_with_auth_and_osv(
     config: Config,
     auth: AuthState,
     osv_index: Option<Arc<pnpr_osv::OsvIndex>>,
-) -> Router {
+) -> pnpr_error::Result<Router> {
     let storage =
-        Storage::new(&config.hosted_store, config.storage.clone(), config.cache_storage.clone());
+        Storage::new(&config.hosted_store, config.storage.clone(), config.cache_storage.clone())?;
     let registry_enabled = config.registry.enabled;
     let resolver_enabled = config.resolver.enabled;
     let artifacts_enabled = config.resolver.artifacts;
@@ -239,7 +239,7 @@ pub(super) fn router_with_auth_and_osv(
             // `DELETE /~<name>/@scope/name/-/<file>/-rev/<rev>`
             .route("/{a}/{b}/{c}/{d}/{e}/{f}/{g}", delete(delete_seven_segments));
     }
-    router
+    Ok(router
         .layer(DefaultBodyLimit::max(MAX_PUBLISH_BODY_BYTES))
         // Authenticate once, ahead of every handler: resolve the caller,
         // enforce bearer-token read-only / CIDR restrictions (so a
@@ -298,7 +298,7 @@ pub(super) fn router_with_auth_and_osv(
                 })
                 .on_failure(()),
         )
-        .with_state(state)
+        .with_state(state))
 }
 
 // --------------------------------------------------------------------

--- a/pnpr/crates/pnpr/tests/s3_backend.rs
+++ b/pnpr/crates/pnpr/tests/s3_backend.rs
@@ -28,7 +28,7 @@ fn s3_config(storage: PathBuf, store: Arc<dyn ObjectStore>) -> Config {
     let mut config = Config::static_serve(listen, storage);
     config.public_url = "http://example.test".to_string();
     config.auth.htpasswd.max_users = MaxUsers::Unlimited;
-    config.hosted_store = HostedStoreConfig::S3 { store, prefix: String::new() };
+    config.hosted_store = HostedStoreConfig::ObjectStore { store, prefix: String::new() };
     config
 }
 

--- a/pnpr/crates/pnpr/tests/s3_backend.rs
+++ b/pnpr/crates/pnpr/tests/s3_backend.rs
@@ -229,3 +229,56 @@ fn sha1_hex(bytes: &[u8]) -> String {
         acc
     })
 }
+
+/// An embedder supplying its own store gives a prefix in the form a person
+/// writes it. `S3Store` concatenates the prefix onto the package name, so a
+/// raw `packages` has to be normalized on the way in — otherwise every object
+/// lands at `packagesmypkg/...` and nothing that reads by prefix finds it.
+#[tokio::test]
+async fn a_caller_supplied_prefix_is_normalized_before_it_reaches_the_keys() {
+    let tmp = TempDir::new().unwrap();
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+
+    let listen = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 4873));
+    let mut config = Config::static_serve(listen, tmp.path().to_path_buf());
+    config.public_url = "http://example.test".to_string();
+    config.auth.htpasswd.max_users = MaxUsers::Unlimited;
+    config.hosted_store = HostedStoreConfig::ObjectStore {
+        store: Arc::clone(&store),
+        // Deliberately not `/`-terminated.
+        prefix: "packages".to_string(),
+    };
+
+    let app = router(config);
+    let (app, token) = add_user_and_get_token(app, "alice", "secret").await;
+
+    let body = sample_publish_body("mypkg", "1.0.0", b"fake-tarball-bytes");
+    let response = app
+        .clone()
+        .oneshot(
+            Request::put("/mypkg")
+                .header("content-type", "application/json")
+                .header("Authorization", format!("Bearer {token}"))
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let keys: Vec<String> =
+        store.list(None).map(|entry| entry.unwrap().location.to_string()).collect().await;
+    assert!(
+        keys.iter().any(|key| key.starts_with("packages/mypkg/")),
+        "objects should be keyed under `packages/`, got {keys:?}",
+    );
+    assert!(
+        !keys.iter().any(|key| key.starts_with("packagesmypkg")),
+        "an unnormalized prefix would run into the package name: {keys:?}",
+    );
+
+    // And the package still serves back through the prefixed keys.
+    let response =
+        app.clone().oneshot(Request::get("/mypkg").body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}

--- a/pnpr/crates/storage/src/journal.rs
+++ b/pnpr/crates/storage/src/journal.rs
@@ -232,7 +232,7 @@ impl SealedTxn {
 /// should call it themselves on startup.
 pub async fn recover_publish_journal(config: &Config) -> Result<()> {
     let storage =
-        Storage::new(&config.hosted_store, config.storage.clone(), config.cache_storage.clone());
+        Storage::new(&config.hosted_store, config.storage.clone(), config.cache_storage.clone())?;
     storage.publish_journal().recover(&storage).await
 }
 

--- a/pnpr/crates/storage/src/journal/tests.rs
+++ b/pnpr/crates/storage/src/journal/tests.rs
@@ -126,10 +126,11 @@ async fn roll_forward_persists_revision_references() {
     let tmp = tempdir().unwrap();
     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     let storage = Storage::new(
-        &HostedStoreConfig::S3 { store: object_store, prefix: String::new() },
+        &HostedStoreConfig::ObjectStore { store: object_store, prefix: String::new() },
         tmp.path().join("hosted"),
         tmp.path().join("cache"),
-    );
+    )
+    .unwrap();
     let name = PackageName::parse("pkg").unwrap();
     let packument = serde_json::to_vec(&json!({
         "name": "pkg",
@@ -168,7 +169,8 @@ async fn roll_forward_persists_revision_references() {
 async fn roll_forward_drops_a_version_that_cannot_reserve_a_revision_reference() {
     let tmp = tempdir().unwrap();
     let storage =
-        Storage::new(&HostedStoreConfig::Fs, tmp.path().join("hosted"), tmp.path().join("cache"));
+        Storage::new(&HostedStoreConfig::Fs, tmp.path().join("hosted"), tmp.path().join("cache"))
+            .unwrap();
     let digest = URL_SAFE_NO_PAD.encode([7_u8; 64]);
     for index in 0..crate::MAX_HOSTED_REVISION_REFS {
         storage
@@ -220,7 +222,8 @@ async fn roll_forward_drops_a_version_that_cannot_reserve_a_revision_reference()
 async fn roll_forward_only_removes_transaction_owned_references_for_a_dropped_version() {
     let tmp = tempdir().unwrap();
     let storage =
-        Storage::new(&HostedStoreConfig::Fs, tmp.path().join("hosted"), tmp.path().join("cache"));
+        Storage::new(&HostedStoreConfig::Fs, tmp.path().join("hosted"), tmp.path().join("cache"))
+            .unwrap();
     let transaction_owned_digest = URL_SAFE_NO_PAD.encode([5_u8; 64]);
     let previously_owned_digest = URL_SAFE_NO_PAD.encode([6_u8; 64]);
     let full_digest = URL_SAFE_NO_PAD.encode([7_u8; 64]);
@@ -305,10 +308,11 @@ async fn roll_forward_preserves_tarball_conflict_across_a_later_package_failure(
     let tmp = tempdir().unwrap();
     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     let storage = Storage::new(
-        &HostedStoreConfig::S3 { store: object_store, prefix: String::new() },
+        &HostedStoreConfig::ObjectStore { store: object_store, prefix: String::new() },
         tmp.path().join("hosted"),
         tmp.path().join("cache"),
-    );
+    )
+    .unwrap();
     let conflicted_name = PackageName::parse("conflicted-pkg").unwrap();
     let later_name = PackageName::parse("later-pkg").unwrap();
     let filename = "conflicted-pkg-1.0.0.tgz";

--- a/pnpr/crates/storage/src/lib.rs
+++ b/pnpr/crates/storage/src/lib.rs
@@ -8,7 +8,7 @@ use crate::s3::S3Store;
 use async_trait::async_trait;
 use axum::body::Body;
 use pnpm_crypto_hash::integrity_addressed_tarball_integrity;
-use pnpr_config::HostedStoreConfig;
+use pnpr_config::{HostedStoreConfig, build_s3_store};
 use pnpr_error::{RegistryError, Result};
 use pnpr_package_name::PackageName;
 use serde::{Deserialize, Serialize};
@@ -476,16 +476,24 @@ impl Storage {
     /// the hosted store when it's [`HostedStoreConfig::Fs`];
     /// `cache_storage` always backs the proxy cache and doubles as the
     /// S3 backend's local staging scratch.
-    #[must_use]
-    pub fn new(hosted: &HostedStoreConfig, storage: PathBuf, cache_storage: PathBuf) -> Self {
+    pub fn new(
+        hosted: &HostedStoreConfig,
+        storage: PathBuf,
+        cache_storage: PathBuf,
+    ) -> Result<Self> {
         let cached = Store::new(cache_storage.clone());
         let hosted: Arc<dyn HostedBackend> = match hosted {
             HostedStoreConfig::Fs => Arc::new(Store::new(storage)),
-            HostedStoreConfig::S3 { store, prefix } => {
+            HostedStoreConfig::S3(settings) => Arc::new(S3Store::new(
+                build_s3_store(settings)?,
+                settings.normalized_prefix(),
+                cache_storage,
+            )),
+            HostedStoreConfig::ObjectStore { store, prefix } => {
                 Arc::new(S3Store::new(Arc::clone(store), prefix.clone(), cache_storage))
             }
         };
-        Self { hosted, cached }
+        Ok(Self { hosted, cached })
     }
 
     /// The hosted package names, used by the local search scan (which

--- a/pnpr/crates/storage/src/lib.rs
+++ b/pnpr/crates/storage/src/lib.rs
@@ -8,7 +8,7 @@ use crate::s3::S3Store;
 use async_trait::async_trait;
 use axum::body::Body;
 use pnpm_crypto_hash::integrity_addressed_tarball_integrity;
-use pnpr_config::{HostedStoreConfig, build_s3_store};
+use pnpr_config::{HostedStoreConfig, build_s3_store, normalize_key_prefix};
 use pnpr_error::{RegistryError, Result};
 use pnpr_package_name::PackageName;
 use serde::{Deserialize, Serialize};
@@ -489,9 +489,11 @@ impl Storage {
                 settings.normalized_prefix(),
                 cache_storage,
             )),
-            HostedStoreConfig::ObjectStore { store, prefix } => {
-                Arc::new(S3Store::new(Arc::clone(store), prefix.clone(), cache_storage))
-            }
+            HostedStoreConfig::ObjectStore { store, prefix } => Arc::new(S3Store::new(
+                Arc::clone(store),
+                normalize_key_prefix(Some(prefix)),
+                cache_storage,
+            )),
         };
         Ok(Self { hosted, cached })
     }

--- a/pnpr/crates/storage/src/streaming/tests.rs
+++ b/pnpr/crates/storage/src/streaming/tests.rs
@@ -130,7 +130,8 @@ async fn cancelling_in_flight_response_body_removes_tmp_file() {
 
     let tmp = TempDir::new().unwrap();
     let cache = tmp.path().join("cache");
-    let storage = Storage::new(&HostedStoreConfig::Fs, tmp.path().join("hosted"), cache.clone());
+    let storage =
+        Storage::new(&HostedStoreConfig::Fs, tmp.path().join("hosted"), cache.clone()).unwrap();
     let name = PackageName::parse("foo").unwrap();
     let write =
         storage.open_upstream_tarball_tmp("~public/test", &name, "foo-1.0.0.tgz").await.unwrap();
@@ -161,7 +162,8 @@ async fn oversized_response_is_rejected_and_tmp_is_removed() {
 
     let tmp = TempDir::new().unwrap();
     let cache = tmp.path().join("cache");
-    let storage = Storage::new(&HostedStoreConfig::Fs, tmp.path().join("hosted"), cache.clone());
+    let storage =
+        Storage::new(&HostedStoreConfig::Fs, tmp.path().join("hosted"), cache.clone()).unwrap();
     let name = PackageName::parse("foo").unwrap();
     let write =
         storage.open_upstream_tarball_tmp("~public/test", &name, "foo-1.0.0.tgz").await.unwrap();

--- a/pnpr/crates/storage/src/tests.rs
+++ b/pnpr/crates/storage/src/tests.rs
@@ -6,6 +6,7 @@ use tempfile::TempDir;
 
 fn storage_in(tmp: &TempDir) -> Storage {
     Storage::new(&HostedStoreConfig::Fs, tmp.path().join("storage"), tmp.path().join("cache"))
+        .unwrap()
 }
 
 fn pkg(name: &str) -> PackageName {


### PR DESCRIPTION
## Summary

> **The original framing of this PR was wrong and has been corrected.** I
> claimed config parsing "dials out" to S3 and that deferring it moves
> credential/endpoint failures to startup. It does not — see below. The change
> is still worth making, for a smaller and different reason.

`HostedStoreConfig::S3` held a constructed `Arc<dyn ObjectStore>`, built during
`Config::from_yaml_str`. It now holds the parsed `S3Settings`, and
`Storage::new` builds the client.

**What that actually buys:** a parsed config stays plain data. Nothing in
`Config` holds a live object-store handle a reader has to reason about, which
matches `BackendConfig` immediately below it in the same file. And an
embedder-supplied store gets its own variant instead of being disguised as a
parsed one.

**What it does not buy** — and what I incorrectly claimed on the first push:
`AmazonS3Builder::build` does not contact the bucket. I probed it: an empty
bucket, a malformed endpoint and junk credentials *all build successfully*.
The client is lazy and fails on first request. So nothing was "dialling out"
during parse, and `Storage::new` is fallible only because `build` validates its
settings. The doc comments now say this, and a test I had written called
`an_s3_block_parses_without_opening_the_store` is gone: it asserted the claim
and passed trivially.

### The seam

The first attempt at this (during pnpm/pnpm#14204) was reverted because it
broke `tests/s3_backend.rs`, which drives the server against an in-memory
`ObjectStore` assigned into `config.hosted_store`. Settings-only leaves that no
way in. The fix is a third variant, so parsing and injection stop sharing an
arm:

```rust
/// A caller-supplied object store. Parsing never produces this variant —
/// it is how an embedder brings its own `ObjectStore`: a provider pnpr
/// has no settings shape for, or an in-memory one under test.
ObjectStore { store: Arc<dyn ObjectStore>, prefix: String },
```

### Two bugs found in review, both in code this PR added

- **Router error checked after bind.** `serve` evaluated the now-fallible
  router *inside* `axum::serve`, so a failure bound the port and printed
  `pnpr listening` immediately above the error. Found independently by Qodo and
  CodeRabbit. The router is now built before the port is taken, in both startup
  paths.
- **`ObjectStore`'s prefix was not normalized.** The parsed path runs
  `normalized_prefix()`; the new variant passed the raw string to `S3Store`,
  which concatenates it onto the package name — so `packages` would key
  `packagesfoo/…`. Both paths now share one `normalize_key_prefix`, with a test.
  Every current caller passes an empty prefix, so no existing test could have
  caught it.

`S3Settings` is also now re-exported from `pnpr`: it appears in a public enum
variant, so embedders could not otherwise name the type they must construct.

Suite 734 → 735. Full gate green.

## Checklist

- [x] Added or updated tests. — added `a_key_prefix_is_normalized_to_empty_or_slash_terminated`;
  the existing suite, S3 integration tests included, passes unchanged.

---
Written by an agent (Claude Code, claude-opus-5[1m]).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure S3 storage without connecting during configuration loading.
  * Use normalized, slash-terminated storage prefixes.
  * Provide an existing object store directly.
  * Expose S3 settings for integrations.

* **Bug Fixes**
  * Storage initialization failures are now reported instead of silently ignored.
  * Server startup and journal recovery stop cleanly when storage setup fails.

* **Tests**
  * Added coverage for storage-prefix normalization, package access, and initialization errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->